### PR TITLE
feat(diagnose): per-container actions on crash_loop probe (B15)

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -288,9 +288,20 @@ export async function POST(request: Request) {
       return { line, snippet };
     }),
   );
-  const offenderDetail = offenderDiagnostics.map(o =>
-    o.snippet ? `${o.line}\n      ↳ ${o.snippet.split('\n').join('\n        ')}` : o.line,
-  ).join('\n');
+  // Build per-container items so the UI can attach Restart / Show
+  // recent logs actions to each looping container individually
+  // (B15 / #251 items[] schema).
+  const crashLoopItems: ProbeItem[] = offenderDiagnostics.map((o): ProbeItem => {
+    const name = (o.line.split('|')[0] ?? '').trim();
+    const podmanStatus = (o.line.split('|')[1] ?? '').trim();
+    return {
+      id: name,
+      label: name,
+      detail: o.snippet ? `${podmanStatus} — ${o.snippet.split('\n').slice(-2).join(' | ')}` : podmanStatus,
+      status: 'warn',
+      actionIds: ['restart_pod', 'show_recent_logs'],
+    };
+  }).filter(item => item.id);
 
   probes.push({
     id: 'crash_loop',
@@ -304,10 +315,11 @@ export async function POST(request: Request) {
             ? (treatYoungAsLoop
                 ? `${psLines.length} container(s), all stable.`
                 : `${psLines.length} container(s) — system booted ${systemUptimeSec}s ago, young containers expected. Re-run after ~2 min for a real restart-loop check.`)
-            : `${looping.length} of ${psLines.length} container(s) may be in a restart loop:\n${offenderDetail}`),
+            : `${looping.length} of ${psLines.length} container(s) may be in a restart loop.`),
     hint: looping.length > 0
-      ? 'The lines under `↳` are the last 3 stderr lines from `podman logs`. Common causes: bind-mount permission mismatch (rootless UID), missing config file, port conflicts, image entrypoint argv errors.'
+      ? 'Each row shows the last log lines from the container. Click "Restart" after fixing the root cause (bind-mount perms, missing config, port conflict). "Show recent logs" pulls the last 5 lines for a quick triage without SSH.'
       : undefined,
+    _items: crashLoopItems.length > 0 ? crashLoopItems : undefined,
   });
 
   // 10) Health-check coverage. After a few minutes since boot every enabled

