### PR TITLE
refactor(api): complete withApiHandler burn-down — 100% adoption (#603)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -161,7 +161,7 @@ rules:
           `@/lib/api/handler` — gives shared Zod validation, error envelope,
           and ApiError short-circuiting. See docs/ARCHITECTURE_INVARIANTS.md.
       languages: [typescript]
-      severity: INFO
+      severity: WARNING
       paths:
           include:
               - 'src/app/api/**/route.ts'

--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -81,11 +81,11 @@ Thresholds are **deliberate decisions**, not aspirational defaults. Two paths:
 | Invariant | Current | Threshold | Enforced by |
 |---|---:|---:|---|
 | `executor.exec(\`…${x}…\`)` call sites | 26 | 26 | `check-invariants.ts:EXEC_TEMPLATE_LITERAL_MAX` + `sb/no-exec-template-literal` |
-| `withApiHandler` adoption (route.ts files) | 64 of 108 | ≥ 55% | `check-invariants.ts:MIN_WITH_API_HANDLER_RATIO` + `sb/api-route-needs-handler` |
+| `withApiHandler` adoption (route.ts files) | 108 of 108 | 100% | `check-invariants.ts:MIN_WITH_API_HANDLER_RATIO` + `sb/api-route-needs-handler` |
 
 **executor.exec template literals.** Ratcheted to 0 in #602. ESLint rule `sb/no-exec-template-literal` is `error` everywhere — every previous offender was converted to `execArgv`. `EXEC_TEMPLATE_LITERAL_MAX = 0` in `check-invariants.ts` blocks any regression.
 
-**withApiHandler adoption.** `@/lib/api/handler` provides shared Zod validation + error envelope + ApiError short-circuiting. Currently 64 of 108 routes use it. The ratio must monotonically increase; new routes must use it (ESLint warning + semgrep INFO). Ratchet target: ≥ 90% adoption.
+**withApiHandler adoption.** `@/lib/api/handler` provides shared Zod validation + error envelope + ApiError short-circuiting. The #603 burn-down completed the migration — all 108 route.ts files use `withApiHandler` / `withApiHandlerParams`. The floor is locked at 100%; every new route must use the wrapper. Enforced as a hard error by the `sb/api-route-needs-handler` ESLint rule (per verb export) and the `check-invariants.ts` ratio (per file). Intentionally-public routes (login, OIDC, family-portal submission) wrap with `{ skipAuth: true }` to opt out of the requireSession gate while keeping the shared envelope.
 
 ### Security boundaries (pattern enforcement)
 

--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -81,11 +81,11 @@ Thresholds are **deliberate decisions**, not aspirational defaults. Two paths:
 | Invariant | Current | Threshold | Enforced by |
 |---|---:|---:|---|
 | `executor.exec(\`…${x}…\`)` call sites | 26 | 26 | `check-invariants.ts:EXEC_TEMPLATE_LITERAL_MAX` + `sb/no-exec-template-literal` |
-| `withApiHandler` adoption (route.ts files) | 1 of 96 | ≥ 1% | `check-invariants.ts:MIN_WITH_API_HANDLER_RATIO` + `sb/api-route-needs-handler` |
+| `withApiHandler` adoption (route.ts files) | 64 of 108 | ≥ 55% | `check-invariants.ts:MIN_WITH_API_HANDLER_RATIO` + `sb/api-route-needs-handler` |
 
 **executor.exec template literals.** Ratcheted to 0 in #602. ESLint rule `sb/no-exec-template-literal` is `error` everywhere — every previous offender was converted to `execArgv`. `EXEC_TEMPLATE_LITERAL_MAX = 0` in `check-invariants.ts` blocks any regression.
 
-**withApiHandler adoption.** `src/lib/api/handler.ts` provides shared Zod validation + error envelope + ApiError short-circuiting. Currently 1 of 96 routes use it. The ratio must monotonically increase; new routes must use it (ESLint warning + semgrep INFO). Ratchet target: ≥ 90% adoption.
+**withApiHandler adoption.** `@/lib/api/handler` provides shared Zod validation + error envelope + ApiError short-circuiting. Currently 64 of 108 routes use it. The ratio must monotonically increase; new routes must use it (ESLint warning + semgrep INFO). Ratchet target: ≥ 90% adoption.
 
 ### Security boundaries (pattern enforcement)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -213,9 +213,10 @@ const eslintConfig = defineConfig([
         },
       ],
       "sb/no-exec-template-literal": "error",
-      // Soft warning — the architecture-invariants script enforces the
-      // adoption ratio. This rule nudges new authors in their editor.
-      "sb/api-route-needs-handler": "warn",
+      // Hard error since the #603 burn-down — every API route verb
+      // export must use withApiHandler / withApiHandlerParams. The
+      // architecture-invariants script holds the file-level backstop.
+      "sb/api-route-needs-handler": "error",
       // Phase 1 of the FE/BE separation (#753). The fe-backend-imports
       // baseline was dropped to 0 in the same PR that lands this rule
       // — any new violation fails CI both via the rule and via

