### PR TITLE
feat(portal): switch from emoji icons to Lucide line-art

### DIFF
--- a/src/app/portal/PortalGrid.tsx
+++ b/src/app/portal/PortalGrid.tsx
@@ -3,10 +3,50 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ChevronDown, ChevronUp, Download, ExternalLink, Loader2, QrCode, Smartphone } from 'lucide-react';
+import {
+  BookOpen, Calendar, CalendarDays, Camera, ChevronDown, ChevronUp,
+  Download, ExternalLink, Files, Film, Folder, FolderOpen, Globe,
+  Headphones, House, Image as ImageIcon, Images, KeyRound, Lightbulb,
+  Lightbulb as LightbulbIcon, Loader2, Lock, Mail, MessageSquare,
+  Music, Package, QrCode, Router, Shield, Smartphone, Video,
+  Sparkles,
+} from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import type { PortalCard } from '@/lib/portal/services';
-import type { AppPlatform, SetupAssetKind } from '@/lib/portal/userGuide';
+import type { AppPlatform, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
+
+type IconComponent = typeof Camera;
+
+/** Maps the kebab-case Lucide names allowlisted in user-guide
+ *  frontmatter to their imported components. Keep in sync with
+ *  PORTAL_ICONS in userGuide.ts. */
+const PORTAL_ICON_MAP: Record<PortalIconName, IconComponent> = {
+  'camera': Camera,
+  'image': ImageIcon,
+  'images': Images,
+  'folder': Folder,
+  'folder-open': FolderOpen,
+  'files': Files,
+  'calendar': Calendar,
+  'calendar-days': CalendarDays,
+  'music': Music,
+  'headphones': Headphones,
+  'book-open': BookOpen,
+  'lock': Lock,
+  'shield': Shield,
+  'key-round': KeyRound,
+  'house': House,
+  'lightbulb': Lightbulb,
+  'globe': Globe,
+  'router': Router,
+  'mail': Mail,
+  'message-square': MessageSquare,
+  'video': Video,
+  'film': Film,
+  'package': Package,
+};
+
+void LightbulbIcon; // alias kept for parser-friendliness, not used directly
 
 const PLATFORM_LABELS: Record<AppPlatform, string> = {
   ios: 'iOS',
@@ -15,7 +55,7 @@ const PLATFORM_LABELS: Record<AppPlatform, string> = {
   browser: 'Browser',
 };
 
-const ASSET_LABELS: Record<SetupAssetKind, { label: string; icon: typeof Download }> = {
+const ASSET_LABELS: Record<SetupAssetKind, { label: string; icon: IconComponent }> = {
   ios_calendar_profile: { label: 'Add to iPhone (Calendar + Contacts)', icon: Download },
   audiobookshelf_deeplink: { label: 'Open in Audiobookshelf app', icon: Smartphone },
   syncthing_qr: { label: 'Pair Syncthing device', icon: QrCode },
@@ -39,7 +79,7 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
             className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden flex flex-col"
           >
             <div className="p-6 flex-1">
-              <div className="text-5xl mb-3" aria-hidden>{card.icon || '📦'}</div>
+              <CardIcon card={card} />
               <h2 className="text-xl font-bold text-gray-900 dark:text-white">{card.label}</h2>
               {card.tagline && (
                 <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">{card.tagline}</p>
@@ -95,7 +135,7 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
               {card.recommendedApps.length > 0 && (
                 <div className="pt-2 space-y-1.5">
                   <div className="text-[11px] uppercase tracking-wide font-medium text-gray-500 dark:text-gray-400">
-                    💡 Recommended apps
+                    <Sparkles size={11} className="inline align-middle -mt-0.5" /> Recommended apps
                   </div>
                   <ul className="space-y-1.5">
                     {card.recommendedApps.map(app => (
@@ -310,5 +350,34 @@ function SyncthingQrButton({
         </div>
       )}
     </>
+  );
+}
+
+/**
+ * Card hero icon. Renders the Lucide line-art icon when the
+ * frontmatter declares `lucide_icon`; falls back to the legacy
+ * emoji for any user-guide that hasn't migrated; finally falls
+ * back to a neutral Package icon for guides with neither.
+ *
+ * The line-art rendering matches ServiceBay's dashboard chrome
+ * (Sidebar, header logos) so the family portal feels like the
+ * same product, not a separate emoji-themed surface.
+ */
+function CardIcon({ card }: { card: PortalCard }) {
+  if (card.lucideIcon) {
+    const Icon = PORTAL_ICON_MAP[card.lucideIcon];
+    return (
+      <div className="mb-3 inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400">
+        <Icon size={28} strokeWidth={1.75} />
+      </div>
+    );
+  }
+  if (card.icon) {
+    return <div className="text-5xl mb-3" aria-hidden>{card.icon}</div>;
+  }
+  return (
+    <div className="mb-3 inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+      <Package size={28} strokeWidth={1.75} />
+    </div>
   );
 }

--- a/src/app/portal/icon.svg
+++ b/src/app/portal/icon.svg
@@ -1,10 +1,19 @@
 <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <!-- Portal icon for the family-facing /portal route. House-shape on a
-       violet background mirrors the 🏠 emoji that opens the portal page
-       header. Used as the manifest icon for PWA install ("Add to Home
-       Screen") so the family-portal app icon is distinct from the
-       admin dashboard's. -->
+  <!-- PWA app icon for the family-portal route. Uses the ServiceBay
+       logo's line-art style (currentColor stroke, 2px equivalent at
+       this scale) on a violet brand background. Differs from the
+       admin dashboard's icon only by the violet fill — same shape
+       cues so it's recognizable as a ServiceBay product on the
+       home screen. -->
   <rect width="512" height="512" rx="96" fill="#7c3aed"/>
-  <path d="M256 96 L96 224 V416 H192 V288 H320 V416 H416 V224 Z"
-        fill="#fff" stroke="#fff" stroke-width="16" stroke-linejoin="round"/>
+  <g transform="translate(96 96) scale(13.33)" fill="none" stroke="#fff"
+     stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Server unit -->
+    <rect x="4" y="2" width="16" height="10" rx="2" ry="2" />
+    <line x1="8" y1="7" x2="8.01" y2="7" />
+    <line x1="12" y1="7" x2="12.01" y2="7" />
+    <!-- Bay waves -->
+    <path d="M2 17c5.5 0 5.5-3 11-3s5.5 3 11 3" />
+    <path d="M2 21c5.5 0 5.5-3 11-3s5.5 3 11 3" />
+  </g>
 </svg>

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,3 +1,4 @@
+import ServiceBayLogo from '@/components/ServiceBayLogo';
 import { buildPortalCards } from '@/lib/portal/services';
 import PortalGrid from './PortalGrid';
 import RequestAccessButton from './RequestAccessButton';
@@ -19,9 +20,12 @@ export default async function PortalPage() {
   return (
     <main className="max-w-6xl mx-auto px-6 py-12">
       <header className="mb-10 text-center">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
-          🏠 Home — your family&apos;s private cloud
-        </h1>
+        <div className="flex items-center justify-center gap-3">
+          <ServiceBayLogo size={36} className="text-violet-600 dark:text-violet-400 shrink-0" />
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
+            Home <span className="text-gray-400 dark:text-gray-600 font-normal">— your family&apos;s private cloud</span>
+          </h1>
+        </div>
         <p className="mt-3 text-base text-gray-600 dark:text-gray-400">
           Pick a service below to get started.
         </p>

--- a/src/lib/portal/services.ts
+++ b/src/lib/portal/services.ts
@@ -27,7 +27,7 @@ import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getTemplateUserGuide } from '@/lib/registry';
 import { logger } from '@/lib/logger';
-import { parseUserGuide, type RecommendedApp, type SetupAsset } from './userGuide';
+import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAsset } from './userGuide';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
@@ -36,7 +36,12 @@ export interface PortalCard {
   name: string;
   /** User-facing label (from frontmatter title fallback or `servicebay.label`). */
   label: string;
-  /** Frontmatter icon emoji, or empty string. */
+  /** Lucide icon name from `lucide_icon` frontmatter (line-art,
+   *  matches dashboard chrome). Null when only the legacy emoji is
+   *  set or no icon at all. */
+  lucideIcon: PortalIconName | null;
+  /** Legacy emoji icon (`icon` frontmatter). Empty string when only
+   *  lucideIcon is set or no icon at all. */
   icon: string;
   /** Frontmatter tagline, or empty string. */
   tagline: string;
@@ -156,6 +161,7 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
     cards.push({
       name: svc.name,
       label,
+      lucideIcon: parsed.frontmatter.lucide_icon ?? null,
       icon: parsed.frontmatter.icon ?? '',
       tagline: parsed.frontmatter.tagline ?? '',
       url,

--- a/src/lib/portal/userGuide.test.ts
+++ b/src/lib/portal/userGuide.test.ts
@@ -144,6 +144,25 @@ setup_assets:
     expect(result!.frontmatter.setup_assets).toHaveLength(1);
   });
 
+  it('parses lucide_icon when in the allowlist', () => {
+    const raw = `---
+lucide_icon: "camera"
+tagline: "..."
+---
+`;
+    const result = parseUserGuide(raw, 'immich');
+    expect(result!.frontmatter.lucide_icon).toBe('camera');
+  });
+
+  it('drops lucide_icon values not in the allowlist', () => {
+    const raw = `---
+lucide_icon: "<script>"
+---
+`;
+    const result = parseUserGuide(raw, 'evil');
+    expect(result!.frontmatter.lucide_icon).toBeUndefined();
+  });
+
   it('returns null on YAML parse error', () => {
     const raw = `---
 icon: "📷

--- a/src/lib/portal/userGuide.ts
+++ b/src/lib/portal/userGuide.ts
@@ -82,7 +82,38 @@ export interface SetupAsset {
   description?: string;
 }
 
+/**
+ * Curated allowlist of Lucide icon names usable on portal cards.
+ * Lucide is the same line-art icon set the dashboard sidebar uses,
+ * so picking from this set keeps the portal visually consistent
+ * with ServiceBay's existing chrome (no emoji, no per-template SVG
+ * imports). The whitelist also acts as a safety boundary —
+ * frontmatter is template-author input but only these names render;
+ * unknown values silently drop to fallback.
+ */
+const PORTAL_ICONS = [
+  'camera', 'image', 'images',          // photos / gallery
+  'folder', 'folder-open', 'files',     // files / sharing
+  'calendar', 'calendar-days',          // calendar / contacts
+  'music', 'headphones', 'book-open',   // music / audiobooks
+  'lock', 'shield', 'key-round',        // passwords / vault
+  'house', 'lightbulb',                 // smart home
+  'globe', 'router',                    // network
+  'mail', 'message-square',             // mail / chat
+  'video', 'film',                      // video / streaming
+  'package',                            // generic fallback
+] as const;
+export type PortalIconName = typeof PORTAL_ICONS[number];
+
+const PORTAL_ICON_SET: ReadonlySet<string> = new Set(PORTAL_ICONS);
+
 export interface UserGuideFrontmatter {
+  /** Lucide icon name (line-art, matches ServiceBay's dashboard
+   *  chrome). Preferred over the legacy emoji `icon` field. */
+  lucide_icon?: PortalIconName;
+  /** Legacy emoji icon (📷 / 🏠 / …). Kept for back-compat;
+   *  templates should migrate to `lucide_icon` for visual
+   *  consistency with the dashboard. */
   icon?: string;
   tagline?: string;
   /** Preferred — richer recommended-apps with platforms + notes. */
@@ -164,6 +195,9 @@ export function parseUserGuide(raw: string | null, templateName: string): Parsed
     const { data, content } = matter(raw);
     const fm: UserGuideFrontmatter = {};
     if (typeof data.icon === 'string') fm.icon = data.icon;
+    if (typeof data.lucide_icon === 'string' && PORTAL_ICON_SET.has(data.lucide_icon)) {
+      fm.lucide_icon = data.lucide_icon as PortalIconName;
+    }
     if (typeof data.tagline === 'string') fm.tagline = data.tagline;
 
     // Prefer `recommended_apps` when present; fall back to lifting

--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -1,9 +1,9 @@
 ---
-icon: "📁"
+lucide_icon: "folder-open"
 tagline: "Share documents across phones, laptops, and the family — like a private Dropbox."
 setup_assets:
   - kind: "syncthing_qr"
-    label: "📷 Pair this Syncthing device"
+    label: "Pair this Syncthing device"
     description: "Shows a QR code with the home server's device ID. The Android Syncthing app's \"Add Device → Scan QR\" picks it up directly."
 recommended_apps:
   - name: "Syncthing"

--- a/templates/home-assistant/user-guide.md
+++ b/templates/home-assistant/user-guide.md
@@ -1,5 +1,5 @@
 ---
-icon: "🏠"
+lucide_icon: "lightbulb"
 tagline: "Control lights, sensors, and smart-home devices from one app — and keep all the data on your home server."
 recommended_apps:
   - name: "Home Assistant Companion"

--- a/templates/immich/user-guide.md
+++ b/templates/immich/user-guide.md
@@ -1,5 +1,5 @@
 ---
-icon: "📷"
+lucide_icon: "camera"
 tagline: "Auto-backup the photos on your phone and browse them like Google Photos — but private to your family."
 recommended_apps:
   - name: "Immich"

--- a/templates/media/user-guide.md
+++ b/templates/media/user-guide.md
@@ -1,9 +1,9 @@
 ---
-icon: "🎵"
+lucide_icon: "headphones"
 tagline: "Stream your music collection and listen to audiobooks — offline-capable on phones."
 setup_assets:
   - kind: "audiobookshelf_deeplink"
-    label: "📲 Open in Audiobookshelf app"
+    label: "Open in Audiobookshelf app"
     description: "Pre-configures the server URL — works only after you've installed the app from the App Store / Play Store."
 recommended_apps:
   - name: "Audiobookshelf"

--- a/templates/radicale/user-guide.md
+++ b/templates/radicale/user-guide.md
@@ -1,9 +1,9 @@
 ---
-icon: "📅"
+lucide_icon: "calendar-days"
 tagline: "Calendar and contacts that sync between every device — no separate app, just your phone's built-in Calendar and Contacts."
 setup_assets:
   - kind: "ios_calendar_profile"
-    label: "📲 One-tap iOS setup"
+    label: "One-tap iOS setup"
     description: "Downloads an Apple-standard configuration profile that adds CalDAV + CardDAV accounts. iOS prompts for your username and password during install."
 recommended_apps:
   - name: "iOS Calendar / Contacts"

--- a/templates/vaultwarden/user-guide.md
+++ b/templates/vaultwarden/user-guide.md
@@ -1,5 +1,5 @@
 ---
-icon: "🔒"
+lucide_icon: "shield"
 tagline: "Save passwords once, autofill them on every phone, browser, and laptop in the family."
 recommended_apps:
   - name: "Bitwarden"


### PR DESCRIPTION
## What you flagged
The portal was using emoji icons (🏠 / 📷 / 📁 / 📅 / 🎵 / 🔒) but ServiceBay's dashboard chrome uses Lucide line-art icons throughout. Brings the family portal into visual alignment.

## Changes
- **Schema:** \`user-guide.md\` frontmatter gains a \`lucide_icon\` field validated against a curated allowlist. Legacy \`icon\` (emoji) still parsed and rendered as fallback so unmigrated templates keep working.
- **Card hero icon:** rendered in a violet rounded-square chip with the Lucide icon at 28px / 1.75 stroke — matches the dashboard sidebar nav item treatment.
- **Page header:** uses \`ServiceBayLogo\` (the canonical line-art logo) instead of 🏠 emoji.
- **Recommended apps label:** Lucide \`Sparkles\` glyph instead of 💡.
- **Setup-asset button labels:** dropped the 📲 prefix (the Lucide icon next to the text already conveys "external app").
- **PWA icon:** redrawn as the ServiceBay server-on-waves logo in white on a violet rounded square. Recognizable as a ServiceBay product on the home screen.

## User-guide migrations
| Service | New icon |
|---|---|
| immich | \`camera\` |
| vaultwarden | \`shield\` |
| file-share | \`folder-open\` |
| radicale | \`calendar-days\` |
| media | \`headphones\` |
| home-assistant | \`lightbulb\` |

## Test plan
- [x] 481 tests pass; \`next build\` clean
- [x] Curated allowlist enforces safe icon names; +2 parser tests
- [ ] Manual: visit portal, confirm cards show Lucide line-art chips matching dashboard chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)