### PR TITLE
feat(diagnose): HTTP-status check on every public domain (#611)

### DIFF
--- a/src/lib/diagnose/probes/domainExternalReachability.test.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.test.ts
@@ -105,6 +105,13 @@ beforeEach(() => {
   state.letsdebugCalls = [];
   state.letsdebugResult = { problems: [], submissionUrl: 'https://letsdebug.net/one.example.com/42' };
   state.letsdebugError = undefined;
+  // #611 — the probe now does an HTTPS GET per public domain. Stub
+  // global fetch so existing tests don't hit the network and so the
+  // HTTP layer reports `ok` by default (existing DNS-focused tests
+  // were written against an HTTP-less world).
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response('', { status: 200 }) as Response,
+  );
 });
 
 describe('checkDomainExternalReachability', () => {
@@ -201,6 +208,60 @@ describe('checkDomainExternalReachability', () => {
     expect(r.items).toHaveLength(1);
     expect(r.items![0].status).toBe('info');
     expect(r.items![0].detail).toMatch(/DNS check could not run/);
+  });
+
+  it('#611 — flags DNS-green + HTTP-fail combo (the v4.0.x outage shape)', async () => {
+    // DNS is healthy for both domains.
+    state.results.set('dns_routing:one.example.com', {
+      check_id: 'dns_routing:one.example.com',
+      timestamp: isoAgo(60_000),
+      status: 'ok',
+      message: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
+    });
+    state.results.set('dns_routing:two.example.com', {
+      check_id: 'dns_routing:two.example.com',
+      timestamp: isoAgo(60_000),
+      status: 'ok',
+      message: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
+    });
+    // But the HTTPS GET surfaces a 502 for one.example.com (proxy
+    // forwarding to a crash-looping upstream).
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('one.example.com')) {
+        return new Response('', { status: 502 }) as Response;
+      }
+      return new Response('', { status: 200 }) as Response;
+    }) as typeof fetch);
+
+    const r = await checkDomainExternalReachability();
+    expect(r.status).toBe('fail');
+    expect(r.items).toHaveLength(1);
+    expect(r.items![0].id).toBe('one.example.com');
+    expect(r.items![0].detail).toMatch(/HTTP 502/);
+    expect(r.items![0].detail).toMatch(/DNS layer OK/);
+  });
+
+  it('#611 — accepts 302 → auth.<publicDomain> as a healthy redirect (forward-auth)', async () => {
+    state.config.reverseProxy.publicDomain = 'example.com';
+    state.results.set('dns_routing:one.example.com', {
+      check_id: 'dns_routing:one.example.com',
+      timestamp: isoAgo(60_000),
+      status: 'ok',
+      message: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
+    });
+    state.results.set('dns_routing:two.example.com', {
+      check_id: 'dns_routing:two.example.com',
+      timestamp: isoAgo(60_000),
+      status: 'ok',
+      message: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 302, headers: { location: 'https://auth.example.com/' } }) as Response,
+    );
+    const r = await checkDomainExternalReachability();
+    expect(r.status).toBe('ok');
+    expect(r.items).toBeUndefined(); // healthy rows are collapsed
   });
 
   it('appends letsdebug summary to a flagged row when one exists', async () => {
@@ -313,5 +374,98 @@ describe('_internalsForTesting', () => {
 
   it('returns null for a plaintext message', () => {
     expect(_internalsForTesting.decodeDnsRouting('connect ETIMEDOUT')).toBeNull();
+  });
+});
+
+describe('probeHttpStatus (#611)', () => {
+  // Run the helper directly via dependency injection so the test
+  // doesn't have to mock globalThis.fetch.
+  async function probe(
+    domain: string,
+    publicDomain: string | null,
+    fetchImpl: typeof fetch,
+  ): Promise<{ status: 'ok' | 'warn' | 'fail'; detail: string }> {
+    const { probeHttpStatus } = await import('./domainExternalReachability');
+    return probeHttpStatus(domain, publicDomain, fetchImpl, 1_000);
+  }
+
+  function fakeFetch(response: Response): typeof fetch {
+    return (async () => response) as typeof fetch;
+  }
+
+  it('200 → ok', async () => {
+    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 200 })));
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/HTTP 200/);
+  });
+
+  it('302 → auth.<publicDomain> → ok (forward-auth)', async () => {
+    const r = await probe(
+      'vault.example.com',
+      'example.com',
+      fakeFetch(new Response('', {
+        status: 302,
+        headers: { location: 'https://auth.example.com/?rd=https://vault.example.com/' },
+      })),
+    );
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/forward-auth/);
+  });
+
+  it('302 to an unrelated host → warn', async () => {
+    const r = await probe(
+      'vault.example.com',
+      'example.com',
+      fakeFetch(new Response('', {
+        status: 302,
+        headers: { location: 'https://google.com/' },
+      })),
+    );
+    expect(r.status).toBe('warn');
+  });
+
+  it('401 → ok (auth-gated)', async () => {
+    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 401 })));
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/auth-gated/);
+  });
+
+  it('502 → fail with status code', async () => {
+    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 502 })));
+    expect(r.status).toBe('fail');
+    expect(r.detail).toMatch(/HTTP 502/);
+  });
+
+  it('500 → fail', async () => {
+    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 500 })));
+    expect(r.status).toBe('fail');
+  });
+
+  it('404 (other 4xx) → warn — many apps don\'t serve /', async () => {
+    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 404 })));
+    expect(r.status).toBe('warn');
+  });
+
+  it('network error → fail with the message', async () => {
+    const failingFetch = (async () => {
+      throw new Error('connect ECONNREFUSED');
+    }) as typeof fetch;
+    const r = await probe('x.example.com', 'example.com', failingFetch);
+    expect(r.status).toBe('fail');
+    expect(r.detail).toMatch(/ECONNREFUSED/);
+  });
+
+  it('no public-domain suffix → 302 to anything is warn (can\'t recognise auth host)', async () => {
+    const r = await probe(
+      'vault.home.arpa',
+      null,
+      fakeFetch(new Response('', {
+        status: 302,
+        headers: { location: 'https://auth.home.arpa/' },
+      })),
+    );
+    // Without a configured publicDomain we can't tell forward-auth from
+    // any other redirect.
+    expect(r.status).toBe('warn');
   });
 });

