### PR TITLE
refactor(api): migrate /api/settings/** to withApiHandler (#603)

### DIFF
--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -154,12 +154,12 @@ async function checkExecTemplateLiterals() {
 // 4. withApiHandler adoption ratio.
 //
 // Routes that hand-roll their own try/catch + envelope drift apart. The
-// abstraction in src/lib/api/handler.ts is the SoT. Pinned to current
-// adoption (1 of 96 = ~1%), should monotonically increase. The threshold
-// is "ratio must not decrease", not a fixed number, so a new
-// non-conforming route fails CI immediately.
+// abstraction in src/lib/api/handler.ts is the SoT. Should monotonically
+// increase; ratchet up after each cluster migration so any regression
+// fails CI immediately. Current run: 12/104 routes (~11%) after the
+// settings cluster landed in #603.
 // ---------------------------------------------------------------------------
-const MIN_WITH_API_HANDLER_RATIO = 0.01;
+const MIN_WITH_API_HANDLER_RATIO = 0.10;
 
 async function checkWithApiHandlerAdoption() {
     const routeFiles = await walk(path.join(SRC, 'app', 'api'), p => p.endsWith('/route.ts'));

--- a/src/app/api/settings/backup-sync/route.ts
+++ b/src/app/api/settings/backup-sync/route.ts
@@ -1,101 +1,86 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getConfig, updateConfig } from '@/lib/config';
 import { runBackup, getBackupHistory, isBackupRunning, testBackupTarget, scheduleBackup } from '@/lib/backup/service';
 import type { BackupConfig, BackupTarget } from '@/lib/backup/types';
 import { HealthStore } from '@/lib/health/store';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 import crypto from 'crypto';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
 const BACKUP_CHECK_NAME = 'Backup Sync';
 
 function ensureBackupHealthCheck(enabled: boolean) {
-    const checks = HealthStore.getChecks();
-    const existing = checks.find(c => c.type === 'backup' && c.name === BACKUP_CHECK_NAME);
-
-    if (enabled && !existing) {
-        HealthStore.saveCheck({
-            id: crypto.randomUUID(),
-            name: BACKUP_CHECK_NAME,
-            type: 'backup',
-            target: 'backup-sync',
-            interval: 300, // check every 5 minutes
-            enabled: true,
-            created_at: new Date().toISOString(),
-        });
-    } else if (!enabled && existing) {
-        HealthStore.deleteCheck(existing.id);
-    }
+  const checks = HealthStore.getChecks();
+  const existing = checks.find(c => c.type === 'backup' && c.name === BACKUP_CHECK_NAME);
+  if (enabled && !existing) {
+    HealthStore.saveCheck({
+      id: crypto.randomUUID(),
+      name: BACKUP_CHECK_NAME,
+      type: 'backup',
+      target: 'backup-sync',
+      interval: 300,
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+  } else if (!enabled && existing) {
+    HealthStore.deleteCheck(existing.id);
+  }
 }
 
 // GET — Return backup config + recent history + status
-export async function GET() {
-    try {
-        const config = await getConfig();
-        const history = await getBackupHistory();
-        return NextResponse.json({
-            config: config.backup || null,
-            history: history.slice(0, 20),
-            running: isBackupRunning(),
-        });
-    } catch (error) {
-        return apiError(error, { tag: 'api:settings:backup-sync:get', status: 500 });
+export const GET = withApiHandler({}, async () => {
+  const config = await getConfig();
+  const history = await getBackupHistory();
+  return NextResponse.json({
+    config: config.backup || null,
+    history: history.slice(0, 20),
+    running: isBackupRunning(),
+  });
+});
+
+// POST — action dispatcher. Body validation per branch is loose
+// (BackupConfig + BackupTarget come from `lib/backup/types.ts` and
+// have a richer schema than is worth duplicating here); the migration
+// keeps the same shape while picking up requireSession + uniform
+// error envelope.
+const PostBody = z.object({
+  action: z.enum(['save', 'run', 'test']),
+  config: z.unknown().optional(),
+  target: z.unknown().optional(),
+});
+
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  switch (body.action) {
+    case 'save': {
+      const backupConfig = body.config as BackupConfig | undefined;
+      if (!backupConfig) {
+        return NextResponse.json({ error: 'config is required' }, { status: 400 });
+      }
+      await updateConfig({ backup: backupConfig });
+      ensureBackupHealthCheck(backupConfig.enabled);
+      scheduleBackup();
+      return NextResponse.json({ success: true });
     }
-}
-
-// POST — Actions: save, run, test
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-    try {
-        const body = await request.json();
-        const action = body.action as string;
-
-        switch (action) {
-            case 'save': {
-                const backupConfig = body.config as BackupConfig;
-                if (!backupConfig) {
-                    return NextResponse.json({ error: 'config is required' }, { status: 400 });
-                }
-                await updateConfig({ backup: backupConfig });
-                // Create or remove health check
-                ensureBackupHealthCheck(backupConfig.enabled);
-                // Reschedule
-                scheduleBackup();
-                return NextResponse.json({ success: true });
-            }
-
-            case 'run': {
-                if (isBackupRunning()) {
-                    return NextResponse.json({ error: 'Backup is already running' }, { status: 409 });
-                }
-                // Run in background, return immediately
-                const config = await getConfig();
-                if (!config.backup) {
-                    return NextResponse.json({ error: 'No backup configured' }, { status: 400 });
-                }
-                // Fire and forget — client polls for status
-                runBackup(config.backup).catch(() => { /* logged internally */ });
-                return NextResponse.json({ success: true, message: 'Backup started' });
-            }
-
-            case 'test': {
-                const target = body.target as BackupTarget;
-                if (!target) {
-                    return NextResponse.json({ error: 'target is required' }, { status: 400 });
-                }
-                const result = await testBackupTarget(target);
-                return NextResponse.json(result);
-            }
-
-            default:
-                return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
-        }
-    } catch (error) {
-        return apiError(error, { tag: 'api:settings:backup-sync:post', status: 500 });
+    case 'run': {
+      if (isBackupRunning()) {
+        return NextResponse.json({ error: 'Backup is already running' }, { status: 409 });
+      }
+      const config = await getConfig();
+      if (!config.backup) {
+        return NextResponse.json({ error: 'No backup configured' }, { status: 400 });
+      }
+      runBackup(config.backup).catch(() => { /* logged internally */ });
+      return NextResponse.json({ success: true, message: 'Backup started' });
     }
-}
+    case 'test': {
+      const target = body.target as BackupTarget | undefined;
+      if (!target) {
+        return NextResponse.json({ error: 'target is required' }, { status: 400 });
+      }
+      const result = await testBackupTarget(target);
+      return NextResponse.json(result);
+    }
+  }
+});

