### PR TITLE
feat(settings): factory-reset UI + clear saved credentials (#623)

### DIFF
--- a/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, Loader2, Trash2 } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+/**
+ * Factory Reset card (#623). The migration entry point for moving an
+ * existing box to the post-Phase-1 architecture: wipes every service
+ * AND clears `installedSecrets`, `installManifest`, and the legacy
+ * `lldap` / `adguard` / `reverseProxy.npm` config fields so the next
+ * wizard run starts from genuine zero.
+ *
+ * Distinct from the wizard's "Clean install" flow:
+ *   - clean install is granular (per-group preserve flags) and tuned for
+ *     re-installing while keeping useful state
+ *   - factory reset is the nuclear option for "I want zero baseline"
+ *
+ * The confirmation token is FACTORY-RESET (not RESET) so an operator
+ * can't accidentally type the wrong thing into the wrong dialog.
+ */
+const REQUIRED_CONFIRM = 'FACTORY-RESET';
+
+export default function FactoryResetSection() {
+  const { addToast } = useToast();
+  const [confirmText, setConfirmText] = useState('');
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<{
+    deleted: number;
+    cleared: string[];
+    wipeSteps: string[];
+  } | null>(null);
+
+  const matches = confirmText === REQUIRED_CONFIRM;
+
+  const handleFactoryReset = async () => {
+    if (!matches || running) return;
+    setRunning(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/system/factory-reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm: REQUIRED_CONFIRM }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `Server error (${res.status})`);
+      setResult({
+        deleted: data.reset?.deleted?.length ?? 0,
+        cleared: data.config?.cleared ?? [],
+        wipeSteps: data.reset?.wipeStepsRun ?? [],
+      });
+      setConfirmText('');
+      addToast('success', 'Factory reset complete', 'Open the install wizard to set up from a clean baseline.');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      addToast('error', 'Factory reset failed', msg);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-red-200 dark:border-red-900/50 shadow-sm overflow-hidden w-full">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-red-50 dark:bg-red-950/30 flex items-center gap-3">
+        <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg text-red-600 dark:text-red-400">
+          <AlertTriangle size={20} />
+        </div>
+        <div>
+          <h3 className="font-bold text-gray-900 dark:text-white">Factory Reset</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">Wipe every service + clear saved credentials. Start from zero.</p>
+        </div>
+      </div>
+
+      <div className="p-6 space-y-4">
+        <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+          <p>This deletes every installed service (photos, vault, identity, proxy, all of it) and clears the saved credentials in ServiceBay&apos;s config. The next wizard run goes through the full first-install flow with no pre-filled values.</p>
+          <p className="font-medium text-red-700 dark:text-red-400">
+            Not what you want for a normal re-install. Use Clean install in the wizard for that — it&apos;s granular.
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Family members will need to re-create their LLDAP accounts. NPM&apos;s Let&apos;s Encrypt certs are wiped (LE has a rate limit on re-issuance, so don&apos;t do this repeatedly).
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Type <span className="font-mono font-bold text-red-600 dark:text-red-400">{REQUIRED_CONFIRM}</span> to confirm:
+          </label>
+          <input
+            type="text"
+            value={confirmText}
+            onChange={e => setConfirmText(e.target.value)}
+            disabled={running}
+            placeholder={REQUIRED_CONFIRM}
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white font-mono text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+          />
+        </div>
+
+        <button
+          onClick={handleFactoryReset}
+          disabled={!matches || running}
+          className="w-full sm:w-auto px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors shadow-sm flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+        >
+          {running ? <Loader2 size={18} className="animate-spin" /> : <Trash2 size={18} />}
+          {running ? 'Resetting…' : 'Factory reset this server'}
+        </button>
+
+        {result && (
+          <div className="mt-4 p-4 bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-900/50 rounded-lg text-sm text-gray-700 dark:text-gray-300 space-y-1">
+            <p className="font-medium text-green-700 dark:text-green-400">Reset complete.</p>
+            <p>Removed {result.deleted} service{result.deleted === 1 ? '' : 's'}; wiped {result.wipeSteps.length} data group{result.wipeSteps.length === 1 ? '' : 's'}.</p>
+            {result.cleared.length > 0 && (
+              <p>Config fields cleared: <span className="font-mono text-xs">{result.cleared.join(', ')}</span>.</p>
+            )}
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">Open the install wizard to set up the server from scratch.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/system/page.tsx
+++ b/src/app/(dashboard)/settings/system/page.tsx
@@ -4,6 +4,7 @@ import LogLevelControl from '@/components/LogLevelControl';
 import ServerIdentitySection from '../_lib/sections/ServerIdentitySection';
 import UpdatesSection from '../_lib/sections/UpdatesSection';
 import UpdateWindowSection from '../_lib/sections/UpdateWindowSection';
+import FactoryResetSection from '../_lib/sections/FactoryResetSection';
 
 export default function SystemSettingsPage() {
   return (
@@ -12,6 +13,7 @@ export default function SystemSettingsPage() {
       <UpdatesSection />
       <UpdateWindowSection />
       <LogLevelControl />
+      <FactoryResetSection />
     </>
   );
 }

--- a/src/app/api/system/factory-reset/route.ts
+++ b/src/app/api/system/factory-reset/route.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
+import { performStackReset, StackResetError } from '@/lib/install/performStackReset';
+import { clearSensitiveConfig } from '@/lib/install/clearSensitiveConfig';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/system/factory-reset
+ *
+ * The nuclear option (#623). Runs the same wipe as `/api/system/stacks/reset`
+ * with `preserve: []` AND clears the sensitive in-memory config fields
+ * that survive a stacks-only reset (installedSecrets, installManifest,
+ * lldap/adguard legacy fields, NPM admin creds).
+ *
+ * The next wizard run should see no pre-fills — a true clean baseline.
+ *
+ * Distinct from the wizard's "Clean install" flow: that one is granular
+ * (per-group preserve flags) and tuned for re-installing while keeping
+ * useful state. This one is for the rare "I want zero baseline" case.
+ *
+ * Confirmation token: 'FACTORY-RESET' (different from the wizard's
+ * 'RESET' so the operator can't accidentally type the wrong thing into
+ * the wrong dialog).
+ */
+const Body = z.object({
+  confirm: z.literal('FACTORY-RESET'),
+  node: z.string().optional(),
+});
+
+export const POST = withApiHandler({ body: Body }, async ({ body }) => {
+  try {
+    const reset = await performStackReset({ preserve: [], node: body.node });
+    const configCleared = await clearSensitiveConfig();
+    logger.info('FactoryReset', `Wiped ${reset.deleted.length} services + cleared ${configCleared.cleared.length} config fields`);
+    return NextResponse.json({ ok: true, reset, config: configCleared });
+  } catch (error) {
+    if (error instanceof StackResetError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    throw error;
+  }
+});

--- a/src/app/api/system/stacks/reset/route.ts
+++ b/src/app/api/system/stacks/reset/route.ts
@@ -1,17 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ServiceManager } from '@/lib/services/ServiceManager';
-import { agentManager } from '@/lib/agent/manager';
-import { getConfig } from '@/lib/config';
-import { DigitalTwinStore } from '@/lib/store/twin';
-import { logger } from '@/lib/logger';
 import { requireSession } from '@/lib/api/requireSession';
 import { apiError } from '@/lib/api/errors';
-import { RESET_GROUPS, DEFAULT_PRESERVE, isAlwaysWipe, type ResetGroup } from '@/lib/install/resetGroups';
+import { performStackReset, StackResetError } from '@/lib/install/performStackReset';
 
 export const dynamic = 'force-dynamic';
-
-/** Service names that must never be auto-deleted by the reset endpoint. */
-const PROTECTED = new Set(['servicebay']);
 
 /**
  * POST /api/system/stacks/reset
@@ -22,19 +14,9 @@ const PROTECTED = new Set(['servicebay']);
  * }
  *
  * Wipes stack data so the install wizard can re-deploy. Granular per
- * #568 — the operator picks which groups to keep. Defaults preserve
- * the three system-critical groups (secrets / certs / identity); only
- * service-data wipes unless the operator explicitly opts in.
- *
- * Concrete steps:
- *   - stops + removes Quadlet definitions for all non-protected services
- *   - reloads systemd
- *   - archives NPM data to /mnt/data/servicebay/cert-archive/ (so a
- *     full wipe still leaves the cert-reuse helper a fallback)
- *   - deletes paths under `<DATA_DIR>` according to the preserve map
- *   - purges every `alwaysWipe` group (currently just `quadlet-backup`)
- *     unconditionally — setup-raid.sh would otherwise replay stale
- *     units and resurrect deleted services after an OS reinstall.
+ * #568 — the operator picks which groups to keep. The implementation
+ * lives in `lib/install/performStackReset.ts` so the Factory Reset
+ * endpoint (#623) can drive the same wipe.
  *
  * ServiceBay itself is intentionally not touched (Quadlet definition).
  */
@@ -47,7 +29,7 @@ export async function POST(request: NextRequest) {
     const { confirm, node: requestedNode, preserve: rawPreserve } = body as {
       confirm?: string;
       node?: string;
-      preserve?: string[];
+      preserve?: unknown;
     };
 
     if (confirm !== 'RESET') {
@@ -57,159 +39,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate preserve groups; ignore unknown ids rather than failing
-    // so a forward-compatible caller (newer ServiceBay client talking
-    // to an older backend) doesn't break — unknown groups just have
-    // no effect. Default to system-critical preservation when omitted.
-    // alwaysWipe groups (quadlet-backup) are dropped from preserve
-    // even if requested — leaving stale Quadlet units behind would
-    // resurrect deleted services after an OS reinstall.
-    const validGroups = Object.keys(RESET_GROUPS) as ResetGroup[];
-    const preserve: ResetGroup[] = (Array.isArray(rawPreserve)
-      ? (rawPreserve.filter((g): g is ResetGroup => validGroups.includes(g as ResetGroup)))
-      : DEFAULT_PRESERVE.slice()
-    ).filter(g => !isAlwaysWipe(g));
-
-    const twin = DigitalTwinStore.getInstance();
-    const nodeName = requestedNode || Object.keys(twin.nodes)[0];
-    if (!nodeName) {
-      return NextResponse.json({ error: 'No nodes available' }, { status: 404 });
-    }
-
-    const config = await getConfig();
-    const dataDir = config.templateSettings?.DATA_DIR || '/mnt/data/stacks';
-    // Belt-and-suspenders: refuse to wipe a path that is dangerously high in
-    // the filesystem tree. Even if a malicious config injected '/' or '/mnt',
-    // this endpoint will not act on it.
-    const safeRe = /^\/(mnt|var\/mnt|opt|srv|home)\/[^.][^\s]+/;
-    if (!safeRe.test(dataDir) || dataDir.length < 8) {
-      return NextResponse.json(
-        { error: `Refusing to wipe DATA_DIR="${dataDir}" — outside the safe path whitelist` },
-        { status: 500 }
-      );
-    }
-
-    // Service inventory: stop + remove Quadlet for everything except
-    // services whose data dir falls under a preserved group. Otherwise
-    // the operator would lose the cert-reuse benefit because the NPM
-    // service was torn down even though its data dir stays.
-    const services = await ServiceManager.listServices(nodeName);
-    const preservedServices = new Set<string>();
-    if (preserve.includes('certs')) preservedServices.add('nginx-proxy-manager');
-    if (preserve.includes('identity')) preservedServices.add('auth');
-    const toDelete = services
-      .map(s => s.name)
-      .filter(name => !PROTECTED.has(name) && !preservedServices.has(name));
-
-    const deleted: string[] = [];
-    const failed: { name: string; error: string }[] = [];
-
-    for (const name of toDelete) {
-      try {
-        await ServiceManager.deleteService(nodeName, name);
-        deleted.push(name);
-      } catch (e) {
-        failed.push({ name, error: e instanceof Error ? e.message : 'unknown' });
-        logger.warn('StackReset', `Failed to delete service ${name}`, e);
-      }
-    }
-
-    const agent = await agentManager.ensureAgent(nodeName);
-
-    // Snapshot NPM's data dir to cert-archive UNLESS the secrets group
-    // is also being wiped (which would delete the archive itself, making
-    // the snapshot useless). When secrets is preserved AND certs is
-    // wiped, the archive lets cert-reuse pull from a backup tarball on
-    // next install — without re-running into LE's rate limit.
-    let certArchive: string | null = null;
-    const willWipeCerts = !preserve.includes('certs');
-    const willWipeSecrets = !preserve.includes('secrets');
-    if (willWipeCerts && !willWipeSecrets) {
-      try {
-        const npmDir = `${dataDir}/nginx-proxy-manager`;
-        const probe = await agent.sendCommand('exec', {
-          command: `[ -d "${npmDir}/letsencrypt/live" ] && find "${npmDir}/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
-        });
-        const hasCerts = !!(probe.stdout || '').trim();
-        if (hasCerts) {
-          const ts = new Date().toISOString().replace(/[:.]/g, '-');
-          const archivePath = `/mnt/data/servicebay/cert-archive/npm-${ts}.tar.gz`;
-          await agent.sendCommand('exec', {
-            command: `mkdir -p /mnt/data/servicebay/cert-archive && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
-          });
-          certArchive = archivePath;
-          logger.info('StackReset', `Archived NPM data to ${archivePath} before wipe.`);
-        }
-      } catch (e) {
-        logger.warn('StackReset', `Cert archive failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
-    }
-
-    // Build the wipe plan: stacks subdirs (NPM, auth, service-data) are
-    // handled per-group; the servicebay dir is handled separately.
-    // Each rm -rf is a single shell exec so the agent can log them.
-    const wipeStepsRun: string[] = [];
-
-    // service-data: wipe everything under /mnt/data/stacks/* except
-    // the preserved subdirs (NPM, auth).
-    if (!preserve.includes('service-data')) {
-      const exclusions: string[] = [];
-      if (preserve.includes('certs')) exclusions.push('nginx-proxy-manager');
-      if (preserve.includes('identity')) exclusions.push('auth');
-      // Use `find -mindepth 1 -maxdepth 1 ! -name X ! -name Y -exec rm -rf`
-      const findExclusions = exclusions.map(n => `! -name ${JSON.stringify(n)}`).join(' ');
-      const cmd = `find ${dataDir} -mindepth 1 -maxdepth 1 ${findExclusions} -exec rm -rf {} +`;
-      await agent.sendCommand('exec', { command: cmd });
-      wipeStepsRun.push(`service-data (kept ${exclusions.length} preserved subdir${exclusions.length === 1 ? '' : 's'})`);
-    } else {
-      // service-data preserved but NPM/auth might individually be wiped
-      // — narrowly target those.
-      if (!preserve.includes('certs')) {
-        await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(`${dataDir}/nginx-proxy-manager`)}` });
-        wipeStepsRun.push('certs only (service-data preserved)');
-      }
-      if (!preserve.includes('identity')) {
-        await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(`${dataDir}/auth`)}` });
-        wipeStepsRun.push('identity only (service-data preserved)');
-      }
-    }
-
-    // secrets: wipe contents of /var/mnt/data/servicebay/.
-    // Clear contents rather than removing the dir itself so the systemd
-    // mount unit + setup-raid don't trip on a missing path.
-    if (!preserve.includes('secrets')) {
-      await agent.sendCommand('exec', {
-        command: 'find /var/mnt/data/servicebay -mindepth 1 -maxdepth 1 -exec rm -rf {} +',
-      });
-      wipeStepsRun.push('secrets (ServiceBay state)');
-    }
-
-    // alwaysWipe groups (quadlet-backup): always purged, even when
-    // their parent group is preserved. Quadlet snapshots specifically
-    // would resurrect deleted services after an OS reinstall because
-    // setup-raid.sh replays them. setup-raid recreates the dir on
-    // next boot, so removing the path itself is safe.
-    for (const id of Object.keys(RESET_GROUPS) as ResetGroup[]) {
-      if (!isAlwaysWipe(id)) continue;
-      for (const p of RESET_GROUPS[id].paths) {
-        await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(p)}` });
-      }
-      wipeStepsRun.push(`${id} (always-wipe)`);
-    }
-
-    return NextResponse.json({
-      ok: true,
-      node: nodeName,
-      dataDir,
-      preserve,
-      wipeStepsRun,
-      deleted,
-      failed,
-      protected: Array.from(PROTECTED),
-      preservedServices: Array.from(preservedServices),
-      certArchive,
-    });
+    const result = await performStackReset({ node: requestedNode, preserve: rawPreserve });
+    return NextResponse.json(result);
   } catch (error) {
+    if (error instanceof StackResetError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
     return apiError(error, { tag: 'api:system:stacks:reset', status: 500 });
   }
 }

--- a/src/lib/install/clearSensitiveConfig.test.ts
+++ b/src/lib/install/clearSensitiveConfig.test.ts
@@ -1,0 +1,108 @@
+/**
+ * clearSensitiveConfig — #623 / Factory Reset.
+ *
+ * The factory-reset endpoint relies on this helper to wipe in-memory +
+ * on-disk secret state that survives a stacks-only reset. The contract:
+ * removes the field entirely (not just sets empty), preserves unrelated
+ * keys inside `reverseProxy`, and reports which fields were actually
+ * cleared so the UI can show a meaningful summary.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+let mockConfigState: Partial<AppConfig> = {};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfigState as AppConfig),
+  saveConfig: vi.fn(async (config: AppConfig) => {
+    mockConfigState = config;
+  }),
+}));
+
+import { clearSensitiveConfig } from './clearSensitiveConfig';
+import type { AppConfig } from '@/lib/config';
+import { saveConfig } from '@/lib/config';
+
+const saveConfigMock = vi.mocked(saveConfig);
+
+beforeEach(() => {
+  mockConfigState = {};
+  saveConfigMock.mockClear();
+});
+
+describe('clearSensitiveConfig', () => {
+  it('removes installedSecrets, installManifest, lldap, adguard, and reverseProxy.npm', async () => {
+    mockConfigState = {
+      installedSecrets: [{ varName: 'LLDAP_ADMIN_PASSWORD', password: 'pw' }],
+      installManifest: { credentials: [] } as never,
+      lldap: { url: 'http://x', username: 'admin', password: 'pw' },
+      adguard: { adminUrl: 'http://x', username: 'admin', password: 'pw' },
+      reverseProxy: {
+        publicDomain: 'example.com',
+        npm: { email: 'admin@x', password: 'pw' },
+      } as never,
+    };
+
+    const result = await clearSensitiveConfig();
+
+    expect(result.cleared.sort()).toEqual([
+      'adguard',
+      'installManifest',
+      'installedSecrets',
+      'lldap',
+      'reverseProxy.npm',
+    ]);
+    expect(mockConfigState.installedSecrets).toBeUndefined();
+    expect(mockConfigState.installManifest).toBeUndefined();
+    expect(mockConfigState.lldap).toBeUndefined();
+    expect(mockConfigState.adguard).toBeUndefined();
+    expect(mockConfigState.reverseProxy?.npm).toBeUndefined();
+  });
+
+  it('preserves operator-set fields on reverseProxy (only npm is sensitive)', async () => {
+    mockConfigState = {
+      reverseProxy: {
+        publicDomain: 'example.com',
+        lanDomain: 'home.arpa',
+        npm: { email: 'admin@x', password: 'pw' },
+      } as never,
+    };
+
+    await clearSensitiveConfig();
+
+    expect(mockConfigState.reverseProxy).toEqual({
+      publicDomain: 'example.com',
+      lanDomain: 'home.arpa',
+    });
+  });
+
+  it('reports an empty cleared list when nothing was set', async () => {
+    mockConfigState = {};
+    const result = await clearSensitiveConfig();
+    expect(result.cleared).toEqual([]);
+    // saveConfig still runs — the call is the canonical write-and-flush
+    // signal, and the wipe step is idempotent.
+    expect(saveConfigMock).toHaveBeenCalledOnce();
+  });
+
+  it('treats an empty installedSecrets array as already-cleared', async () => {
+    mockConfigState = { installedSecrets: [] };
+    const result = await clearSensitiveConfig();
+    expect(result.cleared).toEqual([]);
+  });
+
+  it('does not touch unrelated fields', async () => {
+    mockConfigState = {
+      serverName: 'pi.home',
+      domain: 'home.arpa',
+      autoUpdate: { enabled: true, schedule: '0 0 * * *' } as never,
+      installedSecrets: [{ varName: 'X', password: 'y' }],
+    };
+
+    await clearSensitiveConfig();
+
+    expect(mockConfigState.serverName).toBe('pi.home');
+    expect(mockConfigState.domain).toBe('home.arpa');
+    expect(mockConfigState.autoUpdate).toEqual({ enabled: true, schedule: '0 0 * * *' });
+    expect(mockConfigState.installedSecrets).toBeUndefined();
+  });
+});

--- a/src/lib/install/clearSensitiveConfig.ts
+++ b/src/lib/install/clearSensitiveConfig.ts
@@ -1,0 +1,55 @@
+/**
+ * Clear in-memory + on-disk `AppConfig` fields that carry secret state
+ * tied to a specific install — used by the Factory Reset endpoint
+ * (#623) after the stack wipe so the next wizard run truly starts from
+ * zero.
+ *
+ * Why a dedicated helper: `updateConfig` deep-merges its `Partial<AppConfig>`
+ * argument with the current config. Nested objects are merged, not
+ * replaced, so passing `lldap: undefined` would not actually remove the
+ * `lldap` field. We bypass deepMerge by reading the current config,
+ * mutating the fields directly, and writing the whole thing via
+ * `saveConfig`. `saveConfig` holds the same write-lock as `updateConfig`
+ * so this is safe under concurrent callers.
+ *
+ * Fields cleared:
+ *   - `installedSecrets` — wizard-generated secret material from #615 / #622
+ *   - `installManifest` — saved credentials surfaced in Settings → Credentials
+ *   - `lldap` / `adguard` — legacy back-compat secret stores
+ *   - `reverseProxy.npm` — NPM admin creds (rest of `reverseProxy` kept,
+ *     since it also holds operator-set fields like `publicDomain`)
+ */
+import { getConfig, saveConfig } from '@/lib/config';
+
+export interface ClearSensitiveConfigResult {
+  cleared: string[];
+}
+
+export async function clearSensitiveConfig(): Promise<ClearSensitiveConfigResult> {
+  const config = await getConfig();
+  const cleared: string[] = [];
+
+  if (config.installedSecrets && config.installedSecrets.length > 0) {
+    delete config.installedSecrets;
+    cleared.push('installedSecrets');
+  }
+  if (config.installManifest) {
+    delete config.installManifest;
+    cleared.push('installManifest');
+  }
+  if (config.lldap) {
+    delete config.lldap;
+    cleared.push('lldap');
+  }
+  if (config.adguard) {
+    delete config.adguard;
+    cleared.push('adguard');
+  }
+  if (config.reverseProxy?.npm) {
+    delete config.reverseProxy.npm;
+    cleared.push('reverseProxy.npm');
+  }
+
+  await saveConfig(config);
+  return { cleared };
+}

--- a/src/lib/install/performStackReset.ts
+++ b/src/lib/install/performStackReset.ts
@@ -1,0 +1,196 @@
+/**
+ * Stack-reset engine. Extracted from `/api/system/stacks/reset` (#568) so
+ * the new Factory Reset endpoint (#623) can drive the same wipe without
+ * re-implementing the inventory + wipe-plan logic.
+ *
+ * The wizard's "clean install" path still hits the route directly — only
+ * the implementation moved.
+ */
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { DigitalTwinStore } from '@/lib/store/twin';
+import { logger } from '@/lib/logger';
+import { RESET_GROUPS, DEFAULT_PRESERVE, isAlwaysWipe, type ResetGroup } from './resetGroups';
+
+/** Service names the reset endpoint refuses to delete. */
+const PROTECTED_SERVICES = new Set(['servicebay']);
+
+export interface PerformStackResetOptions {
+  /** Operator-supplied preserve list. Already-normalised arrays are
+   *  accepted; raw input (`unknown[]`) gets validated here. */
+  preserve?: unknown;
+  /** Optional node name; defaults to the first node in the twin. */
+  node?: string;
+}
+
+export interface PerformStackResetResult {
+  ok: true;
+  node: string;
+  dataDir: string;
+  preserve: ResetGroup[];
+  wipeStepsRun: string[];
+  deleted: string[];
+  failed: { name: string; error: string }[];
+  protected: string[];
+  preservedServices: string[];
+  certArchive: string | null;
+}
+
+/** Error class so the calling route can return the appropriate HTTP status. */
+export class StackResetError extends Error {
+  constructor(message: string, public status = 400) {
+    super(message);
+  }
+}
+
+export async function performStackReset(
+  options: PerformStackResetOptions,
+): Promise<PerformStackResetResult> {
+  // Validate preserve groups; ignore unknown ids rather than failing
+  // so a forward-compatible caller (newer ServiceBay client talking to
+  // an older backend) doesn't break — unknown groups just have no
+  // effect. Default to system-critical preservation when omitted.
+  // alwaysWipe groups (quadlet-backup) are dropped from preserve even
+  // if requested — leaving stale Quadlet units behind would resurrect
+  // deleted services after an OS reinstall.
+  const validGroups = Object.keys(RESET_GROUPS) as ResetGroup[];
+  const preserve: ResetGroup[] = (Array.isArray(options.preserve)
+    ? (options.preserve.filter((g): g is ResetGroup => validGroups.includes(g as ResetGroup)))
+    : DEFAULT_PRESERVE.slice()
+  ).filter(g => !isAlwaysWipe(g));
+
+  const twin = DigitalTwinStore.getInstance();
+  const nodeName = options.node || Object.keys(twin.nodes)[0];
+  if (!nodeName) throw new StackResetError('No nodes available', 404);
+
+  const config = await getConfig();
+  const dataDir = config.templateSettings?.DATA_DIR || '/mnt/data/stacks';
+  // Belt-and-suspenders: refuse to wipe a path that is dangerously high
+  // in the filesystem tree. Even if a malicious config injected '/' or
+  // '/mnt', this engine will not act on it.
+  const safeRe = /^\/(mnt|var\/mnt|opt|srv|home)\/[^.][^\s]+/;
+  if (!safeRe.test(dataDir) || dataDir.length < 8) {
+    throw new StackResetError(`Refusing to wipe DATA_DIR="${dataDir}" — outside the safe path whitelist`, 500);
+  }
+
+  // Service inventory: stop + remove Quadlet for everything except
+  // services whose data dir falls under a preserved group. Otherwise
+  // the operator would lose the cert-reuse benefit because the NPM
+  // service was torn down even though its data dir stays.
+  const services = await ServiceManager.listServices(nodeName);
+  const preservedServices = new Set<string>();
+  if (preserve.includes('certs')) preservedServices.add('nginx-proxy-manager');
+  if (preserve.includes('identity')) preservedServices.add('auth');
+  const toDelete = services
+    .map(s => s.name)
+    .filter(name => !PROTECTED_SERVICES.has(name) && !preservedServices.has(name));
+
+  const deleted: string[] = [];
+  const failed: { name: string; error: string }[] = [];
+
+  for (const name of toDelete) {
+    try {
+      await ServiceManager.deleteService(nodeName, name);
+      deleted.push(name);
+    } catch (e) {
+      failed.push({ name, error: e instanceof Error ? e.message : 'unknown' });
+      logger.warn('StackReset', `Failed to delete service ${name}`, e);
+    }
+  }
+
+  const agent = await agentManager.ensureAgent(nodeName);
+
+  // Snapshot NPM's data dir to cert-archive UNLESS the secrets group is
+  // also being wiped (which would delete the archive itself, making the
+  // snapshot useless). When secrets is preserved AND certs is wiped, the
+  // archive lets cert-reuse pull from a backup tarball on next install —
+  // without re-running into LE's rate limit.
+  let certArchive: string | null = null;
+  const willWipeCerts = !preserve.includes('certs');
+  const willWipeSecrets = !preserve.includes('secrets');
+  if (willWipeCerts && !willWipeSecrets) {
+    try {
+      const npmDir = `${dataDir}/nginx-proxy-manager`;
+      const probe = await agent.sendCommand('exec', {
+        command: `[ -d "${npmDir}/letsencrypt/live" ] && find "${npmDir}/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
+      });
+      const hasCerts = !!(probe.stdout || '').trim();
+      if (hasCerts) {
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const archivePath = `/mnt/data/servicebay/cert-archive/npm-${ts}.tar.gz`;
+        await agent.sendCommand('exec', {
+          command: `mkdir -p /mnt/data/servicebay/cert-archive && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+        });
+        certArchive = archivePath;
+        logger.info('StackReset', `Archived NPM data to ${archivePath} before wipe.`);
+      }
+    } catch (e) {
+      logger.warn('StackReset', `Cert archive failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // Build the wipe plan: stacks subdirs (NPM, auth, service-data) are
+  // handled per-group; the servicebay dir is handled separately.
+  // Each rm -rf is a single shell exec so the agent can log them.
+  const wipeStepsRun: string[] = [];
+
+  // service-data: wipe everything under /mnt/data/stacks/* except the
+  // preserved subdirs (NPM, auth).
+  if (!preserve.includes('service-data')) {
+    const exclusions: string[] = [];
+    if (preserve.includes('certs')) exclusions.push('nginx-proxy-manager');
+    if (preserve.includes('identity')) exclusions.push('auth');
+    const findExclusions = exclusions.map(n => `! -name ${JSON.stringify(n)}`).join(' ');
+    const cmd = `find ${dataDir} -mindepth 1 -maxdepth 1 ${findExclusions} -exec rm -rf {} +`;
+    await agent.sendCommand('exec', { command: cmd });
+    wipeStepsRun.push(`service-data (kept ${exclusions.length} preserved subdir${exclusions.length === 1 ? '' : 's'})`);
+  } else {
+    // service-data preserved but NPM/auth might individually be wiped —
+    // narrowly target those.
+    if (!preserve.includes('certs')) {
+      await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(`${dataDir}/nginx-proxy-manager`)}` });
+      wipeStepsRun.push('certs only (service-data preserved)');
+    }
+    if (!preserve.includes('identity')) {
+      await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(`${dataDir}/auth`)}` });
+      wipeStepsRun.push('identity only (service-data preserved)');
+    }
+  }
+
+  // secrets: wipe contents of /var/mnt/data/servicebay/. Clear contents
+  // rather than removing the dir itself so the systemd mount unit +
+  // setup-raid don't trip on a missing path.
+  if (!preserve.includes('secrets')) {
+    await agent.sendCommand('exec', {
+      command: 'find /var/mnt/data/servicebay -mindepth 1 -maxdepth 1 -exec rm -rf {} +',
+    });
+    wipeStepsRun.push('secrets (ServiceBay state)');
+  }
+
+  // alwaysWipe groups (quadlet-backup): always purged, even when their
+  // parent group is preserved. Quadlet snapshots specifically would
+  // resurrect deleted services after an OS reinstall because
+  // setup-raid.sh replays them. setup-raid recreates the dir on next
+  // boot, so removing the path itself is safe.
+  for (const id of Object.keys(RESET_GROUPS) as ResetGroup[]) {
+    if (!isAlwaysWipe(id)) continue;
+    for (const p of RESET_GROUPS[id].paths) {
+      await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(p)}` });
+    }
+    wipeStepsRun.push(`${id} (always-wipe)`);
+  }
+
+  return {
+    ok: true,
+    node: nodeName,
+    dataDir,
+    preserve,
+    wipeStepsRun,
+    deleted,
+    failed,
+    protected: Array.from(PROTECTED_SERVICES),
+    preservedServices: Array.from(preservedServices),
+    certArchive,
+  };
+}


