### PR TITLE
fix(wizard): only collapse pull-progress lines, not post-deploy.py output

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -986,8 +986,20 @@ export default function OnboardingWizard() {
                     } catch { /* malformed marker — drop it */ }
                     continue;
                   }
-                  // Update last progress line in-place to avoid log spam
-                  if (lastProgressLine) {
+                  // In-place collapse — ONLY for image-pull progress lines
+                  // (which tick once a second per layer and would otherwise
+                  // bury everything else). Anything else — including
+                  // post-deploy.py stdout — appends a new log entry so the
+                  // operator can see what's actually happening.
+                  //
+                  // Earlier this collapsed every consecutive progress event
+                  // indiscriminately. Once any line came through, every
+                  // subsequent line replaced it, and the only visible trace
+                  // of a post-deploy.py was the final summary line — so
+                  // every script appeared to "exit 1" with no breadcrumb to
+                  // the actual error.
+                  const isPullProgress = /Pulling image \d+\/\d+|MB\s*\/\s*[\d.]+\s*MB/.test(evt.message ?? '');
+                  if (isPullProgress && lastProgressLine && /Pulling image \d+\/\d+|MB\s*\/\s*[\d.]+\s*MB/.test(lastProgressLine)) {
                     setStackLogs(prev => {
                       const next = [...prev];
                       next[next.length - 1] = evt.message;


### PR DESCRIPTION
## Why

Live regression on the user's 3.7.0 fresh install — every migrated stack reported \`post-deploy exited 1\` with NO script output visible:

\`\`\`
Installing nginx-web...
⚠️ nginx-web post-deploy exited 1. Service is deployed; the seed step did not finish — check the log lines above for the cause.
✅ nginx-web deployed (containers may still be starting in background).
\`\`\`

Same pattern for \`auth\`, \`adguard\`, \`file-share\`, \`media\`. The \`adguard\` script in particular has zero possible runtime errors (no HTTP, no env-var misses — just emits credentials and exits 0), yet it "exited 1" too. That's the smoking gun: the bug isn't in the scripts, it's in the wizard.

## Root cause

\`OnboardingWizard.tsx:935\` — the deploy-stream handler collapses **every** consecutive progress event in-place, originally to stop image-pull ticks (\`Pulling 5.1 MB / 10.0 MB\`) from spamming the log:

\`\`\`ts
if (lastProgressLine) {
  setStackLogs(prev => { next[next.length-1] = evt.message; return next; });  // REPLACES
}
\`\`\`

That worked fine when the only progress events were pull ticks. Now that scripts emit their own stdout via the same channel, every script log line replaces the previous — and the only line that survives is the engine's final \`⚠️ post-deploy exited N\` summary. The actual cause of the failure (whatever the script printed to stdout/stderr) is gone before the operator sees it.

## Fix

Only collapse when **both** the previous and new lines look like pull progress (regex matches \`Pulling image N/M\` or \`<num> MB / <num> MB\`). Everything else — script stdout, settle-wait heartbeats, NPM bootstrap status — appends a new entry.

## What this DOESN'T fix

This PR doesn't fix whatever's actually wrong with the post-deploy.py scripts. Once it lands and you re-run the install, we'll finally see the real error in the log and can target it in a follow-up.

## Test plan

- [x] \`npm test\` — 339 pass
- [x] \`npm run lint\` clean
- [ ] Live: re-run install on next release. Expect to see real script output between \`Installing X...\` and the final \`⚠️ exited N\` (which will hopefully no longer fire once we fix what the script is actually doing wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)