### PR TITLE
fix(network): de-duplicate proxied domains off the nginx node

### DIFF
--- a/src/lib/network/service.ts
+++ b/src/lib/network/service.ts
@@ -1910,19 +1910,28 @@ export class NetworkService {
         // Store full list of domains for Router/Gateway
         nginxNode.metadata.allVerifiedDomains = [...(nginxNode.metadata.verifiedDomains as string[])];
 
+        // The loopback fallback above attributes proxy_pass http://127.0.0.1:<port>
+        // entries (NPM admin UI, nginx's own subdomain) to nginx itself. Those land
+        // in containerUrlMapping under the service / container id — not under
+        // `nginxId` (which is the visual `group-nginx` node) — so we have to recognise
+        // every shape of "this is nginx" before deciding a domain is mapped elsewhere.
+        const nginxAliasIds = new Set<string>([nginxId]);
+        if (proxyService) nginxAliasIds.add(prefix(`service-${proxyService.name}`));
+        if (nginxContainer?.id) nginxAliasIds.add(prefix(nginxContainer.id));
+
+        // Values in containerUrlMapping are *bare hostnames* (see `cleanedDomain`
+        // earlier in this function), not full URLs. The previous implementation
+        // called `new URL(url)` on each entry, which threw on every iteration
+        // and silently produced an empty set — leaving every working domain
+        // attributed to nginx as well as to its real target. Compare strings.
         const domainsMappedToOthers = new Set<string>();
         for (const [targetId, urls] of containerUrlMapping.entries()) {
-            if (targetId === nginxId) continue; // Don't exclude domains explicitly mapped to Nginx
-            for (const url of urls) {
-                try {
-                    const u = new URL(url);
-                    domainsMappedToOthers.add(u.hostname);
-                } catch {
-                    // Ignore invalid URLs
-                }
+            if (nginxAliasIds.has(targetId)) continue;
+            for (const domain of urls) {
+                if (domain) domainsMappedToOthers.add(domain);
             }
         }
-        
+
         nginxNode.metadata.verifiedDomains = (nginxNode.metadata.verifiedDomains as string[])
             .filter(d => !domainsMappedToOthers.has(d));
     }

--- a/tests/backend/graph.test.ts
+++ b/tests/backend/graph.test.ts
@@ -407,4 +407,88 @@ describe('Network Graph Generation', () => {
         expect(proxyEdge).toBeDefined();
         expect(proxyEdge?.label).toBe(':8123');
     });
+
+    it("should not list domains on the nginx node that are proxied to other services", async () => {
+        // Reproduces the bug where bare-domain entries in containerUrlMapping
+        // were being passed through `new URL(...)` (which throws on a hostname
+        // without a scheme), the catch swallowed every domain, and the nginx
+        // node ended up showing all externally-verified domains even when the
+        // route actually targeted a different service.
+        const dns = await import('../../src/lib/network/dns');
+        (dns.checkDomains as any).mockResolvedValueOnce([
+            { domain: 'photos.dopp.cloud', matches: true },
+            { domain: 'nginx.dopp.cloud',  matches: true },
+        ]);
+
+        const twinStore = DigitalTwinStore.getInstance() as any;
+        const localNode = twinStore.nodes['Local'];
+
+        localNode.proxy = [];
+        localNode.services = [
+            {
+                name: 'nginx-web',
+                active: true,
+                isPrimaryProxy: true,
+                associatedContainerIds: ['nginx-container'],
+                ports: [{ hostPort: 80, containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0' }],
+                proxyConfiguration: {
+                    servers: [
+                        // photos.dopp.cloud → immich service (should NOT show on nginx)
+                        {
+                            server_name: ['photos.dopp.cloud'],
+                            listen: ['443 ssl', '80'],
+                            locations: [{ path: '/', proxy_pass: 'http://192.168.178.99:2283' }],
+                        },
+                        // nginx.dopp.cloud → nginx admin UI itself (SHOULD stay on nginx)
+                        {
+                            server_name: ['nginx.dopp.cloud'],
+                            listen: ['443 ssl', '80'],
+                            locations: [{ path: '/', proxy_pass: 'http://127.0.0.1:81' }],
+                        },
+                    ],
+                },
+            },
+            {
+                name: 'immich',
+                active: true,
+                ports: [{ hostPort: 2283, containerPort: 2283, protocol: 'tcp', hostIp: '0.0.0.0' }],
+                associatedContainerIds: ['immich-container'],
+            },
+        ];
+        localNode.containers = [
+            {
+                id: 'nginx-container',
+                names: ['/nginx-web'],
+                labels: { 'servicebay.role': 'reverse-proxy' },
+                state: 'running',
+                ports: [{ hostPort: 80, containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0' }],
+            },
+            {
+                id: 'immich-container',
+                names: ['/immich-server'],
+                state: 'running',
+                ports: [{ hostPort: 2283, containerPort: 2283, protocol: 'tcp', hostIp: '0.0.0.0' }],
+            },
+        ];
+
+        const graph = await service.getGraph('Local');
+        const nginxNode = graph.nodes.find(n => n.id.includes('group-nginx'));
+        expect(nginxNode).toBeDefined();
+
+        const verified = (nginxNode!.metadata?.verifiedDomains ?? []) as string[];
+        const allVerified = (nginxNode!.metadata?.allVerifiedDomains ?? []) as string[];
+
+        // Filtered list: only domains nginx itself serves, not what it proxies elsewhere.
+        expect(verified).not.toContain('photos.dopp.cloud');
+        // Loopback admin route should survive — that *is* nginx's own UI.
+        expect(verified).toContain('nginx.dopp.cloud');
+        // Unfiltered backup is still around for the side panel.
+        expect(allVerified).toContain('photos.dopp.cloud');
+        expect(allVerified).toContain('nginx.dopp.cloud');
+
+        // The proxied domain should land on its real service instead.
+        const immichNode = graph.nodes.find(n => n.id.includes('service-immich'));
+        const immichDomains = (immichNode?.metadata?.verifiedDomains ?? []) as string[];
+        expect(immichDomains).toContain('photos.dopp.cloud');
+    });
 });


### PR DESCRIPTION
## Summary

The network graph showed up to 4 of your verified domains pinned to the **nginx-web** node (e.g. `admin / home / nginx / photos.dopp.cloud`) even though only `nginx.dopp.cloud` and the NPM admin loopback actually terminate at the proxy — the others proxy through to home-assistant, immich, etc.

## Root cause

`src/lib/network/service.ts` had a filter that's *meant* to remove domains from the nginx node when they're already attributed to a real backend service:

\`\`\`ts
for (const url of urls) {
  try {
    const u = new URL(url);                  // ← \`url\` is "photos.dopp.cloud", no scheme
    domainsMappedToOthers.add(u.hostname);   // ← \`new URL(...)\` throws
  } catch { /* Ignore invalid URLs */ }      // ← swallowed, set stays empty
}
\`\`\`

`containerUrlMapping` is keyed on bare hostnames (the `cleanedDomain` write earlier in the file strips any scheme). Calling `new URL("photos.dopp.cloud")` throws "Invalid URL" on every iteration, the catch swallows it, the resulting set is empty, and the filter is a no-op — so every externally-verified domain stayed on nginx as well as on its real target.

Why exactly 4 and not 15? Those were the only domains `checkDomains` could probe and verify externally on your setup; the other 11 routes never made it onto the nginx node in the first place, which masked the broken filter.

A second issue surfaced once the first was fixed: the loopback fallback (NPM admin UI, nginx's own subdomain) attributes domains to the *service* id (`service-nginx-web`) and the *container* id, not to the visual `group-nginx` node id that the filter compares against. So domains that should stay on nginx (the admin UI, the proxy itself) were getting filtered off.

## Changes

- `src/lib/network/service.ts:1905` — compare hostname strings directly; recognise all three "this is nginx" id shapes (`group-nginx`, `service-<proxy>`, container id) before deciding a domain is mapped elsewhere
- `tests/backend/graph.test.ts` — regression test: one route proxied to another service must be filtered off nginx, one loopback admin route must stay, and the unfiltered list lives on `allVerifiedDomains` for the side panel

## Test plan

- [x] `npm test` — 285 pass (was 284 + 1 new)
- [x] `npm run lint` clean
- [ ] Reload the network map, click the nginx-web node — its `verifiedDomains` now lists only domains nginx actually terminates (typically the proxy admin + any static/loopback routes), and the proxied-elsewhere domains appear on their real service nodes instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)