### PR TITLE
fix(install): syncthing runAsUser+PVC, strict mustache render, settle wait, real crash logs

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -226,6 +226,24 @@ export async function POST(request: Request) {
     if (m && parseInt(m[1], 10) < 30) return true;
     return false;
   });
+  // Pull the actual crash reason for each restart-looping container instead
+  // of leaving the operator to run `podman logs <name>` by hand. Three lines
+  // of stderr is usually enough to identify the failure mode (chmod EPERM,
+  // missing config file, port collision, etc). Best-effort: if a fetch fails
+  // we just omit that container's snippet.
+  const offenderDiagnostics = await Promise.all(
+    looping.map(async line => {
+      const name = (line.split('|')[0] ?? '').trim();
+      if (!name) return { line, snippet: '' };
+      const logs = await exec(`podman logs --tail 3 ${name} 2>&1 | tail -3`, 3000);
+      const snippet = (logs.stdout ?? '').trim();
+      return { line, snippet };
+    }),
+  );
+  const offenderDetail = offenderDiagnostics.map(o =>
+    o.snippet ? `${o.line}\n      ↳ ${o.snippet.split('\n').join('\n        ')}` : o.line,
+  ).join('\n');
+
   probes.push({
     id: 'crash_loop',
     label: 'Containers stable',
@@ -238,9 +256,9 @@ export async function POST(request: Request) {
             ? (treatYoungAsLoop
                 ? `${psLines.length} container(s), all stable.`
                 : `${psLines.length} container(s) — system booted ${systemUptimeSec}s ago, young containers expected. Re-run after ~2 min for a real restart-loop check.`)
-            : `${looping.length} of ${psLines.length} container(s) may be in a restart loop:\n${looping.join('\n')}`),
+            : `${looping.length} of ${psLines.length} container(s) may be in a restart loop:\n${offenderDetail}`),
     hint: looping.length > 0
-      ? 'Run `podman logs <name>` for the crash reason. Common causes: bind-mount permission mismatch (rootless UID), missing config file, port conflicts, image entrypoint argv errors.'
+      ? 'The lines under `↳` are the last 3 stderr lines from `podman logs`. Common causes: bind-mount permission mismatch (rootless UID), missing config file, port conflicts, image entrypoint argv errors.'
       : undefined,
   });
 

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
     checkOnboardingStatus,
@@ -208,6 +208,12 @@ export default function OnboardingWizard() {
     'file-share':     { recommendedWith: ['auth'], reason: 'FileBrowser uses authelia forward-auth for family-facing access' },
   };
 
+  // Sentinel at the bottom of the install log. The single scrollbar lives on
+  // the modal body, so when new log lines append we scrollIntoView this
+  // anchor to bring the latest text under the user's eyes without their
+  // having to manually scroll the modal.
+  const logTailRef = useRef<HTMLDivElement | null>(null);
+
   // Track which service is currently mid-deploy. The deploy loop sets
   // this before the API call and clears after — the install-progress
   // strip below reads this to show "installing" while the API is in
@@ -342,6 +348,18 @@ export default function OnboardingWizard() {
     const id = setInterval(tick, 20_000);
     return () => clearInterval(id);
   }, [stackInstallStep]);
