### PR TITLE
refactor(api): withApiHandler small-cluster sweep — 9 more routes (#603)

### DIFF
--- a/src/app/api/agents/restart/route.ts
+++ b/src/app/api/agents/restart/route.ts
@@ -1,31 +1,38 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { getConfig } from '@/lib/config';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const Body = z
+  .object({
+    nodeName: z.string().optional(),
+    // Older callers used `node` instead of `nodeName`; accept both.
+    node: z.string().optional(),
+    reason: z.string().optional(),
+  })
+  .default({});
 
-  try {
-    const body = await request.json().catch(() => ({}));
-    const nodeName = body?.nodeName || body?.node;
-    const reason = body?.reason || 'manual';
+export const POST = withApiHandler<z.infer<typeof Body>>(
+  { body: Body },
+  async ({ body }) => {
+    const nodeName = body.nodeName || body.node;
+    const reason = body.reason || 'manual';
     const config = await getConfig();
     const timeoutMs = (config.agent?.gracefulShutdownTimeout ?? 30) * 1000;
 
-    if (nodeName) {
-      await agentManager.restartAgent(nodeName, reason, timeoutMs);
-    } else {
-      await agentManager.restartAll(reason, timeoutMs);
+    try {
+      if (nodeName) {
+        await agentManager.restartAgent(nodeName, reason, timeoutMs);
+      } else {
+        await agentManager.restartAll(reason, timeoutMs);
+      }
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      return NextResponse.json(
+        { success: false, error: (error as Error).message },
+        { status: 500 },
+      );
     }
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    return NextResponse.json(
-      { success: false, error: (error as Error).message },
-      { status: 500 }
-    );
-  }
-}
+  },
+);

--- a/src/app/api/auth/lldap-url/route.ts
+++ b/src/app/api/auth/lldap-url/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getConfig } from '@/lib/config';
+import { withApiHandler } from '@/lib/api/handler';
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   try {
     const config = await getConfig();
     const hosts = config.reverseProxy?.hosts || [];
@@ -38,4 +39,4 @@ export async function GET() {
   } catch {
     return NextResponse.json({ url: null });
   }
-}
+});

--- a/src/app/api/containers/route.ts
+++ b/src/app/api/containers/route.ts
@@ -1,24 +1,28 @@
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
-    const searchParams = request.nextUrl.searchParams;
-    const nodeName = searchParams.get('node') || 'Local';
+const Query = z.object({ node: z.string().optional() });
 
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+    const nodeName = query.node || 'Local';
     try {
-        const agent = agentManager.getAgent(nodeName);
-        if (!agent) {
-             return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
-        }
-        
-        // Use V4 'listContainers' command
-        const list = await agent.sendCommand('listContainers');
-        return NextResponse.json(list || []);
+      const agent = agentManager.getAgent(nodeName);
+      if (!agent) {
+        return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+      }
+      // Use V4 'listContainers' command
+      const list = await agent.sendCommand('listContainers');
+      return NextResponse.json(list || []);
     } catch (e) {
-        return apiError(e, { tag: 'api:containers:get', status: 500 });
+      return apiError(e, { tag: 'api:containers:get', status: 500 });
     }
-}
+  },
+);

--- a/src/app/api/help/route.ts
+++ b/src/app/api/help/route.ts
@@ -1,35 +1,35 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import fs from 'fs/promises';
 import path from 'path';
+import { withApiHandler } from '@/lib/api/handler';
 
 const HELP_ALIASES: Record<string, string> = {
   containers: 'container-engine',
   volumes: 'container-engine',
 };
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const id = searchParams.get('id');
+const Query = z.object({ id: z.string().min(1) });
 
-  if (!id) {
-    return NextResponse.json({ error: 'ID is required' }, { status: 400 });
-  }
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+    // Prevent directory traversal
+    const safeId = query.id.replace(/[^a-zA-Z0-9-]/g, '');
+    const normalizedId = HELP_ALIASES[safeId] ?? safeId;
 
