### PR TITLE
feat(install): stack runner + stack-level health aggregation (#633)

### DIFF
--- a/src/lib/install/stackHealth.test.ts
+++ b/src/lib/install/stackHealth.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Stack-health aggregation tests (#633).
+ *
+ * Tests the pure `aggregateStackHealth` over fixture maps — the
+ * runtime `getStackHealth` (which reads the twin singleton + registry)
+ * is tested at integration scope.
+ */
+import { describe, it, expect } from 'vitest';
+import { aggregateStackHealth } from './stackHealth';
+
+describe('aggregateStackHealth', () => {
+  it('returns ready=true when every child is ready', () => {
+    const r = aggregateStackHealth(['nginx', 'auth'], new Map([
+      ['nginx', { ready: true }],
+      ['auth', { ready: true }],
+    ]));
+    expect(r.ready).toBe(true);
+    expect(r.children).toEqual({ nginx: 'ready', auth: 'ready' });
+    expect(r.hasAnySignal).toBe(true);
+  });
+
+  it('returns ready=false when any child is unhealthy', () => {
+    const r = aggregateStackHealth(['nginx', 'auth'], new Map([
+      ['nginx', { ready: true }],
+      ['auth', { ready: false }],
+    ]));
+    expect(r.ready).toBe(false);
+    expect(r.children).toEqual({ nginx: 'ready', auth: 'unhealthy' });
+  });
+
+  it('marks children with no health signal as unknown', () => {
+    const r = aggregateStackHealth(['nginx', 'auth'], new Map([
+      ['nginx', { ready: true }],
+      // auth missing entirely
+    ]));
+    expect(r.ready).toBe(false);
+    expect(r.children.auth).toBe('unknown');
+  });
+
+  it('all-unknown stacks report hasAnySignal=false', () => {
+    const r = aggregateStackHealth(['a', 'b'], new Map());
+    expect(r.ready).toBe(false);
+    expect(r.hasAnySignal).toBe(false);
+  });
+
+  it('degraded propagates from any child', () => {
+    const r = aggregateStackHealth(['a'], new Map([
+      ['a', { ready: true, degraded: true }],
+    ]));
+    expect(r.ready).toBe(true);
+    expect(r.degraded).toBe(true);
+  });
+
+  it('empty stack reports ready=false (nothing to aggregate)', () => {
+    const r = aggregateStackHealth([], new Map());
+    expect(r.ready).toBe(false);
+    expect(r.children).toEqual({});
+  });
+});

--- a/src/lib/install/stackHealth.ts
+++ b/src/lib/install/stackHealth.ts
@@ -1,0 +1,90 @@
+/**
+ * Stack-level health aggregation (#633 / Phase 5A).
+ *
+ * One value answers "is stack X healthy?" by joining each child
+ * template's `twin.services[].health.ready` field (populated by the
+ * service-health poller from #626).
+ *
+ * Used by:
+ *   - The cross-stack dependency gate (`stackRunner.canInstall`) —
+ *     refuses to install a stack whose declared dependencies aren't
+ *     all `ready`.
+ *   - Phase 5C's tier-status gate — feature-stack installs are
+ *     blocked when any `tier: core` stack reports `ready: false`.
+ *
+ * Children with no health record yet are reported as `unknown`. The
+ * caller decides whether to treat that as ready (e.g. during the
+ * first 30 seconds after a fresh deploy before the poller has run)
+ * or as a hard fail.
+ */
+import { DigitalTwinStore } from '@/lib/store/twin';
+import { getStackManifest } from '@/lib/registry';
+
+export type ChildHealthState = 'ready' | 'unhealthy' | 'unknown';
+
+export interface StackHealth {
+  /** True iff every child reports ready=true. `unknown` counts as not-ready. */
+  ready: boolean;
+  /** True if any child is reachable but reports degraded. Informational. */
+  degraded: boolean;
+  /** Per-child status. Keys are template names from the stack manifest. */
+  children: Record<string, ChildHealthState>;
+  /** When at least one child has been probed at all. Distinguishes "fully
+   *  uninstalled" from "fresh boot, poller hasn't run". */
+  hasAnySignal: boolean;
+}
+
+/** Pure version — caller provides the twin snapshot and the manifest.
+ *  Exposed for testing without needing to bootstrap the singleton. */
+export function aggregateStackHealth(
+  templateNames: readonly string[],
+  serviceHealthByName: ReadonlyMap<string, { ready: boolean; degraded?: boolean } | undefined>,
+): StackHealth {
+  const children: Record<string, ChildHealthState> = {};
+  let degraded = false;
+  let hasAnySignal = false;
+  let allReady = templateNames.length > 0;
+  for (const name of templateNames) {
+    const h = serviceHealthByName.get(name);
+    if (!h) {
+      children[name] = 'unknown';
+      allReady = false;
+      continue;
+    }
+    hasAnySignal = true;
+    if (h.degraded) degraded = true;
+    if (h.ready) {
+      children[name] = 'ready';
+    } else {
+      children[name] = 'unhealthy';
+      allReady = false;
+    }
+  }
+  return { ready: allReady, degraded, children, hasAnySignal };
+}
+
+/**
+ * Runtime entry point: look up the stack manifest, scan the twin for
+ * each child template's health, return aggregated result.
+ *
+ * Returns `null` when the stack has no manifest (legacy README-only).
+ * Throws when the manifest exists but is structurally broken (per
+ * `getStackManifest`'s contract — caught by the consistency lint at
+ * build time, surfaces here only on a runtime registry mismatch).
+ */
+export async function getStackHealth(
+  stackName: string,
+  nodeName: string = 'Local',
+): Promise<StackHealth | null> {
+  const manifest = await getStackManifest(stackName);
+  if (!manifest) return null;
+  const twin = DigitalTwinStore.getInstance();
+  const node = twin.nodes[nodeName];
+  const services = node?.services ?? [];
+  const map = new Map<string, { ready: boolean; degraded?: boolean }>();
+  for (const svc of services) {
+    if (!svc.health) continue;
+    map.set(svc.name, { ready: svc.health.ready, degraded: svc.health.degraded });
+  }
+  return aggregateStackHealth(manifest.templates, map);
+}

--- a/src/lib/install/stackRunner.test.ts
+++ b/src/lib/install/stackRunner.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Stack-runner tests (#633).
+ *
+ * Mocks the registry + twin so we drive the runner with deterministic
+ * fixtures. The actual per-template deploy is supplied via the
+ * `deployTemplate` callback in `StackInstallOptions` — tests stub it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StackManifest } from '@/lib/template/stackContract';
+
+const getStackManifestMock = vi.fn<(name: string) => Promise<StackManifest | null>>();
+vi.mock('@/lib/registry', () => ({
+  getStackManifest: (name: string) => getStackManifestMock(name),
+}));
+
+const twinStub: {
+  nodes: Record<string, { services?: Array<{ name: string; health?: { ready: boolean; degraded?: boolean } }> }>;
+} = { nodes: {} };
+vi.mock('@/lib/store/twin', () => ({
+  DigitalTwinStore: { getInstance: () => twinStub },
+}));
+
+import { installStack, preflightCrossStackDeps, prepareStackInstall } from './stackRunner';
+
+const basic: StackManifest = {
+  name: 'basic',
+  label: 'Core',
+  tier: 'core',
+  lifecycle: 'atomic-wipe',
+  dependsOnStacks: [],
+  templates: ['nginx', 'auth', 'adguard'],
+};
+
+const immich: StackManifest = {
+  name: 'immich',
+  label: 'Immich',
+  tier: 'feature',
+  lifecycle: 'wipeable',
+  dependsOnStacks: ['basic'],
+  templates: ['immich'],
+};
+
+beforeEach(() => {
+  getStackManifestMock.mockReset();
+  twinStub.nodes = {};
+});
+
+function setNodeHealth(node: string, health: Record<string, boolean>): void {
+  twinStub.nodes[node] = {
+    services: Object.entries(health).map(([name, ready]) => ({
+      name,
+      health: { ready, lastCheckedAt: '' } as never,
+    })),
+  };
+}
+
+describe('preflightCrossStackDeps', () => {
+  it('passes when stack has no deps', async () => {
+    const r = await preflightCrossStackDeps(basic);
+    expect(r.ok).toBe(true);
+  });
+
+  it('blocks when a depended-on stack has no manifest', async () => {
+    getStackManifestMock.mockResolvedValueOnce(null);
+    const r = await preflightCrossStackDeps(immich);
+    expect(r.ok).toBe(false);
+    expect(r.blockedBy[0].stack).toBe('basic');
+    expect(r.blockedBy[0].health).toBeNull();
+  });
+
+  it('blocks when a depended-on stack is unhealthy', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    setNodeHealth('Local', { nginx: true, auth: false, adguard: true });
+    const r = await preflightCrossStackDeps(immich);
+    expect(r.ok).toBe(false);
+    expect(r.blockedBy[0].health?.ready).toBe(false);
+  });
+
+  it('passes when every depended-on stack is fully ready', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    setNodeHealth('Local', { nginx: true, auth: true, adguard: true });
+    const r = await preflightCrossStackDeps(immich);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('prepareStackInstall', () => {
+  function tmpl(name: string, deps: string[]): string {
+    return `apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+  annotations:
+    servicebay.label: "${name}"
+${deps.length > 0 ? `    servicebay.dependencies: "${deps.join(',')}"` : ''}
+spec:
+  containers: []
+`;
+  }
+
+  it('orders templates by their per-template dependencies', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    const load = vi.fn(async (n: string) => {
+      // adguard depends on nginx + auth; auth depends on nginx; nginx no deps.
+      // Topo order should be nginx → auth → adguard.
+      if (n === 'nginx') return tmpl('nginx', []);
+      if (n === 'auth') return tmpl('auth', ['nginx']);
+      if (n === 'adguard') return tmpl('adguard', ['nginx', 'auth']);
+      return null;
+    });
+    const r = await prepareStackInstall('basic', new Set(), load);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.plan.order).toEqual(['nginx', 'auth', 'adguard']);
+  });
+
+  it('skips templates that are already healthy', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    const load = vi.fn(async (n: string) => {
+      if (n === 'nginx') return tmpl('nginx', []);
+      if (n === 'auth') return tmpl('auth', ['nginx']);
+      if (n === 'adguard') return tmpl('adguard', ['nginx']);
+      return null;
+    });
+    const r = await prepareStackInstall('basic', new Set(['nginx']), load);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.plan.order).toEqual(['auth', 'adguard']);
+    expect(r.plan.status.nginx).toBe('already-installed');
+    expect(r.plan.status.auth).toBe('pending');
+  });
+
+  it('returns an error when a template references a non-existent template', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    const r = await prepareStackInstall('basic', new Set(), async () => null);
+    expect(r.ok).toBe(false);
+  });
+
+  it('returns an error when manifest is missing', async () => {
+    getStackManifestMock.mockResolvedValueOnce(null);
+    const r = await prepareStackInstall('ghost', new Set(), async () => null);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toMatch(/has no manifest/);
+  });
+});
+
+describe('installStack', () => {
+  function makeOpts(overrides: {
+    deployedSet?: Set<string>;
+    deploys?: Record<string, { ok: true } | { ok: false; error: string }>;
+  } = {}) {
+    const events: unknown[] = [];
+    return {
+      events,
+      opts: {
+        loadTemplateYaml: async (n: string) =>
+          `apiVersion: v1\nkind: Pod\nmetadata:\n  name: ${n}\n  annotations:\n    servicebay.label: "${n}"\nspec:\n  containers: []\n`,
+        getReadyTemplates: async () => overrides.deployedSet ?? new Set<string>(),
+        deployTemplate: async (t: string) => {
+          return overrides.deploys?.[t] ?? { ok: true };
+        },
+        onProgress: (e: unknown) => events.push(e),
+      },
+    };
+  }
+
+  it('refuses to install when a cross-stack dep is missing', async () => {
+    getStackManifestMock.mockResolvedValueOnce(immich); // outer call
+    getStackManifestMock.mockResolvedValueOnce(null);   // basic is missing
+    const { opts, events } = makeOpts();
+    const r = await installStack('immich', opts);
+    expect(r.ok).toBe(false);
+    expect(events.some(e => (e as { kind?: string }).kind === 'preflight-failed')).toBe(true);
+  });
+
+  it('topo-installs templates in order on the happy path', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic); // installStack outer
+    getStackManifestMock.mockResolvedValueOnce(basic); // prepareStackInstall
+    const { opts, events } = makeOpts();
+    const r = await installStack('basic', opts);
+    expect(r.ok).toBe(true);
+    const starts = events.filter(e => (e as { kind?: string }).kind === 'template-start') as Array<{ template: string }>;
+    expect(starts.map(s => s.template)).toEqual(['nginx', 'auth', 'adguard']);
+    expect(events.at(-1)).toMatchObject({ kind: 'stack-ok' });
+  });
+
+  it('stops at the failing template and reports stack-partial', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    const { opts, events } = makeOpts({
+      deploys: { auth: { ok: false, error: 'auth crashed' } },
+    });
+    const r = await installStack('basic', opts);
+    expect(r.ok).toBe(false);
+    expect(r.failedAt).toBe('auth');
+    const starts = events.filter(e => (e as { kind?: string }).kind === 'template-start') as Array<{ template: string }>;
+    // nginx ran (deploy ok), auth ran (failed). adguard never started.
+    expect(starts.map(s => s.template)).toEqual(['nginx', 'auth']);
+    expect(events.at(-1)).toMatchObject({ kind: 'stack-partial', failed: 'auth' });
+  });
+
+  it('skips already-healthy templates and resumes from the first pending', async () => {
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    const { opts, events } = makeOpts({
+      deployedSet: new Set(['nginx']),
+    });
+    const r = await installStack('basic', opts);
+    expect(r.ok).toBe(true);
+    const starts = events.filter(e => (e as { kind?: string }).kind === 'template-start') as Array<{ template: string }>;
+    // nginx already-installed → skipped; deploy fires for auth, adguard.
+    expect(starts.map(s => s.template)).toEqual(['auth', 'adguard']);
+  });
+});