--- a/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -122,10 +122,89 @@ async function listPublicDomains(): Promise<string[]> {
   return Array.from(new Set(hosts.filter(isPublicEntry).map(h => h.domain)));
 }
 
+async function getPublicDomainSuffix(): Promise<string | null> {
+  const config = await getConfig();
+  return config.reverseProxy?.publicDomain ?? null;
+}
+
 function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'warn' | 'fail' {
   if (a === 'fail' || b === 'fail') return 'fail';
   if (a === 'warn' || b === 'warn') return 'warn';
   return 'ok';
+}
+
+/** Outcome of one HTTP-status check (#611). */
+interface HttpStatusResult {
+  status: 'ok' | 'warn' | 'fail';
+  detail: string;
+}
+
+/**
+ * HTTP-status check for a single public domain (#611).
+ *
+ * Probes `https://<domain>/` from inside the ServiceBay container.
+ * Caught the v4.0.x outage where every proxied service was 502-ing
+ * because Authelia was crash-looping but DNS still resolved fine.
+ *
+ * Classification:
+ *   - 2xx → ok
+ *   - 302/303/307/308 → ok if Location points at `auth.<publicDomain>`
+ *     (Authelia forward-auth redirect for unauthenticated visitors).
+ *     Other redirects → warn.
+ *   - 401 / 403 → ok (auth-gated endpoint serving an unauthenticated
+ *     request; the proxy is healthy, the app just wants creds).
+ *   - 5xx → fail with the status code in the detail.
+ *   - 4xx other than 401/403 → warn (some apps 404 on `/` by design,
+ *     which is normal — don't fail-fast on it).
+ *   - Network error / timeout → fail.
+ *
+ * Internal probe by design — runs from inside the container, hits the
+ * local NPM. Cheap, no third-party dep, no rate limits. Catches "NPM
+ * up + backend down" which is the failure mode #611 was filed for.
+ * The DNS layer (Cloudflare DoH) and letsdebug already cover the
+ * external-reachability question for cases where the upstream firewall
+ * itself is the problem.
+ */
+export async function probeHttpStatus(
+  domain: string,
+  publicDomain: string | null,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 5_000,
+): Promise<HttpStatusResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(`https://${domain}/`, {
+      method: 'GET',
+      redirect: 'manual',
+      headers: { 'Accept': 'text/html,*/*' },
+      signal: controller.signal,
+    });
+    const code = res.status;
+    if (code >= 200 && code < 300) return { status: 'ok', detail: `HTTP ${code}` };
+    if (code >= 300 && code < 400) {
+      const location = res.headers.get('location') || '';
+      const authHost = publicDomain ? `auth.${publicDomain}` : null;
+      if (authHost && location.includes(authHost)) {
+        return { status: 'ok', detail: `HTTP ${code} → ${authHost} (forward-auth)` };
+      }
+      return { status: 'warn', detail: `HTTP ${code} → ${location || 'no Location header'}` };
+    }
+    if (code === 401 || code === 403) {
+      return { status: 'ok', detail: `HTTP ${code} (auth-gated, proxy healthy)` };
+    }
+    if (code >= 500) return { status: 'fail', detail: `HTTP ${code}` };
+    // 400, 404, 405, 410, etc. — common on apps that don't serve `/`.
+    return { status: 'warn', detail: `HTTP ${code}` };
+  } catch (e) {
+    const aborted = e instanceof Error && e.name === 'AbortError';
+    return {
+      status: 'fail',
+      detail: aborted ? `timeout after ${timeoutMs}ms` : (e instanceof Error ? e.message : String(e)),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export async function checkDomainExternalReachability(): Promise<DomainExternalReachabilityResult> {
@@ -136,6 +215,16 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
       detail: 'No public domains configured — external reachability check skipped.',
     };
   }
+
+  // #611 — also issue an internal HTTPS GET per domain to catch the
+  // "DNS green but upstream returning 5xx" class that v4.0.x had
+  // silently. Run in parallel so the probe round-trip stays roughly
+  // the same wall-time as the existing DNS-only path.
+  const publicDomainSuffix = await getPublicDomainSuffix();
+  const httpResults: Map<string, HttpStatusResult> = new Map();
+  await Promise.all(publicDomains.map(async domain => {
+    httpResults.set(domain, await probeHttpStatus(domain, publicDomainSuffix));
+  }));
 
   let overall: 'ok' | 'warn' | 'fail' = 'ok';
   const items: ProbeItem[] = [];
@@ -224,6 +313,25 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
         }
       } else if (letsdebugResult.status === 'fail') {
         rowDetail += `\nLetsdebug last run failed: ${(letsdebugResult.message ?? '').slice(0, 120)}`;
+      }
+    }
+
+    // #611 — fold in the HTTP-status check. Worst-of aggregation
+    // matches the existing DNS+letsdebug pattern.
+    const httpResult = httpResults.get(domain);
+    if (httpResult) {
+      const httpLayerOk = httpResult.status === 'ok';
+      const dnsLayerOk = rowStatus === 'ok';
+      if (!httpLayerOk) {
+        // Spell out which layer the operator should investigate. A
+        // DNS-green + HTTP-fail row almost always means upstream
+        // crash (the v4.0.x Authelia case) — name it so the operator
+        // doesn't re-run `dig` on a row that's already DNS-correct.
+        const hint = dnsLayerOk
+          ? 'DNS layer OK — issue is in the upstream backend (NPM → service is failing).'
+          : 'DNS layer also has findings — fix that first; HTTP may resolve once DNS is correct.';
+        rowDetail += `\n${hint} HTTPS GET: ${httpResult.detail}`;
+        rowStatus = worst(rowStatus, httpResult.status);
       }
     }
 