-  // Prevent directory traversal
-  const safeId = id.replace(/[^a-zA-Z0-9-]/g, '');
-  const normalizedId = HELP_ALIASES[safeId] ?? safeId;
+    // Special-case: CHANGELOG.md lives at the project root (release-please
+    // owns it). Serve it through this endpoint so the existing SectionHelp
+    // modal can render it without a separate API surface.
+    const filePath = normalizedId === 'changelog'
+      ? path.join(process.cwd(), 'CHANGELOG.md')
+      : path.join(process.cwd(), 'src/content/help', `${normalizedId}.md`);
 
-  // Special-case: CHANGELOG.md lives at the project root (release-please owns
-  // it). Serve it through this endpoint so the existing SectionHelp modal can
-  // render it without a separate API surface.
-  const filePath = normalizedId === 'changelog'
-    ? path.join(process.cwd(), 'CHANGELOG.md')
-    : path.join(process.cwd(), 'src/content/help', `${normalizedId}.md`);
-
-  try {
-    const content = await fs.readFile(filePath, 'utf-8');
-    return NextResponse.json({ content });
-  } catch {
-    return NextResponse.json({ error: 'Help content not found' }, { status: 404 });
-  }
-}
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return NextResponse.json({ content });
+    } catch {
+      return NextResponse.json({ error: 'Help content not found' }, { status: 404 });
+    }
+  },
+);

--- a/src/app/api/history/[filename]/route.ts
+++ b/src/app/api/history/[filename]/route.ts
@@ -1,38 +1,45 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getHistory, getSnapshotContent } from '@/lib/history';
 import { listNodes } from '@/lib/nodes';
 import { BackupFileName } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 const TIMESTAMP_RE = /^[0-9_\-]{1,64}$/;
 
-export async function GET(request: Request, { params }: { params: Promise<{ filename: string }> }) {
-  const parsed = await parseRouteParam(params, 'filename', BackupFileName);
-  if (!parsed.ok) return parsed.response;
-  const filename = parsed.value;
-  const { searchParams } = new URL(request.url);
-  const timestamp = searchParams.get('timestamp');
-  const nodeName = searchParams.get('node');
+const Query = z.object({
+  timestamp: z.string().regex(TIMESTAMP_RE, 'invalid timestamp').optional(),
+  node: z.string().optional(),
+});
 
-  if (timestamp !== null && !TIMESTAMP_RE.test(timestamp)) {
-    return NextResponse.json({ error: 'invalid timestamp' }, { status: 400 });
-  }
+type Params = { filename: string };
 
-  let connection;
-  if (nodeName && nodeName !== 'local') {
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, Params>(
+  { query: Query },
+  async ({ query, params }) => {
+    const nameCheck = BackupFileName.safeParse(decodeURIComponent(params.filename));
+    if (!nameCheck.success) {
+      return NextResponse.json({ error: 'invalid filename' }, { status: 400 });
+    }
+    const filename = nameCheck.data;
+    const { timestamp, node: nodeName } = query;
+
+    let connection;
+    if (nodeName && nodeName !== 'local') {
       const nodes = await listNodes();
       connection = nodes.find(n => n.Name === nodeName);
-  }
-
-  if (timestamp) {
-    try {
-      const content = await getSnapshotContent(filename, timestamp, connection);
-      return new NextResponse(content);
-    } catch {
-      return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 });
     }
-  } else {
+
+    if (timestamp) {
+      try {
+        const content = await getSnapshotContent(filename, timestamp, connection);
+        return new NextResponse(content);
+      } catch {
+        return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 });
+      }
+    }
+
     const history = await getHistory(filename, connection);
     return NextResponse.json(history);
-  }
-}
+  },
+);

