### PR TITLE
fix(login): guard socket + 401 redirects so /login doesn't loop (#854)

### DIFF
--- a/packages/frontend/src/hooks/useSocket.ts
+++ b/packages/frontend/src/hooks/useSocket.ts
@@ -30,8 +30,17 @@ export const useSocket = () => {
     // DigitalTwinProvider — bounce to /login so the operator
     // re-authenticates. Only the auth error redirects; transient network
     // `connect_error`s must keep retrying silently.
+    //
+    // The path guard prevents an infinite reload loop on /login itself:
+    // the root layout mounts DigitalTwinProvider unconditionally, so the
+    // socket also connects from the login page; without the guard, every
+    // failed connect would redirect the browser back to /login (#854).
     function onConnectError(err: Error) {
-      if (err?.message === 'unauthorized' && typeof window !== 'undefined') {
+      if (
+        err?.message === 'unauthorized' &&
+        typeof window !== 'undefined' &&
+        window.location.pathname !== '/login'
+      ) {
         window.location.href = '/login';
       }
     }

--- a/packages/frontend/src/providers/DigitalTwinProvider.tsx
+++ b/packages/frontend/src/providers/DigitalTwinProvider.tsx
@@ -23,11 +23,16 @@ const DigitalTwinContext = createContext<DigitalTwinContextType | undefined>(und
 
 // Intercept 401 responses from API calls and redirect to login.
 // This handles session expiry gracefully instead of showing JSON parse errors.
+//
+// The pathname guard prevents an infinite reload loop on /login itself:
+// the login page calls /api/auth/oidc/status (and similar pre-auth probes)
+// which can transiently 401; without the guard, every 401 from /login would
+// hard-reload the page back to /login forever (#854).
 if (typeof window !== 'undefined') {
     const originalFetch = window.fetch.bind(window);
     window.fetch = async (...args: Parameters<typeof fetch>) => {
         const response = await originalFetch(...args);
-        if (response.status === 401) {
+        if (response.status === 401 && window.location.pathname !== '/login') {
             const url = typeof args[0] === 'string' ? args[0] : args[0] instanceof Request ? args[0].url : '';
             // Only redirect for our own API calls, not external fetches
             if (url.startsWith('/api/') || url.startsWith(window.location.origin + '/api/')) {

--- a/tests/frontend/useSocket.test.tsx
+++ b/tests/frontend/useSocket.test.tsx
@@ -24,7 +24,7 @@ describe('useSocket — connect_error handling', () => {
     const originalLocation = window.location;
     // jsdom's window.location is read-only; swap in a writable stub.
     Object.defineProperty(window, 'location', {
-      value: { href: '' }, writable: true, configurable: true,
+      value: { href: '', pathname: '/services' }, writable: true, configurable: true,
     });
 
     try {
@@ -41,6 +41,24 @@ describe('useSocket — connect_error handling', () => {
       // stale session cookie after a reinstall — bounces to /login.
       handlers.connect_error(new Error('unauthorized'));
       expect(window.location.href).toBe('/login');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation, writable: true, configurable: true,
+      });
+    }
+  });
+
+  it('does NOT redirect when already on /login (#854 — prevents reload loop)', () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { href: 'http://x/login', pathname: '/login' }, writable: true, configurable: true,
+    });
+
+    try {
+      renderHook(() => useSocket());
+      handlers.connect_error(new Error('unauthorized'));
+      // Must NOT have been replaced — staying on /login lets the user log in.
+      expect(window.location.href).toBe('http://x/login');
     } finally {
       Object.defineProperty(window, 'location', {
         value: originalLocation, writable: true, configurable: true,


### PR DESCRIPTION
## Summary
Two redirect handlers in the root layout were firing while the user was already on /login, hard-reloading the page in an infinite loop:

- `packages/frontend/src/hooks/useSocket.ts` — Socket.IO `connect_error` with message `unauthorized` redirected to `/login`. The root layout mounts `DigitalTwinProvider` on every route including `/login`, so the unauthenticated socket connect always fails this way for a logged-out visitor, and the redirect just reloaded the same page.
- `packages/frontend/src/providers/DigitalTwinProvider.tsx` — module-level fetch wrapper redirected to `/login` on any 401 from `/api/*`. The login page itself probes `/api/auth/oidc/status` on mount; any 401 there fed the same loop.

Both now check `window.location.pathname` before redirecting.

## Test plan
- [x] `tests/frontend/useSocket.test.tsx` — new case: pathname `/login` + `unauthorized` error → no redirect (the existing happy-path case continues to assert the redirect on `/services`).
- [x] `tsc --noEmit` — clean.
- [ ] Manual: open `http://192.168.178.100:5888/login` in incognito after deploy; page must stay still long enough to type credentials.

Closes #854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)