### PR TITLE
feat(ui): detect server restart + setup-revert, prompt reload

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -459,6 +459,26 @@ app.prepare().then(() => {
     updateMonitoringState();
     socket.emit('twin:state', twinStore.getSnapshot());
 
+    // Server identity — emitted once per (re)connect so the client can detect
+    // server restarts and `setupCompleted` flips while the page is open.
+    // `sessionId` is regenerated on every process start, so a delta on this
+    // field across a socket reconnect means the server actually restarted
+    // (vs. a transient network blip, which keeps the same id). The
+    // `<ServerIdentityWatcher>` client component diff-checks the value and
+    // either reloads silently (setup wizard appeared) or shows a 10s-grace
+    // "Server restarted — reloading…" banner.
+    void (async () => {
+      try {
+        const config = await getConfig();
+        socket.emit('server:identity', {
+          sessionId,
+          setupCompleted: Boolean(config.setupCompleted),
+        });
+      } catch (e) {
+        logger.warn('Server', `Could not emit server:identity: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })();
+
     socket.on('logs:subscribe', () => { socket.join('logs:live'); });
     socket.on('logs:unsubscribe', () => { socket.leave('logs:live'); });
     socket.on('disconnect', () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ToastProvider } from "@/providers/ToastProvider";
 import { DigitalTwinProvider } from "@/providers/DigitalTwinProvider";
+import ServerIdentityWatcher from "@/components/ServerIdentityWatcher";
 import { getConfig } from "@/lib/config";
 import { DigitalTwinStore } from "@/lib/store/twin";
 
@@ -71,6 +72,7 @@ export default function RootLayout({
       >
         <ToastProvider>
           <DigitalTwinProvider>
+            <ServerIdentityWatcher />
             {children}
           </DigitalTwinProvider>
         </ToastProvider>

--- a/src/components/ServerIdentityWatcher.tsx
+++ b/src/components/ServerIdentityWatcher.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+/**
+ * Detects ServiceBay server restarts + `setupCompleted` flips that happen
+ * while the page is open, and prompts the user to reload before the stale
+ * UI gets them stuck.
+ *
+ * Server emits `server:identity` on every socket (re)connect with
+ * `{ sessionId, setupCompleted }`. `sessionId` is regenerated per process
+ * start, so:
+ *   - normal reconnect (network blip)   → same sessionId, no action
+ *   - server restart                    → new sessionId, banner + 10s
+ *                                          auto-reload
+ *   - reinstall (setupCompleted: false) → forced immediate reload, since
+ *                                          the wizard is binding anyway
+ *
+ * Mounted once at the root layout. Renders a small fixed banner at the
+ * top of the viewport when a restart is detected; auto-reloads after
+ * `RELOAD_GRACE_SECONDS`. The user can click "Reload now" to skip the
+ * countdown or "Dismiss" to hide the banner for the current session
+ * (useful if they're mid-form and want to copy something out first —
+ * they still control when to refresh).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { RefreshCcw, X } from 'lucide-react';
+import { useSocket } from '@/hooks/useSocket';
+
+interface ServerIdentity {
+  sessionId: string;
+  setupCompleted: boolean;
+}
+
+const RELOAD_GRACE_SECONDS = 10;
+
+export default function ServerIdentityWatcher() {
+  const { socket } = useSocket();
+  /** First identity received this page-load. Compared against every
+   *  subsequent emit to detect a restart. */
+  const initial = useRef<ServerIdentity | null>(null);
+  /** When non-null, the banner is shown with `remaining` seconds left. */
+  const [reload, setReload] = useState<{ remaining: number } | null>(null);
+  /** True once the user clicks Dismiss; suppresses further detection
+   *  until the page is reloaded. */
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    function onIdentity(data: ServerIdentity) {
+      if (initial.current === null) {
+        initial.current = data;
+        return;
+      }
+      if (dismissed) return;
+
+      const setupReverted = initial.current.setupCompleted && !data.setupCompleted;
+      const restarted = initial.current.sessionId !== data.sessionId;
+
+      if (setupReverted) {
+        // The install wizard is showing again — every API call from this
+        // page will redirect / 401. There's no useful state to preserve;
+        // skip the banner and reload immediately.
+        window.location.reload();
+        return;
+      }
+
+      if (restarted) {
+        setReload({ remaining: RELOAD_GRACE_SECONDS });
+      }
+    }
+    socket.on('server:identity', onIdentity);
+    return () => {
+      socket.off('server:identity', onIdentity);
+    };
+  }, [socket, dismissed]);
+
+  // Countdown + auto-reload at zero.
+  useEffect(() => {
+    if (!reload) return;
+    if (reload.remaining <= 0) {
+      window.location.reload();
+      return;
+    }
+    const t = setTimeout(() => {
+      setReload(r => (r ? { ...r, remaining: r.remaining - 1 } : null));
+    }, 1000);
+    return () => clearTimeout(t);
+  }, [reload]);
+
+  if (!reload) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="fixed top-3 left-1/2 -translate-x-1/2 z-[60] max-w-md px-4 py-2.5 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 shadow-lg flex items-center gap-3"
+    >
+      <RefreshCcw size={16} className="shrink-0 text-amber-700 dark:text-amber-300" />
+      <span className="text-sm text-amber-900 dark:text-amber-100">
+        ServiceBay was restarted. Reloading in {reload.remaining}s…
+      </span>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="text-xs font-medium px-2.5 py-1 rounded bg-amber-600 hover:bg-amber-700 text-white"
+      >
+        Reload now
+      </button>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => {
+          setDismissed(true);
+          setReload(null);
+        }}
+        className="text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `<ServerIdentityWatcher>` mounted at the root layout that subscribes to a new `server:identity` Socket.io event emitted on every (re)connect with `{ sessionId, setupCompleted }`.
- First emit becomes the page-load baseline; subsequent emits are compared:
  - **normal reconnect** (transient blip) → same sessionId, no action
  - **server restart** → new sessionId, banner *\"ServiceBay was restarted — reloading in 10s…\"* with **Reload now** + **Dismiss** buttons
  - **reinstall (setupCompleted true → false)** → silent forced reload; the wizard is binding anyway, no useful state to preserve

## Why
User report: open ServiceBay UI, restart server + reinstall on the host, the page keeps showing stale state until hard reload. Every background API call would 401 or redirect, but the page has no signal to act on.

`sessionId` is regenerated per process start (existing `ensureSessionId()` in `server.ts`), so the delta on reconnect is a reliable restart marker — transient socket drops keep the same id, so no false positives.

## Surface area
| File | Change |
|---|---|
| `server.ts` | `io.on('connection')` now emits `server:identity` alongside the existing `twin:state` |
| `src/components/ServerIdentityWatcher.tsx` | **New.** Client component, ~100 lines, owns banner + countdown + reload |
| `src/app/layout.tsx` | Mounts the watcher inside `<DigitalTwinProvider>` so it shares the singleton socket |

## Test plan
- [x] Lint + tsc clean on changed files.
- [x] Pre-push test suite passes.
- [ ] After release: open ServiceBay → `systemctl --user restart servicebay.service` from host → expect banner within ~1s of the socket reconnect → click Reload, or wait 10s for auto-reload.
- [ ] After release: open ServiceBay → trigger a reinstall (wizard flips `setupCompleted` to false) → expect silent immediate reload to the install wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)