### PR TITLE
feat(agent): structured safe_exec dispatcher + TS execSafe (#722)

### DIFF
--- a/src/lib/agent/executor.ts
+++ b/src/lib/agent/executor.ts
@@ -51,6 +51,31 @@ export class AgentExecutor implements Executor {
     return this.exec(shellQuoteAll(argv), options);
   }
 
+  /**
+   * Structured-argv exec backed by the agent's `safe_exec` command
+   * (#722). Sends the argv list verbatim, so the agent never shell-
+   * parses the payload — there's no opportunity to inject extra
+   * commands via metacharacters even if the backend is compromised.
+   * The agent rejects the call unless argv[0] is on its
+   * SAFE_EXEC_ALLOWLIST.
+   *
+   * Use this for any new call site that doesn't need shell features
+   * (pipelines, redirection, glob expansion). The legacy `exec` /
+   * `execArgv` paths remain available for sites that genuinely need
+   * shell semantics; those are the migration target for future
+   * hardening passes.
+   */
+  async execSafe(argv: string[], options: { timeoutMs?: number } = {}): Promise<{ stdout: string; stderr: string; code: number }> {
+    if (!Array.isArray(argv) || argv.length === 0) {
+      throw new Error('execSafe requires a non-empty argv array');
+    }
+    await this.ensureConnected();
+    const truncatedCmd = argv.join(' ').slice(0, 100);
+    logger.info(`Executor:${this.agent.nodeName}`, `safe_exec: ${truncatedCmd}`);
+    const res = await this.agent.sendCommand('safe_exec', { argv }, { timeoutMs: options.timeoutMs });
+    return { stdout: res.stdout ?? '', stderr: res.stderr ?? '', code: res.code ?? -1 };
+  }
+
   async readFile(path: string): Promise<string> {
     await this.ensureConnected();
     const res = await this.agent.sendCommand('read_file', { path });

--- a/src/lib/agent/v4/agent.py
+++ b/src/lib/agent/v4/agent.py
@@ -63,6 +63,41 @@ SESSION_ID = os.getenv('SERVICEBAY_SESSION') or os.getenv('SERVICEBAY_SESSION_ID
 AGENT_CLEANUP_ON_START = os.getenv('SERVICEBAY_AGENT_CLEANUP_ON_START', 'true').lower() == 'true'
 AGENT_CLEANUP_ENABLED = os.getenv('SERVICEBAY_AGENT_CLEANUP_ENABLED', 'true').lower() == 'true'
 AGENT_CLEANUP_DRY_RUN = os.getenv('SERVICEBAY_AGENT_CLEANUP_DRY_RUN', 'false').lower() == 'true'
+
+# `safe_exec` allow-list (#722). The legacy `exec` command path
+# accepts arbitrary shell strings — a foot-gun if the backend is ever
+# compromised because the agent runs commands as the host UID. The
+# `safe_exec` command takes an explicit argv array and only runs the
+# binary if it appears below. Each entry should have a short audit
+# comment naming the consumer that requires it; do not add binaries
+# speculatively.
+SAFE_EXEC_ALLOWLIST = frozenset({
+    # State inspection — used by every diagnose probe + the agent's
+    # own initial sync.
+    'systemctl',     # service / unit state queries, --user restart
+    'podman',        # container inspection + per-row restart actions
+    'journalctl',    # log tail for the diagnose card
+    'cat',           # config / unit file reads + /proc/uptime
+    'ls',            # directory listings for data-dir probes
+    'stat',          # file metadata for cert / db freshness checks
+    'df',            # disk-usage probe
+    'du',            # "show largest dirs" diagnose action
+    'find',          # cert-archive + dangling-file enumeration
+    'echo',          # health-check + agent-ok ping
+    'hostname',      # initial-sync identity probe
+    'uptime',        # diagnose's crash-loop boot-grace gate
+    'ip',            # nodeIPs collection
+    'ss',            # listening-ports probe
+    'dig',           # DNS routing probe
+    'curl',          # external reachability probes
+    'tar',           # cert-archive snapshot
+    'rm',            # reset wipe-plan (path-validated upstream)
+    'mkdir',         # initial path provisioning
+    'touch',         # install-nginx-done marker
+    'mv',            # rename helper (callers validate paths)
+    'test',          # exists() probe in the agent executor
+    'ping',          # router-DNS probe
+})
 AGENT_CLEANUP_MAX_AGE_MINUTES = os.getenv('SERVICEBAY_AGENT_CLEANUP_MAX_AGE_MINUTES')
 try:
     AGENT_CLEANUP_MAX_AGE_MINUTES = int(AGENT_CLEANUP_MAX_AGE_MINUTES) if AGENT_CLEANUP_MAX_AGE_MINUTES else None
@@ -1841,6 +1876,43 @@ class Agent:
                     if active:
                         self.last_resource_push = 0
                 reply(result='ok')
+            elif cmd == 'safe_exec':
+                # Structured-argv exec path (#722). Callers pass an
+                # explicit argv list (no shell parsing) and the agent
+                # only accepts binaries listed in SAFE_EXEC_ALLOWLIST.
+                # This is the migration target for the legacy `exec`
+                # path below; new call sites should use this and old
+                # ones should be ported incrementally. The legacy path
+                # remains available for transitional compatibility and
+                # for the small set of operations that genuinely need
+                # shell semantics (pipelines, heredocs, redirection).
+                payload_dict = msg.get('payload', {})
+                argv = payload_dict.get('argv')
+                stdin_data = payload_dict.get('stdin')
+                raw_timeout = payload_dict.get('timeout')
+                try:
+                    timeout_val: Optional[float] = float(raw_timeout) if raw_timeout is not None else None
+                except (TypeError, ValueError):
+                    timeout_val = None
+                if not isinstance(argv, list) or not argv or not all(isinstance(a, str) for a in argv):
+                    reply(error="safe_exec requires payload.argv as a non-empty list of strings")
+                else:
+                    binary = argv[0]
+                    if binary not in SAFE_EXEC_ALLOWLIST:
+                        reply(error=f"safe_exec: binary '{binary}' is not on the allow-list. Add it to SAFE_EXEC_ALLOWLIST in agent.py with an audit comment, or use the legacy 'exec' path explicitly.")
+                    else:
+                        log_info(f"safe_exec: {' '.join(argv)}")
+                        stdout, stderr, returncode = _executor.execute(
+                            argv,
+                            check=False,
+                            timeout=timeout_val,
+                            stdin_data=stdin_data,
+                        )
+                        reply(result={
+                            "code": returncode,
+                            "stdout": stdout,
+                            "stderr": stderr,
+                        })
             elif cmd == 'exec':
                 payload_dict = msg.get('payload', {})
                 command_str = payload_dict.get('command')


### PR DESCRIPTION
## Summary

Adds a \`safe_exec\` command path to \`agent.py\` that takes an explicit \`argv\` list, runs the binary directly (no shell parsing), and rejects any call whose \`argv[0]\` isn't on \`SAFE_EXEC_ALLOWLIST\`. The list ships with the minimal set of binaries the agent's own probes/actions need, each annotated with the consumer that pulled it in.

The legacy \`exec\` path remains for transitional compatibility and for the small set of operations that genuinely need shell semantics (pipelines, heredocs, redirection). Migrating each of those 113 call sites is incremental from here — but every new call site that just needs an argv exec now has a hardened path available via \`executor.execSafe(argv)\`.

This narrows the blast radius if the backend is ever compromised: an attacker can no longer smuggle arbitrary shell into the agent via metacharacters on the new path. It does not eliminate the existing \`exec\` exposure on its own — that's the follow-up migration.

## Test plan
- [x] \`python3 -m py_compile src/lib/agent/v4/agent.py\`
- [x] \`npx tsc --noEmit\`
- [ ] Manual: from a route, call \`executor.execSafe(['systemctl', '--user', 'status', 'foo'])\`, confirm result
- [ ] Manual: call \`executor.execSafe(['unallowed-binary'])\`, confirm rejection

Refs #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)