### PR TITLE
feat(install): persist install secrets at first generation (#622)

### DIFF
--- a/src/app/api/system/install/persist-secret/route.ts
+++ b/src/app/api/system/install/persist-secret/route.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
+import { persistSingleSecret } from '@/lib/install/savedSecrets';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Single-secret atomic upsert into `config.installedSecrets`. The wizard
+ * (`useStackInstall.ts`) calls this every time it generates a secret /
+ * RSA key / bcrypt hash, so the value is persisted before any unit is
+ * deployed. If the install then fails mid-flow, the retry sees the same
+ * values instead of regenerating and mismatching encrypted-at-rest data.
+ * #622.
+ */
+const Body = z.object({
+  varName: z.string().min(1),
+  value: z.string().min(1),
+});
+
+export const POST = withApiHandler({ body: Body }, async ({ body }) => {
+  const wrote = await persistSingleSecret(body.varName, body.value);
+  return NextResponse.json({ ok: true, wrote });
+});

--- a/src/hooks/useStackInstall.ts
+++ b/src/hooks/useStackInstall.ts
@@ -542,6 +542,12 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     // (e.g. subdomain vars used only for proxy configuration).
     for (const key of Object.keys(allMeta)) vars.add(key);
 
+    // Tracks variables whose value came from a fresh generation in *this*
+    // Configure run (not from storage / prefill / Settings). These are the
+    // ones we have to persist to `config.installedSecrets` right now —
+    // values that already came from storage are already saved by definition.
+    const newlyGenerated: Array<{ name: string; value: string }> = [];
+
     const resolvedVars: StackVariable[] = Array.from(vars).map(name => {
       const meta = allMeta[name];
       // Caller-provided prefills (PUBLIC_DOMAIN, NGINX_ADMIN_EMAIL, ...)
@@ -561,7 +567,12 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
       if (!value && meta?.type === 'secret') {
         // On a reinstall without RESET, use the stored value if available so
         // services with existing data volumes keep the password they know.
-        value = storedValues[name] ?? generateRandomSecret();
+        if (storedValues[name]) {
+          value = storedValues[name];
+        } else {
+          value = generateRandomSecret();
+          newlyGenerated.push({ name, value });
+        }
       }
       return { name, value, global: isGlobal, meta };
     });
@@ -569,12 +580,20 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     // RSA private keys — server-generated, PEM pre-indented for YAML block scalars.
     await Promise.all(resolvedVars.map(async v => {
       if (v.value || v.meta?.type !== 'rsa-private') return;
+      // Reuse a stored RSA key over generating a new one — Authelia's OIDC
+      // tokens issued under the prior key would be rejected by clients
+      // pinned to it.
+      if (storedValues[v.name]) {
+        v.value = storedValues[v.name];
+        return;
+      }
       try {
         const res = await fetch('/api/system/keys/rsa');
         if (res.ok) {
           const data = await res.json();
           if (typeof data.pem === 'string') {
             v.value = data.pem.trimEnd().split('\n').map((l: string) => '          ' + l).join('\n');
+            newlyGenerated.push({ name: v.name, value: v.value });
           }
         }
       } catch { /* install will fail with a clearer error if it matters */ }
@@ -584,6 +603,10 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     // the secret pass so the source value is already populated.
     await Promise.all(resolvedVars.map(async v => {
       if (v.value || v.meta?.type !== 'bcrypt') return;
+      if (storedValues[v.name]) {
+        v.value = storedValues[v.name];
+        return;
+      }
       const sourceName = v.meta?.bcryptSource;
       if (!sourceName) return;
       const source = resolvedVars.find(x => x.name === sourceName);
@@ -596,10 +619,30 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
         });
         if (res.ok) {
           const data = await res.json();
-          if (typeof data.hash === 'string') v.value = data.hash;
+          if (typeof data.hash === 'string') {
+            v.value = data.hash;
+            newlyGenerated.push({ name: v.name, value: data.hash });
+          }
         }
       } catch { /* leave empty */ }
     }));
+
+    // Persist every newly-generated secret-typed value BEFORE returning, so
+    // a mid-install failure (or the operator closing the wizard) doesn't
+    // strand values that exist only in browser state. The server endpoint
+    // is idempotent; if the same name+value already lives in
+    // `config.installedSecrets` the write is a no-op. #622.
+    if (newlyGenerated.length > 0) {
+      await Promise.all(newlyGenerated.map(async ({ name, value }) => {
+        try {
+          await fetch('/api/system/install/persist-secret', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ varName: name, value }),
+          });
+        } catch { /* server-side persistInstalledSecrets at install end is the safety net */ }
+      }));
+    }
 
     // VAULTWARDEN_DOMAIN derives from SUBDOMAIN + PUBLIC_DOMAIN.
     const pubDomain = resolvedVars.find(v => v.name === 'PUBLIC_DOMAIN')?.value;

