### PR TITLE
feat(security): soft-delete services to a trash bucket, 7-day restore window

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -368,6 +368,30 @@ app.prepare().then(() => {
     // email isn't configured. Deduped per-release via config.autoUpdate.
     scheduleUpdateNotifier();
 
+    // Auto-purge soft-deleted services older than 7 days. Runs once at
+    // boot, then every 12 hours — the deletion latency target is "you have
+    // a week to undo", not "we delete on the dot".
+    const TRASH_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+    const TRASH_PURGE_INTERVAL_MS = 12 * 60 * 60 * 1000;
+    const purgeTrashAcrossNodes = async () => {
+      try {
+        const { listNodes: lN } = await import('./src/lib/nodes');
+        const { ServiceManager: SM } = await import('./src/lib/services/ServiceManager');
+        const nodes = await lN();
+        for (const n of nodes) {
+          try {
+            await SM.purgeTrash(n.Name, { olderThanMs: TRASH_RETENTION_MS });
+          } catch (e) {
+            logger.warn('Server', `Trash purge failed for ${n.Name}: ${e instanceof Error ? e.message : String(e)}`);
+          }
+        }
+      } catch (e) {
+        logger.warn('Server', `Trash purge sweep failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    };
+    setTimeout(() => { void purgeTrashAcrossNodes(); }, 60_000);
+    setInterval(() => { void purgeTrashAcrossNodes(); }, TRASH_PURGE_INTERVAL_MS);
+
   // Periodic Agent Health Sync (every 30 seconds)
   setInterval(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -45,6 +45,7 @@ function errorResult(msg: string) {
 const MUTATING_TOOLS = new Set([
   'start_service', 'stop_service', 'restart_service',
   'deploy_service', 'delete_service', 'rename_service', 'update_service_yaml',
+  'restore_trashed_service', 'purge_trashed_service',
   'add_proxy_route', 'remove_proxy_route',
   'create_health_check', 'delete_health_check', 'run_check_now',
   'run_backup', 'restore_backup',
@@ -56,9 +57,14 @@ const MUTATING_TOOLS = new Set([
  * non-trivially-reversible ways. These trigger an automatic
  * pre-mutation system snapshot so the operator always has a one-click
  * rewind point.
+ *
+ * Note: `delete_service` is now soft (moves to trash, recoverable for 7d
+ * via restore_trashed_service), so it doesn't need an extra snapshot.
+ * `purge_trashed_service`, by contrast, IS the irreversible step.
  */
 const DESTRUCTIVE_TOOLS = new Set([
-  'deploy_service', 'delete_service', 'rename_service', 'update_service_yaml',
+  'deploy_service', 'rename_service', 'update_service_yaml',
+  'purge_trashed_service',
   'remove_proxy_route', 'restore_backup',
   'update_config', 'exec_command',
 ]);
@@ -278,15 +284,51 @@ export function createMcpServer() {
     },
   );
 
-  // --- Delete Service ---
+  // --- Delete Service (soft) ---
   server.tool(
     'delete_service',
-    'Delete a service and its associated files',
+    'Soft-delete a service: stops the unit and moves its files to the trash bucket. Restorable via restore_trashed_service for 7 days; then auto-purged. Use purge_trashed_service to delete immediately.',
     { name: z.string().describe('Service name'), node: nodeParam },
     async ({ name, node }) => {
       const nodeName = await resolveNode(node);
       await ServiceManager.deleteService(nodeName, name);
-      return textResult(`Service "${name}" deleted successfully`);
+      return textResult(`Service "${name}" moved to trash. Use list_trashed_services / restore_trashed_service to recover.`);
+    },
+  );
+
+  // --- List Trashed Services ---
+  server.tool(
+    'list_trashed_services',
+    'List soft-deleted services available to restore. Each entry has an `id` you can pass to restore_trashed_service or purge_trashed_service.',
+    { node: nodeParam },
+    async ({ node }) => {
+      const nodeName = await resolveNode(node);
+      const items = await ServiceManager.listTrashedServices(nodeName);
+      return textResult(items);
+    },
+  );
+
+  // --- Restore From Trash ---
+  server.tool(
+    'restore_trashed_service',
+    'Restore a soft-deleted service from trash. Use list_trashed_services to find the id.',
+    { id: z.string().describe('Trash entry id'), node: nodeParam },
+    async ({ id, node }) => {
+      const nodeName = await resolveNode(node);
+      const result = await ServiceManager.restoreTrashedService(nodeName, id);
+      return textResult(`Service "${result.service}" restored from trash on ${nodeName}.`);
+    },
+  );
+
+  // --- Purge Trash (permanent delete) ---
+  server.tool(
+    'purge_trashed_service',
+    'Permanently delete a trash entry. Use list_trashed_services to find the id. Counts as a destructive op (snapshotted).',
+    { id: z.string().describe('Trash entry id'), node: nodeParam },
+    async ({ id, node }) => {
+      const nodeName = await resolveNode(node);
+      const result = await ServiceManager.purgeTrash(nodeName, { trashId: id });
+      return textResult(`Purged ${result.purged.length} trash entr${result.purged.length === 1 ? 'y' : 'ies'} on ${nodeName}.`);
     },
   );
 

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -1006,6 +1006,18 @@ export class ServiceManager {
         this.backupQuadlets(nodeName);
     }
 
+    /**
+     * Soft-delete a service: stop the unit, then *move* its .kube and .yml
+     * files into ~/.config/containers/systemd/.trash/<ts>-<name>/ instead
+     * of deleting them. The operator (or an MCP client) can `restore_from_trash`
+     * to undo within 7 days; `purge_trash` actually removes them. Auto-purge
+     * older than 7 days runs on server startup.
+     *
+     * Why "move, don't rm": delete-by-mistake is the easiest way to lose
+     * service config, and the existing system-backup mechanism only takes
+     * snapshots periodically. A trash bucket gives an immediate one-step
+     * recovery without restoring from a backup tarball.
+     */
     static async deleteService(nodeName: string, serviceName: string) {
         const { yamlPath } = await this.getServiceFiles(nodeName, serviceName);
         const agent = await agentManager.ensureAgent(nodeName);
@@ -1015,16 +1027,37 @@ export class ServiceManager {
             await agent.sendCommand('exec', { command: `systemctl --user stop ${serviceName}.service` });
         } catch { /* ignore if already stopped */ }
 
-        // Remove kube file
+        // Move the files into the trash bucket. ISO-8601 with no colons in
+        // the name so it sorts by timestamp and survives shells that hate
+        // colons in paths.
+        const trashStamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const trashDir = `~/${SYSTEMD_DIR}/.trash/${trashStamp}-${serviceName}`;
+        await agent.sendCommand('exec', { command: `mkdir -p '${trashDir}'` });
+
+        // Move kube file
         await agent.sendCommand('exec', {
-            command: `rm -f ~/${SYSTEMD_DIR}/${serviceName}.kube`
+            command: `mv -f ~/${SYSTEMD_DIR}/${serviceName}.kube '${trashDir}/' 2>/dev/null || true`
         });
 
-        // Remove yaml file
+        // Move yaml file
         if (yamlPath) {
             const resolvedYaml = yamlPath.startsWith('/') ? yamlPath : `~/${yamlPath}`;
-            await agent.sendCommand('exec', { command: `rm -f ${resolvedYaml}` });
+            await agent.sendCommand('exec', {
+                command: `mv -f ${resolvedYaml} '${trashDir}/' 2>/dev/null || true`,
+            });
         }
+
+        // Stash a small manifest so restore knows the original yaml path
+        // even if it lived outside the systemd dir (legacy migrations did).
+        const manifest = JSON.stringify({
+            service: serviceName,
+            deletedAt: new Date().toISOString(),
+            originalYamlPath: yamlPath || null,
+            originalKubePath: `~/${SYSTEMD_DIR}/${serviceName}.kube`,
+        });
+        await agent.sendCommand('exec', {
+            command: `printf '%s' ${JSON.stringify(manifest)} > '${trashDir}/.manifest.json'`,
+        });
 
         await this.reloadDaemon(nodeName);
 
@@ -1035,6 +1068,132 @@ export class ServiceManager {
 
         await this.refreshAgent(nodeName);
         this.backupQuadlets(nodeName);
+
+        logger.info('ServiceManager', `Soft-deleted ${serviceName} on ${nodeName} → ${trashDir}`);
+    }
+
+    /** Recursive listing of the trash bucket for one node. Each entry maps
+     *  to a single soft-deleted service. */
+    static async listTrashedServices(nodeName: string): Promise<Array<{
+        id: string;
+        service: string;
+        deletedAt: string;
+        path: string;
+    }>> {
+        const agent = await agentManager.ensureAgent(nodeName);
+        const trashRoot = `~/${SYSTEMD_DIR}/.trash`;
+        try {
+            const res = await agent.sendCommand('exec', {
+                command: `ls -1 ${trashRoot} 2>/dev/null`,
+            });
+            const out = (res?.stdout ?? '') as string;
+            const entries = out.trim().split('\n').filter(Boolean);
+            const results = [];
+            for (const entry of entries) {
+                let manifest: { service?: string; deletedAt?: string } = {};
+                try {
+                    const m = await agent.sendCommand('exec', {
+                        command: `cat '${trashRoot}/${entry}/.manifest.json' 2>/dev/null`,
+                    });
+                    manifest = JSON.parse(((m?.stdout ?? '') as string) || '{}');
+                } catch { /* fall back to filename parse */ }
+                // Fallback: derive from directory name "<iso-stamp>-<service>"
+                const fallback = entry.match(/^(\d{4}-\d{2}-\d{2}T[\d-]+Z)-(.+)$/);
+                results.push({
+                    id: entry,
+                    service: manifest.service || fallback?.[2] || entry,
+                    deletedAt: manifest.deletedAt || (fallback ? fallback[1].replace(/-(\d\d)-(\d\d)Z$/, ':$1:$2Z') : ''),
+                    path: `${trashRoot}/${entry}`,
+                });
+            }
+            return results.sort((a, b) => b.deletedAt.localeCompare(a.deletedAt));
+        } catch {
+            return [];
+        }
+    }
+
+    /** Restore a soft-deleted service from trash. Moves the files back to
+     *  their original locations and reloads systemd. */
+    static async restoreTrashedService(nodeName: string, trashId: string): Promise<{ service: string }> {
+        const agent = await agentManager.ensureAgent(nodeName);
+        const trashRoot = `~/${SYSTEMD_DIR}/.trash`;
+        const trashDir = `${trashRoot}/${trashId}`;
+
+        // Read manifest. Manifest is the source of truth for original
+        // paths because the service may have referenced a yaml file
+        // outside SYSTEMD_DIR.
+        const m = await agent.sendCommand('exec', {
+            command: `cat '${trashDir}/.manifest.json' 2>/dev/null`,
+        });
+        let manifest: { service?: string; originalYamlPath?: string | null; originalKubePath?: string };
+        try {
+            manifest = JSON.parse(((m?.stdout ?? '') as string) || '{}');
+        } catch {
+            throw new Error(`Trash entry ${trashId} is missing or has a corrupt manifest — restore manually`);
+        }
+        if (!manifest.service) {
+            throw new Error(`Trash entry ${trashId} has no service name in manifest`);
+        }
+
+        const kubePath = manifest.originalKubePath || `~/${SYSTEMD_DIR}/${manifest.service}.kube`;
+        const yamlPath = manifest.originalYamlPath
+            ? (manifest.originalYamlPath.startsWith('/') ? manifest.originalYamlPath : `~/${manifest.originalYamlPath}`)
+            : null;
+
+        await agent.sendCommand('exec', {
+            command: `mv '${trashDir}/${manifest.service}.kube' ${kubePath} 2>/dev/null || true`,
+        });
+        if (yamlPath) {
+            // The yaml lives in the trash dir under its basename.
+            const yamlBasename = manifest.originalYamlPath?.split('/').pop();
+            if (yamlBasename) {
+                await agent.sendCommand('exec', {
+                    command: `mv '${trashDir}/${yamlBasename}' ${yamlPath} 2>/dev/null || true`,
+                });
+            }
+        }
+        // Wipe the now-empty trash dir.
+        await agent.sendCommand('exec', { command: `rm -rf '${trashDir}'` });
+
+        await this.reloadDaemon(nodeName);
+        await this.refreshAgent(nodeName);
+        this.backupQuadlets(nodeName);
+
+        logger.info('ServiceManager', `Restored ${manifest.service} from trash on ${nodeName}`);
+        return { service: manifest.service };
+    }
+
+    /** Permanently delete one trash entry, or all entries older than the
+     *  given retention (in milliseconds). */
+    static async purgeTrash(nodeName: string, opts: { trashId?: string; olderThanMs?: number }): Promise<{ purged: string[] }> {
+        const agent = await agentManager.ensureAgent(nodeName);
+        const trashRoot = `~/${SYSTEMD_DIR}/.trash`;
+        if (opts.trashId) {
+            // Strict basename — no traversal allowed.
+            if (!/^[a-zA-Z0-9._-]+$/.test(opts.trashId)) {
+                throw new Error(`Invalid trash id: ${opts.trashId}`);
+            }
+            await agent.sendCommand('exec', { command: `rm -rf '${trashRoot}/${opts.trashId}'` });
+            logger.info('ServiceManager', `Purged trash entry ${opts.trashId} on ${nodeName}`);
+            return { purged: [opts.trashId] };
+        }
+        if (opts.olderThanMs !== undefined) {
+            const list = await this.listTrashedServices(nodeName);
+            const now = Date.now();
+            const toPurge = list.filter(e => {
+                const ts = Date.parse(e.deletedAt);
+                if (!isFinite(ts)) return false;
+                return (now - ts) > opts.olderThanMs!;
+            });
+            for (const entry of toPurge) {
+                await agent.sendCommand('exec', { command: `rm -rf '${trashRoot}/${entry.id}'` });
+            }
+            if (toPurge.length > 0) {
+                logger.info('ServiceManager', `Purged ${toPurge.length} trash entr${toPurge.length === 1 ? 'y' : 'ies'} older than ${Math.round(opts.olderThanMs / 86_400_000)}d on ${nodeName}`);
+            }
+            return { purged: toPurge.map(e => e.id) };
+        }
+        return { purged: [] };
     }
 
     static async getServiceLogs(nodeName: string, serviceName: string) {


### PR DESCRIPTION
## Summary

PR 2 of 5 in the MCP safety series. `delete_service` is the single biggest "I just lost a service config" risk, and the existing system-backup is only periodic. This adds a per-service trash bucket as the immediate undo path.

## Behaviour

- `delete_service` no longer `rm -f`s the `.kube`/`.yml`. Instead it moves them into `~/.config/containers/systemd/.trash/<isoStamp>-<name>/` alongside a `.manifest.json` recording the original paths (yaml may live outside SYSTEMD_DIR for legacy-migrated services).
- Three new MCP tools:
  - `list_trashed_services` (read) — lists trash entries with `id`, `service`, `deletedAt`
  - `restore_trashed_service` (mutating) — moves files back to their original paths, reloads systemd
  - `purge_trashed_service` (destructive — snapshotted by the safety layer from #169) — permanent removal
- Auto-purge runs 60 s after boot and every 12 h thereafter. Entries older than 7 days are removed across all known nodes. Best-effort — a per-node failure logs and continues.
- The `MUTATING_TOOLS` / `DESTRUCTIVE_TOOLS` sets in `mcp/server.ts` are updated: `delete_service` is no longer destructive (it's reversible); `purge_trashed_service` is the irreversible step.

## Recovery

```
mcp__servicebay__list_trashed_services    # find your entry's id
mcp__servicebay__restore_trashed_service id="<id>"
```

…or wait: anything older than 7 days is permanently gone via the auto-purge.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] `delete_service name=foo` → service stops, files move to `.trash/<ts>-foo/` with manifest
- [ ] `list_trashed_services` shows the entry
- [ ] `restore_trashed_service id=<id>` → service reappears in `list_services`, can be `start_service`'d
- [ ] `purge_trashed_service id=<id>` triggers a pre-mutation snapshot (visible in `Settings → Backups`) then permanently removes the entry
- [ ] Backdate a `.trash/<old-stamp>-svc/` directory, restart server → after 60 s sweep, that entry is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)