### PR TITLE
fix(backup): serialize appendHistory writes

### DIFF
--- a/src/lib/backup/service.ts
+++ b/src/lib/backup/service.ts
@@ -31,13 +31,27 @@ export async function getBackupHistory(): Promise<BackupRunResult[]> {
     }
 }
 
+// Per-process serialization for backup-history mutations. Concurrent
+// backups completing at the same time would otherwise race here:
+// both read the same history, both prepend their own result, both
+// write — second clobbers the first. Same Promise-chain pattern as
+// updateConfig (#299), NetworkStore (#300), nodes (#301).
+let historyWriteQueue: Promise<unknown> = Promise.resolve();
+function withHistoryLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = historyWriteQueue.then(fn, fn);
+    historyWriteQueue = next.catch(() => undefined);
+    return next;
+}
+
 async function appendHistory(result: BackupRunResult): Promise<void> {
-    const history = await getBackupHistory();
-    history.unshift(result);
-    if (history.length > MAX_HISTORY_ENTRIES) {
-        history.length = MAX_HISTORY_ENTRIES;
-    }
-    await atomicWriteFile(BACKUP_HISTORY_FILE, JSON.stringify(history, null, 2));
+    return withHistoryLock(async () => {
+        const history = await getBackupHistory();
+        history.unshift(result);
+        if (history.length > MAX_HISTORY_ENTRIES) {
+            history.length = MAX_HISTORY_ENTRIES;
+        }
+        await atomicWriteFile(BACKUP_HISTORY_FILE, JSON.stringify(history, null, 2));
+    });
 }
 
 // ─── Target Resolution ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fourth installment of the same async read-modify-write race I fixed in #299 (config), #300 (NetworkStore), #301 (nodes).

\`appendHistory\` does \`getBackupHistory + unshift + atomicWriteFile\` without holding a lock — concurrent backup completions would race:
1. Both read the same history
2. Both prepend their own result
3. Both write, second clobbers the first

Less common in practice (backups are typically scheduled serially) but still real, particularly when manual + scheduled backups overlap.

Fix: same Promise-chain mutex pattern.

## Test plan
- [x] 440 tests pass; \`next build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)