### PR TITLE
feat(stacks): stack.yml manifest schema + parser + consistency lint (#624)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     ],
     "ignore": [
       "scripts/check-invariants.ts"
-    ]
+    ],
+    "ignoreExportsUsedInFile": true
   },
   "overrides": {
     "ellipsize": "^0.7.0",

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -5,6 +5,7 @@ import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getConfig, RegistryConfig } from './config';
 import { readManifestAnnotations } from './template/contract';
+import { parseStackManifest, type StackManifest } from './template/stackContract';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -94,8 +95,36 @@ export async function getTemplateSettingsSchema(): Promise<Record<string, Templa
 async function readTemplateMeta(
   itemDir: string,
   type: 'template' | 'stack',
+  name: string,
+  source: string,
 ): Promise<{ tier?: 'infrastructure' | 'feature'; dependencies: string[] }> {
-  if (type === 'stack') return { tier: undefined, dependencies: [] };
+  if (type === 'stack') {
+    // Stacks today are READMEs (`stacks/ai-stack/`, `stacks/full-stack/`).
+    // From #624 onward they MAY ship a `stack.yml` whose `servicebay.tier`
+    // annotation (`core` | `feature`) maps onto the existing template
+    // tier surface. README-only stacks keep returning empty meta — the
+    // wizard treats absence as "feature, no deps", same as before.
+    try {
+      const manifest = await getStackManifest(name, source);
+      if (manifest) {
+        return {
+          // `core` stacks present as `infrastructure` in the wizard's
+          // current shape — same gate as platform templates (auto-checked,
+          // can't be opted out of). Phase 5 introduces the explicit `core`
+          // tier; until then this mapping keeps the legacy UI behaviour.
+          tier: manifest.tier === 'core' ? 'infrastructure' : 'feature',
+          dependencies: manifest.dependsOnStacks,
+        };
+      }
+    } catch (e) {
+      // A malformed stack.yml shouldn't drop the stack from the registry
+      // listing — surface defaults so the operator still sees the stack
+      // (with a broken-manifest warning the consistency lint will catch
+      // at build time).
+      console.warn(`[registry] failed to load stack manifest for ${name}:`, e);
+    }
+    return { tier: undefined, dependencies: [] };
+  }
   try {
     const yaml = await fs.readFile(path.join(itemDir, 'template.yml'), 'utf-8');
     const annotations = readManifestAnnotations(yaml);
@@ -122,7 +151,7 @@ async function fetchDir(dirPath: string, type: 'template' | 'stack', source: str
 
     return await Promise.all(directories.map(async item => {
         const itemPath = path.join(dirPath, item.name);
-        const { tier, dependencies } = await readTemplateMeta(itemPath, type);
+        const { tier, dependencies } = await readTemplateMeta(itemPath, type, item.name, source);
         return {
             name: item.name,
             path: itemPath,
@@ -672,4 +701,54 @@ export async function getTemplateMigrationScripts(
   }
 
   return scanDir(path.join(TEMPLATES_PATH, name));
+}
+
+/**
+ * Read + parse a stack's `stack.yml` manifest (#624). Returns the parsed
+ * manifest, `null` when the stack has no `stack.yml` (README-only legacy),
+ * or throws when the file exists but is structurally broken — the caller
+ * (registry sync / consistency lint) should surface the error.
+ *
+ * Same registry-priority chain as `getTemplateYaml`: if `source` is
+ * pinned, read only from there; otherwise registries take priority over
+ * built-in. Throwing on parse failure (rather than returning `null`) is
+ * intentional — a typo'd annotation should never silently degrade to
+ * "no manifest, treat as README-only" because the wizard would then
+ * present the stack with default tier/lifecycle instead of complaining.
+ */
+export async function getStackManifest(
+  name: string,
+  source?: string,
+): Promise<StackManifest | null> {
+  const tryRead = async (dir: string): Promise<string | null> => {
+    try {
+      return await fs.readFile(path.join(dir, 'stack.yml'), 'utf-8');
+    } catch { return null; }
+  };
+
+  let yamlText: string | null = null;
+  if (source && source !== 'Built-in') {
+    yamlText = await tryRead(path.join(REGISTRIES_DIR, source, 'stacks', name));
+  } else {
+    if (!source) {
+      const config = await getConfig();
+      const registries = getRegistries(config);
+      for (const reg of registries) {
+        const found = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'stacks', name));
+        if (found !== null) { yamlText = found; break; }
+      }
+    }
+    if (yamlText === null) yamlText = await tryRead(path.join(STACKS_PATH, name));
+  }
+
+  if (yamlText === null) return null;
+
+  const result = parseStackManifest(yamlText);
+  if (!result.ok) {
+    throw new Error(
+      `stack \`${name}\` has an invalid stack.yml:\n` +
+      result.errors.map(e => `  - ${e}`).join('\n'),
+    );
+  }
+  return result.manifest;
 }

--- a/src/lib/template/stackContract.test.ts
+++ b/src/lib/template/stackContract.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Stack manifest parser — #624.
+ *
+ * Validates the shape both `getStackManifest` (registry runtime) and the
+ * `stack_consistency` build-time lint rely on. Each test is a single
+ * input + expected outcome — failures point at one rule.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseStackManifest, tryParseStackManifest } from './stackContract';
+
+const VALID_BASIC = `apiVersion: v1
+kind: Stack
+metadata:
+  name: basic
+  annotations:
+    servicebay.label: "Core services"
+    servicebay.tier: "core"
+    servicebay.lifecycle: "atomic-wipe"
+    servicebay.depends-on-stacks: ""
+spec:
+  templates: [nginx, auth, adguard]
+`;
+
+const VALID_FEATURE = `apiVersion: v1
+kind: Stack
+metadata:
+  name: immich
+  annotations:
+    servicebay.label: "Immich (Photos + AI search)"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates:
+    - immich
+`;
+
+describe('parseStackManifest — happy paths', () => {
+  it('parses a complete core stack manifest', () => {
+    const r = parseStackManifest(VALID_BASIC);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.manifest).toEqual({
+      name: 'basic',
+      label: 'Core services',
+      tier: 'core',
+      lifecycle: 'atomic-wipe',
+      dependsOnStacks: [],
+      templates: ['nginx', 'auth', 'adguard'],
+    });
+    expect(r.warnings).toEqual([]);
+  });
+
+  it('parses a feature stack and applies defaults (tier=feature, lifecycle=wipeable)', () => {
+    const r = parseStackManifest(VALID_FEATURE);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.manifest.tier).toBe('feature');
+    expect(r.manifest.lifecycle).toBe('wipeable');
+    expect(r.manifest.dependsOnStacks).toEqual(['basic']);
+    expect(r.manifest.templates).toEqual(['immich']);
+  });
+
+  it('handles comma-separated depends-on-stacks lists', () => {
+    const yamlText = VALID_FEATURE.replace('"basic"', '"basic, identity ,  media "');
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.manifest.dependsOnStacks).toEqual(['basic', 'identity', 'media']);
+  });
+
+  it('tryParseStackManifest returns the manifest on success', () => {
+    expect(tryParseStackManifest(VALID_BASIC)?.name).toBe('basic');
+  });
+});
+
+describe('parseStackManifest — structural errors', () => {
+  it('rejects non-mapping top-level documents', () => {
+    const r = parseStackManifest('- a\n- b\n');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/must be a YAML mapping/);
+  });
+
+  it('rejects malformed YAML with the parser error', () => {
+    const r = parseStackManifest('apiVersion: v1\n  bad: indent\n: missing-key');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/not valid YAML/);
+  });
+
+  it('rejects missing apiVersion / kind', () => {
+    const r = parseStackManifest(`metadata:
+  name: x
+  annotations:
+    servicebay.label: "x"
+spec:
+  templates: [foo]
+`);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /apiVersion/.test(e))).toBe(true);
+    expect(r.errors.some(e => /kind/.test(e))).toBe(true);
+  });
+
+  it('rejects missing metadata.name', () => {
+    const r = parseStackManifest(`apiVersion: v1
+kind: Stack
+metadata:
+  annotations:
+    servicebay.label: "x"
+spec:
+  templates: [foo]
+`);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /metadata\.name/.test(e))).toBe(true);
+  });
+
+  it('rejects missing servicebay.label', () => {
+    const r = parseStackManifest(`apiVersion: v1
+kind: Stack
+metadata:
+  name: x
+spec:
+  templates: [foo]
+`);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /servicebay\.label/.test(e))).toBe(true);
+  });
+});
+
+describe('parseStackManifest — annotation validation', () => {
+  it('rejects unknown tier values', () => {
+    const yamlText = VALID_BASIC.replace('"core"', '"platform"');
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/servicebay\.tier.*core.*feature/);
+  });
+
+  it('rejects unknown lifecycle values', () => {
+    const yamlText = VALID_BASIC.replace('"atomic-wipe"', '"reincarnate"');
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/servicebay\.lifecycle.*atomic-wipe.*wipeable/);
+  });
+
+  it('warns when atomic-wipe is used on a non-core tier', () => {
+    const yamlText = `apiVersion: v1
+kind: Stack
+metadata:
+  name: foo
+  annotations:
+    servicebay.label: "Foo"
+    servicebay.tier: "feature"
+    servicebay.lifecycle: "atomic-wipe"
+spec:
+  templates: [foo]
+`;
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.warnings.some(w => /atomic-wipe.*core/.test(w))).toBe(true);
+  });
+});
+
+describe('parseStackManifest — spec.templates validation', () => {
+  it('rejects a missing spec.templates field', () => {
+    const yamlText = `apiVersion: v1
+kind: Stack
+metadata:
+  name: foo
+  annotations:
+    servicebay.label: "Foo"
+spec:
+  somethingElse: 1
+`;
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /spec\.templates/.test(e))).toBe(true);
+  });
+
+  it('rejects an empty spec.templates list', () => {
+    const yamlText = `apiVersion: v1
+kind: Stack
+metadata:
+  name: foo
+  annotations:
+    servicebay.label: "Foo"
+spec:
+  templates: []
+`;
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /spec\.templates.* is empty/.test(e))).toBe(true);
+  });
+
+  it('rejects non-string entries in spec.templates', () => {
+    const yamlText = `apiVersion: v1
+kind: Stack
+metadata:
+  name: foo
+  annotations:
+    servicebay.label: "Foo"
+spec:
+  templates:
+    - foo
+    - 42
+    - ""
+`;
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /spec\.templates\[1\]/.test(e))).toBe(true);
+    expect(r.errors.some(e => /spec\.templates\[2\]/.test(e))).toBe(true);
+  });
+
+  it('rejects duplicate templates', () => {
+    const yamlText = `apiVersion: v1
+kind: Stack
+metadata:
+  name: foo
+  annotations:
+    servicebay.label: "Foo"
+spec:
+  templates: [a, b, a, c, b]
+`;
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /duplicates.*a.*b/.test(e))).toBe(true);
+  });
+});
+
+describe('parseStackManifest — self-dep', () => {
+  it('rejects a stack that lists itself in depends-on-stacks', () => {
+    const yamlText = `apiVersion: v1
+kind: Stack
+metadata:
+  name: foo
+  annotations:
+    servicebay.label: "Foo"
+    servicebay.depends-on-stacks: "bar, foo"
+spec:
+  templates: [foo]
+`;
+    const r = parseStackManifest(yamlText);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => /cannot depend on itself/.test(e))).toBe(true);
+  });
+});

