### PR TITLE
feat: better defaults + friction cuts (auto-update, login hint, failed-service nudge)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -163,7 +163,7 @@ export default function LoginPage() {
           <p className="text-center text-xs text-gray-400 dark:text-gray-500 mt-4">
             {oidcEnabled
               ? 'Use your admin credentials or login with SSO above.'
-              : 'Use your system (Linux) username and password to log in.'}
+              : 'Use the admin credentials configured during first start.'}
           </p>
         </div>
 

--- a/src/hooks/useServiceActions.tsx
+++ b/src/hooks/useServiceActions.tsx
@@ -105,6 +105,16 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     setShowActions(true);
   }, []);
 
+  // Inline-restart entry point used by the "Service is failed" banner on the
+  // service card. Skips the actions menu — selects the service and opens the
+  // ActionProgressModal directly.
+  const triggerRestart = useCallback((service: ServiceViewModel) => {
+    setSelectedService(service);
+    setActionService(service);
+    setCurrentAction('restart');
+    setActionModalOpen(true);
+  }, []);
+
   const requestDelete = useCallback((service: ServiceViewModel) => {
     setServiceToDelete(service);
     setDeleteModalOpen(true);
@@ -384,6 +394,7 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     openMonitorDrawer,
     openEditDrawer,
     openActions,
+    triggerRestart,
     requestDelete,
     actionLoading,
     overlays: actionOverlays,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -166,7 +166,11 @@ const DEFAULT_CONFIG: AppConfig = {
     }
   },
   autoUpdate: {
-    enabled: false,
+    // Auto-update on the stable channel by default for fresh installs. The
+    // home-lab use case strongly prefers "stays patched on its own" over
+    // "asks before every minor security release." Users can flip this off
+    // in Settings → System.
+    enabled: true,
     schedule: '0 0 * * *', // Daily at midnight
     channel: 'stable'
   }

--- a/src/plugins/ServicesPlugin.tsx
+++ b/src/plugins/ServicesPlugin.tsx
@@ -26,7 +26,7 @@ import { EnrichedContainer } from '@/lib/agent/types';
 // We keep Service interface but recreate it or import from shared data if it matches?
 // SharedData Service is a complex UI object. digital twin ServiceUnit is simple.
 // WE NEED TO MAP TWIN -> UI SERVICE here.
-import { Plus, RefreshCw, Activity, Trash2, Power, Box, Search, X, AlertCircle, FileCode, ArrowRight, ShieldCheck, Terminal as TerminalIcon, Eraser } from 'lucide-react';
+import { Plus, RefreshCw, Activity, Trash2, Power, Box, Search, X, AlertCircle, FileCode, ArrowRight, ShieldCheck, Terminal as TerminalIcon, Eraser, RotateCcw } from 'lucide-react';
 import { ServiceBundle, BundleValidation, BundleStackArtifacts, BundlePortSummary, BundleContainerSummary, generateBundleStackArtifacts, sanitizeBundleName } from '@/lib/unmanaged/bundleShared';
 
 interface MigrationPlan {
@@ -302,6 +302,7 @@ export default function ServicesPlugin() {
         openMonitorDrawer,
         openEditDrawer,
         openActions,
+        triggerRestart,
         requestDelete,
         overlays: serviceActionOverlays,
         closeOverlays,
@@ -641,6 +642,34 @@ export default function ServicesPlugin() {
                         onDelete={requestDelete}
                     />
                 </div>
+
+                {/* Failed-state nudge: when a managed service is not active,
+                    surface a one-click restart and a direct link to logs
+                    instead of forcing the user to dig through the Actions
+                    menu. Hidden for gateway/link "services" because they
+                    have their own lifecycle. */}
+                {!service.active && service.type !== 'gateway' && service.type !== 'link' && (
+                    <div className="mb-3 -mt-1 flex items-center gap-2 px-3 py-2 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/60 text-sm text-red-800 dark:text-red-200">
+                        <AlertCircle size={14} className="shrink-0" />
+                        <span className="flex-1 truncate" title={service.status}>Service is {service.status || 'inactive'}.</span>
+                        <button
+                            type="button"
+                            onClick={() => triggerRestart(service)}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded border border-red-300 dark:border-red-700 text-red-800 dark:text-red-100 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
+                            title="Restart this service"
+                        >
+                            <RotateCcw size={12} /> Restart
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => openMonitorDrawer(service)}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded border border-red-300 dark:border-red-700 text-red-800 dark:text-red-100 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
+                            title="View recent logs"
+                        >
+                            View logs
+                        </button>
+                    </div>
+                )}
 
                 <div className="grid grid-cols-2 gap-x-4 gap-y-2 mb-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-md p-3 border border-gray-100 dark:border-gray-800/50 flex-1">
                     {service.type === 'gateway' ? (


### PR DESCRIPTION
## Summary

Three small changes that together make a fresh install feel more thought-through:

### 1. Auto-update enabled by default
`src/lib/config.ts` — `autoUpdate.enabled` flips from `false` to `true`. Channel stays `stable`. Home-lab strongly prefers "stays patched on its own" over "asks before every minor". Toggle remains in Settings → System.

### 2. Login hint matches reality
`src/app/login/page.tsx` — the helper line claimed "system (Linux) username and password". The current login route only does bootstrap-password / stored hash / OIDC — no PAM. Hint now reads "Use the admin credentials configured during first start."

### 3. Failed-service inline nudge
`src/plugins/ServicesPlugin.tsx` — when a managed service is not active, the card grows a red banner above the metadata grid:

```
[!] Service is failed.   [↻ Restart]   [View logs]
```

Both buttons land on existing flows — Restart routes through `useServiceActions.triggerRestart` (new export that opens the ActionProgressModal directly without needing the user to first open the actions menu); View logs opens the existing monitor drawer. Hidden for `type=gateway` and `type=link` "services" because they don't have a meaningful systemd lifecycle.

## Test plan
- [x] Type-check shows no new errors (24 pre-existing test fixture errors unchanged)
- [ ] CI green
- [ ] Walk a fresh install: confirm auto-update toggle is on by default in Settings → System
- [ ] Manually stop a managed service; confirm the red banner + Restart button appear on the card and the restart works

## Notes
- No backend changes.
- No migration needed for #1 — existing installs keep whatever was already configured (the change only affects the *default* used when no value is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)