### PR TITLE
docs(install): credential self-heal audit + LLDAP drift warning (#666)

### DIFF
--- a/docs/CREDENTIAL_SELF_HEAL.md
+++ b/docs/CREDENTIAL_SELF_HEAL.md
@@ -1,0 +1,68 @@
+# Credential self-heal — coverage matrix
+
+ServiceBay encrypts service admin credentials in `config.json` using
+`/mnt/data/servicebay/secret.key`. When the operator wipes the
+`secrets` group during a clean install, that key — and the AUTHELIA-
+style `.auth-secret.env` — goes with it. Every existing `enc:v1:`
+ciphertext in `config.json` becomes garbage.
+
+What happens next depends on the *service*: some self-heal cleanly,
+some drift, one is a known foot-gun.
+
+## Coverage matrix
+
+| Service | Stored cred | On-disk state | Self-heal path | Status |
+|---|---|---|---|---|
+| **NPM** | `config.reverseProxy.npm.password` | sqlite DB at `nginx-proxy-manager/data/database.sqlite` | post-deploy `bootstrapNpmAdmin` re-rotates via NPM API using the previous-pw fallback chain | ✅ |
+| **AdGuard** | `config.adguard.password` | `adguard/conf/AdGuardHome.yaml` (bcrypt in plain YAML) | Mustache renders `AdGuardHome.yaml.mustache` on every deploy → bcrypt with new pw → `extraFiles` writes overwrite the on-disk YAML → AdGuard reads new config on next restart | ✅ |
+| **Authelia** | `AUTHELIA_STORAGE_ENCRYPTION_KEY` (`enc:` in `config.json`) | `auth/authelia-data/db.sqlite3` (rows encrypted with the key) | Runner detects fresh key + non-empty data dir → wipes `authelia-data/` only (#619). LLDAP users at sibling `auth/lldap` host path are preserved. | ✅ |
+| **LLDAP** | `LLDAP_ADMIN_PASSWORD` (`enc:` in `config.json`) | `auth/lldap/users.db` (admin bcrypt set on first start, never updated from env) | None — the LLDAP image does *not* rotate the admin password from env after the DB is initialised | ⚠️ documented edge case |
+| **Cloudflare API key** | `config.dns.cloudflareToken` | n/a — operator-supplied | None possible; operator re-enters via wizard | n/a |
+| **FritzBox** | `config.gateway.fritzbox.password` | n/a — operator-supplied | None possible | n/a |
+| **SMTP** | `config.notifications.email.smtp.password` | n/a — operator-supplied | None possible | n/a |
+| **Vaultwarden admin token** | n/a (per-vault) | inside the vault container | n/a — ServiceBay doesn't own | n/a |
+
+## The LLDAP edge case
+
+The pathological combination is **wipe `secrets`, preserve `identity`**:
+
+1. Operator unchecks `secrets` in the clean-install dialog (non-default).
+2. `secret.key` + `.auth-secret.env` + `config.json` deleted from
+   `/mnt/data/servicebay/`.
+3. `/mnt/data/stacks/auth/lldap/users.db` is preserved (identity kept).
+4. Wizard generates a fresh `LLDAP_ADMIN_PASSWORD`.
+5. Install deploys LLDAP, env var `LLDAP_LDAP_USER_PASS` is set to the
+   new value.
+6. LLDAP boots, sees an *existing* `users.db`, **does not update** the
+   admin password from env.
+7. Operator can't log in to LLDAP admin UI with the wizard's new
+   password. They also can't recover the previous password (it's
+   in the now-deleted `config.json`).
+
+**Recovery**: SSH to the node and either:
+- `rm -rf /mnt/data/stacks/auth/lldap/users.db` and redeploy (loses all
+  user accounts — re-create them from the wizard's seed user list).
+- Or use the LLDAP CLI on the host to reset the admin password against
+  the live DB. This is undocumented and image-version-specific.
+
+**Mitigation**: the diagnose page and S9 warning (#668) flag this
+combination *before* the wipe runs so the operator picks the
+intentional path.
+
+The defaults (`preserve secrets + certs + identity`, wipe only
+`service-data`) avoid this entirely.
+
+## Pattern: when to add a self-heal
+
+A new service template needs an explicit self-heal entry above when
+**both** of these are true:
+
+1. The service stores admin credentials *in addition to*
+   `config.json` (sqlite DB, encrypted column, bcrypt hash on disk).
+2. The image does not re-key from env on every start.
+
+If either is false, mustache overwrite (AdGuard pattern) or API-side
+rotation (NPM pattern) is sufficient.
+
+See [`feedback_ux_philosophy.md`](../.claude/projects/-home-mdopp-servicebay/memory/feedback_ux_philosophy.md)
+— self-heal first, structured-action second.

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -679,6 +679,40 @@ async function runJob(jobId: string): Promise<void> {
     }
   }
 
+  // LLDAP admin-password drift detection (#666). The pathological
+  // combination is "wipe secrets, preserve identity": the wizard
+  // generates a fresh LLDAP_ADMIN_PASSWORD, but the LLDAP image does
+  // not rotate the admin password from env on subsequent starts — it
+  // only does so on first DB init. So the operator can't log in with
+  // the wizard's password, and the previous password is gone with the
+  // wiped `secret.key`. Authelia self-heals by wiping its data dir
+  // (#619); LLDAP can't because that would destroy *all* user accounts.
+  //
+  // Best we can do is detect the situation and log a clear breadcrumb
+  // so the operator finds the recovery path (docs/CREDENTIAL_SELF_HEAL.md)
+  // instead of silently getting locked out. No code action — the
+  // recovery is operator-decision territory.
+  if (authIncluded && !reusedSecretNames.has('LLDAP_ADMIN_PASSWORD')) {
+    try {
+      const { agentManager } = await import('@/lib/agent/manager');
+      const { getConfig } = await import('@/lib/config');
+      const cfg = await getConfig();
+      const dataDir = cfg.templateSettings?.DATA_DIR || '/mnt/data/stacks';
+      const lldapDbPath = `${dataDir}/auth/lldap/users.db`;
+      const node = input.node || 'Local';
+      const agent = await agentManager.ensureAgent(node);
+      const probe = await agent.sendCommand('exec', {
+        command: `[ -s "${lldapDbPath}" ] && echo present || true`,
+      });
+      const dbPresent = (probe.stdout || '').trim() === 'present';
+      if (dbPresent) {
+        await log(jobId, `⚠️ LLDAP admin-password drift detected: existing users.db at ${lldapDbPath} won't accept the wizard's freshly-generated password. If you can't log in to LLDAP, see docs/CREDENTIAL_SELF_HEAL.md for the recovery path.`);
+      }
+    } catch (e) {
+      await log(jobId, `(note) LLDAP drift probe failed: ${e instanceof Error ? e.message : String(e)} — continuing.`);
+    }
+  }
+
   // Cert archive restore — runs once before the deploy loop when nginx
   // is in the install set AND the volume on disk is empty (fresh
   // install). The reset endpoint snapshots NPM's data dir to


### PR DESCRIPTION
## Summary

- New \`docs/CREDENTIAL_SELF_HEAL.md\` — credential coverage matrix and the LLDAP edge-case writeup
- Runner: log a clear warning when LLDAP drift is likely (wipe secrets + preserve identity), parallel to the Authelia self-heal block — points the operator to the recovery doc instead of silently locking them out

Audit conclusion (in the doc):
- NPM: self-heals via API + previous-pw fallback chain ✅
- AdGuard: self-heals via mustache overwrite of \`AdGuardHome.yaml\` on every deploy ✅
- Authelia: self-heals via data-dir wipe (#619) ✅
- LLDAP: cannot self-heal without destroying users — documented edge case ⚠️

Closes #666.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)