### PR TITLE
fix: real wait-for-ready logic + bootstrap NPM admin creds at deploy time

### DIFF
--- a/src/app/api/system/lldap/probe/route.ts
+++ b/src/app/api/system/lldap/probe/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/system/lldap/probe
+ * Body: { host: string, port: number }
+ *
+ * Tries to reach LLDAP's HTTP endpoint with a short timeout. Returns
+ * `{ reachable: boolean }`. Used by the install wizard to wait for LLDAP
+ * to come up before firing the group-seed call (LLDAP needs ~5–15 s on
+ * cold start to initialize its SQLite DB and bind to its HTTP port).
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { host, port } = body as { host?: string; port?: number };
+    if (typeof host !== 'string' || !host || typeof port !== 'number' || !port) {
+      return NextResponse.json({ error: 'host and port are required' }, { status: 400 });
+    }
+
+    const url = `http://${host}:${port}/`;
+    try {
+      const res = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(3000) });
+      // LLDAP serves its login page on root once the HTTP listener is up.
+      // Anything in the 2xx/3xx range counts as reachable.
+      return NextResponse.json({ reachable: res.status < 400, status: res.status });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unreachable';
+      return NextResponse.json({ reachable: false, error: msg });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'probe failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -53,10 +53,27 @@ async function fetchExistingServices(node?: string): Promise<Set<string>> {
   }
 }
 
-/** Wait for NPM to become reachable, polling up to maxWait ms.
- *  3 minutes covers cold-start image pull + first-time DB schema init. */
-async function waitForNpm(node: string | undefined, maxWait = 180_000): Promise<boolean> {
+/** Format elapsed milliseconds as `Mm Ss` for human-readable log lines. */
+function fmtElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+/** Wait for NPM to become reachable. Polls every 3 s and emits a heartbeat
+ *  log line every 30 s so the user sees forward motion while NPM cold-starts.
+ *  Default ceiling 60 min — generous enough for slow CPUs / first-boot DB
+ *  init / late image extracts on weak hardware.
+ *
+ *  `onProgress` receives a human-readable status line for the UI. */
+async function waitForNpm(
+  node: string | undefined,
+  onProgress: (msg: string) => void,
+  maxWait = 60 * 60_000,
+): Promise<boolean> {
   const start = Date.now();
+  let lastBeat = 0;
   while (Date.now() - start < maxWait) {
     try {
       const query = node ? `?node=${node}` : '';
@@ -66,14 +83,26 @@ async function waitForNpm(node: string | undefined, maxWait = 180_000): Promise<
         if (data.installed && data.active) return true;
       }
     } catch { /* keep trying */ }
+    const elapsed = Date.now() - start;
+    if (elapsed - lastBeat >= 30_000) {
+      onProgress(`Still waiting for Nginx Proxy Manager (${fmtElapsed(elapsed)} elapsed)...`);
+      lastBeat = elapsed;
+    }
     await new Promise(r => setTimeout(r, 3000));
   }
   return false;
 }
 
