### PR TITLE
feat(wizard): domain prompt at top + LAN-only opt-out + USB auto-pick

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -165,6 +165,12 @@ export default function OnboardingWizard() {
   const [stackSelectedNode, setStackSelectedNode] = useState('');
   const [stacksLoading, setStacksLoading] = useState(false);
   const [stackDomain, setStackDomain] = useState('');
+  // Operator can opt out of providing a public domain. When true, services
+  // are deployed in LAN-only mode (no SSL, accessible only by IP+port). The
+  // wizard's "Continue" button is gated until either a domain is set or
+  // this flag is checked, so the operator can't accidentally finish without
+  // making a deliberate choice.
+  const [stackNoDomain, setStackNoDomain] = useState(false);
   const [stackDeviceOptions, setStackDeviceOptions] = useState<Record<string, string[]>>({});
   const [stackLoadingDevices, setStackLoadingDevices] = useState(false);
 
@@ -452,7 +458,9 @@ export default function OnboardingWizard() {
     }
   };
 
-  // Fetch USB devices when node is selected and device-type variables exist
+  // Fetch USB devices when node is selected and device-type variables exist.
+  // Auto-pick when a path has exactly one device available — saves the
+  // operator a click for the common Z-Wave/Zigbee single-stick case.
   useEffect(() => {
     if (!stackSelectedNode) return;
     const deviceVars = stackVariables.filter(v => v.meta?.type === 'device');
@@ -475,6 +483,23 @@ export default function OnboardingWizard() {
       for (const r of results) opts[r.path] = r.devices;
       setStackDeviceOptions(opts);
       setStackLoadingDevices(false);
+
+      // Auto-pick the single device per path. Only fills variables that
+      // are still empty — never overwrites an explicit operator choice.
+      setStackVariables(prev => {
+        let changed = false;
+        const next = prev.map(v => {
+          if (v.meta?.type !== 'device' || v.value) return v;
+          const path = v.meta?.devicePath || '/dev/serial/by-id';
+          const devices = opts[path] ?? [];
+          if (devices.length === 1) {
+            changed = true;
+            return { ...v, value: devices[0] };
+          }
+          return v;
+        });
+        return changed ? next : prev;
+      });
     });
   }, [stackSelectedNode, stackVariables]);
 
