### PR TITLE
chore: finalize engine/template separation

### DIFF
--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -1,0 +1,238 @@
+# Template authoring guide
+
+ServiceBay treats every installable service as a **template** — a
+self-contained directory that can be added, edited, or removed without
+changing core code. This guide describes the on-disk contract.
+
+The same model also applies to **stacks** (a `stacks/<name>/` directory
+with a `README.md` whose `- [x] foo` lines reference template names).
+
+## Anatomy of a template
+
+```
+templates/<name>/
+├── template.yml          # required — kube Pod manifest with mustache placeholders
+├── variables.json        # required — variable schema
+├── README.md             # required — short description for the wizard
+├── post-deploy.py        # optional — runs on the host after the unit starts
+└── *.mustache            # optional — companion config files (e.g. authelia config)
+```
+
+### `template.yml`
+
+A standard `kind: Pod` manifest with `{{MUSTACHE}}` placeholders that
+the wizard substitutes at deploy time. Use these annotations under
+`metadata.annotations`:
+
+| Annotation | Required | Purpose |
+|---|---|---|
+| `servicebay.label` | yes | Friendly UI label shown in the wizard's configure step (e.g. `"Vaultwarden (Passwords)"`). Without it the section header falls back to the raw template name. |
+| `servicebay.ports` | recommended | Comma-separated `port/proto` list. Drives gateway probes + the network graph. |
+| `servicebay.config-mount` | required if any `*.mustache` files | Container mountPath that companion config files should land in. Avoids the `/config`-suffix heuristic picking the wrong volume in multi-container pods. |
+
+Use `metadata.labels` for `servicebay.role` (`dns`, `reverse-proxy`,
+`media`, …) — those steer health-check defaults.
+
+The pod must satisfy one of:
+- `spec.hostNetwork: true`, OR
+- every published `containerPort` declares an explicit `hostPort`
+
+…otherwise the deploy is silently unreachable. The consistency test
+enforces this.
+
+### `variables.json`
+
+Map of variable name to metadata. Recognized fields:
+
+```jsonc
+{
+  "MY_PORT": {
+    "type": "text",          // text | password | secret | rsa-private |
+                             // bcrypt | select | device | subdomain
+    "description": "Web UI port",
+    "default": "8080",
+    "options": ["a", "b"],   // for type=select
+    "devicePath": "/dev/serial/by-id",  // for type=device
+    "proxyPort": "MY_PORT",  // for type=subdomain — variable name OR literal port number
+    "proxyConfig": {         // for type=subdomain — passed to NPM verbatim
+      "block_exploits": true,
+      "ssl_forced": true,
+      "advanced_config": "client_max_body_size 0;"  // mustache-rendered
+    },
+    "oidcClient": {          // optional — registered with Authelia
+      "client_id": "myapp",
+      "client_name": "My App",
+      "authorization_policy": "one_factor",
+      "redirect_uris": ["/auth/callback"],
+      "scopes": ["openid", "profile", "email"],
+      "clientSecretVar": "MY_SSO_SECRET"  // optional — env-wired SSO
+    },
+    "bcryptSource": "ADMIN_PASSWORD"  // for type=bcrypt — name of the var to hash
+  }
+}
+```
+
+What each `type` does generically (no per-template code needed):
+
+- **`text` / `select` / `device`** — rendered as a form input.
+- **`password` / `secret`** — auto-generated random string, shown
+  read-only with a regenerate button.
+- **`rsa-private`** — auto-generated PEM, hidden from the UI.
+- **`bcrypt`** — hash of `bcryptSource`'s value, hidden from the UI.
+  Use this when you need both the plaintext (in env) and the hash
+  (in a config file).
+- **`subdomain`** — registers an NPM proxy host using `proxyPort` +
+  `proxyConfig`. Mustache placeholders inside `advanced_config` are
+  rendered against the user's variables, so cross-template wiring
+  (`{{AUTHELIA_PORT}}`, `{{PUBLIC_DOMAIN}}`) works.
+- **`oidcClient` on any var** — collected across every selected
+  template and registered with Authelia in one POST. When
+  `clientSecretVar` is set, the secret is wired into the container
+  env (e.g. `SSO_CLIENT_SECRET`) automatically — no UI paste needed.
+
+`templates/settings.json` declares a few global variables (`DATA_DIR`,
+`LLDAP_HOST`, `LLDAP_LDAP_PORT`, `LLDAP_BASE_DN`) that every template
+can reference without re-declaring.
+
+### Companion mustache files (`*.mustache`)
+
+Any `<name>.mustache` file in the template directory gets rendered with
+the user's variables and shipped to the host as `<name>` (extension
+stripped). The target path is derived from the volume that mounts the
+container's `servicebay.config-mount`.
+
+Use these for service config files that need substituted values
+on first start (AdGuard's `AdGuardHome.yaml`, Authelia's
+`configuration.yml`).
+
+### `post-deploy.py`
+
+Optional Python script that runs on the host **after** the unit starts.
+This is where per-service glue lives — credential surfacing, admin
+seeding, post-install validation, etc. There is no other extension
+point: if you need it, put it here.
+
+```python
+#!/usr/bin/env python3
+import json, os, sys
+
+def emit_credential(**fields):
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+def main() -> int:
+    password = os.environ.get("MY_ADMIN_PASSWORD", "")
+    if not password:
+        return 0  # nothing to surface — early return is fine
+
+    # Plain log lines stream into the install panel.
+    print(f"🔑 My App admin (user: admin, password: {password})")
+
+    # Credential markers go into the SAVE-THESE-NOW banner + Bitwarden CSV.
+    emit_credential(
+        service="My App",
+        url=f"http://{os.environ.get('HOST', '<server-ip>')}:{os.environ.get('MY_PORT', '8080')}",
+        username="admin",
+        password=password,
+        importance="critical",            # or "system" for DR-only secrets
+        notes="Admin panel. Save now.",
+    )
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+#### Environment available to the script
+
+- Every wizard variable, exported as the same env var name
+  (e.g. `MY_ADMIN_PASSWORD`, `PUBLIC_DOMAIN`).
+- `HOST` — hostname the operator is browsing ServiceBay through.
+- `SB_NODE` — node name the script is running on.
+- `SB_API_URL` — `http://localhost:<servicebay-port>`. Use this to
+  call back into ServiceBay (LLDAP probe, FileBrowser init, …).
+- `SB_API_TOKEN` — internal token. Attach as `X-SB-Internal-Token`
+  on POSTs to `SB_API_URL`; without it the same-origin guard
+  rejects the call (see `auth/post-deploy.py` for the canonical
+  pattern).
+
+#### Output protocol
+
+- **Plain stdout lines** — relayed to the install log as-is.
+- **`__SB_CREDENTIAL__ {json}` lines** — parsed by the wizard. The
+  JSON object goes into the SAVE-THESE-NOW banner and the Bitwarden
+  CSV download. Required fields: `service`, `url`, `username`,
+  `password`, `importance` (`critical` | `system`). Optional: `notes`.
+- **Exit code** — `0` on success. Non-zero is logged but does **not**
+  roll back the deploy (the unit is already running).
+
+#### Wait loops
+
+When your script needs the upstream service to be reachable before
+seeding (LLDAP, FileBrowser, ABS), follow the pattern in the existing
+scripts: 5-minute deadline, 10-second heartbeat log, sleep between
+retries. The agent budget is 20 minutes, so leave slack.
+
+## What stays in core
+
+These behaviours live in the engine and **cannot** be moved to a
+template script — don't try:
+
+- **NPM admin bootstrap** (`postInstall.ts:bootstrapNpmAdmin`) returns
+  a tri-state result that drives the wizard's NPM-credentials prompt
+  UI when bootstrap fails. This is the only `isSelected('nginx-web')`
+  branch left, and the consistency test allows it.
+- **Cross-template proxy-host aggregation** walks `subdomain`-typed
+  variables across every selected template and POSTs once to the NPM
+  REST API. A per-template script would need to know about every
+  other template.
+- **Cross-template OIDC client registration** walks
+  `variables[].meta.oidcClient` across every selected template and
+  POSTs once to `/api/system/authelia/oidc-clients`.
+- **The variable-driven OIDC credential entry** in
+  `credentialsManifest.ts` derives client_secret entries from
+  `oidcClient.clientSecretVar`. Template-agnostic — adding a new OIDC
+  client to a template just requires an `oidcClient` block in
+  `variables.json`.
+
+## Adding a new template
+
+1. Create `templates/<my-name>/template.yml` with:
+   - `metadata.annotations['servicebay.label']: "<friendly name>"`
+   - `metadata.annotations['servicebay.ports']: "<port>/<proto>,..."`
+2. Create `templates/<my-name>/variables.json` declaring every
+   `{{MUSTACHE}}` placeholder you used.
+3. Write a one-paragraph `templates/<my-name>/README.md`.
+4. (Optional) Add `<config>.mustache` files and the matching
+   `servicebay.config-mount` annotation.
+5. (Optional) Add `post-deploy.py` if the service needs any seeding,
+   credential surfacing, or admin pre-promotion. Add a smoke test
+   case to `tests/templates/test_post_deploy.py`.
+6. Add a `- [x] <my-name> — <description>` line to whichever
+   `stacks/<stack>/README.md` should offer it in the wizard.
+7. Run `npm test` — the consistency suite catches the common typos
+   (undeclared variables, dangling proxyPort references, missing
+   labels, kube manifests that don't render to a valid Pod).
+
+## Editing or replacing a built-in template
+
+You can freely change `template.yml`, `variables.json`,
+`*.mustache`, `README.md`, or `post-deploy.py`. Core code has **no
+hardcoded knowledge** of any built-in template name; the consistency
+test (`tests/backend/template_consistency.test.ts > stackInstall has
+no unauthorized per-template branches`) guards this boundary.
+
+If you find yourself needing to add an `if (templateName === 'foo')`
+branch in core, that is the build failure the test produces — please
+either extend the script protocol (a new env var, a new
+`__SB_*` marker) or document the case in the test's `ALLOWED` list
+with a justifying comment.
+
+## External registries
+
+`config.registries[]` accepts git URLs that follow the same on-disk
+layout (a `templates/` directory at the repo root). The `registry.ts`
+sync clones with `--depth 1 --filter=blob:none --sparse`, then
+`sparse-checkout set templates stacks`. External registries override
+built-ins with the same name, so you can ship a custom variant of any
+bundled template by publishing it under the same directory name.

--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -6,6 +6,7 @@ import { runPostInstall } from '@/lib/stackInstall/postInstall';
 import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
 import { buildCredentialsManifest, buildBitwardenCsv } from '@/lib/stackInstall/credentialsManifest';
 import { fetchTemplateYaml, fetchTemplateVariables, fetchTemplateConfigFiles } from '@/app/actions';
+import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getNodes } from '@/app/actions/system';
 import { PodmanConnection } from '@/lib/nodes';
 import { Layers, Loader2, AlertCircle, X, Folder, Server, RefreshCw } from 'lucide-react';
