### PR TITLE
fix(install): setup-raid deadlock + syncthing PUID + extraFiles consistency guard

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -318,13 +318,18 @@ storage:
             echo "setup-raid: saved Ignition config from OS disk"
           fi
 
-          # Mount RAID — trigger the systemd mount unit (or mount directly as fallback)
+          # Mount RAID directly. We avoid `systemctl start var-mnt-data.mount`
+          # from inside this service because the synchronous systemctl call
+          # used to deadlock against the mount unit's previous After=setup-raid
+          # ordering (now removed, but a direct mount is simpler and faster
+          # anyway). The systemd mount unit still exists and will reattach the
+          # RAID on subsequent boots via its WantedBy=multi-user.target.
           mkdir -p "$MOUNT_POINT"
-          if systemctl start var-mnt-data.mount 2>/dev/null; then
-            echo "setup-raid: mounted via systemd mount unit"
+          if findmnt -n "$MOUNT_POINT" >/dev/null 2>&1; then
+            echo "setup-raid: $MOUNT_POINT already mounted, skipping"
           else
             mount "$MD_DEV" "$MOUNT_POINT"
-            echo "setup-raid: mounted directly"
+            echo "setup-raid: mounted $MD_DEV at $MOUNT_POINT"
           fi
 
           # Create data directories (no-op if they already exist)
@@ -369,14 +374,23 @@ storage:
 
     # Systemd mount unit for RAID at /var/mnt/data (FCOS: /mnt -> /var/mnt)
     # Uses filesystem label so it works regardless of md device number.
-    # nofail: don't block boot if RAID doesn't exist yet (first boot before setup-raid)
+    # nofail: don't block boot if RAID doesn't exist yet (first boot before setup-raid).
+    #
+    # NB: the previous After=setup-raid.service caused a one-hour first-boot
+    # deadlock — setup-raid.sh calls `systemctl start var-mnt-data.mount`
+    # synchronously, but systemd refused to start the mount until setup-raid
+    # was `active`, and setup-raid wasn't going active until the systemctl
+    # call returned. Relying solely on `Before=var-mnt-data.mount` declared
+    # *on setup-raid.service* (next unit below) preserves correct boot
+    # ordering while letting the explicit start call from inside setup-raid
+    # actually proceed.
     - path: /etc/systemd/system/var-mnt-data.mount
       mode: 0644
       contents:
         inline: |
           [Unit]
           Description=Mount RAID data volume
