### PR TITLE
fix(diagnose): OIDC probe false-positive 500 + stale log classifier (#781)

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import { getConfig } from '@/lib/config';
-import { checkOidcProviderReachable, classifyAutheliaLogs } from './oidcProviderReachable';
+import { checkOidcProviderReachable, classifyAutheliaLogs, trimToCurrentStartup } from './oidcProviderReachable';
 
 const baseConfig = {
   reverseProxy: { publicDomain: 'example.com' },
@@ -72,6 +72,28 @@ describe('oidc_provider_reachable probe', () => {
     })));
     const r = await checkOidcProviderReachable();
     expect(r.status).toBe('ok');
+  });
+
+  // #781 — Authelia derives its effective issuer from Host +
+  // X-Forwarded-Proto. Without those, a healthy install answers
+  // HTTP 500 to a plain `127.0.0.1` GET. The probe must look like
+  // proxied traffic.
+  it('sends X-Forwarded-Proto: https and Host: auth.<publicDomain>', async () => {
+    vi.mocked(getConfig).mockResolvedValue(baseConfig as never);
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      new Response(JSON.stringify(validDiscovery), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await checkOidcProviderReachable();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Forwarded-Proto']).toBe('https');
+    expect(headers['Host']).toBe('auth.example.com');
+    expect(headers['X-Forwarded-Host']).toBe('auth.example.com');
   });
 
   // Regression for #622: probe must FAIL when Authelia returns 502 —
@@ -168,5 +190,56 @@ describe('classifyAutheliaLogs', () => {
   it('matches storage drift', () => {
     const logs = 'fatal error: unable to decrypt the storage encryption key';
     expect(classifyAutheliaLogs(logs).category).toBe('storage');
+  });
+
+  // #781 — stale errors from a previous process must not outvote
+  // the current process's actual state. A startup banner resets the
+  // classification window.
+  it('ignores LDAP errors that precede the most recent startup banner', () => {
+    const logs = [
+      'time="2026-05-20T10:00:00Z" level=error msg="LDAP Result Code 49 Invalid Credentials"',
+      'time="2026-05-21T08:00:00Z" level=info msg="Authelia v4.39.19 is starting"',
+      'time="2026-05-21T08:00:01Z" level=info msg="Listening on 0.0.0.0:9091"',
+    ].join('\n');
+    expect(classifyAutheliaLogs(logs).category).toBe('unknown');
+  });
+
+  it('still classifies errors that appear after the startup banner', () => {
+    const logs = [
+      'time="2026-05-21T08:00:00Z" level=info msg="Authelia v4.39.19 is starting"',
+      'time="2026-05-21T08:00:01Z" level=error msg="LDAP Result Code 49 Invalid Credentials"',
+    ].join('\n');
+    expect(classifyAutheliaLogs(logs).category).toBe('ldap');
+  });
+});
+
+describe('trimToCurrentStartup', () => {
+  it('returns input unchanged when no banner is present', () => {
+    const logs = 'level=error msg="something broke"\nlevel=warn msg="another thing"';
+    expect(trimToCurrentStartup(logs)).toBe(logs);
+  });
+
+  it('trims everything before the banner when one is present', () => {
+    const logs = [
+      'level=error msg="old failure"',
+      'level=info msg="Authelia v4.39.19 is starting"',
+      'level=info msg="ready"',
+    ].join('\n');
+    const trimmed = trimToCurrentStartup(logs);
+    expect(trimmed).not.toContain('old failure');
+    expect(trimmed).toContain('is starting');
+    expect(trimmed).toContain('ready');
+  });
+
+  it('uses the LAST banner when several are present (process restarts)', () => {
+    const logs = [
+      'level=info msg="Authelia v4.39.18 is starting"',
+      'level=error msg="first-boot error"',
+      'level=info msg="Authelia v4.39.19 is starting"',
+      'level=info msg="post-restart line"',
+    ].join('\n');
+    const trimmed = trimToCurrentStartup(logs);
+    expect(trimmed).not.toContain('first-boot error');
+    expect(trimmed).toContain('post-restart line');
   });
 });

--- a/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.ts
+++ b/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.ts
@@ -73,18 +73,62 @@ function buildDiscoveryUrl(): string {
   return `http://127.0.0.1:${effective}/.well-known/openid-configuration`;
 }
 
+/** Headers that make the local-loopback probe look like real
+ *  proxied traffic. Authelia derives its effective issuer from
+ *  Host + X-Forwarded-Proto; without these it returns HTTP 500
+ *  with "invalid X-Forwarded-Proto header value 'http'" even on
+ *  a perfectly healthy install. The `publicDomain` argument is
+ *  the wizard-configured apex (e.g. `dopp.cloud`); the issuer
+ *  template in `configuration.yml.mustache` is always
+ *  `https://auth.<publicDomain>`. */
+function buildDiscoveryHeaders(publicDomain: string): Record<string, string> {
+  return {
+    Accept: 'application/json',
+    Host: `auth.${publicDomain}`,
+    'X-Forwarded-Proto': 'https',
+    'X-Forwarded-Host': `auth.${publicDomain}`,
+  };
+}
+
+/** Authelia prints exactly one banner per process start that names
+ *  the version and "is starting" — keep the regex narrow so a log
+ *  line mentioning the word "starting" elsewhere doesn't get
+ *  treated as a banner. */
+const STARTUP_BANNER_RE = /Authelia v[\d.]+\s+is starting/i;
+
+/** Trim `logs` to only the lines emitted since the most recent
+ *  Authelia startup banner. If no banner is present (truncated
+ *  tail), return the original logs unchanged — better to classify
+ *  on stale data than to classify on nothing. */
+export function trimToCurrentStartup(logs: string): string {
+  const lines = logs.split('\n');
+  let lastBanner = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (STARTUP_BANNER_RE.test(lines[i])) {
+      lastBanner = i;
+      break;
+    }
+  }
+  if (lastBanner < 0) return logs;
+  return lines.slice(lastBanner).join('\n');
+}
+
 /** Pattern-match Authelia log tail into a category. The first match
  *  wins; storage/config patterns are checked before LDAP because LDAP
  *  errors often appear as side-effects of a broken config (the bind
- *  string never gets evaluated). */
+ *  string never gets evaluated). The classifier scopes itself to log
+ *  lines since the most-recent startup banner — pre-restart errors
+ *  (e.g. a stale "Invalid Credentials" from before a wipe) must not
+ *  outvote the current process's actual state. */
 export function classifyAutheliaLogs(logs: string): {
   category: OidcFailCategory;
   summary: string;
 } {
-  const trimmed = logs.trim();
-  if (!trimmed) {
+  const scoped = trimToCurrentStartup(logs).trim();
+  if (!scoped) {
     return { category: 'unknown', summary: 'Authelia logs were empty' };
   }
+  const trimmed = scoped;
   // Storage / encryption key drift — single most painful failure
   // mode (preserved DB + new install = decrypt failure on every
   // boot). Authelia logs this as a fatal-level error referencing
@@ -163,11 +207,12 @@ export async function checkOidcProviderReachable(nodeName: string = 'Local'): Pr
   }
 
   const url = buildDiscoveryUrl();
+  const headers = buildDiscoveryHeaders(cfg.reverseProxy.publicDomain);
   let response: Response;
   try {
     response = await fetch(url, {
       method: 'GET',
-      headers: { Accept: 'application/json' },
+      headers,
       signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
     });
   } catch (e) {


### PR DESCRIPTION
Closes #781.

## Summary

Two bugs stacked on each other made `oidc_provider_reachable` fire FAIL on perfectly healthy installs:

1. **Probe didn't send `X-Forwarded-Proto: https` / `Host: auth.<publicDomain>`.** Authelia derives its effective issuer from those headers; a plain-loopback GET makes it answer HTTP 500 `invalid X-Forwarded-Proto header value 'http'`. The probe now sets `Host`, `X-Forwarded-Proto: https`, and `X-Forwarded-Host` so it looks like real NPM traffic. Issuer template in `templates/auth/configuration.yml.mustache` is always `https://auth.<publicDomain>`, so the host is reconstructed deterministically.
2. **`classifyAutheliaLogs` grepped a time-unbounded tail.** Stale `Invalid Credentials` / `LDAP Result Code 49` lines from before a reinstall outvoted the current process's actual state. New `trimToCurrentStartup()` slices the tail at the most-recent `Authelia v… is starting` banner so only the current process's log lines feed the classifier.

## Verification

Local: `npx vitest run packages/backend/src/lib/diagnose/probes/oidcProviderReachable.test.ts` — 18 tests pass (3 new — headers shape, banner-scoped classifier, banner picker).

Live box (192.168.178.100): built the bundle into a patch image, restarted servicebay, re-ran `/api/system/diagnose`:
- Before: `status: "fail"`, detail `Authelia OIDC discovery returned HTTP 500 (expected 200) … Cause: LDAP bind to LLDAP is failing.` (false positive — direct `curl -H 'X-Forwarded-Proto: https' -H 'Host: auth.dopp.cloud'` returned HTTP 200 with the full discovery JSON).
- After: `status: "ok"`, detail `Authelia OIDC discovery answers 200 with a valid configuration document.`

Box was reverted to `ghcr.io/mdopp/servicebay:latest` after verification — the fix returns once this PR lands and release-please cuts the next image.

## Test plan
- [x] `npx vitest run packages/backend/src/lib/diagnose/probes/oidcProviderReachable.test.ts` — green
- [x] `npx tsc -b packages/backend` — clean
- [x] `npm run check:arch` — clean
- [x] Verified on live box at 192.168.178.100

🤖 Generated with [Claude Code](https://claude.com/claude-code)