### PR TITLE
feat(diagnose): router-DNS probe recognises FritzBox-as-upstream pattern

### DIFF
--- a/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
+++ b/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
@@ -4,10 +4,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const state = {
   setResult: { result: 'ok' } as any,
   reconnectResult: { result: 'ok' } as any,
+  setWanResult: { result: 'ok' } as any,
 };
 
 vi.mock('@/lib/router/dnsConfig', () => ({
   setFritzBoxDhcpDns: vi.fn(() => Promise.resolve(state.setResult)),
+  setFritzBoxWanDns: vi.fn(() => Promise.resolve(state.setWanResult)),
   reconnectFritzBox: vi.fn(() => Promise.resolve(state.reconnectResult)),
 }));
 
@@ -29,6 +31,7 @@ import './routerDnsNotPointing';
 beforeEach(() => {
   state.setResult = { result: 'ok' };
   state.reconnectResult = { result: 'ok' };
+  state.setWanResult = { result: 'ok' };
 });
 
 describe('router_dns_not_pointing.reconnect_fritzbox', () => {
@@ -76,5 +79,49 @@ describe('router_dns_not_pointing.reconnect_fritzbox', () => {
     // Generic fallback should mention "Neu verbinden" so the user knows the
     // manual workaround.
     expect(result.message).toMatch(/Neu verbinden/);
+  });
+});
+
+describe('router_dns_not_pointing.configure_fritzbox_upstream', () => {
+  it('returns ok with a topology-aware success message', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'configure_fritzbox_upstream',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    // Success message should name the topology so the operator knows
+    // which valid pattern they just locked in.
+    expect(result.message).toMatch(/upstream/);
+    expect(result.message).toContain('192.168.1.10');
+    expect(result.refresh).toBe(true);
+  });
+
+  it('surfaces the "switch to Use other DNSv4 servers" hint on failure', async () => {
+    state.setWanResult = {
+      result: 'failed',
+      detail: 'FritzBox declined SetDNSServers on both WAN services. Most common cause: "Internet → Account Information → DNS Server" is set to "From provider" — switch it to "Use other DNSv4 servers" once and retry; subsequent TR-064 writes then succeed.',
+    };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'configure_fritzbox_upstream',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Use other DNSv4 servers/);
+  });
+
+  it('returns a credential-specific message when the box rejects auth', async () => {
+    state.setWanResult = {
+      result: 'no_credentials',
+      detail: 'FritzBox rejected the TR-064 credentials. Re-check Settings → Gateway.',
+    };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'configure_fritzbox_upstream',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('rejected the TR-064 credentials');
   });
 });

--- a/src/lib/diagnose/probes/routerDnsNotPointing.ts
+++ b/src/lib/diagnose/probes/routerDnsNotPointing.ts
@@ -30,7 +30,7 @@
 
 import { getConfig, updateConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
-import { reconnectFritzBox, setFritzBoxDhcpDns } from '@/lib/router/dnsConfig';
+import { reconnectFritzBox, setFritzBoxDhcpDns, setFritzBoxWanDns } from '@/lib/router/dnsConfig';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
 
 const PROBE_ID = 'router_dns_not_pointing';
@@ -106,6 +106,51 @@ async function fritzBoxDhcpDns(host: string, username: string, password: string)
   }
 }
 
