### PR TITLE
feat(ui): persistent Local-only mode badge in header (A5)

### DIFF
--- a/src/app/api/system/mode/route.ts
+++ b/src/app/api/system/mode/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getConfig } from '@/lib/config';
+import { isLocalOnly } from '@/lib/mode';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/system/mode
+ *
+ * Classifies the install mode for the dashboard header badge.
+ * Currently exposes:
+ *   - localOnly: true when no `reverseProxy.publicDomain` is set —
+ *     services run on local IP:port only; SSO + HTTPS proxy paths
+ *     are skipped automatically.
+ *
+ * Cheap and cacheable (no agent calls). Read on every page load by
+ * `LocalOnlyBadge`.
+ */
+export async function GET() {
+  const config = await getConfig();
+  return NextResponse.json({
+    localOnly: isLocalOnly(config),
+    publicDomain: config.reverseProxy?.publicDomain ?? null,
+  });
+}

--- a/src/components/LocalOnlyBadge.tsx
+++ b/src/components/LocalOnlyBadge.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Home } from 'lucide-react';
+
+/**
+ * Persistent header badge that surfaces "Local-only mode" — the install
+ * has no public domain configured, so services run on local IP:port,
+ * SSO is off, and the reverse-proxy / OIDC paths are skipped. Without
+ * this badge users can spend a confused minute wondering why their
+ * `https://photos.<domain>` link doesn't work; with it the answer is
+ * one glance away.
+ *
+ * Reads `/api/system/mode` once on mount. Cheap (no agent calls).
+ * Renders nothing while loading and nothing in non-local-only mode.
+ */
+export default function LocalOnlyBadge() {
+  const [localOnly, setLocalOnly] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/system/mode')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => { if (!cancelled) setLocalOnly(Boolean(data?.localOnly)); })
+      .catch(() => { /* badge is non-essential — silently skip on error */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!localOnly) return null;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] font-medium rounded-full bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800"
+      title="No public domain set. Services run on local IP:port only — SSO, HTTPS, and reverse-proxy paths are off. Open Settings → Reverse Proxy to set a domain."
+    >
+      <Home size={11} />
+      <span className="hidden sm:inline">Local-only</span>
+    </span>
+  );
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import PluginHelp from './PluginHelp';
 import ConnectionIndicator from './ConnectionIndicator';
+import LocalOnlyBadge from './LocalOnlyBadge';
 
 interface PageHeaderProps {
   title: string;
@@ -49,6 +50,7 @@ export default function PageHeader({ title, children, actions, showBack = false,
 
       <div className={`flex items-center gap-3 shrink-0 ${children ? '' : 'ml-auto'}`}>
         {actions}
+        <LocalOnlyBadge />
         <ConnectionIndicator inline />
       </div>
     </div>

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -1,0 +1,17 @@
+import type { AppConfig } from '@/lib/config';
+
+/**
+ * "Local-only mode" — a runtime classification we derive from config so
+ * the rest of the app can branch on a single boolean rather than
+ * scattering `if (!publicDomain)` checks. True iff there is no
+ * `reverseProxy.publicDomain` set; in that case ServiceBay skips
+ * Authelia / OIDC auto-registration, NPM proxy-host creation, and any
+ * step that assumes services are reachable on a public hostname.
+ *
+ * Pure function, no I/O, no network. Safe to call from server actions
+ * and from server-rendered components alike.
+ */
+export function isLocalOnly(config: Pick<AppConfig, 'reverseProxy'>): boolean {
+  const domain = config.reverseProxy?.publicDomain;
+  return !domain || domain.trim() === '';
+}


### PR DESCRIPTION
Section **A5** of #241. Adds a small "🏠 Local-only" badge to PageHeader when no public domain is set, plus the `isLocalOnly()` helper + `/api/system/mode` endpoint. Behavioral skips (proxy-host creation, OIDC registration) already worked via existing `!domain` checks; this PR just surfaces the mode.