### PR TITLE
feat(templates): add navidrome (music) + audiobookshelf

### DIFF
--- a/stacks/full-stack/README.md
+++ b/stacks/full-stack/README.md
@@ -13,6 +13,8 @@ Passwort-Manager, Foto-Verwaltung, Dateifreigabe und Smart-Home.
 - [x] immich — Selbst gehostete Foto- und Video-Sicherung mit AI-Suche, Mobile-Apps und Auto-Upload
 - [x] file-share — Datei-Sync (Syncthing) + Windows-Netzlaufwerk (Samba) auf einem geteilten Volume
 - [x] home-assistant-stack — Smart-Home-Hub, lokaler Sprachassistent, Z-Wave-/Matter-Bridges
+- [ ] navidrome — Musik-Server mit Subsonic-API (Symfonium / DSub / ähnliches)
+- [ ] audiobookshelf — Hörbücher und Podcasts mit eigenen iOS/Android-Apps
 
 ## Reverse Proxy
 
@@ -29,6 +31,8 @@ Domain und Subdomains sind bei der Installation anpassbar.
 | dns.{domain} | AdGuard Home | 8083 | — | LAN-Zugriff empfohlen |
 | home.{domain} | Home Assistant | 8123 | Ja | 24h Timeouts, kein Buffering |
 | drive.{domain} | File Share (WebDAV) | 8090 | — | Unbegrenzter Upload |
+| music.{domain} | Navidrome | 4533 | Ja | Subsonic-API für Mobile-Apps (siehe Template-README für Authelia-Bypass) |
+| books.{domain} | Audiobookshelf | 13378 | Ja | Hörbücher + Podcasts, eigene Mobile-Apps |
 
 ## Nach der Installation
 

--- a/templates/audiobookshelf/README.md
+++ b/templates/audiobookshelf/README.md
@@ -1,0 +1,87 @@
+# Audiobookshelf — Audiobooks + Podcasts
+
+Self-hosted server for audiobooks and podcasts. Has its own web UI, official iOS + Android apps, and also exposes a Subsonic-compatible API so apps like Symfonium can be pointed at it as a "music server" for audiobook listening.
+
+## Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `ABS_PORT` | Web UI + API port | `13378` |
+| `TZ` | Timezone (used for podcast download schedules) | `Europe/Berlin` |
+| `ABS_AUDIOBOOKS_PATH` | Host path to your audiobook library | `/mnt/data/stacks/file-share/data/Audiobooks` |
+| `ABS_PODCASTS_PATH` | Host path where Audiobookshelf saves downloaded podcast episodes | `/mnt/data/stacks/file-share/data/Podcasts` |
+
+Both library paths default into the **file-share template's Samba volume** — drop M4B/MP3 files into `Audiobooks/<Author>/<Title>/` from any device, refresh the library in Audiobookshelf, and they show up.
+
+## Ports
+
+| Port | Purpose |
+|---|---|
+| 13378 | Web UI + REST API + Subsonic API |
+
+## Setup
+
+1. Deploy via ServiceBay
+2. Open `https://books.<your-domain>` (or `http://<server-ip>:13378`)
+3. The first user you create becomes **root admin**
+4. Add libraries:
+   - `Audiobooks` → folder `/audiobooks` (mounted from `ABS_AUDIOBOOKS_PATH`)
+   - `Podcasts` → folder `/podcasts` (mounted from `ABS_PODCASTS_PATH`)
+5. Add podcast feeds: each library → ⋮ → "Add Podcast" → paste RSS URL
+
+## Apps
+
+| Platform | App | Notes |
+|---|---|---|
+| Android | **Audiobookshelf** (official, Play Store + F-Droid) | Best UX. Server URL = `https://books.<your-domain>`, regular login. |
+| iOS | **Audiobookshelf** (official, App Store) | Same as Android. |
+| Any Subsonic client (e.g. Symfonium) | Set type = Subsonic, URL = `https://books.<your-domain>`, login. | One app for music + audiobooks if you want a single player. |
+
+## Authelia + mobile apps
+
+Same caveat as Navidrome: the Audiobookshelf API endpoints (`/api/*`, `/socket.io/*`) cannot complete an interactive Authelia login from a mobile app. Either:
+
+- **Use direct IP from mobile** (`http://<server-ip>:13378`) on LAN
+- **Bypass Authelia for the API** by adding the following rules to Authelia's `configuration.yml` ahead of the wildcard rule:
+
+  ```yaml
+  access_control:
+    rules:
+      - domain: 'books.{{PUBLIC_DOMAIN}}'
+        resources: ['^/api/.*', '^/socket\.io/.*', '^/feed/.*', '^/public/.*']
+        policy: bypass
+      - domain: 'books.{{PUBLIC_DOMAIN}}'
+        policy: one_factor
+        subject:
+          - 'group:family'
+          - 'group:admins'
+  ```
+
+  Restart Authelia after the change.
+
+## Data Layout
+
+```
+{{DATA_DIR}}/audiobookshelf/
+  config/             ← user DB, settings, server keys
+  metadata/           ← cover art cache, transcoded segments
+
+{{ABS_AUDIOBOOKS_PATH}}  ← your audiobook library
+{{ABS_PODCASTS_PATH}}    ← downloaded podcast episodes
+```
+
+## Recommended Library Layout
+
+```
+Audiobooks/
+└── Author Name/
+    └── Book Title/
+        ├── 01 - Chapter 1.m4b
+        ├── 02 - Chapter 2.m4b
+        └── cover.jpg
+
+Podcasts/
+└── (Audiobookshelf manages this; auto-downloads from RSS)
+```
+
+Audiobookshelf reads metadata tags but folder structure is the authoritative grouping for libraries.

