### PR TITLE
fix: post-install polish (link scheme, device discovery, sidecar ports)

### DIFF
--- a/src/app/api/system/devices/route.ts
+++ b/src/app/api/system/devices/route.ts
@@ -4,7 +4,23 @@ import { apiError } from '@/lib/api/errors';
 
 export const dynamic = 'force-dynamic';
 
-/** List device files from a directory on the target node (e.g. /dev/serial/by-id). */
+/**
+ * List device files from a directory on the target node.
+ *
+ * When `path` is `/dev/serial/by-id` (the Linux convention for stable
+ * USB-serial naming) the endpoint resolves each symlink to its
+ * canonical `/dev/tty*` target. Podman's `CharDevice` mount doesn't
+ * follow symlinks, so returning the resolved path is what makes the
+ * variable usable as a device mount. Side effect: the result is
+ * pre-filtered to actual USB-serial devices (null/zero/random/…
+ * never appear under /dev/serial/by-id), so the InstallerModal's
+ * "auto-pick when there's exactly one device" rule fires reliably
+ * for the single-stick Z-Wave / Zigbee case.
+ *
+ * For any other `path` the endpoint falls back to a flat `ls -1`,
+ * preserving the previous behavior for callers that already pass an
+ * explicit folder.
+ */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const nodeName = searchParams.get('node');
@@ -14,17 +30,30 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Missing node parameter' }, { status: 400 });
   }
 
+  // Refuse anything that isn't a plain absolute path so an injected
+  // `path` can't smuggle shell metacharacters into the exec below.
+  if (!/^\/[a-zA-Z0-9_./-]+$/.test(devicePath)) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 });
+  }
+
   try {
     const agent = await agentManager.ensureAgent(nodeName);
-    const res = await agent.sendCommand('exec', {
-      command: `ls -1 ${devicePath} 2>/dev/null || echo ""`
-    });
+    // For /dev/serial/by-id, resolve each entry's symlink target so
+    // callers get a CharDevice-mountable path. Sort + dedupe so a
+    // multi-radio stick (one device, multiple by-id symlinks like
+    // `…-if00` / `…-if01`) doesn't double up. For other paths, plain
+    // ls -1 like before.
+    const isByIdPath = devicePath === '/dev/serial/by-id';
+    const cmd = isByIdPath
+      ? `for f in ${devicePath}/*; do [ -e "$f" ] && readlink -f "$f"; done 2>/dev/null | sort -u`
+      : `ls -1 ${devicePath} 2>/dev/null || echo ""`;
+    const res = await agent.sendCommand('exec', { command: cmd });
 
     const devices = (res.stdout || '')
       .split('\n')
       .map((d: string) => d.trim())
       .filter(Boolean)
-      .map((name: string) => `${devicePath}/${name}`);
+      .map((name: string) => isByIdPath ? name : `${devicePath}/${name}`);
 
     return NextResponse.json({ devices });
   } catch (error) {

--- a/src/plugins/ServicesPlugin.tsx
+++ b/src/plugins/ServicesPlugin.tsx
@@ -574,6 +574,27 @@ export default function ServicesPlugin() {
         setShowRegistryOverlay(false);
     }, []);
 
