### PR TITLE
feat(services): surface pending template upgrades on the Services page (partial #510)

### DIFF
--- a/src/app/api/system/templates/upgrades-pending/route.ts
+++ b/src/app/api/system/templates/upgrades-pending/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { getConfig } from '@/lib/config';
+import { getTemplateYaml, getTemplateChangelog } from '@/lib/registry';
+import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
+import { parseChangelog, filterUpgradeSections, hasBreakingChanges } from '@/lib/templateChangelog';
+
+export const dynamic = 'force-dynamic';
+
+interface UpgradeSummary {
+  name: string;
+  installedVersion: number;
+  currentVersion: number;
+  hasBreakingChange: boolean;
+  /** Section headers between the installed and current version, in
+   *  ascending order. The dashboard uses these for the badge tooltip. */
+  sectionHeaders: string[];
+}
+
+/**
+ * GET /api/system/templates/upgrades-pending
+ *
+ * Aggregated answer to "which deployed services have a pending
+ * template upgrade?" — the same comparison the per-template
+ * `upgrade-preview` endpoint does, fanned out across every entry in
+ * `config.installedTemplates`.
+ *
+ * Returned so the Services list can render a per-card badge without
+ * firing N requests on every page load. The shape mirrors
+ * `upgrade-preview` per item, minus the full section bodies (only
+ * the headers — the operator opens the InstallerModal for the full
+ * read-through).
+ *
+ * Filed as #510 alongside the SSO push that surfaced the gap:
+ * three schema-version bumps (file-share, adguard, home-assistant)
+ * would sit unnoticed for any operator who never opens the
+ * Re-deploy modal.
+ */
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const config = await getConfig();
+    const installed = config.installedTemplates ?? {};
+
+    const summaries: UpgradeSummary[] = [];
+    for (const [name, record] of Object.entries(installed)) {
+      // Skip names that wouldn't pass the per-template route's
+      // validation — they can't have a CHANGELOG anyway.
+      if (!/^[a-z][a-z0-9-]{0,63}$/.test(name)) continue;
+      try {
+        const yaml = await getTemplateYaml(name);
+        if (yaml === null) continue;
+        const currentVersion = parseTemplateSchemaVersion(yaml);
+        if (currentVersion <= record.schemaVersion) continue;
+        const changelog = await getTemplateChangelog(name);
+        const allSections = parseChangelog(changelog ?? '');
+        const sections = filterUpgradeSections(allSections, record.schemaVersion, currentVersion);
+        if (sections.length === 0) {
+          // Version moved forward but the template has no CHANGELOG to
+          // explain why — still flag it, but with an empty header
+          // list. The badge falls back to "Upgrade available" tooltip.
+          summaries.push({
+            name,
+            installedVersion: record.schemaVersion,
+            currentVersion,
+            hasBreakingChange: false,
+            sectionHeaders: [],
+          });
+          continue;
+        }
+        summaries.push({
+          name,
+          installedVersion: record.schemaVersion,
+          currentVersion,
+          hasBreakingChange: hasBreakingChanges(sections),
+          // Reconstruct the headers from each section. parseChangelog
+          // strips them from `body`, so we rebuild
+          // "v<N>" or "v<N> (breaking)" so the UI tooltip stays
+          // useful without re-walking the markdown.
+          sectionHeaders: sections.map(s => `v${s.version}${s.breaking ? ' (breaking)' : ''}`),
+        });
+      } catch {
+        // A single template failing yaml-read shouldn't take the
+        // whole aggregate down — the wizard's modal will surface the
+        // real error if the operator clicks Re-deploy on that card.
+      }
+    }
+
+    return NextResponse.json({
+      pending: summaries,
+      hasBreakingChange: summaries.some(s => s.hasBreakingChange),
+    });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:templates:upgrades-pending', status: 500 });
+  }
+}

