### PR TITLE
fix(health): npm_auth probe self-heals + refresh_now on Phase 3b probes (closes #496)

### DIFF
--- a/src/lib/diagnose/probes/certExpiry.ts
+++ b/src/lib/diagnose/probes/certExpiry.ts
@@ -23,6 +23,7 @@ import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
 import { HealthStore } from '@/lib/health/store';
 import { CERT_EXPIRY_MESSAGE_PREFIX } from '@/lib/health/runner';
+import { registerRefreshNow } from './refreshHealthCheck';
 
 const PROBE_ID = 'cert_expiry';
 const CHECK_ID = 'cert_expiry';
@@ -178,3 +179,5 @@ registerProbeAction(
   },
   renewCert,
 );
+
+registerRefreshNow(PROBE_ID, CHECK_ID, 'Cert expiry');

--- a/src/lib/diagnose/probes/certRequestFailure.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.ts
@@ -33,6 +33,7 @@ import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../
 import { HealthStore } from '@/lib/health/store';
 import { CERT_REQUEST_FAILURE_MESSAGE_PREFIX } from '@/lib/health/runner';
 import { parseLetsencryptTail } from '@/lib/health/probes/letsencryptLogParser';
+import { registerRefreshNow } from './refreshHealthCheck';
 
 // Re-export so callers (and the existing unit test) can import the
 // parser via the old module path.
@@ -260,3 +261,5 @@ registerProbeAction(
   },
   retryRequest,
 );
+
+registerRefreshNow(PROBE_ID, CHECK_ID, 'Cert request failure');

--- a/src/lib/diagnose/probes/lanIpChanged.ts
+++ b/src/lib/diagnose/probes/lanIpChanged.ts
@@ -16,6 +16,7 @@
 
 import { HealthStore } from '@/lib/health/store';
 import { LAN_IP_DRIFT_MESSAGE_PREFIX } from '@/lib/health/runner';