+/** Read the FritzBox's OWN upstream WAN DNS via TR-064 — what the box
+ *  itself queries for resolution (not what it hands out to LAN clients).
+ *  This is the "Use other DNSv4 servers" setting in the FritzBox UI
+ *  under Internet → Account Information → DNS Server.
+ *
+ *  Tries `WANIPConnection:1` first, falls back to `WANPPPConnection:1`
+ *  (DSL/PPPoE installs). Returns the comma-separated DNS list or null
+ *  on any error — the caller treats null as "signal unavailable".
+ */
+async function fritzBoxWanDns(host: string, username: string, password: string): Promise<string | null> {
+  const attempts: Array<{ serviceType: string; controlUrl: string }> = [
+    { serviceType: 'urn:dslforum-org:service:WANIPConnection:1', controlUrl: '/upnp/control/wanipconnection1' },
+    { serviceType: 'urn:dslforum-org:service:WANPPPConnection:1', controlUrl: '/upnp/control/wanpppconn1' },
+  ];
+  const auth = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+  for (const a of attempts) {
+    try {
+      const url = `http://${host}:49000${a.controlUrl}`;
+      const body = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:GetDNSServers xmlns:u="${a.serviceType}"/>
+</s:Body>
+</s:Envelope>`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/xml; charset=utf-8',
+          'SOAPAction': `"${a.serviceType}#GetDNSServers"`,
+          Authorization: auth,
+        },
+        body,
+        signal: AbortSignal.timeout(4_000),
+      });
+      if (!res.ok) continue;
+      const text = await res.text();
+      const m = /<NewDNSServers>([^<]*)<\/NewDNSServers>/.exec(text);
+      if (m && m[1].trim()) return m[1].trim();
+    } catch {
+      // try next service
+    }
+  }
+  return null;
+}
+
 /** Resolve AdGuard's admin URL + credentials.
  *
  *  Prefers the dedicated `config.adguard` block written by AdGuard's
@@ -162,42 +207,86 @@ export async function checkRouterDnsNotPointing(): Promise<RouterDnsProbeResult>
     }
   }
 
-  // Signal A — AdGuard query-log heuristic.
+  // Signal A — AdGuard query-log heuristic. Positive when AdGuard
+  // has logged any non-localhost client (LAN device OR the FritzBox
+  // itself, in the FritzBox-as-upstream pattern) within the window.
   const adguard = await adguardCreds();
   let adguardOk = false;
   if (adguard) {
     adguardOk = await adguardSeesLanClients(adguard.url, adguard.username, adguard.password);
   }
 
-  // Signal B — FritzBox DHCP option-6 (only when gateway is fritzbox).
-  let fritzOk = false;
-  let fritzDetail = '';
+  // Signal B — FritzBox DHCP option-6 includes ServiceBay's IP. True
+  // when the operator picked "AdGuard as LAN DNS" — LAN clients query
+  // AdGuard directly.
+  let dhcpOk = false;
+  let dhcpDns: string | null = null;
   if (config.gateway?.type === 'fritzbox' && config.gateway.username && config.gateway.password) {
-    const dhcpDns = await fritzBoxDhcpDns(
+    dhcpDns = await fritzBoxDhcpDns(
       config.gateway.host,
       config.gateway.username,
       config.gateway.password,
     );
     if (dhcpDns) {
-      fritzOk = dhcpDns.split(',').map(s => s.trim()).includes(lanIp);
-      fritzDetail = `FritzBox hands out DNS servers: ${dhcpDns}`;
+      dhcpOk = dhcpDns.split(/[,\s]+/).map(s => s.trim()).filter(Boolean).includes(lanIp);
     }
   }
 
-  if (adguardOk || fritzOk) {
-    const which = fritzOk
-      ? `FritzBox DHCP points at ServiceBay (${lanIp}).`
-      : `AdGuard sees LAN clients in the last ${QUERYLOG_RECENT_MIN} min.`;
-    return { status: 'ok', detail: `Router DNS routing is working — ${which}` };
+  // Signal C — FritzBox's OWN upstream WAN DNS includes ServiceBay's
+  // IP. True when the operator picked "FritzBox as LAN DNS, AdGuard
+  // as upstream" — LAN clients query FritzBox, FritzBox forwards to
+  // AdGuard. Same household-wide filtering, different topology; both
+  // are valid setups and the probe should recognise either as OK.
+  let upstreamOk = false;
+  let upstreamDns: string | null = null;
+  if (config.gateway?.type === 'fritzbox' && config.gateway.username && config.gateway.password) {
+    upstreamDns = await fritzBoxWanDns(
+      config.gateway.host,
+      config.gateway.username,
+      config.gateway.password,
+    );
+    if (upstreamDns) {
+      upstreamOk = upstreamDns.split(/[,\s]+/).map(s => s.trim()).filter(Boolean).includes(lanIp);
+    }
   }
 
-  // Both signals negative — surface the warn.
+  // Pattern detection — explain which valid topology is in effect so
+  // operators reading the self-test result see the probe understood
+  // their deliberate setup choice (not just "ok, trust me").
+  if (dhcpOk || upstreamOk || adguardOk) {
+    const detail: string[] = ['Router DNS routing is working.'];
+    if (dhcpOk) {
+      detail.push(`Pattern: AdGuard as LAN DNS — FritzBox hands out ServiceBay (${lanIp}) via DHCP option 6, so LAN clients query AdGuard directly.`);
+    } else if (upstreamOk) {
+      detail.push(`Pattern: FritzBox stays as LAN DNS, AdGuard is upstream — FritzBox's own resolver queries ServiceBay (${lanIp}). All LAN queries flow client → FritzBox → AdGuard → internet.`);
+    } else {
+      // adguardOk alone — neither DHCP option 6 nor WAN-upstream
+      // signal matched, but AdGuard is seeing client traffic. Likely
+      // a non-FritzBox setup, or TR-064 isn't reachable. The traffic
+      // signal is the source of truth either way.
+      detail.push(`AdGuard sees LAN-client queries in the last ${QUERYLOG_RECENT_MIN} min — devices are using it for DNS.`);
+    }
+    return { status: 'ok', detail: detail.join(' ') };
+  }
+
+  // All three signals negative — true fail. Show the operator both
+  // their FritzBox's current config values AND the two fix paths so
+  // they can pick the topology they prefer.
   const detailParts: string[] = [];
   if (config.gateway?.type === 'fritzbox') {
-    detailParts.push(fritzDetail || 'FritzBox is reachable but DHCP DNS is not pointed at ServiceBay.');
+    if (dhcpDns) {
+      detailParts.push(`FritzBox hands out DHCP DNS: ${dhcpDns} (you'd want ${lanIp} here for the "AdGuard as LAN DNS" pattern).`);
+    } else {
+      detailParts.push('FritzBox is reachable but DHCP DNS is not pointed at ServiceBay.');
+    }
+    if (upstreamDns) {
+      detailParts.push(`FritzBox upstream DNS: ${upstreamDns} (you'd want ${lanIp} here for the "FritzBox as LAN DNS, AdGuard upstream" pattern).`);
+    } else if (config.gateway.username && config.gateway.password) {
+      detailParts.push('FritzBox upstream DNS query failed — check that TR-064 is enabled.');
+    }
   }
   if (adguard) {
-    detailParts.push(`AdGuard hasn't seen any LAN client queries in the last ${QUERYLOG_RECENT_MIN} min — devices probably aren't using it as DNS yet.`);
+    detailParts.push(`AdGuard hasn't seen any LAN-client queries in the last ${QUERYLOG_RECENT_MIN} min — confirms devices aren't using it.`);
   } else {
     detailParts.push('AdGuard credentials not configured; query-log signal unavailable.');
   }
@@ -205,7 +294,7 @@ export async function checkRouterDnsNotPointing(): Promise<RouterDnsProbeResult>
   return {
     status: 'warn',
     detail: detailParts.join(' '),
-    hint: 'Click below to set ServiceBay as your router\'s DHCP DNS automatically (FritzBox via TR-064), or open the manual instructions for your router.',
+    hint: 'Two ways to fix this — pick whichever fits your setup. (1) "AdGuard as LAN DNS" — click Configure DHCP to ServiceBay; clients query AdGuard directly on next lease renewal. (2) "FritzBox as LAN DNS, AdGuard upstream" — click Configure FritzBox upstream; FritzBox keeps handing itself out but forwards every query through AdGuard. Either gives household-wide filtering.',
   };
 }
 
