### PR TITLE
fix(diagnose): suppress crash_loop young-container rule after a fresh install

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -11,6 +11,7 @@ import { checkProxyRouteMissing } from '@/lib/diagnose/probes/proxyRouteMissing'
 import { checkCertExpiry } from '@/lib/diagnose/probes/certExpiry';
 import { checkCertRequestFailure } from '@/lib/diagnose/probes/certRequestFailure';
 import { checkAdguardRewritesMissing } from '@/lib/diagnose/probes/adguardRewritesMissing';
+import { wasInstallActiveWithin } from '@/lib/install/jobStore';
 import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
@@ -343,7 +344,16 @@ export async function POST(request: Request) {
   // restarting; younger ones are just "started at boot, not looping". 90 s
   // covers the slowest cold-start + a tiny grace window.
   const recentBootGrace = 90;
-  const treatYoungAsLoop = systemUptimeSec > recentBootGrace;
+  // Same suppression after an install: the /setup auto-diagnose fires
+  // the moment a job lands in `done`, by which point the fresh
+  // containers are 30-90 s old and would all trip the "Up <30s" rule.
+  // System uptime is past `recentBootGrace` by then (FCoS booted
+  // hours ago), so the boot-time gate doesn't help. Five minutes is
+  // wide enough for the slowest first-boot install path (image pulls
+  // + post-deploy seeds + the operator clicking "Finish") to settle.
+  const RECENT_INSTALL_GRACE_MS = 5 * 60_000;
+  const recentInstall = await wasInstallActiveWithin(RECENT_INSTALL_GRACE_MS);
+  const treatYoungAsLoop = systemUptimeSec > recentBootGrace && !recentInstall;
 
   const psLines = trimOutput(psStatus.stdout, 80).split('\n').filter(Boolean);
   const looping = psLines.filter(l => {
@@ -398,7 +408,9 @@ export async function POST(request: Request) {
           : looping.length === 0
             ? (treatYoungAsLoop
                 ? `${psLines.length} container(s), all stable.`
-                : `${psLines.length} container(s) — system booted ${systemUptimeSec}s ago, young containers expected. Re-run after ~2 min for a real restart-loop check.`)
+                : recentInstall
+                    ? `${psLines.length} container(s) — install just finished, young containers expected. Re-run after ~5 min for a real restart-loop check.`
+                    : `${psLines.length} container(s) — system booted ${systemUptimeSec}s ago, young containers expected. Re-run after ~2 min for a real restart-loop check.`)
             : `${looping.length} of ${psLines.length} container(s) may be in a restart loop.`),
     hint: looping.length > 0
       ? 'Each row shows the last log lines from the container. Click "Restart" after fixing the root cause (bind-mount perms, missing config, port conflict). "Show recent logs" pulls the last 5 lines for a quick triage without SSH.'

--- a/src/lib/install/jobStore.ts
+++ b/src/lib/install/jobStore.ts
@@ -196,6 +196,27 @@ async function listJobs(): Promise<JobState[]> {
   }
 }
 
+/**
+ * "Has there been recent install activity?" — true if a job is
+ * currently running OR the most-recent terminal job ended less than
+ * `graceMs` milliseconds ago. Used by diagnose probes (e.g.
+ * crash_loop) to soften "container is too young → must be restarting"
+ * heuristics that would otherwise fire on freshly-deployed services
+ * the moment the install finishes. Cheap (one disk scan); callers
+ * are usually rare (one probe run per diagnose), so we don't cache.
+ */
+export async function wasInstallActiveWithin(graceMs: number): Promise<boolean> {
+  const jobs = await listJobs();
+  if (jobs.length === 0) return false;
+  const now = Date.now();
+  for (const j of jobs) {
+    if (j.phase === 'running' || j.phase === 'needs_credentials') return true;
+    const ended = j.endedAt ? Date.parse(j.endedAt) : Date.parse(j.updatedAt);
+    if (Number.isFinite(ended) && now - ended < graceMs) return true;
+  }
+  return false;
+}
+
 /** Singleton "is an install in progress?" check. Returns the most
  *  recent job in an active phase, or null. Replaces installLock.ts. */
 export async function getCurrentJob(): Promise<JobState | null> {


### PR DESCRIPTION
## Symptom

`/setup` auto-runs the self-test the moment an install lands in `done`. With 38 containers freshly deployed, the operator sees:

```
⚠️ Containers stable
7 of 38 container(s) may be in a restart loop.
```

…even though every flagged container is just 30–90 s old because we *just* deployed them.

## Root cause

The probe already has a system-uptime gate (don't flag young containers if the host has been up <90 s, because they can't have been up *longer* than the kernel). That gate doesn't help here: FCoS has been up for hours by the time ServiceBay deploys containers, so the gate passes and every young container trips the `Up <30s` heuristic.

## Fix

Add a second gate that mirrors the boot one for installs:

```ts
const recentInstall = await wasInstallActiveWithin(5 * 60_000);
const treatYoungAsLoop = systemUptimeSec > recentBootGrace && !recentInstall;
```

If any install job is running OR ended in the last 5 minutes, treat young containers as expected and surface a friendlier message ("install just finished, young containers expected — re-run after ~5 min for a real restart-loop check"). The 5-minute window covers the slowest first-boot path with slack. Re-runs after that go back to the strict heuristic so a genuine crash-loop still surfaces.

`wasInstallActiveWithin(graceMs)` is a single-purpose helper on `jobStore` — one disk scan of `/app/data/install-jobs/*.json`, no caching (diagnose runs are rare relative to anything that churns the job store).

## Test plan
- [ ] Fresh install → /setup auto-diagnose shows `38 container(s) — install just finished, young containers expected.` (not `7 of 38 may be in a restart loop`)
- [ ] Wait 6 min, click "Run again" → strict heuristic returns; if a container actually keeps restarting it shows up
- [ ] System restart (no install) → existing boot-grace gate still works; behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)