### PR TITLE
feat(access-requests): collect username + first/last name on portal form

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -10,6 +10,9 @@ interface AccessRequest {
   name: string;
   email: string;
   message?: string;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
   status: 'pending' | 'resolved';
   resolvedAt?: string;
 }
@@ -188,8 +191,13 @@ function RequestRow({
     <div className={`p-3 rounded-lg border border-gray-200 dark:border-gray-700 ${muted ? 'opacity-60' : 'bg-white dark:bg-gray-900'}`}>
       <div className="flex items-start gap-3">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 text-sm">
+          <div className="flex items-center gap-2 text-sm flex-wrap">
             <span className="font-medium text-gray-900 dark:text-white">{r.name}</span>
+            {r.username && (
+              <span className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-mono bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded">
+                {r.username}
+              </span>
+            )}
             <a href={`mailto:${r.email}`} className="inline-flex items-center gap-1 text-blue-700 dark:text-blue-300 hover:underline text-xs">
               <Mail size={12} /> {r.email}
             </a>

--- a/src/app/api/system/access-requests/route.ts
+++ b/src/app/api/system/access-requests/route.ts
@@ -29,10 +29,23 @@ export const dynamic = 'force-dynamic';
 const MAX_PENDING = 50;
 const POST_BODY_LIMIT = 4_096;
 
+// LLDAP `uid` accepts a wider character set, but we constrain to
+// `[a-z0-9._-]` so it round-trips cleanly through URLs, filesystem
+// paths, and most app-level username validators without further
+// sanitization on the admin side.
+const USERNAME_RE = /^[a-z0-9._-]{1,60}$/;
+
 const PostBody = z.object({
-  name: z.string().trim().min(1).max(120),
+  // Free-text name kept for backward compatibility with portal clients
+  // that haven't been updated yet. New submissions also send firstName
+  // and lastName; if those are present, the server composes `name`
+  // from them — see the POST handler.
+  name: z.string().trim().min(1).max(120).optional(),
   email: z.email().max(200),
   message: z.string().trim().max(1_000).optional(),
+  username: z.string().trim().regex(USERNAME_RE, 'Username must be lowercase letters, digits, ., _ or -, max 60 chars').optional(),
+  firstName: z.string().trim().min(1).max(60).optional(),
+  lastName: z.string().trim().min(1).max(60).optional(),
 });
 
 export async function POST(request: Request) {
@@ -63,12 +76,28 @@ export async function POST(request: Request) {
     );
   }
 
+  // Compose display name from firstName/lastName when both are
+  // provided (new clients); otherwise fall back to the free-text
+  // `name` field (old clients). At least one source is required.
+  const composed = parsed.firstName && parsed.lastName
+    ? `${parsed.firstName} ${parsed.lastName}`
+    : parsed.name?.trim();
+  if (!composed) {
+    return NextResponse.json(
+      { error: 'Name is required (or firstName + lastName).' },
+      { status: 400 },
+    );
+  }
+
   const newRequest: AccessRequest = {
     id: crypto.randomUUID(),
     requestedAt: new Date().toISOString(),
-    name: parsed.name,
+    name: composed,
     email: parsed.email,
     message: parsed.message,
+    username: parsed.username,
+    firstName: parsed.firstName,
+    lastName: parsed.lastName,
     status: 'pending',
   };
   await saveConfig({ ...config, accessRequests: [...existing, newRequest] });

--- a/src/app/portal/RequestAccessButton.tsx
+++ b/src/app/portal/RequestAccessButton.tsx
@@ -6,13 +6,18 @@ import { UserPlus, Loader2 } from 'lucide-react';
 /**
  * "Don't have an account?" affordance on the family portal (#242
  * follow-up). Renders a small button below the card grid; clicking
- * opens a modal with name/email/optional message → POSTs to
- * /api/system/access-requests (public). The admin sees the request
- * in Settings → Access Requests and creates an LLDAP user.
+ * opens a modal that collects everything LLDAP needs to provision an
+ * account — first/last name, desired login, email, optional note —
+ * and POSTs to /api/system/access-requests (public). The admin
+ * approves in Settings → Access Requests; #405 wired this form to
+ * gather the profile data so approval is one click rather than a
+ * round-trip to ask the requester for a username.
  */
 export default function RequestAccessButton() {
   const [open, setOpen] = useState(false);
-  const [name, setName] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -20,7 +25,9 @@ export default function RequestAccessButton() {
   const [submitted, setSubmitted] = useState(false);
 
   const reset = () => {
-    setName('');
+    setFirstName('');
+    setLastName('');
+    setUsername('');
     setEmail('');
     setMessage('');
     setError(null);
@@ -37,11 +44,23 @@ export default function RequestAccessButton() {
     e.preventDefault();
     setSubmitting(true);
     setError(null);
+    const trimmedUsername = username.trim().toLowerCase();
+    if (!/^[a-z0-9._-]{1,60}$/.test(trimmedUsername)) {
+      setError('Username may only contain lowercase letters, digits, dots, underscores, and hyphens (max 60 characters).');
+      setSubmitting(false);
+      return;
+    }
     try {
       const res = await fetch('/api/system/access-requests', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name.trim(), email: email.trim(), message: message.trim() || undefined }),
+        body: JSON.stringify({
+          firstName: firstName.trim(),
+          lastName: lastName.trim(),
+          username: trimmedUsername,
+          email: email.trim(),
+          message: message.trim() || undefined,
+        }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
@@ -74,7 +93,7 @@ export default function RequestAccessButton() {
           onClick={onClose}
         >
           <div
-            className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-md w-full p-6"
+            className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-md w-full p-6 max-h-[90vh] overflow-y-auto"
             onClick={e => e.stopPropagation()}
           >
             {submitted ? (
@@ -100,19 +119,56 @@ export default function RequestAccessButton() {
                   </p>
                 </div>
 
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                      First name <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={firstName}
+                      onChange={e => setFirstName(e.target.value)}
+                      required
+                      maxLength={60}
+                      autoComplete="given-name"
+                      className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                      Last name <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={lastName}
+                      onChange={e => setLastName(e.target.value)}
+                      required
+                      maxLength={60}
+                      autoComplete="family-name"
+                      className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                </div>
+
                 <div className="space-y-1">
                   <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                    Your name <span className="text-red-500">*</span>
+                    Desired username <span className="text-red-500">*</span>
                   </label>
                   <input
                     type="text"
-                    value={name}
-                    onChange={e => setName(e.target.value)}
+                    value={username}
+                    onChange={e => setUsername(e.target.value.toLowerCase())}
                     required
-                    maxLength={120}
-                    autoComplete="name"
+                    minLength={1}
+                    maxLength={60}
+                    pattern="[a-z0-9._\-]{1,60}"
+                    autoComplete="username"
+                    placeholder="e.g. max.mustermann"
                     className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                    Your login — lowercase letters, digits, dots, underscores, and hyphens only. Can&apos;t be changed later.
+                  </p>
                 </div>
 
                 <div className="space-y-1">

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -356,10 +356,26 @@ export interface AccessRequest {
   id: string;
   /** ISO timestamp of when the form was submitted. */
   requestedAt: string;
+  /**
+   * Display name. Originally a single free-text field; newer requests
+   * compose this from firstName + lastName on submit but it remains
+   * the canonical "human-readable label" for old entries that don't
+   * carry the split fields.
+   */
   name: string;
   email: string;
   /** Optional "why" note from the requester. */
   message?: string;
+  /**
+   * Desired LLDAP login. Validated to `[a-z0-9._-]{1,60}` so it maps
+   * cleanly to LLDAP's `uid` without further sanitization. Optional
+   * for backward-compatibility with requests submitted before #405.
+   */
+  username?: string;
+  /** Given name — feeds LLDAP `firstName` when the admin approves. */
+  firstName?: string;
+  /** Family name — feeds LLDAP `lastName` when the admin approves. */
+  lastName?: string;
   status: 'pending' | 'resolved';
   /** ISO timestamp of when the admin marked it resolved. */
   resolvedAt?: string;


### PR DESCRIPTION
## Summary
- Portal request-access form now collects everything LLDAP needs to provision an account: `firstName`, `lastName`, desired `username`, plus the existing email + optional message.
- Username is validated against `[a-z0-9._-]{1,60}` on both client and server so it round-trips cleanly to LLDAP's `uid`.
- The pending-request rows in `Settings → Integrations` render the username as a monospace badge next to the name, so the admin can copy it into LLDAP without scrolling.
- New fields are optional in the `AccessRequest` model — old pending entries (submitted before this change) still render correctly.

Unblocks #406 (auto-create the LLDAP user on approve) since the API now has the username + profile data on hand.

Closes #405

## Test plan
- [ ] Open `/portal` while logged-out, click *Don't have an account yet?* → form shows first name, last name, username (with lowercase-coercion as you type), email, optional message.
- [ ] Submit with an invalid username (e.g. capital letters) → inline error, no POST.
- [ ] Submit a valid request → admin sees a new row in Settings → Integrations → Access requests with the username badge.
- [ ] Old pending requests (no `username` field) still render without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)