### PR TITLE
feat(diagnose): low-priority polish on remaining 4 probes — closes #547

### DIFF
--- a/src/lib/diagnose/probes/certExpiry.ts
+++ b/src/lib/diagnose/probes/certExpiry.ts
@@ -151,13 +151,18 @@ async function renewCert({
       logger.warn('diagnose:cert_expiry', `Renew id=${itemId} returned HTTP ${res.status}: ${body.slice(0, 200)}`);
       return {
         ok: false,
-        message: `NPM returned HTTP ${res.status}. Check NPM admin → SSL Certificates for the underlying error (most common: DNS challenge regression or port-80 unreachable).`,
+        message: `NPM returned HTTP ${res.status}. The cert_request_failure probe shows the certbot log tail with the categorised cause (port-80 / DNS / CAA / rate-limit).`,
         refresh: false,
       };
     }
+    // Concrete next-step + visible timestamp: the operator should know
+    // exactly when the renewal was kicked off and where to look for
+    // the result. cert_expiry sweeps hourly; the Refresh-now action
+    // short-circuits the wait when needed.
+    const triggeredAt = new Date().toISOString().replace('T', ' ').replace(/\..+/, ' UTC');
     return {
       ok: true,
-      message: `Renewal triggered for cert ${itemId}. NPM may take 30-60 s to complete the ACME challenge.`,
+      message: `Renewal triggered for cert ${itemId} at ${triggeredAt}. ACME usually completes in 30-60 s — click "Refresh now" or wait for the next hourly cert_expiry sweep to see the new expiry date.`,
       refresh: true,
     };
   } catch (e) {

--- a/src/lib/diagnose/probes/failedUnits.ts
+++ b/src/lib/diagnose/probes/failedUnits.ts
@@ -65,17 +65,39 @@ async function restartUnit({ node, itemId }: { node: string; itemId?: string }):
   const res = await agent.sendCommand('exec', {
     command: `systemctl --user reset-failed ${itemId} 2>/dev/null; systemctl --user restart ${itemId} 2>&1`,
   }, { timeoutMs: 30_000 }) as { code?: number; stdout?: string; stderr?: string };
-  if (res.code === 0) {
+  if (res.code !== 0) {
+    return {
+      ok: false,
+      message: `Restart failed: ${(res.stderr ?? res.stdout ?? '').trim().slice(0, 200) || 'unknown error'}.`,
+      refresh: false,
+    };
+  }
+  // Ground-truth check: `systemctl restart` returning 0 means "the
+  // start command was accepted", not "the unit is now running". For
+  // Type=service units that crash immediately after start the
+  // operator would see a false-positive "Restarted" without this
+  // follow-up. Give the live status so they don't have to navigate
+  // to the Services page to check.
+  const probe = await agent.sendCommand('exec', {
+    command: `systemctl --user is-active ${itemId} 2>&1 || true`,
+  }, { timeoutMs: 5_000 }) as { stdout?: string };
+  const liveState = (probe.stdout || '').trim();
+  const serviceName = itemId?.replace(/\.service$/, '') ?? itemId;
+  if (liveState === 'active') {
     return {
       ok: true,
-      message: `Restarted ${itemId}. Re-check in ~10 s; if it fails again the underlying cause is still present.`,
+      message: `Restarted ${itemId} — unit is now active. See Services → ${serviceName} for live logs and status.`,
       refresh: true,
     };
   }
   return {
-    ok: false,
-    message: `Restart failed: ${(res.stderr ?? res.stdout ?? '').trim().slice(0, 200) || 'unknown error'}.`,
-    refresh: false,
+    ok: liveState === 'activating',
+    message: `Restart command accepted but unit reports state: ${liveState || 'unknown'}. ${
+      liveState === 'activating'
+        ? 'Re-check in ~10 s — it may still be coming up.'
+        : 'The underlying cause is still present; check Services → ' + serviceName + ' for the crash log.'
+    }`,
+    refresh: true,
   };
 }
 

--- a/src/lib/diagnose/probes/postDeployFailed.ts
+++ b/src/lib/diagnose/probes/postDeployFailed.ts
@@ -48,13 +48,24 @@ export async function checkPostDeployFailed(): Promise<PostDeployFailedResult> {
       detail: `${Object.keys(records).length} post-deploy run(s) recorded, all exited 0.`,
     };
   }
