### PR TITLE
feat(access-requests): deep-link admin email to settings

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -94,7 +94,7 @@ export default function AccessRequestsSection() {
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+    <div id="access-requests" className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full scroll-mt-24">
       <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
         <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
           <UserPlus size={20} />

--- a/src/app/api/system/access-requests/route.ts
+++ b/src/app/api/system/access-requests/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import crypto from 'crypto';
-import { getConfig, saveConfig, type AccessRequest } from '@/lib/config';
+import { getConfig, saveConfig, getAdminBaseUrl, type AccessRequest } from '@/lib/config';
 import { sendEmailAlert } from '@/lib/email';
 import { logger } from '@/lib/logger';
 
@@ -76,11 +76,15 @@ export async function POST(request: Request) {
 
   // Best-effort email notification — sendEmailAlert no-ops when
   // email isn't configured.
+  const adminBase = getAdminBaseUrl(config);
+  const deepLink = adminBase ? `${adminBase}/settings/integrations#access-requests` : null;
   void sendEmailAlert(
     'New access request',
     `${parsed.name} (${parsed.email}) has requested access to your home server.\n\n` +
     (parsed.message ? `Message: ${parsed.message}\n\n` : '') +
-    'Open Settings → Access Requests to create the LLDAP user.',
+    (deepLink
+      ? `Review and approve: ${deepLink}`
+      : 'Open Settings → Access Requests to create the LLDAP user.'),
   );
 
   return NextResponse.json({ ok: true, id: newRequest.id });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -373,6 +373,25 @@ export function getOidcCallbackUrl(config: { reverseProxy?: { publicDomain?: str
   return 'http://localhost:3000/api/auth/oidc/callback';
 }
 
+/**
+ * Base URL of the ServiceBay admin UI for use in outbound communications
+ * (e.g. notification emails). Prefers the public domain when available so
+ * the link works from outside the LAN; otherwise falls back to the LAN
+ * domain. Returns null when nothing usable is configured — callers should
+ * omit the link rather than generating a broken localhost URL.
+ */
+export function getAdminBaseUrl(config: { reverseProxy?: { publicDomain?: string; lanDomain?: string } }): string | null {
+  const publicDomain = config.reverseProxy?.publicDomain;
+  if (publicDomain) {
+    return `https://admin.${publicDomain}`;
+  }
+  const lanDomain = config.reverseProxy?.lanDomain;
+  if (lanDomain) {
+    return `http://admin.${lanDomain}`;
+  }
+  return null;
+}
+
 const normalizeExternalLinkEntry = (link: ExternalLink): ExternalLink => {
   const normalizedTargets = normalizeExternalTargets(link.ipTargets ?? []);
   return {


### PR DESCRIPTION
## Summary
- Admin notification email for new access requests now includes a direct deep-link to `Settings → Integrations` with the `AccessRequestsSection` scrolled into view via an `#access-requests` anchor.
- New helper `getAdminBaseUrl()` in `src/lib/config.ts` derives the URL from `reverseProxy.publicDomain` (preferred) or `reverseProxy.lanDomain` (fallback), so the link works in both `public` and `lan` install modes.
- When neither domain is configured, falls back to the previous "Open Settings → Access Requests" text-only hint.

Closes #404

## Test plan
- [ ] Trigger a portal access request on a configured instance with `publicDomain` set → email contains `https://admin.<domain>/settings/integrations#access-requests` and clicking opens the section in view.
- [ ] Same on a `lan`-mode instance with only `lanDomain` set → link uses `http://admin.<lanDomain>/...`.
- [ ] Without any domain configured → email still sends with the legacy text hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)