### PR TITLE
feat(wizard): end-of-install credentials summary + Bitwarden CSV export

### DIFF
--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Template, VariableMeta } from '@/lib/registry';
 import { runPostInstall } from '@/lib/stackInstall/postInstall';
 import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
+import { buildCredentialsManifest, buildBitwardenCsv } from '@/lib/stackInstall/credentialsManifest';
 import { fetchTemplateYaml, fetchTemplateVariables, fetchTemplateConfigFiles } from '@/app/actions';
 import { getNodes } from '@/app/actions/system';
 import { PodmanConnection } from '@/lib/nodes';
@@ -699,14 +700,55 @@ WantedBy=default.target`;
                             )}
                         </div>
 
-                        {step === 'done' && variables.some(v => v.meta?.type === 'subdomain' && v.value) && (() => {
+                        {step === 'done' && (() => {
                             const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
                             const subdomains = variables.filter(v => v.meta?.type === 'subdomain' && v.value);
-                            if (!domain || subdomains.length === 0) return null;
+                            const hasProxyRoutes = !!domain && subdomains.length > 0;
+                            const selected = items.filter(i => i.checked);
+                            const host = typeof window !== 'undefined' ? window.location.hostname : '<server-ip>';
+                            const manifest = buildCredentialsManifest({ selected, variables, host });
+                            if (!hasProxyRoutes && manifest.length === 0) return null;
+                            const downloadCsv = () => {
+                                const blob = new Blob([buildBitwardenCsv(manifest)], { type: 'text/csv' });
+                                const a = document.createElement('a');
+                                a.href = URL.createObjectURL(blob);
+                                a.download = `servicebay-credentials-${new Date().toISOString().slice(0, 10)}.csv`;
+                                a.click();
+                                URL.revokeObjectURL(a.href);
+                            };
                             return (
                                 <div className="space-y-3">
                                     <p className="text-sm font-bold text-gray-700 dark:text-gray-300">Next steps</p>
 
+                                    {manifest.length > 0 && (
+                                        <div className="p-3 bg-rose-50 dark:bg-rose-900/20 rounded border border-rose-200 dark:border-rose-800 text-sm">
+                                            <div className="flex items-center justify-between mb-2">
+                                                <p className="font-medium text-rose-800 dark:text-rose-200">🔑 Credentials — save now</p>
+                                                <button
+                                                    type="button"
+                                                    onClick={downloadCsv}
+                                                    className="text-xs px-2 py-1 bg-rose-600 hover:bg-rose-700 text-white rounded"
+                                                    title="Download as Bitwarden / Vaultwarden CSV"
+                                                >
+                                                    ⬇ Download CSV
+                                                </button>
+                                            </div>
+                                            <p className="text-xs text-rose-700 dark:text-rose-300 mb-2">
+                                                Won&apos;t be shown again. Copy now, or use the CSV: Vaultwarden → Tools → Import → Bitwarden (csv).
+                                            </p>
+                                            <div className="space-y-1.5 font-mono text-xs">
+                                                {manifest.filter(c => c.importance === 'critical').map(c => (
+                                                    <div key={c.service} className="border-l-2 border-rose-300 dark:border-rose-700 pl-2">
+                                                        <div className="font-sans font-medium text-rose-900 dark:text-rose-100">{c.service}</div>
+                                                        <div className="text-rose-700 dark:text-rose-300 break-all">{c.url}</div>
+                                                        <div className="text-rose-600 dark:text-rose-400">{c.username} / {c.password}</div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {hasProxyRoutes && (
                                     <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-800 text-sm space-y-2">
                                         <p className="font-medium text-blue-800 dark:text-blue-200">1. Configure DNS</p>
                                         <p className="text-blue-700 dark:text-blue-300">
@@ -718,20 +760,25 @@ WantedBy=default.target`;
                                             ))}
                                         </div>
                                     </div>
+                                    )}
 
+                                    {hasProxyRoutes && (
                                     <div className="p-3 bg-amber-50 dark:bg-amber-900/20 rounded border border-amber-200 dark:border-amber-800 text-sm space-y-2">
                                         <p className="font-medium text-amber-800 dark:text-amber-200">2. SSL Certificates</p>
                                         <p className="text-amber-700 dark:text-amber-300">
                                             Open Nginx Proxy Manager and add Let&apos;s Encrypt SSL certificates for each proxy host.
                                         </p>
                                     </div>
+                                    )}
 
