### PR TITLE
fix(immich): admin seed + OIDC wiring + hostNetwork

### DIFF
--- a/templates/immich/CHANGELOG.md
+++ b/templates/immich/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Immich — template changelog
+
+## v2 (breaking) — #410
+
+Three changes land together because they all sit on the same SSO path:
+
+1. **Admin seed.** A new `post-deploy.py` waits for Immich to become
+   ready, then creates the initial admin user via
+   `/api/auth/admin-sign-up` using the new `IMMICH_ADMIN_NAME`,
+   `IMMICH_ADMIN_EMAIL`, and `IMMICH_ADMIN_PASSWORD` variables. The
+   password is surfaced in the post-install credentials banner. Before
+   v2 the operator landed on Immich's first-run sign-up screen
+   themselves.
+
+2. **OIDC client secret + auto-config.** `variables.json` now declares
+   `IMMICH_SSO_SECRET` (auto-generated) and pins it via
+   `clientSecretVar`, so the same secret is in Authelia's `clients[]`
+   entry and in Immich's system config. The post-deploy logs in as the
+   seeded admin and PUTs `/api/system-config` to enable OAuth against
+   `https://auth.<PUBLIC_DOMAIN>` with `autoRegister: true` and
+   button text "Login with Authelia". Before v2 the wizard generated
+   a secret on Authelia's side but Immich never learned what it was.
+
+3. **`hostNetwork: true`.** Same hairpin-NAT trap as Vaultwarden (#408):
+   under bridge networking the container resolved `auth.<PUBLIC_DOMAIN>`
+   to the router's WAN IP and OIDC discovery failed. Under hostNetwork
+   Immich uses the host resolver and AdGuard rewrites send the
+   discovery request to NPM → Authelia. Side-effect: redis + postgres
+   sidecars are now pinned to `127.0.0.1` via `--bind` / `-c
+   listen_addresses=127.0.0.1` so they remain accessible to
+   immich-server over loopback without being exposed on the LAN.
+
+Operator impact: redeploy regenerates the env file, the wizard fills
+in the new admin + SSO variables (or you set them manually). After
+the redeploy the post-deploy script runs once and emits the admin
+credential — fold that into your password manager and you can either
+sign in locally or click *Login with Authelia* on the Immich login
+page.

--- a/templates/immich/migrations/v1-to-v2.py
+++ b/templates/immich/migrations/v1-to-v2.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Migration: immich v1 → v2 (#410).
+
+What changed between v1 and v2:
+  - The pod moved from Podman bridge networking to `hostNetwork: true`
+    so OIDC discovery against `https://auth.<PUBLIC_DOMAIN>` works.
+  - Three new wizard variables: IMMICH_ADMIN_NAME / IMMICH_ADMIN_EMAIL
+    / IMMICH_ADMIN_PASSWORD seed the initial admin user.
+  - A new IMMICH_SSO_SECRET pins the OIDC client secret so Authelia
+    and Immich share the same value.
+  - A new post-deploy.py runs admin sign-up + system-config OAuth wiring.
+
+No on-disk data moves — the upload, model-cache, and pgdata volumes
+keep their paths under `${DATA_DIR}/immich/`.
+
+What this script does:
+  - Inform the operator that the redeploy will rebind IMMICH_PORT at
+    the host level (no NPM proxy changes needed).
+  - If they had run v1 and already created an Immich admin via the
+    first-run sign-up screen, flag that the new post-deploy will see
+    a 400 on its idempotent re-seed and skip — no data loss.
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    port = os.environ.get("IMMICH_PORT", "2283")
+    print("Immich v1 → v2: switching to hostNetwork + adding admin/OIDC auto-config (#410).")
+    print(f"  immich-server will bind {port}/tcp directly on the host so OIDC discovery")
+    print("  against auth.<PUBLIC_DOMAIN> reaches Authelia via AdGuard rewrites.")
+    print("  Redis + postgres sidecars are pinned to 127.0.0.1 so they stay off the LAN.")
+    print("  If you already created an admin via Immich's first-run screen, the new")
+    print("  post-deploy.py will see a 400 on its idempotent re-seed and leave that")
+    print("  account untouched — no data loss.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `immich` stack (#410).
+
+What this does:
+  1. Wait for Immich server to report ready on http://127.0.0.1:IMMICH_PORT.
+  2. Idempotently seed the initial admin account via /api/auth/admin-sign-up.
+     If the admin already exists (returning installs, re-runs after success),
+     the endpoint returns 400 — we log and continue.
+  3. Log in as that admin and PUT /api/system-config to enable OAuth pointed
+     at https://auth.<PUBLIC_DOMAIN> with the same client secret the wizard
+     pushed into Authelia's clients[] via `clientSecretVar: IMMICH_SSO_SECRET`.
+  4. Emit `__SB_CREDENTIAL__` for the seeded admin so the operator can sign
+     in once and immediately switch to SSO from the settings UI.
+
+Without this script, the operator hits Immich's first-run sign-up screen
+themselves and SSO has to be wired up by hand. See lib/registry.ts:
+getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+READY_TIMEOUT = 180.0
+READY_INTERVAL = 2.0
+REQUEST_TIMEOUT = 30.0
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def request_json(method: str, url: str, payload: object | None = None, token: str | None = None, timeout: float = REQUEST_TIMEOUT) -> tuple[int, object | None]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(raw) if raw else None
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, None
+
+
+def wait_ready(base_url: str) -> bool:
+    """Poll Immich's /api/server-info until it returns 200, then return True."""
+    started = time.time()
+    while time.time() - started < READY_TIMEOUT:
+        code, _ = request_json("GET", f"{base_url}/api/server-info")
+        if code == 200:
+            return True
+        time.sleep(READY_INTERVAL)
+    return False
+
+
+def main() -> int:
+    port = env("IMMICH_PORT", "2283")
+    base_url = f"http://127.0.0.1:{port}"
+    public_domain = env("PUBLIC_DOMAIN")
+    sso_enabled = env("IMMICH_SSO_ENABLED") == "true"
+    sso_secret = env("IMMICH_SSO_SECRET")
+    admin_name = env("IMMICH_ADMIN_NAME", "Admin")
+    admin_email = env("IMMICH_ADMIN_EMAIL")
+    admin_password = env("IMMICH_ADMIN_PASSWORD")
+    subdomain = env("IMMICH_SUBDOMAIN", "photos")
+    public_url = f"https://{subdomain}.{public_domain}" if public_domain else base_url
+
+    log(f"Waiting up to {int(READY_TIMEOUT)}s for Immich at {base_url}…")
+    if not wait_ready(base_url):
+        log(f"❌ Immich did not become ready within {int(READY_TIMEOUT)}s — skipping seed/OIDC config.")
+        return 1
+    log("✅ Immich is ready.")
+
+    if not admin_email or not admin_password:
+        log("⚠️  IMMICH_ADMIN_EMAIL / IMMICH_ADMIN_PASSWORD not set — skipping admin seed and OIDC config. Re-run the wizard to regenerate them.")
+        return 0
+
+    # 1. Seed admin (idempotent — 400 means an admin already exists).
+    code, body = request_json(
+        "POST",
+        f"{base_url}/api/auth/admin-sign-up",
+        {"name": admin_name, "email": admin_email, "password": admin_password},
+    )
+    if code in (200, 201):
+        log(f"✅ Created Immich admin {admin_email}.")
+        emit_credential(
+            service="Immich",
+            url=public_url,
+            username=admin_email,
+            password=admin_password,
+            importance="critical",
+            notes="Initial admin password — rotate after first sign-in or switch to SSO.",
+        )
+    elif code == 400:
+        log("ℹ️  Immich admin already exists — leaving it alone.")
+    else:
+        log(f"⚠️  Immich admin sign-up returned HTTP {code}: {body}. Continuing.")
+
+    # 2. Log in to fetch a token for the system-config call.
+    code, body = request_json(
+        "POST",
+        f"{base_url}/api/auth/login",
+        {"email": admin_email, "password": admin_password},
+    )
+    token = body.get("accessToken") if isinstance(body, dict) else None
+    if code != 201 or not token:
+        log(f"⚠️  Could not log in as admin (HTTP {code}). Skipping OIDC config.")
+        return 0
+
+    # 3. Configure OAuth. Read-modify-write so we don't clobber any
+    #    fields Immich expects to be present in the system config.
+    if not sso_enabled:
+        log("ℹ️  IMMICH_SSO_ENABLED=false — skipping OAuth configuration.")
+        return 0
+    if not sso_secret or not public_domain:
+        log("⚠️  Missing IMMICH_SSO_SECRET or PUBLIC_DOMAIN — skipping OAuth configuration.")
+        return 0
+
+    code, current = request_json("GET", f"{base_url}/api/system-config", token=token)
+    if code != 200 or not isinstance(current, dict):
+        log(f"⚠️  Could not read /api/system-config (HTTP {code}). Skipping OAuth update.")
+        return 0
+
+    current["oauth"] = {
+        "enabled": True,
+        "issuerUrl": f"https://auth.{public_domain}",
+        "clientId": "immich",
+        "clientSecret": sso_secret,
+        "scope": "openid profile email",
+        "buttonText": "Login with Authelia",
+        "autoRegister": True,
+        # Keep the password field visible so the operator can still log in
+        # locally if SSO breaks; flip to True later via the Immich UI.
+        "autoLaunch": False,
+        "signingAlgorithm": "RS256",
+        "mobileOverrideEnabled": False,
+        "mobileRedirectUri": "",
+        "storageLabelClaim": "preferred_username",
+        "storageQuotaClaim": "immich_quota",
+    }
+
+    code, body = request_json("PUT", f"{base_url}/api/system-config", current, token=token)
+    if code in (200, 201):
+        log(f"✅ Immich OIDC configured against https://auth.{public_domain}.")
+    else:
+        log(f"⚠️  Could not write OIDC config (HTTP {code}): {body}.")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -6,16 +6,36 @@ metadata:
     app: immich
   annotations:
     servicebay.label: "Immich (Photos)"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
+    servicebay.ports: "{{IMMICH_PORT}}/tcp"
     # photos.<domain> is served via nginx; Immich's SSO uses Authelia.
     servicebay.dependencies: "nginx,auth"
 spec:
+  # v2 (#410): hostNetwork is required so Immich can fetch
+  # https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration for
+  # OIDC discovery. Under bridge networking the container resolves the
+  # public auth subdomain to the router's WAN IP and the request fails
+  # (most home routers don't hairpin NAT). Under hostNetwork Immich
+  # inherits the host resolver and AdGuard rewrites *.<PUBLIC_DOMAIN>
+  # to the LAN IP — same pattern Vaultwarden uses (#408).
+  #
+  # Side-effect for the sidecars: redis + postgres now share the host
+  # network namespace. The args overrides below pin both to 127.0.0.1
+  # so they stay reachable for immich-server / machine-learning via
+  # loopback without being exposed on the LAN.
+  hostNetwork: true
   containers:
     - name: immich-server
       image: ghcr.io/immich-app/immich-server:release
       env:
+        # Under hostNetwork `hostPort:` is invalid — IMMICH_PORT here
+        # makes the server bind {{IMMICH_PORT}} directly on the host;
+        # the servicebay.ports annotation documents it for the UI /
+        # network graph.
+        - name: IMMICH_PORT
+          value: "{{IMMICH_PORT}}"
         - name: DB_HOSTNAME
-          value: "localhost"
+          value: "127.0.0.1"
         - name: DB_USERNAME
           value: "postgres"
         - name: DB_PASSWORD
@@ -23,12 +43,11 @@ spec:
         - name: DB_DATABASE_NAME
           value: "immich"
         - name: REDIS_HOSTNAME
-          value: "localhost"
+          value: "127.0.0.1"
         - name: IMMICH_MACHINE_LEARNING_URL
-          value: "http://localhost:3003"
+          value: "http://127.0.0.1:3003"
       ports:
-        - containerPort: 2283
-          hostPort: {{IMMICH_PORT}}
+        - containerPort: {{IMMICH_PORT}}
       volumeMounts:
         - mountPath: /usr/src/app/upload
           name: immich-upload
@@ -41,9 +60,15 @@ spec:
 
     - name: redis
       image: docker.io/redis:6.2-alpine
+      # Pin redis to loopback so hostNetwork doesn't accidentally
+      # expose it on the LAN. immich-server reaches it via 127.0.0.1.
+      args: ["--bind", "127.0.0.1", "--protected-mode", "yes"]
 
     - name: database
       image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0
+      # Postgres image defaults to listen_addresses='*'. Override to
+      # localhost-only so the sidecar isn't reachable from the LAN.
+      args: ["postgres", "-c", "listen_addresses=127.0.0.1"]
       env:
         - name: POSTGRES_PASSWORD
           value: "{{DB_PASSWORD}}"

--- a/templates/immich/variables.json
+++ b/templates/immich/variables.json
@@ -8,6 +8,35 @@
     "description": "Web UI port",
     "default": "2283"
   },
+  "IMMICH_ADMIN_NAME": {
+    "type": "text",
+    "description": "Display name for the seeded Immich admin user. Used in the first-run sign-up that runs in post-deploy.",
+    "default": "Admin"
+  },
+  "IMMICH_ADMIN_EMAIL": {
+    "type": "text",
+    "description": "Email of the seeded Immich admin user — also doubles as the login. Set this to the operator's email so SSO auto-linking (matching by email) works on first sign-in.",
+    "default": ""
+  },
+  "IMMICH_ADMIN_PASSWORD": {
+    "type": "secret",
+    "description": "Initial password for the seeded Immich admin user. Auto-generated; surfaced in the post-install credentials banner so the operator can sign in once and immediately rotate or hand off to SSO."
+  },
+  "IMMICH_SSO_ENABLED": {
+    "type": "select",
+    "description": "Enable Immich ↔ Authelia SSO. On by default so family members sign in once with the household password. Flip to false if you hit an SSO regression and want to fall back to local Immich accounts.",
+    "options": ["true", "false"],
+    "default": "true"
+  },
+  "IMMICH_SSO_SECRET": {
+    "type": "secret",
+    "description": "OIDC client secret for Immich ↔ Authelia. Auto-generated; the wizard wires the same value into Authelia's clients[] entry and the Immich system-config OAuth section via post-deploy."
+  },
+  "PUBLIC_DOMAIN": {
+    "type": "text",
+    "description": "Public domain (used to build the SSO authority URL https://auth.<domain>)",
+    "default": "dopp.cloud"
+  },
   "IMMICH_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Immich",
@@ -25,7 +54,8 @@
       "client_name": "Immich",
       "authorization_policy": "one_factor",
       "redirect_uris": ["/auth/login", "/user-settings", "app.immich:/"],
-      "scopes": ["openid", "profile", "email"]
+      "scopes": ["openid", "profile", "email"],
+      "clientSecretVar": "IMMICH_SSO_SECRET"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `post-deploy.py` that idempotently seeds the initial Immich admin via `/api/auth/admin-sign-up` and configures OAuth against Authelia via `PUT /api/system-config`. Surfaces the admin password as a `__SB_CREDENTIAL__` so the operator can sign in once and switch to SSO.
- New wizard variables `IMMICH_ADMIN_NAME/EMAIL/PASSWORD`, `IMMICH_SSO_ENABLED`, and `IMMICH_SSO_SECRET`. Pins the OIDC client secret via `clientSecretVar` so Authelia and Immich share the same value (today's loop generates a secret for Authelia but Immich never sees it).
- Switches the pod to `hostNetwork: true` so OIDC discovery against `auth.<PUBLIC_DOMAIN>` works — same hairpin-NAT trap Vaultwarden hit in #408. Redis + postgres sidecars are pinned to `127.0.0.1` via `--bind` / `-c listen_addresses=127.0.0.1` so they stay off the LAN.
- Bumps schema-version to v2 with a CHANGELOG entry and an informational `migrations/v1-to-v2.py`.

Closes #410

## Test plan
- [ ] Fresh install: deploy Immich → post-deploy logs "Created Immich admin" → credentials banner shows the password → `https://photos.<domain>` opens straight to the login screen (no first-run admin form) → *Login with Authelia* button is visible and signs in successfully.
- [ ] Existing v1 install with a hand-created admin: redeploy via Services → Immich → migration script logs notice → post-deploy logs "Immich admin already exists" → OAuth still gets configured against Authelia.
- [ ] `IMMICH_SSO_ENABLED=false`: post-deploy still seeds the admin but skips the OAuth PUT.
- [ ] After redeploy, `ss -ltnp | grep -E ':5432|:6379'` shows postgres + redis bound only to 127.0.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)