### PR TITLE
fix(file-share): correct syncthing exec name + silence UPnP logspam

### DIFF
--- a/src/lib/portal/assets.ts
+++ b/src/lib/portal/assets.ts
@@ -149,13 +149,14 @@ export async function generateAudiobookshelfDeepLink(serviceName: string, subdom
 }
 
 /**
- * Read the running Syncthing container's device ID. Uses
- * `podman exec syncthing cat /var/syncthing/config/config.xml`
- * (the file-share template mounts the syncthing-config PVC there)
- * and pulls the `<device id="...">` line that matches the special
- * "ourselves" entry. Falls back to running `syncthing --device-id`
- * inside the container if the config file isn't readable yet
- * (rare cold-start window).
+ * Read the running Syncthing container's device ID via
+ * `podman exec file-share-syncthing syncthing --device-id`.
+ *
+ * The container name follows podman play-kube's `<pod>-<container>`
+ * convention — the YAML's container is named `syncthing` but the
+ * actual podman container is `file-share-syncthing`. Calling it
+ * just by `syncthing` returns 404 and the UI ends up hiding the
+ * QR with "Syncthing container might not be running yet".
  *
  * Returns `null` when the container isn't running, the agent
  * doesn't respond, or the parse fails — the caller treats that as
@@ -169,7 +170,7 @@ export async function fetchSyncthingDeviceId(node: string = 'Local'): Promise<st
     // parsing the XML's myID attribute or matching against the
     // container's hostname; the CLI is one less moving part.
     const res = await agent.sendCommand('exec', {
-      command: 'podman exec syncthing syncthing --device-id 2>/dev/null',
+      command: 'podman exec file-share-syncthing syncthing --device-id 2>/dev/null',
     }, { timeoutMs: 6_000 }) as { code?: number; stdout?: string };
     if (res.code !== 0) return null;
     const id = (res.stdout ?? '').trim();

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -62,6 +62,14 @@ spec:
         value: "0"
       - name: STGUIADDRESS
         value: "0.0.0.0:8384"
+      # Disable Syncthing's UPnP / NAT-PMP NAT-traversal (#415). The
+      # FritzBox replies 403 to AddPortMapping on its IPv6 WAN entry
+      # (WANIPConn2), which Syncthing then retries on a loop and
+      # buries the real container logs. LAN sync still works; remote
+      # sync falls back to Syncthing's relay servers — acceptable
+      # for a family home-server scenario.
+      - name: STNOUPNP
+        value: "1"
     ports:
       - containerPort: 8384
       - containerPort: 22000


### PR DESCRIPTION
## Summary
Two unrelated Syncthing bugs that happened to land in the same area:

- `fetchSyncthingDeviceId` called `podman exec syncthing ...`, but `podman play-kube` names containers `<pod>-<container>` — the actual name is `file-share-syncthing`. Endpoint returned 404, portal hid the QR with "container might not be running yet". Aligns the call with the existing reference in `post-deploy.py:167`.
- Syncthing's UPnP probe spammed the container log with `Failed to acquire open port ... Not available Action (403)` because the FritzBox rejects `AddPortMapping` on its IPv6 WAN entry. Adds `STNOUPNP=1` to the syncthing container env to disable NAT-traversal. LAN sync is unaffected; remote sync transparently falls back to Syncthing's relays — acceptable for a family server.

Closes #415

## Test plan
- [ ] Open the file-share portal → Syncthing card → QR-code asset renders (no 404 in the network tab).
- [ ] `podman logs file-share-syncthing` no longer shows the `nat` package's `403` warnings.
- [ ] LAN device-pair from a phone via the QR still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)