### PR TITLE
feat(diagnose): persist post-deploy exit + B8 probe (#252)

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -6,6 +6,7 @@ import { actionsForProbe, resolveItemActions, type ProbeAction, type ProbeItem, 
 import { checkNpmDataStale } from '@/lib/diagnose/probes/npmDataStale';
 import { checkLanIpChanged } from '@/lib/diagnose/probes/lanIpChanged';
 import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPointing';
+import { checkPostDeployFailed } from '@/lib/diagnose/probes/postDeployFailed';
 import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
@@ -494,6 +495,29 @@ export async function POST(request: Request) {
     probes.push({
       id: 'router_dns_not_pointing',
       label: 'Router DNS routing',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 15) Post-deploy seed failures (B8 / #252). Surfaces services whose
+  //     last `post-deploy.py` exited non-zero so silent seed failures
+  //     don't sit there indefinitely. Each failed service is one item
+  //     with per-row "Re-run post-install" + "Clear record" actions.
+  try {
+    const pd = await checkPostDeployFailed();
+    probes.push({
+      id: 'post_deploy_failed',
+      label: 'Service seed steps',
+      status: pd.status,
+      detail: pd.detail,
+      hint: pd.hint,
+      _items: pd.items,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'post_deploy_failed',
+      label: 'Service seed steps',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -200,6 +200,26 @@ export interface AppConfig {
   };
   setupCompleted?: boolean;
   stackSetupPending?: boolean;
+  /**
+   * Per-service record of the last `post-deploy.py` run. Written by
+   * `ServiceManager.runPostDeployScript` after every run; read by the
+   * `post_deploy_failed` probe (B8 / #241) so it can surface
+   * "Re-run post-install" actions instead of letting silent seed
+   * failures linger. See #252.
+   *
+   * Key is the template/service name (e.g. `vaultwarden`, `auth`).
+   * `stdoutTail` is bounded to ~1KB so config.json stays small.
+   */
+  servicePostDeploy?: Record<string, ServicePostDeployRecord>;
+}
+
+export interface ServicePostDeployRecord {
+  /** ISO timestamp of when the script finished (success or failure). */
+  lastRunAt: string;
+  /** Exit code; 0 = success. */
+  exitCode: number;
+  /** Tail of stdout (last ~1KB). Aids "what failed" diagnosis without bloating config. */
+  stdoutTail?: string;
 }
 
 export function getOidcCallbackUrl(config: { reverseProxy?: { publicDomain?: string } }): string {

--- a/src/lib/diagnose/probes/postDeployFailed.ts
+++ b/src/lib/diagnose/probes/postDeployFailed.ts
@@ -1,0 +1,175 @@
+/**
+ * `post_deploy_failed` probe (B8 / #241) — surfaces services whose
+ * last `post-deploy.py` run exited non-zero. Without this signal,
+ * silent seed failures (LLDAP not initialized, NPM proxy host not
+ * created, FileBrowser admin not promoted) sit there indefinitely;
+ * the install log already scrolled away and there's no other place
+ * the operator would notice.
+ *
+ * Each failed service shows up as one item in the probe with two
+ * actions:
+ *   - `rerun_post_deploy` (per-item) — re-runs the same script the
+ *     original deploy ran, using the env file already on disk.
+ *   - `dismiss_post_deploy` (per-item) — clears the persisted
+ *     failure for that service so the probe stops nagging when the
+ *     operator has fixed it manually.
+ *
+ * Reads `config.servicePostDeploy[name]` written by
+ * `ServiceManager.runPostDeployScript`. See #252 for the schema.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig, updateConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+
+const PROBE_ID = 'post_deploy_failed';
+
+export interface PostDeployFailedResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+export async function checkPostDeployFailed(): Promise<PostDeployFailedResult> {
+  const config = await getConfig();
+  const records = config.servicePostDeploy ?? {};
+  const failed = Object.entries(records).filter(([, r]) => r.exitCode !== 0);
+  if (Object.keys(records).length === 0) {
+    return {
+      status: 'info',
+      detail: 'No post-deploy runs recorded yet — either no services are installed or they predate the persistence change.',
+    };
+  }
+  if (failed.length === 0) {
+    return {
+      status: 'ok',
+      detail: `${Object.keys(records).length} post-deploy run(s) recorded, all exited 0.`,
+    };
+  }
+  const items: ProbeItem[] = failed.map(([name, r]) => ({
+    id: name,
+    label: name,
+    detail: `exit ${r.exitCode} at ${new Date(r.lastRunAt).toLocaleString()}`,
+    status: 'warn',
+    actionIds: ['rerun_post_deploy', 'dismiss_post_deploy'],
+  }));
+  return {
+    status: 'warn',
+    detail: `${failed.length} service${failed.length === 1 ? '' : 's'} ended its last post-deploy with a non-zero exit. Seeds (admin users, default proxy hosts, etc.) likely didn\'t complete.`,
+    hint: 'Click "Re-run post-install" on a row to repeat the seed step. The script + env are already on disk from the original run.',
+    items,
+  };
+}
+
+async function rerunPostDeploy({
+  node,
+  itemId,
+}: {
+  node: string;
+  itemId?: string;
+}): Promise<ProbeActionResult> {
+  if (!itemId) {
+    return { ok: false, message: 'No service id supplied.', refresh: false };
+  }
+  const agent = await agentManager.ensureAgent(node);
+  const scriptDir = `~/.local/share/servicebay/post-deploy`;
+  const scriptPath = `${scriptDir}/${itemId}.py`;
+  const envPath = `${scriptDir}/${itemId}.env`;
+  // Verify the artifacts are still on disk before trying to re-run.
+  const check = await agent.sendCommand('exec', {
+    command: `test -f ${scriptPath} && test -f ${envPath} && echo ok`,
+  }, { timeoutMs: 5_000 });
+  if ((check as { stdout?: string }).stdout?.trim() !== 'ok') {
+    return {
+      ok: false,
+      message: `Couldn't find the original post-deploy artifacts for ${itemId} on the node. Re-run a Settings → Services → ${itemId} → redeploy to regenerate them.`,
+      refresh: false,
+    };
+  }
+  // The original deploy used a 20-min client budget; the same applies
+  // here. exec_stream isn't strictly needed — the operator already saw
+  // the failure once; re-runs surface success/failure in the toast.
+  const result = await agent.sendCommand('exec', {
+    command: `set -a; source ${envPath}; set +a; python3 ${scriptPath} 2>&1`,
+    timeout: 1200,
+  }, { timeoutMs: 1_200_000 }) as { code?: number; stdout?: string };
+
+  // Persist the new run so the probe transitions to ok / stays warn.
+  const stdoutTail = (result.stdout ?? '').slice(-1024) || undefined;
+  try {
+    await updateConfig({
+      servicePostDeploy: {
+        [itemId]: {
+          lastRunAt: new Date().toISOString(),
+          exitCode: result.code ?? -1,
+          stdoutTail,
+        },
+      },
+    });
+  } catch (e) {
+    logger.warn('diagnose:post_deploy_failed', `Could not persist re-run for ${itemId}:`, e);
+  }
+
+  if (result.code === 0) {
+    return {
+      ok: true,
+      message: `${itemId} post-deploy re-run succeeded.`,
+      refresh: true,
+    };
+  }
+  // Tail the last line of stdout so the operator gets a concrete hint
+  // in the toast — usually that's where the script's own error message
+  // landed.
+  const lastLine = (result.stdout ?? '').trim().split('\n').pop() ?? '';
+  return {
+    ok: false,
+    message: `${itemId} re-run still failed (exit ${result.code}). ${lastLine ? `Last log line: ${lastLine.slice(0, 200)}` : ''}`,
+    refresh: true,
+  };
+}
+
+async function dismissPostDeploy({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
+  if (!itemId) {
+    return { ok: false, message: 'No service id supplied.', refresh: false };
+  }
+  const config = await getConfig();
+  const records = { ...(config.servicePostDeploy ?? {}) };
+  if (!(itemId in records)) {
+    return { ok: false, message: `No post-deploy record for ${itemId}.`, refresh: false };
+  }
+  delete records[itemId];
+  // updateConfig deep-merges, so we need to write the whole object —
+  // a simple merge would re-add the missing key from the previous
+  // value. Re-save the full config explicitly.
+  const { saveConfig } = await import('@/lib/config');
+  await saveConfig({ ...config, servicePostDeploy: records });
+  return {
+    ok: true,
+    message: `Cleared post-deploy record for ${itemId}.`,
+    refresh: true,
+  };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'rerun_post_deploy',
+    label: 'Re-run post-install',
+    description:
+      'Re-runs the seed script for this service using the same env file the original deploy generated. Idempotent for well-written scripts (admin user already exists → skip; proxy host already created → skip).',
+  },
+  rerunPostDeploy,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'dismiss_post_deploy',
+    label: 'Clear record',
+    description:
+      'Removes the persisted failure record for this service so the probe stops surfacing it. Use when you fixed the seed manually and don\'t want the warning anymore.',
+  },
+  dismissPostDeploy,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -15,5 +15,6 @@
 import './npmDataStale';
 import './routerDnsNotPointing';
 import './danglingProxy';
+import './postDeployFailed';
 
 export {};

--- a/src/lib/services/ServiceManager.ts
+++ b/src/lib/services/ServiceManager.ts
@@ -2,7 +2,7 @@ import { agentManager } from '../agent/manager';
 import path from 'path';
 import yaml from 'js-yaml';
 import { logger } from '../logger';
-import { getConfig } from '../config';
+import { getConfig, updateConfig } from '../config';
 import { saveSnapshot } from '../history';
 import { injectServiceDirectives } from './quadletDirectives';
 
@@ -720,6 +720,27 @@ export class ServiceManager {
         }
         if (result.code !== 0) {
             onProgress?.(`⚠️ ${name} post-deploy exited ${result.code}. Service is deployed; the seed step did not finish — check the log lines above for the cause.`);
+        }
+
+        // Persist the run so the diagnose page can surface failed seeds
+        // long after the install log scrolled away (#252). Bound the
+        // stdout tail to ~1KB so config.json stays small. Failures here
+        // are best-effort — the seed result itself was already logged
+        // and shown to the user; losing the persistence just means B8
+        // can't surface this run later.
+        try {
+            const stdoutTail = (result.stdout ?? '').slice(-1024) || undefined;
+            await updateConfig({
+                servicePostDeploy: {
+                    [name]: {
+                        lastRunAt: new Date().toISOString(),
+                        exitCode: result.code,
+                        stdoutTail,
+                    },
+                },
+            });
+        } catch (e) {
+            logger.warn('ServiceManager', `Could not persist post-deploy result for ${name}:`, e);
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `config.servicePostDeploy[name] = { lastRunAt, exitCode, stdoutTail }` written by every \`ServiceManager.runPostDeployScript\` invocation.
- New B8 \`post_deploy_failed\` probe — uses #251's \`items[]\` schema to list each failed service with per-row actions:
  - **Re-run post-install** — re-runs the same script using the env file already on disk (idempotent for well-written scripts).
  - **Clear record** — drops the persisted failure when the operator fixed it manually.
- \`stdoutTail\` is bounded to ~1KB to keep config.json small.

## Stacked on
\`feat/diagnose-per-item-actions\` (#282) — re-target to \`main\` once that lands.

## Test plan
- [x] Full vitest suite green (393 passed)
- [x] ESLint clean
- [ ] Manual: deploy a service with a deliberately-broken post-deploy.py (e.g. exit 1), confirm the probe surfaces it as a row with both actions; click "Re-run" on a fixed script and watch it transition to ok.

Closes #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)