### PR TITLE
feat(wizard): clean-install option to wipe existing service data

### DIFF
--- a/src/app/api/system/stacks/reset/route.ts
+++ b/src/app/api/system/stacks/reset/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { DigitalTwinStore } from '@/lib/store/twin';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/** Service names that must never be auto-deleted by the reset endpoint. */
+const PROTECTED = new Set(['servicebay']);
+
+/**
+ * POST /api/system/stacks/reset
+ * Body: { confirm: 'RESET', node?: string }
+ *
+ * Wipes all stack data so the install wizard can re-deploy from a truly
+ * clean slate. Specifically:
+ *   - lists all installed services on the target node
+ *   - stops + removes their Quadlet definitions (.kube + .yml)
+ *   - reloads systemd
+ *   - deletes everything in `<DATA_DIR>` (default /mnt/data/stacks)
+ *   - removes /mnt/data/servicebay/quadlet-backup so an OS reinstall does
+ *     not restore the now-deleted services from setup-raid.sh
+ *
+ * ServiceBay itself is intentionally not touched.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { confirm, node: requestedNode } = body as {
+      confirm?: string;
+      node?: string;
+    };
+
+    if (confirm !== 'RESET') {
+      return NextResponse.json(
+        { error: "Confirmation required: pass {\"confirm\": \"RESET\"} in body" },
+        { status: 400 }
+      );
+    }
+
+    const twin = DigitalTwinStore.getInstance();
+    const nodeName = requestedNode || Object.keys(twin.nodes)[0];
+    if (!nodeName) {
+      return NextResponse.json({ error: 'No nodes available' }, { status: 404 });
+    }
+
+    const config = await getConfig();
+    const dataDir = config.templateSettings?.DATA_DIR || '/mnt/data/stacks';
+    // Belt-and-suspenders: refuse to wipe a path that is dangerously high in
+    // the filesystem tree. Even if a malicious config injected '/' or '/mnt',
+    // this endpoint will not act on it.
+    const safeRe = /^\/(mnt|var\/mnt|opt|srv|home)\/[^.][^\s]+/;
+    if (!safeRe.test(dataDir) || dataDir.length < 8) {
+      return NextResponse.json(
+        { error: `Refusing to wipe DATA_DIR="${dataDir}" — outside the safe path whitelist` },
+        { status: 500 }
+      );
+    }
+
+    const services = await ServiceManager.listServices(nodeName);
+    const toDelete = services
+      .map(s => s.name)
+      .filter(name => !PROTECTED.has(name));
+
+    const deleted: string[] = [];
+    const failed: { name: string; error: string }[] = [];
+
+    for (const name of toDelete) {
+      try {
+        await ServiceManager.deleteService(nodeName, name);
+        deleted.push(name);
+      } catch (e) {
+        failed.push({ name, error: e instanceof Error ? e.message : 'unknown' });
+        logger.warn('StackReset', `Failed to delete service ${name}`, e);
+      }
+    }
+
+    const agent = await agentManager.ensureAgent(nodeName);
+
+    // Wipe stack data dir contents (but keep the dir itself).
+    await agent.sendCommand('exec', {
+      command: `find ${dataDir} -mindepth 1 -maxdepth 1 -exec rm -rf {} +`,
+    });
+
+    // Remove Quadlet backup so an OS reinstall does not restore stale units.
+    // Path is intentionally hardcoded — setup-raid.sh always writes here.
+    await agent.sendCommand('exec', {
+      command: 'rm -rf /mnt/data/servicebay/quadlet-backup',
+    });
+
+    return NextResponse.json({
+      ok: true,
+      node: nodeName,
+      dataDir,
+      deleted,
+      failed,
+      protected: Array.from(PROTECTED),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'reset failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -55,6 +55,10 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
   const [deviceOptions, setDeviceOptions] = useState<Record<string, string[]>>({});
   const [loadingDevices, setLoadingDevices] = useState(false);
 
+  // Clean install — wipe existing service data before deploying.
+  const [cleanInstall, setCleanInstall] = useState(false);
+  const [cleanInstallConfirm, setCleanInstallConfirm] = useState('');
+
   useEffect(() => {
     getNodes().then(setNodes);
   }, []);
@@ -361,6 +365,31 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
   const handleInstall = async () => {
     setStep('installing');
     setLogs([]);
+
+    if (cleanInstall && cleanInstallConfirm === 'RESET') {
+      setLogs(prev => [...prev, '🧹 Clean install — wiping existing service data...']);
+      try {
+        const res = await fetch('/api/system/stacks/reset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ confirm: 'RESET', node: selectedNode || undefined }),
+        });
+        const data = await res.json();
+        if (res.ok) {
+          const removed = data.deleted?.length ?? 0;
+          setLogs(prev => [...prev, `✅ Reset done — removed ${removed} service${removed === 1 ? '' : 's'}, wiped ${data.dataDir}.`]);
+          if (data.failed?.length) {
+            setLogs(prev => [...prev, `⚠️ Some services could not be cleanly removed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`]);
+          }
+        } else {
+          setLogs(prev => [...prev, `⚠️ Reset failed: ${data.error || 'unknown error'}. Continuing — existing data may remain.`]);
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'unknown error';
+        setLogs(prev => [...prev, `⚠️ Reset call failed: ${msg}. Continuing.`]);
+      }
+    }
+
     const selectedItems = items.filter(i => i.checked);
 
     for (const item of selectedItems) {
@@ -642,6 +671,38 @@ WantedBy=default.target`;
                             </div>
                         </div>
 
+                        <div className="mb-6 border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
+                            <label className="flex items-start gap-2 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={cleanInstall}
+                                    onChange={(e) => { setCleanInstall(e.target.checked); if (!e.target.checked) setCleanInstallConfirm(''); }}
+                                    className="mt-0.5"
+                                />
+                                <div className="text-sm text-amber-900 dark:text-amber-100">
+                                    <strong>Clean install</strong> — wipe existing service data first.
+                                    <p className="text-xs text-amber-800 dark:text-amber-200/80 mt-1">
+                                        Stops every stack service, deletes their Quadlet definitions and the contents of <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code>. ServiceBay itself is not affected.
+                                    </p>
+                                </div>
+                            </label>
+                            {cleanInstall && (
+                                <div className="mt-3 pt-3 border-t border-amber-300 dark:border-amber-700">
+                                    <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
+                                        Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={cleanInstallConfirm}
+                                        onChange={(e) => setCleanInstallConfirm(e.target.value)}
+                                        className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
+                                        placeholder="RESET"
+                                        autoComplete="off"
+                                    />
+                                </div>
+                            )}
+                        </div>
+
                         {variables.length > 0 ? (
                             <div className="space-y-4 mb-6">
                                 {/* Global settings (read-only, from Settings > Template Settings) */}
