### PR TITLE
fix(install): stop wizard device-poll runaway during install

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -767,7 +767,12 @@ export default function OnboardingWizard() {
         if (devices.length === 1) installFlow.setVariableValue(v.name, devices[0]);
       }
     });
-  }, [stackSelectedNode, stackVariables, installFlow]);
+    // Depend on the specific stable callback, NOT the whole `installFlow`
+    // object — the hook's return literal is recreated every render, which
+    // would otherwise re-fire this effect on every appendLog during install
+    // and saturate the browser's HTTP connection pool with
+    // /api/system/devices polls.
+  }, [stackSelectedNode, stackVariables, installFlow.setVariableValue]);
 
   // Detect unmounted RAID arrays when node is selected
   useEffect(() => {

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -253,12 +253,31 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     nodeRef.current = '';
   }, []);
 
+  // No-op writes return the same array reference so subscribers (e.g. the
+  // wizard's device-poll effect) don't see a spurious change. Pre-refactor
+  // (v3.19.1) the wizard owned variables state and guarded with a
+  // `changed ? next : prev` map; the v3.19.2 refactor moved state in here
+  // and lost that guard, which turned the device-poll effect into a hot
+  // loop during install (every appendLog re-render queued another
+  // /api/system/devices fetch and saturated the browser connection pool).
   const setItemChecked = useCallback((name: string, checked: boolean) => {
-    setItems(prev => prev.map(i => (i.name === name ? { ...i, checked } : i)));
+    setItems(prev => {
+      const i = prev.findIndex(x => x.name === name);
+      if (i === -1 || prev[i].checked === checked) return prev;
+      const next = prev.slice();
+      next[i] = { ...next[i], checked };
+      return next;
+    });
   }, []);
 
   const setVariableValue = useCallback((name: string, value: string) => {
-    setVariables(prev => prev.map(v => (v.name === name ? { ...v, value } : v)));
+    setVariables(prev => {
+      const i = prev.findIndex(x => x.name === name);
+      if (i === -1 || prev[i].value === value) return prev;
+      const next = prev.slice();
+      next[i] = { ...next[i], value };
+      return next;
+    });
   }, []);
 
   const startConfigure = useCallback(async (

--- a/tests/frontend/useStackInstall.test.tsx
+++ b/tests/frontend/useStackInstall.test.tsx
@@ -462,6 +462,77 @@ spec:
     });
   });
 
