### PR TITLE
fix(install): reuse saved secrets across clean installs that preserve identity

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -32,20 +32,18 @@ export async function syncAllRegistries() {
 }
 
 /**
- * Return stored secret values that the wizard should re-use on a
- * non-clean reinstall instead of generating new random values.
+ * Return stored secret values the wizard should re-use instead of
+ * generating fresh random ones. Wizard pre-fills with these so an
+ * operator who walks through `Configure` sees the actual passwords
+ * their services already have; the server-side install runner then
+ * applies the same override defensively (#615).
  *
- * Called by startConfigure when cleanInstall is false so that services
- * like LLDAP (which only reads its admin password from env on first DB
- * init) continue to work with the password already baked into their
- * data volume.
+ * Sourced from `loadSavedSecrets` so this surface stays in sync with
+ * the install runner's reuse logic — both walk `config.installedSecrets`
+ * plus the legacy `config.lldap` / `config.reverseProxy.npm` /
+ * `config.adguard` fields.
  */
 export async function fetchStoredVariableValues(): Promise<Record<string, string>> {
-  const config = await getConfig();
-  const values: Record<string, string> = {};
-  if (config.lldap?.password)           values['LLDAP_ADMIN_PASSWORD']   = config.lldap.password;
-  if (config.reverseProxy?.npm?.password) values['NGINX_ADMIN_PASSWORD'] = config.reverseProxy.npm.password;
-  if (config.reverseProxy?.npm?.email)    values['NGINX_ADMIN_EMAIL']    = config.reverseProxy.npm.email;
-  if (config.adguard?.password)          values['ADGUARD_ADMIN_PASSWORD'] = config.adguard.password;
-  return values;
+  const { loadSavedSecrets } = await import('@/lib/install/savedSecrets');
+  return loadSavedSecrets(await getConfig());
 }

--- a/src/hooks/useStackInstall.ts
+++ b/src/hooks/useStackInstall.ts
@@ -489,13 +489,16 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       }
     } catch { /* empty defaults are fine */ }
 
-    // On a non-clean reinstall, prefer stored passwords over freshly
-    // generated ones. Services like LLDAP only read their admin password
-    // on first DB init — a new random value would mismatch the data volume.
+    // Pre-fill the wizard with the operator's existing passwords so they
+    // see the actual values their services have on disk rather than
+    // freshly-regenerated ones (#615). The server-side install runner
+    // applies the same reuse logic defensively based on the operator's
+    // `preserve` flags at the Reset step — by then we know which groups
+    // they chose to keep. Loading here unconditionally is safe: clean-
+    // install + secrets-wiped will write fresh values back at install
+    // end, so the next install sees the post-wipe state.
     let storedValues: Record<string, string> = {};
