### PR TITLE
fix(install): persist the credentials manifest to config.installManifest

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -41,12 +41,12 @@ import {
   buildProxyHosts,
   type StackVariable,
 } from '@/lib/stackInstall/postInstall';
-import { buildCredentialsManifest, type Credential } from '@/lib/stackInstall/credentialsManifest';
+import { buildCredentialsManifest, mergeCredentials, type Credential } from '@/lib/stackInstall/credentialsManifest';
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
 import { getCapabilityBus } from '@/lib/capabilities/bus';
 import { DigitalTwinStore } from '@/lib/store/twin';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
-import { getConfig, saveConfig } from '@/lib/config';
+import { getConfig, saveConfig, type InstalledCredential } from '@/lib/config';
 import { reconcileLanIp } from '@/lib/lanIp';
 import {
   appendLog,
@@ -1159,6 +1159,32 @@ async function runJob(jobId: string): Promise<void> {
     ...scriptCredentials,
   ];
   await patchJob(jobId, { credentialsManifest: manifest });
+
+  // Persist the manifest to `config.installManifest` — the store the
+  // Settings → Saved Credentials page reads. The per-template
+  // credentials capability handler only emits OIDC client_secrets, so
+  // without this end-of-job write the post-deploy service logins
+  // (LLDAP, NPM, AdGuard, Jellyfin, Samba, …) never reach the
+  // persistent store and the page shows empty. Merged per-template so a
+  // feature-only install doesn't drop credentials from earlier installs.
+  try {
+    const cfg = await getConfig();
+    const merged = mergeCredentials(
+      (cfg.installManifest?.credentials ?? []) as Credential[],
+      manifest,
+      ctx.deployed.map(d => d.name),
+    );
+    await saveConfig({
+      ...cfg,
+      installManifest: {
+        savedAt: new Date().toISOString(),
+        credentials: merged as unknown as InstalledCredential[],
+      },
+    });
+    await log(jobId, `Saved ${manifest.length} credential(s) to the install manifest.`);
+  } catch (e) {
+    await log(jobId, `(note) couldn't persist the credentials manifest: ${e instanceof Error ? e.message : String(e)}`);
+  }
 
   // Portal routing — apex + wildcard rewrites for the active domain.
   // Always runs after a successful install (#707). Pre-fix this was

--- a/packages/backend/src/lib/stackInstall/credentialsManifest.test.ts
+++ b/packages/backend/src/lib/stackInstall/credentialsManifest.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { mergeCredentials, type Credential } from './credentialsManifest';
+
+const cred = (service: string, template?: string): Credential => ({
+  service,
+  url: `https://${service}.example`,
+  username: 'admin',
+  password: 'secret',
+  importance: 'critical',
+  template,
+});
+
+describe('mergeCredentials', () => {
+  it('returns the fresh manifest verbatim on a clean install (no existing entries)', () => {
+    const fresh = [cred('lldap', 'auth'), cred('npm', 'nginx')];
+    expect(mergeCredentials([], fresh, ['auth', 'nginx'])).toEqual(fresh);
+  });
+
+  it('replaces entries owned by a re-installed template', () => {
+    const existing = [{ ...cred('lldap', 'auth'), password: 'OLD' }];
+    const fresh = [{ ...cred('lldap', 'auth'), password: 'NEW' }];
+    const merged = mergeCredentials(existing, fresh, ['auth']);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].password).toBe('NEW');
+  });
+
+  it('preserves entries owned by templates not in this install (feature-only add)', () => {
+    const existing = [cred('lldap', 'auth'), cred('npm', 'nginx')];
+    const fresh = [cred('immich', 'immich')];
+    const merged = mergeCredentials(existing, fresh, ['immich']);
+    expect(merged.map(c => c.service).sort()).toEqual(['immich', 'lldap', 'npm']);
+  });
+
+  it('keeps legacy untagged entries (no template field) — never auto-dropped', () => {
+    const existing = [cred('legacy-thing', undefined)];
+    const fresh = [cred('immich', 'immich')];
+    const merged = mergeCredentials(existing, fresh, ['immich']);
+    expect(merged.map(c => c.service).sort()).toEqual(['immich', 'legacy-thing']);
+  });
+
+  it('drops a template\'s old entry even when this run produced none for it (uninstall-via-reinstall)', () => {
+    const existing = [cred('lldap', 'auth'), cred('immich', 'immich')];
+    // 'immich' is re-installed but emits no credentials this run
+    const merged = mergeCredentials(existing, [cred('lldap', 'auth')], ['auth', 'immich']);
+    expect(merged.map(c => c.service)).toEqual(['lldap']);
+  });
+});

--- a/packages/backend/src/lib/stackInstall/credentialsManifest.ts
+++ b/packages/backend/src/lib/stackInstall/credentialsManifest.ts
@@ -86,6 +86,31 @@ export function buildCredentialsManifest(opts: BuildOpts): Credential[] {
   return out;
 }
 
+/**
+ * Merge a freshly-built credentials manifest into a previously persisted
+ * one, keyed by owning template.
+ *
+ * The install runner calls this at end-of-job to keep
+ * `config.installManifest` complete. Entries owned by a template in
+ * `deployedTemplates` are dropped (the run just rebuilt them, so `fresh`
+ * carries the current values); entries owned by *other* templates — and
+ * legacy untagged entries — are preserved, so a feature-only install
+ * doesn't wipe credentials captured by earlier installs.
+ *
+ * Same per-template-replace semantics as the credentials capability
+ * handler (`capabilities/credentials.ts`), generalised to the set of
+ * templates one install job touched.
+ */
+export function mergeCredentials(
+  existing: Credential[],
+  fresh: Credential[],
+  deployedTemplates: readonly string[],
+): Credential[] {
+  const deployed = new Set(deployedTemplates);
+  const kept = existing.filter(c => !c.template || !deployed.has(c.template));
+  return [...kept, ...fresh];
+}
+
 // #632 removed `formatCredentialsBanner` — the install runner no longer
 // dumps the manifest into the deploy log. The wizard's Done UI reads
 // the same data from `job.credentialsManifest` and the credentials


### PR DESCRIPTION
## Symptom

After a successful install, **Settings → Saved Credentials** shows
"No credentials saved" — even though the install captured every
credential and the CSV export downloads all of them.

## Cause

The Saved Credentials page reads `config.installManifest`. Nothing
populates it with the real service logins:

- The install runner builds the full manifest (OIDC `client_secret`
  entries + post-deploy `__SB_CREDENTIAL__` captures) but only writes it
  to the **job** state (`job.credentialsManifest`) — which feeds the
  Done step and the CSV, not config.
- The credentials **capability handler** (`capabilities/credentials.ts`)
  is the only writer of `config.installManifest`, and it emits **only**
  the variable-derived OIDC `client_secret` entries — never the
  post-deploy service logins (LLDAP, NPM, AdGuard, Jellyfin, Samba, …).

So the persistent store stayed empty.

## Fix

The runner now persists the complete manifest to
`config.installManifest` at end-of-job, right after it builds it for the
job state. Merged per-template via a new pure `mergeCredentials` helper
(same per-template-replace semantics as the capability handler,
generalised to the set of templates one job touched) so a feature-only
install doesn't drop credentials captured by earlier installs; legacy
untagged entries are preserved.

## Tests

- New `credentialsManifest.test.ts` — 5 cases for `mergeCredentials`
  (clean install, re-install replace, feature-add preserve, legacy
  untagged kept, drop-on-reinstall-with-no-fresh-entry).
- `npm run check:arch` clean; backend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)