### PR TITLE
fix: diagnose + media + install copy batch (#736 #735 #734 #733 #725)

### DIFF
--- a/src/app/api/system/nginx/bootstrap/route.ts
+++ b/src/app/api/system/nginx/bootstrap/route.ts
@@ -161,8 +161,16 @@ export async function POST(request: Request) {
       email?: string;
       password?: string;
       fullName?: string;
+      /**
+       * Set true by the install runner's self-heal retry path (#733).
+       * The retry happens immediately after a data-dir wipe + nginx
+       * restart, so the user table seeds in seconds — the default 90 s
+       * budget would just stall the install with a second long wait
+       * for no extra coverage. Caps the retry budget at 20 s instead.
+       */
+      quickRetry?: boolean;
     };
-    const { node, email, password, fullName } = body;
+    const { node, email, password, fullName, quickRetry } = body;
 
     if (typeof email !== 'string' || !email || typeof password !== 'string' || !password) {
       return NextResponse.json({ ok: false, error: 'email and password are required' }, { status: 400 });
@@ -184,7 +192,7 @@ export async function POST(request: Request) {
     // The defaults fallback below remains as a safety net for older NPM
     // versions that ignored the INITIAL_ADMIN_* env vars, or for installs
     // that somehow lost them.
-    const TARGET_RETRY_BUDGET_MS = 90_000;
+    const TARGET_RETRY_BUDGET_MS = quickRetry ? 20_000 : 90_000;
     const RETRY_INTERVAL_MS = 3_000;
     const start = Date.now();
     let targetToken: string | null = null;

--- a/src/components/ActionProgressModal.tsx
+++ b/src/components/ActionProgressModal.tsx
@@ -207,9 +207,21 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
               </button>
             )}
             <button
-              onClick={onClose}
+              onClick={() => {
+                // While the action is still running, treat the X like
+                // "Run in background" — closing this modal aborts the
+                // SSE stream and breaks completion notification, even
+                // though the host-side systemctl operation keeps going
+                // (#725). Surface the same toast affordance instead.
+                if (status === 'running') {
+                  setMinimized(true);
+                } else {
+                  onClose();
+                }
+              }}
               className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 p-1 rounded transition-colors"
-              aria-label="Close"
+              aria-label={status === 'running' ? 'Run in background' : 'Close'}
+              title={status === 'running' ? 'Run in background' : 'Close'}
             >
               <X size={20} />
             </button>
@@ -218,7 +230,7 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
         
         <div className="p-4 bg-[#1e1e1e] border-b border-gray-800">
           <div className="p-3 bg-blue-900/20 border border-blue-900/50 rounded text-blue-200 text-xs">
-             <p>Note: This operation may take several minutes. Please do not close this window.</p>
+             <p>Operation in progress. You can safely minimize this window to keep working &mdash; we&apos;ll notify you when it finishes. Closing this modal keeps the task running in the background.</p>
           </div>
         </div>
 

--- a/src/lib/diagnose/probes/oidcProviderReachable.test.ts
+++ b/src/lib/diagnose/probes/oidcProviderReachable.test.ts
@@ -4,8 +4,22 @@ vi.mock('@/lib/config', () => ({
   getConfig: vi.fn(),
 }));
 
+// Mock the agent manager so the log-fetch path inside the probe doesn't
+// open a real connection during unit tests. Tests can override the
+// per-call behavior by stubbing `agentManager.ensureAgent`.
+const sendCommandMock = vi.fn();
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: {
+    ensureAgent: vi.fn(async () => ({ sendCommand: sendCommandMock })),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 import { getConfig } from '@/lib/config';
-import { checkOidcProviderReachable } from './oidcProviderReachable';
+import { checkOidcProviderReachable, classifyAutheliaLogs } from './oidcProviderReachable';
 
 const baseConfig = {
   reverseProxy: { publicDomain: 'example.com' },
@@ -22,6 +36,10 @@ const validDiscovery = {
 
 beforeEach(() => {
   vi.mocked(getConfig).mockReset();
+  sendCommandMock.mockReset();
+  // Default: log fetch returns nothing — tests that exercise the
+  // classifier path override this.
+  sendCommandMock.mockResolvedValue({ code: 0, stdout: '' });
   vi.restoreAllMocks();
 });
 
@@ -64,7 +82,10 @@ describe('oidc_provider_reachable probe', () => {
     const r = await checkOidcProviderReachable();
     expect(r.status).toBe('fail');
     expect(r.detail).toContain('502');
-    expect(r.hint).toMatch(/podman logs auth-authelia/i);
+    // New structured behaviour: the hint references the structured
+    // action label, not the loose "podman logs" paragraph.
+    expect(r.hint).toMatch(/Show recent logs|Reset wizard|Restart auth/i);
+    expect(r.category).toBeDefined();
   });
 
   // Regression for #622: probe must FAIL when fetch itself throws
@@ -77,7 +98,7 @@ describe('oidc_provider_reachable probe', () => {
     expect(r.status).toBe('fail');
     expect(r.detail).toMatch(/did not respond/i);
     expect(r.detail).toContain('ECONNREFUSED');
-    expect(r.hint).toMatch(/encryption key|crash-looping/i);
+    expect(r.hint).toBeDefined();
   });
 
   it('returns warn when 200 body is missing required endpoints', async () => {
@@ -102,5 +123,50 @@ describe('oidc_provider_reachable probe', () => {
     const r = await checkOidcProviderReachable();
     expect(r.status).toBe('fail');
     expect(r.detail).toMatch(/not valid json/i);
+  });
+
+  // #736 — classification surfaces a specific cause in `detail` so the
+  // diagnose card can show "storage drift" / "LDAP bind" / "config
+  // invalid" instead of a paragraph listing all three.
+  it('classifies 500 + storage-key log tail as category=storage', async () => {
+    vi.mocked(getConfig).mockResolvedValue(baseConfig as never);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 500 })));
+    sendCommandMock.mockResolvedValueOnce({
+      code: 0,
+      stdout: 'level=fatal msg="unable to decrypt the storage encryption key has been altered"',
+    });
+    const r = await checkOidcProviderReachable();
+    expect(r.status).toBe('fail');
+    expect(r.category).toBe('storage');
+    expect(r.detail).toMatch(/encryption key drift/i);
+  });
+
+  it('classifies 500 + LDAP-bind log tail as category=ldap', async () => {
+    vi.mocked(getConfig).mockResolvedValue(baseConfig as never);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 500 })));
+    sendCommandMock.mockResolvedValueOnce({
+      code: 0,
+      stdout: 'level=error msg="error occurred performing LDAP bind: LDAP Result Code 49 \\"Invalid Credentials\\""',
+    });
+    const r = await checkOidcProviderReachable();
+    expect(r.status).toBe('fail');
+    expect(r.category).toBe('ldap');
+    expect(r.detail).toMatch(/LDAP bind/i);
+  });
+});
+
+describe('classifyAutheliaLogs', () => {
+  it('returns unknown for empty logs', () => {
+    expect(classifyAutheliaLogs('').category).toBe('unknown');
+  });
+
+  it('matches config errors before LDAP', () => {
+    const logs = 'Configuration: parse error at line 14: expected mapping value\nLDAP Result Code 49 "Invalid Credentials"';
+    expect(classifyAutheliaLogs(logs).category).toBe('config');
+  });
+
+  it('matches storage drift', () => {
+    const logs = 'fatal error: unable to decrypt the storage encryption key';
+    expect(classifyAutheliaLogs(logs).category).toBe('storage');
   });
 });

