### PR TITLE
feat(diagnose): per-row Refresh now + last-checked timestamp on letsdebug rows

### DIFF
--- a/src/lib/diagnose/probes/domainExternalReachability.test.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.test.ts
@@ -1,0 +1,156 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  config: {} as any,
+  // Each call to `runLetsdebugForDomain` returns the next queued
+  // result, then sticks on the last one if the queue runs dry.
+  letsdebugResults: [] as Array<{ problems: Array<{ name: string; explanation: string; severity?: string }>; submissionUrl: string | null }>,
+  letsdebugThrows: null as Error | null,
+  callsByDomain: new Map<string, number>(),
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('../../letsdebug/client', () => ({
+  runLetsdebugForDomain: vi.fn((domain: string) => {
+    state.callsByDomain.set(domain, (state.callsByDomain.get(domain) ?? 0) + 1);
+    if (state.letsdebugThrows) return Promise.reject(state.letsdebugThrows);
+    const next = state.letsdebugResults.shift() ?? state.letsdebugResults[0] ?? { problems: [], submissionUrl: null };
+    return Promise.resolve(next);
+  }),
+}));
+
+// Importing the probe module also runs `registerProbeAction` for
+// `refresh_now`, which lives in the singleton registry — fine across
+// tests since the registration is idempotent within a single import.
+import {
+  checkDomainExternalReachability,
+  forceRefreshDomain,
+  _resetCacheForTesting,
+} from './domainExternalReachability';
+import { dispatchProbeAction } from '../actions';
+
+beforeEach(() => {
+  state.config = {
+    reverseProxy: {
+      hosts: [
+        { domain: 'one.example.com', exposure: 'public' },
+        { domain: 'two.example.com', exposure: 'public' },
+      ],
+    },
+  };
+  state.letsdebugResults = [];
+  state.letsdebugThrows = null;
+  state.callsByDomain.clear();
+  _resetCacheForTesting();
+});
+
+describe('checkDomainExternalReachability', () => {
+  it('renders "Last checked X ago" suffix on rows with cache data', async () => {
+    state.letsdebugResults = [
+      { problems: [{ name: 'IssueX', explanation: 'thing broke', severity: 'warning' }], submissionUrl: 'https://letsdebug.net/?id=1' },
+    ];
+    await forceRefreshDomain('one.example.com');
+
+    const result = await checkDomainExternalReachability();
+    const item = result.items?.find(i => i.id === 'one.example.com');
+    expect(item).toBeDefined();
+    expect(item!.detail).toMatch(/Last checked /);
+    expect(item!.detail).toMatch(/IssueX: thing broke/);
+  });
+
+  it('offers refresh_now action on queued rows (no cache yet)', async () => {
+    const result = await checkDomainExternalReachability();
+    const queued = result.items?.find(i => i.id === 'one.example.com');
+    expect(queued).toBeDefined();
+    expect(queued!.actionIds).toContain('refresh_now');
+  });
+
+  it('offers refresh_now action on rows with a cached problem', async () => {
+    state.letsdebugResults = [
+      { problems: [{ name: 'IssueY', explanation: 'still broken', severity: 'fatal' }], submissionUrl: null },
+    ];
+    await forceRefreshDomain('two.example.com');
+    // Reset the background-sweep state so the next `check` call doesn't
+    // race against an in-flight sweep that would overwrite our seeded
+    // cache for the other domain.
+    const after = await checkDomainExternalReachability();
+    const cached = after.items?.find(i => i.id === 'two.example.com');
+    expect(cached).toBeDefined();
+    expect(cached!.actionIds).toContain('refresh_now');
+  });
+
+  it('does not crash and renders queued rows when the cache is empty', async () => {
+    const result = await checkDomainExternalReachability();
+    // Both domains have no cache → both render as queued or probing
+    // rows, and the overall detail mentions queued count.
+    expect(result.items).toHaveLength(2);
+    expect(result.detail).toMatch(/queued/i);
+  });
+});
+
+describe('refresh_now action', () => {
+  it('runs the probe and reports a healthy result', async () => {
+    state.letsdebugResults = [
+      { problems: [], submissionUrl: 'https://letsdebug.net/?id=42' },
+    ];
+    const r = await dispatchProbeAction({
+      probeId: 'domain_external_reachability',
+      actionId: 'refresh_now',
+      node: 'Local',
+      itemId: 'one.example.com',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.message).toMatch(/reachable/);
+    expect(r.refresh).toBe(true);
+    expect(state.callsByDomain.get('one.example.com')).toBe(1);
+  });
+
+  it('reports problem counts when letsdebug finds issues', async () => {
+    state.letsdebugResults = [
+      {
+        problems: [
+          { name: 'IssueA', explanation: 'a', severity: 'fatal' },
+          { name: 'IssueB', explanation: 'b', severity: 'warning' },
+        ],
+        submissionUrl: null,
+      },
+    ];
+    const r = await dispatchProbeAction({
+      probeId: 'domain_external_reachability',
+      actionId: 'refresh_now',
+      node: 'Local',
+      itemId: 'one.example.com',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.message).toMatch(/2 problem/);
+  });
+
+  it('returns ok:false when no domain is supplied', async () => {
+    const r = await dispatchProbeAction({
+      probeId: 'domain_external_reachability',
+      actionId: 'refresh_now',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/No domain/);
+  });
+
+  it('surfaces a clear error message and still refreshes the UI on transport failure', async () => {
+    state.letsdebugThrows = new Error('HTTP 429 — too many requests');
+    const r = await dispatchProbeAction({
+      probeId: 'domain_external_reachability',
+      actionId: 'refresh_now',
+      node: 'Local',
+      itemId: 'one.example.com',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/429/);
+    // We still want a UI refresh so the row's "letsdebug probe could
+    // not run automatically" detail renders.
+    expect(r.refresh).toBe(true);
+  });
+});

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -6,7 +6,7 @@
  *
  * ## Refresh model
  *
- * Three layers, each respecting letsdebug's rate limit:
+ * Four layers, each respecting letsdebug's rate limit:
  *
  *   1. **On every diagnose run** — read the cache as-is, return
  *      immediately. If anything is stale, kick off a non-blocking
@@ -24,6 +24,15 @@
  *   3. **Per-domain in-flight lock** — ensures concurrent diagnose
  *      runs + the periodic timer don't duplicate submissions for
  *      the same domain.
+ *
+ *   4. **Per-row `refresh_now` action** — operator clicks a row's
+ *      "Refresh now" button, the dispatcher calls
+ *      `forceRefreshDomain(domain)` which bypasses the 15 min 429
+ *      backoff and awaits a single probe. The UI re-runs diagnose
+ *      after the action returns, so the row shows the new state
+ *      without a second click. Use when the periodic sweep is
+ *      paused (rate-limited) or the operator wants confirmation
+ *      they just fixed something.
  *
  * ## Cache TTL
  *
@@ -43,7 +52,9 @@
 import { getConfig } from '@/lib/config';
 import { runLetsdebugForDomain, type LetsdebugProblem } from '../../letsdebug/client';
 import { logger } from '../../logger';
-import type { ProbeItem } from '../actions';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+
+const PROBE_ID = 'domain_external_reachability';
 
 export interface DomainExternalReachabilityResult {
   status: 'ok' | 'warn' | 'fail' | 'info';
@@ -92,6 +103,24 @@ function isPublicEntry(entry: { domain: string; exposure?: 'public' | 'lan' }): 
 function isCacheFresh(entry: CacheEntry): boolean {
   const ttl = entry.error ? CACHE_TTL_FAIL_MS : CACHE_TTL_OK_MS;
   return Date.now() - entry.fetchedAt < ttl;
+}
+
+/**
+ * Compact "X ago" string for the operator-facing "last checked" suffix
+ * on each row. Bins coarsen as age grows — minute granularity is the
+ * right resolution at <1h, hour granularity beyond. We round down so
+ * a probe that just landed reads "just now" rather than "1 min ago".
+ */
+function formatRelativeAge(fetchedAt: number, now: number = Date.now()): string {
+  const seconds = Math.max(0, Math.floor((now - fetchedAt) / 1000));
+  if (seconds < 30)                  return 'just now';
+  if (seconds < 60)                  return `${seconds} s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60)                  return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24)                    return `${hours} h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
 }
 
 function severityForProblem(p: LetsdebugProblem): 'warn' | 'fail' {
@@ -195,6 +224,28 @@ async function sweepStaleDomains(): Promise<void> {
 }
 
 /**
+ * Operator-initiated single-domain refresh — bypasses both the
+ * 4 h cache TTL and the 15 min 429 backoff (the operator is
+ * explicitly asking to retry now). Awaits the probe so the
+ * caller can re-fetch immediately afterwards and render fresh
+ * data. Returns the resulting cache entry.
+ *
+ * This is the handler behind the `refresh_now` per-row action;
+ * exported separately so unit tests can drive it without going
+ * through the dispatcher.
+ */
+export async function forceRefreshDomain(domain: string): Promise<CacheEntry | null> {
+  // Clear the backoff gate so this one probe can fire. The gate is
+  // only meant to throttle automatic sweeps; if the operator clicks
+  // refresh, they want a result, not a "please wait" message. We
+  // don't restore the old value — if letsdebug 429s again, the new
+  // backoff window starts from this attempt's failure.
+  backoffUntil = 0;
+  await probeOne(domain);
+  return cache.get(domain) ?? null;
+}
+
+/**
  * Kick off the periodic sweep timer. Safe to call multiple times —
  * second call is a no-op. server.ts calls this once on boot;
  * `checkDomainExternalReachability` also calls it lazily so the
@@ -237,13 +288,15 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   for (const domain of publicDomains) {
     const probing = inFlight.has(domain);
     const entry = cache.get(domain);
+    const manualUrl = `https://letsdebug.net/?domain=${encodeURIComponent(domain)}&method=http-01`;
     if (!entry) {
       // Differentiate "right now being checked" from "queued for the
       // sweep but hasn't started yet" so the operator sees real
       // progress on a re-run. Cached entries below render their
       // real results regardless of whether this domain is the one
-      // currently being probed.
-      const manualUrl = `https://letsdebug.net/?domain=${encodeURIComponent(domain)}&method=http-01`;
+      // currently being probed. `refresh_now` is offered on
+      // queued-but-not-yet-running rows so the operator can jump
+      // their domain ahead of the sweep without waiting their turn.
       if (probing) {
         probingCount++;
         items.push({
@@ -260,19 +313,19 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
           label: domain,
           detail: `⏳ Queued — waiting its turn in the sweep. Manual: ${manualUrl}`,
           status: 'info',
-          actionIds: [],
+          actionIds: ['refresh_now'],
         });
       }
       continue;
     }
+    const ageSuffix = ` · Last checked ${formatRelativeAge(entry.fetchedAt)}`;
     if (entry.error) {
-      const manualUrl = `https://letsdebug.net/?domain=${encodeURIComponent(domain)}&method=http-01`;
       items.push({
         id: domain,
         label: domain,
-        detail: `letsdebug probe could not run automatically (${entry.error.slice(0, 120)}). Open manually: ${manualUrl}`,
+        detail: `letsdebug probe could not run automatically (${entry.error.slice(0, 120)}). Open manually: ${manualUrl}${ageSuffix}`,
         status: 'info',
-        actionIds: [],
+        actionIds: ['refresh_now'],
       });
       continue;
     }
@@ -286,9 +339,9 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     items.push({
       id: domain,
       label: domain,
-      detail: `${top.name || 'problem'}: ${(top.explanation || '').slice(0, 200)}${entry.submissionUrl ? ` · Report: ${entry.submissionUrl}` : ''}`,
+      detail: `${top.name || 'problem'}: ${(top.explanation || '').slice(0, 200)}${entry.submissionUrl ? ` · Report: ${entry.submissionUrl}` : ''}${ageSuffix}`,
       status: itemStatus,
-      actionIds: [],
+      actionIds: ['refresh_now'],
     });
   }
 
@@ -309,7 +362,80 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   return {
     status: stillWorking && overall === 'ok' ? 'info' : overall,
     detail: `${parts.join(' · ')} of ${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'}.`,
-    hint: 'A diagnose run kicks off a background refresh of every stale domain, one at a time (each probe takes 10-30 s to complete). The cache also auto-refreshes every 4 h without operator input. If letsdebug rate-limits us mid-sweep, a 15 min backoff kicks in automatically.',
+    hint: 'A diagnose run kicks off a background refresh of every stale domain, one at a time (each probe takes 10-30 s to complete). The cache also auto-refreshes every 4 h without operator input. If letsdebug rate-limits us mid-sweep, a 15 min backoff kicks in automatically. Click "Refresh now" on any row to jump that domain ahead of the queue and ignore the backoff.',
     items,
   };
+}
+
+/**
+ * `refresh_now` — operator-initiated single-domain re-probe. Bypasses
+ * the rate-limit backoff (the operator is explicitly asking for a
+ * fresh result). Waits for the probe to complete (10-30 s) so the
+ * UI re-fetches diagnose right after and the row already shows the
+ * new state — no second click required.
+ */
+async function refreshNow({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
+  if (!itemId) {
+    return { ok: false, message: 'No domain supplied — nothing to refresh.', refresh: false };
+  }
+  try {
+    const entry = await forceRefreshDomain(itemId);
+    if (!entry) {
+      // probeOne always writes a cache entry (success or error
+      // branch); a null here means something went very wrong above
+      // the cache layer, e.g. a thrown error we don't catch.
+      return {
+        ok: false,
+        message: `Probe for ${itemId} did not produce a result.`,
+        refresh: true,
+      };
+    }
+    if (entry.error) {
+      logger.warn(
+        'diagnose:domain_external_reachability',
+        `refresh_now for ${itemId} failed: ${entry.error}`,
+      );
+      return {
+        ok: false,
+        message: `letsdebug couldn't be reached for ${itemId}: ${entry.error.slice(0, 160)}`,
+        refresh: true,
+      };
+    }
+    return {
+      ok: true,
+      message: entry.problems.length === 0
+        ? `${itemId} is reachable from the internet.`
+        : `${itemId} has ${entry.problems.length} problem(s) — see the row for details.`,
+      refresh: true,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      message: `Refresh failed: ${e instanceof Error ? e.message : String(e)}`,
+      refresh: false,
+    };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'refresh_now',
+    label: 'Refresh now',
+    description:
+      'Re-runs letsdebug for this domain immediately, ignoring the 15 min rate-limit backoff. Takes 10-30 s — the row updates in place when the probe finishes.',
+  },
+  refreshNow,
+);
+
+/**
+ * Test-only: reset the in-memory cache + in-flight set + backoff so
+ * each unit test starts from a known empty state. Production code
+ * must never call this.
+ */
+export function _resetCacheForTesting(): void {
+  cache.clear();
+  inFlight.clear();
+  backoffUntil = 0;
+  sweepActive = false;
 }

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -25,5 +25,6 @@ import './podsAndEngine';
 import './certExpiry';
 import './certRequestFailure';
 import './adguardRewritesMissing';
+import './domainExternalReachability';
 
 export {};


### PR DESCRIPTION
## Summary

- Surfaces `fetchedAt` as a `· Last checked X ago` suffix on every cached letsdebug row so operators can tell stale data from fresh.
- Adds a per-row `refresh_now` action that bypasses the 15 min 429 backoff for explicit retries — the row updates in place once the probe finishes (10-30 s) without a second click.
- Adds `domainExternalReachability.test.ts` (8 tests) covering the timestamp, the action, transport errors, and empty-cache rendering.

Phase 1 of the diagnose / health-check rework — see #482.

Closes #480.

## Why

Today the diagnose UI shows `🔄 Probing now` / `⏳ Queued` rows that never visibly update — the background sweep refreshes the in-memory cache 10-30 s later but the UI has no way to know. Operators were re-clicking "Run self-test" hoping for fresh data. The timestamp removes the ambiguity; the per-row refresh gives an explicit "I want this one now" path that also ignores rate-limit backoff.

This is the small, self-contained fix. The bigger architectural move — lifting letsdebug out of diagnose into a real health-check type — is tracked in #483 (Phase 2).

## Test plan

- [x] Unit tests pass (`npx vitest run src/lib/diagnose/probes/domainExternalReachability.test.ts`) — 8/8.
- [x] Full suite green (674 passed / 2 skipped).
- [x] Lint clean.
- [x] `npm run build` succeeds.
- [ ] On the live install, click "Refresh now" on a queued row and confirm the row transitions to a real result without a second "Run self-test" click.
- [ ] Confirm 429 backoff is bypassed (force one by clicking refresh on multiple rows rapidly; each should still attempt rather than be silently skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)