### PR TITLE
feat(install): cut runner.ts over to capability bus events (#632)

### DIFF
--- a/src/app/api/install/credentials/route.ts
+++ b/src/app/api/install/credentials/route.ts
@@ -8,8 +8,9 @@ export const dynamic = 'force-dynamic';
 /**
  * Resume a paused install with operator-supplied NPM admin credentials.
  * The runner is awaiting an in-memory promise keyed by `jobId`; this
- * endpoint resolves it with the supplied creds so the deploy loop can
- * retry `configureProxyRoutes` with them.
+ * endpoint resolves it with the supplied creds. The runner saves them
+ * to `config.reverseProxy.npm` and lets the nginx capability handler
+ * pick them up on the next emit.
  */
 export async function POST(request: Request) {
   // requireSession gate (#596) — defense-in-depth atop proxy.ts.

--- a/src/lib/install/jobStore.ts
+++ b/src/lib/install/jobStore.ts
@@ -59,8 +59,8 @@ export interface JobInputItem {
 }
 
 /** Persisted variable shape. `meta` is intentionally `unknown` — only
- *  the runner re-types it when reading (see `meta?.oidcClient` access in
- *  registerOidcClients). The type system isn't load-bearing here. */
+ *  consumers re-type it when reading (see `meta?.oidcClient` access in
+ *  the Authelia capability handler). The type system isn't load-bearing here. */
 export interface JobInputVariable {
   name: string;
   value: string;

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -29,17 +29,19 @@ import Mustache from 'mustache';
 import {
   getTemplatePostDeployScript,
   getTemplateMigrationScripts,
+  getTemplateYaml,
 } from '@/lib/registry';
 import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
+import { parseTemplateManifest } from '@/lib/template/contract';
 import { topoSortByDependencies } from '@/lib/stackInstall/dependencies';
 import { selectMigrationChain } from '@/lib/stackInstall/migrations';
 import {
-  runPostInstall,
-  configureProxyRoutes,
+  bootstrapNpmAdmin,
   type StackVariable,
 } from '@/lib/stackInstall/postInstall';
 import { buildCredentialsManifest, type Credential } from '@/lib/stackInstall/credentialsManifest';
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
+import { getCapabilityBus } from '@/lib/capabilities/bus';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { getConfig, saveConfig } from '@/lib/config';
@@ -201,46 +203,6 @@ async function settleWait(
     await log(jobId, `✅ All ${expected.length} services active after ${elapsed}s.`);
   } else {
     await log(jobId, `⚠️ ${lastReady}/${expected.length} services active after ${elapsed}s — slow image pulls or a real failure. Self-diagnose below will tell you which.`);
-  }
-}
-
-/** Cross-template OIDC client registration. One POST collects every
- *  checked template's clients in a single call. */
-async function registerOidcClients(
-  jobId: string,
-  checkedItems: JobInputItem[],
-  vars: StackVariable[],
-  templateSource: string,
-): Promise<void> {
-  if (!vars.find(v => v.name === 'PUBLIC_DOMAIN')?.value) return;
-  const hasOidcClients = vars.some(v => v.meta?.oidcClient && v.meta?.type === 'subdomain' && v.value);
-  if (!hasOidcClients) return;
-
-  await log(jobId, 'Registering OIDC clients with Authelia...');
-  const variableValues = vars.reduce<Record<string, string>>((acc, v) => {
-    acc[v.name] = v.value;
-    return acc;
-  }, {});
-  try {
-    const res = await apiFetch('/api/system/authelia/oidc-clients', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        templates: checkedItems.map(i => ({ name: i.name, source: templateSource })),
-        variables: variableValues,
-      }),
-    });
-    const data = await res.json().catch(() => ({}));
-    if (res.ok) {
-      if (data.added?.length) await log(jobId, `✅ OIDC clients registered: ${data.added.join(', ')}`);
-      if (data.skipped?.length) await log(jobId, `ℹ️ Already registered: ${data.skipped.join(', ')}`);
-    } else if (res.status === 404) {
-      await log(jobId, '⚠️ Authelia not deployed — OIDC clients not registered. Deploy Authelia first, then redeploy this service.');
-    } else {
-      await log(jobId, `⚠️ Could not register OIDC clients: ${data.error || 'unknown error'}`);
-    }
-  } catch {
-    await log(jobId, '⚠️ Could not reach Authelia. Register OIDC clients manually.');
   }
 }
 
