### PR TITLE
feat(install): bake PUBLIC_DOMAIN into config + auto-wire OIDC secrets

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -1149,6 +1149,10 @@ else
   prompt_secret SERVICEBAY_ADMIN_PASSWORD "ServiceBay admin password"
   prompt_secret HOST_PASSWORD "Host user console password (will be hashed)"
 
+  # --- Public domain (used by Authelia, NPM, all OIDC clients) ---
+  echo ""
+  prompt PUBLIC_DOMAIN "Public domain (e.g. dopp.cloud) — leave empty to set later in the wizard" "$(prev PUBLIC_DOMAIN "")"
+
   # --- Gateway (FRITZ!Box) ---
 
   echo ""
@@ -1223,6 +1227,15 @@ SERVICEBAY_CONFIG='{
   "templateSettings": {
     "DATA_DIR": "'"$DATA_ROOT/stacks"'"
   }'
+
+# Add reverseProxy.publicDomain if user supplied one — wizard reads this
+# as the default for PUBLIC_DOMAIN so they don't have to type it again.
+if [[ -n "$PUBLIC_DOMAIN" ]]; then
+  SERVICEBAY_CONFIG+=',
+  "reverseProxy": {
+    "publicDomain": "'"$PUBLIC_DOMAIN"'"
+  }'
+fi
 
 # Add gateway config if provided
 if [[ -n "$GW_USER" ]]; then

--- a/src/app/api/system/authelia/oidc-clients/route.ts
+++ b/src/app/api/system/authelia/oidc-clients/route.ts
@@ -54,13 +54,20 @@ export async function POST(request: NextRequest) {
           uri.startsWith('http') || uri.includes(':/') ? uri : `https://${fqdn}${uri}`
         );
 
