### PR TITLE
feat(access-requests): confirmation email to requester on approve

### DIFF
--- a/src/app/api/system/access-requests/[id]/approve/route.ts
+++ b/src/app/api/system/access-requests/[id]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getConfig, saveConfig } from '@/lib/config';
 import { createLldapUser, getLldapUserDeepLink } from '@/lib/lldap/client';
+import { sendTransactionalEmail } from '@/lib/email';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -72,6 +73,32 @@ export async function POST(
   };
   await saveConfig({ ...config, accessRequests: requests });
   logger.info('access-requests:approve', `Provisioned LLDAP user ${req.username} for ${req.email}`);
+
+  // Best-effort confirmation to the requester. No-ops cleanly when
+  // email isn't configured — we still return success because the
+  // LLDAP user *is* created and the admin can hand-deliver the URL.
+  const publicDomain = config.reverseProxy?.publicDomain;
+  const lanDomain = config.reverseProxy?.lanDomain;
+  const portalBase = publicDomain
+    ? `https://admin.${publicDomain}`
+    : lanDomain
+      ? `http://admin.${lanDomain}`
+      : null;
+  const greetingName = req.firstName ?? req.name;
+  const loginHint = portalBase
+    ? `Login here: ${portalBase}/portal\n\n`
+    : '';
+  void sendTransactionalEmail(
+    req.email,
+    'Your home server account is ready',
+    [
+      `Hi ${greetingName},`,
+      ``,
+      `Your account has been approved. Your username is "${req.username}".`,
+      ``,
+      `${loginHint}First time signing in? Click "Forgot password" on the login page — you'll get an email to set your password.`,
+    ].join('\n'),
+  );
 
   const deepLink = await getLldapUserDeepLink(req.username);
   return NextResponse.json({ ok: true, lldapUrl: deepLink });

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,7 +1,42 @@
 import nodemailer from 'nodemailer';
 import { getConfig } from './config';
 
+/**
+ * Operator-facing alert email. Always goes to the operator addresses
+ * configured under `notifications.email.to` and is decorated with the
+ * `[ServiceBay Alert]` subject prefix so the operator's inbox rules
+ * can route them.
+ */
 export async function sendEmailAlert(subject: string, message: string) {
+  await sendMailInternal({
+    subject: `[ServiceBay Alert] ${subject}`,
+    message,
+    headingColor: '#e53e3e',
+  });
+}
+
+/**
+ * Transactional email to a specific recipient — used for confirmations
+ * the operator's family members receive (e.g. access-request approval,
+ * welcome emails). Unlike `sendEmailAlert` this does not prefix the
+ * subject and uses a friendlier heading color, because the recipient
+ * is a non-technical user, not the operator triaging system alerts.
+ */
+export async function sendTransactionalEmail(to: string, subject: string, message: string) {
+  await sendMailInternal({
+    overrideTo: to,
+    subject,
+    message,
+    headingColor: '#3182ce',
+  });
+}
+
+async function sendMailInternal(opts: {
+  overrideTo?: string;
+  subject: string;
+  message: string;
+  headingColor: string;
+}) {
   const config = await getConfig();
   const emailConfig = config.notifications?.email;
 
@@ -20,21 +55,22 @@ export async function sendEmailAlert(subject: string, message: string) {
       },
     });
 
+    const recipient = opts.overrideTo ?? emailConfig.to.join(', ');
     await transporter.sendMail({
       from: emailConfig.from,
-      to: emailConfig.to.join(', '), // Join with comma for better compatibility
-      subject: `[ServiceBay Alert] ${subject}`,
-      text: message,
+      to: recipient,
+      subject: opts.subject,
+      text: opts.message,
       html: `<div style="font-family: sans-serif; padding: 20px; border: 1px solid #eee; border-radius: 5px;">
-        <h2 style="color: #e53e3e;">${subject}</h2>
-        <p style="font-size: 16px; line-height: 1.5;">${message.replace(/\n/g, '<br>')}</p>
+        <h2 style="color: ${opts.headingColor};">${opts.subject}</h2>
+        <p style="font-size: 16px; line-height: 1.5;">${opts.message.replace(/\n/g, '<br>')}</p>
         <hr style="border: 0; border-top: 1px solid #eee; margin: 20px 0;">
-        <p style="color: #718096; font-size: 12px;">Sent by ServiceBay Health</p>
+        <p style="color: #718096; font-size: 12px;">Sent by ServiceBay</p>
       </div>`
     });
 
-    console.log(`[Email] Sent alert to ${emailConfig.to}`);
+    console.log(`[Email] Sent to ${recipient}`);
   } catch (error) {
-    console.error('[Email] Failed to send alert:', error);
+    console.error('[Email] Failed to send:', error);
   }
 }


### PR DESCRIPTION
## Summary
- After the approve route provisions a new LLDAP user, it now best-effort emails the requester their username, the portal URL, and a hint to use "Forgot password" on first sign-in (LLDAP creates accounts without a password).
- New `sendTransactionalEmail(to, subject, body)` helper alongside `sendEmailAlert` so confirmation mail addressed to a family member doesn't carry the operator-facing `[ServiceBay Alert]` subject prefix or alert-red heading.
- No-ops cleanly when SMTP isn't configured — approve still succeeds because the LLDAP user is already created.

Stacked on #406 (which is stacked on #405). Retarget to the appropriate base before merging if those land first.

Closes #407

## Test plan
- [ ] With SMTP configured, click Approve on a pending request → requester receives an email titled "Your home server account is ready" with their username and a portal link.
- [ ] Without SMTP configured, approve still returns 200, LLDAP user is created, no email is attempted.
- [ ] On a `lan`-only install (no `publicDomain`), the email links to `http://admin.<lanDomain>/portal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)