### PR TITLE
feat(adguard): wildcard DNS rewrites for LAN + public domains

### DIFF
--- a/src/app/api/system/adguard/credentials/route.ts
+++ b/src/app/api/system/adguard/credentials/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { getConfig, saveConfig, updateConfig } from '@/lib/config';
+import { apiError } from '@/lib/api/errors';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Read whether AdGuard admin credentials are stored. Never returns the
+ * password itself — only `configured: boolean`, the admin URL, and the
+ * username. Mirrors the LLDAP/NPM credentials pattern.
+ */
+export async function GET() {
+  const config = await getConfig();
+  const adguard = config.adguard;
+  return NextResponse.json({
+    configured: Boolean(adguard?.password),
+    adminUrl: adguard?.adminUrl ?? '',
+    username: adguard?.username ?? '',
+  });
+}
+
+/**
+ * Save AdGuard admin credentials. Body: `{ adminUrl, username, password }`.
+ * Called by the AdGuard post-deploy after a successful login probe so
+ * ServiceBay can manage DNS rewrites + run the FritzBox-DNS hand-off
+ * without ever prompting the operator again.
+ *
+ * Side effect: triggers `provisionPortalRouting()` in the background.
+ * That's the moment AdGuard's admin password becomes available, so
+ * the wildcard rewrites (`*.<lanDomain>`, `*.<publicDomain>` for
+ * split-horizon) get a chance to land. The provisioner is idempotent
+ * — if it fires here and again at server-boot, the second call is a
+ * no-op.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { adminUrl, username, password } = body as {
+      adminUrl?: string;
+      username?: string;
+      password?: string;
+    };
+
+    if (typeof adminUrl !== 'string' || !adminUrl || typeof password !== 'string' || !password) {
+      return NextResponse.json({ error: 'adminUrl and password are required' }, { status: 400 });
+    }
+
+    await updateConfig({
+      adguard: { adminUrl, username: username || 'admin', password },
+    });
+
+    // Fire-and-forget: with creds now stored, retry the portal/rewrite
+    // provisioner. AdGuard's post-deploy runs after the container is
+    // healthy, so AdGuard is reachable here. The provisioner is
+    // best-effort and logs its own failures; we don't block the
+    // credential save on it.
+    void (async () => {
+      try {
+        const { provisionPortalRouting } = await import('@/lib/portal/provisioner');
+        const result = await provisionPortalRouting();
+        logger.info('api:system:adguard:credentials', `Triggered portal+rewrite provisioner: ${result.detail}`);
+      } catch (e) {
+        logger.warn('api:system:adguard:credentials', `Provisioner retry after AdGuard creds save failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })();
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:adguard:credentials:post', status: 500 });
+  }
+}
+
+/**
+ * Forget stored AdGuard credentials. Uses saveConfig directly because
+ * updateConfig deep-merges and cannot delete keys.
+ */
+export async function DELETE() {
+  const config = await getConfig();
+  const next = { ...config };
+  delete next.adguard;
+  await saveConfig(next);
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -226,6 +226,18 @@ export interface AppConfig {
     username: string;
     password: string;
   };
+  /**
+   * AdGuard Home admin credentials, persisted by the AdGuard post-deploy
+   * after a successful login probe. ServiceBay reads these when it needs
+   * to manage DNS rewrites (split-horizon wildcards for the LAN + public
+   * domains, FritzBox-DNS hand-off probe), without prompting the operator
+   * again. Same trust class as `reverseProxy.npm` and `lldap`.
+   */
+  adguard?: {
+    adminUrl: string;
+    username: string;
+    password: string;
+  };
   setupCompleted?: boolean;
   stackSetupPending?: boolean;
   /**

--- a/src/lib/portal/provisioner.ts
+++ b/src/lib/portal/provisioner.ts
@@ -32,12 +32,14 @@ import { logger } from '@/lib/logger';
 
 const LOG = 'portal:provisioner';
 
+type RewriteResult = 'added' | 'updated' | 'unchanged' | 'failed';
+
 interface ProvisionResult {
   ok: boolean;
   detail: string;
   proxyHost?: 'created' | 'unchanged' | 'failed' | 'skipped';
-  apexRewrite?: 'added' | 'updated' | 'unchanged' | 'failed';
-  wwwRewrite?: 'added' | 'updated' | 'unchanged' | 'failed';
+  /** Per-rewrite outcomes, keyed by AdGuard domain pattern. */
+  rewrites?: Record<string, RewriteResult>;
 }
 
 /** Locate ServiceBay's own LAN IP from config. Used as the rewrite
@@ -47,10 +49,20 @@ async function findServiceBayLanIp(): Promise<string | null> {
   return config.reverseProxy?.lanIp ?? null;
 }
 
-/** Find AdGuard admin URL + password from config. Mirrors the
- *  pattern used by the router-DNS probe. */
+/** Find AdGuard admin URL + password from config. Prefer the dedicated
+ *  `config.adguard` block (written by AdGuard's post-deploy via
+ *  /api/system/adguard/credentials) and fall back to the legacy
+ *  templateSettings lookup for installs that predate the credentials
+ *  endpoint. */
 async function findAdguardCreds(): Promise<{ adminUrl: string; username: string; password: string } | null> {
   const config = await getConfig();
+  if (config.adguard?.password) {
+    return {
+      adminUrl: config.adguard.adminUrl || `http://localhost:${config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083'}`,
+      username: config.adguard.username || 'admin',
+      password: config.adguard.password,
+    };
+  }
   const password = config.templateSettings?.ADGUARD_ADMIN_PASSWORD;
   const port = config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083';
   if (!password) return null;
@@ -163,8 +175,8 @@ async function provisionAdguardRewrite(name: string, lanIp: string): Promise<'ad
  */
 export async function provisionPortalRouting(): Promise<ProvisionResult> {
   const config = await getConfig();
-  const domain = getActiveDomain(config);
-  if (!domain) {
+  const activeDomain = getActiveDomain(config);
+  if (!activeDomain) {
     return { ok: false, detail: 'No active domain configured.' };
   }
   const lanIp = await findServiceBayLanIp();
@@ -172,19 +184,44 @@ export async function provisionPortalRouting(): Promise<ProvisionResult> {
     return { ok: false, detail: 'No LAN IP recorded in config — install-time detection hasn\'t run yet.' };
   }
 
-  const proxyHost = await provisionNpmProxyHost(domain);
-  // AdGuard rewrites only matter in LAN mode (or as a soft-fallback
-  // alongside a public domain). Add them whenever AdGuard's running;
-  // they're harmless when the domain is also externally-routable.
-  const apexRewrite = await provisionAdguardRewrite(domain, lanIp);
-  const wwwRewrite = await provisionAdguardRewrite(`www.${domain}`, lanIp);
+  // NPM apex+www proxy host. Only the active domain needs an NPM
+  // host — that's where browser traffic actually hits ServiceBay.
+  const proxyHost = await provisionNpmProxyHost(activeDomain);
 
-  const ok = proxyHost !== 'failed' && apexRewrite !== 'failed' && wwwRewrite !== 'failed';
-  const summary = `proxy:${proxyHost} apex:${apexRewrite} www:${wwwRewrite}`;
-  if (ok) {
-    logger.info(LOG, `Portal routing provisioned for ${domain} (${summary})`);
-  } else {
-    logger.warn(LOG, `Portal routing provisioning had failures for ${domain} (${summary})`);
+  // AdGuard rewrites. Two-domain split-horizon for typical home installs:
+  //   * `lanDomain` (default `home.arpa`) — always present. Devices
+  //     resolving `<lan>` or `*.<lan>` need to hit ServiceBay directly.
+  //   * `publicDomain` (e.g. `dopp.cloud`) — when set, LAN devices
+  //     resolving `<public>` or `*.<public>` should bypass the
+  //     FritzBox-hairpin-NAT and reach ServiceBay over the LAN.
+  // For each domain we install three rewrites:
+  //   - <domain> → lanIp                       (portal apex)
+  //   - www.<domain> → lanIp                   (portal apex, with www)
+  //   - *.<domain> → lanIp                     (subdomain catch-all)
+  // AdGuard accepts both literal and wildcard patterns at the same
+  // endpoint; the wildcard pattern is the standard catch-all for any
+  // service subdomain (vault, immich, dns, …) that NPM routes by
+  // Host-header behind ServiceBay.
+  const rewriteDomains = new Set<string>();
+  const lanDomain = config.reverseProxy?.lanDomain ?? 'home.arpa';
+  const publicDomain = config.reverseProxy?.publicDomain;
+  if (lanDomain) rewriteDomains.add(lanDomain);
+  if (publicDomain) rewriteDomains.add(publicDomain);
+
+  const rewrites: Record<string, RewriteResult> = {};
+  for (const d of rewriteDomains) {
+    rewrites[d] = await provisionAdguardRewrite(d, lanIp);
+    rewrites[`www.${d}`] = await provisionAdguardRewrite(`www.${d}`, lanIp);
+    rewrites[`*.${d}`] = await provisionAdguardRewrite(`*.${d}`, lanIp);
   }
-  return { ok, detail: summary, proxyHost, apexRewrite, wwwRewrite };
+
+  const anyRewriteFailed = Object.values(rewrites).some(r => r === 'failed');
+  const ok = proxyHost !== 'failed' && !anyRewriteFailed;
+  const summary = `proxy:${proxyHost} rewrites=${Object.entries(rewrites).map(([k, v]) => `${k}:${v}`).join(',')}`;
+  if (ok) {
+    logger.info(LOG, `Portal routing provisioned for ${activeDomain} (${summary})`);
+  } else {
+    logger.warn(LOG, `Portal routing provisioning had failures for ${activeDomain} (${summary})`);
+  }
+  return { ok, detail: summary, proxyHost, rewrites };
 }

--- a/templates/adguard/post-deploy.py
+++ b/templates/adguard/post-deploy.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import json
 import os
 import sys
+import urllib.error
+import urllib.request
 
 
 def env(key: str, default: str = "") -> str:
@@ -34,6 +36,29 @@ def emit_credential(**fields: object) -> None:
 def log(msg: str) -> None:
     sys.stdout.write(msg + "\n")
     sys.stdout.flush()
+
+
+def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("SB_API_TOKEN", "")
+    if token:
+        headers["X-SB-Internal-Token"] = token
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(data) if data else None
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, None
 
 
 def main() -> int:
@@ -55,6 +80,30 @@ def main() -> int:
         importance="critical",
         notes="DNS console. Add custom rewrites + manage blocklists.",
     )
+
+    # Persist the admin credentials into ServiceBay's config so the
+    # provisioner can pick them up later for DNS rewrites + the
+    # FritzBox-DNS hand-off probe. Mirrors what nginx + lldap post-
+    # deploys do. The endpoint also triggers provisionPortalRouting()
+    # in the background, which installs the wildcard rewrites
+    # (`*.<lan>`, `*.<public>`) the operator expects to land
+    # automatically after install. See #341 + the AdGuard-rewrites
+    # follow-up.
+    sb_api = env("SB_API_URL", "http://localhost:3000")
+    persist_status, _ = post_json(
+        f"{sb_api}/api/system/adguard/credentials",
+        {
+            "adminUrl": f"http://localhost:{port}",
+            "username": user,
+            "password": password,
+        },
+        timeout=10,
+    )
+    if persist_status == 200:
+        log("ServiceBay registered AdGuard credentials — wildcard DNS rewrites will be provisioned.")
+    else:
+        log(f"⚠️ Could not register AdGuard credentials with ServiceBay (HTTP {persist_status}). Wildcard rewrites won't auto-install; add them manually in AdGuard if subdomains don't resolve.")
+
     return 0
 
 

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -120,8 +120,15 @@ class AdguardScript(unittest.TestCase):
             "ADGUARD_ADMIN_USER": "admin",
             "ADGUARD_ADMIN_PASSWORD": "s3cret",
             "ADGUARD_ADMIN_PORT": "8083",
+            "SB_API_URL": "http://sb.test",
         }
-        with run_with_env(env):
+        # Mock the credentials-persist POST so the script doesn't try
+        # urllib against a real localhost (would block 10s+ in CI).
+        responses = {
+            "/api/system/adguard/credentials": {"status": 200, "body": {"ok": True}},
+        }
+        import urllib.request
+        with run_with_env(env), mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)):
             rc, out = capture_main(m)
         self.assertEqual(rc, 0)
         creds = parse_credentials(out)
