### PR TITLE
feat(hermes): expose the web dashboard with a subdomain + portal card

### DIFF
--- a/templates/hermes/CHANGELOG.md
+++ b/templates/hermes/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Hermes — template changelog
+
+## v2 — #829
+
+The Hermes web dashboard is now exposed as a real service.
+
+Before v2 the dashboard was nominally opt-in via `HERMES_DASHBOARD_PORT`
+and a set of `HERMES_DASHBOARD*` env vars — but `hermes gateway run`
+never reads those env vars, so the dashboard never actually started. It
+also had no subdomain, so no NPM proxy host, no portal card and no URL:
+an operator could not reach it at all.
+
+v2:
+
+- A second container, `hermes-dashboard`, runs `hermes dashboard` — the
+  dashboard's real launch path. It shares the Hermes home volume
+  (`/opt/data`) with the gateway container; upstream supports running
+  the gateway and dashboard side by side.
+- `HERMES_DASHBOARD_PORT` now defaults to `9119` (the dashboard is on by
+  default) and the dead `HERMES_DASHBOARD*` env block is removed.
+- A new `HERMES_SUBDOMAIN` variable (default `hermes`) gives the
+  dashboard an internal-exposure NPM proxy host behind Authelia
+  forward-auth — which in turn yields a portal card and a URL.
+
+Operator impact: after redeploy the dashboard is reachable at
+`https://hermes.<PUBLIC_DOMAIN>` (LAN-only, SSO-gated) and appears on the
+ServiceBay portal. No data migration is needed — the dashboard reads the
+same Hermes home the gateway already uses.

--- a/templates/hermes/README.md
+++ b/templates/hermes/README.md
@@ -24,9 +24,10 @@ ServiceBay pod that:
   Default `http://127.0.0.1:11434/v1` (the `ollama` template).
 - `HERMES_LLM_MODEL` — model tag for the LLM provider. Default
   `gemma3:4b`.
-- `HERMES_DASHBOARD_PORT` — leave blank to skip the dashboard
-  (default); set to a port to enable, gated behind Authelia
-  forward-auth.
+- `HERMES_DASHBOARD_PORT` — host loopback port for the web
+  dashboard. Default `9119`.
+- `HERMES_SUBDOMAIN` — subdomain for the dashboard. Default
+  `hermes`; internal exposure, behind Authelia forward-auth.
 
 ## What `post-deploy.py` does
 
@@ -106,22 +107,20 @@ applies to other messaging platforms (Telegram bot-token paste,
 Discord OAuth, etc.) — those have a one-time interactive setup
 before the bot is paired with a chat account.
 
-## Dashboard (optional)
+## Dashboard
 
-Setting `HERMES_DASHBOARD_PORT` to e.g. `9119` enables the in-browser
-dashboard on 127.0.0.1:9119. To make it reachable remotely with
-SSO:
+The Hermes web dashboard (config, API keys, sessions) runs in its own
+`hermes-dashboard` container and is on by default. It is a separate
+`hermes dashboard` process — `hermes gateway run` does not start it, and
+the `HERMES_DASHBOARD*` env vars are not read — so it cannot share the
+gateway container. Both containers share the `/opt/data` Hermes home.
 
-1. Add an NPM proxy host for `hermes.<PUBLIC_DOMAIN>` → `http://127.0.0.1:9119`.
-2. In Advanced → Custom Nginx Configuration, paste the
-   `__authelia_forward_auth__` sentinel (or use the AdGuard /
-   Syncthing admin pages as a copy-paste source — see
-   `src/lib/stackInstall/forwardAuth.ts`).
-3. Add the resulting subdomain to Authelia's access-control rules.
-
-A future template version may collapse this into a `subdomain`-typed
-variable that auto-registers the proxy host with forward-auth, once
-the dashboard's TLS+auth assumptions are validated end-to-end.
+It binds `127.0.0.1:HERMES_DASHBOARD_PORT` (default `9119`) and is
+reached at `https://<HERMES_SUBDOMAIN>.<PUBLIC_DOMAIN>` (default
+`hermes.<domain>`): the `HERMES_SUBDOMAIN` variable auto-registers an
+internal-exposure NPM proxy host behind Authelia forward-auth, so the
+dashboard is LAN-only and SSO-gated. Because it surfaces API keys it is
+never bound to a LAN-reachable address (no `--insecure`).
 
 ## Storage
 