--- a/src/app/api/settings/backups/download/route.ts
+++ b/src/app/api/settings/backups/download/route.ts
@@ -1,33 +1,29 @@
 import fs from 'fs';
 import { Readable } from 'stream';
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getBackupFileMeta } from '@/lib/systemBackup';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const fileName = searchParams.get('file');
+const QuerySchema = z.object({ file: z.string().min(1) });
 
-  if (!fileName) {
-    return NextResponse.json({ error: 'file query parameter is required' }, { status: 400 });
-  }
-
+export const GET = withApiHandler({ query: QuerySchema }, async ({ query }) => {
   try {
-    const meta = await getBackupFileMeta(fileName);
+    const meta = await getBackupFileMeta(query.file);
     const nodeStream = fs.createReadStream(meta.path);
     const webStream = Readable.toWeb(nodeStream) as ReadableStream;
-
     return new NextResponse(webStream, {
       headers: {
         'Content-Type': 'application/gzip',
         'Content-Disposition': `attachment; filename="${meta.fileName}"`,
         'Content-Length': meta.size.toString(),
-        'Cache-Control': 'no-store'
-      }
+        'Cache-Control': 'no-store',
+      },
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Backup not found';
     return NextResponse.json({ error: message }, { status: 404 });
   }
-}
+});

--- a/src/app/api/settings/backups/file/route.ts
+++ b/src/app/api/settings/backups/file/route.ts
@@ -1,41 +1,34 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import os from 'os';
 import path from 'path';
 import { getBackupFileMeta, readSystemBackupFile } from '@/lib/systemBackup';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const PostBody = z.object({
+  fileName: z.string().min(1).optional(),
+  uploadToken: z.string().min(1).optional(),
+  nodeName: z.string().min(1),
+  relativePath: z.string().min(1),
+});
 
