### PR TITLE
fix(nginx): bind NPM on hostNetwork so it reaches hostNetwork upstreams

### DIFF
--- a/templates/nginx/CHANGELOG.md
+++ b/templates/nginx/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Nginx Proxy Manager — template changelog
+
+Tracks breaking changes to the `nginx` template's pod structure /
+variable shape. Each H2 corresponds to a value of
+`servicebay.schema-version` in `template.yml`.
+
+## v2
+
+**NPM moved to `hostNetwork: true`.**
+
+NPM used to run in its own pod netns with `hostPort` mappings for
+80/443/81. That broke the reverse-proxy upstream path for every
+service template that runs in `hostNetwork: true` mode (adguard,
+auth, file-share, home-assistant, media, radicale, voice): under
+rootless podman, a bridge-netns container cannot reach the host's
+LAN IP (hairpin NAT), so `proxy_pass http://<lan-ip>:<port>` never
+landed on the upstream and every such proxy host returned 502.
+
+Putting NPM on `hostNetwork: true` matches the network model of the
+other infrastructure templates and removes the hairpin entirely.
+Ports 80/443/81 are now bound directly on the host — no behavior
+change from the outside, but cross-pod traffic now works.
+
+Required action: re-deploy the `nginx` template. NPM's data
+directory is preserved (proxy hosts, certs, settings all intact).
+
+## v1
+
+Initial release. Nginx Proxy Manager in own pod netns with hostPort
+mappings.

--- a/templates/nginx/template.yml
+++ b/templates/nginx/template.yml
@@ -7,9 +7,10 @@ metadata:
     servicebay.role: reverse-proxy
   annotations:
     servicebay.label: "Nginx Proxy Manager"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     servicebay.tier: "infrastructure"
 spec:
+  hostNetwork: true
   containers:
   - name: nginx-proxy-manager
     image: docker.io/jc21/nginx-proxy-manager:latest

--- a/templates/nginx/variables.json
+++ b/templates/nginx/variables.json
@@ -1,8 +1,8 @@
 {
   "NGINX_ADMIN_EMAIL": {
     "type": "text",
-    "description": "NPM admin email. Also used as the Let's Encrypt account email — must be a real address you can receive at, and Let's Encrypt rejects `.local` / `.example` / IP-literal addresses.",
-    "example": "you@example.com"
+    "description": "Initial NPM admin email (used as the login for ServiceBay's auto-sync of proxy routes)",
+    "default": "admin@servicebay.local"
   },
   "NGINX_ADMIN_PASSWORD": {
     "type": "secret",

--- a/templates/nginx/variables.json
+++ b/templates/nginx/variables.json
@@ -1,8 +1,8 @@
 {
   "NGINX_ADMIN_EMAIL": {
     "type": "text",
-    "description": "Initial NPM admin email (used as the login for ServiceBay's auto-sync of proxy routes)",
-    "default": "admin@servicebay.local"
+    "description": "NPM admin email. Also used as the Let's Encrypt account email — must be a real address you can receive at, and Let's Encrypt rejects `.local` / `.example` / IP-literal addresses.",
+    "example": "you@example.com"
   },
   "NGINX_ADMIN_PASSWORD": {
     "type": "secret",


### PR DESCRIPTION
## Summary
- NPM was running in its own pod netns; under rootless podman, bridge containers can't reach the host's LAN IP (hairpin NAT)
- All upstreams with `hostNetwork: true` (adguard, auth, file-share, home-assistant, media, radicale, voice) returned **502** — only the few hostPort-mapped services (vaultwarden, immich) worked, because podman's DNAT rules opened a direct path
- Moving NPM to `hostNetwork: true` removes the hairpin entirely; ports 80/443/81 bind directly on the host, no external behavior change
- Schema bumped to v2 → existing installs get re-deploy prompt; NPM data dir preserved

## Test plan
- [x] Live-verified on a stuck install: dns.dopp.cloud / auth.dopp.cloud went from 502 to 302/200 after applying
- [ ] Fresh install: NPM comes up + sync proxy hosts works
- [ ] Update path: existing v1 install gets the v2 re-deploy prompt; cert + admin password survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)