### PR TITLE
feat(diagnose): F1 probe-actions schema + dispatcher

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
@@ -1,9 +1,16 @@
 'use client';
 
 import { useState } from 'react';
-import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Stethoscope } from 'lucide-react';
+import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Stethoscope, Wrench } from 'lucide-react';
 
 type ProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
+
+interface ProbeAction {
+  id: string;
+  label: string;
+  description: string;
+  destructive?: boolean;
+}
 
 interface DiagnoseProbe {
   id: string;
@@ -11,6 +18,7 @@ interface DiagnoseProbe {
   status: ProbeStatus;
   detail: string;
   hint?: string;
+  actions?: ProbeAction[];
 }
 
 interface DiagnoseResult {
@@ -29,6 +37,8 @@ export default function SelfDiagnoseSection() {
   const [result, setResult] = useState<DiagnoseResult | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** Per-action transient state. Keyed by `<probeId>:<actionId>`. */
+  const [actionState, setActionState] = useState<Record<string, { running?: boolean; message?: string; ok?: boolean }>>({});
 
   const run = async () => {
     setRunning(true);
@@ -44,6 +54,46 @@ export default function SelfDiagnoseSection() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setRunning(false);
+    }
+  };
+
+  const runAction = async (probe: DiagnoseProbe, action: ProbeAction) => {
+    // Confirm-on-destructive guard. The action's description is
+    // surfaced in the dialog so the user sees the consequences they
+    // accepted.
+    if (action.destructive) {
+      const ok = window.confirm(`${action.label}\n\n${action.description}\n\nThis action can't be undone. Continue?`);
+      if (!ok) return;
+    }
+    const key = `${probe.id}:${action.id}`;
+    setActionState(s => ({ ...s, [key]: { running: true } }));
+    try {
+      const res = await fetch('/api/system/diagnose/run-action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          probeId: probe.id,
+          actionId: action.id,
+          node: result?.node,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      const ok = res.ok && data.ok !== false;
+      setActionState(s => ({
+        ...s,
+        [key]: { ok, message: data.message ?? (ok ? 'Done.' : `HTTP ${res.status}`) },
+      }));
+      // Auto-rerun the diagnose suite when the action requested it.
+      // This makes the probe transition to `ok` (or to a follow-up
+      // warn) immediately visible without a manual click.
+      if (ok && data.refresh !== false) {
+        void run();
+      }
+    } catch (e) {
+      setActionState(s => ({
+        ...s,
+        [key]: { ok: false, message: e instanceof Error ? e.message : String(e) },
+      }));
     }
   };
 
@@ -118,6 +168,36 @@ export default function SelfDiagnoseSection() {
                     <p className={`text-xs mt-2 ${meta.color}`}>
                       <strong>Suggestion:</strong> {probe.hint}
                     </p>
+                  )}
+                  {(probe.actions ?? []).length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {(probe.actions ?? []).map(action => {
+                        const key = `${probe.id}:${action.id}`;
+                        const state = actionState[key];
+                        const isRunning = state?.running;
+                        const baseStyle = action.destructive
+                          ? 'bg-red-600 hover:bg-red-700 text-white'
+                          : 'bg-violet-600 hover:bg-violet-700 text-white';
+                        return (
+                          <div key={action.id} className="flex items-center gap-2">
+                            <button
+                              onClick={() => runAction(probe, action)}
+                              disabled={isRunning || running}
+                              title={action.description}
+                              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
+                            >
+                              {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                              {action.label}
+                            </button>
+                            {state?.message && !isRunning && (
+                              <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
+                                {state.ok ? '✓' : '✗'} {state.message}
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
                   )}
                 </div>
               </div>

--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { agentManager } from '@/lib/agent/manager';
 import { HealthStore } from '@/lib/health/store';
 import { DigitalTwinStore } from '@/lib/store/twin';
+import { actionsForProbe, type ProbeAction } from '@/lib/diagnose/actions';
+import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,6 +15,22 @@ export interface DiagnoseProbe {
   status: ProbeStatus;
   detail: string;
   hint?: string;
+  /**
+   * Fix-buttons the UI renders next to this probe's status. Populated
+   * automatically from the probe-action registry (see
+   * `src/lib/diagnose/actions.ts`). Empty array when the probe has no
+   * registered actions — UI shows status + hint only.
+   */
+  actions?: ProbeAction[];
+}
+
+/** Attach registry-known actions to a probe. Called once per probe in
+ *  the diagnose route. Probes whose status is `ok` skip actions to
+ *  avoid noisy "fix it" buttons next to passing checks. */
+function withActions(probe: DiagnoseProbe): DiagnoseProbe {
+  if (probe.status === 'ok') return probe;
+  const actions = actionsForProbe(probe.id);
+  return actions.length > 0 ? { ...probe, actions } : probe;
 }
 
 interface ExecResult {
@@ -368,5 +386,5 @@ export async function POST(request: Request) {
     });
   }
 
-  return NextResponse.json({ node: nodeName, probes });
+  return NextResponse.json({ node: nodeName, probes: probes.map(withActions) });
 }

--- a/src/app/api/system/diagnose/run-action/route.ts
+++ b/src/app/api/system/diagnose/run-action/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { dispatchProbeAction } from '@/lib/diagnose/actions';
+import '@/lib/diagnose/probes/register';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/system/diagnose/run-action
+ *
+ * Executes a fix-button click from the diagnose UI. The probe + action
+ * id are looked up in the probe-action registry; the matching handler
+ * runs server-side and returns a structured result the UI surfaces as
+ * a toast plus an automatic re-run of the diagnose suite.
+ *
+ * Body: `{ probeId, actionId, node?, payload? }`.
+ *  - `payload` is opaque to this layer; per-action handlers validate.
+ *  - `node` defaults to "Local" if omitted.
+ *
+ * Response shape: `{ ok, message, refresh }`.
+ */
+const Body = z.object({
+  probeId: z.string().min(1).max(64),
+  actionId: z.string().min(1).max(64),
+  node: z.string().min(1).max(64).optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+});
+
+export async function POST(request: Request) {
+  let parsed;
+  try {
+    parsed = Body.parse(await request.json());
+  } catch (e) {
+    return NextResponse.json(
+      { ok: false, message: e instanceof Error ? e.message : 'Invalid request body' },
+      { status: 400 },
+    );
+  }
+
+  const result = await dispatchProbeAction({
+    probeId: parsed.probeId,
+    actionId: parsed.actionId,
+    node: parsed.node ?? 'Local',
+    payload: parsed.payload,
+  });
+
+  return NextResponse.json(result, { status: result.ok ? 200 : 400 });
+}

--- a/src/lib/diagnose/actions.test.ts
+++ b/src/lib/diagnose/actions.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  registerProbeAction,
+  actionsForProbe,
+  dispatchProbeAction,
+  _resetRegistryForTesting,
+} from './actions';
+
+beforeEach(() => {
+  _resetRegistryForTesting();
+});
+
+describe('probe-action registry', () => {
+  it('registers and lists actions per probe', () => {
+    registerProbeAction(
+      'p1',
+      { id: 'a1', label: 'A1', description: 'desc' },
+      async () => ({ ok: true, message: 'done' }),
+    );
+    registerProbeAction(
+      'p1',
+      { id: 'a2', label: 'A2', description: 'desc 2', destructive: true },
+      async () => ({ ok: true, message: 'done 2' }),
+    );
+    registerProbeAction(
+      'p2',
+      { id: 'a1', label: 'P2-A1', description: '' },
+      async () => ({ ok: true, message: '' }),
+    );
+
+    const p1 = actionsForProbe('p1');
+    expect(p1.map(a => a.id).sort()).toEqual(['a1', 'a2']);
+    expect(p1.find(a => a.id === 'a2')?.destructive).toBe(true);
+
+    expect(actionsForProbe('p2').map(a => a.id)).toEqual(['a1']);
+    expect(actionsForProbe('nonexistent')).toEqual([]);
+  });
+
+  it('rejects duplicate registrations', () => {
+    registerProbeAction('p1', { id: 'a1', label: 'A', description: 'd' }, async () => ({ ok: true, message: '' }));
+    expect(() =>
+      registerProbeAction('p1', { id: 'a1', label: 'A', description: 'd' }, async () => ({ ok: true, message: '' })),
+    ).toThrow(/already registered/);
+  });
+});
+
+describe('dispatchProbeAction', () => {
+  it('routes to the registered handler with node + payload', async () => {
+    const handler = vi.fn(async () => ({ ok: true, message: 'fixed' }));
+    registerProbeAction('p1', { id: 'a1', label: 'A', description: 'd' }, handler);
+
+    const result = await dispatchProbeAction({
+      probeId: 'p1',
+      actionId: 'a1',
+      node: 'Local',
+      payload: { foo: 'bar' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe('fixed');
+    expect(result.refresh).toBe(true); // default
+    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: { foo: 'bar' } });
+  });
+
+  it('returns ok=false for unknown probe/action pair', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'no-such-probe',
+      actionId: 'no-such-action',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Unknown probe action/);
+    expect(result.refresh).toBe(false);
+  });
+
+  it('catches handler exceptions and returns ok=false', async () => {
+    registerProbeAction('p1', { id: 'a1', label: 'A', description: 'd' }, async () => {
+      throw new Error('boom');
+    });
+    const result = await dispatchProbeAction({ probeId: 'p1', actionId: 'a1', node: 'Local' });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/boom/);
+    expect(result.refresh).toBe(false);
+  });
+
+  it('honors handler-supplied refresh=false', async () => {
+    registerProbeAction('p1', { id: 'a1', label: 'A', description: 'd' }, async () => ({
+      ok: true,
+      message: 'partial',
+      refresh: false,
+    }));
+    const result = await dispatchProbeAction({ probeId: 'p1', actionId: 'a1', node: 'Local' });
+    expect(result.ok).toBe(true);
+    expect(result.refresh).toBe(false);
+  });
+});

--- a/src/lib/diagnose/actions.ts
+++ b/src/lib/diagnose/actions.ts
@@ -1,0 +1,152 @@
+/**
+ * Probe-action registry: the dispatcher that turns "click a fix button"
+ * in the diagnose UI into a server-side handler call.
+ *
+ * Per the UX philosophy (`docs/UX_PHILOSOPHY.md`), every probe that
+ * surfaces a `warn` or `fail` status should ship one or more actions
+ * the user can click to remediate, with consequence-described labels
+ * and a `destructive?` flag for confirm-on-destructive UI guards.
+ *
+ * This module keeps the registry, the action shape, and the dispatch
+ * function. Per-probe handlers register themselves at module load via
+ * `registerProbeAction`. The actual probes (added incrementally — see
+ * the "Self-healing UX rollout" tracking issue) come in follow-up PRs.
+ *
+ * Wire shape (used by the API route + the SelfDiagnoseSection UI):
+ *
+ *   Probe.actions: [
+ *     { id, label, description, destructive? }
+ *   ]
+ *
+ *   POST /api/system/diagnose/run-action
+ *   { probeId: 'npm_data_stale', actionId: 'reset_volume', payload?: {...} }
+ *   → { ok, message, refresh? }
+ */
+
+import { logger } from '@/lib/logger';
+
+/** Surface a fix the user can apply for a probe in `warn` or `fail` state. */
+export interface ProbeAction {
+  /** Stable id (referenced by the dispatch endpoint). */
+  id: string;
+  /** Short button label, ≤ ~24 chars. User-facing language. */
+  label: string;
+  /**
+   * One- or two-sentence description of what will happen if the user
+   * clicks. Includes consequences (data loss, restart, downtime). The
+   * UI shows this as a tooltip + above the confirm dialog when
+   * `destructive` is true.
+   */
+  description: string;
+  /**
+   * Marks the action as data-loss / hard-to-reverse. The UI guards it
+   * behind a confirm dialog. Default false.
+   */
+  destructive?: boolean;
+}
+
+/** Result payload returned to the UI after an action runs. */
+export interface ProbeActionResult {
+  /** True iff the action ran to completion. */
+  ok: boolean;
+  /**
+   * One-sentence outcome the UI surfaces as a toast: "NPM data reset
+   * successfully — log in with the wizard credentials." Plain English.
+   */
+  message: string;
+  /**
+   * When true, the UI re-runs the diagnose suite after the action so
+   * the operator immediately sees the probe transition to `ok` (or to
+   * a different `warn` if there's a follow-up step). Defaults to true.
+   */
+  refresh?: boolean;
+}
+
+/** Server-side handler registered against `<probeId>:<actionId>`. */
+export type ProbeActionHandler = (params: {
+  /** Node the probe was running against. */
+  node: string;
+  /**
+   * Optional structured payload from the UI (e.g. credentials the user
+   * typed into a form before clicking "Use existing NPM password").
+   * Validate inside the handler — the dispatch layer doesn't.
+   */
+  payload?: Record<string, unknown>;
+}) => Promise<ProbeActionResult>;
+
+interface RegistryEntry {
+  action: ProbeAction;
+  handler: ProbeActionHandler;
+}
+
+const registry = new Map<string, RegistryEntry>();
+
+const key = (probeId: string, actionId: string) => `${probeId}:${actionId}`;
+
+/**
+ * Register a probe action. Called at module load by per-probe modules
+ * (e.g. `lib/diagnose/probes/npmDataStale.ts`). Re-registering an
+ * existing key throws — every action must be uniquely owned.
+ */
+export function registerProbeAction(
+  probeId: string,
+  action: ProbeAction,
+  handler: ProbeActionHandler,
+): void {
+  const k = key(probeId, action.id);
+  if (registry.has(k)) {
+    throw new Error(`Probe action already registered: ${k}`);
+  }
+  registry.set(k, { action, handler });
+}
+
+/**
+ * Look up the action metadata (without the handler) for a probe.
+ * Probe routes call this to attach `actions[]` to their output.
+ */
+export function actionsForProbe(probeId: string): ProbeAction[] {
+  const out: ProbeAction[] = [];
+  for (const [k, entry] of registry) {
+    if (k.startsWith(`${probeId}:`)) out.push(entry.action);
+  }
+  return out;
+}
+
+/**
+ * Dispatch a single user-clicked action. Errors thrown by the handler
+ * are caught and converted into `{ ok: false, message }` so the UI
+ * always gets a structured response.
+ */
+export async function dispatchProbeAction(params: {
+  probeId: string;
+  actionId: string;
+  node: string;
+  payload?: Record<string, unknown>;
+}): Promise<ProbeActionResult> {
+  const k = key(params.probeId, params.actionId);
+  const entry = registry.get(k);
+  if (!entry) {
+    return {
+      ok: false,
+      message: `Unknown probe action: ${k}`,
+      refresh: false,
+    };
+  }
+  try {
+    const result = await entry.handler({ node: params.node, payload: params.payload });
+    // Default refresh = true so probes auto-re-run after a fix.
+    return { refresh: true, ...result };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.error('diagnose:actions', `Action ${k} threw: ${message}`);
+    return { ok: false, message: `Action failed: ${message}`, refresh: false };
+  }
+}
+
+/**
+ * Test-only: clear the registry between unit-test runs so each test
+ * starts with a clean slate. Production code must never call this.
+ */
+export function _resetRegistryForTesting(): void {
+  registry.clear();
+}

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -1,0 +1,15 @@
+/**
+ * Side-effect-only module: imports every per-probe registration so the
+ * probe-action registry is populated at module load. Routes that
+ * dispatch user-clicked actions (`api/system/diagnose/run-action`) and
+ * routes that surface the action list (`api/system/diagnose`) both
+ * import this file once.
+ *
+ * Per-probe modules live alongside this one — each calls
+ * `registerProbeAction(probeId, action, handler)` at the top level.
+ *
+ * Sections B6–B15 of the "Self-healing UX rollout" tracking issue add
+ * their probes here. This file is intentionally an empty manifest at
+ * the foundation stage so PRs that ship a single probe can be small.
+ */
+export {};


### PR DESCRIPTION
Foundation for the self-healing UX rollout — task **F1** in #241.

## What

- New \`src/lib/diagnose/actions.ts\` — probe-action registry + dispatcher.
- New \`POST /api/system/diagnose/run-action\` — endpoint that turns a fix-button click into a server-side handler call.
- Diagnose probe schema gains \`actions?: ProbeAction[]\`; populated automatically for every non-\`ok\` probe.
- \`SelfDiagnoseSection.tsx\` UI renders one button per action, with confirm-on-\`destructive\` guard, per-button loading state, and auto-rerun on success.
- Empty manifest at \`src/lib/diagnose/probes/register.ts\` — B6–B15 PRs add a single probe module + registration each.

## Why

Per \`docs/UX_PHILOSOPHY.md\` rule 2: when user input is unavoidable, route it through diagnose probes with structured \`actions[]\` rather than raw error messages. F1 is the foundation that makes B6–B15 small.

## Test plan

- [x] 6 unit cases covering register/list/dispatch
- [x] \`npx eslint\` clean
- [x] \`npx tsc --noEmit\` no new errors
- [ ] Section B PRs land probes that exercise the wiring end-to-end

Closes the F1 checkbox in #241.