--- a/src/lib/template/stackContract.ts
+++ b/src/lib/template/stackContract.ts
@@ -1,0 +1,269 @@
+/**
+ * Stack manifest parser (#624 / Phase 2A of the install rearchitecture).
+ *
+ * `stack.yml` is the structured sibling of `template.yml`: it groups one
+ * or more templates into a single lifecycle unit (install / wipe / health
+ * aggregate). Today the `stacks/` directory is README-only; this module
+ * is the contract that future `stack.yml` manifests must satisfy.
+ *
+ * Schema:
+ *
+ *   apiVersion: v1
+ *   kind: Stack
+ *   metadata:
+ *     name: basic
+ *     annotations:
+ *       servicebay.label: "Core services (NPM + LLDAP/Authelia + AdGuard)"
+ *       servicebay.tier: "core"             # core | feature
+ *       servicebay.lifecycle: "atomic-wipe" # atomic-wipe | wipeable
+ *       servicebay.depends-on-stacks: "basic"
+ *   spec:
+ *     templates: [nginx, auth, adguard]
+ *
+ * Why a separate file from `template/contract.ts`: stack.yml has none of
+ * template.yml's Mustache placeholders, so we can use a real YAML parser
+ * (`js-yaml`) instead of regex-based annotation reads. The template
+ * parser stays regex-based because it has to operate on un-rendered
+ * templates with `{{VAR}}` strings.
+ *
+ * No fs/Node deps — pure function, safe to import from React components.
+ */
+
+import yaml from 'js-yaml';
+
+/**
+ * Lifecycle tier. Drives the feature-install gate (#PH5C): if any
+ * `tier: core` stack is unhealthy, the wizard refuses to install any
+ * `tier: feature` stack.
+ */
+export type StackTier = 'core' | 'feature';
+const KNOWN_TIERS: ReadonlySet<StackTier> = new Set(['core', 'feature']);
+
+/**
+ * Wipe semantics. `atomic-wipe` is reserved for the core stack — wiping
+ * it is FACTORY RESET; the UI gates it behind explicit confirmation.
+ * `wipeable` is the default — operators can one-click wipe a feature
+ * stack at any time.
+ */
+export type StackLifecycle = 'atomic-wipe' | 'wipeable';
+const KNOWN_LIFECYCLES: ReadonlySet<StackLifecycle> = new Set(['atomic-wipe', 'wipeable']);
+
+/** Parsed stack metadata. Stable shape — both runtime + tests rely on it. */
+export interface StackManifest {
+  /** `metadata.name`. Required, must match the directory name (caller checks). */
+  name: string;
+  /** `metadata.annotations['servicebay.label']` — friendly UI label. Required. */
+  label: string;
+  /** `metadata.annotations['servicebay.tier']`. Defaults to `feature`. */
+  tier: StackTier;
+  /** `metadata.annotations['servicebay.lifecycle']`. Defaults to `wipeable`. */
+  lifecycle: StackLifecycle;
+  /**
+   * `metadata.annotations['servicebay.depends-on-stacks']` — comma-separated
+   * list of stack names that must be healthy before this stack installs.
+   * Whole-stack dependency, not per-template; the per-template dep graph
+   * (servicebay.dependencies on template.yml) still drives the deploy
+   * order *within* a stack. Empty when missing.
+   */
+  dependsOnStacks: string[];
+  /** `spec.templates`. Required, non-empty list of template names. */
+  templates: string[];
+}
+
+export type StackParseResult =
+  | { ok: true; manifest: StackManifest; warnings: string[] }
+  | { ok: false; errors: string[]; warnings: string[] };
+
+interface RawAnnotations {
+  [key: string]: unknown;
+}
+
+interface RawMetadata {
+  name?: unknown;
+  annotations?: unknown;
+}
+
+interface RawSpec {
+  templates?: unknown;
+}
+
+interface RawDoc {
+  apiVersion?: unknown;
+  kind?: unknown;
+  metadata?: unknown;
+  spec?: unknown;
+}
+
+/**
+ * Parse a stack.yml manifest. Pure function — caller passes the YAML text
+ * and gets back either a complete manifest or a list of human-readable
+ * errors. Does NOT verify that referenced template names exist on disk;
+ * that's the `stack_consistency` lint's job (runs over the file system).
+ */
+export function parseStackManifest(yamlText: string): StackParseResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  let doc: RawDoc;
+  try {
+    const loaded = yaml.load(yamlText);
+    if (loaded === null || typeof loaded !== 'object' || Array.isArray(loaded)) {
+      return {
+        ok: false,
+        errors: ['stack.yml must be a YAML mapping (top-level object with apiVersion/kind/metadata/spec keys).'],
+        warnings,
+      };
+    }
+    doc = loaded as RawDoc;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, errors: [`stack.yml is not valid YAML: ${msg}`], warnings };
+  }
+
+  if (doc.apiVersion !== 'v1') {
+    errors.push(`Field \`apiVersion\` must be "v1"; got ${JSON.stringify(doc.apiVersion ?? null)}.`);
+  }
+  if (doc.kind !== 'Stack') {
+    errors.push(`Field \`kind\` must be "Stack"; got ${JSON.stringify(doc.kind ?? null)}.`);
+  }
+
+  const meta: RawMetadata =
+    typeof doc.metadata === 'object' && doc.metadata !== null && !Array.isArray(doc.metadata)
+      ? (doc.metadata as RawMetadata)
+      : {};
+  const spec: RawSpec =
+    typeof doc.spec === 'object' && doc.spec !== null && !Array.isArray(doc.spec)
+      ? (doc.spec as RawSpec)
+      : {};
+
+  const name = typeof meta.name === 'string' ? meta.name.trim() : '';
+  if (!name) {
+    errors.push('Missing required field `metadata.name`. Set it to the stack directory name (e.g. `metadata.name: basic`).');
+  }
+
+  const annotations: RawAnnotations =
+    typeof meta.annotations === 'object' && meta.annotations !== null && !Array.isArray(meta.annotations)
+      ? (meta.annotations as RawAnnotations)
+      : {};
+
+  const label = readAnnotationString(annotations, 'servicebay.label');
+  if (!label) {
+    errors.push(
+      'Missing required annotation `servicebay.label`. Add it under `metadata.annotations` ' +
+      'with a friendly display name (e.g. `servicebay.label: "Immich (Photos)"`).',
+    );
+  }
+
+  let tier: StackTier = 'feature';
+  const tierRaw = readAnnotationString(annotations, 'servicebay.tier');
+  if (tierRaw !== undefined) {
+    if (KNOWN_TIERS.has(tierRaw as StackTier)) {
+      tier = tierRaw as StackTier;
+    } else {
+      errors.push(
+        `Annotation \`servicebay.tier\` must be one of ${[...KNOWN_TIERS].map(v => `"${v}"`).join(', ')}; ` +
+        `got "${tierRaw}".`,
+      );
+    }
+  }
+
+  let lifecycle: StackLifecycle = 'wipeable';
+  const lifecycleRaw = readAnnotationString(annotations, 'servicebay.lifecycle');
+  if (lifecycleRaw !== undefined) {
+    if (KNOWN_LIFECYCLES.has(lifecycleRaw as StackLifecycle)) {
+      lifecycle = lifecycleRaw as StackLifecycle;
+    } else {
+      errors.push(
+        `Annotation \`servicebay.lifecycle\` must be one of ${[...KNOWN_LIFECYCLES].map(v => `"${v}"`).join(', ')}; ` +
+        `got "${lifecycleRaw}".`,
+      );
+    }
+  }
+
+  // `atomic-wipe` only makes sense for core. Surface as a warning rather
+  // than an error so future combinations stay possible without a parser
+  // bump, but flag it loudly.
+  if (lifecycle === 'atomic-wipe' && tier !== 'core') {
+    warnings.push(
+      `Lifecycle \`atomic-wipe\` is intended for \`tier: core\` stacks only. ` +
+      `Stack \`${name || '?'}\` has tier "${tier}" — operators won't be able to wipe it from the UI.`,
+    );
+  }
+
+  const dependsRaw = readAnnotationString(annotations, 'servicebay.depends-on-stacks');
+  const dependsOnStacks = dependsRaw
+    ? dependsRaw.split(',').map(s => s.trim()).filter(Boolean)
+    : [];
+
+  const templatesRaw = spec.templates;
+  const templates: string[] = [];
+  if (!Array.isArray(templatesRaw)) {
+    errors.push('Missing required field `spec.templates`. Set it to a non-empty list of template names (e.g. `[nginx, auth]`).');
+  } else {
+    for (let i = 0; i < templatesRaw.length; i++) {
+      const entry = templatesRaw[i];
+      if (typeof entry !== 'string' || !entry.trim()) {
+        errors.push(`Field \`spec.templates[${i}]\` must be a non-empty string template name; got ${JSON.stringify(entry)}.`);
+        continue;
+      }
+      templates.push(entry.trim());
+    }
+    if (templates.length === 0 && templatesRaw.length === 0) {
+      errors.push('Field `spec.templates` is empty. A stack must own at least one template.');
+    }
+
+    // Duplicates in `spec.templates` make the topo-install order ambiguous
+    // and break the wipe step (the second entry's data dir is already
+    // gone by the time we get to it).
+    const seen = new Set<string>();
+    const dupes = new Set<string>();
+    for (const t of templates) {
+      if (seen.has(t)) dupes.add(t);
+      seen.add(t);
+    }
+    if (dupes.size > 0) {
+      errors.push(`Field \`spec.templates\` contains duplicates: ${[...dupes].join(', ')}.`);
+    }
+  }
+
+  // A stack that depends on itself is a structural error — surface here
+  // instead of letting the consistency lint catch it as a cycle, so the
+  // error message points at the offending stack directly.
+  if (name && dependsOnStacks.includes(name)) {
+    errors.push(`Annotation \`servicebay.depends-on-stacks\` lists \`${name}\` itself — a stack cannot depend on itself.`);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors, warnings };
+  }
+
+  return {
+    ok: true,
+    manifest: {
+      name,
+      label: label!,
+      tier,
+      lifecycle,
+      dependsOnStacks,
+      templates,
+    },
+    warnings,
+  };
+}
+
+/**
+ * Compact helper for callers that only care whether a manifest exists.
+ * Returns `null` when parsing fails. Use the full `parseStackManifest`
+ * when you need the error list (registry sync, consistency tests).
+ */
+export function tryParseStackManifest(yamlText: string): StackManifest | null {
+  const r = parseStackManifest(yamlText);
+  return r.ok ? r.manifest : null;
+}
+
+function readAnnotationString(annotations: RawAnnotations, key: string): string | undefined {
+  const val = annotations[key];
+  if (typeof val !== 'string') return undefined;
+  const trimmed = val.trim();
+  return trimmed === '' ? undefined : trimmed;
+}