--- a/templates/hermes/template.yml
+++ b/templates/hermes/template.yml
@@ -6,8 +6,8 @@ metadata:
     app: hermes
   annotations:
     servicebay.label: "Hermes Agent"
-    servicebay.schema-version: "1"
-    servicebay.ports: "{{HERMES_API_PORT}}/tcp"
+    servicebay.schema-version: "2"
+    servicebay.ports: "{{HERMES_API_PORT}}/tcp,{{HERMES_DASHBOARD_PORT}}/tcp"
     # Hermes' default LLM_PROVIDER_URL points at the `ollama` template's
     # default port. The wizard topo-sorts based on this annotation so
     # ollama lands first and the http://127.0.0.1:11434 target resolves
@@ -31,8 +31,8 @@ spec:
   #      that loopback-cross-pod call work.
   #   2. OSCAR's `oscar-household` pod (also hostNetwork) can reach
   #      Hermes' API at 127.0.0.1:{{HERMES_API_PORT}}.
-  #   3. NPM (also hostNetwork) can proxy the optional dashboard from
-  #      the same host loopback, behind Authelia forward-auth.
+  #   3. NPM (also hostNetwork) proxies the dashboard container from the
+  #      same host loopback, behind Authelia forward-auth.
   hostNetwork: true
   containers:
   - name: hermes
@@ -72,25 +72,35 @@ spec:
       value: "{{HERMES_API_KEY}}"
     - name: API_SERVER_CORS_ORIGINS
       value: "*"
-    # Dashboard — opt-in. Empty HERMES_DASHBOARD_PORT keeps the
-    # dashboard off entirely; setting it (e.g. to 9119) renders the
-    # block below and Hermes' entrypoint launches the dashboard on
-    # 127.0.0.1:<port>. Remote access goes through NPM forward-auth
-    # → Authelia (see README — there is no LAN-exposed dashboard
-    # path on purpose).
-    {{#HERMES_DASHBOARD_PORT}}
-    - name: HERMES_DASHBOARD
-      value: "1"
-    - name: HERMES_DASHBOARD_HOST
-      value: "127.0.0.1"
-    - name: HERMES_DASHBOARD_PORT
-      value: "{{HERMES_DASHBOARD_PORT}}"
-    {{/HERMES_DASHBOARD_PORT}}
     ports:
     - containerPort: {{HERMES_API_PORT}}
-    {{#HERMES_DASHBOARD_PORT}}
+    volumeMounts:
+    - mountPath: /opt/data
+      name: hermes-data
+
+  # The Hermes web dashboard (config / API-key / session UI) runs as its
+  # own `hermes dashboard` process — the HERMES_DASHBOARD* env vars are
+  # NOT read by `hermes gateway run`, so it cannot share the gateway
+  # container. Both containers share the hermes-data volume (one Hermes
+  # home); upstream supports running the gateway and dashboard together.
+  #   - `hermes dashboard` binds 127.0.0.1:{{HERMES_DASHBOARD_PORT}} (its
+  #     default host). The pod is hostNetwork, so NPM — also hostNetwork —
+  #     proxies hermes.{{PUBLIC_DOMAIN}} to that loopback address behind
+  #     Authelia forward-auth. The dashboard surfaces API keys, so it is
+  #     never bound to a LAN-reachable address (no `--insecure`).
+  #   - `--skip-build` serves the web UI dist bundled in the image
+  #     (/opt/hermes/hermes_cli/web_dist); `--no-open` suppresses the
+  #     browser launch, which is meaningless in a container.
+  - name: hermes-dashboard
+    image: docker.io/nousresearch/hermes-agent:latest
+    args:
+    - dashboard
+    - --port
+    - "{{HERMES_DASHBOARD_PORT}}"
+    - --no-open
+    - --skip-build
+    ports:
     - containerPort: {{HERMES_DASHBOARD_PORT}}
-    {{/HERMES_DASHBOARD_PORT}}
     volumeMounts:
     - mountPath: /opt/data
       name: hermes-data

--- a/templates/hermes/variables.json
+++ b/templates/hermes/variables.json
@@ -20,7 +20,20 @@
   },
   "HERMES_DASHBOARD_PORT": {
     "type": "text",
-    "description": "Optional: host port for Hermes' web dashboard. Leave blank to skip the dashboard entirely (Phase-0 chat-via-Signal doesn't need it). Set to a port (e.g. 9119) to enable; bound to 127.0.0.1 only — remote access goes through NPM + Authelia forward-auth, see README. The dashboard is opt-in because it's a debugging surface, not an operator portal.",
-    "default": ""
+    "description": "Host loopback port for Hermes' web dashboard (config, API keys, sessions). Bound to 127.0.0.1 only — reached through NPM + Authelia forward-auth at https://<HERMES_SUBDOMAIN>.<domain>, never directly on the LAN.",
+    "default": "9119"
+  },
+  "HERMES_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for the Hermes web dashboard. Internal exposure — it gets a real LE cert (Authelia forward-auth needs https) but NPM binds the LAN-only access list, so it isn't reachable from outside the LAN. Authelia forward-auth gates it on top of that, because the dashboard surfaces Hermes' API keys.",
+    "default": "hermes",
+    "exposure": "internal",
+    "proxyPort": "HERMES_DASHBOARD_PORT",
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": true,
+      "advanced_config": "__authelia_forward_auth__"
+    }
   }
 }


