### PR TITLE
fix(nginx): drop letsencrypt_{email,agree} from cert-create meta

### DIFF
--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -227,6 +227,18 @@ async function requestPublicCert(
 ): Promise<{ ok: true; certId: number } | { ok: false; reason: string }> {
     // 1) Create the LE cert in NPM. NPM blocks until the ACME exchange
     //    completes (success or failure), so the timeout here is generous.
+    //
+    // Schema note: recent NPM (master) tightened the certificate `meta`
+    // schema with `additionalProperties: false` and dropped both
+    // `letsencrypt_email` and `letsencrypt_agree`. The ACME email now
+    // comes from the owner user's account (NPM reads `user.email` on
+    // the authenticated principal), which our bootstrap step already
+    // sets via PUT /api/users/1. Sending the legacy fields makes NPM
+    // 400 with "data/meta must NOT have additional properties". The
+    // `leEmail` param stays only as a precondition gate — callers skip
+    // cert issuance when it isn't set, because "no admin email" means
+    // NPM can't register with Let's Encrypt regardless of payload.
+    void leEmail;
     let certId: number;
     try {
         const res = await fetch(`${baseUrl}/api/nginx/certificates`, {
@@ -238,11 +250,7 @@ async function requestPublicCert(
             body: JSON.stringify({
                 provider: 'letsencrypt',
                 domain_names: [domain],
-                meta: {
-                    letsencrypt_email: leEmail,
-                    letsencrypt_agree: true,
-                    dns_challenge: false,
-                },
+                meta: { dns_challenge: false },
             }),
             signal: AbortSignal.timeout(120_000),
         });
@@ -274,7 +282,6 @@ async function requestPublicCert(
                 ssl_forced: true,
                 http2_support: true,
                 hsts_enabled: false,
-                meta: { letsencrypt_agree: true, dns_challenge: false },
             }),
             signal: AbortSignal.timeout(10_000),
         });


### PR DESCRIPTION
## Summary
Recent NPM tightened the `/api/nginx/certificates` POST schema — `meta` now has `additionalProperties: false` and the allowed set is `dns_challenge | dns_provider | dns_provider_credentials | key_type | propagation_seconds | certificate | certificate_key | letsencrypt_certificate`. The legacy `letsencrypt_email` and `letsencrypt_agree` fields are gone.

NPM now derives the ACME registration email from the owning user account (reads `user.email` on the authenticated principal). Our `/api/system/nginx/bootstrap` already PUTs that during install, so no other plumbing changes.

## Symptom (user-reported on fresh install)
```
⚠️ Cert request for auth.dopp.cloud failed — NPM /api/nginx/certificates returned HTTP 400:
{\"error\":{\"code\":400,\"message\":\"data/meta must NOT have additional properties, data/meta must NOT have additional properties\"},…}
```
(Two \"additional properties\" errors → both `letsencrypt_email` and `letsencrypt_agree` rejected.)

## Changes
- `src/app/api/system/nginx/proxy-hosts/route.ts` — POST cert: `meta` is now `{ dns_challenge: false }`. PUT proxy-host (cert binding): drops `meta` entirely (proxy-host's meta documents only `nginx_online` / `nginx_err`; our `letsencrypt_agree` was always silently ignored noise).
- `leEmail` parameter on `requestPublicCert` stays as a precondition gate — callers skip issuance when the operator hasn't filled in `reverseProxy.npm.email`.

## Test plan
- [x] Lint + tsc clean on changed file.
- [x] Pre-push test suite passes.
- [ ] After release: trigger a fresh install with a public domain configured → confirm install log shows `Issued + bound LE cert N for <subdomain>` instead of the HTTP 400 from NPM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)