+                                    {hasProxyRoutes && (
                                     <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 text-sm space-y-2">
                                         <p className="font-medium text-gray-800 dark:text-gray-200">3. Access Restrictions (optional)</p>
                                         <p className="text-gray-600 dark:text-gray-400">
                                             Add IP-based access lists in NPM for admin-only services (Nginx Admin, AdGuard).
                                         </p>
                                     </div>
+                                    )}
                                 </div>
                             );
                         })()}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -21,6 +21,7 @@ import {
   configureProxyRoutes as sharedConfigureProxyRoutes,
 } from '@/lib/stackInstall/postInstall';
 import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
+import { buildCredentialsManifest, buildBitwardenCsv } from '@/lib/stackInstall/credentialsManifest';
 import Mustache from 'mustache';
 
 import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive } from 'lucide-react';
@@ -1319,9 +1320,60 @@ export default function OnboardingWizard() {
                                 const domain = stackVariables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
                                 const subdomains = stackVariables.filter(v => v.meta?.type === 'subdomain' && v.value);
                                 const hasProxyRoutes = domain && subdomains.length > 0;
+                                const selected = stackItems.filter(i => i.checked && !i.alreadyInstalled);
+                                const host = typeof window !== 'undefined' ? window.location.hostname : '<server-ip>';
+                                const manifest = buildCredentialsManifest({ selected, variables: stackVariables, host });
+                                const downloadCsv = () => {
+                                    const blob = new Blob([buildBitwardenCsv(manifest)], { type: 'text/csv' });
+                                    const a = document.createElement('a');
+                                    a.href = URL.createObjectURL(blob);
+                                    a.download = `servicebay-credentials-${new Date().toISOString().slice(0, 10)}.csv`;
+                                    a.click();
+                                    URL.revokeObjectURL(a.href);
+                                };
                                 return (
-                                    <div className="mt-3 space-y-2 max-h-48 overflow-y-auto">
-                                        {hasProxyRoutes ? (
+                                    <div className="mt-3 space-y-3 max-h-[60vh] overflow-y-auto">
+                                        {manifest.length > 0 && (
+                                            <div className="p-3 bg-rose-50 dark:bg-rose-900/20 rounded border border-rose-200 dark:border-rose-800 text-sm">
+                                                <div className="flex items-center justify-between mb-2">
+                                                    <p className="font-medium text-rose-800 dark:text-rose-200">🔑 Credentials — save now</p>
+                                                    <button
+                                                        type="button"
+                                                        onClick={downloadCsv}
+                                                        className="text-xs px-2 py-1 bg-rose-600 hover:bg-rose-700 text-white rounded"
+                                                        title="Download as Bitwarden / Vaultwarden CSV"
+                                                    >
+                                                        ⬇ Download CSV
+                                                    </button>
+                                                </div>
+                                                <p className="text-xs text-rose-700 dark:text-rose-300 mb-2">
+                                                    Won&apos;t be shown again. Either copy them into your password manager now or use the CSV button: Vaultwarden → Tools → Import → Bitwarden (csv).
+                                                </p>
+                                                <div className="space-y-1.5 font-mono text-xs">
+                                                    {manifest.filter(c => c.importance === 'critical').map(c => (
+                                                        <div key={c.service} className="border-l-2 border-rose-300 dark:border-rose-700 pl-2">
+                                                            <div className="font-sans font-medium text-rose-900 dark:text-rose-100">{c.service}</div>
+                                                            <div className="text-rose-700 dark:text-rose-300 break-all">{c.url}</div>
+                                                            <div className="text-rose-600 dark:text-rose-400">{c.username} / {c.password}</div>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                                {manifest.some(c => c.importance === 'system') && (
+                                                    <details className="mt-2 text-xs">
+                                                        <summary className="cursor-pointer text-rose-700 dark:text-rose-300">System / DR secrets ({manifest.filter(c => c.importance === 'system').length})</summary>
+                                                        <div className="mt-1 space-y-1 font-mono">
+                                                            {manifest.filter(c => c.importance === 'system').map(c => (
+                                                                <div key={c.service} className="text-rose-600 dark:text-rose-400 pl-2">
+                                                                    <span className="font-sans">{c.service}:</span> {c.password}
+                                                                </div>
+                                                            ))}
+                                                        </div>
+                                                    </details>
+                                                )}
+                                            </div>
+                                        )}
+
+                                        {hasProxyRoutes && (
                                             <>
                                                 <div className="p-2.5 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-800 text-sm space-y-1.5">
                                                     <p className="font-medium text-blue-800 dark:text-blue-200">1. Configure DNS</p>
@@ -1349,7 +1401,9 @@ export default function OnboardingWizard() {
                                                     </p>
                                                 </div>
                                             </>
-                                        ) : (
+                                        )}
+
+                                        {!hasProxyRoutes && manifest.length === 0 && (
                                             <p className="text-sm text-green-600 dark:text-green-400 font-medium">
                                                 Stack installation complete.
                                             </p>

--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -1,0 +1,253 @@
+/**
+ * Manifest of every credential the install wizard auto-generates.
+ *
+ * Used for:
+ *  - the end-of-install summary banner in the live install log
+ *  - the credentials table on the Done step
+ *  - the Bitwarden-CSV export so users can bulk-import into Vaultwarden
+ *
+ * The list is built from the wizard's own variables array, so secrets the
+ * user override-typed survive into the export.
+ */
+
+import type { StackVariable } from './postInstall';
+
+export interface Credential {
+  /** User-facing service name, e.g. "LLDAP" or "Audiobookshelf". */
+  service: string;
+  /** Reachable URL or URI hint. Use `<server-ip>` placeholder when host unknown. */
+  url: string;
+  username: string;
+  password: string;
+  /**
+   * "critical" — user MUST log in here at some point (admin panels).
+   * "system"   — internal secret the user normally never touches but might
+   *              need for disaster recovery / external SSO config / etc.
+   */
+  importance: 'critical' | 'system';
+  /** One-liner shown next to the entry. */
+  notes?: string;
+}
+
+interface BuildOpts {
+  selected: { name: string }[];
+  variables: StackVariable[];
+  /** Hostname or IP the user is browsing ServiceBay through. Used to build
+   *  reachable URLs in the manifest. Empty string falls back to the
+   *  `<server-ip>` placeholder. */
+  host?: string;
+}
+
+const get = (vars: StackVariable[], name: string): string | undefined =>
+  vars.find(v => v.name === name)?.value;
+
+export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
+  const { variables: v } = opts;
+  const isSelected = (n: string) => opts.selected.some(i => i.name === n);
+  const host = opts.host || '<server-ip>';
+  const out: Credential[] = [];
+
+  if (isSelected('lldap')) {
+    const port = get(v, 'LLDAP_PORT') || '17170';
+    const password = get(v, 'LLDAP_ADMIN_PASSWORD');
+    if (password) {
+      out.push({
+        service: 'LLDAP (User Directory)',
+        url: `http://${host}:${port}`,
+        username: 'admin',
+        password,
+        importance: 'critical',
+        notes: 'Manage users + groups here. Required to add family members.',
+      });
+    }
+  }
+
+  if (isSelected('nginx-web')) {
+    const adminPort = get(v, 'NGINX_ADMIN_PORT') || '81';
+    const email = get(v, 'NGINX_ADMIN_EMAIL') || 'admin@servicebay.local';
+    const password = get(v, 'NGINX_ADMIN_PASSWORD');
+    if (password) {
+      out.push({
+        service: 'Nginx Proxy Manager',
+        url: `http://${host}:${adminPort}`,
+        username: email,
+        password,
+        importance: 'critical',
+        notes: 'Reverse-proxy admin. Needed for SSL cert renewal + access lists.',
+      });
+    }
+  }
+
+  if (isSelected('adguard')) {
+    const port = get(v, 'ADGUARD_ADMIN_PORT') || '8083';
+    const username = get(v, 'ADGUARD_ADMIN_USER') || 'admin';
+    const password = get(v, 'ADGUARD_ADMIN_PASSWORD');
+    if (password) {
+      out.push({
+        service: 'AdGuard Home',
+        url: `http://${host}:${port}`,
+        username,
+        password,
+        importance: 'critical',
+        notes: 'DNS console. Add custom rewrites + manage blocklists.',
+      });
+    }
+  }
+
+  if (isSelected('audiobookshelf')) {
+    const port = get(v, 'ABS_PORT') || '13378';
+    const username = get(v, 'ABS_ADMIN_USER') || 'root';
+    const password = get(v, 'ABS_ADMIN_PASSWORD');
+    if (password) {
+      out.push({
+        service: 'Audiobookshelf',
+        url: `http://${host}:${port}`,
+        username,
+        password,
+        importance: 'critical',
+        notes: 'Library manager. Mobile apps use this credential too.',
+      });
+    }
+  }
+
+  if (isSelected('navidrome')) {
+    const port = get(v, 'NAVIDROME_PORT') || '4533';
+    const username = get(v, 'NAVIDROME_ADMIN_USER') || 'admin';
+    const password = get(v, 'NAVIDROME_ADMIN_PASSWORD');
+    if (password) {
+      out.push({
+        service: 'Navidrome',
+        url: `http://${host}:${port}`,
+        username,
+        password,
+        importance: 'critical',
+        notes: 'Music server. Symfonium / Subsonic clients use this too.',
+      });
+    }
+  }
+
+  if (isSelected('file-share')) {
+    const username = get(v, 'SHARE_USER') || 'samba';
+    const password = get(v, 'SHARE_PASSWORD');
+    if (password) {
+      out.push({
+        service: 'Samba (file-share)',
+        url: `\\\\${host}\\data`,
+        username,
+        password,
+        importance: 'critical',
+        notes: 'Windows network drive. Type once per PC when mounting.',
+      });
+    }
+  }
+
+  // ─── system-internal secrets (rarely needed, kept for DR) ────────────
+
+  if (isSelected('audiobookshelf')) {
+    const secret = get(v, 'ABS_OIDC_SECRET');
+    const domain = get(v, 'PUBLIC_DOMAIN');
+    if (secret) {
+      out.push({
+        service: 'Audiobookshelf OIDC client_secret',
+        url: domain ? `https://auth.${domain}` : 'auth.<domain>',
+        username: 'audiobookshelf',
+        password: secret,
+        importance: 'system',
+        notes: 'Paste into ABS Settings → Authentication → OIDC client_secret to enable SSO.',
+      });
+    }
+  }
+
+  if (isSelected('vaultwarden')) {
+    const secret = get(v, 'VAULTWARDEN_SSO_SECRET');
+    const enabled = get(v, 'VAULTWARDEN_SSO_ENABLED') === 'true';
+    if (secret) {
+      out.push({
+        service: 'Vaultwarden OIDC client_secret',
+        url: 'env: SSO_CLIENT_SECRET',
+        username: 'vaultwarden',
+        password: secret,
+        importance: 'system',
+        notes: enabled
+          ? 'SSO is enabled. Already wired into the container env — no manual paste needed.'
+          : 'SSO is OFF. To enable: flip VAULTWARDEN_SSO_ENABLED=true and redeploy.',
+      });
+    }
+  }
+
+  if (isSelected('lldap')) {
+    const seed = get(v, 'LLDAP_JWT_SECRET');
+    if (seed) {
+      out.push({
+        service: 'LLDAP JWT secret',
+        url: 'env: LLDAP_JWT_SECRET',
+        username: '—',
+        password: seed,
+        importance: 'system',
+        notes: 'Signs LLDAP user sessions. Save for disaster recovery — without it old browser cookies become invalid after a restore.',
+      });
+    }
+  }
+
+  return out;
+}
+
+/** Format a manifest as a banner-style block for the install log. */
+export function formatCredentialsBanner(manifest: Credential[]): string[] {
+  if (manifest.length === 0) return [];
+  const critical = manifest.filter(c => c.importance === 'critical');
+  const system = manifest.filter(c => c.importance === 'system');
+  const lines: string[] = [
+    '',
+    '═══════════════════════════════════════════════════',
+    '🔑 SAVE THESE NOW — they are not shown again',
+    '═══════════════════════════════════════════════════',
+  ];
+  for (const c of critical) {
+    lines.push(`  ${c.service}`);
+    lines.push(`    URL:      ${c.url}`);
+    lines.push(`    User:     ${c.username}`);
+    lines.push(`    Password: ${c.password}`);
+    if (c.notes) lines.push(`    ↳ ${c.notes}`);
+    lines.push('');
+  }
+  if (system.length) {
+    lines.push('───── system / disaster-recovery (rarely needed) ─────');
+    for (const c of system) {
+      lines.push(`  ${c.service}: ${c.password}`);
+      if (c.notes) lines.push(`    ↳ ${c.notes}`);
+    }
+    lines.push('');
+  }
+  lines.push('💡 You can also download a Bitwarden-compatible CSV from the Done step.');
+  lines.push('═══════════════════════════════════════════════════');
+  return lines;
+}
+
+/** Build a Bitwarden-import-ready CSV. Bitwarden's importer is forgiving on
+ *  column order; we use the canonical set documented at
+ *  https://bitwarden.com/help/condition-bitwarden-import/. */
+export function buildBitwardenCsv(manifest: Credential[]): string {
+  const escape = (s: string) => `"${(s ?? '').replace(/"/g, '""')}"`;
+  const header = [
+    'folder', 'favorite', 'type', 'name', 'notes',
+    'fields', 'reprompt',
+    'login_uri', 'login_username', 'login_password', 'login_totp',
+  ].join(',');
+
+  const rows = manifest.map(c => [
+    escape('ServiceBay Home'),
+    '',
+    escape('login'),
+    escape(c.service),
+    escape(`${c.notes || ''}${c.importance === 'system' ? '\n[system / DR — usually not needed for daily use]' : ''}`.trim()),
+    '',
+    '',
+    escape(c.url),
+    escape(c.username),
+    escape(c.password),
+    '',
+  ].join(','));
+
+  return [header, ...rows].join('\n') + '\n';
+}

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -12,6 +12,7 @@
  */
 
 import type { VariableMeta } from '@/lib/registry';
+import { buildCredentialsManifest, formatCredentialsBanner } from './credentialsManifest';
 
 /** Variable shape shared between wizard and modal. */
 export interface StackVariable {
@@ -461,5 +462,14 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
     void seedNavidrome({ variables, onLog }).catch(() => { /* logged inline */ });
   }
 
-  return configureProxyRoutes({ variables, node, onLog });
+  const proxyResult = await configureProxyRoutes({ variables, node, onLog });
+
+  // Final banner — single block where every credential the user might
+  // have to remember is collected. Same data is exposed to the wizard's
+  // Done view + a Bitwarden CSV download via buildCredentialsManifest().
+  const host = typeof window !== 'undefined' ? window.location.hostname : '';
+  const manifest = buildCredentialsManifest({ selected, variables, host });
+  formatCredentialsBanner(manifest).forEach(onLog);
+
+  return proxyResult;
 }


### PR DESCRIPTION
## Summary

User feedback: the install scatters auto-gen credentials across many log lines (LLDAP admin, NPM admin, AdGuard, Audiobookshelf, Navidrome, Samba, Vaultwarden SSO, ABS OIDC, …). Easy to lose, easy to mistype.

This adds:

1. **\`src/lib/stackInstall/credentialsManifest.ts\`** — single source of truth for "what credentials did the wizard mint?". Returns a typed \`Credential[]\` with importance ranking: \`critical\` (user MUST log in here) vs \`system\` (DR-only — JWT keys, OIDC client secrets the env already consumes).
2. **End-of-install banner** in the live log — \`formatCredentialsBanner()\` collapses the scattered lines into one block at the bottom of the install panel.
3. **Done-step credentials panel** — rendered in both OnboardingWizard and InstallerModal. Critical creds shown plain; system / DR secrets tucked under a \`<details>\`.
4. **⬇ Download CSV** — \`buildBitwardenCsv()\` emits a Bitwarden-compatible CSV (\`folder, favorite, type, name, notes, fields, reprompt, login_uri, login_username, login_password, login_totp\`). Click → browser downloads → user goes to Vaultwarden → Tools → Import → Bitwarden (csv) → done.

Not pushing directly to Vaultwarden's API: that would need the user's master password and the user's first-time Vaultwarden registration hasn't happened yet at install time. CSV-via-import keeps the user in control and works with any Bitwarden-compatible vault.

## Test plan

- [x] \`npx vitest run\` — 261 pass / 1 skipped
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: full-stack install → see banner block at end of log → Done step shows credentials → click Download CSV → import into Vaultwarden after registering, verify all entries land in the \"ServiceBay Home\" folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)