--- a/src/lib/install/savedSecrets.test.ts
+++ b/src/lib/install/savedSecrets.test.ts
@@ -12,11 +12,19 @@
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+// Mocked config store: getConfig returns whatever updateConfig last wrote.
+// persistSingleSecret does a read-modify-write through both, so the tests
+// need them coupled rather than independent stubs.
+let mockConfigState: Partial<AppConfig> = {};
 vi.mock('@/lib/config', () => ({
-  updateConfig: vi.fn(async (_: unknown) => undefined),
+  getConfig: vi.fn(async () => mockConfigState as AppConfig),
+  updateConfig: vi.fn(async (updates: Partial<AppConfig>) => {
+    mockConfigState = { ...mockConfigState, ...updates };
+    return mockConfigState as AppConfig;
+  }),
 }));
 
-import { loadSavedSecrets, persistInstalledSecrets } from './savedSecrets';
+import { loadSavedSecrets, persistInstalledSecrets, persistSingleSecret } from './savedSecrets';
 import type { AppConfig } from '@/lib/config';
 import { updateConfig } from '@/lib/config';
 import type { StackVariable } from '@/lib/stackInstall/types';
@@ -25,6 +33,7 @@ const updateConfigMock = vi.mocked(updateConfig);
 
 beforeEach(() => {
   updateConfigMock.mockClear();
+  mockConfigState = {};
 });
 
 function mkConfig(partial: Partial<AppConfig>): AppConfig {
@@ -118,5 +127,70 @@ describe('persistInstalledSecrets', () => {
     }));
     const arg = updateConfigMock.mock.calls[0][0] as { installedSecrets: Array<{ varName: string; password: string }> };
     expect(arg.installedSecrets).toEqual([{ varName: 'LLDAP_ADMIN_PASSWORD', password: 'keep-me' }]);
