### PR TITLE
feat(templates): add filebrowser + radicale (CalDAV)

### DIFF
--- a/stacks/full-stack/README.md
+++ b/stacks/full-stack/README.md
@@ -15,6 +15,8 @@ Passwort-Manager, Foto-Verwaltung, Dateifreigabe und Smart-Home.
 - [x] home-assistant-stack — Smart-Home-Hub, lokaler Sprachassistent, Z-Wave-/Matter-Bridges
 - [x] navidrome — Musik-Server mit Subsonic-API (Symfonium / DSub / ähnliches)
 - [x] audiobookshelf — Hörbücher und Podcasts mit eigenen iOS/Android-Apps
+- [x] filebrowser — Web-UI für die Samba-Freigabe (SSO via Authelia, kein eigener Login nötig)
+- [x] radicale — CalDAV/CardDAV-Server, authentifiziert direkt gegen LLDAP (DAVx⁵, iOS, Thunderbird)
 
 ## Reverse Proxy
 
@@ -33,6 +35,8 @@ Domain und Subdomains sind bei der Installation anpassbar.
 | drive.{domain} | File Share (WebDAV) | 8090 | — | Unbegrenzter Upload |
 | music.{domain} | Navidrome | 4533 | Ja | Subsonic-API für Mobile-Apps (siehe Template-README für Authelia-Bypass) |
 | books.{domain} | Audiobookshelf | 13378 | Ja | Hörbücher + Podcasts, eigene Mobile-Apps |
+| files.{domain} | FileBrowser | 8088 | — | Web-UI für die Samba-Freigabe; Authelia-SSO via auth_request (kein eigener Login) |
+| caldav.{domain} | Radicale | 5232 | — | CalDAV/CardDAV; auth direkt gegen LLDAP, kein Authelia (Mobile-Clients = Basic-Auth) |
 
 ## Nach der Installation
 

--- a/templates/filebrowser/.filebrowser.json.mustache
+++ b/templates/filebrowser/.filebrowser.json.mustache
@@ -1,0 +1,33 @@
+{
+  "port": {{FILEBROWSER_PORT}},
+  "address": "127.0.0.1",
+  "database": "/database/filebrowser.db",
+  "root": "/srv",
+  "log": "stdout",
+  "auth": {
+    "method": "proxy",
+    "header": "Remote-User"
+  },
+  "branding": {
+    "name": "ServiceBay Files"
+  },
+  "defaults": {
+    "scope": ".",
+    "locale": "en",
+    "viewMode": "list",
+    "singleClick": false,
+    "perm": {
+      "admin": false,
+      "execute": false,
+      "create": true,
+      "rename": true,
+      "modify": true,
+      "delete": true,
+      "share": true,
+      "download": true
+    },
+    "commands": [],
+    "sorting": {"by": "name", "asc": true}
+  },
+  "createUserDir": false
+}

--- a/templates/filebrowser/README.md
+++ b/templates/filebrowser/README.md
@@ -1,0 +1,40 @@
+# FileBrowser
+
+A web file manager for the shared `/data` volume. Same files Samba and Syncthing see — drop a file via Windows-mount, browse it from the phone via this UI.
+
+## Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `FILEBROWSER_PORT` | HTTP port (bound to 127.0.0.1) | `8088` |
+
+## How auth works
+
+FileBrowser is intentionally bound to **localhost only**. The only way in is through the `files.<your-domain>` proxy host in NPM, and that proxy host has an `auth_request` block to Authelia's `/api/verify` endpoint pre-configured (see `proxyConfig.advanced_config` in `variables.json`).
+
+Flow:
+
+1. Browser opens `https://files.<your-domain>`
+2. NPM hits Authelia's `/api/verify` first; unauthenticated users get redirected to `https://auth.<your-domain>` for SSO login
+3. After SSO success, NPM forwards the request to FileBrowser with `Remote-User: <username>` set
+4. FileBrowser is configured with `auth.method=proxy` + `auth.header=Remote-User`, so it trusts that header and creates / reuses an account by that name
+
+This means **no separate FileBrowser login**. SSO once, browse everything. As long as you don't punch a hole through NPM that bypasses Authelia, the localhost binding makes any other path unreachable.
+
+## What the user sees
+
+- Everyone in the `family` group (Authelia rule) can reach the UI
+- Each user gets their own FileBrowser account on first visit (auto-created from the SSO header)
+- All accounts default to permission `create + rename + modify + delete + share + download` on `/srv`
+- Admin promotion is manual: log into FileBrowser as the user → as admin user (the first one to log in) → User Settings → tick "Admin"
+
+## Data Layout
+
+```
+{{DATA_DIR}}/file-share/data/   ← the shared volume — same Samba/Syncthing see
+{{DATA_DIR}}/filebrowser/
+  config/.filebrowser.json      ← pre-seeded by ServiceBay
+  db/filebrowser.db             ← user accounts, share links
+```
+
+The shared volume is mounted **rw** by FileBrowser. Files created here show up in Samba/Syncthing instantly (and vice-versa).

