### PR TITLE
fix(install): wizard auto-open + NPM creds survive OS reinstall / clean-install

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -664,6 +664,23 @@ ${SERVICEBAY_SSH_PRIV}
               os.replace(tmp, OLD)
               os.remove(NEW)
               print(f"setup-config-merge: merged config.iso.json into config.json (preserved {kept} runtime path(s)).")
+
+              # Wipe install-jobs from the previous OS instance. The
+              # job files survive a re-install (RAID mount), and the
+              # OnboardingWizard's auto-open gates on "no terminal
+              # job exists" — stale jobs from before the re-install
+              # suppress the wizard. They're also useless after a re-
+              # install: their logs reference container IDs and paths
+              # that no longer exist. Drop them so the wizard fires
+              # cleanly on first boot.
+              import shutil
+              jobs_dir = os.path.join(DIR, "install-jobs")
+              if os.path.isdir(jobs_dir):
+                  try:
+                      shutil.rmtree(jobs_dir)
+                      print("setup-config-merge: cleared stale install-jobs from previous OS install.")
+                  except OSError as e:
+                      print(f"setup-config-merge: could not clear install-jobs: {e}", file=sys.stderr)
               return 0
 
           if __name__ == "__main__":

--- a/src/app/api/install/status/route.ts
+++ b/src/app/api/install/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getCurrentJob, getJob, getLatestJob, readLog } from '@/lib/install/jobStore';
+import { getCurrentJob, getJob, getLatestJob, PROCESS_STARTED_AT, readLog } from '@/lib/install/jobStore';
 import { getConfig } from '@/lib/config';
 import { apiError } from '@/lib/api/errors';
 
@@ -19,6 +19,9 @@ export const dynamic = 'force-dynamic';
  *     jobIsActive:   <true while phase is running|needs_credentials>
  *     stackSetupPending: <config flag — true while the operator hasn't
  *                    clicked Finish on /setup>
+ *     serverStartedAt: <ISO timestamp the current server process booted at;
+ *                    lets the wizard tell a job from *this* boot apart from
+ *                    one left over on disk after an OS re-install>
  *     logs / logsOffset
  *   }
  *
@@ -54,6 +57,7 @@ export async function GET(request: Request) {
         job: null,
         jobIsActive: false,
         stackSetupPending,
+        serverStartedAt: PROCESS_STARTED_AT,
         logs: '',
         logsOffset: 0,
       });
