### PR TITLE
fix(lldap): deep-link + sidebar find proxy host by port, not by service name

### DIFF
--- a/src/app/api/auth/lldap-url/route.ts
+++ b/src/app/api/auth/lldap-url/route.ts
@@ -6,10 +6,32 @@ export async function GET() {
     const config = await getConfig();
     const hosts = config.reverseProxy?.hosts || [];
 
-    // Find the LLDAP proxy host entry (created during deployment)
-    const lldapHost = hosts.find(h => h.service === 'lldap' && h.created);
+    // Discriminate by forwardPort, not service name: LLDAP_SUBDOMAIN
+    // lives in the `auth` template alongside AUTHELIA_SUBDOMAIN, so
+    // buildProxyHosts writes `service: 'auth'` on both — the
+    // legacy `service === 'lldap'` match never hits on real installs.
+    // See `lib/lldap/client.ts:getLldapUserDeepLink` for the same
+    // fix + the regression context (#442 follow-up).
+    let lldapPort: number | null = null;
+    const lldapUrl = config.lldap?.url;
+    if (lldapUrl) {
+      try {
+        const parsedPort = Number(new URL(lldapUrl).port);
+        if (Number.isFinite(parsedPort) && parsedPort > 0) lldapPort = parsedPort;
+      } catch {
+        // malformed URL — fall through to service-name match
+      }
+    }
+    const lldapHost = hosts.find(h =>
+      h.created && (
+        (lldapPort !== null && h.forwardPort === lldapPort)
+        || h.service === 'lldap'
+      ),
+    );
     if (lldapHost) {
-      return NextResponse.json({ url: `https://${lldapHost.domain}` });
+      const isPureLanDomain = /\.(home\.arpa|local)$/i.test(lldapHost.domain);
+      const scheme = isPureLanDomain ? 'http' : 'https';
+      return NextResponse.json({ url: `${scheme}://${lldapHost.domain}` });
     }
 
     return NextResponse.json({ url: null });

--- a/src/lib/lldap/client.ts
+++ b/src/lib/lldap/client.ts
@@ -194,11 +194,54 @@ export async function listLldapUsers(): Promise<LldapListUsersResult> {
  * browser (#442). Falls back to `config.lldap.url` for LAN-only installs
  * with no NPM entry, where localhost may at least work for an admin
  * browsing from the server itself.
+ *
+ * **Discriminator: forwardPort, not service name.** LLDAP_SUBDOMAIN
+ * lives in the `auth` template alongside AUTHELIA_SUBDOMAIN, so the
+ * installer's `buildProxyHosts` writes `service: 'auth'` on both
+ * hosts (`templateName` from `useStackInstall` populates that field;
+ * see `lib/stackInstall/postInstall.ts`). Matching on
+ * `service === 'lldap'` silently fails and the deep-link falls
+ * through to the localhost URL — what the operator reported when
+ * the approval flow opened a tab pointing at `http://localhost:17170/user/<id>`
+ * instead of `https://ldap.<domain>/user/<id>`. We discriminate by
+ * port instead: parse LLDAP_PORT out of `config.lldap.url` (always
+ * `http://localhost:<LLDAP_PORT>`) and find the host whose
+ * `forwardPort` matches. Falls back to the legacy `service === 'lldap'`
+ * match for any older install where the field happens to carry that
+ * literal value.
+ *
+ * Scheme: NPM serves subdomains under `publicDomain` via its
+ * wildcard Let's Encrypt cert — HTTPS works whether the entry is
+ * tagged `public` or `lan`. Pure `.home.arpa` / `.local` domains
+ * have no cert; fall back to HTTP for those so the link actually
+ * loads.
  */
 export async function getLldapUserDeepLink(userId: string): Promise<string | null> {
   const config = await getConfig();
-  const proxied = config.reverseProxy?.hosts?.find(h => h.service === 'lldap' && h.created);
-  const base = proxied ? `https://${proxied.domain}` : config.lldap?.url;
+  const lldapUrl = config.lldap?.url;
+  let lldapPort: number | null = null;
+  if (lldapUrl) {
+    try {
+      const parsedPort = Number(new URL(lldapUrl).port);
+      if (Number.isFinite(parsedPort) && parsedPort > 0) lldapPort = parsedPort;
+    } catch {
+      // malformed URL — ignore, fall through to service-name match
+    }
+  }
+  const hosts = config.reverseProxy?.hosts ?? [];
+  const proxied = hosts.find(h =>
+    h.created && (
+      (lldapPort !== null && h.forwardPort === lldapPort)
+      || h.service === 'lldap'
+    ),
+  );
+  let base: string | undefined;
+  if (proxied) {
+    const isPureLanDomain = /\.(home\.arpa|local)$/i.test(proxied.domain);
+    base = `${isPureLanDomain ? 'http' : 'https'}://${proxied.domain}`;
+  } else {
+    base = lldapUrl;
+  }
   if (!base) return null;
   return `${base.replace(/\/$/, '')}/user/${encodeURIComponent(userId)}`;
 }

--- a/tests/backend/lldap_deep_link.test.ts
+++ b/tests/backend/lldap_deep_link.test.ts
@@ -78,4 +78,76 @@ describe('getLldapUserDeepLink', () => {
     const link = await getLldapUserDeepLink('alice');
     expect(link).toBeNull();
   });
+
+  // Real-world regression: the `auth` template owns both
+  // LLDAP_SUBDOMAIN and AUTHELIA_SUBDOMAIN, so buildProxyHosts
+  // writes `service: 'auth'` on both (via meta.templateName injected
+  // by useStackInstall.ts). The pre-fix lookup matched on
+  // `service === 'lldap'`, never hit, and silently fell back to
+  // `http://localhost:17170`. We now discriminate by port instead.
+  it('matches the LLDAP host by forwardPort when service is the template name "auth"', async () => {
+    mockConfig.lldap = { url: 'http://localhost:17170', username: 'admin', password: 'x' };
+    mockConfig.reverseProxy = {
+      hosts: [
+        { domain: 'ldap.dopp.cloud', service: 'auth', forwardPort: 17170, created: true },
+        { domain: 'auth.dopp.cloud', service: 'auth', forwardPort: 9091, created: true },
+      ],
+    };
+
+    const link = await getLldapUserDeepLink('mdopp');
+    expect(link).toBe('https://ldap.dopp.cloud/user/mdopp');
+  });
+
+  it('picks the LLDAP host, not the Authelia host, when both share service=auth', async () => {
+    // Order shouldn't matter — port match wins regardless of which entry
+    // appears first in hosts[].
+    mockConfig.lldap = { url: 'http://localhost:17170', username: 'admin', password: 'x' };
+    mockConfig.reverseProxy = {
+      hosts: [
+        { domain: 'auth.dopp.cloud', service: 'auth', forwardPort: 9091, created: true },
+        { domain: 'ldap.dopp.cloud', service: 'auth', forwardPort: 17170, created: true },
+      ],
+    };
+
+    const link = await getLldapUserDeepLink('mdopp');
+    expect(link).toBe('https://ldap.dopp.cloud/user/mdopp');
+  });
+
+  it('honours a non-default LLDAP port via config.lldap.url', async () => {
+    mockConfig.lldap = { url: 'http://localhost:18888' };
+    mockConfig.reverseProxy = {
+      hosts: [
+        { domain: 'ldap.dopp.cloud', service: 'auth', forwardPort: 18888, created: true },
+      ],
+    };
+
+    const link = await getLldapUserDeepLink('mdopp');
+    expect(link).toBe('https://ldap.dopp.cloud/user/mdopp');
+  });
+
+  it('falls back to http for pure LAN-only domains (home.arpa) with no wildcard cert', async () => {
+    mockConfig.lldap = { url: 'http://localhost:17170' };
+    mockConfig.reverseProxy = {
+      hosts: [
+        { domain: 'ldap.home.arpa', service: 'auth', forwardPort: 17170, created: true },
+      ],
+    };
+
+    const link = await getLldapUserDeepLink('mdopp');
+    // .home.arpa has no LE cert; https would fail in the browser.
+    expect(link).toBe('http://ldap.home.arpa/user/mdopp');
+  });
+
+  it('returns null when only an Authelia host is created (no LLDAP entry to point at)', async () => {
+    mockConfig.lldap = { url: 'http://localhost:17170' };
+    mockConfig.reverseProxy = {
+      hosts: [
+        { domain: 'auth.dopp.cloud', service: 'auth', forwardPort: 9091, created: true },
+      ],
+    };
+
+    // No host whose forwardPort = 17170; lldap.url fallback works.
+    const link = await getLldapUserDeepLink('mdopp');
+    expect(link).toBe('http://localhost:17170/user/mdopp');
+  });
 });


### PR DESCRIPTION
## What you saw

After approving an access request, the link pointed at \`http://localhost:17170/user/mdopp\` instead of \`https://ldap.dopp.cloud/user/mdopp\`. Same root cause hits the sidebar "Open LLDAP" button — it would silently disappear or fall back to localhost depending on the install age.

## Root cause

\`LLDAP_SUBDOMAIN\` and \`AUTHELIA_SUBDOMAIN\` both live in the \`auth\` template. When the installer writes their proxy host entries, \`buildProxyHosts\` sets \`service\` to the **template name** (\`'auth'\`) — that comes from \`meta.templateName\` injected by \`useStackInstall.ts:515\`. The two lookups (\`getLldapUserDeepLink\` and \`/api/auth/lldap-url\`) were matching on \`service === 'lldap'\` — never hit on real installs — and silently fell through to the localhost URL the auth post-deploy persists for ServiceBay's own GraphQL calls.

The existing tests didn't catch it: they hand-built fixtures with \`service: 'lldap'\` directly, never exercising the value the real installer writes.

## Fix

Discriminate by **forwardPort** instead of service name. Parse LLDAP's port out of \`config.lldap.url\` and find the host whose \`forwardPort\` matches:

\`\`\`ts
const lldapPort = config.lldap?.url
  ? Number(new URL(config.lldap.url).port) || null
  : null;
const proxied = hosts.find(h =>
  h.created && (
    (lldapPort !== null && h.forwardPort === lldapPort)
    || h.service === 'lldap'   // legacy fallback
  ),
);
\`\`\`

Port match works regardless of template renames and handles the auth-template's two-subdomain shape cleanly. The legacy \`service === 'lldap'\` clause stays as a fallback for any install whose hosts[] happens to carry that literal value.

Also fix the scheme: NPM serves any subdomain under \`publicDomain\` via its wildcard LE cert (https works for both \`public\` and \`lan\` exposure when the suffix is publicDomain), but pure \`.home.arpa\` / \`.local\` domains have no cert — fall back to http so the link loads in the browser instead of erroring on TLS.

## Test plan

- [x] \`npm test\` — 787 passed, 2 skipped (was 782 → 787; 5 new tests).
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm run lint\` no new warnings.
- [ ] **On your install:** approve another access request (or use the existing resolved one's resend-welcome button). Expected link in the new tab: \`https://ldap.dopp.cloud/user/<id>\` — not localhost.
- [ ] **Sidebar "Open LLDAP" button**: clicking it now also opens \`https://ldap.dopp.cloud\` (or \`http://ldap.home.arpa\` if you're pure-LAN).

## Files

- \`src/lib/lldap/client.ts\` — \`getLldapUserDeepLink\` rewritten to discriminate by port + handle the home.arpa http fallback.
- \`src/app/api/auth/lldap-url/route.ts\` — same fix applied to the sidebar lookup.
- \`tests/backend/lldap_deep_link.test.ts\` — 5 new test cases covering the real-world \`service: 'auth'\` shape, the Authelia-sharing-the-template case, non-default LLDAP ports, the home.arpa http fallback, and the Authelia-only-host fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)