### PR TITLE
fix(install): set SB_API_URL so post-deploy scripts can reach back

### DIFF
--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -607,8 +607,22 @@ export class ServiceManager {
         // `source` exports each line to the python child. The ServiceBay
         // node identity is added so scripts can self-identify in multi-node
         // installs.
+        //
+        // SB_API_URL is critical: scripts call back into ServiceBay to
+        // probe LLDAP, persist credentials, etc. Without it the script
+        // defaults to http://localhost:3000 which is *not* ServiceBay
+        // (the container listens on PORT, default 5888 from the install
+        // script's Quadlet). On the FCoS host where the script runs,
+        // ServiceBay is reachable as http://localhost:${PORT} thanks to
+        // Network=host. This was the silent reason auth's post-deploy
+        // hit its 10-minute LLDAP-wait deadline on every install — the
+        // probe couldn't reach back, even though LLDAP itself came up
+        // in <1 s.
+        const sbPort = process.env.PORT || '5888';
+        const sbApiUrl = `http://localhost:${sbPort}`;
         const envLines = [
             `SB_NODE=${nodeName}`,
+            `SB_API_URL=${sbApiUrl}`,
             ...Object.entries(env).map(([k, v]) => {
                 // Only export string-shaped values; skip empty entries the
                 // wizard sometimes carries for variables the user hasn't


### PR DESCRIPTION
## Summary
You were right — time wasn't the problem. Diagnosed live via MCP:

- LLDAP came up in **0.7 seconds** (auth-lldap journal, 17:40:24)
- Auth's post-deploy script probes ServiceBay at \`SB_API_URL/api/system/lldap/probe\` to know when LLDAP is ready
- The env var was never set, so the script fell back to its hardcoded default \`http://localhost:3000\`
- ServiceBay listens on \`PORT=5888\` (per the install Quadlet's \`Environment=PORT=\${SERVICEBAY_PORT}\`)
- Nothing listens on 3000 on the FCoS host → every probe call refused
- Script looped for the full 10-min deadline → wizard's client timeout fired first

So even with v3.9.0's longer timeout, this would have failed at exactly 10 minutes.

Fix: inject \`SB_API_URL=http://localhost:\${process.env.PORT || 5888}\` into every post-deploy script's env file. ServiceBay runs with \`Network=host\`, so localhost on the agent reaches the ServiceBay container.

## Test plan
- [x] \`npx vitest run\` — 340/340 passing
- [ ] Live install — auth post-deploy should now finish in seconds (LLDAP probe → seed groups → done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)