### PR TITLE
refactor(wizard): collapse machine + install-confirm into one canonical step (#689)

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -39,22 +39,21 @@ import { FinishStep } from './wizard/steps/FinishStep';
 //   welcome         → pick which features to configure
 //   network         → gateway + SSH (if selected on welcome)
 //   email           → SMTP (if selected on welcome)
-//   install-confirm → compact "express install" summary: domain + clean
-//                     install + auto-mount + preselected full-stack.
-//                     Default landing for stacksOnlyMode and the next
-//                     step after email in fresh setup. Click Install
-//                     and the wizard runs the whole install with
-//                     sensible defaults; click Edit on a row to fall
-//                     through into the explicit machine + stacks steps
-//                     below.
-//   machine         → host-side prep: domain choice, drive detection
-//                     / RAID mount, optional clean-install reset.
-//                     Reached via Edit from install-confirm.
-//   stacks          → stack picker + per-service selection + per-
-//                     service config. Reached via Edit from install-
-//                     confirm OR by Continue from machine.
+//   install-confirm → canonical "confirm install" screen: domain + clean
+//                     install + auto-mount + storage layout. Either kick
+//                     off the express full-stack install via the primary
+//                     button OR navigate into the stacks picker for
+//                     manual selection. Default landing for stacksOnlyMode
+//                     and the next step after email in fresh setup.
+//                     #689 collapsed the former duplicate `machine` step
+//                     into this one — the two used to render the same
+//                     MachineStep component with isExpressMode toggling
+//                     copy + ordering.
+//   stacks          → stack picker + per-service selection + per-service
+//                     config. Reached via "Pick stacks" from install-
+//                     confirm.
 //   finish          → summary
-type WizardStep = 'welcome' | 'network' | 'email' | 'install-confirm' | 'machine' | 'stacks' | 'finish';
+type WizardStep = 'welcome' | 'network' | 'email' | 'install-confirm' | 'stacks' | 'finish';
 
 interface ConfigFile {
   filename: string;
@@ -539,12 +538,12 @@ export default function OnboardingWizard() {
       setCommittedStepCount(null);
       return;
     }
-    if (currentStep === 'machine' || currentStep === 'stacks') return;
-    const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'machine', 'stacks', 'finish'];
+    if (currentStep === 'stacks') return;
+    const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'stacks', 'finish'];
     const active = order.filter(step => {
       if (step === 'welcome' || step === 'finish' || step === 'network') return true;
       if (step === 'install-confirm') return selection.stacks;
-      if (step === 'machine' || step === 'stacks') return false;
+      if (step === 'stacks') return false;
       return selection[step as keyof typeof selection];
     });
     setCommittedStepCount(active.length);
@@ -652,7 +651,7 @@ export default function OnboardingWizard() {
     // and for the explicit stack picker. loadStacks() also seeds
     // stackSelectedNode for single-node setups.
     if (
-        (currentStep === 'stacks' || currentStep === 'machine' || currentStep === 'install-confirm')
+        (currentStep === 'stacks' || currentStep === 'install-confirm')
         && availableStacks.length === 0
         && !stacksLoading
     ) {
@@ -743,24 +742,24 @@ export default function OnboardingWizard() {
   };
 
   const getNextStep = (current: WizardStep): WizardStep => {
-      const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'machine', 'stacks', 'finish'];
+      const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'stacks', 'finish'];
 
-      // Two paths through the install region of the wizard:
+      // Two paths through the install region of the wizard (#689):
       //   express mode  → welcome → network → email → install-confirm → finish
-      //   edit mode     → welcome → network → email → machine → stacks → finish
-      // Edit mode is entered when the operator clicks "Edit details"
-      // on the confirm screen (jumps to 'machine'). Once they're in
-      // either machine or stacks, we treat them as committed to the
-      // verbose flow — install-confirm drops out of the activeSteps
-      // and the existing machine → stacks → finish chain takes over.
-      const inEditMode = current === 'machine' || current === 'stacks';
+      //   edit mode     → welcome → network → email → install-confirm → stacks → finish
+      // Edit mode is entered when the operator clicks "Pick stacks"
+      // on install-confirm. Once they're in stacks, the picker drives
+      // the rest of the flow until 'finish'. install-confirm remains
+      // visible in the sidebar in both paths so the operator can walk
+      // back to the confirm screen without losing their place.
+      const inEditMode = current === 'stacks';
       const activeSteps = order.filter(step => {
          if (step === 'welcome' || step === 'finish') return true;
          // network step is always active now — captures publicDomain
          // (#662) in addition to optional gateway/SSH config.
          if (step === 'network') return true;
-         if (step === 'install-confirm') return selection.stacks && !inEditMode;
-         if (step === 'machine' || step === 'stacks') return inEditMode;
+         if (step === 'install-confirm') return selection.stacks;
+         if (step === 'stacks') return inEditMode;
          return selection[step as keyof typeof selection];
       });
 
@@ -1049,13 +1048,13 @@ export default function OnboardingWizard() {
 
   if (!isOpen) return null;
 
-  const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'machine', 'stacks', 'finish'];
-  const inEditMode = currentStep === 'machine' || currentStep === 'stacks';
+  const order: WizardStep[] = ['welcome', 'network', 'email', 'install-confirm', 'stacks', 'finish'];
+  const inEditMode = currentStep === 'stacks';
   const activeSteps = order.filter(step => {
     if (step === 'welcome' || step === 'finish') return true;
     if (step === 'network') return true;
-    if (step === 'install-confirm') return selection.stacks && !inEditMode;
-    if (step === 'machine' || step === 'stacks') return inEditMode;
+    if (step === 'install-confirm') return selection.stacks;
+    if (step === 'stacks') return inEditMode;
     return selection[step as keyof typeof selection];
   });
   const currentIndex = activeSteps.indexOf(currentStep);
@@ -1262,9 +1261,8 @@ export default function OnboardingWizard() {
               <EmailStep emailConfig={emailConfig} setEmailConfig={setEmailConfig} />
             )}
 