--- a/src/lib/install/stackRunner.ts
+++ b/src/lib/install/stackRunner.ts
@@ -1,0 +1,245 @@
+/**
+ * Stack-level install orchestrator (#633 / Phase 5A).
+ *
+ * Sequential-with-resume install across a stack's templates. The
+ * existing per-template runner (`runner.ts`) still drives each
+ * template's deploy + post-deploy + capability-bus emit; this module
+ * is the glue that gates a stack on cross-stack dependencies and
+ * orders the templates within a stack.
+ *
+ * Why not extend `runner.ts` in place: the per-template runner is the
+ * unit of work the wizard's UI shows progress for. Stack runner
+ * decides which units of work to run + in what order; the two
+ * separations are intentional.
+ *
+ * Atomic-rollback is NOT in v1. If template N fails, templates 0..N-1
+ * stay deployed and the stack reports `partially-installed`. The
+ * operator retries — `prepareStackInstall` figures out what's left to
+ * deploy, the runner does just those. Sequential-with-resume semantics
+ * per the user-locked design.
+ */
+import { getStackManifest } from '@/lib/registry';
+import type { StackManifest } from '@/lib/template/stackContract';
+import { getStackHealth, type StackHealth } from './stackHealth';
+import { topoSortByDependencies } from '@/lib/stackInstall/dependencies';
+import { logger } from '@/lib/logger';
+
+export interface StackInstallPlan {
+  stack: StackManifest;
+  /** Templates to deploy in this run, in install order. Excludes those
+   *  already-installed-and-healthy. */
+  order: string[];
+  /** Per-template state at plan time. */
+  status: Record<string, 'pending' | 'already-installed'>;
+}
+
+export interface StackInstallPreflight {
+  ok: boolean;
+  blockedBy: Array<{ stack: string; health: StackHealth | null; reason: string }>;
+}
+
+/**
+ * Check that every stack listed in `manifest.dependsOnStacks` is
+ * fully healthy. Used at the top of `installStack` to refuse with a
+ * clear error rather than starting and failing later when the install
+ * runner can't reach an upstream service.
+ *
+ * `null` for a dependency means the stack has no manifest yet (legacy
+ * README-only) — treated as `ok: false` with a specific message so
+ * the operator sees "install the basic stack first" instead of a
+ * confusing "missing manifest" message.
+ */
+export async function preflightCrossStackDeps(
+  manifest: StackManifest,
+  nodeName: string = 'Local',
+): Promise<StackInstallPreflight> {
+  if (manifest.dependsOnStacks.length === 0) return { ok: true, blockedBy: [] };
+  const blockedBy: StackInstallPreflight['blockedBy'] = [];
+  for (const dep of manifest.dependsOnStacks) {
+    const health = await getStackHealth(dep, nodeName);
+    if (health === null) {
+      blockedBy.push({
+        stack: dep,
+        health: null,
+        reason: `dependency stack \`${dep}\` is not installed (no stack.yml found)`,
+      });
+      continue;
+    }
+    if (!health.ready) {
+      const offenders = Object.entries(health.children)
+        .filter(([, s]) => s !== 'ready')
+        .map(([n, s]) => `${n}=${s}`)
+        .join(', ');
+      blockedBy.push({
+        stack: dep,
+        health,
+        reason: `dependency stack \`${dep}\` is not healthy: ${offenders}`,
+      });
+    }
+  }
+  return { ok: blockedBy.length === 0, blockedBy };
+}
+
+/**
+ * Resolve which templates in this stack still need to be deployed and
+ * the order to deploy them in.
+ *
+ * `alreadyHealthy` is the set of template names whose `twin.health.
+ * ready === true` right now — those get marked `already-installed` and
+ * skipped. The remaining templates are topo-sorted by their per-
+ * template `servicebay.dependencies` annotation.
+ *
+ * Returns `null` if the topo-sort detects a cycle or a missing dep —
+ * the consistency lint catches both at build time so this should only
+ * happen mid-install if a registry update changed the dep graph
+ * underneath the operator.
+ */
+export async function prepareStackInstall(
+  stackName: string,
+  alreadyHealthy: ReadonlySet<string>,
+  loadTemplateYaml: (name: string) => Promise<string | null>,
+): Promise<{ ok: true; plan: StackInstallPlan } | { ok: false; error: string }> {
+  const manifest = await getStackManifest(stackName);
+  if (!manifest) {
+    return { ok: false, error: `Stack \`${stackName}\` has no manifest.` };
+  }
+
+  // Pull per-template dependency annotations to feed topoSortByDependencies.
+  // The function operates on `{ name, dependencies, ... }` items; we
+  // construct the minimal shape it needs.
+  const items = [];
+  for (const tName of manifest.templates) {
+    const yaml = await loadTemplateYaml(tName);
+    if (!yaml) {
+      return { ok: false, error: `Template \`${tName}\` referenced by stack \`${stackName}\` not found.` };
+    }
+    const deps = parseTemplateDeps(yaml).filter(d => manifest.templates.includes(d));
+    items.push({
+      name: tName,
+      checked: true,
+      alreadyInstalled: alreadyHealthy.has(tName),
+      dependencies: deps,
+    });
+  }
+
+  const sorted = topoSortByDependencies(items, {
+    alreadyInstalled: alreadyHealthy,
+  });
+  if (!sorted.ok) {
+    if (sorted.reason === 'missing') {
+      return {
+        ok: false,
+        error: `Template \`${sorted.item}\` depends on ${sorted.missing.join(', ')}, which ${sorted.missing.length === 1 ? 'is' : 'are'} not in stack \`${stackName}\`.`,
+      };
+    }
+    return {
+      ok: false,
+      error: `Templates in stack \`${stackName}\` form a dependency cycle: ${sorted.involved.join(' ↔ ')}.`,
+    };
+  }
+
+  const order = sorted.ordered.map(i => i.name);
+  const status: Record<string, 'pending' | 'already-installed'> = {};
+  for (const name of manifest.templates) {
+    status[name] = alreadyHealthy.has(name) ? 'already-installed' : 'pending';
+  }
+  // Trim `order` to only the not-yet-installed templates while preserving
+  // their relative topo order.
+  const toDeploy = order.filter(n => !alreadyHealthy.has(n));
+
+  return {
+    ok: true,
+    plan: {
+      stack: manifest,
+      order: toDeploy,
+      status,
+    },
+  };
+}
+
+/**
+ * Minimal `servicebay.dependencies` parser. Mirrors the regex in the
+ * full template-manifest parser but stays inline so this module can
+ * stay independent of the full parsing surface (and so the stackRunner
+ * test suite doesn't need to drag in the heavier dependencies).
+ */
+function parseTemplateDeps(yamlText: string): string[] {
+  const m = /^\s+servicebay\.dependencies:\s*(?:"([^"]*)"|'([^']*)'|([^\n#]+?))\s*$/m.exec(yamlText);
+  if (!m) return [];
+  const raw = (m[1] ?? m[2] ?? m[3] ?? '').trim();
+  if (!raw) return [];
+  return raw.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+/** What the operator-visible install loop reports as it goes. */
+export type StackInstallProgress =
+  | { kind: 'preflight-failed'; blockedBy: StackInstallPreflight['blockedBy'] }
+  | { kind: 'plan'; plan: StackInstallPlan }
+  | { kind: 'template-start'; template: string }
+  | { kind: 'template-ok'; template: string }
+  | { kind: 'template-failed'; template: string; error: string }
+  | { kind: 'stack-ok'; stack: string }
+  | { kind: 'stack-partial'; stack: string; failed: string };
+
+export interface StackInstallOptions {
+  nodeName?: string;
+  loadTemplateYaml: (name: string) => Promise<string | null>;
+  /** Returns the set of template names that are currently
+   *  `twin.health.ready === true`. The runner uses this both for the
+   *  preflight `alreadyHealthy` check AND for the per-template wait
+   *  after deploy. */
+  getReadyTemplates: () => Promise<Set<string>>;
+  /** Deploy + post-deploy + bus.emit for a single template. Returns
+   *  ok=true once the template's `twin.health.ready === true` (the
+   *  caller polls `getReadyTemplates` against a deadline). */
+  deployTemplate: (template: string) => Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Optional reporter for live log lines. */
+  onProgress?: (event: StackInstallProgress) => void;
+}
+
+export async function installStack(
+  stackName: string,
+  opts: StackInstallOptions,
+): Promise<{ ok: boolean; failedAt?: string; error?: string }> {
+  const manifest = await getStackManifest(stackName);
+  if (!manifest) {
+    return { ok: false, error: `Stack \`${stackName}\` has no manifest.` };
+  }
+  const node = opts.nodeName ?? 'Local';
+
+  // Cross-stack dep gate.
+  const pre = await preflightCrossStackDeps(manifest, node);
+  if (!pre.ok) {
+    opts.onProgress?.({ kind: 'preflight-failed', blockedBy: pre.blockedBy });
+    return {
+      ok: false,
+      error: `Stack \`${stackName}\` install refused: ${pre.blockedBy.map(b => b.reason).join('; ')}`,
+    };
+  }
+
+  // Plan.
+  const alreadyHealthy = await opts.getReadyTemplates();
+  const planResult = await prepareStackInstall(stackName, alreadyHealthy, opts.loadTemplateYaml);
+  if (!planResult.ok) {
+    return { ok: false, error: planResult.error };
+  }
+  opts.onProgress?.({ kind: 'plan', plan: planResult.plan });
+
+  // Sequential deploy. On failure of template N, stop — sibling
+  // templates further down the order would still race on N's
+  // unmet dependency.
+  for (const template of planResult.plan.order) {
+    opts.onProgress?.({ kind: 'template-start', template });
+    const result = await opts.deployTemplate(template);
+    if (!result.ok) {
+      opts.onProgress?.({ kind: 'template-failed', template, error: result.error });
+      opts.onProgress?.({ kind: 'stack-partial', stack: stackName, failed: template });
+      logger.warn('StackRunner', `Stack ${stackName} partially installed; template ${template} failed: ${result.error}`);
+      return { ok: false, failedAt: template, error: result.error };
+    }
+    opts.onProgress?.({ kind: 'template-ok', template });
+  }
+
+  opts.onProgress?.({ kind: 'stack-ok', stack: stackName });
+  return { ok: true };
+}


