### PR TITLE
fix(wizard): don't auto-open after install — route operator to /setup instead

### DIFF
--- a/src/app/api/install/status/route.ts
+++ b/src/app/api/install/status/route.ts
@@ -1,24 +1,32 @@
 import { NextResponse } from 'next/server';
-import { getCurrentJob, getJob, readLog } from '@/lib/install/jobStore';
+import { getCurrentJob, getJob, getLatestJob, readLog } from '@/lib/install/jobStore';
+import { getConfig } from '@/lib/config';
 import { apiError } from '@/lib/api/errors';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * Read job state + accumulated logs since a byte offset. Used by the
- * client for two purposes:
+ * Read job state + accumulated logs since a byte offset.
  *
- *   1. Initial load on mount — fetches full state and any log lines
- *      the socket connection might have missed before subscribe.
- *   2. Active-install detection — when no jobId is supplied, returns
- *      the most recent active job so a reopened browser tab can attach
- *      without prior knowledge of the jobId.
- *
- * Query params:
- *   - `jobId`     (optional) — specific job to fetch; defaults to the
- *                              currently active job
+ *   - `jobId`     (optional) — specific job to fetch.
  *   - `logsSince` (optional) — byte offset; only returns log content
- *                              past this point (incremental fetch)
+ *                              past this point (incremental fetch).
+ *
+ * Response shape:
+ *   {
+ *     job:           <active job, or the most recent job in any phase if no
+ *                    active one, or null when no jobs have ever run>
+ *     jobIsActive:   <true while phase is running|needs_credentials>
+ *     stackSetupPending: <config flag — true while the operator hasn't
+ *                    clicked Finish on /setup>
+ *     logs / logsOffset
+ *   }
+ *
+ * Both Sidebar (Setup pill visibility) and OnboardingWizard (auto-open
+ * suppression) hang off this one endpoint. Returning the latest *any*
+ * job instead of only active ones closes the UX gap where the wizard
+ * pops back open on every reload after install finishes but the
+ * operator hasn't acknowledged the result yet.
  */
 export async function GET(request: Request) {
   try {
@@ -26,12 +34,33 @@ export async function GET(request: Request) {
     const jobId = url.searchParams.get('jobId');
     const sinceBytes = parseInt(url.searchParams.get('logsSince') || '0', 10);
 
-    const job = jobId ? await getJob(jobId) : await getCurrentJob();
-    if (!job) return NextResponse.json({ job: null, logs: '', logsOffset: 0 });
+    let job = jobId ? await getJob(jobId) : await getCurrentJob();
+    const jobIsActive = !!job; // getCurrentJob only returns active phases
+    if (!job && !jobId) {
+      // Fall through to the most-recent job so /setup + Sidebar can
+      // still show the "click Finish" state after the operator
+      // minimised the wizard.
+      job = await getLatestJob();
+    }
+
+    const config = await getConfig();
+    const stackSetupPending = config.stackSetupPending === true;
+
+    if (!job) {
+      return NextResponse.json({
+        job: null,
+        jobIsActive: false,
+        stackSetupPending,
+        logs: '',
+        logsOffset: 0,
+      });
+    }
 
     const logs = await readLog(job.id, isNaN(sinceBytes) ? 0 : sinceBytes);
     return NextResponse.json({
       job,
+      jobIsActive,
+      stackSetupPending,
       logs: logs.content,
       logsOffset: logs.nextOffset,
     });

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -360,8 +360,23 @@ export default function OnboardingWizard() {
   }, []);
 
   useEffect(() => {
-    checkOnboardingStatus().then(s => {
+    // We check two things in parallel: the wizard-onboarding status
+    // (does setup need to start at all?) and the install-job status
+    // (is there a *terminal* job sitting around that the operator
+    // never acknowledged?). The second one decides whether to skip
+    // the auto-open: if there's a finished install + stackSetupPending
+    // we route the operator to /setup instead of slamming the modal
+    // back over their screen on every reload (#wizard-pop-on-reload).
+    Promise.all([
+      checkOnboardingStatus(),
+      fetch('/api/install/status', { cache: 'no-store' })
+        .then(r => r.ok ? r.json() : null)
+        .then(d => d as { job?: { phase?: string } | null; jobIsActive?: boolean } | null)
+        .catch(() => null),
+    ]).then(([s, installStatus]) => {
       setStatus(s);
+      const hasTerminalJob = !!installStatus?.job && installStatus.jobIsActive === false;
+
       // If the server reports an active install job and we're NOT
       // already tracking it locally, auto-attach to it. This is the
       // critical "operator reopened the tab mid-install" path: the
@@ -395,6 +410,23 @@ export default function OnboardingWizard() {
           );
         }
       } else if (s.stackSetupPending) {
+        // If there's already a terminal install job on the server, the
+        // operator has *started* an install; they just haven't clicked
+        // "Finish" on /setup yet. Popping the modal back open on every
+        // reload in this state is hostile — the operator is using
+        // ServiceBay normally and gets a 90vh dialog shoved in their
+        // face. The Sidebar Setup pill stays visible (and pulses) while
+        // `stackSetupPending: true`, and /setup is one click away to
+        // see credentials / DNS verify / Finish. So: skip auto-open.
+        if (hasTerminalJob) {
+          // Suppress the modal but keep `stacksOnlyMode` armed so if
+          // the operator does open the wizard via the sidebar's
+          // "Open wizard" affordance they land on install-confirm.
+          setStacksOnlyMode(true);
+          setCurrentStep('install-confirm');
+          return;
+        }
+        // No prior install attempt yet: legitimate first-run auto-open.
         // Setup was completed by installer, but stacks haven't been chosen
         // yet. Land on the install-confirm screen — domain +
         // clean-install + preselected full-stack. Edit drops them into

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -52,14 +52,27 @@ export default function Sidebar() {
   // second tab/phone should see the same affordance as the operator
   // who clicked Install. Short interval is fine: payload is tiny and
   // it pauses naturally when there's no active job.
+  //
+  // Visibility rule: show the pill whenever EITHER (a) an install job
+  // is currently running, OR (b) the operator hasn't acknowledged a
+  // terminal install yet (`stackSetupPending: true`). The second case
+  // is what gives the operator a path back to /setup after they
+  // minimised the wizard but never clicked "Finish".
   useEffect(() => {
     let cancelled = false;
     const tick = async () => {
       try {
         const res = await fetch('/api/install/status', { cache: 'no-store' });
         if (!res.ok) return;
-        const data = await res.json() as { job: { phase?: string } | null };
-        if (!cancelled) setHasActiveInstall(Boolean(data.job));
+        const data = await res.json() as {
+          job: { phase?: string } | null;
+          jobIsActive?: boolean;
+          stackSetupPending?: boolean;
+        };
+        if (cancelled) return;
+        setHasActiveInstall(
+          Boolean(data.jobIsActive) || Boolean(data.stackSetupPending),
+        );
       } catch { /* offline / mid-redeploy — keep the previous value */ }
     };
     void tick();

--- a/src/lib/install/jobStore.ts
+++ b/src/lib/install/jobStore.ts
@@ -217,6 +217,20 @@ export async function wasInstallActiveWithin(graceMs: number): Promise<boolean> 
   return false;
 }
 
+/**
+ * Most-recent job in *any* phase, sorted by start time. Used by the
+ * UI to decide whether to show "Setup" affordances after an install
+ * has finished — `getCurrentJob` filters to active phases only, so a
+ * job that's already `done` is invisible to it. Returns `null` only
+ * when no jobs have ever been recorded.
+ */
+export async function getLatestJob(): Promise<JobState | null> {
+  const jobs = await listJobs();
+  if (jobs.length === 0) return null;
+  jobs.sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  return jobs[0];
+}
+
 /** Singleton "is an install in progress?" check. Returns the most
  *  recent job in an active phase, or null. Replaces installLock.ts. */
 export async function getCurrentJob(): Promise<JobState | null> {


### PR DESCRIPTION
## Symptom

Operator report: every hard reload re-pops the install wizard over the screen. Minimising it makes the wizard disappear but also makes the Sidebar Setup pill disappear → no way back to /setup to click Finish.

## Root cause

- `config.stackSetupPending: true` is the legitimate "operator hasn't clicked Finish yet" signal.
- `OnboardingWizard.tsx:422` force-opens the modal at install-confirm whenever that flag is true, regardless of whether the install has already completed.
- `Sidebar.tsx`'s Setup pill only renders when `getCurrentJob()` returns a non-null job — and that helper filters to *active* phases only. Once the job is `done` the pill vanishes.

So after a finished but un-Finished install: modal slams over the screen, pill vanishes, /setup is unreachable from the chrome.

## Fix

One server signal, three consumers:

- **`getLatestJob()`** — new `jobStore` helper returning the most-recent job in *any* phase. Stays distinct from `getCurrentJob()` (active-only).
- **`/api/install/status`** now returns `{ job, jobIsActive, stackSetupPending, … }`. `job` falls back to the latest terminal job when no active one exists; `jobIsActive` is the disambiguator; `stackSetupPending` mirrors the config flag.
- **`Sidebar.tsx`** shows the Setup pill while `jobIsActive || stackSetupPending`. Persists through a terminal install until the operator clicks Finish.
- **`OnboardingWizard.tsx`** skips the `stackSetupPending` auto-open branch when a terminal install job exists. The operator finds /setup via the Sidebar pill (which is now correctly visible).

## Test plan

- [ ] Reload the dashboard after a finished install that wasn't Finished — wizard does NOT pop up; Sidebar Setup pill is visible and pulses.
- [ ] Click the Sidebar Setup pill → land on /setup → click Finish → pill disappears, wizard stops auto-opening.
- [ ] Fresh install with no jobs yet: wizard still auto-opens at install-confirm (no regression for first-run).
- [ ] Mid-install reload: existing "attach to running job" path still kicks in (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)