### PR TITLE
fix(immich): extend post-deploy budget + wait for pod Running first

### DIFF
--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -22,13 +22,24 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
 
 
-READY_TIMEOUT = 180.0
+# First-boot budget is generous because Immich has four containers
+# (immich-server, immich-machine-learning, redis, postgres) and the
+# server-image alone is ~2 GB. On a fresh install the path is
+# image-pull → pod-start → postgres-initdb → server-migrations →
+# /api/server-info goes 200. 180 s used to cover the API-probe only —
+# which fired before image pulls even finished. The split below gives
+# image pulls + pod start up to 10 min, and the server bootstrap
+# after the pod is Running another 5 min. Healthy fast machines exit
+# both loops within seconds.
+POD_RUNNING_TIMEOUT = 600.0
+READY_TIMEOUT = 300.0
 READY_INTERVAL = 2.0
 REQUEST_TIMEOUT = 30.0
 
@@ -72,8 +83,31 @@ def request_json(method: str, url: str, payload: object | None = None, token: st
         return 0, None
 
 
+def wait_pod_running(pod_name: str, deadline_sec: float = POD_RUNNING_TIMEOUT) -> bool:
+    """Poll `podman pod inspect` until the pod is Running. Covers image-pull
+    + first container start on fresh installs; on warm machines exits within
+    a second. Best-effort — any subprocess failure is treated as 'not yet'."""
+    started = time.time()
+    while time.time() - started < deadline_sec:
+        try:
+            r = subprocess.run(
+                ["podman", "pod", "inspect", pod_name, "--format", "{{.State}}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if r.returncode == 0 and r.stdout.strip().lower() == "running":
+                return True
+        except Exception:  # pylint: disable=broad-except
+            pass
+        time.sleep(2)
+    return False
+
+
 def wait_ready(base_url: str) -> bool:
-    """Poll Immich's /api/server-info until it returns 200, then return True."""
+    """Poll Immich's /api/server-info until it returns 200. Runs only after
+    the pod is already Running, so this budget covers postgres init +
+    Immich server migrations, not image pulls."""
     started = time.time()
     while time.time() - started < READY_TIMEOUT:
         code, _ = request_json("GET", f"{base_url}/api/server-info")
@@ -95,9 +129,16 @@ def main() -> int:
     subdomain = env("IMMICH_SUBDOMAIN", "photos")
     public_url = f"https://{subdomain}.{public_domain}" if public_domain else base_url
 
-    log(f"Waiting up to {int(READY_TIMEOUT)}s for Immich at {base_url}…")
+    log(f"Waiting up to {int(POD_RUNNING_TIMEOUT)}s for the immich pod to enter Running state (covers image pull)…")
+    if not wait_pod_running("immich"):
+        log(f"❌ immich pod did not reach Running within {int(POD_RUNNING_TIMEOUT)}s — skipping seed/OIDC config.")
+        log("   Re-run this post-deploy from Diagnose → post_deploy_failed → 'Re-run post-install' once the pod is up.")
+        return 1
+
+    log(f"Waiting up to {int(READY_TIMEOUT)}s for Immich at {base_url} to accept API calls (postgres init + server migrations)…")
     if not wait_ready(base_url):
-        log(f"❌ Immich did not become ready within {int(READY_TIMEOUT)}s — skipping seed/OIDC config.")
+        log(f"❌ Immich /api/server-info did not respond within {int(READY_TIMEOUT)}s — skipping seed/OIDC config.")
+        log("   Re-run this post-deploy from Diagnose → post_deploy_failed → 'Re-run post-install' once /api/server-info returns 200.")
         return 1
     log("✅ Immich is ready.")
 


### PR DESCRIPTION
The Immich post-deploy fired its 180 s readiness probe before image pulls finished — Immich ships four containers (server, ML, redis, postgres); the server image alone is ~2 GB. Probe timed out, exit 1, seed + OIDC skipped.

```
Waiting up to 180s for Immich at http://127.0.0.1:2283…
❌ Immich did not become ready within 180s — skipping seed/OIDC config.
⚠️ immich post-deploy exited 1.
```

Split the budget into two phases mirroring what `file-share` already does:

- 10 min `wait_pod_running("immich")` via `podman pod inspect` — covers image pulls + first container start.
- 5 min `/api/server-info` probe — only runs *after* the pod is Running, so it spends that budget on postgres initdb + Immich migrations instead of image extraction.

Warm machines exit both loops in seconds. Failure paths now log a `Diagnose → post_deploy_failed → 'Re-run post-install'` hint inline.

(The pgvecto.rs preload regression that also surfaced during the same install lives in #439 and is the immediate install blocker — this PR is the polish around the timing.)

## Test plan
- [ ] Fresh install with cold image cache → pod Running within 10 min, server-info responds within 5 min, admin seed + OIDC config land.
- [ ] Warm install → both wait loops exit in seconds.
- [ ] Mid-install failure → Diagnose → re-run idempotently succeeds.