-            {(currentStep === 'machine' || currentStep === 'install-confirm') && (
+            {currentStep === 'install-confirm' && (
               <MachineStep
-                isExpressMode={currentStep === 'install-confirm'}
                 installMode={installMode}
                 setInstallMode={setInstallMode}
                 publicDomain={publicDomain}
@@ -1346,17 +1344,13 @@ export default function OnboardingWizard() {
                       {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <span className="flex items-center gap-2">Continue <ArrowRight className="w-5 h-5" /></span>}
                    </Button>
                 )}
-                {(currentStep === 'machine' || currentStep === 'install-confirm') && (
-                   <Button 
-                      onClick={currentStep === 'install-confirm' ? handleStartExpressInstall : handleNext} 
-                      disabled={loading || (currentStep === 'install-confirm' && cleanInstall && !cleanInstallConfirm)} 
+                {currentStep === 'install-confirm' && (
+                   <Button
+                      onClick={handleStartExpressInstall}
+                      disabled={loading || (cleanInstall && !cleanInstallConfirm)}
                       className="px-10 py-4 text-base shadow-xl shadow-blue-500/20"
                    >
-                      {currentStep === 'install-confirm' ? (
-                         <span className="flex items-center gap-2"><Layers className="w-5 h-5" /> Install Now</span>
-                      ) : (
-                         <span className="flex items-center gap-2">Continue <ArrowRight className="w-5 h-5" /></span>
-                      )}
+                      <span className="flex items-center gap-2"><Layers className="w-5 h-5" /> Install Now</span>
                    </Button>
                 )}
                 {currentStep === 'stacks' && (

--- a/src/components/wizard/steps/MachineStep.tsx
+++ b/src/components/wizard/steps/MachineStep.tsx
@@ -6,7 +6,7 @@ import type { Template } from '@/lib/registry';
 import { Input, Button } from '../WizardUI';
 import CleanInstallPanel from '../../CleanInstallPanel';
 
-type WizardStep = 'welcome' | 'network' | 'email' | 'install-confirm' | 'machine' | 'stacks' | 'finish';
+type WizardStep = 'welcome' | 'network' | 'email' | 'install-confirm' | 'stacks' | 'finish';
 
 interface DetectedDrive {
     name: string;
@@ -48,11 +48,6 @@ interface MachineStepProps {
     navigateTo: (step: WizardStep) => void;
     detectedDrives: DetectedDrive[];
     stackLoadingDevices: boolean;
-    /** True when the operator landed on the express install-confirm
-     *  screen (vs the verbose machine step). Surfaces the "Edit details"
-     *  drop-into-verbose-flow button + the express banner so the
-     *  express landing has its own copy. */
-    isExpressMode?: boolean;
 }
 
 export function MachineStep({
@@ -76,7 +71,6 @@ export function MachineStep({
     navigateTo,
     detectedDrives,
     stackLoadingDevices,
-    isExpressMode,
 }: MachineStepProps) {
     return (
         <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
@@ -88,22 +82,18 @@ export function MachineStep({
                     <h3 className="font-bold text-lg leading-none">Machine & Review</h3>
                     <p className="text-xs text-gray-500 mt-1">Finalize host configuration and storage</p>
                 </div>
-                {isExpressMode && (
-                    <Button
-                        variant="outline"
-                        onClick={() => navigateTo('machine')}
-                        className="!py-1.5 !px-3 !text-xs"
-                    >
-                        Edit details
-                    </Button>
-                )}
+                <Button
+                    variant="outline"
+                    onClick={() => navigateTo('stacks')}
+                    className="!py-1.5 !px-3 !text-xs"
+                >
+                    Pick stacks
+                </Button>
             </div>
 
-            {isExpressMode && (
-                <p className="text-sm text-gray-500 leading-relaxed">
-                    We&apos;ll install the recommended stack with sensible defaults. Adjust the two questions below or click <em>Edit details</em> for the full wizard.
-                </p>
-            )}
+            <p className="text-sm text-gray-500 leading-relaxed">
+                We&apos;ll install the recommended stack with sensible defaults. Adjust the questions below, or click <em>Pick stacks</em> to choose individual services.
+            </p>
 
             {!publicDomain.trim() && installMode === 'public' && (
                 <div className="flex items-start gap-4 p-4 rounded-2xl border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 shadow-sm">

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -99,17 +99,16 @@ const optOutOfDomain = () => {
   if (!radios[0].checked) fireEvent.click(radios[0]);
 };
 
-// stacksOnlyMode now lands on the express 'install-confirm' screen.
-// The existing stack-picker tests want the verbose wizard, so this
-// helper picks internal-only (state is shared with the machine step),
-// clicks Edit details to drop into the wizard, then clicks Continue on
-// the machine step — ending up on the stack picker.
+// stacksOnlyMode lands on the canonical install-confirm screen.
+// The existing stack-picker tests want the stack picker, so this
+// helper picks internal-only (releases the Continue gate) and then
+// clicks "Pick stacks" to drop into the picker directly. The former
+// 'machine' step was collapsed into install-confirm in #689, so
+// there's no separate Continue step in between anymore.
 const advancePastMachineStep = async () => {
   await waitFor(() => screen.getAllByRole('radio', { name: /No, internal only/i }));
   optOutOfDomain();
-  fireEvent.click(screen.getByRole('button', { name: /Edit details/i }));
-  await waitFor(() => screen.getByRole('button', { name: /Continue/i }));
-  fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
+  fireEvent.click(screen.getByRole('button', { name: /Pick stacks/i }));
 };
 
 // Pre-#682 the picker was click-a-tile-to-pick; now it's a multi-
@@ -559,18 +558,15 @@ describe('OnboardingWizard', () => {
             });
         });
 
-        it('shows domain prompt on machine step', async () => {
+        it('shows domain prompt on install-confirm step', async () => {
             (checkOnboardingStatus as any).mockResolvedValue(stacksPendingStatus);
 
             render(<OnboardingWizard />);
 
-            // Domain prompt is on the machine step. Pre-#685 the
-            // install-confirm step *also* had an editable text input
-            // (operator-visible duplicate); now it's a read-only
-            // display. Navigate explicitly to machine to find the
-            // input.
-            await waitFor(() => screen.getByRole('button', { name: /Edit details/i }));
-            fireEvent.click(screen.getByRole('button', { name: /Edit details/i }));
+            // #689: machine + install-confirm collapsed into the same
+            // canonical confirm step. The domain prompt + reachability
+            // picker render on install-confirm directly — no second
+            // step to drop into.
             await waitFor(() => {
                 expect(screen.getAllByPlaceholderText('example.com').length).toBeGreaterThan(0);
                 expect(screen.getAllByRole('radio', { name: /No, internal only/i }).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

The pre-fix wizard had two top-level steps that rendered the same \`MachineStep\` component with \`isExpressMode\` toggling copy + button labels. Both asked for publicDomain + operatorEmail (radio-picker layout in both), both showed CleanInstallPanel + RAID detection. Operators saw two visually-identical screens with different behaviour.

This PR:
- Drops the \`machine\` step from \`WizardStep\`. The \`MachineStep\` component remains (it's the only confirm-screen renderer), but the \`isExpressMode\` prop is gone — the layout is the same in every mode.
- Renames the \"Edit details\" button to \"Pick stacks\" and routes it to \`stacks\` directly. The former machine → stacks Continue chain is replaced by a single button click that lands the operator on the stack picker.
- Step order shrinks: \`welcome → network → email → install-confirm → stacks → finish\` (was: \`… → install-confirm → machine → stacks → finish\`).
- Test helper \`advancePastMachineStep\` updated to click \"Pick stacks\" once. The \"shows domain prompt on machine step\" test is renamed and asserts directly on install-confirm.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` — 1113 passing
- [ ] Manual: walk the wizard end-to-end, confirm no \"machine\" step
- [ ] Manual: from install-confirm click Pick stacks, confirm direct landing on picker
- [ ] Manual: from install-confirm click Install Now, confirm express install kicks off

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)