### PR TITLE
fix(health): treat letsdebug `Complete + result:null` as a transport error (closes #499)

### DIFF
--- a/src/lib/letsdebug/client.test.ts
+++ b/src/lib/letsdebug/client.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runLetsdebugForDomain } from './client';
+
+const SUBMIT_URL = 'https://letsdebug.net/';
+
+function mockFetchSequence(responses: Array<{ status: number; body: unknown; bodyText?: string }>) {
+  let i = 0;
+  return vi.fn(async () => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    const text = r.bodyText ?? JSON.stringify(r.body);
+    return new Response(text, { status: r.status });
+  });
+}
+
+describe('runLetsdebugForDomain', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns { problems: [] } when letsdebug completes with an empty result object', async () => {
+    vi.stubGlobal('fetch', mockFetchSequence([
+      { status: 200, body: { id: 42 } },
+      { status: 200, body: { status: 'Complete', result: { problems: [] } } },
+    ]));
+    const r = await runLetsdebugForDomain('ok.example.com');
+    expect(r.problems).toEqual([]);
+    expect(r.submissionUrl).toBe(`${SUBMIT_URL}ok.example.com/42`);
+  });
+
+  it('returns the problems list when letsdebug completes with findings', async () => {
+    vi.stubGlobal('fetch', mockFetchSequence([
+      { status: 200, body: { id: 7 } },
+      { status: 200, body: {
+        status: 'Complete',
+        result: { problems: [{ name: 'X', explanation: 'broken', severity: 'fatal' }] },
+      } },
+    ]));
+    const r = await runLetsdebugForDomain('fatal.example.com');
+    expect(r.problems).toHaveLength(1);
+    expect(r.problems[0].severity).toBe('fatal');
+  });
+
+  it('throws on `Complete` with `result: null` so it cannot be mistaken for "no problems"', async () => {
+    // Real-world shape when letsdebug aborts the probe mid-flight
+    // (rate limit, backend hiccup). Without the guard, our parser
+    // silently coerced this to `problems: []` → status:'ok', leading
+    // to suspiciously fast OK rows on the health page.
+    vi.stubGlobal('fetch', mockFetchSequence([
+      { status: 200, body: { id: 99 } },
+      { status: 200, body: { status: 'Complete', result: null } },
+    ]));
+    await expect(runLetsdebugForDomain('null.example.com')).rejects.toThrow(/result payload/);
+  });
+
+  it('throws on `Complete` with no `result` field at all', async () => {
+    vi.stubGlobal('fetch', mockFetchSequence([
+      { status: 200, body: { id: 100 } },
+      { status: 200, body: { status: 'Complete' } },
+    ]));
+    await expect(runLetsdebugForDomain('missing.example.com')).rejects.toThrow(/result payload/);
+  });
+
+  it('throws on submission HTTP error', async () => {
+    vi.stubGlobal('fetch', mockFetchSequence([
+      { status: 429, body: { error: 'rate limited' } },
+    ]));
+    await expect(runLetsdebugForDomain('ratelimited.example.com')).rejects.toThrow(/submission HTTP 429/);
+  });
+
+  it('handles PascalCase keys (letsdebug Go default)', async () => {
+    vi.stubGlobal('fetch', mockFetchSequence([
+      { status: 200, body: { ID: 5 } },
+      { status: 200, body: {
+        Status: 'Complete',
+        Result: { Problems: [{ Name: 'A', Explanation: 'b', Severity: 'warning' }] },
+      } },
+    ]));
+    const r = await runLetsdebugForDomain('pascal.example.com');
+    expect(r.problems).toHaveLength(1);
+    expect(r.problems[0].severity).toBe('warning');
+  });
+});

