### PR TITLE
refactor: schema-validate Pod YAML at runtime input boundaries (closes #2)

### DIFF
--- a/src/app/api/services/[name]/route.ts
+++ b/src/app/api/services/[name]/route.ts
@@ -216,6 +216,21 @@ export async function PUT(request: Request, { params }: { params: Promise<{ name
       return NextResponse.json({ error: 'kubeContent and yamlContent are required' }, { status: 400 });
   }
 
+  // Validate the Pod manifest. Same call as POST /api/services — keeps
+  // bundle imports + Settings → Services edits honest about manifest shape.
+  const { validatePodManifest } = await import('@/lib/services/podSchema');
+  const validation = validatePodManifest(yamlContent);
+  if (!validation.ok) {
+      return NextResponse.json(
+          {
+              error: 'invalid Pod manifest',
+              path: validation.error?.path,
+              detail: validation.error?.message,
+          },
+          { status: 400 },
+      );
+  }
+
   await ServiceManager.saveService(nodeName, safeName, kubeContent, yamlContent, yamlFileName);
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -298,6 +298,22 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
   }
 
+  // Validate the Pod manifest before the agent write. Catches typoed
+  // apiVersion / missing spec.containers / cross-volume mismatches before
+  // they produce a permanently-failed unit nobody can debug from the UI.
+  const { validatePodManifest } = await import('@/lib/services/podSchema');
+  const validation = validatePodManifest(yamlContent);
+  if (!validation.ok) {
+    return NextResponse.json(
+      {
+        error: 'invalid Pod manifest',
+        path: validation.error?.path,
+        detail: validation.error?.message,
+      },
+      { status: 400 },
+    );
+  }
+
   // Streaming mode: return progress events as they happen
   if (searchParams.get('stream') === '1') {
     const encoder = new TextEncoder();

--- a/src/lib/services/podSchema.ts
+++ b/src/lib/services/podSchema.ts
@@ -1,0 +1,226 @@
+/**
+ * Runtime validation for Pod manifests submitted via the API.
+ *
+ * Two write paths feed `ServiceManager.deployKubeService` / `saveService`:
+ *   1. POST /api/services — wizard + InstallerModal + MCP deploy_service
+ *   2. PUT  /api/services/[name] — Settings → Services edit panel
+ *
+ * Until this module landed, both paths accepted whatever `yamlContent` the
+ * caller sent and called `js-yaml.loadAll` with `as any[]`. A typoed
+ * `apiVersion`, missing `spec.containers`, malformed `volumeMounts.name`,
+ * or a port with no `hostPort` outside a `hostNetwork` pod surfaces only
+ * when systemd reloads and `podman play kube` fails — at which point the
+ * operator gets a cryptic systemd-journal entry and no breadcrumb back to
+ * the API call that produced it.
+ *
+ * `validatePodManifest` parses the YAML, finds the Pod doc (templates may
+ * ship a Pod + PersistentVolumeClaim multi-doc since 3.6.4), validates a
+ * deliberately narrow subset of the K8s Pod spec we actually use, and
+ * returns either { ok: true } or a structured error pointing at the
+ * offending path. The two API routes call this before the agent write
+ * and 400 with the structured error if it fails.
+ *
+ * Scope:
+ *   - We don't try to chase the full upstream Kubernetes JSON schema.
+ *     `podman play kube` itself implements the long tail; we just want
+ *     to catch the things the operator can recover from in the wizard.
+ *   - The consistency suite (tests/backend/template_consistency.test.ts)
+ *     uses a similar shape at PR-time for shipped templates. This module
+ *     is the runtime equivalent for *user* input — bundle imports, manual
+ *     edits, MCP calls.
+ */
+
+import { z } from 'zod';
+import yaml from 'js-yaml';
+
+// DNS-1123 label rules: lowercase, digits, hyphens, must start + end with
+// alphanumeric, max 63 chars. systemd unit names follow the same shape via
+// our template generator, so this is what we use throughout.
+const DNS1123_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+const dns1123 = z
+    .string()
+    .min(1, 'must not be empty')
+    .max(63, 'must be at most 63 characters')
+    .regex(DNS1123_LABEL, 'must be a DNS-1123 label (lowercase alphanumeric + hyphens, start/end with alphanumeric)');
+
+const ContainerPortSchema = z.object({
+    containerPort: z.number().int().positive(),
+    hostPort: z.number().int().positive().optional(),
+    protocol: z.enum(['TCP', 'UDP']).optional(),
+    hostIp: z.string().optional(),
+}).passthrough();
+
+const VolumeMountSchema = z.object({
+    name: z.string().min(1, 'volumeMount.name is required'),
+    mountPath: z.string().startsWith('/', 'mountPath must be absolute'),
+    readOnly: z.boolean().optional(),
+    subPath: z.string().optional(),
+}).passthrough();
+
+const ContainerSchema = z.object({
+    name: dns1123,
+    image: z.string().min(1, 'container.image is required'),
+    command: z.array(z.string()).optional(),
+    args: z.array(z.string()).optional(),
+    env: z.array(z.object({
+        name: z.string().min(1),
+        value: z.string().optional(),
+    }).passthrough()).optional(),
+    ports: z.array(ContainerPortSchema).optional(),
+    volumeMounts: z.array(VolumeMountSchema).optional(),
+    securityContext: z.object({}).passthrough().optional(),
+}).passthrough();
+
+const HostPathVolumeSchema = z.object({
+    name: z.string().min(1),
+    hostPath: z.object({
+        path: z.string().startsWith('/', 'hostPath.path must be absolute'),
+        type: z.string().optional(),
+    }),
+}).passthrough();
+
+const PvcVolumeSchema = z.object({
+    name: z.string().min(1),
+    persistentVolumeClaim: z.object({
+        claimName: z.string().min(1),
+    }),
+}).passthrough();
+
+const EmptyDirVolumeSchema = z.object({
+    name: z.string().min(1),
+    emptyDir: z.object({}).passthrough(),
+}).passthrough();
+
+const VolumeSchema = z.union([HostPathVolumeSchema, PvcVolumeSchema, EmptyDirVolumeSchema]);
+
+const PodSchema = z.object({
+    apiVersion: z.literal('v1'),
+    kind: z.literal('Pod'),
+    metadata: z.object({
+        name: dns1123,
+        labels: z.record(z.string(), z.string()).optional(),
+        annotations: z.record(z.string(), z.string()).optional(),
+    }).passthrough(),
+    spec: z.object({
+        hostNetwork: z.boolean().optional(),
+        containers: z.array(ContainerSchema).min(1, 'spec.containers must contain at least one entry'),
+        initContainers: z.array(ContainerSchema).optional(),
+        volumes: z.array(VolumeSchema).optional(),
+    }).passthrough(),
+}).passthrough();
+
+const PvcSchema = z.object({
+    apiVersion: z.literal('v1'),
+    kind: z.literal('PersistentVolumeClaim'),
+    metadata: z.object({
+        name: dns1123,
+    }).passthrough(),
+}).passthrough();
+
+interface PodValidationError {
+    path: string;
+    message: string;
+}
+
+export interface PodValidationResult {
+    ok: boolean;
+    error?: PodValidationError;
+}
+
+/** Parse + validate a YAML Pod manifest. Multi-doc support: a Pod + PVC
+ *  bundle is normal (file-share since 3.6.4), the validator finds the Pod
+ *  by `kind` and validates the PVC alongside if present. */
+export function validatePodManifest(yamlContent: string): PodValidationResult {
+    if (typeof yamlContent !== 'string' || yamlContent.trim().length === 0) {
+        return { ok: false, error: { path: '$', message: 'yamlContent is empty' } };
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let docs: any[];
+    try {
+        docs = yaml.loadAll(yamlContent);
+    } catch (e) {
+        return { ok: false, error: { path: '$', message: `not valid YAML: ${e instanceof Error ? e.message : String(e)}` } };
+    }
+    if (docs.length === 0 || docs.every(d => !d)) {
+        return { ok: false, error: { path: '$', message: 'no documents found in YAML' } };
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pod = docs.find((d: any) => d?.kind === 'Pod');
+    if (!pod) {
+        return { ok: false, error: { path: 'kind', message: 'no kind=Pod document in YAML' } };
+    }
+
+    const podResult = PodSchema.safeParse(pod);
+    if (!podResult.success) {
+        const issue = podResult.error.issues[0];
+        return {
+            ok: false,
+            error: {
+                path: issue.path.length ? issue.path.join('.') : '$',
+                message: issue.message,
+            },
+        };
+    }
+
+    // Cross-reference: every volumeMount.name must match a declared volume.
+    // Catches the typo-class bug where the YAML parses cleanly but a mount
+    // points at a volume that doesn't exist (`podman play kube` would
+    // accept this in some versions, then the container starts with the
+    // expected mountPath empty).
+    const declared = new Set((podResult.data.spec.volumes ?? []).map(v => v.name));
+    const containers = [...podResult.data.spec.containers, ...(podResult.data.spec.initContainers ?? [])];
+    for (const c of containers) {
+        for (const vm of c.volumeMounts ?? []) {
+            if (!declared.has(vm.name)) {
+                return {
+                    ok: false,
+                    error: {
+                        path: `spec.containers[${c.name}].volumeMounts[${vm.name}]`,
+                        message: `references volume "${vm.name}" which is not declared in spec.volumes`,
+                    },
+                };
+            }
+        }
+    }
+
+    // Reachability: every container port either has hostPort, or the pod
+    // is hostNetwork. The same rule the consistency suite enforces for
+    // shipped templates — moved to runtime so user-uploaded YAML can't
+    // produce a service that "deploys" but is unreachable from the host.
+    const hostNetwork = podResult.data.spec.hostNetwork === true;
+    if (!hostNetwork) {
+        for (const c of podResult.data.spec.containers) {
+            for (const p of c.ports ?? []) {
+                if (!p.hostPort) {
+                    return {
+                        ok: false,
+                        error: {
+                            path: `spec.containers[${c.name}].ports[containerPort=${p.containerPort}].hostPort`,
+                            message: 'port has no hostPort and pod is not hostNetwork — would be unreachable from the host',
+                        },
+                    };
+                }
+            }
+        }
+    }
+
+    // PVC docs (if any) — basic shape only; podman creates the volume on
+    // first deploy regardless of most fields.
+    for (const doc of docs) {
+        if (doc?.kind === 'PersistentVolumeClaim') {
+            const pvcResult = PvcSchema.safeParse(doc);
+            if (!pvcResult.success) {
+                const issue = pvcResult.error.issues[0];
+                return {
+                    ok: false,
+                    error: {
+                        path: `(PVC).${issue.path.join('.')}`,
+                        message: issue.message,
+                    },
+                };
+            }
+        }
+    }
+
+    return { ok: true };
+}

--- a/tests/backend/pod_schema.test.ts
+++ b/tests/backend/pod_schema.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { validatePodManifest } from '../../src/lib/services/podSchema';
+
+const VALID = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+spec:
+  hostNetwork: true
+  containers:
+  - name: app
+    image: docker.io/library/nginx:latest
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - mountPath: /data
+      name: data
+  volumes:
+  - name: data
+    hostPath:
+      path: /mnt/data/example
+      type: DirectoryOrCreate
+`;
+
+describe('validatePodManifest', () => {
+    it('accepts a well-formed Pod', () => {
+        const r = validatePodManifest(VALID);
+        expect(r.ok).toBe(true);
+    });
+
+    it('rejects empty input', () => {
+        const r = validatePodManifest('');
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('$');
+    });
+
+    it('rejects YAML that does not parse', () => {
+        const r = validatePodManifest('this: is: broken: yaml');
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('$');
+    });
+
+    it('rejects when no Pod doc is present', () => {
+        const r = validatePodManifest(`apiVersion: v1\nkind: Service\nmetadata:\n  name: foo\n`);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('kind');
+    });
+
+    it('rejects wrong apiVersion', () => {
+        const yaml = VALID.replace('apiVersion: v1', 'apiVersion: v2alpha1');
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('apiVersion');
+    });
+
+    it('rejects metadata.name that is not a DNS-1123 label', () => {
+        const yaml = VALID.replace('name: example', 'name: Example_Pod');
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('metadata.name');
+    });
+
+    it('rejects empty containers array', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: empty
+spec:
+  hostNetwork: true
+  containers: []
+`;
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('spec.containers');
+    });
+
+    it('rejects a container with no image', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: noimg
+spec:
+  hostNetwork: true
+  containers:
+  - name: app
+`;
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toContain('containers');
+    });
+
+    it('rejects a volumeMount that points at an undeclared volume', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: typo
+spec:
+  hostNetwork: true
+  containers:
+  - name: app
+    image: x
+    volumeMounts:
+    - mountPath: /data
+      name: typo-data
+  volumes:
+  - name: actual-data
+    hostPath:
+      path: /mnt/data
+`;
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.message).toMatch(/typo-data/);
+        expect(r.error?.message).toMatch(/not declared/);
+    });
+
+    it('rejects a port without hostPort outside hostNetwork', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unreachable
+spec:
+  containers:
+  - name: app
+    image: x
+    ports:
+    - containerPort: 8080
+`;
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.message).toMatch(/unreachable/);
+    });
+
+    it('accepts a port without hostPort when hostNetwork: true', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ok
+spec:
+  hostNetwork: true
+  containers:
+  - name: app
+    image: x
+    ports:
+    - containerPort: 8080
+`;
+        expect(validatePodManifest(yaml).ok).toBe(true);
+    });
+
+    it('accepts a Pod + PVC multi-doc bundle (file-share shape)', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: file-share
+spec:
+  hostNetwork: true
+  containers:
+  - name: syncthing
+    image: docker.io/syncthing/syncthing:latest
+    ports:
+    - containerPort: 8384
+    volumeMounts:
+    - mountPath: /var/syncthing/config
+      name: syncthing-config
+  volumes:
+  - name: syncthing-config
+    persistentVolumeClaim:
+      claimName: file-share-syncthing-config
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: file-share-syncthing-config
+`;
+        expect(validatePodManifest(yaml).ok).toBe(true);
+    });
+
+    it('rejects a malformed PVC alongside a valid Pod', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ok
+spec:
+  hostNetwork: true
+  containers:
+  - name: app
+    image: x
+---
+apiVersion: v2
+kind: PersistentVolumeClaim
+metadata:
+  name: bad
+`;
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toMatch(/PVC/);
+    });
+});


