### PR TITLE
feat(templates): SSO integration for media servers + AdGuard

### DIFF
--- a/templates/adguard/README.md
+++ b/templates/adguard/README.md
@@ -26,6 +26,12 @@ ServiceBay pre-seeds `AdGuardHome.yaml` with the configured ports and admin user
 
 The auto-generated password is shown once during install — copy it into your password manager.
 
+## SSO / Authelia
+
+AdGuard Home has no native OIDC or trusted-header support — every visit shows AdGuard's own login form. The Authelia wildcard rule in front of `dns.<your-domain>` adds a layer (admins-group + 2FA), but you'll still type the AdGuard admin password on the AdGuard login page itself. Save it in your password manager.
+
+If you want strictly-LAN access without bothering with Authelia at all, add an Access List in NPM (Settings → Access Lists → Add → Allow `192.168.0.0/16`) and assign it to the `dns.<domain>` proxy host.
+
 ## Port 53 on the host
 
 AdGuard binds DNS to `0.0.0.0:53`. On Fedora CoreOS the systemd-resolved stub listener occupies that port by default. The ServiceBay Butane config disables the stub (`DNSStubListener=no`) and repoints `/etc/resolv.conf` at `/run/systemd/resolve/resolv.conf` so name resolution keeps working on the host.

--- a/templates/audiobookshelf/README.md
+++ b/templates/audiobookshelf/README.md
@@ -37,6 +37,20 @@ Both library paths default into the **file-share template's Samba volume** — d
 | iOS | **Audiobookshelf** (official, App Store) | Same as Android. |
 | Any Subsonic client (e.g. Symfonium) | Set type = Subsonic, URL = `https://books.<your-domain>`, login. | One app for music + audiobooks if you want a single player. |
 
+## SSO via Authelia (OIDC)
+
+Audiobookshelf supports OpenID Connect natively. ServiceBay auto-registers an OIDC client with Authelia when both are installed in the same stack — the client credentials end up in Authelia's `configuration.yml`. To finish wiring it up:
+
+1. Open Audiobookshelf → **Settings** → **Authentication**
+2. Enable **OpenID Connect**
+3. Issuer URL: `https://auth.<your-domain>`
+4. Client ID: `audiobookshelf`
+5. Client Secret: (visible in Authelia's `configuration.yml` — under `identity_providers.oidc.clients`, look for `client_id: 'audiobookshelf'`, copy the `$plaintext$<value>` after `client_secret`)
+6. Redirect URI: leave default (Audiobookshelf shows it back to you)
+7. Save → log out → next browser login goes through Authelia
+
+Mobile apps fall back to the Subsonic / built-in admin login as before.
+
 ## Authelia + mobile apps
 
 Same caveat as Navidrome: the Audiobookshelf API endpoints (`/api/*`, `/socket.io/*`) cannot complete an interactive Authelia login from a mobile app. Either:

--- a/templates/audiobookshelf/variables.json
+++ b/templates/audiobookshelf/variables.json
@@ -37,6 +37,13 @@
       "allow_websocket_upgrade": true,
       "block_exploits": true,
       "ssl_forced": true
+    },
+    "oidcClient": {
+      "client_id": "audiobookshelf",
+      "client_name": "Audiobookshelf",
+      "authorization_policy": "one_factor",
+      "redirect_uris": ["/auth/openid/callback", "/auth/openid/mobile-redirect"],
+      "scopes": ["openid", "profile", "email", "groups"]
     }
   }
 }

--- a/templates/navidrome/README.md
+++ b/templates/navidrome/README.md
@@ -34,6 +34,22 @@ Add server in Symfonium:
 
 > ℹ️ Symfonium calls the Subsonic API directly (`/rest/*` endpoints). Authelia in front of the subdomain can interfere — see the **Authelia + Subsonic API** section below if your setup blocks mobile apps.
 
+## SSO via Authelia (header trust)
+
+Navidrome doesn't speak OIDC natively but **does** trust an upstream proxy header for SSO. The template pre-sets `ND_REVERSEPROXYUSERHEADER=Remote-User` so once Authelia injects that header, browser users skip the Navidrome login entirely.
+
+To enable it:
+
+1. NPM → edit the `music.<your-domain>` proxy host → tab **Advanced** → paste:
+
+   ```
+   include /data/nginx/snippets/authelia.conf;  # or paste the auth_request block from https://www.authelia.com/integration/proxies/nginx-proxy-manager/
+   ```
+
+2. Save. Browser visit to `https://music.<your-domain>` now goes Authelia → Navidrome with the user already signed in.
+
+Mobile Subsonic clients (Symfonium etc.) keep using the built-in `admin` user since they cannot complete an interactive Authelia login. See **Authelia + Subsonic API** below for path-bypass rules so the API endpoints stay reachable.
+
 ## Authelia + Subsonic API
 
 The Subsonic API used by mobile apps is at `/rest/ping.view`, `/rest/getArtists.view`, etc. The default Authelia `*.{{PUBLIC_DOMAIN}}` rule (one_factor) will block these calls because mobile apps cannot complete an interactive login.


### PR DESCRIPTION
## Summary

Audit follow-up #3 of 3.

Each of the three media-adjacent services has a different SSO surface upstream — this PR aligns each with what's actually possible and documents it.

- **Audiobookshelf** — native OIDC since v2.7. Adds \`oidcClient\` to ABS_SUBDOMAIN so the existing oidc-clients pipeline auto-registers it with Authelia. README documents the in-app fields.
- **Navidrome** — no native OIDC but \`ND_REVERSEPROXYUSERHEADER=Remote-User\` is already pre-set in the template. README adds the NPM Advanced snippet to inject the header.
- **AdGuard** — no OIDC / no header trust upstream. README clarifies that Authelia still gates access at the proxy level (admins + 2FA) but the AdGuard login form remains. Suggests NPM Access List for LAN-only alt.

No template.yml changes — SSO wiring is config-only.

## Test plan

- [x] \`npx vitest run\` clean
- [ ] Manual: install ABS+Authelia → check Authelia's configuration.yml for the audiobookshelf client_id with auto-gen secret
- [ ] Manual: enable ABS OIDC per README → browser login goes through Authelia

🤖 Generated with [Claude Code](https://claude.com/claude-code)