### PR TITLE
fix(installer): bootstrap NPM admin credentials on first install

### DIFF
--- a/src/app/api/system/nginx/bootstrap/route.ts
+++ b/src/app/api/system/nginx/bootstrap/route.ts
@@ -1,0 +1,196 @@
+import { NextResponse } from 'next/server';
+import { getConfig, updateConfig } from '@/lib/config';
+import { DigitalTwinStore } from '@/lib/store/twin';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { logger } from '@/lib/logger';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Bootstrap a fresh Nginx Proxy Manager instance: log in with NPM's built-in
+ * default credentials (admin@example.com / changeme), update user #1 to the
+ * caller-supplied email + password, then persist the new credentials so the
+ * rest of ServiceBay (proxy-host creation, future syncs) can authenticate.
+ *
+ * Why this exists: NPM does not read env vars for admin credentials. It ships
+ * with the well-known defaults and requires a one-time API login + password
+ * change to lock them down. The OnboardingWizard previously skipped this
+ * step, persisting the wizard's *aspirational* random credentials in
+ * ServiceBay's config without ever telling NPM about them. Subsequent proxy
+ * calls then 401'd and surfaced the "NPM Admin Login" prompt to the user.
+ *
+ * Request body:
+ *   { node?: string; email: string; password: string; fullName?: string }
+ *
+ * Response:
+ *   { ok: true,  bootstrapped: true }                     – defaults applied
+ *   { ok: true,  bootstrapped: false, reason: 'already_using_target' }
+ *                                                          – idempotent retry
+ *   { ok: true,  bootstrapped: false, reason: 'defaults_rejected' }
+ *                                                          – NPM is locked to
+ *                                                            something else
+ *                                                            (stale data
+ *                                                            volume) – user
+ *                                                            must enter creds
+ *   { ok: false, error: '…', status: <http> }              – fatal
+ */
+const NPM_DEFAULT_EMAIL = 'admin@example.com';
+const NPM_DEFAULT_PASSWORD = 'changeme';
+
+interface NpmResolution {
+  apiUrl: string;
+  nodeName: string;
+}
+
+function getNodeIp(nodeName: string, twinStore: DigitalTwinStore): string {
+  const twin = twinStore.nodes[nodeName];
+  if (twin?.nodeIPs?.length) {
+    const lanIp = twin.nodeIPs.find(ip => !ip.startsWith('127.'));
+    if (lanIp) return lanIp;
+    return twin.nodeIPs[0];
+  }
+  return '127.0.0.1';
+}
+
+async function resolveNpm(nodeHint?: string): Promise<NpmResolution | null> {
+  const twinStore = DigitalTwinStore.getInstance();
+  const nodeNames = nodeHint ? [nodeHint] : Object.keys(twinStore.nodes);
+  if (nodeNames.length === 0) nodeNames.push('Local');
+
+  for (const nodeName of nodeNames) {
+    const services = await ServiceManager.listServices(nodeName);
+    const nginxService = services.find(s =>
+      s.name === 'nginx-web' ||
+      (s.name.includes('nginx') && !s.name.startsWith('install-'))
+    );
+    if (!nginxService?.active) continue;
+
+    const svc = nginxService as { ports?: { containerPort?: number; hostPort?: number }[] };
+    const adminMapping = svc.ports?.find(p => p.containerPort === 81);
+    let adminPort = adminMapping?.hostPort?.toString();
+    if (!adminPort) {
+      const config = await getConfig();
+      adminPort = config.templateSettings?.NGINX_ADMIN_PORT || '81';
+    }
+    const apiHost = nodeName === 'Local' ? '127.0.0.1' : getNodeIp(nodeName, twinStore);
+    return { apiUrl: `http://${apiHost}:${adminPort}`, nodeName };
+  }
+  return null;
+}
+
+async function npmLogin(baseUrl: string, identity: string, secret: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identity, secret }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data.token === 'string' ? data.token : null;
+  } catch {
+    return null;
+  }
+}
+
+async function npmUpdateUser(baseUrl: string, token: string, payload: Record<string, unknown>): Promise<void> {
+  const res = await fetch(`${baseUrl}/api/users/1`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`NPM PUT /api/users/1 failed (${res.status}): ${body || 'no body'}`);
+  }
+}
+
+async function npmUpdatePassword(baseUrl: string, token: string, current: string, secret: string): Promise<void> {
+  const res = await fetch(`${baseUrl}/api/users/1/auth`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    body: JSON.stringify({ type: 'password', current, secret }),
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`NPM PUT /api/users/1/auth failed (${res.status}): ${body || 'no body'}`);
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const body = await request.json() as {
+      node?: string;
+      email?: string;
+      password?: string;
+      fullName?: string;
+    };
+    const { node, email, password, fullName } = body;
+
+    if (typeof email !== 'string' || !email || typeof password !== 'string' || !password) {
+      return NextResponse.json({ ok: false, error: 'email and password are required' }, { status: 400 });
+    }
+
+    const npm = await resolveNpm(node);
+    if (!npm) {
+      return NextResponse.json({ ok: false, error: 'Nginx Proxy Manager not found or not running' }, { status: 404 });
+    }
+
+    // Idempotency: if the target credentials already authenticate, NPM is
+    // already on these creds — just persist on our side and return.
+    const targetToken = await npmLogin(npm.apiUrl, email, password);
+    if (targetToken) {
+      const config = await getConfig();
+      await updateConfig({ reverseProxy: { ...config.reverseProxy, npm: { email, password } } });
+      return NextResponse.json({ ok: true, bootstrapped: false, reason: 'already_using_target' });
+    }
+
+    // Defaults — only valid on a brand-new NPM data volume. If NPM was
+    // previously bootstrapped with a different password, this returns null
+    // and we surface that to the caller so the user can intervene.
+    const defaultsToken = await npmLogin(npm.apiUrl, NPM_DEFAULT_EMAIL, NPM_DEFAULT_PASSWORD);
+    if (!defaultsToken) {
+      return NextResponse.json({ ok: true, bootstrapped: false, reason: 'defaults_rejected' });
+    }
+
+    // Order matters: change user fields first (email is the login identity),
+    // then change the password using the *defaults* `current`. NPM rotates
+    // the token on email change, but the existing token stays valid for this
+    // request stream — the next /api/tokens call will get a new one.
+    const name = fullName || email.split('@')[0] || 'admin';
+    await npmUpdateUser(npm.apiUrl, defaultsToken, {
+      name,
+      nickname: name,
+      email,
+      roles: ['admin'],
+      is_disabled: false,
+    });
+    await npmUpdatePassword(npm.apiUrl, defaultsToken, NPM_DEFAULT_PASSWORD, password);
+
+    // Verify by re-logging in with the new creds before persisting. If this
+    // fails the NPM bootstrap is in a bad state and the user needs to know.
+    const verifyToken = await npmLogin(npm.apiUrl, email, password);
+    if (!verifyToken) {
+      return NextResponse.json({
+        ok: false,
+        error: 'NPM accepted the credential change but rejected the new credentials on re-login',
+      }, { status: 500 });
+    }
+
+    const config = await getConfig();
+    await updateConfig({ reverseProxy: { ...config.reverseProxy, npm: { email, password } } });
+
+    logger.info('npm:bootstrap', `NPM admin updated to ${email} on node ${npm.nodeName}`);
+    return NextResponse.json({ ok: true, bootstrapped: true });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:nginx:bootstrap', status: 500 });
+  }
+}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1277,9 +1277,9 @@ export default function OnboardingWizard() {
                             </div>
                             {npmCredPrompt && (
                                 <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
-                                    <p className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">NPM Admin Login</p>
+                                    <p className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">NPM admin login required</p>
                                     <p className="text-xs text-amber-700 dark:text-amber-300 mb-3">
-                                        The default NPM password was changed. Enter your NPM admin credentials to configure proxy routes.
+                                        We pre-filled the credentials this wizard generated, but Nginx Proxy Manager rejected them — usually because the data volume on this host carries an admin password from a previous install. Either click <span className="font-semibold">Authenticate &amp; Retry</span> with the values below, or paste the existing NPM admin password if you remember it. Skip to configure proxy routes manually later.
                                     </p>
                                     <div className="space-y-2">
                                         <input

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -293,21 +293,52 @@ function logNavidromeCredentials(opts: { variables: StackVariable[]; onLog: (msg
   opts.onLog(`🔑 Navidrome admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Subsonic clients (Symfonium etc.) use the same credentials.`);
 }
 
-/** Persist NPM admin credentials so subsequent proxy-host operations
- *  authenticate without prompting. */
-async function persistNpmCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {
+/** Bootstrap a freshly-deployed NPM: log it in with built-in defaults
+ *  (admin@example.com / changeme), apply the wizard's chosen email + password
+ *  via NPM's REST API, then persist them on our side. NPM does not read env
+ *  vars for admin credentials — without this step it stays on defaults forever
+ *  and our subsequent proxy-host calls authenticate against credentials NPM
+ *  has never heard of, surfacing the dreaded "NPM Admin Login" prompt.
+ *
+ *  Idempotent: if NPM already accepts the target credentials, the endpoint
+ *  short-circuits to "already_using_target" and we just persist locally.
+ *  If NPM is locked to something else (stale data volume), we report the
+ *  problem so the caller can hand control to the user. */
+async function bootstrapNpmAdmin(opts: {
+  variables: StackVariable[];
+  node?: string;
+  onLog: (msg: string) => void;
+}): Promise<'ok' | 'needs_credentials' | 'skipped'> {
   const email = opts.variables.find(v => v.name === 'NGINX_ADMIN_EMAIL')?.value;
   const password = opts.variables.find(v => v.name === 'NGINX_ADMIN_PASSWORD')?.value;
-  if (!email || !password) return;
+  const fullName = opts.variables.find(v => v.name === 'NGINX_ADMIN_NAME')?.value;
+  if (!email || !password) return 'skipped';
+
   try {
-    await fetch('/api/system/nginx/credentials', {
+    const res = await fetch('/api/system/nginx/bootstrap', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email, password, fullName, node: opts.node }),
     });
-    opts.onLog('✅ Saved NPM admin credentials for auto-sync.');
-  } catch {
-    opts.onLog('⚠️ Could not persist NPM credentials — set them later in Settings → Integrations.');
+    const data = await res.json().catch(() => ({} as Record<string, unknown>));
+
+    if (res.ok && data.ok && data.bootstrapped === true) {
+      opts.onLog(`✅ NPM admin set to ${email} (default credentials disabled).`);
+      return 'ok';
+    }
+    if (res.ok && data.ok && data.reason === 'already_using_target') {
+      opts.onLog('✅ NPM admin already on the wizard credentials — nothing to do.');
+      return 'ok';
+    }
+    if (res.ok && data.ok && data.reason === 'defaults_rejected') {
+      opts.onLog('⚠️ NPM is not on default credentials (stale data volume from a previous install?). You will need to enter the existing NPM admin password manually.');
+      return 'needs_credentials';
+    }
+    opts.onLog(`⚠️ NPM bootstrap failed: ${typeof data.error === 'string' ? data.error : `HTTP ${res.status}`}. You may need to set NPM credentials manually in Settings → Integrations.`);
+    return 'needs_credentials';
+  } catch (e) {
+    opts.onLog(`⚠️ Could not reach the NPM bootstrap endpoint: ${e instanceof Error ? e.message : String(e)}`);
+    return 'needs_credentials';
   }
 }
 
@@ -504,8 +535,18 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   // Surface OIDC client secrets (one log line per service that needs UI
   // configuration or has an env-flag to flip).
   logOidcClientSecrets({ selected, variables, onLog });
+  // NPM bootstrap is best-effort: if it fails we still want to run the rest
+  // of the post-install pipeline (LLDAP seeding, OIDC client creation, proxy
+  // routes) — the user can finish the NPM piece via the credentials prompt.
+  let npmBootstrap: 'ok' | 'needs_credentials' | 'skipped' = 'skipped';
   if (isSelected('nginx-web')) {
-    await persistNpmCredentials({ variables, onLog });
+    // NPM cold-starts the SQLite schema after the container is ready, so the
+    // very first /api/tokens call sometimes 502s. Wait until it's reachable
+    // before bootstrapping; configureProxyRoutes below would do the same wait
+    // anyway, just less informatively.
+    onLog('Waiting for Nginx Proxy Manager to start (image pull / DB schema init can take a while)...');
+    await waitForNpm(node, onLog);
+    npmBootstrap = await bootstrapNpmAdmin({ variables, node, onLog });
   }
 
   // Kick off all "wait + initialize" tasks in the background. Their logs
@@ -524,7 +565,15 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
     void seedFileBrowserAdmin({ variables, node, onLog }).catch(() => { /* logged inline */ });
   }
 
-  const proxyResult = await configureProxyRoutes({ variables, node, onLog });
+  // If we just bootstrapped NPM (or determined it's locked to other creds),
+  // we already waited for it to be reachable — skip the second wait inside
+  // configureProxyRoutes so the install log doesn't repeat the heartbeat.
+  const proxyResult = await configureProxyRoutes({
+    variables,
+    node,
+    onLog,
+    skipWait: npmBootstrap !== 'skipped',
+  });
 
   // Final banner — single block where every credential the user might
   // have to remember is collected. Same data is exposed to the wizard's


### PR DESCRIPTION
## Summary

Real fix for the "NPM Admin Login" prompt that fired on every fresh install, asking the user to type credentials the wizard had just generated and shown in the install log right above.

### Root cause
NPM doesn't read env vars for admin credentials. It ships with the well-known defaults (`admin@example.com` / `changeme`) and requires a one-time API login + password change to lock them down. The OnboardingWizard generated random `NGINX_ADMIN_EMAIL` + `NGINX_ADMIN_PASSWORD`, deployed NPM, and persisted those values in `config.reverseProxy.npm` — but **never told NPM about them**. The next proxy-host call then 401'd (`getNpmToken` tried `stored=wizard-random` and `defaults=changeme`, both rejected).

### Fix

1. **`POST /api/system/nginx/bootstrap`** — new backend endpoint:
   - Idempotency check: try the target credentials first → if they already work, just persist locally and return `already_using_target`.
   - Login with `admin@example.com / changeme` → if rejected, return `defaults_rejected` without persisting (NPM is locked to something else, e.g. stale data volume).
   - `PUT /api/users/1` with email + name + admin role.
   - `PUT /api/users/1/auth` with `current=changeme`, `secret=<new>`.
   - Verify with re-login.
   - Persist to `config.reverseProxy.npm`.

2. **`runPostInstall` wires it in** — waits for NPM, calls bootstrap, then runs `configureProxyRoutes` (which now authenticates cleanly because NPM truly has the wizard's creds). The proxy step skips its own wait since we just did it.

3. **Reworded the fallback prompt** for the rare case it still fires (stale data volume from a previous install). The old copy said "the default NPM password was changed", which was misleading since the wizard had never tried to change it.

### Behavior

| Scenario | Old behavior | New behavior |
|---|---|---|
| Fresh install, fresh data volume | Prompt fires asking user to type the wizard's pre-filled credentials | NPM is bootstrapped with wizard creds; no prompt |
| Reinstall with stale `/mnt/data` from previous boot | Same prompt, no explanation | Honest message about data-volume reuse, pre-filled retry, Skip option |
| Wizard re-runs on already-bootstrapped NPM | Tries wizard creds → 401 → prompt | Idempotency short-circuit, just persists |

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [ ] Fresh-install dry-run: install nginx-web → no "NPM Admin Login" prompt → proxy routes created → `Settings → Integrations → Reverse Proxy` shows configured email
- [ ] Login to NPM admin UI with the wizard-generated credentials → works
- [ ] Re-run wizard on the same host → `already_using_target` short-circuit, no prompt
- [ ] Simulated stale-data case (manually rotate NPM admin password) → wizard surfaces the new prompt copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)