--- a/src/app/api/logs/list/route.ts
+++ b/src/app/api/logs/list/route.ts
@@ -1,26 +1,26 @@
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   try {
     const dates = logger.listLogDates();
     return NextResponse.json({
       success: true,
-      // Map to structure expected by frontend (name/path) or just array of dates
+      // Map to structure expected by frontend (name/path).
       files: dates.map(date => ({
         name: date,
-        // No path needed really, but keeping shape for now
-        path: date
-      }))
+        path: date,
+      })),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error('API', 'Failed to list log dates:', err);
     return NextResponse.json({
       success: false,
-      error: message
+      error: message,
     }, { status: 500 });
   }
-}
+});

--- a/src/app/api/logs/tags/route.ts
+++ b/src/app/api/logs/tags/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-    try {
-        const tags = logger.getTags();
-        return NextResponse.json({
-            success: true,
-            tags
-        });
-    } catch (err) {
-        logger.error('api:logs:tags', 'Failed to list tags', err);
-        return NextResponse.json({ success: false, tags: [] }, { status: 500 });
-    }
-}
+export const GET = withApiHandler({}, async () => {
+  try {
+    const tags = logger.getTags();
+    return NextResponse.json({
+      success: true,
+      tags,
+    });
+  } catch (err) {
+    logger.error('api:logs:tags', 'Failed to list tags', err);
+    return NextResponse.json({ success: false, tags: [] }, { status: 500 });
+  }
+});

--- a/src/app/api/portal/asset/[service]/[kind]/route.ts
+++ b/src/app/api/portal/asset/[service]/[kind]/route.ts
@@ -1,12 +1,20 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getConfig } from '@/lib/config';
 import { getMode } from '@/lib/mode';
 import { resolveSetupAsset } from '@/lib/portal/assets';
 import type { SetupAssetKind } from '@/lib/portal/userGuide';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
 const KIND_VALUES: SetupAssetKind[] = ['ios_calendar_profile', 'audiobookshelf_deeplink', 'syncthing_qr'];
