### PR TITLE
fix(home-assistant): default OIDC group names to match LLDAP seed

### DIFF
--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -36,13 +36,13 @@
   },
   "HA_OIDC_ADMIN_GROUP": {
     "type": "text",
-    "description": "LLDAP group whose members become Home Assistant admins via auth_oidc's `roles` mapping. Anyone outside this group lands as a regular user.",
-    "default": "lldap_admin"
+    "description": "LLDAP group whose members become Home Assistant admins via auth_oidc's `roles` mapping. Anyone outside this group lands as a regular user. Default matches what `src/app/api/system/lldap/seed/route.ts` actually creates (`admins`, `family`) — earlier defaults named `lldap_admin` / `lldap_strict_readonly` were aspirational and locked every fresh install out of HA with 'not in the correct group'.",
+    "default": "admins"
   },
   "HA_OIDC_USER_GROUP": {
     "type": "text",
-    "description": "LLDAP group whose members can log into Home Assistant as a non-admin user. Members of HA_OIDC_ADMIN_GROUP also pass this check automatically.",
-    "default": "lldap_strict_readonly"
+    "description": "LLDAP group whose members can log into Home Assistant as a non-admin user. Members of HA_OIDC_ADMIN_GROUP also pass this check automatically. Default matches the seeded `family` group.",
+    "default": "family"
   },
   "HA_SUBDOMAIN": {
     "type": "subdomain",


### PR DESCRIPTION
## What you saw

Home Assistant rejected every fresh-install user with:

> Login failed.
> User is not in the correct group to access Home Assistant, contact your administrator!

## Root cause

`templates/home-assistant/variables.json` defaulted to:

\`\`\`json
"HA_OIDC_ADMIN_GROUP": { "default": "lldap_admin" },
"HA_OIDC_USER_GROUP":  { "default": "lldap_strict_readonly" }
\`\`\`

But the LLDAP seed (\`src/app/api/system/lldap/seed/route.ts:21\`) only creates \`['admins', 'family']\`. So fresh-install users are in \`admins + family\` and NEVER in \`lldap_admin\` or \`lldap_strict_readonly\` — HA's auth_oidc \`roles\` mapping correctly rejects them.

The wiring was right; the defaults pointed at groups that don't exist.

## Fix

Default-only change in variables.json:

| Variable | Before | After |
|---|---|---|
| \`HA_OIDC_ADMIN_GROUP\` | \`lldap_admin\` | \`admins\` |
| \`HA_OIDC_USER_GROUP\` | \`lldap_strict_readonly\` | \`family\` |

Operators who want a stricter HA group mapping still override via the wizard — they'll just need to also create those groups in LLDAP themselves.

## Manual fix on your existing install

Wizard → Reconfigure → Home Assistant. The two group fields are already populated with their (broken) install-time values; change them to \`admins\` / \`family\` and save. Triggers an HA restart; SSO then works.

## Test plan

- [x] \`npm test\` — 782 passed.
- [x] \`npx tsc --noEmit\` clean.
- [ ] **On your install:** Reconfigure HA with the new defaults, restart, sign in via Authelia. Expected: lands on the Lovelace dashboard.
- [ ] Fresh install: a user in \`admins\` becomes HA admin; a user in only \`family\` becomes regular HA user; a user in neither is rejected (existing test for the deny branch stays valid).

Closes #557. Tracker: #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)