--- a/packages/backend/src/lib/api/handler.ts
+++ b/packages/backend/src/lib/api/handler.ts
@@ -49,6 +49,14 @@ export interface ApiHandlerOptions<B, Q> {
   body?: z.ZodType<B>;
   /** Validates URL query params. Use undefined when no query is expected. */
   query?: z.ZodType<Q>;
+  /**
+   * Opt out of the built-in requireSession gate on mutating verbs (#603).
+   * Only for routes that are *intentionally* public — login, the OIDC
+   * initiator, the family-portal access-request submission. These mirror
+   * `src/proxy.ts:PUBLIC_API_RULES`; keep the two in sync. Authenticated
+   * routes must never set this.
+   */
+  skipAuth?: boolean;
 }
 
 export interface ParsedRequest<B, Q> {
@@ -72,7 +80,7 @@ async function runHandler<B, Q>(
   invoke: (parsed: { body: B; query: Q }) => Promise<Response | NextResponse | unknown>,
 ): Promise<Response> {
   try {
-    if (MUTATING_METHODS.has(request.method)) {
+    if (!options.skipAuth && MUTATING_METHODS.has(request.method)) {
       // Lazy import to keep handler.ts free of the cookie-parse import
       // chain when the module is loaded by middleware-adjacent code.
       const { requireSession } = await import('./requireSession');

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -166,12 +166,11 @@ async function checkExecTemplateLiterals() {
 // Routes that hand-roll their own try/catch + envelope drift apart. The
 // abstraction in src/lib/api/handler.ts is the SoT. Should monotonically
 // increase; ratchet up after each cluster migration so any regression
-// fails CI immediately. Current run: 59/108 routes (~55%) after the
-// small-cluster sweep (auth/oidc, health/run+history, logs/query,
-// network/graph, system/{discovery,mcp-audit,version,services,keys,
-// core-health,portal/provision}, install/abort).
+// fails CI immediately. Current run: 64/108 routes (~59%) after the
+// nginx cluster sweep (system/nginx/{status,export,import,install,
+// bootstrap}).
 // ---------------------------------------------------------------------------
-const MIN_WITH_API_HANDLER_RATIO = 0.50;
+const MIN_WITH_API_HANDLER_RATIO = 0.55;
 
 async function checkWithApiHandlerAdoption() {
     const routeFiles = await walk(path.join(SRC, 'app', 'api'), p => p.endsWith('/route.ts'));

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -166,11 +166,13 @@ async function checkExecTemplateLiterals() {
 // Routes that hand-roll their own try/catch + envelope drift apart. The
 // abstraction in src/lib/api/handler.ts is the SoT. Should monotonically
 // increase; ratchet up after each cluster migration so any regression
-// fails CI immediately. Current run: 64/108 routes (~59%) after the
-// nginx cluster sweep (system/nginx/{status,export,import,install,
-// bootstrap}).
+// fails CI immediately. The #603 burn-down completed the migration:
+// 108/108 routes (100%) now use withApiHandler / withApiHandlerParams.
+// Floor is locked at 1.0 — every new route.ts must use the wrapper
+// (the `sb/api-route-needs-handler` ESLint rule, now `error`, is the
+// per-export gate; this ratio is the file-level backstop).
 // ---------------------------------------------------------------------------
-const MIN_WITH_API_HANDLER_RATIO = 0.55;
+const MIN_WITH_API_HANDLER_RATIO = 1.0;
 
 async function checkWithApiHandlerAdoption() {
     const routeFiles = await walk(path.join(SRC, 'app', 'api'), p => p.endsWith('/route.ts'));

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { login } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
 import { hashPassword, isPasswordHash, verifyPassword } from '@/lib/auth/password';
 import { checkRateLimit, recordFailure, clearAttempts, clientKeyFromHeaders } from '@/lib/auth/rateLimit';
 import { isRequestSecure } from '@/lib/auth/requestSecurity';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 
 // Pre-hashed sentinel used when the supplied username does not match. Verifying
@@ -19,7 +20,9 @@ function userKey(username: string): string {
   return `user:${username.toLowerCase()}`;
 }
 
-export async function POST(request: NextRequest) {
+// skipAuth: login is intentionally public — requiring a session to log
+// in would be circular. Mirrors src/proxy.ts:PUBLIC_API_RULES.
+export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
   try {
     const clientKey = clientKeyFromHeaders(request.headers);
     const ipDecision = checkRateLimit(clientKey);
@@ -104,4 +107,4 @@ export async function POST(request: NextRequest) {
     logger.error('auth:login', 'login crash', error instanceof Error ? error.message : String(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/src/app/api/auth/oidc/callback/route.ts
+++ b/src/app/api/auth/oidc/callback/route.ts
@@ -1,12 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getConfig, getOidcCallbackUrl } from '@/lib/config';
 import { login } from '@/lib/auth';
 import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { assertValidOidcIssuer } from '@/lib/auth/oidcIssuer';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
 
-export async function GET(request: NextRequest) {
+export const GET = withApiHandler({}, async ({ request }) => {
   try {
     const config = await getConfig();
 
@@ -101,4 +102,4 @@ export async function GET(request: NextRequest) {
     logger.error('api:auth:oidc:callback', 'OIDC callback error', error);
     return NextResponse.redirect(new URL('/login?error=oidc_error', request.url));
   }
-}
+});

--- a/src/app/api/auth/oidc/route.ts
+++ b/src/app/api/auth/oidc/route.ts
@@ -1,12 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getConfig } from '@/lib/config';
 import { getOidcCallbackUrl } from '@/lib/config';
 import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { assertValidOidcIssuer } from '@/lib/auth/oidcIssuer';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 import crypto from 'crypto';
 
-export async function GET(request: NextRequest) {
+export const GET = withApiHandler({}, async ({ request }) => {
   try {
     const config = await getConfig();
 
@@ -54,4 +55,4 @@ export async function GET(request: NextRequest) {
     logger.error('api:auth:oidc', 'OIDC redirect error', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-}
+});

--- a/src/app/api/containers/[id]/action/route.ts
+++ b/src/app/api/containers/[id]/action/route.ts
@@ -1,26 +1,23 @@
-
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { ContainerId } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const Query = z.object({ node: z.string().optional() });
 
-  const parsed = await parseRouteParam(params, 'id', ContainerId);
-  if (!parsed.ok) return parsed.response;
-  const id = parsed.value;
-  const searchParams = request.nextUrl.searchParams;
-  const nodeName = searchParams.get('node') || 'Local';
+export const POST = withApiHandlerParams<undefined, z.infer<typeof Query>, { id: string }>(
+  { query: Query },
+  async ({ request, query, params }) => {
+  const check = ContainerId.safeParse(params.id);
+  if (!check.success) {
+    return NextResponse.json({ error: 'invalid id' }, { status: 400 });
+  }
+  const id = check.data;
+  const nodeName = query.node || 'Local';
 
   try {
       const body = await request.json();
@@ -47,10 +44,10 @@ export async function POST(
       if (response && response.code === 0) {
           return NextResponse.json({ success: true, output: response.stdout });
       }
-      
+
       return NextResponse.json({ error: 'Action failed', details: response }, { status: 500 });
-      
+
   } catch (error) {
       return apiError(error, { tag: 'api:containers:action', status: 500 });
   }
-}
+});

--- a/src/app/api/containers/[id]/logs/route.ts
+++ b/src/app/api/containers/[id]/logs/route.ts
@@ -1,20 +1,23 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { ContainerId } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const parsed = await parseRouteParam(params, 'id', ContainerId);
-  if (!parsed.ok) return parsed.response;
-  const id = parsed.value;
-  const searchParams = request.nextUrl.searchParams;
-  const nodeName = searchParams.get('node') || 'Local';
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { id: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+  const check = ContainerId.safeParse(params.id);
+  if (!check.success) {
+    return NextResponse.json({ logs: 'invalid id' }, { status: 400 });
+  }
+  const id = check.data;
+  const nodeName = query.node || 'Local';
 
   try {
     const agent = agentManager.getAgent(nodeName);
@@ -33,9 +36,9 @@ export async function GET(
              return NextResponse.json({ logs: response.stderr || 'Error fetching logs' }, { status: 500 });
         }
     }
-    
+
     return NextResponse.json({ logs: 'Unknown error' }, { status: 500 });
   } catch (error) {
     return apiError(error, { tag: 'api:containers:logs', status: 500 });
   }
-}
+});

--- a/src/app/api/containers/[id]/logs/stream/route.ts
+++ b/src/app/api/containers/[id]/logs/stream/route.ts
@@ -1,23 +1,22 @@
-
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { ContainerId } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const parsed = await parseRouteParam(params, 'id', ContainerId);
-  if (!parsed.ok) {
-    const r = parsed.response.clone();
-    return new NextResponse(await r.text(), { status: 400 });
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { id: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+  const check = ContainerId.safeParse(params.id);
+  if (!check.success) {
+    return new NextResponse('invalid id', { status: 400 });
   }
-  const id = parsed.value;
-  const searchParams = request.nextUrl.searchParams;
-  const nodeName = searchParams.get('node') || 'Local';
+  const id = check.data;
+  const nodeName = query.node || 'Local';
 
   try {
     const agent = agentManager.getAgent(nodeName);
@@ -39,10 +38,10 @@ export async function GET(
              return new NextResponse(response.stderr || 'Error fetching logs', { status: 500 });
         }
     }
-    
+
     return new NextResponse('Unknown error', { status: 500 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     return new NextResponse(msg, { status: 500 });
   }
-}
+});

--- a/src/app/api/containers/[id]/route.ts
+++ b/src/app/api/containers/[id]/route.ts
@@ -1,21 +1,23 @@
-
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { ContainerId } from '@/lib/api/schemas';
-import { parseRouteParam } from '@/lib/api/validate';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const parsed = await parseRouteParam(params, 'id', ContainerId);
-  if (!parsed.ok) return parsed.response;
-  const id = parsed.value;
-  const searchParams = request.nextUrl.searchParams;
-  const nodeName = searchParams.get('node') || 'Local';
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { id: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+  const check = ContainerId.safeParse(params.id);
+  if (!check.success) {
+    return NextResponse.json({ error: 'invalid id' }, { status: 400 });
+  }
+  const id = check.data;
+  const nodeName = query.node || 'Local';
 
   try {
     const agent = agentManager.getAgent(nodeName);
@@ -35,10 +37,10 @@ export async function GET(
             return NextResponse.json(data[0]);
         }
     }
-    
+
     return NextResponse.json({ error: 'Container not found or inspect failed', details: response }, { status: 404 });
 
   } catch (error) {
     return apiError(error, { tag: 'api:containers:inspect', status: 500 });
   }
-}
+});

--- a/src/app/api/health/checks/route.ts
+++ b/src/app/api/health/checks/route.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { withApiHandler } from '@/lib/api/handler';
 import { HealthCheckTarget, NodeName } from '@/lib/api/schemas';
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   const checks = HealthStore.getChecks();
   // Enrich with last result
   const enrichedChecks = checks.map(check => {
@@ -29,7 +29,7 @@ export async function GET() {
     };
   });
   return NextResponse.json(enrichedChecks);
-}
+});
 
 const CheckPostBody = z.object({
   id: z.string().min(1).max(64).optional(),

--- a/src/app/api/install/credentials/route.ts
+++ b/src/app/api/install/credentials/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { provideCredentials } from '@/lib/install/runner';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 /**
@@ -12,11 +12,7 @@ export const dynamic = 'force-dynamic';
  * to `config.reverseProxy.npm` and lets the nginx capability handler
  * pick them up on the next emit.
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = (await request.json()) as {
       jobId?: string;
@@ -40,4 +36,4 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:install:credentials', status: 500 });
   }
-}
+});

--- a/src/app/api/install/progress/route.ts
+++ b/src/app/api/install/progress/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getJob, readLog } from '@/lib/install/jobStore';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
+
+const Query = z.object({
+  jobId: z.string().optional(),
+  logsSince: z.string().optional(),
+});
 
 /**
  * Public, sanitized view of an install job's progress (#663 — S1).
@@ -34,14 +41,15 @@ export const dynamic = 'force-dynamic';
  * variables; widening `/progress` to include them would defeat the
  * purpose. See `src/proxy.ts:PUBLIC_API_RULES` for the gate config.
  */
-export async function GET(request: Request) {
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
   try {
-    const url = new URL(request.url);
-    const jobId = url.searchParams.get('jobId');
+    const jobId = query.jobId;
     if (!jobId) {
       return NextResponse.json({ error: 'jobId query parameter required' }, { status: 400 });
     }
-    const sinceBytes = parseInt(url.searchParams.get('logsSince') || '0', 10);
+    const sinceBytes = parseInt(query.logsSince || '0', 10);
 
     const job = await getJob(jobId);
     if (!job) {
@@ -71,4 +79,4 @@ export async function GET(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:install:progress', status: 500 });
   }
-}
+});

--- a/src/app/api/install/skip-credentials/route.ts
+++ b/src/app/api/install/skip-credentials/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { skipCredentials } from '@/lib/install/runner';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 /**
@@ -10,11 +10,7 @@ export const dynamic = 'force-dynamic';
  * Proxy routes won't be configured in this run; the operator can fix
  * this later via Settings → Integrations.
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = (await request.json()) as { jobId?: string };
     if (!body.jobId) {
@@ -31,4 +27,4 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:install:skip-credentials', status: 500 });
   }
-}
+});

--- a/src/app/api/install/start/route.ts
+++ b/src/app/api/install/start/route.ts
@@ -3,7 +3,7 @@ import { createJob, getCurrentJob, type JobInput } from '@/lib/install/jobStore'
 import { startJob } from '@/lib/install/runner';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 /**
@@ -16,11 +16,7 @@ export const dynamic = 'force-dynamic';
  * active phase (running / needs_credentials). The wizard surfaces this
  * via the `installInProgress` banner + reattach flow.
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = (await request.json()) as { source?: string; input?: JobInput };
     const input = body.input;
@@ -40,4 +36,4 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:install:start', status: 500 });
   }
-}
+});

--- a/src/app/api/install/status/route.ts
+++ b/src/app/api/install/status/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getCurrentJob, getJob, getLatestJob, PROCESS_STARTED_AT, readLog } from '@/lib/install/jobStore';
 import { getConfig } from '@/lib/config';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
+
+const Query = z.object({
+  jobId: z.string().optional(),
+  logsSince: z.string().optional(),
+});
 
 /**
  * Read job state + accumulated logs since a byte offset.
@@ -31,11 +38,12 @@ export const dynamic = 'force-dynamic';
  * pops back open on every reload after install finishes but the
  * operator hasn't acknowledged the result yet.
  */
-export async function GET(request: Request) {
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
   try {
-    const url = new URL(request.url);
-    const jobId = url.searchParams.get('jobId');
-    const sinceBytes = parseInt(url.searchParams.get('logsSince') || '0', 10);
+    const jobId = query.jobId;
+    const sinceBytes = parseInt(query.logsSince || '0', 10);
 
     let job = jobId ? await getJob(jobId) : await getCurrentJob();
     if (!job && !jobId) {
@@ -75,4 +83,4 @@ export async function GET(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:install:status', status: 500 });
   }
-}
+});

--- a/src/app/api/network/edges/route.ts
+++ b/src/app/api/network/edges/route.ts
@@ -1,16 +1,13 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { NetworkStore } from '@/lib/network/store';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 import crypto from 'crypto';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function POST(req: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(req);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
-    const body = await req.json();
+    const body = await request.json();
     const { source, target, port } = body;
 
     if (!source || !target) {
@@ -32,16 +29,15 @@ export async function POST(req: Request) {
     logger.error('api:network:edges:post', 'Failed to add edge', e);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
-}
+});
 
-export async function DELETE(req: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(req);
-  if (__auth instanceof NextResponse) return __auth;
+const DeleteQuery = z.object({ id: z.string().optional() });
 
+export const DELETE = withApiHandler<undefined, z.infer<typeof DeleteQuery>>(
+  { query: DeleteQuery },
+  async ({ query }) => {
   try {
-    const { searchParams } = new URL(req.url);
-    const id = searchParams.get('id');
+    const id = query.id;
 
     if (!id) {
       return NextResponse.json({ error: 'Missing id' }, { status: 400 });
@@ -53,4 +49,4 @@ export async function DELETE(req: Request) {
     logger.error('api:network:edges:delete', 'Failed to remove edge', e);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
-}
+});

--- a/src/app/api/services/[name]/route.ts
+++ b/src/app/api/services/[name]/route.ts
@@ -1,13 +1,16 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { getConfig, saveConfig, ExternalLink } from '@/lib/config';
 import { HealthStore } from '@/lib/health/store';
 import { buildExternalLinkPorts, normalizeExternalTargets } from '@/lib/network/externalLinks';
 import { ServiceName } from '@/lib/api/schemas';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import crypto from 'crypto';
 
-import { requireSession } from '@/lib/api/requireSession';
+const Query = z.object({ node: z.string().optional() });
+
 const parseIpTargets = (input: unknown, fallback: string[] = []) => {
   const parsed = normalizeExternalTargets(input);
   if (parsed.length > 0) {
@@ -16,19 +19,12 @@ const parseIpTargets = (input: unknown, fallback: string[] = []) => {
   return fallback;
 };
 
-function getNodeName(request: Request): string {
-    const { searchParams } = new URL(request.url);
-    return searchParams.get('node') || 'Local';
-}
-
 // Decode + validate the [name] segment. External links can use a UUID or a
 // human-readable label; managed services flow into shell commands so they
 // must satisfy ServiceName. We accept any non-empty string here and let the
 // caller decide how strict to be (link lookup vs. shell-bound action).
-async function decodeName(params: Promise<{ name: string }>): Promise<string | null> {
-  const resolved = await params;
-  const raw = resolved?.name ?? '';
-  try { return decodeURIComponent(raw); } catch { return null; }
+function decodeName(raw: string): string | null {
+  try { return decodeURIComponent(raw ?? ''); } catch { return null; }
 }
 
 function ensureServiceName(name: string): { ok: true; value: string } | { ok: false; response: NextResponse } {
@@ -39,29 +35,29 @@ function ensureServiceName(name: string): { ok: true; value: string } | { ok: fa
   return { ok: true, value: check.data };
 }
 
-export async function GET(request: Request, { params }: { params: Promise<{ name: string }> }) {
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { name: string }>(
+  { query: Query },
+  async ({ query, params }) => {
   try {
-    const decoded = await decodeName(params);
+    const decoded = decodeName(params.name);
     if (decoded === null) return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
     const guard = ensureServiceName(decoded);
     if (!guard.ok) return guard.response;
-    const nodeName = getNodeName(request);
+    const nodeName = query.node || 'Local';
 
     const files = await ServiceManager.getServiceFiles(nodeName, guard.value);
     return NextResponse.json(files);
   } catch {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
-}
+});
 
-export async function DELETE(request: Request, { params }: { params: Promise<{ name: string }> }) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-  const decoded = await decodeName(params);
+export const DELETE = withApiHandlerParams<undefined, z.infer<typeof Query>, { name: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+  const decoded = decodeName(params.name);
   if (decoded === null) return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
-  const nodeName = getNodeName(request);
+  const nodeName = query.node || 'Local';
 
   // External-link branch: name may be a UUID or label, no shell interpolation. Match before strict validation.
   const config = await getConfig();
@@ -88,18 +84,16 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ n
   if (!guard.ok) return guard.response;
   await ServiceManager.deleteService(nodeName, guard.value);
   return NextResponse.json({ success: true });
-}
+});
 
-export async function PUT(request: Request, { params }: { params: Promise<{ name: string }> }) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
-  const decoded = await decodeName(params);
+export const PUT = withApiHandlerParams<undefined, z.infer<typeof Query>, { name: string }>(
+  { query: Query },
+  async ({ request, query, params }) => {
+  const decoded = decodeName(params.name);
   if (decoded === null) return NextResponse.json({ error: 'invalid name encoding' }, { status: 400 });
   const name = decoded;
   const body = await request.json();
-  const nodeName = getNodeName(request);
+  const nodeName = query.node || 'Local';
 
   // Check if it's a link update
   if (body.type === 'link') {
@@ -242,4 +236,4 @@ export async function PUT(request: Request, { params }: { params: Promise<{ name
 
   await ServiceManager.saveService(nodeName, safeName, kubeContent, yamlContent, yamlFileName);
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,15 +1,21 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getConfig, saveConfig, ExternalLink } from '@/lib/config';
 import { HealthStore } from '@/lib/health/store';
 import { listNodes } from '@/lib/nodes';
 import { buildExternalLinkPorts, normalizeExternalTargets } from '@/lib/network/externalLinks';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 import crypto from 'crypto';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
+
+const ListQuery = z.object({
+  scope: z.string().optional(),
+  node: z.string().optional(),
+});
 
 const parseIpTargets = (input: unknown, fallback: string[] = []) => {
     const parsed = normalizeExternalTargets(input);
@@ -63,10 +69,11 @@ const mapExternalLinks = (links: ExternalLink[]) => {
     });
 };
 
-export async function GET(request: Request) {
+export const GET = withApiHandler<undefined, z.infer<typeof ListQuery>>(
+  { query: ListQuery },
+  async ({ query }) => {
   try {
-    const { searchParams } = new URL(request.url);
-    const scope = searchParams.get('scope');
+    const scope = query.scope;
 
     if (scope === 'links') {
         const config = await getConfig();
@@ -74,7 +81,7 @@ export async function GET(request: Request) {
         return NextResponse.json(mapExternalLinks(links));
     }
 
-    const nodeName = searchParams.get('node');
+    const nodeName = query.node;
     const isLocal = !nodeName || nodeName === 'Local';
     
     // Start fetching config immediately
@@ -239,17 +246,19 @@ export async function GET(request: Request) {
         { status: 500 }
     );
   }
-}
+});
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const CreateQuery = z.object({
+  node: z.string().optional(),
+  stream: z.string().optional(),
+});
 
+export const POST = withApiHandler<undefined, z.infer<typeof CreateQuery>>(
+  { query: CreateQuery },
+  async ({ request, query }) => {
   const body = await request.json();
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node');
-  
+  const nodeName = query.node;
+
   const targetNode = (!nodeName || nodeName === 'Local') ? 'Local' : nodeName;
   
   // Handle Link Creation
@@ -320,7 +329,7 @@ export async function POST(request: Request) {
   }
 
   // Streaming mode: return progress events as they happen
-  if (searchParams.get('stream') === '1') {
+  if (query.stream === '1') {
     const encoder = new TextEncoder();
     const stream = new TransformStream();
     const writer = stream.writable.getWriter();
@@ -395,4 +404,4 @@ export async function POST(request: Request) {
     migrations,
   );
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/system/access-requests/route.ts
+++ b/src/app/api/system/access-requests/route.ts
@@ -8,11 +8,10 @@ import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-// NOTE: POST is intentionally NOT routed through `withApiHandler` —
-// the endpoint is public (anonymous family-LAN visitors hit it from
-// the portal) and the handler's built-in requireSession gate would
-// reject every submission. GET is admin-only and goes through the
-// handler.
+// NOTE: POST uses `withApiHandler({ skipAuth: true })` — the endpoint
+// is public (anonymous family-LAN visitors hit it from the portal) so
+// it opts out of the handler's built-in requireSession gate. GET is
+// admin-only and goes through the handler normally.
 
 /**
  * "Request access" endpoint for the family portal (#242 follow-up).
@@ -55,7 +54,7 @@ const PostBody = z.object({
   lastName: z.string().trim().min(1).max(60).optional(),
 });
 
-export async function POST(request: Request) {
+export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
   // Cap raw body size so a hostile client can't push gigabytes.
   // Next.js doesn't enforce this by default for route handlers.
   const text = await request.text();
@@ -124,7 +123,7 @@ export async function POST(request: Request) {
   );
 
   return NextResponse.json({ ok: true, id: newRequest.id });
-}
+});
 
 export const GET = withApiHandler({}, async () => {
   const config = await getConfig();

--- a/src/app/api/system/authelia/oidc-clients/[client_id]/route.ts
+++ b/src/app/api/system/authelia/oidc-clients/[client_id]/route.ts
@@ -13,10 +13,10 @@
  * duplication is small enough today (yaml load/dump + restart) that
  * factoring it out wasn't worth the indirection for one new endpoint.
  */
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { DigitalTwinStore } from '@/lib/store/twin';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { agentManager } from '@/lib/agent/manager';
 import yaml from 'js-yaml';
@@ -32,15 +32,11 @@ interface AutheliaConfig {
   };
 }
 
-export async function DELETE(
-  request: NextRequest,
-  ctx: { params: Promise<{ client_id: string }> },
-) {
+export const DELETE = withApiHandlerParams<undefined, undefined, { client_id: string }>(
+  {},
+  async ({ params }) => {
   try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-
-    const { client_id: clientId } = await ctx.params;
+    const { client_id: clientId } = params;
     if (!clientId) {
       return NextResponse.json({ error: 'client_id required' }, { status: 400 });
     }
@@ -120,4 +116,4 @@ export async function DELETE(
   } catch (error) {
     return apiError(error, { tag: 'api:system:authelia:oidc-clients:delete', status: 500 });
   }
-}
+});

--- a/src/app/api/system/authelia/oidc-clients/route.ts
+++ b/src/app/api/system/authelia/oidc-clients/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getTemplateVariables } from '@/lib/registry';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import crypto from 'crypto';
 import yaml from 'js-yaml';
@@ -52,11 +52,8 @@ interface OidcClientsRequest {
  * Looks up each template's variables.json for oidcClient definitions,
  * builds client configs, and appends them to Authelia's configuration.yml.
  */
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-
     const body: OidcClientsRequest = await request.json();
     if (!body.templates?.length || !body.variables) {
       return NextResponse.json({ error: 'templates and variables required' }, { status: 400 });
@@ -230,4 +227,4 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:authelia:oidc-clients', status: 500 });
   }
-}
+});

--- a/src/app/api/system/devices/route.ts
+++ b/src/app/api/system/devices/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
+
+const Query = z.object({
+  node: z.string().optional(),
+  path: z.string().optional(),
+});
 
 /**
  * List device files from a directory on the target node.
@@ -21,10 +28,11 @@ export const dynamic = 'force-dynamic';
  * preserving the previous behavior for callers that already pass an
  * explicit folder.
  */
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const nodeName = searchParams.get('node');
-  const devicePath = searchParams.get('path') || '/dev/serial/by-id';
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+  const nodeName = query.node;
+  const devicePath = query.path || '/dev/serial/by-id';
 
   if (!nodeName) {
     return NextResponse.json({ error: 'Missing node parameter' }, { status: 400 });
@@ -59,4 +67,4 @@ export async function GET(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:devices:get', status: 500 });
   }
-}
+});

--- a/src/app/api/system/diagnose/route.ts
+++ b/src/app/api/system/diagnose/route.ts
@@ -11,17 +11,14 @@
  */
 
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { runDiagnose, type DiagnoseProbe } from '@/lib/diagnose/runDiagnose';
 
 export type { DiagnoseProbe };
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   let nodeName = 'Local';
   try {
     const body = await request.json().catch(() => ({}));
@@ -32,4 +29,4 @@ export async function POST(request: Request) {
 
   const result = await runDiagnose(nodeName);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/system/diagnose/run-action/route.ts
+++ b/src/app/api/system/diagnose/run-action/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { dispatchProbeAction } from '@/lib/diagnose/actions';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import '@/lib/diagnose/probes/register';
 
 export const dynamic = 'force-dynamic';
@@ -29,11 +29,7 @@ const Body = z.object({
   itemId: z.string().min(1).max(128).optional(),
 });
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   let parsed;
   try {
     parsed = Body.parse(await request.json());
@@ -53,4 +49,4 @@ export async function POST(request: Request) {
   });
 
   return NextResponse.json(result, { status: result.ok ? 200 : 400 });
-}
+});

--- a/src/app/api/system/discovery/dismiss/route.ts
+++ b/src/app/api/system/discovery/dismiss/route.ts
@@ -5,7 +5,7 @@ import { listNodes } from '@/lib/nodes';
 import type { PodmanConnection } from '@/lib/nodes';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 interface DismissPayload {
@@ -13,11 +13,7 @@ interface DismissPayload {
     nodeName?: string;
 }
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
     try {
         const body = (await request.json()) as DismissPayload;
         const bundleId = body?.bundleId?.trim();
@@ -56,4 +52,4 @@ export async function POST(request: Request) {
     } catch (error) {
         return apiError(error, { tag: 'api:system:discovery:dismiss', status: 500 });
     }
-}
+});

--- a/src/app/api/system/discovery/merge/route.ts
+++ b/src/app/api/system/discovery/merge/route.ts
@@ -1,13 +1,16 @@
 
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { cookies } from 'next/headers';
 import { mergeServices, type DiscoveredService } from '@/lib/migration';
 import { listNodes } from '@/lib/nodes';
 import { decrypt } from '@/lib/auth';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 
-import { requireSession } from '@/lib/api/requireSession';
+const Query = z.object({ node: z.string().optional() });
+
 async function resolveActor(request: Request): Promise<string> {
   const forwarded = request.headers.get('x-forwarded-user') || request.headers.get('remote-user');
   if (forwarded) {
@@ -30,14 +33,11 @@ async function resolveActor(request: Request): Promise<string> {
   return 'unknown';
 }
 
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ request, query }) => {
   try {
-    const { searchParams } = new URL(request.url);
-    const nodeName = searchParams.get('node');
+    const nodeName = query.node;
 
     const body = await request.json();
     const { services, newName, dryRun } = body as { services: DiscoveredService[], newName: string, dryRun?: boolean };
@@ -74,4 +74,4 @@ export async function POST(request: Request) {
   } catch (error: unknown) {
     return apiError(error, { tag: 'api:system:discovery:merge', status: 500 });
   }
-}
+});

--- a/src/app/api/system/discovery/migrate/route.ts
+++ b/src/app/api/system/discovery/migrate/route.ts
@@ -1,17 +1,17 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { migrateService, type DiscoveredService } from '@/lib/migration';
 import { listNodes } from '@/lib/nodes';
 import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const Query = z.object({ node: z.string().optional() });
 
+export const POST = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ request, query }) => {
   try {
-    const { searchParams } = new URL(request.url);
-    const nodeName = searchParams.get('node');
+    const nodeName = query.node;
 
     const body = await request.json();
     const { service, customName, dryRun } = body as { service: DiscoveredService, customName?: string, dryRun?: boolean };
@@ -37,4 +37,4 @@ export async function POST(request: Request) {
   } catch (error: unknown) {
     return apiError(error, { tag: 'api:system:discovery:migrate', status: 500 });
   }
-}
+});

--- a/src/app/api/system/dns/verify/route.ts
+++ b/src/app/api/system/dns/verify/route.ts
@@ -4,7 +4,7 @@ import { getConfig } from '@/lib/config';
 import { FritzBoxClient } from '@/lib/fritzbox/client';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 interface DomainResult {
@@ -34,11 +34,7 @@ interface DomainResult {
  * results still come through — the per-domain match flag just
  * reflects what we know. The endpoint never throws on partial info.
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = (await request.json().catch(() => ({}))) as { domains?: unknown };
     const domains = Array.isArray(body.domains)
@@ -90,4 +86,4 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:dns:verify', status: 500 });
   }
-}
+});

--- a/src/app/api/system/file-share/samba/users/[id]/set-password/route.ts
+++ b/src/app/api/system/file-share/samba/users/[id]/set-password/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { setSambaPassword } from '@/lib/fileShare/sambaSync';
 
@@ -21,12 +21,11 @@ const SAFE_USERNAME = /^[A-Za-z0-9._-]{1,64}$/;
  * id, so unknown users are rejected with 404 rather than silently
  * adding a Samba-only account.
  */
-export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
+  {},
+  async ({ request, params }) => {
   try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-
-    const { id } = await params;
+    const { id } = params;
     if (!SAFE_USERNAME.test(id)) {
       return NextResponse.json({ error: 'Invalid username.' }, { status: 400 });
     }
@@ -50,4 +49,4 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   } catch (error) {
     return apiError(error, { tag: 'api:system:file-share:samba:set-password', status: 500 });
   }
-}
+});

--- a/src/app/api/system/file-share/samba/users/route.ts
+++ b/src/app/api/system/file-share/samba/users/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { syncSambaWithLldap } from '@/lib/fileShare/sambaSync';
 
@@ -19,13 +20,9 @@ export const dynamic = 'force-dynamic';
  *  LLDAP user (LLDAP's user-create flow runs in a separate pod and
  *  has no broadcast hook).
  */
-export async function GET(request: NextRequest) {
-  return handle(request);
-}
+export const GET = withApiHandler({}, async ({ request }) => handle(request));
 
-export async function POST(request: NextRequest) {
-  return handle(request);
-}
+export const POST = withApiHandler({}, async ({ request }) => handle(request));
 
 async function handle(request: NextRequest) {
   try {

--- a/src/app/api/system/filebrowser/init/route.ts
+++ b/src/app/api/system/filebrowser/init/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import crypto from 'crypto';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 
 export const dynamic = 'force-dynamic';
@@ -54,11 +54,8 @@ interface FbUser {
  * on startup. Spoofing Remote-User here doesn't widen the existing
  * trust surface.
  */
-export async function POST(request: Request) {
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-
     const body = await request.json() as InitRequest;
     const username = (body.username || 'admin').trim();
     if (!/^[a-z][a-z0-9_-]{1,31}$/.test(username)) {
@@ -157,4 +154,4 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:filebrowser:init', status: 500 });
   }
-}
+});

--- a/src/app/api/system/files/route.ts
+++ b/src/app/api/system/files/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getExecutor } from '@/lib/executor';
 import { listNodes } from '@/lib/nodes';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const path = searchParams.get('path');
-  const nodeName = searchParams.get('node');
+const Query = z.object({
+  path: z.string().optional(),
+  node: z.string().optional(),
+});
+
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+  const path = query.path;
+  const nodeName = query.node;
 
   if (!path) {
     return NextResponse.json({ error: 'Missing path parameter' }, { status: 400 });
@@ -32,4 +40,4 @@ export async function GET(request: Request) {
     logger.error('api:system:files', 'Failed to read file content', error);
     return NextResponse.json({ error: `Failed to read file: ${message}` }, { status: 500 });
   }
-}
+});

--- a/src/app/api/system/lldap/probe/route.ts
+++ b/src/app/api/system/lldap/probe/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 /**
@@ -13,11 +13,7 @@ export const dynamic = 'force-dynamic';
  * to come up before firing the group-seed call (LLDAP needs ~5–15 s on
  * cold start to initialize its SQLite DB and bind to its HTTP port).
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = await request.json();
     const { host, port } = body as { host?: string; port?: number };
@@ -46,4 +42,4 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:lldap:probe', status: 500 });
   }
-}
+});

--- a/src/app/api/system/lldap/seed/route.ts
+++ b/src/app/api/system/lldap/seed/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 const LLDAP_GRAPHQL_GROUPS = `
@@ -91,11 +91,7 @@ async function createGroup(baseUrl: string, token: string, groupName: string): P
 }
 
 /** Seed LLDAP with default groups after installation. */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   const body = await request.json() as SeedRequest;
   const host = body.host || 'localhost';
   const port = body.port || 17170;
@@ -134,4 +130,4 @@ export async function POST(request: Request) {
   const failed = results.filter(r => r.error).map(r => ({ name: r.name, error: r.error }));
 
   return NextResponse.json({ created, existing, failed });
-}
+});

--- a/src/app/api/system/mcp-tokens/route.ts
+++ b/src/app/api/system/mcp-tokens/route.ts
@@ -3,17 +3,18 @@ import { z } from 'zod';
 import { listTokens, createToken, revokeToken, ALL_SCOPES, type ApiScope } from '@/lib/mcp/tokens';
 import { revokeBootstrapToken } from '@/lib/mcp/bootstrapToken';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
+export const GET = withApiHandler({}, async ({ request }) => {
   const auth = await requireSession(request);
   if (auth instanceof NextResponse) return auth;
   const tokens = await listTokens();
   return NextResponse.json({ tokens });
-}
+});
 
 const CreateBody = z.object({
   name: z.string().min(1).max(100),
@@ -21,7 +22,9 @@ const CreateBody = z.object({
   expiresAt: z.string().datetime().optional(),
 });
 
-export async function POST(request: Request) {
+export const POST = withApiHandler({}, async ({ request }) => {
+  // requireSession is re-run here (the wrapper already gated POST) to
+  // recover the session's user for the token's `createdBy` field.
   const auth = await requireSession(request);
   if (auth instanceof NextResponse) return auth;
   try {
@@ -50,17 +53,18 @@ export async function POST(request: Request) {
   } catch (e) {
     return apiError(e, { tag: 'api:system:mcp-tokens:post', status: 400 });
   }
-}
+});
 
-export async function DELETE(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-  const { searchParams } = new URL(request.url);
-  const id = searchParams.get('id');
+const DeleteQuery = z.object({ id: z.string().optional() });
+
+export const DELETE = withApiHandler<undefined, z.infer<typeof DeleteQuery>>(
+  { query: DeleteQuery },
+  async ({ query }) => {
+  const id = query.id;
   if (!id || !/^[0-9a-f]{8}$/.test(id)) {
     return NextResponse.json({ error: 'invalid token id' }, { status: 400 });
   }
   const ok = await revokeToken(id);
   if (!ok) return NextResponse.json({ error: 'token not found' }, { status: 404 });
   return NextResponse.json({ ok: true });
-}
+});

--- a/src/app/api/system/media/init/route.ts
+++ b/src/app/api/system/media/init/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { apiError } from '@/lib/api/errors';
 
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 interface InitRequest {
@@ -27,11 +27,7 @@ interface InitRequest {
  *                                   exists; not an error, just a signal
  *   { error: '...' }              — anything else
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = await request.json() as Partial<InitRequest>;
     const { service, host, port, username, password } = body;
@@ -49,7 +45,7 @@ export async function POST(request: Request) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:media:init', status: 500 });
   }
-}
+});
 
 async function initAudiobookshelf(host: string, port: number, username: string, password: string) {
   const url = `http://${host}:${port}/init`;

--- a/src/app/api/system/nginx/bootstrap/route.ts
+++ b/src/app/api/system/nginx/bootstrap/route.ts
@@ -4,7 +4,7 @@ import { DigitalTwinStore } from '@/lib/store/twin';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { agentManager } from '@/lib/agent/manager';
 import { logger } from '@/lib/logger';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 
 /** Touch the install-nginx-done marker so the FCoS first-boot
@@ -151,10 +151,7 @@ async function npmUpdatePassword(baseUrl: string, token: string, current: string
   }
 }
 
-export async function POST(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = await request.json() as {
       node?: string;
@@ -279,4 +276,4 @@ export async function POST(request: Request) {
   } catch (e) {
     return apiError(e, { tag: 'api:system:nginx:bootstrap', status: 500 });
   }
-}
+});

--- a/src/app/api/system/nginx/export/route.ts
+++ b/src/app/api/system/nginx/export/route.ts
@@ -1,14 +1,19 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getExecutor } from '@/lib/executor';
 import { findNginxConfDir } from '@/lib/nginx/confDir';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
     try {
-        const { searchParams } = new URL(request.url);
-        const nodeParam = searchParams.get('node');
+        const nodeParam = query.node;
 
         const result = await findNginxConfDir();
         const debug = result?.debug || ['findNginxConfDir returned null'];
@@ -63,4 +68,5 @@ export async function GET(request: Request) {
         logger.error('api:nginx:export', 'Failed to export nginx config', error);
         return NextResponse.json({ error: 'Failed to export nginx config' }, { status: 500 });
     }
-}
+  },
+);

--- a/src/app/api/system/nginx/import/route.ts
+++ b/src/app/api/system/nginx/import/route.ts
@@ -1,18 +1,21 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getExecutor } from '@/lib/executor';
 import { findNginxConfDir } from '@/lib/nginx/confDir';
 import { extractNginxConfFromBackup } from '@/lib/nginx/backupExtract';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
+const Query = z.object({ node: z.string().optional() });
 
+// Body is parsed inline: this route accepts either a JSON `{ files }`
+// payload or a multipart backup upload, so it can't use the wrapper's
+// JSON-only `body:` slot.
+export const POST = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ request, query }) => {
     try {
-        const { searchParams } = new URL(request.url);
-        const nodeParam = searchParams.get('node');
+        const nodeParam = query.node;
 
         const contentType = request.headers.get('content-type') || '';
         let files: Record<string, string>;
@@ -86,4 +89,5 @@ export async function POST(request: Request) {
         logger.error('api:nginx:import', 'Failed to import nginx config', error);
         return NextResponse.json({ error: 'Failed to import nginx config' }, { status: 500 });
     }
-}
+  },
+);

--- a/src/app/api/system/nginx/install/route.ts
+++ b/src/app/api/system/nginx/install/route.ts
@@ -5,13 +5,9 @@ import { getConfig } from '@/lib/config';
 import { listNodes } from '@/lib/nodes';
 import { getExecutor } from '@/lib/executor';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
-import { requireSession } from '@/lib/api/requireSession';
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async () => {
     try {
         // 1. Get the template content
         const templateContent = await getTemplateYaml('nginx');
@@ -60,7 +56,7 @@ WantedBy=default.target
         logger.error('api:nginx:install', 'Failed to install nginx container', error);
         return NextResponse.json({ error: 'Failed to install nginx container' }, { status: 500 });
     }
-}
+});
 
 /**
  * Remove the install-nginx oneshot service left behind by the CoreOS install script.

--- a/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -1,11 +1,17 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { getConfig, updateConfig, ProxyHostEntry } from '@/lib/config';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { ServiceManager } from '@/lib/services/ServiceManager';
+import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 
-import { requireSession } from '@/lib/api/requireSession';
 export const dynamic = 'force-dynamic';
+
+const DeleteQuery = z.object({
+  domain: z.string().optional(),
+  node: z.string().optional(),
+});
 
 interface ProxyHostRequest {
     domain: string;
@@ -527,11 +533,7 @@ async function requestPublicCert(
  *
  * If forwardHost is not set, it defaults to the node's LAN IP.
  */
-export async function POST(request: Request) {
-  // requireSession gate (#596) — defense-in-depth atop proxy.ts.
-  const __auth = await requireSession(request);
-  if (__auth instanceof NextResponse) return __auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
     try {
         const { hosts, node, publicDomain, npmCredentials } = await request.json() as {
             hosts: ProxyHostRequest[];
@@ -718,7 +720,7 @@ export async function POST(request: Request) {
         logger.error('api:nginx:proxy-hosts', 'Failed to configure proxy hosts', error);
         return NextResponse.json({ error: 'Failed to configure proxy hosts' }, { status: 500 });
     }
-}
+});
 
 
 /**
@@ -734,14 +736,12 @@ export async function POST(request: Request) {
  * shared cert bundle may still be in use by another host), and the
  * cert_request_failure diagnose probe surfaces stale certs separately.
  */
-export async function DELETE(request: Request) {
-    const __auth = await requireSession(request);
-    if (__auth instanceof NextResponse) return __auth;
-
+export const DELETE = withApiHandler<undefined, z.infer<typeof DeleteQuery>>(
+  { query: DeleteQuery },
+  async ({ query }) => {
     try {
-        const url = new URL(request.url);
-        const domain = url.searchParams.get('domain');
-        const node = url.searchParams.get('node') ?? undefined;
+        const domain = query.domain;
+        const node = query.node;
         if (!domain) {
             return NextResponse.json({ error: 'domain query parameter is required' }, { status: 400 });
         }
@@ -803,4 +803,4 @@ export async function DELETE(request: Request) {
         logger.error('api:nginx:proxy-hosts:delete', 'Failed to delete proxy host', error);
         return NextResponse.json({ error: 'Failed to delete proxy host' }, { status: 500 });
     }
-}
+});

--- a/src/app/api/system/nginx/status/route.ts
+++ b/src/app/api/system/nginx/status/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
     try {
         // Check all known nodes for nginx, not just Local
         const twinStore = DigitalTwinStore.getInstance();
@@ -43,4 +44,4 @@ export async function GET() {
         logger.error('api:nginx:status', 'Failed to check nginx status', error);
         return NextResponse.json({ installed: false, error: String(error) });
     }
-}
+});

--- a/src/app/api/system/notifications/email/test/route.ts
+++ b/src/app/api/system/notifications/email/test/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { sendTestEmail } from '@/lib/email';
 
@@ -22,10 +22,7 @@ export const dynamic = 'force-dynamic';
  */
 const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export async function POST(request: Request) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = await request.json().catch(() => ({}));
     const to = typeof body?.to === 'string' ? body.to.trim() : '';
@@ -42,4 +39,4 @@ export async function POST(request: Request) {
     const message = error instanceof Error ? error.message : String(error);
     return apiError(new Error(message), { tag: 'api:system:notifications:email:test', status: 502 });
   }
-}
+});

