### PR TITLE
fix(install): cascade-bug batch (#702 #703 #704 #705 #706 #707)

### DIFF
--- a/src/lib/install/jobStore.ts
+++ b/src/lib/install/jobStore.ts
@@ -114,6 +114,16 @@ async function ensureDir(): Promise<void> {
 const statePath = (id: string) => path.join(JOBS_DIR, `${id}.json`);
 const logPath = (id: string) => path.join(JOBS_DIR, `${id}.log`);
 
+/** In-memory cache of every job created this process. Survives a
+ *  vanishing on-disk state file (#705): the reset endpoint used to
+ *  wipe `/mnt/data/servicebay/install-jobs/` along with the rest of
+ *  the secrets group, dropping the state-json out from under the
+ *  runner mid-install. The next \`updateJob\` couldn't find it,
+ *  silently bailed, and the wizard's progress poll returned null
+ *  for the rest of the run. The cache lets \`updateJob\` rewrite
+ *  the disk file from in-memory state when that happens. */
+const memCache = new Map<string, JobState>();
+
 /** Atomic write via tmp + rename. Prevents readers from ever seeing a
  *  partially-written state file even if the process is killed mid-write. */
 async function atomicWrite(p: string, content: string): Promise<void> {
@@ -141,15 +151,23 @@ export async function createJob(opts: { source: string; input: JobInput }): Prom
   };
   await atomicWrite(statePath(job.id), JSON.stringify(job, null, 2));
   await fs.writeFile(logPath(job.id), '', 'utf-8');
+  memCache.set(job.id, job);
   return job;
 }
 
 export async function getJob(id: string): Promise<JobState | null> {
   try {
     const raw = await fs.readFile(statePath(id), 'utf-8');
-    return JSON.parse(raw) as JobState;
+    const parsed = JSON.parse(raw) as JobState;
+    // Refresh memory cache from disk on every read so server-restart
+    // gets stale-but-correct state until the next update writes back.
+    memCache.set(id, parsed);
+    return parsed;
   } catch {
-    return null;
+    // Fall back to memory cache when the disk file is missing or
+    // corrupt — see #705. Returning null silently used to strand the
+    // wizard's status poll.
+    return memCache.get(id) ?? null;
   }
 }
 
@@ -160,7 +178,18 @@ export async function updateJob(
   const current = await getJob(id);
   if (!current) return null;
   const next: JobState = { ...current, ...partial, updatedAt: new Date().toISOString() };
-  await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
+  // Best-effort disk write. The memory cache is the authoritative
+  // store within this process; disk is for status-route reads + post-
+  // restart recovery (#705).
+  try {
+    await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
+  } catch {
+    // Disk write failed (volume gone? permissions?). Cache still has
+    // the new state, status route reads from cache, runner keeps
+    // going. Worst case: a restart loses progress for this job, but
+    // the install itself continues.
+  }
+  memCache.set(id, next);
   return next;
 }
 

--- a/src/lib/install/performStackReset.ts
+++ b/src/lib/install/performStackReset.ts
@@ -165,14 +165,69 @@ export async function performStackReset(
     }
   }
 
