### PR TITLE
chore: misc resilience fixes from local WIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json package-lock.json* ./
+COPY packages/api-client/package.json ./packages/api-client/package.json
+COPY packages/backend/package.json ./packages/backend/package.json
+COPY packages/frontend/package.json ./packages/frontend/package.json
 RUN npm ci
 
 # Rebuild the source code only when needed

--- a/packages/backend/src/lib/install/manifestAssembler.test.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.test.ts
@@ -12,10 +12,12 @@ import type { VariableMeta } from '@/lib/registry';
 const getTemplateYaml = vi.fn<(n: string, s?: string) => Promise<string | null>>();
 const getTemplateVariables = vi.fn<(n: string, s?: string) => Promise<Record<string, VariableMeta> | null>>();
 const getTemplateConfigFiles = vi.fn<(n: string, s?: string) => Promise<{ filename: string; content: string }[]>>();
+const getTemplateSettingsSchema = vi.fn<() => Promise<Record<string, { default: string; description?: string }>>>();
 vi.mock('@/lib/registry', () => ({
   getTemplateYaml: (n: string, s?: string) => getTemplateYaml(n, s),
   getTemplateVariables: (n: string, s?: string) => getTemplateVariables(n, s),
   getTemplateConfigFiles: (n: string, s?: string) => getTemplateConfigFiles(n, s),
+  getTemplateSettingsSchema: () => getTemplateSettingsSchema(),
 }));
 
 const getConfig = vi.fn<() => Promise<{ templateSettings?: Record<string, string> }>>();
@@ -55,6 +57,8 @@ beforeEach(() => {
   getTemplateVariables.mockReset();
   getTemplateConfigFiles.mockReset();
   getTemplateConfigFiles.mockResolvedValue([]);
+  getTemplateSettingsSchema.mockReset();
+  getTemplateSettingsSchema.mockResolvedValue({});
   getConfig.mockReset();
   getConfig.mockResolvedValue({ templateSettings: {} });
   loadSavedSecrets.mockReset();

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -27,6 +27,7 @@ import {
   getTemplateYaml,
   getTemplateVariables,
   getTemplateConfigFiles,
+  getTemplateSettingsSchema,
   type VariableMeta,
 } from '@/lib/registry';
 import { parseTemplateDependencies } from '@/lib/stackInstall/dependencies';
@@ -231,6 +232,21 @@ export async function assembleManifest(
   // returning so a mid-install failure doesn't strand a value that
   // exists only in this manifest (#622).
   const newlyGenerated: { name: string; value: string }[] = [];
+
+  // Merge global settings schema variables into allMeta so their defaults
+  // are respected if not prefilled.
+  const globalSchema = await getTemplateSettingsSchema().catch(() => ({}));
+  for (const [key, val] of Object.entries(globalSchema)) {
+    if (!allMeta[key]) {
+      allMeta[key] = {
+        type: 'text',
+        default: val.default,
+        description: val.description,
+        templateName: 'global',
+        templateLabel: 'Global Settings',
+      };
+    }
+  }
 
   const variables: JobInputVariable[] = [];
   vars.delete('LLDAP_FORCE_LDAP_USER_PASS_RESET');

--- a/src/app/api/system/lldap/seed/route.ts
+++ b/src/app/api/system/lldap/seed/route.ts
@@ -78,8 +78,13 @@ async function createGroup(baseUrl: string, token: string, groupName: string): P
     const data = await res.json();
     if (data.errors?.length) {
       const msg = data.errors[0].message || '';
+      const lowerMsg = msg.toLowerCase();
       // "already exists" is fine
-      if (msg.toLowerCase().includes('already exists') || msg.toLowerCase().includes('duplicate')) {
+      if (
+        lowerMsg.includes('already exists') ||
+        lowerMsg.includes('duplicate') ||
+        lowerMsg.includes('unique constraint')
+      ) {
         return { name: groupName, created: false };
       }
       return { name: groupName, created: false, error: msg };


### PR DESCRIPTION
## Summary
Three independent fixes that were sitting uncommitted locally:

1. **Dockerfile**: copy workspace package manifests before `npm ci` in the `deps` stage. The `prod-deps` stage already does this (and explains why in a comment); the `deps` stage was missing the same copies. A workspace-root `npm ci` against a tree without member package.json files can silently drop transitive deps; mirroring the prod-deps approach removes that hazard.

2. **install/manifestAssembler.ts (+ test)**: merge global settings schema defaults into the manifest's variable metadata before prompting. `getTemplateSettingsSchema()` in `registry.ts` already exposes DATA_DIR + friends with their canonical defaults — wiring them into `allMeta` means an install whose templates reference a global key the operator hasn't customised gets the default automatically instead of erroring as \"missing variable\".

3. **system/lldap/seed/route.ts**: treat \"unique constraint\" as already-exists alongside \"already exists\" / \"duplicate\". Different LLDAP versions phrase the duplicate-group error differently; the broader matcher keeps the idempotent seed path working across versions.

All three are local quality improvements with no behaviour change when the conditions don't apply.

## Test plan
- [x] `tsc --noEmit` — clean.
- [x] `vitest manifestAssembler.test.ts` — 7 pass (1 new mock for `getTemplateSettingsSchema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)