### PR TITLE
fix(installer): auto-select node on single-node installs

### DIFF
--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -54,7 +54,13 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
   const allUpgradesReady = checkedItems.length > 0 && checkedItems.every(i => upgradeReady[i.name] === true);
 
   useEffect(() => {
-    getNodes().then(setNodes);
+    getNodes().then(ns => {
+      setNodes(ns);
+      // Single-node installs: the picker in StackInstallFlow hides itself
+      // when nodes.length <= 1, so without this the Install button would
+      // stay disabled forever (selectedNode never gets set).
+      if (ns.length === 1) setSelectedNode(ns[0].Name);
+    });
   }, []);
 
   // Reset state when re-opening (modal persists in the DOM between opens).


### PR DESCRIPTION
## Summary
- Install button stayed disabled forever on single-node setups: `StackInstallFlow` hides its node picker when `nodes.length <= 1`, but `InstallerModal` defaulted `selectedNode` to `''` and the button's disabled clause requires it to be non-empty.
- Auto-select the lone node when `getNodes()` returns exactly one entry. Multi-node installs keep their explicit picker.

## Test plan
- [ ] Single-node install: open the Installer for any template, fill required vars, confirm the Install button is enabled without further input.
- [ ] Multi-node install: picker still appears, Install stays disabled until a node is chosen.
- [ ] Zero-node edge case: button remains disabled (nothing to install on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)