### PR TITLE
feat(settings): Gateway (FritzBox) edit section + fix wrong link (#333)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/GatewaySection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/GatewaySection.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Router, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+interface GatewayState {
+  configured: boolean;
+  type: string | null;
+  host: string;
+  username: string;
+  hasPassword: boolean;
+  ssl: boolean;
+}
+
+/**
+ * Settings → Gateway (#333). FritzBox host/username/password edit.
+ *
+ * The install-fedora-coreos.sh writes config.gateway at install time;
+ * before this section, the only way to update it was a full re-install
+ * or hand-editing config.json on the box. The "Edit Gateway" button
+ * on the Internet-Gateway card also linked here-but-wrongly to
+ * /registry?selected=gateway — that link is fixed in this same PR.
+ */
+export default function GatewaySection() {
+  const { addToast } = useToast();
+  const [state, setState] = useState<GatewayState | null>(null);
+  const [busy, setBusy] = useState<'load' | 'save' | 'test' | null>('load');
+  const [host, setHost] = useState('');
+  const [username, setUsername] = useState('');
+  // Empty string means "no change". The placeholder reflects whether a
+  // password is currently stored so the operator knows whether to type.
+  const [password, setPassword] = useState('');
+  const [ssl, setSsl] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/settings/gateway')
+      .then(r => (r.ok ? r.json() : null))
+      .then((data: GatewayState | null) => {
+        if (data) {
+          setState(data);
+          setHost(data.host);
+          setUsername(data.username);
+          setSsl(data.ssl);
+        }
+      })
+      .finally(() => setBusy(null));
+  }, []);
+
+  const submit = async (test: boolean) => {
+    if (!host.trim()) {
+      addToast('error', 'Host is required');
+      return;
+    }
+    setBusy(test ? 'test' : 'save');
+    try {
+      const res = await fetch('/api/settings/gateway', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          host: host.trim(),
+          username: username.trim(),
+          password,
+          ssl,
+          test,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        addToast(
+          'error',
+          test ? 'Connection test failed' : 'Could not save gateway',
+          data.message || data.error || `HTTP ${res.status}`,
+        );
+        return;
+      }
+      addToast(
+        'success',
+        test ? 'Connected — credentials saved' : 'Gateway saved',
+      );
+      // Refresh to reset the password placeholder + reflect new hasPassword
+      const refreshed = await fetch('/api/settings/gateway').then(r => r.ok ? r.json() : null);
+      if (refreshed) setState(refreshed);
+      setPassword('');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (busy === 'load' || !state) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading gateway settings…
+      </div>
+    );
+  }
+
+  return (
+    <div id="gateway" className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400">
+          <Router size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">Internet Gateway (FritzBox)</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Credentials for TR-064 access — used to read external IP, port-forward status, and (with the router-DNS probe) push DHCP-DNS settings.
+          </p>
+        </div>
+        {state.configured ? (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+            <CheckCircle2 size={14} /> Configured
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+            <AlertCircle size={14} /> Not configured
+          </span>
+        )}
+      </div>
+
+      <div className="p-6 space-y-4">
+        <div className="grid sm:grid-cols-2 gap-4">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Host</span>
+            <input
+              type="text"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+              placeholder="fritz.box or 192.168.178.1"
+              className="p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 rounded text-sm font-mono"
+              autoComplete="off"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Username</span>
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="fritz4554"
+              className="p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 rounded text-sm font-mono"
+              autoComplete="off"
+            />
+          </label>
+          <label className="flex flex-col gap-1 sm:col-span-2">
+            <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Password</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={state.hasPassword ? '•••••••• (leave blank to keep current)' : '(set a password)'}
+              className="p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 rounded text-sm font-mono"
+              autoComplete="new-password"
+            />
+          </label>
+        </div>
+
+        <label className="inline-flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={ssl}
+            onChange={(e) => setSsl(e.target.checked)}
+            className="w-4 h-4"
+          />
+          Use HTTPS for TR-064 (uncommon — most FritzBoxes use unencrypted port 49000)
+        </label>
+
+        <div className="flex gap-2 pt-2">
+          <button
+            onClick={() => submit(true)}
+            disabled={busy !== null}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded disabled:opacity-50"
+          >
+            {busy === 'test' && <Loader2 size={14} className="animate-spin" />}
+            Test connection &amp; save
+          </button>
+          <button
+            onClick={() => submit(false)}
+            disabled={busy !== null}
+            className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-800 dark:text-gray-200 text-sm font-medium rounded disabled:opacity-50"
+            title="Save without testing — useful when the FritzBox is currently unreachable"
+          >
+            {busy === 'save' && <Loader2 size={14} className="animate-spin" />}
+            Save without test
+          </button>
+        </div>
+
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 italic">
+          The TR-064 user needs the &quot;Smart Home&quot; permission in the FritzBox UI (System → FRITZ!Box-Benutzer). The password is stored encrypted at rest in <span className="font-mono">config.gateway.password</span>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -3,6 +3,7 @@
 import AccessRequestsSection from '../_lib/sections/AccessRequestsSection';
 import CredentialsSection from '../_lib/sections/CredentialsSection';
 import EmailNotificationsSection from '../_lib/sections/EmailNotificationsSection';
+import GatewaySection from '../_lib/sections/GatewaySection';
 import McpSection from '../_lib/sections/McpSection';
 import PublicDomainSection from '../_lib/sections/PublicDomainSection';
 import ReverseProxySection from '../_lib/sections/ReverseProxySection';
@@ -13,6 +14,7 @@ export default function IntegrationsSettingsPage() {
   return (
     <>
       <PublicDomainSection />
+      <GatewaySection />
       <AccessRequestsSection />
       <CredentialsSection />
       <ReverseProxySection />

--- a/src/app/api/settings/gateway/route.ts
+++ b/src/app/api/settings/gateway/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getConfig, updateConfig } from '@/lib/config';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { FritzBoxClient } from '@/lib/fritzbox/client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Settings → Gateway (FritzBox) — read + update endpoint (#333).
+ *
+ * Until this PR the only ways to change `config.gateway` were
+ * re-running install-fedora-coreos.sh or hand-editing config.json on
+ * the box. The "Edit Gateway" button on the Internet-Gateway card
+ * also wrongly linked to /registry?selected=gateway (templates).
+ */
+
+/** Read-only view: omit the password (we never echo it back). */
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const config = await getConfig();
+    const gw = config.gateway;
+    return NextResponse.json({
+      configured: !!gw,
+      type: gw?.type ?? null,
+      host: gw?.host ?? '',
+      username: gw?.username ?? '',
+      hasPassword: !!gw?.password,
+      ssl: !!gw?.ssl,
+    });
+  } catch (e) {
+    return apiError(e, { tag: 'api:settings:gateway:get', status: 500 });
+  }
+}
+
+const UpdateBody = z.object({
+  host: z.string().min(1).max(255),
+  username: z.string().max(255).optional(),
+  /** Empty / undefined means "keep the existing password unchanged". */
+  password: z.string().max(255).optional(),
+  ssl: z.boolean().optional(),
+  /** When true, validate credentials against the FritzBox before saving. */
+  test: z.boolean().optional(),
+});
+
+export async function POST(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const body = UpdateBody.parse(await request.json());
+    const current = await getConfig();
+    const existing = current.gateway;
+
+    // Only overwrite password when the body provided one. The form
+    // sends an empty string when the operator didn't touch the field —
+    // keep what's there in that case.
+    const password = body.password && body.password.length > 0
+      ? body.password
+      : existing?.password;
+
+    const next = {
+      type: 'fritzbox' as const,
+      host: body.host.trim(),
+      username: body.username?.trim() || undefined,
+      password,
+      ssl: body.ssl ?? existing?.ssl,
+    };
+
+    if (body.test) {
+      // Best-effort credential check — getStatus hits both the
+      // unauthenticated UPnP path (anonymous IP/uptime) and, if
+      // username+password are provided, switches to authenticated
+      // TR-064. A failure here means either wrong creds, wrong
+      // host, or unreachable box; surface it before persisting so
+      // the operator doesn't silently lock themselves out.
+      try {
+        const client = new FritzBoxClient({
+          host: next.host,
+          username: next.username,
+          password: next.password,
+        });
+        await client.getStatus();
+      } catch (e) {
+        return NextResponse.json({
+          error: 'connection_failed',
+          message: e instanceof Error ? e.message : String(e),
+        }, { status: 400 });
+      }
+    }
+
+    await updateConfig({ gateway: next });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return apiError(e, { tag: 'api:settings:gateway:post', status: 400 });
+  }
+}

