### PR TITLE
fix(ui): read app version from /api/system/version (#812)

### DIFF
--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -6,7 +6,6 @@ import { Github, Settings, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import { dashboards } from './Sidebar';
 import { useToast } from '@/providers/ToastProvider';
-import pkg from '../../package.json';
 
 const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
 
@@ -21,6 +20,16 @@ export function MobileTopBar() {
   // users who pressed "Minimize" on the wizard would otherwise have
   // no way back to /setup since the Sidebar is hidden < md.
   const [hasActiveInstall, setHasActiveInstall] = useState(false);
+  // Workspace package.json stays at 0.0.0 (release-please only bumps the
+  // root). Read the live version from the API instead. (#812)
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/system/version')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.version) setAppVersion(d.version); })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (hintFired.current) return;
@@ -67,7 +76,7 @@ export function MobileTopBar() {
              <span className="font-bold text-gray-900 dark:text-white text-sm leading-none">
                 ServiceBay
              </span>
-             <span className="text-[10px] text-gray-500 dark:text-gray-400">by Korgraph.io - v{pkg.version}</span>
+             <span className="text-[10px] text-gray-500 dark:text-gray-400">by Korgraph.io{appVersion ? ` - v${appVersion}` : ''}</span>
           </div>
        </div>
        {/* Right: Icons */}

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings, Network, Users, ExternalLink, Sparkles, Home, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
-import pkg from '../../package.json';
 import { typedFetch, InstallStatusResponseSchema } from '@servicebay/api-client';
 
 export const dashboards = [
@@ -33,12 +32,22 @@ export default function Sidebar() {
   // operator can navigate to Services / Terminal / Health and still
   // come back to watch progress.
   const [hasActiveInstall, setHasActiveInstall] = useState(false);
+  // Workspace package.json stays at 0.0.0 (release-please only bumps the
+  // root). Read the live version from the API instead. (#812)
+  const [appVersion, setAppVersion] = useState<string | null>(null);
 
   useEffect(() => {
     if (window.innerWidth < 768) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsCollapsed(true);
     }
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/system/version')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.version) setAppVersion(d.version); })
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -88,7 +97,7 @@ export default function Sidebar() {
                             ServiceBay
                         </h3>
                         <span className="text-[10px] text-gray-500 dark:text-gray-400 font-medium whitespace-nowrap">
-                            by Korgraph.io - v{pkg.version}
+                            by Korgraph.io{appVersion ? ` - v${appVersion}` : ''}
                         </span>
                     </div>
                 </div>

--- a/tests/frontend/Sidebar.test.tsx
+++ b/tests/frontend/Sidebar.test.tsx
@@ -13,6 +13,25 @@ vi.mock('next/navigation', () => ({
 
 describe('Sidebar', () => {
     let fetchSpy: ReturnType<typeof vi.spyOn>;
+    // Route-aware mock. `mockResolvedValue` would hand back the same Response
+    // object across calls, so the second `.json()` would throw (a Response's
+    // body can only be read once). Sidebar fires fetches in parallel
+    // (/api/system/version, /api/auth/lldap-url, /api/install/status), so we
+    // mint a fresh Response per URL.
+    const lldapResponse = { url: null as string | null };
+    function mockFetch(url: RequestInfo | URL) {
+        const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+        if (u.includes('/api/system/version')) {
+            return new Response(JSON.stringify({ version: '9.9.9' }), { status: 200 });
+        }
+        if (u.includes('/api/auth/lldap-url')) {
+            return new Response(JSON.stringify(lldapResponse), { status: 200 });
+        }
+        if (u.includes('/api/install/status')) {
+            return new Response(JSON.stringify({ jobIsActive: false, stackSetupPending: false }), { status: 200 });
+        }
+        return new Response('{}', { status: 200 });
+    }
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -20,10 +39,8 @@ describe('Sidebar', () => {
         Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
         window.dispatchEvent(new Event('resize'));
 
-        // Default: LLDAP not deployed (url: null)
-        fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-            new Response(JSON.stringify({ url: null }), { status: 200 })
-        );
+        lldapResponse.url = null;
+        fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((url) => Promise.resolve(mockFetch(url)));
     });
 
     afterEach(() => {
@@ -87,9 +104,7 @@ describe('Sidebar', () => {
     });
 
     it('shows Users & Groups link when LLDAP is deployed', async () => {
-        fetchSpy.mockResolvedValue(
-            new Response(JSON.stringify({ url: 'https://ldap.example.com' }), { status: 200 })
-        );
+        lldapResponse.url = 'https://ldap.example.com';
 
         render(<Sidebar />);
 
@@ -104,7 +119,13 @@ describe('Sidebar', () => {
     });
 
     it('does not show Users & Groups when fetch fails', async () => {
-        fetchSpy.mockRejectedValue(new Error('Network error'));
+        fetchSpy.mockImplementation((url) => {
+            const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+            if (u.includes('/api/auth/lldap-url')) {
+                return Promise.reject(new Error('Network error'));
+            }
+            return Promise.resolve(mockFetch(url));
+        });
 
         render(<Sidebar />);
 

--- a/tests/frontend/Sidebar.test.tsx
+++ b/tests/frontend/Sidebar.test.tsx
@@ -119,7 +119,7 @@ describe('Sidebar', () => {
     });
 
     it('does not show Users & Groups when fetch fails', async () => {
-        fetchSpy.mockImplementation((url) => {
+        fetchSpy.mockImplementation((url: RequestInfo | URL) => {
             const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
             if (u.includes('/api/auth/lldap-url')) {
                 return Promise.reject(new Error('Network error'));


### PR DESCRIPTION
## Summary
Sidebar.tsx and MobileNav.tsx imported `packages/frontend/package.json` whose version is permanently `0.0.0` (release-please only bumps the root package.json). Both rendered "v0.0.0" on real releases.

Switched both to the same pattern `OnboardingWizard` already uses: `fetch('/api/system/version')` (60s server cache) with a clean fallback to "by Korgraph.io" while the fetch is pending or fails.

## Test plan
- [x] `tsc --noEmit` — clean.
- [ ] Manual: load /services and verify sidebar / mobile-nav header shows the live release version.

Closes #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)