### PR TITLE
fix(docker): point agent COPY at new package + ship scripts dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,13 +93,18 @@ COPY --from=builder /app/CHANGELOG.md ./CHANGELOG.md
 # server.ts is folded into dist-server/server.cjs by scripts/build-server.mjs.
 COPY --from=builder /app/dist-server ./dist-server
 
-# Python agent script — streamed over SSH to each managed node and executed
-# there. Read at runtime by src/lib/agent/handler.ts (path resolved with
-# `process.cwd() + 'src/lib/agent/v4/agent.py'`), so it must exist at that
-# exact path inside the runner image. Not bundled into dist-server because
-# it's Python, not JS, and not invoked locally.
-COPY --from=builder /app/src/lib/agent/v4/agent.py ./src/lib/agent/v4/agent.py
-COPY --from=builder /app/src/lib/agent/v4/quadlet_parser.py ./src/lib/agent/v4/quadlet_parser.py
+# Python agent + shell scripts streamed over SSH to each managed node.
+# Read at runtime by packages/backend/src/lib/agent/handler.ts with paths
+# resolved via `process.cwd() + 'src/lib/agent/v4/...'`, so the container-
+# internal destination stays as `/app/src/lib/agent/v4/` even though the
+# source moved into the backend workspace in #767. Scripts dir is part of
+# the same fix that adds `nginx_inspector.sh` (extracted from inline JS in
+# #750 — never made it into the Docker image until now, which is why
+# `SSH agent startup failed: ENOENT … nginx_inspector.sh` shows up at
+# agent boot).
+COPY --from=builder /app/packages/backend/src/lib/agent/v4/agent.py ./src/lib/agent/v4/agent.py
+COPY --from=builder /app/packages/backend/src/lib/agent/v4/quadlet_parser.py ./src/lib/agent/v4/quadlet_parser.py
+COPY --from=builder /app/packages/backend/src/lib/agent/v4/scripts ./src/lib/agent/v4/scripts
 
 # Copy production node_modules (with built native modules)
 COPY --from=prod-deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary

Two related bugs in the runtime container image, surfaced together when a real 4.x install stalled mid-setup with:

\`\`\`
SSH agent startup failed: ENOENT: no such file or directory,
open '/app/src/lib/agent/v4/scripts/nginx_inspector.sh'
\`\`\`

The SSH agent boot fails, no agent → reset call has nothing to wipe → operator sees \"Reset failed: Internal error\" and the install aborts.

### Bug 1 — \`scripts/\` dir never reached the image (pre-existing since #750)

When #750 extracted the inline nginx-inspector shell into a real \`.sh\` file, the Dockerfile picked up \`agent.py\` and \`quadlet_parser.py\` with explicit COPY lines but didn't add anything for the new \`scripts/\` dir. Every build since then has produced a runner image missing \`nginx_inspector.sh\`.

### Bug 2 — Source paths went stale after Phase 3.3 (#767, this session)

Phase 3.3 moved \`src/lib/\` → \`packages/backend/src/lib/\`, but Dockerfile lines 101–102 still read \`/app/src/lib/agent/v4/agent.py\` etc. as their COPY source. A fresh \`podman build\` from current main would fail at COPY (the source no longer exists in the builder stage).

The container-internal *destination* stays at \`./src/lib/agent/v4/\` because \`handler.ts\` resolves runtime paths via \`process.cwd() + 'src/lib/agent/v4/agent.py'\`. Keeping the destination put avoids a second runtime-path change.

### Fix

- Re-point the three COPY sources at \`packages/backend/src/lib/agent/v4/\`.
- Add one COPY for the whole \`scripts/\` directory so future extractions don't need per-file follow-ups.

### Verification

| Check | Result |
|---|---|
| \`podman build -t servicebay-test:fix .\` | clean build |
| \`podman run --rm servicebay-test:fix ls /app/src/lib/agent/v4/scripts/\` | \`nginx_inspector.sh\` present |
| \`agent.py\` + \`quadlet_parser.py\` | present at expected path |

### Test plan

- [x] Local Docker build succeeds
- [x] Inspected runner image contents
- [ ] CI green
- [ ] Deploy and confirm SSH agent boots cleanly (\"SSH connection established, starting Python agent...\" without the ENOENT line)