### PR TITLE
feat(ui): add error/loading/not-found boundaries

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Project-specific build artifacts:
+    "dist-server/**",
   ]),
 ]);
 

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Dashboard route error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex-1 flex items-center justify-center px-6 py-12">
+      <div className="max-w-md w-full text-center space-y-4">
+        <div className="text-4xl">⚠</div>
+        <h2 className="text-xl font-semibold">This view failed to load</h2>
+        <p className="opacity-70 text-sm">
+          {error.message || 'An unexpected error occurred while rendering this page.'}
+        </p>
+        {error.digest && (
+          <p className="text-xs opacity-50 font-mono">ref: {error.digest}</p>
+        )}
+        <button
+          onClick={() => reset()}
+          className="mt-2 px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-500 text-white text-sm transition"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('App route error:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-[var(--background)] text-[var(--foreground)]">
+      <div className="max-w-md w-full text-center space-y-4">
+        <div className="text-5xl">⚠</div>
+        <h1 className="text-2xl font-semibold">Something went wrong</h1>
+        <p className="opacity-70 text-sm">
+          The page hit an unexpected error. The full details have been logged.
+        </p>
+        {error.digest && (
+          <p className="text-xs opacity-50 font-mono">ref: {error.digest}</p>
+        )}
+        <div className="flex gap-2 justify-center pt-2">
+          <button
+            onClick={() => reset()}
+            className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-500 text-white text-sm transition"
+          >
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="px-4 py-2 rounded-md border border-current/30 hover:bg-current/10 text-sm transition"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--background)] text-[var(--foreground)]">
+      <div className="flex flex-col items-center gap-3">
+        <div
+          className="w-8 h-8 rounded-full border-2 border-current/20 border-t-blue-500 animate-spin"
+          aria-hidden="true"
+        />
+        <span className="text-sm opacity-60">Loading…</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6 py-12 bg-[var(--background)] text-[var(--foreground)]">
+      <div className="max-w-md w-full text-center space-y-4">
+        <div className="text-6xl font-mono opacity-40">404</div>
+        <h1 className="text-2xl font-semibold">Page not found</h1>
+        <p className="opacity-70 text-sm">
+          The page you’re looking for doesn’t exist or has been moved.
+        </p>
+        <div className="pt-2">
+          <Link
+            href="/"
+            className="inline-block px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-500 text-white text-sm transition"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New \`src/app/error.tsx\`, \`loading.tsx\`, \`not-found.tsx\` at the app root, plus a per-segment \`(dashboard)/error.tsx\` so a broken view doesn't take down the whole shell.
- Audit found zero error boundaries; failed server actions surfaced Next's default raw error page. Now users get a styled message with a retry / go-home action.
- Also ignore \`dist-server/\` in eslint config — generated CJS bundle was producing ~70 spurious \`no-require-imports\` errors.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] Manual: throw inside a (dashboard) route and confirm the in-shell boundary fires
- [ ] Manual: visit a nonexistent path and confirm not-found.tsx renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)