### PR TITLE
fix(templates,network): rootless UID mapping in filebrowser/syncthing + NPM self-reference on network map

### DIFF
--- a/src/lib/network/service.ts
+++ b/src/lib/network/service.ts
@@ -1409,6 +1409,19 @@ export class NetworkService {
                             if (!targetId && proxyService?.ports?.some(p => p.hostPort === targetPort)) {
                                 targetId = prefix(`service-${proxyService.name}`);
                             }
+                            // NPM's own nginx config has server blocks that proxy_pass to
+                            // 127.0.0.1:<internal-port> for the admin UI backend (port 3000
+                            // by default). The internal port isn't published on the host, so
+                            // the previous check above never matches. Since these locations
+                            // are *inside* nginx-web's own config — `proxyService` IS the
+                            // emitter — attribute the edge back to nginx-web rather than
+                            // inventing a virtual "Local Service :3000" ghost node.
+                            if (!targetId && proxyService) {
+                                const isLoopback = ['localhost', '127.0.0.1', '::1'].includes(targetHost);
+                                if (isLoopback) {
+                                    targetId = prefix(`service-${proxyService.name}`);
+                                }
+                            }
                         }
 
                         // Fallback to Pod if no container found but we have a pod

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -12,9 +12,16 @@ spec:
   # 1. Syncthing — Bidirectional folder sync (Android & Windows apps)
   - name: syncthing
     image: docker.io/syncthing/syncthing:latest
+    # Run as container UID 0 so rootless podman's user-namespace maps the
+    # process to the host user that owns the hostPath bind dir. Setting
+    # runAsUser: 1000 here was the bug — in rootless mode that maps to a
+    # sub-UID (~100999), not host uid 1000, so the syncthing process
+    # couldn't `chmod /var/syncthing/config` or write `cert.pem` and
+    # crashed in a restart loop. There's no security regression; rootless
+    # "root" is already the unprivileged host user.
     securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
+      runAsUser: 0
+      runAsGroup: 0
     env:
       - name: STGUIADDRESS
         value: "0.0.0.0:8384"

--- a/templates/filebrowser/template.yml
+++ b/templates/filebrowser/template.yml
@@ -12,6 +12,17 @@ spec:
   containers:
   - name: filebrowser
     image: docker.io/filebrowser/filebrowser:latest
+    # Run as container UID 0. Under rootless podman that maps to the host
+    # user running podman (e.g. `core`/uid 1000), which owns the hostPath
+    # dirs we mount below. Without this override the filebrowser image's
+    # default non-root user maps to a sub-UID that has no write access on
+    # the host directories, causing the entrypoint's seed-config `cp` to
+    # fail with "Permission denied" in a tight restart loop. There's no
+    # security regression — rootless containers' "root" is already the
+    # unprivileged host user.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
     # Bind to loopback only — Authelia forward-auth at the NPM layer is
     # the gate. Direct host-IP access on this port is intentionally
     # unreachable so a misconfigured proxy can't accidentally expose an


### PR DESCRIPTION
## Summary

Three fixes that all surface on a fresh install — discovered via live MCP debugging on the user's 3.1.1 appliance.

### 1. `templates/filebrowser/template.yml` — `runAsUser: 0`
Filebrowser pod was crash-looping with:
```
cp: can't create '/config/settings.json': Permission denied
```
The filebrowser image's default non-root user maps to a sub-UID (~100999) under rootless podman, but the `hostPath` bind dirs are owned by the host user running podman (uid 1000 / `core`). Forcing container UID 0 maps it back to host uid 1000 → matches dir ownership.

### 2. `templates/file-share/template.yml` — `runAsUser` 1000 → 0 (syncthing)
Same root cause:
```
WRN Failed to correct directory permissions (error="chmod /var/syncthing/config: operation not permitted")
ERR Failed to load/generate certificate (error="save cert: open /var/syncthing/config/cert.pem: permission denied")
```
The manifest pinned syncthing to in-container uid 1000, which under rootless maps to host sub-uid ~100999 (not 1000). Restart-looped forever.

**Why `runAsUser: 0` is safe under rootless podman:** the container's "root" *is* the unprivileged host user. No security regression vs. running as in-container 1000.

### 3. `src/lib/network/service.ts` — NPM admin self-reference
NPM's own nginx config has a server block that `proxy_pass`es to `127.0.0.1:3000` (NPM's admin UI backend). The existing match in `service.ts:1409` only fired when `targetPort` was an **externally published** port — internal-only 3000 never matched, so the network map drew a `Local Service :3000` virtual ghost forever. Now: any loopback target encountered while parsing `proxyService`'s own config attributes the edge back to `nginx-web` itself.

## Why bundled
All three were found live via `mcp__servicebay__get_container_logs` + `exec_command` on the same install. User intends to reinstall the appliance from the next published image, so packaging them as one release minimizes the rebuild cost.

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [ ] Re-run `install-fedora-coreos.sh`, install file-share + filebrowser stacks
- [ ] Confirm `podman ps` shows both `filebrowser-filebrowser` and `file-share-syncthing` running (not in restart loop)
- [ ] Confirm bind dirs `/mnt/data/stacks/filebrowser/{config,db}` and `/mnt/data/stacks/file-share/{data,syncthing}` exist and have files written by the apps
- [ ] Open the Network Map → `Local Service :3000` ghost no longer appears; nginx-web now has a self-loop edge for the admin UI route

🤖 Generated with [Claude Code](https://claude.com/claude-code)