+    // Domains the reverse proxy actually serves over HTTPS. LAN-only
+    // routes (NPM access-list locked, no LE cert provisioned) only
+    // listen on port 80; linking them via https:// gives the operator
+    // a TLS error on first click. Cross-reference each verifiedDomain
+    // against the proxy's per-server `listen` array — a "443 ssl" entry
+    // means the domain has an active TLS listener.
+    const httpsDomains = useMemo(() => {
+        const out = new Set<string>();
+        type ProxyServer = { server_name?: string[]; listen?: string[] };
+        const proxyService = services.find(s =>
+            (s as ServiceViewModel & { proxyConfiguration?: { servers?: ProxyServer[] } }).proxyConfiguration?.servers,
+        ) as (ServiceViewModel & { proxyConfiguration?: { servers?: ProxyServer[] } }) | undefined;
+        const proxyServers = proxyService?.proxyConfiguration?.servers ?? [];
+        for (const srv of proxyServers) {
+            const hasTls = (srv.listen ?? []).some(l => /\b443\b.*\bssl\b|\bssl\b.*\b443\b|^443\s+ssl$/.test(l));
+            if (!hasTls) continue;
+            for (const name of srv.server_name ?? []) out.add(name.toLowerCase());
+        }
+        return out;
+    }, [services]);
+
     const ServiceCard = ({ service }: { service: ServiceViewModel }) => {
         const dedupedPorts = useMemo(() => {
             const uniquePortsMap = new Map<string, ServicePort>();
@@ -742,11 +763,16 @@ export default function ServicesPlugin() {
                                             // `localhost-nginx-proxy-manager` slip through unchanged.
                                             const bareDomain = d.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
                                             const looksLikeDomain = /\./.test(bareDomain);
+                                            // Pick the scheme NPM actually serves for this domain.
+                                            // LAN-only services have no 443 listener → linking
+                                            // them via https:// produces a TLS error on click.
+                                            const scheme = httpsDomains.has(bareDomain.toLowerCase()) ? 'https' : 'http';
+                                            const href = d.startsWith('http') ? d : `${scheme}://${d}`;
                                             return (
                                                 <span key={d} className="inline-flex items-center gap-1.5 text-xs font-mono text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 px-1.5 py-0.5 rounded">
                                                     {looksLikeDomain && <DomainHealthDot domain={bareDomain} />}
                                                     <a
-                                                        href={d.startsWith('http') ? d : `https://${d}`}
+                                                        href={href}
                                                         target="_blank"
                                                         rel="noopener noreferrer"
                                                         className="hover:underline"

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -10,8 +10,8 @@
   },
   "ZWAVE_DEVICE": {
     "type": "device",
-    "description": "Optional: USB device path of your Z-Wave stick (e.g. /dev/ttyACM0 or /dev/ttyUSB0). Use the real device path, not a /dev/serial/by-id symlink — symlinks don't work as CharDevice mounts. Leave blank if you don't have one yet.",
-    "devicePath": "/dev"
+    "description": "Optional: USB device path of your Z-Wave stick. The installer discovers sticks via /dev/serial/by-id and auto-fills this field with the resolved /dev/tty* path when a single USB-serial device is present. Leave blank if you don't have a stick yet — Z-Wave JS UI will still run in 'no device configured' mode and you can plug one in later.",
+    "devicePath": "/dev/serial/by-id"
   },
   "ZWAVE_JS_SUBDOMAIN": {
     "type": "subdomain",

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -63,6 +63,11 @@ spec:
       # Pin redis to loopback so hostNetwork doesn't accidentally
       # expose it on the LAN. immich-server reaches it via 127.0.0.1.
       args: ["--bind", "127.0.0.1", "--protected-mode", "yes"]
+      # Declared so the digital twin attributes 127.0.0.1:6379 to this
+      # container — without it the diagnose ports probe flags 6379 as
+      # "unknown" even though it's the immich pod's redis sidecar.
+      ports:
+        - containerPort: 6379
 
     - name: database
       image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0
@@ -86,6 +91,11 @@ spec:
           value: "postgres"
         - name: POSTGRES_DB
           value: "immich"
+      # Declared so the digital twin attributes 127.0.0.1:5432 to this
+      # container — without it the diagnose ports probe flags 5432 as
+      # "unknown" even though it's the immich pod's postgres sidecar.
+      ports:
+        - containerPort: 5432
       volumeMounts:
         - mountPath: /var/lib/postgresql/data
           name: pgdata


### PR DESCRIPTION
## Summary
Four small bugs from a fresh-install pass:

1. **Service-card links → wrong scheme.** Cards always linked via `https://` even for LAN-only routes NPM only serves on port 80. Cross-reference each `verifiedDomain` against the proxy's `proxyConfiguration.servers[].listen` — only `"443 ssl"` listeners get `https://`.
2. **ZWAVE_DEVICE auto-discovery never fired.** The variable's `devicePath` was `/dev`, so the API listed ~100 entries (null, zero, random, ttyS*, ttyACM0, …) and the InstallerModal's "auto-pick when there's exactly one device" rule never triggered. Switch to `/dev/serial/by-id` (Linux's stable USB-serial convention) and have the endpoint resolve symlinks to canonical `/dev/tty*` targets so the value is mountable as a podman `CharDevice` (which doesn't follow symlinks).
3. **Immich sidecar ports labeled "unknown"** in diagnose. The redis/postgres containers had no `ports:` declaration → twin's port walk had nothing to attribute `5432`/`6379` to. Declared.
4. Bonus: validate `path` on `/api/system/devices` so the value can't smuggle shell metacharacters into the agent exec.

## Test plan
- [ ] LAN-only domain pill (e.g. `nginx.dopp.cloud`) renders an `http://` link; public domain (`auth.dopp.cloud`) renders `https://`.
- [ ] InstallerModal for `home-assistant` with one USB-serial stick plugged in: ZWAVE_DEVICE auto-fills with `/dev/ttyACM0` (or whatever the stick's resolved canonical path is) — no operator click needed.
- [ ] InstallerModal with zero or multiple sticks: field stays empty / shows the picker.
- [ ] Diagnose run on a host with immich deployed: `Open TCP ports` lists `5432 (database)` and `6379 (redis)` instead of "unknown".
- [ ] `/api/system/devices?path=/etc/passwd;rm -rf /` returns 400, not a 200 with garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)