### PR DESCRIPTION
## What

Closes #2 — the runtime Pod YAML validation that's been on the backlog. New module \`src/lib/services/podSchema.ts\` exports \`validatePodManifest(yamlContent)\`, wired into both API write paths so a malformed manifest fails at submit-time instead of at unit-reload-time.

## How

\`validatePodManifest\` does four things:

1. **Parse the YAML** (\`loadAll\` for multi-doc; finds the Pod by \`kind\`, validates a PVC alongside if present — file-share's shape since 3.6.4).
2. **Schema-check** with zod: \`apiVersion=v1\`, \`kind=Pod\`, DNS-1123 \`metadata.name\`, ≥1 container each with name + image, volume kind subset (hostPath / persistentVolumeClaim / emptyDir).
3. **Cross-reference**: every \`volumeMount.name\` must match a declared \`volumes[].name\`. Catches the typo-class bug where a mount points at a non-existent volume → container starts with the expected mountPath empty → operator spends an hour wondering why their config didn't take effect.
4. **Reachability**: if not \`hostNetwork: true\`, every container port must declare \`hostPort\`. Same rule the consistency suite enforces at PR-time for shipped templates — now applies to user input too.

## Wired into

- \`POST /api/services\` — wizard + InstallerModal + MCP \`deploy_service\`
- \`PUT  /api/services/[name]\` — Settings → Services edit panel

Both return \`400\` on failure with a structured error:

\`\`\`json
{
  "error": "invalid Pod manifest",
  "path": "spec.containers.app.volumeMounts.typo-data",
  "detail": "references volume \"typo-data\" which is not declared in spec.volumes"
}
\`\`\`

## Out of scope (intentionally — narrowed scope was discussed on #2)

- **Quadlet \`.kube\` syntax** — separate format with a smaller blast radius (the unit either loads or it doesn't, no silent corruption).
- **Full upstream K8s schema** — \`podman play kube\` itself implements the long tail; we want to catch operator-recoverable errors, not chase parity with kube-apiserver.

## Test plan

- [x] 13 new test cases in \`tests/backend/pod_schema.test.ts\` — happy path, empty/non-YAML/wrong-kind input, bad apiVersion + metadata.name, empty containers, missing image, volumeMount typo, hostNetwork-port rule both directions, Pod+PVC multi-doc bundle, malformed PVC
- [x] \`npm test\` — 339 pass (was 326)
- [x] \`npm run lint\` clean
- [x] \`next build --webpack\` clean
- [ ] Live: edit a deployed service in Settings → Services with a busted YAML (delete \`spec.containers\` entirely) → submit fails at the API with a clear "spec.containers" error, original unit untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)