### PR TITLE
fix(vaultwarden): hostNetwork so SSO discovery works

### DIFF
--- a/templates/vaultwarden/CHANGELOG.md
+++ b/templates/vaultwarden/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Vaultwarden — template changelog
+
+## v2 (breaking) — #408
+
+Vaultwarden now runs under `hostNetwork: true` instead of Podman's
+bridge network. This is required for the SSO sign-in flow to work:
+under bridge networking, the container resolves
+`https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration` to the
+router's WAN IP and the OIDC-discovery request fails (most home
+routers don't hairpin NAT). Under `hostNetwork` Vaultwarden inherits
+the host's DNS resolver — AdGuard rewrites `*.<PUBLIC_DOMAIN>` to the
+LAN IP, so discovery goes through NPM → Authelia and succeeds.
+
+Operator impact: nothing on disk moved; the redeploy applies the new
+pod definition and the SSO login starts working again. If you don't
+use SSO (`VAULTWARDEN_SSO_ENABLED=false`), the change is still safe —
+Vaultwarden now binds `VAULTWARDEN_PORT` directly on the host instead
+of via Podman's port-forwarding shim, which is what NPM already
+proxies to.

--- a/templates/vaultwarden/migrations/v1-to-v2.py
+++ b/templates/vaultwarden/migrations/v1-to-v2.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Migration: vaultwarden v1 → v2 (#408).
+
+What changed between v1 and v2: the pod moved from Podman bridge
+networking to `hostNetwork: true`, and Vaultwarden's Rocket server
+now listens directly on `VAULTWARDEN_PORT` on the host instead of
+behind a `hostPort:` shim. No data on disk moves — the volume mount
+at `${DATA_DIR}/vaultwarden` is unchanged.
+
+What this script does:
+  - Inform the operator that the redeploy will rebind the port at
+    the host level. Existing NPM proxy hosts continue to forward
+    to `127.0.0.1:VAULTWARDEN_PORT` so the user-visible URL stays
+    the same.
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
+
+This script is intentionally read-only — it just logs guidance.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 1
+  - NEW_SCHEMA_VERSION = 2
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (PUBLIC_DOMAIN, VAULTWARDEN_PORT, …)
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    port = os.environ.get("VAULTWARDEN_PORT", "8222")
+    print(f"Vaultwarden v1 → v2: switching to hostNetwork (#408).")
+    print(f"  Rocket will bind {port}/tcp directly on the host so SSO discovery")
+    print(f"  reaches https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration")
+    print(f"  via the host's resolver (AdGuard rewrites). NPM proxy routes that")
+    print(f"  forward to 127.0.0.1:{port} keep working unchanged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -6,12 +6,22 @@ metadata:
     app: vaultwarden
   annotations:
     servicebay.label: "Vaultwarden (Passwords)"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
+    servicebay.ports: "{{VAULTWARDEN_PORT}}/tcp"
     # Install order: proxy + SSO foundation needs to land first so the
     # post-deploy OIDC-client registration can talk to Authelia and the
     # vault.<domain> proxy route resolves to a running NPM.
     servicebay.dependencies: "nginx,auth"
 spec:
+  # v2 (#408): hostNetwork is required so Vaultwarden can reach
+  # https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration for
+  # OIDC discovery. Under bridge networking the container resolves the
+  # public auth subdomain to the router's WAN IP and the request fails
+  # (most home routers don't hairpin NAT). Under hostNetwork the
+  # container inherits the host's resolver, which AdGuard rewrites
+  # *.PUBLIC_DOMAIN to the LAN IP — so the OIDC discovery request goes
+  # NPM → Authelia → success.
+  hostNetwork: true
   containers:
   - name: vaultwarden
     image: docker.io/vaultwarden/server:latest
@@ -35,9 +45,18 @@ spec:
       value: "{{VAULTWARDEN_SSO_SECRET}}"
     - name: SSO_SCOPES
       value: "email profile"
+    # Vaultwarden listens on port 80 by default. Under hostNetwork that
+    # collides with NPM's HTTP listener — point Rocket at the operator's
+    # configured port so it binds directly there on the host.
+    - name: ROCKET_PORT
+      value: "{{VAULTWARDEN_PORT}}"
+    # `hostPort:` is invalid under hostNetwork (podman rejects with
+    # "PortMappings can only be used with Bridge, slirp4netns, or pasta
+    # networking"). The servicebay.ports annotation above carries the
+    # port for the UI / network graph; the container now binds
+    # {{VAULTWARDEN_PORT}} directly on the host.
     ports:
-    - containerPort: 80
-      hostPort: {{VAULTWARDEN_PORT}}
+    - containerPort: {{VAULTWARDEN_PORT}}
     volumeMounts:
     - mountPath: /data
       name: vaultwarden-data


### PR DESCRIPTION
## Summary
- Switch the Vaultwarden pod from Podman bridge networking to `hostNetwork: true` so OIDC discovery against `https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration` succeeds. Under bridge networking the container resolves the public auth subdomain to the router's WAN IP and the discovery request dies on missing hairpin NAT — under hostNetwork it uses the host's resolver, AdGuard rewrites `*.<PUBLIC_DOMAIN>` to the LAN IP, and the request flows NPM → Authelia.
- `hostPort:` is invalid with hostNetwork (podman rejects with *"PortMappings can only be used with Bridge, slirp4netns, or pasta networking"*), so port mapping moved to the existing `servicebay.ports` annotation and `ROCKET_PORT={{VAULTWARDEN_PORT}}` makes Rocket bind the operator's chosen port directly on the host. NPM proxy routes that forward to `127.0.0.1:VAULTWARDEN_PORT` keep working — user-visible URL is unchanged.
- Bumped `servicebay.schema-version` to `2`, added `CHANGELOG.md` (breaking — operator should redeploy Vaultwarden), and added an informational `migrations/v1-to-v2.py`.

Same pattern that nginx and the auth pod already use.

Closes #408

## Test plan
- [ ] Fresh install: deploy Vaultwarden → pod comes up healthy on hostNetwork → `https://vault.<PUBLIC_DOMAIN>` opens → "Login with SSO" completes without "Failed to discover OpenID provider".
- [ ] Existing install on v1: redeploy via Services → Vaultwarden → migration script logs the upgrade notice, schema-version moves to v2, SSO login starts working.
- [ ] `VAULTWARDEN_SSO_ENABLED=false`: redeploy on the new template still works — Vaultwarden binds `VAULTWARDEN_PORT` directly, NPM continues to proxy to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)