@@ -176,10 +177,11 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
 
             // Fetch variable metadata
             const meta = await fetchTemplateVariables(item.name, template.source);
+            const templateLabel = parseTemplateLabel(yaml);
             if (meta) {
               for (const [key, value] of Object.entries(meta)) {
                 if (!allMeta[key]) {
-                  allMeta[key] = { ...value, templateName: item.name };
+                  allMeta[key] = { ...value, templateName: item.name, templateLabel };
                 }
               }
             }

--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -756,9 +756,8 @@ WantedBy=default.target`;
                             const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
                             const subdomains = variables.filter(v => v.meta?.type === 'subdomain' && v.value);
                             const hasProxyRoutes = !!domain && subdomains.length > 0;
-                            const selected = items.filter(i => i.checked);
                             const host = typeof window !== 'undefined' ? window.location.hostname : '<server-ip>';
-                            const manifest = buildCredentialsManifest({ selected, variables, host });
+                            const manifest = buildCredentialsManifest({ variables, host });
                             if (!hasProxyRoutes && manifest.length === 0) return null;
                             const downloadCsv = () => {
                                 const blob = new Blob([buildBitwardenCsv(manifest)], { type: 'text/csv' });

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/app/actions/onboarding';
 import { generateLocalKey } from '@/app/actions/ssh';
 import { fetchTemplates, fetchReadme, fetchTemplateYaml, fetchTemplateVariables, fetchTemplateConfigFiles, fetchTemplatePostDeployScript } from '@/app/actions';
+import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getNodes } from '@/app/actions/system';
 import { Template, VariableMeta } from '@/lib/registry';
 import {
@@ -745,13 +746,14 @@ export default function OnboardingWizard() {
         const matches = yaml.matchAll(/\{\{\s*([\w\d_]+)\s*\}\}/g);
         for (const match of matches) vars.add(match[1]);
         const meta = await fetchTemplateVariables(item.name, selectedStack?.source || 'Built-in');
+        const templateLabel = parseTemplateLabel(yaml);
         if (meta) {
           // First template that declares a variable owns it for grouping —
           // shared vars (LLDAP_ADMIN_PASSWORD, LLDAP_HOST, ...) live under
           // the originator and are inherited by other templates' YAMLs.
           for (const [key, value] of Object.entries(meta)) {
             if (!allMeta[key]) {
-              allMeta[key] = { ...value, templateName: item.name };
+              allMeta[key] = { ...value, templateName: item.name, templateLabel };
             }
           }
         }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -980,12 +980,6 @@ export default function OnboardingWizard() {
     // hung for 3 min on a container that was never going to start.
     const deployed: { name: string; checked: boolean }[] = [];
 
-    // Templates that supplied a post-deploy.py \u2014 for those we skip the
-    // hardcoded helpers in postInstall.ts (the script handles credentials,
-    // admin seeding, etc. for that service). See templates/<name>/post-deploy.py
-    // and the script-protocol comment in lib/registry.ts.
-    const templatesWithScript = new Set<string>();
-
     // Credentials parsed from `__SB_CREDENTIAL__ {json}` markers the scripts
     // emit on stdout \u2014 appended to the SAVE-THESE-NOW banner at the end.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1054,9 +1048,8 @@ export default function OnboardingWizard() {
           Mustache.escape = (text: string) => text;
           postDeployScript = Mustache.render(raw, view);
           Mustache.escape = savedEscape2;
-          templatesWithScript.add(item.name);
         }
-      } catch { /* template ships no script — fall through to hardcoded helpers */ }
+      } catch { /* template ships no post-deploy script — that's fine, no per-service glue runs */ }
 
       // Variables exported as env vars to the script. Scoped to string-shaped
       // entries; the engine in ServiceManager handles bash-quote escaping.
@@ -1160,22 +1153,19 @@ export default function OnboardingWizard() {
       }
     }
 
-    // Post-install (LLDAP seed, ABS/Navidrome/FileBrowser admin seed, OIDC
-    // client registration, NPM bootstrap, proxy-host creation) runs only
-    // for services that actually deployed cleanly. A failed deploy is
-    // dropped from `deployed` above so its post-install steps don't hang
+    // Post-install (NPM bootstrap, proxy-host creation, credentials banner)
+    // runs only for services that actually deployed cleanly. A failed deploy
+    // is dropped from `deployed` above so its post-install steps don't hang
     // on a container that was never going to start.
     //
-    // `skipDefaults` lets per-template post-deploy.py scripts replace the
-    // hardcoded helpers in postInstall.ts. `extraCredentials` are the
-    // entries those scripts emitted via `__SB_CREDENTIAL__` markers, to
-    // be appended to the final SAVE-THESE-NOW banner.
+    // `extraCredentials` are the `__SB_CREDENTIAL__` entries each template's
+    // post-deploy.py emitted on stdout, appended to the SAVE-THESE-NOW
+    // banner alongside the variable-driven OIDC entries.
     const proxyResult = await runPostInstall({
       selected: deployed,
       variables: varsBase,
       node: stackSelectedNode || undefined,
       onLog: (msg) => setStackLogs(prev => [...prev, msg]),
-      skipDefaults: templatesWithScript,
       extraCredentials: scriptCredentials,
     });
 
@@ -2481,9 +2471,8 @@ export default function OnboardingWizard() {
                                 const domain = stackVariables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
                                 const subdomains = stackVariables.filter(v => v.meta?.type === 'subdomain' && v.value);
                                 const hasProxyRoutes = domain && subdomains.length > 0;
-                                const selected = stackItems.filter(i => i.checked && !i.alreadyInstalled);
                                 const host = typeof window !== 'undefined' ? window.location.hostname : '<server-ip>';
-                                const manifest = buildCredentialsManifest({ selected, variables: stackVariables, host });
+                                const manifest = buildCredentialsManifest({ variables: stackVariables, host });
                                 const downloadCsv = () => {
                                     const blob = new Blob([buildBitwardenCsv(manifest)], { type: 'text/csv' });
                                     const a = document.createElement('a');

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -290,6 +290,12 @@ export interface VariableMeta {
    * used by the UI to group the configure step by service.
    */
   templateName?: string;
+  /**
+   * Friendly display label for the template that first declared this
+   * variable, read from `metadata.annotations['servicebay.label']` in the
+   * template.yml. Set alongside templateName by the wizard / installer.
+   */
+  templateLabel?: string;
 }
 
 export async function getTemplateVariables(name: string, source?: string): Promise<Record<string, VariableMeta> | null> {

--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -162,13 +162,16 @@ export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
     if (!secretVar) continue;
     const secret = get(v, secretVar);
     if (!secret) continue;
+    // `clientSecretVar` means the secret is wired into the container env
+    // (e.g. SSO_CLIENT_SECRET) — there's nothing to paste into a UI. The
+    // entry exists only for disaster recovery / cross-stack restoration.
     out.push({
       service: `${oidc.client_name || oidc.client_id} OIDC client_secret`,
       url: domain ? `https://auth.${domain}` : 'auth.<domain>',
       username: oidc.client_id,
       password: secret,
       importance: 'system',
-      notes: `Paste into ${oidc.client_name || oidc.client_id} Settings → Authentication → OIDC client_secret to enable SSO.`,
+      notes: 'Wired into the container env (SSO_CLIENT_SECRET) automatically — save for disaster recovery only.',
     });
   }
 

--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -6,8 +6,12 @@
  *  - the credentials table on the Done step
  *  - the Bitwarden-CSV export so users can bulk-import into Vaultwarden
  *
- * The list is built from the wizard's own variables array, so secrets the
- * user override-typed survive into the export.
+ * Almost every entry is contributed by a template's post-deploy.py via
+ * `__SB_CREDENTIAL__` markers — those are merged in by the wizard before
+ * calling buildCredentialsManifest. The only entries this module
+ * generates itself are the OIDC client_secret system entries, derived
+ * from variables[].meta.oidcClient.clientSecretVar — that part is
+ * variable-driven (no per-template knowledge) so it stays here.
  */
 
 import type { StackVariable } from './postInstall';
@@ -30,130 +34,26 @@ export interface Credential {
 }
 
 interface BuildOpts {
-  selected: { name: string }[];
   variables: StackVariable[];
   /** Hostname or IP the user is browsing ServiceBay through. Used to build
    *  reachable URLs in the manifest. Empty string falls back to the
    *  `<server-ip>` placeholder. */
   host?: string;
-  /** Templates whose post-deploy.py emitted their own credential markers.
-   *  This builder skips its hardcoded branches for those stacks so the
-   *  SAVE-THESE-NOW banner doesn't double-list the same entry once from
-   *  the script (via `__SB_CREDENTIAL__`) and once from here. */
-  skipDefaults?: Set<string>;
 }
 
 const get = (vars: StackVariable[], name: string): string | undefined =>
   vars.find(v => v.name === name)?.value;
 
 export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
-  const { variables: v, skipDefaults } = opts;
-  const handled = (n: string): boolean => skipDefaults?.has(n) ?? false;
-  const isSelected = (n: string) => opts.selected.some(i => i.name === n) && !handled(n);
-  const host = opts.host || '<server-ip>';
+  const { variables: v } = opts;
   const out: Credential[] = [];
 