@@ -140,6 +147,9 @@ class AdguardScript(unittest.TestCase):
             if not line.startswith("__SB_CREDENTIAL__ ")
         )
         self.assertNotIn("s3cret", log_only)
+        # Confirm the credentials-persist call was made (status 200
+        # → success log line).
+        self.assertIn("ServiceBay registered AdGuard credentials", out)
 
     def test_no_password_skips_credential_silently(self):
         m = load_script("adguard")


### PR DESCRIPTION
**Symptom:** Fresh install on 192.168.178.100. AdGuard's DNS-rewrite list is empty — no apex, no www, no \`*.home.arpa\`. Every service subdomain (vault, immich, dns, …) NXDOMAINs on the LAN. Operator can't reach anything by hostname until they hand-add rewrites.

**Root cause** (two gaps end-to-end):

1. **AdGuard's admin password never landed in ServiceBay's config.** \`findAdguardCreds()\` looked at \`config.templateSettings.ADGUARD_ADMIN_PASSWORD\` — but install-time variables don't get persisted there. \`provisionAdguardRewrite()\` always returned \`'failed'\`.
2. **No wildcard rewrite was ever attempted.** Even with creds, the provisioner only installed apex + www. Each service subdomain stayed unreachable.

**Fix:**

* New \`config.adguard: { adminUrl, username, password }\` schema (same trust class as \`reverseProxy.npm\` and \`lldap\`).
* New \`/api/system/adguard/credentials\` endpoint — GET / POST / DELETE, mirrors LLDAP pattern. POST also fires \`provisionPortalRouting()\` in the background so rewrites land the moment creds become available.
* AdGuard post-deploy calls the new endpoint after emitting its credential marker.
* \`findAdguardCreds()\` prefers \`config.adguard\` and falls back to the legacy lookup so older installs keep working.
* \`provisionPortalRouting()\` now installs **three rewrites per domain**: \`<d>\`, \`www.<d>\`, \`*.<d>\` — for both the LAN domain (always) and the public domain (when set). The \`*.<public>\` wildcard is the **split-horizon** rewrite: phones on the home network resolving \`vault.dopp.cloud\` get the LAN IP directly instead of hairpin-NAT'ing through the FritzBox.

| Entry | When |
|---|---|
| \`home.arpa → lanIp\` | LAN domain present (always for the default install) |
| \`www.home.arpa → lanIp\` | same |
| \`*.home.arpa → lanIp\` | same — catches every service subdomain |
| \`dopp.cloud → lanIp\` | Public domain set |
| \`www.dopp.cloud → lanIp\` | same |
| \`*.dopp.cloud → lanIp\` | same — split-horizon for LAN devices |

Idempotent. Per-rewrite outcomes returned so the diagnose page can flag a partial failure.

## Test plan

- [x] \`npx vitest run\` — 525 passed
- [x] \`npm run lint\`, \`npm run build\` — clean
- [x] AdGuard post-deploy test mocks the new endpoint
- [ ] After merge + release + reinstall on 192.168.178.100:
  - [ ] AdGuard UI → DNS rewrites — shows \`home.arpa\`, \`www.home.arpa\`, \`*.home.arpa\`, \`dopp.cloud\`, \`www.dopp.cloud\`, \`*.dopp.cloud\` all → 192.168.178.100
  - [ ] \`vault.home.arpa\` from LAN resolves to the box and NPM routes it correctly
  - [ ] \`vault.dopp.cloud\` from LAN resolves locally (split-horizon — no hairpin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)