### PR TITLE
refactor(viewmodel): add displayName + basename fields, migrate FE callers (#844)

### DIFF
--- a/packages/api-client/src/serviceView.ts
+++ b/packages/api-client/src/serviceView.ts
@@ -26,7 +26,20 @@ export interface ServiceVolume {
 export type ServiceType = 'kube' | 'container' | 'link' | 'gateway';
 
 export interface ServiceViewModel {
+  /** The original systemd unit identifier (e.g. `vaultwarden.service`).
+   *  Used for matching/equality and as the canonical id. The UI should
+   *  NOT render this directly — use `displayName` instead. (#844) */
   name: string;
+  /** Pre-computed user-facing label. The backend strips `.service`,
+   *  expands `nginx` → `Reverse Proxy (Nginx)`, etc. Frontend code
+   *  must never `.replace('.service', '')` again. (#844) */
+  displayName: string;
+  /** Pre-split filename portion of `yamlPath` for display in chips and
+   *  copy-to-clipboard affordances. Null when the file is not on disk. (#844) */
+  yamlBasename: string | null;
+  /** Pre-split filename portion of `kubePath`. Null when the unit is
+   *  not a Quadlet `.kube` file. (#844) */
+  kubeBasename: string | null;
   id?: string;
   description?: string | null;
   nodeName?: string;

--- a/packages/backend/src/lib/services/serviceViewModel.test.ts
+++ b/packages/backend/src/lib/services/serviceViewModel.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { buildServiceViewModel } from './serviceViewModel';
+import type { ServiceUnit } from '@/lib/agent/types';
+import type { NodeTwin } from '@/lib/store/twin';
+
+function makeUnit(overrides: Partial<ServiceUnit> = {}): ServiceUnit {
+  return {
+    name: 'vaultwarden.service',
+    active: true,
+    activeState: 'active',
+    subState: 'running',
+    loadState: 'loaded',
+    description: '',
+    path: '/var/home/core/.config/containers/systemd/vaultwarden.kube',
+    isManaged: true,
+    associatedContainerIds: [],
+    ports: [],
+    verifiedDomains: [],
+    ...overrides,
+  };
+}
+
+function makeTwin(files: Record<string, { content: string }> = {}): NodeTwin {
+  return {
+    connected: true,
+    initialSyncComplete: true,
+    containers: [],
+    services: [],
+    files,
+    resources: undefined,
+  } as unknown as NodeTwin;
+}
+
+describe('buildServiceViewModel — display fields (#844)', () => {
+  it('strips `.service` from the unit name into displayName for normal services', () => {
+    const vm = buildServiceViewModel({
+      unit: makeUnit({ name: 'vaultwarden.service' }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+    });
+    expect(vm).not.toBeNull();
+    expect(vm?.displayName).toBe('vaultwarden');
+    // id stays the unit identifier for matching/lookups
+    expect(vm?.id).toBe('vaultwarden.service');
+  });
+
+  it('overrides displayName to "Reverse Proxy (Nginx)" for nginx', () => {
+    const vm = buildServiceViewModel({
+      unit: makeUnit({ name: 'nginx.service', isReverseProxy: true }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+    });
+    expect(vm?.displayName).toBe('Reverse Proxy (Nginx)');
+  });
+
+  it('overrides displayName to "ServiceBay System" for the servicebay unit', () => {
+    const vm = buildServiceViewModel({
+      unit: makeUnit({ name: 'servicebay.service', isServiceBay: true, isManaged: false }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+    });
+    expect(vm?.displayName).toBe('ServiceBay System');
+  });
+
+  it('extracts yamlBasename and kubeBasename from full paths', () => {
+    const kubePath = '/var/home/core/.config/containers/systemd/vaultwarden.kube';
+    const yamlPath = '/var/home/core/.config/containers/systemd/vaultwarden.yml';
+    const vm = buildServiceViewModel({
+      unit: makeUnit({ path: kubePath }),
+      nodeName: 'Local',
+      nodeState: makeTwin({
+        [kubePath]: { content: `Yaml=vaultwarden.yml\n` },
+        [yamlPath]: { content: 'apiVersion: v1\nkind: Pod\n' },
+      }),
+    });
+    expect(vm?.kubeBasename).toBe('vaultwarden.kube');
+    expect(vm?.yamlBasename).toBe('vaultwarden.yml');
+  });
+
+  it('returns null kubeBasename/yamlBasename when files are absent', () => {
+    const vm = buildServiceViewModel({
+      unit: makeUnit({ path: '' }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+    });
+    expect(vm?.kubeBasename).toBeNull();
+    expect(vm?.yamlBasename).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/services/serviceViewModel.ts
+++ b/packages/backend/src/lib/services/serviceViewModel.ts
@@ -81,13 +81,35 @@ export function buildServiceViewModel({ unit, nodeName, nodeState, proxyRoutes }
   if (unit.isReverseProxy) labels['servicebay.role'] = 'reverse-proxy';
   if (unit.isServiceBay) labels['servicebay.role'] = 'system';
 
-  let displayName = unit.name;
-  if (unit.isReverseProxy) displayName = 'Reverse Proxy (Nginx)';
-  else if (unit.isServiceBay) displayName = 'ServiceBay System';
+  // Backend-computed display fields (#844 / ARCH-12). The frontend used
+  // to derive these with `.replace('.service', '')` and `.split('/').pop()`
+  // — those rules belong here so every consumer sees the same answer.
+  let displayName = baseName;
+  let legacyName = unit.name;
+  if (unit.isReverseProxy) {
+    displayName = 'Reverse Proxy (Nginx)';
+    legacyName = displayName;
+  } else if (unit.isServiceBay) {
+    displayName = 'ServiceBay System';
+    legacyName = displayName;
+  }
 
+  const yamlBasename = yamlPath ? (yamlPath.split('/').pop() ?? null) : null;
+  const kubeBasename = unit.path ? (unit.path.split('/').pop() ?? null) : null;
+
+  // Note on `name` vs `displayName`: historically `name` held the unit
+  // identifier (e.g. `vaultwarden.service`) for normal rows but the
+  // human label (e.g. `Reverse Proxy (Nginx)`) for the special
+  // overrides. That overload is what callers compensated for with
+  // `.replace('.service', '')`. New code should read `displayName`
+  // (always the rendered string) and `id` (always the unit name);
+  // `name` keeps its legacy shape so the migration stays incremental. (#844)
   const viewModel: ServiceViewModel = {
     id: unit.name,
-    name: displayName,
+    name: legacyName,
+    displayName,
+    yamlBasename,
+    kubeBasename,
     nodeName,
     description: unit.description,
     active: unit.activeState === 'active',

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -250,6 +250,9 @@ export default function ServicesDashboard() {
                       return {
                           id: link.id || link.name,
                           name: link.name,
+                          displayName: link.name,
+                          yamlBasename: link.yamlPath ? (link.yamlPath.split('/').pop() ?? null) : null,
+                          kubeBasename: link.kubePath ? (link.kubePath.split('/').pop() ?? null) : null,
                           nodeName: link.nodeName || 'Global',
                           description: link.description,
                           active: typeof link.active === 'boolean' ? link.active : true,
@@ -436,8 +439,12 @@ export default function ServicesDashboard() {
         const finalServices = Array.from(uniqueServices.values());
 
         if (twin.gateway) {
+            const gatewayDisplayName = twin.gateway.provider === 'fritzbox' ? 'FritzBox Gateway' : 'Internet Gateway';
             finalServices.push({
-                name: twin.gateway.provider === 'fritzbox' ? 'FritzBox Gateway' : 'Internet Gateway',
+                name: gatewayDisplayName,
+                displayName: gatewayDisplayName,
+                yamlBasename: null,
+                kubeBasename: null,
                 id: 'gateway',
                 nodeName: 'Global',
                 description: 'Upstream Internet Connection',
@@ -634,9 +641,9 @@ export default function ServicesDashboard() {
                                 <h3
                                     className="font-bold text-lg text-gray-900 dark:text-gray-100 truncate"
                                     title={service.name}
-                                    data-testid={`service-name-${service.name.replace('.service', '')}`}
+                                    data-testid={`service-name-${service.displayName}`}
                                 >
-                                    {service.name.replace('.service', '')}
+                                    {service.displayName}
                                 </h3>
                                 {service.nodeName && service.nodeName !== 'Local' && (
                                     <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800 rounded">

--- a/packages/frontend/src/hooks/useServiceActions.tsx
+++ b/packages/frontend/src/hooks/useServiceActions.tsx
@@ -70,9 +70,9 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
       }
 
       const files = await res.json();
-      const yamlFileName = files.yamlPath?.split('/').pop() || `${serviceName.replace('.service', '')}.yml`;
+      const yamlFileName = service.yamlBasename || `${service.displayName}.yml`;
       const initialData: ServiceFormInitialData = {
-        name: service.name.replace('.service', ''),
+        name: service.displayName,
         kubeContent: files.kubeContent || '',
         yamlContent: files.yamlContent || '',
         yamlFileName,
@@ -312,7 +312,7 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
                   {drawerState.mode === 'monitor' ? 'Service Monitor' : 'Edit Service'}
                 </p>
                 <h3 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1 flex items-center gap-2">
-                  {drawerState.service.name.replace('.service', '')}
+                  {drawerState.service.displayName}
                   {drawerState.service.nodeName && (
                     <span className="px-2 py-0.5 rounded-full text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
                       {drawerState.service.nodeName}


### PR DESCRIPTION
## Summary

ServiceViewModel now exposes pre-computed display fields so the frontend stops doing `.replace('.service', '')` and `.split('/').pop()` on service identifiers.

**Backend** (`packages/backend/src/lib/services/serviceViewModel.ts`)
- `displayName`: strips `.service`, expands to `Reverse Proxy (Nginx)` / `ServiceBay System` for the two override services.
- `yamlBasename` / `kubeBasename`: filename portion of the resolved paths.
- `name` keeps its legacy shape (override-aware) so existing matching code stays correct during the migration. `id` is always the unit name.

**api-client** — Documents the new fields on `ServiceViewModel` and explains `name` vs `displayName` so future callers don't reintroduce the string-stripping pattern.

**Frontend**
- `useServiceActions.tsx` — edit drawer header, ServiceFormInitialData seed, and `yamlFileName` fallback all read `service.displayName` / `service.yamlBasename`.
- `ServicesDashboard.tsx` — service card heading + data-testid migrated. The inline link / gateway view-models carry the new fields so the type stays required (no optional escape hatch).

## Acceptance criteria from #844
- [x] Backend ServiceViewModel builder computes the display fields.
- [x] api-client type carries them.
- [x] Frontend hooks and cards no longer call `.replace('.service', '')` or `.split('/').pop()` on view-model paths.
- [x] Backend unit test covers the new field computation (5 cases).

## Out of scope (left as-is)
- `ServiceMonitor.tsx` takes `serviceName: string` as a prop, not a ServiceViewModel — its `.replace('.service', '')` is doing legitimate prop manipulation, not view-model derivation. Migrating it would require a wider prop change.
- The generic path-display helper at `ServicesDashboard.tsx:185` works on arbitrary paths from a different shape and is not in the `ServiceViewModel` path.

## Test plan
- [x] `vitest` — 1212 pass, 0 fail (new file: 5 cases).
- [x] `tsc --noEmit` — clean.
- [ ] Manual: open /services and confirm Nginx still renders as "Reverse Proxy (Nginx)" and normal services render without ".service".

Closes #844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)