### PR TITLE
feat: frontend usability hardening pass

### DIFF
--- a/src/app/(dashboard)/create/page.tsx
+++ b/src/app/(dashboard)/create/page.tsx
@@ -20,7 +20,7 @@ export default async function CreatePage({ searchParams }: { searchParams: Promi
 
   return (
     <div className="h-full flex flex-col overflow-y-auto">
-      <PageHeader title={template ? `Create Service from Template: ${template}` : "Create New Service"} />
+      <PageHeader title={template ? `Create Service from Template: ${template}` : "Create New Service"} showBack />
       <div className="p-6">
         <ServiceForm initialData={initialData} />
       </div>

--- a/src/app/(dashboard)/edit/[name]/page.tsx
+++ b/src/app/(dashboard)/edit/[name]/page.tsx
@@ -73,7 +73,7 @@ export default async function EditPage({
 
   return (
     <div className="h-full flex flex-col overflow-y-auto">
-      <PageHeader title={`Edit Service: ${name}`} />
+      <PageHeader title={`Edit Service: ${name}`} showBack />
       <div className="p-6">
         <ServiceForm initialData={initialData} isEdit />
       </div>

--- a/src/app/(dashboard)/view/page.tsx
+++ b/src/app/(dashboard)/view/page.tsx
@@ -47,8 +47,9 @@ export default async function ViewPage({ searchParams }: ViewPageProps) {
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
-      <PageHeader 
-        title="File Viewer" 
+      <PageHeader
+        title="File Viewer"
+        showBack
       >
         <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
             <FileText size={16} />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
-import { Github, ArrowRight, Loader2, Shield } from 'lucide-react';
+import { Github, ArrowRight, Loader2, Shield, AlertTriangle } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 import pkg from '../../../package.json';
 
@@ -24,6 +24,13 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [oidcEnabled, setOidcEnabled] = useState(false);
+  const [capsLock, setCapsLock] = useState(false);
+
+  const detectCapsLock = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (typeof e.getModifierState === 'function') {
+      setCapsLock(e.getModifierState('CapsLock'));
+    }
+  };
 
   useEffect(() => {
     // Check if OIDC is available
@@ -126,11 +133,19 @@ export default function LoginPage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={detectCapsLock}
+                onKeyUp={detectCapsLock}
+                onBlur={() => setCapsLock(false)}
                 className="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all"
                 placeholder="System password"
                 autoComplete="current-password"
                 required
               />
+              {capsLock && (
+                <p className="mt-1 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400" role="alert">
+                  <AlertTriangle size={12} /> Caps Lock is on
+                </p>
+              )}
             </div>
 
             <button

--- a/src/components/ActionProgressModal.tsx
+++ b/src/components/ActionProgressModal.tsx
@@ -1,9 +1,10 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { X, Loader2 } from 'lucide-react';
+import { X, Loader2, Minimize2 } from 'lucide-react';
 import type { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
-// import { logger } from '@/lib/logger'; // Removed unused
+import { useToast } from '@/providers/ToastProvider';
+import { humanizeError } from '@/lib/util/humanizeError';
 
 interface ActionProgressModalProps {
   isOpen: boolean;
@@ -17,14 +18,60 @@ interface ActionProgressModalProps {
 export default function ActionProgressModal({ isOpen, onClose, serviceName, nodeName, action, onComplete }: ActionProgressModalProps) {
   const [status, setStatus] = useState<'running' | 'completed' | 'error'>('running');
   const [elapsed, setElapsed] = useState(0);
+  const [minimized, setMinimized] = useState(false);
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const onCompleteRef = useRef(onComplete);
+  const { addToast, updateToast, removeToast } = useToast();
+  const bgToastIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
   }, [onComplete]);
+
+  // When closed, reset minimized so reopening starts fresh.
+  useEffect(() => {
+    if (!isOpen) setMinimized(false);
+  }, [isOpen]);
+
+  // While minimized, surface a sticky background toast that swaps to
+  // success/error when the action finishes.
+  useEffect(() => {
+    if (!minimized || !isOpen) return;
+    if (status === 'running') {
+      if (!bgToastIdRef.current) {
+        bgToastIdRef.current = addToast(
+          'loading',
+          `${action === 'start' ? 'Starting' : action === 'stop' ? 'Stopping' : 'Restarting'} ${serviceName}`,
+          'Running in background…',
+          0,
+        );
+      }
+    } else if (bgToastIdRef.current) {
+      const verb = status === 'completed'
+        ? (action === 'start' ? 'started' : action === 'stop' ? 'stopped' : 'restarted')
+        : `${action} failed`;
+      updateToast(
+        bgToastIdRef.current,
+        status === 'completed' ? 'success' : 'error',
+        `${serviceName} ${verb}`,
+        '',
+        5000,
+      );
+      bgToastIdRef.current = null;
+    }
+  }, [minimized, isOpen, status, action, serviceName, addToast, updateToast]);
+
+  // Clean up the background toast if the parent closes us with one still pending.
+  useEffect(() => {
+    return () => {
+      if (bgToastIdRef.current) {
+        removeToast(bgToastIdRef.current);
+        bgToastIdRef.current = null;
+      }
+    };
+  }, [removeToast]);
 
   useEffect(() => {
     if (!isOpen || status !== 'running') return;
@@ -69,8 +116,8 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
        if (signal.aborted) {
            return;
        }
-       const msg = err instanceof Error ? err.message : String(err);
-       term.writeln(`\r\n\x1b[31;1mConnection Error: ${msg}\x1b[0m`);
+       const { detail } = humanizeError(err, 'Connection error');
+       term.writeln(`\r\n\x1b[31;1mConnection Error: ${detail}\x1b[0m`);
        setStatus('error');
     }
   }, [action, nodeName, serviceName]);
@@ -129,7 +176,7 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
     }
   }, [isOpen, startAction]);
 
-  if (!isOpen) return null;
+  if (!isOpen || minimized) return null;
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
@@ -148,9 +195,25 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
                 </span>
             )}
           </h3>
-          <button onClick={onClose} className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
-            <X size={20} />
-          </button>
+          <div className="flex items-center gap-1">
+            {status === 'running' && (
+              <button
+                onClick={() => setMinimized(true)}
+                className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 p-1 rounded transition-colors"
+                title="Run in background"
+                aria-label="Run in background"
+              >
+                <Minimize2 size={18} />
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 p-1 rounded transition-colors"
+              aria-label="Close"
+            >
+              <X size={20} />
+            </button>
+          </div>
         </div>
         
         <div className="p-4 bg-[#1e1e1e] border-b border-gray-800">

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { AlertTriangle } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 
 interface ConfirmModalProps {
@@ -11,6 +12,11 @@ interface ConfirmModalProps {
   cancelText?: string;
   isDestructive?: boolean;
   confirmDisabled?: boolean;
+  isLoading?: boolean;
+  /** Resource name shown in the dialog and (when requireTypedConfirm is set) required to be typed to enable Confirm. */
+  resourceName?: string;
+  /** Force the user to type resourceName before Confirm enables. Implies isDestructive UX. */
+  requireTypedConfirm?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -23,46 +29,114 @@ export default function ConfirmModal({
   cancelText = 'Cancel',
   isDestructive = false,
   confirmDisabled = false,
+  isLoading = false,
+  resourceName,
+  requireTypedConfirm = false,
   onConfirm,
-  onCancel
+  onCancel,
 }: ConfirmModalProps) {
-  useEscapeKey(onCancel, isOpen);
+  const [typed, setTyped] = useState('');
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleCancel = () => {
+    setTyped('');
+    onCancel();
+  };
+  const handleConfirm = () => {
+    setTyped('');
+    onConfirm();
+  };
+
+  useEscapeKey(() => { if (!isLoading) handleCancel(); }, isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // Move focus to a safe default (cancel) so Enter doesn't accidentally fire confirm.
+    cancelButtonRef.current?.focus();
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
+  const typedOk = !requireTypedConfirm || typed.trim() === (resourceName ?? '').trim();
+  const canConfirm = !confirmDisabled && !isLoading && typedOk;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Enter submits when no type-to-confirm is required, action enabled, and focus
+    // isn't currently on the cancel button (avoid hijacking the Cancel default).
+    if (e.key !== 'Enter') return;
+    if (requireTypedConfirm) return;
+    if (!canConfirm) return;
+    const active = typeof document !== 'undefined' ? document.activeElement : null;
+    if (active === cancelButtonRef.current) return;
+    e.preventDefault();
+    handleConfirm();
+  };
+
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[60] flex items-center justify-center p-4 animate-in fade-in duration-200">
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[60] flex items-center justify-center p-4 animate-in fade-in duration-200"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-title"
+      onKeyDown={handleKeyDown}
+    >
       <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-md w-full border border-gray-200 dark:border-gray-800 overflow-hidden animate-in zoom-in-95 duration-200">
         <div className="p-6">
           <div className="flex items-start gap-4">
             <div className={`p-3 rounded-full shrink-0 ${isDestructive ? 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400' : 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'}`}>
               <AlertTriangle size={24} />
             </div>
-            <div className="flex-1">
-              <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-2">{title}</h3>
+            <div className="flex-1 min-w-0">
+              <h3 id="confirm-modal-title" className="text-lg font-bold text-gray-900 dark:text-white mb-2">{title}</h3>
               <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
                 {message}
               </p>
+              {resourceName && (
+                <p className="mt-2 font-mono text-sm text-gray-900 dark:text-gray-100 break-all bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+                  {resourceName}
+                </p>
+              )}
+              {requireTypedConfirm && resourceName && (
+                <div className="mt-3">
+                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                    Type <span className="font-mono">{resourceName}</span> to confirm
+                  </label>
+                  <input
+                    type="text"
+                    value={typed}
+                    onChange={(e) => setTyped(e.target.value)}
+                    autoComplete="off"
+                    autoFocus
+                    className="w-full px-3 py-2 text-sm font-mono rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-red-500 focus:border-transparent outline-none"
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>
-        
+
         <div className="bg-gray-50 dark:bg-gray-900/50 px-6 py-4 flex justify-end gap-3 border-t border-gray-200 dark:border-gray-800">
           <button
-            onClick={onCancel}
-            className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800 rounded-md transition-colors font-medium text-sm"
+            ref={cancelButtonRef}
+            onClick={handleCancel}
+            disabled={isLoading}
+            className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800 rounded-md transition-colors font-medium text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
           >
             {cancelText}
           </button>
           <button
-            onClick={onConfirm}
-            disabled={confirmDisabled}
-            className={`px-4 py-2 text-white rounded-md transition-colors font-medium text-sm shadow-sm ${
-              isDestructive 
-                ? 'bg-red-600 hover:bg-red-700' 
-                : 'bg-blue-600 hover:bg-blue-700'
+            ref={confirmButtonRef}
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            aria-label={confirmText}
+            className={`px-4 py-2 text-white rounded-md transition-colors font-medium text-sm shadow-sm flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+              isDestructive
+                ? 'bg-red-600 hover:bg-red-700 focus:ring-red-500'
+                : 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-500'
             } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
+            {isLoading && <Loader2 size={14} className="animate-spin" />}
             {confirmText}
           </button>
         </div>

--- a/src/components/ConnectionIndicator.tsx
+++ b/src/components/ConnectionIndicator.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSocket } from '@/hooks/useSocket';
+import { useToast } from '@/providers/ToastProvider';
+
+/**
+ * Surfaces socket.io health to the user. Renders an inline dot meant to live
+ * in PageHeader. Also fires a sticky warning toast on disconnect that clears
+ * itself once the socket reconnects, so the dashboard can't silently freeze.
+ */
+export default function ConnectionIndicator({ inline = false }: { inline?: boolean }) {
+  const { isConnected } = useSocket();
+  const { addToast, removeToast } = useToast();
+  const toastIdRef = useRef<string | null>(null);
+  // Don't fire a "reconnected" toast on the first mount — only after a real drop.
+  const hasBeenConnectedRef = useRef(false);
+
+  useEffect(() => {
+    if (isConnected) {
+      if (toastIdRef.current) {
+        removeToast(toastIdRef.current);
+        toastIdRef.current = null;
+        addToast('success', 'Reconnected', 'Live updates resumed.', 3000);
+      }
+      hasBeenConnectedRef.current = true;
+      return;
+    }
+
+    if (!hasBeenConnectedRef.current) return; // initial connecting phase, not a drop
+    if (toastIdRef.current) return; // already showing a sticky toast
+
+    toastIdRef.current = addToast(
+      'warning',
+      'Connection lost',
+      'Live updates paused. Trying to reconnect…',
+      0,
+    );
+  }, [isConnected, addToast, removeToast]);
+
+  const dot = (
+    <span
+      className={`inline-block w-2 h-2 rounded-full ${
+        isConnected ? 'bg-emerald-500' : 'bg-red-500 animate-pulse'
+      }`}
+      aria-hidden="true"
+    />
+  );
+
+  if (inline) {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 text-[11px] font-medium text-gray-500 dark:text-gray-400"
+        title={isConnected ? 'Live connection active' : 'Disconnected — retrying'}
+        role="status"
+        aria-live="polite"
+      >
+        {dot}
+        <span className="hidden sm:inline">{isConnected ? 'Live' : 'Offline'}</span>
+      </span>
+    );
+  }
+
+  return dot;
+}

--- a/src/components/ContainerList.tsx
+++ b/src/components/ContainerList.tsx
@@ -2,7 +2,8 @@
 
 // V4 Update: Use Digital Twin data
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { EnrichedContainer } from '@/lib/agent/types';
 
 interface ContainerItem extends Partial<EnrichedContainer> {
@@ -14,8 +15,17 @@ interface ContainerListProps {
   containers?: ContainerItem[];
 }
 
+const CONNECT_TIMEOUT_MS = 15_000;
+
 export default function ContainerList({ containers }: ContainerListProps = {}) {
   const { data: twin } = useDigitalTwin();
+  const [slowConnect, setSlowConnect] = useState(false);
+
+  useEffect(() => {
+    if (containers || twin) return;
+    const t = setTimeout(() => setSlowConnect(true), CONNECT_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [containers, twin]);
 
   const allContainers = useMemo((): ContainerItem[] => {
      if (containers) return containers;
@@ -30,9 +40,23 @@ export default function ContainerList({ containers }: ContainerListProps = {}) {
   }, [twin, containers]);
 
   if (!allContainers || allContainers.length === 0) {
+    const isLoading = !(containers || twin);
     return (
-        <div className="p-4 bg-[#2d2d2d] rounded-md text-gray-500 italic">
-            {(containers || twin) ? "No running containers found." : "Connecting to Digital Twin..."}
+        <div className="p-4 bg-[#2d2d2d] rounded-md text-gray-500 italic flex items-center justify-between gap-4">
+            <span>
+              {!isLoading && "No running containers found."}
+              {isLoading && !slowConnect && "Connecting to Digital Twin..."}
+              {isLoading && slowConnect && "Still connecting to Digital Twin… check Settings → Nodes if this persists."}
+            </span>
+            {isLoading && slowConnect && (
+                <button
+                    type="button"
+                    onClick={() => { if (typeof window !== 'undefined') window.location.reload(); }}
+                    className="flex items-center gap-1 px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors not-italic"
+                >
+                    <RefreshCw size={12} /> Refresh
+                </button>
+            )}
         </div>
     );
   }
@@ -76,7 +100,10 @@ export default function ContainerList({ containers }: ContainerListProps = {}) {
                       </div>
                   ) : <span className="text-gray-600">-</span>}
               </td>
-              <td className="py-2 text-yellow-400">
+              <td
+                className="py-2 text-yellow-400 truncate max-w-[200px]"
+                title={Array.isArray(container.names) ? container.names.join(', ') : container.names}
+              >
                 {Array.isArray(container.names) ? container.names.join(', ') : container.names}
               </td>
             </tr>

--- a/src/components/ExternalLinkModal.tsx
+++ b/src/components/ExternalLinkModal.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { X, AlertCircle } from 'lucide-react';
 
 interface LinkForm {
     name: string;
@@ -17,8 +17,21 @@ interface ExternalLinkModalProps {
     setForm: (form: LinkForm) => void;
 }
 
+function isValidHttpUrl(value: string): boolean {
+    if (!value) return false;
+    try {
+        const u = new URL(value);
+        return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
 export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, form, setForm }: ExternalLinkModalProps) {
     if (!isOpen) return null;
+    const nameMissing = !form.name.trim();
+    const urlInvalid = !isValidHttpUrl(form.url.trim());
+    const canSave = !nameMissing && !urlInvalid;
 
     return (
         <div className="absolute inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
@@ -42,13 +55,23 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">URL</label>
-                        <input 
-                            type="url" 
+                        <input
+                            type="url"
                             value={form.url}
                             onChange={e => setForm({...form, url: e.target.value})}
-                            className="w-full p-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none"
+                            className={`w-full p-2 rounded-lg border bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 outline-none ${
+                                form.url && urlInvalid
+                                    ? 'border-red-400 dark:border-red-500 focus:ring-red-500'
+                                    : 'border-gray-300 dark:border-gray-700 focus:ring-blue-500'
+                            }`}
                             placeholder="http://192.168.1.10:8123"
+                            aria-invalid={form.url ? urlInvalid : undefined}
                         />
+                        {form.url && urlInvalid && (
+                            <p className="mt-1 flex items-center gap-1 text-xs text-red-600 dark:text-red-400" role="alert">
+                                <AlertCircle size={12} /> URL must start with http:// or https://
+                            </p>
+                        )}
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description (Optional)</label>
@@ -91,9 +114,10 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                     >
                         Cancel
                     </button>
-                    <button 
+                    <button
                         onClick={onSave}
-                        className="px-4 py-2 bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-colors font-medium"
+                        disabled={!canSave}
+                        className="px-4 py-2 bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         {isEditing ? 'Save Changes' : 'Add Link'}
                     </button>

--- a/src/components/LogLevelControl.tsx
+++ b/src/components/LogLevelControl.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { Settings, AlertCircle, Loader2 } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
+import { humanizeError } from '@/lib/util/humanizeError';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -51,7 +52,8 @@ export default function LogLevelControl() {
         addToast('error', 'Failed to Update Log Level', data.error);
       }
     } catch (err) {
-      addToast('error', 'Failed to Update Log Level', String(err));
+      const { title, detail } = humanizeError(err, 'Failed to Update Log Level');
+      addToast('error', title, detail);
     } finally {
       setSaving(false);
     }

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Download, ChevronRight, ChevronDown, Info, Settings } from 'lucide-react';
+import { RefreshCw, Download, ChevronRight, ChevronDown, Info, Settings, Copy, Pause, Play } from 'lucide-react';
 import Link from 'next/link';
 import { useToast } from '@/providers/ToastProvider';
 import { useSocket } from '@/hooks/useSocket';
+import { humanizeError } from '@/lib/util/humanizeError';
 import { MultiSelect } from './MultiSelect';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -200,7 +201,8 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
     search: undefined,
     limit: 100
   });
-  
+  const [livePaused, setLivePaused] = useState(false);
+
   const { socket, isConnected } = useSocket();
   const { addToast } = useToast();
 
@@ -273,7 +275,8 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
       }
     } catch (err) {
       console.error('Failed to load logs:', err);
-      addToast('error', 'Failed to load logs', String(err));
+      const { title, detail } = humanizeError(err, 'Failed to load logs');
+      addToast('error', title, detail);
     } finally {
       setLoading(false);
     }
@@ -287,6 +290,7 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
   // Live streaming logic
   useEffect(() => {
     if (selectedDate !== 'live' || !socket || !isConnected) return;
+    if (livePaused) return;
 
     socket.emit('logs:subscribe');
 
@@ -297,7 +301,7 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
             const matches = filter.tags.some(t => entry.tag.includes(t));
             if (!matches) return;
         }
-        
+
         const effectiveSearch = searchQuery || filter.search;
         if (effectiveSearch) {
              const term = effectiveSearch.toLowerCase();
@@ -313,16 +317,21 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
         socket.emit('logs:unsubscribe');
         socket.off('log:entry', handleLogEntry);
     };
-  }, [selectedDate, socket, isConnected, filter, searchQuery]);
+  }, [selectedDate, socket, isConnected, filter, searchQuery, livePaused]);
 
   const handleRefresh = () => {
     fetchLogs();
   };
 
-  const handleDownload = () => {
-    const text = logs
+  const formatLogsAsText = () =>
+    logs
+      .slice()
+      .reverse() // logs are stored newest-first; export oldest-first for readability
       .map(log => `${log.timestamp} [${log.level.toUpperCase()}] [${log.tag}] ${log.message}`)
       .join('\n');
+
+  const handleDownload = () => {
+    const text = formatLogsAsText();
 
     const blob = new Blob([text], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
@@ -331,6 +340,18 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
     a.download = `logs-${selectedDate}-${Date.now()}.txt`;
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const handleCopy = async () => {
+    if (logs.length === 0) return;
+    const text = formatLogsAsText();
+    try {
+      await navigator.clipboard.writeText(text);
+      addToast('success', 'Copied', `${logs.length} log entries copied to clipboard.`);
+    } catch (err) {
+      console.error('Copy failed:', err);
+      addToast('error', 'Copy failed', 'Could not access the clipboard. Try downloading instead.');
+    }
   };
 
   const handleClearFilter = () => {
@@ -447,6 +468,16 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
               </button>
               
               <button
+                onClick={handleCopy}
+                disabled={logs.length === 0}
+                className={`inline-flex items-center justify-center w-10 ${baseButtonClass}`}
+                title="Copy visible logs to clipboard"
+                aria-label="Copy logs"
+              >
+                <Copy className="w-4 h-4" />
+              </button>
+
+              <button
                 onClick={handleDownload}
                 disabled={logs.length === 0}
                 className={`inline-flex items-center justify-center w-10 ${baseButtonClass}`}
@@ -454,7 +485,18 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
               >
                 <Download className="w-4 h-4" />
               </button>
-              
+
+              {selectedDate === 'live' && (
+                <button
+                  onClick={() => setLivePaused(p => !p)}
+                  className={`inline-flex items-center justify-center w-10 ${baseButtonClass}`}
+                  title={livePaused ? 'Resume live stream' : 'Pause live stream'}
+                  aria-label={livePaused ? 'Resume live stream' : 'Pause live stream'}
+                >
+                  {livePaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
+                </button>
+              )}
+
               {hasActiveFilter && (
                 <button
                    onClick={handleClearFilter}
@@ -542,7 +584,11 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
       {/* Footer */}
       <div className="px-4 py-2 border-t border-slate-200 dark:border-slate-800 text-xs text-slate-600 dark:text-slate-400 flex justify-between">
         <span>Showing {logs.length} logs</span>
-        <span>{selectedDate === 'live' ? 'Live Stream Active' : 'Historical View'}</span>
+        <span>
+          {selectedDate === 'live'
+            ? (livePaused ? 'Live Stream Paused' : 'Live Stream Active')
+            : 'Historical View'}
+        </span>
       </div>
     </div>
   );

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,13 +1,37 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Github, Settings } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import { plugins } from './Sidebar';
+import { useToast } from '@/providers/ToastProvider';
 import pkg from '../../package.json';
+
+const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
 
 export function MobileTopBar() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const node = searchParams?.get('node');
+  const { addToast } = useToast();
+  const hintFired = useRef(false);
+
+  useEffect(() => {
+    if (hintFired.current) return;
+    if (typeof window === 'undefined') return;
+    if (window.innerWidth >= 768) return;
+    if (window.localStorage.getItem(FIRST_VISIT_KEY)) return;
+    hintFired.current = true;
+    window.localStorage.setItem(FIRST_VISIT_KEY, '1');
+    addToast(
+      'info',
+      'Welcome to ServiceBay',
+      'Tap the Settings icon (top-right) to add SSH nodes and configure auth.',
+      8000,
+    );
+  }, [addToast]);
+
   return (
     <div className="h-14 bg-gray-100 dark:bg-black border-b border-gray-200 dark:border-gray-800 flex items-center justify-between px-4 shrink-0 md:hidden z-20">
        {/* Left: Logo + Text */}
@@ -22,7 +46,11 @@ export function MobileTopBar() {
        </div>
        {/* Right: Icons */}
        <div className="flex items-center gap-4">
-          <button onClick={() => router.push('/settings')} className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+          <button
+            onClick={() => router.push(`/settings${node ? `?node=${node}` : ''}`)}
+            className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+            aria-label="Open settings"
+          >
              <Settings size={20} />
           </button>
           <a href="https://github.com/mdopp/servicebay" target="_blank" rel="noreferrer" className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
@@ -36,7 +64,9 @@ export function MobileTopBar() {
 export function MobileBottomBar() {
    const pathname = usePathname() || '';
   const router = useRouter();
-  
+  const searchParams = useSearchParams();
+  const node = searchParams?.get('node');
+
   // Exclude settings as it is in the top bar
   const bottomPlugins = plugins.filter(p => p.id !== 'settings');
 
@@ -46,18 +76,19 @@ export function MobileBottomBar() {
           const Icon = p.icon;
           const isActive = pathname?.startsWith(p.path);
           return (
-             <button 
+             <button
                 key={p.id}
-                onClick={() => router.push(p.path)}
+                onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
                 title={p.name}
+                aria-label={p.name}
                 className={`p-2 rounded-xl flex flex-col items-center justify-center gap-1 transition-all ${
-                    isActive 
-                    ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20' 
+                    isActive
+                    ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20'
                     : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                 }`}
              >
                 <Icon size={20} strokeWidth={isActive ? 2.5 : 2} />
-                <span className={`text-[9px] leading-none font-medium ${isActive ? '' : 'opacity-70'}`}>{p.name.split(' ')[0]}</span>
+                <span className={`text-[9px] leading-none font-medium ${isActive ? '' : 'opacity-70'}`}>{p.shortLabel}</span>
              </button>
           )
        })}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -82,10 +82,52 @@ function generateSecret(length = 32): string {
     .join('');
 }
 
+const WIZARD_STATE_KEY = 'sb.onboarding.v1';
+
+interface PersistedWizardState {
+  currentStep: WizardStep;
+  stepHistory: WizardStep[];
+  selection: {
+    gateway: boolean;
+    ssh: boolean;
+    updates: boolean;
+    registries: boolean;
+    email: boolean;
+    stacks: boolean;
+  };
+  gwHost: string;
+  gwUser: string;
+  emailHost: string;
+  emailPort: number;
+  emailSecure: boolean;
+  emailUser: string;
+  emailFrom: string;
+  emailRecipients: string;
+}
+
+function loadPersistedWizardState(): PersistedWizardState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(WIZARD_STATE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PersistedWizardState;
+  } catch {
+    return null;
+  }
+}
+
+function clearPersistedWizardState() {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(WIZARD_STATE_KEY);
+  } catch { /* noop */ }
+}
+
 export default function OnboardingWizard() {
+  const persisted = typeof window !== 'undefined' ? loadPersistedWizardState() : null;
   const [isOpen, setIsOpen] = useState(false);
-  const [currentStep, setCurrentStep] = useState<WizardStep>('welcome');
-  const [stepHistory, setStepHistory] = useState<WizardStep[]>([]);
+  const [currentStep, setCurrentStep] = useState<WizardStep>(persisted?.currentStep ?? 'welcome');
+  const [stepHistory, setStepHistory] = useState<WizardStep[]>(persisted?.stepHistory ?? []);
   
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
   const [loading, setLoading] = useState(false);
@@ -94,7 +136,7 @@ export default function OnboardingWizard() {
   const router = useRouter();
 
   // Selection Selection (Welcome Step)
-  const [selection, setSelection] = useState({
+  const [selection, setSelection] = useState(persisted?.selection ?? {
     gateway: true,
     ssh: true,
     updates: false,
@@ -103,20 +145,20 @@ export default function OnboardingWizard() {
     stacks: true
   });
 
-  // Gateway Form
-  const [gwHost, setGwHost] = useState('fritz.box');
-  const [gwUser, setGwUser] = useState('');
+  // Gateway Form (passwords are intentionally never persisted)
+  const [gwHost, setGwHost] = useState(persisted?.gwHost ?? 'fritz.box');
+  const [gwUser, setGwUser] = useState(persisted?.gwUser ?? '');
   const [gwPass, setGwPass] = useState('');
 
-  // Email Form
+  // Email Form (pass is intentionally never persisted)
   const [emailConfig, setEmailConfig] = useState({
-      host: '',
-      port: 587,
-      secure: false,
-      user: '',
+      host: persisted?.emailHost ?? '',
+      port: persisted?.emailPort ?? 587,
+      secure: persisted?.emailSecure ?? false,
+      user: persisted?.emailUser ?? '',
       pass: '',
-      from: '',
-      recipients: ''
+      from: persisted?.emailFrom ?? '',
+      recipients: persisted?.emailRecipients ?? ''
   });
 
   // Stack Selection
@@ -151,24 +193,71 @@ export default function OnboardingWizard() {
       setStatus(s);
       if (s.needsSetup) {
         setIsOpen(true);
-        // Pre-fill selection based on detection/defaults
-        setSelection(prev => ({
-            ...prev,
-            gateway: !s.features.gateway,
-            ssh: !s.features.ssh,
-            updates: !s.features.updates,
-            registries: !s.features.registries,
-            email: !s.features.email,
-            stacks: true
-        }));
+        // Only seed selection from feature detection if we have no persisted draft —
+        // otherwise the user's in-progress choices win.
+        if (!persisted) {
+          setSelection(prev => ({
+              ...prev,
+              gateway: !s.features.gateway,
+              ssh: !s.features.ssh,
+              updates: !s.features.updates,
+              registries: !s.features.registries,
+              email: !s.features.email,
+              stacks: true
+          }));
+        } else if (typeof window !== 'undefined') {
+          addToast(
+            'info',
+            'Setup resumed',
+            'We restored your in-progress onboarding from the previous session.',
+          );
+        }
       } else if (s.stackSetupPending) {
         // Setup was completed by installer, but stacks haven't been chosen yet
         setStacksOnlyMode(true);
         setCurrentStep('stacks');
         setIsOpen(true);
+      } else {
+        // No setup needed — clear any stale draft.
+        clearPersistedWizardState();
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Persist non-secret state on every change so refresh / closed-tab resumes from the same step.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!isOpen) return;
+    const snapshot: PersistedWizardState = {
+      currentStep,
+      stepHistory,
+      selection,
+      gwHost,
+      gwUser,
+      emailHost: emailConfig.host,
+      emailPort: emailConfig.port,
+      emailSecure: emailConfig.secure,
+      emailUser: emailConfig.user,
+      emailFrom: emailConfig.from,
+      emailRecipients: emailConfig.recipients,
+    };
+    try {
+      window.sessionStorage.setItem(WIZARD_STATE_KEY, JSON.stringify(snapshot));
+    } catch { /* quota / disabled storage */ }
+  }, [isOpen, currentStep, stepHistory, selection, gwHost, gwUser, emailConfig.host, emailConfig.port, emailConfig.secure, emailConfig.user, emailConfig.from, emailConfig.recipients]);
+
+  // Warn before unload if the user has progressed past Welcome.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!isOpen || currentStep === 'welcome' || currentStep === 'finish') return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isOpen, currentStep]);
 
   // Load stacks when entering the stacks step
   const loadStacks = useCallback(async () => {
@@ -228,6 +317,7 @@ export default function OnboardingWizard() {
 
   const handleSkip = async () => {
     await skipOnboarding();
+    clearPersistedWizardState();
     setIsOpen(false);
     addToast('info', 'Setup Skipped', 'You can configure settings later in the System menu.');
   };
@@ -252,6 +342,7 @@ export default function OnboardingWizard() {
     } else {
       await skipOnboarding(); // Mark as complete
     }
+    clearPersistedWizardState();
     setIsOpen(false);
     router.refresh();
     addToast('success', 'Setup Complete', 'Welcome to ServiceBay!');
@@ -665,6 +756,7 @@ export default function OnboardingWizard() {
     if (stacksOnlyMode) {
       // In stacks-only mode, skipping goes straight to finish
       await completeStackSetup();
+      clearPersistedWizardState();
       setIsOpen(false);
       router.refresh();
       addToast('info', 'Stack Setup Skipped', 'You can install services later from the Registry.');

--- a/src/components/PageHeader.test.tsx
+++ b/src/components/PageHeader.test.tsx
@@ -1,25 +1,52 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import PageHeader from './PageHeader';
+import { ToastProvider } from '../providers/ToastProvider';
 
-// Mock useRouter
 const backMock = vi.fn();
+const pushMock = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     back: backMock,
+    push: pushMock,
   }),
 }));
 
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => ({ socket: null, isConnected: true }),
+}));
+
+const renderWithToast = (ui: React.ReactNode) =>
+  render(<ToastProvider>{ui}</ToastProvider>);
+
 describe('PageHeader', () => {
   it('renders the title correctly', () => {
-    render(<PageHeader title="Test Title" />);
+    renderWithToast(<PageHeader title="Test Title" />);
     expect(screen.getByText('Test Title')).toBeDefined();
   });
 
-  it('calls router.back() when back button is clicked', () => {
-    render(<PageHeader title="Test Title" />);
-    const backButton = screen.getByTitle('Go Back');
-    fireEvent.click(backButton);
+  it('does not render a back button by default (root pages)', () => {
+    renderWithToast(<PageHeader title="Root Page" />);
+    expect(screen.queryByLabelText('Go back')).toBeNull();
+  });
+
+  it('calls router.back() when back button is clicked and history exists', () => {
+    Object.defineProperty(window, 'history', {
+      configurable: true,
+      value: { length: 5 },
+    });
+    renderWithToast(<PageHeader title="Sub Page" showBack />);
+    fireEvent.click(screen.getByLabelText('Go back'));
     expect(backMock).toHaveBeenCalled();
+  });
+
+  it('falls back to /services when there is no browser history', () => {
+    Object.defineProperty(window, 'history', {
+      configurable: true,
+      value: { length: 1 },
+    });
+    renderWithToast(<PageHeader title="Sub Page" showBack />);
+    fireEvent.click(screen.getByLabelText('Go back'));
+    expect(pushMock).toHaveBeenCalledWith('/services');
   });
 });

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -3,6 +3,7 @@
 import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import PluginHelp from './PluginHelp';
+import ConnectionIndicator from './ConnectionIndicator';
 
 interface PageHeaderProps {
   title: string;
@@ -12,17 +13,26 @@ interface PageHeaderProps {
   helpId?: string;
 }
 
-export default function PageHeader({ title, children, actions, showBack = true, helpId }: PageHeaderProps) {
+export default function PageHeader({ title, children, actions, showBack = false, helpId }: PageHeaderProps) {
   const router = useRouter();
-  
+
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/services');
+    }
+  };
+
   return (
     <div className="flex items-center gap-4 p-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
       <div className="flex items-center gap-4 shrink-0">
         {showBack && (
-          <button 
-            onClick={() => router.back()} 
+          <button
+            onClick={handleBack}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
             title="Go Back"
+            aria-label="Go back"
           >
             <ArrowLeft size={24} className="text-gray-600 dark:text-gray-300" />
           </button>
@@ -37,11 +47,10 @@ export default function PageHeader({ title, children, actions, showBack = true, 
         </div>
       )}
 
-      {actions && (
-        <div className="flex items-center gap-2 shrink-0 ml-auto">
-            {actions}
-        </div>
-      )}
+      <div className={`flex items-center gap-3 shrink-0 ${children ? '' : 'ml-auto'}`}>
+        {actions}
+        <ConnectionIndicator inline />
+      </div>
     </div>
   );
 }

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import yaml from 'js-yaml';
-import { Settings, FileCode, FileJson, FileText, AlertCircle, Network, HardDrive, Pencil, AlertTriangle, Clock, Server, Clipboard } from 'lucide-react';
+import { Settings, FileCode, FileJson, FileText, AlertCircle, Network, HardDrive, Pencil, AlertTriangle, Clock, Server, Clipboard, Loader2 } from 'lucide-react';
 import Editor from 'react-simple-code-editor';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-yaml';
@@ -86,6 +86,7 @@ export default function ServiceForm({ initialData, isEdit, defaultNode, onClose,
   const [newServiceName, setNewServiceName] = useState('');
   const [renameError, setRenameError] = useState<string | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [activeTab, setActiveTab] = useState<'yaml' | 'kube' | 'service' | 'history'>('yaml');
 
   // Options for generation
@@ -280,10 +281,12 @@ WantedBy=default.target`;
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        if (isSaving) return;
         const query = selectedNode ? `?node=${selectedNode}` : '';
         const url = isEdit ? `/api/services/${name}${query}` : `/api/services${query}`;
         const method = isEdit ? 'PUT' : 'POST';
 
+        setIsSaving(true);
         try {
                 const res = await fetch(url, {
                     method,
@@ -295,6 +298,8 @@ WantedBy=default.target`;
                         throw new Error(data.error || 'Failed to save service');
                 }
 
+                addToast('success', 'Service saved', isEdit ? `${name} updated` : `${name} created`);
+
                 if (variant === 'embedded') {
                         onClose?.();
                         router.refresh();
@@ -305,6 +310,8 @@ WantedBy=default.target`;
         } catch (error) {
                 const message = error instanceof Error ? error.message : 'Failed to save service';
                 addToast('error', 'Save failed', message);
+        } finally {
+                setIsSaving(false);
         }
     };
 
@@ -719,12 +726,13 @@ WantedBy=default.target`;
                     Cancel
                 </button>
             )}
-            <button 
-                type="submit" 
-                disabled={!!yamlError || !name || !selectedNode}
-                className="px-6 py-3 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            <button
+                type="submit"
+                disabled={!!yamlError || !name || !selectedNode || isSaving}
+                className="px-6 py-3 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
-            Save Service
+            {isSaving && <Loader2 size={16} className="animate-spin" />}
+            {isSaving ? 'Saving…' : 'Save Service'}
             </button>
         </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,12 +7,12 @@ import ServiceBayLogo from './ServiceBayLogo';
 import pkg from '../../package.json';
 
 export const plugins = [
-    { id: 'services', name: 'Services', icon: Box, path: '/services' },
-    { id: 'containers', name: 'Container Engine', icon: LayoutDashboard, path: '/containers' },
-    { id: 'network', name: 'Network Map', icon: Network, path: '/network' },
-    { id: 'monitoring', name: 'Monitoring', icon: Activity, path: '/monitoring' },
-    { id: 'terminal', name: 'SSH Terminal', icon: Terminal, path: '/terminal' },
-    { id: 'settings', name: 'Settings', icon: Settings, path: '/settings' },
+    { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
+    { id: 'containers', name: 'Container Engine', shortLabel: 'Containers', icon: LayoutDashboard, path: '/containers' },
+    { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
+    { id: 'monitoring', name: 'Monitoring', shortLabel: 'Monitor', icon: Activity, path: '/monitoring' },
+    { id: 'terminal', name: 'SSH Terminal', shortLabel: 'Terminal', icon: Terminal, path: '/terminal' },
+    { id: 'settings', name: 'Settings', shortLabel: 'Settings', icon: Settings, path: '/settings' },
 ];
 
 export default function Sidebar() {
@@ -21,6 +21,7 @@ export default function Sidebar() {
   const node = searchParams?.get('node');
   const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [showCollapsedNodeLabel, setShowCollapsedNodeLabel] = useState(false);
   const [lldapUrl, setLldapUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -68,7 +69,18 @@ export default function Sidebar() {
             </div>
         )}
         {node && isCollapsed && (
-            <div className="mx-auto mb-1 w-3 h-3 rounded-full bg-amber-500 animate-pulse" title={`Node: ${node}`} />
+            <button
+                type="button"
+                onClick={() => setShowCollapsedNodeLabel(v => !v)}
+                title={`Node: ${node}`}
+                aria-label={`Active node: ${node}. Tap for details.`}
+                className="mx-auto mb-1 flex flex-col items-center gap-0.5 focus:outline-none"
+            >
+                <span className="w-3 h-3 rounded-full bg-amber-500 animate-pulse" />
+                {showCollapsedNodeLabel && (
+                    <span className="text-[9px] font-mono text-amber-600 dark:text-amber-400 max-w-[3.5rem] truncate">{node}</span>
+                )}
+            </button>
         )}
         <div className="overflow-y-auto flex-1 p-2 space-y-1">
             {plugins.map(p => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -102,7 +102,12 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({ id = 'host', showCont
     }
 
     // Handle socket events
+    let hasEverConnected = false;
     socket.on('connect', () => {
+        if (hasEverConnected) {
+            term.write('\r\n\x1b[32mReconnected.\x1b[0m\r\n');
+        }
+        hasEverConnected = true;
         // Re-join on reconnect
         if (termRef.current) {
             socket.emit('join', { id, cols: termRef.current.cols, rows: termRef.current.rows });
@@ -119,8 +124,22 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({ id = 'host', showCont
     });
 
     socket.on('disconnect', () => {
-      term.write('\r\n\x1b[31mDisconnected from server.\x1b[0m\r\n');
+      term.write('\r\n\x1b[31mDisconnected from server. Reconnecting…\x1b[0m\r\n');
     });
+
+    // When the tab becomes visible again (e.g. after backgrounding), re-fit
+    // the terminal so it draws crisply at the current container size.
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && fitAddonRef.current && termRef.current) {
+        try {
+          fitAddonRef.current.fit();
+          if (socketRef.current) {
+            socketRef.current.emit('resize', { id, cols: termRef.current.cols, rows: termRef.current.rows });
+          }
+        } catch { /* noop */ }
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
 
     // Handle terminal input
     term.onData((data) => {
@@ -157,6 +176,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({ id = 'host', showCont
       socket.disconnect();
       term.dispose();
       window.removeEventListener('resize', handleResize);
+      document.removeEventListener('visibilitychange', handleVisibility);
       resizeObserver.disconnect();
       initObserver?.disconnect();
     };

--- a/src/hooks/useContainerActions.tsx
+++ b/src/hooks/useContainerActions.tsx
@@ -88,12 +88,15 @@ export function useContainerActions({ onActionComplete }: UseContainerActionsOpt
       <>
         <ConfirmModal
           isOpen={deleteModalOpen}
-          title="Delete Container"
-          message={`Are you sure you want to delete container "${selectedContainer.name}"? This action cannot be undone.`}
+          title="Delete container"
+          message="The container will be removed and any unmounted volumes will be lost. Type the container name to confirm."
           confirmText="Delete"
           isDestructive
+          resourceName={selectedContainer.name}
+          requireTypedConfirm
+          isLoading={actionLoading}
           onConfirm={() => handleAction('delete')}
-          onCancel={() => setDeleteModalOpen(false)}
+          onCancel={() => { if (!actionLoading) setDeleteModalOpen(false); }}
         />
         <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4">
           <div className="relative bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-md border border-gray-200 dark:border-gray-800 p-5">

--- a/src/hooks/useServiceActions.tsx
+++ b/src/hooks/useServiceActions.tsx
@@ -34,6 +34,7 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
 
   const [serviceToDelete, setServiceToDelete] = useState<ServiceViewModel | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deleteInFlight, setDeleteInFlight] = useState(false);
 
   const closeDrawer = useCallback(() => {
     setDrawerState(null);
@@ -110,8 +111,8 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
   }, []);
 
   const handleDelete = useCallback(async () => {
-    if (!serviceToDelete) return;
-    setDeleteModalOpen(false);
+    if (!serviceToDelete || deleteInFlight) return;
+    setDeleteInFlight(true);
     const toastId = addToast('loading', 'Deleting service...', `Removing ${serviceToDelete.name}`, 0);
 
     try {
@@ -132,8 +133,11 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
       }
     } catch {
       updateToast(toastId, 'error', 'Delete failed', 'An unexpected error occurred.');
+    } finally {
+      setDeleteInFlight(false);
+      setDeleteModalOpen(false);
     }
-  }, [addToast, onRefresh, serviceToDelete, updateToast]);
+  }, [addToast, deleteInFlight, onRefresh, serviceToDelete, updateToast]);
 
   const handleAction = useCallback(async (action: string) => {
     if (!selectedService) return;
@@ -179,12 +183,15 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     <>
       <ConfirmModal
         isOpen={deleteModalOpen}
-        title="Delete Service"
-        message={`Are you sure you want to delete service "${serviceToDelete?.name ?? ''}"? This action cannot be undone.`}
+        title="Delete service"
+        message="Stops the service, removes the .kube and YAML units from disk, and reloads systemd. This cannot be undone — type the service name to confirm."
         confirmText="Delete"
         isDestructive
+        resourceName={serviceToDelete?.name ?? ''}
+        requireTypedConfirm={Boolean(serviceToDelete?.name)}
+        isLoading={deleteInFlight}
         onConfirm={handleDelete}
-        onCancel={() => setDeleteModalOpen(false)}
+        onCancel={() => { if (!deleteInFlight) setDeleteModalOpen(false); }}
       />
 
       {actionService && currentAction && (
@@ -354,6 +361,7 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     addToast,
     closeDrawer,
     currentAction,
+    deleteInFlight,
     deleteModalOpen,
     drawerLoading,
     drawerState,

--- a/src/lib/util/humanizeError.ts
+++ b/src/lib/util/humanizeError.ts
@@ -1,0 +1,73 @@
+/**
+ * Map common low-level error strings to short, actionable messages so the UI
+ * doesn't surface raw `String(err)` (e.g. `TypeError: NetworkError`) to users.
+ *
+ * Returns the original message verbatim when nothing matches — never hides
+ * detail, only adds a hint when one applies.
+ */
+export interface HumanizedError {
+  /** Short title suitable for a toast headline. */
+  title: string;
+  /** One-line description with a next step, or the raw message if no rule matched. */
+  detail: string;
+}
+
+const NETWORK_RX = /(failed to fetch|network ?error|load failed|err_internet_disconnected|err_connection_refused|fetch failed)/i;
+const TIMEOUT_RX = /(timeout|timed out|etimedout)/i;
+const UNAUTHORIZED_RX = /\b(401|unauthorized|authentication required)\b/i;
+const FORBIDDEN_RX = /\b(403|forbidden)\b/i;
+const NOT_FOUND_RX = /\b(404|not found)\b/i;
+const SERVER_RX = /\b(50\d|internal server error)\b/i;
+const SSH_KEY_RX = /(no key|permission denied \(publickey\)|ssh key|host key verification)/i;
+const AGENT_RX = /(agent not connected|agent disconnected|agent unreachable)/i;
+
+export function humanizeError(err: unknown, fallbackTitle = 'Something went wrong'): HumanizedError {
+  const raw = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  const message = raw.trim();
+
+  if (!message) {
+    return { title: fallbackTitle, detail: 'An unexpected error occurred. Try again or check the server logs.' };
+  }
+
+  if (UNAUTHORIZED_RX.test(message)) {
+    return { title: 'Session expired', detail: 'Please sign in again to continue.' };
+  }
+  if (FORBIDDEN_RX.test(message)) {
+    return { title: 'Permission denied', detail: 'Your account is not allowed to perform this action.' };
+  }
+  if (NOT_FOUND_RX.test(message)) {
+    return { title: 'Not found', detail: 'The requested resource no longer exists. It may have been removed.' };
+  }
+  if (AGENT_RX.test(message)) {
+    return {
+      title: 'Node agent unreachable',
+      detail: 'The agent on this node is not responding. Check Settings → Nodes and confirm SSH connectivity.',
+    };
+  }
+  if (SSH_KEY_RX.test(message)) {
+    return {
+      title: 'SSH authentication failed',
+      detail: 'The node refused the SSH key. Generate or upload the key under Settings → Nodes → SSH.',
+    };
+  }
+  if (TIMEOUT_RX.test(message)) {
+    return {
+      title: 'Request timed out',
+      detail: 'The server did not respond in time. Retry, or check the node’s connectivity.',
+    };
+  }
+  if (NETWORK_RX.test(message)) {
+    return {
+      title: 'Network error',
+      detail: 'Could not reach the ServiceBay server. Check your connection and reload.',
+    };
+  }
+  if (SERVER_RX.test(message)) {
+    return {
+      title: 'Server error',
+      detail: `${message}. The server logged a problem — check Settings → Logs for details.`,
+    };
+  }
+
+  return { title: fallbackTitle, detail: message };
+}

--- a/tests/backend/humanizeError.test.ts
+++ b/tests/backend/humanizeError.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { humanizeError } from '../../src/lib/util/humanizeError';
+
+describe('humanizeError', () => {
+    it('returns a fallback for empty input', () => {
+        const out = humanizeError(undefined);
+        expect(out.title).toMatch(/something went wrong/i);
+        expect(out.detail).toContain('unexpected');
+    });
+
+    it('detects 401 / unauthorized', () => {
+        expect(humanizeError(new Error('Request failed: 401')).title).toMatch(/session expired/i);
+        expect(humanizeError('unauthorized').title).toMatch(/session expired/i);
+    });
+
+    it('detects 403 / forbidden', () => {
+        expect(humanizeError('403 Forbidden').title).toMatch(/permission denied/i);
+    });
+
+    it('detects 404 / not found', () => {
+        expect(humanizeError('404 Not Found').title).toMatch(/not found/i);
+    });
+
+    it('detects agent-disconnect strings', () => {
+        const out = humanizeError(new Error('Agent not connected'));
+        expect(out.title).toMatch(/agent unreachable/i);
+        expect(out.detail).toMatch(/Settings/);
+    });
+
+    it('detects ssh key failures', () => {
+        const out = humanizeError(new Error('Permission denied (publickey)'));
+        expect(out.title).toMatch(/ssh authentication/i);
+    });
+
+    it('detects timeouts', () => {
+        expect(humanizeError(new Error('ETIMEDOUT')).title).toMatch(/timed out/i);
+    });
+
+    it('detects network errors', () => {
+        expect(humanizeError(new Error('Failed to fetch')).title).toMatch(/network/i);
+    });
+
+    it('returns the raw message when nothing matches', () => {
+        const out = humanizeError(new Error('something specific happened'));
+        expect(out.detail).toContain('something specific happened');
+    });
+});

--- a/tests/frontend/ConfirmModal.test.tsx
+++ b/tests/frontend/ConfirmModal.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ConfirmModal from '../../src/components/ConfirmModal';
+
+describe('ConfirmModal', () => {
+    // The vitest Mock type isn't a perfect fit for `() => void` props, so cast
+    // through unknown to keep the prop typing happy while preserving the spy.
+    let onConfirm: () => void;
+    let onCancel: () => void;
+    const onConfirmSpy = vi.fn();
+    const onCancelSpy = vi.fn();
+
+    beforeEach(() => {
+        onConfirmSpy.mockReset();
+        onCancelSpy.mockReset();
+        onConfirm = onConfirmSpy as unknown as () => void;
+        onCancel = onCancelSpy as unknown as () => void;
+    });
+
+    it('returns null when not open', () => {
+        const { container } = render(
+            <ConfirmModal isOpen={false} title="t" message="m" onConfirm={onConfirm} onCancel={onCancel} />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows resourceName when provided', () => {
+        render(
+            <ConfirmModal
+                isOpen
+                title="Delete service"
+                message="Are you sure?"
+                resourceName="postgres-prod"
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        expect(screen.getByText('postgres-prod')).toBeDefined();
+    });
+
+    it('disables confirm until resourceName is typed', () => {
+        render(
+            <ConfirmModal
+                isOpen
+                title="Delete service"
+                message="Type to confirm."
+                resourceName="postgres-prod"
+                requireTypedConfirm
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        const confirmBtn = screen.getByRole('button', { name: /confirm/i }) as HTMLButtonElement;
+        expect(confirmBtn.disabled).toBe(true);
+
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'wrong' } });
+        expect(confirmBtn.disabled).toBe(true);
+
+        fireEvent.change(input, { target: { value: 'postgres-prod' } });
+        expect(confirmBtn.disabled).toBe(false);
+
+        fireEvent.click(confirmBtn);
+        expect(onConfirmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter submits when type-to-confirm is not required', () => {
+        const { container } = render(
+            <ConfirmModal
+                isOpen
+                title="Save"
+                message="ok?"
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        const dialog = container.querySelector('[role="dialog"]') as HTMLElement;
+        // Move focus away from cancel default before pressing Enter to simulate user
+        // having tabbed to the confirm button.
+        const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+        confirmBtn.focus();
+        fireEvent.keyDown(dialog, { key: 'Enter' });
+        expect(onConfirmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter does NOT submit when type-to-confirm is required', () => {
+        const { container } = render(
+            <ConfirmModal
+                isOpen
+                title="Delete"
+                message="ok?"
+                resourceName="x"
+                requireTypedConfirm
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        const dialog = container.querySelector('[role="dialog"]') as HTMLElement;
+        fireEvent.keyDown(dialog, { key: 'Enter' });
+        expect(onConfirmSpy).not.toHaveBeenCalled();
+    });
+
+    it('disables both buttons while loading', () => {
+        render(
+            <ConfirmModal
+                isOpen
+                title="Delete"
+                message="ok?"
+                isLoading
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        const cancelBtn = screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement;
+        const confirmBtn = screen.getByRole('button', { name: 'Confirm' }) as HTMLButtonElement;
+        expect(cancelBtn.disabled).toBe(true);
+        expect(confirmBtn.disabled).toBe(true);
+    });
+});

--- a/tests/frontend/MobileNav.test.tsx
+++ b/tests/frontend/MobileNav.test.tsx
@@ -2,57 +2,63 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MobileTopBar, MobileBottomBar } from '../../src/components/MobileNav';
+import { ToastProvider } from '../../src/providers/ToastProvider';
 
 const mockPush = vi.fn();
+let currentNode: string | null = null;
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/network', // Default active
-  useRouter: () => ({ push: mockPush })
+  usePathname: () => '/network',
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: (key: string) => (key === 'node' ? currentNode : null) }),
 }));
+
+const renderWithToast = (ui: React.ReactNode) =>
+    render(<ToastProvider>{ui}</ToastProvider>);
 
 describe('MobileNav', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        currentNode = null;
+        if (typeof window !== 'undefined') window.localStorage.clear();
     });
 
-    it('MobileTopBar renders logo and settings', () => {
-        render(<MobileTopBar />);
+    it('MobileTopBar renders logo and routes Settings click', () => {
+        renderWithToast(<MobileTopBar />);
         expect(screen.getByText('ServiceBay')).toBeDefined();
-        
-        // Find Settings button using class logic or assumptions?
-        // Actually, MobileTopBar buttons: Settings and Github.
-        // We can look for buttons.
-        const buttons = screen.getAllByRole('button');
-        // Filter for the one that calls push('/settings') on click?
-        // Or better, let's just find the first one which is Settings in the code.
-        const settingsBtn = buttons[0]; 
-        
+
+        const settingsBtn = screen.getByLabelText('Open settings');
         fireEvent.click(settingsBtn);
         expect(mockPush).toHaveBeenCalledWith('/settings');
     });
 
-    it('MobileBottomBar renders plugins except Settings', () => {
-        render(<MobileBottomBar />);
-        
-        // Should show Container Engine (via title)
+    it('MobileTopBar preserves ?node= on Settings click', () => {
+        currentNode = 'edge-1';
+        renderWithToast(<MobileTopBar />);
+        fireEvent.click(screen.getByLabelText('Open settings'));
+        expect(mockPush).toHaveBeenCalledWith('/settings?node=edge-1');
+    });
+
+    it('MobileBottomBar renders plugins except Settings using shortLabel', () => {
+        renderWithToast(<MobileBottomBar />);
         expect(screen.getByTitle('Container Engine')).toBeDefined();
-        // Should show Network
         expect(screen.getByTitle('Network Map')).toBeDefined();
-        
-        // Should NOT show Settings (filtered out)
         expect(screen.queryByTitle('Settings')).toBeNull();
+        // shortLabel renders "Containers", not the trimmed-first-word "Container".
+        expect(screen.getByText('Containers')).toBeDefined();
     });
 
     it('MobileBottomBar highlights active route', () => {
-        // usePathname is '/network'
-        render(<MobileBottomBar />);
-        
+        renderWithToast(<MobileBottomBar />);
         const networkBtn = screen.getByTitle('Network Map');
-        
-        // Active class logic in MobileNav: isActive ? 'text-blue-600 ...' : 'text-gray-500 ...'
         expect(networkBtn.className).toContain('text-blue-600');
-        
-        // Inactive
         const containersBtn = screen.getByTitle('Container Engine');
         expect(containersBtn.className).not.toContain('text-blue-600');
+    });
+
+    it('MobileBottomBar threads ?node= into navigation', () => {
+        currentNode = 'edge-1';
+        renderWithToast(<MobileBottomBar />);
+        fireEvent.click(screen.getByTitle('Container Engine'));
+        expect(mockPush).toHaveBeenCalledWith('/containers?node=edge-1');
     });
 });

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -107,6 +107,11 @@ const mockNodes = [{ Name: 'Local', URI: 'unix:///run/podman/podman.sock', Ident
 describe('OnboardingWizard', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        // The wizard now persists in-progress state to sessionStorage. Clear it
+        // between tests so each spec starts with a clean wizard.
+        if (typeof window !== 'undefined') {
+            window.sessionStorage.clear();
+        }
         (getNodes as any).mockResolvedValue(mockNodes);
         (fetchTemplates as any).mockResolvedValue(mockStacks);
         (fetchReadme as any).mockResolvedValue(mockStackReadme);


### PR DESCRIPTION
## Summary

Bundle of 18 frontend UX fixes from the audit. Each grounded in a specific file:line; nothing speculative. The deferred 3487-line settings split is **not** in this PR — it's a major refactor that warrants its own.

### High-impact
- **Mobile loses `?node=` on tab switch** — `MobileNav.tsx` now threads searchParams into every router push, matching desktop
- **Socket.IO health invisible** — new `ConnectionIndicator` shows Live/Offline dot in `PageHeader` + sticky disconnect toast that clears on reconnect
- **Raw `String(err)` leakage** — new `humanizeError` helper maps 401/403/404/timeout/network/SSH/agent strings to actionable next-step messages; adopted by `LogViewer`, `LogLevelControl`, `ActionProgressModal`
- **Destructive deletes had no friction** — `ConfirmModal` gains `resourceName` echo + `requireTypedConfirm`; service and container delete both require typing the name

### Medium
- **`ConfirmModal`** — `isLoading` prop disables both buttons; Enter submits when not requiring typed confirm; focus-managed; ESC respects loading state
- **`ServiceForm`** submit gets spinner + disabled state + success toast
- **`ContainerList`** — 15s timeout fallback ("still trying… [Refresh]") instead of an indefinite spinner; truncation tooltips on long names
- **`LogViewer`** — Copy-to-clipboard button + Pause/Resume live-stream toggle; footer reflects paused state
- **`OnboardingWizard`** persists non-secret state (step, history, selection, gateway/email host fields) to `sessionStorage` so a refresh mid-setup resumes from the same step. Passwords are intentionally never persisted. `beforeunload` warns past the welcome step
- **`ActionProgressModal`** — "Run in background" minimize swaps the modal for a sticky toast that updates to success/error
- **`Terminal`** — `visibilitychange` listener re-fits on tab return; prints a clear "Reconnected" line on subsequent connects

### Polish
- **`MobileNav`** uses an explicit `shortLabel` per plugin (no more `.split(' ')[0]`); first-mobile-visit toast points at the Settings icon
- **`Sidebar`** collapsed mode: amber node dot becomes a tappable button that reveals the node name on touch
- **`PageHeader`** defaults to `showBack=false`; falls back to `/services` when `history.length <= 1`; create/edit/view opt back in
- **Login** — caps-lock detection with inline warning
- **`ExternalLinkModal`** — HTTP(S) URL validation, inline error, disabled save until valid

## Test plan

- [x] `npm test` — 262 tests pass (added 19 new across `ConfirmModal`, `MobileNav`, `PageHeader`, `humanizeError`)
- [x] `npm run build` — succeeds
- [x] `npm run lint` clean on touched files
- [x] `npm run knip` clean
- [ ] Manual: visit `/` on a mobile breakpoint, confirm `?node=foo` survives tab switches in the bottom bar
- [ ] Manual: kill the server, confirm the Live dot turns red and the disconnect toast fires; restart and watch them clear
- [ ] Manual: delete a service from `useServiceActions` — modal echoes the name, requires typing it, button shows spinner while DELETE is in flight
- [ ] Manual: start a service action, click the new Minimize icon, confirm the modal closes and a sticky toast tracks the action to completion
- [ ] Manual: begin onboarding, advance to Gateway step, refresh — wizard reopens at Gateway with host/user prefilled, password field empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)