### PR TITLE
fix(adguard): use GET for /control/rewrite/list, not POST

### DIFF
--- a/src/lib/adguard/rewrites.test.ts
+++ b/src/lib/adguard/rewrites.test.ts
@@ -6,11 +6,12 @@ import {
   listRewrites,
 } from './rewrites';
 
-function mockFetch(handler: (path: string, body: unknown) => { ok: boolean; body?: unknown }) {
+function mockFetch(handler: (path: string, body: unknown, method: string) => { ok: boolean; body?: unknown }) {
   return vi.fn(async (url: string, init: RequestInit) => {
     const path = new URL(url).pathname;
     const body = init.body ? JSON.parse(init.body as string) : undefined;
-    const result = handler(path, body);
+    const method = init.method ?? 'GET';
+    const result = handler(path, body, method);
     return {
       ok: result.ok,
       json: async () => result.body ?? {},
@@ -43,6 +44,16 @@ describe('listRewrites', () => {
     }));
     const rewrites = await listRewrites(opts(fetchImpl as unknown as typeof fetch));
     expect(rewrites).toEqual([{ domain: '*.home.arpa', answer: '10.0.0.5' }]);
+  });
+
+  it('uses GET for the list endpoint (AdGuard rejects POST with 405)', async () => {
+    const seen: { method: string; path: string }[] = [];
+    const fetchImpl = mockFetch((path, _body, method) => {
+      seen.push({ method, path });
+      return { ok: true, body: [] };
+    });
+    await listRewrites(opts(fetchImpl as unknown as typeof fetch));
+    expect(seen).toEqual([{ method: 'GET', path: '/control/rewrite/list' }]);
   });
 
   it('returns empty array on non-OK response', async () => {

--- a/src/lib/adguard/rewrites.ts
+++ b/src/lib/adguard/rewrites.ts
@@ -38,23 +38,31 @@ function authHeader(opts: ClientOpts): string | undefined {
   return `Basic ${token}`;
 }
 
-async function request(opts: ClientOpts, path: string, body?: unknown): Promise<Response> {
+async function request(opts: ClientOpts, path: string, body?: unknown, method: 'GET' | 'POST' = 'POST'): Promise<Response> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const auth = authHeader(opts);
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const headers: Record<string, string> = {};
+  if (method === 'POST') headers['Content-Type'] = 'application/json';
   if (auth) headers['Authorization'] = auth;
   return fetchImpl(`${opts.adminUrl.replace(/\/$/, '')}${path}`, {
-    method: 'POST',
+    method,
     headers,
-    body: body !== undefined ? JSON.stringify(body) : '{}',
+    body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined,
   });
 }
 
 /** Read all current rewrites from AdGuard. Returns empty array if the
- *  call fails (e.g. AdGuard down). */
+ *  call fails (e.g. AdGuard down).
+ *
+ *  AdGuard's API: `GET /control/rewrite/list`. The mutating endpoints
+ *  (add/update/delete) are POST. This function used to POST `list` too,
+ *  which AdGuard treats as 405 — silently returning empty here.
+ *  ensureWildcardRewrite still "worked" because it falls through to ADD
+ *  when the list returns empty, but the diagnose probe (which trusts
+ *  the list as ground truth) reported every entry as missing. */
 export async function listRewrites(opts: ClientOpts): Promise<AdguardRewrite[]> {
   try {
-    const res = await request(opts, REWRITES_LIST);
+    const res = await request(opts, REWRITES_LIST, undefined, 'GET');
     if (!res.ok) return [];
     const data = (await res.json()) as AdguardRewrite[];
     return Array.isArray(data) ? data : [];


### PR DESCRIPTION
## Summary
- AdGuard's REST API: `/control/rewrite/list` is GET; `add`/`update`/`delete` are POST. Our `request()` helper always used POST → `listRewrites` silently returned `[]` (AdGuard responds non-2xx to POST against the GET endpoint, and `listRewrites` swallows `!res.ok`).
- The bug stayed hidden because every existing caller is `ensureWildcardRewrite`, which falls through to ADD when the list returns empty. AdGuard ended up with the right rewrites, the list just lied. Then the new \`adguard_rewrites_missing\` probe (#379) started trusting the list as ground truth → false \"6 missing\" warnings on installs that actually had every entry.
- Extends `request()` with a `method` param (defaults POST so write endpoints stay unchanged) and switches list to GET. Adds a regression test asserting the method.

## Repro (user-reported)
After install, click Reprovision → all 6 added → `home.arpa`, `www.home.arpa`, `*.home.arpa`, `dopp.cloud`, `www.dopp.cloud`, `*.dopp.cloud` visible in AdGuard UI. Re-run diagnose → still reports \"6 missing\".

## Test plan
- [x] `npx vitest run src/lib/adguard/ src/lib/diagnose/` — 95 tests pass (existing 88 + new regression test asserting GET method).
- [x] Lint + tsc clean on changed files.
- [x] Pre-push test suite passes.
- [ ] After release: re-run diagnose on the affected install — \`adguard_rewrites_missing\` should transition from warn → ok without any user action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)