--- a/src/lib/diagnose/probes/oidcProviderReachable.ts
+++ b/src/lib/diagnose/probes/oidcProviderReachable.ts
@@ -1,11 +1,9 @@
 /**
- * `oidc_provider_reachable` probe (#623) — surfaces the case where
+ * `oidc_provider_reachable` probe (#623, #736) — surfaces the case where
  * Authelia's container is "up" but its OIDC discovery endpoint
- * doesn't answer with a parseable 200. Sister-probe to
- * `crash_loop` (which catches container-level loops) and to
- * `domain_external_reachability` (which only checks DNS):
- * specifically catches the layer between "container up" and "SSO
- * actually works".
+ * doesn't answer with a parseable 200, and classifies the underlying
+ * cause so the diagnose card can offer one structured action instead
+ * of a paragraph of "could be one of these three things".
  *
  * Why a dedicated probe: the Authelia outage in #622 had
  * `crash_loop` saying "all stable" (RestartCount blind spot,
@@ -15,6 +13,22 @@
  * encryption key had drifted from its preserved DB. Every
  * SSO-gated service was returning 502 to the user. This probe
  * fires within one diagnose-cycle in that scenario.
+ *
+ * Structured-actions refactor (#736): when fetch returns non-200
+ * or the connection refuses, the probe pulls `podman logs --tail
+ * 50 auth-authelia` and pattern-matches the output into one of:
+ *   - `config`  — Authelia's YAML / env failed validation.
+ *   - `ldap`    — LLDAP bind failing (Invalid Credentials / no
+ *                 connection).
+ *   - `storage` — encryption key drift from a reinstall —
+ *                 db.sqlite3 + lldap users.db are encrypted with
+ *                 the previous deployment's key.
+ *   - `unknown` — fetch broke but logs don't match a known pattern.
+ * The detail line names the specific cause; `show_recent_logs` +
+ * `restart_authelia` actions (registered below) are available on
+ * every fail/warn state. Destructive recovery (wiping storage) is
+ * deliberately not surfaced as a one-click — the operator should
+ * follow the Reset wizard if encryption-key drift is confirmed.
  *
  * Skip cases:
  *   - No `auth` template installed → nothing to probe (info).
@@ -28,12 +42,20 @@
  * JSON are the same either way.
  */
 