### PR DESCRIPTION
Closes #829.

## Open question — resolved

The issue asked to first verify whether `nousresearch/hermes-agent`
ships the `[web,pty]` extra and whether the dashboard starts from the
existing `HERMES_DASHBOARD=1` env. Verified directly against the running
image on the test box:

- ✅ The image ships the web/pty deps — `fastapi`, `uvicorn`,
  `starlette`, `ptyprocess`, `websockets` all import.
- ✅ `hermes dashboard` is a real subcommand; `--skip-build` serves a
  **pre-built web dist bundled in the image** (`/opt/hermes/hermes_cli/web_dist`).
  Launching it printed `Hermes Web UI → http://127.0.0.1:9119`.
- ❌ The dashboard does **not** start from env. `HERMES_DASHBOARD*` is
  referenced nowhere in the hermes package, and `hermes gateway run` has
  no dashboard flags. The template's old opt-in env block was dead
  config — the dashboard only runs as its own `hermes dashboard` process.

## Changes

- **New `hermes-dashboard` container** in the hermes pod, running
  `hermes dashboard --port <port> --no-open --skip-build`. It shares the
  `/opt/data` Hermes home with the gateway container (upstream supports
  running both together).
- Removed the dead `HERMES_DASHBOARD*` env block.
- `HERMES_DASHBOARD_PORT` now defaults to `9119` (dashboard on by
  default); bound to `127.0.0.1`.
- **New `HERMES_SUBDOMAIN`** variable (`type: subdomain`, default
  `hermes`, internal exposure, `__authelia_forward_auth__`). This
  auto-registers the NPM proxy host, which yields the `/portal` card and
  the URL — no backend code change needed.
- The pod stays on `hostNetwork`, so NPM (also `hostNetwork`) proxies
  `hermes.<domain>` → `127.0.0.1:<port>`. The dashboard surfaces API
  keys, so it is never bound to a LAN-reachable address (no `--insecure`).
- Schema bumped to v2 + new `CHANGELOG.md`; README dashboard section
  rewritten.

## Test plan

- `npm run check:arch` clean; `template_consistency` (70) +
  `templateChangelog` (14) pass; full pre-push suite green.
- Pending: reinstall the test box and confirm the `hermes-dashboard`
  container comes up, `hermes.<domain>` resolves through NPM behind
  Authelia, and the portal card appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)