### PR TITLE
fix(installer): set AUTH_SECRET + bootstrap admin password in Quadlet, add diagnose script

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -363,3 +363,37 @@ Host filesystem (after FCOS install)
 │  UserNS: keep-id  (root in container = user on host)           │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+## 12. Post-Install Diagnostics
+
+When the box is up but ServiceBay isn't reachable on the configured port,
+run the diagnostics script from your dev machine:
+
+```bash
+scripts/fcos-diagnose.sh
+```
+
+It auto-detects the target IP, host user, SSH key, and ServiceBay port
+from `build/fcos/install-settings.env` and runs an SSH session that
+reports the seven things that are usually wrong:
+
+- `systemctl --user status servicebay` — is the unit active or
+  auto-restarting?
+- `podman ps -a` — is the container actually there?
+- `ss -ltn` — is anything listening on the configured port?
+- `curl http://localhost:$PORT` from inside the box — does the server
+  respond locally? If yes, the issue is firewall / routing; if no, the
+  container itself didn't start.
+- `firewall-cmd --list-ports` — only relevant if firewalld is installed
+  (FCOS default does not ship it; this is informational).
+- Status of the three first-boot oneshots (`setup-raid`,
+  `install-python`, `install-nginx`).
+- `df -h /mnt/data` + last 20 ServiceBay log lines for the smoking gun.
+
+Override the target by passing args or env:
+
+```bash
+scripts/fcos-diagnose.sh 192.168.1.50          # different IP
+FCOS_PORT=5888 scripts/fcos-diagnose.sh        # different port
+FCOS_KEY=~/.ssh/id_ed25519 scripts/fcos-diagnose.sh
+```

--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -424,6 +424,9 @@ storage:
           Environment=PORT=${SERVICEBAY_PORT}
           Environment=NODE_ENV=production
           Environment=HOST_USER=${HOST_USER}
+          Environment=AUTH_SECRET=${AUTH_SECRET}
+          Environment=SERVICEBAY_USERNAME=${SERVICEBAY_ADMIN_USER}
+          Environment=SERVICEBAY_PASSWORD=${SERVICEBAY_ADMIN_PASSWORD}
           SecurityLabelDisable=true
 
           [Service]
@@ -909,6 +912,7 @@ EMAIL_SECURE=${EMAIL_SECURE:-N}
 EMAIL_USER=${EMAIL_USER:-}
 EMAIL_FROM=${EMAIL_FROM:-}
 EMAIL_RECIPIENTS=${EMAIL_RECIPIENTS:-}
+AUTH_SECRET=${AUTH_SECRET:-}
 SETTINGS
   echo "Settings saved to $SETTINGS_FILE"
 }
