### PR TITLE
fix(install): chown merged config.json to core (#331 follow-up #2)

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -634,6 +634,24 @@ ${SERVICEBAY_SSH_PRIV}
               tmp = OLD + ".merge.tmp"
               with open(tmp, "w") as f:
                   json.dump(merged, f, indent=2)
+              # ServiceBay runs as the host user (uid 1000, `core`).
+              # This service runs as root, so without explicit chown
+              # the merged config.json ends up root:root and the
+              # container gets EACCES when reading it. getConfig()'s
+              # catch then falls back to DEFAULT_CONFIG, migrateConfig
+              # saves that empty default, and every install-time value
+              # (auth, gateway, bootstrap token, setupCompleted,
+              # stackSetupPending) vanishes silently. Match the
+              # ownership setup-raid uses for everything else in
+              # /var/mnt/data/servicebay.
+              try:
+                  import pwd
+                  core = pwd.getpwnam("core")
+                  os.chown(tmp, core.pw_uid, core.pw_gid)
+              except (KeyError, OSError):
+                  # Static fallback — install-fedora-coreos.sh always
+                  # creates `core` with uid/gid 1000.
+                  os.chown(tmp, 1000, 1000)
               os.chmod(tmp, 0o600)
               os.replace(tmp, OLD)
               os.remove(NEW)


### PR DESCRIPTION
**Symptom:** Box installs cleanly, but post-install config is essentially empty — no auth, no setupCompleted, no stackSetupPending, no gateway. Dashboard stuck on "Loading services… Waiting for agent synchronization". Bootstrap-token bearers 401.

**Why:** \`setup-config-merge.service\` runs as root and was writing the merged config.json as **root:root with mode 600**. ServiceBay runs as uid 1000 (\`core\`) and gets EACCES on read. \`getConfig\` swallows the read error in its catch, returns \`DEFAULT_CONFIG\`, then \`migrateConfig\` saves that empty default back to disk — silently dropping every install-time value.

**Reproduces on 192.168.178.100 right now:**
- \`list_system_services\` shows \`setup-config-merge.service active=exited\` (the unit ran)
- \`get_config\` returns only \`DEFAULT_CONFIG\` + runtime-written \`reverseProxy.lanIp\`
- Bootstrap-token cleartext 401's
- Auth keys empty → no login possible from a fresh session

**Fix:** Chown the merged config.json to core:core before \`os.replace\`. The "promote in place" branch (fresh-disk install) didn't have the bug because the new file inherits the staging file's owner, which setup-raid already chown'd via its post-mount sweep.

## Test plan

- [x] \`bash -n install-fedora-coreos.sh\` — clean
- [x] AST parse of embedded python — clean
- [x] Local smoke test (with chown stubbed) — merge produces expected output, staging file removed
- [ ] After new ISO build + re-install on 192.168.178.100:
  - [ ] \`stat -c '%U:%G' /var/mnt/data/servicebay/config.json\` → \`core:core\`
  - [ ] \`get_config\` shows full install-script content (auth, gateway, setupCompleted, stackSetupPending)
  - [ ] Bootstrap token works within 30 min
  - [ ] Wizard pops up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)