### PR TITLE
feat(setup): non-blocking install workspace at /setup

### DIFF
--- a/src/app/(dashboard)/setup/page.tsx
+++ b/src/app/(dashboard)/setup/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+/**
+ * /setup — non-blocking install workspace.
+ *
+ * The wizard's install phase used to monopolise the screen with a
+ * full-bleed modal: while the deploy ran the operator couldn't open
+ * Terminal to tail a log, peek at /services, or check Diagnose. That's
+ * uncomfortable for a 10-minute first-boot install where everything
+ * useful is right *behind* the modal.
+ *
+ * Now: once an install job is registered server-side (the wizard hits
+ * /api/install/start) the modal becomes minimisable, a "Setup" entry
+ * pops into the sidebar, and this page is the always-available view of
+ * the current job. Every connected client sees the same logs because
+ * the source of truth is the persisted job under /app/data/install-jobs,
+ * not per-tab React state. When the job lands in a terminal phase
+ * (`done` / `error` / `aborted` / `crashed`), the operator can click
+ * "Finish" — it clears `stackSetupPending` so the wizard stops
+ * auto-opening for everyone and the sidebar entry disappears.
+ *
+ * Deliberately spare: no input collection here, no per-template config.
+ * That stays in the wizard (which the operator can re-open any time).
+ * This page is just "what is the install doing right now, and what did
+ * it log?". For richer interaction (re-running a failed seed, etc.)
+ * operators land on Health → Diagnose.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CheckCircle2, AlertTriangle, Loader2, KeyRound, Maximize2 } from 'lucide-react';
+import { completeStackSetup } from '@/app/actions/onboarding';
+import type { JobPhase, JobState } from '@/lib/install/jobStore';
+
+interface StatusResponse {
+  job: JobState | null;
+  logs: string;
+  logsOffset: number;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+function phaseChrome(phase: JobPhase): { label: string; tone: 'info' | 'warn' | 'success' | 'error'; Icon: typeof Loader2 } {
+  switch (phase) {
+    case 'running':           return { label: 'Installing', tone: 'info', Icon: Loader2 };
+    case 'needs_credentials': return { label: 'Needs credentials', tone: 'warn', Icon: KeyRound };
+    case 'done':              return { label: 'Finished', tone: 'success', Icon: CheckCircle2 };
+    case 'error':             return { label: 'Error', tone: 'error', Icon: AlertTriangle };
+    case 'aborted':           return { label: 'Aborted', tone: 'warn', Icon: AlertTriangle };
+    case 'crashed':           return { label: 'Crashed', tone: 'error', Icon: AlertTriangle };
+  }
+}
+
+const TONE_CLASSES: Record<'info' | 'warn' | 'success' | 'error', string> = {
+  info:    'text-blue-700 bg-blue-100 dark:text-blue-200 dark:bg-blue-900/40',
+  warn:    'text-amber-700 bg-amber-100 dark:text-amber-200 dark:bg-amber-900/40',
+  success: 'text-emerald-700 bg-emerald-100 dark:text-emerald-200 dark:bg-emerald-900/40',
+  error:   'text-rose-700 bg-rose-100 dark:text-rose-200 dark:bg-rose-900/40',
+};
+
+const TERMINAL_PHASES: JobPhase[] = ['done', 'error', 'aborted', 'crashed'];
+
+export default function SetupPage() {
+  const router = useRouter();
+  const [job, setJob] = useState<JobState | null>(null);
+  const [logs, setLogs] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [finishing, setFinishing] = useState(false);
+  const logsOffsetRef = useRef(0);
+  const logViewRef = useRef<HTMLPreElement>(null);
+  const lastJobIdRef = useRef<string | null>(null);
+  const autoScrollRef = useRef(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const url = lastJobIdRef.current
+          ? `/api/install/status?jobId=${encodeURIComponent(lastJobIdRef.current)}&logsSince=${logsOffsetRef.current}`
+          : '/api/install/status';
+        const res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) return;
+        const data: StatusResponse = await res.json();
+        if (cancelled) return;
+
+        if (data.job?.id && data.job.id !== lastJobIdRef.current) {
+          lastJobIdRef.current = data.job.id;
+          logsOffsetRef.current = 0;
+          setLogs('');
+        }
+        setJob(data.job);
+        if (data.logs) {
+          setLogs(prev => prev + data.logs);
+          logsOffsetRef.current = data.logsOffset;
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void tick();
+    const handle = setInterval(tick, POLL_INTERVAL_MS);
+    return () => { cancelled = true; clearInterval(handle); };
+  }, []);
+
+  useEffect(() => {
+    if (!autoScrollRef.current) return;
+    const el = logViewRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [logs]);
+
+  const handleScroll = () => {
+    const el = logViewRef.current;
+    if (!el) return;
+    // Re-enable auto-scroll only when the user is at the very bottom.
+    autoScrollRef.current = el.scrollHeight - (el.scrollTop + el.clientHeight) < 8;
+  };
+
+  const handleFinish = async () => {
+    setFinishing(true);
+    try {
+      await completeStackSetup();
+      router.push('/services');
+      router.refresh();
+    } finally {
+      setFinishing(false);
+    }
+  };
+
+  const reopenWizard = () => {
+    // The wizard listens for this on the window so it can re-render
+    // even when minimised. Defined in OnboardingWizard.tsx.
+    window.dispatchEvent(new CustomEvent('servicebay:open-wizard'));
+  };
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-gray-500 dark:text-gray-400">
+        <Loader2 className="animate-spin mr-2" size={20} /> Loading install status…
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
+        <CheckCircle2 className="text-emerald-500 mb-3" size={36} />
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">No install in progress</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 max-w-md">
+          Open Services to manage what&apos;s deployed, or start a new install from
+          the wizard.
+        </p>
+      </div>
+    );
+  }
+
+  const { label, tone, Icon } = phaseChrome(job.phase);
+  const isTerminal = TERMINAL_PHASES.includes(job.phase);
+  const progress = job.progress;
+  const itemsLine = progress?.totalCount
+    ? `${progress.deployedNames.length} of ${progress.totalCount} deployed${progress.currentItem ? ` — currently: ${progress.currentItem}` : ''}`
+    : null;
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="px-6 py-4 border-b border-gray-200 dark:border-gray-800 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <span className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-medium ${TONE_CLASSES[tone]}`}>
+            <Icon size={14} className={job.phase === 'running' ? 'animate-spin' : ''} />
+            {label}
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold text-gray-900 dark:text-gray-100 truncate">Install in progress</h1>
+            {itemsLine && (
+              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{itemsLine}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={reopenWizard}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-200"
+            title="Re-open the install wizard"
+          >
+            <Maximize2 size={13} /> Open wizard
+          </button>
+          {isTerminal && (
+            <button
+              type="button"
+              onClick={handleFinish}
+              disabled={finishing}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-emerald-600 hover:bg-emerald-700 text-white disabled:opacity-50"
+            >
+              {finishing ? <Loader2 className="animate-spin" size={13} /> : <CheckCircle2 size={13} />}
+              Finish
+            </button>
+          )}
+        </div>
+      </header>
+
+      {job.error && (
+        <div className="mx-6 mt-4 p-3 rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-900/20 text-sm text-rose-800 dark:text-rose-200">
+          {job.error}
+        </div>
+      )}
+
+      <pre
+        ref={logViewRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-auto m-6 mt-4 p-4 rounded-md border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-pre-wrap leading-relaxed"
+      >
+        {logs || (job.phase === 'running' ? 'Waiting for log output…' : 'No log output captured.')}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -22,7 +22,7 @@ import type { TemplateTier } from '@/lib/templateTier';
 import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
 import { useStackInstall } from '@/lib/stackInstall/useStackInstall';
 
-import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive, Home } from 'lucide-react';
+import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive, Home, Minimize2 } from 'lucide-react';
 import StackVariableField from './StackVariableField';
 import { StackInstallProgress, StackInstallSummary } from './StackInstallFlow';
 import DiagnoseProbeList, { type DiagnoseProbe } from './DiagnoseProbeList';
@@ -346,6 +346,17 @@ export default function OnboardingWizard() {
       .then(r => r.ok ? r.json() : null)
       .then(d => { if (d?.version) setAppVersion(d.version); })
       .catch(() => { /* version is informational; silent failure is fine */ });
