### PR TITLE
chore(lint): max-lines / max-lines-per-function / complexity warnings (#724)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -164,6 +164,24 @@ const eslintConfig = defineConfig([
       // Soft warning — the architecture-invariants script enforces the
       // adoption ratio. This rule nudges new authors in their editor.
       "sb/api-route-needs-handler": "warn",
+      // Maintainability thresholds (#724). Several core modules
+      // currently exceed these — flagging them as warn (not error) so
+      // CI doesn't break on legacy files while the rule still surfaces
+      // every new violation in the editor. The architecture-invariants
+      // script (scripts/check-invariants.ts) is the right place to
+      // enforce a ratchet count when we want forward-only pressure.
+      //
+      // Thresholds chosen to match the issue body:
+      //   - File:    800 lines (skipBlankLines/skipComments so doc-
+      //              dense files aren't punished)
+      //   - Function: 50 lines
+      //   - Complexity: 15
+      "max-lines": ["warn", { max: 800, skipBlankLines: true, skipComments: true }],
+      "max-lines-per-function": [
+        "warn",
+        { max: 50, skipBlankLines: true, skipComments: true, IIFEs: false },
+      ],
+      "complexity": ["warn", { max: 15 }],
     },
   },
   // All 5 ratchet-exempted files swept clean in #602 — the rule is now


### PR DESCRIPTION
## Summary

Adds the maintainability thresholds called out in #724 — 800-line files, 50-line functions, complexity 15 — as ESLint warn-level rules so every new violation surfaces in the editor without breaking CI on the legacy God Objects (\`discovery.ts\`, \`agent.py\`, \`runner.ts\`).

- \`max-lines\`: warn @ 800 lines (skipBlankLines + skipComments)
- \`max-lines-per-function\`: warn @ 50 lines
- \`complexity\`: warn @ 15

Forward-only pressure is the goal; tightening to error and ratcheting the count is a follow-up once the modularization PRs land. #721 (decouple migration from \`discovery.ts\`) and #723 (modularize \`agent.py\`) are larger structural extractions and intentionally not bundled here.

## Test plan
- [x] \`npx tsc --noEmit\`
- [ ] CI: verify no new errors (warnings expected)

Refs #724 #721 #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)