### PR TITLE
fix(install): authenticate post-deploy callbacks via internal token

### DIFF
--- a/src/lib/auth/internalToken.ts
+++ b/src/lib/auth/internalToken.ts
@@ -1,0 +1,37 @@
+import crypto from 'node:crypto';
+
+/**
+ * Token shared between the ServiceBay process and its own post-deploy
+ * scripts. Derived (not equal) from AUTH_SECRET so it survives restarts
+ * without needing extra config plumbing, but compromise of this token
+ * alone doesn't reveal the session-signing secret.
+ *
+ * Used by:
+ *   - ServiceManager.runPostDeployScript writes it into each post-
+ *     deploy script's env file as SB_API_TOKEN.
+ *   - The shipped post-deploy.py scripts attach it as the
+ *     `X-SB-Internal-Token` header on every callback into ServiceBay
+ *     (e.g. /api/system/lldap/probe, /api/system/lldap/credentials).
+ *   - proxy.ts validates the header before applying the CSRF + session
+ *     checks, so server-to-server calls from the agent host can hit
+ *     the API without a browser session cookie.
+ *
+ * Read AUTH_SECRET lazily so test environments that import this module
+ * before setting AUTH_SECRET don't crash at import time.
+ */
+let cached: string | null = null;
+
+export function getInternalApiToken(): string {
+    if (cached) return cached;
+    const secret = process.env.AUTH_SECRET ?? '';
+    if (!secret) {
+        // Fall back to a per-process random token. Without AUTH_SECRET
+        // the install isn't supportable anyway, but at least don't
+        // crash — yield a random value and let the rest of the app
+        // surface the underlying configuration problem.
+        cached = crypto.randomBytes(32).toString('hex');
+        return cached;
+    }
+    cached = crypto.createHmac('sha256', secret).update('servicebay:internal-api:v1').digest('hex');
+    return cached;
+}

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -618,11 +618,21 @@ export class ServiceManager {
         // hit its 10-minute LLDAP-wait deadline on every install — the
         // probe couldn't reach back, even though LLDAP itself came up
         // in <1 s.
+        //
+        // SB_API_TOKEN authenticates server-to-server calls. The
+        // scripts attach it as `X-SB-Internal-Token` so proxy.ts can
+        // bypass the browser-flow CSRF + session checks (urllib has
+        // no Origin header, so the same-origin guard rejected every
+        // POST with 403 — even though the call was reaching the
+        // ServiceBay container as intended).
         const sbPort = process.env.PORT || '5888';
         const sbApiUrl = `http://localhost:${sbPort}`;
+        const { getInternalApiToken } = await import('@/lib/auth/internalToken');
+        const sbApiToken = getInternalApiToken();
         const envLines = [
             `SB_NODE=${nodeName}`,
             `SB_API_URL=${sbApiUrl}`,
+            `SB_API_TOKEN=${sbApiToken}`,
             ...Object.entries(env).map(([k, v]) => {
                 // Only export string-shaped values; skip empty entries the
                 // wizard sometimes carries for variables the user hasn't

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { decrypt } from '@/lib/auth/session';
+import { getInternalApiToken } from '@/lib/auth/internalToken';
 
 const PUBLIC_API_PREFIXES = [
   '/api/auth/login',
@@ -11,6 +12,31 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 function isPublicApi(pathname: string): boolean {
   return PUBLIC_API_PREFIXES.some(p => pathname === p || pathname.startsWith(p + '/'));
+}
+
+// Server-to-server calls from ServiceBay's own post-deploy scripts on
+// the agent host. The script reads SB_API_TOKEN from its env file and
+// sends it as `X-SB-Internal-Token`. Token is derived from AUTH_SECRET
+// so it survives restarts without extra config plumbing. Without this,
+// every callback (LLDAP probe, credentials persistence, …) from the
+// post-deploy scripts hit the CSRF check (no Origin header from
+// urllib) and got 403, which the wizard surfaced as e.g. "LLDAP did
+// not respond in time" while LLDAP was actually up in <1 s.
+function isInternalCall(request: NextRequest): boolean {
+  const presented = request.headers.get('x-sb-internal-token');
+  if (!presented) return false;
+  const expected = getInternalApiToken();
+  if (presented.length !== expected.length) return false;
+  // Constant-time compare via Buffer to avoid timing leaks.
+  try {
+    const a = Buffer.from(presented);
+    const b = Buffer.from(expected);
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+    return diff === 0;
+  } catch {
+    return false;
+  }
 }
 
 // Same-origin CSRF check: for state-changing methods, the request's Origin
@@ -36,6 +62,10 @@ export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (!pathname.startsWith('/api/')) return NextResponse.next();
+
+  // Internal calls (post-deploy scripts on the agent host) bypass
+  // both CSRF and session checks — the token authenticates them.
+  if (isInternalCall(request)) return NextResponse.next();
 
   if (!SAFE_METHODS.has(request.method) && !isSameOrigin(request)) {
     return NextResponse.json({ error: 'Forbidden: cross-site request' }, { status: 403 });

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -49,7 +49,14 @@ def log(msg: str) -> None:
 
 def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
     body = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+    headers = {"Content-Type": "application/json"}
+    # Pin internal API token. ServiceBay's proxy.ts checks this header
+    # to bypass the browser-flow CSRF + session guards (urllib doesn't
+    # send an Origin header, so without this every POST got 403).
+    token = os.environ.get("SB_API_TOKEN", "")
+    if token:
+        headers["X-SB-Internal-Token"] = token
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = resp.read().decode("utf-8")

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -44,7 +44,11 @@ def log(msg: str) -> None:
 
 def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
     body = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("SB_API_TOKEN", "")
+    if token:
+        headers["X-SB-Internal-Token"] = token
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = resp.read().decode("utf-8")

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -57,10 +57,14 @@ def log(msg: str) -> None:
 def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
     """POST JSON, return (status, parsed-body-or-None)."""
     body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("SB_API_TOKEN", "")
+    if token:
+        headers["X-SB-Internal-Token"] = token
     req = urllib.request.Request(
         url,
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     try:


### PR DESCRIPTION
## Summary
The streaming + multiplexing fixes from v3.9.2 worked — we can finally see what's happening:

\`\`\`
Running auth post-deploy script...
⚠️ Could not persist LLDAP credentials (HTTP 403). Note now: admin / xxx
Waiting for LLDAP to start (cold-start usually < 30s)...
Still waiting for LLDAP (12s elapsed)...
Still waiting for LLDAP (24s elapsed)...
Still waiting for LLDAP (36s elapsed)...
\`\`\`

The script is alive and streaming. Hitting **HTTP 403** on every callback into ServiceBay's API. Cause: \`proxy.ts\` rejects state-changing requests whose Origin/Referer doesn't match Host. Python's \`urllib\` sends neither header, so every POST from the post-deploy scripts gets 403 — silent because the script only checks for 200 and just retries.

Fix: token-based internal auth.
- New \`getInternalApiToken()\` derived from AUTH_SECRET via HMAC (stable across restarts, leak doesn't reveal AUTH_SECRET).
- \`ServiceManager.runPostDeployScript\` injects it as \`SB_API_TOKEN\` into every post-deploy env file.
- The three scripts that call back (auth, file-share, media) attach it as \`X-SB-Internal-Token\` on every request.
- \`proxy.ts\` validates the header with constant-time compare; matching requests skip both CSRF and session-cookie checks.

## Test plan
- [x] \`npx vitest run\` — 340/340 passing
- [x] \`tsc --noEmit\` clean
- [x] \`python3 -m py_compile\` clean for all 3 modified scripts
- [ ] Live install — auth's LLDAP probe should now return 200 in <2 s, credentials should persist, all subsequent stacks should follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)