--- a/templates/filebrowser/template.yml
+++ b/templates/filebrowser/template.yml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: filebrowser
+  labels:
+    app: filebrowser
+  annotations:
+    servicebay.ports: "{{FILEBROWSER_PORT}}/tcp"
+    servicebay.config-mount: /config
+spec:
+  hostNetwork: true
+  containers:
+  - name: filebrowser
+    image: docker.io/filebrowser/filebrowser:latest
+    # Bind to loopback only — Authelia forward-auth at the NPM layer is
+    # the gate. Direct host-IP access on this port is intentionally
+    # unreachable so a misconfigured proxy can't accidentally expose an
+    # unauth-allowing service.
+    args:
+      - "--config=/config/.filebrowser.json"
+      - "--database=/database/filebrowser.db"
+      - "--root=/srv"
+      - "--address=127.0.0.1"
+      - "--port={{FILEBROWSER_PORT}}"
+    volumeMounts:
+      - mountPath: /srv
+        name: shared-data
+      - mountPath: /database
+        name: filebrowser-db
+      - mountPath: /config
+        name: filebrowser-config
+  volumes:
+  - name: shared-data
+    hostPath:
+      path: {{DATA_DIR}}/file-share/data
+      type: DirectoryOrCreate
+  - name: filebrowser-db
+    hostPath:
+      path: {{DATA_DIR}}/filebrowser/db
+      type: DirectoryOrCreate
+  - name: filebrowser-config
+    hostPath:
+      path: {{DATA_DIR}}/filebrowser/config
+      type: DirectoryOrCreate

--- a/templates/filebrowser/variables.json
+++ b/templates/filebrowser/variables.json
@@ -1,0 +1,19 @@
+{
+  "FILEBROWSER_PORT": {
+    "type": "text",
+    "description": "FileBrowser HTTP port — bound to 127.0.0.1 so it's only reachable through NPM (which terminates Authelia SSO).",
+    "default": "8088"
+  },
+  "FILEBROWSER_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for FileBrowser. Authelia forward-auth in the proxy snippet means SSO login → FileBrowser session in one step.",
+    "default": "files",
+    "proxyPort": "FILEBROWSER_PORT",
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": true,
+      "advanced_config": "auth_request /authelia;\nauth_request_set $target_url $scheme://$http_host$request_uri;\nauth_request_set $user $upstream_http_remote_user;\nauth_request_set $groups $upstream_http_remote_groups;\nauth_request_set $name $upstream_http_remote_name;\nauth_request_set $email $upstream_http_remote_email;\nproxy_set_header Remote-User $user;\nproxy_set_header Remote-Groups $groups;\nproxy_set_header Remote-Name $name;\nproxy_set_header Remote-Email $email;\nerror_page 401 =302 https://auth.{{PUBLIC_DOMAIN}}/?rd=$target_url;\n\nlocation = /authelia {\n    internal;\n    proxy_pass http://127.0.0.1:9091/api/verify;\n    proxy_pass_request_body off;\n    proxy_set_header Content-Length \"\";\n    proxy_set_header X-Original-URL $scheme://$http_host$request_uri;\n    proxy_set_header X-Real-IP $remote_addr;\n    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n    proxy_set_header X-Forwarded-Proto $scheme;\n}"
+    }
+  }
+}

