### PR TITLE
feat(file-share): per-user Samba accounts via LLDAP→tdbsam sync (closes #494)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Copy, KeyRound, Loader2, RefreshCw, Users } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+interface SambaUser {
+  id: string;
+  displayName?: string;
+  email?: string;
+  presentInSamba: boolean;
+}
+
+interface SyncResponse {
+  ok: true;
+  users: SambaUser[];
+  added: string[];
+  removed: string[];
+}
+
+/**
+ * Per-LLDAP-user Samba password management (#494).
+ *
+ * The backend keeps the Samba `tdbsam` DB in step with LLDAP: every
+ * GET to the sync endpoint adds missing users with a random initial
+ * password and removes orphan entries. Operators then use this
+ * section to flash the random password (for first-time mount) or
+ * roll a new one whenever a family member needs a Samba reset.
+ *
+ * Samba can't speak OIDC, so this is the closest we get to the
+ * single-source-of-truth model the rest of the stack enjoys —
+ * docs/UX_PHILOSOPHY.md "single login flow" carves out SMB as a
+ * deliberate exception.
+ */
+export default function FileShareSection() {
+  const { addToast } = useToast();
+  const [users, setUsers] = useState<SambaUser[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyUser, setBusyUser] = useState<string | null>(null);
+  const [flashed, setFlashed] = useState<{ id: string; password: string } | null>(null);
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/system/file-share/samba/users');
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || `HTTP ${res.status}`);
+        setUsers(null);
+        return;
+      }
+      const data = (await res.json()) as SyncResponse;
+      setUsers(data.users);
+      if (data.added.length > 0) {
+        addToast('info', 'Samba sync', `${data.added.length} new user(s) added to the Samba directory.`);
+      }
+      if (data.removed.length > 0) {
+        addToast('info', 'Samba sync', `${data.removed.length} stale user(s) removed.`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const setPassword = useCallback(async (id: string) => {
+    setBusyUser(id);
+    try {
+      const res = await fetch(`/api/system/file-share/samba/users/${encodeURIComponent(id)}/set-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        addToast('error', 'Could not set password', data.error || `HTTP ${res.status}`);
+        return;
+      }
+      setFlashed({ id, password: data.password });
+      addToast('success', 'Samba password set', 'Copy the value below — it will not be shown again.');
+    } catch (e) {
+      addToast('error', 'Could not set password', e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyUser(null);
+    }
+  }, [addToast]);
+
+  const copyPassword = useCallback((value: string) => {
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(value).then(() => {
+      addToast('success', 'Copied', 'Samba password copied to clipboard.');
+    });
+  }, [addToast]);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400">
+          <Users size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">File Share — Samba accounts</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Every LLDAP user mounts the Samba share with their own credentials. Samba can&apos;t speak OIDC, so the password lives in Samba&apos;s own DB — set it here.
+          </p>
+        </div>
+        <button
+          onClick={loadUsers}
+          disabled={loading}
+          className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+          type="button"
+          title="Re-run LLDAP → Samba sync"
+        >
+          {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+          Sync
+        </button>
+      </div>
+
+      <div className="p-6 space-y-3">
+        {error && (
+          <div className="p-3 rounded-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800">
+            {error}
+          </div>
+        )}
+
+        {loading && !users && (
+          <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading LLDAP users…
+          </div>
+        )}
+
+        {users && users.length === 0 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No LLDAP users yet — create one in LLDAP first.</p>
+        )}
+
+        {users && users.length > 0 && (
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {users.map(u => (
+              <li key={u.id} className="py-2 flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
+                    {u.displayName || u.id}
+                    <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                      ({u.id})
+                    </span>
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {u.presentInSamba ? 'Samba account ready' : 'Samba account missing — click Set password to provision'}
+                  </div>
+                  {flashed?.id === u.id && (
+                    <div className="mt-2 p-2 rounded bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-xs">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono break-all">{flashed.password}</span>
+                        <button
+                          onClick={() => copyPassword(flashed.password)}
+                          className="inline-flex items-center gap-1 px-2 py-1 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/40 rounded"
+                          type="button"
+                        >
+                          <Copy size={12} /> Copy
+                        </button>
+                      </div>
+                      <div className="mt-1 text-amber-700 dark:text-amber-300">
+                        This is the only time the password is shown — copy it now.
+                      </div>
+                    </div>
+                  )}
+                </div>
+                <button
+                  onClick={() => setPassword(u.id)}
+                  disabled={busyUser === u.id}
+                  className="inline-flex items-center gap-1 px-3 py-1.5 text-xs bg-emerald-600 hover:bg-emerald-700 text-white rounded disabled:opacity-50"
+                  type="button"
+                >
+                  {busyUser === u.id ? <Loader2 size={12} className="animate-spin" /> : <KeyRound size={12} />}
+                  {u.presentInSamba ? 'Reset password' : 'Set password'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -3,6 +3,7 @@
 import AccessRequestsSection from '../_lib/sections/AccessRequestsSection';
 import CredentialsSection from '../_lib/sections/CredentialsSection';
 import EmailNotificationsSection from '../_lib/sections/EmailNotificationsSection';
+import FileShareSection from '../_lib/sections/FileShareSection';
 import GatewaySection from '../_lib/sections/GatewaySection';
 import McpSection from '../_lib/sections/McpSection';
 import PublicDomainSection from '../_lib/sections/PublicDomainSection';
@@ -18,6 +19,7 @@ export default function IntegrationsSettingsPage() {
       <AccessRequestsSection />
       <CredentialsSection />
       <ReverseProxySection />
+      <FileShareSection />
       <EmailNotificationsSection />
       <McpSection />
       <TemplateRegistriesSection />

--- a/src/app/api/system/file-share/samba/users/[id]/set-password/route.ts
+++ b/src/app/api/system/file-share/samba/users/[id]/set-password/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { setSambaPassword } from '@/lib/fileShare/sambaSync';
+
+export const dynamic = 'force-dynamic';
+
+const SAFE_USERNAME = /^[A-Za-z0-9._-]{1,64}$/;
+
+/**
+ * POST /api/system/file-share/samba/users/[id]/set-password
+ *
+ * Body:
+ *   - omitted or `{}` → generate a fresh random password (returned in
+ *     the response so the UI can flash it once for the operator to
+ *     copy + share with the user).
+ *   - `{ "password": "..." }` → set the given value verbatim.
+ *
+ * The route runs `smbpasswd -s -a <user>` inside the file-share-samba
+ * container via the agent. Reads the LLDAP user list to validate the
+ * id, so unknown users are rejected with 404 rather than silently
+ * adding a Samba-only account.
+ */
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { id } = await params;
+    if (!SAFE_USERNAME.test(id)) {
+      return NextResponse.json({ error: 'Invalid username.' }, { status: 400 });
+    }
+
+    let body: { password?: unknown } = {};
+    try {
+      body = await request.json();
+    } catch {
+      // Empty body = generate random. Don't 400 on missing JSON.
+    }
+    const password = typeof body.password === 'string' && body.password.length >= 8
+      ? body.password
+      : undefined;
+
+    const result = await setSambaPassword(id, password ? { password } : {});
+    if (!result.ok) {
+      const status = result.reason === 'not_in_lldap' ? 404 : 500;
+      return NextResponse.json({ error: result.message, reason: result.reason }, { status });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:file-share:samba:set-password', status: 500 });
+  }
+}

--- a/src/app/api/system/file-share/samba/users/route.ts
+++ b/src/app/api/system/file-share/samba/users/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { syncSambaWithLldap } from '@/lib/fileShare/sambaSync';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET  /api/system/file-share/samba/users
+ *  Returns the LLDAP user list with each user's Samba sync state.
+ *  Side-effect: missing tdbsam entries get added (with a random
+ *  initial password); orphan tdbsam entries get removed. The route
+ *  IS the sync — calling it idempotently from the UI keeps things in
+ *  step without a separate "Run sync" button.
+ *
+ * POST /api/system/file-share/samba/users
+ *  Manually trigger the same sync. Same response shape. Exists so
+ *  the operator can force a refresh from the UI after creating a new
+ *  LLDAP user (LLDAP's user-create flow runs in a separate pod and
+ *  has no broadcast hook).
+ */
+export async function GET(request: NextRequest) {
+  return handle(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handle(request);
+}
+
+async function handle(request: NextRequest) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+    const result = await syncSambaWithLldap();
+    if (!result.ok) {
+      const status = result.reason === 'samba_unavailable' ? 404
+        : result.reason === 'lldap_unavailable' ? 503
+        : 500;
+      return NextResponse.json({ error: result.message, reason: result.reason }, { status });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:file-share:samba:users', status: 500 });
+  }
+}

--- a/src/lib/fileShare/sambaSync.ts
+++ b/src/lib/fileShare/sambaSync.ts
@@ -1,0 +1,211 @@
+/**
+ * LLDAP → Samba `tdbsam` sync for the file-share template (#494).
+ *
+ * Samba can't speak OIDC, and rehashing LLDAP's Argon2/bcrypt password
+ * into the NT-hash Samba needs is not possible. The locked design is
+ * Option A from the issue: keep per-user Samba accounts in `tdbsam`,
+ * with passwords set independently by the operator (or randomised at
+ * create-time + user resets via the Settings → Integrations UI).
+ *
+ * This module wraps the `pdbedit` + `smbpasswd` shell incantations
+ * that run inside the running `file-share-samba` container. Every
+ * function returns a structured `{ ok, ... }` union so the API route
+ * can render an actionable error.
+ *
+ * Idempotent by design: re-running the sync only adds users that are
+ * in LLDAP but not yet in tdbsam, and removes users that were in
+ * tdbsam but no longer exist in LLDAP. Existing Samba passwords are
+ * never overwritten — set/regen is an explicit operator action.
+ */
+
+import { agentManager } from '../agent/manager';
+import { listLldapUsers } from '../lldap/client';
+import crypto from 'crypto';
+
+const SAMBA_CONTAINER_NAME = 'file-share-samba';
+
+export interface SambaUserSummary {
+  /** LLDAP user id, used as the Samba username. */
+  id: string;
+  displayName?: string;
+  email?: string;
+  /** True iff `pdbedit -L` lists this user in the Samba tdbsam DB. */
+  presentInSamba: boolean;
+}
+
+export type SambaSyncResult =
+  | { ok: true; users: SambaUserSummary[]; added: string[]; removed: string[] }
+  | { ok: false; reason: 'lldap_unavailable' | 'samba_unavailable' | 'exec_failed'; message: string };
+
+export type SambaPasswordResult =
+  | { ok: true; userId: string; password: string }
+  | { ok: false; reason: 'not_in_lldap' | 'samba_unavailable' | 'exec_failed'; message: string };
+
+/**
+ * Username pattern. We refuse any LLDAP id that would need shell-escaping —
+ * Samba's username is the same string we feed to `smbpasswd` via stdin
+ * and to `pdbedit -u`. Conservative ASCII-only matches LLDAP's own
+ * default username constraints anyway.
+ */
+const SAFE_USERNAME = /^[A-Za-z0-9._-]{1,64}$/;
+
+/**
+ * 18 url-safe chars of randomness for the initial Samba password. Long
+ * enough that brute-force isn't a concern; the operator is expected to
+ * use the "Set Samba password" button to replace this with their own
+ * value the first time they mount the share. Same flavour as
+ * `crypto.randomBytes(...).toString('base64url')`.
+ */
+function generatePassword(): string {
+  return crypto.randomBytes(14).toString('base64').replace(/[+/=]/g, '').slice(0, 18);
+}
+
+async function exec(node: string, cmd: string, opts: { stdin?: string; timeout?: number } = {}): Promise<{ code: number; stdout: string; stderr: string }> {
+  const agent = await agentManager.ensureAgent(node);
+  const res = await agent.sendCommand('exec', {
+    command: cmd,
+    stdin: opts.stdin,
+    timeout: opts.timeout ?? 10,
+  });
+  return {
+    code: typeof res.code === 'number' ? res.code : (res.exitCode ?? 1),
+    stdout: typeof res.stdout === 'string' ? res.stdout : '',
+    stderr: typeof res.stderr === 'string' ? res.stderr : '',
+  };
+}
+
+/**
+ * Parse the output of `pdbedit -L`. Each line looks like
+ *   `username:1001:Full Name`
+ * but the locked design only relies on the leading username, so we
+ * tolerate anything past the first colon. Empty / non-conforming
+ * lines are dropped silently.
+ */
+export function parsePdbeditList(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => line.split(':')[0])
+    .filter(name => SAFE_USERNAME.test(name));
+}
+
+/** List Samba's tdbsam usernames. Returns `null` when the container
+ *  isn't reachable (file-share not installed, samba container down). */
+async function listSambaUsers(node: string): Promise<string[] | null> {
+  const cmd = `podman exec ${SAMBA_CONTAINER_NAME} pdbedit -L`;
+  const res = await exec(node, cmd, { timeout: 10 });
+  if (res.code !== 0) return null;
+  return parsePdbeditList(res.stdout);
+}
+
+/**
+ * Sync LLDAP users → Samba tdbsam.
+ *
+ *   - Users in LLDAP missing from Samba: added with a random initial
+ *     password (the operator can replace it via Settings → Integrations
+ *     → File Share).
+ *   - Users in Samba missing from LLDAP: removed via `pdbedit -x`.
+ *   - Users present in both: left alone (no password overwrite).
+ *
+ * Returns the merged view of who's where so the UI can render a
+ * per-user "Set password" affordance.
+ */
+export async function syncSambaWithLldap(node: string = 'Local'): Promise<SambaSyncResult> {
+  const lldap = await listLldapUsers();
+  if (!lldap.ok) {
+    return { ok: false, reason: 'lldap_unavailable', message: lldap.message };
+  }
+  const lldapUsers = lldap.users.filter(u => SAFE_USERNAME.test(u.id));
+
+  const sambaUsers = await listSambaUsers(node);
+  if (sambaUsers === null) {
+    return { ok: false, reason: 'samba_unavailable', message: `Could not run \`pdbedit -L\` in ${SAMBA_CONTAINER_NAME}. Is the file-share template deployed and the container running?` };
+  }
+
+  const sambaSet = new Set(sambaUsers);
+  const lldapSet = new Set(lldapUsers.map(u => u.id));
+
+  const toAdd = lldapUsers.filter(u => !sambaSet.has(u.id));
+  const toRemove = sambaUsers.filter(s => !lldapSet.has(s));
+
+  const added: string[] = [];
+  for (const u of toAdd) {
+    const pw = generatePassword();
+    // smbpasswd -s -a <user>: -s reads stdin (newpass\nnewpass), -a adds.
+    // Conservative escape of username via SAFE_USERNAME above; password
+    // goes via stdin, never the command line.
+    const cmd = `podman exec -i ${SAMBA_CONTAINER_NAME} smbpasswd -s -a ${u.id}`;
+    const res = await exec(node, cmd, { stdin: `${pw}\n${pw}\n`, timeout: 10 });
+    if (res.code === 0) added.push(u.id);
+    // If the add fails, the user just stays missing from Samba. The
+    // sync result still surfaces them via presentInSamba=false so the
+    // UI can retry.
+  }
+
+  const removed: string[] = [];
+  for (const s of toRemove) {
+    const cmd = `podman exec ${SAMBA_CONTAINER_NAME} pdbedit -x -u ${s}`;
+    const res = await exec(node, cmd, { timeout: 10 });
+    if (res.code === 0) removed.push(s);
+  }
+
+  const final = new Set([...sambaSet, ...added].filter(name => !removed.includes(name)));
+  return {
+    ok: true,
+    users: lldapUsers.map((u): SambaUserSummary => ({
+      id: u.id,
+      displayName: u.displayName,
+      email: u.email,
+      presentInSamba: final.has(u.id),
+    })),
+    added,
+    removed,
+  };
+}
+
+/**
+ * Set (or regenerate) the Samba password for a specific LLDAP user.
+ * Pass `password` to set a chosen value, omit it to roll a fresh
+ * random one (returned in the result so the UI can flash it once for
+ * the operator to copy).
+ *
+ * The user must already exist in LLDAP — we refuse to set a Samba
+ * password for an identity that's not in the directory, to keep
+ * tdbsam in lockstep with LLDAP. To add a new user, run `syncSambaWithLldap`
+ * after the LLDAP-side create.
+ */
+export async function setSambaPassword(
+  userId: string,
+  options: { node?: string; password?: string } = {},
+): Promise<SambaPasswordResult> {
+  if (!SAFE_USERNAME.test(userId)) {
+    return { ok: false, reason: 'not_in_lldap', message: `'${userId}' is not a valid username.` };
+  }
+  const node = options.node ?? 'Local';
+
+  // Sanity: the user must exist in LLDAP. This both prevents the
+  // orphan-tdbsam-account case and gives the caller a meaningful error
+  // when the username has a typo.
+  const lldap = await listLldapUsers();
+  if (lldap.ok && !lldap.users.some(u => u.id === userId)) {
+    return { ok: false, reason: 'not_in_lldap', message: `LLDAP has no user with id '${userId}'. Create the user in LLDAP first.` };
+  }
+  // If LLDAP itself is unreachable we still let the password set proceed
+  // — the operator might be fixing a Samba-only outage and we don't
+  // want to gate that on LLDAP availability.
+
+  const password = options.password ?? generatePassword();
+  // smbpasswd is idempotent: adds the user if not yet present, updates
+  // the password otherwise. Stdin format: newpass\nnewpass\n.
+  const cmd = `podman exec -i ${SAMBA_CONTAINER_NAME} smbpasswd -s -a ${userId}`;
+  const res = await exec(node, cmd, { stdin: `${password}\n${password}\n`, timeout: 10 });
+  if (res.code !== 0) {
+    return {
+      ok: false,
+      reason: 'exec_failed',
+      message: `Could not set Samba password (smbpasswd exit ${res.code}): ${(res.stderr || res.stdout || '').slice(0, 200)}`,
+    };
+  }
+  return { ok: true, userId, password };
+}

--- a/src/lib/lldap/client.ts
+++ b/src/lib/lldap/client.ts
@@ -24,6 +24,16 @@ const CREATE_USER_MUTATION = `
   }
 `;
 
+const LIST_USERS_QUERY = `
+  query Users {
+    users {
+      id
+      displayName
+      email
+    }
+  }
+`;
+
 interface LldapCredentials {
   url: string;
   username: string;
@@ -119,6 +129,53 @@ export async function createLldapUser(input: CreateUserInput): Promise<LldapCrea
       return { ok: false, reason: 'graphql_error', message: 'LLDAP response did not include the created user.' };
     }
     return { ok: true, userId: created.id, displayName: created.displayName ?? input.displayName ?? input.id };
+  } catch (e) {
+    return { ok: false, reason: 'network_error', message: e instanceof Error ? e.message : 'Network error talking to LLDAP.' };
+  }
+}
+
+export interface LldapUser {
+  id: string;
+  displayName?: string;
+  email?: string;
+}
+
+export type LldapListUsersResult =
+  | { ok: true; users: LldapUser[] }
+  | { ok: false; reason: 'not_configured' | 'unreachable' | 'auth_failed' | 'graphql_error' | 'network_error'; message: string };
+
+/**
+ * List all LLDAP users. Used by the file-share template's Samba sync
+ * (#494) to mirror per-user accounts into Samba's tdbsam DB, and by
+ * future SSO-aware features that need to enumerate the identity
+ * directory.
+ *
+ * Returns the same `{ ok, ... }` discriminated union shape as
+ * `createLldapUser` so callers stay uniform.
+ */
+export async function listLldapUsers(): Promise<LldapListUsersResult> {
+  const auth = await authenticateWithLldap();
+  if (!auth.ok) {
+    return { ok: false, reason: auth.reason, message: auth.message };
+  }
+  try {
+    const res = await fetch(`${auth.baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.token}`,
+      },
+      body: JSON.stringify({ query: LIST_USERS_QUERY }),
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+    const data = await res.json().catch(() => ({})) as {
+      data?: { users?: LldapUser[] };
+      errors?: Array<{ message?: string }>;
+    };
+    if (data.errors?.length) {
+      return { ok: false, reason: 'graphql_error', message: data.errors[0]?.message ?? 'Unknown LLDAP error.' };
+    }
+    return { ok: true, users: data.data?.users ?? [] };
   } catch (e) {
     return { ok: false, reason: 'network_error', message: e instanceof Error ? e.message : 'Network error talking to LLDAP.' };
   }

--- a/templates/file-share/CHANGELOG.md
+++ b/templates/file-share/CHANGELOG.md
@@ -4,6 +4,39 @@ Tracks breaking changes to the `file-share` template's pod structure /
 variable shape. Each H2 corresponds to a value of
 `servicebay.schema-version` in `template.yml`.
 
+## v4 (breaking) — #494
+
+**Per-user Samba accounts via LLDAP → tdbsam sync.**
+
+Samba used to mount the share with a single shared service account
+(`SHARE_USER` / `SHARE_PASSWORD`). Every family member typed the
+same credentials — no audit trail, no per-user permissions, no way
+to revoke one device without rotating everyone's password.
+
+Now each LLDAP user maps to their own Samba `tdbsam` account.
+Samba can't speak OIDC and the Argon2/bcrypt → NT-hash conversion
+isn't reversible, so the password lives in Samba's own DB. Set or
+regenerate it from **Settings → Integrations → File Share** —
+clicking the per-user button flashes a fresh random password once
+for the operator to copy and share.
+
+The share's `SAMBA_VOLUME_CONFIG_data` no longer pins
+`valid users = <SHARE_USER>`; any tdbsam user mounts the share with
+their own LLDAP id. `SHARE_USER` + `SHARE_PASSWORD` remain as a
+backward-compat fallback so existing installs keep working until
+the operator migrates each family member onto their LLDAP account.
+
+Lifecycle is automatic: every visit to **Settings → Integrations →
+File Share** runs the LLDAP → tdbsam sync (adds missing accounts
+with random initial passwords, removes orphans). LLDAP user
+creation in another tab + clicking *Sync* surfaces the new user
+ready for a password set.
+
+Required action: redeploy `file-share`. Existing mounts on
+`SHARE_USER` keep working with the same password. New LLDAP users
+need their Samba password set once via the Settings panel before
+they can mount.
+
 ## v3 (breaking)
 
 **Syncthing GUI behind Authelia.**

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -170,6 +170,27 @@ def main() -> int:
         # silently disappears with the install log scroll. See #317.
         return 1
 
+    # ── Samba ↔ LLDAP first-sync (#494) ────────────────────────────────
+    # Trigger the API endpoint that adds tdbsam accounts for every
+    # LLDAP user. Best-effort: a failure here just means the operator
+    # has to click "Sync" in Settings → Integrations → File Share to
+    # populate accounts. Without this step the operator opens the UI
+    # to an empty list on first install and has to click Sync
+    # themselves; with it, the per-user accounts are ready for a
+    # password-set right after deploy.
+    samba_sync_url = f"{sb_api}/api/system/file-share/samba/users"
+    sync_status, sync_body = post_json(samba_sync_url, {}, timeout=30)
+    if sync_status == 200 and sync_body and sync_body.get("ok"):
+        users = sync_body.get("users") or []
+        added = sync_body.get("added") or []
+        log(f"✅ Samba ↔ LLDAP sync complete — {len(users)} user(s) in directory, {len(added)} new account(s) added with random initial passwords (set them via Settings → Integrations → File Share before first mount).")
+    elif sync_status == 503:
+        log(f"ℹ️  Samba sync skipped: LLDAP not reachable yet. Open Settings → Integrations → File Share once LLDAP is up to populate accounts.")
+    elif sync_status == 404:
+        log(f"ℹ️  Samba sync skipped: file-share-samba container not running yet. Try again once the pod is healthy.")
+    else:
+        log(f"⚠️  Samba ↔ LLDAP sync returned HTTP {sync_status}. Open Settings → Integrations → File Share to populate accounts manually.")
+
     return 0
 
 

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: file-share
   annotations:
     servicebay.label: "File Share (Syncthing + Samba + FileBrowser)"
-    servicebay.schema-version: "3"
+    servicebay.schema-version: "4"
     # FileBrowser is fronted by Authelia via the nginx proxy host — both
     # must be running before this template's post-deploy can wire SSO.
     servicebay.dependencies: "nginx,auth"
@@ -87,7 +87,19 @@ spec:
       - mountPath: /var/syncthing/config
         name: syncthing-config
 
-  # 2. Samba — SMB/CIFS network shares with simple user/password auth
+  # 2. Samba — SMB/CIFS network shares with per-user authentication.
+  #
+  # Per-user accounts are synced from LLDAP into Samba's tdbsam DB by
+  # ServiceBay's /api/system/file-share/samba/users endpoint and managed
+  # operator-side via Settings → Integrations → File Share. Samba can't
+  # speak OIDC, so the password lives in tdbsam — set/regenerated from
+  # the UI, deliberately not derived from the LLDAP password (Argon2/
+  # bcrypt → NT-hash is not a reversible operation).
+  #
+  # SHARE_USER + SHARE_PASSWORD remain as a legacy fallback so existing
+  # installs keep working until the operator migrates family members
+  # onto LLDAP-backed Samba accounts. The share config no longer pins
+  # `valid users` to a single name — any tdbsam user can mount.
   - name: samba
     image: docker.io/servercontainers/samba:latest
     env:
@@ -96,7 +108,7 @@ spec:
       - name: ACCOUNT_{{SHARE_USER}}
         value: "{{SHARE_PASSWORD}}"
       - name: SAMBA_VOLUME_CONFIG_data
-        value: "[data]; path=/data; valid users = {{SHARE_USER}}; guest ok = no; read only = no; browseable = yes;"
+        value: "[data]; path=/data; guest ok = no; read only = no; browseable = yes;"
     volumeMounts:
       - mountPath: /data
         name: shared-data

--- a/tests/backend/sambaSync.test.ts
+++ b/tests/backend/sambaSync.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn() },
+}));
+vi.mock('@/lib/lldap/client', () => ({
+  listLldapUsers: vi.fn(),
+}));
+
+import { agentManager } from '@/lib/agent/manager';
+import { listLldapUsers } from '@/lib/lldap/client';
+import {
+  parsePdbeditList,
+  setSambaPassword,
+  syncSambaWithLldap,
+} from '@/lib/fileShare/sambaSync';
+
+/**
+ * Unit coverage for the LLDAP → Samba tdbsam sync (#494). Mocks the
+ * agent so `pdbedit -L` / `smbpasswd -a` calls are captured in-process,
+ * plus the LLDAP client so the test rig drives both sides.
+ */
+
+interface ExecCall {
+  command: string;
+  stdin?: string;
+}
+
+function makeAgent() {
+  const calls: ExecCall[] = [];
+  const sambaState = new Set<string>();
+  const passwords = new Map<string, string>();
+
+  const sendCommand = vi.fn(async (kind: string, payload: { command: string; stdin?: string }) => {
+    if (kind !== 'exec') throw new Error(`unexpected agent command: ${kind}`);
+    calls.push({ command: payload.command, stdin: payload.stdin });
+    if (payload.command.includes('pdbedit -L')) {
+      const lines = [...sambaState].map(u => `${u}:1000:${u}`).join('\n');
+      return { code: 0, stdout: lines, stderr: '' };
+    }
+    if (payload.command.includes('smbpasswd -s -a')) {
+      const match = payload.command.match(/smbpasswd -s -a ([\w.-]+)/);
+      if (!match) return { code: 1, stdout: '', stderr: 'parse failed' };
+      const user = match[1];
+      sambaState.add(user);
+      // smbpasswd stdin is `pw\npw\n`. Persist the first line.
+      const pw = payload.stdin?.split('\n')[0] ?? '';
+      passwords.set(user, pw);
+      return { code: 0, stdout: '', stderr: '' };
+    }
+    if (payload.command.includes('pdbedit -x -u')) {
+      const match = payload.command.match(/pdbedit -x -u ([\w.-]+)/);
+      if (!match) return { code: 1, stdout: '', stderr: 'parse failed' };
+      sambaState.delete(match[1]);
+      return { code: 0, stdout: '', stderr: '' };
+    }
+    return { code: 1, stdout: '', stderr: `unmocked: ${payload.command}` };
+  });
+
+  vi.mocked(agentManager.ensureAgent).mockResolvedValue({ sendCommand } as never);
+  return { calls, sambaState, passwords };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('parsePdbeditList', () => {
+  it('extracts usernames from real pdbedit output', () => {
+    const stdout = 'alice:1001:Alice Example\nbob:1002:Bob Example\n';
+    expect(parsePdbeditList(stdout)).toEqual(['alice', 'bob']);
+  });
+
+  it('drops blank lines and lines with unsafe usernames', () => {
+    const stdout = '\nvalid:1001:OK\n!evil:1002:nope\n   \ndots.ok:1003:OK\n';
+    expect(parsePdbeditList(stdout)).toEqual(['valid', 'dots.ok']);
+  });
+});
+
+describe('syncSambaWithLldap', () => {
+  it('adds LLDAP users missing from Samba and surfaces them in the result', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [
+        { id: 'alice', displayName: 'Alice' },
+        { id: 'bob', displayName: 'Bob' },
+      ],
+    });
+    const { calls, passwords } = makeAgent();
+    const res = await syncSambaWithLldap('Local');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.added.sort()).toEqual(['alice', 'bob']);
+    expect(res.removed).toEqual([]);
+    expect(res.users.every(u => u.presentInSamba)).toBe(true);
+
+    // smbpasswd was called twice with non-empty stdin.
+    const smbCalls = calls.filter(c => c.command.includes('smbpasswd'));
+    expect(smbCalls).toHaveLength(2);
+    for (const c of smbCalls) {
+      expect(c.stdin).toMatch(/^[A-Za-z0-9]+\n[A-Za-z0-9]+\n$/);
+    }
+    // The two stdin passwords must match the same value duplicated on
+    // both lines (smbpasswd contract).
+    for (const c of smbCalls) {
+      const [a, b] = (c.stdin ?? '').split('\n');
+      expect(a).toBe(b);
+    }
+    // Different users get different random passwords.
+    expect(new Set(passwords.values()).size).toBe(2);
+  });
+
+  it('removes Samba accounts that no longer exist in LLDAP', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'alice' }],
+    });
+    const { calls, sambaState } = makeAgent();
+    sambaState.add('alice');
+    sambaState.add('orphan');
+
+    const res = await syncSambaWithLldap('Local');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.removed).toEqual(['orphan']);
+    expect(res.added).toEqual([]);
+
+    const removeCalls = calls.filter(c => c.command.includes('pdbedit -x'));
+    expect(removeCalls.map(c => c.command)).toContain('podman exec file-share-samba pdbedit -x -u orphan');
+  });
+
+  it('is idempotent — second sync with the same inputs adds + removes nothing', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'alice' }, { id: 'bob' }],
+    });
+    const env = makeAgent();
+    env.sambaState.add('alice');
+    env.sambaState.add('bob');
+
+    const res = await syncSambaWithLldap('Local');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.added).toEqual([]);
+    expect(res.removed).toEqual([]);
+  });
+
+  it('returns lldap_unavailable when the LLDAP client fails', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: false,
+      reason: 'unreachable',
+      message: 'cannot reach LLDAP',
+    });
+    makeAgent();
+    const res = await syncSambaWithLldap('Local');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe('lldap_unavailable');
+  });
+});
+
+describe('setSambaPassword', () => {
+  it('sets the requested password via smbpasswd and reports back', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'alice' }],
+    });
+    const { calls } = makeAgent();
+    const res = await setSambaPassword('alice', { password: 'hunter2x' });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.password).toBe('hunter2x');
+
+    const smb = calls.find(c => c.command.includes('smbpasswd'));
+    expect(smb?.command).toBe('podman exec -i file-share-samba smbpasswd -s -a alice');
+    expect(smb?.stdin).toBe('hunter2x\nhunter2x\n');
+  });
+
+  it('generates a random password when none is provided', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'alice' }],
+    });
+    makeAgent();
+    const r1 = await setSambaPassword('alice');
+    const r2 = await setSambaPassword('alice');
+    expect(r1.ok && r2.ok).toBe(true);
+    if (!r1.ok || !r2.ok) return;
+    expect(r1.password).not.toBe(r2.password);
+    expect(r1.password.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('rejects unknown LLDAP users with not_in_lldap', async () => {
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'alice' }],
+    });
+    makeAgent();
+    const res = await setSambaPassword('stranger');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe('not_in_lldap');
+  });
+
+  it('rejects unsafe usernames before reaching LLDAP or the agent', async () => {
+    const res = await setSambaPassword('alice; rm -rf /');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe('not_in_lldap');
+    // listLldapUsers must NOT have been consulted for invalid input.
+    expect(vi.mocked(listLldapUsers)).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Third and last SSO PR closing the #412 gap list.

## Summary

Samba can't speak OIDC and LLDAP's password hash isn't reversible into an NT-hash, so the locked design (Option A in the issue) keeps Samba's own \`tdbsam\` DB in step with LLDAP and lets the operator set per-user passwords from the Settings UI.

- **Backend** — \`src/lib/fileShare/sambaSync.ts\` wraps the \`smbpasswd\` / \`pdbedit\` shell incantations behind two functions: \`syncSambaWithLldap\` (idempotent add-missing + remove-orphan) and \`setSambaPassword\` (roll or set for one user). Strict ASCII username validation before anything reaches the shell.
- **API** — \`GET/POST /api/system/file-share/samba/users\` returns the merged view + runs the sync as a side effect; \`POST /api/system/file-share/samba/users/[id]/set-password\` rolls or sets one user's password.
- **UI** — new \`FileShareSection\` lands in Settings → Integrations. Per-user button flashes a freshly-rolled password once with a Copy button so the operator can share it out-of-band.
- **Template** — \`file-share/template.yml\` drops \`valid users = <SHARE_USER>\` (any tdbsam user mounts), schema 3 → 4. \`SHARE_USER\` / \`SHARE_PASSWORD\` stay as a legacy fallback so existing installs keep working.
- **post-deploy.py** — calls the new endpoint at the end of install so accounts are ready when the operator opens the Settings section.
- **CHANGELOG** — \`## v4 (breaking)\` section walking the operator through the migration.

## Test plan

- [x] 10 new unit tests for \`sambaSync\` covering parsePdbeditList, add/remove/idempotent sync, password-set happy + reject paths.
- [x] Full suite (773 tests) passes; tsc --noEmit clean.
- [ ] Manual smoke: deploy file-share on a fresh install, create an LLDAP user, click *Set password* in Settings → Integrations → File Share, mount the share from a Windows / macOS client with the flashed credentials.

## Conflict notes

This PR was built off \`main\` before PR-#508 (\`feat/sso-495-adguard-syncthing-forward-auth\`) landed. Both touch \`templates/file-share/template.yml\` and \`CHANGELOG.md\` — the schema-version field collides (\`#508\` bumps 2 → 3, this PR bumps 3 → 4). Easy auto-merge once #508 lands; if not, I'll rebase before merging.

Refs #412, closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)