+import { registerRefreshNow } from './refreshHealthCheck';
 
 export interface LanIpProbeResult {
   status: 'ok' | 'warn' | 'info';
@@ -23,7 +24,10 @@ export interface LanIpProbeResult {
   hint?: string;
 }
 
+const PROBE_ID = 'lan_ip_changed_since_install';
 const CHECK_ID = 'lan_ip_drift';
+
+registerRefreshNow(PROBE_ID, CHECK_ID, 'LAN IP drift');
 
 export async function checkLanIpChanged(): Promise<LanIpProbeResult> {
   const result = HealthStore.getLastResult(CHECK_ID);

--- a/src/lib/diagnose/probes/npmDataStale.ts
+++ b/src/lib/diagnose/probes/npmDataStale.ts
@@ -30,6 +30,7 @@ import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
 import { HealthStore } from '@/lib/health/store';
 import { NPM_AUTH_MESSAGE_PREFIX } from '@/lib/health/runner';
+import { registerRefreshNow } from './refreshHealthCheck';
 
 export interface NpmDataStaleResult {
   /** undefined when not applicable (no nginx-web, or NPM not reachable). */
@@ -253,3 +254,5 @@ registerProbeAction(
   },
   useExistingNpmCreds,
 );
+
+registerRefreshNow(PROBE_ID, CHECK_ID, 'NPM auth');

--- a/src/lib/diagnose/probes/refreshHealthCheck.test.ts
+++ b/src/lib/diagnose/probes/refreshHealthCheck.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckConfig } from '@/lib/health/types';
+
+const checks: CheckConfig[] = [];
+const runMock = vi.fn();
+
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: { getChecks: () => checks },
+}));
+
+vi.mock('@/lib/health/runner', () => ({
+  CheckRunner: { run: (c: CheckConfig) => runMock(c) },
+}));
+
+import { makeRefreshNowAction } from './refreshHealthCheck';
+
+beforeEach(() => {
+  checks.length = 0;
+  runMock.mockReset();
+});
+
+describe('refresh_now handler (shared)', () => {
+  it('runs the matching singleton check via CheckRunner and returns ok=true', async () => {
+    const check: CheckConfig = {
+      id: 'npm_auth',
+      name: 'NPM auth',
+      type: 'npm_auth',
+      target: '',
+      interval: 900,
+      enabled: true,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+    checks.push(check);
+    runMock.mockResolvedValue({ status: 'ok', message: '' });
+
+    const { handler } = makeRefreshNowAction('npm_auth', 'NPM auth');
+    const r = await handler({ node: 'Local' });
+    expect(runMock).toHaveBeenCalledWith(check);
+    expect(r.ok).toBe(true);
+    expect(r.refresh).toBe(true);
+    expect(r.message).toMatch(/NPM auth re-run/);
+  });
+
+  it('returns ok=false (with refresh) when the singleton check is not registered yet', async () => {
+    const { handler } = makeRefreshNowAction('cert_expiry', 'Cert expiry');
+    const r = await handler({ node: 'Local' });
+    expect(runMock).not.toHaveBeenCalled();
+    expect(r.ok).toBe(false);
+    expect(r.refresh).toBe(true);
+    expect(r.message).toMatch(/should appear automatically/);
+  });
+
+  it('returns ok=false when CheckRunner throws', async () => {
+    checks.push({
+      id: 'lan_ip_drift',
+      name: 'LAN IP',
+      type: 'lan_ip_drift',
+      target: '',
+      interval: 300,
+      enabled: true,
+      created_at: '2024-01-01T00:00:00Z',
+    });
+    runMock.mockRejectedValue(new Error('agent unreachable'));
+
+    const { handler } = makeRefreshNowAction('lan_ip_drift', 'LAN IP drift');
+    const r = await handler({ node: 'Local' });
+    expect(r.ok).toBe(false);
+    expect(r.refresh).toBe(false);
+    expect(r.message).toMatch(/agent unreachable/);
+  });
+
+  it('builds an action with the standard refresh_now id and a label-aware description', () => {
+    const { action } = makeRefreshNowAction('cert_expiry', 'Cert expiry');
+    expect(action.id).toBe('refresh_now');
+    expect(action.label).toBe('Refresh now');
+    expect(action.description).toMatch(/Cert expiry/);
+  });
+});

--- a/src/lib/diagnose/probes/refreshHealthCheck.ts
+++ b/src/lib/diagnose/probes/refreshHealthCheck.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared per-row "Refresh now" handler for the Phase 3b singleton
+ * health-check probes (`npm_data_stale`, `cert_expiry`,
+ * `cert_request_failure`, `lan_ip_changed_since_install`).
+ *
+ * Mirrors the Phase 2 letsdebug `refresh_now` action: looks up the
+ * matching singleton check by id, runs it synchronously via
+ * `CheckRunner.run`, and returns a `ProbeActionResult` that asks the
+ * UI to re-fetch so the row updates in place.
+ *
+ * The four probes inherited the deferred-evaluation problem from the
+ * health-check schedule (5–15 min ticks) without inheriting the manual
+ * override Phase 2 added; this helper closes that gap with one shared
+ * implementation rather than four near-duplicate copies.
+ */
+
+import { HealthStore } from '@/lib/health/store';
+import { CheckRunner } from '@/lib/health/runner';
+import { logger } from '@/lib/logger';
+import type { ProbeActionResult, ProbeAction, ProbeActionHandler } from '../actions';
+import { registerProbeAction } from '../actions';
+
+/** Build a `refresh_now` ProbeAction + handler for a singleton check. */
+export function makeRefreshNowAction(checkId: string, label: string): {
+  action: ProbeAction;
+  handler: ProbeActionHandler;
+} {
+  return {
+    action: {
+      id: 'refresh_now',
+      label: 'Refresh now',
+      description:
+        `Re-runs the ${label} check immediately, skipping the wait for the next scheduled tick. The row updates in place when the check finishes.`,
+    },
+    handler: async (): Promise<ProbeActionResult> => {
+      const check = HealthStore.getChecks().find(c => c.id === checkId);
+      if (!check) {
+        return {
+          ok: false,
+          message: `No "${label}" check is registered yet — it should appear automatically on the next agent sync.`,
+          refresh: true,
+        };
+      }
+      try {
+        await CheckRunner.run(check);
+        return { ok: true, message: `${label} re-run.`, refresh: true };
+      } catch (e) {
+        logger.warn(
+          'diagnose:refresh_now',
+          `refresh of ${checkId} failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        return {
+          ok: false,
+          message: `Refresh failed: ${e instanceof Error ? e.message : String(e)}`,
+          refresh: false,
+        };
+      }
+    },
+  };
+}
+
+/** Convenience wrapper: build + register the refresh_now action against a probe id. */
+export function registerRefreshNow(probeId: string, checkId: string, label: string): void {
+  const { action, handler } = makeRefreshNowAction(checkId, label);
+  registerProbeAction(probeId, action, handler);
+}

--- a/src/lib/health/probes/npmAdmin.test.ts
+++ b/src/lib/health/probes/npmAdmin.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const twinNodes: Record<string, { services: unknown[]; containers: unknown[]; files: Record<string, unknown> }> = {};
+const serviceList: unknown[] = [];
+
+vi.mock('../../store/twin', () => ({
+  DigitalTwinStore: {
+    getInstance: () => ({ nodes: twinNodes }),
+  },
+}));
+
+vi.mock('../../services/ServiceManager', () => ({
+  ServiceManager: {
+    listServices: vi.fn(async () => serviceList),
+  },
+}));
+
+import { findNpmAdminUrl } from './npmAdmin';
+
+beforeEach(() => {
+  for (const k of Object.keys(twinNodes)) delete twinNodes[k];
+  serviceList.length = 0;
+});
+
+describe('findNpmAdminUrl', () => {
+  it('returns twin-not-ready when the twin has no entry for the node', async () => {
+    const r = await findNpmAdminUrl('Local');
+    expect(r.kind).toBe('twin-not-ready');
+  });
+
+  it('returns twin-not-ready when the twin entry has empty services and containers', async () => {
+    twinNodes['Local'] = { services: [], containers: [], files: {} };
+    const r = await findNpmAdminUrl('Local');
+    expect(r.kind).toBe('twin-not-ready');
+  });
+
+  it('returns nginx-not-found when twin has data but no nginx service', async () => {
+    twinNodes['Local'] = {
+      services: [{ name: 'unrelated.service' }],
+      containers: [{ id: 'abc' }],
+      files: {},
+    };
+    serviceList.push({ name: 'adguard', ports: [] });
+    const r = await findNpmAdminUrl('Local');
+    expect(r.kind).toBe('nginx-not-found');
+  });
+
+  it('returns the admin URL even when nginx.active is false (kube unit-name mismatch)', async () => {
+    // The bug we're fixing: kube-deployed nginx-pod's unit name doesn't
+    // match the template `nginx` service name, so `active` reads false
+    // even though every container in the pod is running. We trust the
+    // twin entry's presence + port mapping and let the actual fetch
+    // be the source of truth.
+    twinNodes['Local'] = {
+      services: [{ name: 'nginx-pod.service' }],
+      containers: [{ id: 'abc' }],
+      files: {},
+    };
+    serviceList.push({
+      name: 'nginx-web',
+      active: false,
+      ports: [{ host: '80' }, { host: '443' }, { host: '8181' }],
+    });
+    const r = await findNpmAdminUrl('Local');
+    expect(r).toEqual({ kind: 'url', url: 'http://localhost:8181' });
+  });
+
+  it('falls back to port 81 when the manifest exposes only 80/443', async () => {
+    twinNodes['Local'] = {
+      services: [{ name: 'nginx.service' }],
+      containers: [],
+      files: {},
+    };
+    serviceList.push({
+      name: 'nginx',
+      active: true,
+      ports: [{ host: '80' }, { host: '443' }],
+    });
+    const r = await findNpmAdminUrl('Local');
+    expect(r).toEqual({ kind: 'url', url: 'http://localhost:81' });
+  });
+
+  it('ignores `install-*` helper services and matches the real nginx', async () => {
+    twinNodes['Local'] = {
+      services: [{ name: 'nginx.service' }],
+      containers: [],
+      files: {},
+    };
+    serviceList.push(
+      { name: 'install-nginx', active: true, ports: [] },
+      { name: 'nginx-web', active: true, ports: [{ host: '8181' }] },
+    );
+    const r = await findNpmAdminUrl('Local');
+    expect(r).toEqual({ kind: 'url', url: 'http://localhost:8181' });
+  });
+});

--- a/src/lib/health/probes/npmAdmin.ts
+++ b/src/lib/health/probes/npmAdmin.ts
@@ -10,31 +10,64 @@
  * makes a single shared home cheaper to maintain.
  *
  *   - `findNpmAdminUrl(node)` — locates the running nginx-web service
- *     and returns its `http://localhost:<adminPort>` URL, or null when
- *     nginx isn't installed/active.
+ *     and returns its `http://localhost:<adminPort>` URL, or a reason
+ *     code when it can't.
  *   - `getNpmToken(adminUrl)` — tries stored creds first, then the
  *     wizard's default (`admin@example.com`/`changeme`); returns null
  *     if all candidates 401.
  */
 import { getConfig } from '../../config';
 import { ServiceManager } from '../../services/ServiceManager';
+import { DigitalTwinStore } from '../../store/twin';
 
-/** Locate the running nginx-web service on `node` and return its admin URL.
- *  Returns null when nginx-web isn't installed or its admin port can't
- *  be derived from the service manifest. */
-export async function findNpmAdminUrl(node: string): Promise<string | null> {
+/**
+ * Discriminated result for `findNpmAdminUrl`.
+ *
+ *   - `url` — nginx is in the twin and we derived its admin port.
+ *   - `twin-not-ready` — the digital twin for this node hasn't been
+ *     populated yet (cold-start race after the runner fires before the
+ *     agent's first sync). Caller should surface this as info and let
+ *     the next scheduled tick self-correct rather than cementing a
+ *     misleading "not deployed" result for 5–15 min.
+ *   - `nginx-not-found` — twin has data, but no nginx entry exists —
+ *     genuine "NPM not installed" case.
+ */
+export type FindNpmAdminResult =
+  | { kind: 'url'; url: string }
+  | { kind: 'twin-not-ready' }
+  | { kind: 'nginx-not-found' };
+
+/** Locate the running nginx-web service on `node` and return its admin URL,
+ *  or a reason code explaining why we couldn't.
+ *
+ *  Note: deliberately does NOT short-circuit on `service.active === false`.
+ *  The `active` flag is unreliable for kube-deployed services because the
+ *  matching between the template service name (`nginx`) and the
+ *  systemd unit Quadlet generates (`nginx-pod.service`, container-by-
+ *  container `<sha>.service`) is brittle. We trust the twin entry's
+ *  presence + port mapping and let the caller's actual `fetch
+ *  ${adminUrl}/api/tokens` be the source of truth — if NPM is genuinely
+ *  stopped, the fetch fails with `ECONNREFUSED` and the caller surfaces
+ *  the precise reason instead of a misleading "not deployed". */
+export async function findNpmAdminUrl(node: string): Promise<FindNpmAdminResult> {
   try {
+    const twin = DigitalTwinStore.getInstance().nodes[node];
+    if (!twin || (twin.services.length === 0 && twin.containers.length === 0)) {
+      return { kind: 'twin-not-ready' };
+    }
     const services = await ServiceManager.listServices(node);
     const nginx = services.find(
       s => s.name === 'nginx' || s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
     );
-    if (!nginx?.active) return null;
+    if (!nginx) {
+      return { kind: 'nginx-not-found' };
+    }
     const ports = (nginx.ports ?? [])
       .map(p => parseInt(String(p.host ?? ''), 10))
       .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
-    return `http://localhost:${ports[0] ?? 81}`;
+    return { kind: 'url', url: `http://localhost:${ports[0] ?? 81}` };
   } catch {
-    return null;
+    return { kind: 'nginx-not-found' };
   }
 }
 

--- a/src/lib/health/runner.ts
+++ b/src/lib/health/runner.ts
@@ -419,10 +419,14 @@ export class CheckRunner {
       if (!npm?.email || !npm?.password) {
         return encode({ status: 'info', detail: 'No NPM admin credentials stored — skipping staleness check.' });
       }
-      const adminUrl = await findNpmAdminUrl(node);
-      if (!adminUrl) {
+      const admin = await findNpmAdminUrl(node);
+      if (admin.kind === 'twin-not-ready') {
+        return encode({ status: 'info', detail: 'Digital twin not populated yet — check will retry on the next tick.' });
+      }
+      if (admin.kind === 'nginx-not-found') {
         return encode({ status: 'info', detail: 'Nginx Proxy Manager not deployed on this node — nothing to check.' });
       }
+      const adminUrl = admin.url;
       try {
         const res = await fetch(`${adminUrl}/api/tokens`, {
           method: 'POST',
@@ -484,10 +488,14 @@ export class CheckRunner {
       ({ status: payload.status === 'fail' ? ('fail' as const) : ('ok' as const), message: `${CERT_EXPIRY_MESSAGE_PREFIX}${JSON.stringify(payload)}` });
 
     try {
-      const adminUrl = await findNpmAdminUrl(node);
-      if (!adminUrl) {
+      const admin = await findNpmAdminUrl(node);
+      if (admin.kind === 'twin-not-ready') {
+        return encode({ status: 'info', detail: 'Digital twin not populated yet — check will retry on the next tick.' });
+      }
+      if (admin.kind === 'nginx-not-found') {
         return encode({ status: 'info', detail: 'Nginx Proxy Manager not deployed — no certificates to check.' });
       }
+      const adminUrl = admin.url;
       const token = await getNpmToken(adminUrl);
       if (!token) {
         return encode({ status: 'info', detail: 'Could not authenticate with NPM — skipping certificate check.' });


### PR DESCRIPTION
## Summary

Settings → Health → \`Nginx Proxy Manager auth\` reported \"NPM not deployed on this node\" on installs where NPM was unambiguously running (proxy hosts serving traffic, admin UI reachable). Same false negative leaked into \`cert_expiry\` and \`cert_request_failure\` because all three share \`findNpmAdminUrl\`.

## Root cause

\`findNpmAdminUrl\` short-circuited on \`service.active === false\`. For kube-deployed NPM (\`podman play kube\`), the matching between the template service name (\`nginx\`) and the systemd unit Quadlet generates (\`nginx-pod.service\`, container-by-container \`<sha>.service\`) is brittle. The twin can carry an \`nginx\` entry whose \`active\` flag reads false even though every container is running.

Compounding this, the four Phase 3b singleton checks fire immediately when \`init.ts\` saves them — *before* the agent has populated the twin. A cold-boot tick cemented \"not deployed\" for the next 5–15 min.

## Fix

1. **Drop the \`.active\` short-circuit.** \`findNpmAdminUrl\` returns a discriminated \`{ kind: 'url' | 'twin-not-ready' | 'nginx-not-found' }\` union. Trust the twin entry's presence + port mapping; the actual \`fetch \${adminUrl}/api/tokens\` is the source of truth — \`ECONNREFUSED\` surfaces the precise reason if NPM is genuinely stopped.
2. **Distinguish twin-not-ready from nginx-absent.** Cold-boot races render as \"Digital twin not populated yet — check will retry on the next tick\" so the next scheduled tick self-corrects.
3. **\`refresh_now\` action on all four Phase 3b probes** via shared \`refreshHealthCheck.ts\` helper. Mirrors the Phase 2 letsdebug action: looks up the singleton check by id, runs it via \`CheckRunner.run\`, asks the UI to re-fetch.

## Files

- \`src/lib/health/probes/npmAdmin.ts\` — return-shape change, drop \`.active\`, twin-readiness check.
- \`src/lib/health/runner.ts\` — \`runNpmAuthCheck\` + \`runCertExpiryCheck\` consume the new union (cert_request_failure doesn't use this helper).
- \`src/lib/diagnose/probes/refreshHealthCheck.ts\` (new) — shared refresh_now action factory.
- \`src/lib/diagnose/probes/{npmDataStale,certExpiry,certRequestFailure,lanIpChanged}.ts\` — register refresh_now.

## Test plan

- [x] \`vitest run\` — 715/715 pass (101 files).
- [x] \`tsc --noEmit\` clean.
- [x] New \`src/lib/health/probes/npmAdmin.test.ts\` (6 tests) covers all three reason codes including the regression case (\`active=false\` still returns URL).
- [x] New \`src/lib/diagnose/probes/refreshHealthCheck.test.ts\` (4 tests) covers shared dispatch.
- [ ] On a live install: \"Refresh now\" appears on each non-OK Phase 3b probe row; clicking re-runs the check and the row updates without a page reload.
- [ ] After a fresh ServiceBay reboot, the four probes self-correct on the next tick instead of cementing \"not deployed\" / cold-twin info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)