### PR TITLE
chore(templates): English sweep + VariableMeta.example field (C17)

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -2313,7 +2313,7 @@ export default function OnboardingWizard() {
                                                             setStackVariables(newVars);
                                                         }}
                                                         className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-md text-sm"
-                                                        placeholder={v.meta?.default ? `Default: ${v.meta.default}` : `Value for ${v.name}`}
+                                                        placeholder={v.meta?.example ? `e.g. ${v.meta.example}` : (v.meta?.default ? `Default: ${v.meta.default}` : `Value for ${v.name}`)}
                                                     />
                                                 )}
                                             </div>

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -274,6 +274,15 @@ export interface VariableMeta {
   type?: 'text' | 'password' | 'secret' | 'rsa-private' | 'bcrypt' | 'select' | 'device' | 'subdomain';
   description?: string;
   default?: string;
+  /**
+   * Concrete example value shown next to the input in the Configure
+   * step (small grey hint text). Use for fields whose `description`
+   * tells the user *what* but not what a *valid value looks like* —
+   * URLs, e-mail addresses, fully-qualified domains, etc. Distinct
+   * from `default` because we don't want to pre-fill every field
+   * with example data the user then has to remember to change.
+   */
+  example?: string;
   options?: string[];
   devicePath?: string;
   /** For subdomain type: variable name referencing the target port, or a literal port number */

--- a/templates/vaultwarden/variables.json
+++ b/templates/vaultwarden/variables.json
@@ -6,12 +6,13 @@
   },
   "VAULTWARDEN_DOMAIN": {
     "type": "text",
-    "description": "Public URL (z.B. https://vault.example.com)",
-    "default": ""
+    "description": "Public URL where Vaultwarden will be reachable, e.g. https://vault.example.com. Auto-derived from VAULTWARDEN_SUBDOMAIN + PUBLIC_DOMAIN at install time — leave blank unless you want to override.",
+    "default": "",
+    "example": "https://vault.example.com"
   },
   "VAULTWARDEN_SIGNUPS": {
     "type": "select",
-    "description": "Registrierungen erlauben",
+    "description": "Allow new users to create accounts on the Vaultwarden web UI directly. Leave 'true' on first install so you can register your own account; flip to 'false' afterwards to lock the family-only vault down.",
     "options": ["true", "false"],
     "default": "true"
   },


### PR DESCRIPTION
Section **C17** of #241. Translates the two German leftovers in vaultwarden/variables.json + flesh-out the descriptions. Adds optional `example` field to VariableMeta that the wizard renders as `placeholder="e.g. …"`. Distinct from `default` so we don't pre-fill fields with sample data the user has to remember to change.