### PR TITLE
test(diagnose): handler tests for the remaining probes + README sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The installer creates a bootable USB that provisions the entire system: OS, netw
 - **Multi-Node** — manage containers across machines via SSH from a single UI
 - **System Backups** — snapshot all configs across nodes (auto-snapshot before destructive ops); restore in seconds
 - **Auto-Updates** — keep ServiceBay and containers current automatically; email notification on each new release
-- **Self-Diagnose** — built-in probe battery (containers stable / health-check coverage / dangling proxy routes / disk / failed units / first-boot units); auto-runs at end of install
+- **Self-Diagnose** — built-in probe battery with one-click fixes for every detected problem: restart crash-looping containers, retry stale NPM auth, delete dangling proxy routes, configure FritzBox DNS via TR-064, re-run failed seed scripts, free disk space, and more. Auto-runs at end of install.
 - **Mobile-Responsive** — full UI with dedicated mobile navigation
 - **MCP Server** — 37+ MCP tools, scoped tokens, audit log, soft-delete, auto-snapshot, exec denylist, destructive-op email alerts
 

--- a/src/lib/diagnose/probes/danglingProxy.test.ts
+++ b/src/lib/diagnose/probes/danglingProxy.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  config: {} as any,
+  services: [] as any[],
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(() => Promise.resolve(state.services)) },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { dispatchProbeAction } from '../actions';
+import './danglingProxy';
+
+const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', container: '81' }] }];
+
+beforeEach(() => {
+  state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
+  state.services = ACTIVE_NGINX;
+  mockFetch.mockReset();
+});
+
+describe('dangling_proxy.delete_route', () => {
+  it('rejects empty itemId', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'dangling_proxy',
+      actionId: 'delete_route',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('aborts when nginx is not deployed', async () => {
+    state.services = [];
+    const result = await dispatchProbeAction({
+      probeId: 'dangling_proxy',
+      actionId: 'delete_route',
+      itemId: 'old.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not deployed/i);
+  });
+
+  it('returns failure when NPM auth fails', async () => {
+    // /api/tokens with stored creds → 401
+    // /api/tokens with default creds → 401
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) });
+    const result = await dispatchProbeAction({
+      probeId: 'dangling_proxy',
+      actionId: 'delete_route',
+      itemId: 'old.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Could not authenticate/);
+  });
+
+  it('reports when domain not found in NPM host list', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'tok' }) }) // /api/tokens
+      .mockResolvedValueOnce({ // /api/nginx/proxy-hosts list
+        ok: true,
+        json: () => Promise.resolve([
+          { id: 5, domain_names: ['vault.example.com'] },
+        ]),
+      });
+    const result = await dispatchProbeAction({
+      probeId: 'dangling_proxy',
+      actionId: 'delete_route',
+      itemId: 'gone.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Couldn't find/);
+  });
+
+  it('DELETEs the matching id and returns success', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'tok' }) }) // /api/tokens
+      .mockResolvedValueOnce({ // host list
+        ok: true,
+        json: () => Promise.resolve([
+          { id: 7, domain_names: ['old.example.com'] },
+          { id: 8, domain_names: ['vault.example.com'] },
+        ]),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('') }); // DELETE
+    const result = await dispatchProbeAction({
+      probeId: 'dangling_proxy',
+      actionId: 'delete_route',
+      itemId: 'old.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/Route old\.example\.com removed/);
+    // Verify DELETE went to id=7, not id=8
+    const deleteCall = mockFetch.mock.calls[2];
+    expect(deleteCall[0]).toMatch(/\/api\/nginx\/proxy-hosts\/7$/);
+    expect(deleteCall[1].method).toBe('DELETE');
+  });
+});