--- a/src/app/api/system/reverse-proxy/migrate-to-public/route.ts
+++ b/src/app/api/system/reverse-proxy/migrate-to-public/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import {
   applyMigrationToPublic,
@@ -26,11 +26,8 @@ export const dynamic = 'force-dynamic';
  * lands in PR-2; until then this endpoint can only be exercised via
  * curl with a valid session cookie.
  */
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-
     let body: { publicDomain?: unknown; dryRun?: unknown };
     try {
       body = await request.json();
@@ -50,4 +47,4 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:reverse-proxy:migrate-to-public', status: 500 });
   }
-}
+});

--- a/src/app/api/system/reverse-proxy/preflight/route.ts
+++ b/src/app/api/system/reverse-proxy/preflight/route.ts
@@ -1,10 +1,14 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getPreflightStatus } from '@/lib/reverseProxy/preflight';
 import { validatePublicDomain } from '@/lib/reverseProxy/migrateToPublic';
 
 export const dynamic = 'force-dynamic';
+
+const Query = z.object({ publicDomain: z.string().optional() });
 
 /**
  * GET /api/system/reverse-proxy/preflight?publicDomain=<...>
@@ -19,13 +23,14 @@ export const dynamic = 'force-dynamic';
  * with the most recent answer and skips background scheduling. PR-2
  * can throttle on the UI side.
  */
