### PR TITLE
feat(security): scoped MCP API tokens (read/lifecycle/mutate/destroy)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -173,19 +173,40 @@ app.prepare().then(() => {
         }
 
         // Auth: MCP lives outside /api/* so the Next proxy gate doesn't see it.
-        const session = await getSessionFromCookieHeader(req.headers.cookie);
-        if (!session) {
+        // Two paths supported:
+        //   1. Authorization: Bearer sb_<id>_<secret>   — scoped API token
+        //   2. Cookie: session=...                      — full-access (legacy)
+        // Token path is preferred; cookie kept for back-compat with clients
+        // that connected before tokens existed.
+        const { verifyToken } = await import('./src/lib/mcp/tokens');
+        const authHeader = req.headers.authorization || '';
+        const bearerMatch = authHeader.match(/^Bearer\s+(\S+)$/i);
+        let auth: { user: string; scopes: import('./src/lib/mcp/tokens').ApiScope[]; tokenId?: string } | null = null;
+        if (bearerMatch) {
+          const t = await verifyToken(bearerMatch[1]);
+          if (t) auth = { user: `token:${t.name}`, scopes: t.scopes, tokenId: t.id };
+        }
+        if (!auth) {
+          const session = await getSessionFromCookieHeader(req.headers.cookie);
+          if (session) {
+            // Cookie auth retains full scopes for back-compat. Fresh
+            // installs that want stricter behaviour use named tokens.
+            auth = { user: session.user, scopes: ['read', 'lifecycle', 'mutate', 'destroy'] };
+          }
+        }
+        if (!auth) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({
             jsonrpc: '2.0',
-            error: { code: -32001, message: 'Unauthorized' },
+            error: { code: -32001, message: 'Unauthorized — provide Authorization: Bearer sb_… or a session cookie' },
             id: null,
           }));
           return;
         }
 
-        // Stateless: create a fresh server + transport per request
-        const mcpServer = createMcpServer();
+        // Stateless: create a fresh server + transport per request, with
+        // the auth context closed over so each tool call can scope-check.
+        const mcpServer = createMcpServer({ auth });
         const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
         await mcpServer.connect(transport);
         const body = await collectBody(req);