+  });
+});
+
+describe('persistSingleSecret (#622 — persist at first generation)', () => {
+  it('appends a new entry on first call', async () => {
+    const wrote = await persistSingleSecret('LLDAP_ADMIN_PASSWORD', 'pw-1');
+    expect(wrote).toBe(true);
+    expect(mockConfigState.installedSecrets).toEqual([
+      { varName: 'LLDAP_ADMIN_PASSWORD', password: 'pw-1' },
+    ]);
+  });
+
+  it('is idempotent — same name+value is a no-op', async () => {
+    await persistSingleSecret('LLDAP_ADMIN_PASSWORD', 'pw-1');
+    updateConfigMock.mockClear();
+    const wrote = await persistSingleSecret('LLDAP_ADMIN_PASSWORD', 'pw-1');
+    expect(wrote).toBe(false);
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('updates the entry in place when the value changes (operator rotation)', async () => {
+    await persistSingleSecret('LLDAP_ADMIN_PASSWORD', 'pw-old');
+    await persistSingleSecret('LLDAP_ADMIN_PASSWORD', 'pw-new');
+    expect(mockConfigState.installedSecrets).toEqual([
+      { varName: 'LLDAP_ADMIN_PASSWORD', password: 'pw-new' },
+    ]);
+  });
+
+  it('preserves entries from prior installs when appending a new one', async () => {
+    mockConfigState = {
+      installedSecrets: [{ varName: 'PRIOR', password: 'keep' }],
+    };
+    await persistSingleSecret('NEW', 'fresh');
+    expect(mockConfigState.installedSecrets).toEqual([
+      { varName: 'PRIOR', password: 'keep' },
+      { varName: 'NEW', password: 'fresh' },
+    ]);
+  });
+
+  it('skips writes when varName or value is empty', async () => {
+    expect(await persistSingleSecret('', 'value')).toBe(false);
+    expect(await persistSingleSecret('NAME', '')).toBe(false);
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent upserts so neither write is lost', async () => {
+    // Without the internal queue, both calls would read the same empty list,
+    // each compute a single-entry array, and the second write would clobber
+    // the first. With the queue, the second call sees the first's write.
+    await Promise.all([
+      persistSingleSecret('A', '1'),
+      persistSingleSecret('B', '2'),
+    ]);
+    const names = (mockConfigState.installedSecrets ?? []).map(e => e.varName).sort();
+    expect(names).toEqual(['A', 'B']);
+  });
+
+  it('round-trips through loadSavedSecrets', async () => {
+    await persistSingleSecret('IMMICH_ADMIN_PASSWORD', 'immich-pw');
+    await persistSingleSecret('AUTHELIA_JWT_SECRET', 'jwt-pw');
+    const loaded = loadSavedSecrets(mockConfigState as AppConfig);
+    expect(loaded).toEqual({
+      IMMICH_ADMIN_PASSWORD: 'immich-pw',
+      AUTHELIA_JWT_SECRET: 'jwt-pw',
+    });
   });
 });

--- a/src/lib/install/savedSecrets.ts
+++ b/src/lib/install/savedSecrets.ts
@@ -1,5 +1,5 @@
 /**
- * Secret reuse across installs (#615).
+ * Secret reuse across installs (#615, extended in #622).
  *
  * The wizard's "secret" / "bcrypt" / "rsa-private" type variables get
  * fresh random values on every install — fine on a brand-new node,
@@ -7,10 +7,15 @@
  * like LLDAP only honour `LLDAP_LDAP_USER_PASS` on first DB init.
  *
  * This module:
- *   1. Persists every `type: secret | bcrypt | rsa-private` variable
- *      value at the end of every successful install (`persistInstalledSecrets`).
- *   2. Loads them back on the next install (`loadSavedSecrets`).
- *   3. Falls back to the legacy `config.lldap` / `config.adguard` /
+ *   1. Persists each secret-typed variable **at first generation**, before
+ *      any unit deploys (`persistSingleSecret`, called from the wizard's
+ *      Configure step). #622 — was previously post-success in #615, which
+ *      meant a mid-install failure lost the secrets the next retry needed.
+ *   2. Still runs an end-of-run persist (`persistInstalledSecrets`) as a
+ *      safety net for variables the wizard didn't generate explicitly
+ *      (e.g. operator-typed values).
+ *   3. Loads saved secrets back on the next install (`loadSavedSecrets`).
+ *   4. Falls back to the legacy `config.lldap` / `config.adguard` /
  *      `config.reverseProxy.npm` shapes for installs that predate the
  *      `installedSecrets` field.
  *
@@ -22,7 +27,7 @@
  * plaintext.
  */
 import type { AppConfig } from '@/lib/config';
-import { updateConfig } from '@/lib/config';
+import { getConfig, updateConfig } from '@/lib/config';
 
 /** Variable types that hold sensitive material the wizard regenerates. */
 const SECRET_TYPES = new Set(['secret', 'bcrypt', 'rsa-private']);
@@ -95,4 +100,47 @@ export async function persistInstalledSecrets(
   }
   const list = Array.from(map, ([varName, password]) => ({ varName, password }));
   await updateConfig({ installedSecrets: list });
+}
+
+/**
+ * Per-process queue for single-secret upserts. `updateConfig` already
+ * serializes its own read-modify-write across the config file, but the
+ * "append a single entry to an array field" pattern needs an outer lock:
+ * deepMerge replaces arrays wholesale, so two concurrent callers each
+ * reading the current list, computing `list + [their entry]`, and writing
+ * back would lose one of the two entries. Serializing here closes that
+ * window for all callers that go through `persistSingleSecret`.
+ */
+let singleSecretQueue: Promise<unknown> = Promise.resolve();
+function withSingleSecretLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = singleSecretQueue.then(fn, fn);
+  singleSecretQueue = next.catch(() => undefined);
+  return next;
+}
+
+/**
+ * Upsert one secret-typed variable into `config.installedSecrets` atomically.
+ * Called from the wizard's Configure step the moment a value is generated,
+ * so a mid-install failure can never strand the operator with secrets that
+ * exist only in browser state.
+ *
+ * No-ops if the entry already exists with the same value (idempotent), or
+ * if either argument is empty (an empty value must never clobber a saved
+ * one — see persistInstalledSecrets for the same rule).
+ *
+ * Returns `true` if it wrote, `false` if it was already up-to-date.
+ */
+export async function persistSingleSecret(varName: string, value: string): Promise<boolean> {
+  if (!varName || !value) return false;
+  return withSingleSecretLock(async () => {
+    const current = await getConfig();
+    const existing = current.installedSecrets ?? [];
+    const idx = existing.findIndex(e => e.varName === varName);
+    if (idx >= 0 && existing[idx].password === value) return false;
+    const next = idx >= 0
+      ? existing.map((e, i) => (i === idx ? { varName, password: value } : e))
+      : [...existing, { varName, password: value }];
+    await updateConfig({ installedSecrets: next });
+    return true;
+  });
 }


