### PR TITLE
feat(templates): infrastructure-tier flag + locked wizard include (D19-PR1)

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -19,6 +19,7 @@ import { fetchTemplates, fetchReadme, fetchTemplateYaml, fetchTemplateVariables,
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getNodes } from '@/app/actions/system';
 import { Template, VariableMeta } from '@/lib/registry';
+import type { TemplateTier } from '@/lib/templateTier';
 import {
   runPostInstall,
   configureProxyRoutes as sharedConfigureProxyRoutes,
@@ -67,6 +68,13 @@ interface StackItem {
   yaml?: string;
   alreadyInstalled?: boolean;
   configFiles?: ConfigFile[];
+  /**
+   * Platform vs feature classification, parsed from the template's
+   * `metadata.annotations['servicebay.tier']`. Defaults to 'feature'.
+   * Infrastructure-tier templates are auto-included by the wizard
+   * with their checkbox locked-on; users pick features on top.
+   */
+  tier?: TemplateTier;
 }
 
 /** Fetch names of services already deployed on the target node */
@@ -182,6 +190,11 @@ export default function OnboardingWizard() {
 
   // Stack Selection
   const [availableStacks, setAvailableStacks] = useState<Template[]>([]);
+  /** name → tier map of every template (not just stacks). Populated by
+   *  loadStacks(), used by handleSelectStack to mark each StackItem as
+   *  'infrastructure' or 'feature' so the wizard can lock-include the
+   *  platform tier. See `src/lib/templateTier.ts`. */
+  const [templateTiers, setTemplateTiers] = useState<Map<string, TemplateTier>>(new Map());
   const [selectedStack, setSelectedStack] = useState<Template | null>(null);
   const [stackItems, setStackItems] = useState<StackItem[]>([]);
   const [stackVariables, setStackVariables] = useState<Variable[]>([]);
@@ -438,6 +451,15 @@ export default function OnboardingWizard() {
       const [templates, nodes] = await Promise.all([fetchTemplates(), getNodes()]);
       const stacks = templates.filter(t => t.type === 'stack');
       setAvailableStacks(stacks);
+      // Cache per-template tier info so handleSelectStack can decorate
+      // its parsed stackItems with `tier` lookups instead of re-fetching
+      // each template.yml on stack-pick. Templates list is small (~10
+      // entries), the lookup is one-off per install.
+      const tiers = new Map<string, 'infrastructure' | 'feature'>();
+      for (const t of templates.filter(t => t.type === 'template')) {
+        tiers.set(t.name, t.tier ?? 'feature');
+      }
+      setTemplateTiers(tiers);
       setStackNodes(nodes);
       if (nodes.length === 1) setStackSelectedNode(nodes[0].Name);
       // Single-stack-only installs (the common case — only `full-stack`
@@ -699,7 +721,14 @@ export default function OnboardingWizard() {
           parsedItems.push({
             name,
             description: match[3]?.trim() || undefined,
-            checked: !isInstalled && match[1].toLowerCase() === 'x',
+            // Infrastructure-tier templates (adguard, nginx, auth) are
+            // always installed — force-checked regardless of the
+            // README's [x] / [ ] state. Users pick features; the
+            // platform is non-negotiable. See #258 / #249.
+            tier: templateTiers.get(name) ?? 'feature',
+            checked: templateTiers.get(name) === 'infrastructure'
+              ? !isInstalled
+              : (!isInstalled && match[1].toLowerCase() === 'x'),
             alreadyInstalled: isInstalled,
           });
         }
@@ -2074,7 +2103,37 @@ export default function OnboardingWizard() {
                                 </div>
                             ) : (
                                 <div className="space-y-2">
-                                    {stackItems.map((item, i) => (
+                                    {/* Platform-tier templates render as a small
+                                        read-only block above the feature checkboxes —
+                                        users always get DNS / proxy / auth and can't
+                                        opt out. Per the design conversation in #249. */}
+                                    {stackItems.some(i => i.tier === 'infrastructure') && (
+                                        <div className="p-3 border border-indigo-200 dark:border-indigo-800/60 bg-indigo-50 dark:bg-indigo-900/10 rounded">
+                                            <div className="text-[11px] uppercase font-bold text-indigo-700 dark:text-indigo-300 mb-1.5">
+                                                Platform · always installed
+                                            </div>
+                                            <div className="flex flex-wrap gap-1.5">
+                                                {stackItems.filter(i => i.tier === 'infrastructure').map(item => (
+                                                    <span
+                                                        key={item.name}
+                                                        className="text-xs font-medium px-2 py-0.5 rounded bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-indigo-200 dark:border-indigo-800/60"
+                                                        title={item.description ?? ''}
+                                                    >
+                                                        {item.name}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                            <p className="text-[11px] text-indigo-700/80 dark:text-indigo-300/70 mt-1.5">
+                                                DNS, reverse proxy, and SSO are part of every install. Pick your features below.
+                                            </p>
+                                        </div>
+                                    )}
+                                    {stackItems.filter(i => i.tier !== 'infrastructure').map((item) => {
+                                        // Find this item's index in the master array
+                                        // so the checkbox onChange mutates the right
+                                        // entry. Filtering only changes render order.
+                                        const i = stackItems.findIndex(x => x.name === item.name);
+                                        return (
                                         <label key={item.name} className={`flex items-start gap-3 p-3 border rounded transition-colors ${
                                             item.alreadyInstalled
                                                 ? 'border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/10'
@@ -2157,7 +2216,8 @@ export default function OnboardingWizard() {
                                                 )}
                                             </div>
                                         </label>
-                                    ))}
+                                        );
+                                    })}
                                 </div>
                             )}
 

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -28,6 +28,13 @@ export interface Template {
   url: string;
   type: 'template' | 'stack';
   source: string;
+  /**
+   * Platform vs feature classification. Read from each template.yml's
+   * `metadata.annotations['servicebay.tier']`. `undefined` for stacks
+   * and for templates without the annotation (treated as 'feature' by
+   * the wizard). See `src/lib/templateTier.ts`.
+   */
+  tier?: 'infrastructure' | 'feature';
 }
 
 export interface TemplateSettingsSchemaEntry {
@@ -59,6 +66,28 @@ export async function getTemplateSettingsSchema(): Promise<Record<string, Templa
     }
 }
 
+/**
+ * Extract `servicebay.tier` from a template.yml. Returns 'feature' on
+ * any failure mode (missing file, unparseable YAML, missing
+ * annotation) — that matches the wizard's default-to-feature rule.
+ * Stacks have no tier.
+ */
+async function readTemplateTier(itemDir: string, type: 'template' | 'stack'): Promise<'infrastructure' | 'feature' | undefined> {
+  if (type === 'stack') return undefined;
+  try {
+    const yaml = await fs.readFile(path.join(itemDir, 'template.yml'), 'utf-8');
+    // Same regex as parseTemplateTier in src/lib/templateTier.ts —
+    // duplicated here because that module is client-safe (no fs) and
+    // we don't want to import from server code into it.
+    const m = /^\s+servicebay\.tier:\s*(?:"([^"]*)"|'([^']*)'|([^\n#]+?))\s*$/m.exec(yaml);
+    const raw = (m ? (m[1] ?? m[2] ?? m[3] ?? '') : '').trim();
+    if (raw === 'infrastructure') return 'infrastructure';
+    return 'feature';
+  } catch {
+    return 'feature';
+  }
+}
+
 async function fetchDir(dirPath: string, type: 'template' | 'stack', source: string): Promise<Template[]> {
   try {
     // Check if directory exists
@@ -69,16 +98,20 @@ async function fetchDir(dirPath: string, type: 'template' | 'stack', source: str
     }
 
     const items = await fs.readdir(dirPath, { withFileTypes: true });
-    
-    return items
-        .filter(item => item.isDirectory() && !item.name.startsWith('.'))
-        .map(item => ({
+    const directories = items.filter(item => item.isDirectory() && !item.name.startsWith('.'));
+
+    return await Promise.all(directories.map(async item => {
+        const itemPath = path.join(dirPath, item.name);
+        const tier = await readTemplateTier(itemPath, type);
+        return {
             name: item.name,
-            path: path.join(dirPath, item.name),
+            path: itemPath,
             url: '', // No URL for local files
             type,
-            source
-        }));
+            source,
+            tier,
+        };
+    }));
   } catch (e) {
       console.error(`Error fetching ${type}s from ${source}:`, e);
       return [];

--- a/src/lib/templateTier.test.ts
+++ b/src/lib/templateTier.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseTemplateTier, isInfrastructureTier } from './templateTier';
+
+describe('parseTemplateTier', () => {
+  it('extracts infrastructure when annotated', () => {
+    const yaml =
+      '  annotations:\n    servicebay.tier: "infrastructure"\n    servicebay.ports: "80/tcp"\n';
+    expect(parseTemplateTier(yaml)).toBe('infrastructure');
+  });
+
+  it('extracts feature when annotated explicitly', () => {
+    expect(parseTemplateTier('  annotations:\n    servicebay.tier: feature\n')).toBe('feature');
+  });
+
+  it("defaults to 'feature' when annotation is missing", () => {
+    const yaml = 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\n';
+    expect(parseTemplateTier(yaml)).toBe('feature');
+  });
+
+  it("defaults to 'feature' for unrecognized values", () => {
+    expect(parseTemplateTier('  annotations:\n    servicebay.tier: "wat"\n')).toBe('feature');
+  });
+
+  it('handles single quotes', () => {
+    expect(parseTemplateTier("  annotations:\n    servicebay.tier: 'infrastructure'\n")).toBe('infrastructure');
+  });
+
+  it('does not match similarly-named keys', () => {
+    expect(parseTemplateTier('  annotations:\n    servicebay-tier: "infrastructure"\n')).toBe('feature');
+  });
+});
+
+describe('isInfrastructureTier', () => {
+  it('returns true for infrastructure', () => {
+    expect(isInfrastructureTier('infrastructure')).toBe(true);
+  });
+  it('returns false for feature', () => {
+    expect(isInfrastructureTier('feature')).toBe(false);
+  });
+});

--- a/src/lib/templateTier.ts
+++ b/src/lib/templateTier.ts
@@ -1,0 +1,48 @@
+/**
+ * Extract `metadata.annotations['servicebay.tier']` from a template's
+ * raw YAML content. Mirrors `parseTemplateLabel` in shape so it can be
+ * imported from client components without dragging Node deps.
+ *
+ * Two tiers, per the design conversation in #249:
+ *
+ *   - **`infrastructure`** — auto-included by the install wizard,
+ *     locked-checked. The platform layer every install carries
+ *     (currently `adguard`, `nginx`, `auth`).
+ *   - **`feature`** — user-pickable in the wizard's checkbox grid.
+ *     Default when the annotation is missing or unrecognized.
+ *
+ * Note: a separate, pre-existing `servicebay.role` label on each
+ * template (`reverse-proxy`, `system`, `dns`, ...) is **distinct**
+ * from this tier classification — the label is consumed by service-
+ * detection code paths (network/service.ts, ServicesPlugin) for
+ * visual grouping, not by the install wizard.
+ */
+
+/** Recognized template tiers. `feature` is the implicit default. */
+export type TemplateTier = 'infrastructure' | 'feature';
+
+const KNOWN_TIERS: ReadonlySet<string> = new Set(['infrastructure', 'feature']);
+
+/**
+ * Pull the tier annotation from a template.yml string. Returns
+ * `'feature'` when the annotation is missing or unrecognized — that
+ * way new templates default to user-pickable without ceremony.
+ *
+ * Intentionally regex-based for the same reason as parseTemplateLabel:
+ * runs in client code before mustache substitution, so we don't want
+ * to require the YAML to be parseable as-is.
+ */
+export function parseTemplateTier(yamlText: string): TemplateTier {
+  const re = /^\s+servicebay\.tier:\s*(?:"([^"]*)"|'([^']*)'|([^\n#]+?))\s*$/m;
+  const m = re.exec(yamlText);
+  const raw = (m ? (m[1] ?? m[2] ?? m[3] ?? '') : '').trim();
+  if (raw && KNOWN_TIERS.has(raw)) {
+    return raw as TemplateTier;
+  }
+  return 'feature';
+}
+
+/** True iff the tier marks the template as platform-tier (always installed). */
+export function isInfrastructureTier(tier: TemplateTier): boolean {
+  return tier === 'infrastructure';
+}

--- a/templates/adguard/template.yml
+++ b/templates/adguard/template.yml
@@ -7,6 +7,7 @@ metadata:
     servicebay.role: dns
   annotations:
     servicebay.label: "AdGuard Home (DNS)"
+    servicebay.tier: "infrastructure"
     servicebay.ports: "{{ADGUARD_ADMIN_PORT}}/tcp,53/udp,53/tcp"
     servicebay.config-mount: /opt/adguardhome/conf
 spec:

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -6,6 +6,7 @@ metadata:
     app: auth
   annotations:
     servicebay.label: "Auth (LLDAP + Authelia)"
+    servicebay.tier: "infrastructure"
     servicebay.ports: "{{LLDAP_PORT}}/tcp,{{LLDAP_LDAP_PORT}}/tcp,{{AUTHELIA_PORT}}/tcp"
     # Pin the configuration.yml.mustache target to authelia's /config mount —
     # without this the wizard's path resolver would also consider lldap's

--- a/templates/nginx-web/template.yml
+++ b/templates/nginx-web/template.yml
@@ -7,6 +7,7 @@ metadata:
     servicebay.role: reverse-proxy
   annotations:
     servicebay.label: "Nginx Proxy Manager"
+    servicebay.tier: "infrastructure"
 spec:
   containers:
   - name: nginx-proxy-manager

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -608,6 +608,31 @@ describe('stackInstall has no unauthorized per-template branches', () => {
   }
 });
 
+// ─── 11. Template tier classification ─────────────────────────────────────
+describe('Template tier classification', () => {
+  // Per the design conversation in #249, every install ships with the
+  // `infrastructure`-tier templates (DNS, reverse proxy, SSO) auto-
+  // included and locked-checked. Currently three templates fill these
+  // roles. The wizard reads the tier from each template.yml's
+  // `metadata.annotations['servicebay.tier']`.
+  //
+  // Enforce that exactly the expected three templates declare
+  // `infrastructure`. Drift (a 4th infra template appearing without
+  // a design decision, or one of the three losing the annotation)
+  // is a build failure.
+  const EXPECTED_INFRA = new Set(['adguard', 'auth', 'nginx-web']); // post-rename: 'nginx'
+
+  it('exactly the platform templates are tier=infrastructure', async () => {
+    const { parseTemplateTier } = await import('../../src/lib/templateTier');
+    const infraNames = templates
+      .filter(t => parseTemplateTier(t.yamlContent) === 'infrastructure')
+      .map(t => t.name)
+      .sort();
+    const expected = [...EXPECTED_INFRA].sort();
+    expect(infraNames).toEqual(expected);
+  });
+});
+
 // ─── 9. post-deploy.py scripts parse as valid Python ───────────────────────
 describe('Template post-deploy.py syntax', () => {
   // The wizard executes templates/<name>/post-deploy.py on the agent host

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -255,13 +255,24 @@ class FileShareScript(unittest.TestCase):
             "FILEBROWSER_ADMIN_USER": "admin",
             "SB_NODE": "Local",
         }
-        # The script does time.sleep(8) before the first FB seed call.
-        # Patch sleep to a no-op for the test.
+        # The script calls wait_pod_running() which invokes subprocess.run
+        # against `podman pod inspect`; mock it to fast-return Running so
+        # the 60s readiness loop exits on the first iteration. Also patch
+        # time.sleep to a no-op (file-share keeps a few sleeps in the
+        # FB seed retry loop). See #254.
         import urllib.request
+        import subprocess as subprocess_mod
         import time as time_mod
+
+        class _FakeCompletedProcess:
+            returncode = 0
+            stdout = "Running"
+            stderr = ""
+
         with run_with_env(env), \
              mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)), \
-             mock.patch.object(time_mod, "sleep", lambda _s: None):
+             mock.patch.object(time_mod, "sleep", lambda _s: None), \
+             mock.patch.object(subprocess_mod, "run", lambda *a, **kw: _FakeCompletedProcess()):
             rc, out = capture_main(m)
         self.assertEqual(rc, 0)
         creds = parse_credentials(out)


### PR DESCRIPTION
Resolves #258. First PR in the LAN-domain mode rollout (#249).

Marks the three platform templates (`adguard`, `nginx-web`, `auth`) with `metadata.annotations['servicebay.tier']: "infrastructure"`. Wizard auto-includes them locked-checked; users pick features on top. New `parseTemplateTier()` helper mirrors `parseTemplateLabel`; `Template.tier` field populated at `fetchTemplates()` time.

## Tests
- 6 unit cases for the parser
- Consistency rule: exactly the expected 3 templates are infrastructure-tier