### PR TITLE
refactor(security): drop hostNetwork from media + radicale (#817)

### DIFF
--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -23,7 +23,24 @@ metadata:
       timeout: 5s
       startup_timeout: 5m
 spec:
-  hostNetwork: true
+  # #817: Media runs in its own network namespace (no hostNetwork) so a
+  # compromised audiobookshelf/jellyfin container can't reach the host's
+  # other service ports or the ServiceBay control API.
+  #   - Both apps are published to the host via `hostPort` on their
+  #     container ports below; nothing else in the pod is LAN-reachable.
+  #   - Audiobookshelf does *server-side* OIDC discovery against
+  #     https://auth.<PUBLIC_DOMAIN>. An isolated container's resolver
+  #     doesn't apply AdGuard's `*.PUBLIC_DOMAIN → LAN IP` rewrite, so
+  #     the `hostAliases` entry pins that name to the LAN IP — the
+  #     request then flows container → LAN IP → NPM → Authelia.
+  #     {{LAN_IP}} is filled in by the install runner at deploy time.
+  #   - post-deploy.py runs in the host netns (not the pod), so its
+  #     `127.0.0.1:9091` Authelia probe and `127.0.0.1:<ABS_PORT>`
+  #     audiobookshelf probe keep working — the latter via the hostPort.
+  hostAliases:
+    - ip: "{{LAN_IP}}"
+      hostnames:
+        - "auth.{{PUBLIC_DOMAIN}}"
   containers:
   # 1. Audiobookshelf — Audiobooks + podcasts library + listening apps.
   #    Authentication: native OIDC against Authelia (configured by
@@ -37,6 +54,7 @@ spec:
         value: "{{TZ}}"
     ports:
       - containerPort: {{ABS_PORT}}
+        hostPort: {{ABS_PORT}}
     volumeMounts:
       - mountPath: /config
         name: abs-config
@@ -67,6 +85,7 @@ spec:
       # nginx-style restart logic; we manage the unit via Quadlet.
     ports:
       - containerPort: {{JELLYFIN_PORT}}
+        hostPort: {{JELLYFIN_PORT}}
     volumeMounts:
       - mountPath: /config
         name: jellyfin-config

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -18,7 +18,17 @@ metadata:
       timeout: 5s
       startup_timeout: 5m
 spec:
-  hostNetwork: true
+  # #817: Radicale runs in its own network namespace (no hostNetwork) so
+  # a compromised container can't reach the host's other service ports
+  # or the ServiceBay control API.
+  #   - Radicale's HTTP port is published to the host via `hostPort` on
+  #     the container port below.
+  #   - Radicale binds LLDAP for user lookup over LDAP. LLDAP lives in
+  #     the `auth` pod (still hostNetwork), so it listens on the host —
+  #     an isolated Radicale pod can't reach it on 127.0.0.1, so the
+  #     `ldap_uri` below targets {{LAN_IP}} (filled in by the install
+  #     runner at deploy time). Radicale does no OIDC, so no
+  #     auth.<domain> hostAliases entry is needed.
   initContainers:
   # Seed /config/config in-pod, every deploy. Earlier versions wrote a
   # config.mustache to the host bind-mount during the wizard's deploy
@@ -45,7 +55,7 @@ spec:
 
         [auth]
         type = ldap
-        ldap_uri = ldap://{{LLDAP_HOST}}:{{LLDAP_LDAP_PORT}}
+        ldap_uri = ldap://{{LAN_IP}}:{{LLDAP_LDAP_PORT}}
         ldap_base = ou=people,{{LLDAP_BASE_DN}}
         ldap_reader_dn = uid=admin,ou=people,{{LLDAP_BASE_DN}}
         ldap_secret = {{LLDAP_ADMIN_PASSWORD}}
@@ -88,6 +98,7 @@ spec:
         value: /config/config
     ports:
       - containerPort: {{RADICALE_PORT}}
+        hostPort: {{RADICALE_PORT}}
     volumeMounts:
       - mountPath: /data
         name: radicale-data

--- a/templates/radicale/variables.json
+++ b/templates/radicale/variables.json
@@ -4,11 +4,6 @@
     "description": "Radicale CalDAV/CardDAV port",
     "default": "5232"
   },
-  "LLDAP_HOST": {
-    "type": "text",
-    "description": "LLDAP host (localhost when both run on the same node)",
-    "default": "localhost"
-  },
   "LLDAP_LDAP_PORT": {
     "type": "text",
     "description": "LLDAP LDAP-protocol port",


### PR DESCRIPTION
## What

Second increment of the `hostNetwork` removal tracked in #817. Increment 1
(#824, shipped in 4.15.0) covered vaultwarden + immich; this moves
**media** and **radicale** into their own network namespaces.

A container in a `hostNetwork` pod shares the host's entire network
namespace — it can reach the ServiceBay control API, every other
service's port, and the host's sshd. Isolating these pods removes that
host-wide reach for a compromised container.

## media (audiobookshelf + jellyfin)

- Removed `spec.hostNetwork`.
- Added `hostPort` to the audiobookshelf and jellyfin container ports so
  both stay reachable on the host.
- Added a `hostAliases` entry pinning `auth.<PUBLIC_DOMAIN>` → `{{LAN_IP}}`:
  audiobookshelf does server-side OIDC discovery, and an isolated
  container's resolver doesn't get AdGuard's `*.PUBLIC_DOMAIN → LAN IP`
  rewrite — same fix as immich/vaultwarden.
- `post-deploy.py` needs no change: it runs in the **host** netns, so its
  `127.0.0.1:9091` (Authelia) and `127.0.0.1:<ABS_PORT>` probes still
  resolve — the latter now via the hostPort.

## radicale

- Removed `spec.hostNetwork`.
- Added `hostPort` to the CalDAV container port.
- Rewrote the LDAP bind URI from the loopback `LLDAP_HOST` variable to
  `{{LAN_IP}}`. LLDAP lives in the still-`hostNetwork` `auth` pod, so it
  listens on the host; an isolated radicale pod can't reach it on
  `127.0.0.1`. Removed the now-unused `LLDAP_HOST` variable.
- No `hostAliases` needed — radicale authenticates over LDAP, not OIDC.

## Deliberately left on hostNetwork

`ollama`, `hermes` and `file-share` are **not** migrated here:

- **ollama / hermes** — ollama ships no auth and is currently bound to
  loopback only. A plain `hostPort` would newly expose an unauthenticated
  ollama to the whole LAN (no host firewall on the box), and hermes can
  only reach an isolated ollama via the LAN IP. Needs a host-firewall or
  private-network story first.
- **file-share** — needs privileged ports (139/445 for Samba) and has a
  deliberately loopback-bound Syncthing GUI; both need design decisions.

## Test plan

- `npm run check:arch` — clean.
- `template_consistency.test.ts` (70) + `templateChangelog.test.ts` (14)
  pass; full pre-push suite green.
- Pending: reinstall the test box and confirm media + radicale come up
  isolated, CalDAV LDAP login works, and audiobookshelf SSO completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)