--- a/src/components/ServiceActionBar.tsx
+++ b/src/components/ServiceActionBar.tsx
@@ -33,7 +33,7 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
             <Activity size={16} />
           </Link>
           <Link
-            href="/registry?selected=gateway"
+            href="/settings/integrations#gateway"
             className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
             title="Edit Gateway"
           >


### PR DESCRIPTION
## Why

You hit two things on the Internet Gateway card:
1. The pencil "Edit Gateway" button linked to \`/registry?selected=gateway\` — that's the template registry, not a config form. Wrong destination.
2. Even with a working link, there was no UI to edit FritzBox host/username/password. Only paths were a full re-install or hand-editing \`config.json\` on the box.

## What

- **\`GatewaySection.tsx\`** under \`/settings/integrations#gateway\`: host, username, password, SSL toggle. Two buttons:
  - **Test connection & save** — round-trips \`FritzBoxClient.getStatus()\` (TR-064 \`GetStatusInfo\`) before persisting, so wrong creds get caught upfront.
  - **Save without test** — escape hatch when the box is briefly unreachable.
  - Password field shows \`••••••••\` if one is stored; empty submit keeps the existing password (refresh-and-save doesn't wipe it).
- **\`GET/POST /api/settings/gateway\`** — Zod-validated, never echoes the password back.
- **\`ServiceActionBar.tsx\`** — pencil button now links to \`/settings/integrations#gateway\` so it lands on the new section.

## Test plan

- [x] \`npx vitest run\` — 525 passed, 1 skipped
- [x] \`npm run lint\`, \`npm run knip\`, \`npm run build\` — clean
- [ ] Browser smoke (after deploy):
  - [ ] Settings → Integrations shows the new "Internet Gateway (FritzBox)" section
  - [ ] Pencil button on the Network plugin's gateway card jumps there
  - [ ] Test connection succeeds with valid creds, fails informatively with wrong ones
  - [ ] Save without typing a password keeps the previously stored one

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)