### PR TITLE
feat(install): explicit portal-routing provision with retries

### DIFF
--- a/src/lib/stackInstall/portalProvision.test.ts
+++ b/src/lib/stackInstall/portalProvision.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const originalSetTimeout = globalThis.setTimeout;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  // Patch setTimeout to a no-op resolver so retries don't burn real wall-clock.
+  globalThis.setTimeout = ((fn: () => void) => {
+    fn();
+    return 0;
+  }) as unknown as typeof setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+// useStackInstall imports a lot of React/Next plumbing — we only want the
+// pure helper. Pull it in *after* fetch is stubbed.
+import { provisionPortalWithRetries } from './useStackInstall';
+
+function mockJsonResponse(ok: boolean, body: unknown, status = ok ? 200 : 400): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('provisionPortalWithRetries', () => {
+  it('returns true and logs the detail on first-attempt success', async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(true, { ok: true, detail: 'proxy:unchanged rewrites=*.dopp.cloud:added' }));
+    const logs: string[] = [];
+    const ok = await provisionPortalWithRetries(m => logs.push(m));
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(logs.some(l => l.startsWith('✅'))).toBe(true);
+    expect(logs[0]).toContain('proxy:unchanged');
+  });
+
+  it('retries when the endpoint reports ok=false, succeeds on a later attempt', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockJsonResponse(false, { ok: false, detail: 'rewrites=*.dopp.cloud:failed' }, 400))
+      .mockResolvedValueOnce(mockJsonResponse(false, { ok: false, detail: 'rewrites=*.dopp.cloud:failed' }, 400))
+      .mockResolvedValueOnce(mockJsonResponse(true, { ok: true, detail: 'rewrites=*.dopp.cloud:added' }));
+    const logs: string[] = [];
+    const ok = await provisionPortalWithRetries(m => logs.push(m));
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(logs.filter(l => l.startsWith('⏳'))).toHaveLength(2);
+    expect(logs.find(l => l.startsWith('✅'))).toBeTruthy();
+  });
+
+  it('returns false after exhausting all attempts and emits a fallback hint', async () => {
+    mockFetch.mockResolvedValue(mockJsonResponse(false, { ok: false, detail: 'rewrites=*.dopp.cloud:failed' }, 400));
+    const logs: string[] = [];
+    const ok = await provisionPortalWithRetries(m => logs.push(m));
+    expect(ok).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(logs[logs.length - 1]).toMatch(/Reprovision/);
+  });
+
+  it('treats network exceptions as a failed attempt and retries', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce(mockJsonResponse(true, { ok: true, detail: 'rewrites=*.dopp.cloud:added' }));
+    const logs: string[] = [];
+    const ok = await provisionPortalWithRetries(m => logs.push(m));
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(logs.find(l => l.includes('ECONNREFUSED'))).toBeTruthy();
+  });
+
+  it('treats invalid JSON as a failed attempt without throwing', async () => {
+    const badRes = {
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not JSON')),
+    } as unknown as Response;
+    mockFetch.mockResolvedValue(badRes);
+    const logs: string[] = [];
+    const ok = await provisionPortalWithRetries(m => logs.push(m));
+    expect(ok).toBe(false);
+    expect(logs.some(l => l.includes('HTTP 500'))).toBe(true);
+  });
+});

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -225,6 +225,59 @@ async function resolveConfigFilePaths(yaml: string, cfgFiles: ConfigFile[]): Pro
 const MAX_DEPLOY_ATTEMPTS = 3;
 const DEPLOY_BACKOFF_MS = [0, 1000, 4000];
 
+const PORTAL_PROVISION_ATTEMPTS = 4;
+/** Backoff between portal-provision attempts (ms). Total wall-clock cost if
+ *  every attempt fails: ~18s. Hits the cold-start window for AdGuard's
+ *  `/control/rewrite/*` endpoints, which can lag `/control/status` by a few
+ *  seconds on first boot. */
+const PORTAL_PROVISION_BACKOFF_MS = [0, 3000, 6000, 9000];
+
+/**
+ * Drive `/api/system/portal/provision` with retries, narrating progress to the
+ * wizard log. The endpoint already calls `provisionPortalRouting()` which is
+ * idempotent — we just give it more chances than the implicit fire-and-forget
+ * triggers (AdGuard's post-deploy hook + the 60s-post-boot timer in server.ts).
+ *
+ * Why this exists: on a fresh install, AdGuard's post-deploy POSTs credentials
+ * the moment the container reports healthy, which then fires
+ * `provisionPortalRouting()` in the background. That one shot can land while
+ * AdGuard's REST API is still finishing its own bootstrap — the call returns
+ * non-2xx, the provisioner records "failed", and nothing retries until the
+ * operator notices missing rewrites and clicks Reprovision in diagnose. By
+ * the time the install loop reaches this helper, every other service is
+ * deployed and AdGuard has had time to warm up; a short retry loop here turns
+ * the lossy fire-and-forget into a guaranteed-present rewrite list.
+ *
+ * Returns true if the endpoint reported `ok` on any attempt; false if every
+ * attempt failed (the caller logs a fallback suggestion in that case).
+ */
+export async function provisionPortalWithRetries(onLog: (msg: string) => void): Promise<boolean> {
+  for (let attempt = 1; attempt <= PORTAL_PROVISION_ATTEMPTS; attempt++) {
+    if (attempt > 1) {
+      await new Promise(r => setTimeout(r, PORTAL_PROVISION_BACKOFF_MS[attempt - 1]));
+    }
+    try {
+      const res = await fetch('/api/system/portal/provision', { method: 'POST' });
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; detail?: string }
+        | null;
+      if (data?.ok) {
+        onLog(`✅ Portal routing: ${data.detail ?? 'provisioned'}`);
+        return true;
+      }
+      const reason = data?.detail ?? `HTTP ${res.status}`;
+      const tag = attempt < PORTAL_PROVISION_ATTEMPTS ? '⏳' : '⚠️';
+      onLog(`${tag} Portal routing attempt ${attempt}/${PORTAL_PROVISION_ATTEMPTS}: ${reason}`);
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      const tag = attempt < PORTAL_PROVISION_ATTEMPTS ? '⏳' : '⚠️';
+      onLog(`${tag} Portal routing attempt ${attempt}/${PORTAL_PROVISION_ATTEMPTS}: ${reason}`);
+    }
+  }
+  onLog('⚠️ Portal routing did not fully provision after retries. Open Settings → Self-Diagnose → Reprovision if rewrites are missing.');
+  return false;
+}
+
 export function useStackInstall(options: UseStackInstallOptions): UseStackInstallReturn {
   const { templateSource, onBeforeDone } = options;
 
@@ -786,6 +839,16 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       return;
     }
 