--- a/src/components/TemplateUpgradesPendingBanner.tsx
+++ b/src/components/TemplateUpgradesPendingBanner.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Info, X } from 'lucide-react';
+
+interface UpgradeSummary {
+  name: string;
+  installedVersion: number;
+  currentVersion: number;
+  hasBreakingChange: boolean;
+  sectionHeaders: string[];
+}
+
+interface PendingResponse {
+  pending: UpgradeSummary[];
+  hasBreakingChange: boolean;
+}
+
+const DISMISS_STORAGE_KEY = 'sb_template_upgrades_dismissed';
+
+/**
+ * Surface a single banner on the Services page when one or more
+ * deployed templates have a newer schema-version available in the
+ * registry. Counterpart to the gap noted in #510 — the per-template
+ * `TemplateUpgradeBanner` only renders inside the InstallerModal, so
+ * an operator who never opens the re-deploy flow would miss SSO /
+ * security tightenings indefinitely.
+ *
+ * Local state only:
+ *  - Dismissal lives in localStorage, keyed by the
+ *    `<template>@<version>` pair. A bump beyond the dismissed
+ *    version re-surfaces the banner so the operator isn't
+ *    permanently silenced after one dismissal.
+ *
+ * The badge-on-each-card variant + the email path stay as follow-ups
+ * tracked in #510 — the visible banner is enough to close the
+ * "silent rollout" hole on its own.
+ */
+function loadDismissed(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem(DISMISS_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as string[];
+    return Array.isArray(parsed) ? new Set(parsed) : new Set();
+  } catch {
+    // localStorage unavailable / corrupted; banner just re-appears.
+    return new Set();
+  }
+}
+
+export default function TemplateUpgradesPendingBanner() {
+  const [data, setData] = useState<PendingResponse | null>(null);
+  const [dismissed, setDismissed] = useState<Set<string>>(loadDismissed);
+
+  useEffect(() => {
+    fetch('/api/system/templates/upgrades-pending')
+      .then(r => (r.ok ? r.json() : null))
+      .then((res: PendingResponse | null) => res && setData(res))
+      .catch(() => undefined);
+  }, []);
+
+  const visible = (data?.pending ?? []).filter(p => !dismissed.has(`${p.name}@${p.currentVersion}`));
+  if (visible.length === 0) return null;
+
+  const dismissAll = () => {
+    const next = new Set(dismissed);
+    for (const p of visible) next.add(`${p.name}@${p.currentVersion}`);
+    setDismissed(next);
+    try {
+      localStorage.setItem(DISMISS_STORAGE_KEY, JSON.stringify([...next]));
+    } catch {
+      // ignore — banner just re-appears next session.
+    }
+  };
+
+  const breaking = visible.some(p => p.hasBreakingChange);
+  const Icon = breaking ? AlertTriangle : Info;
+
+  return (
+    <div
+      className={`mb-4 rounded-lg border ${
+        breaking
+          ? 'border-amber-300 dark:border-amber-700 bg-amber-50/70 dark:bg-amber-900/20'
+          : 'border-blue-200 dark:border-blue-800 bg-blue-50/70 dark:bg-blue-900/20'
+      }`}
+    >
+      <div className="p-4 flex items-start gap-3">
+        <div
+          className={`shrink-0 p-1.5 rounded ${
+            breaking
+              ? 'bg-amber-100 dark:bg-amber-800/30 text-amber-700 dark:text-amber-300'
+              : 'bg-blue-100 dark:bg-blue-800/30 text-blue-700 dark:text-blue-300'
+          }`}
+        >
+          <Icon size={16} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="font-semibold text-sm text-gray-900 dark:text-white">
+            {visible.length} template upgrade{visible.length === 1 ? '' : 's'} available
+            {breaking ? ' — includes breaking changes' : ''}
+          </div>
+          <ul className="mt-2 space-y-1 text-xs text-gray-700 dark:text-gray-300">
+            {visible.map(p => (
+              <li key={p.name} className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono font-medium">{p.name}</span>
+                <span className="text-gray-500 dark:text-gray-400">
+                  v{p.installedVersion} → v{p.currentVersion}
+                </span>
+                {p.sectionHeaders.length > 0 && (
+                  <span className="text-gray-500 dark:text-gray-400">
+                    ({p.sectionHeaders.join(', ')})
+                  </span>
+                )}
+                {p.hasBreakingChange && (
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-amber-200 dark:bg-amber-700/50 text-amber-900 dark:text-amber-100">
+                    breaking
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+            Click <span className="font-medium">Re-deploy</span> on each service below to review the changelog and apply.
+          </p>
+        </div>
+        <button
+          onClick={dismissAll}
+          className="shrink-0 p-1 rounded hover:bg-gray-200/50 dark:hover:bg-gray-700/50 text-gray-500 dark:text-gray-400"
+          title="Dismiss until the next version bump"
+          type="button"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/ServicesPlugin.tsx
+++ b/src/plugins/ServicesPlugin.tsx
@@ -10,6 +10,7 @@ import PluginLoading from '@/components/PluginLoading';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
 import PageHeader from '@/components/PageHeader';
+import TemplateUpgradesPendingBanner from '@/components/TemplateUpgradesPendingBanner';
 import { DomainHealthDot } from '@/components/DomainHealthDot';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
 import PluginHelp from '@/components/PluginHelp';
@@ -1412,8 +1413,9 @@ export default function ServicesPlugin() {
                 }}
             />
 
-      <PageHeader 
-        title="Services" 
+      <TemplateUpgradesPendingBanner />
+      <PageHeader
+        title="Services"
         showBack={false} 
         helpId="services"
         actions={

--- a/tests/backend/upgradesPending.test.ts
+++ b/tests/backend/upgradesPending.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: vi.fn(async () => ({ user: 'test', expires: new Date(Date.now() + 60_000) })),
+}));
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
+vi.mock('@/lib/registry', () => ({
+  getTemplateYaml: vi.fn(),
+  getTemplateChangelog: vi.fn(),
+}));
+
+import { GET } from '@/app/api/system/templates/upgrades-pending/route';
+import { getConfig } from '@/lib/config';
+import { getTemplateYaml, getTemplateChangelog } from '@/lib/registry';
+
+/**
+ * Coverage for #510's aggregated upgrades-pending endpoint. The
+ * per-template `/api/system/templates/[name]/upgrade-preview` route
+ * already has its own integration tests; this file only verifies
+ * that the aggregator filters + composes the right summaries.
+ */
+
+const sampleChangelog = `# Sample
+
+## v4 (breaking)
+
+Did something interesting.
+
+## v3
+
+Did something small.
+
+## v2
+
+initial fix.
+
+## v1
+
+initial.
+`;
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/system/templates/upgrades-pending');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/system/templates/upgrades-pending', () => {
+  it('returns only templates whose installed version is older than the registry', async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      installedTemplates: {
+        'file-share': { schemaVersion: 2, installedAt: '' },
+        adguard: { schemaVersion: 2, installedAt: '' },
+        nginx: { schemaVersion: 1, installedAt: '' },
+      },
+      autoUpdate: { enabled: false, schedule: '' },
+    } as any);
+
+    vi.mocked(getTemplateYaml).mockImplementation(async (name: string) => {
+      if (name === 'file-share') return 'metadata:\n  annotations:\n    servicebay.schema-version: "4"\n';
+      if (name === 'adguard') return 'metadata:\n  annotations:\n    servicebay.schema-version: "2"\n'; // same — no upgrade
+      if (name === 'nginx') return 'metadata:\n  annotations:\n    servicebay.schema-version: "1"\n'; // same — no upgrade
+      return null;
+    });
+    vi.mocked(getTemplateChangelog).mockResolvedValue(sampleChangelog);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.pending).toHaveLength(1);
+    expect(data.pending[0].name).toBe('file-share');
+    expect(data.pending[0].installedVersion).toBe(2);
+    expect(data.pending[0].currentVersion).toBe(4);
+    expect(data.pending[0].sectionHeaders).toContain('v4 (breaking)');
+    expect(data.pending[0].sectionHeaders).toContain('v3');
+    expect(data.hasBreakingChange).toBe(true);
+  });
+
+  it('returns an entry with empty sectionHeaders when version bumped but changelog has no matching section', async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      installedTemplates: { foo: { schemaVersion: 2, installedAt: '' } },
+      autoUpdate: { enabled: false, schedule: '' },
+    } as any);
+    vi.mocked(getTemplateYaml).mockResolvedValue('metadata:\n  annotations:\n    servicebay.schema-version: "3"\n');
+    vi.mocked(getTemplateChangelog).mockResolvedValue('');
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+    expect(data.pending).toHaveLength(1);
+    expect(data.pending[0].sectionHeaders).toEqual([]);
+    expect(data.hasBreakingChange).toBe(false);
+  });
+
+  it('returns an empty array when nothing is deployed', async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      installedTemplates: {},
+      autoUpdate: { enabled: false, schedule: '' },
+    } as any);
+    const res = await GET(makeRequest());
+    const data = await res.json();
+    expect(data.pending).toEqual([]);
+    expect(data.hasBreakingChange).toBe(false);
+  });
+
+  it('skips templates whose yaml could not be read instead of failing the whole call', async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      installedTemplates: {
+        good: { schemaVersion: 1, installedAt: '' },
+        broken: { schemaVersion: 1, installedAt: '' },
+      },
+      autoUpdate: { enabled: false, schedule: '' },
+    } as any);
+    vi.mocked(getTemplateYaml).mockImplementation(async (name: string) => {
+      if (name === 'broken') throw new Error('disk read failure');
+      return 'metadata:\n  annotations:\n    servicebay.schema-version: "2"\n';
+    });
+    vi.mocked(getTemplateChangelog).mockResolvedValue(sampleChangelog);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.pending.map((p: { name: string }) => p.name)).toEqual(['good']);
+  });
+});