-  try {
-    const body = await request.json().catch(() => ({}));
-    const fileName = body.fileName as string | undefined;
-    const uploadToken = body.uploadToken as string | undefined;
-    const nodeName = body.nodeName as string | undefined;
-    const relativePath = body.relativePath as string | undefined;
-
-    if (!nodeName || !relativePath) {
-      return NextResponse.json({ error: 'nodeName and relativePath are required' }, { status: 400 });
-    }
-
-    let archivePath: string;
-    if (uploadToken) {
-      archivePath = path.join(os.tmpdir(), `servicebay-upload-${uploadToken}.tar.gz`);
-    } else if (fileName) {
-      const entry = await getBackupFileMeta(fileName);
-      archivePath = entry.path;
-    } else {
-      return NextResponse.json({ error: 'fileName or uploadToken is required' }, { status: 400 });
-    }
-
-    const content = await readSystemBackupFile(archivePath, nodeName, relativePath);
-    return NextResponse.json({ content });
-  } catch (error) {
-    return apiError(error, { tag: 'api:settings:backups:file', status: 500 });
+/**
+ * POST — fetch one file from a backup archive (either stored on disk
+ * by fileName, or an upload referenced by uploadToken from /preview).
+ */
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  const { fileName, uploadToken, nodeName, relativePath } = body;
+  let archivePath: string;
+  if (uploadToken) {
+    archivePath = path.join(os.tmpdir(), `servicebay-upload-${uploadToken}.tar.gz`);
+  } else if (fileName) {
+    const entry = await getBackupFileMeta(fileName);
+    archivePath = entry.path;
+  } else {
+    return NextResponse.json({ error: 'fileName or uploadToken is required' }, { status: 400 });
   }
-}
+  const content = await readSystemBackupFile(archivePath, nodeName, relativePath);
+  return NextResponse.json({ content });
+});

--- a/src/app/api/settings/backups/preview/route.ts
+++ b/src/app/api/settings/backups/preview/route.ts
@@ -4,51 +4,44 @@ import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
 import { getBackupFileMeta, previewSystemBackup } from '@/lib/systemBackup';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-const createUploadPath = (token: string) => path.join(os.tmpdir(), `servicebay-upload-${token}.tar.gz`);
+const createUploadPath = (token: string) =>
+  path.join(os.tmpdir(), `servicebay-upload-${token}.tar.gz`);
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-  try {
-    const contentType = request.headers.get('content-type') || '';
-    if (contentType.includes('multipart/form-data')) {
-      const formData = await request.formData();
-      const file = formData.get('file');
-      if (!file || typeof file === 'string') {
-        return NextResponse.json({ error: 'file is required' }, { status: 400 });
-      }
-      const token = crypto.randomBytes(8).toString('hex');
-      const archivePath = createUploadPath(token);
-      const buffer = Buffer.from(await file.arrayBuffer());
-      await fs.writeFile(archivePath, buffer);
-
-      const preview = await previewSystemBackup(archivePath);
-      return NextResponse.json({
-        preview,
-        source: { type: 'upload', token }
-      });
+/**
+ * POST — preview a backup before restoring. Accepts either a JSON
+ * body `{ fileName }` (preview a stored backup) or a multipart form
+ * with `file` (preview an uploaded archive).
+ *
+ * Multipart routes can't use `withApiHandler`'s `body:` slot — it
+ * reads JSON. The handler skeleton still buys us requireSession +
+ * uniform error envelope; multipart handling stays inline.
+ */
+export const POST = withApiHandler({}, async ({ request }) => {
+  const contentType = request.headers.get('content-type') || '';
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!file || typeof file === 'string') {
+      return NextResponse.json({ error: 'file is required' }, { status: 400 });
     }
-
-    const body = await request.json().catch(() => ({}));
-    const fileName = body.fileName as string | undefined;
-    if (!fileName) {
-      return NextResponse.json({ error: 'fileName is required' }, { status: 400 });
-    }
-
-    const entry = await getBackupFileMeta(fileName);
-    const preview = await previewSystemBackup(entry.path);
-    return NextResponse.json({
-      preview,
-      source: { type: 'stored', fileName: entry.fileName }
-    });
-  } catch (error) {
-    return apiError(error, { tag: 'api:settings:backups:preview', status: 500 });
+    const token = crypto.randomBytes(8).toString('hex');
+    const archivePath = createUploadPath(token);
+    const buffer = Buffer.from(await file.arrayBuffer());
+    await fs.writeFile(archivePath, buffer);
+    const preview = await previewSystemBackup(archivePath);
+    return NextResponse.json({ preview, source: { type: 'upload', token } });
   }
-}
+
+  const body = await request.json().catch(() => ({}));
+  const fileName = body.fileName as string | undefined;
+  if (!fileName) {
+    return NextResponse.json({ error: 'fileName is required' }, { status: 400 });
+  }
+  const entry = await getBackupFileMeta(fileName);
+  const preview = await previewSystemBackup(entry.path);
+  return NextResponse.json({ preview, source: { type: 'stored', fileName: entry.fileName } });
+});

