### PR TITLE
feat(wizard): capture publicDomain in network step (#662)

### DIFF
--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -102,6 +102,30 @@ export async function saveGatewayConfig(host: string, username?: string, passwor
     return { success: true };
 }
 
+/**
+ * Persist the public domain captured in the wizard's network step (#662 — S3).
+ *
+ * Without this, the operator walks through the wizard, never gets asked
+ * for a public domain (it only appears in the `install-confirm` step,
+ * which is skipped when stacks aren't selected), and dozens of diagnose
+ * probes degrade to "publicDomain not yet configured" — the same probes
+ * that gate TLS, OIDC, AdGuard wildcard rewrites, external reachability.
+ *
+ * Empty string means "LAN-only install" — explicit operator choice.
+ * Existing probes treat absent publicDomain as not-configured; an
+ * empty save thus reverts to that state cleanly.
+ */
+export async function savePublicDomainConfig(publicDomain: string) {
+    const config = await getConfig();
+    const cleaned = publicDomain.trim().toLowerCase();
+    config.reverseProxy = {
+        ...config.reverseProxy,
+        publicDomain: cleaned || undefined,
+    };
+    await saveConfig(config);
+    return { success: true };
+}
+
 export async function saveAutoUpdateConfig(enabled: boolean) {
     const config = await getConfig();
     config.autoUpdate = {

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -6,6 +6,7 @@ import {
     checkOnboardingStatus,
     skipOnboarding,
     saveGatewayConfig,
+    savePublicDomainConfig,
     saveAutoUpdateConfig,
     saveRegistriesConfig,
     saveEmailConfig,
@@ -615,6 +616,23 @@ export default function OnboardingWizard() {
   // `config.notifications.email.to[0]` — the operator already gave us
   // this during bootstrap so they don't have to retype.
   useEffect(() => {
+    // Network step prefill (#662 — S3): pull publicDomain so the
+    // operator sees the install-script-baked or previously-saved value
+    // rather than an empty box. Same source as install-confirm uses.
+    if (currentStep !== 'network') return;
+    if (publicDomain) return;
+    let cancelled = false;
+    fetch('/api/settings').then(r => r.ok ? r.json() : null).then(s => {
+      if (cancelled) return;
+      const baked = s?.reverseProxy?.publicDomain;
+      if (typeof baked === 'string' && baked.length > 0) {
+        setPublicDomain(baked);
+      }
+    }).catch(() => { /* silent — operator can type the value */ });
+    return () => { cancelled = true; };
+  }, [currentStep, publicDomain]);
+
+  useEffect(() => {
     if (currentStep !== 'install-confirm') return;
     if (stackDomain && operatorEmail) return;
     let cancelled = false;
@@ -664,7 +682,9 @@ export default function OnboardingWizard() {
       const inEditMode = current === 'machine' || current === 'stacks';
       const activeSteps = order.filter(step => {
          if (step === 'welcome' || step === 'finish') return true;
-         if (step === 'network') return selection.gateway || selection.ssh;
+         // network step is always active now — captures publicDomain
+         // (#662) in addition to optional gateway/SSH config.
+         if (step === 'network') return true;
          if (step === 'install-confirm') return selection.stacks && !inEditMode;
          if (step === 'machine' || step === 'stacks') return inEditMode;
          return selection[step as keyof typeof selection];
@@ -733,6 +753,11 @@ export default function OnboardingWizard() {
           await saveGatewayConfig(gwHost, gwUser, gwPass);
           addToast('success', 'Gateway Saved');
       }
+      // Public domain (#662 — S3). Always persisted on this step so
+      // dependent probes (TLS, OIDC, AdGuard rewrites, external
+      // reachability) unblock the moment the wizard moves on — instead
+      // of degrading silently when the operator skips `install-confirm`.
+      await savePublicDomainConfig(publicDomain);
   });
 
   const handleSaveEmail = () => saveAndNext(async () => {
@@ -1083,7 +1108,7 @@ export default function OnboardingWizard() {
              const inEditMode = currentStep === 'machine' || currentStep === 'stacks';
              const activeSteps = order.filter(step => {
                if (step === 'welcome' || step === 'finish') return true;
-               if (step === 'network') return selection.gateway || selection.ssh;
+               if (step === 'network') return true;
                if (step === 'install-confirm') return selection.stacks && !inEditMode;
                if (step === 'machine' || step === 'stacks') return inEditMode;
                return selection[step as keyof typeof selection];
@@ -1211,6 +1236,24 @@ export default function OnboardingWizard() {
 
             {currentStep === 'network' && (
                 <div className="space-y-6">
+                    {/* Public domain (#662 — S3). Always asked, regardless
+                        of feature toggles, because the diagnose probes
+                        (TLS, OIDC, AdGuard rewrites, external reachability)
+                        all gate on it — and skipping the install-confirm
+                        step used to mean it was never captured. Leave
+                        blank for a LAN-only install. */}
+                    <section className="space-y-3">
+                        <h3 className="font-semibold text-lg flex items-center gap-2"><Globe className="w-5 h-5 text-blue-500"/> Public Domain</h3>
+                        <p className="text-sm text-gray-500">
+                            The domain your services will live under (e.g. <span className="font-mono">vault.example.com</span>, <span className="font-mono">photos.example.com</span>). Required for HTTPS via Let&apos;s Encrypt and external access. Leave blank for a LAN-only install.
+                        </p>
+                        <Input label="Public Domain" value={publicDomain} onChange={setPublicDomain} placeholder="example.com" />
+                    </section>
+
+                    {selection.gateway && (
+                        <hr className="border-gray-200 dark:border-gray-700" />
+                    )}
+
                     {selection.gateway && (
                         <section className="space-y-3">
                              <h3 className="font-semibold text-lg flex items-center gap-2"><Network className="w-5 h-5 text-purple-500"/> Internet Gateway</h3>


### PR DESCRIPTION
## Summary

- Lift publicDomain capture out of \`install-confirm\` (which is skipped when stacks aren't selected) into the always-active \`network\` step
- New server action \`savePublicDomainConfig\` persists to \`config.reverseProxy.publicDomain\`
- Prefill from \`/api/settings\` so an install-script-baked value shows up rather than an empty box
- Empty value = explicit LAN-only

Closes #662.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors
- [x] OnboardingWizard tests pass — 21/22 (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)