### PR TITLE
refactor(store): migrate backend call sites through repository selectors [ARCH-10a/10b]

### DIFF
--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -12,7 +12,7 @@
 
 import { agentManager } from '@/lib/agent/manager';
 import { HealthStore } from '@/lib/health/store';
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { getNodeTwin } from '@/lib/store/repository';
 import { actionsForProbe, resolveItemActions, type ProbeAction, type ProbeItem, type ResolvedProbeItem } from '@/lib/diagnose/actions';
 import { buildPortSourceMap, renderUnexpectedPort, type TwinPortService, type TwinPortContainer } from '@/lib/diagnose/portsProbe';
 import { checkNpmDataStale } from '@/lib/diagnose/probes/npmDataStale';
@@ -286,7 +286,7 @@ export async function runDiagnose(nodeName: string = 'Local'): Promise<DiagnoseR
   //    so the operator doesn't have to cross-reference manually.
   //    See `lib/diagnose/portsProbe.ts` for the source-walk helpers.
   const ports = trimOutput(listen.stdout, 50).split('\n').filter(Boolean);
-  const portsTwin = DigitalTwinStore.getInstance().nodes[nodeName];
+  const portsTwin = getNodeTwin(nodeName);
   const portSource = buildPortSourceMap(
     portsTwin?.services as TwinPortService[] | undefined,
     portsTwin?.containers as TwinPortContainer[] | undefined,
@@ -513,7 +513,7 @@ export async function runDiagnose(nodeName: string = 'Local'): Promise<DiagnoseR
   //     `lib/diagnose/probes/danglingProxy.ts` (registers
   //     `delete_route`).
   try {
-    const twin = DigitalTwinStore.getInstance().nodes[nodeName];
+    const twin = getNodeTwin(nodeName);
     type ProxyServer = {
       _targetPort?: number;
       _id?: number;

--- a/packages/backend/src/lib/gateway/poller.ts
+++ b/packages/backend/src/lib/gateway/poller.ts
@@ -1,4 +1,4 @@
-import { DigitalTwinStore } from '../store/twin';
+import { updateGateway } from '../store/repository';
 import { GatewayProvider } from './types';
 import { FritzBoxProvider } from './fritzbox';
 import { getConfig } from '../config';
@@ -8,11 +8,8 @@ export class GatewayPoller {
   private static instance: GatewayPoller;
   private provider: GatewayProvider | null = null;
   private interval: NodeJS.Timeout | null = null;
-  private store: DigitalTwinStore;
 
-  private constructor() {
-    this.store = DigitalTwinStore.getInstance();
-  }
+  private constructor() {}
 
   public static getInstance(): GatewayPoller {
     if (!GatewayPoller.instance) {
@@ -66,7 +63,7 @@ export class GatewayPoller {
     if (!this.provider) return;
     try {
         const update = await this.provider.poll();
-        this.store.updateGateway(update);
+        updateGateway(update);
     } catch (e) {
         logger.error('GatewayPoller', 'Error:', e);
     }

--- a/packages/backend/src/lib/health/probes/dnsRouting.ts
+++ b/packages/backend/src/lib/health/probes/dnsRouting.ts
@@ -14,8 +14,8 @@ registerProbe({
     const domain = check.target;
     if (!domain) return { status: 'fail', message: 'dns_routing check has no target domain.' };
 
-    const { DigitalTwinStore } = await import('../../store/twin');
-    const expectedIp = DigitalTwinStore.getInstance().gateway?.publicIp ?? '';
+    const { getGateway } = await import('../../store/repository');
+    const expectedIp = getGateway()?.publicIp ?? '';
     const haveExpected = !!expectedIp && expectedIp !== '0.0.0.0';
 
     let answers: string[];

--- a/packages/backend/src/lib/health/probes/npmAdmin.ts
+++ b/packages/backend/src/lib/health/probes/npmAdmin.ts
@@ -18,7 +18,7 @@
  */
 import { getConfig } from '../../config';
 import { ServiceManager } from '../../services/ServiceManager';
-import { DigitalTwinStore } from '../../store/twin';
+import { getNodeTwin } from '../../store/repository';
 
 /**
  * Discriminated result for `findNpmAdminUrl`.
@@ -51,7 +51,7 @@ export type FindNpmAdminResult =
  *  the precise reason instead of a misleading "not deployed". */
 export async function findNpmAdminUrl(node: string): Promise<FindNpmAdminResult> {
   try {
-    const twin = DigitalTwinStore.getInstance().nodes[node];
+    const twin = getNodeTwin(node);
     if (!twin || (twin.services.length === 0 && twin.containers.length === 0)) {
       return { kind: 'twin-not-ready' };
     }

--- a/packages/backend/src/lib/health/serviceHealth.ts
+++ b/packages/backend/src/lib/health/serviceHealth.ts
@@ -35,7 +35,7 @@
  *   and a long fetch is bounded by `timeoutMs`.
  */
 import net from 'net';
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { clearServiceHealth as repoClearServiceHealth, setServiceHealth as repoSetServiceHealth } from '@/lib/store/repository';
 import { logger } from '@/lib/logger';
 import type { ServiceHealth } from '@/lib/agent/types';
 import type { HealthcheckConfig } from './serviceHealthcheck';
@@ -94,7 +94,7 @@ export class ServiceHealthPoller {
     const key = this.keyFor(nodeName, serviceName);
     this.stopTimer(key);
     this.registry.delete(key);
-    DigitalTwinStore.getInstance().clearServiceHealth(nodeName, serviceName);
+    repoClearServiceHealth(nodeName, serviceName);
   }
 
   /** Returns the current registrations — exposed for diagnose / debug. */
@@ -137,7 +137,7 @@ export class ServiceHealthPoller {
     if (!reg) return;
     try {
       const health = await this.probe(reg);
-      DigitalTwinStore.getInstance().setServiceHealth(reg.nodeName, reg.serviceName, health);
+      repoSetServiceHealth(reg.nodeName, reg.serviceName, health);
     } catch (e) {
       // probe() itself never throws; this catch is defence-in-depth so a
       // bug in the probe path can't kill the polling loop for every

--- a/packages/backend/src/lib/install/performStackReset.ts
+++ b/packages/backend/src/lib/install/performStackReset.ts
@@ -9,7 +9,7 @@
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { agentManager } from '@/lib/agent/manager';
 import { getConfig, scrubEncryptedConfig } from '@/lib/config';
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { getNodeIds } from '@/lib/store/repository';
 import { logger } from '@/lib/logger';
 import { RESET_GROUPS, DEFAULT_PRESERVE, isAlwaysWipe, type ResetGroup } from './resetGroups';
 import { validateResetCombo } from './resetValidation';
@@ -71,8 +71,7 @@ export async function performStackReset(
     );
   }
 
-  const twin = DigitalTwinStore.getInstance();
-  const nodeName = options.node || Object.keys(twin.nodes)[0];
+  const nodeName = options.node || getNodeIds()[0];
   if (!nodeName) throw new StackResetError('No nodes available', 404);
 
   const config = await getConfig();

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -44,7 +44,7 @@ import {
 import { buildCredentialsManifest, mergeCredentials, type Credential } from '@/lib/stackInstall/credentialsManifest';
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
 import { getCapabilityBus } from '@/lib/capabilities/bus';
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { getStoreSnapshot } from '@/lib/store/repository';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { getConfig, saveConfig, type InstalledCredential } from '@/lib/config';
 import { reconcileLanIp } from '@/lib/lanIp';
@@ -244,10 +244,9 @@ async function settleWait(
   const startedAt = Date.now();
   let lastReady = -1;
   let lastLogAt = Date.now();
-  const twin = DigitalTwinStore.getInstance();
   while (Date.now() - startedAt < SETTLE_TIMEOUT_MS) {
     if (abortFlags.get(jobId)) return;
-    const snapshot = twin.getSnapshot();
+    const snapshot = getStoreSnapshot();
     const twinNode = snapshot.nodes?.[node];
     const services = twinNode?.services ?? [];
     const ready = expected.filter(name => isServiceReady(services, name)).length;
@@ -299,14 +298,13 @@ export async function waitForDependencies(
     await bootstrapServiceHealth(node);
   } catch { /* fall back to the systemd-active signal */ }
 
-  const twin = DigitalTwinStore.getInstance();
   const startedAt = Date.now();
   let lastLogAt = startedAt;
   const pending = new Set(deps);
   await log(jobId, `Waiting for ${item.name}'s dependencies to become healthy: ${deps.join(', ')}...`);
   while (pending.size > 0 && Date.now() - startedAt < DEP_READY_TIMEOUT_MS) {
     if (abortFlags.get(jobId)) return;
-    const services = twin.getSnapshot().nodes?.[node]?.services ?? [];
+    const services = getStoreSnapshot().nodes?.[node]?.services ?? [];
     for (const dep of [...pending]) {
       if (isServiceReady(services, dep)) pending.delete(dep);
     }

--- a/packages/backend/src/lib/install/stackHealth.ts
+++ b/packages/backend/src/lib/install/stackHealth.ts
@@ -17,7 +17,7 @@
  * first 30 seconds after a fresh deploy before the poller has run)
  * or as a hard fail.
  */
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { getNodeTwin } from '@/lib/store/repository';
 import { getStackManifest } from '@/lib/registry';
 import { getConfig } from '@/lib/config';
 
@@ -187,8 +187,7 @@ export async function getStackHealth(
 ): Promise<StackHealth | null> {
   const manifest = await getStackManifest(stackName);
   if (!manifest) return null;
-  const twin = DigitalTwinStore.getInstance();
-  const node = twin.nodes[nodeName];
+  const node = getNodeTwin(nodeName);
   const services = node?.services ?? [];
   const map = new Map<string, { ready: boolean; degraded?: boolean }>();
   for (const svc of services) {

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1,8 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { randomUUID } from 'crypto';
-import { DigitalTwinStore } from '@/lib/store/twin';
-import { getUnmanagedBundles } from '@/lib/store/repository';
+import {
+  getStoreSnapshot,
+  getServices,
+  getContainers,
+  getNodeTwin,
+  getUnmanagedBundles,
+} from '@/lib/store/repository';
 import { mergeServices, type DiscoveredService } from '@/lib/migration';
 import {
   getAllSystemServices,
@@ -247,8 +252,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   // --- List Nodes ---
   server.tool('list_nodes', 'List all registered nodes with connection status and resources', {}, async () => {
-    const twin = DigitalTwinStore.getInstance();
-    const snapshot = twin.getSnapshot();
+    const snapshot = getStoreSnapshot();
     const nodes = await listNodes();
 
     const result = nodes.map(n => {
@@ -268,18 +272,14 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   // --- List Services ---
   server.tool('list_services', 'List services on a node with status, ports, volumes', { node: nodeParam }, async ({ node }) => {
-    const twin = DigitalTwinStore.getInstance();
     const nodeName = await resolveNode(node);
-    const services = twin.nodes[nodeName]?.services || [];
-    return textResult(services);
+    return textResult(getServices(nodeName));
   });
 
   // --- List Containers ---
   server.tool('list_containers', 'List running containers with image, state, ports', { node: nodeParam }, async ({ node }) => {
-    const twin = DigitalTwinStore.getInstance();
     const nodeName = await resolveNode(node);
-    const containers = twin.nodes[nodeName]?.containers || [];
-    return textResult(containers);
+    return textResult(getContainers(nodeName));
   });
 
   // --- Get Service Logs ---
@@ -506,9 +506,8 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   // --- Get System Info ---
   server.tool('get_system_info', 'Get CPU, memory, disk, and uptime info for a node', { node: nodeParam }, async ({ node }) => {
-    const twin = DigitalTwinStore.getInstance();
     const nodeName = await resolveNode(node);
-    const nodeTwin = twin.nodes[nodeName];
+    const nodeTwin = getNodeTwin(nodeName);
 
     if (!nodeTwin) {
       return errorResult(`Node "${nodeName}" not found`);
@@ -576,8 +575,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   // --- Get Network Graph ---
   server.tool('get_network_graph', 'Get network topology: nodes, edges, port mappings', {}, async () => {
-    const twin = DigitalTwinStore.getInstance();
-    const snapshot = twin.getSnapshot();
+    const snapshot = getStoreSnapshot();
     const nodes = await listNodes();
 
     const graphNodes: Array<{ id: string; type: string; data: Record<string, unknown> }> = [];
@@ -645,16 +643,12 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   // --- Get Gateway Status ---
   server.tool('get_gateway_status', 'Get gateway info: public IP, port mappings, uptime', {}, async () => {
-    const twin = DigitalTwinStore.getInstance();
-    const snapshot = twin.getSnapshot();
-    return textResult(snapshot.gateway);
+    return textResult(getStoreSnapshot().gateway);
   });
 
   // --- Get Proxy Routes ---
   server.tool('get_proxy_routes', 'Get reverse proxy routes configuration', {}, async () => {
-    const twin = DigitalTwinStore.getInstance();
-    const snapshot = twin.getSnapshot();
-    return textResult(snapshot.proxyState);
+    return textResult(getStoreSnapshot().proxyState);
   });
 
   // --- Exec Command ---

--- a/packages/backend/src/lib/migration.ts
+++ b/packages/backend/src/lib/migration.ts
@@ -31,7 +31,8 @@ import yaml from 'js-yaml';
 import { injectServiceDirectives } from './services/quadletDirectives';
 import { randomUUID } from 'crypto';
 import { saveSnapshot } from './history';
-import { DigitalTwinStore, MigrationHistoryEntry } from './store/twin';
+import { MigrationHistoryEntry } from './store/twin';
+import { recordMigrationEvent } from './store/repository';
 import {
     type DiscoveredService,
     getSystemdDir,
@@ -344,7 +345,6 @@ function recordMigrationHistory(params: {
     error?: string;
 }) {
     try {
-        const store = DigitalTwinStore.getInstance();
         const entry: MigrationHistoryEntry = {
             id: randomUUID(),
             timestamp: new Date().toISOString(),
@@ -362,7 +362,7 @@ function recordMigrationHistory(params: {
             status: params.status,
             error: params.error
         };
-        store.recordMigrationEvent(params.nodeName, entry);
+        recordMigrationEvent(params.nodeName, entry);
     } catch (error) {
         console.warn('Failed to record migration history', error);
     }

--- a/packages/backend/src/lib/network/flowSampler.ts
+++ b/packages/backend/src/lib/network/flowSampler.ts
@@ -12,7 +12,7 @@
  * by ≥2 ticks before it surfaces, which cuts one-off noise).
  */
 import { listNodes } from '@/lib/nodes';
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { getStoreSnapshot } from '@/lib/store/repository';
 import { logger } from '@/lib/logger';
 import { collectHostSockets, resolveFlows } from './socketFlows';
 import { recordFlows } from './flowsStore';
@@ -28,7 +28,7 @@ const SAMPLE_BOOT_DELAY_MS = 90 * 1000;
  */
 export function containerServiceMap(node: string): Map<string, string> {
   const map = new Map<string, string>();
-  const twinNode = DigitalTwinStore.getInstance().getSnapshot().nodes?.[node];
+  const twinNode = getStoreSnapshot().nodes?.[node];
   for (const c of twinNode?.containers ?? []) {
     const unit = c.labels?.['PODMAN_SYSTEMD_UNIT'];
     const svc = unit ? unit.replace(/\.service$/, '') : c.podName;

--- a/packages/backend/src/lib/network/service.ts
+++ b/packages/backend/src/lib/network/service.ts
@@ -6,7 +6,7 @@ import { NetworkStore } from './store';
 import { getActiveEdges } from './flowsStore';
 import { checkDomains } from './dns';
 import watcher from '../watcher';
-import { DigitalTwinStore } from '../store/twin'; // Import Twin Store
+import { getGateway, getNodeTwin } from '../store/repository';
 import { logger } from '../logger';
 import yaml from 'js-yaml'; // Helper: YAML parser
 import { EnrichedContainer, PortMapping, ServiceUnit, WatchedFile } from '../agent/types';
@@ -341,8 +341,7 @@ export class NetworkService {
     const config = await getConfig();
     
     // SSOT: Use Digital Twin Gateway State
-    const twin = DigitalTwinStore.getInstance();
-    const gw = twin.gateway;
+    const gw = getGateway();
 
     // Map Twin State to legacy fbStatus format for compatibility
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -481,7 +480,7 @@ export class NetworkService {
     // 0. Prepare Data for this Node
     
     // Check Digital Twin first
-    const twinNode = DigitalTwinStore.getInstance().nodes[nodeName];
+    const twinNode = getNodeTwin(nodeName);
     // We consider twin usable if it has basic data. 
     // Agent V4 pushes 'containers' and 'services'.
     

--- a/packages/backend/src/lib/nginx/confDir.ts
+++ b/packages/backend/src/lib/nginx/confDir.ts
@@ -1,5 +1,5 @@
 import { ServiceManager } from '@/lib/services/ServiceManager';
-import { DigitalTwinStore } from '@/lib/store/twin';
+import { getNodeIds, getNodeTwin, getProxyState } from '@/lib/store/repository';
 import { getExecutor } from '@/lib/executor';
 import { parseQuadletFile } from '@/lib/quadlet/parser';
 import { getConfig } from '@/lib/config';
@@ -42,8 +42,7 @@ const NPM_CONF_SUBDIRS = [
  */
 export async function findNginxConfDir(): Promise<NginxConfDirResult | null> {
     const debug: string[] = [];
-    const twinStore = DigitalTwinStore.getInstance();
-    const nodeNames = Object.keys(twinStore.nodes);
+    const nodeNames = getNodeIds();
     if (nodeNames.length === 0) {
         nodeNames.push('Local');
         debug.push('No nodes in twin store, falling back to Local');
@@ -67,7 +66,7 @@ export async function findNginxConfDir(): Promise<NginxConfDirResult | null> {
         debug.push(`Node "${nodeName}": found nginx service "${nginxService.name}"`);
 
         // Try resolving from Digital Twin YAML
-        const yamlResult = resolveFromTwinFiles(twinStore, nodeName, debug);
+        const yamlResult = resolveFromTwinFiles(nodeName, debug);
 
         if (yamlResult.exactConfDir) {
             logger.info('NginxConfDir', `Resolved conf.d from YAML: ${yamlResult.exactConfDir} on ${nodeName}`);
@@ -113,18 +112,17 @@ export async function findNginxConfDir(): Promise<NginxConfDirResult | null> {
 }
 
 function resolveFromTwinFiles(
-    twinStore: DigitalTwinStore,
     nodeName: string,
     debug: string[],
 ): YamlResolution {
     const result: YamlResolution = { exactConfDir: null, proxyHostPaths: [], isNpm: false };
-    const twin = twinStore.nodes[nodeName];
+    const twin = getNodeTwin(nodeName);
     if (!twin?.files) {
         debug.push(`Node "${nodeName}": no files in twin store`);
         return result;
     }
 
-    const proxyState = twinStore.proxyState;
+    const proxyState = getProxyState();
     const fileKeys = Object.keys(twin.files);
     const yamlFiles = fileKeys.filter(f => f.endsWith('.yml') || f.endsWith('.yaml'));
     const kubeFiles = fileKeys.filter(f => f.endsWith('.kube'));

--- a/packages/backend/src/lib/reverseProxy/migrateToPublic.ts
+++ b/packages/backend/src/lib/reverseProxy/migrateToPublic.ts
@@ -31,7 +31,7 @@
  */
 
 import { getConfig, updateConfig } from '../config';
-import { DigitalTwinStore } from '../store/twin';
+import { getNodeIds, getNodeTwin } from '../store/repository';
 import { ServiceManager } from '../services/ServiceManager';
 import { logger } from '../logger';
 import yaml from 'js-yaml';
@@ -143,8 +143,7 @@ interface NpmDeps {
 async function realNpmDeps(): Promise<NpmDeps> {
   return {
     resolveNpm: async (nodeHint) => {
-      const twin = DigitalTwinStore.getInstance();
-      const nodeNames = nodeHint ? [nodeHint] : Object.keys(twin.nodes);
+      const nodeNames = nodeHint ? [nodeHint] : getNodeIds();
       if (nodeNames.length === 0) nodeNames.push('Local');
       for (const nodeName of nodeNames) {
         const services = await ServiceManager.listServices(nodeName);
@@ -157,8 +156,8 @@ async function realNpmDeps(): Promise<NpmDeps> {
           const config = await getConfig();
           adminPort = config.templateSettings?.NGINX_ADMIN_PORT || '81';
         }
-        const t = twin.nodes[nodeName];
-        const nodeIp = t?.nodeIPs?.find(ip => !ip.startsWith('127.')) ?? t?.nodeIPs?.[0] ?? '127.0.0.1';
+        const t = getNodeTwin(nodeName);
+        const nodeIp = t?.nodeIPs?.find((ip: string) => !ip.startsWith('127.')) ?? t?.nodeIPs?.[0] ?? '127.0.0.1';
         const apiHost = nodeName === 'Local' ? '127.0.0.1' : nodeIp;
         return { apiUrl: `http://${apiHost}:${adminPort}`, nodeName, nodeIp };
       }
@@ -259,8 +258,7 @@ async function realAutheliaDeps(): Promise<AutheliaDeps> {
   const { agentManager } = await import('../agent/manager');
   return {
     locateConfig: async () => {
-      const twin = DigitalTwinStore.getInstance();
-      for (const nodeName of Object.keys(twin.nodes)) {
+      for (const nodeName of getNodeIds()) {
         try {
           const files = await ServiceManager.getServiceFiles(nodeName, 'auth');
           if (!files.yamlContent) continue;

--- a/packages/backend/src/lib/services/serviceListing.ts
+++ b/packages/backend/src/lib/services/serviceListing.ts
@@ -49,9 +49,9 @@ export interface ServiceInfo {
 export class ServiceListing {
     static async listServices(nodeName: string): Promise<ServiceInfo[]> {
         // V4: Use DigitalTwinStore
-        const { DigitalTwinStore } = await import('../store/twin');
-        const twin = DigitalTwinStore.getInstance().nodes[nodeName];
-        const proxyState = DigitalTwinStore.getInstance().proxyState; // Access Global Proxy State
+        const { getNodeTwin, getProxyState } = await import('../store/repository');
+        const twin = getNodeTwin(nodeName);
+        const proxyState = getProxyState(); // Access Global Proxy State
 
         if (!twin) return [];
 
@@ -494,8 +494,8 @@ export class ServiceListing {
 
         try {
             // First try reading from the Digital Twin cache
-            const { DigitalTwinStore } = await import('../store/twin');
-            const twin = DigitalTwinStore.getInstance().nodes[nodeName];
+            const { getNodeTwin } = await import('../store/repository');
+            const twin = getNodeTwin(nodeName);
 
             const fullKubePath = twin ? Object.keys(twin.files).find(p => p.endsWith(`${serviceName}.kube`)) : null;
 

--- a/packages/backend/src/lib/store/repository.ts
+++ b/packages/backend/src/lib/store/repository.ts
@@ -1,11 +1,24 @@
 import { DigitalTwinStore } from './twin';
-import type { NodeTwin, GatewayState, ProxyState } from './twin';
-import type { EnrichedContainer, ServiceUnit } from '../agent/types';
+import type { NodeTwin, GatewayState, ProxyState, MigrationHistoryEntry } from './twin';
+import type { EnrichedContainer, ServiceUnit, ServiceHealth } from '../agent/types';
+import type { ServiceBundle } from '../unmanaged/bundleShared';
 
 /**
- * Encapsulated store access selectors (#841).
- * Isolates direct references to the global DigitalTwinStore singleton.
+ * Encapsulated store access selectors (#841 / #842).
+ *
+ * Every read of the global `DigitalTwinStore` singleton must go through
+ * one of these selectors. The `check:invariants` script blocks new
+ * `DigitalTwinStore.getInstance()` calls anywhere outside this file —
+ * raising the budget needs an explicit ratchet bump.
+ *
+ * Reads come first (the bulk of the API); writes are grouped at the end
+ * and kept narrow so future CQRS work can lift them into a separate
+ * command bus without touching every call site again.
  */
+
+export type StoreSnapshot = ReturnType<DigitalTwinStore['getSnapshot']>;
+
+// --- Read selectors ---
 
 export function getNodeTwins(): Record<string, NodeTwin> {
   return DigitalTwinStore.getInstance().nodes;
@@ -31,23 +44,15 @@ export function getProxyState(): ProxyState {
   return DigitalTwinStore.getInstance().proxyState;
 }
 
-export function getStoreSnapshot() {
+export function getStoreSnapshot(): StoreSnapshot {
   return DigitalTwinStore.getInstance().getSnapshot();
 }
 
-// --- Write operations ---
-
-export function setServerName(name: string | null): void {
-  DigitalTwinStore.getInstance().setServerName(name);
+export function getNodeIds(): string[] {
+  return Object.keys(DigitalTwinStore.getInstance().nodes);
 }
 
-export function dismissUnmanagedBundle(nodeId: string, bundleId: string): boolean {
-  return DigitalTwinStore.getInstance().dismissUnmanagedBundle(nodeId, bundleId);
-}
-
-// --- Compound selectors ---
-
-export function getUnmanagedBundles(nodeId: string): import('../unmanaged/bundleShared').ServiceBundle[] {
+export function getUnmanagedBundles(nodeId: string): ServiceBundle[] {
   return DigitalTwinStore.getInstance().nodes[nodeId]?.unmanagedBundles ?? [];
 }
 
@@ -70,4 +75,30 @@ export function getFirstNodeHostname(): string | null {
   }
 
   return null;
+}
+
+// --- Write selectors ---
+
+export function setServerName(name: string | null): void {
+  DigitalTwinStore.getInstance().setServerName(name);
+}
+
+export function dismissUnmanagedBundle(nodeId: string, bundleId: string): boolean {
+  return DigitalTwinStore.getInstance().dismissUnmanagedBundle(nodeId, bundleId);
+}
+
+export function setServiceHealth(nodeName: string, serviceName: string, health: ServiceHealth): void {
+  DigitalTwinStore.getInstance().setServiceHealth(nodeName, serviceName, health);
+}
+
+export function clearServiceHealth(nodeName: string, serviceName: string): void {
+  DigitalTwinStore.getInstance().clearServiceHealth(nodeName, serviceName);
+}
+
+export function updateGateway(update: Partial<GatewayState>): void {
+  DigitalTwinStore.getInstance().updateGateway(update);
+}
+
+export function recordMigrationEvent(nodeId: string, entry: MigrationHistoryEntry): void {
+  DigitalTwinStore.getInstance().recordMigrationEvent(nodeId, entry);
 }

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -714,19 +714,18 @@ export async function createSystemBackup(progress?: ProgressCallback): Promise<S
         const serviceDataDir = path.join(stagingDir, 'service-data');
         metadata.serviceData = [];
 
-        const { DigitalTwinStore } = await import('./store/twin');
+        const { getNodeTwin, getProxyState } = await import('./store/repository');
         const { default: yamlLib } = await import('js-yaml');
-        const twinStore = DigitalTwinStore.getInstance();
         const allNodes = await listNodes();
         const sshNodes = allNodes.filter(node => node.URI?.startsWith('ssh://'));
 
         for (const node of sshNodes) {
-            const twin = twinStore.nodes[node.Name];
+            const twin = getNodeTwin(node.Name);
             if (!twin) continue;
 
             // Parse hostPath volumes from reverse-proxy YAML files in twin.files
             const proxyMounts: { source: string; label: string }[] = [];
-            const proxyState = twinStore.proxyState;
+            const proxyState = getProxyState();
 
             for (const [filePath, file] of Object.entries(twin.files || {})) {
                 if (!filePath.endsWith('.yml') && !filePath.endsWith('.yaml')) continue;

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -21,6 +21,7 @@ import path from 'node:path';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const SRC = path.join(REPO_ROOT, 'src');
+const BACKEND_SRC = path.join(REPO_ROOT, 'packages', 'backend', 'src');
 
 interface Violation {
     check: string;
@@ -199,16 +200,25 @@ async function checkWithApiHandlerAdoption() {
 // 35 direct getInstance() consumers today. Architecture audit ARCH-05ff
 // flags that this should go through a reader API. Ratcheted to 0 now that
 // all Next.js route call-sites use repository.ts selectors (#841, #842).
+//
+// Scans both `src/` (Next.js routes / pages / components) and
+// `packages/backend/src/` (extracted backend library). The store itself
+// (`store/twin.ts`) and the encapsulation layer (`store/repository.ts`)
+// are the only allowed call sites.
 // ---------------------------------------------------------------------------
 const TWIN_GETINSTANCE_MAX = 0;
 
 async function checkTwinFanIn() {
-    const files = await walk(SRC, isTs);
+    const files = [
+        ...await walk(SRC, isTs),
+        ...await walk(BACKEND_SRC, isTs),
+    ];
     let count = 0;
     for (const file of files) {
         if (isTestFile(file)) continue;
-        // Skip the store itself.
+        // Skip the store itself and the encapsulation layer.
         if (file.endsWith(path.join('store', 'twin.ts'))) continue;
+        if (file.endsWith(path.join('store', 'repository.ts'))) continue;
         const content = await readFile(file, 'utf-8');
         const hits = content.match(/\bDigitalTwinStore\.getInstance\(\)/g)?.length ?? 0;
         count += hits;
@@ -216,7 +226,7 @@ async function checkTwinFanIn() {
     if (count > TWIN_GETINSTANCE_MAX) {
         violations.push({
             check: 'twin-singleton-fan-in',
-            detail: `${count} direct DigitalTwinStore.getInstance() call sites (max ${TWIN_GETINSTANCE_MAX}). Route new reads through a reader API.`,
+            detail: `${count} direct DigitalTwinStore.getInstance() call sites (max ${TWIN_GETINSTANCE_MAX}). Route new reads through packages/backend/src/lib/store/repository.ts.`,
         });
     }
 }


### PR DESCRIPTION
## Summary
Closes the gap left by the original twin store encapsulation: the invariant ratcheted `src/` to zero direct `DigitalTwinStore.getInstance()` calls, but `packages/backend/src/` still had 29 of them. This PR finishes the migration and tightens the invariant to scan both trees.

## Changes

**`store/repository.ts`** — added read selectors (`getNodeIds`, `getServices`, `getContainers`, `getNodeTwin`, `getStoreSnapshot`, etc.) and four narrow write selectors (`setServiceHealth`, `clearServiceHealth`, `updateGateway`, `recordMigrationEvent`). Exports `StoreSnapshot` as `ReturnType<DigitalTwinStore['getSnapshot']>` so callers don't pin the inline shape.

**Migrated call sites (29 hits across 14 files):**
- `diagnose/runDiagnose.ts`, `health/probes/{dnsRouting,npmAdmin}.ts`, `health/serviceHealth.ts`
- `install/{performStackReset,runner,stackHealth}.ts`
- `network/{service,flowSampler}.ts`, `nginx/confDir.ts`, `reverseProxy/migrateToPublic.ts`
- `services/serviceListing.ts`, `systemBackup.ts`, `migration.ts`
- `mcp/server.ts` (7 sites)
- `gateway/poller.ts` (no longer captures `this.store` in the constructor)
- `nginx/confDir.ts`: `resolveFromTwinFiles` signature dropped the store parameter — reads by `nodeName` via selectors instead.

**Invariant** (`scripts/check-invariants.ts`):
- Walks both `src/` and `packages/backend/src/`.
- Skips `store/twin.ts` (the store itself) and `store/repository.ts` (the encapsulation layer).
- `TWIN_GETINSTANCE_MAX` stays at `0`. Non-allowed call sites: 29 → 0.

## Test plan
- [x] `npm test` — 1184 passed
- [x] `tsc --noEmit` — clean
- [x] `npm run check:arch` — clean
- [x] Fixed two pre-existing TS errors in `repository.test.ts` (EnrichedContainer/ServiceUnit fixture shape) that vitest was silently transpiling around.

Closes #841, #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)