### PR TITLE
fix(immich): oauth schema requires tokenEndpointAuthMethod + signing algos

### DIFF
--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -228,6 +228,25 @@ def main() -> int:
         # locally if SSO breaks; flip to True later via the Immich UI.
         "autoLaunch": False,
         "signingAlgorithm": "RS256",
+        # Immich 2.x added three required oauth fields that older
+        # immich-server builds tolerated being absent. PATCH/PUT now
+        # 400s with `should not be empty` / `must be a string` if
+        # any of them are missing.
+        #   - tokenEndpointAuthMethod: how Immich authenticates to the
+        #     OIDC provider when redeeming the auth code. Authelia
+        #     accepts both `client_secret_post` and `client_secret_basic`;
+        #     `client_secret_post` is the safer default for first-time
+        #     setups (won't trip basic-auth parsing on proxies).
+        #   - profileSigningAlgorithm: signing algo Immich expects on
+        #     the userinfo JWT. Authelia doesn't sign userinfo by
+        #     default, but the field still has to be a non-empty
+        #     string. `RS256` matches Authelia's id_token signing.
+        #   - roleClaim: optional claim name that maps to Immich admin
+        #     role. Empty string opts out of role-based assignment —
+        #     operators promote to admin manually for now.
+        "tokenEndpointAuthMethod": "client_secret_post",
+        "profileSigningAlgorithm": "RS256",
+        "roleClaim": "",
         "mobileOverrideEnabled": False,
         "mobileRedirectUri": "",
         "storageLabelClaim": "preferred_username",


### PR DESCRIPTION
## Symptom

From the install just now (v3.30.0 + Immich 2.7.5):

```
✅ Created Immich admin mdopp79@gmail.com.
⚠️  Could not write OIDC config (HTTP 400): {
  'oauth.tokenEndpointAuthMethod should not be empty',
  'oauth.tokenEndpointAuthMethod must be one of the following values:
     client_secret_post, client_secret_basic',
  'oauth.profileSigningAlgorithm should not be empty',
  'oauth.profileSigningAlgorithm must be a string',
  'oauth.roleClaim must be a string',
  ...
}
```

Admin is seeded; only the OIDC config write is rejected.

## Root cause

Newer immich-server builds added three required fields to the oauth object. Older builds tolerated their absence; the PUT now 400s.

## Fix

Add safe defaults that match Authelia's OIDC behaviour:

- `tokenEndpointAuthMethod = "client_secret_post"` — Authelia accepts both `post` and `basic`; `post` is safer for first-time installs.
- `profileSigningAlgorithm = "RS256"` — non-empty string required; matches Authelia's id_token signing algorithm.
- `roleClaim = ""` — opt out of role-claim → admin auto-promotion; operators promote manually.

## Test plan
- [ ] Fresh immich install or "Re-run post-install" from Diagnose → no HTTP 400, log shows `✅ Immich OIDC configured against https://auth.<domain>`.
- [ ] Click "Login with Authelia" in the Immich UI → redirect through Authelia → land back in Immich logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)