### PR TITLE
fix(install): probe immich on LAN_IP + stop seeding broken registry

### DIFF
--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -113,23 +113,19 @@ export async function saveAutoUpdateConfig(enabled: boolean) {
 
 export async function saveRegistriesConfig(enabled: boolean) {
     const config = await getConfig();
-    // Default registries if enabling
-    const defaultRegistry = {
-        name: 'ServiceBay Templates',
-        url: 'https://github.com/mdopp/servicebay-templates'
+    // No default external registry. The previous seed
+    // (`mdopp/servicebay-templates`) was a 404, and once #443 landed
+    // and the container actually bundled git, every fresh install
+    // tried to clone that URL on startup and aborted the whole sync
+    // loop — which is why operators kept hitting templates frozen at
+    // pre-sync state. `lib/registry.ts:getRegistries` already
+    // prepends the canonical `mdopp/servicebay` default, so leaving
+    // `items` empty here gives us the right behaviour: enable the
+    // mechanism, but only sync the bundled built-in registry.
+    config.registries = {
+        enabled,
+        items: config.registries?.items || []
     };
-    
-    if (enabled && (!config.registries?.items || config.registries.items.length === 0)) {
-        config.registries = {
-            enabled: true,
-            items: [defaultRegistry]
-        };
-    } else {
-        config.registries = {
-            enabled,
-            items: config.registries?.items || []
-        };
-    }
     await saveConfig(config);
 }
 

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -40,6 +40,7 @@ import { buildCredentialsManifest, type Credential } from '@/lib/stackInstall/cr
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
+import { getConfig } from '@/lib/config';
 import {
   appendLog,
   getJob,
@@ -354,6 +355,19 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
     if (typeof v.value === 'string') postDeployEnv[v.name] = v.value;
   }
   postDeployEnv.HOST = input.host || 'localhost';
+
+  // LAN_IP — the address rootless podman actually port-forwards to. With
+  // `hostNetwork: true` on a rootless pod, ports inside the container's
+  // namespace (e.g. immich-server binding [::1]:2283) are NOT visible on
+  // the host's main loopback; podman only publishes them on the LAN IP.
+  // Templates that need to HTTP-probe their own service from the host
+  // post-deploy shell should prefer LAN_IP over 127.0.0.1 / [::1].
+  // See templates/immich/post-deploy.py for the canonical use site.
+  try {
+    const config = await getConfig();
+    const lanIp = config.reverseProxy?.lanIp;
+    if (lanIp) postDeployEnv.LAN_IP = lanIp;
+  } catch { /* best-effort — missing LAN_IP just means templates fall back to loopback */ }
 
   const attemptDeploy = async (): Promise<void> => {
     const query = input.node ? `?node=${input.node}&stream=1` : '?stream=1';

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -208,22 +208,33 @@ export async function syncRegistries() {
 
     for (const reg of registries) {
         const regPath = path.join(REGISTRIES_DIR, reg.name);
+        // Isolate each registry: a single bad URL (a 404'd repo, an
+        // unreachable mirror) used to abort the entire loop, so the
+        // registries listed *after* it never got synced — which is why
+        // a stale `ServiceBay Templates` entry could silently strand
+        // the canonical `mdopp/servicebay` clone. Per-registry try/catch
+        // keeps subsequent registries syncing.
         try {
-            await fs.access(path.join(regPath, '.git'));
-            // Exists — fetch latest and reset (shallow clones can't reliably git pull)
-            console.log(`Updating registry ${reg.name}...`);
-            const branch = reg.branch || 'main';
-            await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath });
-            await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath });
-        } catch {
-            // Doesn't exist, clone
-            console.log(`Cloning registry ${reg.name}...`);
             try {
-                await cloneSparse(reg.url, regPath, ['templates', 'stacks']);
+                await fs.access(path.join(regPath, '.git'));
+                // Exists — fetch latest and reset (shallow clones can't reliably git pull)
+                console.log(`Updating registry ${reg.name}...`);
+                const branch = reg.branch || 'main';
+                await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath });
+                await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath });
             } catch {
-                // Fallback to full clone if sparse checkout not supported
-                await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath]);
+                // Doesn't exist, clone
+                console.log(`Cloning registry ${reg.name}...`);
+                try {
+                    await cloneSparse(reg.url, regPath, ['templates', 'stacks']);
+                } catch {
+                    // Fallback to full clone if sparse checkout not supported
+                    await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath]);
+                }
             }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.warn(`Registry ${reg.name} (${reg.url}) sync failed — skipping (other registries continue): ${msg}`);
         }
     }
 }