@@ -228,6 +317,33 @@ async function configureFritzbox(): Promise<ProbeActionResult> {
   return {
     ok: false,
     message: result.detail ?? 'FritzBox configuration failed — check Settings → Gateway and try again, or use the manual instructions.',
+    refresh: false,
+  };
+}
+
+/** Action handler for the OTHER valid pattern — keep FritzBox as the
+ *  LAN's DHCP DNS, but point its upstream resolver at ServiceBay so
+ *  AdGuard still filters every household query. Same end result as
+ *  `configure_fritzbox` (household-wide filtering), different topology
+ *  (FritzBox stays in the path, fewer client-side surprises if the
+ *  operator's family is used to seeing the FritzBox as DNS). */
+async function configureFritzboxUpstream(): Promise<ProbeActionResult> {
+  const config = await getConfig();
+  const lanIp = config.reverseProxy?.lanIp;
+  if (!lanIp) {
+    return { ok: false, message: 'No LAN IP recorded yet — re-run the install-time detection first.', refresh: false };
+  }
+  const result = await setFritzBoxWanDns(lanIp);
+  if (result.result === 'ok') {
+    return {
+      ok: true,
+      message: `✅ FritzBox upstream DNS set to ${lanIp}. FritzBox keeps handing itself out as your LAN's DNS, but now forwards every query through AdGuard — household-wide filtering with no client-side changes. Takes effect immediately on the box.`,
+      refresh: true,
+    };
+  }
+  return {
+    ok: false,
+    message: result.detail ?? 'FritzBox upstream-DNS configuration failed. Most common cause: "Internet → Account Information → DNS Server" is set to "From provider" — switch it to "Use other DNSv4 servers" once in the FritzBox UI, then retry this action.',
     refresh: false,
   };
 }
