### PR TITLE
fix(wizard): settle-wait reads stale digitalTwin from closure

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -294,6 +294,15 @@ export default function OnboardingWizard() {
   // when the deploy API just returned. (Earlier log-parsing version
   // showed "12/12 deployed" while NPM was still pulling its image.)
   const { data: digitalTwin } = useDigitalTwin();
+  // Async install handlers (deploy → settle-wait → done) capture the
+  // initial digitalTwin closure value and never see SSE-driven updates
+  // for the duration of the loop. Mirror the latest value into a ref
+  // so those long-running async functions can read fresh state via
+  // `digitalTwinRef.current`. Without this, the settle-wait loop reads
+  // stale data and reports "0/N services active" indefinitely even
+  // though services are actually coming up.
+  const digitalTwinRef = useRef(digitalTwin);
+  useEffect(() => { digitalTwinRef.current = digitalTwin; }, [digitalTwin]);
 
   // Configure-step tab. Variables are categorised so the operator isn't
   // staring at a 50-line flat list — the "subdomains" tab shows the
@@ -1314,14 +1323,17 @@ export default function OnboardingWizard() {
       // actually deployed. A failed deploy isn't going to become active
       // and a stuck "0/9 up" heartbeat is just noise.
       const expected = deployed.map(i => i.name);
-      if (digitalTwin && expected.length > 0) {
+      // Read via the ref so each poll iteration sees fresh SSE updates
+      // — `digitalTwin` from the closure is the snapshot at handler-
+      // start time and never changes for the duration of this loop.
+      if (digitalTwinRef.current && expected.length > 0) {
         const SETTLE_TIMEOUT_MS = 3 * 60_000;
         const SETTLE_POLL_MS = 5_000;
         const startedAt = Date.now();
         let lastReady = -1;
         while (Date.now() - startedAt < SETTLE_TIMEOUT_MS) {
           const node = stackSelectedNode || 'Local';
-          const twinNode = digitalTwin?.nodes?.[node];
+          const twinNode = digitalTwinRef.current?.nodes?.[node];
           const services = twinNode?.services ?? [];
           const ready = expected.filter(name =>
             services.some(s => (s.name === name || s.name === `${name}.service`) && s.active),


### PR DESCRIPTION
## What you saw

Fresh install of 3.12.0:
- Wizard log: \`Waiting for services to become active... (0/9 up)\` for the full 3-min budget
- Then: \`⚠️ 0/9 services active after 216s — slow image pulls or a real failure. Self-diagnose below will tell you which.\`
- Done screen self-test: \`✅ Self-test passed — 11 ok · 0 warn · 0 fail\`
- All 9 services actually up — just the wizard's settle-wait counter never registered them.

## What was wrong

The settle-wait loop in \`OnboardingWizard.tsx\` reads \`digitalTwin\` straight out of the React state hook — which gets captured by closure when the async install handler starts. SSE-driven twin updates that arrive *after* the handler started flow into a fresh React state, but the long-running async loop only ever sees the snapshot it started with.

Net effect: \`ready\` stayed at 0 for the entire poll budget regardless of what was actually deploying.

## Fix

Mirror \`digitalTwin\` into a \`useRef\` kept in sync via \`useEffect\`. The settle-wait loop now reads \`digitalTwinRef.current\` on each iteration, picking up live updates.

## Test plan
- [x] Full vitest suite green (393 passed)
- [x] \`next build\` clean
- [ ] Manual: redo a fresh install, confirm the log progresses (1/9 → 2/9 → … → 9/9 up) within ~30 s of services starting, and the final summary reads \`✅ All 9 services active after Xs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)