### PR TITLE
fix(portal): use install-time subdomain not template default

### DIFF
--- a/src/lib/portal/assets.test.ts
+++ b/src/lib/portal/assets.test.ts
@@ -18,6 +18,44 @@ beforeEach(() => {
 });
 
 describe('generateIosCalendarProfile', () => {
+  it('uses the operator-customized subdomain from reverseProxy.hosts when present', async () => {
+    // Operator chose `agenda` instead of the template default `caldav` —
+    // proxy-host entry reflects what got deployed; profile must follow.
+    (getConfig as any).mockResolvedValue({
+      reverseProxy: {
+        lanDomain: 'home.arpa',
+        hosts: [{
+          domain: 'agenda.home.arpa',
+          service: 'radicale',
+          forwardPort: 5232,
+          created: true,
+        }],
+      },
+    });
+    const xml = await generateIosCalendarProfile('radicale');
+    expect(xml).not.toBeNull();
+    expect(xml!).toMatch(/<key>CalDAVHostName<\/key>\s*<string>agenda\.home\.arpa<\/string>/);
+    expect(xml!).not.toMatch(/caldav\.home\.arpa/);
+  });
+
+  it('skips uncreated proxy-host entries and falls back to template default', async () => {
+    // entry exists but failed to create → fallback to default subdomain.
+    (getConfig as any).mockResolvedValue({
+      reverseProxy: {
+        lanDomain: 'home.arpa',
+        hosts: [{
+          domain: 'broken.home.arpa',
+          service: 'radicale',
+          forwardPort: 5232,
+          created: false,
+        }],
+      },
+    });
+    const xml = await generateIosCalendarProfile('radicale');
+    expect(xml).not.toBeNull();
+    expect(xml!).toMatch(/caldav\.home\.arpa/);
+  });
+
   it('produces a well-formed mobileconfig with CalDAV + CardDAV payloads', async () => {
     (getConfig as any).mockResolvedValue({
       reverseProxy: { lanDomain: 'home.arpa' },

--- a/src/lib/portal/assets.ts
+++ b/src/lib/portal/assets.ts
@@ -9,46 +9,16 @@
  */
 
 import crypto from 'crypto';
-import { getActiveDomain, getMode } from '@/lib/mode';
-import { getConfig, type AppConfig } from '@/lib/config';
+import { getConfig } from '@/lib/config';
 import { agentManager } from '@/lib/agent/manager';
 import { logger } from '@/lib/logger';
-import path from 'path';
-import fs from 'fs/promises';
+import { resolveServiceUrl } from './services';
 import type { SetupAssetKind } from './userGuide';
 
-const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
-
-/**
- * Read a service's `*_SUBDOMAIN` variable default from its
- * variables.json. Mirrors `pickSubdomainDefault` in services.ts;
- * lifted here to avoid a cross-module dep cycle.
- */
-async function readSubdomainDefault(serviceName: string): Promise<string | null> {
-  try {
-    const raw = await fs.readFile(path.join(TEMPLATES_PATH, serviceName, 'variables.json'), 'utf-8');
-    const vars = JSON.parse(raw) as Record<string, { type?: string; default?: string }>;
-    for (const [name, meta] of Object.entries(vars)) {
-      if (meta.type === 'subdomain' && name.endsWith('_SUBDOMAIN') && typeof meta.default === 'string') {
-        return meta.default;
-      }
-    }
-  } catch { /* fall through */ }
-  return null;
-}
-
-/**
- * Derive the externally-reachable URL for a given service in the
- * current install mode. Copies the lookup buildPortalCards uses so
- * assets see the same URL as the "Open" button.
- */
-async function urlForService(config: AppConfig, serviceName: string): Promise<string | null> {
-  const sub = await readSubdomainDefault(serviceName);
-  if (!sub) return null;
-  const domain = getActiveDomain(config);
-  const scheme = getMode(config) === 'public' ? 'https' : 'http';
-  return `${scheme}://${sub}.${domain}`;
-}
+// Asset URLs go through the shared `resolveServiceUrl` helper so the
+// iOS profile hostname + abs:// link always match what the portal's
+// "Open" button renders. Avoids drift between the card URL and the
+// asset URL when the operator customized a subdomain.
 
 /**
  * iOS Configuration Profile (.mobileconfig) that adds CalDAV +
@@ -64,7 +34,7 @@ async function urlForService(config: AppConfig, serviceName: string): Promise<st
  */
 export async function generateIosCalendarProfile(serviceName: string): Promise<string | null> {
   const config = await getConfig();
-  const url = await urlForService(config, serviceName);
+  const url = await resolveServiceUrl(config, serviceName);
   if (!url) return null;
   const parsed = new URL(url);
   const hostname = parsed.hostname;
@@ -171,7 +141,7 @@ export async function generateIosCalendarProfile(serviceName: string): Promise<s
  */
 export async function generateAudiobookshelfDeepLink(serviceName: string): Promise<string | null> {
   const config = await getConfig();
-  const url = await urlForService(config, serviceName);
+  const url = await resolveServiceUrl(config, serviceName);
   if (!url) return null;
   const parsed = new URL(url);
   const ssl = parsed.protocol === 'https:' ? 'true' : 'false';

--- a/src/lib/portal/services.ts
+++ b/src/lib/portal/services.ts
@@ -20,7 +20,7 @@
 
 import path from 'path';
 import fs from 'fs/promises';
-import { getConfig } from '@/lib/config';
+import { getConfig, type AppConfig } from '@/lib/config';
 import { getActiveDomain, getMode } from '@/lib/mode';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { parseTemplateTier } from '@/lib/templateTier';
@@ -82,6 +82,45 @@ function pickSubdomainDefault(variables: Record<string, { type?: string; default
 }
 
 /**
+ * Resolve the externally-reachable URL for a service. Used by both
+ * the portal card builder (Open button) and the asset generators
+ * (iOS profile hostname, abs:// deep link).
+ *
+ * Lookup order:
+ *   1. `config.reverseProxy.hosts[]` — install-time proxy host
+ *      entries reflect *exactly* what got deployed (operator's
+ *      customized subdomain, the right TLD for the install mode).
+ *      Match by service name.
+ *   2. Template default subdomain + active domain — fallback for
+ *      LAN-mode installs that don't create NPM proxy hosts, and
+ *      for cards whose proxy entry is missing for any reason.
+ *
+ * Returns null when no template subdomain variable exists either —
+ * matches the "skip this card" path in the caller.
+ */
+export async function resolveServiceUrl(
+  config: AppConfig,
+  serviceName: string,
+): Promise<string | null> {
+  const scheme = getMode(config) === 'public' ? 'https' : 'http';
+
+  // Prefer the persisted proxy-host entry — it has the operator's
+  // chosen subdomain baked in.
+  const hostEntry = (config.reverseProxy?.hosts ?? []).find(
+    h => h.service === serviceName && h.created,
+  );
+  if (hostEntry) {
+    return `${scheme}://${hostEntry.domain}`;
+  }
+
+  // Fallback: template default subdomain + active domain.
+  const variables = await readVariables(serviceName);
+  const sub = pickSubdomainDefault(variables);
+  if (!sub) return null;
+  return `${scheme}://${sub}.${getActiveDomain(config)}`;
+}
+
+/**
  * Build the portal-card list. Async because it walks per-template
  * files; cheap enough to run on every /portal request (which is
  * already gated by mode).
@@ -95,9 +134,6 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
   if (running.length === 0) return [];
 
   const config = await getConfig();
-  const activeDomain = getActiveDomain(config);
-  const mode = getMode(config);
-  const scheme = mode === 'public' ? 'https' : 'http';
 
   const cards: PortalCard[] = [];
   for (const svc of running) {
@@ -110,22 +146,19 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
     const parsed = parseUserGuide(rawGuide, svc.name);
     if (!parsed) continue; // No guide → not on the portal in v1
 
-    const variables = await readVariables(svc.name);
-    const sub = pickSubdomainDefault(variables);
-    if (!sub) {
-      logger.warn('portal', `Template ${svc.name} has user-guide.md but no subdomain variable — skipping`);
+    const url = await resolveServiceUrl(config, svc.name);
+    if (!url) {
+      logger.warn('portal', `Template ${svc.name} has user-guide.md but no subdomain variable and no proxy-host entry — skipping`);
       continue;
     }
 
-    const label = parsed.frontmatter.tagline
-      ? (parseTemplateLabel(yaml) ?? svc.name)
-      : (parseTemplateLabel(yaml) ?? svc.name);
+    const label = parseTemplateLabel(yaml) ?? svc.name;
     cards.push({
       name: svc.name,
       label,
       icon: parsed.frontmatter.icon ?? '',
       tagline: parsed.frontmatter.tagline ?? '',
-      url: `${scheme}://${sub}.${activeDomain}`,
+      url,
       body: parsed.body,
       recommendedApps: parsed.frontmatter.recommended_apps ?? [],
       setupAssets: parsed.frontmatter.setup_assets ?? [],


### PR DESCRIPTION
## What was wrong
Portal cards (and the iOS profile / abs:// deep link / Syncthing QR that hang off them) used the template's default \`*_SUBDOMAIN\` variable. If the operator customized a subdomain at install time (e.g. \`agenda\` instead of Radicale's \`caldav\` default), the **Open** button still pointed at the default → broken link.

## Fix
New shared \`resolveServiceUrl(config, serviceName)\` helper that looks up \`config.reverseProxy.hosts[]\` first (entries are written at install with whatever subdomain got deployed) and falls back to the template default + active domain when no proxy-host entry exists. Both the portal card builder and the asset generators route through it, so the iOS profile hostname + abs:// link always match the Open button URL.

Skips entries with \`created: false\` (failed creations, surfaced by the \`proxy_route_missing\` probe); falls back to the template default so the portal URL remains intact even when NPM is misconfigured.

## Test plan
- [x] 479 tests pass (was 477, +2 new)
- [x] \`next build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)