### PR TITLE
feat(install): granular preserve per group on Clean install (#568)

### DIFF
--- a/src/app/api/system/stacks/reset/info/route.ts
+++ b/src/app/api/system/stacks/reset/info/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { agentManager } from '@/lib/agent/manager';
+import { DigitalTwinStore } from '@/lib/store/twin';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { RESET_GROUPS, type ResetGroup } from '@/lib/install/resetGroups';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/system/stacks/reset/info?node=<name>
+ *
+ * Returns per-group disk usage so the wizard's "what will Clean
+ * install wipe?" panel can show concrete sizes next to each
+ * preserve/wipe checkbox — operators decide intentionally instead of
+ * blind-clicking RESET (the #568 transparency rework).
+ *
+ * Response:
+ *   {
+ *     node: "atHome-Server",
+ *     groups: [
+ *       { id: "secrets",       label: "...", description: "...", paths: [...], bytes: 123, exists: true },
+ *       { id: "certs",         ...,                                            bytes: 456 },
+ *       { id: "identity",      ...,                                            bytes: 789 },
+ *       { id: "service-data",  ...,                                            bytes: 12_345_678 }
+ *     ]
+ *   }
+ *
+ * Sizes are computed via `du -sb` on each path, summed across paths in
+ * the group. Empty/missing paths report 0 + `exists: false` so the UI
+ * can grey out groups that have nothing to wipe. Best-effort: a `du`
+ * failure on one path doesn't kill the whole response — that group
+ * reports `bytes: null` so the UI can fall back to "size unknown".
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireSession(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const url = new URL(request.url);
+    const requestedNode = url.searchParams.get('node') || undefined;
+
+    const twin = DigitalTwinStore.getInstance();
+    const nodeName = requestedNode || Object.keys(twin.nodes)[0];
+    if (!nodeName) {
+      return NextResponse.json({ error: 'No nodes available' }, { status: 404 });
+    }
+
+    const agent = await agentManager.ensureAgent(nodeName);
+
+    type GroupInfo = {
+      id: ResetGroup;
+      label: string;
+      description: string;
+      paths: string[];
+      bytes: number | null;
+      exists: boolean;
+    };
+
+    const groupIds = Object.keys(RESET_GROUPS) as ResetGroup[];
+    const groups: GroupInfo[] = await Promise.all(groupIds.map(async (id): Promise<GroupInfo> => {
+      const def = RESET_GROUPS[id];
+      const paths = [...def.paths];
+      // Compute du for each path; sum. service-data excludes the certs +
+      // identity subdirs so the UI doesn't double-count.
+      let total = 0;
+      let anyExists = false;
+      let anyFailed = false;
+      for (const p of paths) {
+        try {
+          // `du -sb` reports bytes (Linux). exit=1 means path missing — treat as 0.
+          // For the service-data path (= /mnt/data/stacks), subtract the certs +
+          // identity subdirs so we don't double-count them. We compute via
+          // `du -sb --exclude` instead of doing math, because excluding gets
+          // the right answer even when the operator added more services.
+          const exclusions = id === 'service-data'
+            ? ['nginx-proxy-manager', 'auth'].map(n => `--exclude=${n}`).join(' ')
+            : '';
+          const cmd = `if [ -e ${JSON.stringify(p)} ]; then du -sb ${exclusions} ${JSON.stringify(p)} 2>/dev/null | awk '{print $1}'; else echo "MISSING"; fi`;
+          const res = await agent.sendCommand('exec', { command: cmd });
+          const out = (res.stdout || '').trim();
+          if (out === 'MISSING' || out === '') continue;
+          const n = parseInt(out, 10);
+          if (Number.isFinite(n)) {
+            total += n;
+            anyExists = true;
+          } else {
+            anyFailed = true;
+          }
+        } catch {
+          anyFailed = true;
+        }
+      }
+      return {
+        id,
+        label: def.label,
+        description: def.description,
+        paths,
+        bytes: anyFailed && !anyExists ? null : total,
+        exists: anyExists,
+      };
+    }));
+
+    return NextResponse.json({ node: nodeName, groups });
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:stacks:reset:info', status: 500 });
+  }
+}

--- a/src/app/api/system/stacks/reset/route.ts
+++ b/src/app/api/system/stacks/reset/route.ts
@@ -6,6 +6,7 @@ import { DigitalTwinStore } from '@/lib/store/twin';
 import { logger } from '@/lib/logger';
 import { requireSession } from '@/lib/api/requireSession';
 import { apiError } from '@/lib/api/errors';
+import { RESET_GROUPS, DEFAULT_PRESERVE, type ResetGroup } from '@/lib/install/resetGroups';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,18 +15,27 @@ const PROTECTED = new Set(['servicebay']);
 
 /**
  * POST /api/system/stacks/reset
- * Body: { confirm: 'RESET', node?: string }
+ * Body: {
+ *   confirm: 'RESET',
+ *   node?: string,
+ *   preserve?: ResetGroup[]   // omit = use DEFAULT_PRESERVE
+ * }
  *
- * Wipes all stack data so the install wizard can re-deploy from a truly
- * clean slate. Specifically:
- *   - lists all installed services on the target node
- *   - stops + removes their Quadlet definitions (.kube + .yml)
+ * Wipes stack data so the install wizard can re-deploy. Granular per
+ * #568 — the operator picks which groups to keep. Defaults preserve
+ * the three system-critical groups (secrets / certs / identity); only
+ * service-data wipes unless the operator explicitly opts in.
+ *
+ * Concrete steps:
+ *   - stops + removes Quadlet definitions for all non-protected services
  *   - reloads systemd
- *   - deletes everything in `<DATA_DIR>` (default /mnt/data/stacks)
- *   - removes /mnt/data/servicebay/quadlet-backup so an OS reinstall does
- *     not restore the now-deleted services from setup-raid.sh
+ *   - archives NPM data to /mnt/data/servicebay/cert-archive/ (so a
+ *     full wipe still leaves the cert-reuse helper a fallback)
+ *   - deletes paths under `<DATA_DIR>` according to the preserve map
+ *   - removes /mnt/data/servicebay/quadlet-backup so an OS reinstall
+ *     does not restore now-deleted services from setup-raid.sh
  *
- * ServiceBay itself is intentionally not touched.
+ * ServiceBay itself is intentionally not touched (Quadlet definition).
  */
 export async function POST(request: NextRequest) {
   try {
@@ -33,9 +43,10 @@ export async function POST(request: NextRequest) {
     if (auth instanceof NextResponse) return auth;
 
     const body = await request.json();
-    const { confirm, node: requestedNode } = body as {
+    const { confirm, node: requestedNode, preserve: rawPreserve } = body as {
       confirm?: string;
       node?: string;
+      preserve?: string[];
     };
 
     if (confirm !== 'RESET') {
@@ -44,6 +55,15 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // Validate preserve groups; ignore unknown ids rather than failing
+    // so a forward-compatible caller (newer ServiceBay client talking
+    // to an older backend) doesn't break — unknown groups just have
+    // no effect. Default to system-critical preservation when omitted.
+    const validGroups = Object.keys(RESET_GROUPS) as ResetGroup[];
+    const preserve: ResetGroup[] = Array.isArray(rawPreserve)
+      ? (rawPreserve.filter((g): g is ResetGroup => validGroups.includes(g as ResetGroup)))
+      : DEFAULT_PRESERVE.slice();
 
     const twin = DigitalTwinStore.getInstance();
     const nodeName = requestedNode || Object.keys(twin.nodes)[0];
@@ -64,10 +84,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Service inventory: stop + remove Quadlet for everything except
+    // services whose data dir falls under a preserved group. Otherwise
+    // the operator would lose the cert-reuse benefit because the NPM
+    // service was torn down even though its data dir stays.
     const services = await ServiceManager.listServices(nodeName);
+    const preservedServices = new Set<string>();
+    if (preserve.includes('certs')) preservedServices.add('nginx-proxy-manager');
+    if (preserve.includes('identity')) preservedServices.add('auth');
     const toDelete = services
       .map(s => s.name)
-      .filter(name => !PROTECTED.has(name));
+      .filter(name => !PROTECTED.has(name) && !preservedServices.has(name));
 
     const deleted: string[] = [];
     const failed: { name: string; error: string }[] = [];
@@ -84,51 +111,93 @@ export async function POST(request: NextRequest) {
 
     const agent = await agentManager.ensureAgent(nodeName);
 
-    // Snapshot NPM's data dir (cert files + DB) to a path that survives
-    // the wipe below. Without this, every clean install burns a fresh
-    // batch of Let's Encrypt issuances and we run head-first into the
-    // "5 duplicate certs / 168h" rate limit after a few re-deploys.
-    // Archive path is intentionally under /mnt/data/servicebay/cert-archive/
-    // — neither this endpoint nor any other code path wipes that.
+    // Snapshot NPM's data dir to cert-archive UNLESS the secrets group
+    // is also being wiped (which would delete the archive itself, making
+    // the snapshot useless). When secrets is preserved AND certs is
+    // wiped, the archive lets cert-reuse pull from a backup tarball on
+    // next install — without re-running into LE's rate limit.
     let certArchive: string | null = null;
-    try {
-      const npmDir = `${dataDir}/nginx-proxy-manager`;
-      const probe = await agent.sendCommand('exec', {
-        command: `[ -d "${npmDir}/letsencrypt/live" ] && find "${npmDir}/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
-      });
-      const hasCerts = !!(probe.stdout || '').trim();
-      if (hasCerts) {
-        const ts = new Date().toISOString().replace(/[:.]/g, '-');
-        const archivePath = `/mnt/data/servicebay/cert-archive/npm-${ts}.tar.gz`;
-        await agent.sendCommand('exec', {
-          command: `mkdir -p /mnt/data/servicebay/cert-archive && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+    const willWipeCerts = !preserve.includes('certs');
+    const willWipeSecrets = !preserve.includes('secrets');
+    if (willWipeCerts && !willWipeSecrets) {
+      try {
+        const npmDir = `${dataDir}/nginx-proxy-manager`;
+        const probe = await agent.sendCommand('exec', {
+          command: `[ -d "${npmDir}/letsencrypt/live" ] && find "${npmDir}/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
         });
-        certArchive = archivePath;
-        logger.info('StackReset', `Archived NPM data to ${archivePath} before wipe.`);
+        const hasCerts = !!(probe.stdout || '').trim();
+        if (hasCerts) {
+          const ts = new Date().toISOString().replace(/[:.]/g, '-');
+          const archivePath = `/mnt/data/servicebay/cert-archive/npm-${ts}.tar.gz`;
+          await agent.sendCommand('exec', {
+            command: `mkdir -p /mnt/data/servicebay/cert-archive && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+          });
+          certArchive = archivePath;
+          logger.info('StackReset', `Archived NPM data to ${archivePath} before wipe.`);
+        }
+      } catch (e) {
+        logger.warn('StackReset', `Cert archive failed: ${e instanceof Error ? e.message : String(e)}`);
       }
-    } catch (e) {
-      // Best-effort — a failed archive shouldn't block the reset.
-      logger.warn('StackReset', `Cert archive failed: ${e instanceof Error ? e.message : String(e)}`);
     }
 
-    // Wipe stack data dir contents (but keep the dir itself).
-    await agent.sendCommand('exec', {
-      command: `find ${dataDir} -mindepth 1 -maxdepth 1 -exec rm -rf {} +`,
-    });
+    // Build the wipe plan: stacks subdirs (NPM, auth, service-data) are
+    // handled per-group; the servicebay dir is handled separately.
+    // Each rm -rf is a single shell exec so the agent can log them.
+    const wipeStepsRun: string[] = [];
 
-    // Remove Quadlet backup so an OS reinstall does not restore stale units.
-    // Path is intentionally hardcoded — setup-raid.sh always writes here.
+    // service-data: wipe everything under /mnt/data/stacks/* except
+    // the preserved subdirs (NPM, auth).
+    if (!preserve.includes('service-data')) {
+      const exclusions: string[] = [];
+      if (preserve.includes('certs')) exclusions.push('nginx-proxy-manager');
+      if (preserve.includes('identity')) exclusions.push('auth');
+      // Use `find -mindepth 1 -maxdepth 1 ! -name X ! -name Y -exec rm -rf`
+      const findExclusions = exclusions.map(n => `! -name ${JSON.stringify(n)}`).join(' ');
+      const cmd = `find ${dataDir} -mindepth 1 -maxdepth 1 ${findExclusions} -exec rm -rf {} +`;
+      await agent.sendCommand('exec', { command: cmd });
+      wipeStepsRun.push(`service-data (kept ${exclusions.length} preserved subdir${exclusions.length === 1 ? '' : 's'})`);
+    } else {
+      // service-data preserved but NPM/auth might individually be wiped
+      // — narrowly target those.
+      if (!preserve.includes('certs')) {
+        await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(`${dataDir}/nginx-proxy-manager`)}` });
+        wipeStepsRun.push('certs only (service-data preserved)');
+      }
+      if (!preserve.includes('identity')) {
+        await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(`${dataDir}/auth`)}` });
+        wipeStepsRun.push('identity only (service-data preserved)');
+      }
+    }
+
+    // secrets: wipe /var/mnt/data/servicebay/ (except quadlet-backup
+    // which we always wipe — handled below).
+    if (!preserve.includes('secrets')) {
+      // Refuse to wipe the path itself; clear its contents instead so
+      // the systemd mount unit + setup-raid don't trip on a missing
+      // dir.
+      await agent.sendCommand('exec', {
+        command: 'find /var/mnt/data/servicebay -mindepth 1 -maxdepth 1 -exec rm -rf {} +',
+      });
+      wipeStepsRun.push('secrets (ServiceBay state)');
+    }
+
+    // Quadlet backup: always wipe so an OS reinstall does not restore
+    // stale units from setup-raid.sh. setup-raid re-creates the dir
+    // on next boot.
     await agent.sendCommand('exec', {
-      command: 'rm -rf /mnt/data/servicebay/quadlet-backup',
+      command: 'rm -rf /var/mnt/data/servicebay/quadlet-backup',
     });
 
     return NextResponse.json({
       ok: true,
       node: nodeName,
       dataDir,
+      preserve,
+      wipeStepsRun,
       deleted,
       failed,
       protected: Array.from(PROTECTED),
+      preservedServices: Array.from(preservedServices),
       certArchive,
     });
   } catch (error) {

--- a/src/components/CleanInstallPanel.tsx
+++ b/src/components/CleanInstallPanel.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle, ShieldCheck, Trash2 } from 'lucide-react';
+
+/**
+ * "Clean install" wizard panel with per-group preserve checkboxes
+ * (#568 transparency rework). Replaces the old binary
+ * Preserve-data / Clean-install radio with a granular control so the
+ * operator picks *what* a wipe actually deletes.
+ *
+ * The four groups + their defaults mirror `src/lib/install/resetGroups`
+ * on the backend; we fetch the runtime sizes from
+ * `/api/system/stacks/reset/info` so the wipe panel shows "Service
+ * data (4.7 GB)" instead of an abstract checkbox the operator can't
+ * size up before clicking RESET.
+ *
+ * State contract:
+ *   - `cleanInstall = false` → outer install runs without a wipe.
+ *     `preserve` value is irrelevant.
+ *   - `cleanInstall = true` + `preserve = undefined` → API default
+ *     (keep secrets/certs/identity, wipe service-data).
+ *   - `cleanInstall = true` + `preserve = [<ids>]` → explicit choices.
+ *     Empty array `[]` means factory reset (wipe everything).
+ */
+
+type GroupInfo = {
+  id: 'secrets' | 'certs' | 'identity' | 'service-data';
+  label: string;
+  description: string;
+  paths: string[];
+  bytes: number | null;
+  exists: boolean;
+};
+
+type InfoResponse = { node: string; groups: GroupInfo[] };
+
+const DEFAULT_KEPT: GroupInfo['id'][] = ['secrets', 'certs', 'identity'];
+
+function formatBytes(n: number | null): string {
+  if (n === null) return 'size unknown';
+  if (n === 0) return 'empty';
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v < 10 ? v.toFixed(1) : Math.round(v)} ${units[i]}`;
+}
+
+export default function CleanInstallPanel({
+  cleanInstall,
+  setCleanInstall,
+  cleanInstallConfirm,
+  setCleanInstallConfirm,
+  preserve,
+  setPreserve,
+  node,
+}: {
+  cleanInstall: boolean;
+  setCleanInstall: (b: boolean) => void;
+  cleanInstallConfirm: string;
+  setCleanInstallConfirm: (s: string) => void;
+  preserve: string[] | undefined;
+  setPreserve: (p: string[] | undefined) => void;
+  node?: string;
+}) {
+  const [info, setInfo] = useState<InfoResponse | null>(null);
+  const [infoError, setInfoError] = useState<string | null>(null);
+
+  // Fetch group sizes whenever the panel is expanded. Avoid hammering
+  // the endpoint when the panel is collapsed — `du -sb` walks the
+  // whole tree which can take a few hundred ms on a deep service-data
+  // dir. Refetch when `node` changes so multi-node setups show the
+  // right numbers.
+  useEffect(() => {
+    if (!cleanInstall) return;
+    let cancelled = false;
+    const qs = node ? `?node=${encodeURIComponent(node)}` : '';
+    fetch(`/api/system/stacks/reset/info${qs}`)
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((d: InfoResponse) => {
+        if (cancelled) return;
+        setInfo(d);
+        setInfoError(null);
+      })
+      .catch(e => { if (!cancelled) setInfoError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, [cleanInstall, node]);
+
+  // Source of truth for which groups are kept right now. When the
+  // operator hasn't touched anything, `preserve === undefined` and we
+  // show the safe defaults. Toggling a checkbox materialises the
+  // array so we know the operator made an intentional choice.
+  const effectivePreserve = preserve ?? DEFAULT_KEPT;
+  const isKept = (id: GroupInfo['id']) => effectivePreserve.includes(id);
+  const toggleKept = (id: GroupInfo['id']) => {
+    const cur = preserve ?? [...DEFAULT_KEPT];
+    setPreserve(cur.includes(id) ? cur.filter(x => x !== id) : [...cur, id]);
+  };
+
+  const willWipe = info?.groups.filter(g => !isKept(g.id) && g.exists) ?? [];
+  const willKeep = info?.groups.filter(g => isKept(g.id) && g.exists) ?? [];
+  const totalWipeBytes = willWipe.reduce<number | null>(
+    (acc, g) => acc === null || g.bytes === null ? null : acc + g.bytes,
+    0,
+  );
+
+  return (
+    <div className="border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
+      <label className="flex items-start gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={cleanInstall}
+          onChange={(e) => {
+            setCleanInstall(e.target.checked);
+            if (!e.target.checked) {
+              setCleanInstallConfirm('');
+              setPreserve(undefined);
+            }
+          }}
+          className="mt-0.5"
+        />
+        <div className="text-sm text-amber-900 dark:text-amber-100">
+          <strong>Clean install</strong> — wipe selected groups before installing.
+          <p className="text-xs text-amber-800 dark:text-amber-200/80 mt-1">
+            Defaults keep system-critical data (secrets, certs, identity) and wipe only service payload. Override per group below. ServiceBay itself is never touched.
+          </p>
+        </div>
+      </label>
+
+      {cleanInstall && (
+        <div className="mt-3 pt-3 border-t border-amber-300 dark:border-amber-700 space-y-3">
+          {infoError && (
+            <p className="text-xs text-amber-700 dark:text-amber-300">
+              Could not load group sizes ({infoError}) — checkboxes still work, just no bytes shown.
+            </p>
+          )}
+
+          <div className="space-y-1.5">
+            {(info?.groups ?? [
+              { id: 'secrets', label: 'ServiceBay secrets + config', description: 'Encryption keys, AUTH_SECRET, config.json, cert-archive', paths: [], bytes: null, exists: true },
+              { id: 'certs', label: "NPM proxy + Let's Encrypt certs", description: 'Reverse-proxy config + issued LE certificates', paths: [], bytes: null, exists: true },
+              { id: 'identity', label: 'Identity provider (Authelia + LLDAP)', description: 'User accounts, groups, OIDC clients, session cookies', paths: [], bytes: null, exists: true },
+              { id: 'service-data', label: 'Service data', description: 'Photos, HA, media, files, vault, …', paths: [], bytes: null, exists: true },
+            ] as GroupInfo[]).map(g => {
+              const kept = isKept(g.id);
+              const disabled = !g.exists;
+              return (
+                <label
+                  key={g.id}
+                  className={`flex items-start gap-2 p-2 rounded border ${
+                    disabled
+                      ? 'opacity-50 border-amber-200 dark:border-amber-800'
+                      : kept
+                        ? 'cursor-pointer border-emerald-300 dark:border-emerald-700 bg-emerald-50/60 dark:bg-emerald-900/10 hover:bg-emerald-50 dark:hover:bg-emerald-900/20'
+                        : 'cursor-pointer border-red-300 dark:border-red-700 bg-red-50/60 dark:bg-red-900/10 hover:bg-red-50 dark:hover:bg-red-900/20'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={kept}
+                    disabled={disabled}
+                    onChange={() => toggleKept(g.id)}
+                    className="mt-0.5"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5 text-xs font-medium text-amber-900 dark:text-amber-100">
+                      {kept ? <ShieldCheck className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400" /> : <Trash2 className="w-3.5 h-3.5 text-red-600 dark:text-red-400" />}
+                      <span>{kept ? 'Keep' : 'Wipe'} — {g.label}</span>
+                      <span className="ml-auto text-[10px] text-amber-700 dark:text-amber-300 font-mono">{g.exists ? formatBytes(g.bytes) : 'not present'}</span>
+                    </div>
+                    <p className="text-[11px] text-amber-800/80 dark:text-amber-200/70 leading-snug mt-0.5">
+                      {g.description}
+                    </p>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+
+          {willWipe.length > 0 && (
+            <div className="text-xs text-amber-900 dark:text-amber-100 flex items-start gap-1.5 p-2 rounded bg-amber-100/60 dark:bg-amber-900/30">
+              <AlertTriangle className="w-4 h-4 text-amber-700 dark:text-amber-400 shrink-0 mt-0.5" />
+              <span>
+                Will wipe <strong>{formatBytes(totalWipeBytes)}</strong> across <strong>{willWipe.length}</strong> group{willWipe.length === 1 ? '' : 's'}
+                {willKeep.length > 0 && <>, keeping {willKeep.length} group{willKeep.length === 1 ? '' : 's'}</>}.
+                This is irreversible.
+              </span>
+            </div>
+          )}
+
+          <div>
+            <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
+              Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
+            </label>
+            <input
+              type="text"
+              value={cleanInstallConfirm}
+              onChange={(e) => setCleanInstallConfirm(e.target.value)}
+              className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
+              placeholder="RESET"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -25,6 +25,7 @@ import { useStackInstall } from '@/lib/stackInstall/useStackInstall';
 import { Loader2, Monitor, Network, Key, CheckCircle, ArrowRight, SkipForward, RefreshCw, Box, Mail, Layers, Package, Globe, HardDrive, Home, Minimize2 } from 'lucide-react';
 import StackVariableField from './StackVariableField';
 import { StackInstallProgress, StackInstallSummary } from './StackInstallFlow';
+import CleanInstallPanel from './CleanInstallPanel';
 import DiagnoseProbeList, { type DiagnoseProbe } from './DiagnoseProbeList';
 import { DoneStepDnsCheck } from './DoneStepDnsCheck';
 import { useToast } from '@/providers/ToastProvider';
@@ -327,6 +328,8 @@ export default function OnboardingWizard() {
   const cleanInstallConfirm = installFlow.cleanInstallConfirm;
   const setCleanInstall = installFlow.setCleanInstall;
   const setCleanInstallConfirm = installFlow.setCleanInstallConfirm;
+  const preserve = installFlow.preserve;
+  const setPreserve = installFlow.setPreserve;
   const stackVariables = installFlow.variables;
   const stackLogs = installFlow.logs;
   const installingNow = installFlow.installingNow;
@@ -1417,49 +1420,16 @@ export default function OnboardingWizard() {
                             </p>
                         </div>
 
-                        {/* Existing data — explicit choice, no default */}
-                        <div className="p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-300 dark:border-amber-700 space-y-2">
-                            <span className="flex items-center gap-2 text-sm font-medium text-amber-900 dark:text-amber-100">
-                                Existing service data
-                            </span>
-                            <div className="flex flex-col gap-1">
-                                <label className="flex items-start gap-2 cursor-pointer text-xs text-amber-900 dark:text-amber-100">
-                                    <input
-                                        type="radio"
-                                        name="data-policy"
-                                        checked={!cleanInstall}
-                                        onChange={() => { setCleanInstall(false); setCleanInstallConfirm(''); }}
-                                        className="mt-0.5"
-                                    />
-                                    <span><strong>Preserve data</strong> — keep anything already in <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code>. Failed installs of the same service will reuse old volumes.</span>
-                                </label>
-                                <label className="flex items-start gap-2 cursor-pointer text-xs text-amber-900 dark:text-amber-100">
-                                    <input
-                                        type="radio"
-                                        name="data-policy"
-                                        checked={cleanInstall}
-                                        onChange={() => setCleanInstall(true)}
-                                        className="mt-0.5"
-                                    />
-                                    <span><strong>Clean install</strong> — wipe <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code> first. Use for true fresh-installs or re-testing from scratch.</span>
-                                </label>
-                            </div>
-                            {cleanInstall && (
-                                <div className="pt-2">
-                                    <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
-                                        Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
-                                    </label>
-                                    <input
-                                        type="text"
-                                        value={cleanInstallConfirm}
-                                        onChange={(e) => setCleanInstallConfirm(e.target.value)}
-                                        className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
-                                        placeholder="RESET"
-                                        autoComplete="off"
-                                    />
-                                </div>
-                            )}
-                        </div>
+                        {/* Existing data — granular preserve/wipe per group (#568) */}
+                        <CleanInstallPanel
+                            cleanInstall={cleanInstall}
+                            setCleanInstall={setCleanInstall}
+                            cleanInstallConfirm={cleanInstallConfirm}
+                            setCleanInstallConfirm={setCleanInstallConfirm}
+                            preserve={preserve}
+                            setPreserve={setPreserve}
+                            node={stackSelectedNode || undefined}
+                        />
                     </div>
                 );
             })()}
@@ -1645,38 +1615,16 @@ export default function OnboardingWizard() {
                         </div>
                     )}
 
-                    {/* Clean install / reset */}
-                    <div className="border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-3">
-                        <label className="flex items-start gap-2 cursor-pointer">
-                            <input
-                                type="checkbox"
-                                checked={cleanInstall}
-                                onChange={(e) => { setCleanInstall(e.target.checked); if (!e.target.checked) setCleanInstallConfirm(''); }}
-                                className="mt-0.5"
-                            />
-                            <div className="text-sm text-amber-900 dark:text-amber-100">
-                                <strong>Clean install</strong> — wipe existing service data first.
-                                <p className="text-xs text-amber-800 dark:text-amber-200/80 mt-1">
-                                    Stops every stack service, deletes their Quadlet definitions and the contents of <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/mnt/data/stacks/*</code>. ServiceBay itself is not affected. Use for true fresh-installs or when re-testing from scratch.
-                                </p>
-                            </div>
-                        </label>
-                        {cleanInstall && (
-                            <div className="mt-3 pt-3 border-t border-amber-300 dark:border-amber-700">
-                                <label className="text-xs font-medium block mb-1 text-amber-900 dark:text-amber-100">
-                                    Type <code className="bg-amber-100 dark:bg-amber-900/40 px-1 rounded">RESET</code> to confirm:
-                                </label>
-                                <input
-                                    type="text"
-                                    value={cleanInstallConfirm}
-                                    onChange={(e) => setCleanInstallConfirm(e.target.value)}
-                                    className="w-full px-2 py-1 border border-amber-300 dark:border-amber-700 rounded text-sm bg-white dark:bg-gray-900"
-                                    placeholder="RESET"
-                                    autoComplete="off"
-                                />
-                            </div>
-                        )}
-                    </div>
+                    {/* Clean install — granular preserve/wipe per group (#568) */}
+                    <CleanInstallPanel
+                        cleanInstall={cleanInstall}
+                        setCleanInstall={setCleanInstall}
+                        cleanInstallConfirm={cleanInstallConfirm}
+                        setCleanInstallConfirm={setCleanInstallConfirm}
+                        preserve={preserve}
+                        setPreserve={setPreserve}
+                        node={stackSelectedNode || undefined}
+                    />
                 </div>
             )}
 

--- a/src/lib/install/jobStore.ts
+++ b/src/lib/install/jobStore.ts
@@ -74,6 +74,11 @@ export interface JobInput {
   node?: string;
   cleanInstall: boolean;
   cleanInstallConfirm: string;
+  /** Per-group preserve flags for the clean-install wipe (#568). Each
+   *  entry the operator left checked means "keep this group". Maps to
+   *  `ResetGroup` from `@/lib/install/resetGroups`. Omitted = use the
+   *  API default (keep system-critical: secrets + certs + identity). */
+  preserve?: string[];
   templateSource: string;
   /** `window.location.hostname` captured client-side so the credentials
    *  banner can render reachable URLs without the server having to guess. */

--- a/src/lib/install/resetGroups.ts
+++ b/src/lib/install/resetGroups.ts
@@ -1,0 +1,61 @@
+/**
+ * Reset preserve-group identifiers used by `/api/system/stacks/reset`
+ * and `/api/system/stacks/reset/info`. The wizard surfaces a checkbox
+ * per group so the operator can pick *what* a "clean install"
+ * actually wipes (#568 transparency rework).
+ *
+ * Defaults preserve the three system-critical groups; only
+ * `service-data` (app payload — photos, HA, media, …) wipes unless
+ * the operator explicitly opts in. The previous behaviour was "wipe
+ * everything" which caused the May-15 data-loss incident
+ * (see [[feedback_destructive_install_options]]).
+ *
+ * Lives in /src/lib because Next.js route files cannot export extra
+ * symbols — the route handler imports from here instead.
+ */
+
+export const RESET_GROUPS = {
+  /** ServiceBay's own state: secret.key, .auth-secret.env, config.json,
+   *  cert-archive. Wiping this turns every `enc:v1:` encrypted credential
+   *  in config.json into garbage (the AES key + AUTH_SECRET are here).
+   *  Default: PRESERVE. */
+  secrets: {
+    paths: ['/var/mnt/data/servicebay'],
+    excludePaths: ['/var/mnt/data/servicebay/quadlet-backup'],
+    label: 'ServiceBay secrets + config',
+    description: 'Encryption keys (secret.key, AUTH_SECRET), config.json, cert-archive. Wiping these forces every encrypted credential to be re-entered and the wizard to start over.',
+  },
+  /** NPM proxy + LE certs as a unit. Cert-reuse logic (#566) needs
+   *  both the on-disk certs AND NPM's DB rows that reference them by
+   *  id, so we treat them atomically.
+   *  Default: PRESERVE — LE has a 5-duplicate-certs / 168h rate limit
+   *  that bites if you wipe + re-issue more than a couple of times. */
+  certs: {
+    paths: ['/var/mnt/data/stacks/nginx-proxy-manager'],
+    label: 'NPM proxy + Let\'s Encrypt certs',
+    description: 'Reverse-proxy config + issued LE certificates. Wiping triggers fresh ACME challenges on next install — LE\'s rate limit blocks repeated wipes.',
+  },
+  /** Authelia + LLDAP — identity provider state. Wiping means
+   *  re-seeding users, regenerating OIDC client secrets, and every
+   *  SSO-enabled service has to be re-linked.
+   *  Default: PRESERVE. */
+  identity: {
+    paths: ['/var/mnt/data/stacks/auth'],
+    label: 'Identity provider (Authelia + LLDAP)',
+    description: 'User accounts, groups, OIDC clients, session cookies. Wiping means every family member re-creates their login and every SSO-enabled service re-pairs.',
+  },
+  /** Everything else under stacks/*: photos, music, HA configs,
+   *  Vaultwarden vault, Syncthing config, AdGuard rules, …
+   *  Default: WIPE. The "clean" in clean install. */
+  'service-data': {
+    paths: ['/var/mnt/data/stacks'],
+    label: 'Service data (photos, HA, media, files, vault, …)',
+    description: 'Immich photos, Home Assistant configs, media library, Vaultwarden vault, Syncthing data, AdGuard rules, etc. The "clean" in clean install.',
+  },
+} as const;
+
+export type ResetGroup = keyof typeof RESET_GROUPS;
+
+/** Default `preserve` array when the API caller omits one. Keeps the
+ *  three system-critical groups; only `service-data` wipes. */
+export const DEFAULT_PRESERVE: ResetGroup[] = ['secrets', 'certs', 'identity'];

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -489,17 +489,37 @@ async function runJob(jobId: string): Promise<void> {
 
   // Optional clean-install reset.
   if (input.cleanInstall && input.cleanInstallConfirm === 'RESET') {
-    await log(jobId, '🧹 Clean install — wiping existing service data...');
+    // Per-group preserve flags (#568): operator's checkbox state from
+    // the wizard. Omitted entirely → endpoint applies the conservative
+    // default (keep secrets + certs + identity, wipe service-data).
+    const preserve = input.preserve;
+    const previewLabel = preserve === undefined
+      ? 'default (keep secrets/certs/identity, wipe service-data)'
+      : preserve.length === 0
+        ? 'FACTORY RESET — wipe everything'
+        : `keep ${preserve.join(' + ')}`;
+    await log(jobId, `🧹 Clean install — ${previewLabel}…`);
     try {
       const res = await apiFetch('/api/system/stacks/reset', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ confirm: 'RESET', node: input.node || undefined }),
+        body: JSON.stringify({
+          confirm: 'RESET',
+          node: input.node || undefined,
+          ...(preserve !== undefined ? { preserve } : {}),
+        }),
       });
       const data = await res.json();
       if (res.ok) {
         const removed = data.deleted?.length ?? 0;
-        await log(jobId, `✅ Reset done — removed ${removed} service${removed === 1 ? '' : 's'}, wiped ${data.dataDir}.`);
+        const kept = data.preservedServices?.length ?? 0;
+        await log(jobId, `✅ Reset done — removed ${removed} service${removed === 1 ? '' : 's'}${kept ? `, kept ${kept} (${(data.preservedServices ?? []).join(', ')})` : ''}.`);
+        if (data.wipeStepsRun?.length) {
+          await log(jobId, `   Wiped: ${data.wipeStepsRun.join('; ')}.`);
+        }
+        if (data.certArchive) {
+          await log(jobId, `   Archived NPM data to ${data.certArchive} — cert-reuse will pull from it on next install.`);
+        }
         if (data.failed?.length) {
           await log(jobId, `⚠️ Some services could not be cleanly removed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`);
         }

--- a/src/lib/stackInstall/useStackInstall.ts
+++ b/src/lib/stackInstall/useStackInstall.ts
@@ -104,6 +104,12 @@ export interface UseStackInstallReturn {
   cleanInstallConfirm: string;
   setCleanInstall: (b: boolean) => void;
   setCleanInstallConfirm: (s: string) => void;
+  /** Per-group preserve flags for the clean-install wipe (#568). Each
+   *  entry left in the array means "keep this group". `undefined` =
+   *  defer to API default (keep secrets+certs+identity, wipe service-data).
+   *  Explicit `[]` = factory reset (wipe everything). */
+  preserve: string[] | undefined;
+  setPreserve: (p: string[] | undefined) => void;
 
   /** Toggle an item's checked state (used by select-step UIs in caller). */
   setItemChecked: (name: string, checked: boolean) => void;
@@ -274,6 +280,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
   const [error, setError] = useState<string | null>(null);
   const [cleanInstall, setCleanInstall] = useState(false);
   const [cleanInstallConfirm, setCleanInstallConfirm] = useState('');
+  const [preserve, setPreserve] = useState<string[] | undefined>(undefined);
   const [jobId, setJobId] = useState<string | null>(null);
 
   /** Latest node value. Cached in a ref so async runInstall sees fresh
@@ -648,6 +655,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
         node: node || undefined,
         cleanInstall,
         cleanInstallConfirm,
+        preserve,
         templateSource,
         host,
       },
@@ -687,7 +695,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       setError(`Could not start install: ${msg}`);
       setPhase("error");
     }
-  }, [items, variables, cleanInstall, cleanInstallConfirm, templateSource, source, attachToJob]);
+  }, [items, variables, cleanInstall, cleanInstallConfirm, preserve, templateSource, source, attachToJob]);
 
   const retryNpmCredentials = useCallback(async (email: string, password: string): Promise<void> => {
     if (!email || !password) return;
@@ -733,6 +741,8 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     cleanInstallConfirm,
     setCleanInstall,
     setCleanInstallConfirm,
+    preserve,
+    setPreserve,
     setItemChecked,
     setItems,
     setVariableValue,

--- a/tests/backend/resetGroups.test.ts
+++ b/tests/backend/resetGroups.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { RESET_GROUPS, DEFAULT_PRESERVE, type ResetGroup } from '@/lib/install/resetGroups';
+
+/**
+ * Regression coverage for the #568 transparency rework:
+ *
+ *  - the four group ids stay stable (they're persisted in `JobInput.preserve`
+ *    and any rename would orphan in-flight jobs)
+ *  - the default `preserve` array keeps the three system-critical groups
+ *    and wipes only service-data — flipping the default in the future
+ *    would silently reintroduce the May-15 data-loss regression
+ *  - every group declares a non-empty `paths` array (the wipe step in
+ *    the route handler dereferences these)
+ */
+
+describe('RESET_GROUPS contract', () => {
+  it('declares exactly the four groups the route + UI expect', () => {
+    const ids = Object.keys(RESET_GROUPS).sort();
+    expect(ids).toEqual(['certs', 'identity', 'secrets', 'service-data']);
+  });
+
+  it('every group has at least one path to wipe', () => {
+    for (const [id, def] of Object.entries(RESET_GROUPS)) {
+      expect(def.paths.length, `group ${id} must declare paths`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every group has a label + description for the wizard panel', () => {
+    for (const [id, def] of Object.entries(RESET_GROUPS)) {
+      expect(def.label.length, `group ${id} label`).toBeGreaterThan(5);
+      expect(def.description.length, `group ${id} description`).toBeGreaterThan(20);
+    }
+  });
+
+  it('default preserve keeps system-critical groups and wipes only service-data', () => {
+    // Lock the default in a test — flipping it back to "wipe everything"
+    // would re-introduce the May-15 incident silently.
+    expect([...DEFAULT_PRESERVE].sort()).toEqual(['certs', 'identity', 'secrets']);
+    const wiped = (Object.keys(RESET_GROUPS) as ResetGroup[]).filter(g => !DEFAULT_PRESERVE.includes(g));
+    expect(wiped).toEqual(['service-data']);
+  });
+
+  it('service-data path is /var/mnt/data/stacks (top-level — wipe excludes preserved subdirs)', () => {
+    // The route handler builds `find $dataDir -mindepth 1 -maxdepth 1 ! -name X ! -name Y`,
+    // which only works because service-data's path is the parent of the
+    // certs + identity subdirs. Lock the relationship.
+    expect(RESET_GROUPS['service-data'].paths).toEqual(['/var/mnt/data/stacks']);
+    expect(RESET_GROUPS.certs.paths[0].startsWith('/var/mnt/data/stacks/')).toBe(true);
+    expect(RESET_GROUPS.identity.paths[0].startsWith('/var/mnt/data/stacks/')).toBe(true);
+  });
+
+  it('secrets path is the ServiceBay state dir (separate tree from stacks/)', () => {
+    expect(RESET_GROUPS.secrets.paths).toEqual(['/var/mnt/data/servicebay']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #568. Replaces the binary "Preserve data / Clean install" radio with four preserve-group checkboxes so the operator picks *what* a wipe actually deletes — instead of nuking everything and learning what was in the path the hard way (May-15 incident).

### Groups + defaults

| Group | Path | Default | Why |
|---|---|---|---|
| ServiceBay secrets + config | `/var/mnt/data/servicebay` | **KEEP** | AES key + AUTH_SECRET — wiping turns every `enc:v1:` credential into garbage |
| NPM proxy + LE certs | `/var/mnt/data/stacks/nginx-proxy-manager` | **KEEP** | LE rate limit (5 duplicate certs / 168h); cert-reuse (#566) needs both DB + on-disk certs |
| Identity provider | `/var/mnt/data/stacks/auth` | **KEEP** | Wiping = re-seed users + regenerate OIDC clients + re-pair every SSO service |
| Service data | `/var/mnt/data/stacks/*` (minus the above) | **WIPE** | Photos, HA, media, vault, sync, AdGuard rules — the "clean" payload |

### Wizard UI

`CleanInstallPanel.tsx` — one panel reused at both wizard spots. Each checkbox shows the live byte size from the new `/api/system/stacks/reset/info` endpoint so the operator picks intentionally.

When all four are checked: factory reset (the old behaviour). The "RESET" confirmation input still gates the action — the granularity is the *what*, not the *whether*.

### Backward compatibility

`POST /api/system/stacks/reset` still accepts the bare `{confirm:'RESET'}` body — the conservative default (keep secrets/certs/identity) applies. Pass `preserve: []` to opt back into the old wipe-everything behaviour. The runner.ts caller now passes `preserve` from the wizard state.

### Test plan

- [x] `npm test` — 811 passed, 2 skipped, 0 failed (+6 new tests in `tests/backend/resetGroups.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke: install wizard with all-defaults → only `/var/mnt/data/stacks/*` minus NPM + auth is wiped, certs survive
- [ ] Smoke: factory reset (all 4 checked) → wipe-all behaviour preserved
- [ ] Smoke: per-group preserve respected by route + service Quadlet definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)