+
+  // Keep the install log tail in view as new lines arrive. Only fires while
+  // the install is actually streaming — not during 'done' or other steps —
+  // so the modal doesn't snap-jump on unrelated re-renders. Guard the call
+  // because jsdom (and some older browsers) don't implement scrollIntoView.
+  useEffect(() => {
+    if (stackInstallStep !== 'installing') return;
+    const el = logTailRef.current;
+    if (typeof el?.scrollIntoView === 'function') {
+      el.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+  }, [stackLogs, stackInstallStep]);
 
   // Auto-run the self-diagnose once the install pipeline lands on 'done'.
   // Gated by `diagnoseRanOnce` so reopening the panel doesn't re-fire and
@@ -820,7 +838,29 @@ export default function OnboardingWizard() {
 
       const kubeContent = `[Kube]\nYaml=${item.name}.yml\nAutoUpdate=registry\n\n[Install]\nWantedBy=default.target`;
 
-      // Render extra config files (.mustache) with the same variables
+      // Render extra config files (.mustache) with the same variables.
+      // First sanity-check that every {{VAR}} the config references has a
+      // value in the view — Mustache renders an undefined var as empty
+      // string by default, which is exactly how the user's auth pod ended
+      // up with a configuration.yml that loaded but had session.cookies
+      // and storage.* collapsed to empty (authelia rejected it and the
+      // pod crash-looped, with no breadcrumb back to the wizard step
+      // that produced the broken config). Failing loudly here turns that
+      // class of bug into a deploy-time error message instead.
+      const refRe = /\{\{\s*[#^/{]?\s*([A-Z_][A-Z0-9_]*)\s*\}{1,3}/g;
+      for (const cf of (item.configFiles || [])) {
+        if (!cf.targetPath) continue;
+        const refs = new Set<string>();
+        for (const m of cf.content.matchAll(refRe)) refs.add(m[1]);
+        const missing = [...refs].filter(r => !(r in view) || view[r as keyof typeof view] === '');
+        if (missing.length > 0) {
+          Mustache.escape = savedEscape;
+          throw new Error(
+            `Cannot deploy ${item.name}: ${cf.filename} references variable(s) with no value: ${missing.join(', ')}. ` +
+            `Go back to the Configure step and fill them in (or check the template's variables.json defaults).`,
+          );
+        }
+      }
       const extraFiles = (item.configFiles || [])
         .filter(cf => cf.targetPath)
         .map(cf => {
@@ -911,6 +951,48 @@ export default function OnboardingWizard() {
       if (fallbackPassword) setNpmPassword(fallbackPassword);
       setNpmCredPrompt(true);
     } else {
+      // Settle wait — don't transition to 'done' until each newly-deployed
+      // service shows up as active in the digital twin. Previously we
+      // declared 'done' the moment the deploy API + post-install pipeline
+      // returned, then the auto self-diagnose ran ~immediately and saw
+      // containers still pulling their images, flagging them as restart-
+      // looping ghosts. Cap the wait at 3 minutes — long enough for
+      // cold-start image pulls on a normal connection — then transition
+      // either way and let the diagnose probe report what's genuinely stuck.
+      //
+      // Skip the wait entirely if there's no twin connection (tests, or a
+      // disconnected agent — in either case hanging the wizard for 3 min
+      // helps no one) or if nothing was deployed.
+      const expected = selected.map(i => i.name);
+      if (digitalTwin && expected.length > 0) {
+        const SETTLE_TIMEOUT_MS = 3 * 60_000;
+        const SETTLE_POLL_MS = 5_000;
+        const startedAt = Date.now();
+        let lastReady = -1;
+        while (Date.now() - startedAt < SETTLE_TIMEOUT_MS) {
+          const node = stackSelectedNode || 'Local';
+          const twinNode = digitalTwin?.nodes?.[node];
+          const services = twinNode?.services ?? [];
+          const ready = expected.filter(name =>
+            services.some(s => (s.name === name || s.name === `${name}.service`) && s.active),
+          ).length;
+          if (ready !== lastReady) {
+            setStackLogs(prev => [...prev, `Waiting for services to become active... (${ready}/${expected.length} up)`]);
+            lastReady = ready;
+          }
+          if (ready === expected.length) break;
+          await new Promise(r => setTimeout(r, SETTLE_POLL_MS));
+        }
+        const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+        if (lastReady === expected.length) {
+          setStackLogs(prev => [...prev, `✅ All ${expected.length} services active after ${elapsed}s.`]);
+        } else {
+          setStackLogs(prev => [
+            ...prev,
+            `⚠️ ${lastReady}/${expected.length} services active after ${elapsed}s — slow image pulls or a real failure. Self-diagnose below will tell you which.`,
+          ]);
+        }
+      }
       setStackInstallStep('done');
     }
   };
@@ -1802,13 +1884,23 @@ export default function OnboardingWizard() {
                                     </div>
                                 );
                             })()}
-                            <div className="bg-gray-900 text-gray-100 p-4 rounded-md font-mono text-xs h-[28rem] overflow-y-auto border border-gray-800">
+                            {/* Log panel grows with its content; the modal-level
+                                scrollbar is the only one. Earlier this had its own
+                                fixed height + overflow, which produced two stacked
+                                vertical scrollbars (modal + log) — confusing and
+                                fiddly to drive. The min-height keeps the box from
+                                visually collapsing when the log is just a couple
+                                of lines, and the bottom sentinel auto-scrolls the
+                                modal so new lines stay visible without manual
+                                scrolling. */}
+                            <div className="bg-gray-900 text-gray-100 p-4 rounded-md font-mono text-xs min-h-[12rem] border border-gray-800">
                                 {stackLogs.map((log, i) => <div key={i} className="mb-1">{log}</div>)}
                                 {stackInstallStep === 'installing' && (
                                     <div className="flex items-center gap-2 text-gray-400 mt-2">
                                         <Loader2 size={14} className="animate-spin" /> Processing...
                                     </div>
                                 )}
+                                <div ref={logTailRef} />
                             </div>
                             {npmCredPrompt && (
                                 <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -441,9 +441,17 @@ async function seedAudiobookshelf(opts: { variables: StackVariable[]; onLog: (ms
  *  the FileBrowser CLI inside the running container. Idempotent. */
 async function seedFileBrowserAdmin(opts: { variables: StackVariable[]; node?: string; onLog: (msg: string) => void }): Promise<void> {
   const username = opts.variables.find(v => v.name === 'FILEBROWSER_ADMIN_USER')?.value || 'admin';
-  // Give the pod ~30s to come up before we exec into it.
+  // Give the pod a moment to start before the first exec attempt — but the
+  // real budget is in the retry loop below.
   await new Promise(r => setTimeout(r, 8000));
-  for (let attempt = 0; attempt < 12; attempt++) {
+  // 36 attempts × 5 s = 3 min. The earlier 60-s budget timed out for users
+  // on slow connections where the filebrowser image pull alone can take
+  // 90 s+, leaving the wizard with the "Could not pre-seed FileBrowser
+  // admin" warning and a manual `podman exec` fallback nobody actually runs.
+  const MAX_ATTEMPTS = 36;
+  let lastBeat = 0;
+  const startedAt = Date.now();
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     try {
       const res = await fetch('/api/system/filebrowser/init', {
         method: 'POST',
@@ -457,9 +465,14 @@ async function seedFileBrowserAdmin(opts: { variables: StackVariable[]; node?: s
       }
       // Container probably not ready yet — retry with backoff.
     } catch { /* retry */ }
+    const elapsed = Date.now() - startedAt;
+    if (elapsed - lastBeat >= 30_000) {
+      opts.onLog(`Still waiting for FileBrowser to accept the admin seed (${fmtElapsed(elapsed)} elapsed)...`);
+      lastBeat = elapsed;
+    }
     await new Promise(r => setTimeout(r, 5000));
   }
-  opts.onLog('⚠️ Could not pre-seed FileBrowser admin. Run `podman exec file-share-filebrowser filebrowser users add <user> _ --perm.admin --database /database/filebrowser.db` once the pod is up.');
+  opts.onLog('⚠️ Could not pre-seed FileBrowser admin after 3 minutes. Run `podman exec file-share-filebrowser filebrowser users add <user> _ --perm.admin --database /database/filebrowser.db` once the pod is up.');
 }
 
 async function seedNavidrome(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -25,17 +25,25 @@ spec:
   # 1. Syncthing — Bidirectional folder sync (Android & desktop apps)
   - name: syncthing
     image: docker.io/syncthing/syncthing:latest
-    # Why no privileged / runAsUser overrides any more:
-    # The chmod-the-config-dir crash was the *symptom* of a deeper rootless-
-    # podman + bind-mount + idmap interaction — even with privileged: true
-    # and runAsUser: 0 the kernel returned EPERM on chmod against a host
-    # bind mount. Switching syncthing-config to a podman-managed volume
-    # (see PVC below) sidesteps the whole class of problem: podman creates
-    # the volume with container-UID-0 ownership and the right SELinux
-    # context, so syncthing's startup permission-correct call succeeds.
-    # The shared-data volume is still a bind mount because users care
-    # about the host path of their files; samba writes inside it without
-    # needing to chmod the dir itself.
+    # Two ingredients are needed to make syncthing's startup `chmod` of
+    # /var/syncthing/config succeed under rootless podman + FCoS:
+    #
+    #   1. Use a podman-managed PVC for syncthing-config (see PVC below).
+    #      A host bind mount fails with EPERM no matter what the container
+    #      capabilities are — that's a kernel-level idmap issue.
+    #
+    #   2. runAsUser: 0. Podman creates the named volume owned by the host
+    #      user running rootless podman (uid 1000 = `core`), which inside
+    #      the container appears as uid 0. The syncthing image's default
+    #      ENTRYPOINT runs as the `syncthing` user (container uid 1000 =
+    #      host sub-uid 100999), which does NOT own the volume dir, so
+    #      chmod fails. Forcing container uid 0 lines up with the volume's
+    #      ownership and chmod succeeds.
+    #
+    # Both pieces together = no crash loop. Either one alone = EPERM.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
     env:
       - name: STGUIADDRESS
         value: "0.0.0.0:8384"


### PR DESCRIPTION
## Live MCP probe of the user's freshly-reinstalled box surfaced four bugs

Used the new MCP token + LAN endpoint to read actual container logs on the user's 3.6.2 install. All four below ship together because the failure modes were compounding — syncthing crashes masked the authelia config bug masked the "done is premature" wizard problem.

### 1. Syncthing — needs **runAsUser:0 AND** the PVC, not either alone

Live container log:
\`\`\`
chmod /var/syncthing/config: operation not permitted
Failed to load/generate certificate (error="save cert: open /var/syncthing/config/cert.pem: permission denied")
\`\`\`

PR #204 swapped \`syncthing-config\` from hostPath to a podman-managed PVC, but also dropped \`runAsUser: 0\` thinking the PVC was sufficient. It isn't:

- Podman creates the named volume owned by the host user running rootless podman (uid 1000 = \`core\`), which the container sees as uid 0.
- Without \`runAsUser: 0\`, the syncthing image's default ENTRYPOINT runs as the \`syncthing\` user (container uid 1000 = host sub-uid 100999), which doesn't own the volume dir → \`chmod\` fails.

Restored \`runAsUser: 0\`. Both pieces are needed; either alone = EPERM. Comment on the syncthing container records that.

### 2. Authelia — wizard's mustache rendering was non-strict

Live authelia log:
\`\`\`
Configuration: session: option 'cookies' is required
Configuration: storage: option 'encryption_key' is required
Configuration: storage: configuration ... must be provided
Configuration: notifier: ... must be configured
fatal: Can't continue due to the errors loading the configuration
\`\`\`

The \`configuration.yml\` on disk parses but has whole blocks collapsed to empty strings. Classic Mustache "undefined → empty" silent failure: one of the auto-generated secrets / async-loaded RSA key didn't populate, the wizard rendered the template anyway, the file was written, the deploy reported success, and authelia crash-looped with no breadcrumb back to the wizard step that produced it.

Fix: pre-render check that scans each \`*.mustache\`'s \`{{VAR}}\` references, asserts each has a non-empty value in the wizard's view, and throws with the offending variable names if not. Future deploys fail loudly at the wizard step with \`"AUTHELIA_X is empty"\` instead of producing a broken pod.

### 3. Wizard transitioned to 'done' before containers were actually up

Auto self-diagnose ran while images were still pulling, flagging fresh containers as restart-loops purely because they were Up <30s. The user saw "9 ok 1 warn" on a healthy install.

Fix: settle-wait between post-install and step='done' — poll the digital twin every 5s for up to 3 min, log heartbeats each time the (active / total) count changes, transition either way. Skipped when the twin is unavailable (tests, disconnected agent) so the wizard never hangs.

### 4. \`seedFileBrowserAdmin\` retry budget bumped 60s → 3min

The "Could not pre-seed FileBrowser admin" warning was just the seed routine giving up before the image pull finished. 36 attempts × 5s with a 30-s heartbeat now.

### 5. \`crash_loop\` probe shows actual log lines

Instead of "X may be in a restart loop" + a generic hint, the probe fetches the last 3 lines of \`podman logs <name>\` for each offender and includes them inline:

\`\`\`
file-share-syncthing|Up 1 second
  ↳ ERR Failed to load/generate certificate
    (error="save cert: open .../cert.pem: permission denied")
\`\`\`

Operator gets the actual cause without leaving the UI.

### 6. Dual-scrollbar in install overlay

The log panel had its own \`overflow-y-auto\` *plus* the modal-level scroll. Now: log grows with content under a \`min-h-[12rem]\` floor; only the modal scrolls; auto-scroll-to-tail anchor keeps new lines visible.

## Test plan

- [x] \`npm test\` — 321 pass, 1 skipped
- [x] \`npm run lint\` clean
- [ ] Live: redeploy file-share — \`file-share-syncthing\` stays Up; \`get_container_logs\` shows \`Listening on 0.0.0.0:8384\` instead of EPERM loop
- [ ] Live: redeploy auth on 3.6.4 — strict-render asserts every \`{{X}}\` has a value before write; if a secret didn't generate, wizard surfaces it at install time instead of a crash-looping pod
- [ ] Live: full-stack install — wizard logs "Waiting for services to become active... (X/Y up)" until all are active, only then runs auto-diagnose

🤖 Generated with [Claude Code](https://claude.com/claude-code)