### PR TITLE
feat(sso): AdGuard + Syncthing admin UIs behind Authelia forward-auth (closes #495)

### DIFF
--- a/src/lib/stackInstall/forwardAuth.ts
+++ b/src/lib/stackInstall/forwardAuth.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared NPM `advanced_config` block for services that gate their UI
+ * behind Authelia via the `forward_auth` pattern (#495).
+ *
+ * Three+ services use the same nginx snippet now (FileBrowser already,
+ * AdGuard + Syncthing being wired). Rather than copy-paste the same
+ * 600-character block into every `variables.json`, templates set
+ * `advanced_config: "__authelia_forward_auth__"` (the
+ * `AUTHELIA_FORWARD_AUTH_SENTINEL` value below) and the install runner
+ * expands it via `expandForwardAuthSentinel` right before Mustache
+ * renders cross-template placeholders like `{{AUTHELIA_PORT}}`.
+ *
+ * Adding `__authelia_forward_auth__:` followed by extra nginx
+ * directives lets a template tack service-specific config (e.g.
+ * upload size limits) onto the end. Everything after the sentinel
+ * line is appended verbatim to the rendered snippet.
+ */
+
+export const AUTHELIA_FORWARD_AUTH_SENTINEL = '__authelia_forward_auth__';
+
+/**
+ * The actual nginx config block. References `{{PUBLIC_DOMAIN}}` and
+ * `{{AUTHELIA_PORT}}` so it survives the Mustache pass that turns
+ * cross-template placeholders into concrete values at install time.
+ *
+ * Kept identical to the FileBrowser-shipped variant so the helper can
+ * be back-substituted into `templates/file-share/variables.json`
+ * without a behaviour change.
+ */
+export const AUTHELIA_FORWARD_AUTH_SNIPPET = [
+  'auth_request /authelia;',
+  'auth_request_set $target_url $scheme://$http_host$request_uri;',
+  'auth_request_set $user $upstream_http_remote_user;',
+  'auth_request_set $groups $upstream_http_remote_groups;',
+  'auth_request_set $name $upstream_http_remote_name;',
+  'auth_request_set $email $upstream_http_remote_email;',
+  'proxy_set_header Remote-User $user;',
+  'proxy_set_header Remote-Groups $groups;',
+  'proxy_set_header Remote-Name $name;',
+  'proxy_set_header Remote-Email $email;',
+  'error_page 401 =302 https://auth.{{PUBLIC_DOMAIN}}/?rd=$target_url;',
+  '',
+  'location = /authelia {',
+  '    internal;',
+  '    proxy_pass http://127.0.0.1:{{AUTHELIA_PORT}}/api/verify;',
+  '    proxy_pass_request_body off;',
+  '    proxy_set_header Content-Length "";',
+  '    proxy_set_header X-Original-URL $scheme://$http_host$request_uri;',
+  '    proxy_set_header X-Real-IP $remote_addr;',
+  '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
+  '    proxy_set_header X-Forwarded-Proto $scheme;',
+  '}',
+].join('\n');
+
+/**
+ * Expand the sentinel value (if present) to the full snippet. Anything
+ * other than the sentinel is returned unchanged so templates that
+ * still ship the verbatim block (or use a different `advanced_config`
+ * entirely) keep working.
+ *
+ * A template can append extra nginx directives by writing
+ * `__authelia_forward_auth__\n<extra config>` — anything past the
+ * sentinel line is glued onto the end of the rendered snippet.
+ */
+export function expandForwardAuthSentinel(advancedConfig: string | undefined): string | undefined {
+  if (!advancedConfig) return advancedConfig;
+  if (advancedConfig === AUTHELIA_FORWARD_AUTH_SENTINEL) {
+    return AUTHELIA_FORWARD_AUTH_SNIPPET;
+  }
+  // Prefix form: `__authelia_forward_auth__\n<extras>`.
+  if (advancedConfig.startsWith(`${AUTHELIA_FORWARD_AUTH_SENTINEL}\n`)) {
+    const extras = advancedConfig.slice(AUTHELIA_FORWARD_AUTH_SENTINEL.length + 1);
+    return `${AUTHELIA_FORWARD_AUTH_SNIPPET}\n${extras}`;
+  }
+  return advancedConfig;
+}

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -27,6 +27,7 @@
 import Mustache from 'mustache';
 import type { VariableMeta } from '@/lib/registry';
 import { buildCredentialsManifest, formatCredentialsBanner, type Credential } from './credentialsManifest';
+import { expandForwardAuthSentinel } from './forwardAuth';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
 
 /** Loopback fetch helper. The post-install pipeline runs server-side
@@ -107,12 +108,17 @@ function renderProxyConfig(
 ): VariableMeta['proxyConfig'] | undefined {
   if (!proxyConfig) return proxyConfig;
   if (!proxyConfig.advanced_config) return proxyConfig;
+  // Expand the `__authelia_forward_auth__` sentinel into the shared
+  // nginx snippet before the Mustache pass so the snippet's own
+  // {{PUBLIC_DOMAIN}} / {{AUTHELIA_PORT}} placeholders still get
+  // substituted from `view`.
+  const expanded = expandForwardAuthSentinel(proxyConfig.advanced_config) ?? proxyConfig.advanced_config;
   const savedEscape = Mustache.escape;
   Mustache.escape = (text: string) => text;
   try {
     return {
       ...proxyConfig,
-      advanced_config: Mustache.render(proxyConfig.advanced_config, view),
+      advanced_config: Mustache.render(expanded, view),
     };
   } finally {
     Mustache.escape = savedEscape;

--- a/templates/adguard/AdGuardHome.yaml.mustache
+++ b/templates/adguard/AdGuardHome.yaml.mustache
@@ -2,7 +2,14 @@ http:
   pprof:
     port: 6060
     enabled: false
-  address: 0.0.0.0:{{ADGUARD_ADMIN_PORT}}
+  # Bind on loopback only. The admin UI is reachable to LAN clients
+  # via `https://<ADGUARD_SUBDOMAIN>.<PUBLIC_DOMAIN>`, which NPM
+  # gates with Authelia forward-auth. A 0.0.0.0 bind would let any
+  # LAN device hit `:{{ADGUARD_ADMIN_PORT}}` directly and skip SSO.
+  # If Authelia is down, the operator can still reach AdGuard from
+  # the host itself (SSH tunnel or `curl localhost:{{ADGUARD_ADMIN_PORT}}`)
+  # using the local AdGuard credentials as a recovery backstop.
+  address: 127.0.0.1:{{ADGUARD_ADMIN_PORT}}
   session_ttl: 720h
 users:
   - name: {{ADGUARD_ADMIN_USER}}

--- a/templates/adguard/CHANGELOG.md
+++ b/templates/adguard/CHANGELOG.md
@@ -1,0 +1,28 @@
+# AdGuard Home — template changelog
+
+Tracks breaking changes to the `adguard` template's pod structure /
+variable shape. Each H2 corresponds to a value of
+`servicebay.schema-version` in `template.yml`.
+
+## v2 (breaking)
+
+**Admin UI behind Authelia forward-auth.**
+
+The AdGuard admin UI used to bind on `0.0.0.0:{{ADGUARD_ADMIN_PORT}}`
+with only AdGuard's local username/password as the gate. It now binds
+on `127.0.0.1:{{ADGUARD_ADMIN_PORT}}` and is reachable to LAN devices
+only via `https://<ADGUARD_SUBDOMAIN>.<PUBLIC_DOMAIN>`, which NPM
+gates with Authelia forward-auth.
+
+Required action after re-deploy: log in to AdGuard via SSO at the new
+URL (the `<dns>.<domain>` proxy host is reconfigured automatically).
+The local AdGuard credentials remain as a recovery backstop reachable
+from the host loopback (SSH tunnel or `curl localhost:{{ADGUARD_ADMIN_PORT}}`),
+which is the safety net for Authelia-down scenarios.
+
+`servicebay.dependencies` now lists `auth` in addition to `nginx`,
+which the wizard's deploy ordering respects automatically.
+
+## v1
+
+Initial release.

--- a/templates/adguard/template.yml
+++ b/templates/adguard/template.yml
@@ -7,8 +7,12 @@ metadata:
     servicebay.role: dns
   annotations:
     servicebay.label: "AdGuard Home (DNS)"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     servicebay.tier: "infrastructure"
+    # NPM proxies `<ADGUARD_SUBDOMAIN>.<PUBLIC_DOMAIN>` through Authelia
+    # forward-auth, so the auth pod must exist before this template's
+    # proxy host is created — without the gate the admin UI sits open.
+    servicebay.dependencies: "nginx,auth"
     servicebay.ports: "{{ADGUARD_ADMIN_PORT}}/tcp,53/udp,53/tcp"
     servicebay.config-mount: /opt/adguardhome/conf
 spec:

--- a/templates/adguard/variables.json
+++ b/templates/adguard/variables.json
@@ -20,13 +20,14 @@
   },
   "ADGUARD_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for AdGuard Home admin",
+    "description": "Subdomain for AdGuard Home admin — gated by Authelia forward-auth. AdGuard itself binds on 127.0.0.1, so the only way in is via SSO. Local AdGuard credentials remain as a recovery backstop when reached from the host loopback.",
     "default": "dns",
     "exposure": "lan",
     "proxyPort": "ADGUARD_ADMIN_PORT",
     "proxyConfig": {
       "block_exploits": true,
-      "ssl_forced": true
+      "ssl_forced": true,
+      "advanced_config": "__authelia_forward_auth__"
     }
   }
 }

--- a/templates/file-share/CHANGELOG.md
+++ b/templates/file-share/CHANGELOG.md
@@ -4,6 +4,26 @@ Tracks breaking changes to the `file-share` template's pod structure /
 variable shape. Each H2 corresponds to a value of
 `servicebay.schema-version` in `template.yml`.
 
+## v3 (breaking)
+
+**Syncthing GUI behind Authelia.**
+
+The Syncthing web UI used to bind on `0.0.0.0:8384`, so any LAN
+device could hit it directly and skip SSO. It now binds on
+`127.0.0.1:8384` and is reachable only through
+`https://<SYNCTHING_SUBDOMAIN>.<PUBLIC_DOMAIN>`, which NPM gates
+with Authelia forward-auth.
+
+Required action after re-deploy: log in to Syncthing via SSO at the
+new URL (your `<sync>.<domain>` proxy host gets the forward-auth
+snippet automatically). The Syncthing mobile/desktop apps continue
+to work — they authenticate with API keys against the REST API,
+not the GUI session.
+
+FileBrowser's `advanced_config` block also moved to the shared
+`__authelia_forward_auth__` sentinel. Pure refactor, no behaviour
+change.
+
 ## v2
 
 **FileBrowser bind address fix.**

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: file-share
   annotations:
     servicebay.label: "File Share (Syncthing + Samba + FileBrowser)"
-    servicebay.schema-version: "2"
+    servicebay.schema-version: "3"
     # FileBrowser is fronted by Authelia via the nginx proxy host — both
     # must be running before this template's post-deploy can wire SSO.
     servicebay.dependencies: "nginx,auth"
@@ -60,8 +60,16 @@ spec:
         value: "0"
       - name: PGID
         value: "0"
+      # Bind the GUI on loopback only. LAN devices reach Syncthing's
+      # web UI via `https://<SYNCTHING_SUBDOMAIN>.<PUBLIC_DOMAIN>`,
+      # which NPM gates with Authelia forward-auth. A 0.0.0.0 bind
+      # would let any LAN device hit `:8384` directly and skip the
+      # SSO gate. The Syncthing mobile/desktop apps speak the REST
+      # API on the same port with their own API keys — those keep
+      # working because they hit Syncthing through the local pod
+      # network (hostNetwork=true, so 127.0.0.1 is reachable).
       - name: STGUIADDRESS
-        value: "0.0.0.0:8384"
+        value: "127.0.0.1:8384"
       # Disable Syncthing's UPnP / NAT-PMP NAT-traversal (#415). The
       # FritzBox replies 403 to AddPortMapping on its IPv6 WAN entry
       # (WANIPConn2), which Syncthing then retries on a loop and

--- a/templates/file-share/variables.json
+++ b/templates/file-share/variables.json
@@ -10,14 +10,15 @@
   },
   "SYNCTHING_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for Syncthing Web UI",
+    "description": "Subdomain for Syncthing Web UI — gated by Authelia forward-auth. The Syncthing mobile/desktop apps use API keys, not the GUI session, so device sync keeps working.",
     "default": "sync",
     "exposure": "lan",
     "proxyPort": "8384",
     "proxyConfig": {
       "allow_websocket_upgrade": true,
       "block_exploits": true,
-      "ssl_forced": true
+      "ssl_forced": true,
+      "advanced_config": "__authelia_forward_auth__"
     }
   },
   "FILEBROWSER_PORT": {
@@ -40,7 +41,7 @@
       "allow_websocket_upgrade": true,
       "block_exploits": true,
       "ssl_forced": true,
-      "advanced_config": "auth_request /authelia;\nauth_request_set $target_url $scheme://$http_host$request_uri;\nauth_request_set $user $upstream_http_remote_user;\nauth_request_set $groups $upstream_http_remote_groups;\nauth_request_set $name $upstream_http_remote_name;\nauth_request_set $email $upstream_http_remote_email;\nproxy_set_header Remote-User $user;\nproxy_set_header Remote-Groups $groups;\nproxy_set_header Remote-Name $name;\nproxy_set_header Remote-Email $email;\nerror_page 401 =302 https://auth.{{PUBLIC_DOMAIN}}/?rd=$target_url;\n\nlocation = /authelia {\n    internal;\n    proxy_pass http://127.0.0.1:{{AUTHELIA_PORT}}/api/verify;\n    proxy_pass_request_body off;\n    proxy_set_header Content-Length \"\";\n    proxy_set_header X-Original-URL $scheme://$http_host$request_uri;\n    proxy_set_header X-Real-IP $remote_addr;\n    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n    proxy_set_header X-Forwarded-Proto $scheme;\n}"
+      "advanced_config": "__authelia_forward_auth__"
     }
   }
 }

--- a/tests/backend/forwardAuth.test.ts
+++ b/tests/backend/forwardAuth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AUTHELIA_FORWARD_AUTH_SENTINEL,
+  AUTHELIA_FORWARD_AUTH_SNIPPET,
+  expandForwardAuthSentinel,
+} from '@/lib/stackInstall/forwardAuth';
+
+/**
+ * The expansion helper is what lets four+ services share one nginx
+ * forward-auth block instead of duplicating ~600 chars across each
+ * `variables.json`. Regressions here would silently leak a literal
+ * sentinel string into NPM's config, which the operator only
+ * notices on a 502 from the proxied service.
+ */
+describe('expandForwardAuthSentinel', () => {
+  it('expands the bare sentinel to the full nginx snippet', () => {
+    expect(expandForwardAuthSentinel(AUTHELIA_FORWARD_AUTH_SENTINEL)).toBe(AUTHELIA_FORWARD_AUTH_SNIPPET);
+  });
+
+  it('appends per-template extras after the sentinel line', () => {
+    const input = `${AUTHELIA_FORWARD_AUTH_SENTINEL}\nclient_max_body_size 256M;`;
+    const out = expandForwardAuthSentinel(input);
+    expect(out?.startsWith(AUTHELIA_FORWARD_AUTH_SNIPPET)).toBe(true);
+    expect(out?.endsWith('client_max_body_size 256M;')).toBe(true);
+  });
+
+  it('leaves verbatim advanced_config blocks untouched', () => {
+    const verbatim = 'auth_request /custom; proxy_set_header X-Custom "1";';
+    expect(expandForwardAuthSentinel(verbatim)).toBe(verbatim);
+  });
+
+  it('passes undefined / empty through unchanged', () => {
+    expect(expandForwardAuthSentinel(undefined)).toBeUndefined();
+    expect(expandForwardAuthSentinel('')).toBe('');
+  });
+});


### PR DESCRIPTION
First of three PRs closing the SSO gaps tracked in #412.

## Summary

- Pulls the existing FileBrowser forward-auth nginx snippet into a single source of truth (\`src/lib/stackInstall/forwardAuth.ts\`); templates opt in via the \`__authelia_forward_auth__\` sentinel.
- Wires AdGuard and Syncthing through the same Authelia gate. Both services now bind on loopback only, so LAN-direct bypass is impossible.
- NPM admin **deliberately** stays untouched — the recovery path for an NPM crash mustn't depend on NPM itself.

## Test plan

- [x] 4 unit tests for the sentinel expansion helper
- [x] Full suite (767 tests) passes
- [x] tsc --noEmit clean

## Migration impact

- file-share \`schema-version\` 2 → 3 (CHANGELOG warns the operator on re-deploy: Syncthing GUI moves behind SSO; mobile/desktop apps unaffected because they use REST API keys).
- adguard \`schema-version\` 1 → 2 (CHANGELOG warns: AdGuard admin UI moves behind SSO; local credentials remain as a loopback-only backstop for Authelia-down recovery).

Refs #412, closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)