### PR TITLE
feat(certs): archive NPM data on reset + auto-restore on fresh install

### DIFF
--- a/src/app/api/system/certs/archive/route.ts
+++ b/src/app/api/system/certs/archive/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { DigitalTwinStore } from '@/lib/store/twin';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Cert archive management.
+ *
+ * **Why this exists:** LE's "5 duplicate certs per 168h" rate limit
+ * bites hard when an operator iterates on a fresh install — every
+ * clean-install/reset wipes NPM's `/etc/letsencrypt` and `data/`
+ * directories, so the next install re-requests the same domains and
+ * the operator quickly hits the wall.
+ *
+ * Archives live at `/mnt/data/servicebay/cert-archive/npm-<ts>.tar.gz`.
+ * That path is outside the reset endpoint's wipe target and outside
+ * the OS-reinstall-recovery `quadlet-backup`, so a snapshot survives
+ * everything short of `rm -rf /mnt/data/servicebay`.
+ *
+ * Endpoints:
+ *   - `GET`  — list archives (newest first), each with size + mtime.
+ *   - `POST` — take a fresh snapshot of the current NPM data dir.
+ *   - `POST { restore: <filename> }` — restore an archive into NPM's
+ *     data dir. Refuses if NPM has running services that would block
+ *     the operation; recommends a stop-and-redeploy flow.
+ */
+
+const ARCHIVE_DIR = '/mnt/data/servicebay/cert-archive';
+
+function resolveDataDir(cfg: { templateSettings?: Record<string, string> }): string {
+  return cfg.templateSettings?.DATA_DIR || '/mnt/data/stacks';
+}
+
+function resolveNode(twin: DigitalTwinStore, requested?: string | null): string | null {
+  if (requested) return requested;
+  return Object.keys(twin.nodes)[0] ?? null;
+}
+
+interface ListEntry {
+  filename: string;
+  size: number;
+  modifiedAt: string;
+}
+
+async function listArchives(): Promise<ListEntry[]> {
+  const twin = DigitalTwinStore.getInstance();
+  const node = resolveNode(twin);
+  if (!node) return [];
+  const agent = await agentManager.ensureAgent(node);
+  const res = await agent.sendCommand('exec', {
+    // GNU stat output: name|size|epoch. Sort by epoch desc so newest is first.
+    command: `mkdir -p ${ARCHIVE_DIR} && find ${ARCHIVE_DIR} -maxdepth 1 -type f -name 'npm-*.tar.gz' -printf '%f|%s|%T@\\n' 2>/dev/null | sort -t '|' -k3 -r`,
+  });
+  const lines = (res.stdout || '').split('\n').filter(Boolean);
+  return lines.map((line: string) => {
+    const [filename, sizeStr, epochStr] = line.split('|');
+    const epoch = parseFloat(epochStr || '0');
+    return {
+      filename,
+      size: parseInt(sizeStr || '0', 10),
+      modifiedAt: Number.isFinite(epoch) ? new Date(epoch * 1000).toISOString() : new Date(0).toISOString(),
+    };
+  });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+    const archives = await listArchives();
+    return NextResponse.json({ archives, archiveDir: ARCHIVE_DIR });
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:certs:archive:list', status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const body = (await request.json().catch(() => ({}))) as { restore?: string; node?: string };
+    const twin = DigitalTwinStore.getInstance();
+    const node = resolveNode(twin, body.node);
+    if (!node) return NextResponse.json({ error: 'No nodes available' }, { status: 404 });
+
+    const cfg = await getConfig();
+    const dataDir = resolveDataDir(cfg);
+    const agent = await agentManager.ensureAgent(node);
+
+    if (body.restore) {
+      // Refuse paths that escape the archive dir — the only way to
+      // weaponise this endpoint is to point it at an arbitrary
+      // tarball outside our control.
+      if (!/^npm-[A-Za-z0-9_.\-]+\.tar\.gz$/.test(body.restore)) {
+        return NextResponse.json({ error: 'Invalid archive filename' }, { status: 400 });
+      }
+      const archivePath = `${ARCHIVE_DIR}/${body.restore}`;
+      // Refuse if NPM's data dir is non-empty — we don't want to
+      // half-overwrite a running stack's state. Operator should
+      // reset (which now auto-snapshots) and reinstall instead.
+      const probe = await agent.sendCommand('exec', {
+        command: `[ -d "${dataDir}/nginx-proxy-manager" ] && find "${dataDir}/nginx-proxy-manager" -mindepth 1 -maxdepth 1 | head -1 || true`,
+      });
+      if ((probe.stdout || '').trim()) {
+        return NextResponse.json({
+          error: 'NPM data dir is not empty. Run a clean install (which auto-archives current state) and the install runner will restore this snapshot on the next nginx deploy.',
+        }, { status: 409 });
+      }
+      await agent.sendCommand('exec', {
+        command: `mkdir -p "${dataDir}" && tar xzf "${archivePath}" -C "${dataDir}"`,
+      });
+      logger.info('CertArchive', `Restored ${archivePath} into ${dataDir}/nginx-proxy-manager`);
+      return NextResponse.json({ ok: true, restored: archivePath });
+    }
+
+    // Snapshot path.
+    const probe = await agent.sendCommand('exec', {
+      command: `[ -d "${dataDir}/nginx-proxy-manager/letsencrypt/live" ] && find "${dataDir}/nginx-proxy-manager/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
+    });
+    if (!(probe.stdout || '').trim()) {
+      return NextResponse.json({ error: 'No issued certs found — nothing worth archiving yet.' }, { status: 400 });
+    }
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `npm-${ts}.tar.gz`;
+    const archivePath = `${ARCHIVE_DIR}/${filename}`;
+    await agent.sendCommand('exec', {
+      command: `mkdir -p ${ARCHIVE_DIR} && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+    });
+    const stat = await agent.sendCommand('exec', {
+      command: `stat -c '%s|%Y' "${archivePath}" 2>/dev/null || true`,
+    });
+    const [sizeStr, epochStr] = (stat.stdout || '').trim().split('|');
+    logger.info('CertArchive', `Snapshot saved to ${archivePath}`);
+    return NextResponse.json({
+      ok: true,
+      archive: {
+        filename,
+        size: parseInt(sizeStr || '0', 10),
+        modifiedAt: epochStr ? new Date(parseFloat(epochStr) * 1000).toISOString() : new Date().toISOString(),
+      },
+    });
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:certs:archive:write', status: 500 });
+  }
+}

