### PR TITLE
fix(install): sync LAN-IP capture in runner (#660)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -633,15 +633,17 @@ app.prepare().then(() => {
       }
     })();
 
-    // LAN IP reconcile (#318). Captures the install-time IP on first
-    // boot and updates the stored value (with history) when the IP
-    // drifts. Deferred 60s so the Local agent has time to come up
-    // through the socket lifecycle — detectLanIp() needs an `exec`
-    // round-trip. Best-effort: a missing IP just leaves the previous
-    // value alone, the diagnose probe handles the no-value case.
+    // LAN-IP drift detection (#318, #660). Install-time *capture* now
+    // happens synchronously inside the install runner (see #660 — the
+    // 60s boot-timer was race-prone). What stays here is the drift
+    // safety net for long-running installs where the host's outbound
+    // IP changes after install (DHCP lease, NIC swap, OS upgrade).
+    // `reconcileLanIp` is idempotent: no-op when current == stored,
+    // history append when it drifts. Deferred 60s so the Local agent
+    // has time to come up through the socket lifecycle.
     setTimeout(() => {
       reconcileLanIp('Local').catch(err =>
-        logger.warn('Server', `LAN IP reconcile failed: ${err instanceof Error ? err.message : String(err)}`),
+        logger.warn('Server', `LAN IP drift check failed: ${err instanceof Error ? err.message : String(err)}`),
       );
     }, 60_000);
 

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -45,6 +45,7 @@ import { getCapabilityBus } from '@/lib/capabilities/bus';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { getConfig, saveConfig } from '@/lib/config';
+import { reconcileLanIp } from '@/lib/lanIp';
 import {
   appendLog,
   getJob,
@@ -513,6 +514,33 @@ async function runJob(jobId: string): Promise<void> {
       const msg = e instanceof Error ? e.message : 'unknown error';
       await log(jobId, `⚠️ Reset call failed: ${msg}. Continuing with install.`);
     }
+  }
+
+  // Capture / refresh the host's LAN IP synchronously (#660 — S2).
+  //
+  // Was previously a 60s boot-deferred setTimeout in server.ts that could
+  // race: when the timer fired before the agent was up, or before
+  // `secret.key` was rewritten on a wipe, `lanIp` never landed in config —
+  // and ~6 diagnose probes (router-DNS, AdGuard rewrites, NPM bootstrap,
+  // OIDC, TLS certs, LE requests) degraded to "no install-time value
+  // recorded yet" with no clear recovery path.
+  //
+  // Doing it here, in the runner that already has the agent under
+  // contract, makes the capture deterministic: every install (clean or
+  // not) writes the current outbound LAN IP before the deploy loop fires.
+  // The boot-timer in server.ts is now a drift-detection safety net for
+  // installs that pre-date this change; both call the same idempotent
+  // `reconcileLanIp` (no-op when value matches, history append on drift).
+  try {
+    const node = input.node || 'Local';
+    const ip = await reconcileLanIp(node);
+    if (ip) {
+      await log(jobId, `Captured LAN IP: ${ip}`);
+    } else {
+      await log(jobId, '⚠️ Could not detect LAN IP (agent returned no `ip route get` result); diagnose probes that depend on it will degrade.');
+    }
+  } catch (e) {
+    await log(jobId, `⚠️ LAN IP capture failed: ${e instanceof Error ? e.message : String(e)}`);
   }
 
   const checked = input.items.filter(i => i.checked);


### PR DESCRIPTION
## Summary

- Move \`reconcileLanIp\` from a 60s boot-timer to the install runner's pre-deploy phase
- Boot-timer kept as drift-detection safety net (renamed in comment)
- Eliminates the race where ~6 diagnose probes degraded to "no install-time value recorded yet"

Closes #660.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors (pre-existing warnings only)
- [x] \`npm run check:arch\` — all checks passed
- [x] \`vitest run src/lib/lanIp.test.ts\` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)