@@ -1102,7 +1127,40 @@ export default function OnboardingWizard() {
 
                     {stackInstallStep === 'services' && (
                         <>
-                            <p className="text-sm text-gray-500 mb-2">Select which services to install from <span className="font-medium">{selectedStack?.name}</span>:</p>
+                            {/* Domain prompt — moved to the TOP of the services
+                                step so the operator answers it before scrolling
+                                through the (potentially long) service list. The
+                                Continue button below is gated until the domain
+                                is set OR the "no domain" checkbox is ticked,
+                                so finishing without a deliberate choice isn't
+                                possible. */}
+                            <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-2">
+                                <label className="flex items-center gap-2 text-sm font-medium text-blue-800 dark:text-blue-200">
+                                    <Globe className="w-4 h-4" /> Public Domain
+                                </label>
+                                <p className="text-xs text-blue-600 dark:text-blue-400">
+                                    Your services will be reachable as subdomains (photos.{stackDomain || 'yourdomain.com'}, vault.{stackDomain || 'yourdomain.com'}, …) with automatic Let&apos;s Encrypt SSL.
+                                </p>
+                                <input
+                                    type="text"
+                                    value={stackDomain}
+                                    onChange={(e) => { setStackDomain(e.target.value); if (e.target.value) setStackNoDomain(false); }}
+                                    disabled={stackNoDomain}
+                                    className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none disabled:opacity-50"
+                                    placeholder="example.com"
+                                />
+                                <label className="flex items-center gap-2 text-xs text-blue-700 dark:text-blue-300 cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        checked={stackNoDomain}
+                                        onChange={e => { setStackNoDomain(e.target.checked); if (e.target.checked) setStackDomain(''); }}
+                                        className="rounded"
+                                    />
+                                    I don&apos;t have a public domain — install services in LAN-only mode (no SSL, no subdomains; access by IP:port).
+                                </label>
+                            </div>
+
+                            <p className="text-sm text-gray-500 mb-2 mt-3">Select which services to install from <span className="font-medium">{selectedStack?.name}</span>:</p>
                             {stacksLoading ? (
                                 <div className="flex items-center justify-center py-4 text-gray-400">
                                     <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading...
@@ -1145,24 +1203,9 @@ export default function OnboardingWizard() {
                                 </div>
                             )}
 
-                            {/* Domain prompt — shown here before configure step */}
-                            {stackItems.some(i => i.checked && !i.alreadyInstalled) && (
-                                <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-                                    <label className="flex items-center gap-2 text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">
-                                        <Globe className="w-4 h-4" /> Public Domain
-                                    </label>
-                                    <p className="text-xs text-blue-600 dark:text-blue-400 mb-2">
-                                        Your services will be accessible as subdomains of this domain (e.g. photos.yourdomain.com).
-                                    </p>
-                                    <input
-                                        type="text"
-                                        value={stackDomain}
-                                        onChange={(e) => setStackDomain(e.target.value)}
-                                        className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none"
-                                        placeholder="example.com"
-                                    />
-                                </div>
-                            )}
+                            {/* Domain prompt is now at the TOP of this step
+                                so the operator answers it before scrolling
+                                through services. See the block above. */}
 
                             {/* RAID detection prompt */}
                             {raidArrays.length > 0 && !raidMounted && (
@@ -1640,9 +1683,19 @@ export default function OnboardingWizard() {
                 <Button onClick={handleStackSkip}>Skip <ArrowRight className="w-4 h-4 ml-2" /></Button>
             )}
             {currentStep === 'stacks' && stackInstallStep === 'services' && (
-                <div className="flex gap-2">
+                <div className="flex gap-2 items-center">
                     <button onClick={() => { setStackInstallStep('select'); setSelectedStack(null); }} className="px-4 py-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">Back</button>
-                    <Button onClick={handleStackFetchVars} disabled={stackItems.filter(i => i.checked).length === 0 || stacksLoading}>
+                    {!stackDomain.trim() && !stackNoDomain && (
+                        <span className="text-xs text-amber-700 dark:text-amber-300">Set a public domain (or check the LAN-only box) to continue.</span>
+                    )}
+                    <Button
+                        onClick={handleStackFetchVars}
+                        disabled={
+                            stackItems.filter(i => i.checked).length === 0
+                            || stacksLoading
+                            || (!stackDomain.trim() && !stackNoDomain)
+                        }
+                    >
                         {stacksLoading ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null} Continue
                     </Button>
                 </div>

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -67,10 +67,19 @@ vi.mock('mustache', () => ({
   },
 }));
 
+// Tick the "I don't have a public domain" checkbox so the wizard's
+// Continue gate releases. The services step now blocks Continue until
+// the operator either fills in a domain or actively opts out.
+const optOutOfDomain = () => {
+  const cb = screen.getByLabelText(/I don't have a public domain/i) as HTMLInputElement;
+  if (!cb.checked) fireEvent.click(cb);
+};
+
 // Helper: default status with no setup needed
 const completedStatus = {
   needsSetup: false,
   stackSetupPending: false,
+  installInProgress: null,
   hasGateway: true,
   hasSshKey: true,
   hasExternalLinks: false,
@@ -94,6 +103,7 @@ const stacksPendingStatus = {
   hasGateway: true,
   hasSshKey: true,
   hasExternalLinks: false,
+  installInProgress: null,
   features: { gateway: true, ssh: true, updates: true, registries: true, email: false, auth: true },
 };
 
@@ -289,14 +299,18 @@ describe('OnboardingWizard', () => {
 
             await waitFor(() => screen.getByText('nginx-web'));
 
+            // The first checkbox on the services step is the new "I don't
+            // have a public domain" toggle (added by the domain-at-top
+            // gating fix). The actual service checkboxes follow.
+            const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+            const services = checkboxes.slice(1);
             // nginx-web is already installed (from mock /api/services GET) — unchecked + disabled
             // redis-cache is not installed but marked [x] in README — checked
             // immich is not installed and marked [ ] — unchecked
-            const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
-            expect(checkboxes[0].checked).toBe(false);   // nginx-web — already installed, unchecked
-            expect(checkboxes[0].disabled).toBe(true);    // nginx-web — disabled
-            expect(checkboxes[1].checked).toBe(true);     // redis-cache [x]
-            expect(checkboxes[2].checked).toBe(false);    // immich [ ]
+            expect(services[0].checked).toBe(false);   // nginx-web — already installed, unchecked
+            expect(services[0].disabled).toBe(true);    // nginx-web — disabled
+            expect(services[1].checked).toBe(true);     // redis-cache [x]
+            expect(services[2].checked).toBe(false);    // immich [ ]
 
             // Should show "already installed" badge
             expect(screen.getByText('already installed')).toBeDefined();
@@ -330,6 +344,7 @@ describe('OnboardingWizard', () => {
             fireEvent.click(screen.getByText('full-stack'));
 
             await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
+            optOutOfDomain();
             fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
             await waitFor(() => {
@@ -351,6 +366,7 @@ describe('OnboardingWizard', () => {
 
             // Continue to configure
             await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
+            optOutOfDomain();
             fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
             // Wait for configure step, then install
@@ -380,6 +396,7 @@ describe('OnboardingWizard', () => {
             fireEvent.click(screen.getByText('full-stack'));
 
             await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
+            optOutOfDomain();
             fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
             await waitFor(() => screen.getByRole('button', { name: /Install Stack/i }));
@@ -413,8 +430,10 @@ describe('OnboardingWizard', () => {
             fireEvent.click(screen.getByText('full-stack'));
 
             await waitFor(() => {
-                expect(screen.getByText(/Public Domain/i)).toBeDefined();
+                // Domain prompt label appears (multiple times now: header,
+                // gating message, hint). Just verify the input is present.
                 expect(screen.getByPlaceholderText('example.com')).toBeDefined();
+                expect(screen.getByLabelText(/I don't have a public domain/i)).toBeDefined();
             });
         });
 
@@ -434,6 +453,7 @@ describe('OnboardingWizard', () => {
             fireEvent.click(screen.getByText('full-stack'));
 
             await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
+            optOutOfDomain();
             fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
             await waitFor(() => screen.getByRole('button', { name: /Install Stack/i }));
@@ -497,6 +517,7 @@ describe('OnboardingWizard', () => {
             fireEvent.click(screen.getByText('full-stack'));
 
             await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
+            optOutOfDomain();
             fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
             await waitFor(() => screen.getByRole('button', { name: /Install Stack/i }));


### PR DESCRIPTION
Two operator UX requests:

### A. Domain at the top, gated Continue
The domain prompt used to appear at the bottom of the services step. Operator could scroll past it and click Continue with the field empty — variables depending on `PUBLIC_DOMAIN` then resolved to junk and broke SSO + proxy routes downstream.

- Move the prompt to the top.
- Add an explicit "I don't have a public domain — install services in LAN-only mode" checkbox.
- Gate Continue until field is filled OR checkbox is ticked.
- Inline hint when the gate is engaged so the operator isn't confused.

### D. USB device auto-pick
Z-Wave / Zigbee / Matter sticks resolve from `/dev/serial/by-id/`. When only one device is plugged in, the dropdown has a single option — asking the operator to pick from it is busywork. After the device list comes back, auto-fill the first matching device-type variable whose value is still empty. Never overwrites an explicit choice.

Tests updated for the new gating + checkbox positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)