@@ -64,6 +68,7 @@ export async function GET(request: Request) {
       job,
       jobIsActive,
       stackSetupPending,
+      serverStartedAt: PROCESS_STARTED_AT,
       logs: logs.content,
       logsOffset: logs.nextOffset,
     });

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -371,11 +371,26 @@ export default function OnboardingWizard() {
       checkOnboardingStatus(),
       fetch('/api/install/status', { cache: 'no-store' })
         .then(r => r.ok ? r.json() : null)
-        .then(d => d as { job?: { phase?: string } | null; jobIsActive?: boolean } | null)
+        .then(d => d as {
+          job?: { phase?: string; startedAt?: string } | null;
+          jobIsActive?: boolean;
+          serverStartedAt?: string;
+        } | null)
         .catch(() => null),
     ]).then(([s, installStatus]) => {
       setStatus(s);
-      const hasTerminalJob = !!installStatus?.job && installStatus.jobIsActive === false;
+      // A terminal job suppresses the wizard auto-open only when it
+      // belongs to the current server process. After an OS re-install
+      // the install-jobs dir survives on the RAID mount, so a stale
+      // terminal job from the previous boot would otherwise gate the
+      // wizard off and the operator never gets prompted to deploy
+      // their stack. setup-config-merge.py wipes the dir post-merge;
+      // this client-side check is defense-in-depth.
+      const job = installStatus?.job;
+      const jobIsFromThisBoot = !!job?.startedAt
+        && !!installStatus?.serverStartedAt
+        && job.startedAt >= installStatus.serverStartedAt;
+      const hasTerminalJob = !!job && installStatus?.jobIsActive === false && jobIsFromThisBoot;
 
       // If the server reports an active install job and we're NOT
       // already tracking it locally, auto-attach to it. This is the

--- a/src/lib/install/jobStore.ts
+++ b/src/lib/install/jobStore.ts
@@ -25,6 +25,14 @@ import type { Credential } from '@/lib/stackInstall/credentialsManifest';
 
 const JOBS_DIR = path.join(DATA_DIR, 'install-jobs');
 
+/** Captured at module load — effectively the current server process's
+ *  start time. Used by /api/install/status to distinguish a terminal
+ *  job that belongs to this server instance from one that's left over
+ *  on disk from a previous boot (e.g. after an OS re-install where
+ *  the install-jobs dir survives on the RAID mount but the jobs it
+ *  contains reference a long-gone server process). */
+export const PROCESS_STARTED_AT = new Date().toISOString();
+
 /** Pruning threshold — keep this many most-recent jobs on disk so the
  *  /api/install/status route can fetch a finished job's logs after the
  *  Done step lands. Older jobs get cleaned up on each createJob call. */

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -581,6 +581,45 @@ async function runJob(jobId: string): Promise<void> {
             command: `mkdir -p "${dataDir}" && tar xzf "${archivePath}" -C "${dataDir}"`,
           });
           await log(jobId, `✅ Cert archive restored. NPM will pick up existing certs on first start.`);
+
+          // The archive contains NPM's sqlite DB, which has the previous
+          // admin credentials bcrypt-hashed inside. NPM ignores
+          // INITIAL_ADMIN_* env vars when the user table is already
+          // seeded, so the wizard's fresh random NGINX_ADMIN_PASSWORD
+          // would never authenticate — bootstrap times out, all cert
+          // requests cascade-fail with "defaults_rejected". Saved creds
+          // from config.reverseProxy.npm survived the reset (it only
+          // wipes service data, not config), so override the wizard's
+          // generated values with them to match what's actually in the
+          // restored DB.
+          const savedEmail = cfg.reverseProxy?.npm?.email;
+          const savedPassword = cfg.reverseProxy?.npm?.password;
+          if (savedEmail && savedPassword) {
+            // Mutate `input.variables` in-place. The deploy loop reads
+            // through the same reference (see line 268), so the
+            // override propagates without persisting back to the job
+            // state. `updateJob` deliberately disallows input updates
+            // to keep the wizard's submitted intent immutable on disk
+            // — a server restart mid-install transitions the job to
+            // `crashed` anyway, and the operator restarts from the
+            // wizard with fresh state.
+            let overrode = false;
+            for (const v of input.variables) {
+              if (v.name === 'NGINX_ADMIN_EMAIL' && v.value !== savedEmail) {
+                v.value = savedEmail;
+                overrode = true;
+              }
+              if (v.name === 'NGINX_ADMIN_PASSWORD' && v.value !== savedPassword) {
+                v.value = savedPassword;
+                overrode = true;
+              }
+            }
+            if (overrode) {
+              await log(jobId, `🔑 Reusing NPM admin (${savedEmail}) from before the reset so the restored DB stays accessible.`);
+            }
+          } else {
+            await log(jobId, `(note) cert archive restored, but no NPM admin password saved in config — bootstrap will likely prompt for the existing password.`);
+          }
         }
       }
     } catch (e) {

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -179,7 +179,12 @@ def main() -> int:
     # themselves; with it, the per-user accounts are ready for a
     # password-set right after deploy.
     samba_sync_url = f"{sb_api}/api/system/file-share/samba/users"
-    sync_status, sync_body = post_json(samba_sync_url, {}, timeout=30)
+    # 90s budget: the endpoint does up to 20s of LLDAP GraphQL (auth +
+    # query, both 10s timeouts) followed by a podman exec per user. On
+    # a freshly-installed stack LLDAP is often still warming up — a
+    # 30s outer cap routinely tripped before the GraphQL response
+    # landed and the wizard surfaced a misleading "HTTP 0" line.
+    sync_status, sync_body = post_json(samba_sync_url, {}, timeout=90)
     if sync_status == 200 and sync_body and sync_body.get("ok"):
         users = sync_body.get("users") or []
         added = sync_body.get("added") or []

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -294,6 +294,52 @@ describe('OnboardingWizard', () => {
             expect(screen.queryByText(/Welcome to ServiceBay/i)).toBeNull();
         });
 
+        // Defense-in-depth for the OS-reinstall path: install-jobs/ on
+        // the RAID mount survives an OS re-flash, so /api/install/status
+        // can return a terminal job that pre-dates the new server's boot.
+        // That job must NOT suppress the wizard's auto-open — the operator
+        // is on a freshly re-installed box and needs to be prompted to
+        // deploy their stack.
+        it('still auto-opens when the latest terminal job pre-dates this server boot', async () => {
+            (checkOnboardingStatus as any).mockResolvedValue(stacksPendingStatus);
+            const serverStartedAt = new Date('2026-05-15T10:00:00Z').toISOString();
+            const oldJobStartedAt = new Date('2026-05-01T08:00:00Z').toISOString();
+            (global.fetch as any).mockImplementation((url: string) => {
+                if (url.includes('/api/install/status')) {
+                    return Promise.resolve({ ok: true, json: () => Promise.resolve({
+                        job: {
+                            id: 'old-job',
+                            source: 'wizard',
+                            phase: 'done',
+                            startedAt: oldJobStartedAt,
+                            updatedAt: oldJobStartedAt,
+                            endedAt: oldJobStartedAt,
+                            progress: { currentItem: null, deployedNames: [], totalCount: 0 },
+                            credentialsManifest: [],
+                        },
+                        jobIsActive: false,
+                        stackSetupPending: true,
+                        serverStartedAt,
+                        logs: '',
+                        logsOffset: 0,
+                    }) });
+                }
+                if (url.includes('/api/services')) {
+                    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+                }
+                if (url.includes('/api/system/nginx/status')) {
+                    return Promise.resolve({ ok: true, json: () => Promise.resolve({ installed: false }) });
+                }
+                return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+            });
+
+            render(<OnboardingWizard />);
+
+            await waitFor(() => {
+                expect(screen.getAllByText(/ServiceBay Setup/i).length).toBeGreaterThan(0);
+            });
+        });
+
         it('renders an honest step counter even in stacks-only mode', async () => {
             (checkOnboardingStatus as any).mockResolvedValue(stacksPendingStatus);
 


### PR DESCRIPTION
## Summary

Two operator-facing regressions after re-flashing FCOS / running a clean install on a box with surviving RAID-mounted data:

- **Wizard didn't auto-open on a freshly reinstalled box.** `/mnt/data/servicebay/install-jobs/` survived the OS re-flash, so `getLatestJob()` returned a terminal job from the previous OS instance and the `hasTerminalJob` guard from #462 suppressed the auto-open. Fixed at two layers: `setup-config-merge.py` now wipes `install-jobs/` after the ISO-config merge, and the wizard ignores terminal jobs whose `startedAt` pre-dates the current server boot.
- **NPM admin login failed on every clean-install with a cert archive present.** The cert-archive restore from #534 brings NPM's sqlite DB back with the previous admin user, but the wizard generated fresh random `NGINX_ADMIN_PASSWORD` because `cleanInstall=true` skips `fetchStoredVariableValues`. Bootstrap exhausted its 90s retry → `defaults_rejected` → 8 cert requests cascade-failed (forwarding LE's duplicate-cert error). Fix: when the runner restores the archive, override `input.variables` for `NGINX_ADMIN_EMAIL/PASSWORD` with the values saved in `config.reverseProxy.npm` (which survives the reset).
- Bonus: bumped Samba↔LLDAP first-sync timeout in `templates/file-share/post-deploy.py` from 30s to 90s. The endpoint can legitimately take ~40s on a freshly-installed stack (LLDAP cold-start auth + GraphQL + `pdbedit` + `smbpasswd` per user).

## Test plan

- [x] `npx vitest run tests/frontend/OnboardingWizard.test.tsx tests/backend/onboarding.test.ts tests/backend/sambaSync.test.ts tests/backend/post_deploy_runtime.test.ts` — 35/36 passing, 1 pre-existing skip.
- [x] New test covers the stale-terminal-job case: wizard still auto-opens when `job.startedAt < serverStartedAt`.
- [x] `npx tsc --noEmit` clean.
- [x] `python3 -m py_compile templates/file-share/post-deploy.py` clean.
- [ ] Manual: re-flash FCOS on a box with prior data → wizard auto-opens on first dashboard load.
- [ ] Manual: clean install with cert archive present → NPM bootstrap succeeds first try, credentials manifest shows the existing password, no cert-request cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)