### PR TITLE
fix(network): serialize NetworkStore add/removeEdge writes

### DIFF
--- a/src/lib/network/store.test.ts
+++ b/src/lib/network/store.test.ts
@@ -1,0 +1,60 @@
+ 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+
+vi.mock('@/lib/dirs', () => ({
+  DATA_DIR: path.join(os.tmpdir(), `sb-network-store-race-${process.pid}`),
+}));
+
+const TEST_DIR = path.join(os.tmpdir(), `sb-network-store-race-${process.pid}`);
+const STORE_PATH = path.join(TEST_DIR, 'network-edges.json');
+
+import { NetworkStore } from './store';
+
+beforeEach(async () => {
+  await fs.mkdir(TEST_DIR, { recursive: true });
+  await fs.rm(STORE_PATH, { force: true });
+});
+
+const mkEdge = (id: string, source = `s-${id}`, target = `t-${id}`) => ({
+  id,
+  source,
+  target,
+  created_at: new Date().toISOString(),
+});
+
+describe('NetworkStore mutex', () => {
+  it('does not lose edges from concurrent addEdge calls', async () => {
+    // Without serialization, both adds would read [] and each save
+    // a one-element array — second write clobbers the first.
+    await Promise.all([
+      NetworkStore.addEdge(mkEdge('a')),
+      NetworkStore.addEdge(mkEdge('b')),
+      NetworkStore.addEdge(mkEdge('c')),
+    ]);
+    const edges = await NetworkStore.getEdges();
+    expect(edges.map(e => e.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('serializes add + remove correctly', async () => {
+    await NetworkStore.addEdge(mkEdge('a'));
+    await NetworkStore.addEdge(mkEdge('b'));
+    // Remove 'a' while concurrently adding 'c' — both must land.
+    await Promise.all([
+      NetworkStore.removeEdge('a'),
+      NetworkStore.addEdge(mkEdge('c')),
+    ]);
+    const edges = await NetworkStore.getEdges();
+    expect(edges.map(e => e.id).sort()).toEqual(['b', 'c']);
+  });
+
+  it('skips duplicate source+target pairs', async () => {
+    await NetworkStore.addEdge(mkEdge('a', 'X', 'Y'));
+    await NetworkStore.addEdge(mkEdge('b', 'X', 'Y'));
+    const edges = await NetworkStore.getEdges();
+    expect(edges).toHaveLength(1);
+    expect(edges[0].id).toBe('a');
+  });
+});

--- a/src/lib/network/store.ts
+++ b/src/lib/network/store.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { DATA_DIR } from '../dirs';
+import { atomicWriteFile } from '../util/atomicWrite';
 
 const STORE_PATH = path.join(DATA_DIR, 'network-edges.json');
 
@@ -11,6 +12,20 @@ export interface ManualEdge {
   label?: string;
   port?: number;
   created_at: string;
+}
+
+/**
+ * Per-process serialization for edge mutations. addEdge/removeEdge
+ * do an async read-modify-write — without the lock, concurrent calls
+ * race: both read state X, both compute X±edge, both write — second
+ * write clobbers the first's update. Same pattern as the config
+ * mutex; see lib/config.ts.
+ */
+let writeQueue: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = writeQueue.then(fn, fn);
+  writeQueue = next.catch(() => undefined);
+  return next;
 }
 
 export class NetworkStore {
@@ -24,22 +39,30 @@ export class NetworkStore {
   }
 
   static async addEdge(edge: ManualEdge): Promise<void> {
-    const edges = await this.getEdges();
-    // Avoid duplicates
-    if (!edges.find(e => e.source === edge.source && e.target === edge.target)) {
+    return withLock(async () => {
+      const edges = await this.getEdges();
+      // Avoid duplicates
+      if (!edges.find(e => e.source === edge.source && e.target === edge.target)) {
         edges.push(edge);
         await this.saveEdges(edges);
-    }
+      }
+    });
   }
 
   static async removeEdge(id: string): Promise<void> {
-    const edges = await this.getEdges();
-    const filtered = edges.filter(e => e.id !== id);
-    await this.saveEdges(filtered);
+    return withLock(async () => {
+      const edges = await this.getEdges();
+      const filtered = edges.filter(e => e.id !== id);
+      await this.saveEdges(filtered);
+    });
   }
 
   private static async saveEdges(edges: ManualEdge[]): Promise<void> {
     await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
-    await fs.writeFile(STORE_PATH, JSON.stringify(edges, null, 2));
+    // Use atomicWriteFile so a crash mid-save can't corrupt the file
+    // (writes a temp + rename). The previous fs.writeFile would
+    // truncate the file before refilling, leaving an empty edge list
+    // on disk if the process died at the wrong moment.
+    await atomicWriteFile(STORE_PATH, JSON.stringify(edges, null, 2));
   }
 }


### PR DESCRIPTION
## What was wrong
Same race I fixed in #299 for \`updateConfig\`. \`NetworkStore.addEdge\` and \`removeEdge\` do an async read-modify-write without serialization. Two concurrent calls both read state X, both compute X±edge, both call saveEdges — the second write clobbers the first.

## Fix
Wrap the read-modify-write in the same Promise-chain mutex pattern. Drive-by: switch \`saveEdges\` from \`fs.writeFile\` to \`atomicWriteFile\` so a crash mid-save can't leave the file truncated.

## Test plan
- [x] 443 tests pass (was 440, +3 new):
  - Concurrent addEdge calls all land in the final state
  - Concurrent add + remove serialize correctly
  - Existing duplicate-skip behavior preserved
- [x] \`next build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)