### PR TITLE
fix(install): readiness gating + per-service proxy hosts (#807, #808, #809, #810)

### DIFF
--- a/packages/backend/src/lib/install/runner.test.ts
+++ b/packages/backend/src/lib/install/runner.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Install-runner unit tests (#810).
+ *
+ * Covers the inter-template readiness gate: `isServiceReady` (the
+ * readiness predicate) and `waitForDependencies` (the gate that blocks
+ * a template's deploy until its declared dependencies are healthy).
+ *
+ * The twin is mocked the same way `stackRunner.test.ts` does it, so the
+ * gate reads deterministic fixtures instead of a live digital twin.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const twinStub: {
+  nodes: Record<string, { services?: Array<{ name: string; active?: boolean; health?: { ready: boolean } }> }>;
+} = { nodes: {} };
+vi.mock('@/lib/store/twin', () => ({
+  DigitalTwinStore: {
+    getInstance: () => ({
+      getSnapshot: () => ({ nodes: twinStub.nodes }),
+    }),
+  },
+}));
+
+// The gate registers deployed services with the health poller before
+// polling. In a unit test there is no agent to list services from, so
+// stub the bootstrap to a no-op.
+const bootstrapMock = vi.fn().mockResolvedValue({ registered: [], skipped: [] });
+vi.mock('@/lib/health/serviceHealthBootstrap', () => ({
+  bootstrapServiceHealth: () => bootstrapMock(),
+}));
+
+import { isServiceReady, waitForDependencies } from './runner';
+
+beforeEach(() => {
+  twinStub.nodes = {};
+  bootstrapMock.mockClear();
+});
+
+describe('isServiceReady', () => {
+  it('prefers the health signal over systemd-active', () => {
+    // active=true but health.ready=false → not ready (app still booting
+    // inside an active unit — the exact #810 failure mode).
+    expect(isServiceReady([{ name: 'auth', active: true, health: { ready: false } }], 'auth')).toBe(false);
+    expect(isServiceReady([{ name: 'auth', active: false, health: { ready: true } }], 'auth')).toBe(true);
+  });
+
+  it('falls back to systemd-active when no health signal is present', () => {
+    expect(isServiceReady([{ name: 'nginx', active: true }], 'nginx')).toBe(true);
+    expect(isServiceReady([{ name: 'nginx', active: false }], 'nginx')).toBe(false);
+  });
+
+  it('matches a unit name with or without the .service suffix', () => {
+    expect(isServiceReady([{ name: 'auth.service', active: true }], 'auth')).toBe(true);
+  });
+
+  it('returns false when the service is absent from the twin', () => {
+    expect(isServiceReady([{ name: 'nginx', active: true }], 'auth')).toBe(false);
+  });
+});
+
+describe('waitForDependencies', () => {
+  it('returns immediately when the item declares no dependencies', async () => {
+    await waitForDependencies('job1', { name: 'ollama', dependencies: [] }, 'Local');
+    // No twin read, no health bootstrap when there is nothing to gate on.
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves once every declared dependency is healthy', async () => {
+    twinStub.nodes['Local'] = {
+      services: [
+        { name: 'nginx', health: { ready: true } },
+        { name: 'auth', health: { ready: true } },
+      ],
+    };
+    await expect(
+      waitForDependencies('job1', { name: 'media', dependencies: ['nginx', 'auth'] }, 'Local'),
+    ).resolves.toBeUndefined();
+    // The gate registers deployed services with the health poller first.
+    expect(bootstrapMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/lib/install/runner.test.ts
+++ b/packages/backend/src/lib/install/runner.test.ts
@@ -29,11 +29,21 @@ vi.mock('@/lib/health/serviceHealthBootstrap', () => ({
   bootstrapServiceHealth: () => bootstrapMock(),
 }));
 
-import { isServiceReady, waitForDependencies } from './runner';
+// `ensureProxyHosts` POSTs via the loopback apiFetch, which attaches the
+// internal token — stub it so the test doesn't need a real token file.
+vi.mock('@/lib/auth/internalToken', () => ({
+  getInternalApiToken: () => 'test-token',
+}));
+
+import { isServiceReady, waitForDependencies, ensureProxyHosts } from './runner';
+import type { StackVariable } from '@/lib/stackInstall/postInstall';
+
+const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
 beforeEach(() => {
   twinStub.nodes = {};
   bootstrapMock.mockClear();
+  fetchSpy.mockReset();
 });
 
 describe('isServiceReady', () => {
@@ -77,5 +87,48 @@ describe('waitForDependencies', () => {
     ).resolves.toBeUndefined();
     // The gate registers deployed services with the health poller first.
     expect(bootstrapMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ensureProxyHosts', () => {
+  const subdomainVar = (template: string, varName: string, sub: string): StackVariable => ({
+    name: varName,
+    value: sub,
+    meta: {
+      type: 'subdomain',
+      templateName: template,
+      proxyPort: '2283',
+      exposure: 'public',
+    } as StackVariable['meta'],
+  });
+
+  it('POSTs every subdomain host in one batch, even across templates', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, created: ['photos.dopp.cloud', 'vault.dopp.cloud'] }), { status: 200 }),
+    );
+    const variables: StackVariable[] = [
+      { name: 'PUBLIC_DOMAIN', value: 'dopp.cloud' },
+      subdomainVar('immich', 'IMMICH_SUBDOMAIN', 'photos'),
+      subdomainVar('vaultwarden', 'VAULTWARDEN_SUBDOMAIN', 'vault'),
+    ];
+    await ensureProxyHosts('job1', variables, undefined);
+    // Single consolidated POST — not one-per-template.
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/system\/nginx\/proxy-hosts$/);
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.publicDomain).toBe('dopp.cloud');
+    const domains = body.hosts.map((h: { domain: string }) => h.domain).sort();
+    expect(domains).toEqual(['photos.dopp.cloud', 'vault.dopp.cloud']);
+  });
+
+  it('no-ops on a pure-LAN install with no PUBLIC_DOMAIN', async () => {
+    await ensureProxyHosts('job1', [subdomainVar('immich', 'IMMICH_SUBDOMAIN', 'photos')], undefined);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when there are no subdomain-typed variables', async () => {
+    await ensureProxyHosts('job1', [{ name: 'PUBLIC_DOMAIN', value: 'dopp.cloud' }], undefined);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -68,6 +68,19 @@ const SETTLE_TIMEOUT_MS = 3 * 60_000;
 const SETTLE_POLL_MS = 5_000;
 const SETTLE_HEARTBEAT_MS = 15_000;
 
+/** Inter-template dependency-readiness gate (#810). The topo-sort
+ *  guarantees a template deploys *after* its `servicebay.dependencies`,
+ *  but ordering is not readiness — the deploy loop fires each template's
+ *  post-deploy script back-to-back, so a script that talks to a
+ *  dependency's API (e.g. `media` post-deploy → Authelia OIDC discovery)
+ *  can run while that dependency is still booting. Before deploying an
+ *  item we block until every declared dependency reports health-ready in
+ *  the twin. Same 3-minute cap as the settle-wait — long enough for a
+ *  cold-start image pull, then proceed and let diagnose surface a real
+ *  failure rather than hanging the install forever. */
+const DEP_READY_TIMEOUT_MS = 3 * 60_000;
+const DEP_READY_POLL_MS = 3_000;
+
 /** Set by `abortJob`. Checked at top of every deploy-loop iteration and
  *  before each retry attempt so the loop bails out as soon as possible. */
 const abortFlags = new Map<string, boolean>();
@@ -164,6 +177,23 @@ async function waitForCredentials(
   });
 }
 
+/** True when `name` reports ready in the twin's service list. Prefers
+ *  the unified health signal (#627) — set by the service-health poller
+ *  when the template ships a `servicebay.healthcheck` annotation — and
+ *  falls back to the systemd-active flag for templates that don't ship
+ *  one yet. `degraded: true` still counts as ready (the operator sees
+ *  the soft-fail banner; gating doesn't hang on it). */
+export function isServiceReady(
+  services: ReadonlyArray<{ name: string; active?: boolean; health?: { ready: boolean } }>,
+  name: string,
+): boolean {
+  return services.some(s => {
+    if (s.name !== name && s.name !== `${name}.service`) return false;
+    if (s.health) return s.health.ready === true;
+    return s.active === true;
+  });
+}
+
 /** Settle-wait: poll the digital twin in-process until every newly
  *  deployed service is ready.
  *
@@ -195,17 +225,7 @@ async function settleWait(
     const snapshot = twin.getSnapshot();
     const twinNode = snapshot.nodes?.[node];
     const services = twinNode?.services ?? [];
-    const ready = expected.filter(name =>
-      services.some(s => {
-        if (s.name !== name && s.name !== `${name}.service`) return false;
-        // Prefer the unified health signal when the poller has populated
-        // it. `degraded: true` still counts as ready for settle purposes —
-        // the operator sees the soft-fail in the UI banner, but the install
-        // doesn't get stuck on it.
-        if (s.health) return s.health.ready === true;
-        return s.active === true;
-      }),
-    ).length;
+    const ready = expected.filter(name => isServiceReady(services, name)).length;
     const now = Date.now();
     if (ready !== lastReady) {
       await log(jobId, `Waiting for services to become active... (${ready}/${expected.length} up)`);
@@ -224,6 +244,61 @@ async function settleWait(
     await log(jobId, `✅ All ${expected.length} services active after ${elapsed}s.`);
   } else {
     await log(jobId, `⚠️ ${lastReady}/${expected.length} services active after ${elapsed}s — slow image pulls or a real failure. Self-diagnose below will tell you which.`);
+  }
+}
+
+/** Block until every declared dependency of `item` reports health-ready
+ *  in the twin (#810). Called before the item deploys — its post-deploy
+ *  script runs as part of the same `/api/services` POST, so the
+ *  dependency must be responsive *before* the deploy fires, not just
+ *  ordered ahead of it.
+ *
+ *  Best-effort by design: on timeout we log a warning and proceed. The
+ *  post-deploy may then report errors, but those surface through the
+ *  normal diagnose path — far better than wedging the whole install on
+ *  one slow dependency. `bootstrapServiceHealth` is invoked first so the
+ *  poller is already probing every just-deployed dependency; without
+ *  that the gate would only ever see the coarse systemd-active flag. */
+export async function waitForDependencies(
+  jobId: string,
+  item: { name: string; dependencies?: string[] },
+  node: string,
+): Promise<void> {
+  const deps = item.dependencies ?? [];
+  if (deps.length === 0) return;
+
+  // Register every deployed-so-far service with the health poller so the
+  // dependencies we're about to wait on have a live `health` signal.
+  try {
+    const { bootstrapServiceHealth } = await import('@/lib/health/serviceHealthBootstrap');
+    await bootstrapServiceHealth(node);
+  } catch { /* fall back to the systemd-active signal */ }
+
+  const twin = DigitalTwinStore.getInstance();
+  const startedAt = Date.now();
+  let lastLogAt = startedAt;
+  const pending = new Set(deps);
+  await log(jobId, `Waiting for ${item.name}'s dependencies to become healthy: ${deps.join(', ')}...`);
+  while (pending.size > 0 && Date.now() - startedAt < DEP_READY_TIMEOUT_MS) {
+    if (abortFlags.get(jobId)) return;
+    const services = twin.getSnapshot().nodes?.[node]?.services ?? [];
+    for (const dep of [...pending]) {
+      if (isServiceReady(services, dep)) pending.delete(dep);
+    }
+    if (pending.size === 0) break;
+    const now = Date.now();
+    if (now - lastLogAt >= SETTLE_HEARTBEAT_MS) {
+      const elapsed = Math.floor((now - startedAt) / 1000);
+      await log(jobId, `Still waiting for ${[...pending].join(', ')} to be healthy (${elapsed}s elapsed)...`);
+      lastLogAt = now;
+    }
+    await new Promise(r => setTimeout(r, DEP_READY_POLL_MS));
+  }
+  if (pending.size === 0) {
+    await log(jobId, `✅ ${item.name}'s dependencies are healthy.`);
+  } else {
+    const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+    await log(jobId, `⚠️ ${item.name}'s dependencies not healthy after ${elapsed}s (${[...pending].join(', ')}). Continuing anyway — its post-deploy may report errors; self-diagnose below will tell you what's stuck.`);
   }
 }
 
@@ -831,6 +906,20 @@ async function runJob(jobId: string): Promise<void> {
       await log(jobId, `✅ ${item.name} already installed, skipping.`);
       ctx.deployed.push({ name: item.name });
       continue;
+    }
+    // #810 — gate on dependency readiness before deploying. The item's
+    // post-deploy script runs inside `deployItem`, so a dependency that
+    // is merely ordered ahead (not yet healthy) would otherwise be hit
+    // mid-boot.
+    await waitForDependencies(jobId, item, input.node || 'Local');
+    if (abortFlags.get(jobId)) {
+      await patchJob(jobId, {
+        phase: 'aborted',
+        endedAt: new Date().toISOString(),
+        error: 'Installation aborted by user.',
+      });
+      await log(jobId, '⛔ Install aborted by user.');
+      return;
     }
     try {
       const ok = await deployItem(ctx, item);

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -38,6 +38,7 @@ import { parseTemplateTier } from '@/lib/templateTier';
 import { selectMigrationChain } from '@/lib/stackInstall/migrations';
 import {
   bootstrapNpmAdmin,
+  buildProxyHosts,
   type StackVariable,
 } from '@/lib/stackInstall/postInstall';
 import { buildCredentialsManifest, type Credential } from '@/lib/stackInstall/credentialsManifest';
@@ -533,6 +534,55 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
     : `after ${MAX_DEPLOY_ATTEMPTS} attempt(s): ${lastErr?.message ?? 'unknown error'}`;
   await log(jobId, `❌ Failed to install ${item.name} ${tail}`);
   return false;
+}
+
+/** Consolidated per-service proxy-host provisioning (#807).
+ *
+ *  The capability bus fires one `feature.installed` per template and the
+ *  nginx handler creates only *that* template's subdomain hosts. If any
+ *  single per-template emit is skipped or under-produces, the operator
+ *  is left with the portal routes (created separately by the portal
+ *  provisioner) but no service subdomains — and the failure is silent
+ *  because the handler no-ops `{ ok: true }` when it finds nothing of
+ *  its own to do.
+ *
+ *  This pass builds the host list from every subdomain-typed variable
+ *  across the whole install and creates them in one batch. The
+ *  proxy-hosts route is idempotent (it dedupes by domain), so running
+ *  this after the per-template emits is safe — anything the handlers
+ *  already created is a no-op, anything they missed gets created here.
+ *  The install no longer depends on every per-template emit landing. */
+export async function ensureProxyHosts(
+  jobId: string,
+  variables: StackVariable[],
+  node: string | undefined,
+): Promise<void> {
+  const { domain, hosts } = buildProxyHosts(variables);
+  // No public/LAN domain or no subdomain-typed variables → nothing to
+  // route. A pure-LAN install with no subdomains is a valid no-op.
+  if (!domain || hosts.length === 0) return;
+  try {
+    const res = await apiFetch('/api/system/nginx/proxy-hosts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hosts, publicDomain: domain, node }),
+    });
+    const data = await res.json().catch(() => ({} as Record<string, unknown>));
+    if (!res.ok) {
+      const msg = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+      await log(jobId, `⚠️ Could not create per-service proxy hosts: ${msg}. Settings → Self-Diagnose → Reprovision will retry.`);
+      return;
+    }
+    const created = Array.isArray(data.created) ? (data.created as string[]) : [];
+    const failed = Array.isArray(data.failed) ? (data.failed as Array<{ domain?: string }>) : [];
+    await log(jobId, `✅ Per-service proxy hosts ensured for ${hosts.length} service domain(s)${created.length ? ` (${created.join(', ')})` : ''}.`);
+    if (failed.length > 0) {
+      const names = failed.map(f => f.domain ?? '?').join(', ');
+      await log(jobId, `⚠️ Some proxy hosts could not be created: ${names}. Self-diagnose → Reprovision will retry.`);
+    }
+  } catch (e) {
+    await log(jobId, `⚠️ Per-service proxy-host creation failed: ${e instanceof Error ? e.message : String(e)}. Settings → Self-Diagnose → Reprovision will retry.`);
+  }
 }
 
 /** Inner async pipeline — wrapped by `startJob` so the public surface
@@ -1085,6 +1135,11 @@ async function runJob(jobId: string): Promise<void> {
       await log(jobId, `(note) capability emit failed for ${name}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
+
+  // #807 — guarantee every service subdomain has an NPM proxy host,
+  // regardless of whether each per-template `feature.installed` emit
+  // created its own. Idempotent: re-creating an existing host no-ops.
+  await ensureProxyHosts(jobId, variables, input.node);
 
   // Build the final credentials manifest for the Done UI. Handler
   // already persisted per-template entries to `config.installManifest`

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -27,8 +27,20 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
+
+
+# LLDAP readiness gate (#808). LLDAP shares the `auth` pod with Authelia,
+# but the pod's continuous healthcheck only probes Authelia's
+# `/api/health` — Authelia reaches LLDAP over the LDAP socket, which says
+# nothing about LLDAP's HTTP/GraphQL API being up. The group seed below
+# talks to that HTTP API, so it must wait for it explicitly. Module-level
+# so the test suite can shrink the budget.
+LLDAP_READY_TIMEOUT = 5 * 60
+LLDAP_READY_INTERVAL = 5
+SEED_MAX_ATTEMPTS = 3
 
 
 def env(key: str, default: str = "") -> str:
@@ -70,6 +82,31 @@ def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tu
             return e.code, None
     except (urllib.error.URLError, TimeoutError, OSError):
         return 0, None
+
+
+def wait_for_lldap(sb_api: str, port: int) -> bool:
+    """Poll ServiceBay's LLDAP readiness probe until LLDAP's HTTP/GraphQL
+    endpoint accepts connections. Returns True once reachable, False if
+    the deadline passes first. The probe returns `reachable: true` only
+    after LLDAP's SQLite schema is initialized and the API layer is up
+    (a bare 401 on `/api/graphql`), so seeding straight after it is
+    safe."""
+    started = time.time()
+    last_beat = 0.0
+    while time.time() - started < LLDAP_READY_TIMEOUT:
+        status, body = post_json(
+            f"{sb_api}/api/system/lldap/probe",
+            {"host": "localhost", "port": port},
+            timeout=10,
+        )
+        if status == 200 and body and body.get("reachable"):
+            return True
+        elapsed = time.time() - started
+        if elapsed - last_beat >= 10:
+            log(f"Waiting for LLDAP's HTTP API to come up ({int(elapsed)}s elapsed)...")
+            last_beat = elapsed
+        time.sleep(LLDAP_READY_INTERVAL)
+    return False
 
 
 def main() -> int:
@@ -122,30 +159,51 @@ def main() -> int:
         )
 
     # ── Seed `admins` + `family` groups ──────────────────────────────────
-    # The install runner's readiness probes (servicebay.readiness in this
-    # template's template.yml, #613) already blocked on LLDAP's GraphQL
-    # endpoint returning 401 — by the time we get here the SQLite schema
-    # is initialized and seed can run immediately.
-    log("Seeding LLDAP groups...")
-    seed_status, seed_body = post_json(
-        f"{sb_api}/api/system/lldap/seed",
-        {"host": "localhost", "port": int(lldap_port), "password": lldap_password},
-        timeout=15,
-    )
-    if seed_status == 200 and seed_body:
-        created = seed_body.get("created") or []
-        existing = seed_body.get("existing") or []
-        failed = seed_body.get("failed") or []
-        if created:
-            log(f"✅ Groups created: {', '.join(str(x) for x in created)}")
-        if existing:
-            log(f"ℹ️ Groups already exist: {', '.join(str(x) for x in existing)}")
-        if failed:
-            names = ", ".join(str(f.get("name", "?")) for f in failed)
-            log(f"⚠️ Failed: {names}")
+    # Wait for LLDAP's HTTP API before seeding (#808). The install
+    # runner's per-template readiness probes were retired in Phase 3C, so
+    # this script can no longer assume LLDAP is up by the time it runs —
+    # and a single unguarded seed attempt that lands mid-boot fails
+    # silently, leaving `admins`/`family` uncreated forever. Gate on the
+    # readiness probe, then retry the seed itself a few times in case the
+    # schema is still settling.
+    if not wait_for_lldap(sb_api, int(lldap_port)):
+        log(
+            f"⚠️ LLDAP's HTTP API never became reachable within {LLDAP_READY_TIMEOUT // 60} min — "
+            "skipping group seed. The `admins`/`family` groups were NOT created; "
+            "re-run setup once LLDAP is up, or create them in LLDAP's web UI. "
+            "Family members can't be group-assigned until they exist."
+        )
     else:
-        err = (seed_body or {}).get("error", f"HTTP {seed_status}")
-        log(f"⚠️ Could not seed LLDAP groups: {err}")
+        log("Seeding LLDAP groups...")
+        for attempt in range(1, SEED_MAX_ATTEMPTS + 1):
+            seed_status, seed_body = post_json(
+                f"{sb_api}/api/system/lldap/seed",
+                {"host": "localhost", "port": int(lldap_port), "password": lldap_password},
+                timeout=15,
+            )
+            ok = seed_status == 200 and isinstance(seed_body, dict)
+            failed = (seed_body.get("failed") or []) if ok else []
+            if ok and not failed:
+                created = seed_body.get("created") or []
+                existing = seed_body.get("existing") or []
+                if created:
+                    log(f"✅ Groups created: {', '.join(str(x) for x in created)}")
+                if existing:
+                    log(f"ℹ️ Groups already exist: {', '.join(str(x) for x in existing)}")
+                break
+            # The seed endpoint is idempotent (it reports `existing` for
+            # groups already present), so retrying a partial/failed run
+            # is safe.
+            err = (
+                ", ".join(str(f.get("name", "?")) for f in failed)
+                if failed
+                else (seed_body or {}).get("error", f"HTTP {seed_status}")
+            )
+            if attempt < SEED_MAX_ATTEMPTS:
+                log(f"⏳ LLDAP group seed attempt {attempt}/{SEED_MAX_ATTEMPTS} incomplete ({err}); retrying in {LLDAP_READY_INTERVAL}s...")
+                time.sleep(LLDAP_READY_INTERVAL)
+            else:
+                log(f"⚠️ Could not fully seed LLDAP groups after {SEED_MAX_ATTEMPTS} attempts: {err}")
 
     # ── Authelia portal URL — credential entry only (no admin user; auth
     # via LLDAP) ─────────────────────────────────────────────────────────

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -75,6 +75,11 @@ def render_http_code(code: int) -> str:
 
 REQUEST_TIMEOUT = 30.0
 
+# Jellyfin first-run readiness gate (#809). Module-level so the test
+# suite can shrink the budget.
+JELLYFIN_READY_TIMEOUT = 5 * 60
+JELLYFIN_READY_INTERVAL = 5
+
 
 def request_json(
     method: str,
@@ -192,11 +197,32 @@ JELLYFIN_AUTH_HEADER = (
 )
 
 
-# Jellyfin's readiness is now declared in servicebay.readiness on this
-# template's template.yml (#613). The install runner blocks on
-# /Startup/FirstUser → 200 *before* invoking this script, replacing the
-# previous in-script jellyfin_wait_ready + jellyfin_wait_default_user
-# helpers (both polled the same surface from inside post-deploy.py).
+def jellyfin_wait_default_user(base_url: str) -> bool:
+    """Poll `GET /Startup/FirstUser` until it returns 200.
+
+    That endpoint runs the UserManager's async init pass — which creates
+    Jellyfin's default user — *before* responding. A successful GET
+    therefore both confirms Jellyfin is up AND guarantees the default
+    user exists. `POST /Startup/User` does NOT initialize the
+    UserManager; it just calls `GetFirstUser()` and returns 404
+    ("NotFound") when no user exists yet. So without this wait the admin
+    seed races first-run init and Jellyfin answers 404.
+
+    Phase 3C retired the install runner's per-template readiness probe
+    that used to do this wait, so it has to live back in this script
+    (#809). Returns True once ready, False if the deadline passes."""
+    started = time.time()
+    last_beat = 0.0
+    while time.time() - started < JELLYFIN_READY_TIMEOUT:
+        code, _ = request_json("GET", f"{base_url}/Startup/FirstUser", timeout=10)
+        if code == 200:
+            return True
+        elapsed = time.time() - started
+        if elapsed - last_beat >= 10:
+            log(f"Waiting for Jellyfin to finish first-run init ({int(elapsed)}s elapsed)...")
+            last_beat = elapsed
+        time.sleep(JELLYFIN_READY_INTERVAL)
+    return False
 
 
 def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str, tz: str) -> bool:
@@ -210,6 +236,13 @@ def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str
     if code == 200 and isinstance(info, dict) and info.get("StartupWizardCompleted"):
         log("ℹ️ Jellyfin startup wizard already completed — leaving the existing admin.")
         return True
+
+    # Wait for Jellyfin's UserManager to finish initializing before
+    # touching any /Startup/* endpoint (#809) — POST /Startup/User 404s
+    # until the default user exists.
+    if not jellyfin_wait_default_user(base_url):
+        log(f"⚠️ Jellyfin: /Startup/FirstUser never returned 200 within {JELLYFIN_READY_TIMEOUT // 60} min — install-blocking. Open the Jellyfin web UI and finish the setup wizard manually.")
+        return False
 
     # Locale + metadata language. German default to match the home;
     # operator can change in Settings → Server later.
@@ -471,10 +504,8 @@ def main() -> int:
     seed_audiobookshelf(abs_port, abs_user, abs_password)
 
     # ── Jellyfin first-run + Quick Connect + Music library ───────────
-    # The install runner's readiness probe (servicebay.readiness, #613)
-    # already blocked on /Startup/FirstUser → 200, so the UserManager has
-    # finished its async init pass and the default user exists. No
-    # in-script wait needed.
+    # `jellyfin_run_first_setup` waits for the UserManager's async init
+    # (via GET /Startup/FirstUser) before seeding the admin — see #809.
     if jf_password:
         jellyfin_base = f"http://127.0.0.1:{jf_port}"
         ready = jellyfin_run_first_setup(

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -264,6 +264,62 @@ class AuthScript(unittest.TestCase):
         self.assertNotIn("lldap-pass", log_only)
         self.assertNotIn("jwt-secret", log_only)
 
+    def test_seed_skipped_when_lldap_never_reachable(self):
+        """If LLDAP's HTTP API never comes up, the group seed is skipped
+        with a clear breadcrumb instead of firing blind against a
+        not-ready LLDAP and failing silently (regression-guard for
+        #808)."""
+        m = load_script("auth")
+        responses = {
+            "/api/system/lldap/credentials": {"status": 200, "body": {"ok": True}},
+            # Probe answers but reports LLDAP not yet reachable, forever.
+            "/api/system/lldap/probe": {"status": 200, "body": {"reachable": False}},
+        }
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "LLDAP_ADMIN_PASSWORD": "lldap-pass",
+            "LLDAP_PORT": "17170",
+        }
+        import time as time_mod
+        import urllib.request
+        with run_with_env(env), \
+             mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)), \
+             mock.patch.object(time_mod, "sleep", lambda _s: None), \
+             mock.patch.object(m, "LLDAP_READY_TIMEOUT", 0.01), \
+             mock.patch.object(m, "LLDAP_READY_INTERVAL", 0.001):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("skipping group seed", out)
+        # The seed endpoint must never have been hit while LLDAP is down.
+        self.assertNotIn("Seeding LLDAP groups", out)
+
+    def test_seed_retries_then_warns_on_persistent_failure(self):
+        """Once LLDAP is reachable, a failing seed is retried a few
+        times before the script gives up — the pre-#808 code ran it
+        exactly once and never retried."""
+        m = load_script("auth")
+        responses = {
+            "/api/system/lldap/credentials": {"status": 200, "body": {"ok": True}},
+            "/api/system/lldap/probe": {"status": 200, "body": {"reachable": True}},
+            "/api/system/lldap/seed": {"status": 500, "body": {"error": "boom"}},
+        }
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "LLDAP_ADMIN_PASSWORD": "lldap-pass",
+            "LLDAP_PORT": "17170",
+        }
+        import time as time_mod
+        import urllib.request
+        with run_with_env(env), \
+             mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)), \
+             mock.patch.object(time_mod, "sleep", lambda _s: None), \
+             mock.patch.object(m, "LLDAP_READY_INTERVAL", 0.001):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("Could not fully seed LLDAP groups after 3 attempts", out)
+
 
 class FileShareScript(unittest.TestCase):
     def test_samba_credential_emitted_when_password_set(self):
@@ -413,6 +469,77 @@ class MediaScript(unittest.TestCase):
         )
         self.assertNotIn("abs-pass", log_only)
         self.assertNotIn("jf-pass", log_only)
+
+    def test_jellyfin_waits_for_default_user_before_seeding_admin(self):
+        """`POST /Startup/User` returns 404 until Jellyfin's UserManager
+        has initialized the default user. The script must GET
+        /Startup/FirstUser — which triggers that init — before POSTing
+        the admin (regression-guard for #809)."""
+        m = load_script("media")
+        import urllib.error
+        import urllib.request
+
+        class _Resp:
+            def __init__(self, status, body):
+                self.status = status
+                self._b = json.dumps(body or {}).encode("utf-8")
+
+            def read(self):
+                return self._b
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        calls: list[tuple[str, str]] = []
+        first_user_initialized = {"v": False}
+
+        def recording_urlopen(req, *_a, **_kw):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            method = req.get_method() if hasattr(req, "get_method") else "GET"
+            calls.append((method, url))
+            if "/Startup/FirstUser" in url:
+                # GET /Startup/FirstUser runs the UserManager init pass.
+                first_user_initialized["v"] = True
+                return _Resp(200, {"Name": "stub"})
+            if "/Startup/User" in url:
+                # Mimic real Jellyfin: 404 until the default user exists.
+                return _Resp(204 if first_user_initialized["v"] else 404, None)
+            if "/System/Info/Public" in url:
+                return _Resp(200, {"StartupWizardCompleted": False})
+            if "/Users/AuthenticateByName" in url:
+                return _Resp(200, {"AccessToken": "tok"})
+            if any(p in url for p in (
+                "/Startup/Configuration", "/Startup/RemoteAccess", "/Startup/Complete",
+                "/QuickConnect/Enable", "/Library/VirtualFolders",
+            )):
+                return _Resp(204, None)
+            raise urllib.error.URLError(f"unmocked URL: {url}")
+
+        env = {
+            "HOST": "h",
+            "SB_API_URL": "http://sb.test",
+            "JELLYFIN_ADMIN_PASSWORD": "jf-pass",
+            "JELLYFIN_PORT": "8096",
+        }
+        with run_with_env(env), mock.patch.object(urllib.request, "urlopen", recording_urlopen):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        # The admin seed must have succeeded — i.e. POST /Startup/User
+        # was not a 404.
+        self.assertIn("admin 'admin' seeded", out)
+        # GET /Startup/FirstUser must come before POST /Startup/User.
+        get_first = next(
+            i for i, (meth, u) in enumerate(calls)
+            if meth == "GET" and "/Startup/FirstUser" in u
+        )
+        post_user = next(
+            i for i, (meth, u) in enumerate(calls)
+            if meth == "POST" and u.endswith("/Startup/User")
+        )
+        self.assertLess(get_first, post_user)
 
 
 class HomeAssistantScript(unittest.TestCase):


### PR DESCRIPTION
## Summary

Four install-reliability fixes, all rooted in the same theme: install steps running against a service that isn't ready yet.

- **#810** — the deploy loop ran each template's post-deploy script back-to-back with no readiness gate. Added `waitForDependencies`: before deploying a template, block until every declared `servicebay.dependencies` entry reports health-ready in the twin (3-min cap, then proceed). Extracted the shared `isServiceReady` predicate.
- **#808** — the `auth` LLDAP group seed fired before LLDAP's HTTP/GraphQL API was up, failed once, never retried — so `admins`/`family` were never created. The post-deploy now polls the LLDAP readiness probe first (`wait_for_lldap`) and retries the seed up to 3×.
- **#809** — Jellyfin's `POST /Startup/User` returns 404 until the UserManager has created the default user; only `GET /Startup/FirstUser` triggers that init pass. The `media` post-deploy now waits on that GET before seeding the admin.
- **#807** — the capability bus fires one `feature.installed` per template and the nginx handler no-ops silently when it owns no hosts; any skipped/under-producing emit left the operator with portal routes but no service subdomains. Added `ensureProxyHosts`: a consolidated, idempotent post-install pass that creates every subdomain's proxy host in one batch.

Context: #808 and #809 regressed when Phase 3C retired the install runner's per-template `servicebay.readiness` probes — the post-deploy scripts still assumed those probes had gated readiness. The fix restores the wait inside each script.

## Test plan

- [x] `vitest run` — full suite green (ran in pre-push hook)
- [x] New `runner.test.ts` — `isServiceReady`, `waitForDependencies`, `ensureProxyHosts` (9 tests)
- [x] New post-deploy regression tests — LLDAP seed skip/retry, Jellyfin GET-before-POST ordering
- [x] `tsc --noEmit` clean
- [ ] Manual: fresh multi-stack install on a live node (not run — no hardware in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)