### PR TITLE
refactor(nav): extract sidebar/mobile-nav schema into a single config (#845)

### DIFF
--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Github, Settings, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
-import { dashboards } from './Sidebar';
+import { NAVIGATION_ENTRIES } from '@/config/navigation';
 import { useToast } from '@/providers/ToastProvider';
 
 const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
@@ -117,8 +117,9 @@ export function MobileBottomBar() {
   const searchParams = useSearchParams();
   const node = searchParams?.get('node');
 
-  // Exclude settings as it is in the top bar
-  const bottomDashboards = dashboards.filter(p => p.id !== 'settings');
+  // Honor the per-entry `hiddenOnMobileBottom` flag from the navigation
+  // schema — Settings opts out (it's in the mobile top bar's icon row).
+  const bottomDashboards = NAVIGATION_ENTRIES.filter(p => !p.hiddenOnMobileBottom);
 
   return (
     <div className="h-[72px] bg-gray-100 dark:bg-black border-t border-gray-200 dark:border-gray-800 flex items-center justify-around px-2 shrink-0 md:hidden z-20 pb-2">

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,19 +2,16 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Box, Terminal, Activity, ChevronLeft, Github, Settings, Network, Users, ExternalLink, Sparkles, Home, Wrench } from 'lucide-react';
+import { ChevronLeft, Github, Users, ExternalLink, Sparkles, Home, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import { typedFetch, InstallStatusResponseSchema } from '@servicebay/api-client';
+import { NAVIGATION_ENTRIES } from '@/config/navigation';
 
-export const dashboards = [
-    { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
-    { id: 'containers', name: 'Container Engine', shortLabel: 'Containers', icon: LayoutDashboard, path: '/containers' },
-    { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
-    { id: 'health', name: 'Health', shortLabel: 'Health', icon: Activity, path: '/health' },
-    { id: 'terminal', name: 'SSH Terminal', shortLabel: 'Terminal', icon: Terminal, path: '/terminal' },
-    { id: 'settings', name: 'Settings', shortLabel: 'Settings', icon: Settings, path: '/settings' },
-];
+// Back-compat re-export — MobileNav imports `dashboards` from here.
+// New code should import NAVIGATION_ENTRIES directly from
+// `@/config/navigation`. (#845)
+export const dashboards = NAVIGATION_ENTRIES;
 
 export default function Sidebar() {
     const pathname = usePathname() || '';

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -1,0 +1,47 @@
+/**
+ * Sidebar & mobile-nav navigation schema (#845 / ARCH-13).
+ *
+ * Single source of truth for the primary navigation entries. The
+ * sidebar (`Sidebar.tsx`) and the mobile bottom bar (`MobileNav.tsx`)
+ * both read from this list — adding, removing, or re-ordering a
+ * dashboard link is one edit here, no component changes needed.
+ *
+ * Extending this is the recommended way to add a new dashboard:
+ *   1. Build a route at `/<path>`.
+ *   2. Append a NavigationEntry below.
+ *   3. (Optional) hide from the mobile bottom bar with
+ *      `hiddenOnMobileBottom: true` — Settings does this so the
+ *      bottom bar doesn't get cluttered (it's still in the top
+ *      bar's icon row).
+ */
+import { LayoutDashboard, Box, Terminal, Activity, Settings, Network } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface NavigationEntry {
+  /** Stable identifier used in keys / `data-testid` / `dashboards.id`
+   *  references throughout the codebase. Do not change once shipped. */
+  id: string;
+  /** Sidebar label (full). */
+  name: string;
+  /** Mobile bottom-bar label (terser). */
+  shortLabel: string;
+  /** Lucide icon component. Accepts the full Lucide prop surface
+   *  (size, strokeWidth, className, color, …). */
+  icon: LucideIcon;
+  /** Route path. The `usePathname().startsWith(path)` test marks an
+   *  entry active, so prefer "/X" over "/X/" or "/X/index". */
+  path: string;
+  /** When true, the mobile bottom bar omits this entry. The desktop
+   *  sidebar always renders every entry. Used today for Settings
+   *  (already in the mobile top bar's icon row). */
+  hiddenOnMobileBottom?: boolean;
+}
+
+export const NAVIGATION_ENTRIES: NavigationEntry[] = [
+  { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
+  { id: 'containers', name: 'Container Engine', shortLabel: 'Containers', icon: LayoutDashboard, path: '/containers' },
+  { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
+  { id: 'health', name: 'Health', shortLabel: 'Health', icon: Activity, path: '/health' },
+  { id: 'terminal', name: 'SSH Terminal', shortLabel: 'Terminal', icon: Terminal, path: '/terminal' },
+  { id: 'settings', name: 'Settings', shortLabel: 'Settings', icon: Settings, path: '/settings', hiddenOnMobileBottom: true },
+];

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "paths": {
       "@/components/*": ["./src/components/*"],
+      "@/config/*": ["./src/config/*"],
       "@/hooks/*": ["./src/hooks/*"],
       "@/dashboards/*": ["./src/dashboards/*"],
       "@/providers/*": ["./src/providers/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
       "@/*": ["./src/*"],
       "@/lib/*": ["./packages/backend/src/lib/*"],
       "@/components/*": ["./packages/frontend/src/components/*"],
+      "@/config/*": ["./packages/frontend/src/config/*"],
       "@/hooks/*": ["./packages/frontend/src/hooks/*"],
       "@/dashboards/*": ["./packages/frontend/src/dashboards/*"],
       "@/providers/*": ["./packages/frontend/src/providers/*"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       // routes into packages/frontend before the catch-all `@/*` mapping
       // into src/.
       { find: /^@\/components\//, replacement: path.resolve(__dirname, './packages/frontend/src/components/') + '/' },
+      { find: /^@\/config\//, replacement: path.resolve(__dirname, './packages/frontend/src/config/') + '/' },
       { find: /^@\/hooks\//, replacement: path.resolve(__dirname, './packages/frontend/src/hooks/') + '/' },
       { find: /^@\/dashboards\//, replacement: path.resolve(__dirname, './packages/frontend/src/dashboards/') + '/' },
       { find: /^@\/providers\//, replacement: path.resolve(__dirname, './packages/frontend/src/providers/') + '/' },


### PR DESCRIPTION
## Summary

Both `Sidebar.tsx` and `MobileNav.tsx` now read primary navigation entries from `packages/frontend/src/config/navigation.ts` instead of a literal array inside Sidebar.tsx. Adding, removing, or reordering a dashboard link is now one edit in the config file — no component changes needed.

`NavigationEntry` is typed with:
- `id / name / shortLabel / icon / path` (existing fields)
- `hiddenOnMobileBottom?: boolean` — replaces the inline `filter(p => p.id !== 'settings')` that hardcoded "exclude settings as it is in the top bar".

`Sidebar.tsx` keeps a back-compat `export const dashboards = NAVIGATION_ENTRIES` so any external consumer that previously imported `dashboards` from there (none in-repo besides MobileNav, updated separately) doesn't break.

Path-alias `@/config/*` added in all three places: `tsconfig.json` (root), `packages/frontend/tsconfig.json` (FE-workspace tsc), `vitest.config.ts` (vitest doesn't read tsconfig paths, separate alias config).

## Acceptance from #845
- [x] Adding/removing/reordering a sidebar entry is a single-file edit (`navigation.ts`).
- [x] No hardcoded dashboard paths inside Sidebar.tsx / MobileNav.tsx component bodies.

## Test plan
- [x] `tsc --noEmit` — clean.
- [x] `vitest` — 1212 pass.

Closes #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)