### PR DESCRIPTION
Closes #611.

## Summary

The \`domain_external_reachability\` probe was DNS-only, so the v4.0.x outage shape (\"Authelia crash-looping → every proxied service returns 502, but DNS still resolves\") read as green across the board on the diagnose page.

This PR adds an **internal HTTPS GET per public domain**, folded into the existing row aggregation alongside DNS + letsdebug.

### Classification

| HTTP response | Status |
|---|---|
| 2xx | ok |
| 302/303/307/308 → \`auth.<publicDomain>\` | ok (Authelia forward-auth redirect) |
| Other 3xx | warn |
| 401 / 403 | ok (auth-gated endpoint; proxy is healthy, app just wants creds) |
| 5xx | **fail** with status code in detail |
| Other 4xx | warn (many apps 404 on \`/\` by design) |
| Network error / timeout | fail |

### Design decisions (from #611 body)

- **Internal probe by design** — runs from inside the container, hits the local NPM. Catches \"NPM up + backend down\" which is the failure mode #611 was filed for. The DNS layer (Cloudflare DoH) + letsdebug already cover external-firewall failures.
- **Worst-of aggregation** — matches the existing DNS + letsdebug pattern. DNS-green + HTTP-fail rows spell the layer out explicitly so operators don't re-run \`dig\` on a row that's already DNS-correct:
  > DNS layer OK — issue is in the upstream backend (NPM → service is failing). HTTPS GET: HTTP 502
- **Recognises forward-auth** — \`auth.<publicDomain>\` redirects are the intended unauthenticated-visitor flow; not flagged as warn.

## Test plan

- [x] \`npm run check:arch\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 1110 pass / 2 skipped; **11 new tests**:
  - 9 unit tests on \`probeHttpStatus\` covering 2xx, 302→forward-auth, 302→unrelated, 401, 502, 500, 4xx, network error, no-public-domain edge case.
  - 2 integration tests on \`checkDomainExternalReachability\` row aggregation: DNS-green+HTTP-fail (the v4.0.x outage shape) surfaces with the layer-named hint; 302 forward-auth doesn't flag a healthy stack as warn.
- [x] \`npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)