### PR TITLE
feat(portal): Syncthing QR setup asset for one-tap Android device pairing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "node-pty": "^1.1.0",
         "nodemailer": "^8.0.7",
         "prismjs": "^1.30.0",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -10508,6 +10509,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "node-pty": "^1.1.0",
     "nodemailer": "^8.0.7",
     "prismjs": "^1.30.0",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/src/app/api/portal/asset/[service]/[kind]/route.ts
+++ b/src/app/api/portal/asset/[service]/[kind]/route.ts
@@ -6,7 +6,7 @@ import type { SetupAssetKind } from '@/lib/portal/userGuide';
 
 export const dynamic = 'force-dynamic';
 
-const KIND_VALUES: SetupAssetKind[] = ['ios_calendar_profile', 'audiobookshelf_deeplink'];
+const KIND_VALUES: SetupAssetKind[] = ['ios_calendar_profile', 'audiobookshelf_deeplink', 'syncthing_qr'];
 
 /**
  * Public asset endpoint for the family portal (#242 follow-up).
@@ -65,6 +65,12 @@ export async function GET(
         'Content-Disposition': `attachment; filename="${service}.mobileconfig"`,
       },
     });
+  }
+  if (asset.kind === 'syncthing_qr') {
+    // Return the device ID; the client renders the QR code itself.
+    // Keeping QR generation client-side avoids shipping a server-
+    // side QR library + lets the modal scale the QR responsively.
+    return NextResponse.json({ deviceId: asset.data });
   }
   // audiobookshelf_deeplink — return JSON so the client controls
   // navigation (location.href = url, with a fallback message).

--- a/src/app/portal/PortalGrid.tsx
+++ b/src/app/portal/PortalGrid.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ChevronDown, ChevronUp, Download, ExternalLink, Smartphone } from 'lucide-react';
+import { ChevronDown, ChevronUp, Download, ExternalLink, Loader2, QrCode, Smartphone } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 import type { PortalCard } from '@/lib/portal/services';
 import type { AppPlatform, SetupAssetKind } from '@/lib/portal/userGuide';
 
@@ -17,6 +18,7 @@ const PLATFORM_LABELS: Record<AppPlatform, string> = {
 const ASSET_LABELS: Record<SetupAssetKind, { label: string; icon: typeof Download }> = {
   ios_calendar_profile: { label: 'Add to iPhone (Calendar + Contacts)', icon: Download },
   audiobookshelf_deeplink: { label: 'Open in Audiobookshelf app', icon: Smartphone },
+  syncthing_qr: { label: 'Pair Syncthing device', icon: QrCode },
 };
 
 /**
@@ -78,6 +80,11 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                     if (asset.kind === 'audiobookshelf_deeplink') {
                       return (
                         <DeepLinkButton key={asset.kind} card={card} kind={asset.kind} label={label} description={asset.description} Icon={Icon} />
+                      );
+                    }
+                    if (asset.kind === 'syncthing_qr') {
+                      return (
+                        <SyncthingQrButton key={asset.kind} card={card} label={label} description={asset.description} Icon={Icon} />
                       );
                     }
                     return null;
@@ -203,5 +210,105 @@ function DeepLinkButton({
         <p className="text-[11px] text-red-600 dark:text-red-400 mt-1 leading-snug text-center">{error}</p>
       )}
     </div>
+  );
+}
+
+/**
+ * Syncthing QR pairing button. Fetches the server's device ID
+ * lazily on click (it's a podman-exec round-trip, so we don't
+ * pre-fetch it on every card render) and opens a modal with the QR
+ * code rendered client-side. The Android Syncthing app's "Add
+ * Device → Scan QR" reads it directly.
+ */
+function SyncthingQrButton({
+  card,
+  label,
+  description,
+  Icon,
+}: {
+  card: PortalCard;
+  label: string;
+  description?: string;
+  Icon: typeof QrCode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onOpen = async () => {
+    setOpen(true);
+    if (deviceId || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/portal/asset/${card.name}/syncthing_qr`);
+      if (!res.ok) {
+        setError(`Couldn't read the device id (HTTP ${res.status}). The Syncthing container might not be running yet — try again in a minute.`);
+        return;
+      }
+      const data = await res.json() as { deviceId?: string };
+      if (typeof data.deviceId !== 'string') {
+        setError('No device id returned.');
+        return;
+      }
+      setDeviceId(data.deviceId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div>
+        <button
+          onClick={onOpen}
+          className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+        >
+          <Icon size={14} /> {label}
+        </button>
+        {description && (
+          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 leading-snug text-center">{description}</p>
+        )}
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={() => setOpen(false)}>
+          <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-sm w-full p-6 text-center" onClick={e => e.stopPropagation()}>
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white">Pair this device</h2>
+            <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              In the Syncthing Android app, tap <strong>+</strong> → <strong>Add Device</strong> → <strong>Scan QR</strong>, then point your camera here.
+            </p>
+
+            <div className="mt-5 flex justify-center min-h-[12rem] items-center">
+              {loading && <Loader2 className="animate-spin text-violet-500" size={32} />}
+              {!loading && error && (
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+              )}
+              {!loading && deviceId && (
+                <div className="bg-white p-4 rounded-lg">
+                  <QRCodeSVG value={deviceId} size={192} level="M" />
+                </div>
+              )}
+            </div>
+
+            {deviceId && (
+              <p className="mt-3 text-[10px] font-mono text-gray-500 dark:text-gray-400 break-all">
+                {deviceId}
+              </p>
+            )}
+
+            <button
+              onClick={() => setOpen(false)}
+              className="mt-4 px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/lib/portal/assets.test.ts
+++ b/src/lib/portal/assets.test.ts
@@ -4,12 +4,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/lib/config', () => ({
   getConfig: vi.fn(),
 }));
+const mockAgent = { sendCommand: vi.fn() };
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
 
 import { getConfig } from '@/lib/config';
-import { generateIosCalendarProfile, generateAudiobookshelfDeepLink, resolveSetupAsset } from './assets';
+import { generateIosCalendarProfile, generateAudiobookshelfDeepLink, fetchSyncthingDeviceId, resolveSetupAsset } from './assets';
 
 beforeEach(() => {
   (getConfig as any).mockReset();
+  mockAgent.sendCommand.mockReset();
 });
 
 describe('generateIosCalendarProfile', () => {
@@ -69,6 +74,34 @@ describe('generateAudiobookshelfDeepLink', () => {
   });
 });
 
+describe('fetchSyncthingDeviceId', () => {
+  const VALID = 'ABCDEFG-HIJKLMN-OPQRSTU-VWXYZ23-4567ABC-DEFGHIJ-KLMNOPQ';
+
+  it('returns the device id when podman exec succeeds', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: `${VALID}\n` });
+    const id = await fetchSyncthingDeviceId('Local');
+    expect(id).toBe(VALID);
+  });
+
+  it('returns null when the container is not running (non-zero exit)', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'no such container' });
+    const id = await fetchSyncthingDeviceId('Local');
+    expect(id).toBeNull();
+  });
+
+  it('rejects malformed device-id output (defends against noisy stdout)', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: 'WARNING: foo\n' });
+    const id = await fetchSyncthingDeviceId('Local');
+    expect(id).toBeNull();
+  });
+
+  it('returns null when the agent throws', async () => {
+    mockAgent.sendCommand.mockRejectedValueOnce(new Error('agent down'));
+    const id = await fetchSyncthingDeviceId('Local');
+    expect(id).toBeNull();
+  });
+});
+
 describe('resolveSetupAsset', () => {
   it('routes ios_calendar_profile to the XML generator', async () => {
     (getConfig as any).mockResolvedValue({ reverseProxy: { lanDomain: 'home.arpa' } });
@@ -82,5 +115,13 @@ describe('resolveSetupAsset', () => {
     const out = await resolveSetupAsset('audiobookshelf_deeplink', 'media');
     expect(out?.kind).toBe('audiobookshelf_deeplink');
     expect(out?.data).toMatch(/^abs:\/\//);
+  });
+
+  it('routes syncthing_qr to the device-id fetcher', async () => {
+    const VALID = 'ABCDEFG-HIJKLMN-OPQRSTU-VWXYZ23-4567ABC-DEFGHIJ-KLMNOPQ';
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: VALID });
+    const out = await resolveSetupAsset('syncthing_qr', 'file-share');
+    expect(out?.kind).toBe('syncthing_qr');
+    expect(out?.data).toBe(VALID);
   });
 });

--- a/src/lib/portal/assets.ts
+++ b/src/lib/portal/assets.ts
@@ -11,6 +11,8 @@
 import crypto from 'crypto';
 import { getActiveDomain, getMode } from '@/lib/mode';
 import { getConfig, type AppConfig } from '@/lib/config';
+import { agentManager } from '@/lib/agent/manager';
+import { logger } from '@/lib/logger';
 import path from 'path';
 import fs from 'fs/promises';
 import type { SetupAssetKind } from './userGuide';
@@ -176,6 +178,46 @@ export async function generateAudiobookshelfDeepLink(serviceName: string): Promi
   return `abs://${parsed.host}?ssl=${ssl}`;
 }
 