--- a/templates/audiobookshelf/template.yml
+++ b/templates/audiobookshelf/template.yml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: audiobookshelf
+  labels:
+    app: audiobookshelf
+    servicebay.role: media
+  annotations:
+    servicebay.ports: "{{ABS_PORT}}/tcp"
+spec:
+  hostNetwork: true
+  containers:
+  - name: audiobookshelf
+    image: ghcr.io/advplyr/audiobookshelf:latest
+    env:
+      - name: PORT
+        value: "{{ABS_PORT}}"
+      - name: TZ
+        value: "{{TZ}}"
+    ports:
+      - containerPort: {{ABS_PORT}}
+    volumeMounts:
+      - mountPath: /config
+        name: abs-config
+      - mountPath: /metadata
+        name: abs-metadata
+      - mountPath: /audiobooks
+        name: abs-audiobooks
+      - mountPath: /podcasts
+        name: abs-podcasts
+  volumes:
+  - name: abs-config
+    hostPath:
+      path: {{DATA_DIR}}/audiobookshelf/config
+      type: DirectoryOrCreate
+  - name: abs-metadata
+    hostPath:
+      path: {{DATA_DIR}}/audiobookshelf/metadata
+      type: DirectoryOrCreate
+  - name: abs-audiobooks
+    hostPath:
+      path: {{ABS_AUDIOBOOKS_PATH}}
+      type: DirectoryOrCreate
+  - name: abs-podcasts
+    hostPath:
+      path: {{ABS_PODCASTS_PATH}}
+      type: DirectoryOrCreate

--- a/templates/audiobookshelf/variables.json
+++ b/templates/audiobookshelf/variables.json
@@ -1,0 +1,33 @@
+{
+  "ABS_PORT": {
+    "type": "text",
+    "description": "Port for the Audiobookshelf web UI + API",
+    "default": "13378"
+  },
+  "TZ": {
+    "type": "text",
+    "description": "Timezone (used for podcast download schedules)",
+    "default": "Europe/Berlin"
+  },
+  "ABS_AUDIOBOOKS_PATH": {
+    "type": "text",
+    "description": "Host path to your audiobook library. Defaults to the file-share Samba volume.",
+    "default": "/mnt/data/stacks/file-share/data/Audiobooks"
+  },
+  "ABS_PODCASTS_PATH": {
+    "type": "text",
+    "description": "Host path where Audiobookshelf will download podcast episodes.",
+    "default": "/mnt/data/stacks/file-share/data/Podcasts"
+  },
+  "ABS_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for Audiobookshelf",
+    "default": "books",
+    "proxyPort": "ABS_PORT",
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": true
+    }
+  }
+}

