### PR TITLE
feat(health): lift letsdebug into a real health-check type

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -595,17 +595,18 @@ app.prepare().then(() => {
       }
     })();
 
-    // Periodic letsdebug refresh (every 4 h) so a dashboard left
-    // open overnight wakes up with fresh external-reachability data
-    // without the operator having to re-run diagnose. The probe's
-    // own implementation throttles serial submissions per rate
-    // limit; this just starts the timer.
+    // Per-public-domain letsdebug health checks (4 h interval).
+    // Phase 2 of #483: the periodic sweep that used to live inside
+    // the diagnose probe now runs through the regular health-check
+    // scheduler. This call creates one `letsdebug:<domain>` check
+    // per public proxy host on boot — the file watcher picks them
+    // up and schedules them like any other check.
     (async () => {
       try {
-        const { startBackgroundSweep } = await import('./src/lib/diagnose/probes/domainExternalReachability');
-        startBackgroundSweep();
+        const { syncLetsdebugChecks } = await import('./src/lib/health/letsdebugChecks');
+        await syncLetsdebugChecks();
       } catch (err) {
-        logger.warn('Server', `External reachability sweep init failed: ${err instanceof Error ? err.message : String(err)}`);
+        logger.warn('Server', `Letsdebug-check sync failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     })();
 

--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -583,13 +583,15 @@ export async function POST(request: Request) {
                     hosts: merged,
                 },
             });
-            // Keep domain-reachability health checks in sync with the
-            // newly persisted host list. Fire-and-forget: failures
-            // are non-blocking and the next call (or boot-time sync)
-            // catches up.
+            // Keep domain-reachability + letsdebug health checks in
+            // sync with the newly persisted host list. Fire-and-forget:
+            // failures are non-blocking and the next call (or boot-time
+            // sync) catches up.
             try {
                 const { syncDomainChecks } = await import('@/lib/health/domainChecks');
+                const { syncLetsdebugChecks } = await import('@/lib/health/letsdebugChecks');
                 void syncDomainChecks();
+                void syncLetsdebugChecks();
             } catch { /* nice-to-have observability — never block deploy */ }
         } catch (e) {
             logger.warn('ProxyHosts', `Failed to persist proxy host config: ${e}`);

--- a/src/lib/diagnose/probes/domainExternalReachability.test.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.test.ts
@@ -1,39 +1,59 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckConfig, CheckResult } from '@/lib/health/types';
 
 const state = {
   config: {} as any,
-  // Each call to `runLetsdebugForDomain` returns the next queued
-  // result, then sticks on the last one if the queue runs dry.
-  letsdebugResults: [] as Array<{ problems: Array<{ name: string; explanation: string; severity?: string }>; submissionUrl: string | null }>,
-  letsdebugThrows: null as Error | null,
-  callsByDomain: new Map<string, number>(),
+  checks: [] as CheckConfig[],
+  results: new Map<string, CheckResult>(),
+  runOutcome: { status: 'ok' as 'ok' | 'fail', message: '' as string },
+  runCallCount: 0,
 };
 
 vi.mock('@/lib/config', () => ({
   getConfig: vi.fn(() => Promise.resolve(state.config)),
 }));
 
-vi.mock('../../letsdebug/client', () => ({
-  runLetsdebugForDomain: vi.fn((domain: string) => {
-    state.callsByDomain.set(domain, (state.callsByDomain.get(domain) ?? 0) + 1);
-    if (state.letsdebugThrows) return Promise.reject(state.letsdebugThrows);
-    const next = state.letsdebugResults.shift() ?? state.letsdebugResults[0] ?? { problems: [], submissionUrl: null };
-    return Promise.resolve(next);
-  }),
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    getChecks: () => state.checks,
+    getLastResult: (id: string) => state.results.get(id) ?? null,
+    saveResult: (r: CheckResult) => state.results.set(r.check_id, r),
+  },
 }));
 
-// Importing the probe module also runs `registerProbeAction` for
-// `refresh_now`, which lives in the singleton registry — fine across
-// tests since the registration is idempotent within a single import.
+vi.mock('@/lib/health/runner', () => ({
+  LETSDEBUG_MESSAGE_PREFIX: 'letsdebug:',
+  CheckRunner: {
+    run: vi.fn((check: CheckConfig) => {
+      state.runCallCount++;
+      const result: CheckResult = {
+        check_id: check.id,
+        timestamp: new Date().toISOString(),
+        status: state.runOutcome.status,
+        message: state.runOutcome.message,
+        latency: 100,
+      };
+      state.results.set(check.id, result);
+      return Promise.resolve(result);
+    }),
+  },
+}));
+
 import {
   checkDomainExternalReachability,
-  forceRefreshDomain,
-  _resetCacheForTesting,
+  _internalsForTesting,
 } from './domainExternalReachability';
 import { dispatchProbeAction } from '../actions';
 
+const NOW = Date.UTC(2026, 4, 14, 12, 0, 0);
+
+const isoNow = () => new Date(NOW).toISOString();
+const isoAgo = (ms: number) => new Date(NOW - ms).toISOString();
+
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW));
   state.config = {
     reverseProxy: {
       hosts: [
@@ -42,61 +62,123 @@ beforeEach(() => {
       ],
     },
   };
-  state.letsdebugResults = [];
-  state.letsdebugThrows = null;
-  state.callsByDomain.clear();
-  _resetCacheForTesting();
+  state.checks = [
+    {
+      id: 'letsdebug:one.example.com',
+      name: 'External reachability — one.example.com',
+      type: 'letsdebug',
+      target: 'one.example.com',
+      interval: 14400,
+      enabled: true,
+      created_at: isoNow(),
+    },
+    {
+      id: 'letsdebug:two.example.com',
+      name: 'External reachability — two.example.com',
+      type: 'letsdebug',
+      target: 'two.example.com',
+      interval: 14400,
+      enabled: true,
+      created_at: isoNow(),
+    },
+  ];
+  state.results = new Map();
+  state.runOutcome = { status: 'ok', message: '' };
+  state.runCallCount = 0;
 });
 
 describe('checkDomainExternalReachability', () => {
-  it('renders "Last checked X ago" suffix on rows with cache data', async () => {
-    state.letsdebugResults = [
-      { problems: [{ name: 'IssueX', explanation: 'thing broke', severity: 'warning' }], submissionUrl: 'https://letsdebug.net/?id=1' },
-    ];
-    await forceRefreshDomain('one.example.com');
-
+  it('renders "First check pending" when HealthStore has no result yet', async () => {
     const result = await checkDomainExternalReachability();
-    const item = result.items?.find(i => i.id === 'one.example.com');
-    expect(item).toBeDefined();
-    expect(item!.detail).toMatch(/Last checked /);
-    expect(item!.detail).toMatch(/IssueX: thing broke/);
-  });
-
-  it('offers refresh_now action on queued rows (no cache yet)', async () => {
-    const result = await checkDomainExternalReachability();
-    const queued = result.items?.find(i => i.id === 'one.example.com');
-    expect(queued).toBeDefined();
-    expect(queued!.actionIds).toContain('refresh_now');
-  });
-
-  it('offers refresh_now action on rows with a cached problem', async () => {
-    state.letsdebugResults = [
-      { problems: [{ name: 'IssueY', explanation: 'still broken', severity: 'fatal' }], submissionUrl: null },
-    ];
-    await forceRefreshDomain('two.example.com');
-    // Reset the background-sweep state so the next `check` call doesn't
-    // race against an in-flight sweep that would overwrite our seeded
-    // cache for the other domain.
-    const after = await checkDomainExternalReachability();
-    const cached = after.items?.find(i => i.id === 'two.example.com');
-    expect(cached).toBeDefined();
-    expect(cached!.actionIds).toContain('refresh_now');
-  });
-
-  it('does not crash and renders queued rows when the cache is empty', async () => {
-    const result = await checkDomainExternalReachability();
-    // Both domains have no cache → both render as queued or probing
-    // rows, and the overall detail mentions queued count.
     expect(result.items).toHaveLength(2);
-    expect(result.detail).toMatch(/queued/i);
+    expect(result.items![0].detail).toMatch(/First check pending/);
+    expect(result.items![0].actionIds).toContain('refresh_now');
+    expect(result.detail).toMatch(/pending/);
+  });
+
+  it('omits the row for a healthy domain (ok + empty message)', async () => {
+    state.results.set('letsdebug:one.example.com', {
+      check_id: 'letsdebug:one.example.com',
+      timestamp: isoAgo(15 * 60_000), // 15 min ago
+      status: 'ok',
+      message: '',
+      latency: 200,
+    });
+    // two.example.com has no result → pending row.
+    const result = await checkDomainExternalReachability();
+    const rows = result.items?.map(i => i.id);
+    expect(rows).not.toContain('one.example.com');
+    expect(rows).toContain('two.example.com');
+  });
+
+  it('renders a problem row with last-checked + Report URL for an encoded payload', async () => {
+    const payload = JSON.stringify({
+      problems: [{ name: 'IssueX', explanation: 'thing broke', severity: 'warning' }],
+      submissionUrl: 'https://letsdebug.net/?id=1',
+    });
+    state.results.set('letsdebug:one.example.com', {
+      check_id: 'letsdebug:one.example.com',
+      timestamp: isoAgo(12 * 60_000), // 12 min ago
+      status: 'ok',
+      message: `letsdebug:${payload}`,
+      latency: 200,
+    });
+    const result = await checkDomainExternalReachability();
+    const row = result.items?.find(i => i.id === 'one.example.com');
+    expect(row).toBeDefined();
+    expect(row!.detail).toMatch(/IssueX: thing broke/);
+    expect(row!.detail).toMatch(/Report: https/);
+    expect(row!.detail).toMatch(/Last checked 12 min ago/);
+    expect(row!.status).toBe('warn');
+    expect(row!.actionIds).toContain('refresh_now');
+  });
+
+  it('escalates to fail when any problem is severity=fatal', async () => {
+    const payload = JSON.stringify({
+      problems: [{ name: 'IssueY', explanation: 'really broken', severity: 'fatal' }],
+      submissionUrl: null,
+    });
+    state.results.set('letsdebug:one.example.com', {
+      check_id: 'letsdebug:one.example.com',
+      timestamp: isoNow(),
+      status: 'fail',
+      message: `letsdebug:${payload}`,
+      latency: 200,
+    });
+    const result = await checkDomainExternalReachability();
+    const row = result.items?.find(i => i.id === 'one.example.com');
+    expect(row!.status).toBe('fail');
+    expect(result.status).toBe('fail');
+  });
+
+  it('renders a transport-error row for a plaintext fail message', async () => {
+    state.results.set('letsdebug:one.example.com', {
+      check_id: 'letsdebug:one.example.com',
+      timestamp: isoAgo(2 * 60_000),
+      status: 'fail',
+      message: 'letsdebug error: HTTP 429',
+      latency: 200,
+    });
+    const result = await checkDomainExternalReachability();
+    const row = result.items?.find(i => i.id === 'one.example.com');
+    expect(row).toBeDefined();
+    expect(row!.detail).toMatch(/could not run automatically/);
+    expect(row!.detail).toMatch(/HTTP 429/);
+    expect(row!.detail).toMatch(/Last checked 2 min ago/);
+    expect(row!.actionIds).toContain('refresh_now');
+  });
+
+  it('returns ok when no public domains are configured', async () => {
+    state.config = { reverseProxy: { hosts: [] } };
+    const result = await checkDomainExternalReachability();
+    expect(result.status).toBe('ok');
+    expect(result.items).toBeUndefined();
   });
 });
 
 describe('refresh_now action', () => {
-  it('runs the probe and reports a healthy result', async () => {
-    state.letsdebugResults = [
-      { problems: [], submissionUrl: 'https://letsdebug.net/?id=42' },
-    ];
+  it('runs the matching health check and reports the result', async () => {
+    state.runOutcome = { status: 'ok', message: '' };
     const r = await dispatchProbeAction({
       probeId: 'domain_external_reachability',
       actionId: 'refresh_now',
@@ -105,20 +187,18 @@ describe('refresh_now action', () => {
     });
     expect(r.ok).toBe(true);
     expect(r.message).toMatch(/reachable/);
-    expect(r.refresh).toBe(true);
-    expect(state.callsByDomain.get('one.example.com')).toBe(1);
+    expect(state.runCallCount).toBe(1);
   });
 
-  it('reports problem counts when letsdebug finds issues', async () => {
-    state.letsdebugResults = [
-      {
-        problems: [
-          { name: 'IssueA', explanation: 'a', severity: 'fatal' },
-          { name: 'IssueB', explanation: 'b', severity: 'warning' },
-        ],
-        submissionUrl: null,
-      },
-    ];
+  it('reports problem count when the check finds issues', async () => {
+    const payload = JSON.stringify({
+      problems: [
+        { name: 'A', explanation: 'a', severity: 'warning' },
+        { name: 'B', explanation: 'b', severity: 'warning' },
+      ],
+      submissionUrl: null,
+    });
+    state.runOutcome = { status: 'ok', message: `letsdebug:${payload}` };
     const r = await dispatchProbeAction({
       probeId: 'domain_external_reachability',
       actionId: 'refresh_now',
@@ -127,6 +207,19 @@ describe('refresh_now action', () => {
     });
     expect(r.ok).toBe(true);
     expect(r.message).toMatch(/2 problem/);
+  });
+
+  it('surfaces transport errors and still refreshes the UI', async () => {
+    state.runOutcome = { status: 'fail', message: 'letsdebug error: timeout' };
+    const r = await dispatchProbeAction({
+      probeId: 'domain_external_reachability',
+      actionId: 'refresh_now',
+      node: 'Local',
+      itemId: 'one.example.com',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/timeout/);
+    expect(r.refresh).toBe(true);
   });
 
   it('returns ok:false when no domain is supplied', async () => {
@@ -139,18 +232,35 @@ describe('refresh_now action', () => {
     expect(r.message).toMatch(/No domain/);
   });
 
-  it('surfaces a clear error message and still refreshes the UI on transport failure', async () => {
-    state.letsdebugThrows = new Error('HTTP 429 — too many requests');
+  it('returns ok:false when the check does not exist', async () => {
+    state.checks = []; // no checks at all
     const r = await dispatchProbeAction({
       probeId: 'domain_external_reachability',
       actionId: 'refresh_now',
       node: 'Local',
-      itemId: 'one.example.com',
+      itemId: 'missing.example.com',
     });
     expect(r.ok).toBe(false);
-    expect(r.message).toMatch(/429/);
-    // We still want a UI refresh so the row's "letsdebug probe could
-    // not run automatically" detail renders.
-    expect(r.refresh).toBe(true);
+    expect(r.message).toMatch(/No external-reachability check/);
+  });
+});
+
+describe('formatRelativeAge', () => {
+  const { formatRelativeAge } = _internalsForTesting;
+  const NOW2 = Date.UTC(2026, 4, 14, 12, 0, 0);
+  it('renders "just now" for <30s', () => {
+    expect(formatRelativeAge(NOW2 - 5_000, NOW2)).toBe('just now');
+  });
+  it('renders seconds for <60s', () => {
+    expect(formatRelativeAge(NOW2 - 45_000, NOW2)).toBe('45 s ago');
+  });
+  it('renders minutes for <1h', () => {
+    expect(formatRelativeAge(NOW2 - 12 * 60_000, NOW2)).toBe('12 min ago');
+  });
+  it('renders hours for <24h', () => {
+    expect(formatRelativeAge(NOW2 - 5 * 60 * 60_000, NOW2)).toBe('5 h ago');
+  });
+  it('renders days otherwise', () => {
+    expect(formatRelativeAge(NOW2 - 3 * 24 * 60 * 60_000, NOW2)).toBe('3 d ago');
   });
 });

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -1,60 +1,59 @@
 /**
- * `domain_external_reachability` probe — runs letsdebug.net against
- * every public-exposure domain we've registered with NPM, surfacing
- * problems with the internet's view (DNS, port-80 reachability, ACME
- * readiness) that the internal `domain` health check can't see.
+ * `domain_external_reachability` probe — surfaces what letsdebug.net
+ * sees from the internet's view of every public-exposure domain
+ * (DNS, port-80 reachability, ACME readiness).
+ *
+ * Phase 2 of the diagnose / health-check rework (#483): this probe
+ * is now a **thin reader** over the health-check subsystem. The
+ * actual probing is a `letsdebug`-type health check (4 h interval),
+ * managed by `letsdebugChecks.ts` and run by `health/runner.ts`.
+ * Result persistence, scheduling, socket broadcast, and rate-limit
+ * tolerance all live there — this file just joins the latest
+ * results into the diagnose narrative + handles the per-row
+ * "Refresh now" action.
+ *
+ * ## Row rendering rules
+ *
+ *   - HealthStore has no result for `letsdebug:<domain>` yet
+ *     → "⏳ First check pending — runs within a few seconds of boot
+ *        or right after a new public domain is added."
+ *   - `status='ok'` + empty message
+ *     → row is omitted from the items list (healthy, no signal).
+ *   - `status='ok' | 'fail'` + `letsdebug:<json>` payload
+ *     → parse, render top problem + Report URL + Last checked Xago.
+ *   - `status='fail'` + plaintext message (transport error / 429)
+ *     → render "letsdebug probe could not run automatically" + the
+ *       manual letsdebug URL so the operator can submit by hand.
  *
  * ## Refresh model
  *
- * Four layers, each respecting letsdebug's rate limit:
+ * Two layers:
  *
- *   1. **On every diagnose run** — read the cache as-is, return
- *      immediately. If anything is stale, kick off a non-blocking
- *      background sweep that walks the stale set serially with a
- *      delay between submissions. The diagnose response carries
- *      whatever's currently cached plus a "queued — sweep in
- *      progress" marker for the domains being refreshed.
+ *   1. **Scheduled check** (4 h interval) — fires automatically once
+ *      a check exists, no operator action needed. The health-check
+ *      file watcher re-schedules whenever proxy hosts change.
  *
- *   2. **Periodic background sweep** (every 4 h) — fires the same
- *      walk without operator interaction, so a dashboard left
- *      open overnight wakes up with fresh data. Started once
- *      lazily on the first probe call (or via the explicit
- *      `startBackgroundSweep()` from server boot).
- *
- *   3. **Per-domain in-flight lock** — ensures concurrent diagnose
- *      runs + the periodic timer don't duplicate submissions for
- *      the same domain.
- *
- *   4. **Per-row `refresh_now` action** — operator clicks a row's
- *      "Refresh now" button, the dispatcher calls
- *      `forceRefreshDomain(domain)` which bypasses the 15 min 429
- *      backoff and awaits a single probe. The UI re-runs diagnose
- *      after the action returns, so the row shows the new state
- *      without a second click. Use when the periodic sweep is
- *      paused (rate-limited) or the operator wants confirmation
- *      they just fixed something.
- *
- * ## Cache TTL
- *
- *   - successful results: 24 h
- *   - transport errors:  10 min (so 429s clear quickly)
- *
- * ## Rate-limit awareness
- *
- * No artificial inter-submission delay: each `await probeOne()`
- * already takes 10-30 s (the poll waits for letsdebug's test to
- * complete), so submissions are strictly one-at-a-time anyway.
- * Total sweep time for 10 domains: ~3-5 min, well within the cache
- * TTL. The 429 backoff below is the safety net if letsdebug
- * decides we're going too fast despite that.
+ *   2. **Per-row `refresh_now` action** — operator clicks, the
+ *      dispatcher runs the matching health check synchronously
+ *      (bypasses the next-tick wait) and the UI re-fetches diagnose
+ *      so the row reflects the new state without a second click.
  */
 
 import { getConfig } from '@/lib/config';
-import { runLetsdebugForDomain, type LetsdebugProblem } from '../../letsdebug/client';
-import { logger } from '../../logger';
-import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+import {
+  registerProbeAction,
+  type ProbeActionResult,
+  type ProbeItem,
+} from '../actions';
+import { HealthStore } from '@/lib/health/store';
+import { CheckRunner } from '@/lib/health/runner';
+import { LETSDEBUG_MESSAGE_PREFIX } from '@/lib/health/runner';
+import type { CheckResult } from '@/lib/health/types';
+import type { LetsdebugProblem } from '@/lib/letsdebug/client';
+import { logger } from '@/lib/logger';
 
 const PROBE_ID = 'domain_external_reachability';
+const LETSDEBUG_CHECK_PREFIX = 'letsdebug:';
 
 export interface DomainExternalReachabilityResult {
   status: 'ok' | 'warn' | 'fail' | 'info';
@@ -63,53 +62,26 @@ export interface DomainExternalReachabilityResult {
   items?: ProbeItem[];
 }
 
-const CACHE_TTL_OK_MS    = 24 * 60 * 60 * 1000; // 24 h for successful checks
-const CACHE_TTL_FAIL_MS  =  10 * 60 * 1000;     // 10 min for transport errors
-const RATE_LIMIT_BACKOFF_MS = 15 * 60 * 1000;   // if letsdebug 429s mid-sweep, pause this long
-const SWEEP_INTERVAL_MS  =   4 * 60 * 60 * 1000; // periodic 4-h refresh
-// No fixed inter-submission delay: each probe already takes 10-30 s
-// naturally (the poll waits for letsdebug's test to complete), and
-// `await probeOne()` serialises strictly. The earlier 30 s gap was
-// overkill and the 429 backoff below catches the only case where we
-// need to slow down.
-
-/**
- * When letsdebug returns 429 we hold off until this timestamp. Any
- * sweep that lands during the hold-off bails immediately, and the
- * inline diagnose check skips its auto-trigger. The hold lifts on
- * its own; nothing else has to remember to clear it.
- */
-let backoffUntil = 0;
-
-interface CacheEntry {
-  fetchedAt: number;
-  ok: boolean;
-  problems: LetsdebugProblem[];
-  submissionUrl: string | null;
-  error?: string;
-}
-
-const cache = new Map<string, CacheEntry>();
-const inFlight = new Set<string>();
-let sweepActive = false;
-let sweepTimer: NodeJS.Timeout | null = null;
-
 function isPublicEntry(entry: { domain: string; exposure?: 'public' | 'lan' }): boolean {
   if (entry.exposure) return entry.exposure === 'public';
   if (!entry.domain) return false;
   return !entry.domain.endsWith('.home.arpa') && !entry.domain.endsWith('.local');
 }
 
-function isCacheFresh(entry: CacheEntry): boolean {
-  const ttl = entry.error ? CACHE_TTL_FAIL_MS : CACHE_TTL_OK_MS;
-  return Date.now() - entry.fetchedAt < ttl;
+function severityForProblem(p: LetsdebugProblem): 'warn' | 'fail' {
+  return (p.severity || '').toLowerCase() === 'fatal' ? 'fail' : 'warn';
+}
+
+function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'warn' | 'fail' {
+  if (a === 'fail' || b === 'fail') return 'fail';
+  if (a === 'warn' || b === 'warn') return 'warn';
+  return 'ok';
 }
 
 /**
- * Compact "X ago" string for the operator-facing "last checked" suffix
- * on each row. Bins coarsen as age grows — minute granularity is the
- * right resolution at <1h, hour granularity beyond. We round down so
- * a probe that just landed reads "just now" rather than "1 min ago".
+ * Compact "X ago" string for the operator-facing "last checked"
+ * suffix. Bins coarsen as age grows — minutes <1h, hours <24h, days
+ * after. Rounds down so a probe that just landed reads "just now".
  */
 function formatRelativeAge(fetchedAt: number, now: number = Date.now()): string {
   const seconds = Math.max(0, Math.floor((now - fetchedAt) / 1000));
@@ -123,44 +95,26 @@ function formatRelativeAge(fetchedAt: number, now: number = Date.now()): string 
   return `${days} d ago`;
 }
 
-function severityForProblem(p: LetsdebugProblem): 'warn' | 'fail' {
-  return (p.severity || '').toLowerCase() === 'fatal' ? 'fail' : 'warn';
+interface DecodedPayload {
+  problems: LetsdebugProblem[];
+  submissionUrl: string | null;
 }
 
-function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'warn' | 'fail' {
-  if (a === 'fail' || b === 'fail') return 'fail';
-  if (a === 'warn' || b === 'warn') return 'warn';
-  return 'ok';
-}
-
-async function probeOne(domain: string): Promise<{ rateLimited: boolean }> {
-  if (inFlight.has(domain)) return { rateLimited: false };
-  inFlight.add(domain);
+/** Extract the structured `{ problems, submissionUrl }` payload from
+ *  a result message, or null if the message isn't a letsdebug-encoded
+ *  one (e.g. a plaintext transport error). */
+function decodeMessage(message: string | undefined): DecodedPayload | null {
+  if (!message || !message.startsWith(LETSDEBUG_MESSAGE_PREFIX)) return null;
   try {
-    const result = await runLetsdebugForDomain(domain);
-    cache.set(domain, {
-      fetchedAt: Date.now(),
-      ok: result.problems.length === 0,
-      problems: result.problems,
-      submissionUrl: result.submissionUrl,
-    });
-    return { rateLimited: false };
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    cache.set(domain, {
-      fetchedAt: Date.now(),
-      ok: false,
-      problems: [],
-      submissionUrl: null,
-      error: msg,
-    });
-    // Detect 429 by message text — the client throws
-    // "letsdebug submission HTTP 429". Any future variant of
-    // "rate limit" / "too many" follows the same heuristic.
-    const rateLimited = /429|rate.?limit|too.?many/i.test(msg);
-    return { rateLimited };
-  } finally {
-    inFlight.delete(domain);
+    const json = message.slice(LETSDEBUG_MESSAGE_PREFIX.length);
+    const parsed = JSON.parse(json);
+    if (!parsed || !Array.isArray(parsed.problems)) return null;
+    return {
+      problems: parsed.problems as LetsdebugProblem[],
+      submissionUrl: typeof parsed.submissionUrl === 'string' ? parsed.submissionUrl : null,
+    };
+  } catch {
+    return null;
   }
 }
 
@@ -170,112 +124,14 @@ async function listPublicDomains(): Promise<string[]> {
   return Array.from(new Set(hosts.filter(isPublicEntry).map(h => h.domain)));
 }
 
-/**
- * Walk every stale public domain in serial with a delay between
- * submissions. Guarded by `sweepActive` so a second caller while
- * the first is still running silently no-ops — the existing sweep
- * is already covering whatever the second caller would want.
- */
-async function sweepStaleDomains(): Promise<void> {
-  if (sweepActive) return;
-  if (Date.now() < backoffUntil) {
-    logger.info(
-      'diagnose:domain_external_reachability',
-      `Sweep skipped — in 429 backoff until ${new Date(backoffUntil).toISOString()}.`,
-    );
-    return;
-  }
-  sweepActive = true;
-  try {
-    const domains = await listPublicDomains();
-    const stale = domains
-      .filter(d => {
-        const entry = cache.get(d);
-        return !entry || !isCacheFresh(entry);
-      })
-      .sort((a, b) => {
-        const ta = cache.get(a)?.fetchedAt ?? 0;
-        const tb = cache.get(b)?.fetchedAt ?? 0;
-        return ta - tb;
-      });
-    if (stale.length === 0) return;
-    logger.info(
-      'diagnose:domain_external_reachability',
-      `Background sweep starting for ${stale.length} domain(s) — one at a time, each takes 10-30 s.`,
-    );
-    for (const domain of stale) {
-      const { rateLimited } = await probeOne(domain);
-      if (rateLimited) {
-        // Bail the rest of the sweep — letsdebug just told us to
-        // slow down. Wait `RATE_LIMIT_BACKOFF_MS` before any new
-        // sweep is allowed. Periodic timer + on-diagnose triggers
-        // both check this gate.
-        backoffUntil = Date.now() + RATE_LIMIT_BACKOFF_MS;
-        logger.warn(
-          'diagnose:domain_external_reachability',
-          `letsdebug 429 on ${domain} — pausing sweep, next attempt in ${RATE_LIMIT_BACKOFF_MS / 60_000} min.`,
-        );
-        return;
-      }
-    }
-  } finally {
-    sweepActive = false;
-  }
-}
-
-/**
- * Operator-initiated single-domain refresh — bypasses both the
- * 4 h cache TTL and the 15 min 429 backoff (the operator is
- * explicitly asking to retry now). Awaits the probe so the
- * caller can re-fetch immediately afterwards and render fresh
- * data. Returns the resulting cache entry.
- *
- * This is the handler behind the `refresh_now` per-row action;
- * exported separately so unit tests can drive it without going
- * through the dispatcher.
- */
-export async function forceRefreshDomain(domain: string): Promise<CacheEntry | null> {
-  // Clear the backoff gate so this one probe can fire. The gate is
-  // only meant to throttle automatic sweeps; if the operator clicks
-  // refresh, they want a result, not a "please wait" message. We
-  // don't restore the old value — if letsdebug 429s again, the new
-  // backoff window starts from this attempt's failure.
-  backoffUntil = 0;
-  await probeOne(domain);
-  return cache.get(domain) ?? null;
-}
-
-/**
- * Kick off the periodic sweep timer. Safe to call multiple times —
- * second call is a no-op. server.ts calls this once on boot;
- * `checkDomainExternalReachability` also calls it lazily so the
- * timer exists even on dev runs that bypass server.ts.
- */
-export function startBackgroundSweep(): void {
-  if (sweepTimer) return;
-  sweepTimer = setInterval(() => { void sweepStaleDomains(); }, SWEEP_INTERVAL_MS);
-}
-
 export async function checkDomainExternalReachability(): Promise<DomainExternalReachabilityResult> {
-  startBackgroundSweep();
   const publicDomains = await listPublicDomains();
 
   if (publicDomains.length === 0) {
     return {
-      status: 'info',
+      status: 'ok',
       detail: 'No public domains configured — external reachability check skipped.',
     };
-  }
-
-  // Diagnose-triggered sweep — async, non-blocking. The diagnose
-  // response returns whatever's currently cached; the next diagnose
-  // run picks up the new state.
-  const anyStale = publicDomains.some(d => {
-    const e = cache.get(d);
-    return !e || !isCacheFresh(e);
-  });
-  if (anyStale) {
-    void sweepStaleDomains();
   }
 
   let overall: 'ok' | 'warn' | 'fail' = 'ok';
@@ -283,69 +139,56 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   let failedCount = 0;
   let warnCount = 0;
   let pendingCount = 0;
-  let probingCount = 0;
 
   for (const domain of publicDomains) {
-    const probing = inFlight.has(domain);
-    const entry = cache.get(domain);
     const manualUrl = `https://letsdebug.net/?domain=${encodeURIComponent(domain)}&method=http-01`;
-    if (!entry) {
-      // Differentiate "right now being checked" from "queued for the
-      // sweep but hasn't started yet" so the operator sees real
-      // progress on a re-run. Cached entries below render their
-      // real results regardless of whether this domain is the one
-      // currently being probed. `refresh_now` is offered on
-      // queued-but-not-yet-running rows so the operator can jump
-      // their domain ahead of the sweep without waiting their turn.
-      if (probing) {
-        probingCount++;
-        items.push({
-          id: domain,
-          label: domain,
-          detail: `🔄 Probing now (letsdebug takes 10-30 s per domain). Re-run diagnose in a moment for the result. Manual: ${manualUrl}`,
-          status: 'info',
-          actionIds: [],
-        });
-      } else {
-        pendingCount++;
-        items.push({
-          id: domain,
-          label: domain,
-          detail: `⏳ Queued — waiting its turn in the sweep. Manual: ${manualUrl}`,
-          status: 'info',
-          actionIds: ['refresh_now'],
-        });
-      }
-      continue;
-    }
-    const ageSuffix = ` · Last checked ${formatRelativeAge(entry.fetchedAt)}`;
-    if (entry.error) {
+    const checkId = `${LETSDEBUG_CHECK_PREFIX}${domain}`;
+    const result: CheckResult | null = HealthStore.getLastResult(checkId);
+    if (!result) {
+      // No result yet — the check exists (boot-time sync creates it)
+      // but its 4 h timer hasn't fired or the first tick is in
+      // flight. The operator can click "Refresh now" to skip the
+      // wait.
+      pendingCount++;
       items.push({
         id: domain,
         label: domain,
-        detail: `letsdebug probe could not run automatically (${entry.error.slice(0, 120)}). Open manually: ${manualUrl}${ageSuffix}`,
+        detail: `⏳ First check pending — runs within a few seconds of boot. Manual: ${manualUrl}`,
         status: 'info',
         actionIds: ['refresh_now'],
       });
       continue;
     }
-    if (entry.problems.length === 0) {
-      continue; // healthy — no row
+    const ageSuffix = ` · Last checked ${formatRelativeAge(Date.parse(result.timestamp))}`;
+    const payload = decodeMessage(result.message);
+    if (!payload) {
+      // status='fail' with a plaintext message → transport error.
+      // status='ok' with no message → healthy, omit row.
+      if (result.status === 'ok' && !result.message) continue;
+      items.push({
+        id: domain,
+        label: domain,
+        detail: `letsdebug probe could not run automatically (${(result.message ?? 'unknown error').slice(0, 120)}). Open manually: ${manualUrl}${ageSuffix}`,
+        status: 'info',
+        actionIds: ['refresh_now'],
+      });
+      continue;
     }
-    const itemStatus = entry.problems.some(p => severityForProblem(p) === 'fail') ? 'fail' : 'warn';
+    if (payload.problems.length === 0) continue; // healthy with no payload — omit
+    const itemStatus = payload.problems.some(p => severityForProblem(p) === 'fail') ? 'fail' : 'warn';
     overall = worst(overall, itemStatus);
     if (itemStatus === 'fail') failedCount++; else warnCount++;
-    const top = entry.problems[0];
+    const top = payload.problems[0];
     items.push({
       id: domain,
       label: domain,
-      detail: `${top.name || 'problem'}: ${(top.explanation || '').slice(0, 200)}${entry.submissionUrl ? ` · Report: ${entry.submissionUrl}` : ''}${ageSuffix}`,
+      detail: `${top.name || 'problem'}: ${(top.explanation || '').slice(0, 200)}${payload.submissionUrl ? ` · Report: ${payload.submissionUrl}` : ''}${ageSuffix}`,
       status: itemStatus,
       actionIds: ['refresh_now'],
     });
   }
 
-  if (overall === 'ok' && pendingCount === 0 && probingCount === 0) {
+  if (overall === 'ok' && pendingCount === 0) {
     return {
       status: 'ok',
       detail: `${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'} reachable from the internet.`,
@@ -355,57 +198,58 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   const parts: string[] = [];
   if (failedCount)   parts.push(`${failedCount} fatal`);
   if (warnCount)     parts.push(`${warnCount} warning`);
-  if (probingCount)  parts.push(`${probingCount} probing`);
-  if (pendingCount)  parts.push(`${pendingCount} queued`);
+  if (pendingCount)  parts.push(`${pendingCount} pending`);
 
-  const stillWorking = pendingCount > 0 || probingCount > 0;
   return {
-    status: stillWorking && overall === 'ok' ? 'info' : overall,
+    status: pendingCount > 0 && overall === 'ok' ? 'info' : overall,
     detail: `${parts.join(' · ')} of ${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'}.`,
-    hint: 'A diagnose run kicks off a background refresh of every stale domain, one at a time (each probe takes 10-30 s to complete). The cache also auto-refreshes every 4 h without operator input. If letsdebug rate-limits us mid-sweep, a 15 min backoff kicks in automatically. Click "Refresh now" on any row to jump that domain ahead of the queue and ignore the backoff.',
+    hint: 'Every public domain runs an external reachability check every 4 h via letsdebug.net. The result lives in the health-check subsystem (Settings → Health) — this row is a join into that data. Click "Refresh now" on any row to bypass the wait and re-probe immediately.',
     items,
   };
 }
 
 /**
- * `refresh_now` — operator-initiated single-domain re-probe. Bypasses
- * the rate-limit backoff (the operator is explicitly asking for a
- * fresh result). Waits for the probe to complete (10-30 s) so the
- * UI re-fetches diagnose right after and the row already shows the
- * new state — no second click required.
+ * `refresh_now` — operator-initiated single-domain re-probe. Runs
+ * the matching letsdebug health check synchronously (10-30 s) and
+ * saves the result so the UI's auto-refresh picks up the new state
+ * without a second click. Bypasses the next-tick wait — there's no
+ * separate rate-limit backoff in Phase 2 because the 4 h interval
+ * already keeps us well under letsdebug's threshold.
  */
 async function refreshNow({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
   if (!itemId) {
     return { ok: false, message: 'No domain supplied — nothing to refresh.', refresh: false };
   }
+  const checkId = `${LETSDEBUG_CHECK_PREFIX}${itemId}`;
+  const check = HealthStore.getChecks().find(c => c.id === checkId);
+  if (!check) {
+    return {
+      ok: false,
+      message: `No external-reachability check found for ${itemId}. It should appear automatically — try reloading.`,
+      refresh: true,
+    };
+  }
   try {
-    const entry = await forceRefreshDomain(itemId);
-    if (!entry) {
-      // probeOne always writes a cache entry (success or error
-      // branch); a null here means something went very wrong above
-      // the cache layer, e.g. a thrown error we don't catch.
-      return {
-        ok: false,
-        message: `Probe for ${itemId} did not produce a result.`,
-        refresh: true,
-      };
-    }
-    if (entry.error) {
+    const result = await CheckRunner.run(check);
+    if (result.status === 'fail' && !result.message?.startsWith(LETSDEBUG_MESSAGE_PREFIX)) {
+      // Plaintext message → transport error (429, timeout, parse fail).
       logger.warn(
         'diagnose:domain_external_reachability',
-        `refresh_now for ${itemId} failed: ${entry.error}`,
+        `refresh_now for ${itemId} failed: ${result.message}`,
       );
       return {
         ok: false,
-        message: `letsdebug couldn't be reached for ${itemId}: ${entry.error.slice(0, 160)}`,
+        message: `letsdebug couldn't be reached for ${itemId}: ${(result.message ?? 'unknown').slice(0, 160)}`,
         refresh: true,
       };
     }
+    const payload = result.message ? decodeMessage(result.message) : null;
+    const problemCount = payload?.problems.length ?? 0;
     return {
       ok: true,
-      message: entry.problems.length === 0
+      message: problemCount === 0
         ? `${itemId} is reachable from the internet.`
-        : `${itemId} has ${entry.problems.length} problem(s) — see the row for details.`,
+        : `${itemId} has ${problemCount} problem(s) — see the row for details.`,
       refresh: true,
     };
   } catch (e) {
@@ -423,19 +267,17 @@ registerProbeAction(
     id: 'refresh_now',
     label: 'Refresh now',
     description:
-      'Re-runs letsdebug for this domain immediately, ignoring the 15 min rate-limit backoff. Takes 10-30 s — the row updates in place when the probe finishes.',
+      'Re-runs letsdebug for this domain immediately, skipping the wait for the next scheduled check. Takes 10-30 s — the row updates in place when the probe finishes.',
   },
   refreshNow,
 );
 
 /**
- * Test-only: reset the in-memory cache + in-flight set + backoff so
- * each unit test starts from a known empty state. Production code
- * must never call this.
+ * Test-only helpers. Exported for the unit test; production code
+ * must not call these (decodeMessage is internal, formatRelativeAge
+ * is a presentation helper).
  */
-export function _resetCacheForTesting(): void {
-  cache.clear();
-  inFlight.clear();
-  backoffUntil = 0;
-  sweepActive = false;
-}
+export const _internalsForTesting = {
+  formatRelativeAge,
+  decodeMessage,
+};

--- a/src/lib/health/letsdebugChecks.test.ts
+++ b/src/lib/health/letsdebugChecks.test.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckConfig } from './types';
+
+const state = {
+  config: {} as any,
+  checks: [] as CheckConfig[],
+  saved: [] as CheckConfig[],
+  deleted: [] as string[],
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('./store', () => ({
+  HealthStore: {
+    getChecks: () => state.checks,
+    saveCheck: (c: CheckConfig) => {
+      state.saved.push(c);
+      const i = state.checks.findIndex(x => x.id === c.id);
+      if (i >= 0) state.checks[i] = c; else state.checks.push(c);
+    },
+    deleteCheck: (id: string) => {
+      state.deleted.push(id);
+      state.checks = state.checks.filter(c => c.id !== id);
+    },
+  },
+}));
+
+import { syncLetsdebugChecks } from './letsdebugChecks';
+
+beforeEach(() => {
+  state.config = { reverseProxy: { hosts: [] } };
+  state.checks = [];
+  state.saved = [];
+  state.deleted = [];
+});
+
+describe('syncLetsdebugChecks', () => {
+  it('creates one letsdebug:<domain> check per public host', async () => {
+    state.config = {
+      reverseProxy: {
+        hosts: [
+          { domain: 'public.example.com', exposure: 'public' },
+          { domain: 'lan-only.home.arpa' },
+          { domain: 'auto-public.example.org' },
+        ],
+      },
+    };
+    await syncLetsdebugChecks();
+    const ids = state.saved.map(c => c.id).sort();
+    expect(ids).toEqual([
+      'letsdebug:auto-public.example.org',
+      'letsdebug:public.example.com',
+    ]);
+    for (const c of state.saved) {
+      expect(c.type).toBe('letsdebug');
+      expect(c.interval).toBe(14400);
+      expect(c.enabled).toBe(true);
+    }
+  });
+
+  it('skips LAN-only domains', async () => {
+    state.config = {
+      reverseProxy: {
+        hosts: [{ domain: 'node.home.arpa' }, { domain: 'server.local' }],
+      },
+    };
+    await syncLetsdebugChecks();
+    expect(state.saved).toHaveLength(0);
+  });
+
+  it('respects exposure:"lan" override on a public-shaped domain', async () => {
+    state.config = {
+      reverseProxy: {
+        hosts: [{ domain: 'private.example.com', exposure: 'lan' }],
+      },
+    };
+    await syncLetsdebugChecks();
+    expect(state.saved).toHaveLength(0);
+  });
+
+  it('does not re-save an existing identical check (preserves history)', async () => {
+    const existing: CheckConfig = {
+      id: 'letsdebug:public.example.com',
+      name: 'External reachability — public.example.com',
+      type: 'letsdebug',
+      target: 'public.example.com',
+      interval: 14400,
+      enabled: true,
+      created_at: '2026-01-01T00:00:00Z',
+      nodeName: 'Local',
+    };
+    state.checks = [existing];
+    state.config = {
+      reverseProxy: {
+        hosts: [{ domain: 'public.example.com', exposure: 'public' }],
+      },
+    };
+    await syncLetsdebugChecks();
+    expect(state.saved).toHaveLength(0);
+  });
+
+  it('removes orphans when a host is deleted', async () => {
+    state.checks = [{
+      id: 'letsdebug:gone.example.com',
+      name: 'External reachability — gone.example.com',
+      type: 'letsdebug',
+      target: 'gone.example.com',
+      interval: 14400,
+      enabled: true,
+      created_at: '2026-01-01T00:00:00Z',
+    }];
+    state.config = { reverseProxy: { hosts: [] } };
+    await syncLetsdebugChecks();
+    expect(state.deleted).toEqual(['letsdebug:gone.example.com']);
+  });
+
+  it('removes the orphan when a host flips public → lan', async () => {
+    state.checks = [{
+      id: 'letsdebug:flipped.example.com',
+      name: 'External reachability — flipped.example.com',
+      type: 'letsdebug',
+      target: 'flipped.example.com',
+      interval: 14400,
+      enabled: true,
+      created_at: '2026-01-01T00:00:00Z',
+    }];
+    state.config = {
+      reverseProxy: {
+        hosts: [{ domain: 'flipped.example.com', exposure: 'lan' }],
+      },
+    };
+    await syncLetsdebugChecks();
+    expect(state.deleted).toContain('letsdebug:flipped.example.com');
+  });
+
+  it('does not touch unrelated check types', async () => {
+    state.checks = [
+      { id: 'http:my-svc', name: 'HTTP', type: 'http', target: 'http://localhost', interval: 60, enabled: true, created_at: '2026-01-01T00:00:00Z' },
+      { id: 'domain:public.example.com', name: 'Domain', type: 'domain', target: 'public.example.com', interval: 60, enabled: true, created_at: '2026-01-01T00:00:00Z' },
+    ];
+    state.config = { reverseProxy: { hosts: [] } };
+    await syncLetsdebugChecks();
+    expect(state.deleted).toHaveLength(0);
+  });
+});

--- a/src/lib/health/letsdebugChecks.ts
+++ b/src/lib/health/letsdebugChecks.ts
@@ -1,0 +1,111 @@
+/**
+ * Auto-managed `letsdebug`-type health checks for every public NPM
+ * proxy host. Mirrors `domainChecks.ts` (which handles internal
+ * reachability) but probes the *internet's* view of each domain via
+ * letsdebug.net — surfacing TLS, DNS, port-80, and ACME readiness
+ * problems that an internal probe can't see.
+ *
+ * Phase 2 of the diagnose / health-check rework (#483): the
+ * `domain_external_reachability` diagnose probe used to keep its own
+ * 24 h in-memory cache + 4 h background sweep. With the check living
+ * here, persistence + scheduling + socket broadcast all come for
+ * free, and the diagnose probe becomes a thin reader.
+ *
+ * Convention:
+ *   - check.id = `letsdebug:<domain>` so lookups stay deterministic.
+ *   - Only public hosts get a check (LAN-only domains have no
+ *     internet-side view to probe).
+ *   - Interval is 4 h — letsdebug rate-limits aggressively, and a
+ *     longer cadence is plenty for "did my public domain break?".
+ *     Operators who need a sooner answer click "Refresh now" on the
+ *     diagnose row.
+ *
+ * Idempotent on every call. Called from the same lifecycle points as
+ * `syncDomainChecks`: server boot + proxy-host writes.
+ */
+
+import { HealthStore } from './store';
+import type { CheckConfig } from './types';
+import { getConfig, type ProxyHostEntry } from '../config';
+import { logger } from '../logger';
+
+const LETSDEBUG_CHECK_INTERVAL_SECONDS = 4 * 60 * 60; // 4 h
+const LETSDEBUG_CHECK_PREFIX = 'letsdebug:';
+
+function isLanDomain(domain: string): boolean {
+  return domain.endsWith('.home.arpa') || domain.endsWith('.local');
+}
+
+function isPublicExposure(entry: ProxyHostEntry): boolean {
+  if (entry.exposure) return entry.exposure === 'public';
+  return !isLanDomain(entry.domain);
+}
+
+function buildCheck(entry: ProxyHostEntry, now: string): CheckConfig {
+  return {
+    id: `${LETSDEBUG_CHECK_PREFIX}${entry.domain}`,
+    name: `External reachability — ${entry.domain}`,
+    type: 'letsdebug',
+    target: entry.domain,
+    interval: LETSDEBUG_CHECK_INTERVAL_SECONDS,
+    enabled: true,
+    created_at: now,
+    nodeName: 'Local',
+  };
+}
+
+/**
+ * Walk the configured proxy hosts and ensure every public one has a
+ * matching letsdebug-type health check. Removes letsdebug checks for
+ * hosts that have been deleted or flipped from public → LAN.
+ *
+ * Best-effort: any storage error is logged and swallowed —
+ * external-reachability checks are nice-to-have observability, not
+ * load-bearing functionality.
+ */
+export async function syncLetsdebugChecks(): Promise<void> {
+  try {
+    const config = await getConfig();
+    const hosts = config.reverseProxy?.hosts ?? [];
+    const existing = HealthStore.getChecks();
+    const wanted = new Map<string, ProxyHostEntry>();
+    for (const h of hosts) {
+      if (isPublicExposure(h)) {
+        wanted.set(`${LETSDEBUG_CHECK_PREFIX}${h.domain}`, h);
+      }
+    }
+
+    const now = new Date().toISOString();
+
+    // Add or refresh
+    for (const [id, host] of wanted) {
+      const current = existing.find(c => c.id === id);
+      const next = buildCheck(host, current?.created_at ?? now);
+      // Don't churn the saved record (and bust the result history) if
+      // the operator-visible state didn't change.
+      if (
+        current
+        && current.type === next.type
+        && current.target === next.target
+        && current.interval === next.interval
+        && current.enabled === next.enabled
+      ) continue;
+      HealthStore.saveCheck(next);
+    }
+
+    // Remove orphans — any letsdebug check whose domain is no longer
+    // in the wanted set (host deleted, or flipped to LAN-only).
+    for (const check of existing) {
+      if (check.type !== 'letsdebug') continue;
+      if (!check.id.startsWith(LETSDEBUG_CHECK_PREFIX)) continue;
+      if (!wanted.has(check.id)) {
+        HealthStore.deleteCheck(check.id);
+      }
+    }
+  } catch (e) {
+    logger.warn(
+      'letsdebugChecks',
+      `syncLetsdebugChecks failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}

--- a/src/lib/health/runner.ts
+++ b/src/lib/health/runner.ts
@@ -7,6 +7,16 @@ import { agentManager } from '../agent/manager';
 import { getConfig } from '../config';
 import { assertHttpTargetAllowed } from './ssrfGuard';
 import { ContainerId, ServiceName, HostString } from '../api/schemas';
+import { runLetsdebugForDomain } from '../letsdebug/client';
+
+/**
+ * Encoded payload for letsdebug-type results so the diagnose probe
+ * can recover the full `{ problems, submissionUrl }` shape from the
+ * persisted `CheckResult.message`. Prefix lets cheap consumers
+ * detect "structured letsdebug data" vs. "plaintext transport error"
+ * without parsing every message.
+ */
+export const LETSDEBUG_MESSAGE_PREFIX = 'letsdebug:';
 
 export class CheckRunner {
   static async run(check: CheckConfig): Promise<CheckResult> {
@@ -71,6 +81,18 @@ export class CheckRunner {
           if (domainMsg) message = domainMsg;
           status = 'ok';
           break;
+        case 'letsdebug': {
+          // letsdebug returns 0..N problems with severity 'fatal' or
+          // 'warning'. Status 'fail' is reserved for fatal problems +
+          // transport errors so the health page only goes red on
+          // genuinely broken external reachability; warnings are
+          // encoded in the message and the diagnose probe surfaces
+          // them as amber rows.
+          const r = await this.runLetsdebugCheck(check);
+          message = r.message;
+          status = r.status;
+          break;
+        }
       }
     } catch (e: unknown) {
       status = 'fail';
@@ -202,6 +224,53 @@ export class CheckRunner {
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  /**
+   * Run letsdebug.net against `check.target` (a public domain) and
+   * encode the result back into the CheckResult shape.
+   *
+   *   - reachable, no problems → status 'ok', message ''.
+   *   - reachable with warnings only → status 'ok', message
+   *     prefixed `letsdebug:` + JSON-encoded payload.
+   *   - reachable with a fatal problem → status 'fail', same encoded
+   *     payload (so the diagnose probe can render the problem text
+   *     and submission URL without re-running the probe).
+   *   - transport error / 429 / parse failure → status 'fail',
+   *     message is the plaintext error so the operator sees what
+   *     happened on the health page directly.
+   *
+   * The 4 h interval (set in `letsdebugChecks.ts`) is the rate-limit
+   * shield — a 429 just means the next scheduled tick wins, and the
+   * diagnose probe's per-row `refresh_now` action bypasses the wait
+   * if the operator wants confirmation sooner.
+   */
+  private static async runLetsdebugCheck(
+    check: CheckConfig,
+  ): Promise<{ status: 'ok' | 'fail'; message: string }> {
+    let result;
+    try {
+      result = await runLetsdebugForDomain(check.target);
+    } catch (e) {
+      return {
+        status: 'fail',
+        message: `letsdebug error: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+    if (result.problems.length === 0) {
+      return { status: 'ok', message: '' };
+    }
+    const hasFatal = result.problems.some(
+      p => (p.severity || '').toLowerCase() === 'fatal',
+    );
+    const payload = JSON.stringify({
+      problems: result.problems,
+      submissionUrl: result.submissionUrl,
+    });
+    return {
+      status: hasFatal ? 'fail' : 'ok',
+      message: `${LETSDEBUG_MESSAGE_PREFIX}${payload}`,
+    };
   }
 
   private static async runPingCheck(host: string, executor: Executor) {

--- a/src/lib/health/types.ts
+++ b/src/lib/health/types.ts
@@ -1,4 +1,4 @@
-export type CheckType = 'http' | 'ping' | 'script' | 'podman' | 'service' | 'systemd' | 'fritzbox' | 'node' | 'agent' | 'backup' | 'domain';
+export type CheckType = 'http' | 'ping' | 'script' | 'podman' | 'service' | 'systemd' | 'fritzbox' | 'node' | 'agent' | 'backup' | 'domain' | 'letsdebug';
 
 export interface CheckConfig {
   id: string;

--- a/tests/backend/health_runner.test.ts
+++ b/tests/backend/health_runner.test.ts
@@ -30,6 +30,30 @@ vi.mock('../../src/lib/executor', () => {
 });
 vi.mock('../../src/lib/nodes');
 
+// letsdebug client is exercised by its own unit tests; mock here so
+// CheckRunner.run('letsdebug', ...) returns a known shape without any
+// network calls.
+vi.mock('../../src/lib/letsdebug/client', () => ({
+    runLetsdebugForDomain: vi.fn(async (domain: string) => {
+        if (domain === 'fatal.example.com') {
+            return {
+                problems: [{ name: 'X', explanation: 'broken', severity: 'fatal' }],
+                submissionUrl: 'https://letsdebug.net/?id=1',
+            };
+        }
+        if (domain === 'warn.example.com') {
+            return {
+                problems: [{ name: 'Y', explanation: 'meh', severity: 'warning' }],
+                submissionUrl: 'https://letsdebug.net/?id=2',
+            };
+        }
+        if (domain === 'throw.example.com') {
+            throw new Error('HTTP 429');
+        }
+        return { problems: [], submissionUrl: 'https://letsdebug.net/?id=3' };
+    }),
+}));
+
 // Mock child_process for Ping check
 vi.mock('child_process', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -176,5 +200,69 @@ describe('CheckRunner', () => {
         const result = await CheckRunner.run(check);
         expect(result.status).toBe('fail');
         expect(result.message).toContain('Custom Failure');
+    });
+
+    it('should pass a letsdebug check with no problems', async () => {
+        const check: CheckConfig = {
+            id: 'letsdebug:ok.example.com',
+            name: 'External reachability — ok.example.com',
+            type: 'letsdebug',
+            target: 'ok.example.com',
+            interval: 14400,
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z',
+        };
+        const result = await CheckRunner.run(check);
+        expect(result.status).toBe('ok');
+        expect(result.message).toBe('');
+    });
+
+    it('should encode warnings in the message and stay status:ok', async () => {
+        const check: CheckConfig = {
+            id: 'letsdebug:warn.example.com',
+            name: 'External reachability — warn.example.com',
+            type: 'letsdebug',
+            target: 'warn.example.com',
+            interval: 14400,
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z',
+        };
+        const result = await CheckRunner.run(check);
+        expect(result.status).toBe('ok');
+        expect(result.message).toMatch(/^letsdebug:/);
+        const payload = JSON.parse(result.message!.slice('letsdebug:'.length));
+        expect(payload.problems).toHaveLength(1);
+        expect(payload.submissionUrl).toMatch(/letsdebug\.net/);
+    });
+
+    it('should escalate to status:fail when any problem is fatal', async () => {
+        const check: CheckConfig = {
+            id: 'letsdebug:fatal.example.com',
+            name: 'External reachability — fatal.example.com',
+            type: 'letsdebug',
+            target: 'fatal.example.com',
+            interval: 14400,
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z',
+        };
+        const result = await CheckRunner.run(check);
+        expect(result.status).toBe('fail');
+        expect(result.message).toMatch(/^letsdebug:/);
+    });
+
+    it('should report transport errors as status:fail with plaintext message', async () => {
+        const check: CheckConfig = {
+            id: 'letsdebug:throw.example.com',
+            name: 'External reachability — throw.example.com',
+            type: 'letsdebug',
+            target: 'throw.example.com',
+            interval: 14400,
+            enabled: true,
+            created_at: '2024-01-01T00:00:00Z',
+        };
+        const result = await CheckRunner.run(check);
+        expect(result.status).toBe('fail');
+        expect(result.message).toMatch(/letsdebug error: HTTP 429/);
+        expect(result.message).not.toMatch(/^letsdebug:/);
     });
 });


### PR DESCRIPTION
## Summary

- Moves the external-reachability probing into a new \`letsdebug\`-type health check (4 h interval, persisted, socket-broadcast on result change).
- \`syncLetsdebugChecks()\` creates one \`letsdebug:<domain>\` check per public NPM proxy host, called from boot + every proxy-host write (mirrors \`syncDomainChecks\`).
- The \`domain_external_reachability\` diagnose probe is now a thin reader over \`HealthStore.getLastResult()\` — no module-private cache, no background sweep, no rate-limit backoff machinery.
- Per-row "Refresh now" action stays — it now invokes \`CheckRunner.run()\` directly so the operator still has an explicit bypass for the next-tick wait.
- 33 new/changed tests; 0 broken; 693 total pass.

Phase 2 of the diagnose / health-check rework. Closes #483.

## Why

Today the diagnose probe runs its own 24 h in-memory cache + 4 h background sweep + 15 min rate-limit backoff. That worked but it was a parallel observability system the UI couldn't see into — the cache updated and the dashboard had no signal to re-fetch. Lifting it into the health-check subsystem gives us persistence, scheduling, and the existing socket broadcast for free, and the probe becomes ~200 lines of "join HealthStore results into the diagnose narrative."

## Result encoding

\`CheckResult.message\` carries either:
- empty string → healthy, no problems.
- \`letsdebug:<json>\` → structured \`{ problems, submissionUrl }\` payload (diagnose probe parses to render problem rows).
- plaintext → transport error (429, timeout, parse failure).

\`status='fail'\` only when there's a fatal letsdebug problem **or** a transport error. Warnings stay \`status='ok'\` with the encoded payload so the health page only goes red on hard failures.

## Test plan

- [x] Unit tests pass: \`npx vitest run src/lib/health/letsdebugChecks.test.ts src/lib/diagnose/probes/domainExternalReachability.test.ts tests/backend/health_runner.test.ts\` (33/33).
- [x] Full suite green (693 passed, 2 pre-existing skips).
- [x] \`npx tsc --noEmit\` clean.
- [x] Lint clean.
- [x] \`npm run build\` succeeds.
- [ ] On the live install, confirm \`letsdebug:<domain>\` checks appear in Settings → Health within a few seconds of boot.
- [ ] Confirm the diagnose "External reachability" rows render with timestamps once the first check completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)