### PR TITLE
feat(templates): add claude-dev stack — containerised Claude Code CLI (#779)

### DIFF
--- a/.github/workflows/claude-dev-image.yml
+++ b/.github/workflows/claude-dev-image.yml
@@ -1,0 +1,42 @@
+name: Build claude-dev image
+
+# Builds and publishes the container image for the `claude-dev` stack
+# template. The image carries the Claude Code CLI + the ServiceBay dev
+# toolchain (see templates/claude-dev/Dockerfile); the template
+# references ghcr.io/<owner>/<repo>-claude-dev:latest.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'templates/claude-dev/Dockerfile'
+      - 'templates/claude-dev/docker-entrypoint.sh'
+      - '.github/workflows/claude-dev-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: templates/claude-dev
+          push: true
+          tags: ghcr.io/${{ github.repository }}-claude-dev:latest

--- a/stacks/claude-dev/README.md
+++ b/stacks/claude-dev/README.md
@@ -1,0 +1,14 @@
+# Claude Dev stack
+
+A one-template stack that runs a containerised [Claude Code](https://claude.com/claude-code)
+development environment on the homelab itself.
+
+The motivation: driving a coding session against ServiceBay from the
+Claude Code mobile app normally needs a powered-on laptop running the
+CLI somewhere reachable over SSH. The moment that laptop sleeps, mobile
+development stops. This stack moves the toolchain into a container the
+homelab already runs 24/7, so the dev box is no longer a single point of
+failure for development.
+
+It contains a single template, [`claude-dev`](../../templates/claude-dev/README.md) —
+see that README for the container contents and how to start a session.

--- a/stacks/claude-dev/stack.yml
+++ b/stacks/claude-dev/stack.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Stack
+metadata:
+  name: claude-dev
+  annotations:
+    servicebay.label: "Claude Dev (containerised Claude Code CLI)"
+    servicebay.tier: "feature"
+spec:
+  # Single-template stack: a long-lived dev container so a coding
+  # session against this repo can be driven from the Claude Code mobile
+  # app without keeping a laptop awake. No depends-on-stacks — the dev
+  # box is self-contained and needs neither the reverse proxy nor SSO.
+  templates: [claude-dev]

--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -1,0 +1,51 @@
+# claude-dev — containerised Claude Code CLI + ServiceBay dev toolchain.
+#
+# Published as ghcr.io/mdopp/servicebay-claude-dev:latest by
+# .github/workflows/claude-dev-image.yml. The `claude-dev` stack
+# template references that tag.
+#
+# Built FROM node:20-bookworm-slim so the Node version matches the
+# repo's `engines.node` (20.x) — native npm modules compiled inside a
+# session are ABI-compatible with what CI builds against.
+FROM node:20-bookworm-slim
+
+# Toolchain:
+#   - openssh-server/-client : SSH in (mobile app) + host-key gen
+#   - git                    : repo ops
+#   - make/gcc/g++/python3   : native-module builds (better-sqlite3, …)
+#   - podman                 : run the repo's container e2e scripts
+#   - procps/iproute2        : ps/ss for debugging from inside a session
+#   - curl/ca-certificates/gnupg : fetch the GitHub CLI apt key
+# The GitHub CLI (`gh`) is not in Debian's repos, so add its apt source.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openssh-server openssh-client git bash \
+      make gcc g++ python3 \
+      podman procps iproute2 \
+      curl ca-certificates gnupg \
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI — installed globally so `claude` is on PATH for every
+# SSH session. Package name per the published npm package.
+RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
+
+# Non-root `dev` user. Its home is /workspace — the template mounts a
+# persistent volume there, so git checkouts, ~/.claude session history
+# and gh auth all survive container restarts. --create-home seeds the
+# skeleton; the runtime bind mount then takes over and the entrypoint
+# re-scaffolds it.
+RUN useradd --create-home --home-dir /workspace --shell /bin/bash dev
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Informational — the real port is set at runtime via CLAUDE_DEV_SSH_PORT.
+EXPOSE 2222
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -1,0 +1,63 @@
+# claude-dev
+
+A long-lived development container that carries the [Claude Code](https://claude.com/claude-code)
+CLI and the ServiceBay toolchain, so a coding session against this repo
+can be driven from the Claude Code mobile app without keeping a laptop
+awake. The homelab already runs 24/7 — this makes it the dev host too,
+removing the laptop as a single point of failure for development.
+
+## What's in the image
+
+Built from [`Dockerfile`](./Dockerfile) (published as
+`ghcr.io/mdopp/servicebay-claude-dev:latest` by
+`.github/workflows/claude-dev-image.yml`):
+
+- Node.js 20.x + npm — matches the repo's `engines.node`
+- `@anthropic-ai/claude-code` installed globally (`claude` on `PATH`)
+- `git` + the GitHub CLI (`gh`)
+- `make` / `gcc` / `g++` / `python3` — native-module builds
+- the `podman` client — for the repo's `scripts/test-container-e2e.sh`
+- an SSH server
+
+`/workspace` is a persistent volume and the `dev` user's home, so git
+checkouts, Claude Code session history (`~/.claude`), `gh` auth and the
+SSH host keys all survive a container restart.
+
+## Variables
+
+| Variable | Purpose |
+|---|---|
+| `CLAUDE_DEV_SSH_PORT` | Host port sshd listens on (default `2222`). |
+| `CLAUDE_DEV_SSH_PASSWORD` | Auto-generated password for the `dev` user; surfaced as a credential after install. |
+| `CLAUDE_DEV_SSH_AUTHORIZED_KEY` | Optional SSH public key; enables key-based login (recommended when the box is reachable from outside the LAN). |
+
+## Reaching it from a phone
+
+`sshd` binds `CLAUDE_DEV_SSH_PORT` directly on the host (the pod runs
+with `hostNetwork`). On the LAN, connect straight to
+`dev@<server-ip>:<port>`. From outside, add a FritzBox port-forward for
+that port and point the Claude Code mobile app's SSH connection at it.
+
+## Starting a session
+
+```sh
+# SSH in (password from the post-install credentials banner, or your key)
+ssh -p 2222 dev@<server-ip>
+
+# Clone the repo you want to work on into the persistent volume
+git clone https://github.com/<you>/servicebay /workspace/servicebay
+cd /workspace/servicebay
+
+# Start Claude Code
+claude
+```
+
+The clone only has to be done once — `/workspace` persists, so later
+sessions just `cd /workspace/servicebay && claude`.
+
+## Non-goals (first iteration)
+
+- Running the full ServiceBay test suite *inside* this container
+  (podman-in-podman / CI parity) — a later phase can add the e2e harness.
+- Auto-cloning a repo on container start — the operator clones manually.
+- Multi-user / multi-session concurrency.

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Entrypoint for the claude-dev container image.
+#
+# Wires SSH auth from the env vars the `claude-dev` template passes,
+# persists host keys on the /workspace volume so the SSH client doesn't
+# warn about a changed host key after every restart, then hands off to
+# sshd as PID 1.
+set -euo pipefail
+
+SSH_PORT="${CLAUDE_DEV_SSH_PORT:-2222}"
+DEV_HOME=/workspace
+HOSTKEY_DIR="$DEV_HOME/.ssh/host_keys"
+
+# /workspace is a fresh, root-owned bind mount on first install. Make it
+# the dev user's home and lay down the .ssh scaffolding. The chown is
+# non-recursive on purpose — the operator's own checkouts inside are
+# created as `dev` already, and a recursive chown over a large repo
+# tree on every restart would be wasteful.
+chown dev:dev "$DEV_HOME"
+install -d -o dev -g dev -m 700 "$DEV_HOME/.ssh"
+install -d -o dev -g dev -m 700 "$HOSTKEY_DIR"
+
+# Persist host keys on the volume.
+for keytype in ed25519 rsa; do
+  keyfile="$HOSTKEY_DIR/ssh_host_${keytype}_key"
+  [ -f "$keyfile" ] || ssh-keygen -t "$keytype" -f "$keyfile" -N "" -q
+done
+
+password_auth=no
+if [ -n "${CLAUDE_DEV_SSH_AUTHORIZED_KEY:-}" ]; then
+  printf '%s\n' "$CLAUDE_DEV_SSH_AUTHORIZED_KEY" > "$DEV_HOME/.ssh/authorized_keys"
+  chown dev:dev "$DEV_HOME/.ssh/authorized_keys"
+  chmod 600 "$DEV_HOME/.ssh/authorized_keys"
+  echo "claude-dev: key-based SSH login enabled for user 'dev'."
+fi
+if [ -n "${CLAUDE_DEV_SSH_PASSWORD:-}" ]; then
+  echo "dev:${CLAUDE_DEV_SSH_PASSWORD}" | chpasswd
+  password_auth=yes
+  echo "claude-dev: password SSH login enabled for user 'dev'."
+fi
+if [ "$password_auth" = no ] && [ -z "${CLAUDE_DEV_SSH_AUTHORIZED_KEY:-}" ]; then
+  echo "claude-dev: WARNING — no SSH password or authorized key set; nobody can log in." >&2
+fi
+
+mkdir -p /run/sshd
+echo "claude-dev: starting sshd on port ${SSH_PORT}."
+exec /usr/sbin/sshd -D -e \
+  -p "$SSH_PORT" \
+  -o "PasswordAuthentication=${password_auth}" \
+  -o "PubkeyAuthentication=yes" \
+  -o "PermitRootLogin=no" \
+  -o "HostKey=${HOSTKEY_DIR}/ssh_host_ed25519_key" \
+  -o "HostKey=${HOSTKEY_DIR}/ssh_host_rsa_key"

--- a/templates/claude-dev/post-deploy.py
+++ b/templates/claude-dev/post-deploy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""post-deploy hook for the `claude-dev` stack.
+
+Surfaces the SSH login as a credential so the operator can attach the
+Claude Code mobile app, and prints the one-time setup steps (clone a
+repo into /workspace, start a session).
+
+See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    host = env("HOST", "<server-ip>")
+    ssh_port = env("CLAUDE_DEV_SSH_PORT", "2222")
+    ssh_password = env("CLAUDE_DEV_SSH_PASSWORD")
+    has_key = bool(env("CLAUDE_DEV_SSH_AUTHORIZED_KEY"))
+
+    auth_hint = "SSH key" if has_key else "the password below"
+    log(f"✅ Claude Dev container is up — SSH in on port {ssh_port} as user 'dev' ({auth_hint}).")
+    log(f"   Attach:  ssh -p {ssh_port} dev@{host}")
+    log("   First session — clone a repo into the persistent volume and start Claude Code:")
+    log("     git clone https://github.com/<you>/<repo> /workspace/<repo>")
+    log("     cd /workspace/<repo> && claude")
+    log("   /workspace persists across container restarts (git checkouts, ~/.claude history, gh auth).")
+    log("   Point the Claude Code mobile app at the same SSH endpoint to drive sessions from a phone.")
+
+    if ssh_password:
+        emit_credential(
+            service="Claude Dev (SSH)",
+            url=f"ssh://dev@{host}:{ssh_port}",
+            username="dev",
+            password=ssh_password,
+            importance="critical",
+            notes="SSH into the containerised Claude Code dev box; point the Claude Code mobile app here. Key-based login is also enabled when CLAUDE_DEV_SSH_AUTHORIZED_KEY was set.",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/claude-dev/template.yml
+++ b/templates/claude-dev/template.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: claude-dev
+  labels:
+    app: claude-dev
+  annotations:
+    servicebay.label: "Claude Dev (Claude Code CLI + toolchain)"
+    servicebay.schema-version: "1"
+    servicebay.ports: "{{CLAUDE_DEV_SSH_PORT}}/tcp"
+    # Continuous health probe (#628). A raw TCP connect to the SSH port
+    # proves sshd accepted the listener — a dev box has no
+    # unauthenticated HTTP surface to probe.
+    servicebay.healthcheck: |
+      kind: tcp
+      host: 127.0.0.1
+      port: "{{CLAUDE_DEV_SSH_PORT}}"
+      interval: 30s
+      timeout: 5s
+      startup_timeout: 5m
+spec:
+  # hostNetwork so sshd binds {{CLAUDE_DEV_SSH_PORT}} directly on the
+  # host — the operator port-maps that on the FritzBox (or reaches it
+  # over the LAN) to drive a Claude Code session from the mobile app.
+  hostNetwork: true
+  containers:
+  # Built from templates/claude-dev/Dockerfile and published by
+  # .github/workflows/claude-dev-image.yml. The image carries Node 20,
+  # npm, @anthropic-ai/claude-code, git, the GitHub CLI, the native-
+  # module build deps (make/gcc/python3), the podman client, and an SSH
+  # server. We do NOT override command:/args: — the image's entrypoint
+  # wires SSH auth from the env vars below and hands off to sshd.
+  - name: claude-dev
+    image: ghcr.io/mdopp/servicebay-claude-dev:latest
+    env:
+      - name: CLAUDE_DEV_SSH_PORT
+        value: "{{CLAUDE_DEV_SSH_PORT}}"
+      - name: CLAUDE_DEV_SSH_PASSWORD
+        value: "{{CLAUDE_DEV_SSH_PASSWORD}}"
+      - name: CLAUDE_DEV_SSH_AUTHORIZED_KEY
+        value: "{{CLAUDE_DEV_SSH_AUTHORIZED_KEY}}"
+    ports:
+      - containerPort: {{CLAUDE_DEV_SSH_PORT}}
+    volumeMounts:
+      # Persistent home for the `dev` user: git checkouts, Claude Code
+      # session history (~/.claude), gh auth and SSH host keys all live
+      # here and survive a container restart.
+      - mountPath: /workspace
+        name: claude-dev-workspace
+  volumes:
+  - name: claude-dev-workspace
+    hostPath:
+      path: {{DATA_DIR}}/claude-dev/workspace
+      type: DirectoryOrCreate

--- a/templates/claude-dev/variables.json
+++ b/templates/claude-dev/variables.json
@@ -1,0 +1,16 @@
+{
+  "CLAUDE_DEV_SSH_PORT": {
+    "type": "text",
+    "description": "Host port the dev container's SSH server listens on. The operator port-forwards this on the FritzBox (or reaches it over the LAN) to attach the Claude Code mobile app. Default 2222 so it stays clear of the host's own sshd on 22.",
+    "default": "2222"
+  },
+  "CLAUDE_DEV_SSH_PASSWORD": {
+    "type": "secret",
+    "description": "Password for the `dev` SSH user. Auto-generated and surfaced as a credential after install. Used to attach over SSH when no public key is supplied. Regenerate from the wizard if it leaks."
+  },
+  "CLAUDE_DEV_SSH_AUTHORIZED_KEY": {
+    "type": "text",
+    "description": "Optional SSH public key (one line, e.g. `ssh-ed25519 AAAA... you@phone`). When set, key-based login is enabled for the `dev` user — recommended over the password for a box reachable from outside the LAN. Leave blank to use the password only.",
+    "default": ""
+  }
+}

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -554,5 +554,39 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertIn("/auth/oidc/welcome answered", out)
 
 
+class ClaudeDevScript(unittest.TestCase):
+    def test_emits_ssh_credential_when_password_set(self):
+        m = load_script("claude-dev")
+        env = {
+            "HOST": "192.168.1.10",
+            "CLAUDE_DEV_SSH_PORT": "2222",
+            "CLAUDE_DEV_SSH_PASSWORD": "s3cr3t-ssh",
+        }
+        with run_with_env(env):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        creds = parse_credentials(out)
+        self.assertEqual(len(creds), 1)
+        self.assertEqual(creds[0]["service"], "Claude Dev (SSH)")
+        self.assertEqual(creds[0]["username"], "dev")
+        self.assertEqual(creds[0]["password"], "s3cr3t-ssh")
+        self.assertEqual(creds[0]["url"], "ssh://dev@192.168.1.10:2222")
+        # The SSH password must NOT leak into user-visible log lines —
+        # it only travels via the __SB_CREDENTIAL__ JSON marker (#321).
+        log_only = "\n".join(
+            line for line in out.splitlines()
+            if not line.startswith("__SB_CREDENTIAL__ ")
+        )
+        self.assertNotIn("s3cr3t-ssh", log_only)
+        self.assertIn("git clone", out)
+
+    def test_no_password_emits_no_credential(self):
+        m = load_script("claude-dev")
+        with run_with_env({"HOST": "h", "CLAUDE_DEV_SSH_PORT": "2222"}):
+            rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertEqual(parse_credentials(out), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a `claude-dev` stack: a long-lived container that carries the Claude Code CLI and the ServiceBay dev toolchain, so a coding session against this repo can be driven from the Claude Code mobile app without keeping a laptop awake. The homelab already runs 24/7 — this makes it the dev host too.

- `templates/claude-dev/` — one-pod feature-tier template, no install deps. The image (`Dockerfile` + `docker-entrypoint.sh` shipped here) carries Node 20, npm, `@anthropic-ai/claude-code`, git, the GitHub CLI, the native-module build deps (make/gcc/python3), the podman client, and an SSH server.
- `/workspace` is a persistent volume **and** the `dev` user's home, so git checkouts, `~/.claude` session history, `gh` auth and SSH host keys all survive container restarts.
- `stacks/claude-dev/stack.yml` — makes it selectable in the wizard's stack picker.
- `.github/workflows/claude-dev-image.yml` — builds + publishes the image to `ghcr.io/<owner>/<repo>-claude-dev:latest`.
- `post-deploy.py` surfaces the SSH login as a credential and prints the clone-and-start steps.

## Test plan

- [x] `template_consistency` + `stack_consistency` suites green (claude-dev validated like every other template/stack)
- [x] `post_deploy_runtime` — new `ClaudeDevScript` tests (credential emitted, password not leaked to logs)
- [x] `python3 -m py_compile` + `bash -n` on the shipped scripts
- [x] full `vitest` suite + `npm run build` green (pre-push hook)
- [ ] Manual: install the stack on a live node and SSH in (not run — needs the image published by the new workflow first)

## Notes

The container image must be published once (the new workflow does this on merge to `main`) before the stack can be installed — the template references `ghcr.io/mdopp/servicebay-claude-dev:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)