### PR TITLE
fix(health): accept deterministic check IDs in history+run routes (closes #498)

### DIFF
--- a/src/app/api/health/checks/[id]/history/route.ts
+++ b/src/app/api/health/checks/[id]/history/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
 import { HealthStore } from '@/lib/health/store';
-import { UuidString } from '@/lib/api/schemas';
+import { CheckIdString } from '@/lib/api/schemas';
 import { parseRouteParam } from '@/lib/api/validate';
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const parsed = await parseRouteParam(params, 'id', UuidString);
+  const parsed = await parseRouteParam(params, 'id', CheckIdString);
   if (!parsed.ok) return parsed.response;
   const results = HealthStore.getResults(parsed.value);
   return NextResponse.json(results);

--- a/src/app/api/health/checks/[id]/run/route.ts
+++ b/src/app/api/health/checks/[id]/run/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import { HealthStore } from '@/lib/health/store';
 import { CheckRunner } from '@/lib/health/runner';
-import { UuidString } from '@/lib/api/schemas';
+import { CheckIdString } from '@/lib/api/schemas';
 import { parseRouteParam } from '@/lib/api/validate';
 import { apiError } from '@/lib/api/errors';
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const parsed = await parseRouteParam(params, 'id', UuidString);
+  const parsed = await parseRouteParam(params, 'id', CheckIdString);
   if (!parsed.ok) return parsed.response;
   const id = parsed.value;
   const checks = HealthStore.getChecks();

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -41,6 +41,12 @@ export const BackupFileName = z.string()
   .refine(s => !s.startsWith('.'), 'leading dot not allowed')
   .refine(s => !s.includes('..'), 'parent traversal not allowed');
 
-// Generic UUID (v1–v5). HealthStore uses crypto.randomUUID().
-export const UuidString = z.string().uuid();
+// Health-check IDs. Auto-managed checks use deterministic, human-readable IDs
+// (`domain:<host>`, `letsdebug:<host>`, `lan_ip_drift`, …) while user-created
+// checks use UUIDs. Both shapes need to pass route validators. Constrained to
+// filename-safe chars + colon (POSIX accepts the latter; we never run on
+// Windows). Path separators stay rejected so traversal is impossible.
+export const CheckIdString = z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/, {
+  message: 'invalid check id',
+});
 

--- a/tests/backend/api_schemas.test.ts
+++ b/tests/backend/api_schemas.test.ts
@@ -6,6 +6,7 @@ import {
   HostString,
   HealthCheckTarget,
   BackupFileName,
+  CheckIdString,
 } from '../../src/lib/api/schemas';
 
 describe('ContainerId', () => {
@@ -73,6 +74,39 @@ describe('BackupFileName', () => {
   it('rejects path traversal and separators', () => {
     for (const bad of ['../etc/passwd', 'a/b', 'a\\b', '..', '.hidden']) {
       expect(BackupFileName.safeParse(bad).success, bad).toBe(false);
+    }
+  });
+});
+
+describe('CheckIdString', () => {
+  it('accepts UUID-shaped IDs from HealthStore.saveCheck', () => {
+    expect(CheckIdString.safeParse('11111111-2222-3333-4444-555555555555').success).toBe(true);
+  });
+  it('accepts deterministic auto-managed IDs', () => {
+    for (const good of [
+      'domain:files.dopp.cloud',
+      'letsdebug:vault.dopp.cloud',
+      'lan_ip_drift',
+      'npm_auth',
+      'cert_expiry',
+      'cert_request_failure',
+    ]) {
+      expect(CheckIdString.safeParse(good).success, good).toBe(true);
+    }
+  });
+  it('rejects path traversal and shell metacharacters', () => {
+    for (const bad of [
+      '../etc/passwd',
+      'a/b',
+      'a\\b',
+      'foo;rm',
+      '`whoami`',
+      '$(echo)',
+      'with space',
+      '',
+      'x'.repeat(129),
+    ]) {
+      expect(CheckIdString.safeParse(bad).success, bad).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## Summary

`/api/health/checks/[id]/{history,run}` validated `[id]` against strict
`UuidString` (`z.string().uuid()`), which rejected every deterministic ID
introduced after the validator was written:

- \`domain:<host>\` (NPM auto-sync)
- \`letsdebug:<host>\` (Phase 2, #488)
- \`lan_ip_drift\`, \`npm_auth\`, \`cert_expiry\`, \`cert_request_failure\` (Phase 3b, #492)

Symptom: per-row Run → \"unexpected error\" toast; History Drawer → \"No history
data available\" — even though the result files on disk were intact.

## Fix

Introduce \`CheckIdString\` (filename-safe chars + colon, max 128). Swap it
into both route validators. Drop the now-unused \`UuidString\` export.

- UUIDs still pass.
- Path traversal (\`/\`, \`\\\`) still rejected.
- Length cap stays.

## Test plan
- [x] \`tests/backend/api_schemas.test.ts\` covers UUID, all four singleton IDs, \`domain:\`, \`letsdebug:\`, plus traversal / shell metacharacter / length / empty rejection.
- [x] \`npx tsc --noEmit\` clean.
- [ ] On a live install, click \"Run\" on a \`letsdebug:*\` row and confirm the toast renders with the actual result, not \"unexpected error\".
- [ ] Open the History Drawer for \`lan_ip_drift\` and confirm the timeline renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)