### PR TITLE
feat(templates): extract voice stack from home-assistant (#348)

### DIFF
--- a/stacks/full-stack/README.md
+++ b/stacks/full-stack/README.md
@@ -11,7 +11,8 @@ Passwort-Manager, Foto-Verwaltung, Dateifreigabe und Smart-Home.
 - [x] vaultwarden — Selbst gehostetes Bitwarden: Passwörter, Notizen, TOTP, mit Apps für alle Plattformen
 - [x] immich — Selbst gehostete Foto- und Video-Sicherung mit AI-Suche, Mobile-Apps und Auto-Upload
 - [x] file-share — Datei-Sync (Syncthing) + Windows-Netzlaufwerk (Samba) + Web-Dateimanager (FileBrowser, SSO via Authelia)
-- [x] home-assistant — Smart-Home-Hub, lokaler Sprachassistent, Z-Wave-/Matter-Bridges
+- [x] home-assistant — Smart-Home-Hub, Z-Wave-/Matter-Bridges (Sprachassistent läuft im separaten `voice`-Template)
+- [x] voice — Lokale Sprach-Pipeline (Wyoming: Faster Whisper STT + Piper TTS + openWakeWord); HA verbindet sich via `localhost:10300/10200/10400`
 - [x] media — Musik (Navidrome / Subsonic-API) + Hörbücher & Podcasts (Audiobookshelf, eigene Mobile-Apps)
 - [x] radicale — CalDAV/CardDAV-Server, authentifiziert direkt gegen LLDAP (DAVx⁵, iOS, Thunderbird)
 

--- a/templates/home-assistant/README.md
+++ b/templates/home-assistant/README.md
@@ -1,40 +1,39 @@
 # Home Assistant Stack
 
-This stack combines the core components of a modern smart home into a single, highly integrated unit:
+This stack combines the core smart-home components into a single pod:
 
 1.  **Home Assistant**: The core automation hub
-2.  **Z-Wave JS UI**: Driver for Z-Wave USB sticks
+2.  **Z-Wave JS UI**: Driver for Z-Wave USB sticks (only when `ZWAVE_DEVICE` is set)
 3.  **Matter Server**: Connectivity layer for Matter/Thread devices
-4.  **Faster Whisper**: Local speech-to-text (Wyoming protocol, CTranslate2-accelerated)
-5.  **Piper**: Local text-to-speech (Wyoming protocol)
-6.  **openWakeWord**: Wake-word detection ("Hey Jarvis", "Ok Nabu")
+
+The voice pipeline (Faster Whisper + Piper + openWakeWord) lives in the separate `voice` template since #348 — deploy it alongside HA when you want a local voice assistant. HA's voice-pipeline config points at `localhost:10300/10200/10400` regardless of which pod hosts those services.
 
 ## Features
 *   **Host Network**: All services run on the host network for optimal auto-discovery (mDNS, UPnP, Thread)
 *   **Integrated Storage**: All data is persisted under `${DATA_DIR}/home-assistant/`
 *   **USB Passthrough**: The Z-Wave stick is mapped via the `ZWAVE_DEVICE` variable
-*   **Voice Pipeline**: Faster Whisper + Piper + openWakeWord provide a fully local voice assistant (no cloud)
 
 ## Variables
 *   **DATA_DIR**: Base directory for stack data (default: `/mnt/data`)
-*   **ZWAVE_SECRET**: A random string for Z-Wave JS session security
+*   **TZ**: Timezone (default: `Europe/Berlin`)
+*   **ZWAVE_SECRET**: A random string for Z-Wave JS session security (auto-generated)
 *   **ZWAVE_DEVICE**: Absolute path to the USB device (e.g., `/dev/serial/by-id/usb-0658_0200-if00`)
-*   **WHISPER_MODEL**: Faster Whisper model size (`tiny-int8`, `base-int8`, `small-int8`, `medium-int8`, `tiny`, `base`, `small`, `medium` — default: `base-int8`)
-*   **WHISPER_LANGUAGE**: Language code for speech recognition (default: `de`)
-*   **PIPER_VOICE**: TTS voice (default: `de_DE-thorsten-high`)
+
+Voice-related variables (Whisper model, Piper voice, language) now live in the `voice` template.
 
 ## Ports
 *   Home Assistant: `http://<server-ip>:8123`
 *   Z-Wave JS UI: `http://<server-ip>:8091`
-*   Faster Whisper (Wyoming): `10300`
-*   Piper (Wyoming): `10200`
-*   openWakeWord (Wyoming): `10400`
 
 ## Voice Setup
-After installation, go to Home Assistant > Settings > Voice Assistants and add:
-1. Speech-to-text: Wyoming > `localhost:10300`
-2. Text-to-speech: Wyoming > `localhost:10200`
-3. Wake word: Wyoming > `localhost:10400`
+
+Deploy the `voice` template alongside this one, then in HA go to *Settings → Voice Assistants* and add:
+
+1. Speech-to-text: Wyoming → `localhost:10300`
+2. Text-to-speech: Wyoming → `localhost:10200`
+3. Wake word: Wyoming → `localhost:10400`
+
+Because voice runs on host network on the same node, `localhost` resolves to the voice pod directly — no Wyoming-over-LAN setup needed.
 
 ## SSO (Authelia)
 

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: home-assistant
   annotations:
     servicebay.label: "Home Assistant"
-    servicebay.ports: "8123/tcp,8091/tcp,3000/tcp,10300/tcp,10200/tcp,10400/tcp"
+    servicebay.ports: "8123/tcp,8091/tcp,3000/tcp"
 spec:
   hostNetwork: true
   containers:
@@ -60,42 +60,10 @@ spec:
     securityContext:
       privileged: true
 
-  # 4. Faster Whisper (Speech-to-Text via Wyoming protocol)
-  - name: faster-whisper
-    image: docker.io/rhasspy/wyoming-whisper:latest
-    args:
-    - --model
-    - "{{WHISPER_MODEL}}"
-    - --language
-    - "{{WHISPER_LANGUAGE}}"
-    - --data-dir
-    - /data
-    - --uri
-    - tcp://0.0.0.0:10300
-    volumeMounts:
-    - mountPath: /data
-      name: whisper-data
-
-  # 5. Piper (Text-to-Speech via Wyoming protocol)
-  - name: piper
-    image: docker.io/rhasspy/wyoming-piper:latest
-    args:
-    - --voice
-    - "{{PIPER_VOICE}}"
-    - --data-dir
-    - /data
-    - --uri
-    - tcp://0.0.0.0:10200
-    volumeMounts:
-    - mountPath: /data
-      name: piper-data
-
-  # 6. openWakeWord (Wake-word detection via Wyoming protocol)
-  - name: openwakeword
-    image: docker.io/rhasspy/wyoming-openwakeword:latest
-    args:
-    - --uri
-    - tcp://0.0.0.0:10400
+  # Voice services (Faster Whisper, Piper, openWakeWord) live in the
+  # separate `voice` template since #348. They listen on the same
+  # localhost ports (10300/10200/10400) so HA's voice-pipeline config
+  # keeps pointing at `localhost:10300` etc. without changes.
 
   volumes:
   # Persistence
@@ -112,14 +80,6 @@ spec:
   - name: matter-config
     hostPath:
       path: {{DATA_DIR}}/home-assistant/matter-server
-      type: DirectoryOrCreate
-  - name: whisper-data
-    hostPath:
-      path: {{DATA_DIR}}/home-assistant/whisper
-      type: DirectoryOrCreate
-  - name: piper-data
-    hostPath:
-      path: {{DATA_DIR}}/home-assistant/piper
       type: DirectoryOrCreate
 
   # System Mounts

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -13,18 +13,6 @@
     "description": "USB device path for your Z-Wave stick",
     "devicePath": "/dev/serial/by-id"
   },
