### PR TITLE
fix(security): only set Secure cookie flag on HTTPS requests

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { login } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
 import { hashPassword, isPasswordHash, verifyPassword } from '@/lib/auth/password';
 import { checkRateLimit, recordFailure, clearAttempts, clientKeyFromHeaders } from '@/lib/auth/rateLimit';
+import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { logger } from '@/lib/logger';
 
 // Pre-hashed sentinel used when the supplied username does not match. Verifying
@@ -97,7 +98,7 @@ export async function POST(request: NextRequest) {
 
     clearAttempts(clientKey);
     clearAttempts(uKey);
-    await login(username);
+    await login(username, isRequestSecure(request));
     return NextResponse.json({ success: true });
   } catch (error) {
     logger.error('auth:login', 'login crash', error instanceof Error ? error.message : String(error));

--- a/src/app/api/auth/oidc/callback/route.ts
+++ b/src/app/api/auth/oidc/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getConfig, getOidcCallbackUrl } from '@/lib/config';
 import { login } from '@/lib/auth';
+import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { logger } from '@/lib/logger';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
 
@@ -75,7 +76,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Create session using existing login function
-    await login(username);
+    await login(username, isRequestSecure(request));
 
     // Clear the state cookie and redirect to services
     const response = NextResponse.redirect(new URL('/services', request.url));

--- a/src/app/api/auth/oidc/route.ts
+++ b/src/app/api/auth/oidc/route.ts
@@ -1,10 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getConfig } from '@/lib/config';
 import { getOidcCallbackUrl } from '@/lib/config';
+import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { logger } from '@/lib/logger';
 import crypto from 'crypto';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const config = await getConfig();
 
@@ -32,7 +33,7 @@ export async function GET() {
     response.cookies.set('oidc_state', state, {
       httpOnly: true,
       sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
+      secure: isRequestSecure(request),
       maxAge: 600, // 10 minutes
       path: '/',
     });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,7 +11,7 @@ export {
   readSessionCookie,
 } from './auth/session';
 
-export async function login(username: string) {
+export async function login(username: string, secure: boolean) {
   const expires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
   const session = await encryptSession({ user: username, expires });
 
@@ -20,8 +20,10 @@ export async function login(username: string) {
     expires,
     httpOnly: true,
     sameSite: 'lax',
-    // Require HTTPS in production. Dev runs over plain HTTP on localhost.
-    secure: process.env.NODE_ENV === 'production',
+    // `secure` is decided per-request by the caller via isRequestSecure().
+    // Setting it unconditionally in production breaks plain-HTTP LAN installs:
+    // browsers refuse to store Secure cookies that arrive over HTTP.
+    secure,
     path: '/',
   });
 }

--- a/src/lib/auth/requestSecurity.ts
+++ b/src/lib/auth/requestSecurity.ts
@@ -1,0 +1,22 @@
+// Decide whether to set the `Secure` flag on cookies issued for a given
+// request. ServiceBay is commonly self-hosted on a plain-HTTP LAN address
+// (e.g. http://192.168.x.x:5888) — `secure: NODE_ENV === 'production'` is
+// wrong there, because the browser will refuse to *store* the cookie when
+// it arrives over a non-HTTPS connection (RFC 6265bis §5.4). The result is
+// a silent login failure: the server thinks it set a session, the browser
+// drops it, and the next request is unauthenticated.
+//
+// Detect the actual scheme of the inbound request instead. Honour
+// `X-Forwarded-Proto` first so installs behind a TLS-terminating reverse
+// proxy (Nginx Proxy Manager, Caddy, …) still get Secure cookies.
+export function isRequestSecure(request: Request): boolean {
+  const xf = request.headers.get('x-forwarded-proto');
+  if (xf) {
+    return xf.split(',')[0]!.trim().toLowerCase() === 'https';
+  }
+  try {
+    return new URL(request.url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

PR #147 hardened cookies with `secure: process.env.NODE_ENV === 'production'` on the session and OIDC-state cookies. That breaks the most common ServiceBay deployment: a self-hosted LAN install accessed over plain HTTP (`http://192.168.x.x:5888`).

Modern browsers **refuse to store** a `Secure` cookie that arrives over a non-HTTPS connection (RFC 6265bis §5.4). Symptom from a real install:

```
POST /api/auth/login           → 200 OK   Set-Cookie: session=…; Secure
(browser drops the cookie)
GET  /api/services?scope=links → 401 Unauthorized
```

The frontend then bounces back to `/login` with no error shown — login appears to silently fail.

## Fix

Decide `secure` per request: honour `X-Forwarded-Proto` first (TLS-terminating reverse proxies like NPM/Caddy still get Secure cookies), then fall back to the request URL.

- `src/lib/auth/requestSecurity.ts` — new `isRequestSecure(request)` helper
- `src/lib/auth.ts` — `login()` now takes `secure: boolean`
- `src/app/api/auth/login/route.ts` — passes `isRequestSecure(request)`
- `src/app/api/auth/oidc/route.ts` — `oidc_state` cookie uses the helper
- `src/app/api/auth/oidc/callback/route.ts` — passes it through to `login()`

## Workaround for unpatched 3.0.0/3.0.1 installs

```
ssh -L 5888:localhost:5888 admin@<host>
# then open http://localhost:5888
```

Chrome accepts Secure cookies over HTTP when the origin is `localhost`.

## Test plan
- [x] `npx tsc --noEmit` — no new errors from the fix
- [ ] Manual: `http://<lan-ip>:5888` login lands on `/services` and survives a refresh
- [ ] Manual: `https://<public-domain>` (behind NPM) still sets `Secure` cookie
- [ ] Manual: OIDC redirect flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)