### PR TITLE
feat(letsdebug): background sweep + on-diagnose all-domain refresh + 429 backoff

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -595,6 +595,20 @@ app.prepare().then(() => {
       }
     })();
 
+    // Periodic letsdebug refresh (every 4 h) so a dashboard left
+    // open overnight wakes up with fresh external-reachability data
+    // without the operator having to re-run diagnose. The probe's
+    // own implementation throttles serial submissions per rate
+    // limit; this just starts the timer.
+    (async () => {
+      try {
+        const { startBackgroundSweep } = await import('./src/lib/diagnose/probes/domainExternalReachability');
+        startBackgroundSweep();
+      } catch (err) {
+        logger.warn('Server', `External reachability sweep init failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    })();
+
     // LAN IP reconcile (#318). Captures the install-time IP on first
     // boot and updates the stored value (with history) when the IP
     // drifts. Deferred 60s so the Local agent has time to come up

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -4,31 +4,39 @@
  * problems with the internet's view (DNS, port-80 reachability, ACME
  * readiness) that the internal `domain` health check can't see.
  *
- * Internal vs. external split:
- *   - The continuous 60-s `domain` health check answers "ServiceBay
- *     itself can reach <domain>". That catches missing proxy hosts,
- *     wrong scheme, dead backends — but it's blind to router-side
- *     issues because ServiceBay is sitting on the LAN.
- *   - This probe answers "the rest of the internet can reach
- *     <domain>". Catches DNS not pointed at your WAN IP, port 80
- *     not forwarded, IPv6 misconfig, ACME CAA records, etc.
+ * ## Refresh model
  *
- * Rate-limit etiquette: letsdebug.net 429s aggressively when you
- * submit more than a couple of tests in quick succession. So:
- *   - At most ONE fresh letsdebug submission per diagnose run.
- *     Other domains read from cache (or show "queued").
- *   - The domain picked for the fresh probe is the one whose cache
- *     entry is oldest (or missing) — round-robins naturally across
- *     re-runs without us having to track it explicitly.
- *   - Successful results cached 24 h. Failures (429, 5xx, timeouts)
- *     cached only 10 min so we don't get stuck reporting a stale
- *     transport error.
+ * Three layers, each respecting letsdebug's rate limit:
  *
- * Behaviour:
- *   - status 'info' when no public domains exist (nothing to check)
- *   - status 'ok' when every probe completed and reported no problems
- *   - status 'warn' for non-Fatal problems (e.g. CAA inferiority)
- *   - status 'fail' when at least one Fatal problem is found
+ *   1. **On every diagnose run** — read the cache as-is, return
+ *      immediately. If anything is stale, kick off a non-blocking
+ *      background sweep that walks the stale set serially with a
+ *      delay between submissions. The diagnose response carries
+ *      whatever's currently cached plus a "queued — sweep in
+ *      progress" marker for the domains being refreshed.
+ *
+ *   2. **Periodic background sweep** (every 4 h) — fires the same
+ *      walk without operator interaction, so a dashboard left
+ *      open overnight wakes up with fresh data. Started once
+ *      lazily on the first probe call (or via the explicit
+ *      `startBackgroundSweep()` from server boot).
+ *
+ *   3. **Per-domain in-flight lock** — ensures concurrent diagnose
+ *      runs + the periodic timer don't duplicate submissions for
+ *      the same domain.
+ *
+ * ## Cache TTL
+ *
+ *   - successful results: 24 h
+ *   - transport errors:  10 min (so 429s clear quickly)
+ *
+ * ## Rate-limit awareness
+ *
+ * Between submissions in a sweep we wait `SUBMIT_DELAY_MS` (30 s).
+ * letsdebug 429s aggressively under repeated unauthenticated
+ * submissions; this matches their observed tolerance in practice.
+ * Total sweep time for 10 domains: ~5 min, well within the cache
+ * TTL.
  */
 
 import { getConfig } from '@/lib/config';
@@ -45,7 +53,17 @@ export interface DomainExternalReachabilityResult {
 
 const CACHE_TTL_OK_MS    = 24 * 60 * 60 * 1000; // 24 h for successful checks
 const CACHE_TTL_FAIL_MS  =  10 * 60 * 1000;     // 10 min for transport errors
-const MAX_FRESH_PROBES_PER_RUN = 1;
+const SUBMIT_DELAY_MS    =  30 * 1000;          // baseline gap between sweep submissions
+const RATE_LIMIT_BACKOFF_MS = 15 * 60 * 1000;   // if letsdebug 429s mid-sweep, pause this long
+const SWEEP_INTERVAL_MS  =   4 * 60 * 60 * 1000; // periodic 4-h refresh
+
+/**
+ * When letsdebug returns 429 we hold off until this timestamp. Any
+ * sweep that lands during the hold-off bails immediately, and the
+ * inline diagnose check skips its auto-trigger. The hold lifts on
+ * its own; nothing else has to remember to clear it.
+ */
+let backoffUntil = 0;
 
 interface CacheEntry {
   fetchedAt: number;
@@ -54,18 +72,12 @@ interface CacheEntry {
   submissionUrl: string | null;
   error?: string;
 }
-const cache = new Map<string, CacheEntry>();
 
-/**
- * "Is this entry meant to be reachable from the internet?"
- *   - Trust `exposure` first (persisted since we started reusing the
- *     public domain for LAN-only services).
- *   - Fall back to suffix-based heuristic for older persisted entries
- *     that don't carry `exposure`.
- * letsdebug.net only makes sense for `public` entries — running it
- * for LAN-only ones is wasted budget against their rate limit and
- * always reports the same "DNS doesn't resolve" answer.
- */
+const cache = new Map<string, CacheEntry>();
+const inFlight = new Set<string>();
+let sweepActive = false;
+let sweepTimer: NodeJS.Timeout | null = null;
+
 function isPublicEntry(entry: { domain: string; exposure?: 'public' | 'lan' }): boolean {
   if (entry.exposure) return entry.exposure === 'public';
   if (!entry.domain) return false;
@@ -87,48 +99,113 @@ function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'wa
   return 'ok';
 }
 
-async function probeNow(domain: string): Promise<CacheEntry> {
+async function probeOne(domain: string): Promise<{ rateLimited: boolean }> {
+  if (inFlight.has(domain)) return { rateLimited: false };
+  inFlight.add(domain);
   try {
     const result = await runLetsdebugForDomain(domain);
-    const entry: CacheEntry = {
+    cache.set(domain, {
       fetchedAt: Date.now(),
       ok: result.problems.length === 0,
       problems: result.problems,
       submissionUrl: result.submissionUrl,
-    };
-    cache.set(domain, entry);
-    return entry;
+    });
+    return { rateLimited: false };
   } catch (e) {
-    const entry: CacheEntry = {
+    const msg = e instanceof Error ? e.message : String(e);
+    cache.set(domain, {
       fetchedAt: Date.now(),
       ok: false,
       problems: [],
       submissionUrl: null,
-      error: e instanceof Error ? e.message : String(e),
-    };
-    cache.set(domain, entry);
-    return entry;
+      error: msg,
+    });
+    // Detect 429 by message text — the client throws
+    // "letsdebug submission HTTP 429". Any future variant of
+    // "rate limit" / "too many" follows the same heuristic.
+    const rateLimited = /429|rate.?limit|too.?many/i.test(msg);
+    return { rateLimited };
+  } finally {
+    inFlight.delete(domain);
   }
 }
 
-function pickDomainsToRefresh(allDomains: string[]): string[] {
-  // Stale-first ordering. Domains with no cache entry are "fully
-  // stale" and tied; ties broken alphabetically for stability.
-  const sorted = [...allDomains].sort((a, b) => {
-    const ea = cache.get(a);
-    const eb = cache.get(b);
-    const ta = ea ? ea.fetchedAt : 0;
-    const tb = eb ? eb.fetchedAt : 0;
-    if (ta !== tb) return ta - tb;
-    return a.localeCompare(b);
-  });
-  return sorted.slice(0, MAX_FRESH_PROBES_PER_RUN);
+async function listPublicDomains(): Promise<string[]> {
+  const config = await getConfig();
+  const hosts = config.reverseProxy?.hosts ?? [];
+  return Array.from(new Set(hosts.filter(isPublicEntry).map(h => h.domain)));
+}
+
+/**
+ * Walk every stale public domain in serial with a delay between
+ * submissions. Guarded by `sweepActive` so a second caller while
+ * the first is still running silently no-ops — the existing sweep
+ * is already covering whatever the second caller would want.
+ */
+async function sweepStaleDomains(): Promise<void> {
+  if (sweepActive) return;
+  if (Date.now() < backoffUntil) {
+    logger.info(
+      'diagnose:domain_external_reachability',
+      `Sweep skipped — in 429 backoff until ${new Date(backoffUntil).toISOString()}.`,
+    );
+    return;
+  }
+  sweepActive = true;
+  try {
+    const domains = await listPublicDomains();
+    const stale = domains
+      .filter(d => {
+        const entry = cache.get(d);
+        return !entry || !isCacheFresh(entry);
+      })
+      .sort((a, b) => {
+        const ta = cache.get(a)?.fetchedAt ?? 0;
+        const tb = cache.get(b)?.fetchedAt ?? 0;
+        return ta - tb;
+      });
+    if (stale.length === 0) return;
+    logger.info(
+      'diagnose:domain_external_reachability',
+      `Background sweep starting for ${stale.length} domain(s); ~${Math.ceil((stale.length * SUBMIT_DELAY_MS) / 60_000)} min total.`,
+    );
+    for (let i = 0; i < stale.length; i++) {
+      const { rateLimited } = await probeOne(stale[i]);
+      if (rateLimited) {
+        // Bail the rest of the sweep — letsdebug just told us to
+        // slow down. Wait `RATE_LIMIT_BACKOFF_MS` before any new
+        // sweep is allowed. Periodic timer + on-diagnose triggers
+        // both check this gate.
+        backoffUntil = Date.now() + RATE_LIMIT_BACKOFF_MS;
+        logger.warn(
+          'diagnose:domain_external_reachability',
+          `letsdebug 429 on ${stale[i]} — pausing sweep, next attempt in ${RATE_LIMIT_BACKOFF_MS / 60_000} min.`,
+        );
+        return;
+      }
+      if (i < stale.length - 1) {
+        await new Promise(r => setTimeout(r, SUBMIT_DELAY_MS));
+      }
+    }
+  } finally {
+    sweepActive = false;
+  }
+}
+
+/**
+ * Kick off the periodic sweep timer. Safe to call multiple times —
+ * second call is a no-op. server.ts calls this once on boot;
+ * `checkDomainExternalReachability` also calls it lazily so the
+ * timer exists even on dev runs that bypass server.ts.
+ */
+export function startBackgroundSweep(): void {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(() => { void sweepStaleDomains(); }, SWEEP_INTERVAL_MS);
 }
 
 export async function checkDomainExternalReachability(): Promise<DomainExternalReachabilityResult> {
-  const config = await getConfig();
-  const hosts = config.reverseProxy?.hosts ?? [];
-  const publicDomains = Array.from(new Set(hosts.filter(isPublicEntry).map(h => h.domain)));
+  startBackgroundSweep();
+  const publicDomains = await listPublicDomains();
 
   if (publicDomains.length === 0) {
     return {
@@ -137,15 +214,15 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     };
   }
 
-  const toRefresh = new Set(
-    pickDomainsToRefresh(publicDomains.filter(d => !isCacheFresh(cache.get(d) ?? { fetchedAt: 0, ok: false, problems: [], submissionUrl: null, error: 'never-checked' }))),
-  );
-  logger.info(
-    'diagnose:domain_external_reachability',
-    `Refreshing ${toRefresh.size} of ${publicDomains.length} public domain(s); others read from cache.`,
-  );
-  for (const d of toRefresh) {
-    await probeNow(d);
+  // Diagnose-triggered sweep — async, non-blocking. The diagnose
+  // response returns whatever's currently cached; the next diagnose
+  // run picks up the new state.
+  const anyStale = publicDomains.some(d => {
+    const e = cache.get(d);
+    return !e || !isCacheFresh(e);
+  });
+  if (anyStale) {
+    void sweepStaleDomains();
   }
 
   let overall: 'ok' | 'warn' | 'fail' = 'ok';
@@ -158,23 +235,18 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     const entry = cache.get(domain);
     if (!entry) {
       pendingCount++;
+      const manualUrl = `https://letsdebug.net/?domain=${encodeURIComponent(domain)}&method=http-01`;
       items.push({
         id: domain,
         label: domain,
-        detail: 'Queued — letsdebug rate-limited; will refresh on the next diagnose run.',
+        detail: `Refresh in progress — re-run diagnose in a few minutes for results. Manual: ${manualUrl}`,
         status: 'info',
         actionIds: [],
       });
       continue;
     }
     if (entry.error) {
-      // Transport failure on letsdebug's side (rate-limit, WAF, bad
-      // response). NOT the operator's setup. Surface as 'info' with
-      // a manual fallback URL so the diagnose roll-up doesn't show
-      // a scary "warn" colour for what is actually our probe being
-      // flaky against a third-party service. Operator can still
-      // open the URL in a browser to get the real letsdebug view.
-      const manualUrl = `${'https://letsdebug.net'}/?domain=${encodeURIComponent(domain)}&method=http-01`;
+      const manualUrl = `https://letsdebug.net/?domain=${encodeURIComponent(domain)}&method=http-01`;
       items.push({
         id: domain,
         label: domain,
@@ -185,8 +257,7 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
       continue;
     }
     if (entry.problems.length === 0) {
-      // Healthy — no row.
-      continue;
+      continue; // healthy — no row
     }
     const itemStatus = entry.problems.some(p => severityForProblem(p) === 'fail') ? 'fail' : 'warn';
     overall = worst(overall, itemStatus);
@@ -211,12 +282,12 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   const parts: string[] = [];
   if (failedCount) parts.push(`${failedCount} fatal`);
   if (warnCount) parts.push(`${warnCount} warning`);
-  if (pendingCount) parts.push(`${pendingCount} queued`);
+  if (pendingCount) parts.push(`${pendingCount} refreshing`);
 
   return {
     status: pendingCount > 0 && overall === 'ok' ? 'info' : overall,
     detail: `${parts.join(' · ')} of ${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'}.`,
-    hint: 'Most common cause: public port 80 not reachable (router port-forward missing or hairpin issue). Each domain\'s row includes its letsdebug.net report URL — copy + paste to view. Only one fresh probe runs per diagnose run to stay under letsdebug\'s rate limit; re-run diagnose to refresh the next one.',
+    hint: 'A diagnose run kicks off a background refresh of every stale domain (one every 30 s to respect letsdebug\'s rate limit). The cache also auto-refreshes every 4 h without operator input. Re-run diagnose after the sweep completes for fresh data.',
     items,
   };
 }


### PR DESCRIPTION
Operator wants fresh external-reachability data without re-running diagnose 10 times. Probe now has three coordinated refresh sources, all sharing the same cache and rate-limit awareness:

1. **On diagnose run** — kicks off an async sweep for every stale public domain (non-blocking). Diagnose returns whatever's in the cache immediately; the sweep walks serially with 30 s between submissions.

2. **Periodic every 4 h** — `startBackgroundSweep()` runs on server boot, refreshing without operator input.

3. **Per-domain in-flight lock** prevents duplicate submissions.

## Rate-limit awareness

- 30 s baseline gap between sweep submissions.
- **Adaptive 429 backoff**: if any probe returns 429, the sweep bails and a 15-min hold-off engages. Both periodic + on-diagnose triggers respect the gate.

This keeps us within letsdebug's observed tolerance without committing to their (undocumented) exact limits. Worst case: graceful backoff instead of being blocked.

## UI

- "Refresh in progress" for domains being probed.
- Transport failures show "Open manually: https://letsdebug.net/?domain=…" and stay at `info` (not `warn`).
- Hint copy explains the cadence.

## Test plan
- [ ] Diagnose run with empty cache → response returns immediately, log shows sweep started.
- [ ] Wait 5 min, re-run diagnose → fresh results for all public domains.
- [ ] Force a 429 (10 quick submissions) → log shows "pausing sweep, next attempt in 15 min".

🤖 Generated with [Claude Code](https://claude.com/claude-code)