### PR TITLE
feat(portal): recommended_apps schema with platform badges + per-app notes

### DIFF
--- a/src/app/portal/PortalGrid.tsx
+++ b/src/app/portal/PortalGrid.tsx
@@ -3,8 +3,16 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ChevronDown, ChevronUp, ExternalLink, Smartphone } from 'lucide-react';
+import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import type { PortalCard } from '@/lib/portal/services';
+import type { AppPlatform } from '@/lib/portal/userGuide';
+
+const PLATFORM_LABELS: Record<AppPlatform, string> = {
+  ios: 'iOS',
+  android: 'Android',
+  desktop: 'Desktop',
+  browser: 'Browser',
+};
 
 /**
  * Renders the portal card grid + per-card collapsible Getting-started
@@ -41,19 +49,40 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                 Open <ExternalLink size={16} />
               </a>
 
-              {card.mobileApps.length > 0 && (
-                <div className="flex flex-wrap gap-2 justify-center pt-1">
-                  {card.mobileApps.map(app => (
-                    <a
-                      key={app.url}
-                      href={app.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 hover:text-violet-700 dark:hover:text-violet-300 underline"
-                    >
-                      <Smartphone size={12} /> {app.name}
-                    </a>
-                  ))}
+              {card.recommendedApps.length > 0 && (
+                <div className="pt-2 space-y-1.5">
+                  <div className="text-[11px] uppercase tracking-wide font-medium text-gray-500 dark:text-gray-400">
+                    💡 Recommended apps
+                  </div>
+                  <ul className="space-y-1.5">
+                    {card.recommendedApps.map(app => (
+                      <li key={app.url} className="text-xs">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                          <a
+                            href={app.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-violet-700 dark:text-violet-300 hover:underline"
+                          >
+                            {app.name}
+                          </a>
+                          {app.platforms?.map(p => (
+                            <span
+                              key={p}
+                              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                            >
+                              {PLATFORM_LABELS[p]}
+                            </span>
+                          ))}
+                        </div>
+                        {app.note && (
+                          <p className="text-gray-500 dark:text-gray-400 mt-0.5 leading-snug">
+                            {app.note}
+                          </p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               )}
 

--- a/src/lib/portal/services.ts
+++ b/src/lib/portal/services.ts
@@ -27,7 +27,7 @@ import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getTemplateUserGuide } from '@/lib/registry';
 import { logger } from '@/lib/logger';
-import { parseUserGuide, type UserGuideFrontmatter } from './userGuide';
+import { parseUserGuide, type RecommendedApp } from './userGuide';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
@@ -44,8 +44,8 @@ export interface PortalCard {
   url: string;
   /** Markdown body for the expandable Getting-started section. May be empty. */
   body: string;
-  /** Mobile-app download links from frontmatter (validated http/https). */
-  mobileApps: NonNullable<UserGuideFrontmatter['mobile_apps']>;
+  /** Companion apps recommended by the template author (validated). */
+  recommendedApps: RecommendedApp[];
 }
 
 /** Read a template's variables.json (best-effort, returns empty record on miss). */
@@ -125,7 +125,7 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
       tagline: parsed.frontmatter.tagline ?? '',
       url: `${scheme}://${sub}.${activeDomain}`,
       body: parsed.body,
-      mobileApps: parsed.frontmatter.mobile_apps ?? [],
+      recommendedApps: parsed.frontmatter.recommended_apps ?? [],
     });
   }
   return cards;

--- a/src/lib/portal/userGuide.test.ts
+++ b/src/lib/portal/userGuide.test.ts
@@ -8,69 +8,109 @@ describe('parseUserGuide', () => {
     expect(parseUserGuide('   \n  ', 'x')).toBeNull();
   });
 
