### PR TITLE
docs(mcp): MCP setup guide + Settings → Integrations → MCP Server card

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,31 +101,21 @@ keypair that the in-container agent uses to manage the host.
 ## Programmatic API & MCP
 
 Every UI action has an HTTP equivalent under `/api/`. For LLM-driven
-automation, ServiceBay also exposes a Model Context Protocol server
-at `/mcp` (session-cookie auth — same as the UI).
-
-The MCP server publishes 37 tools across read paths
-(`list_nodes`, `list_services`, `get_container_logs`,
-`get_network_graph`, `get_health_checks`, …) and write paths
-(`start_service`/`stop_service`/`restart_service`, `update_service_yaml`,
+automation, ServiceBay also exposes a [Model Context Protocol](https://modelcontextprotocol.io)
+server at `/mcp` (session-cookie auth — same as the UI), publishing ~37 tools
+across services, containers, proxy, backups, health checks, and config:
+read paths like `list_nodes`, `list_services`, `get_container_logs`,
+`get_network_graph`, `get_health_checks`, …, and write paths like
+`start_service`/`stop_service`/`restart_service`, `update_service_yaml`,
 `add_proxy_route`/`remove_proxy_route`, `run_backup`/`restore_backup`,
 `create_health_check`/`run_check_now`, `get_config`/`update_config`,
-`exec_command`). Sensitive fields (`auth.passwordHash`,
-`oidc.clientSecret`, SMTP/NPM passwords) are redacted in `get_config`
-and write-allowlisted in `update_config`.
+`exec_command`. Sensitive fields (`auth.passwordHash`, `oidc.clientSecret`,
+SMTP/NPM passwords) are redacted in `get_config` and write-allowlisted in
+`update_config`.
 
-Example client config (Claude Desktop / Claude Code):
-
-```json
-{
-  "mcpServers": {
-    "servicebay": {
-      "url": "http://localhost:3000/mcp",
-      "headers": { "Cookie": "session=YOUR_SESSION_COOKIE" }
-    }
-  }
-}
-```
+**Setup walk-through with `claude mcp add` syntax, env-var refresh, and
+troubleshooting:** [docs/MCP.md](docs/MCP.md). The same instructions are
+also linked from **Settings → Integrations → MCP Server** in the running UI.
 
 ## Troubleshooting
 
@@ -179,6 +169,7 @@ Settings → System → Check for Updates → Update. Your service containers ar
 |----------|---------|
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System design, data flow, API reference, testing strategy, frontend design |
 | [docs/INSTALLATION.md](docs/INSTALLATION.md) | Build pipeline, startup procedure, first-boot sequence, system modifications |
+| [docs/MCP.md](docs/MCP.md) | Connect Claude Code / Claude Desktop / any MCP client to your ServiceBay instance |
 | [CHANGELOG.md](CHANGELOG.md) | Version history |
 
 ## Comparison

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,164 @@
+# Connecting an LLM to ServiceBay (MCP)
+
+ServiceBay exposes a [Model Context Protocol](https://modelcontextprotocol.io)
+server at `/mcp` so an AI assistant — Claude Code, Claude Desktop, or anything
+else that speaks MCP — can drive your homelab directly. Available tools include
+`list_services`, `start_service` / `stop_service` / `restart_service`,
+`update_service_yaml`, `add_proxy_route`, `run_backup`, `get_health_checks`,
+`exec_command`, and ~30 others. Sensitive fields (`auth.passwordHash`,
+SMTP/OIDC secrets) are redacted on read and write-allowlisted.
+
+## Quick start (Claude Code)
+
+> **Prereq:** you can log into the ServiceBay UI in your browser.
+
+### 1. Grab a session cookie
+
+ServiceBay's `/mcp` endpoint authenticates the same way the web UI does — a
+session-cookie JWT. The cookie is `HttpOnly`, so you have to copy it via
+DevTools (one-time):
+
+1. Open the ServiceBay UI in Chrome/Firefox and log in.
+2. Open DevTools → **Application** → **Storage → Cookies → `http://your-host:5888`**.
+3. Copy the value of the `session` cookie. It looks like
+   `eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWRtaW4i…` (JWT).
+
+### 2. Register with Claude Code
+
+```bash
+claude mcp add --transport http servicebay \
+  http://192.168.x.x:5888/mcp \
+  --header "Cookie: session=PASTE_THE_JWT_HERE"
+```
+
+All flags must come **before** the server name (`servicebay`). For multiple
+headers, repeat `--header`.
+
+### 3. Verify
+
+```bash
+claude mcp list                # should include "servicebay: http://..."
+claude mcp get servicebay      # full details
+```
+
+Inside Claude Code, run `/mcp` to see the connection status and tool count.
+
+### 4. Remove (if needed)
+
+```bash
+claude mcp remove servicebay
+```
+
+## Manual config (any MCP client)
+
+Equivalent JSON for `~/.claude.json` (user scope), `.mcp.json` (project scope),
+or Claude Desktop's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "servicebay": {
+      "type": "http",
+      "url": "http://192.168.x.x:5888/mcp",
+      "headers": {
+        "Cookie": "session=PASTE_THE_JWT_HERE"
+      }
+    }
+  }
+}
+```
+
+## Sessions expire after 24 hours
+
+The session JWT is short-lived. When it expires the MCP server returns 401 and
+you'll need to grab a fresh cookie from the browser. Two ways to soften this:
+
+### Option A: env var
+
+Claude Code (v2.1.121+) supports `${VAR}` expansion in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "servicebay": {
+      "type": "http",
+      "url": "http://192.168.x.x:5888/mcp",
+      "headers": {
+        "Cookie": "session=${SERVICEBAY_JWT}"
+      }
+    }
+  }
+}
+```
+
+Then `export SERVICEBAY_JWT=…` (or set it in your shell rc) and restart
+Claude Code. Refreshing the JWT becomes a one-line `export`, no JSON edit.
+
+### Option B: dynamic refresh script
+
+```json
+{
+  "mcpServers": {
+    "servicebay": {
+      "type": "http",
+      "url": "http://192.168.x.x:5888/mcp",
+      "headersHelper": "/usr/local/bin/get-servicebay-jwt.sh"
+    }
+  }
+}
+```
+
+`get-servicebay-jwt.sh` must print a JSON object to stdout, e.g.
+`{"Cookie": "session=…"}`. Useful if you can wrap a real login flow.
+
+## Connection notes
+
+- **HTTPS:** if you're behind a TLS-terminating reverse proxy (Nginx Proxy
+  Manager, Caddy, …), use the `https://` URL — the session cookie is set
+  `Secure` in that case and only travels over TLS.
+- **Plain HTTP on LAN:** works fine. Just make sure the URL in your MCP config
+  matches the origin you logged into in the browser (otherwise the JWT is for
+  a different origin and won't be valid here).
+- **SSH tunnel from a remote workstation:**
+  ```bash
+  ssh -L 5888:localhost:5888 admin@your-servicebay-host
+  ```
+  Then point Claude Code at `http://localhost:5888/mcp`. Many browsers and
+  clients treat `localhost` as trustworthy, sidestepping cookie/CORS quirks.
+
+## What can the LLM actually do?
+
+A non-exhaustive list — call `claude mcp get servicebay` (or `/mcp` inside
+Claude Code) to see the live tool registry on your version.
+
+| Category | Tools |
+|----------|-------|
+| Services | `list_services`, `start_service`, `stop_service`, `restart_service`, `deploy_service`, `update_service_yaml`, `delete_service`, `rename_service` |
+| Containers | `list_containers`, `get_container_logs`, `get_podman_logs` |
+| Health | `get_health_checks`, `create_health_check`, `delete_health_check`, `run_check_now` |
+| Proxy | `get_proxy_routes`, `add_proxy_route`, `remove_proxy_route` |
+| Backups | `list_backups`, `run_backup`, `restore_backup` |
+| System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command` |
+
+Sensitive config fields (`auth.passwordHash`, `oidc.clientSecret`, SMTP
+passwords) are redacted from `get_config` and write-allowlisted in
+`update_config`.
+
+## Troubleshooting
+
+- **`401 Unauthorized` on first use** — the JWT pasted into your config is
+  expired or for a different host. Grab a fresh one from DevTools.
+- **`401 Unauthorized` after working for a while** — the JWT expired (24h).
+  Refresh it. See the env-var option above to make this less painful.
+- **Custom-header bug ([upstream issue #29562](https://github.com/anthropics/claude-code/issues/29562))**
+  — there's a known Claude Code edge case where headers aren't sent during
+  the initial MCP session-establishment handshake, surfacing as an instant
+  401. Workaround: `headersHelper` script (Option B above).
+- **`405 Method not allowed`** — only `POST /mcp` is implemented. If you see
+  this, your client is using GET or another verb.
+
+## Future work
+
+A first-class API-token surface (long-lived, revocable, scoped) is on the
+roadmap so MCP clients don't have to scrape a browser cookie. Until that
+lands, the env-var pattern above is the recommended path.

--- a/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bot, Check, Copy } from 'lucide-react';
+import PluginHelp from '@/components/PluginHelp';
+
+export default function McpSection() {
+  const [mcpUrl, setMcpUrl] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    // Read window.location after mount to avoid SSR/hydration mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMcpUrl(`${window.location.origin}/mcp`);
+  }, []);
+
+  const handleCopy = async () => {
+    if (!mcpUrl) return;
+    try {
+      await navigator.clipboard.writeText(mcpUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API can be blocked on insecure origins; user can select & copy manually
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
+            <Bot size={20} className="text-purple-600 dark:text-purple-400" />
+          </div>
+          <div>
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white">MCP Server</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Let an AI assistant (Claude Code, Claude Desktop, …) drive ServiceBay through the Model Context Protocol.
+            </p>
+          </div>
+        </div>
+        <PluginHelp
+          helpId="mcp"
+          title="Connecting an LLM via MCP"
+          label="How to connect"
+        />
+      </div>
+
+      <div className="mt-4">
+        <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
+          MCP endpoint
+        </label>
+        <div className="flex items-stretch gap-2">
+          <input
+            type="text"
+            readOnly
+            value={mcpUrl}
+            onFocus={(e) => e.currentTarget.select()}
+            className="flex-1 font-mono text-sm px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+          />
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-2 text-sm"
+            title="Copy URL"
+          >
+            {copied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          Auth uses the same session cookie as this UI. Click <span className="font-medium">How to connect</span> for the full setup walk-through.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import EmailNotificationsSection from '../_lib/sections/EmailNotificationsSection';
+import McpSection from '../_lib/sections/McpSection';
 import ReverseProxySection from '../_lib/sections/ReverseProxySection';
 import TemplateRegistriesSection from '../_lib/sections/TemplateRegistriesSection';
 import TemplateVariablesSection from '../_lib/sections/TemplateVariablesSection';
@@ -10,6 +11,7 @@ export default function IntegrationsSettingsPage() {
     <>
       <ReverseProxySection />
       <EmailNotificationsSection />
+      <McpSection />
       <TemplateRegistriesSection />
       <TemplateVariablesSection />
     </>

--- a/src/content/help/mcp.md
+++ b/src/content/help/mcp.md
@@ -1,0 +1,72 @@
+# Connecting an LLM (MCP)
+
+ServiceBay exposes a Model Context Protocol (MCP) server at `/mcp` so an AI
+assistant — Claude Code, Claude Desktop, or any MCP-aware client — can drive
+your homelab directly. Tools include start/stop/restart services, edit Quadlet
+YAML, manage proxy routes, run backups, configure health checks, and more.
+
+## Setup (Claude Code)
+
+### 1. Copy your session cookie
+
+The MCP endpoint uses the same auth as this UI. The session cookie is
+`HttpOnly`, so it has to come from DevTools — one-time:
+
+1. Open DevTools (F12) on this tab.
+2. **Application → Storage → Cookies → (your ServiceBay origin)**.
+3. Copy the value of the `session` cookie. It looks like
+   `eyJhbGciOiJIUzI1NiJ9.eyJ1c2Vy…`.
+
+### 2. Register the server
+
+```bash
+claude mcp add --transport http servicebay \
+  <YOUR_SERVICEBAY_URL>/mcp \
+  --header "Cookie: session=PASTE_THE_JWT_HERE"
+```
+
+Replace `<YOUR_SERVICEBAY_URL>` with the URL you used to log in (the same one
+shown in the **MCP Server** card on Settings → Integrations).
+
+### 3. Verify
+
+```bash
+claude mcp list           # should list "servicebay"
+claude mcp get servicebay # full status + tool count
+```
+
+Inside Claude Code, run `/mcp` to confirm the connection.
+
+## Manual JSON config
+
+For Claude Desktop or `~/.claude.json` / `.mcp.json` direct edits:
+
+```json
+{
+  "mcpServers": {
+    "servicebay": {
+      "type": "http",
+      "url": "<YOUR_SERVICEBAY_URL>/mcp",
+      "headers": { "Cookie": "session=PASTE_THE_JWT_HERE" }
+    }
+  }
+}
+```
+
+## Heads-ups
+
+- **The session JWT expires after 24h.** When it does, the MCP server returns
+  `401` and you need to copy a fresh cookie. Use a `${SERVICEBAY_JWT}` env-var
+  in `.mcp.json` so refreshing is one `export`.
+- **Use the URL you logged into.** A JWT issued for `http://192.168.x.x:5888`
+  isn't valid for `http://localhost:5888`. If you log in via an SSH tunnel,
+  use the `localhost` URL in your MCP config.
+- **TLS:** if you reach this UI via `https://…`, use that URL. The cookie is
+  marked `Secure` and won't travel over plain HTTP.
+
+## What's documented in full
+
+The complete reference (env-var setup, dynamic refresh scripts, full tool
+list, troubleshooting) lives at
+[`docs/MCP.md`](https://github.com/mdopp/servicebay/blob/main/docs/MCP.md)
+in the repo.


### PR DESCRIPTION
## Summary

The MCP endpoint has been live since 2.x but was barely documented — the README had a single config blob and the appliance UI had no surface for "how do I point Claude Code at this thing?". This PR fills the gap.

### 1. `docs/MCP.md` — canonical guide
Full walk-through: extracting the session JWT from DevTools (HttpOnly so DevTools is the only path today), `claude mcp add` syntax with `--transport http` + `--header`, equivalent JSON for `~/.claude.json` / `.mcp.json` / Claude Desktop, env-var (`${SERVICEBAY_JWT}`) and `headersHelper` patterns for the 24h expiry pain point, troubleshooting, and a tool catalog by category.

### 2. `src/content/help/mcp.md` — in-frontend version
Slimmer guide rendered through the existing `/api/help?id=mcp` endpoint via the `PluginHelp` modal. Linked from the Settings card.

### 3. Settings → Integrations → **MCP Server** card
New `McpSection.tsx`:
- Shows the live MCP URL computed from `window.location.origin` (no guessing what to paste).
- Copy-to-clipboard button (graceful fallback when Clipboard API is blocked on insecure origins).
- **How to connect** button opens the help modal with the full guide.

README's MCP section now points at `docs/MCP.md` so canonical instructions live in one place.

## Open question we deliberately documented as future work
MCP auth is currently session-cookie-only (24h JWT, scraped from DevTools). A first-class API-token surface (long-lived, revocable, scoped) would be the right next step but is out of scope for this PR. Documented under "Future work" in `docs/MCP.md`.

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [x] ESLint clean (pre-commit pass)
- [ ] Manual: open Settings → Integrations — MCP Server card visible, URL matches the address bar
- [ ] Manual: click **Copy** — URL on clipboard, button shows ✓ briefly
- [ ] Manual: click **How to connect** — modal opens with `mcp.md` rendered as Markdown
- [ ] Manual: follow `docs/MCP.md` step-by-step, run `claude mcp list` in Claude Code, see `servicebay` connected with ~37 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)