--- a/templates/navidrome/README.md
+++ b/templates/navidrome/README.md
@@ -1,0 +1,78 @@
+# Navidrome — Music Server
+
+Self-hosted music collection server with a web UI and a Subsonic-compatible API. Plays nicely with **Symfonium**, **Subsonic-Music-Player**, **DSub**, **play:Sub**, and any other Subsonic client.
+
+## Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `NAVIDROME_PORT` | Web + API port | `4533` |
+| `NAVIDROME_MUSIC_PATH` | Host path to your music library | `/mnt/data/stacks/file-share/data/Music` |
+
+The default music path is **inside the file-share template's Samba volume**. If you have file-share installed, you can drop MP3s/FLACs into the Samba share's `Music/` folder from any device and Navidrome will pick them up on its next scan (every hour by default).
+
+## Ports
+
+| Port | Purpose |
+|---|---|
+| 4533 | Web UI + Subsonic API (HTTP) |
+
+## Setup
+
+1. Deploy via ServiceBay
+2. Open `https://music.<your-domain>` (or `http://<server-ip>:4533`) — the **first user you register becomes the admin**, by Navidrome convention
+3. Drop music files into the Samba share's `Music/` folder (or whatever you set `NAVIDROME_MUSIC_PATH` to)
+4. Wait up to 1h for the first scan, or hit "Scan now" in Navidrome's settings
+
+## Symfonium (Android) configuration
+
+Add server in Symfonium:
+- **Type**: Subsonic
+- **URL**: `https://music.<your-domain>` (HTTPS, exact subdomain)
+- **Username + password**: the admin user you registered
+
+> ℹ️ Symfonium calls the Subsonic API directly (`/rest/*` endpoints). Authelia in front of the subdomain can interfere — see the **Authelia + Subsonic API** section below if your setup blocks mobile apps.
+
+## Authelia + Subsonic API
+
+The Subsonic API used by mobile apps is at `/rest/ping.view`, `/rest/getArtists.view`, etc. The default Authelia `*.{{PUBLIC_DOMAIN}}` rule (one_factor) will block these calls because mobile apps cannot complete an interactive login.
+
+**Options**:
+
+1. **Use direct IP from mobile** — configure Symfonium with `http://<server-ip>:4533`. Bypasses Authelia entirely. Works on LAN, not from outside the network.
+2. **Bypass Authelia for `/rest/.*`** — edit Authelia's `configuration.yml` to add a path-specific bypass:
+
+   ```yaml
+   access_control:
+     rules:
+       - domain: 'music.{{PUBLIC_DOMAIN}}'
+         resources: ['^/rest/.*', '^/share/.*']
+         policy: bypass
+       - domain: 'music.{{PUBLIC_DOMAIN}}'
+         policy: one_factor
+         subject:
+           - 'group:family'
+           - 'group:admins'
+   ```
+
+   Restart Authelia. Now web UI requires SSO, mobile apps go through with just Subsonic auth.
+
+## Data Layout
+
+```
+{{DATA_DIR}}/navidrome/
+  data/             ← SQLite DB, cache, transcoded files
+{{NAVIDROME_MUSIC_PATH}}  ← your music library (read-only mount)
+```
+
+## Recommended Library Layout
+
+```
+Music/
+├── Artist Name/
+│   ├── Album Name (Year)/
+│   │   ├── 01 - Track Title.flac
+│   │   └── ...
+```
+
+Navidrome reads ID3 tags. Folder structure is for your convenience.

