### PR TITLE
fix(ui): guard ServerIdentityWatcher against undefined socket

### DIFF
--- a/src/components/ServerIdentityWatcher.tsx
+++ b/src/components/ServerIdentityWatcher.tsx
@@ -45,6 +45,15 @@ export default function ServerIdentityWatcher() {
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
+    // `useSocket` initializes the singleton socket inside its own
+    // useEffect, which runs after the first render returns. The very
+    // first time this component renders the destructured `socket`
+    // value is still `undefined`; reading `.on()` on it crashed the
+    // app at the root layout (TypeError: Cannot read properties of
+    // undefined (reading 'on')). Bail out until the next render fires
+    // with the initialized socket — `socket` is in the dep array so
+    // the effect re-runs once `useSocket` returns a defined value.
+    if (!socket) return;
     function onIdentity(data: ServerIdentity) {
       if (initial.current === null) {
         initial.current = data;


### PR DESCRIPTION
## Summary
The watcher subscribes to `server:identity` in a `useEffect` that reads `socket.on(...)`. `useSocket` initializes the module-level socket inside its own `useEffect`, which runs AFTER the watcher's first render returns — so the destructured `socket` value the watcher closes over on first render is `undefined`. Reading `.on()` on it threw

```
Uncaught TypeError: Cannot read properties of undefined (reading 'on')
    at layout-a90c9ba829054c40.js:1:1333
```

and crashed the entire app at first paint.

## Fix
Bail out of the effect when `socket` is undefined. `socket` is in the dep array; once `useSocket`'s first `setIsConnected(true)` triggers a re-render the destructured value is the live Socket and the effect re-runs with the subscription wired correctly. One-line change, no other behaviour modified.

## Why this only showed up now
Every other useSocket consumer mounts inside a child route. The watcher I added in #390 mounts at the **root layout** — earliest possible point — so it's the first caller and races the init.

## Test plan
- [x] Lint + tsc clean.
- [ ] After release: load the dashboard cold → expect no console error and the page renders. Restart ServiceBay from the host → expect the banner to appear after the socket reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)