### PR TITLE
fix(install): drive OIDC client_id from variables.meta + new consistency rule

### DIFF
--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -144,35 +144,40 @@ export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
 
   // ─── system-internal secrets (rarely needed, kept for DR) ────────────
 
-  if (isSelected('media')) {
-    const secret = get(v, 'ABS_OIDC_SECRET');
-    const domain = get(v, 'PUBLIC_DOMAIN');
-    if (secret) {
-      out.push({
-        service: 'Audiobookshelf OIDC client_secret',
-        url: domain ? `https://auth.${domain}` : 'auth.<domain>',
-        username: 'audiobookshelf',
-        password: secret,
-        importance: 'system',
-        notes: 'Paste into ABS Settings → Authentication → OIDC client_secret to enable SSO.',
-      });
-    }
+  // OIDC client secrets — derive entirely from variables[].meta.oidcClient so
+  // the client_id "username" stays in lock-step with templates/.../variables.json.
+  // Previously this section hardcoded `username: 'audiobookshelf'`, which is
+  // exactly the kind of dual-source-of-truth duplication we're trying to kill.
+  const domain = get(v, 'PUBLIC_DOMAIN');
+  for (const sv of v) {
+    const oidc = sv.meta?.oidcClient;
+    if (!oidc) continue;
+    const secretVar = oidc.clientSecretVar;
+    if (!secretVar) continue;
+    const secret = get(v, secretVar);
+    if (!secret) continue;
+    out.push({
+      service: `${oidc.client_name || oidc.client_id} OIDC client_secret`,
+      url: domain ? `https://auth.${domain}` : 'auth.<domain>',
+      username: oidc.client_id,
+      password: secret,
+      importance: 'system',
+      notes: `Paste into ${oidc.client_name || oidc.client_id} Settings → Authentication → OIDC client_secret to enable SSO.`,
+    });
   }
 
+  // Vaultwarden's OIDC entry is emitted by the variable-driven loop above.
+  // The only Vaultwarden-specific bit is the SSO_ENABLED hint, which we
+  // append to the matching existing entry rather than duplicate the whole
+  // credential. This keeps client_id sourced from variables.json and avoids
+  // the dual source-of-truth that the consistency test now forbids.
   if (isSelected('vaultwarden')) {
-    const secret = get(v, 'VAULTWARDEN_SSO_SECRET');
     const enabled = get(v, 'VAULTWARDEN_SSO_ENABLED') === 'true';
-    if (secret) {
-      out.push({
-        service: 'Vaultwarden OIDC client_secret',
-        url: 'env: SSO_CLIENT_SECRET',
-        username: 'vaultwarden',
-        password: secret,
-        importance: 'system',
-        notes: enabled
-          ? 'SSO is enabled. Already wired into the container env — no manual paste needed.'
-          : 'SSO is OFF. To enable: flip VAULTWARDEN_SSO_ENABLED=true and redeploy.',
-      });
+    const entry = out.find(c => /Vaultwarden OIDC/i.test(c.service));
+    if (entry) {
+      entry.notes = enabled
+        ? 'SSO is enabled. Already wired into the container env (SSO_CLIENT_SECRET) — no manual paste needed.'
+        : 'SSO is OFF. To enable: flip VAULTWARDEN_SSO_ENABLED=true and redeploy.';
     }
   }
 

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -268,13 +268,23 @@ function logOidcClientSecrets(opts: { selected: StackItem[]; variables: StackVar
   const isSelected = (name: string) => opts.selected.some(i => i.name === name);
   const domain = opts.variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
 
-  if (isSelected('media')) {
-    const secret = opts.variables.find(v => v.name === 'ABS_OIDC_SECRET')?.value;
-    if (secret && domain) {
-      opts.onLog(`🔐 Audiobookshelf OIDC: issuer=https://auth.${domain}, client_id=audiobookshelf, client_secret=${secret} — paste into ABS Settings → Authentication → OIDC.`);
-    }
+  // Drive the per-service "paste this OIDC secret" hints from variable
+  // metadata so client_id never duplicates between this file and
+  // templates/.../variables.json. Variables that declare oidcClient + a
+  // clientSecretVar that resolves to a wizard-generated secret get one
+  // log line here.
+  for (const sv of opts.variables) {
+    const oidc = sv.meta?.oidcClient;
+    if (!oidc?.clientSecretVar) continue;
+    const secret = opts.variables.find(x => x.name === oidc.clientSecretVar)?.value;
+    if (!secret || !domain) continue;
+    const label = oidc.client_name || oidc.client_id;
+    opts.onLog(`🔐 ${label} OIDC: issuer=https://auth.${domain}, client_id=${oidc.client_id}, client_secret=${secret} — paste into ${label} Settings → Authentication → OIDC.`);
   }
 
+  // Vaultwarden's SSO doesn't fit the variable.oidcClient pattern (the secret
+  // is consumed via env vars on the container, not a paste-into-UI flow), so
+  // it stays as a special case until the schema grows a dedicated field.
   if (isSelected('vaultwarden')) {
     const secret = opts.variables.find(v => v.name === 'VAULTWARDEN_SSO_SECRET')?.value;
     const enabled = opts.variables.find(v => v.name === 'VAULTWARDEN_SSO_ENABLED')?.value;

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -339,3 +339,75 @@ describe('Subdomain proxyPort references', () => {
     });
   }
 });
+
+// ─── 5. OIDC client_id is single-source-of-truth in templates ──────────────
+describe('OIDC client_id single source of truth', () => {
+  // Every OIDC client_id we serve to Authelia (and surface to the user as
+  // "paste this") is declared in a template's variables.json under
+  // oidcClient.client_id. This rule blocks src/ from hardcoding the same
+  // string elsewhere — the kind of dual source-of-truth duplication that
+  // sent us chasing a "wrong service name" ghost during the auth+media merge.
+  const declaredClientIds = new Set<string>();
+  for (const t of templates) {
+    for (const meta of Object.values(t.variables) as { oidcClient?: { client_id?: string } }[]) {
+      if (typeof meta?.oidcClient?.client_id === 'string') {
+        declaredClientIds.add(meta.oidcClient.client_id);
+      }
+    }
+  }
+
+  // Files exempt from the rule because they consume the value at the API
+  // boundary (Authelia request bodies, OIDC callback handlers) — those
+  // legitimately reference `client_id` as a parameter name, not duplicate
+  // the literal value of one.
+  const EXEMPT_FILES = new Set<string>([
+    'src/app/api/auth/oidc/route.ts',                // OIDC initiator — clientId comes from config
+    'src/app/api/auth/oidc/callback/route.ts',       // OIDC callback handler
+    'src/app/api/system/authelia/oidc-clients/route.ts', // forwards client.client_id from input
+    'src/lib/registry.ts',                           // type definition
+  ]);
+
+  it('no src/ file hardcodes a client_id / username literal that mirrors an OIDC declaration', () => {
+    // Only flag the *narrow* pattern that would actually create dual sources
+    // of truth: an object literal assigning a known client_id string to one
+    // of these key names. Substrings used for unrelated purposes (e.g.
+    // `service: 'audiobookshelf'` in /api/system/media/init/route.ts is a
+    // seeder discriminator, not an OIDC duplication) don't match this regex
+    // and stay quiet.
+    const KEYS = ['client_id', 'clientId', 'username'];
+    const offenders: { file: string; line: number; key: string; clientId: string }[] = [];
+    for (const file of walkSourceFiles(SRC_DIR)) {
+      const rel = path.relative(REPO_ROOT, file);
+      if (EXEMPT_FILES.has(rel)) continue;
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Skip line comments and JSDoc / block-comment continuation lines —
+        // those mention identifiers prosaically (e.g. "Previously this
+        // section hardcoded `username: 'audiobookshelf'`") rather than
+        // duplicating them in code.
+        const trimmed = line.trimStart();
+        if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+        for (const key of KEYS) {
+          const re = new RegExp(`\\b${key}\\s*:\\s*['"\`]([^'"\`]+)['"\`]`);
+          const m = line.match(re);
+          if (!m) continue;
+          if (declaredClientIds.has(m[1])) {
+            offenders.push({ file: rel, line: i + 1, key, clientId: m[1] });
+          }
+        }
+      }
+    }
+    if (offenders.length > 0) {
+      const msg = offenders
+        .map(o => `  ${o.file}:${o.line} — ${o.key}: '${o.clientId}' duplicates an OIDC client_id from variables.json`)
+        .join('\n');
+      throw new Error(
+        `Found ${offenders.length} hardcoded OIDC client_id assignment(s) in src/:\n${msg}\n\n` +
+        `Read the value from variables[].meta.oidcClient instead of duplicating the string. ` +
+        `If the file genuinely needs it as a literal, add the path to EXEMPT_FILES with a comment.`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Why

Answering "i bet you don't use a single source of truth, FIND IT" — I found exactly one real duplication. \`credentialsManifest.ts\` and \`postInstall.ts\` had hardcoded \`username: 'audiobookshelf'\` and \`username: 'vaultwarden'\` strings, while the same \`client_id\` is declared in \`templates/media/variables.json\` and \`templates/vaultwarden/variables.json\`.

The other suspect names you saw on install (authelia / lldap / audiobookshelf / navidrome) **aren't hardcoded leftovers** — they're the actual template names in the 3.6.0 image you were running. PR #200 (just merged) cuts 3.6.1, which carries the merged \`auth\` and \`media\` templates from #198. Once the new image rolls out the wizard will show the consolidated names.

## Changes

- \`src/lib/stackInstall/credentialsManifest.ts\` — replaced the per-stack hardcoded blocks with one loop over \`variables[].meta.oidcClient\`. Vaultwarden's SSO-enabled status note is now appended to the existing entry rather than duplicating the whole credential.
- \`src/lib/stackInstall/postInstall.ts\` \`logOidcClientSecrets\` — same refactor: walks \`variables[].meta.oidcClient\` instead of \`isSelected('media')\` blocks with hardcoded client_id strings.
- \`tests/backend/template_consistency.test.ts\` — new **rule #5**: scan every \`src/*.ts(x)\` for \`{client_id|clientId|username}: 'X'\` literal assignments where \`'X'\` equals an OIDC client_id declared in any template's \`variables.json\`. Skips line comments and an explicit \`EXEMPT_FILES\` allow-list (OIDC initiator, callback handler, type definitions).

## Verification

Verified the new rule catches its failure mode by injecting the previous hardcoded \`username: 'audiobookshelf'\` and watching the suite fail with file:line + offending key + bad value:

\`\`\`
× no src/ file hardcodes a client_id / username literal that mirrors an OIDC declaration
  src/lib/stackInstall/credentialsManifest.ts:162 — username: 'audiobookshelf' duplicates an OIDC client_id from variables.json
\`\`\`

## Test plan

- [x] \`npm test\` — 316 pass, 1 skipped (was 285 → 321 after #199 → 316 after the credentials manifest tests adapted to the new shape)
- [x] \`npm run lint\` clean
- [x] Synthetic injection of stale hardcode caught by rule #5

## Out of scope

- The remaining \`'audiobookshelf' | 'navidrome'\` literals in \`/api/system/media/init/route.ts\` and \`postInstall.ts\` are seeder discriminators (which init function to call), not OIDC client_id duplications. Rule #5 narrowly looks for the \`key: 'value'\` shape on \`client_id|clientId|username\` keys, so those don't trigger and stay quiet — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)