-  "WHISPER_MODEL": {
-    "type": "select",
-    "description": "Faster Whisper speech-to-text model size (int8 variants are faster with minimal quality loss)",
-    "options": ["tiny-int8", "base-int8", "small-int8", "medium-int8", "tiny", "base", "small", "medium"],
-    "default": "base-int8"
-  },
-  "WHISPER_LANGUAGE": {
-    "type": "select",
-    "description": "Language for speech recognition",
-    "options": ["de", "en", "fr", "es", "it", "nl", "pl", "pt", "ru", "zh", "ja", "ko"],
-    "default": "de"
-  },
   "HA_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Home Assistant",
@@ -43,26 +31,5 @@
       "redirect_uris": ["/auth/oidc/callback"],
       "scopes": ["openid", "profile", "email", "groups"]
     }
-  },
-  "PIPER_VOICE": {
-    "type": "select",
-    "description": "Text-to-speech voice",
-    "options": [
-      "de_DE-thorsten-high",
-      "de_DE-thorsten-medium",
-      "de_DE-thorsten-low",
-      "en_US-lessac-high",
-      "en_US-lessac-medium",
-      "en_US-amy-medium",
-      "en_GB-alan-medium",
-      "fr_FR-siwis-medium",
-      "es_ES-sharvard-medium",
-      "it_IT-riccardo-x_low",
-      "nl_NL-mls-medium",
-      "pl_PL-darkman-medium",
-      "pt_BR-edresson-low",
-      "ru_RU-denis-medium"
-    ],
-    "default": "de_DE-thorsten-high"
   }
 }

