### PR TITLE
fix: health-check scheduler + radicale dumb-init + SELinux annotations on bind mounts

### DIFF
--- a/src/lib/health/service.ts
+++ b/src/lib/health/service.ts
@@ -1,13 +1,18 @@
 import { Server } from 'socket.io';
+import fs from 'fs';
+import path from 'path';
 import { logger } from '@/lib/logger';
 import { HealthStore } from './store';
 import { CheckRunner } from './runner';
 import { CheckConfig, CheckResult } from './types';
 import { initializeDefaultChecks } from './init';
 import { sendEmailAlert } from '@/lib/email';
+import { DATA_DIR } from '@/lib/dirs';
 
 // In-memory interval tracking
 const intervals = new Map<string, NodeJS.Timeout>();
+
+const CHECKS_FILE = path.join(DATA_DIR, 'checks.json');
 
 export class HealthService {
   private static io: Server | null = null;
@@ -15,40 +20,53 @@ export class HealthService {
   static async init(io: Server) {
     this.io = io;
 
-    // Re-schedule whenever a check is added/edited/removed via the API,
-    // ServiceManager auto-add, the wizard, or any other store mutation.
-    // Without this, only the checks present at init time ever ran — checks
-    // added later (e.g. the per-service `Service: <name>` checks created
-    // when a stack deploys) sat dormant with lastResult=null forever.
-    HealthStore.subscribe({
-      onSave: (check) => this.scheduleOne(check),
-      onDelete: (id) => this.unscheduleOne(id),
-    });
-
     // 1. Ensure defaults
     await initializeDefaultChecks();
 
     // 2. Start initial scheduling
     this.restartAll();
+
+    // 3. Re-schedule whenever the checks file changes on disk.
+    //
+    // The previous design used an in-process listener on HealthStore,
+    // which worked for code paths that shared this module instance — but
+    // Next.js bundles API routes (and the wizard's ServiceManager
+    // auto-add path) into a webpack graph that's separate from the
+    // custom server's esbuild bundle. saveCheck calls from there
+    // landed on a *different* `listeners[]` array, so the listener
+    // never fired and the new checks sat dormant with lastResult=null.
+    //
+    // fs.watch is bundle-agnostic: any process that mutates the file
+    // triggers our restart, regardless of which module wrote it. We
+    // debounce because a single saveCheck typically emits two `change`
+    // events on Linux (one for each step of an atomic-ish replace).
+    this.startChecksFileWatcher();
   }
 
-  /** Schedule (or re-schedule) a single check. Idempotent. */
-  private static scheduleOne(check: CheckConfig) {
-    const existing = intervals.get(check.id);
-    if (existing) clearInterval(existing);
-    if (!check.enabled) {
-      intervals.delete(check.id);
-      return;
-    }
-    this.scheduleCheck(check);
-  }
+  private static checksWatcher: fs.FSWatcher | null = null;
+  private static checksWatcherDebounce: NodeJS.Timeout | null = null;
 
-  /** Stop a single check's interval. */
-  private static unscheduleOne(id: string) {
-    const t = intervals.get(id);
-    if (t) {
-      clearInterval(t);
-      intervals.delete(id);
+  private static startChecksFileWatcher() {
+    if (this.checksWatcher) return;
+    try {
+      // Make sure the file's parent dir exists; fs.watch on a missing
+      // path throws synchronously.
+      try { fs.mkdirSync(DATA_DIR, { recursive: true }); } catch { /* ok */ }
+      this.checksWatcher = fs.watch(DATA_DIR, (_event, filename) => {
+        if (filename !== 'checks.json') return;
+        if (this.checksWatcherDebounce) clearTimeout(this.checksWatcherDebounce);
+        this.checksWatcherDebounce = setTimeout(() => {
+          this.checksWatcherDebounce = null;
+          logger.info('Health', 'checks.json changed — re-scheduling.');
+          this.restartAll();
+        }, 250);
+      });
+      this.checksWatcher.on('error', (e) => {
+        logger.warn('Health', `checks.json watcher error: ${e instanceof Error ? e.message : String(e)}`);
+      });
+      logger.info('Health', `Watching ${CHECKS_FILE} for new/changed checks.`);
+    } catch (e) {
+      logger.warn('Health', `Could not start checks.json watcher: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/src/lib/health/store.ts
+++ b/src/lib/health/store.ts
@@ -17,28 +17,20 @@ function ensureDirs() {
 }
 
 /**
- * Listener interface for check mutations. HealthService subscribes here in
- * init() so any code path that adds/edits/removes a check (the wizard, the
- * API, ServiceManager auto-add, backup-sync) immediately gets the new check
- * scheduled — without each call site needing to know about the scheduler.
+ * Note: an earlier listener-callback design (PR #166) was abandoned because
+ * Next.js bundles API routes in a webpack module graph that's separate from
+ * the custom server's esbuild bundle. saveCheck calls from API routes
+ * therefore landed on a *different* listeners[] array than where
+ * HealthService.init subscribed — so the listener never fired and per-
+ * service checks created via the wizard sat dormant with lastResult=null.
+ *
+ * The current design is bundle-agnostic: HealthService watches the on-disk
+ * checks.json file with fs.watch and re-schedules whenever it changes.
+ * Both bundles share the filesystem, so the signal lands wherever the
+ * server is actually running.
  */
-export interface HealthStoreListener {
-  onSave?: (check: CheckConfig) => void;
-  onDelete?: (id: string) => void;
-}
-
-const listeners: HealthStoreListener[] = [];
 
 export class HealthStore {
-  /** Register a listener. Returns an unsubscribe fn. */
-  static subscribe(listener: HealthStoreListener): () => void {
-    listeners.push(listener);
-    return () => {
-      const i = listeners.indexOf(listener);
-      if (i >= 0) listeners.splice(i, 1);
-    };
-  }
-
   static getChecks(): CheckConfig[] {
     if (!fs.existsSync(CHECKS_FILE)) return [];
     try {
@@ -59,14 +51,12 @@ export class HealthStore {
       checks.push(check);
     }
     fs.writeFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
-    for (const l of listeners) l.onSave?.(check);
   }
 
   static deleteCheck(id: string) {
     ensureDirs();
     const checks = this.getChecks().filter(c => c.id !== id);
     fs.writeFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
-    for (const l of listeners) l.onDelete?.(id);
   }
 
   static saveResult(result: CheckResult) {

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -6,6 +6,14 @@ metadata:
     app: file-share
   annotations:
     servicebay.ports: "8384/tcp,22000/tcp,139/tcp,445/tcp"
+    # Disable SELinux labelling on the syncthing + samba bind mounts.
+    # Fedora CoreOS ships SELinux enforcing; without this annotation,
+    # podman play-kube doesn't relabel the hostPath dirs and syncthing
+    # can't `chmod` or write its cert.pem ("operation not permitted")
+    # even with runAsUser: 0. Targeted per-container disable is safer
+    # than `privileged: true` — no extra capabilities granted.
+    io.podman.annotations.label/syncthing: "disable"
+    io.podman.annotations.label/samba: "disable"
 spec:
   hostNetwork: true
   containers:

--- a/templates/filebrowser/template.yml
+++ b/templates/filebrowser/template.yml
@@ -7,6 +7,11 @@ metadata:
   annotations:
     servicebay.ports: "{{FILEBROWSER_PORT}}/tcp"
     servicebay.config-mount: /config
+    # Disable SELinux labelling on the bind mounts. Same reason as the
+    # file-share pod: FCoS ships SELinux enforcing, podman play-kube
+    # doesn't relabel hostPath dirs by default, and the entrypoint's
+    # initial-config seed `cp` fails with EPERM otherwise.
+    io.podman.annotations.label/filebrowser: "disable"
 spec:
   hostNetwork: true
   containers:

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -7,25 +7,33 @@ metadata:
   annotations:
     servicebay.ports: "{{RADICALE_PORT}}/tcp"
     servicebay.config-mount: /config
+    # Disable SELinux labelling on the bind mounts (same as file-share /
+    # filebrowser). FCoS + SELinux + podman play-kube otherwise refuses
+    # writes to hostPath bind dirs from the container.
+    io.podman.annotations.label/radicale: "disable"
 spec:
   hostNetwork: true
   containers:
   - name: radicale
     image: docker.io/tomsquest/docker-radicale:latest
-    # The image's ENTRYPOINT is `["dumb-init", "--"]` and its CMD is
-    # `["radicale"]`. K8s `args:` replaces CMD only — without an explicit
-    # `command:` here, the resulting exec becomes
+    # The image's ENTRYPOINT is `["dumb-init", "--"]` and CMD is
+    # `["radicale"]`. K8s `args:` replaces CMD only. The original bug was
+    # passing `--config=…` directly as args, producing
     #     dumb-init -- --config=/config/config
-    # and dumb-init then tries to run `--config=…` as a program, exiting
-    # with `exec: line 49: illegal option --` in a tight restart loop.
-    # Setting `command:` re-injects the radicale binary in the chain so
-    # the args land where they belong. dumb-init stays the entrypoint
-    # (signal forwarding, zombie reaping intact).
-    command:
-      - "dumb-init"
-      - "--"
-      - "radicale"
+    # → dumb-init ran `--config=…` as a program and exited.
+    #
+    # PR #164's fix used `command: ["dumb-init", "--", "radicale"]` to
+    # force the chain. That broke differently: when K8s `command:` is set,
+    # podman/crun doesn't propagate the image's PATH, so `dumb-init`
+    # wasn't found ("crun: executable file `dumb-init` not found in
+    # $PATH"). Image's ENTRYPOINT path resolution doesn't apply when
+    # we replace it from the manifest.
+    #
+    # The reliable fix: just restore the binary name as the first arg.
+    # ENTRYPOINT (`dumb-init --`) stays from the image, dumb-init resolves
+    # via the image's own PATH, then it execs `radicale` with our flags.
     args:
+      - "radicale"
       - "--config=/config/config"
     ports:
       - containerPort: {{RADICALE_PORT}}


### PR DESCRIPTION
## Summary

Three distinct bugs surfaced on the clean 3.4.x reinstall today; bundling them so a single follow-up reinstall closes everything.

### 1. Health-check scheduler doesn't tick for wizard-created checks
Per-service checks (`Service: nginx-web`, `Service: lldap`, …, 12 of them) sat with `lastResult: null` indefinitely. Defaults (Internet Gateway, Podman Socket, Agent: Local) ticked fine.

**Root cause:** Next.js bundles API routes + the wizard's `ServiceManager` auto-add path into a **webpack module graph** that's separate from the custom server's **esbuild** bundle. The PR #166 listener-callback design registered callbacks in one bundle's `listeners[]` and `saveCheck` calls from the other bundle hit a different empty `listeners[]`. Defaults worked because `HealthService.init` calls `saveCheck` during init — same bundle, same array. Wizard-created checks failed silently.

**Fix:** drop the listener pattern. `HealthService.init` now `fs.watch`es `DATA_DIR/checks.json`. Whoever writes the file — regardless of which bundle loaded the writing module — triggers a debounced `restartAll()`. The filesystem is the only shared signal between the two bundles.

### 2. Radicale: `crun: executable file 'dumb-init' not found in $PATH`
PR #164 set `command: ["dumb-init", "--", "radicale"]` to bypass the original `--config=…` arg-passing bug. But when K8s `command:` overrides ENTRYPOINT, podman/crun doesn't propagate the image's PATH, so the bare binary name failed to resolve.

**Fix:** revert the `command:` override. Just use `args: ["radicale", "--config=…"]` — the image's ENTRYPOINT (`dumb-init --`) stays in place, dumb-init resolves via the image's own PATH, then execs `radicale --config=…`.

### 3. Syncthing/filebrowser/radicale bind-mount writes denied
Despite `runAsUser: 0` from PR #162, syncthing still hits `chmod /var/syncthing/config: operation not permitted`. The `EPERM` (not `EACCES`) is SELinux's signature, and FCoS ships SELinux enforcing.

**Fix:** add `io.podman.annotations.label/<container>: "disable"` annotations on the three pods that write to hostPath bind dirs. Per-container scoping is safer than `privileged: true` — no extra capabilities granted — and works with podman's existing `play kube` semantics.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Reinstall 3.4.x with these fixes
- [ ] `Settings → Health` shows lastResult populated for all 15 enabled checks within 60 s
- [ ] `podman ps` shows radicale-radicale, file-share-syncthing, filebrowser-filebrowser all `Up`
- [ ] `Settings → Self-Diagnose` shows ✅ all green

## Diagnostic trail
Found via MCP into the user's running 3.4.x install:
- `get_container_logs servicebay tail=10000` → 12 `[ServiceManager] Created health check` entries, zero `[Health] Started …` entries after init
- `get_container_logs radicale-radicale` → "no such container" because the pod exits immediately on dumb-init lookup failure
- `get_container_logs file-share-syncthing` → identical chmod/cert.pem EPERM as before despite runAsUser:0

🤖 Generated with [Claude Code](https://claude.com/claude-code)