+/**
+ * Read the running Syncthing container's device ID. Uses
+ * `podman exec syncthing cat /var/syncthing/config/config.xml`
+ * (the file-share template mounts the syncthing-config PVC there)
+ * and pulls the `<device id="...">` line that matches the special
+ * "ourselves" entry. Falls back to running `syncthing --device-id`
+ * inside the container if the config file isn't readable yet
+ * (rare cold-start window).
+ *
+ * Returns `null` when the container isn't running, the agent
+ * doesn't respond, or the parse fails — the caller treats that as
+ * "asset not available, hide the button".
+ */
+export async function fetchSyncthingDeviceId(node: string = 'Local'): Promise<string | null> {
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    // The Syncthing CLI prints the device ID directly. We use it
+    // because the config.xml's "ourselves" device ID requires
+    // parsing the XML's myID attribute or matching against the
+    // container's hostname; the CLI is one less moving part.
+    const res = await agent.sendCommand('exec', {
+      command: 'podman exec syncthing syncthing --device-id 2>/dev/null',
+    }, { timeoutMs: 6_000 }) as { code?: number; stdout?: string };
+    if (res.code !== 0) return null;
+    const id = (res.stdout ?? '').trim();
+    // Syncthing device IDs are 56 chars in 7 groups of 7 separated
+    // by hyphens (e.g. ABCDEFG-HIJKLMN-...). Lightly validate so
+    // a noisy stdout (warning lines, etc.) doesn't smuggle junk
+    // into the QR.
+    if (!/^[A-Z2-7]{7}(-[A-Z2-7]{7}){6}$/.test(id)) {
+      logger.warn('portal:assets', `Unexpected syncthing device-id shape: ${id.slice(0, 40)}`);
+      return null;
+    }
+    return id;
+  } catch (e) {
+    logger.warn('portal:assets', `Could not fetch syncthing device id: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
 /** Resolve any setup-asset kind into its concrete artifact. */
 export async function resolveSetupAsset(kind: SetupAssetKind, serviceName: string): Promise<{ kind: SetupAssetKind; data: string } | null> {
   switch (kind) {
@@ -186,6 +228,10 @@ export async function resolveSetupAsset(kind: SetupAssetKind, serviceName: strin
     case 'audiobookshelf_deeplink': {
       const url = await generateAudiobookshelfDeepLink(serviceName);
       return url ? { kind, data: url } : null;
+    }
+    case 'syncthing_qr': {
+      const deviceId = await fetchSyncthingDeviceId('Local');
+      return deviceId ? { kind, data: deviceId } : null;
     }
   }
 }

--- a/src/lib/portal/userGuide.ts
+++ b/src/lib/portal/userGuide.ts
@@ -56,18 +56,20 @@ export interface RecommendedApp {
  *  Whitelist of recognized kinds:
  *    - `ios_calendar_profile` — Apple-standard .mobileconfig that
  *      adds CalDAV + CardDAV accounts to iOS Settings in two taps.
- *    - `audiobookshelf_deeplink` — \`abs://\` URL the official
+ *    - `audiobookshelf_deeplink` — `abs://` URL the official
  *      Audiobookshelf app picks up to pre-configure the server.
- *
- *  Future kinds (deferred):
- *    - `syncthing_qr` — needs Syncthing REST API to read the
- *      server's device ID at request time.
+ *    - `syncthing_qr` — encodes the file-share container's
+ *      device ID into a QR; the Android Syncthing app's "Add
+ *      Device" → "Scan QR" reads it directly. The server fetches
+ *      the device ID at request time via `podman exec` against the
+ *      running syncthing container.
  */
-export type SetupAssetKind = 'ios_calendar_profile' | 'audiobookshelf_deeplink';
+export type SetupAssetKind = 'ios_calendar_profile' | 'audiobookshelf_deeplink' | 'syncthing_qr';
 
 const KNOWN_ASSET_KINDS: ReadonlySet<SetupAssetKind> = new Set([
   'ios_calendar_profile',
   'audiobookshelf_deeplink',
+  'syncthing_qr',
 ]);
 
 export interface SetupAsset {

--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -1,6 +1,10 @@
 ---
 icon: "📁"
 tagline: "Share documents across phones, laptops, and the family — like a private Dropbox."
+setup_assets:
+  - kind: "syncthing_qr"
+    label: "📷 Pair this Syncthing device"
+    description: "Shows a QR code with the home server's device ID. The Android Syncthing app's \"Add Device → Scan QR\" picks it up directly."
 recommended_apps:
   - name: "Syncthing"
     url: "https://syncthing.net/downloads/"


### PR DESCRIPTION
## Summary
Family member opens the family portal on their Android phone, taps the new **📷 Pair this Syncthing device** button on the Files card — a modal opens with a QR code encoding the home server's Syncthing device ID. They open Syncthing → **+ → Add Device → Scan QR** → done.

Replaces the manual "find the device ID in the Web UI, type it in" dance that was the friction point on every Android Syncthing setup.

## Plumbing
- New \`syncthing_qr\` asset kind in the schema whitelist.
- \`fetchSyncthingDeviceId(node)\` runs \`podman exec syncthing syncthing --device-id\` against the running container; validates the output shape (Syncthing's canonical 56-char hyphen-grouped format) so noisy stdout can't smuggle junk into the QR.
- \`/api/portal/asset/[service]/syncthing_qr\` returns \`{ deviceId: "ABC-..." }\` JSON; the client renders the QR with \`qrcode.react\` (new dep, ~5KB).
- Card UI: lazy fetch — device-id call only fires when the modal opens, not on every card render. Modal also shows the raw ID below the QR so admins on a desktop browser without a phone scanner can still copy/paste.

## Test plan
- [x] 477 tests pass (was 472, +5 new)
- [x] \`next build\` clean
- [ ] Manual: visit portal on Android device, tap **📷 Pair this Syncthing device**, scan QR with Syncthing app → device added.
- [ ] Manual: visit portal in desktop browser, open modal, copy device ID from below the QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)