-  // LLDAP + Authelia live in the merged 'auth' stack now; the variables
-  // and credentials shapes are unchanged, only the gating template name.
-  if (isSelected('auth')) {
-    const port = get(v, 'LLDAP_PORT') || '17170';
-    const password = get(v, 'LLDAP_ADMIN_PASSWORD');
-    if (password) {
-      out.push({
-        service: 'LLDAP (User Directory)',
-        url: `http://${host}:${port}`,
-        username: 'admin',
-        password,
-        importance: 'critical',
-        notes: 'Manage users + groups here. Required to add family members.',
-      });
-    }
-  }
-
-  if (isSelected('nginx-web')) {
-    const adminPort = get(v, 'NGINX_ADMIN_PORT') || '81';
-    const email = get(v, 'NGINX_ADMIN_EMAIL') || 'admin@servicebay.local';
-    const password = get(v, 'NGINX_ADMIN_PASSWORD');
-    if (password) {
-      out.push({
-        service: 'Nginx Proxy Manager',
-        url: `http://${host}:${adminPort}`,
-        username: email,
-        password,
-        importance: 'critical',
-        notes: 'Reverse-proxy admin. Needed for SSL cert renewal + access lists.',
-      });
-    }
-  }
-
-  if (isSelected('adguard')) {
-    const port = get(v, 'ADGUARD_ADMIN_PORT') || '8083';
-    const username = get(v, 'ADGUARD_ADMIN_USER') || 'admin';
-    const password = get(v, 'ADGUARD_ADMIN_PASSWORD');
-    if (password) {
-      out.push({
-        service: 'AdGuard Home',
-        url: `http://${host}:${port}`,
-        username,
-        password,
-        importance: 'critical',
-        notes: 'DNS console. Add custom rewrites + manage blocklists.',
-      });
-    }
-  }
-
-  // Audiobookshelf + Navidrome live in the merged 'media' stack now.
-  if (isSelected('media')) {
-    const absPort = get(v, 'ABS_PORT') || '13378';
-    const absUser = get(v, 'ABS_ADMIN_USER') || 'root';
-    const absPassword = get(v, 'ABS_ADMIN_PASSWORD');
-    if (absPassword) {
-      out.push({
-        service: 'Audiobookshelf',
-        url: `http://${host}:${absPort}`,
-        username: absUser,
-        password: absPassword,
-        importance: 'critical',
-        notes: 'Library manager. Mobile apps use this credential too.',
-      });
-    }
-
-    const ndPort = get(v, 'NAVIDROME_PORT') || '4533';
-    const ndUser = get(v, 'NAVIDROME_ADMIN_USER') || 'admin';
-    const ndPassword = get(v, 'NAVIDROME_ADMIN_PASSWORD');
-    if (ndPassword) {
-      out.push({
-        service: 'Navidrome',
-        url: `http://${host}:${ndPort}`,
-        username: ndUser,
-        password: ndPassword,
-        importance: 'critical',
-        notes: 'Music server. Symfonium / Subsonic clients use this too.',
-      });
-    }
-  }
-
-  if (isSelected('file-share')) {
-    const username = get(v, 'SHARE_USER') || 'samba';
-    const password = get(v, 'SHARE_PASSWORD');
-    if (password) {
-      out.push({
-        service: 'Samba (file-share)',
-        url: `\\\\${host}\\data`,
-        username,
-        password,
-        importance: 'critical',
-        notes: 'Windows network drive. Type once per PC when mounting.',
-      });
-    }
-  }
-
-  // ─── system-internal secrets (rarely needed, kept for DR) ────────────
-
-  // OIDC client secrets — derive entirely from variables[].meta.oidcClient so
-  // the client_id "username" stays in lock-step with templates/.../variables.json.
-  // Previously this section hardcoded `username: 'audiobookshelf'`, which is
-  // exactly the kind of dual-source-of-truth duplication we're trying to kill.
+  // OIDC client_secret entries — derived entirely from
+  // variables[].meta.oidcClient.clientSecretVar so the username
+  // (client_id) stays in lock-step with templates/.../variables.json.
+  // `clientSecretVar` means the secret is wired into the container env
+  // (e.g. SSO_CLIENT_SECRET) — there's nothing to paste into a UI. The
+  // entry exists only for disaster recovery / cross-stack restoration.
   const domain = get(v, 'PUBLIC_DOMAIN');
   for (const sv of v) {
     const oidc = sv.meta?.oidcClient;
@@ -162,9 +62,6 @@ export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
     if (!secretVar) continue;
     const secret = get(v, secretVar);
     if (!secret) continue;
-    // `clientSecretVar` means the secret is wired into the container env
-    // (e.g. SSO_CLIENT_SECRET) — there's nothing to paste into a UI. The
-    // entry exists only for disaster recovery / cross-stack restoration.
     out.push({
       service: `${oidc.client_name || oidc.client_id} OIDC client_secret`,
       url: domain ? `https://auth.${domain}` : 'auth.<domain>',
@@ -173,35 +70,6 @@ export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
       importance: 'system',
       notes: 'Wired into the container env (SSO_CLIENT_SECRET) automatically — save for disaster recovery only.',
     });
-  }
-
-  // Vaultwarden's OIDC entry is emitted by the variable-driven loop above.
-  // The only Vaultwarden-specific bit is the SSO_ENABLED hint, which we
-  // append to the matching existing entry rather than duplicate the whole
-  // credential. This keeps client_id sourced from variables.json and avoids
-  // the dual source-of-truth that the consistency test now forbids.
-  if (isSelected('vaultwarden')) {
-    const enabled = get(v, 'VAULTWARDEN_SSO_ENABLED') === 'true';
-    const entry = out.find(c => /Vaultwarden OIDC/i.test(c.service));
-    if (entry) {
-      entry.notes = enabled
-        ? 'SSO is enabled. Already wired into the container env (SSO_CLIENT_SECRET) — no manual paste needed.'
-        : 'SSO is OFF. To enable: flip VAULTWARDEN_SSO_ENABLED=true and redeploy.';
-    }
-  }
-
-  if (isSelected('auth')) {
-    const seed = get(v, 'LLDAP_JWT_SECRET');
-    if (seed) {
-      out.push({
-        service: 'LLDAP JWT secret',
-        url: 'env: LLDAP_JWT_SECRET',
-        username: '—',
-        password: seed,
-        importance: 'system',
-        notes: 'Signs LLDAP user sessions. Save for disaster recovery — without it old browser cookies become invalid after a restore.',
-      });
-    }
   }
 
   return out;

--- a/src/lib/stackInstall/groupVariables.ts
+++ b/src/lib/stackInstall/groupVariables.ts
@@ -1,19 +1,7 @@
 import type { StackVariable } from './postInstall';
 
-/** Friendly display names for templates that show up grouped in the UI. */
-const DISPLAY_NAMES: Record<string, string> = {
-  'nginx-web': 'Nginx Proxy Manager',
-  'auth': 'Auth (LLDAP + Authelia)',
-  'adguard': 'AdGuard Home (DNS)',
-  'vaultwarden': 'Vaultwarden (Passwords)',
-  'immich': 'Immich (Photos)',
-  'media': 'Media (Audiobookshelf + Navidrome)',
-  'file-share': 'File Share (Syncthing + Samba + FileBrowser)',
-  'home-assistant': 'Home Assistant',
-};
-
 export interface VariableGroup {
-  /** Internal template key (e.g. "lldap") or "_global" / "_shared". */
+  /** Internal template key (e.g. "lldap") or "_global" / "_other". */
   key: string;
   /** User-facing display name. */
   label: string;
@@ -28,7 +16,10 @@ export interface VariableGroup {
  *
  * - Variables marked `global: true` go into the special `_global` bucket,
  *   which the UI renders read-only at the top.
- * - Variables whose `meta.templateName` is set are grouped by that name.
+ * - Variables whose `meta.templateName` is set are grouped by that name;
+ *   the section's display label comes from `meta.templateLabel` (read at
+ *   collection time from the template.yml's
+ *   `metadata.annotations['servicebay.label']`).
  * - Anything else (legacy templates without origin tagging) lands in
  *   `_other` so it stays visible to the user.
  *
@@ -45,12 +36,19 @@ export function groupVariablesByTemplate(variables: StackVariable[]): VariableGr
     v.meta?.type === 'rsa-private' ||
     v.meta?.type === 'bcrypt';
 
+  // Track the friendly label per group key, captured from the first
+  // variable that declares one. Per group, every variable should agree
+  // on the label since they share a templateName.
   const groups = new Map<string, StackVariable[]>();
+  const labels = new Map<string, string>();
   for (const v of variables) {
     if (isHidden(v)) continue; // never displayed
     const key = v.global ? '_global' : (v.meta?.templateName || '_other');
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key)!.push(v);
+    if (v.meta?.templateLabel && !labels.has(key)) {
+      labels.set(key, v.meta.templateLabel);
+    }
   }
 
   // Stable ordering: globals first, then services in declaration order
@@ -65,7 +63,7 @@ export function groupVariablesByTemplate(variables: StackVariable[]): VariableGr
   for (const [key, vars] of groups) {
     result.push({
       key,
-      label: DISPLAY_NAMES[key] || key,
+      label: labels.get(key) || key,
       variables: vars,
     });
   }

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -6,6 +6,19 @@
  * the two install entry points behaviourally identical — every change lands
  * once and applies to both flows.
  *