--- a/src/app/api/system/stacks/reset/route.ts
+++ b/src/app/api/system/stacks/reset/route.ts
@@ -84,6 +84,33 @@ export async function POST(request: NextRequest) {
 
     const agent = await agentManager.ensureAgent(nodeName);
 
+    // Snapshot NPM's data dir (cert files + DB) to a path that survives
+    // the wipe below. Without this, every clean install burns a fresh
+    // batch of Let's Encrypt issuances and we run head-first into the
+    // "5 duplicate certs / 168h" rate limit after a few re-deploys.
+    // Archive path is intentionally under /mnt/data/servicebay/cert-archive/
+    // — neither this endpoint nor any other code path wipes that.
+    let certArchive: string | null = null;
+    try {
+      const npmDir = `${dataDir}/nginx-proxy-manager`;
+      const probe = await agent.sendCommand('exec', {
+        command: `[ -d "${npmDir}/letsencrypt/live" ] && find "${npmDir}/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
+      });
+      const hasCerts = !!(probe.stdout || '').trim();
+      if (hasCerts) {
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const archivePath = `/mnt/data/servicebay/cert-archive/npm-${ts}.tar.gz`;
+        await agent.sendCommand('exec', {
+          command: `mkdir -p /mnt/data/servicebay/cert-archive && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+        });
+        certArchive = archivePath;
+        logger.info('StackReset', `Archived NPM data to ${archivePath} before wipe.`);
+      }
+    } catch (e) {
+      // Best-effort — a failed archive shouldn't block the reset.
+      logger.warn('StackReset', `Cert archive failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
     // Wipe stack data dir contents (but keep the dir itself).
     await agent.sendCommand('exec', {
       command: `find ${dataDir} -mindepth 1 -maxdepth 1 -exec rm -rf {} +`,
@@ -102,6 +129,7 @@ export async function POST(request: NextRequest) {
       deleted,
       failed,
       protected: Array.from(PROTECTED),
+      certArchive,
     });
   } catch (error) {
     return apiError(error, { tag: 'api:system:stacks:reset', status: 500 });

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -548,6 +548,48 @@ async function runJob(jobId: string): Promise<void> {
 
   const ctx: DeployContext = { jobId, input, scriptCredentials, deployed: [] };
 
+  // Cert archive restore — runs once before the deploy loop when nginx
+  // is in the install set AND the volume on disk is empty (fresh
+  // install). The reset endpoint snapshots NPM's data dir to
+  // /mnt/data/servicebay/cert-archive/ before wiping; restoring the
+  // most-recent snapshot here lets NPM come up with the previous
+  // certificate + sqlite-DB state intact, so re-issuance is skipped
+  // and we don't burn LE's 5-duplicate-certs-per-168h limit.
+  if (selected.some(s => s.name === 'nginx' && !s.alreadyInstalled)) {
+    try {
+      const { agentManager } = await import('@/lib/agent/manager');
+      const { getConfig } = await import('@/lib/config');
+      const cfg = await getConfig();
+      const dataDir = cfg.templateSettings?.DATA_DIR || '/mnt/data/stacks';
+      const node = input.node || 'Local';
+      const agent = await agentManager.ensureAgent(node);
+      // Only restore on a fresh NPM dir — leave existing cert state
+      // alone so a re-deploy that isn't preceded by a reset doesn't
+      // clobber whatever the operator did since the last archive.
+      const probe = await agent.sendCommand('exec', {
+        command: `[ -d "${dataDir}/nginx-proxy-manager" ] && find "${dataDir}/nginx-proxy-manager" -mindepth 1 -maxdepth 1 | head -1 || true`,
+      });
+      const npmDirHasContent = !!(probe.stdout || '').trim();
+      if (!npmDirHasContent) {
+        const newest = await agent.sendCommand('exec', {
+          command: `ls -1t /mnt/data/servicebay/cert-archive/npm-*.tar.gz 2>/dev/null | head -1 || true`,
+        });
+        const archivePath = (newest.stdout || '').trim();
+        if (archivePath) {
+          await log(jobId, `🔒 Restoring NPM cert archive from ${archivePath} — skipping re-issuance against Let's Encrypt.`);
+          await agent.sendCommand('exec', {
+            command: `mkdir -p "${dataDir}" && tar xzf "${archivePath}" -C "${dataDir}"`,
+          });
+          await log(jobId, `✅ Cert archive restored. NPM will pick up existing certs on first start.`);
+        }
+      }
+    } catch (e) {
+      // Best-effort — a restore failure shouldn't block the install.
+      // Operator can always click "Retry Let's Encrypt" in NPM later.
+      await log(jobId, `(note) cert archive restore skipped: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
   // Deploy loop.
   for (const item of selected) {
     if (abortFlags.get(jobId)) {


### PR DESCRIPTION
## Summary
The LE "5 duplicate certs / 168h" rate limit bites every operator who iterates on a fresh install. Each clean install / reset wipes \`<DATA_DIR>/nginx-proxy-manager/\` — cert files AND NPM's sqlite DB — so the next deploy re-requests the same domains, and after the fifth attempt LE refuses to issue. Whole stack ends up "HTTP Only" with no way out short of waiting 7 days.

Three pieces:

1. **Reset endpoint snapshots before wiping** to \`/mnt/data/servicebay/cert-archive/npm-<ISO>.tar.gz\`. Path is outside both the reset target and the quadlet-backup recovery path — survives anything short of a full \`/mnt/data/servicebay\` wipe.
2. **Install runner auto-restores on fresh nginx deploy.** Before the deploy loop, if nginx is being installed AND \`<DATA_DIR>/nginx-proxy-manager/\` is empty AND there's a recent archive, the runner extracts the newest one into place. NPM comes up with intact certs + DB; certbot reuses them instead of issuing fresh.
3. **Manual archive endpoint** at \`/api/system/certs/archive\` for explicit operator control (list, snapshot, restore).

Best-effort throughout: archive failure doesn't block the reset; restore failure doesn't block the install.

## Test plan
- [ ] Run a clean install of the whole stack, confirm LE issues 8+ certs successfully.
- [ ] Trigger reset (from a stack-install flow, since the banner-button path correctly hides Clean install). Confirm \`/mnt/data/servicebay/cert-archive/npm-*.tar.gz\` appears.
- [ ] Run a fresh stack install. Install log should include "🔒 Restoring NPM cert archive from …". After install, NPM shows "Let's Encrypt" status for each public route without any new \`certbot certonly\` calls being made (NPM logs).
- [ ] \`GET /api/system/certs/archive\` lists the snapshot. \`POST\` with an empty body takes a fresh snapshot; with \`{ restore: <filename> }\` against an empty NPM dir restores it; with \`{ restore }\` against a non-empty dir returns 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)