### PR TITLE
fix(installer): hide Clean install on single-template re-deploys

### DIFF
--- a/src/components/InstallerModal.tsx
+++ b/src/components/InstallerModal.tsx
@@ -235,6 +235,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
               nodes={nodes}
               selectedNode={selectedNode}
               onSelectNode={setSelectedNode}
+              allowCleanInstall={template.type === 'stack'}
               deviceContext={{
                 deviceOptions,
                 loadingDevices,

--- a/src/components/StackInstallFlow.tsx
+++ b/src/components/StackInstallFlow.tsx
@@ -57,6 +57,11 @@ interface ConfigureFormProps extends CommonProps {
   beforeVariables?: React.ReactNode;
   /** Rendered below the variable form. */
   afterVariables?: React.ReactNode;
+  /** Show the Clean install toggle. Defaults to true. Single-template
+   *  re-deploys (e.g. the upgrade banner) pass false because the
+   *  reset action is system-wide — wiping every stack to update one
+   *  service is never what the operator meant. */
+  allowCleanInstall?: boolean;
 }
 
 export function StackInstallConfigureForm({
@@ -68,6 +73,7 @@ export function StackInstallConfigureForm({
   deviceContext,
   beforeVariables,
   afterVariables,
+  allowCleanInstall = true,
 }: ConfigureFormProps) {
   const { variables, cleanInstall, cleanInstallConfirm, setCleanInstall, setCleanInstallConfirm, setVariableValue, setVariableExposure } = controller;
   const groups = groupVariablesByTemplate(variables).filter(g => g.key !== '_global');
@@ -91,37 +97,39 @@ export function StackInstallConfigureForm({
         </div>
       )}
 
-      <div className="border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
-        <label className="flex items-start gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={cleanInstall}
-            onChange={(e) => { setCleanInstall(e.target.checked); if (!e.target.checked) setCleanInstallConfirm(''); }}
-            className="mt-0.5"
-          />
-          <div className="text-sm text-amber-900 dark:text-amber-100">
-            <strong>Clean install</strong> — wipe existing service data first.
-            <p className="text-xs text-amber-800 dark:text-amber-200/80 mt-1">
-              Stops every stack service, deletes their Quadlet definitions and the contents of <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code>. ServiceBay itself is not affected.
-            </p>
-          </div>
-        </label>
-        {cleanInstall && (
-          <div className="mt-3 pt-3 border-t border-amber-300 dark:border-amber-700">
-            <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
-              Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
-            </label>
+      {allowCleanInstall && (
+        <div className="border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
+          <label className="flex items-start gap-2 cursor-pointer">
             <input
-              type="text"
-              value={cleanInstallConfirm}
-              onChange={(e) => setCleanInstallConfirm(e.target.value)}
-              className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
-              placeholder="RESET"
-              autoComplete="off"
+              type="checkbox"
+              checked={cleanInstall}
+              onChange={(e) => { setCleanInstall(e.target.checked); if (!e.target.checked) setCleanInstallConfirm(''); }}
+              className="mt-0.5"
             />
-          </div>
-        )}
-      </div>
+            <div className="text-sm text-amber-900 dark:text-amber-100">
+              <strong>Clean install</strong> — wipe existing service data first.
+              <p className="text-xs text-amber-800 dark:text-amber-200/80 mt-1">
+                Stops every stack service, deletes their Quadlet definitions and the contents of <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code>. ServiceBay itself is not affected.
+              </p>
+            </div>
+          </label>
+          {cleanInstall && (
+            <div className="mt-3 pt-3 border-t border-amber-300 dark:border-amber-700">
+              <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
+                Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
+              </label>
+              <input
+                type="text"
+                value={cleanInstallConfirm}
+                onChange={(e) => setCleanInstallConfirm(e.target.value)}
+                className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
+                placeholder="RESET"
+                autoComplete="off"
+              />
+            </div>
+          )}
+        </div>
+      )}
 
       {beforeVariables}
 
@@ -372,6 +380,7 @@ export default function StackInstallFlow(props: {
   afterVariables?: React.ReactNode;
   beforeLog?: React.ReactNode;
   doneFooter?: React.ReactNode;
+  allowCleanInstall?: boolean;
 }) {
   const phase = props.controller.phase;
   if (phase === 'configure') {
@@ -385,6 +394,7 @@ export default function StackInstallFlow(props: {
         deviceContext={props.deviceContext}
         beforeVariables={props.beforeVariables}
         afterVariables={props.afterVariables}
+        allowCleanInstall={props.allowCleanInstall}
       />
     );
   }


### PR DESCRIPTION
## Summary
- The Clean install toggle calls `/api/system/stacks/reset`, which is **system-wide**: it stops + deletes every service on the node and `rm -rf`s `/mnt/data/stacks/*`. Appropriate from onboarding or a stack install. Not appropriate from the Services-page upgrade banner.
- Ticking it on a single-template re-deploy (e.g. "update file-share") silently destroyed every other service on the node — nginx, auth, adguard, home-assistant, etc. — and wiped all their data.
- Gate the toggle behind a new `allowCleanInstall` prop. `InstallerModal` passes `template.type === 'stack'` so the toggle is hidden for the single-template path. Controller state defaults to false and resets on every open, so hiding the UI is a complete fix.

## Test plan
- [ ] Single-template re-deploy from the upgrade banner: Clean install block is not rendered.
- [ ] Stack install on /registry: Clean install block still appears and works.
- [ ] Onboarding wizard's clean-install path (if any) is unaffected — it composes its own form, this only touches the modal/flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)