### PR TITLE
feat(install): public/LAN exposure + auto LE cert + cert_request_failure probe

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -9,6 +9,7 @@ import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPoi
 import { checkPostDeployFailed } from '@/lib/diagnose/probes/postDeployFailed';
 import { checkProxyRouteMissing } from '@/lib/diagnose/probes/proxyRouteMissing';
 import { checkCertExpiry } from '@/lib/diagnose/probes/certExpiry';
+import { checkCertRequestFailure } from '@/lib/diagnose/probes/certRequestFailure';
 import { checkAdguardRewritesMissing } from '@/lib/diagnose/probes/adguardRewritesMissing';
 import '@/lib/diagnose/probes/register';
 
@@ -651,6 +652,31 @@ export async function POST(request: Request) {
     probes.push({
       id: 'cert_expiry',
       label: 'TLS certificates',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 16b) Recent ACME failures from NPM's letsencrypt.log. NPM surfaces
+  //      cert-issuance failures as a generic "Internal Error"; this
+  //      probe parses the actual log tail and turns each failed domain
+  //      into a row with show_log_tail + retry_request actions. Silent
+  //      (info) when the log is missing, the last failure is older than
+  //      24h, or the file is unparseable.
+  try {
+    const crf = await checkCertRequestFailure(nodeName);
+    probes.push({
+      id: 'cert_request_failure',
+      label: 'Cert request failures',
+      status: crf.status,
+      detail: crf.detail,
+      hint: crf.hint,
+      _items: crf.items,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'cert_request_failure',
+      label: 'Cert request failures',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -13,6 +13,17 @@ interface ProxyHostRequest {
     forwardScheme?: string;
     /** Template name this proxy host belongs to (e.g. "vaultwarden") */
     service?: string;
+    /**
+     * Exposure profile for the host. `public` triggers an auto Let's
+     * Encrypt cert request on this endpoint right after the proxy host
+     * is created (best-effort — the install does not fail if the ACME
+     * challenge fails; the `cert_request_failure` diagnose probe surfaces
+     * the underlying reason). `lan` (or unset) creates the proxy host
+     * without a cert. Templates declare a sensible default per
+     * subdomain variable in `variables.json`; the wizard's configure
+     * step lets the operator override per service.
+     */
+    exposure?: 'public' | 'lan';
     /** Service-specific NPM proxy host settings */
     proxyConfig?: {
         allow_websocket_upgrade?: boolean;
@@ -192,6 +203,94 @@ async function createProxyHost(baseUrl: string, token: string, host: ProxyHostRe
 }
 
 /**
+ * Request a Let's Encrypt cert from NPM and bind it to the just-created
+ * proxy host. Best-effort: returns `{ ok: false, reason }` on every kind
+ * of failure (HTTP non-OK, network, malformed response). The caller
+ * surfaces the reason in the per-host result so the wizard log shows
+ * "cert pending" rather than blowing up the install — the
+ * cert_request_failure diagnose probe parses NPM's letsencrypt.log on
+ * the next diagnose run and lets the operator click Retry once the
+ * underlying cause (DNS / port 80 / CAA) is fixed.
+ *
+ * NPM's certbot is webroot HTTP-01 by default (see
+ * templates/nginx/template.yml). The challenge file is served by NPM on
+ * port 80 across every configured server_name, which is why the proxy
+ * host MUST exist before issuance — without a server_name match, NPM's
+ * default-server rejects the ACME request and certbot times out.
+ */
+async function requestPublicCert(
+    baseUrl: string,
+    token: string,
+    proxyHostId: number,
+    domain: string,
+    leEmail: string,
+): Promise<{ ok: true; certId: number } | { ok: false; reason: string }> {
+    // 1) Create the LE cert in NPM. NPM blocks until the ACME exchange
+    //    completes (success or failure), so the timeout here is generous.
+    let certId: number;
+    try {
+        const res = await fetch(`${baseUrl}/api/nginx/certificates`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+                provider: 'letsencrypt',
+                domain_names: [domain],
+                meta: {
+                    letsencrypt_email: leEmail,
+                    letsencrypt_agree: true,
+                    dns_challenge: false,
+                },
+            }),
+            signal: AbortSignal.timeout(120_000),
+        });
+        if (!res.ok) {
+            const body = await res.text().catch(() => '');
+            return { ok: false, reason: `NPM /api/nginx/certificates returned HTTP ${res.status}: ${body.slice(0, 200) || 'no body'}` };
+        }
+        const data = await res.json() as { id?: number };
+        if (typeof data.id !== 'number') {
+            return { ok: false, reason: 'NPM accepted the cert request but returned no id.' };
+        }
+        certId = data.id;
+    } catch (e) {
+        return { ok: false, reason: `Cert request failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+
+    // 2) Bind the cert to the proxy host so HTTPS becomes the canonical
+    //    URL. Without this step the cert exists in NPM but the proxy
+    //    host still serves on port 80 only.
+    try {
+        const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts/${proxyHostId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+                certificate_id: certId,
+                ssl_forced: true,
+                http2_support: true,
+                hsts_enabled: false,
+                meta: { letsencrypt_agree: true, dns_challenge: false },
+            }),
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!res.ok) {
+            const body = await res.text().catch(() => '');
+            // Cert is issued; binding failed. Operator can do this manually
+            // in NPM admin → Hosts → Edit. Surface the partial success.
+            return { ok: false, reason: `Cert ${certId} issued but binding to proxy host ${proxyHostId} failed (HTTP ${res.status}: ${body.slice(0, 160)}). Open NPM admin → Hosts → Edit → SSL to bind it.` };
+        }
+    } catch (e) {
+        return { ok: false, reason: `Cert ${certId} issued but the bind PUT failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+    return { ok: true, certId };
+}
+
+/**
  * POST: Create proxy hosts in NPM
  * Body: { hosts: [{ domain, forwardPort, forwardHost?, forwardScheme?, proxyConfig? }], node? }
  *
@@ -226,7 +325,13 @@ export async function POST(request: Request) {
             }, { status: 401 });
         }
 
-        const results: { domain: string; success: boolean; error?: string }[] = [];
+        // ACME registration email — needed when any host has
+        // `exposure: 'public'`. Falls back to the stored NPM admin email
+        // (the wizard hoists operatorEmail into both fields).
+        const config = await getConfig();
+        const leEmail = config.reverseProxy?.npm?.email;
+
+        const results: { domain: string; success: boolean; error?: string; certIssued?: boolean; certError?: string }[] = [];
 
         for (const host of hosts) {
             // Default forward host = node LAN IP (NPM is in a container,
@@ -234,14 +339,44 @@ export async function POST(request: Request) {
             if (!host.forwardHost) {
                 host.forwardHost = npm.nodeIp;
             }
+            let createdHost: { id?: number } | null = null;
             try {
-                await createProxyHost(npm.apiUrl, token, host);
+                createdHost = await createProxyHost(npm.apiUrl, token, host);
                 results.push({ domain: host.domain, success: true });
-                logger.info('ProxyHosts', `Created proxy host: ${host.domain} → ${host.forwardHost}:${host.forwardPort}`);
+                logger.info('ProxyHosts', `Created proxy host: ${host.domain} → ${host.forwardHost}:${host.forwardPort} (exposure=${host.exposure ?? 'lan'})`);
             } catch (e) {
                 const msg = e instanceof Error ? e.message : String(e);
                 results.push({ domain: host.domain, success: false, error: msg });
                 logger.warn('ProxyHosts', `Failed to create proxy host ${host.domain}: ${msg}`);
+                continue;
+            }
+
+            // Auto-cert for public-exposure hosts. Best-effort: install
+            // continues regardless of ACME outcome — the diagnose probe
+            // (`cert_request_failure`) is the recovery path.
+            if (host.exposure === 'public') {
+                if (!leEmail) {
+                    const reason = 'No ACME registration email configured (set reverseProxy.npm.email in Settings → Integrations); skipped cert request.';
+                    results[results.length - 1].certError = reason;
+                    logger.warn('ProxyHosts', `Skip cert for ${host.domain}: ${reason}`);
+                } else if (typeof createdHost?.id !== 'number') {
+                    results[results.length - 1].certError = 'NPM did not return a proxy host id; cannot bind a cert without it.';
+                } else {
+                    const certResult = await requestPublicCert(
+                        npm.apiUrl,
+                        token,
+                        createdHost.id,
+                        host.domain,
+                        leEmail,
+                    );
+                    if (certResult.ok) {
+                        results[results.length - 1].certIssued = true;
+                        logger.info('ProxyHosts', `Issued + bound LE cert ${certResult.certId} for ${host.domain}`);
+                    } else {
+                        results[results.length - 1].certError = certResult.reason;
+                        logger.warn('ProxyHosts', `Cert request failed for ${host.domain}: ${certResult.reason}`);
+                    }
+                }
             }
         }
 
@@ -250,7 +385,6 @@ export async function POST(request: Request) {
 
         // Persist proxy host state and public domain to config
         try {
-            const config = await getConfig();
             const existingHosts = config.reverseProxy?.hosts || [];
             const newEntries: ProxyHostEntry[] = hosts.map(h => ({
                 domain: h.domain,
@@ -281,6 +415,15 @@ export async function POST(request: Request) {
             success: failed.length === 0,
             created: created.map(r => r.domain),
             failed: failed.map(r => ({ domain: r.domain, error: r.error })),
+            // Per-host cert outcomes — present only for hosts whose
+            // request body had `exposure: 'public'`. Successful issuance
+            // → `certIssued: true`; any failure → `certError: <reason>`.
+            // The wizard surfaces successes/failures as a short summary;
+            // the cert_request_failure diagnose probe is the recovery
+            // path for the failure case.
+            certs: results
+                .filter(r => r.certIssued || r.certError)
+                .map(r => ({ domain: r.domain, issued: r.certIssued === true, error: r.certError })),
             adminUrl: npm.apiUrl,
             node: npm.nodeName,
         });

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -2036,6 +2036,7 @@ export default function OnboardingWizard() {
                                                 <StackVariableField
                                                     variable={v}
                                                     onChange={(value) => installFlow.setVariableValue(v.name, value)}
+                                                    onExposureChange={(exposure) => installFlow.setVariableExposure(v.name, exposure)}
                                                     publicDomain={stackVariables.find(x => x.name === 'PUBLIC_DOMAIN')?.value}
                                                     inputClassName="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-md text-sm"
                                                     deviceContext={{

--- a/src/components/StackInstallFlow.tsx
+++ b/src/components/StackInstallFlow.tsx
@@ -69,7 +69,7 @@ export function StackInstallConfigureForm({
   beforeVariables,
   afterVariables,
 }: ConfigureFormProps) {
-  const { variables, cleanInstall, cleanInstallConfirm, setCleanInstall, setCleanInstallConfirm, setVariableValue } = controller;
+  const { variables, cleanInstall, cleanInstallConfirm, setCleanInstall, setCleanInstallConfirm, setVariableValue, setVariableExposure } = controller;
   const groups = groupVariablesByTemplate(variables).filter(g => g.key !== '_global');
   const publicDomain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
 
@@ -157,6 +157,7 @@ export function StackInstallConfigureForm({
                     <StackVariableField
                       variable={v}
                       onChange={(value) => setVariableValue(v.name, value)}
+                      onExposureChange={(exposure) => setVariableExposure(v.name, exposure)}
                       publicDomain={publicDomain}
                       deviceContext={deviceContext}
                       inputClassName={inputClassName}

--- a/src/components/StackVariableField.tsx
+++ b/src/components/StackVariableField.tsx
@@ -39,6 +39,13 @@ interface StackVariableFieldProps {
    *  variables render a disabled dropdown — same fallback both
    *  consumers had before. */
   deviceContext?: StackVariableFieldDeviceContext;
+  /**
+   * For subdomain variables: change the exposure profile (public vs
+   * lan-only). Omit to hide the inline toggle — the field then shows
+   * only the template default as a static badge. The wizard owns
+   * the state mutation via useStackInstall.setVariableExposure.
+   */
+  onExposureChange?: (exposure: 'public' | 'lan') => void;
   /** Tailwind class shape. Pre-extraction the two consumers used
    *  slightly different paddings/border-radii; defaulting to the
    *  InstallerModal shape and letting OnboardingWizard pass its own
@@ -64,6 +71,7 @@ export default function StackVariableField({
   onChange,
   publicDomain,
   deviceContext,
+  onExposureChange,
   inputClassName,
 }: StackVariableFieldProps) {
   const cls = inputClassName ?? 'w-full p-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded focus:ring-2 focus:ring-blue-500';
@@ -122,20 +130,52 @@ export default function StackVariableField({
     );
   }
 
-  // Subdomain field (shows .domain suffix)
+  // Subdomain field (shows .domain suffix). When `onExposureChange` is
+  // provided, an inline Public/LAN segmented toggle hangs to the right
+  // — operators override the per-template default; the choice drives
+  // whether the install auto-requests a Let's Encrypt cert. Without
+  // `onExposureChange` (e.g. read-only contexts) we fall back to a
+  // small static badge so the operator still sees what's planned.
   if (v.meta?.type === 'subdomain') {
+    const exposure: 'public' | 'lan' = v.meta.exposure === 'public' ? 'public' : 'lan';
     return (
-      <div className="flex items-center gap-0">
-        <input
-          type="text"
-          value={v.value}
-          onChange={(e) => onChange(e.target.value)}
-          className={`${cls} rounded-r-none border-r-0`}
-          placeholder={v.meta.default || 'subdomain'}
-        />
-        <span className="px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-700 text-gray-500 dark:text-gray-400 rounded-r text-sm whitespace-nowrap">
-          .{publicDomain || 'example.com'}
-        </span>
+      <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-0 flex-1 min-w-[12rem]">
+          <input
+            type="text"
+            value={v.value}
+            onChange={(e) => onChange(e.target.value)}
+            className={`${cls} rounded-r-none border-r-0`}
+            placeholder={v.meta.default || 'subdomain'}
+          />
+          <span className="px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-700 text-gray-500 dark:text-gray-400 rounded-r text-sm whitespace-nowrap">
+            .{publicDomain || 'example.com'}
+          </span>
+        </div>
+        {onExposureChange ? (
+          <div className="inline-flex rounded border border-gray-300 dark:border-gray-700 overflow-hidden text-xs" role="group" aria-label="Exposure profile">
+            <button
+              type="button"
+              onClick={() => onExposureChange('public')}
+              className={`px-2.5 py-1.5 ${exposure === 'public' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+              title="Reachable from the internet on 80/443. Auto-requests a Let's Encrypt cert at install."
+            >
+              Public
+            </button>
+            <button
+              type="button"
+              onClick={() => onExposureChange('lan')}
+              className={`px-2.5 py-1.5 border-l border-gray-300 dark:border-gray-700 ${exposure === 'lan' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+              title="LAN-only — no public exposure, no TLS cert provisioned."
+            >
+              LAN
+            </button>
+          </div>
+        ) : (
+          <span className={`px-2 py-0.5 rounded text-xs ${exposure === 'public' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100' : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'}`}>
+            {exposure === 'public' ? 'Public' : 'LAN'}
+          </span>
+        )}
       </div>
     );
   }

--- a/src/lib/diagnose/probes/certRequestFailure.test.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.test.ts
@@ -1,0 +1,247 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  config: {} as any,
+  services: [] as any[],
+};
+
+const mockAgent = { sendCommand: vi.fn() };
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(() => Promise.resolve(state.services)) },
+}));
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { dispatchProbeAction } from '../actions';
+import { checkCertRequestFailure, parseLetsencryptTail } from './certRequestFailure';
+import './certRequestFailure';
+
+const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', container: '81' }] }];
+
+beforeEach(() => {
+  state.config = {
+    reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } },
+    templateSettings: { DATA_DIR: '/mnt/data' },
+  };
+  state.services = ACTIVE_NGINX;
+  mockAgent.sendCommand.mockReset();
+  mockFetch.mockReset();
+});
+
+// ─── Parser ─────────────────────────────────────────────────────────────
+
+describe('parseLetsencryptTail', () => {
+  it('extracts the structured Domain/Type/Detail block', () => {
+    const tail = `2026-05-12 00:27:14,123:DEBUG:certbot:Some leading noise
+2026-05-12 00:27:14,200:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   connection
+  Detail: 1.2.3.4: Fetching http://vault.dopp.cloud/.well-known/acme-challenge/abc: Connection refused
+2026-05-12 00:27:14,250:ERROR:certbot:Cleaning up challenges`;
+    const out = parseLetsencryptTail(tail);
+    expect(out.failures).toHaveLength(1);
+    expect(out.failures[0].domain).toBe('vault.dopp.cloud');
+    expect(out.failures[0].type).toBe('connection');
+    expect(out.failures[0].detail).toMatch(/Connection refused/);
+    expect(out.rateLimited).toBe(false);
+    expect(out.ts).toBeGreaterThan(0);
+  });
+
+  it('falls back to the inline "Failed authorization procedure" format', () => {
+    const tail = `2026-05-12 00:30:00,000:ERROR:certbot:Some challenges have failed.
+2026-05-12 00:30:00,000:ERROR:certbot:Failed authorization procedure. vault.dopp.cloud (http-01): urn:ietf:params:acme:error:dns :: DNS problem: NXDOMAIN looking up A for vault.dopp.cloud`;
+    const out = parseLetsencryptTail(tail);
+    expect(out.failures).toHaveLength(1);
+    expect(out.failures[0].domain).toBe('vault.dopp.cloud');
+    expect(out.failures[0].type).toBe('http-01');
+    expect(out.failures[0].detail).toMatch(/NXDOMAIN/);
+  });
+
+  it('detects rate-limit URN even without per-domain block', () => {
+    const tail = `2026-05-12 00:35:00,000:ERROR:certbot:Some challenges have failed.
+2026-05-12 00:35:00,000:ERROR:certbot:An unexpected error occurred:
+acme.errors.Error: urn:ietf:params:acme:error:rateLimited :: Error creating new order :: too many failed authorizations recently`;
+    const out = parseLetsencryptTail(tail);
+    expect(out.failures).toHaveLength(0);
+    expect(out.rateLimited).toBe(true);
+  });
+
+  it('returns no failures for a clean tail', () => {
+    const tail = `2026-05-12 00:40:00,000:INFO:certbot:Successfully received certificate.
+2026-05-12 00:40:00,000:INFO:certbot:Certificate is saved at: /etc/letsencrypt/live/npm-3/fullchain.pem`;
+    const out = parseLetsencryptTail(tail);
+    expect(out.failures).toHaveLength(0);
+    expect(out.rateLimited).toBe(false);
+  });
+
+  it('keeps only the failures from the most recent failed run', () => {
+    const tail = `2026-05-11 10:00:00,000:ERROR:certbot:Some challenges have failed.
+  Domain: old.dopp.cloud
+  Type:   connection
+  Detail: old failure
+2026-05-12 00:27:14,200:INFO:certbot:Successfully received certificate.
+2026-05-12 00:30:00,000:ERROR:certbot:Some challenges have failed.
+  Domain: new.dopp.cloud
+  Type:   connection
+  Detail: new failure`;
+    const out = parseLetsencryptTail(tail);
+    expect(out.failures.map(f => f.domain)).toEqual(['new.dopp.cloud']);
+  });
+});
+
+// ─── Probe top-level ────────────────────────────────────────────────────
+
+describe('checkCertRequestFailure', () => {
+  function mockTail(stdout: string, code = 0) {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code, stdout, stderr: '' });
+  }
+
+  it('returns info when the log tail is empty', async () => {
+    mockTail('');
+    const out = await checkCertRequestFailure('Local');
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/hasn't attempted/);
+  });
+
+  it('returns info when tail has no failure markers', async () => {
+    mockTail('2026-05-12 00:00:00,000:INFO:certbot:All clean.');
+    const out = await checkCertRequestFailure('Local');
+    expect(out.status).toBe('info');
+  });
+
+  it('returns fail with one item per failed domain', async () => {
+    const recent = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').slice(0, 19);
+    mockTail(`${recent},123:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   connection
+  Detail: 1.2.3.4: Fetching http://vault.dopp.cloud/.well-known/acme-challenge/abc: Connection refused`);
+    const out = await checkCertRequestFailure('Local');
+    expect(out.status).toBe('fail');
+    expect(out.items).toHaveLength(1);
+    expect(out.items?.[0].label).toBe('vault.dopp.cloud');
+    expect(out.items?.[0].detail).toMatch(/Connection refused/);
+    expect(out.items?.[0].actionIds).toEqual(['show_log_tail', 'retry_request']);
+  });
+
+  it('returns info when the failure is older than the freshness window', async () => {
+    // 48h old → outside the 24h freshness window.
+    const old = new Date(Date.now() - 48 * 3600_000).toISOString().replace('T', ' ').slice(0, 19);
+    mockTail(`${old},000:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   connection
+  Detail: stale failure`);
+    const out = await checkCertRequestFailure('Local');
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/outside the .* freshness window/);
+  });
+
+  it('surfaces a rate-limit pseudo-item when no per-domain block', async () => {
+    const recent = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').slice(0, 19);
+    mockTail(`${recent},000:ERROR:certbot:Some challenges have failed.
+acme.errors.Error: urn:ietf:params:acme:error:rateLimited :: too many failed authorizations recently`);
+    const out = await checkCertRequestFailure('Local');
+    expect(out.status).toBe('fail');
+    expect(out.items?.[0].label).toMatch(/rate limit/i);
+  });
+
+  it('returns info when reading the log fails (non-zero exit)', async () => {
+    mockTail('', 1);
+    const out = await checkCertRequestFailure('Local');
+    expect(out.status).toBe('info');
+  });
+});
+
+// ─── Action: show_log_tail ──────────────────────────────────────────────
+
+describe('cert_request_failure.show_log_tail', () => {
+  it('returns the last 80 lines of the log in details', async () => {
+    const lines = Array.from({ length: 200 }, (_, i) => `line${i}`).join('\n');
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 0, stdout: lines, stderr: '' });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_request_failure',
+      actionId: 'show_log_tail',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    const detailsLines = (result.details ?? '').split('\n');
+    expect(detailsLines.length).toBe(80);
+    expect(detailsLines[detailsLines.length - 1]).toBe('line199');
+  });
+
+  it('reports failure when the log read fails', async () => {
+    mockAgent.sendCommand.mockResolvedValueOnce({ code: 1, stdout: '', stderr: '' });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_request_failure',
+      actionId: 'show_log_tail',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Could not read/);
+  });
+});
+
+// ─── Action: retry_request ──────────────────────────────────────────────
+
+describe('cert_request_failure.retry_request', () => {
+  it('rejects empty itemId', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'cert_request_failure',
+      actionId: 'retry_request',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('triggers NPM renew for the matching cert id', async () => {
+    mockFetch
+      // /api/tokens
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'tok' }) })
+      // /api/nginx/certificates
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([
+          { id: 4, domain_names: ['other.dopp.cloud'] },
+          { id: 7, domain_names: ['vault.dopp.cloud'] },
+        ]),
+      })
+      // /api/nginx/certificates/7/renew
+      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('') });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_request_failure',
+      actionId: 'retry_request',
+      itemId: 'vault.dopp.cloud',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockFetch.mock.calls[2][0]).toMatch(/\/api\/nginx\/certificates\/7\/renew/);
+  });
+
+  it('reports a clear message when no NPM cert exists for the domain yet', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'tok' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ id: 4, domain_names: ['other.dopp.cloud'] }]),
+      });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_request_failure',
+      actionId: 'retry_request',
+      itemId: 'vault.dopp.cloud',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/No NPM certificate exists/);
+  });
+});

--- a/src/lib/diagnose/probes/certRequestFailure.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.ts
@@ -1,0 +1,331 @@
+/**
+ * `cert_request_failure` probe — parses the tail of NPM's
+ * `letsencrypt.log` and surfaces recent ACME failures (the underlying
+ * reason NPM returns its opaque "Internal Error" when a cert request
+ * fails). Each failed domain becomes a per-row item with a `show_log_tail`
+ * action (returns the last ~80 lines of letsencrypt.log in the
+ * expandable details block) and a `retry_request` action (re-runs NPM's
+ * renew endpoint).
+ *
+ * Silent (info) when no log exists, when the last failure is older than
+ * `FRESHNESS_HOURS`, or when the log is unparseable — keeps the diagnose
+ * surface tidy until something is actually broken.
+ *
+ * House style: helpers (`findNpmAdminUrl`, `getNpmToken`) are duplicated
+ * from `certExpiry.ts` rather than extracted into a shared module — see
+ * the note in `danglingProxy.ts:29`.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+
+const PROBE_ID = 'cert_request_failure';
+const FRESHNESS_HOURS = 24;
+const TAIL_BYTES = 65_536;
+
+export interface CertRequestFailureResult {
+  status: 'ok' | 'warn' | 'fail' | 'info';
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+interface ParsedFailure {
+  domain: string;
+  type: string;
+  detail: string;
+}
+
+export interface ParsedFailureBlock {
+  failures: ParsedFailure[];
+  rateLimited: boolean;
+  /** Newest timestamp anywhere in the tail (epoch ms, UTC-interpreted). */
+  ts?: number;
+}
+
+function letsencryptLogPath(dataDir: string): string {
+  return `${dataDir}/nginx-proxy-manager/data/logs/letsencrypt.log`;
+}
+
+// Refuse to compose a shell command unless the path is a clean POSIX
+// absolute path. DATA_DIR comes from config and is admin-editable; this
+// is belt-and-braces against an accidental shell-meta in the value.
+function safePath(p: string): boolean {
+  return /^\/[A-Za-z0-9_./-]+$/.test(p);
+}
+
+async function findNpmAdminUrl(node: string): Promise<string | null> {
+  try {
+    const services = await ServiceManager.listServices(node);
+    const nginx = services.find(
+      s => s.name === 'nginx' || s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
+    );
+    if (!nginx?.active) return null;
+    const ports = (nginx.ports ?? [])
+      .map(p => parseInt(String(p.host ?? ''), 10))
+      .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
+    return `http://localhost:${ports[0] ?? 81}`;
+  } catch {
+    return null;
+  }
+}
+
+async function getNpmToken(adminUrl: string): Promise<string | null> {
+  const config = await getConfig();
+  const candidates: { identity: string; secret: string }[] = [];
+  const stored = config.reverseProxy?.npm;
+  if (stored?.email && stored?.password) {
+    candidates.push({ identity: stored.email, secret: stored.password });
+  }
+  candidates.push({ identity: 'admin@example.com', secret: 'changeme' });
+  for (const cred of candidates) {
+    try {
+      const res = await fetch(`${adminUrl}/api/tokens`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cred),
+        signal: AbortSignal.timeout(4000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (typeof data.token === 'string') return data.token;
+      }
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+async function readLogTail(node: string, path: string, bytes = TAIL_BYTES): Promise<string | null> {
+  if (!safePath(path)) {
+    logger.warn('diagnose:cert_request_failure', `Refusing tail of unsafe path: ${path}`);
+    return null;
+  }
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    const res = await agent.sendCommand('exec', {
+      command: `tail -c ${bytes} ${path} 2>/dev/null`,
+    }, { timeoutMs: 5_000 }) as { code?: number; stdout?: string };
+    if (res.code !== 0) return null;
+    return res.stdout ?? '';
+  } catch (e) {
+    logger.warn('diagnose:cert_request_failure', `tail letsencrypt.log failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
+const STRUCTURED_FAILURE_RE = /Domain:\s*(\S+)\s*\n\s*Type:\s*(\S+)\s*\n\s*Detail:\s*([^\n]+)/g;
+// Legacy/inline format used by older certbot releases.
+const INLINE_FAILURE_RE = /Failed authorization procedure\.\s+(\S+)\s+\(([^)]+)\):\s+urn:ietf:params:acme:error:\S+\s*::\s*([^\n]+)/g;
+const RATE_LIMIT_RE = /urn:ietf:params:acme:error:rateLimited/i;
+const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/gm;
+
+export function parseLetsencryptTail(tail: string): ParsedFailureBlock {
+  // Scope to the slice starting at the most recent "Some challenges
+  // have failed" line so older failure blocks higher up don't leak in.
+  // Failures in certbot output come AFTER the marker line, so we
+  // start at the beginning of that line. Fall back to the full tail
+  // when the marker isn't present — older log lines sometimes just
+  // have "Challenge failed for domain X" without it.
+  const lastMarker = tail.lastIndexOf('Some challenges have failed');
+  const sliceStart = lastMarker >= 0
+    ? Math.max(0, tail.lastIndexOf('\n', lastMarker) + 1)
+    : 0;
+  const slice = tail.slice(sliceStart);
+
+  const failures: ParsedFailure[] = [];
+  STRUCTURED_FAILURE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = STRUCTURED_FAILURE_RE.exec(slice)) !== null) {
+    failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
+  }
+  if (failures.length === 0) {
+    INLINE_FAILURE_RE.lastIndex = 0;
+    while ((m = INLINE_FAILURE_RE.exec(slice)) !== null) {
+      failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
+    }
+  }
+
+  const rateLimited = RATE_LIMIT_RE.test(slice);
+
+  let ts: number | undefined;
+  TIMESTAMP_RE.lastIndex = 0;
+  const tsMatches = slice.match(TIMESTAMP_RE);
+  if (tsMatches && tsMatches.length > 0) {
+    const last = tsMatches[tsMatches.length - 1];
+    const parsed = Date.parse(`${last.replace(' ', 'T')}Z`);
+    if (Number.isFinite(parsed)) ts = parsed;
+  }
+
+  return { failures, rateLimited, ts };
+}
+
+export async function checkCertRequestFailure(node: string): Promise<CertRequestFailureResult> {
+  const config = await getConfig();
+  const dataDir = config.templateSettings?.DATA_DIR ?? '/mnt/data';
+  const path = letsencryptLogPath(dataDir);
+
+  const tail = await readLogTail(node, path);
+  if (tail === null || tail.length === 0) {
+    return {
+      status: 'info',
+      detail: 'No letsencrypt.log found — NPM hasn\'t attempted any cert requests yet.',
+    };
+  }
+
+  const parsed = parseLetsencryptTail(tail);
+  if (parsed.failures.length === 0 && !parsed.rateLimited) {
+    return { status: 'info', detail: 'Most recent NPM cert request did not record a failure.' };
+  }
+
+  if (parsed.ts) {
+    const ageMs = Date.now() - parsed.ts;
+    if (ageMs > FRESHNESS_HOURS * 3_600_000) {
+      return {
+        status: 'info',
+        detail: `Last NPM cert failure was ${Math.round(ageMs / 3_600_000)}h ago — outside the ${FRESHNESS_HOURS}h freshness window.`,
+      };
+    }
+  }
+
+  // De-duplicate by domain (most recent wins thanks to insertion order).
+  const byDomain = new Map<string, ParsedFailure>();
+  for (const f of parsed.failures) byDomain.set(f.domain, f);
+
+  const items: ProbeItem[] = [];
+  for (const [domain, f] of byDomain) {
+    const detail = f.detail.length > 140 ? `${f.detail.slice(0, 140)}…` : f.detail;
+    items.push({
+      id: domain,
+      label: domain,
+      detail: `ACME ${f.type} challenge failed: ${detail}`,
+      status: 'fail',
+      actionIds: ['show_log_tail', 'retry_request'],
+    });
+  }
+  if (parsed.rateLimited && items.length === 0) {
+    items.push({
+      id: 'rate-limited',
+      label: 'Let\'s Encrypt rate limit',
+      detail: 'Hit the ACME rate limit (5 failed validations / host / hour). Wait ~1h and fix the root cause before retrying.',
+      status: 'fail',
+      actionIds: ['show_log_tail'],
+    });
+  }
+
+  return {
+    status: 'fail',
+    detail: `${items.length} domain${items.length === 1 ? '' : 's'} with recent ACME failure${items.length === 1 ? '' : 's'} in NPM\'s letsencrypt.log.`,
+    hint: 'Most common cause is public port 80 not reachable from the internet. Run letsdebug.net for an external view of what the ACME server sees, then click Retry once the underlying cause is fixed.',
+    items,
+  };
+}
+
+// ─── Action handlers ────────────────────────────────────────────────────
+
+async function showLogTail({ node }: { node: string }): Promise<ProbeActionResult> {
+  const config = await getConfig();
+  const dataDir = config.templateSettings?.DATA_DIR ?? '/mnt/data';
+  const path = letsencryptLogPath(dataDir);
+  const tail = await readLogTail(node, path, 16_384);
+  if (tail === null) {
+    return { ok: false, message: `Could not read ${path}.`, refresh: false };
+  }
+  const lines = tail.split('\n');
+  const slice = lines.slice(-80).join('\n');
+  return {
+    ok: true,
+    message: `Showing the last ${Math.min(80, lines.length)} lines of letsencrypt.log.`,
+    details: slice,
+    refresh: false,
+  };
+}
+
+async function retryRequest({ node, itemId }: { node: string; itemId?: string }): Promise<ProbeActionResult> {
+  if (!itemId) return { ok: false, message: 'No domain supplied.', refresh: false };
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return { ok: false, message: 'Nginx Proxy Manager is not deployed on this node.', refresh: false };
+  }
+  const token = await getNpmToken(adminUrl);
+  if (!token) {
+    return {
+      ok: false,
+      message: 'Could not authenticate against NPM — fix the npm_data_stale probe first.',
+      refresh: false,
+    };
+  }
+
+  let certId: number | null = null;
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/certificates`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) {
+      return { ok: false, message: `NPM returned HTTP ${res.status} listing certificates.`, refresh: false };
+    }
+    const certs = await res.json() as Array<{ id?: number; domain_names?: string[] }>;
+    for (const c of certs) {
+      if ((c.domain_names ?? []).includes(itemId) && typeof c.id === 'number') {
+        certId = c.id;
+        break;
+      }
+    }
+  } catch (e) {
+    return { ok: false, message: `Could not reach NPM: ${e instanceof Error ? e.message : String(e)}`, refresh: false };
+  }
+  if (certId === null) {
+    return {
+      ok: false,
+      message: `No NPM certificate exists for ${itemId} yet — open NPM admin → SSL Certificates → "Add Let's Encrypt Certificate" to create one. (The failure log entry came from a request that didn't successfully create the cert row.)`,
+      refresh: false,
+    };
+  }
+
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/certificates/${certId}/renew`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      logger.warn('diagnose:cert_request_failure', `Retry id=${certId} (${itemId}) returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+      return {
+        ok: false,
+        message: `NPM returned HTTP ${res.status}. Open NPM admin → SSL Certificates for the live error, or run letsdebug.net to confirm port 80 is publicly reachable.`,
+        refresh: false,
+      };
+    }
+    return {
+      ok: true,
+      message: `Re-requested certificate for ${itemId}. Re-run diagnose in ~30 s; if it fails again the underlying cause (DNS / port 80 / CAA) is still present.`,
+      refresh: true,
+    };
+  } catch (e) {
+    return { ok: false, message: `Could not reach NPM: ${e instanceof Error ? e.message : String(e)}`, refresh: false };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'show_log_tail',
+    label: 'Show log tail',
+    description: 'Returns the last ~80 lines of NPM\'s letsencrypt.log in an expandable code block so you can see the full certbot error context — the ACME response that triggered the failure is usually within 10 lines of the timestamp.',
+  },
+  showLogTail,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'retry_request',
+    label: 'Retry now',
+    description: 'Re-runs NPM\'s cert renewal for this domain. Useful when the underlying cause was transient (rate limit just expired, brief router blip). If the root cause is still present, certbot will fail again with the same error.',
+  },
+  retryRequest,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -23,6 +23,7 @@ import './healthChecks';
 import './disk';
 import './podsAndEngine';
 import './certExpiry';
+import './certRequestFailure';
 import './adguardRewritesMissing';
 
 export {};

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -343,6 +343,17 @@ export interface VariableMeta {
   proxyPort?: string;
   /** For subdomain type: service-specific NPM proxy host configuration */
   proxyConfig?: ProxyConfig;
+  /**
+   * For subdomain type: how this service is meant to be exposed.
+   *   - `public`: reachable from the internet on 80/443, auto-request
+   *     Let's Encrypt cert at install time and bind it to the proxy host.
+   *   - `lan`: reachable only on the LAN, no TLS cert provisioned.
+   * Each template declares a sensible default in variables.json; the
+   * operator can override per-service in the wizard's configure step.
+   * Missing/undefined treated the same as `lan` (the conservative
+   * default — never auto-request a cert without explicit opt-in).
+   */
+  exposure?: 'public' | 'lan';
   /** OIDC client to register with Authelia when this service is deployed */
   oidcClient?: OidcClientConfig;
   /** For bcrypt type: name of another variable whose plaintext gets bcrypt-hashed */

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -107,7 +107,14 @@ function renderProxyConfig(
 /** Build the proxy-host list from subdomain-typed variables. */
 function buildProxyHosts(variables: StackVariable[]): {
   domain: string | undefined;
-  hosts: { domain: string; forwardPort: number; service: string; proxyConfig?: VariableMeta['proxyConfig'] }[];
+  hosts: {
+    domain: string;
+    forwardPort: number;
+    service: string;
+    /** 'public' triggers auto-cert request server-side; 'lan' skips. */
+    exposure: 'public' | 'lan';
+    proxyConfig?: VariableMeta['proxyConfig'];
+  }[];
 } {
   const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
   if (!domain) return { domain, hosts: [] };
@@ -126,6 +133,10 @@ function buildProxyHosts(variables: StackVariable[]): {
       domain: `${sv.value}.${domain}`,
       forwardPort: parseInt(port, 10),
       service,
+      // Conservative default: missing/unknown → 'lan'. Templates declare
+      // `"exposure": "public"` explicitly for services that should get a
+      // Let's Encrypt cert at install time.
+      exposure: (sv.meta?.exposure === 'public' ? 'public' : 'lan') as 'public' | 'lan',
       proxyConfig: renderProxyConfig(sv.meta?.proxyConfig, view),
     };
   }).filter(h => Number.isFinite(h.forwardPort) && h.forwardPort > 0);
@@ -177,6 +188,20 @@ export async function configureProxyRoutes(opts: ConfigureProxyOpts): Promise<Pr
       onLog(`✅ Proxy routes created: ${data.created.join(', ')}`);
       if (data.failed?.length) {
         onLog(`⚠️ Some routes failed: ${data.failed.map((f: { domain: string }) => f.domain).join(', ')}`);
+      }
+      // Surface per-host cert outcomes for the public-exposure hosts.
+      // Failures here are not fatal — the cert_request_failure diagnose
+      // probe parses NPM's letsencrypt.log and lets the operator click
+      // Retry once the underlying cause is fixed.
+      type CertResult = { domain: string; issued: boolean; error?: string };
+      const certs: CertResult[] = Array.isArray(data.certs) ? data.certs : [];
+      const issued = certs.filter(c => c.issued).map(c => c.domain);
+      const failedCerts = certs.filter(c => !c.issued);
+      if (issued.length > 0) {
+        onLog(`🔒 Let's Encrypt certs issued: ${issued.join(', ')}`);
+      }
+      for (const fc of failedCerts) {
+        onLog(`⚠️ Cert request for ${fc.domain} failed — ${fc.error ?? 'see diagnose page for details'}.`);
       }
       return 'ok';
     }

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -112,6 +112,14 @@ export interface UseStackInstallReturn {
   setItemChecked: (name: string, checked: boolean) => void;
   setItems: (items: StackItem[]) => void;
   setVariableValue: (name: string, value: string) => void;
+  /**
+   * Override the exposure profile of a subdomain-typed variable. Per-
+   * template defaults live in `variables.json` (`meta.exposure`); this
+   * setter mutates `meta.exposure` on the live install state so the
+   * proxy-hosts POST sees the operator's choice. Only meaningful for
+   * subdomain variables — no-op on others.
+   */
+  setVariableExposure: (name: string, exposure: 'public' | 'lan') => void;
 
   /** Fetch yamls + variable metadata + configFiles for every checked
    *  item, resolve placeholders, transition to 'configure'. `prefilled`
@@ -279,6 +287,18 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       if (i === -1 || prev[i].value === value) return prev;
       const next = prev.slice();
       next[i] = { ...next[i], value };
+      return next;
+    });
+  }, []);
+
+  const setVariableExposure = useCallback((name: string, exposure: 'public' | 'lan') => {
+    setVariables(prev => {
+      const i = prev.findIndex(x => x.name === name);
+      if (i === -1) return prev;
+      const cur = prev[i];
+      if (cur.meta?.type !== 'subdomain' || cur.meta?.exposure === exposure) return prev;
+      const next = prev.slice();
+      next[i] = { ...cur, meta: { ...cur.meta, exposure } };
       return next;
     });
   }, []);
@@ -831,6 +851,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     setItemChecked,
     setItems,
     setVariableValue,
+    setVariableExposure,
     startConfigure,
     runInstall,
     retryNpmCredentials,

--- a/templates/adguard/variables.json
+++ b/templates/adguard/variables.json
@@ -22,6 +22,7 @@
     "type": "subdomain",
     "description": "Subdomain for AdGuard Home admin",
     "default": "dns",
+    "exposure": "lan",
     "proxyPort": "ADGUARD_ADMIN_PORT",
     "proxyConfig": {
       "block_exploits": true,

--- a/templates/auth/variables.json
+++ b/templates/auth/variables.json
@@ -26,6 +26,7 @@
     "type": "subdomain",
     "description": "Subdomain for LLDAP Web UI",
     "default": "ldap",
+    "exposure": "lan",
     "proxyPort": "LLDAP_PORT",
     "proxyConfig": {
       "block_exploits": true,
@@ -41,6 +42,7 @@
     "type": "subdomain",
     "description": "Subdomain for Authelia portal",
     "default": "auth",
+    "exposure": "public",
     "proxyPort": "AUTHELIA_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/file-share/variables.json
+++ b/templates/file-share/variables.json
@@ -12,6 +12,7 @@
     "type": "subdomain",
     "description": "Subdomain for Syncthing Web UI",
     "default": "sync",
+    "exposure": "lan",
     "proxyPort": "8384",
     "proxyConfig": {
       "allow_websocket_upgrade": true,
@@ -33,6 +34,7 @@
     "type": "subdomain",
     "description": "Subdomain for FileBrowser. Authelia forward-auth in the proxy snippet means SSO login → FileBrowser session in one step.",
     "default": "files",
+    "exposure": "public",
     "proxyPort": "FILEBROWSER_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -17,6 +17,7 @@
     "type": "subdomain",
     "description": "Subdomain for Home Assistant",
     "default": "home",
+    "exposure": "public",
     "proxyPort": "8123",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/immich/variables.json
+++ b/templates/immich/variables.json
@@ -12,6 +12,7 @@
     "type": "subdomain",
     "description": "Subdomain for Immich",
     "default": "photos",
+    "exposure": "public",
     "proxyPort": "IMMICH_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -36,6 +36,7 @@
     "type": "subdomain",
     "description": "Subdomain for Audiobookshelf",
     "default": "books",
+    "exposure": "public",
     "proxyPort": "ABS_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,
@@ -74,6 +75,7 @@
     "type": "subdomain",
     "description": "Subdomain for Navidrome (web UI + Symfonium endpoint)",
     "default": "music",
+    "exposure": "public",
     "proxyPort": "NAVIDROME_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/nginx/variables.json
+++ b/templates/nginx/variables.json
@@ -32,6 +32,7 @@
     "type": "subdomain",
     "description": "Subdomain for Nginx Proxy Manager admin",
     "default": "nginx",
+    "exposure": "lan",
     "proxyPort": "NGINX_ADMIN_PORT",
     "proxyConfig": {
       "block_exploits": true,
@@ -42,6 +43,7 @@
     "type": "subdomain",
     "description": "Subdomain for ServiceBay admin panel",
     "default": "admin",
+    "exposure": "lan",
     "proxyPort": "5888",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/radicale/variables.json
+++ b/templates/radicale/variables.json
@@ -27,6 +27,7 @@
     "type": "subdomain",
     "description": "Subdomain for both CalDAV (calendars) and CardDAV (address books). Radicale serves both protocols on the same port, so there's no separate `carddav.` host — contacts live at `https://caldav.<domain>/<user>/contacts/`. Mobile clients (DAVx⁵, iOS, Thunderbird) speak HTTP Basic auth — Authelia in front would block them, so this proxy host has NO Authelia forward-auth.",
     "default": "caldav",
+    "exposure": "public",
     "proxyPort": "RADICALE_PORT",
     "proxyConfig": {
       "block_exploits": true,

--- a/templates/vaultwarden/variables.json
+++ b/templates/vaultwarden/variables.json
@@ -35,6 +35,7 @@
     "type": "subdomain",
     "description": "Subdomain for Vaultwarden",
     "default": "vault",
+    "exposure": "public",
     "proxyPort": "VAULTWARDEN_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/tests/frontend/useStackInstall.test.tsx
+++ b/tests/frontend/useStackInstall.test.tsx
@@ -533,6 +533,42 @@ spec:
     });
   });
 
+  describe('setVariableExposure', () => {
+    it('overrides exposure on subdomain variables and is a no-op on others', async () => {
+      (fetchTemplateYaml as any).mockResolvedValue(
+        'apiVersion: v1\nkind: Pod\nmetadata:\n  name: vw',
+      );
+      (fetchTemplateVariables as any).mockResolvedValue({
+        VW_SUBDOMAIN: { type: 'subdomain', default: 'vault', exposure: 'public', proxyPort: '8222' },
+        VW_PORT: { type: 'text', default: '8222' },
+      });
+      (fetchTemplateConfigFiles as any).mockResolvedValue([]);
+      (fetchTemplatePostDeployScript as any).mockResolvedValue(null);
+      global.fetch = buildFetchMock({
+        '/api/settings': () => ({ jsonBody: { templateSettings: {} } }),
+      });
+
+      const { result } = renderHook(() => useStackInstall({ templateSource: 'Built-in' }));
+      await act(async () => {
+        await result.current.startConfigure([{ name: 'vw', checked: true }], {});
+      });
+      expect(result.current.variables.find(v => v.name === 'VW_SUBDOMAIN')?.meta?.exposure).toBe('public');
+
+      // Override → 'lan' takes effect.
+      act(() => result.current.setVariableExposure('VW_SUBDOMAIN', 'lan'));
+      expect(result.current.variables.find(v => v.name === 'VW_SUBDOMAIN')?.meta?.exposure).toBe('lan');
+
+      // Same-value write is a no-op (referential stability).
+      const before = result.current.variables;
+      act(() => result.current.setVariableExposure('VW_SUBDOMAIN', 'lan'));
+      expect(result.current.variables).toBe(before);
+
+      // Non-subdomain variable is ignored.
+      act(() => result.current.setVariableExposure('VW_PORT', 'public'));
+      expect(result.current.variables).toBe(before);
+    });
+  });
+
   describe('OIDC client registration', () => {
     it('POSTs to authelia/oidc-clients when subdomain vars carry oidcClient metadata', async () => {
       (fetchTemplateYaml as any).mockResolvedValue(


### PR DESCRIPTION
## Summary
- New `exposure: "public" | "lan"` meta key on subdomain variables. Each template declares its sensible default in `variables.json`; the wizard's configure step renders a Public/LAN toggle for per-service override.
- Auto Let's Encrypt cert request at install time for `exposure: "public"` hosts (POST `/api/nginx/certificates` + PUT proxy-host with `certificate_id`/`ssl_forced`). Best-effort — install does not fail on ACME error.
- New `cert_request_failure` diagnose probe parses NPM's `letsencrypt.log` and surfaces one row per recently-failed domain with `show_log_tail` and `retry_request` actions. Recovery path when NPM's generic "Internal Error" hides the real ACME failure (DNS / port 80 / CAA / rate limit).

Per-template defaults:
- **public**: vault, photos, files, home, auth, books, music, caldav
- **lan**: dns, ldap, sync, nginx-admin, servicebay-admin

## Test plan
- [x] `npx vitest run src/lib/diagnose/ src/lib/stackInstall/ src/components/ tests/frontend/useStackInstall.test.tsx` — 110 tests pass
- [x] Full suite: 595 passing (excluding 5 pre-existing broken backend/frontend test files unrelated to this change)
- [x] `npx tsc --noEmit` — no new errors
- [x] Lint clean on all touched files
- [ ] Manual: reinstall on a fresh ServiceBay, confirm public services get certs at install time and LAN services don't
- [ ] Manual: trigger a synthetic cert failure (e.g. NXDOMAIN subdomain), confirm diagnose probe surfaces the real reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)