-    if (!opts?.cleanInstall) {
-      try { storedValues = await fetchStoredVariableValues(); } catch { /* best-effort */ }
-    }
+    try { storedValues = await fetchStoredVariableValues(); } catch { /* best-effort */ }
 
     for (const item of selected) {
       try {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -363,6 +363,19 @@ export interface AppConfig {
    */
   installManifest?: InstallManifest;
   /**
+   * Internal: every `type: secret | bcrypt | rsa-private` variable value
+   * from the most recent install, keyed by template-variable name. Used
+   * by the install runner to reuse passwords across clean-installs that
+   * preserve secrets/identity — without this, the wizard regenerates
+   * `LLDAP_ADMIN_PASSWORD` etc. on every run and the new value mismatches
+   * the still-on-disk LDAP DB hash. Per-entry `password` field auto-
+   * encrypts via the SENSITIVE_KEYS regex; the `varName` is plaintext.
+   * Distinct from `installManifest.credentials` (user-facing) — that
+   * indexes by display name and skips internal-only secrets like
+   * `LLDAP_JWT_SECRET`.
+   */
+  installedSecrets?: Array<{ varName: string; password: string }>;
+  /**
    * Anonymous "request access" submissions from the family portal
    * (#242). Public POST endpoint appends here; admin Settings page
    * reads + resolves. Capped at 50 pending so spam can't fill the

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -570,6 +570,55 @@ async function runJob(jobId: string): Promise<void> {
 
   const ctx: DeployContext = { jobId, input, scriptCredentials, deployed: [] };
 
+  // Secret reuse (#615) — before any deploy fires, override the wizard's
+  // freshly-generated `type: secret | bcrypt | rsa-private` values with
+  // whatever the saved state has for the same `varName`. Without this,
+  // a clean install that preserves `secrets`/`identity` regenerates
+  // LLDAP_ADMIN_PASSWORD (and friends), the new value mismatches the
+  // still-on-disk LDAP DB hash, and post-deploy.py's seed call gets a
+  // 401 from LLDAP. The operator's recovery path was "wipe the data dir
+  // and reinstall", which silently destroys identity state — the
+  // opposite of what they ticked.
+  //
+  // Conditions for the override:
+  //   - Not a clean install (always reuse saved state on plain re-install), OR
+  //   - Clean install AND `secrets` is in the preserve list (operator
+  //     explicitly chose to keep prior identity).
+  //
+  // The legacy NPM-specific block below is now subsumed by this general
+  // path; kept anyway because it has a specific cert-archive-was-just-
+  // restored log line that helps operators reason about what happened.
+  const shouldReuseSecrets = !input.cleanInstall || (input.preserve?.includes('secrets') ?? true);
+  if (shouldReuseSecrets) {
+    try {
+      const { getConfig } = await import('@/lib/config');
+      const { loadSavedSecrets } = await import('./savedSecrets');
+      const saved = loadSavedSecrets(await getConfig());
+      let overrides = 0;
+      const overrideNames: string[] = [];
+      for (const v of input.variables) {
+        // `meta` is `unknown` on the persisted JobInputVariable shape —
+        // narrow to the {type} subset we need without reaching for
+        // VariableMeta (a UI-side type).
+        const type = (v.meta as { type?: string } | undefined)?.type;
+        if (type !== 'secret' && type !== 'bcrypt' && type !== 'rsa-private') continue;
+        const stored = saved[v.name];
+        if (!stored || stored === v.value) continue;
+        v.value = stored;
+        overrides++;
+        overrideNames.push(v.name);
+      }
+      if (overrides > 0) {
+        await log(jobId, `🔑 Reusing ${overrides} saved secret${overrides === 1 ? '' : 's'} from before the reset (${overrideNames.slice(0, 4).join(', ')}${overrideNames.length > 4 ? `, +${overrideNames.length - 4} more` : ''}) so services with preserved data volumes can still authenticate.`);
+      }
+    } catch (e) {
+      // Best-effort — a missing config or decryption failure shouldn't
+      // block the install. The wizard's regenerated values still flow
+      // through; we just lose the reuse benefit for this run.
+      await log(jobId, `(note) could not load saved secrets: ${e instanceof Error ? e.message : String(e)}. Continuing with wizard-generated values.`);
+    }
+  }
+
   // Cert archive restore — runs once before the deploy loop when nginx
   // is in the install set AND the volume on disk is empty (fresh
   // install). The reset endpoint snapshots NPM's data dir to
@@ -783,6 +832,21 @@ async function runJob(jobId: string): Promise<void> {
       totalCount: input.items.filter(i => i.checked).length,
     },
   });
+
+  // Persist every secret-typed variable so the next install can reuse
+  // them (#615). Has to happen after `phase: 'done'` because we only
+  // want to record values from a successful run — a half-failed install
+  // might have rewritten LLDAP's DB with a new password mid-flight, and
+  // the operator's recovery action could be to retry with the previous
+  // value. Best-effort: a write failure here doesn't fail the install
+  // (config might be temporarily locked); the next successful install
+  // gets another chance.
+  try {
+    const { persistInstalledSecrets } = await import('./savedSecrets');
+    await persistInstalledSecrets(input.variables, await getConfig());
+  } catch (e) {
+    await log(jobId, `(note) couldn't persist installed secrets: ${e instanceof Error ? e.message : String(e)}`);
+  }
 
   // The CoreOS first-boot installer writes `stackSetupPending: true`
   // to flag "we set the box up, but no stack services are deployed

--- a/src/lib/install/savedSecrets.test.ts
+++ b/src/lib/install/savedSecrets.test.ts
@@ -1,0 +1,122 @@
+/**
+ * loadSavedSecrets + persistInstalledSecrets — #615.
+ *
+ * Validates the two contracts the install runner depends on:
+ *   1. `loadSavedSecrets` returns a flat varName→value map drawn from
+ *      `installedSecrets` (canonical) AND the legacy `config.lldap` /
+ *      `config.reverseProxy.npm` / `config.adguard` fields (back-compat).
+ *      Canonical wins on collision.
+ *   2. `persistInstalledSecrets` merges with whatever's already saved
+ *      so partial re-installs don't blow away secrets for templates
+ *      that weren't touched this run.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/config', () => ({
+  updateConfig: vi.fn(async (_: unknown) => undefined),
+}));
+
+import { loadSavedSecrets, persistInstalledSecrets } from './savedSecrets';
+import type { AppConfig } from '@/lib/config';
+import { updateConfig } from '@/lib/config';
+import type { StackVariable } from '@/lib/stackInstall/types';
+
+const updateConfigMock = vi.mocked(updateConfig);
+
+beforeEach(() => {
+  updateConfigMock.mockClear();
+});
+
+function mkConfig(partial: Partial<AppConfig>): AppConfig {
+  return partial as AppConfig;
+}
+
+describe('loadSavedSecrets', () => {
+  it('returns the legacy fields when installedSecrets is absent', () => {
+    const out = loadSavedSecrets(mkConfig({
+      lldap: { url: 'http://x', username: 'admin', password: 'lldap-pw' },
+      adguard: { adminUrl: 'http://x', username: 'admin', password: 'adg-pw' },
+      reverseProxy: { npm: { email: 'op@x', password: 'npm-pw' } },
+    }));
+    expect(out).toEqual({
+      LLDAP_ADMIN_PASSWORD: 'lldap-pw',
+      ADGUARD_ADMIN_PASSWORD: 'adg-pw',
+      NGINX_ADMIN_PASSWORD: 'npm-pw',
+      NGINX_ADMIN_EMAIL: 'op@x',
+    });
+  });
+
+  it('layers installedSecrets over legacy fields (canonical wins)', () => {
+    const out = loadSavedSecrets(mkConfig({
+      lldap: { url: 'http://x', username: 'admin', password: 'old-legacy' },
+      installedSecrets: [
+        { varName: 'LLDAP_ADMIN_PASSWORD', password: 'new-canonical' },
+        { varName: 'IMMICH_ADMIN_PASSWORD', password: 'immich-pw' },
+      ],
+    }));
+    expect(out.LLDAP_ADMIN_PASSWORD).toBe('new-canonical');
+    expect(out.IMMICH_ADMIN_PASSWORD).toBe('immich-pw');
+  });
+
+  it('skips entries with empty varName or password', () => {
+    const out = loadSavedSecrets(mkConfig({
+      installedSecrets: [
+        { varName: '', password: 'x' },
+        { varName: 'GOOD', password: '' },
+        { varName: 'KEEP', password: 'pw' },
+      ],
+    }));
+    expect(out).toEqual({ KEEP: 'pw' });
+  });
+
+  it('returns an empty map when config has neither layer', () => {
+    expect(loadSavedSecrets(mkConfig({}))).toEqual({});
+  });
+});
+
+describe('persistInstalledSecrets', () => {
+  const vars = (entries: Array<{ name: string; value: string; type: string }>): StackVariable[] =>
+    entries.map(e => ({ name: e.name, value: e.value, meta: { type: e.type } as StackVariable['meta'] }));
+
+  it('saves every secret/bcrypt/rsa-private value to installedSecrets', async () => {
+    await persistInstalledSecrets(vars([
+      { name: 'LLDAP_ADMIN_PASSWORD', value: 'lldap-pw', type: 'secret' },
+      { name: 'ADGUARD_ADMIN_PASSWORD_HASH', value: 'bcrypt-hash', type: 'bcrypt' },
+      { name: 'AUTHELIA_OIDC_RSA_PRIVATE_KEY', value: '-----BEGIN-----', type: 'rsa-private' },
+      { name: 'LLDAP_PORT', value: '17170', type: 'text' }, // non-secret — skipped
+    ]), mkConfig({}));
+    expect(updateConfigMock).toHaveBeenCalledOnce();
+    const arg = updateConfigMock.mock.calls[0][0] as { installedSecrets: Array<{ varName: string; password: string }> };
+    const names = arg.installedSecrets.map(e => e.varName).sort();
+    expect(names).toEqual(['ADGUARD_ADMIN_PASSWORD_HASH', 'AUTHELIA_OIDC_RSA_PRIVATE_KEY', 'LLDAP_ADMIN_PASSWORD']);
+  });
+
+  it('merges with existing entries — partial re-installs preserve untouched secrets', async () => {
+    await persistInstalledSecrets(vars([
+      { name: 'IMMICH_ADMIN_PASSWORD', value: 'fresh', type: 'secret' },
+    ]), mkConfig({
+      installedSecrets: [
+        { varName: 'LLDAP_ADMIN_PASSWORD', value: 'from-prior-install' } as never,
+        { varName: 'IMMICH_ADMIN_PASSWORD', password: 'stale' },
+      ],
+    }));
+    const arg = updateConfigMock.mock.calls[0][0] as { installedSecrets: Array<{ varName: string; password: string }> };
+    const map = new Map(arg.installedSecrets.map(e => [e.varName, e.password]));
+    // LLDAP entry came from prior config and was carried forward.
+    expect(map.has('LLDAP_ADMIN_PASSWORD')).toBe(true);
+    // IMMICH entry was rewritten with the fresh value.
+    expect(map.get('IMMICH_ADMIN_PASSWORD')).toBe('fresh');
+  });
+
+  it('skips empty-value vars rather than clobbering a saved value', async () => {
+    await persistInstalledSecrets(vars([
+      { name: 'LLDAP_ADMIN_PASSWORD', value: '', type: 'secret' }, // empty
+    ]), mkConfig({
+      installedSecrets: [
+        { varName: 'LLDAP_ADMIN_PASSWORD', password: 'keep-me' },
+      ],
+    }));
+    const arg = updateConfigMock.mock.calls[0][0] as { installedSecrets: Array<{ varName: string; password: string }> };
+    expect(arg.installedSecrets).toEqual([{ varName: 'LLDAP_ADMIN_PASSWORD', password: 'keep-me' }]);
+  });
+});

--- a/src/lib/install/savedSecrets.ts
+++ b/src/lib/install/savedSecrets.ts
@@ -1,0 +1,98 @@
+/**
+ * Secret reuse across installs (#615).
+ *
+ * The wizard's "secret" / "bcrypt" / "rsa-private" type variables get
+ * fresh random values on every install — fine on a brand-new node,
+ * catastrophic on a clean-install-with-preserved-data because services
+ * like LLDAP only honour `LLDAP_LDAP_USER_PASS` on first DB init.
+ *
+ * This module:
+ *   1. Persists every `type: secret | bcrypt | rsa-private` variable
+ *      value at the end of every successful install (`persistInstalledSecrets`).
+ *   2. Loads them back on the next install (`loadSavedSecrets`).
+ *   3. Falls back to the legacy `config.lldap` / `config.adguard` /
+ *      `config.reverseProxy.npm` shapes for installs that predate the
+ *      `installedSecrets` field.
+ *
+ * The override decision (apply or skip) lives in `install/runner.ts` —
+ * this module only handles read + write.
+ *
+ * SECURITY NOTE: each entry's `password` field auto-encrypts at rest
+ * via the existing `SENSITIVE_KEYS` regex in config.ts. `varName` is
+ * plaintext.
+ */
+import type { AppConfig } from '@/lib/config';
+import { updateConfig } from '@/lib/config';
+
+/** Variable types that hold sensitive material the wizard regenerates. */
+const SECRET_TYPES = new Set(['secret', 'bcrypt', 'rsa-private']);
+
+/** Minimal shape this module needs from a variable entry. Deliberately
+ *  loose — accepts both the runtime `StackVariable` and the persisted
+ *  `JobInputVariable` (whose `meta` is typed `unknown` by design). */
+interface VariableLike {
+  name: string;
+  value: string;
+  meta?: unknown;
+}
+
+/**
+ * Flat lookup `varName → value` of every saved secret. Sources:
+ *
+ *   1. `config.installedSecrets` — the canonical record, populated by
+ *      `persistInstalledSecrets` after every install.
+ *   2. Legacy back-compat: the three dedicated fields that pre-date
+ *      `installedSecrets` (LLDAP, NPM, AdGuard). Read so the first
+ *      install after upgrading still reuses the operator's known
+ *      passwords instead of silently regenerating.
+ *
+ * Layer (1) wins when both are present.
+ */
+export function loadSavedSecrets(config: AppConfig): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  // Legacy back-compat — read first so the canonical map can override.
+  if (config.lldap?.password)             out.LLDAP_ADMIN_PASSWORD  = config.lldap.password;
+  if (config.reverseProxy?.npm?.password) out.NGINX_ADMIN_PASSWORD  = config.reverseProxy.npm.password;
+  if (config.reverseProxy?.npm?.email)    out.NGINX_ADMIN_EMAIL     = config.reverseProxy.npm.email;
+  if (config.adguard?.password)           out.ADGUARD_ADMIN_PASSWORD = config.adguard.password;
+
+  // Canonical record (post-#615).
+  for (const entry of config.installedSecrets ?? []) {
+    if (entry.varName && entry.password) out[entry.varName] = entry.password;
+  }
+  return out;
+}
+
+/**
+ * Save every secret-typed variable from a just-completed install. Called
+ * at the end of `runJob` after `phase: 'done'` is set. Idempotent in the
+ * sense that re-running the same install overwrites with the same values.
+ *
+ * Merges with whatever is already in `config.installedSecrets` — variables
+ * from a previous install for a template that *wasn't* re-deployed this
+ * run are preserved. Without that merge, an operator who installs auth
+ * first and then later runs an "add Immich" install would lose the LLDAP
+ * secret entries from the prior run.
+ */
+export async function persistInstalledSecrets(
+  variables: readonly VariableLike[],
+  existing: AppConfig,
+): Promise<void> {
+  const map = new Map<string, string>();
+  for (const entry of existing.installedSecrets ?? []) {
+    map.set(entry.varName, entry.password);
+  }
+  for (const v of variables) {
+    const meta = v.meta as { type?: string } | undefined;
+    if (!meta?.type || !SECRET_TYPES.has(meta.type)) continue;
+    // An empty value would erase a previously-saved secret on re-install
+    // — skip rather than clobber. Empty here means the wizard couldn't
+    // resolve a value (e.g. RSA endpoint unreachable), not "operator
+    // cleared it" — the input shape doesn't carry that distinction.
+    if (!v.value) continue;
+    map.set(v.name, v.value);
+  }
+  const list = Array.from(map, ([varName, password]) => ({ varName, password }));
+  await updateConfig({ installedSecrets: list });
+}


### PR DESCRIPTION
## Summary

Stop the wizard from regenerating `LLDAP_ADMIN_PASSWORD`, `IMMICH_ADMIN_PASSWORD`, `ADGUARD_ADMIN_PASSWORD`, etc. on every install. After this change:

- Every `type: secret | bcrypt | rsa-private` variable is persisted in `config.installedSecrets` at the end of every successful install (auto-encrypted at rest via existing SENSITIVE_KEYS regex).
- The next install's runner overrides the wizard's freshly-generated values from the saved state when **`!cleanInstall` OR `preserve.includes('secrets')`** — i.e. either a normal re-install or a clean install where the operator opted to keep secrets.
- Legacy `config.lldap.password` / `config.reverseProxy.npm.password` / `config.adguard.password` stay as back-compat sources so the first install after this upgrade already benefits.
- Wizard prefill now loads stored values unconditionally — the server-side runner is the load-bearing override.

## The failure mode this fixes

> ⚠️ Could not seed LLDAP groups: LLDAP rejected the admin password. This usually means an existing LLDAP data volume from a previous install still holds the old password…

LLDAP only reads `LLDAP_LDAP_USER_PASS` on first DB init. With "keep identity" the DB persists with the *old* hash; the wizard's new random value mismatches; seed call gets 401. Same pattern: Immich admin login fails, Samba sync gives up because LLDAP isn't reachable for it either, and so on.

## Test plan

- [x] Unit tests for `loadSavedSecrets` (legacy + canonical, layering, empty-config edge cases)
- [x] Unit tests for `persistInstalledSecrets` (merge with prior, skip non-secret types, skip empty values)
- [x] `npx vitest run` — 983 passed, 2 skipped, 0 failed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run check:arch` — invariants + depcruiser pass
- [ ] Real install on 192.168.178.100: clean install with "keep identity + secrets" → second install with same → confirm no LLDAP/Immich/AdGuard auth failures
- [ ] Edge case: clean install with `preserve = []` (wipe everything) → confirm fresh secrets get generated and used

🤖 Generated with [Claude Code](https://claude.com/claude-code)