### PR DESCRIPTION
Ships the *banner* surface from #510 — the most visible of the three asks. The per-card badge / health-check row / email channels stay open in #510 because they touch external systems and warrant a separate design pass.

## Summary

- **\`/api/system/templates/upgrades-pending\`** (new) — single GET aggregates every \`config.installedTemplates\` entry whose current schema-version exceeds the installed one. Returns \`installedVersion → currentVersion\`, the matching CHANGELOG section headers, and a \`hasBreakingChange\` flag per service. One call replaces N \`upgrade-preview\` calls.
- **\`<TemplateUpgradesPendingBanner />\`** mounts above the Services page header. Lists each pending service with version arrows, section-header chips, and a *breaking* tag when applicable. Click *Re-deploy* on the affected service to enter the existing flow.
- Per-version dismissal via \`localStorage\` (key \`<template>@<version>\`) — dismissed once, re-surfaces after the next bump so an operator who acknowledged v3 still sees v4 when it lands.

## What's deliberately out of scope (still tracked in #510)

- **Service card badge** — would require weaving into the 1,972-line \`ServicesPlugin.tsx\` render loop. Lower-risk surface to ship later once the banner proves the data contract.
- **Health-check row** — needs a new \`check-type: 'template_upgrades'\` plus a runner method.
- **Operator email** — needs dedup state in \`config\` (\`templateUpgradeNotifications\`) + a fresh send-once-per-version path. Email touches operator inboxes — deserves a separate explicit ack.

## Test plan

- [x] 4 unit tests covering version-delta filter, empty changelog fallback, empty installedTemplates, per-template error isolation.
- [x] Full suite (781 tests) passes; tsc --noEmit clean; no new lint warnings.
- [ ] Manual smoke: install a service, bump its schema-version locally, restart server → banner appears on Services page.

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)