+        // If the template references an env-var-pinned secret (`clientSecretVar`),
+        // use the wizard-provided value so the SAME secret is in both the
+        // service's env and Authelia's clients[]. Otherwise auto-generate.
+        const sharedSecret = oidc.clientSecretVar
+          ? body.variables[oidc.clientSecretVar]
+          : undefined;
+
         clients.push({
           client_id: oidc.client_id,
           client_name: oidc.client_name,
           authorization_policy: oidc.authorization_policy,
           redirect_uris: redirectUris,
           scopes: oidc.scopes,
-          client_secret: generateSecret(),
+          client_secret: sharedSecret || generateSecret(),
         });
       }
     }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -481,6 +481,13 @@ export default function OnboardingWizard() {
       if (settingsRes.ok) {
         const settings = await settingsRes.json();
         globalSettings = settings.templateSettings || {};
+        // The install script can pre-bake reverseProxy.publicDomain into
+        // config.json — pull it here so the wizard's domain prompt shows
+        // it as default and the user doesn't have to retype it.
+        const bakedDomain = settings.reverseProxy?.publicDomain;
+        if (bakedDomain && !stackDomain) {
+          setStackDomain(bakedDomain);
+        }
       }
     } catch { /* use empty defaults */ }
 

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -259,6 +259,15 @@ export interface OidcClientConfig {
   authorization_policy?: string;
   redirect_uris: string[];
   scopes?: string[];
+  /**
+   * Name of a `secret`-type variable whose value should be used as the
+   * client_secret. When set, the wizard auto-generates the secret once and
+   * substitutes it into BOTH the service's env (e.g. SSO_CLIENT_SECRET) and
+   * Authelia's clients[] entry, so env-var-driven OIDC integrations work
+   * without any post-deploy copy-paste. Omit to let the oidc-clients
+   * endpoint generate a fresh random secret each time (legacy behaviour).
+   */
+  clientSecretVar?: string;
 }
 
 export interface VariableMeta {

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -229,6 +229,31 @@ function logFileShareCredentials(opts: { variables: StackVariable[]; onLog: (msg
   opts.onLog(`🔑 Samba share (user: ${user}, password: ${password}) — mount via \\\\<server-ip>\\data on Windows or smb://<server-ip>/data on macOS. Note now, only shown once.`);
 }
 
+/** Surface OIDC client secrets that the user has to paste into a service's
+ *  Settings UI (e.g. Audiobookshelf). Vaultwarden picks up its secret via
+ *  env so it doesn't need a paste — only a note about how to flip the
+ *  feature on. */
+function logOidcClientSecrets(opts: { selected: StackItem[]; variables: StackVariable[]; onLog: (msg: string) => void }): void {
+  const isSelected = (name: string) => opts.selected.some(i => i.name === name);
+  const domain = opts.variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
+
+  if (isSelected('audiobookshelf')) {
+    const secret = opts.variables.find(v => v.name === 'ABS_OIDC_SECRET')?.value;
+    if (secret && domain) {
+      opts.onLog(`🔐 Audiobookshelf OIDC: issuer=https://auth.${domain}, client_id=audiobookshelf, client_secret=${secret} — paste into ABS Settings → Authentication → OIDC.`);
+    }
+  }
+
+  if (isSelected('vaultwarden')) {
+    const secret = opts.variables.find(v => v.name === 'VAULTWARDEN_SSO_SECRET')?.value;
+    const enabled = opts.variables.find(v => v.name === 'VAULTWARDEN_SSO_ENABLED')?.value;
+    if (secret) {
+      const status = enabled === 'true' ? 'SSO is ENABLED via env (test login then keep)' : 'SSO is OFF — flip VAULTWARDEN_SSO_ENABLED=true to enable';
+      opts.onLog(`🔐 Vaultwarden OIDC: client_secret=${secret} (${status}).`);
+    }
+  }
+}
+
 function logNavidromeCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
   const user = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_USER')?.value || 'admin';
   const password = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_PASSWORD')?.value;
@@ -416,6 +441,9 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   if (isSelected('file-share')) {
     logFileShareCredentials({ variables, onLog });
   }
+  // Surface OIDC client secrets (one log line per service that needs UI
+  // configuration or has an env-flag to flip).
+  logOidcClientSecrets({ selected, variables, onLog });
   if (isSelected('nginx-web')) {
     await persistNpmCredentials({ variables, onLog });
   }

--- a/templates/audiobookshelf/variables.json
+++ b/templates/audiobookshelf/variables.json
@@ -28,6 +28,10 @@
     "description": "Host path where Audiobookshelf will download podcast episodes.",
     "default": "/mnt/data/stacks/file-share/data/Podcasts"
   },
+  "ABS_OIDC_SECRET": {
+    "type": "secret",
+    "description": "OIDC client secret for Audiobookshelf ↔ Authelia. Auto-generated; surfaced in the install log so you can paste it into ABS Settings → Authentication → OIDC."
+  },
   "ABS_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Audiobookshelf",
@@ -43,7 +47,8 @@
       "client_name": "Audiobookshelf",
       "authorization_policy": "one_factor",
       "redirect_uris": ["/auth/openid/callback", "/auth/openid/mobile-redirect"],
-      "scopes": ["openid", "profile", "email", "groups"]
+      "scopes": ["openid", "profile", "email", "groups"],
+      "clientSecretVar": "ABS_OIDC_SECRET"
     }
   }
 }

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -13,6 +13,19 @@ spec:
       value: "{{VAULTWARDEN_DOMAIN}}"
     - name: SIGNUPS_ALLOWED
       value: "{{VAULTWARDEN_SIGNUPS}}"
