### PR TITLE
feat: redact MCP secrets + LAN-only bootstrap token (#321, #322)

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -967,6 +967,20 @@ prompt_secret() {
   done
 }
 
+# Prompt for an *optional* secret. No "Confirm:" pass — the operator
+# is pasting a value they already generated locally (e.g. via
+# `openssl rand -hex 32`) and they keep the cleartext on their side.
+# Empty input means "skip" — the calling code treats that as "no
+# bootstrap token, MCP-during-install disabled".
+prompt_optional_secret() {
+  local var_name="$1"; shift
+  local prompt_text="$1"; shift
+  local value
+  read -r -s -p "$prompt_text: " value || true
+  echo
+  printf -v "$var_name" '%s' "$value"
+}
+
 # --- Load / save settings ---
 load_setting() {
   local key="$1"
@@ -1108,6 +1122,20 @@ if $USE_SAVED; then
   if [[ "${ENABLE_EMAIL^^}" =~ ^Y ]]; then
     prompt_secret EMAIL_PASS "SMTP password ($EMAIL_USER)"
   fi
+
+  # Bootstrap MCP token (#322): optional, LAN-only, read-only,
+  # 30 minutes of usable life from first server boot. If the operator
+  # leaves it empty we don't write anything — they'll mint MCP tokens
+  # via the dashboard later. To enable: paste a token they generated
+  # locally (e.g. `openssl rand -hex 32`) — the script SHA-256s it
+  # before writing into config.json so the cleartext never leaves the
+  # operator's terminal.
+  echo ""
+  echo "Optional: MCP bootstrap token for install-time diagnostics."
+  echo "  - Generate locally with: openssl rand -hex 32"
+  echo "  - Read-only, LAN-only, 30 minutes from first boot."
+  echo "  - Press Enter to skip (you can mint MCP tokens later via the dashboard)."
+  prompt_optional_secret SERVICEBAY_BOOTSTRAP_TOKEN "Paste bootstrap token (or Enter to skip)"
 
   # Backup restore (also available in saved-settings mode)
   echo ""
@@ -1277,12 +1305,30 @@ else
   else
     BACKUP_FILE=""
   fi
+
+  # Bootstrap MCP token (#322) — same prompt as the saved-settings
+  # branch above, repeated here for the full-interactive path.
+  echo ""
+  echo "Optional: MCP bootstrap token for install-time diagnostics."
+  echo "  - Generate locally with: openssl rand -hex 32"
+  echo "  - Read-only, LAN-only, 30 minutes from first boot."
+  echo "  - Press Enter to skip (you can mint MCP tokens later via the dashboard)."
+  prompt_optional_secret SERVICEBAY_BOOTSTRAP_TOKEN "Paste bootstrap token (or Enter to skip)"
 fi
 
 # --- Save settings for next run ---
 save_settings
 
 PASSWORD_HASH="$(printf '%s' "$HOST_PASSWORD" | openssl passwd -6 -stdin)"
+
+# Hash the optional bootstrap token (#322). The cleartext stays on the
+# operator's box — only the SHA-256 hex hash lands in config.json. We
+# don't echo or save the cleartext anywhere.
+SERVICEBAY_BOOTSTRAP_TOKEN_HASH=""
+if [[ -n "${SERVICEBAY_BOOTSTRAP_TOKEN:-}" ]]; then
+  SERVICEBAY_BOOTSTRAP_TOKEN_HASH="$(printf '%s' "$SERVICEBAY_BOOTSTRAP_TOKEN" | openssl dgst -sha256 -hex | awk '{print $NF}')"
+  unset SERVICEBAY_BOOTSTRAP_TOKEN  # don't keep cleartext in env
+fi
 
 # Properly escape arbitrary strings as JSON literals — prevents user-supplied
 # values (passwords, hostnames, email addresses) from breaking the JSON or
@@ -1292,11 +1338,25 @@ json_str() {
   python3 -c 'import json,sys;print(json.dumps(sys.argv[1]))' "$1"
 }
 
+# Build the auth block. If the operator pasted a bootstrap token, the
+# SHA-256 hash + scope='read' are inlined — the server reads it on
+# first boot, lazy-initializes expiresAt to first-boot + 30 min, then
+# uses it to authenticate LAN-only read-scope MCP requests until the
+# operator mints their first dashboard token. See #322.
+AUTH_BLOCK='"username": '"$(json_str "$SERVICEBAY_ADMIN_USER")"
+if [[ -n "${SERVICEBAY_BOOTSTRAP_TOKEN_HASH:-}" ]]; then
+  AUTH_BLOCK+=',
+    "bootstrapToken": {
+      "hash": '"$(json_str "$SERVICEBAY_BOOTSTRAP_TOKEN_HASH")"',
+      "scope": "read"
+    }'
+fi
+
 # Build ServiceBay config.json (with optional sections)
 SERVICEBAY_CONFIG='{
   "serverName": '"$(json_str "$SERVER_NAME")"',
   "auth": {
-    "username": '"$(json_str "$SERVICEBAY_ADMIN_USER")"'
+    '"$AUTH_BLOCK"'
   },
   "autoUpdate": {
     "enabled": true,

--- a/server.ts
+++ b/server.ts
@@ -32,6 +32,7 @@ import { logger } from './src/lib/logger';
 import { migrateConfig, getConfig, updateConfig } from './src/lib/config';
 import { syncRegistries } from './src/lib/registry';
 import { reconcileLanIp } from './src/lib/lanIp';
+import { lazyInitializeExpiry as initBootstrapTokenExpiry } from './src/lib/mcp/bootstrapToken';
 import { createMcpServer } from './src/lib/mcp/server';
 import { scheduleBackup } from './src/lib/backup/service';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -195,12 +196,22 @@ app.prepare().then(() => {
         // Token path is preferred; cookie kept for back-compat with clients
         // that connected before tokens existed.
         const { verifyToken } = await import('./src/lib/mcp/tokens');
+        const { verifyBootstrapToken } = await import('./src/lib/mcp/bootstrapToken');
         const authHeader = req.headers.authorization || '';
         const bearerMatch = authHeader.match(/^Bearer\s+(\S+)$/i);
         let auth: { user: string; scopes: import('./src/lib/mcp/tokens').ApiScope[]; tokenId?: string } | null = null;
         if (bearerMatch) {
           const t = await verifyToken(bearerMatch[1]);
           if (t) auth = { user: `token:${t.name}`, scopes: t.scopes, tokenId: t.id };
+          // Bootstrap token (#322): only valid bearer that doesn't
+          // match the sb_<id>_<secret> shape. Always read-only, always
+          // LAN-only, always TTL'd. The verifier handles all three
+          // gates — server.ts just hands off remoteAddress.
+          if (!auth) {
+            const remoteIp = (req.socket?.remoteAddress) ?? undefined;
+            const bt = await verifyBootstrapToken(bearerMatch[1], remoteIp);
+            if (bt) auth = bt;
+          }
         }
         if (!auth) {
           const session = await getSessionFromCookieHeader(req.headers.cookie);
@@ -498,6 +509,13 @@ app.prepare().then(() => {
 
     // Sync template registries in background (non-blocking)
     syncRegistries().catch(err => logger.warn('Server', `Registry sync failed: ${err}`));
+
+    // Bootstrap-token TTL initialisation (#322). Idempotent: only
+    // writes expiresAt when the install script left a hash but no
+    // expiry; subsequent boots see expiresAt already set and skip.
+    initBootstrapTokenExpiry().catch(err =>
+      logger.warn('Server', `Bootstrap-token expiry init failed: ${err instanceof Error ? err.message : String(err)}`),
+    );
 
     // LAN IP reconcile (#318). Captures the install-time IP on first
     // boot and updates the stored value (with history) when the IP

--- a/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -88,6 +88,33 @@ export default function McpSection() {
       .finally(() => setAuditLoading(false));
   };
 
+  // ── Bootstrap-token state (#322) ──────────────────────────────────
+  // The hash is set by the install script; this UI just reflects
+  // status + offers a manual revoke. Auto-revoked when the operator
+  // mints their first regular MCP token below.
+  type BootstrapStatus =
+    | { active: false }
+    | { active: true; expiresAt: string | null; minutesRemaining: number | null };
+  const [bootstrap, setBootstrap] = useState<BootstrapStatus | null>(null);
+  const [revokingBootstrap, setRevokingBootstrap] = useState(false);
+
+  const loadBootstrap = () => {
+    fetch('/api/system/mcp-bootstrap')
+      .then(r => r.ok ? r.json() : { active: false })
+      .then((data: BootstrapStatus) => setBootstrap(data))
+      .catch(() => setBootstrap({ active: false }));
+  };
+
+  const revokeBootstrap = async () => {
+    setRevokingBootstrap(true);
+    try {
+      await fetch('/api/system/mcp-bootstrap', { method: 'DELETE' });
+      loadBootstrap();
+    } finally {
+      setRevokingBootstrap(false);
+    }
+  };
+
   // ── API token state ──────────────────────────────────────────────
   const [tokensOpen, setTokensOpen] = useState(false);
   const [tokens, setTokens] = useState<TokenView[] | null>(null);
@@ -123,6 +150,9 @@ export default function McpSection() {
       setNewScopes(['read']);
       setShowCreate(false);
       loadTokens();
+      // Server-side createToken auto-revokes the bootstrap token —
+      // refresh the panel so the operator sees it disappear.
+      loadBootstrap();
     } catch (e) {
       setCreateError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -150,8 +180,16 @@ export default function McpSection() {
 
   useEffect(() => {
     // Read window.location after mount to avoid SSR/hydration mismatch.
-     
+
     setMcpUrl(`${window.location.origin}/mcp`);
+    // Bootstrap-token status (#322) loads alongside the rest of the
+    // panel so a fresh-install operator sees the active bootstrap
+    // banner without having to expand a sub-section.
+    fetch('/api/system/mcp-bootstrap')
+      .then(r => r.ok ? r.json() : { active: false })
+      .then((data: BootstrapStatus) => setBootstrap(data))
+      .catch(() => setBootstrap({ active: false }));
+
   }, []);
 
   useEffect(() => {
@@ -213,6 +251,28 @@ export default function McpSection() {
           label="How to connect"
         />
       </div>
+
+      {bootstrap?.active && (
+        <div className="mt-4 rounded-lg border border-amber-200 dark:border-amber-700/40 bg-amber-50/80 dark:bg-amber-900/20 px-4 py-3 flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-amber-900 dark:text-amber-200">Bootstrap token active</p>
+            <p className="text-xs text-amber-800/90 dark:text-amber-200/80 mt-0.5">
+              {bootstrap.minutesRemaining !== null
+                ? `LAN-only, read scope, ${bootstrap.minutesRemaining} min remaining.`
+                : 'LAN-only, read scope. Expiry will be set on next server boot.'}
+              {' '}Auto-revokes when you mint your first regular token below.
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={revokingBootstrap}
+            onClick={revokeBootstrap}
+            className="shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg border border-amber-300 dark:border-amber-700 text-amber-900 dark:text-amber-100 bg-white dark:bg-amber-900/40 hover:bg-amber-100 dark:hover:bg-amber-900/60 disabled:opacity-50"
+          >
+            {revokingBootstrap ? 'Revoking…' : 'Revoke now'}
+          </button>
+        </div>
+      )}
 
       <div className="mt-4">
         <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">

--- a/src/app/api/system/mcp-bootstrap/route.ts
+++ b/src/app/api/system/mcp-bootstrap/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import {
+  getBootstrapTokenStatus,
+  revokeBootstrapToken,
+} from '@/lib/mcp/bootstrapToken';
+
+export const dynamic = 'force-dynamic';
+
+/** Surface bootstrap-token state for the Settings UI. The actual hash
+ *  is never returned — only `active`, `expiresAt`, `minutesRemaining`. */
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const status = await getBootstrapTokenStatus();
+    return NextResponse.json(status);
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:mcp-bootstrap:get', status: 500 });
+  }
+}
+
+/** Manual revoke. Idempotent — returns 200 either way so the UI
+ *  doesn't have to special-case "already gone". */
+export async function DELETE(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const removed = await revokeBootstrapToken();
+    return NextResponse.json({ ok: true, removed });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:mcp-bootstrap:delete', status: 500 });
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -179,6 +179,34 @@ export interface AppConfig {
     username?: string;
     /** scrypt-encoded password hash. Use hashPassword() to produce. */
     passwordHash?: string;
+    /**
+     * One-shot LAN-only bootstrap token for MCP. The operator types it
+     * into the install wizard (`install-fedora-coreos.sh`); the script
+     * SHA-256s the cleartext and persists only the hash here. The
+     * server never sees the cleartext.
+     *
+     * Used to bootstrap MCP-based diagnostics during the install
+     * window — before the operator has logged into the dashboard to
+     * mint their first scoped token. Lifecycle:
+     *
+     *   - install: hash written, no expiresAt yet
+     *   - first server boot that observes a hash with no expiresAt:
+     *     persist `expiresAt = now + 30 min`
+     *   - first dashboard-minted MCP token: entire entry deleted
+     *   - operator clicks "revoke bootstrap token": same, immediate
+     *
+     * Validation requires the request originate from RFC1918 / loopback
+     * (see src/lib/mcp/bootstrapToken.ts) and current time < expiresAt.
+     * See #322.
+     */
+    bootstrapToken?: {
+      /** sha256(cleartext) hex, written by the install script */
+      hash: string;
+      /** Always 'read' — the only scope this token gets */
+      scope: 'read';
+      /** Lazy-initialized at first boot to install + 30 min */
+      expiresAt?: string;
+    };
   };
   oidc?: {
     enabled: boolean;

--- a/src/lib/mcp/bootstrapToken.test.ts
+++ b/src/lib/mcp/bootstrapToken.test.ts
@@ -1,0 +1,216 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'crypto';
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
+import {
+  isLanIp,
+  lazyInitializeExpiry,
+  verifyBootstrapToken,
+  revokeBootstrapToken,
+  getBootstrapTokenStatus,
+} from './bootstrapToken';
+import { getConfig, updateConfig } from '@/lib/config';
+
+const mockGetConfig = getConfig as any;
+const mockUpdateConfig = updateConfig as any;
+
+const sha256 = (s: string) => crypto.createHash('sha256').update(s).digest('hex');
+
+beforeEach(() => {
+  mockGetConfig.mockReset();
+  mockUpdateConfig.mockReset();
+});
+
+describe('isLanIp', () => {
+  it('accepts loopback', () => {
+    expect(isLanIp('127.0.0.1')).toBe(true);
+    expect(isLanIp('::1')).toBe(true);
+    expect(isLanIp('::ffff:127.0.0.1')).toBe(true);
+  });
+  it('accepts RFC1918', () => {
+    expect(isLanIp('10.0.0.5')).toBe(true);
+    expect(isLanIp('172.16.0.1')).toBe(true);
+    expect(isLanIp('172.31.255.255')).toBe(true);
+    expect(isLanIp('192.168.178.100')).toBe(true);
+  });
+  it('rejects 172.32.* (just outside RFC1918)', () => {
+    expect(isLanIp('172.32.0.1')).toBe(false);
+    expect(isLanIp('172.15.0.1')).toBe(false);
+  });
+  it('accepts IPv6 ULA + link-local', () => {
+    expect(isLanIp('fc00::1')).toBe(true);
+    expect(isLanIp('fd12::1')).toBe(true);
+    expect(isLanIp('fe80::1')).toBe(true);
+  });
+  it('rejects public IPs', () => {
+    expect(isLanIp('1.1.1.1')).toBe(false);
+    expect(isLanIp('8.8.8.8')).toBe(false);
+    expect(isLanIp('2001:4860:4860::8888')).toBe(false);
+  });
+  it('rejects empty / null', () => {
+    expect(isLanIp('')).toBe(false);
+    expect(isLanIp(undefined)).toBe(false);
+    expect(isLanIp(null)).toBe(false);
+  });
+});
+
+describe('verifyBootstrapToken', () => {
+  it('returns null when no bootstrap-token entry exists', async () => {
+    mockGetConfig.mockResolvedValue({ auth: {} });
+    expect(await verifyBootstrapToken('any-token', '127.0.0.1')).toBeNull();
+  });
+
+  it('rejects requests from non-LAN IPs even with the right token', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: { bootstrapToken: { hash: sha256('right-token'), scope: 'read' } },
+    });
+    expect(await verifyBootstrapToken('right-token', '8.8.8.8')).toBeNull();
+  });
+
+  it('rejects wrong tokens', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: { bootstrapToken: { hash: sha256('right-token'), scope: 'read' } },
+    });
+    expect(await verifyBootstrapToken('wrong-token', '127.0.0.1')).toBeNull();
+  });
+
+  it('rejects expired tokens', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: {
+        bootstrapToken: {
+          hash: sha256('right-token'),
+          scope: 'read',
+          expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        },
+      },
+    });
+    expect(await verifyBootstrapToken('right-token', '127.0.0.1')).toBeNull();
+  });
+
+  it('accepts a correct token from a LAN IP within the window', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: {
+        bootstrapToken: {
+          hash: sha256('right-token'),
+          scope: 'read',
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        },
+      },
+    });
+    const ctx = await verifyBootstrapToken('right-token', '192.168.1.10');
+    expect(ctx).toEqual({
+      user: 'bootstrap',
+      scopes: ['read'],
+      tokenId: 'bootstrap',
+    });
+  });
+
+  it('uses constant-time compare (sanity: rejects same-length wrong hash)', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: { bootstrapToken: { hash: sha256('right-token'), scope: 'read' } },
+    });
+    // Pass a different token whose own hash has the same length (always true
+    // for sha256). The compare should reject.
+    expect(await verifyBootstrapToken('different-token-here', '127.0.0.1')).toBeNull();
+  });
+});
+
+describe('lazyInitializeExpiry', () => {
+  it('writes expiresAt when hash exists but expiresAt is unset', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: { bootstrapToken: { hash: 'abc', scope: 'read' } },
+    });
+    await lazyInitializeExpiry();
+    expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
+    const arg = mockUpdateConfig.mock.calls[0][0];
+    expect(arg.auth.bootstrapToken.hash).toBe('abc');
+    const t = Date.parse(arg.auth.bootstrapToken.expiresAt);
+    // ~30 min from now; allow a 1 min jitter for test slowness
+    expect(t).toBeGreaterThan(Date.now() + 29 * 60_000);
+    expect(t).toBeLessThan(Date.now() + 31 * 60_000);
+  });
+
+  it('no-ops when expiresAt already set', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: {
+        bootstrapToken: {
+          hash: 'abc',
+          scope: 'read',
+          expiresAt: '2099-01-01T00:00:00Z',
+        },
+      },
+    });
+    await lazyInitializeExpiry();
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when no bootstrap-token entry exists', async () => {
+    mockGetConfig.mockResolvedValue({ auth: {} });
+    await lazyInitializeExpiry();
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('revokeBootstrapToken', () => {
+  it('removes the bootstrapToken entry from auth', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: {
+        username: 'admin',
+        passwordHash: 'kept',
+        bootstrapToken: { hash: 'abc', scope: 'read' },
+      },
+    });
+    expect(await revokeBootstrapToken()).toBe(true);
+    const arg = mockUpdateConfig.mock.calls[0][0];
+    expect(arg.auth.bootstrapToken).toBeUndefined();
+    expect(arg.auth.username).toBe('admin');
+    expect(arg.auth.passwordHash).toBe('kept');
+  });
+
+  it('returns false when nothing to revoke', async () => {
+    mockGetConfig.mockResolvedValue({ auth: { username: 'admin' } });
+    expect(await revokeBootstrapToken()).toBe(false);
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('getBootstrapTokenStatus', () => {
+  it('returns inactive when no token', async () => {
+    mockGetConfig.mockResolvedValue({ auth: {} });
+    expect(await getBootstrapTokenStatus()).toEqual({ active: false });
+  });
+
+  it('returns active + minutes remaining when within window', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: {
+        bootstrapToken: {
+          hash: 'abc',
+          scope: 'read',
+          expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+        },
+      },
+    });
+    const s = await getBootstrapTokenStatus();
+    expect(s.active).toBe(true);
+    expect((s as any).minutesRemaining).toBeGreaterThanOrEqual(9);
+    expect((s as any).minutesRemaining).toBeLessThanOrEqual(10);
+  });
+
+  it('returns inactive when expired', async () => {
+    mockGetConfig.mockResolvedValue({
+      auth: {
+        bootstrapToken: {
+          hash: 'abc',
+          scope: 'read',
+          expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        },
+      },
+    });
+    expect(await getBootstrapTokenStatus()).toEqual({ active: false });
+  });
+});

