### PR TITLE
feat(routing): use publicDomain for LAN-only services (drop home.arpa default)

### DIFF
--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -556,13 +556,25 @@ export async function POST(request: Request) {
                 forwardPort: h.forwardPort,
                 created: results.find(r => r.domain === h.domain)?.success ?? false,
                 createdAt: new Date().toISOString(),
+                // Persist exposure so downstream consumers (domain
+                // health checks, diagnose probes, letsdebug filter)
+                // can tell `lan` from `public` without trying to
+                // re-derive it from the domain string — which doesn't
+                // work now that LAN-only services live on the public
+                // domain too.
+                exposure: h.exposure,
             }));
-            // Merge: update existing entries by domain, append new ones
+            // Merge: update existing entries by domain, append new
+            // ones. Preserve the previous `exposure` value when the
+            // incoming entry doesn't carry one (older clients).
             const merged = [...existingHosts];
             for (const entry of newEntries) {
                 const idx = merged.findIndex(e => e.domain === entry.domain);
-                if (idx >= 0) merged[idx] = entry;
-                else merged.push(entry);
+                if (idx >= 0) {
+                    merged[idx] = { ...merged[idx], ...entry, exposure: entry.exposure ?? merged[idx].exposure };
+                } else {
+                    merged.push(entry);
+                }
             }
             await updateConfig({
                 reverseProxy: {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -55,6 +55,22 @@ export interface ProxyHostEntry {
   sslConfigured?: boolean;
   /** Timestamp of creation */
   createdAt?: string;
+  /**
+   * Operator-facing intent: `public` services are meant to be
+   * reachable from the internet (Let's Encrypt cert at install time,
+   * public DNS A-record at the operator's registrar), `lan` services
+   * are LAN-only (no public DNS record needed; AdGuard's wildcard
+   * `*.<publicDomain> → <lanIp>` handles internal resolution). The
+   * field is persisted here so the continuous `domain` health check
+   * and the diagnose probes can decide:
+   *   - the expected scheme for the NPM probe (`https` for public,
+   *     `http` for LAN — NPM's ssl_forced only fires for public),
+   *   - whether to bother letsdebug.net with this domain (skipped
+   *     entirely for `lan` since it'll never have a public record).
+   * Missing on entries that pre-date this field; treat as `lan` so
+   * the conservative default applies.
+   */
+  exposure?: 'public' | 'lan';
 }
 
 export interface ReverseProxyConfig {

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -56,9 +56,20 @@ interface CacheEntry {
 }
 const cache = new Map<string, CacheEntry>();
 
-function isPublicDomain(domain: string): boolean {
-  if (!domain) return false;
-  return !domain.endsWith('.home.arpa') && !domain.endsWith('.local');
+/**
+ * "Is this entry meant to be reachable from the internet?"
+ *   - Trust `exposure` first (persisted since we started reusing the
+ *     public domain for LAN-only services).
+ *   - Fall back to suffix-based heuristic for older persisted entries
+ *     that don't carry `exposure`.
+ * letsdebug.net only makes sense for `public` entries — running it
+ * for LAN-only ones is wasted budget against their rate limit and
+ * always reports the same "DNS doesn't resolve" answer.
+ */
+function isPublicEntry(entry: { domain: string; exposure?: 'public' | 'lan' }): boolean {
+  if (entry.exposure) return entry.exposure === 'public';
+  if (!entry.domain) return false;
+  return !entry.domain.endsWith('.home.arpa') && !entry.domain.endsWith('.local');
 }
 
 function isCacheFresh(entry: CacheEntry): boolean {
@@ -117,7 +128,7 @@ function pickDomainsToRefresh(allDomains: string[]): string[] {
 export async function checkDomainExternalReachability(): Promise<DomainExternalReachabilityResult> {
   const config = await getConfig();
   const hosts = config.reverseProxy?.hosts ?? [];
-  const publicDomains = Array.from(new Set(hosts.filter(h => isPublicDomain(h.domain)).map(h => h.domain)));
+  const publicDomains = Array.from(new Set(hosts.filter(isPublicEntry).map(h => h.domain)));
 
   if (publicDomains.length === 0) {
     return {

--- a/src/lib/diagnose/probes/domainUnreachable.ts
+++ b/src/lib/diagnose/probes/domainUnreachable.ts
@@ -57,6 +57,16 @@ function isLanDomain(domain: string): boolean {
   return domain.endsWith('.home.arpa') || domain.endsWith('.local');
 }
 
+/**
+ * Trust the persisted `exposure` flag when it's there (set by the
+ * apex/NPM provisioner since the publicDomain-LAN switch); fall back
+ * to the suffix heuristic for older entries.
+ */
+function entryIsLan(entry: ProxyHostEntry): boolean {
+  if (entry.exposure) return entry.exposure === 'lan';
+  return isLanDomain(entry.domain);
+}
+
 interface Diagnosis {
   /** Severity for the per-item row. */
   status: 'warn' | 'fail';
@@ -163,7 +173,7 @@ async function fetchWithHostHeader(npmUrl: string, hostHeader: string): Promise<
 async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<Diagnosis | null> {
   const domain = host.domain;
   const lanIp = config.reverseProxy?.lanIp;
-  const isLan = isLanDomain(domain);
+  const isLan = entryIsLan(host);
   const scheme = isLan ? 'http' : 'https';
 
   // 1. Did NPM actually accept the proxy host?

--- a/src/lib/health/domainChecks.ts
+++ b/src/lib/health/domainChecks.ts
@@ -37,8 +37,21 @@ function isLanDomain(domain: string): boolean {
   return domain.endsWith('.home.arpa') || domain.endsWith('.local');
 }
 
+/**
+ * Source of truth for "is this entry public or LAN-only?":
+ *   1. Persisted `entry.exposure` (set since the publicDomain LAN
+ *      switch — required because LAN-only hosts can now live on the
+ *      same domain as public ones).
+ *   2. Fallback to the legacy heuristic for entries persisted before
+ *      that schema field existed.
+ */
+function isPublicExposure(entry: ProxyHostEntry): boolean {
+  if (entry.exposure) return entry.exposure === 'public';
+  return !isLanDomain(entry.domain);
+}
+
 function buildCheck(entry: ProxyHostEntry, now: string): CheckConfig {
-  const isPublic = !isLanDomain(entry.domain);
+  const isPublic = isPublicExposure(entry);
   return {
     id: `${DOMAIN_CHECK_PREFIX}${entry.domain}`,
     name: `Domain — ${entry.domain}`,

--- a/src/lib/portal/provisioner.ts
+++ b/src/lib/portal/provisioner.ts
@@ -84,17 +84,19 @@ function buildPortalProxyHost(domain: string, lanIp: string): {
     forwardHost: string;
     forwardScheme: string;
     service: string;
+    exposure: 'public' | 'lan';
   }>;
 } {
   const port = parseInt(process.env.PORT ?? '5888', 10);
-  // Encode both names into a single NPM host. The /api/system/nginx/
-  // proxy-hosts route currently creates one NPM host per domain
-  // entry, so we pass two list entries with the same target. NPM's
-  // de-dupe behaviour will collapse them on update.
+  // The portal apex is reachable from outside (operator sees it at
+  // the public domain), so exposure is `public`. Without this the
+  // letsdebug check and the domain-health dot defaulted via the
+  // suffix heuristic — now that LAN-only hosts can share the public
+  // domain, the heuristic isn't safe and we set the value explicitly.
   return {
     hosts: [
-      { domain, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal' },
-      { domain: `www.${domain}`, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal' },
+      { domain, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal', exposure: 'public' },
+      { domain: `www.${domain}`, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal', exposure: 'public' },
     ],
   };
 }

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -127,11 +127,24 @@ function renderProxyConfig(
  * Hosts are split by their declared `exposure`:
  *   - `public` → `<sub>.<PUBLIC_DOMAIN>` (Let's Encrypt cert, externally
  *     reachable once DNS points here).
- *   - `lan`    → `<sub>.<LAN_DOMAIN or 'home.arpa'>` so admin-only UIs
- *     (e.g. Z-Wave JS at `zwave.home.arpa`) never accidentally land on
- *     the public domain — that previously produced a `zwave.<publicDomain>`
- *     entry the DNS-verify probe nagged about, and would have exposed the
- *     UI publicly if the operator ever created the A record.
+ *   - `lan`    → `<sub>.<PUBLIC_DOMAIN>` too. The split is enforced by
+ *     the AdGuard wildcard rewrite `*.<PUBLIC_DOMAIN> → <lanIp>` — LAN
+ *     clients reach NPM directly without leaving the network, the same
+ *     names from outside resolve via public DNS only for the public-
+ *     exposure subset (the operator's DNS provider has explicit A/CNAME
+ *     records only for those). LAN-only services have no public-DNS
+ *     entry → external clients get NXDOMAIN, exactly as intended. This
+ *     replaces the older `<sub>.home.arpa` model which required either
+ *     AdGuard as the DHCP DNS (LAN SPOF) or special-casing in FritzBox
+ *     (refused per RFC 8375).
+ *
+ *     Operators on a fully LAN-only install (no public domain) fall back
+ *     to `home.arpa` so the old model still works there — fixed
+ *     `<sub>.home.arpa` is the only sensible answer when there's no
+ *     public domain to graft onto.
+ *
+ *     An explicit `LAN_DOMAIN` variable still wins so existing setups
+ *     keep behaving the same after upgrade (back-compat).
  *
  * Public-exposure hosts are skipped when no `PUBLIC_DOMAIN` is set
  * (LAN-only install).
@@ -148,7 +161,12 @@ export function buildProxyHosts(variables: StackVariable[]): {
   }[];
 } {
   const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
-  const lanDomain = variables.find(v => v.name === 'LAN_DOMAIN')?.value || 'home.arpa';
+  // LAN_DOMAIN wins (explicit operator choice). Else use the public
+  // domain itself — relies on the AdGuard wildcard `*.<publicDomain>
+  // → <lanIp>` that the portal provisioner installs at boot. Else fall
+  // back to `home.arpa` (LAN-only installs with no public domain).
+  const explicitLanDomain = variables.find(v => v.name === 'LAN_DOMAIN')?.value;
+  const lanDomain = explicitLanDomain || domain || 'home.arpa';
   const view = variables.reduce<Record<string, string>>(
     (acc, v) => { acc[v.name] = v.value; return acc; },
     {},

--- a/tests/backend/buildProxyHosts.test.ts
+++ b/tests/backend/buildProxyHosts.test.ts
@@ -47,21 +47,43 @@ describe('buildProxyHosts', () => {
     });
   });
 
-  it('routes lan-exposure subdomains onto the LAN domain (default home.arpa)', () => {
+  it('routes lan-exposure subdomains onto the public domain when one is configured', () => {
+    // Architectural shift: LAN-only services share the public domain
+    // (e.g. `zwave.example.com`). The AdGuard wildcard
+    // `*.<publicDomain> → <lanIp>` keeps LAN clients on the local IP
+    // without any external DNS dependency, and the absence of a public
+    // A-record for the LAN-only subset stops external resolution dead.
     const { hosts } = buildProxyHosts([
       v('PUBLIC_DOMAIN', 'example.com'),
       v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
     ]);
     expect(hosts).toHaveLength(1);
     expect(hosts[0]).toMatchObject({
-      domain: 'zwave.home.arpa',
+      domain: 'zwave.example.com',
       forwardPort: 8091,
       exposure: 'lan',
       service: 'zwave_js',
     });
   });
 
-  it('honours LAN_DOMAIN override when present', () => {
+  it('falls back to home.arpa when no public domain is configured', () => {
+    // LAN-only install: there's nothing to graft onto. Keep the old
+    // `<sub>.home.arpa` behaviour so RFC 8375 + AdGuard rewrites
+    // still give the operator a working LAN-only setup.
+    const { hosts } = buildProxyHosts([
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
+    ]);
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0]).toMatchObject({
+      domain: 'zwave.home.arpa',
+      exposure: 'lan',
+    });
+  });
+
+  it('honours an explicit LAN_DOMAIN override when present', () => {
+    // Operator escape hatch: explicit `LAN_DOMAIN` wins over both
+    // defaults. Existing installs that pinned the old `home.arpa`
+    // setup keep their proxy hosts pointing where they expect.
     const { hosts } = buildProxyHosts([
       v('PUBLIC_DOMAIN', 'example.com'),
       v('LAN_DOMAIN', 'lan.example'),
@@ -77,7 +99,7 @@ describe('buildProxyHosts', () => {
     ]);
     expect(hosts).toHaveLength(1);
     expect(hosts[0]).toMatchObject({
-      domain: 'mystery.home.arpa',
+      domain: 'mystery.example.com',
       exposure: 'lan',
     });
   });
@@ -92,7 +114,10 @@ describe('buildProxyHosts', () => {
     const byDomain = Object.fromEntries(hosts.map(h => [h.domain, h]));
     expect(byDomain['home.dopp.cloud'].exposure).toBe('public');
     expect(byDomain['photos.dopp.cloud'].exposure).toBe('public');
-    expect(byDomain['zwave.home.arpa'].exposure).toBe('lan');
+    // Same domain for public and lan now — the AdGuard wildcard +
+    // absence of a public A-record for the LAN-only one provides
+    // the split-horizon implicitly.
+    expect(byDomain['zwave.dopp.cloud'].exposure).toBe('lan');
     expect(hosts).toHaveLength(3);
   });
 
@@ -102,6 +127,7 @@ describe('buildProxyHosts', () => {
       v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
     ]);
     expect(domain).toBeUndefined();
+    // No public domain → fallback `home.arpa` covers the LAN entry.
     expect(hosts.map(h => h.domain)).toEqual(['zwave.home.arpa']);
   });
 


### PR DESCRIPTION
## Why

The `home.arpa` LAN-domain default only works if **AdGuard is the DHCP DNS** for the entire LAN — which makes the home network depend on ServiceBay being up for resolution (a real SPOF) — OR if the router special-cases the zone. FritzBox refuses to forward `home.arpa` queries per RFC 8375, so the second path isn't an option in practice.

Empirical confirmation from a live install:
- FritzBox as DHCP DNS + AdGuard as FritzBox's upstream → `nginx.home.arpa` returns NXDOMAIN (FritzBox handles it locally without forwarding).
- Same config + a regular public-domain subdomain → `test.lan.dopp.cloud` correctly returns `192.168.178.100` via AdGuard's existing `*.dopp.cloud → lanIp` wildcard.

So the public domain already gives us a working LAN-side resolution path without any router config changes.

## Model after this PR

The public domain carries **both** public and LAN-only services. Split-horizon comes from which DNS records exist where:

| Type | Public DNS | LAN DNS (AdGuard) | NPM has proxy host? |
|---|---|---|---|
| Public service (e.g. `vault.dopp.cloud`) | A/CNAME → WAN IP | wildcard → LAN IP | yes, https-forced |
| LAN-only service (e.g. `nginx.dopp.cloud`) | (nothing) | wildcard → LAN IP | yes, plain http |

External clients querying for LAN-only names get NXDOMAIN. LAN clients always go to NPM directly (hairpin-NAT bypass as a free bonus for the public services). The operator's router stays whatever it was — no DHCP DNS change required.

## Changes

- `buildProxyHosts`: `lanDomain = LAN_DOMAIN ?? publicDomain ?? 'home.arpa'`. Explicit `LAN_DOMAIN` wins for back-compat; `home.arpa` is the fallback for pure LAN-only installs (no public domain configured).
- `ProxyHostEntry.exposure` (new optional field): persists the operator-facing intent so the continuous `domain` health check, `domain_external_reachability` probe, and letsdebug filter can tell `lan` from `public` without guessing from the domain suffix — which no longer works.
- `portal/provisioner.ts`: apex + www declare `exposure: 'public'`.
- Domain probes (`domainChecks.ts`, `domain_external_reachability`, `domain_unreachable`): use `exposure` first, fall back to suffix for older entries.
- `tests/backend/buildProxyHosts.test.ts`: updated to assert new defaults.

## Migration

Existing installs with `<sub>.home.arpa` entries keep working — the `home.arpa` AdGuard wildcard is still provisioned alongside the public-domain one. Operators can re-deploy affected templates to migrate to the new naming, or leave as-is.

## Test plan
- [ ] Fresh install with a public domain: new LAN-only services (Z-Wave UI, NPM admin, AdGuard, LLDAP, syncthing UI) get proxy hosts on `<sub>.<publicDomain>`, not `<sub>.home.arpa`.
- [ ] AdGuard wildcard `*.<publicDomain> → lanIp` resolves them from any LAN client whose FritzBox forwards to AdGuard upstream.
- [ ] Public services keep working unchanged from outside.
- [ ] Pure LAN-only install (no public domain configured) falls back to `home.arpa`.
- [ ] `domain_external_reachability` doesn't waste letsdebug submissions on LAN-exposure hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)