### PR TITLE
feat(reverse-proxy): LAN→Public migration orchestrator + pre-flight (PR-1 of #265)

### DIFF
--- a/src/app/api/system/reverse-proxy/migrate-to-public/route.ts
+++ b/src/app/api/system/reverse-proxy/migrate-to-public/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import {
+  applyMigrationToPublic,
+  validatePublicDomain,
+} from '@/lib/reverseProxy/migrateToPublic';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/system/reverse-proxy/migrate-to-public
+ *
+ * Plans (or applies) the LAN→Public migration locked in on #265.
+ *
+ * Body:
+ *   { publicDomain: string; dryRun?: boolean }
+ *
+ * `dryRun: true` returns the plan + per-step would-be outcomes without
+ * touching NPM, Authelia, or config. The default (`dryRun: false`)
+ * runs the plan: each step's failure surfaces in `errors[]` but does
+ * not abort subsequent steps (idempotent + retryable per the locked
+ * design).
+ *
+ * Auth-gated via `requireSession`. No feature flag — the UI surface
+ * lands in PR-2; until then this endpoint can only be exercised via
+ * curl with a valid session cookie.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
+    let body: { publicDomain?: unknown; dryRun?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+
+    const domainError = validatePublicDomain(body.publicDomain);
+    if (domainError) {
+      return NextResponse.json({ error: domainError }, { status: 400 });
+    }
+    const publicDomain = (body.publicDomain as string).trim();
+    const dryRun = body.dryRun === true;
+
+    const result = await applyMigrationToPublic({ publicDomain, dryRun });
+    return NextResponse.json(result);
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:reverse-proxy:migrate-to-public', status: 500 });
+  }
+}

--- a/src/app/api/system/reverse-proxy/preflight/route.ts
+++ b/src/app/api/system/reverse-proxy/preflight/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { getPreflightStatus } from '@/lib/reverseProxy/preflight';
+import { validatePublicDomain } from '@/lib/reverseProxy/migrateToPublic';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/system/reverse-proxy/preflight?publicDomain=<...>
+ *
+ * Reports the three-check gate for the LAN→Public migration (#265):
+ *   - DNS resolves the target public domain to this install's WAN IP
+ *   - HTTP-01 reachability on port 80 from the internet
+ *   - Router port-forward for 80/443 (fritzbox health check)
+ *
+ * The UI (PR-2) polls this on a 5-s loop. Each tick re-runs the
+ * letsdebug probe — pricey enough that the route returns immediately
+ * with the most recent answer and skips background scheduling. PR-2
+ * can throttle on the UI side.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const url = new URL(request.url);
+    const publicDomain = url.searchParams.get('publicDomain');
+    const domainError = validatePublicDomain(publicDomain);
+    if (domainError) {
+      return NextResponse.json({ error: domainError }, { status: 400 });
+    }
+    const status = await getPreflightStatus(publicDomain!);
+    return NextResponse.json(status);
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:reverse-proxy:preflight', status: 500 });
+  }
+}

