### PR TITLE
feat(home-assistant): OIDC SSO via auth_oidc custom component (closes #493)

### DIFF
--- a/templates/home-assistant/CHANGELOG.md
+++ b/templates/home-assistant/CHANGELOG.md
@@ -10,6 +10,42 @@ operator's installed schema-version and the current one and surfaces
 them in the re-deploy dialog. Each `(breaking)` section needs an
 explicit acknowledgement before the deploy can proceed.
 
+## v5 (breaking) — #493
+
+**OIDC SSO via the `auth_oidc` custom component.**
+
+Home Assistant has no native OIDC auth provider, so this release
+adds the `auth_oidc` HACS-style integration directly into
+`<config>/custom_components/auth_oidc/`. The `post-deploy.py` hook
+downloads the pinned release tarball
+(https://github.com/christiaangoossens/hass-oidc-auth — version
+`HA_OIDC_AUTH_VERSION`, default `v0.6.0`) on every deploy and skips
+the network round-trip when the on-disk `.sb_installed_version`
+stamp already matches.
+
+The rendered `configuration.yaml.mustache` ships an `auth_oidc:` block
+pointing at the Authelia `discovery_url`, with
+`features.automatic_user_linking` + `automatic_person_creation` on
+and a roles mapping for `HA_OIDC_ADMIN_GROUP` / `HA_OIDC_USER_GROUP`
+(default `lldap_admin` / `lldap_strict_readonly`).
+
+Required action: re-deploy. After the deploy, the HA login screen
+shows a *Sign in with Authelia* button — click it, log in via SSO,
+and the LLDAP user lands as HA admin (when in `lldap_admin`) or
+regular user. The Companion app captures a HA-native long-lived
+token on first OIDC login and keeps working independently of
+Authelia from that point.
+
+**If you customised `/config/configuration.yaml` by hand**, back it
+up before re-deploying — the deploy step renders the template's
+`.mustache` over the live file. After re-deploy, merge your custom
+keys back in, leaving the new `auth_oidc:` block in place.
+
+Bumping `HA_OIDC_AUTH_VERSION` between deploys upgrades the
+component in place: the post-deploy detects the version mismatch,
+re-downloads the tarball, and restarts the HA container so the new
+code loads.
+
 ## v4 (breaking) — #420 / #422
 
 **Z-Wave JS UI always runs + reachable at `zwave.<lanDomain>`.**

--- a/templates/home-assistant/configuration.yaml.mustache
+++ b/templates/home-assistant/configuration.yaml.mustache
@@ -22,3 +22,26 @@ http:
     - 192.168.0.0/16
     - 10.0.0.0/8
     - 172.16.0.0/12
+
+# OIDC auth via the `auth_oidc` custom component (installed by
+# post-deploy.py from a pinned tarball — see HA_OIDC_AUTH_VERSION).
+# HA core has no native OIDC provider yet, so this is the bridge.
+# Restart HA after first install for the integration to register the
+# `/auth/oidc/*` endpoints; subsequent re-deploys skip the reinstall
+# when the version stamp on disk already matches HA_OIDC_AUTH_VERSION.
+auth_oidc:
+  client_id: homeassistant
+  client_secret: {{HA_OIDC_SECRET}}
+  discovery_url: https://auth.{{PUBLIC_DOMAIN}}/.well-known/openid-configuration
+  features:
+    # LLDAP-side `sub` claim auto-binds to the matching HA user record
+    # on first SSO login, so existing local accounts don't get
+    # duplicated.
+    automatic_user_linking: true
+    # Auto-create a `person` entity for new SSO users — without this
+    # the HA UI shows the user as unattached and dashboards filtered
+    # by `person.*` skip them.
+    automatic_person_creation: true
+  roles:
+    admin: "{{HA_OIDC_ADMIN_GROUP}}"
+    user:  "{{HA_OIDC_USER_GROUP}}"

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -18,6 +18,12 @@ Responsibilities:
      be up on port 8091, then PATCHes gateway.wsServer + gateway.wsServerPort
      via the REST API. Idempotent — skips if already correct.
 
+  3. **auth_oidc custom component** — downloads the pinned release tarball
+     of the `auth_oidc` HA custom component (#493) and drops it into
+     `<config>/custom_components/auth_oidc/`. HA Core has no native OIDC
+     provider, so this is the bridge. Idempotent via a `.sb_installed_version`
+     stamp; only re-downloads + extracts when HA_OIDC_AUTH_VERSION changes.
+
 Idempotent overall: safe to re-run on every deploy.
 """
 
@@ -26,8 +32,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tarfile
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -40,6 +49,13 @@ ZWAVEJS_WS_PORT = 3001
 ZWAVEJS_READY_TIMEOUT = 60.0
 ZWAVEJS_READY_INTERVAL = 2.0
 REQUEST_TIMEOUT = 10.0
+
+# auth_oidc install
+HA_API = "http://127.0.0.1:8123"
+HA_OIDC_REPO = "christiaangoossens/hass-oidc-auth"
+HA_READY_TIMEOUT = 180.0
+HA_READY_INTERVAL = 3.0
+HA_CONTAINER_NAME = "home-assistant-homeassistant"
 
 
 def env(key: str, default: str = "") -> str:
@@ -162,6 +178,218 @@ def configure_ws_port() -> None:
         log(f"   ⚠️  POST /api/settings failed (HTTP {code2}). Set WS port manually.")
 
 
+# ── auth_oidc custom component (#493) ────────────────────────────────────────
+
+def _wait_ha_ready(timeout: float | None = None) -> bool:
+    """Poll HA's root until it answers. HA returns HTTP 200 with the
+    frontend HTML once the core is up; we don't care which auth state
+    it's in, just that the HTTP layer answers. Returns False on
+    timeout.
+
+    The timeout + sleep interval are read from module constants at
+    call time (not as default-arg values), so tests can monkey-patch
+    `HA_READY_TIMEOUT` / `HA_READY_INTERVAL` to drop the loop into
+    millisecond budgets."""
+    budget = timeout if timeout is not None else HA_READY_TIMEOUT
+    deadline = time.time() + budget
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{HA_API}/", timeout=5) as resp:
+                if resp.status < 500:
+                    return True
+        except (urllib.error.URLError, TimeoutError, OSError):
+            pass
+        time.sleep(HA_READY_INTERVAL)
+    return False
+
+
+def _ha_config_dir() -> str:
+    """Resolve the host-side path of HA's /config volume. The
+    `home-assistant` pod mounts `{{DATA_DIR}}/home-assistant/homeassistant`
+    onto `/config`; DATA_DIR is passed through to the post-deploy env."""
+    base = env("DATA_DIR", "/mnt/data")
+    return os.path.join(base, "home-assistant", "homeassistant")
+
+
+def _strip_first_component(member_path: str) -> str | None:
+    """Tarballs from GitHub release tags are wrapped in a top-level
+    directory like `hass-oidc-auth-0.6.0/`. We unwrap that prefix and
+    then keep only entries under `custom_components/auth_oidc/`."""
+    parts = member_path.split("/")
+    if len(parts) < 2:
+        return None
+    rest = parts[1:]
+    if len(rest) < 2 or rest[0] != "custom_components" or rest[1] != "auth_oidc":
+        return None
+    return "/".join(rest[2:])  # path inside auth_oidc/
+
+
+def _extract_auth_oidc(tar_path: str, target_dir: str) -> None:
+    """Extract only the `custom_components/auth_oidc/` subtree from
+    the release tarball into `target_dir`. Replaces the directory
+    atomically so a half-extracted tree on disk never confuses HA."""
+    staging = tempfile.mkdtemp(prefix="sb_auth_oidc_")
+    try:
+        with tarfile.open(tar_path, "r:gz") as tf:
+            for member in tf.getmembers():
+                if not (member.isfile() or member.isdir()):
+                    continue
+                rel = _strip_first_component(member.name)
+                if rel is None:
+                    continue
+                out_path = os.path.join(staging, rel) if rel else staging
+                if member.isdir():
+                    os.makedirs(out_path, exist_ok=True)
+                    continue
+                os.makedirs(os.path.dirname(out_path) or staging, exist_ok=True)
+                src = tf.extractfile(member)
+                if src is None:
+                    continue
+                with open(out_path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        # Atomic swap: replace target_dir with the staging tree.
+        if os.path.exists(target_dir):
+            shutil.rmtree(target_dir)
+        shutil.move(staging, target_dir)
+    finally:
+        if os.path.isdir(staging):
+            shutil.rmtree(staging, ignore_errors=True)
+
+
+def install_auth_oidc(version: str) -> bool:
+    """Idempotent install. Skips when `.sb_installed_version` already
+    matches. Returns True iff the on-disk component was added or
+    upgraded (the caller restarts HA only when something changed)."""
+    config_dir = _ha_config_dir()
+    target = os.path.join(config_dir, "custom_components", "auth_oidc")
+    stamp = os.path.join(target, ".sb_installed_version")
+
+    try:
+        if os.path.isfile(stamp):
+            with open(stamp, encoding="utf-8") as fh:
+                current = fh.read().strip()
+            if current == version:
+                log(f"   auth_oidc {version} already installed — skipping.")
+                return False
+            log(f"   Upgrading auth_oidc: {current} → {version}.")
+        else:
+            log(f"   Installing auth_oidc {version}.")
+    except OSError as exc:
+        log(f"   ⚠️ Could not read existing version stamp: {exc}. Proceeding with install.")
+
+    url = f"https://github.com/{HA_OIDC_REPO}/archive/refs/tags/{version}.tar.gz"
+    log(f"   Downloading {url}")
+    tar_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+            tar_path = tmp.name
+        urllib.request.urlretrieve(url, tar_path)  # noqa: S310 (pinned URL)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        _extract_auth_oidc(tar_path, target)
+    except (urllib.error.URLError, OSError, tarfile.TarError) as exc:
+        log(f"   ⚠️ auth_oidc install failed: {exc}")
+        log(f"   Manual recovery: download {url} and unpack `custom_components/auth_oidc/` into {target}.")
+        return False
+    finally:
+        if tar_path and os.path.isfile(tar_path):
+            try:
+                os.unlink(tar_path)
+            except OSError:
+                pass
+
+    try:
+        with open(stamp, "w", encoding="utf-8") as fh:
+            fh.write(version + "\n")
+    except OSError as exc:
+        log(f"   ⚠️ Could not write version stamp ({exc}). Future runs will re-download.")
+
+    log(f"   ✅ auth_oidc {version} installed at {target}")
+    return True
+
+
+def restart_home_assistant() -> bool:
+    """Restart just the HA container so the new custom component is
+    loaded. Z-Wave JS / Matter Server stay up — they're independent
+    containers in the same pod."""
+    try:
+        result = subprocess.run(
+            ["podman", "container", "restart", HA_CONTAINER_NAME],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            log(f"   Restarted {HA_CONTAINER_NAME}.")
+            return True
+        log(f"   ⚠️ `podman container restart {HA_CONTAINER_NAME}` exited {result.returncode}: {result.stderr.strip()}")
+        return False
+    except (subprocess.SubprocessError, OSError) as exc:
+        log(f"   ⚠️ Could not restart HA: {exc}")
+        return False
+
+
+def verify_oidc_endpoint(timeout: float = 90.0) -> bool:
+    """After the restart, poll HA's `/auth/oidc/welcome` until it
+    answers. The integration registers the path on startup; a 404
+    means the component didn't load (manifest mismatch, HA version
+    drift). We accept 200, 302 (redirect to Authelia), and 401 — all
+    of which prove the route exists."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(f"{HA_API}/auth/oidc/welcome", method="GET")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status in (200, 302, 401):
+                    log(f"   ✅ /auth/oidc/welcome answered HTTP {resp.status}.")
+                    return True
+        except urllib.error.HTTPError as exc:
+            if exc.code in (200, 302, 401):
+                log(f"   ✅ /auth/oidc/welcome answered HTTP {exc.code}.")
+                return True
+            if exc.code == 404:
+                # Integration not loaded yet — keep polling.
+                pass
+        except (urllib.error.URLError, TimeoutError, OSError):
+            pass
+        time.sleep(3)
+    return False
+
+
+def configure_auth_oidc() -> None:
+    version = env("HA_OIDC_AUTH_VERSION", "v0.6.0").strip()
+    if not version:
+        log("⚠️  HA_OIDC_AUTH_VERSION is empty — skipping auth_oidc install.")
+        return
+
+    log(f"Configuring Home Assistant OIDC via auth_oidc {version}...")
+    log("   Waiting for Home Assistant to come up...")
+    if not _wait_ha_ready():
+        log(f"   ⚠️ HA did not respond within {HA_READY_TIMEOUT}s. Skipping auth_oidc install — re-run the deploy once HA is up.")
+        return  # noqa: RET502 — explicit early-out for the unreachable path
+
+    changed = install_auth_oidc(version)
+    if not changed:
+        # Already at the pinned version — but configuration.yaml might
+        # have been edited between deploys, so still verify the
+        # endpoint responds rather than declaring victory blindly.
+        if verify_oidc_endpoint(timeout=30.0):
+            log("   ✅ OIDC endpoint already serving — no restart needed.")
+        else:
+            log("   ⚠️ OIDC endpoint is not responding even though the component is installed. Check Home Assistant logs.")
+        return
+
+    if not restart_home_assistant():
+        log("   Manual recovery: `podman container restart home-assistant-homeassistant` once you have shell access.")
+        return
+
+    log("   Waiting for HA to restart and the OIDC route to register...")
+    if verify_oidc_endpoint():
+        log("✅ Home Assistant OIDC is live. The login screen now shows a `Sign in with Authelia` button.")
+    else:
+        log("⚠️ Home Assistant restarted but /auth/oidc/welcome did not answer in time.")
+        log("   Check `podman logs home-assistant-homeassistant` for auth_oidc errors (manifest mismatch / HA major-version drift).")
+
+
 # ── main ──────────────────────────────────────────────────────────────────────
 
 def main() -> int:
@@ -177,6 +405,8 @@ def main() -> int:
         log(f"✅ Connect Home Assistant to Z-Wave JS: ws://localhost:{ZWAVEJS_WS_PORT}")
     else:
         log("No ZWAVE_DEVICE set — skipping udev rule and WS port config.")
+
+    configure_auth_oidc()
 
     return 0
 

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: home-assistant
   annotations:
     servicebay.label: "Home Assistant"
-    servicebay.schema-version: "4"
+    servicebay.schema-version: "5"
     # Home Assistant is reached at home.<domain> via nginx, and (when
     # the operator enables it) authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -27,7 +27,22 @@
   },
   "HA_OIDC_SECRET": {
     "type": "secret",
-    "description": "OIDC client secret for the Home Assistant client registered with Authelia. Auto-generated and pinned via clientSecretVar so Authelia always uses the same value. HA itself does not have a native OIDC auth provider — use this secret when configuring a custom integration (e.g. homeassistant_auth_oidc via HACS)."
+    "description": "OIDC client secret for the Home Assistant client registered with Authelia. Auto-generated and pinned via clientSecretVar so Authelia always uses the same value. Both Authelia and the auth_oidc custom component (installed by post-deploy) read this secret."
+  },
+  "HA_OIDC_AUTH_VERSION": {
+    "type": "text",
+    "description": "Pinned release tag of the auth_oidc custom component (https://github.com/christiaangoossens/hass-oidc-auth). post-deploy downloads + extracts the matching tarball into <config>/custom_components/auth_oidc/ on every deploy and skips the network round-trip when the on-disk version stamp already matches. Bump this string and re-deploy to upgrade.",
+    "default": "v0.6.0"
+  },
+  "HA_OIDC_ADMIN_GROUP": {
+    "type": "text",
+    "description": "LLDAP group whose members become Home Assistant admins via auth_oidc's `roles` mapping. Anyone outside this group lands as a regular user.",
+    "default": "lldap_admin"
+  },
+  "HA_OIDC_USER_GROUP": {
+    "type": "text",
+    "description": "LLDAP group whose members can log into Home Assistant as a non-admin user. Members of HA_OIDC_ADMIN_GROUP also pass this check automatically.",
+    "default": "lldap_strict_readonly"
   },
   "HA_SUBDOMAIN": {
     "type": "subdomain",

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -401,5 +401,76 @@ class MediaScript(unittest.TestCase):
         self.assertNotIn("nav-pass", log_only)
 
 
+class HomeAssistantScript(unittest.TestCase):
+    """The HA post-deploy is gated on Z-Wave device presence (skips
+    udev + WS port config without it) and always tries the
+    `auth_oidc` install (#493). We mock urllib so the HA-readiness
+    probe + the OIDC verify call both run without touching a real
+    network."""
+
+    def test_no_zwave_no_ha_returns_zero(self):
+        m = load_script("home-assistant")
+        import urllib.error
+        import urllib.request
+        # All HTTP calls fail → HA not reachable; the script logs and
+        # returns 0 rather than crashing.
+
+        def always_unreachable(*_a, **_kw):
+            raise urllib.error.URLError("connection refused")
+
+        # Patch the ready-poll's timeout + sleep so the unreachable path
+        # exits in milliseconds instead of the 3-minute production wait.
+        env = {"HA_OIDC_AUTH_VERSION": "v0.6.0"}
+        with run_with_env(env), \
+                mock.patch.object(urllib.request, "urlopen", always_unreachable), \
+                mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("No ZWAVE_DEVICE set", out)
+        self.assertIn("HA did not respond", out)
+
+    def test_already_installed_skips_download(self):
+        """When the on-disk version stamp matches HA_OIDC_AUTH_VERSION,
+        the script must skip the tarball download entirely. We assert
+        this by configuring urllib so any HTTPS GET to github.com
+        triggers a test failure."""
+        m = load_script("home-assistant")
+        import tempfile
+        import urllib.request
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Pre-seed the stamp so install_auth_oidc returns False.
+            target = os.path.join(tmp, "home-assistant", "homeassistant", "custom_components", "auth_oidc")
+            os.makedirs(target, exist_ok=True)
+            with open(os.path.join(target, ".sb_installed_version"), "w") as fh:
+                fh.write("v0.6.0\n")
+
+            def fake_urlopen(req, *_a, **_kw):
+                url = req.full_url if hasattr(req, "full_url") else str(req)
+                if "github.com" in url:
+                    raise AssertionError(f"unexpected tarball download: {url}")
+                # HA-readiness probe → return 200 so wait_ha_ready proceeds.
+                # OIDC verify call → return 200.
+                class _R:
+                    status = 200
+                    def read(self):
+                        return b"<html></html>"
+                    def __enter__(self):
+                        return self
+                    def __exit__(self, *a):
+                        return False
+                return _R()
+
+            env = {"HA_OIDC_AUTH_VERSION": "v0.6.0", "DATA_DIR": tmp}
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen", fake_urlopen), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("already installed", out)
+            self.assertIn("/auth/oidc/welcome answered", out)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Second of three SSO PRs from #412. HA Core has no native OIDC auth provider, so this PR drops in the [`auth_oidc`](https://github.com/christiaangoossens/hass-oidc-auth) HACS-style integration directly and wires the matching config block.

## Summary

- **`variables.json`** — adds \`HA_OIDC_AUTH_VERSION\` (pinned release tag, default \`v0.6.0\`), \`HA_OIDC_ADMIN_GROUP\`, \`HA_OIDC_USER_GROUP\`.
- **\`configuration.yaml.mustache\`** — appends the \`auth_oidc:\` block with Authelia's discovery URL, automatic-user-linking, and the roles mapping.
- **\`post-deploy.py\`** — \`configure_auth_oidc()\` step: wait for HA → check version stamp → download + atomically extract the tarball → write stamp → restart HA container → verify \`/auth/oidc/welcome\` answers. Idempotent across re-deploys.
- **\`template.yml\`** — schema 4 → 5.
- **\`CHANGELOG.md\`** — \`## v5 (breaking)\` walks the operator through the post-deploy behaviour + the \`HA_OIDC_AUTH_VERSION\`-bump upgrade path.

## Test plan

- [x] 2 new Python unit tests in \`tests/templates/test_post_deploy.py\` (HA-unreachable graceful skip + already-installed no-download path).
- [x] Full vitest suite (763 tests) passes; tsc --noEmit clean.
- [ ] Manual smoke after deploy: HA login screen shows *Sign in with Authelia* button; LLDAP-admin user lands as HA admin.

## Out of scope (separate follow-ups, per the issue)

- Diagnose probe for \"OIDC button reachable\" — can ship after.
- HACS adoption — deliberately not (pinned tarball is more predictable).

Refs #412, closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)