### PR TITLE
fix(install): scrub config.json under in-process lock (#711)

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -659,3 +659,74 @@ export async function updateConfig(updates: Partial<AppConfig>): Promise<AppConf
   });
 }
 
+/**
+ * Strip every secret value from `config.json` so that the next
+ * `getConfig()` can't surface stale ciphertext that the upcoming new
+ * install will be unable to decrypt (secret.key is being wiped
+ * alongside this call).
+ *
+ * Reset-flow contract (#711):
+ *   - Deletes every value still in `enc:v1:` form (raw on-disk
+ *     ciphertext — getConfig() decrypts those to plaintext, so this
+ *     reads the raw file directly).
+ *   - Drops `auth.passwordHash` + `auth.bootstrapToken` (plaintext
+ *     hashes that survive the cipher wipe — useless once secret.key
+ *     is gone).
+ *   - Preserves operator-input fields (publicDomain, lanDomain,
+ *     gateway.host, etc.) so the wizard's already-written context
+ *     survives the reset.
+ *
+ * Runs under the same `withConfigLock` queue as `updateConfig` /
+ * `saveConfig` — that's the reason it lives here and not in
+ * `performStackReset`. The pre-#711 implementation invoked a Python
+ * one-liner via the agent's shell exec, which read and wrote
+ * `config.json` outside the Node.js lock. A concurrent
+ * post-deploy that called `updateConfig({ adguard: { password }})`
+ * would land its write *between* the Python script's read and
+ * write — the python write then clobbered the post-deploy update
+ * because it persisted its older in-memory snapshot. Operators
+ * surfaced this as "adguard.password missing after install" + the
+ * wildcard DNS rewrites silently failing to provision.
+ */
+export async function scrubEncryptedConfig(): Promise<{ removedKeys: number }> {
+  return withConfigLock(async () => {
+    let removedKeys = 0;
+    let raw: unknown;
+    try {
+      const content = await fs.readFile(CONFIG_PATH, 'utf-8');
+      raw = JSON.parse(content);
+    } catch {
+      return { removedKeys };
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const walk = (obj: any): void => {
+      if (Array.isArray(obj)) {
+        for (const v of obj) walk(v);
+        return;
+      }
+      if (obj !== null && typeof obj === 'object') {
+        for (const k of Object.keys(obj)) {
+          const v = obj[k];
+          if (typeof v === 'string' && v.startsWith('enc:v1:')) {
+            delete obj[k];
+            removedKeys += 1;
+          } else if (v !== null && typeof v === 'object') {
+            walk(v);
+          }
+        }
+      }
+    };
+    walk(raw);
+    if (raw !== null && typeof raw === 'object' && 'auth' in (raw as Record<string, unknown>)) {
+      const auth = (raw as { auth?: Record<string, unknown> }).auth;
+      if (auth && typeof auth === 'object') {
+        if ('passwordHash' in auth) { delete auth.passwordHash; removedKeys += 1; }
+        if ('bootstrapToken' in auth) { delete auth.bootstrapToken; removedKeys += 1; }
+      }
+    }
+    await fs.mkdir(path.dirname(CONFIG_PATH), { recursive: true });
+    await atomicWriteFile(CONFIG_PATH, JSON.stringify(raw, null, 2));
+    return { removedKeys };
+  });
+}
+

--- a/src/lib/install/performStackReset.ts
+++ b/src/lib/install/performStackReset.ts
@@ -8,7 +8,7 @@
  */
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { agentManager } from '@/lib/agent/manager';
-import { getConfig } from '@/lib/config';
+import { getConfig, scrubEncryptedConfig } from '@/lib/config';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { logger } from '@/lib/logger';
 import { RESET_GROUPS, DEFAULT_PRESERVE, isAlwaysWipe, type ResetGroup } from './resetGroups';
@@ -188,37 +188,23 @@ export async function performStackReset(
   //     publicDomain, lanDomain, gateway.host (see #702)
   //   - cert-archive/ → preserved
   if (!preserve.includes('secrets')) {
-    // 1) Scrub config.json in place (Python one-liner: drop every
-    //    enc:v1:* value, drop auth.passwordHash, drop the encrypted
-    //    .password subkeys; keep everything else).
-    const scrubConfig = `python3 -c '
-import json, os, sys
-p = "/var/mnt/data/servicebay/config.json"
-if not os.path.exists(p):
-    sys.exit(0)
-with open(p) as f:
-    d = json.load(f)
-def scrub(obj):
-    if isinstance(obj, dict):
-        for k in list(obj.keys()):
-            v = obj[k]
-            if isinstance(v, str) and v.startswith("enc:v1:"):
-                del obj[k]
-            elif isinstance(v, (dict, list)):
-                scrub(v)
-    elif isinstance(obj, list):
-        for v in obj:
-            scrub(v)
-scrub(d)
-auth = d.get("auth", {})
-auth.pop("passwordHash", None)
-auth.pop("bootstrapToken", None)
-tmp = p + ".tmp"
-with open(tmp, "w") as f:
-    json.dump(d, f, indent=2)
-os.replace(tmp, p)
-' 2>&1 || true`;
-    await agent.sendCommand('exec', { command: scrubConfig });
+    // 1) Scrub config.json via the Node.js side under the same
+    //    `withConfigLock` queue as `updateConfig` / `saveConfig`
+    //    (#711). The pre-fix implementation ran a Python one-liner
+    //    via `agent.sendCommand('exec')` — that read + wrote
+    //    config.json directly on the host, bypassing the in-process
+    //    lock. A concurrent post-deploy that called
+    //    `updateConfig({ adguard: { password }})` landed its write
+    //    *between* the Python script's read and write; the script's
+    //    older snapshot then clobbered the new credential, surfacing
+    //    as "adguard.password missing after install" + wildcard DNS
+    //    rewrites failing to provision.
+    try {
+      const { removedKeys } = await scrubEncryptedConfig();
+      logger.info('StackReset', `Scrubbed config.json — removed ${removedKeys} encrypted/auth key(s).`);
+    } catch (e) {
+      logger.warn('StackReset', `scrubEncryptedConfig failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
 
     // 2) Wipe everything else under /var/mnt/data/servicebay/ except
     //    the preserved subdirs + the just-scrubbed config.json.


### PR DESCRIPTION
## Summary

Reset's pre-fix scrub ran a Python one-liner via the agent's shell exec, which read+wrote \`/var/mnt/data/servicebay/config.json\` directly on the host — bypassing the Node.js \`withConfigLock\` queue. A concurrent post-deploy that called \`updateConfig({ adguard: { password }})\` landed its write between the Python script's read and write; the script's older snapshot then clobbered the new credential. Operators saw this as \"adguard.password missing after install\" and wildcard DNS rewrites silently failing to provision.

- Move the scrub into \`lib/config.ts\` as \`scrubEncryptedConfig()\` so it runs under the same \`withConfigLock\` queue as \`updateConfig\` / \`saveConfig\`.
- Same semantics (delete every \`enc:v1:\` value, drop \`auth.passwordHash\` + \`bootstrapToken\`) without the read-write race.

## Test plan
- [x] \`npx tsc --noEmit\`
- [ ] Manual: fresh clean-install reset with concurrent AdGuard post-deploy, confirm \`config.json\` ends with \`adguard.password\` set and DNS rewrites provision
- [ ] Verify reset still strips known-encrypted keys (e.g. \`auth.providers.openid.clientSecret\`)

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)