### PR TITLE
fix(terminal): container:local:* fails in container-mode install

### DIFF
--- a/src/lib/terminal/sessionManager.test.ts
+++ b/src/lib/terminal/sessionManager.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  nodes: [] as any[],
+};
+
+vi.mock('../nodes', () => ({
+  listNodes: vi.fn(() => Promise.resolve(state.nodes)),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// node-pty pulls in a native binary at import time. The functions under test
+// don't spawn anything (they just compute the spec), so stub the module out.
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+import { resolvePtySpec } from './sessionManager';
+
+beforeEach(() => {
+  state.nodes = [];
+});
+
+describe('resolvePtySpec — container terminals', () => {
+  it('routes container:local:* through SSH when the Local node has an ssh:// URI (container-mode install)', async () => {
+    state.nodes = [{
+      Name: 'Local',
+      URI: 'ssh://core@127.0.0.1',
+      Identity: '/app/data/ssh/id_rsa',
+    }];
+
+    const spec = await resolvePtySpec('container:local:abc123');
+
+    expect(spec.shell).toBe('ssh');
+    expect(spec.args).toContain('-i');
+    expect(spec.args).toContain('/app/data/ssh/id_rsa');
+    expect(spec.args).toContain('core@127.0.0.1');
+    // The trailing arg is the remote command — must invoke podman exec
+    // against the container id, with the bash-or-sh fallback dance.
+    const remoteCmd = spec.args[spec.args.length - 1];
+    expect(remoteCmd).toContain('podman exec -it');
+    expect(remoteCmd).toContain('abc123');
+    expect(remoteCmd).toContain('if [ -x /bin/bash ]');
+  });
+
+  it('routes container:<remote>:* through SSH for a remote ssh:// node (existing behaviour preserved)', async () => {
+    state.nodes = [{
+      Name: 'edge',
+      URI: 'ssh://core@10.0.0.5:2222',
+      Identity: '/keys/edge',
+    }];
+
+    const spec = await resolvePtySpec('container:edge:xyz789');
+
+    expect(spec.shell).toBe('ssh');
+    expect(spec.args).toContain('-p');
+    expect(spec.args).toContain('2222');
+    expect(spec.args).toContain('core@10.0.0.5');
+    expect(spec.args[spec.args.length - 1]).toContain('xyz789');
+  });
+
+  it('falls back to direct podman when no matching node is registered (bare-metal install)', async () => {
+    state.nodes = []; // no Local node — bare-metal/dev mode
+
+    const spec = await resolvePtySpec('container:local:abc123');
+
+    expect(spec.shell).toBe('podman');
+    expect(spec.args[0]).toBe('exec');
+    expect(spec.args).toContain('abc123');
+  });
+
+  it('falls back to direct podman when the matched node has a non-ssh URI', async () => {
+    state.nodes = [{
+      Name: 'Local',
+      URI: 'unix:///run/podman/podman.sock',
+      Identity: '',
+    }];
+
+    const spec = await resolvePtySpec('container:local:abc123');
+
+    expect(spec.shell).toBe('podman');
+  });
+
+  it('throws when the container id is empty', async () => {
+    await expect(resolvePtySpec('container:local:')).rejects.toThrow(/Invalid container ID/);
+  });
+});

--- a/src/lib/terminal/sessionManager.ts
+++ b/src/lib/terminal/sessionManager.ts
@@ -186,7 +186,7 @@ function resolveHomeDir(): string {
   }
 }
 
-async function resolvePtySpec(id: string): Promise<PtySpec> {
+export async function resolvePtySpec(id: string): Promise<PtySpec> {
   const defaultShell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || 'bash');
 
   if (id.startsWith('container:')) {
@@ -197,28 +197,41 @@ async function resolvePtySpec(id: string): Promise<PtySpec> {
       throw new Error('Invalid container ID');
     }
 
-    if (nodeName && nodeName !== 'local') {
-      try {
-        const nodes = await listNodes();
-        const node = nodes.find(n => n.Name === nodeName);
-        if (node) {
-          const uri = new URL(node.URI);
-          if (uri.protocol === 'ssh:') {
-            const args: string[] = [];
-            if (node.Identity) args.push('-i', node.Identity);
-            if (uri.port) args.push('-p', uri.port);
-            args.push('-o', 'StrictHostKeyChecking=no');
-            args.push('-o', 'UserKnownHostsFile=/dev/null');
-            args.push('-t');
-            args.push(`${uri.username}@${uri.hostname}`);
-            args.push(`podman exec -it -e TERM=xterm-256color ${containerId} sh -c 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'`);
-            return { shell: 'ssh', args, fallbackWarning: '' };
-          }
+    // Always try to resolve the node (incl. `local` → `Local`) and route via
+    // SSH when the node has an ssh:// URI. In container-mode installs every
+    // node — including `Local` (`ssh://core@127.0.0.1`) — is reached via SSH
+    // because the ServiceBay container deliberately ships without the podman
+    // CLI (see Dockerfile: "Removed podman and systemd - agent uses SSH to
+    // execute commands on host"). Before this, `container:local:<id>` skipped
+    // the SSH branch and tried to spawn `podman` directly inside the
+    // ServiceBay container — failing with `execvp(3) failed.: No such file or
+    // directory`.
+    const nodeKey = nodeName === 'local' ? 'Local' : nodeName;
+    try {
+      const nodes = await listNodes();
+      const node = nodes.find(n => n.Name === nodeKey);
+      if (node) {
+        const uri = new URL(node.URI);
+        if (uri.protocol === 'ssh:') {
+          const args: string[] = [];
+          if (node.Identity) args.push('-i', node.Identity);
+          if (uri.port) args.push('-p', uri.port);
+          args.push('-o', 'StrictHostKeyChecking=no');
+          args.push('-o', 'UserKnownHostsFile=/dev/null');
+          args.push('-t');
+          args.push(`${uri.username}@${uri.hostname}`);
+          args.push(`podman exec -it -e TERM=xterm-256color ${containerId} sh -c 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'`);
+          return { shell: 'ssh', args, fallbackWarning: '' };
         }
-      } catch (e) {
-        logger.error('Server', `Failed to setup remote container terminal for ${nodeName}:`, e);
       }
+    } catch (e) {
+      logger.error('Server', `Failed to setup container terminal for ${nodeKey}:`, e);
     }
+
+    // Bare-metal install path: ServiceBay runs on the host with the podman CLI
+    // in PATH. Container-mode installs don't reach this — see the SSH branch
+    // above. Kept so a hypothetical `node:` install (or a future packaged
+    // binary) still works without a per-node SSH config entry.
     return {
       shell: 'podman',
       args: ['exec', '-it', '-e', 'TERM=xterm-256color', containerId, 'sh', '-c', 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'],


### PR DESCRIPTION
## Summary
- `resolvePtySpec` skipped the SSH branch for `nodeName === 'local'` and tried to spawn `podman` directly. The ServiceBay container deliberately ships without the podman CLI (Dockerfile: \`# Removed podman and systemd - agent uses SSH to execute commands on host\`), so every container terminal opened from the UI failed with \`execvp(3) failed.: No such file or directory\` followed by \`Session exited with code 1\`.
- Map \`local\` → \`Local\` and always try the SSH path first. The direct-\`podman\` fallback is preserved for bare-metal / dev installs where the CLI is on PATH.
- Export \`resolvePtySpec\` so the test can exercise its branches without spinning a real PTY (the existing terminal test specifically called out that PTY-internals testing was hard without native modules).

## Why
Container-mode is the supported install path. \`config Local\` has \`URI: ssh://core@127.0.0.1\` — the same SSH branch the remote-node case already used was the right transport here. The bug was a stale guard (\`!== 'local'\`) from the pre-container era when ServiceBay had podman in its image.

## Test plan
- [x] \`npx vitest run src/lib/terminal/ tests/backend/terminal.test.ts\` — 9 tests pass (4 existing + 5 new).
- [x] Lint clean.
- [x] Pre-push test suite passes.
- [ ] After merge + release, open a container terminal on the running install (e.g. \`nginx-nginx-proxy-manager\`) and confirm bash/sh prompt appears instead of the execvp error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)