### PR TITLE
fix(home-assistant): seed configuration.yaml with trusted_proxies

### DIFF
--- a/templates/home-assistant/CHANGELOG.md
+++ b/templates/home-assistant/CHANGELOG.md
@@ -10,6 +10,28 @@ operator's installed schema-version and the current one and surfaces
 them in the re-deploy dialog. Each `(breaking)` section needs an
 explicit acknowledgement before the deploy can proceed.
 
+## v3
+
+**Seed `configuration.yaml` with `http.trusted_proxies` so NPM can talk to HA.**
+
+Home Assistant's first-boot wrote a minimal `configuration.yaml`
+without an `http:` block. Behind NPM (which forwards `X-Forwarded-For`),
+HA's `http.forwarded` component then rejected every proxied request
+with HTTP 400 ("request from reverse proxy but HTTP integration is
+not set up for reverse proxies").
+
+The template now ships `configuration.yaml.mustache` that gets
+written to `/config/configuration.yaml` on install. Trusts the
+private RFC1918 ranges + loopback — covers any LAN ServiceBay sits
+on without per-install variable injection.
+
+Required action: nothing, unless you already customized
+`configuration.yaml`. Schema bump triggers a re-deploy prompt; the
+new file ships next to your existing one, you decide whether to
+overwrite. After a HA backup-restore the snapshot's
+`configuration.yaml` takes over — re-add the `http:` block manually,
+otherwise `home.<domain>` will start returning 400 again.
+
 ## v2 (breaking)
 
 **Voice extracted into the `voice` template.**

--- a/templates/home-assistant/configuration.yaml.mustache
+++ b/templates/home-assistant/configuration.yaml.mustache
@@ -1,0 +1,24 @@
+# Home Assistant base config. ServiceBay writes this once on first
+# install. Edit freely afterwards — re-deploys don't overwrite.
+#
+# Backup-restore caveat: when you restore a HA backup, the snapshot's
+# own configuration.yaml replaces this file. Re-add an `http:` block
+# with `use_x_forwarded_for: true` and the trusted-proxy CIDRs below,
+# otherwise NPM-proxied requests fail with HTTP 400 "request from
+# reverse proxy but HTTP integration is not set up for reverse
+# proxies".
+
+# Loads default set of integrations. Do not remove.
+default_config:
+
+# Reverse-proxy trust list. NPM (on the same host) forwards
+# X-Forwarded-For for every proxied request. Trusting the private
+# RFC1918 ranges + loopback works regardless of which LAN subnet
+# ServiceBay sits on — no per-install variable injection needed.
+http:
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 127.0.0.1
+    - 192.168.0.0/16
+    - 10.0.0.0/8
+    - 172.16.0.0/12

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -6,7 +6,8 @@ metadata:
     app: home-assistant
   annotations:
     servicebay.label: "Home Assistant"
-    servicebay.schema-version: "2"
+    servicebay.schema-version: "3"
+    servicebay.config-mount: "/config"
     servicebay.ports: "8123/tcp,8091/tcp,3000/tcp"
 spec:
   hostNetwork: true

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -409,8 +409,13 @@ describe('Mustache configs have a resolvable target mount', () => {
   for (const t of templates) {
     if (Object.keys(t.configs).length === 0) continue;
     it(`${t.name}: has a servicebay.config-mount annotation that resolves to a real mountPath`, () => {
-      // Render the YAML with a stub view so we can parse it.
-      const safeYaml = t.yamlContent.replace(/\{\{[^}]+\}\}/g, '0');
+      // Render the YAML with a stub view so we can parse it. Strip
+      // mustache section delimiters first ({{#FOO}}, {{/FOO}}, {{^FOO}})
+      // so optional blocks survive parsing — the remaining variable
+      // placeholders get a benign "0" stub.
+      const safeYaml = t.yamlContent
+        .replace(/\{\{[#/^][^}]+\}\}/g, '')
+        .replace(/\{\{[^}]+\}\}/g, '0');
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let docs: any[];
       try {


### PR DESCRIPTION
## Summary
- HA's autogenerated `configuration.yaml` had no `http:` block, so behind NPM every proxied request hit HTTP 400 (`A request from a reverse proxy was received... but your HTTP integration is not set up for reverse proxies`)
- Template now ships `configuration.yaml.mustache` with `default_config:` + an `http.trusted_proxies` block covering loopback + RFC1918 ranges — works for any LAN without per-install variable injection
- Schema bumped to v3; `servicebay.config-mount: "/config"` added so the mustache lands at `/config/configuration.yaml`
- Drive-by: `template-consistency` test now handles `{{#FOO}}...{{/FOO}}` section delimiters cleanly (broke when HA gained its first config-mount)

## Backup-restore caveat (documented in CHANGELOG)
When a user restores a HA backup, the snapshot's `configuration.yaml` replaces ours. They have to manually re-add the `http:` block — otherwise `home.<domain>` goes back to 400. Worth a smarter `!include`-based pattern in a follow-up.

## Test plan
- [x] Live-verified on stuck install: `home.dopp.cloud` went from 400 to 302 after writing the file + restarting HA
- [x] `npm test tests/backend/template_consistency.test.ts` passes
- [ ] Fresh install: configuration.yaml lands with both blocks; HA boots clean; NPM-proxied requests reach HA
- [ ] Re-deploy on existing v2 install: user picks "apply v3" → configuration.yaml gets the http block

🤖 Generated with [Claude Code](https://claude.com/claude-code)