+
+const Query = z.object({
+  subdomain_var: z.string().regex(/^[A-Z][A-Z0-9_]*_SUBDOMAIN$/).optional(),
+});
+
+type Params = { service: string; kind: string };
 
 /**
  * Public asset endpoint for the family portal (#242 follow-up).
@@ -17,67 +25,62 @@ const KIND_VALUES: SetupAssetKind[] = ['ios_calendar_profile', 'audiobookshelf_d
  * mode (mirrors the rest of the portal — exposing pre-config
  * artifacts publicly is something we'd revisit alongside #265).
  *
- * GET /api/portal/asset/[service]/[kind]
- *
  *   - kind=`ios_calendar_profile` → returns .mobileconfig with
- *     Content-Type `application/x-apple-aspen-config`. iOS treats it
- *     as an installable Configuration Profile.
- *   - kind=`audiobookshelf_deeplink` → returns JSON `{ url: "abs://..." }`
- *     so the client can decide what to do with it (most likely
- *     `window.location = url`).
+ *     Content-Type `application/x-apple-aspen-config`.
+ *   - kind=`audiobookshelf_deeplink` → returns JSON `{ url: "abs://…" }`.
+ *   - kind=`syncthing_qr` → returns JSON `{ deviceId }`; client
+ *     renders the QR locally.
  *
- * The service name and kind are validated against the templates
- * that actually ship the asset — random combos return 404.
+ * The service name and kind are validated against the templates that
+ * actually ship the asset — random combos return 404.
  */
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ service: string; kind: string }> },
-) {
-  const { service, kind } = await params;
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, Params>(
+  { query: Query },
+  async ({ query, params }) => {
+    const { service, kind } = params;
 
-  // Mode gate: portal assets are LAN-only (same as /portal page).
-  const config = await getConfig();
-  if (getMode(config) === 'public') {
-    return new NextResponse('Not found', { status: 404 });
-  }
+    // Mode gate: portal assets are LAN-only (same as /portal page).
+    const config = await getConfig();
+    if (getMode(config) === 'public') {
+      return new NextResponse('Not found', { status: 404 });
+    }
 
-  if (!KIND_VALUES.includes(kind as SetupAssetKind)) {
-    return new NextResponse('Unknown asset kind', { status: 404 });
-  }
+    if (!KIND_VALUES.includes(kind as SetupAssetKind)) {
+      return new NextResponse('Unknown asset kind', { status: 404 });
+    }
 
-  // Sanity-check the service name — must be a known template
-  // directory layout (no path traversal). Templates have lowercase
-  // names with dashes per existing convention.
-  if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(service)) {
-    return new NextResponse('Invalid service name', { status: 400 });
-  }
+    // Sanity-check the service name — must match the template
+    // directory naming convention (lowercase + dashes, no traversal).
+    if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(service)) {
+      return new NextResponse('Invalid service name', { status: 400 });
+    }
 
-  const url = new URL(request.url);
-  const subdomainVarRaw = url.searchParams.get('subdomain_var');
-  const subdomainVar = subdomainVarRaw && /^[A-Z][A-Z0-9_]*_SUBDOMAIN$/.test(subdomainVarRaw)
-    ? subdomainVarRaw
-    : undefined;
-  const asset = await resolveSetupAsset(kind as SetupAssetKind, service, subdomainVar);
-  if (!asset) {
-    return new NextResponse('Asset not available — service may not be installed yet.', { status: 404 });
-  }
+    const asset = await resolveSetupAsset(
+      kind as SetupAssetKind,
+      service,
+      query.subdomain_var,
+    );
+    if (!asset) {
+      return new NextResponse('Asset not available — service may not be installed yet.', { status: 404 });
+    }
 
-  if (asset.kind === 'ios_calendar_profile') {
-    return new NextResponse(asset.data, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/x-apple-aspen-config',
-        'Content-Disposition': `attachment; filename="${service}.mobileconfig"`,
-      },
-    });
-  }
-  if (asset.kind === 'syncthing_qr') {
-    // Return the device ID; the client renders the QR code itself.
-    // Keeping QR generation client-side avoids shipping a server-
-    // side QR library + lets the modal scale the QR responsively.
-    return NextResponse.json({ deviceId: asset.data });
-  }
-  // audiobookshelf_deeplink — return JSON so the client controls
-  // navigation (location.href = url, with a fallback message).
-  return NextResponse.json({ url: asset.data });
-}
+    if (asset.kind === 'ios_calendar_profile') {
+      return new NextResponse(asset.data, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/x-apple-aspen-config',
+          'Content-Disposition': `attachment; filename="${service}.mobileconfig"`,
+        },
+      });
+    }
+    if (asset.kind === 'syncthing_qr') {
+      // Return the device ID; the client renders the QR locally.
+      // Keeps the server free of a QR library and lets the modal
+      // size the QR responsively.
+      return NextResponse.json({ deviceId: asset.data });
+    }
+    // audiobookshelf_deeplink — JSON so the client controls
+    // navigation (location.href = url, with a fallback message).
+    return NextResponse.json({ url: asset.data });
+  },
+);

--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -1,12 +1,13 @@
 
 import { NextResponse } from 'next/server';
 import watcher from '@/lib/watcher';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   const encoder = new TextEncoder();
-  
+
   let cleanup: (() => void) | null = null;
 
   const stream = new ReadableStream({
@@ -53,4 +54,4 @@ export async function GET() {
       'Connection': 'keep-alive',
     },
   });
-}
+});

