### PR TITLE
feat(templates): post-deploy.py for file-share + adguard (phase 2 / part 1)

### DIFF
--- a/templates/adguard/post-deploy.py
+++ b/templates/adguard/post-deploy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `adguard` stack.
+
+What this replaces (was hardcoded in src/lib/stackInstall/postInstall.ts):
+  - logAdguardCredentials  → `__SB_CREDENTIAL__` for AdGuard admin
+
+AdGuard's first-start config is pre-seeded by the wizard's mustache step
+(AdGuardHome.yaml.mustache lives in this directory). The bcrypt password
+hash is computed server-side via /api/system/keys/bcrypt and baked into
+that config. So this script has nothing to seed — it just surfaces the
+credential the operator needs for their first login.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    host = env("HOST", "<server-ip>")
+    user = env("ADGUARD_ADMIN_USER", "admin")
+    password = env("ADGUARD_ADMIN_PASSWORD")
+    port = env("ADGUARD_ADMIN_PORT", "8083")
+
+    if not password:
+        log("⚠️ ADGUARD_ADMIN_PASSWORD missing — first-login won't work; reset via the AdGuard Home setup wizard at http://<server-ip>:" + port)
+        return 0
+
+    log(f"🔑 AdGuard admin (user: {user}, password: {password}) — open http://{host}:{port}. Note now, only shown once.")
+    emit_credential(
+        service="AdGuard Home",
+        url=f"http://{host}:{port}",
+        username=user,
+        password=password,
+        importance="critical",
+        notes="DNS console. Add custom rewrites + manage blocklists.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `file-share` stack (Syncthing + Samba + FileBrowser).
+
+What this replaces (was hardcoded in src/lib/stackInstall/postInstall.ts):
+  - logFileShareCredentials       → `__SB_CREDENTIAL__` for Samba
+  - seedFileBrowserAdmin          → /api/system/filebrowser/init via SB_API_URL
+
+Notes:
+  - Syncthing emits its own GUI URL on the host port; nothing to seed there
+    (device pairing is interactive). We just include a credential entry so
+    the operator knows where the GUI lives.
+  - FileBrowser proxy-auth mode auto-creates a non-admin user record on the
+    first SSO request. The init endpoint pre-promotes a chosen LLDAP user
+    to FB admin so there's a working admin from the first login.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(data) if data else None
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, None
+
+
+def main() -> int:
+    host = env("HOST", "<server-ip>")
+
+    # ── Samba ──────────────────────────────────────────────────────────
+    share_user = env("SHARE_USER", "samba")
+    share_password = env("SHARE_PASSWORD")
+    if share_password:
+        log(f"🔑 Samba share (user: {share_user}, password: {share_password}) — mount via \\\\{host}\\data on Windows or smb://{host}/data on macOS. Note now, only shown once.")
+        emit_credential(
+            service="Samba (file-share)",
+            url=f"\\\\{host}\\data",
+            username=share_user,
+            password=share_password,
+            importance="critical",
+            notes="Windows network drive. Type once per PC when mounting.",
+        )
+
+    # ── FileBrowser admin pre-promotion ────────────────────────────────
+    # Proxy-auth: FB auto-creates accounts on first SSO request, but they
+    # default to non-admin. Pre-promote one LLDAP user (default `admin`)
+    # to FB admin via the existing init endpoint, which exec's into the
+    # running container. Idempotent — repeat calls upgrade-permission
+    # rather than recreate.
+    fb_user = env("FILEBROWSER_ADMIN_USER", "admin")
+    sb_api = env("SB_API_URL", "http://localhost:3000")
+    init_url = f"{sb_api}/api/system/filebrowser/init"
+
+    # Brief grace period for the pod to come up before the first exec.
+    time.sleep(8)
+    deadline = time.time() + 3 * 60  # 3 min total budget — covers slow pulls
+    last_beat = 0.0
+    started = time.time()
+    seeded = False
+    while time.time() < deadline:
+        status, body = post_json(init_url, {"username": fb_user, "node": env("SB_NODE", "Local")}, timeout=15)
+        if status == 200 and body and body.get("ok"):
+            action = body.get("action", "ready")
+            log(f"✅ FileBrowser admin: {fb_user} ({action}) — log in via Authelia at https://files.<your-domain> to manage shares.")
+            seeded = True
+            break
+        elapsed = time.time() - started
+        if elapsed - last_beat >= 30:
+            log(f"Still waiting for FileBrowser to accept the admin seed ({int(elapsed)}s elapsed)...")
+            last_beat = elapsed
+        time.sleep(5)
+    if not seeded:
+        log("⚠️ Could not pre-seed FileBrowser admin after 3 minutes. Run `podman exec file-share-filebrowser filebrowser users add <user> _ --perm.admin --database /database/filebrowser.db` once the pod is up.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Phase 2 progress

Two more templates migrated to the per-template script model from PR #217.

### \`templates/file-share/post-deploy.py\`
Replaces:
- \`logFileShareCredentials\` → \`__SB_CREDENTIAL__\` for Samba
- \`seedFileBrowserAdmin\` → POST \`/api/system/filebrowser/init\` with the same 3-min retry budget + 30-s heartbeats + idempotency handling the hardcoded helper used

### \`templates/adguard/post-deploy.py\`
Replaces:
- \`logAdguardCredentials\` → \`__SB_CREDENTIAL__\` for the admin portal

AdGuard's first-start config is pre-seeded by the wizard's \`AdGuardHome.yaml.mustache\` + bcrypt-hash flow already, so there's no admin seed call to make.

### Phase 2 plan

Deferred to separate PRs (or "no migration needed" — the engine doesn't require every template to ship a script):

| stack | hardcoded today | migrate? |
|---|---|---|
| auth | \`persistLldapCredentials\` + \`seedLldap\` + cross-template Authelia OIDC client reg | yes — separate PR (most complex) |
| nginx-web | \`bootstrapNpmAdmin\` + cross-template proxy-route aggregation | partial — script for credentials, cross-template proxy aggregation stays in engine |
| immich | OIDC entry only (already template-driven via \`variables[].meta.oidcClient\`) | no script needed |
| vaultwarden | OIDC entry + special SSO-enabled note | maybe — if we want the SSO note out of postInstall.ts |
| radicale | nothing to seed | no script needed |
| home-assistant | nothing to seed | no script needed |

Hardcoded helpers in \`postInstall.ts\` stay in place — they only fire when the script didn't (\`skipDefaults\` from PR #217). InstallerModal-driven installs and unmigrated stacks keep working unchanged.

## Test plan

- [x] \`npm test\` — 324 pass (was 322; +2 from py_compile coverage on the two new scripts)
- [x] \`npm run lint\` clean
- [x] Pre-commit \`py_compile\` accepts both scripts
- [ ] Live: install \`file-share\` + \`adguard\` on a fresh box. Install log should show:
  - \`Running file-share post-deploy script...\` then \`🔑 Samba share (...)\` then FileBrowser admin retry heartbeats
  - \`Running adguard post-deploy script...\` then \`🔑 AdGuard admin (...)\`
  - No duplicate credential lines from the hardcoded helpers (skipDefaults working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)