### PR TITLE
refactor(api): withApiHandler cluster — access-requests + storage + action-stream (#603)

### DIFF
--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -166,10 +166,10 @@ async function checkExecTemplateLiterals() {
 // Routes that hand-roll their own try/catch + envelope drift apart. The
 // abstraction in src/lib/api/handler.ts is the SoT. Should monotonically
 // increase; ratchet up after each cluster migration so any regression
-// fails CI immediately. Current run: 12/104 routes (~11%) after the
-// settings cluster landed in #603.
+// fails CI immediately. Current run: 36/108 routes (~33%) after the
+// access-requests + storage + action-stream cluster landed.
 // ---------------------------------------------------------------------------
-const MIN_WITH_API_HANDLER_RATIO = 0.15;
+const MIN_WITH_API_HANDLER_RATIO = 0.30;
 
 async function checkWithApiHandlerAdoption() {
     const routeFiles = await walk(path.join(SRC, 'app', 'api'), p => p.endsWith('/route.ts'));

--- a/src/app/api/services/[name]/action-stream/route.ts
+++ b/src/app/api/services/[name]/action-stream/route.ts
@@ -1,185 +1,176 @@
 
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getExecutor } from '@/lib/executor';
 import { listNodes } from '@/lib/nodes';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { agentManager } from '@/lib/agent/manager';
 import { ServiceName } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import yaml from 'js-yaml';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
-) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const Body = z.object({
+  action: z.enum(['start', 'stop', 'restart']).default('start'),
+}).default({ action: 'start' });
 
-  const parsed = await parseRouteParam(params, 'name', ServiceName);
-  if (!parsed.ok) return parsed.response;
-  const name = parsed.value;
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node');
-  
-  // Parse body for action
-  let action = 'start';
-  try {
-      const body = await request.json();
-      if (body.action) action = body.action;
-  } catch {
-      // Ignore if body is empty/invalid, default to start (backward compatibility if needed)
-  }
+const Query = z.object({ node: z.string().optional() });
 
-  const encoder = new TextEncoder();
-  const stream = new TransformStream();
-  const writer = stream.writable.getWriter();
-  let writerClosed = false;
+type Params = { name: string };
 
-  const write = async (msg: string) => {
-    if (writerClosed) return;
-    try {
-      await writer.write(encoder.encode(msg + '\r\n'));
-    } catch {
-      // Client aborted — stop attempting to write to a closed stream.
-      writerClosed = true;
+export const POST = withApiHandlerParams<z.infer<typeof Body>, z.infer<typeof Query>, Params>(
+  { body: Body, query: Query },
+  async ({ body, query, params }) => {
+    const nameCheck = ServiceName.safeParse(decodeURIComponent(params.name));
+    if (!nameCheck.success) {
+      return NextResponse.json({ error: 'invalid name' }, { status: 400 });
     }
-  };
+    const name = nameCheck.data;
+    const nodeName = query.node;
+    const action = body.action;
 
-  const writeRaw = async (msg: string) => {
-    if (writerClosed) return;
-    try {
-      await writer.write(encoder.encode(msg));
-    } catch {
-      writerClosed = true;
-    }
-  };
+    const encoder = new TextEncoder();
+    const stream = new TransformStream();
+    const writer = stream.writable.getWriter();
+    let writerClosed = false;
 
-  (async () => {
-    try {
-      let connection;
-      if (nodeName) {
-          const nodes = await listNodes();
-          connection = nodes.find(n => n.Name === nodeName);
-      }
-      
-      const executor = getExecutor(connection);
-
-      const streamNodeName = nodeName || connection?.Name || 'Local';
-
-      if (action === 'start') {
-          const { yamlPath } = await ServiceManager.getServiceFiles(streamNodeName, name);
-
-          if (yamlPath) {
-            await write(`Found YAML configuration: ${yamlPath}`);
-            const content = await executor.readFile(yamlPath);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const parsed = yaml.load(content) as any;
-            
-            const images = new Set<string>();
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const findImages = (obj: any) => {
-                if (!obj) return;
-                if (obj.image && typeof obj.image === 'string') images.add(obj.image);
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                if (Array.isArray(obj.containers)) obj.containers.forEach((c: any) => findImages(c));
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                if (Array.isArray(obj.initContainers)) obj.initContainers.forEach((c: any) => findImages(c));
-                if (obj.spec) findImages(obj.spec);
-                if (obj.template) findImages(obj.template);
-            };
-            findImages(parsed);
-
-            if (images.size > 0) {
-                await write(`Found ${images.size} images to pull...`);
-                const agent = await agentManager.ensureAgent(streamNodeName);
-                for (const image of images) {
-                    await write(`Pulling ${image}...`);
-                    try {
-                        await agent.pullImage(image, async (evt) => {
-                            if (evt.id && evt.status) {
-                                if (evt.total && evt.current !== undefined) {
-                                    const currentMB = (evt.current / 1048576).toFixed(1);
-                                    const totalMB = (evt.total / 1048576).toFixed(1);
-                                    const pct = Math.round(evt.current / evt.total * 100);
-                                    await write(`  Layer ${evt.id.slice(0, 12)}: ${evt.status} ${currentMB} MB / ${totalMB} MB (${pct}%)`);
-                                } else {
-                                    await write(`  Layer ${evt.id.slice(0, 12)}: ${evt.status}`);
-                                }
-                            }
-                        });
-                        await write(`✓ Successfully pulled ${image}`);
-                    } catch (e) {
-                        await write(`✗ Failed to pull ${image}: ${e instanceof Error ? e.message : String(e)}`);
-                    }
-                }
-            } else {
-                await write('No images found in YAML configuration.');
-            }
-          } else {
-              await write('No YAML configuration found. Skipping explicit pull.');
-          }
-
-          await write('Starting service...');
-          await executor.execArgv(['systemctl', '--user', 'start', `${name}.service`]);
-          await write('✓ Service started successfully.');
-      } else if (action === 'stop') {
-          await write(`Stopping service ${name}...`);
-          await executor.execArgv(['systemctl', '--user', 'stop', `${name}.service`]);
-          await write('✓ Service stopped.');
-      } else if (action === 'restart') {
-          await write(`Restarting service ${name}...`);
-          await executor.execArgv(['systemctl', '--user', 'restart', `${name}.service`]);
-          await write('✓ Service restarted.');
-      }
-
-      // Show status output
-      await write('\r\n--- Service Status ---\r\n');
+    const write = async (msg: string) => {
+      if (writerClosed) return;
       try {
-          // We use spawn to stream the status output, although it's usually short.
-          // But it preserves colors if we use PTY (systemctl status has colors).
-          // Use --no-pager to avoid hanging on user input, and -l to show full lines.
-          const { stdout, stderr, promise } = executor.spawn(`systemctl --user status ${name}.service --no-pager -l`, { pty: true, cols: 160 });
-          
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const streamToWriter = async (stream: any) => {
-              for await (const chunk of stream) {
-                  await writeRaw(chunk.toString());
-              }
-          };
-
-          await Promise.all([
-              streamToWriter(stdout),
-              streamToWriter(stderr),
-              promise
-          ]);
+        await writer.write(encoder.encode(msg + '\r\n'));
       } catch {
-          // systemctl status returns non-zero if service is stopped/failed, which causes spawn promise to reject.
-          // We still want to show the output.
-          // Our spawn implementation rejects on non-zero exit code.
-          // But we might have already streamed the output.
-          // So we can just ignore the error here, as the output is what matters.
-          // Or we can catch it and print a message if needed.
-          // Actually, our spawn implementation in executor.ts rejects AFTER streaming.
-          // So the output should be visible.
+        // Client aborted — stop attempting to write to a closed stream.
+        writerClosed = true;
       }
+    };
 
-    } catch (e) {
-      await write(`Error: ${e instanceof Error ? e.message : String(e)}`);
-    } finally {
-      if (!writerClosed) {
-        try { await writer.close(); } catch { /* already closed */ }
+    const writeRaw = async (msg: string) => {
+      if (writerClosed) return;
+      try {
+        await writer.write(encoder.encode(msg));
+      } catch {
+        writerClosed = true;
       }
-    }
-  })();
+    };
 
-  return new NextResponse(stream.readable, {
-    headers: {
-      'Content-Type': 'text/plain; charset=utf-8',
-      'Transfer-Encoding': 'chunked',
-    },
-  });
-}
+    (async () => {
+      try {
+        let connection;
+        if (nodeName) {
+            const nodes = await listNodes();
+            connection = nodes.find(n => n.Name === nodeName);
+        }
+
+        const executor = getExecutor(connection);
+
+        const streamNodeName = nodeName || connection?.Name || 'Local';
+
+        if (action === 'start') {
+            const { yamlPath } = await ServiceManager.getServiceFiles(streamNodeName, name);
+
+            if (yamlPath) {
+              await write(`Found YAML configuration: ${yamlPath}`);
+              const content = await executor.readFile(yamlPath);
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const parsed = yaml.load(content) as any;
+
+              const images = new Set<string>();
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const findImages = (obj: any) => {
+                  if (!obj) return;
+                  if (obj.image && typeof obj.image === 'string') images.add(obj.image);
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  if (Array.isArray(obj.containers)) obj.containers.forEach((c: any) => findImages(c));
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  if (Array.isArray(obj.initContainers)) obj.initContainers.forEach((c: any) => findImages(c));
+                  if (obj.spec) findImages(obj.spec);
+                  if (obj.template) findImages(obj.template);
+              };
+              findImages(parsed);
+
+              if (images.size > 0) {
+                  await write(`Found ${images.size} images to pull...`);
+                  const agent = await agentManager.ensureAgent(streamNodeName);
+                  for (const image of images) {
+                      await write(`Pulling ${image}...`);
+                      try {
+                          await agent.pullImage(image, async (evt) => {
+                              if (evt.id && evt.status) {
+                                  if (evt.total && evt.current !== undefined) {
+                                      const currentMB = (evt.current / 1048576).toFixed(1);
+                                      const totalMB = (evt.total / 1048576).toFixed(1);
+                                      const pct = Math.round(evt.current / evt.total * 100);
+                                      await write(`  Layer ${evt.id.slice(0, 12)}: ${evt.status} ${currentMB} MB / ${totalMB} MB (${pct}%)`);
+                                  } else {
+                                      await write(`  Layer ${evt.id.slice(0, 12)}: ${evt.status}`);
+                                  }
+                              }
+                          });
+                          await write(`✓ Successfully pulled ${image}`);
+                      } catch (e) {
+                          await write(`✗ Failed to pull ${image}: ${e instanceof Error ? e.message : String(e)}`);
+                      }
+                  }
+              } else {
+                  await write('No images found in YAML configuration.');
+              }
+            } else {
+                await write('No YAML configuration found. Skipping explicit pull.');
+            }
+
+            await write('Starting service...');
+            await executor.execArgv(['systemctl', '--user', 'start', `${name}.service`]);
+            await write('✓ Service started successfully.');
+        } else if (action === 'stop') {
+            await write(`Stopping service ${name}...`);
+            await executor.execArgv(['systemctl', '--user', 'stop', `${name}.service`]);
+            await write('✓ Service stopped.');
+        } else if (action === 'restart') {
+            await write(`Restarting service ${name}...`);
+            await executor.execArgv(['systemctl', '--user', 'restart', `${name}.service`]);
+            await write('✓ Service restarted.');
+        }
+
+        // Show status output
+        await write('\r\n--- Service Status ---\r\n');
+        try {
+            // Use --no-pager so systemctl status doesn't hang on user input,
+            // and -l for full lines. PTY preserves color codes.
+            const { stdout, stderr, promise } = executor.spawn(`systemctl --user status ${name}.service --no-pager -l`, { pty: true, cols: 160 });
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const streamToWriter = async (stream: any) => {
+                for await (const chunk of stream) {
+                    await writeRaw(chunk.toString());
+                }
+            };
+
+            await Promise.all([
+                streamToWriter(stdout),
+                streamToWriter(stderr),
+                promise
+            ]);
+        } catch {
+            // systemctl status exits non-zero on stopped/failed services
+            // which makes our spawn() reject; the stream output has
+            // already been written, so swallow the error here.
+        }
+
+      } catch (e) {
+        await write(`Error: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        if (!writerClosed) {
+          try { await writer.close(); } catch { /* already closed */ }
+        }
+      }
+    })();
+
+    return new NextResponse(stream.readable, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Transfer-Encoding': 'chunked',
+      },
+    });
+  },
+);

--- a/src/app/api/system/access-requests/[id]/approve/route.ts
+++ b/src/app/api/system/access-requests/[id]/approve/route.ts
@@ -4,6 +4,7 @@ import { createLldapUser, getLldapUserDeepLink } from '@/lib/lldap/client';
 import { sendTransactionalEmail } from '@/lib/email';
 import { composeWelcomeEmail, getWelcomeEmailUrls } from '@/lib/email/welcome';
 import { logger } from '@/lib/logger';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,68 +27,70 @@ export const dynamic = 'force-dynamic';
  * rejects the create, the request stays pending so the admin can
  * fix the conflict (e.g. picking a different username) and retry.
  */
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const config = await getConfig();
-  const requests = [...(config.accessRequests ?? [])];
-  const idx = requests.findIndex(r => r.id === id);
-  if (idx < 0) {
-    return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
-  }
-  const req = requests[idx];
-  if (req.status !== 'pending') {
-    return NextResponse.json({ error: 'Request is not pending.' }, { status: 409 });
-  }
-  if (!req.username) {
-    return NextResponse.json(
-      {
-        error: 'This request has no username — it was submitted before the profile fields were added. Create the LLDAP user manually and click "Mark resolved".',
-        reason: 'missing_username',
-      },
-      { status: 412 },
-    );
-  }
 
-  const created = await createLldapUser({
-    id: req.username,
-    email: req.email,
-    displayName: req.firstName && req.lastName ? `${req.firstName} ${req.lastName}` : req.name,
-    firstName: req.firstName,
-    lastName: req.lastName,
-  });
+type Params = { id: string };
 
-  if (!created.ok) {
-    logger.warn('access-requests:approve', `LLDAP create failed for ${req.username}: ${created.message}`);
-    return NextResponse.json(
-      { error: created.message, reason: created.reason },
-      { status: created.reason === 'username_taken' ? 409 : 502 },
-    );
-  }
+export const POST = withApiHandlerParams<undefined, undefined, Params>(
+  {},
+  async ({ params }) => {
+    const config = await getConfig();
+    const requests = [...(config.accessRequests ?? [])];
+    const idx = requests.findIndex(r => r.id === params.id);
+    if (idx < 0) {
+      return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
+    }
+    const req = requests[idx];
+    if (req.status !== 'pending') {
+      return NextResponse.json({ error: 'Request is not pending.' }, { status: 409 });
+    }
+    if (!req.username) {
+      return NextResponse.json(
+        {
+          error: 'This request has no username — it was submitted before the profile fields were added. Create the LLDAP user manually and click "Mark resolved".',
+          reason: 'missing_username',
+        },
+        { status: 412 },
+      );
+    }
 
-  requests[idx] = {
-    ...req,
-    status: 'resolved',
-    resolvedAt: new Date().toISOString(),
-  };
-  await saveConfig({ ...config, accessRequests: requests });
-  logger.info('access-requests:approve', `Provisioned LLDAP user ${req.username} for ${req.email}`);
+    const created = await createLldapUser({
+      id: req.username,
+      email: req.email,
+      displayName: req.firstName && req.lastName ? `${req.firstName} ${req.lastName}` : req.name,
+      firstName: req.firstName,
+      lastName: req.lastName,
+    });
 
-  // Best-effort welcome email to the requester. No-ops cleanly when
-  // email isn't configured — we still return success because the
-  // LLDAP user *is* created and the admin can hand-deliver the URL.
-  // Same composer the "Resend welcome email" button uses (#418).
-  const urls = await getWelcomeEmailUrls();
-  const welcome = composeWelcomeEmail({
-    greetingName: req.firstName ?? req.name,
-    username: req.username,
-    portalUrl: urls.portalUrl,
-    authUrl: urls.authUrl,
-  });
-  void sendTransactionalEmail(req.email, welcome.subject, welcome.body);
+    if (!created.ok) {
+      logger.warn('access-requests:approve', `LLDAP create failed for ${req.username}: ${created.message}`);
+      return NextResponse.json(
+        { error: created.message, reason: created.reason },
+        { status: created.reason === 'username_taken' ? 409 : 502 },
+      );
+    }
 
-  const deepLink = await getLldapUserDeepLink(req.username);
-  return NextResponse.json({ ok: true, lldapUrl: deepLink });
-}
+    requests[idx] = {
+      ...req,
+      status: 'resolved',
+      resolvedAt: new Date().toISOString(),
+    };
+    await saveConfig({ ...config, accessRequests: requests });
+    logger.info('access-requests:approve', `Provisioned LLDAP user ${req.username} for ${req.email}`);
+
+    // Best-effort welcome email to the requester. No-ops cleanly when
+    // email isn't configured — we still return success because the
+    // LLDAP user *is* created and the admin can hand-deliver the URL.
+    // Same composer the "Resend welcome email" button uses (#418).
+    const urls = await getWelcomeEmailUrls();
+    const welcome = composeWelcomeEmail({
+      greetingName: req.firstName ?? req.name,
+      username: req.username,
+      portalUrl: urls.portalUrl,
+      authUrl: urls.authUrl,
+    });
+    void sendTransactionalEmail(req.email, welcome.subject, welcome.body);
+
+    const deepLink = await getLldapUserDeepLink(req.username);
+    return NextResponse.json({ ok: true, lldapUrl: deepLink });
+  },
+);

--- a/src/app/api/system/access-requests/[id]/route.ts
+++ b/src/app/api/system/access-requests/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getConfig, saveConfig } from '@/lib/config';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
 /**
@@ -9,48 +9,42 @@ export const dynamic = 'force-dynamic';
  * (#242 follow-up).
  *
  *   PATCH  — mark a pending request resolved (admin clicked "create
- *            user" or "ignore"). Body: `{ status: 'resolved' }`.
+ *            user" or "ignore").
  *   DELETE — drop the request entirely. Used for spam cleanup.
  *
  * Both endpoints require a session — proxy.ts only allows
  * `/api/system/access-requests` for POST publicly; PATCH and DELETE
- * fall through the existing session check.
+ * fall through the existing session check, and withApiHandlerParams
+ * additionally re-validates the session (defense-in-depth per #596).
  */
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
 
-  const { id } = await params;
-  const config = await getConfig();
-  const requests = [...(config.accessRequests ?? [])];
-  const idx = requests.findIndex(r => r.id === id);
-  if (idx < 0) {
-    return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
-  }
-  requests[idx] = {
-    ...requests[idx],
-    status: 'resolved',
-    resolvedAt: new Date().toISOString(),
-  };
-  await saveConfig({ ...config, accessRequests: requests });
-  return NextResponse.json({ ok: true });
-}
+type Params = { id: string };
 
-export async function DELETE(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+export const PATCH = withApiHandlerParams<undefined, undefined, Params>(
+  {},
+  async ({ params }) => {
+    const config = await getConfig();
+    const requests = [...(config.accessRequests ?? [])];
+    const idx = requests.findIndex(r => r.id === params.id);
+    if (idx < 0) {
+      return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
+    }
+    requests[idx] = {
+      ...requests[idx],
+      status: 'resolved',
+      resolvedAt: new Date().toISOString(),
+    };
+    await saveConfig({ ...config, accessRequests: requests });
+    return NextResponse.json({ ok: true });
+  },
+);
 
-  const { id } = await params;
-  const config = await getConfig();
-  const requests = (config.accessRequests ?? []).filter(r => r.id !== id);
-  await saveConfig({ ...config, accessRequests: requests });
-  return NextResponse.json({ ok: true });
-}
+export const DELETE = withApiHandlerParams<undefined, undefined, Params>(
+  {},
+  async ({ params }) => {
+    const config = await getConfig();
+    const requests = (config.accessRequests ?? []).filter(r => r.id !== params.id);
+    await saveConfig({ ...config, accessRequests: requests });
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/system/access-requests/[id]/welcome/route.ts
+++ b/src/app/api/system/access-requests/[id]/welcome/route.ts
@@ -3,6 +3,7 @@ import { getConfig } from '@/lib/config';
 import { sendTransactionalEmail } from '@/lib/email';
 import { composeWelcomeEmail, getWelcomeEmailUrls } from '@/lib/email/welcome';
 import { logger } from '@/lib/logger';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,38 +18,40 @@ export const dynamic = 'force-dynamic';
  * through the new profile-fields flow from #405). Legacy entries
  * without one return 412 — those didn't get an auto-welcome either.
  */
-export async function POST(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const config = await getConfig();
-  const req = (config.accessRequests ?? []).find(r => r.id === id);
-  if (!req) {
-    return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
-  }
-  if (!req.username) {
-    return NextResponse.json(
-      { error: 'This request has no username on file — no welcome email was ever sent and there is nothing to resend.' },
-      { status: 412 },
-    );
-  }
-  const emailEnabled = config.notifications?.email?.enabled;
-  if (!emailEnabled) {
-    return NextResponse.json(
-      { error: 'SMTP is not configured under Settings → Integrations → Email Notifications.' },
-      { status: 412 },
-    );
-  }
 
-  const urls = await getWelcomeEmailUrls();
-  const welcome = composeWelcomeEmail({
-    greetingName: req.firstName ?? req.name,
-    username: req.username,
-    portalUrl: urls.portalUrl,
-    authUrl: urls.authUrl,
-  });
-  await sendTransactionalEmail(req.email, welcome.subject, welcome.body);
-  logger.info('access-requests:welcome', `Resent welcome email to ${req.email}`);
-  return NextResponse.json({ ok: true });
-}
+type Params = { id: string };
+
+export const POST = withApiHandlerParams<undefined, undefined, Params>(
+  {},
+  async ({ params }) => {
+    const config = await getConfig();
+    const req = (config.accessRequests ?? []).find(r => r.id === params.id);
+    if (!req) {
+      return NextResponse.json({ error: 'Request not found.' }, { status: 404 });
+    }
+    if (!req.username) {
+      return NextResponse.json(
+        { error: 'This request has no username on file — no welcome email was ever sent and there is nothing to resend.' },
+        { status: 412 },
+      );
+    }
+    const emailEnabled = config.notifications?.email?.enabled;
+    if (!emailEnabled) {
+      return NextResponse.json(
+        { error: 'SMTP is not configured under Settings → Integrations → Email Notifications.' },
+        { status: 412 },
+      );
+    }
+
+    const urls = await getWelcomeEmailUrls();
+    const welcome = composeWelcomeEmail({
+      greetingName: req.firstName ?? req.name,
+      username: req.username,
+      portalUrl: urls.portalUrl,
+      authUrl: urls.authUrl,
+    });
+    await sendTransactionalEmail(req.email, welcome.subject, welcome.body);
+    logger.info('access-requests:welcome', `Resent welcome email to ${req.email}`);
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/system/storage/route.ts
+++ b/src/app/api/system/storage/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
 interface RaidArray {
@@ -90,13 +91,12 @@ const mapNode = (raw: RawLsblkNode): DetectedDrive => {
  *     way to tell from the install log whether all expected disks were
  *     even visible.
  */
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node');
+const GetQuery = z.object({ node: z.string().min(1) });
 
-  if (!nodeName) {
-    return NextResponse.json({ error: 'Missing node parameter' }, { status: 400 });
-  }
+export const GET = withApiHandler<undefined, z.infer<typeof GetQuery>>(
+  { query: GetQuery },
+  async ({ query, request }) => {
+  const nodeName = query.node;
 
   try {
     const agent = await agentManager.ensureAgent(nodeName);
@@ -202,32 +202,23 @@ export async function GET(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:storage:get', status: 500 });
   }
-}
+  },
+);
+
+const PostBody = z.object({
+  device: z.string().min(1),
+  mountpoint: z.string().min(1),
+  label: z.string().optional(),
+  fstype: z.string().optional(),
+});
+const PostQuery = z.object({ node: z.string().min(1) });
 
 /** Mount a RAID array and create persistent systemd units. */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node');
-
-  if (!nodeName) {
-    return NextResponse.json({ error: 'Missing node parameter' }, { status: 400 });
-  }
-
-  const body = await request.json();
-  const { device, mountpoint, label, fstype } = body as {
-    device: string;
-    mountpoint: string;
-    label?: string;
-    fstype?: string;
-  };
-
-  if (!device || !mountpoint) {
-    return NextResponse.json({ error: 'Missing device or mountpoint' }, { status: 400 });
-  }
+export const POST = withApiHandler<z.infer<typeof PostBody>, z.infer<typeof PostQuery>>(
+  { body: PostBody, query: PostQuery },
+  async ({ body, query }) => {
+  const nodeName = query.node;
+  const { device, mountpoint, label, fstype } = body;
 
   // Sanitize inputs to prevent command injection
   const safeDevice = device.replace(/[^a-zA-Z0-9/_.-]/g, '');
@@ -313,4 +304,5 @@ UNIT`
   } catch (error) {
     return apiError(error, { tag: 'api:system:storage:post', status: 500 });
   }
-}
+  },
+);

--- a/tests/backend/access_requests.test.ts
+++ b/tests/backend/access_requests.test.ts
@@ -115,7 +115,7 @@ describe('PATCH /api/system/access-requests/[id]', () => {
       { id: 'r1', requestedAt: '2026-01-01', name: 'A', email: 'a@b.c', status: 'pending' },
     ];
     const res = await PATCH(
-      new Request('http://test/api/system/access-requests/r1', { method: 'PATCH' }),
+      new NextRequest('http://test/api/system/access-requests/r1', { method: 'PATCH' }),
       { params: Promise.resolve({ id: 'r1' }) },
     );
     expect(res.status).toBe(200);
@@ -125,7 +125,7 @@ describe('PATCH /api/system/access-requests/[id]', () => {
 
   it('returns 404 when id not found', async () => {
     const res = await PATCH(
-      new Request('http://test/api/system/access-requests/nope', { method: 'PATCH' }),
+      new NextRequest('http://test/api/system/access-requests/nope', { method: 'PATCH' }),
       { params: Promise.resolve({ id: 'nope' }) },
     );
     expect(res.status).toBe(404);
@@ -139,7 +139,7 @@ describe('DELETE /api/system/access-requests/[id]', () => {
       { id: 'r2', requestedAt: '2026-01-02', name: 'B', email: 'b@b.c', status: 'pending' },
     ];
     const res = await DELETE(
-      new Request('http://test/api/system/access-requests/r1', { method: 'DELETE' }),
+      new NextRequest('http://test/api/system/access-requests/r1', { method: 'DELETE' }),
       { params: Promise.resolve({ id: 'r1' }) },
     );
     expect(res.status).toBe(200);


### PR DESCRIPTION
Re #603. Burn-down PR — migrates five more routes from hand-rolled try/catch/validate to `withApiHandler` / `withApiHandlerParams`.

## Routes migrated

| Route | Methods | Notes |
|---|---|---|
| `system/access-requests/[id]/route.ts` | PATCH, DELETE | dynamic-segment variant; mark-resolved + delete |
| `system/access-requests/[id]/approve/route.ts` | POST | one-click LLDAP provisioning + auto welcome email |
| `system/access-requests/[id]/welcome/route.ts` | POST | resend welcome email |
| `system/storage/route.ts` | GET, POST | RAID/drive enumeration + persistent mount |
| `services/[name]/action-stream/route.ts` | POST | streaming start/stop/restart |

Each picks up:
- The handler's built-in `requireSession` gate on mutating verbs (#596 defense-in-depth) for free — the manual `__auth` checks are removed.
- Zod-validated body + query — replaces ad-hoc `searchParams.get`/`request.json()` + manual null checks.
- Typed `ApiError` short-circuit on validation failure.

**Response shapes are preserved verbatim** (handlers still return `NextResponse.json(...)` directly). Frontend callers don't need updating — `AccessRequestsSection.tsx`, `ActionProgressModal.tsx`, and the storage hooks all read the same shapes as before.

## Ratchet bump

- Adoption: **31/108 → 36/108 (28.7% → 33.3%)**.
- `scripts/check-invariants.ts` `MIN_WITH_API_HANDLER_RATIO`: **0.15 → 0.30**.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npm run check:arch` — passes with the new 0.30 floor
- `npx vitest run` — 1113 tests pass, 2 skipped (existing skips)
- `tests/backend/access_requests.test.ts` updated to use `NextRequest` (the migrated handlers now take `NextRequest`; runtime path unaffected)

## Test plan
- [x] `npm run check:arch`
- [x] `npx vitest run`
- [x] `npx tsc --noEmit -p tsconfig.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)