### PR TITLE
feat(templates): post-deploy.py for auth + nginx-web (phase 2 / part 2)

### DIFF
--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -36,14 +36,20 @@ interface BuildOpts {
    *  reachable URLs in the manifest. Empty string falls back to the
    *  `<server-ip>` placeholder. */
   host?: string;
+  /** Templates whose post-deploy.py emitted their own credential markers.
+   *  This builder skips its hardcoded branches for those stacks so the
+   *  SAVE-THESE-NOW banner doesn't double-list the same entry once from
+   *  the script (via `__SB_CREDENTIAL__`) and once from here. */
+  skipDefaults?: Set<string>;
 }
 
 const get = (vars: StackVariable[], name: string): string | undefined =>
   vars.find(v => v.name === name)?.value;
 
 export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
-  const { variables: v } = opts;
-  const isSelected = (n: string) => opts.selected.some(i => i.name === n);
+  const { variables: v, skipDefaults } = opts;
+  const handled = (n: string): boolean => skipDefaults?.has(n) ?? false;
+  const isSelected = (n: string) => opts.selected.some(i => i.name === n) && !handled(n);
   const host = opts.host || '<server-ip>';
   const out: Credential[] = [];
 

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -638,7 +638,7 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   // hardcoded helpers produced for templates that haven't migrated yet.
   const host = typeof window !== 'undefined' ? window.location.hostname : '';
   const manifest = [
-    ...buildCredentialsManifest({ selected, variables, host }),
+    ...buildCredentialsManifest({ selected, variables, host, skipDefaults }),
     ...(extraCredentials ?? []),
   ];
   formatCredentialsBanner(manifest).forEach(onLog);

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `auth` stack (LLDAP + Authelia in one pod).
+
+What this replaces (was hardcoded in src/lib/stackInstall/postInstall.ts):
+  - persistLldapCredentials  → POST /api/system/lldap/credentials so the
+                                admin login surfaces in
+                                Settings → Integrations after install.
+  - seedLldap                → POST /api/system/lldap/seed to create the
+                                `admins` + `family` groups every other
+                                template's access_control rules expect.
+  - LLDAP credential entry    → __SB_CREDENTIAL__ for the directory portal.
+  - Authelia OIDC RS256 key   → emitted as a system credential for DR.
+  - LLDAP JWT secret          → emitted as a system credential for DR.
+
+What stays in the engine (genuinely cross-template):
+  - Authelia OIDC client registration walks variables[].meta.oidcClient
+    across ALL deployed templates and POSTs once to
+    /api/system/authelia/oidc-clients. That can't easily live in a single
+    template's script.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(data) if data else None
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, None
+
+
+def wait_for_lldap(port: str, deadline_sec: int) -> bool:
+    """LLDAP cold-start is fast (<30s) but image pull can stretch this to a few min.
+    Probe via ServiceBay's reachability endpoint so the wait + heartbeat
+    behaves identically to the old hardcoded waitForLldap helper."""
+    sb_api = env("SB_API_URL", "http://localhost:3000")
+    started = time.time()
+    last_beat = 0.0
+    while time.time() - started < deadline_sec:
+        status, body = post_json(
+            f"{sb_api}/api/system/lldap/probe",
+            {"host": "localhost", "port": int(port)},
+            timeout=10,
+        )
+        if status == 200 and body and body.get("reachable"):
+            return True
+        elapsed = time.time() - started
+        if elapsed - last_beat >= 10:
+            log(f"Still waiting for LLDAP ({int(elapsed)}s elapsed)...")
+            last_beat = elapsed
+        time.sleep(3)
+    return False
+
+
+def main() -> int:
+    host = env("HOST", "<server-ip>")
+    sb_api = env("SB_API_URL", "http://localhost:3000")
+    public_domain = env("PUBLIC_DOMAIN")
+
+    lldap_password = env("LLDAP_ADMIN_PASSWORD")
+    lldap_port = env("LLDAP_PORT", "17170")
+    if not lldap_password:
+        log("⚠️ LLDAP_ADMIN_PASSWORD missing — skipping persist + seed steps.")
+        return 0
+
+    # ── Persist LLDAP credentials in ServiceBay's settings store ─────────
+    # Surfaces the password in Settings → Integrations → LLDAP for later
+    # reference. Best-effort: a 4xx here doesn't block the install, the
+    # operator just notes the password from the credential banner below.
+    persist_status, _ = post_json(
+        f"{sb_api}/api/system/lldap/credentials",
+        {"url": f"http://localhost:{lldap_port}", "username": "admin", "password": lldap_password},
+        timeout=10,
+    )
+    if persist_status == 200:
+        log(f"🔑 LLDAP admin (user: admin, password: {lldap_password}) — open http://{host}:{lldap_port} or via NPM. Stored in Settings → Integrations.")
+    else:
+        log(f"⚠️ Could not persist LLDAP credentials (HTTP {persist_status}). Note now: admin / {lldap_password}")
+
+    emit_credential(
+        service="LLDAP (User Directory)",
+        url=f"http://{host}:{lldap_port}",
+        username="admin",
+        password=lldap_password,
+        importance="critical",
+        notes="Manage users + groups here. Required to add family members.",
+    )
+
+    # ── LLDAP JWT secret — system credential for DR ──────────────────────
+    jwt_secret = env("LLDAP_JWT_SECRET")
+    if jwt_secret:
+        emit_credential(
+            service="LLDAP JWT secret",
+            url="env: LLDAP_JWT_SECRET",
+            username="—",
+            password=jwt_secret,
+            importance="system",
+            notes="Signs LLDAP user sessions. Save for disaster recovery — without it old browser cookies become invalid after a restore.",
+        )
+
+    # ── Wait for LLDAP, seed `admins` + `family` groups ──────────────────
+    log("Waiting for LLDAP to start (cold-start usually < 30s)...")
+    if not wait_for_lldap(lldap_port, deadline_sec=10 * 60):
+        log(f"⚠️ LLDAP did not respond in time. Open http://{host}:{lldap_port} as admin and create groups admins+family manually.")
+        return 0
+
+    log("Seeding LLDAP groups...")
+    seed_status, seed_body = post_json(
+        f"{sb_api}/api/system/lldap/seed",
+        {"host": "localhost", "port": int(lldap_port), "password": lldap_password},
+        timeout=15,
+    )
+    if seed_status == 200 and seed_body:
+        created = seed_body.get("created") or []
+        existing = seed_body.get("existing") or []
+        failed = seed_body.get("failed") or []
+        if created:
+            log(f"✅ Groups created: {', '.join(str(x) for x in created)}")
+        if existing:
+            log(f"ℹ️ Groups already exist: {', '.join(str(x) for x in existing)}")
+        if failed:
+            names = ", ".join(str(f.get("name", "?")) for f in failed)
+            log(f"⚠️ Failed: {names}")
+    else:
+        err = (seed_body or {}).get("error", f"HTTP {seed_status}")
+        log(f"⚠️ Could not seed LLDAP groups: {err}")
+
+    # ── Authelia portal URL — credential entry only (no admin user; auth
+    # via LLDAP) ─────────────────────────────────────────────────────────
+    if public_domain:
+        emit_credential(
+            service="Authelia (SSO portal)",
+            url=f"https://auth.{public_domain}",
+            username="(LLDAP-managed)",
+            password="(see LLDAP)",
+            importance="system",
+            notes="SSO portal in front of every protected service. Identities + groups come from LLDAP — no separate Authelia password.",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/nginx-web/post-deploy.py
+++ b/templates/nginx-web/post-deploy.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `nginx-web` stack (Nginx Proxy Manager).
+
+What this replaces (was hardcoded in src/lib/stackInstall/credentialsManifest.ts):
+  - NPM admin entry in the SAVE-THESE-NOW banner → __SB_CREDENTIAL__
+
+What stays in the engine (intentionally):
+  - bootstrapNpmAdmin in postInstall.ts handles NPM's special first-init
+    quirk (the image ships with admin@example.com/changeme as fallback;
+    INITIAL_ADMIN_EMAIL/PASSWORD env vars get applied a few seconds AFTER
+    the API reports up). The function returns a tri-state result that
+    drives a wizard-side credential-prompt UI when the auto-bootstrap
+    fails, which a script can't cleanly express. So the NPM bootstrap
+    + the cross-template proxy-route aggregation continue to live in
+    runPostInstall — this script only owns the banner entry.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    host = env("HOST", "<server-ip>")
+    admin_port = env("NGINX_ADMIN_PORT", "81")
+    email = env("NGINX_ADMIN_EMAIL", "admin@servicebay.local")
+    password = env("NGINX_ADMIN_PASSWORD")
+
+    if not password:
+        # No password generated — bootstrapNpmAdmin will skip too. Nothing
+        # to put in the credential banner.
+        return 0
+
+    emit_credential(
+        service="Nginx Proxy Manager",
+        url=f"http://{host}:{admin_port}",
+        username=email,
+        password=password,
+        importance="critical",
+        notes="Reverse-proxy admin. Needed for SSL cert renewal + access lists.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Migrates the last two stacks where the per-template script form pulls its weight.

### \`templates/auth/post-deploy.py\`
- \`persistLldapCredentials\` → POST \`/api/system/lldap/credentials\` so the admin login surfaces in Settings → Integrations
- \`seedLldap\` → wait for LLDAP HTTP via \`/api/system/lldap/probe\`, then POST \`/api/system/lldap/seed\` to create admins + family groups
- LLDAP admin → \`__SB_CREDENTIAL__\`
- LLDAP JWT secret → \`__SB_CREDENTIAL__\` (importance: system, for DR)
- Authelia portal → \`__SB_CREDENTIAL__\` (system, no separate password)

Authelia **OIDC client registration** stays in the engine — it walks \`variables[].meta.oidcClient\` across ALL deployed templates and POSTs once. Genuinely cross-template, can't fit in a single template's script.

### \`templates/nginx-web/post-deploy.py\`
- NPM admin → \`__SB_CREDENTIAL__\`

\`bootstrapNpmAdmin\` in \`postInstall.ts\` **stays put**. The hardcoded function returns a tri-state result that drives a wizard-side credential-prompt UI when auto-bootstrap fails — that handshake doesn't fit the script protocol. The cross-template proxy-route aggregation in \`configureProxyRoutes\` also stays.

### \`credentialsManifest.ts\` — \`skipDefaults\` plumbing

Without this the SAVE-THESE-NOW banner would double-list the same entry once from each script's \`__SB_CREDENTIAL__\` markers and once from the hardcoded builder. \`buildCredentialsManifest\` now accepts a \`Set<string>\` of stacks whose script handled its own credentials and omits those branches.

## Phase 2 status

| stack | hardcoded → script | done |
|---|---|---|
| media | logXCredentials (×2) + seedX (×2) + ABS OIDC | ✅ #217 |
| file-share | logFileShareCredentials + seedFileBrowserAdmin | ✅ #219 |
| adguard | logAdguardCredentials | ✅ #219 |
| auth | persistLldapCredentials + seedLldap | ✅ this PR |
| nginx-web | NPM admin credential entry | ✅ this PR (bootstrap stays in engine) |
| immich, vaultwarden, radicale, home-assistant | nothing custom today | ⏸ no script needed unless we want to add stack-specific behaviour |

## Phase 3 (future)

Drop the hardcoded helpers in \`postInstall.ts\` + \`credentialsManifest.ts\` now that scripts cover them. Defer until \`InstallerModal\` also passes \`skipDefaults\` (or we mark InstallerModal as a single-template legacy path that doesn't run scripts).

## Test plan

- [x] \`npm test\` — 326 pass
- [x] \`npm run lint\` clean
- [x] Pre-commit \`py_compile\` accepts both new scripts
- [ ] Live: install \`auth\` on a fresh box. Install log shows:
  - \`Running auth post-deploy script...\`
  - \`🔑 LLDAP admin (...)\` (from script, not duplicated by hardcoded)
  - \`Waiting for LLDAP to start...\` heartbeats
  - \`✅ Groups created: admins, family\`
- [ ] Live: \`nginx-web\` install — NPM admin entry appears once in the SAVE-THESE-NOW banner (no duplicate)
- [ ] Live: full-stack install — both scripts run interleaved with the still-hardcoded NPM bootstrap, no double-credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)