+import { agentManager } from '@/lib/agent/manager';
 import { getConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const PROBE_ID = 'oidc_provider_reachable';
+
+export type OidcFailCategory = 'config' | 'ldap' | 'storage' | 'unknown';
 
 export interface OidcProviderResult {
   status: 'ok' | 'warn' | 'fail' | 'info';
   detail: string;
   hint?: string;
+  category?: OidcFailCategory;
 }
 
 // Authelia's default port inside the auth pod. Hard-coded here to keep
@@ -42,6 +64,8 @@ export interface OidcProviderResult {
 // (AUTHELIA_PORT), so honour that first.
 const AUTHELIA_DEFAULT_PORT = 9091;
 const DISCOVERY_TIMEOUT_MS = 4000;
+const LOG_FETCH_TIMEOUT_MS = 5000;
+const AUTHELIA_CONTAINER = 'auth-authelia';
 
 function buildDiscoveryUrl(): string {
   const port = parseInt(process.env.AUTHELIA_PORT || '', 10);
@@ -49,7 +73,80 @@ function buildDiscoveryUrl(): string {
   return `http://127.0.0.1:${effective}/.well-known/openid-configuration`;
 }
 
-export async function checkOidcProviderReachable(): Promise<OidcProviderResult> {
+/** Pattern-match Authelia log tail into a category. The first match
+ *  wins; storage/config patterns are checked before LDAP because LDAP
+ *  errors often appear as side-effects of a broken config (the bind
+ *  string never gets evaluated). */
+export function classifyAutheliaLogs(logs: string): {
+  category: OidcFailCategory;
+  summary: string;
+} {
+  const trimmed = logs.trim();
+  if (!trimmed) {
+    return { category: 'unknown', summary: 'Authelia logs were empty' };
+  }
+  // Storage / encryption key drift — single most painful failure
+  // mode (preserved DB + new install = decrypt failure on every
+  // boot). Authelia logs this as a fatal-level error referencing
+  // the storage driver and cipher.
+  if (/(unable to decrypt|encryption.+(?:invalid|mismatch|drift)|storage.*(?:decrypt|cipher)|cipher.*storage|encryption key (?:has )?(?:changed|been altered)|encryption_key)/i.test(trimmed)) {
+    return {
+      category: 'storage',
+      summary: 'storage encryption key drift (DB cannot be decrypted with the current config key)',
+    };
+  }
+  // Authelia explicitly logs "Configuration:" / "configuration is invalid"
+  // when YAML fails to parse or required fields are missing.
+  if (/(configuration[:\s].*(?:invalid|error|cannot|failed)|panic:|fatal.*configuration|YAML)/i.test(trimmed)) {
+    return {
+      category: 'config',
+      summary: 'Authelia configuration failed validation',
+    };
+  }
+  // LDAP bind against LLDAP — surfaces as "Invalid Credentials" or
+  // "LDAP Result Code 49" or connection errors against the lldap
+  // host. Check after config/storage because those broader failures
+  // can spuriously emit LDAP errors as a side effect.
+  if (/(invalid credentials|ldap result code 49|ldap.*(?:bind|connect).*(?:fail|refused)|lldap.*refused)/i.test(trimmed)) {
+    return {
+      category: 'ldap',
+      summary: 'LDAP bind to LLDAP is failing',
+    };
+  }
+  return {
+    category: 'unknown',
+    summary: 'Authelia is unhealthy but the log tail does not match a known pattern',
+  };
+}
+
+const HINT_BY_CATEGORY: Record<OidcFailCategory, string> = {
+  config:
+    'Click "Show recent logs" for the offending lines, then edit /opt/servicebay/services/auth/authelia/configuration.yml and restart auth.service. Common causes: malformed YAML after a manual edit or a missing required field after a version bump.',
+  ldap:
+    'Click "Show recent logs" to confirm the bind message. Most common cause is a reinstall that kept LLDAP\'s users.db but reset the password file — easiest recovery is the Reset wizard from Settings → Install (it re-seeds LLDAP and re-derives the bind password).',
+  storage:
+    'Authelia\'s db.sqlite3 was encrypted with a previous install\'s storage key. Use the Reset wizard from Settings → Install to wipe authelia-data/ + lldap users.db and re-seed — restarting auth.service alone will not recover.',
+  unknown:
+    'Click "Show recent logs" to inspect the failure mode, then "Restart auth" once the underlying cause is corrected.',
+};
+
+async function fetchAutheliaLogs(nodeName: string): Promise<string | null> {
+  try {
+    const agent = await agentManager.ensureAgent(nodeName);
+    const res = await agent.sendCommand(
+      'exec',
+      { command: `podman logs --tail 50 ${AUTHELIA_CONTAINER} 2>&1` },
+      { timeoutMs: LOG_FETCH_TIMEOUT_MS },
+    ) as { code?: number; stdout?: string };
+    const out = (res.stdout ?? '').trim();
+    return out || null;
+  } catch (e) {
+    logger.info(`diagnose:${PROBE_ID}`, `log fetch failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
+export async function checkOidcProviderReachable(nodeName: string = 'Local'): Promise<OidcProviderResult> {
   const cfg = await getConfig();
   const installed = cfg.installedTemplates?.auth;
   if (!installed) {
@@ -75,18 +172,28 @@ export async function checkOidcProviderReachable(): Promise<OidcProviderResult> 
     });
   } catch (e) {
     const reason = e instanceof Error ? e.message : String(e);
+    const logs = await fetchAutheliaLogs(nodeName);
+    const { category, summary } = logs
+      ? classifyAutheliaLogs(logs)
+      : { category: 'unknown' as OidcFailCategory, summary: 'no log output' };
     return {
       status: 'fail',
-      detail: `Authelia OIDC discovery (${url}) did not respond: ${reason}`,
-      hint: 'Authelia is likely crash-looping or wedged on a storage/LDAP error. Check `podman logs auth-authelia` for fatal-level messages. Most common cause: a reinstall left the preserved DB encryption key out of sync with the new config — wipe authelia-data/db.sqlite3 + lldap/users.db, restart auth, re-add LLDAP users.',
+      detail: `Authelia OIDC discovery (${url}) did not respond: ${reason}. Cause: ${summary}.`,
+      hint: HINT_BY_CATEGORY[category],
+      category,
     };
   }
 
   if (response.status !== 200) {
+    const logs = await fetchAutheliaLogs(nodeName);
+    const { category, summary } = logs
+      ? classifyAutheliaLogs(logs)
+      : { category: 'unknown' as OidcFailCategory, summary: 'no log output' };
     return {
       status: 'fail',
-      detail: `Authelia OIDC discovery returned HTTP ${response.status} (expected 200). Every SSO-gated service will be returning 502 to users right now.`,
-      hint: 'Common causes: Authelia config invalid (check `podman logs auth-authelia` for "Configuration:" errors), LDAP bind failing against LLDAP (Invalid Credentials), or storage encryption key drift from a reinstall. Restarting auth.service alone usually does not fix this — the config or DB state needs attention first.',
+      detail: `Authelia OIDC discovery returned HTTP ${response.status} (expected 200) — every SSO-gated service will be returning 502 to users right now. Cause: ${summary}.`,
+      hint: HINT_BY_CATEGORY[category],
+      category,
     };
   }
 
@@ -98,6 +205,7 @@ export async function checkOidcProviderReachable(): Promise<OidcProviderResult> 
       status: 'fail',
       detail: 'Authelia OIDC discovery answered 200 but the body was not valid JSON.',
       hint: 'Likely a reverse-proxy mismatch (NPM returned an error page with a 200 status code). Test with `curl -v http://127.0.0.1:9091/.well-known/openid-configuration` on the host.',
+      category: 'unknown',
     };
   }
 
@@ -111,7 +219,8 @@ export async function checkOidcProviderReachable(): Promise<OidcProviderResult> 
     return {
       status: 'warn',
       detail: `Authelia OIDC discovery answered 200 but is missing: ${missing.join(', ')}.`,
-      hint: 'Likely an Authelia config that disabled some endpoints, or an in-progress upgrade. SSO clients that need those endpoints will fail.',
+      hint: 'Likely an Authelia config that disabled some endpoints, or an in-progress upgrade. Click "Show recent logs" for context, then "Restart auth" once the config is corrected.',
+      category: 'config',
     };
   }
 
@@ -120,3 +229,81 @@ export async function checkOidcProviderReachable(): Promise<OidcProviderResult> 
     detail: `Authelia OIDC discovery answers 200 with a valid configuration document.`,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Actions: structured remediations the diagnose card hangs off the probe row.
+// Both are read/restart-only — destructive recovery (storage wipe) is left to
+// the Reset wizard so the operator gets confirm-screen guards around it.
+// ---------------------------------------------------------------------------
+
+async function showRecentLogs({ node }: { node: string }): Promise<ProbeActionResult> {
+  const logs = await fetchAutheliaLogs(node);
+  if (!logs) {
+    return {
+      ok: true,
+      message: 'No log output from auth-authelia (container may be down — try "Restart auth" first).',
+      refresh: false,
+    };
+  }
+  const { summary } = classifyAutheliaLogs(logs);
+  return {
+    ok: true,
+    message: `Pulled ${logs.split('\n').length} lines from auth-authelia — ${summary}.`,
+    details: logs,
+    refresh: false,
+  };
+}
+
+async function restartAuthelia({ node }: { node: string }): Promise<ProbeActionResult> {
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    const res = await agent.sendCommand(
+      'exec',
+      { command: 'systemctl --user restart auth.service 2>&1' },
+      { timeoutMs: 30_000 },
+    ) as { code?: number; stdout?: string; stderr?: string };
+    if (res.code === 0) {
+      return {
+        ok: true,
+        message: 'Restarted auth.service. Re-check in ~20 s; if discovery still fails the underlying cause is still present.',
+        refresh: true,
+      };
+    }
+    const err = (res.stderr ?? res.stdout ?? '').trim().slice(0, 200) || `exit ${res.code}`;
+    return {
+      ok: false,
+      message: `Could not restart auth.service: ${err}.`,
+      refresh: false,
+    };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn(`diagnose:${PROBE_ID}`, `restart action threw: ${message}`);
+    return {
+      ok: false,
+      message: `Restart failed: ${message}`,
+      refresh: false,
+    };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'show_recent_logs',
+    label: 'Show recent logs',
+    description:
+      'Fetches the last 50 lines of `podman logs auth-authelia` and renders them inline — enough to identify the exact failure mode (config error, LDAP bind, storage decrypt) without SSH-ing into the box.',
+  },
+  showRecentLogs,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'restart_authelia',
+    label: 'Restart auth',
+    description:
+      'Restarts auth.service via systemctl. Use after fixing the underlying cause (config edit, LLDAP re-seed). Storage encryption key drift will NOT recover from a restart — use the Reset wizard for that.',
+  },
+  restartAuthelia,
+);

--- a/src/lib/diagnose/probes/register.ts
+++ b/src/lib/diagnose/probes/register.ts
@@ -28,5 +28,6 @@ import './adguardRewritesMissing';
 import './domainExternalReachability';
 import './domainUnreachable';
 import './lanIpChanged';
+import './oidcProviderReachable';
 
 export {};

--- a/src/lib/diagnose/runDiagnose.ts
+++ b/src/lib/diagnose/runDiagnose.ts
@@ -677,7 +677,7 @@ export async function runDiagnose(nodeName: string = 'Local'): Promise<DiagnoseR
   //     the post-reinstall config; every OIDC-gated service was
   //     surfacing 502 to the operator while diagnose said all green.
   try {
-    const oidc = await checkOidcProviderReachable();
+    const oidc = await checkOidcProviderReachable(nodeName);
     probes.push({
       id: 'oidc_provider_reachable',
       label: 'OIDC provider (Authelia)',

--- a/src/lib/install/runner.ts
+++ b/src/lib/install/runner.ts
@@ -893,9 +893,13 @@ async function runJob(jobId: string): Promise<void> {
           variables,
           node: input.node || undefined,
           onLog: (line: string) => { void log(jobId, line); },
+          // Tells the bootstrap helper to suppress the duplicated 90 s
+          // preamble and emit a post-self-heal success line on
+          // already_using_target (#733). Also caps the server-side
+          // retry budget at 20 s — the user table is already seeded.
+          phase: 'retry',
         });
         if (retry === 'ok') {
-          await log(jobId, '✅ NPM bootstrap succeeded after self-heal.');
           bootstrapState = 'ok';
         } else {
           await log(jobId, '⚠️ NPM still rejecting credentials after data-wipe retry; falling back to the credentials prompt.');

--- a/src/lib/stackInstall/postInstall.ts
+++ b/src/lib/stackInstall/postInstall.ts
@@ -171,25 +171,42 @@ export async function bootstrapNpmAdmin(opts: {
   variables: StackVariable[];
   node?: string;
   onLog: (msg: string) => void;
+  /**
+   * Distinguishes the initial bootstrap call from a post-self-heal retry
+   * (#733). On retry the data dir has just been wiped + nginx restarted,
+   * so the user table seeds within ~10s — there's no need to display
+   * the same "up to 90s" preamble, and the success log line for an
+   * `already_using_target` outcome is misleading (the previous bootstrap
+   * *did* do work; only this call short-circuited). Use `'retry'` from
+   * the install runner's self-heal branch.
+   */
+  phase?: 'initial' | 'retry';
 }): Promise<'ok' | 'needs_credentials' | 'skipped'> {
   const email = opts.variables.find(v => v.name === 'NGINX_ADMIN_EMAIL')?.value;
   const password = opts.variables.find(v => v.name === 'NGINX_ADMIN_PASSWORD')?.value;
   const fullName = opts.variables.find(v => v.name === 'NGINX_ADMIN_NAME')?.value;
   if (!email || !password) return 'skipped';
 
+  const isRetry = opts.phase === 'retry';
+
   // The pod template sets INITIAL_ADMIN_EMAIL / INITIAL_ADMIN_PASSWORD env
   // vars, so on first init NPM seeds the user table with these exact
   // credentials — but the seed step lands ~30-60 s after `/status` reports
   // the API is up. The bootstrap endpoint retries the target-creds login
-  // for 90 s server-side; preview that to the operator so the wait isn't
-  // a black box.
-  opts.onLog('Verifying NPM admin credentials (waiting up to 90s for the user table to seed)...');
+  // for ~90 s on the initial call, ~20 s on a self-heal retry (#733):
+  // by the time we get to the retry the data dir has been wiped + nginx
+  // was restarted ~30 s ago, so the seed should land within seconds.
+  if (isRetry) {
+    opts.onLog('Re-verifying NPM admin credentials after self-heal (waiting up to 20s)...');
+  } else {
+    opts.onLog('Verifying NPM admin credentials (waiting up to 90s for the user table to seed)...');
+  }
 
   try {
     const res = await apiFetch('/api/system/nginx/bootstrap', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password, fullName, node: opts.node }),
+      body: JSON.stringify({ email, password, fullName, node: opts.node, quickRetry: isRetry }),
     });
     const data = await res.json().catch(() => ({} as Record<string, unknown>));
 
@@ -198,7 +215,15 @@ export async function bootstrapNpmAdmin(opts: {
       return 'ok';
     }
     if (res.ok && data.ok && data.reason === 'already_using_target') {
-      opts.onLog('✅ NPM admin already on the wizard credentials — nothing to do.');
+      // After a self-heal the data dir was just freshly seeded — the
+      // "nothing to do" framing reads like the retry no-op'd, which is
+      // confusing immediately after the "Wiping NPM data/" log line.
+      // Phrase the same outcome in terms of what just happened (#733).
+      if (isRetry) {
+        opts.onLog(`✅ NPM bootstrap fresh on wizard credentials (${email}).`);
+      } else {
+        opts.onLog('✅ NPM admin already on the wizard credentials — nothing to do.');
+      }
       return 'ok';
     }
     if (res.ok && data.ok && data.reason === 'using_saved') {

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -62,6 +62,17 @@ def log(msg: str) -> None:
     sys.stdout.flush()
 
 
+def render_http_code(code: int) -> str:
+    """Render a `request_json` status code in a way the operator can
+    immediately interpret. `code == 0` is our local convention for "the
+    request never reached the server" (URLError/TimeoutError/OSError);
+    "returned 0" reads like a successful exit code, so spell that case
+    out instead of leaving the operator to guess (#734)."""
+    if code == 0:
+        return "no response (connection refused / DNS / timeout)"
+    return f"HTTP {code}"
+
+
 REQUEST_TIMEOUT = 30.0
 
 
@@ -208,7 +219,7 @@ def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str
         "PreferredMetadataLanguage": "de",
     })
     if code not in (200, 204):
-        log(f"⚠️ Jellyfin: POST /Startup/Configuration returned {code} — finish setup at the web UI.")
+        log(f"⚠️ Jellyfin: POST /Startup/Configuration → {render_http_code(code)} — install-blocking. Open Dashboard → Server and finish the locale step before using Jellyfin.")
         return False
 
     # Admin user.
@@ -217,7 +228,7 @@ def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str
         "Password": admin_password,
     })
     if code not in (200, 204):
-        log(f"⚠️ Jellyfin: POST /Startup/User returned {code} — finish setup at the web UI.")
+        log(f"⚠️ Jellyfin: POST /Startup/User → {render_http_code(code)} — install-blocking. Admin '{admin_user}' was not created; finish the wizard at the web UI and set the password to the one shown in the credentials banner.")
         return False
 
     # Remote access settings: enable HTTP access from non-LAN clients
@@ -229,11 +240,11 @@ def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str
     })
     if code not in (200, 204):
         # Non-fatal — the operator can flip these in Dashboard later.
