### PR TITLE
fix(install): attach internal token on runner loopback fetches

### DIFF
--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -39,6 +39,7 @@ import {
 import { buildCredentialsManifest, type Credential } from '@/lib/stackInstall/credentialsManifest';
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
 import { DigitalTwinStore } from '@/lib/store/twin';
+import { getInternalApiToken } from '@/lib/auth/internalToken';
 import {
   appendLog,
   getJob,
@@ -72,12 +73,19 @@ const pendingCredentials = new Map<string, {
   resolve: (creds: { email: string; password: string } | null) => void;
 }>();
 
-/** Loopback fetch helper. Uses the same Next.js port the rest of the
- *  process is listening on. The auth REST API has no middleware-level
- *  gating, so a session cookie isn't required for these calls. */
+/** Loopback fetch helper. proxy.ts middleware gates state-changing API
+ *  calls on either a session cookie OR the X-SB-Internal-Token header
+ *  (the same token the post-deploy scripts on the agent host use). The
+ *  runner has no session, so we attach the token here — without it
+ *  every POST /api/services / NPM / portal call from this process gets
+ *  403'd by the CSRF check (no Origin header from Node fetch). */
 function apiFetch(p: string, init?: RequestInit): Promise<Response> {
   const port = process.env.PORT || '3000';
-  return fetch(`http://127.0.0.1:${port}${p}`, init);
+  const headers = new Headers(init?.headers);
+  if (!headers.has('x-sb-internal-token')) {
+    headers.set('x-sb-internal-token', getInternalApiToken());
+  }
+  return fetch(`http://127.0.0.1:${port}${p}`, { ...init, headers });
 }
 
 /**

--- a/src/lib/stackInstall/portalProvision.test.ts
+++ b/src/lib/stackInstall/portalProvision.test.ts
@@ -18,9 +18,10 @@ afterEach(() => {
   globalThis.setTimeout = originalSetTimeout;
 });
 
-// useStackInstall imports a lot of React/Next plumbing — we only want the
-// pure helper. Pull it in *after* fetch is stubbed.
-import { provisionPortalWithRetries } from './useStackInstall';
+// Pulled from the new home: the helper was extracted out of the React-
+// tagged useStackInstall hook so the server-side install runner could
+// share it. Imported after fetch is stubbed so the module sees the mock.
+import { provisionPortalWithRetries } from './portalProvision';
 
 function mockJsonResponse(ok: boolean, body: unknown, status = ok ? 200 : 400): Response {
   return {

--- a/src/lib/stackInstall/portalProvision.ts
+++ b/src/lib/stackInstall/portalProvision.ts
@@ -32,10 +32,15 @@ const PORTAL_PROVISION_ATTEMPTS = 4;
  *  few seconds on first boot. */
 const PORTAL_PROVISION_BACKOFF_MS = [0, 3000, 6000, 9000];
 
+import { getInternalApiToken } from '@/lib/auth/internalToken';
+
 function apiFetch(p: string, init?: RequestInit): Promise<Response> {
-  if (typeof window !== 'undefined') return fetch(p, init);
   const port = process.env.PORT || '3000';
-  return fetch(`http://127.0.0.1:${port}${p}`, init);
+  const headers = new Headers(init?.headers);
+  if (!headers.has('x-sb-internal-token')) {
+    headers.set('x-sb-internal-token', getInternalApiToken());
+  }
+  return fetch(`http://127.0.0.1:${port}${p}`, { ...init, headers });
 }
 
 export async function provisionPortalWithRetries(onLog: (msg: string) => void): Promise<boolean> {

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -27,17 +27,20 @@
 import Mustache from 'mustache';
 import type { VariableMeta } from '@/lib/registry';
 import { buildCredentialsManifest, formatCredentialsBanner, type Credential } from './credentialsManifest';
+import { getInternalApiToken } from '@/lib/auth/internalToken';
 
-/** Env-aware fetch wrapper. The post-install pipeline used to run only
- *  in the browser, so every call site used relative `/api/...` URLs. The
- *  server-side install runner now invokes the same code path on the
- *  Node side, where `fetch('/api/...')` would fail with "Invalid URL".
- *  Detecting the environment here keeps every existing call site working
- *  without sprinkling URL-builder logic through the file. */
+/** Loopback fetch helper. The post-install pipeline runs server-side
+ *  inside the install runner; this file is no longer pulled into the
+ *  client bundle (only its types are). proxy.ts middleware blocks plain
+ *  Node-fetch POSTs as cross-site (no Origin header), so we attach the
+ *  internal token to every call. */
 function apiFetch(p: string, init?: RequestInit): Promise<Response> {
-  if (typeof window !== 'undefined') return fetch(p, init);
   const port = process.env.PORT || '3000';
-  return fetch(`http://127.0.0.1:${port}${p}`, init);
+  const headers = new Headers(init?.headers);
+  if (!headers.has('x-sb-internal-token')) {
+    headers.set('x-sb-internal-token', getInternalApiToken());
+  }
+  return fetch(`http://127.0.0.1:${port}${p}`, { ...init, headers });
 }
 
 /** Variable shape shared between wizard and modal. */

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -33,7 +33,6 @@ import { parseTemplateLabel } from '@/lib/templateLabel';
 import { type Credential } from './credentialsManifest';
 import { generateRandomSecret } from './randomSecret';
 import { parseTemplateDependencies } from './dependencies';
-import { provisionPortalWithRetries } from './portalProvision';
 import { useSocket } from '@/hooks/useSocket';
 import type { JobState as RemoteJobState } from '@/lib/install/jobStore';
 
@@ -235,11 +234,9 @@ async function resolveConfigFilePaths(yaml: string, cfgFiles: ConfigFile[]): Pro
   }
 }
 
-// provisionPortalWithRetries moved to ./portalProvision so the server-side
-// install runner (runner.ts) can share the same implementation without
-// pulling in this 'use client'-tagged file. Re-exported above for any
-// external callers that still import it from here.
-export { provisionPortalWithRetries };
+// provisionPortalWithRetries lives in ./portalProvision (server-only).
+// Don't re-export it here — the chain client→useStackInstall→portalProvision
+// would pull AUTH_SECRET-touching code into the browser bundle.
 
 /** Map server-side `JobPhase` to the client-facing display phase the
  *  rest of the wizard already understands. `crashed` and `aborted` both


### PR DESCRIPTION
## Summary
The deploy loop refactor in #398 moved server-to-server fetches into the runner. Node fetch sends no `Origin` header, which `proxy.ts` middleware treats as cross-site and rejects with 403 on every state-changing call. Net effect: 3.25.0 wizard reaches `phase=installing`, runner starts, the very first `POST /api/services?stream=1` gets 403'd, no socket events fire, wizard stuck on "Processing... 0/10" forever.

Discovered live: `curl http://192.168.178.100:5888/api/install/status` from the LAN returned 401 (route exists, gate blocks server-to-server). Container logs showed zero install activity despite the wizard saying it was running.

## Fix
- Attach `X-SB-Internal-Token` (the same header post-deploy scripts use for server-to-server callbacks) on every loopback fetch in `runner.ts`, `postInstall.ts`, and `portalProvision.ts`. The middleware already honors this header to bypass both CSRF and session checks.
- Drop the `provisionPortalWithRetries` re-export from `useStackInstall.ts` (was unused; would have pulled the now-server-only token import into the client bundle). Test imports updated to `./portalProvision` directly.

## Test plan
- [x] `npm run build` clean (no client-bundle leak of node:crypto)
- [x] `npx vitest run` 648 passing (5 portal-provision tests retargeted to the new import path)
- [ ] Manual: hit Install in the wizard on 3.25.x — should actually deploy this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)