### PR TITLE
fix(home-assistant): pin auth_oidc to v1.1.0 + quiet zwave restart race

### DIFF
--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -191,9 +191,18 @@ def restart_zwave_js() -> None:
         )
         if result.returncode == 0:
             log(f"   restarted {ZWAVE_CONTAINER_NAME} so the new settings take effect.")
-        else:
-            log(f"   ⚠️ podman restart {ZWAVE_CONTAINER_NAME} exited {result.returncode}: {result.stderr.strip()}")
-            log("   New WS settings will load on next pod restart.")
+            return
+        stderr = result.stderr.strip()
+        # First-deploy race: post-deploy ran before podman play kube
+        # finished spawning the pod's containers. The container will
+        # come up shortly and pick the env-var + file up on its first
+        # boot, so no restart is needed — only flag genuine restart
+        # failures.
+        if "no such container" in stderr.lower() or "no container with name" in stderr.lower():
+            log(f"   {ZWAVE_CONTAINER_NAME} not running yet — settings will apply when the pod brings it up.")
+            return
+        log(f"   ⚠️ podman restart {ZWAVE_CONTAINER_NAME} exited {result.returncode}: {stderr}")
+        log("   New WS settings will load on next pod restart.")
     except (subprocess.SubprocessError, OSError) as exc:
         log(f"   ⚠️ Could not restart zwave-js: {exc}. Settings will apply on next pod restart.")
 
@@ -376,7 +385,7 @@ def verify_oidc_endpoint(timeout: float = 90.0) -> bool:
 
 
 def configure_auth_oidc() -> None:
-    version = env("HA_OIDC_AUTH_VERSION", "v0.6.0").strip()
+    version = env("HA_OIDC_AUTH_VERSION", "v1.1.0").strip()
     if not version:
         log("⚠️  HA_OIDC_AUTH_VERSION is empty — skipping auth_oidc install.")
         return

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -32,7 +32,7 @@
   "HA_OIDC_AUTH_VERSION": {
     "type": "text",
     "description": "Pinned release tag of the auth_oidc custom component (https://github.com/christiaangoossens/hass-oidc-auth). post-deploy downloads + extracts the matching tarball into <config>/custom_components/auth_oidc/ on every deploy and skips the network round-trip when the on-disk version stamp already matches. Bump this string and re-deploy to upgrade.",
-    "default": "v0.6.0"
+    "default": "v1.1.0"
   },
   "HA_OIDC_ADMIN_GROUP": {
     "type": "text",


### PR DESCRIPTION
## Summary
Two bugs surfaced from the user's fresh onboarding run on v3.40.4:

1. **HA OIDC never installs.** The pinned default `HA_OIDC_AUTH_VERSION=v0.6.0` doesn't exist — never did. The integration jumped from `v0.6.5-alpha` to `v1.0.x` → currently `v1.1.0`. Every fresh HA install 404'd on the tarball fetch, leaving `custom_components/auth_oidc/` empty and HA SSO broken. Bump default to **v1.1.0**. YAML config keys we render (`client_id`, `client_secret`, `discovery_url`, `features.{automatic_user_linking,automatic_person_creation}`, `roles.{admin,user}`) are all unchanged in 1.x per the integration's `docs/configuration.md`.
2. **Noisy zwave-js restart warning.** post-deploy v6 runs `podman container restart home-assistant-zwave-js` after seeding `sb-external-settings.json`. On first deploy the pod is still spawning, so the container doesn't exist yet → restart fails → warning. The env var + on-disk file already make the container come up correctly on its first start, so a restart is purely an optimization for "container already running." Treat `no such container` stderr as the benign first-deploy race instead of flagging it.

## Test plan
- [x] `tests/templates/test_post_deploy.py::HomeAssistantScript` — 4 tests pass.
- [ ] Fresh HA deploy: confirm `custom_components/auth_oidc/.sb_installed_version` contains `v1.1.0` and `/auth/oidc/welcome` responds.
- [ ] Re-deploy with `home-assistant-zwave-js` already running: confirm restart succeeds and the noisy warning is absent.
- [ ] Fresh deploy: confirm log shows "home-assistant-zwave-js not running yet — settings will apply when the pod brings it up" instead of the `exited 125` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)