### PR TITLE
fix(security): reach host services via host.containers.internal, not LAN_IP

### DIFF
--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -30,11 +30,15 @@ spec:
   #   - Immich does *server-side* OIDC discovery against
   #     https://auth.<PUBLIC_DOMAIN>; an isolated container's resolver
   #     doesn't apply AdGuard's `*.PUBLIC_DOMAIN → LAN IP` rewrite
-  #     (#408/#410), so the `hostAliases` entry pins that name to the
-  #     LAN IP — request flows container → LAN IP → NPM → Authelia.
-  #     {{LAN_IP}} is filled in by the install runner at deploy time.
+  #     (#408/#410), so the `hostAliases` entry pins that name to a
+  #     host-reachable IP. It must be HOST_GATEWAY_IP (podman's
+  #     `host.containers.internal`), NOT the host's LAN IP — a
+  #     rootless-podman pod can't reach the host's own LAN IP (#817).
+  #     The request flows container → host → NPM → Authelia; the
+  #     canonical `auth.<PUBLIC_DOMAIN>` name is preserved so the OIDC
+  #     issuer still validates.
   hostAliases:
-    - ip: "{{LAN_IP}}"
+    - ip: "{{HOST_GATEWAY_IP}}"
       hostnames:
         - "auth.{{PUBLIC_DOMAIN}}"
   containers:

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -31,14 +31,15 @@ spec:
   #   - Audiobookshelf does *server-side* OIDC discovery against
   #     https://auth.<PUBLIC_DOMAIN>. An isolated container's resolver
   #     doesn't apply AdGuard's `*.PUBLIC_DOMAIN → LAN IP` rewrite, so
-  #     the `hostAliases` entry pins that name to the LAN IP — the
-  #     request then flows container → LAN IP → NPM → Authelia.
-  #     {{LAN_IP}} is filled in by the install runner at deploy time.
+  #     the `hostAliases` entry pins that name to HOST_GATEWAY_IP —
+  #     podman's `host.containers.internal`. It must NOT be the host's
+  #     LAN IP: a rootless-podman pod can't reach the host's own LAN IP
+  #     (#817). The request flows container → host → NPM → Authelia.
   #   - post-deploy.py runs in the host netns (not the pod), so its
   #     `127.0.0.1:9091` Authelia probe and `127.0.0.1:<ABS_PORT>`
   #     audiobookshelf probe keep working — the latter via the hostPort.
   hostAliases:
-    - ip: "{{LAN_IP}}"
+    - ip: "{{HOST_GATEWAY_IP}}"
       hostnames:
         - "auth.{{PUBLIC_DOMAIN}}"
   containers:

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -25,10 +25,11 @@ spec:
   #     the container port below.
   #   - Radicale binds LLDAP for user lookup over LDAP. LLDAP lives in
   #     the `auth` pod (still hostNetwork), so it listens on the host —
-  #     an isolated Radicale pod can't reach it on 127.0.0.1, so the
-  #     `ldap_uri` below targets {{LAN_IP}} (filled in by the install
-  #     runner at deploy time). Radicale does no OIDC, so no
-  #     auth.<domain> hostAliases entry is needed.
+  #     an isolated Radicale pod can't reach it on 127.0.0.1, nor on the
+  #     host's own LAN IP (rootless podman refuses both). It reaches the
+  #     host via `host.containers.internal`, the name podman puts in
+  #     every container's /etc/hosts — that's the `ldap_uri` target
+  #     below. Radicale does no OIDC, so no auth.<domain> hostAliases.
   initContainers:
   # Seed /config/config in-pod, every deploy. Earlier versions wrote a
   # config.mustache to the host bind-mount during the wizard's deploy
@@ -55,7 +56,7 @@ spec:
 
         [auth]
         type = ldap
