### PR TITLE
fix(install): strict extraFile writes, MCP deploy_service accepts extraFiles, install-nginx self-marks done

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -543,48 +543,74 @@ ${SERVICEBAY_SSH_PRIV}
           set -euo pipefail
           PORT="${SERVICEBAY_PORT:-3000}"
           API="http://localhost:$PORT"
-          API_WAIT=300        # 5 min for ServiceBay API + agent — long
-                              # enough to cover slow image pulls / first boot.
+          API_WAIT=1800       # 30 min for ServiceBay API + agent. Earlier
+                              # 5-min cap timed out before the agent came
+                              # up on slow first-boots, leaving the unit in
+                              # `failed` state forever even though NPM was
+                              # later installed cleanly via the wizard.
           INSTALLED_WAIT=1800 # 30 min for nginx to appear via the onboarding
                               # wizard before we step in. Avoids racing the
                               # interactive install which can take a while
                               # to reach the "Reverse Proxy" step.
           WAITED=0
+          MARKER=/var/home/${HOST_USER}/.config/install-nginx-done
 
-          echo "install-nginx: waiting for ServiceBay API on port $PORT..."
+          # Always touch the marker on EXIT (success OR failure). The marker's
+          # ConditionPathExists in the .service unit then suppresses the unit
+          # on subsequent boots — even if this run gave up because the
+          # operator had already installed NPM via the wizard, we're done
+          # and the wizard owns NPM going forward. Without this trap a
+          # one-time wait timeout produced an permanently-`failed` unit
+          # the operator couldn't get rid of without a manual reset-failed.
+          trap 'mkdir -p "$(dirname "$MARKER")" && touch "$MARKER"' EXIT
+
+          # Helper: returns 0 if NPM is reported as installed, 1 otherwise.
+          is_installed() {
+            curl -sf "$API/api/system/nginx/status" 2>/dev/null \
+              | grep -q '"installed":true'
+          }
+
+          echo "install-nginx: waiting for ServiceBay API on port $PORT (up to ${API_WAIT}s)..."
           while ! curl -sf "$API/api/system/nginx/status" >/dev/null 2>&1; do
             sleep 5
             WAITED=$((WAITED + 5))
             if (( WAITED >= API_WAIT )); then
-              echo "install-nginx: timeout waiting for ServiceBay API" >&2
-              exit 1
+              echo "install-nginx: timeout waiting for ServiceBay API after ${API_WAIT}s — assume the operator will install NPM via the wizard" >&2
+              exit 0
             fi
           done
 
-          # Wait for at least one agent to be connected (needs python3 installed first).
+          # Quick win: if NPM is already installed by the time the API is
+          # reachable (interactive wizard finished first), skip everything.
+          if is_installed; then
+            echo "install-nginx: nginx already installed — nothing to do"
+            exit 0
+          fi
+
+          # Wait for at least one agent to be connected (needs python3 first).
           echo "install-nginx: waiting for agent to connect..."
           while true; do
+            if is_installed; then
+              echo "install-nginx: nginx came up while we were waiting — done"
+              exit 0
+            fi
             CONNECTED=$(curl -sf "$API/api/system/health" | grep -o '"isConnected":true' || true)
             if [[ -n "$CONNECTED" ]]; then break; fi
             sleep 5
             WAITED=$((WAITED + 5))
             if (( WAITED >= API_WAIT )); then
-              echo "install-nginx: timeout waiting for agent" >&2
-              exit 1
+              echo "install-nginx: timeout waiting for agent after ${API_WAIT}s — operator will install NPM via the wizard" >&2
+              exit 0
             fi
           done
           echo "install-nginx: agent connected"
 
-          # Poll for installed=true. The user may install nginx via the
-          # onboarding wizard concurrently — we should *not* race it. If
-          # that's in progress we'd see installed=false here and our own
-          # POST /install would collide with the wizard's POST. So just
-          # wait it out.
+          # Poll for installed=true. The operator may install NPM via the
+          # onboarding wizard concurrently — don't race it.
           echo "install-nginx: polling for nginx-web service (up to ${INSTALLED_WAIT}s for the wizard to finish)..."
           POLL_WAITED=0
           while (( POLL_WAITED < INSTALLED_WAIT )); do
-            INSTALLED=$(curl -sf "$API/api/system/nginx/status" | grep -o '"installed":true' || true)
-            if [[ -n "$INSTALLED" ]]; then
+            if is_installed; then
               echo "install-nginx: nginx is installed, nothing to do"
               exit 0
             fi
@@ -602,6 +628,9 @@ ${SERVICEBAY_SSH_PRIV}
             sleep 10
           done
           echo "install-nginx: all attempts failed — install nginx manually from Settings → Reverse Proxy" >&2
