### PR TITLE
diagnose: inline fix actions on domain_unreachable items (closes #548)

### DIFF
--- a/src/lib/diagnose/probes/adguardRewritesMissing.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.ts
@@ -146,8 +146,14 @@ export async function checkAdguardRewritesMissing(): Promise<AdguardRewritesMiss
 /** Action handler — re-runs `provisionPortalRouting` end-to-end, the
  *  same code path the install wizard and the 60s-post-boot hook use.
  *  Surfaces the structured `detail` summary as `details` so the
- *  operator sees which rewrites were added vs unchanged. */
-async function reprovision(): Promise<ProbeActionResult> {
+ *  operator sees which rewrites were added vs unchanged.
+ *
+ *  Exported (not just registered) so `domain_unreachable` can mount
+ *  the same handler under its own action namespace when it diagnoses
+ *  a missing/drifted AdGuard rewrite — operator clicks the button on
+ *  the failing domain row directly, no probe-to-probe navigation.
+ */
+export async function reprovision(): Promise<ProbeActionResult> {
   try {
     const result = await provisionPortalRouting();
     if (!result.ok) {

--- a/src/lib/diagnose/probes/domainUnreachable.test.ts
+++ b/src/lib/diagnose/probes/domainUnreachable.test.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocked sibling-probe handlers so dispatch-through-this-probe doesn't
+// actually call NPM / AdGuard. The shared-handler claim only holds if
+// dispatching `(domain_unreachable, retry_create)` reaches the same
+// function object dispatch on `(proxy_route_missing, retry_create)`
+// reaches — the mock returns a sentinel so we can verify that.
+vi.mock('./proxyRouteMissing', () => ({
+  retryCreate: vi.fn(async ({ itemId }: { itemId?: string }) => ({
+    ok: true,
+    message: `retry_create reached, itemId=${itemId ?? '(none)'}`,
+    refresh: true,
+  })),
+}));
+
+vi.mock('./adguardRewritesMissing', () => ({
+  reprovision: vi.fn(async () => ({
+    ok: true,
+    message: 'reprovision reached',
+    refresh: true,
+  })),
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve({
+    reverseProxy: {
+      publicDomain: 'example.com',
+      lanIp: '192.168.1.10',
+      hosts: [],
+    },
+  })),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/adguard/rewrites', () => ({
+  listRewrites: vi.fn(() => Promise.resolve([])),
+}));
+
+import { dispatchProbeAction, actionsForProbe } from '../actions';
+import './domainUnreachable';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('domain_unreachable.action registration', () => {
+  it('registers retry_create, reprovision, and show_public_dns_instructions', () => {
+    const actions = actionsForProbe('domain_unreachable');
+    const ids = actions.map(a => a.id).sort();
+    expect(ids).toEqual(['reprovision', 'retry_create', 'show_public_dns_instructions']);
+  });
+});
+
+describe('domain_unreachable.retry_create', () => {
+  it('dispatches to the shared retryCreate handler from proxyRouteMissing', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'domain_unreachable',
+      actionId: 'retry_create',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    // Sentinel from the mocked retryCreate proves the call landed on
+    // the shared handler with the right itemId — confirms the
+    // "fix-button on the failing-domain row" topology works.
+    expect(result.message).toContain('retry_create reached');
+    expect(result.message).toContain('vault.example.com');
+  });
+});
+
+describe('domain_unreachable.reprovision', () => {
+  it('dispatches to the shared reprovision handler from adguardRewritesMissing', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'domain_unreachable',
+      actionId: 'reprovision',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('reprovision reached');
+  });
+});
+
+describe('domain_unreachable.show_public_dns_instructions', () => {
+  it('renders the A-record instructions using the configured apex', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'domain_unreachable',
+      actionId: 'show_public_dns_instructions',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.details).toBeTruthy();
+    // Apex comes from config.reverseProxy.publicDomain — the
+    // operator's existing setting, not invented from the itemId.
+    expect(result.details).toContain('*.example.com');
+    // A-record + wildcard advice present.
+    expect(result.details).toContain('Type:  A');
+    expect(result.details).toContain('wildcard');
+  });
+
+  it('falls back to the itemId\'s parent zone when publicDomain is unset', async () => {
+    const config = await import('@/lib/config');
+    (config.getConfig as any).mockResolvedValueOnce({
+      reverseProxy: { lanIp: '192.168.1.10', hosts: [] },
+    });
+    const result = await dispatchProbeAction({
+      probeId: 'domain_unreachable',
+      actionId: 'show_public_dns_instructions',
+      itemId: 'vault.example.com',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    // Fallback: strip the first label from the itemId to get the
+    // apex. `vault.example.com` → `example.com`.
+    expect(result.details).toContain('*.example.com');
+  });
+
+  it('returns ok=false when itemId is missing', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'domain_unreachable',
+      actionId: 'show_public_dns_instructions',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/No domain supplied/);
+  });
+});