+ * Per-template glue (credential surfacing, admin seeding, etc.) lives in
+ * each template's `post-deploy.py` script. The engine only keeps logic
+ * that genuinely needs core access:
+ *   - NPM bootstrap (returns a tri-state used by the wizard credential
+ *     prompt — a script can't cleanly express that)
+ *   - Cross-template proxy-host aggregation (walks subdomain-typed vars
+ *     across every selected template)
+ *
+ * The `tests/backend/template_consistency.test.ts` "no unauthorized
+ * per-template branches" rule guards this boundary — adding a new
+ * isSelected call with a template-name literal is a build failure
+ * unless added to the test's ALLOWED list with a justifying comment.
+ *
  * The functions are UI-agnostic: state mutation is funnelled through the
  * `onLog` / `onNpmCredentialsNeeded` callbacks so the caller can render
  * however it likes.
@@ -13,7 +26,7 @@
 
 import Mustache from 'mustache';
 import type { VariableMeta } from '@/lib/registry';
-import { buildCredentialsManifest, formatCredentialsBanner } from './credentialsManifest';
+import { buildCredentialsManifest, formatCredentialsBanner, type Credential } from './credentialsManifest';
 
 /** Variable shape shared between wizard and modal. */
 export interface StackVariable {
@@ -66,37 +79,6 @@ async function waitForNpm(
   return false;
 }
 
-/** Wait for LLDAP HTTP+API to be reachable. Same heartbeat pattern. */
-async function waitForLldap(
-  host: string,
-  port: number,
-  onProgress: (msg: string) => void,
-  maxWait = 10 * 60_000,
-): Promise<boolean> {
-  const start = Date.now();
-  let lastBeat = 0;
-  while (Date.now() - start < maxWait) {
-    try {
-      const res = await fetch('/api/system/lldap/probe', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ host, port }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        if (data.reachable) return true;
-      }
-    } catch { /* keep trying */ }
-    const elapsed = Date.now() - start;
-    if (elapsed - lastBeat >= 10_000) {
-      onProgress(`Still waiting for LLDAP (${fmtElapsed(elapsed)} elapsed)...`);
-      lastBeat = elapsed;
-    }
-    await new Promise(r => setTimeout(r, 3000));
-  }
-  return false;
-}
-
 /**
  * Render Mustache placeholders inside an NPM proxyConfig (mainly the
  * `advanced_config` block, which references things like `{{PUBLIC_DOMAIN}}`
@@ -125,7 +107,7 @@ function renderProxyConfig(
 /** Build the proxy-host list from subdomain-typed variables. */
 function buildProxyHosts(variables: StackVariable[]): {
   domain: string | undefined;
-  hosts: { domain: string; forwardPort: number; service: string; proxyConfig?: unknown }[];
+  hosts: { domain: string; forwardPort: number; service: string; proxyConfig?: VariableMeta['proxyConfig'] }[];
 } {
   const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
   if (!domain) return { domain, hosts: [] };
@@ -138,7 +120,8 @@ function buildProxyHosts(variables: StackVariable[]): {
     let port = sv.meta?.proxyPort || '';
     const portVar = variables.find(v => v.name === port);
     if (portVar) port = portVar.value;
-    const service = sv.name.replace(/_SUBDOMAIN$/, '').toLowerCase().replace(/^ha$/, 'home-assistant');
+    const service = sv.meta?.templateName
+      || sv.name.replace(/_SUBDOMAIN$/, '').toLowerCase();
     return {
       domain: `${sv.value}.${domain}`,
       forwardPort: parseInt(port, 10),
@@ -209,100 +192,6 @@ export async function configureProxyRoutes(opts: ConfigureProxyOpts): Promise<Pr
   }
 }
 
-interface PersistLldapCredsOpts {
-  variables: StackVariable[];
-  onLog: (msg: string) => void;
-}
-
-/** Persist LLDAP admin credentials and log them once for the user. */
-async function persistLldapCredentials(opts: PersistLldapCredsOpts): Promise<void> {
-  const password = opts.variables.find(v => v.name === 'LLDAP_ADMIN_PASSWORD')?.value;
-  const port = opts.variables.find(v => v.name === 'LLDAP_PORT')?.value || '17170';
-  if (!password) return;
-  try {
-    await fetch('/api/system/lldap/credentials', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        url: `http://localhost:${port}`,
-        username: 'admin',
-        password,
-      }),
-    });
-    opts.onLog(`🔑 LLDAP admin (user: admin, password: ${password}) — open http://<server-ip>:${port} or via NPM. Stored in Settings → Integrations.`);
-  } catch {
-    opts.onLog(`⚠️ Could not persist LLDAP credentials. Note now: admin / ${password}`);
-  }
-}
-
-/** Just log AdGuard credentials once — config is already pre-seeded into
- *  AdGuardHome.yaml by the wizard's mustache step. */
-function logAdguardCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
-  const user = opts.variables.find(v => v.name === 'ADGUARD_ADMIN_USER')?.value || 'admin';
-  const password = opts.variables.find(v => v.name === 'ADGUARD_ADMIN_PASSWORD')?.value;
-  const port = opts.variables.find(v => v.name === 'ADGUARD_ADMIN_PORT')?.value || '8083';
-  if (!password) return;
-  opts.onLog(`🔑 AdGuard admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Note now, only shown once.`);
-}
-
-function logAudiobookshelfCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
-  const user = opts.variables.find(v => v.name === 'ABS_ADMIN_USER')?.value || 'root';
-  const password = opts.variables.find(v => v.name === 'ABS_ADMIN_PASSWORD')?.value;
-  const port = opts.variables.find(v => v.name === 'ABS_PORT')?.value || '13378';
-  if (!password) return;
-  opts.onLog(`🔑 Audiobookshelf admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Note now, only shown once.`);
-}
-
-function logFileShareCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
-  const user = opts.variables.find(v => v.name === 'SHARE_USER')?.value || 'samba';
-  const password = opts.variables.find(v => v.name === 'SHARE_PASSWORD')?.value;
-  if (!password) return;
-  opts.onLog(`🔑 Samba share (user: ${user}, password: ${password}) — mount via \\\\<server-ip>\\data on Windows or smb://<server-ip>/data on macOS. Note now, only shown once.`);
-}
-
-/** Surface OIDC client secrets that the user has to paste into a service's
- *  Settings UI (e.g. Audiobookshelf). Vaultwarden picks up its secret via
- *  env so it doesn't need a paste — only a note about how to flip the
- *  feature on. */
-function logOidcClientSecrets(opts: { selected: StackItem[]; variables: StackVariable[]; onLog: (msg: string) => void }): void {
-  const isSelected = (name: string) => opts.selected.some(i => i.name === name);
-  const domain = opts.variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
-
-  // Drive the per-service "paste this OIDC secret" hints from variable
-  // metadata so client_id never duplicates between this file and
-  // templates/.../variables.json. Variables that declare oidcClient + a
-  // clientSecretVar that resolves to a wizard-generated secret get one
-  // log line here.
-  for (const sv of opts.variables) {
-    const oidc = sv.meta?.oidcClient;
-    if (!oidc?.clientSecretVar) continue;
-    const secret = opts.variables.find(x => x.name === oidc.clientSecretVar)?.value;
-    if (!secret || !domain) continue;
-    const label = oidc.client_name || oidc.client_id;
-    opts.onLog(`🔐 ${label} OIDC: issuer=https://auth.${domain}, client_id=${oidc.client_id}, client_secret=${secret} — paste into ${label} Settings → Authentication → OIDC.`);
-  }
-
-  // Vaultwarden's SSO doesn't fit the variable.oidcClient pattern (the secret
-  // is consumed via env vars on the container, not a paste-into-UI flow), so
-  // it stays as a special case until the schema grows a dedicated field.
-  if (isSelected('vaultwarden')) {
-    const secret = opts.variables.find(v => v.name === 'VAULTWARDEN_SSO_SECRET')?.value;
-    const enabled = opts.variables.find(v => v.name === 'VAULTWARDEN_SSO_ENABLED')?.value;
-    if (secret) {
-      const status = enabled === 'true' ? 'SSO is ENABLED via env (test login then keep)' : 'SSO is OFF — flip VAULTWARDEN_SSO_ENABLED=true to enable';
-      opts.onLog(`🔐 Vaultwarden OIDC: client_secret=${secret} (${status}).`);
-    }
-  }
-}
-
-function logNavidromeCredentials(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): void {
-  const user = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_USER')?.value || 'admin';
-  const password = opts.variables.find(v => v.name === 'NAVIDROME_ADMIN_PASSWORD')?.value;
-  const port = opts.variables.find(v => v.name === 'NAVIDROME_PORT')?.value || '4533';
-  if (!password) return;
-  opts.onLog(`🔑 Navidrome admin (user: ${user}, password: ${password}) — open http://<server-ip>:${port}. Subsonic clients (Symfonium etc.) use the same credentials.`);
-}
-
 /** Bootstrap a freshly-deployed NPM: log it in with built-in defaults
  *  (admin@example.com / changeme), apply the wizard's chosen email + password
  *  via NPM's REST API, then persist them on our side. NPM does not read env
@@ -313,7 +202,10 @@ function logNavidromeCredentials(opts: { variables: StackVariable[]; onLog: (msg
  *  Idempotent: if NPM already accepts the target credentials, the endpoint
  *  short-circuits to "already_using_target" and we just persist locally.
  *  If NPM is locked to something else (stale data volume), we report the
- *  problem so the caller can hand control to the user. */
+ *  problem so the caller can hand control to the user.
+ *
+ *  This stays in the engine (rather than nginx-web/post-deploy.py) because
+ *  the tri-state result drives the wizard's NPM-credentials prompt UI. */
 async function bootstrapNpmAdmin(opts: {
   variables: StackVariable[];
   node?: string;
@@ -363,238 +255,34 @@ async function bootstrapNpmAdmin(opts: {
   }
 }
 
-/** Poll until a media server's first-run init endpoint accepts our admin
- *  payload. Retries every 5s for up to 5 minutes — enough for image pull
- *  to finish on slow connections. */
-async function seedMediaServer(opts: {
-  service: 'audiobookshelf' | 'navidrome';
-  variables: StackVariable[];
-  userVar: string;
-  passwordVar: string;
-  portVar: string;
-  defaultUser: string;
-  defaultPort: string;
-  serviceLabel: string;
-  onLog: (msg: string) => void;
-}): Promise<void> {
-  const username = opts.variables.find(v => v.name === opts.userVar)?.value || opts.defaultUser;
-  const password = opts.variables.find(v => v.name === opts.passwordVar)?.value;
-  const port = opts.variables.find(v => v.name === opts.portVar)?.value || opts.defaultPort;
-  if (!password) return;
-
-  opts.onLog(`Waiting for ${opts.serviceLabel} to start...`);
-  const start = Date.now();
-  let lastBeat = 0;
-  while (Date.now() - start < 5 * 60_000) {
-    try {
-      const res = await fetch('/api/system/media/init', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          service: opts.service,
-          host: 'localhost',
-          port: parseInt(port, 10),
-          username,
-          password,
-        }),
-      });
-      const data = await res.json();
-      if (res.ok && data.ok) {
-        opts.onLog(`✅ ${opts.serviceLabel} root user '${username}' created.`);
-        return;
-      }
-      if (res.ok && data.alreadySetup) {
-        opts.onLog(`ℹ️ ${opts.serviceLabel} already initialized — keeping existing admin. Reset manually if the password doesn't match.`);
-        return;
-      }
-      // Other errors: keep retrying — service might still be cold-starting.
-    } catch { /* not reachable yet */ }
-    const elapsed = Date.now() - start;
-    if (elapsed - lastBeat >= 10_000) {
-      opts.onLog(`Still waiting for ${opts.serviceLabel} (${fmtElapsed(elapsed)} elapsed)...`);
-      lastBeat = elapsed;
-    }
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  opts.onLog(`⚠️ ${opts.serviceLabel} did not become reachable in 5 minutes. Open http://<server-ip>:${port} and create the admin user manually.`);
-}
-
-async function seedAudiobookshelf(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {
-  return seedMediaServer({
-    service: 'audiobookshelf',
-    variables: opts.variables,
-    userVar: 'ABS_ADMIN_USER',
-    passwordVar: 'ABS_ADMIN_PASSWORD',
-    portVar: 'ABS_PORT',
-    defaultUser: 'root',
-    defaultPort: '13378',
-    serviceLabel: 'Audiobookshelf',
-    onLog: opts.onLog,
-  });
-}
-
-/** FileBrowser proxy-auth mode auto-creates user records on first SSO
- *  request, but the new account inherits non-admin defaults. Without an
- *  admin nobody can manage settings or other users — chicken-and-egg.
- *  Pre-promote one LLDAP user (default 'admin') to FileBrowser admin
- *  via the dedicated /api/system/filebrowser/init endpoint, which execs
- *  the FileBrowser CLI inside the running container. Idempotent. */
-async function seedFileBrowserAdmin(opts: { variables: StackVariable[]; node?: string; onLog: (msg: string) => void }): Promise<void> {
-  const username = opts.variables.find(v => v.name === 'FILEBROWSER_ADMIN_USER')?.value || 'admin';
-  // Give the pod a moment to start before the first exec attempt — but the
-  // real budget is in the retry loop below.
-  await new Promise(r => setTimeout(r, 8000));
-  // 36 attempts × 5 s = 3 min. The earlier 60-s budget timed out for users
-  // on slow connections where the filebrowser image pull alone can take
-  // 90 s+, leaving the wizard with the "Could not pre-seed FileBrowser
-  // admin" warning and a manual `podman exec` fallback nobody actually runs.
-  const MAX_ATTEMPTS = 36;
-  let lastBeat = 0;
-  const startedAt = Date.now();
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    try {
-      const res = await fetch('/api/system/filebrowser/init', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, node: opts.node }),
-      });
-      const data = await res.json();
-      if (res.ok && data.ok) {
-        opts.onLog(`✅ FileBrowser admin: ${username} (${data.action}) — log in via Authelia at https://files.<your-domain> to manage shares.`);
-        return;
-      }
-      // Container probably not ready yet — retry with backoff.
-    } catch { /* retry */ }
-    const elapsed = Date.now() - startedAt;
-    if (elapsed - lastBeat >= 30_000) {
-      opts.onLog(`Still waiting for FileBrowser to accept the admin seed (${fmtElapsed(elapsed)} elapsed)...`);
-      lastBeat = elapsed;
-    }
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  opts.onLog('⚠️ Could not pre-seed FileBrowser admin after 3 minutes. Run `podman exec file-share-filebrowser filebrowser users add <user> _ --perm.admin --database /database/filebrowser.db` once the pod is up.');
-}
-
-async function seedNavidrome(opts: { variables: StackVariable[]; onLog: (msg: string) => void }): Promise<void> {
-  return seedMediaServer({
-    service: 'navidrome',
-    variables: opts.variables,
-    userVar: 'NAVIDROME_ADMIN_USER',
-    passwordVar: 'NAVIDROME_ADMIN_PASSWORD',
-    portVar: 'NAVIDROME_PORT',
-    defaultUser: 'admin',
-    defaultPort: '4533',
-    serviceLabel: 'Navidrome',
-    onLog: opts.onLog,
-  });
-}
-
-interface SeedLldapOpts {
-  variables: StackVariable[];
-  onLog: (msg: string) => void;
-}
-
-/** Wait for LLDAP, then create the default admins+family groups. */
-async function seedLldap(opts: SeedLldapOpts): Promise<void> {
-  const password = opts.variables.find(v => v.name === 'LLDAP_ADMIN_PASSWORD')?.value;
-  const port = opts.variables.find(v => v.name === 'LLDAP_PORT')?.value || '17170';
-  if (!password) return;
-
-  opts.onLog('Waiting for LLDAP to start (cold-start usually < 30s)...');
-  const ready = await waitForLldap('localhost', parseInt(port, 10), opts.onLog);
-  if (!ready) {
-    opts.onLog(`⚠️ LLDAP did not respond in time. Open http://<server-ip>:${port} as admin and create groups admins+family manually.`);
-    return;
-  }
-
-  opts.onLog('Seeding LLDAP groups...');
-  try {
-    const res = await fetch('/api/system/lldap/seed', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        host: 'localhost',
-        port: parseInt(port, 10),
-        password,
-      }),
-    });
-    const data = await res.json();
-    if (res.ok) {
-      if (data.created?.length) opts.onLog(`✅ Groups created: ${data.created.join(', ')}`);
-      if (data.existing?.length) opts.onLog(`ℹ️ Groups already exist: ${data.existing.join(', ')}`);
-      if (data.failed?.length) opts.onLog(`⚠️ Failed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`);
-    } else {
-      opts.onLog(`⚠️ Could not seed LLDAP groups: ${data.error || 'unknown error'}`);
-    }
-  } catch {
-    opts.onLog('⚠️ Could not reach LLDAP to seed groups. Create admins/family manually in the LLDAP UI.');
-  }
-}
-
 interface RunPostInstallOpts {
   selected: StackItem[];
   variables: StackVariable[];
   node?: string;
   onLog: (msg: string) => void;
   /**
-   * Templates whose post-deploy.py already handled credential logging +
-   * admin seeding. Hardcoded helpers below check this set and skip per-
-   * template work that the script already did, so we don't double-emit
-   * credentials or re-call admin-init endpoints.
-   *
-   * Phase 1 — only `media` migrates. Other templates' hardcoded paths
-   * still run as before. As more templates ship post-deploy.py the
-   * branches in this function will shrink.
-   */
-  skipDefaults?: Set<string>;
-  /**
    * Credentials parsed from `__SB_CREDENTIAL__` markers a template's
    * post-deploy.py emitted on stdout. Appended to the SAVE-THESE-NOW
-   * banner alongside the hardcoded entries.
+   * banner.
    */
-  // Re-using the Credential shape from credentialsManifest without an
-  // import cycle — the entries already conform.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extraCredentials?: any[];
+  extraCredentials?: Credential[];
 }
 
 /** Orchestrate every post-install step. Returns the proxy-route status so
  *  the caller can decide whether to render the NPM-credential prompt.
  *
- *  LLDAP group seeding is **fire-and-forget**: it runs in the background
- *  while we await the proxy step. That way the NPM credentials prompt
- *  appears as soon as the proxy call returns, instead of waiting on the
- *  LLDAP cold-start (up to 10 minutes). Seed logs interleave with proxy
- *  logs in the install panel — both streams are independent. */
+ *  Per-template seed/credential-surfacing logic runs as part of each
+ *  service's post-deploy.py script during deploy (see ServiceManager.
+ *  runPostDeployScript). This function only handles cross-template
+ *  concerns: NPM bootstrap, proxy-host aggregation, and the final
+ *  credentials banner. */
 export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyResult> {
-  const { selected, variables, node, onLog, skipDefaults, extraCredentials } = opts;
+  const { selected, variables, node, onLog, extraCredentials } = opts;
   const isSelected = (name: string) => selected.some(i => i.name === name);
-  const handled = (name: string): boolean => skipDefaults?.has(name) ?? false;
 
-  // Surface credentials immediately — independent of any wait.
-  // LLDAP + Authelia live in the merged 'auth' stack now; whenever the auth
-  // stack is selected, both run together.
-  if (isSelected('auth') && !handled('auth')) {
-    await persistLldapCredentials({ variables, onLog });
-  }
-  if (isSelected('adguard') && !handled('adguard')) {
-    logAdguardCredentials({ variables, onLog });
-  }
-  // Audiobookshelf + Navidrome live in the merged 'media' stack now.
-  if (isSelected('media') && !handled('media')) {
-    logAudiobookshelfCredentials({ variables, onLog });
-    logNavidromeCredentials({ variables, onLog });
-  }
-  if (isSelected('file-share') && !handled('file-share')) {
-    logFileShareCredentials({ variables, onLog });
-  }
-  // Surface OIDC client secrets (one log line per service that needs UI
-  // configuration or has an env-flag to flip). Driven by variables[].meta
-  // so it stays template-driven regardless of skipDefaults.
-  logOidcClientSecrets({ selected, variables, onLog });
-  // NPM bootstrap is best-effort: if it fails we still want to run the rest
-  // of the post-install pipeline (LLDAP seeding, OIDC client creation, proxy
-  // routes) — the user can finish the NPM piece via the credentials prompt.
+  // NPM bootstrap is best-effort: if it fails we still want to run the
+  // proxy-route step — the user can finish the NPM piece via the
+  // credentials prompt.
   let npmBootstrap: 'ok' | 'needs_credentials' | 'skipped' = 'skipped';
   if (isSelected('nginx-web')) {
     // NPM cold-starts the SQLite schema after the container is ready, so the
@@ -604,21 +292,6 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
     onLog('Waiting for Nginx Proxy Manager to start (image pull / DB schema init can take a while)...');
     await waitForNpm(node, onLog);
     npmBootstrap = await bootstrapNpmAdmin({ variables, node, onLog });
-  }
-
-  // Kick off all "wait + initialize" tasks in the background. Their logs
-  // interleave with the proxy step's, but the proxy result returns ASAP
-  // so the NPM credentials prompt (if needed) appears responsive.
-  if (isSelected('auth') && !handled('auth')) {
-    void seedLldap({ variables, onLog }).catch(() => { /* logged inline */ });
-  }
-  if (isSelected('media') && !handled('media')) {
-    void seedAudiobookshelf({ variables, onLog }).catch(() => { /* logged inline */ });
-    void seedNavidrome({ variables, onLog }).catch(() => { /* logged inline */ });
-  }
-  // FileBrowser is now part of the file-share stack (alongside syncthing + samba).
-  if (isSelected('file-share') && !handled('file-share')) {
-    void seedFileBrowserAdmin({ variables, node, onLog }).catch(() => { /* logged inline */ });
   }
 
   // If we just bootstrapped NPM (or determined it's locked to other creds),
@@ -631,14 +304,13 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
     skipWait: npmBootstrap !== 'skipped',
   });
 
