### PR TITLE
fix: file-share seed timeout, SSO defaults to true, portal polish

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -96,7 +96,7 @@ export default function AccessRequestsSection() {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
       <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-        <div className="p-2 bg-violet-100 dark:bg-violet-900/30 rounded-lg text-violet-600 dark:text-violet-400">
+        <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
           <UserPlus size={20} />
         </div>
         <div className="flex-1 min-w-0">
@@ -117,7 +117,7 @@ export default function AccessRequestsSection() {
             href={lldapUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 text-sm font-medium bg-violet-600 hover:bg-violet-700 text-white rounded-lg"
+            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
           >
             Open LLDAP <ExternalLink size={14} />
           </a>
@@ -190,7 +190,7 @@ function RequestRow({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 text-sm">
             <span className="font-medium text-gray-900 dark:text-white">{r.name}</span>
-            <a href={`mailto:${r.email}`} className="inline-flex items-center gap-1 text-violet-700 dark:text-violet-300 hover:underline text-xs">
+            <a href={`mailto:${r.email}`} className="inline-flex items-center gap-1 text-blue-700 dark:text-blue-300 hover:underline text-xs">
               <Mail size={12} /> {r.email}
             </a>
           </div>

--- a/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -80,7 +80,7 @@ export default function CredentialsSection() {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
       <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-        <div className="p-2 bg-violet-100 dark:bg-violet-900/30 rounded-lg text-violet-600 dark:text-violet-400">
+        <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
           <Key size={20} />
         </div>
         <div className="flex-1 min-w-0">

--- a/src/app/api/portal/asset/[service]/[kind]/route.ts
+++ b/src/app/api/portal/asset/[service]/[kind]/route.ts
@@ -52,7 +52,12 @@ export async function GET(
     return new NextResponse('Invalid service name', { status: 400 });
   }
 
-  const asset = await resolveSetupAsset(kind as SetupAssetKind, service);
+  const url = new URL(request.url);
+  const subdomainVarRaw = url.searchParams.get('subdomain_var');
+  const subdomainVar = subdomainVarRaw && /^[A-Z][A-Z0-9_]*_SUBDOMAIN$/.test(subdomainVarRaw)
+    ? subdomainVarRaw
+    : undefined;
+  const asset = await resolveSetupAsset(kind as SetupAssetKind, service, subdomainVar);
   if (!asset) {
     return new NextResponse('Asset not available — service may not be installed yet.', { status: 404 });
   }

--- a/src/app/portal/PortalGrid.tsx
+++ b/src/app/portal/PortalGrid.tsx
@@ -72,29 +72,42 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {cards.map(card => {
-        const isExpanded = !!expanded[card.name];
+        const isExpanded = !!expanded[card.id];
         return (
           <div
-            key={card.name}
+            key={card.id}
             className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden flex flex-col"
           >
-            <div className="p-6 flex-1">
+            {/* Header — icon + title + tagline. The tagline area is
+                clamped to 3 lines + min-h so the Open button below
+                lands at the same Y on every card in a row. */}
+            <div className="p-6 pb-3">
               <CardIcon card={card} />
               <h2 className="text-xl font-bold text-gray-900 dark:text-white">{card.label}</h2>
-              {card.tagline && (
-                <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">{card.tagline}</p>
-              )}
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-3 min-h-[3.75rem]">
+                {card.tagline ?? ''}
+              </p>
             </div>
 
-            <div className="px-6 pb-6 space-y-3">
+            {/* Open button — at fixed offset from card top thanks to
+                the clamped header above. Consistent Y across cards. */}
+            <div className="px-6">
               <a
                 href={card.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center justify-center gap-2 w-full bg-violet-600 hover:bg-violet-700 text-white font-medium py-2.5 rounded-lg transition-colors"
+                className="flex items-center justify-center gap-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors"
               >
                 Open <ExternalLink size={16} />
               </a>
+            </div>
+
+            {/* Variable content below — fills the rest of the card so
+                grid-cell heights stay equal even with different
+                amounts of recommended apps / setup assets. */}
+            <div className="px-6 pt-3 pb-6 space-y-3 flex-1">
+              {/* (the original wrapper continues; adjusted closing
+                   tag is below — left here so the diff is contained.) */}
 
               {card.setupAssets.length > 0 && (
                 <div className="space-y-1.5">
@@ -106,7 +119,7 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                       return (
                         <div key={asset.kind}>
                           <a
-                            href={`/api/portal/asset/${card.name}/${asset.kind}`}
+                            href={`/api/portal/asset/${card.name}/${asset.kind}?subdomain_var=${encodeURIComponent(card.subdomainVar)}`}
                             className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
                           >
                             <Icon size={14} /> {label}
@@ -145,7 +158,7 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                             href={app.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="font-medium text-violet-700 dark:text-violet-300 hover:underline"
+                            className="font-medium text-blue-700 dark:text-blue-300 hover:underline"
                           >
                             {app.name}
                           </a>
@@ -172,8 +185,8 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
               {card.body.trim().length > 0 && (
                 <div>
                   <button
-                    onClick={() => setExpanded(s => ({ ...s, [card.name]: !s[card.name] }))}
-                    className="flex items-center gap-1 text-sm text-violet-700 dark:text-violet-300 hover:underline mt-2"
+                    onClick={() => setExpanded(s => ({ ...s, [card.id]: !s[card.id] }))}
+                    className="flex items-center gap-1 text-sm text-blue-700 dark:text-blue-300 hover:underline mt-2"
                     aria-expanded={isExpanded}
                   >
                     {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
@@ -217,7 +230,7 @@ function DeepLinkButton({
   const onClick = async () => {
     setError(null);
     try {
-      const res = await fetch(`/api/portal/asset/${card.name}/${kind}`);
+      const res = await fetch(`/api/portal/asset/${card.name}/${kind}?subdomain_var=${encodeURIComponent(card.subdomainVar)}`);
       if (!res.ok) {
         setError(`Couldn't load the link (HTTP ${res.status}).`);
         return;
@@ -282,7 +295,7 @@ function SyncthingQrButton({
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/portal/asset/${card.name}/syncthing_qr`);
+      const res = await fetch(`/api/portal/asset/${card.name}/syncthing_qr?subdomain_var=${encodeURIComponent(card.subdomainVar)}`);
       if (!res.ok) {
         setError(`Couldn't read the device id (HTTP ${res.status}). The Syncthing container might not be running yet — try again in a minute.`);
         return;
@@ -323,7 +336,7 @@ function SyncthingQrButton({
             </p>
 
             <div className="mt-5 flex justify-center min-h-[12rem] items-center">
-              {loading && <Loader2 className="animate-spin text-violet-500" size={32} />}
+              {loading && <Loader2 className="animate-spin text-blue-500" size={32} />}
               {!loading && error && (
                 <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
               )}
@@ -367,7 +380,7 @@ function CardIcon({ card }: { card: PortalCard }) {
   if (card.lucideIcon) {
     const Icon = PORTAL_ICON_MAP[card.lucideIcon];
     return (
-      <div className="mb-3 inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400">
+      <div className="mb-3 inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
         <Icon size={28} strokeWidth={1.75} />
       </div>
     );

--- a/src/app/portal/RequestAccessButton.tsx
+++ b/src/app/portal/RequestAccessButton.tsx
@@ -61,7 +61,7 @@ export default function RequestAccessButton() {
       <div className="mt-12 text-center">
         <button
           onClick={() => setOpen(true)}
-          className="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 hover:border-violet-500 hover:text-violet-700 dark:hover:text-violet-300 text-sm font-medium text-gray-700 dark:text-gray-300 rounded-full transition-colors"
+          className="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 hover:border-blue-500 hover:text-blue-700 dark:hover:text-blue-300 text-sm font-medium text-gray-700 dark:text-gray-300 rounded-full transition-colors"
         >
           <UserPlus size={16} />
           Don&apos;t have an account yet?
@@ -86,7 +86,7 @@ export default function RequestAccessButton() {
                 </p>
                 <button
                   onClick={onClose}
-                  className="mt-2 px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium rounded-lg"
+                  className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg"
                 >
                   Got it
                 </button>
@@ -111,7 +111,7 @@ export default function RequestAccessButton() {
                     required
                     maxLength={120}
                     autoComplete="name"
-                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -126,7 +126,7 @@ export default function RequestAccessButton() {
                     required
                     maxLength={200}
                     autoComplete="email"
-                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -140,7 +140,7 @@ export default function RequestAccessButton() {
                     maxLength={1000}
                     rows={3}
                     placeholder="e.g. which services you'd like access to"
-                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
 
@@ -161,7 +161,7 @@ export default function RequestAccessButton() {
                   <button
                     type="submit"
                     disabled={submitting}
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
                   >
                     {submitting && <Loader2 size={14} className="animate-spin" />}
                     Send request

--- a/src/app/portal/icon.svg
+++ b/src/app/portal/icon.svg
@@ -1,11 +1,10 @@
 <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <!-- PWA app icon for the family-portal route. Uses the ServiceBay
-       logo's line-art style (currentColor stroke, 2px equivalent at
-       this scale) on a violet brand background. Differs from the
-       admin dashboard's icon only by the violet fill — same shape
-       cues so it's recognizable as a ServiceBay product on the
-       home screen. -->
-  <rect width="512" height="512" rx="96" fill="#7c3aed"/>
+  <!-- PWA app icon for the family-portal route. ServiceBay's
+       server-on-waves logo in line-art on the blue brand fill
+       (Tailwind blue-600 = #2563eb, the same color the dashboard
+       uses for the sidebar logo + primary actions). Recognizable
+       as a ServiceBay product on the home screen. -->
+  <rect width="512" height="512" rx="96" fill="#2563eb"/>
   <g transform="translate(96 96) scale(13.33)" fill="none" stroke="#fff"
      stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
     <!-- Server unit -->

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -24,14 +24,14 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: '#7c3aed',
+  themeColor: '#2563eb',
   width: 'device-width',
   initialScale: 1,
 };
 
 export default function PortalLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-violet-50 to-white dark:from-gray-900 dark:to-gray-950">
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950">
       {children}
     </div>
   );

--- a/src/app/portal/manifest.webmanifest/route.ts
+++ b/src/app/portal/manifest.webmanifest/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
     display: 'standalone',
     orientation: 'portrait',
     background_color: '#fafafa',
-    theme_color: '#7c3aed',
+    theme_color: '#2563eb',
     icons: [
       {
         src: '/portal/icon.svg',

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -21,7 +21,7 @@ export default async function PortalPage() {
     <main className="max-w-6xl mx-auto px-6 py-12">
       <header className="mb-10 text-center">
         <div className="flex items-center justify-center gap-3">
-          <ServiceBayLogo size={36} className="text-violet-600 dark:text-violet-400 shrink-0" />
+          <ServiceBayLogo size={36} className="text-blue-600 dark:text-blue-400 shrink-0" />
           <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
             Home <span className="text-gray-400 dark:text-gray-600 font-normal">— your family&apos;s private cloud</span>
           </h1>

--- a/src/lib/api/requireSession.test.ts
+++ b/src/lib/api/requireSession.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionFromCookieHeader: vi.fn(),
+}));
+vi.mock('@/lib/auth/internalToken', () => ({
+  getInternalApiToken: vi.fn(() => 'test-internal-token-32-chars-long'),
+}));
+
+import { requireSession } from './requireSession';
+import { getSessionFromCookieHeader } from '@/lib/auth/session';
+
+beforeEach(() => {
+  (getSessionFromCookieHeader as unknown as { mockReset: () => void }).mockReset();
+});
+
+const mkRequest = (headers: Record<string, string>) =>
+  new Request('http://test/', { headers });
+
+describe('requireSession', () => {
+  it('accepts a valid session cookie', async () => {
+    (getSessionFromCookieHeader as unknown as { mockResolvedValueOnce: (v: unknown) => void })
+      .mockResolvedValueOnce({ user: 'admin', expires: new Date(Date.now() + 60_000) });
+    const result = await requireSession(mkRequest({ cookie: 'session=abc' }));
+    expect(result instanceof NextResponse).toBe(false);
+    expect((result as { user: string }).user).toBe('admin');
+  });
+
+  it('rejects when no cookie and no token', async () => {
+    (getSessionFromCookieHeader as unknown as { mockResolvedValueOnce: (v: unknown) => void })
+      .mockResolvedValueOnce(null);
+    const result = await requireSession(mkRequest({}));
+    expect(result instanceof NextResponse).toBe(true);
+    expect((result as NextResponse).status).toBe(401);
+  });
+
+  it('accepts the X-SB-Internal-Token header (post-deploy script path)', async () => {
+    const result = await requireSession(mkRequest({
+      'x-sb-internal-token': 'test-internal-token-32-chars-long',
+    }));
+    expect(result instanceof NextResponse).toBe(false);
+    expect((result as { user: string }).user).toBe('internal');
+  });
+
+  it('rejects an invalid X-SB-Internal-Token (wrong value, same length)', async () => {
+    (getSessionFromCookieHeader as unknown as { mockResolvedValueOnce: (v: unknown) => void })
+      .mockResolvedValueOnce(null);
+    const result = await requireSession(mkRequest({
+      'x-sb-internal-token': 'wrong-token-but-correct-length-x',
+    }));
+    expect(result instanceof NextResponse).toBe(true);
+  });
+
+  it('rejects a wrong-length internal token without comparing bytes (length mismatch is cheap)', async () => {
+    (getSessionFromCookieHeader as unknown as { mockResolvedValueOnce: (v: unknown) => void })
+      .mockResolvedValueOnce(null);
+    const result = await requireSession(mkRequest({
+      'x-sb-internal-token': 'too-short',
+    }));
+    expect(result instanceof NextResponse).toBe(true);
+  });
+});

--- a/src/lib/api/requireSession.ts
+++ b/src/lib/api/requireSession.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getSessionFromCookieHeader, type SessionPayload } from '@/lib/auth/session';
+import { getInternalApiToken } from '@/lib/auth/internalToken';
 
 /**
  * Gate an API route on a valid ServiceBay session cookie.
@@ -11,6 +12,14 @@ import { getSessionFromCookieHeader, type SessionPayload } from '@/lib/auth/sess
  *     if (auth instanceof NextResponse) return auth;
  *     // …auth is the session payload from here on…
  *
+ * Also accepts the `X-SB-Internal-Token` server-to-server header — the
+ * same one `proxy.ts` honors at the middleware layer. Without this,
+ * post-deploy scripts that legitimately reach internal admin endpoints
+ * (e.g. file-share's filebrowser/init seed) get 401'd at the route
+ * handler even though middleware lets them through. Returns a synthetic
+ * session payload tagged `user: 'internal'` so callers can distinguish
+ * if needed.
+ *
  * This is intentionally a per-handler helper rather than a global
  * middleware: the broader hardening plan (PR1) layers a `middleware.ts`
  * gate on top of this. Until that lands, the helper at least closes the
@@ -19,6 +28,21 @@ import { getSessionFromCookieHeader, type SessionPayload } from '@/lib/auth/sess
 export async function requireSession(
   request: Request,
 ): Promise<SessionPayload | NextResponse> {
+  const presented = request.headers.get('x-sb-internal-token');
+  if (presented) {
+    const expected = getInternalApiToken();
+    if (presented.length === expected.length) {
+      // Constant-time compare via Buffer to avoid timing leaks —
+      // mirrors proxy.ts's check.
+      const a = Buffer.from(presented);
+      const b = Buffer.from(expected);
+      let diff = 0;
+      for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+      if (diff === 0) {
+        return { user: 'internal', expires: new Date(Date.now() + 60_000) };
+      }
+    }
+  }
   const session = await getSessionFromCookieHeader(request.headers.get('cookie') ?? undefined);
   if (!session) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });

--- a/src/lib/portal/assets.ts
+++ b/src/lib/portal/assets.ts
@@ -32,9 +32,9 @@ import type { SetupAssetKind } from './userGuide';
  * `application/x-apple-aspen-config` Content-Type that triggers the
  * "Install Profile" prompt on download.
  */
-export async function generateIosCalendarProfile(serviceName: string): Promise<string | null> {
+export async function generateIosCalendarProfile(serviceName: string, subdomainVar?: string): Promise<string | null> {
   const config = await getConfig();
-  const url = await resolveServiceUrl(config, serviceName);
+  const url = await resolveServiceUrl(config, serviceName, subdomainVar);
   if (!url) return null;
   const parsed = new URL(url);
   const hostname = parsed.hostname;
@@ -139,9 +139,9 @@ export async function generateIosCalendarProfile(serviceName: string): Promise<s
  * Format derived from Audiobookshelf's documented client deep link:
  * `abs://<host>?ssl=true|false`.
  */
-export async function generateAudiobookshelfDeepLink(serviceName: string): Promise<string | null> {
+export async function generateAudiobookshelfDeepLink(serviceName: string, subdomainVar?: string): Promise<string | null> {
   const config = await getConfig();
-  const url = await resolveServiceUrl(config, serviceName);
+  const url = await resolveServiceUrl(config, serviceName, subdomainVar);
   if (!url) return null;
   const parsed = new URL(url);
   const ssl = parsed.protocol === 'https:' ? 'true' : 'false';
@@ -189,14 +189,18 @@ export async function fetchSyncthingDeviceId(node: string = 'Local'): Promise<st
 }
 
 /** Resolve any setup-asset kind into its concrete artifact. */
-export async function resolveSetupAsset(kind: SetupAssetKind, serviceName: string): Promise<{ kind: SetupAssetKind; data: string } | null> {
+export async function resolveSetupAsset(
+  kind: SetupAssetKind,
+  serviceName: string,
+  subdomainVar?: string,
+): Promise<{ kind: SetupAssetKind; data: string } | null> {
   switch (kind) {
     case 'ios_calendar_profile': {
-      const xml = await generateIosCalendarProfile(serviceName);
+      const xml = await generateIosCalendarProfile(serviceName, subdomainVar);
       return xml ? { kind, data: xml } : null;
     }
     case 'audiobookshelf_deeplink': {
-      const url = await generateAudiobookshelfDeepLink(serviceName);
+      const url = await generateAudiobookshelfDeepLink(serviceName, subdomainVar);
       return url ? { kind, data: url } : null;
     }
     case 'syncthing_qr': {

--- a/src/lib/portal/services.ts
+++ b/src/lib/portal/services.ts
@@ -32,26 +32,30 @@ import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAss
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
 export interface PortalCard {
-  /** Template name (e.g. "immich"). Used as React key. */
+  /** Stable id, e.g. "media:ABS_SUBDOMAIN" or "immich:IMMICH_SUBDOMAIN".
+   *  Used as React key + lets multi-service templates emit one card
+   *  per subdomain (#242 follow-up). */
+  id: string;
+  /** Template name (e.g. "media"). Used for asset endpoint paths. */
   name: string;
-  /** User-facing label (from frontmatter title fallback or `servicebay.label`). */
+  /** Subdomain-variable name on the template (`*_SUBDOMAIN`). The
+   *  asset endpoint uses this to resolve the right URL when the
+   *  template has multiple subdomains (e.g. media → ABS_SUBDOMAIN
+   *  for the Audiobookshelf card). */
+  subdomainVar: string;
+  /** User-facing label */
   label: string;
-  /** Lucide icon name from `lucide_icon` frontmatter (line-art,
-   *  matches dashboard chrome). Null when only the legacy emoji is
-   *  set or no icon at all. */
+  /** Lucide icon name */
   lucideIcon: PortalIconName | null;
-  /** Legacy emoji icon (`icon` frontmatter). Empty string when only
-   *  lucideIcon is set or no icon at all. */
+  /** Legacy emoji icon */
   icon: string;
-  /** Frontmatter tagline, or empty string. */
   tagline: string;
   /** External URL the "Open" button should point at. */
   url: string;
-  /** Markdown body for the expandable Getting-started section. May be empty. */
+  /** Markdown body shared across all cards from the same template
+   *  (the template's `user-guide.md` body). */
   body: string;
-  /** Companion apps recommended by the template author (validated). */
   recommendedApps: RecommendedApp[];
-  /** Pre-configured setup artifacts (iOS profile, deep links, …). */
   setupAssets: SetupAsset[];
 }
 
@@ -68,22 +72,6 @@ async function readTemplateYaml(templateName: string): Promise<string | null> {
   try {
     return await fs.readFile(path.join(TEMPLATES_PATH, templateName, 'template.yml'), 'utf-8');
   } catch { return null; }
-}
-
-/**
- * Given a template's variables.json, pick the operator-facing
- * subdomain default. Heuristic: first variable whose `meta.type` is
- * `subdomain` and whose name ends in `_SUBDOMAIN`. Returns the
- * default value (e.g. `'photos'` for Immich's `IMMICH_SUBDOMAIN`),
- * or null when the template has no subdomain variable.
- */
-function pickSubdomainDefault(variables: Record<string, { type?: string; default?: string }>): string | null {
-  for (const [name, meta] of Object.entries(variables)) {
-    if (meta.type === 'subdomain' && name.endsWith('_SUBDOMAIN') && typeof meta.default === 'string') {
-      return meta.default;
-    }
-  }
-  return null;
 }
 
 /**
@@ -105,23 +93,41 @@ function pickSubdomainDefault(variables: Record<string, { type?: string; default
  */
 export async function resolveServiceUrl(
   config: AppConfig,
-  serviceName: string,
+  templateName: string,
+  /** Optional explicit *_SUBDOMAIN variable name. Required for
+   *  multi-subdomain templates (media has both ABS_SUBDOMAIN and
+   *  NAVIDROME_SUBDOMAIN); when omitted, falls back to the first
+   *  subdomain variable in variables.json (single-subdomain case). */
+  subdomainVar?: string,
 ): Promise<string | null> {
   const scheme = getMode(config) === 'public' ? 'https' : 'http';
+  const variables = await readVariables(templateName);
 
-  // Prefer the persisted proxy-host entry — it has the operator's
-  // chosen subdomain baked in.
+  // Resolve which variable to read.
+  let chosenVar = subdomainVar;
+  if (!chosenVar) {
+    chosenVar = Object.keys(variables).find(
+      k => k.endsWith('_SUBDOMAIN') && variables[k].type === 'subdomain',
+    );
+  }
+  if (!chosenVar) return null;
+  const sub = variables[chosenVar]?.default;
+  if (typeof sub !== 'string' || !sub) return null;
+
+  // Prefer a created proxy-host entry. The wizard's `buildProxyHosts`
+  // derives `service` per subdomain variable: lowercase `<NAME>` from
+  // `<NAME>_SUBDOMAIN`. Match against that so operator-customized
+  // subdomains (e.g. `agenda` instead of `caldav` for Radicale) get
+  // honoured even when the install renamed away from the default.
+  const expectedService = chosenVar.replace(/_SUBDOMAIN$/i, '').toLowerCase();
   const hostEntry = (config.reverseProxy?.hosts ?? []).find(
-    h => h.service === serviceName && h.created,
+    h => h.created && h.service === expectedService,
   );
   if (hostEntry) {
     return `${scheme}://${hostEntry.domain}`;
   }
 
   // Fallback: template default subdomain + active domain.
-  const variables = await readVariables(serviceName);
-  const sub = pickSubdomainDefault(variables);
-  if (!sub) return null;
   return `${scheme}://${sub}.${getActiveDomain(config)}`;
 }
 
@@ -151,24 +157,53 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
     const parsed = parseUserGuide(rawGuide, svc.name);
     if (!parsed) continue; // No guide → not on the portal in v1
 
-    const url = await resolveServiceUrl(config, svc.name);
-    if (!url) {
-      logger.warn('portal', `Template ${svc.name} has user-guide.md but no subdomain variable and no proxy-host entry — skipping`);
-      continue;
-    }
+    const templateLabel = parseTemplateLabel(yaml) ?? svc.name;
 
-    const label = parseTemplateLabel(yaml) ?? svc.name;
-    cards.push({
-      name: svc.name,
-      label,
-      lucideIcon: parsed.frontmatter.lucide_icon ?? null,
-      icon: parsed.frontmatter.icon ?? '',
-      tagline: parsed.frontmatter.tagline ?? '',
-      url,
-      body: parsed.body,
-      recommendedApps: parsed.frontmatter.recommended_apps ?? [],
-      setupAssets: parsed.frontmatter.setup_assets ?? [],
-    });
+    // Multi-card templates: emit one card per `cards[]` entry. Single-
+    // service templates: synthesize one implicit card from top-level
+    // frontmatter (legacy path).
+    const cardDefs = parsed.frontmatter.cards
+      ?? [{
+        // Implicit single card — use the first *_SUBDOMAIN variable.
+        subdomain_var: '',
+        lucide_icon: parsed.frontmatter.lucide_icon,
+        icon: parsed.frontmatter.icon,
+        tagline: parsed.frontmatter.tagline,
+        recommended_apps: parsed.frontmatter.recommended_apps,
+        setup_assets: parsed.frontmatter.setup_assets,
+      }];
+
+    for (const def of cardDefs) {
+      const url = await resolveServiceUrl(config, svc.name, def.subdomain_var || undefined);
+      if (!url) {
+        logger.warn('portal', `Template ${svc.name} card (subdomain_var=${def.subdomain_var || '<auto>'}) couldn't resolve a URL — skipping`);
+        continue;
+      }
+      const subdomainVar = def.subdomain_var || (await firstSubdomainVar(svc.name)) || '';
+      cards.push({
+        id: `${svc.name}:${subdomainVar || 'default'}`,
+        name: svc.name,
+        subdomainVar,
+        label: def.label ?? templateLabel,
+        lucideIcon: def.lucide_icon ?? null,
+        icon: def.icon ?? '',
+        tagline: def.tagline ?? '',
+        url,
+        body: parsed.body,
+        recommendedApps: def.recommended_apps ?? [],
+        setupAssets: def.setup_assets ?? [],
+      });
+    }
   }
   return cards;
+}
+
+/** Helper for the implicit-card path — find the first `*_SUBDOMAIN`
+ *  variable name so the resulting PortalCard can record it. */
+async function firstSubdomainVar(templateName: string): Promise<string | null> {
+  const variables = await readVariables(templateName);
+  for (const [name, meta] of Object.entries(variables)) {
+    if (meta.type === 'subdomain' && name.endsWith('_SUBDOMAIN')) return name;
+  }
+  return null;
 }

--- a/src/lib/portal/userGuide.ts
+++ b/src/lib/portal/userGuide.ts
@@ -107,9 +107,38 @@ export type PortalIconName = typeof PORTAL_ICONS[number];
 
 const PORTAL_ICON_SET: ReadonlySet<string> = new Set(PORTAL_ICONS);
 
+/**
+ * Per-subdomain card definition. Templates that host multiple
+ * services (e.g. `media` runs both Audiobookshelf at `books.<domain>`
+ * and Navidrome at `music.<domain>`) declare one entry per service
+ * via `cards[]` in the frontmatter, and the portal emits one card
+ * per entry.
+ *
+ * Single-service templates skip `cards[]` entirely — the parser
+ * synthesizes a single implicit card from the top-level frontmatter.
+ */
+export interface UserGuideCard {
+  /** Variable name in the template's `variables.json` to use as the
+   *  subdomain. e.g. `"ABS_SUBDOMAIN"` for Audiobookshelf. */
+  subdomain_var: string;
+  /** Optional override label; falls back to the template label. */
+  label?: string;
+  lucide_icon?: PortalIconName;
+  icon?: string;
+  tagline?: string;
+  recommended_apps?: RecommendedApp[];
+  setup_assets?: SetupAsset[];
+}
+
 export interface UserGuideFrontmatter {
+  /** Multi-service templates (`media`) declare per-subdomain cards
+   *  here. When present, top-level icon/tagline/etc. are ignored and
+   *  one PortalCard is emitted per entry. */
+  cards?: UserGuideCard[];
+
   /** Lucide icon name (line-art, matches ServiceBay's dashboard
-   *  chrome). Preferred over the legacy emoji `icon` field. */
+   *  chrome). Preferred over the legacy emoji `icon` field. Used
+   *  when `cards` is absent. */
   lucide_icon?: PortalIconName;
   /** Legacy emoji icon (📷 / 🏠 / …). Kept for back-compat;
    *  templates should migrate to `lucide_icon` for visual
@@ -208,6 +237,45 @@ export function parseUserGuide(raw: string | null, templateName: string): Parsed
     } else if (Array.isArray(data.mobile_apps)) {
       const lifted = liftMobileApps(data.mobile_apps);
       if (lifted.length > 0) fm.recommended_apps = lifted;
+    }
+
+    if (Array.isArray(data.cards)) {
+      const cards = data.cards
+        .map((entry: unknown): UserGuideCard | null => {
+          if (!entry || typeof entry !== 'object') return null;
+          const e = entry as Record<string, unknown>;
+          if (typeof e.subdomain_var !== 'string' || !/^[A-Z][A-Z0-9_]*_SUBDOMAIN$/.test(e.subdomain_var)) {
+            return null;
+          }
+          const card: UserGuideCard = { subdomain_var: e.subdomain_var };
+          if (typeof e.label === 'string' && e.label.trim()) card.label = e.label.trim();
+          if (typeof e.icon === 'string') card.icon = e.icon;
+          if (typeof e.lucide_icon === 'string' && PORTAL_ICON_SET.has(e.lucide_icon)) {
+            card.lucide_icon = e.lucide_icon as PortalIconName;
+          }
+          if (typeof e.tagline === 'string') card.tagline = e.tagline;
+          if (Array.isArray(e.recommended_apps)) {
+            const apps = parseRecommendedApps(e.recommended_apps);
+            if (apps.length > 0) card.recommended_apps = apps;
+          }
+          if (Array.isArray(e.setup_assets)) {
+            const assets = (e.setup_assets as unknown[])
+              .map((a): SetupAsset | null => {
+                if (!a || typeof a !== 'object') return null;
+                const ae = a as Record<string, unknown>;
+                if (typeof ae.kind !== 'string' || !KNOWN_ASSET_KINDS.has(ae.kind as SetupAssetKind)) return null;
+                const out: SetupAsset = { kind: ae.kind as SetupAssetKind };
+                if (typeof ae.label === 'string' && ae.label.trim()) out.label = ae.label.trim();
+                if (typeof ae.description === 'string' && ae.description.trim()) out.description = ae.description.trim();
+                return out;
+              })
+              .filter((a): a is SetupAsset => a !== null);
+            if (assets.length > 0) card.setup_assets = assets;
+          }
+          return card;
+        })
+        .filter((c): c is UserGuideCard => c !== null);
+      if (cards.length > 0) fm.cards = cards;
     }
 
     if (Array.isArray(data.setup_assets)) {

--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -83,7 +83,7 @@ export function formatCredentialsBanner(manifest: Credential[]): string[] {
   const lines: string[] = [
     '',
     '═══════════════════════════════════════════════════',
-    '🔑 SAVE THESE NOW — they are not shown again',
+    'CREDENTIALS — saved encrypted at Settings → Integrations → Saved credentials',
     '═══════════════════════════════════════════════════',
   ];
   for (const c of critical) {
@@ -102,7 +102,7 @@ export function formatCredentialsBanner(manifest: Credential[]): string[] {
     }
     lines.push('');
   }
-  lines.push('💡 You can also download a Bitwarden-compatible CSV from the Done step.');
+  lines.push('Visible in Settings → Integrations → Saved credentials, or download a Bitwarden CSV from the Done step.');
   lines.push('═══════════════════════════════════════════════════');
   return lines;
 }

--- a/templates/media/user-guide.md
+++ b/templates/media/user-guide.md
@@ -1,27 +1,40 @@
 ---
-lucide_icon: "headphones"
-tagline: "Stream your music collection and listen to audiobooks — offline-capable on phones."
-setup_assets:
-  - kind: "audiobookshelf_deeplink"
-    label: "Open in Audiobookshelf app"
-    description: "Pre-configures the server URL — works only after you've installed the app from the App Store / Play Store."
-recommended_apps:
-  - name: "Audiobookshelf"
-    url: "https://www.audiobookshelf.org/docs#mobile-apps"
-    platforms: ["ios", "android"]
-    note: "Official audiobook + podcast player. Bookmarks and progress sync between phone and tablet."
-  - name: "Symfonium"
-    url: "https://symfonium.app/"
-    platforms: ["android"]
-    note: "Best Subsonic-compatible music client on Android — paid app but well worth it for car audio + offline play."
-  - name: "play:Sub"
-    url: "https://apps.apple.com/app/play-sub-music-streamer/id955329386"
-    platforms: ["ios"]
-    note: "Highly-rated Subsonic music client for iPhone — the iOS counterpart to Symfonium."
-  - name: "Sonixd"
-    url: "https://github.com/jeffvli/sonixd"
-    platforms: ["desktop"]
-    note: "Cross-platform Subsonic desktop client — great for big libraries on a laptop."
+# The `media` template hosts two services on different subdomains —
+# Audiobookshelf at <books>.<domain> and Navidrome at <music>.<domain>.
+# One card per service so the family-portal "Open" button per row
+# routes to the right place.
+cards:
+  - subdomain_var: "ABS_SUBDOMAIN"
+    label: "Audiobooks"
+    lucide_icon: "book-open"
+    tagline: "Listen to audiobooks and podcasts — offline on your phone, with bookmark + progress sync between devices."
+    setup_assets:
+      - kind: "audiobookshelf_deeplink"
+        label: "Open in Audiobookshelf app"
+        description: "Pre-configures the server URL — works only after you've installed the app."
+    recommended_apps:
+      - name: "Audiobookshelf"
+        url: "https://www.audiobookshelf.org/docs#mobile-apps"
+        platforms: ["ios", "android"]
+        note: "Official audiobook + podcast player. Bookmarks + progress sync between phone and tablet."
+
+  - subdomain_var: "NAVIDROME_SUBDOMAIN"
+    label: "Music"
+    lucide_icon: "music"
+    tagline: "Stream your music collection — works with every Subsonic-compatible client."
+    recommended_apps:
+      - name: "Symfonium"
+        url: "https://symfonium.app/"
+        platforms: ["android"]
+        note: "Best Subsonic-compatible music client on Android — paid, but worth it for car audio + offline play."
+      - name: "play:Sub"
+        url: "https://apps.apple.com/app/play-sub-music-streamer/id955329386"
+        platforms: ["ios"]
+        note: "Highly-rated Subsonic music client for iPhone — the iOS counterpart to Symfonium."
+      - name: "Sonixd"
+        url: "https://github.com/jeffvli/sonixd"
+        platforms: ["desktop"]
+        note: "Cross-platform Subsonic desktop client — great for big libraries on a laptop."
 ---
 
 # Getting started with Media

--- a/templates/vaultwarden/post-deploy.py
+++ b/templates/vaultwarden/post-deploy.py
@@ -51,13 +51,14 @@ def main() -> int:
 
     if enabled:
         log(
-            "🔐 Vaultwarden SSO is ENABLED via env (SSO_CLIENT_SECRET is wired in). "
-            "Test login through Authelia once before relying on it."
+            "Vaultwarden SSO is ENABLED via env (SSO_CLIENT_SECRET is wired in). "
+            "Family members log in via Authelia with the household password."
         )
     else:
         log(
-            "🔐 Vaultwarden SSO is OFF (default). "
-            "To enable: set VAULTWARDEN_SSO_ENABLED=true on this template and redeploy."
+            "Vaultwarden SSO is DISABLED. Family members will use local "
+            "Vaultwarden accounts. To re-enable: set VAULTWARDEN_SSO_ENABLED=true "
+            "in the wizard and redeploy."
         )
 
     if domain:

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -15,9 +15,11 @@ spec:
       value: "{{VAULTWARDEN_DOMAIN}}"
     - name: SIGNUPS_ALLOWED
       value: "{{VAULTWARDEN_SIGNUPS}}"
-    # Authelia SSO — disabled by default (set VAULTWARDEN_SSO_ENABLED=true).
-    # When enabled, the wizard has already registered the matching OIDC
-    # client with Authelia using the same VAULTWARDEN_SSO_SECRET below.
+    # Authelia SSO — enabled by default so family members log in once
+    # via the household password and have access to every service.
+    # Wizard auto-registers the matching OIDC client with Authelia
+    # using the same VAULTWARDEN_SSO_SECRET below. Flip to false in
+    # the wizard if you need to fall back to local-account auth.
     - name: SSO_ENABLED
       value: "{{VAULTWARDEN_SSO_ENABLED}}"
     - name: SSO_AUTHORITY

--- a/templates/vaultwarden/variables.json
+++ b/templates/vaultwarden/variables.json
@@ -18,9 +18,9 @@
   },
   "VAULTWARDEN_SSO_ENABLED": {
     "type": "select",
-    "description": "Enable Vaultwarden ↔ Authelia SSO. Off by default — Vaultwarden's SSO is still experimental upstream. Flip to true once you've tested local login.",
+    "description": "Enable Vaultwarden ↔ Authelia SSO. On by default so family members log in once and have access to every service. Flip to false if you hit Vaultwarden SSO regressions and need to fall back to local accounts.",
     "options": ["true", "false"],
-    "default": "false"
+    "default": "true"
   },
   "VAULTWARDEN_SSO_SECRET": {
     "type": "secret",

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -190,7 +190,7 @@ class VaultwardenScript(unittest.TestCase):
         with run_with_env(env):
             rc, out = capture_main(m)
         self.assertEqual(rc, 0)
-        self.assertIn("Vaultwarden SSO is OFF", out)
+        self.assertIn("Vaultwarden SSO is DISABLED", out)
 
     def test_no_secret_returns_zero_silently(self):
         m = load_script("vaultwarden")


### PR DESCRIPTION
## Summary

Bundle of fixes flagged from a fresh install:

- **File-share seed timeout** (`Could not pre-seed FileBrowser admin after 3 minutes`). The post-deploy script's call to `/api/system/filebrowser/init` was 401'ing because middleware passed (internal token allowed) but `requireSession` still required the dashboard cookie. Internal-token check now lives in `requireSession` itself with a timing-safe compare. New test in `src/lib/api/requireSession.test.ts`.
- **Vaultwarden SSO default → true.** Most family deployments want one-login-per-everything; opt-in default avoids a setup cliff.
- **Credentials manifest banner reworded.** Old `🔑 SAVE THESE NOW — they are not shown again` contradicted the encrypted persistent store at Settings → Integrations → Saved credentials. Now points there.
- **Portal: violet → blue** to match ServiceBay's brand (blue-600 / `#2563eb`). Touches PortalGrid, layout, page, RequestAccessButton, icon.svg, manifest, plus the same accents in Settings sections (Credentials, Access requests).
- **Portal card alignment.** Headers (icon + title + tagline) use `line-clamp-3` + `min-h` so the Open button sits at a fixed offset regardless of tagline length.
- **One card per subdomain.** `user-guide.md` frontmatter now supports a `cards[]` array; media template ships two cards (Audiobookshelf + Navidrome). `resolveServiceUrl` matches `reverseProxy.hosts[]` by `service` (derived from `<NAME>_SUBDOMAIN`), so multi-service templates resolve correctly and operator-customized subdomains keep working.
- PWA manifest + portal icon repainted blue.

## Test plan

- [x] `npx vitest run` — 486 passed, 1 skipped
- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run build` — clean
- [ ] Reinstall on the LAN tester, confirm:
  - [ ] FileBrowser pre-seed succeeds (no 3-min timeout)
  - [ ] Vaultwarden SSO is wired to Authelia post-install
  - [ ] Portal shows two cards for `media` (Audiobooks, Music) each with their own Open button
  - [ ] Portal page colors are blue, not violet

🤖 Generated with [Claude Code](https://claude.com/claude-code)