### PR TITLE
chore(install): drop dead autoUpdate.channel from config.json

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -1361,8 +1361,7 @@ SERVICEBAY_CONFIG='{
   },
   "autoUpdate": {
     "enabled": true,
-    "schedule": "0 0 * * *",
-    "channel": '"$(json_str "$SERVICEBAY_CHANNEL")"'
+    "schedule": "0 0 * * *"
   },
   "templateSettings": {
     "DATA_DIR": '"$(json_str "$DATA_ROOT/stacks")"'


### PR DESCRIPTION
The install script writes \`"channel": <stable|dev|test>\` into \`config.json\` under \`autoUpdate\`, but **no runtime code reads it.** \`AppConfig.autoUpdate\` in \`src/lib/config.ts\` has no \`channel\` field, so flipping it in the dashboard would change nothing today.

Channel selection is install-time-only — it drives \`SERVICEBAY_VERSION\` in the Quadlet \`Image=\` line. That part stays untouched. This PR just removes the dead write so the install path is honest about what it actually controls.

If we later want runtime channel-switching (rewrite \`Image=\` + restart container on channel change), that's a separate feature with its own config field.

## Test plan

- [x] \`bash -n install-fedora-coreos.sh\` — clean
- [x] Diff is one line removed + one trailing comma — same JSON shape minus the dead key

🤖 Generated with [Claude Code](https://claude.com/claude-code)