### PR TITLE
feat(portal): PWA install — Add to Home Screen on mobile

### DIFF
--- a/src/app/portal/icon.svg
+++ b/src/app/portal/icon.svg
@@ -1,0 +1,10 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <!-- Portal icon for the family-facing /portal route. House-shape on a
+       violet background mirrors the 🏠 emoji that opens the portal page
+       header. Used as the manifest icon for PWA install ("Add to Home
+       Screen") so the family-portal app icon is distinct from the
+       admin dashboard's. -->
+  <rect width="512" height="512" rx="96" fill="#7c3aed"/>
+  <path d="M256 96 L96 224 V416 H192 V288 H320 V416 H416 V224 Z"
+        fill="#fff" stroke="#fff" stroke-width="16" stroke-linejoin="round"/>
+</svg>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,12 +1,34 @@
+import type { Metadata, Viewport } from 'next';
+
 /**
  * /portal — minimal layout, no admin chrome (#242). Inherits the
  * root layout's providers but skips the (dashboard) sidebar/header.
  *
- * Auth: anonymous on the LAN (per the v1 design conversation). The
- * route handler in `page.tsx` short-circuits to 404 when the install
- * is in public-domain mode — until #265 ships the migration there's
- * no way to expose this safely outside the LAN.
+ * Adds PWA manifest + iOS Safari meta tags so family members can
+ * "Add to Home Screen" and the portal launches in its own standalone
+ * window with the violet house icon. The manifest endpoint at
+ * `/portal/manifest.webmanifest` returns a per-install JSON with the
+ * active domain in the app name.
  */
+export const metadata: Metadata = {
+  manifest: '/portal/manifest.webmanifest',
+  appleWebApp: {
+    capable: true,
+    title: 'Home',
+    statusBarStyle: 'default',
+  },
+  icons: {
+    icon: [{ url: '/portal/icon.svg', type: 'image/svg+xml' }],
+    apple: [{ url: '/portal/icon.svg' }],
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: '#7c3aed',
+  width: 'device-width',
+  initialScale: 1,
+};
+
 export default function PortalLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-gradient-to-b from-violet-50 to-white dark:from-gray-900 dark:to-gray-950">

--- a/src/app/portal/manifest.webmanifest/route.ts
+++ b/src/app/portal/manifest.webmanifest/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { getConfig } from '@/lib/config';
+import { getActiveDomain } from '@/lib/mode';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Web App Manifest for the family portal (#242 follow-up).
+ *
+ * Served at `/portal/manifest.webmanifest`. Mobile browsers + desktop
+ * Chrome use this for the "Install app" / "Add to Home Screen"
+ * affordance — once installed, the portal launches in its own
+ * standalone window with the violet house icon, separate from any
+ * browser chrome.
+ *
+ * The `name` field uses the active domain so the home-screen label
+ * reads "<your-domain> Portal" instead of generic "ServiceBay".
+ * Personal touch; one less reminder this is generic infrastructure.
+ */
+export async function GET() {
+  const config = await getConfig();
+  const domain = getActiveDomain(config);
+  const manifest = {
+    name: domain ? `${domain} — Family Portal` : 'Family Portal',
+    short_name: 'Home',
+    description: 'Pick a service to use — your family\'s private cloud.',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    background_color: '#fafafa',
+    theme_color: '#7c3aed',
+    icons: [
+      {
+        src: '/portal/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'any',
+      },
+    ],
+  };
+  return NextResponse.json(manifest, {
+    headers: {
+      'Content-Type': 'application/manifest+json',
+      'Cache-Control': 'public, max-age=300',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Family members can install the portal as a home-screen app. Tap "Add to Home Screen" on iOS Safari or get the install prompt automatically on Chrome (Android / desktop) — the portal launches in its own standalone window with a violet house icon, distinct from the admin dashboard.

### Pieces
- \`/portal/manifest.webmanifest\` route returning a per-install JSON. App name uses the active domain ("home.arpa — Family Portal") so the home-screen label feels personal. \`start_url: "/"\` so the installed app launches at the apex (which the middleware rewrites to /portal).
- New violet 🏠 SVG at \`/portal/icon.svg\` — single asset serves the PWA manifest icon, iOS apple-touch-icon, and the portal favicon.
- Portal layout sets \`metadata.manifest\`, \`appleWebApp.title\`, and \`theme_color\` via Next.js's typed metadata API.

### Out of scope
No service worker — the portal isn't useful offline (it lists network-bound services). PWA install works fine without one. We can add offline fallback for just the card grid in a follow-up if useful.

## Test plan
- [x] 477 tests pass; \`next build\` clean
- [ ] Manual on iPhone Safari: visit home.arpa → tap Share → "Add to Home Screen" → confirm icon appears + launches in standalone mode
- [ ] Manual on Android Chrome: visit home.arpa → install prompt should appear in browser menu within ~30 s of viewing

🤖 Generated with [Claude Code](https://claude.com/claude-code)