--- a/templates/radicale/README.md
+++ b/templates/radicale/README.md
@@ -1,0 +1,55 @@
+# Radicale — CalDAV / CardDAV Server
+
+Self-hosted calendar + contact server. Authentication is delegated directly to LLDAP via the LDAP backend, so any LLDAP user can log in with their existing credentials — **no separate Radicale account to manage**.
+
+## Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `RADICALE_PORT` | CalDAV/CardDAV HTTP port | `5232` |
+| `LLDAP_HOST` | LLDAP hostname | `localhost` |
+| `LLDAP_LDAP_PORT` | LLDAP LDAP-protocol port | `3890` |
+| `LLDAP_BASE_DN` | LLDAP base DN | `dc=dopp,dc=cloud` |
+| `LLDAP_ADMIN_PASSWORD` | LLDAP admin password (used as Radicale's reader bind) | inherited from lldap template |
+
+## How auth works
+
+CalDAV/CardDAV clients (DAVx⁵, Thunderbird, iOS, macOS, Outlook) send HTTP Basic auth on every request — they can't complete an interactive Authelia login. So Radicale **bypasses Authelia entirely** and validates credentials directly against LLDAP via the LDAP protocol:
+
+1. Client → `https://caldav.<domain>/<username>/calendar/`
+2. NPM forwards (no Authelia rule on this subdomain)
+3. Radicale BIND-DN checks `uid=<username>,ou=people,<base-dn>` against LLDAP
+4. Match → request authorized; user reads/writes their own collections at `/<username>/`
+
+The `[rights] type = owner_only` policy enforces that user X can only see/edit collections at `/X/`. To share a calendar between users, put the principal-collection-set together via the Radicale web UI.
+
+## Setup
+
+1. Deploy via ServiceBay
+2. Web UI: `https://caldav.<domain>` — log in with any LLDAP user → collection-management interface
+3. Mobile / desktop CalDAV clients use the **base URL** with the user's path:
+
+   ```
+   Server  : https://caldav.<your-domain>
+   Username: <lldap-username>
+   Password: <lldap-password>
+   ```
+
+   Most clients auto-discover collections from there.
+
+## Apps
+
+| Platform | App | Notes |
+|---|---|---|
+| Android | **DAVx⁵** (F-Droid + Play Store) | One-time setup, syncs into the system Calendar/Contacts apps |
+| iOS / macOS | Settings → Calendar/Contacts → Add Account → Other → CalDAV | Native, no extra app |
+| Windows | Thunderbird with the *TbSync + Provider for CalDAV* extension | |
+| Linux | Evolution, GNOME Calendar | |
+
+## Data Layout
+
+```
+{{DATA_DIR}}/radicale/
+  config/config              ← LDAP-backed auth config
+  data/collections/<user>/   ← per-user calendars & address books
+```

--- a/templates/radicale/config.mustache
+++ b/templates/radicale/config.mustache
@@ -1,0 +1,30 @@
+[server]
+hosts = 0.0.0.0:{{RADICALE_PORT}}
+max_connections = 20
+max_content_length = 100000000
+
+[encoding]
+request = utf-8
+stock = utf-8
+
+[auth]
+type = ldap
+ldap_uri = ldap://{{LLDAP_HOST}}:{{LLDAP_LDAP_PORT}}
+ldap_base = ou=people,{{LLDAP_BASE_DN}}
+ldap_reader_dn = uid=admin,ou=people,{{LLDAP_BASE_DN}}
+ldap_secret = {{LLDAP_ADMIN_PASSWORD}}
+ldap_filter = (&(objectClass=person)(uid={0}))
+ldap_user_attribute = uid
+
+[storage]
+type = multifilesystem
+filesystem_folder = /data/collections
+
+[rights]
+type = owner_only
+
+[web]
+type = internal
+
+[logging]
+level = info

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: radicale
+  labels:
+    app: radicale
+  annotations:
+    servicebay.ports: "{{RADICALE_PORT}}/tcp"
+    servicebay.config-mount: /config
+spec:
+  hostNetwork: true
+  containers:
+  - name: radicale
+    image: docker.io/tomsquest/docker-radicale:latest
+    args:
+      - "--config=/config/config"
+    ports:
+      - containerPort: {{RADICALE_PORT}}
+    volumeMounts:
+      - mountPath: /data
+        name: radicale-data
+      - mountPath: /config
+        name: radicale-config
+  volumes:
+  - name: radicale-data
+    hostPath:
+      path: {{DATA_DIR}}/radicale/data
+      type: DirectoryOrCreate
+  - name: radicale-config
+    hostPath:
+      path: {{DATA_DIR}}/radicale/config
+      type: DirectoryOrCreate

--- a/templates/radicale/variables.json
+++ b/templates/radicale/variables.json
@@ -1,0 +1,36 @@
+{
+  "RADICALE_PORT": {
+    "type": "text",
+    "description": "Radicale CalDAV/CardDAV port",
+    "default": "5232"
+  },
+  "LLDAP_HOST": {
+    "type": "text",
+    "description": "LLDAP host (localhost when both run on the same node)",
+    "default": "localhost"
+  },
+  "LLDAP_LDAP_PORT": {
+    "type": "text",
+    "description": "LLDAP LDAP-protocol port",
+    "default": "3890"
+  },
+  "LLDAP_BASE_DN": {
+    "type": "text",
+    "description": "LLDAP base DN (e.g. dc=dopp,dc=cloud)",
+    "default": "dc=dopp,dc=cloud"
+  },
+  "LLDAP_ADMIN_PASSWORD": {
+    "type": "secret",
+    "description": "LLDAP admin password — used as the bind DN for Radicale's user-lookup. Inherited from the lldap template when both are installed together."
+  },
+  "RADICALE_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for CalDAV/CardDAV. Mobile clients (DAVx⁵, iOS, Thunderbird) speak HTTP Basic auth — Authelia in front would block them, so this proxy host has NO Authelia forward-auth.",
+    "default": "caldav",
+    "proxyPort": "RADICALE_PORT",
+    "proxyConfig": {
+      "block_exploits": true,
+      "ssl_forced": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two new templates for the full-stack, both LDAP/SSO-integrated:

**filebrowser** — Web file manager bound to \`127.0.0.1\` only. Reachable solely through NPM's \`files.<domain>\` proxy host, which has an Authelia \`auth_request\` snippet baked into \`proxyConfig.advanced_config\`. FileBrowser runs in proxy-auth mode (\`auth.method=proxy auth.header=Remote-User\`) so the SSO user lands as a trusted header and FileBrowser auto-creates the account. Shares the file-share \`/data\` volume rw — files appear in Samba/Syncthing instantly.

**radicale** — CalDAV/CardDAV server with native LDAP backend pointing at the LLDAP pod (\`localhost:3890\`). No Authelia in front (mobile DAV clients can't do interactive SSO); each user logs in with their LLDAP credentials directly. \`[rights] type=owner_only\` so each user only sees their own collections.

Both added to \`stacks/full-stack/README.md\` as \`[x]\` and to the subdomain table (\`files.{domain}\`, \`caldav.{domain}\`).

## Test plan

- [x] \`npx vitest run\` clean
- [ ] Manual: install full-stack with both → \`https://files.<domain>\` redirects to Authelia → login → FileBrowser shows shared volume
- [ ] Manual: DAVx⁵ → \`https://caldav.<domain>\` + LLDAP user/pass → calendar discovery works

🤖 Generated with [Claude Code](https://claude.com/claude-code)