+    # Authelia SSO — disabled by default (set VAULTWARDEN_SSO_ENABLED=true).
+    # When enabled, the wizard has already registered the matching OIDC
+    # client with Authelia using the same VAULTWARDEN_SSO_SECRET below.
+    - name: SSO_ENABLED
+      value: "{{VAULTWARDEN_SSO_ENABLED}}"
+    - name: SSO_AUTHORITY
+      value: "https://auth.{{PUBLIC_DOMAIN}}"
+    - name: SSO_CLIENT_ID
+      value: "vaultwarden"
+    - name: SSO_CLIENT_SECRET
+      value: "{{VAULTWARDEN_SSO_SECRET}}"
+    - name: SSO_SCOPES
+      value: "email profile"
     ports:
     - containerPort: 80
       hostPort: {{VAULTWARDEN_PORT}}

--- a/templates/vaultwarden/variables.json
+++ b/templates/vaultwarden/variables.json
@@ -15,6 +15,21 @@
     "options": ["true", "false"],
     "default": "true"
   },
+  "VAULTWARDEN_SSO_ENABLED": {
+    "type": "select",
+    "description": "Enable Vaultwarden ↔ Authelia SSO. Off by default — Vaultwarden's SSO is still experimental upstream. Flip to true once you've tested local login.",
+    "options": ["true", "false"],
+    "default": "false"
+  },
+  "VAULTWARDEN_SSO_SECRET": {
+    "type": "secret",
+    "description": "OIDC client secret for Vaultwarden ↔ Authelia. Auto-generated; the wizard wires it into both the SSO_CLIENT_SECRET env and Authelia's clients[] entry."
+  },
+  "PUBLIC_DOMAIN": {
+    "type": "text",
+    "description": "Public domain (used to build the SSO authority URL https://auth.<domain>)",
+    "default": "dopp.cloud"
+  },
   "VAULTWARDEN_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Vaultwarden",
@@ -30,8 +45,9 @@
       "client_id": "vaultwarden",
       "client_name": "Vaultwarden",
       "authorization_policy": "one_factor",
-      "redirect_uris": ["/identity/connect/authorize"],
-      "scopes": ["openid", "profile", "email", "groups"]
+      "redirect_uris": ["/identity/connect/oidc-signin"],
+      "scopes": ["openid", "profile", "email", "groups"],
+      "clientSecretVar": "VAULTWARDEN_SSO_SECRET"
     }
   }
 }


### PR DESCRIPTION
## Summary

User feedback: stop asking for the public domain on every install, and auto-wire as many services to Authelia/LLDAP as possible.

- **install-fedora-coreos.sh** — new \`PUBLIC_DOMAIN\` prompt, written to config.json as \`reverseProxy.publicDomain\` if supplied.
- **OnboardingWizard** — reads \`settings.reverseProxy.publicDomain\` and seeds \`stackDomain\` from it on stack-step entry. Empty stays manual.
- **oidcClient + oidc-clients route** — new optional \`clientSecretVar\` on the declaration. When set, the same auto-gen'd secret ends up in both the service's env and Authelia's clients[] — no post-deploy copy-paste needed.
- **vaultwarden** — \`SSO_*\` env vars wired (SSO_ENABLED default \`false\` since upstream still calls it experimental). New \`VAULTWARDEN_SSO_SECRET\` auto-gen'd and pinned to the OIDC client.
- **audiobookshelf** — same \`clientSecretVar\` pinning. ABS has no env-var OAuth config so the install log surfaces the secret + issuer URL for the user to paste into ABS Settings.
- **postInstall.ts** — new \`logOidcClientSecrets\` step alongside the other credential surfacing.

Skipped: Immich OAuth (DB-driven, no env support — would need /admin/system-settings API call, separate PR).

## Test plan

- [x] \`npx vitest run\` — 261 pass / 1 skipped
- [x] \`npx tsc --noEmit\` clean
- [ ] Fresh install: USB build prompts for domain, value lands in config.json, wizard skips the manual prompt
- [ ] Install Vaultwarden + Authelia together → \`grep client_secret\` in Authelia's configuration.yml matches \`SSO_CLIENT_SECRET\` env in vaultwarden's \`podman inspect\`
- [ ] Same for Audiobookshelf — install log shows the secret, paste into ABS Settings, OIDC login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)