### PR TITLE
feat(diagnose): adguard_rewrites_missing probe + reprovision action

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -9,6 +9,7 @@ import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPoi
 import { checkPostDeployFailed } from '@/lib/diagnose/probes/postDeployFailed';
 import { checkProxyRouteMissing } from '@/lib/diagnose/probes/proxyRouteMissing';
 import { checkCertExpiry } from '@/lib/diagnose/probes/certExpiry';
+import { checkAdguardRewritesMissing } from '@/lib/diagnose/probes/adguardRewritesMissing';
 import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
@@ -650,6 +651,30 @@ export async function POST(request: Request) {
     probes.push({
       id: 'cert_expiry',
       label: 'TLS certificates',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 17) AdGuard DNS rewrites. The portal provisioner is fire-and-forget
+  //     at install + 60s after boot; either invocation can silently
+  //     fail (AdGuard cold-starting, auth flapping). This probe is the
+  //     safety net — it diffs AdGuard's current rewrite list against
+  //     the expected set and offers a one-click "Reprovision" that
+  //     re-runs the same code path.
+  try {
+    const ar = await checkAdguardRewritesMissing();
+    probes.push({
+      id: 'adguard_rewrites_missing',
+      label: 'AdGuard DNS rewrites',
+      status: ar.status,
+      detail: ar.detail,
+      hint: ar.hint,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'adguard_rewrites_missing',
+      label: 'AdGuard DNS rewrites',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/src/lib/diagnose/probes/adguardRewritesMissing.test.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.test.ts
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `vi.mock` hoists above any top-level `const`, so we can't reference
+// shared state directly. Instead, expose state via getters and mock
+// modules with closures that read those getters at call time.
+const state = {
+  config: {} as any,
+  rewrites: [] as { domain: string; answer: string }[],
+  provisionResult: { ok: true, detail: 'proxy:unchanged rewrites=*.dopp.cloud:unchanged' } as any,
+  provisionThrows: null as Error | null,
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('@/lib/adguard/rewrites', () => ({
+  listRewrites: vi.fn(() => Promise.resolve(state.rewrites)),
+}));
+
+vi.mock('@/lib/portal/provisioner', () => ({
+  provisionPortalRouting: vi.fn(() => {
+    if (state.provisionThrows) return Promise.reject(state.provisionThrows);
+    return Promise.resolve(state.provisionResult);
+  }),
+}));
+
+import { checkAdguardRewritesMissing } from './adguardRewritesMissing';
+import { dispatchProbeAction } from '../actions';
+import './adguardRewritesMissing';
+
+beforeEach(() => {
+  state.config = {
+    installedTemplates: { adguard: { schemaVersion: 1, installedAt: '' } },
+    adguard: { adminUrl: 'http://localhost:8083', username: 'admin', password: 'pw' },
+    reverseProxy: { lanIp: '192.168.1.10', publicDomain: 'dopp.cloud' },
+  };
+  state.rewrites = [];
+  state.provisionResult = { ok: true, detail: 'proxy:unchanged rewrites=*.dopp.cloud:unchanged' };
+  state.provisionThrows = null;
+});
+
+describe('checkAdguardRewritesMissing', () => {
+  it('returns ok when AdGuard is not installed', async () => {
+    state.config = { installedTemplates: {} };
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/not installed/);
+  });
+
+  it('returns info when AdGuard credentials are not recorded', async () => {
+    state.config = {
+      installedTemplates: { adguard: { schemaVersion: 1, installedAt: '' } },
+      adguard: undefined,
+      reverseProxy: { lanIp: '192.168.1.10' },
+    };
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('info');
+    expect(r.detail).toMatch(/credentials are not recorded/);
+  });
+
+  it('returns info when LAN IP is missing', async () => {
+    state.config.reverseProxy = { publicDomain: 'dopp.cloud' };
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('info');
+    expect(r.detail).toMatch(/LAN IP/);
+  });
+
+  it('warns when wildcard + apex rewrites are missing', async () => {
+    state.rewrites = [];
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('warn');
+    // Expected: home.arpa trio + dopp.cloud trio = 6 entries.
+    expect(r.detail).toMatch(/6 missing/);
+    expect(r.detail).toContain('*.dopp.cloud');
+    expect(r.detail).toContain('*.home.arpa');
+    expect(r.hint).toMatch(/Reprovision/);
+  });
+
+  it('warns when a rewrite points at the wrong IP', async () => {
+    state.rewrites = [
+      { domain: 'dopp.cloud', answer: '192.168.1.10' },
+      { domain: 'www.dopp.cloud', answer: '192.168.1.10' },
+      { domain: '*.dopp.cloud', answer: '10.0.0.1' }, // stale
+      { domain: 'home.arpa', answer: '192.168.1.10' },
+      { domain: 'www.home.arpa', answer: '192.168.1.10' },
+      { domain: '*.home.arpa', answer: '192.168.1.10' },
+    ];
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/pointing elsewhere/);
+    expect(r.detail).toContain('*.dopp.cloud → 10.0.0.1');
+  });
+
+  it('returns ok when every expected rewrite is present and correct', async () => {
+    state.rewrites = [
+      { domain: 'dopp.cloud', answer: '192.168.1.10' },
+      { domain: 'www.dopp.cloud', answer: '192.168.1.10' },
+      { domain: '*.dopp.cloud', answer: '192.168.1.10' },
+      { domain: 'home.arpa', answer: '192.168.1.10' },
+      { domain: 'www.home.arpa', answer: '192.168.1.10' },
+      { domain: '*.home.arpa', answer: '192.168.1.10' },
+    ];
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/6 portal\/wildcard rewrites in AdGuard point at 192\.168\.1\.10/);
+  });
+
+  it('skips the public domain when no public domain is configured (LAN-only mode)', async () => {
+    state.config.reverseProxy = { lanIp: '192.168.1.10' }; // no publicDomain
+    state.rewrites = [
+      { domain: 'home.arpa', answer: '192.168.1.10' },
+      { domain: 'www.home.arpa', answer: '192.168.1.10' },
+      { domain: '*.home.arpa', answer: '192.168.1.10' },
+    ];
+    const r = await checkAdguardRewritesMissing();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/3 portal\/wildcard rewrites/);
+  });
+});
+
+describe('adguard_rewrites_missing.reprovision', () => {
+  it('returns ok and a details summary when provisionPortalRouting succeeds', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'adguard_rewrites_missing',
+      actionId: 'reprovision',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/reprovisioned/);
+    expect(result.details).toBe('proxy:unchanged rewrites=*.dopp.cloud:unchanged');
+    expect(result.refresh).toBe(true);
+  });
+
+  it('surfaces the structured detail when the provisioner reports partial failure', async () => {
+    state.provisionResult = { ok: false, detail: 'proxy:failed rewrites=*.dopp.cloud:failed' };
+    const result = await dispatchProbeAction({
+      probeId: 'adguard_rewrites_missing',
+      actionId: 'reprovision',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/finished with errors/);
+    expect(result.details).toContain('failed');
+  });
+
+  it('returns ok=false when the provisioner throws', async () => {
+    state.provisionThrows = new Error('AdGuard unreachable');
+    const result = await dispatchProbeAction({
+      probeId: 'adguard_rewrites_missing',
+      actionId: 'reprovision',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('AdGuard unreachable');
+  });
+});

--- a/src/lib/diagnose/probes/adguardRewritesMissing.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.ts
@@ -1,0 +1,189 @@
+/**
+ * `adguard_rewrites_missing` probe — surfaces when AdGuard is missing
+ * the portal-apex / wildcard DNS rewrites that LAN devices need in
+ * order to resolve `<sub>.<domain>` to ServiceBay's LAN IP.
+ *
+ * The install-time provisioner (`provisionPortalRouting`) is invoked
+ * fire-and-forget after AdGuard's post-deploy stamps credentials, and
+ * again 60s after server boot. Either invocation can silently fail
+ * — AdGuard not yet listening, auth flapping, /control/rewrite/list
+ * returning non-200 — and the operator gets no feedback until they
+ * notice that *.<domain> doesn't resolve. This probe is the safety
+ * net: it derives the expected set the same way the provisioner does
+ * and compares it to what AdGuard actually has, surfacing a
+ * single-button "Reprovision" action that re-runs the same code path.
+ *
+ * Detection (per `getActiveDomain` / `provisionPortalRouting`):
+ *   - lanDomain (default `home.arpa`) always contributes three entries:
+ *       <lanDomain>, www.<lanDomain>, *.<lanDomain>  → lanIp
+ *   - publicDomain (when set) contributes the same trio for itself.
+ * A rewrite is "missing" if the expected domain isn't present at all,
+ * and "stale" if it points at an IP that isn't the current lanIp.
+ */
+
+import { getConfig } from '@/lib/config';
+import { listRewrites } from '@/lib/adguard/rewrites';
+import { provisionPortalRouting } from '@/lib/portal/provisioner';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const PROBE_ID = 'adguard_rewrites_missing';
+const DEFAULT_LAN_DOMAIN = 'home.arpa';
+
+export interface AdguardRewritesMissingResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+}
+
+/** Build the expected set of AdGuard rewrite domains for the current
+ *  install. Mirrors the loop inside `provisionPortalRouting` so the
+ *  two stay in lockstep — if that function changes the rewrite shape,
+ *  this needs to follow. */
+function buildExpectedRewrites(
+  lanDomain: string | undefined,
+  publicDomain: string | undefined,
+): string[] {
+  const domains: string[] = [];
+  const lan = (lanDomain && lanDomain.trim()) || DEFAULT_LAN_DOMAIN;
+  if (lan) domains.push(lan);
+  const pub = publicDomain?.trim();
+  if (pub && pub !== lan) domains.push(pub);
+  const out: string[] = [];
+  for (const d of domains) {
+    out.push(d, `www.${d}`, `*.${d}`);
+  }
+  return out;
+}
+
+export async function checkAdguardRewritesMissing(): Promise<AdguardRewritesMissingResult> {
+  const config = await getConfig();
+
+  // Skip when AdGuard isn't installed — nothing to provision against.
+  // The npm/cert/pods probes already cover the "service missing" case.
+  if (!config.installedTemplates?.adguard) {
+    return {
+      status: 'ok',
+      detail: 'AdGuard is not installed — DNS rewrite check skipped.',
+    };
+  }
+
+  const adguard = config.adguard;
+  if (!adguard?.password) {
+    // Credentials live in a separate config block written by AdGuard's
+    // post-deploy. Without them we can't query /control/rewrite/list —
+    // surface as info so the probe doesn't masquerade as healthy, and
+    // leave the actual remediation to the credentials-saving flow.
+    return {
+      status: 'info',
+      detail: 'AdGuard credentials are not recorded yet — DNS rewrite check skipped.',
+    };
+  }
+
+  const lanIp = config.reverseProxy?.lanIp;
+  if (!lanIp) {
+    return {
+      status: 'info',
+      detail: 'No LAN IP recorded in config — DNS rewrite check skipped.',
+    };
+  }
+
+  const expected = buildExpectedRewrites(
+    config.reverseProxy?.lanDomain,
+    config.reverseProxy?.publicDomain,
+  );
+
+  let actual: Awaited<ReturnType<typeof listRewrites>>;
+  try {
+    actual = await listRewrites({
+      adminUrl:
+        adguard.adminUrl ||
+        `http://localhost:${config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083'}`,
+      username: adguard.username || 'admin',
+      password: adguard.password,
+    });
+  } catch (e) {
+    return {
+      status: 'info',
+      detail: `Could not reach AdGuard to list rewrites: ${e instanceof Error ? e.message : String(e)}.`,
+    };
+  }
+
+  // `listRewrites` swallows network/auth failures and returns []. An
+  // empty list against an installed AdGuard is more likely "rewrites
+  // were never created" than "AdGuard has zero rewrites by design",
+  // so we lean toward warn — the Reprovision action is safe either
+  // way because `ensureWildcardRewrite` is idempotent.
+  const byDomain = new Map(actual.map(r => [r.domain, r.answer]));
+  const missing: string[] = [];
+  const stale: string[] = [];
+  for (const d of expected) {
+    const got = byDomain.get(d);
+    if (got === undefined) missing.push(d);
+    else if (got !== lanIp) stale.push(`${d} → ${got}`);
+  }
+
+  if (missing.length === 0 && stale.length === 0) {
+    return {
+      status: 'ok',
+      detail: `${expected.length} portal/wildcard rewrite${
+        expected.length === 1 ? '' : 's'
+      } in AdGuard point at ${lanIp}.`,
+    };
+  }
+
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`${missing.length} missing (${missing.join(', ')})`);
+  if (stale.length > 0) {
+    parts.push(`${stale.length} pointing elsewhere (${stale.join('; ')})`);
+  }
+
+  return {
+    status: 'warn',
+    detail: `AdGuard DNS rewrites incomplete: ${parts.join('; ')}.`,
+    hint: 'LAN devices can\'t resolve service subdomains to ServiceBay until these exist. Click "Reprovision" to re-run the install-time provisioner — it is idempotent and only touches the entries that are missing or stale.',
+  };
+}
+
+/** Action handler — re-runs `provisionPortalRouting` end-to-end, the
+ *  same code path the install wizard and the 60s-post-boot hook use.
+ *  Surfaces the structured `detail` summary as `details` so the
+ *  operator sees which rewrites were added vs unchanged. */
+async function reprovision(): Promise<ProbeActionResult> {
+  try {
+    const result = await provisionPortalRouting();
+    if (!result.ok) {
+      return {
+        ok: false,
+        message: `Reprovision finished with errors: ${result.detail}`,
+        details: result.detail,
+        refresh: true,
+      };
+    }
+    return {
+      ok: true,
+      message: 'AdGuard rewrites reprovisioned.',
+      details: result.detail,
+      refresh: true,
+    };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn('diagnose:adguard_rewrites_missing', `Reprovision threw: ${message}`);
+    return {
+      ok: false,
+      message: `Reprovision failed: ${message}`,
+      refresh: false,
+    };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'reprovision',
+    label: 'Reprovision',
+    description:
+      'Re-runs the install-time portal provisioner: adds the apex, www, and wildcard DNS rewrites for your active domains and the LAN domain. Idempotent — existing rewrites with the right answer are left untouched.',
+  },
+  reprovision,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -23,5 +23,6 @@ import './healthChecks';
 import './disk';
 import './podsAndEngine';
 import './certExpiry';
+import './adguardRewritesMissing';
 
 export {};


### PR DESCRIPTION
## Summary
- Adds a `adguard_rewrites_missing` diagnose probe that detects when AdGuard is missing the portal-apex / wildcard DNS rewrites the install-time provisioner is supposed to create.
- Probe diffs `/control/rewrite/list` against the expected set (`<d>`, `www.<d>`, `*.<d>` for both `lanDomain` and `publicDomain`) and surfaces a one-click `reprovision` action when anything is missing or stale.
- Action delegates to the existing `provisionPortalRouting()` helper, so the diagnose path and the manual `/api/system/portal/provision` endpoint can't drift.

## Why
`provisionPortalRouting()` runs fire-and-forget after AdGuard's post-deploy and again 60s after server boot. Either invocation can silently fail (AdGuard cold-starting, auth flapping, transient 4xx) and the operator has no signal — LAN devices just can't resolve `*.<domain>` until someone notices. Hit this on a fresh reinstall today. Matches the self-heal + structured-actions pattern in `docs/UX_PHILOSOPHY.md`.

## Test plan
- [x] `npx vitest run src/lib/diagnose/` — 67 tests pass (57 existing + 10 new).
- [x] Lint clean (`eslint --fix` via pre-commit).
- [x] Pre-push test suite passes.
- [ ] After merge + release, delete one rewrite in AdGuard and confirm the probe fires `warn` and the "Reprovision" action restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)