### PR TITLE
feat(templates): per-template post-deploy.py scripts (phase 1: media)

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { getReadme, getTemplateYaml, getTemplateVariables, getTemplateConfigFiles, getTemplates, syncRegistries } from '@/lib/registry';
+import { getReadme, getTemplateYaml, getTemplateVariables, getTemplateConfigFiles, getTemplatePostDeployScript, getTemplates, syncRegistries } from '@/lib/registry';
 
 export async function fetchTemplates() {
   return await getTemplates();
@@ -20,6 +20,10 @@ export async function fetchTemplateVariables(name: string, source: string = 'Bui
 
 export async function fetchTemplateConfigFiles(name: string, source: string = 'Built-in') {
     return await getTemplateConfigFiles(name, source);
+}
+
+export async function fetchTemplatePostDeployScript(name: string, source: string = 'Built-in') {
+    return await getTemplatePostDeployScript(name, source);
 }
 
 export async function syncAllRegistries() {

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -292,7 +292,7 @@ export async function POST(request: Request) {
   }
 
   // Handle Container Creation
-  const { name, kubeContent, yamlContent, yamlFileName, extraFiles } = body;
+  const { name, kubeContent, yamlContent, yamlFileName, extraFiles, postDeployScript, postDeployEnv } = body;
 
   if (!name || !kubeContent || !yamlContent || !yamlFileName) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
@@ -306,9 +306,19 @@ export async function POST(request: Request) {
 
     (async () => {
       try {
-        await ServiceManager.deployKubeService(targetNode, name, kubeContent, yamlContent, yamlFileName, extraFiles, (message) => {
-          writer.write(encoder.encode(JSON.stringify({ type: 'progress', message }) + '\n')).catch(() => {});
-        });
+        await ServiceManager.deployKubeService(
+          targetNode,
+          name,
+          kubeContent,
+          yamlContent,
+          yamlFileName,
+          extraFiles,
+          (message) => {
+            writer.write(encoder.encode(JSON.stringify({ type: 'progress', message }) + '\n')).catch(() => {});
+          },
+          postDeployScript,
+          postDeployEnv,
+        );
         await writer.write(encoder.encode(JSON.stringify({ type: 'complete', success: true }) + '\n'));
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -326,6 +336,16 @@ export async function POST(request: Request) {
     });
   }
 
-  await ServiceManager.deployKubeService(targetNode, name, kubeContent, yamlContent, yamlFileName, extraFiles);
+  await ServiceManager.deployKubeService(
+    targetNode,
+    name,
+    kubeContent,
+    yamlContent,
+    yamlFileName,
+    extraFiles,
+    undefined,
+    postDeployScript,
+    postDeployEnv,
+  );
   return NextResponse.json({ success: true });
 }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -15,7 +15,7 @@ import {
     OnboardingStatus
 } from '@/app/actions/onboarding';
 import { generateLocalKey } from '@/app/actions/ssh';
-import { fetchTemplates, fetchReadme, fetchTemplateYaml, fetchTemplateVariables, fetchTemplateConfigFiles } from '@/app/actions';
+import { fetchTemplates, fetchReadme, fetchTemplateYaml, fetchTemplateVariables, fetchTemplateConfigFiles, fetchTemplatePostDeployScript } from '@/app/actions';
 import { getNodes } from '@/app/actions/system';
 import { Template, VariableMeta } from '@/lib/registry';
 import {
@@ -853,6 +853,17 @@ export default function OnboardingWizard() {
     // hung for 3 min on a container that was never going to start.
     const deployed: { name: string; checked: boolean }[] = [];
 
+    // Templates that supplied a post-deploy.py \u2014 for those we skip the
+    // hardcoded helpers in postInstall.ts (the script handles credentials,
+    // admin seeding, etc. for that service). See templates/<name>/post-deploy.py
+    // and the script-protocol comment in lib/registry.ts.
+    const templatesWithScript = new Set<string>();
+
+    // Credentials parsed from `__SB_CREDENTIAL__ {json}` markers the scripts
+    // emit on stdout \u2014 appended to the SAVE-THESE-NOW banner at the end.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scriptCredentials: any[] = [];
+
     for (const item of selected) {
       // Skip already-installed services
       if (item.alreadyInstalled) {
@@ -904,12 +915,44 @@ export default function OnboardingWizard() {
         });
       Mustache.escape = savedEscape;
 
+      // Optional per-template post-deploy.py — rendered with the same view
+      // and shipped to the agent inside the deploy POST. Server runs it
+      // after the unit starts; output streams back as `progress` events
+      // and gets parsed for `__SB_CREDENTIAL__ {json}` markers below.
+      let postDeployScript: string | undefined;
+      try {
+        const raw = await fetchTemplatePostDeployScript(item.name, selectedStack?.source || 'Built-in');
+        if (raw) {
+          const savedEscape2 = Mustache.escape;
+          Mustache.escape = (text: string) => text;
+          postDeployScript = Mustache.render(raw, view);
+          Mustache.escape = savedEscape2;
+          templatesWithScript.add(item.name);
+        }
+      } catch { /* template ships no script — fall through to hardcoded helpers */ }
+
+      // Variables exported as env vars to the script. Scoped to string-shaped
+      // entries; the engine in ServiceManager handles bash-quote escaping.
+      const postDeployEnv: Record<string, string> = {};
+      for (const v of stackVariables) {
+        if (typeof v.value === 'string') postDeployEnv[v.name] = v.value;
+      }
+      if (typeof window !== 'undefined') postDeployEnv.HOST = window.location.hostname || 'localhost';
+
       try {
         const query = stackSelectedNode ? `?node=${stackSelectedNode}&stream=1` : '?stream=1';
         const res = await fetch(`/api/services${query}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: item.name, kubeContent, yamlContent: content, yamlFileName: `${item.name}.yml`, extraFiles }),
+          body: JSON.stringify({
+            name: item.name,
+            kubeContent,
+            yamlContent: content,
+            yamlFileName: `${item.name}.yml`,
+            extraFiles,
+            postDeployScript,
+            postDeployEnv: postDeployScript ? postDeployEnv : undefined,
+          }),
         });
         if (!res.ok) {
           const err = await res.json();
@@ -933,6 +976,16 @@ export default function OnboardingWizard() {
               try {
                 const evt = JSON.parse(line);
                 if (evt.type === 'progress') {
+                  // Intercept `__SB_CREDENTIAL__ {json}` markers from the
+                  // post-deploy.py script: park the parsed entry in
+                  // scriptCredentials so it lands in the SAVE-THESE-NOW
+                  // banner. Don't echo the raw marker to the install log.
+                  if (typeof evt.message === 'string' && evt.message.startsWith('__SB_CREDENTIAL__ ')) {
+                    try {
+                      scriptCredentials.push(JSON.parse(evt.message.slice('__SB_CREDENTIAL__ '.length)));
+                    } catch { /* malformed marker — drop it */ }
+                    continue;
+                  }
                   // Update last progress line in-place to avoid log spam
                   if (lastProgressLine) {
                     setStackLogs(prev => {
@@ -973,11 +1026,18 @@ export default function OnboardingWizard() {
     // for services that actually deployed cleanly. A failed deploy is
     // dropped from `deployed` above so its post-install steps don't hang
     // on a container that was never going to start.
+    //
+    // `skipDefaults` lets per-template post-deploy.py scripts replace the
+    // hardcoded helpers in postInstall.ts. `extraCredentials` are the
+    // entries those scripts emitted via `__SB_CREDENTIAL__` markers, to
+    // be appended to the final SAVE-THESE-NOW banner.
     const proxyResult = await runPostInstall({
       selected: deployed,
       variables: stackVariables,
       node: stackSelectedNode || undefined,
       onLog: (msg) => setStackLogs(prev => [...prev, msg]),
+      skipDefaults: templatesWithScript,
+      extraCredentials: scriptCredentials,
     });
 
     if (proxyResult === 'needs_credentials') {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -353,3 +353,44 @@ export async function getTemplateConfigFiles(name: string, source?: string): Pro
 
   return scanDir(path.join(TEMPLATES_PATH, name));
 }
+
+/**
+ * Read a template's post-deploy script if present. Convention: a single
+ * `post-deploy.py` file in the template directory, executed by the agent
+ * (python3 is guaranteed by FCoS install-python.service) after the unit
+ * has started. The script gets the wizard's variables as env vars and
+ * can either talk to the now-running container directly (e.g. POST to
+ * the service's /init endpoint on its host port) or call ServiceBay's
+ * own admin endpoints.
+ *
+ * It can emit:
+ *   - regular stdout lines → relayed to the install log as-is
+ *   - lines beginning with `__SB_CREDENTIAL__ ` followed by JSON →
+ *     parsed by the wizard and added to the SAVE-THESE-NOW banner +
+ *     Bitwarden CSV export
+ *
+ * Returns the script content (un-rendered, mustache placeholders intact)
+ * or null if the template ships no post-deploy script.
+ */
+export async function getTemplatePostDeployScript(name: string, source?: string): Promise<string | null> {
+  const tryRead = async (dir: string): Promise<string | null> => {
+    try {
+      return await fs.readFile(path.join(dir, 'post-deploy.py'), 'utf-8');
+    } catch { return null; }
+  };
+
+  if (source && source !== 'Built-in') {
+    return tryRead(path.join(REGISTRIES_DIR, source, 'templates', name));
+  }
+
+  if (!source) {
+    const config = await getConfig();
+    const registries = getRegistries(config);
+    for (const reg of registries) {
+      const found = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'templates', name));
+      if (found !== null) return found;
+    }
+  }
+
+  return tryRead(path.join(TEMPLATES_PATH, name));
+}

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -566,7 +566,97 @@ export class ServiceManager {
         }
     }
 
-    static async deployKubeService(nodeName: string, name: string, kubeContent: string, yamlContent: string, yamlName: string, extraFiles?: { path: string; content: string }[], onProgress?: (message: string) => void) {
+    /**
+     * Run a template's post-deploy.py on the agent host. Writes the script
+     * to a stable per-template path (so reruns overwrite cleanly), exports
+     * the wizard's variables as env vars + SB_NODE, then `python3` it. The
+     * script's stdout is collected and replayed line-by-line through
+     * `onProgress` so it interleaves with the rest of the install log.
+     *
+     * Failures are non-fatal: a misbehaving post-deploy script doesn't roll
+     * back the service deploy. We log a warning + a "post-deploy exit N"
+     * line and continue. Restart-loop / config-broken issues will surface
+     * via the diagnose probe instead.
+     */
+    private static async runPostDeployScript(
+        nodeName: string,
+        name: string,
+        scriptContent: string,
+        env: Record<string, string>,
+        onProgress?: (message: string) => void,
+    ): Promise<void> {
+        const agent = await agentManager.ensureAgent(nodeName);
+        const scriptDir = `~/.local/share/servicebay/post-deploy`;
+        const scriptPath = `${scriptDir}/${name}.py`;
+        try {
+            await agent.sendCommand('exec', { command: `mkdir -p ${scriptDir}` });
+        } catch (e) {
+            logger.warn('ServiceManager', `Could not prepare post-deploy dir for ${name}:`, e);
+            onProgress?.(`⚠️ ${name} post-deploy: could not prepare script dir, skipping.`);
+            return;
+        }
+        const writeRes = await agent.sendCommand('write_file', { path: scriptPath, content: scriptContent });
+        if (writeRes !== 'ok') {
+            logger.warn('ServiceManager', `Could not write post-deploy script for ${name}:`, writeRes);
+            onProgress?.(`⚠️ ${name} post-deploy: write_file returned ${JSON.stringify(writeRes)}, skipping.`);
+            return;
+        }
+
+        // Build a sourceable env file alongside the script so we don't have
+        // to worry about quoting every value through the shell. `set -a` +
+        // `source` exports each line to the python child. The ServiceBay
+        // node identity is added so scripts can self-identify in multi-node
+        // installs.
+        const envLines = [
+            `SB_NODE=${nodeName}`,
+            ...Object.entries(env).map(([k, v]) => {
+                // Only export string-shaped values; skip empty entries the
+                // wizard sometimes carries for variables the user hasn't
+                // resolved yet (the deploy step's strict-render check
+                // catches the cases where empty values would actually
+                // matter).
+                if (typeof v !== 'string') return null;
+                // Single-quote escape for bash `source`: replace ' with '\''
+                const esc = v.replace(/'/g, `'\\''`);
+                return `${k}='${esc}'`;
+            }).filter((l): l is string => l !== null),
+        ].join('\n');
+        const envPath = `${scriptDir}/${name}.env`;
+        const envWrite = await agent.sendCommand('write_file', { path: envPath, content: envLines + '\n' });
+        if (envWrite !== 'ok') {
+            logger.warn('ServiceManager', `Could not write post-deploy env for ${name}:`, envWrite);
+            onProgress?.(`⚠️ ${name} post-deploy: env file write failed, skipping.`);
+            return;
+        }
+
+        onProgress?.(`Running ${name} post-deploy script...`);
+        // Long timeout — scripts wait for HTTP services that can take a
+        // minute or two to come up after image pull. Keep below the
+        // wizard's overall settle window.
+        const result = await agent.sendCommand('exec', {
+            command: `set -a; source '${envPath}'; set +a; python3 '${scriptPath}' 2>&1`,
+            timeout: 300,
+        });
+        const stdout = (result.stdout || '').replace(/\r/g, '');
+        for (const line of stdout.split('\n')) {
+            if (line.length > 0) onProgress?.(line);
+        }
+        if (result.code !== 0) {
+            onProgress?.(`⚠️ ${name} post-deploy exited ${result.code}. Service is deployed; the seed step did not finish — check the log lines above for the cause.`);
+        }
+    }
+
+    static async deployKubeService(
+        nodeName: string,
+        name: string,
+        kubeContent: string,
+        yamlContent: string,
+        yamlName: string,
+        extraFiles?: { path: string; content: string }[],
+        onProgress?: (message: string) => void,
+        postDeployScript?: string,
+        postDeployEnv?: Record<string, string>,
+    ) {
         // Migrate any pre-rename predecessor units first so their host-port
         // ownership is released before the port-collision pre-flight runs.
         await ServiceManager.migratePredecessors(nodeName, name, onProgress);
@@ -713,6 +803,18 @@ export class ServiceManager {
         } catch(e) {
              logger.warn('ServiceManager', `Service ${name} deployed but start failed:`, e);
         }
+
+        // Run the template's post-deploy.py if it shipped one. Convention:
+        // see lib/registry.ts:getTemplatePostDeployScript for the protocol.
+        // The script can talk to the now-running container directly (e.g.
+        // POST to its /init on the host port) or call ServiceBay's own
+        // admin endpoints. Stdout streams to onProgress; lines starting with
+        // `__SB_CREDENTIAL__ ` are the structured credential markers the
+        // wizard parses for the SAVE-THESE-NOW banner.
+        if (postDeployScript) {
+            await this.runPostDeployScript(nodeName, name, postDeployScript, postDeployEnv ?? {}, onProgress);
+        }
+
         this.backupQuadlets(nodeName);
 
         // Create health check for the new service if one doesn't exist

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -536,6 +536,26 @@ interface RunPostInstallOpts {
   variables: StackVariable[];
   node?: string;
   onLog: (msg: string) => void;
+  /**
+   * Templates whose post-deploy.py already handled credential logging +
+   * admin seeding. Hardcoded helpers below check this set and skip per-
+   * template work that the script already did, so we don't double-emit
+   * credentials or re-call admin-init endpoints.
+   *
+   * Phase 1 — only `media` migrates. Other templates' hardcoded paths
+   * still run as before. As more templates ship post-deploy.py the
+   * branches in this function will shrink.
+   */
+  skipDefaults?: Set<string>;
+  /**
+   * Credentials parsed from `__SB_CREDENTIAL__` markers a template's
+   * post-deploy.py emitted on stdout. Appended to the SAVE-THESE-NOW
+   * banner alongside the hardcoded entries.
+   */
+  // Re-using the Credential shape from credentialsManifest without an
+  // import cycle — the entries already conform.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  extraCredentials?: any[];
 }
 
 /** Orchestrate every post-install step. Returns the proxy-route status so
@@ -547,28 +567,30 @@ interface RunPostInstallOpts {
  *  LLDAP cold-start (up to 10 minutes). Seed logs interleave with proxy
  *  logs in the install panel — both streams are independent. */
 export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyResult> {
-  const { selected, variables, node, onLog } = opts;
+  const { selected, variables, node, onLog, skipDefaults, extraCredentials } = opts;
   const isSelected = (name: string) => selected.some(i => i.name === name);
+  const handled = (name: string): boolean => skipDefaults?.has(name) ?? false;
 
   // Surface credentials immediately — independent of any wait.
   // LLDAP + Authelia live in the merged 'auth' stack now; whenever the auth
   // stack is selected, both run together.
-  if (isSelected('auth')) {
+  if (isSelected('auth') && !handled('auth')) {
     await persistLldapCredentials({ variables, onLog });
   }
-  if (isSelected('adguard')) {
+  if (isSelected('adguard') && !handled('adguard')) {
     logAdguardCredentials({ variables, onLog });
   }
   // Audiobookshelf + Navidrome live in the merged 'media' stack now.
-  if (isSelected('media')) {
+  if (isSelected('media') && !handled('media')) {
     logAudiobookshelfCredentials({ variables, onLog });
     logNavidromeCredentials({ variables, onLog });
   }
-  if (isSelected('file-share')) {
+  if (isSelected('file-share') && !handled('file-share')) {
     logFileShareCredentials({ variables, onLog });
   }
   // Surface OIDC client secrets (one log line per service that needs UI
-  // configuration or has an env-flag to flip).
+  // configuration or has an env-flag to flip). Driven by variables[].meta
+  // so it stays template-driven regardless of skipDefaults.
   logOidcClientSecrets({ selected, variables, onLog });
   // NPM bootstrap is best-effort: if it fails we still want to run the rest
   // of the post-install pipeline (LLDAP seeding, OIDC client creation, proxy
@@ -587,15 +609,15 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   // Kick off all "wait + initialize" tasks in the background. Their logs
   // interleave with the proxy step's, but the proxy result returns ASAP
   // so the NPM credentials prompt (if needed) appears responsive.
-  if (isSelected('auth')) {
+  if (isSelected('auth') && !handled('auth')) {
     void seedLldap({ variables, onLog }).catch(() => { /* logged inline */ });
   }
-  if (isSelected('media')) {
+  if (isSelected('media') && !handled('media')) {
     void seedAudiobookshelf({ variables, onLog }).catch(() => { /* logged inline */ });
     void seedNavidrome({ variables, onLog }).catch(() => { /* logged inline */ });
   }
   // FileBrowser is now part of the file-share stack (alongside syncthing + samba).
-  if (isSelected('file-share')) {
+  if (isSelected('file-share') && !handled('file-share')) {
     void seedFileBrowserAdmin({ variables, node, onLog }).catch(() => { /* logged inline */ });
   }
 
@@ -612,8 +634,13 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   // Final banner — single block where every credential the user might
   // have to remember is collected. Same data is exposed to the wizard's
   // Done view + a Bitwarden CSV download via buildCredentialsManifest().
+  // Per-template post-deploy.py output is appended to whatever the
+  // hardcoded helpers produced for templates that haven't migrated yet.
   const host = typeof window !== 'undefined' ? window.location.hostname : '';
-  const manifest = buildCredentialsManifest({ selected, variables, host });
+  const manifest = [
+    ...buildCredentialsManifest({ selected, variables, host }),
+    ...(extraCredentials ?? []),
+  ];
   formatCredentialsBanner(manifest).forEach(onLog);
 
   return proxyResult;

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `media` stack (Audiobookshelf + Navidrome).
+
+Convention (see lib/registry.ts:getTemplatePostDeployScript):
+  - Runs on the agent host after `systemctl --user start media.service`
+    succeeds.
+  - All wizard variables are exported as env vars (`os.environ['ABS_PORT']`
+    etc.). `SB_NODE` is the node name. `HOST` is the operator's browsing
+    hostname (set by the wizard from window.location).
+  - stdout is relayed to the install log line by line.
+  - Lines starting with `__SB_CREDENTIAL__ ` followed by JSON go into the
+    SAVE-THESE-NOW banner / Bitwarden export — emit one per service.
+  - Non-zero exit logs a warning but doesn't roll back the deploy.
+
+What this replaces (was hardcoded in src/lib/stackInstall/postInstall.ts
+under `if (isSelected('media'))`):
+  - logAudiobookshelfCredentials  → `__SB_CREDENTIAL__` for ABS
+  - logNavidromeCredentials       → `__SB_CREDENTIAL__` for Navidrome
+  - seedAudiobookshelf            → POST localhost:<port>/init via the
+                                    /api/system/media/init proxy endpoint
+  - seedNavidrome                 → same, with service=navidrome
+
+We keep using the existing /api/system/media/init endpoint rather than
+talking to ABS / Navidrome directly because that endpoint already
+encapsulates the right retry budget, idempotency check, and "first-run
+already done" handling. The script just supplies the inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def env(key: str, default: str = "") -> str:
+    """Fetch an env var, falling back to a default. Empty string means missing."""
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def emit_credential(**fields: object) -> None:
+    """Print a single SAVE-THESE-NOW banner entry. The wizard parses this."""
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
+    """POST JSON, return (status, parsed-body-or-None)."""
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(data) if data else None
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, None
+
+
+def seed_media(service_label: str, service_payload_name: str, port_var: str, default_port: str,
+               user_var: str, default_user: str, password_var: str) -> None:
+    """
+    Wait for the media service to come up, then POST to ServiceBay's media-init
+    proxy endpoint. The endpoint itself retries against the upstream service
+    while the image is still pulling, so we just wrap it with a sensible
+    overall budget here. Idempotent: re-calls report `alreadySetup`.
+    """
+    user = env(user_var, default_user)
+    password = env(password_var)
+    port = env(port_var, default_port)
+    if not password:
+        log(f"⚠️ {service_label}: no admin password in env ({password_var}), skipping seed.")
+        return
+
+    sb_api = env("SB_API_URL", "http://localhost:3000")
+    init_url = f"{sb_api}/api/system/media/init"
+
+    log(f"Waiting for {service_label} to start...")
+    started = time.time()
+    last_beat = 0.0
+    deadline = 5 * 60  # 5 min — same budget the old hardcoded helper used
+    while time.time() - started < deadline:
+        status, body = post_json(init_url, {
+            "service": service_payload_name,
+            "host": "localhost",
+            "port": int(port),
+            "username": user,
+            "password": password,
+        }, timeout=15)
+        if status == 200 and body and body.get("ok"):
+            if body.get("alreadySetup"):
+                log(f"ℹ️ {service_label} already initialized — keeping existing admin. Reset manually if the password doesn't match.")
+            else:
+                log(f"✅ {service_label} root user '{user}' created.")
+            return
+        elapsed = time.time() - started
+        if elapsed - last_beat >= 10:
+            log(f"Still waiting for {service_label} ({int(elapsed)}s elapsed)...")
+            last_beat = elapsed
+        time.sleep(5)
+
+    log(f"⚠️ {service_label} did not become reachable in 5 minutes. Open http://<server-ip>:{port} and create the admin user manually.")
+
+
+def main() -> int:
+    host = env("HOST", "<server-ip>")
+
+    # ── Audiobookshelf ──────────────────────────────────────────────────
+    abs_user = env("ABS_ADMIN_USER", "root")
+    abs_password = env("ABS_ADMIN_PASSWORD")
+    abs_port = env("ABS_PORT", "13378")
+    if abs_password:
+        log(f"🔑 Audiobookshelf admin (user: {abs_user}, password: {abs_password}) — open http://{host}:{abs_port}. Note now, only shown once.")
+        emit_credential(
+            service="Audiobookshelf",
+            url=f"http://{host}:{abs_port}",
+            username=abs_user,
+            password=abs_password,
+            importance="critical",
+            notes="Library manager. Mobile apps use this credential too.",
+        )
+
+    # ── Navidrome ───────────────────────────────────────────────────────
+    nd_user = env("NAVIDROME_ADMIN_USER", "admin")
+    nd_password = env("NAVIDROME_ADMIN_PASSWORD")
+    nd_port = env("NAVIDROME_PORT", "4533")
+    if nd_password:
+        log(f"🔑 Navidrome admin (user: {nd_user}, password: {nd_password}) — open http://{host}:{nd_port}. Subsonic clients (Symfonium etc.) use the same credentials.")
+        emit_credential(
+            service="Navidrome",
+            url=f"http://{host}:{nd_port}",
+            username=nd_user,
+            password=nd_password,
+            importance="critical",
+            notes="Music server. Symfonium / Subsonic clients use this too.",
+        )
+
+    # ── Audiobookshelf admin seed ──────────────────────────────────────
+    seed_media(
+        service_label="Audiobookshelf",
+        service_payload_name="audiobookshelf",
+        port_var="ABS_PORT",
+        default_port="13378",
+        user_var="ABS_ADMIN_USER",
+        default_user="root",
+        password_var="ABS_ADMIN_PASSWORD",
+    )
+
+    # ── Navidrome admin seed ───────────────────────────────────────────
+    seed_media(
+        service_label="Navidrome",
+        service_payload_name="navidrome",
+        port_var="NAVIDROME_PORT",
+        default_port="4533",
+        user_var="NAVIDROME_ADMIN_USER",
+        default_user="admin",
+        password_var="NAVIDROME_ADMIN_PASSWORD",
+    )
+
+    # ── ABS OIDC client_secret (system credential, pasted into ABS UI) ──
+    abs_oidc_secret = env("ABS_OIDC_SECRET")
+    public_domain = env("PUBLIC_DOMAIN")
+    if abs_oidc_secret:
+        url = f"https://auth.{public_domain}" if public_domain else "auth.<domain>"
+        log(f"🔐 Audiobookshelf OIDC: issuer={url}, client_id=audiobookshelf, client_secret={abs_oidc_secret} — paste into ABS Settings → Authentication → OIDC.")
+        emit_credential(
+            service="Audiobookshelf OIDC client_secret",
+            url=url,
+            username="audiobookshelf",
+            password=abs_oidc_secret,
+            importance="system",
+            notes="Paste into ABS Settings → Authentication → OIDC client_secret to enable SSO.",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -548,3 +548,36 @@ describe('OIDC client_id single source of truth', () => {
     }
   });
 });
+
+// ─── 9. post-deploy.py scripts parse as valid Python ───────────────────────
+describe('Template post-deploy.py syntax', () => {
+  // The wizard executes templates/<name>/post-deploy.py on the agent host
+  // after a successful deploy. A syntax error there would silently break
+  // the seed / credential-banner step at install time. Catch them at
+  // PR-time via `python3 -m py_compile`. Skipped if python3 isn't on the
+  // CI runner (rare but possible in some docker-only setups).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { execSync } = require('child_process') as typeof import('child_process');
+  let pythonAvailable = true;
+  try {
+    execSync('python3 --version', { stdio: 'ignore' });
+  } catch {
+    pythonAvailable = false;
+  }
+
+  for (const t of templates) {
+    const script = path.join(TEMPLATES_DIR, t.name, 'post-deploy.py');
+    if (!fs.existsSync(script)) continue;
+    const testFn = pythonAvailable ? it : it.skip;
+    testFn(`${t.name}/post-deploy.py is syntactically valid Python`, () => {
+      try {
+        execSync(`python3 -m py_compile ${JSON.stringify(script)}`, { stdio: 'pipe' });
+      } catch (e) {
+        const msg = e instanceof Error && 'stderr' in e
+          ? String((e as { stderr: Buffer }).stderr)
+          : String(e);
+        throw new Error(`${t.name}/post-deploy.py has a Python syntax error:\n${msg}`);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What

Templates can now ship a \`post-deploy.py\` next to \`template.yml\`. The wizard runs it on the agent host after the unit starts; stdout streams to the install log; lines beginning with \`__SB_CREDENTIAL__ \` followed by JSON land in the SAVE-THESE-NOW banner / Bitwarden CSV export.

Adding a new service no longer needs:

- \`isSelected('X')\` branches in \`postInstall.ts\` and \`credentialsManifest.ts\`
- bespoke \`seedX\` / \`logXCredentials\` helpers
- a per-service \`/api/system/<X>/init\` endpoint (templates can call existing endpoints or talk to the container directly via stdlib \`urllib\`)

## How

\`\`\`
templates/<name>/
  template.yml
  variables.json
  post-deploy.py    ← new, optional
\`\`\`

**Engine** (\`lib/registry.ts\` + \`lib/services/ServiceManager.ts\`):
- \`getTemplatePostDeployScript(name, source)\` — reads the file (returns null if absent)
- \`deployKubeService\` accepts \`postDeployScript\` + \`postDeployEnv\`. After a successful start: writes the (already-mustache-rendered) script + an env file under \`~/.local/share/servicebay/post-deploy/<name>.{py,env}\`, then runs \`set -a; source <env>; set +a; python3 <script>\` via the agent. Output streams back through \`onProgress\` line by line.
- Non-zero exit logs a warning, doesn't roll back the deploy.

**Wizard** (\`OnboardingWizard.tsx\`):
- Fetches the script per item, mustache-renders against the wizard's view, ships it in the deploy POST.
- Tracks \`templatesWithScript: Set<string>\`.
- Parses \`__SB_CREDENTIAL__\` markers from streamed log lines into a parallel \`scriptCredentials\` array.

**runPostInstall** gains:
- \`skipDefaults: Set<string>\` — hardcoded helpers (\`logXCredentials\`, \`seedX\`, etc.) skip a stack when its \`post-deploy.py\` handled it.
- \`extraCredentials: Credential[]\` — appended to the SAVE-THESE-NOW manifest.

## Migration — phase 1 only

\`templates/media/post-deploy.py\` replaces \`logAudiobookshelfCredentials\`, \`logNavidromeCredentials\`, \`seedAudiobookshelf\`, \`seedNavidrome\`, and the Audiobookshelf OIDC log/credential entry.

Hardcoded helpers in \`postInstall.ts\` stay in place — they're skipped only when \`skipDefaults\` includes the stack name. \`InstallerModal\` doesn't pass \`skipDefaults\` yet, so it continues using the hardcoded path. Phase 2 will migrate the remaining built-ins one PR at a time and drop the hardcoded helpers as each adopts a script.

## New consistency rule

Rule #9 in \`tests/backend/template_consistency.test.ts\`: every \`post-deploy.py\` must pass \`python3 -m py_compile\`. Catches syntax errors at PR-time instead of at install time. Skipped on runners without python3.

## Test plan

- [x] \`npm test\` — 322 pass, 1 skipped
- [x] \`npm run lint\` clean
- [x] \`next build --webpack\` clean
- [x] Pre-commit \`py_compile\` hook accepts the new \`templates/media/post-deploy.py\`
- [ ] Live: install the \`media\` stack on a fresh box. Install log should show:
  - \`Running media post-deploy script...\`
  - \`🔑 Audiobookshelf admin (user: root, password: …)\` from the script
  - \`🔑 Navidrome admin (user: admin, password: …)\` from the script
  - \`Waiting for Audiobookshelf to start...\` heartbeats
  - \`✅ Audiobookshelf root user 'root' created.\`
  - \`✅ Navidrome root user 'admin' created.\`
  - \`🔐 Audiobookshelf OIDC: …\` if domain is set
  - The hardcoded helpers in \`postInstall.ts\` should NOT also fire (no duplicate log lines / duplicate credential banner entries)

## Out of scope (intentionally)

- MCP \`deploy_service\` doesn't accept \`postDeployScript\` yet — agent-driven flows still use the hardcoded helpers via \`runPostInstall\`. Adding it is straightforward; deferring to a follow-up so this PR stays focused.
- Phase 2 migrations (auth / file-share / nginx-web / adguard / vaultwarden / immich / home-assistant / radicale) — separate PRs, tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)