### PR TITLE
fix(wizard): preserve mustache placeholders in extraFiles paths (the authelia-config root cause)

### DIFF
--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -195,7 +195,16 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
             // ServiceManager extraFiles consistency guard.
             const cfgFiles = await fetchTemplateConfigFiles(item.name, template.source);
             if (cfgFiles.length > 0) {
-              const safeYaml = yaml.replace(/\{\{[^}]+\}\}/g, '0');
+              // Sentinel-encode mustache placeholders so YAML parses but
+              // we don't poison host-path strings. See the matching
+              // comment in OnboardingWizard.tsx for the live-debugged
+              // pathology that made `{{DATA_DIR}}` end up as a literal
+              // `0` in `targetPath`, writing config files under `~/0/`.
+              const SENTINEL_RE_OUT = /\{\{\s*([\w\d_]+)\s*\}\}/g;
+              const SENTINEL_RE_IN = /__SBVAR_([\w\d_]+)__/g;
+              const safeYaml = yaml.replace(SENTINEL_RE_OUT, (_m, n) => `__SBVAR_${n}__`);
+              const restorePlaceholders = (s: string): string =>
+                s.replace(SENTINEL_RE_IN, (_m, n) => `{{${n}}}`);
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               let docs: any[] = [];
               try {
@@ -210,7 +219,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               for (const v of (doc?.spec?.volumes ?? []) as any[]) {
                 if (typeof v?.name === 'string' && typeof v?.hostPath?.path === 'string') {
-                  nameToHostPath.set(v.name, v.hostPath.path);
+                  nameToHostPath.set(v.name, restorePlaceholders(v.hostPath.path));
                 }
               }
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -667,17 +667,30 @@ export default function OnboardingWizard() {
           // by chasing the `name` reference on each volumeMount across all containers.
           const nameToHostPath = new Map<string, string>();
           const mountPathToHostPath = new Map<string, string>();
-          // Render Mustache placeholders so that string interpolations like
-          // `{{FILEBROWSER_PORT}}` don't trip the YAML parser. Values aren't
-          // material here — we only need the structure.
-          const safeYaml = yaml.replace(/\{\{[^}]+\}\}/g, '0');
+          // YAML-parse the template so we can chase volume names instead of
+          // doing fragile regex matching. Mustache placeholders need to be
+          // pre-escaped (raw {{X}} isn't valid YAML in some positions like
+          // `containerPort: {{X}}`), but we can't just substitute them with
+          // junk values — earlier versions replaced `{{X}}` with `0`, which
+          // poisoned the host-path strings: `path: {{DATA_DIR}}/auth/...`
+          // became `path: 0/auth/...`, and the resolver then computed
+          // targetPath = "0/auth/authelia-config/configuration.yml" — a
+          // RELATIVE path the agent's mkdir resolved under ~, leaving the
+          // actual /mnt/data/stacks/auth/authelia-config/ empty for
+          // authelia to fill with its 71KB upstream-sample default. Live-
+          // debugged this exact pathology twice.
+          //
+          // Round-trip the placeholders: encode `{{X}}` to a YAML-safe
+          // sentinel that preserves the variable name, parse, then decode
+          // back to `{{X}}` in the extracted strings. Mustache.render at
+          // deploy time resolves them with the user's actual values.
+          const SENTINEL_RE_OUT = /\{\{\s*([\w\d_]+)\s*\}\}/g;
+          const SENTINEL_RE_IN = /__SBVAR_([\w\d_]+)__/g;
+          const safeYaml = yaml.replace(SENTINEL_RE_OUT, (_m, n) => `__SBVAR_${n}__`);
+          const restorePlaceholders = (s: string): string =>
+            s.replace(SENTINEL_RE_IN, (_m, n) => `{{${n}}}`);
           // Multi-doc support — file-share ships Pod + PVC since 3.6.4.
-          // js-yaml's `load()` throws on multi-doc, was caught silently,
-          // left `parsed = null` and the resolver skipped writing the
-          // mustache config. Symptom was the wizard's defensive guard
-          // refusing the file-share deploy with "1 mustache config
-          // file(s) weren't sent to the deploy step". Use `loadAll` and
-          // find the Pod doc explicitly.
+          // js-yaml's `load()` throws on multi-doc, so use `loadAll`.
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           let docs: any[] = [];
           try {
@@ -694,7 +707,10 @@ export default function OnboardingWizard() {
           const annotations: Record<string, string> = doc?.metadata?.annotations ?? {};
           for (const v of volumes) {
             if (typeof v?.name === 'string' && typeof v?.hostPath?.path === 'string') {
-              nameToHostPath.set(v.name, v.hostPath.path);
+              // Restore {{VAR}} placeholders that we sentinel-encoded for
+              // YAML parsing. The deploy step's Mustache.render then
+              // expands them against the wizard's view.
+              nameToHostPath.set(v.name, restorePlaceholders(v.hostPath.path));
             }
           }
           for (const c of containers) {

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -626,6 +626,21 @@ export class ServiceManager {
                     );
                 }
             }
+            // Belt-and-suspenders: every extraFile path must be absolute. The
+            // earlier failure mode (#PR for this) had the wizard's resolver
+            // poison `{{DATA_DIR}}` to the literal `0`, producing a relative
+            // path like `0/auth/authelia-config/configuration.yml`. The
+            // agent's `mkdir -p` resolved it under ~ — so configs landed at
+            // `/var/home/core/0/...` and the actual mount stayed empty.
+            // Authelia's image then auto-created a 71KB upstream sample
+            // there, crash-looped, and the operator had no obvious cause.
+            const relative = (extraFiles ?? []).filter(f => !f.path.startsWith('/'));
+            if (relative.length > 0) {
+                throw new Error(
+                    `Template "${name}" extraFiles include ${relative.length} relative path(s) — the agent will resolve these under ~ and the file will land in the wrong place:\n  ${relative.map(f => f.path).join('\n  ')}\n\n` +
+                    `This usually means the wizard's resolver substituted a Mustache placeholder (e.g. {{DATA_DIR}}) with junk before parsing. Check that targetPath preserves the {{...}} placeholder until deploy-time render.`,
+                );
+            }
         } catch (e) {
             // Re-throw deploy-blocking errors; swallow only registry-level
             // issues (e.g. node-side template dir missing in the container).


### PR DESCRIPTION
## Live evidence

\`\`\`
/var/home/core/0/auth/authelia-config/configuration.yml   ← OUR rendered file
/mnt/data/stacks/auth/authelia-config/configuration.yml   ← Authelia's 71KB sample default
\`\`\`

That literal \`0\` in the path is the **actual root cause** of every "authelia crash-loops with storage/notifier missing" report we've been chasing for two days. It's been there since PR #193 (3.6.2).

## The bug

The wizard's resolver pre-replaces \`{{X}}\` placeholders with the literal \`0\` so js-yaml can parse the template. That worked for *structure* but poisoned the *host-path strings*:

\`\`\`yaml
- name: authelia-config
  hostPath:
    path: {{DATA_DIR}}/auth/authelia-config    ←  template
    path: 0/auth/authelia-config                ←  after `safeYaml` substitution
\`\`\`

Resolver stored \`0/auth/authelia-config\` as the host-path. \`targetPath\` ended up as the relative \`0/auth/authelia-config/configuration.yml\`. The agent's \`mkdir -p\` + \`write_file\` resolved the relative path under \`~\` and landed at \`/var/home/core/0/...\`. The actual \`/mnt/data/stacks/auth/authelia-config/\` stayed empty. Authelia's image then auto-created its 71KB upstream-sample default in there on first start. Crash loop forever, no breadcrumb.

3.6.5's defensive guard didn't catch it because it only checks filenames, not whether \`targetPath\` is an absolute path. Same shape reproduced in InstallerModal's resolver in PR #213.

## Fix

Round-trip the placeholders. Encode \`{{X}}\` → \`__SBVAR_X__\` (a YAML-safe sentinel that preserves the variable name), parse, then decode back to \`{{X}}\` in the extracted strings. The deploy step's existing \`Mustache.render(cf.targetPath, view)\` resolves them with the user's actual values.

Belt-and-suspenders in \`ServiceManager.deployKubeService\`: any \`extraFile\` with a relative path now triggers an explicit deploy-time error pointing at the placeholder-substitution problem.

## Test plan

- [x] \`npm test\` — 321 pass
- [x] \`npm run lint\` clean
- [ ] Live: redeploy auth → \`/mnt/data/stacks/auth/authelia-config/configuration.yml\` is OUR ~4KB rendered config (not the 71KB upstream sample), authelia starts and listens on :9091
- [ ] Live: \`/var/home/core/0/\` no longer accumulates orphan config files
- [ ] Synthetic regression: revert the resolver fix → \`extraFile\` validation in ServiceManager fires with the new "relative path" error message at deploy time, not on container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)