### PR TITLE
feat(credentials): persist install manifest encrypted at rest (#19/A1)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Eye, EyeOff, Key, Loader2, Trash2 } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+interface Credential {
+  service: string;
+  url: string;
+  username: string;
+  password: string;
+  importance: 'critical' | 'system';
+  notes?: string;
+}
+
+interface Manifest {
+  savedAt: string;
+  credentials: Credential[];
+}
+
+/**
+ * Settings section that surfaces the encrypted credentials manifest
+ * the install wizard persisted (#19 / A1). Encrypted at rest in
+ * `config.json`; decrypted by the same admin session that's loading
+ * this page.
+ *
+ * Two affordances:
+ *   - Per-row password reveal (default hidden) so the page doesn't
+ *     leak secrets at a glance to anyone shoulder-surfing.
+ *   - "Wipe from server" button that clears the manifest after the
+ *     operator has stored credentials in their password manager —
+ *     narrows the window during which plaintext-decryptable secrets
+ *     sit in config.json.
+ */
+export default function CredentialsSection() {
+  const { addToast } = useToast();
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [busy, setBusy] = useState<'load' | 'wipe' | null>('load');
+  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    fetch('/api/system/credentials')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (data) setManifest(data.manifest ?? null);
+      })
+      .finally(() => setBusy(null));
+  }, []);
+
+  const onWipe = async () => {
+    if (!window.confirm(
+      'Wipe credentials from the server?\n\n' +
+      'Make sure you\'ve already saved them in your password manager — once wiped, you\'ll need to dig them out of running services manually (or reinstall) to recover.\n\n' +
+      'The credentials themselves remain in the running services; this only clears ServiceBay\'s saved copy.',
+    )) return;
+    setBusy('wipe');
+    try {
+      const res = await fetch('/api/system/credentials', { method: 'DELETE' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        addToast('error', 'Could not wipe credentials', data.error || `HTTP ${res.status}`);
+        return;
+      }
+      setManifest(null);
+      addToast('success', 'Credentials wiped from server', 'The saved manifest is gone. Services keep running with the same passwords — they just aren\'t in ServiceBay\'s config anymore.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (busy === 'load') {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading credentials…
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 bg-violet-100 dark:bg-violet-900/30 rounded-lg text-violet-600 dark:text-violet-400">
+          <Key size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">Saved credentials</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {manifest
+              ? `Persisted at ${new Date(manifest.savedAt).toLocaleString()} — encrypted at rest, visible to logged-in admins.`
+              : 'No credentials saved. Install a service via the wizard to populate this list.'}
+          </p>
+        </div>
+        {manifest && manifest.credentials.length > 0 && (
+          <button
+            onClick={onWipe}
+            disabled={busy === 'wipe'}
+            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+            title="Remove the saved credentials from the server. Useful once you've stored them safely in your password manager."
+          >
+            {busy === 'wipe' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+            Wipe from server
+          </button>
+        )}
+      </div>
+
+      <div className="p-6">
+        {!manifest || manifest.credentials.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+            Nothing saved yet. The install wizard writes here at the end of every successful run.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs uppercase text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                <tr>
+                  <th className="text-left py-2 pr-3">Service</th>
+                  <th className="text-left py-2 pr-3">URL</th>
+                  <th className="text-left py-2 pr-3">Username</th>
+                  <th className="text-left py-2 pr-3">Password</th>
+                  <th className="text-left py-2">Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {manifest.credentials.map((c, i) => {
+                  const isRevealed = !!revealed[i];
+                  const rowClass = c.importance === 'critical'
+                    ? 'border-b border-gray-100 dark:border-gray-800'
+                    : 'border-b border-gray-100 dark:border-gray-800 opacity-80';
+                  return (
+                    <tr key={i} className={rowClass}>
+                      <td className="py-2 pr-3 font-medium text-gray-900 dark:text-white">
+                        {c.service}
+                        {c.importance === 'system' && (
+                          <span className="ml-2 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">system</span>
+                        )}
+                      </td>
+                      <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-mono text-xs">{c.url}</td>
+                      <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-mono text-xs">{c.username}</td>
+                      <td className="py-2 pr-3">
+                        <div className="flex items-center gap-2">
+                          <code className="font-mono text-xs">{isRevealed ? c.password : '••••••••••'}</code>
+                          <button
+                            onClick={() => setRevealed(s => ({ ...s, [i]: !s[i] }))}
+                            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                            title={isRevealed ? 'Hide password' : 'Reveal password'}
+                          >
+                            {isRevealed ? <EyeOff size={12} /> : <Eye size={12} />}
+                          </button>
+                          {isRevealed && (
+                            <button
+                              onClick={() => {
+                                navigator.clipboard.writeText(c.password).then(
+                                  () => addToast('success', 'Copied to clipboard', `${c.service} password`),
+                                  () => addToast('error', 'Copy failed', 'Browser refused clipboard access.'),
+                                );
+                              }}
+                              className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-[10px] uppercase tracking-wide"
+                            >
+                              copy
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                      <td className="py-2 text-xs text-gray-500 dark:text-gray-400">{c.notes ?? ''}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import CredentialsSection from '../_lib/sections/CredentialsSection';
 import EmailNotificationsSection from '../_lib/sections/EmailNotificationsSection';
 import McpSection from '../_lib/sections/McpSection';
 import PublicDomainSection from '../_lib/sections/PublicDomainSection';
@@ -11,6 +12,7 @@ export default function IntegrationsSettingsPage() {
   return (
     <>
       <PublicDomainSection />
+      <CredentialsSection />
       <ReverseProxySection />
       <EmailNotificationsSection />
       <McpSection />

--- a/src/app/api/system/credentials/route.ts
+++ b/src/app/api/system/credentials/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getConfig, saveConfig, type InstalledCredential, type InstallManifest } from '@/lib/config';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Install-credentials manifest persistence (#19 / A1).
+ *
+ *   GET    — return the manifest stored at install time so the operator
+ *            can copy/save it later without keeping the wizard open.
+ *   POST   — replace the manifest. Called by the wizard at the end of
+ *            an install run.
+ *   DELETE — wipe the manifest. The "I saved these — wipe from server"
+ *            action that narrows the post-install window of plaintext
+ *            credentials sitting in config.json.
+ *
+ * The `password` field on each entry is auto-encrypted at rest by the
+ * existing `SENSITIVE_KEYS` regex in lib/config.ts — same trust
+ * boundary as the kube YAMLs that already embed plaintext secrets.
+ *
+ * Auth: same as every other /api/system route — proxy.ts gates on a
+ * valid session cookie or the X-SB-Internal-Token header.
+ */
+
+const CredentialSchema = z.object({
+  service: z.string().min(1).max(120),
+  url: z.string().min(1).max(400),
+  username: z.string().max(120),
+  password: z.string().max(400),
+  importance: z.enum(['critical', 'system']),
+  notes: z.string().max(400).optional(),
+});
+
+const ManifestBody = z.object({
+  credentials: z.array(CredentialSchema).max(64),
+});
+
+export async function GET() {
+  const config = await getConfig();
+  const manifest = config.installManifest;
+  if (!manifest) {
+    return NextResponse.json({ manifest: null });
+  }
+  // getConfig has already decrypted sensitive fields, so credentials
+  // come back in plaintext for the same admin who just authenticated.
+  return NextResponse.json({ manifest });
+}
+
+export async function POST(request: Request) {
+  let parsed;
+  try {
+    parsed = ManifestBody.parse(await request.json());
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Invalid request body' },
+      { status: 400 },
+    );
+  }
+  const config = await getConfig();
+  const manifest: InstallManifest = {
+    savedAt: new Date().toISOString(),
+    credentials: parsed.credentials as InstalledCredential[],
+  };
+  await saveConfig({ ...config, installManifest: manifest });
+  return NextResponse.json({ ok: true, savedAt: manifest.savedAt, count: manifest.credentials.length });
+}
+
+export async function DELETE() {
+  const config = await getConfig();
+  if (!config.installManifest) {
+    return NextResponse.json({ ok: true, alreadyEmpty: true });
+  }
+  // Re-save with the field stripped. updateConfig deep-merges, so we
+  // can't use it to delete a key — saveConfig with a copy minus the
+  // field is the right primitive.
+  const { installManifest, ...rest } = config;
+  void installManifest;
+  await saveConfig(rest);
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -211,6 +211,14 @@ export interface AppConfig {
    * `stdoutTail` is bounded to ~1KB so config.json stays small.
    */
   servicePostDeploy?: Record<string, ServicePostDeployRecord>;
+  /**
+   * Credentials the install wizard saved for later retrieval (#19/A1).
+   * Persisted at the end of every install so the operator can come
+   * back to "what's the LLDAP admin password" days later without
+   * having to keep the install log open. Encrypted at rest via the
+   * existing `SENSITIVE_KEYS` regex on the password field.
+   */
+  installManifest?: InstallManifest;
 }
 
 export interface ServicePostDeployRecord {
@@ -220,6 +228,31 @@ export interface ServicePostDeployRecord {
   exitCode: number;
   /** Tail of stdout (last ~1KB). Aids "what failed" diagnosis without bloating config. */
   stdoutTail?: string;
+}
+
+/**
+ * One credential the install wizard saved for the operator. Mirrors
+ * the wire-shape `Credential` in `lib/stackInstall/credentialsManifest.ts`
+ * but kept here to avoid a cross-module import in `AppConfig`.
+ *
+ * Each entry's `password` field is auto-encrypted at rest via
+ * `SENSITIVE_KEYS` — same trust boundary as the kube YAMLs that
+ * already embed plaintext secrets. See #19 / A1.
+ */
+export interface InstalledCredential {
+  service: string;
+  url: string;
+  username: string;
+  /** Auto-encrypted at rest by `transformConfig` (key matches SENSITIVE_KEYS). */
+  password: string;
+  importance: 'critical' | 'system';
+  notes?: string;
+}
+
+export interface InstallManifest {
+  /** ISO timestamp of when this manifest was persisted. */
+  savedAt: string;
+  credentials: InstalledCredential[];
 }
 
 export function getOidcCallbackUrl(config: { reverseProxy?: { publicDomain?: string } }): string {

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -315,5 +315,27 @@ export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyRes
   ];
   formatCredentialsBanner(manifest).forEach(onLog);
 
+  // Persist the manifest so the operator can come back to "what's the
+  // LLDAP admin password?" days later without keeping the install log
+  // open. Encrypted at rest via SENSITIVE_KEYS on the password field
+  // (#19 / A1). Best-effort: a failure here doesn't block the install.
+  if (manifest.length > 0) {
+    try {
+      const res = await fetch('/api/system/credentials', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ credentials: manifest }),
+      });
+      if (res.ok) {
+        onLog(`💾 Saved ${manifest.length} credential${manifest.length === 1 ? '' : 's'} to Settings → Credentials. Wipe them from there once you've stored them safely elsewhere.`);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        onLog(`⚠️ Couldn't persist the credentials manifest (${data.error ?? `HTTP ${res.status}`}) — they're still shown above; copy them now.`);
+      }
+    } catch (e) {
+      onLog(`⚠️ Couldn't reach the credentials endpoint (${e instanceof Error ? e.message : String(e)}) — copy the credentials above before continuing.`);
+    }
+  }
+
   return proxyResult;
 }


### PR DESCRIPTION
## Summary
The install wizard no longer wipes the credentials manifest on close. It's now persisted to \`config.installManifest\`, encrypted at rest via the existing \`SENSITIVE_KEYS\` regex on the password field, and surfaced under **Settings → Integrations → Saved credentials**.

**Trust boundary:** same as the kube YAMLs that already embed plaintext secrets — decryptable by the running app and any logged-in admin session. We chose option (a) over a stricter model because recovering "what was the LLDAP admin password again?" without searching through live containers is the win this delivers.

## What ships
- \`installManifest\` field on \`AppConfig\` with a typed \`InstalledCredential\`
- \`GET / POST / DELETE /api/system/credentials\`
- Wizard POSTs the manifest after every successful install (best-effort; install isn't blocked on persistence)
- Settings → Saved credentials section with:
  - Per-row password reveal (default hidden, copy-to-clipboard when revealed)
  - "Wipe from server" button — clears the manifest once the operator has stored creds in their password manager

## Test plan
- [x] Full vitest suite green (394 passed)
- [x] \`next build\` clean
- [ ] Manual: complete an install with at least 2 credentials emitted; visit Settings → Integrations; confirm the table renders, reveal works, copy works; click "Wipe from server" and confirm the table empties.

## Notes
- Existing crypto path: any field whose key matches \`/password|secret|token|key|apiKey/\` already gets encrypted on save / decrypted on load by \`transformConfig\` in \`config.ts\`. \`InstalledCredential.password\` matches → no new crypto code.
- Future iteration the user noted: we may revisit the trust boundary (e.g. wipe-after-N-days, separate at-rest key) once we see how this gets used in practice.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)