### PR TITLE
fix(templates): radicale entrypoint chain + filebrowser containerPort

### DIFF
--- a/templates/filebrowser/template.yml
+++ b/templates/filebrowser/template.yml
@@ -33,6 +33,12 @@ spec:
       - "--root=/srv"
       - "--address=127.0.0.1"
       - "--port={{FILEBROWSER_PORT}}"
+    # Declare the listening port so the agent surfaces it in the service's
+    # `ports[]` and the network map can match the proxy_pass route to this
+    # service. Host network = the containerPort is also the host port.
+    # Without this the `servicebay.ports` annotation alone is decorative.
+    ports:
+      - containerPort: {{FILEBROWSER_PORT}}
     volumeMounts:
       - mountPath: /srv
         name: shared-data

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -12,6 +12,19 @@ spec:
   containers:
   - name: radicale
     image: docker.io/tomsquest/docker-radicale:latest
+    # The image's ENTRYPOINT is `["dumb-init", "--"]` and its CMD is
+    # `["radicale"]`. K8s `args:` replaces CMD only — without an explicit
+    # `command:` here, the resulting exec becomes
+    #     dumb-init -- --config=/config/config
+    # and dumb-init then tries to run `--config=…` as a program, exiting
+    # with `exec: line 49: illegal option --` in a tight restart loop.
+    # Setting `command:` re-injects the radicale binary in the chain so
+    # the args land where they belong. dumb-init stays the entrypoint
+    # (signal forwarding, zombie reaping intact).
+    command:
+      - "dumb-init"
+      - "--"
+      - "radicale"
     args:
       - "--config=/config/config"
     ports:


### PR DESCRIPTION
## Summary

Two more template bugs found during a pre-reinstall MCP sweep on the live 3.1.1 appliance.

### 1. Radicale crash-loop — `exec: illegal option --`
`tomsquest/docker-radicale` has `ENTRYPOINT ["dumb-init", "--"]` and `CMD ["radicale"]`. K8s `args:` only replaces CMD, so the effective exec was:
```
dumb-init -- --config=/config/config
```
…and dumb-init tried to run `--config=…` as a program, exiting with `illegal option --` ~13×/sec. Fixed by setting `command: ["dumb-init", "--", "radicale"]` explicitly so the radicale binary stays in the chain.

### 2. Filebrowser pod has no `ports:` block
`service.ports[]` for filebrowser is empty in the agent's snapshot, so the network map can't link the `files.dopp.cloud → 192.168.178.100:8088` route to the filebrowser service. The `servicebay.ports` annotation alone is decorative — the agent reads K8s `ports[]`.

## Test plan
- [ ] Reinstall the appliance with the new image
- [ ] `podman ps` — radicale-radicale stable, no restart loop
- [ ] `mcp__servicebay__list_services` — filebrowser entry now has `ports: [{containerPort: 8088, …}]`
- [ ] Network map: `files.dopp.cloud → 192.168.178.100:8088` connects to the filebrowser service node, no ghost

🤖 Generated with [Claude Code](https://claude.com/claude-code)