### PR TITLE
feat(diagnose): pods Start + podman engine Enable-socket actions

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -130,10 +130,26 @@ export async function POST(request: Request) {
     hint: podmanInfo.code === 0 ? undefined : 'Run `systemctl --user enable --now podman.socket` on the node.',
   });
 
-  // 3) Running pods
+  // 3) Running pods — one item per non-running pod with a per-row Start
+  //    action (per podsAndEngine.ts). Pods whose containers crash-loop
+  //    are surfaced separately by the crash_loop probe with their own
+  //    actions; this row catches the pod-level "Created/Exited" cases.
   const pods = await exec('podman pod ps --format "{{.Name}}|{{.Status}}|{{.NumberOfContainers}}"', 5000);
   const podLines = trimOutput(pods.stdout, 30).split('\n').filter(Boolean);
   const failedPods = podLines.filter(l => !/Running/i.test(l.split('|')[1] ?? ''));
+  const podItems: ProbeItem[] = failedPods.map((line): ProbeItem | null => {
+    const tokens = line.split('|');
+    const name = (tokens[0] ?? '').trim();
+    const podStatus = (tokens[1] ?? '').trim();
+    if (!name) return null;
+    return {
+      id: name,
+      label: name,
+      detail: podStatus,
+      status: 'warn' as const,
+      actionIds: ['start_pod'],
+    };
+  }).filter((i): i is ProbeItem => i !== null);
   probes.push({
     id: 'pods',
     label: 'Pods',
@@ -141,7 +157,8 @@ export async function POST(request: Request) {
     detail: pods.code !== 0
       ? (pods.stderr || 'podman pod ps failed')
       : (podLines.length === 0 ? 'No pods deployed yet.' : `${podLines.length} pod(s): ${podLines.length - failedPods.length} running, ${failedPods.length} not running.`),
-    hint: failedPods.length > 0 ? `Check pods that aren't running:\n${failedPods.join('\n')}` : undefined,
+    hint: failedPods.length > 0 ? 'Click "Start" on a row to bring the pod back up. If individual containers are crash-looping, the crash_loop probe below has per-container actions.' : undefined,
+    _items: podItems.length > 0 ? podItems : undefined,
   });
 
   // 4) Failed user services

--- a/src/lib/diagnose/probes/podsAndEngine.ts
+++ b/src/lib/diagnose/probes/podsAndEngine.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-pod actions for the `pods` probe + an `enable_socket` action
+ * for the `podman` engine probe.
+ *
+ * The pods probe surfaces every pod whose status isn't `Running`.
+ * Most live failure modes belong to specific containers (covered by
+ * crash_loop) but a pod can also be `Created` or `Exited` as a whole
+ * — usually after a manual `podman pod stop`. The `start_pod` action
+ * is the right answer there.
+ *
+ * The podman engine probe fails when `podman info` doesn't return —
+ * the most common cause on a fresh user-space install is the
+ * `podman.socket` user unit not being enabled. The `enable_socket`
+ * action runs the canonical fix.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const SAFE_NAME = /^[a-z0-9][a-z0-9_-]{0,127}$/i;
+
+function rejectUnsafeName(itemId?: string): ProbeActionResult | null {
+  if (!itemId) return { ok: false, message: 'No pod name supplied.', refresh: false };
+  if (!SAFE_NAME.test(itemId)) return { ok: false, message: `Pod name "${itemId}" looks unsafe — refusing.`, refresh: false };
+  return null;
+}
+
+async function startPod({ node, itemId }: { node: string; itemId?: string }): Promise<ProbeActionResult> {
+  const guard = rejectUnsafeName(itemId);
+  if (guard) return guard;
+  const agent = await agentManager.ensureAgent(node);
+  // Quadlet-managed pods come up via `<name>.service` (a generated
+  // systemd unit). Try the unit path first because that re-applies
+  // restart policy + dependencies; fall back to direct `podman pod
+  // start` for hand-managed pods.
+  const unitRes = await agent.sendCommand('exec', {
+    command: `systemctl --user start ${itemId}.service 2>&1`,
+  }, { timeoutMs: 30_000 }) as { code?: number; stderr?: string; stdout?: string };
+  if (unitRes.code === 0) {
+    return {
+      ok: true,
+      message: `Started ${itemId}.service. Re-check in ~30 s; if it stops again the pod's containers may be in a restart loop.`,
+      refresh: true,
+    };
+  }
+  const podmanRes = await agent.sendCommand('exec', {
+    command: `podman pod start ${itemId} 2>&1`,
+  }, { timeoutMs: 30_000 }) as { code?: number; stderr?: string; stdout?: string };
+  if (podmanRes.code === 0) {
+    return { ok: true, message: `Started pod ${itemId}.`, refresh: true };
+  }
+  return {
+    ok: false,
+    message: `Could not start ${itemId}: ${(podmanRes.stderr ?? podmanRes.stdout ?? '').trim().slice(0, 200) || 'unknown error'}.`,
+    refresh: false,
+  };
+}
+
+async function enablePodmanSocket({ node }: { node: string }): Promise<ProbeActionResult> {
+  const agent = await agentManager.ensureAgent(node);
+  const res = await agent.sendCommand('exec', {
+    command: 'systemctl --user enable --now podman.socket 2>&1',
+  }, { timeoutMs: 15_000 }) as { code?: number; stderr?: string; stdout?: string };
+  if (res.code === 0) {
+    return {
+      ok: true,
+      message: 'podman.socket enabled and started. Re-running diagnose…',
+      refresh: true,
+    };
+  }
+  return {
+    ok: false,
+    message: `Could not enable podman.socket: ${(res.stderr ?? res.stdout ?? '').trim().slice(0, 200) || 'unknown error'}. SSH into the host to investigate.`,
+    refresh: false,
+  };
+}
+
+registerProbeAction(
+  'pods',
+  {
+    id: 'start_pod',
+    label: 'Start',
+    description:
+      'Starts the pod via systemctl (or `podman pod start` for non-quadlet pods). Use after a manual stop or a failed boot. If containers within the pod are crash-looping, the crash_loop probe surfaces them with their own actions.',
+  },
+  startPod,
+);
+
+registerProbeAction(
+  'podman',
+  {
+    id: 'enable_socket',
+    label: 'Enable podman socket',
+    description:
+      'Runs `systemctl --user enable --now podman.socket` on the node. The canonical fix when the diagnose engine probe says podman isn\'t responding — the daemon is fine, the user-space socket just isn\'t up.',
+  },
+  enablePodmanSocket,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -21,5 +21,6 @@ import './proxyRouteMissing';
 import './failedUnits';
 import './healthChecks';
 import './disk';
+import './podsAndEngine';
 
 export {};

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -83,8 +83,11 @@ function sha256(s: string): string {
 /** Strip the hash field for any caller-facing list. The hash never leaves
  *  the server. */
 function publicView(t: ApiToken): Omit<ApiToken, 'hash'> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { hash, ...rest } = t;
+  // Underscore-prefixed `_hash` matches the unused-vars rule's allow
+  // pattern, so the destructuring stays explicit about which field is
+  // being stripped without needing a per-line disable.
+  const { hash: _hash, ...rest } = t;
+  void _hash;
   return rest;
 }
 


### PR DESCRIPTION
## Summary
Two small action additions to existing probes:

- **\`pods\`**: each non-running pod becomes a row with a **Start** action (\`systemctl --user start <name>.service\` then \`podman pod start\` fallback for non-quadlet pods). Crash-looping containers stay the domain of the \`crash_loop\` probe.
- **\`podman\`** engine: when \`podman info\` fails, registers an **Enable podman socket** action that runs the canonical \`systemctl --user enable --now podman.socket\` fix the existing hint already pointed at.

Drive-by: cleans up the pre-existing unused-var warning in \`lib/mcp/tokens.ts\` so \`npm run lint\` is silent.

## Test plan
- [x] Full vitest suite green (394 passed)
- [x] \`next build\` clean
- [x] \`npm run lint\` clean (was 1 warning, now 0)
- [ ] Manual: stop a pod via \`podman pod stop <name>\` → diagnose shows it as a row → click Start → confirm it transitions to ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)