### PR TITLE
refactor(arch): stand up @/contracts seam (#756)

### DIFF
--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -105,18 +105,18 @@ These are enforced as depcruise rules:
 - **One renderer** — all Mustache rendering goes through `src/lib/template/render.ts` (post-#599). `install/runner.ts` and the `stackInstall/` family still import `mustache` directly and are exempt for the moment; the next ratchet step migrates them to the shared helper too.
 - **One Digital Twin store** — singleton via `DigitalTwinStore.getInstance()`. Fan-in cap enforced by `check-invariants.ts`.
 
-### Frontend ↔ Backend boundary (Phase 0 of #753)
+### Frontend ↔ Backend boundary (#753)
 
 Three ratcheted counts pin how much server-side logic still lives in the frontend. Each one is expected to go **down** as the FE/BE split phases land — never up.
 
 - `fe-template-lib-imports` — `js-yaml` / `mustache` imports in `src/components`, `src/hooks`, `src/dashboards`. Currently capped at 1 (the `js-yaml` import in `ServiceForm.tsx` for live editor feedback). Phase 2 routes YAML through `POST /api/services/validate-yaml`.
-- `fe-backend-imports` — imports of `@/lib/install`, `@/lib/agent`, `@/lib/diagnose` from the same dirs. Currently capped at 7. Phase 1 stands up `src/contracts/` as the typed seam; Phase 3 enforces direction via workspace boundaries.
+- `fe-backend-imports` — imports of `@/lib/install`, `@/lib/agent`, `@/lib/diagnose` from the same dirs. **Capped at 0** as of Phase 1 (#756). The `sb/no-fe-backend-import` ESLint rule enforces the same boundary at edit-time. Phase 3 will move this from a count to a workspace boundary.
 - `fe-install-helpers` — references to `generateRandomSecret` / `parseTemplateDependencies` in the same dirs. Currently capped at 6 (across `useStackInstall.ts` + `StackVariableField.tsx`). Phase 2 moves these into `POST /api/install/configure`.
 
-Frontend code should reach the backend exclusively through:
-- `@/contracts/*` (once Phase 1 lands), or
-- `@/app/actions/*` (server actions — already typed), or
-- typed REST/WebSocket calls through the same contracts surface.
+Frontend code reaches the backend exclusively through:
+- `@/contracts/*` — typed seam. Types + zod schemas live here; `@/contracts/client.ts` wraps `fetch` with schema validation. Phase 1 (#756) stood up the seam.
+- `@/app/actions/*` — server actions, already typed.
+- Direct `fetch('/api/...')` is grandfathered for the ~80 existing call sites; Phase 2 migrates them onto `typedFetch`.
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import unusedImports from "eslint-plugin-unused-imports";
 // ---------------------------------------------------------------------------
 // Custom ServiceBay rules.
 //
-// Two rules, both architecture-doc-derived (see docs/ARCHITECTURE_INVARIANTS.md):
+// Three rules, all architecture-doc-derived (see docs/ARCHITECTURE_INVARIANTS.md):
 //   - `sb/no-exec-template-literal` — bans `executor.exec(`…${x}…`)` in
 //     favor of `executor.execArgv([...])`. Mirrors the semgrep rule for
 //     IDE-time feedback; the aggregate count is enforced by
@@ -15,6 +15,11 @@ import unusedImports from "eslint-plugin-unused-imports";
 //     a verb handler without using `withApiHandler` from
 //     `@/lib/api/handler`. Soft warning for new routes; the adoption
 //     ratio floor is enforced by scripts/check-invariants.ts.
+//   - `sb/no-fe-backend-import` — bans frontend files (under
+//     `src/components/**`, `src/hooks/**`, `src/dashboards/**`) from
+//     importing `@/lib/install/**`, `@/lib/agent/**`, or
+//     `@/lib/diagnose/**`. They route through `@/contracts/*` instead.
+//     Phase 1 of the FE/BE separation (#753).
 // ---------------------------------------------------------------------------
 const servicebayPlugin = {
   rules: {
@@ -137,6 +142,43 @@ const servicebayPlugin = {
         };
       },
     },
+    "no-fe-backend-import": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Frontend files must not import from server-side modules (@/lib/install, @/lib/agent, @/lib/diagnose). Go through @/contracts/* instead.",
+        },
+        schema: [],
+        messages: {
+          forbidden:
+            "Frontend files (src/components, src/hooks, src/dashboards) cannot import from {{path}}. Use @/contracts/* instead. See docs/ARCHITECTURE_INVARIANTS.md § fe-be-boundary.",
+        },
+      },
+      create(context) {
+        const filename = context.filename ?? context.getFilename();
+        if (
+          !/[\\/]src[\\/](components|hooks|dashboards)[\\/]/.test(filename)
+        ) {
+          return {};
+        }
+        return {
+          ImportDeclaration(node) {
+            const source = node.source.value;
+            if (typeof source !== "string") return;
+            if (
+              /^@\/lib\/(install|agent|diagnose)(\/|$)/.test(source)
+            ) {
+              context.report({
+                node: node.source,
+                messageId: "forbidden",
+                data: { path: source },
+              });
+            }
+          },
+        };
+      },
+    },
   },
 };
 
@@ -164,6 +206,11 @@ const eslintConfig = defineConfig([
       // Soft warning — the architecture-invariants script enforces the
       // adoption ratio. This rule nudges new authors in their editor.
       "sb/api-route-needs-handler": "warn",
+      // Phase 1 of the FE/BE separation (#753). The fe-backend-imports
+      // baseline was dropped to 0 in the same PR that lands this rule
+      // — any new violation fails CI both via the rule and via
+      // scripts/check-invariants.ts.
+      "sb/no-fe-backend-import": "error",
       // Maintainability thresholds (#724). Several core modules
       // currently exceed these — flagging them as warn (not error) so
       // CI doesn't break on legacy files while the rule still surfaces

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -243,7 +243,7 @@ async function checkTwinFanIn() {
 // ---------------------------------------------------------------------------
 const FE_DIRS = ['components', 'hooks', 'dashboards'];
 const FE_TEMPLATE_LIB_MAX = 1;     // js-yaml + mustache imports from FE
-const FE_BACKEND_IMPORT_MAX = 7;   // imports of @/lib/{install,agent,diagnose} from FE
+const FE_BACKEND_IMPORT_MAX = 0;   // imports of @/lib/{install,agent,diagnose} from FE — Phase 1 (#756) routed them through @/contracts; sb/no-fe-backend-import now enforces editor-time
 const FE_INSTALL_HELPER_MAX = 6;   // generateRandomSecret + parseTemplateDependencies refs from FE
 
 const inFeDir = (file: string): boolean =>

--- a/src/components/AttachedContainerList.tsx
+++ b/src/components/AttachedContainerList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Activity, MoreVertical, Terminal as TerminalIcon } from 'lucide-react';
-import { EnrichedContainer } from '@/lib/agent/types';
+import type { EnrichedContainer } from '@/contracts/agent';
 
 interface AttachedContainerListProps {
   containers?: EnrichedContainer[];

--- a/src/components/ContainerList.tsx
+++ b/src/components/ContainerList.tsx
@@ -4,7 +4,7 @@
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 import { useEffect, useMemo, useState } from 'react';
 import { RefreshCw } from 'lucide-react';
-import { EnrichedContainer } from '@/lib/agent/types';
+import type { EnrichedContainer } from '@/contracts/agent';
 
 interface ContainerItem extends Partial<EnrichedContainer> {
   // Allow partial for legacy passed props, but prefer EnrichedContainer shape

--- a/src/components/ServiceMonitor.tsx
+++ b/src/components/ServiceMonitor.tsx
@@ -5,7 +5,7 @@ import { RefreshCw, Terminal, Activity, Box, ArrowLeft, FileJson } from 'lucide-
 import { useRouter, useSearchParams } from 'next/navigation';
 import { logger } from '@/lib/logger';
 import ContainerList from './ContainerList';
-import { EnrichedContainer } from '@/lib/agent/types';
+import type { EnrichedContainer } from '@/contracts/agent';
 
 interface ServiceMonitorProps {
     serviceName: string;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,8 @@ import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import pkg from '../../package.json';
+import { typedFetch } from '@/contracts/client';
+import { InstallStatusResponseSchema } from '@/contracts/install';
 
 export const dashboards = [
     { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
@@ -62,18 +64,14 @@ export default function Sidebar() {
     let cancelled = false;
     const tick = async () => {
       try {
-        const res = await fetch('/api/install/status', { cache: 'no-store' });
-        if (!res.ok) return;
-        const data = await res.json() as {
-          job: { phase?: string } | null;
-          jobIsActive?: boolean;
-          stackSetupPending?: boolean;
-        };
-        if (cancelled) return;
-        setHasActiveInstall(
-          Boolean(data.jobIsActive) || Boolean(data.stackSetupPending),
+        const data = await typedFetch(
+          '/api/install/status',
+          InstallStatusResponseSchema,
+          { cache: 'no-store' },
         );
-      } catch { /* offline / mid-redeploy — keep the previous value */ }
+        if (cancelled) return;
+        setHasActiveInstall(data.jobIsActive || data.stackSetupPending);
+      } catch { /* offline / mid-redeploy / schema drift — keep the previous value */ }
     };
     void tick();
     const handle = setInterval(tick, 5000);

--- a/src/components/StackCard.tsx
+++ b/src/components/StackCard.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { AlertTriangle, CheckCircle2, HelpCircle, Layers, Loader2, Trash2 } from 'lucide-react';
 
 import type { StackManifest } from '@/lib/template/stackContract';
-import type { StackHealth, ChildHealthState } from '@/lib/install/stackHealth';
+import type { StackHealth, ChildHealthState } from '@/contracts/install';
 import { useToast } from '@/providers/ToastProvider';
 
 /**

--- a/src/contracts/agent.ts
+++ b/src/contracts/agent.ts
@@ -1,0 +1,10 @@
+// Agent / digital-twin types shared between the frontend and the
+// backend. The frontend imports the types it needs from here instead
+// of reaching into `@/lib/agent/*`; the `sb/no-fe-backend-import` rule
+// enforces that direction.
+//
+// Today these re-export from `@/lib/agent/types`. Phase 2 of the
+// FE/BE separation (#753) hoists the canonical definitions into
+// `@/contracts` and inverts the import direction.
+
+export type { EnrichedContainer, PortMapping, ServiceUnit } from '@/lib/agent/types';

--- a/src/contracts/client.ts
+++ b/src/contracts/client.ts
@@ -1,0 +1,51 @@
+// Typed fetch client. Phase 1 of the FE/BE separation (#753) —
+// proof-of-life so the seam carries actual behaviour, not just
+// re-exports. Frontend call sites get a runtime-validated response
+// shape from a zod schema that lives next to the type it describes.
+//
+// Phase 2 migrates the bulk of the ~80 raw `fetch('/api/...')` call
+// sites in src/{components,hooks,dashboards} onto this helper. Today
+// only the worked example (Sidebar.tsx → /api/install/status) does.
+
+import type { ZodType } from 'zod';
+
+export class TypedFetchError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'TypedFetchError';
+  }
+}
+
+/**
+ * Fetch + zod-validate the response. Throws `TypedFetchError` on
+ * non-OK status or schema mismatch — callers that want to swallow
+ * failures (e.g. periodic polling) wrap in try/catch.
+ */
+export async function typedFetch<T>(
+  url: string,
+  schema: ZodType<T>,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new TypedFetchError(
+      `${init?.method ?? 'GET'} ${url} → HTTP ${res.status}`,
+      undefined,
+      res.status,
+    );
+  }
+  const raw: unknown = await res.json();
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new TypedFetchError(
+      `${init?.method ?? 'GET'} ${url}: response failed schema validation`,
+      parsed.error,
+      res.status,
+    );
+  }
+  return parsed.data;
+}

