### PR TITLE
refactor(api): migrate system mode/update/reinstall/certs/etc. to withApiHandler (#603)

### DIFF
--- a/src/app/api/system/access-requests/route.ts
+++ b/src/app/api/system/access-requests/route.ts
@@ -4,8 +4,15 @@ import crypto from 'crypto';
 import { getConfig, saveConfig, getAdminBaseUrl, type AccessRequest } from '@/lib/config';
 import { sendEmailAlert } from '@/lib/email';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
+
+// NOTE: POST is intentionally NOT routed through `withApiHandler` —
+// the endpoint is public (anonymous family-LAN visitors hit it from
+// the portal) and the handler's built-in requireSession gate would
+// reject every submission. GET is admin-only and goes through the
+// handler.
 
 /**
  * "Request access" endpoint for the family portal (#242 follow-up).
@@ -119,8 +126,8 @@ export async function POST(request: Request) {
   return NextResponse.json({ ok: true, id: newRequest.id });
 }
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   const config = await getConfig();
   const requests = config.accessRequests ?? [];
   return NextResponse.json({ requests });
-}
+});

--- a/src/app/api/system/certs/archive/route.ts
+++ b/src/app/api/system/certs/archive/route.ts
@@ -1,33 +1,20 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { getConfig } from '@/lib/config';
 import { DigitalTwinStore } from '@/lib/store/twin';
-import { requireSession } from '@/lib/api/requireSession';
-import { apiError } from '@/lib/api/errors';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * Cert archive management.
+ * Cert archive management (#603 — migrated to withApiHandler).
  *
- * **Why this exists:** LE's "5 duplicate certs per 168h" rate limit
- * bites hard when an operator iterates on a fresh install — every
- * clean-install/reset wipes NPM's `/etc/letsencrypt` and `data/`
- * directories, so the next install re-requests the same domains and
- * the operator quickly hits the wall.
- *
- * Archives live at `/mnt/data/servicebay/cert-archive/npm-<ts>.tar.gz`.
- * That path is outside the reset endpoint's wipe target and outside
- * the OS-reinstall-recovery `quadlet-backup`, so a snapshot survives
- * everything short of `rm -rf /mnt/data/servicebay`.
- *
- * Endpoints:
- *   - `GET`  — list archives (newest first), each with size + mtime.
- *   - `POST` — take a fresh snapshot of the current NPM data dir.
- *   - `POST { restore: <filename> }` — restore an archive into NPM's
- *     data dir. Refuses if NPM has running services that would block
- *     the operation; recommends a stop-and-redeploy flow.
+ * LE's "5 duplicate certs per 168h" rate limit bites when an operator
+ * iterates on a fresh install; this endpoint manages snapshots at
+ * `/mnt/data/servicebay/cert-archive/npm-<ts>.tar.gz` that survive
+ * a clean install + OS reinstall.
  */
 
 const ARCHIVE_DIR = '/mnt/data/servicebay/cert-archive';
@@ -53,7 +40,6 @@ async function listArchives(): Promise<ListEntry[]> {
   if (!node) return [];
   const agent = await agentManager.ensureAgent(node);
   const res = await agent.sendCommand('exec', {
-    // GNU stat output: name|size|epoch. Sort by epoch desc so newest is first.
     command: `mkdir -p ${ARCHIVE_DIR} && find ${ARCHIVE_DIR} -maxdepth 1 -type f -name 'npm-*.tar.gz' -printf '%f|%s|%T@\\n' 2>/dev/null | sort -t '|' -k3 -r`,
   });
   const lines = (res.stdout || '').split('\n').filter(Boolean);
@@ -68,84 +54,69 @@ async function listArchives(): Promise<ListEntry[]> {
   });
 }
 
