### PR TITLE
fix(diagnose): read AdGuard creds from config.adguard, not stale templateSettings

### DIFF
--- a/src/lib/diagnose/probes/routerDnsNotPointing.ts
+++ b/src/lib/diagnose/probes/routerDnsNotPointing.ts
@@ -50,9 +50,9 @@ interface AdguardQueryLogEntry {
 }
 
 /** Read AdGuard's recent query log for non-localhost clients. */
-async function adguardSeesLanClients(adminUrl: string, password: string): Promise<boolean> {
+async function adguardSeesLanClients(adminUrl: string, username: string, password: string): Promise<boolean> {
   try {
-    const auth = `Basic ${Buffer.from(`admin:${password}`).toString('base64')}`;
+    const auth = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
     const cutoff = Date.now() - QUERYLOG_RECENT_MIN * 60 * 1000;
     const res = await fetch(`${adminUrl.replace(/\/$/, '')}/control/querylog?limit=200`, {
       headers: { Authorization: auth },
@@ -106,13 +106,34 @@ async function fritzBoxDhcpDns(host: string, username: string, password: string)
   }
 }
 
-/** Resolve AdGuard's admin URL + password from config + templateSettings. */
-async function adguardCreds(): Promise<{ url: string; password: string } | null> {
+/** Resolve AdGuard's admin URL + credentials.
+ *
+ *  Prefers the dedicated `config.adguard` block written by AdGuard's
+ *  post-deploy (via `/api/system/adguard/credentials`) — this is where
+ *  current installs store creds. Falls back to the legacy
+ *  `templateSettings.ADGUARD_ADMIN_PASSWORD` for installs that predate
+ *  the credentials endpoint. Mirrors `findAdguardCreds()` in the portal
+ *  provisioner so the probe sees the same creds the provisioner uses
+ *  to write rewrites; previously this probe only read the legacy path,
+ *  which left freshly-installed boxes (no `templateSettings` password)
+ *  reporting "AdGuard credentials not configured" even though
+ *  `config.adguard.password` was set, suppressing the query-log signal. */
+async function adguardCreds(): Promise<{ url: string; username: string; password: string } | null> {
   const config = await getConfig();
+  const direct = config.adguard;
+  if (direct?.password) {
+    return {
+      url:
+        direct.adminUrl ||
+        `http://localhost:${config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083'}`,
+      username: direct.username || 'admin',
+      password: direct.password,
+    };
+  }
   const password = config.templateSettings?.ADGUARD_ADMIN_PASSWORD;
   const port = config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083';
   if (!password) return null;
-  return { url: `http://localhost:${port}`, password };
+  return { url: `http://localhost:${port}`, username: 'admin', password };
 }
 
 /** Top-level probe entry — returns the partial probe payload. */
@@ -145,7 +166,7 @@ export async function checkRouterDnsNotPointing(): Promise<RouterDnsProbeResult>
   const adguard = await adguardCreds();
   let adguardOk = false;
   if (adguard) {
-    adguardOk = await adguardSeesLanClients(adguard.url, adguard.password);
+    adguardOk = await adguardSeesLanClients(adguard.url, adguard.username, adguard.password);
   }
 
   // Signal B — FritzBox DHCP option-6 (only when gateway is fritzbox).


### PR DESCRIPTION
## Summary
- `router_dns_not_pointing` looked up AdGuard credentials at the legacy `templateSettings.ADGUARD_ADMIN_PASSWORD` path only. Current installs write to `config.adguard.{adminUrl, username, password}` via the post-deploy → `/api/system/adguard/credentials` flow, so the legacy key is unset on fresh boxes.
- Result: probe printed \"AdGuard credentials not configured; query-log signal unavailable\" even when AdGuard was reachable and seeing queries — suppressing the very signal that would have flipped the probe to \`ok\` when AdGuard is being used (incl. via FritzBox upstream-DNS forwarding).
- Mirrors `findAdguardCreds()` in `lib/portal/provisioner.ts` (already dual-path) so probe + provisioner agree on what counts as \"configured\".

## Why
User report (in production install):

> ⚠️ Router DNS routing — FritzBox is reachable but DHCP DNS is not pointed at ServiceBay. **AdGuard credentials not configured; query-log signal unavailable.**
>
> aber FritzBox … Genutzte DNS-Server **192.168.178.100** (aktuell genutzt für Standardanfragen)

FritzBox UI confirmed AdGuard was the upstream resolver — but the probe's query-log fallback never ran because of the stale lookup. Once this lands, on installs where FritzBox forwards queries to AdGuard the probe will see those queries (the FritzBox IP is a non-localhost client) and flip to `ok` without the user needing to touch DHCP option 6.

## Test plan
- [x] `npx vitest run src/lib/diagnose/` — 83 tests pass.
- [x] Lint + tsc clean on changed file.
- [x] Pre-push test suite passes.
- [ ] After release: re-run diagnose on the affected install. Expect `router_dns_not_pointing` to transition from warn → ok (FritzBox is forwarding queries to AdGuard, so the query-log signal fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)