-        log(f"(note) Jellyfin: POST /Startup/RemoteAccess returned {code} — flip the remote-access toggles in Dashboard if needed.")
+        log(f"(note) Jellyfin: POST /Startup/RemoteAccess → {render_http_code(code)} — non-blocking; flip the remote-access toggles in Dashboard if Jellyfin isn't reachable from outside the LAN.")
 
     code, _ = request_json("POST", f"{base_url}/Startup/Complete", {})
     if code not in (200, 204):
-        log(f"⚠️ Jellyfin: POST /Startup/Complete returned {code} — finish setup at the web UI.")
+        log(f"⚠️ Jellyfin: POST /Startup/Complete → {render_http_code(code)} — install-blocking. Open Dashboard at the web UI and click 'Finish' on the wizard so Jellyfin leaves first-run mode.")
         return False
 
     log(f"✅ Jellyfin first-run wizard skipped; admin '{admin_user}' seeded.")
@@ -346,25 +357,47 @@ def configure_abs_oidc(
     #    Discovery values point at the *public* issuer regardless of
     #    which probe answered — clients hit those URLs from a
     #    browser, not from the host.
+    # Discovery candidate order matches the `oidc_provider_reachable`
+    # diagnose probe, which is known to succeed against the running
+    # Authelia (#735). Two prior issues with the old order:
+    #   - `localhost` resolved IPv6 first on some FCoS builds while
+    #     Authelia binds IPv4-only — every probe returned code=0 and
+    #     fell into the hardcoded-path branch.
+    #   - The public URL was attempted before DNS/proxy was ready, so
+    #     the second candidate also failed and the fallback message
+    #     ran on every install.
+    # Probe 127.0.0.1 first (loopback IPv4, matches the diagnose probe
+    # at oidcProviderReachable.ts:49), then ::1 for IPv6-only binds,
+    # then the public URL for re-runs against a settled install.
     authelia_port = env("AUTHELIA_PORT", "9091")
     discovery_candidates = [
-        f"http://localhost:{authelia_port}",
+        f"http://127.0.0.1:{authelia_port}",
+        f"http://[::1]:{authelia_port}",
         issuer_url,
     ]
     disc = None
+    last_codes: list[str] = []
     for candidate in discovery_candidates:
         code, body = request_json("GET", f"{candidate}/.well-known/openid-configuration")
         if code == 200 and isinstance(body, dict):
             disc = body
             log(f"ℹ️  Authelia OIDC discovery via {candidate}.")
             break
+        last_codes.append(f"{candidate} → {render_http_code(code)}")
     if disc is not None:
         auth_url = disc.get("authorization_endpoint", "")
         token_url = disc.get("token_endpoint", "")
         userinfo_url = disc.get("userinfo_endpoint", "")
         jwks_url = disc.get("jwks_uri", "")
     else:
-        log("ℹ️  Authelia OIDC discovery unreachable on every candidate — falling back to known Authelia 4.x paths.")
+        # If we ever land here the install will still complete (the
+        # hardcoded Authelia-4.x paths match the discovery doc verbatim),
+        # but the diagnose probe at the same endpoint is known to work,
+        # so seeing this branch on a successful install means something
+        # changed about how the post-deploy reaches Authelia. Log every
+        # candidate's outcome so the next operator can compare against
+        # the diagnose probe instead of re-discovering this.
+        log(f"ℹ️  Authelia OIDC discovery unreachable on every candidate — falling back to known Authelia 4.x paths. Candidates: {'; '.join(last_codes)}.")
         auth_url = f"{issuer_url}/api/oidc/authorization"
         token_url = f"{issuer_url}/api/oidc/token"
         userinfo_url = f"{issuer_url}/api/oidc/userinfo"


### PR DESCRIPTION
## Summary

Five small, low-risk fixes bundled because they all touch user-facing copy + diagnose patterns.

- **#736** \`oidc_provider_reachable\` probe now classifies the cause of an Authelia 500/timeout from the log tail (config / ldap / storage / unknown) and registers two structured actions (\`show_recent_logs\`, \`restart_authelia\`) so the diagnose card surfaces a one-click read + restart instead of a three-branch hint paragraph.
- **#735** Media post-deploy OIDC discovery now uses \`127.0.0.1 → ::1 → public URL\` candidates (matches the working diagnose probe at \`oidcProviderReachable.ts:49\`); per-candidate outcomes are logged when the hardcoded-path fallback fires so the next operator can diff against the diagnose probe.
- **#734** Jellyfin \`/Startup/*\` failures now state severity + recovery step (\`HTTP 401 — install-blocking. Admin 'X' was not created; …\`). \`request_json\` code=0 renders as \"no response (connection refused / DNS / timeout)\".
- **#733** NPM bootstrap self-heal retry uses \`quickRetry: true\` (20 s budget instead of 90 s) and \`phase: 'retry'\` so the duplicated \"waiting up to 90s\" preamble and misleading \"nothing to do\" success line are replaced with self-heal-aware copy.
- **#725** \`ActionProgressModal\`: contradictory \"do not close this window\" warning replaced with safe-minimize copy; clicking X while the action is running now minimizes (keeping the toast alive) instead of aborting the stream.

## Test plan
- [x] \`npx vitest run src/lib/diagnose/probes/oidcProviderReachable.test.ts\` (12 / 12 incl. 2 new classifier tests)
- [x] \`npx tsc --noEmit\`
- [x] \`python3 -m py_compile templates/media/post-deploy.py\`
- [ ] Manual: trigger Authelia 500 on the live box, confirm \`Show recent logs\` action renders inline
- [ ] Manual: clean install with preserved certs — confirm bootstrap log no longer reads \"nothing to do\" after wipe+reseed
- [ ] Manual: restart a service, click X mid-action, confirm background toast persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)