### PR TITLE
feat(reinstall): welcome-back banner with live restore progress (#337)

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -631,6 +631,14 @@ ${SERVICEBAY_SSH_PRIV}
                   if found:
                       set_path(merged, path, val)
                       kept += 1
+              # Tag the merge so the dashboard can show a "Welcome
+              # back — services restoring" banner instead of a silent
+              # boot (#337). Only set on the merge path; a true fresh
+              # install (no prior config.json) goes through the
+              # promote-in-place branch above and leaves `reinstall`
+              # unset.
+              import datetime
+              merged["reinstall"] = {"completedAt": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
               tmp = OLD + ".merge.tmp"
               with open(tmp, "w") as f:
                   json.dump(merged, f, indent=2)

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import Sidebar from '@/components/Sidebar';
 import { MobileTopBar, MobileBottomBar } from '@/components/MobileNav';
 import OnboardingWizard from '@/components/OnboardingWizard';
+import RestoreStatusBanner from '@/components/RestoreStatusBanner';
 
 // Dashboard pages depend on the live Digital Twin state and SSH-pool
 // connectivity; never try to pre-render them at build time.
@@ -14,6 +15,7 @@ export default function DashboardLayout({
   return (
     <div className="flex flex-col md:flex-row h-dvh w-full bg-gray-100 dark:bg-black overflow-hidden md:p-4 md:gap-4">
       <OnboardingWizard />
+      <RestoreStatusBanner />
       <div className="hidden md:flex h-full shrink-0">
         <Sidebar />
       </div>

--- a/src/app/api/system/reinstall/route.ts
+++ b/src/app/api/system/reinstall/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { getConfig, saveConfig } from '@/lib/config';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+// Banner auto-dismisses after this many minutes from completedAt.
+// Long enough to cover slow first-boot service restore on a cold
+// box, short enough to never show on a "normal" session.
+const REINSTALL_BANNER_TTL_MIN = 10;
+
+/**
+ * GET /api/system/reinstall
+ *
+ * Tell the dashboard whether to show the "Welcome back — services
+ * restoring" banner. Returns `active: false` when:
+ *   - no re-install was recorded (true fresh install)
+ *   - the completedAt timestamp is older than the TTL (banner expired)
+ *   - the operator already dismissed it (handled by DELETE)
+ *
+ * See #337.
+ */
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const config = await getConfig();
+    const completedAt = config.reinstall?.completedAt;
+    if (!completedAt) {
+      return NextResponse.json({ active: false });
+    }
+    const completedMs = Date.parse(completedAt);
+    if (!Number.isFinite(completedMs)) {
+      return NextResponse.json({ active: false });
+    }
+    const ageMin = (Date.now() - completedMs) / 60_000;
+    if (ageMin > REINSTALL_BANNER_TTL_MIN) {
+      return NextResponse.json({ active: false });
+    }
+    const minutesRemaining = Math.max(0, Math.ceil(REINSTALL_BANNER_TTL_MIN - ageMin));
+    return NextResponse.json({
+      active: true,
+      completedAt,
+      minutesRemaining,
+    });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:reinstall:get', status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/system/reinstall
+ *
+ * Dismiss the banner. Clears `config.reinstall` outright so subsequent
+ * GETs report `active: false`.
+ */
+export async function DELETE(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const config = await getConfig();
+    if (!config.reinstall) {
+      return NextResponse.json({ ok: true, removed: false });
+    }
+    const next = { ...config };
+    delete next.reinstall;
+    await saveConfig(next);
+    return NextResponse.json({ ok: true, removed: true });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:reinstall:delete', status: 500 });
+  }
+}

--- a/src/components/RestoreStatusBanner.tsx
+++ b/src/components/RestoreStatusBanner.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Loader2, RefreshCw, X } from 'lucide-react';
+
+interface ReinstallStatus {
+  active: boolean;
+  minutesRemaining?: number;
+}
+
+interface ServiceLike {
+  name: string;
+  active?: boolean;
+  status?: string;
+}
+
+/**
+ * Re-install welcome banner (#337). After setup-raid restores
+ * Quadlet service definitions from the RAID backup, the dashboard
+ * just sits there saying "Loading services…" while the user-systemd
+ * instance churns through bringing them back up. Indistinguishable
+ * from "nothing happened" — which is what you reported.
+ *
+ * This banner shows for up to 10 min after a re-install (set by
+ * setup-config-merge.service via config.reinstall.completedAt), polls
+ * /api/services to count how many managed services are active, and
+ * auto-dismisses once they're all up. The operator can also dismiss
+ * early.
+ *
+ * Doesn't render in fresh-install boots — config.reinstall is only
+ * written when setup-config-merge took the merge path (existing
+ * config.json was present on the RAID), so this stays invisible the
+ * very first time.
+ */
+export default function RestoreStatusBanner() {
+  const [status, setStatus] = useState<ReinstallStatus | null>(null);
+  const [services, setServices] = useState<ServiceLike[] | null>(null);
+  const [dismissing, setDismissing] = useState(false);
+
+  const refresh = async () => {
+    try {
+      const [statusRes, servicesRes] = await Promise.all([
+        fetch('/api/system/reinstall').then(r => (r.ok ? r.json() : null)),
+        fetch('/api/services').then(r => (r.ok ? r.json() : [])),
+      ]);
+      setStatus(statusRes);
+      setServices(Array.isArray(servicesRes) ? servicesRes : null);
+    } catch {
+      /* leave previous state — UI will fade out on the next clean poll */
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // Poll while the banner is plausibly active. 8s is fast enough
+    // that the operator sees the count change as services come up,
+    // slow enough that we're not hammering the API.
+    const id = setInterval(refresh, 8000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Don't render anything when:
+  //   - we haven't loaded status yet (avoid flash)
+  //   - server says no active re-install
+  //   - all managed services are already up (silently auto-dismiss
+  //     while the underlying record decays)
+  if (!status || !status.active) return null;
+
+  const total = services?.length ?? 0;
+  const up = services?.filter(s => s.active).length ?? 0;
+  const allUp = total > 0 && up === total;
+
+  if (allUp) {
+    // Auto-dismiss the moment everything's running. Don't wait for
+    // the operator to manually X out.
+    return null;
+  }
+
+  const dismiss = async () => {
+    setDismissing(true);
+    try {
+      await fetch('/api/system/reinstall', { method: 'DELETE' });
+      setStatus({ active: false });
+    } finally {
+      setDismissing(false);
+    }
+  };
+
+  return (
+    <div className="fixed top-4 right-4 z-40 max-w-md bg-white dark:bg-gray-800 rounded-xl border border-blue-200 dark:border-blue-800 shadow-lg overflow-hidden">
+      <div className="p-4 flex items-start gap-3">
+        <div className="shrink-0 p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+          {total > 0 && up > 0 ? <RefreshCw size={20} className="animate-spin" /> : <Loader2 size={20} className="animate-spin" />}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Welcome back — restoring services from RAID backup
+          </h3>
+          <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
+            {total > 0
+              ? <>{up} of {total} services running. The rest are still starting up — Quadlet brings them back automatically after a re-install.</>
+              : <>The agent is still picking up services from the RAID backup. This usually clears within a minute.</>}
+          </p>
+          {total > 0 && (
+            <div className="mt-2 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-blue-600 rounded-full transition-all duration-300"
+                style={{ width: `${(up / total) * 100}%` }}
+              />
+            </div>
+          )}
+          {typeof status.minutesRemaining === 'number' && (
+            <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1.5 flex items-center gap-1">
+              <CheckCircle2 size={10} />
+              Auto-dismisses in {status.minutesRemaining} min.
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          disabled={dismissing}
+          onClick={dismiss}
+          className="shrink-0 p-1 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -229,6 +229,22 @@ export interface AppConfig {
   setupCompleted?: boolean;
   stackSetupPending?: boolean;
   /**
+   * Set by `setup-config-merge.service` on re-install when an existing
+   * config.json was merged with a freshly-staged ISO config. The
+   * dashboard reads `reinstall.completedAt` to show a "Welcome back —
+   * services restoring" banner so an operator who just re-flashed
+   * doesn't stare at "Loading services…" with no signal that work is
+   * happening in the background. Cleared via `POST
+   * /api/system/reinstall/ack` (operator dismissal) or by auto-decay
+   * once the timestamp is older than 10 min. See #337.
+   *
+   * Absent on a true fresh install (the promote-in-place branch of
+   * setup-config-merge skips it).
+   */
+  reinstall?: {
+    completedAt: string;
+  };
+  /**
    * Per-service record of the last `post-deploy.py` run. Written by
    * `ServiceManager.runPostDeployScript` after every run; read by the
    * `post_deploy_failed` probe (B8 / #241) so it can surface


### PR DESCRIPTION
Re-installs were silent — \`setup-raid\` restores Quadlet definitions from the RAID backup in the background while the dashboard showed "Loading services… Waiting for agent synchronization." Indistinguishable from "nothing happened."

## What

- \`setup-config-merge.service\` now tags every merged config with \`reinstall.completedAt\` (ISO timestamp, UTC). The fresh-install promote-in-place branch deliberately skips it.
- New \`GET /api/system/reinstall\` reports the banner state — \`active: true\` only when \`completedAt\` is set AND younger than 10 min. \`DELETE\` for explicit dismissal.
- New \`<RestoreStatusBanner />\` in the dashboard layout: polls \`/api/services\` every 8 s, shows "Welcome back — N of M services running" with a progress bar, auto-dismisses when everything's up or after the TTL expires. Operator can also X out early.

No wizard logic changed. The banner is purely additive — invisible on fresh installs, invisible after services come back up.

## Test plan

- [x] \`npx vitest run\` — 525 passed
- [x] \`npm run lint\`, \`npm run build\` — clean
- [x] \`bash -n install-fedora-coreos.sh\` — clean
- [ ] After merge + release + a re-install on 192.168.178.100:
  - [ ] Banner appears top-right on dashboard load
  - [ ] Service count climbs as Quadlet units come up
  - [ ] Banner auto-dismisses once all services active
  - [ ] X button dismisses early and stays dismissed across reloads

Closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)