### PR TITLE
feat(portal): user-guides for vaultwarden, file-share, home-assistant, media, radicale

### DIFF
--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -1,0 +1,48 @@
+---
+icon: "📁"
+tagline: "Share documents across phones, laptops, and the family — like a private Dropbox."
+mobile_apps:
+  - name: "Syncthing for Android"
+    url: "https://play.google.com/store/apps/details?id=com.fsck.syncthing"
+  - name: "Möbius Sync for iOS"
+    url: "https://apps.apple.com/app/m%C3%B6bius-sync/id1539203216"
+---
+
+# Getting started with Files
+
+This service runs three different ways to access your files. Pick the one that fits how you'd normally use it.
+
+## In the browser (FileBrowser)
+
+The simplest path — no setup. Click the *Open* button on this card, log in with the family password, and you see every shared folder. You can upload, download, rename, share links — like Dropbox's web UI.
+
+Best for: occasional access, sharing a link with someone outside the family, mobile browsers.
+
+## From a laptop or PC (Samba)
+
+Mount the share like a network drive — files show up in your file manager natively.
+
+**On Windows:** open File Explorer, type `\\<your-server>` in the address bar, and a shared folder appears.
+
+**On macOS:** Finder → Go → Connect to Server → `smb://<your-server>` → mount.
+
+**On Linux:** in your file manager, *Other Locations* → `smb://<your-server>`.
+
+The username + password are the family ones. Once mounted, drag files in/out as you would with any folder.
+
+Best for: working with large files (video, photos), where uploading through a browser would be slow.
+
+## On your phone (Syncthing)
+
+Syncthing keeps a folder on your phone in sync with the home server in both directions. Photos you take, documents you save — they appear on the server within minutes.
+
+1. Install **Syncthing** (Android) or **Möbius Sync** (iOS) from the links above.
+2. The app shows a *device ID*. Add ServiceBay's device ID (you'll find it in the FileBrowser web UI under *Settings → Sync*).
+3. Pick which folders on your phone to sync.
+
+Best for: continuous backup of phone documents, two-way sync between phone and laptop.
+
+## Tips
+
+- **The three methods see the same files.** Upload via the browser → it's there in Samba and in Syncthing immediately.
+- **Phone storage is limited.** Syncthing supports *receive-only* folders so the server keeps everything but the phone only carries what you actively use.

