### PR TITLE
feat(stacks): migrate existing templates to stack manifests (#625)

### DIFF
--- a/stacks/ai-stack/stack.yml
+++ b/stacks/ai-stack/stack.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: ai-stack
+  annotations:
+    servicebay.label: "AI stack (Ollama + Hermes)"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  # Two-template stack: ollama is the LLM runtime, hermes is the
+  # ServiceBay-side chat UI. Install order is derived from each
+  # template's `servicebay.dependencies` annotation — hermes depends on
+  # ollama, so the topo-sort within this stack puts ollama first.
+  templates: [ollama, hermes]

--- a/stacks/basic/README.md
+++ b/stacks/basic/README.md
@@ -1,0 +1,18 @@
+# Basic stack
+
+ServiceBay's core platform services — the three templates every feature
+stack depends on:
+
+- **nginx** — Nginx Proxy Manager: reverse proxy + Let's Encrypt certs
+- **auth** — LLDAP + Authelia: identity provider, SSO, family-account
+  management
+- **adguard** — AdGuard Home: LAN DNS with split-horizon rewrites for
+  `<sub>.<public-domain>` resolution
+
+This stack is `tier: core` — every feature stack's install is gated on
+it being healthy. Wiping is gated behind FACTORY RESET (Settings → System
+→ Factory Reset) so identity state and Let's Encrypt cert quota can't be
+lost by accident.
+
+Per-template details live in `templates/nginx/`, `templates/auth/`,
+`templates/adguard/`.

--- a/stacks/basic/stack.yml
+++ b/stacks/basic/stack.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: basic
+  annotations:
+    servicebay.label: "Core services (NPM + LLDAP/Authelia + AdGuard)"
+    servicebay.tier: "core"
+    # `atomic-wipe` gates the stack-wipe button behind explicit FACTORY
+    # RESET — the core stack carries identity + cert state every feature
+    # depends on, so it can't be one-click wiped from the UI.
+    servicebay.lifecycle: "atomic-wipe"
+spec:
+  templates: [nginx, auth, adguard]

--- a/stacks/file-share/README.md
+++ b/stacks/file-share/README.md
@@ -1,0 +1,4 @@
+# File-share stack
+
+Single-template stack. See `templates/file-share/README.md` for service
+details.

--- a/stacks/file-share/stack.yml
+++ b/stacks/file-share/stack.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: file-share
+  annotations:
+    servicebay.label: "File share (Filebrowser + Samba)"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates: [file-share]

--- a/stacks/home-assistant/README.md
+++ b/stacks/home-assistant/README.md
@@ -1,0 +1,6 @@
+# Home Assistant stack
+
+Single-template stack. See `templates/home-assistant/README.md` for
+service details. The `voice` stack carries the voice-assistant pieces
+that used to live in this template (extracted in 2025) — install both
+together if you want voice control.

--- a/stacks/home-assistant/stack.yml
+++ b/stacks/home-assistant/stack.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: home-assistant
+  annotations:
+    servicebay.label: "Home Assistant"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates: [home-assistant]

--- a/stacks/immich/README.md
+++ b/stacks/immich/README.md
@@ -1,0 +1,4 @@
+# Immich stack
+
+Single-template stack. See `templates/immich/README.md` for service
+details.

--- a/stacks/immich/stack.yml
+++ b/stacks/immich/stack.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: immich
+  annotations:
+    servicebay.label: "Immich (Photos + AI search)"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates: [immich]

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,4 @@
+# Media stack
+
+Single-template stack. See `templates/media/README.md` for service
+details.

--- a/stacks/media/stack.yml
+++ b/stacks/media/stack.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: media
+  annotations:
+    servicebay.label: "Media (Jellyfin + Audiobookshelf)"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates: [media]

--- a/stacks/radicale/README.md
+++ b/stacks/radicale/README.md
@@ -1,0 +1,4 @@
+# Radicale stack
+
+Single-template stack. See `templates/radicale/README.md` for service
+details.

--- a/stacks/radicale/stack.yml
+++ b/stacks/radicale/stack.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: radicale
+  annotations:
+    servicebay.label: "Radicale (CalDAV + CardDAV)"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates: [radicale]

--- a/stacks/vaultwarden/README.md
+++ b/stacks/vaultwarden/README.md
@@ -1,0 +1,4 @@
+# Vaultwarden stack
+
+Single-template stack. See `templates/vaultwarden/README.md` for service
+details.

--- a/stacks/vaultwarden/stack.yml
+++ b/stacks/vaultwarden/stack.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: vaultwarden
+  annotations:
+    servicebay.label: "Vaultwarden (Passwords)"
+    servicebay.tier: "feature"
+    servicebay.depends-on-stacks: "basic"
+spec:
+  templates: [vaultwarden]

--- a/stacks/voice/README.md
+++ b/stacks/voice/README.md
@@ -1,0 +1,7 @@
+# Voice stack
+
+Voice-assistant pipeline (Whisper STT, Piper TTS, OpenWakeWord) for Home
+Assistant. Was extracted from the `home-assistant` template; cross-stack
+dependency keeps the two paired.
+
+See `templates/voice/README.md` for service details.

--- a/stacks/voice/stack.yml
+++ b/stacks/voice/stack.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: voice
+  annotations:
+    servicebay.label: "Voice (Whisper + Piper + OpenWakeWord)"
+    servicebay.tier: "feature"
+    # Hard cross-stack dep: voice was extracted from home-assistant and
+    # the voice pipeline only makes sense alongside HA's voice-assistant
+    # integration. Phase 5 enforces this as a refuse-to-install gate.
+    servicebay.depends-on-stacks: "basic, home-assistant"
+spec:
+  templates: [voice]


### PR DESCRIPTION
Closes #625. Part of #621 (Phase 2B). Builds on #624 (stack manifest schema/parser, merged in v4.4.0).

## Summary

Authors a \`stack.yml\` for every group of templates so Phase 5's stack runner has manifests to operate on. **Pure data-only change** — no behaviour change in the wizard yet.

### Manifests created

| Stack | Templates | Depends on |
|---|---|---|
| \`basic\` (core, atomic-wipe) | nginx, auth, adguard | — |
| \`vaultwarden\` | vaultwarden | basic |
| \`immich\` | immich | basic |
| \`file-share\` | file-share | basic |
| \`home-assistant\` | home-assistant | basic |
| \`voice\` | voice | basic, home-assistant |
| \`media\` | media | basic |
| \`radicale\` | radicale | basic |
| \`ai-stack\` | ollama, hermes | basic (existing README preserved) |

### Notes

- \`stacks/full-stack/\` stays README-only — it's a wizard preset (\"Full Home Server\" 10-template selection), not a real stack. Phase 5 will decide whether to elevate it to a meta-stack-of-stacks.
- \`voice\` carries a hard \`depends-on-stacks: basic, home-assistant\` because voice was extracted from HA and only makes sense alongside HA's voice-assistant integration. Phase 5 enforces this as a refuse-to-install gate.

## Test plan

- [x] \`npm test\` — 1099 pass / 2 skipped / 144 files; \`stack_consistency.test.ts\` from #624 validates: every \`templates:\` entry resolves, every \`depends-on-stacks\` target resolves, no cycles, \`metadata.name\` matches the directory.
- [x] \`npm run check:arch\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)