-export async function GET(request: NextRequest) {
-  try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-    const archives = await listArchives();
-    return NextResponse.json({ archives, archiveDir: ARCHIVE_DIR });
-  } catch (error) {
-    return apiError(error, { tag: 'api:system:certs:archive:list', status: 500 });
-  }
-}
+export const GET = withApiHandler({}, async () => {
+  const archives = await listArchives();
+  return NextResponse.json({ archives, archiveDir: ARCHIVE_DIR });
+});
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
+const PostBody = z.object({
+  restore: z.string().optional(),
+  node: z.string().optional(),
+});
 
-    const body = (await request.json().catch(() => ({}))) as { restore?: string; node?: string };
-    const twin = DigitalTwinStore.getInstance();
-    const node = resolveNode(twin, body.node);
-    if (!node) return NextResponse.json({ error: 'No nodes available' }, { status: 404 });
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  const twin = DigitalTwinStore.getInstance();
+  const node = resolveNode(twin, body.node);
+  if (!node) return NextResponse.json({ error: 'No nodes available' }, { status: 404 });
 
-    const cfg = await getConfig();
-    const dataDir = resolveDataDir(cfg);
-    const agent = await agentManager.ensureAgent(node);
+  const cfg = await getConfig();
+  const dataDir = resolveDataDir(cfg);
+  const agent = await agentManager.ensureAgent(node);
 
