### PR TITLE
docs: sync README + INSTALLATION + ARCHITECTURE with recent feature work

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ The installer creates a bootable USB that provisions the entire system: OS, netw
 - **Web Terminal** — SSH into any managed node from the browser
 - **Multi-Node** — manage containers across machines via SSH from a single UI
 - **System Backups** — snapshot all configs across nodes, restore in seconds
-- **Auto-Updates** — keep ServiceBay and containers current automatically
+- **Auto-Updates** — keep ServiceBay and containers current automatically (on by default for new installs)
 - **Mobile-Responsive** — full UI with dedicated mobile navigation
+- **MCP Server** — programmatic API with 37 tools so an LLM (Claude, OpenAI, etc.) can drive ServiceBay directly: list/start/stop/restart services, edit Quadlet YAML, manage proxy routes, run backups, change settings
 
 ## Architecture
 
@@ -73,12 +74,57 @@ For Nginx Proxy Manager: enable **Websockets Support**, then add `proxy_bufferin
 
 ## Development
 
+Two paths, depending on what you're working on:
+
 ```bash
 git clone https://github.com/mdopp/servicebay.git && cd servicebay
 npm install
-npm run dev        # http://localhost:3000
+
+# Fast iteration (hot-reload, no container)
+npm run dev                              # http://localhost:3000
+
+# Production-shape container (matches CI image, builds on host
+# to avoid OOM in WSL/podman; expects sshd reachable on the host)
+scripts/dev-container.sh up              # http://localhost:3000
+scripts/dev-container.sh logs            # follow
+scripts/dev-container.sh restart         # rebuild + restart
+scripts/dev-container.sh reset           # nukes ~/.servicebay-dev/
+
 npm test           # vitest
 npm run lint       # eslint
+```
+
+`dev-container.sh` generates and persists a bootstrap admin password
+(written once to `~/.servicebay-dev/.bootstrap-password`) and an SSH
+keypair that the in-container agent uses to manage the host.
+
+## Programmatic API & MCP
+
+Every UI action has an HTTP equivalent under `/api/`. For LLM-driven
+automation, ServiceBay also exposes a Model Context Protocol server
+at `/mcp` (session-cookie auth — same as the UI).
+
+The MCP server publishes 37 tools across read paths
+(`list_nodes`, `list_services`, `get_container_logs`,
+`get_network_graph`, `get_monitoring_checks`, …) and write paths
+(`start_service`/`stop_service`/`restart_service`, `update_service_yaml`,
+`add_proxy_route`/`remove_proxy_route`, `run_backup`/`restore_backup`,
+`create_monitoring_check`/`run_check_now`, `get_config`/`update_config`,
+`exec_command`). Sensitive fields (`auth.passwordHash`,
+`oidc.clientSecret`, SMTP/NPM passwords) are redacted in `get_config`
+and write-allowlisted in `update_config`.
+
+Example client config (Claude Desktop / Claude Code):
+
+```json
+{
+  "mcpServers": {
+    "servicebay": {
+      "url": "http://localhost:3000/mcp",
+      "headers": { "Cookie": "session=YOUR_SESSION_COOKIE" }
+    }
+  }
+}
 ```
 
 ## Troubleshooting

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -323,6 +323,16 @@ sequenceDiagram
     *   **Backend**: `AgentExecutor` spawns a persistent SSH shell session using `ssh2` Client.
     *   **Security**: Restricted to authenticated users. SSH session runs as the configured rootless user.
 
+### 4.5. MCP Server (LLM-Driven Automation)
+*   **Goal**: Let an external LLM (Claude, OpenAI, etc.) drive ServiceBay end-to-end via the [Model Context Protocol](https://modelcontextprotocol.io).
+*   **Endpoint**: `POST /mcp` — handled directly in `server.ts` (intercepts the request before the Next.js handler) and bridged to `@modelcontextprotocol/sdk`'s `StreamableHTTPServerTransport`. Authentication is the same `session` cookie the UI uses, decoded via `getSessionFromCookieHeader`. No additional token surface.
+*   **Stateless**: a fresh `McpServer` + transport are created per request, both closed when the response stream ends. No long-lived sessions.
+*   **Tool surface** (`src/lib/mcp/server.ts`, 37 tools):
+    *   *Read*: `list_nodes`, `list_services`, `list_containers`, `get_container_logs`, `get_service_logs`, `get_system_info`, `get_network_graph`, `get_monitoring_checks`, `get_gateway_status`, `get_proxy_routes`, `list_templates`, `get_template_readme`/`yaml`/`variables`, `verify_node_connection`, `get_podman_logs`, `list_system_services`, `get_config`.
+    *   *Mutate*: `start_service`/`stop_service`/`restart_service`, `deploy_service`/`update_service_yaml`/`delete_service`/`rename_service`, `add_proxy_route`/`remove_proxy_route`, `run_backup`/`restore_backup`/`list_backups`, `create_monitoring_check`/`delete_monitoring_check`/`run_check_now`, `update_config`, `exec_command`, `refresh_agent`.
+*   **SoT alignment**: all tools route through the same Digital Twin / `ServiceManager` / `MonitoringStore` paths the UI uses — no parallel mutation surface. `update_config` is allow-listed (`logLevel`, `serverName`, `domain`, `autoUpdate`, `templateSettings`); auth/OIDC/SMTP credentials are intentionally excluded so they always need a human in the loop.
+*   **Secret hygiene**: `get_config` redacts `auth.passwordHash`, `oidc.clientSecret`, `notifications.email.pass`. Inputs that flow into a shell command (container id, service name, domain) are constrained with regex schemas to prevent command injection through the `exec_command` / `get_container_logs` / `get_service_logs` paths.
+
 ### 5. Network Graph Aggregation
 *   **Goal**: Visualize the relationships between Nodes, Services, and the Internet.
 *   **Mechanism**: `NetworkService.getGraph()` aggregates data from three layers on-demand:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -129,24 +129,21 @@ flowchart TD
     subgraph "Multi-Stage Dockerfile"
         B[base<br/>node:20-slim<br/>+ python3, make, g++]
         D[deps<br/>npm ci]
-        BU[builder<br/>npm run build<br/>Next.js production]
-        P[prod-deps<br/>npm ci --omit=dev<br/>+ tsx, typescript]
-        R[runner<br/>node:20-slim]
+        BU[builder<br/>npm run build<br/>= next build --webpack<br/>+ patch-routes-manifest<br/>+ esbuild server.ts → CJS]
+        P[prod-deps<br/>npm ci --omit=dev<br/>builds native modules]
+        R[runner<br/>node:20-slim<br/>CMD: node dist-server/server.cjs]
     end
 
     B --> D --> BU
     B --> P
 
-    BU -->|.next/standalone<br/>.next/static<br/>public/| R
+    BU -->|.next/<br/>dist-server/server.cjs<br/>public/| R
     P -->|node_modules/| R
 
     subgraph "Also copied into runner"
-        direction LR
         T[templates/ stacks/]
-        SRC[server.ts src/]
     end
     T --> R
-    SRC --> R
 
     subgraph "Runtime apt packages"
         direction LR
@@ -158,6 +155,14 @@ flowchart TD
     style BU fill:#e3f2fd
 ```
 