-  // Final banner — single block where every credential the user might
-  // have to remember is collected. Same data is exposed to the wizard's
-  // Done view + a Bitwarden CSV download via buildCredentialsManifest().
-  // Per-template post-deploy.py output is appended to whatever the
-  // hardcoded helpers produced for templates that haven't migrated yet.
+  // Final banner — one block collecting every credential the user may need
+  // to remember. Built from `__SB_CREDENTIAL__` markers each template's
+  // post-deploy.py emitted plus the variable-driven OIDC entries derived
+  // from variables[].meta.oidcClient.
   const host = typeof window !== 'undefined' ? window.location.hostname : '';
   const manifest = [
-    ...buildCredentialsManifest({ selected, variables, host, skipDefaults }),
+    ...buildCredentialsManifest({ variables, host }),
     ...(extraCredentials ?? []),
   ];
   formatCredentialsBanner(manifest).forEach(onLog);

--- a/src/lib/templateLabel.test.ts
+++ b/src/lib/templateLabel.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { parseTemplateLabel } from './templateLabel';
+
+describe('parseTemplateLabel', () => {
+  it('extracts a double-quoted label', () => {
+    const yaml =
+      'apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\n' +
+      '  annotations:\n' +
+      '    servicebay.label: "Foo (Bar)"\n' +
+      '    servicebay.ports: "80/tcp"\n';
+    expect(parseTemplateLabel(yaml)).toBe('Foo (Bar)');
+  });
+
+  it('extracts a single-quoted label', () => {
+    const yaml = "  annotations:\n    servicebay.label: 'My Service'\n";
+    expect(parseTemplateLabel(yaml)).toBe('My Service');
+  });
+
+  it('extracts a bare (unquoted) label', () => {
+    const yaml = '  annotations:\n    servicebay.label: Something Plain\n';
+    expect(parseTemplateLabel(yaml)).toBe('Something Plain');
+  });
+
+  it('returns undefined when the annotation is missing', () => {
+    const yaml = 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\n';
+    expect(parseTemplateLabel(yaml)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty quoted label', () => {
+    const yaml = '  annotations:\n    servicebay.label: ""\n';
+    expect(parseTemplateLabel(yaml)).toBeUndefined();
+  });
+
+  it('does not match a similarly-named key without the dot', () => {
+    const yaml = '  annotations:\n    servicebay-label: "wrong key"\n';
+    expect(parseTemplateLabel(yaml)).toBeUndefined();
+  });
+});

--- a/src/lib/templateLabel.ts
+++ b/src/lib/templateLabel.ts
@@ -1,0 +1,25 @@
+/**
+ * Extract `metadata.annotations['servicebay.label']` from a template's
+ * raw YAML content. Pure function with no Node dependencies — safe to
+ * import from client components.
+ *
+ * Why a regex instead of a YAML parser: this runs in the wizard /
+ * installer modal at variable-collection time, before the YAML is
+ * known to be parseable (the user's variables haven't been substituted
+ * yet, and our YAMLs contain `{{MUSTACHE}}` placeholders that valid
+ * YAML happens to accept as bare strings — but we don't want to
+ * couple to that). The annotation value itself is always a literal
+ * string in our templates (the consistency test enforces it), so a
+ * targeted regex is sufficient and avoids pulling js-yaml into the
+ * earliest render path.
+ */
+export function parseTemplateLabel(yamlText: string): string | undefined {
+  // Match `servicebay.label: "..."`, `servicebay.label: '...'`,
+  // or `servicebay.label: bare value` (until end of line). Anchored to
+  // an annotation-style indented line (any leading whitespace) so we
+  // don't match references inside multi-line strings or comments.
+  const re = /^\s+servicebay\.label:\s*(?:"([^"]*)"|'([^']*)'|([^\n#]+?))\s*$/m;
+  const m = re.exec(yamlText);
+  if (!m) return undefined;
+  return (m[1] ?? m[2] ?? m[3] ?? '').trim() || undefined;
+}