### PR DESCRIPTION
Closes #633. Part of #621 (Phase 5A). Builds on:
- #625 (stack manifests — merged in v4.5.0 lineage)
- #627 (twin.health is real signal — merged)
- #632 (per-template runner uses the bus — merged)

## Summary

Adds the orchestrator that drives sequential-with-resume installs at the stack level.

### \`stackHealth.ts\`

- **\`aggregateStackHealth(templateNames, serviceHealthMap)\`** — pure function. \`ready = AND(children.ready)\`, \`degraded = OR\`, plus per-child status (\`ready\` / \`unhealthy\` / \`unknown\`) and \`hasAnySignal\` so callers can distinguish \"fully uninstalled\" from \"fresh boot, poller hasn't run yet.\"
- **\`getStackHealth(stackName, node?)\`** — runtime entry point. Looks up the manifest, scans the twin, returns aggregated result.

### \`stackRunner.ts\`

- **\`preflightCrossStackDeps(manifest)\`** — refuses installs when any \`servicebay.depends-on-stacks\` target isn't fully healthy. Each blocker surfaces with a clear reason naming the unhealthy children.
- **\`prepareStackInstall(name, alreadyHealthy, loadYaml)\`** — topo-sorts the stack's templates by their per-template \`servicebay.dependencies\`. Skips already-healthy ones. Returns an ordered plan or a structured error.
- **\`installStack(name, opts)\`** — sequential deploy with bail-on-first-failure. Reports plan + per-template start/ok/fail via the \`onProgress\` event sink. Templates 0..N-1 stay deployed when N fails — operator retries with the same stack name and the runner resumes from N.

## Test plan

- [x] \`npm run check:arch\` — 526 modules, no violations
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1117 pass / 2 skipped; **18 new tests** covering:
  - aggregateStackHealth: ready=true when all children ready; ready=false on any unhealthy or unknown; hasAnySignal distinguishes empty vs unprobed; degraded propagation; empty-stack case.
  - preflightCrossStackDeps: passes with no deps; blocks on missing manifest; blocks on unhealthy dep; passes when all deps fully ready.
  - prepareStackInstall: topo-orders by per-template deps; skips already-healthy; returns errors for missing templates / missing manifests.
  - installStack: refuses on preflight failure; topo-installs on happy path; bails at failing template + reports stack-partial; skips already-healthy + resumes from first pending.
- [x] \`npm run build\` — clean

## Out of scope

- UI for stack-level install — #PH5B / #634.
- Stack-level wipe — #PH5B too.
- Tier gate (refuse feature install on degraded core) — #PH5C / #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)