### PR TITLE
refactor(security): drop hostNetwork from vaultwarden + immich (#817)

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -674,6 +674,15 @@ async function runJob(jobId: string): Promise<void> {
     const ip = await reconcileLanIp(node);
     if (ip) {
       await log(jobId, `Captured LAN IP: ${ip}`);
+      // Expose LAN_IP to template rendering (#817). Templates that drop
+      // `hostNetwork` need it for a `hostAliases` entry that resolves
+      // the public auth subdomain to the LAN. `LAN_IP` is declared as a
+      // global in templates/settings.json (blank default); the wizard
+      // can't know the host IP, so the runner fills it in here — every
+      // `{{LAN_IP}}` in a rendered template.yml resolves to this value.
+      const lanVar = input.variables.find(v => v.name === 'LAN_IP');
+      if (lanVar) lanVar.value = ip;
+      else input.variables.push({ name: 'LAN_IP', value: ip, global: true });
     } else {
       await log(jobId, '⚠️ Could not detect LAN IP (agent returned no `ip route get` result); diagnose probes that depend on it will degrade.');
     }

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -18,27 +18,29 @@ metadata:
       timeout: 5s
       startup_timeout: 5m
 spec:
-  # v2 (#410): hostNetwork is required so Immich can fetch
-  # https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration for
-  # OIDC discovery. Under bridge networking the container resolves the
-  # public auth subdomain to the router's WAN IP and the request fails
-  # (most home routers don't hairpin NAT). Under hostNetwork Immich
-  # inherits the host resolver and AdGuard rewrites *.<PUBLIC_DOMAIN>
-  # to the LAN IP — same pattern Vaultwarden uses (#408).
-  #
-  # Side-effect for the sidecars: redis + postgres now share the host
-  # network namespace. The args overrides below pin both to 127.0.0.1
-  # so they stay reachable for immich-server / machine-learning via
-  # loopback without being exposed on the LAN.
-  hostNetwork: true
+  # #817: Immich runs in its own network namespace (no hostNetwork).
+  #   - Only `immich-server` is published to the host, via `hostPort`
+  #     below. redis / postgres / machine-learning stay pod-internal —
+  #     the four containers share the pod's netns, so the `127.0.0.1`
+  #     references between them (DB_HOSTNAME, REDIS_HOSTNAME,
+  #     IMMICH_MACHINE_LEARNING_URL) keep working unchanged, and the
+  #     loopback binds below mean the sidecars are never LAN-reachable.
+  #   - Immich does *server-side* OIDC discovery against
+  #     https://auth.<PUBLIC_DOMAIN>; an isolated container's resolver
+  #     doesn't apply AdGuard's `*.PUBLIC_DOMAIN → LAN IP` rewrite
+  #     (#408/#410), so the `hostAliases` entry pins that name to the
+  #     LAN IP — request flows container → LAN IP → NPM → Authelia.
+  #     {{LAN_IP}} is filled in by the install runner at deploy time.
+  hostAliases:
+    - ip: "{{LAN_IP}}"
+      hostnames:
+        - "auth.{{PUBLIC_DOMAIN}}"
   containers:
     - name: immich-server
       image: ghcr.io/immich-app/immich-server:release
       env:
-        # Under hostNetwork `hostPort:` is invalid — IMMICH_PORT here
-        # makes the server bind {{IMMICH_PORT}} directly on the host;
-        # the servicebay.ports annotation documents it for the UI /
-        # network graph.
+        # immich-server binds {{IMMICH_PORT}} inside the pod netns;
+        # the `hostPort` on the container port below publishes it.
         - name: IMMICH_PORT
           value: "{{IMMICH_PORT}}"
         - name: DB_HOSTNAME
@@ -55,6 +57,7 @@ spec:
           value: "http://127.0.0.1:3003"
       ports:
         - containerPort: {{IMMICH_PORT}}
+          hostPort: {{IMMICH_PORT}}
       volumeMounts:
         - mountPath: /usr/src/app/upload
           name: immich-upload
@@ -67,14 +70,12 @@ spec:
 
     - name: redis
       image: docker.io/redis:6.2-alpine
-      # Pin redis to loopback so hostNetwork doesn't accidentally
-      # expose it on the LAN. immich-server reaches it via 127.0.0.1.
+      # Bind redis to the pod loopback — immich-server reaches it via
+      # 127.0.0.1 (same pod netns); never LAN-reachable. No `ports:` —
+      # redis is pod-internal, so it's published nowhere on the host
+      # (#817: a declared port with no hostPort is now a consistency
+      # error, and a hostPort would wrongly LAN-expose it).
       args: ["--bind", "127.0.0.1", "--protected-mode", "yes"]
-      # Declared so the digital twin attributes 127.0.0.1:6379 to this
-      # container — without it the diagnose ports probe flags 6379 as
-      # "unknown" even though it's the immich pod's redis sidecar.
-      ports:
-        - containerPort: 6379
 
     - name: database
       image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0
@@ -98,11 +99,8 @@ spec:
           value: "postgres"
         - name: POSTGRES_DB
           value: "immich"
-      # Declared so the digital twin attributes 127.0.0.1:5432 to this
-      # container — without it the diagnose ports probe flags 5432 as
-      # "unknown" even though it's the immich pod's postgres sidecar.
-      ports:
-        - containerPort: 5432
+      # No `ports:` — postgres is pod-internal (immich-server reaches
+      # it on the pod loopback), published nowhere on the host (#817).
       volumeMounts:
         - mountPath: /var/lib/postgresql/data
           name: pgdata

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -16,6 +16,10 @@
     "LLDAP_BASE_DN": {
       "default": "dc=dopp,dc=cloud",
       "description": "LDAP base distinguished name"
+    },
+    "LAN_IP": {
+      "default": "",
+      "description": "Host LAN IP. Auto-detected and filled in by ServiceBay at install time (#817) — leave blank; the installer overrides it. Used by isolated-network templates for a hostAliases entry that points the public auth subdomain at the LAN."
     }
   },
   "notes": [

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -21,15 +21,24 @@ metadata:
       timeout: 5s
       startup_timeout: 5m
 spec:
-  # v2 (#408): hostNetwork is required so Vaultwarden can reach
-  # https://auth.<PUBLIC_DOMAIN>/.well-known/openid-configuration for
-  # OIDC discovery. Under bridge networking the container resolves the
-  # public auth subdomain to the router's WAN IP and the request fails
-  # (most home routers don't hairpin NAT). Under hostNetwork the
-  # container inherits the host's resolver, which AdGuard rewrites
-  # *.PUBLIC_DOMAIN to the LAN IP — so the OIDC discovery request goes
-  # NPM → Authelia → success.
-  hostNetwork: true
+  # #817: Vaultwarden runs in its own network namespace (no
+  # hostNetwork), so a compromised container can't reach the host's
+  # other service ports or the ServiceBay control API. Two consequences
+  # the config handles:
+  #   1. The port is published to the host explicitly via `hostPort`
+  #      on the container port below.
+  #   2. Vaultwarden does *server-side* OIDC discovery against
+  #      https://auth.<PUBLIC_DOMAIN>. An isolated container's resolver
+  #      doesn't apply AdGuard's `*.PUBLIC_DOMAIN → LAN IP` rewrite
+  #      (#408), so the `hostAliases` entry pins that one name to the
+  #      LAN IP. The request then flows container → LAN IP → NPM →
+  #      Authelia — the only path Authelia accepts (it validates the
+  #      canonical https issuer and the X-Forwarded headers NPM sets).
+  #      {{LAN_IP}} is filled in by the install runner at deploy time.
+  hostAliases:
+    - ip: "{{LAN_IP}}"
+      hostnames:
+        - "auth.{{PUBLIC_DOMAIN}}"
   containers:
   - name: vaultwarden
     image: docker.io/vaultwarden/server:latest
@@ -53,18 +62,15 @@ spec:
       value: "{{VAULTWARDEN_SSO_SECRET}}"
     - name: SSO_SCOPES
       value: "email profile"
-    # Vaultwarden listens on port 80 by default. Under hostNetwork that
-    # collides with NPM's HTTP listener — point Rocket at the operator's
-    # configured port so it binds directly there on the host.
+    # Rocket binds {{VAULTWARDEN_PORT}} on 0.0.0.0 inside the pod
+    # netns (Vaultwarden's default ROCKET_ADDRESS); `hostPort` below
+    # publishes it on the host. Bridge networking means there's no
+    # collision with NPM's :80 — they're in separate namespaces.
     - name: ROCKET_PORT
       value: "{{VAULTWARDEN_PORT}}"
-    # `hostPort:` is invalid under hostNetwork (podman rejects with
-    # "PortMappings can only be used with Bridge, slirp4netns, or pasta
-    # networking"). The servicebay.ports annotation above carries the
-    # port for the UI / network graph; the container now binds
-    # {{VAULTWARDEN_PORT}} directly on the host.
     ports:
     - containerPort: {{VAULTWARDEN_PORT}}
+      hostPort: {{VAULTWARDEN_PORT}}
     volumeMounts:
     - mountPath: /data
       name: vaultwarden-data


### PR DESCRIPTION
## Summary

First increment of #817 — moving app templates off `hostNetwork` so a compromised container can't reach the host's other service ports or the ServiceBay control API. Scoped to **two templates** to prove the pattern before the rest.

**Groundwork**
- `LAN_IP` is now a `templates/settings.json` global; the install runner fills it with the reconciled host IP at deploy time, so `{{LAN_IP}}` resolves in any rendered `template.yml`.

**vaultwarden + immich** — drop `spec.hostNetwork`, publish the public port via `hostPort`. Both do *server-side* OIDC discovery against `https://auth.<PUBLIC_DOMAIN>`; an isolated container's resolver can't apply AdGuard's `*.domain → LAN IP` rewrite, so a `hostAliases` entry pins that one name to `{{LAN_IP}}` — keeping the request on the `container → LAN IP → NPM → Authelia` path (the only one Authelia accepts; an internal name bypasses NPM's TLS + `X-Forwarded` headers and 500s).

immich's redis / postgres / machine-learning stay pod-internal — the containers share the pod netns so their `127.0.0.1` references are unchanged; the redis/postgres `ports:` entries are dropped (published nowhere on the host now).

## Why incremental

Reading the templates showed `hostNetwork` is load-bearing in non-obvious ways (DNS for OIDC discovery, loopback binds, cross-pod reaches) — per-template surgery, not a mechanical sweep. Each template is migrated + verified on the box before the next. Remaining: `ollama`, `hermes`, `media`, `file-share`, `radicale`; `auth` last (highest-stakes).

## Test plan

- [x] `template_consistency` suite green (70) — both migrated templates satisfy the hostPort rule + render to valid Pods
- [x] full `vitest` + `tsc` + `npm run check:arch` clean
- [ ] **Manual (the real test):** reinstall the box, confirm vaultwarden + immich come up, are reachable through NPM, and their SSO login works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)