### PR TITLE
feat(diagnose): distinguish missing-prereq from pending-schedule (#664)

### DIFF
--- a/src/lib/diagnose/probes/certExpiry.test.ts
+++ b/src/lib/diagnose/probes/certExpiry.test.ts
@@ -6,6 +6,7 @@ const state = {
   config: {} as any,
   services: [] as any[],
   results: new Map<string, CheckResult>(),
+  checks: [{ id: 'cert_expiry' }] as Array<{ id: string }>,
 };
 
 vi.mock('@/lib/config', () => ({
@@ -19,6 +20,7 @@ vi.mock('@/lib/services/ServiceManager', () => ({
 vi.mock('@/lib/health/store', () => ({
   HealthStore: {
     getLastResult: (id: string) => state.results.get(id) ?? null,
+    getChecks: () => state.checks,
   },
 }));
 
@@ -35,16 +37,24 @@ beforeEach(() => {
   state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
   state.services = ACTIVE_NGINX;
   state.results = new Map();
+  state.checks = [{ id: 'cert_expiry' }];
   mockFetch.mockReset();
 });
 
 // ─── Reader (Phase 3b: thin HealthStore reader) ─────────────────────────
 
 describe('checkCertExpiry (reader)', () => {
-  it('returns info when HealthStore has no result yet', async () => {
+  it('returns info when HealthStore has no result yet (check exists, first run pending)', async () => {
     const out = await checkCertExpiry();
     expect(out.status).toBe('info');
-    expect(out.detail).toMatch(/has not run yet/);
+    expect(out.detail).toMatch(/first run pending/);
+  });
+
+  it('reports the missing-prereq state when the cert_expiry check has not been created yet (#664)', async () => {
+    state.checks = [];
+    const out = await checkCertExpiry();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/No proxy hosts with public exposure/);
   });
 
   it('decodes the runner-encoded payload (warn with items[])', async () => {

--- a/src/lib/diagnose/probes/certExpiry.ts
+++ b/src/lib/diagnose/probes/certExpiry.ts
@@ -44,9 +44,19 @@ export interface CertExpiryResult {
 export async function checkCertExpiry(): Promise<CertExpiryResult> {
   const result = HealthStore.getLastResult(CHECK_ID);
   if (!result) {
+    // #664 — S4: distinguish missing-prereq from pending-schedule.
+    // The cert_expiry check exists once at least one proxy host with
+    // a public exposure is recorded (NPM has certs to inspect).
+    const exists = HealthStore.getChecks().some(c => c.id === CHECK_ID);
+    if (!exists) {
+      return {
+        status: 'info',
+        detail: 'No proxy hosts with public exposure recorded yet — nothing to check expiry on. Add a public domain in the wizard or Settings → Reverse Proxy.',
+      };
+    }
     return {
       status: 'info',
-      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+      detail: 'Scheduled — first run pending. Open Settings → Health to trigger it manually.',
     };
   }
   if (result.message && result.message.startsWith(CERT_EXPIRY_MESSAGE_PREFIX)) {

--- a/src/lib/diagnose/probes/certRequestFailure.test.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.test.ts
@@ -6,6 +6,7 @@ const state = {
   config: {} as any,
   services: [] as any[],
   results: new Map<string, CheckResult>(),
+  checks: [{ id: 'cert_request_failure' }] as Array<{ id: string }>,
 };
 
 const mockAgent = { sendCommand: vi.fn() };
@@ -25,6 +26,7 @@ vi.mock('@/lib/agent/manager', () => ({
 vi.mock('@/lib/health/store', () => ({
   HealthStore: {
     getLastResult: (id: string) => state.results.get(id) ?? null,
+    getChecks: () => state.checks,
   },
 }));
 
@@ -44,6 +46,7 @@ beforeEach(() => {
   };
   state.services = ACTIVE_NGINX;
   state.results = new Map();
+  state.checks = [{ id: 'cert_request_failure' }];
   mockAgent.sendCommand.mockReset();
   mockFetch.mockReset();
 });
@@ -151,10 +154,17 @@ acme.errors.Error: urn:ietf:params:acme:error:rateLimited :: Error creating new 
 // ─── Reader (Phase 3b: thin HealthStore reader) ─────────────────────────
 
 describe('checkCertRequestFailure (reader)', () => {
-  it('returns info when HealthStore has no result yet', async () => {
+  it('returns info when HealthStore has no result yet (check exists, first run pending)', async () => {
     const out = await checkCertRequestFailure();
     expect(out.status).toBe('info');
-    expect(out.detail).toMatch(/has not run yet/);
+    expect(out.detail).toMatch(/first run pending/);
+  });
+
+  it('reports the missing-prereq state when the le_request_failure check has not been created yet (#664)', async () => {
+    state.checks = [];
+    const out = await checkCertRequestFailure();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/NPM bootstrap/);
   });
 
   it('decodes the runner-encoded payload into the probe shape', async () => {

--- a/src/lib/diagnose/probes/certRequestFailure.ts
+++ b/src/lib/diagnose/probes/certRequestFailure.ts
@@ -56,9 +56,18 @@ export interface CertRequestFailureResult {
 export async function checkCertRequestFailure(): Promise<CertRequestFailureResult> {
   const result = HealthStore.getLastResult(CHECK_ID);
   if (!result) {
+    // #664 — S4: distinguish missing-prereq from pending-schedule.
+    // The le_request_failure check is created at NPM bootstrap.
+    const exists = HealthStore.getChecks().some(c => c.id === CHECK_ID);
+    if (!exists) {
+      return {
+        status: 'info',
+        detail: 'Waiting on NPM bootstrap — the LE request-failure check is created once the proxy stack is in place.',
+      };
+    }
     return {
       status: 'info',
-      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+      detail: 'Scheduled — first run pending. Open Settings → Health to trigger it manually.',
     };
   }
   if (result.message && result.message.startsWith(CERT_REQUEST_FAILURE_MESSAGE_PREFIX)) {

--- a/src/lib/diagnose/probes/lanIpChanged.test.ts
+++ b/src/lib/diagnose/probes/lanIpChanged.test.ts
@@ -12,6 +12,7 @@ import type { CheckResult } from '@/lib/health/types';
 
 const state = {
   results: new Map<string, CheckResult>(),
+  checks: [{ id: 'lan_ip_drift' }] as Array<{ id: string }>,
   reconcileResult: '192.168.1.10' as string | null,
   provisionResult: { ok: true, detail: 'all 3 rewrites in place' } as { ok: boolean; detail: string },
   config: {
@@ -23,6 +24,7 @@ const state = {
 vi.mock('@/lib/health/store', () => ({
   HealthStore: {
     getLastResult: (id: string) => state.results.get(id) ?? null,
+    getChecks: () => state.checks,
   },
 }));
 
@@ -51,6 +53,7 @@ import { dispatchProbeAction, actionsForProbe } from '../actions';
 
 beforeEach(() => {
   state.results = new Map();
+  state.checks = [{ id: 'lan_ip_drift' }];
   state.reconcileResult = '192.168.1.10';
   state.provisionResult = { ok: true, detail: 'all 3 rewrites in place' };
   state.config = {
@@ -60,10 +63,17 @@ beforeEach(() => {
 });
 
 describe('checkLanIpChanged (reader)', () => {
-  it('returns info when HealthStore has no result yet', async () => {
+  it('returns info when HealthStore has no result yet (check exists, first run pending)', async () => {
     const out = await checkLanIpChanged();
     expect(out.status).toBe('info');
-    expect(out.detail).toMatch(/has not run yet/);
+    expect(out.detail).toMatch(/first run pending/);
+  });
+
+  it('reports the missing-prereq state when the lan_ip_drift check has not been created yet (#664)', async () => {
+    state.checks = [];
+    const out = await checkLanIpChanged();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/install-time LAN-IP/);
   });
 
   it('decodes a happy-path warn payload', async () => {

--- a/src/lib/diagnose/probes/lanIpChanged.ts
+++ b/src/lib/diagnose/probes/lanIpChanged.ts
@@ -50,9 +50,21 @@ registerRefreshNow(PROBE_ID, CHECK_ID, 'LAN IP drift');
 export async function checkLanIpChanged(): Promise<LanIpProbeResult> {
   const result = HealthStore.getLastResult(CHECK_ID);
   if (!result) {
+    // #664 — S4: tell apart "config missing" from "first run pending."
+    // The lan_ip_drift check exists once an install has recorded
+    // reverseProxy.lanIp (#660 makes this synchronous at install
+    // time). If it doesn't exist, the install hasn't completed its
+    // LAN-IP capture yet.
+    const exists = HealthStore.getChecks().some(c => c.id === CHECK_ID);
+    if (!exists) {
+      return {
+        status: 'info',
+        detail: 'Waiting on install-time LAN-IP capture (#660). The drift check is created once reverseProxy.lanIp is recorded. Run a clean install or click "Reconcile now" below to capture the current IP.',
+      };
+    }
     return {
       status: 'info',
-      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+      detail: 'Scheduled — first run pending. Open Settings → Health to trigger it manually.',
     };
   }
   if (result.message && result.message.startsWith(LAN_IP_DRIFT_MESSAGE_PREFIX)) {

--- a/src/lib/diagnose/probes/npmDataStale.test.ts
+++ b/src/lib/diagnose/probes/npmDataStale.test.ts
@@ -8,11 +8,13 @@ import type { CheckResult } from '@/lib/health/types';
 
 const state = {
   results: new Map<string, CheckResult>(),
+  checks: [{ id: 'npm_auth' }] as Array<{ id: string }>,
 };
 
 vi.mock('@/lib/health/store', () => ({
   HealthStore: {
     getLastResult: (id: string) => state.results.get(id) ?? null,
+    getChecks: () => state.checks,
   },
 }));
 
@@ -20,13 +22,21 @@ import { checkNpmDataStale } from './npmDataStale';
 
 beforeEach(() => {
   state.results = new Map();
+  state.checks = [{ id: 'npm_auth' }];
 });
 
 describe('checkNpmDataStale (reader)', () => {
-  it('returns info when HealthStore has no result yet', async () => {
+  it('returns info when HealthStore has no result yet (check exists, just pending first run)', async () => {
     const out = await checkNpmDataStale();
     expect(out.status).toBe('info');
-    expect(out.detail).toMatch(/has not run yet/);
+    expect(out.detail).toMatch(/first run pending/);
+  });
+
+  it('reports the missing-prereq state when the npm_auth check has not been created yet (#664)', async () => {
+    state.checks = [];
+    const out = await checkNpmDataStale();
+    expect(out.status).toBe('info');
+    expect(out.detail).toMatch(/NPM admin bootstrap/);
   });
 
   it('decodes a stale-credentials fail payload', async () => {

--- a/src/lib/diagnose/probes/npmDataStale.ts
+++ b/src/lib/diagnose/probes/npmDataStale.ts
@@ -50,9 +50,22 @@ const CHECK_ID = 'npm_auth';
 export async function checkNpmDataStale(): Promise<NpmDataStaleResult> {
   const result = HealthStore.getLastResult(CHECK_ID);
   if (!result) {
+    // #664 — S4: distinguish "not yet scheduled (config missing)" from
+    // "scheduled, first run pending." The npm_auth check is created
+    // when ServiceBay records NPM admin credentials (see
+    // `postInstall.bootstrapNpmAdmin`). If the check doesn't exist
+    // yet the probe is blocked on NPM bootstrap; if it exists but has
+    // no result, the scheduler will fire it shortly.
+    const exists = HealthStore.getChecks().some(c => c.id === CHECK_ID);
+    if (!exists) {
+      return {
+        status: 'info',
+        detail: 'Waiting on NPM admin bootstrap — the npm_auth check is created once ServiceBay records the NPM admin credentials. Re-run after the install finishes its NPM step.',
+      };
+    }
     return {
       status: 'info',
-      detail: 'Check has not run yet. Open Settings → Health to trigger it manually.',
+      detail: 'Scheduled — first run pending. Open Settings → Health to trigger it manually.',
     };
   }
   if (result.message && result.message.startsWith(NPM_AUTH_MESSAGE_PREFIX)) {


### PR DESCRIPTION
## Summary

Four reader-probes returned identical "Check has not run yet" strings when HealthStore had no result. Operators couldn't tell whether the check was just about to fire or was permanently blocked on missing config.

Each probe now consults \`HealthStore.getChecks()\` to disambiguate:
- check exists → "Scheduled — first run pending"
- check absent → specific blocker (NPM bootstrap, install-time LAN-IP capture, public exposure, …)

Closes #664.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors
- [x] vitest probes — 145/145 pass, 4 new tests for the missing-prereq branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)