### PR TITLE
feat(security): email operator on every successful destructive MCP op

### DIFF
--- a/src/lib/mcp/notify.ts
+++ b/src/lib/mcp/notify.ts
@@ -1,0 +1,113 @@
+/**
+ * Email the operator after every successful destructive MCP call. The
+ * point isn't real-time alerting (audit log already covers post-mortem)
+ * — it's "if a stolen token is exfiltrating data right now, you find
+ * out within minutes instead of hours". Hard to ignore something
+ * sitting in your inbox.
+ *
+ * Coalescing: a runaway agent calling delete_service in a loop would
+ * spam the operator's inbox. Coalesce by tool over a 5-minute window:
+ * the first event in a window emails immediately; subsequent events
+ * within the window are counted; an aggregate email lands at flush
+ * time noting how many fired.
+ *
+ * No-op when SMTP isn't configured (sendEmailAlert short-circuits).
+ */
+import { sendEmailAlert } from '@/lib/email';
+import { logger } from '@/lib/logger';
+
+const COALESCE_WINDOW_MS = 5 * 60_000;
+
+interface PendingNotice {
+  count: number;
+  firstAt: string;
+  lastCaller?: string;
+  flushTimer: NodeJS.Timeout;
+}
+const pending = new Map<string, PendingNotice>();
+
+function summarizeArgs(args?: Record<string, unknown>): string {
+  if (!args) return '(no args)';
+  const lines: string[] = [];
+  for (const [k, v] of Object.entries(args)) {
+    if (k === 'password' || k === 'secret' || k === 'token' || k === 'credentials') {
+      lines.push(`  ${k}: [redacted]`);
+      continue;
+    }
+    if (k === 'command' && typeof v === 'string' && v.length > 200) {
+      lines.push(`  ${k}: ${v.slice(0, 200)}…`);
+      continue;
+    }
+    if (k === 'kubeContent' || k === 'yamlContent') {
+      const len = typeof v === 'string' ? v.length : 0;
+      lines.push(`  ${k}: ${len} chars`);
+      continue;
+    }
+    let str: string;
+    try { str = typeof v === 'string' ? v : JSON.stringify(v); } catch { str = '[unserializable]'; }
+    if (str.length > 120) str = `${str.slice(0, 120)}…`;
+    lines.push(`  ${k}: ${str}`);
+  }
+  return lines.length ? lines.join('\n') : '(empty)';
+}
+
+export async function notifyDestructiveOp(opts: {
+  tool: string;
+  caller?: string;
+  args?: Record<string, unknown>;
+  ts: string;
+}): Promise<void> {
+  try {
+    const existing = pending.get(opts.tool);
+    if (existing) {
+      // Within the coalesce window — count and let the timer flush later.
+      existing.count += 1;
+      existing.lastCaller = opts.caller;
+      return;
+    }
+    // First event for this tool in the current window — send immediately.
+    await sendEmailAlert(
+      `MCP destructive op: ${opts.tool}`,
+      [
+        `A destructive MCP call just succeeded on this ServiceBay.`,
+        ``,
+        `  Tool:      ${opts.tool}`,
+        `  Caller:    ${opts.caller ?? 'unknown'}`,
+        `  Timestamp: ${opts.ts}`,
+        ``,
+        `Arguments:`,
+        summarizeArgs(opts.args),
+        ``,
+        `If this wasn't you, revoke the token at Settings → Integrations → MCP Server → API tokens, then restore from the auto-snapshot taken at the same timestamp under Settings → Backups.`,
+      ].join('\n'),
+    );
+    // Schedule a possible "+N more" follow-up.
+    const flushTimer = setTimeout(() => {
+      const entry = pending.get(opts.tool);
+      pending.delete(opts.tool);
+      if (!entry || entry.count < 2) return;
+      sendEmailAlert(
+        `MCP destructive op: ${opts.tool} ×${entry.count - 1} more`,
+        [
+          `Continued activity on this ServiceBay since the last alert.`,
+          ``,
+          `  Tool:           ${opts.tool}`,
+          `  Additional ops: ${entry.count - 1}`,
+          `  Window since:   ${entry.firstAt}`,
+          `  Last caller:    ${entry.lastCaller ?? 'unknown'}`,
+          ``,
+          `Check Settings → Integrations → MCP Server → Recent MCP activity for the full list.`,
+        ].join('\n'),
+      ).catch((e: unknown) => logger.warn('mcp:notify', `Coalesced flush email failed: ${e instanceof Error ? e.message : String(e)}`));
+    }, COALESCE_WINDOW_MS);
+    flushTimer.unref?.();
+    pending.set(opts.tool, {
+      count: 1,
+      firstAt: opts.ts,
+      lastCaller: opts.caller,
+      flushTimer,
+    });
+  } catch (e) {
+    logger.warn('mcp:notify', `Destructive-op notification failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -21,6 +21,7 @@ import {
 import { restoreSystemBackup } from '@/lib/systemBackup';
 import { guardMutation, guardExec, snapshotBeforeMutation } from './safety';
 import { recordAudit } from './audit';
+import { notifyDestructiveOp } from './notify';
 import type { ApiScope } from './tokens';
 
 interface McpAuthContext {
@@ -176,10 +177,11 @@ function safeHandler(
       errorMessage = e instanceof Error ? e.message : String(e);
       throw e;
     } finally {
+      const ts = new Date().toISOString();
       // Audit fire-and-forget — never block the tool response on the log
       // write. Tracked separately by mcp:audit logger.
       void recordAudit({
-        ts: new Date().toISOString(),
+        ts,
         tool: toolName,
         caller: auth?.user,
         outcome,
@@ -187,6 +189,13 @@ function safeHandler(
         args,
         errorMessage,
       });
+      // Email the operator on every successful destructive call so a stolen
+      // token / runaway agent shows up in their inbox right away. Skip
+      // failures and `blocked` (the safety layer already handled those).
+      // No-op when SMTP isn't configured.
+      if (DESTRUCTIVE_TOOLS.has(toolName) && outcome === 'ok') {
+        void notifyDestructiveOp({ tool: toolName, caller: auth?.user, args, ts }).catch(() => undefined);
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary

Final (5/5) PR in the MCP safety series. If a stolen token or runaway agent fires a destructive call, the operator now gets an immediate email so they can intervene within minutes instead of hours.

## Triggers

Email fires on every **successful** call to:
- `delete_service` / `purge_trashed_service`
- `update_service_yaml` / `update_config`
- `add_proxy_route` / `remove_proxy_route` (matters because route loss can break SSO)
- `restore_backup`
- `exec_command`
- `deploy_service` / `rename_service`

(Same set as `DESTRUCTIVE_TOOLS` from PR #169.) Skipped on `error` and `blocked` — the audit log already covers those, and an email per blocked attempt would itself be noise during exploitation.

## Coalescing

A runaway agent calling `delete_service` in a tight loop would spam the inbox into uselessness. Coalesce per-tool over a 5-minute window:
- **First event** in a window → immediate email with caller, timestamp, redacted args, recovery hint.
- **Subsequent events** within the window → silently counted.
- **Window flush** (5 min after the first event) → single `+N more` follow-up email if any additional events occurred.

## Args redaction

Same scheme as the audit log:
- `password`/`secret`/`token`/`credentials` → `[redacted]`
- `command` (exec_command) → truncated at 200 chars
- `kubeContent`/`yamlContent` → reported as `<N> chars`
- everything else included up to 120 chars

## Recovery copy in the email body

Each alert ends with: *"If this wasn't you, revoke the token at Settings → Integrations → MCP Server → API tokens, then restore from the auto-snapshot taken at the same timestamp under Settings → Backups."*

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Configure SMTP, then call `delete_service` via MCP → email arrives within ~1 min with redacted args
- [ ] Call `delete_service` 5 times back-to-back → first one emails immediately; the rest are silently counted; 5 minutes later, one summary email lands
- [ ] Call with `exec_command command="<200-char string>"` → email shows truncated command (`…(N more chars)`)
- [ ] Block a call (e.g. mutations off) → no email (audit log entry only)

## Series wrap-up

| PR | Status |
|---|---|
| #169 — A+B+C: read-only mode, exec denylist, pre-mutation snapshot | ✅ shipped 3.3.0 |
| #171 — D: soft-delete to trash, 7-day restore | ✅ shipped |
| #173 — E: audit log + Recent activity panel | ✅ shipped |
| #174 — F: scoped API tokens (read/lifecycle/mutate/destroy) | ✅ shipped |
| **this PR** — G: destructive-op email alerts | shipping now |

🤖 Generated with [Claude Code](https://claude.com/claude-code)