### PR TITLE
feat(install): stream post-deploy stdout + multiplex agent commands

### DIFF
--- a/src/lib/agent/agent.py
+++ b/src/lib/agent/agent.py
@@ -14,9 +14,17 @@ def log(msg):
     sys.stderr.write(f"[Agent] {msg}\n")
     sys.stderr.flush()
 
+# stdout is the SSH channel back to ServiceBay. Once handle_command runs
+# in worker threads (so a long exec doesn't block other commands on the
+# same channel), multiple threads will race on print() — which can
+# interleave bytes mid-message and break the framing the JS client
+# expects ("\n"-delimited JSON). Serialize every emit through a lock.
+_emit_lock = threading.Lock()
+
 def emit(event_type, payload):
     msg = json.dumps({"type": event_type, "payload": payload})
-    print(msg, flush=True)
+    with _emit_lock:
+        print(msg, flush=True)
 
 class FileWatcher(threading.Thread):
     def __init__(self):
@@ -101,8 +109,44 @@ def handle_command(cmd_line):
             except Exception as e:
                 error = str(e)
 
+        elif action == "exec_stream":
+            # Execute a shell command, streaming stdout line-by-line as
+            # `exec:chunk` events while the process runs. Final response
+            # carries the exit code and the joined stdout/stderr (so
+            # callers that don't subscribe to chunks still get the
+            # legacy result shape). Used for post-deploy scripts so the
+            # operator sees the script's heartbeat instead of staring
+            # at "Running auth post-deploy script..." for ten minutes
+            # while the command buffers in subprocess.PIPE.
+            command = cmd.get("command")
+            try:
+                proc = subprocess.Popen(
+                    command,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,  # line-buffered
+                )
+                stdout_lines = []
+                # Stream every line back as it arrives. Carries the
+                # request id so the client can correlate chunks with
+                # the in-flight request — same id will appear on the
+                # final `response` event.
+                assert proc.stdout is not None
+                for line in proc.stdout:
+                    line = line.rstrip("\n")
+                    stdout_lines.append(line)
+                    emit("exec:chunk", {"id": req_id, "line": line})
+                proc.wait()
+                result = {
+                    "code": proc.returncode,
+                    "stdout": "\n".join(stdout_lines),
+                    "stderr": "",  # merged into stdout via stderr=STDOUT above
+                }
+            except Exception as e:
+                error = str(e)
 
-                
         elif action == "list_files":
              if os.path.exists(WATCH_DIR):
                  result = os.listdir(WATCH_DIR)
@@ -164,7 +208,18 @@ def main():
             line = sys.stdin.readline()
             if not line:
                 break # EOF
-            handle_command(line.strip())
+            # Spawn each command in a worker thread so a long-running
+            # exec (e.g. a 10-minute post-deploy waiting on LLDAP)
+            # doesn't block the read loop. Without this, every
+            # subsequent write_file / exec the wizard sent for the
+            # next service queued behind the in-flight exec on the
+            # SSH channel and timed out client-side at 30s — a
+            # single slow service used to fail the entire install.
+            threading.Thread(
+                target=handle_command,
+                args=(line.strip(),),
+                daemon=True,
+            ).start()
         except KeyboardInterrupt:
             break
         except Exception as e:

