### PR TITLE
fix(reliability): syncthing podman volume + auto-migrate orphan units on upgrade

### DIFF
--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -519,7 +519,58 @@ export class ServiceManager {
         }
     }
 
+    /**
+     * Stacks that were renamed or merged at some point. Mapping: new name →
+     * the OLD systemd-unit names whose quadlet files should be soft-deleted
+     * before re-deploy.
+     *
+     * Without this, an in-place upgrade from a pre-rename release leaves
+     * orphan `<old>.kube` units running alongside the new merged pod. The
+     * wizard surfaces them as restart-looping ghosts (because the *new* pod
+     * grabs the host ports the old one wanted) and the operator has to
+     * clean up by hand. The trashed predecessor files are recoverable from
+     * `~/.config/containers/systemd/.trash/` for 7 days, so this is safe.
+     */
+    static readonly STACK_MIGRATIONS: Record<string, string[]> = {
+        'auth':           ['authelia', 'lldap'],
+        'media':          ['audiobookshelf', 'navidrome'],
+        'home-assistant': ['home-assistant-stack'],
+        'file-share':     ['filebrowser'],
+    };
+
+    private static async migratePredecessors(
+        nodeName: string,
+        newName: string,
+        onProgress?: (message: string) => void,
+    ): Promise<void> {
+        const predecessors = ServiceManager.STACK_MIGRATIONS[newName] ?? [];
+        if (predecessors.length === 0) return;
+        const agent = await agentManager.ensureAgent(nodeName);
+        for (const old of predecessors) {
+            // Cheap existence check — if the kube unit isn't on disk there's
+            // nothing to migrate. Skip silently to keep fresh-install logs clean.
+            const check = await agent.sendCommand('exec', {
+                command: `test -f ~/${SYSTEMD_DIR}/${old}.kube && echo present || echo absent`,
+            });
+            if ((check.stdout || '').trim() !== 'present') continue;
+            onProgress?.(`Migrating predecessor: soft-deleting ${old} (replaced by ${newName})`);
+            logger.info('ServiceManager', `Soft-deleting predecessor "${old}" before deploying "${newName}"`);
+            try {
+                await ServiceManager.deleteService(nodeName, old);
+            } catch (e) {
+                // Non-fatal — if the old unit can't be cleaned, the deploy
+                // below either succeeds (different ports / pod name) or
+                // fails loudly via the port-collision pre-flight.
+                logger.warn('ServiceManager', `Failed to soft-delete predecessor ${old}:`, e);
+            }
+        }
+    }
+
     static async deployKubeService(nodeName: string, name: string, kubeContent: string, yamlContent: string, yamlName: string, extraFiles?: { path: string; content: string }[], onProgress?: (message: string) => void) {
+        // Migrate any pre-rename predecessor units first so their host-port
+        // ownership is released before the port-collision pre-flight runs.
+        await ServiceManager.migratePredecessors(nodeName, name, onProgress);
+
         // Pre-flight: refuse to deploy if the YAML claims a host port that
         // another service on the same node already owns. Without this check,
         // the second deploy "succeeds" but the unit fails to start because the

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -8,15 +8,14 @@ metadata:
     servicebay.ports: "8384/tcp,22000/tcp,139/tcp,445/tcp,{{FILEBROWSER_PORT}}/tcp"
     # Pin the .filebrowser.json.mustache target to filebrowser's /config
     # mount — without this the wizard's path resolver would also consider
-    # syncthing's /var/syncthing/config (which ends in /config) and pick
-    # whichever lands first in the parsed YAML.
+    # other /config-style mounts and pick whichever lands first in the
+    # parsed YAML.
     servicebay.config-mount: "/config"
     # Disable SELinux labelling on the bind mounts. FCoS ships SELinux
     # enforcing; without this annotation podman play-kube doesn't relabel
-    # the hostPath dirs and syncthing can't `chmod` its config, samba
-    # can't write the share state, and filebrowser's seed-config `cp`
-    # fails with EPERM. Targeted per-container disable is safer than a
-    # pod-wide privileged flag.
+    # the host bind dirs and samba can't write the share state, and
+    # filebrowser's seed-config `cp` fails with EPERM. Targeted per-
+    # container disable is safer than a pod-wide privileged flag.
     io.podman.annotations.label/syncthing: "disable"
     io.podman.annotations.label/samba: "disable"
     io.podman.annotations.label/filebrowser: "disable"
@@ -26,21 +25,17 @@ spec:
   # 1. Syncthing — Bidirectional folder sync (Android & desktop apps)
   - name: syncthing
     image: docker.io/syncthing/syncthing:latest
-    # Earlier attempts (runAsUser:0 + io.podman.annotations.label/syncthing
-    # = disable) didn't actually let syncthing chmod its config dir on
-    # FCoS. Either the annotation isn't honoured by this podman version,
-    # or the deeper issue is the bind-mount label rather than the
-    # process's SELinux context. Skip the puzzle and grant privileged:
-    # the UID-namespace + SELinux + cap-drop combo all step out of the
-    # way at once. This pod's containers are standard, unprivileged-
-    # on-the-host services; on a single-tenant homelab the operator
-    # already trusts the workload completely. The rootless-podman
-    # boundary still applies — privileged here means "no extra
-    # capability *deductions*", not "host root".
-    securityContext:
-      runAsUser: 0
-      runAsGroup: 0
-      privileged: true
+    # Why no privileged / runAsUser overrides any more:
+    # The chmod-the-config-dir crash was the *symptom* of a deeper rootless-
+    # podman + bind-mount + idmap interaction — even with privileged: true
+    # and runAsUser: 0 the kernel returned EPERM on chmod against a host
+    # bind mount. Switching syncthing-config to a podman-managed volume
+    # (see PVC below) sidesteps the whole class of problem: podman creates
+    # the volume with container-UID-0 ownership and the right SELinux
+    # context, so syncthing's startup permission-correct call succeeds.
+    # The shared-data volume is still a bind mount because users care
+    # about the host path of their files; samba writes inside it without
+    # needing to chmod the dir itself.
     env:
       - name: STGUIADDRESS
         value: "0.0.0.0:8384"
@@ -104,10 +99,14 @@ spec:
     hostPath:
       path: {{DATA_DIR}}/file-share/data
       type: DirectoryOrCreate
+  # syncthing-config is a podman-managed PVC (see kind: PersistentVolumeClaim
+  # below). Earlier versions used hostPath here; even with privileged: true,
+  # runAsUser: 0 and the SELinux disable annotation, syncthing's startup
+  # `chmod` against the bind mount returned EPERM on rootless podman + FCoS.
+  # The named volume sidesteps it entirely.
   - name: syncthing-config
-    hostPath:
-      path: {{DATA_DIR}}/file-share/syncthing
-      type: DirectoryOrCreate
+    persistentVolumeClaim:
+      claimName: file-share-syncthing-config
   - name: filebrowser-db
     hostPath:
       path: {{DATA_DIR}}/file-share/filebrowser-db
@@ -116,3 +115,10 @@ spec:
     hostPath:
       path: {{DATA_DIR}}/file-share/filebrowser-config
       type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: file-share-syncthing-config
+  labels:
+    app: file-share

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -274,15 +274,20 @@ describe('Templates render to valid Pod manifests', () => {
         throw new Error(`${t.name}: Mustache failed to render: ${e instanceof Error ? e.message : String(e)}`);
       }
 
+      // Multi-document YAML support — some templates ship a Pod plus a
+      // PersistentVolumeClaim alongside (e.g. file-share's syncthing-config
+      // is podman-managed via a PVC declared in the same file).
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let parsed: any;
+      let docs: any[];
       try {
-        parsed = yaml.load(rendered);
+        docs = yaml.loadAll(rendered);
       } catch (e) {
         throw new Error(`${t.name}: rendered YAML is not parseable:\n${e instanceof Error ? e.message : String(e)}`);
       }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parsed = docs.find((d: any) => d?.kind === 'Pod');
 
-      expect(parsed?.kind, `${t.name}: rendered doc must be kind=Pod`).toBe('Pod');
+      expect(parsed?.kind, `${t.name}: rendered doc must contain a kind=Pod entry`).toBe('Pod');
       expect(parsed?.metadata?.name, `${t.name}: pod must have metadata.name`).toBeTruthy();
       // Reachability rule: either hostNetwork=true OR every published port
       // declares a hostPort. Some stacks (nginx-web / vaultwarden / immich)
@@ -338,6 +343,37 @@ describe('Subdomain proxyPort references', () => {
       ).toEqual([]);
     });
   }
