### PR TITLE
feat(diagnose): live-update on health:update + fix dead 'pass' branch (Phase 3a)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, Loader2, Stethoscope } from 'lucide-react';
 import DiagnoseProbeList, {
   type DiagnoseProbe,
   type ProbeStatus,
 } from '@/components/DiagnoseProbeList';
+import { useSocket } from '@/hooks/useSocket';
 
 interface DiagnoseResult {
   node: string;
@@ -23,8 +24,14 @@ export default function SelfDiagnoseSection() {
   const [result, setResult] = useState<DiagnoseResult | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { socket } = useSocket();
+  // Keep `result` accessible to the socket-driven auto-refresh effect
+  // without re-binding it on every state change (which would tear down
+  // and re-establish the socket listener each render).
+  const hasResultRef = useRef(false);
+  hasResultRef.current = result !== null;
 
-  const run = async () => {
+  const run = useCallback(async () => {
     setRunning(true);
     setError(null);
     try {
@@ -39,7 +46,29 @@ export default function SelfDiagnoseSection() {
     } finally {
       setRunning(false);
     }
-  };
+  }, []);
+
+  // Phase 3a (#484): live-update the diagnose panel when underlying
+  // health-check results change. The server emits `health:update`
+  // every time a check ticks; we debounce 1 s so a burst (e.g. boot
+  // when many checks fire at once) coalesces into a single re-run.
+  // No-op until the operator has clicked "Run self-test" at least
+  // once — there's no point eagerly running the suite for someone
+  // who isn't looking at it.
+  useEffect(() => {
+    if (!socket) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const onUpdate = () => {
+      if (!hasResultRef.current) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => { void run(); }, 1000);
+    };
+    socket.on('health:update', onUpdate);
+    return () => {
+      socket.off('health:update', onUpdate);
+      if (timer) clearTimeout(timer);
+    };
+  }, [socket, run]);
 
   const counts = result ? result.probes.reduce<Record<ProbeStatus, number>>(
     (a, p) => ({ ...a, [p.status]: (a[p.status] || 0) + 1 }),

--- a/src/lib/diagnose/probes/healthChecks.test.ts
+++ b/src/lib/diagnose/probes/healthChecks.test.ts
@@ -1,0 +1,117 @@
+ 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckConfig, CheckResult } from '@/lib/health/types';
+
+const state = {
+  checks: [] as CheckConfig[],
+  results: new Map<string, CheckResult>(),
+  // Each call to CheckRunner.run returns the next outcome from the
+  // queue. Lets a single test seed mixed pass/fail outcomes.
+  runOutcomes: [] as Array<'ok' | 'fail' | 'throw'>,
+  runCallCount: 0,
+};
+
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    getChecks: () => state.checks,
+    getLastResult: (id: string) => state.results.get(id) ?? null,
+    saveResult: (r: CheckResult) => state.results.set(r.check_id, r),
+  },
+}));
+
+vi.mock('@/lib/health/runner', () => ({
+  CheckRunner: {
+    run: vi.fn((check: CheckConfig) => {
+      state.runCallCount++;
+      const outcome = state.runOutcomes.shift() ?? 'ok';
+      if (outcome === 'throw') return Promise.reject(new Error('runner exploded'));
+      const result: CheckResult = {
+        check_id: check.id,
+        timestamp: new Date().toISOString(),
+        status: outcome,
+        latency: 1,
+      };
+      state.results.set(check.id, result);
+      return Promise.resolve(result);
+    }),
+  },
+}));
+
+import { dispatchProbeAction } from '../actions';
+import './healthChecks';
+
+const oldCheck = (id: string): CheckConfig => ({
+  id,
+  name: id,
+  type: 'http',
+  target: 'http://x',
+  interval: 60,
+  enabled: true,
+  // 5 min ago — past the 2 min "stale" grace.
+  created_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+});
+
+beforeEach(() => {
+  state.checks = [];
+  state.results = new Map();
+  state.runOutcomes = [];
+  state.runCallCount = 0;
+});
+
+describe('health_checks probe action: run_all_stale', () => {
+  it('reports "all passed" when every stale check returns status:ok', async () => {
+    // Three enabled, stale checks (no result yet, created > 2 min ago).
+    state.checks = [oldCheck('a'), oldCheck('b'), oldCheck('c')];
+    state.runOutcomes = ['ok', 'ok', 'ok'];
+
+    const r = await dispatchProbeAction({
+      probeId: 'health_checks',
+      actionId: 'run_all_stale',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.message).toMatch(/all passed/);
+    expect(state.runCallCount).toBe(3);
+  });
+
+  it('counts mixed pass/fail outcomes accurately (regression: "pass" → "ok" rename)', async () => {
+    state.checks = [oldCheck('a'), oldCheck('b'), oldCheck('c'), oldCheck('d')];
+    state.runOutcomes = ['ok', 'fail', 'ok', 'fail'];
+
+    const r = await dispatchProbeAction({
+      probeId: 'health_checks',
+      actionId: 'run_all_stale',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/2 passed, 2 failed/);
+  });
+
+  it('counts a thrown runner as a failure', async () => {
+    state.checks = [oldCheck('a'), oldCheck('b')];
+    state.runOutcomes = ['ok', 'throw'];
+
+    const r = await dispatchProbeAction({
+      probeId: 'health_checks',
+      actionId: 'run_all_stale',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/1 passed, 1 failed/);
+  });
+
+  it('returns an informational message when no stale checks remain', async () => {
+    // Check exists but already has a result → not stale.
+    state.checks = [oldCheck('a')];
+    state.results.set('a', { check_id: 'a', timestamp: new Date().toISOString(), status: 'ok', latency: 1 });
+
+    const r = await dispatchProbeAction({
+      probeId: 'health_checks',
+      actionId: 'run_all_stale',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.message).toMatch(/No stale checks/);
+    expect(state.runCallCount).toBe(0);
+  });
+});

--- a/src/lib/diagnose/probes/healthChecks.ts
+++ b/src/lib/diagnose/probes/healthChecks.ts
@@ -40,11 +40,15 @@ async function runAllStale(): Promise<ProbeActionResult> {
   // Run in parallel; CheckRunner.run is independent per-check.
   // Cap concurrent runs implicitly via Promise.allSettled — for the
   // ~10-20 checks a typical install has this is fine.
+  // CheckRunner.run emits status:'ok'|'fail' (not 'pass'); an earlier
+  // version of this code compared against 'pass' and silently counted
+  // every success as a failure, so the toast always read "0 passed,
+  // N failed" even when every stale check came back green.
   const results = await Promise.allSettled(stale.map(c => CheckRunner.run(c)));
   let passed = 0;
   let failed = 0;
   for (const r of results) {
-    if (r.status === 'fulfilled' && r.value && (r.value as { status?: string }).status === 'pass') {
+    if (r.status === 'fulfilled' && r.value?.status === 'ok') {
       passed += 1;
     } else {
       failed += 1;


### PR DESCRIPTION
## Summary

Two small but load-bearing changes from #484.

1. **SSE auto-refresh** in \`SelfDiagnoseSection.tsx\` — subscribes to the existing \`health:update\` socket event and re-runs the diagnose suite (1 s debounced) whenever an underlying check posts a fresh result. The panel now updates in place as letsdebug / cert / domain checks tick, without the operator clicking "Run self-test" again. No-op until the suite has been run once — keeps idle dashboards cheap.
2. **Fix the dead \`result.status === 'pass'\` branch** in \`run_all_stale\`. CheckRunner emits \`'ok'\` / \`'fail'\`, never \`'pass'\`, so the comparison was silently always false and the success toast read "0 passed, N failed" even when every stale check came back green. Adds 4 regression tests.

This is the small slice of Phase 3 — the four probe migrations (cert_expiry, cert_request_failure, lan_ip_drift, npm_auth) ship in a follow-up PR.

## Why split?

Phase 3 is ~1000 LoC across 4 probe migrations. Doing this small slice first delivers the live-update UX immediately, exercises the same socket pipeline the future migrations will rely on, and keeps the bigger PR reviewable on its own merits.

## Test plan

- [x] Unit tests: \`npx vitest run src/lib/diagnose/probes/healthChecks.test.ts\` (4/4).
- [x] Full suite green (697 passed, 2 pre-existing skips).
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm run lint\` clean (warnings only, pre-existing).
- [x] \`npm run build\` succeeds.
- [ ] On the live install, run the self-test, then trigger a check tick (e.g. flip a service down and back) and confirm the panel re-renders without re-clicking "Run self-test".

🤖 Generated with [Claude Code](https://claude.com/claude-code)