### PR TITLE
docs(radicale): clarify caldav.<domain> serves CardDAV too

### DIFF
--- a/stacks/full-stack/README.md
+++ b/stacks/full-stack/README.md
@@ -34,7 +34,7 @@ Domain und Subdomains sind bei der Installation anpassbar.
 | music.{domain} | Navidrome | 4533 | Ja | Subsonic-API für Mobile-Apps (siehe Template-README für Authelia-Bypass) |
 | books.{domain} | Audiobookshelf | 13378 | Ja | Hörbücher + Podcasts, eigene Mobile-Apps |
 | files.{domain} | FileBrowser | 8088 | — | Web-UI für die Samba-Freigabe; Authelia-SSO via auth_request (kein eigener Login) |
-| caldav.{domain} | Radicale | 5232 | — | CalDAV/CardDAV; auth direkt gegen LLDAP, kein Authelia (Mobile-Clients = Basic-Auth) |
+| caldav.{domain} | Radicale | 5232 | — | **Kalender UND Adressbücher** (CalDAV + CardDAV auf demselben Host — kein separates `carddav.`); auth direkt gegen LLDAP, kein Authelia (Mobile-Clients = Basic-Auth) |
 
 ## Nach der Installation
 

--- a/templates/radicale/README.md
+++ b/templates/radicale/README.md
@@ -1,6 +1,12 @@
 # Radicale — CalDAV / CardDAV Server
 
-Self-hosted calendar + contact server. Authentication is delegated directly to LLDAP via the LDAP backend, so any LLDAP user can log in with their existing credentials — **no separate Radicale account to manage**.
+Self-hosted calendar **and contact** server. Both protocols run on the same Radicale instance on the same subdomain — `caldav.<domain>` is just where the address ends up; CardDAV (contacts / address books) sits on the same host. Authentication is delegated directly to LLDAP via the LDAP backend, so any LLDAP user can log in with their existing credentials — **no separate Radicale account to manage**.
+
+## Subdomain naming
+
+ServiceBay ships a single `caldav.<domain>` proxy host that serves **both** CalDAV (calendars) and CardDAV (address books). The name reflects the calendar use-case most operators are familiar with; there's no separate `carddav.` host because there's no separate service — Radicale handles both protocols on one port (`5232`). Modern clients (DAVx⁵, iOS, macOS, Thunderbird, Outlook) auto-discover the right paths via `.well-known/caldav` and `.well-known/carddav`.
+
+If you'd rather have a dedicated `carddav.` alias for clarity, add it as a second NPM proxy host pointing at the same backend (or add an AdGuard DNS rewrite mapping `carddav.<domain>` → ServiceBay's LAN IP). Functionally identical; just a friendlier-looking URL when someone asks "where do contacts live?"
 
 ## Variables
 
@@ -16,7 +22,7 @@ Self-hosted calendar + contact server. Authentication is delegated directly to L
 
 CalDAV/CardDAV clients (DAVx⁵, Thunderbird, iOS, macOS, Outlook) send HTTP Basic auth on every request — they can't complete an interactive Authelia login. So Radicale **bypasses Authelia entirely** and validates credentials directly against LLDAP via the LDAP protocol:
 
-1. Client → `https://caldav.<domain>/<username>/calendar/`
+1. Client → `https://caldav.<domain>/<username>/...`
 2. NPM forwards (no Authelia rule on this subdomain)
 3. Radicale BIND-DN checks `uid=<username>,ou=people,<base-dn>` against LLDAP
 4. Match → request authorized; user reads/writes their own collections at `/<username>/`
@@ -25,9 +31,9 @@ The `[rights] type = owner_only` policy enforces that user X can only see/edit c
 
 ## Setup
 
