### PR TITLE
feat(diagnose): inline form inputs for probe actions (#250, #255)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
@@ -5,11 +5,21 @@ import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Stethoscope, W
 
 type ProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
 
+interface ProbeActionInput {
+  name: string;
+  label: string;
+  type: 'text' | 'password' | 'email';
+  placeholder?: string;
+  hint?: string;
+  required?: boolean;
+}
+
 interface ProbeAction {
   id: string;
   label: string;
   description: string;
   destructive?: boolean;
+  inputs?: ProbeActionInput[];
 }
 
 interface DiagnoseProbe {
@@ -39,6 +49,10 @@ export default function SelfDiagnoseSection() {
   const [error, setError] = useState<string | null>(null);
   /** Per-action transient state. Keyed by `<probeId>:<actionId>`. */
   const [actionState, setActionState] = useState<Record<string, { running?: boolean; message?: string; ok?: boolean }>>({});
+  /** Which actions have their inline form expanded. Keyed by `<probeId>:<actionId>`. */
+  const [expandedForms, setExpandedForms] = useState<Record<string, boolean>>({});
+  /** Form-field values per action. Keyed by `<probeId>:<actionId>` → { fieldName: value }. */
+  const [formValues, setFormValues] = useState<Record<string, Record<string, string>>>({});
 
   const run = async () => {
     setRunning(true);
@@ -57,7 +71,7 @@ export default function SelfDiagnoseSection() {
     }
   };
 
-  const runAction = async (probe: DiagnoseProbe, action: ProbeAction) => {
+  const runAction = async (probe: DiagnoseProbe, action: ProbeAction, payload?: Record<string, string>) => {
     // Confirm-on-destructive guard. The action's description is
     // surfaced in the dialog so the user sees the consequences they
     // accepted.
@@ -115,6 +129,7 @@ export default function SelfDiagnoseSection() {
           probeId: probe.id,
           actionId: action.id,
           node: result?.node,
+          ...(payload ? { payload } : {}),
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -210,31 +225,107 @@ export default function SelfDiagnoseSection() {
                     </p>
                   )}
                   {(probe.actions ?? []).length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-2">
+                    <div className="mt-3 space-y-2">
+                      <div className="flex flex-wrap gap-2">
+                        {(probe.actions ?? []).map(action => {
+                          const key = `${probe.id}:${action.id}`;
+                          const state = actionState[key];
+                          const isRunning = state?.running;
+                          const hasInputs = (action.inputs ?? []).length > 0;
+                          const isExpanded = expandedForms[key];
+                          const baseStyle = action.destructive
+                            ? 'bg-red-600 hover:bg-red-700 text-white'
+                            : 'bg-violet-600 hover:bg-violet-700 text-white';
+                          return (
+                            <div key={action.id} className="flex items-center gap-2">
+                              <button
+                                onClick={() => {
+                                  if (hasInputs) {
+                                    setExpandedForms(s => ({ ...s, [key]: !s[key] }));
+                                  } else {
+                                    void runAction(probe, action);
+                                  }
+                                }}
+                                disabled={isRunning || running}
+                                title={action.description}
+                                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
+                              >
+                                {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                                {action.label}
+                                {hasInputs && (isExpanded ? ' ▴' : ' ▾')}
+                              </button>
+                              {state?.message && !isRunning && (
+                                <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
+                                  {state.ok ? '✓' : '✗'} {state.message}
+                                </span>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
                       {(probe.actions ?? []).map(action => {
                         const key = `${probe.id}:${action.id}`;
+                        const hasInputs = (action.inputs ?? []).length > 0;
+                        if (!hasInputs || !expandedForms[key]) return null;
+                        const values = formValues[key] ?? {};
                         const state = actionState[key];
                         const isRunning = state?.running;
-                        const baseStyle = action.destructive
-                          ? 'bg-red-600 hover:bg-red-700 text-white'
-                          : 'bg-violet-600 hover:bg-violet-700 text-white';
+                        const inputs = action.inputs ?? [];
+                        const allRequiredFilled = inputs
+                          .filter(i => i.required !== false)
+                          .every(i => (values[i.name] ?? '').length > 0);
                         return (
-                          <div key={action.id} className="flex items-center gap-2">
-                            <button
-                              onClick={() => runAction(probe, action)}
-                              disabled={isRunning || running}
-                              title={action.description}
-                              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
-                            >
-                              {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
-                              {action.label}
-                            </button>
-                            {state?.message && !isRunning && (
-                              <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
-                                {state.ok ? '✓' : '✗'} {state.message}
-                              </span>
-                            )}
-                          </div>
+                          <form
+                            key={`${key}-form`}
+                            onSubmit={e => {
+                              e.preventDefault();
+                              void runAction(probe, action, values);
+                            }}
+                            className="p-3 rounded-md bg-white/60 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-2"
+                          >
+                            <p className="text-xs text-gray-600 dark:text-gray-400">{action.description}</p>
+                            {inputs.map(input => (
+                              <div key={input.name} className="space-y-1">
+                                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                                  {input.label}{input.required !== false && <span className="text-red-500"> *</span>}
+                                </label>
+                                <input
+                                  type={input.type}
+                                  value={values[input.name] ?? ''}
+                                  placeholder={input.placeholder}
+                                  required={input.required !== false}
+                                  onChange={e =>
+                                    setFormValues(s => ({
+                                      ...s,
+                                      [key]: { ...(s[key] ?? {}), [input.name]: e.target.value },
+                                    }))
+                                  }
+                                  className="w-full px-2 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                                  autoComplete="off"
+                                />
+                                {input.hint && (
+                                  <p className="text-xs text-gray-500 dark:text-gray-400">{input.hint}</p>
+                                )}
+                              </div>
+                            ))}
+                            <div className="flex items-center gap-2 pt-1">
+                              <button
+                                type="submit"
+                                disabled={!allRequiredFilled || isRunning || running}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 hover:bg-violet-700 text-white disabled:opacity-50"
+                              >
+                                {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                                Submit
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setExpandedForms(s => ({ ...s, [key]: false }))}
+                                className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </form>
                         );
                       })}
                     </div>

--- a/src/lib/diagnose/actions.test.ts
+++ b/src/lib/diagnose/actions.test.ts
@@ -94,3 +94,94 @@ describe('dispatchProbeAction', () => {
     expect(result.refresh).toBe(false);
   });
 });
+
+describe('inline-form inputs', () => {
+  it('rejects dispatch when required inputs are missing', async () => {
+    const handler = vi.fn(async () => ({ ok: true, message: 'should not run' }));
+    registerProbeAction(
+      'p1',
+      {
+        id: 'a1',
+        label: 'A',
+        description: 'd',
+        inputs: [
+          { name: 'email', label: 'Email', type: 'email', required: true },
+          { name: 'password', label: 'Password', type: 'password' /* required defaults true */ },
+        ],
+      },
+      handler,
+    );
+    const result = await dispatchProbeAction({
+      probeId: 'p1',
+      actionId: 'a1',
+      node: 'Local',
+      payload: { email: 'a@b.c' /* password missing */ },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Password/);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('rejects dispatch when required inputs are empty strings', async () => {
+    const handler = vi.fn(async () => ({ ok: true, message: '' }));
+    registerProbeAction(
+      'p1',
+      {
+        id: 'a1',
+        label: 'A',
+        description: 'd',
+        inputs: [{ name: 'email', label: 'Email', type: 'email', required: true }],
+      },
+      handler,
+    );
+    const result = await dispatchProbeAction({
+      probeId: 'p1',
+      actionId: 'a1',
+      node: 'Local',
+      payload: { email: '' },
+    });
+    expect(result.ok).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('passes payload through when all required inputs are present', async () => {
+    const handler = vi.fn(async () => ({ ok: true, message: 'saved' }));
+    registerProbeAction(
+      'p1',
+      {
+        id: 'a1',
+        label: 'A',
+        description: 'd',
+        inputs: [
+          { name: 'email', label: 'Email', type: 'email', required: true },
+          { name: 'note', label: 'Note', type: 'text', required: false },
+        ],
+      },
+      handler,
+    );
+    const result = await dispatchProbeAction({
+      probeId: 'p1',
+      actionId: 'a1',
+      node: 'Local',
+      payload: { email: 'a@b.c' /* note optional, omitted */ },
+    });
+    expect(result.ok).toBe(true);
+    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: { email: 'a@b.c' } });
+  });
+
+  it('exposes inputs[] via actionsForProbe', () => {
+    registerProbeAction(
+      'p1',
+      {
+        id: 'a1',
+        label: 'A',
+        description: 'd',
+        inputs: [{ name: 'email', label: 'Email', type: 'email' }],
+      },
+      async () => ({ ok: true, message: '' }),
+    );
+    const [action] = actionsForProbe('p1');
+    expect(action.inputs).toHaveLength(1);
+    expect(action.inputs?.[0].name).toBe('email');
+  });
+});

--- a/src/lib/diagnose/actions.ts
+++ b/src/lib/diagnose/actions.ts
@@ -25,6 +25,31 @@
 
 import { logger } from '@/lib/logger';
 
+/**
+ * Inline form field for an action that needs user input before it can
+ * run (e.g. "use existing NPM password" needs the operator to type the
+ * password). Without `inputs[]` an action dispatches on click; with
+ * `inputs[]` the UI expands a small form first and submits the values
+ * as the dispatch payload.
+ */
+export interface ProbeActionInput {
+  /** Form field name — passed back as `payload[name]` to the handler. */
+  name: string;
+  /** Short label shown above the input. */
+  label: string;
+  /**
+   * Field input type. `password` masks the value; `email`/`text` are
+   * surface differences only — the handler should still validate.
+   */
+  type: 'text' | 'password' | 'email';
+  /** Placeholder hint inside the input. */
+  placeholder?: string;
+  /** Helper text shown below the field. */
+  hint?: string;
+  /** Defaults to true. Required fields are validated before submit. */
+  required?: boolean;
+}
+
 /** Surface a fix the user can apply for a probe in `warn` or `fail` state. */
 export interface ProbeAction {
   /** Stable id (referenced by the dispatch endpoint). */
@@ -43,6 +68,15 @@ export interface ProbeAction {
    * behind a confirm dialog. Default false.
    */
   destructive?: boolean;
+  /**
+   * Optional inline form fields. When present, clicking the action
+   * button reveals a small form rather than dispatching immediately;
+   * the form's values are sent as `payload`. Use for actions that
+   * legitimately need operator input (credentials, free-text values).
+   * Hide expert-only knobs entirely instead of asking for them — see
+   * the UX philosophy.
+   */
+  inputs?: ProbeActionInput[];
 }
 
 /** Result payload returned to the UI after an action runs. */
@@ -131,6 +165,24 @@ export async function dispatchProbeAction(params: {
       message: `Unknown probe action: ${k}`,
       refresh: false,
     };
+  }
+  // Validate required inline-form inputs are present before invoking
+  // the handler. Handlers still need to validate types/values, but
+  // missing-required is uniform and surfaces a clear message.
+  const required = (entry.action.inputs ?? []).filter(i => i.required !== false);
+  if (required.length > 0) {
+    const payload = params.payload ?? {};
+    const missing = required.filter(i => {
+      const v = payload[i.name];
+      return v === undefined || v === null || (typeof v === 'string' && v.length === 0);
+    });
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        message: `Missing required field${missing.length === 1 ? '' : 's'}: ${missing.map(i => i.label).join(', ')}.`,
+        refresh: false,
+      };
+    }
   }
   try {
     const result = await entry.handler({ node: params.node, payload: params.payload });

--- a/src/lib/diagnose/probes/npmDataStale.ts
+++ b/src/lib/diagnose/probes/npmDataStale.ts
@@ -17,15 +17,14 @@
  *
  * Action `reset_volume` (destructive) wipes NPM's data dir and restarts
  * the service so it re-seeds with the wizard's INITIAL_ADMIN_*
- * credentials. The `use_existing` path is currently surfaced via the
- * probe's `hint` field — operators who know the existing password go
- * to Settings → Reverse Proxy and update there. Adding an inline
- * credentials form on the diagnose page is a follow-up (needs F1
- * extension for action inputs[]).
+ * credentials. Action `use_existing` (non-destructive) accepts the
+ * password the operator knows works and persists it to config — no
+ * data loss, the right path for "I already changed the password
+ * outside the wizard."
  */
 
 import { agentManager } from '@/lib/agent/manager';
-import { getConfig } from '@/lib/config';
+import { getConfig, updateConfig } from '@/lib/config';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
@@ -97,7 +96,7 @@ export async function checkNpmDataStale(node: string): Promise<NpmDataStaleResul
         status: 'fail',
         detail:
           'Nginx Proxy Manager is rejecting the stored admin credentials. This usually means a previous install left an admin password in the NPM database that no longer matches.',
-        hint: 'Click "Reset NPM data" below to wipe and reinstall, or open Settings → Reverse Proxy to enter the credentials NPM is actually using.',
+        hint: 'If you know the password NPM is actually using, click "Use existing password" below to save it (no data loss). Otherwise "Reset NPM data" wipes the database and re-seeds with the wizard credentials.',
       };
     }
     return {
@@ -169,4 +168,95 @@ registerProbeAction(
     destructive: true,
   },
   resetNpmVolume,
+);
+
+/**
+ * Non-destructive sibling of `reset_volume` — saves credentials the
+ * operator already knows are correct. Uses NPM's /api/tokens to
+ * confirm the password works before persisting; if NPM still 401s we
+ * surface the error rather than overwriting good config with bad.
+ */
+async function useExistingNpmCreds({
+  node,
+  payload,
+}: {
+  node: string;
+  payload?: Record<string, unknown>;
+}): Promise<ProbeActionResult> {
+  const email = typeof payload?.email === 'string' ? payload.email.trim() : '';
+  const password = typeof payload?.password === 'string' ? payload.password : '';
+  if (!email || !password) {
+    return { ok: false, message: 'Email and password are required.', refresh: false };
+  }
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return {
+      ok: false,
+      message: 'Nginx Proxy Manager is not deployed on this node — nothing to authenticate against.',
+      refresh: false,
+    };
+  }
+  let res: Response;
+  try {
+    res = await fetch(`${adminUrl}/api/tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identity: email, secret: password }),
+      signal: AbortSignal.timeout(4000),
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      message: `Could not reach NPM at ${adminUrl}: ${e instanceof Error ? e.message : String(e)}`,
+      refresh: false,
+    };
+  }
+  if (res.status === 401) {
+    return {
+      ok: false,
+      message: 'NPM still rejected those credentials — double-check the password and try again. (Nothing was saved.)',
+      refresh: false,
+    };
+  }
+  if (!res.ok) {
+    return { ok: false, message: `NPM returned HTTP ${res.status} during verification.`, refresh: false };
+  }
+  await updateConfig({
+    reverseProxy: {
+      npm: { email, password },
+    },
+  });
+  logger.info('diagnose:npm_data_stale', `Saved verified NPM credentials for ${email}`);
+  return {
+    ok: true,
+    message: 'Credentials verified and saved. Future installs and proxy syncs will use these.',
+    refresh: true,
+  };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'use_existing',
+    label: 'Use existing password',
+    description:
+      'Saves the NPM admin email + password you already know works. ServiceBay verifies them against NPM before persisting, so a wrong entry can\'t lock you out further.',
+    inputs: [
+      {
+        name: 'email',
+        label: 'NPM admin email',
+        type: 'email',
+        placeholder: 'admin@example.com',
+        required: true,
+      },
+      {
+        name: 'password',
+        label: 'NPM admin password',
+        type: 'password',
+        placeholder: 'The password you can log in with at NPM\'s admin UI',
+        required: true,
+      },
+    ],
+  },
+  useExistingNpmCreds,
 );


### PR DESCRIPTION
## Summary
- Extends F1's probe-action schema with optional `inputs?: ProbeActionInput[]` so actions can collect operator-supplied values inline (no separate Settings page round-trip).
- Dispatcher validates required inputs are present + non-empty before invoking handlers.
- Diagnose UI renders an expandable inline form per action; values become the dispatch `payload`.
- Wires the first user — `npm_data_stale.use_existing` — so an operator who knows the NPM password can paste it; ServiceBay verifies it against `/api/tokens` before persisting (no chance to overwrite good config with bad).

## Test plan
- [x] Unit tests for the dispatcher's required-input validation, including empty-string rejection
- [x] Unit test confirming `inputs[]` survives `actionsForProbe`
- [x] Full vitest suite green (390 passed, 1 skipped)
- [x] ESLint clean on changed files
- [ ] Manual: Trigger NPM auth-stale state, click "Use existing password", confirm form expands, accepts credentials, verifies, persists, and probe transitions to `ok`.

Closes #250, #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)