-export async function GET(request: NextRequest) {
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ request, query }) => {
   try {
     const auth = await requireSession(request);
     if (auth instanceof NextResponse) return auth;
 
-    const url = new URL(request.url);
-    const publicDomain = url.searchParams.get('publicDomain');
+    const publicDomain = query.publicDomain ?? null;
     const domainError = validatePublicDomain(publicDomain);
     if (domainError) {
       return NextResponse.json({ error: domainError }, { status: 400 });
@@ -35,4 +40,4 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:reverse-proxy:preflight', status: 500 });
   }
-}
+});

--- a/src/app/api/system/stacks/[name]/status/route.ts
+++ b/src/app/api/system/stacks/[name]/status/route.ts
@@ -4,23 +4,23 @@
  * Single-stack detail: parsed manifest + per-child health. Drives the
  * stack-detail view (StackCard).
  */
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getStackManifest } from '@/lib/registry';
 import { getStackHealth } from '@/lib/install/stackHealth';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(
-  request: NextRequest,
-  ctx: { params: Promise<{ name: string }> },
-) {
+export const GET = withApiHandlerParams<undefined, undefined, { name: string }>(
+  {},
+  async ({ request, params }) => {
   const auth = await requireSession(request);
   if (auth instanceof NextResponse) return auth;
 
   try {
-    const { name } = await ctx.params;
+    const { name } = params;
     if (!name) return NextResponse.json({ error: 'name required' }, { status: 400 });
 
     let manifest;
@@ -41,4 +41,4 @@ export async function GET(
   } catch (e) {
     return apiError(e, { tag: 'api:system:stacks:status', status: 500 });
   }
-}
+});

--- a/src/app/api/system/stacks/[name]/wipe/route.ts
+++ b/src/app/api/system/stacks/[name]/wipe/route.ts
@@ -22,8 +22,8 @@
  * this endpoint — the basic stack is wipe-via-FACTORY-RESET only. The
  * caller can use `/api/system/factory-reset` for that path.
  */
-import { NextRequest, NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getStackManifest } from '@/lib/registry';
 import { ServiceManager } from '@/lib/services/ServiceManager';
@@ -44,15 +44,11 @@ interface WipeResult {
   wipedPaths: string[];
 }
 
-export async function POST(
-  request: NextRequest,
-  ctx: { params: Promise<{ name: string }> },
-) {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-
+export const POST = withApiHandlerParams<undefined, undefined, { name: string }>(
+  {},
+  async ({ request, params }) => {
   try {
-    const { name } = await ctx.params;
+    const { name } = params;
     const body = await request.json().catch(() => ({} as Record<string, unknown>));
     const expected = `WIPE-${name}`;
     if (body.confirm !== expected) {
@@ -172,7 +168,7 @@ export async function POST(
   } catch (e) {
     return apiError(e, { tag: 'api:system:stacks:wipe', status: 500 });
   }
-}
+});
 
 /**
  * Reconstruct the install-time variable map from persisted config.

--- a/src/app/api/system/stacks/reset/info/route.ts
+++ b/src/app/api/system/stacks/reset/info/route.ts
@@ -1,7 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { agentManager } from '@/lib/agent/manager';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getConfig } from '@/lib/config';
 import { RESET_GROUPS, getChildExclusions, isAlwaysWipe, type ResetGroup } from '@/lib/install/resetGroups';
@@ -53,13 +55,16 @@ export const dynamic = 'force-dynamic';
  * `du` failure on one path doesn't kill the whole response — that
  * group reports `bytes: null` so the UI can fall back to "size unknown".
  */
-export async function GET(request: NextRequest) {
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ request, query }) => {
   try {
     const auth = await requireSession(request);
     if (auth instanceof NextResponse) return auth;
 
-    const url = new URL(request.url);
-    const requestedNode = url.searchParams.get('node') || undefined;
+    const requestedNode = query.node || undefined;
 
     const twin = DigitalTwinStore.getInstance();
     const nodeName = requestedNode || Object.keys(twin.nodes)[0];
@@ -145,4 +150,4 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     return apiError(error, { tag: 'api:system:stacks:reset:info', status: 500 });
   }
-}
+});