-    if (body.restore) {
-      // Refuse paths that escape the archive dir — the only way to
-      // weaponise this endpoint is to point it at an arbitrary
-      // tarball outside our control.
-      if (!/^npm-[A-Za-z0-9_.\-]+\.tar\.gz$/.test(body.restore)) {
-        return NextResponse.json({ error: 'Invalid archive filename' }, { status: 400 });
-      }
-      const archivePath = `${ARCHIVE_DIR}/${body.restore}`;
-      // Refuse if NPM's data dir is non-empty — we don't want to
-      // half-overwrite a running stack's state. Operator should
-      // reset (which now auto-snapshots) and reinstall instead.
-      const probe = await agent.sendCommand('exec', {
-        command: `[ -d "${dataDir}/nginx-proxy-manager" ] && find "${dataDir}/nginx-proxy-manager" -mindepth 1 -maxdepth 1 | head -1 || true`,
-      });
-      if ((probe.stdout || '').trim()) {
-        return NextResponse.json({
-          error: 'NPM data dir is not empty. Run a clean install (which auto-archives current state) and the install runner will restore this snapshot on the next nginx deploy.',
-        }, { status: 409 });
-      }
-      await agent.sendCommand('exec', {
-        command: `mkdir -p "${dataDir}" && tar xzf "${archivePath}" -C "${dataDir}"`,
-      });
-      logger.info('CertArchive', `Restored ${archivePath} into ${dataDir}/nginx-proxy-manager`);
-      return NextResponse.json({ ok: true, restored: archivePath });
+  if (body.restore) {
+    if (!/^npm-[A-Za-z0-9_.\-]+\.tar\.gz$/.test(body.restore)) {
+      return NextResponse.json({ error: 'Invalid archive filename' }, { status: 400 });
     }
-
-    // Snapshot path.
+    const archivePath = `${ARCHIVE_DIR}/${body.restore}`;
     const probe = await agent.sendCommand('exec', {
-      command: `[ -d "${dataDir}/nginx-proxy-manager/letsencrypt/live" ] && find "${dataDir}/nginx-proxy-manager/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
+      command: `[ -d "${dataDir}/nginx-proxy-manager" ] && find "${dataDir}/nginx-proxy-manager" -mindepth 1 -maxdepth 1 | head -1 || true`,
     });
-    if (!(probe.stdout || '').trim()) {
-      return NextResponse.json({ error: 'No issued certs found — nothing worth archiving yet.' }, { status: 400 });
+    if ((probe.stdout || '').trim()) {
+      return NextResponse.json({
+        error: 'NPM data dir is not empty. Run a clean install (which auto-archives current state) and the install runner will restore this snapshot on the next nginx deploy.',
+      }, { status: 409 });
     }
-    const ts = new Date().toISOString().replace(/[:.]/g, '-');
-    const filename = `npm-${ts}.tar.gz`;
-    const archivePath = `${ARCHIVE_DIR}/${filename}`;
     await agent.sendCommand('exec', {
-      command: `mkdir -p ${ARCHIVE_DIR} && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+      command: `mkdir -p "${dataDir}" && tar xzf "${archivePath}" -C "${dataDir}"`,
     });
-    const stat = await agent.sendCommand('exec', {
-      command: `stat -c '%s|%Y' "${archivePath}" 2>/dev/null || true`,
-    });
-    const [sizeStr, epochStr] = (stat.stdout || '').trim().split('|');
-    logger.info('CertArchive', `Snapshot saved to ${archivePath}`);
-    return NextResponse.json({
-      ok: true,
-      archive: {
-        filename,
-        size: parseInt(sizeStr || '0', 10),
-        modifiedAt: epochStr ? new Date(parseFloat(epochStr) * 1000).toISOString() : new Date().toISOString(),
-      },
-    });
-  } catch (error) {
-    return apiError(error, { tag: 'api:system:certs:archive:write', status: 500 });
+    logger.info('CertArchive', `Restored ${archivePath} into ${dataDir}/nginx-proxy-manager`);
+    return NextResponse.json({ ok: true, restored: archivePath });
   }
-}
+
+  // Snapshot path.
+  const probe = await agent.sendCommand('exec', {
+    command: `[ -d "${dataDir}/nginx-proxy-manager/letsencrypt/live" ] && find "${dataDir}/nginx-proxy-manager/letsencrypt/live" -mindepth 1 -maxdepth 1 -type d | head -1 || true`,
+  });
+  if (!(probe.stdout || '').trim()) {
+    return NextResponse.json({ error: 'No issued certs found — nothing worth archiving yet.' }, { status: 400 });
+  }
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = `npm-${ts}.tar.gz`;
+  const archivePath = `${ARCHIVE_DIR}/${filename}`;
+  await agent.sendCommand('exec', {
+    command: `mkdir -p ${ARCHIVE_DIR} && tar czf "${archivePath}" -C "${dataDir}" nginx-proxy-manager`,
+  });
+  const stat = await agent.sendCommand('exec', {
+    command: `stat -c '%s|%Y' "${archivePath}" 2>/dev/null || true`,
+  });
+  const [sizeStr, epochStr] = (stat.stdout || '').trim().split('|');
+  logger.info('CertArchive', `Snapshot saved to ${archivePath}`);
+  return NextResponse.json({
+    ok: true,
+    archive: {
+      filename,
+      size: parseInt(sizeStr || '0', 10),
+      modifiedAt: epochStr ? new Date(parseFloat(epochStr) * 1000).toISOString() : new Date().toISOString(),
+    },
+  });
+});

--- a/src/app/api/system/mcp-bootstrap/route.ts
+++ b/src/app/api/system/mcp-bootstrap/route.ts
@@ -1,35 +1,20 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
-import { apiError } from '@/lib/api/errors';
-import {
-  getBootstrapTokenStatus,
-  revokeBootstrapToken,
-} from '@/lib/mcp/bootstrapToken';
+import { getBootstrapTokenStatus, revokeBootstrapToken } from '@/lib/mcp/bootstrapToken';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-/** Surface bootstrap-token state for the Settings UI. The actual hash
- *  is never returned — only `active`, `expiresAt`, `minutesRemaining`. */
-export async function GET(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  try {
-    const status = await getBootstrapTokenStatus();
-    return NextResponse.json(status);
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:mcp-bootstrap:get', status: 500 });
-  }
-}
+/**
+ * MCP bootstrap token state + manual revoke (#603 migration).
+ * GET returns `{ active, expiresAt, minutesRemaining }` — never the
+ * hash itself. DELETE is idempotent.
+ */
+export const GET = withApiHandler({}, async () => {
+  const status = await getBootstrapTokenStatus();
+  return NextResponse.json(status);
+});
 