--- a/src/contracts/install.ts
+++ b/src/contracts/install.ts
@@ -1,0 +1,37 @@
+// Install / stack-runner types shared between the frontend and the
+// backend. The frontend imports from here instead of reaching into
+// `@/lib/install/*`; the `sb/no-fe-backend-import` rule enforces
+// that direction.
+//
+// Today these re-export from `@/lib/install/*`. Phase 2 of the
+// FE/BE separation (#753) hoists the canonical definitions into
+// `@/contracts` and inverts the import direction.
+
+import { z } from 'zod';
+
+export type { JobState, JobPhase } from '@/lib/install/jobStore';
+export type { StackHealth, ChildHealthState } from '@/lib/install/stackHealth';
+
+// ---------------------------------------------------------------------------
+// /api/install/status response — Phase 1 worked example (#756). Schema
+// is intentionally narrow: only the fields the frontend actually reads
+// today. Widening it later is additive. The job sub-shape is lenient
+// (passthrough on extra fields) because the canonical JobState lives
+// in @/lib/install/jobStore and Phase 2 will hoist it here.
+// ---------------------------------------------------------------------------
+
+const JobShapeSchema = z
+  .object({
+    phase: z.string().optional(),
+    startedAt: z.string().optional(),
+  })
+  .passthrough();
+
+export const InstallStatusResponseSchema = z.object({
+  job: JobShapeSchema.nullable(),
+  jobIsActive: z.boolean(),
+  stackSetupPending: z.boolean(),
+  serverStartedAt: z.string(),
+  logs: z.string().optional(),
+  logsOffset: z.number().optional(),
+});

