### PR TITLE
fix: inject restart directives on every stack + radicale via env + syncthing privileged

### DIFF
--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -533,11 +533,19 @@ export class ServiceManager {
             throw new Error(`Port collision on node "${nodeName}": ${detail}. Change the host port and retry.`);
         }
 
-        // Ensure TimeoutStartSec for multi-image pods so image pulls don't cause systemd timeout
+        // Inject the default systemd directives (TimeoutStartSec for slow
+        // image pulls + Restart=on-failure with exponential backoff) into
+        // every .kube unit, single-image or multi-image. The previous
+        // multi-image-only gate was a leftover from when only the
+        // TimeoutStartSec was injected; it caused single-image services
+        // (radicale, filebrowser, nginx-web, …) to land *without* any
+        // restart directives, so a transient image-pull failure or any
+        // crash put the unit permanently in `failed` state with no auto-
+        // recovery. injectServiceDirectives is idempotent per-directive,
+        // so re-deploys never duplicate keys.
+        kubeContent = injectServiceDirectives(kubeContent);
+
         const images = this.extractImages(yamlContent);
-        if (images.length > 1 && !kubeContent.includes('TimeoutStartSec')) {
-            kubeContent = injectServiceDirectives(kubeContent);
-        }
 
         await this.writeFile(nodeName, yamlName, yamlContent);
         await this.writeFile(nodeName, `${name}.kube`, kubeContent);

--- a/src/lib/services/quadletDirectives.ts
+++ b/src/lib/services/quadletDirectives.ts
@@ -23,6 +23,13 @@ const DEFAULT_SERVICE_DIRECTIVES: readonly string[] = [
   'RestartSec=5',
   'RestartSteps=4',
   'RestartMaxDelaySec=300',
+  // Disable systemd's "5 fails in 10 s = give up" guard. A fast-failing
+  // image pull (~2 s before crash) hits the burst limit before our
+  // backoff has had a chance to expand, and systemd marks the unit
+  // start-limit-hit and stops retrying — exactly the symptom that bit
+  // nginx-web on the post-3.4.2 reinstall. 0 = no limit, retry forever
+  // per the backoff schedule.
+  'StartLimitIntervalSec=0',
 ];
 
 /**

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -20,16 +20,21 @@ spec:
   # 1. Syncthing — Bidirectional folder sync (Android & Windows apps)
   - name: syncthing
     image: docker.io/syncthing/syncthing:latest
-    # Run as container UID 0 so rootless podman's user-namespace maps the
-    # process to the host user that owns the hostPath bind dir. Setting
-    # runAsUser: 1000 here was the bug — in rootless mode that maps to a
-    # sub-UID (~100999), not host uid 1000, so the syncthing process
-    # couldn't `chmod /var/syncthing/config` or write `cert.pem` and
-    # crashed in a restart loop. There's no security regression; rootless
-    # "root" is already the unprivileged host user.
+    # Earlier attempts (runAsUser:0 + io.podman.annotations.label/syncthing
+    # = disable) didn't actually let syncthing chmod its config dir on
+    # FCoS. Either the annotation isn't honoured by this podman version,
+    # or the deeper issue is the bind-mount label rather than the
+    # process's SELinux context. Skip the puzzle and grant privileged:
+    # the UID-namespace + SELinux + cap-drop combo all step out of the
+    # way at once. This pod's containers (syncthing + samba) are both
+    # standard, unprivileged-on-the-host services; on a single-tenant
+    # homelab the operator already trusts the workload completely. The
+    # rootless-podman boundary still applies — privileged here means
+    # "no extra capability *deductions*", not "host root".
     securityContext:
       runAsUser: 0
       runAsGroup: 0
+      privileged: true
     env:
       - name: STGUIADDRESS
         value: "0.0.0.0:8384"

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -16,25 +16,21 @@ spec:
   containers:
   - name: radicale
     image: docker.io/tomsquest/docker-radicale:latest
-    # The image's ENTRYPOINT is `["dumb-init", "--"]` and CMD is
-    # `["radicale"]`. K8s `args:` replaces CMD only. The original bug was
-    # passing `--config=…` directly as args, producing
-    #     dumb-init -- --config=/config/config
-    # → dumb-init ran `--config=…` as a program and exited.
+    # We DO NOT override command: or args:. Each previous attempt to do
+    # so broke differently:
+    #   PR #164  command:[dumb-init,--,radicale] → "dumb-init not found
+    #            in PATH" (K8s command: doesn't carry the image's PATH).
+    #   PR #178  args:[radicale,--config=…]      → "radicale: not found"
+    #            (entrypoint.sh's PATH excludes the user-pip install loc).
     #
-    # PR #164's fix used `command: ["dumb-init", "--", "radicale"]` to
-    # force the chain. That broke differently: when K8s `command:` is set,
-    # podman/crun doesn't propagate the image's PATH, so `dumb-init`
-    # wasn't found ("crun: executable file `dumb-init` not found in
-    # $PATH"). Image's ENTRYPOINT path resolution doesn't apply when
-    # we replace it from the manifest.
-    #
-    # The reliable fix: just restore the binary name as the first arg.
-    # ENTRYPOINT (`dumb-init --`) stays from the image, dumb-init resolves
-    # via the image's own PATH, then it execs `radicale` with our flags.
-    args:
-      - "radicale"
-      - "--config=/config/config"
+    # The image's full default chain is
+    #   dumb-init -- /usr/local/bin/entrypoint.sh radicale
+    # which Just Works because the image was built with the right PATH
+    # and the right user. Don't fight it. Pass the config path via env
+    # var instead — radicale reads RADICALE_CONFIG natively.
+    env:
+      - name: RADICALE_CONFIG
+        value: /config/config
     ports:
       - containerPort: {{RADICALE_PORT}}
     volumeMounts:


### PR DESCRIPTION
Three reinstall-blocker fixes found via live MCP debugging.

### 1. `injectServiceDirectives` was multi-image-only

`ServiceManager.ts:538` had `if (images.length > 1 && ...)` — a leftover from when only `TimeoutStartSec` was injected. After PR #167 expanded the directive set, the gate stuck around, so every single-image service (radicale, filebrowser, nginx-web, lldap, authelia, adguard, vaultwarden, audiobookshelf, navidrome) deployed with **zero `[Service]` directives**. That's why nginx-web didn't auto-restart on its transient image-pull failure — `Restart=on-failure` was never applied.

Fix: drop the gate. Helper is idempotent per-directive.

### 2. `StartLimitIntervalSec=0`

A fast-failing image pull (~2 s) hits systemd's default `StartLimitBurst=5 / IntervalSec=10` guard before our backoff ramps. systemd then marks the unit `start-limit-hit` and stops retrying. `0` = no burst limit; retry forever per the backoff schedule.

### 3. Radicale: `RADICALE_CONFIG` env, no command/args override

Two prior fixes hit different exec-path issues:
- PR #164 `command:[dumb-init,--,radicale]` → dumb-init not on PATH (K8s `command:` doesn't carry image PATH).
- PR #178 `args:[radicale,--config=…]` → radicale not on entrypoint.sh's PATH (image's pip-user install location).

Stop fighting the image. Use `RADICALE_CONFIG` env var — radicale reads it natively, image defaults handle the rest.

### 4. Syncthing: `privileged: true`

`runAsUser:0` + `io.podman.annotations.label/syncthing:disable` didn't actually let syncthing chmod its config dir on FCoS+SELinux. Adding `privileged:true` bypasses the SELinux + cap-drop combo. On a single-tenant homelab the workload is trusted; rootless-podman's outer boundary still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)