+  }, []);
+
+  // Re-open the wizard when /setup (or any other page) requests it.
+  // /setup is the non-blocking workspace shown while an install is
+  // running — its "Open wizard" button dispatches this event so the
+  // operator can come back to credential prompts / progress detail
+  // without losing wizard state.
+  useEffect(() => {
+    const onOpen = () => setIsOpen(true);
+    window.addEventListener('servicebay:open-wizard', onOpen);
+    return () => window.removeEventListener('servicebay:open-wizard', onOpen);
   }, []);
 
   useEffect(() => {
@@ -985,17 +996,34 @@ export default function OnboardingWizard() {
             filtering, so an express operator naturally sees a smaller
             denominator ("Step 1 of 2") without needing a separate UI. */}
         <div className="p-6 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
-           <h2 className="text-xl font-bold flex items-center gap-2">
-             <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
-               <Monitor className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-             </div>
-             ServiceBay Setup
-             {appVersion && (
-               <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400 align-middle">
-                 v{appVersion}
-               </span>
-             )}
-           </h2>
+           <div className="flex items-start justify-between gap-3">
+             <h2 className="text-xl font-bold flex items-center gap-2">
+               <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
+                 <Monitor className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+               </div>
+               ServiceBay Setup
+               {appVersion && (
+                 <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400 align-middle">
+                   v{appVersion}
+                 </span>
+               )}
+             </h2>
+             {/* Continue-in-background button. The install runs entirely
+                 server-side once `/api/install/start` returns, so closing
+                 the modal doesn't pause or abort anything — it just lets
+                 the operator navigate to Services / Terminal / Health
+                 while the deploy progresses. /setup keeps the live log
+                 view, the sidebar has a pulsing Setup entry, and the
+                 operator can pop the wizard back open from there. */}
+             <button
+               type="button"
+               onClick={() => setIsOpen(false)}
+               className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300"
+               title="Hide this dialog. The install keeps running; reopen from the Setup entry in the sidebar or /setup."
+             >
+               <Minimize2 size={13} /> Minimize
+             </button>
+           </div>
            {(() => {
              const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'machine', 'stacks', 'finish'];
              // Same two-path logic as getNextStep — see comment there.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings, Network, Users, ExternalLink, Sparkles, Home } from 'lucide-react';
+import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings, Network, Users, ExternalLink, Sparkles, Home, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import PluginHelp from './PluginHelp';
 import pkg from '../../package.json';
@@ -24,6 +24,14 @@ export default function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [showCollapsedNodeLabel, setShowCollapsedNodeLabel] = useState(false);
   const [lldapUrl, setLldapUrl] = useState<string | null>(null);
+  // Conditional sidebar entry for /setup. Visible whenever the server
+  // reports an active install job (running / needs_credentials) OR a
+  // recently-finished job that hasn't been acknowledged yet (terminal
+  // phases with stackSetupPending still set). This way "Setup" is a
+  // first-class destination during the 10-minute install window — the
+  // operator can navigate to Services / Terminal / Health and still
+  // come back to watch progress.
+  const [hasActiveInstall, setHasActiveInstall] = useState(false);
 
   useEffect(() => {
     if (window.innerWidth < 768) {
@@ -37,6 +45,26 @@ export default function Sidebar() {
       .then(r => r.ok ? r.json() : null)
       .then(data => { if (data?.url) setLldapUrl(data.url); })
       .catch(() => {});
+  }, []);
+
+  // Poll the install-job singleton so every connected client picks up
+  // (and drops) the "Setup" entry within 5 s — the operator on a
+  // second tab/phone should see the same affordance as the operator
+  // who clicked Install. Short interval is fine: payload is tiny and
+  // it pauses naturally when there's no active job.
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch('/api/install/status', { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = await res.json() as { job: { phase?: string } | null };
+        if (!cancelled) setHasActiveInstall(Boolean(data.job));
+      } catch { /* offline / mid-redeploy — keep the previous value */ }
+    };
+    void tick();
+    const handle = setInterval(tick, 5000);
+    return () => { cancelled = true; clearInterval(handle); };
   }, []);
 
   return (
@@ -84,6 +112,27 @@ export default function Sidebar() {
             </button>
         )}
         <div className="overflow-y-auto flex-1 p-2 space-y-1">
+            {hasActiveInstall && (() => {
+                const isActive = pathname?.startsWith('/setup') ?? false;
+                return (
+                    <button
+                        type="button"
+                        onClick={() => router.push('/setup')}
+                        className={`w-full text-left px-3 py-3 rounded-md flex items-center transition-colors ${
+                            isActive
+                            ? 'bg-white dark:bg-gray-800 text-blue-600 dark:text-blue-400 shadow-sm'
+                            : 'bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-300'
+                        } ${isCollapsed ? 'justify-center' : 'gap-3'}`}
+                        title={isCollapsed ? 'Setup in progress' : ''}
+                    >
+                        <div className="relative shrink-0">
+                            <Wrench size={20} className={isActive ? 'text-blue-500 dark:text-blue-400' : 'text-blue-600 dark:text-blue-400'} />
+                            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                        </div>
+                        {!isCollapsed && <span className="font-medium whitespace-nowrap overflow-hidden">Setup</span>}
+                    </button>
+                );
+            })()}
             {plugins.map(p => {
                 const Icon = p.icon;
                 const isActive = pathname?.startsWith(p.path) ?? false;


### PR DESCRIPTION
## Summary

While the install is running server-side, the wizard's modal monopolises the screen, so even though the deploy is fully async the operator can't reach Terminal, Services, Health, or Files until it finishes.

This PR adds a non-blocking workspace:

1. **`/setup` route** — live view of the active install job (phase, per-template progress, accumulated stdout) backed by the existing `/api/install/status` endpoint. Every connected client sees the same logs because the source of truth is the persisted job. Terminal phases get a "Finish" button that calls `completeStackSetup` so the wizard stops auto-opening and the sidebar entry disappears.

2. **Pulsing Setup entry in the sidebar** — shown only while there's an active install job. Polled every 5 s so a second tab / phone picks it up automatically.

3. **Minimize button on the wizard** — closes the modal without aborting the install (which is server-side anyway). A `servicebay:open-wizard` window event lets `/setup` pop the modal back open without losing wizard state.

## Out of scope

- This is **not** a wizard replacement. Input collection (domain, gateway, stacks, variables) still happens in the modal.
- No backend changes — uses the already-existing `/api/install/status` + `completeStackSetup` action.

## Test plan
- [ ] Start an install → minimize the wizard → confirm the sidebar shows a pulsing "Setup" entry above Services.
- [ ] Navigate to Services / Terminal / Health while install runs — sidebar entry still visible, install keeps progressing.
- [ ] Click "Setup" in the sidebar → land on /setup → confirm phase/progress/log render.
- [ ] When install completes successfully, "Finish" appears → click → returns to /services and Setup entry disappears.
- [ ] Open the same /setup URL in a second browser tab — both see the same logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)