### PR TITLE
fix(install): pre-reinstall batch — AUTH_SECRET, cert reuse, Authelia auth-request, exposure: internal, Z-Wave udev, mobile Setup icon

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -435,7 +435,17 @@ storage:
     - path: /var/lib/systemd/linger/${HOST_USER}
       mode: 0644
 
-    # ServiceBay Quadlet (rootless)
+    # ServiceBay Quadlet (rootless).
+    #
+    # AUTH_SECRET is loaded from an EnvironmentFile on the persistent
+    # data volume (${DATA_ROOT}/servicebay/.auth-secret.env) so it
+    # survives OS reinstalls. Without this, every reinstall would
+    # regenerate AUTH_SECRET → all encrypted values in config.json
+    # (FritzBox password, NPM password, anything else sealed via the
+    # secrets helper) decrypt to garbage. The companion oneshot
+    # `servicebay-auth-secret-init.service` (declared below in
+    # `systemd.units`) writes that file on first boot if missing.
+    # See issue #565.
     - path: /var/home/${HOST_USER}/.config/containers/systemd/servicebay.container
       mode: 0644
       user:
@@ -446,7 +456,8 @@ storage:
         inline: |
           [Unit]
           Description=ServiceBay Rootless Management Interface
-          After=network-online.target
+          After=network-online.target servicebay-auth-secret-init.service
+          Requires=servicebay-auth-secret-init.service
 
           [Container]
           Image=ghcr.io/mdopp/servicebay:${SERVICEBAY_VERSION}
@@ -459,7 +470,7 @@ storage:
           Environment=PORT=${SERVICEBAY_PORT}
           Environment=NODE_ENV=production
           Environment=HOST_USER=${HOST_USER}
-          Environment=AUTH_SECRET=${AUTH_SECRET}
+          EnvironmentFile=${DATA_ROOT}/servicebay/.auth-secret.env
           Environment=SERVICEBAY_USERNAME=${SERVICEBAY_ADMIN_USER}
           Environment=SERVICEBAY_PASSWORD=${SERVICEBAY_ADMIN_PASSWORD}
           SecurityLabelDisable=true
@@ -686,6 +697,42 @@ ${SERVICEBAY_SSH_PRIV}
           if __name__ == "__main__":
               sys.exit(main())
 
