### PR TITLE
fix(installer): persist PUBLIC_DOMAIN + detect USBs without root

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -929,6 +929,7 @@ DNS_SERVERS=${DNS_SERVERS}
 SERVICEBAY_PORT=${SERVICEBAY_PORT}
 SERVICEBAY_CHANNEL=${SERVICEBAY_CHANNEL}
 SERVICEBAY_ADMIN_USER=${SERVICEBAY_ADMIN_USER}
+PUBLIC_DOMAIN=${PUBLIC_DOMAIN:-}
 GW_HOST=${GW_HOST}
 GW_USER=${GW_USER}
 ENABLE_REGISTRIES=${ENABLE_REGISTRIES}
@@ -995,6 +996,7 @@ if $USE_SAVED; then
   SERVICEBAY_PORT="$(load_setting SERVICEBAY_PORT)"
   SERVICEBAY_CHANNEL="$(load_setting SERVICEBAY_CHANNEL)"
   SERVICEBAY_ADMIN_USER="$(load_setting SERVICEBAY_ADMIN_USER)"
+  PUBLIC_DOMAIN="$(load_setting PUBLIC_DOMAIN)"
   GW_HOST="$(load_setting GW_HOST)"
   GW_USER="$(load_setting GW_USER)"
   ENABLE_REGISTRIES="$(load_setting ENABLE_REGISTRIES)"
@@ -1246,7 +1248,8 @@ SERVICEBAY_CONFIG='{
 
 # Add reverseProxy.publicDomain if user supplied one — wizard reads this
 # as the default for PUBLIC_DOMAIN so they don't have to type it again.
-if [[ -n "$PUBLIC_DOMAIN" ]]; then
+# Default-empty in case an older saved-settings file pre-dates this field.
+if [[ -n "${PUBLIC_DOMAIN:-}" ]]; then
   SERVICEBAY_CONFIG+=',
   "reverseProxy": {
     "publicDomain": '"$(json_str "$PUBLIC_DOMAIN")"'
@@ -1478,13 +1481,19 @@ echo ""
 
 # --- Write to USB ---
 
-# Find removable USB drives
+# Find removable USB drives. Read size from sysfs (world-readable) rather
+# than `blockdev`, which needs read on the raw device — denied to regular
+# users not in the `disk` group, so the loop would silently report 0 and
+# drop genuine USB sticks.
 mapfile -t USB_DEVS < <(
   for dev in /sys/block/sd*; do
     [[ -e "$dev/removable" ]] || continue
     [[ "$(cat "$dev/removable" 2>/dev/null)" == "1" ]] || continue
     name=$(basename "$dev")
-    size_bytes=$(blockdev --getsize64 "/dev/$name" 2>/dev/null || echo 0)
+    sectors=$(cat "$dev/size" 2>/dev/null || echo 0)
+    # /sys/block/*/size is always in 512-byte units regardless of physical
+    # block size — see Documentation/ABI/stable/sysfs-block.
+    size_bytes=$(( sectors * 512 ))
     (( size_bytes > 0 )) || continue
     size_gib=$(( size_bytes / 1073741824 ))
     model=$(cat "$dev/device/model" 2>/dev/null | xargs || echo "Unknown")


### PR DESCRIPTION
## Summary

Two installer bugs hit during a real Fedora CoreOS install run, both verified fixed locally before this PR.

### 1. `PUBLIC_DOMAIN: unbound variable` on saved-settings re-runs
The full interactive branch prompts for `PUBLIC_DOMAIN`, but `save_settings` never persisted it and the `USE_SAVED` fast path never re-loaded it. With `set -euo pipefail`, the JSON-build step then died:

```
Settings saved to /home/.../install-settings.env
./install-fedora-coreos.sh: line 1249: PUBLIC_DOMAIN: unbound variable
```

**Fix:** persist in `save_settings`, load in the `USE_SAVED` branch, default-empty at the use site so older saved-settings files (which pre-date the field) keep working.

### 2. USB stick detection silently dropped real devices
The loop used `blockdev --getsize64 /dev/$name`, which needs read on the raw block device — denied to regular users not in the `disk` group. So `blockdev` returned nothing, size was 0, and the `(( > 0 ))` guard rejected the device.

Real-world symptom on a 59.5G stick at `/dev/sdf`:
```
No USB drives detected. You can write manually with:
  sudo dd if=... of=/dev/sdX bs=4M ...
```

**Fix:** read sector count from `/sys/block/$name/size` (always 512-byte units per sysfs ABI, world-readable) and multiply. Same data, no perms needed.

## Test plan
- [x] Re-ran installer with existing saved settings — no more `PUBLIC_DOMAIN` crash
- [x] Dry-ran the patched USB-detection loop on the live system — returns `/dev/sdf 59GiB SD/MMC/MS/MSPRO` where the old loop returned nothing
- [x] `bash -n install-fedora-coreos.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)