--- a/src/app/api/system/stacks/reset/route.ts
+++ b/src/app/api/system/stacks/reset/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { performStackReset, StackResetError } from '@/lib/install/performStackReset';
 
@@ -20,11 +20,8 @@ export const dynamic = 'force-dynamic';
  *
  * ServiceBay itself is intentionally not touched (Quadlet definition).
  */
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler({}, async ({ request }) => {
   try {
-    const auth = await requireSession(request);
-    if (auth instanceof NextResponse) return auth;
-
     const body = await request.json();
     const { confirm, node: requestedNode, preserve: rawPreserve } = body as {
       confirm?: string;
@@ -47,4 +44,4 @@ export async function POST(request: NextRequest) {
     }
     return apiError(error, { tag: 'api:system:stacks:reset', status: 500 });
   }
-}
+});

--- a/src/app/api/system/stacks/route.ts
+++ b/src/app/api/system/stacks/route.ts
@@ -9,6 +9,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { NextResponse } from 'next/server';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getStackManifest } from '@/lib/registry';
 import { getStackHealth, type StackHealth } from '@/lib/install/stackHealth';
@@ -25,7 +26,7 @@ interface StackSummary {
   health: StackHealth | null;
 }
 
-export async function GET(request: Request) {
+export const GET = withApiHandler({}, async ({ request }) => {
   const auth = await requireSession(request);
   if (auth instanceof NextResponse) return auth;
 
@@ -68,4 +69,4 @@ export async function GET(request: Request) {
   } catch (e) {
     return apiError(e, { tag: 'api:system:stacks:list', status: 500 });
   }
-}
+});