--- a/src/app/api/settings/backups/restore/route.ts
+++ b/src/app/api/settings/backups/restore/route.ts
@@ -1,55 +1,46 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import path from 'path';
 import os from 'os';
 import fs from 'fs/promises';
 import { getBackupFileMeta, restoreSystemBackup, restoreSystemBackupSelection, type BackupRestoreSelection } from '@/lib/systemBackup';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const PostBody = z.object({
+  fileName: z.string().min(1).optional(),
+  uploadToken: z.string().regex(/^[a-z0-9-]+$/i).optional(),
+  selection: z.unknown().optional(),
+});
 
-  try {
-    const body = await request.json().catch(() => ({}));
-    const fileName = body.fileName as string | undefined;
-    const uploadToken = body.uploadToken as string | undefined;
-    const selection = body.selection as BackupRestoreSelection | undefined;
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  const { fileName, uploadToken } = body;
+  const selection = body.selection as BackupRestoreSelection | undefined;
 
-    let archivePath: string | undefined;
-    let cleanupPath: string | undefined;
-    if (fileName) {
-      const entry = await getBackupFileMeta(fileName);
-      archivePath = entry.path;
-    } else if (uploadToken && /^[a-z0-9-]+$/i.test(uploadToken)) {
-      archivePath = path.join(os.tmpdir(), `servicebay-upload-${uploadToken}.tar.gz`);
-      cleanupPath = archivePath;
-    } else {
-      return NextResponse.json({ error: 'fileName or uploadToken is required' }, { status: 400 });
-    }
-
-    if (selection) {
-      await restoreSystemBackupSelection(archivePath, selection);
-      if (cleanupPath) {
-        await fs.rm(cleanupPath, { force: true });
-      }
-      return NextResponse.json({ success: true });
-    }
-
-    if (cleanupPath) {
-      return NextResponse.json({ error: 'selection is required for uploaded backups' }, { status: 400 });
-    }
-
-    const restored = await restoreSystemBackup(fileName || path.basename(archivePath));
-    const payload = { fileName: restored.fileName, createdAt: restored.createdAt, size: restored.size };
-    if (cleanupPath) {
-      await fs.rm(cleanupPath, { force: true });
-    }
-    return NextResponse.json({ success: true, restored: payload });
-  } catch (error) {
-    return apiError(error, { tag: 'api:settings:backups:restore', status: 500 });
+  let archivePath: string | undefined;
+  let cleanupPath: string | undefined;
+  if (fileName) {
+    const entry = await getBackupFileMeta(fileName);
+    archivePath = entry.path;
+  } else if (uploadToken) {
+    archivePath = path.join(os.tmpdir(), `servicebay-upload-${uploadToken}.tar.gz`);
+    cleanupPath = archivePath;
+  } else {
+    return NextResponse.json({ error: 'fileName or uploadToken is required' }, { status: 400 });
   }
-}
+
+  if (selection) {
+    await restoreSystemBackupSelection(archivePath, selection);
+    if (cleanupPath) await fs.rm(cleanupPath, { force: true });
+    return NextResponse.json({ success: true });
+  }
+
+  if (cleanupPath) {
+    return NextResponse.json({ error: 'selection is required for uploaded backups' }, { status: 400 });
+  }
+
+  const restored = await restoreSystemBackup(fileName || path.basename(archivePath));
+  const payload = { fileName: restored.fileName, createdAt: restored.createdAt, size: restored.size };
+  return NextResponse.json({ success: true, restored: payload });
+});