-  // secrets: wipe contents of /var/mnt/data/servicebay/. Clear contents
-  // rather than removing the dir itself so the systemd mount unit +
-  // setup-raid don't trip on a missing path.
+  // secrets: clear secret.key + the encryption-keyed encrypted state.
+  // Operator-supplied non-secret config (publicDomain, gateway host,
+  // SMTP host etc.) and the agent's SSH key are NOT key-dependent;
+  // wiping them just creates a worse re-install experience (#702, #703).
+  //
+  // Pre-fix: \`find /var/mnt/data/servicebay -mindepth 1 -maxdepth 1\`
+  // removed everything — including \`ssh/id_rsa\` (agent loses its
+  // own host's SSH key → infinite ensureAgent retry loop) and
+  // \`config.json\` (publicDomain that the wizard JUST wrote vanishes
+  // before any deploy can read it — see #702).
+  //
+  // The targeted wipe:
+  //   - secret.key, .auth-secret.env → always (the actual cipher key)
+  //   - mcp-tokens.json → always (encrypted with secret.key)
+  //   - auth.db, logs.db, results/ → always (sqlite encrypted with key)
+  //   - checks.json → always (regenerated from manifests)
+  //   - install-jobs/ → preserved (job state survives — see #705)
+  //   - ssh/ → preserved (agent's own host key — see #703)
+  //   - config.json → scrubbed in place: drop every enc:v1: field and
+  //     the auth.passwordHash, keep operator-input fields like
+  //     publicDomain, lanDomain, gateway.host (see #702)
+  //   - cert-archive/ → preserved
   if (!preserve.includes('secrets')) {
+    // 1) Scrub config.json in place (Python one-liner: drop every
+    //    enc:v1:* value, drop auth.passwordHash, drop the encrypted
+    //    .password subkeys; keep everything else).
+    const scrubConfig = `python3 -c '
+import json, os, sys
+p = "/var/mnt/data/servicebay/config.json"
+if not os.path.exists(p):
+    sys.exit(0)
+with open(p) as f:
+    d = json.load(f)
+def scrub(obj):
+    if isinstance(obj, dict):
+        for k in list(obj.keys()):
+            v = obj[k]
+            if isinstance(v, str) and v.startswith("enc:v1:"):
+                del obj[k]
+            elif isinstance(v, (dict, list)):
+                scrub(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            scrub(v)
+scrub(d)
+auth = d.get("auth", {})
+auth.pop("passwordHash", None)
+auth.pop("bootstrapToken", None)
+tmp = p + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(d, f, indent=2)
+os.replace(tmp, p)
+' 2>&1 || true`;
+    await agent.sendCommand('exec', { command: scrubConfig });
+
+    // 2) Wipe everything else under /var/mnt/data/servicebay/ except
+    //    the preserved subdirs + the just-scrubbed config.json.
+    const preservedNames = ['ssh', 'install-jobs', 'cert-archive', 'config.json'];
+    const findExclusions = preservedNames.map(n => `! -name ${JSON.stringify(n)}`).join(' ');
     await agent.sendCommand('exec', {
-      command: 'find /var/mnt/data/servicebay -mindepth 1 -maxdepth 1 -exec rm -rf {} +',
+      command: `find /var/mnt/data/servicebay -mindepth 1 -maxdepth 1 ${findExclusions} -exec rm -rf {} +`,
     });
-    wipeStepsRun.push('secrets (ServiceBay state)');
+    wipeStepsRun.push('secrets (kept ssh/, install-jobs/, cert-archive/, scrubbed config.json)');
   }
 
   // alwaysWipe groups (quadlet-backup): always purged, even when their

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -849,7 +849,50 @@ async function runJob(jobId: string): Promise<void> {
       node: input.node || undefined,
       onLog: (line: string) => { void log(jobId, line); },
     });
