### PR TITLE
feat(install): tier gate refuses feature install on degraded core (#635)

### DIFF
--- a/src/app/api/system/core-health/route.ts
+++ b/src/app/api/system/core-health/route.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /api/system/core-health (#635 / Phase 5C)
+ *
+ * UI-shaped summary of every `tier: core` stack that isn't fully
+ * `health.ready === true`. Drives the <CoreHealthBanner> and the
+ * tier-gate refusal modal in <StackCard>.
+ *
+ * Returns `{ degraded: DegradedCoreEntry[] }`. Empty array = core is
+ * healthy (banner stays hidden, feature-stack installs are allowed).
+ */
+import { NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { apiError } from '@/lib/api/errors';
+import { getDegradedCoreSummary } from '@/lib/install/stackHealth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const degraded = await getDegradedCoreSummary();
+    return NextResponse.json({ degraded });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:core-health', status: 500 });
+  }
+}

--- a/src/components/CoreHealthBanner.tsx
+++ b/src/components/CoreHealthBanner.tsx
@@ -5,44 +5,33 @@ import { AlertTriangle, X } from 'lucide-react';
 import Link from 'next/link';
 
 /**
- * Core-stack health banner (#627 / Phase 3B).
+ * Core-stack health banner (#627 / Phase 3B, enriched in #635 /
+ * Phase 5C).
  *
- * Shows at the top of every dashboard page when any service in the
- * `basic` stack (`nginx`, `auth`, `adguard`) reports `health.ready ===
- * false` for more than the startup grace. Names the specific service
- * that's degraded and links to its diagnose probe.
- *
- * Today the core-stack membership is hardcoded — it'll come from the
- * \`stacks/basic/stack.yml\` manifest (#625) once Phase 5 wires the
- * stack runner up to the wizard. Until then this list is the source
- * of truth for "what does the system need to function?"
+ * Shows at the top of every dashboard page when any `tier: core` stack
+ * reports `health.ready !== true`. Sourced from the live stack
+ * manifests via `/api/system/core-health` so the membership list isn't
+ * hardcoded anymore.
  *
  * Polls every 15s, dismissable per browser session (sessionStorage).
  */
 
-const CORE_SERVICES = ['nginx', 'auth', 'adguard'] as const;
 const POLL_INTERVAL_MS = 15_000;
 const DISMISS_KEY = 'sb:core-health-banner-dismissed';
 
-interface ServiceHealth {
-  ready: boolean;
-  degraded?: boolean;
-  lastCheckedAt: string;
-  message?: string;
+interface DegradedNotReady {
+  template: string;
+  state: 'unhealthy' | 'unknown';
 }
 
-interface SystemInfoService {
-  name: string;
-  health?: ServiceHealth;
-  active?: boolean;
-}
-
-interface SystemInfo {
-  services?: SystemInfoService[];
+interface DegradedEntry {
+  stack: string;
+  label: string;
+  notReady: DegradedNotReady[];
 }
 
 export default function CoreHealthBanner() {
-  const [unhealthy, setUnhealthy] = useState<string[]>([]);
+  const [degraded, setDegraded] = useState<DegradedEntry[]>([]);
   // Read once at construct time. sessionStorage is synchronous; only the
   // server side has to guard against it being undefined. Doing this in
   // useState's initialiser avoids the synchronous-setState-in-effect
@@ -56,23 +45,11 @@ export default function CoreHealthBanner() {
     let cancelled = false;
     const tick = async () => {
       try {
-        const res = await fetch('/api/system/info');
+        const res = await fetch('/api/system/core-health');
         if (!res.ok) return;
-        const data: SystemInfo = await res.json();
+        const data = await res.json() as { degraded: DegradedEntry[] };
         if (cancelled) return;
-        const services = Array.isArray(data.services) ? data.services : [];
-        const flagged = CORE_SERVICES.filter(name => {
-          const svc = services.find(s => s.name === name);
-          if (!svc) return false;
-          // A core service without a health record yet (template hasn't
-          // shipped the annotation, or poller hasn't run) is NOT flagged.
-          // We only surface explicit `ready: false` — the alternative is
-          // a chatty banner while infrastructure templates without
-          // healthcheck annotations roll out in Phase 3C.
-          if (!svc.health) return false;
-          return svc.health.ready === false;
-        });
-        setUnhealthy(flagged);
+        setDegraded(Array.isArray(data.degraded) ? data.degraded : []);
       } catch {
         /* keep previous state */
       }
@@ -82,12 +59,20 @@ export default function CoreHealthBanner() {
     return () => { cancelled = true; clearInterval(id); };
   }, [dismissed]);
 
-  if (dismissed || unhealthy.length === 0) return null;
+  if (dismissed || degraded.length === 0) return null;
 
   const dismiss = () => {
     sessionStorage.setItem(DISMISS_KEY, '1');
     setDismissed(true);
   };
+
+  // Only surface stacks that have a concrete "unhealthy" signal — pure
+  // `unknown` (template has no healthcheck annotation yet) doesn't
+  // warrant a red banner. Stays consistent with the tier-gate, which
+  // treats `unknown` as "not ready" for install gating but doesn't
+  // shout about it in the UI.
+  const visible = degraded.filter(d => d.notReady.some(n => n.state === 'unhealthy'));
+  if (visible.length === 0) return null;
 
   return (
     <div className="fixed top-4 left-1/2 -translate-x-1/2 z-40 max-w-2xl w-[calc(100%-2rem)] bg-red-50 dark:bg-red-950/40 border border-red-300 dark:border-red-800 rounded-xl shadow-lg overflow-hidden">
@@ -97,9 +82,17 @@ export default function CoreHealthBanner() {
         </div>
         <div className="flex-1 min-w-0">
           <h3 className="text-sm font-semibold text-red-900 dark:text-red-100">
-            Core service{unhealthy.length === 1 ? '' : 's'} unhealthy: {unhealthy.join(', ')}
+            Core {visible.length === 1 ? 'stack' : 'stacks'} unhealthy: {visible.map(d => d.label).join(', ')}
           </h3>
-          <p className="text-xs text-red-800/80 dark:text-red-200/80 mt-0.5">
+          <ul className="mt-1.5 space-y-0.5">
+            {visible.flatMap(d => d.notReady.filter(n => n.state === 'unhealthy').map(n => (
+              <li key={`${d.stack}/${n.template}`} className="text-xs text-red-800/90 dark:text-red-200/90">
+                <code className="font-mono">{n.template}</code>{' '}
+                <span className="text-red-700/70 dark:text-red-300/70">({n.state})</span>
+              </li>
+            )))}
+          </ul>
+          <p className="text-xs text-red-800/80 dark:text-red-200/80 mt-2">
             Feature installs are gated on core health. Open <Link href="/diagnose" className="underline font-medium">Self-diagnose</Link> for the recovery path.
           </p>
         </div>

--- a/src/lib/install/stackHealth.ts
+++ b/src/lib/install/stackHealth.ts
@@ -64,6 +64,60 @@ export function aggregateStackHealth(
 }
 
 /**
+ * One degraded core stack — UI-shaped summary for the tier-gate
+ * refusal modal and the CoreHealthBanner (#635 / Phase 5C). Names
+ * the stack + its unhealthy children so the operator can act without
+ * re-reading the diagnose page.
+ */
+export interface DegradedCoreEntry {
+  stack: string;
+  /** Friendly label from the stack's manifest. */
+  label: string;
+  /** Per-child state; only `unhealthy` / `unknown` keys appear. */
+  notReady: Array<{ template: string; state: 'unhealthy' | 'unknown' }>;
+}
+
+/**
+ * Scan every stack whose manifest declares `tier: core` and return the
+ * subset that isn't `health.ready === true`. Used by:
+ *   - `installStack` to refuse feature-stack installs when core is
+ *     degraded (#635 / Phase 5C tier gate).
+ *   - `<CoreHealthBanner>` to show what's broken with click-through
+ *     to diagnose actions.
+ */
+export async function getDegradedCoreSummary(nodeName: string = 'Local'): Promise<DegradedCoreEntry[]> {
+  const fs = await import('fs/promises');
+  const path = await import('path');
+  const stacksDir = path.join(process.cwd(), 'stacks');
+  let dirents: import('fs').Dirent[];
+  try {
+    dirents = await fs.readdir(stacksDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const names = dirents.filter(d => d.isDirectory() && !d.name.startsWith('.')).map(d => d.name);
+
+  const degraded: DegradedCoreEntry[] = [];
+  for (const name of names) {
+    let manifest;
+    try {
+      manifest = await getStackManifest(name);
+    } catch { continue; }
+    if (!manifest || manifest.tier !== 'core') continue;
+    const health = await getStackHealth(name, nodeName);
+    if (!health || health.ready) continue;
+    degraded.push({
+      stack: name,
+      label: manifest.label,
+      notReady: Object.entries(health.children)
+        .filter(([, s]) => s !== 'ready')
+        .map(([template, state]) => ({ template, state: state as 'unhealthy' | 'unknown' })),
+    });
+  }
+  return degraded;
+}
+
+/**
  * Runtime entry point: look up the stack manifest, scan the twin for
  * each child template's health, return aggregated result.
  *

--- a/src/lib/install/stackRunner.test.ts
+++ b/src/lib/install/stackRunner.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { StackManifest } from '@/lib/template/stackContract';
+import type { DegradedCoreEntry } from './stackHealth';
 
 const getStackManifestMock = vi.fn<(name: string) => Promise<StackManifest | null>>();
 vi.mock('@/lib/registry', () => ({
@@ -19,6 +20,18 @@ const twinStub: {
 vi.mock('@/lib/store/twin', () => ({
   DigitalTwinStore: { getInstance: () => twinStub },
 }));
+
+// `getDegradedCoreSummary` walks the on-disk `stacks/` directory in
+// real use. The tier-gate test cares about its return value, not its
+// fs traversal, so we stub it. Default = no degraded core (gate passes).
+const degradedCoreMock = vi.fn<() => Promise<DegradedCoreEntry[]>>().mockResolvedValue([]);
+vi.mock('./stackHealth', async () => {
+  const actual = await vi.importActual<typeof import('./stackHealth')>('./stackHealth');
+  return {
+    ...actual,
+    getDegradedCoreSummary: () => degradedCoreMock(),
+  };
+});
 
 import { installStack, preflightCrossStackDeps, prepareStackInstall } from './stackRunner';
 
@@ -43,6 +56,8 @@ const immich: StackManifest = {
 beforeEach(() => {
   getStackManifestMock.mockReset();
   twinStub.nodes = {};
+  degradedCoreMock.mockReset();
+  degradedCoreMock.mockResolvedValue([]);
 });
 
 function setNodeHealth(node: string, health: Record<string, boolean>): void {
@@ -211,5 +226,70 @@ describe('installStack', () => {
     const starts = events.filter(e => (e as { kind?: string }).kind === 'template-start') as Array<{ template: string }>;
     // nginx already-installed → skipped; deploy fires for auth, adguard.
     expect(starts.map(s => s.template)).toEqual(['auth', 'adguard']);
+  });
+});
+
+describe('installStack — tier gate (#635 / Phase 5C)', () => {
+  function makeOpts() {
+    const events: unknown[] = [];
+    return {
+      events,
+      opts: {
+        loadTemplateYaml: async (n: string) =>
+          `apiVersion: v1\nkind: Pod\nmetadata:\n  name: ${n}\n  annotations:\n    servicebay.label: "${n}"\nspec:\n  containers: []\n`,
+        getReadyTemplates: async () => new Set<string>(),
+        deployTemplate: async () => ({ ok: true as const }),
+        onProgress: (e: unknown) => events.push(e),
+      },
+    };
+  }
+
+  it('refuses feature-stack install when any core stack is degraded', async () => {
+    getStackManifestMock.mockResolvedValue(immich);
+    degradedCoreMock.mockResolvedValueOnce([
+      { stack: 'basic', label: 'Core services', notReady: [{ template: 'auth', state: 'unhealthy' }] },
+    ]);
+    const { opts, events } = makeOpts();
+    const r = await installStack('immich', opts);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/core not ready/);
+    expect(r.error).toMatch(/auth\(unhealthy\)/);
+    const gate = events.find(e => (e as { kind?: string }).kind === 'tier-gate-failed') as { degraded: DegradedCoreEntry[] };
+    expect(gate.degraded).toHaveLength(1);
+  });
+
+  it('allows feature-stack install when core is healthy', async () => {
+    const basicCore: StackManifest = {
+      name: 'basic', label: 'Core', tier: 'core', lifecycle: 'atomic-wipe',
+      dependsOnStacks: [], templates: ['nginx'],
+    };
+    // Use mockImplementation so multiple lookups (installStack, preflight
+    // → getStackHealth → getStackManifest('basic'), prepareStackInstall)
+    // all resolve correctly by name.
+    getStackManifestMock.mockImplementation(async (name: string) => {
+      if (name === 'immich') return immich;
+      if (name === 'basic') return basicCore;
+      return null;
+    });
+    twinStub.nodes['Local'] = {
+      services: [{ name: 'nginx', health: { ready: true } }],
+    };
+    degradedCoreMock.mockResolvedValueOnce([]);
+    const r = await installStack('immich', makeOpts().opts);
+    expect(r.ok).toBe(true);
+  });
+
+  it('does NOT gate a tier=core stack on itself (core install can fix core)', async () => {
+    // `basic` is tier:core; even if it reports as degraded (because
+    // it's not installed yet), installing it must not refuse on the
+    // tier gate — that's the install path that would fix the
+    // problem.
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    getStackManifestMock.mockResolvedValueOnce(basic);
+    degradedCoreMock.mockResolvedValueOnce([
+      { stack: 'basic', label: 'Core', notReady: [{ template: 'nginx', state: 'unknown' }] },
+    ]);
+    const r = await installStack('basic', makeOpts().opts);
+    expect(r.ok).toBe(true);
   });
 });

--- a/src/lib/install/stackRunner.ts
+++ b/src/lib/install/stackRunner.ts
@@ -20,7 +20,7 @@
  */
 import { getStackManifest } from '@/lib/registry';
 import type { StackManifest } from '@/lib/template/stackContract';
-import { getStackHealth, type StackHealth } from './stackHealth';
+import { getStackHealth, getDegradedCoreSummary, type StackHealth, type DegradedCoreEntry } from './stackHealth';
 import { topoSortByDependencies } from '@/lib/stackInstall/dependencies';
 import { logger } from '@/lib/logger';
 
@@ -174,6 +174,7 @@ function parseTemplateDeps(yamlText: string): string[] {
 /** What the operator-visible install loop reports as it goes. */
 export type StackInstallProgress =
   | { kind: 'preflight-failed'; blockedBy: StackInstallPreflight['blockedBy'] }
+  | { kind: 'tier-gate-failed'; degraded: DegradedCoreEntry[] }
   | { kind: 'plan'; plan: StackInstallPlan }
   | { kind: 'template-start'; template: string }
   | { kind: 'template-ok'; template: string }
@@ -206,6 +207,26 @@ export async function installStack(
     return { ok: false, error: `Stack \`${stackName}\` has no manifest.` };
   }
   const node = opts.nodeName ?? 'Local';
+
+  // Tier gate (#635 / Phase 5C): refuse feature-stack installs when any
+  // tier:core stack isn't healthy. The user-locked rule has no override
+  // — operator must fix core first. Core stack installs (self-install
+  // or re-install) bypass this gate; otherwise an unhealthy core would
+  // prevent the operator from running the install that would fix it.
+  if (manifest.tier === 'feature') {
+    const degraded = await getDegradedCoreSummary(node);
+    if (degraded.length > 0) {
+      opts.onProgress?.({ kind: 'tier-gate-failed', degraded });
+      const summary = degraded.map(d => {
+        const offenders = d.notReady.map(n => `${n.template}(${n.state})`).join(', ');
+        return `${d.stack}: ${offenders}`;
+      }).join('; ');
+      return {
+        ok: false,
+        error: `Cannot install \`${stackName}\`: core not ready — ${summary}. Fix core services first.`,
+      };
+    }
+  }
 
   // Cross-stack dep gate.
   const pre = await preflightCrossStackDeps(manifest, node);


### PR DESCRIPTION
Closes #635. Part of #621 (Phase 5C — the final piece). Builds on #633 (stack runner) and #634 (stack APIs).

**Base branch**: this PR is based on \`main\` but logically depends on #651 (#634) landing first — they touch different files so no rebase needed.

## Summary

The user-locked rule for the rearchitecture: when any \`tier: core\` stack reports \`health.ready !== true\`, every \`tier: feature\` install refuses with a structured error naming the offending stack + children. No override. Core-stack installs (self-install / re-install) bypass the gate — the install path is itself the recovery.

### Implementation

- **\`getDegradedCoreSummary(node?)\`** in \`stackHealth.ts\` — walks every \`tier: core\` stack, returns the subset with at least one not-ready child. UI-shaped (stack name + label + per-child state list).
- **\`installStack\`** consults the summary before running. Surfaces failures via a new \`tier-gate-failed\` progress event.
- **\`GET /api/system/core-health\`** exposes the summary to clients (banner, future install-refusal modal).
- **\`<CoreHealthBanner>\`** rewired to use the live API instead of the hardcoded \`['nginx','auth','adguard']\` list it shipped in #627. Shows per-child names; only renders when at least one child has a concrete \`unhealthy\` signal (pure \`unknown\` is too quiet to surface).

## Test plan

- [x] \`npm run check:arch\` — 520 modules, no violations
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1099 pass / 2 skipped; **3 new tier-gate tests**:
  - refuses feature install when core is degraded (surfaces \`tier-gate-failed\` event)
  - allows feature install when core is healthy (full happy path)
  - core-stack install bypasses the gate (so \"install basic\" can fix \"basic is degraded\")
- [x] \`npm run build\` — clean; new \`/api/system/core-health\` route registered

## Out of scope (per #635 body)

- Automatic core auto-restart — operator-initiated only.
- Action buttons in the banner that map to MCP restart / diagnose flows — deferred to a follow-up.

## With this PR, #621 Phase 5 is complete — the full rearchitecture is shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)