-  it('extracts icon, tagline, and mobile_apps', () => {
+  it('extracts icon and tagline', () => {
     const raw = `---
 icon: "📷"
 tagline: "Auto-backup your photos."
+---
+
+# Getting started
+`;
+    const result = parseUserGuide(raw, 'immich');
+    expect(result).not.toBeNull();
+    expect(result!.frontmatter.icon).toBe('📷');
+    expect(result!.frontmatter.tagline).toBe('Auto-backup your photos.');
+    expect(result!.body.trim()).toMatch(/^# Getting started/);
+  });
+
+  it('parses recommended_apps with platforms + note', () => {
+    const raw = `---
+recommended_apps:
+  - name: "Obsidian"
+    url: "https://obsidian.md"
+    platforms: ["desktop", "ios", "android"]
+    note: "Notes app; pair with Syncthing for live sync."
+  - name: "VLC"
+    url: "https://www.videolan.org/"
+    platforms: ["desktop", "android"]
+---
+
+body
+`;
+    const result = parseUserGuide(raw, 'file-share');
+    expect(result!.frontmatter.recommended_apps).toHaveLength(2);
+    expect(result!.frontmatter.recommended_apps?.[0]).toEqual({
+      name: 'Obsidian',
+      url: 'https://obsidian.md',
+      platforms: ['desktop', 'ios', 'android'],
+      note: 'Notes app; pair with Syncthing for live sync.',
+    });
+    expect(result!.frontmatter.recommended_apps?.[1].note).toBeUndefined();
+  });
+
+  it('drops unknown platform values silently', () => {
+    const raw = `---
+recommended_apps:
+  - name: "X"
+    url: "https://x.example"
+    platforms: ["desktop", "smartwatch", "ios"]
+---
+`;
+    const result = parseUserGuide(raw, 'x');
+    expect(result!.frontmatter.recommended_apps?.[0].platforms).toEqual(['desktop', 'ios']);
+  });
+
+  it('rejects non-http(s) URLs in recommended_apps', () => {
+    const raw = `---
+recommended_apps:
+  - name: "Evil"
+    url: "javascript:alert(1)"
+  - name: "Real"
+    url: "https://example.com"
+---
+`;
+    const result = parseUserGuide(raw, 'evil');
+    expect(result!.frontmatter.recommended_apps).toHaveLength(1);
+    expect(result!.frontmatter.recommended_apps?.[0].name).toBe('Real');
+  });
+
+  it('lifts legacy mobile_apps into recommended_apps with inferred platforms', () => {
+    const raw = `---
 mobile_apps:
   - name: "Immich for iOS"
     url: "https://apps.apple.com/app/immich/id1"
   - name: "Immich for Android"
     url: "https://play.google.com/store/apps/details?id=app.immich"
 ---
-
-# Getting started
-
-Step 1.
 `;
-    const result = parseUserGuide(raw, 'immich');
-    expect(result).not.toBeNull();
-    expect(result!.frontmatter.icon).toBe('📷');
-    expect(result!.frontmatter.tagline).toBe('Auto-backup your photos.');
-    expect(result!.frontmatter.mobile_apps).toHaveLength(2);
-    expect(result!.frontmatter.mobile_apps?.[0].name).toBe('Immich for iOS');
-    expect(result!.body.trim()).toMatch(/^# Getting started/);
+    const result = parseUserGuide(raw, 'legacy');
+    const apps = result!.frontmatter.recommended_apps;
+    expect(apps).toHaveLength(2);
+    expect(apps?.[0].platforms).toEqual(['ios']);
+    expect(apps?.[1].platforms).toEqual(['android']);
   });
 
-  it('rejects non-http(s) URLs in mobile_apps', () => {
+  it('prefers recommended_apps over mobile_apps when both are present', () => {
     const raw = `---
+recommended_apps:
+  - name: "New"
+    url: "https://new.example"
 mobile_apps:
-  - name: "Evil"
-    url: "javascript:alert(1)"
-  - name: "Real"
-    url: "https://example.com"
+  - name: "Old"
+    url: "https://apps.apple.com/old"
 ---
-
-body
 `;
-    const result = parseUserGuide(raw, 'evil');
-    expect(result!.frontmatter.mobile_apps).toHaveLength(1);
-    expect(result!.frontmatter.mobile_apps?.[0].name).toBe('Real');
+    const result = parseUserGuide(raw, 'mixed');
+    expect(result!.frontmatter.recommended_apps).toHaveLength(1);
+    expect(result!.frontmatter.recommended_apps?.[0].name).toBe('New');
   });
 
   it('tolerates missing frontmatter (returns body only)', () => {
-    const raw = `# Just a title
-
-Body with no frontmatter.
-`;
+    const raw = `# Just a title\n\nbody\n`;
     const result = parseUserGuide(raw, 'plain');
     expect(result).not.toBeNull();
     expect(result!.frontmatter).toEqual({});
     expect(result!.body).toContain('Just a title');
-  });
-
-  it('drops malformed mobile_apps entries silently', () => {
-    const raw = `---
-mobile_apps:
-  - name: "Missing url"
-  - url: "https://example.com"
-  - "not an object"
-  - name: "Real"
-    url: "https://real.example"
----
-`;
-    const result = parseUserGuide(raw, 'mixed');
-    expect(result!.frontmatter.mobile_apps).toEqual([{ name: 'Real', url: 'https://real.example' }]);
   });
 
   it('returns null on YAML parse error', () => {

--- a/src/lib/portal/userGuide.ts
+++ b/src/lib/portal/userGuide.ts
@@ -22,15 +22,41 @@
 import matter from 'gray-matter';
 import { logger } from '@/lib/logger';
 
-export interface MobileAppLink {
+/** Platforms a recommended app runs on. The UI renders these as
+ *  small text badges next to the app name so visitors can see at a
+ *  glance whether the recommendation applies to their device. */
+export type AppPlatform = 'ios' | 'android' | 'desktop' | 'browser';
+const KNOWN_PLATFORMS: ReadonlySet<AppPlatform> = new Set(['ios', 'android', 'desktop', 'browser']);
+
+/**
+ * Recommended companion software for a service. Replaces the older
+ * narrower `mobile_apps[]` schema — supports desktop apps, browser
+ * extensions, and per-app notes explaining the recommendation
+ * (e.g. "Obsidian for notes, syncs via Syncthing").
+ *
+ * Authors using the old `mobile_apps:` shape still work — the parser
+ * back-fills platforms/notes from name conventions when both fields
+ * are present we use `recommended_apps` and ignore `mobile_apps`.
+ */
+export interface RecommendedApp {
   name: string;
   url: string;
+  /** Platforms this app runs on. Empty/missing = no badge shown. */
+  platforms?: AppPlatform[];
+  /** One-line "why this app" note, rendered small under the name. */
+  note?: string;
 }
 
 export interface UserGuideFrontmatter {
   icon?: string;
   tagline?: string;
-  mobile_apps?: MobileAppLink[];
+  /** Preferred — richer recommended-apps with platforms + notes. */
+  recommended_apps?: RecommendedApp[];
+  /** Legacy mobile-app shape (#242 v1). Lifted into recommended_apps
+   *  by the parser when present and recommended_apps isn't. Kept as
+   *  inline type rather than a named export so knip doesn't flag the
+   *  back-compat-only interface. */
+  mobile_apps?: { name: string; url: string }[];
 }
 
 export interface ParsedUserGuide {
@@ -44,6 +70,57 @@ export interface ParsedUserGuide {
  * the input is empty or the YAML is unparseable; missing fields are
  * tolerated (the caller renders best-effort with whatever's there).
  */
+/** Filter array of unknown entries down to a clean { name, url, ... }
+ *  list, dropping any that fail validation (non-string fields,
+ *  non-http URLs, unknown platforms). Frontmatter is template-author
+ *  input — we do basic sanitization so a hostile guide can't smuggle
+ *  e.g. `javascript:` URLs or arbitrary platform values into the UI. */
+function parseRecommendedApps(input: unknown): RecommendedApp[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((entry: unknown): RecommendedApp | null => {
+      if (!entry || typeof entry !== 'object') return null;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.name !== 'string' || typeof e.url !== 'string') return null;
+      if (!/^https?:\/\//i.test(e.url)) return null;
+      const out: RecommendedApp = { name: e.name, url: e.url };
+      if (Array.isArray(e.platforms)) {
+        const platforms = e.platforms
+          .filter((p): p is string => typeof p === 'string')
+          .map(p => p.toLowerCase())
+          .filter((p): p is AppPlatform => KNOWN_PLATFORMS.has(p as AppPlatform));
+        if (platforms.length > 0) out.platforms = platforms;
+      }
+      if (typeof e.note === 'string' && e.note.trim()) {
+        out.note = e.note.trim();
+      }
+      return out;
+    })
+    .filter((e): e is RecommendedApp => e !== null);
+}
+
+/** Lift a legacy `mobile_apps[]` entry list into the richer
+ *  `recommended_apps[]` shape — used as a fallback when a template
+ *  hasn't migrated yet. Heuristically infers the platform from the
+ *  link's host (App Store → ios, Play Store → android). */
+function liftMobileApps(input: unknown): RecommendedApp[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((entry: unknown): RecommendedApp | null => {
+      if (!entry || typeof entry !== 'object') return null;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.name !== 'string' || typeof e.url !== 'string') return null;
+      if (!/^https?:\/\//i.test(e.url)) return null;
+      const platforms: AppPlatform[] = [];
+      if (/apps\.apple\.com|itunes\.apple\.com/.test(e.url)) platforms.push('ios');
+      if (/play\.google\.com/.test(e.url)) platforms.push('android');
+      const out: RecommendedApp = { name: e.name, url: e.url };
+      if (platforms.length > 0) out.platforms = platforms;
+      return out;
+    })
+    .filter((e): e is RecommendedApp => e !== null);
+}
+
 export function parseUserGuide(raw: string | null, templateName: string): ParsedUserGuide | null {
   if (!raw || !raw.trim()) return null;
   try {
@@ -51,20 +128,17 @@ export function parseUserGuide(raw: string | null, templateName: string): Parsed
     const fm: UserGuideFrontmatter = {};
     if (typeof data.icon === 'string') fm.icon = data.icon;
     if (typeof data.tagline === 'string') fm.tagline = data.tagline;
-    if (Array.isArray(data.mobile_apps)) {
-      fm.mobile_apps = data.mobile_apps
-        .map((entry: unknown): MobileAppLink | null => {
-          if (!entry || typeof entry !== 'object') return null;
-          const e = entry as Record<string, unknown>;
-          if (typeof e.name !== 'string' || typeof e.url !== 'string') return null;
-          // Reject anything that isn't an http(s) URL — frontmatter is
-          // template-author input that ends up rendered as a link
-          // attribute. Reject `javascript:` etc.
-          if (!/^https?:\/\//i.test(e.url)) return null;
-          return { name: e.name, url: e.url };
-        })
-        .filter((e): e is MobileAppLink => e !== null);
+
+    // Prefer `recommended_apps` when present; fall back to lifting
+    // legacy `mobile_apps` so older guides keep working.
+    if (Array.isArray(data.recommended_apps)) {
+      const apps = parseRecommendedApps(data.recommended_apps);
+      if (apps.length > 0) fm.recommended_apps = apps;
+    } else if (Array.isArray(data.mobile_apps)) {
+      const lifted = liftMobileApps(data.mobile_apps);
+      if (lifted.length > 0) fm.recommended_apps = lifted;
     }
+
     return { frontmatter: fm, body: content };
   } catch (e) {
     logger.warn('portal:userGuide', `Failed to parse user-guide for ${templateName}: ${e instanceof Error ? e.message : String(e)}`);

--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -1,11 +1,27 @@
 ---
 icon: "📁"
 tagline: "Share documents across phones, laptops, and the family — like a private Dropbox."
-mobile_apps:
-  - name: "Syncthing for Android"
-    url: "https://play.google.com/store/apps/details?id=com.fsck.syncthing"
-  - name: "Möbius Sync for iOS"
+recommended_apps:
+  - name: "Syncthing"
+    url: "https://syncthing.net/downloads/"
+    platforms: ["desktop", "android"]
+    note: "Two-way folder sync between your devices and the home server."
+  - name: "Möbius Sync"
     url: "https://apps.apple.com/app/m%C3%B6bius-sync/id1539203216"
+    platforms: ["ios"]
+    note: "Syncthing-compatible iOS client — Apple doesn't allow Syncthing itself on iOS."
+  - name: "Obsidian"
+    url: "https://obsidian.md"
+    platforms: ["desktop", "ios", "android"]
+    note: "Markdown notes — point your vault at a Syncthing folder and notes auto-sync across every device."
+  - name: "KOReader"
+    url: "https://koreader.rocks/"
+    platforms: ["android"]
+    note: "Beautiful e-reader for PDFs / EPUBs / comics — opens files directly from a Syncthing folder."
+  - name: "VLC"
+    url: "https://www.videolan.org/vlc/"
+    platforms: ["desktop", "ios", "android"]
+    note: "Plays videos from the SMB share without downloading — pick \"Local Network\" → your server."
 ---
 
 # Getting started with Files

--- a/templates/home-assistant/user-guide.md
+++ b/templates/home-assistant/user-guide.md
@@ -1,11 +1,11 @@
 ---
 icon: "🏠"
 tagline: "Control lights, sensors, and smart-home devices from one app — and keep all the data on your home server."
-mobile_apps:
-  - name: "Home Assistant for iOS"
-    url: "https://apps.apple.com/app/home-assistant/id1099568401"
-  - name: "Home Assistant for Android"
-    url: "https://play.google.com/store/apps/details?id=io.homeassistant.companion.android"
+recommended_apps:
+  - name: "Home Assistant Companion"
+    url: "https://companion.home-assistant.io/"
+    platforms: ["ios", "android"]
+    note: "Official app — exposes your phone's sensors (location, battery) to HA so automations can react to who's home."
 ---
 
 # Getting started with Home Assistant

--- a/templates/immich/user-guide.md
+++ b/templates/immich/user-guide.md
@@ -1,11 +1,11 @@
 ---
 icon: "📷"
 tagline: "Auto-backup the photos on your phone and browse them like Google Photos — but private to your family."
-mobile_apps:
-  - name: "Immich for iOS"
-    url: "https://apps.apple.com/app/immich/id1613945652"
-  - name: "Immich for Android"
-    url: "https://play.google.com/store/apps/details?id=app.alextran.immich"
+recommended_apps:
+  - name: "Immich"
+    url: "https://immich.app/"
+    platforms: ["ios", "android"]
+    note: "Official mobile app — does the photo upload from your phone in the background. Install on every family member's phone."
 ---
 
 # Getting started with Photos

--- a/templates/media/user-guide.md
+++ b/templates/media/user-guide.md
@@ -1,13 +1,23 @@
 ---
 icon: "🎵"
 tagline: "Stream your music collection and listen to audiobooks — offline-capable on phones."
-mobile_apps:
-  - name: "Audiobookshelf for iOS"
-    url: "https://apps.apple.com/app/audiobookshelf/id1610212799"
-  - name: "Audiobookshelf for Android"
-    url: "https://play.google.com/store/apps/details?id=com.audiobookshelf.app"
-  - name: "Symfonium for Android (music)"
-    url: "https://play.google.com/store/apps/details?id=app.symfonik.music.player"
+recommended_apps:
+  - name: "Audiobookshelf"
+    url: "https://www.audiobookshelf.org/docs#mobile-apps"
+    platforms: ["ios", "android"]
+    note: "Official audiobook + podcast player. Bookmarks and progress sync between phone and tablet."
+  - name: "Symfonium"
+    url: "https://symfonium.app/"
+    platforms: ["android"]
+    note: "Best Subsonic-compatible music client on Android — paid app but well worth it for car audio + offline play."
+  - name: "play:Sub"
+    url: "https://apps.apple.com/app/play-sub-music-streamer/id955329386"
+    platforms: ["ios"]
+    note: "Highly-rated Subsonic music client for iPhone — the iOS counterpart to Symfonium."
+  - name: "Sonixd"
+    url: "https://github.com/jeffvli/sonixd"
+    platforms: ["desktop"]
+    note: "Cross-platform Subsonic desktop client — great for big libraries on a laptop."
 ---
 
 # Getting started with Media

--- a/templates/radicale/user-guide.md
+++ b/templates/radicale/user-guide.md
@@ -1,6 +1,19 @@
 ---
 icon: "📅"
 tagline: "Calendar and contacts that sync between every device — no separate app, just your phone's built-in Calendar and Contacts."
+recommended_apps:
+  - name: "iOS Calendar / Contacts"
+    url: "https://support.apple.com/guide/iphone/use-multiple-calendars-iph3d1110d4/ios"
+    platforms: ["ios"]
+    note: "Built-in. Add a CalDAV / CardDAV account in Settings — events appear in the native app."
+  - name: "DAVx⁵"
+    url: "https://www.davx5.com/"
+    platforms: ["android"]
+    note: "Required CalDAV / CardDAV bridge for Android — once set up, calendars + contacts sync to the stock Calendar and Contacts apps."
+  - name: "Thunderbird"
+    url: "https://www.thunderbird.net/"
+    platforms: ["desktop"]
+    note: "Best desktop CalDAV / CardDAV client — works on Windows, macOS, Linux."
 ---
 
 # Getting started with Calendar & Contacts

--- a/templates/vaultwarden/user-guide.md
+++ b/templates/vaultwarden/user-guide.md
@@ -1,11 +1,15 @@
 ---
 icon: "🔒"
 tagline: "Save passwords once, autofill them on every phone, browser, and laptop in the family."
-mobile_apps:
-  - name: "Bitwarden for iOS"
-    url: "https://apps.apple.com/app/bitwarden-password-manager/id1137397744"
-  - name: "Bitwarden for Android"
-    url: "https://play.google.com/store/apps/details?id=com.x8bit.bitwarden"
+recommended_apps:
+  - name: "Bitwarden"
+    url: "https://bitwarden.com/download/"
+    platforms: ["ios", "android", "desktop"]
+    note: "Official app — set Server URL to your home URL in Settings before logging in."
+  - name: "Bitwarden browser extension"
+    url: "https://bitwarden.com/download/#downloads-web-browser"
+    platforms: ["browser"]
+    note: "Autofill on Chrome, Firefox, Safari, Edge — same self-hosted URL."
 ---
 
 # Getting started with Passwords


### PR DESCRIPTION
## Summary
Replaces the narrow \`mobile_apps[]\` frontmatter with a richer \`recommended_apps[]\` shape so each card can suggest specific companion software with platform badges and a one-line "why this app" note.

### Examples shipped
| Service | New recommendations |
|---|---|
| file-share | **Obsidian** (notes via Syncthing), **KOReader** (e-reader), **VLC** (video over SMB) |
| media | **Symfonium** (Android, music), **play:Sub** (iOS, music), **Sonixd** (desktop) |
| vaultwarden | Official **Bitwarden** app + **browser extension** |
| radicale | **DAVx⁵** (Android), **iOS Calendar/Contacts**, **Thunderbird** (desktop) |
| immich, home-assistant | Cleaned up to point at the official-app download page |

### Schema
\`\`\`yaml
recommended_apps:
  - name: "Obsidian"
    url: "https://obsidian.md"
    platforms: ["desktop", "ios", "android"]
    note: "Notes app; pair with Syncthing for live sync."
\`\`\`

Backwards-compat: legacy \`mobile_apps\` still parsed — the parser infers platforms from App Store / Play Store URLs and lifts the list into the new shape, so older guides keep working without manual migration.

### Card UI
Each app renders as a violet name link + small uppercase platform badges (\`iOS\` / \`Android\` / \`Desktop\` / \`Browser\`) + grey one-liner note. Section labelled "💡 Recommended apps" above the existing "How do I use this?" expander.

## Test plan
- [x] 452 tests pass; \`next build\` clean
- [x] Parser tests rewritten — 9 covering recommended_apps with platforms, unknown-platform filtering, http-only URL validation, the legacy-lift path, prefer-recommended-over-mobile precedence
- [ ] Manual: visit \`home.arpa\`, confirm each card shows the new "Recommended apps" block with platform badges + notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)