--- a/src/lib/agent/handler.ts
+++ b/src/lib/agent/handler.ts
@@ -85,8 +85,13 @@ export class AgentHandler extends EventEmitter {
     private isStarting = false;
     private startPromise: Promise<void> | null = null;
     private currentRunId?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private pendingRequests: Map<string, { resolve: (val: any) => void; reject: (err: any) => void }> = new Map();
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  private pendingRequests: Map<string, {
+      resolve: (val: any) => void;
+      reject: (err: any) => void;
+      onChunk?: (line: string) => void;
+  }> = new Map();
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   private isConnected: boolean = false;
   private consecutiveParseErrors = 0;
   private readonly MAX_PARSE_ERRORS = 5;
@@ -366,6 +371,20 @@ export class AgentHandler extends EventEmitter {
         return;
     }
 
+    // 1b. Streaming chunk for an in-flight exec_stream — forward to
+    // the per-request onChunk callback if the caller registered one.
+    if (msg.type === 'exec:chunk' && msg.payload && msg.payload.id) {
+        const req = this.pendingRequests.get(msg.payload.id);
+        if (req?.onChunk && typeof msg.payload.line === 'string') {
+            try { req.onChunk(msg.payload.line); }
+            catch (e) { this.log(this.nodeName, 'warn', 'onChunk handler threw:', e); }
+        }
+        // Don't fall through to the generic event emitter for chunks
+        // — they're noisy and the only legitimate consumer is the
+        // request that owns this id.
+        return;
+    }
+
     // 2. Generic Event
     this.emit('event', msg);
     // Also specific types
@@ -374,8 +393,13 @@ export class AgentHandler extends EventEmitter {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async sendCommand(action: string, params: any = {}, options: { timeoutMs?: number } = {}): Promise<any> {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  public async sendCommand(
+      action: string,
+      params: any = {},
+      options: { timeoutMs?: number; onChunk?: (line: string) => void } = {},
+  ): Promise<any> {
+  /* eslint-enable @typescript-eslint/no-explicit-any */
     if (!this.isConnected) {
         // Single start() used to be enough, but install loops that
         // straddle a ServiceBay autoupdate or host reboot need to wait
@@ -424,8 +448,11 @@ export class AgentHandler extends EventEmitter {
     this.log(this.nodeName, 'info', `Sending command '${action}' (id: ${id}) payload: ${payloadPreview}`);
     
     return new Promise((resolve, reject) => {
-        // maintain pending map
-        this.pendingRequests.set(id, { resolve, reject });
+        // maintain pending map. onChunk (when set) is invoked for each
+        // exec:chunk event the agent emits with this id — used by
+        // exec_stream callers (post-deploy scripts) so the wizard can
+        // surface each line as it arrives instead of a 10-min void.
+        this.pendingRequests.set(id, { resolve, reject, onChunk: options.onChunk });
         
         // Timeout (extendable per command; defaults to 30s).
         // 10s was too aggressive: a `systemctl start <pod>` for a fresh deploy

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -631,8 +631,11 @@ export class ServiceManager {
 
         onProgress?.(`Running ${name} post-deploy script...`);
         // Long timeout — scripts wait for HTTP services that can take a
-        // minute or two to come up after image pull. Keep below the
-        // wizard's overall settle window.
+        // minute or two to come up after image pull. The auth script's
+        // LLDAP wait deadline is 10 min on its own (image pull on a
+        // fresh install + database init); we give a 20 min client
+        // timeout so it outlasts the agent-side process budget plus
+        // generous slack.
         //
         // NB on the unquoted paths: scriptPath / envPath start with `~/`.
         // Bash only expands `~` when it's an *unquoted* token at the
@@ -643,22 +646,48 @@ export class ServiceManager {
         // framework-controlled (no spaces, no shell metas) so unquoted is
         // safe and the simplest form that does the right thing.
         //
-        // Two timeouts: `timeout: 300` is the agent-side process kill
-        // budget (seconds). `timeoutMs: 360_000` is the client-side
-        // sendCommand wait — it MUST outlast the agent budget, otherwise
-        // the client gives up at 30 s (the default), the agent keeps
-        // running, and every queued command behind it also times out.
-        // That was the failure mode in 3.7.x: auth post-deploy ran longer
-        // than 30 s waiting on LLDAP, the wizard surfaced "exec after
-        // 30000ms", and subsequent stacks all reported "write_file after
-        // 30000ms" while the agent was still single-threading the script.
-        const result = await agent.sendCommand('exec', {
-            command: `set -a; source ${envPath}; set +a; python3 ${scriptPath} 2>&1`,
-            timeout: 300,
-        }, { timeoutMs: 360_000 });
-        const stdout = (result.stdout || '').replace(/\r/g, '');
-        for (const line of stdout.split('\n')) {
-            if (line.length > 0) onProgress?.(line);
+        // exec_stream forwards each stdout line to onProgress as soon
+        // as the script prints it — without it, ServiceBay buffered the
+        // whole 10-min run and the wizard sat showing "Running auth
+        // post-deploy script..." with no signal that LLDAP was actually
+        // coming up. Falls back to the legacy `exec` action if the
+        // remote agent is older than 3.8.2.
+        let streamed = false;
+        let result: { code: number; stdout: string; stderr: string };
+        try {
+            result = await agent.sendCommand(
+                'exec_stream',
+                {
+                    command: `set -a; source ${envPath}; set +a; python3 ${scriptPath} 2>&1`,
+                    timeout: 1200,
+                },
+                {
+                    timeoutMs: 1_200_000,
+                    onChunk: (line: string) => {
+                        streamed = true;
+                        if (line.length > 0) onProgress?.(line);
+                    },
+                },
+            );
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            // Older agent that doesn't know exec_stream — fall back.
+            if (/exec_stream|Unknown|action/i.test(msg)) {
+                result = await agent.sendCommand('exec', {
+                    command: `set -a; source ${envPath}; set +a; python3 ${scriptPath} 2>&1`,
+                    timeout: 1200,
+                }, { timeoutMs: 1_200_000 });
+            } else {
+                throw e;
+            }
+        }
+        // If we didn't get any chunks (legacy fallback path or empty
+        // stream), surface the buffered stdout the way we used to.
+        if (!streamed) {
+            const stdout = (result.stdout || '').replace(/\r/g, '');
+            for (const line of stdout.split('\n')) {
+                if (line.length > 0) onProgress?.(line);
+            }
         }
         if (result.code !== 0) {
             onProgress?.(`⚠️ ${name} post-deploy exited ${result.code}. Service is deployed; the seed step did not finish — check the log lines above for the cause.`);


### PR DESCRIPTION
## Summary
Two install-loop UX/correctness problems, shipped together so the next install you run can succeed end-to-end:

1. **Streaming post-deploy stdout** — the old \`exec\` action buffered the whole script's stdout until the process exited. Wizard sat showing \"Running auth post-deploy script...\" for 10 min while LLDAP came up, with no signal. New \`exec_stream\` agent action emits each stdout line as an \`exec:chunk\` event keyed by request id; \`AgentHandler\` routes them to a per-request \`onChunk\` callback; \`ServiceManager.runPostDeployScript\` forwards each line to \`onProgress\` live.
2. **Multiplex agent commands** — the agent's read loop ran one command at a time over the SSH channel, so a 10-min exec blocked every queued \`write_file\` behind it (\"write_file after 30000ms\" cascading across services). Spawn each command in a worker thread; serialize \`emit()\` through a stdout lock so JSON framing doesn't get interleaved across threads.

Bonus: post-deploy client timeout extended from 6 min → 20 min so it outlasts auth's 10-min LLDAP-wait deadline plus margin. Falls back to the legacy \`exec\` action if the remote agent is older than this release.

## Test plan
- [x] \`npx vitest run\` — 340/340 passing
- [x] \`tsc --noEmit\` clean for changed files
- [x] \`python3 -m py_compile agent.py\` clean
- [ ] Live install on FCoS host: should see auth's \"Still waiting for LLDAP (Ns elapsed)...\" lines streaming live, and adguard/vaultwarden should not time out while auth's exec is in-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)