+    # AUTH_SECRET init — generates a fresh secret on first boot if no
+    # persistent one exists yet. Re-installs find the existing file and
+    # leave it alone so encrypted values in config.json keep decrypting.
+    # See #565.
+    - path: /etc/systemd/system/servicebay-auth-secret-init.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Initialise persistent AUTH_SECRET for ServiceBay (#565)
+          DefaultDependencies=no
+          After=var-mnt-data.mount local-fs.target
+          RequiresMountsFor=/var/mnt/data
+          Before=user@1000.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          # mkdir is idempotent; the conditional generation lives in the
+          # shell script so an existing .auth-secret.env survives intact
+          # even when this oneshot re-runs (e.g. after `systemctl daemon-reload`).
+          ExecStart=/usr/bin/sh -c '\
+            install -d -m 0755 -o ${HOST_USER} -g ${HOST_USER} /var/mnt/data/servicebay; \
+            if [ ! -s /var/mnt/data/servicebay/.auth-secret.env ]; then \
+              SECRET=$$(/usr/bin/openssl rand -hex 32); \
+              umask 0177; \
+              printf "AUTH_SECRET=%s\\n" "$$SECRET" > /var/mnt/data/servicebay/.auth-secret.env; \
+              chown ${HOST_USER}:${HOST_USER} /var/mnt/data/servicebay/.auth-secret.env; \
+              echo "AUTH_SECRET written (fresh install or first migration)"; \
+            else \
+              echo "AUTH_SECRET preserved from previous install"; \
+            fi'
+
+          [Install]
+          WantedBy=multi-user.target
+
     # Systemd unit for the config-merge — runs once after install-python
     # so python3 is guaranteed available, before servicebay.service.
     - path: /etc/systemd/system/setup-config-merge.service
@@ -695,7 +742,7 @@ ${SERVICEBAY_SSH_PRIV}
           [Unit]
           Description=Merge re-install ISO config into existing config.json (#331)
           ConditionPathExists=/var/mnt/data/servicebay/config.iso.json
-          After=install-python.service var-mnt-data.mount
+          After=install-python.service var-mnt-data.mount servicebay-auth-secret-init.service
           Requires=install-python.service var-mnt-data.mount
           # No `Before=servicebay.service` — that unit is in the user
           # systemd instance (Quadlet under ~/.config/containers/systemd)
@@ -926,6 +973,14 @@ ${SERVICEBAY_SSH_PRIV}
     # Enable Python3 install on first boot
     - path: /etc/systemd/system/multi-user.target.wants/install-python.service
       target: /etc/systemd/system/install-python.service
+
+    # Enable AUTH_SECRET init on first boot (#565). The `[Install]
+    # WantedBy=` block in the unit file isn't enough on its own because
+    # Ignition writes the file but doesn't `systemctl enable` it — the
+    # symlink has to be present in the wants/ directory at ignition
+    # time, matching how every other system-level oneshot here is wired.
+    - path: /etc/systemd/system/multi-user.target.wants/servicebay-auth-secret-init.service
+      target: /etc/systemd/system/servicebay-auth-secret-init.service
 
     # Enable setup-config-merge on first boot (#331). Without this
     # symlink, Ignition drops the unit file at /etc/systemd/system/

--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -127,6 +127,23 @@ storage:
           ACTION=="add", SUBSYSTEM=="block", ENV{ID_BUS}=="usb", ENV{DEVTYPE}=="partition", TAG+="systemd", ENV{SYSTEMD_WANTS}="usb-mount@%k.service"
           ACTION=="remove", SUBSYSTEM=="block", ENV{ID_BUS}=="usb", ENV{DEVTYPE}=="partition", RUN+="/usr/local/bin/usb-mount.sh remove %k"
 
+    # Z-Wave / serial USB passthrough to rootless containers.
+    # /dev/ttyACM* defaults to crw-rw---- root:dialout, which leaves a
+    # rootless podman container's "nobody" user with no read access
+    # (logs as "permission denied opening serial port"). MODE=0666
+    # opens it to everyone — fine on a single-user homelab, and the
+    # only practical option without rebuilding the rootless uid
+    # mapping. The SYMLINK= rule pins the Sigma Designs / Aeotec
+    # Z-Wave stick at /dev/zwave so the home-assistant template can
+    # mount a stable path regardless of which /dev/ttyACM<N> the
+    # kernel assigns this boot.
+    - path: /etc/udev/rules.d/99-zwave.rules
+      mode: 0644
+      contents:
+        inline: |
+          SUBSYSTEM=="tty", KERNEL=="ttyACM*", MODE="0666"
+          SUBSYSTEM=="tty", ATTRS{idVendor}=="0658", ATTRS{idProduct}=="0200", SYMLINK+="zwave"
+
     # USB automount: mount/unmount script
     - path: /usr/local/bin/usb-mount.sh
       mode: 0755

--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -362,13 +362,76 @@ async function createProxyHost(baseUrl: string, token: string, host: ProxyHostRe
  * host MUST exist before issuance — without a server_name match, NPM's
  * default-server rejects the ACME request and certbot times out.
  */
+/**
+ * Look for an existing, still-valid Let's Encrypt cert that already
+ * covers `domain`. Returns its id when found so the caller can bind
+ * the proxy host without going to ACME — critical for re-installs
+ * where the cert files survived in `letsencrypt/` (via #534's
+ * auto-restore) and NPM's DB has the cert rows after replay, but the
+ * install runner used to ALWAYS request fresh certs anyway and burn
+ * through Let's Encrypt's "5 identical certs / week" rate limit
+ * within minutes of a re-install. See #566.
+ *
+ * Returns `null` when no usable cert exists, falling back to the
+ * legacy "request a fresh one" path. A cert that expires in less than
+ * `EXPIRY_MIN_DAYS` is treated as no-match so NPM's nightly renew
+ * doesn't race the install — we'd rather request fresh now than
+ * inherit something about to flip red on the operator.
+ */
+const EXPIRY_MIN_DAYS = 14;
+async function findReusableCert(
+    baseUrl: string,
+    token: string,
+    domain: string,
+): Promise<number | null> {
+    try {
+        const res = await fetch(`${baseUrl}/api/nginx/certificates?expand=owner`, {
+            method: 'GET',
+            headers: { 'Authorization': `Bearer ${token}` },
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!res.ok) return null;
+        const certs = await res.json() as Array<{
+            id: number;
+            provider: string;
+            domain_names: string[];
+            expires_on: string | null;
+        }>;
+        if (!Array.isArray(certs)) return null;
+        const cutoff = Date.now() + EXPIRY_MIN_DAYS * 24 * 60 * 60 * 1000;
+        // Newest-first so multiple matches pick the freshest cert (NPM
+        // doesn't dedupe by domain on its side; an operator who hit
+        // the rate limit and ran an old install too could have two
+        // certificate rows for the same domain. We want the one with
+        // the latest valid expires_on).
+        const candidates = certs
+            .filter(c => c.provider === 'letsencrypt')
+            .filter(c => Array.isArray(c.domain_names) && c.domain_names.includes(domain))
+            .filter(c => c.expires_on && Date.parse(c.expires_on) > cutoff)
+            .sort((a, b) => Date.parse(b.expires_on!) - Date.parse(a.expires_on!));
+        return candidates[0]?.id ?? null;
+    } catch {
+        return null;
+    }
+}
+
 async function requestPublicCert(
     baseUrl: string,
     token: string,
     proxyHostId: number,
     domain: string,
     leEmail: string,
-): Promise<{ ok: true; certId: number } | { ok: false; reason: string }> {
+): Promise<{ ok: true; certId: number; reused?: boolean } | { ok: false; reason: string }> {
+    // 0) Reuse path (#566). If NPM already has a valid LE cert covering
+    //    `domain`, bind that instead of asking ACME for a new one — the
+    //    LE "5 identical / week" rate limit otherwise breaks every
+    //    re-install where the cert files were restored by #534.
+    const reusable = await findReusableCert(baseUrl, token, domain);
+    let certId: number;
+    if (reusable !== null) {
+        logger.info('ProxyHosts', `Reusing existing NPM cert #${reusable} for ${domain} (avoids LE rate-limit churn on re-installs)`);
+        certId = reusable;
+    } else {
     // 1) Create the LE cert in NPM. NPM blocks until the ACME exchange
     //    completes (success or failure), so the timeout here is generous.
     //
@@ -383,7 +446,6 @@ async function requestPublicCert(
     // cert issuance when it isn't set, because "no admin email" means
     // NPM can't register with Let's Encrypt regardless of payload.
     void leEmail;
-    let certId: number;
     try {
         const res = await fetch(`${baseUrl}/api/nginx/certificates`, {
             method: 'POST',
@@ -409,6 +471,7 @@ async function requestPublicCert(
         certId = data.id;
     } catch (e) {
         return { ok: false, reason: `Cert request failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
     }
 
     // 2) Bind the cert to the proxy host so HTTPS becomes the canonical
@@ -438,7 +501,7 @@ async function requestPublicCert(
     } catch (e) {
         return { ok: false, reason: `Cert ${certId} issued but the bind PUT failed: ${e instanceof Error ? e.message : String(e)}` };
     }
-    return { ok: true, certId };
+    return { ok: true, certId, reused: reusable !== null };
 }
 
 /**
@@ -535,7 +598,11 @@ export async function POST(request: Request) {
                     );
                     if (certResult.ok) {
                         results[results.length - 1].certIssued = true;
-                        logger.info('ProxyHosts', `Issued + bound LE cert ${certResult.certId} for ${host.domain}`);
+                        if (certResult.reused) {
+                            logger.info('ProxyHosts', `Reused existing LE cert ${certResult.certId} for ${host.domain} (re-install survived #534 cert-archive — no ACME call needed)`);
+                        } else {
+                            logger.info('ProxyHosts', `Issued + bound LE cert ${certResult.certId} for ${host.domain}`);
+                        }
                     } else {
                         results[results.length - 1].certError = certResult.reason;
                         logger.warn('ProxyHosts', `Cert request failed for ${host.domain}: ${certResult.reason}`);

--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -14,16 +14,32 @@ interface ProxyHostRequest {
     /** Template name this proxy host belongs to (e.g. "vaultwarden") */
     service?: string;
     /**
-     * Exposure profile for the host. `public` triggers an auto Let's
-     * Encrypt cert request on this endpoint right after the proxy host
-     * is created (best-effort — the install does not fail if the ACME
-     * challenge fails; the `cert_request_failure` diagnose probe surfaces
-     * the underlying reason). `lan` (or unset) creates the proxy host
-     * without a cert. Templates declare a sensible default per
-     * subdomain variable in `variables.json`; the wizard's configure
-     * step lets the operator override per service.
+     * Exposure profile for the host. Three tiers:
+     *
+     * - `public` — auto LE cert + open access. Reachable from anywhere
+     *   on the internet. Use for end-user-facing services (Authelia
+     *   portal, Vaultwarden, files, photos, …).
+     * - `internal` — auto LE cert + NPM IP-allowlist to LAN-CIDR. The
+     *   domain has a public DNS record so LE HTTP-01 can validate (the
+     *   ACME-challenge location bypasses the allowlist inside NPM by
+     *   design), but every other path is denied from non-LAN IPs.
+     *   Use for admin consoles that need real HTTPS (so Authelia
+     *   forward-auth works) but should never be hit from outside
+     *   — ldap, dns, sync, zwave.
+     * - `lan` (or unset) — no cert, NPM IP-allowlist binding only.
+     *   The host serves plain HTTP. Authelia forward-auth gating
+     *   does NOT work here (Authelia rejects http scheme on
+     *   /api/authz/auth-request — see forwardAuth.ts).
+     *
+     * Cert request is best-effort for both `public` and `internal`:
+     * install does not fail on ACME hiccups; `cert_request_failure`
+     * diagnose probe surfaces the reason.
+     *
+     * Templates declare a sensible default per subdomain variable in
+     * `variables.json`; the wizard's configure step lets the operator
+     * override per service.
      */
-    exposure?: 'public' | 'lan';
+    exposure?: 'public' | 'internal' | 'lan';
     /** Service-specific NPM proxy host settings */
     proxyConfig?: {
         allow_websocket_upgrade?: boolean;
@@ -552,7 +568,11 @@ export async function POST(request: Request) {
         // to the previous open behaviour for that subset of hosts so the
         // install doesn't fail just because the access-list creation
         // hiccupped — the diagnose UI is the recovery path.
-        const needsLanList = hosts.some(h => h.exposure === 'lan');
+        //
+        // `lan` AND `internal` both bind the LAN access list; `internal`
+        // additionally requests a public LE cert (the ACME challenge
+        // location bypasses the allowlist by design inside NPM).
+        const needsLanList = hosts.some(h => h.exposure === 'lan' || h.exposure === 'internal');
         const lanAccessListId = needsLanList
             ? await ensureLanAccessList(npm.apiUrl, token, npm.nodeIp)
             : null;
@@ -565,7 +585,8 @@ export async function POST(request: Request) {
             if (!host.forwardHost) {
                 host.forwardHost = npm.nodeIp;
             }
-            const accessListId = host.exposure === 'lan' && lanAccessListId !== null ? lanAccessListId : 0;
+            const wantsLanList = host.exposure === 'lan' || host.exposure === 'internal';
+            const accessListId = wantsLanList && lanAccessListId !== null ? lanAccessListId : 0;
             let createdHost: { id?: number } | null = null;
             try {
                 createdHost = await createProxyHost(npm.apiUrl, token, host, accessListId);
@@ -578,10 +599,12 @@ export async function POST(request: Request) {
                 continue;
             }
 
-            // Auto-cert for public-exposure hosts. Best-effort: install
-            // continues regardless of ACME outcome — the diagnose probe
-            // (`cert_request_failure`) is the recovery path.
-            if (host.exposure === 'public') {
+            // Auto-cert for public AND internal hosts. Best-effort:
+            // install continues regardless of ACME outcome — the
+            // diagnose probe (`cert_request_failure`) is the recovery
+            // path. Internal hosts get a real cert too so Authelia
+            // forward-auth (which requires https scheme) works.
+            if (host.exposure === 'public' || host.exposure === 'internal') {
                 if (!leEmail) {
                     const reason = 'No ACME registration email configured (set reverseProxy.npm.email in Settings → Integrations); skipped cert request.';
                     results[results.length - 1].certError = reason;

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { Github, Settings } from 'lucide-react';
+import { Github, Settings, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import { plugins } from './Sidebar';
 import { useToast } from '@/providers/ToastProvider';
@@ -12,10 +12,15 @@ const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
 
 export function MobileTopBar() {
   const router = useRouter();
+  const pathname = usePathname() || '';
   const searchParams = useSearchParams();
   const node = searchParams?.get('node');
   const { addToast } = useToast();
   const hintFired = useRef(false);
+  // Mirror of the desktop Sidebar's hasActiveInstall pill — mobile
+  // users who pressed "Minimize" on the wizard would otherwise have
+  // no way back to /setup since the Sidebar is hidden < md.
+  const [hasActiveInstall, setHasActiveInstall] = useState(false);
 
   useEffect(() => {
     if (hintFired.current) return;
@@ -32,6 +37,27 @@ export function MobileTopBar() {
     );
   }, [addToast]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch('/api/install/status', { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = await res.json() as {
+          jobIsActive?: boolean;
+          stackSetupPending?: boolean;
+        };
+        if (cancelled) return;
+        setHasActiveInstall(Boolean(data.jobIsActive) || Boolean(data.stackSetupPending));
+      } catch { /* offline / mid-redeploy — keep the previous value */ }
+    };
+    void tick();
+    const handle = setInterval(tick, 5000);
+    return () => { cancelled = true; clearInterval(handle); };
+  }, []);
+
+  const setupActive = pathname.startsWith('/setup');
+
   return (
     <div className="h-14 bg-gray-100 dark:bg-black border-b border-gray-200 dark:border-gray-800 flex items-center justify-between px-4 shrink-0 md:hidden z-20">
        {/* Left: Logo + Text */}
@@ -46,6 +72,21 @@ export function MobileTopBar() {
        </div>
        {/* Right: Icons */}
        <div className="flex items-center gap-4">
+          {hasActiveInstall && (
+            <button
+              onClick={() => router.push('/setup')}
+              className={`relative transition-colors ${
+                setupActive
+                  ? 'text-blue-600 dark:text-blue-400'
+                  : 'text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300'
+              }`}
+              aria-label="Resume setup"
+              title="Resume setup"
+            >
+              <Wrench size={20} />
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+            </button>
+          )}
           <button
             onClick={() => router.push(`/settings${node ? `?node=${node}` : ''}`)}
             className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"

--- a/src/components/StackVariableField.tsx
+++ b/src/components/StackVariableField.tsx
@@ -45,7 +45,7 @@ interface StackVariableFieldProps {
    * only the template default as a static badge. The wizard owns
    * the state mutation via useStackInstall.setVariableExposure.
    */
-  onExposureChange?: (exposure: 'public' | 'lan') => void;
+  onExposureChange?: (exposure: 'public' | 'internal' | 'lan') => void;
   /** Tailwind class shape. Pre-extraction the two consumers used
    *  slightly different paddings/border-radii; defaulting to the
    *  InstallerModal shape and letting OnboardingWizard pass its own
@@ -131,13 +131,23 @@ export default function StackVariableField({
   }
 
   // Subdomain field (shows .domain suffix). When `onExposureChange` is
-  // provided, an inline Public/LAN segmented toggle hangs to the right
-  // — operators override the per-template default; the choice drives
-  // whether the install auto-requests a Let's Encrypt cert. Without
+  // provided, an inline Public/Internal/LAN segmented toggle hangs to
+  // the right — operators override the per-template default; the choice
+  // drives whether the install auto-requests a Let's Encrypt cert and
+  // whether NPM binds the LAN-only access list. Without
   // `onExposureChange` (e.g. read-only contexts) we fall back to a
   // small static badge so the operator still sees what's planned.
   if (v.meta?.type === 'subdomain') {
-    const exposure: 'public' | 'lan' = v.meta.exposure === 'public' ? 'public' : 'lan';
+    const exposure: 'public' | 'internal' | 'lan' =
+      v.meta.exposure === 'public' ? 'public'
+      : v.meta.exposure === 'internal' ? 'internal'
+      : 'lan';
+    const badgeClass = exposure === 'public'
+      ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100'
+      : exposure === 'internal'
+        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-100'
+        : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+    const badgeLabel = exposure === 'public' ? 'Public' : exposure === 'internal' ? 'Internal' : 'LAN';
     return (
       <div className="flex items-center gap-2 flex-wrap">
         <div className="flex items-center gap-0 flex-1 min-w-[12rem]">
@@ -164,17 +174,23 @@ export default function StackVariableField({
             </button>
             <button
               type="button"
+              onClick={() => onExposureChange('internal')}
+              className={`px-2.5 py-1.5 border-l border-gray-300 dark:border-gray-700 ${exposure === 'internal' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+              title="LAN-only access but with a real Let's Encrypt cert. Authelia forward-auth works (needs HTTPS); NPM blocks non-LAN IPs. ACME challenge bypasses the allowlist so LE can validate."
+            >
+              Internal
+            </button>
+            <button
+              type="button"
               onClick={() => onExposureChange('lan')}
               className={`px-2.5 py-1.5 border-l border-gray-300 dark:border-gray-700 ${exposure === 'lan' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
-              title="LAN-only — no public exposure, no TLS cert provisioned."
+              title="LAN-only, plain HTTP — no cert provisioned. Authelia forward-auth does NOT work here (rejects http scheme)."
             >
               LAN
             </button>
           </div>
         ) : (
-          <span className={`px-2 py-0.5 rounded text-xs ${exposure === 'public' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100' : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'}`}>
-            {exposure === 'public' ? 'Public' : 'LAN'}
-          </span>
+          <span className={`px-2 py-0.5 rounded text-xs ${badgeClass}`}>{badgeLabel}</span>
         )}
       </div>
     );

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -68,9 +68,10 @@ export interface ProxyHostEntry {
    *   - whether to bother letsdebug.net with this domain (skipped
    *     entirely for `lan` since it'll never have a public record).
    * Missing on entries that pre-date this field; treat as `lan` so
-   * the conservative default applies.
+   * the conservative default applies. See VariableMeta.exposure for
+   * the three-tier semantics.
    */
-  exposure?: 'public' | 'lan';
+  exposure?: 'public' | 'internal' | 'lan';
 }
 
 export interface ReverseProxyConfig {

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -48,7 +48,11 @@ export interface DomainExternalReachabilityResult {
   items?: ProbeItem[];
 }
 
-function isPublicEntry(entry: { domain: string; exposure?: 'public' | 'lan' }): boolean {
+function isPublicEntry(entry: { domain: string; exposure?: 'public' | 'internal' | 'lan' }): boolean {
+  // Only `public` should be probed for external reachability — `internal`
+  // hosts have a public DNS record (so LE can validate) but are firewalled
+  // to the LAN by NPM, so probing from a public DNS-over-HTTPS resolver
+  // returns false-positives ("LAN IP, looks broken").
   if (entry.exposure) return entry.exposure === 'public';
   if (!entry.domain) return false;
   return !entry.domain.endsWith('.home.arpa') && !entry.domain.endsWith('.local');

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -415,8 +415,11 @@ export interface VariableMeta {
    * operator can override per-service in the wizard's configure step.
    * Missing/undefined treated the same as `lan` (the conservative
    * default — never auto-request a cert without explicit opt-in).
+   * `internal` requests a cert (so Authelia forward-auth works) but
+   * binds an NPM LAN-only access list so the host isn't reachable
+   * from outside the LAN.
    */
-  exposure?: 'public' | 'lan';
+  exposure?: 'public' | 'internal' | 'lan';
   /** OIDC client to register with Authelia when this service is deployed */
   oidcClient?: OidcClientConfig;
   /** For bcrypt type: name of another variable whose plaintext gets bcrypt-hashed */

--- a/src/lib/stackInstall/forwardAuth.ts
+++ b/src/lib/stackInstall/forwardAuth.ts
@@ -23,24 +23,35 @@ export const AUTHELIA_FORWARD_AUTH_SENTINEL = '__authelia_forward_auth__';
  * `{{AUTHELIA_PORT}}` so it survives the Mustache pass that turns
  * cross-template placeholders into concrete values at install time.
  *
- * **Authelia 4.38+ endpoint:** `/api/authz/forward-auth`. The legacy
- * `/api/verify` was deprecated in v4.38 — Authelia 4.39 refuses to
- * read the (Secure) session cookie when /api/verify is called over
- * `http://` (logs: *"Target URL 'http://127.0.0.1:9091/api/verify'
- * has an insecure scheme 'http', only the 'https' and 'wss' schemes
- * are supported so session cookies can be transmitted securely"*).
- * Operators saw FileBrowser bounce them to its local login form with
- * an empty `Remote-User` header even with a valid Authelia session;
- * root cause traced via container logs (Authelia kept logging the
- * verify request as `user=<anonymous>`). The new endpoint takes the
- * forwarded URL via `X-Forwarded-*` headers and is transport-aware,
- * so the cookie is read correctly even when nginx proxies to it
- * over http on the loopback.
+ * **Endpoint:** `/api/authz/auth-request`, NOT `/api/authz/forward-auth`.
+ * Authelia 4.38+ exposes two distinct endpoints for proxy integration:
+ * - `forward-auth` returns a 302 with a `Location` header (for Traefik,
+ *   Caddy — proxies that follow redirects themselves).
+ * - `auth-request` returns 401 plus the Location in a response header
+ *   (for nginx `ngx_http_auth_request_module`, which only accepts
+ *   2xx/401 from the subrequest and silently treats 3xx as 5xx).
  *
- * Also drops the explicit `error_page 401 =302` redirect — the new
- * endpoint returns a 302 with the correct `Location: auth.<domain>`
- * header on its own when the user isn't authenticated, so we don't
- * need to rewrite the status code on the nginx side.
+ * Using `forward-auth` from an nginx `auth_request` directive surfaces
+ * as `"auth request unexpected status: 302"` in `error.log` and the
+ * client gets 500. Live-fixed 2026-05-17 after a v3.42.0 install left
+ * every gated subdomain returning 500.
+ *
+ * The auth-request endpoint also keeps Authelia's legacy header API:
+ * `X-Original-URL` + `X-Original-Method` carry the request, NOT the
+ * `X-Forwarded-*` set that the forward-auth endpoint expects.
+ *
+ * Authelia validates the scheme in `X-Original-URL` — anything other
+ * than `https://` triggers *"Target URL has an insecure scheme 'http',
+ * only the 'https' and 'wss' schemes are supported so session cookies
+ * can be transmitted securely"* and a 400. So this snippet is only
+ * useful on hosts that actually serve traffic over HTTPS (= have a
+ * cert bound). For cert-less LAN-only hosts, gate auth differently
+ * (or don't gate at all).
+ *
+ * `error_page 401 =302 $redirect` converts the 401 back to a 302 the
+ * browser can follow; `$redirect` is captured from
+ * `$upstream_http_location` which Authelia populates with the correct
+ * `auth.<domain>/?rd=<original>` URL.
  */
 export const AUTHELIA_FORWARD_AUTH_SNIPPET = [
   'auth_request /authelia;',
@@ -54,22 +65,15 @@ export const AUTHELIA_FORWARD_AUTH_SNIPPET = [
   'proxy_set_header Remote-Groups $groups;',
   'proxy_set_header Remote-Name $name;',
   'proxy_set_header Remote-Email $email;',
-  // Authelia's forward-auth endpoint already returns a Location header
-  // pointing at the auth portal with the correct rd= param; honour it
-  // verbatim. Fall back to the bare portal URL if no Location came back
-  // (e.g. transient Authelia error) so the operator at least lands
-  // somewhere they can re-authenticate.
   'error_page 401 =302 $redirect;',
   '',
   'location = /authelia {',
   '    internal;',
-  '    proxy_pass http://127.0.0.1:{{AUTHELIA_PORT}}/api/authz/forward-auth;',
+  '    proxy_pass http://127.0.0.1:{{AUTHELIA_PORT}}/api/authz/auth-request;',
   '    proxy_pass_request_body off;',
   '    proxy_set_header Content-Length "";',
-  '    proxy_set_header X-Forwarded-Method $request_method;',
-  '    proxy_set_header X-Forwarded-Proto $scheme;',
-  '    proxy_set_header X-Forwarded-Host $http_host;',
-  '    proxy_set_header X-Forwarded-Uri $request_uri;',
+  '    proxy_set_header X-Original-URL $scheme://$http_host$request_uri;',
+  '    proxy_set_header X-Original-Method $request_method;',
   '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
   '    proxy_set_header X-Real-IP $remote_addr;',
   '}',

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -131,10 +131,13 @@ function renderProxyConfig(
  * `tests/backend/buildProxyHosts.test.ts`).
  *
  * Hosts are split by their declared `exposure`:
- *   - `public` → `<sub>.<PUBLIC_DOMAIN>` (Let's Encrypt cert,
+ *   - `public`   → `<sub>.<PUBLIC_DOMAIN>` (Let's Encrypt cert,
  *     externally reachable once DNS points here).
- *   - `lan`    → `<sub>.<PUBLIC_DOMAIN>` too. Split-horizon is
- *     enforced by AdGuard's `*.<PUBLIC_DOMAIN> → <lanIp>` wildcard
+ *   - `internal` → `<sub>.<PUBLIC_DOMAIN>` (LE cert too, so Authelia
+ *     forward-auth works) but the proxy host binds the NPM LAN-only
+ *     access list. ACME-challenge bypasses the allowlist by design.
+ *   - `lan`      → `<sub>.<PUBLIC_DOMAIN>` too, no cert. Split-horizon
+ *     is enforced by AdGuard's `*.<PUBLIC_DOMAIN> → <lanIp>` wildcard
  *     plus the absence of a public DNS record for LAN-only names.
  *
  * Pure LAN-only installs (no `PUBLIC_DOMAIN` set) get `<sub>.home.arpa`
@@ -146,8 +149,8 @@ export function buildProxyHosts(variables: StackVariable[]): {
     domain: string;
     forwardPort: number;
     service: string;
-    /** 'public' triggers auto-cert request server-side; 'lan' skips. */
-    exposure: 'public' | 'lan';
+    /** 'public' and 'internal' trigger auto-cert; 'lan' skips. */
+    exposure: 'public' | 'internal' | 'lan';
     proxyConfig?: VariableMeta['proxyConfig'];
   }[];
 } {
@@ -160,10 +163,14 @@ export function buildProxyHosts(variables: StackVariable[]): {
   const subdomainVars = variables.filter(v => v.meta?.type === 'subdomain' && v.value);
   const hosts = subdomainVars.flatMap(sv => {
     // Conservative default: missing/unknown → 'lan'. Templates declare
-    // `"exposure": "public"` explicitly for services that should get a
-    // Let's Encrypt cert at install time.
-    const exposure: 'public' | 'lan' = sv.meta?.exposure === 'public' ? 'public' : 'lan';
-    const hostDomain = exposure === 'public' ? domain : lanDomain;
+    // `"exposure": "public"` or `"internal"` explicitly when they want
+    // a cert at install time.
+    const raw = sv.meta?.exposure;
+    const exposure: 'public' | 'internal' | 'lan' =
+      raw === 'public' ? 'public'
+      : raw === 'internal' ? 'internal'
+      : 'lan';
+    const hostDomain = (exposure === 'public' || exposure === 'internal') ? domain : lanDomain;
     if (!hostDomain) return [];
     let port = sv.meta?.proxyPort || '';
     const portVar = variables.find(v => v.name === port);

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -116,7 +116,7 @@ export interface UseStackInstallReturn {
    * proxy-hosts POST sees the operator's choice. Only meaningful for
    * subdomain variables — no-op on others.
    */
-  setVariableExposure: (name: string, exposure: 'public' | 'lan') => void;
+  setVariableExposure: (name: string, exposure: 'public' | 'internal' | 'lan') => void;
 
   /** Fetch yamls + variable metadata + configFiles for every checked
    *  item, resolve placeholders, transition to 'configure'. `prefilled`
@@ -440,7 +440,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     });
   }, []);
 
-  const setVariableExposure = useCallback((name: string, exposure: 'public' | 'lan') => {
+  const setVariableExposure = useCallback((name: string, exposure: 'public' | 'internal' | 'lan') => {
     setVariables(prev => {
       const i = prev.findIndex(x => x.name === name);
       if (i === -1) return prev;

--- a/templates/adguard/variables.json
+++ b/templates/adguard/variables.json
@@ -22,7 +22,7 @@
     "type": "subdomain",
     "description": "Subdomain for AdGuard Home admin — gated by Authelia forward-auth. AdGuard itself binds on 127.0.0.1, so the only way in is via SSO. Local AdGuard credentials remain as a recovery backstop when reached from the host loopback.",
     "default": "dns",
-    "exposure": "lan",
+    "exposure": "internal",
     "proxyPort": "ADGUARD_ADMIN_PORT",
     "proxyConfig": {
       "block_exploits": true,

--- a/templates/auth/variables.json
+++ b/templates/auth/variables.json
@@ -46,7 +46,6 @@
     "proxyPort": "AUTHELIA_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,
-      "block_exploits": true,
       "ssl_forced": true
     }
   },

--- a/templates/auth/variables.json
+++ b/templates/auth/variables.json
@@ -26,7 +26,7 @@
     "type": "subdomain",
     "description": "Subdomain for LLDAP Web UI",
     "default": "ldap",
-    "exposure": "lan",
+    "exposure": "internal",
     "proxyPort": "LLDAP_PORT",
     "proxyConfig": {
       "block_exploits": true,

--- a/templates/file-share/variables.json
+++ b/templates/file-share/variables.json
@@ -12,7 +12,7 @@
     "type": "subdomain",
     "description": "Subdomain for Syncthing Web UI — gated by Authelia forward-auth. The Syncthing mobile/desktop apps use API keys, not the GUI session, so device sync keeps working.",
     "default": "sync",
-    "exposure": "lan",
+    "exposure": "internal",
     "proxyPort": "8384",
     "proxyConfig": {
       "allow_websocket_upgrade": true,

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -15,14 +15,15 @@
   },
   "ZWAVE_JS_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for the Z-Wave JS UI. LAN-only — Z-Wave management doesn't need to be exposed to the public internet.",
+    "description": "Subdomain for the Z-Wave JS UI. Internal exposure — gets a real LE cert (Authelia forward-auth needs https) but NPM binds the LAN-only access list, so it's not reachable from outside the LAN.",
     "default": "zwave",
-    "exposure": "lan",
+    "exposure": "internal",
     "proxyPort": "8091",
     "proxyConfig": {
       "allow_websocket_upgrade": true,
       "block_exploits": true,
-      "ssl_forced": false
+      "ssl_forced": true,
+      "advanced_config": "__authelia_forward_auth__"
     }
   },
   "HA_OIDC_SECRET": {

--- a/tests/backend/buildProxyHosts.test.ts
+++ b/tests/backend/buildProxyHosts.test.ts
@@ -21,7 +21,7 @@ const v = (
 ): StackVariable => ({ name, value, meta });
 
 const subdomain = (
-  exposure: 'public' | 'lan' | undefined,
+  exposure: 'public' | 'internal' | 'lan' | undefined,
   port: string,
   extras: Partial<NonNullable<StackVariable['meta']>> = {},
 ): StackVariable['meta'] => ({
@@ -144,6 +144,34 @@ describe('buildProxyHosts', () => {
       v('SET_SUBDOMAIN', 'real', subdomain('public', '8001')),
     ]);
     expect(hosts.map(h => h.domain)).toEqual(['real.example.com']);
+  });
+
+  it('routes internal-exposure subdomains onto PUBLIC_DOMAIN with internal flag', () => {
+    // `internal` is `public` for routing (needs a real DNS A-record so LE
+    // HTTP-01 can validate) but the install runner binds the LAN-only
+    // access list. ACME-challenge bypasses that list inside NPM by design.
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('internal', '8091')),
+    ]);
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0]).toMatchObject({
+      domain: 'zwave.example.com',
+      forwardPort: 8091,
+      exposure: 'internal',
+    });
+  });
+
+  it('skips internal-exposure hosts when PUBLIC_DOMAIN is empty (no domain to graft onto)', () => {
+    // Internal requires a real cert which requires a real domain.
+    // Without PUBLIC_DOMAIN the host is dropped — `home.arpa` can't
+    // hold a public LE cert, so falling back would create a broken
+    // (cert-less) host. Surface this loudly via the dropped entry
+    // and let the wizard's PUBLIC_DOMAIN validation catch it.
+    const { hosts } = buildProxyHosts([
+      v('ZWAVE_JS_SUBDOMAIN', 'zwave', subdomain('internal', '8091')),
+    ]);
+    expect(hosts).toEqual([]);
   });
 
   it('uses templateName from meta when present, else derives from var name', () => {


### PR DESCRIPTION
## Summary

Pre-reinstall fix batch for v3.42.1. Three commits covering issues that surfaced after the v3.42.0 deploy left the live server in a partially-broken state. **MUST land before the next `.100` reinstall** — without it, every reinstall reproduces the same issues (encrypted secrets become un-decryptable, LE rate-limit triggers cert-less hosts, every gated subdomain returns 500).

### `47273f9` — persist AUTH_SECRET + reuse existing NPM certs (#565, #566)

- AUTH_SECRET is now read from `/var/mnt/data/servicebay/.auth-secret.env`, seeded once by a new oneshot unit `servicebay-auth-secret-init.service`. Re-installing no longer regenerates a fresh secret → all `enc:v1:…` config entries (FritzBox creds, NPM password) stay decryptable.
- New `findReusableCert(domain)` helper in the proxy-hosts route: if NPM already has a non-expired LE cert for a domain, bind it instead of POSTing to `/api/nginx/certificates`. Skips ACME entirely for re-installs → no more rate-limit lockouts.

### `fdf3940` — Authelia auth-request, Z-Wave udev, mobile Setup icon, drop auth block_exploits

- **Authelia endpoint:** switch from `/api/authz/forward-auth` (302 → nginx `auth_request` rejects) to `/api/authz/auth-request` (401 + Location header → nginx error_page converts to 302). Use the legacy `X-Original-URL` + `X-Original-Method` headers the auth-request endpoint expects.
- **Z-Wave udev:** ship `/etc/udev/rules.d/99-zwave.rules` via ignition so `/dev/ttyACM*` lands at MODE=0666 and `/dev/zwave` symlink points at Sigma Designs sticks (0658:0200). Rootless containers see `nobody:nobody` on the device — without 0666 they get EACCES.
- **Mobile Setup icon:** when an install job is active, the desktop sidebar shows a pulsing Wrench → /setup pill. Mobile hides the sidebar; minimized wizards became unreachable. Add the same affordance to `MobileTopBar`.
- **Drop block_exploits from auth subdomain:** NPM's regex `/[a-zA-Z0-9_]=http://i` 403s every Authelia redirect (`?rd=http://…`). Gated services keep block_exploits.

### `bc710f8` — `exposure: internal` (real cert + LAN-only)

New exposure tier for admin UIs that need Authelia forward-auth (HTTPS-only) but shouldn't be reachable from outside the LAN.

- `internal` → LE cert + NPM LAN-only access list. ACME challenge bypasses the allowlist by design (`auth_basic off; auth_request off; allow all;` inside `letsencrypt-acme-challenge.conf`), so HTTP-01 validates while the rest of the host stays LAN-restricted.
- Templates moved to `internal`: `auth/LLDAP_SUBDOMAIN`, `adguard/ADGUARD_SUBDOMAIN`, `file-share/SYNCTHING_SUBDOMAIN`, `home-assistant/ZWAVE_JS_SUBDOMAIN`.
- Wizard segmented toggle is now 3-way: Public / Internal / LAN.
- 2 new regression tests in `tests/backend/buildProxyHosts.test.ts`.

## Test plan

- [x] `npm test` — 805 passed, 2 skipped, 0 failed
- [x] `npx tsc --noEmit` — clean
- [ ] Live-verified on `.100` (HTTPS works for 10 cert-bound subdomains, files.dopp.cloud → auth.dopp.cloud forward-auth redirect, Z-Wave stick accessible inside zwave-js container — but these used live-patches that drift back to template state on reinstall, which is why this PR exists)
- [ ] Smoke: fresh ignition install with stick plugged in → /dev/zwave appears at 0666 before HA stack lands
- [ ] Smoke: re-install over existing data → NPM creds + FritzBox creds still decryptable, public domains still HTTPS
- [ ] Smoke: ldap.dopp.cloud / dns.dopp.cloud / sync.dopp.cloud / zwave.dopp.cloud reachable from LAN with valid cert, 403 from a non-LAN source

## Out of scope (follow-ups)

- Wildcard `*.dopp.cloud` cert via DNS-01 challenge — picked up after `internal` is bedded in (memory: `project_wildcard_cert_future`)
- "Clean install" mode transparency rework — separate PR with disclosure screens listing what each mode preserves vs wipes (memory: `project_install_modes_rework`, task #37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)