--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -96,16 +96,30 @@ def request_json(method: str, url: str, payload: object | None = None, token: st
 
 
 def wait_ready(port: str) -> tuple[bool, str]:
-    """Poll Immich's /api/server-info until it returns 200. Tries both
-    127.0.0.1 and [::1] because NestJS on Linux defaults to binding :: and
-    the effective loopback address depends on the kernel IPV6_V6ONLY
-    setting — on FCoS only [::1] answers. Returns (success, base_url).
+    """Poll Immich's /api/server-info until it returns 200. Returns
+    (success, base_url).
 
-    Carries the whole "is immich up?" budget on its own; covers image
-    pull + pod start + DB init + migrations. Emits a heartbeat line
-    every HEARTBEAT_INTERVAL seconds so the operator sees progress and
-    the install runner's NDJSON stream stays warm."""
-    candidates = [f"http://127.0.0.1:{port}", f"http://[::1]:{port}"]
+    Probes the host-published LAN_IP first, then 127.0.0.1 and [::1] as
+    fallbacks. The reason LAN_IP comes first: with rootless podman +
+    `hostNetwork: true` (immich's setup), ports the container binds
+    inside its own namespace — even on what the container thinks is
+    [::1] — are NOT routed back to the host's main loopback. Podman
+    only publishes them on the LAN IP via the userspace forwarder, so
+    the host post-deploy shell can reach immich at
+    http://<LAN_IP>:2283 but NOT at http://127.0.0.1:2283 or
+    http://[::1]:2283. We keep the loopback candidates around for
+    rootful / bridge-network environments where they actually work.
+
+    Carries the whole 'is immich up?' budget; covers image pull + pod
+    start + DB init + migrations. Emits a heartbeat line every
+    HEARTBEAT_INTERVAL seconds so the operator sees progress and the
+    install runner's NDJSON stream stays warm."""
+    lan_ip = env("LAN_IP")
+    candidates: list[str] = []
+    if lan_ip:
+        candidates.append(f"http://{lan_ip}:{port}")
+    candidates.extend([f"http://127.0.0.1:{port}", f"http://[::1]:{port}"])
+
     started = time.time()
     last_heartbeat = started
     while time.time() - started < READY_TIMEOUT:
@@ -116,7 +130,7 @@ def wait_ready(port: str) -> tuple[bool, str]:
         now = time.time()
         if now - last_heartbeat >= HEARTBEAT_INTERVAL:
             elapsed = int(now - started)
-            log(f"   …still waiting for /api/server-info on 127.0.0.1 / [::1] ({elapsed}s/{int(READY_TIMEOUT)}s)")
+            log(f"   …still waiting for /api/server-info on {', '.join(candidates)} ({elapsed}s/{int(READY_TIMEOUT)}s)")
             last_heartbeat = now
         time.sleep(READY_INTERVAL)
     return False, candidates[0]


### PR DESCRIPTION
## Evidence

Real reinstall trace, v3.27.3:
```
Waiting up to 900s for Immich API on 127.0.0.1 / [::1]…
…still waiting for /api/server-info on 127.0.0.1 / [::1] (60s/900s)
…
…still waiting for /api/server-info on 127.0.0.1 / [::1] (421s/900s)
⏳ immich attempt 1/3 failed (Agent disconnected); retrying in 1s…
```
…while the immich-server container was healthy and the bootstrap log clearly said `Immich Server is listening on http://[::1]:2283`.

## Root cause

Rootless podman with `hostNetwork: true` does **not** bridge the container's loopback bindings back to the host's main loopback. The userspace forwarder only publishes the port on the LAN IP (visible in `podman ps` as `hostIp: 192.168.178.100`). So:

- `core@host curl http://192.168.178.100:2283/api/server-info` → 200
- `core@host curl http://127.0.0.1:2283/api/server-info` → connection refused
- `core@host curl http://[::1]:2283/api/server-info` → connection refused

The previous post-deploy probed only the two loopback candidates and never got an answer. After ~7 min the SSH agent disconnected and the runner retried.

Why other templates didn't hit this: `auth`/`media` post-deploys bounce probes through `SB_API_URL` (ServiceBay's own API endpoint), so the probe runs inside ServiceBay's container and works regardless. `immich` was the only template doing a direct loopback probe from the host shell.

## Fix

1. **`templates/immich/post-deploy.py`** — try `LAN_IP` first, keep 127.0.0.1 / [::1] as fallbacks for rootful/bridge-network environments where they do work. Heartbeat line now shows every candidate.
2. **`src/lib/install/runner.ts`** — populate `LAN_IP` in `postDeployEnv` from `config.reverseProxy.lanIp`.
3. **`src/app/actions/onboarding.ts`** — stop seeding `mdopp/servicebay-templates` (a 404 repo). Combined with #443 finally putting git in the runtime image, that seed was actually getting cloned on every fresh install and aborting the sync loop, stranding the legitimate `mdopp/servicebay` default registry sync.
4. **`src/lib/registry.ts:syncRegistries`** — per-registry try/catch so one bad URL doesn't kill the entire loop.

## Test plan
- [ ] Fresh wipe + reinstall → wizard streams `…still waiting for /api/server-info on http://<LAN_IP>:2283, …` and exits with the admin credential within seconds of the pod going Running.
- [ ] Confirm `installedTemplates.immich` lands in config + diagnose's `post_deploy_failed` clears.
- [ ] Confirm the new install's `config.registries.items` is `[]` (or whatever the operator added), not the auto-seeded 404 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)