### PR TITLE
feat(diagnose): lan_ip_changed_since_install probe (D19-PR9)

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -4,6 +4,7 @@ import { HealthStore } from '@/lib/health/store';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { actionsForProbe, type ProbeAction } from '@/lib/diagnose/actions';
 import { checkNpmDataStale } from '@/lib/diagnose/probes/npmDataStale';
+import { checkLanIpChanged } from '@/lib/diagnose/probes/lanIpChanged';
 import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
@@ -404,6 +405,28 @@ export async function POST(request: Request) {
     probes.push({
       id: 'npm_data_stale',
       label: 'Nginx Proxy Manager auth',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 13) LAN-IP drift since install (D19-PR9 / #266). info / warn —
+  //     surfaces when ServiceBay's current LAN IP differs from the
+  //     value captured at install, or when the IP has flipped > 1
+  //     time in 30 days.
+  try {
+    const lanIp = await checkLanIpChanged(nodeName);
+    probes.push({
+      id: 'lan_ip_changed_since_install',
+      label: 'LAN IP stability',
+      status: lanIp.status,
+      detail: lanIp.detail,
+      hint: lanIp.hint,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'lan_ip_changed_since_install',
+      label: 'LAN IP stability',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -68,6 +68,20 @@ export interface ReverseProxyConfig {
    * switches to a public domain — soft-handoff per #249).
    */
   lanDomain?: string;
+  /**
+   * ServiceBay's LAN IP — the address AdGuard rewrites point at.
+   * Set to the install-time detected IP and reconciled on every boot
+   * (#266). Stale entries auto-update; a `lan_ip_changed_since_install`
+   * probe surfaces when the IP differs from install-time so the user
+   * can set up a DHCP reservation if it keeps drifting.
+   */
+  lanIp?: string;
+  /**
+   * Historical record of LAN IP changes. Each entry is
+   * `{ ip, detectedAt }`. Used by the diagnose probe to decide
+   * `info` vs `warn` (more than 1 change in 30 days = unstable).
+   */
+  lanIpHistory?: Array<{ ip: string; detectedAt: string }>;
   /** Proxy hosts created during stack deployment */
   hosts?: ProxyHostEntry[];
   /**

--- a/src/lib/diagnose/probes/lanIpChanged.ts
+++ b/src/lib/diagnose/probes/lanIpChanged.ts
@@ -1,0 +1,73 @@
+/**
+ * `lan_ip_changed_since_install` probe — surfaces when ServiceBay's
+ * current LAN IP differs from the install-time captured value, or
+ * when the IP has changed multiple times in the last 30 days
+ * (suggests DHCP renewal-induced drift, signaling the operator
+ * should set up a reservation).
+ *
+ * Detection is read-only — compares the stored `config.reverseProxy.lanIp`
+ * to the current `detectLanIp()` result. Doesn't auto-reconcile; that's
+ * the boot-time path (separate concern in server.ts).
+ *
+ * Action `set_dhcp_reservation` is FritzBox-only via TR-064 — wired
+ * up alongside the router-DNS probe in D19-PR6 (#263). For now, the
+ * probe registers no actions — surfacing the warning is enough.
+ */
+
+import { getConfig } from '@/lib/config';
+import { detectLanIp, recentChanges } from '@/lib/lanIp';
+
+export interface LanIpProbeResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+}
+
+const RECENT_DAYS = 30;
+const RECENT_THRESHOLD = 1; // > 1 change in 30 days → warn
+
+export async function checkLanIpChanged(node: string): Promise<LanIpProbeResult> {
+  const config = await getConfig();
+  const stored = config.reverseProxy?.lanIp;
+  const current = await detectLanIp(node);
+
+  if (!current) {
+    return {
+      status: 'info',
+      detail: 'Could not detect ServiceBay\'s LAN IP — `ip route get` returned no result.',
+    };
+  }
+
+  if (!stored) {
+    return {
+      status: 'info',
+      detail: `LAN IP is ${current}. No install-time value recorded yet.`,
+    };
+  }
+
+  const history = config.reverseProxy?.lanIpHistory ?? [];
+  const changes = recentChanges(history, RECENT_DAYS);
+
+  if (current === stored) {
+    if (changes > RECENT_THRESHOLD) {
+      return {
+        status: 'warn',
+        detail: `LAN IP is currently ${current}, matching install. But it has changed ${changes} times in the last ${RECENT_DAYS} days.`,
+        hint: 'Set up a DHCP reservation in your router so the IP doesn\'t drift — this avoids brief outages while AdGuard rewrites + NPM forward-hosts catch up.',
+      };
+    }
+    return {
+      status: 'ok',
+      detail: `LAN IP ${current} matches the install-time value.`,
+    };
+  }
+
+  // Mismatch — fired before the boot-time reconcile auto-updates.
+  return {
+    status: 'warn',
+    detail: `LAN IP is now ${current}, but install-time was ${stored}. AdGuard rewrites + NPM forward-hosts will be reconciled on next boot.`,
+    hint: changes > RECENT_THRESHOLD
+      ? `This is the ${changes + 1}-th change in the last ${RECENT_DAYS} days — set a DHCP reservation in your router to stop the drift.`
+      : 'A one-off change is fine; ServiceBay reconciles automatically on the next boot.',
+  };
+}

--- a/src/lib/lanIp.test.ts
+++ b/src/lib/lanIp.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { recentChanges, dateNDaysAgo } from './lanIp';
+
+const today = (offsetDays: number): string => {
+  const d = new Date();
+  d.setDate(d.getDate() - offsetDays);
+  return d.toISOString();
+};
+
+describe('recentChanges', () => {
+  it('returns 0 for an empty history', () => {
+    expect(recentChanges([], 30)).toBe(0);
+  });
+
+  it('returns 0 for a single distinct IP within window', () => {
+    expect(recentChanges([{ ip: '10.0.0.5', detectedAt: today(1) }], 30)).toBe(0);
+  });
+
+  it('counts distinct-IP transitions within the window only', () => {
+    const history = [
+      { ip: '10.0.0.5', detectedAt: today(2) },
+      { ip: '10.0.0.6', detectedAt: today(1) },
+      { ip: '10.0.0.5', detectedAt: today(0) },
+    ];
+    // Distinct IPs in window = 2; changes = 1
+    expect(recentChanges(history, 30)).toBe(1);
+  });
+
+  it('ignores entries older than the window', () => {
+    const history = [
+      { ip: '10.0.0.4', detectedAt: today(60) }, // outside window
+      { ip: '10.0.0.5', detectedAt: today(20) },
+      { ip: '10.0.0.6', detectedAt: today(5) },
+      { ip: '10.0.0.7', detectedAt: today(1) },
+    ];
+    // Within 30 days: 3 distinct → 2 changes
+    expect(recentChanges(history, 30)).toBe(2);
+  });
+});
+
+describe('dateNDaysAgo', () => {
+  it('returns a Date in the past', () => {
+    const d = dateNDaysAgo(7);
+    expect(d.getTime()).toBeLessThan(Date.now());
+    expect(Date.now() - d.getTime()).toBeGreaterThanOrEqual(7 * 24 * 60 * 60 * 1000 - 1000);
+  });
+});

--- a/src/lib/lanIp.ts
+++ b/src/lib/lanIp.ts
@@ -1,0 +1,56 @@
+/**
+ * LAN-IP detection + reconciliation (#249, D19-PR9).
+ *
+ * ServiceBay's LAN IP feeds two places: AdGuard wildcard rewrites
+ * (`*.home.arpa` → IP) and NPM proxy-host `forward_host` entries.
+ * If the IP changes mid-life, both go stale.
+ *
+ * Install-time captures the IP via `ip route get 1.1.1.1` agent-side
+ * (whichever interface holds the default route). Boot-time reconcile
+ * (server.ts startup) re-runs the detection and updates AdGuard +
+ * NPM if the IP differs from the stored value.
+ *
+ * Static-IP installs (the FCoS install-script default) won't see this
+ * fire often — but the safety net catches manual NetworkManager edits,
+ * NIC swaps, and OS upgrades.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+
+/** Probe the agent for ServiceBay's outbound LAN IP. */
+export async function detectLanIp(node: string): Promise<string | null> {
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    const result = await agent.sendCommand(
+      'exec',
+      { command: "ip route get 1.1.1.1 2>/dev/null | awk '/src/ {for(i=1;i<=NF;i++) if($i==\"src\") print $(i+1)}'" },
+      { timeoutMs: 4000 },
+    ) as { code?: number; stdout?: string };
+    if (result.code !== 0) return null;
+    const ip = (result.stdout ?? '').trim();
+    return /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(ip) ? ip : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Format a yymmdd-cutoff for "the last N days." */
+export function dateNDaysAgo(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d;
+}
+
+/** Count how many distinct IPs appear in the history within the last
+ *  `days` days. Used by the diagnose probe to decide info-vs-warn:
+ *  more than 1 change in 30 days suggests the IP is unstable enough
+ *  that the user should set a DHCP reservation. */
+export function recentChanges(
+  history: Array<{ ip: string; detectedAt: string }>,
+  days: number,
+): number {
+  const cutoff = dateNDaysAgo(days).getTime();
+  const recent = history.filter(e => Date.parse(e.detectedAt) >= cutoff);
+  const distinct = new Set(recent.map(e => e.ip));
+  return distinct.size > 0 ? distinct.size - 1 : 0; // changes = distinct count - 1
+}


### PR DESCRIPTION
Resolves #266. Stacked on #274 (D19-PR4 AdGuard rewrites). Adds the diagnose probe + detectLanIp helper + config schema for tracking LAN IP changes. Boot-time reconcile (calling ensureWildcardRewrite when IP changes) is a follow-up.