--- a/src/app/api/settings/backups/route.ts
+++ b/src/app/api/settings/backups/route.ts
@@ -1,37 +1,39 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { createSystemBackup, deleteSystemBackup, listSystemBackups } from '@/lib/systemBackup';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  try {
-    const backups = await listSystemBackups();
-    const payload = backups.map(({ fileName, createdAt, size }) => ({ fileName, createdAt, size }));
-    return NextResponse.json(payload);
-  } catch (error) {
-    return apiError(error, { tag: 'api:settings:backups:list', status: 500 });
-  }
-}
+export const GET = withApiHandler({}, async () => {
+  const backups = await listSystemBackups();
+  const payload = backups.map(({ fileName, createdAt, size }) => ({ fileName, createdAt, size }));
+  return NextResponse.json(payload);
+});
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+/**
+ * POST — create a new system backup. Streams progress as NDJSON. Body
+ * deliberately unused; `withApiHandler` skips body parsing when
+ * `options.body` isn't set.
+ */
+export const POST = withApiHandler({}, async () => {
   const encoder = new TextEncoder();
-
   const stream = new ReadableStream({
     start(controller) {
       const push = (data: unknown) => {
         controller.enqueue(encoder.encode(`${JSON.stringify(data)}\n`));
       };
-
       (async () => {
         try {
           const result = await createSystemBackup(entry => push({ type: 'log', entry }));
-          push({ type: 'done', backup: { fileName: result.entry.fileName, createdAt: result.entry.createdAt, size: result.entry.size } });
+          push({
+            type: 'done',
+            backup: {
+              fileName: result.entry.fileName,
+              createdAt: result.entry.createdAt,
+              size: result.entry.size,
+            },
+          });
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Failed to create backup';
           push({ type: 'error', message });
@@ -39,32 +41,27 @@ export async function POST(request: Request) {
           controller.close();
         }
       })();
-    }
+    },
   });
-
   return new NextResponse(stream, {
     headers: {
       'Content-Type': 'application/x-ndjson',
-      'Cache-Control': 'no-store'
-    }
+      'Cache-Control': 'no-store',
+    },
   });
-}
+});
 