--- a/src/lib/diagnose/probes/domainUnreachable.ts
+++ b/src/lib/diagnose/probes/domainUnreachable.ts
@@ -41,7 +41,11 @@ import dns from 'dns/promises';
 import { getConfig, type ProxyHostEntry, type AppConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
 import { listRewrites } from '@/lib/adguard/rewrites';
-import type { ProbeItem } from '../actions';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+import { retryCreate as retryCreateProxyHost } from './proxyRouteMissing';
+import { reprovision as reprovisionAdguardRewrites } from './adguardRewritesMissing';
+
+const PROBE_ID = 'domain_unreachable';
 
 export interface DomainUnreachableResult {
   status: 'ok' | 'warn' | 'fail' | 'info';
@@ -67,6 +71,30 @@ function entryIsLan(entry: ProxyHostEntry): boolean {
   return isLanDomain(entry.domain);
 }
 
+/**
+ * `cause` is the discriminator that maps to inline auto-fix actions
+ * on the item. The `reason` + `fixHint` strings stay as prose for
+ * operators reading; `cause` is the machine-readable hook that
+ * decides which fix button shows up on the row.
+ *
+ * When a cause has no automatic fix today (TLS errors, raw refused,
+ * timeouts) we leave it as `'other'` — the row still renders with
+ * the prose hint, just no button.
+ */
+type DiagnosisCause =
+  | 'proxy_not_created'           // → retry_create (shared w/ proxy_route_missing)
+  | 'adguard_rewrite_missing'      // → reprovision (shared w/ adguard_rewrites_missing)
+  | 'adguard_rewrite_drifted'      // → reprovision (same handler; idempotent)
+  | 'public_dns_missing'           // → show_public_dns_instructions (new informational)
+  | 'lan_ip_not_set'               // → no action yet; #549 (lan_ip_changed) will add reconcile
+  | 'tls_failed'                   // → no action; cert_request_failure has the retry
+  | 'connection_refused'           // → no action; backend service issue
+  | 'timeout'                      // → no action; manual investigation
+  | 'npm_route_missing'            // → retry_create (same as proxy_not_created)
+  | 'backend_unhealthy'            // → no action; container-log inspection
+  | 'redirect_misconfigured'       // → no action; NPM config issue
+  | 'other';                       // → no action
+
 interface Diagnosis {
   /** Severity for the per-item row. */
   status: 'warn' | 'fail';
@@ -74,6 +102,25 @@ interface Diagnosis {
   reason: string;
   /** Where the operator finds the fix; rendered as the row hint. */
   fixHint: string;
+  /** Machine-readable failure-class — drives the inline actionIds. */
+  cause: DiagnosisCause;
+}
+
+/** Map diagnosed cause → action IDs to attach to the item.
+ *  Causes not in this map render with prose hint only. */
+function actionsForCause(cause: DiagnosisCause): string[] {
+  switch (cause) {
+    case 'proxy_not_created':
+    case 'npm_route_missing':
+      return ['retry_create'];
+    case 'adguard_rewrite_missing':
+    case 'adguard_rewrite_drifted':
+      return ['reprovision'];
+    case 'public_dns_missing':
+      return ['show_public_dns_instructions'];
+    default:
+      return [];
+  }
 }
 
 async function resolveOrNull(hostname: string): Promise<string[] | null> {
@@ -181,7 +228,8 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
     return {
       status: 'warn',
       reason: 'Proxy host not confirmed in NPM (install-time creation failed).',
-      fixHint: 'See `proxy_route_missing` → Retry create. Most common cause: wrong NPM credentials (see `npm_data_stale`).',
+      fixHint: 'Click "Retry create" below — pushes this route into NPM via the same path the install wizard uses. Most common cause if it keeps failing: wrong NPM credentials (see `npm_data_stale`).',
+      cause: 'proxy_not_created',
     };
   }
 
@@ -196,14 +244,16 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
       return {
         status: 'fail',
         reason: 'No matching AdGuard rewrite for this domain — LAN clients can\'t resolve it.',
-        fixHint: 'See `adguard_rewrites_missing` → Reprovision.',
+        fixHint: 'Click "Reprovision AdGuard rewrites" below — re-runs the install-time provisioner (idempotent, only touches missing entries).',
+        cause: 'adguard_rewrite_missing',
       };
     }
     if (lanIp && !rewriteAnswers.includes(lanIp)) {
       return {
         status: 'fail',
         reason: `AdGuard rewrite points at ${rewriteAnswers.join(', ')} but ServiceBay's LAN IP is ${lanIp} (drifted since install?).`,
-        fixHint: 'See `adguard_rewrites_missing` → Reprovision (refreshes the rewrite to the current LAN IP).',
+        fixHint: 'Click "Reprovision AdGuard rewrites" below — refreshes the rewrite to the current LAN IP.',
+        cause: 'adguard_rewrite_drifted',
       };
     }
   } else {
@@ -214,7 +264,8 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
       return {
         status: 'fail',
         reason: 'Hostname does not resolve via public DNS. A-record likely missing.',
-        fixHint: 'Add an A-record at your DNS provider pointing the apex/wildcard at your WAN IP. See `router_dns_not_pointing` for the LAN side of the same trio.',
+        fixHint: 'Click "Show DNS instructions" below for the exact A-record you need to add at your registrar.',
+        cause: 'public_dns_missing',
       };
     }
   }
