### PR TITLE
fix: Z-Wave device permissions + SSO OIDC wiring + MCP deploy API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,11 @@ ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV PATH="/app/node_modules/.bin:$PATH"
 
-# Install SSH client and Python (required for Agent V4 in container mode)
-# Removed podman and systemd - agent uses SSH to execute commands on host
+# Install SSH client, Python, and git.
+# - SSH/Python: Agent V4 runs commands on the host over SSH.
+# - git: external registry sync (#443) clones template repositories into
+#   the on-disk cache. Without git, `Registry sync skipped: git not
+#   available` silently falls back to built-in templates only.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     openssh-client \
@@ -56,6 +59,7 @@ RUN apt-get update && \
     python3-paramiko \
     procps \
     iproute2 \
+    git \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 

--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -209,7 +209,12 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
               }}
               doneFooter={(() => {
                 const domain = controller.variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
-                const subdomains = controller.variables.filter(v => v.meta?.type === 'subdomain' && v.value);
+                // Only public-exposure subdomains need a public A record. LAN-only
+                // ones (e.g. Z-Wave JS admin UI) resolve via AdGuard on `.home.arpa`
+                // and would mislead the operator into creating unwanted public records.
+                const subdomains = controller.variables.filter(
+                  v => v.meta?.type === 'subdomain' && v.value && v.meta?.exposure === 'public',
+                );
                 if (!domain || subdomains.length === 0) return null;
                 return (
                   <div className="space-y-3">

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -2152,7 +2152,13 @@ export default function OnboardingWizard() {
                         // next-step panels when the install produced any proxy
                         // routes. Rendered via the StackInstallSummary slot below.
                         const domain = stackVariables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
-                        const subdomains = stackVariables.filter(v => v.meta?.type === 'subdomain' && v.value);
+                        // DNS verification runs only against public-exposure subdomains.
+                        // LAN-exposed ones (e.g. ZWAVE_JS_SUBDOMAIN) live on `.home.arpa`
+                        // via AdGuard rewrites — querying a public resolver for those
+                        // would always fail and surface as spurious "not resolving" hints.
+                        const subdomains = stackVariables.filter(
+                            v => v.meta?.type === 'subdomain' && v.value && v.meta?.exposure === 'public',
+                        );
                         const hasProxyRoutes = !!domain && subdomains.length > 0;
                         const diagCounts = (diagnoseProbes ?? []).reduce<Record<ProbeStatus, number>>(
                             (a, p) => { a[p.status] = (a[p.status] ?? 0) + 1; return a; },

--- a/src/lib/lldap/client.ts
+++ b/src/lib/lldap/client.ts
@@ -128,10 +128,20 @@ export async function createLldapUser(input: CreateUserInput): Promise<LldapCrea
  * LLDAP's web UI URL for a specific user's detail page — used as the
  * deep-link target after auto-create so the admin lands directly on
  * the group-assignment view.
+ *
+ * Prefers the NPM-exposed subdomain stored under `reverseProxy.hosts`
+ * (same source as `/api/auth/lldap-url`, used by the sidebar) over
+ * `config.lldap.url`. The latter is the server-internal URL —
+ * `http://localhost:17170` — which is what `templates/auth/post-deploy.py`
+ * writes for in-process API calls and is unreachable from the admin's
+ * browser (#442). Falls back to `config.lldap.url` for LAN-only installs
+ * with no NPM entry, where localhost may at least work for an admin
+ * browsing from the server itself.
  */
 export async function getLldapUserDeepLink(userId: string): Promise<string | null> {
   const config = await getConfig();
-  const url = config.lldap?.url;
-  if (!url) return null;
-  return `${url.replace(/\/$/, '')}/user/${encodeURIComponent(userId)}`;
+  const proxied = config.reverseProxy?.hosts?.find(h => h.service === 'lldap' && h.created);
+  const base = proxied ? `https://${proxied.domain}` : config.lldap?.url;
+  if (!base) return null;
+  return `${base.replace(/\/$/, '')}/user/${encodeURIComponent(userId)}`;
 }

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -395,12 +395,18 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     },
     async ({ name, kubeContent, yamlContent, yamlFileName, extraFiles, node }) => {
       const nodeName = await resolveNode(node);
+      // `kubeContent` here is the Pod YAML (Kubernetes manifest). We generate
+      // the systemd .kube unit internally — same pattern as the install runner
+      // (src/lib/install/runner.ts:275-276). The parameter name is historical;
+      // the MCP description says "kube YAML content" meaning the Pod YAML.
+      const resolvedYamlFileName = yamlFileName ?? `${name}.yml`;
+      const generatedKubeUnit = `[Kube]\nYaml=${resolvedYamlFileName}\nAutoUpdate=registry\n\n[Install]\nWantedBy=default.target`;
       await ServiceManager.deployKubeService(
         nodeName,
         name,
+        generatedKubeUnit,
         kubeContent,
-        yamlContent ?? '',
-        yamlFileName ?? `${name}.yaml`,
+        resolvedYamlFileName,
         extraFiles,
       );
       return textResult(`Service "${name}" deployed successfully${extraFiles?.length ? ` (${extraFiles.length} extra file${extraFiles.length === 1 ? '' : 's'} written)` : ''}`);
@@ -733,12 +739,14 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     async ({ name, kubeContent, yamlContent, yamlFileName, node }) => {
       const nodeName = await resolveNode(node);
       try {
+        const resolvedYamlFileName = yamlFileName ?? `${name}.yml`;
+        const generatedKubeUnit = `[Kube]\nYaml=${resolvedYamlFileName}\nAutoUpdate=registry\n\n[Install]\nWantedBy=default.target`;
         await ServiceManager.deployKubeService(
           nodeName,
           name,
+          generatedKubeUnit,
           kubeContent,
-          yamlContent ?? '',
-          yamlFileName ?? `${name}.yaml`,
+          resolvedYamlFileName,
         );
         return textResult(`Service "${name}" updated and redeployed`);
       } catch (err) {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -192,10 +192,11 @@ export async function syncRegistries() {
 
     if (registries.length === 0) return;
 
-    // Fedora CoreOS doesn't ship git. Without it we can still serve the
-    // built-in templates/stacks bundled with ServiceBay; only external
-    // registry sync is unavailable. Log once and skip rather than fail
-    // every server start.
+    // The official ServiceBay container bundles git (#443). This guard
+    // stays for unofficial runtime environments — without git we can
+    // still serve the built-in templates/stacks bundled with
+    // ServiceBay; only external registry sync is unavailable. Log once
+    // and skip rather than fail every server start.
     if (!(await isGitAvailable())) {
         console.log('Registry sync skipped: git not available (built-in templates still served).');
         return;

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -119,8 +119,24 @@ function renderProxyConfig(
   }
 }
 
-/** Build the proxy-host list from subdomain-typed variables. */
-function buildProxyHosts(variables: StackVariable[]): {
+/** Build the proxy-host list from subdomain-typed variables. Exported
+ * for unit testing — the public-vs-LAN routing rule is subtle enough
+ * that a regression test is worth pinning (see
+ * `tests/backend/buildProxyHosts.test.ts`).
+ *
+ * Hosts are split by their declared `exposure`:
+ *   - `public` → `<sub>.<PUBLIC_DOMAIN>` (Let's Encrypt cert, externally
+ *     reachable once DNS points here).
+ *   - `lan`    → `<sub>.<LAN_DOMAIN or 'home.arpa'>` so admin-only UIs
+ *     (e.g. Z-Wave JS at `zwave.home.arpa`) never accidentally land on
+ *     the public domain — that previously produced a `zwave.<publicDomain>`
+ *     entry the DNS-verify probe nagged about, and would have exposed the
+ *     UI publicly if the operator ever created the A record.
+ *
+ * Public-exposure hosts are skipped when no `PUBLIC_DOMAIN` is set
+ * (LAN-only install).
+ */
+export function buildProxyHosts(variables: StackVariable[]): {
   domain: string | undefined;
   hosts: {
     domain: string;
@@ -132,28 +148,31 @@ function buildProxyHosts(variables: StackVariable[]): {
   }[];
 } {
   const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
-  if (!domain) return { domain, hosts: [] };
+  const lanDomain = variables.find(v => v.name === 'LAN_DOMAIN')?.value || 'home.arpa';
   const view = variables.reduce<Record<string, string>>(
     (acc, v) => { acc[v.name] = v.value; return acc; },
     {},
   );
   const subdomainVars = variables.filter(v => v.meta?.type === 'subdomain' && v.value);
-  const hosts = subdomainVars.map(sv => {
+  const hosts = subdomainVars.flatMap(sv => {
+    // Conservative default: missing/unknown → 'lan'. Templates declare
+    // `"exposure": "public"` explicitly for services that should get a
+    // Let's Encrypt cert at install time.
+    const exposure: 'public' | 'lan' = sv.meta?.exposure === 'public' ? 'public' : 'lan';
+    const hostDomain = exposure === 'public' ? domain : lanDomain;
+    if (!hostDomain) return [];
     let port = sv.meta?.proxyPort || '';
     const portVar = variables.find(v => v.name === port);
     if (portVar) port = portVar.value;
     const service = sv.meta?.templateName
       || sv.name.replace(/_SUBDOMAIN$/, '').toLowerCase();
-    return {
-      domain: `${sv.value}.${domain}`,
+    return [{
+      domain: `${sv.value}.${hostDomain}`,
       forwardPort: parseInt(port, 10),
       service,
-      // Conservative default: missing/unknown → 'lan'. Templates declare
-      // `"exposure": "public"` explicitly for services that should get a
-      // Let's Encrypt cert at install time.
-      exposure: (sv.meta?.exposure === 'public' ? 'public' : 'lan') as 'public' | 'lan',
+      exposure,
       proxyConfig: renderProxyConfig(sv.meta?.proxyConfig, view),
-    };
+    }];
   }).filter(h => Number.isFinite(h.forwardPort) && h.forwardPort > 0);
   return { domain, hosts };
 }
@@ -175,6 +194,11 @@ interface ConfigureProxyOpts {
 export async function configureProxyRoutes(opts: ConfigureProxyOpts): Promise<ProxyResult> {
   const { variables, node, onLog, credentials, skipWait } = opts;
   const { domain, hosts } = buildProxyHosts(variables);
+  // Public mode: PUBLIC_DOMAIN set + at least one host built. LAN-only
+  // mode (no PUBLIC_DOMAIN) is intentionally not handled here — proxy
+  // routing on `.home.arpa` exists only for individual lan-exposed hosts
+  // alongside a public install. Pure LAN-mode reverse proxy is a
+  // separate flow.
   if (!domain || hosts.length === 0) return 'skipped';
 
   if (!credentials && !skipWait) {

--- a/templates/home-assistant/README.md
+++ b/templates/home-assistant/README.md
@@ -37,20 +37,21 @@ Because voice runs on host network on the same node, `localhost` resolves to the
 
 ## SSO (Authelia)
 
-To enable OIDC login via Authelia, add this client to your Authelia `configuration.yml`:
+ServiceBay registers an OIDC client for Home Assistant in Authelia automatically. The client secret is stored in the `HA_OIDC_SECRET` variable and can be retrieved from **Settings → Integrations → Saved credentials**.
+
+Home Assistant does not ship a native OIDC auth provider. To wire up SSO you have two options:
+
+**Option A — HACS custom integration (recommended)**
+
+Install [homeassistant_auth_oidc](https://github.com/christiaangoossens/hacs-oidc-client) via HACS, then add to `configuration.yaml`:
 
 ```yaml
-      - client_id: 'homeassistant'
-        client_name: 'Home Assistant'
-        client_secret: '$plaintext$<your-secret>'
-        public: false
-        authorization_policy: 'one_factor'
-        redirect_uris:
-          - 'https://ha.<your-domain>/auth/oidc/callback'
-        scopes: ['openid', 'profile', 'email', 'groups']
-        response_types: ['code']
-        grant_types: ['authorization_code']
-        token_endpoint_auth_method: 'client_secret_post'
+homeassistant_auth_oidc:
+  client_id: homeassistant
+  client_secret: "<HA_OIDC_SECRET from saved credentials>"
+  discovery_url: "https://auth.<your-domain>/.well-known/openid-configuration"
 ```
 
-Then add the OIDC integration in Home Assistant's `configuration.yaml`.
+**Option B — Authelia forward-auth at the proxy level**
+
+Configure NPM to forward-authenticate every request to `home.<domain>` via Authelia before it reaches HA. Users log in to Authelia once; HA sees them as coming from a trusted proxy. No changes to `configuration.yaml` needed, but HA still maintains its own user accounts.

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -2,30 +2,44 @@
 """
 post-deploy hook for the `home-assistant` stack.
 
-When ZWAVE_DEVICE is set: writes a udev rule that grants world read/write
-access to the Z-Wave USB stick. This is required for rootless Podman to pass
-the device into the zwave-js container — in a rootless user-namespace, the
-device appears as nobody:nobody inside the container (host root UID/GID is not
-mapped), so mode 0666 is the only way to make it accessible without running the
-container process as root.
+Responsibilities:
 
-The rule is written to /etc/udev/rules.d/99-zwave.rules via sudo and fires on
-every boot when the device is detected, so it survives reboots, re-installs,
-and hardware moves to a different machine.
+  1. **udev rule** — when ZWAVE_DEVICE is set, writes
+     /etc/udev/rules.d/99-zwave.rules via sudo so the Z-Wave USB stick is
+     accessible to the rootless Podman container on every boot. In a rootless
+     user-namespace, host root (UID 0) maps to nobody inside the container, so
+     the device appears as crw-rw---- nobody:nobody and is inaccessible without
+     mode 0666. The rule fires on every device detection event, survives
+     reboots and re-installs on any machine.
 
-Idempotent: re-running with the same device is a no-op if the rule file
-already contains the correct content.
+  2. **Z-Wave JS WS port** — configures the Z-Wave JS UI Home Assistant
+     WebSocket server to port 3001 (NPM's admin UI occupies port 3000 on the
+     same hostNetwork pod, so 3000 is always taken). Waits for Z-Wave JS UI to
+     be up on port 8091, then PATCHes gateway.wsServer + gateway.wsServerPort
+     via the REST API. Idempotent — skips if already correct.
+
+Idempotent overall: safe to re-run on every deploy.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
 import sys
+import time
+import urllib.error
+import urllib.request
 
 UDEV_RULE_DIR = "/etc/udev/rules.d"
 UDEV_RULE_FILE = "99-zwave.rules"
+
+ZWAVEJS_API = "http://127.0.0.1:8091"
+ZWAVEJS_WS_PORT = 3001
+ZWAVEJS_READY_TIMEOUT = 60.0
+ZWAVEJS_READY_INTERVAL = 2.0
+REQUEST_TIMEOUT = 10.0
 
 
 def env(key: str, default: str = "") -> str:
@@ -38,12 +52,9 @@ def log(msg: str) -> None:
     sys.stdout.flush()
 
 
-def _device_kernel_pattern(device_path: str) -> str:
-    """Return a udev KERNEL glob for the given device path.
+# ── udev ──────────────────────────────────────────────────────────────────────
 
-    /dev/ttyACM0 -> ttyACM*
-    /dev/ttyUSB0 -> ttyUSB*
-    """
+def _device_kernel_pattern(device_path: str) -> str:
     name = os.path.basename(device_path)
     return re.sub(r"\d+$", "*", name)
 
@@ -53,16 +64,14 @@ def ensure_udev_rule(zwave_device: str) -> None:
     rule_line = f'SUBSYSTEM=="tty", KERNEL=="{pattern}", MODE="0666"\n'
     rule_path = os.path.join(UDEV_RULE_DIR, UDEV_RULE_FILE)
 
-    # Idempotent: skip if the file already has the right content.
     try:
         if os.path.isfile(rule_path) and open(rule_path).read() == rule_line:
             log(f"   udev rule already in place ({rule_path}) — skipping.")
-            _reload_udev(zwave_device, rule_path)
+            _reload_udev(zwave_device)
             return
     except OSError:
         pass
 
-    # Write the rule file via sudo (core user on Fedora CoreOS has NOPASSWD sudo).
     try:
         result = subprocess.run(
             ["sudo", "tee", rule_path],
@@ -75,32 +84,85 @@ def ensure_udev_rule(zwave_device: str) -> None:
         log(f"   wrote {rule_path}: {rule_line.strip()}")
     except Exception as exc:
         log(f"   ⚠️  could not write {rule_path}: {exc}")
-        log(f"   Run this once manually to fix device permissions permanently:")
-        log(f"     echo '{rule_line.strip()}' | sudo tee {rule_path}")
-        log(f"     sudo udevadm control --reload-rules")
+        log(f"   Run manually: echo '{rule_line.strip()}' | sudo tee {rule_path}")
+        log(f"                 sudo udevadm control --reload-rules")
         return
 
-    _reload_udev(zwave_device, rule_path)
+    _reload_udev(zwave_device)
 
 
-def _reload_udev(zwave_device: str, rule_path: str) -> None:
-    """Reload udev rules and trigger the device so permissions apply immediately."""
+def _reload_udev(zwave_device: str) -> None:
     try:
-        subprocess.run(
-            ["sudo", "udevadm", "control", "--reload-rules"],
-            check=True,
-            capture_output=True,
-        )
+        subprocess.run(["sudo", "udevadm", "control", "--reload-rules"], check=True, capture_output=True)
         if os.path.exists(zwave_device):
-            subprocess.run(
-                ["sudo", "udevadm", "trigger", zwave_device],
-                check=True,
-                capture_output=True,
-            )
-        log("   udev rules reloaded — permissions will be applied on every boot.")
+            subprocess.run(["sudo", "udevadm", "trigger", zwave_device], check=True, capture_output=True)
+        log("   udev rules reloaded — permissions applied on every boot.")
     except Exception as exc:
         log(f"   ⚠️  udevadm reload failed: {exc}. Permissions will apply on next reboot.")
 
+
+# ── Z-Wave JS WS port ──────────────────────────────────────────────────────────
+
+def _request(method: str, url: str, payload: object | None = None) -> tuple[int, object | None]:
+    body = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode())
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except Exception:  # pylint: disable=broad-except
+        return 0, None
+
+
+def _wait_zwavejs_ready() -> bool:
+    deadline = time.time() + ZWAVEJS_READY_TIMEOUT
+    while time.time() < deadline:
+        code, _ = _request("GET", f"{ZWAVEJS_API}/api/health")
+        if code == 200:
+            return True
+        time.sleep(ZWAVEJS_READY_INTERVAL)
+    return False
+
+
+def configure_ws_port() -> None:
+    log(f"   Waiting for Z-Wave JS UI (port 8091)...")
+    if not _wait_zwavejs_ready():
+        log("   ⚠️  Z-Wave JS UI not ready in time.")
+        log(f"   Set WS port manually: Settings → Home Assistant → WS Server Port → {ZWAVEJS_WS_PORT}")
+        return
+
+    code, data = _request("GET", f"{ZWAVEJS_API}/api/settings")
+    if code != 200 or not isinstance(data, dict):
+        log(f"   ⚠️  GET /api/settings failed (HTTP {code}). Set WS port manually.")
+        return
+
+    # The settings object may be top-level or wrapped in a "settings" key.
+    settings = data.get("settings", data)
+    gateway = settings.get("gateway", {})
+
+    if gateway.get("wsServer") is True and gateway.get("wsServerPort") == ZWAVEJS_WS_PORT:
+        log(f"   Z-Wave JS WS server already on port {ZWAVEJS_WS_PORT} — skipping.")
+        return
+
+    gateway["wsServer"] = True
+    gateway["wsServerPort"] = ZWAVEJS_WS_PORT
+    settings["gateway"] = gateway
+
+    post_body = {"settings": settings} if "settings" in data else settings
+    code2, _ = _request("POST", f"{ZWAVEJS_API}/api/settings", post_body)
+    if code2 in (200, 201, 204):
+        log(f"   ✅ Z-Wave JS WS server set to port {ZWAVEJS_WS_PORT}.")
+    else:
+        log(f"   ⚠️  POST /api/settings failed (HTTP {code2}). Set WS port manually.")
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
 
 def main() -> int:
     zwave_device = env("ZWAVE_DEVICE")
@@ -108,9 +170,13 @@ def main() -> int:
     if zwave_device:
         log(f"Z-Wave stick configured ({zwave_device}) — ensuring host udev permissions...")
         ensure_udev_rule(zwave_device)
-        log("✅ Z-Wave JS will have access to the device after each system boot.")
+        log("✅ Z-Wave JS will have device access after each system boot.")
+
+        log(f"Configuring Z-Wave JS WS server port ({ZWAVEJS_WS_PORT})...")
+        configure_ws_port()
+        log(f"✅ Connect Home Assistant to Z-Wave JS: ws://localhost:{ZWAVEJS_WS_PORT}")
     else:
-        log("No ZWAVE_DEVICE set — skipping udev rule (can be added later via re-deploy).")
+        log("No ZWAVE_DEVICE set — skipping udev rule and WS port config.")
 
     return 0
 

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `home-assistant` stack.
+
+When ZWAVE_DEVICE is set: writes a udev rule that grants world read/write
+access to the Z-Wave USB stick. This is required for rootless Podman to pass
+the device into the zwave-js container — in a rootless user-namespace, the
+device appears as nobody:nobody inside the container (host root UID/GID is not
+mapped), so mode 0666 is the only way to make it accessible without running the
+container process as root.
+
+The rule is written to /etc/udev/rules.d/99-zwave.rules via sudo and fires on
+every boot when the device is detected, so it survives reboots, re-installs,
+and hardware moves to a different machine.
+
+Idempotent: re-running with the same device is a no-op if the rule file
+already contains the correct content.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+UDEV_RULE_DIR = "/etc/udev/rules.d"
+UDEV_RULE_FILE = "99-zwave.rules"
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def _device_kernel_pattern(device_path: str) -> str:
+    """Return a udev KERNEL glob for the given device path.
+
+    /dev/ttyACM0 -> ttyACM*
+    /dev/ttyUSB0 -> ttyUSB*
+    """
+    name = os.path.basename(device_path)
+    return re.sub(r"\d+$", "*", name)
+
+
+def ensure_udev_rule(zwave_device: str) -> None:
+    pattern = _device_kernel_pattern(zwave_device)
+    rule_line = f'SUBSYSTEM=="tty", KERNEL=="{pattern}", MODE="0666"\n'
+    rule_path = os.path.join(UDEV_RULE_DIR, UDEV_RULE_FILE)
+
+    # Idempotent: skip if the file already has the right content.
+    try:
+        if os.path.isfile(rule_path) and open(rule_path).read() == rule_line:
+            log(f"   udev rule already in place ({rule_path}) — skipping.")
+            _reload_udev(zwave_device, rule_path)
+            return
+    except OSError:
+        pass
+
+    # Write the rule file via sudo (core user on Fedora CoreOS has NOPASSWD sudo).
+    try:
+        result = subprocess.run(
+            ["sudo", "tee", rule_path],
+            input=rule_line,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip())
+        log(f"   wrote {rule_path}: {rule_line.strip()}")
+    except Exception as exc:
+        log(f"   ⚠️  could not write {rule_path}: {exc}")
+        log(f"   Run this once manually to fix device permissions permanently:")
+        log(f"     echo '{rule_line.strip()}' | sudo tee {rule_path}")
+        log(f"     sudo udevadm control --reload-rules")
+        return
+
+    _reload_udev(zwave_device, rule_path)
+
+
+def _reload_udev(zwave_device: str, rule_path: str) -> None:
+    """Reload udev rules and trigger the device so permissions apply immediately."""
+    try:
+        subprocess.run(
+            ["sudo", "udevadm", "control", "--reload-rules"],
+            check=True,
+            capture_output=True,
+        )
+        if os.path.exists(zwave_device):
+            subprocess.run(
+                ["sudo", "udevadm", "trigger", zwave_device],
+                check=True,
+                capture_output=True,
+            )
+        log("   udev rules reloaded — permissions will be applied on every boot.")
+    except Exception as exc:
+        log(f"   ⚠️  udevadm reload failed: {exc}. Permissions will apply on next reboot.")
+
+
+def main() -> int:
+    zwave_device = env("ZWAVE_DEVICE")
+
+    if zwave_device:
+        log(f"Z-Wave stick configured ({zwave_device}) — ensuring host udev permissions...")
+        ensure_udev_rule(zwave_device)
+        log("✅ Z-Wave JS will have access to the device after each system boot.")
+    else:
+        log("No ZWAVE_DEVICE set — skipping udev rule (can be added later via re-deploy).")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -11,7 +11,7 @@ metadata:
     # the operator enables it) authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"
     servicebay.config-mount: "/config"
-    servicebay.ports: "8123/tcp,8091/tcp,3000/tcp"
+    servicebay.ports: "8123/tcp,8091/tcp,3001/tcp"
 spec:
   hostNetwork: true
   containers:

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -49,7 +49,7 @@ spec:
     - mountPath: /usr/src/app/store
       name: zwave-config
     {{#ZWAVE_DEVICE}}
-    - mountPath: /dev/serial-device
+    - mountPath: {{ZWAVE_DEVICE}}
       name: zwave-stick
     {{/ZWAVE_DEVICE}}
     securityContext:

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -10,8 +10,8 @@
   },
   "ZWAVE_DEVICE": {
     "type": "device",
-    "description": "Optional: USB device path of your Z-Wave stick. Leave blank if you don't have one yet — Z-Wave JS UI will still start and you can add the stick later via its settings UI or by re-running the wizard.",
-    "devicePath": "/dev/serial/by-id"
+    "description": "Optional: USB device path of your Z-Wave stick (e.g. /dev/ttyACM0 or /dev/ttyUSB0). Use the real device path, not a /dev/serial/by-id symlink — symlinks don't work as CharDevice mounts. Leave blank if you don't have one yet.",
+    "devicePath": "/dev"
   },
   "ZWAVE_JS_SUBDOMAIN": {
     "type": "subdomain",

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -25,6 +25,10 @@
       "ssl_forced": false
     }
   },
+  "HA_OIDC_SECRET": {
+    "type": "secret",
+    "description": "OIDC client secret for the Home Assistant client registered with Authelia. Auto-generated and pinned via clientSecretVar so Authelia always uses the same value. HA itself does not have a native OIDC auth provider — use this secret when configuring a custom integration (e.g. homeassistant_auth_oidc via HACS)."
+  },
   "HA_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Home Assistant",
@@ -42,7 +46,8 @@
       "client_name": "Home Assistant",
       "authorization_policy": "one_factor",
       "redirect_uris": ["/auth/oidc/callback"],
-      "scopes": ["openid", "profile", "email", "groups"]
+      "scopes": ["openid", "profile", "email", "groups"],
+      "clientSecretVar": "HA_OIDC_SECRET"
     }
   }
 }

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -54,6 +54,43 @@ def log(msg: str) -> None:
     sys.stdout.flush()
 
 
+REQUEST_TIMEOUT = 30.0
+
+
+def request_json(
+    method: str,
+    url: str,
+    payload: object | None = None,
+    token: str | None = None,
+    extra_headers: dict[str, str] | None = None,
+    timeout: float = REQUEST_TIMEOUT,
+) -> tuple[int, object | None]:
+    """Generic HTTP helper — GET/PATCH/POST with optional Bearer auth and extra headers."""
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers: dict[str, str] = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(raw) if raw else None
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:  # pylint: disable=broad-except
+            return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, None
+
+
 def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
     """POST JSON, return (status, parsed-body-or-None)."""
     body = json.dumps(payload).encode("utf-8")
@@ -128,6 +165,79 @@ def seed_media(service_label: str, service_payload_name: str, port_var: str, def
     log(f"⚠️ {service_label} did not become reachable in 5 minutes. Open http://<server-ip>:{port} and create the admin user manually.")
 
 
+def configure_abs_oidc(
+    abs_port: str,
+    abs_user: str,
+    abs_password: str,
+    public_domain: str,
+    oidc_secret: str,
+) -> bool:
+    """Configure Audiobookshelf OIDC via its /api/auth-settings API.
+    Tries 127.0.0.1 and [::1] because Node.js on FCoS may bind IPv6-only.
+    Returns True if the settings were written successfully."""
+    issuer_url = f"https://auth.{public_domain}"
+
+    # 1. Login to get a bearer token (x-return-tokens: true puts it in the body).
+    token: str | None = None
+    abs_base: str | None = None
+    for host in (f"http://127.0.0.1:{abs_port}", f"http://[::1]:{abs_port}"):
+        code, body = request_json(
+            "POST", f"{host}/login",
+            {"username": abs_user, "password": abs_password},
+            extra_headers={"x-return-tokens": "true"},
+        )
+        if code == 200 and isinstance(body, dict):
+            token = (body.get("user") or {}).get("accessToken")
+            if token:
+                abs_base = host
+                break
+
+    if not token or not abs_base:
+        log("⚠️  Could not log in to Audiobookshelf for OIDC setup — skipping auto-config.")
+        return False
+
+    # 2. Fetch endpoint URLs from Authelia's OIDC discovery document.
+    #    Fall back to known Authelia path conventions if the host isn't reachable yet.
+    code, disc = request_json("GET", f"{issuer_url}/.well-known/openid-configuration")
+    if code == 200 and isinstance(disc, dict):
+        auth_url = disc.get("authorization_endpoint", "")
+        token_url = disc.get("token_endpoint", "")
+        userinfo_url = disc.get("userinfo_endpoint", "")
+        jwks_url = disc.get("jwks_uri", "")
+    else:
+        log(f"ℹ️  Authelia OIDC discovery returned HTTP {code} — using standard Authelia endpoint paths.")
+        auth_url = f"{issuer_url}/api/oidc/authorization"
+        token_url = f"{issuer_url}/api/oidc/token"
+        userinfo_url = f"{issuer_url}/api/oidc/userinfo"
+        jwks_url = f"{issuer_url}/jwks.json"
+
+    # 3. Write auth settings.
+    code, resp = request_json(
+        "PATCH", f"{abs_base}/api/auth-settings",
+        {
+            "authActiveAuthMethods": ["local", "openid"],
+            "authOpenIDIssuerURL": issuer_url,
+            "authOpenIDAuthorizationURL": auth_url,
+            "authOpenIDTokenURL": token_url,
+            "authOpenIDUserInfoURL": userinfo_url,
+            "authOpenIDJwksURL": jwks_url,
+            "authOpenIDClientID": "audiobookshelf",
+            "authOpenIDClientSecret": oidc_secret,
+            "authOpenIDButtonText": "Login with Authelia",
+            "authOpenIDAutoLaunch": False,
+            "authOpenIDAutoRegister": True,
+            "authOpenIDMatchExistingBy": "email",
+            "authOpenIDTokenSigningAlgorithm": "RS256",
+        },
+        token=token,
+    )
+    if code == 200:
+        log(f"✅ Audiobookshelf OIDC configured against {issuer_url}.")
+        return True
+    log(f"⚠️  Could not write ABS OIDC settings (HTTP {code}): {resp}.")
+    return False
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
 
@@ -183,15 +293,20 @@ def main() -> int:
         password_var="NAVIDROME_ADMIN_PASSWORD",
     )
 
-    # ── ABS OIDC client_secret (system credential, pasted into ABS UI) ──
+    # ── ABS OIDC auto-configuration ───────────────────────────────────────
     abs_oidc_secret = env("ABS_OIDC_SECRET")
     public_domain = env("PUBLIC_DOMAIN")
-    if abs_oidc_secret:
-        url = f"https://auth.{public_domain}" if public_domain else "auth.<domain>"
-        log(f"🔐 Audiobookshelf OIDC: issuer={url}, client_id=audiobookshelf, client_secret={abs_oidc_secret} — paste into ABS Settings → Authentication → OIDC.")
+    abs_oidc_ok = False
+    if abs_oidc_secret and public_domain:
+        abs_oidc_ok = configure_abs_oidc(abs_port, abs_user, abs_password, public_domain, abs_oidc_secret)
+
+    if not abs_oidc_ok and abs_oidc_secret:
+        # Auto-config failed or prerequisites missing — surface secret for manual paste.
+        auth_url = f"https://auth.{public_domain}" if public_domain else "auth.<domain>"
+        log(f"🔐 Audiobookshelf OIDC: issuer={auth_url}, client_id=audiobookshelf, client_secret={abs_oidc_secret} — paste into ABS Settings → Authentication → OIDC.")
         emit_credential(
             service="Audiobookshelf OIDC client_secret",
-            url=url,
+            url=auth_url,
             username="audiobookshelf",
             password=abs_oidc_secret,
             importance="system",

--- a/tests/backend/buildProxyHosts.test.ts
+++ b/tests/backend/buildProxyHosts.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { buildProxyHosts, type StackVariable } from '@/lib/stackInstall/postInstall';
+
+/**
+ * Regression coverage for the public-vs-LAN routing rule in
+ * `buildProxyHosts`. Prior to the fix, every subdomain — including those
+ * a template flagged `exposure: 'lan'` — landed on `<sub>.<publicDomain>`,
+ * which surfaced two visible symptoms in `public` mode installs:
+ *   1. The DNS-verify probe complained about a missing A record for
+ *      `zwave.<publicDomain>` even though Z-Wave is LAN-only by design.
+ *   2. If the operator created that A record anyway, the Z-Wave UI was
+ *      reachable from the public internet without a Let's Encrypt cert.
+ * The function now honours `exposure` and routes LAN hosts to
+ * `<sub>.home.arpa` (or `LAN_DOMAIN` when set).
+ */
+
+const v = (
+  name: string,
+  value: string,
+  meta?: StackVariable['meta'],
+): StackVariable => ({ name, value, meta });
+
+const subdomain = (
+  exposure: 'public' | 'lan' | undefined,
+  port: string,
+  extras: Partial<NonNullable<StackVariable['meta']>> = {},
+): StackVariable['meta'] => ({
+  type: 'subdomain',
+  proxyPort: port,
+  ...(exposure ? { exposure } : {}),
+  ...extras,
+});
+
+describe('buildProxyHosts', () => {
+  it('routes public-exposure subdomains onto PUBLIC_DOMAIN with a public flag', () => {
+    const { domain, hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('HA_SUBDOMAIN', 'home', subdomain('public', '8123')),
+    ]);
+    expect(domain).toBe('example.com');
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0]).toMatchObject({
+      domain: 'home.example.com',
+      forwardPort: 8123,
+      exposure: 'public',
+      service: 'ha',
+    });
+  });
+
+  it('routes lan-exposure subdomains onto the LAN domain (default home.arpa)', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
+    ]);
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0]).toMatchObject({
+      domain: 'zwave.home.arpa',
+      forwardPort: 8091,
+      exposure: 'lan',
+      service: 'zwave_js',
+    });
+  });
+
+  it('honours LAN_DOMAIN override when present', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('LAN_DOMAIN', 'lan.example'),
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
+    ]);
+    expect(hosts[0].domain).toBe('zwave.lan.example');
+  });
+
+  it('treats missing exposure as lan (conservative — never auto-cert)', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('MYSTERY_SUBDOMAIN', 'mystery', subdomain(undefined, '9000')),
+    ]);
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0]).toMatchObject({
+      domain: 'mystery.home.arpa',
+      exposure: 'lan',
+    });
+  });
+
+  it('routes mixed exposures from a single install correctly', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'dopp.cloud'),
+      v('HA_SUBDOMAIN', 'home', subdomain('public', '8123')),
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
+      v('IMMICH_SUBDOMAIN', 'photos', subdomain('public', '2283')),
+    ]);
+    const byDomain = Object.fromEntries(hosts.map(h => [h.domain, h]));
+    expect(byDomain['home.dopp.cloud'].exposure).toBe('public');
+    expect(byDomain['photos.dopp.cloud'].exposure).toBe('public');
+    expect(byDomain['zwave.home.arpa'].exposure).toBe('lan');
+    expect(hosts).toHaveLength(3);
+  });
+
+  it('skips public-exposure hosts when PUBLIC_DOMAIN is empty (LAN-only install)', () => {
+    const { domain, hosts } = buildProxyHosts([
+      v('HA_SUBDOMAIN', 'home', subdomain('public', '8123')),
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
+    ]);
+    expect(domain).toBeUndefined();
+    expect(hosts.map(h => h.domain)).toEqual(['zwave.home.arpa']);
+  });
+
+  it('resolves proxyPort given as a variable reference', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('AUTHELIA_PORT', '9091'),
+      v('AUTH_SUBDOMAIN', 'auth', subdomain('public', 'AUTHELIA_PORT')),
+    ]);
+    expect(hosts[0].forwardPort).toBe(9091);
+  });
+
+  it('drops subdomain entries with an unresolvable port', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('BROKEN_SUBDOMAIN', 'broken', subdomain('public', 'NOT_A_PORT_VAR')),
+      v('OK_SUBDOMAIN', 'ok', subdomain('public', '8080')),
+    ]);
+    expect(hosts.map(h => h.domain)).toEqual(['ok.example.com']);
+  });
+
+  it('skips subdomain variables whose value is empty', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('UNSET_SUBDOMAIN', '', subdomain('public', '8000')),
+      v('SET_SUBDOMAIN', 'real', subdomain('public', '8001')),
+    ]);
+    expect(hosts.map(h => h.domain)).toEqual(['real.example.com']);
+  });
+
+  it('uses templateName from meta when present, else derives from var name', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('ABS_SUBDOMAIN', 'audio', subdomain('public', '13378', { templateName: 'media' })),
+      v('NAVIDROME_SUBDOMAIN', 'navi', subdomain('public', '4533', { templateName: 'media' })),
+      v('FOO_SUBDOMAIN', 'foo', subdomain('public', '5000')),
+    ]);
+    expect(hosts.find(h => h.domain === 'audio.example.com')?.service).toBe('media');
+    expect(hosts.find(h => h.domain === 'navi.example.com')?.service).toBe('media');
+    expect(hosts.find(h => h.domain === 'foo.example.com')?.service).toBe('foo');
+  });
+});

--- a/tests/backend/lldap_deep_link.test.ts
+++ b/tests/backend/lldap_deep_link.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Regression coverage for #442: after access-request approval, the admin
+ * redirect must point at the NPM-exposed LLDAP subdomain (e.g.
+ * `https://ldap.example.com/user/<id>`), not the internal
+ * `http://localhost:17170` URL that `templates/auth/post-deploy.py`
+ * persists under `config.lldap.url` for in-process API calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockConfig: {
+  lldap?: { url?: string; username?: string; password?: string };
+  reverseProxy?: { hosts?: any[] };
+} = {};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(mockConfig)),
+}));
+
+import { getLldapUserDeepLink } from '../../src/lib/lldap/client';
+
+describe('getLldapUserDeepLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete mockConfig.lldap;
+    delete mockConfig.reverseProxy;
+  });
+
+  it('prefers the NPM-exposed subdomain over config.lldap.url', async () => {
+    mockConfig.lldap = { url: 'http://localhost:17170', username: 'admin', password: 'x' };
+    mockConfig.reverseProxy = {
+      hosts: [{ domain: 'ldap.example.com', service: 'lldap', forwardPort: 17170, created: true }],
+    };
+
+    const link = await getLldapUserDeepLink('alice');
+    expect(link).toBe('https://ldap.example.com/user/alice');
+  });
+
+  it('ignores LLDAP host entries that are not yet created', async () => {
+    mockConfig.lldap = { url: 'http://localhost:17170' };
+    mockConfig.reverseProxy = {
+      hosts: [{ domain: 'ldap.example.com', service: 'lldap', forwardPort: 17170, created: false }],
+    };
+
+    const link = await getLldapUserDeepLink('alice');
+    expect(link).toBe('http://localhost:17170/user/alice');
+  });
+
+  it('falls back to config.lldap.url when no proxy host exists (LAN-only install)', async () => {
+    mockConfig.lldap = { url: 'http://localhost:17170' };
+    mockConfig.reverseProxy = { hosts: [] };
+
+    const link = await getLldapUserDeepLink('alice');
+    expect(link).toBe('http://localhost:17170/user/alice');
+  });
+
+  it('encodes user IDs containing special characters', async () => {
+    mockConfig.reverseProxy = {
+      hosts: [{ domain: 'ldap.example.com', service: 'lldap', forwardPort: 17170, created: true }],
+    };
+
+    const link = await getLldapUserDeepLink('a b/c');
+    expect(link).toBe('https://ldap.example.com/user/a%20b%2Fc');
+  });
+
+  it('returns null when neither a proxy host nor lldap.url is set', async () => {
+    const link = await getLldapUserDeepLink('alice');
+    expect(link).toBeNull();
+  });
+
+  it('does not match unrelated services even if domain looks LDAP-y', async () => {
+    mockConfig.reverseProxy = {
+      hosts: [{ domain: 'ldap.example.com', service: 'authelia', forwardPort: 9091, created: true }],
+    };
+
+    const link = await getLldapUserDeepLink('alice');
+    expect(link).toBeNull();
+  });
+});

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -528,7 +528,7 @@ describe('OnboardingWizard', () => {
             (fetchTemplateVariables as any).mockResolvedValue({
                 SERVICE_NAME: { type: 'text', default: 'my-service' },
                 PUBLIC_DOMAIN: { type: 'text', default: 'example.com' },
-                TEST_SUBDOMAIN: { type: 'subdomain', default: 'test', proxyPort: '8080' },
+                TEST_SUBDOMAIN: { type: 'subdomain', default: 'test', proxyPort: '8080', exposure: 'public' },
             });
 
             render(<OnboardingWizard />);
@@ -571,7 +571,7 @@ describe('OnboardingWizard', () => {
             (fetchTemplateVariables as any).mockResolvedValue({
                 SERVICE_NAME: { type: 'text', default: 'my-service' },
                 PUBLIC_DOMAIN: { type: 'text', default: 'example.com' },
-                TEST_SUBDOMAIN: { type: 'subdomain', default: 'test', proxyPort: '8080' },
+                TEST_SUBDOMAIN: { type: 'subdomain', default: 'test', proxyPort: '8080', exposure: 'public' },
             });
 
             // Make proxy-hosts return 401 with needsCredentials


### PR DESCRIPTION
Closes three gaps from #412 plus two follow-ups (#442, #443).

## Changes

### 1. Audiobookshelf — full OIDC auto-configuration (`templates/media/post-deploy.py`)
- After seeding the admin account, post-deploy now logs in to ABS via `POST /login` and calls `PATCH /api/auth-settings` with the Authelia issuer URL + pinned client secret
- Endpoint field values are fetched from Authelia's `/.well-known/openid-configuration` discovery document, with known Authelia path conventions as fallback
- Falls back to emitting the secret for manual paste if the API call fails (same UX as before for failure cases)
- No more "paste into ABS Settings → OIDC" step

### 2. Home Assistant — pin Authelia client secret + Z-Wave device wiring (`templates/home-assistant/`)
- Adds `HA_OIDC_SECRET` (type: secret) + `clientSecretVar` so Authelia always registers a consistent secret instead of a fresh random one each install
- HA does not have a native OIDC auth provider in core — README updated with the two viable paths: HACS `homeassistant_auth_oidc` integration, or Authelia forward-auth at the NPM proxy level
- `post-deploy.py` writes a persistent udev rule (`/etc/udev/rules.d/99-zwave.rules`, MODE="0666") so rootless podman can open the Z-Wave USB stick; survives reboots and re-installs on any machine
- `post-deploy.py` patches the Z-Wave JS UI WebSocket server to port 3001 via REST API — NPM admin UI occupies port 3000 on the same hostNetwork pod
- `servicebay.ports` annotation updated 3000 → 3001 to match
- `variables.json` `ZWAVE_DEVICE` description warns against `/dev/serial/by-id` symlinks (don't work as CharDevice mounts)

### 3. LAN vs public subdomain routing (`src/`)
- `buildProxyHosts` now honours `exposure`: `public` → routes to `PUBLIC_DOMAIN` (Let's Encrypt cert); `lan` → routes to `home.arpa` (or `LAN_DOMAIN`). Previously every subdomain landed on `PUBLIC_DOMAIN`, so `zwave.<publicDomain>` appeared in the DNS-verify probe and would have been publicly reachable if the operator created the A record.
- `InstallerModal` + `OnboardingWizard` filter to `exposure === 'public'` only when building DNS-verify hints
- `buildProxyHosts` exported for unit testing; 10 regression tests added

### 4. MCP `deploy_service` parameter inversion (`src/lib/mcp/server.ts`)
- `kubeContent` and `yamlContent` were swapped relative to what `ServiceManager.deployKubeService` expects (kube unit vs Pod yaml). Auto-generates the systemd `.kube` unit from the resolved yaml filename so MCP callers only need to pass Pod YAML.

### 5. LLDAP admin deep link (`src/lib/lldap/client.ts`, closes #442)
- After access-request approval the admin redirect previously went to `http://localhost:17170/user/<id>` because `getLldapUserDeepLink` read `config.lldap.url` (in-process URL set by `templates/auth/post-deploy.py` for server-side API calls). Now prefers the NPM-exposed subdomain from `reverseProxy.hosts[].service === 'lldap'`, falling back to `config.lldap.url` only when no NPM entry exists. 6 regression tests added.

### 6. Bundle git in runtime image (`Dockerfile`, closes #443)
- External registry sync silently no-op'd with `Registry sync skipped: git not available` because the runner image didn't include git. Added `git` to the runtime apt-get install; updated the in-code comment in `registry.ts` to reflect that the guard is now for unofficial runtime environments only.

## Test plan
- [ ] Install `media` template → verify ABS shows "Login with Authelia" button after post-deploy without manual paste
- [ ] Install `home-assistant` template with a Z-Wave stick → verify Z-Wave JS UI starts with device access AND WS port is 3001 with no manual config
- [ ] Install any template with a LAN subdomain → verify `<sub>.home.arpa` route is created and `<sub>.<publicDomain>` does NOT appear in DNS-verify hints
- [ ] Approve an access request → verify admin lands on `https://<lldap-subdomain>/user/<id>`, not localhost
- [ ] Add an external registry (e.g. `https://github.com/mdopp/oscar.git`) → verify templates appear after sync (no more `git not available` log)

Refs #412.

Closes #442
Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