--- a/src/app/api/system/templates/[name]/upgrade-preview/route.ts
+++ b/src/app/api/system/templates/[name]/upgrade-preview/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandlerParams } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getConfig } from '@/lib/config';
 import { getTemplateYaml, getTemplateChangelog } from '@/lib/registry';
@@ -34,19 +36,19 @@ export const dynamic = 'force-dynamic';
  *
  * See #353 / #352.
  */
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> },
-) {
+const Query = z.object({ source: z.string().optional() });
+
+export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, { name: string }>(
+  { query: Query },
+  async ({ request, query, params }) => {
   const auth = await requireSession(request);
   if (auth instanceof NextResponse) return auth;
   try {
-    const { name } = await params;
+    const { name } = params;
     if (!/^[a-z][a-z0-9-]{0,63}$/.test(name)) {
       return NextResponse.json({ error: 'invalid template name' }, { status: 400 });
     }
-    const { searchParams } = new URL(request.url);
-    const source = searchParams.get('source') ?? undefined;
+    const source = query.source ?? undefined;
 
     const yaml = await getTemplateYaml(name, source);
     if (yaml === null) {
@@ -78,4 +80,4 @@ export async function GET(
   } catch (e) {
     return apiError(e, { tag: 'api:system:templates:upgrade-preview', status: 500 });
   }
-}
+});

--- a/src/app/api/system/templates/upgrades-pending/route.ts
+++ b/src/app/api/system/templates/upgrades-pending/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getConfig } from '@/lib/config';
 import { getTemplateYaml, getTemplateChangelog } from '@/lib/registry';
@@ -37,7 +38,7 @@ interface UpgradeSummary {
  * would sit unnoticed for any operator who never opens the
  * Re-deploy modal.
  */
-export async function GET(request: Request) {
+export const GET = withApiHandler({}, async ({ request }) => {
   const auth = await requireSession(request);
   if (auth instanceof NextResponse) return auth;
   try {
@@ -95,4 +96,4 @@ export async function GET(request: Request) {
   } catch (e) {
     return apiError(e, { tag: 'api:system:templates:upgrades-pending', status: 500 });
   }
-}
+});

--- a/src/app/api/system/verify-lan-dns/route.ts
+++ b/src/app/api/system/verify-lan-dns/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getConfig } from '@/lib/config';
 import { getActiveDomain } from '@/lib/mode';
+import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,7 +32,7 @@ export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: corsHeaders() });
 }
 
