### PR TITLE
fix(sso): Authelia OIDC clients honour per-template token_endpoint_auth_method

### DIFF
--- a/src/app/api/system/authelia/oidc-clients/route.ts
+++ b/src/app/api/system/authelia/oidc-clients/route.ts
@@ -101,6 +101,15 @@ export async function POST(request: NextRequest) {
           redirect_uris: redirectUris,
           scopes: oidc.scopes,
           client_secret: sharedSecret || generateSecret(),
+          // RFC 6749 default is `client_secret_basic`. Templates whose
+          // OIDC client library uses a different default (Immich's admin
+          // API explicitly sends `client_secret_post`) override here.
+          // Without this field, Authelia's registration locked every
+          // client to `client_secret_post` and Vaultwarden's
+          // `openidconnect-rs` calls failed with "client registration
+          // does not allow this method" — operator-reported regression.
+          token_endpoint_auth_method:
+            oidc.token_endpoint_auth_method || 'client_secret_basic',
         });
       }
     }
@@ -191,7 +200,7 @@ export async function POST(request: NextRequest) {
         scopes: client.scopes || ['openid', 'profile', 'email', 'groups'],
         response_types: ['code'],
         grant_types: ['authorization_code'],
-        token_endpoint_auth_method: 'client_secret_post',
+        token_endpoint_auth_method: client.token_endpoint_auth_method || 'client_secret_basic',
       });
       added.push(client.client_id);
     }

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -367,6 +367,24 @@ export interface OidcClientConfig {
    * endpoint generate a fresh random secret each time (legacy behaviour).
    */
   clientSecretVar?: string;
+  /**
+   * Which credential transport the service's OIDC client library uses to
+   * authenticate against Authelia's token endpoint. Authelia per-client
+   * registration locks this to a single method — if the service sends
+   * a different one, the token call fails with
+   * `invalid_client / "client registration does not allow this method"`.
+   *
+   * Common values per service:
+   *   - `client_secret_basic` — RFC 6749 default; what `openidconnect-rs`
+   *     (Vaultwarden) sends. **Use this for new clients unless the
+   *     upstream service explicitly documents `_post`.**
+   *   - `client_secret_post` — what Immich's admin-API-driven
+   *     configuration writes; also Audiobookshelf, Navidrome.
+   *
+   * Omit for the platform default (`client_secret_basic` from the
+   * oidc-clients route).
+   */
+  token_endpoint_auth_method?: 'client_secret_basic' | 'client_secret_post';
 }
 
 export interface VariableMeta {

--- a/templates/immich/variables.json
+++ b/templates/immich/variables.json
@@ -55,7 +55,8 @@
       "authorization_policy": "one_factor",
       "redirect_uris": ["/auth/login", "/user-settings", "app.immich:/"],
       "scopes": ["openid", "profile", "email"],
-      "clientSecretVar": "IMMICH_SSO_SECRET"
+      "clientSecretVar": "IMMICH_SSO_SECRET",
+      "token_endpoint_auth_method": "client_secret_post"
     }
   }
 }

--- a/templates/vaultwarden/variables.json
+++ b/templates/vaultwarden/variables.json
@@ -49,7 +49,8 @@
       "authorization_policy": "one_factor",
       "redirect_uris": ["/identity/connect/oidc-signin"],
       "scopes": ["openid", "profile", "email", "groups"],
-      "clientSecretVar": "VAULTWARDEN_SSO_SECRET"
+      "clientSecretVar": "VAULTWARDEN_SSO_SECRET",
+      "token_endpoint_auth_method": "client_secret_basic"
     }
   }
 }


### PR DESCRIPTION
## What you saw

Vaultwarden SSO via Authelia failed with:

> "Failed to contact token endpoint: ServerResponse(StandardErrorResponse { error: invalid_client, error_description: Some(\"Client authentication failed (...). The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_basic', however the OAuth 2.0 client registration does not allow this method.\"), ... })"

