### PR TITLE
fix(media): switch Navidrome from header-trust to OIDC

### DIFF
--- a/templates/media/CHANGELOG.md
+++ b/templates/media/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Media (Audiobookshelf + Navidrome) — template changelog
+
+## v2 (breaking) — #413
+
+Navidrome moves from reverse-proxy-auth to OIDC. The previous setup
+expected NPM to forward an Authelia-injected `Remote-User` header,
+but the proxy host was never configured with Authelia forward-auth —
+so the header never arrived, Navidrome's own login screen showed up,
+and only the local admin worked.
+
+What changed:
+
+- `variables.json` declares `NAVIDROME_OIDC_ENABLED`,
+  `NAVIDROME_OIDC_SECRET`, and an `oidcClient` block on
+  `NAVIDROME_SUBDOMAIN` pinned via `clientSecretVar`. The same secret
+  flows into Authelia's `clients[]` entry and Navidrome's env.
+- `template.yml` drops `ND_REVERSEPROXYUSERHEADER` /
+  `ND_REVERSEPROXYWHITELIST` and adds the Navidrome OIDC env vars
+  (`ND_OIDC_ENABLED`, `ND_OIDC_ISSUER`, `ND_OIDC_CLIENTID`,
+  `ND_OIDC_CLIENTSECRET`, `ND_OIDC_REDIRECTURL`, `ND_OIDC_AUTOREGISTER`).
+  Requires Navidrome v0.52 or newer.
+
+Operator impact: redeploy → Navidrome's login screen now shows a
+*Sign in with Authelia* button. LLDAP users land in Navidrome on
+first sign-in (auto-registered). Subsonic API clients (mobile apps)
+keep using the local admin account because Subsonic doesn't speak
+OIDC.
+
+If you specifically want the silent header-trust pattern back, you
+can re-add `ND_REVERSEPROXYUSERHEADER` after wiring NPM's
+`advanced_config` for Navidrome up with Authelia forward-auth — but
+that path isn't documented here, see issue #412 for the trade-offs.

