### PR TITLE
fix(setup): drop stale jobId pin so /setup picks up new re-deploys

### DIFF
--- a/src/app/(dashboard)/setup/page.tsx
+++ b/src/app/(dashboard)/setup/page.tsx
@@ -353,6 +353,17 @@ export default function SetupPage() {
           setLogs(prev => prev + data.logs);
           logsOffsetRef.current = data.logsOffset;
         }
+        // Once the pinned job hits a terminal phase, drop the pin so
+        // the next tick fetches with no jobId — that lets the API
+        // hand back a freshly-started install when the operator kicks
+        // off a re-deploy. Without this /setup stays glued to the
+        // previous finished job and never re-discovers the new one.
+        // If nothing newer is running we'll just re-pin to the same
+        // terminal job on the next tick; the id-change branch above
+        // won't fire (same id), so the log buffer is preserved.
+        if (data.job && TERMINAL_PHASES.includes(data.job.phase)) {
+          lastJobIdRef.current = null;
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/src/app/api/install/status/route.ts
+++ b/src/app/api/install/status/route.ts
@@ -35,13 +35,16 @@ export async function GET(request: Request) {
     const sinceBytes = parseInt(url.searchParams.get('logsSince') || '0', 10);
 
     let job = jobId ? await getJob(jobId) : await getCurrentJob();
-    const jobIsActive = !!job; // getCurrentJob only returns active phases
     if (!job && !jobId) {
       // Fall through to the most-recent job so /setup + Sidebar can
       // still show the "click Finish" state after the operator
       // minimised the wizard.
       job = await getLatestJob();
     }
+    // Derive from phase, not existence — querying a specific terminal
+    // jobId returns a job in `done`/`error`/`aborted`/`crashed`, which
+    // is NOT active. /setup keys its pinning logic off this flag.
+    const jobIsActive = !!job && (job.phase === 'running' || job.phase === 'needs_credentials');
 
     const config = await getConfig();
     const stackSetupPending = config.stackSetupPending === true;


### PR DESCRIPTION
## Summary
Two bugs kept the full-screen `/setup` view stuck on a previous install:

- **Setup page** pins the first response's job id in `lastJobIdRef` and passes `?jobId=<pinned>` on every subsequent poll → once locked onto a terminal job it never re-discovers a newer one.
- **`/api/install/status`** sets `jobIsActive = !!job` (any job exists) instead of deriving from phase, so the documented contract didn't match reality.

Fix: derive `jobIsActive` from phase. In the setup page, clear the pin once the pinned job hits a terminal phase — the next tick fetches with no `jobId` and the API hands back the new active install. Log continuity preserved (id-change branch only fires on actual id change).

## Test plan
- [ ] Open `/setup` after an install finishes (terminal phase). Trigger a new re-deploy from the wizard. `/setup` should switch to the new job's phase + logs within 2s.
- [ ] If no new install starts, `/setup` stays on the terminal job (re-pinned). No log flicker.
- [ ] `GET /api/install/status?jobId=<terminal-id>` returns `jobIsActive: false` (not `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)