Authelia named the mismatch verbatim: Vaultwarden sends `client_secret_basic`, the OIDC client registration in `configuration.yml` was locked to `client_secret_post`.

## Root cause

`src/app/api/system/authelia/oidc-clients/route.ts` hardcoded `token_endpoint_auth_method: 'client_secret_post'` for every client it registered. Vaultwarden's `openidconnect-rs` client library uses the RFC 6749 default (`client_secret_basic`) — Authelia matches per-client strictly, so the call fails before token issuance.

## Fix

- New `token_endpoint_auth_method` field on `OidcClientConfig` (`src/lib/registry.ts`) so each template declares what its OIDC library actually sends.
- Default changed from `client_secret_post` → `client_secret_basic` (the RFC default; what most modern libraries send when not overridden).
- Per-template overrides:
  - `templates/vaultwarden/variables.json` → `client_secret_basic` (matches its library — the bug).
  - `templates/immich/variables.json` → `client_secret_post` (matches the `tokenEndpointAuthMethod` Immich's post-deploy.py writes to its admin API).
  - Audiobookshelf + Navidrome get the new default — their config APIs don't expose the field, library default is RFC.

## **Important — manual fix needed for your existing install**

This PR fixes **fresh installs going forward**. Your already-deployed Authelia config still has `token_endpoint_auth_method: 'client_secret_post'` on the Vaultwarden client; the OIDC-registration route is idempotent and won't overwrite existing entries (intentional — protects hand-customised configs).

One-line edit on your server:

\`\`\`
sudo nano /mnt/data/auth/authelia/configuration.yml
\`\`\`

Find the \`vaultwarden\` client block (under \`identity_providers.oidc.clients\`):

\`\`\`yaml
- client_id: 'vaultwarden'
  ...
  token_endpoint_auth_method: 'client_secret_post'   ← change this
\`\`\`

Change to:

\`\`\`yaml
  token_endpoint_auth_method: 'client_secret_basic'
\`\`\`

Save, then:

\`\`\`
systemctl --user restart auth.service
\`\`\`

(Or restart from the ServiceBay UI: Services → auth → ⋯ → Restart.)

Should fix the Vaultwarden flow immediately.

## **Note on the Immich + FileBrowser failures**

Same operator report mentioned 500 errors on \`https://photos.dopp.cloud/api/oauth/callback\` and \`https://files.dopp.cloud/api/login\`. Both are likely separate issues, not the same root cause:

- **Immich's 500**: the consent page rendered, the callback was hit — meaning Authelia's token endpoint accepted the request, so Immich's auth method isn't the issue. The 500 is on Immich's side processing the callback. Need Immich's container logs (\`podman logs immich-immich-server --tail 200\`) to diagnose; likely Immich rejecting the userinfo response, a missing claim, or an Immich 2.x signing-algorithm strictness change.

- **FileBrowser's 500**: \`POST /api/login\` is FileBrowser's *own* login form, not the forward-auth path. That suggests Authelia's forward-auth isn't injecting \`Remote-User\` on \`files.dopp.cloud\` and the user got bounced to FileBrowser's local login. Check the NPM proxy host's Advanced → Custom Nginx Configuration for files.dopp.cloud — should contain the \`__authelia_forward_auth__\` sentinel snippet. If it doesn't, the proxy host was never wired with forward-auth.

Will follow up on both once you share the diagnostics.

## Test plan

- [x] \`npm test\` — 782 passed.
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm run lint\` no new warnings.
- [ ] Apply the manual fix above on your install. Verify Vaultwarden SSO flow completes.
- [ ] On a fresh install: Vaultwarden's registration in Authelia's config should already use \`client_secret_basic\` — verify with \`grep -A1 vaultwarden /mnt/data/auth/authelia/configuration.yml\`.

## Follow-up

Open a separate issue: "OIDC clients route should support update mode" so existing registrations can be corrected via a button in the UI rather than a YAML edit. Currently the route only adds new clients (intentional, to protect hand-customised configs), but operators bumping into config-drift like this should have a UI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)