+  describe('referential stability — no-op writes preserve array reference', () => {
+    // Regression guard for the wizard device-poll runaway loop. The
+    // OnboardingWizard's "fetch USB devices" effect depends on
+    // `stackVariables` (the hook's `variables`). Pre-refactor (v3.19.1)
+    // the wizard owned variables state and used `prev.map → changed ? next : prev`
+    // so no-op writes returned the same array reference. The v3.19.2
+    // refactor moved state into this hook but the new setter always
+    // allocated a new array, which made the effect re-fire on every
+    // render and hammered `/api/system/devices` at ~90Hz during install
+    // — saturating the browser HTTP pool and causing intermittent
+    // `Failed to fetch` on the streaming `/api/services` POST.
+    //
+    // The contract: `setVariableValue(name, sameValue)` and
+    // `setItemChecked(name, sameChecked)` MUST NOT change the array
+    // reference. Any future refactor that breaks this regresses the
+    // wizard's install reliability.
+    it('setItemChecked keeps the same items reference when checked is unchanged', () => {
+      const { result } = renderHook(() =>
+        useStackInstall({ templateSource: 'Built-in' }),
+      );
+      act(() => {
+        result.current.setItems([
+          { name: 'a', checked: true },
+          { name: 'b', checked: false },
+        ]);
+      });
+      const before = result.current.items;
+      act(() => result.current.setItemChecked('a', true));
+      expect(result.current.items).toBe(before);
+      act(() => result.current.setItemChecked('unknown', true));
+      expect(result.current.items).toBe(before);
+      act(() => result.current.setItemChecked('a', false));
+      expect(result.current.items).not.toBe(before);
+      expect(result.current.items.find(i => i.name === 'a')?.checked).toBe(false);
+    });
+
+    it('setVariableValue keeps the same variables reference when value is unchanged', async () => {
+      (fetchTemplateYaml as any).mockResolvedValue(
+        'apiVersion: v1\nkind: Pod\nmetadata:\n  name: x\nspec:\n  containers:\n  - name: x\n    env:\n    - name: FOO\n      value: "{{FOO}}"',
+      );
+      (fetchTemplateVariables as any).mockResolvedValue({
+        FOO: { type: 'text', default: 'bar' },
+      });
+      (fetchTemplateConfigFiles as any).mockResolvedValue([]);
+      (fetchTemplatePostDeployScript as any).mockResolvedValue(null);
+      global.fetch = buildFetchMock({
+        '/api/settings': () => ({ jsonBody: { templateSettings: {} } }),
+      });
+
+      const { result } = renderHook(() =>
+        useStackInstall({ templateSource: 'Built-in' }),
+      );
+      await act(async () => {
+        await result.current.startConfigure(
+          [{ name: 'x', checked: true }],
+          {},
+        );
+      });
+      expect(result.current.variables.find(v => v.name === 'FOO')?.value).toBe('bar');
+
+      const before = result.current.variables;
+      act(() => result.current.setVariableValue('FOO', 'bar'));
+      expect(result.current.variables).toBe(before);
+      act(() => result.current.setVariableValue('UNKNOWN_VAR', 'whatever'));
+      expect(result.current.variables).toBe(before);
+      act(() => result.current.setVariableValue('FOO', 'baz'));
+      expect(result.current.variables).not.toBe(before);
+      expect(result.current.variables.find(v => v.name === 'FOO')?.value).toBe('baz');
+    });
+  });
+
   describe('OIDC client registration', () => {
     it('POSTs to authelia/oidc-clients when subdomain vars carry oidcClient metadata', async () => {
       (fetchTemplateYaml as any).mockResolvedValue(


### PR DESCRIPTION
## Summary

The OnboardingWizard's "fetch USB devices" effect re-fired on every render during install — once `home-assistant` (or any other template with a `type: device` variable) was in the selected stack, the effect was emitting ~90 `/api/system/devices` fetches per second, saturating the browser's HTTP connection pool and causing intermittent `Failed to fetch` on the long-lived streaming `/api/services` POST. Some deploys (e.g. `adguard`, `file-share`) failed where neighbours succeeded by luck of timing.

## Root cause (regression from #341 phase 2, v3.19.1 → v3.19.2)

Two compounding bugs introduced when state moved into `useStackInstall`:

1. **`setVariableValue` / `setItemChecked` lost the "no-op = same ref" invariant.** Pre-refactor (v3.19.1) the wizard owned variables state and guarded with `setStackVariables(prev => changed ? next : prev)`. The refactor switched to `prev.map(...)`, which always allocates a new array — even for no-op writes.

2. **The wizard's device-poll effect deps included the whole `installFlow` object** (the un-memoized return literal from `useStackInstall`). That object is fresh every render, so React's `Object.is` dep check always failed, firing the effect unconditionally.

During install, each streamed log line calls `appendLog` → `setLogs` → re-render → new `installFlow` → effect fires → fetch → response comes back → if it auto-picked a device, `setVariableValue` allocated a new variables array → another render. The result is a hot loop.

## Fix

- **`useStackInstall.ts`** — `setVariableValue` and `setItemChecked` return `prev` on no-op writes, restoring the pre-refactor invariant the wizard relied on (and making the engine API safer for future subscribers).
- **`OnboardingWizard.tsx`** — device-poll effect now depends on the specific stable callback `installFlow.setVariableValue` instead of the whole `installFlow` object. Mirrors what `InstallerModal.tsx` already does (`[selectedNode, controller.variables]`).
- **`tests/frontend/useStackInstall.test.tsx`** — new test locks in the "no-op writes preserve array reference" contract.

InstallerModal didn't regress because its effect deps already used a stable slice (`controller.variables`).

## Test plan
- [x] `npx vitest run tests/frontend/useStackInstall.test.tsx` — 13/13 pass (2 new + 11 existing)
- [x] `npx vitest run tests/frontend/OnboardingWizard.test.tsx` — 20/21 pass (1 pre-existing skip)
- [ ] Manual: run a multi-template install (incl. home-assistant) end-to-end and confirm no `Failed to fetch` retries fire and `/api/system/devices` is hit only once per node

🤖 Generated with [Claude Code](https://claude.com/claude-code)