### PR TITLE
feat(wizard,ux): observability + UX batch (#732 #729 #728 #727)

### DIFF
--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -22,7 +22,12 @@ export interface OnboardingStatus {
    * server flips its jobs to phase=crashed on next boot, so this never
    * stays stuck on a dead install.
    */
-  installInProgress: { jobId: string; startedAt: string; source?: string } | null;
+  /**
+   * `updatedAt` is the last time the install runner wrote to the job
+   * state (or appended a log line) — the wizard uses it to decide
+   * whether a job is making progress or has stalled (#727).
+   */
+  installInProgress: { jobId: string; startedAt: string; updatedAt: string; source?: string } | null;
   features: {
     gateway: boolean;
     ssh: boolean;
@@ -69,7 +74,12 @@ export async function checkOnboardingStatus(): Promise<OnboardingStatus> {
 
   const activeJob = await getCurrentJob();
   const installInProgress = activeJob
-    ? { jobId: activeJob.id, startedAt: activeJob.startedAt, source: activeJob.source }
+    ? {
+        jobId: activeJob.id,
+        startedAt: activeJob.startedAt,
+        updatedAt: activeJob.updatedAt,
+        source: activeJob.source,
+      }
     : null;
 
   return {

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Download, ChevronRight, ChevronDown, Info, Settings, Copy, Pause, Play } from 'lucide-react';
+import { RefreshCw, Download, ChevronRight, ChevronDown, Info, Settings, Copy, Pause, Play, ListFilter } from 'lucide-react';
 import Link from 'next/link';
 import { useToast } from '@/providers/ToastProvider';
 import { useSocket } from '@/hooks/useSocket';
@@ -51,6 +51,25 @@ const LEVEL_STYLES: Record<LogLevel, { label: string; accent: string; runId: str
 };
 
 const RUN_ID_PREFIX_REGEX = /^\[([A-Za-z0-9:-]+)\]\s+([\s\S]*)$/;
+
+// Lifecycle-keyword allowlist for Summary mode (#728). A log line
+// passes the summary filter if its level is warn/error OR its
+// message matches one of these patterns. The list is intentionally
+// short — the goal is "what changed?", not "everything that might
+// matter someday" — and biased toward state transitions the operator
+// can map back to a UI affordance.
+const SUMMARY_LIFECYCLE_RE = new RegExp(
+  [
+    'deployed', 'undeployed', 'restarted', 'crashed', 'started', 'stopped',
+    'created', 'removed', 'installed', 'uninstalled', 'enabled', 'disabled',
+    'pulled', 'pulling', 'downloading', 'self.?heal', 'self.?healed',
+    'reconciled', 'provisioned', 'configured', 'bootstrap', 'wizard',
+    'failure', 'aborted', 'healthy', 'unhealthy', 'login', 'logged',
+  ].join('|'),
+  'i',
+);
+
+const SUMMARY_EMOJI_RE = /[✅⚠️❌🔄ℹ️🔐]/;
 
 const stripRunIdPrefix = (message: string) => {
   const match = message.match(RUN_ID_PREFIX_REGEX);
@@ -202,6 +221,13 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
     limit: 100
   });
   const [livePaused, setLivePaused] = useState(false);
+  // Summary mode (#728): collapses the firehose to lifecycle-only
+  // events. Drops debug + info noise unless the message matches a
+  // small allowlist of meaningful state transitions (deployed /
+  // started / healthy / failed / restart / installed). Errors and
+  // warnings always pass through. The raw filter remains the default
+  // so deep debugging is one click away.
+  const [summaryMode, setSummaryMode] = useState(false);
 
   const { socket, isConnected } = useSocket();
   const { addToast } = useToast();
@@ -459,6 +485,20 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
               </Link>
 
               <button
+                onClick={() => setSummaryMode(s => !s)}
+                className={`inline-flex items-center gap-2 px-3 text-xs ${baseButtonClass} ${
+                  summaryMode ? 'border-blue-500 text-blue-600 dark:text-blue-300' : ''
+                }`}
+                title={summaryMode
+                  ? 'Summary mode: showing lifecycle events + warnings/errors only. Click to see raw logs.'
+                  : 'Switch to summary mode (lifecycle events + warnings/errors only).'}
+                aria-pressed={summaryMode}
+              >
+                <ListFilter className="w-3 h-3" />
+                <span>{summaryMode ? 'Summary' : 'Raw'}</span>
+              </button>
+
+              <button
                 onClick={handleRefresh}
                 disabled={loading || selectedDate === 'live'}
                 className={`inline-flex items-center justify-center w-10 ${baseButtonClass}`}
@@ -532,7 +572,14 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
           </div>
         )}
 
-        {logs.map((log) => {
+        {logs
+          .filter((log) => {
+            if (!summaryMode) return true;
+            if (log.level === 'warn' || log.level === 'error') return true;
+            if (SUMMARY_EMOJI_RE.test(log.message)) return true;
+            return SUMMARY_LIFECYCLE_RE.test(log.message);
+          })
+          .map((log) => {
           const { runId: prefixRunId, strippedMessage } = stripRunIdPrefix(log.message);
           const jsonRunId = prefixRunId ? undefined : extractRunIdFromJson(log.message);
           const effectiveRunId = prefixRunId || jsonRunId;

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1146,27 +1146,72 @@ export default function OnboardingWizard() {
           </header>
 
           <main className="flex-1 overflow-y-auto px-12 pb-12 scrollbar-thin">
-            {status?.installInProgress && stackInstallStep !== 'installing' && (
-               <div className="mb-10 p-6 rounded-[2rem] border border-amber-500/20 bg-amber-500/5 backdrop-blur-md animate-in slide-in-from-top-4 duration-700">
+            {status?.installInProgress && stackInstallStep !== 'installing' && (() => {
+              // Stalled-detection (#727): if the runner hasn't touched
+              // the job state for STALL_THRESHOLD_MS we treat it as a
+              // ghost lock left behind by a crashed session, and offer
+              // resume / start-fresh affordances instead of the
+              // ambiguous force-clear-or-switch-tab copy.
+              const STALL_THRESHOLD_MS = 5 * 60_000;
+              const updatedAt = status.installInProgress.updatedAt;
+              const inactiveMs = updatedAt
+                ? Date.now() - new Date(updatedAt).getTime()
+                : 0;
+              const stalled = inactiveMs >= STALL_THRESHOLD_MS;
+              const inactiveMin = Math.floor(inactiveMs / 60_000);
+              return (
+                <div className="mb-10 p-6 rounded-[2rem] border border-amber-500/20 bg-amber-500/5 backdrop-blur-md animate-in slide-in-from-top-4 duration-700">
                   <div className="flex items-center gap-3 text-amber-500 mb-3">
                     <div className="p-2 bg-amber-500/10 rounded-xl">
                         <AlertTriangle size={20} />
                     </div>
-                    <h4 className="font-bold text-base">Concurrent Pipeline Active</h4>
+                    <h4 className="font-bold text-base">
+                      {stalled ? 'Previous install appears stalled' : 'Concurrent Pipeline Active'}
+                    </h4>
                   </div>
                   <p className="text-sm text-amber-200/70 leading-relaxed mb-6">
-                    Another session is currently driving an installation. Racing two pipelines will corrupt the system state. Switch to the active tab or force-clear if it&apos;s a ghost lock.
+                    {stalled
+                      ? `The install runner hasn't written to the job log in ~${inactiveMin} min, which usually means the previous session crashed before the run could finish. You can resume from where it left off, or clear the lock and start fresh.`
+                      : 'Another session is currently driving an installation. Racing two pipelines will corrupt the system state. Switch to the active tab or force-clear if it’s a ghost lock.'}
                   </p>
-                  <Button variant="outline" className="!py-2 !px-4 !text-xs !border-amber-500/30 hover:!bg-amber-500/10 text-amber-500" onClick={async () => {
-                    if (!confirm('Force-clear the install lock?')) return;
-                    await forceClearInstallLock();
-                    const fresh = await checkOnboardingStatus();
-                    setStatus(fresh);
-                  }}>
-                    Force-clear lock
-                  </Button>
-               </div>
-            )}
+                  <div className="flex flex-wrap items-center gap-2">
+                    {stalled && (
+                      <Button
+                        variant="outline"
+                        className="!py-2 !px-4 !text-xs !border-blue-500/40 hover:!bg-blue-500/10 text-blue-500"
+                        onClick={async () => {
+                          // Resume = attach this tab to the existing
+                          // job. The runner is still the source of
+                          // truth — we just re-subscribe to its log /
+                          // progress stream.
+                          await installFlow.attachToJob(status.installInProgress!.jobId);
+                          // attachToJob hydrates installFlow.phase from
+                          // the server's JobState — phase=running
+                          // drives stackInstallStep='installing' via
+                          // the derived union above.
+                          setCurrentStep('stacks');
+                        }}
+                      >
+                        Resume install
+                      </Button>
+                    )}
+                    <Button
+                      variant="outline"
+                      className="!py-2 !px-4 !text-xs !border-amber-500/30 hover:!bg-amber-500/10 text-amber-500"
+                      onClick={async () => {
+                        const verb = stalled ? 'Clear the stalled install and start fresh?' : 'Force-clear the install lock?';
+                        if (!confirm(verb)) return;
+                        await forceClearInstallLock();
+                        const fresh = await checkOnboardingStatus();
+                        setStatus(fresh);
+                      }}
+                    >
+                      {stalled ? 'Start fresh' : 'Force-clear lock'}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })()}
 
             {currentStep === 'welcome' && (
               <WelcomeStep selection={selection} setSelection={setSelection} />

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import yaml from 'js-yaml';
+import { humanizeYamlError, type HumanizedYamlError } from '@/lib/util/humanizeYamlError';
 import { Settings, FileCode, FileJson, FileText, AlertCircle, Network, HardDrive, Pencil, AlertTriangle, Clock, Server, Clipboard, Loader2, RefreshCw } from 'lucide-react';
 import Editor from 'react-simple-code-editor';
 import Prism from 'prismjs';
@@ -76,7 +77,7 @@ export default function ServiceForm({ initialData, isEdit, defaultNode, onClose,
   const [yamlFileName, setYamlFileName] = useState(initialData?.yamlFileName || 'pod.yml');
   const [serviceContent] = useState(initialData?.serviceContent || '');
   const [description, setDescription] = useState('');
-  const [yamlError, setYamlError] = useState<string | null>(null);
+  const [yamlError, setYamlError] = useState<HumanizedYamlError | null>(null);
   const [cursorLine, setCursorLine] = useState(1);
   const [extractedPorts, setExtractedPorts] = useState<{ host?: string; container: string }[]>([]);
   const [extractedVolumes, setExtractedVolumes] = useState<{ host: string; container: string }[]>([]);
@@ -233,8 +234,7 @@ WantedBy=default.target`;
         }
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setYamlError(msg);
+      setYamlError(humanizeYamlError(e));
       setExtractedPorts([]);
       setExtractedVolumes([]);
     }
@@ -746,8 +746,7 @@ WantedBy=default.target`;
                             extractInfo(parsed);
                             setYamlError(null);
                         } catch (e) {
-                            const msg = e instanceof Error ? e.message : String(e);
-                            setYamlError(msg);
+                            setYamlError(humanizeYamlError(e));
                         }
                     }}
                 />
@@ -779,7 +778,15 @@ WantedBy=default.target`;
         {yamlError && (
             <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-200 rounded-md shadow-sm flex items-start gap-3 animate-in fade-in slide-in-from-top-2">
                 <AlertCircle size={20} className="mt-0.5 shrink-0 text-red-500 dark:text-red-400" />
-                <div className="text-sm font-mono whitespace-pre-wrap">{yamlError}</div>
+                <div className="flex-1 min-w-0">
+                    <div className="text-sm">{yamlError.message}</div>
+                    {yamlError.raw && yamlError.raw !== yamlError.message && (
+                        <details className="mt-1">
+                            <summary className="text-[11px] uppercase tracking-wider font-bold cursor-pointer text-red-500/80 dark:text-red-300/70">Parser details</summary>
+                            <pre className="text-[11px] mt-1 font-mono whitespace-pre-wrap break-words text-red-600/80 dark:text-red-300/80">{yamlError.raw}</pre>
+                        </details>
+                    )}
+                </div>
             </div>
         )}
       </div>

--- a/src/components/wizard/SelectedStacksPanel.tsx
+++ b/src/components/wizard/SelectedStacksPanel.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { Check, Clock, Loader2, Package, AlertCircle } from 'lucide-react';
+
+/**
+ * Selected-stacks status card (#732). On a multi-stack install the
+ * rolling log is the only signal — the operator can't tell at a glance
+ * "11/12 done, currently on auth, 1 still queued" without parsing
+ * lines. This panel surfaces per-item state in one row each.
+ *
+ * The four states cover the install lifecycle the wizard tracks:
+ *   - `already`   — checkbox was satisfied before runInstall ran;
+ *                   shown so the operator sees what was preserved.
+ *   - `done`      — the runner reports the item under
+ *                   `progress.deployedNames`.
+ *   - `installing` — name matches `progress.currentItem`.
+ *   - `queued`    — checked but not yet processed.
+ *   - `failed`    — top-level install error; the in-flight item is
+ *                   marked failed (everything after it is queued).
+ *
+ * Data is derived from `installingNow`, `deployedNames` and the
+ * checked `items[]` — no new state, no new endpoints.
+ */
+
+interface SelectedStacksPanelItem {
+  /** Stack name (matches `JobInputItem.name` / `currentItem`). */
+  name: string;
+  /** Whether the operator selected this stack for install. */
+  checked: boolean;
+  /**
+   * The wizard's pre-install flag for "this stack was already on the
+   * node when the picker loaded" — surfaced as a separate state so the
+   * operator sees what was preserved.
+   */
+  alreadyInstalled?: boolean;
+}
+
+type Status = 'already' | 'done' | 'installing' | 'queued' | 'failed' | 'skipped';
+
+interface StatusRowProps {
+  name: string;
+  status: Status;
+}
+
+const ROW_STYLES: Record<Status, { icon: typeof Check; label: string; classes: string }> = {
+  already: {
+    icon: Check,
+    label: 'Already installed',
+    classes: 'text-gray-400',
+  },
+  done: {
+    icon: Check,
+    label: 'Done',
+    classes: 'text-emerald-500',
+  },
+  installing: {
+    icon: Loader2,
+    label: 'Installing',
+    classes: 'text-blue-500',
+  },
+  queued: {
+    icon: Clock,
+    label: 'Queued',
+    classes: 'text-gray-400',
+  },
+  failed: {
+    icon: AlertCircle,
+    label: 'Failed',
+    classes: 'text-red-500',
+  },
+  skipped: {
+    icon: Check,
+    label: 'Skipped',
+    classes: 'text-gray-400',
+  },
+};
+
+function StatusRow({ name, status }: StatusRowProps) {
+  const { icon: Icon, label, classes } = ROW_STYLES[status];
+  const animate = status === 'installing' ? 'animate-spin' : '';
+  return (
+    <li className="flex items-center justify-between gap-3 py-1.5 text-sm">
+      <span className="flex items-center gap-2 min-w-0 truncate">
+        <Icon className={`shrink-0 ${classes} ${animate}`} size={14} aria-hidden="true" />
+        <span className="text-gray-700 dark:text-gray-200 truncate">{name}</span>
+      </span>
+      <span className={`text-[10px] font-bold uppercase tracking-wider ${classes}`}>{label}</span>
+    </li>
+  );
+}
+
+export interface SelectedStacksPanelProps {
+  items: SelectedStacksPanelItem[];
+  /** Name from `progress.currentItem`, or null. */
+  installingNow: string | null;
+  /** Names from `progress.deployedNames`. */
+  deployedNames: readonly string[];
+  /** Top-level install phase — `error`/`aborted`/`crashed` flips the
+   *  in-flight item to `failed`. */
+  phase: 'idle' | 'configure' | 'installing' | 'done' | 'error' | 'aborted' | 'crashed' | 'needs_credentials';
+}
+
+export default function SelectedStacksPanel({
+  items,
+  installingNow,
+  deployedNames,
+  phase,
+}: SelectedStacksPanelProps) {
+  const deployedSet = new Set(deployedNames);
+  const failedPhase = phase === 'error' || phase === 'aborted' || phase === 'crashed';
+  const reachedInstallingNow = (idx: number) => {
+    if (!installingNow) return false;
+    const installingIdx = items.findIndex(i => i.name === installingNow);
+    return installingIdx >= 0 && idx > installingIdx;
+  };
+
+  const rows = items.map((item, idx) => {
+    let status: Status;
+    if (!item.checked) {
+      status = 'skipped';
+    } else if (item.alreadyInstalled && !deployedSet.has(item.name)) {
+      status = 'already';
+    } else if (deployedSet.has(item.name)) {
+      status = 'done';
+    } else if (installingNow === item.name) {
+      // The currently-installing item flips to `failed` when the
+      // pipeline errors out mid-step — everything past it stays queued.
+      status = failedPhase ? 'failed' : 'installing';
+    } else {
+      // For items past the failure point we still render `queued` (no
+      // useful action) but the panel's heading shows the failure.
+      status = reachedInstallingNow(idx) ? 'queued' : 'queued';
+    }
+    return { name: item.name, status } as const;
+  });
+
+  const summary = (() => {
+    const counts = rows.reduce<Record<Status, number>>(
+      (acc, r) => {
+        acc[r.status] += 1;
+        return acc;
+      },
+      { already: 0, done: 0, installing: 0, queued: 0, failed: 0, skipped: 0 },
+    );
+    const ready = counts.done + counts.already;
+    const total = rows.length - counts.skipped;
+    if (failedPhase) return `${ready}/${total} done · install failed`;
+    if (counts.installing > 0) {
+      return `${ready}/${total} done · ${installingNow ?? 'installing'} in flight`;
+    }
+    if (counts.queued > 0) return `${ready}/${total} done · ${counts.queued} queued`;
+    return `${ready}/${total} done`;
+  })();
+
+  if (rows.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Selected stacks status"
+      className="rounded-2xl border border-white/5 bg-white/[0.02] p-4"
+    >
+      <header className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+          <Package size={12} />
+          Selected stacks
+        </div>
+        <div className="text-[11px] font-mono text-gray-400">{summary}</div>
+      </header>
+      <ul role="list" className="divide-y divide-white/5">
+        {rows.map(r => (
+          <StatusRow key={r.name} name={r.name} status={r.status} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/wizard/steps/StacksStep.tsx
+++ b/src/components/wizard/steps/StacksStep.tsx
@@ -30,6 +30,7 @@ import { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
 import { StackInstallProgress, StackInstallSummary } from '../../StackInstallFlow';
 import DiagnoseProbeList from '../../DiagnoseProbeList';
 import { DoneStepDnsCheck } from '../../DoneStepDnsCheck';
+import SelectedStacksPanel from '../SelectedStacksPanel';
 
 type InstallFlow = ReturnType<typeof useStackInstall>;
 
@@ -413,6 +414,12 @@ export function StacksStep({
 
             {(stackInstallStep === 'installing' || stackInstallStep === 'done') && (
                 <div className="space-y-6 animate-in fade-in duration-700">
+                    <SelectedStacksPanel
+                        items={stackItems}
+                        installingNow={installingNow}
+                        deployedNames={installFlow.deployedNames}
+                        phase={installFlow.phase}
+                    />
                     <StackInstallProgress
                         controller={installFlow}
                         beforeLog={

--- a/src/hooks/useStackInstall.ts
+++ b/src/hooks/useStackInstall.ts
@@ -93,6 +93,14 @@ export interface UseStackInstallReturn {
   variables: StackVariable[];
   logs: string[];
   installingNow: string | null;
+  /**
+   * Names of services the runner has already deployed in this job.
+   * Driven by `JobState.progress.deployedNames` — the wizard's stack
+   * status panel diffs this against the checked `items[]` to render
+   * per-stack state (queued / installing / done) without parsing the
+   * log (#732).
+   */
+  deployedNames: string[];
   credentialsManifest: Credential[];
   npmCredPrompt: boolean;
   /** Pre-fill values for the NPM-credentials prompt — usually the
@@ -274,6 +282,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
   const [variables, setVariables] = useState<StackVariable[]>([]);
   const [logs, setLogs] = useState<string[]>([]);
   const [installingNow, setInstallingNow] = useState<string | null>(null);
+  const [deployedNames, setDeployedNames] = useState<string[]>([]);
   const [credentialsManifest, setCredentialsManifest] = useState<Credential[]>([]);
   const [npmCredPrompt, setNpmCredPrompt] = useState(false);
   const [npmCredFallback, setNpmCredFallback] = useState<{ email: string; password: string }>({ email: '', password: '' });
@@ -307,6 +316,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
   const applyJobState = useCallback((state: RemoteJobState) => {
     setPhase(mapPhase(state.phase));
     setInstallingNow(state.progress?.currentItem ?? null);
+    setDeployedNames(state.progress?.deployedNames ?? []);
     if (state.credentialsManifest) setCredentialsManifest(state.credentialsManifest);
     setError(state.phase === 'aborted' || state.phase === 'crashed' || state.phase === 'error'
       ? state.error ?? 'Install failed.'
@@ -325,6 +335,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     setVariables([]);
     setLogs([]);
     setInstallingNow(null);
+    setDeployedNames([]);
     setCredentialsManifest([]);
     setNpmCredPrompt(false);
     setNpmCredFallback({ email: '', password: '' });
@@ -806,6 +817,7 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     variables,
     logs,
     installingNow,
+    deployedNames,
     credentialsManifest,
     npmCredPrompt,
     npmCredFallback,

--- a/src/lib/util/humanizeYamlError.ts
+++ b/src/lib/util/humanizeYamlError.ts
@@ -1,0 +1,130 @@
+/**
+ * Translate a `js-yaml` parse error into a plain-English message
+ * (#729). The library renders messages like:
+ *
+ *     end of the stream or a document separator is expected at line 14, column 1:
+ *
+ * which is technically accurate but reads as gibberish to anyone who
+ * hasn't worked with libyaml internals. This helper detects the
+ * common cases and rewrites them; everything else passes through
+ * unchanged so we never lose information.
+ *
+ * The output is `{ message, line, column }` so the caller can both
+ * surface the short text and highlight the offending row in the
+ * editor — see `ServiceForm.tsx`.
+ */
+
+export interface HumanizedYamlError {
+  /** Short user-facing summary. */
+  message: string;
+  /** 1-based line number of the failure, when known. */
+  line?: number;
+  /** 1-based column number, when known. */
+  column?: number;
+  /** Original raw message — surfaced as a "Details" disclosure in the UI. */
+  raw: string;
+}
+
+interface YamlMark {
+  line?: number;
+  column?: number;
+  position?: number;
+}
+
+interface ParsedRaw {
+  rawMessage: string;
+  reason: string;
+  mark: YamlMark | null;
+}
+
+function parseRaw(err: unknown): ParsedRaw {
+  if (err && typeof err === 'object') {
+    const e = err as { message?: string; reason?: string; mark?: YamlMark; toString?: () => string };
+    const rawMessage = typeof e.message === 'string' && e.message.length > 0
+      ? e.message
+      : (typeof e.toString === 'function' ? e.toString() : String(err));
+    return {
+      rawMessage,
+      reason: typeof e.reason === 'string' ? e.reason : rawMessage,
+      mark: e.mark ?? null,
+    };
+  }
+  return { rawMessage: String(err), reason: String(err), mark: null };
+}
+
+/** Concrete cases worth rewriting. Order matters: more specific
+ *  matches must come first. */
+const RULES: { match: RegExp; rewrite: (raw: string) => string }[] = [
+  {
+    match: /end of the stream or a document separator is expected/i,
+    rewrite: () =>
+      'Unexpected content — expected the document to end here. Likely a stray character (often an extra `---`, a tab in indentation, or a trailing colon) on the line below.',
+  },
+  {
+    match: /could not find expected ':'/i,
+    rewrite: () =>
+      'Missing `:` after a key. Each YAML key needs a colon and a space before its value (e.g. `name: my-service`).',
+  },
+  {
+    match: /(mapping values are not allowed|expected.*scalar.*mapping)/i,
+    rewrite: () =>
+      'Two colons on one line. The parser saw a key whose value also contains a `:`. Wrap the value in quotes: `image: "docker.io/foo:latest"`.',
+  },
+  {
+    match: /(bad indentation of a mapping entry|expected.*indent)/i,
+    rewrite: () =>
+      'Indentation problem. YAML uses spaces (not tabs) and every nested level must be at least 2 spaces deeper than its parent.',
+  },
+  {
+    match: /(can not read a block mapping entry|expected.*block.*mapping)/i,
+    rewrite: () =>
+      'A list item or nested block is missing its leading `- ` / proper indent. Check that every list entry starts with `- ` and that nested fields are indented under it.',
+  },
+  {
+    match: /duplicated mapping key/i,
+    rewrite: () =>
+      'Duplicate key — the same field is listed twice in this block. Remove one, or merge their values into a single entry.',
+  },
+  {
+    match: /unexpected end of the stream within a (flow|double-quoted|single-quoted) scalar/i,
+    rewrite: () =>
+      'Unterminated quoted string or bracket. A `"` / `\'` / `[` / `{` was opened and never closed before the file ended.',
+  },
+  {
+    match: /tab characters/i,
+    rewrite: () =>
+      'Tab character used for indentation. YAML only allows spaces — replace tabs with two spaces per indent level.',
+  },
+];
+
+export function humanizeYamlError(err: unknown): HumanizedYamlError {
+  const { rawMessage, reason, mark } = parseRaw(err);
+  // `js-yaml` reports lines and columns as 0-based; UIs and human
+  // conventions are 1-based, so add 1 when we know the value.
+  const line = typeof mark?.line === 'number' ? mark.line + 1 : undefined;
+  const column = typeof mark?.column === 'number' ? mark.column + 1 : undefined;
+  const locator = line ? ` Line ${line}${column ? `:${column}` : ''}.` : '';
+
+  for (const rule of RULES) {
+    if (rule.match.test(reason) || rule.match.test(rawMessage)) {
+      return {
+        message: `${rule.rewrite(rawMessage)}${locator}`.trim(),
+        line,
+        column,
+        raw: rawMessage,
+      };
+    }
+  }
+
+  // Fallback: keep the raw reason but prefix the line locator so the
+  // operator at least knows where to look.
+  return {
+    message: line
+      ? `YAML parse error on line ${line}${column ? ` column ${column}` : ''}: ${reason}.`
+      : `YAML parse error: ${reason}.`,
+    line,
+    column,
+    raw: rawMessage,
+  };
+}
+


### PR DESCRIPTION
## Summary

- **#732** \`SelectedStacksPanel\`: per-stack status panel in the wizard's install/done view. Diffs \`progress.deployedNames\` + \`currentItem\` against the checked \`items[]\` so the operator sees at a glance \"11/12 done · auth in flight · 1 queued\" without parsing the log.
- **#729** \`humanizeYamlError\`: translate js-yaml parser messages into plain English with line/column. ServiceForm error block now leads with the humanized text and tucks the raw parser output behind a \"Parser details\" disclosure.
- **#728** LogViewer: Summary toggle filters the firehose to warnings, errors and lifecycle keywords. Default stays Raw so deep debugging is one click away.
- **#727** OnboardingWizard: detect stalled install pipelines (5 min of inactivity on \`JobState.updatedAt\`) and surface a \"Resume install\" / \"Start fresh\" choice instead of the ambiguous \"Concurrent Pipeline Active\" + Force-clear copy.

## Test plan
- [x] \`npx tsc --noEmit\`
- [ ] Manual: kick off multi-stack install, confirm SelectedStacksPanel renders correct queued/installing/done states as the runner progresses
- [ ] Manual: paste malformed YAML into ServiceForm, confirm humanized error + line locator
- [ ] Manual: trigger LogViewer in Summary mode, confirm only lifecycle + warn/error lines render
- [ ] Manual: leave a stalled install, reopen the wizard, confirm the Resume/Start-fresh banner

Closes #732 #729 #728 #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)