### PR TITLE
fix(adguard): use /login.html for the healthcheck, not /control/status

### DIFF
--- a/templates/adguard/template.yml
+++ b/templates/adguard/template.yml
@@ -15,12 +15,15 @@ metadata:
     servicebay.dependencies: "nginx,auth"
     servicebay.ports: "{{ADGUARD_ADMIN_PORT}}/tcp,53/udp,53/tcp"
     servicebay.config-mount: /opt/adguardhome/conf
-    # Continuous health probe (#626). `/control/status` is AdGuard's
-    # built-in JSON status endpoint — unauthenticated, returns `running`
-    # + DNS query counters. Cheap 200 that confirms the admin listener
-    # is alive.
+    # Continuous health probe (#626). AdGuard's `/control/*` API requires
+    # authentication once the admin password is set — and the post-deploy
+    # sets it — so `/control/status` returns 401 to the unauthenticated
+    # poller and can never go ready (#827: it was one of the two services
+    # that left settle-wait stuck at 10/12). `/login.html` is the static
+    # login page AdGuard always serves unauthenticated; a 200 there
+    # confirms the admin listener is alive.
     servicebay.healthcheck: |
-      url: http://localhost:{{ADGUARD_ADMIN_PORT}}/control/status
+      url: http://localhost:{{ADGUARD_ADMIN_PORT}}/login.html
       interval: 30s
       timeout: 5s
       startup_timeout: 5m


### PR DESCRIPTION
Closes #827.

## Root cause

The install settle-wait consistently logged `⚠️ 10/12 services active
after 180s` — two services never flipped to ready even though every
container was up. Diagnosed on the test box: the settle-wait counts a
service ready via `twin.services[].health.ready` when it has a
`servicebay.healthcheck` annotation, and two healthchecks never returned
a 2xx:

| Service | Healthcheck URL | Live result |
|---|---|---|
| **adguard** | `/control/status` | **401** — `/control/*` needs auth once the admin password is set |
| **immich** | `/api/server-info/ping` | **404** — endpoint renamed in immich v2.7 |

(`probeHttp` in `serviceHealth.ts` follows redirects but treats a
non-2xx final response as not-ready — so radicale's `/` → 302 → 200 was
fine; 401/404 were not.)

Not slow image pulls — both were just wrong endpoints, so lengthening
the cap would not have helped.

## Fix

This PR: AdGuard's healthcheck → `/login.html`, the static login page
AdGuard always serves unauthenticated (verified `200` on the box). A 200
there confirms the admin listener is alive — the same liveness intent as
the other templates' healthchecks.

The immich half was fixed separately in #831 (`/api/server/ping`,
already merged). With both endpoints corrected, settle-wait reaches
12/12.

## Test plan

- `npm run check:arch` clean; `template_consistency` (70) passes;
  full pre-push suite green.
- Endpoint verified live: `GET /login.html` on AdGuard → `200`.
- Pending: reinstall the test box and confirm the install log ends with
  `✅ All 12 services active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)