### PR TITLE
feat: expand MCP tool surface; rename /monitor/[name] to /services/[name]

### DIFF
--- a/src/app/(dashboard)/services/[name]/page.tsx
+++ b/src/app/(dashboard)/services/[name]/page.tsx
@@ -1,6 +1,6 @@
 import ServiceMonitor from '@/components/ServiceMonitor';
 
-export default async function MonitorPage({ params }: { params: Promise<{ name: string }> }) {
+export default async function ServiceDetailPage({ params }: { params: Promise<{ name: string }> }) {
   const { name: rawName } = await params;
   const name = decodeURIComponent(rawName);
   return <ServiceMonitor serviceName={name} />;

--- a/src/components/ServiceActionBar.tsx
+++ b/src/components/ServiceActionBar.tsx
@@ -26,7 +26,7 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
       {isGateway ? (
         <>
           <Link
-            href="/monitor/gateway"
+            href="/services/gateway"
             className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/30 rounded transition-colors"
             title="Monitor Gateway"
           >

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { randomUUID } from 'crypto';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import {
   getAllSystemServices,
@@ -9,6 +10,15 @@ import { getTemplates, getReadme, getTemplateYaml, getTemplateVariables } from '
 import { listNodes, getNodeConnection, verifyNodeConnection } from '@/lib/nodes';
 import { agentManager } from '@/lib/agent/manager';
 import { MonitoringStore } from '@/lib/monitoring/store';
+import { CheckRunner } from '@/lib/monitoring/runner';
+import type { CheckConfig, CheckType } from '@/lib/monitoring/types';
+import { getConfig, updateConfig, type AppConfig, type ProxyHostEntry } from '@/lib/config';
+import {
+  getBackupHistory,
+  runBackup as runBackupService,
+  isBackupRunning,
+} from '@/lib/backup/service';
+import { restoreSystemBackup } from '@/lib/systemBackup';
 
 const nodeParam = z.string().optional().describe('Node name (defaults to first available node)');
 
@@ -73,30 +83,54 @@ export function createMcpServer() {
   // --- Get Service Logs ---
   server.tool(
     'get_service_logs',
-    'Fetch systemd and podman logs for a service',
-    { name: z.string().describe('Service name'), node: nodeParam },
-    async ({ name, node }) => {
+    'Fetch systemd journal logs for a service. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
+    {
+      name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').describe('Service name'),
+      node: nodeParam,
+      lines: z.number().int().min(1).max(10000).optional().describe('Number of lines from the end (default 200)'),
+      since: z.number().int().optional().describe('Unix seconds — return only entries newer than this'),
+    },
+    async ({ name, node, lines, since }) => {
       const nodeName = await resolveNode(node);
-      const logs = await ServiceManager.getServiceLogs(nodeName, name);
-      return textResult(logs);
+      try {
+        const agent = agentManager.getAgent(nodeName);
+        const unit = name.match(/\.(service|scope|socket|timer)$/) ? name : `${name}.service`;
+        const args = [`--user`, `-u`, unit, `-n`, String(lines ?? 200), '--no-pager', '--output', 'short-iso'];
+        if (since) args.push('--since', `@${since}`);
+        const result = await agent.sendCommand('exec', { command: `journalctl ${args.join(' ')} 2>&1` });
+        return textResult({
+          stdout: result.stdout ?? '',
+          exitCode: result.code,
+          fetchedAt: Math.floor(Date.now() / 1000),
+        });
+      } catch (err) {
+        return errorResult(`Error fetching service logs: ${err instanceof Error ? err.message : String(err)}`);
+      }
     },
   );
 
   // --- Get Container Logs ---
   server.tool(
     'get_container_logs',
-    'Fetch container stdout/stderr logs',
+    'Fetch container stdout/stderr logs. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
     {
-      id: z.string().describe('Container ID or name'),
+      id: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid container id').describe('Container ID or name'),
       node: nodeParam,
-      tail: z.number().optional().describe('Number of lines from the end (default 100)'),
+      tail: z.number().int().min(1).max(10000).optional().describe('Number of lines from the end (default 200)'),
+      since: z.number().int().optional().describe('Unix seconds — return only lines newer than this'),
     },
-    async ({ id, node, tail }) => {
+    async ({ id, node, tail, since }) => {
       const nodeName = await resolveNode(node);
       try {
         const agent = agentManager.getAgent(nodeName);
-        const result = await agent.sendCommand('containerLogs', { id, tail: tail ?? 100 });
-        return textResult(result);
+        const args = [`--tail ${tail ?? 200}`, '--timestamps'];
+        if (since) args.push(`--since ${since}`);
+        const result = await agent.sendCommand('exec', { command: `podman logs ${args.join(' ')} ${id} 2>&1` });
+        return textResult({
+          stdout: result.stdout ?? '',
+          exitCode: result.code,
+          fetchedAt: Math.floor(Date.now() / 1000),
+        });
       } catch (err) {
         return errorResult(`Error fetching container logs: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -421,6 +455,261 @@ export function createMcpServer() {
         return textResult(`Agent for "${nodeName}" refreshed successfully`);
       } catch (err) {
         return errorResult(`Error refreshing agent: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  // --- Update Service YAML (edit then redeploy) ---
+  server.tool(
+    'update_service_yaml',
+    'Replace a service\'s kube YAML and redeploy it. Use `get_service_files` first, modify, then call this. The file is written and `systemctl --user daemon-reload` + service restart is triggered.',
+    {
+      name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').describe('Service name'),
+      kubeContent: z.string().min(1).describe('Full kube YAML content (replaces existing)'),
+      yamlContent: z.string().optional().describe('Optional companion compose/config YAML'),
+      yamlFileName: z.string().optional().describe('Filename for companion YAML (default: <name>.yaml)'),
+      node: nodeParam,
+    },
+    async ({ name, kubeContent, yamlContent, yamlFileName, node }) => {
+      const nodeName = await resolveNode(node);
+      try {
+        await ServiceManager.deployKubeService(
+          nodeName,
+          name,
+          kubeContent,
+          yamlContent ?? '',
+          yamlFileName ?? `${name}.yaml`,
+        );
+        return textResult(`Service "${name}" updated and redeployed`);
+      } catch (err) {
+        return errorResult(`Error updating service: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  // --- Reverse-proxy routes (declarative; updates config.reverseProxy.hosts) ---
+  // Note: writing to config records the desired route. Pushing to NPM (Nginx
+  // Proxy Manager) still happens via the UI / POST /api/system/nginx/proxy-hosts
+  // because that requires NPM admin credentials.
+
+  server.tool(
+    'add_proxy_route',
+    'Add or update a reverse-proxy route entry in ServiceBay config. Domain is the public hostname; forwardPort is the internal port. Updates `config.reverseProxy.hosts`. Pushing to NPM still requires the user to click "sync" in Settings.',
+    {
+      domain: z.string().regex(/^[a-zA-Z0-9.-]+$/, 'invalid domain').describe('Public domain, e.g. "vault.example.com"'),
+      forwardPort: z.number().int().min(1).max(65535).describe('Internal port the upstream service listens on'),
+      service: z.string().optional().describe('Logical service name (default: first label of domain)'),
+    },
+    async ({ domain, forwardPort, service }) => {
+      const config = await getConfig();
+      const hosts = [...(config.reverseProxy?.hosts ?? [])];
+      const idx = hosts.findIndex(h => h.domain === domain);
+      const entry: ProxyHostEntry = {
+        domain,
+        service: service ?? domain.split('.')[0],
+        forwardPort,
+        created: idx >= 0 ? hosts[idx].created : false,
+        sslConfigured: idx >= 0 ? hosts[idx].sslConfigured : false,
+        createdAt: idx >= 0 ? hosts[idx].createdAt : new Date().toISOString(),
+      };
+      if (idx >= 0) hosts[idx] = entry;
+      else hosts.push(entry);
+      await updateConfig({ reverseProxy: { ...config.reverseProxy, hosts } });
+      return textResult({
+        action: idx >= 0 ? 'updated' : 'added',
+        entry,
+        note: 'Config updated. Push to NPM via Settings → Reverse Proxy → Sync.',
+      });
+    },
+  );
+
+  server.tool(
+    'remove_proxy_route',
+    'Remove a reverse-proxy route entry from ServiceBay config (does not remove from NPM — do that in the UI).',
+    {
+      domain: z.string().regex(/^[a-zA-Z0-9.-]+$/, 'invalid domain').describe('Public domain to remove'),
+    },
+    async ({ domain }) => {
+      const config = await getConfig();
+      const hosts = config.reverseProxy?.hosts ?? [];
+      const filtered = hosts.filter(h => h.domain !== domain);
+      if (filtered.length === hosts.length) {
+        return errorResult(`No proxy route found for domain "${domain}"`);
+      }
+      await updateConfig({ reverseProxy: { ...config.reverseProxy, hosts: filtered } });
+      return textResult({ action: 'removed', domain });
+    },
+  );
+
+  // --- Backups ---
+
+  server.tool('list_backups', 'List recent backup runs (success / failed) with timestamps and file paths', {}, async () => {
+    const history = await getBackupHistory();
+    return textResult(history);
+  });
+
+  server.tool(
+    'run_backup',
+    'Trigger a backup run now. Returns the run record once complete. Errors if a backup is already running.',
+    {},
+    async () => {
+      if (isBackupRunning()) {
+        return errorResult('A backup is already running. Wait for it to finish before starting another.');
+      }
+      try {
+        const result = await runBackupService();
+        return textResult(result);
+      } catch (err) {
+        return errorResult(`Backup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  server.tool(
+    'restore_backup',
+    'Restore a full system backup from a backup file. This restores config, services, and data — use with care. For selective restore, use the UI.',
+    {
+      fileName: z.string().min(1).describe('Backup file name as returned by list_backups (e.g. "servicebay-2026-05-04.tar.gz")'),
+    },
+    async ({ fileName }) => {
+      try {
+        const entry = await restoreSystemBackup(fileName);
+        return textResult({ restored: entry });
+      } catch (err) {
+        return errorResult(`Restore failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  // --- Monitoring checks ---
+
+  const checkTypeSchema = z.enum([
+    'http', 'ping', 'script', 'podman', 'service', 'systemd', 'fritzbox', 'node', 'agent', 'backup',
+  ]);
+
+  server.tool(
+    'create_monitoring_check',
+    'Create a new monitoring check (HTTP, ping, container, service, …). Returns the created check including generated id.',
+    {
+      name: z.string().min(1).describe('Display name'),
+      type: checkTypeSchema.describe('Check type'),
+      target: z.string().min(1).describe('URL / IP / container id / service name / script depending on type'),
+      interval: z.number().int().min(10).max(86400).describe('Interval in seconds (10s–24h)'),
+      enabled: z.boolean().optional().describe('Default: true'),
+      nodeName: z.string().optional().describe('Node to run the check from (default: first available)'),
+      httpExpectedStatus: z.number().int().optional().describe('For type=http: expected HTTP status'),
+      httpBodyMatch: z.string().optional().describe('For type=http: substring or regex the response body must match'),
+    },
+    async ({ name, type, target, interval, enabled, nodeName, httpExpectedStatus, httpBodyMatch }) => {
+      const check: CheckConfig = {
+        id: randomUUID(),
+        name,
+        type: type as CheckType,
+        target,
+        interval,
+        enabled: enabled ?? true,
+        created_at: new Date().toISOString(),
+        nodeName,
+        ...(type === 'http' && (httpExpectedStatus || httpBodyMatch)
+          ? {
+              httpConfig: {
+                expectedStatus: httpExpectedStatus,
+                bodyMatch: httpBodyMatch,
+                bodyMatchType: 'contains',
+              },
+            }
+          : {}),
+      };
+      MonitoringStore.saveCheck(check);
+      return textResult(check);
+    },
+  );
+
+  server.tool(
+    'delete_monitoring_check',
+    'Delete a monitoring check by id (use list_monitoring_checks/get_monitoring_checks to find ids).',
+    { id: z.string().min(1).describe('Check id') },
+    async ({ id }) => {
+      const before = MonitoringStore.getChecks().length;
+      MonitoringStore.deleteCheck(id);
+      const after = MonitoringStore.getChecks().length;
+      if (before === after) return errorResult(`No check with id "${id}" found`);
+      return textResult({ deleted: id });
+    },
+  );
+
+  server.tool(
+    'run_check_now',
+    'Run a monitoring check immediately and persist the result. Returns the result.',
+    { id: z.string().min(1).describe('Check id') },
+    async ({ id }) => {
+      const check = MonitoringStore.getChecks().find(c => c.id === id);
+      if (!check) return errorResult(`No check with id "${id}" found`);
+      try {
+        const result = await CheckRunner.run(check);
+        MonitoringStore.saveResult(result);
+        return textResult(result);
+      } catch (err) {
+        return errorResult(`Check run failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  // --- Config (read + selective write) ---
+
+  // Strip secrets and compute-only fields when returning config to the LLM.
+  // Anything not listed here is passed through; explicit deletes are below.
+  const sanitizeConfig = (cfg: AppConfig): Partial<AppConfig> => {
+    const out: AppConfig = JSON.parse(JSON.stringify(cfg));
+    if (out.auth) delete out.auth.passwordHash;
+    if (out.oidc) {
+      out.oidc.clientSecret = out.oidc.clientSecret ? '***' : '';
+    }
+    if (out.notifications?.email) {
+      out.notifications.email = { ...out.notifications.email, pass: out.notifications.email.pass ? '***' : '' };
+    }
+    return out;
+  };
+
+  server.tool('get_config', 'Read the ServiceBay app config (secrets like password hash and SMTP password redacted)', {}, async () => {
+    const config = await getConfig();
+    return textResult(sanitizeConfig(config));
+  });
+
+  // Allowlist: only fields the LLM is allowed to change without explicit user
+  // intervention. Auth, OIDC, and notification credentials are deliberately
+  // excluded — those need a human in the loop.
+  const ConfigPatchSchema = z.object({
+    logLevel: z.enum(['debug', 'info', 'warn', 'error']).optional(),
+    serverName: z.string().max(64).optional(),
+    domain: z.string().max(255).optional(),
+    autoUpdate: z.object({
+      enabled: z.boolean().optional(),
+      schedule: z.string().optional(),
+      channel: z.enum(['stable', 'test', 'dev']).optional(),
+    }).partial().optional(),
+    templateSettings: z.record(z.string(), z.string()).optional(),
+  }).strict();
+
+  server.tool(
+    'update_config',
+    'Update select ServiceBay config fields. Allowed: logLevel, serverName, domain, autoUpdate, templateSettings. Auth/OIDC/SMTP are intentionally excluded.',
+    { patch: ConfigPatchSchema.describe('Partial config to merge') },
+    async ({ patch }) => {
+      try {
+        const current = await getConfig();
+        const merged: Partial<AppConfig> = {};
+        if (patch.logLevel !== undefined) merged.logLevel = patch.logLevel;
+        if (patch.serverName !== undefined) merged.serverName = patch.serverName;
+        if (patch.domain !== undefined) merged.domain = patch.domain;
+        if (patch.templateSettings !== undefined) merged.templateSettings = patch.templateSettings;
+        if (patch.autoUpdate) {
+          merged.autoUpdate = { ...current.autoUpdate, ...patch.autoUpdate };
+        }
+        const updated = await updateConfig(merged);
+        return textResult({ ok: true, config: sanitizeConfig(updated) });
+      } catch (err) {
+        return errorResult(`Update failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
   );


### PR DESCRIPTION
## Summary

Adds 11 new MCP tools so an LLM can drive ServiceBay end-to-end instead of just inspecting it, and renames the service-detail page (`/monitor/[name]` → `/services/[name]`) so it stops getting confused with the health-check `/monitoring` page.

### New MCP tools (11)
| Tool | Mutating? | Backed by |
|---|---|---|
| `update_service_yaml` | yes | `ServiceManager.deployKubeService` |
| `add_proxy_route`, `remove_proxy_route` | yes | declarative edit of `config.reverseProxy.hosts` (NPM sync still via UI) |
| `list_backups`, `run_backup`, `restore_backup` | yes (run/restore) | `src/lib/backup/service`, `src/lib/systemBackup` |
| `create_monitoring_check`, `delete_monitoring_check`, `run_check_now` | yes | `MonitoringStore`, `CheckRunner` |
| `get_config`, `update_config` | yes (update) | `getConfig`/`updateConfig` |

`get_config` redacts `auth.passwordHash`, `oidc.clientSecret`, and `notifications.email.pass`. `update_config` is allow-listed to `logLevel`, `serverName`, `domain`, `autoUpdate`, `templateSettings` — auth/OIDC/SMTP credentials deliberately need a human in the loop.

### Bug fix
`get_container_logs` was previously broken — it called `agent.sendCommand('containerLogs', ...)` but the Python agent only handles `exec`/`refresh`/`pull_image`/file ops. Switched to `exec` with `podman logs`, added a `since` (Unix seconds) cursor and a `fetchedAt` field in the response so an LLM can chain calls and get only new lines.

`get_service_logs` got matching `lines` + `since` parameters.

All inputs that flow into a shell command (container id, service name, domain) now have `regex` validators so they can't be turned into a command-injection vector.

### Rename
`src/app/(dashboard)/monitor/[name]/page.tsx` → `src/app/(dashboard)/services/[name]/page.tsx`. Same component (`ServiceMonitor`), clearer URL — `/monitoring` is health checks, `/services/<name>` is a service-specific live view. Single caller updated (`ServiceActionBar.tsx`).

## Test plan
- [x] `tools/list` returns 37 tools (was 26)
- [x] `get_config` returns sanitized config
- [x] `add_proxy_route` + `remove_proxy_route` round-trip cleanly
- [x] `list_backups` returns `[]` on a fresh data dir
- [x] `get_container_logs` returns actual podman log output (was broken on `main`)
- [x] `/services/gateway` → 200, `/monitor/gateway` → 404
- [ ] CI green
- [ ] Quick UI sanity check that the gateway monitor link still lands on the same page

## Notes
- Independent of #105; this can land first.
- The proxy-route tools intentionally only update config — they do *not* push to NPM, because that requires interactive admin credentials. The user still has to click "sync" in the Reverse Proxy settings tab. Documented in the tool description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)