### PR TITLE
fix(docker): install workspace prod deps + allow pre-seeded install secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,14 @@ FROM base AS prod-deps
 WORKDIR /app
 # Base image already has python3 make g++
 COPY package.json package-lock.json* ./
+# Workspace package manifests — `npm ci` against a workspace root needs
+# each member's package.json present so it can resolve their deps too.
+# Without these copies, runtime modules listed in packages/*/package.json
+# (ssh2, better-sqlite3, node-pty, etc. after #767) silently drop out of
+# the runner image and the custom server crashes on first import.
+COPY packages/api-client/package.json ./packages/api-client/package.json
+COPY packages/backend/package.json ./packages/backend/package.json
+COPY packages/frontend/package.json ./packages/frontend/package.json
 # Install prod deps (builds native modules). tsx/typescript are no longer
 # needed at runtime because the custom server is pre-bundled to CJS.
 RUN npm ci --omit=dev

--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -16,6 +16,29 @@ IGNITION_OUT="$BUILD_DIR/install.ign"
 
 mkdir -p "$BUILD_DIR"
 
+# Pre-seed env vars from the gitignored settings file so any secrets
+# the operator (or a debug workflow) stored there land in the
+# environment before `prompt_secret` / `prompt_optional_secret`
+# decide whether to ask. We can't `source` the file because values
+# routinely contain spaces (e.g. SSH_AUTHORIZED_KEY = "ssh-rsa AAAA…
+# user@host"); a plain `source` would treat the trailing tokens as
+# commands. Read the file KEY=VALUE-line by line instead — the value
+# after the first `=` is preserved verbatim with no shell expansion.
+# The file is in `.gitignore` (entry `/build`) so its contents — pwds,
+# tokens, etc — never reach source control. Downstream `prompt`s still
+# fire normally for anything not pre-seeded.
+if [[ -f "$BUILD_DIR/install-settings.env" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    [[ -z "$key" ]] && continue
+    printf -v "$key" '%s' "$value"
+    export "$key"
+  done < "$BUILD_DIR/install-settings.env"
+  unset key value line
+fi
+
 # Embedded Butane Template
 cat <<'EOF' > "$TEMPLATE"
 variant: fcos
@@ -1315,6 +1338,21 @@ prompt_secret() {
   local var_name="$1"; shift
   local prompt_text="$1"; shift
   local value value_confirm
+  # Skip the interactive prompt if the variable is already non-empty in
+  # the environment — lets operators (and debug workflows) pre-seed
+  # passwords via the gitignored install-settings.env, which gets
+  # sourced at script start. The validation below still runs so an
+  # invalid pre-seeded password is rejected the same way an interactive
+  # one would be.
+  if [[ -n "${!var_name}" ]]; then
+    value="${!var_name}"
+    if [[ "$value" == *$'\n'* || "$value" == *'"'* || "$value" == *'\'* || "$value" == *'$'* || "$value" == *'`'* ]]; then
+      echo "Pre-seeded $var_name contains characters that break the install pipeline (newline, quote, backslash, \$ or backtick)." >&2
+      exit 1
+    fi
+    echo "Using pre-seeded $var_name from environment."
+    return
+  fi
   while true; do
     read -r -s -p "$prompt_text: " value || true
     echo
@@ -1345,6 +1383,13 @@ prompt_optional_secret() {
   local var_name="$1"; shift
   local prompt_text="$1"; shift
   local value
+  # Same env-var pre-seed pattern as `prompt_secret` — lets the gitignored
+  # install-settings.env carry tokens for unattended/debug runs without
+  # ever putting them in source control.
+  if [[ -n "${!var_name}" ]]; then
+    echo "Using pre-seeded $var_name from environment."
+    return
+  fi
   read -r -s -p "$prompt_text: " value || true
   echo
   printf -v "$var_name" '%s' "$value"


### PR DESCRIPTION
Two regressions surfaced when running ghcr.io/mdopp/servicebay:latest directly to debug a stalled real-box install.

**Bug 1 — runtime crash `Cannot find module 'ssh2'`**: Phase 3.3 (#767) moved backend-only runtime deps (ssh2, better-sqlite3, node-pty, nodemailer, gray-matter, semver, elkjs) out of root `package.json` into `packages/backend/package.json`. The Docker `prod-deps` stage only copies the root manifest before `npm ci --omit=dev`, so the workspace package.jsons aren't visible to npm. Native modules drop out of the runner image, `dist-server/server.cjs` throws on first `require('ssh2')`. Fix: copy each workspace `package.json` into prod-deps before `npm ci` so npm hoists shared deps to root `node_modules`.

**Bug 2 — installer re-prompts for secrets**: `build/fcos/install-settings.env` (gitignored) can pre-seed non-secret install settings, but `prompt_secret` / `prompt_optional_secret` always re-prompt. Fix: both helpers now honor a non-empty env var with the same validation as the interactive path. The installer pre-seeds env vars by parsing the file line-by-line (can't `source` — values like the SSH key have spaces).

## Verification

| Check | Before | After |
|---|---|---|
| `podman run ghcr.io/.../servicebay:latest` | crash | boots, HTTP / → 307 |
| `node_modules/ssh2` | missing | present |
| `/api/*` endpoints | 5xx / refused | 401 auth-gate |
| Agent script paths | ENOENT (covered by #770 only for COPY source) | resolves |

Refs #770.