### PR TITLE
fix(security): persist rate-limit, equalize login timing, drop vulnerable deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "jsdom": "^27.4.0",
         "knip": "^5.81.0",
         "lint-staged": "^16.2.7",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.10",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5",
@@ -6539,12 +6539,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7418,9 +7418,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9525,34 +9525,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-abi": {
       "version": "3.85.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
@@ -10021,10 +9993,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
-      "dev": true,
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jsdom": "^27.4.0",
     "knip": "^5.81.0",
     "lint-staged": "^16.2.7",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.10",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",
@@ -91,6 +91,7 @@
     "ellipsize": "^0.7.0",
     "react-highlight-words": {
       "react": "$react"
-    }
+    },
+    "postcss": "^8.5.10"
   }
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,15 +3,29 @@ import { login } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
 import { hashPassword, isPasswordHash, verifyPassword } from '@/lib/auth/password';
 import { checkRateLimit, recordFailure, clearAttempts, clientKeyFromHeaders } from '@/lib/auth/rateLimit';
+import { logger } from '@/lib/logger';
+
+// Pre-hashed sentinel used when the supplied username does not match. Verifying
+// against this hash is intentionally indistinguishable in timing from verifying
+// the real hash, so a remote attacker cannot probe usernames by clock.
+let DUMMY_HASH: string | null = null;
+async function getDummyHash(): Promise<string> {
+  if (!DUMMY_HASH) DUMMY_HASH = await hashPassword('dummy-password-for-timing-equalization');
+  return DUMMY_HASH;
+}
+
+function userKey(username: string): string {
+  return `user:${username.toLowerCase()}`;
+}
 
 export async function POST(request: NextRequest) {
   try {
     const clientKey = clientKeyFromHeaders(request.headers);
-    const decision = checkRateLimit(clientKey);
-    if (!decision.allowed) {
+    const ipDecision = checkRateLimit(clientKey);
+    if (!ipDecision.allowed) {
       return NextResponse.json(
         { error: 'Too many failed attempts. Try again later.' },
-        { status: 429, headers: { 'Retry-After': String(decision.retryAfterSec ?? 60) } },
+        { status: 429, headers: { 'Retry-After': String(ipDecision.retryAfterSec ?? 60) } },
       );
     }
 
@@ -22,13 +36,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Username and password required' }, { status: 400 });
     }
 
+    // Per-username throttle: defends against credential stuffing across many
+    // source IPs (botnets) by limiting attempts on a single account.
+    const uKey = userKey(username);
+    const userDecision = checkRateLimit(uKey);
+    if (!userDecision.allowed) {
+      return NextResponse.json(
+        { error: 'Too many failed attempts. Try again later.' },
+        { status: 429, headers: { 'Retry-After': String(userDecision.retryAfterSec ?? 60) } },
+      );
+    }
+
     const config = await getConfig();
     const configHash = config.auth?.passwordHash;
     const configUsername = config.auth?.username || process.env.SERVICEBAY_USERNAME || 'admin';
-
-    // Bootstrap path: if SERVICEBAY_PASSWORD is set and no hash is stored yet,
-    // accept it once and persist a hash on success. Plaintext is never compared
-    // to plaintext at rest.
     const bootstrapPassword = process.env.SERVICEBAY_PASSWORD;
 
     if (!configHash && !bootstrapPassword) {
@@ -43,34 +64,43 @@ export async function POST(request: NextRequest) {
       }, { status: 503 });
     }
 
-    if (username !== configUsername) {
-      recordFailure(clientKey);
-      return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+    // Always run scrypt verify regardless of whether the username matched, so
+    // a wrong-username response takes the same wall-clock time as a wrong-password
+    // response. We discard the verify result if the username didn't match.
+    const usernameMatches = username === configUsername;
+
+    let referenceHash: string;
+    let tempBootstrapHash: string | null = null;
+    if (usernameMatches && configHash) {
+      referenceHash = configHash;
+    } else if (usernameMatches && bootstrapPassword) {
+      tempBootstrapHash = await hashPassword(bootstrapPassword);
+      referenceHash = tempBootstrapHash;
+    } else {
+      referenceHash = await getDummyHash();
     }
 
-    let ok = false;
-    if (configHash) {
-      ok = await verifyPassword(password, configHash);
-    } else if (bootstrapPassword) {
-      // Constant-time-ish equality via verifyPassword on a freshly-hashed bootstrap value.
-      const tempHash = await hashPassword(bootstrapPassword);
-      ok = await verifyPassword(password, tempHash);
-      if (ok) {
-        const { updateConfig } = await import('@/lib/config');
-        await updateConfig({ auth: { username: configUsername, passwordHash: tempHash } });
-      }
-    }
+    const verifyOk = await verifyPassword(password, referenceHash);
+    const ok = usernameMatches && verifyOk;
 
     if (!ok) {
       recordFailure(clientKey);
+      recordFailure(uKey);
+      logger.warn('auth:login', 'failed login', { ip: clientKey, username });
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
     }
 
+    if (tempBootstrapHash) {
+      const { updateConfig } = await import('@/lib/config');
+      await updateConfig({ auth: { username: configUsername, passwordHash: tempBootstrapHash } });
+    }
+
     clearAttempts(clientKey);
+    clearAttempts(uKey);
     await login(username);
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Login error:', error);
+    logger.error('auth:login', 'login crash', error instanceof Error ? error.message : String(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/lib/auth/rateLimit.ts
+++ b/src/lib/auth/rateLimit.ts
@@ -1,33 +1,110 @@
-// In-memory sliding-window login rate limiter, keyed by client IP.
-// Single-process custom server → no shared store needed. Resets on success.
+// Sliding-window login rate limiter, persisted to SQLite so failed attempts
+// survive process restarts (the agent updater restarts the server nightly,
+// which would otherwise zero a brute-forcer's progress).
+//
+// Storage is opt-in: in environments where SQLite cannot be initialized
+// (e.g. unit tests with no writable DATA_DIR) the limiter falls back to a
+// process-local Map so its behavior is unchanged from the v1 implementation.
+
+import path from 'path';
+import { DATA_DIR } from '../dirs';
 
 const WINDOW_MS = 15 * 60 * 1000;
 const MAX_FAILURES = 5;
 
-interface Bucket {
-  failures: number[]; // unix-ms timestamps of recent failed attempts
+interface BucketRow { ts: number }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Stmt = { all: (...args: any[]) => unknown[]; run: (...args: any[]) => unknown };
+interface DBLike {
+  prepare: (sql: string) => Stmt;
+  exec: (sql: string) => void;
+  pragma: (sql: string) => unknown;
 }
 
-const buckets = new Map<string, Bucket>();
+let db: DBLike | null = null;
+const memoryFallback = new Map<string, number[]>();
 
-function pruneOlderThan(b: Bucket, cutoff: number) {
-  if (b.failures.length === 0) return;
-  let i = 0;
-  while (i < b.failures.length && b.failures[i] < cutoff) i++;
-  if (i > 0) b.failures.splice(0, i);
+function tryOpenDb(): DBLike | null {
+  if (db) return db;
+  if (typeof window !== 'undefined') return null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    const inst = new Database(path.join(DATA_DIR, 'auth.db')) as DBLike;
+    inst.pragma('journal_mode = WAL');
+    inst.exec(`
+      CREATE TABLE IF NOT EXISTS rate_limit_attempts (
+        key TEXT NOT NULL,
+        ts  INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_rl_key ON rate_limit_attempts(key);
+      CREATE INDEX IF NOT EXISTS idx_rl_ts  ON rate_limit_attempts(ts);
+    `);
+    db = inst;
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+function getFailuresFromStore(key: string, cutoff: number): number[] {
+  const inst = tryOpenDb();
+  if (!inst) {
+    const arr = memoryFallback.get(key) ?? [];
+    return arr.filter(t => t >= cutoff);
+  }
+  const rows = inst
+    .prepare('SELECT ts FROM rate_limit_attempts WHERE key = ? AND ts >= ? ORDER BY ts ASC')
+    .all(key, cutoff) as BucketRow[];
+  return rows.map(r => r.ts);
+}
+
+function addFailureToStore(key: string, ts: number) {
+  const inst = tryOpenDb();
+  if (!inst) {
+    const arr = memoryFallback.get(key) ?? [];
+    arr.push(ts);
+    memoryFallback.set(key, arr);
+    return;
+  }
+  inst.prepare('INSERT INTO rate_limit_attempts (key, ts) VALUES (?, ?)').run(key, ts);
+}
+
+function clearStoreKey(key: string) {
+  const inst = tryOpenDb();
+  if (!inst) {
+    memoryFallback.delete(key);
+    return;
+  }
+  inst.prepare('DELETE FROM rate_limit_attempts WHERE key = ?').run(key);
+}
+
+function pruneOldStore(cutoff: number) {
+  const inst = tryOpenDb();
+  if (!inst) {
+    for (const [k, arr] of memoryFallback) {
+      const kept = arr.filter(t => t >= cutoff);
+      if (kept.length === 0) memoryFallback.delete(k);
+      else memoryFallback.set(k, kept);
+    }
+    return;
+  }
+  inst.prepare('DELETE FROM rate_limit_attempts WHERE ts < ?').run(cutoff);
 }
 
 export interface RateLimitDecision {
   allowed: boolean;
-  /** Seconds until the next attempt is allowed (only set when blocked). */
   retryAfterSec?: number;
-  /** Failures recorded in the current window — useful for logging. */
   recentFailures: number;
 }
 
 /**
- * Check whether a login attempt from `key` is currently allowed.
- * Does NOT mutate state — call recordFailure / clear after handling the attempt.
+ * Check whether an attempt from `key` is currently allowed.
+ * Does NOT mutate state — call recordFailure / clearAttempts after handling.
  */
 export function checkRateLimit(
   key: string,
@@ -35,37 +112,35 @@ export function checkRateLimit(
   windowMs: number = WINDOW_MS,
   maxFailures: number = MAX_FAILURES,
 ): RateLimitDecision {
-  const b = buckets.get(key);
-  if (!b) return { allowed: true, recentFailures: 0 };
-  pruneOlderThan(b, now - windowMs);
-  if (b.failures.length >= maxFailures) {
-    const oldest = b.failures[0];
+  const cutoff = now - windowMs;
+  // Opportunistic prune: cheap when the table is small.
+  pruneOldStore(cutoff);
+  const failures = getFailuresFromStore(key, cutoff);
+  if (failures.length >= maxFailures) {
+    const oldest = failures[0];
     const retryAfterMs = (oldest + windowMs) - now;
     return {
       allowed: false,
       retryAfterSec: Math.max(1, Math.ceil(retryAfterMs / 1000)),
-      recentFailures: b.failures.length,
+      recentFailures: failures.length,
     };
   }
-  return { allowed: true, recentFailures: b.failures.length };
+  return { allowed: true, recentFailures: failures.length };
 }
 
 export function recordFailure(key: string, now: number = Date.now()) {
-  let b = buckets.get(key);
-  if (!b) {
-    b = { failures: [] };
-    buckets.set(key, b);
-  }
-  b.failures.push(now);
+  addFailureToStore(key, now);
 }
 
 export function clearAttempts(key: string) {
-  buckets.delete(key);
+  clearStoreKey(key);
 }
 
 /** Test-only: nuke all state. */
 export function _resetForTests() {
-  buckets.clear();
+  memoryFallback.clear();
+  const inst = tryOpenDb();
+  if (inst) inst.exec('DELETE FROM rate_limit_attempts');
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Rate-limit persistence** — login buckets moved from in-memory Map to SQLite (`data/auth.db`) so failed attempts survive process restarts. Memory fallback when DATA_DIR isn't writable (test env).
- **Per-username throttle** — added alongside the existing per-IP bucket so a botnet rotating source IPs can't bypass account lockout.
- **Constant-time login** — wrong-username paths now run scrypt against a dummy hash, equalizing wall-clock with wrong-password paths and removing the username-enumeration timing oracle.
- **Dependency vulns** — bumped dev `postcss` to `^8.5.10` + added an override so Next's bundled postcss is also patched. `npm update` pulls patched `express-rate-limit` / `ip-address`. `npm audit`: **4 moderate → 0**.

Closes the post-audit findings on auth + deps.

## Test plan
- [x] `npx vitest run tests/backend/auth_ratelimit tests/backend/auth_session tests/backend/auth_csrf` — 21/21 pass
- [x] `npm audit --omit=dev` — 0 vulnerabilities
- [x] `npx tsc --noEmit` — clean in src/
- [ ] Manual: confirm a wrong username takes the same time as a wrong password
- [ ] Manual: confirm rate-limit state survives a server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)