-  const items: ProbeItem[] = failed.map(([name, r]) => ({
-    id: name,
-    label: name,
-    detail: `exit ${r.exitCode} at ${new Date(r.lastRunAt).toLocaleString()}`,
-    status: 'warn',
-    actionIds: ['rerun_post_deploy', 'dismiss_post_deploy'],
-  }));
+  const items: ProbeItem[] = failed.map(([name, r]) => {
+    // Surface the last few lines of stdout when persisted (recorded
+    // by ServiceManager.runPostDeployScript). Without this the row
+    // says "exit 1" and the operator has to open the service detail
+    // to find the actual error — usually 2-3 lines that name the
+    // missing env var / failed API call / etc. directly.
+    const tail = (r.stdoutTail ?? '').trim();
+    const tailExcerpt = tail
+      ? '\n' + tail.split('\n').slice(-3).join('\n').slice(-240)
+      : '';
+    return {
+      id: name,
+      label: name,
+      detail: `exit ${r.exitCode} at ${new Date(r.lastRunAt).toLocaleString()}${tailExcerpt}`,
+      status: 'warn',
+      actionIds: ['rerun_post_deploy', 'dismiss_post_deploy'],
+    };
+  });
   return {
     status: 'warn',
     detail: `${failed.length} service${failed.length === 1 ? '' : 's'} ended its last post-deploy with a non-zero exit. Seeds (admin users, default proxy hosts, etc.) likely didn\'t complete.`,

--- a/src/lib/diagnose/probes/proxyRouteMissing.ts
+++ b/src/lib/diagnose/probes/proxyRouteMissing.ts
@@ -138,9 +138,10 @@ export async function retryCreate({
       signal: AbortSignal.timeout(15_000),
     });
   } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
     return {
       ok: false,
-      message: `Could not reach the proxy-hosts API: ${e instanceof Error ? e.message : String(e)}.`,
+      message: `Could not reach the proxy-hosts API: ${msg}. ${pointerForFetchError(msg)}`,
       refresh: false,
     };
   }
@@ -172,10 +173,44 @@ export async function retryCreate({
   return {
     ok: false,
     message: failure?.error
-      ? `NPM rejected the route: ${failure.error.slice(0, 200)}`
-      : `Retry returned HTTP ${res.status} without a domain-specific error.`,
+      ? `NPM rejected the route: ${failure.error.slice(0, 200)} ${pointerForNpmError(failure.error)}`.trimEnd()
+      : `Retry returned HTTP ${res.status} without a domain-specific error. See failed_units / pods_and_engine for NPM container health.`,
     refresh: false,
   };
+}
+
+/** Sibling-probe pointer based on the fetch-level error text. Lets
+ *  the operator skip a hop instead of guessing which probe to open
+ *  when retry fails — connection-refused points at the engine, DNS
+ *  errors at network. */
+function pointerForFetchError(msg: string): string {
+  const m = msg.toLowerCase();
+  if (m.includes('econnrefused') || m.includes('connection refused')) {
+    return 'NPM container is likely not running — check pods_and_engine + failed_units.';
+  }
+  if (m.includes('etimedout') || m.includes('timeout')) {
+    return 'NPM is unreachable in time — likely a heavy container restart or a sibling pod blocking the port. Check pods_and_engine.';
+  }
+  if (m.includes('enotfound') || m.includes('getaddrinfo')) {
+    return 'localhost name lookup failed — the install host is in an unusual DNS state.';
+  }
+  return '';
+}
+
+/** Sibling-probe pointer based on NPM's domain-level error text. Same
+ *  intent — short-cut the diagnosis tree by naming the right probe. */
+function pointerForNpmError(err: string): string {
+  const m = err.toLowerCase();
+  if (m.includes('401') || m.includes('unauthor') || m.includes('forbidden')) {
+    return '→ npm_data_stale: NPM credentials likely rejected.';
+  }
+  if (m.includes('certificate') || m.includes('cert')) {
+    return '→ cert_request_failure: the ACME side likely failed; see the categorised log tail.';
+  }
+  if (m.includes('forward_host') || m.includes('forward_port') || m.includes('upstream')) {
+    return '→ check that the target service is actually running (Services list).';
+  }
+  return '';
 }
 
 registerProbeAction(


### PR DESCRIPTION
## Summary

Sweeps the "Audit, expect no change" rows from #547's inventory and applies the one-line improvements that surfaced. Closes the issue completely (medium + success-condition done in #573; this is the long-tail polish).

### What changed

| Probe | Change |
|---|---|
| `cert_expiry` | Renew-now success message names the trigger time + next refresh window; failure points at `cert_request_failure` by name |
| `failed_units` | Post-restart `is-active` check distinguishes active / activating / failed and links to Services → X |
| `post_deploy_failed` | Per-row detail now includes the last 3 lines of persisted `stdoutTail` (≤240 chars) so the operator sees the cause without opening Service detail |
| `proxy_route_missing` | Retry-create failure messages append a sibling-probe pointer based on the error class (401 → npm_data_stale, ECONNREFUSED → pods_and_engine, etc.) |

### Probes audited and left alone

- `crash_loop` — restart_pod + show_recent_logs both already handle fallbacks + empty states. No silence action (never implemented; not adding without a real use-case).
- `pods_and_engine` — both `start_pod` and `enable_socket` are clean.
- `dangling_proxy` — destructive: true marked, edge cases covered.
- `health_checks` — stale-filter + parallel run + correct pass/fail counting.
- `npm_data_stale` — canonical example per the inventory; untouched.

### Test plan

- [x] `npm test` — 815 passed, 2 skipped, 0 failed
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke: trigger renewal on an expiring cert → toast shows time + "Refresh now or wait for hourly sweep"
- [ ] Smoke: restart a unit that crashes immediately → message says "unit reports state: failed"
- [ ] Smoke: post-deploy fails with traceback → row detail shows last 3 lines of the trace

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)