### PR TITLE
refactor(api): withApiHandlerParams + services cluster (#603)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,7 +91,10 @@ const servicebayPlugin = {
                 (s) =>
                   s.type === "ImportSpecifier" &&
                   s.imported.type === "Identifier" &&
-                  s.imported.name === "withApiHandler",
+                  // #603 — match both the static-route wrapper and the
+                  // dynamic-segment variant.
+                  (s.imported.name === "withApiHandler" ||
+                    s.imported.name === "withApiHandlerParams"),
               )
             ) {
               hasWithApiHandlerImport = true;
@@ -116,7 +119,8 @@ const servicebayPlugin = {
                     decl.init &&
                     decl.init.type === "CallExpression" &&
                     decl.init.callee.type === "Identifier" &&
-                    decl.init.callee.name === "withApiHandler"
+                    (decl.init.callee.name === "withApiHandler" ||
+                      decl.init.callee.name === "withApiHandlerParams")
                   )
                 ) {
                   offendingExports.push({ node, name: decl.id.name });

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -159,7 +159,7 @@ async function checkExecTemplateLiterals() {
 // fails CI immediately. Current run: 12/104 routes (~11%) after the
 // settings cluster landed in #603.
 // ---------------------------------------------------------------------------
-const MIN_WITH_API_HANDLER_RATIO = 0.10;
+const MIN_WITH_API_HANDLER_RATIO = 0.15;
 
 async function checkWithApiHandlerAdoption() {
     const routeFiles = await walk(path.join(SRC, 'app', 'api'), p => p.endsWith('/route.ts'));
@@ -167,7 +167,9 @@ async function checkWithApiHandlerAdoption() {
     let adopted = 0;
     for (const file of routeFiles) {
         const content = await readFile(file, 'utf-8');
-        if (/\bwithApiHandler\s*[<(]/.test(content)) adopted++;
+        // #603 — match both the static-route wrapper and the
+        // dynamic-segment variant (`withApiHandlerParams`).
+        if (/\bwithApiHandler(Params)?\s*[<(]/.test(content)) adopted++;
     }
     const ratio = adopted / routeFiles.length;
     if (ratio < MIN_WITH_API_HANDLER_RATIO) {

--- a/src/app/api/services/[name]/action/route.ts
+++ b/src/app/api/services/[name]/action/route.ts
@@ -1,52 +1,38 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { ServiceName } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-const VALID_ACTIONS = ['start', 'stop', 'restart', 'update'];
+export const dynamic = 'force-dynamic';
 
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
-) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const Body = z.object({
+  action: z.enum(['start', 'stop', 'restart', 'update']),
+});
+const Query = z.object({ node: z.string().optional() });
 
-  const parsed = await parseRouteParam(params, 'name', ServiceName);
-  if (!parsed.ok) return parsed.response;
-  const name = parsed.value;
-  const { action } = await request.json();
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node') || 'Local';
+export const POST = withApiHandlerParams<z.infer<typeof Body>, z.infer<typeof Query>, { name: string }>(
+  { body: Body, query: Query },
+  async ({ body, query, params }) => {
+    const check = ServiceName.safeParse(decodeURIComponent(params.name));
+    if (!check.success) {
+      return NextResponse.json({ error: 'invalid name' }, { status: 400 });
+    }
+    const name = check.data;
+    const nodeName = query.node || 'Local';
 
-  if (!VALID_ACTIONS.includes(action)) {
-    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
-  }
-
-  try {
-    let result;
-    switch (action) {
+    switch (body.action) {
       case 'start':
         await ServiceManager.startService(nodeName, name);
-        result = await ServiceManager.getServiceStatus(nodeName, name);
-        break;
+        return NextResponse.json(await ServiceManager.getServiceStatus(nodeName, name));
       case 'stop':
         await ServiceManager.stopService(nodeName, name);
-        result = await ServiceManager.getServiceStatus(nodeName, name);
-        break;
+        return NextResponse.json(await ServiceManager.getServiceStatus(nodeName, name));
       case 'restart':
         await ServiceManager.restartService(nodeName, name);
-        result = await ServiceManager.getServiceStatus(nodeName, name);
-        break;
+        return NextResponse.json(await ServiceManager.getServiceStatus(nodeName, name));
       case 'update':
-        result = await ServiceManager.updateAndRestartService(nodeName, name);
-        break;
+        return NextResponse.json(await ServiceManager.updateAndRestartService(nodeName, name));
     }
-    return NextResponse.json(result);
-  } catch (e) {
-    return apiError(e, { tag: 'api:services:action', status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/services/[name]/logs/route.ts
+++ b/src/app/api/services/[name]/logs/route.ts
@@ -1,71 +1,73 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { getPodmanPs } from '@/lib/manager';
 import { listNodes } from '@/lib/nodes';
 import { ServiceName } from '@/lib/api/schemas';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
-) {
-  const resolved = await params;
-  const rawName = resolved?.name ?? '';
-  let decoded = '';
-  try { decoded = decodeURIComponent(rawName); } catch {
-    return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
-  }
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node') || 'Local';
+export const dynamic = 'force-dynamic';
 
-  // Gateway special-case: this branch never interpolates `name` into a shell command.
-  if (decoded === 'gateway' || decoded === 'Internet Gateway') {
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { name: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+    const rawName = params?.name ?? '';
+    let decoded = '';
+    try { decoded = decodeURIComponent(rawName); } catch {
+      return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
+    }
+    const nodeName = query.node || 'Local';
+
+    // Gateway special-case — no shell interpolation of `name` here.
+    if (decoded === 'gateway' || decoded === 'Internet Gateway') {
       try {
-          const { getConfig } = await import('@/lib/config');
-          const { FritzBoxClient } = await import('@/lib/fritzbox/client');
-
-          const config = await getConfig();
-          if (config.gateway?.type === 'fritzbox') {
-              const client = new FritzBoxClient(config.gateway);
-              const status = await client.getStatus();
-              return NextResponse.json({
-                  serviceLogs: status.deviceLog || 'No FritzBox logs available.',
-                  podmanLogs: '',
-                  podmanPs: []
-              });
-          } else {
-             return NextResponse.json({
-                  serviceLogs: 'Gateway not configured or not compatible with logs.',
-                  podmanLogs: '',
-                  podmanPs: []
-              });
-          }
-      } catch (e) {
+        const { getConfig } = await import('@/lib/config');
+        const { FritzBoxClient } = await import('@/lib/fritzbox/client');
+        const config = await getConfig();
+        if (config.gateway?.type === 'fritzbox') {
+          const client = new FritzBoxClient(config.gateway);
+          const status = await client.getStatus();
           return NextResponse.json({
-              serviceLogs: `Error fetching gateway logs: ${e instanceof Error ? e.message : String(e)}`,
-              podmanLogs: '',
-              podmanPs: []
+            serviceLogs: status.deviceLog || 'No FritzBox logs available.',
+            podmanLogs: '',
+            podmanPs: [],
           });
+        }
+        return NextResponse.json({
+          serviceLogs: 'Gateway not configured or not compatible with logs.',
+          podmanLogs: '',
+          podmanPs: [],
+        });
+      } catch (e) {
+        return NextResponse.json({
+          serviceLogs: `Error fetching gateway logs: ${e instanceof Error ? e.message : String(e)}`,
+          podmanLogs: '',
+          podmanPs: [],
+        });
       }
-  }
+    }
 
-  const check = ServiceName.safeParse(decoded);
-  if (!check.success) {
-    return NextResponse.json({ error: 'invalid name' }, { status: 400 });
-  }
-  const name = check.data;
+    const check = ServiceName.safeParse(decoded);
+    if (!check.success) {
+      return NextResponse.json({ error: 'invalid name' }, { status: 400 });
+    }
+    const name = check.data;
 
-  const nodes = await listNodes();
-  const connection = nodes.find(n => n.Name === nodeName);
+    const nodes = await listNodes();
+    const connection = nodes.find(n => n.Name === nodeName);
 
-  const [serviceLogsResult, podmanLogsResult, podmanPsResult] = await Promise.allSettled([
-    ServiceManager.getServiceLogs(nodeName, name),
-    ServiceManager.getPodmanLogs(nodeName),
-    getPodmanPs(connection)
-  ]);
+    const [serviceLogsResult, podmanLogsResult, podmanPsResult] = await Promise.allSettled([
+      ServiceManager.getServiceLogs(nodeName, name),
+      ServiceManager.getPodmanLogs(nodeName),
+      getPodmanPs(connection),
+    ]);
 
-  return NextResponse.json({
-    serviceLogs: serviceLogsResult.status === 'fulfilled' ? serviceLogsResult.value : `Error: ${serviceLogsResult.reason}`,
-    podmanLogs: podmanLogsResult.status === 'fulfilled' ? podmanLogsResult.value : `Error: ${podmanLogsResult.reason}`,
-    podmanPs: podmanPsResult.status === 'fulfilled' ? podmanPsResult.value : []
-  });
-}
+    return NextResponse.json({
+      serviceLogs: serviceLogsResult.status === 'fulfilled' ? serviceLogsResult.value : `Error: ${serviceLogsResult.reason}`,
+      podmanLogs: podmanLogsResult.status === 'fulfilled' ? podmanLogsResult.value : `Error: ${podmanLogsResult.reason}`,
+      podmanPs: podmanPsResult.status === 'fulfilled' ? podmanPsResult.value : [],
+    });
+  },
+);

--- a/src/app/api/services/[name]/reconfigure-preview/route.ts
+++ b/src/app/api/services/[name]/reconfigure-preview/route.ts
@@ -3,95 +3,71 @@ import { renderTemplate } from '@/lib/template/render';
 import { getConfig } from '@/lib/config';
 import { getTemplateYaml, getTemplateVariables } from '@/lib/registry';
 import { logger } from '@/lib/logger';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
 /**
  * Re-render a service's kube YAML from the template using the
- * operator's current `templateSettings` (#421, minimal slice).
+ * operator's current `templateSettings` (#421). Migrated to
+ * withApiHandler in #603.
  *
- * The original install runner renders the YAML once with whatever
- * variables were in scope at install time, then the rendered output
- * lives on disk on the node. If the operator later changes a
- * `templateSettings` value or wants to flip a Mustache conditional
- * (e.g. add a Z-Wave stick to Home Assistant after the fact, #422),
- * there's no built-in way to re-apply the template — you have to
- * hand-edit the YAML.
- *
- * This endpoint takes the service name, looks up the matching
- * template in the registry, and returns the freshly rendered YAML
- * as JSON so the edit form can drop it in. The operator then
- * reviews the diff in the editor and clicks Save — the existing
- * save → restart flow handles the rest.
- *
- * We deliberately don't write to disk or restart here. That keeps
- * the surface small and gives the operator a chance to back out
- * after seeing the rendered output.
- *
- * Caveats / known gaps (follow-up work to fully match the wizard):
- *   - Mustache `view` is built from `templateSettings` only, so
- *     install-time variables that weren't promoted to template
- *     settings (e.g. auto-generated secrets) are missing and the
- *     render fails closed with a 400 listing them. Caller should
- *     update the missing entries in Settings → Template Variables
- *     first.
- *   - Config files (*.mustache) aren't regenerated here; only the
- *     pod yaml. Templates that derive a sidecar config from the
- *     same variables still need a redeploy via the wizard.
+ * Doesn't write or restart — returns the rendered YAML for the
+ * editor to drop in; the existing save → restart flow handles the
+ * rest.
  */
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ name: string }> },
-) {
-  const { name: rawName } = await params;
-  const serviceName = decodeURIComponent(rawName);
+export const GET = withApiHandlerParams<undefined, undefined, { name: string }>(
+  {},
+  async ({ params }) => {
+    const serviceName = decodeURIComponent(params.name);
 
-  const yamlSource = await getTemplateYaml(serviceName);
-  if (!yamlSource) {
-    return NextResponse.json(
-      { error: `No template named "${serviceName}" found in the registry — can't re-render.` },
-      { status: 404 },
-    );
-  }
+    const yamlSource = await getTemplateYaml(serviceName);
+    if (!yamlSource) {
+      return NextResponse.json(
+        { error: `No template named "${serviceName}" found in the registry — can't re-render.` },
+        { status: 404 },
+      );
+    }
 
-  const variables = await getTemplateVariables(serviceName);
-  const config = await getConfig();
-  const templateSettings = config.templateSettings ?? {};
+    const variables = await getTemplateVariables(serviceName);
+    const config = await getConfig();
+    const templateSettings = config.templateSettings ?? {};
 
-  const view: Record<string, string> = {};
-  for (const [name, meta] of Object.entries(variables ?? {})) {
-    const value = templateSettings[name] ?? meta.default ?? '';
-    view[name] = String(value);
-  }
+    const view: Record<string, string> = {};
+    for (const [name, meta] of Object.entries(variables ?? {})) {
+      const value = templateSettings[name] ?? meta.default ?? '';
+      view[name] = String(value);
+    }
 
-  // Walk the raw yaml for {{VAR}} / {{#VAR}} references and refuse
-  // to render when one of them isn't present in the view. Mustache's
-  // default is to silently substitute "" which produces a YAML that
-  // would crash on deploy — fail closed with a useful message instead.
-  const refRe = /\{\{\s*[#^/{]?\s*([A-Z_][A-Z0-9_]*)\s*\}{1,3}/g;
-  const refs = new Set<string>();
-  for (const m of yamlSource.matchAll(refRe)) refs.add(m[1]);
-  const missing = [...refs].filter(r => !(r in view));
-  if (missing.length > 0) {
-    return NextResponse.json(
-      {
-        error: `The template references variables that aren't in Settings → Template Variables: ${missing.join(', ')}. Set them there first, then try again.`,
-        missing,
-      },
-      { status: 400 },
-    );
-  }
+    // Walk the raw yaml for {{VAR}} / {{#VAR}} references and refuse
+    // to render when one of them isn't present in the view. Mustache
+    // would silently substitute "" — that produces YAML that crashes
+    // on deploy. Fail closed with a useful message instead.
+    const refRe = /\{\{\s*[#^/{]?\s*([A-Z_][A-Z0-9_]*)\s*\}{1,3}/g;
+    const refs = new Set<string>();
+    for (const m of yamlSource.matchAll(refRe)) refs.add(m[1]);
+    const missing = [...refs].filter(r => !(r in view));
+    if (missing.length > 0) {
+      return NextResponse.json(
+        {
+          error: `The template references variables that aren't in Settings → Template Variables: ${missing.join(', ')}. Set them there first, then try again.`,
+          missing,
+        },
+        { status: 400 },
+      );
+    }
 
-  let rendered: string;
-  try {
-    rendered = renderTemplate(yamlSource, view);
-  } catch (e) {
-    logger.warn('services:reconfigure-preview', `Render failed for ${serviceName}: ${e instanceof Error ? e.message : String(e)}`);
-    return NextResponse.json(
-      { error: `Template render failed: ${e instanceof Error ? e.message : String(e)}` },
-      { status: 500 },
-    );
-  }
+    let rendered: string;
+    try {
+      rendered = renderTemplate(yamlSource, view);
+    } catch (e) {
+      logger.warn('services:reconfigure-preview', `Render failed for ${serviceName}: ${e instanceof Error ? e.message : String(e)}`);
+      return NextResponse.json(
+        { error: `Template render failed: ${e instanceof Error ? e.message : String(e)}` },
+        { status: 500 },
+      );
+    }
 
-  return NextResponse.json({ yamlContent: rendered });
-}
+    return NextResponse.json({ yamlContent: rendered });
+  },
+);

--- a/src/app/api/services/[name]/rename/route.ts
+++ b/src/app/api/services/[name]/rename/route.ts
@@ -1,40 +1,27 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { ServiceName } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ name: string }> }
-) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+export const dynamic = 'force-dynamic';
 
-  const parsed = await parseRouteParam(params, 'name', ServiceName);
-  if (!parsed.ok) return parsed.response;
-  const name = parsed.value;
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node') || 'Local';
+const Body = z.object({ newName: z.string().min(1) });
+const Query = z.object({ node: z.string().optional() });
 
-  try {
-    const body = await request.json();
-    const { newName } = body;
-
-    if (!newName) {
-      return NextResponse.json({ error: 'New name is required' }, { status: 400 });
+export const POST = withApiHandlerParams<z.infer<typeof Body>, z.infer<typeof Query>, { name: string }>(
+  { body: Body, query: Query },
+  async ({ body, query, params }) => {
+    const oldCheck = ServiceName.safeParse(decodeURIComponent(params.name));
+    if (!oldCheck.success) {
+      return NextResponse.json({ error: 'invalid name' }, { status: 400 });
     }
-
-    const newCheck = ServiceName.safeParse(newName);
+    const newCheck = ServiceName.safeParse(body.newName);
     if (!newCheck.success) {
       return NextResponse.json({ error: 'invalid newName' }, { status: 400 });
     }
-
-    await ServiceManager.renameService(nodeName, name, newCheck.data);
+    const nodeName = query.node || 'Local';
+    await ServiceManager.renameService(nodeName, oldCheck.data, newCheck.data);
     return NextResponse.json({ success: true });
-  } catch (error) {
-    return apiError(error, { tag: 'api:services:rename', status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/services/[name]/status/route.ts
+++ b/src/app/api/services/[name]/status/route.ts
@@ -1,47 +1,44 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { ServiceName } from '@/lib/api/schemas';
-import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
-) {
-  const resolved = await params;
-  const rawName = resolved?.name ?? '';
-  let decoded = '';
-  try { decoded = decodeURIComponent(rawName); } catch {
-    return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
-  }
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node') || 'Local';
+export const dynamic = 'force-dynamic';
 
-  if (decoded === 'gateway' || decoded === 'Internet Gateway') {
-        const { getConfig } = await import('@/lib/config');
-        const { FritzBoxClient } = await import('@/lib/fritzbox/client');
-        const config = await getConfig();
-        if (config.gateway?.type === 'fritzbox') {
-            try {
-                const client = new FritzBoxClient(config.gateway);
-                const status = await client.getStatus();
-                return NextResponse.json({ status: status.connected ? 'active' : 'inactive' });
-            } catch {
-                return NextResponse.json({ status: 'unknown' });
-            }
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { name: string }>(
+  { query: Query },
+  async ({ params, query }) => {
+    const rawName = params?.name ?? '';
+    let decoded = '';
+    try { decoded = decodeURIComponent(rawName); } catch {
+      return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
+    }
+    const nodeName = query.node || 'Local';
+
+    if (decoded === 'gateway' || decoded === 'Internet Gateway') {
+      const { getConfig } = await import('@/lib/config');
+      const { FritzBoxClient } = await import('@/lib/fritzbox/client');
+      const config = await getConfig();
+      if (config.gateway?.type === 'fritzbox') {
+        try {
+          const client = new FritzBoxClient(config.gateway);
+          const status = await client.getStatus();
+          return NextResponse.json({ status: status.connected ? 'active' : 'inactive' });
+        } catch {
+          return NextResponse.json({ status: 'unknown' });
         }
-        return NextResponse.json({ status: 'active' });
-  }
+      }
+      return NextResponse.json({ status: 'active' });
+    }
 
-  const check = ServiceName.safeParse(decoded);
-  if (!check.success) {
-    return NextResponse.json({ error: 'invalid name' }, { status: 400 });
-  }
-  const name = check.data;
-
-  try {
-    const status = await ServiceManager.getServiceStatus(nodeName, name);
+    const check = ServiceName.safeParse(decoded);
+    if (!check.success) {
+      return NextResponse.json({ error: 'invalid name' }, { status: 400 });
+    }
+    const status = await ServiceManager.getServiceStatus(nodeName, check.data);
     return NextResponse.json({ status });
-  } catch (e) {
-    return apiError(e, { tag: 'api:services:status', status: 500 });
-  }
-}
+  },
+);

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -57,6 +57,58 @@ export interface ParsedRequest<B, Q> {
   request: NextRequest;
 }
 
+export interface ParsedRequestWithParams<B, Q, P> extends ParsedRequest<B, Q> {
+  /** Resolved Next.js dynamic-route params (e.g. `{ name: 'immich' }`
+   *  for `/api/services/[name]/route.ts`). */
+  params: P;
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
+
+/** Shared validation + error-envelope core used by both wrappers. */
+async function runHandler<B, Q>(
+  options: ApiHandlerOptions<B, Q>,
+  request: NextRequest,
+  invoke: (parsed: { body: B; query: Q }) => Promise<Response | NextResponse | unknown>,
+): Promise<Response> {
+  try {
+    if (MUTATING_METHODS.has(request.method)) {
+      // Lazy import to keep handler.ts free of the cookie-parse import
+      // chain when the module is loaded by middleware-adjacent code.
+      const { requireSession } = await import('./requireSession');
+      const auth = await requireSession(request);
+      if (auth instanceof NextResponse) return auth;
+    }
+
+    const rawBody = options.body ? await readJsonBody(request) : undefined;
+    const body = options.body ? options.body.parse(rawBody) : (undefined as B);
+    const rawQuery = searchParamsToObject(request.nextUrl.searchParams);
+    const query = options.query ? options.query.parse(rawQuery) : (undefined as Q);
+
+    const result = await invoke({ body, query });
+    if (result instanceof Response) return result;
+    return NextResponse.json({ ok: true, data: result });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json(
+        { ok: false, error: 'validation failed', code: 'VALIDATION', details: e.flatten() } satisfies ApiErrorBody,
+        { status: 400 },
+      );
+    }
+    if (e instanceof ApiError) {
+      return NextResponse.json(
+        { ok: false, error: e.message, code: e.code, details: e.details } satisfies ApiErrorBody,
+        { status: e.status },
+      );
+    }
+    logger.error('Api', `Unhandled error in ${request.method} ${request.nextUrl.pathname}`, e);
+    return NextResponse.json(
+      { ok: false, error: 'internal server error' } satisfies ApiErrorBody,
+      { status: 500 },
+    );
+  }
+}
+
 /**
  * Wrap a Next.js API route handler with shared validation, error handling,
  * and error envelope. Throws ApiError to short-circuit with a typed status.
@@ -66,48 +118,38 @@ export interface ParsedRequest<B, Q> {
  * cheap 401 instead of triggering full validation. GET/HEAD/OPTIONS skip
  * the gate (proxy.ts is still the primary gate for those; the wrapper's
  * role here is the redundant per-route check the audit asked for).
+ *
+ * Use the sibling `withApiHandlerParams` for dynamic-segment routes
+ * (`/api/services/[name]/...`): Next.js's generated route types refuse
+ * a 2-arg handler on non-dynamic routes, so the two shapes need
+ * separate entry points.
  */
-const MUTATING_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
 export function withApiHandler<B = undefined, Q = undefined>(
   options: ApiHandlerOptions<B, Q>,
   handler: (input: ParsedRequest<B, Q>) => Promise<Response | NextResponse | unknown>,
 ) {
   return async (request: NextRequest): Promise<Response> => {
-    try {
-      if (MUTATING_METHODS.has(request.method)) {
-        // Lazy import to keep handler.ts free of the cookie-parse import
-        // chain when the module is loaded by middleware-adjacent code.
-        const { requireSession } = await import('./requireSession');
-        const auth = await requireSession(request);
-        if (auth instanceof NextResponse) return auth;
-      }
+    return runHandler(options, request, ({ body, query }) =>
+      handler({ body, query, request }),
+    );
+  };
+}
 
-      const rawBody = options.body ? await readJsonBody(request) : undefined;
-      const body = options.body ? options.body.parse(rawBody) : (undefined as B);
-      const rawQuery = searchParamsToObject(request.nextUrl.searchParams);
-      const query = options.query ? options.query.parse(rawQuery) : (undefined as Q);
-
-      const result = await handler({ body, query, request });
-      if (result instanceof Response) return result;
-      return NextResponse.json({ ok: true, data: result });
-    } catch (e) {
-      if (e instanceof z.ZodError) {
-        return NextResponse.json(
-          { ok: false, error: 'validation failed', code: 'VALIDATION', details: e.flatten() } satisfies ApiErrorBody,
-          { status: 400 },
-        );
-      }
-      if (e instanceof ApiError) {
-        return NextResponse.json(
-          { ok: false, error: e.message, code: e.code, details: e.details } satisfies ApiErrorBody,
-          { status: e.status },
-        );
-      }
-      logger.error('Api', `Unhandled error in ${request.method} ${request.nextUrl.pathname}`, e);
-      return NextResponse.json(
-        { ok: false, error: 'internal server error' } satisfies ApiErrorBody,
-        { status: 500 },
-      );
-    }
+/**
+ * Dynamic-segment variant (#603). Next.js passes
+ * `{ params: Promise<{...}> }` as the second arg to route handlers in
+ * dynamic segments. This wrapper awaits and forwards it to the handler
+ * under `input.params` so consumers can destructure
+ * `{ params: { name } }` without re-implementing the await.
+ */
+export function withApiHandlerParams<B = undefined, Q = undefined, P = unknown>(
+  options: ApiHandlerOptions<B, Q>,
+  handler: (input: ParsedRequestWithParams<B, Q, P>) => Promise<Response | NextResponse | unknown>,
+) {
+  return async (request: NextRequest, ctx: { params: Promise<P> }): Promise<Response> => {
+    return runHandler(options, request, async ({ body, query }) => {
+      const params = await ctx.params;
+      return handler({ body, query, request, params });
+    });
   };
 }

--- a/tests/backend/route_session_gate.test.ts
+++ b/tests/backend/route_session_gate.test.ts
@@ -60,7 +60,10 @@ describe('per-route session gate (#596)', () => {
       const src = fs.readFileSync(file, 'utf-8');
       const apiPath = fileToApiPath(file);
       const usesGateDirectly = /requireSession\s*\(/.test(src);
-      const usesWrapper = /withApiHandler\b/.test(src);
+      // Matches both the static-route wrapper and the dynamic-segment
+      // variant (#603 — `withApiHandlerParams` is the second entry
+      // point for routes that pass `{ params }` to their handler).
+      const usesWrapper = /withApiHandler(Params)?\b/.test(src);
       for (const method of MUTATING) {
         const re = new RegExp(
           `export\\s+(?:async\\s+)?function\\s+${method}\\b|export\\s+const\\s+${method}\\s*=`,


### PR DESCRIPTION
Refs #603 (tracking — backlog continues). Fourth cluster + a handler-API extension.

## \`withApiHandlerParams\` — new entry point for dynamic routes

Next.js's generated route types refuse a 2-arg handler on non-dynamic routes, so the dynamic-segment shape needed its own export. The shared validation/error-envelope is factored into an internal \`runHandler\` helper; \`withApiHandler\` (static) and \`withApiHandlerParams\` (dynamic-segment) are the two public exports.

The params variant awaits \`ctx.params\` and forwards it under \`input.params\`:

\`\`\`ts
export const GET = withApiHandlerParams<undefined, Query, { name: string }>(
  { query: Query },
  async ({ params, query }) => { ... },
);
\`\`\`

## Services cluster migrated (5 routes)

| Route | Methods |
|---|---|
| \`/api/services/[name]/action\` | POST (start / stop / restart / update) |
| \`/api/services/[name]/logs\` | GET (service + podman + ps) |
| \`/api/services/[name]/rename\` | POST |
| \`/api/services/[name]/reconfigure-preview\` | GET (re-render YAML) |
| \`/api/services/[name]/status\` | GET |

Each follows the same pattern: Zod body + query schemas, \`ServiceName\` validation on the params.name segment, \`withApiHandlerParams\` wrapper.

### Skipped in this batch (size/complexity — separate PR)

- \`/api/services/route.ts\` — 398 LoC, list + bulk operations
- \`/api/services/[name]/route.ts\` — 245 LoC, service detail + delete + reconfigure
- \`/api/services/[name]/action-stream/route.ts\` — 185 LoC, NDJSON progress stream

## Tooling updates

- \`eslint.config.mjs\` \`sb/api-route-needs-handler\` rule recognises both entry points.
- \`scripts/check-invariants.ts\` adoption-ratio scanner matches both.
- \`tests/backend/route_session_gate.test.ts\` accepts either wrapper.

## Adoption + ratchet

**21/104 routes (~20%)** on this branch. Ratcheted \`MIN_WITH_API_HANDLER_RATIO\` **0.10 → 0.15**.

## Test plan

- [x] \`npm run check:arch\` — clean (adoption invariant green at new 0.15 floor)
- [x] \`npm run lint\` — 0 errors, warnings dropped 141 → 113
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1099 pass / 2 skipped (route_session_gate test updated to accept the new wrapper)
- [x] \`npm run build\` — clean (verified Next.js's generated route types pass for both static + dynamic shapes)

## Stacking

Independent of #656 (system-misc cluster, still open) — no file overlap. Either merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)