### PR TITLE
feat(diagnose): FritzBox reconnect action + fix-buttons in onboarding wizard

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
@@ -1,68 +1,28 @@
 'use client';
 
 import { useState } from 'react';
-import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Stethoscope, Wrench } from 'lucide-react';
-
-type ProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
-
-interface ProbeActionInput {
-  name: string;
-  label: string;
-  type: 'text' | 'password' | 'email';
-  placeholder?: string;
-  hint?: string;
-  required?: boolean;
-}
-
-interface ProbeAction {
-  id: string;
-  label: string;
-  description: string;
-  destructive?: boolean;
-  inputs?: ProbeActionInput[];
-}
-
-interface ProbeItem {
-  id: string;
-  label: string;
-  detail?: string;
-  status?: ProbeStatus;
-  actions: ProbeAction[];
-}
-
-interface DiagnoseProbe {
-  id: string;
-  label: string;
-  status: ProbeStatus;
-  detail: string;
-  hint?: string;
-  actions?: ProbeAction[];
-  items?: ProbeItem[];
-}
+import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Stethoscope } from 'lucide-react';
+import DiagnoseProbeList, {
+  type DiagnoseProbe,
+  type ProbeStatus,
+} from '@/components/DiagnoseProbeList';
 
 interface DiagnoseResult {
   node: string;
   probes: DiagnoseProbe[];
 }
 
-const STATUS_META: Record<ProbeStatus, { color: string; bg: string; ring: string; Icon: React.ComponentType<{ size?: number; className?: string }> }> = {
-  ok: { color: 'text-emerald-700 dark:text-emerald-300', bg: 'bg-emerald-50 dark:bg-emerald-900/20', ring: 'border-emerald-200 dark:border-emerald-800', Icon: CheckCircle2 },
-  warn: { color: 'text-amber-700 dark:text-amber-300', bg: 'bg-amber-50 dark:bg-amber-900/20', ring: 'border-amber-200 dark:border-amber-800', Icon: AlertTriangle },
-  fail: { color: 'text-red-700 dark:text-red-300', bg: 'bg-red-50 dark:bg-red-900/20', ring: 'border-red-200 dark:border-red-800', Icon: AlertCircle },
-  info: { color: 'text-blue-700 dark:text-blue-300', bg: 'bg-blue-50 dark:bg-blue-900/20', ring: 'border-blue-200 dark:border-blue-800', Icon: Info },
+const STATUS_META: Record<ProbeStatus, { color: string; bg: string; Icon: React.ComponentType<{ size?: number; className?: string }> }> = {
+  ok: { color: 'text-emerald-700 dark:text-emerald-300', bg: 'bg-emerald-50 dark:bg-emerald-900/20', Icon: CheckCircle2 },
+  warn: { color: 'text-amber-700 dark:text-amber-300', bg: 'bg-amber-50 dark:bg-amber-900/20', Icon: AlertTriangle },
+  fail: { color: 'text-red-700 dark:text-red-300', bg: 'bg-red-50 dark:bg-red-900/20', Icon: AlertCircle },
+  info: { color: 'text-blue-700 dark:text-blue-300', bg: 'bg-blue-50 dark:bg-blue-900/20', Icon: Info },
 };
 
 export default function SelfDiagnoseSection() {
   const [result, setResult] = useState<DiagnoseResult | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  /** Per-action transient state. Keyed by `<probeId>:<actionId>` for probe-level
-   *  actions, or `<probeId>:<actionId>:<itemId>` for per-item actions. */
-  const [actionState, setActionState] = useState<Record<string, { running?: boolean; message?: string; details?: string; ok?: boolean }>>({});
-  /** Which actions have their inline form expanded. Keyed by `<probeId>:<actionId>`. */
-  const [expandedForms, setExpandedForms] = useState<Record<string, boolean>>({});
-  /** Form-field values per action. Keyed by `<probeId>:<actionId>` → { fieldName: value }. */
-  const [formValues, setFormValues] = useState<Record<string, Record<string, string>>>({});
 
   const run = async () => {
     setRunning(true);
@@ -78,94 +38,6 @@ export default function SelfDiagnoseSection() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setRunning(false);
-    }
-  };
-
-  const runAction = async (probe: DiagnoseProbe, action: ProbeAction, payload?: Record<string, string>, itemId?: string) => {
-    // Confirm-on-destructive guard. The action's description is
-    // surfaced in the dialog so the user sees the consequences they
-    // accepted.
-    if (action.destructive) {
-      const ok = window.confirm(`${action.label}\n\n${action.description}\n\nThis action can't be undone. Continue?`);
-      if (!ok) return;
-    }
-    // Per-item actions key off the item id too so a row's button
-    // state doesn't bleed into siblings.
-    const key = itemId ? `${probe.id}:${action.id}:${itemId}` : `${probe.id}:${action.id}`;
-    setActionState(s => ({ ...s, [key]: { running: true } }));
-    // Special case: actions with id `verify_from_device` run as a
-    // browser-side fetch instead of dispatching to the server (#264).
-    // The whole point of "verify from this device" is to test what
-    // *this device's* DNS resolver does — which has to happen in the
-    // browser, not on the ServiceBay backend.
-    if (action.id === 'verify_from_device') {
-      try {
-        // First call /api/system/mode (same-origin, always works) to
-        // learn the active domain — then fetch from `admin.<domain>`
-        // to verify *this device's* DNS routes home.arpa to ServiceBay.
-        const modeRes = await fetch('/api/system/mode');
-        const modeData = await modeRes.json().catch(() => ({}));
-        const activeDomain = modeData.activeDomain ?? 'home.arpa';
-        const verifyRes = await fetch(`http://admin.${activeDomain}/api/system/verify-lan-dns`, {
-          method: 'GET',
-          signal: AbortSignal.timeout(3000),
-        });
-        const data = await verifyRes.json().catch(() => ({}));
-        const ok = verifyRes.ok && data.ok === true;
-        setActionState(s => ({
-          ...s,
-          [key]: {
-            ok,
-            message: ok
-              ? `✅ This device resolves ${activeDomain} → ${data.lanIp ?? 'ok'}.`
-              : `Got HTTP ${verifyRes.status} — DNS may be partially configured.`,
-          },
-        }));
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        setActionState(s => ({
-          ...s,
-          [key]: {
-            ok: false,
-            message: `❌ This device can't resolve the LAN domain — your router may not be using AdGuard as DNS, or this device has DNS-over-HTTPS overriding it. (${msg})`,
-          },
-        }));
-      }
-      return;
-    }
-    try {
-      const res = await fetch('/api/system/diagnose/run-action', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          probeId: probe.id,
-          actionId: action.id,
-          node: result?.node,
-          ...(itemId ? { itemId } : {}),
-          ...(payload ? { payload } : {}),
-        }),
-      });
-      const data = await res.json().catch(() => ({}));
-      const ok = res.ok && data.ok !== false;
-      setActionState(s => ({
-        ...s,
-        [key]: {
-          ok,
-          message: data.message ?? (ok ? 'Done.' : `HTTP ${res.status}`),
-          details: typeof data.details === 'string' ? data.details : undefined,
-        },
-      }));
-      // Auto-rerun the diagnose suite when the action requested it.
-      // This makes the probe transition to `ok` (or to a follow-up
-      // warn) immediately visible without a manual click.
-      if (ok && data.refresh !== false) {
-        void run();
-      }
-    } catch (e) {
-      setActionState(s => ({
-        ...s,
-        [key]: { ok: false, message: e instanceof Error ? e.message : String(e) },
-      }));
     }
   };
 
