### PR TITLE
refactor(routing): strip home.arpa back-compat, single-domain model

### DIFF
--- a/src/lib/diagnose/probes/adguardRewritesMissing.test.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.test.ts
@@ -71,10 +71,10 @@ describe('checkAdguardRewritesMissing', () => {
     state.rewrites = [];
     const r = await checkAdguardRewritesMissing();
     expect(r.status).toBe('warn');
-    // Expected: home.arpa trio + dopp.cloud trio = 6 entries.
-    expect(r.detail).toMatch(/6 missing/);
+    // Single-domain model: only the publicDomain trio is expected.
+    expect(r.detail).toMatch(/3 missing/);
     expect(r.detail).toContain('*.dopp.cloud');
-    expect(r.detail).toContain('*.home.arpa');
+    expect(r.detail).not.toContain('home.arpa');
     expect(r.hint).toMatch(/Reprovision/);
   });
 
@@ -83,9 +83,6 @@ describe('checkAdguardRewritesMissing', () => {
       { domain: 'dopp.cloud', answer: '192.168.1.10' },
       { domain: 'www.dopp.cloud', answer: '192.168.1.10' },
       { domain: '*.dopp.cloud', answer: '10.0.0.1' }, // stale
-      { domain: 'home.arpa', answer: '192.168.1.10' },
-      { domain: 'www.home.arpa', answer: '192.168.1.10' },
-      { domain: '*.home.arpa', answer: '192.168.1.10' },
     ];
     const r = await checkAdguardRewritesMissing();
     expect(r.status).toBe('warn');
@@ -98,13 +95,10 @@ describe('checkAdguardRewritesMissing', () => {
       { domain: 'dopp.cloud', answer: '192.168.1.10' },
       { domain: 'www.dopp.cloud', answer: '192.168.1.10' },
       { domain: '*.dopp.cloud', answer: '192.168.1.10' },
-      { domain: 'home.arpa', answer: '192.168.1.10' },
-      { domain: 'www.home.arpa', answer: '192.168.1.10' },
-      { domain: '*.home.arpa', answer: '192.168.1.10' },
     ];
     const r = await checkAdguardRewritesMissing();
     expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/6 portal\/wildcard rewrites in AdGuard point at 192\.168\.1\.10/);
+    expect(r.detail).toMatch(/3 portal\/wildcard rewrites in AdGuard point at 192\.168\.1\.10/);
   });
 
   it('skips the public domain when no public domain is configured (LAN-only mode)', async () => {

--- a/src/lib/diagnose/probes/adguardRewritesMissing.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.ts
@@ -39,21 +39,19 @@ export interface AdguardRewritesMissingResult {
 /** Build the expected set of AdGuard rewrite domains for the current
  *  install. Mirrors the loop inside `provisionPortalRouting` so the
  *  two stay in lockstep — if that function changes the rewrite shape,
- *  this needs to follow. */
+ *  this needs to follow.
+ *
+ *  Single-domain model: `publicDomain` when set, `home.arpa`
+ *  otherwise. There's no longer a dual-rewrite (both home.arpa AND
+ *  publicDomain) because the publicDomain wildcard alone covers
+ *  every LAN client's resolution needs once the operator has a
+ *  domain. */
 function buildExpectedRewrites(
-  lanDomain: string | undefined,
+  _lanDomain: string | undefined,
   publicDomain: string | undefined,
 ): string[] {
-  const domains: string[] = [];
-  const lan = (lanDomain && lanDomain.trim()) || DEFAULT_LAN_DOMAIN;
-  if (lan) domains.push(lan);
-  const pub = publicDomain?.trim();
-  if (pub && pub !== lan) domains.push(pub);
-  const out: string[] = [];
-  for (const d of domains) {
-    out.push(d, `www.${d}`, `*.${d}`);
-  }
-  return out;
+  const target = (publicDomain?.trim()) || DEFAULT_LAN_DOMAIN;
+  return [target, `www.${target}`, `*.${target}`];
 }
 
 export async function checkAdguardRewritesMissing(): Promise<AdguardRewritesMissingResult> {

--- a/src/lib/portal/provisioner.ts
+++ b/src/lib/portal/provisioner.ts
@@ -190,25 +190,25 @@ export async function provisionPortalRouting(): Promise<ProvisionResult> {
   // host — that's where browser traffic actually hits ServiceBay.
   const proxyHost = await provisionNpmProxyHost(activeDomain);
 
-  // AdGuard rewrites. Two-domain split-horizon for typical home installs:
-  //   * `lanDomain` (default `home.arpa`) — always present. Devices
-  //     resolving `<lan>` or `*.<lan>` need to hit ServiceBay directly.
-  //   * `publicDomain` (e.g. `dopp.cloud`) — when set, LAN devices
-  //     resolving `<public>` or `*.<public>` should bypass the
-  //     FritzBox-hairpin-NAT and reach ServiceBay over the LAN.
-  // For each domain we install three rewrites:
+  // AdGuard rewrites. We pick exactly one domain to terminate LAN
+  // resolution on:
+  //   * `publicDomain` when set — LAN clients querying any
+  //     `<sub>.<publicDomain>` get the LAN IP (hairpin-NAT bypass for
+  //     public services; the only resolution path for LAN-only
+  //     services since they have no public DNS record).
+  //   * `home.arpa` otherwise — pure LAN-only install with nothing
+  //     to graft onto.
+  // For the chosen domain we install three rewrites:
   //   - <domain> → lanIp                       (portal apex)
   //   - www.<domain> → lanIp                   (portal apex, with www)
   //   - *.<domain> → lanIp                     (subdomain catch-all)
-  // AdGuard accepts both literal and wildcard patterns at the same
-  // endpoint; the wildcard pattern is the standard catch-all for any
-  // service subdomain (vault, immich, dns, …) that NPM routes by
-  // Host-header behind ServiceBay.
   const rewriteDomains = new Set<string>();
-  const lanDomain = config.reverseProxy?.lanDomain ?? 'home.arpa';
   const publicDomain = config.reverseProxy?.publicDomain;
-  if (lanDomain) rewriteDomains.add(lanDomain);
-  if (publicDomain) rewriteDomains.add(publicDomain);
+  if (publicDomain) {
+    rewriteDomains.add(publicDomain);
+  } else {
+    rewriteDomains.add('home.arpa');
+  }
 
   const rewrites: Record<string, RewriteResult> = {};
   for (const d of rewriteDomains) {

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -125,29 +125,14 @@ function renderProxyConfig(
  * `tests/backend/buildProxyHosts.test.ts`).
  *
  * Hosts are split by their declared `exposure`:
- *   - `public` → `<sub>.<PUBLIC_DOMAIN>` (Let's Encrypt cert, externally
- *     reachable once DNS points here).
- *   - `lan`    → `<sub>.<PUBLIC_DOMAIN>` too. The split is enforced by
- *     the AdGuard wildcard rewrite `*.<PUBLIC_DOMAIN> → <lanIp>` — LAN
- *     clients reach NPM directly without leaving the network, the same
- *     names from outside resolve via public DNS only for the public-
- *     exposure subset (the operator's DNS provider has explicit A/CNAME
- *     records only for those). LAN-only services have no public-DNS
- *     entry → external clients get NXDOMAIN, exactly as intended. This
- *     replaces the older `<sub>.home.arpa` model which required either
- *     AdGuard as the DHCP DNS (LAN SPOF) or special-casing in FritzBox
- *     (refused per RFC 8375).
+ *   - `public` → `<sub>.<PUBLIC_DOMAIN>` (Let's Encrypt cert,
+ *     externally reachable once DNS points here).
+ *   - `lan`    → `<sub>.<PUBLIC_DOMAIN>` too. Split-horizon is
+ *     enforced by AdGuard's `*.<PUBLIC_DOMAIN> → <lanIp>` wildcard
+ *     plus the absence of a public DNS record for LAN-only names.
  *
- *     Operators on a fully LAN-only install (no public domain) fall back
- *     to `home.arpa` so the old model still works there — fixed
- *     `<sub>.home.arpa` is the only sensible answer when there's no
- *     public domain to graft onto.
- *
- *     An explicit `LAN_DOMAIN` variable still wins so existing setups
- *     keep behaving the same after upgrade (back-compat).
- *
- * Public-exposure hosts are skipped when no `PUBLIC_DOMAIN` is set
- * (LAN-only install).
+ * Pure LAN-only installs (no `PUBLIC_DOMAIN` set) get `<sub>.home.arpa`
+ * as the only sensible answer — they have nothing to graft onto.
  */
 export function buildProxyHosts(variables: StackVariable[]): {
   domain: string | undefined;
@@ -161,12 +146,7 @@ export function buildProxyHosts(variables: StackVariable[]): {
   }[];
 } {
   const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
-  // LAN_DOMAIN wins (explicit operator choice). Else use the public
-  // domain itself — relies on the AdGuard wildcard `*.<publicDomain>
-  // → <lanIp>` that the portal provisioner installs at boot. Else fall
-  // back to `home.arpa` (LAN-only installs with no public domain).
-  const explicitLanDomain = variables.find(v => v.name === 'LAN_DOMAIN')?.value;
-  const lanDomain = explicitLanDomain || domain || 'home.arpa';
+  const lanDomain = domain || 'home.arpa';
   const view = variables.reduce<Record<string, string>>(
     (acc, v) => { acc[v.name] = v.value; return acc; },
     {},

--- a/tests/backend/buildProxyHosts.test.ts
+++ b/tests/backend/buildProxyHosts.test.ts
@@ -80,18 +80,6 @@ describe('buildProxyHosts', () => {
     });
   });
 
-  it('honours an explicit LAN_DOMAIN override when present', () => {
-    // Operator escape hatch: explicit `LAN_DOMAIN` wins over both
-    // defaults. Existing installs that pinned the old `home.arpa`
-    // setup keep their proxy hosts pointing where they expect.
-    const { hosts } = buildProxyHosts([
-      v('PUBLIC_DOMAIN', 'example.com'),
-      v('LAN_DOMAIN', 'lan.example'),
-      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('lan', '8091')),
-    ]);
-    expect(hosts[0].domain).toBe('zwave.lan.example');
-  });
-
   it('treats missing exposure as lan (conservative — never auto-cert)', () => {
     const { hosts } = buildProxyHosts([
       v('PUBLIC_DOMAIN', 'example.com'),


### PR DESCRIPTION
Per operator request, follow-up to #471: drop the LAN_DOMAIN escape hatch and the dual-rewrite noise. The publicDomain is the LAN domain when one is configured; `home.arpa` only when no public domain at all.

## Changes

- `buildProxyHosts`: `lanDomain = publicDomain || 'home.arpa'`. No `LAN_DOMAIN` override.
- `portal/provisioner.ts`: AdGuard rewrites for a single domain — `*.<publicDomain>` when set, else `*.home.arpa`.
- `adguard_rewrites_missing`: mirrors the single-domain expectation (3 entries instead of 6).
- Tests updated.

## Migration

Existing `*.home.arpa` rewrites in AdGuard from old installs become dead config the provisioner stops refreshing. Operators can clean up manually via AdGuard UI; their existing `*.home.arpa` NPM proxy hosts keep working as long as the rewrite stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)