-export async function DELETE(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const DeleteBody = z.object({ fileName: z.string().min(1).optional() });
 
-  try {
-    const body = await request.json().catch(() => ({}));
-    const url = new URL(request.url);
-    const fileName = body.fileName ?? url.searchParams.get('file');
-    if (!fileName) {
-      return NextResponse.json({ error: 'fileName is required' }, { status: 400 });
-    }
-    await deleteSystemBackup(fileName);
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    return apiError(error, { tag: 'api:settings:backups:delete', status: 500 });
+export const DELETE = withApiHandler({ body: DeleteBody.optional() }, async ({ body, request }) => {
+  // Accept fileName from body OR ?file= query for back-compat — the
+  // settings UI sends it in the body, but operator-supplied curl might
+  // use the query form.
+  const url = new URL(request.url);
+  const fileName = body?.fileName ?? url.searchParams.get('file');
+  if (!fileName) {
+    return NextResponse.json({ error: 'fileName is required' }, { status: 400 });
   }
-}
+  await deleteSystemBackup(fileName);
+  return NextResponse.json({ success: true });
+});

--- a/src/app/api/settings/gateway/route.ts
+++ b/src/app/api/settings/gateway/route.ts
@@ -1,40 +1,32 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getConfig, updateConfig } from '@/lib/config';
-import { requireSession } from '@/lib/api/requireSession';
-import { apiError } from '@/lib/api/errors';
 import { FritzBoxClient } from '@/lib/fritzbox/client';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * Settings → Gateway (FritzBox) — read + update endpoint (#333).
+ * Settings → Gateway (FritzBox) — read + update endpoint (#333,
+ * migrated to withApiHandler in #603).
  *
- * Until this PR the only ways to change `config.gateway` were
- * re-running install-fedora-coreos.sh or hand-editing config.json on
- * the box. The "Edit Gateway" button on the Internet-Gateway card
- * also wrongly linked to /registry?selected=gateway (templates).
+ * Existing response shape preserved so `GatewaySection.tsx` doesn't
+ * need to change.
  */
 
 /** Read-only view: omit the password (we never echo it back). */
-export async function GET(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  try {
-    const config = await getConfig();
-    const gw = config.gateway;
-    return NextResponse.json({
-      configured: !!gw,
-      type: gw?.type ?? null,
-      host: gw?.host ?? '',
-      username: gw?.username ?? '',
-      hasPassword: !!gw?.password,
-      ssl: !!gw?.ssl,
-    });
-  } catch (e) {
-    return apiError(e, { tag: 'api:settings:gateway:get', status: 500 });
-  }
-}
+export const GET = withApiHandler({}, async () => {
+  const config = await getConfig();
+  const gw = config.gateway;
+  return NextResponse.json({
+    configured: !!gw,
+    type: gw?.type ?? null,
+    host: gw?.host ?? '',
+    username: gw?.username ?? '',
+    hasPassword: !!gw?.password,
+    ssl: !!gw?.ssl,
+  });
+});
 
 const UpdateBody = z.object({
   host: z.string().min(1).max(255),
@@ -46,54 +38,45 @@ const UpdateBody = z.object({
   test: z.boolean().optional(),
 });
 
-export async function POST(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  try {
-    const body = UpdateBody.parse(await request.json());
-    const current = await getConfig();
-    const existing = current.gateway;
+export const POST = withApiHandler({ body: UpdateBody }, async ({ body }) => {
+  const current = await getConfig();
+  const existing = current.gateway;
 
-    // Only overwrite password when the body provided one. The form
-    // sends an empty string when the operator didn't touch the field —
-    // keep what's there in that case.
-    const password = body.password && body.password.length > 0
-      ? body.password
-      : existing?.password;
+  // Only overwrite password when the body provided one. The form sends
+  // an empty string when the operator didn't touch the field — keep
+  // what's there in that case.
+  const password = body.password && body.password.length > 0
+    ? body.password
+    : existing?.password;
 
-    const next = {
-      type: 'fritzbox' as const,
-      host: body.host.trim(),
-      username: body.username?.trim() || undefined,
-      password,
-      ssl: body.ssl ?? existing?.ssl,
-    };
+  const next = {
+    type: 'fritzbox' as const,
+    host: body.host.trim(),
+    username: body.username?.trim() || undefined,
+    password,
+    ssl: body.ssl ?? existing?.ssl,
+  };
 
-    if (body.test) {
-      // Best-effort credential check — getStatus hits both the
-      // unauthenticated UPnP path (anonymous IP/uptime) and, if
-      // username+password are provided, switches to authenticated
-      // TR-064. A failure here means either wrong creds, wrong
-      // host, or unreachable box; surface it before persisting so
-      // the operator doesn't silently lock themselves out.
-      try {
-        const client = new FritzBoxClient({
-          host: next.host,
-          username: next.username,
-          password: next.password,
-        });
-        await client.getStatus();
-      } catch (e) {
-        return NextResponse.json({
-          error: 'connection_failed',
-          message: e instanceof Error ? e.message : String(e),
-        }, { status: 400 });
-      }
+  if (body.test) {
+    // Best-effort credential check — getStatus hits both the
+    // unauthenticated UPnP path and, with credentials, authenticated
+    // TR-064. Surface failures before persisting so the operator
+    // doesn't silently lock themselves out.
+    try {
+      const client = new FritzBoxClient({
+        host: next.host,
+        username: next.username,
+        password: next.password,
+      });
+      await client.getStatus();
+    } catch (e) {
+      return NextResponse.json({
+        error: 'connection_failed',
+        message: e instanceof Error ? e.message : String(e),
+      }, { status: 400 });
     }
-
-    await updateConfig({ gateway: next });
-    return NextResponse.json({ ok: true });
-  } catch (e) {
-    return apiError(e, { tag: 'api:settings:gateway:post', status: 400 });
   }
-}
+
+  await updateConfig({ gateway: next });
+  return NextResponse.json({ ok: true });
+});

--- a/src/app/api/settings/logLevel/route.ts
+++ b/src/app/api/settings/logLevel/route.ts
@@ -1,59 +1,30 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { logger } from '@/lib/logger';
 import { updateConfig } from '@/lib/config';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  try {
-    const currentLevel = logger.getLogLevel();
-    return NextResponse.json({
-      success: true,
-      logLevel: currentLevel
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({
-      success: false,
-      error: message
-    }, { status: 500 });
-  }
-}
+const LogLevel = z.enum(['debug', 'info', 'warn', 'error']);
+const PutBody = z.object({ logLevel: LogLevel });
 
-export async function PUT(req: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(req);
-  if (__auth instanceof NextResponse) return __auth;
+/**
+ * Log-level GET/PUT (#603 / ARCH-14 settings cluster migration).
+ *
+ * Returns `{ success: true, logLevel }` rather than wrapping in the
+ * canonical `{ ok, data }` envelope so existing callers
+ * (`LogLevelControl.tsx`, `LogViewer.tsx`) don't need to change. The
+ * handler still buys us Zod validation, requireSession on PUT, and
+ * uniform error shape.
+ */
+export const GET = withApiHandler({}, async () => {
+  return NextResponse.json({ success: true, logLevel: logger.getLogLevel() });
+});
 
-  try {
-    const body = await req.json();
-    const { logLevel } = body;
-    
-    if (!logLevel) {
-      return NextResponse.json({
-        success: false,
-        error: 'logLevel is required'
-      }, { status: 400 });
-    }
-    
-    // Update in-memory logger
-    logger.setLogLevel(logLevel);
-    logger.info('API', `Log level changed to: ${logLevel}`);
-
-    // Persist to config
-    await updateConfig({ logLevel });
-    
-    return NextResponse.json({
-      success: true,
-      logLevel: logger.getLogLevel()
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error('API', 'Failed to update log level:', err);
-    return NextResponse.json({
-      success: false,
-      error: message
-    }, { status: 500 });
-  }
-}
+export const PUT = withApiHandler({ body: PutBody }, async ({ body }) => {
+  logger.setLogLevel(body.logLevel);
+  logger.info('API', `Log level changed to: ${body.logLevel}`);
+  await updateConfig({ logLevel: body.logLevel });
+  return NextResponse.json({ success: true, logLevel: logger.getLogLevel() });
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -4,25 +4,30 @@ import { getTemplateSettingsSchema } from '@/lib/registry';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { logger } from '@/lib/logger';
 import { AppConfigPartialSchema, formatConfigErrors } from '@/lib/config/schema';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function GET() {
+export const dynamic = 'force-dynamic';
+
+export const GET = withApiHandler({}, async () => {
   const [config, templateSettingsSchema] = await Promise.all([
     getConfig(),
-    getTemplateSettingsSchema()
+    getTemplateSettingsSchema(),
   ]);
+  return NextResponse.json({ ...config, templateSettingsSchema });
+});
 
-  return NextResponse.json({
-    ...config,
-    templateSettingsSchema
-  });
-}
-
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+/**
+ * Settings POST — accepts a Partial<AppConfig> via the AppConfigPartialSchema
+ * validator (#595), merges with the persisted config, persists, and returns
+ * the new full config so the UI doesn't have to re-fetch.
+ *
+ * Body validation is deliberately done inside the handler rather than via
+ * `withApiHandler`'s `body:` slot — `AppConfigPartialSchema` already
+ * formats errors with the more detailed `formatConfigErrors` shape the
+ * settings UI displays. Re-routing through the handler's Zod path would
+ * lose that fidelity.
+ */
+export const POST = withApiHandler({}, async ({ request }) => {
   let body: unknown;
   try {
     body = await request.json();
@@ -30,12 +35,6 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  // Validate the body shape against AppConfigSchema BEFORE merging (#595).
-  // `.partial().strict()` rejects unknown top-level keys (catches typos
-  // like `servername` vs `serverName` before they corrupt config.json)
-  // and wrong-typed primitives, while still allowing PATCH-style writes
-  // that only touch a subset of fields. Complex nested objects pass
-  // through for now — tightening them is purely additive.
   const parsed = AppConfigPartialSchema.safeParse(body);
   if (!parsed.success) {
     const errors = formatConfigErrors(parsed.error);
@@ -44,30 +43,22 @@ export async function POST(request: Request) {
   }
   const validated = parsed.data as Partial<AppConfig>;
 
-  try {
-    const currentConfig = await getConfig();
+  const currentConfig = await getConfig();
+  const newConfig: AppConfig = {
+    ...currentConfig,
+    ...validated,
+    templateSettings: validated.templateSettings ?? currentConfig.templateSettings,
+    notifications: validated.notifications ? {
+      ...currentConfig.notifications,
+      ...validated.notifications,
+    } : currentConfig.notifications,
+  };
 
-    // Merge — same shallow shape the old code used. notifications is
-    // shallow-merged so the UI can send a partial notifications block.
-    const newConfig: AppConfig = {
-      ...currentConfig,
-      ...validated,
-      templateSettings: validated.templateSettings ?? currentConfig.templateSettings,
-      notifications: validated.notifications ? {
-        ...currentConfig.notifications,
-        ...validated.notifications,
-      } : currentConfig.notifications,
-    };
+  await saveConfig(newConfig);
 
-    await saveConfig(newConfig);
-
-    if ('serverName' in validated) {
-      DigitalTwinStore.getInstance().setServerName(newConfig.serverName ?? null);
-    }
-
-    return NextResponse.json(newConfig);
-  } catch (error) {
-    logger.error('api:settings:post', 'Failed to save config', error);
-    return NextResponse.json({ error: 'Failed to save config' }, { status: 500 });
+  if ('serverName' in validated) {
+    DigitalTwinStore.getInstance().setServerName(newConfig.serverName ?? null);
   }
-}
+
+  return NextResponse.json(newConfig);
+});


### PR DESCRIPTION
Refs #603 (tracking — backlog continues). First cluster done.

## Summary

All 9 routes under \`src/app/api/settings/\` now use \`withApiHandler\`:

| Route | Methods |
|---|---|
| \`/api/settings\` | GET, POST (Partial<AppConfig> mutator) |
| \`/api/settings/logLevel\` | GET, PUT |
| \`/api/settings/gateway\` | GET, POST (FritzBox config + connection test) |
| \`/api/settings/backup-sync\` | GET, POST (action dispatcher: save/run/test) |
| \`/api/settings/backups\` | GET, POST (NDJSON stream), DELETE |
| \`/api/settings/backups/preview\` | POST (JSON or multipart) |
| \`/api/settings/backups/file\` | POST (read one file from archive) |
| \`/api/settings/backups/download\` | GET (streams gzip) |
| \`/api/settings/backups/restore\` | POST (full + partial restore) |

### What stayed the same

Existing response shapes are preserved by returning explicit \`NextResponse.json(...)\` instead of relying on \`withApiHandler\`'s \`{ ok, data }\` wrapping — clients keep working without changes. Multipart parsing in \`preview/\` stays inline (the handler's \`body:\` slot only handles JSON).

### What's better

- **Uniform requireSession gate** on all mutating methods (POST/PUT/DELETE).
- **Zod-validated body + query** — validation errors return the canonical \`{ ok: false, error: 'validation failed', code: 'VALIDATION', details }\` shape, replacing the per-route \`return NextResponse.json({error: ...}, {status: 400})\` pattern.
- **One try/catch instead of nine** — \`withApiHandler\` catches and logs internally.
- **~100 net LoC removed** across the cluster (321 ins, 421 del).

### Ratchet

Adoption: **1/96 → 12/104** routes (~11.5%). Ratcheted \`MIN_WITH_API_HANDLER_RATIO\` floor 0.01 → 0.10 so this gain can't slide back.

## Test plan

- [x] \`npm run check:arch\` — 525 modules, no violations; adoption-ratio invariant green at new floor
- [x] \`npm run lint\` — 0 errors, **warnings dropped 141 → 130** (the migrated routes no longer trigger \`sb/api-route-needs-handler\`)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1099 pass / 2 skipped (no behaviour change)
- [x] \`npm run build\` — clean

## Next clusters (per #603)

- credentials cluster (~12 routes) — \`system/credentials\`, \`system/nginx/credentials\`, \`system/lldap/credentials\`, \`system/adguard/credentials\`
- system/access-requests, mode, storage, update, update-window, reinstall (~12 routes)
- services (~10 routes, biggest payoff)
- the long tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)