### PR TITLE
feat(access-requests): polished welcome email + resend button

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Check, ExternalLink, Loader2, Mail, Trash2, UserCheck, UserPlus } from 'lucide-react';
+import { Check, ExternalLink, Loader2, Mail, Send, Trash2, UserCheck, UserPlus } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 
 interface AccessRequest {
@@ -89,6 +89,22 @@ export default function AccessRequestsSection() {
     }
   };
 
+  const onResendWelcome = async (id: string) => {
+    setBusy('action');
+    try {
+      const res = await fetch(`/api/system/access-requests/${id}/welcome`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        addToast('success', 'Welcome email sent', 'The family member should see it shortly.');
+      } else {
+        const message = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+        addToast('error', 'Could not send welcome email', message);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
   const onDelete = async (id: string) => {
     if (!window.confirm('Delete this access request? Use for spam — there\'s no undo.')) return;
     setBusy('action');
@@ -164,6 +180,7 @@ export default function AccessRequestsSection() {
                       r={r}
                       onApprove={() => onApprove(r.id)}
                       onResolve={() => onResolve(r.id)}
+                      onResendWelcome={() => onResendWelcome(r.id)}
                       onDelete={() => onDelete(r.id)}
                       busy={busy === 'action'}
                     />
@@ -181,6 +198,7 @@ export default function AccessRequestsSection() {
                       r={r}
                       onApprove={() => onApprove(r.id)}
                       onResolve={() => onResolve(r.id)}
+                      onResendWelcome={() => onResendWelcome(r.id)}
                       onDelete={() => onDelete(r.id)}
                       busy={busy === 'action'}
                       muted
@@ -200,6 +218,7 @@ function RequestRow({
   r,
   onApprove,
   onResolve,
+  onResendWelcome,
   onDelete,
   busy,
   muted,
@@ -207,11 +226,13 @@ function RequestRow({
   r: AccessRequest;
   onApprove: () => void;
   onResolve: () => void;
+  onResendWelcome: () => void;
   onDelete: () => void;
   busy: boolean;
   muted?: boolean;
 }) {
   const canAutoApprove = Boolean(r.username);
+  const canResendWelcome = Boolean(r.username);
   return (
     <div className={`p-3 rounded-lg border border-gray-200 dark:border-gray-700 ${muted ? 'opacity-60' : 'bg-white dark:bg-gray-900'}`}>
       <div className="flex items-start gap-3">
@@ -254,6 +275,16 @@ function RequestRow({
               title={canAutoApprove ? 'Mark resolved without creating the LLDAP user' : 'Mark resolved (after creating the LLDAP user)'}
             >
               <Check size={16} />
+            </button>
+          )}
+          {r.status === 'resolved' && canResendWelcome && (
+            <button
+              onClick={onResendWelcome}
+              disabled={busy}
+              className="p-1.5 text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded disabled:opacity-50"
+              title="Resend the welcome email to this family member"
+            >
+              <Send size={16} />
             </button>
           )}
           <button

--- a/src/app/api/system/access-requests/[id]/approve/route.ts
+++ b/src/app/api/system/access-requests/[id]/approve/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getConfig, saveConfig } from '@/lib/config';
 import { createLldapUser, getLldapUserDeepLink } from '@/lib/lldap/client';
 import { sendTransactionalEmail } from '@/lib/email';
+import { composeWelcomeEmail, getWelcomeEmailUrls } from '@/lib/email/welcome';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -74,31 +75,18 @@ export async function POST(
   await saveConfig({ ...config, accessRequests: requests });
   logger.info('access-requests:approve', `Provisioned LLDAP user ${req.username} for ${req.email}`);
 
-  // Best-effort confirmation to the requester. No-ops cleanly when
+  // Best-effort welcome email to the requester. No-ops cleanly when
   // email isn't configured — we still return success because the
   // LLDAP user *is* created and the admin can hand-deliver the URL.
-  const publicDomain = config.reverseProxy?.publicDomain;
-  const lanDomain = config.reverseProxy?.lanDomain;
-  const portalBase = publicDomain
-    ? `https://admin.${publicDomain}`
-    : lanDomain
-      ? `http://admin.${lanDomain}`
-      : null;
-  const greetingName = req.firstName ?? req.name;
-  const loginHint = portalBase
-    ? `Login here: ${portalBase}/portal\n\n`
-    : '';
-  void sendTransactionalEmail(
-    req.email,
-    'Your home server account is ready',
-    [
-      `Hi ${greetingName},`,
-      ``,
-      `Your account has been approved. Your username is "${req.username}".`,
-      ``,
-      `${loginHint}First time signing in? Click "Forgot password" on the login page — you'll get an email to set your password.`,
-    ].join('\n'),
-  );
+  // Same composer the "Resend welcome email" button uses (#418).
+  const urls = await getWelcomeEmailUrls();
+  const welcome = composeWelcomeEmail({
+    greetingName: req.firstName ?? req.name,
+    username: req.username,
+    portalUrl: urls.portalUrl,
+    authUrl: urls.authUrl,
+  });
+  void sendTransactionalEmail(req.email, welcome.subject, welcome.body);
 
   const deepLink = await getLldapUserDeepLink(req.username);
   return NextResponse.json({ ok: true, lldapUrl: deepLink });

--- a/src/app/api/system/access-requests/[id]/welcome/route.ts
+++ b/src/app/api/system/access-requests/[id]/welcome/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { getConfig } from '@/lib/config';
+import { sendTransactionalEmail } from '@/lib/email';
+import { composeWelcomeEmail, getWelcomeEmailUrls } from '@/lib/email/welcome';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Re-send the welcome email for an already-approved access request
+ * (#418). The first welcome mail is sent automatically by the
+ * approve route (#406/#407); this endpoint is the "the family member
+ * lost the email, send it again" affordance. Same composer is used
+ * for both so the wording stays consistent.
+ *
+ * Requires the request to have a `username` (i.e. it must have gone
+ * through the new profile-fields flow from #405). Legacy entries
+ * without one return 412 — those didn't get an auto-welcome either.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const config = await getConfig();
+  const req = (config.accessRequests ?? []).find(r => r.id === id);
+  if (!req) {
+    return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
+  }
+  if (!req.username) {
+    return NextResponse.json(
+      { error: 'This request has no username on file — no welcome email was ever sent and there is nothing to resend.' },
+      { status: 412 },
+    );
+  }
+  const emailEnabled = config.notifications?.email?.enabled;
+  if (!emailEnabled) {
+    return NextResponse.json(
+      { error: 'SMTP is not configured under Settings → Integrations → Email Notifications.' },
+      { status: 412 },
+    );
+  }
+
+  const urls = await getWelcomeEmailUrls();
+  const welcome = composeWelcomeEmail({
+    greetingName: req.firstName ?? req.name,
+    username: req.username,
+    portalUrl: urls.portalUrl,
+    authUrl: urls.authUrl,
+  });
+  await sendTransactionalEmail(req.email, welcome.subject, welcome.body);
+  logger.info('access-requests:welcome', `Resent welcome email to ${req.email}`);
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/email/welcome.ts
+++ b/src/lib/email/welcome.ts
@@ -1,0 +1,69 @@
+/**
+ * Welcome / "your account is ready" email composer (#418, follow-up
+ * to #407). Used both right after access-request approval and from
+ * the resend button in Settings → Integrations → Access Requests so
+ * the message stays consistent.
+ *
+ * The portal URL prefers the bare apex (`https://<publicDomain>/`)
+ * because that's the family-facing entry point — NPM rewrites the
+ * apex to ServiceBay's /portal. Falls back to the LAN domain for
+ * `lan`-mode installs, and to admin.<domain> only when nothing else
+ * is configured.
+ */
+import { getConfig } from '@/lib/config';
+
+export interface WelcomeEmailUrls {
+  portalUrl: string | null;
+  authUrl: string | null;
+}
+
+export async function getWelcomeEmailUrls(): Promise<WelcomeEmailUrls> {
+  const config = await getConfig();
+  const publicDomain = config.reverseProxy?.publicDomain;
+  const lanDomain = config.reverseProxy?.lanDomain;
+  if (publicDomain) {
+    return {
+      portalUrl: `https://${publicDomain}/`,
+      authUrl: `https://auth.${publicDomain}/`,
+    };
+  }
+  if (lanDomain) {
+    return {
+      portalUrl: `http://${lanDomain}/`,
+      authUrl: `http://auth.${lanDomain}/`,
+    };
+  }
+  return { portalUrl: null, authUrl: null };
+}
+
+export function composeWelcomeEmail(opts: {
+  greetingName: string;
+  username: string;
+  portalUrl: string | null;
+  authUrl: string | null;
+}): { subject: string; body: string } {
+  const lines: string[] = [
+    `Hi ${opts.greetingName},`,
+    ``,
+    `Your account on our home server is ready. Your username is "${opts.username}".`,
+    ``,
+  ];
+  if (opts.portalUrl) {
+    lines.push(`Open the family portal: ${opts.portalUrl}`, ``);
+  }
+  lines.push(`First time signing in? You'll need to set your password:`);
+  if (opts.authUrl) {
+    lines.push(`  1. Go to ${opts.authUrl}`);
+    lines.push(`  2. Click "Forgot password"`);
+    lines.push(`  3. Enter your email — you'll get a link to set your password`);
+  } else {
+    lines.push(`  Click "Forgot password" on the login page — you'll get an email`);
+    lines.push(`  with a link to set your password.`);
+  }
+  lines.push(``, `Have fun!`);
+
+  return {
+    subject: 'Your home server account is ready',
+    body: lines.join('\n'),
+  };
+}


### PR DESCRIPTION
## Summary
- Factors welcome-email composition into \`lib/email/welcome.ts\` so the approve route (#407) and the new resend button share identical wording.
- The portal link prefers the bare apex (\`https://<publicDomain>/\`) — NPM rewrites it to /portal, which is the family-facing entry point. Step-by-step "forgot password" instructions point at \`https://auth.<domain>/\`. Falls back to LAN domain when public domain isn't configured, omits the URLs when nothing is set.
- New \`POST /api/system/access-requests/[id]/welcome\` re-sends the welcome email for an already-resolved request. The Settings row picks up a Send icon (only for resolved entries with a \`username\` on file).
- Returns 412 with a helpful error when SMTP isn't configured or the request predates the username field.

Stacked on #407 (\`feat/issue-407-confirmation-email\`). Retarget to \`main\` before merging if #407 lands first.

Closes #418

## Test plan
- [ ] Approve a fresh access request → requester gets the new welcome email with the apex portal link + "Forgot password" steps at \`auth.<domain>\`.
- [ ] In Settings → Integrations, click the Send icon on a resolved row → requester gets the same email; toast confirms send.
- [ ] Disable SMTP → resend button toast surfaces "SMTP is not configured" (412).
- [ ] Try resend on a legacy resolved request that has no \`username\` → toast surfaces "no welcome email was ever sent".

🤖 Generated with [Claude Code](https://claude.com/claude-code)