--- a/templates/adguard/template.yml
+++ b/templates/adguard/template.yml
@@ -6,6 +6,7 @@ metadata:
     app: adguard
     servicebay.role: dns
   annotations:
+    servicebay.label: "AdGuard Home (DNS)"
     servicebay.ports: "{{ADGUARD_ADMIN_PORT}}/tcp,53/udp,53/tcp"
     servicebay.config-mount: /opt/adguardhome/conf
 spec:

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: auth
   annotations:
+    servicebay.label: "Auth (LLDAP + Authelia)"
     servicebay.ports: "{{LLDAP_PORT}}/tcp,{{LLDAP_LDAP_PORT}}/tcp,{{AUTHELIA_PORT}}/tcp"
     # Pin the configuration.yml.mustache target to authelia's /config mount —
     # without this the wizard's path resolver would also consider lldap's

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: file-share
   annotations:
+    servicebay.label: "File Share (Syncthing + Samba + FileBrowser)"
     servicebay.ports: "8384/tcp,22000/tcp,139/tcp,445/tcp,{{FILEBROWSER_PORT}}/tcp"
     # Pin the .filebrowser.json.mustache target to filebrowser's /config
     # mount — without this the wizard's path resolver would also consider

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: home-assistant
   annotations:
+    servicebay.label: "Home Assistant"
     servicebay.ports: "8123/tcp,8091/tcp,3000/tcp,10300/tcp,10200/tcp,10400/tcp"
 spec:
   hostNetwork: true

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -4,6 +4,8 @@ metadata:
   name: immich
   labels:
     app: immich
+  annotations:
+    servicebay.label: "Immich (Photos)"
 spec:
   containers:
     - name: immich-server

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -6,6 +6,7 @@ metadata:
     app: media
     servicebay.role: media
   annotations:
+    servicebay.label: "Media (Audiobookshelf + Navidrome)"
     servicebay.ports: "{{ABS_PORT}}/tcp,{{NAVIDROME_PORT}}/tcp"
 spec:
   hostNetwork: true

--- a/templates/nginx-web/template.yml
+++ b/templates/nginx-web/template.yml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: nginx-web
     servicebay.role: reverse-proxy
+  annotations:
+    servicebay.label: "Nginx Proxy Manager"
 spec:
   containers:
   - name: nginx-proxy-manager

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: radicale
   annotations:
+    servicebay.label: "Radicale (CalDAV + CardDAV)"
     servicebay.ports: "{{RADICALE_PORT}}/tcp"
 spec:
   hostNetwork: true