+The custom server (`server.ts`) is bundled to a single CommonJS file
+under `dist-server/server.cjs` via esbuild. The runtime image runs
+plain `node` — no `tsx`, no TypeScript loader, no Next.js standalone
+output. This avoids two Next 16 quirks the build script also patches:
+`routes-manifest.json` missing `onMatchHeaders`, and Turbopack's chunk
+layout duplicating `workAsyncStorage` so `getStore()` returns
+`undefined` mid-render.
+
 **Environment baked into image:**
 
 ```
@@ -166,6 +171,11 @@ HOST_SSH=host.containers.internal   SSH_KEY_PATH=/root/.ssh/id_rsa
 ```
 
 Container runs as root internally — `UserNS=keep-id` maps to host's rootless user.
+
+For a leaner local dev image that re-uses the host build (avoids
+running webpack inside the container), see `Dockerfile.dev` and
+`scripts/dev-container.sh`. That path is **development only** — the
+production FCOS image always uses the multi-stage `Dockerfile`.
 
 ## 6. Startup Procedure
 


### PR DESCRIPTION
## Summary

Three doc gaps closed — code-only changes from recent PRs (#105, #106, #107, #110) hadn't been reflected in the user-facing docs yet.

### `README.md`
- Adds **MCP server** to the Features list and a new **"Programmatic API & MCP"** section with the tool inventory and a Claude-Desktop-style example client config.
- **Development** section now shows both `npm run dev` (fast iteration) and the container-shaped `scripts/dev-container.sh` flow.
- Auto-updates feature mention notes the new "on by default" stance from PR #110.

### `docs/INSTALLATION.md` (Section 5 — Docker Image Build)
- Mermaid + prose were stale. Removed references to runtime `tsx` / `typescript` and Next.js `output: 'standalone'` (both gone in PR #105).
- The runner now runs `node dist-server/server.cjs`, an esbuild-bundled CJS file. Diagram + text updated.
- Added a paragraph explaining the two Next 16.2.4 quirks the build script works around (`onMatchHeaders` patch, Webpack instead of Turbopack to avoid duplicate `workAsyncStorage` instances).
- Notes that `Dockerfile.dev` + `dev-container.sh` exist for local development but are deliberately not used for the FCOS image.

### `docs/ARCHITECTURE.md`
- New **§4.5 "MCP Server (LLM-Driven Automation)"**: endpoint shape (`POST /mcp`), session-cookie auth, stateless per-request server, full tool surface grouped read/mutate, SoT alignment notes, secret hygiene (redacted fields, regex schemas on shell-bound inputs).

## Notes
- No code changes; docs only.
- Independent of #111/#112/#113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)