### PR TITLE
fix(diagnose): correct LAN domain diagnosis + throttle letsdebug

### DIFF
--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -13,19 +13,22 @@
  *     <domain>". Catches DNS not pointed at your WAN IP, port 80
  *     not forwarded, IPv6 misconfig, ACME CAA records, etc.
  *
- * Cost: letsdebug.net does a 10-30 s probe per submission, and they
- * publish a rate limit. We cap to one HTTP-01 test per submission,
- * fire them in parallel, and cache the result for 24 h so re-runs of
- * `/api/system/diagnose` don't hammer their endpoint. Only public
- * domains (anything NOT ending in `.home.arpa` / `.local`) are
- * checked; LAN domains are skipped silently.
+ * Rate-limit etiquette: letsdebug.net 429s aggressively when you
+ * submit more than a couple of tests in quick succession. So:
+ *   - At most ONE fresh letsdebug submission per diagnose run.
+ *     Other domains read from cache (or show "queued").
+ *   - The domain picked for the fresh probe is the one whose cache
+ *     entry is oldest (or missing) — round-robins naturally across
+ *     re-runs without us having to track it explicitly.
+ *   - Successful results cached 24 h. Failures (429, 5xx, timeouts)
+ *     cached only 10 min so we don't get stuck reporting a stale
+ *     transport error.
  *
  * Behaviour:
  *   - status 'info' when no public domains exist (nothing to check)
  *   - status 'ok' when every probe completed and reported no problems
  *   - status 'warn' for non-Fatal problems (e.g. CAA inferiority)
- *   - status 'fail' when at least one Fatal problem is found OR a
- *     submission failed for transport reasons
+ *   - status 'fail' when at least one Fatal problem is found
  */
 
 import { getConfig } from '@/lib/config';
@@ -40,7 +43,10 @@ export interface DomainExternalReachabilityResult {
   items?: ProbeItem[];
 }
 
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CACHE_TTL_OK_MS    = 24 * 60 * 60 * 1000; // 24 h for successful checks
+const CACHE_TTL_FAIL_MS  =  10 * 60 * 1000;     // 10 min for transport errors
+const MAX_FRESH_PROBES_PER_RUN = 1;
+
 interface CacheEntry {
   fetchedAt: number;
   ok: boolean;
@@ -55,6 +61,11 @@ function isPublicDomain(domain: string): boolean {
   return !domain.endsWith('.home.arpa') && !domain.endsWith('.local');
 }
 
+function isCacheFresh(entry: CacheEntry): boolean {
+  const ttl = entry.error ? CACHE_TTL_FAIL_MS : CACHE_TTL_OK_MS;
+  return Date.now() - entry.fetchedAt < ttl;
+}
+
 function severityForProblem(p: LetsdebugProblem): 'warn' | 'fail' {
   return (p.severity || '').toLowerCase() === 'fatal' ? 'fail' : 'warn';
 }
@@ -65,11 +76,7 @@ function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'wa
   return 'ok';
 }
 