--- a/src/lib/reverseProxy/autheliaRewrite.ts
+++ b/src/lib/reverseProxy/autheliaRewrite.ts
@@ -1,0 +1,257 @@
+/**
+ * Pure transform from the install-time Authelia `configuration.yml`
+ * to its post-migration counterpart, used by the LAN→Public migration
+ * orchestrator (#265).
+ *
+ * The migration is "soft handoff": existing LAN URLs keep working,
+ * with public-domain twins added side-by-side in access_control rules
+ * and OIDC redirect_uris. The single non-additive change is the
+ * session cookie domain — Authelia binds one cookie per session.cookies[i],
+ * so the cookie's `domain` flips from the lan root to the public root.
+ * That invalidates active sessions; the locked design surfaces this
+ * via a pre-flight banner.
+ *
+ * Kept as a string-in / string-out function with no I/O so the surface
+ * is fully unit-testable. Callers (the orchestrator) do the
+ * read-file → rewrite → write-file → restart-pod dance.
+ */
+
+import yaml from 'js-yaml';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type YamlNode = any;
+
+export interface AutheliaRewriteChanges {
+  /** Cookie domain flipped from lan root to public domain. */
+  cookieDomain: { from: string | null; to: string };
+  /** Cookie authelia_url rewritten to the public auth subdomain. */
+  cookieAutheliaUrl: { from: string | null; to: string };
+  /**
+   * Per-rule before/after of `access_control.rules[i].domain`.
+   * Empty when the rules array was missing.
+   */
+  accessControlRuleDomains: { from: unknown; to: unknown }[];
+  /**
+   * Per-client list of newly-appended `redirect_uris`. Existing entries
+   * are preserved untouched (additive, per the locked design).
+   */
+  oidcRedirectUriAdditions: { clientId: string; added: string[] }[];
+}
+
+export interface AutheliaRewriteResult {
+  /** Rewritten yaml, ready to write back. */
+  yaml: string;
+  /** What changed — for plan output + post-apply audit log. */
+  changes: AutheliaRewriteChanges;
+}
+
+/**
+ * Twin a single hostname string against the public domain.
+ *
+ * - `home.arpa` → `[home.arpa, dopp.cloud]`
+ * - `auth.home.arpa` → `[auth.home.arpa, auth.dopp.cloud]`
+ * - anything else → returned unchanged
+ *
+ * Returns either the input string (no match) or a deduplicated array
+ * containing the original plus the public-domain twin.
+ */
+function twinHost(value: string, lanRoot: string, publicDomain: string): string | string[] {
+  const lc = value.toLowerCase();
+  const lan = lanRoot.toLowerCase();
+  if (lc === lan) {
+    return value === publicDomain ? [value] : [value, publicDomain];
+  }
+  if (lc.endsWith(`.${lan}`)) {
+    const sub = value.slice(0, value.length - lan.length - 1);
+    const twin = `${sub}.${publicDomain}`;
+    return value === twin ? [value] : [value, twin];
+  }
+  return value;
+}
+
+/**
+ * Twin a `domain` field on an access_control rule. Handles both forms
+ * Authelia accepts: a single string or a list of strings.
+ *
+ * For lists, every entry that matches the lan root contributes a new
+ * public-domain entry. Existing entries are preserved verbatim. The
+ * result is deduplicated so a re-run of the migration is a no-op on
+ * already-migrated config.
+ */
+function twinAccessControlDomain(value: unknown, lanRoot: string, publicDomain: string): unknown {
+  if (typeof value === 'string') {
+    return twinHost(value, lanRoot, publicDomain);
+  }
+  if (Array.isArray(value)) {
+    const seen = new Set<string>();
+    const out: unknown[] = [];
+    const push = (v: string) => {
+      if (seen.has(v)) return;
+      seen.add(v);
+      out.push(v);
+    };
+    for (const item of value) {
+      if (typeof item !== 'string') {
+        out.push(item);
+        continue;
+      }
+      const twinned = twinHost(item, lanRoot, publicDomain);
+      if (typeof twinned === 'string') {
+        push(twinned);
+      } else {
+        for (const t of twinned) push(t);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Compute the public-domain twin of a URI whose host is the lan root
+ * (or a subdomain of it). Returns `null` for any URI that doesn't
+ * involve the lan root (third-party callbacks, mobile deep-links,
+ * already-public URIs) so the caller can skip them cleanly.
+ */
+function twinUri(uri: string, lanRoot: string, publicDomain: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  const lan = lanRoot.toLowerCase();
+  if (host === lan) {
+    parsed.hostname = publicDomain;
+    return parsed.toString();
+  }
+  if (host.endsWith(`.${lan}`)) {
+    const sub = parsed.hostname.slice(0, parsed.hostname.length - lan.length - 1);
+    parsed.hostname = `${sub}.${publicDomain}`;
+    return parsed.toString();
+  }
+  return null;
+}
+
+/**
+ * Compute the new `cookies[i].authelia_url`. Existing value is parsed
+ * as a URL so a non-default port or path on the existing url survives
+ * the migration. Falls back to `https://auth.<publicDomain>` if the
+ * existing value is missing or malformed.
+ */
+function rewriteAutheliaUrl(existing: unknown, lanRoot: string, publicDomain: string): string {
+  if (typeof existing === 'string') {
+    try {
+      const u = new URL(existing);
+      const host = u.hostname.toLowerCase();
+      if (host === lanRoot.toLowerCase() || host.endsWith(`.${lanRoot.toLowerCase()}`)) {
+        const sub = host === lanRoot.toLowerCase()
+          ? 'auth'
+          : (host.slice(0, host.length - lanRoot.length - 1) || 'auth');
+        u.hostname = `${sub}.${publicDomain}`;
+        return u.toString();
+      }
+      // URL is already off the lan root (e.g. a second-run on a
+      // migrated config); leave it untouched so the rewrite stays
+      // idempotent.
+      return existing;
+    } catch {
+      // fall through to default
+    }
+  }
+  return `https://auth.${publicDomain}`;
+}
+
+/**
+ * Re-emit yaml using the same serialisation defaults as the existing
+ * `oidc-clients/route.ts` editor so diffs against an Authelia config
+ * touched by either path stay readable.
+ */
+function dumpYaml(node: YamlNode): string {
+  return yaml.dump(node, { lineWidth: -1, quotingType: "'", forceQuotes: false });
+}
+
+/**
+ * Walk a parsed `configuration.yml` and return the
+ * `[yaml, changes]` pair. Idempotent — running the rewrite a second
+ * time on already-migrated config yields the same string + empty
+ * change lists for the additive sections.
+ */
+export function rewriteAutheliaConfig(
+  yamlString: string,
+  lanRoot: string,
+  publicDomain: string,
+): AutheliaRewriteResult {
+  const doc = yaml.load(yamlString) as YamlNode;
+  const changes: AutheliaRewriteChanges = {
+    cookieDomain: { from: null, to: publicDomain },
+    cookieAutheliaUrl: { from: null, to: '' },
+    accessControlRuleDomains: [],
+    oidcRedirectUriAdditions: [],
+  };
+
+  if (!doc || typeof doc !== 'object') {
+    return { yaml: yamlString, changes };
+  }
+
+  // 1) Session cookie — single config value, hard cutover.
+  const cookies = doc?.session?.cookies;
+  if (Array.isArray(cookies) && cookies.length > 0 && cookies[0] && typeof cookies[0] === 'object') {
+    const c = cookies[0];
+    changes.cookieDomain.from = typeof c.domain === 'string' ? c.domain : null;
+    c.domain = publicDomain;
+
+    changes.cookieAutheliaUrl.from = typeof c.authelia_url === 'string' ? c.authelia_url : null;
+    c.authelia_url = rewriteAutheliaUrl(c.authelia_url, lanRoot, publicDomain);
+    changes.cookieAutheliaUrl.to = c.authelia_url;
+  }
+
+  // 2) Access-control rules — additive twin.
+  const rules = doc?.access_control?.rules;
+  if (Array.isArray(rules)) {
+    for (const r of rules) {
+      if (!r || typeof r !== 'object' || !('domain' in r)) continue;
+      const before = r.domain;
+      const after = twinAccessControlDomain(before, lanRoot, publicDomain);
+      // Only log a change when something actually moved. Arrays compare
+      // structurally; strings compare directly.
+      if (JSON.stringify(before) !== JSON.stringify(after)) {
+        r.domain = after;
+        changes.accessControlRuleDomains.push({ from: before, to: after });
+      }
+    }
+  }
+
+  // 3) OIDC clients — append public-domain redirect_uri twins.
+  const clients = doc?.identity_providers?.oidc?.clients;
+  if (Array.isArray(clients)) {
+    for (const client of clients) {
+      if (!client || typeof client !== 'object') continue;
+      const uris = client.redirect_uris;
+      if (!Array.isArray(uris)) continue;
+      const existing = new Set<string>();
+      for (const u of uris) {
+        if (typeof u === 'string') existing.add(u);
+      }
+      const added: string[] = [];
+      for (const u of uris.slice()) {
+        if (typeof u !== 'string') continue;
+        const twin = twinUri(u, lanRoot, publicDomain);
+        if (twin && !existing.has(twin)) {
+          existing.add(twin);
+          uris.push(twin);
+          added.push(twin);
+        }
+      }
+      if (added.length > 0) {
+        changes.oidcRedirectUriAdditions.push({
+          clientId: typeof client.client_id === 'string' ? client.client_id : '(unknown)',
+          added,
+        });
+      }
+    }
+  }
+
+  return { yaml: dumpYaml(doc), changes };
+}

--- a/src/lib/reverseProxy/migrateToPublic.ts
+++ b/src/lib/reverseProxy/migrateToPublic.ts
@@ -1,0 +1,605 @@
+/**
+ * LAN→Public migration orchestrator (#265).
+ *
+ * Takes a `publicDomain`, plans (dry-run) or applies the additive
+ * "soft handoff" migration locked in on the issue comment:
+ *
+ *   1. NPM proxy hosts: each existing host's `domain_names` becomes
+ *      `[<sub>.<lanRoot>, <sub>.<publicDomain>]`. Forward host/port
+ *      unchanged. Idempotent — hosts already carrying the public name
+ *      are skipped.
+ *   2. Authelia `configuration.yml`: session cookie domain flips to
+ *      the public root (single non-additive change), `authelia_url`
+ *      rewritten, access_control rule domains gain public-domain
+ *      twins, OIDC client redirect_uris gain public-domain twins.
+ *      Auth pod restarted to pick up the new config.
+ *   3. Cert request: one Let's Encrypt cert per public-twin host via
+ *      NPM's ACME endpoint, bound to the dual-server_name proxy host.
+ *      Best-effort: a single failed cert doesn't abort — the operator
+ *      retries via the diagnose `cert_request_failure` probe.
+ *   4. Config: `reverseProxy.publicDomain` is set; the letsdebug +
+ *      domain health checks are re-synced so newly-public hosts get
+ *      external-reachability probes on the next tick.
+ *
+ * Re-running the orchestrator is safe and resumes from wherever the
+ * previous run left off, per the locked design's "no transactional
+ * rollback" decision.
+ *
+ * I/O lives in this file; the pure yaml rewrite lives in
+ * `autheliaRewrite.ts` so the trickiest piece has its own unit-test
+ * surface independent of network mocks.
+ */
+
+import { getConfig, updateConfig } from '../config';
+import { DigitalTwinStore } from '../store/twin';
+import { ServiceManager } from '../services/ServiceManager';
+import { logger } from '../logger';
+import yaml from 'js-yaml';
+import { rewriteAutheliaConfig, type AutheliaRewriteChanges } from './autheliaRewrite';
+
+const DEFAULT_LAN_ROOT = 'home.arpa';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface MigrationOptions {
+  publicDomain: string;
+  /** When true, compute the plan but make no network or filesystem writes. */
+  dryRun: boolean;
+}
+
+export interface ProxyHostStep {
+  kind: 'npm-dual-server-name';
+  hostId: number;
+  domain: string;
+  /** `domain_names` before the PUT (or after — see `skipped`). */
+  before: string[];
+  /** `domain_names` we would write. Equal to `before` when `skipped`. */
+  after: string[];
+  /** Already dual-server_name; no PUT needed. */
+  skipped: boolean;
+}
+
+export interface AutheliaStep {
+  kind: 'authelia-config';
+  node: string;
+  configPath: string;
+  /** Summary of yaml-level changes. Empty fields mean "already migrated". */
+  changes: AutheliaRewriteChanges;
+  /** True when the rewrite would yield the same string we read. */
+  noop: boolean;
+}
+
+export interface CertRequestStep {
+  kind: 'cert-request';
+  hostId: number;
+  domain: string;
+  /** Skipped when the proxy host already carries a non-zero certificate_id. */
+  skipped: boolean;
+  skipReason?: string;
+}
+
+export type MigrationStep = ProxyHostStep | AutheliaStep | CertRequestStep;
+
+export interface MigrationPlan {
+  publicDomain: string;
+  lanRoot: string;
+  /** Operator-visible warnings that don't block the run but should be surfaced. */
+  warnings: string[];
+  steps: MigrationStep[];
+}
+
+export interface MigrationApplyError {
+  step: MigrationStep['kind'];
+  detail: string;
+  /** Domain or hostId where the error happened, when applicable. */
+  target?: string;
+}
+
+export interface MigrationResult {
+  plan: MigrationPlan;
+  applied: boolean;
+  errors: MigrationApplyError[];
+  /**
+   * Per-step outcomes, in plan order. Each entry is one of:
+   *  - `{ ok: true }` for steps that ran (or were no-ops) cleanly.
+   *  - `{ ok: false, error }` mirroring the matching `errors[]` entry.
+   */
+  stepResults: { ok: boolean; error?: string }[];
+}
+
+// ─── NPM helpers (slim, migration-scoped) ───────────────────────────
+
+interface NpmTarget {
+  apiUrl: string;
+  nodeName: string;
+  nodeIp: string;
+}
+
+interface NpmHost {
+  id: number;
+  domain_names: string[];
+  forward_host?: string;
+  forward_port?: number;
+  forward_scheme?: string;
+  certificate_id?: number;
+  enabled?: boolean;
+}
+
+interface NpmDeps {
+  resolveNpm(nodeHint?: string): Promise<NpmTarget | null>;
+  getToken(baseUrl: string): Promise<string | null>;
+  listHosts(baseUrl: string, token: string): Promise<NpmHost[]>;
+  updateHost(baseUrl: string, token: string, id: number, patch: Partial<NpmHost>): Promise<void>;
+  requestCert(baseUrl: string, token: string, domain: string): Promise<number>;
+  bindCert(baseUrl: string, token: string, hostId: number, certId: number): Promise<void>;
+}
+
+/**
+ * Lazy-loaded NPM bindings — kept behind a `deps` arg so tests can pass
+ * an in-memory fake without touching `fetch`. The real implementation
+ * mirrors the existing patterns in
+ * `src/app/api/system/nginx/proxy-hosts/route.ts`.
+ */
+async function realNpmDeps(): Promise<NpmDeps> {
+  return {
+    resolveNpm: async (nodeHint) => {
+      const twin = DigitalTwinStore.getInstance();
+      const nodeNames = nodeHint ? [nodeHint] : Object.keys(twin.nodes);
+      if (nodeNames.length === 0) nodeNames.push('Local');
+      for (const nodeName of nodeNames) {
+        const services = await ServiceManager.listServices(nodeName);
+        const nginx = services.find(s => s.name === 'nginx' || (s.name.includes('nginx') && !s.name.startsWith('install-')));
+        if (!nginx?.active) continue;
+        const svc = nginx as { ports?: { containerPort?: number; hostPort?: number }[] };
+        const adminMapping = svc.ports?.find(p => p.containerPort === 81);
+        let adminPort = adminMapping?.hostPort?.toString();
+        if (!adminPort) {
+          const config = await getConfig();
+          adminPort = config.templateSettings?.NGINX_ADMIN_PORT || '81';
+        }
+        const t = twin.nodes[nodeName];
+        const nodeIp = t?.nodeIPs?.find(ip => !ip.startsWith('127.')) ?? t?.nodeIPs?.[0] ?? '127.0.0.1';
+        const apiHost = nodeName === 'Local' ? '127.0.0.1' : nodeIp;
+        return { apiUrl: `http://${apiHost}:${adminPort}`, nodeName, nodeIp };
+      }
+      return null;
+    },
+    getToken: async (baseUrl) => {
+      const config = await getConfig();
+      const candidates: { identity: string; secret: string }[] = [];
+      const stored = config.reverseProxy?.npm;
+      if (stored?.email && stored?.password) candidates.push({ identity: stored.email, secret: stored.password });
+      candidates.push({ identity: 'admin@example.com', secret: 'changeme' });
+      for (const cred of candidates) {
+        try {
+          const res = await fetch(`${baseUrl}/api/tokens`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(cred),
+            signal: AbortSignal.timeout(5000),
+          });
+          if (res.ok) {
+            const data = await res.json() as { token?: string };
+            if (data.token) return data.token;
+          }
+        } catch { /* try next */ }
+      }
+      return null;
+    },
+    listHosts: async (baseUrl, token) => {
+      const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts?expand=owner,access_list,certificate`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) throw new Error(`NPM list-hosts HTTP ${res.status}`);
+      return (await res.json()) as NpmHost[];
+    },
+    updateHost: async (baseUrl, token, id, patch) => {
+      const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(patch),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`NPM update-host ${id} HTTP ${res.status}: ${body.slice(0, 200)}`);
+      }
+    },
+    requestCert: async (baseUrl, token, domain) => {
+      const res = await fetch(`${baseUrl}/api/nginx/certificates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          provider: 'letsencrypt',
+          domain_names: [domain],
+          meta: { dns_challenge: false },
+        }),
+        // ACME exchange blocks until LE either issues or times out; budget
+        // generously per the existing proxy-hosts/route precedent.
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`NPM cert-request HTTP ${res.status}: ${body.slice(0, 200)}`);
+      }
+      const data = await res.json() as { id?: number };
+      if (typeof data.id !== 'number') {
+        throw new Error('NPM accepted the cert request but returned no id.');
+      }
+      return data.id;
+    },
+    bindCert: async (baseUrl, token, hostId, certId) => {
+      const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts/${hostId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ certificate_id: certId, ssl_forced: true, http2_support: true, hsts_enabled: false }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`NPM cert-bind cert=${certId} host=${hostId} HTTP ${res.status}: ${body.slice(0, 200)}`);
+      }
+    },
+  };
+}
+
+// ─── Authelia helpers ───────────────────────────────────────────────
+
+interface AutheliaDeps {
+  /** Locate the auth pod's `configuration.yml` on disk. */
+  locateConfig(): Promise<{ node: string; path: string; content: string } | null>;
+  /** Write the config back. */
+  writeConfig(node: string, path: string, content: string): Promise<void>;
+  /** Restart the auth pod so it re-reads the new config. */
+  restartAuth(node: string): Promise<void>;
+}
+
+async function realAutheliaDeps(): Promise<AutheliaDeps> {
+  const { agentManager } = await import('../agent/manager');
+  return {
+    locateConfig: async () => {
+      const twin = DigitalTwinStore.getInstance();
+      for (const nodeName of Object.keys(twin.nodes)) {
+        try {
+          const files = await ServiceManager.getServiceFiles(nodeName, 'auth');
+          if (!files.yamlContent) continue;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const docs = yaml.loadAll(files.yamlContent) as any[];
+          let configHostPath = '';
+          for (const doc of docs) {
+            const volumes = doc?.spec?.volumes;
+            if (!Array.isArray(volumes)) continue;
+            for (const vol of volumes) {
+              if (vol.name?.includes('config') && vol.hostPath?.path) {
+                configHostPath = vol.hostPath.path;
+                break;
+              }
+            }
+            if (configHostPath) break;
+          }
+          if (!configHostPath) continue;
+          const configFilePath = `${configHostPath}/configuration.yml`;
+          const agent = await agentManager.ensureAgent(nodeName);
+          const readRes = await agent.sendCommand('read_file', { path: configFilePath });
+          const content = readRes.content || readRes.stdout || '';
+          if (!content) continue;
+          return { node: nodeName, path: configFilePath, content };
+        } catch {
+          // Authelia not on this node — try the next.
+        }
+      }
+      return null;
+    },
+    writeConfig: async (node, path, content) => {
+      const agent = await agentManager.ensureAgent(node);
+      await agent.sendCommand('write_file', { path, content });
+    },
+    restartAuth: async (node) => {
+      // Restarting the merged `auth` pod restarts authelia + lldap together —
+      // same trade-off the existing oidc-clients route accepts. Fast (<5s)
+      // and lldap re-attaches cleanly.
+      await ServiceManager.restartService(node, 'auth');
+    },
+  };
+}
+
+// ─── Health-check refresh hook ──────────────────────────────────────
+
+interface HealthDeps {
+  /** Resync letsdebug + domain checks for the newly-public host list. */
+  syncChecks(): Promise<void>;
+}
+
+async function realHealthDeps(): Promise<HealthDeps> {
+  return {
+    syncChecks: async () => {
+      try {
+        const { syncDomainChecks } = await import('../health/domainChecks');
+        const { syncLetsdebugChecks } = await import('../health/letsdebugChecks');
+        await syncDomainChecks();
+        await syncLetsdebugChecks();
+      } catch (e) {
+        logger.warn('migrate-to-public', `Health-check resync failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    },
+  };
+}
+
+// ─── DI shape for tests ─────────────────────────────────────────────
+
+export interface MigrationDeps {
+  npm: NpmDeps;
+  authelia: AutheliaDeps;
+  health: HealthDeps;
+}
+
+/**
+ * Public-domain twin of a lan-rooted hostname. Returns `null` for
+ * anything not on the lan root (so already-public hosts are left
+ * alone by the migration loop).
+ */
+function publicTwin(domain: string, lanRoot: string, publicDomain: string): string | null {
+  const lc = domain.toLowerCase();
+  const root = lanRoot.toLowerCase();
+  if (lc === root) return publicDomain;
+  if (lc.endsWith(`.${root}`)) {
+    const sub = domain.slice(0, domain.length - root.length - 1);
+    return `${sub}.${publicDomain}`;
+  }
+  return null;
+}
+
+// ─── Public entry points ────────────────────────────────────────────
+
+/**
+ * Validate a `publicDomain` against the same hostname-shaped pattern
+ * the mode-classifier endpoint uses. Returns `null` when the domain
+ * is acceptable, or a human-readable error message otherwise.
+ */
+export function validatePublicDomain(input: unknown): string | null {
+  if (typeof input !== 'string') return 'publicDomain must be a string';
+  const trimmed = input.trim();
+  if (!trimmed) return 'publicDomain is required';
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(trimmed)) {
+    return 'publicDomain must be a valid hostname (e.g. example.com).';
+  }
+  return null;
+}
+
+/**
+ * Build a plan against the current install state without making any
+ * changes. Safe to call repeatedly; output is deterministic given the
+ * same inputs.
+ */
+export async function planMigrationToPublic(
+  options: MigrationOptions,
+  depsOverride?: Partial<MigrationDeps>,
+): Promise<MigrationPlan> {
+  const publicDomain = options.publicDomain.trim();
+  const config = await getConfig();
+  const lanRoot = (config.reverseProxy?.lanDomain || DEFAULT_LAN_ROOT).trim();
+
+  const warnings: string[] = [];
+  const steps: MigrationStep[] = [];
+
+  // The orchestrator is only meaningful in lan→public; if a public domain
+  // is already set, surface a warning and re-plan against the *new* domain
+  // so re-runs after a partial apply still converge.
+  if (config.reverseProxy?.publicDomain && config.reverseProxy.publicDomain !== publicDomain) {
+    warnings.push(
+      `reverseProxy.publicDomain is already set to '${config.reverseProxy.publicDomain}'; planning against '${publicDomain}' will add a parallel public domain rather than replace it.`,
+    );
+  }
+
+  const deps: MigrationDeps = {
+    npm: depsOverride?.npm ?? (await realNpmDeps()),
+    authelia: depsOverride?.authelia ?? (await realAutheliaDeps()),
+    health: depsOverride?.health ?? (await realHealthDeps()),
+  };
+
+  // 1) NPM proxy hosts — list, then per-host twin plan. Hosts are
+  //    iterated once and contribute both a dual-server_name step and
+  //    a (conditional) cert-request step so the per-host certificate
+  //    state can be read off the same record.
+  const npmTarget = await deps.npm.resolveNpm();
+  const certSteps: CertRequestStep[] = [];
+  if (!npmTarget) {
+    warnings.push('Nginx Proxy Manager is not deployed or not running; proxy-host steps will be skipped.');
+  } else {
+    const token = await deps.npm.getToken(npmTarget.apiUrl);
+    if (!token) {
+      warnings.push(`Could not authenticate with NPM at ${npmTarget.apiUrl}; proxy-host steps will be skipped.`);
+    } else {
+      let hosts: NpmHost[] = [];
+      try {
+        hosts = await deps.npm.listHosts(npmTarget.apiUrl, token);
+      } catch (e) {
+        warnings.push(`Could not list NPM proxy hosts: ${e instanceof Error ? e.message : String(e)}`);
+      }
+      for (const host of hosts) {
+        const lanEntry = (host.domain_names ?? []).find(d => publicTwin(d, lanRoot, publicDomain) !== null);
+        if (!lanEntry) continue;
+        const twin = publicTwin(lanEntry, lanRoot, publicDomain);
+        if (!twin) continue;
+        const before = (host.domain_names ?? []).slice();
+        const alreadyDual = before.includes(twin);
+        const after = alreadyDual ? before : [...before, twin];
+        steps.push({
+          kind: 'npm-dual-server-name',
+          hostId: host.id,
+          domain: lanEntry,
+          before,
+          after,
+          skipped: alreadyDual,
+        });
+        const hasCert = typeof host.certificate_id === 'number' && host.certificate_id > 0;
+        certSteps.push({
+          kind: 'cert-request',
+          hostId: host.id,
+          domain: twin,
+          skipped: hasCert,
+          skipReason: hasCert
+            ? `host ${host.id} already has certificate_id=${host.certificate_id}`
+            : undefined,
+        });
+      }
+    }
+  }
+
+  // 2) Authelia config — read + dry-run the rewrite to surface changes.
+  const autheliaLoc = await deps.authelia.locateConfig();
+  if (!autheliaLoc) {
+    warnings.push('Authelia (auth pod) is not deployed; SSO migration step will be skipped.');
+  } else {
+    const result = rewriteAutheliaConfig(autheliaLoc.content, lanRoot, publicDomain);
+    const noop = result.yaml === autheliaLoc.content;
+    steps.push({
+      kind: 'authelia-config',
+      node: autheliaLoc.node,
+      configPath: autheliaLoc.path,
+      changes: result.changes,
+      noop,
+    });
+  }
+
+  // 3) Cert requests collected alongside the dual-server_name loop;
+  //    append them after the Authelia step so the order is
+  //    NPM-rewrite → Authelia → cert. Cert issuance depends on the
+  //    proxy host serving on port 80 with the new server_name, which
+  //    only holds true once step 1 has run.
+  steps.push(...certSteps);
+
+  return { publicDomain, lanRoot, warnings, steps };
+}
+
+/**
+ * Plan + apply. Each step's failure lands as a `MigrationApplyError`
+ * but does not abort subsequent steps — the design's "idempotent +
+ * retryable, no rollback" contract means a re-run picks up exactly
+ * the steps that failed.
+ */
+export async function applyMigrationToPublic(
+  options: MigrationOptions,
+  depsOverride?: Partial<MigrationDeps>,
+): Promise<MigrationResult> {
+  const deps: MigrationDeps = {
+    npm: depsOverride?.npm ?? (await realNpmDeps()),
+    authelia: depsOverride?.authelia ?? (await realAutheliaDeps()),
+    health: depsOverride?.health ?? (await realHealthDeps()),
+  };
+
+  const plan = await planMigrationToPublic(options, deps);
+  if (options.dryRun) {
+    // Dry-run never touches anything; report all steps as ok.
+    return {
+      plan,
+      applied: false,
+      errors: [],
+      stepResults: plan.steps.map(() => ({ ok: true })),
+    };
+  }
+
+  const errors: MigrationApplyError[] = [];
+  const stepResults: { ok: boolean; error?: string }[] = [];
+
+  // Resolve NPM once for the apply pass — same target the plan saw.
+  const npmTarget = await deps.npm.resolveNpm();
+  const npmToken = npmTarget ? await deps.npm.getToken(npmTarget.apiUrl) : null;
+
+  for (const step of plan.steps) {
+    try {
+      if (step.kind === 'npm-dual-server-name') {
+        if (step.skipped) {
+          stepResults.push({ ok: true });
+          continue;
+        }
+        if (!npmTarget || !npmToken) {
+          throw new Error('NPM not reachable; cannot dual server_name.');
+        }
+        await deps.npm.updateHost(npmTarget.apiUrl, npmToken, step.hostId, {
+          domain_names: step.after,
+        });
+        stepResults.push({ ok: true });
+        continue;
+      }
+
+      if (step.kind === 'authelia-config') {
+        if (step.noop) {
+          stepResults.push({ ok: true });
+          continue;
+        }
+        // Re-read + re-rewrite right before write to avoid TOCTOU on a
+        // config someone edited between plan and apply.
+        const loc = await deps.authelia.locateConfig();
+        if (!loc) throw new Error('Authelia config disappeared between plan and apply.');
+        const result = rewriteAutheliaConfig(loc.content, plan.lanRoot, plan.publicDomain);
+        if (result.yaml !== loc.content) {
+          await deps.authelia.writeConfig(loc.node, loc.path, result.yaml);
+          await deps.authelia.restartAuth(loc.node);
+        }
+        stepResults.push({ ok: true });
+        continue;
+      }
+
+      if (step.kind === 'cert-request') {
+        if (step.skipped) {
+          stepResults.push({ ok: true });
+          continue;
+        }
+        if (!npmTarget || !npmToken) {
+          throw new Error('NPM not reachable; cannot request cert.');
+        }
+        const certId = await deps.npm.requestCert(npmTarget.apiUrl, npmToken, step.domain);
+        await deps.npm.bindCert(npmTarget.apiUrl, npmToken, step.hostId, certId);
+        stepResults.push({ ok: true });
+        continue;
+      }
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      const target = 'domain' in step ? step.domain : ('node' in step ? step.node : undefined);
+      errors.push({ step: step.kind, detail, target });
+      stepResults.push({ ok: false, error: detail });
+      logger.warn('migrate-to-public', `Step ${step.kind} failed: ${detail}`);
+    }
+  }
+
+  // Persist the new public domain + refresh proxy host entries so the
+  // letsdebug + domain checks pick up the new public-twin domains on
+  // their next tick. We do this even when some steps errored — the
+  // operator's recovery path is re-running the migration, which is
+  // idempotent.
+  try {
+    const config = await getConfig();
+    const existingHosts = config.reverseProxy?.hosts ?? [];
+    const newHostEntries = existingHosts.flatMap(entry => {
+      const twin = publicTwin(entry.domain, plan.lanRoot, plan.publicDomain);
+      if (!twin) return [entry];
+      const alreadyPresent = existingHosts.some(h => h.domain === twin);
+      if (alreadyPresent) return [entry];
+      return [
+        entry,
+        { ...entry, domain: twin, exposure: 'public' as const },
+      ];
+    });
+    await updateConfig({
+      reverseProxy: {
+        ...config.reverseProxy,
+        publicDomain: plan.publicDomain,
+        hosts: newHostEntries,
+      },
+    });
+    await deps.health.syncChecks();
+  } catch (e) {
+    const detail = `Post-apply config persistence failed: ${e instanceof Error ? e.message : String(e)}`;
+    errors.push({ step: 'authelia-config', detail });
+    logger.warn('migrate-to-public', detail);
+  }
+
+  return {
+    plan,
+    applied: true,
+    errors,
+    stepResults,
+  };
+}

--- a/src/lib/reverseProxy/migrateToPublic.ts
+++ b/src/lib/reverseProxy/migrateToPublic.ts
@@ -47,7 +47,7 @@ export interface MigrationOptions {
   dryRun: boolean;
 }
 
-export interface ProxyHostStep {
+interface ProxyHostStep {
   kind: 'npm-dual-server-name';
   hostId: number;
   domain: string;
@@ -59,7 +59,7 @@ export interface ProxyHostStep {
   skipped: boolean;
 }
 
-export interface AutheliaStep {
+interface AutheliaStep {
   kind: 'authelia-config';
   node: string;
   configPath: string;
@@ -69,7 +69,7 @@ export interface AutheliaStep {
   noop: boolean;
 }
 
-export interface CertRequestStep {
+interface CertRequestStep {
   kind: 'cert-request';
   hostId: number;
   domain: string;

--- a/src/lib/reverseProxy/preflight.ts
+++ b/src/lib/reverseProxy/preflight.ts
@@ -1,0 +1,176 @@
+/**
+ * Pre-flight gate for the LAN→Public migration (#265).
+ *
+ * The locked design requires three checks all green before the
+ * orchestrator is allowed to run:
+ *
+ *   1. DNS resolves the proposed public domain to the install's
+ *      public IP (letsdebug-style external probe).
+ *   2. TCP/80 reachable from the internet (same probe — letsdebug
+ *      surfaces both as distinct problem types).
+ *   3. Router port-forward exists for 80 + 443 (`fritzbox` health
+ *      check or, fallback, a TCP-connect from outside the LAN).
+ *
+ * Pure-ish: takes a domain, calls into the letsdebug client + the
+ * existing fritzbox health-check result, returns a single
+ * `{ ready, checks }` payload the API route returns verbatim. No I/O
+ * to the filesystem; the only network call is letsdebug.
+ *
+ * Kept independent of the orchestrator so the UI can poll this on a
+ * 5-s loop without spinning up the migration code path.
+ */
+
+import { runLetsdebugForDomain, type LetsdebugProblem } from '../letsdebug/client';
+import { HealthStore } from '../health/store';
+import { getConfig } from '../config';
+import { logger } from '../logger';
+
+export type CheckId = 'dns' | 'http01' | 'port-forward';
+export type CheckStatus = 'pass' | 'fail' | 'unknown';
+
+export interface PreflightCheck {
+  id: CheckId;
+  label: string;
+  status: CheckStatus;
+  detail: string;
+}
+
+export interface PreflightStatus {
+  publicDomain: string;
+  ready: boolean;
+  checks: PreflightCheck[];
+}
+
+export interface PreflightDeps {
+  runLetsdebug?: (domain: string) => Promise<{ problems: LetsdebugProblem[]; submissionUrl: string }>;
+  /**
+   * Read the most-recent fritzbox health-check result. Default impl
+   * looks at HealthStore for any check of `type: 'fritzbox'` and
+   * returns the latest result, or `null` if none exists.
+   */
+  getFritzboxLastResult?: () => Promise<{ status: 'ok' | 'fail'; message?: string } | null>;
+}
+
+/**
+ * DNS problems letsdebug returns when the domain doesn't resolve or
+ * resolves to the wrong host. Subset matched on `problem.name` —
+ * letsdebug's full taxonomy is public at
+ * https://github.com/letsdebug/letsdebug/blob/master/problem.go.
+ */
+const DNS_PROBLEM_NAMES = new Set([
+  'NoIPAddress',
+  'IPv6AAAANotResolving',
+  'CAAIssuanceNotAllowed',
+  'TXTRecordSizeLimitExceeded',
+]);
+
+/**
+ * Problems that indicate port-80 is not reachable for ACME HTTP-01.
+ * Includes the CA-side simulation failures since letsdebug's
+ * `IssueFromLetsEncrypt` problem is what surfaces a real LE staging
+ * failure when DNS + port 80 don't align.
+ */
+const HTTP01_PROBLEM_NAMES = new Set([
+  'ANotRoutable',
+  'BadRedirect',
+  'CloudflareSpecificDetection',
+  'PortNotOpen',
+  'WebserverNon200',
+  'IssueFromLetsEncrypt',
+]);
+
+function classifyLetsdebug(problems: LetsdebugProblem[]): { dns: CheckStatus; http01: CheckStatus; dnsDetail: string; http01Detail: string } {
+  const fatalDns = problems.filter(p => DNS_PROBLEM_NAMES.has(p.name ?? '') && (p.severity ?? '').toLowerCase() === 'fatal');
+  const fatalHttp = problems.filter(p => HTTP01_PROBLEM_NAMES.has(p.name ?? '') && (p.severity ?? '').toLowerCase() === 'fatal');
+
+  return {
+    dns: fatalDns.length === 0 ? 'pass' : 'fail',
+    http01: fatalHttp.length === 0 ? 'pass' : 'fail',
+    dnsDetail: fatalDns.length === 0
+      ? 'DNS resolves and points at this install.'
+      : fatalDns.map(p => `${p.name}: ${p.explanation ?? ''}`.trim()).join(' | '),
+    http01Detail: fatalHttp.length === 0
+      ? 'Port 80 reachable from the internet; ACME HTTP-01 can complete.'
+      : fatalHttp.map(p => `${p.name}: ${p.explanation ?? ''}`.trim()).join(' | '),
+  };
+}
+
+async function defaultFritzboxResult(): Promise<{ status: 'ok' | 'fail'; message?: string } | null> {
+  const checks = HealthStore.getChecks();
+  const fritz = checks.find(c => c.type === 'fritzbox');
+  if (!fritz) return null;
+  const last = HealthStore.getLastResult(fritz.id);
+  if (!last) return null;
+  return { status: last.status, message: last.message };
+}
+
+/**
+ * Run the three pre-flight checks. Always returns a status object — a
+ * single failed check makes `ready` false but the other two still
+ * report their last known state so the UI can show partial progress.
+ */
+export async function getPreflightStatus(
+  publicDomain: string,
+  deps: PreflightDeps = {},
+): Promise<PreflightStatus> {
+  const trimmed = publicDomain.trim();
+  const runLetsdebug = deps.runLetsdebug ?? runLetsdebugForDomain;
+  const getFritz = deps.getFritzboxLastResult ?? defaultFritzboxResult;
+
+  const checks: PreflightCheck[] = [
+    { id: 'dns', label: `DNS for ${trimmed}`, status: 'unknown', detail: 'Pending.' },
+    { id: 'http01', label: 'Port 80 reachable from the internet', status: 'unknown', detail: 'Pending.' },
+    { id: 'port-forward', label: 'Router port-forward for 80 + 443', status: 'unknown', detail: 'Pending.' },
+  ];
+
+  // letsdebug covers checks 1 + 2.
+  try {
+    const result = await runLetsdebug(trimmed);
+    const { dns, http01, dnsDetail, http01Detail } = classifyLetsdebug(result.problems);
+    checks[0].status = dns;
+    checks[0].detail = dnsDetail;
+    checks[1].status = http01;
+    checks[1].detail = http01Detail;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.warn('preflight', `letsdebug call failed: ${msg}`);
+    checks[0].detail = `letsdebug check failed: ${msg}`;
+    checks[1].detail = checks[0].detail;
+  }
+
+  // Port-forward — read latest fritzbox health-check result if present.
+  try {
+    const fritz = await getFritz();
+    if (!fritz) {
+      // No fritzbox check configured. Per the locked design's fallback,
+      // letsdebug success implies ports work end-to-end, so we report
+      // 'unknown' rather than blocking — the UI can let the operator
+      // override with a "I know my port-forward is set up" toggle in
+      // PR-2 if needed.
+      const config = await getConfig();
+      const hasGateway = !!config.gateway?.type;
+      checks[2].status = hasGateway ? 'unknown' : 'unknown';
+      checks[2].detail = hasGateway
+        ? 'No FritzBox health-check result yet — run it from the diagnose page or wait for the next scheduled tick.'
+        : 'No router gateway configured; relying on the letsdebug result above to confirm ports 80/443 reach the internet.';
+    } else if (fritz.status === 'ok') {
+      checks[2].status = 'pass';
+      checks[2].detail = 'Router reports the expected port-forward rules for 80/443.';
+    } else {
+      checks[2].status = 'fail';
+      checks[2].detail = fritz.message ?? 'FritzBox health check reports a port-forward problem.';
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    checks[2].detail = `FritzBox check read failed: ${msg}`;
+  }
+
+  // Ready iff DNS + http01 are green and the port-forward check is not
+  // an outright fail (unknown is acceptable when the letsdebug result
+  // already confirms internet-side reachability).
+  const ready = checks[0].status === 'pass'
+    && checks[1].status === 'pass'
+    && checks[2].status !== 'fail';
+
+  return { publicDomain: trimmed, ready, checks };
+}

--- a/src/lib/reverseProxy/preflight.ts
+++ b/src/lib/reverseProxy/preflight.ts
@@ -25,8 +25,8 @@ import { HealthStore } from '../health/store';
 import { getConfig } from '../config';
 import { logger } from '../logger';
 
-export type CheckId = 'dns' | 'http01' | 'port-forward';
-export type CheckStatus = 'pass' | 'fail' | 'unknown';
+type CheckId = 'dns' | 'http01' | 'port-forward';
+type CheckStatus = 'pass' | 'fail' | 'unknown';
 
 export interface PreflightCheck {
   id: CheckId;

--- a/tests/backend/autheliaRewrite.test.ts
+++ b/tests/backend/autheliaRewrite.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { rewriteAutheliaConfig } from '@/lib/reverseProxy/autheliaRewrite';
+
+/**
+ * Pure-yaml tests for the Authelia config rewrite step of the
+ * LAN→Public migration (#265). Exercises:
+ *   - hard cutover of session.cookies[0].domain + authelia_url
+ *   - additive twin of access_control rule domains (string and list)
+ *   - additive twin of OIDC client redirect_uris
+ *   - idempotence: a second rewrite on the output is a no-op
+ *
+ * Sample yaml mirrors the structure templated by
+ * `templates/auth/configuration.yml.mustache` after install in lan mode
+ * (i.e. PUBLIC_DOMAIN was rendered with the lan root).
+ */
+
+const LAN_ROOT = 'home.arpa';
+const PUBLIC_DOMAIN = 'dopp.cloud';
+
+const SAMPLE_LAN_CONFIG = `
+session:
+  secret: 's3cret'
+  cookies:
+    - domain: 'home.arpa'
+      authelia_url: 'https://auth.home.arpa'
+
+access_control:
+  default_policy: deny
+  rules:
+    - domain: 'auth.home.arpa'
+      policy: bypass
+    - domain:
+        - 'admin.home.arpa'
+        - 'nginx.home.arpa'
+      policy: two_factor
+      subject:
+        - 'group:admins'
+    - domain: '*.home.arpa'
+      policy: one_factor
+      subject:
+        - 'group:family'
+        - 'group:admins'
+
+identity_providers:
+  oidc:
+    hmac_secret: 'h'
+    clients:
+      - client_id: 'servicebay'
+        client_name: 'ServiceBay'
+        client_secret: 'p'
+        redirect_uris:
+          - 'https://admin.home.arpa/api/auth/oidc/callback'
+        scopes:
+          - 'openid'
+      - client_id: 'vaultwarden'
+        client_name: 'Vaultwarden'
+        client_secret: 'p'
+        redirect_uris:
+          - 'https://vault.home.arpa/identity/connect/oidc-signin'
+          - 'app.bitwarden:/oauth-callback'
+        scopes:
+          - 'openid'
+`;
+
+describe('rewriteAutheliaConfig', () => {
+  it('flips the cookie domain + authelia_url to the public root', () => {
+    const out = rewriteAutheliaConfig(SAMPLE_LAN_CONFIG, LAN_ROOT, PUBLIC_DOMAIN);
+    const parsed = yaml.load(out.yaml) as { session: { cookies: { domain: string; authelia_url: string }[] } };
+    expect(parsed.session.cookies[0].domain).toBe(PUBLIC_DOMAIN);
+    // URL.toString() always emits a trailing slash for host-only URLs;
+    // this is semantically equivalent for Authelia's authelia_url, so
+    // accept either form.
+    expect(parsed.session.cookies[0].authelia_url).toMatch(/^https:\/\/auth\.dopp\.cloud\/?$/);
+    expect(out.changes.cookieDomain).toEqual({ from: 'home.arpa', to: PUBLIC_DOMAIN });
+    expect(out.changes.cookieAutheliaUrl.from).toBe('https://auth.home.arpa');
+    expect(out.changes.cookieAutheliaUrl.to).toMatch(/^https:\/\/auth\.dopp\.cloud\/?$/);
+  });
+
+  it('twins string-form access_control rule domains into a list', () => {
+    const out = rewriteAutheliaConfig(SAMPLE_LAN_CONFIG, LAN_ROOT, PUBLIC_DOMAIN);
+    const parsed = yaml.load(out.yaml) as { access_control: { rules: { domain: unknown }[] } };
+
+    // 'auth.home.arpa' (string) → ['auth.home.arpa', 'auth.dopp.cloud']
+    expect(parsed.access_control.rules[0].domain).toEqual([
+      'auth.home.arpa',
+      'auth.dopp.cloud',
+    ]);
+
+    // '*.home.arpa' (string) → ['*.home.arpa', '*.dopp.cloud']
+    expect(parsed.access_control.rules[2].domain).toEqual([
+      '*.home.arpa',
+      '*.dopp.cloud',
+    ]);
+  });
+
+  it('twins list-form access_control rule domains, preserving order', () => {
+    const out = rewriteAutheliaConfig(SAMPLE_LAN_CONFIG, LAN_ROOT, PUBLIC_DOMAIN);
+    const parsed = yaml.load(out.yaml) as { access_control: { rules: { domain: unknown }[] } };
+
+    expect(parsed.access_control.rules[1].domain).toEqual([
+      'admin.home.arpa',
+      'admin.dopp.cloud',
+      'nginx.home.arpa',
+      'nginx.dopp.cloud',
+    ]);
+  });
+
+  it('appends public-domain twins to OIDC redirect_uris without disturbing third-party URIs', () => {
+    const out = rewriteAutheliaConfig(SAMPLE_LAN_CONFIG, LAN_ROOT, PUBLIC_DOMAIN);
+    const parsed = yaml.load(out.yaml) as { identity_providers: { oidc: { clients: { client_id: string; redirect_uris: string[] }[] } } };
+    const sb = parsed.identity_providers.oidc.clients.find(c => c.client_id === 'servicebay')!;
+    const vw = parsed.identity_providers.oidc.clients.find(c => c.client_id === 'vaultwarden')!;
+
+    expect(sb.redirect_uris).toEqual([
+      'https://admin.home.arpa/api/auth/oidc/callback',
+      'https://admin.dopp.cloud/api/auth/oidc/callback',
+    ]);
+
+    // Custom-scheme deep links are left alone.
+    expect(vw.redirect_uris).toEqual([
+      'https://vault.home.arpa/identity/connect/oidc-signin',
+      'app.bitwarden:/oauth-callback',
+      'https://vault.dopp.cloud/identity/connect/oidc-signin',
+    ]);
+  });
+
+  it('is idempotent — a second rewrite on the output yields the same yaml', () => {
+    const first = rewriteAutheliaConfig(SAMPLE_LAN_CONFIG, LAN_ROOT, PUBLIC_DOMAIN);
+    const second = rewriteAutheliaConfig(first.yaml, LAN_ROOT, PUBLIC_DOMAIN);
+    expect(second.yaml).toBe(first.yaml);
+    // Cookie change re-reports because the editor doesn't know the prior value
+    // was already migrated; the additive sections must report empty deltas.
+    expect(second.changes.accessControlRuleDomains).toEqual([]);
+    expect(second.changes.oidcRedirectUriAdditions).toEqual([]);
+  });
+
+  it('preserves the original yaml when there is nothing to migrate', () => {
+    const inert = `
+unrelated:
+  key: 'value'
+`;
+    const out = rewriteAutheliaConfig(inert, LAN_ROOT, PUBLIC_DOMAIN);
+    // No session block → no cookie change; no rules / clients → no twin work.
+    expect(out.changes.cookieDomain).toEqual({ from: null, to: PUBLIC_DOMAIN });
+    expect(out.changes.accessControlRuleDomains).toEqual([]);
+    expect(out.changes.oidcRedirectUriAdditions).toEqual([]);
+  });
+});

--- a/tests/backend/migrateToPublic.test.ts
+++ b/tests/backend/migrateToPublic.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import yaml from 'js-yaml';
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+vi.mock('@/lib/store/twin', () => ({
+  DigitalTwinStore: { getInstance: () => ({ nodes: {} }) },
+}));
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: {
+    listServices: vi.fn(),
+    getServiceFiles: vi.fn(),
+    restartService: vi.fn(),
+  },
+}));
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn() },
+}));
+vi.mock('@/lib/health/domainChecks', () => ({ syncDomainChecks: vi.fn() }));
+vi.mock('@/lib/health/letsdebugChecks', () => ({ syncLetsdebugChecks: vi.fn() }));
+
+import { getConfig, updateConfig } from '@/lib/config';
+import {
+  applyMigrationToPublic,
+  planMigrationToPublic,
+  validatePublicDomain,
+  type MigrationDeps,
+} from '@/lib/reverseProxy/migrateToPublic';
+
+/**
+ * End-to-end tests for the LAN→Public migration orchestrator. We pass
+ * an in-memory `MigrationDeps` so the real NPM + Authelia + health
+ * paths stay untouched — keeps the test surface focused on the
+ * orchestration logic (plan ordering, step skipping, idempotence,
+ * error containment).
+ */
+
+const LAN_ROOT = 'home.arpa';
+const PUBLIC_DOMAIN = 'dopp.cloud';
+
+const SAMPLE_AUTHELIA = `
+session:
+  secret: 's3cret'
+  cookies:
+    - domain: 'home.arpa'
+      authelia_url: 'https://auth.home.arpa'
+identity_providers:
+  oidc:
+    clients:
+      - client_id: 'servicebay'
+        redirect_uris:
+          - 'https://admin.home.arpa/api/auth/oidc/callback'
+`;
+
+interface FakeHost {
+  id: number;
+  domain_names: string[];
+  certificate_id?: number;
+}
+
+function makeDeps(opts: {
+  hosts?: FakeHost[];
+  autheliaContent?: string | null;
+  npmAvailable?: boolean;
+  failApplyHost?: number;
+  failApplyAuthelia?: boolean;
+  failApplyCertFor?: string;
+}): { deps: MigrationDeps; spies: { updateHost: ReturnType<typeof vi.fn>; writeConfig: ReturnType<typeof vi.fn>; requestCert: ReturnType<typeof vi.fn>; bindCert: ReturnType<typeof vi.fn>; restartAuth: ReturnType<typeof vi.fn>; syncChecks: ReturnType<typeof vi.fn> } } {
+  const npmTarget = opts.npmAvailable === false
+    ? null
+    : { apiUrl: 'http://npm:81', nodeName: 'Local', nodeIp: '10.0.0.1' };
+  const hosts = (opts.hosts ?? []).map(h => ({ ...h, domain_names: h.domain_names.slice() }));
+
+  const updateHost = vi.fn(async (_url: string, _t: string, id: number, patch: { domain_names?: string[]; certificate_id?: number }) => {
+    if (opts.failApplyHost === id && patch.domain_names) throw new Error(`forced update-host failure for ${id}`);
+    const host = hosts.find(h => h.id === id);
+    if (!host) throw new Error(`host ${id} not found`);
+    if (patch.domain_names) host.domain_names = patch.domain_names.slice();
+    if (typeof patch.certificate_id === 'number') host.certificate_id = patch.certificate_id;
+  });
+  const writeConfig = vi.fn(async (_node: string, _path: string, _content: string) => undefined);
+  const requestCert = vi.fn(async (_url: string, _t: string, domain: string) => {
+    if (opts.failApplyCertFor === domain) throw new Error(`forced cert-request failure for ${domain}`);
+    return 999 + Math.floor(Math.random() * 100);
+  });
+  const bindCert = vi.fn(async (_url: string, _t: string, hostId: number, certId: number) => {
+    const host = hosts.find(h => h.id === hostId);
+    if (host) host.certificate_id = certId;
+  });
+  const restartAuth = vi.fn(async () => {
+    if (opts.failApplyAuthelia) throw new Error('forced restart failure');
+  });
+  const syncChecks = vi.fn(async () => undefined);
+
+  return {
+    deps: {
+      npm: {
+        resolveNpm: async () => npmTarget,
+        getToken: async () => (npmTarget ? 'tok' : null),
+        listHosts: async () => hosts,
+        updateHost,
+        requestCert,
+        bindCert,
+      },
+      authelia: {
+        locateConfig: async () => {
+          if (opts.autheliaContent === null) return null;
+          return {
+            node: 'Local',
+            path: '/etc/authelia/configuration.yml',
+            content: opts.autheliaContent ?? SAMPLE_AUTHELIA,
+          };
+        },
+        writeConfig: async (node, path, content) => {
+          await writeConfig(node, path, content);
+          if (opts.failApplyAuthelia) throw new Error('forced write failure');
+        },
+        restartAuth,
+      },
+      health: { syncChecks },
+    },
+    spies: { updateHost, writeConfig, requestCert, bindCert, restartAuth, syncChecks },
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getConfig).mockResolvedValue({
+    reverseProxy: { lanDomain: LAN_ROOT, hosts: [] },
+    autoUpdate: { enabled: false, schedule: '' },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(updateConfig).mockResolvedValue({} as any);
+});
+
+describe('validatePublicDomain', () => {
+  it('accepts a well-formed hostname', () => {
+    expect(validatePublicDomain('example.com')).toBeNull();
+    expect(validatePublicDomain('sub.example.co.uk')).toBeNull();
+  });
+
+  it('rejects non-strings, empty strings, and shapes that aren\'t hostnames', () => {
+    expect(validatePublicDomain(undefined)).toMatch(/string/);
+    expect(validatePublicDomain('')).toMatch(/required/);
+    expect(validatePublicDomain('not a domain')).toMatch(/hostname/);
+    expect(validatePublicDomain('http://example.com')).toMatch(/hostname/);
+  });
+});
+
+describe('planMigrationToPublic', () => {
+  it('emits a dual-server_name step + cert-request step per lan-rooted host', async () => {
+    const { deps } = makeDeps({
+      hosts: [
+        { id: 1, domain_names: ['vault.home.arpa'] },
+        { id: 2, domain_names: ['immich.home.arpa'] },
+      ],
+    });
+    const plan = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    const dualSteps = plan.steps.filter(s => s.kind === 'npm-dual-server-name');
+    const certSteps = plan.steps.filter(s => s.kind === 'cert-request');
+
+    expect(dualSteps).toHaveLength(2);
+    expect(certSteps).toHaveLength(2);
+
+    expect((dualSteps[0] as { after: string[] }).after).toEqual(['vault.home.arpa', 'vault.dopp.cloud']);
+    expect((certSteps[0] as { domain: string }).domain).toBe('vault.dopp.cloud');
+  });
+
+  it('marks dual-server_name as skipped when the host already carries the public twin', async () => {
+    const { deps } = makeDeps({
+      hosts: [{ id: 1, domain_names: ['vault.home.arpa', 'vault.dopp.cloud'] }],
+    });
+    const plan = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    const dual = plan.steps.find(s => s.kind === 'npm-dual-server-name')!;
+    expect((dual as { skipped: boolean }).skipped).toBe(true);
+  });
+
+  it('marks cert-request as skipped when the host already has a non-zero certificate_id', async () => {
+    const { deps } = makeDeps({
+      hosts: [{ id: 1, domain_names: ['vault.home.arpa'], certificate_id: 42 }],
+    });
+    const plan = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    const cert = plan.steps.find(s => s.kind === 'cert-request')!;
+    expect((cert as { skipped: boolean; skipReason?: string }).skipped).toBe(true);
+    expect((cert as { skipReason?: string }).skipReason).toMatch(/certificate_id=42/);
+  });
+
+  it('emits an authelia-config step that captures the cookie + access-control + oidc changes', async () => {
+    const { deps } = makeDeps({ hosts: [] });
+    const plan = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    const step = plan.steps.find(s => s.kind === 'authelia-config')!;
+    const cast = step as { changes: { cookieDomain: { from: string | null; to: string }; oidcRedirectUriAdditions: { clientId: string; added: string[] }[] }; noop: boolean };
+    expect(cast.changes.cookieDomain).toEqual({ from: 'home.arpa', to: PUBLIC_DOMAIN });
+    expect(cast.changes.oidcRedirectUriAdditions[0].added).toEqual(['https://admin.dopp.cloud/api/auth/oidc/callback']);
+    expect(cast.noop).toBe(false);
+  });
+
+  it('surfaces a warning + skips proxy steps when NPM is unavailable', async () => {
+    const { deps } = makeDeps({ npmAvailable: false });
+    const plan = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    expect(plan.warnings.some(w => /Nginx Proxy Manager.*not deployed/i.test(w))).toBe(true);
+    expect(plan.steps.find(s => s.kind === 'npm-dual-server-name')).toBeUndefined();
+  });
+
+  it('surfaces a warning + skips authelia step when the auth pod is absent', async () => {
+    const { deps } = makeDeps({ hosts: [], autheliaContent: null });
+    const plan = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    expect(plan.warnings.some(w => /auth pod/i.test(w))).toBe(true);
+    expect(plan.steps.find(s => s.kind === 'authelia-config')).toBeUndefined();
+  });
+
+  it('is deterministic across re-runs against the same input', async () => {
+    const { deps: d1 } = makeDeps({ hosts: [{ id: 1, domain_names: ['vault.home.arpa'] }] });
+    const { deps: d2 } = makeDeps({ hosts: [{ id: 1, domain_names: ['vault.home.arpa'] }] });
+    const a = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, d1);
+    const b = await planMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, d2);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});
+
+describe('applyMigrationToPublic', () => {
+  it('dry-run never invokes any write hook', async () => {
+    const { deps, spies } = makeDeps({ hosts: [{ id: 1, domain_names: ['vault.home.arpa'] }] });
+    const r = await applyMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: true }, deps);
+    expect(r.applied).toBe(false);
+    expect(spies.updateHost).not.toHaveBeenCalled();
+    expect(spies.writeConfig).not.toHaveBeenCalled();
+    expect(spies.requestCert).not.toHaveBeenCalled();
+    expect(spies.restartAuth).not.toHaveBeenCalled();
+    // All step results pass through ok.
+    expect(r.stepResults.every(s => s.ok)).toBe(true);
+  });
+
+  it('apply: dual-server_name PUT, Authelia write+restart, cert request+bind, config persist + health resync', async () => {
+    const { deps, spies } = makeDeps({ hosts: [{ id: 1, domain_names: ['vault.home.arpa'] }] });
+    const r = await applyMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: false }, deps);
+    expect(r.applied).toBe(true);
+    expect(r.errors).toEqual([]);
+
+    expect(spies.updateHost).toHaveBeenCalledWith('http://npm:81', 'tok', 1, { domain_names: ['vault.home.arpa', 'vault.dopp.cloud'] });
+    expect(spies.writeConfig).toHaveBeenCalledTimes(1);
+    expect(spies.restartAuth).toHaveBeenCalledTimes(1);
+    expect(spies.requestCert).toHaveBeenCalledWith('http://npm:81', 'tok', 'vault.dopp.cloud');
+    expect(spies.bindCert).toHaveBeenCalledTimes(1);
+    expect(spies.syncChecks).toHaveBeenCalledTimes(1);
+
+    // Authelia content actually flips the cookie domain.
+    const written = vi.mocked(spies.writeConfig).mock.calls[0][2];
+    const parsed = yaml.load(written) as { session: { cookies: { domain: string }[] } };
+    expect(parsed.session.cookies[0].domain).toBe(PUBLIC_DOMAIN);
+
+    // Config is persisted with the new publicDomain set.
+    expect(updateConfig).toHaveBeenCalled();
+    const persisted = vi.mocked(updateConfig).mock.calls[0][0] as { reverseProxy: { publicDomain: string } };
+    expect(persisted.reverseProxy.publicDomain).toBe(PUBLIC_DOMAIN);
+  });
+
+  it('isolates a single step failure — other steps still run and the failure lands in errors[]', async () => {
+    const { deps, spies } = makeDeps({
+      hosts: [
+        { id: 1, domain_names: ['vault.home.arpa'] },
+        { id: 2, domain_names: ['immich.home.arpa'] },
+      ],
+      failApplyHost: 1,
+    });
+    const r = await applyMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: false }, deps);
+    expect(r.applied).toBe(true);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0].step).toBe('npm-dual-server-name');
+    expect(r.errors[0].target).toBe('vault.home.arpa');
+    // Host 2 still got dual-server_named.
+    expect(spies.updateHost).toHaveBeenCalledWith('http://npm:81', 'tok', 2, { domain_names: ['immich.home.arpa', 'immich.dopp.cloud'] });
+    // Authelia + cert + health steps still ran.
+    expect(spies.restartAuth).toHaveBeenCalled();
+    expect(spies.syncChecks).toHaveBeenCalled();
+  });
+
+  it('re-runs are idempotent — apply against already-migrated hosts is a no-op for those steps', async () => {
+    const { deps, spies } = makeDeps({
+      hosts: [{ id: 1, domain_names: ['vault.home.arpa', 'vault.dopp.cloud'], certificate_id: 7 }],
+    });
+    const r = await applyMigrationToPublic({ publicDomain: PUBLIC_DOMAIN, dryRun: false }, deps);
+    expect(r.errors).toEqual([]);
+    // Dual-server_name skipped → updateHost(domain_names) not invoked.
+    const writeCalls = spies.updateHost.mock.calls.filter(c => 'domain_names' in (c[3] as Record<string, unknown>));
+    expect(writeCalls).toHaveLength(0);
+    // Cert skipped (has certificate_id).
+    expect(spies.requestCert).not.toHaveBeenCalled();
+    expect(spies.bindCert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/backend/preflight.test.ts
+++ b/tests/backend/preflight.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: { getChecks: vi.fn(), getLastResult: vi.fn() },
+}));
+vi.mock('@/lib/letsdebug/client', () => ({ runLetsdebugForDomain: vi.fn() }));
+
+import { getConfig } from '@/lib/config';
+import { HealthStore } from '@/lib/health/store';
+import { getPreflightStatus } from '@/lib/reverseProxy/preflight';
+
+beforeEach(() => {
+  vi.mocked(getConfig).mockResolvedValue({
+    autoUpdate: { enabled: false, schedule: '' },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  vi.mocked(HealthStore.getChecks).mockReturnValue([]);
+  vi.mocked(HealthStore.getLastResult).mockReturnValue(null);
+});
+
+const okLetsdebug = vi.fn(async () => ({ problems: [], submissionUrl: 'https://letsdebug.net/dopp.cloud/1' }));
+const dnsFailLetsdebug = vi.fn(async () => ({
+  problems: [{ name: 'NoIPAddress', severity: 'Fatal', explanation: 'A record missing' }],
+  submissionUrl: 'https://letsdebug.net/x/2',
+}));
+const http01FailLetsdebug = vi.fn(async () => ({
+  problems: [{ name: 'PortNotOpen', severity: 'Fatal', explanation: 'port 80 closed' }],
+  submissionUrl: 'https://letsdebug.net/x/3',
+}));
+
+describe('getPreflightStatus', () => {
+  it('reports ready when letsdebug returns no problems and port-forward is unknown without gateway', async () => {
+    const r = await getPreflightStatus('dopp.cloud', {
+      runLetsdebug: okLetsdebug,
+      getFritzboxLastResult: async () => null,
+    });
+    expect(r.ready).toBe(true);
+    expect(r.checks.map(c => c.status)).toEqual(['pass', 'pass', 'unknown']);
+  });
+
+  it('reports not-ready when DNS is fatal', async () => {
+    const r = await getPreflightStatus('dopp.cloud', {
+      runLetsdebug: dnsFailLetsdebug,
+      getFritzboxLastResult: async () => null,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.checks[0].status).toBe('fail');
+    expect(r.checks[0].detail).toMatch(/NoIPAddress/);
+  });
+
+  it('reports not-ready when HTTP-01 is fatal', async () => {
+    const r = await getPreflightStatus('dopp.cloud', {
+      runLetsdebug: http01FailLetsdebug,
+      getFritzboxLastResult: async () => null,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.checks[1].status).toBe('fail');
+    expect(r.checks[1].detail).toMatch(/PortNotOpen/);
+  });
+
+  it('reports not-ready when fritzbox returns a fail result', async () => {
+    const r = await getPreflightStatus('dopp.cloud', {
+      runLetsdebug: okLetsdebug,
+      getFritzboxLastResult: async () => ({ status: 'fail', message: 'no port-forward for 443' }),
+    });
+    expect(r.ready).toBe(false);
+    expect(r.checks[2].status).toBe('fail');
+    expect(r.checks[2].detail).toMatch(/443/);
+  });
+
+  it('treats a letsdebug exception as not-ready without crashing', async () => {
+    const r = await getPreflightStatus('dopp.cloud', {
+      runLetsdebug: vi.fn(async () => { throw new Error('rate-limited'); }),
+      getFritzboxLastResult: async () => null,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.checks[0].detail).toMatch(/rate-limited/);
+  });
+});


### PR DESCRIPTION
First of the two PRs locked in on the #265 design comment ([here](https://github.com/mdopp/servicebay/issues/265#issuecomment-4454635483)). Backend-only — the UI lands in PR-2.

## Summary

- **`autheliaRewrite.ts`** — pure yaml→yaml editor. Hard-cutover of `session.cookies[0].domain` + `authelia_url`; additive twin of `access_control.rules[*].domain` (handles both string and list forms); additive twin of OIDC `redirect_uris`. Idempotent — a second pass on the output is a no-op.
- **`migrateToPublic.ts`** — orchestrator with `planMigrationToPublic` (deterministic dry-run) + `applyMigrationToPublic`. Per-step failures land in `errors[]` and never abort subsequent steps, per the locked "idempotent + retryable, no rollback" decision. DI shape lets tests pass an in-memory NPM/Authelia/health backend.
- **`preflight.ts`** — three-check gate (DNS, HTTP-01 via letsdebug, port-forward via the fritzbox health check). Returns `{ ready, checks[] }` the UI can render verbatim.
- **Routes** — `POST /api/system/reverse-proxy/migrate-to-public` and `GET /api/system/reverse-proxy/preflight`. Thin handlers around the lib; both auth-gated via `requireSession`.

No feature flag — endpoint requires a session and no UI calls it until PR-2, so a flag-then-delete would be pure churn.

## Test plan

- [x] `tests/backend/autheliaRewrite.test.ts` (6 tests) — yaml shape guarantees + idempotence
- [x] `tests/backend/migrateToPublic.test.ts` (13 tests) — plan ordering, skip flags, apply happy/error paths, re-run idempotence
- [x] `tests/backend/preflight.test.ts` (5 tests) — pass/fail classification per check
- [x] Full suite — all 757 pre-existing tests still pass
- [x] `tsc --noEmit` clean
- [ ] Manual `curl` smoke against a staging install with `{ dryRun: true }` once one is available
- [ ] PR-2 wires the UI; full end-to-end is exercised there

## Follow-up

- PR-2: UI (pre-flight panel + migration form + status), per the locked plan.
- Out of scope (deliberately): `migration_in_progress` probe, "remove lan URLs" cleanup action — both listed in the design as separate follow-ups.

Refs #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)