### PR TITLE
feat(wizard): hoist operator email into Domain step (#365)

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -17,6 +17,7 @@ import {
 import { generateLocalKey } from '@/app/actions/ssh';
 import { fetchTemplates, fetchReadme, fetchTemplateYaml, fetchTemplateVariables, fetchTemplateConfigFiles, fetchTemplatePostDeployScript } from '@/app/actions';
 import { parseTemplateLabel } from '@/lib/templateLabel';
+import { isValidOperatorEmail, operatorEmailIssue } from '@/lib/operatorEmail';
 import { getNodes } from '@/app/actions/system';
 import { Template, VariableMeta } from '@/lib/registry';
 import type { TemplateTier } from '@/lib/templateTier';
@@ -227,6 +228,16 @@ export default function OnboardingWizard() {
     setPublicDomain(val);
     if (val) setInstallMode('public');
   };
+  /** Operator e-mail. Used as NPM's admin login + Let's Encrypt ACME
+   *  registration. Mandatory in public mode (LE rejects `.local` and
+   *  empty values); ignored in LAN-only mode. Pre-filled from
+   *  `config.notifications.email.to[0]` so the operator doesn't retype
+   *  the address they already gave us during bootstrap.
+   *
+   *  Fans out at variable-collection time (#365): any template variable
+   *  named `NGINX_ADMIN_EMAIL` is overridden with this value and marked
+   *  global so it disappears from the configure step. */
+  const [operatorEmail, setOperatorEmail] = useState('');
   const [stackDeviceOptions, setStackDeviceOptions] = useState<Record<string, string[]>>({});
   const [stackLoadingDevices, setStackLoadingDevices] = useState(false);
 
@@ -546,19 +557,32 @@ export default function OnboardingWizard() {
   // the operator passed --domain to the bootstrap). Same setting that
   // handleStackFetchVars reads later — pulling it eagerly here just
   // means the operator sees their domain rather than an empty input.
+  //
+  // Same call pre-fills `operatorEmail` from
+  // `config.notifications.email.to[0]` — the operator already gave us
+  // this during bootstrap so they don't have to retype.
   useEffect(() => {
     if (currentStep !== 'install-confirm') return;
-    if (stackDomain || stackNoDomain) return;
+    if (stackDomain && operatorEmail) return;
     let cancelled = false;
     fetch('/api/settings').then(r => r.ok ? r.json() : null).then(s => {
       if (cancelled) return;
-      const baked = s?.reverseProxy?.publicDomain;
-      if (typeof baked === 'string' && baked.length > 0) {
-        setStackDomain(baked);
+      if (!stackDomain && !stackNoDomain) {
+        const baked = s?.reverseProxy?.publicDomain;
+        if (typeof baked === 'string' && baked.length > 0) {
+          setStackDomain(baked);
+        }
       }
-    }).catch(() => { /* silent — operator can type the domain */ });
+      if (!operatorEmail) {
+        const notifyTo = s?.notifications?.email?.to;
+        const firstTo = Array.isArray(notifyTo) ? notifyTo[0] : undefined;
+        if (typeof firstTo === 'string' && firstTo.includes('@')) {
+          setOperatorEmail(firstTo);
+        }
+      }
+    }).catch(() => { /* silent — operator can type the values */ });
     return () => { cancelled = true; };
-  }, [currentStep, stackDomain, stackNoDomain]);
+  }, [currentStep, stackDomain, stackNoDomain, operatorEmail]);
 
   const navigateTo = (step: WizardStep) => {
       setStepHistory(prev => [...prev, currentStep]);
@@ -950,6 +974,10 @@ export default function OnboardingWizard() {
       if (v === 'PUBLIC_DOMAIN' && stackDomain) { value = stackDomain; isGlobal = true; }
       // Auto-fill LLDAP_HOST — always localhost when installing in the same stack
       if (v === 'LLDAP_HOST') { value = 'localhost'; isGlobal = true; }
+      // Pre-fill NGINX_ADMIN_EMAIL from the operator-email prompt and
+      // hide it from the configure step (#365). Doubles as NPM admin
+      // login + LE ACME registration email — both need a real address.
+      if (v === 'NGINX_ADMIN_EMAIL' && operatorEmail) { value = operatorEmail; isGlobal = true; }
       if (!value && meta?.default) value = meta.default;
       if (!value && meta?.type === 'secret') value = generateRandomSecret();
       return { name: v, value, global: isGlobal, meta };
@@ -1771,6 +1799,35 @@ export default function OnboardingWizard() {
                                     <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
                                         Enables HTTPS via Let&apos;s Encrypt + external access. Services live at <span className="font-mono">vault.{publicDomain || 'example.com'}</span>, <span className="font-mono">photos.{publicDomain || 'example.com'}</span>, …
                                     </p>
+                                    {/* Operator-email input (#365). NPM admin
+                                        login + Let's Encrypt ACME registration.
+                                        Pre-filled from notifications.email.to[0]
+                                        so the operator doesn't retype. */}
+                                    {installMode === 'public' && (
+                                      <div className="mt-2">
+                                        <label className="block text-[11px] font-medium text-blue-800 dark:text-blue-200 mb-1">
+                                            Email for Let&apos;s Encrypt + NPM admin
+                                        </label>
+                                        <input
+                                            type="email"
+                                            value={operatorEmail}
+                                            onChange={e => setOperatorEmail(e.target.value)}
+                                            className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+                                            placeholder="you@example.com"
+                                            autoComplete="email"
+                                        />
+                                        {operatorEmail && !isValidOperatorEmail(operatorEmail) && (
+                                            <p className="text-[11px] text-amber-700 dark:text-amber-400 mt-1">
+                                                {operatorEmailIssue(operatorEmail)}
+                                            </p>
+                                        )}
+                                        {!operatorEmail && (
+                                            <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
+                                                Required so Let&apos;s Encrypt can issue certificates. Use a real address — <span className="font-mono">.local</span>/<span className="font-mono">.example</span>/<span className="font-mono">.test</span> are rejected.
+                                            </p>
+                                        )}
+                                      </div>
+                                    )}
                                 </div>
                             </label>
                             {/* LAN option */}
@@ -1924,6 +1981,31 @@ export default function OnboardingWizard() {
                                 <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
                                     Enables HTTPS via Let&apos;s Encrypt + external access. Services live at <span className="font-mono">vault.{publicDomain || 'example.com'}</span>, <span className="font-mono">photos.{publicDomain || 'example.com'}</span>, …
                                 </p>
+                                {installMode === 'public' && (
+                                  <div className="mt-2">
+                                    <label className="block text-[11px] font-medium text-blue-800 dark:text-blue-200 mb-1">
+                                        Email for Let&apos;s Encrypt + NPM admin
+                                    </label>
+                                    <input
+                                        type="email"
+                                        value={operatorEmail}
+                                        onChange={e => setOperatorEmail(e.target.value)}
+                                        className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-blue-300 dark:border-blue-700 rounded-md text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+                                        placeholder="you@example.com"
+                                        autoComplete="email"
+                                    />
+                                    {operatorEmail && !isValidOperatorEmail(operatorEmail) && (
+                                        <p className="text-[11px] text-amber-700 dark:text-amber-400 mt-1">
+                                            {operatorEmailIssue(operatorEmail)}
+                                        </p>
+                                    )}
+                                    {!operatorEmail && (
+                                        <p className="text-[11px] text-blue-700 dark:text-blue-300 mt-1">
+                                            Required so Let&apos;s Encrypt can issue certificates. Use a real address — <span className="font-mono">.local</span>/<span className="font-mono">.example</span>/<span className="font-mono">.test</span> are rejected.
+                                        </p>
+                                    )}
+                                  </div>
+                                )}
                             </div>
                         </label>
                         {/* LAN option */}
@@ -2883,6 +2965,9 @@ export default function OnboardingWizard() {
                     {!stackDomain.trim() && !stackNoDomain && (
                         <span className="text-xs text-amber-700 dark:text-amber-300">Enter a domain or check LAN-only.</span>
                     )}
+                    {installMode === 'public' && stackDomain.trim() && !isValidOperatorEmail(operatorEmail) && (
+                        <span className="text-xs text-amber-700 dark:text-amber-300">{operatorEmailIssue(operatorEmail)}.</span>
+                    )}
                     {cleanInstall && cleanInstallConfirm !== 'RESET' && (
                         <span className="text-xs text-amber-700 dark:text-amber-300">Type RESET to confirm clean install.</span>
                     )}
@@ -2890,6 +2975,7 @@ export default function OnboardingWizard() {
                         onClick={handleExpressInstall}
                         disabled={
                             (!stackDomain.trim() && !stackNoDomain)
+                            || (installMode === 'public' && !isValidOperatorEmail(operatorEmail))
                             || (cleanInstall && cleanInstallConfirm !== 'RESET')
                             || availableStacks.length === 0
                         }
@@ -2907,6 +2993,9 @@ export default function OnboardingWizard() {
                     {!stackDomain.trim() && !stackNoDomain && (
                         <span className="text-xs text-amber-700 dark:text-amber-300">Set a public domain (or check the LAN-only box) to continue.</span>
                     )}
+                    {installMode === 'public' && stackDomain.trim() && !isValidOperatorEmail(operatorEmail) && (
+                        <span className="text-xs text-amber-700 dark:text-amber-300">{operatorEmailIssue(operatorEmail)}.</span>
+                    )}
                     {cleanInstall && cleanInstallConfirm !== 'RESET' && (
                         <span className="text-xs text-amber-700 dark:text-amber-300">Type RESET to confirm the clean install.</span>
                     )}
@@ -2914,6 +3003,7 @@ export default function OnboardingWizard() {
                         onClick={handleNext}
                         disabled={
                             (!stackDomain.trim() && !stackNoDomain)
+                            || (installMode === 'public' && !isValidOperatorEmail(operatorEmail))
                             || (cleanInstall && cleanInstallConfirm !== 'RESET')
                         }
                     >

--- a/src/lib/operatorEmail.ts
+++ b/src/lib/operatorEmail.ts
@@ -1,0 +1,60 @@
+/**
+ * Validation for the operator e-mail (#365) — the address used both as
+ * NPM admin login and Let's Encrypt ACME registration. LE rejects a
+ * specific set of TLDs and IP-literal addresses at the account-creation
+ * step; we mirror those rules here so the wizard refuses bad input
+ * up-front instead of letting the user discover the failure when they
+ * later click "Request new SSL Certificate".
+ *
+ * Reference: IANA-reserved special-use domains
+ * (RFC 6761 + RFC 2606) — `.local`, `.example`, `.test`, `.invalid`,
+ * `.localhost`. LE's own staging confirms each of these throws on
+ * account create.
+ */
+const LE_REJECTED_TLDS = new Set([
+  'local',
+  'localhost',
+  'example',
+  'test',
+  'invalid',
+]);
+
+/**
+ * True when `value` is a syntactically valid e-mail address whose TLD
+ * Let's Encrypt will accept. Falsy for empty strings, addresses without
+ * an `@`, or addresses ending in a reserved TLD.
+ *
+ * The check is intentionally syntactic — we cannot verify deliverability
+ * from the browser. The goal is to filter out the addresses that LE
+ * provably rejects at registration so the operator doesn't get stuck
+ * later.
+ */
+export function isValidOperatorEmail(value: string): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  // Rough syntax: one or more chars + @ + at least one dotted label.
+  // Whitespace is forbidden anywhere.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) return false;
+  const lastDot = trimmed.lastIndexOf('.');
+  const tld = trimmed.slice(lastDot + 1).toLowerCase();
+  if (LE_REJECTED_TLDS.has(tld)) return false;
+  return true;
+}
+
+/**
+ * Human-readable reason an operator-email value is invalid. Returns the
+ * empty string when the value is acceptable. Used by the wizard's
+ * inline-validation hint so the user knows what to fix.
+ */
+export function operatorEmailIssue(value: string): string {
+  if (!value || !value.trim()) return 'Email is required for Let’s Encrypt';
+  const trimmed = value.trim();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+    return 'Doesn’t look like an email address';
+  }
+  const tld = trimmed.slice(trimmed.lastIndexOf('.') + 1).toLowerCase();
+  if (LE_REJECTED_TLDS.has(tld)) {
+    return `Let’s Encrypt rejects .${tld} addresses — use a real domain`;
+  }
+  return '';
+}

--- a/templates/nginx/variables.json
+++ b/templates/nginx/variables.json
@@ -1,8 +1,8 @@
 {
   "NGINX_ADMIN_EMAIL": {
     "type": "text",
-    "description": "Initial NPM admin email (used as the login for ServiceBay's auto-sync of proxy routes)",
-    "default": "admin@servicebay.local"
+    "description": "NPM admin email + Let's Encrypt ACME registration. The wizard hoists this from the Domain step (operatorEmail) so it stays hidden in the Configure step under normal installs; this entry is only edited directly via the MCP / single-template installer paths. Real address required — LE rejects `.local` / `.example` / `.test`.",
+    "example": "you@example.com"
   },
   "NGINX_ADMIN_PASSWORD": {
     "type": "secret",

--- a/tests/backend/operatorEmail.test.ts
+++ b/tests/backend/operatorEmail.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { isValidOperatorEmail, operatorEmailIssue } from '@/lib/operatorEmail';
+
+describe('isValidOperatorEmail', () => {
+  it('accepts well-formed public-TLD addresses', () => {
+    expect(isValidOperatorEmail('alice@example.com')).toBe(true);
+    expect(isValidOperatorEmail('user.name+tag@sub.domain.co.uk')).toBe(true);
+    expect(isValidOperatorEmail('  trim@example.org  ')).toBe(true);
+  });
+
+  it('rejects empty / malformed values', () => {
+    expect(isValidOperatorEmail('')).toBe(false);
+    expect(isValidOperatorEmail('   ')).toBe(false);
+    expect(isValidOperatorEmail('plain-string')).toBe(false);
+    expect(isValidOperatorEmail('no-at-sign.com')).toBe(false);
+    expect(isValidOperatorEmail('@no-local-part.com')).toBe(false);
+    expect(isValidOperatorEmail('missing-tld@host')).toBe(false);
+    expect(isValidOperatorEmail('has spaces@example.com')).toBe(false);
+  });
+
+  it('rejects Let\'s-Encrypt-rejected TLDs', () => {
+    expect(isValidOperatorEmail('admin@servicebay.local')).toBe(false);
+    expect(isValidOperatorEmail('admin@home.localhost')).toBe(false);
+    expect(isValidOperatorEmail('admin@anything.example')).toBe(false);
+    expect(isValidOperatorEmail('admin@anything.test')).toBe(false);
+    expect(isValidOperatorEmail('admin@anything.invalid')).toBe(false);
+    // Case-insensitive
+    expect(isValidOperatorEmail('admin@anything.LOCAL')).toBe(false);
+  });
+});
+
+describe('operatorEmailIssue', () => {
+  it('returns empty string for valid addresses', () => {
+    expect(operatorEmailIssue('alice@example.com')).toBe('');
+  });
+
+  it('flags empty values with a required-field hint', () => {
+    expect(operatorEmailIssue('')).toMatch(/required/i);
+    expect(operatorEmailIssue('   ')).toMatch(/required/i);
+  });
+
+  it('flags malformed values', () => {
+    expect(operatorEmailIssue('not-an-email')).toMatch(/email/i);
+  });
+
+  it('names the rejected TLD in the hint', () => {
+    expect(operatorEmailIssue('admin@servicebay.local')).toMatch(/\.local/i);
+    expect(operatorEmailIssue('admin@x.test')).toMatch(/\.test/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #365.

- NPM admin / Let's Encrypt registration email was buried in the Configure step's Settings tab. Default `admin@servicebay.local` made every LE cert request fail at the ACME-account-creation step — the user only found out when clicking "Request new SSL Certificate" after install.
- Hoist the address into the Domain step (and the express install-confirm view); pre-fill from `config.notifications.email.to[0]` so the operator doesn't retype the address from bootstrap.
- Validation mirrors what LE refuses: empty, malformed, or TLD ∈ {`.local`, `.localhost`, `.example`, `.test`, `.invalid`}. Continue / Install buttons stay disabled in public mode until the field passes.
- Variable injection: at collection time, `NGINX_ADMIN_EMAIL` is overridden with the operator value and marked global so it disappears from the Configure step — same pattern `PUBLIC_DOMAIN` / `LLDAP_HOST` use.
- `templates/nginx/variables.json`: drops the `.local` default.

## Test plan
- [x] `npm test` — new `tests/backend/operatorEmail.test.ts` covers validation; full suite green
- [ ] Fresh wizard install with public mode: email field visible + required, .local rejected, NPM admin login uses the typed value, LE cert request succeeds
- [ ] LAN-only install: email field hidden, no validation, install proceeds without operator email
- [ ] Pre-fill: `config.notifications.email.to[0]` set during bootstrap auto-populates the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)