### PR TITLE
fix: install regressions — nginx hostPort + wizard Mustache sections

### DIFF
--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -216,9 +216,20 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
               // comment in OnboardingWizard.tsx for the live-debugged
               // pathology that made `{{DATA_DIR}}` end up as a literal
               // `0` in `targetPath`, writing config files under `~/0/`.
+              // Mustache section tags (`{{#NAME}}` / `{{/NAME}}` / `{{^NAME}}`)
+              // must be stripped first — the sentinel below only covers
+              // bare `{{VAR}}` placeholders, so section tokens slip
+              // through, break js-yaml ("missed comma between flow
+              // collection entries"), and any `.mustache` config file
+              // fails to map a hostPath. Stripping is safe here: we only
+              // need the unconditional volumes/mounts to discover the
+              // config-mount hostPath. Mirrors OnboardingWizard.tsx.
+              const SECTION_RE = /\{\{\s*[#^/]\s*[\w\d_]+\s*\}\}/g;
               const SENTINEL_RE_OUT = /\{\{\s*([\w\d_]+)\s*\}\}/g;
               const SENTINEL_RE_IN = /__SBVAR_([\w\d_]+)__/g;
-              const safeYaml = yaml.replace(SENTINEL_RE_OUT, (_m, n) => `__SBVAR_${n}__`);
+              const safeYaml = yaml
+                .replace(SECTION_RE, '')
+                .replace(SENTINEL_RE_OUT, (_m, n) => `__SBVAR_${n}__`);
               const restorePlaceholders = (s: string): string =>
                 s.replace(SENTINEL_RE_IN, (_m, n) => `{{${n}}}`);
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -896,9 +896,22 @@ export default function OnboardingWizard() {
           // sentinel that preserves the variable name, parse, then decode
           // back to `{{X}}` in the extracted strings. Mustache.render at
           // deploy time resolves them with the user's actual values.
+          // Mustache section tags (`{{#NAME}}` / `{{/NAME}}` / `{{^NAME}}`)
+          // must be stripped before YAML parsing — the sentinel below only
+          // covers bare `{{VAR}}` placeholders, so section tokens slip
+          // through, land mid-list, and js-yaml chokes with
+          // "missed comma between flow collection entries". The volume map
+          // then stays empty and any `.mustache` config file fails to map
+          // a hostPath, tripping the ServiceManager extraFiles guard with
+          // a misleading "didn't send to deploy step" error. Stripping is
+          // safe here: we only need the unconditional volumes/mounts to
+          // discover the config-mount hostPath.
+          const SECTION_RE = /\{\{\s*[#^/]\s*[\w\d_]+\s*\}\}/g;
           const SENTINEL_RE_OUT = /\{\{\s*([\w\d_]+)\s*\}\}/g;
           const SENTINEL_RE_IN = /__SBVAR_([\w\d_]+)__/g;
-          const safeYaml = yaml.replace(SENTINEL_RE_OUT, (_m, n) => `__SBVAR_${n}__`);
+          const safeYaml = yaml
+            .replace(SECTION_RE, '')
+            .replace(SENTINEL_RE_OUT, (_m, n) => `__SBVAR_${n}__`);
           const restorePlaceholders = (s: string): string =>
             s.replace(SENTINEL_RE_IN, (_m, n) => `{{${n}}}`);
           // Multi-doc support — file-share ships Pod + PVC since 3.6.4.

--- a/templates/nginx/template.yml
+++ b/templates/nginx/template.yml
@@ -7,8 +7,9 @@ metadata:
     servicebay.role: reverse-proxy
   annotations:
     servicebay.label: "Nginx Proxy Manager"
-    servicebay.schema-version: "2"
+    servicebay.schema-version: "3"
     servicebay.tier: "infrastructure"
+    servicebay.ports: "{{NGINX_PORT}}/tcp,{{NGINX_SSL_PORT}}/tcp,{{NGINX_ADMIN_PORT}}/tcp"
 spec:
   hostNetwork: true
   containers:
@@ -19,13 +20,18 @@ spec:
       value: "{{NGINX_ADMIN_EMAIL}}"
     - name: INITIAL_ADMIN_PASSWORD
       value: "{{NGINX_ADMIN_PASSWORD}}"
+    # `hostPort:` is invalid under hostNetwork — podman rejects it with
+    # "PortMappings can only be used with Bridge, slirp4netns, or pasta
+    # networking" and the pod crash-loops. Under hostNetwork the container
+    # binds {{NGINX_PORT}}/{{NGINX_SSL_PORT}}/{{NGINX_ADMIN_PORT}} directly
+    # on the host; the servicebay.ports annotation above carries the port
+    # list for the UI / network graph. The NPM image listens on 80/443/81
+    # internally, so the operator's chosen values only work as-is when
+    # they match those defaults.
     ports:
-    - containerPort: 80
-      hostPort: {{NGINX_PORT}}
-    - containerPort: 443
-      hostPort: {{NGINX_SSL_PORT}}
-    - containerPort: 81
-      hostPort: {{NGINX_ADMIN_PORT}}
+    - containerPort: {{NGINX_PORT}}
+    - containerPort: {{NGINX_SSL_PORT}}
+    - containerPort: {{NGINX_ADMIN_PORT}}
     volumeMounts:
     - mountPath: /data
       name: npm-data


### PR DESCRIPTION
## Summary

Two independent regressions a fresh-install hit back-to-back. Both stop the install from completing.

- **nginx pod crash-loops:** PR #364 added `hostNetwork: true` but left `hostPort:` mappings in place. Podman rejects that combination (`PortMappings can only be used with Bridge, slirp4netns, or pasta networking`), the pod never starts, and the wizard hangs on `Still waiting for Nginx Proxy Manager...`. Fixed by dropping `hostPort:` (the other hostNetwork templates already use this shape) and moving the port metadata into a `servicebay.ports` annotation. Schema bumped to v3.
- **home-assistant deploy aborts with a misleading config-mount error:** the wizard's config-file resolver sentinel-encodes `{{VAR}}` placeholders before YAML parsing, but the regex misses Mustache section tags (`{{#NAME}}` / `{{/NAME}}`). They land mid-list, js-yaml dies (`missed comma between flow collection entries`), the volume map stays empty, `configuration.yaml` never gets a `targetPath`, and the ServiceManager extraFiles guard then aborts with the confusing  *"check that the pod manifest declares servicebay.config-mount..."* message — even though the template's annotation was correct all along. Mirrored fix in `OnboardingWizard.tsx` + `InstallerModal.tsx`.

## Test plan
- [x] Reproduced `missed comma between flow collection entries` from the live `home-assistant/template.yml` before the fix; verified the fix resolves `/config` → `{{DATA_DIR}}/home-assistant/homeassistant`
- [x] Pre-push test suite green (`vitest run` via husky pre-push)
- [x] Live-verified the nginx fix on my own server: rewrote the deployed YAML via `update_service_yaml`, NPM came up cleanly, schema migrations + first-init bootstrap completed
- [ ] Fresh-install on a clean node walks through all templates including home-assistant without retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)