+});
+
+// ─── 6. STACK_MIGRATIONS map shape ─────────────────────────────────────────
+describe('ServiceManager.STACK_MIGRATIONS map shape', () => {
+  // Migrations: every key must be a current template (the new name);
+  // every value must NOT be a current template (must be an obsolete name).
+  // Catches typos + accidental "migrate from a template that still exists",
+  // which would soft-delete the active unit on every deploy.
+  it('keys reference real templates, predecessors are no-longer-existing names', () => {
+    const sm = fs.readFileSync(path.join(SRC_DIR, 'lib', 'services', 'ServiceManager.ts'), 'utf-8');
+    const block = sm.match(/STACK_MIGRATIONS:\s*Record<string,\s*string\[\]>\s*=\s*\{([\s\S]*?)\n\s*\};/);
+    expect(block, 'STACK_MIGRATIONS block not found in ServiceManager.ts').toBeTruthy();
+
+    const body = block![1];
+    const entryRe = /^\s*['"]([\w-]+)['"]\s*:\s*\[([^\]]*)\]/gm;
+    const offenders: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = entryRe.exec(body)) !== null) {
+      const key = m[1];
+      const values = [...m[2].matchAll(/['"]([^'"]+)['"]/g)].map(x => x[1]);
+      if (!templateNames.has(key)) {
+        offenders.push(`STACK_MIGRATIONS key "${key}" — no matching template (typo, or stale entry?)`);
+      }
+      for (const v of values) {
+        if (templateNames.has(v)) {
+          offenders.push(`STACK_MIGRATIONS["${key}"] = ["${v}", …] — "${v}" is still a current template; migrating from it would soft-delete the live deploy on every install`);
+        }
+      }
+    }
+    expect(offenders, `STACK_MIGRATIONS shape problems:\n  ${offenders.join('\n  ')}`).toEqual([]);
+  });
 });
 
 // ─── 5. OIDC client_id is single-source-of-truth in templates ──────────────


