### PR TITLE
feat(wizard): server-side install lock + concurrent-install guard

### DIFF
--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -2,6 +2,7 @@
 
 import { getConfig, saveConfig } from '@/lib/config';
 import { SSH_DIR } from '@/lib/dirs';
+import { getInstallActive, setInstallActive, clearInstallActive } from '@/lib/wizard/installLock';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -11,6 +12,13 @@ export interface OnboardingStatus {
   hasGateway: boolean;
   hasSshKey: boolean;
   hasExternalLinks: boolean;
+  /**
+   * Set when an install pipeline is currently running in some session.
+   * Other tabs/devices use this to refuse to start a fresh install while
+   * the first one is still in flight. Auto-clears after 30 min if the
+   * heartbeat stops (covers crashed installs / lost power).
+   */
+  installInProgress: { startedAt: string; source?: string } | null;
   features: {
     gateway: boolean;
     ssh: boolean;
@@ -55,12 +63,15 @@ export async function checkOnboardingStatus(): Promise<OnboardingStatus> {
   
   const needsSetup = !config.setupCompleted && !hasGateway;
 
+  const installInProgress = await getInstallActive();
+
   return {
     needsSetup,
     stackSetupPending: config.stackSetupPending === true,
     hasGateway,
     hasSshKey,
     hasExternalLinks,
+    installInProgress,
     features: {
         gateway: !!config.gateway,
         ssh: hasSshKey,
@@ -144,6 +155,7 @@ export async function skipOnboarding() {
     config.setupCompleted = true;
     setSafeMcpDefaults(config);
     await saveConfig(config);
+    await clearInstallActive();
 }
 
 export async function completeStackSetup() {
@@ -151,6 +163,19 @@ export async function completeStackSetup() {
     delete config.stackSetupPending;
     setSafeMcpDefaults(config);
     await saveConfig(config);
+    await clearInstallActive();
+}
+
+/** Acquire / refresh the install lock. Called by the wizard when it
+ *  enters the install pipeline and on a heartbeat while running. */
+export async function markInstallStarted(source: string = 'wizard'): Promise<void> {
+    await setInstallActive(source);
+}
+
+/** Force-clear a stuck lock. Surfaced in the UI so the operator can
+ *  recover from a crashed install without waiting 30 min for auto-expiry. */
+export async function forceClearInstallLock(): Promise<void> {
+    await clearInstallActive();
 }
 
 /**

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -10,6 +10,8 @@ import {
     saveRegistriesConfig,
     saveEmailConfig,
     completeStackSetup,
+    markInstallStarted,
+    forceClearInstallLock,
     OnboardingStatus
 } from '@/app/actions/onboarding';
 import { generateLocalKey } from '@/app/actions/ssh';
@@ -197,6 +199,16 @@ export default function OnboardingWizard() {
   useEffect(() => {
     checkOnboardingStatus().then(s => {
       setStatus(s);
+      // If a server-side install lock exists and we're NOT actively
+      // running the install in this tab (we'd have set stackInstallStep
+      // = 'installing' already and started heartbeating), show the
+      // "another session is installing" gate so the operator doesn't
+      // race two installs in parallel.
+      if (s.installInProgress && stackInstallStep !== 'installing') {
+         
+        setIsOpen(true);
+        return;
+      }
       if (s.needsSetup) {
         setIsOpen(true);
         // Only seed selection from feature detection if we have no persisted draft —
@@ -269,6 +281,19 @@ export default function OnboardingWizard() {
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, [isOpen, currentStep, stackInstallStep]);
+
+  // Heartbeat the server-side install lock while the wizard is in
+  // 'installing'. Other tabs / devices polling /api/onboarding will see
+  // installInProgress and refuse to start a fresh install. The lock
+  // auto-expires server-side at 30 min if heartbeats stop (covers crashed
+  // installs / lost power).
+  useEffect(() => {
+    if (stackInstallStep !== 'installing') return;
+    const tick = () => { void markInstallStarted('wizard'); };
+    tick();
+    const id = setInterval(tick, 20_000);
+    return () => clearInterval(id);
+  }, [stackInstallStep]);
 
   // Auto-run the self-diagnose once the install pipeline lands on 'done'.
   // Gated by `diagnoseRanOnce` so reopening the panel doesn't re-fire and
@@ -858,7 +883,50 @@ export default function OnboardingWizard() {
 
         {/* Content */}
         <div className="p-6 overflow-y-auto">
-            {currentStep === 'welcome' && (
+            {/* Concurrent-install guard. Another browser tab / device /
+                MCP session is currently running an install. Refuse to
+                start a fresh one — racing two installs corrupts the
+                Quadlet directory and the digital twin. Auto-clears
+                30 min after the other session's last heartbeat. */}
+            {status?.installInProgress && stackInstallStep !== 'installing' ? (
+                <div className="space-y-4">
+                    <div className="p-4 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20">
+                        <p className="text-sm font-semibold text-amber-900 dark:text-amber-100 mb-1">
+                            ⏳ Another session is installing
+                        </p>
+                        <p className="text-xs text-amber-800 dark:text-amber-200 mb-2">
+                            An install pipeline is already running ({status.installInProgress.source ?? 'unknown source'}, started {new Date(status.installInProgress.startedAt).toLocaleString()}). Switch to that tab and let it finish, or wait for it to complete here.
+                        </p>
+                        <p className="text-xs text-amber-700 dark:text-amber-300">
+                            If the other session crashed and the lock is stuck, the wizard will release it automatically after 30 minutes — or click below to force-clear.
+                        </p>
+                    </div>
+                    <div className="flex justify-between">
+                        <button
+                            type="button"
+                            onClick={async () => {
+                                if (!confirm('Force-clear the install lock? Only do this if you are certain no other install is actually running — racing two installs will corrupt the Quadlet directory.')) return;
+                                await forceClearInstallLock();
+                                const fresh = await checkOnboardingStatus();
+                                setStatus(fresh);
+                            }}
+                            className="px-3 py-1.5 text-xs text-amber-700 dark:text-amber-300 hover:underline"
+                        >
+                            Force-clear stuck lock
+                        </button>
+                        <button
+                            type="button"
+                            onClick={async () => {
+                                const fresh = await checkOnboardingStatus();
+                                setStatus(fresh);
+                            }}
+                            className="px-3 py-1.5 text-xs rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+                        >
+                            Re-check
+                        </button>
+                    </div>
+                </div>
+            ) : currentStep === 'welcome' && (
                 <div className="space-y-4">
                     <p className="text-gray-600 dark:text-gray-300">
                         Welcome to ServiceBay! Only a few steps to get your environment ready.

--- a/src/lib/wizard/installLock.ts
+++ b/src/lib/wizard/installLock.ts
@@ -1,0 +1,59 @@
+/**
+ * Tiny file-based lock so the onboarding wizard can detect when an install
+ * is already running in another browser tab / device / session.
+ *
+ * Why a lock and not just client-side state: the wizard wants to refuse a
+ * second initial-install attempt regardless of *who* started the first one
+ * — could be a different browser, the operator's phone, or a Claude MCP
+ * session. The shared signal has to live somewhere both can see, and the
+ * filesystem is what every code path can reach without bundle / Next /
+ * webpack contortions.
+ *
+ * Stale detection: if the lock file is older than `STALE_AFTER_MS`, treat
+ * it as expired (the original install probably crashed / lost power /
+ * timed out). The wizard auto-renews the lock with a heartbeat while
+ * the install is actively running.
+ */
+import fs from 'fs/promises';
+import path from 'path';
+import { DATA_DIR } from '@/lib/dirs';
+
+const LOCK_FILE = path.join(DATA_DIR, 'wizard-install.lock');
+const STALE_AFTER_MS = 30 * 60_000; // 30 min — generous, covers slow first-time pulls.
+
+interface LockState {
+  startedAt: string; // ISO
+  source?: string;   // free-form note: "wizard", "mcp", "api"
+}
+
+/** Acquire (or refresh) the install lock. Idempotent — always wins; the
+ *  caller is the source of truth for "is install actually running". */
+export async function setInstallActive(source: string = 'wizard'): Promise<void> {
+  await fs.mkdir(DATA_DIR, { recursive: true }).catch(() => undefined);
+  const state: LockState = { startedAt: new Date().toISOString(), source };
+  await fs.writeFile(LOCK_FILE, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/** Check whether an install is currently active. Returns the lock state
+ *  if active, or null. Stale locks (older than STALE_AFTER_MS without a
+ *  refresh) report null and are also auto-removed so the next status
+ *  check is fast. */
+export async function getInstallActive(): Promise<LockState | null> {
+  try {
+    const raw = await fs.readFile(LOCK_FILE, 'utf-8');
+    const stat = await fs.stat(LOCK_FILE);
+    if (Date.now() - stat.mtimeMs > STALE_AFTER_MS) {
+      // Stale: clean up so the next caller doesn't trip on it.
+      await fs.unlink(LOCK_FILE).catch(() => undefined);
+      return null;
+    }
+    return JSON.parse(raw) as LockState;
+  } catch {
+    return null;
+  }
+}
+
+/** Clear the lock — call when install completes (success or skip). */
+export async function clearInstallActive(): Promise<void> {
+  await fs.unlink(LOCK_FILE).catch(() => undefined);
+}

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -13,6 +13,8 @@ vi.mock('@/app/actions/onboarding', () => ({
   saveRegistriesConfig: vi.fn(),
   saveEmailConfig: vi.fn(),
   completeStackSetup: vi.fn(),
+  markInstallStarted: vi.fn(),
+  forceClearInstallLock: vi.fn(),
 }));
 
 import { checkOnboardingStatus, saveGatewayConfig, completeStackSetup } from '@/app/actions/onboarding';


### PR DESCRIPTION
Opening the wizard in a second tab while an install was already in progress would happily offer another fresh install — racing two installs corrupts the Quadlet directory and the digital twin.

### Fix

- New `src/lib/wizard/installLock.ts` — file-based lock at `DATA_DIR/wizard-install.lock`.
- Wizard heartbeats every 20 s while in `'installing'` step.
- `checkOnboardingStatus()` exposes `installInProgress: { startedAt, source } | null`.
- Wizard renders a "another session is installing" gate when its own state isn't already `'installing'` — explains who started + when, with "force-clear stuck lock" escape hatch.
- Auto-expires after 30 min of no heartbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)