### PR TITLE
feat(wizard): FRITZ!Box prerequisite + Verify connection (#726)

### DIFF
--- a/src/components/wizard/steps/NetworkStep.tsx
+++ b/src/components/wizard/steps/NetworkStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-
-import { Globe, Network, Key, CheckCircle, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Globe, Network, Key, CheckCircle, Loader2, AlertCircle, ShieldCheck } from 'lucide-react';
 import { Input, Button } from '../WizardUI';
 import { OnboardingStatus } from '@/app/actions/onboarding';
 
@@ -55,25 +55,14 @@ export function NetworkStep({
             </section>
 
             {selection.gateway && (
-                <section className="space-y-4">
-                     <div className="flex items-center gap-3">
-                        <div className="p-2.5 rounded-xl bg-purple-500/10 border border-purple-500/20">
-                            <Network className="w-5 h-5 text-purple-500"/>
-                        </div>
-                        <div>
-                            <h3 className="font-bold text-lg leading-none">Internet Gateway</h3>
-                            <p className="text-xs text-gray-500 mt-1">Connect FRITZ!Box for device discovery</p>
-                        </div>
-                     </div>
-                     
-                     <div className="grid gap-4 p-5 rounded-2xl bg-gray-50/50 dark:bg-white/5 border border-gray-200 dark:border-white/5">
-                        <Input label="Hostname / IP" value={gwHost} onChange={setGwHost} placeholder="fritz.box" hint="Standard is fritz.box" />
-                        <div className="grid grid-cols-2 gap-4">
-                            <Input label="Username" value={gwUser} onChange={setGwUser} placeholder="admin" />
-                            <Input label="Password" type="password" value={gwPass} onChange={setGwPass} />
-                        </div>
-                     </div>
-                </section>
+                <GatewaySection
+                    gwHost={gwHost}
+                    setGwHost={setGwHost}
+                    gwUser={gwUser}
+                    setGwUser={setGwUser}
+                    gwPass={gwPass}
+                    setGwPass={setGwPass}
+                />
             )}
 
             {selection.ssh && (
@@ -109,5 +98,133 @@ export function NetworkStep({
                 </section>
             )}
         </div>
+    );
+}
+
+/**
+ * Gateway (FRITZ!Box) setup block with an inline "Verify connection"
+ * affordance (#726). Device discovery + port-forward management +
+ * Wake-on-LAN all depend on the gateway being reachable; an
+ * operator who can't connect here will hit confusing failures in
+ * `domain_external_reachability` and the install runner's
+ * port-forward provisioner later. The button hits the same
+ * `/api/settings/gateway` endpoint with `test: true` that the
+ * Settings → Gateway page uses, so the validation logic is shared.
+ */
+function GatewaySection({
+    gwHost,
+    setGwHost,
+    gwUser,
+    setGwUser,
+    gwPass,
+    setGwPass,
+}: {
+    gwHost: string;
+    setGwHost: (v: string) => void;
+    gwUser: string;
+    setGwUser: (v: string) => void;
+    gwPass: string;
+    setGwPass: (v: string) => void;
+}) {
+    const [testing, setTesting] = useState(false);
+    const [result, setResult] = useState<
+        { kind: 'ok'; message: string } | { kind: 'fail'; message: string } | null
+    >(null);
+
+    const handleVerify = async () => {
+        setTesting(true);
+        setResult(null);
+        try {
+            const res = await fetch('/api/settings/gateway', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    host: gwHost.trim(),
+                    username: gwUser.trim() || undefined,
+                    password: gwPass || undefined,
+                    test: true,
+                }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok) {
+                setResult({ kind: 'ok', message: `Reached ${gwHost} successfully.` });
+            } else if (data.error === 'connection_failed') {
+                setResult({
+                    kind: 'fail',
+                    message: typeof data.message === 'string'
+                        ? `Could not authenticate: ${data.message}`
+                        : 'Could not authenticate to the gateway.',
+                });
+            } else {
+                setResult({
+                    kind: 'fail',
+                    message: typeof data.error === 'string' ? data.error : `HTTP ${res.status}`,
+                });
+            }
+        } catch (e) {
+            setResult({
+                kind: 'fail',
+                message: e instanceof Error ? e.message : 'Network error while reaching the gateway.',
+            });
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    const canVerify = gwHost.trim().length > 0;
+
+    return (
+        <section className="space-y-4">
+            <div className="flex items-center gap-3">
+                <div className="p-2.5 rounded-xl bg-purple-500/10 border border-purple-500/20">
+                    <Network className="w-5 h-5 text-purple-500" />
+                </div>
+                <div>
+                    <h3 className="font-bold text-lg leading-none">Internet Gateway</h3>
+                    <p className="text-xs text-gray-500 mt-1">
+                        FRITZ!Box powers device discovery, Wake-on-LAN and port-forward
+                        management — verify the connection before continuing.
+                    </p>
+                </div>
+            </div>
+
+            <div className="grid gap-4 p-5 rounded-2xl bg-gray-50/50 dark:bg-white/5 border border-gray-200 dark:border-white/5">
+                <Input
+                    label="Hostname / IP"
+                    value={gwHost}
+                    onChange={setGwHost}
+                    placeholder="fritz.box"
+                    hint="Standard is fritz.box"
+                />
+                <div className="grid grid-cols-2 gap-4">
+                    <Input label="Username" value={gwUser} onChange={setGwUser} placeholder="admin" />
+                    <Input label="Password" type="password" value={gwPass} onChange={setGwPass} />
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3 pt-1">
+                    <Button
+                        onClick={handleVerify}
+                        disabled={!canVerify || testing}
+                        variant="outline"
+                        className="!py-2 !px-4 !text-sm flex items-center gap-2"
+                    >
+                        {testing
+                            ? <Loader2 className="w-4 h-4 animate-spin" />
+                            : <ShieldCheck className="w-4 h-4" />}
+                        Verify Connection
+                    </Button>
+                    {result?.kind === 'ok' && (
+                        <span className="flex items-center gap-2 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-3 py-1.5 rounded-xl border border-emerald-500/20">
+                            <CheckCircle className="w-4 h-4" /> {result.message}
+                        </span>
+                    )}
+                    {result?.kind === 'fail' && (
+                        <span className="flex items-center gap-2 text-xs font-medium text-red-600 dark:text-red-400 bg-red-500/10 px-3 py-1.5 rounded-xl border border-red-500/20">
+                            <AlertCircle className="w-4 h-4" /> {result.message}
+                        </span>
+                    )}
+                </div>
+            </div>
+        </section>
     );
 }

--- a/src/components/wizard/steps/WelcomeStep.tsx
+++ b/src/components/wizard/steps/WelcomeStep.tsx
@@ -36,17 +36,31 @@ export function WelcomeStep({ selection, setSelection }: WelcomeStepProps) {
             </div>
             
             <div className="space-y-3">
+                {/*
+                  Gateway sits in its own section above the rest of the
+                  selection because device discovery + WoL + port-forward
+                  management all rely on it (#726). The verify-connection
+                  affordance lives in NetworkStep; this is the toggle that
+                  decides whether NetworkStep renders the FRITZ!Box block
+                  at all. Operator can still skip it, but the
+                  "Prerequisites" framing makes the impact explicit
+                  rather than hiding it among optional toggles.
+                */}
                 <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-widest ml-1">
+                    Prerequisites
+                </p>
+                <Toggle
+                    checked={selection.gateway}
+                    onChange={(v: boolean) => setSelection(s => ({...s, gateway: v}))}
+                    icon={Network}
+                    color="text-purple-500"
+                    title="FRITZ!Box gateway"
+                    desc="Required for device discovery, Wake-on-LAN and port-forward management — you'll verify the connection on the next step."
+                />
+
+                <p className="pt-3 text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-widest ml-1">
                     Recommended Setup
                 </p>
-                <Toggle 
-                    checked={selection.gateway} 
-                    onChange={(v: boolean) => setSelection(s => ({...s, gateway: v}))}
-                    icon={Network} 
-                    color="text-purple-500"
-                    title="Internet Gateway" 
-                    desc="Connect FRITZ!Box for device discovery"
-                />
                 <Toggle 
                     checked={selection.ssh} 
                     onChange={(v: boolean) => setSelection(s => ({...s, ssh: v}))}


### PR DESCRIPTION
## Summary

- WelcomeStep: pull the FRITZ!Box toggle out of the optional list into a \"Prerequisites\" section above the recommended toggles, with copy that names the dependent features (device discovery, Wake-on-LAN, port-forward management).
- NetworkStep: extract the gateway block into a \`GatewaySection\` subcomponent with a \"Verify Connection\" button. Hits the existing \`POST /api/settings/gateway\` endpoint with \`test: true\` (the same path Settings → Gateway uses); inline success/failure pill so the operator can confirm before continuing.

The toggle is still optional — operators on non-FRITZ networks can skip it — but the framing now matches the actual dependency surface.

## Test plan
- [x] \`npx tsc --noEmit\`
- [ ] Manual: open the wizard, confirm \"Prerequisites\" section above Recommended Setup
- [ ] Manual: enter wrong FRITZ password, confirm Verify Connection surfaces the auth failure
- [ ] Manual: enter correct host + leave password blank → Verify Connection should succeed for unauthenticated reads

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)