### PR TITLE
feat(wizard): rename 'Install a Stack' → 'Install services' (C16)

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -439,12 +439,23 @@ export default function OnboardingWizard() {
       setAvailableStacks(stacks);
       setStackNodes(nodes);
       if (nodes.length === 1) setStackSelectedNode(nodes[0].Name);
+      // Single-stack-only installs (the common case — only `full-stack`
+      // ships built-in) should skip the picker step; the user has
+      // nothing to choose. Auto-select it so they land directly in
+      // the per-service checkbox grid.
+      if (stacks.length === 1 && !selectedStack) {
+        await handleSelectStack(stacks[0]);
+      }
     } catch {
       // Stacks not available yet, that's OK
       setAvailableStacks([]);
     } finally {
       setStacksLoading(false);
     }
+    // handleSelectStack + selectedStack referenced in the auto-select
+    // branch — they don't change identity within a wizard run, so
+    // omitting from deps is safe and avoids a re-loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -1402,7 +1413,7 @@ export default function OnboardingWizard() {
              );
            })()}
            {stacksOnlyMode && (
-             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Choose a service stack to deploy on your new server.</p>
+             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Choose which services to install on your new server.</p>
            )}
         </div>
 
@@ -1888,12 +1899,12 @@ export default function OnboardingWizard() {
 
             {currentStep === 'stacks' && (
                 <div className="space-y-4">
-                    <h3 className="font-semibold text-lg flex items-center gap-2"><Layers className="w-5 h-5 text-indigo-500"/> Install a Stack</h3>
+                    <h3 className="font-semibold text-lg flex items-center gap-2"><Layers className="w-5 h-5 text-indigo-500"/> Install services</h3>
 
                     {stackInstallStep === 'select' && (
                         <>
                             <p className="text-sm text-gray-500">
-                                Choose a pre-configured stack to install, or skip this step and install services later from the Registry.
+                                Pick a curated set of services to install. You&apos;ll choose which ones from the set on the next step. (Or skip and install individual services later from the Registry.)
                             </p>
                             {stacksLoading ? (
                                 <div className="flex items-center justify-center py-8 text-gray-400">

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -241,7 +241,7 @@ describe('OnboardingWizard', () => {
             await waitFor(() => {
                 // Header h2 contains "Install Services"
                 expect(screen.getAllByText(/Install Services/i).length).toBeGreaterThan(0);
-                expect(screen.getByText(/Choose a service stack/i)).toBeDefined();
+                expect(screen.getByText(/Choose which services/i)).toBeDefined();
             });
             // Should NOT show the full setup welcome
             expect(screen.queryByText(/Welcome to ServiceBay/i)).toBeNull();
@@ -252,7 +252,7 @@ describe('OnboardingWizard', () => {
 
             render(<OnboardingWizard />);
 
-            await waitFor(() => screen.getByText(/Choose a service stack/i));
+            await waitFor(() => screen.getByText(/Choose which services/i));
             // Progress bar shows "Step X of Y" — should not be present
             expect(screen.queryByText(/Step \d+ of \d+/)).toBeNull();
         });


### PR DESCRIPTION
Section **C16** of #241. User-facing string sweep — wizard now talks about "services" instead of "stacks" (internal vocabulary that wasn't reaching family-homelab users meaningfully). Plus auto-selects the single bundled stack so the picker step is skipped when there's only one to choose from.