--- a/src/lib/diagnose/probes/crashLoop.ts
+++ b/src/lib/diagnose/probes/crashLoop.ts
@@ -1,0 +1,152 @@
+/**
+ * `crash_loop` probe actions (B15 / #241) — registers per-item handlers
+ * that operate on the specific container the diagnose route surfaces
+ * as restart-looping.
+ *
+ * The detection logic lives inline in the diagnose route (it walks
+ * `podman ps` output and consults system uptime to suppress
+ * just-booted false positives). This file only contributes the
+ * actions that hang off each item:
+ *   - `restart_pod` — `systemctl --user restart <name>.service`. Most
+ *     restart loops resolve once the bind-mount permission, missing
+ *     config, or port collision behind them is corrected; a manual
+ *     restart kicks the unit out of its backoff window so the operator
+ *     gets immediate feedback.
+ *   - `show_recent_logs` — pulls the last 30 stderr lines via
+ *     `podman logs --tail 30`. The diagnose card already shows three
+ *     lines inline; this surfaces enough detail for an operator to
+ *     spot the actual crash cause (missing env var, EPERM, OOM, …)
+ *     without having to SSH into the box.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const PROBE_ID = 'crash_loop';
+
+// Matches a podman container name. Containers we manage are produced by
+// quadlet from a kube YAML; podman normalizes names to lowercase
+// alphanumerics + hyphens + underscores. Reject anything else so an
+// itemId from a malformed payload can't be smuggled into the agent
+// shell.
+const SAFE_NAME = /^[a-z0-9][a-z0-9_-]{0,127}$/i;
+
+function rejectUnsafeName(itemId?: string): ProbeActionResult | null {
+  if (!itemId) {
+    return { ok: false, message: 'No container name supplied.', refresh: false };
+  }
+  if (!SAFE_NAME.test(itemId)) {
+    return { ok: false, message: `Container name "${itemId}" looks unsafe — refusing.`, refresh: false };
+  }
+  return null;
+}
+
+async function restartPod({
+  node,
+  itemId,
+}: {
+  node: string;
+  itemId?: string;
+}): Promise<ProbeActionResult> {
+  const guard = rejectUnsafeName(itemId);
+  if (guard) return guard;
+
+  const agent = await agentManager.ensureAgent(node);
+  // Container name → service unit. Quadlet generates `<name>.service`
+  // for kube units; if the looping name is an infra-pod container that
+  // doesn't have a unit, fall back to `podman restart <name>` so the
+  // user still gets relief. Try the unit path first because it's the
+  // canonical way to restart a managed service.
+  const unitRes = await agent.sendCommand('exec', {
+    command: `systemctl --user restart ${itemId}.service 2>&1`,
+  }, { timeoutMs: 30_000 }) as { code?: number; stderr?: string; stdout?: string };
+
+  if (unitRes.code === 0) {
+    return {
+      ok: true,
+      message: `Restarted ${itemId}.service. Re-check in ~30 s; if it loops again the underlying cause is still present.`,
+      refresh: true,
+    };
+  }
+
+  // Non-zero from systemctl is most often "Unit not found" because
+  // the looping container is a podman-direct one (e.g. an infra-pod
+  // child container quadlet doesn't manage). Fall back to a direct
+  // podman restart in that case.
+  logger.info('diagnose:crash_loop', `systemctl restart ${itemId}.service returned ${unitRes.code}; falling back to podman restart`);
+  const podmanRes = await agent.sendCommand('exec', {
+    command: `podman restart ${itemId} 2>&1`,
+  }, { timeoutMs: 30_000 }) as { code?: number; stderr?: string; stdout?: string };
+
+  if (podmanRes.code === 0) {
+    return {
+      ok: true,
+      message: `Restarted container ${itemId}. Re-check in ~30 s.`,
+      refresh: true,
+    };
+  }
+  return {
+    ok: false,
+    message: `Could not restart ${itemId}: ${(podmanRes.stderr ?? podmanRes.stdout ?? '').trim().slice(0, 200) || 'unknown error'}.`,
+    refresh: false,
+  };
+}
+
+async function showRecentLogs({
+  node,
+  itemId,
+}: {
+  node: string;
+  itemId?: string;
+}): Promise<ProbeActionResult> {
+  const guard = rejectUnsafeName(itemId);
+  if (guard) return guard;
+
+  const agent = await agentManager.ensureAgent(node);
+  const res = await agent.sendCommand('exec', {
+    command: `podman logs --tail 30 ${itemId} 2>&1`,
+  }, { timeoutMs: 10_000 }) as { code?: number; stdout?: string };
+
+  const log = (res.stdout ?? '').trim();
+  if (!log) {
+    return {
+      ok: true,
+      message: `No recent logs for ${itemId} — the container may have crashed before producing output. Try Settings → Services → ${itemId} → Logs for a wider time range.`,
+      refresh: false,
+    };
+  }
+  // Action result messages render as a one-line toast — too small for
+  // 30 lines of log. Surface the last 5 lines (most-recent-failure
+  // signal) plus a count so the operator knows there's more to see.
+  const lines = log.split('\n');
+  const tail = lines.slice(-5).join(' | ');
+  const truncated = lines.length > 5 ? ` (${lines.length} lines total — see Settings → Services → ${itemId} → Logs for full output)` : '';
+  return {
+    ok: true,
+    message: `Last 5 lines: ${tail.slice(0, 600)}${truncated}`,
+    refresh: false,
+  };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'restart_pod',
+    label: 'Restart',
+    description:
+      'Restarts this container via systemctl (or podman restart for non-quadlet containers). Use after fixing the underlying cause (bind-mount perms, missing config, port collision) to break the backoff loop.',
+  },
+  restartPod,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'show_recent_logs',
+    label: 'Show recent logs',
+    description:
+      'Fetches the last 30 stderr lines via `podman logs --tail 30`. Surfaces 5 in the toast — enough to identify the crash cause without SSH-ing into the box.',
+  },
+  showRecentLogs,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -16,5 +16,6 @@ import './npmDataStale';
 import './routerDnsNotPointing';
 import './danglingProxy';
 import './postDeployFailed';
+import './crashLoop';
 
 export {};


### PR DESCRIPTION
## Summary
- Migrates the existing \`crash_loop\` probe from a multi-line \`detail\` string to one item per restart-looping container.
- Each item has two per-row actions:
  - **Restart** — \`systemctl --user restart <name>.service\`, falls back to \`podman restart <name>\` for non-quadlet containers
  - **Show recent logs** — \`podman logs --tail 30\`, surfaces the last 5 lines in the toast for quick triage without SSH

Container names from the agent are validated against \`/^[a-z0-9][a-z0-9_-]{0,127}$/i\` before being interpolated into shell commands.

## Test plan
- [x] Full vitest suite green (393 passed, 1 skipped)
- [x] ESLint clean
- [x] \`next build\` clean (TypeScript narrow check fixed via explicit return type annotation)
- [ ] Manual: deliberately break a service so it enters a restart loop (e.g. invalid mount path), confirm the probe lists it as a row with both buttons; click Restart after fixing the cause and verify the probe transitions to ok.

Refs #241 section B15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)