--- a/tests/backend/lldap_url.test.ts
+++ b/tests/backend/lldap_url.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
 
 // Mock config module
 const mockConfig = {
@@ -16,6 +17,8 @@ vi.mock('@/lib/config', () => ({
 
 import { GET } from '../../src/app/api/auth/lldap-url/route';
 
+const req = () => new NextRequest('http://test/api/auth/lldap-url');
+
 describe('GET /api/auth/lldap-url', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,7 +30,7 @@ describe('GET /api/auth/lldap-url', () => {
       { domain: 'ldap.example.com', service: 'lldap', forwardPort: 17170, created: true },
     ];
 
-    const res = await GET();
+    const res = await GET(req());
     const data = await res.json();
 
     expect(data.url).toBe('https://ldap.example.com');
@@ -38,7 +41,7 @@ describe('GET /api/auth/lldap-url', () => {
       { domain: 'ldap.example.com', service: 'lldap', forwardPort: 17170, created: false },
     ];
 
-    const res = await GET();
+    const res = await GET(req());
     const data = await res.json();
 
     expect(data.url).toBeNull();
@@ -49,7 +52,7 @@ describe('GET /api/auth/lldap-url', () => {
       { domain: 'vault.example.com', service: 'vaultwarden', forwardPort: 8080, created: true },
     ];
 
-    const res = await GET();
+    const res = await GET(req());
     const data = await res.json();
 
     expect(data.url).toBeNull();
@@ -58,7 +61,7 @@ describe('GET /api/auth/lldap-url', () => {
   it('returns null when hosts array is empty', async () => {
     mockConfig.reverseProxy.hosts = [];
 
-    const res = await GET();
+    const res = await GET(req());
     const data = await res.json();
 
     expect(data.url).toBeNull();
@@ -67,7 +70,7 @@ describe('GET /api/auth/lldap-url', () => {
   it('returns null when reverseProxy config is missing', async () => {
     (mockConfig as any).reverseProxy = undefined;
 
-    const res = await GET();
+    const res = await GET(req());
     const data = await res.json();
 
     expect(data.url).toBeNull();


### PR DESCRIPTION
Re #603. Burn-down PR — picks off the single-route and 2-route clusters that were still hand-rolling try/catch + validation.

## Routes migrated

| Route | Method | Notes |
|---|---|---|
| `agents/restart/route.ts` | POST | accepts \`nodeName\` or legacy \`node\` alias |
| `auth/lldap-url/route.ts` | GET | |
| `containers/route.ts` | GET | \`?node=\` query validated |
| `help/route.ts` | GET | \`?id=\` query validated; directory-traversal guard preserved |
| `history/[filename]/route.ts` | GET | dynamic segment + timestamp regex moved into Zod |
| `logs/list/route.ts` | GET | |
| `logs/tags/route.ts` | GET | |
| `portal/asset/[service]/[kind]/route.ts` | GET | dynamic segment + \`?subdomain_var=\` regex moved into Zod |
| `stream/route.ts` | GET | SSE stream (returns ReadableStream directly) |

Each picks up the handler's built-in requireSession gate on mutating verbs (#596 defense-in-depth) for free, Zod-validated body + query, and typed \`ApiError\` short-circuit. **Response shapes are preserved verbatim** (handlers still return \`NextResponse.json(...)\` / \`new NextResponse(...)\` directly). Frontend callers don't need updating.

## Adoption math

Counted on this branch (off main):
- Before: **31/108 (28.7%)**
- After:  **40/108 (37.0%)**

Combined with [PR #785](https://github.com/mdopp/servicebay/pull/785) (5 routes), main → **45/108 (~41.7%)** once both land. The \`MIN_WITH_API_HANDLER_RATIO\` bump to 0.30 in #785 covers both batches; this PR doesn't touch \`check-invariants.ts\` to avoid merge-order conflicts.

## Verification
- \`npx tsc --noEmit -p tsconfig.json\` — clean
- \`npm run check:arch\` — clean
- \`npx vitest run\` — 1113 tests pass, 2 skipped
- \`tests/backend/lldap_url.test.ts\` updated to pass a \`NextRequest\` (test-only change; runtime path unchanged)

## Test plan
- [x] \`npx tsc --noEmit -p tsconfig.json\`
- [x] \`npm run check:arch\`
- [x] \`npx vitest run\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)