### PR TITLE
fix: surface install-time failures (#317, #318, #319)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,7 @@ import { GatewayPoller } from './src/lib/gateway/poller';
 import { logger } from './src/lib/logger';
 import { migrateConfig, getConfig, updateConfig } from './src/lib/config';
 import { syncRegistries } from './src/lib/registry';
+import { reconcileLanIp } from './src/lib/lanIp';
 import { createMcpServer } from './src/lib/mcp/server';
 import { scheduleBackup } from './src/lib/backup/service';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -497,6 +498,18 @@ app.prepare().then(() => {
 
     // Sync template registries in background (non-blocking)
     syncRegistries().catch(err => logger.warn('Server', `Registry sync failed: ${err}`));
+
+    // LAN IP reconcile (#318). Captures the install-time IP on first
+    // boot and updates the stored value (with history) when the IP
+    // drifts. Deferred 60s so the Local agent has time to come up
+    // through the socket lifecycle — detectLanIp() needs an `exec`
+    // round-trip. Best-effort: a missing IP just leaves the previous
+    // value alone, the diagnose probe handles the no-value case.
+    setTimeout(() => {
+      reconcileLanIp('Local').catch(err =>
+        logger.warn('Server', `LAN IP reconcile failed: ${err instanceof Error ? err.message : String(err)}`),
+      );
+    }, 60_000);
 
     // Auto-update logic to be migrated to Executor Task
   });

--- a/src/lib/lanIp.test.ts
+++ b/src/lib/lanIp.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest';
-import { recentChanges, dateNDaysAgo } from './lanIp';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn() },
+}));
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
+import { recentChanges, dateNDaysAgo, reconcileLanIp } from './lanIp';
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig, updateConfig } from '@/lib/config';
 
 const today = (offsetDays: number): string => {
   const d = new Date();
@@ -43,5 +54,65 @@ describe('dateNDaysAgo', () => {
     const d = dateNDaysAgo(7);
     expect(d.getTime()).toBeLessThan(Date.now());
     expect(Date.now() - d.getTime()).toBeGreaterThanOrEqual(7 * 24 * 60 * 60 * 1000 - 1000);
+  });
+});
+
+describe('reconcileLanIp', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockEnsureAgent = agentManager.ensureAgent as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockGetConfig = getConfig as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockUpdateConfig = updateConfig as any;
+
+  function fakeAgent(stdout: string, code = 0) {
+    return { sendCommand: vi.fn().mockResolvedValue({ code, stdout }) };
+  }
+
+  beforeEach(() => {
+    mockEnsureAgent.mockReset();
+    mockGetConfig.mockReset();
+    mockUpdateConfig.mockReset();
+  });
+
+  it('writes the install-time IP on first run with no stored value', async () => {
+    mockEnsureAgent.mockResolvedValue(fakeAgent('192.168.1.50\n'));
+    mockGetConfig.mockResolvedValue({ reverseProxy: {} });
+    const ip = await reconcileLanIp('Local');
+    expect(ip).toBe('192.168.1.50');
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      reverseProxy: { lanIp: '192.168.1.50', lanIpHistory: [] },
+    });
+  });
+
+  it('no-ops when current IP matches stored', async () => {
+    mockEnsureAgent.mockResolvedValue(fakeAgent('10.0.0.5'));
+    mockGetConfig.mockResolvedValue({
+      reverseProxy: { lanIp: '10.0.0.5', lanIpHistory: [] },
+    });
+    const ip = await reconcileLanIp('Local');
+    expect(ip).toBe('10.0.0.5');
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('appends the previous IP to history when it changes', async () => {
+    mockEnsureAgent.mockResolvedValue(fakeAgent('10.0.0.6'));
+    mockGetConfig.mockResolvedValue({
+      reverseProxy: { lanIp: '10.0.0.5', lanIpHistory: [] },
+    });
+    const ip = await reconcileLanIp('Local');
+    expect(ip).toBe('10.0.0.6');
+    const call = mockUpdateConfig.mock.calls[0][0];
+    expect(call.reverseProxy.lanIp).toBe('10.0.0.6');
+    expect(call.reverseProxy.lanIpHistory).toHaveLength(1);
+    expect(call.reverseProxy.lanIpHistory[0].ip).toBe('10.0.0.5');
+  });
+
+  it('returns null and writes nothing when detection fails', async () => {
+    mockEnsureAgent.mockResolvedValue(fakeAgent('', 1));
+    mockGetConfig.mockResolvedValue({ reverseProxy: { lanIp: '10.0.0.5' } });
+    const ip = await reconcileLanIp('Local');
+    expect(ip).toBeNull();
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/lanIp.ts
+++ b/src/lib/lanIp.ts
@@ -16,6 +16,8 @@
  */
 
 import { agentManager } from '@/lib/agent/manager';
+import { getConfig, updateConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
 
 /** Probe the agent for ServiceBay's outbound LAN IP. */
 export async function detectLanIp(node: string): Promise<string | null> {
@@ -32,6 +34,49 @@ export async function detectLanIp(node: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Persist ServiceBay's LAN IP to config. Called at boot from server.ts
+ * so the install-time value (and subsequent changes) actually land in
+ * `config.reverseProxy.lanIp` — without this, the
+ * `lan_ip_changed_since_install` and `router_dns_not_pointing` probes
+ * stay permanently in the `info` "no install-time value recorded yet"
+ * state. See #318.
+ *
+ *   - First call (no stored value): write current IP, no history entry.
+ *   - Subsequent boots, IP unchanged: no-op.
+ *   - IP changed: append the *previous* IP to history (with the time
+ *     this run detected the change) so `recentChanges()` can flag
+ *     drift, and update the stored value.
+ *
+ * Returns the persisted IP, or `null` when detection failed (in which
+ * case nothing is written — leaves the previous value alone so a brief
+ * detection blip doesn't drop a real install-time value).
+ */
+export async function reconcileLanIp(node: string): Promise<string | null> {
+  const current = await detectLanIp(node);
+  if (!current) return null;
+  const config = await getConfig();
+  const stored = config.reverseProxy?.lanIp;
+  if (stored === current) return current;
+
+  const history = [...(config.reverseProxy?.lanIpHistory ?? [])];
+  if (stored && stored !== current) {
+    history.push({ ip: stored, detectedAt: new Date().toISOString() });
+  }
+  await updateConfig({
+    reverseProxy: {
+      lanIp: current,
+      lanIpHistory: history,
+    },
+  });
+  if (!stored) {
+    logger.info('lanIp', `Captured install-time LAN IP: ${current}`);
+  } else {
+    logger.info('lanIp', `LAN IP changed: ${stored} → ${current}`);
+  }
+  return current;
 }
 
 /** Format a yymmdd-cutoff for "the last N days." */

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -144,6 +144,10 @@ def main() -> int:
         time.sleep(5)
     if not seeded:
         log("⚠️ Could not pre-seed FileBrowser admin after 3 minutes. Run `podman exec file-share-filebrowser filebrowser users add <user> _ --perm.admin --database /database/filebrowser.db` once the pod is up.")
+        # Non-zero exit so the post-deploy run record + diagnose probe
+        # (post_deploy_failed) surface this. Otherwise the failure
+        # silently disappears with the install log scroll. See #317.
+        return 1
 
     return 0
 

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -97,6 +97,21 @@ spec:
     securityContext:
       runAsUser: 0
       runAsGroup: 0
+    # The filebrowser image's HEALTHCHECK runs healthcheck.sh, which
+    # probes `http://${FB_ADDRESS:-localhost}:${FB_PORT}/health`. When
+    # those envs aren't set the script falls back to reading
+    # `/config/settings.json` — but our config file is
+    # `/config/.filebrowser.json` (legacy `--config=` style), so the
+    # script's jq lookup fails, PORT comes out empty, and the probe
+    # always fails. `podman ps` then shows `(unhealthy)` even though
+    # filebrowser is serving fine through NPM. Setting FB_PORT +
+    # FB_ADDRESS here gives the healthcheck.sh what it needs without
+    # changing the config-file shape — closes #319.
+    env:
+      - name: FB_PORT
+        value: "{{FILEBROWSER_PORT}}"
+      - name: FB_ADDRESS
+        value: "127.0.0.1"
     args:
       - "--config=/config/.filebrowser.json"
       - "--database=/database/filebrowser.db"

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -280,6 +280,50 @@ class FileShareScript(unittest.TestCase):
         self.assertIn("Samba (file-share)", services)
         self.assertIn("FileBrowser admin", out)
 
+    def test_returns_nonzero_when_seed_times_out(self):
+        """If /api/system/filebrowser/init never accepts the seed within
+        the 3-minute budget, the script must exit non-zero so the
+        post-deploy run record + diagnose probe surface the failure
+        (regression-guard for #317)."""
+        m = load_script("file-share")
+        # 0 → urllib treats it as a connection failure; the script's
+        # post_json catches URLError and returns (0, None), which the
+        # main loop reads as "not seeded yet" and keeps retrying.
+        responses = {
+            "/api/system/filebrowser/init": {"status": 0, "body": None},
+        }
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "FILEBROWSER_ADMIN_USER": "admin",
+            "SB_NODE": "Local",
+        }
+        # Patch time.time so the deadline expires immediately and we
+        # don't actually wait three minutes for the test.
+        import urllib.request
+        import subprocess as subprocess_mod
+        import time as time_mod
+
+        class _FakeCompletedProcess:
+            returncode = 0
+            stdout = "Running"
+            stderr = ""
+
+        # First call inside main() reads the start-of-budget; subsequent
+        # calls must be > deadline so the while-loop exits on the first
+        # iteration.
+        time_calls = iter([0.0, 0.0, 0.0, 10_000.0])
+        def fake_time(): return next(time_calls, 10_000.0)
+
+        with run_with_env(env), \
+             mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)), \
+             mock.patch.object(time_mod, "sleep", lambda _s: None), \
+             mock.patch.object(time_mod, "time", fake_time), \
+             mock.patch.object(subprocess_mod, "run", lambda *a, **kw: _FakeCompletedProcess()):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 1)
+        self.assertIn("Could not pre-seed FileBrowser admin", out)
+
 
 class MediaScript(unittest.TestCase):
     def test_no_passwords_emits_nothing_and_returns_zero(self):


### PR DESCRIPTION
Bundles the three fixes from the post-install audit on 192.168.178.100.

## #317 — file-share post-deploy now returns 1 on seed timeout

Before: \`⚠️ Could not pre-seed FileBrowser admin after 3 minutes\` was logged but the script returned 0, so the post-deploy run was recorded as exit=0 and the \`post_deploy_failed\` diagnose probe stayed green.

After: the not-seeded branch returns 1, so the failure surfaces in both the run record and the diagnose probe. Locked in by \`test_returns_nonzero_when_seed_times_out\`.

## #318 — LAN IP captured + reconciled at boot

Before: \`config.reverseProxy.lanIp\` was never written. \`lan_ip_changed_since_install\` and \`router_dns_not_pointing\` both permanently degraded to "no install-time value recorded yet" — the FritzBox-DNS probe couldn't compare DHCP option-6 against a known IP.

After: new \`reconcileLanIp()\` in \`src/lib/lanIp.ts\`:
- writes the current IP on first run when no stored value exists,
- no-ops when matching,
- pushes the previous IP onto \`lanIpHistory[]\` when it changes.

Wired into \`server.ts\` boot (deferred 60 s so the Local agent has time to come up). Best-effort — a missing IP leaves the previous stored value alone. 4 new tests.

## #319 — \`file-share-filebrowser\` will report healthy

Root cause: the filebrowser image's [healthcheck.sh](https://github.com/filebrowser/filebrowser/blob/master/docker/common/healthcheck.sh) does:

\`\`\`sh
PORT=\${FB_PORT:-\$(jq -r .port /config/settings.json)}
ADDRESS=\${FB_ADDRESS:-\$(jq -r .address /config/settings.json)}
ADDRESS=\${ADDRESS:-localhost}
wget -q --spider http://\$ADDRESS:\$PORT/health || exit 1
\`\`\`

We mount the config as \`/config/.filebrowser.json\` (legacy \`--config=\` flag style), so the \`jq\` lookup fails → \`PORT\` empty → \`wget http://localhost:/health\` fails → \`podman ps\` shows \`(unhealthy)\` even though filebrowser is serving fine through NPM. Adding \`FB_PORT\` + \`FB_ADDRESS\` env vars on the container gives the script what it needs without restructuring the config file.

## Test plan

- [x] \`npx vitest run\` — 490 passed, 1 skipped
- [x] \`npm run lint\`, \`npm run knip\`, \`npm run build\` — clean
- [ ] After merge + reinstall: \`podman ps\` shows file-share-filebrowser as \`healthy\`, diagnose surfaces install-time LAN IP, file-share post-deploy failure (if any) appears in diagnose

Closes #317, #318, #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)