### PR TITLE
feat(access-requests): auto-create LLDAP user on approve

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Check, ExternalLink, Loader2, Mail, Trash2, UserPlus } from 'lucide-react';
+import { Check, ExternalLink, Loader2, Mail, Trash2, UserCheck, UserPlus } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 
 interface AccessRequest {
@@ -69,6 +69,26 @@ export default function AccessRequestsSection() {
     }
   };
 
+  const onApprove = async (id: string) => {
+    setBusy('action');
+    try {
+      const res = await fetch(`/api/system/access-requests/${id}/approve`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        addToast('success', 'User created in LLDAP', 'Assign groups in the LLDAP tab that just opened.');
+        if (typeof data.lldapUrl === 'string') {
+          window.open(data.lldapUrl, '_blank', 'noopener,noreferrer');
+        }
+        await load();
+      } else {
+        const message = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+        addToast('error', 'Could not approve', message);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
   const onDelete = async (id: string) => {
     if (!window.confirm('Delete this access request? Use for spam — there\'s no undo.')) return;
     setBusy('action');
@@ -112,7 +132,7 @@ export default function AccessRequestsSection() {
             )}
           </h3>
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            Family members on the LAN can submit a request from the portal at <span className="font-mono">/portal</span>. Create the user in LLDAP, then mark resolved.
+            Family members on the LAN can submit a request from the portal at <span className="font-mono">/portal</span>. Click <span className="font-medium">Approve</span> to provision the user in LLDAP and open their group-assignment page.
           </p>
         </div>
         {lldapUrl && (
@@ -142,6 +162,7 @@ export default function AccessRequestsSection() {
                     <RequestRow
                       key={r.id}
                       r={r}
+                      onApprove={() => onApprove(r.id)}
                       onResolve={() => onResolve(r.id)}
                       onDelete={() => onDelete(r.id)}
                       busy={busy === 'action'}
@@ -158,6 +179,7 @@ export default function AccessRequestsSection() {
                     <RequestRow
                       key={r.id}
                       r={r}
+                      onApprove={() => onApprove(r.id)}
                       onResolve={() => onResolve(r.id)}
                       onDelete={() => onDelete(r.id)}
                       busy={busy === 'action'}
@@ -176,17 +198,20 @@ export default function AccessRequestsSection() {
 
 function RequestRow({
   r,
+  onApprove,
   onResolve,
   onDelete,
   busy,
   muted,
 }: {
   r: AccessRequest;
+  onApprove: () => void;
   onResolve: () => void;
   onDelete: () => void;
   busy: boolean;
   muted?: boolean;
 }) {
+  const canAutoApprove = Boolean(r.username);
   return (
     <div className={`p-3 rounded-lg border border-gray-200 dark:border-gray-700 ${muted ? 'opacity-60' : 'bg-white dark:bg-gray-900'}`}>
       <div className="flex items-start gap-3">
@@ -211,12 +236,22 @@ function RequestRow({
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          {r.status === 'pending' && canAutoApprove && (
+            <button
+              onClick={onApprove}
+              disabled={busy}
+              className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded disabled:opacity-50"
+              title="Provision the user in LLDAP and open the group assignment page"
+            >
+              <UserCheck size={14} /> Approve
+            </button>
+          )}
           {r.status === 'pending' && (
             <button
               onClick={onResolve}
               disabled={busy}
               className="p-1.5 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded disabled:opacity-50"
-              title="Mark resolved (after creating the LLDAP user)"
+              title={canAutoApprove ? 'Mark resolved without creating the LLDAP user' : 'Mark resolved (after creating the LLDAP user)'}
             >
               <Check size={16} />
             </button>

--- a/src/app/api/system/access-requests/[id]/approve/route.ts
+++ b/src/app/api/system/access-requests/[id]/approve/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { getConfig, saveConfig } from '@/lib/config';
+import { createLldapUser, getLldapUserDeepLink } from '@/lib/lldap/client';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * One-click approval for an access request (#406).
+ *
+ * Flow:
+ *   1. Look up the pending request by id.
+ *   2. Provision the user in LLDAP via GraphQL using the username +
+ *      profile data captured by #405. No password is set — the user
+ *      enrolls via LLDAP's "Forgot password" flow on first login.
+ *   3. Mark the request resolved.
+ *   4. Return the LLDAP user detail URL so the UI can open the group
+ *      assignment page in a new tab — that's the only manual step
+ *      that remains for the admin.
+ *
+ * Fallback: if the request was submitted before #405 and has no
+ * username, the route refuses (412) and the UI keeps the legacy
+ * manual workflow. The route never partially commits — if LLDAP
+ * rejects the create, the request stays pending so the admin can
+ * fix the conflict (e.g. picking a different username) and retry.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const config = await getConfig();
+  const requests = [...(config.accessRequests ?? [])];
+  const idx = requests.findIndex(r => r.id === id);
+  if (idx < 0) {
+    return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
+  }
+  const req = requests[idx];
+  if (req.status !== 'pending') {
+    return NextResponse.json({ error: 'Request is not pending.' }, { status: 409 });
+  }
+  if (!req.username) {
+    return NextResponse.json(
+      {
+        error: 'This request has no username — it was submitted before the profile fields were added. Create the LLDAP user manually and click "Mark resolved".',
+        reason: 'missing_username',
+      },
+      { status: 412 },
+    );
+  }
+
+  const created = await createLldapUser({
+    id: req.username,
+    email: req.email,
+    displayName: req.firstName && req.lastName ? `${req.firstName} ${req.lastName}` : req.name,
+    firstName: req.firstName,
+    lastName: req.lastName,
+  });
+
+  if (!created.ok) {
+    logger.warn('access-requests:approve', `LLDAP create failed for ${req.username}: ${created.message}`);
+    return NextResponse.json(
+      { error: created.message, reason: created.reason },
+      { status: created.reason === 'username_taken' ? 409 : 502 },
+    );
+  }
+
+  requests[idx] = {
+    ...req,
+    status: 'resolved',
+    resolvedAt: new Date().toISOString(),
+  };
+  await saveConfig({ ...config, accessRequests: requests });
+  logger.info('access-requests:approve', `Provisioned LLDAP user ${req.username} for ${req.email}`);
+
+  const deepLink = await getLldapUserDeepLink(req.username);
+  return NextResponse.json({ ok: true, lldapUrl: deepLink });
+}

--- a/src/lib/lldap/client.ts
+++ b/src/lib/lldap/client.ts
@@ -1,0 +1,137 @@
+/**
+ * Minimal LLDAP GraphQL client used by features that need to provision
+ * users from elsewhere in ServiceBay (e.g. access-request approval,
+ * #406). The seed route still has its own inline auth/group helpers
+ * because it runs during the wizard before `config.lldap` is
+ * populated; this module assumes credentials are already persisted.
+ *
+ * Returns structured `{ ok, ... }` discriminated unions instead of
+ * throwing so callers can render a useful error in the UI without
+ * inspecting exception strings.
+ */
+import { getConfig } from '@/lib/config';
+
+const AUTH_TIMEOUT_MS = 10_000;
+const GRAPHQL_TIMEOUT_MS = 10_000;
+
+const CREATE_USER_MUTATION = `
+  mutation CreateUser($user: CreateUserInput!) {
+    createUser(user: $user) {
+      id
+      displayName
+      email
+    }
+  }
+`;
+
+interface LldapCredentials {
+  url: string;
+  username: string;
+  password: string;
+}
+
+type LldapAuthResult =
+  | { ok: true; token: string; baseUrl: string }
+  | { ok: false; reason: 'not_configured' | 'unreachable' | 'auth_failed'; message: string };
+
+export type LldapCreateUserResult =
+  | { ok: true; userId: string; displayName: string }
+  | { ok: false; reason: 'username_taken' | 'graphql_error' | 'network_error'; message: string };
+
+export interface CreateUserInput {
+  id: string;
+  email: string;
+  displayName?: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+function readCredentials(): Promise<LldapCredentials | null> {
+  return getConfig().then(config => {
+    const lldap = config.lldap;
+    if (!lldap?.url || !lldap.password) return null;
+    return { url: lldap.url, username: lldap.username || 'admin', password: lldap.password };
+  });
+}
+
+async function authenticateWithLldap(): Promise<LldapAuthResult> {
+  const creds = await readCredentials();
+  if (!creds) {
+    return { ok: false, reason: 'not_configured', message: 'LLDAP admin credentials are not stored. Open Settings → Integrations to configure LLDAP first.' };
+  }
+  const baseUrl = creds.url.replace(/\/$/, '');
+  try {
+    const res = await fetch(`${baseUrl}/auth/simple/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: creds.username, password: creds.password }),
+      signal: AbortSignal.timeout(AUTH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return { ok: false, reason: 'auth_failed', message: `LLDAP rejected the stored credentials (HTTP ${res.status}). Update them in Settings → Integrations.` };
+    }
+    const data = await res.json().catch(() => ({})) as { token?: string };
+    if (!data.token) {
+      return { ok: false, reason: 'auth_failed', message: 'LLDAP login response was missing a token.' };
+    }
+    return { ok: true, token: data.token, baseUrl };
+  } catch (e) {
+    return { ok: false, reason: 'unreachable', message: e instanceof Error ? e.message : 'Could not reach LLDAP.' };
+  }
+}
+
+export async function createLldapUser(input: CreateUserInput): Promise<LldapCreateUserResult> {
+  const auth = await authenticateWithLldap();
+  if (!auth.ok) {
+    return {
+      ok: false,
+      reason: auth.reason === 'not_configured' || auth.reason === 'unreachable' ? 'network_error' : 'graphql_error',
+      message: auth.message,
+    };
+  }
+  try {
+    const res = await fetch(`${auth.baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.token}`,
+      },
+      body: JSON.stringify({
+        query: CREATE_USER_MUTATION,
+        variables: { user: input },
+      }),
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+    const data = await res.json().catch(() => ({})) as {
+      data?: { createUser?: { id: string; displayName?: string } };
+      errors?: Array<{ message?: string }>;
+    };
+    if (data.errors?.length) {
+      const msg = data.errors[0]?.message ?? 'Unknown LLDAP error.';
+      const lower = msg.toLowerCase();
+      if (lower.includes('already exists') || lower.includes('duplicate')) {
+        return { ok: false, reason: 'username_taken', message: `The username "${input.id}" is already in use in LLDAP.` };
+      }
+      return { ok: false, reason: 'graphql_error', message: msg };
+    }
+    const created = data.data?.createUser;
+    if (!created) {
+      return { ok: false, reason: 'graphql_error', message: 'LLDAP response did not include the created user.' };
+    }
+    return { ok: true, userId: created.id, displayName: created.displayName ?? input.displayName ?? input.id };
+  } catch (e) {
+    return { ok: false, reason: 'network_error', message: e instanceof Error ? e.message : 'Network error talking to LLDAP.' };
+  }
+}
+
+/**
+ * LLDAP's web UI URL for a specific user's detail page — used as the
+ * deep-link target after auto-create so the admin lands directly on
+ * the group-assignment view.
+ */
+export async function getLldapUserDeepLink(userId: string): Promise<string | null> {
+  const config = await getConfig();
+  const url = config.lldap?.url;
+  if (!url) return null;
+  return `${url.replace(/\/$/, '')}/user/${encodeURIComponent(userId)}`;
+}


### PR DESCRIPTION
## Summary
- New `POST /api/system/access-requests/[id]/approve` provisions the LLDAP user via GraphQL `createUser` using the username + profile fields captured by #405, then flips the request to resolved in one transaction.
- The route responds with a deep-link to the LLDAP user-detail page; the Settings UI opens that link in a new tab so the admin lands directly on group assignment.
- Account is created with no password — the new user picks one via LLDAP's password-reset flow (called out for the follow-up confirmation email in #407).
- Falls back gracefully: requests predating #405 (no `username` on file) hide the Approve button and keep the legacy "Mark resolved" workflow; LLDAP errors (username taken, network failure) surface as toasts and leave the request pending so the admin can retry.

Stacked on #405 (`feat/issue-405-access-request-profile-fields`). Retarget to `main` before merging if #405 lands first.

Closes #406

## Test plan
- [ ] Submit a portal access request with a unique username → admin clicks Approve → LLDAP user appears in LLDAP UI; request shows as resolved; LLDAP tab opens on the user's detail page.
- [ ] Submit a second request with the same username → Approve surfaces a "username already in use" toast; request stays pending.
- [ ] Stop the LLDAP container, click Approve → toast describes the unreachable error; request stays pending.
- [ ] Migrate or hand-edit a legacy pending request with no `username` field → only the legacy "Mark resolved" check is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)