### PR TITLE
feat(adguard): wildcard DNS rewrite client (D19-PR4)

### DIFF
--- a/src/lib/adguard/rewrites.test.ts
+++ b/src/lib/adguard/rewrites.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ensureWildcardRewrite,
+  removeWildcardRewrite,
+  wildcardForDomain,
+  listRewrites,
+} from './rewrites';
+
+function mockFetch(handler: (path: string, body: unknown) => { ok: boolean; body?: unknown }) {
+  return vi.fn(async (url: string, init: RequestInit) => {
+    const path = new URL(url).pathname;
+    const body = init.body ? JSON.parse(init.body as string) : undefined;
+    const result = handler(path, body);
+    return {
+      ok: result.ok,
+      json: async () => result.body ?? {},
+    } as Response;
+  });
+}
+
+const opts = (fetchImpl: typeof fetch) => ({
+  adminUrl: 'http://localhost:8083',
+  username: 'admin',
+  password: 'secret',
+  fetchImpl,
+});
+
+describe('wildcardForDomain', () => {
+  it('prepends *. to a bare domain', () => {
+    expect(wildcardForDomain('home.arpa')).toBe('*.home.arpa');
+  });
+  it('strips leading wildcard chars before reapplying', () => {
+    expect(wildcardForDomain('*.example.com')).toBe('*.example.com');
+    expect(wildcardForDomain('.foo.bar')).toBe('*.foo.bar');
+  });
+});
+
+describe('listRewrites', () => {
+  it('returns the parsed list when AdGuard responds OK', async () => {
+    const fetchImpl = mockFetch(() => ({
+      ok: true,
+      body: [{ domain: '*.home.arpa', answer: '10.0.0.5' }],
+    }));
+    const rewrites = await listRewrites(opts(fetchImpl as unknown as typeof fetch));
+    expect(rewrites).toEqual([{ domain: '*.home.arpa', answer: '10.0.0.5' }]);
+  });
+
+  it('returns empty array on non-OK response', async () => {
+    const fetchImpl = mockFetch(() => ({ ok: false }));
+    expect(await listRewrites(opts(fetchImpl as unknown as typeof fetch))).toEqual([]);
+  });
+
+  it('returns empty array on network error', async () => {
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')));
+    expect(await listRewrites(opts(fetchImpl as unknown as typeof fetch))).toEqual([]);
+  });
+});
+
+describe('ensureWildcardRewrite', () => {
+  it("'added' when no matching rule exists", async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const fetchImpl = mockFetch((path, body) => {
+      calls.push({ path, body });
+      if (path === '/control/rewrite/list') return { ok: true, body: [] };
+      return { ok: true };
+    });
+    const result = await ensureWildcardRewrite(
+      opts(fetchImpl as unknown as typeof fetch),
+      '*.home.arpa',
+      '10.0.0.5',
+    );
+    expect(result).toBe('added');
+    expect(calls.find(c => c.path === '/control/rewrite/add')?.body).toEqual({
+      domain: '*.home.arpa',
+      answer: '10.0.0.5',
+    });
+  });
+
+  it("'unchanged' when rule already correct", async () => {
+    const fetchImpl = mockFetch((path) => {
+      if (path === '/control/rewrite/list') {
+        return { ok: true, body: [{ domain: '*.home.arpa', answer: '10.0.0.5' }] };
+      }
+      throw new Error('should not call beyond list');
+    });
+    const result = await ensureWildcardRewrite(
+      opts(fetchImpl as unknown as typeof fetch),
+      '*.home.arpa',
+      '10.0.0.5',
+    );
+    expect(result).toBe('unchanged');
+  });
+
+  it("'updated' when rule exists with different IP", async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const fetchImpl = mockFetch((path, body) => {
+      calls.push({ path, body });
+      if (path === '/control/rewrite/list') {
+        return { ok: true, body: [{ domain: '*.home.arpa', answer: '10.0.0.99' }] };
+      }
+      return { ok: true };
+    });
+    const result = await ensureWildcardRewrite(
+      opts(fetchImpl as unknown as typeof fetch),
+      '*.home.arpa',
+      '10.0.0.5',
+    );
+    expect(result).toBe('updated');
+    const updateCall = calls.find(c => c.path === '/control/rewrite/update');
+    expect(updateCall?.body).toEqual({
+      target: { domain: '*.home.arpa', answer: '10.0.0.99' },
+      update: { domain: '*.home.arpa', answer: '10.0.0.5' },
+    });
+  });
+
+  it("'failed' on add error", async () => {
+    const fetchImpl = mockFetch((path) => {
+      if (path === '/control/rewrite/list') return { ok: true, body: [] };
+      return { ok: false };
+    });
+    expect(
+      await ensureWildcardRewrite(opts(fetchImpl as unknown as typeof fetch), '*.home.arpa', '10.0.0.5'),
+    ).toBe('failed');
+  });
+});
+
+describe('removeWildcardRewrite', () => {
+  it("'removed' when rule exists", async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const fetchImpl = mockFetch((path, body) => {
+      calls.push({ path, body });
+      if (path === '/control/rewrite/list') {
+        return { ok: true, body: [{ domain: '*.home.arpa', answer: '10.0.0.5' }] };
+      }
+      return { ok: true };
+    });
+    expect(
+      await removeWildcardRewrite(opts(fetchImpl as unknown as typeof fetch), '*.home.arpa'),
+    ).toBe('removed');
+    expect(calls.find(c => c.path === '/control/rewrite/delete')?.body).toEqual({
+      domain: '*.home.arpa',
+      answer: '10.0.0.5',
+    });
+  });
+
+  it("'absent' when rule doesn't exist", async () => {
+    const fetchImpl = mockFetch(() => ({ ok: true, body: [] }));
+    expect(
+      await removeWildcardRewrite(opts(fetchImpl as unknown as typeof fetch), '*.home.arpa'),
+    ).toBe('absent');
+  });
+});