@@ -228,7 +279,8 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
     return {
       status: 'warn',
       reason: 'reverseProxy.lanIp not set; cannot probe NPM routing.',
-      fixHint: 'Trigger a LAN-IP reconcile by restarting ServiceBay, or set it explicitly via Settings → Reverse Proxy.',
+      fixHint: 'Trigger a LAN-IP reconcile by restarting ServiceBay, or set it explicitly via Settings → Reverse Proxy. The `lan_ip_changed` probe will get a dedicated reconcile action in a future release.',
+      cause: 'lan_ip_not_set',
     };
   }
   const probe = await fetchWithHostHeader(`http://${lanIp}:80/`, domain);
@@ -237,7 +289,8 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
       return {
         status: 'fail',
         reason: `Connection refused on ${scheme}://${domain} — NPM running, but no backend answering port ${host.forwardPort}.`,
-        fixHint: 'Check that the `${host.service}` service is running. If it is, the proxy host\'s forward_port may not match the container\'s listen port.'.replace('${host.service}', host.service),
+        fixHint: `Check that the \`${host.service}\` service is running. If it is, the proxy host's forward_port may not match the container's listen port.`,
+        cause: 'connection_refused',
       };
     }
     if (probe.reason === 'tls') {
@@ -245,6 +298,7 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
         status: 'fail',
         reason: `TLS handshake failed: ${probe.detail.slice(0, 160)}`,
         fixHint: 'See `cert_request_failure` → Retry now. If Let\'s Encrypt rate-limited you, wait ~1 h and check that public port 80 is reachable.',
+        cause: 'tls_failed',
       };
     }
     if (probe.reason === 'timeout') {
@@ -252,12 +306,14 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
         status: 'fail',
         reason: 'Request timed out before NPM responded.',
         fixHint: 'NPM may be down or the backend is hanging. Restart the nginx service from Services, or check container logs.',
+        cause: 'timeout',
       };
     }
     return {
       status: 'fail',
       reason: `Reachability check failed: ${probe.detail.slice(0, 160)}`,
       fixHint: 'Check NPM and the backing service\'s container logs.',
+      cause: 'other',
     };
   }
 
@@ -268,13 +324,15 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
       return {
         status: 'fail',
         reason: `NPM has no proxy host matching Host: ${domain} — the route isn't actually configured even though the config says created=true.`,
-        fixHint: 'See `proxy_route_missing` → Retry create.',
+        fixHint: 'Click "Retry create" below to push the route into NPM.',
+        cause: 'npm_route_missing',
       };
     }
     return {
       status: 'warn',
       reason: `Backend returned HTTP ${probe.status}.`,
       fixHint: `'${host.service}' is reachable through NPM but the upstream is unhealthy. Check its container logs.`,
+      cause: 'backend_unhealthy',
     };
   }
 
