### PR TITLE
feat(health): migrate cert_expiry / cert_request_failure / lan_ip / npm_auth into health-check types (Phase 3b)

### DIFF
--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -560,7 +560,7 @@ export async function POST(request: Request) {
   // 12) NPM admin credentials staleness — probe-action handlers
   //     attached automatically when status !== 'ok' (see withActions).
   try {
-    const npmStale = await checkNpmDataStale(nodeName);
+    const npmStale = await checkNpmDataStale();
     if (npmStale.status) {
       probes.push({
         id: 'npm_data_stale',
@@ -584,7 +584,7 @@ export async function POST(request: Request) {
   //     value captured at install, or when the IP has flipped > 1
   //     time in 30 days.
   try {
-    const lanIp = await checkLanIpChanged(nodeName);
+    const lanIp = await checkLanIpChanged();
     probes.push({
       id: 'lan_ip_changed_since_install',
       label: 'LAN IP stability',
@@ -672,7 +672,7 @@ export async function POST(request: Request) {
   //     where no certs exist; warn at ≤14d, fail when expired. Per-row
   //     "Renew now" action triggers NPM's ACME endpoint.
   try {
-    const ce = await checkCertExpiry(nodeName);
+    const ce = await checkCertExpiry();
     probes.push({
       id: 'cert_expiry',
       label: 'TLS certificates',
@@ -697,7 +697,7 @@ export async function POST(request: Request) {
   //      (info) when the log is missing, the last failure is older than
   //      24h, or the file is unparseable.
   try {
-    const crf = await checkCertRequestFailure(nodeName);
+    const crf = await checkCertRequestFailure();
     probes.push({
       id: 'cert_request_failure',
       label: 'Let\'s Encrypt cert requests',

--- a/src/lib/diagnose/probes/certExpiry.test.ts
+++ b/src/lib/diagnose/probes/certExpiry.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckResult } from '@/lib/health/types';
 
 const state = {
   config: {} as any,
   services: [] as any[],
+  results: new Map<string, CheckResult>(),
 };
 
 vi.mock('@/lib/config', () => ({
@@ -14,10 +16,17 @@ vi.mock('@/lib/services/ServiceManager', () => ({
   ServiceManager: { listServices: vi.fn(() => Promise.resolve(state.services)) },
 }));
 
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    getLastResult: (id: string) => state.results.get(id) ?? null,
+  },
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
 import { dispatchProbeAction } from '../actions';
+import { checkCertExpiry } from './certExpiry';
 import './certExpiry';
 
 const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', container: '81' }] }];
@@ -25,7 +34,60 @@ const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', con
 beforeEach(() => {
   state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
   state.services = ACTIVE_NGINX;
+  state.results = new Map();
   mockFetch.mockReset();
+});
+
+// ─── Reader (Phase 3b: thin HealthStore reader) ─────────────────────────
+
+describe('checkCertExpiry (reader)', () => {
+  it('returns info when HealthStore has no result yet', async () => {
+    const out = await checkCertExpiry();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/has not run yet/);
+  });
+
+  it('decodes the runner-encoded payload (warn with items[])', async () => {
+    const payload = {
+      status: 'warn',
+      detail: '1 of 1 Let\'s Encrypt cert expiring within 14 days.',
+      hint: 'NPM auto-renews on a schedule.',
+      items: [
+        {
+          id: '7',
+          label: 'vault.example.com',
+          detail: 'Expires in 3 days.',
+          status: 'warn',
+          actionIds: ['renew_cert'],
+        },
+      ],
+    };
+    state.results.set('cert_expiry', {
+      check_id: 'cert_expiry',
+      timestamp: new Date().toISOString(),
+      status: 'ok',
+      message: `cert_expiry:${JSON.stringify(payload)}`,
+      latency: 100,
+    });
+    const out = await checkCertExpiry();
+    expect(out.status).toBe('warn');
+    expect(out.items).toHaveLength(1);
+    expect(out.items?.[0].id).toBe('7'); // NPM cert id passed straight through to renew_cert action
+    expect(out.items?.[0].actionIds).toEqual(['renew_cert']);
+  });
+
+  it('surfaces transport-error plaintext as info', async () => {
+    state.results.set('cert_expiry', {
+      check_id: 'cert_expiry',
+      timestamp: new Date().toISOString(),
+      status: 'fail',
+      message: 'cert_expiry error: NPM unreachable',
+      latency: 100,
+    });
+    const out = await checkCertExpiry();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/Check failed to run.*NPM unreachable/);
+  });
 });
 
 describe('cert_expiry.renew_cert', () => {

--- a/src/lib/diagnose/probes/certExpiry.ts
+++ b/src/lib/diagnose/probes/certExpiry.ts
@@ -4,20 +4,28 @@
  * Each item gets a per-row "Renew now" action that triggers NPM's
  * cert renewal endpoint.
  *
- * Silent (status: info) in LAN-domain mode where no certs exist —
- * keeps the diagnose surface tidy until the operator switches to
- * public-domain mode (D19-PR8 / #265). Also silent on the cold path
- * (no NPM, no creds, no response) — the existing pods / npm_data_stale
- * probes already cover those cases.
+ * Phase 3b of the diagnose / health-check rework (#484): this probe
+ * is now a **thin reader** over the health-check subsystem. Detection
+ * runs on a `cert_expiry`-type singleton check (1 h interval, see
+ * `health/init.ts`) and the result is persisted to `HealthStore`.
+ * Result persistence, scheduling, and the Phase 3a SSE broadcast all
+ * live there — this file just reads the latest result back into the
+ * diagnose narrative.
+ *
+ * The `renew_cert` action handler stays here because it mutates NPM
+ * state at click-time (re-runs the ACME challenge for one cert id) —
+ * only the detection moved into the health subsystem.
  */
 
 import { getConfig } from '@/lib/config';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+import { HealthStore } from '@/lib/health/store';
+import { CERT_EXPIRY_MESSAGE_PREFIX } from '@/lib/health/runner';
 
 const PROBE_ID = 'cert_expiry';
-const WARN_DAYS = 14;
+const CHECK_ID = 'cert_expiry';
 
 export interface CertExpiryResult {
   status: 'ok' | 'warn' | 'fail' | 'info';
@@ -26,13 +34,46 @@ export interface CertExpiryResult {
   items?: ProbeItem[];
 }
 
-interface NpmCert {
-  id: number;
-  provider?: string;
-  nice_name?: string;
-  domain_names?: string[];
-  expires_on?: string;
+/** Reader: surfaces the latest persisted `cert_expiry` health-check
+ *  result. Items carry the numeric NPM cert id encoded by the runner;
+ *  `renew_cert` decodes it back to a `/api/nginx/certificates/<id>/renew`
+ *  POST against NPM.  Diagnose route used to call this with
+ *  `(nodeName)` — the arg is now unused because the singleton check
+ *  captures the node via its `nodeName` field. */
+export async function checkCertExpiry(): Promise<CertExpiryResult> {
+  const result = HealthStore.getLastResult(CHECK_ID);
+  if (!result) {
+    return {
+      status: 'info',
+      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+    };
+  }
+  if (result.message && result.message.startsWith(CERT_EXPIRY_MESSAGE_PREFIX)) {
+    try {
+      const json = result.message.slice(CERT_EXPIRY_MESSAGE_PREFIX.length);
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed.status === 'string' && typeof parsed.detail === 'string') {
+        return {
+          status: parsed.status,
+          detail: parsed.detail,
+          hint: typeof parsed.hint === 'string' ? parsed.hint : undefined,
+          items: Array.isArray(parsed.items) ? (parsed.items as ProbeItem[]) : undefined,
+        };
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (result.status === 'fail') {
+    return {
+      status: 'info',
+      detail: `Check failed to run: ${result.message || 'unknown error'}`,
+    };
+  }
+  return { status: 'info', detail: 'Cert expiry check produced no actionable signal.' };
 }
+
+// ─── Action handlers (kept in the probe file) ───────────────────────────
 
 async function findNpmAdminUrl(node: string): Promise<string | null> {
   try {
@@ -73,83 +114,6 @@ async function getNpmToken(adminUrl: string): Promise<string | null> {
     } catch { /* try next */ }
   }
   return null;
-}
-
-export async function checkCertExpiry(node: string): Promise<CertExpiryResult> {
-  const adminUrl = await findNpmAdminUrl(node);
-  if (!adminUrl) {
-    return { status: 'info', detail: 'Nginx Proxy Manager not deployed — no certificates to check.' };
-  }
-  const token = await getNpmToken(adminUrl);
-  if (!token) {
-    return { status: 'info', detail: 'Could not authenticate with NPM — skipping certificate check.' };
-  }
-  let certs: NpmCert[];
-  try {
-    const res = await fetch(`${adminUrl}/api/nginx/certificates`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(6000),
-    });
-    if (!res.ok) {
-      return { status: 'info', detail: `NPM certificates API returned HTTP ${res.status}.` };
-    }
-    certs = await res.json() as NpmCert[];
-  } catch (e) {
-    return { status: 'info', detail: `Could not list NPM certificates: ${e instanceof Error ? e.message : String(e)}` };
-  }
-
-  // NPM tracks self-uploaded certs too; the diagnose value is in
-  // letsencrypt-managed ones (NPM auto-renews them but renewal can
-  // fail silently — DNS challenge regression, rate limit, etc).
-  const leCerts = (certs ?? []).filter(c => c.provider === 'letsencrypt');
-  if (leCerts.length === 0) {
-    return { status: 'info', detail: 'No Let\'s Encrypt certificates managed by NPM.' };
-  }
-  const now = Date.now();
-  const items: ProbeItem[] = [];
-  let expiringSoon = 0;
-  let expired = 0;
-  for (const c of leCerts) {
-    if (!c.expires_on) continue;
-    const exp = Date.parse(c.expires_on);
-    if (!Number.isFinite(exp)) continue;
-    const daysLeft = Math.floor((exp - now) / (1000 * 60 * 60 * 24));
-    const domains = (c.domain_names ?? []).join(', ') || `cert ${c.id}`;
-    if (daysLeft < 0) {
-      expired += 1;
-      items.push({
-        id: String(c.id),
-        label: domains,
-        detail: `EXPIRED ${-daysLeft} day${daysLeft === -1 ? '' : 's'} ago — services served via this cert show browser warnings.`,
-        status: 'fail',
-        actionIds: ['renew_cert'],
-      });
-    } else if (daysLeft <= WARN_DAYS) {
-      expiringSoon += 1;
-      items.push({
-        id: String(c.id),
-        label: domains,
-        detail: `Expires in ${daysLeft} day${daysLeft === 1 ? '' : 's'}.`,
-        status: 'warn',
-        actionIds: ['renew_cert'],
-      });
-    }
-  }
-  if (items.length === 0) {
-    return {
-      status: 'ok',
-      detail: `${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} managed; none expiring in ${WARN_DAYS} days.`,
-    };
-  }
-  const status: 'warn' | 'fail' = expired > 0 ? 'fail' : 'warn';
-  return {
-    status,
-    detail: expired > 0
-      ? `${expired} expired + ${expiringSoon} expiring soon out of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'}.`
-      : `${expiringSoon} of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} expiring within ${WARN_DAYS} days.`,
-    hint: 'NPM auto-renews on a schedule; click "Renew now" if you want to force a refresh ahead of expiry. Failed renewals usually mean DNS or port-80 challenge changed since issuance.',
-    items,
-  };
 }
 
 async function renewCert({

--- a/src/lib/diagnose/probes/certRequestFailure.test.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckResult } from '@/lib/health/types';
 
 const state = {
   config: {} as any,
   services: [] as any[],
+  results: new Map<string, CheckResult>(),
 };
 
 const mockAgent = { sendCommand: vi.fn() };
@@ -18,6 +20,12 @@ vi.mock('@/lib/services/ServiceManager', () => ({
 
 vi.mock('@/lib/agent/manager', () => ({
   agentManager: { ensureAgent: vi.fn(() => Promise.resolve(mockAgent)) },
+}));
+
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    getLastResult: (id: string) => state.results.get(id) ?? null,
+  },
 }));
 
 const mockFetch = vi.fn();
@@ -35,6 +43,7 @@ beforeEach(() => {
     templateSettings: { DATA_DIR: '/mnt/data' },
   };
   state.services = ACTIVE_NGINX;
+  state.results = new Map();
   mockAgent.sendCommand.mockReset();
   mockFetch.mockReset();
 });
@@ -100,65 +109,55 @@ acme.errors.Error: urn:ietf:params:acme:error:rateLimited :: Error creating new 
   });
 });
 
-// ─── Probe top-level ────────────────────────────────────────────────────
+// ─── Reader (Phase 3b: thin HealthStore reader) ─────────────────────────
 
-describe('checkCertRequestFailure', () => {
-  function mockTail(stdout: string, code = 0) {
-    mockAgent.sendCommand.mockResolvedValueOnce({ code, stdout, stderr: '' });
-  }
-
-  it('returns info when the log tail is empty', async () => {
-    mockTail('');
-    const out = await checkCertRequestFailure('Local');
+describe('checkCertRequestFailure (reader)', () => {
+  it('returns info when HealthStore has no result yet', async () => {
+    const out = await checkCertRequestFailure();
     expect(out.status).toBe('info');
-    expect(out.detail).toMatch(/hasn't attempted/);
+    expect(out.detail).toMatch(/has not run yet/);
   });
 
-  it('returns ok when tail has no failure markers', async () => {
-    mockTail('2026-05-12 00:00:00,000:INFO:certbot:All clean.');
-    const out = await checkCertRequestFailure('Local');
-    expect(out.status).toBe('ok');
-  });
-
-  it('returns fail with one item per failed domain', async () => {
-    const recent = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').slice(0, 19);
-    mockTail(`${recent},123:ERROR:certbot:Some challenges have failed.
-  Domain: vault.dopp.cloud
-  Type:   connection
-  Detail: 1.2.3.4: Fetching http://vault.dopp.cloud/.well-known/acme-challenge/abc: Connection refused`);
-    const out = await checkCertRequestFailure('Local');
+  it('decodes the runner-encoded payload into the probe shape', async () => {
+    const payload = {
+      status: 'fail',
+      detail: '1 domain with recent ACME failure in NPM\'s letsencrypt.log.',
+      hint: 'Most common cause is port 80 not reachable.',
+      items: [
+        {
+          id: 'vault.dopp.cloud',
+          label: 'vault.dopp.cloud',
+          detail: 'ACME connection challenge failed: refused',
+          status: 'fail',
+          actionIds: ['show_log_tail', 'retry_request'],
+        },
+      ],
+    };
+    state.results.set('cert_request_failure', {
+      check_id: 'cert_request_failure',
+      timestamp: new Date().toISOString(),
+      status: 'fail',
+      message: `cert_request_failure:${JSON.stringify(payload)}`,
+      latency: 100,
+    });
+    const out = await checkCertRequestFailure();
     expect(out.status).toBe('fail');
+    expect(out.detail).toMatch(/1 domain with recent ACME failure/);
     expect(out.items).toHaveLength(1);
     expect(out.items?.[0].label).toBe('vault.dopp.cloud');
-    expect(out.items?.[0].detail).toMatch(/Connection refused/);
-    expect(out.items?.[0].actionIds).toEqual(['show_log_tail', 'retry_request']);
   });
 
-  it('returns ok when the failure is older than the freshness window', async () => {
-    // 48h old → outside the 24h freshness window.
-    const old = new Date(Date.now() - 48 * 3600_000).toISOString().replace('T', ' ').slice(0, 19);
-    mockTail(`${old},000:ERROR:certbot:Some challenges have failed.
-  Domain: vault.dopp.cloud
-  Type:   connection
-  Detail: stale failure`);
-    const out = await checkCertRequestFailure('Local');
-    expect(out.status).toBe('ok');
-    expect(out.detail).toMatch(/outside the .* freshness window/);
-  });
-
-  it('surfaces a rate-limit pseudo-item when no per-domain block', async () => {
-    const recent = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').slice(0, 19);
-    mockTail(`${recent},000:ERROR:certbot:Some challenges have failed.
-acme.errors.Error: urn:ietf:params:acme:error:rateLimited :: too many failed authorizations recently`);
-    const out = await checkCertRequestFailure('Local');
-    expect(out.status).toBe('fail');
-    expect(out.items?.[0].label).toMatch(/rate limit/i);
-  });
-
-  it('returns info when reading the log fails (non-zero exit)', async () => {
-    mockTail('', 1);
-    const out = await checkCertRequestFailure('Local');
+  it('surfaces transport-error plaintext as info', async () => {
+    state.results.set('cert_request_failure', {
+      check_id: 'cert_request_failure',
+      timestamp: new Date().toISOString(),
+      status: 'fail',
+      message: 'cert_request_failure error: agent timeout',
+      latency: 100,
+    });
+    const out = await checkCertRequestFailure();
     expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/Check failed to run.*agent timeout/);
   });
 });
 

--- a/src/lib/diagnose/probes/certRequestFailure.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.ts
@@ -7,13 +7,22 @@
  * expandable details block) and a `retry_request` action (re-runs NPM's
  * renew endpoint).
  *
- * Silent (info) when no log exists, when the last failure is older than
- * `FRESHNESS_HOURS`, or when the log is unparseable — keeps the diagnose
- * surface tidy until something is actually broken.
+ * Phase 3b of the diagnose / health-check rework (#484): this probe
+ * is now a **thin reader** over the health-check subsystem. Detection
+ * runs on a `cert_request_failure`-type singleton check (10 min
+ * interval, see `health/init.ts`); the runner calls into the shared
+ * parser at `health/probes/letsencryptLogParser.ts`.  Result
+ * persistence, scheduling, and the Phase 3a SSE broadcast all live in
+ * the health subsystem — this file just reads the latest result back
+ * into the diagnose narrative.
  *
- * House style: helpers (`findNpmAdminUrl`, `getNpmToken`) are duplicated
- * from `certExpiry.ts` rather than extracted into a shared module — see
- * the note in `danglingProxy.ts:29`.
+ * The two action handlers (`show_log_tail`, `retry_request`) stay
+ * here because they mutate NPM state at click-time (one-shot read or
+ * cert renew).
+ *
+ * `parseLetsencryptTail` is re-exported from the new shared module so
+ * the existing test in `certRequestFailure.test.ts` keeps importing it
+ * from this path unchanged.
  */
 
 import { agentManager } from '@/lib/agent/manager';
@@ -21,10 +30,16 @@ import { getConfig } from '@/lib/config';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+import { HealthStore } from '@/lib/health/store';
+import { CERT_REQUEST_FAILURE_MESSAGE_PREFIX } from '@/lib/health/runner';
+import { parseLetsencryptTail } from '@/lib/health/probes/letsencryptLogParser';
+
+// Re-export so callers (and the existing unit test) can import the
+// parser via the old module path.
+export { parseLetsencryptTail };
 
 const PROBE_ID = 'cert_request_failure';
-const FRESHNESS_HOURS = 24;
-const TAIL_BYTES = 65_536;
+const CHECK_ID = 'cert_request_failure';
 
 export interface CertRequestFailureResult {
   status: 'ok' | 'warn' | 'fail' | 'info';
@@ -33,28 +48,71 @@ export interface CertRequestFailureResult {
   items?: ProbeItem[];
 }
 
-interface ParsedFailure {
-  domain: string;
-  type: string;
-  detail: string;
+/** Reader: surfaces the latest persisted `cert_request_failure`
+ *  health-check result. Diagnose route used to call this with
+ *  `(nodeName)` — the arg is now unused; the singleton check captures
+ *  the node via its `nodeName` field. */
+export async function checkCertRequestFailure(): Promise<CertRequestFailureResult> {
+  const result = HealthStore.getLastResult(CHECK_ID);
+  if (!result) {
+    return {
+      status: 'info',
+      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+    };
+  }
+  if (result.message && result.message.startsWith(CERT_REQUEST_FAILURE_MESSAGE_PREFIX)) {
+    try {
+      const json = result.message.slice(CERT_REQUEST_FAILURE_MESSAGE_PREFIX.length);
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed.status === 'string' && typeof parsed.detail === 'string') {
+        return {
+          status: parsed.status,
+          detail: parsed.detail,
+          hint: typeof parsed.hint === 'string' ? parsed.hint : undefined,
+          items: Array.isArray(parsed.items) ? (parsed.items as ProbeItem[]) : undefined,
+        };
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (result.status === 'fail') {
+    return {
+      status: 'info',
+      detail: `Check failed to run: ${result.message || 'unknown error'}`,
+    };
+  }
+  return { status: 'info', detail: 'Cert request failure check produced no actionable signal.' };
 }
 
-export interface ParsedFailureBlock {
-  failures: ParsedFailure[];
-  rateLimited: boolean;
-  /** Newest timestamp anywhere in the tail (epoch ms, UTC-interpreted). */
-  ts?: number;
-}
+// ─── Action handlers (kept in the probe file) ───────────────────────────
+
+const TAIL_BYTES_FOR_DISPLAY = 16_384;
 
 function letsencryptLogPath(dataDir: string): string {
   return `${dataDir}/nginx-proxy-manager/data/logs/letsencrypt.log`;
 }
 
-// Refuse to compose a shell command unless the path is a clean POSIX
-// absolute path. DATA_DIR comes from config and is admin-editable; this
-// is belt-and-braces against an accidental shell-meta in the value.
 function safePath(p: string): boolean {
   return /^\/[A-Za-z0-9_./-]+$/.test(p);
+}
+
+async function readLogTail(node: string, path: string, bytes: number): Promise<string | null> {
+  if (!safePath(path)) {
+    logger.warn('diagnose:cert_request_failure', `Refusing tail of unsafe path: ${path}`);
+    return null;
+  }
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    const res = await agent.sendCommand('exec', {
+      command: `tail -c ${bytes} ${path} 2>/dev/null`,
+    }, { timeoutMs: 5_000 }) as { code?: number; stdout?: string };
+    if (res.code !== 0) return null;
+    return res.stdout ?? '';
+  } catch (e) {
+    logger.warn('diagnose:cert_request_failure', `tail letsencrypt.log failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
 }
 
 async function findNpmAdminUrl(node: string): Promise<string | null> {
@@ -98,138 +156,11 @@ async function getNpmToken(adminUrl: string): Promise<string | null> {
   return null;
 }
 
-async function readLogTail(node: string, path: string, bytes = TAIL_BYTES): Promise<string | null> {
-  if (!safePath(path)) {
-    logger.warn('diagnose:cert_request_failure', `Refusing tail of unsafe path: ${path}`);
-    return null;
-  }
-  try {
-    const agent = await agentManager.ensureAgent(node);
-    const res = await agent.sendCommand('exec', {
-      command: `tail -c ${bytes} ${path} 2>/dev/null`,
-    }, { timeoutMs: 5_000 }) as { code?: number; stdout?: string };
-    if (res.code !== 0) return null;
-    return res.stdout ?? '';
-  } catch (e) {
-    logger.warn('diagnose:cert_request_failure', `tail letsencrypt.log failed: ${e instanceof Error ? e.message : String(e)}`);
-    return null;
-  }
-}
-
-const STRUCTURED_FAILURE_RE = /Domain:\s*(\S+)\s*\n\s*Type:\s*(\S+)\s*\n\s*Detail:\s*([^\n]+)/g;
-// Legacy/inline format used by older certbot releases.
-const INLINE_FAILURE_RE = /Failed authorization procedure\.\s+(\S+)\s+\(([^)]+)\):\s+urn:ietf:params:acme:error:\S+\s*::\s*([^\n]+)/g;
-const RATE_LIMIT_RE = /urn:ietf:params:acme:error:rateLimited/i;
-const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/gm;
-
-export function parseLetsencryptTail(tail: string): ParsedFailureBlock {
-  // Scope to the slice starting at the most recent "Some challenges
-  // have failed" line so older failure blocks higher up don't leak in.
-  // Failures in certbot output come AFTER the marker line, so we
-  // start at the beginning of that line. Fall back to the full tail
-  // when the marker isn't present — older log lines sometimes just
-  // have "Challenge failed for domain X" without it.
-  const lastMarker = tail.lastIndexOf('Some challenges have failed');
-  const sliceStart = lastMarker >= 0
-    ? Math.max(0, tail.lastIndexOf('\n', lastMarker) + 1)
-    : 0;
-  const slice = tail.slice(sliceStart);
-
-  const failures: ParsedFailure[] = [];
-  STRUCTURED_FAILURE_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = STRUCTURED_FAILURE_RE.exec(slice)) !== null) {
-    failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
-  }
-  if (failures.length === 0) {
-    INLINE_FAILURE_RE.lastIndex = 0;
-    while ((m = INLINE_FAILURE_RE.exec(slice)) !== null) {
-      failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
-    }
-  }
-
-  const rateLimited = RATE_LIMIT_RE.test(slice);
-
-  let ts: number | undefined;
-  TIMESTAMP_RE.lastIndex = 0;
-  const tsMatches = slice.match(TIMESTAMP_RE);
-  if (tsMatches && tsMatches.length > 0) {
-    const last = tsMatches[tsMatches.length - 1];
-    const parsed = Date.parse(`${last.replace(' ', 'T')}Z`);
-    if (Number.isFinite(parsed)) ts = parsed;
-  }
-
-  return { failures, rateLimited, ts };
-}
-
-export async function checkCertRequestFailure(node: string): Promise<CertRequestFailureResult> {
-  const config = await getConfig();
-  const dataDir = config.templateSettings?.DATA_DIR ?? '/mnt/data';
-  const path = letsencryptLogPath(dataDir);
-
-  const tail = await readLogTail(node, path);
-  if (tail === null || tail.length === 0) {
-    return {
-      status: 'info',
-      detail: 'No letsencrypt.log found — NPM hasn\'t attempted any cert requests yet.',
-    };
-  }
-
-  const parsed = parseLetsencryptTail(tail);
-  if (parsed.failures.length === 0 && !parsed.rateLimited) {
-    return { status: 'ok', detail: 'No Let\'s Encrypt cert failures in the recent NPM log.' };
-  }
-
-  if (parsed.ts) {
-    const ageMs = Date.now() - parsed.ts;
-    if (ageMs > FRESHNESS_HOURS * 3_600_000) {
-      return {
-        status: 'ok',
-        detail: `Last cert failure was ${Math.round(ageMs / 3_600_000)}h ago (outside the ${FRESHNESS_HOURS}h freshness window). Treating as resolved.`,
-      };
-    }
-  }
-
-  // De-duplicate by domain (most recent wins thanks to insertion order).
-  const byDomain = new Map<string, ParsedFailure>();
-  for (const f of parsed.failures) byDomain.set(f.domain, f);
-
-  const items: ProbeItem[] = [];
-  for (const [domain, f] of byDomain) {
-    const detail = f.detail.length > 140 ? `${f.detail.slice(0, 140)}…` : f.detail;
-    items.push({
-      id: domain,
-      label: domain,
-      detail: `ACME ${f.type} challenge failed: ${detail}`,
-      status: 'fail',
-      actionIds: ['show_log_tail', 'retry_request'],
-    });
-  }
-  if (parsed.rateLimited && items.length === 0) {
-    items.push({
-      id: 'rate-limited',
-      label: 'Let\'s Encrypt rate limit',
-      detail: 'Hit the ACME rate limit (5 failed validations / host / hour). Wait ~1h and fix the root cause before retrying.',
-      status: 'fail',
-      actionIds: ['show_log_tail'],
-    });
-  }
-
-  return {
-    status: 'fail',
-    detail: `${items.length} domain${items.length === 1 ? '' : 's'} with recent ACME failure${items.length === 1 ? '' : 's'} in NPM\'s letsencrypt.log.`,
-    hint: 'Most common cause is public port 80 not reachable from the internet. Run letsdebug.net for an external view of what the ACME server sees, then click Retry once the underlying cause is fixed.',
-    items,
-  };
-}
-
-// ─── Action handlers ────────────────────────────────────────────────────
-
 async function showLogTail({ node }: { node: string }): Promise<ProbeActionResult> {
   const config = await getConfig();
   const dataDir = config.templateSettings?.DATA_DIR ?? '/mnt/data';
   const path = letsencryptLogPath(dataDir);
-  const tail = await readLogTail(node, path, 16_384);
+  const tail = await readLogTail(node, path, TAIL_BYTES_FOR_DISPLAY);
   if (tail === null) {
     return { ok: false, message: `Could not read ${path}.`, refresh: false };
   }

--- a/src/lib/diagnose/probes/lanIpChanged.test.ts
+++ b/src/lib/diagnose/probes/lanIpChanged.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Phase 3b (#484): `checkLanIpChanged` is now a thin HealthStore reader.
+ * Detection logic moved into `CheckRunner.runLanIpDriftCheck` — these
+ * tests cover the reader-side contract only.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckResult } from '@/lib/health/types';
+
+const state = {
+  results: new Map<string, CheckResult>(),
+};
+
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    getLastResult: (id: string) => state.results.get(id) ?? null,
+  },
+}));
+
+import { checkLanIpChanged } from './lanIpChanged';
+
+beforeEach(() => {
+  state.results = new Map();
+});
+
+describe('checkLanIpChanged (reader)', () => {
+  it('returns info when HealthStore has no result yet', async () => {
+    const out = await checkLanIpChanged();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/has not run yet/);
+  });
+
+  it('decodes a happy-path warn payload', async () => {
+    const payload = {
+      status: 'warn',
+      detail: 'LAN IP is now 10.0.0.5, but install-time was 10.0.0.4.',
+      hint: 'A one-off change is fine.',
+    };
+    state.results.set('lan_ip_drift', {
+      check_id: 'lan_ip_drift',
+      timestamp: new Date().toISOString(),
+      status: 'ok',
+      message: `lan_ip_drift:${JSON.stringify(payload)}`,
+      latency: 100,
+    });
+    const out = await checkLanIpChanged();
+    expect(out.status).toBe('warn');
+    expect(out.detail).toBe(payload.detail);
+    expect(out.hint).toBe(payload.hint);
+  });
+
+  it('decodes an ok payload', async () => {
+    const payload = { status: 'ok', detail: 'LAN IP 10.0.0.5 matches the install-time value.' };
+    state.results.set('lan_ip_drift', {
+      check_id: 'lan_ip_drift',
+      timestamp: new Date().toISOString(),
+      status: 'ok',
+      message: `lan_ip_drift:${JSON.stringify(payload)}`,
+      latency: 100,
+    });
+    const out = await checkLanIpChanged();
+    expect(out.status).toBe('ok');
+    expect(out.detail).toBe(payload.detail);
+  });
+
+  it('surfaces transport-error plaintext as info', async () => {
+    state.results.set('lan_ip_drift', {
+      check_id: 'lan_ip_drift',
+      timestamp: new Date().toISOString(),
+      status: 'fail',
+      message: 'lan_ip_drift error: agent unreachable',
+      latency: 100,
+    });
+    const out = await checkLanIpChanged();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/Check failed to run.*agent unreachable/);
+  });
+});

--- a/src/lib/diagnose/probes/lanIpChanged.ts
+++ b/src/lib/diagnose/probes/lanIpChanged.ts
@@ -5,17 +5,17 @@
  * (suggests DHCP renewal-induced drift, signaling the operator
  * should set up a reservation).
  *
- * Detection is read-only — compares the stored `config.reverseProxy.lanIp`
- * to the current `detectLanIp()` result. Doesn't auto-reconcile; that's
- * the boot-time path (separate concern in server.ts).
- *
- * Action `set_dhcp_reservation` is FritzBox-only via TR-064 — wired
- * up alongside the router-DNS probe in D19-PR6 (#263). For now, the
- * probe registers no actions — surfacing the warning is enough.
+ * Phase 3b of the diagnose / health-check rework (#484): this probe
+ * is now a **thin reader** over the health-check subsystem. Detection
+ * runs on a `lan_ip_drift`-type singleton check (5 min interval, see
+ * `health/init.ts`) and the result is persisted to `HealthStore`.
+ * Result persistence, scheduling, and the Phase 3a SSE broadcast all
+ * live there — this file just reads the latest result back into the
+ * diagnose narrative.
  */
 
-import { getConfig } from '@/lib/config';
-import { detectLanIp, recentChanges } from '@/lib/lanIp';
+import { HealthStore } from '@/lib/health/store';
+import { LAN_IP_DRIFT_MESSAGE_PREFIX } from '@/lib/health/runner';
 
 export interface LanIpProbeResult {
   status: 'ok' | 'warn' | 'info';
@@ -23,51 +23,39 @@ export interface LanIpProbeResult {
   hint?: string;
 }
 
-const RECENT_DAYS = 30;
-const RECENT_THRESHOLD = 1; // > 1 change in 30 days → warn
+const CHECK_ID = 'lan_ip_drift';
 
-export async function checkLanIpChanged(node: string): Promise<LanIpProbeResult> {
-  const config = await getConfig();
-  const stored = config.reverseProxy?.lanIp;
-  const current = await detectLanIp(node);
-
-  if (!current) {
+export async function checkLanIpChanged(): Promise<LanIpProbeResult> {
+  const result = HealthStore.getLastResult(CHECK_ID);
+  if (!result) {
     return {
       status: 'info',
-      detail: 'Could not detect ServiceBay\'s LAN IP — `ip route get` returned no result.',
+      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
     };
   }
-
-  if (!stored) {
-    return {
-      status: 'info',
-      detail: `LAN IP is ${current}. No install-time value recorded yet.`,
-    };
-  }
-
-  const history = config.reverseProxy?.lanIpHistory ?? [];
-  const changes = recentChanges(history, RECENT_DAYS);
-
-  if (current === stored) {
-    if (changes > RECENT_THRESHOLD) {
-      return {
-        status: 'warn',
-        detail: `LAN IP is currently ${current}, matching install. But it has changed ${changes} times in the last ${RECENT_DAYS} days.`,
-        hint: 'Set up a DHCP reservation in your router so the IP doesn\'t drift — this avoids brief outages while AdGuard rewrites + NPM forward-hosts catch up.',
-      };
+  if (result.message && result.message.startsWith(LAN_IP_DRIFT_MESSAGE_PREFIX)) {
+    try {
+      const json = result.message.slice(LAN_IP_DRIFT_MESSAGE_PREFIX.length);
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed.status === 'string' && typeof parsed.detail === 'string') {
+        return {
+          status: parsed.status === 'ok' || parsed.status === 'warn' ? parsed.status : 'info',
+          detail: parsed.detail,
+          hint: typeof parsed.hint === 'string' ? parsed.hint : undefined,
+        };
+      }
+    } catch {
+      // fall through to fail-style rendering
     }
+  }
+  if (result.status === 'fail') {
     return {
-      status: 'ok',
-      detail: `LAN IP ${current} matches the install-time value.`,
+      status: 'info',
+      detail: `Check failed to run: ${result.message || 'unknown error'}`,
     };
   }
-
-  // Mismatch — fired before the boot-time reconcile auto-updates.
   return {
-    status: 'warn',
-    detail: `LAN IP is now ${current}, but install-time was ${stored}. AdGuard rewrites + NPM forward-hosts will be reconciled on next boot.`,
-    hint: changes > RECENT_THRESHOLD
-      ? `This is the ${changes + 1}-th change in the last ${RECENT_DAYS} days — set a DHCP reservation in your router to stop the drift.`
-      : 'A one-off change is fine; ServiceBay reconciles automatically on the next boot.',
+    status: 'info',
+    detail: 'LAN IP drift check produced no actionable signal.',
   };
 }

--- a/src/lib/diagnose/probes/npmDataStale.test.ts
+++ b/src/lib/diagnose/probes/npmDataStale.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Phase 3b (#484): `checkNpmDataStale` is now a thin HealthStore reader.
+ * Detection logic moved into `CheckRunner.runNpmAuthCheck` — these
+ * tests cover the reader-side contract only.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckResult } from '@/lib/health/types';
+
+const state = {
+  results: new Map<string, CheckResult>(),
+};
+
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    getLastResult: (id: string) => state.results.get(id) ?? null,
+  },
+}));
+
+import { checkNpmDataStale } from './npmDataStale';
+
+beforeEach(() => {
+  state.results = new Map();
+});
+
+describe('checkNpmDataStale (reader)', () => {
+  it('returns info when HealthStore has no result yet', async () => {
+    const out = await checkNpmDataStale();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/has not run yet/);
+  });
+
+  it('decodes a stale-credentials fail payload', async () => {
+    const payload = {
+      status: 'fail',
+      detail: 'Nginx Proxy Manager is rejecting the stored admin credentials.',
+      hint: 'If you know the password NPM is actually using, click "Use existing password".',
+    };
+    state.results.set('npm_auth', {
+      check_id: 'npm_auth',
+      timestamp: new Date().toISOString(),
+      status: 'fail',
+      message: `npm_auth:${JSON.stringify(payload)}`,
+      latency: 100,
+    });
+    const out = await checkNpmDataStale();
+    expect(out.status).toBe('fail');
+    expect(out.detail).toBe(payload.detail);
+    expect(out.hint).toBe(payload.hint);
+  });
+
+  it('decodes an ok payload', async () => {
+    const payload = { status: 'ok', detail: 'NPM accepts the stored admin credentials.' };
+    state.results.set('npm_auth', {
+      check_id: 'npm_auth',
+      timestamp: new Date().toISOString(),
+      status: 'ok',
+      message: `npm_auth:${JSON.stringify(payload)}`,
+      latency: 100,
+    });
+    const out = await checkNpmDataStale();
+    expect(out.status).toBe('ok');
+    expect(out.detail).toBe(payload.detail);
+  });
+
+  it('surfaces transport-error plaintext as info', async () => {
+    state.results.set('npm_auth', {
+      check_id: 'npm_auth',
+      timestamp: new Date().toISOString(),
+      status: 'fail',
+      message: 'npm_auth error: ServiceManager exploded',
+      latency: 100,
+    });
+    const out = await checkNpmDataStale();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/Check failed to run.*ServiceManager exploded/);
+  });
+});

--- a/src/lib/diagnose/probes/npmDataStale.ts
+++ b/src/lib/diagnose/probes/npmDataStale.ts
@@ -5,29 +5,31 @@
  * SQLite database that no longer matches the wizard's expected one
  * (the volume survived a reinstall / restore).
  *
- * Without this probe the symptom is silent: proxy-host creation 401s
- * once at install time, the wizard prompts for credentials, and from
- * then on every install/redeploy hits the same wall. With it the
- * operator sees a single fix-button on the diagnose page.
- *
- * Detection: try POST /api/tokens against the local NPM admin URL with
- * the stored credentials. 401 → stale. 5xx / connection failure → NPM
- * is just down (don't surface this probe; the existing pods/units
- * probes already cover that).
+ * Phase 3b of the diagnose / health-check rework (#484): this probe
+ * is now a **thin reader** over the health-check subsystem. The
+ * actual detection runs on an `npm_auth`-type singleton check (15 min
+ * interval, see `health/init.ts`) and the result is persisted to
+ * `HealthStore`. Result persistence, scheduling, and the Phase 3a SSE
+ * broadcast all live there — this file just reads the latest result
+ * back into the diagnose narrative.
  *
  * Action `reset_volume` (destructive) wipes NPM's data dir and restarts
  * the service so it re-seeds with the wizard's INITIAL_ADMIN_*
  * credentials. Action `use_existing` (non-destructive) accepts the
  * password the operator knows works and persists it to config — no
  * data loss, the right path for "I already changed the password
- * outside the wizard."
+ * outside the wizard."  Both action handlers stay here because they
+ * mutate operator-facing state (config / NPM volume) at the moment of
+ * the click — only the detection moved into the health subsystem.
  */
 
 import { agentManager } from '@/lib/agent/manager';
-import { getConfig, updateConfig } from '@/lib/config';
+import { updateConfig } from '@/lib/config';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
+import { HealthStore } from '@/lib/health/store';
+import { NPM_AUTH_MESSAGE_PREFIX } from '@/lib/health/runner';
 
 export interface NpmDataStaleResult {
   /** undefined when not applicable (no nginx-web, or NPM not reachable). */
@@ -36,9 +38,57 @@ export interface NpmDataStaleResult {
   hint?: string;
 }
 
-/** Locate the running nginx-web service on `node` and return its admin URL.
- *  Returns null when nginx-web isn't installed or its admin port can't
- *  be derived from the service manifest. */
+const PROBE_ID = 'npm_data_stale';
+const CHECK_ID = 'npm_auth';
+
+/** Reader: surfaces the latest persisted `npm_auth` health-check
+ *  result. Diagnose route used to call this with `(nodeName)` — the
+ *  arg is now unused because the singleton check captures the node
+ *  via its `nodeName` field. The signature drops the arg entirely so
+ *  the call site is a plain `await checkNpmDataStale()`. */
+export async function checkNpmDataStale(): Promise<NpmDataStaleResult> {
+  const result = HealthStore.getLastResult(CHECK_ID);
+  if (!result) {
+    return {
+      status: 'info',
+      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+    };
+  }
+  if (result.message && result.message.startsWith(NPM_AUTH_MESSAGE_PREFIX)) {
+    try {
+      const json = result.message.slice(NPM_AUTH_MESSAGE_PREFIX.length);
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed.status === 'string' && typeof parsed.detail === 'string') {
+        return {
+          status: parsed.status,
+          detail: parsed.detail,
+          hint: typeof parsed.hint === 'string' ? parsed.hint : undefined,
+        };
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (result.status === 'fail') {
+    return {
+      status: 'info',
+      detail: `Check failed to run: ${result.message || 'unknown error'}`,
+    };
+  }
+  return {
+    status: 'info',
+    detail: 'NPM auth check produced no actionable signal.',
+  };
+}
+
+// ─── Action handlers (kept in the probe file) ───────────────────────────
+//
+// Local copy of `findNpmAdminUrl` so the click-time action paths don't
+// depend on health/runner internals.  Mirrors the helper in
+// `src/lib/health/probes/npmAdmin.ts` — kept duplicated because the
+// action handlers run with a different lifecycle (one-shot, operator
+// click) and we don't want to entangle them with the runner's import
+// graph.
 async function findNpmAdminUrl(node: string): Promise<string | null> {
   try {
     const services = await ServiceManager.listServices(node);
@@ -46,7 +96,6 @@ async function findNpmAdminUrl(node: string): Promise<string | null> {
       s => s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
     );
     if (!nginx?.active) return null;
-    // Admin port is the published host port that isn't 80 or 443.
     const ports = (nginx.ports ?? [])
       .map(p => parseInt(String(p.host ?? ''), 10))
       .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
@@ -56,62 +105,6 @@ async function findNpmAdminUrl(node: string): Promise<string | null> {
     return null;
   }
 }
-
-/** Run the detection. Returns a partial probe payload — diagnose route
- *  glues on the id/label/actions from the registry. */
-export async function checkNpmDataStale(node: string): Promise<NpmDataStaleResult> {
-  const config = await getConfig();
-  const npm = config.reverseProxy?.npm;
-  if (!npm?.email || !npm?.password) {
-    // No stored creds — nothing to check. Skip with info status.
-    return {
-      status: 'info',
-      detail: 'No NPM admin credentials stored — skipping staleness check.',
-    };
-  }
-  const adminUrl = await findNpmAdminUrl(node);
-  if (!adminUrl) {
-    return {
-      status: 'info',
-      detail: 'Nginx Proxy Manager not deployed on this node — nothing to check.',
-    };
-  }
-
-  // Authenticate with stored creds. 401 → stale; everything else (200,
-  // 5xx, network error) we treat as "not stale-with-confidence" and
-  // surface info-only — the existing pods/units probes already handle
-  // "NPM is down" cases.
-  try {
-    const res = await fetch(`${adminUrl}/api/tokens`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ identity: npm.email, secret: npm.password }),
-      signal: AbortSignal.timeout(4000),
-    });
-    if (res.ok) {
-      return { status: 'ok', detail: 'NPM accepts the stored admin credentials.' };
-    }
-    if (res.status === 401) {
-      return {
-        status: 'fail',
-        detail:
-          'Nginx Proxy Manager is rejecting the stored admin credentials. This usually means a previous install left an admin password in the NPM database that no longer matches.',
-        hint: 'If you know the password NPM is actually using, click "Use existing password" below to save it (no data loss). Otherwise "Reset NPM data" wipes the database and re-seeds with the wizard credentials.',
-      };
-    }
-    return {
-      status: 'info',
-      detail: `NPM auth probe returned HTTP ${res.status} — assuming transient.`,
-    };
-  } catch (e) {
-    return {
-      status: 'info',
-      detail: `Could not reach NPM at ${adminUrl}: ${e instanceof Error ? e.message : String(e)}`,
-    };
-  }
-}
-
-const PROBE_ID = 'npm_data_stale';
 
 /** Action: stop nginx-web, wipe its data volume, restart it. NPM's
  *  next start re-seeds the admin user from the

--- a/src/lib/health/init.ts
+++ b/src/lib/health/init.ts
@@ -88,6 +88,42 @@ export async function initializeDefaultChecks() {
     console.error('Failed to list managed services for auto-discovery', e);
   }
 
+  // Phase 3b singleton checks (#484): four former diagnose probes
+  // now run on the health-check scheduler. Each uses a deterministic
+  // id so subsequent boots find them idempotently — the diagnose-side
+  // readers look up the result by this exact id, so do NOT use
+  // crypto.randomUUID here.
+  //
+  //   - lan_ip_drift           — 5 min;   compares config.reverseProxy.lanIp
+  //                              to the live `ip route get` result.
+  //   - npm_auth               — 15 min;  POST /api/tokens against NPM
+  //                              with stored creds; 401 → stale.
+  //   - cert_expiry            — 1 h;     lists letsencrypt certs and
+  //                              flags ≤14d / expired ones.
+  //   - cert_request_failure   — 10 min;  tails NPM letsencrypt.log
+  //                              and surfaces recent ACME failures.
+  const phase3bChecks: Array<{ id: string; name: string; interval: number }> = [
+    { id: 'lan_ip_drift', name: 'LAN IP drift', interval: 300 },
+    { id: 'npm_auth', name: 'NPM admin auth', interval: 900 },
+    { id: 'cert_expiry', name: 'TLS certificate expiry', interval: 3600 },
+    { id: 'cert_request_failure', name: 'Let\'s Encrypt cert requests', interval: 600 },
+  ];
+  for (const cfg of phase3bChecks) {
+    if (!exists(cfg.id, 'Local')) {
+      logger.info('Health', `Adding ${cfg.id} singleton check`);
+      HealthStore.saveCheck({
+        id: cfg.id,
+        name: cfg.name,
+        type: cfg.id as 'lan_ip_drift' | 'npm_auth' | 'cert_expiry' | 'cert_request_failure',
+        target: 'Local',
+        interval: cfg.interval,
+        enabled: true,
+        created_at: new Date().toISOString(),
+        nodeName: 'Local',
+      });
+    }
+  }
+
   // 4. Agent Health Checks
   try {
       const nodes = await listNodes();

--- a/src/lib/health/probes/letsencryptLogParser.ts
+++ b/src/lib/health/probes/letsencryptLogParser.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure parser for the tail of NPM's `letsencrypt.log` — extracts
+ * recent ACME failures (Domain / Type / Detail blocks, or the legacy
+ * inline "Failed authorization procedure" format) plus a rate-limit
+ * flag and the newest timestamp anywhere in the tail.
+ *
+ * Hoisted out of the diagnose-side probe in Phase 3b (#484) so the
+ * health-check runner can call it without creating a circular import
+ * (the diagnose probe is now a reader that imports the runner's
+ * prefix constants). Stays a separate file from `runner.ts` because
+ * the existing `certRequestFailure.test.ts` exercises this parser
+ * directly — keeping the export surface stable avoids churning the
+ * test.
+ */
+
+export interface ParsedFailure {
+  domain: string;
+  type: string;
+  detail: string;
+}
+
+export interface ParsedFailureBlock {
+  failures: ParsedFailure[];
+  rateLimited: boolean;
+  /** Newest timestamp anywhere in the tail (epoch ms, UTC-interpreted). */
+  ts?: number;
+}
+
+const STRUCTURED_FAILURE_RE = /Domain:\s*(\S+)\s*\n\s*Type:\s*(\S+)\s*\n\s*Detail:\s*([^\n]+)/g;
+// Legacy/inline format used by older certbot releases.
+const INLINE_FAILURE_RE = /Failed authorization procedure\.\s+(\S+)\s+\(([^)]+)\):\s+urn:ietf:params:acme:error:\S+\s*::\s*([^\n]+)/g;
+const RATE_LIMIT_RE = /urn:ietf:params:acme:error:rateLimited/i;
+const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/gm;
+
+export function parseLetsencryptTail(tail: string): ParsedFailureBlock {
+  // Scope to the slice starting at the most recent "Some challenges
+  // have failed" line so older failure blocks higher up don't leak in.
+  // Failures in certbot output come AFTER the marker line, so we
+  // start at the beginning of that line. Fall back to the full tail
+  // when the marker isn't present — older log lines sometimes just
+  // have "Challenge failed for domain X" without it.
+  const lastMarker = tail.lastIndexOf('Some challenges have failed');
+  const sliceStart = lastMarker >= 0
+    ? Math.max(0, tail.lastIndexOf('\n', lastMarker) + 1)
+    : 0;
+  const slice = tail.slice(sliceStart);
+
+  const failures: ParsedFailure[] = [];
+  STRUCTURED_FAILURE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = STRUCTURED_FAILURE_RE.exec(slice)) !== null) {
+    failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
+  }
+  if (failures.length === 0) {
+    INLINE_FAILURE_RE.lastIndex = 0;
+    while ((m = INLINE_FAILURE_RE.exec(slice)) !== null) {
+      failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
+    }
+  }
+
+  const rateLimited = RATE_LIMIT_RE.test(slice);
+
+  let ts: number | undefined;
+  TIMESTAMP_RE.lastIndex = 0;
+  const tsMatches = slice.match(TIMESTAMP_RE);
+  if (tsMatches && tsMatches.length > 0) {
+    const last = tsMatches[tsMatches.length - 1];
+    const parsed = Date.parse(`${last.replace(' ', 'T')}Z`);
+    if (Number.isFinite(parsed)) ts = parsed;
+  }
+
+  return { failures, rateLimited, ts };
+}

--- a/src/lib/health/probes/npmAdmin.ts
+++ b/src/lib/health/probes/npmAdmin.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared NPM admin helpers used by Phase 3b runner methods
+ * (`runNpmAuthCheck`, `runCertExpiryCheck`, `runCertRequestFailureCheck`).
+ *
+ * Hoisted out of `runner.ts` because three runner methods need them and
+ * duplicating ~40 lines across three case blocks would dwarf the
+ * differences. The previous Phase 3 design had each diagnose probe own
+ * its own copy (see the stale note in `certRequestFailure.ts` header
+ * about "house style: duplicated"); migrating into the health subsystem
+ * makes a single shared home cheaper to maintain.
+ *
+ *   - `findNpmAdminUrl(node)` — locates the running nginx-web service
+ *     and returns its `http://localhost:<adminPort>` URL, or null when
+ *     nginx isn't installed/active.
+ *   - `getNpmToken(adminUrl)` — tries stored creds first, then the
+ *     wizard's default (`admin@example.com`/`changeme`); returns null
+ *     if all candidates 401.
+ */
+import { getConfig } from '../../config';
+import { ServiceManager } from '../../services/ServiceManager';
+
+/** Locate the running nginx-web service on `node` and return its admin URL.
+ *  Returns null when nginx-web isn't installed or its admin port can't
+ *  be derived from the service manifest. */
+export async function findNpmAdminUrl(node: string): Promise<string | null> {
+  try {
+    const services = await ServiceManager.listServices(node);
+    const nginx = services.find(
+      s => s.name === 'nginx' || s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
+    );
+    if (!nginx?.active) return null;
+    const ports = (nginx.ports ?? [])
+      .map(p => parseInt(String(p.host ?? ''), 10))
+      .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
+    return `http://localhost:${ports[0] ?? 81}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Try stored NPM admin creds, then the wizard defaults. Returns null
+ *  when no candidate authenticates (network error or every credential
+ *  came back 401). */
+export async function getNpmToken(adminUrl: string): Promise<string | null> {
+  const config = await getConfig();
+  const candidates: { identity: string; secret: string }[] = [];
+  const stored = config.reverseProxy?.npm;
+  if (stored?.email && stored?.password) {
+    candidates.push({ identity: stored.email, secret: stored.password });
+  }
+  candidates.push({ identity: 'admin@example.com', secret: 'changeme' });
+  for (const cred of candidates) {
+    try {
+      const res = await fetch(`${adminUrl}/api/tokens`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cred),
+        signal: AbortSignal.timeout(4000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (typeof data.token === 'string') return data.token;
+      }
+    } catch { /* try next */ }
+  }
+  return null;
+}

--- a/src/lib/health/runner.ts
+++ b/src/lib/health/runner.ts
@@ -8,6 +8,10 @@ import { getConfig } from '../config';
 import { assertHttpTargetAllowed } from './ssrfGuard';
 import { ContainerId, ServiceName, HostString } from '../api/schemas';
 import { runLetsdebugForDomain } from '../letsdebug/client';
+import { detectLanIp, recentChanges } from '../lanIp';
+import { findNpmAdminUrl, getNpmToken } from './probes/npmAdmin';
+import { parseLetsencryptTail } from './probes/letsencryptLogParser';
+import { logger } from '../logger';
 
 /**
  * Encoded payload for letsdebug-type results so the diagnose probe
@@ -17,6 +21,20 @@ import { runLetsdebugForDomain } from '../letsdebug/client';
  * without parsing every message.
  */
 export const LETSDEBUG_MESSAGE_PREFIX = 'letsdebug:';
+
+/**
+ * Phase 3b (#484) — message-prefix discriminators for the four
+ * diagnose probes lifted into the health-check subsystem. Each runner
+ * encodes its probe-shaped payload as JSON behind the matching prefix
+ * so the thin diagnose readers can `JSON.parse` it back into the
+ * exact `{ status, detail, hint, items? }` row they used to compute
+ * themselves. Plaintext messages (no prefix) mean a transport error
+ * and are surfaced as `info` on the diagnose side.
+ */
+export const LAN_IP_DRIFT_MESSAGE_PREFIX = 'lan_ip_drift:';
+export const NPM_AUTH_MESSAGE_PREFIX = 'npm_auth:';
+export const CERT_EXPIRY_MESSAGE_PREFIX = 'cert_expiry:';
+export const CERT_REQUEST_FAILURE_MESSAGE_PREFIX = 'cert_request_failure:';
 
 export class CheckRunner {
   static async run(check: CheckConfig): Promise<CheckResult> {
@@ -89,6 +107,30 @@ export class CheckRunner {
           // encoded in the message and the diagnose probe surfaces
           // them as amber rows.
           const r = await this.runLetsdebugCheck(check);
+          message = r.message;
+          status = r.status;
+          break;
+        }
+        case 'lan_ip_drift': {
+          const r = await this.runLanIpDriftCheck(check);
+          message = r.message;
+          status = r.status;
+          break;
+        }
+        case 'npm_auth': {
+          const r = await this.runNpmAuthCheck(check);
+          message = r.message;
+          status = r.status;
+          break;
+        }
+        case 'cert_expiry': {
+          const r = await this.runCertExpiryCheck(check);
+          message = r.message;
+          status = r.status;
+          break;
+        }
+        case 'cert_request_failure': {
+          const r = await this.runCertRequestFailureCheck(check);
           message = r.message;
           status = r.status;
           break;
@@ -271,6 +313,368 @@ export class CheckRunner {
       status: hasFatal ? 'fail' : 'ok',
       message: `${LETSDEBUG_MESSAGE_PREFIX}${payload}`,
     };
+  }
+
+  /**
+   * Phase 3b runner methods — each lifts a former diagnose probe into
+   * a periodic health check.  Convention:
+   *
+   *   - On a successful evaluation we encode the probe's
+   *     `{ status, detail, hint?, items? }` JSON behind the
+   *     check-type prefix and report `CheckResult.status='ok'` for
+   *     payload statuses 'ok' | 'warn' | 'info', and 'fail' for the
+   *     payload-level 'fail'.  This keeps the health page green on
+   *     yellow/info conditions — the same convention letsdebug uses —
+   *     while still broadcasting on every tick so the SSE
+   *     auto-refresh wired up in Phase 3a picks up warning changes
+   *     too.
+   *   - Transport / unexpected errors fall through to a plaintext
+   *     `fail` message (no prefix); the diagnose reader displays them
+   *     as an `info` row with "Check failed to run: …".
+   */
+
+  /**
+   * `lan_ip_drift` — compares ServiceBay's currently-detected LAN IP
+   * to the install-time value captured in
+   * `config.reverseProxy.lanIp`. Mirrors the former
+   * `checkLanIpChanged` probe.
+   */
+  private static async runLanIpDriftCheck(
+    check: CheckConfig,
+  ): Promise<{ status: 'ok' | 'fail'; message: string }> {
+    const RECENT_DAYS = 30;
+    const RECENT_THRESHOLD = 1;
+    try {
+      const config = await getConfig();
+      const stored = config.reverseProxy?.lanIp;
+      const node = check.nodeName ?? 'Local';
+      const current = await detectLanIp(node);
+
+      let payload: { status: 'ok' | 'warn' | 'info'; detail: string; hint?: string };
+      if (!current) {
+        payload = {
+          status: 'info',
+          detail: 'Could not detect ServiceBay\'s LAN IP — `ip route get` returned no result.',
+        };
+      } else if (!stored) {
+        payload = {
+          status: 'info',
+          detail: `LAN IP is ${current}. No install-time value recorded yet.`,
+        };
+      } else {
+        const history = config.reverseProxy?.lanIpHistory ?? [];
+        const changes = recentChanges(history, RECENT_DAYS);
+        if (current === stored) {
+          if (changes > RECENT_THRESHOLD) {
+            payload = {
+              status: 'warn',
+              detail: `LAN IP is currently ${current}, matching install. But it has changed ${changes} times in the last ${RECENT_DAYS} days.`,
+              hint: 'Set up a DHCP reservation in your router so the IP doesn\'t drift — this avoids brief outages while AdGuard rewrites + NPM forward-hosts catch up.',
+            };
+          } else {
+            payload = {
+              status: 'ok',
+              detail: `LAN IP ${current} matches the install-time value.`,
+            };
+          }
+        } else {
+          payload = {
+            status: 'warn',
+            detail: `LAN IP is now ${current}, but install-time was ${stored}. AdGuard rewrites + NPM forward-hosts will be reconciled on next boot.`,
+            hint:
+              changes > RECENT_THRESHOLD
+                ? `This is the ${changes + 1}-th change in the last ${RECENT_DAYS} days — set a DHCP reservation in your router to stop the drift.`
+                : 'A one-off change is fine; ServiceBay reconciles automatically on the next boot.',
+          };
+        }
+      }
+      return {
+        status: 'ok',
+        message: `${LAN_IP_DRIFT_MESSAGE_PREFIX}${JSON.stringify(payload)}`,
+      };
+    } catch (e) {
+      return {
+        status: 'fail',
+        message: `lan_ip_drift error: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  }
+
+  /**
+   * `npm_auth` — verifies that the stored NPM admin credentials still
+   * work against the locally-running NPM instance. Mirrors the former
+   * `checkNpmDataStale` probe; 401 → stale (payload `fail`),
+   * unreachable / 5xx → info, 2xx → ok.
+   */
+  private static async runNpmAuthCheck(
+    check: CheckConfig,
+  ): Promise<{ status: 'ok' | 'fail'; message: string }> {
+    const node = check.nodeName ?? 'Local';
+    try {
+      const config = await getConfig();
+      const npm = config.reverseProxy?.npm;
+      const encode = (payload: { status: 'ok' | 'warn' | 'fail' | 'info'; detail: string; hint?: string }) =>
+        ({ status: payload.status === 'fail' ? ('fail' as const) : ('ok' as const), message: `${NPM_AUTH_MESSAGE_PREFIX}${JSON.stringify(payload)}` });
+
+      if (!npm?.email || !npm?.password) {
+        return encode({ status: 'info', detail: 'No NPM admin credentials stored — skipping staleness check.' });
+      }
+      const adminUrl = await findNpmAdminUrl(node);
+      if (!adminUrl) {
+        return encode({ status: 'info', detail: 'Nginx Proxy Manager not deployed on this node — nothing to check.' });
+      }
+      try {
+        const res = await fetch(`${adminUrl}/api/tokens`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ identity: npm.email, secret: npm.password }),
+          signal: AbortSignal.timeout(4000),
+        });
+        if (res.ok) {
+          return encode({ status: 'ok', detail: 'NPM accepts the stored admin credentials.' });
+        }
+        if (res.status === 401) {
+          return encode({
+            status: 'fail',
+            detail:
+              'Nginx Proxy Manager is rejecting the stored admin credentials. This usually means a previous install left an admin password in the NPM database that no longer matches.',
+            hint: 'If you know the password NPM is actually using, click "Use existing password" below to save it (no data loss). Otherwise "Reset NPM data" wipes the database and re-seeds with the wizard credentials.',
+          });
+        }
+        return encode({ status: 'info', detail: `NPM auth probe returned HTTP ${res.status} — assuming transient.` });
+      } catch (e) {
+        return encode({
+          status: 'info',
+          detail: `Could not reach NPM at ${adminUrl}: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+    } catch (e) {
+      return {
+        status: 'fail',
+        message: `npm_auth error: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  }
+
+  /**
+   * `cert_expiry` — lists NPM-managed Let's Encrypt certificates and
+   * flags those expiring within 14 days (warn) or already expired
+   * (fail). Items carry the numeric NPM cert id, which the diagnose
+   * row's `renew_cert` action uses to call NPM's renew endpoint.
+   */
+  private static async runCertExpiryCheck(
+    check: CheckConfig,
+  ): Promise<{ status: 'ok' | 'fail'; message: string }> {
+    const WARN_DAYS = 14;
+    const node = check.nodeName ?? 'Local';
+    interface NpmCert {
+      id: number;
+      provider?: string;
+      domain_names?: string[];
+      expires_on?: string;
+    }
+    interface CertItem {
+      id: string;
+      label: string;
+      detail: string;
+      status: 'warn' | 'fail';
+      actionIds: string[];
+    }
+    const encode = (payload: { status: 'ok' | 'warn' | 'fail' | 'info'; detail: string; hint?: string; items?: CertItem[] }) =>
+      ({ status: payload.status === 'fail' ? ('fail' as const) : ('ok' as const), message: `${CERT_EXPIRY_MESSAGE_PREFIX}${JSON.stringify(payload)}` });
+
+    try {
+      const adminUrl = await findNpmAdminUrl(node);
+      if (!adminUrl) {
+        return encode({ status: 'info', detail: 'Nginx Proxy Manager not deployed — no certificates to check.' });
+      }
+      const token = await getNpmToken(adminUrl);
+      if (!token) {
+        return encode({ status: 'info', detail: 'Could not authenticate with NPM — skipping certificate check.' });
+      }
+      let certs: NpmCert[];
+      try {
+        const res = await fetch(`${adminUrl}/api/nginx/certificates`, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(6000),
+        });
+        if (!res.ok) {
+          return encode({ status: 'info', detail: `NPM certificates API returned HTTP ${res.status}.` });
+        }
+        certs = (await res.json()) as NpmCert[];
+      } catch (e) {
+        return encode({ status: 'info', detail: `Could not list NPM certificates: ${e instanceof Error ? e.message : String(e)}` });
+      }
+
+      const leCerts = (certs ?? []).filter(c => c.provider === 'letsencrypt');
+      if (leCerts.length === 0) {
+        return encode({ status: 'info', detail: 'No Let\'s Encrypt certificates managed by NPM.' });
+      }
+      const now = Date.now();
+      const items: CertItem[] = [];
+      let expiringSoon = 0;
+      let expired = 0;
+      for (const c of leCerts) {
+        if (!c.expires_on) continue;
+        const exp = Date.parse(c.expires_on);
+        if (!Number.isFinite(exp)) continue;
+        const daysLeft = Math.floor((exp - now) / (1000 * 60 * 60 * 24));
+        const domains = (c.domain_names ?? []).join(', ') || `cert ${c.id}`;
+        if (daysLeft < 0) {
+          expired += 1;
+          items.push({
+            id: String(c.id),
+            label: domains,
+            detail: `EXPIRED ${-daysLeft} day${daysLeft === -1 ? '' : 's'} ago — services served via this cert show browser warnings.`,
+            status: 'fail',
+            actionIds: ['renew_cert'],
+          });
+        } else if (daysLeft <= WARN_DAYS) {
+          expiringSoon += 1;
+          items.push({
+            id: String(c.id),
+            label: domains,
+            detail: `Expires in ${daysLeft} day${daysLeft === 1 ? '' : 's'}.`,
+            status: 'warn',
+            actionIds: ['renew_cert'],
+          });
+        }
+      }
+      if (items.length === 0) {
+        return encode({
+          status: 'ok',
+          detail: `${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} managed; none expiring in ${WARN_DAYS} days.`,
+        });
+      }
+      const status: 'warn' | 'fail' = expired > 0 ? 'fail' : 'warn';
+      return encode({
+        status,
+        detail:
+          expired > 0
+            ? `${expired} expired + ${expiringSoon} expiring soon out of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'}.`
+            : `${expiringSoon} of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} expiring within ${WARN_DAYS} days.`,
+        hint:
+          'NPM auto-renews on a schedule; click "Renew now" if you want to force a refresh ahead of expiry. Failed renewals usually mean DNS or port-80 challenge changed since issuance.',
+        items,
+      });
+    } catch (e) {
+      return {
+        status: 'fail',
+        message: `cert_expiry error: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  }
+
+  /**
+   * `cert_request_failure` — tails NPM's `letsencrypt.log` and
+   * extracts recent ACME failures via the shared
+   * `parseLetsencryptTail` parser (kept in the diagnose-side module
+   * since it has its own dedicated test). Each failed domain becomes
+   * a payload item carrying the show_log_tail + retry_request
+   * action ids.
+   */
+  private static async runCertRequestFailureCheck(
+    check: CheckConfig,
+  ): Promise<{ status: 'ok' | 'fail'; message: string }> {
+    const FRESHNESS_HOURS = 24;
+    const TAIL_BYTES = 65_536;
+    const node = check.nodeName ?? 'Local';
+    interface CrfItem {
+      id: string;
+      label: string;
+      detail: string;
+      status: 'fail';
+      actionIds: string[];
+    }
+    const encode = (payload: { status: 'ok' | 'warn' | 'fail' | 'info'; detail: string; hint?: string; items?: CrfItem[] }) =>
+      ({ status: payload.status === 'fail' ? ('fail' as const) : ('ok' as const), message: `${CERT_REQUEST_FAILURE_MESSAGE_PREFIX}${JSON.stringify(payload)}` });
+
+    const safePath = (p: string) => /^\/[A-Za-z0-9_./-]+$/.test(p);
+
+    try {
+      const config = await getConfig();
+      const dataDir = config.templateSettings?.DATA_DIR ?? '/mnt/data';
+      const path = `${dataDir}/nginx-proxy-manager/data/logs/letsencrypt.log`;
+      if (!safePath(path)) {
+        logger.warn('health:cert_request_failure', `Refusing tail of unsafe path: ${path}`);
+        return encode({ status: 'info', detail: 'NPM data dir is not a safe POSIX absolute path — skipping log read.' });
+      }
+
+      // Read the log tail via the agent. Mirrors the former probe's
+      // `readLogTail`. Any error → info (treated identically to
+      // "log doesn't exist yet"); the existing pods / npm_auth probes
+      // already cover hard NPM-down cases.
+      let tail = '';
+      try {
+        const agent = await agentManager.ensureAgent(node);
+        const res = (await agent.sendCommand(
+          'exec',
+          { command: `tail -c ${TAIL_BYTES} ${path} 2>/dev/null` },
+          { timeoutMs: 5_000 },
+        )) as { code?: number; stdout?: string };
+        if (res.code !== 0) {
+          return encode({ status: 'info', detail: 'No letsencrypt.log found — NPM hasn\'t attempted any cert requests yet.' });
+        }
+        tail = res.stdout ?? '';
+      } catch (e) {
+        logger.warn(
+          'health:cert_request_failure',
+          `tail letsencrypt.log failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        return encode({ status: 'info', detail: 'Could not read letsencrypt.log — assuming no cert requests yet.' });
+      }
+      if (tail.length === 0) {
+        return encode({ status: 'info', detail: 'No letsencrypt.log found — NPM hasn\'t attempted any cert requests yet.' });
+      }
+
+      const parsed = parseLetsencryptTail(tail);
+      if (parsed.failures.length === 0 && !parsed.rateLimited) {
+        return encode({ status: 'ok', detail: 'No Let\'s Encrypt cert failures in the recent NPM log.' });
+      }
+      if (parsed.ts) {
+        const ageMs = Date.now() - parsed.ts;
+        if (ageMs > FRESHNESS_HOURS * 3_600_000) {
+          return encode({
+            status: 'ok',
+            detail: `Last cert failure was ${Math.round(ageMs / 3_600_000)}h ago (outside the ${FRESHNESS_HOURS}h freshness window). Treating as resolved.`,
+          });
+        }
+      }
+
+      const byDomain = new Map<string, { domain: string; type: string; detail: string }>();
+      for (const f of parsed.failures) byDomain.set(f.domain, f);
+      const items: CrfItem[] = [];
+      for (const [domain, f] of byDomain) {
+        const detail = f.detail.length > 140 ? `${f.detail.slice(0, 140)}…` : f.detail;
+        items.push({
+          id: domain,
+          label: domain,
+          detail: `ACME ${f.type} challenge failed: ${detail}`,
+          status: 'fail',
+          actionIds: ['show_log_tail', 'retry_request'],
+        });
+      }
+      if (parsed.rateLimited && items.length === 0) {
+        items.push({
+          id: 'rate-limited',
+          label: 'Let\'s Encrypt rate limit',
+          detail: 'Hit the ACME rate limit (5 failed validations / host / hour). Wait ~1h and fix the root cause before retrying.',
+          status: 'fail',
+          actionIds: ['show_log_tail'],
+        });
+      }
+      return encode({
+        status: 'fail',
+        detail: `${items.length} domain${items.length === 1 ? '' : 's'} with recent ACME failure${items.length === 1 ? '' : 's'} in NPM\'s letsencrypt.log.`,
+        hint: 'Most common cause is public port 80 not reachable from the internet. Run letsdebug.net for an external view of what the ACME server sees, then click Retry once the underlying cause is fixed.',
+        items,
+      });
+    } catch (e) {
+      return {
+        status: 'fail',
+        message: `cert_request_failure error: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
   }
 
   private static async runPingCheck(host: string, executor: Executor) {

--- a/src/lib/health/types.ts
+++ b/src/lib/health/types.ts
@@ -1,4 +1,23 @@
-export type CheckType = 'http' | 'ping' | 'script' | 'podman' | 'service' | 'systemd' | 'fritzbox' | 'node' | 'agent' | 'backup' | 'domain' | 'letsdebug';
+export type CheckType =
+  | 'http'
+  | 'ping'
+  | 'script'
+  | 'podman'
+  | 'service'
+  | 'systemd'
+  | 'fritzbox'
+  | 'node'
+  | 'agent'
+  | 'backup'
+  | 'domain'
+  | 'letsdebug'
+  // Phase 3b (#484): four diagnose probes lifted into the health-check
+  // subsystem. Each runs on its own schedule and persists results;
+  // their diagnose-side modules became thin HealthStore readers.
+  | 'lan_ip_drift'
+  | 'npm_auth'
+  | 'cert_expiry'
+  | 'cert_request_failure';
 
 export interface CheckConfig {
   id: string;


### PR DESCRIPTION
## Summary

Final slice of the diagnose / health-check rework. Closes #484.

Four diagnose probes (\`cert_expiry\`, \`cert_request_failure\`, \`lan_ip_changed_since_install\`, \`npm_data_stale\`) used to poll state on demand. Each now runs on the standard health-check schedule and persists its result; Phase 3a's SSE auto-refresh on the diagnose panel picks the broadcasts up live, so the dashboard updates without operator interaction.

| Probe | New check type | Interval |
| --- | --- | --- |
| \`cert_expiry\` | \`cert_expiry\` | 1 h |
| \`cert_request_failure\` | \`cert_request_failure\` | 10 min |
| \`lan_ip_changed_since_install\` | \`lan_ip_drift\` | 5 min |
| \`npm_data_stale\` | \`npm_auth\` | 15 min |

## Pattern

Same shape as Phase 2 (#483):

1. **Encode** — runner method JSON-encodes the structured probe payload behind a discriminating prefix in \`CheckResult.message\`, e.g. \`cert_expiry:{"status":"warn","items":[…]}\`. Payload \`fail\` → \`CheckResult.status='fail'\`; \`ok\`/\`warn\`/\`info\` → \`'ok'\` (so the health page only goes red on hard failures). Transport errors → \`fail\` with plaintext message (no prefix).
2. **Read** — each diagnose probe becomes a thin \`HealthStore.getLastResult()\` reader (~50 LoC) that decodes the payload and returns the existing probe shape. Action handlers stay registered in the probe files.
3. **Seed** — boot-time singleton creation in \`init.ts\` with deterministic IDs so the readers find them idempotently.

## New shared helpers

To break a would-be circular import (runner ↔ diagnose-probe), two pieces moved into \`src/lib/health/probes/\`:
- \`letsencryptLogParser.ts\` — the \`parseLetsencryptTail\` function (re-exported from the old path so existing tests keep working).
- \`npmAdmin.ts\` — \`findNpmAdminUrl\` + \`getNpmToken\`, the shared NPM access helpers used by cert_expiry, cert_request_failure, and npm_auth runners.

The action handlers keep their own local copies of those helpers — handlers run with a different lifecycle from runners and shouldn't pull the runner's import graph in at click time.

## Diff stats

- 14 files changed (10 modified, 4 new).
- +1100 / −410.

## Test plan

- [x] \`npx tsc --noEmit\` — 0 errors.
- [x] \`npx vitest run\` — 705 passed (14 new reader tests), 2 pre-existing skips.
- [x] \`npm run lint\` — 0 errors (9 pre-existing warnings, unrelated).
- [x] \`npm run build\` — succeeds.
- [ ] On the live install, open Settings → Health and confirm the 4 new singleton checks appear within seconds of boot.
- [ ] Trigger \`cert_expiry\` manually (Settings → Health → Run) and verify the diagnose page's "TLS certificates" row updates without re-clicking "Run self-test".

🤖 Generated with [Claude Code](https://claude.com/claude-code)