-        ldap_uri = ldap://{{LAN_IP}}:{{LLDAP_LDAP_PORT}}
+        ldap_uri = ldap://host.containers.internal:{{LLDAP_LDAP_PORT}}
         ldap_base = ou=people,{{LLDAP_BASE_DN}}
         ldap_reader_dn = uid=admin,ou=people,{{LLDAP_BASE_DN}}
         ldap_secret = {{LLDAP_ADMIN_PASSWORD}}

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -19,7 +19,11 @@
     },
     "LAN_IP": {
       "default": "",
-      "description": "Host LAN IP. Auto-detected and filled in by ServiceBay at install time (#817) — leave blank; the installer overrides it. Used by isolated-network templates for a hostAliases entry that points the public auth subdomain at the LAN."
+      "description": "Host LAN IP. Auto-detected and filled in by ServiceBay at install time — leave blank; the installer overrides it. Used internally for AdGuard rewrites and NPM forward-host entries."
+    },
+    "HOST_GATEWAY_IP": {
+      "default": "169.254.1.2",
+      "description": "The address an isolated (bridge-network) pod uses to reach host-network services — podman's `host.containers.internal`. Isolated pods cannot reach the host's own LAN IP under rootless podman (#817), so isolated templates point their hostAliases entry here instead. Default is the rootless-podman/pasta standard; override only if your podman setup differs."
     }
   },
   "notes": [

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -30,13 +30,16 @@ spec:
   #   2. Vaultwarden does *server-side* OIDC discovery against
   #      https://auth.<PUBLIC_DOMAIN>. An isolated container's resolver
   #      doesn't apply AdGuard's `*.PUBLIC_DOMAIN → LAN IP` rewrite
-  #      (#408), so the `hostAliases` entry pins that one name to the
-  #      LAN IP. The request then flows container → LAN IP → NPM →
-  #      Authelia — the only path Authelia accepts (it validates the
-  #      canonical https issuer and the X-Forwarded headers NPM sets).
-  #      {{LAN_IP}} is filled in by the install runner at deploy time.
+  #      (#408), so the `hostAliases` entry pins that one name to a
+  #      host-reachable IP — HOST_GATEWAY_IP, podman's
+  #      `host.containers.internal`. It must NOT be the host's LAN IP:
+  #      a rootless-podman pod can't reach the host's own LAN IP (#817).
+  #      The request flows container → host → NPM → Authelia — the only
+  #      path Authelia accepts (it validates the canonical https issuer,
+  #      kept intact by reusing the `auth.<PUBLIC_DOMAIN>` name, and the
+  #      X-Forwarded headers NPM sets).
   hostAliases:
-    - ip: "{{LAN_IP}}"
+    - ip: "{{HOST_GATEWAY_IP}}"
       hostnames:
         - "auth.{{PUBLIC_DOMAIN}}"
   containers:


### PR DESCRIPTION
## The bug

#817's isolated templates pointed cross-pod references at the host's
**LAN IP** — vaultwarden/immich/media via a `hostAliases` entry for
`auth.<domain>`, radicale via its LDAP bind URI (`LAN_IP` is a
settings.json global the install runner fills in).

In **rootless podman an isolated (bridge-network) pod cannot reach the
host's own LAN IP at all** — TCP connects are refused. Verified on the
live box from inside the radicale and immich pods:

```
192.168.178.100:443   → Connection refused
192.168.178.100:3890  → Connection refused
host.containers.internal:443  → OPEN
host.containers.internal:3890 → OPEN
```

This silently broke, since 4.15.0 (inc 1) and 4.16.0 (inc 2):
- **radicale** → LLDAP bind → CalDAV/CardDAV auth returned 500 (radicale's only auth path).
- **vaultwarden / immich / audiobookshelf** → server-side OIDC discovery against `auth.<domain>` → SSO login broken.

## The fix

Use `host.containers.internal` — podman puts it in every container's
`/etc/hosts` and it routes to host-network services.

- **radicale**: `ldap_uri` now targets `host.containers.internal`
  directly (LDAP has no hostname/issuer validation, so a hostname is
  fine — no `hostAliases` needed).
- **immich / vaultwarden / media**: the `hostAliases` entry for
  `auth.<PUBLIC_DOMAIN>` now points at a new `HOST_GATEWAY_IP`
  settings.json global (default `169.254.1.2`, podman's
  `host.containers.internal` address). The `auth.<PUBLIC_DOMAIN>` name
  is kept so the OIDC issuer still validates — only the IP behind it
  moves.

`LAN_IP` is no longer referenced by any template; its settings.json
description was corrected.

## Verified on the live box

Live-patched the running pods with this exact change and tested:

| Service | Before | After |
|---|---|---|
| radicale → LLDAP | 500 | `Successful login: 'admin' (ldap)`; wrong password → 401 |
| immich → Authelia OIDC discovery | refused | **200** |
| vaultwarden → Authelia OIDC discovery | refused | **200** |
| audiobookshelf → Authelia OIDC discovery | refused | **200** |

`npm run check:arch` clean, `template_consistency` (70) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)