### PR TITLE
fix(diagnose+ui): uptime-gated restart-loop probe + dedup network legend

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -169,12 +169,33 @@ export async function POST(request: Request) {
   //    "Restarting", "Initialized (starting)", or "Up <30s" while we'd
   //    expect long-running services. Catches the bind-mount permission
   //    crash-loops + entrypoint argv mistakes that bit us before 3.1.3.
+  //
+  //    Gate the "Up <30s" rule behind system uptime: if the host itself has
+  //    only been up for ~a minute, every container is naturally young — they
+  //    can't have been up *longer* than the kernel. Auto-running the probe
+  //    right after first boot used to flag every fresh container as
+  //    "may be in a restart loop" purely because it had only just started.
+  const uptimeRes = await exec('cat /proc/uptime 2>/dev/null', 1500);
+  const systemUptimeSec = (() => {
+    const first = (uptimeRes.stdout ?? '').trim().split(/\s+/)[0];
+    const n = parseFloat(first);
+    return Number.isFinite(n) ? Math.floor(n) : Number.POSITIVE_INFINITY;
+  })();
+  // Containers up for less than (system uptime - this margin) are genuinely
+  // restarting; younger ones are just "started at boot, not looping". 90 s
+  // covers the slowest cold-start + a tiny grace window.
+  const recentBootGrace = 90;
+  const treatYoungAsLoop = systemUptimeSec > recentBootGrace;
+
   const psStatus = await exec('podman ps --format "{{.Names}}|{{.Status}}" 2>/dev/null', 4000);
   const psLines = trimOutput(psStatus.stdout, 80).split('\n').filter(Boolean);
   const looping = psLines.filter(l => {
     const status = (l.split('|')[1] ?? '').trim();
     if (/^Restarting/i.test(status)) return true;
     if (/^Initialized/i.test(status)) return true;
+    // Only flag "Up <30s" when the system has been up long enough that a
+    // young container *must* be a fresh restart — see comment above.
+    if (!treatYoungAsLoop) return false;
     if (/^Up Less than a second/i.test(status)) return true;
     const m = status.match(/^Up (\d+) seconds?\b/);
     if (m && parseInt(m[1], 10) < 30) return true;
@@ -189,7 +210,9 @@ export async function POST(request: Request) {
       : (psLines.length === 0
           ? 'No running containers yet.'
           : looping.length === 0
-            ? `${psLines.length} container(s), all stable.`
+            ? (treatYoungAsLoop
+                ? `${psLines.length} container(s), all stable.`
+                : `${psLines.length} container(s) — system booted ${systemUptimeSec}s ago, young containers expected. Re-run after ~2 min for a real restart-loop check.`)
             : `${looping.length} of ${psLines.length} container(s) may be in a restart loop:\n${looping.join('\n')}`),
     hint: looping.length > 0
       ? 'Run `podman logs <name>` for the crash reason. Common causes: bind-mount permission mismatch (rootless UID), missing config file, port conflicts, image entrypoint argv errors.'

--- a/src/plugins/NetworkPlugin.tsx
+++ b/src/plugins/NetworkPlugin.tsx
@@ -1563,19 +1563,9 @@ export default function NetworkPlugin() {
                     }
                 }}
             />
-            <Panel position="top-right" className="bg-white dark:bg-gray-800 p-2 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Legend</div>
-                <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-green-500" />
-                        <span className="text-xs">Healthy</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-red-500" />
-                        <span className="text-xs">Issue</span>
-                    </div>
-                </div>
-            </Panel>
+            {/* Status-only legend was here; consolidated into the bottom-left
+                NetworkLegend (which already covers shape colours + status
+                dots). Two side-by-side legend panels were redundant. */}
         </ReactFlow>
 
       </div>


### PR DESCRIPTION
## Summary

Two unrelated polish fixes that surfaced in the same install report.

### Containers stable probe

The "Up <30s = restart loop" heuristic fires every time the auto-test runs right after a fresh boot, because every container is naturally young — they can't have been up longer than the kernel itself. On the latest reinstall this flagged 10 of 30 containers as "may be in a restart loop" purely because the host had been up ~25s. Re-running it minutes later correctly narrows the list down to the actual offenders.

Read \`/proc/uptime\` once and only apply the "Up <30s" rule when the host has been up for >90s. Genuinely restarting states (\`Restarting\`, \`Initialized\`) still flag immediately — the gate only affects the young-container heuristic. When the gate is active, the detail line says "system booted Ns ago, young containers expected" so the operator knows why this run skipped the check.

### Network map legend

Two legend panels were rendered on top of the React Flow canvas — a comprehensive collapsible one bottom-left, plus a redundant top-right panel that only repeated the green/red status dots. Drop the duplicate; the bottom-left covers status alongside shape colours.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` — 285 pass
- [x] \`next build\` clean (TS strict-checked)
- [ ] Reload the network map → only one legend (bottom-left, expandable)
- [ ] Run /api/system/diagnose within 90s of boot → "Containers stable" probe doesn't flag young containers; detail mentions the boot grace
- [ ] Re-run after a few minutes → probe behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)