### PR TITLE
feat(updates): readable release notes, What's-new modal, email-on-new-release

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -17,7 +17,7 @@ import { createServer } from 'http';
 import { parse } from 'url';
 import next from 'next';
 import { Server } from 'socket.io';
-import { setUpdaterIO } from './src/lib/updater';
+import { setUpdaterIO, scheduleUpdateNotifier } from './src/lib/updater';
 import crypto from 'crypto';
 // Monitoring init moved to Agent logic in V4
 import { HealthService } from './src/lib/health/service';
@@ -363,6 +363,10 @@ app.prepare().then(() => {
 
     // Schedule backup sync based on config
     scheduleBackup();
+
+    // Email the operator when a new ServiceBay release lands. No-op when
+    // email isn't configured. Deduped per-release via config.autoUpdate.
+    scheduleUpdateNotifier();
 
   // Periodic Agent Health Sync (every 30 seconds)
   setInterval(() => {

--- a/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { CheckCircle2, Clock, Download, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
 import type { AppUpdateStatus } from '../helpers';
@@ -239,7 +240,9 @@ export default function UpdatesSection() {
           {appUpdate.hasUpdate && appUpdate.latest && appUpdate.latest.notes && (
             <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
               <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-2">Release Notes</h4>
-              <p className="text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap">{appUpdate.latest.notes}</p>
+              <div className="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300">
+                <ReactMarkdown>{appUpdate.latest.notes}</ReactMarkdown>
+              </div>
             </div>
           )}
         </div>

--- a/src/app/api/help/route.ts
+++ b/src/app/api/help/route.ts
@@ -18,7 +18,13 @@ export async function GET(request: Request) {
   // Prevent directory traversal
   const safeId = id.replace(/[^a-zA-Z0-9-]/g, '');
   const normalizedId = HELP_ALIASES[safeId] ?? safeId;
-  const filePath = path.join(process.cwd(), 'src/content/help', `${normalizedId}.md`);
+
+  // Special-case: CHANGELOG.md lives at the project root (release-please owns
+  // it). Serve it through this endpoint so the existing PluginHelp modal can
+  // render it without a separate API surface.
+  const filePath = normalizedId === 'changelog'
+    ? path.join(process.cwd(), 'CHANGELOG.md')
+    : path.join(process.cwd(), 'src/content/help', `${normalizedId}.md`);
 
   try {
     const content = await fs.readFile(filePath, 'utf-8');

--- a/src/components/PluginHelp.tsx
+++ b/src/components/PluginHelp.tsx
@@ -8,9 +8,13 @@ interface PluginHelpProps {
   helpId: string;
   label?: string;
   className?: string;
+  /** Modal title. Defaults to "Plugin Help". */
+  title?: string;
+  /** Optional icon override for the trigger button. */
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
 }
 
-export default function PluginHelp({ helpId, label, className }: PluginHelpProps) {
+export default function PluginHelp({ helpId, label, className, title = 'Plugin Help', icon: Icon = CircleHelp }: PluginHelpProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -44,9 +48,9 @@ export default function PluginHelp({ helpId, label, className }: PluginHelpProps
         type="button"
         onClick={handleOpen}
         className={buttonClasses}
-        title={label || 'Help'}
+        title={label || title}
       >
-        <CircleHelp size={iconOnly ? 20 : 16} />
+        <Icon size={iconOnly ? 20 : 16} />
         {label && <span>{label}</span>}
       </button>
 
@@ -55,8 +59,8 @@ export default function PluginHelp({ helpId, label, className }: PluginHelpProps
           <div className="bg-white dark:bg-gray-900 rounded-none sm:rounded-2xl shadow-2xl w-full h-full sm:h-auto sm:max-h-[85vh] max-w-none sm:max-w-[1024px] flex flex-col animate-in zoom-in-95 duration-200 border border-gray-200 dark:border-gray-800">
             <div className="flex justify-between items-center p-4 border-b border-gray-100 dark:border-gray-800">
               <h3 className="font-bold text-lg flex items-center gap-2">
-                <CircleHelp size={20} className="text-blue-500" />
-                Plugin Help
+                <Icon size={20} className="text-blue-500" />
+                {title}
               </h3>
               <button
                 onClick={() => setIsOpen(false)}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings, Network, Users, ExternalLink } from 'lucide-react';
+import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings, Network, Users, ExternalLink, Sparkles } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
+import PluginHelp from './PluginHelp';
 import pkg from '../../package.json';
 
 export const plugins = [
@@ -121,7 +122,21 @@ export default function Sidebar() {
             )}
         </div>
 
-        <div className="p-2">
+        <div className="p-2 space-y-1">
+            {/* "What's new" — opens the same modal PluginHelp uses, but loads
+              CHANGELOG.md instead of a per-plugin help file. Available
+              independent of "is there an update pending?". */}
+            <div className={isCollapsed ? 'flex justify-center' : ''}>
+                <PluginHelp
+                    helpId="changelog"
+                    title="What's new in ServiceBay"
+                    icon={Sparkles}
+                    label={isCollapsed ? undefined : "What's new"}
+                    className={isCollapsed
+                        ? 'p-2 hover:bg-gray-200 dark:hover:bg-gray-800 rounded-md text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+                        : 'w-full flex items-center gap-3 px-3 py-3 rounded-md text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors !bg-transparent !border-0 !text-current font-medium'}
+                />
+            </div>
             <a
                 href="https://github.com/mdopp/servicebay"
                 target="_blank"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -106,6 +106,12 @@ export interface AppConfig {
     enabled: boolean;
     schedule: string; // Cron syntax, e.g. "0 0 * * *" for midnight
     channel: 'stable' | 'test' | 'dev';
+    /**
+     * Last version we emailed the operator about. Used to dedupe so the
+     * update notifier sends one email per release, not one per check tick.
+     * Written by the in-process notifier; read on every check.
+     */
+    lastNotifiedVersion?: string;
   };
   registries?: RegistriesSettings;
   externalLinks?: ExternalLink[];

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import semver from 'semver';
 import { Server } from 'socket.io';
 import { getExecutor } from '@/lib/executor';
+import { getConfig, updateConfig } from '@/lib/config';
+import { sendEmailAlert } from '@/lib/email';
+import { logger } from '@/lib/logger';
 
 declare global {
    
@@ -88,6 +91,70 @@ export async function checkForUpdates() {
       notes: latest.body
     }
   };
+}
+
+/**
+ * Check for an update and email the operator if a new version is available.
+ * Deduped via `autoUpdate.lastNotifiedVersion` in config so we send one mail
+ * per release, not one per tick. No-op when email isn't configured/enabled
+ * (sendEmailAlert handles that — we just skip the work).
+ */
+async function notifyOnUpdate(): Promise<void> {
+  try {
+    const config = await getConfig();
+    if (!config.notifications?.email?.enabled) return;
+
+    const status = await checkForUpdates();
+    if (!status.hasUpdate || !status.latest) return;
+
+    const latestVersion = status.latest.version;
+    if (config.autoUpdate.lastNotifiedVersion === latestVersion) return;
+
+    const subject = `ServiceBay update available: ${latestVersion}`;
+    const message = [
+      `A new ServiceBay release is available.`,
+      ``,
+      `  Current: ${status.current}`,
+      `  Latest:  ${latestVersion}`,
+      `  Released: ${status.latest.date}`,
+      `  Details: ${status.latest.url}`,
+      ``,
+      `Release notes:`,
+      status.latest.notes || '(no notes provided)',
+      ``,
+      config.autoUpdate.enabled
+        ? `Auto-update is ON — your appliance will install this on its next scheduled run.`
+        : `Auto-update is OFF — install from Settings → System → Check for Updates when you're ready.`,
+    ].join('\n');
+
+    await sendEmailAlert(subject, message);
+
+    // Persist after the send so a transient SMTP failure doesn't suppress the
+    // next attempt. Worst case: a duplicate email if we crash between send
+    // and persist — preferable to dropping the notification entirely.
+    await updateConfig({
+      autoUpdate: { ...config.autoUpdate, lastNotifiedVersion: latestVersion },
+    });
+
+    logger.info('Updater', `Notified operator about new release ${latestVersion}`);
+  } catch (e) {
+    logger.warn('Updater', `notifyOnUpdate failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+const NOTIFY_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
+const NOTIFY_INITIAL_DELAY_MS = 60 * 1000; // 1 min after boot — let everything settle first
+let notifyTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Kick off the periodic update-availability email notifier. Safe to call
+ * multiple times — second call clears the existing timer first. Idempotent.
+ */
+export function scheduleUpdateNotifier(): void {
+  if (notifyTimer) clearInterval(notifyTimer);
+  setTimeout(() => { void notifyOnUpdate(); }, NOTIFY_INITIAL_DELAY_MS);
+  notifyTimer = setInterval(() => { void notifyOnUpdate(); }, NOTIFY_INTERVAL_MS);
+  logger.info('Updater', `Update-notification poll scheduled every ${NOTIFY_INTERVAL_MS / 3600000}h`);
 }
 
 export async function performUpdate(version: string) {


### PR DESCRIPTION
## Summary

Three small UX wins around versioning that didn't exist before:

### 1. Readable release notes
Release notes in **Settings → Updates** rendered as `whitespace-pre-wrap` plain text — bullet lists and headings showed as literal `*` and `##`. Now rendered through `react-markdown` with `prose` styling. Two-line change.

### 2. "What's new" sidebar entry
Added a `Sparkles`-icon link in the sidebar footer (above "GitHub Repo") that opens a modal showing `CHANGELOG.md`. Reuses the existing `PluginHelp` modal — added optional `title` and `icon` props so it can serve docs and changelog from the same component. Available regardless of update state — the existing Release-Notes panel only appeared when an update was pending, so "what changed in this version?" disappeared the moment you upgraded.

`/api/help/route.ts` special-cases `id=changelog` → `/CHANGELOG.md` from project root. Existing path-traversal guard (only `[a-zA-Z0-9-]` survives) is unchanged.

### 3. Email on new release
`notifyOnUpdate()` in `updater.ts` checks GitHub, dedupes per-version, and uses the existing `sendEmailAlert` SMTP path. Scheduled at boot (`server.ts`, alongside `scheduleBackup()`): one initial check ~60s after boot, then every 6h.

- New `autoUpdate.lastNotifiedVersion?: string` in config persists dedup state across restarts.
- No-op when SMTP isn't configured.
- Errors swallowed and logged at warn level so a transient GitHub/SMTP outage can't crash the server.

## Touched files

- `src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx` — markdown render (#1)
- `src/app/api/help/route.ts` — `id=changelog` → `CHANGELOG.md` (#2)
- `src/components/PluginHelp.tsx` — optional `title` and `icon` props (#2)
- `src/components/Sidebar.tsx` — "What's new" footer entry (#2)
- `src/lib/config.ts` — `autoUpdate.lastNotifiedVersion` (#3)
- `src/lib/updater.ts` — `notifyOnUpdate` + `scheduleUpdateNotifier` (#3)
- `server.ts` — schedule at boot (#3)

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [ ] Manual: `Settings → Updates → Check Now` — release notes render with proper formatting
- [ ] Manual: click "What's new" in sidebar — full CHANGELOG.md opens in modal
- [ ] Manual: configure SMTP, wait for boot or restart — email arrives within ~1 min for any pending newer release
- [ ] Manual: restart again — no duplicate email (dedup via `lastNotifiedVersion`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)