### PR TITLE
fix(install): auto-clear stackSetupPending on successful install

### DIFF
--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -40,7 +40,7 @@ import { buildCredentialsManifest, type Credential } from '@/lib/stackInstall/cr
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
-import { getConfig } from '@/lib/config';
+import { getConfig, saveConfig } from '@/lib/config';
 import {
   appendLog,
   getJob,
@@ -668,6 +668,29 @@ async function runJob(jobId: string): Promise<void> {
       totalCount: input.items.filter(i => i.checked).length,
     },
   });
+
+  // The CoreOS first-boot installer writes `stackSetupPending: true`
+  // to flag "we set the box up, but no stack services are deployed
+  // yet". The OnboardingWizard / Sidebar / /setup page all read that
+  // flag. Historically it was only cleared by the operator clicking
+  // "Finish" on /setup — so even after one or many successful
+  // installs the flag stayed armed, the wizard's auto-open kept
+  // suppressing (terminal-job + stackSetupPending branch), and a
+  // re-install required clicking Finish on the *old* setup view
+  // first. Now: a successful install proves the operator has stack
+  // services. Clear the flag inline so the next re-install flow
+  // doesn't get gated by stale onboarding state.
+  try {
+    const cfg = await getConfig();
+    if (cfg.stackSetupPending) {
+      delete cfg.stackSetupPending;
+      await saveConfig(cfg);
+    }
+  } catch (e) {
+    // Best-effort: a config write failure shouldn't fail the install
+    // job itself — the operator can always click Finish manually.
+    await log(jobId, `(note) couldn't clear stackSetupPending: ${e instanceof Error ? e.message : String(e)}`);
+  }
 }
 
 /** Public entry-point. Fires off `runJob` as a detached task — caller


### PR DESCRIPTION
## Summary
The CoreOS installer writes `stackSetupPending: true` so the wizard / Sidebar / /setup know "no stack services yet." Historically the flag was only cleared by the **Finish** button on /setup. The OnboardingWizard's auto-open gated on it: `stackSetupPending && terminal-job` → suppress modal.

Net effect: an operator who finished one install but never clicked Finish stayed stuck. To start a *new* install they first had to click Finish on the *previous* run's /setup view — acknowledging an install they already knew was done — so the flag would clear and the wizard's next load would auto-open. (Direct quote: *"i have to click 'finish' on the old --- pre installation --- setup to have the new wizzard being opend. uncool. bad ux"*)

Fix: clear `stackSetupPending` inline at the end of a successful install run (phase='done'). A successful install proves stack services exist; the flag's reason to exist is gone. Best-effort — a config save failure is logged into the job, not raised as an install error; manual Finish stays as the fallback.

## Test plan
- [ ] Fresh CoreOS box with `stackSetupPending: true`: run wizard → install completes → config's `stackSetupPending` is gone.
- [ ] On the user's live box (stackSetupPending stuck true through multiple installs): pull v3.40.8, run any install → flag clears.
- [ ] Re-install from the upgrade banner with `stackSetupPending: false`: nothing changes (idempotent / no-op).
- [ ] Failed install (phase='error'): flag is NOT cleared (only cleared on `done`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)