### PR TITLE
feat(health): coalesce boot-grace alert emails into one digest

### DIFF
--- a/src/lib/health/notificationBatcher.test.ts
+++ b/src/lib/health/notificationBatcher.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `vi.mock` is hoisted above top-level `const` declarations. `vi.hoisted`
+// guarantees the mock and the reference our assertions read are the
+// same vi.fn instance.
+const { sendEmailAlertMock } = vi.hoisted(() => ({
+  sendEmailAlertMock: vi.fn(async (_subject: string, _message: string) => undefined),
+}));
+vi.mock('@/lib/email', () => ({
+  sendEmailAlert: sendEmailAlertMock,
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { NotificationBatcher } from './notificationBatcher';
+import type { CheckConfig, CheckResult } from './types';
+
+beforeEach(() => {
+  sendEmailAlertMock.mockClear();
+  NotificationBatcher._resetForTesting();
+});
+
+function check(id: string, name = id): CheckConfig {
+  return {
+    id,
+    name,
+    type: 'http',
+    target: `http://${id}.example`,
+    interval: 60,
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function result(status: 'ok' | 'fail', message?: string, checkId = 'test-check'): CheckResult {
+  return { check_id: checkId, status, timestamp: '2026-01-01T00:00:00Z', message };
+}
+
+const wait = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+describe('NotificationBatcher', () => {
+  it('returns false when not active so callers fall through to per-event email', () => {
+    expect(NotificationBatcher._activeForTesting()).toBe(false);
+    expect(NotificationBatcher.enqueue('fail', check('nginx'), result('fail'))).toBe(false);
+  });
+
+  it('buffers events during the grace window and returns true', () => {
+    NotificationBatcher.start({ maxMs: 5000, settleMs: 1000 });
+    expect(NotificationBatcher.enqueue('fail', check('nginx'), result('fail'))).toBe(true);
+    expect(NotificationBatcher._pendingForTesting()).toHaveLength(1);
+  });
+
+  it('manual flush sends digest immediately when at least one check is still failing', async () => {
+    NotificationBatcher.start({ maxMs: 60_000, settleMs: 1000 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail', 'connection refused'));
+    await NotificationBatcher.flush('manual');
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    const [subject, body] = sendEmailAlertMock.mock.calls[0];
+    expect(subject).toContain('nginx');
+    expect(body).toContain('connection refused');
+    expect(NotificationBatcher._activeForTesting()).toBe(false);
+  });
+
+  it('flushes early after the settle window with no new events', async () => {
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail', 'connection refused'));
+    expect(sendEmailAlertMock).not.toHaveBeenCalled();
+    await wait(150);
+    await NotificationBatcher._awaitFlushForTesting();
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    const [subject, body] = sendEmailAlertMock.mock.calls[0];
+    expect(subject).toContain('nginx');
+    expect(body).toContain('connection refused');
+    expect(NotificationBatcher._activeForTesting()).toBe(false);
+  });
+
+  it('flushes at max grace even if events keep arriving', async () => {
+    NotificationBatcher.start({ maxMs: 200, settleMs: 10_000 });
+    // Drip events every 50 ms — settle (10 s) never fires.
+    for (let i = 0; i < 3; i++) {
+      NotificationBatcher.enqueue('fail', check(`svc-${i}`), result('fail'));
+      await wait(50);
+    }
+    expect(sendEmailAlertMock).not.toHaveBeenCalled();
+    await wait(150);
+    await NotificationBatcher._awaitFlushForTesting();
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces per check.id — latest state wins', async () => {
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.enqueue('recovery', check('nginx'), result('ok'));
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail', 'final'));
+    NotificationBatcher.enqueue('fail', check('adguard'), result('fail'));
+    NotificationBatcher.enqueue('recovery', check('adguard'), result('ok'));
+
+    await wait(150);
+    await NotificationBatcher._awaitFlushForTesting();
+
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    const [subject, body] = sendEmailAlertMock.mock.calls[0];
+    expect(subject).toMatch(/nginx/);
+    expect(body).toContain('final');
+    expect(body).not.toMatch(/Check: adguard/);
+  });
+
+  it('sends no email when every transient event recovered during boot', async () => {
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.enqueue('recovery', check('nginx'), result('ok'));
+    NotificationBatcher.enqueue('fail', check('auth'), result('fail'));
+    NotificationBatcher.enqueue('recovery', check('auth'), result('ok'));
+
+    await wait(150);
+    await NotificationBatcher._awaitFlushForTesting();
+
+    expect(sendEmailAlertMock).not.toHaveBeenCalled();
+  });
+
+  it('uses a digest subject for >1 still-failing checks', async () => {
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.enqueue('fail', check('auth'), result('fail'));
+    NotificationBatcher.enqueue('fail', check('adguard'), result('fail'));
+
+    await wait(150);
+    await NotificationBatcher._awaitFlushForTesting();
+
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailAlertMock.mock.calls[0][0]).toMatch(/3 health checks failing/);
+  });
+
+  it('repeated start() calls are no-ops during an active window', () => {
+    NotificationBatcher.start({ maxMs: 5000, settleMs: 1000 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.start({ maxMs: 99_999, settleMs: 99_999 });
+    expect(NotificationBatcher._pendingForTesting()).toHaveLength(1);
+  });
+
+  it('falls back to per-event after flush', async () => {
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    await wait(150);
+    await NotificationBatcher._awaitFlushForTesting();
+    expect(NotificationBatcher.enqueue('fail', check('auth'), result('fail'))).toBe(false);
+  });
+});

--- a/src/lib/health/notificationBatcher.ts
+++ b/src/lib/health/notificationBatcher.ts
@@ -1,0 +1,205 @@
+/**
+ * Boot-grace alert batcher.
+ *
+ * Health checks fire once per interval (default 60 s). Every time a
+ * check transitions ok → fail, the runAndEmit path sends one email.
+ * Right after a server restart that's a problem: every previously-
+ * passing check goes through the ok → fail transition at the same
+ * moment because the upstream service is still cold-starting, so the
+ * operator gets N "service down" emails followed by N "service
+ * recovered" emails within minutes. Same pattern during install
+ * wipes/reinstalls.
+ *
+ * This module buffers fail/recovery events for a configurable boot
+ * grace window after server startup. At the end of the window — or
+ * earlier, once events stop arriving for `SETTLE_WINDOW_MS` — it
+ * coalesces per check (latest state wins) and sends *one* digest
+ * email summarising the checks still failing. If nothing is still
+ * failing, no email is sent at all: that's the typical clean-boot
+ * case where everything came back up.
+ *
+ * After the window closes, callers fall through to the per-event
+ * email path with no behaviour change.
+ */
+
+import type { CheckConfig, CheckResult } from './types';
+import { logger } from '@/lib/logger';
+import { sendEmailAlert } from '@/lib/email';
+
+/** Hard cap on how long we'll hold alerts after boot. Covers the
+ *  longest cold-start envelope (NPM + AdGuard + auth pods) plus a
+ *  buffer for slow disks; beyond this the operator is owed real-time
+ *  alerts even if events keep arriving. */
+const BOOT_GRACE_MAX_MS = 10 * 60 * 1000;
+
+/** Idle window after the last event before we declare boot
+ *  stabilised and flush early. 90 s comfortably exceeds a normal
+ *  health-check interval (60 s) so we won't flush in the middle of a
+ *  burst, but it's short enough that operators don't wait the full
+ *  10 min when things actually settle quickly. */
+const SETTLE_WINDOW_MS = 90 * 1000;
+
+export type AlertKind = 'fail' | 'recovery';
+
+interface PendingAlert {
+  kind: AlertKind;
+  check: CheckConfig;
+  result: CheckResult;
+  queuedAt: number;
+}
+
+/** Format the same body the per-event path uses, kept inline so the
+ *  digest reads consistently with non-batched alerts. */
+function formatAlert(reason: AlertKind, check: CheckConfig, result: CheckResult): string {
+  const lines = [
+    `Check: ${check.name}`,
+    `Type: ${check.type}`,
+    check.nodeName ? `Node: ${check.nodeName}` : null,
+    check.target ? `Target: ${check.target}` : null,
+    `Status: ${result.status.toUpperCase()} (last seen ${reason === 'fail' ? 'failing' : 'recovered'} at boot)`,
+    result.latency !== undefined ? `Latency: ${result.latency}ms` : null,
+    `Timestamp: ${result.timestamp}`,
+    result.message ? `Details: ${result.message}` : null,
+  ].filter(Boolean);
+  return lines.join('\n');
+}
+
+export class NotificationBatcher {
+  private static pending: PendingAlert[] = [];
+  private static settleTimer: NodeJS.Timeout | null = null;
+  private static maxGraceTimer: NodeJS.Timeout | null = null;
+  /** When true, callers should buffer instead of sending immediately.
+   *  Flips false at flush time. */
+  private static active = false;
+  /** Settle-window length, captured from `start()` so every enqueue
+   *  uses the same value. Previously enqueue read its own default and
+   *  ignored `start({settleMs})`, which silently broke the
+   *  "stabilises early" contract. */
+  private static settleMs = SETTLE_WINDOW_MS;
+  /** Promise of the in-flight flush, exposed for tests so they can
+   *  await the timer-triggered digest. Production callers don't need
+   *  it — the timer callbacks fire-and-forget. */
+  private static flushInFlight: Promise<void> | null = null;
+
+  /** Initialise the grace window. Called from `HealthService.init`
+   *  once per server start. Repeated calls are no-ops so HMR
+   *  reloads in dev don't reset the timer. */
+  static start(opts: { maxMs?: number; settleMs?: number } = {}): void {
+    if (this.active) return;
+    this.active = true;
+    this.pending = [];
+    const maxMs = opts.maxMs ?? BOOT_GRACE_MAX_MS;
+    this.settleMs = opts.settleMs ?? SETTLE_WINDOW_MS;
+    this.maxGraceTimer = setTimeout(() => {
+      this.flushInFlight = this.flush('max-grace-elapsed');
+    }, maxMs);
+    // Don't arm the settle timer until the first alert arrives —
+    // otherwise a quiet boot (no health-check failures at all) would
+    // still send a 90-s-after-boot "everything fine" event through.
+    logger.info(
+      'NotificationBatcher',
+      `Boot grace active (max ${maxMs / 1000}s, settle ${this.settleMs / 1000}s).`,
+    );
+  }
+
+  /** Enqueue a fail/recovery event. Returns true when the caller
+   *  should NOT send the per-event email (we'll send a digest);
+   *  false when the grace window is closed and the caller should
+   *  send normally. */
+  static enqueue(kind: AlertKind, check: CheckConfig, result: CheckResult): boolean {
+    if (!this.active) return false;
+    this.pending.push({ kind, check, result, queuedAt: Date.now() });
+    // Reset the settle timer on every event — boot is still in flux.
+    if (this.settleTimer) clearTimeout(this.settleTimer);
+    this.settleTimer = setTimeout(() => {
+      this.flushInFlight = this.flush('settled');
+    }, this.settleMs);
+    return true;
+  }
+
+  /** Flush the buffer immediately. Public so tests can drive it;
+   *  the timers call it internally. */
+  static async flush(reason: 'settled' | 'max-grace-elapsed' | 'manual' = 'manual'): Promise<void> {
+    if (!this.active) return;
+    this.active = false;
+    if (this.settleTimer) {
+      clearTimeout(this.settleTimer);
+      this.settleTimer = null;
+    }
+    if (this.maxGraceTimer) {
+      clearTimeout(this.maxGraceTimer);
+      this.maxGraceTimer = null;
+    }
+
+    // Coalesce: latest event per check.id wins. Two-step pass so a
+    // check that went fail → recovery → fail during boot lands as
+    // fail (its last observed state).
+    const finalState = new Map<string, PendingAlert>();
+    for (const a of this.pending) finalState.set(a.check.id, a);
+    const stillFailing = [...finalState.values()].filter(a => a.kind === 'fail');
+
+    const total = this.pending.length;
+    this.pending = [];
+
+    if (stillFailing.length === 0) {
+      logger.info(
+        'NotificationBatcher',
+        `Boot grace ${reason}: ${total} transient event${total === 1 ? '' : 's'} settled cleanly, no email sent.`,
+      );
+      return;
+    }
+
+    const subject =
+      stillFailing.length === 1
+        ? `Health check failing after boot: ${stillFailing[0].check.name}`
+        : `${stillFailing.length} health checks failing after boot`;
+
+    const summary = `ServiceBay boot grace window (${reason === 'settled' ? 'stabilised early' : 'max duration reached'}). `
+      + `${stillFailing.length} of ${finalState.size} unique check${finalState.size === 1 ? '' : 's'} `
+      + `that changed state during the window ${stillFailing.length === 1 ? 'is' : 'are'} still failing.`;
+
+    const body = `${summary}\n\n${stillFailing.map(a => formatAlert(a.kind, a.check, a.result)).join('\n---\n')}`;
+
+    try {
+      await sendEmailAlert(subject, body);
+      logger.info(
+        'NotificationBatcher',
+        `Sent digest for ${stillFailing.length} still-failing check(s) after boot (${reason}).`,
+      );
+    } catch (e) {
+      logger.warn(
+        'NotificationBatcher',
+        `Digest email failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
+  /** Test-only: reset module state so each test starts clean. */
+  static _resetForTesting(): void {
+    if (this.settleTimer) clearTimeout(this.settleTimer);
+    if (this.maxGraceTimer) clearTimeout(this.maxGraceTimer);
+    this.settleTimer = null;
+    this.maxGraceTimer = null;
+    this.pending = [];
+    this.active = false;
+  }
+
+  /** Test-only: peek at the pending buffer. */
+  static _pendingForTesting(): readonly PendingAlert[] {
+    return this.pending;
+  }
+
+  /** Test-only: whether the grace window is open. */
+  static _activeForTesting(): boolean {
+    return this.active;
+  }
+
+  /** Test-only: await the in-flight flush promise (if any) that was
+   *  triggered by a timer. Lets tests synchronise on the async flush
+   *  body completing after `advanceTimersByTimeAsync`. */
+  static async _awaitFlushForTesting(): Promise<void> {
+    const p = this.flushInFlight;
+    this.flushInFlight = null;
+    if (p) await p;
+  }
+}

--- a/src/lib/health/service.ts
+++ b/src/lib/health/service.ts
@@ -7,6 +7,7 @@ import { CheckRunner } from './runner';
 import { CheckConfig, CheckResult } from './types';
 import { initializeDefaultChecks } from './init';
 import { sendEmailAlert } from '@/lib/email';
+import { NotificationBatcher } from './notificationBatcher';
 import { DATA_DIR } from '@/lib/dirs';
 
 // In-memory interval tracking
@@ -22,6 +23,15 @@ export class HealthService {
 
     // 1. Ensure defaults
     await initializeDefaultChecks();
+
+    // 1b. Open the boot-grace email-batch window. Health checks
+    //     that flip ok → fail during the first 10 min after boot
+    //     (or until events settle for 90 s, whichever comes first)
+    //     are coalesced into one digest email instead of spamming
+    //     the operator with N "service down" notifications during
+    //     the cold-start race. See NotificationBatcher for the
+    //     coalescing rules.
+    NotificationBatcher.start();
 
     // 2. Start initial scheduling
     this.restartAll();
@@ -137,17 +147,23 @@ export class HealthService {
       }
 
       if (enteredFailure) {
-        await sendEmailAlert(
-          `Check Failed: ${check.name}`,
-          formatAlertMessage('fail', check, result)
-        );
+        const buffered = NotificationBatcher.enqueue('fail', check, result);
+        if (!buffered) {
+          await sendEmailAlert(
+            `Check Failed: ${check.name}`,
+            formatAlertMessage('fail', check, result)
+          );
+        }
       }
 
       if (recoveredNow) {
-        await sendEmailAlert(
-          `Service Recovered: ${check.name}`,
-          formatAlertMessage('recovery', check, result)
-        );
+        const buffered = NotificationBatcher.enqueue('recovery', check, result);
+        if (!buffered) {
+          await sendEmailAlert(
+            `Service Recovered: ${check.name}`,
+            formatAlertMessage('recovery', check, result)
+          );
+        }
       }
     } catch (e) {
       logger.error('Health', `Error running check ${check.name}:`, e);


### PR DESCRIPTION
## Summary
Health checks fire one email per ok→fail transition. Right after a server restart that produces N \"service down\" mails in seconds while pods finish their cold start, followed by N \"recovered\" mails minutes later. Same noise pattern on install / wipe-and-redeploy.

This PR opens a **boot-grace window** at `HealthService.init` time and coalesces alerts into a single digest:

- **Max grace: 10 min.** After that, real-time alerts resume.
- **Settle: 90 s** of no new events flushes the window early — boot stabilised, no need to wait the full max.
- **Coalesce per `check.id`:** latest observed state wins. A check that went fail→recovery→fail during boot lands in the digest as `fail`.
- **One digest** sent only for checks STILL failing at flush time. Clean boot (everything recovers) → no email at all.

Per-event email path stays intact — once the window closes, `enqueue` returns false and `runAndEmit` falls through to the existing `sendEmailAlert(...)` call. No behaviour change after the first 10 min of uptime.

## Why
User report: every restart/reinstall floods the inbox with one mail per service. \"wenn jemand den server durchstartet, dafür sorgen, das EINE email verschickt wird, und nicht alle health checks einzeln sich melden.\"

## Test plan
- [x] `npx vitest run src/lib/health/` — 10 new tests cover: active/inactive enqueue, settle-early flush, max-grace flush, per-check coalesce (latest wins), clean-boot suppression (no email), digest subject for >1 check, repeated `start()` no-op, fall-through after flush.
- [x] Lint + tsc clean.
- [x] Pre-push test suite passes.
- [ ] After release: restart ServiceBay → watch inbox → expect at most one digest email \"N health checks failing after boot\" (or none if everything recovered cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)