### PR TITLE
feat(media): auto-seed Audiobookshelf + Navidrome admin

### DIFF
--- a/src/app/api/system/media/init/route.ts
+++ b/src/app/api/system/media/init/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+interface InitRequest {
+  service: 'audiobookshelf' | 'navidrome';
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+}
+
+/**
+ * POST /api/system/media/init
+ *
+ * Proxy that calls the first-run setup endpoints of media servers so the
+ * install wizard can pre-create their admin users — replicating what the
+ * user would otherwise do by hand on first visit. ServiceBay runs in the
+ * same network namespace as the target pod (host network) so localhost
+ * + the container's port reach it directly.
+ *
+ * Returns:
+ *   { ok: true }                  — admin created
+ *   { alreadySetup: true }        — service refused because an admin already
+ *                                   exists; not an error, just a signal
+ *   { error: '...' }              — anything else
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json() as Partial<InitRequest>;
+    const { service, host, port, username, password } = body;
+    if (!service || !host || !port || !username || !password) {
+      return NextResponse.json({ error: 'service, host, port, username, password required' }, { status: 400 });
+    }
+
+    if (service === 'audiobookshelf') {
+      return await initAudiobookshelf(host, port, username, password);
+    }
+    if (service === 'navidrome') {
+      return await initNavidrome(host, port, username, password);
+    }
+    return NextResponse.json({ error: `unknown service: ${service}` }, { status: 400 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'init failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+async function initAudiobookshelf(host: string, port: number, username: string, password: string) {
+  const url = `http://${host}:${port}/init`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ newRoot: { username, password } }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (res.ok) return NextResponse.json({ ok: true });
+  // 400/409 with "already" in the body means admin already exists — that's
+  // a normal state on a re-install over an existing data dir, not a failure.
+  const text = await res.text().catch(() => '');
+  if (text.toLowerCase().includes('already') || res.status === 409) {
+    return NextResponse.json({ alreadySetup: true });
+  }
+  return NextResponse.json({ error: `Audiobookshelf rejected /init (HTTP ${res.status}): ${text.slice(0, 200)}` }, { status: 502 });
+}
+
+async function initNavidrome(host: string, port: number, username: string, password: string) {
+  const url = `http://${host}:${port}/auth/createAdmin`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (res.ok) return NextResponse.json({ ok: true });
+  const text = await res.text().catch(() => '');
+  if (text.toLowerCase().includes('admin') && (res.status === 400 || res.status === 409)) {
+    return NextResponse.json({ alreadySetup: true });
+  }
+  return NextResponse.json({ error: `Navidrome rejected /auth/createAdmin (HTTP ${res.status}): ${text.slice(0, 200)}` }, { status: 502 });
+}

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -214,6 +214,22 @@ function logAdguardCredentials(opts: { variables: StackVariable[]; onLog: (msg: 
   opts.onLog(`🔑 AdGuard admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Note now, only shown once.`);
 }
 
+function logAudiobookshelfCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
+  const user = opts.variables.find(v => v.name === 'ABS_ADMIN_USER')?.value || 'root';
+  const password = opts.variables.find(v => v.name === 'ABS_ADMIN_PASSWORD')?.value;
+  const port = opts.variables.find(v => v.name === 'ABS_PORT')?.value || '13378';
+  if (!password) return;
+  opts.onLog(`🔑 Audiobookshelf admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Note now, only shown once.`);
+}
+
+function logNavidromeCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
+  const user = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_USER')?.value || 'admin';
+  const password = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_PASSWORD')?.value;
+  const port = opts.variables.find(v => v.name === 'NAVIDROME_PORT')?.value || '4533';
+  if (!password) return;
+  opts.onLog(`🔑 Navidrome admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Subsonic clients (Symfonium etc.) use the same credentials.`);
+}
+
 /** Persist NPM admin credentials so subsequent proxy-host operations
  *  authenticate without prompting. */
 async function persistNpmCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {
@@ -230,6 +246,90 @@ async function persistNpmCredentials(opts: { variables: StackVariable[]; onLog: 
   } catch {
     opts.onLog('⚠️ Could not persist NPM credentials — set them later in Settings → Integrations.');
   }
+}
+
+/** Poll until a media server's first-run init endpoint accepts our admin
+ *  payload. Retries every 5s for up to 5 minutes — enough for image pull
+ *  to finish on slow connections. */
+async function seedMediaServer(opts: {
+  service: 'audiobookshelf' | 'navidrome';
+  variables: StackVariable[];
+  userVar: string;
+  passwordVar: string;
+  portVar: string;
+  defaultUser: string;
+  defaultPort: string;
+  serviceLabel: string;
+  onLog: (msg: string) => void;
+}): Promise<void> {
+  const username = opts.variables.find(v => v.name === opts.userVar)?.value || opts.defaultUser;
+  const password = opts.variables.find(v => v.name === opts.passwordVar)?.value;
+  const port = opts.variables.find(v => v.name === opts.portVar)?.value || opts.defaultPort;
+  if (!password) return;
+
+  opts.onLog(`Waiting for ${opts.serviceLabel} to start...`);
+  const start = Date.now();
+  let lastBeat = 0;
+  while (Date.now() - start < 5 * 60_000) {
+    try {
+      const res = await fetch('/api/system/media/init', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          service: opts.service,
+          host: 'localhost',
+          port: parseInt(port, 10),
+          username,
+          password,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok && data.ok) {
+        opts.onLog(`✅ ${opts.serviceLabel} root user '${username}' created.`);
+        return;
+      }
+      if (res.ok && data.alreadySetup) {
+        opts.onLog(`ℹ️ ${opts.serviceLabel} already initialized — keeping existing admin. Reset manually if the password doesn't match.`);
+        return;
+      }
+      // Other errors: keep retrying — service might still be cold-starting.
+    } catch { /* not reachable yet */ }
+    const elapsed = Date.now() - start;
+    if (elapsed - lastBeat >= 10_000) {
+      opts.onLog(`Still waiting for ${opts.serviceLabel} (${fmtElapsed(elapsed)} elapsed)...`);
+      lastBeat = elapsed;
+    }
+    await new Promise(r => setTimeout(r, 5000));
+  }
+  opts.onLog(`⚠️ ${opts.serviceLabel} did not become reachable in 5 minutes. Open http://<server-ip>:${port} and create the admin user manually.`);
+}
+
+async function seedAudiobookshelf(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {
+  return seedMediaServer({
+    service: 'audiobookshelf',
+    variables: opts.variables,
+    userVar: 'ABS_ADMIN_USER',
+    passwordVar: 'ABS_ADMIN_PASSWORD',
+    portVar: 'ABS_PORT',
+    defaultUser: 'root',
+    defaultPort: '13378',
+    serviceLabel: 'Audiobookshelf',
+    onLog: opts.onLog,
+  });
+}
+
+async function seedNavidrome(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {
+  return seedMediaServer({
+    service: 'navidrome',
+    variables: opts.variables,
+    userVar: 'NAVIDROME_ADMIN_USER',
+    passwordVar: 'NAVIDROME_ADMIN_PASSWORD',
+    portVar: 'NAVIDROME_PORT',
+    defaultUser: 'admin',
+    defaultPort: '4533',
+    serviceLabel: 'Navidrome',
+    onLog: opts.onLog,
+  });
 }
 
 interface SeedLldapOpts {
@@ -300,15 +400,27 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   if (isSelected('adguard')) {
     logAdguardCredentials({ variables, onLog });
   }
+  if (isSelected('audiobookshelf')) {
+    logAudiobookshelfCredentials({ variables, onLog });
+  }
+  if (isSelected('navidrome')) {
+    logNavidromeCredentials({ variables, onLog });
+  }
   if (isSelected('nginx-web')) {
     await persistNpmCredentials({ variables, onLog });
   }
 
-  // Kick off LLDAP seed in the background; failures are logged via onLog
-  // inside seedLldap itself, so an unhandled rejection here is fine to
-  // swallow.
+  // Kick off all "wait + initialize" tasks in the background. Their logs
+  // interleave with the proxy step's, but the proxy result returns ASAP
+  // so the NPM credentials prompt (if needed) appears responsive.
   if (isSelected('lldap')) {
     void seedLldap({ variables, onLog }).catch(() => { /* logged inline */ });
+  }
+  if (isSelected('audiobookshelf')) {
+    void seedAudiobookshelf({ variables, onLog }).catch(() => { /* logged inline */ });
+  }
+  if (isSelected('navidrome')) {
+    void seedNavidrome({ variables, onLog }).catch(() => { /* logged inline */ });
   }
 
   return configureProxyRoutes({ variables, node, onLog });

--- a/templates/audiobookshelf/README.md
+++ b/templates/audiobookshelf/README.md
@@ -21,9 +21,9 @@ Both library paths default into the **file-share template's Samba volume** — d
 
 ## Setup
 
-1. Deploy via ServiceBay
+1. Deploy via ServiceBay — the wizard auto-creates the root admin via Audiobookshelf's `/init` endpoint, so the first-launch wizard is skipped.
 2. Open `https://books.<your-domain>` (or `http://<server-ip>:13378`)
-3. The first user you create becomes **root admin**
+3. Log in with the credentials shown in the install log (default user `root`, auto-generated password)
 4. Add libraries:
    - `Audiobooks` → folder `/audiobooks` (mounted from `ABS_AUDIOBOOKS_PATH`)
    - `Podcasts` → folder `/podcasts` (mounted from `ABS_PODCASTS_PATH`)

--- a/templates/audiobookshelf/variables.json
+++ b/templates/audiobookshelf/variables.json
@@ -4,6 +4,15 @@
     "description": "Port for the Audiobookshelf web UI + API",
     "default": "13378"
   },
+  "ABS_ADMIN_USER": {
+    "type": "text",
+    "description": "Audiobookshelf root admin username",
+    "default": "root"
+  },
+  "ABS_ADMIN_PASSWORD": {
+    "type": "secret",
+    "description": "Audiobookshelf root admin password — auto-generated. ServiceBay calls /init after deploy to skip the first-launch wizard."
+  },
   "TZ": {
     "type": "text",
     "description": "Timezone (used for podcast download schedules)",

--- a/templates/navidrome/README.md
+++ b/templates/navidrome/README.md
@@ -19,10 +19,11 @@ The default music path is **inside the file-share template's Samba volume**. If 
 
 ## Setup
 
-1. Deploy via ServiceBay
-2. Open `https://music.<your-domain>` (or `http://<server-ip>:4533`) — the **first user you register becomes the admin**, by Navidrome convention
-3. Drop music files into the Samba share's `Music/` folder (or whatever you set `NAVIDROME_MUSIC_PATH` to)
-4. Wait up to 1h for the first scan, or hit "Scan now" in Navidrome's settings
+1. Deploy via ServiceBay — the wizard auto-creates the admin user via Navidrome's `/auth/createAdmin` endpoint
+2. Open `https://music.<your-domain>` (or `http://<server-ip>:4533`)
+3. Log in with the credentials shown in the install log (default user `admin`, auto-generated password)
+4. Drop music files into the Samba share's `Music/` folder (or whatever you set `NAVIDROME_MUSIC_PATH` to)
+5. Wait up to 1h for the first scan, or hit "Scan now" in Navidrome's settings
 
 ## Symfonium (Android) configuration
 

--- a/templates/navidrome/variables.json
+++ b/templates/navidrome/variables.json
@@ -4,6 +4,15 @@
     "description": "Port for the Navidrome web UI + Subsonic API",
     "default": "4533"
   },
+  "NAVIDROME_ADMIN_USER": {
+    "type": "text",
+    "description": "Navidrome admin username (also used as Subsonic API user)",
+    "default": "admin"
+  },
+  "NAVIDROME_ADMIN_PASSWORD": {
+    "type": "secret",
+    "description": "Navidrome admin password — auto-generated. ServiceBay calls /auth/createAdmin after deploy so first login works without going through the in-app setup."
+  },
   "NAVIDROME_MUSIC_PATH": {
     "type": "text",
     "description": "Host path to your music library. Defaults to the file-share template's data dir, so files dropped into the Samba share appear automatically.",


### PR DESCRIPTION
## Summary

User hit Audiobookshelf's first-run \"Initial Server Setup\" form after deploy and asked why the admin user wasn't pre-configured the way LLDAP and AdGuard are. Same gap for Navidrome (\"first user becomes admin\").

Both servers expose dedicated init endpoints that ServiceBay can drive automatically:
- ABS: \`POST /init\` body \`{newRoot:{username,password}}\`
- Navidrome: \`POST /auth/createAdmin\` body \`{username,password}\`

This adds:
- new \`POST /api/system/media/init\` proxy route (treats 4xx-with-\"already\" responses as \`alreadySetup\` rather than error)
- new \`ABS_ADMIN_USER\` / \`ABS_ADMIN_PASSWORD\` vars (defaults: root + auto-gen secret)
- new \`NAVIDROME_ADMIN_USER\` / \`NAVIDROME_ADMIN_PASSWORD\` vars
- generic \`seedMediaServer()\` helper in postInstall.ts (5min ceiling, 5s intervals, 10s heartbeat)
- \`runPostInstall\` fires both seeds fire-and-forget alongside the LLDAP seed; the proxy result still returns immediately
- install log shows the auto-gen credentials inline (consistent with LLDAP/AdGuard pattern)
- both READMEs updated

## Test plan

- [x] \`npx vitest run\` — 261 pass / 1 skipped
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: install audiobookshelf via wizard → first-launch \"Initial Server Setup\" form should NOT appear; login with logged credentials works
- [ ] Manual: install navidrome → same; first browser visit goes straight to login screen
- [ ] Manual: install over existing data dir → log shows \"already initialized — keeping existing admin\" instead of an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)