@@ -777,95 +739,114 @@ async function runJob(jobId: string): Promise<void> {
     }
   }
 
-  // Post-install — NPM bootstrap + proxy hosts.
+  // Post-install — NPM bootstrap (seeds admin creds). #632 moved the
+  // bulk proxy-host / OIDC-client / DNS-rewrite / credentials-manifest
+  // work to capability handlers; this section only handles the operator-
+  // interactive NPM credentials prompt that doesn't fit the bus pattern.
   const variables = input.variables as StackVariable[];
-  const proxyResult = await runPostInstall({
-    selected: ctx.deployed.map(d => ({ name: d.name, checked: true })),
-    variables,
-    node: input.node || undefined,
-    onLog: (line: string) => { void log(jobId, line); },
-    extraCredentials: scriptCredentials,
-  });
+  const newlyDeployed = new Set(ctx.deployed.map(d => d.name).filter(name => {
+    const item = input.items.find(i => i.name === name);
+    return item && !item.alreadyInstalled;
+  }));
 
-  await registerOidcClients(jobId, input.items.filter(i => i.checked), variables, input.templateSource);
+  if (newlyDeployed.has('nginx')) {
+    const bootstrap = await bootstrapNpmAdmin({
+      variables,
+      node: input.node || undefined,
+      onLog: (line: string) => { void log(jobId, line); },
+    });
+    if (bootstrap === 'needs_credentials') {
+      // Prefer credentials saved in config over wizard's newly-generated
+      // ones — we're in this branch because NPM rejected the wizard
+      // values, so re-prompting with the same string is just confusing.
+      const savedNpm = (await getConfig()).reverseProxy?.npm;
+      const fallback = {
+        email: savedNpm?.email
+          || variables.find(v => v.name === 'NGINX_ADMIN_EMAIL')?.value
+          || '',
+        password: savedNpm?.password
+          || variables.find(v => v.name === 'NGINX_ADMIN_PASSWORD')?.value
+          || '',
+      };
+      const creds = await waitForCredentials(jobId, fallback);
+      if (abortFlags.get(jobId)) {
+        await patchJob(jobId, { phase: 'aborted', endedAt: new Date().toISOString() });
+        return;
+      }
+      if (creds) {
+        await patchJob(jobId, { phase: 'running', needsCredentials: undefined });
+        // Persist so the nginx capability handler (and every other call
+        // site through getNpmToken) picks up these creds.
+        await apiFetch('/api/system/nginx/credentials', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(creds),
+        }).catch(() => undefined);
+        // Also override the in-memory variables so subsequent emits use
+        // them (the proxy-host POST honours wizard-generated creds, but
+        // operator-supplied ones land in config and get picked up via
+        // getNpmToken's fallback chain).
+        for (const v of variables) {
+          if (v.name === 'NGINX_ADMIN_EMAIL') v.value = creds.email;
+          if (v.name === 'NGINX_ADMIN_PASSWORD') v.value = creds.password;
+        }
+        await log(jobId, 'Saved NPM credentials for future installs.');
+      } else {
+        await log(jobId, '⚠️ NPM credentials skipped — proxy routes may not be configured.');
+        await patchJob(jobId, { phase: 'running', needsCredentials: undefined });
+      }
+    }
+  }
 