-          After=local-fs.target setup-raid.service
+          After=local-fs.target
 
           [Mount]
           What=LABEL=data

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -602,6 +602,37 @@ export class ServiceManager {
         await this.writeFile(nodeName, `${name}.kube`, kubeContent);
         await this.ensurePodmanSocket(nodeName);
 
+        // Defensive: if the template ships any *.mustache config files but the
+        // caller (wizard / MCP / installer) didn't pass them through as
+        // extraFiles, abort the deploy. The live failure mode this guards
+        // against: the OnboardingWizard's resolver returns an empty
+        // configFiles list (e.g. transient template-fetch error) and the
+        // wizard happily writes the kube + yaml without the rendered config.
+        // The container starts, finds /config/ empty, and either crashes
+        // (radicale-shape) or auto-creates an upstream-sample default
+        // (authelia-shape, 71KB of commented-out boilerplate). Both leave
+        // the operator with a permanently-failed pod and no breadcrumb to
+        // the missing seed.
+        try {
+            const { getTemplateConfigFiles } = await import('@/lib/registry');
+            const expected = await getTemplateConfigFiles(name);
+            if (expected.length > 0) {
+                const got = new Set((extraFiles ?? []).map(f => f.path.split('/').pop()).filter(Boolean));
+                const missing = expected.filter(e => !got.has(e.filename));
+                if (missing.length > 0) {
+                    throw new Error(
+                        `Template "${name}" ships ${expected.length} mustache config file(s) but ${missing.length} weren't sent to the deploy step:\n  ${missing.map(m => m.filename).join(', ')}\n\n` +
+                        `This usually means the wizard's resolver couldn't map a config file to a hostPath — check that the pod manifest declares servicebay.config-mount: <mountPath> and that the mountPath has a matching volume.`,
+                    );
+                }
+            }
+        } catch (e) {
+            // Re-throw deploy-blocking errors; swallow only registry-level
+            // issues (e.g. node-side template dir missing in the container).
+            if (e instanceof Error && e.message.startsWith('Template "')) throw e;
+            logger.debug('ServiceManager', 'Could not verify template configFiles parity:', e);
+        }
+
         // Write extra config files (e.g. Authelia configuration.yml) to the node filesystem.
         // Failures here are FATAL — the previous behaviour was to log a warning
         // and continue, which produced the radicale crash-loop class of bug:

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -25,26 +25,36 @@ spec:
   # 1. Syncthing — Bidirectional folder sync (Android & desktop apps)
   - name: syncthing
     image: docker.io/syncthing/syncthing:latest
-    # Two ingredients are needed to make syncthing's startup `chmod` of
+    # THREE ingredients are needed to make syncthing's startup `chmod` of
     # /var/syncthing/config succeed under rootless podman + FCoS:
     #
     #   1. Use a podman-managed PVC for syncthing-config (see PVC below).
     #      A host bind mount fails with EPERM no matter what the container
     #      capabilities are — that's a kernel-level idmap issue.
     #
-    #   2. runAsUser: 0. Podman creates the named volume owned by the host
-    #      user running rootless podman (uid 1000 = `core`), which inside
-    #      the container appears as uid 0. The syncthing image's default
-    #      ENTRYPOINT runs as the `syncthing` user (container uid 1000 =
-    #      host sub-uid 100999), which does NOT own the volume dir, so
-    #      chmod fails. Forcing container uid 0 lines up with the volume's
-    #      ownership and chmod succeeds.
+    #   2. runAsUser: 0 / runAsGroup: 0. Podman creates the named volume
+    #      owned by the host user running rootless podman (uid 1000 =
+    #      `core`), which inside the container appears as uid 0.
     #
-    # Both pieces together = no crash loop. Either one alone = EPERM.
+    #   3. PUID=0 / PGID=0 env vars. The syncthing/syncthing image's
+    #      entrypoint runs `setpriv --reuid $PUID --regid $PGID` REGARDLESS
+    #      of the K8s runAsUser — defaulting to 1000:1000. Without these
+    #      env overrides, the container starts as uid 0 but immediately
+    #      drops to uid 1000, which doesn't own the volume's _data dir
+    #      (created as container uid 0 = host uid 1000). Setting PUID=0
+    #      keeps everything at uid 0 end-to-end and chmod succeeds.
+    #
+    # All three pieces together = no crash loop. Any one missing = EPERM.
+    # Verified the hard way: spent a debugging session walking through each
+    # combination on a live FCoS box.
     securityContext:
       runAsUser: 0
       runAsGroup: 0
     env:
+      - name: PUID
+        value: "0"
+      - name: PGID
+        value: "0"
       - name: STGUIADDRESS
         value: "0.0.0.0:8384"
     ports:


### PR DESCRIPTION
## Three live-debugged fixes

### 1. setup-raid first-boot deadlock

User's box had \`setup-raid.service\` stuck in \`activating (start)\` for **1h+**. Child process blocked on \`systemctl start var-mnt-data.mount\`. Cause: the mount unit had \`After=setup-raid.service\`, so systemd refused to start the mount until setup-raid was \`active\`; setup-raid couldn't go active until its script returned from the systemctl call. Classic ordering deadlock.

**Effect on the user**: RAID stayed unmounted. Every write to \`/mnt/data\` silently landed on the OS partition (not the RAID) — defeating the whole point of having the RAID disk.

**Fix**:
- Drop \`After=setup-raid.service\` from \`var-mnt-data.mount\` (the \`Before=var-mnt-data.mount\` declared on setup-raid.service preserves boot ordering)
- Replace the synchronous \`systemctl start\` in \`setup-raid.sh\` with a direct \`mount $MD_DEV $MOUNT_POINT\` — faster, no scheduler dependency, idempotent

### 2. Syncthing PUID=0 PGID=0 (the missing third ingredient)

The chmod EPERM crash loop survived **both** the PVC swap (PR #204) **and** the \`runAsUser: 0\` fix (PR #209). Live debug revealed why:

\`\`\`
docker.io/syncthing/syncthing  entrypoint:
  setpriv --reuid \$PUID --regid \$PGID --init-groups syncthing serve …
\`\`\`

The image's entrypoint runs \`setpriv\` REGARDLESS of the K8s \`securityContext\`. Defaults to PUID=1000 → image always drops to uid 1000 inside the container, which doesn't own the PVC's \`_data\` dir (created as container uid 0 = host uid 1000) → chmod fails → cert.pem write fails → exit → restart loop.

**Fix**: add \`PUID=0 PGID=0\` env so the image's setpriv keeps everything at uid 0 end-to-end, lining up with the volume's ownership. Comment on the syncthing container records why **all three** ingredients are needed.

### 3. \`deployKubeService\` extraFiles consistency guard

Root cause of the user's broken authelia: wizard's resolver returned an empty \`configFiles\` list for auth, \`deployKubeService\` wrote the kube + yaml without seeding \`configuration.yml.mustache\`, authelia container started, found \`/config/\` empty, auto-created its **71,840-byte upstream-sample default** (every section commented out), crash-looped forever with no breadcrumb back to the missing seed.

**Defensive guard**: at deploy time, server-side calls \`getTemplateConfigFiles(name)\` and asserts every \`*.mustache\` the template ships is in the caller's \`extraFiles[]\`. Missing → throw with the offending filename(s) and a hint about checking the \`servicebay.config-mount\` annotation.

Catches the silent-skip whether the caller is the OnboardingWizard, the InstallerModal, or the MCP \`deploy_service\` tool.

## Live verification

On the user's 3.6.4 box (via MCP):
- ✅ setup-raid stop unblocked var-mnt-data.mount → \`/dev/md127 1.9T\` mounted at \`/var/mnt/data\`
- ✅ syncthing patched with PUID=0 + runAsUser:0 → \`Listening on [::]:8384\`, joined relay
- ✅ Self-diagnose: 9 ✅ + 1 ℹ️ (open ports, info-only)

## Test plan

- [x] \`npm test\` — 321 pass
- [x] \`npm run lint\` clean
- [x] \`next build --webpack\` clean
- [ ] Fresh wipe + reinstall on FCoS — first-boot completes without setup-raid deadlock; \`/dev/md127\` mounts cleanly at \`/var/mnt/data\`
- [ ] Wizard installs file-share — syncthing comes up immediately, no chmod EPERM loop
- [ ] Simulated wizard regression: deploy auth without \`extraFiles\` → server rejects with the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)