### PR TITLE
fix(immich): preserve pgvecto.rs shared_preload_libraries in postgres args

### DIFF
--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -66,9 +66,19 @@ spec:
 
     - name: database
       image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0
-      # Postgres image defaults to listen_addresses='*'. Override to
-      # localhost-only so the sidecar isn't reachable from the LAN.
-      args: ["postgres", "-c", "listen_addresses=127.0.0.1"]
+      # The pgvecto-rs image's default CMD sets
+      # `shared_preload_libraries=vectors.so` — overriding args to
+      # restrict listen_addresses dropped that, postgres started
+      # without the extension and immich's microservices worker
+      # crashed with "pgvecto.rs must be loaded via
+      # shared_preload_libraries" (#410 follow-up). Keep BOTH
+      # `-c` flags: extension load AND localhost-only bind.
+      args:
+        - "postgres"
+        - "-c"
+        - "shared_preload_libraries=vectors.so"
+        - "-c"
+        - "listen_addresses=127.0.0.1"
       env:
         - name: POSTGRES_PASSWORD
           value: "{{DB_PASSWORD}}"


### PR DESCRIPTION
## Install blocker for v3.27.0

PR #428's hostNetwork-sidecar hardening added \`args: [\"postgres\", \"-c\", \"listen_addresses=127.0.0.1\"]\` to the postgres container — that overwrote the pgvecto-rs image's default CMD which set \`-c shared_preload_libraries=vectors.so\`.

Postgres started without the extension, immich's microservices worker crashed every boot:

\`\`\`
microservices worker error: PostgresError: pgvecto.rs: pgvecto.rs must be loaded via shared_preload_libraries.
ADVICE: ... \`psql -U postgres -c 'ALTER SYSTEM SET shared_preload_libraries = "vectors.so"'\`.
microservices worker exited with code 1
Killing api process
\`\`\`

Fix: pass both \`-c\` flags so the extension loads AND the bind stays on loopback. Verified the postgres CLI accepts repeated \`-c\` overrides; order doesn't matter.

The post-deploy budget timeout (which also surfaced during the same install attempt) is a separate concern and lives in its own PR.

## Test plan
- [ ] Fresh install: redeploy Immich → \`podman logs file-share-database\` (database container) shows \`LOG: vectors: loaded\`; immich microservices stays up; web UI reaches the admin/SSO page.
- [ ] Re-deploy of an existing v3.27.0 install where postgres data dir already has the extension state → still works (vectors.so just gets preloaded on the new process; the data files are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)