### PR TITLE
feat(banner): core-stack-unhealthy shows causal chain (#665)

### DIFF
--- a/src/components/CoreHealthBanner.tsx
+++ b/src/components/CoreHealthBanner.tsx
@@ -19,9 +19,16 @@ import Link from 'next/link';
 const POLL_INTERVAL_MS = 15_000;
 const DISMISS_KEY = 'sb:core-health-banner-dismissed';
 
+interface UnhealthyCause {
+  summary: string;
+  action?: { label: string; href: string };
+}
+
 interface DegradedNotReady {
   template: string;
   state: 'unhealthy' | 'unknown';
+  /** Populated when a known config-side cause matches (#665 — S5). */
+  cause?: UnhealthyCause;
 }
 
 interface DegradedEntry {
@@ -84,16 +91,33 @@ export default function CoreHealthBanner() {
           <h3 className="text-sm font-semibold text-red-900 dark:text-red-100">
             Core {visible.length === 1 ? 'stack' : 'stacks'} unhealthy: {visible.map(d => d.label).join(', ')}
           </h3>
-          <ul className="mt-1.5 space-y-0.5">
+          <ul className="mt-1.5 space-y-1.5">
             {visible.flatMap(d => d.notReady.filter(n => n.state === 'unhealthy').map(n => (
               <li key={`${d.stack}/${n.template}`} className="text-xs text-red-800/90 dark:text-red-200/90">
                 <code className="font-mono">{n.template}</code>{' '}
                 <span className="text-red-700/70 dark:text-red-300/70">({n.state})</span>
+                {/* #665 — S5: render the causal-chain hint when the
+                    server inferred a known config-side blocker, so
+                    operators see "X unhealthy → because Y, click Z"
+                    instead of a bare "(unhealthy)" red badge. */}
+                {n.cause && (
+                  <div className="mt-0.5 ml-3 text-red-800/80 dark:text-red-200/80">
+                    → {n.cause.summary}
+                    {n.cause.action && (
+                      <>
+                        {' '}
+                        <Link href={n.cause.action.href} className="underline font-medium">
+                          {n.cause.action.label}
+                        </Link>
+                      </>
+                    )}
+                  </div>
+                )}
               </li>
             )))}
           </ul>
           <p className="text-xs text-red-800/80 dark:text-red-200/80 mt-2">
-            Feature installs are gated on core health. Open <Link href="/diagnose" className="underline font-medium">Self-diagnose</Link> for the recovery path.
+            Feature installs are gated on core health. Open <Link href="/diagnose" className="underline font-medium">Self-diagnose</Link> for the full recovery path.
           </p>
         </div>
         <button

--- a/src/lib/install/stackHealth.ts
+++ b/src/lib/install/stackHealth.ts
@@ -19,6 +19,7 @@
  */
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getStackManifest } from '@/lib/registry';
+import { getConfig } from '@/lib/config';
 
 export type ChildHealthState = 'ready' | 'unhealthy' | 'unknown';
 
@@ -69,12 +70,33 @@ export function aggregateStackHealth(
  * the stack + its unhealthy children so the operator can act without
  * re-reading the diagnose page.
  */
+/**
+ * Best-effort cause inference (#665 — S5). When a known unhealthy
+ * pattern matches missing config we can hint at the recovery instead
+ * of leaving the operator to triage a generic "adguard unhealthy" red
+ * banner. Patterns must be conservative — a wrong hint is worse than
+ * none.
+ */
+export interface UnhealthyCause {
+  /** Short headline rendered next to the template name. */
+  summary: string;
+  /** Optional action label + href for the banner button. */
+  action?: { label: string; href: string };
+}
+
+export interface NotReadyChild {
+  template: string;
+  state: 'unhealthy' | 'unknown';
+  /** Populated when a known config-side cause matches (#665 — S5). */
+  cause?: UnhealthyCause;
+}
+
 export interface DegradedCoreEntry {
   stack: string;
   /** Friendly label from the stack's manifest. */
   label: string;
   /** Per-child state; only `unhealthy` / `unknown` keys appear. */
-  notReady: Array<{ template: string; state: 'unhealthy' | 'unknown' }>;
+  notReady: NotReadyChild[];
 }
 
 /**
@@ -85,6 +107,32 @@ export interface DegradedCoreEntry {
  *   - `<CoreHealthBanner>` to show what's broken with click-through
  *     to diagnose actions.
  */
+/**
+ * Map an unhealthy template name to a known cause when config is the
+ * obvious blocker. Pure read of config; no agent calls. New patterns
+ * land here when a recurring "X unhealthy because Y" emerges from
+ * field reports — keep the matcher narrow so unrelated unhealthy
+ * states still fall through to the generic banner copy.
+ */
+async function inferCause(
+  template: string,
+  config: { reverseProxy?: { lanIp?: string; publicDomain?: string } },
+): Promise<UnhealthyCause | undefined> {
+  if (template === 'adguard' && !config.reverseProxy?.lanIp) {
+    return {
+      summary: 'AdGuard depends on the install-time LAN IP. It hasn\'t been captured yet — wildcard DNS rewrites can\'t be provisioned.',
+      action: { label: 'Reconcile LAN IP', href: '/diagnose' },
+    };
+  }
+  if (template === 'nginx' && !config.reverseProxy?.publicDomain) {
+    return {
+      summary: 'NPM proxy hosts depend on a publicDomain. Wizard didn\'t capture one yet (or LAN-only install).',
+      action: { label: 'Open wizard', href: '/setup' },
+    };
+  }
+  return undefined;
+}
+
 export async function getDegradedCoreSummary(nodeName: string = 'Local'): Promise<DegradedCoreEntry[]> {
   const fs = await import('fs/promises');
   const path = await import('path');
@@ -97,6 +145,10 @@ export async function getDegradedCoreSummary(nodeName: string = 'Local'): Promis
   }
   const names = dirents.filter(d => d.isDirectory() && !d.name.startsWith('.')).map(d => d.name);
 
+  // Load config once for cause inference (#665 — S5).
+  let cfg: { reverseProxy?: { lanIp?: string; publicDomain?: string } } = {};
+  try { cfg = await getConfig(); } catch { /* cause hints stay empty */ }
+
   const degraded: DegradedCoreEntry[] = [];
   for (const name of names) {
     let manifest;
@@ -106,13 +158,16 @@ export async function getDegradedCoreSummary(nodeName: string = 'Local'): Promis
     if (!manifest || manifest.tier !== 'core') continue;
     const health = await getStackHealth(name, nodeName);
     if (!health || health.ready) continue;
-    degraded.push({
-      stack: name,
-      label: manifest.label,
-      notReady: Object.entries(health.children)
+    const notReady = await Promise.all(
+      Object.entries(health.children)
         .filter(([, s]) => s !== 'ready')
-        .map(([template, state]) => ({ template, state: state as 'unhealthy' | 'unknown' })),
-    });
+        .map(async ([template, state]): Promise<NotReadyChild> => ({
+          template,
+          state: state as 'unhealthy' | 'unknown',
+          cause: state === 'unhealthy' ? await inferCause(template, cfg) : undefined,
+        })),
+    );
+    degraded.push({ stack: name, label: manifest.label, notReady });
   }
   return degraded;
 }


### PR DESCRIPTION
## Summary

Banner used to show a bare \`adguard (unhealthy)\` with no path to remediation. Operators had to dig through diagnose to find the cause.

- Server-side cause inference for two known patterns (adguard ↦ lanIp, nginx ↦ publicDomain)
- Banner renders the cause inline with a click-through action link
- Unknown causes fall through to the existing generic banner copy

Depends on S4 (#677) conceptually but doesn't require its changes — uses config-state inference, not the probe-state machine.

Closes #665.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors
- [x] \`stackRunner.test.ts\` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)