### PR TITLE
test(diagnose): handler tests for crash_loop, failed_units, podsAndEngine

### DIFF
--- a/src/lib/diagnose/probes/crashLoop.test.ts
+++ b/src/lib/diagnose/probes/crashLoop.test.ts
@@ -1,0 +1,138 @@
+ 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAgent = { sendCommand: vi.fn() };
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
+
+import {
+  registerProbeAction as _registerProbeAction,
+  dispatchProbeAction,
+} from '../actions';
+// Side-effect import that registers the crash_loop actions.
+import './crashLoop';
+
+beforeEach(() => {
+  mockAgent.sendCommand.mockReset();
+  // crashLoop registers handlers at module load. The reset would
+  // unregister them, so we re-import to repopulate. Vitest module
+  // graph caches the import — explicit re-register via the module
+  // we already imported.
+  void _registerProbeAction;
+});
+
+describe('crash_loop probe actions', () => {
+  describe('restart_pod', () => {
+    it('rejects unsafe container names', async () => {
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'restart_pod',
+        itemId: 'foo;rm -rf /',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/unsafe/i);
+      expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty itemId', async () => {
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'restart_pod',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/no container/i);
+      expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it('runs systemctl restart for safe names', async () => {
+      mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'restart_pod',
+        itemId: 'vaultwarden',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(true);
+      expect(result.message).toMatch(/Restarted vaultwarden\.service/);
+      expect(mockAgent.sendCommand).toHaveBeenCalledWith(
+        'exec',
+        expect.objectContaining({ command: expect.stringContaining('systemctl --user restart vaultwarden.service') }),
+        expect.any(Object),
+      );
+    });
+
+    it('falls back to podman restart when systemctl returns non-zero', async () => {
+      mockAgent.sendCommand
+        .mockResolvedValueOnce({ code: 5, stderr: 'Unit not found.', stdout: '' })
+        .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'restart_pod',
+        itemId: 'sidecar-container',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(true);
+      expect(result.message).toMatch(/Restarted container sidecar-container/);
+      expect(mockAgent.sendCommand).toHaveBeenCalledTimes(2);
+      expect(mockAgent.sendCommand.mock.calls[1][1].command).toContain('podman restart sidecar-container');
+    });
+
+    it('returns failure when both unit and podman restart fail', async () => {
+      mockAgent.sendCommand
+        .mockResolvedValueOnce({ code: 1, stderr: 'unit lookup failed', stdout: '' })
+        .mockResolvedValueOnce({ code: 1, stderr: 'no such container', stdout: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'restart_pod',
+        itemId: 'nope',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/no such container/);
+    });
+  });
+
+  describe('show_recent_logs', () => {
+    it('returns details with log content on success', async () => {
+      const log = ['line 1 of log', 'line 2', 'error: connection refused'].join('\n');
+      mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: log, stderr: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'show_recent_logs',
+        itemId: 'vaultwarden',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(true);
+      expect(result.details).toBe(log);
+      expect(result.message).toMatch(/3 log lines/);
+    });
+
+    it('handles empty log output', async () => {
+      mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'show_recent_logs',
+        itemId: 'vaultwarden',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(true);
+      expect(result.details).toBeUndefined();
+      expect(result.message).toMatch(/No recent logs/);
+    });
+
+    it('rejects unsafe names without invoking the agent', async () => {
+      const result = await dispatchProbeAction({
+        probeId: 'crash_loop',
+        actionId: 'show_recent_logs',
+        itemId: '$(curl evil)',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/diagnose/probes/failedUnits.test.ts
+++ b/src/lib/diagnose/probes/failedUnits.test.ts
@@ -1,0 +1,98 @@
+ 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAgent = { sendCommand: vi.fn() };
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
+
+import { dispatchProbeAction } from '../actions';
+import './failedUnits';
+
+beforeEach(() => {
+  mockAgent.sendCommand.mockReset();
+});
+
+describe('failed_units probe actions', () => {
+  describe('reset_failed', () => {
+    it('runs systemctl reset-failed for safe names', async () => {
+      mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'failed_units',
+        actionId: 'reset_failed',
+        itemId: 'nginx.service',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(true);
+      expect(mockAgent.sendCommand).toHaveBeenCalledWith(
+        'exec',
+        expect.objectContaining({ command: expect.stringContaining('systemctl --user reset-failed nginx.service') }),
+        expect.any(Object),
+      );
+    });
+
+    it('rejects shell metas in unit names', async () => {
+      const result = await dispatchProbeAction({
+        probeId: 'failed_units',
+        actionId: 'reset_failed',
+        itemId: 'nginx.service && curl evil',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it('accepts template units (with @)', async () => {
+      mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      const result = await dispatchProbeAction({
+        probeId: 'failed_units',
+        actionId: 'reset_failed',
+        itemId: 'getty@tty1.service',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns failure with stderr when systemctl errors', async () => {
+      mockAgent.sendCommand.mockResolvedValueOnce({
+        code: 1,
+        stderr: 'Failed to reset failed state of unit foo.service: Unit not loaded',
+        stdout: '',
+      });
+      const result = await dispatchProbeAction({
+        probeId: 'failed_units',
+        actionId: 'reset_failed',
+        itemId: 'foo.service',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/Unit not loaded/);
+    });
+  });
+
+  describe('restart_unit', () => {
+    it('chains reset-failed and restart in a single exec', async () => {
+      mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+      await dispatchProbeAction({
+        probeId: 'failed_units',
+        actionId: 'restart_unit',
+        itemId: 'auth.service',
+        node: 'Local',
+      });
+      const cmd = mockAgent.sendCommand.mock.calls[0][1].command as string;
+      expect(cmd).toContain('reset-failed auth.service');
+      expect(cmd).toContain('restart auth.service');
+    });
+
+    it('rejects empty itemId', async () => {
+      const result = await dispatchProbeAction({
+        probeId: 'failed_units',
+        actionId: 'restart_unit',
+        node: 'Local',
+      });
+      expect(result.ok).toBe(false);
+      expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/diagnose/probes/podsAndEngine.test.ts
+++ b/src/lib/diagnose/probes/podsAndEngine.test.ts
@@ -1,0 +1,81 @@
+ 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAgent = { sendCommand: vi.fn() };
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
+
+import { dispatchProbeAction } from '../actions';
+import './podsAndEngine';
+
+beforeEach(() => {
+  mockAgent.sendCommand.mockReset();
+});
+
+describe('pods.start_pod', () => {
+  it('rejects unsafe names', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'pods',
+      actionId: 'start_pod',
+      itemId: '`evil`',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('starts via systemctl on the happy path', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 0 });
+    const result = await dispatchProbeAction({
+      probeId: 'pods',
+      actionId: 'start_pod',
+      itemId: 'auth',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockAgent.sendCommand.mock.calls[0][1].command).toContain('systemctl --user start auth.service');
+  });
+
+  it('falls back to podman pod start when the unit is missing', async () => {
+    mockAgent.sendCommand
+      .mockResolvedValueOnce({ code: 5, stderr: 'Unit not found.' })
+      .mockResolvedValueOnce({ code: 0 });
+    const result = await dispatchProbeAction({
+      probeId: 'pods',
+      actionId: 'start_pod',
+      itemId: 'orphan',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockAgent.sendCommand.mock.calls[1][1].command).toContain('podman pod start orphan');
+  });
+});
+
+describe('podman.enable_socket', () => {
+  it('runs the enable+start command', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 0 });
+    const result = await dispatchProbeAction({
+      probeId: 'podman',
+      actionId: 'enable_socket',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockAgent.sendCommand.mock.calls[0][1].command).toContain('systemctl --user enable --now podman.socket');
+  });
+
+  it('returns failure with stderr when the command fails', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({
+      code: 1,
+      stderr: 'Failed to enable: PolicyKit refused.',
+    });
+    const result = await dispatchProbeAction({
+      probeId: 'podman',
+      actionId: 'enable_socket',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/PolicyKit refused/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds 19 unit tests covering the per-handler action dispatchers added this session. Each test mocks \`agentManager.ensureAgent\` to return a \`vi.fn()\` shell, then asserts the handler:

- Rejects unsafe item names (shell metas, empty strings) without invoking the agent
- Runs the right \`systemctl\` / \`podman\` command for safe inputs
- Falls back to the secondary command when the primary returns non-zero (e.g. unit-not-found → \`podman restart\` direct)
- Surfaces stderr on failure so the operator gets a useful toast

Hardens the action dispatcher chain against regressions in shell quoting + argument validation, which are the two failure modes that matter most given handlers run as the agent's user.

## Test plan
- [x] 413 tests pass total (was 394, +19 new)
- [x] \`next build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)