--- a/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Bot, Check, Copy, ShieldAlert, History, RefreshCw } from 'lucide-react';
+import { Bot, Check, Copy, ShieldAlert, History, RefreshCw, Key, Plus, Trash2 } from 'lucide-react';
 import PluginHelp from '@/components/PluginHelp';
 
 interface AuditEntry {
@@ -11,6 +11,20 @@ interface AuditEntry {
   durationMs: number;
   args?: Record<string, unknown>;
   errorMessage?: string;
+}
+
+type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'destroy';
+const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'destroy'];
+
+interface TokenView {
+  id: string;
+  name: string;
+  scopes: ApiScope[];
+  prefix: string;
+  createdAt: string;
+  expiresAt?: string;
+  lastUsedAt?: string;
+  createdBy: string;
 }
 
 export default function McpSection() {
@@ -31,6 +45,67 @@ export default function McpSection() {
       .then(data => setAudit(data.entries ?? []))
       .catch(() => setAudit([]))
       .finally(() => setAuditLoading(false));
+  };
+
+  // ── API token state ──────────────────────────────────────────────
+  const [tokensOpen, setTokensOpen] = useState(false);
+  const [tokens, setTokens] = useState<TokenView[] | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newScopes, setNewScopes] = useState<ApiScope[]>(['read']);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+  const [secretCopied, setSecretCopied] = useState(false);
+
+  const loadTokens = () => {
+    fetch('/api/system/mcp-tokens')
+      .then(r => r.ok ? r.json() : { tokens: [] })
+      .then(data => setTokens(data.tokens ?? []))
+      .catch(() => setTokens([]));
+  };
+
+  const createNewToken = async () => {
+    if (!newName.trim() || newScopes.length === 0) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const res = await fetch('/api/system/mcp-tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim(), scopes: newScopes }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setRevealedSecret(data.secret);
+      setNewName('');
+      setNewScopes(['read']);
+      setShowCreate(false);
+      loadTokens();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const revokeOneToken = async (id: string, name: string) => {
+    if (!confirm(`Revoke token "${name}"? Any client using this token will be locked out immediately.`)) return;
+    const res = await fetch(`/api/system/mcp-tokens?id=${id}`, { method: 'DELETE' });
+    if (res.ok) loadTokens();
+  };
+
+  const copySecret = async () => {
+    if (!revealedSecret) return;
+    try {
+      await navigator.clipboard.writeText(revealedSecret);
+      setSecretCopied(true);
+      setTimeout(() => setSecretCopied(false), 1500);
+    } catch { /* manual select */ }
+  };
+
+  const toggleScope = (scope: ApiScope) => {
+    setNewScopes(prev => prev.includes(scope) ? prev.filter(s => s !== scope) : [...prev, scope]);
   };
 
   useEffect(() => {
@@ -185,6 +260,167 @@ export default function McpSection() {
         <p className="text-[11px] text-gray-400 dark:text-gray-500 italic">
           When mutations are enabled, every destructive call (delete/update/exec/restore) takes a labelled system-config snapshot first. Find them in <span className="font-mono">Settings → Backups</span> with a <span className="font-mono">pre-mutation</span> timestamp.
         </p>
+      </div>
+
+      {/* API tokens — named, revocable credentials with explicit scopes.
+          The Bearer-token auth path is preferred over the session cookie:
+          it's revocable per-client, lets you scope down to read-only, and
+          appears as `caller` in the audit log so you can attribute calls.
+          Cookie auth still works but always carries all scopes. */}
+      <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          onClick={() => {
+            const next = !tokensOpen;
+            setTokensOpen(next);
+            if (next && tokens === null) loadTokens();
+          }}
+          className="w-full flex items-center justify-between text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400"
+        >
+          <span className="flex items-center gap-2">
+            <Key size={14} />
+            API tokens
+            {tokens && (
+              <span className="text-xs font-normal text-gray-500">({tokens.length})</span>
+            )}
+          </span>
+          <span className="text-xs text-gray-400">{tokensOpen ? '▾' : '▸'}</span>
+        </button>
+        {tokensOpen && (
+          <div className="mt-3 space-y-3">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Per-client credentials with explicit scopes. Pass as <span className="font-mono">Authorization: Bearer sb_…</span> on every MCP request. Revocable here without disturbing other clients.
+            </p>
+
+            {revealedSecret && (
+              <div className="p-3 bg-amber-50 dark:bg-amber-900/30 rounded border border-amber-300 dark:border-amber-700 space-y-2">
+                <p className="text-xs font-semibold text-amber-900 dark:text-amber-100">⚠️ Save this token now — it will not be shown again.</p>
+                <div className="flex items-stretch gap-2">
+                  <input
+                    type="text"
+                    readOnly
+                    value={revealedSecret}
+                    onFocus={(e) => e.currentTarget.select()}
+                    className="flex-1 font-mono text-xs px-2 py-1.5 rounded border border-amber-300 dark:border-amber-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                  />
+                  <button
+                    type="button"
+                    onClick={copySecret}
+                    className="px-3 py-1.5 text-xs rounded bg-amber-600 hover:bg-amber-700 text-white flex items-center gap-1"
+                  >
+                    {secretCopied ? <Check size={12} /> : <Copy size={12} />}
+                    {secretCopied ? 'Copied' : 'Copy'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setRevealedSecret(null)}
+                    className="px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300 hover:underline"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {tokens && tokens.length > 0 && (
+              <ul className="space-y-1.5">
+                {tokens.map(t => (
+                  <li key={t.id} className="flex items-center justify-between gap-3 px-2 py-1.5 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 text-sm">
+                        <span className="font-medium text-gray-900 dark:text-gray-100 truncate">{t.name}</span>
+                        <span className="font-mono text-xs text-gray-500">sb_{t.id}_{t.prefix}…</span>
+                      </div>
+                      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                        {t.scopes.map(s => (
+                          <span key={s} className={`text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
+                            s === 'destroy' ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300' :
+                            s === 'mutate' ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300' :
+                            s === 'lifecycle' ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300' :
+                            'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          }`}>{s}</span>
+                        ))}
+                        <span className="text-[10px] text-gray-400">
+                          {t.lastUsedAt ? `last used ${new Date(t.lastUsedAt).toLocaleString()}` : 'never used'}
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => revokeOneToken(t.id, t.name)}
+                      className="shrink-0 p-1.5 rounded text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30"
+                      title="Revoke"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {tokens && tokens.length === 0 && !showCreate && (
+              <p className="text-xs text-gray-500 italic">No tokens yet. Create one for each MCP client (Claude Code, Claude Desktop, …).</p>
+            )}
+
+            {showCreate ? (
+              <div className="space-y-2 p-3 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40">
+                <div>
+                  <label className="block text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1">Name</label>
+                  <input
+                    type="text"
+                    value={newName}
+                    onChange={e => setNewName(e.target.value)}
+                    placeholder="e.g. Claude Code on workstation"
+                    className="w-full px-2 py-1.5 text-sm rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+                  />
+                </div>
+                <div>
+                  <label className="block text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1">Scopes</label>
+                  <div className="flex flex-wrap gap-2">
+                    {ALL_SCOPES.map(scope => (
+                      <label key={scope} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={newScopes.includes(scope)}
+                          onChange={() => toggleScope(scope)}
+                          className="rounded"
+                        />
+                        <span className="font-mono">{scope}</span>
+                      </label>
+                    ))}
+                  </div>
+                  <p className="text-[10px] text-gray-400 mt-1">read = list/get only. lifecycle = start/stop/restart. mutate = create/update. destroy = delete/exec/restore.</p>
+                </div>
+                {createError && <p className="text-xs text-red-600">{createError}</p>}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={createNewToken}
+                    disabled={creating || !newName.trim() || newScopes.length === 0}
+                    className="flex-1 px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50"
+                  >
+                    {creating ? 'Creating…' : 'Create'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setShowCreate(false); setCreateError(null); }}
+                    className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowCreate(true)}
+                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <Plus size={12} />
+                New token
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Recent MCP activity. Toggleable so the section stays compact for

--- a/src/app/api/system/mcp-tokens/route.ts
+++ b/src/app/api/system/mcp-tokens/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listTokens, createToken, revokeToken, ALL_SCOPES, type ApiScope } from '@/lib/mcp/tokens';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  const tokens = await listTokens();
+  return NextResponse.json({ tokens });
+}
+
+const CreateBody = z.object({
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.enum(ALL_SCOPES as [ApiScope, ...ApiScope[]])).min(1),
+  expiresAt: z.string().datetime().optional(),
+});
+
+export async function POST(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const body = CreateBody.parse(await request.json());
+    const result = await createToken({
+      name: body.name,
+      scopes: body.scopes,
+      expiresAt: body.expiresAt,
+      createdBy: auth.user,
+    });
+    // The clear-text secret is returned ONCE, here. The client must show
+    // it to the operator and let them copy it before it's gone.
+    return NextResponse.json({ token: result.token, secret: result.secret });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:mcp-tokens:post', status: 400 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  if (!id || !/^[0-9a-f]{8}$/.test(id)) {
+    return NextResponse.json({ error: 'invalid token id' }, { status: 400 });
+  }
+  const ok = await revokeToken(id);
+  if (!ok) return NextResponse.json({ error: 'token not found' }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/content/help/mcp.md
+++ b/src/content/help/mcp.md
@@ -7,26 +7,35 @@ YAML, manage proxy routes, run backups, configure health checks, and more.
 
 ## Setup (Claude Code)
 
-### 1. Copy your session cookie
+### 1. Create an API token (recommended)
 
-The MCP endpoint uses the same auth as this UI. The session cookie is
-`HttpOnly`, so it has to come from DevTools — one-time:
+Open **Settings → Integrations → MCP Server → API tokens → New token**.
+Pick a name (e.g. `Claude Code on workstation`) and the scopes you want
+this client to have:
 
-1. Open DevTools (F12) on this tab.
-2. **Application → Storage → Cookies → (your ServiceBay origin)**.
-3. Copy the value of the `session` cookie. It looks like
-   `eyJhbGciOiJIUzI1NiJ9.eyJ1c2Vy…`.
+- **read** — list/get only. The safest default.
+- **lifecycle** — adds start/stop/restart, run-check-now, refresh-agent.
+- **mutate** — adds deploy/update/add-route/create-check.
+- **destroy** — adds delete/exec/restore/purge. Use sparingly.
+
+The token is shown **once** when you create it — copy it now. Format:
+`sb_<id>_<secret>`. Revoke any time without affecting other clients.
 
 ### 2. Register the server
 
 ```bash
 claude mcp add --transport http servicebay \
   <YOUR_SERVICEBAY_URL>/mcp \
-  --header "Cookie: session=PASTE_THE_JWT_HERE"
+  --header "Authorization: Bearer sb_xxxxxxxx_YOUR_TOKEN_HERE"
 ```
 
-Replace `<YOUR_SERVICEBAY_URL>` with the URL you used to log in (the same one
-shown in the **MCP Server** card on Settings → Integrations).
+Replace `<YOUR_SERVICEBAY_URL>` with the URL you used to log in (the same
+one shown in the **MCP Server** card on Settings → Integrations).
+
+> **Legacy: session cookie.** Pre-existing MCP setups that pass
+> `Cookie: session=<JWT>` still work and have full scopes. New clients
+> should use Bearer tokens — they're per-client, scope-able, and
+> revocable.
 
 ### 3. Verify
 

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -21,6 +21,13 @@ import {
 import { restoreSystemBackup } from '@/lib/systemBackup';
 import { guardMutation, guardExec, snapshotBeforeMutation } from './safety';
 import { recordAudit } from './audit';
+import type { ApiScope } from './tokens';
+
+interface McpAuthContext {
+  user: string;
+  scopes: ApiScope[];
+  tokenId?: string;
+}
 
 const nodeParam = z.string().optional().describe('Node name (defaults to first available node)');
 
@@ -52,6 +59,41 @@ const MUTATING_TOOLS = new Set([
   'run_backup', 'restore_backup',
   'update_config', 'exec_command', 'refresh_agent',
 ]);
+
+/**
+ * Per-tool required scope. Bearer-token auth refuses any tool whose scope
+ * isn't in the token's set. Cookie auth has all scopes for back-compat.
+ *
+ *   read       lookups + diagnose + log readers
+ *   lifecycle  start/stop/restart + run_check_now + refresh + run_backup
+ *   mutate     create/update/add — additive changes
+ *   destroy    delete/exec/restore/purge — irreversible
+ */
+const TOOL_SCOPES: Record<string, ApiScope> = {
+  // read
+  list_nodes: 'read', list_services: 'read', list_containers: 'read',
+  get_service_logs: 'read', get_container_logs: 'read', get_service_files: 'read',
+  list_templates: 'read', get_template_readme: 'read', get_template_yaml: 'read',
+  get_template_variables: 'read',
+  get_system_info: 'read', get_network_graph: 'read', get_health_checks: 'read',
+  get_gateway_status: 'read', get_proxy_routes: 'read', get_config: 'read',
+  get_podman_logs: 'read', list_system_services: 'read',
+  list_backups: 'read', diagnose: 'read', verify_node_connection: 'read',
+  list_trashed_services: 'read',
+  // lifecycle
+  start_service: 'lifecycle', stop_service: 'lifecycle', restart_service: 'lifecycle',
+  run_check_now: 'lifecycle', refresh_agent: 'lifecycle',
+  run_backup: 'lifecycle',
+  // mutate
+  deploy_service: 'mutate', update_service_yaml: 'mutate', rename_service: 'mutate',
+  add_proxy_route: 'mutate', create_health_check: 'mutate',
+  restore_trashed_service: 'mutate',
+  // destroy
+  delete_service: 'destroy', delete_health_check: 'destroy',
+  remove_proxy_route: 'destroy', restore_backup: 'destroy',
+  purge_trashed_service: 'destroy', update_config: 'destroy',
+  exec_command: 'destroy',
+};
 
 /**
  * Subset of MUTATING_TOOLS that can lose data or change config in
@@ -86,6 +128,7 @@ function safeHandler(
   toolName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handler: (...handlerArgs: any[]) => Promise<ToolResult>,
+  auth?: McpAuthContext,
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return async (...handlerArgs: any[]): Promise<ToolResult> => {
@@ -94,6 +137,13 @@ function safeHandler(
     let outcome: 'ok' | 'error' | 'blocked' = 'ok';
     let errorMessage: string | undefined;
     try {
+      // Scope check (token auth only — cookie has all scopes by design).
+      const required = TOOL_SCOPES[toolName] ?? 'read';
+      if (auth && !auth.scopes.includes(required)) {
+        outcome = 'blocked';
+        errorMessage = `Token scope '${required}' required for ${toolName}; this token has [${auth.scopes.join(',')}]`;
+        return { content: [{ type: 'text' as const, text: errorMessage }], isError: true as const };
+      }
       if (MUTATING_TOOLS.has(toolName)) {
         const blocked = await guardMutation(toolName);
         if (blocked) {
@@ -131,6 +181,7 @@ function safeHandler(
       void recordAudit({
         ts: new Date().toISOString(),
         tool: toolName,
+        caller: auth?.user,
         outcome,
         durationMs: Date.now() - start,
         args,
@@ -140,18 +191,19 @@ function safeHandler(
   };
 }
 
-export function createMcpServer() {
+export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   const baseServer = new McpServer({
     name: 'servicebay',
     version: '1.0.0',
   });
   // Wrap every tool registration so the safety layer applies uniformly.
   // Read-only tools pass through unchanged; mutating tools land in the
-  // gates defined above.
+  // gates defined above. The auth context is closed over per-server so
+  // each request gets its own scope set.
   const server = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tool: (name: string, desc: string, schema: any, handler: (...args: any[]) => Promise<ToolResult>) =>
-      baseServer.tool(name, desc, schema, safeHandler(name, handler)),
+      baseServer.tool(name, desc, schema, safeHandler(name, handler, opts?.auth)),
     connect: baseServer.connect.bind(baseServer),
     close: baseServer.close.bind(baseServer),
   };

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -1,0 +1,165 @@
+/**
+ * Scoped API tokens for MCP. Replaces the all-or-nothing session-cookie
+ * auth path with named, revocable tokens that carry an explicit scope set.
+ *
+ * Scopes (cumulative — a token can have any subset; the gate is per-tool):
+ *   - read       list_*, get_*, diagnose, list_trashed_services
+ *   - lifecycle  start/stop/restart, run_check_now, refresh_agent
+ *   - mutate     deploy_service, update_service_yaml, add_proxy_route,
+ *                create_health_check, run_backup, restore_trashed_service,
+ *                rename_service
+ *   - destroy    delete_service, delete_health_check, remove_proxy_route,
+ *                restore_backup, purge_trashed_service, update_config,
+ *                exec_command
+ *
+ * Token format on the wire: `sb_<id>_<secret>` (Bearer header). The id is
+ * a public 8-char hex; the secret is 32 random base32-alphabet characters.
+ * We persist only sha-256(secret) plus the id so a stolen tokens.json
+ * file doesn't leak active credentials.
+ *
+ * Cookie auth (the original surface) still works and is treated as
+ * "all scopes" so we don't break clients that worked before this PR.
+ */
+import fsp from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import { DATA_DIR } from '@/lib/dirs';
+import { atomicWriteFile } from '@/lib/util/atomicWrite';
+import { logger } from '@/lib/logger';
+
+export type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'destroy';
+export const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'destroy'];
+
+export interface ApiToken {
+  id: string;            // 8-hex public id
+  name: string;          // operator-supplied label
+  scopes: ApiScope[];
+  hash: string;          // sha256(secret), hex
+  prefix: string;        // first 4 chars of secret, for UI display only
+  createdAt: string;
+  expiresAt?: string;
+  lastUsedAt?: string;
+  createdBy: string;     // session.user at creation time
+}
+
+const TOKENS_FILE = path.join(DATA_DIR, 'mcp-tokens.json');
+const SECRET_LEN = 32;
+const SECRET_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // base32-ish, no I/0/O/1
+
+interface TokensFile { tokens: ApiToken[] }
+
+async function loadFile(): Promise<TokensFile> {
+  try {
+    const raw = await fsp.readFile(TOKENS_FILE, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && Array.isArray(parsed.tokens)) return parsed;
+  } catch { /* fall through to empty */ }
+  return { tokens: [] };
+}
+
+async function saveFile(data: TokensFile): Promise<void> {
+  await atomicWriteFile(TOKENS_FILE, JSON.stringify(data, null, 2));
+  // chmod restrict: tokens file holds password hashes — same protection
+  // class as auth.passwordHash in config.json.
+  try { await fsp.chmod(TOKENS_FILE, 0o600); } catch { /* best-effort */ }
+}
+
+function genId(): string {
+  return crypto.randomBytes(4).toString('hex');
+}
+function genSecret(): string {
+  // 32 chars from base32-ish alphabet → ~160 bits of entropy.
+  const bytes = crypto.randomBytes(SECRET_LEN);
+  let out = '';
+  for (let i = 0; i < SECRET_LEN; i++) {
+    out += SECRET_ALPHABET[bytes[i] % SECRET_ALPHABET.length];
+  }
+  return out;
+}
+function sha256(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+/** Strip the hash field for any caller-facing list. The hash never leaves
+ *  the server. */
+function publicView(t: ApiToken): Omit<ApiToken, 'hash'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { hash, ...rest } = t;
+  return rest;
+}
+
+export async function listTokens(): Promise<Array<Omit<ApiToken, 'hash'>>> {
+  const data = await loadFile();
+  return data.tokens.map(publicView);
+}
+
+export async function createToken(input: {
+  name: string;
+  scopes: ApiScope[];
+  expiresAt?: string;
+  createdBy: string;
+}): Promise<{ token: Omit<ApiToken, 'hash'>; secret: string }> {
+  if (!input.name?.trim()) throw new Error('Token name is required');
+  if (!input.scopes?.length) throw new Error('At least one scope is required');
+  for (const s of input.scopes) {
+    if (!ALL_SCOPES.includes(s)) throw new Error(`Unknown scope: ${s}`);
+  }
+  const data = await loadFile();
+  const id = genId();
+  const secret = genSecret();
+  const token: ApiToken = {
+    id,
+    name: input.name.trim().slice(0, 100),
+    scopes: [...new Set(input.scopes)],
+    hash: sha256(secret),
+    prefix: secret.slice(0, 4),
+    createdAt: new Date().toISOString(),
+    expiresAt: input.expiresAt,
+    createdBy: input.createdBy,
+  };
+  data.tokens.push(token);
+  await saveFile(data);
+  logger.info('mcp:tokens', `Created MCP token ${id} ("${token.name}") scopes=[${token.scopes.join(',')}] by ${input.createdBy}`);
+  // The clear-text token is `sb_<id>_<secret>` — returned exactly once.
+  return { token: publicView(token), secret: `sb_${id}_${secret}` };
+}
+
+export async function revokeToken(id: string): Promise<boolean> {
+  const data = await loadFile();
+  const before = data.tokens.length;
+  data.tokens = data.tokens.filter(t => t.id !== id);
+  if (data.tokens.length === before) return false;
+  await saveFile(data);
+  logger.info('mcp:tokens', `Revoked MCP token ${id}`);
+  return true;
+}
+
+/**
+ * Verify a Bearer-style raw token string ("sb_<id>_<secret>"). Returns the
+ * token (without hash) on success, or null. Side effect: stamps lastUsedAt
+ * on success — the operator wants to see "this token was used 5 minutes
+ * ago" in the UI.
+ *
+ * Constant-time comparison via crypto.timingSafeEqual to avoid timing
+ * oracles on the hash check (both sides are sha-256 of equal length).
+ */
+export async function verifyToken(raw: string): Promise<Omit<ApiToken, 'hash'> | null> {
+  const m = raw.match(/^sb_([0-9a-f]{8})_([A-Z2-9]+)$/);
+  if (!m) return null;
+  const [, id, secret] = m;
+  const data = await loadFile();
+  const token = data.tokens.find(t => t.id === id);
+  if (!token) return null;
+  if (token.expiresAt && Date.parse(token.expiresAt) < Date.now()) return null;
+
+  const incomingHash = Buffer.from(sha256(secret), 'hex');
+  const storedHash = Buffer.from(token.hash, 'hex');
+  if (incomingHash.length !== storedHash.length) return null;
+  if (!crypto.timingSafeEqual(incomingHash, storedHash)) return null;
+
+  // Stamp lastUsedAt — best-effort, doesn't block auth.
+  token.lastUsedAt = new Date().toISOString();
+  saveFile(data).catch(e => logger.warn('mcp:tokens', `Could not update lastUsedAt for ${id}: ${e instanceof Error ? e.message : String(e)}`));
+
+  return publicView(token);
+}


### PR DESCRIPTION
## Summary

PR 4 of 5 in the MCP safety series — the structurally-right answer. Replaces the all-or-nothing session-cookie auth with named, revocable tokens carrying an explicit scope set.

## Scopes

| Scope | Tools |
|---|---|
| **read** | `list_*`, `get_*`, `diagnose`, `list_trashed_services`, `verify_node_connection` |
| **lifecycle** (cumulative) | adds `start_service`, `stop_service`, `restart_service`, `run_check_now`, `refresh_agent`, `run_backup` |
| **mutate** (cumulative) | adds `deploy_service`, `update_service_yaml`, `rename_service`, `add_proxy_route`, `create_health_check`, `restore_trashed_service` |
| **destroy** (cumulative) | adds `delete_service`, `delete_health_check`, `remove_proxy_route`, `restore_backup`, `purge_trashed_service`, `update_config`, `exec_command` |

A token can carry any subset. `read` is the recommended default for an LLM that just needs visibility.

## Wire format

`Authorization: Bearer sb_<id>_<secret>` where:
- `id` — 8 hex chars, public, used for revocation
- `secret` — 32 chars from a base32-ish alphabet (~160 bits entropy)
- only `sha-256(secret)` is persisted; `tokens.json` is `chmod 600`

Verification uses `crypto.timingSafeEqual` to avoid hash-comparison timing oracles.

## Back-compat

Cookie-based auth still works and is treated as "all scopes" so existing clients don't break. New setups should prefer Bearer tokens — they're per-client, scope-able, and revocable.

## UI

`Settings → Integrations → MCP Server → API tokens`:

- List of tokens with name, scope chips, public id + 4-char prefix, last-used-at, revoke button.
- "New token" form: name, scope checkboxes.
- Cleartext secret shown **once** in an amber "save now" panel with copy button. After dismiss, it's gone — only the hash remains.

## Audit log integration

Every tool call records the caller (`token:<token-name>` for Bearer, `<username>` for cookie). Visible in the Recent MCP activity panel and in `mcp-audit.log`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Create a `read`-only token → use it from Claude Code
- [ ] Call `start_service` with that token → blocked with `Token scope 'lifecycle' required`
- [ ] Audit log shows `caller: token:Claude Code on workstation` and `outcome: blocked`
- [ ] Revoke the token → next call returns 401 from `/mcp`
- [ ] Existing cookie-based MCP setup still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)