### PR TITLE
fix(stacks): README checklist format so wizard parses templates

### DIFF
--- a/stacks/basic/README.md
+++ b/stacks/basic/README.md
@@ -1,13 +1,13 @@
 # Basic stack
 
 ServiceBay's core platform services — the three templates every feature
-stack depends on:
+stack depends on.
 
-- **nginx** — Nginx Proxy Manager: reverse proxy + Let's Encrypt certs
-- **auth** — LLDAP + Authelia: identity provider, SSO, family-account
-  management
-- **adguard** — AdGuard Home: LAN DNS with split-horizon rewrites for
-  `<sub>.<public-domain>` resolution
+## Included Services
+
+- [x] nginx — Nginx Proxy Manager: reverse proxy + Let's Encrypt certs
+- [x] auth — LLDAP + Authelia: identity provider, SSO, family-account management
+- [x] adguard — AdGuard Home: LAN DNS with split-horizon rewrites for `<sub>.<public-domain>`
 
 This stack is `tier: core` — every feature stack's install is gated on
 it being healthy. Wiping is gated behind FACTORY RESET (Settings → System

--- a/stacks/cloud/README.md
+++ b/stacks/cloud/README.md
@@ -1,13 +1,15 @@
 # Cloud stack
 
 The personal-cloud bundle — services reachable from outside the LAN
-that handle private data the household relies on:
+that handle private data the household relies on.
 
-- **vaultwarden** — Bitwarden-compatible password manager
-- **immich** — Photos + AI search, mobile auto-upload
-- **file-share** — Syncthing + Samba + FileBrowser (LDAP/SSO‑wired)
-- **media** — Jellyfin streaming + Audiobookshelf for podcasts/books
-- **radicale** — CalDAV/CardDAV (calendar + contacts), LDAP-bound
+## Included Services
+
+- [x] vaultwarden — Bitwarden-compatible password manager
+- [x] immich — Photos + AI search, mobile auto-upload
+- [x] file-share — Syncthing + Samba + FileBrowser (LDAP/SSO‑wired)
+- [x] media — Jellyfin streaming + Audiobookshelf for podcasts/books
+- [x] radicale — CalDAV/CardDAV (calendar + contacts), LDAP-bound
 
 ## Why a single stack
 

--- a/stacks/home/README.md
+++ b/stacks/home/README.md
@@ -1,10 +1,11 @@
 # Home stack
 
-Smart-home automation + local voice pipeline:
+Smart-home automation + local voice pipeline.
 
-- **home-assistant** — HA core + Z-Wave + Matter bridges
-- **voice** — Wyoming protocol services: faster-whisper (STT) +
-  piper (TTS) + openWakeWord (wake detection)
+## Included Services
+
+- [x] home-assistant — HA core + Z-Wave + Matter bridges
+- [x] voice — Wyoming pipeline: faster-whisper (STT) + piper (TTS) + openWakeWord (wake detection)
 
 ## Why a single stack
 


### PR DESCRIPTION
## Summary

#680's stack consolidation rewrote 3 READMEs (basic, cloud, home) using bold-list format. The wizard's \`handleSelectStack\` only recognises checklist format (\`- [x] name — desc\`), so it parsed each of those stacks to zero items. Net effect on a fresh v4.8.0 install: only \`ai\` stack templates appeared in the install step. basic/cloud/home silently dropped, install runner never deployed them, "Core stack unhealthy" banner.

Fix: convert the 3 READMEs to checklist format so the parser picks them up.

The structural fix (consume \`stack.yml.templates\` instead of parsing README) is the right long-term answer but a separate PR.

## Test plan

- [x] stack-consistency + template-consistency tests pass
- [x] grep verifies each README has the right number of \`- [x]\` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)