### PR DESCRIPTION
## Why

Two reliability bugs surfaced from the live MCP probe of the user's box.

### 1. Syncthing chmod EPERM (the headline crash-loop)

\`get_container_logs\` showed:

\`\`\`
chmod /var/syncthing/config: operation not permitted
Failed to load/generate certificate (error="save cert: open /var/syncthing/config/cert.pem: permission denied")
Syncthing exited (error="exit status 1")
\`\`\`

…repeating every ~250 ms. We've thrown \`privileged: true\`, \`runAsUser: 0\`, and the \`io.podman.annotations.label/syncthing: disable\` annotation at it; the kernel still returns EPERM. This is the rootless-podman + host-bind-mount + idmap interaction, not a SELinux issue — no amount of container-side capability flags fixes it.

**Fix**: switch \`syncthing-config\` from \`hostPath\` to a podman-managed \`PersistentVolumeClaim\` declared in the same \`template.yml\`. Podman creates the named volume with container-UID-0 ownership and the right SELinux context, so syncthing's startup permission-correct call succeeds. Drops the \`privileged\` / \`runAsUser\` workarounds that were patching the wrong layer.

The shared-data volume stays a host bind mount because users care about the host path of their files; samba writes inside it without needing to chmod the dir itself.

**Migration note**: existing data at \`$DATA_DIR/file-share/syncthing/\` no longer auto-migrates. On FCoS this is moot — syncthing has been crash-looping since install for everyone, so there's nothing valuable to copy. Documented in the release note.

### 2. Orphan units on in-place upgrade

When stacks got renamed or merged (PR #193 \`filebrowser → file-share\` + \`home-assistant-stack → home-assistant\`, PR #198 \`authelia+lldap → auth\` + \`audiobookshelf+navidrome → media\`), in-place upgrades left orphan \`<old>.kube\` units alongside the new merged pod. The old units fight the new pod for host ports and show up in the wizard's status strip as permanently-degraded ghosts. PR #198 explicitly punted with "fresh-install only".

**Fix**: \`ServiceManager.deployKubeService\` now calls \`migratePredecessors()\` *before* the port-collision pre-flight. A static \`STACK_MIGRATIONS\` map drives the cleanup:

\`\`\`ts
static readonly STACK_MIGRATIONS: Record<string, string[]> = {
  'auth':           ['authelia', 'lldap'],
  'media':          ['audiobookshelf', 'navidrome'],
  'home-assistant': ['home-assistant-stack'],
  'file-share':     ['filebrowser'],
};
\`\`\`

Each predecessor goes through the existing soft-delete path (\`deleteService\`), so the kube + yaml files end up in \`~/.config/containers/systemd/.trash/\` for 7 days — recoverable if the migration ever turns out to be wrong.

### 3. Tests

- \`template_consistency.test.ts\` switched to \`yaml.loadAll\` so file-share's new Pod + PVC multi-doc shape still passes "renders to a parseable Pod with ≥1 container".
- **New rule #6**: \`STACK_MIGRATIONS\` keys must be current templates, values must NOT be. Catches the failure mode where a misnamed entry would soft-delete the live deploy on every install. Verified by injecting \`auth: ['authelia', 'media']\` and watching the suite fail with:

  \`\`\`
  STACK_MIGRATIONS["auth"] = ["media", …] — "media" is still a current template;
  migrating from it would soft-delete the live deploy on every install
  \`\`\`

## Test plan

- [x] \`npm test\` — all pass (now 33 in the consistency suite, 317 total)
- [x] \`npm run lint\` clean
- [x] Synthetic regression injections verify both new behaviours
- [ ] Live: redeploy file-share on a 3.6.2 install → syncthing's container starts and stays Up; \`get_container_logs\` shows \`Listening on 0.0.0.0:8384\` instead of the chmod EPERM loop
- [ ] Live: in-place upgrade from 3.6.0 → 3.6.2 with a previously-deployed authelia + lldap → wizard installs auth, soft-deletes authelia + lldap, no port collisions, the old units appear in the trash dir
- [ ] Self-test \`Containers stable\` probe stops flagging \`file-share-syncthing\` and the orphan \`authelia-authelia\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)