-  // Build the final credentials manifest now so the Done UI has it as
-  // soon as the job lands in `done`.
+  // Per-template capability events (#632). Each newly-deployed template
+  // fires `feature.installed`; subscribed handlers (Authelia OIDC, NPM
+  // proxy hosts, AdGuard DNS, credentials manifest) do their cross-
+  // service registration. Handlers are idempotent — re-emitting is safe.
+  const bus = getCapabilityBus();
+  for (const name of newlyDeployed) {
+    try {
+      const yamlText = await getTemplateYaml(name, input.templateSource);
+      if (!yamlText) {
+        await log(jobId, `(note) skipped capability emit for ${name}: template.yml not found`);
+        continue;
+      }
+      const parsed = parseTemplateManifest(yamlText);
+      if (!parsed.ok) {
+        await log(jobId, `(note) skipped capability emit for ${name}: ${parsed.errors.join('; ')}`);
+        continue;
+      }
+      const result = await bus.emit({
+        kind: 'feature.installed',
+        template: name,
+        manifest: parsed.manifest,
+        variables,
+      });
+      for (const f of result.failures) {
+        // Surface as diagnose-style log lines but don't abort — handler
+        // failures are recoverable and the operator can retry the
+        // specific service via diagnose actions.
+        if (!f.result.ok) {
+          await log(jobId, `⚠️ ${f.handler} (${name}): ${f.result.message}`);
+        }
+      }
+    } catch (e) {
+      await log(jobId, `(note) capability emit failed for ${name}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // Build the final credentials manifest for the Done UI. Handler
+  // already persisted per-template entries to `config.installManifest`
+  // (credentials capability handler); this builds the JOB-STATE manifest
+  // the wizard's Done step reads.
   const manifest = [
     ...buildCredentialsManifest({ variables, host: input.host }),
     ...scriptCredentials,
   ];
   await patchJob(jobId, { credentialsManifest: manifest });
 
-  // NPM credentials prompt (mid-flow user input). Pause here until the
-  // operator submits or skips.
-  if (proxyResult === 'needs_credentials') {
-    // Prefer the credentials already saved in config over the wizard's
-    // newly-generated ones. We're only in this branch because NPM
-    // rejected the wizard creds — pre-filling the prompt with the same
-    // rejected password just confuses the operator (they think it's a
-    // valid password and copy it into NPM, where it still fails). The
-    // saved creds were what worked the last time NPM accepted anything,
-    // so they're the most plausible guess for what NPM's DB still holds.
-    const savedNpm = (await getConfig()).reverseProxy?.npm;
-    const fallback = {
-      email: savedNpm?.email
-        || variables.find(v => v.name === 'NGINX_ADMIN_EMAIL')?.value
-        || '',
-      password: savedNpm?.password
-        || variables.find(v => v.name === 'NGINX_ADMIN_PASSWORD')?.value
-        || '',
-    };
-    const creds = await waitForCredentials(jobId, fallback);
-    if (abortFlags.get(jobId)) {
-      await patchJob(jobId, { phase: 'aborted', endedAt: new Date().toISOString() });
-      return;
-    }
-    if (creds) {
-      await log(jobId, 'Retrying with provided credentials...');
-      await patchJob(jobId, { phase: 'running', needsCredentials: undefined });
-      const retry = await configureProxyRoutes({
-        variables,
-        node: input.node || undefined,
-        onLog: (line: string) => { void log(jobId, line); },
-        credentials: creds,
-        skipWait: true,
-      });
-      if (retry === 'needs_credentials') {
-        await log(jobId, '❌ Authentication failed. Please check your credentials.');
-        // Re-pause for another attempt.
-        const second = await waitForCredentials(jobId, fallback);
-        if (!second) {
-          await patchJob(jobId, { phase: 'running', needsCredentials: undefined });
-        } else {
-          await configureProxyRoutes({
-            variables,
-            node: input.node || undefined,
-            onLog: (line: string) => { void log(jobId, line); },
-            credentials: second,
-            skipWait: true,
-          });
-          await apiFetch('/api/system/nginx/credentials', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(second),
-          }).catch(() => undefined);
-        }
-      } else {
-        await apiFetch('/api/system/nginx/credentials', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(creds),
-        }).catch(() => undefined);
-        await log(jobId, 'Saved NPM credentials for future installs.');
-      }
-    } else {
-      await log(jobId, 'NPM credentials skipped — proxy routes were not configured.');
-      await patchJob(jobId, { phase: 'running', needsCredentials: undefined });
-    }
-  }
-
-  // Portal routing — only meaningful when AdGuard is in the stack.
+  // Portal routing — apex + wildcard rewrites for the active domain.
+  // Stays here (not a per-template concern): runs once after AdGuard is
+  // deployed in this stack.
   if (ctx.deployed.some(d => d.name === 'adguard')) {
     await log(jobId, 'Provisioning AdGuard DNS rewrites + portal routing...');
     await provisionPortalWithRetries((line: string) => { void log(jobId, line); });

--- a/src/lib/stackInstall/credentialsManifest.ts
+++ b/src/lib/stackInstall/credentialsManifest.ts
@@ -86,37 +86,11 @@ export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
   return out;
 }
 
-/** Format a manifest as a banner-style block for the install log. */
-export function formatCredentialsBanner(manifest: Credential[]): string[] {
-  if (manifest.length === 0) return [];
-  const critical = manifest.filter(c => c.importance === 'critical');
-  const system = manifest.filter(c => c.importance === 'system');
-  const lines: string[] = [
-    '',
-    '═══════════════════════════════════════════════════',
-    'CREDENTIALS — saved encrypted at Settings → Integrations → Saved credentials',
-    '═══════════════════════════════════════════════════',
-  ];
-  for (const c of critical) {
-    lines.push(`  ${c.service}`);
-    lines.push(`    URL:      ${c.url}`);
-    lines.push(`    User:     ${c.username}`);
-    lines.push(`    Password: ${c.password}`);
-    if (c.notes) lines.push(`    ↳ ${c.notes}`);
-    lines.push('');
-  }
-  if (system.length) {
-    lines.push('───── system / disaster-recovery (rarely needed) ─────');
-    for (const c of system) {
-      lines.push(`  ${c.service}: ${c.password}`);
-      if (c.notes) lines.push(`    ↳ ${c.notes}`);
-    }
-    lines.push('');
-  }
-  lines.push('Visible in Settings → Integrations → Saved credentials, or download a Bitwarden CSV from the Done step.');
-  lines.push('═══════════════════════════════════════════════════');
-  return lines;
-}
+// #632 removed `formatCredentialsBanner` — the install runner no longer
+// dumps the manifest into the deploy log. The wizard's Done UI reads
+// the same data from `job.credentialsManifest` and the credentials
+// capability handler persists each template's entries to
+// `config.installManifest`.
 
 /** Build a Bitwarden-import-ready CSV. Bitwarden's importer is forgiving on
  *  column order; we use the canonical set documented at

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -26,7 +26,6 @@
 
 import Mustache from 'mustache';
 import type { VariableMeta } from '@/lib/registry';
-import { buildCredentialsManifest, formatCredentialsBanner, type Credential } from './credentialsManifest';
 import { expandForwardAuthSentinel } from './forwardAuth';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { getConfig } from '@/lib/config';
@@ -51,48 +50,10 @@ function apiFetch(p: string, init?: RequestInit): Promise<Response> {
 export { type StackVariable } from './types';
 import type { StackVariable } from './types';
 
-/** Selected stack item shape (subset, only what post-install needs). */
-interface StackItem {
-  name: string;
-  checked: boolean;
-}
-
-/** Format elapsed milliseconds as `Mm Ss` for human-readable log lines. */
-function fmtElapsed(ms: number): string {
-  const total = Math.floor(ms / 1000);
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return m > 0 ? `${m}m ${s}s` : `${s}s`;
-}
-
-/** Wait for NPM to become reachable. Polls every 3s, heartbeat log every 30s. */
-async function waitForNpm(
-  node: string | undefined,
-  onProgress: (msg: string) => void,
-  maxWait = 60 * 60_000,
-): Promise<boolean> {
-  const start = Date.now();
-  let lastBeat = 0;
-  while (Date.now() - start < maxWait) {
-    try {
-      const query = node ? `?node=${node}` : '';
-      const res = await apiFetch(`/api/system/nginx/status${query}`);
-      if (res.ok) {
-        const data = await res.json();
-        if (data.installed && data.active) return true;
-      }
-    } catch { /* keep trying */ }
-    const elapsed = Date.now() - start;
-    // 10-second heartbeat — frequent enough that the user sees forward
-    // motion without spamming the log on long waits.
-    if (elapsed - lastBeat >= 10_000) {
-      onProgress(`Still waiting for Nginx Proxy Manager (${fmtElapsed(elapsed)} elapsed)...`);
-      lastBeat = elapsed;
-    }
-    await new Promise(r => setTimeout(r, 3000));
-  }
-  return false;
-}
+// #632 removed `waitForNpm` — the /api/system/nginx/bootstrap endpoint
+// already retries the target-creds login for 90s server-side, which
+// subsumes the pre-call reachability poll. NPM-startup waiting now
+// happens inside the bootstrap endpoint.
 
 /**
  * Render Mustache placeholders inside an NPM proxyConfig (mainly the
@@ -187,88 +148,10 @@ export function buildProxyHosts(variables: StackVariable[]): {
   return { domain, hosts };
 }
 
-export type ProxyResult = 'ok' | 'needs_credentials' | 'skipped' | 'error';
-
-interface ConfigureProxyOpts {
-  variables: StackVariable[];
-  node?: string;
-  onLog: (msg: string) => void;
-  credentials?: { email: string; password: string };
-  /** Skip the NPM-readiness wait (used when caller already waited). */
-  skipWait?: boolean;
-}
-
-/** Configure NPM proxy hosts, returns 'needs_credentials' if NPM rejected
- *  the default/stored creds — caller is expected to prompt the user and
- *  call again with `credentials` set. */
-export async function configureProxyRoutes(opts: ConfigureProxyOpts): Promise<ProxyResult> {
-  const { variables, node, onLog, credentials, skipWait } = opts;
-  const { domain, hosts } = buildProxyHosts(variables);
-  // Public mode: PUBLIC_DOMAIN set + at least one host built. LAN-only
-  // mode (no PUBLIC_DOMAIN) is intentionally not handled here — proxy
-  // routing on `.home.arpa` exists only for individual lan-exposed hosts
-  // alongside a public install. Pure LAN-mode reverse proxy is a
-  // separate flow.
-  if (!domain || hosts.length === 0) return 'skipped';
-
-  if (!credentials && !skipWait) {
-    onLog('Waiting for Nginx Proxy Manager to start (image pull / DB schema init can take a while)...');
-    const ready = await waitForNpm(node, onLog);
-    if (!ready) {
-      onLog('⚠️ Nginx Proxy Manager not ready. Configure proxy routes manually in the NPM admin panel.');
-      return 'skipped';
-    }
-    onLog('Configuring reverse proxy routes...');
-  }
-
-  try {
-    const res = await apiFetch('/api/system/nginx/proxy-hosts', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        hosts,
-        publicDomain: domain,
-        node: node || undefined,
-        ...(credentials ? { npmCredentials: credentials } : {}),
-      }),
-    });
-    const data = await res.json();
-    if (res.ok && data.created?.length) {
-      onLog(`✅ Proxy routes created: ${data.created.join(', ')}`);
-      if (data.failed?.length) {
-        onLog(`⚠️ Some routes failed: ${data.failed.map((f: { domain: string }) => f.domain).join(', ')}`);
-      }
-      // Surface per-host cert outcomes for the public-exposure hosts.
-      // Failures here are not fatal — the cert_request_failure diagnose
-      // probe parses NPM's letsencrypt.log and lets the operator click
-      // Retry once the underlying cause is fixed.
-      type CertResult = { domain: string; issued: boolean; error?: string };
-      const certs: CertResult[] = Array.isArray(data.certs) ? data.certs : [];
-      const issued = certs.filter(c => c.issued).map(c => c.domain);
-      const failedCerts = certs.filter(c => !c.issued);
-      if (issued.length > 0) {
-        onLog(`🔒 Let's Encrypt certs issued: ${issued.join(', ')}`);
-      }
-      for (const fc of failedCerts) {
-        onLog(`⚠️ Cert request for ${fc.domain} failed — ${fc.error ?? 'see diagnose page for details'}.`);
-      }
-      const lanRestricted: string[] = Array.isArray(data.lanRestricted) ? data.lanRestricted : [];
-      if (lanRestricted.length > 0) {
-        onLog(`🛡️ LAN-only access list applied to ${lanRestricted.length} host${lanRestricted.length === 1 ? '' : 's'}: ${lanRestricted.join(', ')}`);
-      }
-      return 'ok';
-    }
-    if (res.status === 401 && data.needsCredentials) {
-      onLog('⚠️ NPM default credentials did not work. Please enter your NPM admin credentials below.');
-      return 'needs_credentials';
-    }
-    onLog(`⚠️ Proxy route error: ${data.error || 'unknown'}`);
-    return 'error';
-  } catch {
-    onLog('⚠️ Could not reach Nginx Proxy Manager.');
-    return 'error';
-  }
-}
+// #632 removed `configureProxyRoutes` — the nginx capability handler
+// now creates proxy hosts per-template via the same /api/system/nginx/
+// proxy-hosts endpoint, with the cert + lan-restriction + forward-auth
+// logic unchanged on the server side.
 
 /** Bootstrap a freshly-deployed NPM: log it in with built-in defaults
  *  (admin@example.com / changeme), apply the wizard's chosen email + password
@@ -284,7 +167,7 @@ export async function configureProxyRoutes(opts: ConfigureProxyOpts): Promise<Pr
  *
  *  This stays in the engine (rather than nginx-web/post-deploy.py) because
  *  the tri-state result drives the wizard's NPM-credentials prompt UI. */