--- a/templates/vaultwarden/post-deploy.py
+++ b/templates/vaultwarden/post-deploy.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `vaultwarden` stack.
+
+What this replaces (was hardcoded in src/lib/stackInstall/postInstall.ts and
+src/lib/stackInstall/credentialsManifest.ts):
+  - logOidcClientSecrets vaultwarden branch → informational log line
+    about the SSO_ENABLED state.
+  - credentialsManifest.ts vaultwarden branch that mutated the generic
+    OIDC entry's `notes` field based on VAULTWARDEN_SSO_ENABLED.
+
+The OIDC `__SB_CREDENTIAL__` entry itself is still emitted by the
+variable-driven loop in credentialsManifest.ts (it walks every
+variables[].meta.oidcClient with a clientSecretVar). That loop is
+template-agnostic, so we keep using it. The Vaultwarden-specific bit
+was always just the SSO_ENABLED-dependent note text — that lives here
+now as an install-log line, which is the moment when the operator is
+actually paying attention.
+
+Vaultwarden's OIDC secret is wired into the container env via
+SSO_CLIENT_SECRET — there's nothing to paste into a UI. The credential
+entry exists for disaster recovery only.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    secret = env("VAULTWARDEN_SSO_SECRET")
+    enabled = env("VAULTWARDEN_SSO_ENABLED") == "true"
+    domain = env("PUBLIC_DOMAIN")
+
+    if not secret:
+        # No OIDC secret generated — nothing to surface.
+        return 0
+
+    if enabled:
+        log(
+            "🔐 Vaultwarden SSO is ENABLED via env (SSO_CLIENT_SECRET is wired in). "
+            "Test login through Authelia once before relying on it."
+        )
+    else:
+        log(
+            "🔐 Vaultwarden SSO is OFF (default). "
+            "To enable: set VAULTWARDEN_SSO_ENABLED=true on this template and redeploy."
+        )
+
+    if domain:
+        log(
+            f"   OIDC issuer: https://auth.{domain} — "
+            f"client_id: vaultwarden — secret saved in the credentials banner."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -4,6 +4,8 @@ metadata:
   name: vaultwarden
   labels:
     app: vaultwarden
+  annotations:
+    servicebay.label: "Vaultwarden (Passwords)"
 spec:
   containers:
   - name: vaultwarden

--- a/tests/backend/post_deploy_runtime.test.ts
+++ b/tests/backend/post_deploy_runtime.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Runtime smoke tests for templates/<name>/post-deploy.py scripts.
+ *
+ * The actual test cases live in tests/templates/test_post_deploy.py
+ * (Python unittest, since the scripts are Python and are loaded via
+ * importlib + monkey-patched urllib for HTTP mocking — far cleaner
+ * than spawning each script as a subprocess from JS).
+ *
+ * This vitest wrapper executes the Python suite via `python3 -m
+ * unittest`, parses the output, and surfaces individual failures as
+ * vitest assertions so a developer running `npm test` sees the same
+ * green/red signal regardless of which world the failure came from.
+ *
+ * Skipped if python3 isn't available on the runner.
+ */
+
+import { execSync, spawnSync } from 'child_process';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PY_TEST = path.join(REPO_ROOT, 'tests', 'templates', 'test_post_deploy.py');
+
+function pythonAvailable(): boolean {
+  try {
+    execSync('python3 --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('post-deploy.py runtime smoke tests', () => {
+  const testFn = pythonAvailable() ? it : it.skip;
+  testFn('every script passes its unittest cases', () => {
+    const result = spawnSync(
+      'python3',
+      ['-m', 'unittest', '-v', PY_TEST],
+      { cwd: REPO_ROOT, encoding: 'utf-8' },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `Python post-deploy smoke tests failed (exit ${result.status}):\n\n` +
+        `--- stdout ---\n${result.stdout}\n` +
+        `--- stderr ---\n${result.stderr}\n`,
+      );
+    }
+    // unittest prints to stderr by default; the trailing OK confirms success.
+    expect(result.stderr).toMatch(/\nOK\b/);
+  });
+});

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -3,7 +3,7 @@
  *
  * Catches the class of bugs we hit during the file-share / home-assistant /
  * auth / media merges: a template gets renamed or merged, but `isSelected('X')`
- * / SERVICE_DEPS / DISPLAY_NAMES / getServiceFiles still references the old
+ * / SERVICE_DEPS / servicebay.label / getServiceFiles still references the old
  * name. None of those fail at compile time, only at runtime when the wizard
  * runs and the deploy step skips the seed/credential surfacing.
  *
@@ -188,20 +188,26 @@ describe('Template ↔ source-name consistency', () => {
     expect(offenders, `Stale SERVICE_DEPS entries:\n  ${offenders.join('\n  ')}`).toEqual([]);
   });
 
-  it('groupVariables.DISPLAY_NAMES keys reference real templates only', () => {
-    const groupPath = path.join(SRC_DIR, 'lib', 'stackInstall', 'groupVariables.ts');
-    const content = fs.readFileSync(groupPath, 'utf-8');
-    const block = content.match(/DISPLAY_NAMES:\s*Record<string,\s*string>\s*=\s*\{([\s\S]*?)\n\};/);
-    expect(block, 'DISPLAY_NAMES block not found').toBeTruthy();
-
-    const body = block![1];
-    const keyRe = /^\s*['"]([\w-]+)['"]\s*:/gm;
+  it('every template.yml declares a servicebay.label annotation', async () => {
+    // Friendly template labels live in the template itself
+    // (metadata.annotations['servicebay.label']), so a new template
+    // doesn't need to touch core code to get a non-default UI label.
+    // The wizard / installer modal extracts the label at variable-
+    // collection time via parseTemplateLabel(); the test exercises the
+    // same parser to guarantee consistency.
+    const { parseTemplateLabel } = await import('../../src/lib/templateLabel');
     const offenders: string[] = [];
-    let m: RegExpExecArray | null;
-    while ((m = keyRe.exec(body)) !== null) {
-      if (!templateNames.has(m[1])) offenders.push(m[1]);
+    for (const t of templates) {
+      const label = parseTemplateLabel(t.yamlContent);
+      if (!label) {
+        offenders.push(`${t.name}: parseTemplateLabel returned no label`);
+      }
     }
-    expect(offenders, `DISPLAY_NAMES keys without a matching template:\n  ${offenders.join('\n  ')}`).toEqual([]);
+    expect(
+      offenders,
+      `Templates missing the servicebay.label annotation:\n  ${offenders.join('\n  ')}\n\n` +
+      `Add \`servicebay.label: "<friendly name>"\` under metadata.annotations in template.yml.`,
+    ).toEqual([]);
   });
 });
 

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -549,6 +549,75 @@ describe('OIDC client_id single source of truth', () => {
   });
 });
 
+// ─── 10. No new per-template branches in stackInstall/ ────────────────────
+describe('stackInstall has no unauthorized per-template branches', () => {
+  // Per-template glue (credential surfacing, admin seeding, etc.) lives in
+  // each template's own post-deploy.py. The engine only keeps branches that
+  // genuinely need core knowledge — currently nginx-web's bootstrapNpmAdmin,
+  // because it returns a tri-state result that drives the wizard's
+  // credential-prompt UI (a script can't cleanly express that).
+  //
+  // Every other `isSelected('X')` is dead code or a regression in waiting.
+  // This test fails if a new template name shows up in stackInstall/* —
+  // forcing the author to either (a) extend post-deploy.py or (b) document
+  // why their case can't live in a script and add it to ALLOWED below.
+  const STACKINSTALL_DIR = path.join(SRC_DIR, 'lib', 'stackInstall');
+
+  /** Map of file → set of template names allowed to appear in
+   *  `isSelected('X')` calls. Anything else is a violation. */
+  const ALLOWED: Record<string, Set<string>> = {
+    'postInstall.ts': new Set([
+      // bootstrapNpmAdmin: returns 'needs_credentials' which drives the
+      // wizard credential-prompt UI. Cannot live in a script.
+      'nginx-web',
+      // The following are legacy hardcoded helpers gated by skipDefaults.
+      // They are dead at runtime once the corresponding post-deploy.py
+      // ships (it always does today). This list shrinks to {nginx-web}
+      // after task B in the template-separation cleanup.
+      'auth',
+      'adguard',
+      'media',
+      'file-share',
+      'vaultwarden',
+    ]),
+    'credentialsManifest.ts': new Set([
+      // Same legacy-gated branches; shrinks to {} (or {auth} for the JWT
+      // system entry, if not migrated) after task B.
+      'auth',
+      'nginx-web',
+      'adguard',
+      'media',
+      'file-share',
+      'vaultwarden',
+    ]),
+    'groupVariables.ts': new Set(),
+  };
+
+  for (const [file, allowed] of Object.entries(ALLOWED)) {
+    it(`${file}: no isSelected/get('X') calls outside the allow-list`, () => {
+      const fullPath = path.join(STACKINSTALL_DIR, file);
+      if (!fs.existsSync(fullPath)) return;
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      const re = /isSelected\(\s*['"]([\w-]+)['"]\s*\)/g;
+      const offenders: string[] = [];
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(content)) !== null) {
+        const name = m[1];
+        if (!allowed.has(name)) offenders.push(name);
+      }
+      if (offenders.length > 0) {
+        const unique = [...new Set(offenders)].sort();
+        throw new Error(
+          `${file} references template name(s) not in the allow-list: ${unique.join(', ')}\n\n` +
+          `Per-template glue should live in templates/<name>/post-deploy.py, not in core. ` +
+          `Either migrate the logic (preferred) or, if the case genuinely needs core access, ` +
+          `add the name to ALLOWED in this test with a one-line comment explaining why.`,
+        );
+      }
+    });
+  }
+});
+
 // ─── 9. post-deploy.py scripts parse as valid Python ───────────────────────
 describe('Template post-deploy.py syntax', () => {
   // The wizard executes templates/<name>/post-deploy.py on the agent host

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -564,32 +564,16 @@ describe('stackInstall has no unauthorized per-template branches', () => {
   const STACKINSTALL_DIR = path.join(SRC_DIR, 'lib', 'stackInstall');
 
   /** Map of file → set of template names allowed to appear in
-   *  `isSelected('X')` calls. Anything else is a violation. */
+   *  `isSelected(...)` calls. Anything else is a violation. */
   const ALLOWED: Record<string, Set<string>> = {
     'postInstall.ts': new Set([
-      // bootstrapNpmAdmin: returns 'needs_credentials' which drives the
-      // wizard credential-prompt UI. Cannot live in a script.
+      // bootstrapNpmAdmin returns a tri-state result that drives the
+      // wizard's NPM-credentials-prompt UI when the auto-bootstrap
+      // fails. A post-deploy.py script can't cleanly express that, so
+      // the NPM bootstrap stays in the engine.
       'nginx-web',
-      // The following are legacy hardcoded helpers gated by skipDefaults.
-      // They are dead at runtime once the corresponding post-deploy.py
-      // ships (it always does today). This list shrinks to {nginx-web}
-      // after task B in the template-separation cleanup.
-      'auth',
-      'adguard',
-      'media',
-      'file-share',
-      'vaultwarden',
     ]),
-    'credentialsManifest.ts': new Set([
-      // Same legacy-gated branches; shrinks to {} (or {auth} for the JWT
-      // system entry, if not migrated) after task B.
-      'auth',
-      'nginx-web',
-      'adguard',
-      'media',
-      'file-share',
-      'vaultwarden',
-    ]),
+    'credentialsManifest.ts': new Set(),
     'groupVariables.ts': new Set(),
   };
 

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1,0 +1,307 @@
+"""
+Smoke tests for every templates/<name>/post-deploy.py script.
+
+Each script is loaded as a module via importlib (the scripts aren't a
+Python package), urllib.request is monkey-patched to fake ServiceBay's
+HTTP responses, and main() is called with a controlled os.environ.
+
+Assertions cover:
+  - script returns 0 on the happy path
+  - expected `__SB_CREDENTIAL__ {json}` markers are emitted
+  - missing-required-env paths return early without hanging or crashing
+
+The vitest suite runs this file via subprocess in
+tests/backend/post_deploy_runtime.test.ts, so a single `npm test`
+exercises both worlds.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES_DIR = REPO_ROOT / "templates"
+
+
+def load_script(name: str):
+    """Import templates/<name>/post-deploy.py as a fresh module."""
+    path = TEMPLATES_DIR / name / "post-deploy.py"
+    spec = importlib.util.spec_from_file_location(f"_post_deploy_{name.replace('-', '_')}", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def parse_credentials(stdout: str) -> list[dict[str, Any]]:
+    """Pull out each __SB_CREDENTIAL__ {json} marker into a dict."""
+    out = []
+    for line in stdout.splitlines():
+        prefix = "__SB_CREDENTIAL__ "
+        if line.startswith(prefix):
+            out.append(json.loads(line[len(prefix):]))
+    return out
+
+
+@contextlib.contextmanager
+def run_with_env(env: dict[str, str]):
+    """Run the wrapped block with os.environ set to exactly `env` plus
+    a baseline PATH (so subprocess invocations inside the script work
+    if any). Restores the original env on exit."""
+    saved = os.environ.copy()
+    try:
+        os.environ.clear()
+        os.environ["PATH"] = saved.get("PATH", "/usr/bin:/bin")
+        os.environ.update(env)
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def fake_urlopen_factory(responses: dict[str, dict[str, Any]]):
+    """Return a function that mimics urllib.request.urlopen by looking up
+    the request URL in `responses`. Each entry: { status, body }.
+    Unmatched URLs raise URLError (treated as 'unreachable' by scripts)."""
+    import urllib.error
+
+    class FakeResponse:
+        def __init__(self, status: int, body: dict[str, Any] | None):
+            self.status = status
+            self._body = json.dumps(body or {}).encode("utf-8")
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake(req, *_a, **_kw):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for prefix, resp in responses.items():
+            if prefix in url:
+                return FakeResponse(resp["status"], resp.get("body"))
+        raise urllib.error.URLError(f"unmocked URL: {url}")
+
+    return _fake
+
+
+def capture_main(module) -> tuple[int, str]:
+    """Call module.main() with stdout captured. Returns (exit_code, stdout)."""
+    buf = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        rc = module.main()
+    finally:
+        sys.stdout = old_stdout
+    return rc, buf.getvalue()
+
+
+class AdguardScript(unittest.TestCase):
+    def test_emits_credential_when_password_set(self):
+        m = load_script("adguard")
+        env = {
+            "HOST": "192.168.1.10",
+            "ADGUARD_ADMIN_USER": "admin",
+            "ADGUARD_ADMIN_PASSWORD": "s3cret",
+            "ADGUARD_ADMIN_PORT": "8083",
+        }
+        with run_with_env(env):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        creds = parse_credentials(out)
+        self.assertEqual(len(creds), 1)
+        self.assertEqual(creds[0]["service"], "AdGuard Home")
+        self.assertEqual(creds[0]["username"], "admin")
+        self.assertEqual(creds[0]["password"], "s3cret")
+        self.assertEqual(creds[0]["url"], "http://192.168.1.10:8083")
+        self.assertIn("password: s3cret", out)
+
+    def test_no_password_skips_credential_silently(self):
+        m = load_script("adguard")
+        with run_with_env({"HOST": "h", "ADGUARD_ADMIN_PORT": "8083"}):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertEqual(parse_credentials(out), [])
+        self.assertIn("ADGUARD_ADMIN_PASSWORD missing", out)
+
+
+class NginxWebScript(unittest.TestCase):
+    def test_emits_credential_when_password_set(self):
+        m = load_script("nginx-web")
+        env = {
+            "HOST": "h",
+            "NGINX_ADMIN_PORT": "81",
+            "NGINX_ADMIN_EMAIL": "admin@example.com",
+            "NGINX_ADMIN_PASSWORD": "p4ssw0rd",
+        }
+        with run_with_env(env):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        creds = parse_credentials(out)
+        self.assertEqual(len(creds), 1)
+        self.assertEqual(creds[0]["service"], "Nginx Proxy Manager")
+        self.assertEqual(creds[0]["username"], "admin@example.com")
+        self.assertEqual(creds[0]["password"], "p4ssw0rd")
+
+    def test_no_password_returns_zero_and_emits_nothing(self):
+        m = load_script("nginx-web")
+        with run_with_env({}):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertEqual(parse_credentials(out), [])
+
+
+class VaultwardenScript(unittest.TestCase):
+    def test_sso_enabled_message(self):
+        m = load_script("vaultwarden")
+        env = {
+            "VAULTWARDEN_SSO_SECRET": "sso-secret",
+            "VAULTWARDEN_SSO_ENABLED": "true",
+            "PUBLIC_DOMAIN": "example.com",
+        }
+        with run_with_env(env):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("Vaultwarden SSO is ENABLED", out)
+        self.assertIn("https://auth.example.com", out)
+
+    def test_sso_disabled_message(self):
+        m = load_script("vaultwarden")
+        env = {
+            "VAULTWARDEN_SSO_SECRET": "sso-secret",
+            "VAULTWARDEN_SSO_ENABLED": "false",
+        }
+        with run_with_env(env):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("Vaultwarden SSO is OFF", out)
+
+    def test_no_secret_returns_zero_silently(self):
+        m = load_script("vaultwarden")
+        with run_with_env({}):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        # No secret → no log lines about SSO state
+        self.assertNotIn("Vaultwarden SSO", out)
+
+
+class AuthScript(unittest.TestCase):
+    def test_no_lldap_password_returns_early(self):
+        m = load_script("auth")
+        with run_with_env({"HOST": "h"}):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("LLDAP_ADMIN_PASSWORD missing", out)
+        # No credential markers when env is incomplete
+        self.assertEqual(parse_credentials(out), [])
+
+    def test_happy_path_with_mocked_http(self):
+        m = load_script("auth")
+        # Mock both the credential-persist endpoint and the lldap probe.
+        # The script also calls /api/system/lldap/seed at the end — mock
+        # that too.
+        responses = {
+            "/api/system/lldap/credentials": {"status": 200, "body": {"ok": True}},
+            "/api/system/lldap/probe":       {"status": 200, "body": {"reachable": True}},
+            "/api/system/lldap/seed":        {"status": 200, "body": {"created": ["admins", "family"]}},
+        }
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "LLDAP_ADMIN_PASSWORD": "lldap-pass",
+            "LLDAP_PORT": "17170",
+            "LLDAP_JWT_SECRET": "jwt-secret",
+        }
+        import urllib.request
+        with run_with_env(env), mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        creds = parse_credentials(out)
+        services = {c["service"] for c in creds}
+        self.assertIn("LLDAP (User Directory)", services)
+        self.assertIn("LLDAP JWT secret", services)
+
+
+class FileShareScript(unittest.TestCase):
+    def test_samba_credential_emitted_when_password_set(self):
+        m = load_script("file-share")
+        # FileBrowser seed runs unconditionally — give it a mocked ok-on-
+        # first-try response so the loop terminates immediately and the
+        # 3-min budget never matters.
+        responses = {
+            "/api/system/filebrowser/init": {"status": 200, "body": {"ok": True, "action": "promoted"}},
+        }
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "SHARE_USER": "smb",
+            "SHARE_PASSWORD": "shar3",
+            "FILEBROWSER_ADMIN_USER": "admin",
+            "SB_NODE": "Local",
+        }
+        # The script does time.sleep(8) before the first FB seed call.
+        # Patch sleep to a no-op for the test.
+        import urllib.request
+        import time as time_mod
+        with run_with_env(env), \
+             mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)), \
+             mock.patch.object(time_mod, "sleep", lambda _s: None):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        creds = parse_credentials(out)
+        services = {c["service"] for c in creds}
+        self.assertIn("Samba (file-share)", services)
+        self.assertIn("FileBrowser admin", out)
+
+
+class MediaScript(unittest.TestCase):
+    def test_no_passwords_emits_nothing_and_returns_zero(self):
+        m = load_script("media")
+        # No ABS_ADMIN_PASSWORD / NAVIDROME_ADMIN_PASSWORD → seed_media
+        # short-circuits, no HTTP calls.
+        with run_with_env({"HOST": "h"}):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertEqual(parse_credentials(out), [])
+        self.assertIn("no admin password", out)
+
+    def test_credentials_emitted_with_mocked_seed(self):
+        m = load_script("media")
+        responses = {
+            "/api/system/media/init": {"status": 200, "body": {"ok": True, "alreadySetup": True}},
+        }
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "ABS_ADMIN_PASSWORD": "abs-pass",
+            "ABS_PORT": "13378",
+            "NAVIDROME_ADMIN_PASSWORD": "nav-pass",
+            "NAVIDROME_PORT": "4533",
+        }
+        import urllib.request
+        with run_with_env(env), mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        services = {c["service"] for c in parse_credentials(out)}
+        self.assertIn("Audiobookshelf", services)
+        self.assertIn("Navidrome", services)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Finalizes the migration that's been in progress since the merged-stacks rework: per-template glue (credentials, admin seeding, …) now lives in `templates/<name>/post-deploy.py` and the engine no longer carries any hardcoded knowledge of built-in template names except for `nginx-web`'s NPM bootstrap (which intentionally stays — its tri-state result drives the wizard credentials prompt).

Net diff: **−530 lines of core code**, **+360 lines of tests + docs + 1 new post-deploy.py**.

## Per-commit breakdown

| Commit | Task | What |
|---|---|---|
| `987d168` | E1 | New consistency test rule blocks any new `isSelected('X')` branch in `stackInstall/` outside an explicit allow-list |
| `b425a43` | A | Add `templates/vaultwarden/post-deploy.py` (last live hardcoded branch) + fix misleading "paste into Settings" notes on env-wired OIDC clients |
| `9b6339b` | B+C | Delete every dead helper (~530 lines): `persistLldapCredentials`, `seedLldap`, `waitForLldap`, `logAdguardCredentials`, `logAudiobookshelfCredentials`, `logNavidromeCredentials`, `seedAudiobookshelf`, `seedNavidrome`, `seedMediaServer`, `logFileShareCredentials`, `seedFileBrowserAdmin`, `logOidcClientSecrets`, the per-template branches in `credentialsManifest.ts`, plus the `^ha$` rename hack (now uses `meta.templateName`). Drops `skipDefaults` from the public API. Allow-list shrinks to `{nginx-web}`. |
| `fd79ebf` | D | Move `groupVariables.ts:DISPLAY_NAMES` into `template.yml` `metadata.annotations['servicebay.label']`. New `parseTemplateLabel()` helper + 6 unit tests + consistency check that every template has a parseable label. |
| `1c3c0b8` | E2 | Per-template `post-deploy.py` smoke tests (12 cases) via Python `unittest` + importlib + monkeypatched urllib. Wrapped in a vitest test so `npm test` runs both. |
| `50a4e43` | F | New `docs/TEMPLATE_AUTHORING.md` documenting the full contract (layout, annotations, variable types, post-deploy protocol, what-stays-in-core, recipes for adding/editing templates, external registries). |

## What's left in core after this PR

The engine still carries:
- `bootstrapNpmAdmin` — tri-state result drives the wizard credential prompt; documented in code + the consistency-test allow-list comment
- `configureProxyRoutes` / `buildProxyHosts` — variable-driven walk over `subdomain`-typed vars across every selected template
- The variable-driven OIDC client_secret loop in `credentialsManifest.ts` — derives entries from `variables[].meta.oidcClient.clientSecretVar`, no per-template knowledge

Every other built-in template (`adguard`, `auth`, `file-share`, `media`, `nginx-web`, `vaultwarden`) owns its post-install glue in its own `post-deploy.py`. `immich`, `home-assistant`, `radicale` are pure-template (no post-install glue needed at all).

## Test plan

- [x] `npx vitest run` — 351 passed, 1 skipped (full suite)
- [x] `python3 -m unittest tests/templates/test_post_deploy.py -v` — 12 passed
- [x] `npx eslint` — clean on changed files
- [x] `npx tsc --noEmit` — no new errors (existing failures in unrelated test files)
- [ ] End-to-end: install each template via the wizard on a fresh FCoS box and confirm the credentials banner is correct (especially vaultwarden's SSO note and the OIDC client_secret entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)