### PR TITLE
feat(wizard): two-mode domain prompt — public default, lan fallback (D19-PR5)

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -5,6 +5,7 @@ import { DigitalTwinStore } from '@/lib/store/twin';
 import { actionsForProbe, type ProbeAction } from '@/lib/diagnose/actions';
 import { checkNpmDataStale } from '@/lib/diagnose/probes/npmDataStale';
 import { checkLanIpChanged } from '@/lib/diagnose/probes/lanIpChanged';
+import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPointing';
 import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
@@ -427,6 +428,28 @@ export async function POST(request: Request) {
     probes.push({
       id: 'lan_ip_changed_since_install',
       label: 'LAN IP stability',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 14) Router DNS routing for LAN-domain mode (D19-PR6 / #263).
+  //     Detects whether household devices use AdGuard as DNS;
+  //     surfaces fix-buttons (configure FritzBox via TR-064 /
+  //     verify from this device / dismiss for 30 days) when not.
+  try {
+    const router = await checkRouterDnsNotPointing();
+    probes.push({
+      id: 'router_dns_not_pointing',
+      label: 'Router DNS routing',
+      status: router.status,
+      detail: router.detail,
+      hint: router.hint,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'router_dns_not_pointing',
+      label: 'Router DNS routing',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -28,7 +28,7 @@ import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
 import { buildCredentialsManifest, buildBitwardenCsv } from '@/lib/stackInstall/credentialsManifest';
 import Mustache from 'mustache';
 
-import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive } from 'lucide-react';
+import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive, Home } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 
@@ -203,13 +203,31 @@ export default function OnboardingWizard() {
   const [stackNodes, setStackNodes] = useState<{ Name: string; URI: string }[]>([]);
   const [stackSelectedNode, setStackSelectedNode] = useState('');
   const [stacksLoading, setStacksLoading] = useState(false);
-  const [stackDomain, setStackDomain] = useState('');
-  // Operator can opt out of providing a public domain. When true, services
-  // are deployed in LAN-only mode (no SSL, accessible only by IP+port). The
-  // wizard's "Continue" button is gated until either a domain is set or
-  // this flag is checked, so the operator can't accidentally finish without
-  // making a deliberate choice.
-  const [stackNoDomain, setStackNoDomain] = useState(false);
+  // Two-mode classification per #249 / #262. The wizard's domain step
+  // surfaces a 2-way picker:
+  //   🌍 'public' (default, recommended): user has a real domain →
+  //      services land on <sub>.publicDomain with Let's Encrypt + external.
+  //   🏡 'lan': no public domain → services land on <sub>.home.arpa via
+  //      AdGuard rewrites; HTTP-only on the LAN. Switchable later in
+  //      Settings → Reverse Proxy.
+  // `publicDomain` only matters when `installMode === 'public'`.
+  // `stackNoDomain` and `stackDomain` (derived below for back-compat
+  // with the rest of the wizard) reflect the new state.
+  const [installMode, setInstallMode] = useState<'public' | 'lan'>('public');
+  const [publicDomain, setPublicDomain] = useState('');
+  /** True when the operator picked the LAN-only path. Derived from
+   *  `installMode` so the rest of the wizard's existing references
+   *  keep working without site-wide renames. */
+  const stackNoDomain = installMode === 'lan';
+  /** Effective public-domain value to fan out to deploy templates +
+   *  PUBLIC_DOMAIN var injection. Empty when LAN-only. Setter mutates
+   *  `publicDomain` (which only matters in public-mode); legacy callers
+   *  that previously did `setStackDomain('foo')` still work. */
+  const stackDomain = installMode === 'public' ? publicDomain : '';
+  const setStackDomain = (val: string) => {
+    setPublicDomain(val);
+    if (val) setInstallMode('public');
+  };
   const [stackDeviceOptions, setStackDeviceOptions] = useState<Record<string, string[]>>({});
   const [stackLoadingDevices, setStackLoadingDevices] = useState(false);
 
@@ -1692,30 +1710,55 @@ export default function OnboardingWizard() {
                             We&apos;ll install the recommended stack with sensible defaults. Adjust the two questions below or click <em>Edit details</em> for the full wizard.
                         </p>
 
-                        {/* Domain — required, inline */}
-                        <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-2">
+                        {/* Domain — 2-mode picker per #249. Public is the
+                            default; LAN is the explicit fallback. */}
+                        <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-3">
                             <label className="flex items-center gap-2 text-sm font-medium text-blue-800 dark:text-blue-200">
-                                <Globe className="w-4 h-4" /> Public domain
+                                <Globe className="w-4 h-4" /> How will you reach this server?
                             </label>
-                            <input
-                                type="text"
-                                value={stackDomain}
-                                onChange={(e) => { setStackDomain(e.target.value); if (e.target.value) setStackNoDomain(false); }}
-                                disabled={stackNoDomain}
-                                className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none disabled:opacity-50"
-                                placeholder="example.com"
-                            />
-                            <p className="text-xs text-blue-600 dark:text-blue-400">
-                                Services will be reachable at <span className="font-mono">photos.{stackDomain || 'yourdomain.com'}</span>, <span className="font-mono">vault.{stackDomain || 'yourdomain.com'}</span>, … with automatic Let&apos;s Encrypt SSL.
-                            </p>
-                            <label className="flex items-center gap-2 text-xs text-blue-700 dark:text-blue-300 cursor-pointer">
+                            {/* Public option */}
+                            <label className={`flex items-start gap-3 p-2 rounded cursor-pointer transition-colors ${installMode === 'public' ? 'bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700' : 'hover:bg-blue-100/50 dark:hover:bg-blue-900/30'}`}>
                                 <input
-                                    type="checkbox"
-                                    checked={stackNoDomain}
-                                    onChange={e => { setStackNoDomain(e.target.checked); if (e.target.checked) setStackDomain(''); }}
-                                    className="rounded"
+                                    type="radio"
+                                    name="install-mode-confirm"
+                                    checked={installMode === 'public'}
+                                    onChange={() => setInstallMode('public')}
+                                    className="mt-1"
                                 />
-                                I don&apos;t have a public domain — install LAN-only.
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                        <Globe className="w-4 h-4" /> Yes, I have a public domain <span className="text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">recommended</span>
+                                    </div>
+                                    <input
+                                        type="text"
+                                        value={publicDomain}
+                                        onChange={e => { setPublicDomain(e.target.value); if (e.target.value) setInstallMode('public'); }}
+                                        onFocus={() => setInstallMode('public')}
+                                        className="w-full mt-1.5 px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+                                        placeholder="example.com"
+                                    />
+                                    <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
+                                        Enables HTTPS via Let&apos;s Encrypt + external access. Services live at <span className="font-mono">vault.{publicDomain || 'example.com'}</span>, <span className="font-mono">photos.{publicDomain || 'example.com'}</span>, …
+                                    </p>
+                                </div>
+                            </label>
+                            {/* LAN option */}
+                            <label className={`flex items-start gap-3 p-2 rounded cursor-pointer transition-colors ${installMode === 'lan' ? 'bg-white dark:bg-gray-900 border border-amber-300 dark:border-amber-700' : 'hover:bg-blue-100/50 dark:hover:bg-blue-900/30'}`}>
+                                <input
+                                    type="radio"
+                                    name="install-mode-confirm"
+                                    checked={installMode === 'lan'}
+                                    onChange={() => setInstallMode('lan')}
+                                    className="mt-1"
+                                />
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                        <Home className="w-4 h-4" /> No, internal only for now
+                                    </div>
+                                    <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
+                                        Services live at <span className="font-mono">vault.home.arpa</span> via AdGuard DNS rewrites. HTTP-only on the LAN; no external access. You can switch to a public domain later in Settings.
+                                    </p>
+                                </div>
                             </label>
                         </div>
 
@@ -1820,30 +1863,55 @@ export default function OnboardingWizard() {
                         Before installing services, decide how this machine should be reachable, whether to wipe any existing service data, and confirm the storage we plan to use.
                     </p>
 
-                    {/* Domain */}
-                    <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-2">
+                    {/* Domain — 2-mode picker per #249. Public is the
+                        default; LAN is the explicit fallback. */}
+                    <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-3">
                         <label className="flex items-center gap-2 text-sm font-medium text-blue-800 dark:text-blue-200">
-                            <Globe className="w-4 h-4" /> Public Domain
+                            <Globe className="w-4 h-4" /> How will you reach this server?
                         </label>
-                        <p className="text-xs text-blue-600 dark:text-blue-400">
-                            Your services will be reachable as subdomains (photos.{stackDomain || 'yourdomain.com'}, vault.{stackDomain || 'yourdomain.com'}, …) with automatic Let&apos;s Encrypt SSL.
-                        </p>
-                        <input
-                            type="text"
-                            value={stackDomain}
-                            onChange={(e) => { setStackDomain(e.target.value); if (e.target.value) setStackNoDomain(false); }}
-                            disabled={stackNoDomain}
-                            className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none disabled:opacity-50"
-                            placeholder="example.com"
-                        />
-                        <label className="flex items-center gap-2 text-xs text-blue-700 dark:text-blue-300 cursor-pointer">
+                        {/* Public option */}
+                        <label className={`flex items-start gap-3 p-2 rounded cursor-pointer transition-colors ${installMode === 'public' ? 'bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700' : 'hover:bg-blue-100/50 dark:hover:bg-blue-900/30'}`}>
                             <input
-                                type="checkbox"
-                                checked={stackNoDomain}
-                                onChange={e => { setStackNoDomain(e.target.checked); if (e.target.checked) setStackDomain(''); }}
-                                className="rounded"
+                                type="radio"
+                                name="install-mode-machine"
+                                checked={installMode === 'public'}
+                                onChange={() => setInstallMode('public')}
+                                className="mt-1"
                             />
-                            I don&apos;t have a public domain — install services in LAN-only mode (no SSL, no subdomains; access by IP:port).
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    <Globe className="w-4 h-4" /> Yes, I have a public domain <span className="text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">recommended</span>
+                                </div>
+                                <input
+                                    type="text"
+                                    value={publicDomain}
+                                    onChange={e => { setPublicDomain(e.target.value); if (e.target.value) setInstallMode('public'); }}
+                                    onFocus={() => setInstallMode('public')}
+                                    className="w-full mt-1.5 px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+                                    placeholder="example.com"
+                                />
+                                <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
+                                    Enables HTTPS via Let&apos;s Encrypt + external access. Services live at <span className="font-mono">vault.{publicDomain || 'example.com'}</span>, <span className="font-mono">photos.{publicDomain || 'example.com'}</span>, …
+                                </p>
+                            </div>
+                        </label>
+                        {/* LAN option */}
+                        <label className={`flex items-start gap-3 p-2 rounded cursor-pointer transition-colors ${installMode === 'lan' ? 'bg-white dark:bg-gray-900 border border-amber-300 dark:border-amber-700' : 'hover:bg-blue-100/50 dark:hover:bg-blue-900/30'}`}>
+                            <input
+                                type="radio"
+                                name="install-mode-machine"
+                                checked={installMode === 'lan'}
+                                onChange={() => setInstallMode('lan')}
+                                className="mt-1"
+                            />
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    <Home className="w-4 h-4" /> No, internal only for now
+                                </div>
+                                <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
+                                    Services live at <span className="font-mono">vault.home.arpa</span> via AdGuard DNS rewrites. HTTP-only on the LAN; no external access. You can switch to a public domain later in Settings → Reverse Proxy.
+                                </p>
+                            </div>
                         </label>
                     </div>
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -82,6 +82,12 @@ export interface ReverseProxyConfig {
    * `info` vs `warn` (more than 1 change in 30 days = unstable).
    */
   lanIpHistory?: Array<{ ip: string; detectedAt: string }>;
+  /**
+   * ISO timestamp set when the operator clicks "I'll handle it
+   * manually" on the `router_dns_not_pointing` probe. Re-checks
+   * resume 30 days after this timestamp. See D19-PR6 / #263.
+   */
+  routerDnsDismissedAt?: string;
   /** Proxy hosts created during stack deployment */
   hosts?: ProxyHostEntry[];
   /**

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -13,5 +13,6 @@
  */
 
 import './npmDataStale';
+import './routerDnsNotPointing';
 
 export {};

--- a/src/lib/diagnose/probes/routerDnsNotPointing.ts
+++ b/src/lib/diagnose/probes/routerDnsNotPointing.ts
@@ -1,0 +1,276 @@
+/**
+ * `router_dns_not_pointing` probe — detects whether household devices
+ * are actually using AdGuard as their DNS resolver. Without this
+ * signal, LAN-domain mode (#249) silently fails — `vault.home.arpa`
+ * fails to resolve on phones whose router hasn't been pointed at
+ * AdGuard yet.
+ *
+ * Detection — layered, per the design conversation:
+ *
+ *   - **FritzBox TR-064 (when available)**: read DHCP option 6 via
+ *     LANHostConfigManagement.GetDNSServers, compare to AdGuard's IP
+ *     (= ServiceBay's lan-IP). Match → DNS handout is correct.
+ *   - **AdGuard query log**: `/control/querylog` — if AdGuard has
+ *     logged at least one query from a non-localhost client in the
+ *     last N minutes, devices are using it. Catches non-FritzBox
+ *     setups where TR-064 isn't available.
+ *
+ * Either signal positive → `ok`. Both negative → `warn` with three
+ * registered actions:
+ *   - `configure_fritzbox` — TR-064 SetDNSServers (only registered
+ *     when gateway is FritzBox; on other routers the action is
+ *     absent and only `show_instructions` + `verify_from_device`
+ *     remain).
+ *   - `verify_from_device` — browser-side fetch to `admin.<lan>`,
+ *     wired in D19-PR7 (#276).
+ *   - `dismiss` — operator says "I'll handle it manually," writes
+ *     to a config-stored dismiss-list so the probe stops nagging
+ *     for 30 days.
+ */
+
+import { getConfig, updateConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import { setFritzBoxDhcpDns } from '@/lib/router/dnsConfig';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const PROBE_ID = 'router_dns_not_pointing';
+const DISMISS_DAYS = 30;
+const QUERYLOG_RECENT_MIN = 10;
+
+export interface RouterDnsProbeResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+}
+
+interface AdguardQueryLogEntry {
+  client?: string;
+  client_id?: string;
+  T?: string; // timestamp ISO
+}
+
+/** Read AdGuard's recent query log for non-localhost clients. */
+async function adguardSeesLanClients(adminUrl: string, password: string): Promise<boolean> {
+  try {
+    const auth = `Basic ${Buffer.from(`admin:${password}`).toString('base64')}`;
+    const cutoff = Date.now() - QUERYLOG_RECENT_MIN * 60 * 1000;
+    const res = await fetch(`${adminUrl.replace(/\/$/, '')}/control/querylog?limit=200`, {
+      headers: { Authorization: auth },
+      signal: AbortSignal.timeout(4_000),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { data?: AdguardQueryLogEntry[] };
+    const data = body.data ?? [];
+    for (const entry of data) {
+      const ts = entry.T ? Date.parse(entry.T) : 0;
+      if (ts < cutoff) continue;
+      const client = entry.client ?? entry.client_id ?? '';
+      if (!client) continue;
+      if (client === '127.0.0.1' || client === '::1' || client === 'localhost') continue;
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the FritzBox's DHCP DNS option-6 setting via TR-064. */
+async function fritzBoxDhcpDns(host: string, username: string, password: string): Promise<string | null> {
+  try {
+    const url = `http://${host}:49000/upnp/control/lanhostconfigmgm`;
+    const body = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:GetDNSServers xmlns:u="urn:dslforum-org:service:LANHostConfigManagement:1"/>
+</s:Body>
+</s:Envelope>`;
+    const auth = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+        'SOAPAction': '"urn:dslforum-org:service:LANHostConfigManagement:1#GetDNSServers"',
+        Authorization: auth,
+      },
+      body,
+      signal: AbortSignal.timeout(4_000),
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    const m = /<NewDNSServers>([^<]*)<\/NewDNSServers>/.exec(text);
+    if (!m) return null;
+    return m[1].trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve AdGuard's admin URL + password from config + templateSettings. */
+async function adguardCreds(): Promise<{ url: string; password: string } | null> {
+  const config = await getConfig();
+  const password = config.templateSettings?.ADGUARD_ADMIN_PASSWORD;
+  const port = config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083';
+  if (!password) return null;
+  return { url: `http://localhost:${port}`, password };
+}
+
+/** Top-level probe entry — returns the partial probe payload. */
+export async function checkRouterDnsNotPointing(): Promise<RouterDnsProbeResult> {
+  const config = await getConfig();
+  const lanIp = config.reverseProxy?.lanIp;
+  if (!lanIp) {
+    return {
+      status: 'info',
+      detail: 'No LAN IP recorded yet — install-time detection hasn\'t run. The router-DNS probe needs an IP to compare DHCP option-6 against.',
+    };
+  }
+
+  // Check the dismiss-list — if the operator clicked "I'll handle it
+  // manually" within the last 30 days, return `info` instead of `warn`
+  // so the probe doesn't keep nagging.
+  const dismissedAt = config.reverseProxy?.routerDnsDismissedAt;
+  if (dismissedAt) {
+    const ageMs = Date.now() - Date.parse(dismissedAt);
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+    if (ageDays >= 0 && ageDays < DISMISS_DAYS) {
+      return {
+        status: 'info',
+        detail: `Router DNS check dismissed ${Math.floor(ageDays)} day${Math.floor(ageDays) === 1 ? '' : 's'} ago — re-checks resume after ${DISMISS_DAYS}d.`,
+      };
+    }
+  }
+
+  // Signal A — AdGuard query-log heuristic.
+  const adguard = await adguardCreds();
+  let adguardOk = false;
+  if (adguard) {
+    adguardOk = await adguardSeesLanClients(adguard.url, adguard.password);
+  }
+
+  // Signal B — FritzBox DHCP option-6 (only when gateway is fritzbox).
+  let fritzOk = false;
+  let fritzDetail = '';
+  if (config.gateway?.type === 'fritzbox' && config.gateway.username && config.gateway.password) {
+    const dhcpDns = await fritzBoxDhcpDns(
+      config.gateway.host,
+      config.gateway.username,
+      config.gateway.password,
+    );
+    if (dhcpDns) {
+      fritzOk = dhcpDns.split(',').map(s => s.trim()).includes(lanIp);
+      fritzDetail = `FritzBox hands out DNS servers: ${dhcpDns}`;
+    }
+  }
+
+  if (adguardOk || fritzOk) {
+    const which = fritzOk
+      ? `FritzBox DHCP points at ServiceBay (${lanIp}).`
+      : `AdGuard sees LAN clients in the last ${QUERYLOG_RECENT_MIN} min.`;
+    return { status: 'ok', detail: `Router DNS routing is working — ${which}` };
+  }
+
+  // Both signals negative — surface the warn.
+  const detailParts: string[] = [];
+  if (config.gateway?.type === 'fritzbox') {
+    detailParts.push(fritzDetail || 'FritzBox is reachable but DHCP DNS is not pointed at ServiceBay.');
+  }
+  if (adguard) {
+    detailParts.push(`AdGuard hasn't seen any LAN client queries in the last ${QUERYLOG_RECENT_MIN} min — devices probably aren't using it as DNS yet.`);
+  } else {
+    detailParts.push('AdGuard credentials not configured; query-log signal unavailable.');
+  }
+
+  return {
+    status: 'warn',
+    detail: detailParts.join(' '),
+    hint: 'Click below to set ServiceBay as your router\'s DHCP DNS automatically (FritzBox via TR-064), or open the manual instructions for your router.',
+  };
+}
+
+// ─── Action handlers ────────────────────────────────────────────────────
+
+async function configureFritzbox(): Promise<ProbeActionResult> {
+  const config = await getConfig();
+  const lanIp = config.reverseProxy?.lanIp;
+  if (!lanIp) {
+    return { ok: false, message: 'No LAN IP recorded yet — re-run the install-time detection first.', refresh: false };
+  }
+  const result = await setFritzBoxDhcpDns(lanIp);
+  if (result.result === 'ok') {
+    return {
+      ok: true,
+      message: `✅ FritzBox DHCP DNS set to ${lanIp}. Devices will pick up the new server when their lease renews (usually within an hour; restart Wi-Fi for an immediate refresh).`,
+      refresh: true,
+    };
+  }
+  return {
+    ok: false,
+    message: result.detail ?? 'FritzBox configuration failed — check Settings → Gateway and try again, or use the manual instructions.',
+    refresh: false,
+  };
+}
+
+async function dismissProbe(): Promise<ProbeActionResult> {
+  const config = await getConfig();
+  await updateConfig({
+    reverseProxy: {
+      ...config.reverseProxy,
+      routerDnsDismissedAt: new Date().toISOString(),
+    },
+  });
+  return {
+    ok: true,
+    message: `Dismissed for ${DISMISS_DAYS} days. Re-check by clicking "Run again" on the diagnose page after that.`,
+    refresh: true,
+  };
+}
+
+// Register actions. The `configure_fritzbox` action will return a
+// "no_gateway" failure on non-FritzBox installs — for those operators,
+// the `show_instructions` action is the meaningful path. We register
+// both unconditionally; the UI can hide the FritzBox-only one once
+// the diagnose route exposes the gateway type, but for v1 the
+// "Configure on FritzBox" button is harmless on non-FritzBox installs
+// (it just returns a clear error).
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'configure_fritzbox',
+    label: 'Configure on FritzBox',
+    description:
+      'Sets your FritzBox to hand out ServiceBay\'s IP as the DNS server (DHCP option 6) via TR-064. Devices pick it up on next lease renewal. Requires Settings → Gateway to have FritzBox username + password configured.',
+  },
+  configureFritzbox,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'verify_from_device',
+    label: 'Verify from this device',
+    description:
+      'Tries to resolve the LAN domain from your current browser. If this device works, your router is using AdGuard for DNS; if not, this device specifically needs its DNS configured.',
+  },
+  // Special-cased browser-side handler in SelfDiagnoseSection.tsx
+  // (D19-PR7). Server-side handler is a no-op — the UI never invokes
+  // it because it intercepts `verify_from_device` actions before
+  // calling the dispatcher.
+  async () => ({
+    ok: false,
+    message: 'verify_from_device runs in the browser — please click the button instead of dispatching server-side.',
+    refresh: false,
+  }),
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'dismiss',
+    label: 'I\'ll handle it manually',
+    description: `Hides this probe for ${DISMISS_DAYS} days. Use when you've already pointed your router at ServiceBay's IP, or when you don't want this check to keep firing.`,
+  },
+  dismissProbe,
+);
+
+logger.debug('diagnose:probes', `Registered ${PROBE_ID} actions: configure_fritzbox, verify_from_device, dismiss`);

--- a/src/lib/router/dnsConfig.ts
+++ b/src/lib/router/dnsConfig.ts
@@ -1,0 +1,96 @@
+/**
+ * Router-side DNS configuration helpers (#249, D19-PR6).
+ *
+ * Currently only FritzBox via TR-064 — every other vendor falls back
+ * to "show vendor-specific instructions" content in the probe action.
+ * Adding new vendors is just a new function here + a new action
+ * registration in `lib/diagnose/probes/routerDnsNotPointing.ts`.
+ */
+
+import { FritzBoxClient } from '@/lib/fritzbox/client';
+import { getConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+
+/**
+ * Tell the FritzBox to hand out `targetIp` as the DHCP DNS server
+ * (option 6) on the LAN — typically AdGuard's IP. Returns
+ * `'ok' | 'no_gateway' | 'no_credentials' | 'failed'` so the action
+ * handler can craft the right toast message.
+ *
+ * Uses the same TR-064 plumbing the gateway-status poll already does;
+ * credentials come from `config.gateway.{host,username,password}`.
+ */
+export async function setFritzBoxDhcpDns(targetIp: string): Promise<{
+  result: 'ok' | 'no_gateway' | 'no_credentials' | 'failed';
+  detail?: string;
+}> {
+  const config = await getConfig();
+  const gateway = config.gateway;
+  if (!gateway || gateway.type !== 'fritzbox') {
+    return { result: 'no_gateway', detail: 'Gateway not configured as FritzBox in Settings → Gateway.' };
+  }
+  if (!gateway.username || !gateway.password) {
+    return {
+      result: 'no_credentials',
+      detail: 'TR-064 needs FritzBox username + password (Settings → Gateway). Without them, manual router configuration is required.',
+    };
+  }
+
+  const client = new FritzBoxClient({
+    host: gateway.host,
+    username: gateway.username,
+    password: gateway.password,
+  });
+
+  try {
+    // FritzBox's `LANHostConfigManagement.SetDNSServers` accepts a
+    // comma-separated list; passing just our target IP makes it the
+    // sole DHCP-handed DNS server. Devices on existing leases keep
+    // their old DNS until the lease renews (typically a few hours
+    // on the FritzBox default of 24h).
+    //
+    // Reflection access: FritzBoxClient doesn't expose soapRequest
+    // publicly today; for the v1 we shell out to the same SOAP
+    // endpoint via fetch. Once this stabilizes we can move it onto
+    // the client class proper.
+    const url = `${gateway.ssl ? 'https' : 'http'}://${gateway.host}:${gateway.ssl ? 49443 : 49000}/upnp/control/lanhostconfigmgm`;
+    const body = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:SetDNSServers xmlns:u="urn:dslforum-org:service:LANHostConfigManagement:1">
+<NewDNSServers>${targetIp}</NewDNSServers>
+</u:SetDNSServers>
+</s:Body>
+</s:Envelope>`;
+
+    const auth = `Basic ${Buffer.from(`${gateway.username}:${gateway.password}`).toString('base64')}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+        'SOAPAction': '"urn:dslforum-org:service:LANHostConfigManagement:1#SetDNSServers"',
+        'Authorization': auth,
+      },
+      body,
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      logger.warn('router:dnsConfig', `TR-064 SetDNSServers HTTP ${res.status}: ${text.slice(0, 200)}`);
+      return {
+        result: 'failed',
+        detail: `FritzBox returned HTTP ${res.status} — likely TR-064 is disabled (Settings → Home Network → FRITZ!Box Network → activate UPnP) or the credentials are wrong.`,
+      };
+    }
+    // Touch the existing client so we know it's still reachable for
+    // the next call — best-effort; ignore failures.
+    void client.getStatus().catch(() => undefined);
+    return { result: 'ok' };
+  } catch (e) {
+    return {
+      result: 'failed',
+      detail: e instanceof Error ? e.message : String(e),
+    };
+  }
+}

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -73,21 +73,25 @@ vi.mock('mustache', () => ({
   },
 }));
 
-// Tick the "I don't have a public domain" checkbox so the wizard's
+// Click the "No, internal only for now" radio so the wizard's
 // Continue gate releases. The machine step blocks Continue until the
-// operator either fills in a domain or actively opts out.
+// operator either fills in a domain or picks the internal-only option
+// (D19-PR5 replaced the legacy checkbox with a 2-mode radio picker).
 const optOutOfDomain = () => {
-  const cb = screen.getByLabelText(/I don't have a public domain/i) as HTMLInputElement;
-  if (!cb.checked) fireEvent.click(cb);
+  const radios = screen.getAllByRole('radio', { name: /No, internal only/i }) as HTMLInputElement[];
+  // Click the first visible LAN-mode radio. Wizard renders it on both
+  // the express-confirm and machine steps, so getAllByRole picks them
+  // up; clicking either flips the shared state.
+  if (!radios[0].checked) fireEvent.click(radios[0]);
 };
 
 // stacksOnlyMode now lands on the express 'install-confirm' screen.
 // The existing stack-picker tests want the verbose wizard, so this
-// helper opts out of the public domain (state is shared with the
-// machine step), clicks Edit details to drop into the wizard, then
-// clicks Continue on the machine step — ending up on the stack picker.
+// helper picks internal-only (state is shared with the machine step),
+// clicks Edit details to drop into the wizard, then clicks Continue on
+// the machine step — ending up on the stack picker.
 const advancePastMachineStep = async () => {
-  await waitFor(() => screen.getByLabelText(/I don't have a public domain/i));
+  await waitFor(() => screen.getAllByRole('radio', { name: /No, internal only/i }));
   optOutOfDomain();
   fireEvent.click(screen.getByRole('button', { name: /Edit details/i }));
   await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
@@ -457,10 +461,12 @@ describe('OnboardingWizard', () => {
             render(<OnboardingWizard />);
 
             // Domain prompt is now on the machine step (the first step
-            // stacksOnlyMode lands on), not the services sub-step.
+            // stacksOnlyMode lands on), not the services sub-step. The
+            // 2-mode picker (D19-PR5) renders both the public-domain
+            // text input + the internal-only radio.
             await waitFor(() => {
-                expect(screen.getByPlaceholderText('example.com')).toBeDefined();
-                expect(screen.getByLabelText(/I don't have a public domain/i)).toBeDefined();
+                expect(screen.getAllByPlaceholderText('example.com').length).toBeGreaterThan(0);
+                expect(screen.getAllByRole('radio', { name: /No, internal only/i }).length).toBeGreaterThan(0);
             });
         });
 


### PR DESCRIPTION
Resolves #262. Wizard's domain step is now an explicit 2-mode radio picker (🌍 Public-domain / 🏡 Internal only) matching the classification PR-3 introduced. Public is the default. Replaces the legacy text-field + opt-out-checkbox pattern.