-/** Manual revoke. Idempotent — returns 200 either way so the UI
- *  doesn't have to special-case "already gone". */
-export async function DELETE(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  try {
-    const removed = await revokeBootstrapToken();
-    return NextResponse.json({ ok: true, removed });
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:mcp-bootstrap:delete', status: 500 });
-  }
-}
+export const DELETE = withApiHandler({}, async () => {
+  const removed = await revokeBootstrapToken();
+  return NextResponse.json({ ok: true, removed });
+});

--- a/src/app/api/system/mode/route.ts
+++ b/src/app/api/system/mode/route.ts
@@ -1,65 +1,19 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getConfig, updateConfig } from '@/lib/config';
 import { getMode, getActiveDomain, isLocalOnly } from '@/lib/mode';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
 /**
- * POST /api/system/mode
+ * GET /api/system/mode — install-mode classification for the
+ * dashboard header badge. Cheap, no agent calls.
  *
- * Updates the install mode classification by saving / clearing
- * `reverseProxy.publicDomain`. Body: `{ publicDomain: string | null }`.
- *
- * This is the form-only stub that D19-PR3 ships. The full migration
- * (NPM proxy host dual-server_name, AdGuard double-rewrite, Authelia
- * issuer swap, OIDC client re-registration, Let's Encrypt certs)
- * lands with D19-PR8 (#265). For now, the field is persisted and
- * the next install/redeploy uses the new value.
+ * POST — set or clear `reverseProxy.publicDomain`. Migrated to
+ * withApiHandler in #603.
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-  let body: { publicDomain?: string | null } = {};
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-  }
-  const next = typeof body.publicDomain === 'string' ? body.publicDomain.trim() : '';
-  // Basic validation — let the user clear the domain (empty string)
-  // or set it to a hostname-shaped value. Reject obvious garbage.
-  if (next && !/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(next)) {
-    return NextResponse.json({ error: 'Domain must be a valid hostname (e.g. example.com).' }, { status: 400 });
-  }
-  const config = await getConfig();
-  await updateConfig({
-    reverseProxy: {
-      ...config.reverseProxy,
-      publicDomain: next || undefined,
-    },
-  });
-  return NextResponse.json({ ok: true, mode: next ? 'public' : 'lan' });
-}
-
-/**
- * GET /api/system/mode
- *
- * Classifies the install mode for the dashboard header badge + UI
- * branching. Returns:
- *   - mode: 'lan' | 'public' — the design's two-mode classification
- *     (#249).
- *   - publicDomain / lanDomain: the raw config fields, for UI text.
- *   - activeDomain: the suffix services live on right now (public
- *     when set, lan-domain otherwise).
- *   - localOnly: legacy alias for `mode === 'lan'` — kept for
- *     LocalOnlyBadge.tsx until the badge migrates to ModeBadge.
- *
- * Cheap and cacheable (no agent calls). Read on every page load.
- */
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   const config = await getConfig();
   return NextResponse.json({
     mode: getMode(config),
@@ -68,4 +22,20 @@ export async function GET() {
     lanDomain: config.reverseProxy?.lanDomain ?? null,
     localOnly: isLocalOnly(config),
   });
-}
+});
+
+const PostBody = z.object({
+  publicDomain: z.string().nullable().optional(),
+});
+
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  const next = typeof body.publicDomain === 'string' ? body.publicDomain.trim() : '';
+  if (next && !/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(next)) {
+    return NextResponse.json({ error: 'Domain must be a valid hostname (e.g. example.com).' }, { status: 400 });
+  }
+  const config = await getConfig();
+  await updateConfig({
+    reverseProxy: { ...config.reverseProxy, publicDomain: next || undefined },
+  });
+  return NextResponse.json({ ok: true, mode: next ? 'public' : 'lan' });
+});