--- a/templates/voice/README.md
+++ b/templates/voice/README.md
@@ -1,0 +1,63 @@
+# Voice Stack
+
+Wyoming-protocol voice services — runs as a standalone pod so Home Assistant (or any other Wyoming consumer) can talk to a shared local voice pipeline.
+
+Three containers:
+
+1. **Faster Whisper** — speech-to-text, CTranslate2-accelerated. Bound on `tcp://0.0.0.0:10300`.
+2. **Piper** — text-to-speech. Bound on `tcp://0.0.0.0:10200`.
+3. **openWakeWord** — wake-word detection ("Hey Jarvis", "Ok Nabu"). Bound on `tcp://0.0.0.0:10400`.
+
+## Why a separate template
+
+These three were originally bundled inside `home-assistant/template.yml`, but they're not HA-specific:
+
+- The Wyoming protocol is consumed by Rhasspy, custom conversation agents, and pre/post-processing pipelines (speaker-ID, diarization, custom wake-word training).
+- Voice has its own update cadence — new Whisper models, fresh Piper voices, wake-word releases shouldn't block HA updates and vice versa.
+- Voice has different hardware requirements — running Whisper on a GPU shouldn't drag HA along.
+- Replacing voice with a different stack (e.g. a speaker-ID pre-hook in front of Whisper) shouldn't require forking the HA template.
+
+See #348 for the design rationale.
+
+## Variables
+
+- **WHISPER_MODEL**: Faster Whisper model size (default: `base-int8`). int8 variants are noticeably faster with minimal quality loss; the bigger non-int8 models are higher quality but RAM-heavy.
+- **WHISPER_LANGUAGE**: Language code for speech recognition (default: `de`).
+- **PIPER_VOICE**: Text-to-speech voice (default: `de_DE-thorsten-high`). Format is `<locale>-<voice-name>-<quality>`.
+
+## Ports
+
+All three services use the Wyoming protocol over TCP, bound to host network:
+
+- Faster Whisper: `10300`
+- Piper: `10200`
+- openWakeWord: `10400`
+
+## Wiring with Home Assistant
+
+After both the `voice` and `home-assistant` pods are running:
+
+1. In HA, go to *Settings → Voice Assistants*.
+2. Add a Wyoming integration for each of:
+   - **Speech-to-text**: `localhost:10300`
+   - **Text-to-speech**: `localhost:10200`
+   - **Wake word**: `localhost:10400`
+3. Build a voice pipeline that ties them together.
+
+Because both pods share `hostNetwork: true` on the same host, `localhost` resolves to the voice endpoints directly — no Wyoming-over-LAN config required. Multi-host setups need to swap `localhost` for the voice node's reachable IP.
+
+## Migration from the old in-HA-pod voice
+
+If you previously had voice bundled inside the HA pod, your data lived under:
+
+- `{{DATA_DIR}}/home-assistant/whisper`
+- `{{DATA_DIR}}/home-assistant/piper`
+
+The new voice template uses:
+
+- `{{DATA_DIR}}/voice/whisper`
+- `{{DATA_DIR}}/voice/piper`
+
+`post-deploy.py` handles this automatically on first install: if the old paths exist and the new ones don't, it moves them — no model re-download needed. The operation is idempotent; subsequent runs see the new paths already populated and skip.
+
+HA's existing voice-pipeline configuration keeps working without changes — the endpoints are still `localhost:10300/10200/10400`, the only thing that moved is which pod hosts them.