### PR DESCRIPTION
Closes #622. Part of #621 (Phase 1A).

## Summary

- The wizard's `secret` / `bcrypt` / `rsa-private` variables are now persisted to `config.installedSecrets` the moment they're generated, before any unit deploys — not at end-of-success as in #615.
- `persistSingleSecret(varName, value)` in `savedSecrets.ts` does an atomic read-modify-write through a per-process queue (deepMerge replaces arrays wholesale, so a single-entry append needs the outer lock).
- New `POST /api/system/install/persist-secret` route — `withApiHandler` + Zod body validation, single-secret upsert. Idempotent: same name+value is a no-op.
- `useStackInstall.ts` tracks newly-generated values (vs. values reused from `storedValues`) and POSTs each one before `startConfigure` returns.
- Bonus fix: stored RSA + bcrypt values are now also reused from saved state (previously only plain `secret` types were — Authelia OIDC key rotation would have invalidated client tokens on every install).
- Server-side override block in `runner.ts` is unchanged. It now finds entries on every install run, not just the ones that previously succeeded.

## Why this matters

Five install failures this week traced to the same shape: ServiceBay's install is procedural (wizard re-generates state) but services are stateful (encrypt data with that state). With secrets only saved post-success, a mid-install failure stranded the operator with values that existed only in browser state — the retry regenerated, mismatched the on-disk data, and failed again. Persisting at generation makes the retry safe.

## Test plan

- [x] `npm run check:arch` — 495 modules, no violations
- [x] `npm run lint` — 0 errors (new route uses `withApiHandler` so adds no warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 990 pass / 2 skipped / 134 files; 7 new tests in `savedSecrets.test.ts`:
  - first-generation append
  - idempotent re-write (no-op when value unchanged)
  - in-place update on operator rotation
  - prior entries preserved when appending a new one
  - empty `varName` / `value` is a no-op (never clobbers a saved value)
  - concurrent upserts serialize — neither write is lost
  - round-trip through `loadSavedSecrets`
- [x] `npm run build` — clean, new route registered
- [ ] **Live verify after deploy** (per #622 acceptance):
  ```
  mcp__servicebay__exec_command 'jq .installedSecrets /var/mnt/data/servicebay/config.json'
  ```
  should show every secret-typed variable IMMEDIATELY after the wizard's Configure step, before any unit deploys.
- [ ] Kill an install mid-flow (auth template); retry; assert same secret values used (no regeneration).

## Out of scope / follow-ups

- Per-step idempotency audit of `runner.ts` — issue #622's acceptance bullet "Run install twice with no state changes ⇒ no API calls" is realistic only after Phase 4 (capability bus) and Phase 5 (stack runner). For #622, the deploy loop already short-circuits via `alreadyInstalled`; the rest of the mutations are touched by later phases.
- `persistInstalledSecrets` (the post-success path) is kept as a safety net; can be removed once we're confident every secret is captured at generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)