@@ -226,207 +98,14 @@ export default function SelfDiagnoseSection() {
           </div>
         )}
 
-        {result?.probes.map(probe => {
-          const meta = STATUS_META[probe.status];
-          const Icon = meta.Icon;
-          return (
-            <div key={probe.id} className={`p-3 rounded-lg border ${meta.ring} ${meta.bg}`}>
-              <div className="flex items-start gap-2">
-                <Icon size={16} className={`shrink-0 mt-0.5 ${meta.color}`} />
-                <div className="flex-1 min-w-0">
-                  <div className={`font-medium text-sm ${meta.color}`}>{probe.label}</div>
-                  <pre className="text-xs text-gray-700 dark:text-gray-300 mt-1 whitespace-pre-wrap break-words font-mono">{probe.detail}</pre>
-                  {probe.hint && (
-                    <p className={`text-xs mt-2 ${meta.color}`}>
-                      <strong>Suggestion:</strong> {probe.hint}
-                    </p>
-                  )}
-                  {(probe.actions ?? []).length > 0 && (
-                    <div className="mt-3 space-y-2">
-                      <div className="flex flex-wrap gap-2">
-                        {(probe.actions ?? []).map(action => {
-                          const key = `${probe.id}:${action.id}`;
-                          const state = actionState[key];
-                          const isRunning = state?.running;
-                          const hasInputs = (action.inputs ?? []).length > 0;
-                          const isExpanded = expandedForms[key];
-                          const baseStyle = action.destructive
-                            ? 'bg-red-600 hover:bg-red-700 text-white'
-                            : 'bg-violet-600 hover:bg-violet-700 text-white';
-                          return (
-                            <div key={action.id} className="flex items-center gap-2">
-                              <button
-                                onClick={() => {
-                                  if (hasInputs) {
-                                    setExpandedForms(s => ({ ...s, [key]: !s[key] }));
-                                  } else {
-                                    void runAction(probe, action);
-                                  }
-                                }}
-                                disabled={isRunning || running}
-                                title={action.description}
-                                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
-                              >
-                                {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
-                                {action.label}
-                                {hasInputs && (isExpanded ? ' ▴' : ' ▾')}
-                              </button>
-                              {state?.message && !isRunning && (
-                                <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
-                                  {state.ok ? '✓' : '✗'} {state.message}
-                                </span>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                      {/* Multi-line action result details (e.g. log tails). One
-                          block per action that produced details on its last
-                          run. Rendered as a wrapped <pre> so newlines survive. */}
-                      {(probe.actions ?? []).map(action => {
-                        const key = `${probe.id}:${action.id}`;
-                        const state = actionState[key];
-                        if (!state?.details) return null;
-                        return (
-                          <pre
-                            key={`${key}-details`}
-                            className="text-xs text-gray-700 dark:text-gray-300 bg-white/60 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono"
-                          >{state.details}</pre>
-                        );
-                      })}
-                      {(probe.actions ?? []).map(action => {
-                        const key = `${probe.id}:${action.id}`;
-                        const hasInputs = (action.inputs ?? []).length > 0;
-                        if (!hasInputs || !expandedForms[key]) return null;
-                        const values = formValues[key] ?? {};
-                        const state = actionState[key];
-                        const isRunning = state?.running;
-                        const inputs = action.inputs ?? [];
-                        const allRequiredFilled = inputs
-                          .filter(i => i.required !== false)
-                          .every(i => (values[i.name] ?? '').length > 0);
-                        return (
-                          <form
-                            key={`${key}-form`}
-                            onSubmit={e => {
-                              e.preventDefault();
-                              void runAction(probe, action, values);
-                            }}
-                            className="p-3 rounded-md bg-white/60 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-2"
-                          >
-                            <p className="text-xs text-gray-600 dark:text-gray-400">{action.description}</p>
-                            {inputs.map(input => (
-                              <div key={input.name} className="space-y-1">
-                                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                                  {input.label}{input.required !== false && <span className="text-red-500"> *</span>}
-                                </label>
-                                <input
-                                  type={input.type}
-                                  value={values[input.name] ?? ''}
-                                  placeholder={input.placeholder}
-                                  required={input.required !== false}
-                                  onChange={e =>
-                                    setFormValues(s => ({
-                                      ...s,
-                                      [key]: { ...(s[key] ?? {}), [input.name]: e.target.value },
-                                    }))
-                                  }
-                                  className="w-full px-2 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-violet-500"
-                                  autoComplete="off"
-                                />
-                                {input.hint && (
-                                  <p className="text-xs text-gray-500 dark:text-gray-400">{input.hint}</p>
-                                )}
-                              </div>
-                            ))}
-                            <div className="flex items-center gap-2 pt-1">
-                              <button
-                                type="submit"
-                                disabled={!allRequiredFilled || isRunning || running}
-                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 hover:bg-violet-700 text-white disabled:opacity-50"
-                              >
-                                {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
-                                Submit
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => setExpandedForms(s => ({ ...s, [key]: false }))}
-                                className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-                              >
-                                Cancel
-                              </button>
-                            </div>
-                          </form>
-                        );
-                      })}
-                    </div>
-                  )}
-                  {(probe.items ?? []).length > 0 && (
-                    <div className="mt-3 space-y-1.5">
-                      {(probe.items ?? []).map(item => {
-                        const itemMeta = STATUS_META[item.status ?? probe.status];
-                        return (
-                          <div
-                            key={item.id}
-                            className={`flex flex-wrap items-center gap-2 px-2 py-1.5 rounded border ${itemMeta.ring} bg-white/60 dark:bg-gray-900/40`}
-                          >
-                            <div className="flex-1 min-w-0">
-                              <div className={`text-xs font-mono ${itemMeta.color}`}>{item.label}</div>
-                              {item.detail && (
-                                <div className="text-xs text-gray-600 dark:text-gray-400 font-mono">{item.detail}</div>
-                              )}
-                            </div>
-                            {item.actions.map(action => {
-                              const key = `${probe.id}:${action.id}:${item.id}`;
-                              const state = actionState[key];
-                              const isRunning = state?.running;
-                              const baseStyle = action.destructive
-                                ? 'bg-red-600 hover:bg-red-700 text-white'
-                                : 'bg-violet-600 hover:bg-violet-700 text-white';
-                              return (
-                                <div key={action.id} className="flex items-center gap-2">
-                                  <button
-                                    onClick={() => void runAction(probe, action, undefined, item.id)}
-                                    disabled={isRunning || running}
-                                    title={action.description}
-                                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
-                                  >
-                                    {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
-                                    {action.label}
-                                  </button>
-                                  {state?.message && !isRunning && (
-                                    <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
-                                      {state.ok ? '✓' : '✗'} {state.message}
-                                    </span>
-                                  )}
-                                </div>
-                              );
-                            })}
-                            {/* Multi-line details for any per-item action that
-                                produced them — rendered full-width below the
-                                button row. flex-wrap on the parent makes
-                                w-full take a new line cleanly. */}
-                            {item.actions.map(action => {
-                              const key = `${probe.id}:${action.id}:${item.id}`;
-                              const state = actionState[key];
-                              if (!state?.details) return null;
-                              return (
-                                <pre
-                                  key={`${key}-details`}
-                                  className="w-full text-xs text-gray-700 dark:text-gray-300 bg-white/80 dark:bg-gray-900/60 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono"
-                                >{state.details}</pre>
-                              );
-                            })}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          );
-        })}
+        {result && (
+          <DiagnoseProbeList
+            probes={result.probes}
+            node={result.node}
+            onRefresh={run}
+            parentRunning={running}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/DiagnoseProbeList.tsx
+++ b/src/components/DiagnoseProbeList.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Wrench } from 'lucide-react';
+
+/**
+ * Shared probe-list renderer used by Settings → Self-Diagnose and by the
+ * OnboardingWizard's post-install diagnose panel. Owns the action-dispatch
+ * state machine (button disabled while running, message + details after,
+ * destructive-action confirm, inline form for actions with `inputs[]`) so
+ * the two surfaces don't drift.
+ *
+ * Wizard mode (`compact = true`) hides probes with `status === 'ok'` so the
+ * post-install summary stays focused on actionable issues; settings mode
+ * (`compact = false`) lists every probe for full transparency.
+ */
+
+export type ProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
+
+interface ProbeActionInput {
+  name: string;
+  label: string;
+  type: 'text' | 'password' | 'email';
+  placeholder?: string;
+  hint?: string;
+  required?: boolean;
+}
+
+export interface ProbeAction {
+  id: string;
+  label: string;
+  description: string;
+  destructive?: boolean;
+  inputs?: ProbeActionInput[];
+}
+
+export interface ProbeItem {
+  id: string;
+  label: string;
+  detail?: string;
+  status?: ProbeStatus;
+  actions: ProbeAction[];
+}
+
+export interface DiagnoseProbe {
+  id: string;
+  label: string;
+  status: ProbeStatus;
+  detail: string;
+  hint?: string;
+  actions?: ProbeAction[];
+  items?: ProbeItem[];
+}
+
+const STATUS_META: Record<ProbeStatus, { color: string; bg: string; ring: string; Icon: React.ComponentType<{ size?: number; className?: string }> }> = {
+  ok: { color: 'text-emerald-700 dark:text-emerald-300', bg: 'bg-emerald-50 dark:bg-emerald-900/20', ring: 'border-emerald-200 dark:border-emerald-800', Icon: CheckCircle2 },
+  warn: { color: 'text-amber-700 dark:text-amber-300', bg: 'bg-amber-50 dark:bg-amber-900/20', ring: 'border-amber-200 dark:border-amber-800', Icon: AlertTriangle },
+  fail: { color: 'text-red-700 dark:text-red-300', bg: 'bg-red-50 dark:bg-red-900/20', ring: 'border-red-200 dark:border-red-800', Icon: AlertCircle },
+  info: { color: 'text-blue-700 dark:text-blue-300', bg: 'bg-blue-50 dark:bg-blue-900/20', ring: 'border-blue-200 dark:border-blue-800', Icon: Info },
+};
+
+interface DiagnoseProbeListProps {
+  probes: DiagnoseProbe[];
+  /** Node name passed back to the dispatch endpoint. */
+  node: string;
+  /** Compact = wizard-style. Filters out `ok` rows and tightens spacing. */
+  compact?: boolean;
+  /** Called after a successful action so the host can re-fetch the suite.
+   *  Default no-op; SelfDiagnoseSection passes `run`, the wizard passes
+   *  the function that resets its auto-run gate. */
+  onRefresh?: () => void;
+  /** Disable buttons while the parent is mid-run. */
+  parentRunning?: boolean;
+}
+
+export default function DiagnoseProbeList({
+  probes,
+  node,
+  compact = false,
+  onRefresh,
+  parentRunning = false,
+}: DiagnoseProbeListProps) {
+  /** Per-action transient state. Keyed by `<probeId>:<actionId>` for
+   *  probe-level actions, `<probeId>:<actionId>:<itemId>` for per-item. */
+  const [actionState, setActionState] = useState<Record<string, { running?: boolean; message?: string; details?: string; ok?: boolean }>>({});
+  /** Which actions have their inline form expanded. */
+  const [expandedForms, setExpandedForms] = useState<Record<string, boolean>>({});
+  /** Form-field values per action. */
+  const [formValues, setFormValues] = useState<Record<string, Record<string, string>>>({});
+
+  const runAction = async (probe: DiagnoseProbe, action: ProbeAction, payload?: Record<string, string>, itemId?: string) => {
+    if (action.destructive) {
+      const ok = window.confirm(`${action.label}\n\n${action.description}\n\nThis action can't be undone. Continue?`);
+      if (!ok) return;
+    }
+    const key = itemId ? `${probe.id}:${action.id}:${itemId}` : `${probe.id}:${action.id}`;
+    setActionState(s => ({ ...s, [key]: { running: true } }));
+
+    // `verify_from_device` runs in the browser (the whole point is to test
+    // *this device's* DNS resolver). Mirrors SelfDiagnoseSection.
+    if (action.id === 'verify_from_device') {
+      try {
+        const modeRes = await fetch('/api/system/mode');
+        const modeData = await modeRes.json().catch(() => ({}));
+        const activeDomain = modeData.activeDomain ?? 'home.arpa';
+        const verifyRes = await fetch(`http://admin.${activeDomain}/api/system/verify-lan-dns`, {
+          method: 'GET',
+          signal: AbortSignal.timeout(3000),
+        });
+        const data = await verifyRes.json().catch(() => ({}));
+        const ok = verifyRes.ok && data.ok === true;
+        setActionState(s => ({
+          ...s,
+          [key]: {
+            ok,
+            message: ok
+              ? `✅ This device resolves ${activeDomain} → ${data.lanIp ?? 'ok'}.`
+              : `Got HTTP ${verifyRes.status} — DNS may be partially configured.`,
+          },
+        }));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setActionState(s => ({
+          ...s,
+          [key]: {
+            ok: false,
+            message: `❌ This device can't resolve the LAN domain — your router may not be using AdGuard as DNS, or this device has DNS-over-HTTPS overriding it. (${msg})`,
+          },
+        }));
+      }
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/system/diagnose/run-action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          probeId: probe.id,
+          actionId: action.id,
+          node,
+          ...(itemId ? { itemId } : {}),
+          ...(payload ? { payload } : {}),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      const ok = res.ok && data.ok !== false;
+      setActionState(s => ({
+        ...s,
+        [key]: {
+          ok,
+          message: data.message ?? (ok ? 'Done.' : `HTTP ${res.status}`),
+          details: typeof data.details === 'string' ? data.details : undefined,
+        },
+      }));
+      if (ok && data.refresh !== false && onRefresh) onRefresh();
+    } catch (e) {
+      setActionState(s => ({
+        ...s,
+        [key]: { ok: false, message: e instanceof Error ? e.message : String(e) },
+      }));
+    }
+  };
+
+  // In compact mode, hide ok rows — the wizard's outer panel already
+  // surfaces the overall pass/warn/fail count, so a list of every probe
+  // would be noise.
+  const visible = compact ? probes.filter(p => p.status !== 'ok') : probes;
+
+  return (
+    <div className={compact ? 'space-y-2' : 'space-y-3'}>
+      {visible.map(probe => {
+        const meta = STATUS_META[probe.status];
+        const Icon = meta.Icon;
+        return (
+          <div key={probe.id} className={`${compact ? 'p-2.5' : 'p-3'} rounded-lg border ${meta.ring} ${meta.bg}`}>
+            <div className="flex items-start gap-2">
+              <Icon size={compact ? 14 : 16} className={`shrink-0 mt-0.5 ${meta.color}`} />
+              <div className="flex-1 min-w-0">
+                <div className={`font-medium text-sm ${meta.color}`}>{probe.label}</div>
+                <pre className="text-xs text-gray-700 dark:text-gray-300 mt-1 whitespace-pre-wrap break-words font-mono">{probe.detail}</pre>
+                {probe.hint && (
+                  <p className={`text-xs mt-2 ${meta.color}`}>
+                    <strong>Suggestion:</strong> {probe.hint}
+                  </p>
+                )}
+                {(probe.actions ?? []).length > 0 && (
+                  <div className="mt-3 space-y-2">
+                    <div className="flex flex-wrap gap-2">
+                      {(probe.actions ?? []).map(action => {
+                        const key = `${probe.id}:${action.id}`;
+                        const state = actionState[key];
+                        const isRunning = state?.running;
+                        const hasInputs = (action.inputs ?? []).length > 0;
+                        const isExpanded = expandedForms[key];
+                        const baseStyle = action.destructive
+                          ? 'bg-red-600 hover:bg-red-700 text-white'
+                          : 'bg-violet-600 hover:bg-violet-700 text-white';
+                        return (
+                          <div key={action.id} className="flex items-center gap-2">
+                            <button
+                              onClick={() => {
+                                if (hasInputs) {
+                                  setExpandedForms(s => ({ ...s, [key]: !s[key] }));
+                                } else {
+                                  void runAction(probe, action);
+                                }
+                              }}
+                              disabled={isRunning || parentRunning}
+                              title={action.description}
+                              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
+                            >
+                              {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                              {action.label}
+                              {hasInputs && (isExpanded ? ' ▴' : ' ▾')}
+                            </button>
+                            {state?.message && !isRunning && (
+                              <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
+                                {state.ok ? '✓' : '✗'} {state.message}
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {(probe.actions ?? []).map(action => {
+                      const key = `${probe.id}:${action.id}`;
+                      const state = actionState[key];
+                      if (!state?.details) return null;
+                      return (
+                        <pre
+                          key={`${key}-details`}
+                          className="text-xs text-gray-700 dark:text-gray-300 bg-white/60 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono"
+                        >{state.details}</pre>
+                      );
+                    })}
+                    {(probe.actions ?? []).map(action => {
+                      const key = `${probe.id}:${action.id}`;
+                      const hasInputs = (action.inputs ?? []).length > 0;
+                      if (!hasInputs || !expandedForms[key]) return null;
+                      const values = formValues[key] ?? {};
+                      const state = actionState[key];
+                      const isRunning = state?.running;
+                      const inputs = action.inputs ?? [];
+                      const allRequiredFilled = inputs
+                        .filter(i => i.required !== false)
+                        .every(i => (values[i.name] ?? '').length > 0);
+                      return (
+                        <form
+                          key={`${key}-form`}
+                          onSubmit={e => {
+                            e.preventDefault();
+                            void runAction(probe, action, values);
+                          }}
+                          className="p-3 rounded-md bg-white/60 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 space-y-2"
+                        >
+                          <p className="text-xs text-gray-600 dark:text-gray-400">{action.description}</p>
+                          {inputs.map(input => (
+                            <div key={input.name} className="space-y-1">
+                              <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                                {input.label}{input.required !== false && <span className="text-red-500"> *</span>}
+                              </label>
+                              <input
+                                type={input.type}
+                                value={values[input.name] ?? ''}
+                                placeholder={input.placeholder}
+                                required={input.required !== false}
+                                onChange={e =>
+                                  setFormValues(s => ({
+                                    ...s,
+                                    [key]: { ...(s[key] ?? {}), [input.name]: e.target.value },
+                                  }))
+                                }
+                                className="w-full px-2 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                                autoComplete="off"
+                              />
+                              {input.hint && (
+                                <p className="text-xs text-gray-500 dark:text-gray-400">{input.hint}</p>
+                              )}
+                            </div>
+                          ))}
+                          <div className="flex items-center gap-2 pt-1">
+                            <button
+                              type="submit"
+                              disabled={!allRequiredFilled || isRunning || parentRunning}
+                              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 hover:bg-violet-700 text-white disabled:opacity-50"
+                            >
+                              {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                              Submit
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setExpandedForms(s => ({ ...s, [key]: false }))}
+                              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </form>
+                      );
+                    })}
+                  </div>
+                )}
+                {(probe.items ?? []).length > 0 && (
+                  <div className="mt-3 space-y-1.5">
+                    {(probe.items ?? []).map(item => {
+                      const itemMeta = STATUS_META[item.status ?? probe.status];
+                      return (
+                        <div
+                          key={item.id}
+                          className={`flex flex-wrap items-center gap-2 px-2 py-1.5 rounded border ${itemMeta.ring} bg-white/60 dark:bg-gray-900/40`}
+                        >
+                          <div className="flex-1 min-w-0">
+                            <div className={`text-xs font-mono ${itemMeta.color}`}>{item.label}</div>
+                            {item.detail && (
+                              <div className="text-xs text-gray-600 dark:text-gray-400 font-mono">{item.detail}</div>
+                            )}
+                          </div>
+                          {item.actions.map(action => {
+                            const key = `${probe.id}:${action.id}:${item.id}`;
+                            const state = actionState[key];
+                            const isRunning = state?.running;
+                            const baseStyle = action.destructive
+                              ? 'bg-red-600 hover:bg-red-700 text-white'
+                              : 'bg-violet-600 hover:bg-violet-700 text-white';
+                            return (
+                              <div key={action.id} className="flex items-center gap-2">
+                                <button
+                                  onClick={() => void runAction(probe, action, undefined, item.id)}
+                                  disabled={isRunning || parentRunning}
+                                  title={action.description}
+                                  className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors disabled:opacity-50 ${baseStyle}`}
+                                >
+                                  {isRunning ? <Loader2 size={12} className="animate-spin" /> : <Wrench size={12} />}
+                                  {action.label}
+                                </button>
+                                {state?.message && !isRunning && (
+                                  <span className={`text-xs ${state.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
+                                    {state.ok ? '✓' : '✗'} {state.message}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                          {item.actions.map(action => {
+                            const key = `${probe.id}:${action.id}:${item.id}`;
+                            const state = actionState[key];
+                            if (!state?.details) return null;
+                            return (
+                              <pre
+                                key={`${key}-details`}
+                                className="w-full text-xs text-gray-700 dark:text-gray-300 bg-white/80 dark:bg-gray-900/60 border border-gray-200 dark:border-gray-700 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono"
+                              >{state.details}</pre>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -26,6 +26,7 @@ import { useStackInstall } from '@/lib/stackInstall/useStackInstall';
 import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive, Home } from 'lucide-react';
 import StackVariableField from './StackVariableField';
 import { StackInstallProgress, StackInstallSummary } from './StackInstallFlow';
+import DiagnoseProbeList, { type DiagnoseProbe } from './DiagnoseProbeList';
 import { useToast } from '@/providers/ToastProvider';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 
@@ -349,9 +350,11 @@ export default function OnboardingWizard() {
   // Post-install self-test — auto-runs once the install pipeline reaches
   // 'done' so the user immediately sees a green/yellow/red verdict on
   // their fresh deployment instead of having to navigate to Settings.
+  // `diagnoseNode` is captured from the response so the action-dispatch
+  // calls in DiagnoseProbeList target the same node the suite probed.
   type ProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
-  interface DiagnoseProbe { id: string; label: string; status: ProbeStatus; detail: string; hint?: string }
   const [diagnoseProbes, setDiagnoseProbes] = useState<DiagnoseProbe[] | null>(null);
+  const [diagnoseNode, setDiagnoseNode] = useState<string>('Local');
   const [diagnoseRunning, setDiagnoseRunning] = useState(false);
   const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
   const [diagnoseRanOnce, setDiagnoseRanOnce] = useState(false);
@@ -523,7 +526,10 @@ export default function OnboardingWizard() {
         }
         return r.json();
       })
-      .then((data: { probes: DiagnoseProbe[] }) => setDiagnoseProbes(data.probes))
+      .then((data: { node?: string; probes: DiagnoseProbe[] }) => {
+        setDiagnoseProbes(data.probes);
+        if (data.node) setDiagnoseNode(data.node);
+      })
       .catch(e => setDiagnoseError(e instanceof Error ? e.message : String(e)))
       .finally(() => setDiagnoseRunning(false));
   }, [stackInstallStep, diagnoseRanOnce]);
@@ -2182,17 +2188,15 @@ export default function OnboardingWizard() {
                                         <p className="text-xs text-red-700 dark:text-red-300">{diagnoseError}</p>
                                     )}
                                     {diagnoseProbes && (diagCounts.warn > 0 || diagCounts.fail > 0) && (
-                                        <details className="mt-1 text-xs">
-                                            <summary className={`cursor-pointer ${overallStyle.text}`}>Details ({diagCounts.warn + diagCounts.fail} issue{diagCounts.warn + diagCounts.fail === 1 ? '' : 's'})</summary>
-                                            <ul className="mt-1 space-y-1.5">
-                                                {diagnoseProbes.filter(p => p.status === 'warn' || p.status === 'fail').map(p => (
-                                                    <li key={p.id} className="border-l-2 border-current pl-2 opacity-90">
-                                                        <div className="font-semibold">{p.status === 'fail' ? '❌' : '⚠️'} {p.label}</div>
-                                                        <div className="font-mono whitespace-pre-wrap break-words">{p.detail}</div>
-                                                        {p.hint && <div className="italic mt-0.5 opacity-90">💡 {p.hint}</div>}
-                                                    </li>
-                                                ))}
-                                            </ul>
+                                        <details className="mt-2 text-xs" open>
+                                            <summary className={`cursor-pointer ${overallStyle.text} mb-2`}>Details + fix-buttons ({diagCounts.warn + diagCounts.fail} issue{diagCounts.warn + diagCounts.fail === 1 ? '' : 's'})</summary>
+                                            <DiagnoseProbeList
+                                                probes={diagnoseProbes}
+                                                node={diagnoseNode}
+                                                compact
+                                                parentRunning={diagnoseRunning}
+                                                onRefresh={() => setDiagnoseRanOnce(false)}
+                                            />
                                         </details>
                                     )}
                                     <p className={`text-xs mt-1 ${overallStyle.text} opacity-70`}>

--- a/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
+++ b/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  setResult: { result: 'ok' } as any,
+  reconnectResult: { result: 'ok' } as any,
+};
+
+vi.mock('@/lib/router/dnsConfig', () => ({
+  setFritzBoxDhcpDns: vi.fn(() => Promise.resolve(state.setResult)),
+  reconnectFritzBox: vi.fn(() => Promise.resolve(state.reconnectResult)),
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve({
+    reverseProxy: { lanIp: '192.168.1.10' },
+    gateway: { type: 'fritzbox', host: '192.168.1.1', username: 'admin', password: 'secret' },
+  })),
+  updateConfig: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { dispatchProbeAction } from '../actions';
+import './routerDnsNotPointing';
+
+beforeEach(() => {
+  state.setResult = { result: 'ok' };
+  state.reconnectResult = { result: 'ok' };
+});
+
+describe('router_dns_not_pointing.reconnect_fritzbox', () => {
+  it('returns ok with reconnect-window guidance on success', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'reconnect_fritzbox',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/reconnecting/);
+    expect(result.refresh).toBe(true);
+  });
+
+  it('surfaces the helper detail when reconnect fails', async () => {
+    state.reconnectResult = { result: 'failed', detail: 'TR-064 disabled' };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'reconnect_fritzbox',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('TR-064 disabled');
+  });
+
+  it('returns a credential-specific message when the box rejects auth', async () => {
+    state.reconnectResult = { result: 'no_credentials', detail: 'FritzBox rejected the TR-064 credentials.' };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'reconnect_fritzbox',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('rejected the TR-064 credentials');
+  });
+
+  it('falls back to a generic message when the helper returns no detail', async () => {
+    state.reconnectResult = { result: 'failed' };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'reconnect_fritzbox',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    // Generic fallback should mention "Neu verbinden" so the user knows the
+    // manual workaround.
+    expect(result.message).toMatch(/Neu verbinden/);
+  });
+});

--- a/src/lib/diagnose/probes/routerDnsNotPointing.ts
+++ b/src/lib/diagnose/probes/routerDnsNotPointing.ts
@@ -30,7 +30,7 @@
 
 import { getConfig, updateConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
-import { setFritzBoxDhcpDns } from '@/lib/router/dnsConfig';
+import { reconnectFritzBox, setFritzBoxDhcpDns } from '@/lib/router/dnsConfig';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
 
 const PROBE_ID = 'router_dns_not_pointing';
@@ -211,6 +211,33 @@ async function configureFritzbox(): Promise<ProbeActionResult> {
   };
 }
 
+/** Action handler for `reconnect_fritzbox`. Issues a TR-064
+ *  ForceTermination so the FritzBox drops + re-establishes its WAN
+ *  link. Used after `configure_fritzbox` to push the new DHCP-DNS
+ *  setting through more aggressively than waiting for lease renewal —
+ *  the FritzBox's own DNS resolver re-reads config on reconnect, and
+ *  devices that auto-renew on link-state changes pick up option 6
+ *  immediately. Marked destructive because the WAN goes down for
+ *  5–30 s and DSL users typically get a fresh public IP. */
+async function reconnectFritzboxAction(): Promise<ProbeActionResult> {
+  const result = await reconnectFritzBox();
+  if (result.result === 'ok') {
+    return {
+      ok: true,
+      message:
+        '✅ FritzBox is reconnecting (typically 5–30 s). DSL users will get a fresh public IP; the dynamic-DNS poller will catch up on its next tick.',
+      refresh: true,
+    };
+  }
+  return {
+    ok: false,
+    message:
+      result.detail ??
+      'FritzBox reconnect failed — check Settings → Gateway, or trigger "Neu verbinden" in the FritzBox UI under Internet → Online-Monitor.',
+    refresh: false,
+  };
+}
+
 async function dismissProbe(): Promise<ProbeActionResult> {
   const config = await getConfig();
   await updateConfig({
@@ -247,6 +274,18 @@ registerProbeAction(
 registerProbeAction(
   PROBE_ID,
   {
+    id: 'reconnect_fritzbox',
+    label: 'Reconnect FritzBox',
+    description:
+      'Forces the FritzBox to drop and re-establish its WAN connection via TR-064 ForceTermination. Useful right after "Configure on FritzBox" so the new DHCP DNS setting takes effect without waiting for client lease renewals. Causes a brief (5–30 s) internet outage; DSL users typically get a fresh public IP.',
+    destructive: true,
+  },
+  reconnectFritzboxAction,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
     id: 'verify_from_device',
     label: 'Verify from this device',
     description:
@@ -273,4 +312,7 @@ registerProbeAction(
   dismissProbe,
 );
 
-logger.debug('diagnose:probes', `Registered ${PROBE_ID} actions: configure_fritzbox, verify_from_device, dismiss`);
+logger.debug(
+  'diagnose:probes',
+  `Registered ${PROBE_ID} actions: configure_fritzbox, reconnect_fritzbox, verify_from_device, dismiss`,
+);

--- a/src/lib/router/dnsConfig.ts
+++ b/src/lib/router/dnsConfig.ts
@@ -8,8 +8,18 @@
  */
 
 import { FritzBoxClient } from '@/lib/fritzbox/client';
+import { fetchWithDigest } from '@/lib/fritzbox/digest';
 import { getConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
+
+/** Outcome of a TR-064 call — shared by every router helper here so
+ *  the probe-action layer can show the same status pill regardless of
+ *  which call ran. `no_gateway` and `no_credentials` are user-fixable
+ *  config gaps (Settings → Gateway); `failed` is everything else. */
+export type RouterCallResult = {
+  result: 'ok' | 'no_gateway' | 'no_credentials' | 'failed';
+  detail?: string;
+};
 
 /**
  * Tell the FritzBox to hand out `targetIp` as the DHCP DNS server
@@ -20,10 +30,7 @@ import { logger } from '@/lib/logger';
  * Uses the same TR-064 plumbing the gateway-status poll already does;
  * credentials come from `config.gateway.{host,username,password}`.
  */
-export async function setFritzBoxDhcpDns(targetIp: string): Promise<{
-  result: 'ok' | 'no_gateway' | 'no_credentials' | 'failed';
-  detail?: string;
-}> {
+export async function setFritzBoxDhcpDns(targetIp: string): Promise<RouterCallResult> {
   const config = await getConfig();
   const gateway = config.gateway;
   if (!gateway || gateway.type !== 'fritzbox') {
@@ -93,4 +100,99 @@ export async function setFritzBoxDhcpDns(targetIp: string): Promise<{
       detail: e instanceof Error ? e.message : String(e),
     };
   }
+}
+
+/**
+ * Force the FritzBox to drop its WAN connection and reconnect. The box
+ * does this automatically within ~5–30s; on DSL/cable installs the
+ * external IP usually changes, on FTTH/static-IP installs it doesn't.
+ *
+ * Why this matters: after `setFritzBoxDhcpDns` flips DHCP option 6 to
+ * point at AdGuard, devices on existing leases keep their old DNS
+ * until the lease renews — often hours on the FritzBox default of 24h.
+ * A WAN reconnect doesn't directly refresh those leases, but on the
+ * FritzBox it ALSO causes the box to re-publish its own DHCP server
+ * state, which surfaces the new option-6 value to devices that poll
+ * (mDNS-style discovery, "Renew" buttons, etc.) and forces the box's
+ * own DNS resolver to re-read its configuration. In practice this is
+ * the single quickest way to make new DNS settings take effect across
+ * the LAN without rebooting client devices.
+ *
+ * Tries `WANIPConnection:1` first, falls back to `WANPPPConnection:1`
+ * (DSL/PPPoE installs); whichever one the box exposes will accept the
+ * `ForceTermination` action and return 200 with an empty body.
+ *
+ * Mirrors `setFritzBoxDhcpDns`'s credential resolution + result shape
+ * so the calling probe-action handler doesn't need to know which
+ * helper it invoked.
+ */
+export async function reconnectFritzBox(): Promise<RouterCallResult> {
+  const config = await getConfig();
+  const gateway = config.gateway;
+  if (!gateway || gateway.type !== 'fritzbox') {
+    return { result: 'no_gateway', detail: 'Gateway not configured as FritzBox in Settings → Gateway.' };
+  }
+  if (!gateway.username || !gateway.password) {
+    return {
+      result: 'no_credentials',
+      detail: 'TR-064 needs FritzBox username + password (Settings → Gateway). Without them, click "Reconnect" in the FritzBox UI manually.',
+    };
+  }
+
+  const port = gateway.ssl ? 49443 : 49000;
+  const scheme = gateway.ssl ? 'https' : 'http';
+  // ForceTermination lives on whichever WAN-connection service the box
+  // actually publishes. The fixed paths below match every FritzBox
+  // firmware in the wild — the service-discovery dance in
+  // `FritzBoxClient.detectServiceType` is overkill for this one-shot
+  // call. We just try IP first, PPP as fallback.
+  const attempts: Array<{ serviceType: string; controlUrl: string }> = [
+    { serviceType: 'urn:dslforum-org:service:WANIPConnection:1', controlUrl: '/upnp/control/wanipconnection1' },
+    { serviceType: 'urn:dslforum-org:service:WANPPPConnection:1', controlUrl: '/upnp/control/wanpppconn1' },
+  ];
+  const errors: string[] = [];
+  for (const attempt of attempts) {
+    try {
+      const url = `${scheme}://${gateway.host}:${port}${attempt.controlUrl}`;
+      const body = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:ForceTermination xmlns:u="${attempt.serviceType}"/>
+</s:Body>
+</s:Envelope>`;
+      const res = await fetchWithDigest(
+        url,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'text/xml; charset=utf-8',
+            'SoapAction': `${attempt.serviceType}#ForceTermination`,
+          },
+          body,
+          signal: AbortSignal.timeout(8_000),
+        },
+        { username: gateway.username, password: gateway.password },
+      );
+      if (res.ok) {
+        logger.info('router:dnsConfig', `FritzBox ForceTermination accepted via ${attempt.serviceType}`);
+        return { result: 'ok' };
+      }
+      const text = await res.text().catch(() => '');
+      // 401 = bad credentials — same for both services, no point retrying.
+      if (res.status === 401) {
+        return {
+          result: 'no_credentials',
+          detail: 'FritzBox rejected the TR-064 credentials. Re-check Settings → Gateway.',
+        };
+      }
+      errors.push(`${attempt.serviceType}: HTTP ${res.status} ${text.slice(0, 120)}`);
+    } catch (e) {
+      errors.push(`${attempt.serviceType}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  logger.warn('router:dnsConfig', `FritzBox reconnect failed: ${errors.join(' | ')}`);
+  return {
+    result: 'failed',
+    detail: `FritzBox declined ForceTermination on both WAN services. Likely TR-064 is disabled (Settings → Home Network → FRITZ!Box Network → activate UPnP).`,
+  };
 }


### PR DESCRIPTION
## Summary
- Adds a `reconnect_fritzbox` action on the `router_dns_not_pointing` probe — calls TR-064 `ForceTermination` on the FritzBox's WAN connection. The right "after I just configured DHCP DNS, push it through *now*" button, instead of waiting hours for client lease renewals.
- Extracts a shared `<DiagnoseProbeList>` component so the **OnboardingWizard's post-install diagnose panel renders the same fix-buttons** as `Settings → Self-Test`. Users can hit "Configure on FritzBox" → "Reconnect FritzBox" right from the install summary instead of having to navigate to Settings.

## Why
User-reported (German): on a fresh install, AdGuard is configured but FritzBox still hands out the default upstream DNS until the user clicks "Neu verbinden" in the FritzBox UI. Wanted that one-click fix surfaced from the diagnose page, ideally during install-time diagnose.

## Surface area
| Area | Change |
|---|---|
| `lib/router/dnsConfig.ts` | New `reconnectFritzBox()` helper. Tries WANIPConnection then WANPPPConnection (covers DSL/PPPoE). Shares `RouterCallResult` shape with `setFritzBoxDhcpDns`. |
| `lib/diagnose/probes/routerDnsNotPointing.ts` | Registers `reconnect_fritzbox` action. `destructive: true` (brief WAN outage; DSL users may get a new public IP). |
| `components/DiagnoseProbeList.tsx` | **New.** Pure-rendering probe list — action dispatch, inline forms, per-item rows. Used by both wizard + settings. Compact mode hides `ok` rows. |
| `app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx` | Shrinks to its outer chrome; delegates rendering to the shared component. Behavior unchanged. |
| `components/OnboardingWizard.tsx` | Captures `node` from the diagnose response, replaces the inline warn/fail `<ul>` with `<DiagnoseProbeList compact />`. |

## Test plan
- [x] `npx vitest run src/lib/diagnose/` — 87 tests pass (4 new for `reconnect_fritzbox` covering ok / failed / no_credentials / fallback-message paths).
- [x] Lint clean.
- [x] tsc clean on changed files.
- [x] Pre-push test suite passes.
- [ ] After release: in settings → run self-test → click "Reconnect FritzBox", confirm WAN drops then reconnects (~10–30s).
- [ ] After release: trigger install on a fresh setup, hit the post-install summary, expand "Details + fix-buttons", confirm action buttons render and dispatch correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)