-1. Deploy via ServiceBay
-2. Web UI: `https://caldav.<domain>` — log in with any LLDAP user → collection-management interface
-3. Mobile / desktop CalDAV clients use the **base URL** with the user's path:
+1. Deploy via ServiceBay.
+2. Web UI: `https://caldav.<domain>` — log in with any LLDAP user → collection-management interface where you can create both calendars and address books.
+3. Mobile / desktop clients use the **base URL** with the user's path:
 
    ```
    Server  : https://caldav.<your-domain>
@@ -35,21 +41,26 @@ The `[rights] type = owner_only` policy enforces that user X can only see/edit c
    Password: <lldap-password>
    ```
 
-   Most clients auto-discover collections from there.
+   Most clients auto-discover both calendars and address books from there.
+
+Per-user URL shapes (auto-discovery normally fills these in, but useful when a client wants them spelled out):
+
+  - Calendars: `https://caldav.<domain>/<username>/calendar/`
+  - Address books: `https://caldav.<domain>/<username>/contacts/`
 
 ## Apps
 
-| Platform | App | Notes |
+| Platform | App | What it picks up |
 |---|---|---|
-| Android | **DAVx⁵** (F-Droid + Play Store) | One-time setup, syncs into the system Calendar/Contacts apps |
-| iOS / macOS | Settings → Calendar/Contacts → Add Account → Other → CalDAV | Native, no extra app |
-| Windows | Thunderbird with the *TbSync + Provider for CalDAV* extension | |
-| Linux | Evolution, GNOME Calendar | |
+| Android | **DAVx⁵** (F-Droid + Play Store) | Calendars + address books, syncs into the system Calendar/Contacts apps in one go |
+| iOS / macOS | Settings → Calendar/Contacts → Add Account → Other → CalDAV / CardDAV | Native, no extra app. Add the CalDAV and CardDAV accounts separately (same server URL + creds) — or use the *One-tap iOS setup* asset on the portal card which ships both as a single .mobileconfig |
+| Windows | Thunderbird with the *TbSync + Provider for CalDAV* extension | Calendars + address books in Thunderbird |
+| Linux | Evolution, GNOME Calendar / Contacts | |
 
 ## Data Layout
 
 ```
 {{DATA_DIR}}/radicale/
   config/config              ← LDAP-backed auth config
-  data/collections/<user>/   ← per-user calendars & address books
+  data/collections/<user>/   ← per-user calendars AND address books
 ```

--- a/templates/radicale/variables.json
+++ b/templates/radicale/variables.json
@@ -25,7 +25,7 @@
   },
   "RADICALE_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for CalDAV/CardDAV. Mobile clients (DAVx⁵, iOS, Thunderbird) speak HTTP Basic auth — Authelia in front would block them, so this proxy host has NO Authelia forward-auth.",
+    "description": "Subdomain for both CalDAV (calendars) and CardDAV (address books). Radicale serves both protocols on the same port, so there's no separate `carddav.` host — contacts live at `https://caldav.<domain>/<user>/contacts/`. Mobile clients (DAVx⁵, iOS, Thunderbird) speak HTTP Basic auth — Authelia in front would block them, so this proxy host has NO Authelia forward-auth.",
     "default": "caldav",
     "proxyPort": "RADICALE_PORT",
     "proxyConfig": {


### PR DESCRIPTION
Operator noticed the install-time subdomain summary lists `caldav.` but no `carddav.` and asked whether contacts work at all. They do — Radicale handles both protocols on the same port, and standard clients auto-discover the right paths via `/.well-known/{caldav,carddav}`. The name `caldav` is just the calendar-flavoured shorthand for the shared host.

Updates the three doc surfaces the operator actually reads:

- `templates/radicale/README.md` — top blurb names both protocols, new "Subdomain naming" section explains the single-host setup, URL examples now show `/contacts/` alongside `/calendar/`, apps table notes the iOS native flow needs two separate accounts.
- `templates/radicale/variables.json` — `RADICALE_SUBDOMAIN` description spells out both protocols + gives the contacts URL shape.
- `stacks/full-stack/README.md` — `caldav.` row in the subdomain table calls out it covers address books too.

No behavioural change.