--- a/templates/voice/post-deploy.py
+++ b/templates/voice/post-deploy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `voice` stack.
+
+Two responsibilities:
+
+  1. **Data migration from the old in-HA-pod voice setup.** Whisper
+     models and Piper voices used to live under
+     `${DATA_DIR}/home-assistant/whisper` and `…/piper`. The split in
+     #348 moves them to `${DATA_DIR}/voice/whisper` and `…/piper`.
+     On first install we detect leftover content under the old paths
+     and move it to the new location so the operator doesn't have
+     to re-download multi-gigabyte models.
+
+  2. **Surface the endpoint cheat-sheet** so the operator sees the
+     three Wyoming URLs they need to paste into HA's voice-assistant
+     UI.
+
+Idempotent: a second run sees the new paths already populated and
+the old paths absent, and does nothing.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script
+protocol.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def migrate_dir(old_path: str, new_path: str, label: str) -> None:
+    """Move old_path → new_path if old exists and new is empty/missing.
+
+    Treats a non-empty destination as "already migrated" — never
+    overwrites. Best-effort: a failure logs but doesn't abort the
+    rest of the post-deploy. The voice pod will still come up with
+    an empty data dir and re-download on first request.
+    """
+    if not os.path.isdir(old_path):
+        return
+    if os.path.isdir(new_path) and any(os.scandir(new_path)):
+        # Both exist and the new one is already populated — leave
+        # everything alone. The operator can clean up the old path
+        # manually once they're satisfied the new one works.
+        log(f"   {label}: new path is already populated; leaving the legacy {old_path} as-is.")
+        return
+    try:
+        os.makedirs(os.path.dirname(new_path), exist_ok=True)
+        if os.path.exists(new_path):
+            # New path exists but is empty — remove the empty dir
+            # before move so shutil.move treats this as a rename.
+            os.rmdir(new_path)
+        shutil.move(old_path, new_path)
+        log(f"   {label}: moved {old_path} → {new_path}.")
+    except Exception as e:  # pylint: disable=broad-except
+        log(f"   ⚠️ {label}: could not migrate {old_path} → {new_path}: {e}. The voice pod will re-download models on first request.")
+
+
+def main() -> int:
+    data_dir = env("DATA_DIR", "/mnt/data")
+
+    # Migrate the legacy in-HA-pod voice data.
+    legacy_whisper = os.path.join(data_dir, "home-assistant", "whisper")
+    legacy_piper = os.path.join(data_dir, "home-assistant", "piper")
+    new_whisper = os.path.join(data_dir, "voice", "whisper")
+    new_piper = os.path.join(data_dir, "voice", "piper")
+    if os.path.isdir(legacy_whisper) or os.path.isdir(legacy_piper):
+        log("Migrating voice data from the legacy in-HA-pod paths (#348)...")
+        migrate_dir(legacy_whisper, new_whisper, "Faster Whisper models")
+        migrate_dir(legacy_piper, new_piper, "Piper voices")
+
+    log("✅ Voice pipeline endpoints — paste these into Home Assistant → Settings → Voice Assistants:")
+    log("   • Speech-to-text (Wyoming): tcp://localhost:10300")
+    log("   • Text-to-speech   (Wyoming): tcp://localhost:10200")
+    log("   • Wake word        (Wyoming): tcp://localhost:10400")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/voice/template.yml
+++ b/templates/voice/template.yml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: voice
+  labels:
+    app: voice
+  annotations:
+    servicebay.label: "Voice (Wyoming: Whisper + Piper + openWakeWord)"
+    # No `servicebay.tier` — voice is optional plumbing, not platform
+    # infrastructure (DNS / proxy / SSO are tier=infrastructure and
+    # auto-included by the wizard; voice should be opt-in). The pod
+    # is hidden from the family portal anyway because it ships no
+    # user-guide.md (the portal-card builder only includes templates
+    # that declare one).
+    servicebay.ports: "10300/tcp,10200/tcp,10400/tcp"
+spec:
+  # hostNetwork so other pods (Home Assistant primarily) reach the
+  # Wyoming endpoints at localhost on the standard ports — keeping the
+  # existing HA voice-pipeline configuration working without changes
+  # after the split from #348.
+  hostNetwork: true
+  containers:
+  # 1. Faster Whisper — speech-to-text via Wyoming protocol
+  - name: faster-whisper
+    image: docker.io/rhasspy/wyoming-whisper:latest
+    args:
+    - --model
+    - "{{WHISPER_MODEL}}"
+    - --language
+    - "{{WHISPER_LANGUAGE}}"
+    - --data-dir
+    - /data
+    - --uri
+    - tcp://0.0.0.0:10300
+    volumeMounts:
+    - mountPath: /data
+      name: whisper-data
+
+  # 2. Piper — text-to-speech via Wyoming protocol
+  - name: piper
+    image: docker.io/rhasspy/wyoming-piper:latest
+    args:
+    - --voice
+    - "{{PIPER_VOICE}}"
+    - --data-dir
+    - /data
+    - --uri
+    - tcp://0.0.0.0:10200
+    volumeMounts:
+    - mountPath: /data
+      name: piper-data
+
+  # 3. openWakeWord — wake-word detection via Wyoming protocol
+  - name: openwakeword
+    image: docker.io/rhasspy/wyoming-openwakeword:latest
+    args:
+    - --uri
+    - tcp://0.0.0.0:10400
+
+  volumes:
+  - name: whisper-data
+    hostPath:
+      path: {{DATA_DIR}}/voice/whisper
+      type: DirectoryOrCreate
+  - name: piper-data
+    hostPath:
+      path: {{DATA_DIR}}/voice/piper
+      type: DirectoryOrCreate

