### PR TITLE
refactor(templates): consistent secret types + TZ var + file-share docs

### DIFF
--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -222,6 +222,13 @@ function logAudiobookshelfCredentials(opts: { variables: StackVariable[]; onLog:
   opts.onLog(`🔑 Audiobookshelf admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Note now, only shown once.`);
 }
 
+function logFileShareCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
+  const user = opts.variables.find(v => v.name === 'SHARE_USER')?.value || 'samba';
+  const password = opts.variables.find(v => v.name === 'SHARE_PASSWORD')?.value;
+  if (!password) return;
+  opts.onLog(`🔑 Samba share (user: ${user}, password: ${password}) — mount via \\\\<server-ip>\\data on Windows or smb://<server-ip>/data on macOS. Note now, only shown once.`);
+}
+
 function logNavidromeCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
   const user = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_USER')?.value || 'admin';
   const password = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_PASSWORD')?.value;
@@ -405,6 +412,9 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   }
   if (isSelected('navidrome')) {
     logNavidromeCredentials({ variables, onLog });
+  }
+  if (isSelected('file-share')) {
+    logFileShareCredentials({ variables, onLog });
   }
   if (isSelected('nginx-web')) {
     await persistNpmCredentials({ variables, onLog });

--- a/templates/authelia/variables.json
+++ b/templates/authelia/variables.json
@@ -51,8 +51,8 @@
     "default": "dc=dopp,dc=cloud"
   },
   "LLDAP_ADMIN_PASSWORD": {
-    "type": "password",
-    "description": "LLDAP admin password"
+    "type": "secret",
+    "description": "LLDAP admin password — auto-generated when LLDAP is installed alongside, inherited from lldap/variables.json. Standalone Authelia installs use this for the LDAP bind that is not actually wired up."
   },
   "PUBLIC_DOMAIN": {
     "type": "text",

--- a/templates/file-share/README.md
+++ b/templates/file-share/README.md
@@ -12,8 +12,10 @@ Both containers share a single data volume (`/mnt/data`), so files added through
 | Variable | Description | Default |
 |---|---|---|
 | `DATA_DIR` | Base directory for persistent data (global) | `/mnt/data` |
-| `SHARE_USER` | Username for Samba access | `user` |
-| `SHARE_PASSWORD` | Password for Samba access | — |
+| `SHARE_USER` | Username for Samba access | `samba` |
+| `SHARE_PASSWORD` | Password for Samba access | — (auto-generated, shown in install log) |
+
+> ℹ️ Samba auth is local-only — no LDAP/Authelia integration. The single `SHARE_USER` is the credentials Windows/macOS prompts for when mounting the share. Syncthing devices pair via cryptographic device IDs and don't use LDAP either.
 
 ## Ports
 

--- a/templates/file-share/variables.json
+++ b/templates/file-share/variables.json
@@ -5,8 +5,8 @@
     "default": "samba"
   },
   "SHARE_PASSWORD": {
-    "type": "password",
-    "description": "Samba password for file share access"
+    "type": "secret",
+    "description": "Samba password — auto-generated. Note it during install: you'll type it once per Windows/macOS machine when mounting the share. Use the regenerate icon if you want a custom value before deploy."
   },
   "SYNCTHING_SUBDOMAIN": {
     "type": "subdomain",

--- a/templates/home-assistant-stack/template.yml
+++ b/templates/home-assistant-stack/template.yml
@@ -14,7 +14,7 @@ spec:
     image: ghcr.io/home-assistant/home-assistant:stable
     env:
     - name: TZ
-      value: "Europe/Berlin"
+      value: "{{TZ}}"
     volumeMounts:
     - mountPath: /config
       name: ha-config
@@ -30,7 +30,7 @@ spec:
     image: ghcr.io/zwave-js/zwave-js-ui:latest
     env:
     - name: TZ
-      value: "Europe/Berlin"
+      value: "{{TZ}}"
     - name: SESSION_SECRET
       value: "{{ZWAVE_SECRET}}"
     - name: ZWAVEJS_EXTERNAL_CONFIG
@@ -49,7 +49,7 @@ spec:
     image: ghcr.io/home-assistant-libs/python-matter-server:stable
     env:
     - name: TZ
-      value: "Europe/Berlin"
+      value: "{{TZ}}"
     volumeMounts:
     - mountPath: /data
       name: matter-config

--- a/templates/home-assistant-stack/variables.json
+++ b/templates/home-assistant-stack/variables.json
@@ -1,4 +1,9 @@
 {
+  "TZ": {
+    "type": "text",
+    "description": "Timezone (used by HA, Z-Wave JS and Matter Server for log/scheduling timestamps)",
+    "default": "Europe/Berlin"
+  },
   "ZWAVE_SECRET": {
     "type": "secret",
     "description": "Random string for Z-Wave JS session security (auto-generated)"


### PR DESCRIPTION
## Summary

Audit follow-up #2 of 3.

1. **Secret-type consistency** — \`SHARE_PASSWORD\` (file-share) and \`LLDAP_ADMIN_PASSWORD\` (authelia) were type \`password\` while every other admin credential is \`secret\` (auto-gen, edit/regen in configure). Align them. Samba password now surfaces in the install log via the existing credential pattern.
2. **TZ variable** — pulled \`Europe/Berlin\` out of three places in home-assistant-stack/template.yml into a single \`TZ\` variable, matching what audiobookshelf already does.
3. **file-share docs** — clarify that there's no LDAP/Authelia integration on either Samba or Syncthing.

## Test plan

- [x] \`npx vitest run\` clean
- [ ] Manual: install file-share → password appears in log + works for Windows mount
- [ ] Manual: install home-assistant-stack with TZ=America/New_York → all three sub-containers honor it

🤖 Generated with [Claude Code](https://claude.com/claude-code)