### PR TITLE
fix(immich): drop fragile wait_pod_running + keep install stream warm

### DIFF
--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -331,6 +331,19 @@ export async function POST(request: Request) {
       }
     };
 
+    // Keepalive ping. Templates with long silent post-deploy phases
+    // (e.g. immich's wait_pod_running can be idle 10 min on a cold
+    // first-boot image pull) would otherwise let undici's default
+    // 5-min bodyTimeout close the install runner's fetch with
+    // `terminated`, triggering a phantom retry while the install is
+    // actually still progressing fine. The runner ignores unknown
+    // event types, so emitting `{type: "ping"}` every 30 s keeps the
+    // stream warm without surfacing to the UI.
+    const KEEPALIVE_INTERVAL_MS = 30_000;
+    const keepalive = setInterval(() => {
+      void safeWrite({ type: 'ping' });
+    }, KEEPALIVE_INTERVAL_MS);
+
     (async () => {
       try {
         await ServiceManager.deployKubeService(
@@ -349,6 +362,7 @@ export async function POST(request: Request) {
       } catch (e) {
         await safeWrite({ type: 'error', message: e instanceof Error ? e.message : String(e) });
       } finally {
+        clearInterval(keepalive);
         if (!writerClosed) {
           try { await writer.close(); } catch { /* already closed */ }
         }

--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -42,6 +42,12 @@ POD_RUNNING_TIMEOUT = 600.0
 READY_TIMEOUT = 300.0
 READY_INTERVAL = 2.0
 REQUEST_TIMEOUT = 30.0
+# Heartbeat cadence for the silent poll loops. Keeps the wizard's
+# /api/services NDJSON stream warm so undici doesn't fire its 5-min
+# bodyTimeout mid-wait and the runner doesn't see a phantom
+# "(terminated)" failure on healthy installs. 60 s gives ~5 lines per
+# loop in the worst case — cheap, and the operator can see progress.
+HEARTBEAT_INTERVAL = 60.0
 
 
 def env(key: str, default: str = "") -> str:
@@ -86,8 +92,15 @@ def request_json(method: str, url: str, payload: object | None = None, token: st
 def wait_pod_running(pod_name: str, deadline_sec: float = POD_RUNNING_TIMEOUT) -> bool:
     """Poll `podman pod inspect` until the pod is Running. Covers image-pull
     + first container start on fresh installs; on warm machines exits within
-    a second. Best-effort — any subprocess failure is treated as 'not yet'."""
+    a second. Best-effort — any subprocess failure is treated as 'not yet'.
+
+    Emits a heartbeat line every HEARTBEAT_INTERVAL seconds — the wizard's
+    NDJSON stream from /api/services would otherwise stay silent for up to
+    POD_RUNNING_TIMEOUT and undici's bodyTimeout (5 min) would kill the
+    connection and trigger a phantom retry."""
     started = time.time()
+    last_state = ""
+    last_heartbeat = started
     while time.time() - started < deadline_sec:
         try:
             r = subprocess.run(
@@ -96,10 +109,17 @@ def wait_pod_running(pod_name: str, deadline_sec: float = POD_RUNNING_TIMEOUT) -
                 text=True,
                 timeout=5,
             )
-            if r.returncode == 0 and r.stdout.strip().lower() == "running":
+            state = r.stdout.strip().lower() if r.returncode == 0 else "unknown"
+            if state == "running":
                 return True
         except Exception:  # pylint: disable=broad-except
-            pass
+            state = "unknown"
+        now = time.time()
+        if now - last_heartbeat >= HEARTBEAT_INTERVAL or state != last_state:
+            elapsed = int(now - started)
+            log(f"   …pod state={state or 'pending'} ({elapsed}s/{int(deadline_sec)}s)")
+            last_heartbeat = now
+            last_state = state
         time.sleep(2)
     return False
 
@@ -108,14 +128,23 @@ def wait_ready(port: str) -> tuple[bool, str]:
     """Poll Immich's /api/server-info until it returns 200. Tries both
     127.0.0.1 and [::1] because NestJS on Linux defaults to binding :: and
     the effective loopback address depends on kernel IPV6_V6ONLY setting —
-    on FCoS only [::1] answers. Returns (success, base_url)."""
+    on FCoS only [::1] answers. Returns (success, base_url).
+
+    Emits a heartbeat every HEARTBEAT_INTERVAL seconds — same rationale as
+    wait_pod_running."""
     candidates = [f"http://127.0.0.1:{port}", f"http://[::1]:{port}"]
     started = time.time()
+    last_heartbeat = started
     while time.time() - started < READY_TIMEOUT:
         for url in candidates:
             code, _ = request_json("GET", f"{url}/api/server-info")
             if code == 200:
                 return True, url
+        now = time.time()
+        if now - last_heartbeat >= HEARTBEAT_INTERVAL:
+            elapsed = int(now - started)
+            log(f"   …still waiting for /api/server-info ({elapsed}s/{int(READY_TIMEOUT)}s)")
+            last_heartbeat = now
         time.sleep(READY_INTERVAL)
     return False, candidates[0]
 

--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -3,7 +3,8 @@
 post-deploy hook for the `immich` stack (#410).
 
 What this does:
-  1. Wait for Immich server to report ready on http://127.0.0.1:IMMICH_PORT.
+  1. Wait for Immich's /api/server-info to answer 200 on the loopback
+     (127.0.0.1 or [::1]; NestJS on FCoS binds IPv6-only).
   2. Idempotently seed the initial admin account via /api/auth/admin-sign-up.
      If the admin already exists (returning installs, re-runs after success),
      the endpoint returns 400 — we log and continue.
@@ -22,31 +23,36 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
 
 
-# First-boot budget is generous because Immich has four containers
-# (immich-server, immich-machine-learning, redis, postgres) and the
-# server-image alone is ~2 GB. On a fresh install the path is
-# image-pull → pod-start → postgres-initdb → server-migrations →
-# /api/server-info goes 200. 180 s used to cover the API-probe only —
-# which fired before image pulls even finished. The split below gives
-# image pulls + pod start up to 10 min, and the server bootstrap
-# after the pod is Running another 5 min. Healthy fast machines exit
-# both loops within seconds.
-POD_RUNNING_TIMEOUT = 600.0
-READY_TIMEOUT = 300.0
+# Single end-to-end budget covering everything between deploy and
+# "API answers 200": image pull (~2 GB for immich-server alone),
+# pod start, postgres initdb, immich server migrations, NestJS boot.
+# Healthy fast machines exit within seconds; cold first-boot on slow
+# storage can take many minutes. 15 min is comfortably generous.
+#
+# Earlier shapes of this script had a separate wait_pod_running()
+# polling `podman pod inspect <pod> --format '{{.State}}'` for the
+# string "running" before the API probe. That check is fragile: the
+# pod sits in "Degraded" while containers come up one by one, the
+# format-string value depends on podman version, and the loop is
+# silent. We dropped it — the API probe below is the only signal that
+# actually answers "can the post-deploy talk to immich?", and an HTTP
+# 200 on /api/server-info already implies the pod and database are
+# alive. See PR adding this comment for the failure mode it fixed.
+READY_TIMEOUT = 900.0
 READY_INTERVAL = 2.0
 REQUEST_TIMEOUT = 30.0
-# Heartbeat cadence for the silent poll loops. Keeps the wizard's
+# Heartbeat cadence for the silent poll loop. Keeps the wizard's
 # /api/services NDJSON stream warm so undici doesn't fire its 5-min
 # bodyTimeout mid-wait and the runner doesn't see a phantom
-# "(terminated)" failure on healthy installs. 60 s gives ~5 lines per
-# loop in the worst case — cheap, and the operator can see progress.
+# "(terminated)" failure on healthy installs. 60 s gives one visible
+# progress line per minute, plus the route emits its own
+# `{type:"ping"}` every 30 s as a belt-and-braces stream keepalive.
 HEARTBEAT_INTERVAL = 60.0
 
 
@@ -89,49 +95,16 @@ def request_json(method: str, url: str, payload: object | None = None, token: st
         return 0, None
 
 
-def wait_pod_running(pod_name: str, deadline_sec: float = POD_RUNNING_TIMEOUT) -> bool:
-    """Poll `podman pod inspect` until the pod is Running. Covers image-pull
-    + first container start on fresh installs; on warm machines exits within
-    a second. Best-effort — any subprocess failure is treated as 'not yet'.
-
-    Emits a heartbeat line every HEARTBEAT_INTERVAL seconds — the wizard's
-    NDJSON stream from /api/services would otherwise stay silent for up to
-    POD_RUNNING_TIMEOUT and undici's bodyTimeout (5 min) would kill the
-    connection and trigger a phantom retry."""
-    started = time.time()
-    last_state = ""
-    last_heartbeat = started
-    while time.time() - started < deadline_sec:
-        try:
-            r = subprocess.run(
-                ["podman", "pod", "inspect", pod_name, "--format", "{{.State}}"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            state = r.stdout.strip().lower() if r.returncode == 0 else "unknown"
-            if state == "running":
-                return True
-        except Exception:  # pylint: disable=broad-except
-            state = "unknown"
-        now = time.time()
-        if now - last_heartbeat >= HEARTBEAT_INTERVAL or state != last_state:
-            elapsed = int(now - started)
-            log(f"   …pod state={state or 'pending'} ({elapsed}s/{int(deadline_sec)}s)")
-            last_heartbeat = now
-            last_state = state
-        time.sleep(2)
-    return False
-
-
 def wait_ready(port: str) -> tuple[bool, str]:
     """Poll Immich's /api/server-info until it returns 200. Tries both
     127.0.0.1 and [::1] because NestJS on Linux defaults to binding :: and
-    the effective loopback address depends on kernel IPV6_V6ONLY setting —
-    on FCoS only [::1] answers. Returns (success, base_url).
+    the effective loopback address depends on the kernel IPV6_V6ONLY
+    setting — on FCoS only [::1] answers. Returns (success, base_url).
 
-    Emits a heartbeat every HEARTBEAT_INTERVAL seconds — same rationale as
-    wait_pod_running."""
+    Carries the whole "is immich up?" budget on its own; covers image
+    pull + pod start + DB init + migrations. Emits a heartbeat line
+    every HEARTBEAT_INTERVAL seconds so the operator sees progress and
+    the install runner's NDJSON stream stays warm."""
     candidates = [f"http://127.0.0.1:{port}", f"http://[::1]:{port}"]
     started = time.time()
     last_heartbeat = started
@@ -143,7 +116,7 @@ def wait_ready(port: str) -> tuple[bool, str]:
         now = time.time()
         if now - last_heartbeat >= HEARTBEAT_INTERVAL:
             elapsed = int(now - started)
-            log(f"   …still waiting for /api/server-info ({elapsed}s/{int(READY_TIMEOUT)}s)")
+            log(f"   …still waiting for /api/server-info on 127.0.0.1 / [::1] ({elapsed}s/{int(READY_TIMEOUT)}s)")
             last_heartbeat = now
         time.sleep(READY_INTERVAL)
     return False, candidates[0]
@@ -160,13 +133,7 @@ def main() -> int:
     subdomain = env("IMMICH_SUBDOMAIN", "photos")
     public_url = f"https://{subdomain}.{public_domain}" if public_domain else f"http://127.0.0.1:{port}"
 
-    log(f"Waiting up to {int(POD_RUNNING_TIMEOUT)}s for the immich pod to enter Running state (covers image pull)…")
-    if not wait_pod_running("immich"):
-        log(f"❌ immich pod did not reach Running within {int(POD_RUNNING_TIMEOUT)}s — skipping seed/OIDC config.")
-        log("   Re-run this post-deploy from Diagnose → post_deploy_failed → 'Re-run post-install' once the pod is up.")
-        return 1
-
-    log(f"Waiting up to {int(READY_TIMEOUT)}s for Immich API (tries 127.0.0.1 and [::1] — NestJS binds IPv6-only on FCoS by default)…")
+    log(f"Waiting up to {int(READY_TIMEOUT)}s for Immich API on 127.0.0.1 / [::1] (covers image pull + DB init + migrations)…")
     ready, base_url = wait_ready(port)
     if not ready:
         log(f"❌ Immich /api/server-info did not respond on 127.0.0.1 or [::1] within {int(READY_TIMEOUT)}s — skipping seed/OIDC config.")


### PR DESCRIPTION
## Symptom

A fresh immich install hangs in the wizard with the same loop, regardless of how clean the host is:

```
Running immich post-deploy script...
Waiting up to 600s for the immich pod to enter Running state (covers image pull)…
⏳ immich attempt 1/3 failed (terminated); retrying in 1s…
…
```

Verified via MCP that the pod *is* fully up — the immich-server log clearly says:

```
[Api:Bootstrap] Immich Server is listening on http://[::1]:2283
```

…and ML server is healthy, geodata import is done. The seed step never runs anyway.

## Root cause

`templates/immich/post-deploy.py:wait_pod_running` (added in #438) is the culprit. It polls `podman pod inspect <pod> --format '{{.State}}'` looking for the literal `"running"`. On podman 5.8.1 (Fedora CoreOS) the pod spends a long time in `Degraded` while immich-server, immich-machine-learning, redis, and postgres come up one at a time. The loop is **silent** the entire time — by the time the pod settles to `Running`, undici's default 5-min `bodyTimeout` has already closed the install runner's NDJSON stream with `terminated`. The wizard retries from scratch, hits the same wall, and after `MAX_DEPLOY_ATTEMPTS` gives up — even though immich is healthy.

Pod state was always a proxy for the only thing we actually care about: "can the post-deploy talk to immich?". The API probe added in #441 (try `127.0.0.1` and `[::1]`) answers that directly, so the pod-state check is both fragile and redundant.

## Fix

1. **`templates/immich/post-deploy.py`** — delete `wait_pod_running` entirely. `wait_ready` carries the full budget (raised to 900 s) covering image pull + DB init + migrations + API ready. The probe is the authoritative signal; the loop heartbeats every 60 s for operator visibility.

2. **`src/app/api/services/route.ts`** — emit `{type: "ping"}` every 30 s while a deploy is running. Belt-and-braces stream keepalive that protects any future template whose post-deploy goes silent. The runner ignores unknown event types so this is wire-compatible.

## Test plan
- [ ] Fresh wipe + reinstall immich → wizard streams progress for the full duration, no `(terminated)` retries, `__SB_CREDENTIAL__` for the admin appears at the end
- [ ] Confirm the `…still waiting for /api/server-info on 127.0.0.1 / [::1]` heartbeats appear during the wait phase
- [ ] Diagnose stops surfacing `immich post_deploy_failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