--- a/templates/home-assistant/user-guide.md
+++ b/templates/home-assistant/user-guide.md
@@ -1,0 +1,40 @@
+---
+icon: "🏠"
+tagline: "Control lights, sensors, and smart-home devices from one app — and keep all the data on your home server."
+mobile_apps:
+  - name: "Home Assistant for iOS"
+    url: "https://apps.apple.com/app/home-assistant/id1099568401"
+  - name: "Home Assistant for Android"
+    url: "https://play.google.com/store/apps/details?id=io.homeassistant.companion.android"
+---
+
+# Getting started with Home Assistant
+
+Home Assistant connects to lights, switches, motion sensors, weather stations, and pretty much anything that talks Wi-Fi, Zigbee, Z-Wave, or Matter. Once devices are connected, you can:
+
+- Turn things on/off from your phone or laptop.
+- Build automations ("turn on the porch light at sunset").
+- See sensor history (temperature, humidity, energy use) over time.
+
+## On your phone (one-time setup)
+
+1. Install **Home Assistant** from the App Store or Play Store (links above).
+2. The app asks for a server URL — paste the URL from the *Open* button on this card (e.g. `http://home.home.arpa`).
+3. Log in with the family password.
+4. The app asks if you want to enable **Location** (so HA knows when you're home), **Sensors** (battery, network, etc.), and **Notifications** — turn on what you're comfortable with.
+
+## In the browser
+
+The web UI has the same dashboard as the app, plus the full configuration interface. The mobile app is for quick "turn off the lights" actions; the browser is where you'd build a new automation or add a new device integration.
+
+## Adding devices
+
+Home Assistant auto-discovers most things on the network. Open *Settings → Devices & Services* and you'll likely see your smart speakers, TVs, robot vacuums, and so on already listed — click to add.
+
+For Z-Wave / Zigbee devices, the admin already plugged the USB stick into the server. Go to *Settings → Devices & Services → Add Integration* and search "Z-Wave JS" or "Zigbee2MQTT".
+
+## Tips
+
+- **Everything stays on the server.** Voice commands, sensor history, automations — none of it goes to a cloud.
+- **Voice control via mobile app.** Tap the mic in the iOS / Android app and you can say "turn off the kitchen lights" without picking a device manually.
+- **Companion app sensors.** The mobile app exposes *your* phone's sensors (battery, location, motion) to Home Assistant — useful for automations like "turn on the porch light when my phone connects to home Wi-Fi."

--- a/templates/media/user-guide.md
+++ b/templates/media/user-guide.md
@@ -1,0 +1,47 @@
+---
+icon: "🎵"
+tagline: "Stream your music collection and listen to audiobooks — offline-capable on phones."
+mobile_apps:
+  - name: "Audiobookshelf for iOS"
+    url: "https://apps.apple.com/app/audiobookshelf/id1610212799"
+  - name: "Audiobookshelf for Android"
+    url: "https://play.google.com/store/apps/details?id=com.audiobookshelf.app"
+  - name: "Symfonium for Android (music)"
+    url: "https://play.google.com/store/apps/details?id=app.symfonik.music.player"
+---
+
+# Getting started with Media
+
+Two services live behind this card:
+- **Audiobookshelf** for audiobooks and podcasts.
+- **Navidrome** for music.
+
+Both have polished mobile apps that work offline once content is downloaded.
+
+## Audiobooks (Audiobookshelf)
+
+1. Install **Audiobookshelf** on your phone (links above).
+2. Open it, tap *Add Server*, paste the URL from the *Open* button on this card (look for the audiobook subdomain — e.g. `http://audiobooks.home.arpa`).
+3. Log in with the family password.
+4. Tap a book → *Download* to keep it on the phone for offline listening (great for flights / commute).
+
+Bookmarks, playback position, and listening history sync between devices — start in the car, finish on the couch.
+
+## Music (Navidrome)
+
+Navidrome serves your music collection over a protocol called **Subsonic**, which means dozens of apps work with it. Recommended:
+
+- **Symfonium** (Android) — fast, polished, plays nicely with Bluetooth car audio. Paid app but worth it.
+- **play:Sub** (iOS) — most-recommended Subsonic client on iPhone.
+- **Browser** — Navidrome's web UI is good and works on every device without an app install.
+
+In the app, configure a **Subsonic** server with the URL from the *Open* button (e.g. `http://music.home.arpa`) and the family credentials.
+
+## Adding content
+
+The admin drops audiobooks/podcasts into the server's **Audiobookshelf library folder** (browse via the *Files* card / Samba) and music into the **Navidrome music folder**. Both services pick up new files within a minute or two — no manual import.
+
+## Tips
+
+- **Offline downloads are per-device.** Downloading a book on your phone doesn't take it off the server; it's just cached locally.
+- **Multiple users keep separate progress.** Each family member's listening position, bookmarks, and finished/unfinished list is private to them.

--- a/templates/radicale/user-guide.md
+++ b/templates/radicale/user-guide.md
@@ -1,0 +1,40 @@
+---
+icon: "📅"
+tagline: "Calendar and contacts that sync between every device — no separate app, just your phone's built-in Calendar and Contacts."
+---
+
+# Getting started with Calendar & Contacts
+
+Radicale uses standard CalDAV / CardDAV — the same protocols Apple, Google, and Outlook calendars all speak. So you don't install a new app: you tell your phone's existing **Calendar** and **Contacts** apps to talk to your server.
+
+## On iPhone / iPad
+
+1. Open **Settings → Calendar → Accounts → Add Account → Other**.
+2. Tap **Add CalDAV Account**.
+3. Server: the URL from the *Open* button on this card without the protocol (e.g. `cal.home.arpa`).
+4. Username / password: the family ones.
+5. Save. Repeat for Contacts via *Settings → Contacts → Accounts → Add Account → Other → Add CardDAV Account*.
+
+Your shared calendars and contacts now appear in the native Calendar and Contacts apps. Any event you add on the phone syncs back to the server (and to every other family device) within a minute.
+
+## On Android
+
+Android's native Calendar app doesn't speak CalDAV directly — install **DAVx⁵** from F-Droid or the Play Store as a one-time bridge:
+
+1. Install **[DAVx⁵](https://play.google.com/store/apps/details?id=at.bitfire.davdroid)**.
+2. Open it, tap *+* → *Login with URL and username*.
+3. Server URL: same as above (e.g. `https://cal.home.arpa`).
+4. Family username + password.
+5. Tap *Login*. DAVx⁵ discovers calendars and contacts and asks which to sync.
+
+Now the stock Calendar and Contacts apps see them like any other account.
+
+## On macOS / Windows
+
+Both have native CalDAV / CardDAV support. macOS: *System Settings → Internet Accounts → Add Other Account → CalDAV Account*. Windows: similar via Outlook → *Add Account → Other (CalDAV/CardDAV)*.
+
+## Tips
+
+- **Per-user calendars are separate.** Each family member has their own calendar; shared calendars (e.g. "Family Events") are visible to everyone.
+- **Offline-first.** Your phone's Calendar app caches everything locally. Adding events offline works; they sync when the network is back.
+- **Privacy.** No data leaves your home — invitations to non-family-members go through email like normal, but the events themselves never touch a cloud calendar.

--- a/templates/vaultwarden/user-guide.md
+++ b/templates/vaultwarden/user-guide.md
@@ -1,0 +1,35 @@
+---
+icon: "🔒"
+tagline: "Save passwords once, autofill them on every phone, browser, and laptop in the family."
+mobile_apps:
+  - name: "Bitwarden for iOS"
+    url: "https://apps.apple.com/app/bitwarden-password-manager/id1137397744"
+  - name: "Bitwarden for Android"
+    url: "https://play.google.com/store/apps/details?id=com.x8bit.bitwarden"
+---
+
+# Getting started with Passwords
+
+Vaultwarden uses the same apps as Bitwarden — install **Bitwarden** (links above) on every device and point it at your home server.
+
+## On your phone (one-time setup)
+
+1. Install **Bitwarden** from the App Store or Play Store.
+2. Open it — tap the gear icon (Settings) at the top-left of the login screen.
+3. Tap **Self-hosted** and paste the URL from the *Open* button on this card (e.g. `http://vault.home.arpa`) into **Server URL**. Save.
+4. Back on the login screen, log in with the family password.
+5. Set a strong **master password** when prompted — this is what unlocks the vault on this device. Different from your family password.
+
+## In your browser
+
+1. Install the **Bitwarden** browser extension from your browser's add-on store.
+2. Click the icon → gear → **Self-hosted** → paste the same URL → save.
+3. Log in.
+
+That's it. Save a password once and it autofills everywhere.
+
+## Tips
+
+- **The master password unlocks the vault locally.** If you forget it, you have to re-set up the vault — even the family admin can't recover it. Pick something memorable.
+- **Sharing is via Collections.** Make a "Family" collection and any password added there is visible to everyone in the family group.
+- **Autofill works offline.** Vaultwarden syncs new entries when the network is back, but logging in still works without it.


### PR DESCRIPTION
## Summary
Authors a \`user-guide.md\` for every feature-tier template that didn't have one yet (Immich shipped in #304). After this lands, the family portal at \`home.arpa\` shows six cards instead of one.

| Template | Icon | Tagline |
|---|---|---|
| vaultwarden | 🔒 | Save passwords once, autofill them on every phone, browser, and laptop in the family. |
| file-share | 📁 | Share documents across phones, laptops, and the family — like a private Dropbox. |
| home-assistant | 🏠 | Control lights, sensors, and smart-home devices from one app. |
| media | 🎵 | Stream your music collection and listen to audiobooks — offline-capable on phones. |
| radicale | 📅 | Calendar and contacts that sync between every device. |

Each guide carries icon + tagline frontmatter, mobile-app links where applicable, and a step-by-step body addressed to the non-technical family-member audience.

Radicale ships without mobile_apps[] because the recommended path is the OS's built-in Calendar/Contacts apps (no extra app to install); the body walks through the iOS/Android/desktop CalDAV setup instead.

The portal's existing card builder picks them up automatically — no code changes.

## Test plan
- [x] 449 tests pass; \`next build\` clean
- [ ] Manual: visit \`home.arpa\`, confirm six cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)