### PR DESCRIPTION
Closes #623. Part of #621 (Phase 1B).

Pairs with #636 (#622, persist secrets on first generation). #623 is the migration entry point — operator factory-resets the box once, then the post-Phase-1 flow takes over.

## Summary

- **New Settings → System → Factory Reset card.** Asks the operator to type \`FACTORY-RESET\` (different from the wizard's \`RESET\` so the wrong dialog can't fire by accident). Calls the new endpoint, shows what was wiped.
- **New \`POST /api/system/factory-reset\`** route — \`withApiHandler\` + Zod validation. Runs \`performStackReset({ preserve: [] })\` then \`clearSensitiveConfig()\`.
- **Extracted \`performStackReset()\`** from the existing \`/api/system/stacks/reset\` route into \`lib/install/performStackReset.ts\`. Both routes now share the same wipe engine — no behavioural change to the wizard's clean-install flow.
- **New \`clearSensitiveConfig()\`** helper. Removes \`installedSecrets\`, \`installManifest\`, \`lldap\`, \`adguard\`, and \`reverseProxy.npm\` from the config (in-memory + on-disk). Preserves unrelated \`reverseProxy\` fields like \`publicDomain\` / \`lanDomain\`. Bypasses \`updateConfig\`'s deepMerge (which can't remove nested fields).

## Why this matters

User-locked decision: migration from today's damaged state is **clean baseline only** — no state-import shim. The existing stacks-reset endpoint with \`preserve: []\` wipes service data but leaves saved credentials in memory; the wizard pre-fills with them on the next run, defeating the point of the reset. This PR closes that gap.

## Test plan

- [x] \`npm run check:arch\` — 499 modules, no violations
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 988 pass / 2 skipped / 135 files; 5 new tests in \`clearSensitiveConfig.test.ts\`:
  - removes all five fields (\`installedSecrets\`, \`installManifest\`, \`lldap\`, \`adguard\`, \`reverseProxy.npm\`)
  - preserves operator-set \`reverseProxy.publicDomain\` / \`lanDomain\`
  - empty-config case (cleared list is \`[]\`, save still runs)
  - empty \`installedSecrets\` array is treated as already-cleared
  - never touches unrelated fields (\`serverName\`, \`autoUpdate\`, …)
- [x] \`npm run build\` — clean, new \`/api/system/factory-reset\` route registered
- [ ] **Live verify after deploy** (per #623 acceptance):
  - Click Factory Reset → type FACTORY-RESET → confirm. UI shows what was wiped.
  - \`mcp__servicebay__exec_command 'cat /var/mnt/data/servicebay/config.json'\` shows no \`installedSecrets\`, \`installManifest\`, \`lldap\`, \`adguard\`, \`reverseProxy.npm\`.
  - \`mcp__servicebay__exec_command 'ls /var/mnt/data/stacks'\` empty.
  - Re-opening the wizard shows blank pre-fills (full first-install flow).

## Out of scope

- Snapshot-before-reset (issue body called it out — would be nice but adds a day; the cert-archive snapshot in \`performStackReset\` is the only existing preservation).
- The \`PROTECTED_SERVICES\` set stays inside the engine; if we ever need to vary it (e.g. protecting \`agent\` too), I'll expose it as an option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)