### PR TITLE
feat(home-assistant): Z-Wave JS UI always-on + browser-reachable

### DIFF
--- a/templates/home-assistant/CHANGELOG.md
+++ b/templates/home-assistant/CHANGELOG.md
@@ -10,6 +10,29 @@ operator's installed schema-version and the current one and surfaces
 them in the re-deploy dialog. Each `(breaking)` section needs an
 explicit acknowledgement before the deploy can proceed.
 
+## v4 (breaking) — #420 / #422
+
+**Z-Wave JS UI always runs + reachable at `zwave.<lanDomain>`.**
+
+Previously the Z-Wave JS UI container only started when `ZWAVE_DEVICE`
+was set; without a stick the container was absent entirely and the UI
+unreachable. Adding a stick later meant editing the pod yaml by hand.
+
+The container now starts unconditionally. Without a stick the UI runs
+in "no serial device configured" mode — the operator points it at a
+stick later via the UI's own *Settings → Z-Wave → Serial Port* picker
+(or re-runs the install wizard once #421 lands). The device mount +
+zwave-stick hostPath volume are still guarded by `{{#ZWAVE_DEVICE}}`
+so podman doesn't crash-loop on a missing host path.
+
+Also adds `ZWAVE_JS_SUBDOMAIN` (default `zwave`, LAN-only) so the UI
+is reachable at `https://zwave.<lanDomain>` through NPM. Subdomain is
+created unconditionally because the container is too — visiting it
+without a stick configured just opens the UI's empty state.
+
+Required action: redeploy Home Assistant. Pre-existing zwave-config
+data under `${DATA_DIR}/home-assistant/zwave-js` is preserved.
+
 ## v3
 
 **Seed `configuration.yaml` with `http.trusted_proxies` so NPM can talk to HA.**

--- a/templates/home-assistant/migrations/v3-to-v4.py
+++ b/templates/home-assistant/migrations/v3-to-v4.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Migration: home-assistant v3 → v4 (#420 / #422).
+
+Z-Wave JS UI now starts unconditionally and is reachable at
+`zwave.<lanDomain>` through a new LAN-only NPM proxy host. No data
+moves — the existing `${DATA_DIR}/home-assistant/zwave-js` directory
+is reused.
+
+What this script does:
+  - Inform the operator about the redeploy behaviour. The new
+    container starts in "no serial device configured" mode when
+    ZWAVE_DEVICE is left blank, so installs that previously skipped
+    Z-Wave entirely now expose a UI at zwave.<lan>.
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    device = os.environ.get("ZWAVE_DEVICE", "").strip()
+    print("Home Assistant v3 → v4: Z-Wave JS UI always-on + new LAN subdomain (#420 / #422).")
+    if device:
+        print(f"  Z-Wave stick configured at {device}; the UI keeps that mount and continues to manage it.")
+    else:
+        print("  No ZWAVE_DEVICE configured. The Z-Wave JS UI still starts and is reachable at")
+        print("  zwave.<lanDomain> — you can plug in a stick later and point the UI at it via")
+        print("  Settings → Z-Wave → Serial Port without editing the pod yaml.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: home-assistant
   annotations:
     servicebay.label: "Home Assistant"
-    servicebay.schema-version: "3"
+    servicebay.schema-version: "4"
     # Home Assistant is reached at home.<domain> via nginx, and (when
     # the operator enables it) authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"
@@ -30,8 +30,12 @@ spec:
     securityContext:
       privileged: true
 
-  {{#ZWAVE_DEVICE}}
-  # 2. Z-Wave JS UI (only when Z-Wave stick is present)
+  # 2. Z-Wave JS UI — always runs (v4 / #422). On installs without a
+  # Z-Wave stick the UI starts in "no serial device configured" mode;
+  # the operator can plug a stick in later and point the UI at it
+  # without rewriting the pod yaml. The device mount + volume below
+  # only land when ZWAVE_DEVICE is set so podman doesn't crash-loop
+  # on a missing host path.
   - name: zwave-js
     image: ghcr.io/zwave-js/zwave-js-ui:latest
     env:
@@ -44,11 +48,12 @@ spec:
     volumeMounts:
     - mountPath: /usr/src/app/store
       name: zwave-config
+    {{#ZWAVE_DEVICE}}
     - mountPath: /dev/serial-device
       name: zwave-stick
+    {{/ZWAVE_DEVICE}}
     securityContext:
       privileged: true
-  {{/ZWAVE_DEVICE}}
 
   # 3. Matter Server
   - name: matter-server
@@ -76,12 +81,10 @@ spec:
     hostPath:
       path: {{DATA_DIR}}/home-assistant/homeassistant
       type: DirectoryOrCreate
-  {{#ZWAVE_DEVICE}}
   - name: zwave-config
     hostPath:
       path: {{DATA_DIR}}/home-assistant/zwave-js
       type: DirectoryOrCreate
-  {{/ZWAVE_DEVICE}}
   - name: matter-config
     hostPath:
       path: {{DATA_DIR}}/home-assistant/matter-server

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -10,8 +10,20 @@
   },
   "ZWAVE_DEVICE": {
     "type": "device",
-    "description": "USB device path for your Z-Wave stick",
+    "description": "Optional: USB device path of your Z-Wave stick. Leave blank if you don't have one yet — Z-Wave JS UI will still start and you can add the stick later via its settings UI or by re-running the wizard.",
     "devicePath": "/dev/serial/by-id"
+  },
+  "ZWAVE_JS_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for the Z-Wave JS UI. LAN-only — Z-Wave management doesn't need to be exposed to the public internet.",
+    "default": "zwave",
+    "exposure": "lan",
+    "proxyPort": "8091",
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": false
+    }
   },
   "HA_SUBDOMAIN": {
     "type": "subdomain",


### PR DESCRIPTION
## Summary
Combines the two related Z-Wave issues into one schema bump:

- **#422** — Z-Wave JS UI container was previously gated entirely by \`{{#ZWAVE_DEVICE}}\`; without a stick the container didn't exist. Now runs unconditionally, boots in "no serial device configured" mode without a stick, and the operator points it at a stick later from the UI's Serial Port picker. The device-mount + hostPath volume stay guarded so podman doesn't crash-loop on a missing host path.
- **#420** — Adds \`ZWAVE_JS_SUBDOMAIN\` (default \`zwave\`, **LAN-only**) so the UI is reachable at \`zwave.<lanDomain>\` via NPM. Created unconditionally because the container is now always on.

Bumps schema-version to v4 with CHANGELOG + informational migration.

Closes #420 #422

## Test plan
- [ ] Fresh install without a Z-Wave stick → Z-Wave JS UI loads at \`https://zwave.<lanDomain>\` and shows the "configure serial device" prompt; HA still works.
- [ ] Fresh install with \`ZWAVE_DEVICE\` set → UI loads with the stick already configured.
- [ ] Existing v3 install: redeploy → migration logs the always-on notice; if a stick was set, the existing zwave-config persists.
- [ ] Plug a stick in later, set the device path in Z-Wave JS UI Settings → controller works without a redeploy (host path needs to exist; a redeploy with the new \`ZWAVE_DEVICE\` value re-mounts at \`/dev/serial-device\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)