### PR TITLE
fix(install): enable setup-config-merge.service on first boot (#331 follow-up)

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -884,6 +884,15 @@ ${SERVICEBAY_SSH_PRIV}
     - path: /etc/systemd/system/multi-user.target.wants/install-python.service
       target: /etc/systemd/system/install-python.service
 
+    # Enable setup-config-merge on first boot (#331). Without this
+    # symlink, Ignition drops the unit file at /etc/systemd/system/
+    # but never enables it — systemd ignores the [Install] section
+    # of unit files placed via Ignition, so an explicit
+    # multi-user.target.wants symlink is required, same as the
+    # other first-boot units above.
+    - path: /etc/systemd/system/multi-user.target.wants/setup-config-merge.service
+      target: /etc/systemd/system/setup-config-merge.service
+
     # Enable Nginx install on first boot (user service)
     - path: /var/home/${HOST_USER}/.config/systemd/user/default.target.wants/install-nginx.service
       target: /var/home/${HOST_USER}/.config/systemd/user/install-nginx.service


### PR DESCRIPTION
Ignition silently drops the \`[Install]\` block in unit files placed via Butane \`storage:files\`. Every other first-boot unit (install-python, restore-usb-boot, var-mnt-data.mount, setup-raid) has an explicit \`multi-user.target.wants\` symlink as a separate Butane entry. My new \`setup-config-merge.service\` from #332 was missing that — Ignition wrote the unit file to \`/etc/systemd/system/\` but the unit was never enabled, so it never ran.

Verified on 192.168.178.100 right now: \`list_system_services\` shows install-python + setup-raid as \`loaded/active\` but no \`setup-config-merge.service\` at all. Both \`auth.bootstrapToken\` and \`stackSetupPending\` remain empty in config after re-install — exactly the smoking gun.

Three-line fix: add the symlink under \`multi-user.target.wants/\` just like the other units.

## Test plan

- [x] \`bash -n install-fedora-coreos.sh\` — clean
- [ ] After merge + new ISO build + re-install on 192.168.178.100:
  - [ ] \`list_system_services\` shows \`setup-config-merge.service\` as \`loaded/active (exited)\`
  - [ ] \`auth.bootstrapToken.hash\` lands in config
  - [ ] \`stackSetupPending\` lands in config → onboarding wizard fires
  - [ ] Old runtime-managed values (encrypted password, lldap, npm) preserved

Closes the regression behind #331's reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)