--- a/src/lib/diagnose/probes/postDeployFailed.test.ts
+++ b/src/lib/diagnose/probes/postDeployFailed.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAgent = { sendCommand: vi.fn() };
+let mockConfig: any = {};
+const savedConfigs: any[] = [];
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(mockConfig)),
+  updateConfig: vi.fn((updates: any) => {
+    mockConfig = { ...mockConfig, ...updates, servicePostDeploy: { ...(mockConfig.servicePostDeploy ?? {}), ...(updates.servicePostDeploy ?? {}) } };
+    savedConfigs.push({ ...mockConfig });
+    return Promise.resolve(mockConfig);
+  }),
+  saveConfig: vi.fn((cfg: any) => {
+    mockConfig = cfg;
+    savedConfigs.push({ ...mockConfig });
+    return Promise.resolve();
+  }),
+}));
+
+import { dispatchProbeAction } from '../actions';
+import './postDeployFailed';
+
+beforeEach(() => {
+  mockAgent.sendCommand.mockReset();
+  mockConfig = {};
+  savedConfigs.length = 0;
+});
+
+describe('post_deploy_failed.dismiss_post_deploy', () => {
+  it('rejects empty itemId', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'dismiss_post_deploy',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(savedConfigs).toHaveLength(0);
+  });
+
+  it('returns failure when no record matches', async () => {
+    mockConfig = { servicePostDeploy: { vault: { exitCode: 1, lastRunAt: '2026-05-09T00:00:00Z' } } };
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'dismiss_post_deploy',
+      itemId: 'unknown-service',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/no post-deploy record/i);
+  });
+
+  it('removes the named entry while preserving siblings', async () => {
+    mockConfig = {
+      reverseProxy: { lanIp: '192.168.0.10' },
+      servicePostDeploy: {
+        vault: { exitCode: 1, lastRunAt: '2026-05-09T00:00:00Z' },
+        immich: { exitCode: 0, lastRunAt: '2026-05-09T00:01:00Z' },
+      },
+    };
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'dismiss_post_deploy',
+      itemId: 'vault',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockConfig.servicePostDeploy).toEqual({
+      immich: { exitCode: 0, lastRunAt: '2026-05-09T00:01:00Z' },
+    });
+    // Sibling config keys must survive — saveConfig writes the whole
+    // object, so the dismiss handler can't accidentally drop them.
+    expect(mockConfig.reverseProxy).toEqual({ lanIp: '192.168.0.10' });
+  });
+});
+
+describe('post_deploy_failed.rerun_post_deploy', () => {
+  it('rejects empty itemId', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'rerun_post_deploy',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(mockAgent.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('reports missing artifacts when scripts no longer on disk', async () => {
+    // First call is the test -f check; respond with anything other than 'ok'
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 1, stdout: '', stderr: '' });
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'rerun_post_deploy',
+      itemId: 'vault',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Couldn't find the original post-deploy/);
+    // Only the test-f probe should have run; the python invocation
+    // must not have fired.
+    expect(mockAgent.sendCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the new exit code on a successful re-run', async () => {
+    mockAgent.sendCommand
+      .mockResolvedValueOnce({ code: 0, stdout: 'ok', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: 'seed completed', stderr: '' });
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'rerun_post_deploy',
+      itemId: 'vault',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockConfig.servicePostDeploy?.vault?.exitCode).toBe(0);
+    expect(mockConfig.servicePostDeploy?.vault?.stdoutTail).toBe('seed completed');
+  });
+
+  it('persists exit code and surfaces the last log line on failure', async () => {
+    mockAgent.sendCommand
+      .mockResolvedValueOnce({ code: 0, stdout: 'ok', stderr: '' })
+      .mockResolvedValueOnce({
+        code: 5,
+        stdout: 'connecting...\nbackoff retry...\n[ERROR] LLDAP refused connection',
+        stderr: '',
+      });
+    const result = await dispatchProbeAction({
+      probeId: 'post_deploy_failed',
+      actionId: 'rerun_post_deploy',
+      itemId: 'vault',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/exit 5/);
+    expect(result.message).toMatch(/LLDAP refused connection/);
+    expect(mockConfig.servicePostDeploy?.vault?.exitCode).toBe(5);
+  });
+});

--- a/src/lib/diagnose/probes/proxyRouteMissing.test.ts
+++ b/src/lib/diagnose/probes/proxyRouteMissing.test.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `vi.mock` hoists above any top-level `const`, so we can't reference
+// shared state directly. Instead, expose state via getters and mock
+// modules with closures that read those getters at call time.
+const state = {
+  config: {} as any,
+  services: [] as any[],
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(() => Promise.resolve(state.services)) },
+}));
+
+vi.mock('@/lib/auth/internalToken', () => ({
+  getInternalApiToken: vi.fn(() => 'test-token'),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { dispatchProbeAction } from '../actions';
+import './proxyRouteMissing';
+
+beforeEach(() => {
+  state.config = { reverseProxy: { hosts: [] } };
+  state.services = [];
+  mockFetch.mockReset();
+});
+
+const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', container: '81' }] }];
+
+describe('proxy_route_missing.retry_create', () => {
+  it('rejects empty itemId', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'proxy_route_missing',
+      actionId: 'retry_create',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when entry not in config', async () => {
+    state.config ={ reverseProxy: { hosts: [] } };
+    const result = await dispatchProbeAction({
+      probeId: 'proxy_route_missing',
+      actionId: 'retry_create',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/may have been removed/);
+  });
+
+  it('aborts when nginx is not deployed', async () => {
+    state.config ={
+      reverseProxy: {
+        hosts: [{ domain: 'vault.example.com', service: 'vaultwarden', forwardPort: 8080, created: false }],
+      },
+    };
+    state.services = [];
+    const result = await dispatchProbeAction({
+      probeId: 'proxy_route_missing',
+      actionId: 'retry_create',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not deployed/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('reports needs_credentials when NPM rejects auth', async () => {
+    state.config ={
+      reverseProxy: {
+        hosts: [{ domain: 'vault.example.com', service: 'vaultwarden', forwardPort: 8080, created: false }],
+      },
+    };
+    state.services = ACTIVE_NGINX;
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ needsCredentials: true }),
+    });
+    const result = await dispatchProbeAction({
+      probeId: 'proxy_route_missing',
+      actionId: 'retry_create',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Use existing password/i);
+  });
+
+  it('returns ok on a successful create', async () => {
+    state.config ={
+      reverseProxy: {
+        hosts: [{ domain: 'vault.example.com', service: 'vaultwarden', forwardPort: 8080, created: false }],
+      },
+    };
+    state.services = ACTIVE_NGINX;
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, created: ['vault.example.com'], failed: [] }),
+    });
+    const result = await dispatchProbeAction({
+      probeId: 'proxy_route_missing',
+      actionId: 'retry_create',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/Route vault\.example\.com created/);
+  });
+
+  it('surfaces the per-domain failure message when NPM rejects the host', async () => {
+    state.config ={
+      reverseProxy: {
+        hosts: [{ domain: 'vault.example.com', service: 'vaultwarden', forwardPort: 8080, created: false }],
+      },
+    };
+    state.services = ACTIVE_NGINX;
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({
+        success: false,
+        failed: [{ domain: 'vault.example.com', error: 'Domain already exists' }],
+      }),
+    });
+    const result = await dispatchProbeAction({
+      probeId: 'proxy_route_missing',
+      actionId: 'retry_create',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Domain already exists/);
+  });
+});


### PR DESCRIPTION
## Summary
Brings probe-handler test coverage up to every handler shipped this session.

Each test mocks the right boundary:
- **postDeployFailed**: mocks \`getConfig\` / \`saveConfig\` / agent. Covers empty itemId, missing-record, removal preserving siblings, plus the rerun's persistence on success and failure.
- **proxyRouteMissing**: mocks config + ServiceManager + fetch. Covers the \`needsCredentials\` path, the unknown-domain path, and the per-domain failure surfacing.
- **danglingProxy**: mocks config + ServiceManager + fetch. Covers the domain-to-id lookup chain (#290's fix) — verifies DELETE goes to the right id.

README's Self-Diagnose blurb refreshed to mention the per-row fix buttons rather than just the probe list.

## What I checked but didn't ship
- Closure-capture audit on the wizard: no additional bugs beyond #287's settle-wait fix. The other long-running async loop (deploy stream reading) is event-driven, not state-driven.
- \`cert_expiry\` probe: caller is in LAN mode (no LE certs to monitor); will revisit once a public domain ships.

## Test plan
- [x] 431 tests pass total (was 413, +18 new across 3 files)
- [x] \`next build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)