--- a/src/lib/letsdebug/client.ts
+++ b/src/lib/letsdebug/client.ts
@@ -81,10 +81,19 @@ async function submit(domain: string): Promise<number> {
 interface NormalisedPoll {
   status: string;
   problems: LetsdebugProblem[];
+  // True iff the response had a non-null `result`/`Result` field.
+  // letsdebug occasionally returns `{status:'Complete', result:null}`
+  // when the backend short-circuits a test (rate-limit, server error
+  // mid-probe). Without distinguishing this from a legitimate
+  // empty-problems result, an unrun test silently looks "all green".
+  hasResult: boolean;
 }
 
 function normalisePoll(raw: Record<string, unknown>): NormalisedPoll {
   const status = pick<string>(raw, 'status', 'Status') ?? '';
+  const hasResult =
+    ('result' in raw && raw.result !== null && raw.result !== undefined) ||
+    ('Result' in raw && raw.Result !== null && raw.Result !== undefined);
   const result = pick<Record<string, unknown>>(raw, 'result', 'Result');
   const problems = (pick<LetsdebugProblem[]>(result, 'problems', 'Problems') ?? []).map(p => {
     const o = p as unknown as Record<string, unknown>;
@@ -94,7 +103,7 @@ function normalisePoll(raw: Record<string, unknown>): NormalisedPoll {
       severity: pick<string>(o, 'severity', 'Severity'),
     };
   });
-  return { status, problems };
+  return { status, problems, hasResult };
 }
 
 async function poll(domain: string, id: number): Promise<NormalisedPoll> {
@@ -108,7 +117,16 @@ async function poll(domain: string, id: number): Promise<NormalisedPoll> {
     }
     const raw = (await res.json()) as Record<string, unknown>;
     const data = normalisePoll(raw);
-    if (data.status === 'Complete') return data;
+    if (data.status === 'Complete') {
+      // Guard against the `Complete + result:null` shape — letsdebug
+      // returns this when it didn't actually run a probe (rate limit,
+      // backend error). Surface as a transport-style error so the
+      // runner records `status:'fail'` instead of "no problems".
+      if (!data.hasResult) {
+        throw new Error('letsdebug returned status=Complete with no result payload (test was not actually run — likely rate-limit or backend error)');
+      }
+      return data;
+    }
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
   }
   throw new Error(`letsdebug timed out after ${(MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s`);


### PR DESCRIPTION
## Summary

Builds on #498 (which unblocks the History Drawer for letsdebug rows). Tackles #499 bug 3 — the suspicious sub-second OK rows on \`External reachability\`.

**Root cause:** \`runLetsdebugForDomain\` accepted \`{ status: 'Complete', result: null }\` (or \`result\` missing entirely) as a valid completion. \`pick(raw, 'result', 'Result')\` returns \`undefined\` for both null and missing; \`?? []\` then coerces problems to an empty list; the runner stores \`status: 'ok'\`.

This response shape is what letsdebug returns when its backend short-circuits a probe (rate-limit, mid-test backend hiccup) — i.e. the test was *not* actually run. We were treating "I gave up" as "all clear", hiding genuine reachability problems.

## Fix

- Add \`hasResult\` to \`NormalisedPoll\` and throw from \`poll()\` when status='Complete' arrives with no result payload.
- The runner's existing transport-error catch then records \`status: 'fail'\` with a plaintext message, which the diagnose reader surfaces as an \`info\` row.
- New unit test file \`src/lib/letsdebug/client.test.ts\` covers: empty-problems success, findings success, null-result rejection, missing-result rejection, submission HTTP error, PascalCase parsing.

The runner itself was already correct — transport throws map to \`status: 'fail'\` with prefix-less message, fatal payloads to \`status: 'fail'\` with prefixed payload, warnings to \`status: 'ok'\` with prefixed payload. Existing \`tests/backend/health_runner.test.ts\` already covers all four cases. No runner changes needed.

## Test plan
- [x] \`vitest run src/lib/letsdebug/client.test.ts tests/backend/health_runner.test.ts\` — 16/16 pass.
- [x] \`tsc --noEmit\` clean.
- [ ] On a live install with #498 + this merged: open History Drawer for any letsdebug row and confirm sub-second runs (if any) land as \`fail\` with a plaintext \"result payload\" message, not \`ok\`.

## Notes

This PR can land in any order relative to #496 / #497, but only makes sense to verify in the UI **after** #498 is merged (otherwise the History Drawer stays empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)