+          # Marker still gets touched by the trap so the unit doesn't keep
+          # showing `failed` on every boot. Operator sees the warning above
+          # in journalctl and the diagnose probe surfaces the missing NPM.
           exit 1
 
     # Systemd user unit to install Nginx on first boot

--- a/src/app/api/system/nginx/bootstrap/route.ts
+++ b/src/app/api/system/nginx/bootstrap/route.ts
@@ -2,9 +2,30 @@ import { NextResponse } from 'next/server';
 import { getConfig, updateConfig } from '@/lib/config';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { ServiceManager } from '@/lib/services/ServiceManager';
+import { agentManager } from '@/lib/agent/manager';
 import { logger } from '@/lib/logger';
 import { requireSession } from '@/lib/api/requireSession';
 import { apiError } from '@/lib/api/errors';
+
+/** Touch the install-nginx-done marker so the FCoS first-boot
+ *  install-nginx.service unit's ConditionPathExists short-circuits on the
+ *  next boot. Called whenever we've confirmed NPM is up + reachable on the
+ *  wizard credentials — at that point the install-nginx.sh fallback has
+ *  nothing left to do, and leaving the unit's `failed` state lingering only
+ *  produces noise in the diagnose probe. Best-effort; if the agent isn't
+ *  reachable yet (it should be — we just talked to NPM through it) we just
+ *  swallow the error and let the install-nginx.sh trap handle it on next
+ *  boot. */
+async function markInstallNginxDone(nodeName: string): Promise<void> {
+  try {
+    const agent = await agentManager.ensureAgent(nodeName);
+    await agent.sendCommand('exec', {
+      command: 'mkdir -p ~/.config && touch ~/.config/install-nginx-done && systemctl --user reset-failed install-nginx.service 2>/dev/null || true',
+    });
+  } catch (e) {
+    logger.debug('npm:bootstrap', 'Could not mark install-nginx-done:', e);
+  }
+}
 
 export const dynamic = 'force-dynamic';
 
