### PR TITLE
fix(install): escape %s in AUTH_SECRET init systemd unit

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -741,12 +741,21 @@ ${SERVICEBAY_SSH_PRIV}
           # mkdir is idempotent; the conditional generation lives in the
           # shell script so an existing .auth-secret.env survives intact
           # even when this oneshot re-runs (e.g. after `systemctl daemon-reload`).
+          # systemd treats `%s` in ExecStart= as a specifier ($SHELL) and
+          # substitutes it *before* invoking sh. Pre-fix: the printf format
+          # string was rewritten from "AUTH_SECRET=%s\n" to
+          # "AUTH_SECRET=/bin/bash\n" — so every fresh install wrote that
+          # 9-char nonsense into .auth-secret.env, and ServiceBay's
+          # assertAuthSecret() (≥32 chars required) crashed the container
+          # in a restart loop. Escape with `%%s` so systemd renders it as
+          # literal `%s` before the shell sees it. Same fix anywhere
+          # `printf` is used inside ExecStart=/usr/bin/sh -c.
           ExecStart=/usr/bin/sh -c '\
             install -d -m 0755 -o ${HOST_USER} -g ${HOST_USER} /var/mnt/data/servicebay; \
             if [ ! -s /var/mnt/data/servicebay/.auth-secret.env ]; then \
               SECRET=$$(/usr/bin/openssl rand -hex 32); \
               umask 0177; \
-              printf "AUTH_SECRET=%s\\n" "$$SECRET" > /var/mnt/data/servicebay/.auth-secret.env; \
+              printf "AUTH_SECRET=%%s\\n" "$$SECRET" > /var/mnt/data/servicebay/.auth-secret.env; \
               chown ${HOST_USER}:${HOST_USER} /var/mnt/data/servicebay/.auth-secret.env; \
               echo "AUTH_SECRET written (fresh install or first migration)"; \
             else \

--- a/src/lib/install/performStackReset.ts
+++ b/src/lib/install/performStackReset.ts
@@ -80,7 +80,15 @@ export async function performStackReset(
   // service was torn down even though its data dir stays.
   const services = await ServiceManager.listServices(nodeName);
   const preservedServices = new Set<string>();
-  if (preserve.includes('certs')) preservedServices.add('nginx-proxy-manager');
+  // Service template names (matches the `templates/<name>/` directory),
+  // not the on-disk path basenames. Pre-fix: 'nginx-proxy-manager' was
+  // the *path* basename — but ServiceManager.listServices returns the
+  // template/quadlet-unit name 'nginx', so the name miss never matched
+  // and the operator's `keep certs` choice silently tore down nginx
+  // before the install runner redeployed it (#679 follow-up). 'auth'
+  // happens to match because the template directory + path basename
+  // are both called `auth`.
+  if (preserve.includes('certs')) preservedServices.add('nginx');
   if (preserve.includes('identity')) preservedServices.add('auth');
   const toDelete = services
     .map(s => s.name)


### PR DESCRIPTION
## Summary

Every fresh-install with \`install-fedora-coreos.sh\` since #565 landed has been broken: systemd treats \`%s\` as a specifier (\`\$SHELL\`), so the printf format string \`"AUTH_SECRET=%s\\n"\` is rewritten to \`"AUTH_SECRET=/bin/bash\\n"\` before sh sees it. The init unit writes the literal 9-character string \`AUTH_SECRET=/bin/bash\` into \`.auth-secret.env\`, and the container crashes on boot in a restart loop because \`assertAuthSecret()\` requires ≥32 chars.

Reinstallers with a pre-existing valid file aren't affected (guard preserves it). Operators following the standard install path are.

Fix: \`%s\` → \`%%s\`.

## Recovery on existing broken installs

\`\`\`bash
sudo sed -i "s|AUTH_SECRET=/bin/bash|AUTH_SECRET=\$(openssl rand -hex 32)|" /mnt/data/servicebay/.auth-secret.env
sudo systemctl restart user@1000.service
\`\`\`

## Test plan

- [x] Hot-patched live box: \`5888 → HTTP 307\` (responsive)
- [x] Verified no other \`%X\` specifiers inside any \`ExecStart=/usr/bin/sh -c\` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)