@@ -1190,8 +1194,7 @@ PASSWORD_HASH="$(printf '%s' "$HOST_PASSWORD" | openssl passwd -6 -stdin)"
 SERVICEBAY_CONFIG='{
   "serverName": "'"$SERVER_NAME"'",
   "auth": {
-    "username": "'"$SERVICEBAY_ADMIN_USER"'",
-    "password": "'"$SERVICEBAY_ADMIN_PASSWORD"'"
+    "username": "'"$SERVICEBAY_ADMIN_USER"'"
   },
   "autoUpdate": {
     "enabled": true,
@@ -1270,11 +1273,20 @@ SERVICEBAY_SSH_PUB="$(cat "$SERVICEBAY_SSH_DIR/id_rsa.pub")"
 # Indent private key for YAML inline block (10 spaces to match Butane template nesting)
 SERVICEBAY_SSH_PRIV="$(sed 's/^/          /' "$SERVICEBAY_SSH_DIR/id_rsa")"
 
+# AUTH_SECRET: required by the ServiceBay backend (≥32 bytes). Reuse a
+# previously-generated value across re-runs so an existing FCOS install's
+# encrypted config.json fields still decrypt; otherwise generate fresh.
+AUTH_SECRET="$(load_setting AUTH_SECRET)"
+if [[ -z "$AUTH_SECRET" || ${#AUTH_SECRET} -lt 32 ]]; then
+  AUTH_SECRET="$(openssl rand -hex 32)"
+fi
+
 export SERVER_NAME HOST_USER SSH_AUTHORIZED_KEY PASSWORD_HASH NET_INTERFACE STATIC_IP STATIC_PREFIX GATEWAY DNS_SERVERS \
-       DATA_ROOT SERVICEBAY_PORT SERVICEBAY_VERSION SERVICEBAY_CONFIG_JSON SERVICEBAY_SSH_PUB SERVICEBAY_SSH_PRIV
+       DATA_ROOT SERVICEBAY_PORT SERVICEBAY_VERSION SERVICEBAY_CONFIG_JSON SERVICEBAY_SSH_PUB SERVICEBAY_SSH_PRIV \
+       AUTH_SECRET SERVICEBAY_ADMIN_USER SERVICEBAY_ADMIN_PASSWORD
 
 # Render Butane template (only substitute explicit template variables, not shell vars in embedded scripts)
-envsubst '${SERVER_NAME} ${HOST_USER} ${SSH_AUTHORIZED_KEY} ${PASSWORD_HASH} ${NET_INTERFACE} ${STATIC_IP} ${STATIC_PREFIX} ${GATEWAY} ${DNS_SERVERS} ${DATA_ROOT} ${SERVICEBAY_PORT} ${SERVICEBAY_VERSION} ${SERVICEBAY_CONFIG_JSON} ${SERVICEBAY_SSH_PUB} ${SERVICEBAY_SSH_PRIV}' < "$TEMPLATE" > "$RENDERED_BU"
+envsubst '${SERVER_NAME} ${HOST_USER} ${SSH_AUTHORIZED_KEY} ${PASSWORD_HASH} ${NET_INTERFACE} ${STATIC_IP} ${STATIC_PREFIX} ${GATEWAY} ${DNS_SERVERS} ${DATA_ROOT} ${SERVICEBAY_PORT} ${SERVICEBAY_VERSION} ${SERVICEBAY_CONFIG_JSON} ${SERVICEBAY_SSH_PUB} ${SERVICEBAY_SSH_PRIV} ${AUTH_SECRET} ${SERVICEBAY_ADMIN_USER} ${SERVICEBAY_ADMIN_PASSWORD}' < "$TEMPLATE" > "$RENDERED_BU"
 
 # --- Stage backup file for post-install restore ---
 BACKUP_STAGED=""

--- a/scripts/fcos-diagnose.sh
+++ b/scripts/fcos-diagnose.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Post-install diagnostics for a freshly-installed ServiceBay FCOS box.
+#
+# Usage:
+#   scripts/fcos-diagnose.sh                      # auto-detect from build/fcos/install-settings.env
+#   scripts/fcos-diagnose.sh 192.168.1.50         # override target IP
+#   scripts/fcos-diagnose.sh 192.168.1.50 admin   # override target IP + remote user
+#
+# Reads STATIC_IP, HOST_USER, SERVICEBAY_PORT from build/fcos/install-settings.env,
+# uses build/fcos/servicebay-ssh/id_rsa as the SSH key. Override any of those by
+# setting FCOS_HOST / FCOS_USER / FCOS_PORT / FCOS_KEY in the environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SETTINGS_FILE="$REPO_ROOT/build/fcos/install-settings.env"
+DEFAULT_KEY="$REPO_ROOT/build/fcos/servicebay-ssh/id_rsa"
+
+load() { grep -oP "^$1=\K.*" "$SETTINGS_FILE" 2>/dev/null || echo ""; }
+
+HOST="${1:-${FCOS_HOST:-$(load STATIC_IP)}}"
+USER_NAME="${2:-${FCOS_USER:-$(load HOST_USER)}}"
+PORT="${FCOS_PORT:-$(load SERVICEBAY_PORT)}"
+KEY="${FCOS_KEY:-$DEFAULT_KEY}"
+
+[[ -z "$HOST" ]] && { echo "✗ no host. Pass as arg or set FCOS_HOST." >&2; exit 1; }
+[[ -z "$USER_NAME" ]] && USER_NAME="core"
+[[ -z "$PORT" ]] && PORT="3000"
+[[ ! -f "$KEY" ]] && { echo "✗ SSH key not found at $KEY (set FCOS_KEY to override)." >&2; exit 1; }
+
+echo "▶ ServiceBay FCOS diagnostics: ${USER_NAME}@${HOST} (port ${PORT})"
+echo ""
+
+ssh -i "$KEY" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 "${USER_NAME}@${HOST}" "
+PORT='${PORT}'
+echo '== systemctl =='
+systemctl --user status servicebay --no-pager 2>&1 | head -8
+
+echo
+echo '== container =='
+podman ps -a --format '{{.Names}} {{.Status}} {{.Image}}' 2>&1
+
+echo
+echo '== listening =='
+ss -ltn | grep -E \":\${PORT}\b|:3000\b\" || echo \"(nothing on :\${PORT} or :3000)\"
+
+echo
+echo '== local curl =='
+curl -sS -m 3 -o /dev/null -w 'HTTP %{http_code}\n' \"http://localhost:\${PORT}\" 2>&1 \
+  || echo \"(no response on localhost:\${PORT})\"
+
+echo
+echo '== firewall =='
+if command -v firewall-cmd > /dev/null 2>&1; then
+  sudo firewall-cmd --list-ports 2>&1
+else
+  echo '(firewalld not installed — FCOS default; nothing to open)'
+fi
+
+echo
+echo '== first-boot units =='
+systemctl --no-pager status setup-raid install-python install-nginx 2>&1 \
+  | grep -E '(●|Active:)' || true
+
+echo
+echo '== /mnt/data =='
+df -h /mnt/data 2>&1 | tail -1
+ls -la /mnt/data/servicebay/ 2>&1 | head -5
+
+echo
+echo '== last log =='
+journalctl --user -u servicebay -n 20 --no-pager 2>&1 | tail -20
+"
+
+echo ""
+echo "▶ ServiceBay should be reachable at: http://${HOST}:${PORT}"


### PR DESCRIPTION
## Summary

Every fresh FCOS install crash-loops on startup because the rendered `servicebay.container` Quadlet has no `AUTH_SECRET` env var. ServiceBay's auth hardening made AUTH_SECRET mandatory but the installer was never updated. Symptom: FritzBox / arp shows the host as "up", the configured ServiceBay port refuses connections, journalctl shows:

```
Error: AUTH_SECRET environment variable is required and must be at least 32 characters.
```

Same shape for admin credentials: the installer wrote `auth.password` plaintext to `config.json`, but the login route only honours `auth.passwordHash` (stored) or `SERVICEBAY_PASSWORD` (env bootstrap). The plaintext field was therefore dead code — the user couldn't log in even if the container had started.

## Changes

### `install-fedora-coreos.sh`
- Generates `AUTH_SECRET` (`openssl rand -hex 32`) before rendering the Butane template; **reuses an existing value** from `install-settings.env` on re-run so previously-encrypted config.json fields still decrypt.
- Adds `Environment=AUTH_SECRET`, `Environment=SERVICEBAY_USERNAME`, `Environment=SERVICEBAY_PASSWORD` to the Quadlet. The latter two are the documented bootstrap path — login route hashes the password to `auth.passwordHash` on first successful login, after which both env vars are unused.
- Adds the new vars to the export list and the `envsubst` whitelist; persists `AUTH_SECRET` in `install-settings.env`.
- Drops the dead plaintext `auth.password` field from the config.json render.

### `scripts/fcos-diagnose.sh` (new)
Single-shot SSH diagnostic. Auto-detects target host, user, port, SSH key from `build/fcos/install-settings.env` and `build/fcos/servicebay-ssh/`. Prints seven blocks covering the usual failure modes:

- `systemctl --user status servicebay` — unit state
- `podman ps -a` — container state
- `ss -ltn` — listening ports
- `curl http://localhost:$PORT` from inside — local response
- `firewall-cmd --list-ports` — informational; FCOS default ships no firewalld
- Status of `setup-raid`, `install-python`, `install-nginx` first-boot oneshots
- `df -h /mnt/data` + last 20 ServiceBay log lines

Override targets with positional args or env (`FCOS_HOST` / `FCOS_USER` / `FCOS_PORT` / `FCOS_KEY`).

### `docs/INSTALLATION.md`
New **§12 "Post-Install Diagnostics"** pointing at the script with usage + the seven things it checks.

## Test plan
- [x] `bash -n` on both scripts (syntax)
- [x] Verified existing user's failing install matches exactly the documented failure mode (`AUTH_SECRET environment variable is required` in journalctl)
- [ ] CI green
- [ ] Re-run installer with the patch, confirm `Environment=AUTH_SECRET=...` appears in the rendered Butane and the container starts cleanly
- [ ] First-time login succeeds with `SERVICEBAY_ADMIN_USER` / `SERVICEBAY_ADMIN_PASSWORD` from the installer prompts (no manual config edit needed)

## Notes
- 3 files, +127 / –4 LOC.
- The diagnose script is idempotent and safe to run repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)