+    // Explicit portal-routing provisioner. AdGuard's post-deploy fires this
+    // implicitly via fire-and-forget when credentials are saved, but that one
+    // shot frequently lands during AdGuard's REST-API cold start and is lost.
+    // Gating on `adguard` in `deployed` keeps this a no-op for installs that
+    // didn't include AdGuard. See `provisionPortalWithRetries` for the why.
+    if (deployed.some(d => d.name === 'adguard')) {
+      appendLog('Provisioning AdGuard DNS rewrites + portal routing...');
+      await provisionPortalWithRetries(appendLog);
+    }
+
     if (onBeforeDone) {
       try {
         await onBeforeDone(deployed, appendLog);
@@ -819,11 +882,20 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       });
       appendLog('Saved NPM credentials for future installs.');
     } catch { /* install succeeded — just won't auto-sync next time */ }
+
+    // Mirror the runInstall path's explicit portal-routing provision so the
+    // NPM-credentials-prompt branch ends in the same state as the happy path.
+    const checked = items.filter(i => i.checked);
+    if (checked.some(i => i.name === 'adguard')) {
+      appendLog('Provisioning AdGuard DNS rewrites + portal routing...');
+      await provisionPortalWithRetries(appendLog);
+    }
+
     if (onBeforeDone) {
       try {
         // No `deployed` snapshot available here; pass the checked items as
         // a best-effort substitute. Settle-wait only uses names anyway.
-        await onBeforeDone(items.filter(i => i.checked).map(i => ({ name: i.name })), appendLog);
+        await onBeforeDone(checked.map(i => ({ name: i.name })), appendLog);
       } catch { /* swallow */ }
     }
     setPhase('done');


### PR DESCRIPTION
## Summary
- Adds a blocking `/api/system/portal/provision` call to the install loop in `useStackInstall`, with up to 4 retries (3/6/9 s backoff), gated on AdGuard being in the deployed set.
- Replaces the previous reliance on AdGuard post-deploy's fire-and-forget hook, which lands in AdGuard's REST-API cold-start window and is lost when the call fails. Manual Reprovision worked, auto didn't — same code path, just better timing.
- Wired into both completion paths — the happy `runInstall` finish *and* the `retryNpmCredentials` recovery branch — so an NPM-cred prompt in the middle of the install can't bypass it.

## Why
User report: every fresh install ends with AdGuard rewrites missing. The diagnose panel surfaces it (after #379), and Reprovision always works — but the install itself should leave the system in a complete state.

Trace: AdGuard's post-deploy POSTs creds to `/api/system/adguard/credentials` the moment the container reports healthy. The route's `void async` block calls `provisionPortalRouting()` immediately, while AdGuard's `/control/rewrite/*` endpoints are still finishing their bootstrap. One shot, failure swallowed. The server.ts 60s-post-boot retry doesn't help on fresh installs because AdGuard typically installs minutes later.

This change moves the responsibility to where the wait-for-AdGuard timing is right: after the install loop. The retries cover the small cold-start window without burning much wall-clock (~18 s worst case).

## Test plan
- [x] `npx vitest run src/lib/stackInstall/` — 14 tests pass (9 existing + 5 new for `provisionPortalWithRetries`: first-shot success, retry-then-success, exhausted, network-exception, invalid-JSON).
- [x] Lint clean.
- [x] Pre-push test suite passes.
- [ ] After release: trigger a fresh install with AdGuard selected → confirm install log shows `Provisioning AdGuard DNS rewrites + portal routing…` followed by `✅ Portal routing: …added,…added,…`. AdGuard UI should already have all 6 rewrites without manual Reprovision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)