### PR TITLE
fix(templates): redis-cache deploy + full-stack contents

### DIFF
--- a/stacks/full-stack/README.md
+++ b/stacks/full-stack/README.md
@@ -13,8 +13,8 @@ Passwort-Manager, Foto-Verwaltung, Dateifreigabe und Smart-Home.
 - [x] immich — Selbst gehostete Foto- und Video-Sicherung mit AI-Suche, Mobile-Apps und Auto-Upload
 - [x] file-share — Datei-Sync (Syncthing) + Windows-Netzlaufwerk (Samba) auf einem geteilten Volume
 - [x] home-assistant-stack — Smart-Home-Hub, lokaler Sprachassistent, Z-Wave-/Matter-Bridges
-- [ ] navidrome — Musik-Server mit Subsonic-API (Symfonium / DSub / ähnliches)
-- [ ] audiobookshelf — Hörbücher und Podcasts mit eigenen iOS/Android-Apps
+- [x] navidrome — Musik-Server mit Subsonic-API (Symfonium / DSub / ähnliches)
+- [x] audiobookshelf — Hörbücher und Podcasts mit eigenen iOS/Android-Apps
 
 ## Reverse Proxy
 
@@ -61,12 +61,7 @@ Für Admin-Services (Nginx Admin, AdGuard) eine Access List anlegen:
 - NPM → Access Lists → Add → Allow: `192.168.0.0/16`, `10.0.0.0/8`
 - Dann bei den entsprechenden Proxy Hosts die Access List zuweisen
 
-### 4. AdGuard Setup-Wizard
-
-Beim ersten Start `http://<SERVER-IP>:3000` öffnen und den Setup-Wizard durchlaufen.
-Admin-Port auf **8083** setzen (oder den in der Installation konfigurierten Port).
-
-### 5. Geräte-DNS umstellen
+### 4. Geräte-DNS umstellen
 
 Router-DNS oder Geräte-DNS auf `<SERVER-IP>:53` zeigen lassen,
 damit AdGuard Home netzwerkweit Werbung blockiert.

--- a/templates/redis-cache/template.yml
+++ b/templates/redis-cache/template.yml
@@ -10,5 +10,5 @@ spec:
     image: docker.io/library/redis:{{VERSION}}
     ports:
     - containerPort: 6379
-      hostPort: 6379
+      hostPort: {{REDIS_PORT}}
 

--- a/templates/redis-cache/variables.json
+++ b/templates/redis-cache/variables.json
@@ -1,0 +1,13 @@
+{
+  "VERSION": {
+    "type": "select",
+    "description": "Redis image tag. Use 7-alpine for smaller images, 7 for the standard one.",
+    "default": "7-alpine",
+    "options": ["7-alpine", "7", "alpine", "latest"]
+  },
+  "REDIS_PORT": {
+    "type": "text",
+    "description": "Host port to expose Redis on",
+    "default": "6379"
+  }
+}


### PR DESCRIPTION
## Summary

Three concrete bugs from the template audit:

1. **redis-cache** referenced \`{{VERSION}}\` in template.yml but had no \`variables.json\` — deploy would fail at render time with an unresolved variable. Add variables.json with \`VERSION\` (select dropdown) and \`REDIS_PORT\`, parameterize the hostPort.
2. **full-stack** README marked navidrome + audiobookshelf as \`[ ]\` (uncheck) — they're now part of the install pipeline. Mark both as included.
3. **full-stack** README still told users to run AdGuard's setup wizard at port 3000. Irrelevant since AdGuard is pre-seeded. Drop the section.

This is the first of three small follow-up PRs after the template audit.

## Test plan

- [x] \`npx vitest run\` — 261 pass / 1 skipped
- [ ] Manual: deploy redis-cache via wizard, picks default version, exposes port
- [ ] Manual: full-stack install → all 10 services land

🤖 Generated with [Claude Code](https://claude.com/claude-code)