### PR TITLE
refactor(ux): move Self-Diagnose from Settings → System to Health page

### DIFF
--- a/src/app/(dashboard)/settings/system/page.tsx
+++ b/src/app/(dashboard)/settings/system/page.tsx
@@ -1,14 +1,38 @@
 'use client';
 
+import Link from 'next/link';
+import { Stethoscope, ArrowRight } from 'lucide-react';
 import LogLevelControl from '@/components/LogLevelControl';
-import SelfDiagnoseSection from '../_lib/sections/SelfDiagnoseSection';
 import ServerIdentitySection from '../_lib/sections/ServerIdentitySection';
 import UpdatesSection from '../_lib/sections/UpdatesSection';
 
 export default function SystemSettingsPage() {
   return (
     <>
-      <SelfDiagnoseSection />
+      {/* Self-Diagnose moved to Health → Self-Diagnose so the operator
+          sees probes alongside the live health checks instead of buried
+          in Settings. Leave a small breadcrumb here for muscle-memory
+          users who came looking for it under System. */}
+      <Link
+        href="/health?tab=diagnose"
+        className="block bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+            <Stethoscope size={18} className="text-blue-600 dark:text-blue-400" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Self-Diagnose</p>
+              <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 font-bold">moved</span>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Probe battery (containers stable, dangling proxy routes, failed units, …) lives next to the live Health checks.
+            </p>
+          </div>
+          <ArrowRight size={16} className="text-gray-400 shrink-0" />
+        </div>
+      </Link>
       <ServerIdentitySection />
       <UpdatesSection />
       <LogLevelControl />

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1727,7 +1727,7 @@ export default function OnboardingWizard() {
                                     <div className="mt-3 space-y-3 max-h-[60vh] overflow-y-auto">
                                         {/* Auto self-test verdict — first thing the operator
                                             sees on the Done screen. Same probes as
-                                            Settings → Self-Diagnose, run automatically against
+                                            Health → Self-Diagnose, run automatically against
                                             the just-deployed install. */}
                                         <div className={`p-3 rounded border text-sm ${overallStyle.bg} ${overallStyle.border}`}>
                                             <div className="flex items-center justify-between mb-1.5">
@@ -1766,7 +1766,7 @@ export default function OnboardingWizard() {
                                                 </details>
                                             )}
                                             <p className={`text-xs mt-1 ${overallStyle.text} opacity-70`}>
-                                                Re-run any time at <span className="font-mono">Settings → Self-Diagnose</span>.
+                                                Re-run any time at <span className="font-mono">Health → Self-Diagnose</span>.
                                             </p>
                                         </div>
                                         {manifest.length > 0 && (

--- a/src/plugins/HealthPlugin.tsx
+++ b/src/plugins/HealthPlugin.tsx
@@ -15,6 +15,7 @@ import { getNodes } from '@/app/actions/nodes';
 import { PodmanConnection } from '@/lib/nodes';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { SystemInfoContent } from '@/plugins/SystemInfoPlugin';
+import SelfDiagnoseSection from '@/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection';
 
 interface Container {
   Id: string;
@@ -29,7 +30,7 @@ interface HistoryItem {
   message?: string;
 }
 
-type HealthTab = 'checks' | 'logs' | 'system';
+type HealthTab = 'checks' | 'diagnose' | 'logs' | 'system';
 
 export default function HealthPlugin() {
   const [checks, setChecks] = useState<Check[]>([]);
@@ -58,7 +59,7 @@ export default function HealthPlugin() {
   const searchParams = useSearchParams();
   const searchString = searchParams?.toString() ?? '';
   const tabParam = searchParams?.get('tab');
-  const normalizedTab: HealthTab | null = tabParam === 'logs' || tabParam === 'checks' || tabParam === 'system' ? (tabParam as HealthTab) : null;
+  const normalizedTab: HealthTab | null = tabParam === 'logs' || tabParam === 'checks' || tabParam === 'system' || tabParam === 'diagnose' ? (tabParam as HealthTab) : null;
 
   const closeOverlaysOnEscape = useCallback(() => {
     if (isDeleteModalOpen) return;
@@ -370,6 +371,7 @@ export default function HealthPlugin() {
       <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 px-2 shrink-0 overflow-x-auto">
         {([
           { id: 'checks' as const, label: 'Checks' },
+          { id: 'diagnose' as const, label: 'Self-Diagnose' },
           { id: 'logs' as const, label: 'Logs' },
           { id: 'system' as const, label: 'System' },
         ]).map(tab => (
@@ -400,6 +402,12 @@ export default function HealthPlugin() {
           handleOpenDeleteModal={handleDelete}
           handleViewHistory={handleShowHistory}
         />
+      )}
+
+      {activeTab === 'diagnose' && (
+        <div className="px-2">
+          <SelfDiagnoseSection />
+        </div>
       )}
 
       {activeTab === 'logs' && (


### PR DESCRIPTION
Self-Diagnose has always been "is anything broken?" content — same conceptual space as the live Health checks. Splitting it across Settings/System and Health/Checks meant the operator had to know there were *two* places to look when something seemed off.

### What changed
- **New 'Self-Diagnose' tab in the Health page**, between 'Checks' and 'Logs'. Renders the existing `SelfDiagnoseSection` unchanged — no functional change to the probes themselves.
- **Settings → System loses the section**, replaced with a single-line "moved → Health → Self-Diagnose" breadcrumb (clickable) so muscle-memory operators still find it.
- **Wizard's post-install verdict** now points to "Health → Self-Diagnose" for the re-run.

Settings → System is now a tighter page — server identity, updates, log level. Diagnostic-shaped UI lives under Health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)