### PR TITLE
fix(immich): correct healthcheck endpoint to /api/server/ping

### DIFF
--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -10,10 +10,12 @@ metadata:
     servicebay.ports: "{{IMMICH_PORT}}/tcp"
     # photos.<domain> is served via nginx; Immich's SSO uses Authelia.
     servicebay.dependencies: "nginx,auth"
-    # Continuous health probe (#628). `/api/server-info/ping` is Immich's
+    # Continuous health probe (#628). `/api/server/ping` is Immich's
     # unauthenticated liveness endpoint — returns `{"res":"pong"}`.
+    # (Pre-v2.7 this lived at `/api/server-info/ping`; the old path now
+    # 404s, which made the probe report Immich permanently unhealthy.)
     servicebay.healthcheck: |
-      url: http://localhost:{{IMMICH_PORT}}/api/server-info/ping
+      url: http://localhost:{{IMMICH_PORT}}/api/server/ping
       interval: 30s
       timeout: 5s
       startup_timeout: 5m


### PR DESCRIPTION
## Symptom

The Immich template's continuous health probe (#628) reports Immich as
permanently unhealthy, even on a clean install where the service is
fully operational and reachable.

## Cause

Immich v2.7 renamed its unauthenticated liveness endpoint from
`/api/server-info/ping` to `/api/server/ping`. The template's
`servicebay.healthcheck` annotation still pointed at the old path, which
now returns `404 Not Found`.

Verified on the test box (Immich v2.7.5):
- `GET /api/server-info/ping` → `404`
- `GET /api/server/ping` → `200 {"res":"pong"}`

## Fix

Point the healthcheck URL at `/api/server/ping` and note the rename in
the adjacent comment.

Found while verifying the 4.15.0 `hostNetwork`→`hostPort` migration —
Immich itself comes up fine and is reachable on its `hostPort`; only the
probe URL was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)