### PR TITLE
fix: five fresh-install issues found via MCP diagnostics

### DIFF
--- a/src/app/api/services/[name]/action-stream/route.ts
+++ b/src/app/api/services/[name]/action-stream/route.ts
@@ -32,13 +32,25 @@ export async function POST(
   const encoder = new TextEncoder();
   const stream = new TransformStream();
   const writer = stream.writable.getWriter();
+  let writerClosed = false;
 
   const write = async (msg: string) => {
-    await writer.write(encoder.encode(msg + '\r\n'));
+    if (writerClosed) return;
+    try {
+      await writer.write(encoder.encode(msg + '\r\n'));
+    } catch {
+      // Client aborted — stop attempting to write to a closed stream.
+      writerClosed = true;
+    }
   };
 
   const writeRaw = async (msg: string) => {
-    await writer.write(encoder.encode(msg));
+    if (writerClosed) return;
+    try {
+      await writer.write(encoder.encode(msg));
+    } catch {
+      writerClosed = true;
+    }
   };
 
   (async () => {
@@ -153,7 +165,9 @@ export async function POST(
     } catch (e) {
       await write(`Error: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
-      await writer.close();
+      if (!writerClosed) {
+        try { await writer.close(); } catch { /* already closed */ }
+      }
     }
   })();
 

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -319,6 +319,17 @@ export async function POST(request: Request) {
     const encoder = new TextEncoder();
     const stream = new TransformStream();
     const writer = stream.writable.getWriter();
+    let writerClosed = false;
+    const safeWrite = async (payload: unknown) => {
+      if (writerClosed) return;
+      try {
+        await writer.write(encoder.encode(JSON.stringify(payload) + '\n'));
+      } catch {
+        // Client aborted — mark closed so subsequent writes are no-ops
+        // instead of triggering unhandledRejection.
+        writerClosed = true;
+      }
+    };
 
     (async () => {
       try {
@@ -329,18 +340,17 @@ export async function POST(request: Request) {
           yamlContent,
           yamlFileName,
           extraFiles,
-          (message) => {
-            writer.write(encoder.encode(JSON.stringify({ type: 'progress', message }) + '\n')).catch(() => {});
-          },
+          (message) => { void safeWrite({ type: 'progress', message }); },
           postDeployScript,
           postDeployEnv,
         );
-        await writer.write(encoder.encode(JSON.stringify({ type: 'complete', success: true }) + '\n'));
+        await safeWrite({ type: 'complete', success: true });
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        await writer.write(encoder.encode(JSON.stringify({ type: 'error', message: msg }) + '\n'));
+        await safeWrite({ type: 'error', message: e instanceof Error ? e.message : String(e) });
       } finally {
-        await writer.close();
+        if (!writerClosed) {
+          try { await writer.close(); } catch { /* already closed */ }
+        }
       }
     })();
 

--- a/src/lib/agent/handler.ts
+++ b/src/lib/agent/handler.ts
@@ -200,7 +200,15 @@ export class AgentHandler extends EventEmitter {
         sessionId ? `export SERVICEBAY_SESSION_ID="${sessionId}"` : ''
       ].filter(Boolean).join('; ');
       const sessionArg = sessionId ? ` --session-id "${sessionId}"` : '';
-      const cmd = `${envSetup}; python3 -u -c 'import base64, sys; exec(base64.b64decode("${script}"))'${sessionArg}`;
+      // Wait up to 90 s for python3 to appear before invoking it. Covers the
+      // FCoS first-boot race where install-python.service hasn't finished
+      // rpm-ostree-installing python3 by the time we SSH in. No-op (~0 ms)
+      // when python3 is already on PATH, so safe for established installs.
+      const waitForPython =
+        'i=0; while ! command -v python3 >/dev/null 2>&1; do i=$((i+1)); ' +
+        '[ $i -ge 90 ] && { echo "python3 not available after 90s" >&2; exit 127; }; ' +
+        'sleep 1; done';
+      const cmd = `${envSetup}; ${waitForPython}; python3 -u -c 'import base64, sys; exec(base64.b64decode("${script}"))'${sessionArg}`;
 
       return new Promise<void>((resolve, reject) => {
         conn.exec(cmd, (err, stream) => {

--- a/src/lib/agent/v4/agent.py
+++ b/src/lib/agent/v4/agent.py
@@ -1928,7 +1928,7 @@ class Agent:
                             conn = UnixHTTPConnection(sock_path)
                             from urllib.parse import quote
                             ref = quote(img, safe='')
-                            conn.request('POST', f'/v5.0.0/images/pull?reference={ref}')
+                            conn.request('POST', f'/v5.0.0/libpod/images/pull?reference={ref}')
                             resp = conn.getresponse()
                             if resp.status != 200:
                                 body = resp.read().decode('utf-8', errors='replace')

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -108,11 +108,32 @@ async function cloneSparse(url: string, dest: string, dirs: string[]) {
     await execFileAsync('git', ['sparse-checkout', 'set', ...dirs], { cwd: dest });
 }
 
+let gitAvailability: boolean | null = null;
+async function isGitAvailable(): Promise<boolean> {
+    if (gitAvailability !== null) return gitAvailability;
+    try {
+        await execFileAsync('git', ['--version']);
+        gitAvailability = true;
+    } catch {
+        gitAvailability = false;
+    }
+    return gitAvailability;
+}
+
 export async function syncRegistries() {
     const config = await getConfig();
     const registries = getRegistries(config);
 
     if (registries.length === 0) return;
+
+    // Fedora CoreOS doesn't ship git. Without it we can still serve the
+    // built-in templates/stacks bundled with ServiceBay; only external
+    // registry sync is unavailable. Log once and skip rather than fail
+    // every server start.
+    if (!(await isGitAvailable())) {
+        console.log('Registry sync skipped: git not available (built-in templates still served).');
+        return;
+    }
 
     try {
         await fs.mkdir(REGISTRIES_DIR, { recursive: true });

--- a/src/lib/services/quadletDirectives.test.ts
+++ b/src/lib/services/quadletDirectives.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { injectServiceDirectives } from './quadletDirectives';
+
+describe('injectServiceDirectives', () => {
+  it('injects [Service] directives into an existing [Service] section', () => {
+    const input = '[Kube]\nYaml=foo.yml\n\n[Install]\nWantedBy=default.target\n[Service]\n';
+    const out = injectServiceDirectives(input);
+    expect(out).toMatch(/\[Service\]\s*\n[^[]*Restart=on-failure/);
+    expect(out).toContain('TimeoutStartSec=600');
+  });
+
+  it('places StartLimitIntervalSec in [Unit], not [Service]', () => {
+    const input = '[Kube]\nYaml=foo.yml\n\n[Install]\nWantedBy=default.target\n';
+    const out = injectServiceDirectives(input);
+
+    // StartLimitIntervalSec must be under [Unit] for systemd to honor it.
+    // Prior bug: it was emitted under [Service] and silently ignored.
+    const unitIdx = out.indexOf('[Unit]');
+    const serviceIdx = out.indexOf('[Service]');
+    const limitIdx = out.indexOf('StartLimitIntervalSec=0');
+    expect(unitIdx).toBeGreaterThanOrEqual(0);
+    expect(limitIdx).toBeGreaterThan(unitIdx);
+    if (serviceIdx >= 0 && serviceIdx > unitIdx) {
+      // [Service] follows [Unit] — limit must appear before [Service]
+      expect(limitIdx).toBeLessThan(serviceIdx);
+    }
+  });
+
+  it('is idempotent — does not duplicate keys already set by the source', () => {
+    const input =
+      '[Kube]\nYaml=foo.yml\n[Service]\nRestart=always\nTimeoutStartSec=120\n[Unit]\nStartLimitIntervalSec=42\n';
+    const out = injectServiceDirectives(input);
+    expect(out.match(/^Restart=/gm)?.length).toBe(1);
+    expect(out.match(/^TimeoutStartSec=/gm)?.length).toBe(1);
+    expect(out.match(/^StartLimitIntervalSec=/gm)?.length).toBe(1);
+    expect(out).toContain('Restart=always');
+    expect(out).toContain('TimeoutStartSec=120');
+    expect(out).toContain('StartLimitIntervalSec=42');
+  });
+
+  it('appends [Service] and [Unit] sections when missing', () => {
+    const input = '[Kube]\nYaml=foo.yml\n';
+    const out = injectServiceDirectives(input);
+    expect(out).toContain('[Service]');
+    expect(out).toContain('[Unit]');
+    expect(out).toContain('StartLimitIntervalSec=0');
+    expect(out).toContain('Restart=on-failure');
+  });
+});

--- a/src/lib/services/quadletDirectives.ts
+++ b/src/lib/services/quadletDirectives.ts
@@ -1,10 +1,11 @@
 /**
- * Default `[Service]` directives ServiceBay injects into every .kube unit
+ * Default systemd directives ServiceBay injects into every .kube unit
  * it writes. Pure string transforms — no I/O, no class state — so this
  * module can be imported from any kube-write path (ServiceManager,
  * unmanaged-bundle migration, discovery's service migration) without
  * pulling in dependencies.
  *
+ * [Service] directives:
  * - TimeoutStartSec=600  Image pulls + first-run inits can be slow.
  * - Restart=on-failure   Restart on crash, but not on clean exit (oneshot
  *                        containers exit 0 legitimately).
@@ -13,6 +14,18 @@
  * - RestartSteps=4 +     Geometric backoff from 5 s up to 5 min over 4
  *   RestartMaxDelaySec    steps: ≈ 5 s, 14 s, 39 s, 107 s, 300 s. After
  *   =300                  step 4 every retry waits 5 minutes.
+ *
+ * [Unit] directives:
+ * - StartLimitIntervalSec=0  Disables systemd's "5 fails in 10 s = give
+ *                             up" guard. A fast-failing image pull
+ *                             (~2 s before crash) hits the burst limit
+ *                             before our backoff has had a chance to
+ *                             expand, and systemd marks the unit
+ *                             start-limit-hit and stops retrying —
+ *                             exactly the symptom that bit nginx-web on
+ *                             the post-3.4.2 reinstall. 0 = no limit.
+ *                             Must live in [Unit]; systemd silently
+ *                             ignores it under [Service].
  *
  * Requires systemd ≥ 254 (RestartSteps + RestartMaxDelaySec).
  * FCoS ships systemd 258, well past that.
@@ -23,14 +36,28 @@ const DEFAULT_SERVICE_DIRECTIVES: readonly string[] = [
   'RestartSec=5',
   'RestartSteps=4',
   'RestartMaxDelaySec=300',
-  // Disable systemd's "5 fails in 10 s = give up" guard. A fast-failing
-  // image pull (~2 s before crash) hits the burst limit before our
-  // backoff has had a chance to expand, and systemd marks the unit
-  // start-limit-hit and stops retrying — exactly the symptom that bit
-  // nginx-web on the post-3.4.2 reinstall. 0 = no limit, retry forever
-  // per the backoff schedule.
+];
+
+const DEFAULT_UNIT_DIRECTIVES: readonly string[] = [
   'StartLimitIntervalSec=0',
 ];
+
+function injectIntoSection(
+  kubeContent: string,
+  section: '[Service]' | '[Unit]',
+  directives: readonly string[],
+): string {
+  const missing = directives.filter(d => {
+    const key = d.split('=')[0];
+    return !new RegExp(`^${key}=`, 'm').test(kubeContent);
+  });
+  if (missing.length === 0) return kubeContent;
+  const block = missing.join('\n');
+  if (kubeContent.includes(section)) {
+    return kubeContent.replace(section, `${section}\n${block}`);
+  }
+  return kubeContent + `\n${section}\n${block}\n`;
+}
 
 /**
  * Inject the default systemd directives into a .kube unit. Idempotent
@@ -38,14 +65,7 @@ const DEFAULT_SERVICE_DIRECTIVES: readonly string[] = [
  * already sets explicitly. Safe to apply to user-edited .kube files.
  */
 export function injectServiceDirectives(kubeContent: string): string {
-  const directives = DEFAULT_SERVICE_DIRECTIVES.filter(d => {
-    const key = d.split('=')[0];
-    return !new RegExp(`^${key}=`, 'm').test(kubeContent);
-  });
-  if (directives.length === 0) return kubeContent;
-  const block = directives.join('\n');
-  if (kubeContent.includes('[Service]')) {
-    return kubeContent.replace('[Service]', `[Service]\n${block}`);
-  }
-  return kubeContent + `\n[Service]\n${block}\n`;
+  let out = injectIntoSection(kubeContent, '[Service]', DEFAULT_SERVICE_DIRECTIVES);
+  out = injectIntoSection(out, '[Unit]', DEFAULT_UNIT_DIRECTIVES);
+  return out;
 }


### PR DESCRIPTION
## Summary

Five independent fixes surfaced while investigating "continuous problems freshly installing servicebay with default settings" on a fresh FCoS box. All install probes passed but the journal showed real regressions:

- **Podman 405 on every pre-pull.** `agent.py` POSTed `/v5.0.0/images/pull?reference=…`, which is neither libpod nor Docker-compat. Streaming pull-progress UX silently degraded; quadlet still pulled images on first start so install completed without user-visible errors. Fixed to `/v5.0.0/libpod/images/pull`.
- **`StartLimitIntervalSec=0` ignored by systemd.** Was emitted under `[Service]`; the directive is only valid in `[Unit]`. The fix added after the post-3.4.2 nginx-web start-limit-hit incident has been inactive on every freshly-deployed service. Refactored `injectServiceDirectives` to inject per-section + added regression test.
- **python3 race on first agent connect.** First SSH agent bootstrap fired before FCoS first-boot `install-python.service` finished. Bootstrap now busy-waits up to 90 s for `command -v python3` (no-op once python3 is installed).
- **Registry sync warn-spam.** FCoS doesn't ship git, so every server start warned `Registry sync failed: spawn git ENOENT`. Now probes `git --version` once and skips with a single info log; built-in templates still served.
- **`unhandledRejection: WritableStream is closed`.** `writer.write` on a TransformStream rejected when the deploy/action client aborted mid-stream. Wrapped writes behind `safeWrite` / guarded `write` so post-abort writes are no-ops.

Each commit isolates one fix.

## Test plan

- [x] `npx vitest run` — 344 passed, 1 skipped (incl. 4 new `quadletDirectives.test.ts` cases)
- [x] `npx eslint` — clean on changed files
- [x] `python3 -m py_compile src/lib/agent/v4/agent.py`
- [ ] Verify on next FCoS reinstall: agent shows zero `python3 not found` errors at boot, pre-pull progress streams in the wizard, no more `StartLimitIntervalSec` ignore warnings in service journals, no `Registry sync failed` warning in servicebay logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)