### PR TITLE
feat(dashboards): phased hydration gate for /services and /containers (#737)

### DIFF
--- a/src/components/DashboardHydrationGate.tsx
+++ b/src/components/DashboardHydrationGate.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { Check, Loader2 } from 'lucide-react';
+
+/**
+ * Dashboard hydration progress (#737). The `containers` / `services`
+ * pages previously sat on a single "Connecting to Agent…" spinner for
+ * however long the digital-twin first-broadcast took (often 8–20 s on
+ * a cold start). Operators couldn't tell whether the page was making
+ * progress, wedged, or simply slow.
+ *
+ * This component renders the three phases of the load explicitly:
+ *   1. Socket — the WebSocket transport is connecting / connected.
+ *   2. Sync   — the agent's initial inventory broadcast.
+ *   3. Render — first dataset received, page is about to swap to data.
+ *
+ * Plus the elapsed-seconds counter (so the operator can compare against
+ * their expectation of "fast" vs "stuck") and an escalation hint once
+ * the load takes > 10 s in the same phase. After 25 s we surface a
+ * direct pointer to Settings → Nodes / diagnose instead of leaving the
+ * operator to guess.
+ *
+ * The component is purely presentational — gating logic stays in the
+ * dashboard so each page can choose which phase corresponds to its
+ * own data prerequisites.
+ */
+
+export type HydrationPhase = 'socket' | 'sync' | 'render';
+
+interface PhaseRow {
+  id: HydrationPhase;
+  label: string;
+  description: string;
+}
+
+const PHASES: PhaseRow[] = [
+  {
+    id: 'socket',
+    label: 'Connecting to ServiceBay',
+    description: 'Opening the realtime channel that streams agent state.',
+  },
+  {
+    id: 'sync',
+    label: 'Synchronising agent state',
+    description: 'The agent is enumerating containers, services and ports.',
+  },
+  {
+    id: 'render',
+    label: 'Rendering',
+    description: 'Receiving the first dataset and laying out the page.',
+  },
+];
+
+const SLOW_HINT_AFTER_MS = 10_000;
+const TROUBLESHOOT_AFTER_MS = 25_000;
+const TICK_INTERVAL_MS = 500;
+
+export interface DashboardHydrationGateProps {
+  /** Which phase is currently active. Done phases render with a check. */
+  phase: HydrationPhase;
+  /** Optional sub-message shown under the phase title. */
+  subMessage?: string;
+}
+
+export default function DashboardHydrationGate({ phase, subMessage }: DashboardHydrationGateProps) {
+  // Use a tick counter as the only React state. Multiply by interval to
+  // derive elapsed-ms — no Date.now() during render. The phase-start
+  // tick is captured in an effect so swapping phases resets the slow
+  // hint without touching state mid-render.
+  const [tick, bumpTick] = useReducer((t: number) => t + 1, 0);
+  const phaseStartTickRef = useRef(0);
+
+  useEffect(() => {
+    phaseStartTickRef.current = tick;
+    // Intentional: capture the tick we were on when this phase took
+    // effect. Re-running this on `tick` changes would defeat the
+    // reset — we only want it on `phase` swap.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
+
+  useEffect(() => {
+    const id = setInterval(bumpTick, TICK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const elapsedMs = (tick - phaseStartTickRef.current) * TICK_INTERVAL_MS;
+  const elapsedSec = Math.floor(elapsedMs / 1000);
+  const showSlowHint = elapsedMs >= SLOW_HINT_AFTER_MS;
+  const showTroubleshoot = elapsedMs >= TROUBLESHOOT_AFTER_MS;
+
+  const phaseIndex = useMemo(() => PHASES.findIndex(p => p.id === phase), [phase]);
+  const current = PHASES[phaseIndex] ?? PHASES[0];
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center text-gray-500 dark:text-gray-400 h-full min-h-[300px] px-6">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-6">
+          <Loader2 className="animate-spin inline-block mb-3 text-blue-500" size={28} />
+          <p className="font-medium text-gray-700 dark:text-gray-200">
+            {current.label}
+            <span className="ml-2 text-sm font-normal text-gray-400 tabular-nums">{elapsedSec}s</span>
+          </p>
+          <p className="text-sm text-gray-400 mt-1">{subMessage ?? current.description}</p>
+        </div>
+
+        <ol className="space-y-2" aria-label="Hydration progress">
+          {PHASES.map((p, idx) => {
+            const done = idx < phaseIndex;
+            const active = idx === phaseIndex;
+            return (
+              <li
+                key={p.id}
+                className={[
+                  'flex items-start gap-3 p-2 rounded',
+                  active ? 'bg-blue-50 dark:bg-blue-900/20' : '',
+                ].join(' ')}
+                aria-current={active ? 'step' : undefined}
+              >
+                <span
+                  className={[
+                    'mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold shrink-0',
+                    done ? 'bg-green-500 text-white' : '',
+                    active ? 'bg-blue-500 text-white' : '',
+                    !done && !active ? 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400' : '',
+                  ].join(' ')}
+                >
+                  {done ? <Check size={12} /> : idx + 1}
+                </span>
+                <span className="flex-1">
+                  <span
+                    className={[
+                      'block text-sm',
+                      active ? 'text-blue-700 dark:text-blue-300 font-medium' : '',
+                      done ? 'text-gray-600 dark:text-gray-300' : '',
+                      !done && !active ? 'text-gray-500 dark:text-gray-400' : '',
+                    ].join(' ')}
+                  >
+                    {p.label}
+                  </span>
+                  {active && (
+                    <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                      {p.description}
+                    </span>
+                  )}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+
+        {showSlowHint && !showTroubleshoot && (
+          <p className="mt-4 text-xs text-gray-500 dark:text-gray-400 text-center">
+            Taking a little longer than usual &mdash; first-time syncs on a cold cache can run 15&ndash;20 s.
+          </p>
+        )}
+        {showTroubleshoot && (
+          <div className="mt-4 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40 rounded p-3 text-center">
+            Still on this phase after {elapsedSec}s. The agent may not have completed its first inventory pass &mdash;
+            check <a href="/diagnose" className="underline">Diagnose</a> or
+            restart the node from <a href="/settings/nodes" className="underline">Settings &rarr; Nodes</a>.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/dashboards/ContainersDashboard.tsx
+++ b/src/dashboards/ContainersDashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
-import SectionLoading from '@/components/SectionLoading';
+import DashboardHydrationGate, { type HydrationPhase } from '@/components/DashboardHydrationGate';
 import { Box, Terminal as TerminalIcon, MoreVertical, X, Activity, Search, RefreshCw, Eraser } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
@@ -261,10 +261,16 @@ export default function ContainersDashboard() {
                     </PageHeader>
 
             <div className="flex-1 overflow-y-auto p-4">
-                {loading ? (
-                        <SectionLoading message="Connecting to Agent..." />
-                    ) : waitingForSync ? (
-                        <SectionLoading message="Synchronizing state..." />
+                {loading || waitingForSync ? (
+                        <DashboardHydrationGate
+                            // `loading` flips when the socket transport is
+                            // still connecting (no `isConnected` yet);
+                            // `waitingForSync` flips when the agent is
+                            // streaming the first inventory broadcast. Render
+                            // never reaches this block — the dataset is
+                            // already attached by the time we leave it.
+                            phase={(loading ? 'socket' : 'sync') as HydrationPhase}
+                        />
                     ) : filteredContainers.length === 0 ? (
                         <div className="text-center text-gray-500 dark:text-gray-400 mt-10">
                             {containers.length > 0 ? 'No containers match your filters.' : 'No active containers found.'}

--- a/src/dashboards/ServicesDashboard.tsx
+++ b/src/dashboards/ServicesDashboard.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import { logger } from '@/lib/logger';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin'; // V4 Hook
 import { useEscapeKey } from '@/hooks/useEscapeKey';
-import SectionLoading from '@/components/SectionLoading';
+import DashboardHydrationGate, { type HydrationPhase } from '@/components/DashboardHydrationGate';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
 import PageHeader from '@/components/PageHeader';
@@ -130,7 +130,7 @@ type RawLinkVolume = {
 };
 
 export default function ServicesDashboard() {
-    const { data: twin, isConnected, lastUpdate } = useDigitalTwin();
+    const { data: twin, isConnected, lastUpdate, isNodeSynced } = useDigitalTwin();
     const { addToast, updateToast } = useToast();
 
     const [filteredServices, setFilteredServices] = useState<ServiceViewModel[]>([]);
@@ -473,6 +473,7 @@ export default function ServicesDashboard() {
     }, [twin, externalLinks]);
 
     const loading = !isConnected && services.length === 0;
+    const waitingForSync = isConnected && !isNodeSynced() && services.length === 0;
 
     const collectBundlesFromTwin = useCallback((): ServiceBundle[] => {
         if (!twin || !twin.nodes) return [];
@@ -1007,9 +1008,11 @@ export default function ServicesDashboard() {
     };
 
     const renderServiceContent = () => {
-        if (loading) {
+        if (loading || waitingForSync) {
             return (
-                <SectionLoading message="Loading services..." subMessage="Waiting for agent synchronization..." />
+                <DashboardHydrationGate
+                    phase={(loading ? 'socket' : 'sync') as HydrationPhase}
+                />
             );
         }
 

--- a/tests/frontend/ServicesDashboard.test.tsx
+++ b/tests/frontend/ServicesDashboard.test.tsx
@@ -56,7 +56,10 @@ vi.mock('@/hooks/useDigitalTwin', () => ({
   useDigitalTwin: () => ({
     data: currentMockData,
     isConnected: true,
-    lastUpdate: Date.now()
+    lastUpdate: Date.now(),
+    // Mirrors the provider's getter; tests render past the
+    // hydration gate so we report synced.
+    isNodeSynced: () => true,
   })
 }));
 

--- a/tests/frontend/ServicesDashboard_Twin.test.tsx
+++ b/tests/frontend/ServicesDashboard_Twin.test.tsx
@@ -16,8 +16,15 @@ vi.mock('../../src/providers/ToastProvider', () => ({
   useToast: () => ({ addToast: vi.fn(), updateToast: vi.fn() }),
 }));
 
-// Mock Digital Twin Hook
-const mockUseDigitalTwin = vi.fn();
+// Mock Digital Twin Hook. `isNodeSynced` is provided by default —
+// individual tests can override `mockUseDigitalTwin` to return a
+// different shape if they need to exercise the hydration gate.
+const mockUseDigitalTwin = vi.fn(() => ({
+    data: null,
+    isConnected: true,
+    lastUpdate: 0,
+    isNodeSynced: () => true,
+}));
 vi.mock('../../src/hooks/useDigitalTwin', () => ({
     useDigitalTwin: () => mockUseDigitalTwin()
 }));
@@ -90,7 +97,8 @@ describe('ServicesDashboard E2E Data Rendering', () => {
         mockUseDigitalTwin.mockReturnValue({
             data: mockSnapshot,
             isConnected: true,
-            lastUpdate: Date.now()
+            lastUpdate: Date.now(),
+            isNodeSynced: () => true,
         });
 
         render(<ServicesDashboard />);
@@ -140,11 +148,13 @@ describe('ServicesDashboard E2E Data Rendering', () => {
 
         mockUseDigitalTwin.mockReturnValue({
             data: mockSnapshot,
-            isConnected: true
+            isConnected: true,
+            lastUpdate: Date.now(),
+            isNodeSynced: () => true,
         });
 
         render(<ServicesDashboard />);
-        
+
         expect(await screen.findByText('broken-service')).toBeDefined();
         // Should not crash, maybe show "-" or empty space
         // We just ensure it renders.

--- a/tests/frontend/ServicesDashboard_Twin.test.tsx
+++ b/tests/frontend/ServicesDashboard_Twin.test.tsx
@@ -19,7 +19,12 @@ vi.mock('../../src/providers/ToastProvider', () => ({
 // Mock Digital Twin Hook. `isNodeSynced` is provided by default —
 // individual tests can override `mockUseDigitalTwin` to return a
 // different shape if they need to exercise the hydration gate.
-const mockUseDigitalTwin = vi.fn(() => ({
+const mockUseDigitalTwin = vi.fn<() => {
+    data: DigitalTwinSnapshot | null;
+    isConnected: boolean;
+    lastUpdate: number;
+    isNodeSynced: (n?: string) => boolean;
+}>(() => ({
     data: null,
     isConnected: true,
     lastUpdate: 0,


### PR DESCRIPTION
## Summary

The single \"Connecting to Agent…\" spinner gave the operator no signal about which phase the page was in — socket transport, agent inventory sync, or first render. On a cold start that wait is 8–20 s and felt black-boxed.

\`DashboardHydrationGate\` renders the three phases explicitly with a checkmark trail, time-in-phase counter, slow hint at 10 s and a diagnose pointer at 25 s. Wired into ContainersDashboard + ServicesDashboard; ServicesDashboard gains the same \`waitingForSync\` gate ContainersDashboard already had so the sync phase actually shows up there too.

## Test plan
- [x] \`npx tsc --noEmit\`
- [ ] Manual: load \`/containers\` on a cold cache, confirm phases transition socket → sync → data
- [ ] Manual: stop the agent, confirm the troubleshoot pointer appears at 25 s

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)