--- a/src/app/api/system/reinstall/route.ts
+++ b/src/app/api/system/reinstall/route.ts
@@ -1,73 +1,33 @@
 import { NextResponse } from 'next/server';
 import { getConfig, saveConfig } from '@/lib/config';
-import { requireSession } from '@/lib/api/requireSession';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-// Banner auto-dismisses after this many minutes from completedAt.
-// Long enough to cover slow first-boot service restore on a cold
-// box, short enough to never show on a "normal" session.
 const REINSTALL_BANNER_TTL_MIN = 10;
 
 /**
- * GET /api/system/reinstall
- *
- * Tell the dashboard whether to show the "Welcome back — services
- * restoring" banner. Returns `active: false` when:
- *   - no re-install was recorded (true fresh install)
- *   - the completedAt timestamp is older than the TTL (banner expired)
- *   - the operator already dismissed it (handled by DELETE)
- *
- * See #337.
+ * GET /api/system/reinstall — drives the "Welcome back — services
+ * restoring" banner (#337). DELETE dismisses it. Migrated to
+ * withApiHandler in #603.
  */
-export async function GET(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  try {
-    const config = await getConfig();
-    const completedAt = config.reinstall?.completedAt;
-    if (!completedAt) {
-      return NextResponse.json({ active: false });
-    }
-    const completedMs = Date.parse(completedAt);
-    if (!Number.isFinite(completedMs)) {
-      return NextResponse.json({ active: false });
-    }
-    const ageMin = (Date.now() - completedMs) / 60_000;
-    if (ageMin > REINSTALL_BANNER_TTL_MIN) {
-      return NextResponse.json({ active: false });
-    }
-    const minutesRemaining = Math.max(0, Math.ceil(REINSTALL_BANNER_TTL_MIN - ageMin));
-    return NextResponse.json({
-      active: true,
-      completedAt,
-      minutesRemaining,
-    });
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:reinstall:get', status: 500 });
-  }
-}
+export const GET = withApiHandler({}, async () => {
+  const config = await getConfig();
+  const completedAt = config.reinstall?.completedAt;
+  if (!completedAt) return NextResponse.json({ active: false });
+  const completedMs = Date.parse(completedAt);
+  if (!Number.isFinite(completedMs)) return NextResponse.json({ active: false });
+  const ageMin = (Date.now() - completedMs) / 60_000;
+  if (ageMin > REINSTALL_BANNER_TTL_MIN) return NextResponse.json({ active: false });
+  const minutesRemaining = Math.max(0, Math.ceil(REINSTALL_BANNER_TTL_MIN - ageMin));
+  return NextResponse.json({ active: true, completedAt, minutesRemaining });
+});
 
-/**
- * DELETE /api/system/reinstall
- *
- * Dismiss the banner. Clears `config.reinstall` outright so subsequent
- * GETs report `active: false`.
- */
-export async function DELETE(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  try {
-    const config = await getConfig();
-    if (!config.reinstall) {
-      return NextResponse.json({ ok: true, removed: false });
-    }
-    const next = { ...config };
-    delete next.reinstall;
-    await saveConfig(next);
-    return NextResponse.json({ ok: true, removed: true });
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:reinstall:delete', status: 500 });
-  }
-}
+export const DELETE = withApiHandler({}, async () => {
+  const config = await getConfig();
+  if (!config.reinstall) return NextResponse.json({ ok: true, removed: false });
+  const next = { ...config };
+  delete next.reinstall;
+  await saveConfig(next);
+  return NextResponse.json({ ok: true, removed: true });
+});