--- a/src/lib/adguard/rewrites.ts
+++ b/src/lib/adguard/rewrites.ts
@@ -1,0 +1,130 @@
+/**
+ * AdGuard Home DNS-rewrite client. Manages the wildcard `*.<domain>`
+ * → `<lan-ip>` rewrites that make LAN-domain mode work (#249, D19-PR4).
+ *
+ * Reaches AdGuard via its REST API at `<adminUrl>/control/rewrite/*`.
+ * Auth is HTTP Basic with the admin password ServiceBay auto-generates
+ * at install time (`config.templateSettings.ADGUARD_ADMIN_PASSWORD`,
+ * inherited from the template's variables.json).
+ *
+ * Functions are idempotent — `ensureWildcardRewrite` adds the rule
+ * if missing, updates the IP if the rule exists with a different
+ * answer, no-ops when already correct. `removeWildcardRewrite` is
+ * forgiving on "not present" cases. Designed to be called on every
+ * boot (#266 self-IP auto-update) and on every public-domain switch.
+ */
+
+const REWRITES_LIST = '/control/rewrite/list';
+const REWRITES_ADD = '/control/rewrite/add';
+const REWRITES_UPDATE = '/control/rewrite/update';
+const REWRITES_DELETE = '/control/rewrite/delete';
+
+export interface AdguardRewrite {
+  domain: string;
+  answer: string;
+}
+
+interface ClientOpts {
+  adminUrl: string;
+  username?: string;
+  password?: string;
+  /** Override the global fetch — used by tests. */
+  fetchImpl?: typeof fetch;
+}
+
+function authHeader(opts: ClientOpts): string | undefined {
+  if (!opts.username || !opts.password) return undefined;
+  const token = Buffer.from(`${opts.username}:${opts.password}`).toString('base64');
+  return `Basic ${token}`;
+}
+
+async function request(opts: ClientOpts, path: string, body?: unknown): Promise<Response> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const auth = authHeader(opts);
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (auth) headers['Authorization'] = auth;
+  return fetchImpl(`${opts.adminUrl.replace(/\/$/, '')}${path}`, {
+    method: 'POST',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : '{}',
+  });
+}
+
+/** Read all current rewrites from AdGuard. Returns empty array if the
+ *  call fails (e.g. AdGuard down). */
+export async function listRewrites(opts: ClientOpts): Promise<AdguardRewrite[]> {
+  try {
+    const res = await request(opts, REWRITES_LIST);
+    if (!res.ok) return [];
+    const data = (await res.json()) as AdguardRewrite[];
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Make sure the `<wildcardDomain>` → `<targetIp>` rewrite is live.
+ * `wildcardDomain` is typically `*.home.arpa` (or the user's chosen
+ * LAN domain). `targetIp` is ServiceBay's LAN IP.
+ *
+ * Idempotent. Returns `'added' | 'updated' | 'unchanged' | 'failed'`
+ * so callers can log the right message.
+ */
+export async function ensureWildcardRewrite(
+  opts: ClientOpts,
+  wildcardDomain: string,
+  targetIp: string,
+): Promise<'added' | 'updated' | 'unchanged' | 'failed'> {
+  const existing = await listRewrites(opts);
+  const match = existing.find(r => r.domain === wildcardDomain);
+  if (match && match.answer === targetIp) {
+    return 'unchanged';
+  }
+  if (match) {
+    // AdGuard's `/rewrite/update` takes both the old and new entries.
+    try {
+      const res = await request(opts, REWRITES_UPDATE, {
+        target: { domain: match.domain, answer: match.answer },
+        update: { domain: wildcardDomain, answer: targetIp },
+      });
+      return res.ok ? 'updated' : 'failed';
+    } catch {
+      return 'failed';
+    }
+  }
+  try {
+    const res = await request(opts, REWRITES_ADD, { domain: wildcardDomain, answer: targetIp });
+    return res.ok ? 'added' : 'failed';
+  } catch {
+    return 'failed';
+  }
+}
+
+/**
+ * Remove the wildcard rewrite for the given domain. Returns
+ * `'removed' | 'absent' | 'failed'`. Used by the public→lan
+ * downgrade path and by template uninstall (rare).
+ */
+export async function removeWildcardRewrite(
+  opts: ClientOpts,
+  wildcardDomain: string,
+): Promise<'removed' | 'absent' | 'failed'> {
+  const existing = await listRewrites(opts);
+  const match = existing.find(r => r.domain === wildcardDomain);
+  if (!match) return 'absent';
+  try {
+    const res = await request(opts, REWRITES_DELETE, { domain: match.domain, answer: match.answer });
+    return res.ok ? 'removed' : 'failed';
+  } catch {
+    return 'failed';
+  }
+}
+
+/**
+ * Convenience — build the wildcard pattern for a given domain.
+ * `home.arpa` → `*.home.arpa`. Centralizes the convention.
+ */
+export function wildcardForDomain(domain: string): string {
+  return `*.${domain.replace(/^[*.]+/, '')}`;
+}


### PR DESCRIPTION
Resolves #261. Re-creates closed #272 (auto-closed when its base branch deleted on PR-3 merge). Branch is now off main directly.

New `src/lib/adguard/rewrites.ts` with idempotent `ensureWildcardRewrite` / `removeWildcardRewrite` for the wildcard DNS rules that make LAN-domain mode work.