### PR TITLE
fix(install): NPM readiness probe accepts 400 alongside 401

### DIFF
--- a/templates/nginx/template.yml
+++ b/templates/nginx/template.yml
@@ -12,18 +12,20 @@ metadata:
     servicebay.ports: "{{NGINX_PORT}}/tcp,{{NGINX_SSL_PORT}}/tcp,{{NGINX_ADMIN_PORT}}/tcp"
     # Readiness probe (#613). Every "behind NPM" template depends on
     # nginx and seeds a proxy host in its post-deploy — the admin API
-    # must be answering before that fires. NPM's `/api/tokens` rejects
-    # auth with 401 once the Node.js server is fully started and the
-    # sqlite DB seeded; earlier in startup it returns 502 / connection-
-    # refused. The retry loop in `src/lib/stackInstall/postInstall.ts`
-    # still handles the case where NPM rejects ServiceBay's wizard-
-    # generated credentials, but cold-start liveness is now declarative.
+    # must be answering before that fires. NPM's `/api/tokens` POST
+    # runs joi schema validation BEFORE auth, so it returns 400 when
+    # `identity` isn't a valid email format and 401 when the format
+    # validates but auth fails. Either response proves the API is live;
+    # earlier in startup the listener returns 502 / connection-refused
+    # / 5xx, which the probe keeps waiting on. The retry loop in
+    # `src/lib/stackInstall/postInstall.ts` still handles the case
+    # where NPM rejects ServiceBay's wizard-generated credentials.
     servicebay.readiness: |
       - kind: http
         url: http://localhost:{{NGINX_ADMIN_PORT}}/api/tokens
         method: POST
-        body: '{"identity":"x","secret":"x"}'
-        expect_status: 401
+        body: '{"identity":"probe@servicebay.local","secret":"x"}'
+        expect_status: [400, 401]
         timeout: 5m
 spec:
   hostNetwork: true


### PR DESCRIPTION
## Summary

NPM's `/api/tokens` POST runs joi schema validation **before** auth, so an `identity: "x"` body trips the email-format check and returns 400 — the readiness probe shipped in #614 was waiting on 401 forever and the deploy timed out after 5 min with NPM perfectly healthy on the other side.

```
…probe 1/1 (http) still waiting after 96s — last attempt: HTTP 400 (expected 401) (timeout in 204s)
```

Fix:
- Accept `expect_status: [400, 401]` — both responses prove the API layer is up; cold-start (502 / connection-refused / 5xx) still keeps the probe waiting.
- Pass a syntactically-valid fake email (`probe@servicebay.local`) so behaviour stays the same whichever validation order NPM ships in the future.

Regression from #613 / v4.2.0. Unblocks installs that include nginx.

## Test plan

- [x] Parser round-trip validates the new `expect_status: [400, 401]` shape
- [x] `npx vitest run tests/backend/template_consistency.test.ts` (63 tests) pass
- [ ] Real install on `192.168.178.100` finishes nginx readiness without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)