### PR TITLE
fix(security+zero-config): cookie hardening, login rate-limit, CSRF, port-collision check

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,9 +2,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import { login } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
 import { hashPassword, isPasswordHash, verifyPassword } from '@/lib/auth/password';
+import { checkRateLimit, recordFailure, clearAttempts, clientKeyFromHeaders } from '@/lib/auth/rateLimit';
 
 export async function POST(request: NextRequest) {
   try {
+    const clientKey = clientKeyFromHeaders(request.headers);
+    const decision = checkRateLimit(clientKey);
+    if (!decision.allowed) {
+      return NextResponse.json(
+        { error: 'Too many failed attempts. Try again later.' },
+        { status: 429, headers: { 'Retry-After': String(decision.retryAfterSec ?? 60) } },
+      );
+    }
+
     const body = await request.json();
     const { username, password } = body ?? {};
 
@@ -34,6 +44,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (username !== configUsername) {
+      recordFailure(clientKey);
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
     }
 
@@ -51,9 +62,11 @@ export async function POST(request: NextRequest) {
     }
 
     if (!ok) {
+      recordFailure(clientKey);
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
     }
 
+    clearAttempts(clientKey);
     await login(username);
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/auth/oidc/route.ts
+++ b/src/app/api/auth/oidc/route.ts
@@ -25,10 +25,13 @@ export async function GET() {
     authUrl.searchParams.set('state', state);
 
     const response = NextResponse.redirect(authUrl.toString());
-    // Store state in a short-lived cookie for verification
+    // Store state in a short-lived cookie for verification.
+    // sameSite must stay 'lax' so the cookie survives the issuer's top-level
+    // GET redirect back to /api/auth/oidc/callback.
     response.cookies.set('oidc_state', state, {
       httpOnly: true,
       sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
       maxAge: 600, // 10 minutes
       path: '/',
     });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,5 +16,12 @@ export async function login(username: string) {
   const session = await encryptSession({ user: username, expires });
 
   const cookieStore = await cookies();
-  cookieStore.set('session', session, { expires, httpOnly: true, sameSite: 'lax' });
+  cookieStore.set('session', session, {
+    expires,
+    httpOnly: true,
+    sameSite: 'lax',
+    // Require HTTPS in production. Dev runs over plain HTTP on localhost.
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+  });
 }

--- a/src/lib/auth/rateLimit.ts
+++ b/src/lib/auth/rateLimit.ts
@@ -1,0 +1,92 @@
+// In-memory sliding-window login rate limiter, keyed by client IP.
+// Single-process custom server → no shared store needed. Resets on success.
+
+const WINDOW_MS = 15 * 60 * 1000;
+const MAX_FAILURES = 5;
+
+interface Bucket {
+  failures: number[]; // unix-ms timestamps of recent failed attempts
+}
+
+const buckets = new Map<string, Bucket>();
+
+function pruneOlderThan(b: Bucket, cutoff: number) {
+  if (b.failures.length === 0) return;
+  let i = 0;
+  while (i < b.failures.length && b.failures[i] < cutoff) i++;
+  if (i > 0) b.failures.splice(0, i);
+}
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  /** Seconds until the next attempt is allowed (only set when blocked). */
+  retryAfterSec?: number;
+  /** Failures recorded in the current window — useful for logging. */
+  recentFailures: number;
+}
+
+/**
+ * Check whether a login attempt from `key` is currently allowed.
+ * Does NOT mutate state — call recordFailure / clear after handling the attempt.
+ */
+export function checkRateLimit(
+  key: string,
+  now: number = Date.now(),
+  windowMs: number = WINDOW_MS,
+  maxFailures: number = MAX_FAILURES,
+): RateLimitDecision {
+  const b = buckets.get(key);
+  if (!b) return { allowed: true, recentFailures: 0 };
+  pruneOlderThan(b, now - windowMs);
+  if (b.failures.length >= maxFailures) {
+    const oldest = b.failures[0];
+    const retryAfterMs = (oldest + windowMs) - now;
+    return {
+      allowed: false,
+      retryAfterSec: Math.max(1, Math.ceil(retryAfterMs / 1000)),
+      recentFailures: b.failures.length,
+    };
+  }
+  return { allowed: true, recentFailures: b.failures.length };
+}
+
+export function recordFailure(key: string, now: number = Date.now()) {
+  let b = buckets.get(key);
+  if (!b) {
+    b = { failures: [] };
+    buckets.set(key, b);
+  }
+  b.failures.push(now);
+}
+
+export function clearAttempts(key: string) {
+  buckets.delete(key);
+}
+
+/** Test-only: nuke all state. */
+export function _resetForTests() {
+  buckets.clear();
+}
+
+/**
+ * Extract a stable client identifier from request headers.
+ * Honors X-Forwarded-For (first hop) when present — ServiceBay sits behind
+ * NPM in production. Falls back to a literal "unknown" so absence still
+ * collapses to a single bucket rather than bypassing the limiter.
+ */
+export function clientKeyFromHeaders(headers: Headers | Record<string, string | string[] | undefined>): string {
+  const get = (name: string): string | undefined => {
+    if (headers instanceof Headers) return headers.get(name) ?? undefined;
+    const v = headers[name] ?? headers[name.toLowerCase()];
+    if (Array.isArray(v)) return v[0];
+    return v;
+  };
+  const xff = get('x-forwarded-for');
+  if (xff) {
+    const first = xff.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const real = get('x-real-ip');
+  if (real) return real.trim();
+  return 'unknown';
+}

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -519,6 +519,19 @@ export class ServiceManager {
     }
 
     static async deployKubeService(nodeName: string, name: string, kubeContent: string, yamlContent: string, yamlName: string, extraFiles?: { path: string; content: string }[], onProgress?: (message: string) => void) {
+        // Pre-flight: refuse to deploy if the YAML claims a host port that
+        // another service on the same node already owns. Without this check,
+        // the second deploy "succeeds" but the unit fails to start because the
+        // bind() races; users only notice when the new service stays
+        // permanently inactive in the dashboard.
+        const collisions = await this.findHostPortCollisions(nodeName, name, yamlContent);
+        if (collisions.length > 0) {
+            const detail = collisions
+                .map(c => `port ${c.hostPort} already in use by ${c.serviceName}`)
+                .join('; ');
+            throw new Error(`Port collision on node "${nodeName}": ${detail}. Change the host port and retry.`);
+        }
+
         // Ensure TimeoutStartSec for multi-image pods so image pulls don't cause systemd timeout
         const images = this.extractImages(yamlContent);
         if (images.length > 1 && !kubeContent.includes('TimeoutStartSec')) {
@@ -607,6 +620,78 @@ export class ServiceManager {
         } catch (e) {
             logger.warn('ServiceManager', `Failed to create monitoring check for ${name}:`, e);
         }
+    }
+
+    /**
+     * Pull every hostPort declared in a kube YAML. Tolerates malformed YAML
+     * (returns empty rather than throwing) so a parse error never blocks a
+     * deploy via the collision check.
+     */
+    static extractHostPorts(yamlContent: string): number[] {
+        const ports = new Set<number>();
+        try {
+            const docs = yaml.loadAll(yamlContent) as unknown[];
+            for (const doc of docs) {
+                if (!doc || typeof doc !== 'object') continue;
+                const spec = (doc as { spec?: unknown }).spec as { containers?: unknown } | undefined;
+                const containers = Array.isArray(spec?.containers) ? spec.containers : [];
+                for (const c of containers) {
+                    if (!c || typeof c !== 'object') continue;
+                    const portsField = (c as { ports?: unknown }).ports;
+                    if (!Array.isArray(portsField)) continue;
+                    for (const p of portsField) {
+                        if (!p || typeof p !== 'object') continue;
+                        const hp = (p as { hostPort?: unknown }).hostPort;
+                        if (typeof hp === 'number' && Number.isFinite(hp) && hp > 0) {
+                            ports.add(hp);
+                        } else if (typeof hp === 'string') {
+                            const n = parseInt(hp, 10);
+                            if (Number.isFinite(n) && n > 0) ports.add(n);
+                        }
+                    }
+                }
+            }
+        } catch {
+            // Fallback: regex out hostPort: <num>. Better to under-detect than crash.
+            const regex = /hostPort:\s*["']?(\d+)["']?/g;
+            let m: RegExpExecArray | null;
+            while ((m = regex.exec(yamlContent)) !== null) {
+                const n = parseInt(m[1], 10);
+                if (Number.isFinite(n) && n > 0) ports.add(n);
+            }
+        }
+        return [...ports];
+    }
+
+    /**
+     * Look for hostPort conflicts between a yaml-being-deployed and the
+     * services currently registered on `nodeName`. The service being
+     * (re)deployed under `selfName` is excluded so an upgrade in place is
+     * never blocked by its own already-registered ports.
+     */
+    static async findHostPortCollisions(
+        nodeName: string,
+        selfName: string,
+        yamlContent: string,
+    ): Promise<{ hostPort: number; serviceName: string }[]> {
+        const wanted = this.extractHostPorts(yamlContent);
+        if (wanted.length === 0) return [];
+        const services = await this.listServices(nodeName);
+        const collisions: { hostPort: number; serviceName: string }[] = [];
+        for (const port of wanted) {
+            for (const svc of services) {
+                if (svc.name === selfName) continue;
+                const hit = svc.ports?.some(p => {
+                    if (!p?.host) return false;
+                    return parseInt(p.host, 10) === port;
+                });
+                if (hit) {
+                    collisions.push({ hostPort: port, serviceName: svc.name });
+                    break;
+                }
+            }
+        }
+        return collisions;
     }
 
     /** Extract all container image references from a kube YAML */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,14 +7,40 @@ const PUBLIC_API_PREFIXES = [
   '/api/auth/lldap-url',
 ];
 
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
 function isPublicApi(pathname: string): boolean {
   return PUBLIC_API_PREFIXES.some(p => pathname === p || pathname.startsWith(p + '/'));
+}
+
+// Same-origin CSRF check: for state-changing methods, the request's Origin
+// (or Referer fallback) must match the Host the browser saw. Behind NPM the
+// Host header is the public hostname and the browser's Origin uses that same
+// hostname → match. Cross-site form posts carry the attacker's origin →
+// mismatch → reject. No Origin AND no Referer on an unsafe method → reject.
+function isSameOrigin(request: NextRequest): boolean {
+  const host = request.headers.get('host');
+  if (!host) return false;
+  const originHeader = request.headers.get('origin');
+  if (originHeader) {
+    try { return new URL(originHeader).host === host; } catch { return false; }
+  }
+  const referer = request.headers.get('referer');
+  if (referer) {
+    try { return new URL(referer).host === host; } catch { return false; }
+  }
+  return false;
 }
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (!pathname.startsWith('/api/')) return NextResponse.next();
+
+  if (!SAFE_METHODS.has(request.method) && !isSameOrigin(request)) {
+    return NextResponse.json({ error: 'Forbidden: cross-site request' }, { status: 403 });
+  }
+
   if (isPublicApi(pathname)) return NextResponse.next();
 
   const token = request.cookies.get('session')?.value;

--- a/tests/backend/auth_csrf.test.ts
+++ b/tests/backend/auth_csrf.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+beforeAll(() => {
+  process.env.AUTH_SECRET = process.env.AUTH_SECRET ||
+    '0123456789abcdef0123456789abcdef0123456789abcdef';
+});
+
+// Build a NextRequest-like stand-in. The proxy fn only touches headers,
+// method, cookies.get, and nextUrl.pathname.
+function makeReq(opts: {
+  method?: string;
+  pathname: string;
+  origin?: string;
+  referer?: string;
+  host?: string;
+  sessionCookie?: string;
+}) {
+  const headers = new Headers();
+  if (opts.origin) headers.set('origin', opts.origin);
+  if (opts.referer) headers.set('referer', opts.referer);
+  headers.set('host', opts.host ?? 'admin.example.com');
+  return {
+    method: opts.method ?? 'POST',
+    headers,
+    nextUrl: { pathname: opts.pathname },
+    cookies: { get: (name: string) => opts.sessionCookie && name === 'session' ? { value: opts.sessionCookie } : undefined },
+  } as unknown as import('next/server').NextRequest;
+}
+
+describe('proxy CSRF check', () => {
+  it('allows GET regardless of origin', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const res = await proxy(makeReq({ method: 'GET', pathname: '/api/services' }));
+    // No session cookie → 401 (auth check, not CSRF)
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects unsafe method without Origin or Referer', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const res = await proxy(makeReq({ method: 'POST', pathname: '/api/services' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects unsafe method with cross-origin Origin', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const res = await proxy(makeReq({
+      method: 'POST',
+      pathname: '/api/services',
+      origin: 'https://evil.example',
+    }));
+    expect(res.status).toBe(403);
+  });
+
+  it('allows unsafe method with matching Origin', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const res = await proxy(makeReq({
+      method: 'POST',
+      pathname: '/api/services',
+      origin: 'https://admin.example.com',
+    }));
+    // Origin matches → CSRF passes; falls through to auth → 401 (no session)
+    expect(res.status).toBe(401);
+  });
+
+  it('falls back to Referer when Origin is missing', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const res = await proxy(makeReq({
+      method: 'POST',
+      pathname: '/api/services',
+      referer: 'https://admin.example.com/services',
+    }));
+    expect(res.status).toBe(401);
+  });
+
+  it('allows POST to public endpoint with matching Origin', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const { NextResponse } = await import('next/server');
+    const spy = vi.spyOn(NextResponse, 'next');
+    await proxy(makeReq({
+      method: 'POST',
+      pathname: '/api/auth/login',
+      origin: 'https://admin.example.com',
+    }));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('blocks POST to public endpoint when cross-origin', async () => {
+    const { proxy } = await import('../../src/proxy');
+    const res = await proxy(makeReq({
+      method: 'POST',
+      pathname: '/api/auth/login',
+      origin: 'https://evil.example',
+    }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/backend/auth_ratelimit.test.ts
+++ b/tests/backend/auth_ratelimit.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  checkRateLimit,
+  recordFailure,
+  clearAttempts,
+  clientKeyFromHeaders,
+  _resetForTests,
+} from '../../src/lib/auth/rateLimit';
+
+beforeEach(() => _resetForTests());
+
+describe('rate limiter', () => {
+  it('allows attempts under the threshold', () => {
+    const key = '1.2.3.4';
+    for (let i = 0; i < 4; i++) {
+      const d = checkRateLimit(key);
+      expect(d.allowed).toBe(true);
+      recordFailure(key);
+    }
+    expect(checkRateLimit(key).allowed).toBe(true);
+  });
+
+  it('blocks the 6th attempt and reports retry-after', () => {
+    const key = '1.2.3.4';
+    const t0 = 1_000_000_000_000;
+    for (let i = 0; i < 5; i++) recordFailure(key, t0);
+    const d = checkRateLimit(key, t0);
+    expect(d.allowed).toBe(false);
+    expect(d.retryAfterSec).toBeGreaterThan(0);
+    expect(d.retryAfterSec).toBeLessThanOrEqual(15 * 60);
+  });
+
+  it('expires old failures outside the window', () => {
+    const key = '1.2.3.4';
+    const t0 = 1_000_000_000_000;
+    for (let i = 0; i < 5; i++) recordFailure(key, t0);
+    const later = t0 + 16 * 60 * 1000; // 16 min later
+    expect(checkRateLimit(key, later).allowed).toBe(true);
+  });
+
+  it('clearAttempts wipes the bucket on success', () => {
+    const key = '1.2.3.4';
+    for (let i = 0; i < 5; i++) recordFailure(key);
+    expect(checkRateLimit(key).allowed).toBe(false);
+    clearAttempts(key);
+    expect(checkRateLimit(key).allowed).toBe(true);
+  });
+
+  it('keys are independent', () => {
+    for (let i = 0; i < 5; i++) recordFailure('1.1.1.1');
+    expect(checkRateLimit('1.1.1.1').allowed).toBe(false);
+    expect(checkRateLimit('2.2.2.2').allowed).toBe(true);
+  });
+});
+
+describe('clientKeyFromHeaders', () => {
+  it('uses the first hop of x-forwarded-for', () => {
+    const h = new Headers({ 'x-forwarded-for': '203.0.113.1, 10.0.0.1' });
+    expect(clientKeyFromHeaders(h)).toBe('203.0.113.1');
+  });
+
+  it('falls back to x-real-ip', () => {
+    const h = new Headers({ 'x-real-ip': '198.51.100.7' });
+    expect(clientKeyFromHeaders(h)).toBe('198.51.100.7');
+  });
+
+  it('returns "unknown" when no client header is present', () => {
+    expect(clientKeyFromHeaders(new Headers())).toBe('unknown');
+  });
+
+  it('accepts Node-style header records', () => {
+    expect(clientKeyFromHeaders({ 'x-forwarded-for': '203.0.113.5' })).toBe('203.0.113.5');
+  });
+});

--- a/tests/backend/port_collision.test.ts
+++ b/tests/backend/port_collision.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { ServiceManager } from '../../src/lib/services/ServiceManager';
+
+describe('extractHostPorts', () => {
+  it('returns numeric host ports from a kube YAML', () => {
+    const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: filebrowser
+spec:
+  containers:
+    - name: filebrowser
+      image: filebrowser/filebrowser
+      ports:
+        - containerPort: 8088
+          hostPort: 8088
+        - containerPort: 9999
+          hostPort: 9999
+`;
+    expect(ServiceManager.extractHostPorts(yaml).sort()).toEqual([8088, 9999]);
+  });
+
+  it('handles multiple containers in one pod', () => {
+    const yaml = `
+apiVersion: v1
+kind: Pod
+metadata: { name: stack }
+spec:
+  containers:
+    - name: a
+      image: a:latest
+      ports:
+        - { containerPort: 80, hostPort: 8080 }
+    - name: b
+      image: b:latest
+      ports:
+        - { containerPort: 90, hostPort: 8090 }
+`;
+    expect(ServiceManager.extractHostPorts(yaml).sort()).toEqual([8080, 8090]);
+  });
+
+  it('coerces string hostPort values', () => {
+    const yaml = `
+apiVersion: v1
+kind: Pod
+metadata: { name: x }
+spec:
+  containers:
+    - name: x
+      image: x:latest
+      ports:
+        - containerPort: 80
+          hostPort: "8080"
+`;
+    expect(ServiceManager.extractHostPorts(yaml)).toEqual([8080]);
+  });
+
+  it('skips containerPort-only entries (no hostPort)', () => {
+    const yaml = `
+apiVersion: v1
+kind: Pod
+metadata: { name: x }
+spec:
+  containers:
+    - name: x
+      image: x:latest
+      ports:
+        - containerPort: 80
+`;
+    expect(ServiceManager.extractHostPorts(yaml)).toEqual([]);
+  });
+
+  it('returns deduplicated ports', () => {
+    const yaml = `
+apiVersion: v1
+kind: Pod
+metadata: { name: x }
+spec:
+  containers:
+    - name: x
+      image: x:latest
+      ports:
+        - { containerPort: 80, hostPort: 8080 }
+        - { containerPort: 81, hostPort: 8080 }
+`;
+    expect(ServiceManager.extractHostPorts(yaml)).toEqual([8080]);
+  });
+
+  it('falls back to regex on malformed YAML', () => {
+    // tab + space mixed indentation that yaml.loadAll rejects
+    const yaml = "spec:\n\tcontainers:\n  - hostPort: 7777";
+    expect(ServiceManager.extractHostPorts(yaml)).toContain(7777);
+  });
+
+  it('returns empty for YAML with no ports section', () => {
+    const yaml = `
+apiVersion: v1
+kind: Pod
+metadata: { name: x }
+spec:
+  containers:
+    - name: x
+      image: x:latest
+`;
+    expect(ServiceManager.extractHostPorts(yaml)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Five fixes pulled out of an audit, grouped into two commits by theme.

**Security (commit 1)**
- Session + `oidc_state` cookies set `Secure` in production (`NODE_ENV === 'production'`). Dev still runs over plain HTTP on localhost.
- `/api/auth/login` rate-limited per client IP: 5 fails / 15 min sliding window, reset on success, returns `429 Retry-After`. Honors `X-Forwarded-For`. Applies to both the bcrypt-hash path and the `SERVICEBAY_PASSWORD` bootstrap path.
- Same-origin CSRF check in `proxy.ts` middleware: non-GET/HEAD/OPTIONS requests under `/api/*` must have an `Origin` (or `Referer` fallback) whose host matches `Host`. `sameSite=lax` stays so the OIDC issuer's top-level redirect to the callback still works.

**Zero-config (commit 2)**
- `ServiceManager.deployKubeService` runs a pre-flight host-port collision check against the target node's `listServices()` snapshot and aborts with a specific message before writing any files. Previously the deploy "succeeded" on disk and the unit went straight to inactive when podman's `bind()` lost the race — the wizard logged a green checkmark, only an attentive user noticed the dead service later.

## Test plan

- [x] `npx vitest run tests/backend` — 209 passing, including the 23 new tests in `auth_ratelimit`, `auth_csrf`, and `port_collision`
- [x] `npx vitest run tests/frontend` — 64 passing
- [x] ESLint clean on all changed files
- [x] `tsc --noEmit` — no new errors in changed files
- [ ] Manual: trigger 6 bad logins from a browser → expect 429 on the 6th
- [ ] Manual: cross-origin POST with curl `-H "Origin: https://evil.example"` → expect 403
- [ ] Manual: deploy two templates with the same `hostPort` → expect the second deploy to refuse with a clear error

## Notes

- Filebrowser-specific `{{AUTHELIA_PORT}}` substitution + the matching mustache renderer that makes it work landed separately on #146 (same template, scoped commit).
- Rate-limiter is in-memory (single-process custom Next server, no shared store needed). If we ever scale horizontally, swap for Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)