-/** Wait for an LLDAP HTTP endpoint to respond. Polls up to maxWait ms. */
-async function waitForLldap(host: string, port: number, maxWait = 180_000): Promise<boolean> {
+/** Wait for an LLDAP HTTP endpoint to respond. Same heartbeat pattern as
+ *  waitForNpm. */
+async function waitForLldap(
+  host: string,
+  port: number,
+  onProgress: (msg: string) => void,
+  maxWait = 60 * 60_000,
+): Promise<boolean> {
   const start = Date.now();
+  let lastBeat = 0;
   while (Date.now() - start < maxWait) {
     try {
       const res = await fetch('/api/system/lldap/probe', {
@@ -86,6 +115,11 @@ async function waitForLldap(host: string, port: number, maxWait = 180_000): Prom
         if (data.reachable) return true;
       }
     } catch { /* keep trying */ }
+    const elapsed = Date.now() - start;
+    if (elapsed - lastBeat >= 30_000) {
+      onProgress(`Still waiting for LLDAP (${fmtElapsed(elapsed)} elapsed)...`);
+      lastBeat = elapsed;
+    }
     await new Promise(r => setTimeout(r, 3000));
   }
   return false;
@@ -664,8 +698,12 @@ export default function OnboardingWizard() {
       const lldapPort = stackVariables.find(v => v.name === 'LLDAP_PORT')?.value || '17170';
       const lldapHost = stackSelectedNode || 'localhost';
       if (lldapPassword) {
-        setStackLogs(prev => [...prev, 'Waiting for LLDAP to start (up to 3 min)...']);
-        const lldapReady = await waitForLldap(lldapHost, parseInt(lldapPort, 10));
+        setStackLogs(prev => [...prev, 'Waiting for LLDAP to start (image pull / cold-start can take a while)...']);
+        const lldapReady = await waitForLldap(
+          lldapHost,
+          parseInt(lldapPort, 10),
+          msg => setStackLogs(prev => [...prev, msg]),
+        );
         if (!lldapReady) {
           setStackLogs(prev => [...prev, '\u26a0\ufe0f LLDAP did not respond in time \u2014 seed groups manually via Settings \u2192 Self-Test, then admins/family groups in the LLDAP UI.']);
         } else {
@@ -691,6 +729,28 @@ export default function OnboardingWizard() {
           } catch {
             setStackLogs(prev => [...prev, '\u26a0\ufe0f Could not reach LLDAP to seed groups. Create admins/family groups manually.']);
           }
+        }
+      }
+    }
+
+    // If nginx-web was just installed, persist its NPM admin credentials
+    // into ServiceBay config so all subsequent proxy operations (this run
+    // and future ones) authenticate cleanly. Without this, NPM gets a
+    // user-supplied INITIAL_ADMIN_PASSWORD on first start, but ServiceBay
+    // would still try the hardcoded `changeme` defaults later.
+    if (selected.some(i => i.name === 'nginx-web')) {
+      const npmEmailVar = stackVariables.find(v => v.name === 'NGINX_ADMIN_EMAIL')?.value;
+      const npmPasswordVar = stackVariables.find(v => v.name === 'NGINX_ADMIN_PASSWORD')?.value;
+      if (npmEmailVar && npmPasswordVar) {
+        try {
+          await fetch('/api/system/nginx/credentials', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: npmEmailVar, password: npmPasswordVar }),
+          });
+          setStackLogs(prev => [...prev, '✅ Saved NPM admin credentials for auto-sync.']);
+        } catch {
+          setStackLogs(prev => [...prev, '⚠️ Could not persist NPM credentials — set them later in Settings → Integrations.']);
         }
       }
     }
