### PR TITLE
feat(diagnose): pattern-aware audit on cert_request_failure + domain_external_reachability (#547)

### DIFF
--- a/docs/UX_PHILOSOPHY.md
+++ b/docs/UX_PHILOSOPHY.md
@@ -76,6 +76,44 @@ server. Destructive actions show a confirm-on-destructive guard.
   admin credentials below." → Should be a probe with both options
   (reset volume vs. enter existing creds), each with consequences.
 
+#### 2a. Pattern-aware probes — name the topology, classify the failure
+
+Probes that can have **more than one legitimate "good" state** (e.g.
+the router can route DNS via Pattern A *or* Pattern B; LE cert failures
+can be port-80 / DNS / CAA / rate-limit / DNSSEC) should:
+
+1. **Detect which valid topology is active** and say so in the OK
+   message. *"Router DNS: AdGuard-as-DHCP-DNS (Pattern A)"* beats
+   *"OK"*. The operator confirms the configuration they actually
+   chose, not just "trust me".
+2. **Show actual + desired state in warn/fail.** *"Public DNS → 1.2.3.4
+   but your gateway IP is 5.6.7.8"* beats *"DNS misconfigured"*. The
+   operator sees both numbers and can act without re-reading the docs.
+3. **Categorise the failure with a stable label.** *"Port 80
+   unreachable — ACME http-01 challenge: …"* beats *"ACME error: …"*.
+   The label points at one fix-path (router port-forward, registrar
+   CAA, …) instead of forcing the operator to pattern-match certbot's
+   prose every time.
+4. **Offer one fix action per legitimate path**, not a single
+   "Retry" that doesn't know which path to push the operator down.
+   The action picker is the operator's intent capture.
+
+Worked examples in this repo:
+- `router_dns_not_pointing` recognises Pattern A *and* Pattern B
+  (FritzBox → AdGuard → public-fallback) as OK, picks each in its OK
+  message, and offers one `configure_fritzbox` action plus one
+  `configure_adguard_dhcp` action.
+- `cert_request_failure` classifies certbot detail text into
+  `port-80 | dns | caa | dnssec | rate-limit | tls-sni | other`. The
+  per-row label tells the operator which fix-path to pursue; the
+  hint text shifts to a category-specific next-step ("add `0 issue
+  letsencrypt.org`" vs. "open port 80") when all rows fall into one
+  category.
+- `domain_external_reachability` names the layer ("DNS layer OK —
+  issue is in the cert / ACME / port-80 layer") when DNS resolves
+  correctly but letsdebug.net reports problems. The operator stops
+  running `dig` on rows that already have working DNS.
+
 ### 3. Hide expert-only knobs
 
 If less than 5% of users would meaningfully change a setting, give it

--- a/src/lib/diagnose/probes/certRequestFailure.test.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.test.ts
@@ -107,6 +107,45 @@ acme.errors.Error: urn:ietf:params:acme:error:rateLimited :: Error creating new 
     const out = parseLetsencryptTail(tail);
     expect(out.failures.map(f => f.domain)).toEqual(['new.dopp.cloud']);
   });
+
+  /**
+   * #547 pattern-aware audit — `category` is the labelled fix-path
+   * (port-80 firewall / CAA / DNS / rate-limit / …). Locking it in a
+   * test means a future regex tweak that drops one of these patterns
+   * fails loudly instead of silently downgrading the operator's row
+   * to the generic "ACME error" fallback.
+   */
+  it('classifies the connection-refused detail as port-80', () => {
+    const tail = `2026-05-12 00:27:14,200:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   connection
+  Detail: 1.2.3.4: Fetching http://vault.dopp.cloud/.well-known/acme-challenge/abc: Connection refused`;
+    expect(parseLetsencryptTail(tail).failures[0].category).toBe('port-80');
+  });
+
+  it('classifies an NXDOMAIN detail as dns', () => {
+    const tail = `2026-05-12 00:30:00,000:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   http-01
+  Detail: DNS problem: NXDOMAIN looking up A for vault.dopp.cloud`;
+    expect(parseLetsencryptTail(tail).failures[0].category).toBe('dns');
+  });
+
+  it('classifies a CAA detail as caa', () => {
+    const tail = `2026-05-12 00:30:00,000:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   dns
+  Detail: CAA record for dopp.cloud prevents issuance`;
+    expect(parseLetsencryptTail(tail).failures[0].category).toBe('caa');
+  });
+
+  it('classifies unknown detail text as `other` (catch-all keeps the row visible)', () => {
+    const tail = `2026-05-12 00:30:00,000:ERROR:certbot:Some challenges have failed.
+  Domain: vault.dopp.cloud
+  Type:   http-01
+  Detail: Some new error message we have not pattern-matched yet`;
+    expect(parseLetsencryptTail(tail).failures[0].category).toBe('other');
+  });
 });
 
 // ─── Reader (Phase 3b: thin HealthStore reader) ─────────────────────────

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -199,15 +199,24 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     }
 
     // Append letsdebug summary line when the operator has run one.
