### PR TITLE
fix(security): close C1 + C3 + H6 from the post-2.5 audit

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -890,11 +890,19 @@ prompt_secret() {
     echo
     read -r -s -p "Confirm: " value_confirm || true
     echo
-    if [[ "$value" == "$value_confirm" && -n "$value" ]]; then
-      printf -v "$var_name" '%s' "$value"
-      return
+    if [[ "$value" != "$value_confirm" || -z "$value" ]]; then
+      echo "Passwords do not match or are empty. Try again." >&2
+      continue
     fi
-    echo "Passwords do not match or are empty. Try again." >&2
+    # Reject characters that survive envsubst into the Butane template +
+    # the manually-quoted JSON build. \n breaks systemd Environment= lines
+    # (and YAML); " and \ break JSON; ${ would re-trigger envsubst.
+    if [[ "$value" == *$'\n'* || "$value" == *'"'* || "$value" == *'\'* || "$value" == *'$'* || "$value" == *'`'* ]]; then
+      echo "Password contains characters that break the install pipeline (newline, quote, backslash, \$ or backtick). Pick a different one." >&2
+      continue
+    fi
+    printf -v "$var_name" '%s' "$value"
+    return
   done
 }
 
@@ -1213,19 +1221,27 @@ save_settings
 
 PASSWORD_HASH="$(printf '%s' "$HOST_PASSWORD" | openssl passwd -6 -stdin)"
 
+# Properly escape arbitrary strings as JSON literals — prevents user-supplied
+# values (passwords, hostnames, email addresses) from breaking the JSON or
+# injecting attacker-chosen keys into config.json. Python3 is a hard dep on
+# Fedora CoreOS targets and we already require it on the build host elsewhere.
+json_str() {
+  python3 -c 'import json,sys;print(json.dumps(sys.argv[1]))' "$1"
+}
+
 # Build ServiceBay config.json (with optional sections)
 SERVICEBAY_CONFIG='{
-  "serverName": "'"$SERVER_NAME"'",
+  "serverName": '"$(json_str "$SERVER_NAME")"',
   "auth": {
-    "username": "'"$SERVICEBAY_ADMIN_USER"'"
+    "username": '"$(json_str "$SERVICEBAY_ADMIN_USER")"'
   },
   "autoUpdate": {
     "enabled": true,
     "schedule": "0 0 * * *",
-    "channel": "'"$SERVICEBAY_CHANNEL"'"
+    "channel": '"$(json_str "$SERVICEBAY_CHANNEL")"'
   },
   "templateSettings": {
-    "DATA_DIR": "'"$DATA_ROOT/stacks"'"
+    "DATA_DIR": '"$(json_str "$DATA_ROOT/stacks")"'
   }'
 
 # Add reverseProxy.publicDomain if user supplied one — wizard reads this
@@ -1233,7 +1249,7 @@ SERVICEBAY_CONFIG='{
 if [[ -n "$PUBLIC_DOMAIN" ]]; then
   SERVICEBAY_CONFIG+=',
   "reverseProxy": {
-    "publicDomain": "'"$PUBLIC_DOMAIN"'"
+    "publicDomain": '"$(json_str "$PUBLIC_DOMAIN")"'
   }'
 fi
 
@@ -1242,9 +1258,9 @@ if [[ -n "$GW_USER" ]]; then
   SERVICEBAY_CONFIG+=',
   "gateway": {
     "type": "fritzbox",
-    "host": "'"$GW_HOST"'",
-    "username": "'"$GW_USER"'",
-    "password": "'"$GW_PASS"'"
+    "host": '"$(json_str "$GW_HOST")"',
+    "username": '"$(json_str "$GW_USER")"',
+    "password": '"$(json_str "$GW_PASS")"'
   }'
 fi
 
@@ -1264,21 +1280,22 @@ fi
 
 # Add email notifications config if enabled
 if [[ "${ENABLE_EMAIL^^}" =~ ^Y ]]; then
-  # Convert comma-separated recipients to JSON array
-  EMAIL_TO_JSON="$(echo "$EMAIL_RECIPIENTS" | sed 's/[[:space:]]*,[[:space:]]*/","/g; s/^/"/; s/$/"/')"
+  # Build JSON array of recipients via python — sed-based escaping was
+  # broken on addresses containing quotes.
+  EMAIL_TO_JSON="$(python3 -c 'import json,sys; print(json.dumps([s.strip() for s in sys.argv[1].split(",") if s.strip()]))' "$EMAIL_RECIPIENTS")"
   EMAIL_SECURE_BOOL="false"
   [[ "${EMAIL_SECURE^^}" =~ ^Y ]] && EMAIL_SECURE_BOOL="true"
   SERVICEBAY_CONFIG+=',
   "notifications": {
     "email": {
       "enabled": true,
-      "host": "'"$EMAIL_HOST"'",
+      "host": '"$(json_str "$EMAIL_HOST")"',
       "port": '"$EMAIL_PORT"',
       "secure": '"$EMAIL_SECURE_BOOL"',
-      "user": "'"$EMAIL_USER"'",
-      "pass": "'"$EMAIL_PASS"'",
-      "from": "'"$EMAIL_FROM"'",
-      "to": ['"$EMAIL_TO_JSON"']
+      "user": '"$(json_str "$EMAIL_USER")"',
+      "pass": '"$(json_str "$EMAIL_PASS")"',
+      "from": '"$(json_str "$EMAIL_FROM")"',
+      "to": '"$EMAIL_TO_JSON"'
     }
   }'
 fi

--- a/src/app/api/system/authelia/oidc-clients/route.ts
+++ b/src/app/api/system/authelia/oidc-clients/route.ts
@@ -2,8 +2,36 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getTemplateVariables } from '@/lib/registry';
+import { requireSession } from '@/lib/api/requireSession';
 import crypto from 'crypto';
 import yaml from 'js-yaml';
+
+/** Restrict redirect_uris so a malicious template (or a future bug) can't
+ *  register a callback to attacker.com. Allows:
+ *   - relative paths (rewritten under the service's own subdomain)
+ *   - custom URI schemes (mobile deep-links like `app.immich:/`)
+ *   - http(s) URIs whose host is the configured publicDomain or one of
+ *     its subdomains
+ *  Returns the URI if accepted, or null if it should be dropped. */
+function safeRedirectUri(uri: string, fqdn: string, publicDomain: string): string | null {
+  // Relative path → always rewritten under the service's own subdomain.
+  if (!uri.startsWith('http') && !uri.includes(':/')) {
+    return `https://${fqdn}${uri}`;
+  }
+  try {
+    const u = new URL(uri);
+    // Mobile / native-app deep links use custom schemes (e.g. `app.immich:/auth`).
+    // These don't carry a host the IDP can spoof, so let them through.
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return uri;
+    const host = u.hostname.toLowerCase();
+    const root = publicDomain.toLowerCase();
+    // Allow exact root or any subdomain of the configured public domain.
+    if (host === root || host.endsWith(`.${root}`)) return uri;
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function generateSecret(length = 32): string {
   const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -25,6 +53,9 @@ interface OidcClientsRequest {
  */
 export async function POST(request: NextRequest) {
   try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
     const body: OidcClientsRequest = await request.json();
     if (!body.templates?.length || !body.variables) {
       return NextResponse.json({ error: 'templates and variables required' }, { status: 400 });
@@ -50,9 +81,10 @@ export async function POST(request: NextRequest) {
         if (!subdomain) continue;
 
         const fqdn = `${subdomain}.${domain}`;
-        const redirectUris = oidc.redirect_uris.map(uri =>
-          uri.startsWith('http') || uri.includes(':/') ? uri : `https://${fqdn}${uri}`
-        );
+        const redirectUris = oidc.redirect_uris
+          .map(uri => safeRedirectUri(uri, fqdn, domain))
+          .filter((uri): uri is string => uri !== null);
+        if (redirectUris.length === 0) continue; // skip rather than register an empty client
 
         // If the template references an env-var-pinned secret (`clientSecretVar`),
         // use the wizard-provided value so the SAME secret is in both the

--- a/src/app/api/system/stacks/reset/route.ts
+++ b/src/app/api/system/stacks/reset/route.ts
@@ -4,6 +4,7 @@ import { agentManager } from '@/lib/agent/manager';
 import { getConfig } from '@/lib/config';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { logger } from '@/lib/logger';
+import { requireSession } from '@/lib/api/requireSession';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,6 +28,9 @@ const PROTECTED = new Set(['servicebay']);
  */
 export async function POST(request: NextRequest) {
   try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
     const body = await request.json();
     const { confirm, node: requestedNode } = body as {
       confirm?: string;

--- a/src/lib/api/requireSession.ts
+++ b/src/lib/api/requireSession.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getSessionFromCookieHeader, type SessionPayload } from '@/lib/auth/session';
+
+/**
+ * Gate an API route on a valid ServiceBay session cookie.
+ *
+ * Returns the decoded session on success, or a `NextResponse` 401 that the
+ * caller should return as-is. Pattern at the top of any sensitive handler:
+ *
+ *     const auth = await requireSession(request);
+ *     if (auth instanceof NextResponse) return auth;
+ *     // …auth is the session payload from here on…
+ *
+ * This is intentionally a per-handler helper rather than a global
+ * middleware: the broader hardening plan (PR1) layers a `middleware.ts`
+ * gate on top of this. Until that lands, the helper at least closes the
+ * destructive routes one by one.
+ */
+export async function requireSession(
+  request: Request,
+): Promise<SessionPayload | NextResponse> {
+  const session = await getSessionFromCookieHeader(request.headers.get('cookie') ?? undefined);
+  if (!session) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+  return session;
+}

--- a/tests/backend/oidc_clients.test.ts
+++ b/tests/backend/oidc_clients.test.ts
@@ -47,6 +47,12 @@ vi.mock('@/lib/registry', () => ({
   }),
 }));
 
+// Bypass the session gate: every request in these tests is treated as
+// authenticated. Auth itself is covered by the auth middleware tests.
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: vi.fn(async () => ({ user: 'admin', expires: new Date(Date.now() + 86400_000) })),
+}));
+
 import { POST } from '../../src/app/api/system/authelia/oidc-clients/route';
 
 // Minimal Authelia pod YAML with a config volume


### PR DESCRIPTION
## Summary

Three concrete vulnerabilities surfaced by the post-2.5 audit, all closed here. The broader hardening plan (global middleware.ts gate) will supersede these per-handler checks once it lands; the \`requireSession\` shim deliberately matches that plan's API shape so the eventual migration is one line per route.

### C1 — unauthenticated full-system wipe

\`POST /api/system/stacks/reset\` deleted every Quadlet definition + \`rm -rf <DATA_DIR>/*\` without any auth check. **Repro:** \`curl -X POST .../api/system/stacks/reset -d '{"confirm":"RESET"}'\` from any host that could reach ServiceBay.
**Fix:** new \`requireSession()\` helper at \`src/lib/api/requireSession.ts\` gates the route on a valid session cookie before any other work.

### C3 — JSON / envsubst injection in install-fedora-coreos.sh

User-typed passwords (admin, gateway, SMTP) and hostnames flowed unescaped into the \`SERVICEBAY_CONFIG\` JSON literal AND through \`envsubst\` into the Butane template. A \`"\` broke JSON; a \`\\n\` injected systemd \`Environment=\` directives into the rendered Quadlet.
**Fixes:**
- \`prompt_secret()\` rejects \`\\n\`, \`"\`, \`\\\`, \`$\`, \`\\\`\` early with a retry message.
- \`SERVICEBAY_CONFIG\` values pass through a \`json_str()\` helper that runs \`python3 json.dumps()\`. Same applies to the \`EMAIL_RECIPIENTS\` sed-array which also didn't escape quotes.

### H6 — OIDC redirect_uri whitelist + auth

\`POST /api/system/authelia/oidc-clients\` was unauth and accepted any \`redirect_uri\` starting with \`http\` — auth-code-flow takeover via attacker-host callback.
**Fixes:**
- Same \`requireSession\` gate.
- New \`safeRedirectUri()\` restricts http(s) URIs to the configured \`publicDomain\` or its subdomains. Custom-scheme deep-links (\`app.immich:/auth\`) still allowed since they have no spoofable host.

## Test plan

- [x] \`npx vitest run\` — 261 / 1 skipped
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: \`curl -X POST .../api/system/stacks/reset -d '{"confirm":"RESET"}'\` returns 401 without cookie
- [ ] Manual: same for \`/api/system/authelia/oidc-clients\`
- [ ] Manual: install-script with password \`a"x\` shows the retry message instead of corrupting config.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)