### PR TITLE
feat(install): Abort/Start over + dependency-aware install order

### DIFF
--- a/src/components/StackInstallFlow.tsx
+++ b/src/components/StackInstallFlow.tsx
@@ -24,7 +24,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, RefreshCcw, XCircle } from 'lucide-react';
 import StackVariableField from './StackVariableField';
 import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
 import { buildBitwardenCsv } from '@/lib/stackInstall/credentialsManifest';
@@ -182,7 +182,7 @@ interface ProgressProps extends CommonProps {
 }
 
 export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
-  const { logs, phase, npmCredPrompt, npmCredFallback, retryNpmCredentials, skipNpmCredentials } = controller;
+  const { logs, phase, npmCredPrompt, npmCredFallback, retryNpmCredentials, skipNpmCredentials, abortInstall, reset } = controller;
   const logTailRef = useRef<HTMLDivElement | null>(null);
   const [credEmail, setCredEmail] = useNpmCredFallback(npmCredFallback.email);
   const [credPassword, setCredPassword] = useNpmCredFallback(npmCredFallback.password);
@@ -209,6 +209,43 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
         )}
         <div ref={logTailRef} />
       </div>
+
+      {/* Abort + start-over controls. Visible-only:
+          - `installing`: red Abort button (confirmed). Cancels the
+            in-flight stream and stops the deploy loop.
+          - `error`: amber Start over button. Resets state and returns
+            the wizard to its initial step so the operator can pick
+            their templates again. */}
+      {phase === 'installing' && (
+        <div className="mt-3 flex items-center justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              if (window.confirm('Abort the install? Already-deployed services stay running; in-flight templates may be partially applied.')) {
+                abortInstall();
+              }
+            }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 text-white hover:bg-red-700"
+          >
+            <XCircle size={14} /> Abort install
+          </button>
+        </div>
+      )}
+      {phase === 'error' && (
+        <div className="mt-3 flex items-center justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              if (window.confirm('Start over? This wipes the current install state and returns to the template catalog. Any services already deployed on the host stay running.')) {
+                reset();
+              }
+            }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600 text-white hover:bg-amber-700"
+          >
+            <RefreshCcw size={14} /> Start over
+          </button>
+        </div>
+      )}
 
       {npmCredPrompt && (
         <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
@@ -351,7 +388,7 @@ export default function StackInstallFlow(props: {
       />
     );
   }
-  if (phase === 'installing' || phase === 'done') {
+  if (phase === 'installing' || phase === 'done' || phase === 'error') {
     return (
       <>
         <StackInstallProgress

--- a/src/lib/stackInstall/dependencies.test.ts
+++ b/src/lib/stackInstall/dependencies.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { parseTemplateDependencies, topoSortByDependencies } from './dependencies';
+
+describe('parseTemplateDependencies', () => {
+  it('returns empty array when annotation missing', () => {
+    expect(parseTemplateDependencies('apiVersion: v1\nkind: Pod\n')).toEqual([]);
+  });
+
+  it('parses a comma-separated list', () => {
+    const yaml = `
+metadata:
+  annotations:
+    servicebay.dependencies: "nginx,auth"
+`;
+    expect(parseTemplateDependencies(yaml)).toEqual(['nginx', 'auth']);
+  });
+
+  it('trims whitespace between names', () => {
+    const yaml = `
+metadata:
+  annotations:
+    servicebay.dependencies: "nginx, auth ,  adguard"
+`;
+    expect(parseTemplateDependencies(yaml)).toEqual(['nginx', 'auth', 'adguard']);
+  });
+
+  it('returns empty array for empty/blank annotation value', () => {
+    const yaml1 = `\n    servicebay.dependencies: ""\n`;
+    const yaml2 = `\n    servicebay.dependencies:    \n`;
+    expect(parseTemplateDependencies(yaml1)).toEqual([]);
+    expect(parseTemplateDependencies(yaml2)).toEqual([]);
+  });
+
+  it('accepts a single dep without quotes', () => {
+    const yaml = `\n    servicebay.dependencies: nginx\n`;
+    expect(parseTemplateDependencies(yaml)).toEqual(['nginx']);
+  });
+
+  it('returns empty array on undefined input', () => {
+    expect(parseTemplateDependencies(undefined)).toEqual([]);
+  });
+});
+
+describe('topoSortByDependencies', () => {
+  it('keeps input order when there are no dependencies', () => {
+    const result = topoSortByDependencies([
+      { name: 'nginx', dependencies: [] },
+      { name: 'auth', dependencies: [] },
+      { name: 'adguard', dependencies: [] },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.ordered.map(i => i.name)).toEqual(['nginx', 'auth', 'adguard']);
+  });
+
+  it('moves deps in front of dependents', () => {
+    // input order is "wrong" — dependents listed first
+    const result = topoSortByDependencies([
+      { name: 'vaultwarden', dependencies: ['nginx', 'auth'] },
+      { name: 'media', dependencies: ['nginx', 'auth'] },
+      { name: 'nginx', dependencies: [] },
+      { name: 'auth', dependencies: [] },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const names = result.ordered.map(i => i.name);
+      expect(names.indexOf('nginx')).toBeLessThan(names.indexOf('vaultwarden'));
+      expect(names.indexOf('nginx')).toBeLessThan(names.indexOf('media'));
+      expect(names.indexOf('auth')).toBeLessThan(names.indexOf('vaultwarden'));
+      expect(names.indexOf('auth')).toBeLessThan(names.indexOf('media'));
+    }
+  });
+
+  it('returns missing when a dep is not selected and not already-installed', () => {
+    const result = topoSortByDependencies([
+      { name: 'vaultwarden', dependencies: ['nginx', 'auth'] },
+      { name: 'nginx', dependencies: [] },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'missing') {
+      expect(result.item).toBe('vaultwarden');
+      expect(result.missing).toEqual(['auth']);
+    } else {
+      throw new Error('expected missing failure');
+    }
+  });
+
+  it('treats alreadyInstalled deps as satisfied', () => {
+    const result = topoSortByDependencies(
+      [{ name: 'vaultwarden', dependencies: ['nginx', 'auth'] }],
+      { alreadyInstalled: new Set(['nginx', 'auth']) },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.ordered.map(i => i.name)).toEqual(['vaultwarden']);
+  });
+
+  it('detects cycles', () => {
+    const result = topoSortByDependencies([
+      { name: 'a', dependencies: ['b'] },
+      { name: 'b', dependencies: ['a'] },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'cycle') {
+      expect(result.involved.sort()).toEqual(['a', 'b']);
+    } else {
+      throw new Error('expected cycle failure');
+    }
+  });
+
+  it('is stable across same-depth ties', () => {
+    // adguard and auth both have no deps and don't depend on each other.
+    // Input order is auth-first; output should preserve that.
+    const result = topoSortByDependencies([
+      { name: 'auth', dependencies: [] },
+      { name: 'adguard', dependencies: [] },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.ordered.map(i => i.name)).toEqual(['auth', 'adguard']);
+  });
+});

--- a/src/lib/stackInstall/dependencies.ts
+++ b/src/lib/stackInstall/dependencies.ts
@@ -1,0 +1,124 @@
+/**
+ * Install-time dependency parsing + topological ordering.
+ *
+ * Templates declare dependencies via a single annotation on the
+ * pod-level metadata in `template.yml`:
+ *
+ *     metadata:
+ *       annotations:
+ *         servicebay.dependencies: "auth,nginx"
+ *
+ * Comma-separated list, no surrounding whitespace required. Empty
+ * value or missing annotation = no install-time deps. The
+ * install loop reads this once per template (via the rendered
+ * yaml already loaded in startConfigure) and uses the topological
+ * sort below to reorder the selected set so deps install first.
+ *
+ * Two failure modes the caller surfaces to the operator:
+ * - `missing` — a selected template depends on something the
+ *   operator didn't check. We don't silently auto-add: the user
+ *   already saw the catalog and decided, so a clear "Foo requires
+ *   Bar — go back and check Bar" message lets them recover.
+ * - `cycle` — should never happen if templates are well-formed,
+ *   but defensive: a cycle would otherwise loop the install.
+ */
+
+/** Single regex per yaml — matches `servicebay.dependencies: "..."`,
+ *  `'...'`, or unquoted, anywhere in the file. Indentation isn't
+ *  validated because the templates already pass yaml-syntax tests
+ *  (template_consistency.test.ts); this regex just needs the value. */
+const DEPS_ANNOTATION_RE =
+  /^\s+servicebay\.dependencies:\s*(?:"([^"]*)"|'([^']*)'|([^\n#]+?))\s*$/m;
+
+/** Parse `servicebay.dependencies` from a rendered template.yml.
+ *  Returns the list of dep template names, lowercase-trimmed, or
+ *  an empty array when the annotation is missing/blank. */
+export function parseTemplateDependencies(yaml: string | undefined): string[] {
+  if (!yaml) return [];
+  const m = DEPS_ANNOTATION_RE.exec(yaml);
+  if (!m) return [];
+  const raw = (m[1] ?? m[2] ?? m[3] ?? '').trim();
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export interface DependencyAwareItem {
+  name: string;
+  /** Names this item depends on. Resolved against the candidate set. */
+  dependencies: string[];
+}
+
+export type TopoSortResult<T> =
+  | { ok: true; ordered: T[] }
+  | { ok: false; reason: 'missing'; item: string; missing: string[] }
+  | { ok: false; reason: 'cycle'; involved: string[] };
+
+/**
+ * Topologically sort `items` so every entry's dependencies appear
+ * earlier in the result. Items whose dependencies aren't in
+ * `candidates` (typically `selectedNames`) return `missing`; cycles
+ * return `cycle`. Stable: keeps the input order among items that have
+ * the same dependency depth so the operator sees a predictable
+ * sequence in the wizard log.
+ *
+ * `extra` is used to keep `alreadyInstalled` items as satisfiers
+ * without including them in the output — i.e. if the operator
+ * already installed `auth` in a previous run and is now adding
+ * `vaultwarden`, the dep on `auth` is considered satisfied.
+ */
+export function topoSortByDependencies<T extends DependencyAwareItem>(
+  items: T[],
+  opts: { alreadyInstalled?: ReadonlySet<string> } = {},
+): TopoSortResult<T> {
+  const alreadyInstalled = opts.alreadyInstalled ?? new Set<string>();
+  const namesInSet = new Set(items.map(i => i.name));
+
+  // Check 1: every dep is either in the set or already-installed.
+  for (const item of items) {
+    const missing = item.dependencies.filter(
+      d => !namesInSet.has(d) && !alreadyInstalled.has(d),
+    );
+    if (missing.length > 0) {
+      return { ok: false, reason: 'missing', item: item.name, missing };
+    }
+  }
+
+  // Kahn's algorithm with a stable tiebreaker (input order).
+  const indeg = new Map<string, number>();
+  const byName = new Map<string, T>();
+  const inputOrder = new Map<string, number>();
+  items.forEach((it, i) => {
+    byName.set(it.name, it);
+    inputOrder.set(it.name, i);
+    indeg.set(it.name, it.dependencies.filter(d => namesInSet.has(d)).length);
+  });
+
+  const ready: T[] = items.filter(it => (indeg.get(it.name) ?? 0) === 0);
+  const ordered: T[] = [];
+
+  while (ready.length > 0) {
+    // Stable tiebreaker — sort ready items by input order so the
+    // result is deterministic regardless of Map iteration quirks.
+    ready.sort((a, b) => (inputOrder.get(a.name) ?? 0) - (inputOrder.get(b.name) ?? 0));
+    const next = ready.shift()!;
+    ordered.push(next);
+    for (const other of items) {
+      if (other.dependencies.includes(next.name)) {
+        const newDeg = (indeg.get(other.name) ?? 0) - 1;
+        indeg.set(other.name, newDeg);
+        if (newDeg === 0 && !ordered.includes(other) && !ready.includes(other)) {
+          ready.push(other);
+        }
+      }
+    }
+  }
+
+  if (ordered.length !== items.length) {
+    const involved = items.filter(it => !ordered.includes(it)).map(it => it.name);
+    return { ok: false, reason: 'cycle', involved };
+  }
+  return { ok: true, ordered };
+}

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -45,6 +45,7 @@ import {
 import { buildCredentialsManifest, type Credential } from './credentialsManifest';
 import { generateRandomSecret } from './randomSecret';
 import { selectMigrationChain } from './migrations';
+import { parseTemplateDependencies, topoSortByDependencies } from './dependencies';
 
 export type StackInstallPhase = 'idle' | 'configure' | 'installing' | 'done' | 'error';
 
@@ -60,6 +61,10 @@ export interface StackItem {
   yaml?: string;
   configFiles?: ConfigFile[];
   alreadyInstalled?: boolean;
+  /** Template names that must install before this one. Parsed from the
+   *  `servicebay.dependencies` annotation in template.yml during
+   *  startConfigure. Empty when the template has no install-time deps. */
+  dependencies?: string[];
 }
 
 export interface StackVariable {
@@ -150,6 +155,12 @@ export interface UseStackInstallReturn {
 
   /** Reset all install state. Use when consumer cancels mid-flow. */
   reset: () => void;
+
+  /** Abort the running install. Cancels any in-flight `/api/services`
+   *  fetch and sets a flag the deploy loop checks between iterations,
+   *  so the next item never starts. Transitions phase to `error` with
+   *  a clear message. No-op when called outside `installing`. */
+  abortInstall: () => void;
 }
 
 /** Strip Mustache section tags (`{{#NAME}}` / `{{/NAME}}` / `{{^NAME}}`)
@@ -298,6 +309,16 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
    *  value if the consumer changes nodes mid-resolve. */
   const nodeRef = useRef<string>('');
 
+  /** Set by `abortInstall()`. Checked at top of every deploy-loop
+   *  iteration and before each retry attempt so the loop bails out as
+   *  soon as possible without leaving half-applied work mid-template. */
+  const abortRequestedRef = useRef(false);
+  /** AbortController for the in-flight `/api/services?stream=1` fetch.
+   *  Cleared at the end of each attemptDeploy. Lets abortInstall()
+   *  interrupt a long-running deploy (image pull, slow post-deploy)
+   *  instead of waiting for the next iteration check. */
+  const activeRequestRef = useRef<AbortController | null>(null);
+
   const appendLog = useCallback((line: string) => {
     setLogs(prev => [...prev, line]);
   }, []);
@@ -315,6 +336,24 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     setCleanInstall(false);
     setCleanInstallConfirm('');
     nodeRef.current = '';
+    // Cancel any in-flight deploy fetch and clear the abort flag so a
+    // subsequent runInstall doesn't trip over leftover state.
+    activeRequestRef.current?.abort();
+    activeRequestRef.current = null;
+    abortRequestedRef.current = false;
+  }, []);
+
+  const abortInstall = useCallback(() => {
+    if (abortRequestedRef.current) return;
+    abortRequestedRef.current = true;
+    // Tear down the in-flight fetch immediately so a long image pull
+    // doesn't block the abort. The deploy loop's exception handler
+    // sees the AbortError and stops; the retry loop sees the flag.
+    activeRequestRef.current?.abort();
+    setLogs(prev => [...prev, '⛔ Install aborted by user.']);
+    setError('Installation aborted by user. Click "Start over" to begin again.');
+    setPhase('error');
+    setInstallingNow(null);
   }, []);
 
   // No-op writes return the same array reference so subscribers (e.g. the
@@ -391,7 +430,13 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
         const yaml = await fetchTemplateYaml(item.name, templateSource);
         if (!yaml) continue;
         const idx = newItems.findIndex(i => i.name === item.name);
-        if (idx !== -1) newItems[idx].yaml = yaml;
+        if (idx !== -1) {
+          newItems[idx].yaml = yaml;
+          // Parse install-time deps from the (still un-rendered) yaml.
+          // Mustache placeholders don't appear in the dependencies
+          // annotation, so the raw string is fine here.
+          newItems[idx].dependencies = parseTemplateDependencies(yaml);
+        }
 
         for (const match of yaml.matchAll(MUSTACHE_VAR_RE_OUT)) vars.add(match[1]);
 
@@ -574,19 +619,62 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       }
     }
 
-    const selected = itemsBase.filter(i => i.checked);
-    if (selected.length === 0) {
+    const checked = itemsBase.filter(i => i.checked);
+    if (checked.length === 0) {
       appendLog('⚠️ No services selected to install — aborting.');
       setPhase('done');
       setCredentialsManifest([]);
       return;
     }
 
+    // Topo-sort by install-time deps so e.g. `auth` lands before
+    // `vaultwarden`. `alreadyInstalled` items are treated as satisfied
+    // satisfiers — the operator may add a single template on top of an
+    // existing stack, and that template's `auth` dep is fine if auth
+    // was installed in a previous run. On `missing` (a checked
+    // template depends on something the operator didn't tick) we
+    // surface the gap and stop before any deploy starts — the user
+    // can go back to the catalog and fix it instead of watching a
+    // half-broken stack come up.
+    const sortResult = topoSortByDependencies(
+      checked.map(i => ({
+        name: i.name,
+        checked: i.checked,
+        alreadyInstalled: i.alreadyInstalled,
+        yaml: i.yaml,
+        configFiles: i.configFiles,
+        dependencies: i.dependencies ?? [],
+      })),
+      { alreadyInstalled: new Set(itemsBase.filter(i => i.alreadyInstalled).map(i => i.name)) },
+    );
+    if (!sortResult.ok) {
+      const msg = sortResult.reason === 'missing'
+        ? `Cannot install ${sortResult.item}: it depends on ${sortResult.missing.join(', ')}, which ${sortResult.missing.length === 1 ? 'is' : 'are'} not selected. Go back and check ${sortResult.missing.length === 1 ? 'that template' : 'those templates'}, or unselect ${sortResult.item}.`
+        : `Templates form a dependency cycle (${sortResult.involved.join(' ↔ ')}). This is a template-authoring bug — please report it.`;
+      appendLog(`❌ ${msg}`);
+      setError(msg);
+      setPhase('error');
+      return;
+    }
+    const selected = sortResult.ordered;
+    const sortedNames = selected.map(s => s.name).join(' → ');
+    const checkedNames = checked.map(c => c.name).join(' → ');
+    if (sortedNames !== checkedNames) {
+      appendLog(`Install order (by dependencies): ${sortedNames}`);
+    }
+
     const deployed: { name: string; checked: boolean }[] = [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const scriptCredentials: any[] = [];
 
+    // Reset abort state for this run. A leftover flag from a previous
+    // run that ended in 'error' would otherwise short-circuit the very
+    // first iteration.
+    abortRequestedRef.current = false;
+    activeRequestRef.current = null;
+
     for (const item of selected) {
+      if (abortRequestedRef.current) return;
       if (item.alreadyInstalled) {
         appendLog(`✅ ${item.name} already installed, skipping.`);
         deployed.push({ name: item.name, checked: true });
@@ -705,6 +793,13 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       const attemptDeploy = async (): Promise<void> => {
         const query = node ? `?node=${node}&stream=1` : '?stream=1';
         let res: Response;
+        // Wire an AbortController so abortInstall() can tear down the
+        // in-flight stream. Stored in a ref the abort handler reads;
+        // cleared in `finally` so a slow post-install pipeline call
+        // doesn't get cancelled by a later abort intended for a future
+        // deploy.
+        const controller = new AbortController();
+        activeRequestRef.current = controller;
         try {
           res = await fetch(`/api/services${query}`, {
             method: 'POST',
@@ -719,8 +814,14 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
               postDeployEnv: postDeployScript || (migrations && migrations.length > 0) ? postDeployEnv : undefined,
               migrations,
             }),
+            signal: controller.signal,
           });
         } catch (networkErr) {
+          if (networkErr instanceof DOMException && networkErr.name === 'AbortError') {
+            const aborted = new Error('aborted by user');
+            (aborted as Error & { fatal?: boolean }).fatal = true;
+            throw aborted;
+          }
           throw new Error(`network: ${networkErr instanceof Error ? networkErr.message : String(networkErr)}`);
         }
         if (!res.ok) {
@@ -777,11 +878,16 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
             }
           }
         }
+        // Reached only on a clean stream end — clear the abort handle
+        // so a subsequent abort doesn't tear down work for the next
+        // template.
+        activeRequestRef.current = null;
       };
 
       let lastDeployErr: Error | null = null;
       let deployedOk = false;
       for (let attempt = 1; attempt <= MAX_DEPLOY_ATTEMPTS; attempt++) {
+        if (abortRequestedRef.current) break;
         if (DEPLOY_BACKOFF_MS[attempt - 1] > 0) {
           await new Promise(r => setTimeout(r, DEPLOY_BACKOFF_MS[attempt - 1]));
         }
@@ -793,6 +899,12 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
           deployedOk = true;
           break;
         } catch (e) {
+          // Make sure we don't leak a stale abort handle from a failed
+          // attempt — finally semantics, but kept inline because
+          // attemptDeploy isn't wrapped in try/finally itself (the
+          // throw paths above all happen before the in-flight fetch
+          // hands over its reader anyway).
+          activeRequestRef.current = null;
           lastDeployErr = e instanceof Error ? e : new Error(String(e));
           if ((lastDeployErr as Error & { fatal?: boolean }).fatal) break;
           if (attempt < MAX_DEPLOY_ATTEMPTS) {
@@ -809,6 +921,11 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
         appendLog(`❌ Failed to install ${item.name} ${tail}`);
       }
       setInstallingNow(null);
+      // Bail out before starting the next template if the operator
+      // hit Abort during this one. abortInstall() already moved phase
+      // to 'error' and logged the abort line; the post-install
+      // pipeline below would be a wasted run on partial state.
+      if (abortRequestedRef.current) return;
     }
 
     const proxyResult = await runPostInstall({
@@ -930,5 +1047,6 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     skipNpmCredentials,
     appendLog,
     reset,
+    abortInstall,
   };
 }

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     servicebay.label: "File Share (Syncthing + Samba + FileBrowser)"
     servicebay.schema-version: "2"
+    # FileBrowser is fronted by Authelia via the nginx proxy host — both
+    # must be running before this template's post-deploy can wire SSO.
+    servicebay.dependencies: "nginx,auth"
     servicebay.ports: "8384/tcp,22000/tcp,139/tcp,445/tcp,{{FILEBROWSER_PORT}}/tcp"
     # Pin the .filebrowser.json.mustache target to filebrowser's /config
     # mount — without this the wizard's path resolver would also consider

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     servicebay.label: "Home Assistant"
     servicebay.schema-version: "3"
+    # Home Assistant is reached at home.<domain> via nginx, and (when
+    # the operator enables it) authenticates via Authelia.
+    servicebay.dependencies: "nginx,auth"
     servicebay.config-mount: "/config"
     servicebay.ports: "8123/tcp,8091/tcp,3000/tcp"
 spec:

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     servicebay.label: "Immich (Photos)"
     servicebay.schema-version: "1"
+    # photos.<domain> is served via nginx; Immich's SSO uses Authelia.
+    servicebay.dependencies: "nginx,auth"
 spec:
   containers:
     - name: immich-server

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     servicebay.label: "Media (Audiobookshelf + Navidrome)"
     servicebay.schema-version: "1"
+    # Audiobookshelf's post-deploy registers an OIDC client in Authelia
+    # and its public URLs route through nginx — both prerequisites.
+    servicebay.dependencies: "nginx,auth"
     servicebay.ports: "{{ABS_PORT}}/tcp,{{NAVIDROME_PORT}}/tcp"
 spec:
   hostNetwork: true

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -8,6 +8,8 @@ metadata:
     servicebay.label: "Radicale (CalDAV + CardDAV)"
     servicebay.schema-version: "1"
     servicebay.ports: "{{RADICALE_PORT}}/tcp"
+    # caldav.<domain> goes through nginx; auth is the SSO front.
+    servicebay.dependencies: "nginx,auth"
 spec:
   hostNetwork: true
   initContainers:

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     servicebay.label: "Vaultwarden (Passwords)"
     servicebay.schema-version: "1"
+    # Install order: proxy + SSO foundation needs to land first so the
+    # post-deploy OIDC-client registration can talk to Authelia and the
+    # vault.<domain> proxy route resolves to a running NPM.
+    servicebay.dependencies: "nginx,auth"
 spec:
   containers:
   - name: vaultwarden


### PR DESCRIPTION
## Summary

Two related changes that close the \"I'm stuck mid-install\" trap.

### A) Abort + Start over
- `useStackInstall` gains `abortInstall()`. Stores the in-flight `/api/services?stream=1` fetch in a ref and aborts its `AbortController` on click — kills the streaming response immediately rather than waiting for the next loop iteration. A second `abortRequestedRef` flag is checked at the top of every deploy-loop iteration and before each retry attempt, so the loop bails out cleanly even if abort fires after the fetch resolves.
- `installing` → `error` with a clear log line + matching `error` string. `reset()` also clears the abort flag.
- UI: red **Abort install** button during installing (window.confirm); amber **Start over** button after error (confirms + `reset()`). The flow dispatcher now also renders progress in `phase === 'error'` (was hidden before).

### B) Dependency-aware install order
- New annotation on `template.yml`: `servicebay.dependencies: \"nginx,auth\"`. Annotated: vaultwarden, file-share, media, home-assistant, immich, radicale (all need NPM proxy + Authelia SSO at install time). nginx/auth/adguard/voice have no deps.
- `lib/stackInstall/dependencies.ts` (new): parser + Kahn-style topo sort with stable input-order tiebreaker. Returns:
  - `{ok: true, ordered}` on success,
  - `{ok: false, reason: 'missing', item, missing}` when a checked template depends on something unchecked,
  - `{reason: 'cycle'}` as a defensive guard.
- `runInstall` parses deps during `startConfigure`, topo-sorts `selected` before the install loop. On `missing`: surfaces a precise message and aborts before any deploy starts (operator clicks Start over → checks the missing template). Logs the reordered sequence when it differs from input order:
  ```
  Install order (by dependencies): nginx → auth → vaultwarden
  ```

## Why
User reports: install gets stuck, no way to bail out without a hard reload. And the install-order is currently whatever order the templates happen to be selected in — which means `vaultwarden` can fire its OIDC-client-registration post-deploy before `auth`'s Authelia is reachable. Both fall out from the same \"the wizard doesn't know about install-time invariants\" gap.

## Test plan
- [x] `npx vitest run src/lib/stackInstall/ tests/backend/template_consistency.test.ts` — 77 tests pass (12 new for `parseTemplateDependencies` + `topoSortByDependencies` covering happy path, missing-dep, cycle, alreadyInstalled-satisfies, stability).
- [x] Lint + tsc clean on changed files.
- [x] Pre-push test suite passes.
- [ ] After release: trigger install with vaultwarden but no auth checked → expect a clear \"vaultwarden depends on auth\" failure with the Start-over button visible, no half-deployed state.
- [ ] After release: deselect vaultwarden, hit Install, click Abort mid-deploy → expect the loop stops within ~1s of the click, error banner with Start over button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)