### PR TITLE
feat(security): MCP audit log + Recent activity panel

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -1,8 +1,17 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Bot, Check, Copy, ShieldAlert } from 'lucide-react';
+import { Bot, Check, Copy, ShieldAlert, History, RefreshCw } from 'lucide-react';
 import PluginHelp from '@/components/PluginHelp';
+
+interface AuditEntry {
+  ts: string;
+  tool: string;
+  outcome: 'ok' | 'error' | 'blocked';
+  durationMs: number;
+  args?: Record<string, unknown>;
+  errorMessage?: string;
+}
 
 export default function McpSection() {
   const [mcpUrl, setMcpUrl] = useState('');
@@ -11,6 +20,18 @@ export default function McpSection() {
   const [allowDangerousExec, setAllowDangerousExec] = useState<boolean | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [audit, setAudit] = useState<AuditEntry[] | null>(null);
+  const [auditLoading, setAuditLoading] = useState(false);
+  const [auditOpen, setAuditOpen] = useState(false);
+
+  const loadAudit = () => {
+    setAuditLoading(true);
+    fetch('/api/system/mcp-audit?limit=50')
+      .then(r => r.ok ? r.json() : { entries: [] })
+      .then(data => setAudit(data.entries ?? []))
+      .catch(() => setAudit([]))
+      .finally(() => setAuditLoading(false));
+  };
 
   useEffect(() => {
     // Read window.location after mount to avoid SSR/hydration mismatch.
@@ -164,6 +185,74 @@ export default function McpSection() {
         <p className="text-[11px] text-gray-400 dark:text-gray-500 italic">
           When mutations are enabled, every destructive call (delete/update/exec/restore) takes a labelled system-config snapshot first. Find them in <span className="font-mono">Settings → Backups</span> with a <span className="font-mono">pre-mutation</span> timestamp.
         </p>
+      </div>
+
+      {/* Recent MCP activity. Toggleable so the section stays compact for
+          operators who don't care about the audit feed. Lazy-loads on
+          open so a heavy log doesn't slow down the rest of Settings. */}
+      <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          onClick={() => {
+            const next = !auditOpen;
+            setAuditOpen(next);
+            if (next && audit === null) loadAudit();
+          }}
+          className="w-full flex items-center justify-between text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400"
+        >
+          <span className="flex items-center gap-2">
+            <History size={14} />
+            Recent MCP activity
+            {audit && (
+              <span className="text-xs font-normal text-gray-500">({audit.length} entr{audit.length === 1 ? 'y' : 'ies'})</span>
+            )}
+          </span>
+          <span className="text-xs text-gray-400">{auditOpen ? '▾' : '▸'}</span>
+        </button>
+        {auditOpen && (
+          <div className="mt-3 space-y-2">
+            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+              <span>Newest first. Older entries roll over after 5 MB; full log persists in <span className="font-mono">DATA_DIR/mcp-audit.log</span>.</span>
+              <button
+                type="button"
+                onClick={loadAudit}
+                disabled={auditLoading}
+                className="flex items-center gap-1 px-2 py-1 rounded border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+              >
+                <RefreshCw size={12} className={auditLoading ? 'animate-spin' : ''} />
+                {auditLoading ? 'Loading…' : 'Refresh'}
+              </button>
+            </div>
+            {audit && audit.length === 0 && (
+              <p className="text-xs text-gray-500 italic">No MCP activity recorded yet.</p>
+            )}
+            {audit && audit.length > 0 && (
+              <ul className="space-y-1.5 max-h-64 overflow-y-auto">
+                {audit.map((e, i) => {
+                  const outcomeStyle = e.outcome === 'ok'
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : e.outcome === 'blocked'
+                      ? 'text-amber-600 dark:text-amber-400'
+                      : 'text-red-600 dark:text-red-400';
+                  const outcomeIcon = e.outcome === 'ok' ? '✓' : e.outcome === 'blocked' ? '⛔' : '✗';
+                  return (
+                    <li key={`${e.ts}-${i}`} className="text-xs border-l-2 border-gray-200 dark:border-gray-700 pl-2 py-0.5">
+                      <div className="flex items-center gap-2">
+                        <span className={`font-mono ${outcomeStyle}`}>{outcomeIcon}</span>
+                        <span className="font-mono text-gray-900 dark:text-gray-100">{e.tool}</span>
+                        <span className="text-gray-400">{e.durationMs}ms</span>
+                        <span className="text-gray-400 ml-auto">{new Date(e.ts).toLocaleTimeString()}</span>
+                      </div>
+                      {e.errorMessage && (
+                        <div className={`pl-4 mt-0.5 ${outcomeStyle} opacity-80 break-words`}>{e.errorMessage}</div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/api/system/mcp-audit/route.ts
+++ b/src/app/api/system/mcp-audit/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { readRecentAudit } from '@/lib/mcp/audit';
+import { requireSession } from '@/lib/api/requireSession';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Read recent MCP audit entries. Limited to the most recent 500 entries
+ * to keep payloads bounded — operators wanting deeper history can read
+ * `mcp-audit.log` directly off the host (also captured by system backups).
+ */
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const { searchParams } = new URL(request.url);
+  const limit = parseInt(searchParams.get('limit') || '100', 10);
+  const entries = await readRecentAudit(Number.isFinite(limit) ? limit : 100);
+  return NextResponse.json({ entries });
+}

--- a/src/lib/mcp/audit.ts
+++ b/src/lib/mcp/audit.ts
@@ -1,0 +1,126 @@
+/**
+ * MCP audit log — appends a JSON line per tool call so the operator can
+ * reconstruct who/what touched the appliance after the fact. JSONL is
+ * cheap to grep, easy to render in the UI, survives a process restart,
+ * and can be tail-followed.
+ *
+ * Persistence: append-only `mcp-audit.log` under DATA_DIR. Each line is a
+ * single JSON object terminated by '\n'. We rotate at 5 MB (rename to
+ * .1.log) and keep one backup file — the operator can always pull the
+ * full forensic stream off the host with the existing system backup.
+ *
+ * Redaction: arg values for known-sensitive parameters are masked before
+ * write so an attacker who reads the log doesn't get tokens, passwords,
+ * or full command lines for free.
+ */
+import fsp from 'fs/promises';
+import path from 'path';
+import { DATA_DIR } from '@/lib/dirs';
+import { logger } from '@/lib/logger';
+
+const AUDIT_FILE = path.join(DATA_DIR, 'mcp-audit.log');
+const AUDIT_BACKUP_FILE = path.join(DATA_DIR, 'mcp-audit.1.log');
+const ROTATE_BYTES = 5 * 1024 * 1024;
+const MAX_LINES_RETURNED = 500;
+
+/** A single audit row. Stable shape — operators may grep this directly. */
+export interface AuditEntry {
+  ts: string;            // ISO timestamp
+  tool: string;          // e.g. "delete_service"
+  caller?: string;       // session user, falls back to remote IP
+  outcome: 'ok' | 'error' | 'blocked';
+  durationMs: number;
+  args?: Record<string, unknown>;  // redacted
+  errorMessage?: string;           // present iff outcome === 'error' or 'blocked'
+}
+
+/** Args fields that get masked. Full-redact rather than truncate so the
+ *  log is safe to share verbatim with support. */
+const REDACT_KEYS = new Set([
+  'password', 'secret', 'token', 'apiKey', 'api_key',
+  'authToken', 'credentials', 'pass', 'cookie',
+  'privateKey', 'private_key', 'sshKey',
+  'kubeContent', 'yamlContent',  // can contain inline credentials
+]);
+/** Truncate-rather-than-redact: keep the head so the log is still useful. */
+const TRUNCATE_KEYS = new Set([
+  'command',  // exec_command — keep first 200 chars
+]);
+
+function redactArgs(args?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!args) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (REDACT_KEYS.has(k)) {
+      out[k] = '[redacted]';
+      continue;
+    }
+    if (TRUNCATE_KEYS.has(k) && typeof v === 'string' && v.length > 200) {
+      out[k] = `${v.slice(0, 200)}…(+${v.length - 200} chars)`;
+      continue;
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+let rotating = false;
+async function rotateIfNeeded() {
+  if (rotating) return;
+  try {
+    const stat = await fsp.stat(AUDIT_FILE);
+    if (stat.size < ROTATE_BYTES) return;
+    rotating = true;
+    try {
+      // Single backup ring — overwrite the previous .1 if any.
+      await fsp.rename(AUDIT_FILE, AUDIT_BACKUP_FILE).catch(() => { /* race: another writer rotated */ });
+    } finally {
+      rotating = false;
+    }
+  } catch {
+    // File doesn't exist yet — nothing to rotate.
+  }
+}
+
+export async function recordAudit(entry: AuditEntry): Promise<void> {
+  try {
+    await fsp.mkdir(path.dirname(AUDIT_FILE), { recursive: true }).catch(() => undefined);
+    await rotateIfNeeded();
+    const line = JSON.stringify({
+      ...entry,
+      args: redactArgs(entry.args),
+    }) + '\n';
+    // Append-with-flush: O_APPEND on Linux is atomic for writes < PIPE_BUF
+    // (~4 KiB), which our entries comfortably fit under. fs.appendFile uses
+    // the right flags.
+    await fsp.appendFile(AUDIT_FILE, line, 'utf-8');
+  } catch (e) {
+    logger.warn('mcp:audit', `Failed to record audit entry: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/** Read the last N audit entries from the current log file (does NOT
+ *  read .1.log — operators wanting deep history can grab the file via
+ *  the system backup). Returns newest first. */
+export async function readRecentAudit(limit = 100): Promise<AuditEntry[]> {
+  const cap = Math.min(Math.max(1, limit | 0), MAX_LINES_RETURNED);
+  let raw: string;
+  try {
+    raw = await fsp.readFile(AUDIT_FILE, 'utf-8');
+  } catch {
+    return [];
+  }
+  const lines = raw.split('\n').filter(Boolean);
+  const tail = lines.slice(-cap).reverse();
+  const out: AuditEntry[] = [];
+  for (const line of tail) {
+    try {
+      const e = JSON.parse(line) as AuditEntry;
+      if (e && typeof e.tool === 'string' && typeof e.ts === 'string') {
+        out.push(e);
+      }
+    } catch { /* malformed line, skip */ }
+  }
+  return out;
+}
+

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -20,6 +20,7 @@ import {
 } from '@/lib/backup/service';
 import { restoreSystemBackup } from '@/lib/systemBackup';
 import { guardMutation, guardExec, snapshotBeforeMutation } from './safety';
+import { recordAudit } from './audit';
 
 const nodeParam = z.string().optional().describe('Node name (defaults to first available node)');
 
@@ -89,19 +90,53 @@ function safeHandler(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return async (...handlerArgs: any[]): Promise<ToolResult> => {
     const args = (handlerArgs[0] && typeof handlerArgs[0] === 'object') ? handlerArgs[0] : {};
-    if (MUTATING_TOOLS.has(toolName)) {
-      const blocked = await guardMutation(toolName);
-      if (blocked) return blocked;
+    const start = Date.now();
+    let outcome: 'ok' | 'error' | 'blocked' = 'ok';
+    let errorMessage: string | undefined;
+    try {
+      if (MUTATING_TOOLS.has(toolName)) {
+        const blocked = await guardMutation(toolName);
+        if (blocked) {
+          outcome = 'blocked';
+          errorMessage = blocked.content[0]?.text;
+          return blocked;
+        }
+      }
+      if (toolName === 'exec_command' && typeof args.command === 'string') {
+        const denied = await guardExec(args.command);
+        if (denied) {
+          outcome = 'blocked';
+          errorMessage = denied.content[0]?.text;
+          return denied;
+        }
+      }
+      if (DESTRUCTIVE_TOOLS.has(toolName)) {
+        // Best-effort: don't block the mutation if the snapshot fails.
+        await snapshotBeforeMutation(toolName, args);
+      }
+      const result = await handler(...handlerArgs);
+      // Result is `isError: true` when a tool reports a logical error.
+      if (result && typeof result === 'object' && (result as { isError?: boolean }).isError) {
+        outcome = 'error';
+        errorMessage = (result as { content?: { text?: string }[] }).content?.[0]?.text;
+      }
+      return result;
+    } catch (e) {
+      outcome = 'error';
+      errorMessage = e instanceof Error ? e.message : String(e);
+      throw e;
+    } finally {
+      // Audit fire-and-forget — never block the tool response on the log
+      // write. Tracked separately by mcp:audit logger.
+      void recordAudit({
+        ts: new Date().toISOString(),
+        tool: toolName,
+        outcome,
+        durationMs: Date.now() - start,
+        args,
+        errorMessage,
+      });
     }
-    if (toolName === 'exec_command' && typeof args.command === 'string') {
-      const denied = await guardExec(args.command);
-      if (denied) return denied;
-    }
-    if (DESTRUCTIVE_TOOLS.has(toolName)) {
-      // Best-effort: don't block the mutation if the snapshot fails.
-      await snapshotBeforeMutation(toolName, args);
-    }
-    return handler(...handlerArgs);
   };
 }
 


### PR DESCRIPTION
## Summary

PR 3 of 5 in the MCP safety series. Append-only audit trail of every MCP tool call so the operator can reconstruct who/what touched the appliance after the fact.

## What's new

- **`src/lib/mcp/audit.ts`** — JSONL log under `DATA_DIR/mcp-audit.log`. Each line: `{ts, tool, outcome, durationMs, args (redacted), errorMessage?}`. Rolls over to `mcp-audit.1.log` at 5 MB; one backup retained.
- **MCP safety wrapper** tags every tool call with one of three outcomes: `ok`, `blocked` (guardMutation/guardExec refused), `error` (handler threw or returned `isError: true`).
- **Redaction**: full mask for password/secret/token/apiKey/credentials/cookie/privateKey/sshKey/kubeContent/yamlContent; truncate `command` (exec_command) to 200 chars.
- **`GET /api/system/mcp-audit?limit=N`** — auth-gated, capped at 500 entries.
- **Settings → Integrations → MCP Server** — new collapsible "Recent MCP activity" panel, lazy-loads on open.

## Why fire-and-forget writes
A slow disk should never block a tool response. Audit writes are issued via `void recordAudit(…)` in the wrapper's `finally` block; a failed write logs a warning at `mcp:audit` and tool execution continues normally.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Trigger a few MCP tool calls → see them in the panel within seconds, newest first
- [ ] With mutations off, call `delete_service` → entry shows ⛔ blocked + error message
- [ ] Call `exec_command command="rm -rf /"` → ⛔ blocked, message references matched pattern
- [ ] `password=…` arg shows `[redacted]`; `command=…` truncates at 200 chars
- [ ] > 5 MB of activity → file rolls over to `mcp-audit.1.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)