### PR TITLE
feat(install): public progress endpoint survives AUTH_SECRET rotation (#663)

### DIFF
--- a/src/app/api/install/progress/route.ts
+++ b/src/app/api/install/progress/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { getJob, readLog } from '@/lib/install/jobStore';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Public, sanitized view of an install job's progress (#663 — S1).
+ *
+ * Sibling of `/api/install/status` which carries the full job state
+ * (including `input.variables` — i.e. operator-supplied passwords and
+ * other secrets). This endpoint exists for one specific case:
+ *
+ *   During a clean install with `secrets` wiped, the runner deletes
+ *   `.auth-secret.env`. AUTH_SECRET is regenerated on the next request
+ *   that needs it (self-heal). The operator's session cookie was
+ *   signed with the *old* AUTH_SECRET — it becomes invalid the moment
+ *   the rotation happens. Every poll on `/api/install/status` then
+ *   401s, the wizard's overlay silently stops updating, and the
+ *   operator sees nothing while the install actually keeps running.
+ *
+ * The wizard already has the `jobId` in memory (it created the job
+ * via `/api/install/start`). Knowing a jobId is sufficient auth here
+ * because:
+ *   - jobIds are uuidv4 (122 bits of entropy) — not guessable
+ *   - this endpoint is GET-only, read-only
+ *   - no operator-supplied secrets, no credentials manifest
+ *   - log lines are install-runner text (e.g. "🔑 Reusing 7 saved
+ *     secrets" — names, not values)
+ *
+ * The dual `/status` (cookie-gated, full data) and `/progress`
+ * (jobId-gated, sanitised) split is the minimum-blast-radius fix.
+ * Re-broadening `/status` to allow jobId-only auth would expose
+ * variables; widening `/progress` to include them would defeat the
+ * purpose. See `src/proxy.ts:PUBLIC_API_RULES` for the gate config.
+ */
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const jobId = url.searchParams.get('jobId');
+    if (!jobId) {
+      return NextResponse.json({ error: 'jobId query parameter required' }, { status: 400 });
+    }
+    const sinceBytes = parseInt(url.searchParams.get('logsSince') || '0', 10);
+
+    const job = await getJob(jobId);
+    if (!job) {
+      return NextResponse.json({ error: 'job not found' }, { status: 404 });
+    }
+
+    const logs = await readLog(job.id, isNaN(sinceBytes) ? 0 : sinceBytes);
+
+    return NextResponse.json({
+      job: {
+        id: job.id,
+        phase: job.phase,
+        startedAt: job.startedAt,
+        updatedAt: job.updatedAt,
+        endedAt: job.endedAt,
+        progress: job.progress,
+        error: job.error,
+        // Boolean only — the actual fallback creds live in /status
+        // (cookie-gated) since they'd let an unauthenticated reader
+        // see the NPM admin password ServiceBay generated.
+        needsCredentials: !!job.needsCredentials,
+      },
+      jobIsActive: job.phase === 'running' || job.phase === 'needs_credentials',
+      logs: logs.content,
+      logsOffset: logs.nextOffset,
+    });
+  } catch (error) {
+    return apiError(error, { tag: 'api:install:progress', status: 500 });
+  }
+}

--- a/src/hooks/useStackInstall.ts
+++ b/src/hooks/useStackInstall.ts
@@ -361,8 +361,19 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     let cancelled = false;
     const tick = async () => {
       try {
-        const url = `/api/install/status?jobId=${encodeURIComponent(jobId)}&logsSince=${logsOffsetRef.current}`;
-        const res = await fetch(url);
+        // Primary: the cookie-gated /status endpoint (full data).
+        // Fallback (#663 — S1): /progress is jobId-gated and returns
+        // sanitised progress only. The fallback fires when /status
+        // 401s — which is what happens during a clean install that
+        // wipes `secrets`: AUTH_SECRET rotates mid-install and the
+        // operator's session cookie is no longer trusted. Without
+        // this, the install overlay silently stops updating.
+        const statusUrl = `/api/install/status?jobId=${encodeURIComponent(jobId)}&logsSince=${logsOffsetRef.current}`;
+        let res = await fetch(statusUrl);
+        if (res.status === 401) {
+          const progressUrl = `/api/install/progress?jobId=${encodeURIComponent(jobId)}&logsSince=${logsOffsetRef.current}`;
+          res = await fetch(progressUrl);
+        }
         if (!res.ok || cancelled) return;
         const data = (await res.json()) as {
           job: RemoteJobState | null;
@@ -401,7 +412,11 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
    *  the subscription effect then keeps it live. */
   const attachToJob = useCallback(async (id: string): Promise<void> => {
     try {
-      const res = await fetch(`/api/install/status?jobId=${encodeURIComponent(id)}`);
+      // Same /status → /progress 401 fallback as the poll loop (#663 — S1).
+      let res = await fetch(`/api/install/status?jobId=${encodeURIComponent(id)}`);
+      if (res.status === 401) {
+        res = await fetch(`/api/install/progress?jobId=${encodeURIComponent(id)}`);
+      }
       if (!res.ok) return;
       const data = await res.json() as {
         job: RemoteJobState | null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,6 +22,13 @@ const PUBLIC_API_RULES: Array<{ prefix: string; methods?: ReadonlySet<string> }>
   // also gates by mode (LAN-only) and validates the service +
   // asset-kind path params before producing anything.
   { prefix: '/api/portal/asset', methods: new Set(['GET']) },
+  // Install-progress polling endpoint (#663 — S1). GET-only; the
+  // route handler requires a valid `jobId` query parameter (uuidv4
+  // from `createJob`). Public so that the install-progress overlay
+  // keeps updating when the session cookie is invalidated mid-install
+  // by a wipe-secrets clean install. Returns sanitised progress only
+  // — no `input.variables`, no credentials manifest.
+  { prefix: '/api/install/progress', methods: new Set(['GET']) },
 ];
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);


### PR DESCRIPTION
## Summary

When \`secrets\` is wiped during a clean install, the runner deletes \`.auth-secret.env\`. AUTH_SECRET regenerates self-heal style on the next request; the operator's session cookie was signed with the *old* secret and becomes invalid mid-install. The wizard's status poll then 401s silently, the install overlay stops updating, but the install actually keeps deploying. Operator sees nothing.

- New \`/api/install/progress\` endpoint — GET-only, jobId-gated (122 bits of entropy), public via \`PUBLIC_API_RULES\`. Returns sanitised progress: no \`input.variables\`, no credentials manifest.
- \`useStackInstall\` polling loop + \`attachToJob\` fall back to \`/progress\` on 401 from \`/status\`. Authed users keep getting full data via \`/status\`.

Closes #663.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors
- [x] route-session-gate test still passes (new endpoint is GET-only, allowlisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)