### PR TITLE
fix(ui): redirect to /login when the realtime socket is rejected as unauthorized

### DIFF
--- a/packages/frontend/src/hooks/useSocket.ts
+++ b/packages/frontend/src/hooks/useSocket.ts
@@ -20,8 +20,25 @@ export const useSocket = () => {
       setIsConnected(false);
     }
 
+    // The Socket.IO server's auth middleware (server.ts) rejects any
+    // connection whose session cookie is missing or invalid with
+    // `Error('unauthorized')`. The usual trigger is a stale cookie after
+    // a reinstall rotates AUTH_SECRET: the dashboard then hangs forever
+    // on "Connecting to ServiceBay" because `isConnected` never flips and
+    // nothing surfaces the auth failure (the loader even mis-blames the
+    // agent's inventory pass). Mirror the REST-401 handler in
+    // DigitalTwinProvider — bounce to /login so the operator
+    // re-authenticates. Only the auth error redirects; transient network
+    // `connect_error`s must keep retrying silently.
+    function onConnectError(err: Error) {
+      if (err?.message === 'unauthorized' && typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
+    }
+
     socket.on('connect', onConnect);
     socket.on('disconnect', onDisconnect);
+    socket.on('connect_error', onConnectError);
 
     if (socket.connected) {
         onConnect();
@@ -30,6 +47,7 @@ export const useSocket = () => {
     return () => {
       socket.off('connect', onConnect);
       socket.off('disconnect', onDisconnect);
+      socket.off('connect_error', onConnectError);
     };
   }, []);
 

--- a/tests/frontend/useSocket.test.tsx
+++ b/tests/frontend/useSocket.test.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture the fake socket's event handlers so the test can fire them.
+const handlers: Record<string, (arg?: any) => void> = {};
+const fakeSocket = {
+  connected: false,
+  on: vi.fn((event: string, cb: (arg?: any) => void) => { handlers[event] = cb; }),
+  off: vi.fn(),
+};
+vi.mock('socket.io-client', () => ({
+  default: vi.fn(() => fakeSocket),
+}));
+
+import { useSocket } from '@/hooks/useSocket';
+
+describe('useSocket — connect_error handling', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(handlers)) delete handlers[k];
+  });
+
+  it('redirects to /login on an unauthorized rejection, ignores transient errors', () => {
+    const originalLocation = window.location;
+    // jsdom's window.location is read-only; swap in a writable stub.
+    Object.defineProperty(window, 'location', {
+      value: { href: '' }, writable: true, configurable: true,
+    });
+
+    try {
+      renderHook(() => useSocket());
+      // The hook must subscribe to connect_error.
+      expect(handlers.connect_error).toBeDefined();
+
+      // A transient network connect_error must NOT redirect — Socket.IO
+      // keeps retrying on its own.
+      handlers.connect_error(new Error('xhr poll error'));
+      expect(window.location.href).toBe('');
+
+      // The server auth-middleware rejection ('unauthorized') — e.g. a
+      // stale session cookie after a reinstall — bounces to /login.
+      handlers.connect_error(new Error('unauthorized'));
+      expect(window.location.href).toBe('/login');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation, writable: true, configurable: true,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Found debugging a fresh box reinstall: the dashboard hung forever on "Connecting to ServiceBay", and the install appeared to never finish.

Root cause: a reinstall rotates `AUTH_SECRET`, so a session cookie minted before the reinstall no longer validates. The Socket.IO server's auth middleware (`server.ts`) rejects such a connection with `Error('unauthorized')` — confirmed by `Rejected unauthenticated socket` in the server log. `useSocket` never listened for `connect_error`, so `isConnected` stayed `false`, the dashboard's hydration gate sat on the `socket` phase indefinitely, and its 25s hint even mis-blamed the agent's first inventory pass.

`useSocket` now listens for `connect_error` and, on the `unauthorized` message specifically, redirects to `/login` — mirroring the existing REST-401 interceptor in `DigitalTwinProvider`. Transient network `connect_error`s are left alone so Socket.IO keeps retrying.

## Test plan

- [x] New `useSocket.test.tsx` — `unauthorized` rejection redirects to `/login`; a transient `connect_error` does not
- [x] full `vitest` suite + `npm run build` green (pre-push hook)
- [ ] Manual: reinstall the box with a stale cookie in the browser, confirm it bounces to /login instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)