--- a/src/app/api/system/update-window/route.ts
+++ b/src/app/api/system/update-window/route.ts
@@ -1,104 +1,57 @@
 /**
- * GET + PUT /api/system/update-window
+ * GET + PUT /api/system/update-window (#603 — migrated to withApiHandler).
  *
  * Owns the unified auto-update window — see config.ts:updateWindow for
  * the full state-machine reasoning. The TL;DR is that ServiceBay can
  * reach three different "restart now" buttons (Zincati for OS reboots,
  * `podman-auto-update.timer` for container image refresh, and its own
  * app-updater); this route renders the operator's window choice onto
- * the host so all three fire only inside the same quiet slot. When
- * the operator hasn't decided yet (or has opted out), the locks are
- * applied on server boot — see `applyLocks` in lib/updateWindow.ts
- * and server.ts.
+ * the host so all three fire only inside the same quiet slot.
  */
 import { NextResponse } from 'next/server';
-import { getConfig, updateConfig, type AppConfig } from '@/lib/config';
+import { z } from 'zod';
+import { getConfig, updateConfig } from '@/lib/config';
 import { getExecutor } from '@/lib/executor';
 import { applyUpdateWindow } from '@/lib/updateWindow';
-import { apiError } from '@/lib/api/errors';
-import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-type Window = NonNullable<AppConfig['updateWindow']>;
+const DaySchema = z.enum(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+const WindowSchema = z.object({
+  enabled: z.boolean(),
+  days: z.array(DaySchema).min(1),
+  startTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'startTime must be HH:MM (UTC)'),
+  lengthMinutes: z.number().int().min(30).max(1440),
+  applyTo: z.object({
+    os: z.boolean().optional(),
+    containers: z.boolean().optional(),
+    servicebay: z.boolean().optional(),
+  }).optional(),
+});
 