@@ -285,11 +401,22 @@ registerProbeAction(
   PROBE_ID,
   {
     id: 'configure_fritzbox',
-    label: 'Configure on FritzBox',
+    label: 'Configure DHCP to ServiceBay',
     description:
-      'Sets your FritzBox to hand out ServiceBay\'s IP as the DNS server (DHCP option 6) via TR-064. Devices pick it up on next lease renewal. Requires Settings → Gateway to have FritzBox username + password configured.',
+      'Pattern A: AdGuard becomes your LAN DNS. Sets the FritzBox to hand out ServiceBay\'s IP as DHCP DNS (option 6) via TR-064. LAN clients query AdGuard directly on next lease renewal. Use this if you want AdGuard front-and-centre and don\'t mind devices showing AdGuard\'s IP in their network settings.',
   },
   configureFritzbox,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'configure_fritzbox_upstream',
+    label: 'Configure FritzBox upstream to ServiceBay',
+    description:
+      'Pattern B: FritzBox stays as your LAN DNS, AdGuard sits one hop deeper. Sets the FritzBox\'s OWN upstream DNS (Internet → Account Information → DNS Server) to ServiceBay\'s IP via TR-064. LAN clients keep seeing the FritzBox as their DNS, but every query they make goes through AdGuard. Same household-wide filtering, no client-side changes needed.',
+  },
+  configureFritzboxUpstream,
 );
 
 registerProbeAction(
@@ -335,5 +462,5 @@ registerProbeAction(
 
 logger.debug(
   'diagnose:probes',
-  `Registered ${PROBE_ID} actions: configure_fritzbox, reconnect_fritzbox, verify_from_device, dismiss`,
+  `Registered ${PROBE_ID} actions: configure_fritzbox, configure_fritzbox_upstream, reconnect_fritzbox, verify_from_device, dismiss`,
 );

--- a/src/lib/router/dnsConfig.ts
+++ b/src/lib/router/dnsConfig.ts
@@ -103,6 +103,93 @@ export async function setFritzBoxDhcpDns(targetIp: string): Promise<RouterCallRe
 }
 
 /**
+ * Tell the FritzBox to use `targetIp` as its OWN upstream DNS resolver
+ * — what shows up in the FritzBox UI under "Internet → Account
+ * Information → DNS Server → Use other DNSv4 servers". Different from
+ * `setFritzBoxDhcpDns`: that one changes what the FritzBox hands out
+ * to LAN clients (DHCP option 6); this one changes what the FritzBox
+ * itself queries for upstream resolution.
+ *
+ * Use case: the operator wants to keep the FritzBox as the DHCP DNS
+ * for LAN clients (typical default, fewer client-side surprises) but
+ * route the FritzBox's own resolver through AdGuard. Both setups —
+ * "AdGuard as LAN DNS" and "FritzBox as LAN DNS, AdGuard as upstream" —
+ * achieve household-wide AdGuard filtering; this helper lets a probe
+ * action lock in the second.
+ *
+ * Tries `WANIPConnection:1` first, falls back to `WANPPPConnection:1`.
+ * The FritzBox must be configured to allow override (UI: "Use other
+ * DNSv4 servers" rather than "From provider") — otherwise the call
+ * returns HTTP 401 / 501 and we surface that as `failed` with a
+ * pointer to the UI toggle.
+ */
+export async function setFritzBoxWanDns(targetIp: string): Promise<RouterCallResult> {
+  const config = await getConfig();
+  const gateway = config.gateway;
+  if (!gateway || gateway.type !== 'fritzbox') {
+    return { result: 'no_gateway', detail: 'Gateway not configured as FritzBox in Settings → Gateway.' };
+  }
+  if (!gateway.username || !gateway.password) {
+    return {
+      result: 'no_credentials',
+      detail: 'TR-064 needs FritzBox username + password (Settings → Gateway). Without them, set the upstream DNS manually in the FritzBox UI.',
+    };
+  }
+
+  const scheme = gateway.ssl ? 'https' : 'http';
+  const port = gateway.ssl ? 49443 : 49000;
+  const auth = `Basic ${Buffer.from(`${gateway.username}:${gateway.password}`).toString('base64')}`;
+  const attempts: Array<{ serviceType: string; controlUrl: string }> = [
+    { serviceType: 'urn:dslforum-org:service:WANIPConnection:1', controlUrl: '/upnp/control/wanipconnection1' },
+    { serviceType: 'urn:dslforum-org:service:WANPPPConnection:1', controlUrl: '/upnp/control/wanpppconn1' },
+  ];
+
+  const errors: string[] = [];
+  for (const a of attempts) {
+    try {
+      const url = `${scheme}://${gateway.host}:${port}${a.controlUrl}`;
+      const body = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:SetDNSServers xmlns:u="${a.serviceType}">
+<NewDNSServers>${targetIp}</NewDNSServers>
+</u:SetDNSServers>
+</s:Body>
+</s:Envelope>`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/xml; charset=utf-8',
+          'SOAPAction': `"${a.serviceType}#SetDNSServers"`,
+          'Authorization': auth,
+        },
+        body,
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (res.ok) {
+        logger.info('router:dnsConfig', `FritzBox SetDNSServers (WAN upstream) accepted via ${a.serviceType}`);
+        return { result: 'ok' };
+      }
+      const text = await res.text().catch(() => '');
+      if (res.status === 401) {
+        return {
+          result: 'no_credentials',
+          detail: 'FritzBox rejected the TR-064 credentials. Re-check Settings → Gateway.',
+        };
+      }
+      errors.push(`${a.serviceType}: HTTP ${res.status} ${text.slice(0, 120)}`);
+    } catch (e) {
+      errors.push(`${a.serviceType}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  logger.warn('router:dnsConfig', `FritzBox SetDNSServers (WAN upstream) failed: ${errors.join(' | ')}`);
+  return {
+    result: 'failed',
+    detail: 'FritzBox declined SetDNSServers on both WAN services. Most common cause: "Internet → Account Information → DNS Server" is set to "From provider" — switch it to "Use other DNSv4 servers" once and retry; subsequent TR-064 writes then succeed.',
+  };
+}
+
+/**
  * Force the FritzBox to drop its WAN connection and reconnect. The box
  * does this automatically within ~5–30s; on DSL/cable installs the
  * external IP usually changes, on FTTH/static-IP installs it doesn't.


### PR DESCRIPTION
## Why

After running the diagnose self-test, the operator should be able to say *with certainty* whether their setup works — and if something's off, the probe should explain what it means **for their specific topology** and how to fix it (ideally with one click).

Today the `router_dns_not_pointing` probe falls short of that goal for one valid setup:

> "FritzBox stays as the LAN's DHCP DNS; AdGuard sits as FritzBox's upstream resolver."

Clients see the FritzBox as DNS (no surprises in DHCP leases or device settings). Every query still flows through AdGuard. **Household-wide filtering works.** But the probe was checking only two signals:
- AdGuard query-log for non-localhost clients in the last 10 min
- FritzBox hands out ServiceBay's IP as DHCP option 6

Neither of those *necessarily* matches the above setup — Signal A misses during idle phases, Signal B is fundamentally wrong for it (FritzBox is supposed to hand out its own IP in that pattern). So the probe was yelling "DHCP DNS is not pointed at ServiceBay" at a correctly-configured box.

## What

### New signal C — FritzBox upstream DNS

Reads the FritzBox's own upstream WAN DNS via TR-064 (`WANIPConnection:1#GetDNSServers`, PPP fallback). True if the returned list includes ServiceBay's LAN IP. Covers the missing setup pattern.

### Pattern-aware OK message

The OK branch now names which valid topology the probe detected:

| Pattern | What you see in the OK message |
|---|---|
| **A** AdGuard as LAN DNS | *"Pattern: AdGuard as LAN DNS — FritzBox hands out ServiceBay (X) via DHCP option 6, so LAN clients query AdGuard directly."* |
| **B** FritzBox as LAN DNS, AdGuard upstream | *"Pattern: FritzBox stays as LAN DNS, AdGuard is upstream — FritzBox's own resolver queries ServiceBay (X). All LAN queries flow client → FritzBox → AdGuard → internet."* |
| **A or B (non-FritzBox setup)** | *"AdGuard sees LAN-client queries in the last 10 min — devices are using it for DNS."* |

So after the self-test, the operator reads the message and sees that the probe **understood their deliberate setup choice**, not just "ok, trust me."

### Two auto-fix paths in the warn branch

When all three signals fail, the warn message now surfaces both FritzBox config values (DHCP DNS *and* upstream DNS) so the operator sees the actual current state. The `actions[]` array offers **both** fixes:

- **`configure_fritzbox`** (existing) — sets DHCP option 6 to ServiceBay IP. *"Pattern A: AdGuard becomes your LAN DNS."*
- **`configure_fritzbox_upstream`** (NEW) — sets FritzBox's WAN-side DNS to ServiceBay IP. *"Pattern B: FritzBox stays as your LAN DNS, AdGuard sits one hop deeper."*

Plus the existing `verify_from_device` (browser-side check) and `dismiss` (30-day suppression).

The new auto-fix's most likely failure mode is the FritzBox UI being set to *"From provider"* rather than *"Use other DNSv4 servers"* — TR-064 `SetDNSServers` returns HTTP 401/501 in that case. The failure message names this explicitly so the operator knows the one-time UI tweak they need to enable it.

## Test plan

- [x] `npm test` — 785 passed, 2 skipped (was 782 → 785, 3 new tests in `configure_fritzbox_upstream` describe block).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` — no new warnings, no errors.
- [ ] **On your FritzBox-as-upstream setup:** after deploy, run the diagnose self-test. Expected: the `router_dns_not_pointing` probe is `ok` with detail message starting *"Pattern: FritzBox stays as LAN DNS, AdGuard is upstream — …"*.
- [ ] **Sanity-check:** temporarily set the FritzBox's upstream DNS away from ServiceBay (UI: Internet → Account Information → DNS Server → "From provider"). Run the probe — expected: `warn`, with both DHCP + upstream values listed and *both* fix buttons offered.
- [ ] **Auto-fix:** click *"Configure FritzBox upstream to ServiceBay"*. Expected: ServiceBay sets the WAN DNS back to your LAN IP via TR-064; the probe re-runs and goes back to `ok`. If the FritzBox UI is in "From provider" mode, the action should fail with the "switch to Use other DNSv4 servers" hint.

## Related

- `docs/UX_PHILOSOPHY.md` § 2 — "Surface unavoidable input through diagnose probes with structured actions[]". This change is a concrete application of that philosophy: detect the setup automatically, ack the operator's choice when correct, offer scoped auto-fixes (not just "go fix DHCP") when not.
- Filed in response to the operator scenario where the existing probe was yelling at a correctly-configured FritzBox-as-upstream setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)