### PR TITLE
fix(image): ship agent.py + quadlet_parser.py in the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,14 @@ COPY --from=builder /app/stacks ./stacks
 # server.ts is folded into dist-server/server.cjs by scripts/build-server.mjs.
 COPY --from=builder /app/dist-server ./dist-server
 
+# Python agent script — streamed over SSH to each managed node and executed
+# there. Read at runtime by src/lib/agent/handler.ts (path resolved with
+# `process.cwd() + 'src/lib/agent/v4/agent.py'`), so it must exist at that
+# exact path inside the runner image. Not bundled into dist-server because
+# it's Python, not JS, and not invoked locally.
+COPY --from=builder /app/src/lib/agent/v4/agent.py ./src/lib/agent/v4/agent.py
+COPY --from=builder /app/src/lib/agent/v4/quadlet_parser.py ./src/lib/agent/v4/quadlet_parser.py
+
 # Copy production node_modules (with built native modules)
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json


### PR DESCRIPTION
## Summary

The production `Dockerfile` copied `.next`, `public`, `templates`, `stacks`, `dist-server` and `node_modules` into the runner stage but **not** the Python agent (`src/lib/agent/v4/agent.py`). The runtime resolves it from `process.cwd() + 'src/lib/agent/v4/agent.py'` ([src/lib/agent/handler.ts:46](https://github.com/mdopp/servicebay/blob/main/src/lib/agent/handler.ts#L46)) and streams the file over SSH to each managed node — without it, every agent operation fails with:

```
ENOENT: no such file or directory, open '/app/src/lib/agent/v4/agent.py'
```

## Symptoms in a real FCOS install

- Stack install logs every service as `❌ Failed to install …: ENOENT /app/src/lib/agent/v4/agent.py` and bails before anything reaches the host.
- USB-device variables (e.g. Z-Wave stick path) come up empty in the install picker — the device enumeration runs through the agent, which never loads, so `/dev/serial/by-id` is never read.

## Why dev didn't catch it

The dev image (`Dockerfile.dev`, added in PR #105) already had this COPY because the dev container path was the only one anyone tested end-to-end. The production `Dockerfile` was the gap.

## Fix

Added two `COPY --from=builder` lines in the runner stage:
- `src/lib/agent/v4/agent.py`
- `src/lib/agent/v4/quadlet_parser.py` (sibling helper used by agent.py for parsing existing Quadlet files on the node)

## Test plan
- [x] Trace shows the runtime reads `process.cwd()/src/lib/agent/v4/agent.py`
- [ ] CI green
- [ ] Pull the resulting `:latest` image, exec into it, confirm the file exists at `/app/src/lib/agent/v4/agent.py`
- [ ] Re-run a fresh FCOS install, confirm the stack-install step pushes templates without the ENOENT
- [ ] Confirm `ZWAVE_DEVICE` dropdown lists USB devices found in `/dev/serial/by-id` on the FCOS host

🤖 Generated with [Claude Code](https://claude.com/claude-code)