--- a/src/dashboards/NetworkDashboard.tsx
+++ b/src/dashboards/NetworkDashboard.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: false });
 import dynamic from 'next/dynamic';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
-import { PortMapping, EnrichedContainer, ServiceUnit } from '@/lib/agent/types';
+import type { PortMapping, EnrichedContainer, ServiceUnit } from '@/contracts/agent';
 import { NetworkGraph } from '@/lib/network/types'; 
 import { buildServiceViewModel } from '@/lib/services/serviceViewModel';
 import type { ServiceViewModel } from '@/types/serviceView';

--- a/src/dashboards/ServicesDashboard.tsx
+++ b/src/dashboards/ServicesDashboard.tsx
@@ -24,7 +24,7 @@ import { buildServiceViewModel } from '@/lib/services/serviceViewModel';
 import { ServiceViewModel, ServicePort } from '@/types/serviceView';
 import ContainerLogsPanel, { ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
 import type { TerminalRef } from '@/components/Terminal';
-import { EnrichedContainer } from '@/lib/agent/types';
+import type { EnrichedContainer } from '@/contracts/agent';
 // We keep Service interface but recreate it or import from shared data if it matches?
 // SharedData Service is a complex UI object. digital twin ServiceUnit is simple.
 // WE NEED TO MAP TWIN -> UI SERVICE here.

--- a/src/hooks/useStackInstall.ts
+++ b/src/hooks/useStackInstall.ts
@@ -42,7 +42,7 @@ import { parseTemplateLabel } from '@/lib/templateLabel';
 import { type Credential } from '@/lib/stackInstall/credentialsManifest';
 import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
 import { parseTemplateDependencies } from '@/lib/stackInstall/dependencies';
-import type { JobState as RemoteJobState } from '@/lib/install/jobStore';
+import type { JobState as RemoteJobState } from '@/contracts/install';
 
 export type StackInstallPhase = 'idle' | 'configure' | 'installing' | 'done' | 'error';
 


### PR DESCRIPTION
## Summary

Phase 1 of the FE/BE separation (#753). Stands up `src/contracts/` as the typed seam between frontend and backend. Per #756:

- `src/contracts/{agent,install}.ts` re-export the seven types frontend files actually use (`EnrichedContainer`, `PortMapping`, `ServiceUnit`, `JobState`, `StackHealth`, `ChildHealthState`, `JobPhase`). Phase 2 will hoist the canonical definitions into `@/contracts` and invert the import direction.
- The seven type-only imports under `src/{components,hooks,dashboards}` are migrated to `@/contracts/*`. `fe-backend-imports` ratchet drops **7 → 0** in `scripts/check-invariants.ts`.
- New ESLint rule `sb/no-fe-backend-import` errors at edit-time when files under `src/components/**`, `src/hooks/**`, `src/dashboards/**` import from `@/lib/{install,agent,diagnose}/**`. Modeled on the existing `sb/no-exec-template-literal` rule.
- `src/contracts/client.ts` adds a `typedFetch<T>(url, schema, init?)` helper that wraps `fetch` with zod parse. Worked example: `Sidebar.tsx`'s `/api/install/status` poll now goes through `typedFetch` + `InstallStatusResponseSchema`. The other ~80 raw fetch call sites stay as-is — Phase 2 handles those.
- `docs/ARCHITECTURE_INVARIANTS.md` boundary section updated to reflect the new ratchet value and the rule.

No backend code moved; no API contracts changed. Phase 1 stands up the seam — Phase 2 starts moving logic across it.

## Verification

| Check | Result |
|---|---|
| `npm run check:arch` | all checks pass; `fe-backend-imports` baseline is 0 |
| `npm run lint` | new `sb/no-fe-backend-import` rule is `error`; manual probe with a violating import fires the rule cleanly |
| `npx tsc --noEmit` | clean |
| `npm test` | 143 files / 1113 tests pass locally (including `OnboardingWizard.test.tsx`, which was flaking on CI — see #757) |

## Test plan

- [x] `npm run check:arch && npm run lint && npx tsc --noEmit && npm test` all green locally
- [x] Sidebar's setup-pill visibility still toggles correctly when an install starts/finishes (smoke-test via the worked example endpoint)
- [ ] CI green (modulo #757 flake)

Closes #756, refs #753
