### PR TITLE
diagnose: list specific rewrites in adguard_rewrites_missing OK message (closes #550)

### DIFF
--- a/src/lib/diagnose/probes/adguardRewritesMissing.test.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.test.ts
@@ -90,7 +90,7 @@ describe('checkAdguardRewritesMissing', () => {
     expect(r.detail).toContain('*.dopp.cloud → 10.0.0.1');
   });
 
-  it('returns ok when every expected rewrite is present and correct', async () => {
+  it('returns ok and lists each expected rewrite when the count is small', async () => {
     state.rewrites = [
       { domain: 'dopp.cloud', answer: '192.168.1.10' },
       { domain: 'www.dopp.cloud', answer: '192.168.1.10' },
@@ -98,7 +98,12 @@ describe('checkAdguardRewritesMissing', () => {
     ];
     const r = await checkAdguardRewritesMissing();
     expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/3 portal\/wildcard rewrites in AdGuard point at 192\.168\.1\.10/);
+    // #550 polish: ≤5 entries get named explicitly so the operator
+    // sees *which* domains are mapped, not just a count.
+    expect(r.detail).toContain('3 portal/wildcard rewrites');
+    expect(r.detail).toContain('dopp.cloud → 192.168.1.10');
+    expect(r.detail).toContain('www.dopp.cloud → 192.168.1.10');
+    expect(r.detail).toContain('*.dopp.cloud → 192.168.1.10');
   });
 
   it('skips the public domain when no public domain is configured (LAN-only mode)', async () => {
@@ -110,8 +115,16 @@ describe('checkAdguardRewritesMissing', () => {
     ];
     const r = await checkAdguardRewritesMissing();
     expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/3 portal\/wildcard rewrites/);
+    expect(r.detail).toContain('3 portal/wildcard rewrites');
+    // LAN-only domains also get named individually under the 5-entry threshold.
+    expect(r.detail).toContain('home.arpa → 192.168.1.10');
   });
+
+  // Single-domain model: buildExpectedRewrites never returns more than
+  // 3 entries today, so the >5 count-only fallback in the OK message
+  // isn't exercisable end-to-end through the current API. The
+  // threshold guard is defense for future changes (when we add
+  // additional rewrite types) — code-reading review covers it.
 });
 
 describe('adguard_rewrites_missing.reprovision', () => {

--- a/src/lib/diagnose/probes/adguardRewritesMissing.ts
+++ b/src/lib/diagnose/probes/adguardRewritesMissing.ts
@@ -122,11 +122,23 @@ export async function checkAdguardRewritesMissing(): Promise<AdguardRewritesMiss
   }
 
   if (missing.length === 0 && stale.length === 0) {
+    // OK-message polish (#550): when the rewrite count is small enough
+    // to scan at a glance, name them explicitly so the operator sees
+    // *which* domains are mapped — not just a count. Above ~5 entries
+    // the listing turns into noise and the count is more useful.
+    const LISTING_THRESHOLD = 5;
+    if (expected.length <= LISTING_THRESHOLD) {
+      const listing = expected.map(d => `${d} → ${lanIp}`).join(', ');
+      return {
+        status: 'ok',
+        detail: `${expected.length} portal/wildcard rewrite${
+          expected.length === 1 ? '' : 's'
+        } in AdGuard: ${listing}.`,
+      };
+    }
     return {
       status: 'ok',
-      detail: `${expected.length} portal/wildcard rewrite${
-        expected.length === 1 ? '' : 's'
-      } in AdGuard point at ${lanIp}.`,
+      detail: `${expected.length} portal/wildcard rewrites in AdGuard point at ${lanIp}.`,
     };
   }
 


### PR DESCRIPTION
## Summary

Small polish for `adguard_rewrites_missing`. The OK message named the **count + target IP** but not the specific domains. The operator had to open AdGuard to see which rewrites the probe was actually validating against.

When count ≤ 5 the OK message now lists each rewrite explicitly:

> "3 portal/wildcard rewrites in AdGuard: dopp.cloud → 192.168.1.10, www.dopp.cloud → 192.168.1.10, *.dopp.cloud → 192.168.1.10."

Above the threshold the count-only summary is kept as defense-in-depth for future rewrite-shape changes (the current `buildExpectedRewrites` never exceeds 3 entries, but the threshold is cheap insurance).

## Note on the original #550 framing

The issue claimed the **warn message** didn't list missing/drifted domains. That was wrong — the existing code already does:

```ts
parts.push(`${missing.length} missing (${missing.join(', ')})`);
parts.push(`${stale.length} pointing elsewhere (${stale.join('; ')})`);
```

So the warn side has been correct all along. Only the OK message needed polish. Closing #550 with that correction acknowledged in the commit message.

## Test plan

- [x] `npm test` — 782 passed, 2 skipped.
- [x] `npx tsc --noEmit` clean.
- [x] Existing "all rewrites present" test rewritten to assert per-domain listing.
- [x] LAN-only-mode test extended to verify listing in that mode too.
- [ ] **On a real install:** open diagnose. Expected: the `adguard_rewrites_missing` row shows the three configured domains explicitly when everything is in order, not just a count.

## Tracker

Third and last child issue from #547 — the high-priority targets are now all done.

| # | Probe | Status |
|---|---|---|
| #546 | router_dns_not_pointing | ✅ pattern-aware (3 valid topologies + auto-fixes) |
| #551 / #548 | domain_unreachable | ✅ inline auto-fix actions per diagnosed cause |
| #552 / #549 | lan_ip_changed | ✅ reconcile + DHCP-reservation actions |
| #553 / #550 | adguard_rewrites_missing | ✅ OK-message listing polish (this PR) |

Remaining rows in the tracker are lower-priority audits that should land as drive-by polish on PRs that already touch the relevant files. Updating #547 accordingly.

Closes #550. Refs #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)