@@ -771,10 +832,10 @@ WantedBy=default.target`;
                         </button>
                         <button
                             onClick={handleInstall}
-                            disabled={!selectedNode}
+                            disabled={!selectedNode || (cleanInstall && cleanInstallConfirm !== 'RESET')}
                             className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
-                            Install
+                            {cleanInstall ? 'Reset & Install' : 'Install'}
                         </button>
                     </>
                 )}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -245,6 +245,10 @@ export default function OnboardingWizard() {
   const [npmEmail, setNpmEmail] = useState('admin@example.com');
   const [npmPassword, setNpmPassword] = useState('');
 
+  // Clean install — wipe existing service data before deploying.
+  const [cleanInstall, setCleanInstall] = useState(false);
+  const [cleanInstallConfirm, setCleanInstallConfirm] = useState('');
+
   useEffect(() => {
     checkOnboardingStatus().then(s => {
       setStatus(s);
@@ -644,6 +648,32 @@ export default function OnboardingWizard() {
   const handleStackInstall = async () => {
     setStackInstallStep('installing');
     setStackLogs([]);
+
+    // Optional: wipe existing service data before deploying.
+    if (cleanInstall && cleanInstallConfirm === 'RESET') {
+      setStackLogs(prev => [...prev, '🧹 Clean install — wiping existing service data...']);
+      try {
+        const res = await fetch('/api/system/stacks/reset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ confirm: 'RESET', node: stackSelectedNode || undefined }),
+        });
+        const data = await res.json();
+        if (res.ok) {
+          const removed = data.deleted?.length ?? 0;
+          setStackLogs(prev => [...prev, `✅ Reset done — removed ${removed} service${removed === 1 ? '' : 's'}, wiped ${data.dataDir}.`]);
+          if (data.failed?.length) {
+            setStackLogs(prev => [...prev, `⚠️ Some services could not be cleanly removed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`]);
+          }
+        } else {
+          setStackLogs(prev => [...prev, `⚠️ Reset failed: ${data.error || 'unknown error'}. Continuing with install — existing data may remain.`]);
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'unknown error';
+        setStackLogs(prev => [...prev, `⚠️ Reset call failed: ${msg}. Continuing with install.`]);
+      }
+    }
+
     const selected = stackItems.filter(i => i.checked);
 
     for (const item of selected) {
@@ -1309,6 +1339,38 @@ export default function OnboardingWizard() {
                                     </select>
                                 </div>
                             )}
+
+                            <div className="mb-4 border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
+                                <label className="flex items-start gap-2 cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        checked={cleanInstall}
+                                        onChange={(e) => { setCleanInstall(e.target.checked); if (!e.target.checked) setCleanInstallConfirm(''); }}
+                                        className="mt-0.5"
+                                    />
+                                    <div className="text-sm text-amber-900 dark:text-amber-100">
+                                        <strong>Clean install</strong> — wipe existing service data first.
+                                        <p className="text-xs text-amber-800 dark:text-amber-200/80 mt-1">
+                                            Stops every stack service, deletes their Quadlet definitions and the contents of <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code>. ServiceBay itself is not affected. Use for true fresh-installs or when re-testing from scratch.
+                                        </p>
+                                    </div>
+                                </label>
+                                {cleanInstall && (
+                                    <div className="mt-3 pt-3 border-t border-amber-300 dark:border-amber-700">
+                                        <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
+                                            Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
+                                        </label>
+                                        <input
+                                            type="text"
+                                            value={cleanInstallConfirm}
+                                            onChange={(e) => setCleanInstallConfirm(e.target.value)}
+                                            className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
+                                            placeholder="RESET"
+                                            autoComplete="off"
+                                        />
+                                    </div>
+                                )}
+                            </div>
                             {stacksLoading ? (
                                 <div className="flex items-center justify-center py-4 text-gray-400">
                                     <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading variables...
@@ -1570,8 +1632,11 @@ export default function OnboardingWizard() {
             {currentStep === 'stacks' && stackInstallStep === 'configure' && (
                 <div className="flex gap-2">
                     <button onClick={() => setStackInstallStep('services')} className="px-4 py-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">Back</button>
-                    <Button onClick={handleStackInstall} disabled={!stackSelectedNode && stackNodes.length > 1}>
-                        Install Stack
+                    <Button
+                        onClick={handleStackInstall}
+                        disabled={(!stackSelectedNode && stackNodes.length > 1) || (cleanInstall && cleanInstallConfirm !== 'RESET')}
+                    >
+                        {cleanInstall ? 'Reset & Install' : 'Install Stack'}
                     </Button>
                 </div>
             )}


### PR DESCRIPTION
## Summary

Adds a "Clean install" checkbox to both the OnboardingWizard and the InstallerModal. When enabled (and the user types RESET to confirm), the wizard wipes all existing stack services and their data before deploying — so a re-run after an OS reinstall (where the RAID volume survives by design) actually gives the user a true fresh start.

Implementation:
- New `POST /api/system/stacks/reset` endpoint
- Lists services from the DigitalTwin, deletes them via existing `ServiceManager.deleteService` (stop + rm Quadlet + daemon-reload)
- Wipes `<DATA_DIR>/*` (default `/mnt/data/stacks`)
- Removes `/mnt/data/servicebay/quadlet-backup` so `setup-raid.sh` doesn't restore the now-deleted units on the next OS reinstall
- Body requires `{"confirm":"RESET"}` and the DATA_DIR is whitelist-matched (`/mnt`, `/var/mnt`, `/opt`, `/srv`, `/home`) before the rm runs
- ServiceBay itself is in a PROTECTED set and never touched

UX:
- Checkbox shows the destructive scope explicitly
- Typed confirmation (RESET) blocks accidental clicks
- Install button label flips to "Reset & Install" when armed
- Disabled until typed correctly

## Test plan

- [x] `npx vitest run` — 262/262 pass
- [x] `npx tsc --noEmit` — no errors in changed files
- [ ] Manual: enable checkbox → button stays disabled until "RESET" typed
- [ ] Manual: trigger clean install with existing stack → all services + data dirs gone, fresh wizard install succeeds
- [ ] Manual: try with checkbox off → behaviour unchanged from current

🤖 Generated with [Claude Code](https://claude.com/claude-code)