-const VALID_DAYS = new Set(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
-const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/;
+export const GET = withApiHandler({}, async () => {
+  const config = await getConfig();
+  return NextResponse.json({ window: config.updateWindow ?? null });
+});
 
-function validate(body: unknown): { ok: true; window: Window } | { ok: false; error: string } {
-  if (!body || typeof body !== 'object') return { ok: false, error: 'body must be an object' };
-  const b = body as Record<string, unknown>;
-
-  const enabled = b.enabled;
-  if (typeof enabled !== 'boolean') return { ok: false, error: '`enabled` must be a boolean' };
-
-  if (!Array.isArray(b.days)) return { ok: false, error: '`days` must be an array' };
-  const days = b.days as unknown[];
-  if (days.length === 0) return { ok: false, error: 'at least one day is required' };
-  for (const d of days) {
-    if (typeof d !== 'string' || !VALID_DAYS.has(d)) {
-      return { ok: false, error: `invalid day "${String(d)}" (expected Mon..Sun)` };
-    }
-  }
-  const dedupedDays = (days as Window['days']).filter((d, i, arr) => arr.indexOf(d) === i);
-
-  if (typeof b.startTime !== 'string' || !HHMM.test(b.startTime)) {
-    return { ok: false, error: '`startTime` must be HH:MM (UTC)' };
-  }
-  if (typeof b.lengthMinutes !== 'number' || !Number.isFinite(b.lengthMinutes)) {
-    return { ok: false, error: '`lengthMinutes` must be a number' };
-  }
-  if (b.lengthMinutes < 30 || b.lengthMinutes > 1440) {
-    return { ok: false, error: '`lengthMinutes` must be between 30 and 1440' };
-  }
-
-  const applyTo = (b.applyTo ?? {}) as Record<string, unknown>;
-  const flag = (v: unknown, fallback: boolean): boolean => (typeof v === 'boolean' ? v : fallback);
-
-  return {
-    ok: true,
-    window: {
-      enabled,
-      days: dedupedDays,
-      startTime: b.startTime,
-      lengthMinutes: Math.round(b.lengthMinutes),
-      applyTo: {
-        os: flag(applyTo.os, true),
-        containers: flag(applyTo.containers, true),
-        servicebay: flag(applyTo.servicebay, false),
-      },
+export const PUT = withApiHandler({ body: WindowSchema }, async ({ body }) => {
+  // Dedupe days + apply defaults to the optional applyTo flags.
+  const dedupedDays = body.days.filter((d, i, arr) => arr.indexOf(d) === i);
+  const window = {
+    enabled: body.enabled,
+    days: dedupedDays,
+    startTime: body.startTime,
+    lengthMinutes: body.lengthMinutes,
+    applyTo: {
+      os: body.applyTo?.os ?? true,
+      containers: body.applyTo?.containers ?? true,
+      servicebay: body.applyTo?.servicebay ?? false,
     },
   };
-}
 
-export async function GET() {
-  try {
-    const config = await getConfig();
-    return NextResponse.json({ window: config.updateWindow ?? null });
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:update-window', status: 500 });
-  }
-}
+  await applyUpdateWindow(getExecutor(), window);
+  await updateConfig({ updateWindow: window });
 
-export async function PUT(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-  try {
-    const body = await request.json();
-    const result = validate(body);
-    if (!result.ok) {
-      return NextResponse.json({ error: result.error }, { status: 400 });
-    }
-
-    await applyUpdateWindow(getExecutor(), result.window);
-    await updateConfig({ updateWindow: result.window });
-
-    return NextResponse.json({ window: result.window });
-  } catch (e) {
-    logger.error('api:system:update-window', 'Failed to apply update window', e);
-    return apiError(e, { tag: 'api:system:update-window', status: 500 });
-  }
-}
+  return NextResponse.json({ window });
+});

--- a/src/app/api/system/update/route.ts
+++ b/src/app/api/system/update/route.ts
@@ -1,59 +1,51 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { checkForUpdates, performUpdate } from '@/lib/updater';
 import { getConfig, saveConfig } from '@/lib/config';
-import { apiError } from '@/lib/api/errors';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function GET() {
-  try {
-    const status = await checkForUpdates();
-    const config = await getConfig();
-    return NextResponse.json({ ...status, config });
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:update:get', status: 500 });
-  }
-}
+export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+/**
+ * ServiceBay updater + auto-update config (#603 migration).
+ *
+ * GET returns the current update status (latest version, current
+ * version, whether autoUpdate is on) + the full config so the
+ * UpdatesSection can render without a second fetch.
+ *
+ * POST dispatches on `action`:
+ *   - `update` — trigger an in-place update; the server restarts so
+ *     the response may not reach the client.
+ *   - `configure` — persist `autoUpdate` config (cron schedule, etc.)
+ */
+export const GET = withApiHandler({}, async () => {
+  const status = await checkForUpdates();
+  const config = await getConfig();
+  return NextResponse.json({ ...status, config });
+});
 
-  try {
-    const body = await request.json();
-    
-    if (body.action === 'update') {
-      if (!body.version) {
-        return NextResponse.json({ error: 'Version required' }, { status: 400 });
-      }
-      // This will restart the server, so the response might not reach the client
-      performUpdate(body.version).catch((err) => logger.error('api:system:update', 'performUpdate failed', err));
-      return NextResponse.json({ success: true, message: 'Update started. Service will restart.' });
+const PostBody = z.object({
+  action: z.enum(['update', 'configure']),
+  version: z.string().optional(),
+  autoUpdate: z.unknown().optional(),
+});
+
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  if (body.action === 'update') {
+    if (!body.version) {
+      return NextResponse.json({ error: 'Version required' }, { status: 400 });
     }
-    
-    if (body.action === 'configure') {
-      const config = await getConfig();
-      const newConfig = {
-        ...config,
-        autoUpdate: {
-          ...config.autoUpdate,
-          ...body.autoUpdate
-        }
-      };
-      await saveConfig(newConfig);
-      
-      // We need to notify the main server process to reschedule
-      // Since we are in the same process (Next.js standalone usually runs in same process as custom server if imported),
-      // but here Next.js handles the API.
-      // If we use a custom server, we might need a way to signal it.
-      // For now, a restart is the easiest way to apply schedule changes.
-      
-      return NextResponse.json({ success: true, config: newConfig });
-    }
-
-    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
-  } catch (e) {
-    return apiError(e, { tag: 'api:system:update:post', status: 500 });
+    performUpdate(body.version).catch(err => logger.error('api:system:update', 'performUpdate failed', err));
+    return NextResponse.json({ success: true, message: 'Update started. Service will restart.' });
   }
-}
+  // configure
+  const config = await getConfig();
+  const newConfig = {
+    ...config,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    autoUpdate: { ...config.autoUpdate, ...(body.autoUpdate as any) },
+  };
+  await saveConfig(newConfig);
+  return NextResponse.json({ success: true, config: newConfig });
+});

--- a/tests/backend/access_requests.test.ts
+++ b/tests/backend/access_requests.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
 
 const state: { config: any } = { config: {} };
 
@@ -94,7 +95,7 @@ describe('GET /api/system/access-requests', () => {
     state.config.accessRequests = [
       { id: 'r1', requestedAt: '2026-01-01', name: 'A', email: 'a@b.c', status: 'pending' },
     ];
-    const res = await GET();
+    const res = await GET(new NextRequest('http://localhost/api/system/access-requests'));
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.requests).toHaveLength(1);
@@ -102,7 +103,7 @@ describe('GET /api/system/access-requests', () => {
   });
 
   it('returns empty list when nothing persisted', async () => {
-    const res = await GET();
+    const res = await GET(new NextRequest('http://localhost/api/system/access-requests'));
     const data = await res.json();
     expect(data.requests).toEqual([]);
   });


### PR DESCRIPTION
Refs #603 (tracking — backlog continues). Third cluster done.

## Summary

7 routes migrated:

| Route | Methods |
|---|---|
| \`/api/system/mode\` | GET, POST (public-domain classification) |
| \`/api/system/update\` | GET, POST (updater + autoUpdate config) |
| \`/api/system/update-window\` | GET, PUT (unified update window state machine) |
| \`/api/system/reinstall\` | GET, DELETE ("welcome back" banner) |
| \`/api/system/access-requests\` | GET only |
| \`/api/system/mcp-bootstrap\` | GET, DELETE (bootstrap token mgmt) |
| \`/api/system/certs/archive\` | GET, POST (LE cert snapshots) |

### Patterns

- Zod schemas replace per-route inline validation. The most satisfying win: \`update-window\`'s 45-LoC hand-rolled validator collapses to a Zod object literal.
- requireSession auto-applied on mutating methods.
- Tests updated where they called handlers without arguments (\`access_requests.test.ts\` now constructs \`NextRequest\` instances).

### Skipped in this cluster

- **\`access-requests/[id]/*\`** — dynamic route params; \`withApiHandler\` doesn't natively pass \`{ params }\` through. Needs a handler extension; deferred.
- **\`access-requests\` POST** — intentionally public (anonymous family-LAN visitors). The handler's built-in requireSession gate would reject every submission.
- **\`storage/route.ts\`** — 316 LoC, too big to migrate alongside the rest. Standalone PR.

## Test plan

- [x] \`npm run check:arch\` — clean
- [x] \`npm run lint\` — 0 errors, warnings dropped 141 → 116
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1099 pass / 2 skipped
- [x] \`npm run build\` — clean
- [x] Net delta: **+217 / −378** LoC

## Adoption

Main + this PR: **19 / 104 routes (~18%)**. Floor in \`check-invariants.ts\` stays at 0.10 (set in #654). Will ratchet up once both this PR and #655 (credentials cluster) land.

## Stacking

Independent of #655 (credentials cluster, still open) — no file overlap. Either merges first, neither blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)