### PR TITLE
refactor(arch): break the last circular dependency (#601)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -27,21 +27,10 @@ module.exports = {
             name: 'no-circular',
             severity: 'error',
             comment:
-                'Circular dependencies make refactoring and reasoning painful. Ratchet TODO: ' +
-                'fix the 6 known cycles (agent/executor ↔ ssh/pool ↔ nodes ↔ executor; ' +
-                'config ↔ registry ↔ migrations; mcp/bootstrapToken ↔ mcp/tokens; ' +
-                'stackInstall/credentialsManifest ↔ postInstall), then drop the ' +
-                'exemption below.',
-            from: {
-                pathNot: [
-                    '^src/lib/executor\\.ts$',
-                    '^src/lib/nodes\\.ts$',
-                    '^src/lib/agent/executor\\.ts$',
-                    '^src/lib/agent/manager\\.ts$',
-                    '^src/lib/agent/handler\\.ts$',
-                    '^src/lib/ssh/pool\\.ts$',
-                ],
-            },
+                'Circular dependencies make refactoring and reasoning painful. ' +
+                '#601 broke the last known cycle (extracted verifyNodeConnection ' +
+                'from nodes.ts to nodes/verify.ts). Any new cycle now fails CI.',
+            from: {},
             to: { circular: true },
         },
         {

--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -66,7 +66,7 @@ Thresholds are **deliberate decisions**, not aspirational defaults. Two paths:
 | `lib → app` imports | 0 | 0 | `.dependency-cruiser.cjs:lib-no-import-app` (#600) |
 | `lib → components` imports | 0 | 0 | `.dependency-cruiser.cjs:lib-no-import-components` |
 | `lib → dashboards` imports | 0 | 0 | `.dependency-cruiser.cjs:lib-no-import-dashboards` |
-| Circular dependency cycles | 6 known | 0 new | `.dependency-cruiser.cjs:no-circular` |
+| Circular dependency cycles | 0 | 0 | `.dependency-cruiser.cjs:no-circular` (#601 — final cycle broken by extracting `verifyNodeConnection` out of `nodes.ts`) |
 | Forks of the Mustache renderer | 0 | 0 | `.dependency-cruiser.cjs:one-renderer` (#599) |
 | Bypasses of `ServiceManager` facade | 0 | 0 | `.dependency-cruiser.cjs:service-manager-single-mutation-path` |
 

--- a/src/app/actions/nodes.ts
+++ b/src/app/actions/nodes.ts
@@ -1,6 +1,7 @@
 'use server';
 
-import { listNodes, addNode, updateNode, removeNode, setDefaultNode, verifyNodeConnection, PodmanConnection } from '@/lib/nodes';
+import { listNodes, addNode, updateNode, removeNode, setDefaultNode, PodmanConnection } from '@/lib/nodes';
+import { verifyNodeConnection } from '@/lib/nodes/verify';
 import { HealthStore } from '@/lib/health/store';
 import { revalidatePath } from 'next/cache';
 import * as fs from 'fs';

--- a/src/lib/health/probes/basic.ts
+++ b/src/lib/health/probes/basic.ts
@@ -10,7 +10,7 @@ import vm from 'vm';
 import { registerProbe } from './registry';
 import { assertHttpTargetAllowed } from '../ssrfGuard';
 import { ContainerId, ServiceName, HostString } from '../../api/schemas';
-import { verifyNodeConnection } from '../../nodes';
+import { verifyNodeConnection } from '../../nodes/verify';
 import { agentManager } from '../../agent/manager';
 import { getConfig } from '../../config';
 

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -7,7 +7,8 @@ import {
 } from '@/lib/manager';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { getTemplates, getReadme, getTemplateYaml, getTemplateVariables } from '@/lib/registry';
-import { listNodes, getNodeConnection, verifyNodeConnection } from '@/lib/nodes';
+import { listNodes, getNodeConnection } from '@/lib/nodes';
+import { verifyNodeConnection } from '@/lib/nodes/verify';
 import { agentManager } from '@/lib/agent/manager';
 import { HealthStore } from '@/lib/health/store';
 import { CheckRunner } from '@/lib/health/runner';

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -5,7 +5,10 @@ import { atomicWriteFile } from './util/atomicWrite';
 
 const NODES_FILE = path.join(DATA_DIR, 'nodes.json');
 
-const normalizeName = (name: string) => name.trim().toLowerCase();
+/** Normalise node names for case-insensitive comparison. Exported so
+ *  consumers (like `nodes/verify.ts`) can do the same lookup nodes.ts
+ *  does internally. */
+export const normalizeName = (name: string) => name.trim().toLowerCase();
 
 /**
  * Per-process serialization for node mutations. Without it, two
@@ -173,27 +176,9 @@ export async function updateNode(oldName: string, newNode: Partial<PodmanConnect
   });
 }
 
-export async function verifyNodeConnection(name: string): Promise<{ success: boolean; error?: string }> {
-    try {
-        const nodes = await loadNodes();
-    const node = nodes.find(n => normalizeName(n.Name) === normalizeName(name));
-        if (!node) {
-            throw new Error(`Node ${name} not found`);
-        }
-
-        // Dynamic import to avoid circular dependency (nodes -> executor -> agent -> handler -> nodes)
-        const { getExecutor } = await import('./executor');
-        const executor = getExecutor(node);
-        // We run 'podman info' remotely to verify both SSH access and Podman installation
-        await executor.exec('podman info'); 
-        
-        return { success: true };
-    } catch (e) {
-        console.warn(`Connection check failed for node ${name}:`, e);
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return { success: false, error: errorMessage };
-    }
-}
+// `verifyNodeConnection` moved to `./nodes/verify.ts` (#601) so this
+// module stays a pure config-IO unit with no dependency on
+// `executor.ts` / the agent layer. Callers import from there.
 
 export async function removeNode(name: string): Promise<void> {
   return withLock(async () => {

--- a/src/lib/nodes/verify.ts
+++ b/src/lib/nodes/verify.ts
@@ -1,0 +1,33 @@
+/**
+ * `verifyNodeConnection` — runs a remote `podman info` to confirm SSH
+ * access + Podman installation on a configured node.
+ *
+ * Lives here (not in `nodes.ts`) because it's the only piece of nodes
+ * IO that needs the executor layer at runtime. Keeping it separate
+ * means `nodes.ts` stays a pure config-IO module — no dependency on
+ * `executor.ts` or anything in the agent layer. That break drops the
+ * last cycle in the agent/executor/handler/manager + ssh/pool + nodes
+ * + executor graph (#601 / ARCH-12).
+ */
+import { listNodes, normalizeName } from '../nodes';
+import { getExecutor } from '../executor';
+
+export async function verifyNodeConnection(name: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    const nodes = await listNodes();
+    const node = nodes.find(n => normalizeName(n.Name) === normalizeName(name));
+    if (!node) {
+      throw new Error(`Node ${name} not found`);
+    }
+    const executor = getExecutor(node);
+    // `podman info` is the canonical "everything's wired up" probe —
+    // proves both SSH access and a working Podman socket on the
+    // remote side.
+    await executor.exec('podman info');
+    return { success: true };
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    console.warn(`Connection check failed for node ${name}:`, e);
+    return { success: false, error: errorMessage };
+  }
+}

--- a/tests/backend/nodes.test.ts
+++ b/tests/backend/nodes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { addNode, listNodes, verifyNodeConnection } from '../../src/lib/nodes';
+import { addNode, listNodes } from '../../src/lib/nodes';
+import { verifyNodeConnection } from '../../src/lib/nodes/verify';
 import fs from 'fs/promises';
 import { getExecutor } from '../../src/lib/executor';
 


### PR DESCRIPTION
Closes #601.

## Summary

The agent/executor/handler/manager + ssh/pool + nodes + executor 6-node cycle was the last remaining one. Other cycles listed in the issue body (mcp/tokens, stackInstall/credentialsManifest, config/registry/migrations) had already been broken by other refactors over time.

The cycle existed because \`nodes.ts:verifyNodeConnection\` did \`await import('./executor')\` to run \`podman info\` remotely. \`nodes.ts\` is a pure config-IO module (read/write \`nodes.json\`, manage default-node pointer); the executor runtime had no business hanging off it.

## Fix

- Extracted \`verifyNodeConnection\` to a new \`src/lib/nodes/verify.ts\` that owns the runtime-executor coupling.
- \`nodes.ts\` now has **zero** imports into the agent/executor graph.
- Exported \`normalizeName\` from \`nodes.ts\` so \`verify.ts\` does the same case-insensitive node lookup.
- Removed the \`pathNot\` exemption from \`no-circular\` in \`.dependency-cruiser.cjs\`. Any new cycle now fails CI.
- Updated \`docs/ARCHITECTURE_INVARIANTS.md\` row: **6 known → 0**.

## Test plan

- [x] \`npm run check:arch\` — 526 modules, no violations (depcruise reports zero cycles even with the exemption removed)
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1099 pass / 2 skipped (updated \`tests/backend/nodes.test.ts\` to import from the new module path)
- [x] \`npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)