@@ -290,6 +348,7 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
       status: 'warn',
       reason: `NPM redirected ${probe.status} → ${loc || '(empty Location)'}; expected https://${domain}/.`,
       fixHint: 'The NPM host for this domain may have ssl_forced toggled off, or the cert isn\'t bound. See `cert_request_failure`.',
+      cause: 'redirect_misconfigured',
     };
   }
 
@@ -338,7 +397,7 @@ export async function checkDomainUnreachable(): Promise<DomainUnreachableResult>
     label: host.domain,
     detail: `${diagnosis.reason}  ·  Fix: ${diagnosis.fixHint}`,
     status: diagnosis.status,
-    actionIds: [],
+    actionIds: actionsForCause(diagnosis.cause),
   }));
 
   const parts: string[] = [];
@@ -348,7 +407,88 @@ export async function checkDomainUnreachable(): Promise<DomainUnreachableResult>
   return {
     status: overall,
     detail: `${parts.join(' · ')} of ${hosts.length} configured domain${hosts.length === 1 ? '' : 's'}.`,
-    hint: 'Each row shows what went wrong and which other probe carries the fix action.',
+    hint: 'Each row shows what went wrong. When the failure has a known auto-fix, the row has a button — click it. When the fix is genuinely manual (DNS A-records, TLS rate limits), the row carries the instructions inline.',
     items,
   };
 }
+
+// ─── Action handlers ────────────────────────────────────────────────────
+//
+// Two handlers are *re-exports* of the same logic registered on sibling
+// probes. We mount them here too so the operator gets the fix button on
+// the offending domain row directly — no probe-to-probe navigation.
+
+/** Render an instructions block for the public A-record case.
+ *
+ *  We deliberately don't try to look up the operator's WAN IP from
+ *  here — `dns_routing` health checks already track it and the
+ *  diagnose page can cross-reference. Instructions name the apex
+ *  the operator already configured (`config.publicDomain`) and tell
+ *  them the exact record to add. */
+async function showPublicDnsInstructions({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
+  if (!itemId) {
+    return { ok: false, message: 'No domain supplied.', refresh: false };
+  }
+  const config = await getConfig();
+  const apex = config.reverseProxy?.publicDomain || itemId.replace(/^[^.]+\./, '') || '<your apex>';
+  const lines = [
+    `Public DNS isn't resolving \`${itemId}\` yet. Add this record at your DNS provider:`,
+    '',
+    `  Type:  A`,
+    `  Host:  *.${apex}     (wildcard — covers every subdomain)`,
+    `  Value: <your WAN IP>     (find it at https://api.ipify.org or any "what's my IP" service)`,
+    `  TTL:   300              (5 min — faster propagation if you need to change it)`,
+    '',
+    `If you'd rather pin each subdomain explicitly, add an A record for \`${itemId}\` only,`,
+    `same Value + TTL. The wildcard form is simpler and survives adding new services later.`,
+    '',
+    `On a dynamic public IP, see your registrar's DDNS docs (Cloudflare, MyFRITZ!, DuckDNS, etc.) —`,
+    `the FritzBox can update DDNS automatically under Internet → Freigaben → DynDNS.`,
+    '',
+    `After the record propagates (~5 min), re-run this diagnose probe — the row should clear.`,
+  ];
+  return {
+    ok: true,
+    message: 'Instructions ready below.',
+    details: lines.join('\n'),
+    refresh: false,
+  };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'retry_create',
+    label: 'Retry create',
+    description:
+      'Pushes this proxy host into Nginx Proxy Manager. Same handler as the `proxy_route_missing` probe — registered here so the fix button is on the domain row directly, no probe navigation.',
+  },
+  retryCreateProxyHost,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'reprovision',
+    label: 'Reprovision AdGuard rewrites',
+    description:
+      'Re-runs the install-time portal provisioner so AdGuard\'s rewrite for this domain points at ServiceBay\'s current LAN IP. Idempotent — existing rewrites with the right answer are left alone. Same handler as the `adguard_rewrites_missing` probe.',
+  },
+  reprovisionAdguardRewrites,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'show_public_dns_instructions',
+    label: 'Show DNS instructions',
+    description:
+      'Renders the exact A-record to add at your DNS registrar to make this public domain resolvable. Informational only — public DNS configuration is manual by nature.',
+  },
+  showPublicDnsInstructions,
+);
+
+logger.debug(
+  'diagnose:probes',
+  `Registered ${PROBE_ID} actions: retry_create, reprovision, show_public_dns_instructions`,
+);