--- a/templates/voice/variables.json
+++ b/templates/voice/variables.json
@@ -1,0 +1,35 @@
+{
+  "WHISPER_MODEL": {
+    "type": "select",
+    "description": "Faster Whisper speech-to-text model size (int8 variants are faster with minimal quality loss)",
+    "options": ["tiny-int8", "base-int8", "small-int8", "medium-int8", "tiny", "base", "small", "medium"],
+    "default": "base-int8"
+  },
+  "WHISPER_LANGUAGE": {
+    "type": "select",
+    "description": "Language for speech recognition",
+    "options": ["de", "en", "fr", "es", "it", "nl", "pl", "pt", "ru", "zh", "ja", "ko"],
+    "default": "de"
+  },
+  "PIPER_VOICE": {
+    "type": "select",
+    "description": "Text-to-speech voice",
+    "options": [
+      "de_DE-thorsten-high",
+      "de_DE-thorsten-medium",
+      "de_DE-thorsten-low",
+      "en_US-lessac-high",
+      "en_US-lessac-medium",
+      "en_US-amy-medium",
+      "en_GB-alan-medium",
+      "fr_FR-siwis-medium",
+      "es_ES-sharvard-medium",
+      "it_IT-riccardo-x_low",
+      "nl_NL-mls-medium",
+      "pl_PL-darkman-medium",
+      "pt_BR-edresson-low",
+      "ru_RU-denis-medium"
+    ],
+    "default": "de_DE-thorsten-high"
+  }
+}


### PR DESCRIPTION
Splits Faster Whisper + Piper + openWakeWord out of \`templates/home-assistant/\` into a standalone \`templates/voice/\`. HA is the most obvious consumer but not the only one — Rhasspy, custom conversation agents, and pipelines with speaker-ID / diarization pre-hooks all speak Wyoming and benefit from a shared local voice pod they can point at.

## What

**New \`voice\` template:**
- 3 Wyoming containers — Whisper (10300), Piper (10200), openWakeWord (10400)
- \`hostNetwork: true\` on the same ports as before, so HA's existing voice-pipeline config (\`localhost:10300/10200/10400\`) keeps working without changes
- Persistence under \`\${DATA_DIR}/voice/{whisper,piper}\` instead of nested under home-assistant/
- \`post-deploy.py\` migrates the legacy paths automatically on first install — moves whisper models + piper voices to the new dir so multi-GB downloads aren't repeated. Idempotent; skips when new path is already populated.
- \`WHISPER_MODEL\` / \`WHISPER_LANGUAGE\` / \`PIPER_VOICE\` variables move 1:1 (same options + defaults).

**HA template trimmed:**
- Three voice containers + their volumes removed
- \`servicebay.ports\` trimmed to 8123/8091/3000
- Voice variables out of \`variables.json\`
- README points operators at the voice template and reminds them HA's voice-pipeline endpoints stay \`localhost:10300/10200/10400\`

**Stack manifest** (\`stacks/full-stack/README.md\`) lists \`voice\` as a separate row beside home-assistant.

**Voice deliberately doesn't carry \`servicebay.tier: infrastructure\`** — that tier is reserved for auto-included + locked platform services (DNS / proxy / SSO). Voice is opt-in optional plumbing. It's hidden from the family portal because it ships no \`user-guide.md\`.

## Test plan

- [x] \`npx vitest run\` — 529 passed, 1 skipped (4 new tests gained from auto-discovery of the voice template)
- [x] \`npm run lint\`, \`npm run build\` — clean
- [x] Migration smoke-tested with fake legacy paths — whisper + piper moved as expected, idempotent on re-run
- [ ] After merge + release: deploy voice via the registry alongside HA, confirm:
  - [ ] HA's existing voice-pipeline config (no changes) still reaches Whisper/Piper/openWakeWord
  - [ ] On a box with the old in-HA-pod voice data, models migrate to \`/voice/\` without re-download

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)