-    if (bootstrap === 'needs_credentials') {
+    let bootstrapState: 'ok' | 'needs_credentials' | 'skipped' = bootstrap;
+
+    // Self-heal on clean install with certs preserved (#704). The
+    // operator's data volume kept the OLD admin bcrypt; the wizard's
+    // INITIAL_ADMIN_PASSWORD env never overwrites an existing admin
+    // user. The pre-fix flow paused for the operator to type the old
+    // password — which they typically don't have (forgotten, never
+    // copied off the credentials banner). Auto-wipe the NPM data dir
+    // (admin sqlite + sites table) and retry bootstrap; letsencrypt/
+    // stays untouched so cert files survive — that's the only reason
+    // "preserve certs" exists in the first place.
+    if (
+      bootstrapState === 'needs_credentials'
+      && input.cleanInstall
+      && (input.preserve?.includes('certs') ?? true)
+    ) {
+      const node = input.node || 'Local';
+      const dataDir = (await getConfig()).templateSettings?.DATA_DIR || '/mnt/data/stacks';
+      await log(jobId, '🔄 NPM rejected the wizard credentials (stale admin from a prior install). Wiping NPM data/ — letsencrypt/ certs preserved.');
+      try {
+        const { agentManager } = await import('@/lib/agent/manager');
+        const agent = await agentManager.ensureAgent(node);
+        await agent.sendCommand('exec', {
+          command: `systemctl --user stop nginx.service 2>&1 || true; rm -rf "${dataDir}/nginx-proxy-manager/data"; systemctl --user start nginx.service 2>&1 || true`,
+        });
+        // Give NPM 30s to bootstrap fresh from INITIAL_ADMIN_* env.
+        await new Promise(r => setTimeout(r, 30_000));
+        const retry = await bootstrapNpmAdmin({
+          variables,
+          node: input.node || undefined,
+          onLog: (line: string) => { void log(jobId, line); },
+        });
+        if (retry === 'ok') {
+          await log(jobId, '✅ NPM bootstrap succeeded after self-heal.');
+          bootstrapState = 'ok';
+        } else {
+          await log(jobId, '⚠️ NPM still rejecting credentials after data-wipe retry; falling back to the credentials prompt.');
+        }
+      } catch (e) {
+        await log(jobId, `⚠️ NPM self-heal failed (${e instanceof Error ? e.message : String(e)}); falling back to the credentials prompt.`);
+      }
+    }
+
+    if (bootstrapState === 'needs_credentials') {
       // Prefer credentials saved in config over wizard's newly-generated
       // ones — we're in this branch because NPM rejected the wizard
       // values, so re-prompting with the same string is just confusing.
@@ -939,12 +982,15 @@ async function runJob(jobId: string): Promise<void> {
   await patchJob(jobId, { credentialsManifest: manifest });
 
   // Portal routing — apex + wildcard rewrites for the active domain.
-  // Stays here (not a per-template concern): runs once after AdGuard is
-  // deployed in this stack.
-  if (ctx.deployed.some(d => d.name === 'adguard')) {
-    await log(jobId, 'Provisioning AdGuard DNS rewrites + portal routing...');
-    await provisionPortalWithRetries((line: string) => { void log(jobId, line); });
-  }
+  // Always runs after a successful install (#707). Pre-fix this was
+  // gated on `adguard ∈ newlyDeployed`, which meant a feature-only
+  // install (e.g. operator adds the `cloud` stack to an existing
+  // host) silently skipped DNS-rewrite provisioning even though new
+  // subdomains were being created. Now run it whenever the
+  // prerequisites (publicDomain + AdGuard reachable) are met; the
+  // provisioner internally no-ops when AdGuard isn't installed yet.
+  await log(jobId, 'Provisioning AdGuard DNS rewrites + portal routing...');
+  await provisionPortalWithRetries((line: string) => { void log(jobId, line); });
 
   // Settle-wait against the in-process digital twin.
   await settleWait(jobId, ctx.deployed, input.node || 'Local');

--- a/templates/hermes/template.yml
+++ b/templates/hermes/template.yml
@@ -37,9 +37,10 @@ spec:
   containers:
   - name: hermes
     image: docker.io/nousresearch/hermes-agent:latest
-    command:
-    - gateway
-    - run
+    # Pre-fix the pod overrode `command: [gateway, run]`. Upstream
+    # dropped the `gateway` binary from PATH and the image entrypoint
+    # is now `/usr/bin/tini -g -- /opt/hermes/docker/entrypoint.sh`
+    # — letting that run (no command override) is what works (#706).
     env:
     # API server config (per upstream Docker docs at
     # https://hermes-agent.nousresearch.com/docs/user-guide/docker).


### PR DESCRIPTION
## Six interlocking bugs, one PR

User-visible symptom: \"keine einzige Domain geht\" after fresh install. Root cause: six issues stacked in the install path, all surfacing together on \`keep certs + identity\` clean install.

| Issue | Fix |
|---|---|
| #702 publicDomain wiped by secrets reset | scrub config.json (drop \`enc:v1:\` fields), keep operator-input |
| #703 SSH key wiped → agent can't connect | exclude \`ssh/\` from wipe |
| #704 NPM admin pw drift | self-heal: wipe NPM data/ (keep letsencrypt/), retry bootstrap |
| #705 Install-job .json missing → UI stuck | in-memory cache fallback + preserve install-jobs/ from wipe |
| #706 Hermes \`gateway\` binary missing | drop \`command:\` override |
| #707 AdGuard rewrites not provisioned | run \`provisionPortalWithRetries\` unconditionally at install-tail |

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run check:arch\` — passed
- [x] \`vitest run\` — 1108/1108 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)