--- a/src/lib/diagnose/probes/proxyRouteMissing.ts
+++ b/src/lib/diagnose/probes/proxyRouteMissing.ts
@@ -72,7 +72,14 @@ async function findEntry(domain: string): Promise<ProxyHostEntry | null> {
   return hosts.find(h => h.domain === domain) ?? null;
 }
 
-async function retryCreate({
+/**
+ * Shared with `domain_unreachable` — when that probe diagnoses
+ * "proxy host not confirmed in NPM", it surfaces this same retry as
+ * an inline per-row action so the operator doesn't have to navigate.
+ * Exported (not just registered) so the sibling probe can mount it
+ * under its own action namespace.
+ */
+export async function retryCreate({
   node,
   itemId,
 }: {

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -26,5 +26,6 @@ import './certExpiry';
 import './certRequestFailure';
 import './adguardRewritesMissing';
 import './domainExternalReachability';
+import './domainUnreachable';
 
 export {};


### PR DESCRIPTION
## Summary

`domain_unreachable` had a mature layered diagnosis (10 distinct causes per failing domain) but **zero action handlers** of its own. Each diagnosis's `fixHint` pointed the operator at *another* probe's button — high click distance, the auto-fix was effectively hidden. This PR surfaces three fix actions inline on the failing domain row so the operator clicks once.

## What changed

| Diagnosed cause | Inline action |
|---|---|
| `proxy_not_created`, `npm_route_missing` | **Retry create** (shared handler with `proxy_route_missing.retry_create`) |
| `adguard_rewrite_missing`, `adguard_rewrite_drifted` | **Reprovision AdGuard rewrites** (shared handler with `adguard_rewrites_missing.reprovision`) |
| `public_dns_missing` | **Show DNS instructions** (new informational action — renders the exact A-record using the operator's configured apex) |
| `tls_failed`, `connection_refused`, `timeout`, `backend_unhealthy`, `redirect_misconfigured`, `lan_ip_not_set`, `other` | No button — prose hint only (`lan_ip_not_set` gets its own action in #549; the rest have no auto-fix) |

The shared handlers are re-exports from the sibling probe modules — no duplication. Tests verify that dispatching `(domain_unreachable, retry_create)` reaches the same function as `(proxy_route_missing, retry_create)`.

## Implementation notes

- `Diagnosis` payload gained a `cause: DiagnosisCause` discriminator. Every existing diagnosis return site got tagged.
- `actionsForCause()` maps cause → `actionIds[]`. Causes outside the map render with the prose `fixHint` only.
- `register.ts` now imports `./domainUnreachable` so the three new action handlers actually land in the registry at runtime (previously the file was loaded only via its detection function — actions registered at top level were dead code).
- One small string-interpolation bug fix while touching the file: `\`\${host.service}\` is reachable...` had been quoted as a literal `'${host.service}' is reachable...'` with a `.replace()` workaround; now uses proper template-literal interpolation.

## Test plan

- [x] `npm test` — 791 passed, 2 skipped (785 → 791, 6 new tests in `domainUnreachable.test.ts`).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` — no new warnings.
- [ ] **On a real install with a broken proxy host:** force `created: false` on one entry. Run diagnose. Expected: the row for that domain shows **Retry create** button; clicking it pushes the host into NPM and the row clears.
- [ ] **On a real install with an AdGuard rewrite pointing at an old LAN IP:** drift the rewrite manually in AdGuard. Run diagnose. Expected: the row shows **Reprovision AdGuard rewrites** button; clicking it fixes the rewrite.
- [ ] **On a public domain with no A-record:** click **Show DNS instructions**. Expected: the details block lists the wildcard A-record to add at the registrar with the operator's actual apex.

## Tracker

This is the first child issue from #547. The next two:
- **#549** — `lan_ip_changed`: reconcile + FritzBox-reservation actions
- **#550** — `adguard_rewrites_missing`: list specific missing/drifted rewrites in detail

Closes #548. Refs #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)