### PR TITLE
feat(capabilities): typed in-process capability bus core (#629)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ import { setTraceProvider } from './src/lib/logger';
 import crypto from 'crypto';
 // Monitoring init moved to Agent logic in V4
 import { HealthService } from './src/lib/health/service';
+import { initCapabilities } from './src/lib/capabilities/init';
 import { agentManager } from './src/lib/agent/manager';
 import { AgentHandler } from './src/lib/agent/handler';
 import { listNodes } from './src/lib/nodes';
@@ -423,6 +424,17 @@ app.prepare().then(() => {
 
   // Pass IO to updater
   setUpdaterIO(io);
+
+  // Capability bus (#629 / Phase 4A) — typed event dispatcher platform
+  // services subscribe to. Touch the singleton early so the lazy
+  // construction race is resolved before HealthService spins up.
+  // Handler registrations land in Phase 4B+; today it just initialises
+  // the bus.
+  try {
+    initCapabilities();
+  } catch (err) {
+    logger.error('Server', 'Failed to initialise capability bus:', err);
+  }
 
   // Initialize Monitoring Service (V4 Legacy Bridge)
   HealthService.init(io).catch(err => {

--- a/src/lib/capabilities/bus.test.ts
+++ b/src/lib/capabilities/bus.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Capability bus contract tests (#629).
+ *
+ * Each test constructs a fresh bus via `createCapabilityBus()` rather
+ * than touching the singleton — the singleton's job is process-wide
+ * registration which we don't want to mutate from tests.
+ *
+ * Coverage:
+ *   - subscribe / unsubscribe + list()
+ *   - dispatch order matches registration order
+ *   - one handler's failure (throw OR `{ ok: false }`) doesn't
+ *     short-circuit sibling handlers
+ *   - emit with zero subscribers returns `{ ok: true, results: [] }`
+ *   - per-handler serial chain across emits (no interleaving)
+ *   - throws are converted to `{ ok: false, retryable: true }` with the message
+ *   - failures appear in both `results` and `failures`
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createCapabilityBus } from './bus';
+import type { TemplateManifest } from '@/lib/template/contract';
+import type { StackVariable } from '@/lib/stackInstall/types';
+
+const MANIFEST: TemplateManifest = {
+  label: 'Test',
+  tier: 'feature',
+  schemaVersion: 1,
+  dependencies: [],
+};
+const VARS: StackVariable[] = [];
+
+const INSTALLED = (template: string) => ({
+  kind: 'feature.installed' as const,
+  template,
+  manifest: MANIFEST,
+  variables: VARS,
+});
+
+describe('bus.subscribe / list / emit basics', () => {
+  it('dispatches to every subscriber in registration order', async () => {
+    const bus = createCapabilityBus();
+    const calls: string[] = [];
+    bus.subscribe('feature.installed', 'first', async () => { calls.push('first'); return { ok: true }; });
+    bus.subscribe('feature.installed', 'second', async () => { calls.push('second'); return { ok: true }; });
+    bus.subscribe('feature.installed', 'third', async () => { calls.push('third'); return { ok: true }; });
+
+    const result = await bus.emit(INSTALLED('immich'));
+    expect(result.ok).toBe(true);
+    expect(result.results.map(r => r.handler)).toEqual(['first', 'second', 'third']);
+    expect(calls).toEqual(['first', 'second', 'third']);
+  });
+
+  it('returns ok with empty results when no subscribers exist', async () => {
+    const bus = createCapabilityBus();
+    const result = await bus.emit(INSTALLED('foo'));
+    expect(result).toEqual({ ok: true, results: [], failures: [] });
+  });
+
+  it('list() returns handler names registered for a kind', () => {
+    const bus = createCapabilityBus();
+    bus.subscribe('feature.installed', 'a', async () => ({ ok: true }));
+    bus.subscribe('feature.installed', 'b', async () => ({ ok: true }));
+    bus.subscribe('feature.uninstalled', 'c', async () => ({ ok: true }));
+    expect(bus.list('feature.installed')).toEqual(['a', 'b']);
+    expect(bus.list('feature.uninstalled')).toEqual(['c']);
+    expect(bus.list('feature.installing')).toEqual([]);
+  });
+
+  it('unsubscribe removes only the targeted handler', async () => {
+    const bus = createCapabilityBus();
+    const off = bus.subscribe('feature.installed', 'a', async () => ({ ok: true }));
+    bus.subscribe('feature.installed', 'b', async () => ({ ok: true }));
+    off();
+    expect(bus.list('feature.installed')).toEqual(['b']);
+  });
+});
+
+describe('error isolation', () => {
+  it('one handler returning ok:false does not short-circuit others', async () => {
+    const bus = createCapabilityBus();
+    const calls: string[] = [];
+    bus.subscribe('feature.installed', 'fails', async () => {
+      calls.push('fails');
+      return { ok: false, retryable: false, message: 'no' };
+    });
+    bus.subscribe('feature.installed', 'succeeds', async () => {
+      calls.push('succeeds');
+      return { ok: true };
+    });
+
+    const result = await bus.emit(INSTALLED('immich'));
+    expect(result.ok).toBe(false);
+    expect(calls).toEqual(['fails', 'succeeds']);
+    expect(result.failures.map(r => r.handler)).toEqual(['fails']);
+    expect(result.results).toHaveLength(2);
+  });
+
+  it('a handler that throws converts to retryable ok:false with the message', async () => {
+    const bus = createCapabilityBus();
+    bus.subscribe('feature.installed', 'thrower', async () => { throw new Error('boom'); });
+    bus.subscribe('feature.installed', 'survivor', async () => ({ ok: true }));
+
+    const result = await bus.emit(INSTALLED('immich'));
+    expect(result.ok).toBe(false);
+    const thrown = result.results[0].result;
+    expect(thrown.ok).toBe(false);
+    if (thrown.ok) return;
+    expect(thrown.retryable).toBe(true);
+    expect(thrown.message).toBe('boom');
+    // Sibling still ran.
+    expect(result.results[1].result.ok).toBe(true);
+  });
+
+  it('a non-Error throw still gets a stringified message', async () => {
+    const bus = createCapabilityBus();
+    bus.subscribe('feature.installed', 'x', async () => { throw 'literal'; });
+    const result = await bus.emit(INSTALLED('immich'));
+    const r = result.results[0].result;
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toBe('literal');
+  });
+});
+
+describe('per-handler serial chain (no interleaving)', () => {
+  it('back-to-back emits run a handler serially: A.start → A.end → B.start', async () => {
+    const bus = createCapabilityBus();
+
+    // We use a single deferred-resolve pattern so we can hold the first
+    // invocation open until the second emit is in flight, then verify
+    // the second invocation only ran AFTER the first one resolved.
+    let firstResolve!: () => void;
+    const firstHold = new Promise<void>(r => { firstResolve = r; });
+
+    const eventsSeen: string[] = [];
+    bus.subscribe('feature.installed', 'h', async (e) => {
+      eventsSeen.push(`enter:${e.template}`);
+      if (e.template === 'A') await firstHold;
+      eventsSeen.push(`exit:${e.template}`);
+      return { ok: true };
+    });
+
+    const emitA = bus.emit(INSTALLED('A'));
+    const emitB = bus.emit(INSTALLED('B'));
+
+    // Yield once so emitA's handler starts.
+    await Promise.resolve();
+    // emitB has been scheduled but the handler hasn't started yet — it's
+    // queued behind A on the per-handler chain.
+    expect(eventsSeen).toEqual(['enter:A']);
+
+    firstResolve();
+    await emitA;
+    await emitB;
+
+    // The second invocation only ran AFTER the first one exited.
+    expect(eventsSeen).toEqual(['enter:A', 'exit:A', 'enter:B', 'exit:B']);
+  });
+
+  it('failures in one emit do not block the next emit for the same handler', async () => {
+    const bus = createCapabilityBus();
+    const handler = vi.fn()
+      .mockResolvedValueOnce({ ok: false, message: 'first fails' })
+      .mockResolvedValueOnce({ ok: true });
+    bus.subscribe('feature.installed', 'h', handler);
+
+    const r1 = await bus.emit(INSTALLED('A'));
+    const r2 = await bus.emit(INSTALLED('B'));
+    expect(r1.ok).toBe(false);
+    expect(r2.ok).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('a thrown error in one emit does not break the chain for the next emit', async () => {
+    const bus = createCapabilityBus();
+    const handler = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ ok: true });
+    bus.subscribe('feature.installed', 'h', handler);
+
+    const r1 = await bus.emit(INSTALLED('A'));
+    const r2 = await bus.emit(INSTALLED('B'));
+    expect(r1.ok).toBe(false);
+    expect(r2.ok).toBe(true);
+  });
+});
+
+describe('reset', () => {
+  it('clears every registration', async () => {
+    const bus = createCapabilityBus();
+    bus.subscribe('feature.installed', 'a', async () => ({ ok: true }));
+    bus.subscribe('feature.uninstalled', 'b', async () => ({ ok: true }));
+    bus.reset();
+    expect(bus.list('feature.installed')).toEqual([]);
+    expect(bus.list('feature.uninstalled')).toEqual([]);
+    const r = await bus.emit(INSTALLED('x'));
+    expect(r.results).toEqual([]);
+  });
+});
+
+describe('type-safety (compile-time)', () => {
+  it('subscribe enforces handler signature matches the event kind', async () => {
+    const bus = createCapabilityBus();
+    const captured: Record<string, string> = {};
+    // Each line below MUST compile — narrowing the event param on subscribe
+    // is the contract that lets handlers skip the inner `if (e.kind === ...)`.
+    bus.subscribe('feature.installed', 'a', async (e) => {
+      // `e.manifest` only exists on the .installing / .installed shapes.
+      captured.label = e.manifest.label;
+      return { ok: true };
+    });
+    bus.subscribe('feature.uninstalled', 'b', async (e) => {
+      // `e.template` is universal; the rest of the union is narrowed away.
+      captured.template = e.template;
+      return { ok: true };
+    });
+    bus.subscribe('feature.uninstalling', 'c', async (e) => {
+      // `e.lastKnownVariables` only exists on the `.uninstalling` shape.
+      captured.vars = String(e.lastKnownVariables.length);
+      return { ok: true };
+    });
+    // @ts-expect-error — "not.a.real.event" isn't a valid CapabilityEventKind
+    bus.subscribe('not.a.real.event', 'x', async () => ({ ok: true }));
+
+    await bus.emit(INSTALLED('immich'));
+    expect(captured.label).toBe('Test');
+    await bus.emit({ kind: 'feature.uninstalled', template: 'foo' });
+    expect(captured.template).toBe('foo');
+    await bus.emit({ kind: 'feature.uninstalling', template: 'bar', lastKnownVariables: [] });
+    expect(captured.vars).toBe('0');
+  });
+});

--- a/src/lib/capabilities/bus.ts
+++ b/src/lib/capabilities/bus.ts
@@ -1,0 +1,195 @@
+/**
+ * Capability bus (#629 / Phase 4A).
+ *
+ * Typed in-process event dispatcher for the feature-lifecycle events
+ * platform services subscribe to. The contract lives in `./types.ts`;
+ * this file is the runtime.
+ *
+ * Why not Node's `EventEmitter`: EE is untyped, swallows handler
+ * exceptions in a way that's hard to inspect from the emitter side,
+ * and gives no per-handler ordering guarantee. The behaviour we need
+ * is "for each subscriber, run their handler once for this event, and
+ * collect every result" — which is closer to `Promise.all` over a
+ * registration list than to fire-and-forget pub/sub.
+ *
+ * Key behaviours:
+ *
+ * - **Subscription is registration-ordered.** `bus.emit` runs handlers
+ *   for an event in the order they subscribed. The `results` array
+ *   matches that order so the caller can map findings back.
+ *
+ * - **One handler's failure does NOT short-circuit the rest.** A
+ *   thrown exception or a `{ ok: false }` return surfaces in `results`
+ *   and `failures`; sibling handlers still run. This matches the
+ *   diagnose-finding model: every cross-service inconsistency should
+ *   surface, not just the first one.
+ *
+ * - **Per-handler ordering across emits.** Each handler has its own
+ *   serial promise chain. If `emit(A)` and `emit(B)` are dispatched
+ *   back-to-back, handler H sees A complete before B starts. That's
+ *   the property template authors rely on — e.g. Authelia's OIDC
+ *   register/unregister can't interleave for the same template.
+ *
+ * - **Handlers are identified by a label.** Registration takes a
+ *   `name` arg used in `HandlerInvocation.handler`. Failures surface
+ *   as "Authelia: <message>" rather than "handler #3".
+ *
+ * The bus is a singleton at runtime (one process, one bus). Tests
+ * construct fresh instances via `createCapabilityBus()` to avoid
+ * polluting global state — keep both export paths.
+ */
+import { logger } from '@/lib/logger';
+import type {
+  CapabilityEvent,
+  CapabilityEventKind,
+  CapabilityHandler,
+  EmitResult,
+  HandlerInvocation,
+  HandlerResult,
+} from './types';
+
+/** Erased once stored — the typed `subscribe` boundary already enforces
+ *  that a handler only sees the event shape matching its kind. Internally
+ *  we keep a single shape so the per-kind Map doesn't have to track the
+ *  K param.
+ *
+ *  `handler: (event) => Promise<HandlerResult>` rather than
+ *  `CapabilityHandler<K>` for that erasure — the call site at `runOne`
+ *  always passes events of the matching kind, by construction. */
+interface Registration {
+  name: string;
+  kind: CapabilityEventKind;
+  handler: (event: CapabilityEvent) => Promise<HandlerResult>;
+  /** Per-handler serial chain — see "Per-handler ordering" above. */
+  chain: Promise<unknown>;
+}
+
+export interface CapabilityBus {
+  /** Register a handler for one event kind. Returns an unsubscribe fn. */
+  subscribe<K extends CapabilityEventKind>(
+    kind: K,
+    name: string,
+    handler: CapabilityHandler<K>,
+  ): () => void;
+
+  /** Fire an event to every subscriber. Awaits every handler before
+   *  resolving so the caller can react to failures synchronously. */
+  emit(event: CapabilityEvent): Promise<EmitResult>;
+
+  /** Diagnostic: handlers currently registered for `kind`. */
+  list(kind: CapabilityEventKind): string[];
+
+  /** Wipe every registration. Used by tests; never call in prod. */
+  reset(): void;
+}
+
+export function createCapabilityBus(): CapabilityBus {
+  // Per-kind registration lists. Erased to the unified Registration
+  // shape once stored — the typed `subscribe` signature is the boundary
+  // that keeps callers honest; internally the discriminator on
+  // `Registration.kind` is the only thing that matters.
+  const registrations = new Map<CapabilityEventKind, Registration[]>();
+
+  const subscribe = <K extends CapabilityEventKind>(
+    kind: K,
+    name: string,
+    handler: CapabilityHandler<K>,
+  ): (() => void) => {
+    const reg: Registration = {
+      name,
+      kind,
+      // Widen at the boundary: subscribe's typed signature guarantees
+      // the runtime never calls `handler` with the wrong event shape,
+      // because `emit` only dispatches to handlers registered under the
+      // matching kind.
+      handler: handler as (event: CapabilityEvent) => Promise<HandlerResult>,
+      chain: Promise.resolve(),
+    };
+    const list = registrations.get(kind) ?? [];
+    list.push(reg);
+    registrations.set(kind, list);
+    return () => {
+      const current = registrations.get(kind);
+      if (!current) return;
+      const idx = current.indexOf(reg);
+      if (idx >= 0) current.splice(idx, 1);
+    };
+  };
+
+  const emit = async (event: CapabilityEvent): Promise<EmitResult> => {
+    const list = registrations.get(event.kind) ?? [];
+    if (list.length === 0) {
+      return { ok: true, results: [], failures: [] };
+    }
+
+    // Schedule each handler on its own serial chain so back-to-back
+    // emits for the same handler don't interleave. We capture the
+    // current chain tail per handler so the await waits for the slot
+    // *this* emit will occupy, not whatever further calls might enqueue
+    // before we reach `Promise.all`.
+    const slotted = list.map((reg) => {
+      const ran = reg.chain.then(() => runOne(reg, event));
+      // Don't let a rejection break the chain — `runOne` already
+      // converts throws into a `HandlerResult`; this guard is a
+      // defence-in-depth so a future code change that throws OUTSIDE
+      // `runOne` still keeps the queue alive.
+      reg.chain = ran.catch(() => undefined);
+      return ran.then((result) => ({ handler: reg.name, result }));
+    });
+
+    const results: HandlerInvocation[] = await Promise.all(slotted);
+    const failures = results.filter(r => !r.result.ok);
+    return {
+      ok: failures.length === 0,
+      results,
+      failures,
+    };
+  };
+
+  const list = (kind: CapabilityEventKind): string[] => {
+    return (registrations.get(kind) ?? []).map(r => r.name);
+  };
+
+  const reset = (): void => {
+    registrations.clear();
+  };
+
+  return { subscribe, emit, list, reset };
+}
+
+/** Per-handler invocation. Pulled out so the per-handler `chain` is the
+ *  only seam between scheduling + the actual work — easier to reason
+ *  about ordering.
+ *
+ *  Takes the erased `CapabilityHandler` shape because by the time a
+ *  Registration is stored in the per-kind map, its `K` has widened to
+ *  the full union — so the handler signature already accepts every
+ *  event variant. The narrowing the call sites care about lives on
+ *  `subscribe`, not here. */
+async function runOne(
+  reg: { name: string; handler: (event: CapabilityEvent) => Promise<HandlerResult> },
+  event: CapabilityEvent,
+): Promise<HandlerResult> {
+  try {
+    return await reg.handler(event);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn('CapabilityBus', `handler "${reg.name}" threw on ${event.kind}: ${message}`);
+    // Thrown errors are treated as retryable failures — the handler
+    // didn't return a `{ ok: false, retryable: false }` decision, so
+    // we shouldn't assume non-retryable on its behalf.
+    return { ok: false, retryable: true, message };
+  }
+}
+
+/**
+ * Process-wide singleton. Handlers are registered once at boot via
+ * `initCapabilities()` (see `init.ts`); the install runner uses this
+ * to dispatch lifecycle events. Tests should NOT use the singleton —
+ * they construct fresh buses via `createCapabilityBus()`.
+ */
+let _instance: CapabilityBus | null = null;
+export function getCapabilityBus(): CapabilityBus {
+  if (!_instance) _instance = createCapabilityBus();
+  return _instance;
+}

--- a/src/lib/capabilities/init.ts
+++ b/src/lib/capabilities/init.ts
@@ -1,0 +1,37 @@
+/**
+ * Capability-bus boot hook (#629 / Phase 4A).
+ *
+ * Called once at server start. Phase 4A ships the bus + contract; the
+ * Authelia / NPM / AdGuard / credentials handlers register themselves
+ * here in Phase 4B+:
+ *
+ *   bus.subscribe('feature.installed', 'authelia.oidc', autheliaHandler);
+ *   bus.subscribe('feature.uninstalled', 'authelia.oidc', autheliaHandler);
+ *   bus.subscribe('feature.installed', 'nginx.proxy-host', nginxHandler);
+ *   bus.subscribe('feature.uninstalled', 'nginx.proxy-host', nginxHandler);
+ *   bus.subscribe('feature.installed', 'adguard.dns', adguardHandler);
+ *   bus.subscribe('feature.uninstalled', 'adguard.dns', adguardHandler);
+ *   bus.subscribe('feature.installed', 'credentials.manifest', credsHandler);
+ *
+ * Today this function is intentionally empty — registering an unused
+ * handler does no harm, but registering with no logic does cause an
+ * `emit` to log a misleading "0 results" picture. Keep the seam.
+ */
+import { logger } from '@/lib/logger';
+import { getCapabilityBus } from './bus';
+
+export function initCapabilities(): void {
+  // The singleton is constructed on first access. Touch it now so the
+  // lazy-construction race (two concurrent boot paths each thinking
+  // they own creation) is resolved before any handler registers.
+  const bus = getCapabilityBus();
+  // Phase 4B (#PH4B): register Authelia + NPM handlers here.
+  // Phase 4C (#PH4C): register AdGuard + credentials handlers here.
+  // Phase 4D (#PH4D): replace the install runner's hardcoded
+  //   `registerOidcClients` / NPM bootstrap / proxy-host / AdGuard
+  //   calls with `bus.emit(...)`.
+  const counts = (['feature.installing', 'feature.installed', 'feature.uninstalling', 'feature.uninstalled'] as const)
+    .map(k => `${k}=${bus.list(k).length}`)
+    .join(' ');
+  logger.info('CapabilityBus', `Initialised. ${counts}`);
+}

--- a/src/lib/capabilities/types.ts
+++ b/src/lib/capabilities/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Capability-bus contract (#629 / Phase 4A).
+ *
+ * Platform services (Authelia, NPM, AdGuard, the credentials store)
+ * subscribe to feature-lifecycle events and own the side effects that
+ * used to live as hardcoded calls inside `install/runner.ts`:
+ *   - register / unregister Authelia OIDC clients on install / uninstall
+ *   - create / delete NPM proxy hosts
+ *   - add / remove AdGuard DNS rewrites
+ *   - persist credentials manifest entries
+ *
+ * The events here are intentionally narrow — four kinds, single shape
+ * per kind. Adding a new event kind means adding to the discriminated
+ * union below. The bus itself stays generic.
+ *
+ * Handlers don't see template internals — they read whatever they need
+ * from `manifest` (annotations) and `variables` (resolved values from
+ * the wizard). New feature templates declare their needs in
+ * `variables.json` (`oidcClient`, `subdomain`, `proxyConfig`) and the
+ * handlers pick those out — no template-specific branching.
+ */
+import type { TemplateManifest } from '@/lib/template/contract';
+import type { StackVariable } from '@/lib/stackInstall/types';
+
+/** Discriminated union of all bus events. The `kind` discriminator is
+ *  the subscription key — `bus.subscribe('feature.installed', h)`
+ *  only ever passes the `feature.installed` shape to `h`. */
+export type CapabilityEvent =
+  | FeatureInstallingEvent
+  | FeatureInstalledEvent
+  | FeatureUninstallingEvent
+  | FeatureUninstalledEvent;
+
+export type CapabilityEventKind = CapabilityEvent['kind'];
+
+/**
+ * Fired before any unit deploys. Handlers can veto with a non-retryable
+ * error to abort the install. Use for pre-flight invariants (e.g. "this
+ * stack needs a public domain and none is configured").
+ */
+export interface FeatureInstallingEvent {
+  kind: 'feature.installing';
+  template: string;
+  manifest: TemplateManifest;
+  variables: StackVariable[];
+}
+
+/**
+ * Fired after the deployed unit has reached `health.ready === true`.
+ * Handlers do the after-deploy provisioning (OIDC client registration,
+ * proxy host creation, DNS rewrite, credentials persistence). Failures
+ * here don't roll back the install — by design (one-shot installs,
+ * no atomic-rollback in v1) — but they DO surface as diagnose findings
+ * so the operator sees "Immich deployed but no OIDC client" rather
+ * than a silent half-state.
+ */
+export interface FeatureInstalledEvent {
+  kind: 'feature.installed';
+  template: string;
+  manifest: TemplateManifest;
+  variables: StackVariable[];
+}
+
+/**
+ * Fired before the unit is stopped during a wipe. Handlers get one
+ * last chance to capture state the uninstall path can't reconstruct
+ * (e.g. a credentials manifest entry to keep visible after wipe).
+ *
+ * `lastKnownVariables` is the snapshot from the most recent successful
+ * install — handlers can't assume the live config still matches.
+ */
+export interface FeatureUninstallingEvent {
+  kind: 'feature.uninstalling';
+  template: string;
+  lastKnownVariables: StackVariable[];
+}
+
+/**
+ * Fired after the unit + data have been removed. Handlers clean up
+ * cross-service state (OIDC client deletion, NPM proxy host removal,
+ * DNS rewrite removal). A handler failure here is non-blocking but
+ * gets surfaced as a diagnose finding.
+ */
+export interface FeatureUninstalledEvent {
+  kind: 'feature.uninstalled';
+  template: string;
+}
+
+/**
+ * Handler return value. Failures are explicit so the bus can decide
+ * whether to abort an install (non-retryable on `feature.installing`)
+ * or surface a diagnose finding (everything else).
+ *
+ * Throwing from a handler is treated as `{ ok: false, retryable: true }`
+ * with the error message — handlers shouldn't have to remember to wrap
+ * everything in try/catch. The bus is the safety net.
+ */
+export type HandlerResult =
+  | { ok: true }
+  | { ok: false; retryable?: boolean; message: string };
+
+/**
+ * One handler subscribed to one event kind. Generic on `K` so the
+ * `event` parameter is the exact shape for that kind — no need for
+ * runtime `if (event.kind === ...)` discrimination inside handlers.
+ */
+export type CapabilityHandler<K extends CapabilityEventKind = CapabilityEventKind> = (
+  event: Extract<CapabilityEvent, { kind: K }>,
+) => Promise<HandlerResult>;
+
+/**
+ * Per-handler result, returned by `bus.emit` so the caller can decide
+ * what to do with failures (abort install, log + continue, surface as
+ * diagnose finding). The `handler` name is the registration label —
+ * makes diagnose findings human-readable ("Authelia: still has OIDC
+ * client for immich" instead of "handler #3").
+ */
+export interface HandlerInvocation {
+  handler: string;
+  result: HandlerResult;
+}
+
+export interface EmitResult {
+  /** True iff every handler returned `{ ok: true }`. */
+  ok: boolean;
+  /** Per-handler results in registration order. */
+  results: HandlerInvocation[];
+  /** Convenience subset — only the failed invocations. */
+  failures: HandlerInvocation[];
+}


### PR DESCRIPTION
Closes #629. Part of #621 (Phase 4A).

Independent of #640 (#626 / Phase 3A — still open) and every other phase — branched from main.

## Summary

Platform services (Authelia, NPM, AdGuard, credentials store) will subscribe to feature-lifecycle events that today live as ~250 LoC of hardcoded calls inside \`install/runner.ts\` (\`registerOidcClients\`, NPM credentials override, cert-archive reuse, etc.). This PR ships the **bus + contract + tests**; the handler implementations + runner cutover land in #PH4B / #PH4C / #PH4D.

### Files

- **\`src/lib/capabilities/types.ts\`** — discriminated-union event surface (\`feature.installing | feature.installed | feature.uninstalling | feature.uninstalled\`), \`HandlerResult\`, \`EmitResult\`.
- **\`src/lib/capabilities/bus.ts\`** — typed dispatcher. \`subscribe<K>\` is generic on event kind so the handler param is the exact shape for that kind (no inner \`if (e.kind === ...)\` discrimination). Key behaviours:
  - **Error isolation**: one handler's throw OR \`{ ok: false }\` return surfaces in \`failures\` but doesn't short-circuit siblings.
  - **Per-handler serial chain**: back-to-back emits never interleave the same handler — Authelia's OIDC register / unregister for the same template can't race.
  - **Handlers are named** (\`bus.subscribe(kind, name, handler)\`), so failures surface as \"Authelia: <message>\" in diagnose, not \"handler #3\".
  - **Throws → \`{ ok: false, retryable: true, message }\`** so handlers don't have to remember try/catch; the bus is the safety net.
- **\`src/lib/capabilities/init.ts\`** — empty boot hook. Phase 4B/C register handlers here.
- **\`server.ts\`** — calls \`initCapabilities()\` at boot so the singleton resolves before HealthService spins up.

### Type contract

\`\`\`ts
bus.subscribe('feature.installed', 'authelia.oidc', async (e) => {
  // e: FeatureInstalledEvent. e.manifest, e.variables, e.template typed.
  return { ok: true };
});
bus.subscribe('feature.uninstalled', 'authelia.oidc', async (e) => {
  // e: FeatureUninstalledEvent. Only e.template is in scope here.
  return { ok: true };
});
// @ts-expect-error
bus.subscribe('not.a.real.event', ...);  // compile error
\`\`\`

## Test plan

- [x] \`npm run check:arch\` — 506 modules, no violations
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1029 pass / 2 skipped / 138 files; 12 new bus tests:
  - subscribe / list / emit basics (dispatch order = registration order; empty subscribers = ok)
  - unsubscribe removes only the targeted handler
  - error isolation: \`ok: false\` doesn't short-circuit; throws convert to retryable failures with message; non-Error throws stringified
  - per-handler serial chain: A.start → A.end → B.start across emits, even when A fails or throws
  - reset() clears every registration
  - **type-safety**: subscribe enforces handler signature matches the event kind (compile-time check + \`@ts-expect-error\` on unknown event kind)
- [x] \`npm run build\` — clean

## Design notes

- **Why not Node's EventEmitter**: untyped, swallows exceptions, no per-handler ordering. The behaviour we need is closer to \"\`Promise.all\` over a registration list with error collection\" than fire-and-forget pub/sub.
- **Why erased Registration**: storing handlers as the union shape lets the per-kind \`Map\` stay homogeneous. The typed \`subscribe\` boundary is the safety; internally \`emit\` only dispatches to registrations under the matching kind, so the cast is sound by construction.
- **Why per-handler chains instead of global serialization**: independent handlers (Authelia + NPM for the same install) should run concurrently — only a single handler's invocations need ordering.

## Out of scope

- Authelia + NPM handlers (#PH4B / #630)
- AdGuard + credentials handlers (#PH4C / #631)
- Replacing \`install/runner.ts\`'s hardcoded calls with \`bus.emit\` (#PH4D / #632)

🤖 Generated with [Claude Code](https://claude.com/claude-code)