### PR TITLE
fix(letsdebug): parse PascalCase + downgrade transport errors

### DIFF
--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -168,13 +168,18 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
       continue;
     }
     if (entry.error) {
-      overall = worst(overall, 'warn');
-      warnCount++;
+      // Transport failure on letsdebug's side (rate-limit, WAF, bad
+      // response). NOT the operator's setup. Surface as 'info' with
+      // a manual fallback URL so the diagnose roll-up doesn't show
+      // a scary "warn" colour for what is actually our probe being
+      // flaky against a third-party service. Operator can still
+      // open the URL in a browser to get the real letsdebug view.
+      const manualUrl = `${'https://letsdebug.net'}/?domain=${encodeURIComponent(domain)}&method=http-01`;
       items.push({
         id: domain,
         label: domain,
-        detail: `letsdebug probe could not run: ${entry.error.slice(0, 160)}${entry.submissionUrl ? ` · Report: ${entry.submissionUrl}` : ''}`,
-        status: 'warn',
+        detail: `letsdebug probe could not run automatically (${entry.error.slice(0, 120)}). Open manually: ${manualUrl}`,
+        status: 'info',
         actionIds: [],
       });
       continue;

--- a/src/lib/letsdebug/client.ts
+++ b/src/lib/letsdebug/client.ts
@@ -2,32 +2,22 @@
  * Minimal letsdebug.net client. Submits an HTTP-01 reachability test
  * for a single domain and polls until completion (or our timeout).
  *
+ * letsdebug is a Go service; its JSON responses use PascalCase keys
+ * by default (`ID`, `Status`, `Result`). Reading lowercase
+ * (`data.id`) silently returned `undefined` and triggered a misleading
+ * "submission missing id" error. The parser below normalises both
+ * casings so a future API tweak in either direction stays handled.
+ *
  * Used by:
  *   - `domain_external_reachability` diagnose probe (continuous via
  *     diagnose runs, cached for 24 h to be polite to letsdebug).
  *   - On-demand external checks from the UI (planned).
- *
- * Both consumers share the same submit+poll loop so the caching
- * semantics stay consistent — letsdebug rate-limits, and we don't
- * want two layers of caching to drift.
  */
 
 export interface LetsdebugProblem {
   name?: string;
   explanation?: string;
   severity?: string;
-}
-
-interface SubmissionResponse {
-  id?: number;
-}
-
-interface PollResponse {
-  id?: number;
-  status?: 'Queued' | 'Processing' | 'Complete';
-  result?: {
-    problems?: LetsdebugProblem[];
-  };
 }
 
 export interface LetsdebugResult {
@@ -40,34 +30,84 @@ const MAX_POLL_ATTEMPTS = 30;
 const POLL_INTERVAL_MS = 2000;
 const SUBMIT_TIMEOUT_MS = 15_000;
 const POLL_TIMEOUT_MS = 10_000;
+// letsdebug's WAF can serve a Cloudflare challenge to generic fetch
+// calls. Setting a recognisable User-Agent (and Accept) drops the
+// challenge rate in practice. We also identify ourselves clearly so
+// letsdebug's operator can correlate traffic if it ever becomes a
+// problem.
+const HEADERS_BASE: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent': 'servicebay/diagnose (https://github.com/mdopp/servicebay)',
+};
+
+/** Read either `key` or its case-shifted variant — handles
+ *  `ID`/`id`, `Status`/`status`, etc. without committing to one. */
+function pick<T = unknown>(obj: Record<string, unknown> | null | undefined, ...keys: string[]): T | undefined {
+  if (!obj) return undefined;
+  for (const k of keys) {
+    if (k in obj && obj[k] !== undefined && obj[k] !== null) return obj[k] as T;
+  }
+  return undefined;
+}
 
 async function submit(domain: string): Promise<number> {
   const res = await fetch(`${BASE}/`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    headers: { ...HEADERS_BASE, 'Content-Type': 'application/json' },
     body: JSON.stringify({ domain, method: 'http-01' }),
     signal: AbortSignal.timeout(SUBMIT_TIMEOUT_MS),
   });
   if (!res.ok) {
     throw new Error(`letsdebug submission HTTP ${res.status}`);
   }
-  const data = (await res.json()) as SubmissionResponse;
-  if (typeof data.id !== 'number') {
-    throw new Error('letsdebug submission missing id');
+  // Read as text first so we can include a snippet of the body in the
+  // error message — without it, parser failures showed up as "missing
+  // id" with no way to tell what letsdebug actually returned (HTML
+  // Cloudflare challenge? rate-limit JSON?).
+  const raw = await res.text();
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    throw new Error(`letsdebug submission returned non-JSON (first 120 chars): ${raw.slice(0, 120)}`);
   }
-  return data.id;
+  const id = pick<number>(data, 'id', 'ID', 'Id');
+  if (typeof id !== 'number') {
+    throw new Error(`letsdebug submission missing id (got keys: ${Object.keys(data).join(', ') || 'none'})`);
+  }
+  return id;
 }
 
-async function poll(domain: string, id: number): Promise<PollResponse> {
+interface NormalisedPoll {
+  status: string;
+  problems: LetsdebugProblem[];
+}
+
+function normalisePoll(raw: Record<string, unknown>): NormalisedPoll {
+  const status = pick<string>(raw, 'status', 'Status') ?? '';
+  const result = pick<Record<string, unknown>>(raw, 'result', 'Result');
+  const problems = (pick<LetsdebugProblem[]>(result, 'problems', 'Problems') ?? []).map(p => {
+    const o = p as unknown as Record<string, unknown>;
+    return {
+      name: pick<string>(o, 'name', 'Name'),
+      explanation: pick<string>(o, 'explanation', 'Explanation'),
+      severity: pick<string>(o, 'severity', 'Severity'),
+    };
+  });
+  return { status, problems };
+}
+
+async function poll(domain: string, id: number): Promise<NormalisedPoll> {
   for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
     const res = await fetch(`${BASE}/${encodeURIComponent(domain)}/${id}`, {
-      headers: { Accept: 'application/json' },
+      headers: HEADERS_BASE,
       signal: AbortSignal.timeout(POLL_TIMEOUT_MS),
     });
     if (!res.ok) {
       throw new Error(`letsdebug poll HTTP ${res.status}`);
     }
-    const data = (await res.json()) as PollResponse;
+    const raw = (await res.json()) as Record<string, unknown>;
+    const data = normalisePoll(raw);
     if (data.status === 'Complete') return data;
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
   }
@@ -78,7 +118,7 @@ export async function runLetsdebugForDomain(domain: string): Promise<LetsdebugRe
   const id = await submit(domain);
   const result = await poll(domain, id);
   return {
-    problems: result.result?.problems ?? [],
+    problems: result.problems,
     submissionUrl: `${BASE}/${encodeURIComponent(domain)}/${id}`,
   };
 }


### PR DESCRIPTION
Operator's diagnose was showing "letsdebug submission missing id" on every public domain — letsdebug.net is a Go service whose JSON keys are PascalCase (\`ID\`, \`Status\`, \`Result\`), and the client was reading lowercase, silently getting \`undefined\`, surfacing as the misleading error.

## Changes

- **Parse both casings.** New `pick()` helper accepts `id`/`ID`, `status`/`Status`, etc. Future API tweak in either direction stays handled.
- **Better failure surface.** Submission body is captured as text first so a parse failure includes a body snippet (no more guessing between Cloudflare challenge HTML vs. malformed JSON).
- **Downgrade transport failures to \`info\`.** A 429 or "missing id" is a probe-side problem, NOT the operator's setup. The probe row no longer contributes a \`warn\` to the diagnose roll-up; it carries a manual fallback URL the operator can paste into a browser.
- **User-Agent** identifying us so letsdebug can correlate traffic; also drops the Cloudflare-challenge rate against generic fetch calls.

## Test plan

- Run diagnose → External reachability row no longer shows red text for letsdebug-side problems. Operators see either real results or a copy-pasteable URL.
- If a public domain genuinely has a problem, real letsdebug results render with the proper severity (warn/fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)