### PR TITLE
feat(portal): auth-aware view (logged-in detection)

### DIFF
--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,5 +1,7 @@
+import { headers } from 'next/headers';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
 import { buildPortalCards } from '@/lib/portal/services';
+import { verifyAutheliaSession } from '@/lib/portal/auth';
 import PortalGrid from './PortalGrid';
 import RequestAccessButton from './RequestAccessButton';
 
@@ -8,14 +10,21 @@ export const dynamic = 'force-dynamic';
 
 /**
  * /portal — read-only card grid surfacing every running, feature-tier
- * service that ships a `user-guide.md`. Anonymous on the LAN per the
- * #242 design conversation. Reachable directly at `/portal` and via
- * the apex/www host rewrite in `proxy.ts`. Same UX in public-domain
- * mode — visitors typing the apex see the family portal regardless
- * of mode.
+ * service that ships a `user-guide.md`. Anonymous-readable per the
+ * #242 design conversation, but recognizes signed-in Authelia sessions
+ * (#417) to hide the "Request access" button and greet the visitor by
+ * name. Reachable directly at `/portal` and via the apex/www host
+ * rewrite in `proxy.ts`. Same UX in public-domain mode — visitors
+ * typing the apex see the family portal regardless of mode.
  */
 export default async function PortalPage() {
-  const cards = await buildPortalCards('Local');
+  const hdrs = await headers();
+  const [cards, visitor] = await Promise.all([
+    buildPortalCards('Local'),
+    verifyAutheliaSession(hdrs.get('cookie')),
+  ]);
+  const isLoggedIn = Boolean(visitor.user);
+  const firstName = visitor.name?.trim().split(/\s+/)[0] ?? null;
 
   return (
     <main className="max-w-6xl mx-auto px-6 py-12">
@@ -27,7 +36,9 @@ export default async function PortalPage() {
           </h1>
         </div>
         <p className="mt-3 text-base text-gray-600 dark:text-gray-400">
-          Pick a service below to get started.
+          {isLoggedIn && firstName
+            ? `Welcome back, ${firstName} — pick a service below to get started.`
+            : 'Pick a service below to get started.'}
         </p>
       </header>
 
@@ -42,7 +53,7 @@ export default async function PortalPage() {
         <PortalGrid cards={cards} />
       )}
 
-      <RequestAccessButton />
+      {!isLoggedIn && <RequestAccessButton />}
     </main>
   );
 }

--- a/src/lib/portal/auth.ts
+++ b/src/lib/portal/auth.ts
@@ -1,0 +1,63 @@
+/**
+ * Soft-auth check for the family-portal apex page (#417).
+ *
+ * The portal is intentionally anonymous-readable — random visitors
+ * on the LAN should still see the service tiles. But when the
+ * visitor has an Authelia session (e.g. they signed into FileBrowser
+ * earlier and the cookie is shared across the public domain), we
+ * can render extra affordances: hide the "Request access" button,
+ * greet them by name, etc.
+ *
+ * Implementation: server-side call into Authelia's `/api/verify`
+ * forwarding the visitor's `Cookie` header. Authelia returns 200 +
+ * `Remote-User` / `Remote-Name` response headers when the cookie is
+ * a valid session, or 401 when it isn't (or when there's no cookie
+ * at all). Either way we treat it as best-effort — a stale config
+ * or unreachable Authelia just falls back to the anonymous render.
+ *
+ * This is the same `/api/verify` endpoint the standard NPM
+ * `auth_request` integration uses (see file-share's `FILEBROWSER_SUBDOMAIN`
+ * advanced_config); we just call it ourselves so we don't have to
+ * thread `auth_request_set` headers through the portal proxy host
+ * (which would require an NPM advanced_config update for the apex
+ * and complicates the anonymous-fallback path).
+ */
+import { getConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+
+const VERIFY_TIMEOUT_MS = 3_000;
+const DEFAULT_AUTHELIA_PORT = '9091';
+
+export interface PortalVisitor {
+  /** LLDAP username when Authelia recognizes the cookie, otherwise null. */
+  user: string | null;
+  /** Display name (LLDAP firstName + lastName) when available. */
+  name: string | null;
+}
+
+export async function verifyAutheliaSession(cookieHeader: string | null): Promise<PortalVisitor> {
+  if (!cookieHeader) {
+    return { user: null, name: null };
+  }
+  const config = await getConfig();
+  const port = config.templateSettings?.AUTHELIA_PORT ?? DEFAULT_AUTHELIA_PORT;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/verify`, {
+      headers: { Cookie: cookieHeader },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      // 401 (anonymous) is the expected path for unauthenticated
+      // visitors — silent. Other statuses log at debug since we
+      // don't want noise on every portal hit in a misconfigured
+      // install.
+      return { user: null, name: null };
+    }
+    const user = res.headers.get('remote-user');
+    const name = res.headers.get('remote-name');
+    return { user: user || null, name: name || null };
+  } catch (e) {
+    logger.debug('portal:auth', `Could not verify Authelia session: ${e instanceof Error ? e.message : String(e)}`);
+    return { user: null, name: null };
+  }
+}


### PR DESCRIPTION
## Summary
- Portal apex now recognizes signed-in Authelia visitors. Server-side calls `http://127.0.0.1:AUTHELIA_PORT/api/verify` forwarding the visitor's `Cookie` header — 200 + `Remote-User` / `Remote-Name` → signed in; 401 / unreachable → anonymous.
- Greeting line becomes "Welcome back, &lt;firstName&gt;" when signed in; otherwise the original prompt.
- "Request access" button is hidden for signed-in visitors — they already have an account.

Chose server-side verification over a `auth_request` soft-auth block in the portal proxy host because the latter requires an `error_page 401 = @anonymous` named-location dance to keep the request flowing for non-members — significantly more NPM plumbing for the same UX outcome.

Closes #417 partially. The per-card `upload_hints[]` Dropbox-like affordance described in the issue is left for a follow-up.

## Test plan
- [ ] Open `dopp.cloud` in a private window without signing in → greeting is "Pick a service below…", "Request access" button is visible.
- [ ] Sign in via any SSO-protected service (FileBrowser, Vaultwarden web SSO), then revisit `dopp.cloud` → greeting becomes "Welcome back, &lt;firstName&gt;" and the Request-access button is hidden.
- [ ] Stop the auth pod and reload → portal still renders (fallback to anonymous view, no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)