### PR TITLE
feat(diagnose): per-item dynamic actions (#251)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
@@ -22,6 +22,14 @@ interface ProbeAction {
   inputs?: ProbeActionInput[];
 }
 
+interface ProbeItem {
+  id: string;
+  label: string;
+  detail?: string;
+  status?: ProbeStatus;
+  actions: ProbeAction[];
+}
+
 interface DiagnoseProbe {
   id: string;
   label: string;
@@ -29,6 +37,7 @@ interface DiagnoseProbe {
   detail: string;
   hint?: string;
   actions?: ProbeAction[];
+  items?: ProbeItem[];
 }
 
 interface DiagnoseResult {
@@ -71,7 +80,7 @@ export default function SelfDiagnoseSection() {
     }
   };
 
-  const runAction = async (probe: DiagnoseProbe, action: ProbeAction, payload?: Record<string, string>) => {
+  const runAction = async (probe: DiagnoseProbe, action: ProbeAction, payload?: Record<string, string>, itemId?: string) => {
     // Confirm-on-destructive guard. The action's description is
     // surfaced in the dialog so the user sees the consequences they
     // accepted.
@@ -79,7 +88,9 @@ export default function SelfDiagnoseSection() {
       const ok = window.confirm(`${action.label}\n\n${action.description}\n\nThis action can't be undone. Continue?`);
       if (!ok) return;
     }
-    const key = `${probe.id}:${action.id}`;
+    // Per-item actions key off the item id too so a row's button
+    // state doesn't bleed into siblings.
+    const key = itemId ? `${probe.id}:${action.id}:${itemId}` : `${probe.id}:${action.id}`;
     setActionState(s => ({ ...s, [key]: { running: true } }));
     // Special case: actions with id `verify_from_device` run as a
     // browser-side fetch instead of dispatching to the server (#264).
@@ -129,6 +140,7 @@ export default function SelfDiagnoseSection() {
           probeId: probe.id,
           actionId: action.id,
           node: result?.node,
+          ...(itemId ? { itemId } : {}),
           ...(payload ? { payload } : {}),
         }),
       });
@@ -326,6 +338,52 @@ export default function SelfDiagnoseSection() {
                               </button>
                             </div>
                           </form>
+                        );
+                      })}
+                    </div>
+                  )}
+                  {(probe.items ?? []).length > 0 && (
+                    <div className="mt-3 space-y-1.5">
+                      {(probe.items ?? []).map(item => {
+                        const itemMeta = STATUS_META[item.status ?? probe.status];
+                        return (
+                          <div
+                            key={item.id}
+                            className={`flex flex-wrap items-center gap-2 px-2 py-1.5 rounded border ${itemMeta.ring} bg-white/60 dark:bg-gray-900/40`}
+                          >
+                            <div className="flex-1 min-w-0">
+                              <div className={`text-xs font-mono ${itemMeta.color}`}>{item.label}</div>
+                              {item.detail && (
+                                <div className="text-xs text-gray-600 dark:text-gray-400 font-mono">{item.detail}</div>
+                              )}
+                            </div>
+                            {item.actions.map(action => {
+                              const key = `${probe.id}:${action.id}:${item.id}`;
+                              const state = actionState[key];
+                              const isRunning = state?.running;
+                              const baseStyle = action.destructive
+                                ? 'bg-red-600 hover:bg-red-700 text-white'
+                                : 'bg-violet-600 hover:bg-violet-700 text-white';
+                              return (
+                                <div key={action.id} className="flex items-center gap-2">
+                                  <button
+                                    onClick={() => void runAction(probe, action, undefined, item.id)}
+                                    disabled={isRunning || running}
+                                    title={action.description}
+                                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
+                                  >
+                                    {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                                    {action.label}
+                                  </button>
+                                  {state?.message && !isRunning && (
+                                    <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
+                                      {state.ok ? '✓' : '✗'} {state.message}
+                                    </span>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
                         );
                       })}
                     </div>

--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { agentManager } from '@/lib/agent/manager';
 import { HealthStore } from '@/lib/health/store';
 import { DigitalTwinStore } from '@/lib/store/twin';
-import { actionsForProbe, type ProbeAction } from '@/lib/diagnose/actions';
+import { actionsForProbe, resolveItemActions, type ProbeAction, type ProbeItem, type ResolvedProbeItem } from '@/lib/diagnose/actions';
 import { checkNpmDataStale } from '@/lib/diagnose/probes/npmDataStale';
 import { checkLanIpChanged } from '@/lib/diagnose/probes/lanIpChanged';
 import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPointing';
@@ -25,14 +25,40 @@ export interface DiagnoseProbe {
    * registered actions — UI shows status + hint only.
    */
   actions?: ProbeAction[];
+  /**
+   * Per-item rows for probes that surface multiple targets (#251 —
+   * e.g. dangling proxy routes, expired certificates). Each item
+   * declares which probe-level action ids apply to it; the diagnose
+   * route resolves those to full ProbeAction objects in `actions`.
+   * Probes can populate `_items` with raw `ProbeItem[]`; the route
+   * runs `resolveItemActions` and exposes the result as `items` to
+   * the wire / UI. The internal field uses an underscore so it
+   * doesn't get mistaken for the resolved shape.
+   */
+  _items?: ProbeItem[];
+  items?: ResolvedProbeItem[];
 }
 
 /** Attach registry-known actions to a probe. Called once per probe in
  *  the diagnose route. Probes whose status is `ok` skip actions to
- *  avoid noisy "fix it" buttons next to passing checks. */
+ *  avoid noisy "fix it" buttons next to passing checks.
+ *
+ *  When the probe has `_items`, action ids referenced by any item are
+ *  treated as per-item-only and excluded from the probe-level
+ *  `actions` list — otherwise the same button shows up twice (once at
+ *  the probe header, once per row). Probes that want both behaviors
+ *  should register two distinct actions. */
 function withActions(probe: DiagnoseProbe): DiagnoseProbe {
+  let perItemActionIds: Set<string> | null = null;
+  if (probe._items) {
+    perItemActionIds = new Set(probe._items.flatMap(i => i.actionIds));
+    const items = resolveItemActions(probe.id, probe._items);
+    probe = { ...probe, items };
+    // Strip the unresolved shape so we don't ship duplicate data.
+    delete (probe as { _items?: ProbeItem[] })._items;
+  }
   if (probe.status === 'ok') return probe;
-  const actions = actionsForProbe(probe.id);
+  const actions = actionsForProbe(probe.id).filter(a => !perItemActionIds?.has(a.id));
   return actions.length > 0 ? { ...probe, actions } : probe;
 }
 
@@ -323,10 +349,17 @@ export async function POST(request: Request) {
   //     host:port that no managed service or running container actually
   //     publishes. Surfaces stale routes from removed/renamed services
   //     and crash-failed services that NPM still has a path to.
+  //
+  //     #251: each dangling route is exposed as a `ProbeItem` so the UI
+  //     can show one row per route with a per-item "Delete route"
+  //     action. The action handler lives in
+  //     `lib/diagnose/probes/danglingProxy.ts` (registers
+  //     `delete_route`).
   try {
     const twin = DigitalTwinStore.getInstance().nodes[nodeName];
     type ProxyServer = {
       _targetPort?: number;
+      _id?: number;
       variable_fields?: { targetHost?: string; targetPort?: number };
       server_name?: string[];
       locations?: { proxy_pass?: string }[];
@@ -353,7 +386,7 @@ export async function POST(request: Request) {
         if (typeof p.hostPort === 'number') knownPorts.add(p.hostPort);
       }
     }
-    const dangling: string[] = [];
+    const danglingItems: ProbeItem[] = [];
     for (const server of proxyConfig) {
       const targetHost = server.variable_fields?.targetHost;
       const targetPort = server.variable_fields?.targetPort ?? server._targetPort;
@@ -363,22 +396,33 @@ export async function POST(request: Request) {
       const isProxySelfRef = ['127.0.0.1', 'localhost', '::1'].includes(targetHost ?? '');
       if (isProxySelfRef) continue;
       if (!knownPorts.has(targetPort)) {
-        const name = (server.server_name ?? []).join(', ') || `(unnamed)`;
-        dangling.push(`${name} → ${targetHost}:${targetPort}`);
+        const name = (server.server_name ?? []).join(', ') || '(unnamed)';
+        // The proxy host's NPM id is needed for the delete-route
+        // action to target the right host. If the twin sync didn't
+        // capture it, omit the action by using an empty actionIds[].
+        const id = typeof server._id === 'number' ? String(server._id) : '';
+        danglingItems.push({
+          id: id || `${name}-${targetPort}`,
+          label: name,
+          detail: `→ ${targetHost}:${targetPort}`,
+          status: 'warn',
+          actionIds: id ? ['delete_route'] : [],
+        });
       }
     }
     probes.push({
       id: 'dangling_proxy',
       label: 'Reverse-proxy routes',
-      status: !proxyService ? 'info' : (dangling.length === 0 ? 'ok' : 'warn'),
+      status: !proxyService ? 'info' : (danglingItems.length === 0 ? 'ok' : 'warn'),
       detail: !proxyService
         ? 'No managed reverse proxy yet (or its config is not synced to the twin).'
-        : dangling.length === 0
+        : danglingItems.length === 0
           ? `${proxyConfig.length} proxy route(s), all reach a known service.`
-          : `${dangling.length} dangling route(s) — proxy_pass target not published by any managed service or container:\n${dangling.join('\n')}`,
-      hint: dangling.length > 0
-        ? 'Open NPM admin (or Settings → Reverse Proxy) and either fix or delete these routes. Most often caused by a removed/renamed service.'
+          : `${danglingItems.length} dangling route(s) — proxy_pass target not published by any managed service or container.`,
+      hint: danglingItems.length > 0
+        ? 'Click "Delete route" on a row to remove it from NPM. Most often caused by a removed/renamed service.'
         : undefined,
+      _items: danglingItems.length > 0 ? danglingItems : undefined,
     });
   } catch (e) {
     probes.push({

--- a/src/app/api/system/diagnose/run-action/route.ts
+++ b/src/app/api/system/diagnose/run-action/route.ts
@@ -24,6 +24,8 @@ const Body = z.object({
   actionId: z.string().min(1).max(64),
   node: z.string().min(1).max(64).optional(),
   payload: z.record(z.string(), z.unknown()).optional(),
+  /** Per-item dynamic actions (#251). Bounded length is just hygiene. */
+  itemId: z.string().min(1).max(128).optional(),
 });
 
 export async function POST(request: Request) {
@@ -42,6 +44,7 @@ export async function POST(request: Request) {
     actionId: parsed.actionId,
     node: parsed.node ?? 'Local',
     payload: parsed.payload,
+    itemId: parsed.itemId,
   });
 
   return NextResponse.json(result, { status: result.ok ? 200 : 400 });

--- a/src/lib/diagnose/actions.test.ts
+++ b/src/lib/diagnose/actions.test.ts
@@ -3,6 +3,7 @@ import {
   registerProbeAction,
   actionsForProbe,
   dispatchProbeAction,
+  resolveItemActions,
   _resetRegistryForTesting,
 } from './actions';
 
@@ -59,7 +60,7 @@ describe('dispatchProbeAction', () => {
     expect(result.ok).toBe(true);
     expect(result.message).toBe('fixed');
     expect(result.refresh).toBe(true); // default
-    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: { foo: 'bar' } });
+    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: { foo: 'bar' }, itemId: undefined });
   });
 
   it('returns ok=false for unknown probe/action pair', async () => {
@@ -166,7 +167,7 @@ describe('inline-form inputs', () => {
       payload: { email: 'a@b.c' /* note optional, omitted */ },
     });
     expect(result.ok).toBe(true);
-    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: { email: 'a@b.c' } });
+    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: { email: 'a@b.c' }, itemId: undefined });
   });
 
   it('exposes inputs[] via actionsForProbe', () => {
@@ -183,5 +184,59 @@ describe('inline-form inputs', () => {
     const [action] = actionsForProbe('p1');
     expect(action.inputs).toHaveLength(1);
     expect(action.inputs?.[0].name).toBe('email');
+  });
+});
+
+describe('per-item actions', () => {
+  it('threads itemId through to the handler', async () => {
+    const handler = vi.fn(async () => ({ ok: true, message: 'deleted' }));
+    registerProbeAction('p1', { id: 'delete', label: 'Delete', description: 'd' }, handler);
+    const result = await dispatchProbeAction({
+      probeId: 'p1',
+      actionId: 'delete',
+      itemId: 'host-42',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(handler).toHaveBeenCalledWith({ node: 'Local', payload: undefined, itemId: 'host-42' });
+  });
+
+  it('resolveItemActions inlines action metadata for each item', () => {
+    registerProbeAction(
+      'p1',
+      { id: 'delete', label: 'Delete', description: 'wipe', destructive: true },
+      async () => ({ ok: true, message: '' }),
+    );
+    registerProbeAction(
+      'p1',
+      { id: 'renew', label: 'Renew', description: 'extend' },
+      async () => ({ ok: true, message: '' }),
+    );
+
+    const resolved = resolveItemActions('p1', [
+      { id: 'item-1', label: 'first', actionIds: ['delete', 'renew'] },
+      { id: 'item-2', label: 'second', actionIds: ['renew'] },
+      { id: 'item-3', label: 'third', actionIds: ['nonexistent'] },
+    ]);
+
+    expect(resolved[0].actions.map(a => a.id)).toEqual(['delete', 'renew']);
+    expect(resolved[0].actions[0].destructive).toBe(true);
+    expect(resolved[1].actions.map(a => a.id)).toEqual(['renew']);
+    // Unknown action ids drop silently rather than crashing the page.
+    expect(resolved[2].actions).toEqual([]);
+  });
+
+  it('resolveItemActions preserves item label, detail, status', () => {
+    registerProbeAction(
+      'p1',
+      { id: 'a1', label: 'A', description: '' },
+      async () => ({ ok: true, message: '' }),
+    );
+    const [resolved] = resolveItemActions('p1', [
+      { id: 'i1', label: 'L', detail: 'D', status: 'fail', actionIds: ['a1'] },
+    ]);
+    expect(resolved.label).toBe('L');
+    expect(resolved.detail).toBe('D');
+    expect(resolved.status).toBe('fail');
   });
 });

--- a/src/lib/diagnose/actions.ts
+++ b/src/lib/diagnose/actions.ts
@@ -106,7 +106,73 @@ export type ProbeActionHandler = (params: {
    * Validate inside the handler — the dispatch layer doesn't.
    */
   payload?: Record<string, unknown>;
+  /**
+   * For per-item dynamic actions (`items[]` on a probe), the id of
+   * the specific item the user clicked — e.g. an NPM proxy_host id.
+   * Absent for probe-level actions; validate inside the handler.
+   */
+  itemId?: string;
 }) => Promise<ProbeActionResult>;
+
+/**
+ * One row inside a probe's `items[]` — used for per-item dynamic
+ * actions (#251). E.g. each dangling proxy route is an item with a
+ * "Delete route" action targeted at its NPM proxy_host id.
+ *
+ * Items reference probe-level actions by id; the diagnose route
+ * resolves the matching `ProbeAction` metadata into `actions[]`
+ * before the response leaves the server, so the UI consumes
+ * `ResolvedProbeItem` directly.
+ */
+export interface ProbeItem {
+  /** Unique within the probe — passed back as `itemId` on dispatch. */
+  id: string;
+  /** Human-readable label, e.g. "vault.dopp.cloud → 192.168.0.10:8443". */
+  label: string;
+  /** Optional secondary line shown below the label. */
+  detail?: string;
+  /**
+   * Optional per-item status. Lets the UI color-code an item
+   * differently from its parent probe (e.g. one expired cert in a
+   * list of healthy ones). Defaults to the probe status when omitted.
+   */
+  status?: 'ok' | 'warn' | 'fail' | 'info';
+  /**
+   * Action IDs available on this item. Must each match an action
+   * registered against the probe via `registerProbeAction`.
+   */
+  actionIds: string[];
+}
+
+/** Server-to-client item shape — `actionIds` resolved to full
+ *  `ProbeAction` objects by `resolveItemActions`. */
+export interface ResolvedProbeItem {
+  id: string;
+  label: string;
+  detail?: string;
+  status?: 'ok' | 'warn' | 'fail' | 'info';
+  actions: ProbeAction[];
+}
+
+/**
+ * Resolve a probe's items[] action-ids to the full ProbeAction
+ * objects from the registry, so the UI doesn't need a second lookup.
+ * Items whose actionIds reference unknown actions silently drop those
+ * ids — better to render fewer buttons than crash the diagnose page.
+ */
+export function resolveItemActions(probeId: string, items: ProbeItem[]): ResolvedProbeItem[] {
+  const actions = actionsForProbe(probeId);
+  const byId = new Map(actions.map(a => [a.id, a]));
+  return items.map(item => ({
+    id: item.id,
+    label: item.label,
+    detail: item.detail,
+    status: item.status,
+    actions: item.actionIds
+      .map(id => byId.get(id))
+      .filter((a): a is ProbeAction => a !== undefined),
+  }));
+}
 
 interface RegistryEntry {
   action: ProbeAction;
@@ -156,6 +222,8 @@ export async function dispatchProbeAction(params: {
   actionId: string;
   node: string;
   payload?: Record<string, unknown>;
+  /** Optional — present only for per-item dynamic actions. See ProbeItem. */
+  itemId?: string;
 }): Promise<ProbeActionResult> {
   const k = key(params.probeId, params.actionId);
   const entry = registry.get(k);
@@ -185,7 +253,11 @@ export async function dispatchProbeAction(params: {
     }
   }
   try {
-    const result = await entry.handler({ node: params.node, payload: params.payload });
+    const result = await entry.handler({
+      node: params.node,
+      payload: params.payload,
+      itemId: params.itemId,
+    });
     // Default refresh = true so probes auto-re-run after a fix.
     return { refresh: true, ...result };
   } catch (e) {

--- a/src/lib/diagnose/probes/danglingProxy.ts
+++ b/src/lib/diagnose/probes/danglingProxy.ts
@@ -1,0 +1,137 @@
+/**
+ * `dangling_proxy` probe — surfaces NPM proxy hosts whose forward target
+ * isn't backed by any managed service or running container. The
+ * detection itself lives inline in the diagnose route (it needs the
+ * digital twin); this module only registers the per-item
+ * `delete_route` action (#251) so each row in the items list gets a
+ * "Delete route" button.
+ *
+ * The action handler authenticates against NPM with stored credentials
+ * (or the wizard defaults) and DELETEs the proxy host by id. The id
+ * is threaded through as `itemId` per the F1 per-item-actions
+ * extension.
+ */
+
+import { getConfig } from '@/lib/config';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const PROBE_ID = 'dangling_proxy';
+
+/** Locate NPM's admin URL on the given node. Returns null when nginx
+ *  isn't deployed or its admin port can't be derived. Mirrors the
+ *  helper in npmDataStale.ts but kept local to avoid coupling. */
+async function findNpmAdminUrl(node: string): Promise<string | null> {
+  try {
+    const services = await ServiceManager.listServices(node);
+    const nginx = services.find(
+      s => s.name === 'nginx' || s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
+    );
+    if (!nginx?.active) return null;
+    const ports = (nginx.ports ?? [])
+      .map(p => parseInt(String(p.host ?? ''), 10))
+      .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
+    const adminPort = ports[0] ?? 81;
+    return `http://localhost:${adminPort}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Try stored credentials first, then NPM defaults. Returns the bearer
+ *  token, or null when nothing works. */
+async function getNpmToken(adminUrl: string): Promise<string | null> {
+  const config = await getConfig();
+  const candidates: { identity: string; secret: string }[] = [];
+  const stored = config.reverseProxy?.npm;
+  if (stored?.email && stored?.password) {
+    candidates.push({ identity: stored.email, secret: stored.password });
+  }
+  candidates.push({ identity: 'admin@example.com', secret: 'changeme' });
+
+  for (const cred of candidates) {
+    try {
+      const res = await fetch(`${adminUrl}/api/tokens`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cred),
+        signal: AbortSignal.timeout(4000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (typeof data.token === 'string') return data.token;
+      }
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}
+
+async function deleteRoute({
+  node,
+  itemId,
+}: {
+  node: string;
+  itemId?: string;
+}): Promise<ProbeActionResult> {
+  if (!itemId) {
+    return { ok: false, message: 'No proxy-host id supplied — cannot delete.', refresh: false };
+  }
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return {
+      ok: false,
+      message: 'Nginx Proxy Manager is not deployed on this node.',
+      refresh: false,
+    };
+  }
+  const token = await getNpmToken(adminUrl);
+  if (!token) {
+    return {
+      ok: false,
+      message: 'Could not authenticate against NPM. If a stale-credentials probe is also showing, fix that first.',
+      refresh: false,
+    };
+  }
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/proxy-hosts/${encodeURIComponent(itemId)}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      logger.warn('diagnose:dangling_proxy', `DELETE ${itemId} returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+      return {
+        ok: false,
+        message: `NPM returned HTTP ${res.status} when deleting the route.`,
+        refresh: false,
+      };
+    }
+    return {
+      ok: true,
+      message: `Route ${itemId} removed.`,
+      refresh: true,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      message: `Failed to reach NPM: ${e instanceof Error ? e.message : String(e)}`,
+      refresh: false,
+    };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'delete_route',
+    label: 'Delete route',
+    description:
+      'Removes this proxy host from Nginx Proxy Manager. The forward target is no longer backed by a managed service, so the route is just dead config — but the deletion is permanent. Re-create from a service template if you change your mind.',
+    destructive: true,
+  },
+  deleteRoute,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -14,5 +14,6 @@
 
 import './npmDataStale';
 import './routerDnsNotPointing';
+import './danglingProxy';
 
 export {};


### PR DESCRIPTION
## Summary
- Extends F1 with `items[]` on probes so a probe can list multiple targets (e.g. dangling routes, expired certs) and attach per-row actions instead of stuffing everything into a multi-line `detail` string.
- New `ProbeItem` (id, label, detail?, status?, actionIds[]) — items reference probe-level actions by id; the diagnose route resolves them to full `ProbeAction` metadata before responding.
- Dispatcher threads optional `itemId` through to the handler so per-item handlers (delete X, renew Y) know which row.
- When a probe ships `_items`, action ids referenced by any item are excluded from the probe-level actions list — otherwise the same button would appear at the probe header AND per-row.
- First consumer: `dangling_proxy` probe migrates from a multi-line detail string to one item per stale route, each with a "Delete route" action that DELETEs the matching NPM proxy_host id.

## Test plan
- [x] Unit tests: itemId threading, action-id resolution, unknown-id graceful drop, label/detail/status preservation
- [x] Full vitest suite green (393 passed, 1 skipped)
- [x] ESLint clean
- [ ] Manual: install + remove a service so a route goes stale; confirm dangling_proxy shows it as a row with a "Delete route" button, click it, confirm NPM removes the host and probe re-runs to ok.

Closes #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)