### PR TITLE
chore(portal): drop stale "violet" comments

### DIFF
--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -6,7 +6,7 @@ import type { Metadata, Viewport } from 'next';
  *
  * Adds PWA manifest + iOS Safari meta tags so family members can
  * "Add to Home Screen" and the portal launches in its own standalone
- * window with the violet house icon. The manifest endpoint at
+ * window with the blue ServiceBay icon. The manifest endpoint at
  * `/portal/manifest.webmanifest` returns a per-install JSON with the
  * active domain in the app name.
  */

--- a/src/app/portal/manifest.webmanifest/route.ts
+++ b/src/app/portal/manifest.webmanifest/route.ts
@@ -10,7 +10,7 @@ export const dynamic = 'force-dynamic';
  * Served at `/portal/manifest.webmanifest`. Mobile browsers + desktop
  * Chrome use this for the "Install app" / "Add to Home Screen"
  * affordance — once installed, the portal launches in its own
- * standalone window with the violet house icon, separate from any
+ * standalone window with the blue ServiceBay icon, separate from any
  * browser chrome.
  *
  * The `name` field uses the active domain so the home-screen label


### PR DESCRIPTION
Code-comment cleanup. The portal icon SVG itself is already `#2563eb` (blue, since #315). These two stale references to "violet house icon" remained in code comments only — no UI effect, but misleading when grepping.

Closes nothing — these were comment-only stragglers from the brand-color migration.