### PR TITLE
fix(post-deploy): unquote tilde paths so bash expands ~

### DIFF
--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -633,8 +633,17 @@ export class ServiceManager {
         // Long timeout — scripts wait for HTTP services that can take a
         // minute or two to come up after image pull. Keep below the
         // wizard's overall settle window.
+        //
+        // NB on the unquoted paths: scriptPath / envPath start with `~/`.
+        // Bash only expands `~` when it's an *unquoted* token at the
+        // beginning of a word — `'~/x'` and `"~/x"` both stay literal.
+        // The earlier single-quoted form failed every script with
+        // `sh: line 1: ~/.local/share/...: No such file or directory` and
+        // every migrated stack reported `post-deploy exited 1`. Paths are
+        // framework-controlled (no spaces, no shell metas) so unquoted is
+        // safe and the simplest form that does the right thing.
         const result = await agent.sendCommand('exec', {
-            command: `set -a; source '${envPath}'; set +a; python3 '${scriptPath}' 2>&1`,
+            command: `set -a; source ${envPath}; set +a; python3 ${scriptPath} 2>&1`,
             timeout: 300,
         });
         const stdout = (result.stdout || '').replace(/\r/g, '');


### PR DESCRIPTION
## What

Live agent-journal probe nailed it. Every migrated stack on the user's 3.7.0 install reported \`post-deploy exited 1\` with stderr:

\`\`\`
sh: line 1: ~/.local/share/servicebay/post-deploy/<name>.env: No such file or directory
\`\`\`

## Why

The engine's exec line was:

\`\`\`ts
command: \`set -a; source '\${envPath}'; set +a; python3 '\${scriptPath}' 2>&1\`
\`\`\`

Both paths start with \`~/\`. Bash only expands \`~\` when it's an **unquoted** token at the start of a word — \`'~/x'\` and \`"~/x"\` both stay literal. So \`source\` tried to open \`~/.local/share/servicebay/post-deploy/<name>.env\` as a literal path, failed, exit 1.

## Fix

Drop the single quotes around \`envPath\` and \`scriptPath\`. Paths are framework-controlled (no spaces, no shell metas), so unquoted is safe and does the right thing.

## Why it took two PRs to find

PR #222 (already merged) fixed the wizard's "in-place collapse" log handler — without that, every script's stdout got overwritten by the engine's final \`⚠️ post-deploy exited 1\` summary line, hiding the actual error. With #222 + this PR + the next release, the install log will both **show** what scripts print AND have them actually succeed.

## Test plan

- [x] \`npm test\` — 339 pass
- [x] \`npm run lint\` clean
- [ ] Live: re-run install on next release. Each migrated stack should log:
  - \`Running <name> post-deploy script...\`
  - the script's actual stdout (credential lines, wait heartbeats, ✅ success lines)
  - **no** \`⚠️ exited 1\` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)