@@ -744,8 +804,11 @@ export default function OnboardingWizard() {
     if (!domain || hosts.length === 0) return;
 
     if (!credentials) {
-      setStackLogs(prev => [...prev, 'Waiting for Nginx Proxy Manager to start...']);
-      const npmReady = await waitForNpm(stackSelectedNode || undefined);
+      setStackLogs(prev => [...prev, 'Waiting for Nginx Proxy Manager to start (image pull / DB schema init can take a while)...']);
+      const npmReady = await waitForNpm(
+        stackSelectedNode || undefined,
+        msg => setStackLogs(prev => [...prev, msg]),
+      );
       if (!npmReady) {
         setStackLogs(prev => [...prev, '\u26a0\ufe0f Nginx Proxy Manager not ready. Configure proxy routes manually in the NPM admin panel.']);
         return;

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -53,8 +53,9 @@ async function fetchExistingServices(node?: string): Promise<Set<string>> {
   }
 }
 
-/** Wait for NPM to become reachable, polling up to maxWait ms */
-async function waitForNpm(node: string | undefined, maxWait = 30000): Promise<boolean> {
+/** Wait for NPM to become reachable, polling up to maxWait ms.
+ *  3 minutes covers cold-start image pull + first-time DB schema init. */
+async function waitForNpm(node: string | undefined, maxWait = 180_000): Promise<boolean> {
   const start = Date.now();
   while (Date.now() - start < maxWait) {
     try {
@@ -63,6 +64,26 @@ async function waitForNpm(node: string | undefined, maxWait = 30000): Promise<bo
       if (res.ok) {
         const data = await res.json();
         if (data.installed && data.active) return true;
+      }
+    } catch { /* keep trying */ }
+    await new Promise(r => setTimeout(r, 3000));
+  }
+  return false;
+}
+
+/** Wait for an LLDAP HTTP endpoint to respond. Polls up to maxWait ms. */
+async function waitForLldap(host: string, port: number, maxWait = 180_000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < maxWait) {
+    try {
+      const res = await fetch('/api/system/lldap/probe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ host, port }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.reachable) return true;
       }
     } catch { /* keep trying */ }
     await new Promise(r => setTimeout(r, 3000));
@@ -626,39 +647,50 @@ export default function OnboardingWizard() {
           }
         }
 
-        setStackLogs(prev => [...prev, `\u2705 ${item.name} installed successfully.`]);
+        setStackLogs(prev => [...prev, `\u2705 ${item.name} deployed (containers may still be starting in background).`]);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         setStackLogs(prev => [...prev, `\u274c Failed to install ${item.name}: ${msg}`]);
       }
     }
 
-    // Seed LLDAP groups if lldap was installed
+    // Seed LLDAP groups if lldap was installed.
+    // Need to wait for the LLDAP container to actually start serving HTTP
+    // before firing the seed: `--no-block` returned right after dispatching
+    // the systemd start, so the pod is still cold-starting (image extract,
+    // sqlite init, bind to :17170).
     if (selected.some(i => i.name === 'lldap')) {
-      setStackLogs(prev => [...prev, 'Seeding LLDAP groups...']);
       const lldapPassword = stackVariables.find(v => v.name === 'LLDAP_ADMIN_PASSWORD')?.value;
       const lldapPort = stackVariables.find(v => v.name === 'LLDAP_PORT')?.value || '17170';
+      const lldapHost = stackSelectedNode || 'localhost';
       if (lldapPassword) {
-        try {
-          const res = await fetch('/api/system/lldap/seed', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              host: stackSelectedNode || 'localhost',
-              port: parseInt(lldapPort, 10),
-              password: lldapPassword,
-            }),
-          });
-          const data = await res.json();
-          if (res.ok) {
-            if (data.created?.length) setStackLogs(prev => [...prev, `\u2705 Groups created: ${data.created.join(', ')}`]);
-            if (data.existing?.length) setStackLogs(prev => [...prev, `\u2139\ufe0f Groups already exist: ${data.existing.join(', ')}`]);
-            if (data.failed?.length) setStackLogs(prev => [...prev, `\u26a0\ufe0f Failed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`]);
-          } else {
-            setStackLogs(prev => [...prev, `\u26a0\ufe0f Could not seed LLDAP groups: ${data.error || 'unknown error'}`]);
+        setStackLogs(prev => [...prev, 'Waiting for LLDAP to start (up to 3 min)...']);
+        const lldapReady = await waitForLldap(lldapHost, parseInt(lldapPort, 10));
+        if (!lldapReady) {
+          setStackLogs(prev => [...prev, '\u26a0\ufe0f LLDAP did not respond in time \u2014 seed groups manually via Settings \u2192 Self-Test, then admins/family groups in the LLDAP UI.']);
+        } else {
+          setStackLogs(prev => [...prev, 'Seeding LLDAP groups...']);
+          try {
+            const res = await fetch('/api/system/lldap/seed', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                host: lldapHost,
+                port: parseInt(lldapPort, 10),
+                password: lldapPassword,
+              }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+              if (data.created?.length) setStackLogs(prev => [...prev, `\u2705 Groups created: ${data.created.join(', ')}`]);
+              if (data.existing?.length) setStackLogs(prev => [...prev, `\u2139\ufe0f Groups already exist: ${data.existing.join(', ')}`]);
+              if (data.failed?.length) setStackLogs(prev => [...prev, `\u26a0\ufe0f Failed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`]);
+            } else {
+              setStackLogs(prev => [...prev, `\u26a0\ufe0f Could not seed LLDAP groups: ${data.error || 'unknown error'}`]);
+            }
+          } catch {
+            setStackLogs(prev => [...prev, '\u26a0\ufe0f Could not reach LLDAP to seed groups. Create admins/family groups manually.']);
           }
-        } catch {
-          setStackLogs(prev => [...prev, '\u26a0\ufe0f Could not reach LLDAP to seed groups. Create admins/family groups manually.']);
         }
       }
     }