@@ -167,6 +188,7 @@ export async function POST(request: Request) {
     if (targetToken) {
       const config = await getConfig();
       await updateConfig({ reverseProxy: { ...config.reverseProxy, npm: { email, password } } });
+      await markInstallNginxDone(npm.nodeName);
       return NextResponse.json({ ok: true, bootstrapped: false, reason: 'already_using_target' });
     }
 
@@ -211,6 +233,7 @@ export async function POST(request: Request) {
 
     const config = await getConfig();
     await updateConfig({ reverseProxy: { ...config.reverseProxy, npm: { email, password } } });
+    await markInstallNginxDone(npm.nodeName);
 
     logger.info('npm:bootstrap', `NPM admin updated to ${email} on node ${npm.nodeName}`);
     return NextResponse.json({ ok: true, bootstrapped: true });

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -365,18 +365,34 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Deploy Service ---
   server.tool(
     'deploy_service',
-    'Deploy a new service or update an existing one from kube YAML',
+    'Deploy a new service or update an existing one from kube YAML. Pass extraFiles to seed companion config (e.g. authelia/configuration.yml).',
     {
       name: z.string().describe('Service name'),
       kubeContent: z.string().describe('Kubernetes/Podman kube YAML content'),
       yamlContent: z.string().optional().describe('Companion compose/config YAML content'),
       yamlFileName: z.string().optional().describe('Filename for the companion YAML'),
+      extraFiles: z
+        .array(
+          z.object({
+            path: z.string().describe('Absolute path on the node (e.g. /mnt/data/stacks/auth/authelia-config/configuration.yml)'),
+            content: z.string().describe('File content (already mustache-rendered)'),
+          }),
+        )
+        .optional()
+        .describe('Additional config files to write before the unit starts. Failures are fatal — the deploy aborts so the operator knows the service would have started misconfigured.'),
       node: nodeParam,
     },
-    async ({ name, kubeContent, yamlContent, yamlFileName, node }) => {
+    async ({ name, kubeContent, yamlContent, yamlFileName, extraFiles, node }) => {
       const nodeName = await resolveNode(node);
-      await ServiceManager.deployKubeService(nodeName, name, kubeContent, yamlContent ?? '', yamlFileName ?? `${name}.yaml`);
-      return textResult(`Service "${name}" deployed successfully`);
+      await ServiceManager.deployKubeService(
+        nodeName,
+        name,
+        kubeContent,
+        yamlContent ?? '',
+        yamlFileName ?? `${name}.yaml`,
+        extraFiles,
+      );
+      return textResult(`Service "${name}" deployed successfully${extraFiles?.length ? ` (${extraFiles.length} extra file${extraFiles.length === 1 ? '' : 's'} written)` : ''}`);
     },
   );
 

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -602,9 +602,16 @@ export class ServiceManager {
         await this.writeFile(nodeName, `${name}.kube`, kubeContent);
         await this.ensurePodmanSocket(nodeName);
 
-        // Write extra config files (e.g. Authelia configuration.yml) to the node filesystem
+        // Write extra config files (e.g. Authelia configuration.yml) to the node filesystem.
+        // Failures here are FATAL — the previous behaviour was to log a warning
+        // and continue, which produced the radicale crash-loop class of bug:
+        // service starts, looks for a config file that's not there, dies, and
+        // the operator has no breadcrumb back to the real cause (the silent
+        // write_file failure during deploy). Raising here surfaces the
+        // problem at deploy time with a useful path.
         if (extraFiles?.length) {
             const agent = await agentManager.ensureAgent(nodeName);
+            const failures: string[] = [];
             for (const f of extraFiles) {
                 // Ensure parent directory exists
                 const dir = f.path.substring(0, f.path.lastIndexOf('/'));
@@ -613,10 +620,17 @@ export class ServiceManager {
                 }
                 const res = await agent.sendCommand('write_file', { path: f.path, content: f.content });
                 if (res !== 'ok') {
-                    logger.warn('ServiceManager', `Failed to write extra file ${f.path}`);
+                    failures.push(f.path);
+                    logger.error('ServiceManager', `Failed to write extra file ${f.path}: agent returned ${JSON.stringify(res)}`);
                 } else {
                     logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
                 }
+            }
+            if (failures.length > 0) {
+                throw new Error(
+                    `Failed to write ${failures.length} required config file(s) for service "${name}":\n  ${failures.join('\n  ')}\n\n` +
+                    `The service was not started. Re-run the deploy or check the agent's write permissions on the target paths.`,
+                );
             }
         }
 


### PR DESCRIPTION
## Why

Three remaining-debt items from the post-3.6.1 audit, all fixing the same *shape* of bug in different layers: a deploy "succeeds" while leaving the service in a state that can never start cleanly, and the operator only sees the consequence (crash-loop, stale failed unit) without the cause.

## Changes

### 1. \`ServiceManager.deployKubeService\` — extraFile writes are now fatal

Previously: the loop logged a warning and kept going if \`agent.write_file\` returned anything other than \`"ok"\`. The wizard reported success, the unit started, the container couldn't find its config, and you got the radicale-shape crash loop with no breadcrumb back to "the seed actually didn't land".

Now: collect the failed paths, throw a single error listing all of them. Deploy aborts rather than starting a misconfigured service.

### 2. MCP \`deploy_service\` accepts \`extraFiles\`

The wizard passes \`extraFiles\` through for templates that ship a \`*.mustache\` (authelia \`configuration.yml\`, filebrowser \`.filebrowser.json\`). The MCP tool's schema didn't include the parameter, so any agent-driven deploy of those services wrote the unit files but skipped the config seed — same root cause as the radicale crash, different trigger. Schema now accepts:

\`\`\`ts
extraFiles?: { path: string; content: string }[]
\`\`\`

…and threads it through to \`deployKubeService\`. Combined with #1, agent-driven flows now fail loudly if a config seed doesn't land.

### 3. \`install-nginx.service\` — self-marks done on every exit

The first-boot oneshot timed out at 5 min waiting for the agent if the wizard installed NPM first, exited 1, no marker written, unit permanently \`failed\`. Four changes:

- Trap on EXIT touches the marker regardless of success/failure. The unit's \`ConditionPathExists\` suppresses it on subsequent boots — once the wizard has owned NPM, the script has no business racing it.
- \`API_WAIT\` bumped 5 min → 30 min — slow first boots no longer produce a permanently-failed unit.
- Quick-bail: if \`/api/system/nginx/status\` reports \`installed=true\` at any wait step, exit 0 immediately. Skips the agent-wait entirely when the wizard has already finished.
- Timeout exits cleanly (\`exit 0\`) instead of failing — marker still gets touched, operator sees a clear journal line, the wizard owns NPM going forward.

Plus server-side belt-and-suspenders: after a successful NPM bootstrap, \`/api/system/nginx/bootstrap\` writes the marker via the agent (\`mkdir -p ~/.config && touch ~/.config/install-nginx-done && systemctl --user reset-failed install-nginx.service\`). Handles existing 3.6.x installs whose script doesn't have the new trap.

## Test plan

- [x] \`npm test\` — 317 pass, 1 skipped
- [x] \`npm run lint\` clean
- [x] \`next build --webpack\` clean
- [ ] Live: fresh install on FCoS — \`install-nginx.service\` either succeeds or exits 0; the marker exists; no permanent failed-unit
- [ ] Live: agent-driven \`deploy_service\` with \`extraFiles\` for an authelia-style template — config file lands; subsequent restart shows the unit healthy
- [ ] Live: simulate a write_file failure (chmod the target dir 0500 transiently) — the wizard surfaces the deploy error with the offending path, the unit isn't started

🤖 Generated with [Claude Code](https://claude.com/claude-code)