### PR TITLE
fix(install): infrastructure tier installs before features (#796)

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -34,6 +34,7 @@ import {
 import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
 import { parseTemplateManifest } from '@/lib/template/contract';
 import { topoSortByDependencies } from '@/lib/stackInstall/dependencies';
+import { parseTemplateTier } from '@/lib/templateTier';
 import { selectMigrationChain } from '@/lib/stackInstall/migrations';
 import {
   bootstrapNpmAdmin,
@@ -562,7 +563,14 @@ async function runJob(jobId: string): Promise<void> {
     return;
   }
 
-  // Topo-sort by install-time dependencies.
+  // Topo-sort by install-time dependencies. We also tag each item
+  // with its `servicebay.tier` so the sort adds an implicit edge from
+  // every feature to every infrastructure item — guaranteeing the
+  // whole infra block (nginx, auth, adguard, …) is fully deployed
+  // before any feature can register against it (#796). Without that
+  // gate, an unrelated feature with no declared deps (ollama, hermes)
+  // races nginx and ends up registering NPM proxy hosts that the
+  // late-running NPM credentials self-heal then wipes.
   const sortResult = topoSortByDependencies(
     checked.map(i => ({
       name: i.name,
@@ -571,6 +579,7 @@ async function runJob(jobId: string): Promise<void> {
       yaml: i.yaml,
       configFiles: i.configFiles,
       dependencies: i.dependencies ?? [],
+      tier: i.yaml ? parseTemplateTier(i.yaml) : 'feature',
     })),
     { alreadyInstalled: new Set(input.items.filter(i => i.alreadyInstalled).map(i => i.name)) },
   );

--- a/packages/backend/src/lib/stackInstall/dependencies.test.ts
+++ b/packages/backend/src/lib/stackInstall/dependencies.test.ts
@@ -116,4 +116,75 @@ describe('topoSortByDependencies', () => {
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.ordered.map(i => i.name)).toEqual(['auth', 'adguard']);
   });
+
+  // #796 — infrastructure-tier items must precede every feature-tier
+  // item in the result, regardless of input order, because a feature
+  // that registers against e.g. NPM before its credentials are
+  // verified can lose its registration to a late infrastructure-level
+  // self-heal.
+  describe('tier-implicit edges (#796)', () => {
+    it('puts all infrastructure items before any feature item', () => {
+      // Reproduces the bug timeline: ollama+hermes (feature) appear
+      // first in the input, but should run AFTER nginx/auth/adguard
+      // (infrastructure) regardless.
+      const result = topoSortByDependencies([
+        { name: 'ollama', dependencies: [], tier: 'feature' },
+        { name: 'hermes', dependencies: [], tier: 'feature' },
+        { name: 'nginx', dependencies: [], tier: 'infrastructure' },
+        { name: 'auth', dependencies: [], tier: 'infrastructure' },
+        { name: 'adguard', dependencies: ['nginx', 'auth'], tier: 'infrastructure' },
+        { name: 'vaultwarden', dependencies: [], tier: 'feature' },
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const order = result.ordered.map(i => i.name);
+      const lastInfra = Math.max(
+        order.indexOf('nginx'),
+        order.indexOf('auth'),
+        order.indexOf('adguard'),
+      );
+      const firstFeature = Math.min(
+        order.indexOf('ollama'),
+        order.indexOf('hermes'),
+        order.indexOf('vaultwarden'),
+      );
+      expect(lastInfra).toBeLessThan(firstFeature);
+    });
+
+    it('still respects explicit deps within the infrastructure tier', () => {
+      // adguard explicitly depends on nginx+auth; that ordering must
+      // hold inside the infra block even with the implicit cross-tier
+      // edge.
+      const result = topoSortByDependencies([
+        { name: 'adguard', dependencies: ['nginx', 'auth'], tier: 'infrastructure' },
+        { name: 'nginx', dependencies: [], tier: 'infrastructure' },
+        { name: 'auth', dependencies: [], tier: 'infrastructure' },
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const order = result.ordered.map(i => i.name);
+      expect(order.indexOf('nginx')).toBeLessThan(order.indexOf('adguard'));
+      expect(order.indexOf('auth')).toBeLessThan(order.indexOf('adguard'));
+    });
+
+    it('handles a set with no infrastructure (feature-only)', () => {
+      const result = topoSortByDependencies([
+        { name: 'a', dependencies: [], tier: 'feature' },
+        { name: 'b', dependencies: ['a'], tier: 'feature' },
+      ]);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.ordered.map(i => i.name)).toEqual(['a', 'b']);
+    });
+
+    it('defaults to feature tier when omitted (back-compat)', () => {
+      // Existing callers that don't set `tier` should behave exactly
+      // as before — sort by declared deps only.
+      const result = topoSortByDependencies([
+        { name: 'b', dependencies: ['a'] },
+        { name: 'a', dependencies: [] },
+      ]);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.ordered.map(i => i.name)).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/packages/backend/src/lib/stackInstall/dependencies.ts
+++ b/packages/backend/src/lib/stackInstall/dependencies.ts
@@ -24,6 +24,7 @@
  */
 
 import { readManifestAnnotations } from '../template/contract';
+import type { TemplateTier } from '../templateTier';
 
 /** Parse `servicebay.dependencies` from a rendered template.yml.
  *  Returns the list of dep template names, trimmed, or an empty array
@@ -39,6 +40,15 @@ export interface DependencyAwareItem {
   name: string;
   /** Names this item depends on. Resolved against the candidate set. */
   dependencies: string[];
+  /** Install-tier classification — `infrastructure` items get an
+   *  implicit edge from every `feature` item so the entire infra
+   *  block lands before any feature deploy starts. Without this
+   *  gate, a feature can register itself against an infrastructure
+   *  service (NPM, Authelia) that isn't fully verified yet — and any
+   *  late repair to the infra (NPM credentials self-heal, LLDAP
+   *  re-seed) loses every prior registration. See #796. Default
+   *  when omitted: `feature`. */
+  tier?: TemplateTier;
 }
 
 export type TopoSortResult<T> =
@@ -76,6 +86,29 @@ export function topoSortByDependencies<T extends DependencyAwareItem>(
     }
   }
 
+  // Compute the effective dependency edges:
+  // - each item's declared `servicebay.dependencies`
+  // - PLUS implicit "every feature depends on every infra in this set"
+  //   so the topological order surfaces all infrastructure before any
+  //   feature. Without this, an unrelated feature (`ollama`, `hermes`)
+  //   that declares no deps can sneak in front of nginx/auth and
+  //   register subdomain proxy hosts against NPM data that the
+  //   install runner is about to wipe and recreate (#796).
+  const infraNames = items
+    .filter(it => it.tier === 'infrastructure')
+    .map(it => it.name);
+  const effectiveDeps = new Map<string, string[]>();
+  for (const it of items) {
+    const tier = it.tier ?? 'feature';
+    const explicit = it.dependencies.filter(d => namesInSet.has(d));
+    if (tier === 'infrastructure') {
+      effectiveDeps.set(it.name, explicit);
+    } else {
+      const implicit = infraNames.filter(n => n !== it.name);
+      effectiveDeps.set(it.name, [...new Set([...explicit, ...implicit])]);
+    }
+  }
+
   // Kahn's algorithm with a stable tiebreaker (input order).
   const indeg = new Map<string, number>();
   const byName = new Map<string, T>();
@@ -83,7 +116,7 @@ export function topoSortByDependencies<T extends DependencyAwareItem>(
   items.forEach((it, i) => {
     byName.set(it.name, it);
     inputOrder.set(it.name, i);
-    indeg.set(it.name, it.dependencies.filter(d => namesInSet.has(d)).length);
+    indeg.set(it.name, (effectiveDeps.get(it.name) ?? []).length);
   });
 
   const ready: T[] = items.filter(it => (indeg.get(it.name) ?? 0) === 0);
@@ -96,7 +129,7 @@ export function topoSortByDependencies<T extends DependencyAwareItem>(
     const next = ready.shift()!;
     ordered.push(next);
     for (const other of items) {
-      if (other.dependencies.includes(next.name)) {
+      if ((effectiveDeps.get(other.name) ?? []).includes(next.name)) {
         const newDeg = (indeg.get(other.name) ?? 0) - 1;
         indeg.set(other.name, newDeg);
         if (newDeg === 0 && !ordered.includes(other) && !ready.includes(other)) {


### PR DESCRIPTION
Closes #796.

## Summary

Install-time topo-sort now treats `servicebay.tier: "infrastructure"` as an implicit gate — every infra service lands before any feature service, regardless of input order. Previously, a feature with no declared deps (ollama, hermes) could race ahead of nginx/auth/adguard, register subdomain proxy hosts against the not-yet-verified NPM, and lose those registrations when nginx's credentials self-heal wiped NPM's data/ at the end of install.

## What changed

- **`packages/backend/src/lib/stackInstall/dependencies.ts`**: `topoSortByDependencies` now computes effective deps as `explicit ∪ (for every feature: every infrastructure item)`. Kahn's algorithm walks the combined graph with the same stable input-order tiebreaker.
- **`packages/backend/src/lib/install/runner.ts`**: passes `tier: parseTemplateTier(i.yaml)` to the sort. Defaults to `'feature'` when yaml is missing — matches `templateTier.ts`'s existing default.
- `DependencyAwareItem.tier` is optional; pre-existing callers without it behave exactly as before.

## New install order on a reinstall

Before this PR:
```
ollama → hermes → nginx → auth → adguard → vaultwarden → immich → ...
                          (cred check + wipe here — too late)
```

After:
```
nginx → auth → adguard → ollama → hermes → vaultwarden → immich → ...
   (cred check + wipe here — no feature has registered yet)
```

## Verification

- **16 unit tests pass** (12 existing + 4 new):
  - infra precedes feature regardless of input order (reproduces the #796 reinstall log exactly)
  - intra-infra explicit deps still respected (adguard → after → nginx/auth)
  - feature-only sets still sort by declared deps
  - back-compat: items without `tier` behave as before
- `npx tsc --noEmit -p tsconfig.json` clean
- `npm run check:arch` clean
- `npx vitest run` — full suite green

## Test plan
- [x] new unit tests cover the #796 timeline
- [x] full vitest run green
- [x] typecheck + arch
- [ ] user re-installs on 192.168.178.100 from the next release; verifies all 12 subdomain proxy routes land in `config.reverseProxy.hosts` and `auth.<domain>` is reachable end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)