+    // Naming which layer is broken matters here: if DNS resolves
+    // correctly but letsdebug reports a problem, the cert / ACME /
+    // port-80 path is the culprit — not DNS. Operators were running
+    // `dig` again on a 'fail' row that already had DNS working;
+    // making the layer explicit cuts the diagnostic step.
     if (letsdebugResult) {
       const ldAge = formatRelativeAge(Date.parse(letsdebugResult.timestamp));
       const ldPayload = decodeLetsdebug(letsdebugResult.message);
+      const dnsOkBeforeLd = rowStatus === 'ok';
       if (ldPayload) {
         if (ldPayload.problems.length === 0) {
           rowDetail += `\nLetsdebug (${ldAge}): no problems`;
         } else {
           const top = ldPayload.problems[0];
-          rowDetail += `\nLetsdebug (${ldAge}): ${top.name || 'problem'} — ${(top.explanation || '').slice(0, 160)}`;
+          const layerHint = dnsOkBeforeLd
+            ? 'DNS layer OK — issue is in the cert / ACME / port-80 layer.'
+            : 'DNS and cert layers both have findings — start with the DNS fix above.';
+          rowDetail += `\n${layerHint} Letsdebug (${ldAge}): ${top.name || 'problem'} — ${(top.explanation || '').slice(0, 160)}`;
           if (ldPayload.submissionUrl) rowDetail += ` · ${ldPayload.submissionUrl}`;
           // Letsdebug result escalates row status if DNS said ok.
           const ldStatus: 'warn' | 'fail' = ldPayload.problems.some(p => (p.severity || '').toLowerCase() === 'fatal') ? 'fail' : 'warn';

--- a/src/lib/health/probes/letsencryptLogParser.ts
+++ b/src/lib/health/probes/letsencryptLogParser.ts
@@ -13,10 +13,26 @@
  * test.
  */
 
+/** Coarse category of an ACME failure — derived from the detail text
+ *  by `classifyFailure`. The diagnose probe surfaces this as a label
+ *  ("Port 80 unreachable", "CAA blocked", …) so the operator knows
+ *  which fix-path to pursue without having to read certbot prose
+ *  every time. `other` is the catch-all when the detail doesn't
+ *  match any known pattern — the row still shows the raw text. */
+export type FailureCategory =
+  | 'rate-limit'
+  | 'port-80'
+  | 'dns'
+  | 'caa'
+  | 'dnssec'
+  | 'tls-sni'
+  | 'other';
+
 export interface ParsedFailure {
   domain: string;
   type: string;
   detail: string;
+  category: FailureCategory;
 }
 
 export interface ParsedFailureBlock {
@@ -24,6 +40,35 @@ export interface ParsedFailureBlock {
   rateLimited: boolean;
   /** Newest timestamp anywhere in the tail (epoch ms, UTC-interpreted). */
   ts?: number;
+}
+
+/** Map certbot's free-form `detail` to a coarse failure category.
+ *  Patterns lifted from the ACME error taxonomy + observed messages.
+ *  Order matters: more specific patterns first, generic last.
+ *  Internal — tested indirectly via `parseLetsencryptTail`. */
+function classifyFailure(detail: string): FailureCategory {
+  const d = detail.toLowerCase();
+  if (/ratelimited|too many (failed authorizations|certificates)/.test(d)) return 'rate-limit';
+  if (/caa record|caa for/.test(d)) return 'caa';
+  if (/dnssec|dnskey|rrsig/.test(d)) return 'dnssec';
+  if (/timeout during connect|connection refused|no route to host|connection reset|fetching .+?:80/.test(d)) return 'port-80';
+  if (/dns problem|nxdomain|no a record|no aaaa record|servfail/.test(d)) return 'dns';
+  if (/tls-sni|tls-alpn/.test(d)) return 'tls-sni';
+  return 'other';
+}
+
+/** Human label for the category, shown as a prefix on the per-row
+ *  detail. Keeps the surface a single phrase so the row stays scannable. */
+export function categoryLabel(c: FailureCategory): string {
+  switch (c) {
+    case 'rate-limit': return 'LE rate-limited';
+    case 'port-80':    return 'Port 80 unreachable';
+    case 'dns':        return 'DNS problem';
+    case 'caa':        return 'CAA record blocks issuance';
+    case 'dnssec':     return 'DNSSEC misconfiguration';
+    case 'tls-sni':    return 'Legacy TLS-SNI challenge';
+    case 'other':      return 'ACME error';
+  }
 }
 
 const STRUCTURED_FAILURE_RE = /Domain:\s*(\S+)\s*\n\s*Type:\s*(\S+)\s*\n\s*Detail:\s*([^\n]+)/g;
@@ -49,12 +94,14 @@ export function parseLetsencryptTail(tail: string): ParsedFailureBlock {
   STRUCTURED_FAILURE_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = STRUCTURED_FAILURE_RE.exec(slice)) !== null) {
-    failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
+    const detail = m[3].trim();
+    failures.push({ domain: m[1].trim(), type: m[2].trim(), detail, category: classifyFailure(detail) });
   }
   if (failures.length === 0) {
     INLINE_FAILURE_RE.lastIndex = 0;
     while ((m = INLINE_FAILURE_RE.exec(slice)) !== null) {
-      failures.push({ domain: m[1].trim(), type: m[2].trim(), detail: m[3].trim() });
+      const detail = m[3].trim();
+      failures.push({ domain: m[1].trim(), type: m[2].trim(), detail, category: classifyFailure(detail) });
     }
   }
 

--- a/src/lib/health/runner.ts
+++ b/src/lib/health/runner.ts
@@ -10,7 +10,7 @@ import { ContainerId, ServiceName, HostString } from '../api/schemas';
 import { runLetsdebugForDomain } from '../letsdebug/client';
 import { detectLanIp, recentChanges } from '../lanIp';
 import { findNpmAdminUrl, getNpmToken } from './probes/npmAdmin';
-import { parseLetsencryptTail } from './probes/letsencryptLogParser';
+import { parseLetsencryptTail, categoryLabel, type FailureCategory } from './probes/letsencryptLogParser';
 import { logger } from '../logger';
 
 /**
@@ -735,32 +735,68 @@ export class CheckRunner {
         }
       }
 
-      const byDomain = new Map<string, { domain: string; type: string; detail: string }>();
+      const byDomain = new Map<string, typeof parsed.failures[number]>();
       for (const f of parsed.failures) byDomain.set(f.domain, f);
       const items: CrfItem[] = [];
+      const categories = new Set<FailureCategory>();
       for (const [domain, f] of byDomain) {
         const detail = f.detail.length > 140 ? `${f.detail.slice(0, 140)}…` : f.detail;
+        categories.add(f.category);
         items.push({
           id: domain,
           label: domain,
-          detail: `ACME ${f.type} challenge failed: ${detail}`,
+          // Prefix the row with a category label so the operator
+          // immediately knows which fix-path to pursue (port-80 firewall,
+          // CAA record at registrar, DNS A-record fix, rate-limit wait)
+          // without re-reading certbot's prose every time.
+          detail: `${categoryLabel(f.category)} — ${f.type} challenge: ${detail}`,
           status: 'fail',
           actionIds: ['show_log_tail', 'retry_request'],
         });
       }
       if (parsed.rateLimited && items.length === 0) {
+        categories.add('rate-limit');
         items.push({
           id: 'rate-limited',
           label: 'Let\'s Encrypt rate limit',
-          detail: 'Hit the ACME rate limit (5 failed validations / host / hour). Wait ~1h and fix the root cause before retrying.',
+          detail: `${categoryLabel('rate-limit')} — 5 failed validations / host / hour. Wait ~1h and fix the root cause before retrying.`,
           status: 'fail',
           actionIds: ['show_log_tail'],
         });
       }
+
+      // Pattern-aware hint: surface a different next-step depending
+      // on the failure pattern(s) we just classified. When everything
+      // is one category, point straight at that fix; mixed batches
+      // get the generic ladder. Keeps the operator from chasing
+      // "port 80 unreachable" when their actual problem is CAA.
+      const hint = ((): string => {
+        if (categories.size === 1) {
+          const [only] = Array.from(categories);
+          switch (only) {
+            case 'rate-limit':
+              return 'Let\'s Encrypt blocks repeated identical requests. Wait the window out (1h for failed-auth, 168h for duplicate-certs) before retrying — and fix the underlying cause first.';
+            case 'port-80':
+              return 'ACME HTTP-01 needs port 80 reachable from the public internet. Check router port-forwarding to this LAN IP and any upstream ISP block.';
+            case 'dns':
+              return 'The domain must resolve from public DNS to your gateway IP. Check the A record at your registrar — `domain_external_reachability` shows what public resolvers see today.';
+            case 'caa':
+              return 'A CAA record at your domain forbids Let\'s Encrypt from issuing. Add `0 issue "letsencrypt.org"` at your registrar (or remove the restrictive CAA record entirely).';
+            case 'dnssec':
+              return 'DNSSEC chain is broken — the validator can\'t verify your A record. Fix DS / DNSKEY at your registrar, or disable DNSSEC for this zone until you can.';
+            case 'tls-sni':
+              return 'Legacy TLS-SNI challenge type — NPM should be using HTTP-01 by default. Re-create the certificate entry in NPM to force HTTP-01.';
+            case 'other':
+              return 'Read the detail line — certbot\'s wording usually names the exact cause. Run letsdebug.net for an external view of what the ACME server sees.';
+          }
+        }
+        return 'Multiple failure types in the log — see each row for its category. Run letsdebug.net for an external view of what the ACME server sees, then click Retry once the underlying cause is fixed.';
+      })();
+
       return encode({
         status: 'fail',
-        detail: `${items.length} domain${items.length === 1 ? '' : 's'} with recent ACME failure${items.length === 1 ? '' : 's'} in NPM\'s letsencrypt.log.`,
-        hint: 'Most common cause is public port 80 not reachable from the internet. Run letsdebug.net for an external view of what the ACME server sees, then click Retry once the underlying cause is fixed.',
+        detail: `${items.length} domain${items.length === 1 ? '' : 's'} with recent ACME failure${items.length === 1 ? '' : 's'} (${Array.from(categories).map(categoryLabel).join(', ')}).`,
+        hint,
         items,
       });
     } catch (e) {


### PR DESCRIPTION
## Summary

Two medium-priority audits from #547's inventory + the UX_PHILOSOPHY.md doc paragraph the issue called for as success condition. Builds on #546 / #551 / #552 / #553.

### `cert_request_failure` — categorise the failure type

Operators saw `"ACME http-01 challenge failed: …"` rows and had to re-read certbot's prose every time to figure out whether to open port 80, fix CAA at their registrar, or wait the rate limit out.

`classifyFailure` now maps the detail into a coarse category — `port-80 | dns | caa | dnssec | rate-limit | tls-sni | other`. The diagnose runner prefixes each row with the category label and shifts the probe-level hint to a category-specific next-step when all rows fall into one category. `other` is the catch-all so unknown patterns still surface, just without the prefix.

Per-row before: *"ACME http-01 challenge failed: CAA record for dopp.cloud prevents issuance"*  
Per-row after: *"CAA record blocks issuance — http-01 challenge: CAA record for dopp.cloud prevents issuance"*

Hint before: *"Most common cause is public port 80 not reachable…"* (regardless of actual cause)  
Hint after (single-category): *"A CAA record at your domain forbids Let's Encrypt from issuing. Add `0 issue \"letsencrypt.org\"` at your registrar…"*

### `domain_external_reachability` — name the broken layer

When DNS resolved correctly but letsdebug reported problems, the row showed both but the operator was running `dig` on a row that already had working DNS. Explicit layer label closes the gap:

Before: *"Public DNS → 1.2.3.4 (matches your gateway) · Last checked 5 min ago  
Letsdebug (5 min ago): IssuerVerificationConflict — …"*

After: *"Public DNS → 1.2.3.4 (matches your gateway) · Last checked 5 min ago  
**DNS layer OK — issue is in the cert / ACME / port-80 layer.** Letsdebug (5 min ago): IssuerVerificationConflict — …"*

### `UX_PHILOSOPHY.md` § 2a — pattern-aware probes as house style

Documents the pattern as a checklist + 3 worked examples (router_dns_not_pointing, cert_request_failure, domain_external_reachability). Future PRs that add probes have a template, not just an instinct.

### Out of scope (drive-by polish)

#547 lists 9 "Low" rows ("Audit, expect no change"). Those stay as drive-by polish in whichever PR touches the file — not worth dedicated revs. High-priority rows (#551 domain_unreachable, #552 lan_ip_changed, #553 adguard polish) are already shipped.

## Test plan

- [x] `npm test` — 815 passed, 2 skipped, 0 failed (+4 new classification tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke: trigger a cert request with no port-80 forwarding → row reads "Port 80 unreachable — …" + hint points at port-forward fix
- [ ] Smoke: trigger with a restrictive CAA record → row reads "CAA record blocks issuance — …" + hint points at registrar CAA fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)