### PR TITLE
refactor(arch): move template logic server-side (#759)

### DIFF
--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -107,16 +107,16 @@ These are enforced as depcruise rules:
 
 ### Frontend ↔ Backend boundary (#753)
 
-Three ratcheted counts pin how much server-side logic still lives in the frontend. Each one is expected to go **down** as the FE/BE split phases land — never up.
+Three ratcheted counts pin how much server-side logic still lives in the frontend. **All three are capped at 0** as of Phase 2 (#759) — every cross-boundary violation now fails CI. Phase 3 hardens this from a count into a workspace boundary.
 
-- `fe-template-lib-imports` — `js-yaml` / `mustache` imports in `src/components`, `src/hooks`, `src/dashboards`. Currently capped at 1 (the `js-yaml` import in `ServiceForm.tsx` for live editor feedback). Phase 2 routes YAML through `POST /api/services/validate-yaml`.
-- `fe-backend-imports` — imports of `@/lib/install`, `@/lib/agent`, `@/lib/diagnose` from the same dirs. **Capped at 0** as of Phase 1 (#756). The `sb/no-fe-backend-import` ESLint rule enforces the same boundary at edit-time. Phase 3 will move this from a count to a workspace boundary.
-- `fe-install-helpers` — references to `generateRandomSecret` / `parseTemplateDependencies` in the same dirs. Currently capped at 6 (across `useStackInstall.ts` + `StackVariableField.tsx`). Phase 2 moves these into `POST /api/install/configure`.
+- `fe-template-lib-imports` — `js-yaml` / `mustache` imports in `src/components`, `src/hooks`, `src/dashboards`. **Capped at 0** as of Phase 2 (#759); `ServiceForm` validates YAML via `POST /api/services/validate-yaml`.
+- `fe-backend-imports` — imports of `@/lib/install`, `@/lib/agent`, `@/lib/diagnose` from the same dirs. **Capped at 0** as of Phase 1 (#756). The `sb/no-fe-backend-import` ESLint rule enforces the same boundary at edit-time.
+- `fe-install-helpers` — references to `generateRandomSecret` / `parseTemplateDependencies` in the same dirs. **Capped at 0** as of Phase 2 (#759); `useStackInstall` + `StackVariableField` now POST to `/api/install/generate-secret` and `/api/templates/parse-dependencies`.
 
 Frontend code reaches the backend exclusively through:
-- `@/contracts/*` — typed seam. Types + zod schemas live here; `@/contracts/client.ts` wraps `fetch` with schema validation. Phase 1 (#756) stood up the seam.
+- `@/contracts/*` — typed seam. Types + zod schemas live here; `@/contracts/client.ts` wraps `fetch` with schema validation.
 - `@/app/actions/*` — server actions, already typed.
-- Direct `fetch('/api/...')` is grandfathered for the ~80 existing call sites; Phase 2 migrates them onto `typedFetch`.
+- Direct `fetch('/api/...')` is grandfathered for legacy call sites; new code uses `typedFetch`.
 
 ---
 

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -242,9 +242,9 @@ async function checkTwinFanIn() {
 // documented decision (#753 thread).
 // ---------------------------------------------------------------------------
 const FE_DIRS = ['components', 'hooks', 'dashboards'];
-const FE_TEMPLATE_LIB_MAX = 1;     // js-yaml + mustache imports from FE
+const FE_TEMPLATE_LIB_MAX = 0;     // js-yaml + mustache imports from FE — Phase 2 (#759) routed ServiceForm through POST /api/services/validate-yaml
 const FE_BACKEND_IMPORT_MAX = 0;   // imports of @/lib/{install,agent,diagnose} from FE — Phase 1 (#756) routed them through @/contracts; sb/no-fe-backend-import now enforces editor-time
-const FE_INSTALL_HELPER_MAX = 6;   // generateRandomSecret + parseTemplateDependencies refs from FE
+const FE_INSTALL_HELPER_MAX = 0;   // generateRandomSecret + parseTemplateDependencies refs from FE — Phase 2 (#759) routed them through /api/install/generate-secret + /api/templates/parse-dependencies
 
 const inFeDir = (file: string): boolean =>
     FE_DIRS.some(d => file.includes(`${path.sep}src${path.sep}${d}${path.sep}`));

--- a/src/app/api/install/generate-secret/route.ts
+++ b/src/app/api/install/generate-secret/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
+import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+import { GenerateSecretRequestSchema } from '@/contracts/install';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Server-side random-secret generator. Phase 2 of the FE/BE
+ * separation (#759): the frontend no longer imports
+ * `@/lib/stackInstall/randomSecret`. It POSTs here when the install
+ * flow needs to seed a `type: 'secret'` variable, or when the
+ * operator clicks the regenerate button in `StackVariableField`.
+ *
+ * The function itself is portable (`crypto.getRandomValues` exists in
+ * both runtimes), but the policy is that secret-generation lives
+ * server-side as a logic primitive.
+ */
+export const POST = withApiHandler({ body: GenerateSecretRequestSchema }, async ({ body }) => {
+  const secret = generateRandomSecret(body.length);
+  return NextResponse.json({ secret });
+});

--- a/src/app/api/services/validate-yaml/route.ts
+++ b/src/app/api/services/validate-yaml/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import yaml from 'js-yaml';
+import { withApiHandler } from '@/lib/api/handler';
+import { humanizeYamlError } from '@/lib/util/humanizeYamlError';
+import {
+  ValidateYamlRequestSchema,
+  type KubeDocSchema,
+} from '@/contracts/services';
+import type { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Server-side YAML validation for the ServiceForm editor. Phase 2 of
+ * the FE/BE separation (#759): the frontend no longer imports `js-yaml`.
+ * It POSTs the editor content here and gets back either the parsed
+ * manifest or a humanized error.
+ *
+ * The response mirrors the `KubeDoc` shape the form's `extractInfo`
+ * consumes — kept loose (passthrough) because templates routinely
+ * carry fields outside the strict K8s schema (servicebay annotations,
+ * podman-specific extensions, etc).
+ */
+export const POST = withApiHandler({ body: ValidateYamlRequestSchema }, async ({ body }) => {
+  try {
+    const manifest = yaml.load(body.yaml) as z.infer<typeof KubeDocSchema>;
+    return NextResponse.json({ ok: true, manifest: manifest ?? {} });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: humanizeYamlError(e) });
+  }
+});

--- a/src/app/api/templates/parse-dependencies/route.ts
+++ b/src/app/api/templates/parse-dependencies/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
+import { parseTemplateDependencies } from '@/lib/stackInstall/dependencies';
+import { ParseDependenciesRequestSchema } from '@/contracts/install';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Server-side install-time dependency parser. Phase 2 of the FE/BE
+ * separation (#759): the frontend no longer imports
+ * `@/lib/stackInstall/dependencies`. It POSTs raw template yaml and
+ * gets back the `servicebay.dependencies` annotation's contents.
+ *
+ * Empty array on missing / blank annotation — matches the existing
+ * `parseTemplateDependencies` contract.
+ */
+export const POST = withApiHandler({ body: ParseDependenciesRequestSchema }, async ({ body }) => {
+  const dependencies = parseTemplateDependencies(body.yaml);
+  return NextResponse.json({ dependencies });
+});

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import yaml from 'js-yaml';
-import { humanizeYamlError, type HumanizedYamlError } from '@/lib/util/humanizeYamlError';
+import { type HumanizedYamlError } from '@/lib/util/humanizeYamlError';
+import { typedFetch } from '@/contracts/client';
+import { ValidateYamlResponseSchema } from '@/contracts/services';
 import { Settings, FileCode, FileJson, FileText, AlertCircle, Network, HardDrive, Pencil, AlertTriangle, Clock, Server, Clipboard, Loader2, RefreshCw } from 'lucide-react';
 import Editor from 'react-simple-code-editor';
 import Prism from 'prismjs';
@@ -215,17 +216,50 @@ WantedBy=default.target`;
     }
   };
 
+  // Server-side YAML validation. Phase 2 of the FE/BE separation
+  // (#759) — the form no longer imports `js-yaml`. Returns the parsed
+  // manifest on success and null on parse / transport failure (the
+  // error state is set as a side effect so the editor's error UI lights
+  // up either way).
+  const validateYaml = useCallback(async (content: string): Promise<KubeDoc | null> => {
+    try {
+      const result = await typedFetch(
+        '/api/services/validate-yaml',
+        ValidateYamlResponseSchema,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ yaml: content }),
+        },
+      );
+      if (result.ok) {
+        const manifest = result.manifest as KubeDoc;
+        extractInfo(manifest);
+        setYamlError(null);
+        return manifest;
+      }
+      setYamlError(result.error);
+      setExtractedPorts([]);
+      setExtractedVolumes([]);
+      return null;
+    } catch (e) {
+      setYamlError({
+        message: e instanceof Error ? e.message : 'Validation request failed',
+        raw: String(e),
+      });
+      setExtractedPorts([]);
+      setExtractedVolumes([]);
+      return null;
+    }
+  }, []);
+
   const handleYamlChange = (content: string) => {
     setYamlContent(content);
     setYamlError(null);
-
-    try {
-      const parsed = yaml.load(content) as KubeDoc;
-      extractInfo(parsed);
-      
-      if (!isEdit && parsed && parsed.metadata && parsed.metadata.name) {
+    void (async () => {
+      const parsed = await validateYaml(content);
+      if (parsed && !isEdit && parsed.metadata && parsed.metadata.name) {
         const extractedName = parsed.metadata.name;
-        
         if (!name || name === extractedName) {
           setName(extractedName);
           const newFileName = `${extractedName}.yml`;
@@ -233,21 +267,20 @@ WantedBy=default.target`;
           setKubeContent(generateKubeContent(newFileName, autoUpdate, description));
         }
       }
-    } catch (e) {
-      setYamlError(humanizeYamlError(e));
-      setExtractedPorts([]);
-      setExtractedVolumes([]);
-    }
+    })();
   };
 
   useEffect(() => {
-    if (initialData?.yamlContent) {
-        try {
-            const parsed = yaml.load(initialData.yamlContent) as KubeDoc;
-            extractInfo(parsed);
-        } catch {}
-    }
-  }, [initialData]);
+    if (!initialData?.yamlContent) return;
+    let cancelled = false;
+    void (async () => {
+      const parsed = await validateYaml(initialData.yamlContent);
+      if (cancelled || !parsed) return;
+      // extractInfo already fired inside validateYaml on the success path;
+      // nothing more to do here.
+    })();
+    return () => { cancelled = true; };
+  }, [initialData, validateYaml]);
 
   useEffect(() => {
     if (name && yamlFileName) {
@@ -740,14 +773,7 @@ WantedBy=default.target`;
                     onRestore={(content) => {
                         setYamlContent(content);
                         setActiveTab('yaml');
-                        // Trigger validation/extraction logic
-                        try {
-                            const parsed = yaml.load(content) as KubeDoc;
-                            extractInfo(parsed);
-                            setYamlError(null);
-                        } catch (e) {
-                            setYamlError(humanizeYamlError(e));
-                        }
+                        void validateYaml(content);
                     }}
                 />
             )}

--- a/src/components/StackVariableField.tsx
+++ b/src/components/StackVariableField.tsx
@@ -2,7 +2,8 @@
 
 import { RefreshCw } from 'lucide-react';
 import type { VariableMeta } from '@/lib/registry';
-import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+import { typedFetch } from '@/contracts/client';
+import { GenerateSecretResponseSchema } from '@/contracts/install';
 
 interface StackVariable {
   name: string;
@@ -225,7 +226,24 @@ export default function StackVariableField({
         />
         <button
           type="button"
-          onClick={() => onChange(generateRandomSecret())}
+          onClick={async () => {
+            try {
+              const { secret } = await typedFetch(
+                '/api/install/generate-secret',
+                GenerateSecretResponseSchema,
+                {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({}),
+                },
+              );
+              onChange(secret);
+            } catch {
+              // If the server is unreachable mid-edit the operator can
+              // still type a value manually; swallowing keeps the form
+              // responsive instead of throwing into React.
+            }
+          }}
           className="p-2 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
           title="Regenerate"
         >

--- a/src/contracts/install.ts
+++ b/src/contracts/install.ts
@@ -35,3 +35,33 @@ export const InstallStatusResponseSchema = z.object({
   logs: z.string().optional(),
   logsOffset: z.number().optional(),
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/install/generate-secret — Phase 2 (#759). Returns a fresh
+// random secret using the same alphabet/length the install flow has
+// used since #19. Optional `length` lets callers override the default
+// 32 (currently nothing does, but keeps the schema flexible).
+// ---------------------------------------------------------------------------
+
+export const GenerateSecretRequestSchema = z.object({
+  length: z.number().int().positive().max(256).optional(),
+});
+
+export const GenerateSecretResponseSchema = z.object({
+  secret: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/templates/parse-dependencies — Phase 2 (#759). Reads the
+// `servicebay.dependencies` annotation from a raw template.yml and
+// returns the dep names. Trivial wrapper over the server-side
+// `readManifestAnnotations` so the FE doesn't have to parse YAML.
+// ---------------------------------------------------------------------------
+
+export const ParseDependenciesRequestSchema = z.object({
+  yaml: z.string(),
+});
+
+export const ParseDependenciesResponseSchema = z.object({
+  dependencies: z.array(z.string()),
+});

--- a/src/contracts/services.ts
+++ b/src/contracts/services.ts
@@ -1,0 +1,76 @@
+// Service form / YAML manifest contracts. Phase 2 of the FE/BE
+// separation (#759) — frontend stops importing `js-yaml` for the
+// live editor; validation goes through `POST /api/services/validate-yaml`
+// instead.
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// POST /api/services/validate-yaml
+// ---------------------------------------------------------------------------
+
+export const ValidateYamlRequestSchema = z.object({
+  yaml: z.string(),
+});
+
+const HumanizedYamlErrorSchema = z.object({
+  message: z.string(),
+  line: z.number().optional(),
+  column: z.number().optional(),
+  raw: z.string(),
+});
+
+// Parsed manifest fields that ServiceForm extracts. Shape mirrors the
+// `KubeDoc` interface it used to feed into `extractInfo`. Loose where
+// js-yaml is loose — every field is optional so partial / malformed
+// inputs still round-trip without losing what *was* parseable.
+const KubeVolumeSchema = z
+  .object({
+    name: z.string().optional(),
+    hostPath: z.object({ path: z.string().optional() }).optional(),
+    persistentVolumeClaim: z.object({ claimName: z.string().optional() }).optional(),
+  })
+  .passthrough();
+
+const KubeVolumeMountSchema = z
+  .object({
+    name: z.string().optional(),
+    mountPath: z.string().optional(),
+  })
+  .passthrough();
+
+const KubePortSchema = z
+  .object({
+    containerPort: z.number().optional(),
+    hostPort: z.number().optional(),
+    protocol: z.string().optional(),
+  })
+  .passthrough();
+
+const KubeContainerSchema = z
+  .object({
+    name: z.string().optional(),
+    image: z.string().optional(),
+    ports: z.array(KubePortSchema).optional(),
+    volumeMounts: z.array(KubeVolumeMountSchema).optional(),
+  })
+  .passthrough();
+
+export const KubeDocSchema = z
+  .object({
+    kind: z.string().optional(),
+    metadata: z.object({ name: z.string().optional() }).passthrough().optional(),
+    spec: z
+      .object({
+        containers: z.array(KubeContainerSchema).optional(),
+        volumes: z.array(KubeVolumeSchema).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export const ValidateYamlResponseSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), manifest: KubeDocSchema }),
+  z.object({ ok: z.literal(false), error: HumanizedYamlErrorSchema }),
+]);

--- a/src/hooks/useStackInstall.ts
+++ b/src/hooks/useStackInstall.ts
@@ -40,9 +40,12 @@ import {
 } from '@/app/actions';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { type Credential } from '@/lib/stackInstall/credentialsManifest';
-import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
-import { parseTemplateDependencies } from '@/lib/stackInstall/dependencies';
-import type { JobState as RemoteJobState } from '@/contracts/install';
+import { typedFetch } from '@/contracts/client';
+import {
+  GenerateSecretResponseSchema,
+  ParseDependenciesResponseSchema,
+  type JobState as RemoteJobState,
+} from '@/contracts/install';
 
 export type StackInstallPhase = 'idle' | 'configure' | 'installing' | 'done' | 'error';
 
@@ -548,7 +551,20 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
           // Parse install-time deps from the (still un-rendered) yaml.
           // Mustache placeholders don't appear in the dependencies
           // annotation, so the raw string is fine here.
-          newItems[idx].dependencies = parseTemplateDependencies(yaml);
+          try {
+            const { dependencies } = await typedFetch(
+              '/api/templates/parse-dependencies',
+              ParseDependenciesResponseSchema,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ yaml }),
+              },
+            );
+            newItems[idx].dependencies = dependencies;
+          } catch {
+            newItems[idx].dependencies = [];
+          }
         }
 
         for (const match of yaml.matchAll(MUSTACHE_VAR_RE_OUT)) vars.add(match[1]);
@@ -586,34 +602,50 @@ export function useStackInstall(options: UseStackInstallOptions): UseStackInstal
     // values that already came from storage are already saved by definition.
     const newlyGenerated: Array<{ name: string; value: string }> = [];
 
-    const resolvedVars: StackVariable[] = Array.from(vars).map(name => {
-      const meta = allMeta[name];
-      // Caller-provided prefills (PUBLIC_DOMAIN, NGINX_ADMIN_EMAIL, ...)
-      // win over Settings; LLDAP_HOST is always 'localhost' because every
-      // template assumes the auth pod is reachable via the local stack.
-      let value = '';
-      let isGlobal = false;
-      if (Object.prototype.hasOwnProperty.call(prefilled, name) && prefilled[name]) {
-        value = prefilled[name];
-        isGlobal = true;
-      } else if (globalSettings[name]) {
-        value = globalSettings[name];
-        isGlobal = true;
-      }
-      if (name === 'LLDAP_HOST') { value = 'localhost'; isGlobal = true; }
-      if (!value && meta?.default) value = meta.default;
-      if (!value && meta?.type === 'secret') {
-        // On a reinstall without RESET, use the stored value if available so
-        // services with existing data volumes keep the password they know.
-        if (storedValues[name]) {
-          value = storedValues[name];
-        } else {
-          value = generateRandomSecret();
-          newlyGenerated.push({ name, value });
+    const resolvedVars: StackVariable[] = await Promise.all(
+      Array.from(vars).map(async (name): Promise<StackVariable> => {
+        const meta = allMeta[name];
+        // Caller-provided prefills (PUBLIC_DOMAIN, NGINX_ADMIN_EMAIL, ...)
+        // win over Settings; LLDAP_HOST is always 'localhost' because every
+        // template assumes the auth pod is reachable via the local stack.
+        let value = '';
+        let isGlobal = false;
+        if (Object.prototype.hasOwnProperty.call(prefilled, name) && prefilled[name]) {
+          value = prefilled[name];
+          isGlobal = true;
+        } else if (globalSettings[name]) {
+          value = globalSettings[name];
+          isGlobal = true;
         }
-      }
-      return { name, value, global: isGlobal, meta };
-    });
+        if (name === 'LLDAP_HOST') { value = 'localhost'; isGlobal = true; }
+        if (!value && meta?.default) value = meta.default;
+        if (!value && meta?.type === 'secret') {
+          // On a reinstall without RESET, use the stored value if available so
+          // services with existing data volumes keep the password they know.
+          if (storedValues[name]) {
+            value = storedValues[name];
+          } else {
+            try {
+              const { secret } = await typedFetch(
+                '/api/install/generate-secret',
+                GenerateSecretResponseSchema,
+                {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({}),
+                },
+              );
+              value = secret;
+              newlyGenerated.push({ name, value });
+            } catch {
+              // Server unreachable mid-configure — leave value empty and
+              // let the operator type one manually.
+            }
+          }
+        }
+        return { name, value, global: isGlobal, meta };
+      }),
+    );
 
     // RSA private keys — server-generated, PEM pre-indented for YAML block scalars.
     await Promise.all(resolvedVars.map(async v => {

--- a/tests/frontend/useStackInstall.test.tsx
+++ b/tests/frontend/useStackInstall.test.tsx
@@ -48,6 +48,20 @@ import { useStackInstall } from '@/hooks/useStackInstall';
  * handler returns either `{ ok, jsonBody }` for a plain JSON response
  * or `{ ok, streamLines }` for an NDJSON stream.
  */
+// Built-in defaults for endpoints the hook calls during configure
+// (#759 — Phase 2 moved secret generation and dep parsing server-side).
+// Tests that don't override these get the same behaviour the FE used
+// to have inline: a 32-char alnum secret + an empty deps list.
+function makeRandomSecret(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+}
+
+const PHASE2_DEFAULTS: Record<string, () => { jsonBody: any }> = {
+  '/api/install/generate-secret': () => ({ jsonBody: { secret: makeRandomSecret() } }),
+  '/api/templates/parse-dependencies': () => ({ jsonBody: { dependencies: [] } }),
+};
+
 function buildFetchMock(
   handlers: Record<string, (init?: RequestInit) => {
     ok?: boolean;
@@ -56,8 +70,9 @@ function buildFetchMock(
     streamLines?: string[];
   }>,
 ) {
+  const merged = { ...PHASE2_DEFAULTS, ...handlers };
   return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
-    for (const [prefix, handler] of Object.entries(handlers)) {
+    for (const [prefix, handler] of Object.entries(merged)) {
       if (url.startsWith(prefix) || url.includes(prefix)) {
         const result = handler(init);
         const ok = result.ok ?? true;

--- a/tests/frontend/useStackInstall.test.tsx
+++ b/tests/frontend/useStackInstall.test.tsx
@@ -57,18 +57,20 @@ function makeRandomSecret(): string {
   return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
 }
 
-const PHASE2_DEFAULTS: Record<string, () => { jsonBody: any }> = {
+type FetchMockResult = {
+  ok?: boolean;
+  status?: number;
+  jsonBody?: any;
+  streamLines?: string[];
+};
+
+const PHASE2_DEFAULTS: Record<string, () => FetchMockResult> = {
   '/api/install/generate-secret': () => ({ jsonBody: { secret: makeRandomSecret() } }),
   '/api/templates/parse-dependencies': () => ({ jsonBody: { dependencies: [] } }),
 };
 
 function buildFetchMock(
-  handlers: Record<string, (init?: RequestInit) => {
-    ok?: boolean;
-    status?: number;
-    jsonBody?: any;
-    streamLines?: string[];
-  }>,
+  handlers: Record<string, (init?: RequestInit) => FetchMockResult>,
 ) {
   const merged = { ...PHASE2_DEFAULTS, ...handlers };
   return vi.fn().mockImplementation((url: string, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

Phase 2 of the FE/BE separation (#753). Three logic primitives that ran client-side now live behind typed endpoints; the FE consumes them through `@/contracts/client`. Both remaining boundary ratchets drop to **0**.

### Endpoints (all `withApiHandler` + zod-validated)

| Endpoint | Replaces | Used by |
|---|---|---|
| `POST /api/services/validate-yaml` | inline `yaml.load()` for editor feedback | `ServiceForm.tsx` |
| `POST /api/install/generate-secret` | `generateRandomSecret()` for `type: secret` vars + the regenerate button | `useStackInstall.ts`, `StackVariableField.tsx` |
| `POST /api/templates/parse-dependencies` | `parseTemplateDependencies(yaml)` for install-order resolution | `useStackInstall.ts` |

### FE changes

- `ServiceForm.tsx` no longer imports `js-yaml`. Three sync parse sites collapse into one async `validateYaml` helper.
- `StackVariableField.tsx`'s regenerate button `await`s the server.
- `useStackInstall.ts`'s configure flow `await`s the two new endpoints; sync variable resolution becomes `await Promise.all(...)`.

### Ratchets

| Check | Before | After |
|---|---:|---:|
| `fe-template-lib-imports` | 1 | **0** |
| `fe-backend-imports` | 0 (Phase 1) | 0 |
| `fe-install-helpers` | 6 | **0** |

All three FE→BE counts are now capped at 0 — boundary is fully numeric-enforced. Phase 3 hardens this into a workspace boundary.

### Tests

`tests/frontend/useStackInstall.test.tsx` gets `PHASE2_DEFAULTS` so the existing fetch mock answers the new endpoints with shape-valid responses by default. All 143 test files / 1113 tests pass locally.

## Verification

| Check | Result |
|---|---|
| `npm run check:arch` | clean; all three FE→BE counts at 0 |
| `npm run lint` | no new errors |
| `npx tsc --noEmit` | clean |
| `npm test` | 143/143 files pass, 1113 tests |

## Test plan

- [x] `npm run check:arch && npm run lint && npx tsc --noEmit && npm test` all green locally
- [ ] Smoke-test the ServiceForm editor: YAML changes still light up the error UI and auto-populate the name field.
- [ ] Smoke-test the wizard configure step: `type: secret` vars auto-populate, dependency ordering still works.
- [ ] CI green (modulo #757 flake)

Closes #759, refs #753