--- a/tests/backend/stack_consistency.test.ts
+++ b/tests/backend/stack_consistency.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Stack ↔ codebase consistency suite (#624 / Phase 2A).
+ *
+ * Sibling of `template_consistency.test.ts`. Walks `stacks/`, parses
+ * every `stack.yml`, and asserts:
+ *   1. every manifest parses cleanly via `parseStackManifest`
+ *   2. every `spec.templates` entry resolves to an existing `templates/<name>/`
+ *   3. every `servicebay.depends-on-stacks` target resolves to another stack
+ *      that itself has a `stack.yml`
+ *   4. no dependency cycles between stacks (whole-stack graph)
+ *   5. `metadata.name` matches the directory name
+ *
+ * Stacks without a `stack.yml` (legacy README-only `ai-stack/`,
+ * `full-stack/`) are skipped — Phase 2B migrates them and at that
+ * point every directory will have one.
+ *
+ * No fs writes, no agent — pure file-system + parsing.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import { parseStackManifest, type StackManifest } from '../../src/lib/template/stackContract';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const STACKS_DIR = path.join(REPO_ROOT, 'stacks');
+const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates');
+
+interface StackOnDisk {
+  name: string;
+  yamlPath: string;
+  manifest: StackManifest;
+}
+
+function listStackDirs(): string[] {
+  if (!fs.existsSync(STACKS_DIR)) return [];
+  return fs.readdirSync(STACKS_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+    .map(d => d.name);
+}
+
+function templateExists(name: string): boolean {
+  const dir = path.join(TEMPLATES_DIR, name);
+  return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
+}
+
+/**
+ * Load every stack with a parseable `stack.yml`. The "parses cleanly"
+ * rule is asserted as its own test — this helper would otherwise need
+ * to either skip broken manifests (hiding regressions) or throw
+ * (corrupting every test downstream of it).
+ */
+function loadValidStacks(): { stacks: StackOnDisk[]; parseFailures: string[] } {
+  const stacks: StackOnDisk[] = [];
+  const parseFailures: string[] = [];
+  for (const name of listStackDirs()) {
+    const yamlPath = path.join(STACKS_DIR, name, 'stack.yml');
+    if (!fs.existsSync(yamlPath)) continue;
+    const text = fs.readFileSync(yamlPath, 'utf-8');
+    const result = parseStackManifest(text);
+    if (!result.ok) {
+      parseFailures.push(`${name}:\n  ${result.errors.join('\n  ')}`);
+      continue;
+    }
+    stacks.push({ name, yamlPath, manifest: result.manifest });
+  }
+  return { stacks, parseFailures };
+}
+
+describe('stack consistency', () => {
+  it('every stack.yml parses cleanly', () => {
+    const { parseFailures } = loadValidStacks();
+    if (parseFailures.length > 0) {
+      throw new Error(
+        `One or more stacks have invalid manifests:\n\n${parseFailures.join('\n\n')}\n\n` +
+        'Fix the listed annotations and re-run.',
+      );
+    }
+    // Bare assertion so the test still records a positive in test counts
+    // when no stacks have a manifest yet (Phase 2A is schema-only — Phase
+    // 2B will migrate the first stacks).
+    expect(parseFailures).toEqual([]);
+  });
+
+  it('metadata.name matches the directory name', () => {
+    const { stacks } = loadValidStacks();
+    const mismatches = stacks
+      .filter(s => s.manifest.name !== s.name)
+      .map(s => `${s.name}: metadata.name="${s.manifest.name}"`);
+    if (mismatches.length > 0) {
+      throw new Error(
+        `Stack directory and metadata.name must match:\n  ${mismatches.join('\n  ')}`,
+      );
+    }
+  });
+
+  it('every spec.templates entry resolves to an existing templates/<name>/', () => {
+    const { stacks } = loadValidStacks();
+    const missing: string[] = [];
+    for (const s of stacks) {
+      for (const t of s.manifest.templates) {
+        if (!templateExists(t)) {
+          missing.push(`stacks/${s.name} → templates/${t}/ (missing)`);
+        }
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `Stack manifest references a non-existent template:\n  ${missing.join('\n  ')}\n` +
+        'Either create the template directory or remove the entry from spec.templates.',
+      );
+    }
+  });
+
+  it('every servicebay.depends-on-stacks target resolves to another stack with a manifest', () => {
+    const { stacks } = loadValidStacks();
+    const knownStacks = new Set(stacks.map(s => s.name));
+    const dangling: string[] = [];
+    for (const s of stacks) {
+      for (const dep of s.manifest.dependsOnStacks) {
+        if (!knownStacks.has(dep)) {
+          dangling.push(`stacks/${s.name} → depends-on-stacks "${dep}" (not found)`);
+        }
+      }
+    }
+    if (dangling.length > 0) {
+      throw new Error(
+        `Stack manifest depends on an unknown stack:\n  ${dangling.join('\n  ')}\n` +
+        'Either create the dependency stack\'s manifest or remove the entry.',
+      );
+    }
+  });
+
+  it('the stack dependency graph has no cycles', () => {
+    const { stacks } = loadValidStacks();
+    const graph = new Map<string, string[]>();
+    for (const s of stacks) graph.set(s.name, s.manifest.dependsOnStacks);
+
+    // Three-state DFS — white / grey / black. A grey hit means a back-
+    // edge → cycle. Reports the involved nodes to point the operator at
+    // the right manifests to edit.
+    const WHITE = 0, GREY = 1, BLACK = 2;
+    const color = new Map<string, number>();
+    for (const name of graph.keys()) color.set(name, WHITE);
+
+    const cycles: string[][] = [];
+    const stack: string[] = [];
+
+    const visit = (node: string): boolean => {
+      color.set(node, GREY);
+      stack.push(node);
+      for (const dep of graph.get(node) ?? []) {
+        const c = color.get(dep);
+        if (c === undefined) continue; // dangling deps are caught by their own test
+        if (c === GREY) {
+          // Cycle: slice the path from `dep` to the current node, append
+          // dep again to make the closure obvious in the error.
+          const idx = stack.indexOf(dep);
+          cycles.push([...stack.slice(idx), dep]);
+          continue;
+        }
+        if (c === WHITE && visit(dep)) return true;
+      }
+      stack.pop();
+      color.set(node, BLACK);
+      return false;
+    };
+
+    for (const node of graph.keys()) {
+      if (color.get(node) === WHITE) visit(node);
+    }
+
+    if (cycles.length > 0) {
+      const detail = cycles.map(c => c.join(' → ')).join('\n  ');
+      throw new Error(`Stack dependency graph has cycle(s):\n  ${detail}`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #624. Part of #621 (Phase 2A).

Independent of Phase 1 (#636, #637) and the other Phase 2–4 PRs — branched from main.

## Summary

\`stack.yml\` becomes the structured sibling of \`template.yml\`: it groups one or more templates into a single lifecycle unit (install / wipe / health aggregate). This PR ships only the **schema, parser, registry loader, and consistency lint** — no actual \`stack.yml\` files yet. #625 (Phase 2B) migrates the existing templates; #633 (Phase 5) wires the runner.

### Files

- **\`src/lib/template/stackContract.ts\`** (new) — pure js-yaml parser. Validates \`apiVersion/kind/metadata.name\`, the \`servicebay.label/tier/lifecycle/depends-on-stacks\` annotation set, and \`spec.templates\`. Rejects duplicates, self-deps, invalid enum values. Returns a structured \`{ ok: true, manifest, warnings } | { ok: false, errors, warnings }\`.
- **\`src/lib/registry.ts\`**
  - New \`getStackManifest(name, source?)\` — registry-aware loader using the same registry→built-in priority chain as \`getTemplateYaml\`. Throws on parse failure rather than silently degrading to \"no manifest\".
  - \`readTemplateMeta\` now reads stack tier+depends-on-stacks from the manifest. \`core\` stacks present as \`infrastructure\` in the existing wizard surface; Phase 5 introduces the explicit \`core\` tier in the new stack runner.
- **\`tests/backend/stack_consistency.test.ts\`** (new) — build-time lint: every \`stack.yml\` parses, \`spec.templates\` entries resolve to \`templates/<name>/\`, \`depends-on-stacks\` targets resolve, no cycles, \`metadata.name\` matches the directory.
- **\`src/lib/template/stackContract.test.ts\`** (new) — 17 parser tests (happy paths, structural errors, annotation validation, spec.templates validation, self-dep rejection).
- **\`package.json\`** — knip \`ignoreExportsUsedInFile: true\` so registry helpers consumed by sibling private functions in the same module aren't flagged.

### Schema

\`\`\`yaml
apiVersion: v1
kind: Stack
metadata:
  name: basic
  annotations:
    servicebay.label: \"Core services (NPM + LLDAP/Authelia + AdGuard)\"
    servicebay.tier: \"core\"             # core | feature  (default: feature)
    servicebay.lifecycle: \"atomic-wipe\" # atomic-wipe | wipeable  (default: wipeable)
    servicebay.depends-on-stacks: \"basic\"
spec:
  templates: [nginx, auth, adguard]
\`\`\`

Why js-yaml instead of the template-contract's regex approach: stack.yml has none of template.yml's Mustache placeholders, so we can use a real YAML parser. The template parser stays regex-based because it has to operate on un-rendered templates with \`{{VAR}}\` strings.

## Test plan

- [x] \`npm run check:arch\` — 496 modules, no violations
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1005 pass / 2 skipped / 136 files (17 new parser tests + 5 new consistency-lint tests)
- [x] \`npx knip\` — clean
- [x] \`npm run build\` — clean
- [x] **Manual lint regression check** — created \`stacks/_bad-fixture/stack.yml\` with \`templates: [does-not-exist]\`, confirmed the consistency lint catches it with a clear message (\"stacks/_bad-fixture → templates/does-not-exist/ (missing)\"), then removed the fixture.

## Out of scope

- Any actual \`stack.yml\` files in \`stacks/\` (#625 / Phase 2B handles that).
- Using the manifest in the install runner, wizard, or wipe flow (#633 / Phase 5).
- Auto-generated stack docs table (the template equivalent has \`scripts/gen-template-docs.ts\` driven by \`TEMPLATE_FIELDS\`; the stack parser doesn't yet need one — trimmed the premature \`STACK_FIELDS\` table from the initial draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)