--- a/templates/media/migrations/v1-to-v2.py
+++ b/templates/media/migrations/v1-to-v2.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Migration: media v1 → v2 (#413).
+
+Navidrome switches from reverse-proxy-auth (`Remote-User` header,
+never actually wired up) to OIDC against Authelia. No on-disk data
+moves — `${DATA_DIR}/media/navidrome` keeps its layout.
+
+What this script does:
+  - Inform the operator about the auth flip. Subsonic API clients
+    (mobile apps) keep using the local admin account because Subsonic
+    doesn't speak OIDC.
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    enabled = os.environ.get("NAVIDROME_OIDC_ENABLED", "true") == "true"
+    print("Media v1 → v2: Navidrome switching auth mode (#413).")
+    if enabled:
+        print("  Navidrome login screen will now offer 'Sign in with Authelia'.")
+        print("  LLDAP users land in Navidrome on first sign-in (autoregister).")
+    else:
+        print("  NAVIDROME_OIDC_ENABLED is false — keeping local-account login.")
+    print("  Subsonic API mobile clients (Symfonium etc.) continue to use the")
+    print("  Navidrome admin account because Subsonic doesn't speak OIDC.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -7,7 +7,7 @@ metadata:
     servicebay.role: media
   annotations:
     servicebay.label: "Media (Audiobookshelf + Navidrome)"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     # Audiobookshelf's post-deploy registers an OIDC client in Authelia
     # and its public URLs route through nginx — both prerequisites.
     servicebay.dependencies: "nginx,auth"
@@ -51,14 +51,27 @@ spec:
         value: "@every 1h"
       - name: ND_ENABLEUSEREDITING
         value: "true"
-      # Trust the X-Authelia-User header so the SSO login becomes the
-      # Navidrome login automatically. Bound to the loopback subnet
-      # because the proxy lives on the same host. Subsonic API calls
-      # (mobile apps) ignore this and use built-in user auth.
-      - name: ND_REVERSEPROXYUSERHEADER
-        value: Remote-User
-      - name: ND_REVERSEPROXYWHITELIST
-        value: 127.0.0.1/32
+      # OIDC against Authelia (v2 / #413). The previous
+      # ND_REVERSEPROXYUSERHEADER setup expected NPM to forward an
+      # Authelia-injected `Remote-User` header, but the proxy host was
+      # never wired up with Authelia forward-auth — so the header
+      # never arrived and only the local admin worked. OIDC is the
+      # consistent pattern across services in ServiceBay and lets
+      # Navidrome display an explicit "Sign in with Authelia" button.
+      # Subsonic API calls (mobile apps) bypass this and continue to
+      # use the local admin account.
+      - name: ND_OIDC_ENABLED
+        value: "{{NAVIDROME_OIDC_ENABLED}}"
+      - name: ND_OIDC_ISSUER
+        value: "https://auth.{{PUBLIC_DOMAIN}}"
+      - name: ND_OIDC_CLIENTID
+        value: "navidrome"
+      - name: ND_OIDC_CLIENTSECRET
+        value: "{{NAVIDROME_OIDC_SECRET}}"
+      - name: ND_OIDC_REDIRECTURL
+        value: "https://{{NAVIDROME_SUBDOMAIN}}.{{PUBLIC_DOMAIN}}/auth/oidc/callback"
+      - name: ND_OIDC_AUTOREGISTER
+        value: "true"
     ports:
       - containerPort: {{NAVIDROME_PORT}}
     volumeMounts:

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -71,6 +71,21 @@
     "description": "Host path to your music library. Defaults to the file-share template's data dir, so files dropped into the Samba share appear automatically.",
     "default": "/mnt/data/stacks/file-share/data/Music"
   },
+  "NAVIDROME_OIDC_ENABLED": {
+    "type": "select",
+    "description": "Enable Navidrome ↔ Authelia SSO. On by default so family members sign in with the household password. Flip to false if you hit an SSO regression and want to fall back to local Navidrome accounts.",
+    "options": ["true", "false"],
+    "default": "true"
+  },
+  "NAVIDROME_OIDC_SECRET": {
+    "type": "secret",
+    "description": "OIDC client secret for Navidrome ↔ Authelia. Auto-generated; pinned via clientSecretVar so Authelia and Navidrome share the same value."
+  },
+  "PUBLIC_DOMAIN": {
+    "type": "text",
+    "description": "Public domain (used to build the SSO authority URL https://auth.<domain> and the redirect URL).",
+    "default": "dopp.cloud"
+  },
   "NAVIDROME_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Navidrome (web UI + Symfonium endpoint)",
@@ -81,6 +96,14 @@
       "allow_websocket_upgrade": true,
       "block_exploits": true,
       "ssl_forced": true
+    },
+    "oidcClient": {
+      "client_id": "navidrome",
+      "client_name": "Navidrome",
+      "authorization_policy": "one_factor",
+      "redirect_uris": ["/auth/oidc/callback"],
+      "scopes": ["openid", "profile", "email"],
+      "clientSecretVar": "NAVIDROME_OIDC_SECRET"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Navidrome was set up to trust an Authelia-injected `Remote-User` header forwarded by NPM, but the proxy host was never wired with Authelia forward-auth — so the header never arrived, Navidrome's own login screen showed up, and only the local admin worked.
- Switches Navidrome to OIDC: `NAVIDROME_OIDC_SECRET` is pinned via `clientSecretVar` so Authelia and Navidrome share the secret, `oidcClient` registers the client at install time, and the `template.yml` env section drops `ND_REVERSEPROXY*` for `ND_OIDC_ENABLED/ISSUER/CLIENTID/CLIENTSECRET/REDIRECTURL/AUTOREGISTER`. Requires Navidrome v0.52+.
- Subsonic API mobile clients keep using the local admin account because Subsonic doesn't speak OIDC.
- Bumps schema-version to v2 with CHANGELOG + informational migration.

Closes #413, related to #412.

## Test plan
- [ ] Fresh install: deploy `media` stack → `https://music.<domain>` shows "Sign in with Authelia" → click → land in Navidrome as the signed-in LLDAP user.
- [ ] Existing v1 install: redeploy → migration logs the auth flip → existing local admin still works for the Subsonic API; SSO works in the web UI.
- [ ] `NAVIDROME_OIDC_ENABLED=false`: redeploy → only local accounts work (regression-fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)