--- a/src/lib/mcp/bootstrapToken.ts
+++ b/src/lib/mcp/bootstrapToken.ts
@@ -1,0 +1,155 @@
+/**
+ * LAN-only bootstrap MCP token (#322).
+ *
+ * The operator types a bootstrap token into the ISO install wizard
+ * (`install-fedora-coreos.sh`). That script SHA-256s the cleartext and
+ * writes only the hash into `config.auth.bootstrapToken.hash`. The
+ * server never sees the cleartext.
+ *
+ * The token solves the chicken-and-egg between "MCP needs a token to
+ * authenticate" and "minting tokens needs a logged-in dashboard
+ * session, which on a fresh install hasn't happened yet" — so the
+ * operator can run install-time diagnostics from Claude/Cursor without
+ * exposing their admin password to a programmatic surface.
+ *
+ * Defence-in-depth (any failure rejects):
+ *   - hash compare via timingSafeEqual
+ *   - expiresAt window — lazy-initialised to first-boot + 30 min
+ *   - request must originate from loopback or RFC1918 / fc00::/7
+ *   - scope is locked to ['read']; tool gates apply as normal
+ *
+ * Lifecycle (config.auth.bootstrapToken):
+ *   install      → { hash, scope: 'read' }
+ *   first boot   → above + { expiresAt }   (set by lazyInitializeExpiry)
+ *   first user-minted MCP token → entry deleted (revoke from tokens.ts)
+ *   manual click → entry deleted (revoke API)
+ *   30 min later → entry stays, validation rejects (expired)
+ */
+
+import crypto from 'crypto';
+import { getConfig, updateConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import type { ApiScope } from './tokens';
+
+const TTL_MIN = 30;
+
+/** Confirm the request comes from a LAN-shaped IP, including the
+ *  loopback addresses. Public addresses are rejected outright — this
+ *  is the first defence layer before the hash check, so the bootstrap
+ *  token can never be exercised from the open internet even if it
+ *  somehow leaked. */
+export function isLanIp(addr: string | undefined | null): boolean {
+  if (!addr) return false;
+  // Strip IPv6-mapped prefix (e.g. ::ffff:192.168.0.1)
+  const ip = addr.replace(/^::ffff:/, '');
+  // IPv4 forms
+  if (/^127\./.test(ip)) return true;
+  if (/^10\./.test(ip)) return true;
+  if (/^192\.168\./.test(ip)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+  // IPv6 forms
+  if (ip === '::1') return true;
+  // RFC4193 ULA: fc00::/7  (matches fc.. and fd..)
+  if (/^f[cd][0-9a-f]{2}:/i.test(ip)) return true;
+  // IPv6 link-local: fe80::/10
+  if (/^fe[89ab][0-9a-f]:/i.test(ip)) return true;
+  return false;
+}
+
+function sha256(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+/**
+ * One-time per-install side effect: when the install script wrote a
+ * `hash` but no `expiresAt`, persist `expiresAt = now + 30 min`.
+ * Subsequent boots see expiresAt already set and leave it alone — so
+ * the 30-min window starts at first boot, not at validate time, and
+ * doesn't reset on reboot.
+ *
+ * Idempotent. Safe to call from server.ts boot.
+ */
+export async function lazyInitializeExpiry(): Promise<void> {
+  const config = await getConfig();
+  const bt = config.auth?.bootstrapToken;
+  if (!bt?.hash) return;
+  if (bt.expiresAt) return;
+  const expiresAt = new Date(Date.now() + TTL_MIN * 60 * 1000).toISOString();
+  await updateConfig({
+    auth: {
+      bootstrapToken: { ...bt, expiresAt },
+    },
+  });
+  logger.info(
+    'mcp:bootstrap',
+    `Initialised bootstrap-token expiry to ${expiresAt} (${TTL_MIN} min from first boot)`,
+  );
+}
+
+/** Try to validate a bearer string as the bootstrap token. Returns the
+ *  synthesized auth context on success, null otherwise. Never throws. */
+export async function verifyBootstrapToken(
+  raw: string,
+  remoteIp: string | undefined,
+): Promise<{ user: string; scopes: ApiScope[]; tokenId: 'bootstrap' } | null> {
+  if (!raw) return null;
+  if (!isLanIp(remoteIp)) return null;
+
+  const config = await getConfig();
+  const bt = config.auth?.bootstrapToken;
+  if (!bt?.hash) return null;
+  if (bt.expiresAt && Date.parse(bt.expiresAt) < Date.now()) return null;
+
+  const incomingHash = Buffer.from(sha256(raw), 'hex');
+  const storedHash = Buffer.from(bt.hash, 'hex');
+  if (incomingHash.length !== storedHash.length) return null;
+  if (!crypto.timingSafeEqual(incomingHash, storedHash)) return null;
+
+  return {
+    user: 'bootstrap',
+    scopes: ['read'],
+    tokenId: 'bootstrap',
+  };
+}
+
+/** Delete the bootstrap-token entry from config. Called from the
+ *  Settings UI, and automatically when the operator mints their first
+ *  named MCP token (see tokens.ts createToken). Returns true iff
+ *  there was something to revoke. */
+export async function revokeBootstrapToken(): Promise<boolean> {
+  const config = await getConfig();
+  if (!config.auth?.bootstrapToken?.hash) return false;
+  // deepMerge in updateConfig only acts on keys present on the source
+  // object, so `delete auth.bootstrapToken` would leave the existing
+  // entry intact. Explicit `undefined` falls through deepMerge's
+  // is-object branch and lands in the result as undefined, which
+  // JSON.stringify drops on save — that's the actual delete.
+  await updateConfig({
+    auth: {
+      ...config.auth,
+      bootstrapToken: undefined,
+    },
+  });
+  logger.info('mcp:bootstrap', 'Bootstrap MCP token revoked.');
+  return true;
+}
+
+/** Surface state for the Settings UI. */
+export async function getBootstrapTokenStatus(): Promise<
+  | { active: false }
+  | { active: true; expiresAt: string | null; minutesRemaining: number | null }
+> {
+  const config = await getConfig();
+  const bt = config.auth?.bootstrapToken;
+  if (!bt?.hash) return { active: false };
+  if (!bt.expiresAt) {
+    return { active: true, expiresAt: null, minutesRemaining: null };
+  }
+  const remainingMs = Date.parse(bt.expiresAt) - Date.now();
+  if (remainingMs <= 0) return { active: false };
+  return {
+    active: true,
+    expiresAt: bt.expiresAt,
+    minutesRemaining: Math.floor(remainingMs / 60_000),
+  };
+}

--- a/src/lib/mcp/redact.test.ts
+++ b/src/lib/mcp/redact.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { redactKubeYaml, redactLogText, redactServiceFiles } from './redact';
+
+describe('redactKubeYaml', () => {
+  it('redacts the value of a *_PASSWORD env entry (two-line YAML)', () => {
+    const input = `
+    env:
+      - name: SHARE_PASSWORD
+        value: "FGhl06NSRwfWbEQhs8vOfnB5yhxRmD9X"
+      - name: SOME_PORT
+        value: "8088"
+`;
+    const out = redactKubeYaml(input);
+    expect(out).toContain('SHARE_PASSWORD');
+    expect(out).not.toContain('FGhl06NSRwfWbEQhs8vOfnB5yhxRmD9X');
+    expect(out).toContain('<redacted>');
+    // Non-sensitive value left alone.
+    expect(out).toContain('"8088"');
+  });
+
+  it('redacts ACCOUNT_* env entries (samba convention)', () => {
+    const input = `
+      - name: ACCOUNT_samba
+        value: "supersecretvalue"
+`;
+    const out = redactKubeYaml(input);
+    expect(out).not.toContain('supersecretvalue');
+    expect(out).toContain('<redacted>');
+  });
+
+  it('redacts *_SECRET, *_TOKEN, *_KEY env entries', () => {
+    const input = `
+      - name: VAULTWARDEN_SSO_SECRET
+        value: "client-secret-here"
+      - name: AGENT_AUTH_TOKEN
+        value: "tok-here"
+      - name: ROOM_KEY
+        value: "key-here"
+      - name: SOMETHING_ELSE
+        value: "kept-as-is"
+`;
+    const out = redactKubeYaml(input);
+    expect(out).not.toContain('client-secret-here');
+    expect(out).not.toContain('tok-here');
+    expect(out).not.toContain('key-here');
+    expect(out).toContain('kept-as-is');
+  });
+
+  it('handles unquoted values', () => {
+    const input = `      - name: API_TOKEN\n        value: rawvalue\n`;
+    const out = redactKubeYaml(input);
+    expect(out).not.toContain('rawvalue');
+    expect(out).toContain('<redacted>');
+  });
+
+  it('redacts JSON-form name/value pairs', () => {
+    const input = `{"env":[{"name":"DB_PASSWORD","value":"hunter2"},{"name":"DB_PORT","value":"5432"}]}`;
+    const out = redactKubeYaml(input);
+    expect(out).not.toContain('hunter2');
+    expect(out).toContain('5432');
+  });
+
+  it('returns empty input unchanged', () => {
+    expect(redactKubeYaml('')).toBe('');
+  });
+});
+
+describe('redactLogText', () => {
+  it('redacts `password: X` log lines', () => {
+    expect(redactLogText('Connecting with password: hunter2'))
+      .toBe('Connecting with password: <redacted>');
+  });
+
+  it('redacts `password=X`', () => {
+    expect(redactLogText('admin password=hunter2'))
+      .toBe('admin password=<redacted>');
+  });
+
+  it('redacts JSON-style `"password":"X"`', () => {
+    const out = redactLogText('{"username":"admin","password":"hunter2"}');
+    expect(out).not.toContain('hunter2');
+    expect(out).toContain('<redacted>');
+    expect(out).toContain('"username":"admin"');
+  });
+
+  it('redacts `--password X` CLI args', () => {
+    expect(redactLogText('podman exec foo --password hunter2 add user'))
+      .toBe('podman exec foo --password <redacted> add user');
+  });
+
+  it('redacts `Bearer <token>`', () => {
+    const out = redactLogText('Authorization: Bearer sb_abc123_XYZ');
+    expect(out).toBe('Authorization: Bearer <redacted>');
+  });
+
+  it('redacts secret/token/api-key variants', () => {
+    expect(redactLogText('secret: abc123')).toContain('<redacted>');
+    expect(redactLogText('token=abc123')).toContain('<redacted>');
+    expect(redactLogText('api_key=abc123')).toContain('<redacted>');
+    expect(redactLogText('apikey: abc123')).toContain('<redacted>');
+  });
+
+  it('leaves unrelated text untouched', () => {
+    const input = 'Listening on 127.0.0.1:8088';
+    expect(redactLogText(input)).toBe(input);
+  });
+
+  it('returns empty input unchanged', () => {
+    expect(redactLogText('')).toBe('');
+  });
+});
+
+describe('redactServiceFiles', () => {
+  it('redacts yamlContent + serviceContent + kubeContent, preserves paths', () => {
+    const input = {
+      kubeContent: '[Kube]\nYaml=file-share.yml\n',
+      yamlContent: '      - name: SHARE_PASSWORD\n        value: "hunter2"\n',
+      serviceContent: 'Environment=PODMAN_SYSTEMD_UNIT=%n',
+      yamlPath: '.config/containers/systemd/file-share.yml',
+      kubePath: '.config/containers/systemd/file-share.kube',
+      servicePath: '/run/user/1000/systemd/generator/file-share.service',
+    };
+    const out = redactServiceFiles(input);
+    expect(out.yamlContent).not.toContain('hunter2');
+    expect(out.yamlContent).toContain('<redacted>');
+    expect(out.yamlPath).toBe(input.yamlPath);
+    expect(out.kubePath).toBe(input.kubePath);
+    expect(out.servicePath).toBe(input.servicePath);
+  });
+});

--- a/src/lib/mcp/redact.ts
+++ b/src/lib/mcp/redact.ts
@@ -1,0 +1,145 @@
+/**
+ * Secret-redaction helpers for MCP read tools (#321).
+ *
+ * Three of the read-scope MCP tools (`get_service_files`,
+ * `get_service_logs`, `get_container_logs`) can otherwise hand back the
+ * very secrets the operator typed into the install wizard:
+ *
+ *  - The kube YAML returned by `get_service_files` has env vars like
+ *    `value: "<rendered SHARE_PASSWORD>"` inline.
+ *  - Service journals catch any post-deploy log line that prints the
+ *    rendered password (legacy 🔑 lines, replaced in #321).
+ *  - Container logs catch the same thing for any service that prints
+ *    its admin pwd at startup (e.g. filebrowser's first-run dump).
+ *
+ * The redactor walks raw text and rewrites recognised secret-looking
+ * patterns to `<redacted>`. Optimised for our template conventions
+ * rather than being heuristically clever — we'd rather over-redact
+ * than under-redact, but we also don't want to break diff readability
+ * for unrelated values.
+ *
+ * Two passes:
+ *
+ * 1. **Named env-var pairs** — kube YAML form. Match `name: SOMETHING`
+ *    followed by `value: X` (across one line or two), where SOMETHING
+ *    matches our convention of `*_PASSWORD`, `*_SECRET`, `*_TOKEN`,
+ *    `*_KEY`, or `ACCOUNT_*`.
+ *
+ * 2. **Inline `key: value` patterns** — log form. Match
+ *    `password[: =] <value>` and friends. Conservative — only matches
+ *    explicit named patterns, not arbitrary 32-char strings (which
+ *    would falsely redact UUIDs, container ids, etc.).
+ */
+
+const SENSITIVE_NAME =
+  /(_PASSWORD|_SECRET|_TOKEN|_KEY|^ACCOUNT_[A-Za-z0-9]+|^PASSWORD$|^SECRET$|^TOKEN$)/;
+
+const REDACTED = '<redacted>';
+
+/**
+ * Redact sensitive env-var pairs in a YAML/JSON-ish blob.
+ *
+ *   - name: SHARE_PASSWORD
+ *     value: "FGhl06NSRwf…"     ← becomes value: "<redacted>"
+ *
+ * Also catches the same shape inline (`name: X, value: Y` on one line)
+ * and the JSON variant (`"name": "X", "value": "Y"`).
+ */
+export function redactKubeYaml(text: string): string {
+  if (!text) return text;
+
+  // Two-line YAML form:
+  //   - name: FOO_PASSWORD
+  //     value: "..."           or   value: ...
+  //
+  // The character class is permissive enough for `ACCOUNT_samba` style
+  // names (uppercase prefix, mixed-case suffix) while staying anchored
+  // to the kube-env-var convention.
+  const twoLine = /(\s*-?\s*name:\s*)(?:["']?)([A-Z][A-Za-z0-9_]*)(?:["']?)(\s*\n\s*value:\s*)(?:["']?)([^\n"']*)(?:["']?)/g;
+  let out = text.replace(twoLine, (match, namePrefix, name, valuePrefix) => {
+    if (!SENSITIVE_NAME.test(name)) return match;
+    return `${namePrefix}${name}${valuePrefix}"${REDACTED}"`;
+  });
+
+  // JSON object form (single line):
+  //   {"name":"FOO_PASSWORD","value":"..."}
+  const jsonForm = /("name"\s*:\s*"([A-Z][A-Za-z0-9_]*)"[^}]*?"value"\s*:\s*")([^"]*)(")/g;
+  out = out.replace(jsonForm, (match, prefix, name, _value, suffix) => {
+    if (!SENSITIVE_NAME.test(name)) return match;
+    return `${prefix}${REDACTED}${suffix}`;
+  });
+
+  return out;
+}
+
+/**
+ * Redact recognised credential patterns inside a free-form log blob.
+ *
+ *   "password: hunter2"           → "password: <redacted>"
+ *   "password=hunter2"            → "password=<redacted>"
+ *   '"password": "hunter2"'       → '"password": "<redacted>"'
+ *   "--password hunter2"          → "--password <redacted>"
+ *
+ * Same set of trigger keywords as the YAML pass, plus a few that are
+ * exclusively log-shaped (not env-var names): `Bearer <token>`,
+ * `apikey=`, `api_key=`.
+ */
+export function redactLogText(text: string): string {
+  if (!text) return text;
+
+  const KEYWORDS = '(?:password|passwd|secret|token|api[_-]?key)';
+
+  let out = text;
+
+  // Order matters: handle quoted-keyword forms (JSON-style) first,
+  // since the unquoted patterns below would otherwise eat just the
+  // keyword and miss the leading `"`.
+
+  // `"password": "X"`  (JSON / quoted keys, with optional whitespace)
+  out = out.replace(
+    new RegExp(`("${KEYWORDS}"\\s*:\\s*)(?:"([^"]*)"|'([^']*)')`, 'gi'),
+    (_m, prefix) => `${prefix}${REDACTED}`,
+  );
+
+  // `password=X`   `password="X"`
+  out = out.replace(
+    new RegExp(`(${KEYWORDS}\\s*=\\s*)(?:"([^"]*)"|'([^']*)'|(\\S+))`, 'gi'),
+    (_m, prefix) => `${prefix}${REDACTED}`,
+  );
+
+  // `password: X`   (unquoted, log/YAML)
+  out = out.replace(
+    new RegExp(`(${KEYWORDS}\\s*:\\s*)(?:"([^"]*)"|'([^']*)'|(\\S+))`, 'gi'),
+    (_m, prefix) => `${prefix}${REDACTED}`,
+  );
+
+  // `--password X`
+  out = out.replace(
+    new RegExp(`(--${KEYWORDS}\\s+)(?:"([^"]*)"|'([^']*)'|(\\S+))`, 'gi'),
+    (_m, prefix) => `${prefix}${REDACTED}`,
+  );
+
+  // `Authorization: Bearer X`
+  out = out.replace(
+    /(Bearer\s+)([^\s"'`]+)/g,
+    (_m, prefix) => `${prefix}${REDACTED}`,
+  );
+
+  return out;
+}
+
+/** Redact a `getServiceFiles` payload — touches yamlContent +
+ *  serviceContent (which can echo the env-vars too via systemctl
+ *  cat output), plus the rendered kube file. Path fields stay as-is. */
+export function redactServiceFiles<T extends {
+  kubeContent?: string;
+  yamlContent?: string;
+  serviceContent?: string;
+}>(files: T): T {
+  return {
+    ...files,
+    kubeContent: redactKubeYaml(files.kubeContent ?? ''),
+    yamlContent: redactKubeYaml(files.yamlContent ?? ''),
+    serviceContent: redactKubeYaml(files.serviceContent ?? ''),
+  };
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -22,6 +22,7 @@ import { restoreSystemBackup } from '@/lib/systemBackup';
 import { guardMutation, guardExec, snapshotBeforeMutation } from './safety';
 import { recordAudit } from './audit';
 import { notifyDestructiveOp } from './notify';
+import { redactLogText, redactServiceFiles } from './redact';
 import type { ApiScope } from './tokens';
 
 interface McpAuthContext {
@@ -273,7 +274,11 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         if (since) args.push('--since', `@${since}`);
         const result = await agent.sendCommand('exec', { command: `journalctl ${args.join(' ')} 2>&1` });
         return textResult({
-          stdout: result.stdout ?? '',
+          // Strip credentials before handing journalctl output back to
+          // the MCP client (#321) — service journals catch any
+          // post-deploy line that prints rendered passwords plus
+          // anything the service itself dumps at startup.
+          stdout: redactLogText(result.stdout ?? ''),
           exitCode: result.code,
           fetchedAt: Math.floor(Date.now() / 1000),
         });
@@ -301,7 +306,8 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         if (since) args.push(`--since ${since}`);
         const result = await agent.sendCommand('exec', { command: `podman logs ${args.join(' ')} ${id} 2>&1` });
         return textResult({
-          stdout: result.stdout ?? '',
+          // Same redaction as get_service_logs — see #321.
+          stdout: redactLogText(result.stdout ?? ''),
           exitCode: result.code,
           fetchedAt: Math.floor(Date.now() / 1000),
         });
@@ -358,7 +364,12 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     async ({ name, node }) => {
       const nodeName = await resolveNode(node);
       const files = await ServiceManager.getServiceFiles(nodeName, name);
-      return textResult(files);
+      // Rendered kube YAML inlines templated `{{X_PASSWORD}}` values.
+      // Redact env entries with sensitive names before returning to the
+      // MCP client (#321). The dashboard's own service-file viewer
+      // doesn't go through this path; it reads from the same source
+      // files but is gated by the admin session.
+      return textResult(redactServiceFiles(files));
     },
   );
 

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -123,6 +123,18 @@ export async function createToken(input: {
   data.tokens.push(token);
   await saveFile(data);
   logger.info('mcp:tokens', `Created MCP token ${id} ("${token.name}") scopes=[${token.scopes.join(',')}] by ${input.createdBy}`);
+
+  // First user-minted MCP token closes the bootstrap-token bridge
+  // (#322). The operator now has a real, scoped credential — keep
+  // the bootstrap entry around any longer is just attack surface.
+  // Best-effort: a failure here doesn't unwind the token-create.
+  try {
+    const { revokeBootstrapToken } = await import('./bootstrapToken');
+    await revokeBootstrapToken();
+  } catch (e) {
+    logger.warn('mcp:tokens', `Could not auto-revoke bootstrap token after first mint: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
   // The clear-text token is `sb_<id>_<secret>` — returned exactly once.
   return { token: publicView(token), secret: `sb_${id}_${secret}` };
 }

--- a/templates/adguard/post-deploy.py
+++ b/templates/adguard/post-deploy.py
@@ -46,7 +46,7 @@ def main() -> int:
         log("⚠️ ADGUARD_ADMIN_PASSWORD missing — first-login won't work; reset via the AdGuard Home setup wizard at http://<server-ip>:" + port)
         return 0
 
-    log(f"🔑 AdGuard admin (user: {user}, password: {password}) — open http://{host}:{port}. Note now, only shown once.")
+    log(f"✅ AdGuard admin saved (user: {user}) — open http://{host}:{port}. Password retrievable from Settings → Integrations → Saved credentials.")
     emit_credential(
         service="AdGuard Home",
         url=f"http://{host}:{port}",

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -117,9 +117,12 @@ def main() -> int:
         timeout=10,
     )
     if persist_status == 200:
-        log(f"🔑 LLDAP admin (user: admin, password: {lldap_password}) — open http://{host}:{lldap_port} or via NPM. Stored in Settings → Integrations.")
+        log(f"✅ LLDAP admin saved (user: admin) — open http://{host}:{lldap_port} or via NPM. Password retrievable from Settings → Integrations → Saved credentials.")
     else:
-        log(f"⚠️ Could not persist LLDAP credentials (HTTP {persist_status}). Note now: admin / {lldap_password}")
+        # Even on persist failure, the password still lands in the wizard
+        # banner via emit_credential below — keep the warning short and
+        # don't echo the secret into journalctl.
+        log(f"⚠️ Could not persist LLDAP credentials (HTTP {persist_status}). Password is still shown in the post-install credential banner.")
 
     emit_credential(
         service="LLDAP (User Directory)",

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -96,7 +96,7 @@ def main() -> int:
     share_user = env("SHARE_USER", "samba")
     share_password = env("SHARE_PASSWORD")
     if share_password:
-        log(f"🔑 Samba share (user: {share_user}, password: {share_password}) — mount via \\\\{host}\\data on Windows or smb://{host}/data on macOS. Note now, only shown once.")
+        log(f"✅ Samba share saved (user: {share_user}) — mount via \\\\{host}\\data on Windows or smb://{host}/data on macOS. Password retrievable from Settings → Integrations → Saved credentials.")
         emit_credential(
             service="Samba (file-share)",
             url=f"\\\\{host}\\data",

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -136,7 +136,7 @@ def main() -> int:
     abs_password = env("ABS_ADMIN_PASSWORD")
     abs_port = env("ABS_PORT", "13378")
     if abs_password:
-        log(f"🔑 Audiobookshelf admin (user: {abs_user}, password: {abs_password}) — open http://{host}:{abs_port}. Note now, only shown once.")
+        log(f"✅ Audiobookshelf admin saved (user: {abs_user}) — open http://{host}:{abs_port}. Password retrievable from Settings → Integrations → Saved credentials.")
         emit_credential(
             service="Audiobookshelf",
             url=f"http://{host}:{abs_port}",
@@ -151,7 +151,7 @@ def main() -> int:
     nd_password = env("NAVIDROME_ADMIN_PASSWORD")
     nd_port = env("NAVIDROME_PORT", "4533")
     if nd_password:
-        log(f"🔑 Navidrome admin (user: {nd_user}, password: {nd_password}) — open http://{host}:{nd_port}. Subsonic clients (Symfonium etc.) use the same credentials.")
+        log(f"✅ Navidrome admin saved (user: {nd_user}) — open http://{host}:{nd_port}. Subsonic clients (Symfonium etc.) use the same credentials. Password retrievable from Settings → Integrations → Saved credentials.")
         emit_credential(
             service="Navidrome",
             url=f"http://{host}:{nd_port}",

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -130,7 +130,16 @@ class AdguardScript(unittest.TestCase):
         self.assertEqual(creds[0]["username"], "admin")
         self.assertEqual(creds[0]["password"], "s3cret")
         self.assertEqual(creds[0]["url"], "http://192.168.1.10:8083")
-        self.assertIn("password: s3cret", out)
+        # Password must NOT leak into the user-visible log line — it
+        # only travels via the __SB_CREDENTIAL__ JSON marker, which
+        # ServiceBay stores encrypted (#321).
+        # Strip credential markers before checking, since the JSON line
+        # legitimately contains the password.
+        log_only = "\n".join(
+            line for line in out.splitlines()
+            if not line.startswith("__SB_CREDENTIAL__ ")
+        )
+        self.assertNotIn("s3cret", log_only)
 
     def test_no_password_skips_credential_silently(self):
         m = load_script("adguard")
@@ -236,6 +245,14 @@ class AuthScript(unittest.TestCase):
         services = {c["service"] for c in creds}
         self.assertIn("LLDAP (User Directory)", services)
         self.assertIn("LLDAP JWT secret", services)
+        # The LLDAP admin password and JWT secret must travel only via
+        # __SB_CREDENTIAL__ markers, not user-visible log lines (#321).
+        log_only = "\n".join(
+            line for line in out.splitlines()
+            if not line.startswith("__SB_CREDENTIAL__ ")
+        )
+        self.assertNotIn("lldap-pass", log_only)
+        self.assertNotIn("jwt-secret", log_only)
 
 
 class FileShareScript(unittest.TestCase):
@@ -279,6 +296,14 @@ class FileShareScript(unittest.TestCase):
         services = {c["service"] for c in creds}
         self.assertIn("Samba (file-share)", services)
         self.assertIn("FileBrowser admin", out)
+        # The Samba password must NOT leak into the user-visible log
+        # line (#321). It still ships in the __SB_CREDENTIAL__ marker
+        # for the wizard banner + encrypted store.
+        log_only = "\n".join(
+            line for line in out.splitlines()
+            if not line.startswith("__SB_CREDENTIAL__ ")
+        )
+        self.assertNotIn("shar3", log_only)
 
     def test_returns_nonzero_when_seed_times_out(self):
         """If /api/system/filebrowser/init never accepts the seed within
@@ -356,6 +381,14 @@ class MediaScript(unittest.TestCase):
         services = {c["service"] for c in parse_credentials(out)}
         self.assertIn("Audiobookshelf", services)
         self.assertIn("Navidrome", services)
+        # Neither admin password may leak into user-visible log lines
+        # (#321) — only travel via __SB_CREDENTIAL__ markers.
+        log_only = "\n".join(
+            line for line in out.splitlines()
+            if not line.startswith("__SB_CREDENTIAL__ ")
+        )
+        self.assertNotIn("abs-pass", log_only)
+        self.assertNotIn("nav-pass", log_only)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two security improvements that came out of the post-install audit on 192.168.178.100.

## #321 — secrets redaction in logs + MCP read tools

**Post-deploy scripts** no longer print plaintext passwords in their user-facing log lines. The credentials still travel via the \`__SB_CREDENTIAL__\` JSON marker into the encrypted Saved Credentials store; we just stop dumping them into journalctl / MCP \`get_*_logs\`. Touched: adguard, auth (LLDAP), file-share (samba), media (abs + navidrome).

**MCP read tools** now run output through \`src/lib/mcp/redact.ts\`:
- \`get_service_files\` had \`{{X_PASSWORD}}\` expanded inline in the kube YAML. \`redactKubeYaml\` masks env entries whose \`name\` matches \`*_PASSWORD\` / \`*_SECRET\` / \`*_TOKEN\` / \`*_KEY\` / \`ACCOUNT_*\`.
- \`get_service_logs\` + \`get_container_logs\` get \`redactLogText\`, which catches \`password: X\`, \`password=X\`, \`--password X\`, \`"password":"X"\` JSON, and \`Bearer <token>\`.

15 unit tests for the redactor + regression guards in the post-deploy script tests so future templates can't reintroduce the leak.

## #322 — LAN-only bootstrap MCP token

Closes the chicken-and-egg of "MCP needs a token to authenticate, but minting tokens needs a logged-in dashboard, which a fresh-install operator hasn't reached yet." Lets you run install-time diagnostics from Claude/Cursor without exposing the admin password to a programmatic surface.

**How it works.** \`install-fedora-coreos.sh\` now offers an optional \`prompt_optional_secret\` for a bootstrap token. The operator types a value they generated locally (e.g. \`openssl rand -hex 32\`); the script SHA-256s it and bakes the hash into \`config.json\` under \`auth.bootstrapToken\`. The server never sees the cleartext.

**Validation gates** (in \`src/lib/mcp/bootstrapToken.ts\`, called from server.ts MCP auth):
1. SHA-256 + \`crypto.timingSafeEqual\` against the stored hash
2. Request must originate from \`127.0.0.1\` / \`::1\` / RFC1918 / \`fc00::/7\` / \`fe80::/10\`
3. Current time < \`expiresAt\` (lazy-initialised at first server boot to \`now + 30 min\` — reboot doesn't extend the window)
4. Scope locked to \`['read']\`

**Lifecycle.** Auto-revoked when the operator mints their first regular MCP token in Settings → MCP, or via the new "Revoke now" button on the bootstrap banner. 20 tests cover the IP filter, hash compare, expiry, lazy-init, and revoke paths.

**UI.** Small amber banner at the top of Settings → MCP showing "Bootstrap token active — N min remaining" with a revoke button. Disappears as soon as the bootstrap is gone.

## Test plan

- [x] \`npx vitest run\` — 525 passed, 1 skipped
- [x] \`npm run lint\`, \`npm run knip\`, \`npm run build\` — clean
- [x] \`bash -n install-fedora-coreos.sh\` — clean
- [ ] After merge + reinstall:
  - [ ] Bootstrap-token prompt appears in install-fedora-coreos.sh; pasting one + finishing install lands a hash in \`config.json\` and no cleartext anywhere on disk
  - [ ] Curl against \`/mcp\` with the cleartext bearer works for read tools, fails for non-LAN IPs, fails after 30 min
  - [ ] Minting a regular MCP token via Settings → MCP makes the bootstrap banner disappear
  - [ ] \`get_service_files\` returns \`<redacted>\` for password env entries; logs no longer leak \`password: …\`

Closes #321, #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)