-export async function GET() {
+export const GET = withApiHandler({}, async () => {
   const config = await getConfig();
   return NextResponse.json(
     {
@@ -42,4 +43,4 @@ export async function GET() {
     },
     { headers: corsHeaders() },
   );
-}
+});

--- a/tests/backend/access_requests.test.ts
+++ b/tests/backend/access_requests.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 });
 
 const post = (body: unknown, opts?: { rawBody?: string }) =>
-  POST(new Request('http://test/api/system/access-requests', {
+  POST(new NextRequest('http://test/api/system/access-requests', {
     method: 'POST',
     body: opts?.rawBody ?? JSON.stringify(body),
     headers: { 'Content-Type': 'application/json' },

--- a/tests/backend/upgradesPending.test.ts
+++ b/tests/backend/upgradesPending.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/api/requireSession', () => ({
   requireSession: vi.fn(async () => ({ user: 'test', expires: new Date(Date.now() + 60_000) })),
@@ -41,8 +42,8 @@ initial fix.
 initial.
 `;
 
-function makeRequest(): Request {
-  return new Request('http://localhost/api/system/templates/upgrades-pending');
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/system/templates/upgrades-pending');
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

**Completely solves #603.** Every API route now uses `withApiHandler` / `withApiHandlerParams` — adoption goes from **59/108 (54.6%) → 108/108 (100%)** and the enforcement tooling is promoted to hard errors so it can never regress.

This PR has two commits:
1. **nginx cluster** — `status`, `export`, `import`, `install`, `bootstrap` (the original scope of this PR).
2. **Full burn-down** — the remaining ~47 verb exports across ~45 files, plus the wrapper change and tooling promotion.

### Wrapper change

Adds a `skipAuth` option to `withApiHandler`. The built-in `requireSession` gate fires on every mutating verb, which is wrong for the *intentionally-public* routes (login, OIDC initiator, family-portal access-request submission). `{ skipAuth: true }` opts those out while keeping the shared error envelope. Mirrors `src/proxy.ts:PUBLIC_API_RULES`.

### Routes migrated

services (`route.ts` + `[name]`), `system/stacks/**`, `install/**`, `containers/[id]/**`, `system/nginx/**` (incl. `proxy-hosts`), `system/discovery/**`, `system/diagnose` + `run-action`, `auth/**`, `access-requests` POST, and the long tail of single-route clusters (lldap, media, dns, filebrowser, notifications, reverse-proxy, authelia, file-share, mcp-tokens, network/edges, devices, files, verify-lan-dns, templates, health/checks).

- Dynamic-segment routes use `withApiHandlerParams`.
- Query params are now Zod-validated.
- Response shapes preserved verbatim — frontend callers need no changes.
- GET routes that hand-rolled `requireSession` keep it inline (the wrapper only gates mutating verbs).

### Tooling promoted to hard enforcement

- `check-invariants.ts` `MIN_WITH_API_HANDLER_RATIO`: 0.55 → **1.0**
- ESLint `sb/api-route-needs-handler`: `warn` → **`error`**
- `.semgrep.yml` `api-route-without-with-api-handler`: `INFO` → **`WARNING`**
- `docs/ARCHITECTURE_INVARIANTS.md` adoption row: **108 of 108 (100%)**

### Test changes

Two tests that call route handlers directly were updated to construct `NextRequest` (the wrapper reads `request.nextUrl`): `upgradesPending.test.ts`, `access_requests.test.ts`. The `access_requests` POST test now also exercises `skipAuth` end-to-end.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run check:arch` — clean with the new 1.0 floor
- [x] `npx eslint src/app/api/` — **0 errors** (rule now `error`, 100% compliant)
- [x] `npx vitest run` — 1132 pass, 2 skipped (incl. `route_session_gate`)
- [ ] CI `next build` — final route-type gate
- [ ] Smoke-test login, install wizard, and a public/LAN portal access request

Closes #603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
