### PR TITLE
fix(agent): only replace sentinel inside r"""…""", not in comments

### DIFF
--- a/packages/backend/src/lib/agent/handler.ts
+++ b/packages/backend/src/lib/agent/handler.ts
@@ -62,13 +62,23 @@ function inlineAgentScripts(agentSource: string): string {
     if (!out.includes(sentinel)) continue;
     const scriptPath = path.join(process.cwd(), relativePath);
     const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-    // `replaceAll(string, string)` interprets `$&` / `$$` / `$<n>`
+    // Match the full `r"""<sentinel>"""` Python wrapper, not the
+    // bare sentinel. The bare token shows up in comments too
+    // (e.g. `# substitutes into the @@SENTINEL@@ below…`), and a
+    // bare-string replace would inline the script there as well —
+    // turning the comment's remainder into raw shell that crashes
+    // Python with `SyntaxError: invalid syntax`. Matching
+    // `r"""…"""` means we only ever substitute inside the actual
+    // string literal.
+    //
+    // `replaceAll(string, string)` would interpret `$&` / `$$` / `$<n>`
     // in the replacement — shell scripts contain `$1`, `$file`,
     // `$(...)` everywhere, so we'd corrupt the contents. The
     // callback form bypasses that substitution: the inserted text
     // is verbatim regardless of `$` characters in it.
-    const pattern = new RegExp(sentinel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
-    out = out.replace(pattern, () => scriptContent);
+    const escaped = sentinel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`r"""${escaped}"""`, 'g');
+    out = out.replace(pattern, () => `r"""${scriptContent}"""`);
   }
   return out;
 }

--- a/scripts/test-container-e2e.sh
+++ b/scripts/test-container-e2e.sh
@@ -207,7 +207,7 @@ probe POST /api/services/validate-yaml '{"yaml":"apiVersion: v1\nkind: Pod\nmeta
 #    indicate a real bug.
 # -----------------------------------------------------------------------------
 echo "→ scanning late logs for regression signatures"
-LATE_SIGS='Argument list too long|MODULE_NOT_FOUND|Failed to decrypt secret'
+LATE_SIGS='Argument list too long|MODULE_NOT_FOUND|Failed to decrypt secret|SyntaxError: invalid syntax|Agent Closed\. Code: 1'
 if podman logs "$CONTAINER" 2>&1 | grep -qE "$LATE_SIGS"; then
   podman logs "$CONTAINER" 2>&1 | grep -E "$LATE_SIGS" | head -5
   fail "regression signatures in late logs (see above)" 3


### PR DESCRIPTION
Companion fix to #773. The agent gzip fix in #773 let the script through MAX_ARG_STRLEN, exposing a sister bug:

`inlineAgentScripts` did a global bare-string replace for `@@NGINX_INSPECTOR_SCRIPT@@`. But agent.py mentions the sentinel **twice** — once in the actual `r"""…"""` string literal (the intended target), and once in a comment three lines above it (`# substitutes into the @@…@@ sentinel below…`). The global replace hit both. Inlining shell into the comment turned the rest of the file into a mix of Python comments + raw shell. The agent crashed with:

```
SyntaxError: invalid syntax
  File "<string>", line 1528
    echo "["
         ^^^
```

Operator-facing symptom: `Agent Closed. Code: 1` → reset endpoint can't run → install aborts with **"Reset failed: Internal error"** — same wizard error as before the gzip fix, different root cause.

## Fix

Match the full Python wrapper `r"""<sentinel>"""` instead of the bare sentinel. Comments are now ignored; only the string literal gets substituted.

## Test guard

`scripts/test-container-e2e.sh`'s late-log scan now includes `SyntaxError: invalid syntax` and `Agent Closed. Code: 1` so this class of regression fails the e2e immediately next time.

## Verification

- Inlined output now keeps line 1508's comment intact and only substitutes into `INSPECTOR_SCRIPT = r"""…"""` at line 1514.
- `python3 -c 'compile(...)'` on the gzipped+base64 wire payload returns OK (was `SyntaxError` on the broken inliner).
- `scripts/test-container-e2e.sh` against the rebuilt image → all probes green; late-log scan finds no regression signatures.

Refs #773.