-async function checkOne(domain: string): Promise<CacheEntry> {
-  const cached = cache.get(domain);
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-    return cached;
-  }
+async function probeNow(domain: string): Promise<CacheEntry> {
   try {
     const result = await runLetsdebugForDomain(domain);
     const entry: CacheEntry = {
@@ -93,6 +100,20 @@ async function checkOne(domain: string): Promise<CacheEntry> {
   }
 }
 
+function pickDomainsToRefresh(allDomains: string[]): string[] {
+  // Stale-first ordering. Domains with no cache entry are "fully
+  // stale" and tied; ties broken alphabetically for stability.
+  const sorted = [...allDomains].sort((a, b) => {
+    const ea = cache.get(a);
+    const eb = cache.get(b);
+    const ta = ea ? ea.fetchedAt : 0;
+    const tb = eb ? eb.fetchedAt : 0;
+    if (ta !== tb) return ta - tb;
+    return a.localeCompare(b);
+  });
+  return sorted.slice(0, MAX_FRESH_PROBES_PER_RUN);
+}
+
 export async function checkDomainExternalReachability(): Promise<DomainExternalReachabilityResult> {
   const config = await getConfig();
   const hosts = config.reverseProxy?.hosts ?? [];
@@ -105,29 +126,50 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     };
   }
 
-  logger.info('diagnose:domain_external_reachability', `Running letsdebug for ${publicDomains.length} domain(s)`);
-  const settled = await Promise.all(publicDomains.map(d => checkOne(d).then(r => ({ domain: d, entry: r }))));
+  const toRefresh = new Set(
+    pickDomainsToRefresh(publicDomains.filter(d => !isCacheFresh(cache.get(d) ?? { fetchedAt: 0, ok: false, problems: [], submissionUrl: null, error: 'never-checked' }))),
+  );
+  logger.info(
+    'diagnose:domain_external_reachability',
+    `Refreshing ${toRefresh.size} of ${publicDomains.length} public domain(s); others read from cache.`,
+  );
+  for (const d of toRefresh) {
+    await probeNow(d);
+  }
 
   let overall: 'ok' | 'warn' | 'fail' = 'ok';
   const items: ProbeItem[] = [];
   let failedCount = 0;
   let warnCount = 0;
+  let pendingCount = 0;
 
-  for (const { domain, entry } of settled) {
+  for (const domain of publicDomains) {
+    const entry = cache.get(domain);
+    if (!entry) {
+      pendingCount++;
+      items.push({
+        id: domain,
+        label: domain,
+        detail: 'Queued — letsdebug rate-limited; will refresh on the next diagnose run.',
+        status: 'info',
+        actionIds: [],
+      });
+      continue;
+    }
     if (entry.error) {
       overall = worst(overall, 'warn');
       warnCount++;
       items.push({
         id: domain,
         label: domain,
-        detail: `letsdebug probe could not run: ${entry.error.slice(0, 160)}`,
+        detail: `letsdebug probe could not run: ${entry.error.slice(0, 160)}${entry.submissionUrl ? ` · Report: ${entry.submissionUrl}` : ''}`,
         status: 'warn',
         actionIds: [],
       });
       continue;
     }
     if (entry.problems.length === 0) {
-      // Don't emit an item for healthy domains — too much noise.
+      // Healthy — no row.
       continue;
     }
     const itemStatus = entry.problems.some(p => severityForProblem(p) === 'fail') ? 'fail' : 'warn';
@@ -137,13 +179,13 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     items.push({
       id: domain,
       label: domain,
-      detail: `${top.name || 'problem'}: ${(top.explanation || '').slice(0, 200)}`,
+      detail: `${top.name || 'problem'}: ${(top.explanation || '').slice(0, 200)}${entry.submissionUrl ? ` · Report: ${entry.submissionUrl}` : ''}`,
       status: itemStatus,
       actionIds: [],
     });
   }
 
-  if (overall === 'ok') {
+  if (overall === 'ok' && pendingCount === 0) {
     return {
       status: 'ok',
       detail: `${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'} reachable from the internet.`,
@@ -153,11 +195,12 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   const parts: string[] = [];
   if (failedCount) parts.push(`${failedCount} fatal`);
   if (warnCount) parts.push(`${warnCount} warning`);
+  if (pendingCount) parts.push(`${pendingCount} queued`);
+
   return {
-    status: overall,
-    detail: `${parts.join(' · ')} on ${items.length} of ${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'}.`,
-    hint: 'Most common cause is public port 80 not reachable from the internet (router port-forward missing or hairpin issue). Click a domain to open its letsdebug.net report for the full detail; cached results stay valid for 24 h.',
+    status: pendingCount > 0 && overall === 'ok' ? 'info' : overall,
+    detail: `${parts.join(' · ')} of ${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'}.`,
+    hint: 'Most common cause: public port 80 not reachable (router port-forward missing or hairpin issue). Each domain\'s row includes its letsdebug.net report URL — copy + paste to view. Only one fresh probe runs per diagnose run to stay under letsdebug\'s rate limit; re-run diagnose to refresh the next one.',
     items,
   };
 }
-

--- a/src/lib/diagnose/probes/domainUnreachable.ts
+++ b/src/lib/diagnose/probes/domainUnreachable.ts
@@ -38,8 +38,9 @@
  */
 
 import dns from 'dns/promises';
-import { getConfig, type ProxyHostEntry } from '@/lib/config';
+import { getConfig, type ProxyHostEntry, type AppConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
+import { listRewrites } from '@/lib/adguard/rewrites';
 import type { ProbeItem } from '../actions';
 
 export interface DomainUnreachableResult {
@@ -77,13 +78,46 @@ async function resolveOrNull(hostname: string): Promise<string[] | null> {
   }
 }
 
-async function fetchOrClassify(url: string): Promise<{ ok: true; status: number; bodySnippet: string } | { ok: false; reason: 'tls' | 'refused' | 'timeout' | 'dns' | 'other'; detail: string }> {
+/**
+ * "Is DNS configured for this LAN domain?" — answered by asking
+ * AdGuard, not by trying to resolve the name. ServiceBay's container
+ * doesn't use AdGuard as its own resolver, so `dns.lookup` against
+ * a `.home.arpa` name always fails regardless of how clean the
+ * AdGuard rewrite list looks. Clients using AdGuard as DNS get the
+ * right answer; the diagnose probe needs to verify that, not
+ * mistakenly conflate it with its own resolver setup.
+ *
+ * Returns `null` when AdGuard credentials aren't stored yet — the
+ * caller treats that as "AdGuard not deployed", which is the same
+ * answer as "no rewrite found".
+ */
+async function adguardResolves(domain: string, config: AppConfig): Promise<string[] | null> {
+  const ag = config.adguard;
+  if (!ag?.password) return null;
+  try {
+    const rewrites = await listRewrites({
+      adminUrl: ag.adminUrl || `http://localhost:${config.templateSettings?.ADGUARD_ADMIN_PORT ?? '8083'}`,
+      username: ag.username || 'admin',
+      password: ag.password,
+    });
+    // AdGuard wildcard entries store as `*.home.arpa`. Match either
+    // a literal entry OR a wildcard whose suffix covers the domain.
+    const matches = rewrites
+      .filter(r => r.domain === domain || (r.domain.startsWith('*.') && domain.endsWith(r.domain.slice(1))))
+      .map(r => r.answer);
+    return matches.length > 0 ? Array.from(new Set(matches)) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchOrClassify(url: string): Promise<{ ok: true; status: number; bodySnippet: string; headers: Headers } | { ok: false; reason: 'tls' | 'refused' | 'timeout' | 'dns' | 'other'; detail: string }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
     const res = await fetch(url, { signal: controller.signal, redirect: 'manual' });
     const body = await res.text().catch(() => '');
-    return { ok: true, status: res.status, bodySnippet: body.slice(0, 256) };
+    return { ok: true, status: res.status, bodySnippet: body.slice(0, 256), headers: res.headers };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(msg)) return { ok: false, reason: 'dns', detail: msg };
@@ -96,8 +130,39 @@ async function fetchOrClassify(url: string): Promise<{ ok: true; status: number;
   }
 }
 
-async function diagnoseDomain(host: ProxyHostEntry, lanIp: string | undefined): Promise<Diagnosis | null> {
+/**
+ * Probe NPM directly via the LAN IP with a `Host:` header — the
+ * only way to test proxy routing without depending on a working
+ * resolver. Same shape as `fetchOrClassify`. ServiceBay's container
+ * shares the host's network namespace (hostNetwork), so `lanIp:80`
+ * is just a TCP socket away.
+ */
+async function fetchWithHostHeader(npmUrl: string, hostHeader: string): Promise<ReturnType<typeof fetchOrClassify> extends Promise<infer T> ? T : never> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(npmUrl, {
+      signal: controller.signal,
+      redirect: 'manual',
+      headers: { Host: hostHeader },
+    });
+    const body = await res.text().catch(() => '');
+    return { ok: true, status: res.status, bodySnippet: body.slice(0, 256), headers: res.headers };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/ECONNREFUSED/i.test(msg)) return { ok: false, reason: 'refused', detail: msg };
+    if (/aborted|timeout|ETIMEDOUT/i.test(msg)) return { ok: false, reason: 'timeout', detail: msg };
+    if (/certificate|TLS|SSL|self-signed|unable to verify/i.test(msg)) return { ok: false, reason: 'tls', detail: msg };
+    if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(msg)) return { ok: false, reason: 'dns', detail: msg };
+    return { ok: false, reason: 'other', detail: msg };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<Diagnosis | null> {
   const domain = host.domain;
+  const lanIp = config.reverseProxy?.lanIp;
   const isLan = isLanDomain(domain);
   const scheme = isLan ? 'http' : 'https';
 
@@ -110,33 +175,53 @@ async function diagnoseDomain(host: ProxyHostEntry, lanIp: string | undefined): 
     };
   }
 
-  // 2. Does the hostname resolve at all?
-  const ips = await resolveOrNull(domain);
-  if (!ips || ips.length === 0) {
-    return {
-      status: 'fail',
-      reason: isLan
-        ? 'Hostname does not resolve. AdGuard DNS rewrites probably missing.'
-        : 'Hostname does not resolve. Public DNS A-record likely absent or pointing at the wrong IP.',
-      fixHint: isLan
-        ? 'See `adguard_rewrites_missing` → Reprovision.'
-        : 'Add an A-record at your DNS provider pointing the apex/wildcard at your WAN IP. See `router_dns_not_pointing` for the LAN side of the same trio.',
-    };
+  // 2. DNS configuration check. Two different mechanisms by domain
+  //    class — ServiceBay's container resolver doesn't use AdGuard,
+  //    so asking it about `.home.arpa` will always fail regardless
+  //    of whether the rewrites are correct. Talk to AdGuard
+  //    directly instead.
+  if (isLan) {
+    const rewriteAnswers = await adguardResolves(domain, config);
+    if (!rewriteAnswers) {
+      return {
+        status: 'fail',
+        reason: 'No matching AdGuard rewrite for this domain — LAN clients can\'t resolve it.',
+        fixHint: 'See `adguard_rewrites_missing` → Reprovision.',
+      };
+    }
+    if (lanIp && !rewriteAnswers.includes(lanIp)) {
+      return {
+        status: 'fail',
+        reason: `AdGuard rewrite points at ${rewriteAnswers.join(', ')} but ServiceBay's LAN IP is ${lanIp} (drifted since install?).`,
+        fixHint: 'See `adguard_rewrites_missing` → Reprovision (refreshes the rewrite to the current LAN IP).',
+      };
+    }
+  } else {
+    // Public domain — verify the public resolver returns at least one
+    // address. If it doesn't, the A-record is missing entirely.
+    const ips = await resolveOrNull(domain);
+    if (!ips || ips.length === 0) {
+      return {
+        status: 'fail',
+        reason: 'Hostname does not resolve via public DNS. A-record likely missing.',
+        fixHint: 'Add an A-record at your DNS provider pointing the apex/wildcard at your WAN IP. See `router_dns_not_pointing` for the LAN side of the same trio.',
+      };
+    }
   }
 
-  // 3. For LAN domains, the IP must be ServiceBay's LAN IP. Anything
-  //    else means a stale AdGuard rewrite (drifted lanIp).
-  if (isLan && lanIp && !ips.includes(lanIp)) {
+  // 3. Routing test — talk to NPM directly on the LAN IP with
+  //    a Host: header. Doesn't depend on resolver config so it
+  //    works for both internal and public domains regardless of
+  //    whether the operator's devices have been pointed at AdGuard
+  //    yet. NPM's ssl_forced redirect surfaces as 301 → https://.
+  if (!lanIp) {
     return {
-      status: 'fail',
-      reason: `Resolves to ${ips.join(', ')} but ServiceBay's LAN IP is ${lanIp}.`,
-      fixHint: 'See `adguard_rewrites_missing` → Reprovision (updates the rewrite to the current LAN IP).',
+      status: 'warn',
+      reason: 'reverseProxy.lanIp not set; cannot probe NPM routing.',
+      fixHint: 'Trigger a LAN-IP reconcile by restarting ServiceBay, or set it explicitly via Settings → Reverse Proxy.',
     };
   }
-
-  // 4. Actually try to reach it.
-  const url = `${scheme}://${domain}/`;
-  const probe = await fetchOrClassify(url);
+  const probe = await fetchWithHostHeader(`http://${lanIp}:80/`, domain);
   if (!probe.ok) {
     if (probe.reason === 'refused') {
       return {
@@ -166,26 +251,41 @@ async function diagnoseDomain(host: ProxyHostEntry, lanIp: string | undefined): 
     };
   }
 
-  // 5. We got a response. Is it NPM's default "this is the proxy"
-  //    page (meaning the host record exists but no real route)?
+  // 5. We got a response. Is it NPM's default page (proxy host
+  //    not configured for this `Host:` header)?
   if (probe.status === 404 || probe.status === 503) {
     if (probe.bodySnippet.includes('Congratulations') || probe.bodySnippet.includes('nginx-proxy-manager')) {
       return {
         status: 'fail',
-        reason: `Reached NPM's default page — proxy host configured but not routed to a backend on port ${host.forwardPort}.`,
-        fixHint: `Verify the proxy host's forward_port (${host.forwardPort}) matches what '${host.service}' actually listens on. If the service moved ports, re-run the template's deploy.`,
+        reason: `NPM has no proxy host matching Host: ${domain} — the route isn't actually configured even though the config says created=true.`,
+        fixHint: 'See `proxy_route_missing` → Retry create.',
       };
     }
     return {
       status: 'warn',
       reason: `Backend returned HTTP ${probe.status}.`,
-      fixHint: `'${host.service}' is reachable but unhealthy. Check its container logs.`,
+      fixHint: `'${host.service}' is reachable through NPM but the upstream is unhealthy. Check its container logs.`,
     };
   }
 
-  // 6. 2xx / 3xx — call it healthy. (The continuous `domain` health
-  //    check already covers per-second monitoring; this probe is
-  //    only for "tell me why it broke".)
+  // 6. For ssl_forced public hosts NPM responds 301 → https://. That
+  //    proves the vhost + cert binding are in place. A 301 to anything
+  //    else means the route is half-configured.
+  if (!isLan && (probe.status === 301 || probe.status === 302)) {
+    const loc = probe.headers.get('location') || '';
+    if (loc.startsWith(`https://${domain}`)) {
+      return null; // healthy
+    }
+    return {
+      status: 'warn',
+      reason: `NPM redirected ${probe.status} → ${loc || '(empty Location)'}; expected https://${domain}/.`,
+      fixHint: 'The NPM host for this domain may have ssl_forced toggled off, or the cert isn\'t bound. See `cert_request_failure`.',
+    };
+  }
+
+  // 7. 2xx / 3xx for LAN, anything else → healthy. Continuous
+  //    `domain` health-check dot covers per-minute monitoring; this
+  //    probe is only here to *explain* the broken ones.
   return null;
 }
 
@@ -199,11 +299,10 @@ export async function checkDomainUnreachable(): Promise<DomainUnreachableResult>
     };
   }
 
-  const lanIp = config.reverseProxy?.lanIp;
   const settled = await Promise.all(
     hosts.map(async h => {
       try {
-        const d = await diagnoseDomain(h, lanIp);
+        const d = await diagnoseDomain(h, config);
         return { host: h, diagnosis: d };
       } catch (e) {
         logger.warn('diagnose:domain_unreachable', `Probe for ${h.domain} threw: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/lib/health/runner.ts
+++ b/src/lib/health/runner.ts
@@ -133,51 +133,72 @@ export class CheckRunner {
   }
 
   /**
-   * Probe a configured domain end-to-end:
-   *   1. DNS resolves (implicit — fetch fails if it doesn't).
-   *   2. The expected scheme answers within the timeout.
-   *   3. Response is NOT NPM's default "Congratulations" page —
-   *      that would mean the proxy host exists but isn't routed
-   *      to a real backend, which reads identically to a healthy
-   *      200 without the body sniff.
-   *   4. For https: TLS validates (Node fetch throws on invalid
-   *      cert chains; we surface the error string verbatim).
+   * Probe a configured domain by talking directly to NPM on the LAN
+   * IP with a `Host:` header — *not* by resolving the domain name.
+   * This is the only probe that works for `.home.arpa` from inside
+   * ServiceBay's container, which doesn't use AdGuard as its own
+   * resolver (it uses whatever the host's /etc/resolv.conf points
+   * at — typically the FritzBox, which has no answer for the
+   * RFC 8375 reserved zone). Public domains also benefit: we test
+   * the proxy routing without depending on router hairpin or public
+   * DNS being healthy.
    *
-   * The message returned is a short human-readable detail
-   * ("https reachable, 200", "https failed: cert expired", etc.)
-   * that the UI shows in the dot's tooltip. Throwing flips the
-   * outer try/catch into `status: 'fail'` with the thrown message.
+   *   1. Hit `http://<lanIp>:80/` with `Host: <domain>`.
+   *   2. NPM picks the matching virtual host, applies any
+   *      ssl_forced 301 redirect (visible as 301 → Location:
+   *      https://<domain>/), and then forwards to the backend.
+   *   3. We accept anything 2xx-3xx as "routing healthy".
+   *      For `https` (ssl_forced) routes we expect a 301/302
+   *      with `Location:` starting `https://<domain>` — that
+   *      proves NPM both *knows* this vhost and the cert binding
+   *      is in place.
+   *   4. NPM's default "Congratulations" body on 404/503 means the
+   *      proxy host doesn't exist *yet* for this domain — same
+   *      symptom as a half-finished install.
+   *
+   * No SSRF guard: hitting our own LAN IP is the point.
    */
   private static async runDomainCheck(check: CheckConfig): Promise<string> {
     const cfg = check.domainConfig;
     if (!cfg) throw new Error('domainConfig missing');
-    const scheme = cfg.expectedScheme;
-    const url = `${scheme}://${check.target}/`;
-    await assertHttpTargetAllowed(url);
+    const expectedScheme = cfg.expectedScheme;
 
+    // Resolve NPM's address via config — `reverseProxy.lanIp` is what
+    // the install wizard captures and reconciles on every boot.
+    const { getConfig } = await import('../config');
+    const config = await getConfig();
+    const lanIp = config.reverseProxy?.lanIp;
+    if (!lanIp) throw new Error('reverseProxy.lanIp not configured — cannot probe NPM');
+
+    const url = `http://${lanIp}:80/`;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
     try {
       const res = await fetch(url, {
         signal: controller.signal,
-        redirect: 'manual', // Don't auto-follow http→https; the redirect IS the signal.
+        redirect: 'manual', // `Location:` of a 301 is the proof of life for ssl_forced.
+        headers: { Host: check.target },
       });
-      // 4xx/5xx with NPM's default page = proxy route missing.
-      // Detect via the body — NPM ships its "Congratulations!" page
-      // on the default vhost.
+
       if (res.status === 404 || res.status === 503) {
         const body = await res.text().catch(() => '');
         if (body.includes('Congratulations') || body.includes('nginx-proxy-manager')) {
-          throw new Error(`${scheme} reached NPM default page (proxy host wired but no backend?)`);
+          throw new Error(`Proxy host for ${check.target} not configured in NPM`);
         }
       }
-      if (!res.ok && res.status < 300) {
-        throw new Error(`${scheme} returned HTTP ${res.status}`);
+
+      // For ssl_forced (public) routes NPM answers 301 → https://...
+      // — that's the healthy state for an https-expected domain.
+      if (expectedScheme === 'https' && (res.status === 301 || res.status === 302)) {
+        const loc = res.headers.get('location') || '';
+        if (loc.startsWith('https://')) return `routed via NPM, ssl_forced redirect to ${loc}`;
+        return `routed via NPM, redirect ${res.status} to ${loc || '(empty)'}`;
       }
-      // 3xx is fine — typical for services that auto-redirect /
-      // (Authelia from `/` to its login). We're only checking
-      // reachability + correct scheme.
-      return `${scheme} reachable, HTTP ${res.status}`;
+
+      if (res.status >= 200 && res.status < 400) {
+        return `routed via NPM, HTTP ${res.status}`;
+      }
+      throw new Error(`NPM returned HTTP ${res.status}`);
     } finally {
       clearTimeout(timeout);
     }


### PR DESCRIPTION
## Symptom

After v3.32.0, two operator-visible bugs:

1. Every `*.home.arpa` row in `domain_unreachable` reported "Hostname does not resolve. AdGuard DNS rewrites probably missing." — even when the rewrites were correctly configured. The operator's own PC couldn't reach `nginx.home.arpa` either; the diagnose pointed at the wrong fix.

2. `domain_external_reachability` rate-limited itself off letsdebug.net on the first run (10 simultaneous submissions → HTTP 429 on most). The hint text claimed rows were clickable; they weren't.

## Root causes

**LAN diagnosis:** ServiceBay's container resolver doesn't use AdGuard — it uses `/etc/resolv.conf` (FritzBox by default), which returns NXDOMAIN for the RFC 8375 reserved `home.arpa` zone. `dns.lookup` from inside the container will always fail for LAN domains regardless of how clean the AdGuard rewrite list looks.

**Routing probe:** same DNS dependency in `runDomainCheck` made every internal-domain dot turn red on first probe.

**letsdebug:** parallel submissions + no caching of failures meant the first diagnose run hit the rate limit and locked us out for an hour.

## Fixes

**LAN diagnosis** (`domain_unreachable`):
- New `adguardResolves(domain, config)` helper calls AdGuard's `/control/rewrite/list` directly. Tells us whether the rewrite is configured for clients querying AdGuard, independent of the container's own resolver.
- Stale `lanIp` detected by comparing the rewrite answer to `config.reverseProxy.lanIp`.

**Routing probe** (`runDomainCheck` + `domain_unreachable`):
- Replace `fetch(http(s)://<domain>/)` with `fetch(http://<lanIp>:80/, { headers: { Host: <domain> } })`. Works for both LAN and public domains. NPM's ssl_forced 301 → https://<domain>/ is the healthy signal for public ssl-forced routes.
- Drop SSRF-guard for domain-type checks; probing our own NPM is by design.

**letsdebug rate-limit etiquette** (`domain_external_reachability`):
- Cap to one fresh submission per diagnose run; pick the stale-est cache entry.
- Cache TTLs: 24 h for success, 10 min for transport errors.
- Rows include the letsdebug submission URL in the detail field (copy+paste — proper row linking is a follow-up).
- Pending domains show "Queued — will refresh on the next diagnose run".

## Test plan
- [ ] Diagnose → `domain_unreachable` shows real LAN diagnoses (missing rewrite, stale rewrite, backend down) instead of every domain claiming "DNS not resolving".
- [ ] Continuous `domain` health-check dots turn green for `*.home.arpa` services without needing the operator's PC to be using AdGuard yet.
- [ ] First diagnose run after install: `domain_external_reachability` refreshes ONE public domain, queues the rest with the explanatory message. Re-running picks the next stale one.
- [ ] Each surfaced row carries `Report: https://letsdebug.net/<domain>/<id>` in its detail text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)