### PR TITLE
chore: UX philosophy + remove auto-update channel

### DIFF
--- a/docs/UX_PHILOSOPHY.md
+++ b/docs/UX_PHILOSOPHY.md
@@ -1,0 +1,168 @@
+# UX philosophy: self-heal first
+
+ServiceBay's audience is family-homelab admins, often not IT experts,
+often afraid of doing something wrong. Every feature should look after
+itself wherever possible and, when human judgment is genuinely needed,
+present **clearly-labelled choices with consequences** rather than raw
+error messages.
+
+This document codifies that. Every PR that adds a new error path, a new
+checkbox, or a new "please retry" message should pass the principles
+below before merge.
+
+## The hierarchy
+
+When something goes wrong, walk down this list. Stop at the first that
+applies:
+
+### 1. Heal silently when possible
+
+If retry fixes it, retry. If a fixed sleep can become a readiness
+probe, make it a probe. The user doesn't need to know there was a
+problem.
+
+Examples:
+- **Auto-retry transient deploy failures.** Image-pull flakes,
+  registry rate-limits, and NPM cold-start 502s are common and
+  transient. Try N times with exponential backoff before declaring
+  failure.
+- **Replace fixed sleeps with readiness probes.** `sleep(8)` becomes
+  *poll until `podman pod inspect <name>` reports `Running`*.
+- **Tag first-boot errors as bootstrap.** A fresh agent emits a few
+  errors during install-time (Python install race, RAID setup output
+  on stderr) — those don't belong in the visible error counter.
+
+### 2. Surface unavoidable input through diagnose probes with structured `actions[]`
+
+When the system genuinely needs the human to choose, route it through
+the **diagnose** UI. Each probe ships:
+
+```ts
+{
+  id: 'npm_data_stale',
+  label: 'Nginx Proxy Manager admin credentials',
+  status: 'fail',
+  detail: 'NPM is rejecting auto-generated credentials — likely stale data from a previous install.',
+  actions: [
+    {
+      id: 'reset_volume',
+      label: 'Reset NPM and reinstall',
+      description: 'Wipes the proxy-host database and admin user, recreates from scratch.',
+      destructive: true,
+    },
+    {
+      id: 'use_existing',
+      label: 'I know the existing NPM password',
+      description: 'Enter the credentials NPM is actually using.',
+    },
+  ],
+}
+```
+
+Multiple actions when several solutions exist. The user picks the path
+that matches their comfort level — there isn't always one right answer.
+
+Each action is a button. Clicking it executes the named effect on the
+server. Destructive actions show a confirm-on-destructive guard.
+
+**Anti-patterns that violate this rule:**
+- "⚠️ Could not seed FileBrowser admin after 3 minutes. Run `podman exec
+  file-share-filebrowser filebrowser users add <user> _ --perm.admin
+  --database /database/filebrowser.db` once the pod is up." → Should be
+  a probe with a "Re-run post-install" action.
+- "Failed to install X" with no retry option → Should be a probe with
+  "Retry deploy / Show logs / Skip this service".
+- "NPM did not accept the wizard credentials. Please enter your NPM
+  admin credentials below." → Should be a probe with both options
+  (reset volume vs. enter existing creds), each with consequences.
+
+### 3. Hide expert-only knobs
+
+If less than 5% of users would meaningfully change a setting, give it
+a sensible default and don't surface it. Asking is a footgun for the
+other 95% — they have to evaluate a choice they can't evaluate.
+
+Examples:
+- **Auto-update channels (`stable | test | dev`)** — removed entirely.
+  Stable is what everyone wants; the others were dev-team artefacts
+  that never reached production users.
+- **Anything that requires reading source to understand.** If the
+  description has to mention "Quadlet" or "rpm-ostree" or "kube YAML
+  annotation," it's expert-only.
+- **Knobs whose default is fine forever.** `agent.processCleanup.maxAgeMinutes`,
+  `gracefulShutdownTimeout`. Hide unless a user reports a problem the
+  knob solves.
+
+When unsure: ship without the knob. Adding one later is easy; removing
+one is painful.
+
+### 4. Default to safe
+
+The non-IT-expert default has to *just work*. Decisions that require
+information the user might not have should get a safe fallback, not a
+required input.
+
+- **Local-only mode is the default** when `PUBLIC_DOMAIN` is empty.
+  Don't block the install on "you must enter a domain." Render a
+  persistent "🏠 Local-only" badge; flip later when the user is ready.
+- **Encrypted-at-rest credential persistence > "save now or lose
+  forever".** The data already lives in container env / kube YAML; an
+  encrypted manifest in `config.json` plus a clear "I saved these,
+  wipe from server" action is strictly safer than a one-shot banner
+  the user might miss.
+- **Auto-retry > immediate fail** for any operation that talks to a
+  recently-cold-started container, registry, or external API.
+
+### 5. User-facing language, not infra language
+
+Probe text and action labels are read by people who don't know what a
+Quadlet is. Phrase fixes in user terms.
+
+Bad: *"DELETE /var/lib/postgresql/data and restart the pod"*
+Good: *"Reset Immich's database and start over (you'll lose any
+photos you've uploaded — typically nothing on a fresh install)"*
+
+Bad: *"systemctl --user restart vaultwarden.service"*
+Good: *"Restart Vaultwarden"*
+
+Bad: *"OIDC client_secret rotation requires Authelia config reload"*
+Good: *"Generate a new SSO secret for this app (apps using SSO will
+need to log in again once)"*
+
+## Concrete checklist for new PRs
+
+Before merging code that adds a new error path, ask yourself:
+
+- [ ] Can this auto-heal? Have I tried at least one retry / readiness
+  probe / fallback before surfacing?
+- [ ] If user input is needed, am I surfacing it through a diagnose
+  probe with `actions[]`, not a raw error message?
+- [ ] Does each action have a description that says what will happen,
+  including consequences (data loss, downtime, restart)?
+- [ ] Are destructive actions marked `destructive: true` so the UI
+  guards them with a confirm step?
+- [ ] If I'm adding a checkbox / dropdown / config field — is it
+  actually expert-only? Could a default + diagnose probe replace it?
+- [ ] Does the user-facing text use service names ("Vaultwarden") and
+  outcomes ("you'll lose uploaded photos"), not infra nouns
+  ("Quadlet," "Pod," "PVC")?
+
+## Where this gets enforced
+
+- This document, linked from the repo root README + every relevant
+  ServiceBay code-review checklist.
+- Auto-memory entry in the project's Claude memory bank — future agent
+  sessions auto-apply the principles without re-reading the doc.
+- Tracking issue: **"Self-healing UX rollout"** on GitHub, where the
+  per-task PRs that bring the existing surface into compliance are
+  linked and checked off.
+
+## Where this came from
+
+The PRs landing in autumn 2026 against `chore/finalize-template-separation`
+and the audit conversation that followed. The trigger was a fresh
+install with broken pre-pull progress, NPM credential prompts that
+pre-filled values that just failed, and a credentials banner shown
+once in a log the user could close. The diagnosis was: "the system
+should look after itself; when it can't, it should offer fixes — not
+explain what's wrong."

--- a/src/app/(dashboard)/settings/_lib/helpers.ts
+++ b/src/app/(dashboard)/settings/_lib/helpers.ts
@@ -29,7 +29,6 @@ export interface AppUpdateStatus {
     autoUpdate: {
       enabled: boolean;
       schedule: string;
-      channel?: 'stable' | 'test' | 'dev';
     };
   };
 }

--- a/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
@@ -128,29 +128,6 @@ export default function UpdatesSection() {
     }
   };
 
-  const handleChannelChange = async (newChannel: 'stable' | 'test' | 'dev') => {
-    if (!appUpdate) return;
-    try {
-      const res = await fetch('/api/system/update', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'configure',
-          autoUpdate: {
-            enabled: appUpdate.config.autoUpdate.enabled,
-            channel: newChannel,
-          },
-        }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setAppUpdate(prev => (prev ? { ...prev, config: data.config } : null));
-        addToast('success', 'Release channel updated', `Switched to ${newChannel} channel. Check for updates to apply.`);
-      }
-    } catch {
-      addToast('error', 'Failed to update release channel');
-    }
-  };
 
   if (!appUpdate) {
     return (
@@ -173,19 +150,6 @@ export default function UpdatesSection() {
             <p className="text-xs text-gray-500 dark:text-gray-400">Manage application updates</p>
           </div>
           <div className="ml-auto flex items-center gap-4">
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-gray-500 dark:text-gray-400">Channel:</span>
-              <select
-                value={appUpdate.config.autoUpdate.channel || 'stable'}
-                onChange={e => handleChannelChange(e.target.value as 'stable' | 'test' | 'dev')}
-                className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded px-2 py-1 text-xs focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none cursor-pointer"
-              >
-                <option value="stable">Stable</option>
-                <option value="test">Test</option>
-                <option value="dev">Dev</option>
-              </select>
-            </div>
-            <div className="h-4 w-px bg-gray-300 dark:bg-gray-600"></div>
             <button
               onClick={handleCheckUpdate}
               disabled={checkingUpdate || updateStatus === 'updating'}

--- a/src/app/(dashboard)/settings/backups/page.tsx
+++ b/src/app/(dashboard)/settings/backups/page.tsx
@@ -1376,7 +1376,7 @@ export default function BackupsSettingsPage() {
                           { key: 'notifications' as const, label: 'Notifications', summary: restorePreview.config.notifications ? `${restorePreview.config.notifications.host || 'SMTP'} → ${(restorePreview.config.notifications.to || []).join(', ') || 'no recipients'}` : 'Not configured' },
                           { key: 'templateSettings' as const, label: 'Template settings', summary: restorePreview.config.templateSettings.length === 0 ? 'None' : `${restorePreview.config.templateSettings.length} key${restorePreview.config.templateSettings.length !== 1 ? 's' : ''}` },
                           { key: 'logLevel' as const, label: 'Log level', summary: restorePreview.config.logLevel || 'default' },
-                          { key: 'update' as const, label: 'Auto-update', summary: restorePreview.config.update ? `${restorePreview.config.update.channel || 'stable'}${restorePreview.config.update.enabled === false ? ' (disabled)' : ''}` : 'Not configured' },
+                          { key: 'update' as const, label: 'Auto-update', summary: restorePreview.config.update ? (restorePreview.config.update.enabled === false ? 'Disabled' : 'Enabled') : 'Not configured' },
                         ]).map(item => (
                           <label key={item.key} className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-200 py-1">
                             <input type="checkbox" className="rounded" checked={restoreSelectionState.configFlags[item.key]} onChange={() => toggleRestoreConfigFlag(item.key)} />

--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -100,7 +100,6 @@ export async function saveAutoUpdateConfig(enabled: boolean) {
     config.autoUpdate = {
         ...config.autoUpdate,
         enabled,
-        channel: 'stable'
     };
     await saveConfig(config);
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -105,7 +105,6 @@ export interface AppConfig {
   autoUpdate: {
     enabled: boolean;
     schedule: string; // Cron syntax, e.g. "0 0 * * *" for midnight
-    channel: 'stable' | 'test' | 'dev';
     /**
      * Last version we emailed the operator about. Used to dedupe so the
      * update notifier sends one email per release, not one per check tick.
@@ -213,13 +212,11 @@ const DEFAULT_CONFIG: AppConfig = {
     }
   },
   autoUpdate: {
-    // Auto-update on the stable channel by default for fresh installs. The
-    // home-lab use case strongly prefers "stays patched on its own" over
-    // "asks before every minor security release." Users can flip this off
-    // in Settings → System.
+    // Auto-update by default for fresh installs. The home-lab use case
+    // strongly prefers "stays patched on its own" over "asks before every
+    // minor security release." Users can flip this off in Settings → System.
     enabled: true,
     schedule: '0 0 * * *', // Daily at midnight
-    channel: 'stable'
   }
 };
 

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -935,7 +935,6 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     autoUpdate: z.object({
       enabled: z.boolean().optional(),
       schedule: z.string().optional(),
-      channel: z.enum(['stable', 'test', 'dev']).optional(),
     }).partial().optional(),
     templateSettings: z.record(z.string(), z.string()).optional(),
   }).strict();

--- a/src/lib/systemBackup.ts
+++ b/src/lib/systemBackup.ts
@@ -88,7 +88,6 @@ export interface BackupPreviewConfig {
     update?: {
         enabled?: boolean;
         schedule?: string;
-        channel?: string;
     };
 }
 
@@ -771,7 +770,6 @@ export async function previewSystemBackup(archivePath: string): Promise<BackupPr
             update: backupConfig?.autoUpdate ? {
                 enabled: backupConfig.autoUpdate.enabled,
                 schedule: backupConfig.autoUpdate.schedule,
-                channel: backupConfig.autoUpdate.channel
             } : undefined
         };
 


### PR DESCRIPTION
## Summary

Lays the foundation for the **Self-healing UX rollout** that follows.

- **`docs/UX_PHILOSOPHY.md`** — codifies the principles:
  1. Heal silently when possible (auto-retry, readiness probes).
  2. Surface unavoidable input through diagnose probes with structured `actions[]`.
  3. Hide expert-only knobs (<5% of users → default, no dropdown).
  4. Default to safe (local-only > forced public domain, encrypted persistence > "save now or lose forever").
  5. User-facing language, not infra nouns.

- **First application of rule 3:** removed the auto-update `channel` field (`stable | test | dev`). It was a dev-team artefact that reached production users as an unexplained dropdown. Stripped from config schema, settings UI, helper types, onboarding default, MCP `update_config` schema, backup snapshot, and restore preview.

The philosophy doc is referenced from the project's auto-memory so future Claude sessions auto-apply it without re-reading. A separate "Self-healing UX rollout" tracking issue (linked from this PR) breaks the rest of the rollout into per-task PRs.

## Test plan

- [x] `npx vitest run` — 340 passed, 1 skipped
- [x] `npx eslint` — clean on changed files
- [x] `npx tsc --noEmit` — no new errors
- [ ] After merge: open the master tracking issue with section A/B/C tasks as checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)