--- a/src/lib/agent/handler.ts
+++ b/src/lib/agent/handler.ts
@@ -463,7 +463,11 @@ export class AgentHandler extends EventEmitter {
       }
 
       try {
-        const result = await this.sendCommand('pull_image', { image, pull_id: pullId }, { timeoutMs: 300_000 });
+        // 60 min per image: cover slow internet (multi-GB pulls on a 5 Mbps
+        // line) without giving up. The agent emits PULL_PROGRESS events every
+        // 250 ms while bytes are flowing, so the UI sees forward motion;
+        // we only fall over if the registry is genuinely unreachable.
+        const result = await this.sendCommand('pull_image', { image, pull_id: pullId }, { timeoutMs: 3_600_000 });
         return result as { success: boolean };
       } finally {
         if (handler) {

--- a/templates/nginx-web/template.yml
+++ b/templates/nginx-web/template.yml
@@ -11,9 +11,9 @@ spec:
     image: docker.io/jc21/nginx-proxy-manager:latest
     env:
     - name: INITIAL_ADMIN_EMAIL
-      value: "admin@example.com"
+      value: "{{NGINX_ADMIN_EMAIL}}"
     - name: INITIAL_ADMIN_PASSWORD
-      value: "changeme"
+      value: "{{NGINX_ADMIN_PASSWORD}}"
     ports:
     - containerPort: 80
       hostPort: {{NGINX_PORT}}

--- a/templates/nginx-web/variables.json
+++ b/templates/nginx-web/variables.json
@@ -1,4 +1,13 @@
 {
+  "NGINX_ADMIN_EMAIL": {
+    "type": "text",
+    "description": "Initial NPM admin email (used as the login for ServiceBay's auto-sync of proxy routes)",
+    "default": "admin@servicebay.local"
+  },
+  "NGINX_ADMIN_PASSWORD": {
+    "type": "secret",
+    "description": "Initial NPM admin password — auto-generated, also stored in Settings → Integrations → Reverse Proxy so ServiceBay can sync routes without prompting"
+  },
   "NGINX_PORT": {
     "type": "text",
     "description": "HTTP port",

--- a/tests/backend/pull_image.test.ts
+++ b/tests/backend/pull_image.test.ts
@@ -65,7 +65,7 @@ describe('AgentHandler.pullImage', () => {
         expect(sendSpy).toHaveBeenCalledWith(
             'pull_image',
             expect.objectContaining({ image: 'redis:7', pull_id: expect.any(String) }),
-            { timeoutMs: 300_000 }
+            { timeoutMs: 3_600_000 }
         );
         expect(progressEvents).toHaveLength(2);
         expect(progressEvents[0].status).toBe('Downloading');


### PR DESCRIPTION
## Summary

Two real complaints from an FCOS install:

1. **Bounded timeouts give up too early on slow lines.** A multi-GB image pull on a 5 Mbps connection can take 30+ minutes; the post-install LLDAP seed and NPM proxy-sync timed out long before anything was ready.
2. **NPM's first-boot prompt forced the user to set new admin credentials** because ServiceBay set `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD` to the literal `admin@example.com` / `changeme` defaults — values NPM forces you to change on first login. ServiceBay then kept trying the defaults forever, reporting "NPM credentials did not work" on every proxy-sync.

## Wait logic

- **`pull_image`** per-call timeout: **5 min → 60 min**. The agent emits `PULL_PROGRESS` events every ~250 ms while bytes flow, so the UI sees motion; the ceiling only fires when the registry is genuinely unreachable.
- **`waitForNpm` / `waitForLldap`**: defaults bumped from 30 s / 3 min → **60 min**. Both grew an `onProgress` callback and emit a heartbeat log line every 30 s — `"Still waiting for NPM (5m 30s elapsed)…"` — so the user sees forward motion while the pod cold-starts.

## NPM admin credentials (real bootstrap)

- `templates/nginx-web/template.yml`: replaced hardcoded `admin@example.com` / `changeme` env values with `{{NGINX_ADMIN_EMAIL}}` / `{{NGINX_ADMIN_PASSWORD}}`.
- `templates/nginx-web/variables.json`: added the two new vars. Email defaults to `admin@servicebay.local`; password is type `secret` so the wizard auto-generates a strong random value.
- After installing nginx-web, the wizard now POSTs the chosen email + password to `/api/system/nginx/credentials` (the endpoint added in PR #113), persisting them into `config.reverseProxy.npm`. Every subsequent proxy-route call uses the stored creds.

## What's also in this PR (squash of two commits)

- New `/api/system/lldap/probe` endpoint + `waitForLldap` helper for the LLDAP seed step.
- Per-service install log changed from "✅ X installed successfully" to "✅ X deployed (containers may still be starting in background)" — more honest about what `--no-block` actually means.

## Test plan
- [x] Type-check + lint clean
- [x] All existing vitests pass (updated the `pull_image` timeout assertion)
- [ ] CI green
- [ ] Fresh FCOS install via rebuilt USB stick:
  - [ ] No "NPM default credentials did not work" message
  - [ ] LLDAP seed succeeds without manual retry, even on slow internet (look for `Still waiting for LLDAP (Xm Ys)…` heartbeats in the log instead of "could not seed")
  - [ ] Settings → Integrations → Reverse Proxy shows the auto-saved NPM creds (status `Stored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)