### PR TITLE
chore(tests): clean 23 tsc errors + wire tsc --noEmit into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Lint
       run: npm run lint
 
+    - name: Typecheck
+      run: npx tsc --noEmit
+
     - name: Build
       run: npm run build
 

--- a/tests/backend/agent_data_flow.test.ts
+++ b/tests/backend/agent_data_flow.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { DigitalTwinStore } from '../../src/lib/store/twin';
 import { EnrichedContainer, ServiceUnit } from '../../src/lib/agent/types';
@@ -21,7 +20,7 @@ describe('DigitalTwinStore Data Flow', () => {
       active: true,
       subState: 'running',
       ports: [
-        { host_port: 53, container_port: 53, protocol: 'tcp' }
+        { hostPort: 53, containerPort: 53, protocol: 'tcp' }
       ],
       associatedContainerIds: ['cid1'],
       isManaged: true,
@@ -40,7 +39,7 @@ describe('DigitalTwinStore Data Flow', () => {
       status: 'Up',
       created: 12345,
       ports: [
-        { host_port: 53, container_port: 53, protocol: 'tcp' }
+        { hostPort: 53, containerPort: 53, protocol: 'tcp' }
       ],
       mounts: [],
       labels: {},
@@ -99,7 +98,7 @@ describe('DigitalTwinStore Data Flow', () => {
      const container: EnrichedContainer = {
          id: 'nginx-cid',
          names: ['nginx'], // Matching name
-         ports: [{ host_port: 80, container_port: 80, protocol: 'tcp' }],
+         ports: [{ hostPort: 80, containerPort: 80, protocol: 'tcp' }],
          image: 'nginx',
          state: 'running',
          status: 'up',
@@ -222,15 +221,18 @@ describe('DigitalTwinStore Data Flow', () => {
 
       // B. Check Proxy Configuration (The new source of truth)
       expect(enrichedService.proxyConfiguration).toBeDefined();
-      expect(enrichedService.proxyConfiguration.servers).toHaveLength(2);
-      
-      const server1 = enrichedService.proxyConfiguration.servers.find((s: any) => s.server_name.includes('app.example.com'));
+      const proxyConfig = enrichedService.proxyConfiguration as {
+        servers: Array<{ server_name: string; listen: string }>;
+      };
+      expect(proxyConfig.servers).toHaveLength(2);
+
+      const server1 = proxyConfig.servers.find((s) => s.server_name.includes('app.example.com'));
       expect(server1).toBeDefined();
-      expect(server1.listen).toContain('443 ssl'); // SSL enabled
-      
-      const server2 = enrichedService.proxyConfiguration.servers.find((s: any) => s.server_name.includes('api.example.com'));
+      expect(server1!.listen).toContain('443 ssl'); // SSL enabled
+
+      const server2 = proxyConfig.servers.find((s) => s.server_name.includes('api.example.com'));
       expect(server2).toBeDefined();
-      expect(server2.listen).toContain('80'); // No SSL
+      expect(server2!.listen).toContain('80'); // No SSL
 
       // C. Check Effective Ports (Should be derived from routes)
       // Expect 80 and 443 because at least one route has SSL and one has 80
@@ -324,7 +326,7 @@ describe('DigitalTwinStore Data Flow', () => {
           description: 'My App',
           path: '',
           active: true,
-            ports: [{ host_port: 8080, container_port: 8080, protocol: 'tcp' }],
+            ports: [{ hostPort: 8080, containerPort: 8080, protocol: 'tcp' }],
             isManaged: true,
           isServiceBay: false
       };

--- a/tests/backend/health_runner.test.ts
+++ b/tests/backend/health_runner.test.ts
@@ -70,7 +70,8 @@ describe('CheckRunner', () => {
             target: 'https://example.com',
             interval: 60,
             enabled: true,
-            httpConfig: { expectedStatus: 200 }
+            httpConfig: { expectedStatus: 200 },
+            created_at: '2024-01-01T00:00:00Z'
         };
 
         // Mock fetch
@@ -98,7 +99,8 @@ describe('CheckRunner', () => {
             target: 'https://example.com',
             interval: 60,
             enabled: true,
-            httpConfig: { expectedStatus: 200 }
+            httpConfig: { expectedStatus: 200 },
+            created_at: '2024-01-01T00:00:00Z'
         };
 
         global.fetch = vi.fn().mockResolvedValue({
@@ -121,7 +123,8 @@ describe('CheckRunner', () => {
             type: 'ping',
             target: 'localhost',
             interval: 60,
-            enabled: true
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z'
          };
 
          const result = await CheckRunner.run(check);
@@ -135,7 +138,8 @@ describe('CheckRunner', () => {
             type: 'ping',
             target: 'failhost',
             interval: 60,
-            enabled: true
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z'
          };
 
          const result = await CheckRunner.run(check);
@@ -150,7 +154,8 @@ describe('CheckRunner', () => {
             type: 'script',
             target: 'if (1 !== 1) throw new Error("Math is broken")',
             interval: 60,
-            enabled: true
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z'
         };
 
         const result = await CheckRunner.run(check);
@@ -164,7 +169,8 @@ describe('CheckRunner', () => {
             type: 'script',
             target: 'throw new Error("Custom Failure")',
             interval: 60,
-            enabled: true
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z'
         };
 
         const result = await CheckRunner.run(check);

--- a/tests/backend/oidc_clients.test.ts
+++ b/tests/backend/oidc_clients.test.ts
@@ -194,7 +194,7 @@ describe('POST /api/system/authelia/oidc-clients', () => {
     // Verify the config was written with the new client
     const writeCall = mockAgent.sendCommand.mock.calls.find((c: any) => c[0] === 'write_file');
     expect(writeCall).toBeDefined();
-    const writtenContent = writeCall[1].content;
+    const writtenContent = writeCall![1].content;
     expect(writtenContent).toContain('client_id: immich');
     expect(writtenContent).toContain('https://photos.example.com/auth/login');
     expect(writtenContent).toContain('https://photos.example.com/user-settings');

--- a/tests/backend/public_api.test.ts
+++ b/tests/backend/public_api.test.ts
@@ -28,8 +28,8 @@ Image=nginx
   it('types should be accessible', () => {
     // This test verifies that the types are exported for type-checking
     // In practice, users would import these types for their own usage
-    const _typeCheck: typeof ServiceBundle | undefined = undefined;
-    const _directives: typeof QuadletDirectives | undefined = undefined;
+    const _typeCheck: ServiceBundle | undefined = undefined;
+    const _directives: QuadletDirectives | undefined = undefined;
     expect(_typeCheck).toBeUndefined();
     expect(_directives).toBeUndefined();
   });

--- a/tests/backend/updater.test.ts
+++ b/tests/backend/updater.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Server } from 'socket.io';
 
 const execMock = vi.fn();
 const emitMock = vi.fn();
 
 type ProgressPayload = { step: string; progress: number; message: string };
-type GlobalWithUpdater = typeof global & { updaterIO?: { emit: typeof emitMock } };
+type GlobalWithUpdater = Omit<typeof global, 'updaterIO'> & { updaterIO?: Server };
 
 vi.mock('../../src/lib/executor', () => ({
   getExecutor: vi.fn(() => ({ exec: execMock })),
@@ -14,7 +15,7 @@ describe('performUpdate', () => {
   beforeEach(() => {
     execMock.mockReset();
     emitMock.mockReset();
-    (global as GlobalWithUpdater).updaterIO = { emit: emitMock };
+    (global as GlobalWithUpdater).updaterIO = { emit: emitMock } as unknown as Server;
   });
 
   afterEach(() => {

--- a/tests/frontend/ContainersPlugin_Ports.test.tsx
+++ b/tests/frontend/ContainersPlugin_Ports.test.tsx
@@ -62,7 +62,11 @@ describe('ContainersPlugin Port Rendering', () => {
                     services: [],
                     volumes: [],
                     files: {},
-                    proxy: []
+                    proxy: [],
+                    nodeIPs: [],
+                    unmanagedBundles: [],
+                    dismissedBundles: [],
+                    history: []
                 }
             },
             gateway: { provider: 'mock' } as any,
@@ -126,13 +130,17 @@ describe('ContainersPlugin Port Rendering', () => {
                     services: [],
                     volumes: [],
                     files: {},
-                    proxy: []
+                    proxy: [],
+                    nodeIPs: [],
+                    unmanagedBundles: [],
+                    dismissedBundles: [],
+                    history: []
                 }
             },
             gateway: { provider: 'mock' } as any,
             proxy: { provider: 'nginx', routes: [] }
         };
-        
+
         mockUseDigitalTwin.mockReturnValue({
             data: mockSnapshot,
             isConnected: true,

--- a/tests/frontend/ServicesPlugin_Twin.test.tsx
+++ b/tests/frontend/ServicesPlugin_Twin.test.tsx
@@ -76,7 +76,11 @@ describe('ServicesPlugin E2E Data Rendering', () => {
                     }],
                     volumes: [],
                     files: {},
-                    proxy: []
+                    proxy: [],
+                    nodeIPs: [],
+                    unmanagedBundles: [],
+                    dismissedBundles: [],
+                    history: []
                 }
             },
             gateway: { provider: 'mock', status: 'down', uptime: 0 } as any,
@@ -123,7 +127,11 @@ describe('ServicesPlugin E2E Data Rendering', () => {
                     containers: [],
                     volumes: [],
                     files: {},
-                    proxy: []
+                    proxy: [],
+                    nodeIPs: [],
+                    unmanagedBundles: [],
+                    dismissedBundles: [],
+                    history: []
                 }
             },
             gateway: { provider: 'mock' } as any,


### PR DESCRIPTION
## Summary

- Fixes 23 \`tsc --noEmit\` errors that had accumulated in \`tests/\` while production types drifted (CheckConfig gained \`created_at\`; NodeTwin gained \`nodeIPs\`/\`unmanagedBundles\`/\`dismissedBundles\`/\`history\`; PortMapping went snake_case → camelCase; ServiceBundle/QuadletDirectives are type-only but were \`typeof\`-ed).
- Adds an \`npx tsc --noEmit\` step to \`.github/workflows/ci.yml\` between Lint and Build so these can't regress silently — the actual root cause is that CI didn't typecheck.
- No production code touched, no tests disabled, no \`any\` casts introduced.

Found while shipping Phase 1 of the diagnose / health-check rework (#482, merged in #485).

## Why

CI today runs \`lint\` + \`build\` + \`test\`. \`next build --webpack\` skips test-file typechecking, and \`vitest run\` doesn't enforce tsc errors. Result: tests with stale types still pass locally and in CI, but \`tsc --noEmit\` is dirty. Adding the typecheck step closes the loop.

## Test plan

- [x] \`npx tsc --noEmit\` → 0 errors.
- [x] \`npm run lint\` → 0 errors (9 pre-existing warnings unrelated to these files).
- [x] \`npx vitest run\` → 674 passed, 2 pre-existing skips.
- [x] \`npm run build\` → success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)