### PR TITLE
feat(portal): "request access" flow for visitors without an account

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Check, ExternalLink, Loader2, Mail, Trash2, UserPlus } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+interface AccessRequest {
+  id: string;
+  requestedAt: string;
+  name: string;
+  email: string;
+  message?: string;
+  status: 'pending' | 'resolved';
+  resolvedAt?: string;
+}
+
+/**
+ * Settings section for the family-portal access-request flow
+ * (#242 follow-up). Shows pending + resolved requests with two
+ * actions per row:
+ *
+ *   - Mark resolved: flips status. Use after creating the LLDAP
+ *     user. Resolved entries stay around so admin can see history.
+ *   - Delete: drops the request entirely. Use for spam.
+ *
+ * Plus a top-level link to LLDAP (when known) so the admin can jump
+ * to the user-creation UI without hunting for the URL.
+ */
+export default function AccessRequestsSection() {
+  const { addToast } = useToast();
+  const [requests, setRequests] = useState<AccessRequest[]>([]);
+  const [busy, setBusy] = useState<'load' | 'action' | null>('load');
+  const [lldapUrl, setLldapUrl] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const res = await fetch('/api/system/access-requests');
+      if (res.ok) {
+        const data = await res.json();
+        setRequests(Array.isArray(data.requests) ? data.requests : []);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    fetch('/api/auth/lldap-url')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data?.url) setLldapUrl(data.url); })
+      .catch(() => {});
+  }, []);
+
+  const onResolve = async (id: string) => {
+    setBusy('action');
+    try {
+      const res = await fetch(`/api/system/access-requests/${id}`, { method: 'PATCH' });
+      if (res.ok) {
+        await load();
+      } else {
+        addToast('error', 'Could not resolve', `HTTP ${res.status}`);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!window.confirm('Delete this access request? Use for spam — there\'s no undo.')) return;
+    setBusy('action');
+    try {
+      const res = await fetch(`/api/system/access-requests/${id}`, { method: 'DELETE' });
+      if (res.ok) {
+        await load();
+      } else {
+        addToast('error', 'Could not delete', `HTTP ${res.status}`);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const pending = requests.filter(r => r.status === 'pending');
+  const resolved = requests.filter(r => r.status === 'resolved').sort((a, b) => (b.resolvedAt ?? '').localeCompare(a.resolvedAt ?? ''));
+
+  if (busy === 'load') {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading access requests…
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 bg-violet-100 dark:bg-violet-900/30 rounded-lg text-violet-600 dark:text-violet-400">
+          <UserPlus size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">
+            Access requests
+            {pending.length > 0 && (
+              <span className="ml-2 inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold text-white bg-amber-500 rounded-full">
+                {pending.length}
+              </span>
+            )}
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Family members on the LAN can submit a request from the portal at <span className="font-mono">/portal</span>. Create the user in LLDAP, then mark resolved.
+          </p>
+        </div>
+        {lldapUrl && (
+          <a
+            href={lldapUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 text-sm font-medium bg-violet-600 hover:bg-violet-700 text-white rounded-lg"
+          >
+            Open LLDAP <ExternalLink size={14} />
+          </a>
+        )}
+      </div>
+
+      <div className="p-6 space-y-6">
+        {requests.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+            No access requests yet. They appear here when a family member fills the form on the portal.
+          </p>
+        ) : (
+          <>
+            {pending.length > 0 && (
+              <div>
+                <h4 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">Pending</h4>
+                <div className="space-y-2">
+                  {pending.map(r => (
+                    <RequestRow
+                      key={r.id}
+                      r={r}
+                      onResolve={() => onResolve(r.id)}
+                      onDelete={() => onDelete(r.id)}
+                      busy={busy === 'action'}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            {resolved.length > 0 && (
+              <div>
+                <h4 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">Resolved</h4>
+                <div className="space-y-2">
+                  {resolved.map(r => (
+                    <RequestRow
+                      key={r.id}
+                      r={r}
+                      onResolve={() => onResolve(r.id)}
+                      onDelete={() => onDelete(r.id)}
+                      busy={busy === 'action'}
+                      muted
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RequestRow({
+  r,
+  onResolve,
+  onDelete,
+  busy,
+  muted,
+}: {
+  r: AccessRequest;
+  onResolve: () => void;
+  onDelete: () => void;
+  busy: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <div className={`p-3 rounded-lg border border-gray-200 dark:border-gray-700 ${muted ? 'opacity-60' : 'bg-white dark:bg-gray-900'}`}>
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-medium text-gray-900 dark:text-white">{r.name}</span>
+            <a href={`mailto:${r.email}`} className="inline-flex items-center gap-1 text-violet-700 dark:text-violet-300 hover:underline text-xs">
+              <Mail size={12} /> {r.email}
+            </a>
+          </div>
+          <div className="text-[11px] text-gray-500 dark:text-gray-400">
+            Submitted {new Date(r.requestedAt).toLocaleString()}
+            {r.resolvedAt && ` · resolved ${new Date(r.resolvedAt).toLocaleString()}`}
+          </div>
+          {r.message && (
+            <p className="mt-1 text-xs text-gray-600 dark:text-gray-400 italic">&ldquo;{r.message}&rdquo;</p>
+          )}
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {r.status === 'pending' && (
+            <button
+              onClick={onResolve}
+              disabled={busy}
+              className="p-1.5 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded disabled:opacity-50"
+              title="Mark resolved (after creating the LLDAP user)"
+            >
+              <Check size={16} />
+            </button>
+          )}
+          <button
+            onClick={onDelete}
+            disabled={busy}
+            className="p-1.5 text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+            title="Delete this request"
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AccessRequestsSection from '../_lib/sections/AccessRequestsSection';
 import CredentialsSection from '../_lib/sections/CredentialsSection';
 import EmailNotificationsSection from '../_lib/sections/EmailNotificationsSection';
 import McpSection from '../_lib/sections/McpSection';
@@ -12,6 +13,7 @@ export default function IntegrationsSettingsPage() {
   return (
     <>
       <PublicDomainSection />
+      <AccessRequestsSection />
       <CredentialsSection />
       <ReverseProxySection />
       <EmailNotificationsSection />

--- a/src/app/api/system/access-requests/[id]/route.ts
+++ b/src/app/api/system/access-requests/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { getConfig, saveConfig } from '@/lib/config';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Per-request actions for the family portal access-request flow
+ * (#242 follow-up).
+ *
+ *   PATCH  — mark a pending request resolved (admin clicked "create
+ *            user" or "ignore"). Body: `{ status: 'resolved' }`.
+ *   DELETE — drop the request entirely. Used for spam cleanup.
+ *
+ * Both endpoints require a session — proxy.ts only allows
+ * `/api/system/access-requests` for POST publicly; PATCH and DELETE
+ * fall through the existing session check.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const config = await getConfig();
+  const requests = [...(config.accessRequests ?? [])];
+  const idx = requests.findIndex(r => r.id === id);
+  if (idx < 0) {
+    return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
+  }
+  requests[idx] = {
+    ...requests[idx],
+    status: 'resolved',
+    resolvedAt: new Date().toISOString(),
+  };
+  await saveConfig({ ...config, accessRequests: requests });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const config = await getConfig();
+  const requests = (config.accessRequests ?? []).filter(r => r.id !== id);
+  await saveConfig({ ...config, accessRequests: requests });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/system/access-requests/route.ts
+++ b/src/app/api/system/access-requests/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import crypto from 'crypto';
+import { getConfig, saveConfig, type AccessRequest } from '@/lib/config';
+import { sendEmailAlert } from '@/lib/email';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * "Request access" endpoint for the family portal (#242 follow-up).
+ *
+ *   POST — public (proxy.ts allows POST without a session). Anonymous
+ *          family-LAN visitor submits name + email + optional message.
+ *          Persisted in config.accessRequests; admin gets an email
+ *          notification when notifications.email is configured.
+ *
+ *   GET  — admin-only. Returns all requests so Settings can render
+ *          the table.
+ *
+ * Per-request operations (PATCH/DELETE by id) live in [id]/route.ts.
+ *
+ * Rate-limit: hard cap of 50 pending requests. New POSTs once the
+ * cap is hit return 429. Admin can clear resolved entries to make
+ * room. Cap is per-process; not perfect but enough to prevent a
+ * hostile LAN device from filling config.json.
+ */
+
+const MAX_PENDING = 50;
+const POST_BODY_LIMIT = 4_096;
+
+const PostBody = z.object({
+  name: z.string().trim().min(1).max(120),
+  email: z.email().max(200),
+  message: z.string().trim().max(1_000).optional(),
+});
+
+export async function POST(request: Request) {
+  // Cap raw body size so a hostile client can't push gigabytes.
+  // Next.js doesn't enforce this by default for route handlers.
+  const text = await request.text();
+  if (text.length > POST_BODY_LIMIT) {
+    return NextResponse.json({ error: 'Request body too large.' }, { status: 413 });
+  }
+  let body: unknown;
+  try { body = JSON.parse(text); } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
+  }
+  let parsed;
+  try {
+    parsed = PostBody.parse(body);
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Invalid body.' }, { status: 400 });
+  }
+
+  const config = await getConfig();
+  const existing = config.accessRequests ?? [];
+  const pending = existing.filter(r => r.status === 'pending');
+  if (pending.length >= MAX_PENDING) {
+    return NextResponse.json(
+      { error: 'Too many pending requests right now. The family admin needs to review the existing ones first.' },
+      { status: 429 },
+    );
+  }
+
+  const newRequest: AccessRequest = {
+    id: crypto.randomUUID(),
+    requestedAt: new Date().toISOString(),
+    name: parsed.name,
+    email: parsed.email,
+    message: parsed.message,
+    status: 'pending',
+  };
+  await saveConfig({ ...config, accessRequests: [...existing, newRequest] });
+  logger.info('access-requests', `New request from ${parsed.email}`);
+
+  // Best-effort email notification — sendEmailAlert no-ops when
+  // email isn't configured.
+  void sendEmailAlert(
+    'New access request',
+    `${parsed.name} (${parsed.email}) has requested access to your home server.\n\n` +
+    (parsed.message ? `Message: ${parsed.message}\n\n` : '') +
+    'Open Settings → Access Requests to create the LLDAP user.',
+  );
+
+  return NextResponse.json({ ok: true, id: newRequest.id });
+}
+
+export async function GET() {
+  const config = await getConfig();
+  const requests = config.accessRequests ?? [];
+  return NextResponse.json({ requests });
+}

--- a/src/app/portal/RequestAccessButton.tsx
+++ b/src/app/portal/RequestAccessButton.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState } from 'react';
+import { UserPlus, Loader2 } from 'lucide-react';
+
+/**
+ * "Don't have an account?" affordance on the family portal (#242
+ * follow-up). Renders a small button below the card grid; clicking
+ * opens a modal with name/email/optional message → POSTs to
+ * /api/system/access-requests (public). The admin sees the request
+ * in Settings → Access Requests and creates an LLDAP user.
+ */
+export default function RequestAccessButton() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const reset = () => {
+    setName('');
+    setEmail('');
+    setMessage('');
+    setError(null);
+    setSubmitted(false);
+  };
+
+  const onClose = () => {
+    setOpen(false);
+    // Slight delay so the closing transition doesn't show the form snapping back to empty.
+    setTimeout(reset, 200);
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/system/access-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), email: email.trim(), message: message.trim() || undefined }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data.error === 'string' ? data.error : `Submission failed (${res.status}).`);
+        return;
+      }
+      setSubmitted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="mt-12 text-center">
+        <button
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 hover:border-violet-500 hover:text-violet-700 dark:hover:text-violet-300 text-sm font-medium text-gray-700 dark:text-gray-300 rounded-full transition-colors"
+        >
+          <UserPlus size={16} />
+          Don&apos;t have an account yet?
+        </button>
+      </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50"
+          onClick={onClose}
+        >
+          <div
+            className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-md w-full p-6"
+            onClick={e => e.stopPropagation()}
+          >
+            {submitted ? (
+              <div className="text-center py-8 space-y-3">
+                <div className="text-5xl">✅</div>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Request sent</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  The family admin has been notified. They&apos;ll create your account and let you know when it&apos;s ready.
+                </p>
+                <button
+                  onClick={onClose}
+                  className="mt-2 px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium rounded-lg"
+                >
+                  Got it
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={onSubmit} className="space-y-4">
+                <div>
+                  <h2 className="text-xl font-bold text-gray-900 dark:text-white">Request access</h2>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                    The family admin will get a notification and create your account.
+                  </p>
+                </div>
+
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Your name <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                    required
+                    maxLength={120}
+                    autoComplete="name"
+                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                  />
+                </div>
+
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Your email <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    required
+                    maxLength={200}
+                    autoComplete="email"
+                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                  />
+                </div>
+
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Anything else? <span className="text-gray-400">(optional)</span>
+                  </label>
+                  <textarea
+                    value={message}
+                    onChange={e => setMessage(e.target.value)}
+                    maxLength={1000}
+                    rows={3}
+                    placeholder="e.g. which services you'd like access to"
+                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                  />
+                </div>
+
+                {error && (
+                  <div className="px-3 py-2 text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 rounded">
+                    {error}
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-2 pt-2">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+                  >
+                    {submitting && <Loader2 size={14} className="animate-spin" />}
+                    Send request
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,5 +1,6 @@
 import { buildPortalCards } from '@/lib/portal/services';
 import PortalGrid from './PortalGrid';
+import RequestAccessButton from './RequestAccessButton';
 
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
@@ -36,6 +37,8 @@ export default async function PortalPage() {
       ) : (
         <PortalGrid cards={cards} />
       )}
+
+      <RequestAccessButton />
     </main>
   );
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -219,6 +219,13 @@ export interface AppConfig {
    * existing `SENSITIVE_KEYS` regex on the password field.
    */
   installManifest?: InstallManifest;
+  /**
+   * Anonymous "request access" submissions from the family portal
+   * (#242). Public POST endpoint appends here; admin Settings page
+   * reads + resolves. Capped at 50 pending so spam can't fill the
+   * disk.
+   */
+  accessRequests?: AccessRequest[];
 }
 
 export interface ServicePostDeployRecord {
@@ -253,6 +260,28 @@ export interface InstallManifest {
   /** ISO timestamp of when this manifest was persisted. */
   savedAt: string;
   credentials: InstalledCredential[];
+}
+
+/**
+ * "Request access" submission from the family portal (#242 follow-up).
+ * Anonymous family-LAN visitors fill a form with their name + email
+ * and the admin sees pending requests in Settings, then creates an
+ * LLDAP user. Persisted in `config.accessRequests` so they survive
+ * reboots; auto-capped at 50 pending so a hostile LAN visitor can't
+ * fill the disk.
+ */
+export interface AccessRequest {
+  /** Random uuid; the route handler generates it. */
+  id: string;
+  /** ISO timestamp of when the form was submitted. */
+  requestedAt: string;
+  name: string;
+  email: string;
+  /** Optional "why" note from the requester. */
+  message?: string;
+  status: 'pending' | 'resolved';
+  /** ISO timestamp of when the admin marked it resolved. */
+  resolvedAt?: string;
 }
 
 export function getOidcCallbackUrl(config: { reverseProxy?: { publicDomain?: string } }): string {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,16 +4,30 @@ import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { getConfig } from '@/lib/config';
 import { getActiveDomain } from '@/lib/mode';
 
-const PUBLIC_API_PREFIXES = [
-  '/api/auth/login',
-  '/api/auth/oidc',
-  '/api/auth/lldap-url',
+/**
+ * Routes that bypass the session-cookie check. Each rule can pin
+ * which HTTP methods are public — without `methods`, every method
+ * is allowed.
+ *
+ * `/api/system/access-requests` POST is public so the anonymous
+ * family-portal visitor can submit a request without a session;
+ * GET/PATCH/DELETE on the same path stay admin-only (#242 follow-up).
+ */
+const PUBLIC_API_RULES: Array<{ prefix: string; methods?: ReadonlySet<string> }> = [
+  { prefix: '/api/auth/login' },
+  { prefix: '/api/auth/oidc' },
+  { prefix: '/api/auth/lldap-url' },
+  { prefix: '/api/system/access-requests', methods: new Set(['POST']) },
 ];
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
-function isPublicApi(pathname: string): boolean {
-  return PUBLIC_API_PREFIXES.some(p => pathname === p || pathname.startsWith(p + '/'));
+function isPublicApi(pathname: string, method: string): boolean {
+  return PUBLIC_API_RULES.some(rule => {
+    const matches = pathname === rule.prefix || pathname.startsWith(rule.prefix + '/');
+    if (!matches) return false;
+    return !rule.methods || rule.methods.has(method);
+  });
 }
 
 // Server-to-server calls from ServiceBay's own post-deploy scripts on
@@ -112,7 +126,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden: cross-site request' }, { status: 403 });
   }
 
-  if (isPublicApi(pathname)) return NextResponse.next();
+  if (isPublicApi(pathname, request.method)) return NextResponse.next();
 
   const token = request.cookies.get('session')?.value;
   if (!token) {

--- a/tests/backend/access_requests.test.ts
+++ b/tests/backend/access_requests.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state: { config: any } = { config: {} };
+
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<any>('@/lib/config');
+  return {
+    ...actual,
+    getConfig: vi.fn(async () => state.config),
+    saveConfig: vi.fn(async (cfg: any) => { state.config = cfg; }),
+  };
+});
+vi.mock('@/lib/email', () => ({
+  sendEmailAlert: vi.fn(async () => {}),
+}));
+
+import { POST, GET } from '@/app/api/system/access-requests/route';
+import { PATCH, DELETE } from '@/app/api/system/access-requests/[id]/route';
+
+beforeEach(() => {
+  state.config = {};
+});
+
+const post = (body: unknown, opts?: { rawBody?: string }) =>
+  POST(new Request('http://test/api/system/access-requests', {
+    method: 'POST',
+    body: opts?.rawBody ?? JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  }));
+
+describe('POST /api/system/access-requests', () => {
+  it('creates a request from a valid body', async () => {
+    const res = await post({ name: 'Alice', email: 'alice@example.com', message: 'I want photos' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(typeof data.id).toBe('string');
+    expect(state.config.accessRequests).toHaveLength(1);
+    expect(state.config.accessRequests[0].name).toBe('Alice');
+    expect(state.config.accessRequests[0].status).toBe('pending');
+  });
+
+  it('rejects invalid email', async () => {
+    const res = await post({ name: 'Alice', email: 'not-an-email' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty name', async () => {
+    const res = await post({ name: '', email: 'a@b.c' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects oversized body', async () => {
+    const huge = 'x'.repeat(5_000);
+    const res = await post(null, { rawBody: huge });
+    expect(res.status).toBe(413);
+  });
+
+  it('refuses when 50 pending requests already exist', async () => {
+    state.config.accessRequests = Array.from({ length: 50 }, (_, i) => ({
+      id: `r${i}`,
+      requestedAt: new Date().toISOString(),
+      name: `User ${i}`,
+      email: `user${i}@example.com`,
+      status: 'pending' as const,
+    }));
+    const res = await post({ name: 'Late', email: 'late@example.com' });
+    expect(res.status).toBe(429);
+  });
+
+  it('still accepts when 50 resolved (only pending counts toward cap)', async () => {
+    state.config.accessRequests = Array.from({ length: 50 }, (_, i) => ({
+      id: `r${i}`,
+      requestedAt: new Date().toISOString(),
+      name: `User ${i}`,
+      email: `user${i}@example.com`,
+      status: 'resolved' as const,
+      resolvedAt: new Date().toISOString(),
+    }));
+    const res = await post({ name: 'Fresh', email: 'fresh@example.com' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /api/system/access-requests', () => {
+  it('returns the persisted list', async () => {
+    state.config.accessRequests = [
+      { id: 'r1', requestedAt: '2026-01-01', name: 'A', email: 'a@b.c', status: 'pending' },
+    ];
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.requests).toHaveLength(1);
+    expect(data.requests[0].name).toBe('A');
+  });
+
+  it('returns empty list when nothing persisted', async () => {
+    const res = await GET();
+    const data = await res.json();
+    expect(data.requests).toEqual([]);
+  });
+});
+
+describe('PATCH /api/system/access-requests/[id]', () => {
+  it('marks a request resolved', async () => {
+    state.config.accessRequests = [
+      { id: 'r1', requestedAt: '2026-01-01', name: 'A', email: 'a@b.c', status: 'pending' },
+    ];
+    const res = await PATCH(
+      new Request('http://test/api/system/access-requests/r1', { method: 'PATCH' }),
+      { params: Promise.resolve({ id: 'r1' }) },
+    );
+    expect(res.status).toBe(200);
+    expect(state.config.accessRequests[0].status).toBe('resolved');
+    expect(state.config.accessRequests[0].resolvedAt).toBeDefined();
+  });
+
+  it('returns 404 when id not found', async () => {
+    const res = await PATCH(
+      new Request('http://test/api/system/access-requests/nope', { method: 'PATCH' }),
+      { params: Promise.resolve({ id: 'nope' }) },
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/system/access-requests/[id]', () => {
+  it('removes the matching request and preserves others', async () => {
+    state.config.accessRequests = [
+      { id: 'r1', requestedAt: '2026-01-01', name: 'A', email: 'a@b.c', status: 'pending' },
+      { id: 'r2', requestedAt: '2026-01-02', name: 'B', email: 'b@b.c', status: 'pending' },
+    ];
+    const res = await DELETE(
+      new Request('http://test/api/system/access-requests/r1', { method: 'DELETE' }),
+      { params: Promise.resolve({ id: 'r1' }) },
+    );
+    expect(res.status).toBe(200);
+    expect(state.config.accessRequests).toHaveLength(1);
+    expect(state.config.accessRequests[0].id).toBe('r2');
+  });
+});


### PR DESCRIPTION
## Summary
A LAN visitor without an LLDAP account can submit name + email + optional message directly from the portal; the admin sees the request in Settings → Access Requests and creates the user.

### Three pieces
1. **API** \`/api/system/access-requests\`
   - POST is public (\`proxy.ts\` \`PUBLIC_API_RULES\` upgraded to support per-method gating). Validates name/email, hard-caps at 50 pending, sends an email to the admin when notifications.email is configured.
   - GET / PATCH / DELETE keep the standard session gate.
2. **Portal UI** — \`RequestAccessButton.tsx\`: rounded "Don't have an account yet?" pill below the card grid; modal with name + email + optional message → success state.
3. **Settings UI** — new \`AccessRequestsSection\` in Settings → Integrations with a pending-count badge, per-row resolve/delete actions, and an "Open LLDAP" jump button.

### Test plan
- [x] 460 tests pass (was 449, +11 new for the API)
- [x] \`next build\` clean
- [ ] Manual: visit \`home.arpa\`, click "Don't have an account yet?", submit form, confirm success state.
- [ ] Manual: as admin, visit Settings → Integrations → Access Requests, see the pending row, click ✅ to mark resolved.
- [ ] Manual: with email notifications configured, confirm the admin email arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)