### PR TITLE
fix(wizard): multi-doc YAML resolver + skip post-install for failed deploys

### DIFF
--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -185,19 +185,62 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
             }
 
             // Fetch extra config files (.mustache) and resolve target paths
+            // by parsing the rendered YAML and chasing volume names. The
+            // earlier regex-based resolver broke on multi-container pods
+            // (first-match-wins for same-suffix mountPaths) and on multi-
+            // doc YAML (Pod + PersistentVolumeClaim — file-share ships
+            // both since 3.6.4). Mirrors the OnboardingWizard's resolver
+            // — both code paths must stay in sync or one of them silently
+            // drops mustache configs and the deploy aborts via the
+            // ServiceManager extraFiles consistency guard.
             const cfgFiles = await fetchTemplateConfigFiles(item.name, template.source);
             if (cfgFiles.length > 0) {
-              const volMounts = [...yaml.matchAll(/mountPath:\s*(\S+)/g)].map(m => m[1]);
-              const hostPaths = [...yaml.matchAll(/path:\s*(\S+)/g)].map(m => m[1]);
-              const annotationMatch = yaml.match(/servicebay\.config-mount:\s*['"]?([^'"\s]+)/);
-              const explicitMount = annotationMatch?.[1];
-              for (const cf of cfgFiles) {
-                const configMountIdx = explicitMount
-                  ? volMounts.findIndex(m => m === explicitMount)
-                  : volMounts.findIndex(m => m === '/config' || m.endsWith('/config') || m.endsWith('/conf'));
-                if (configMountIdx !== -1 && hostPaths[configMountIdx]) {
-                  cf.targetPath = `${hostPaths[configMountIdx]}/${cf.filename}`;
+              const safeYaml = yaml.replace(/\{\{[^}]+\}\}/g, '0');
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              let docs: any[] = [];
+              try {
+                docs = (await import('js-yaml')).loadAll(safeYaml);
+              } catch {
+                docs = [];
+              }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const doc = docs.find((d: any) => d?.kind === 'Pod') ?? docs[0];
+              const nameToHostPath = new Map<string, string>();
+              const mountPathToHostPath = new Map<string, string>();
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              for (const v of (doc?.spec?.volumes ?? []) as any[]) {
+                if (typeof v?.name === 'string' && typeof v?.hostPath?.path === 'string') {
+                  nameToHostPath.set(v.name, v.hostPath.path);
                 }
+              }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              for (const c of (doc?.spec?.containers ?? []) as any[]) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                for (const m of (c?.volumeMounts ?? []) as any[]) {
+                  if (typeof m?.mountPath === 'string' && typeof m?.name === 'string') {
+                    const hp = nameToHostPath.get(m.name);
+                    if (hp && !mountPathToHostPath.has(m.mountPath)) {
+                      mountPathToHostPath.set(m.mountPath, hp);
+                    }
+                  }
+                }
+              }
+              const annotations: Record<string, string> = doc?.metadata?.annotations ?? {};
+              const explicitMount = annotations['servicebay.config-mount'];
+              for (const cf of cfgFiles) {
+                let hp: string | undefined;
+                if (explicitMount) {
+                  hp = mountPathToHostPath.get(explicitMount);
+                }
+                if (!hp) {
+                  for (const [mp, h] of mountPathToHostPath.entries()) {
+                    if (mp === '/config' || mp.endsWith('/config') || mp.endsWith('/conf')) {
+                      hp = h;
+                      break;
+                    }
+                  }
+                }
+                if (hp) cf.targetPath = `${hp}/${cf.filename}`;
                 const cfgMatches = cf.content.matchAll(/\{\{\s*([\w\d_]+)\s*\}\}/g);
                 for (const m of cfgMatches) vars.add(m[1]);
               }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -671,14 +671,22 @@ export default function OnboardingWizard() {
           // `{{FILEBROWSER_PORT}}` don't trip the YAML parser. Values aren't
           // material here — we only need the structure.
           const safeYaml = yaml.replace(/\{\{[^}]+\}\}/g, '0');
-          let parsed: unknown;
+          // Multi-doc support — file-share ships Pod + PVC since 3.6.4.
+          // js-yaml's `load()` throws on multi-doc, was caught silently,
+          // left `parsed = null` and the resolver skipped writing the
+          // mustache config. Symptom was the wizard's defensive guard
+          // refusing the file-share deploy with "1 mustache config
+          // file(s) weren't sent to the deploy step". Use `loadAll` and
+          // find the Pod doc explicitly.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let docs: any[] = [];
           try {
-            parsed = (await import('js-yaml')).load(safeYaml);
+            docs = (await import('js-yaml')).loadAll(safeYaml);
           } catch {
-            parsed = null;
+            docs = [];
           }
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const doc = parsed as any;
+          const doc = docs.find((d: any) => d?.kind === 'Pod') ?? docs[0];
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const volumes: any[] = doc?.spec?.volumes ?? [];
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -820,10 +828,20 @@ export default function OnboardingWizard() {
 
     const selected = stackItems.filter(i => i.checked);
 
+    // Track which services actually deployed cleanly. The post-install
+    // pipeline (NPM bootstrap, LLDAP/ABS/Navidrome/FileBrowser admin
+    // seeding, OIDC client registration) iterates this list instead of
+    // the user's *intended* selection \u2014 without this, a failed deploy
+    // (e.g. the wizard's defensive guard refusing a misconfigured
+    // file-share) still kicked off the FileBrowser seeder which then
+    // hung for 3 min on a container that was never going to start.
+    const deployed: { name: string; checked: boolean }[] = [];
+
     for (const item of selected) {
       // Skip already-installed services
       if (item.alreadyInstalled) {
         setStackLogs(prev => [...prev, `\u2705 ${item.name} already installed, skipping.`]);
+        deployed.push({ name: item.name, checked: true });
         continue;
       }
       if (!item.yaml) continue;
@@ -921,9 +939,12 @@ export default function OnboardingWizard() {
         }
 
         setStackLogs(prev => [...prev, `\u2705 ${item.name} deployed (containers may still be starting in background).`]);
+        deployed.push({ name: item.name, checked: true });
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         setStackLogs(prev => [...prev, `\u274c Failed to install ${item.name}: ${msg}`]);
+        // Don't add to `deployed` \u2014 post-install will skip seeders /
+        // proxy routes for this service.
       } finally {
         // Clear in-flight marker so the status strip switches from
         // "installing" to twin-derived state for the next render tick.
@@ -931,8 +952,13 @@ export default function OnboardingWizard() {
       }
     }
 
+    // Post-install (LLDAP seed, ABS/Navidrome/FileBrowser admin seed, OIDC
+    // client registration, NPM bootstrap, proxy-host creation) runs only
+    // for services that actually deployed cleanly. A failed deploy is
+    // dropped from `deployed` above so its post-install steps don't hang
+    // on a container that was never going to start.
     const proxyResult = await runPostInstall({
-      selected,
+      selected: deployed,
       variables: stackVariables,
       node: stackSelectedNode || undefined,
       onLog: (msg) => setStackLogs(prev => [...prev, msg]),
@@ -963,7 +989,10 @@ export default function OnboardingWizard() {
       // Skip the wait entirely if there's no twin connection (tests, or a
       // disconnected agent — in either case hanging the wizard for 3 min
       // helps no one) or if nothing was deployed.
-      const expected = selected.map(i => i.name);
+      // Same rationale as runPostInstall — wait only for services that
+      // actually deployed. A failed deploy isn't going to become active
+      // and a stuck "0/9 up" heartbeat is just noise.
+      const expected = deployed.map(i => i.name);
       if (digitalTwin && expected.length > 0) {
         const SETTLE_TIMEOUT_MS = 3 * 60_000;
         const SETTLE_POLL_MS = 5_000;


### PR DESCRIPTION
## Two bugs the 3.6.5 defensive guard surfaced

The moment your reinstall hit the new \`extraFiles\` consistency guard:

\`\`\`
❌ Failed to install file-share: Template "file-share" ships 1 mustache
  config file(s) but 1 weren't sent to the deploy step: .filebrowser.json
\`\`\`

…the guard caught a **second** silent-skip in the wizard that had been hiding behind the authelia bug all along, plus a third issue (the wizard kept running post-install steps for the failed deploy).

### 1. Multi-doc YAML resolver

\`templates/file-share/template.yml\` ships **Pod + PersistentVolumeClaim** in the same file (since 3.6.4's syncthing PVC swap). The wizard's resolver used \`js-yaml.load(safeYaml)\` — which **throws on multi-doc** — wrapped in a silent catch that set \`parsed = null\`. From there:

- \`volumes = []\`, \`containers = []\`, \`mountPathToHostPath\` empty
- \`cf.targetPath\` never set
- \`extraFiles\` empty
- New ServiceManager guard correctly refuses the deploy

Same shape of bug in **\`InstallerModal.tsx\`** — its old regex-based resolver also failed on multi-doc YAML, *plus* had a first-match-wins issue when multiple containers had \`/config\`-suffix mountPaths.

**Fix**: both resolvers now use \`loadAll()\` + \`find(d => d?.kind === 'Pod')\`, and \`InstallerModal\` now uses the same volume-name-chasing algorithm the wizard's resolver already had. Keeping them as parallel implementations is what produced the bug — making them identical reduces the chance of next drift.

### 2. Skip post-install for failed deploys

When file-share's deploy threw, the wizard still kicked off \`seedFileBrowserAdmin\` because it iterated the user's *intended* selection, not what actually deployed. Result: 3 minutes of \`Still waiting for FileBrowser to accept the admin seed...\` for a container that was never going to start.

**Fix**: track a \`deployed\` list during the install loop — only services that reach the post-deploy \`✅ X deployed\` line get added. Both \`runPostInstall\` and the settle-wait now iterate \`deployed\` instead of \`selected\`. A failed deploy is dropped from both → wizard reports the error, skips the doomed seeder, lets the rest of the install proceed.

## Test plan

- [x] \`npm test\` — 321 pass
- [x] \`npm run lint\` clean
- [ ] Live: redeploy file-share — defensive guard no longer fires (\`.filebrowser.json\` resolves to its hostPath); filebrowser starts and the admin seed succeeds
- [ ] Live: simulate a failed deploy (e.g. break a template's annotation) → wizard logs the error, doesn't hang on a downstream seeder, the *other* services' seeds still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)