### PR TITLE
fix(home-assistant): pin zwave-js WS port via ZWAVE_EXTERNAL_SETTINGS

### DIFF
--- a/templates/home-assistant/CHANGELOG.md
+++ b/templates/home-assistant/CHANGELOG.md
@@ -10,6 +10,35 @@ operator's installed schema-version and the current one and surfaces
 them in the re-deploy dialog. Each `(breaking)` section needs an
 explicit acknowledgement before the deploy can proceed.
 
+## v6
+
+**Z-Wave JS WS server pinned via `ZWAVE_EXTERNAL_SETTINGS`.**
+
+Z-Wave JS UI needs its HA WebSocket server enabled and bound to a
+port other than 3000 — port 3000 on the host is occupied by NPM's
+internal admin backend (NPM uses `hostNetwork`, so its container's
+`127.0.0.1:3000` listener takes the host's `127.0.0.1:3000`). The
+previous post-deploy patched `gateway.wsServer` / `gateway.wsServerPort`
+via the REST API; those field names don't exist in zwave-js-ui, so
+the patch silently did nothing and operators had to enable the
+server in the UI by hand.
+
+This release adds a `ZWAVE_EXTERNAL_SETTINGS` env var on the
+`zwave-js` container pointing at
+`/usr/src/app/store/sb-external-settings.json`. The post-deploy
+seeds that file with `serverEnabled: true`, `serverPort: 3001`,
+`serverHost: "0.0.0.0"` on first install and restarts the zwave-js
+container so the values take effect immediately. Subsequent deploys
+detect the file and skip; if you'd rather manage the WS server
+yourself via the UI, set a `zwave.serverPort` in
+`/usr/src/app/store/settings.json` *before* re-deploying and the
+post-deploy will skip writing the override.
+
+Required action: nothing. Existing installs continue to work — if
+you'd previously configured the WS server manually in the UI, that
+config wins because the seeding step honours your existing
+`settings.json`.
+
 ## v5 (breaking) — #493
 
 **OIDC SSO via the `auth_oidc` custom component.**

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -12,11 +12,15 @@ Responsibilities:
      mode 0666. The rule fires on every device detection event, survives
      reboots and re-installs on any machine.
 
-  2. **Z-Wave JS WS port** — configures the Z-Wave JS UI Home Assistant
-     WebSocket server to port 3001 (NPM's admin UI occupies port 3000 on the
-     same hostNetwork pod, so 3000 is always taken). Waits for Z-Wave JS UI to
-     be up on port 8091, then PATCHes gateway.wsServer + gateway.wsServerPort
-     via the REST API. Idempotent — skips if already correct.
+  2. **Z-Wave JS WS port** — seeds the JSON file pointed at by the
+     `ZWAVE_EXTERNAL_SETTINGS` env var (declared in template.yml) so
+     zwave-js-ui binds its HA WebSocket server on port 3001. Port 3000 is
+     unavailable on the host because NPM uses hostNetwork and its internal
+     admin backend binds 127.0.0.1:3000 — even though the host nginx in the
+     same container only exposes 80/443/81 externally. The external-settings
+     file is read by zwave-js-ui on every boot; we only write it when it's
+     missing AND the operator has not already configured a serverPort via
+     the UI (stored in settings.json under `zwave.serverPort`).
 
   3. **auth_oidc custom component** — downloads the pinned release tarball
      of the `auth_oidc` HA custom component (#493) and drops it into
@@ -44,10 +48,9 @@ import urllib.request
 UDEV_RULE_DIR = "/etc/udev/rules.d"
 UDEV_RULE_FILE = "99-zwave.rules"
 
-ZWAVEJS_API = "http://127.0.0.1:8091"
 ZWAVEJS_WS_PORT = 3001
-ZWAVEJS_READY_TIMEOUT = 60.0
-ZWAVEJS_READY_INTERVAL = 2.0
+ZWAVEJS_WS_HOST = "0.0.0.0"
+ZWAVE_CONTAINER_NAME = "home-assistant-zwave-js"
 REQUEST_TIMEOUT = 10.0
 
 # auth_oidc install
@@ -119,63 +122,80 @@ def _reload_udev(zwave_device: str) -> None:
 
 # ── Z-Wave JS WS port ──────────────────────────────────────────────────────────
 
-def _request(method: str, url: str, payload: object | None = None) -> tuple[int, object | None]:
-    body = json.dumps(payload).encode() if payload is not None else None
-    headers = {"Accept": "application/json", "Content-Type": "application/json"}
-    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+def _zwave_store_dir() -> str:
+    """Host-side path of the zwave-js container's /usr/src/app/store
+    mount. Must stay in sync with the volume declaration in
+    template.yml."""
+    base = env("DATA_DIR", "/mnt/data")
+    return os.path.join(base, "home-assistant", "zwave-js")
+
+
+def _zwave_external_settings_path() -> str:
+    # Filename must match the ZWAVE_EXTERNAL_SETTINGS env var in template.yml.
+    return os.path.join(_zwave_store_dir(), "sb-external-settings.json")
+
+
+def _zwave_ui_has_serverport() -> bool:
+    """True iff settings.json (written by zwave-js-ui when the operator
+    saves anything in Settings → Home Assistant) already pins a
+    serverPort. We honour that and leave the external-settings file
+    unwritten — external settings would otherwise silently override
+    the operator's choice on every boot."""
+    in_store = os.path.join(_zwave_store_dir(), "settings.json")
     try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
-            raw = resp.read().decode()
-            return resp.status, json.loads(raw) if raw else None
-    except urllib.error.HTTPError as e:
-        try:
-            return e.code, json.loads(e.read().decode())
-        except Exception:  # pylint: disable=broad-except
-            return e.code, None
-    except Exception:  # pylint: disable=broad-except
-        return 0, None
+        with open(in_store, encoding="utf-8") as fh:
+            stored = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(stored.get("zwave", {}).get("serverPort"))
 
 
-def _wait_zwavejs_ready() -> bool:
-    deadline = time.time() + ZWAVEJS_READY_TIMEOUT
-    while time.time() < deadline:
-        code, _ = _request("GET", f"{ZWAVEJS_API}/api/health")
-        if code == 200:
-            return True
-        time.sleep(ZWAVEJS_READY_INTERVAL)
-    return False
+def ensure_zwave_external_settings() -> bool:
+    """Seed the JSON file zwave-js-ui reads via ZWAVE_EXTERNAL_SETTINGS.
+    Returns True iff a file was just written (caller restarts the
+    zwave-js container so the new values take effect immediately —
+    without that, the operator would only see the change on the next
+    reboot)."""
+    path = _zwave_external_settings_path()
+    if os.path.isfile(path):
+        log(f"   {os.path.basename(path)} already in place — leaving untouched.")
+        return False
+    if _zwave_ui_has_serverport():
+        log("   Existing UI-configured serverPort found in settings.json — not overriding.")
+        return False
+
+    desired = {
+        "serverEnabled": True,
+        "serverPort": ZWAVEJS_WS_PORT,
+        "serverHost": ZWAVEJS_WS_HOST,
+    }
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(desired, fh, indent=2)
+            fh.write("\n")
+    except OSError as exc:
+        log(f"   ⚠️ Could not write {path}: {exc}. Z-Wave JS will need WS server enabled in the UI.")
+        return False
+    log(f"   wrote {path}: serverEnabled=true, serverPort={ZWAVEJS_WS_PORT}, serverHost={ZWAVEJS_WS_HOST}")
+    return True
 
 
-def configure_ws_port() -> None:
-    log(f"   Waiting for Z-Wave JS UI (port 8091)...")
-    if not _wait_zwavejs_ready():
-        log("   ⚠️  Z-Wave JS UI not ready in time.")
-        log(f"   Set WS port manually: Settings → Home Assistant → WS Server Port → {ZWAVEJS_WS_PORT}")
-        return
-
-    code, data = _request("GET", f"{ZWAVEJS_API}/api/settings")
-    if code != 200 or not isinstance(data, dict):
-        log(f"   ⚠️  GET /api/settings failed (HTTP {code}). Set WS port manually.")
-        return
-
-    # The settings object may be top-level or wrapped in a "settings" key.
-    settings = data.get("settings", data)
-    gateway = settings.get("gateway", {})
-
-    if gateway.get("wsServer") is True and gateway.get("wsServerPort") == ZWAVEJS_WS_PORT:
-        log(f"   Z-Wave JS WS server already on port {ZWAVEJS_WS_PORT} — skipping.")
-        return
-
-    gateway["wsServer"] = True
-    gateway["wsServerPort"] = ZWAVEJS_WS_PORT
-    settings["gateway"] = gateway
-
-    post_body = {"settings": settings} if "settings" in data else settings
-    code2, _ = _request("POST", f"{ZWAVEJS_API}/api/settings", post_body)
-    if code2 in (200, 201, 204):
-        log(f"   ✅ Z-Wave JS WS server set to port {ZWAVEJS_WS_PORT}.")
-    else:
-        log(f"   ⚠️  POST /api/settings failed (HTTP {code2}). Set WS port manually.")
+def restart_zwave_js() -> None:
+    try:
+        result = subprocess.run(
+            ["podman", "container", "restart", ZWAVE_CONTAINER_NAME],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            log(f"   restarted {ZWAVE_CONTAINER_NAME} so the new settings take effect.")
+        else:
+            log(f"   ⚠️ podman restart {ZWAVE_CONTAINER_NAME} exited {result.returncode}: {result.stderr.strip()}")
+            log("   New WS settings will load on next pod restart.")
+    except (subprocess.SubprocessError, OSError) as exc:
+        log(f"   ⚠️ Could not restart zwave-js: {exc}. Settings will apply on next pod restart.")
 
 
 # ── auth_oidc custom component (#493) ────────────────────────────────────────
@@ -399,12 +419,13 @@ def main() -> int:
         log(f"Z-Wave stick configured ({zwave_device}) — ensuring host udev permissions...")
         ensure_udev_rule(zwave_device)
         log("✅ Z-Wave JS will have device access after each system boot.")
-
-        log(f"Configuring Z-Wave JS WS server port ({ZWAVEJS_WS_PORT})...")
-        configure_ws_port()
-        log(f"✅ Connect Home Assistant to Z-Wave JS: ws://localhost:{ZWAVEJS_WS_PORT}")
     else:
-        log("No ZWAVE_DEVICE set — skipping udev rule and WS port config.")
+        log("No ZWAVE_DEVICE set — skipping udev rule.")
+
+    log(f"Seeding Z-Wave JS WS server config (port {ZWAVEJS_WS_PORT})...")
+    if ensure_zwave_external_settings():
+        restart_zwave_js()
+    log(f"✅ Connect Home Assistant to Z-Wave JS: ws://localhost:{ZWAVEJS_WS_PORT}")
 
     configure_auth_oidc()
 

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: home-assistant
   annotations:
     servicebay.label: "Home Assistant"
-    servicebay.schema-version: "5"
+    servicebay.schema-version: "6"
     # Home Assistant is reached at home.<domain> via nginx, and (when
     # the operator enables it) authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"
@@ -45,6 +45,14 @@ spec:
       value: "{{ZWAVE_SECRET}}"
     - name: ZWAVEJS_EXTERNAL_CONFIG
       value: "/usr/src/app/store/.config-db"
+    # Pre-seeded by post-deploy on first install: pins serverEnabled=true
+    # and serverPort=3001 so the HA → zwave-js websocket binds off port
+    # 3000 (which NPM's internal admin backend occupies on the same host
+    # under hostNetwork). zwave-js-ui re-reads this file on every boot;
+    # overrides anything the operator may set in the UI's "Home Assistant"
+    # tab, so deleting the file is the escape hatch for manual control.
+    - name: ZWAVE_EXTERNAL_SETTINGS
+      value: "/usr/src/app/store/sb-external-settings.json"
     volumeMounts:
     - mountPath: /usr/src/app/store
       name: zwave-config

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -430,6 +430,74 @@ class HomeAssistantScript(unittest.TestCase):
         self.assertIn("No ZWAVE_DEVICE set", out)
         self.assertIn("HA did not respond", out)
 
+    def test_seeds_zwave_external_settings_on_first_install(self):
+        """`ensure_zwave_external_settings` must write the file with the
+        correct keys + values when the store dir is empty, and skip
+        when an operator-managed settings.json already pins a
+        serverPort. The container restart is best-effort and must not
+        crash the run even when podman isn't on PATH."""
+        import tempfile
+        import urllib.error
+        import urllib.request
+
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {"HA_OIDC_AUTH_VERSION": "v0.6.0", "DATA_DIR": tmp}
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen",
+                                      lambda *_a, **_kw: (_ for _ in ()).throw(urllib.error.URLError("nope"))), \
+                    mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("Seeding Z-Wave JS WS server config", out)
+            self.assertIn("serverPort=3001", out)
+
+            seeded = os.path.join(tmp, "home-assistant", "zwave-js", "sb-external-settings.json")
+            self.assertTrue(os.path.isfile(seeded), f"expected file at {seeded}")
+            with open(seeded) as fh:
+                data = json.load(fh)
+            self.assertEqual(data, {"serverEnabled": True, "serverPort": 3001, "serverHost": "0.0.0.0"})
+
+            # Second run: file exists, must not be touched + must log skip.
+            mtime_before = os.path.getmtime(seeded)
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen",
+                                      lambda *_a, **_kw: (_ for _ in ()).throw(urllib.error.URLError("nope"))), \
+                    mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc2, out2 = capture_main(m)
+            self.assertEqual(rc2, 0)
+            self.assertIn("already in place", out2)
+            self.assertEqual(os.path.getmtime(seeded), mtime_before)
+
+    def test_skips_external_settings_when_ui_serverport_already_set(self):
+        """If settings.json already has a `zwave.serverPort`, the operator
+        chose it via the UI — don't override silently."""
+        import tempfile
+        import urllib.error
+        import urllib.request
+
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            zwave_dir = os.path.join(tmp, "home-assistant", "zwave-js")
+            os.makedirs(zwave_dir, exist_ok=True)
+            with open(os.path.join(zwave_dir, "settings.json"), "w") as fh:
+                json.dump({"zwave": {"serverPort": 8888}}, fh)
+
+            env = {"HA_OIDC_AUTH_VERSION": "v0.6.0", "DATA_DIR": tmp}
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen",
+                                      lambda *_a, **_kw: (_ for _ in ()).throw(urllib.error.URLError("nope"))), \
+                    mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("UI-configured serverPort", out)
+            self.assertFalse(os.path.isfile(os.path.join(zwave_dir, "sb-external-settings.json")))
+
     def test_already_installed_skips_download(self):
         """When the on-disk version stamp matches HA_OIDC_AUTH_VERSION,
         the script must skip the tarball download entirely. We assert


### PR DESCRIPTION
## Summary
- The old post-deploy patched `gateway.wsServer` / `gateway.wsServerPort` via zwave-js-ui's REST API. **Those field names don't exist in zwave-js-ui** — verified via `gh search code` against `zwave-js/zwave-js-ui`, zero matches. The actual fields are `zwave.serverEnabled` / `zwave.serverPort`. So the patch silently did nothing and operators had to enable the WS server in the UI by hand.
- Switch to the documented `ZWAVE_EXTERNAL_SETTINGS` mechanism: add an env var on the `zwave-js` container pointing at `sb-external-settings.json` under its store mount. The post-deploy seeds that file with the *correct* keys on first install and restarts the container.
- UI override still possible: if `settings.json` already pins a `zwave.serverPort`, the seeder leaves it alone.
- Also fixes the misleading comment that claimed NPM runs on port 3000 *in the same hostNetwork pod* — NPM is in its own pod; the host-port conflict comes from NPM's internal admin backend binding `127.0.0.1:3000` under hostNetwork.
- Schema bump 5 → 6, non-breaking (existing manual UI configs win; no required action).

## Test plan
- [x] `tests/templates/test_post_deploy.py::HomeAssistantScript` — 4 tests pass (existing 2 + 2 new for the seeding logic).
- [x] Template consistency + migration tests pass.
- [ ] Fresh install: confirm `sb-external-settings.json` is written, zwave-js-ui binds WS on `127.0.0.1:3001`, HA's Z-Wave integration picks it up at `ws://localhost:3001`.
- [ ] Existing install with UI-configured serverPort: confirm the seeder skips and the UI value continues to win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)