--- a/templates/navidrome/template.yml
+++ b/templates/navidrome/template.yml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: navidrome
+  labels:
+    app: navidrome
+    servicebay.role: media
+  annotations:
+    servicebay.ports: "{{NAVIDROME_PORT}}/tcp"
+spec:
+  hostNetwork: true
+  containers:
+  - name: navidrome
+    image: docker.io/deluan/navidrome:latest
+    env:
+      - name: ND_PORT
+        value: "{{NAVIDROME_PORT}}"
+      - name: ND_DATAFOLDER
+        value: /data
+      - name: ND_MUSICFOLDER
+        value: /music
+      - name: ND_LOGLEVEL
+        value: info
+      - name: ND_SCANSCHEDULE
+        value: "@every 1h"
+      - name: ND_ENABLEUSEREDITING
+        value: "true"
+      # Trust the X-Authelia-User header so the SSO login becomes the
+      # Navidrome login automatically. Bound to the loopback subnet
+      # because the proxy lives on the same host. Subsonic API calls
+      # (mobile apps) ignore this and use built-in user auth.
+      - name: ND_REVERSEPROXYUSERHEADER
+        value: Remote-User
+      - name: ND_REVERSEPROXYWHITELIST
+        value: 127.0.0.1/32
+    ports:
+      - containerPort: {{NAVIDROME_PORT}}
+    volumeMounts:
+      - mountPath: /data
+        name: navidrome-data
+      - mountPath: /music
+        name: navidrome-music
+        readOnly: true
+  volumes:
+  - name: navidrome-data
+    hostPath:
+      path: {{DATA_DIR}}/navidrome/data
+      type: DirectoryOrCreate
+  - name: navidrome-music
+    hostPath:
+      path: {{NAVIDROME_MUSIC_PATH}}
+      type: DirectoryOrCreate

--- a/templates/navidrome/variables.json
+++ b/templates/navidrome/variables.json
@@ -1,0 +1,23 @@
+{
+  "NAVIDROME_PORT": {
+    "type": "text",
+    "description": "Port for the Navidrome web UI + Subsonic API",
+    "default": "4533"
+  },
+  "NAVIDROME_MUSIC_PATH": {
+    "type": "text",
+    "description": "Host path to your music library. Defaults to the file-share template's data dir, so files dropped into the Samba share appear automatically.",
+    "default": "/mnt/data/stacks/file-share/data/Music"
+  },
+  "NAVIDROME_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for Navidrome (web UI + Symfonium endpoint)",
+    "default": "music",
+    "proxyPort": "NAVIDROME_PORT",
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two new pod templates so users get a real media-server experience instead of fighting Samba for music and audiobooks:

**navidrome** — Subsonic-compatible music server. Works natively with Symfonium / DSub / play:Sub / etc. Music dir defaults to the file-share template's Samba volume so MP3s/FLACs dropped via the share auto-appear. ND_REVERSEPROXYUSERHEADER pre-set so Authelia SSO automatically becomes the Navidrome login for browser users.

**audiobookshelf** — Audiobooks + podcasts in one server, with official iOS/Android apps and a Subsonic API surface. Library paths default into the file-share volume too.

Both READMEs cover the Authelia / mobile-app gotcha (interactive SSO blocks API calls from phones) with two concrete workarounds.

The full-stack stack README gets two opt-in checkbox entries — off by default since not every install needs media servers.

## Test plan

- [x] `npx vitest run` — 262/262 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: install navidrome via wizard → drop a music file in `/mnt/data/stacks/file-share/data/Music/` → wait for scan → plays in Symfonium with `https://music.<domain>` URL
- [ ] Manual: install audiobookshelf via wizard → add audiobook library at `/audiobooks` → official Android app connects + plays
- [ ] Manual: subdomain in NPM auto-created with the configured port

🤖 Generated with [Claude Code](https://claude.com/claude-code)