-async function bootstrapNpmAdmin(opts: {
+export async function bootstrapNpmAdmin(opts: {
   variables: StackVariable[];
   node?: string;
   onLog: (msg: string) => void;
@@ -352,87 +235,9 @@ async function bootstrapNpmAdmin(opts: {
   }
 }
 
-interface RunPostInstallOpts {
-  selected: StackItem[];
-  variables: StackVariable[];
-  node?: string;
-  onLog: (msg: string) => void;
-  /**
-   * Credentials parsed from `__SB_CREDENTIAL__` markers a template's
-   * post-deploy.py emitted on stdout. Appended to the SAVE-THESE-NOW
-   * banner.
-   */
-  extraCredentials?: Credential[];
-}
-
-/** Orchestrate every post-install step. Returns the proxy-route status so
- *  the caller can decide whether to render the NPM-credential prompt.
- *
- *  Per-template seed/credential-surfacing logic runs as part of each
- *  service's post-deploy.py script during deploy (see ServiceManager.
- *  runPostDeployScript). This function only handles cross-template
- *  concerns: NPM bootstrap, proxy-host aggregation, and the final
- *  credentials banner. */
-export async function runPostInstall(opts: RunPostInstallOpts): Promise<ProxyResult> {
-  const { selected, variables, node, onLog, extraCredentials } = opts;
-  const isSelected = (name: string) => selected.some(i => i.name === name);
-
-  // NPM bootstrap is best-effort: if it fails we still want to run the
-  // proxy-route step — the user can finish the NPM piece via the
-  // credentials prompt.
-  let npmBootstrap: 'ok' | 'needs_credentials' | 'skipped' = 'skipped';
-  if (isSelected('nginx')) {
-    // NPM cold-starts the SQLite schema after the container is ready, so the
-    // very first /api/tokens call sometimes 502s. Wait until it's reachable
-    // before bootstrapping; configureProxyRoutes below would do the same wait
-    // anyway, just less informatively.
-    onLog('Waiting for Nginx Proxy Manager to start (image pull / DB schema init can take a while)...');
-    await waitForNpm(node, onLog);
-    npmBootstrap = await bootstrapNpmAdmin({ variables, node, onLog });
-  }
-
-  // If we just bootstrapped NPM (or determined it's locked to other creds),
-  // we already waited for it to be reachable — skip the second wait inside
-  // configureProxyRoutes so the install log doesn't repeat the heartbeat.
-  const proxyResult = await configureProxyRoutes({
-    variables,
-    node,
-    onLog,
-    skipWait: npmBootstrap !== 'skipped',
-  });
-
-  // Final banner — one block collecting every credential the user may need
-  // to remember. Built from `__SB_CREDENTIAL__` markers each template's
-  // post-deploy.py emitted plus the variable-driven OIDC entries derived
-  // from variables[].meta.oidcClient.
-  const host = typeof window !== 'undefined' ? window.location.hostname : '';
-  const manifest = [
-    ...buildCredentialsManifest({ variables, host }),
-    ...(extraCredentials ?? []),
-  ];
-  formatCredentialsBanner(manifest).forEach(onLog);
-
-  // Persist the manifest so the operator can come back to "what's the
-  // LLDAP admin password?" days later without keeping the install log
-  // open. Encrypted at rest via SENSITIVE_KEYS on the password field
-  // (#19 / A1). Best-effort: a failure here doesn't block the install.
-  if (manifest.length > 0) {
-    try {
-      const res = await apiFetch('/api/system/credentials', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ credentials: manifest }),
-      });
-      if (res.ok) {
-        onLog(`💾 Saved ${manifest.length} credential${manifest.length === 1 ? '' : 's'} to Settings → Credentials. Wipe them from there once you've stored them safely elsewhere.`);
-      } else {
-        const data = await res.json().catch(() => ({}));
-        onLog(`⚠️ Couldn't persist the credentials manifest (${data.error ?? `HTTP ${res.status}`}) — they're still shown above; copy them now.`);
-      }
-    } catch (e) {
-      onLog(`⚠️ Couldn't reach the credentials endpoint (${e instanceof Error ? e.message : String(e)}) — copy the credentials above before continuing.`);
-    }
-  }
-
-  return proxyResult;
-}
+// #632 removed `runPostInstall` (the bulk orchestrator that called
+// `configureProxyRoutes` + `registerOidcClients` + manifest persist).
+// The install runner now drives each step itself: `bootstrapNpmAdmin`
+// for NPM bootstrap, `bus.emit('feature.installed', ...)` per template
+// for OIDC + proxy hosts + DNS rewrites + credentials manifest. The
+// helpers below stay exported for diagnose / portal-provisioner reuse.


### PR DESCRIPTION
Closes #632. Part of #621 (Phase 4D). Builds on #629/#630/#631 (Phase 4A–C handlers), all merged.

## Summary

With the bus and four handlers in production, the install runner no longer needs to know how to register OIDC clients, create proxy hosts, add DNS rewrites, or persist credentials. Per-template \`feature.installed\` events fire after deploy + NPM bootstrap; the handlers do their cross-service work in parallel.

### Removed (~250 LoC)

**\`install/runner.ts\`:**
- \`registerOidcClients\` function + call site (Authelia handler now subscribes)
- \`runPostInstall\` call site → replaced with direct \`bootstrapNpmAdmin\` + bus.emit per template
- \`configureProxyRoutes\` retry block in the NPM-credentials prompt flow

**\`stackInstall/postInstall.ts\`** (no remaining callers):
- \`runPostInstall\`, \`configureProxyRoutes\`, \`formatCredentialsBanner\`, \`waitForNpm\`, \`fmtElapsed\`

### Added (~125 LoC)

- Per-template \`feature.installed\` emit loop after bootstrap. Reads each newly-deployed template's manifest via \`parseTemplateManifest\`; handler failures log as diagnose-style warnings but don't abort the install.

### Kept (explicitly out-of-scope per #632 body)

- Cert-archive snapshot/restore — pre-deploy data move, not a registration.
- NPM bootstrap state machine — operator-interactive credentials prompt. Now invoked directly via the exported \`bootstrapNpmAdmin\`.
- Portal-routing apex/wildcard provision — stack-wide, not per-template.
- \`buildCredentialsManifest\` for the job-state manifest the wizard Done UI reads. The credentials capability handler persists per-template entries to \`config.installManifest\` separately.

## Test plan

- [x] \`npm run check:arch\` — 521 modules, no violations
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1091 pass / 2 skipped / 144 files (no regressions; the handlers' own test coverage validates the work the runner used to do)
- [x] \`npx knip\` — clean (deleted exports verified unused)
- [x] \`npm run build\` — clean
- [x] \`git grep registerOidcClients src/\` returns nothing
- [ ] **Live verify** (after deploy):
  - Real install of all 10 services on a clean box produces identical Authelia clients + NPM hosts + AdGuard rewrites + credentials manifest as before
  - Re-running the same install fires the bus events but every handler returns \`{ ok: true }\` no-op

## Net delta

5 files changed, 126 insertions, 365 deletions. ~-239 LoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)