### PR TITLE
docs(ux): primary nav user-task-shaped + household-decision metrics (#801)

### DIFF
--- a/docs/UX_DECISIONS.md
+++ b/docs/UX_DECISIONS.md
@@ -254,6 +254,63 @@ to look the part (a package import, not a path import).
 
 ---
 
+## Primary sidebar is a user-task list, not an infrastructure list
+
+**What.** The desktop sidebar and mobile bottom-nav render from a
+single schema in `packages/frontend/src/config/navigation.ts`
+(`NAVIGATION_ENTRIES`). Each entry is a user-facing destination —
+Services, Network Map, Health, Diagnostics, SSH Terminal, Settings —
+not a raw infrastructure object list. Raw container engine, podman
+socket, system-vitals, system-logs etc. live as **tabs inside
+Diagnostics**, never as peer sidebar entries. New top-level entries
+require an explicit user-task justification ("operators need a
+one-click path to X"), not "the data exists, let's show it."
+
+**Why.** ServiceBay's audience is family-homelab admins; surfacing
+"Container Engine" or "Quadlet files" at the top level trains them
+to think of ServiceBay as a podman frontend instead of a homelab
+manager. The 2026-05 round of user testing landed on the rule from
+[UX_PHILOSOPHY.md](UX_PHILOSOPHY.md) §3: information surface is also
+a "knob," and most operators won't have an opinion on it. The schema
+indirection (#845) makes the rule enforceable — adding an entry
+requires editing the schema, which is reviewable in one place.
+
+**Where enforced.**
+- `packages/frontend/src/config/navigation.ts` — the schema.
+- `Sidebar.tsx` / `MobileNav.tsx` map over the schema; no inline
+  entries.
+- [UX_PHILOSOPHY.md](UX_PHILOSOPHY.md) §3 explicitly lists raw infra
+  views as expert-only.
+
+---
+
+## Progress and capacity displays answer the household question
+
+**What.** Long-running install / backup / capacity readouts default
+to the *household-decision* framing — "about 2 minutes to go", "~3
+years of photos left at current upload rate" — not the raw
+bytes/seconds/percent that a dashboard designer would emit. Raw
+numbers are reachable on hover or behind a "Details" expand for
+operators who explicitly want them.
+
+**Why.** A 16.7% disk gauge tells someone with networking experience
+"plenty of room"; a family operator either ignores it or worries
+unnecessarily. "~3 years of photos left" lets them decide whether to
+keep uploading. Same logic for install progress: "Setting up
+Vaultwarden (4 of 6 services ready)" beats "image pull 7/12 · 2
+healthy" because the operator's actual question is *"is something
+hung or is this normal?"* — a service-name + ratio + ETA answers it,
+raw image counts don't.
+
+**Where enforced.**
+- [UX_PHILOSOPHY.md](UX_PHILOSOPHY.md) §5 with concrete bad/good
+  pairs for progress, capacity, and backup readouts.
+- The install overlay (#805 work) is the first surface to adopt the
+  pattern end-to-end; existing diagnostic panels keep raw numbers
+  while diagnose probes drive household-framed action labels.
+
+---
+
 ## Maintaining this doc
 
 Add an entry when:

--- a/docs/UX_PHILOSOPHY.md
+++ b/docs/UX_PHILOSOPHY.md
@@ -120,6 +120,15 @@ If less than 5% of users would meaningfully change a setting, give it
 a sensible default and don't surface it. Asking is a footgun for the
 other 95% — they have to evaluate a choice they can't evaluate.
 
+This extends to **information surface**, not just settings: the
+sidebar's primary nav should answer *"what do I want to do?"*, not
+*"what infrastructure objects exist?"* The raw Podman container list,
+the raw systemd unit list, the raw Quadlet file tree — these belong
+inside Diagnostics (where an operator who *needs* them already
+expects to find them), not at the top level. The same is true for
+"Setup" / wizard re-entry: visible only while there's something
+pending, hidden once the install is acknowledged.
+
 Examples:
 - **Auto-update channels (`stable | test | dev`)** — removed entirely.
   Stable is what everyone wants; the others were dev-team artefacts
@@ -130,6 +139,12 @@ Examples:
 - **Knobs whose default is fine forever.** `agent.processCleanup.maxAgeMinutes`,
   `gracefulShutdownTimeout`. Hide unless a user reports a problem the
   knob solves.
+- **Raw infrastructure views in the primary navigation.** The
+  container engine, podman socket status, and raw service-unit grid
+  are diagnostic tools — operators who need them know to open
+  Diagnostics. Surfacing them as peer entries with "Services" /
+  "Network Map" trains users to think of ServiceBay as a podman
+  frontend instead of a homelab manager.
 
 When unsure: ship without the knob. Adding one later is easy; removing
 one is painful.
@@ -166,6 +181,27 @@ Good: *"Restart Vaultwarden"*
 Bad: *"OIDC client_secret rotation requires Authelia config reload"*
 Good: *"Generate a new SSO secret for this app (apps using SSO will
 need to log in again once)"*
+
+The same translation applies to **progress and capacity** displays.
+The goal is for the operator to make a household decision (do I keep
+uploading photos? do I need a bigger disk?) without doing arithmetic.
+
+Bad: *"42.7 GB / 256 GB · 16.7% used · 1.4 MB/s write"*
+Good: *"~3 years of photos left at your current upload rate (42 GB of
+256 GB used)"*
+
+Bad: *"Install progress: 7 / 12 images pulled, 2 services healthy"*
+Good: *"Setting up Vaultwarden (4 of 6 services ready, about 2 minutes
+to go)"*
+
+Bad: *"Backup snapshot: 1.8 GB, 23 minutes ago"*
+Good: *"Last backup: this morning (1.8 GB — small enough to restore
+from your phone in a pinch)"*
+
+Hard numbers stay available on hover / in a "Details" expand —
+operators who *want* the raw values shouldn't have to dig. But the
+default view answers the household question, not the dashboard
+designer's.
 
 ## Concrete checklist for new PRs
 


### PR DESCRIPTION
## Summary
Updates the two UX docs with the parts of #801 that apply to the *current* surface — the parts pinned to features that haven't shipped (Overview Landing Page #803, Flexible Workspace Panel #804) are deliberately deferred so the docs don't describe non-existent patterns.

**`UX_PHILOSOPHY.md`**
- **Rule #3 (Hide expert knobs)** now explicitly covers information surface: raw container engine / podman socket / quadlet views live inside Diagnostics, never as peer sidebar entries.
- **Rule #5 (User-facing language)** gains concrete bad/good pairs for progress, capacity, and backup readouts ("~3 years of photos left at current upload rate" vs. "42.7 GB / 256 GB · 16.7%").

**`UX_DECISIONS.md`**
- *Primary sidebar is a user-task list, not an infrastructure list.* Cross-references the #845 `NAVIGATION_ENTRIES` schema and explains why new top-level entries need a user-task justification.
- *Progress and capacity displays answer the household question.* Establishes the framing rule so the install-overlay rework (#805) and any future capacity gauges land consistent.

## Deliberately not added
- *Overview Landing Page* taxonomy — depends on #803.
- *Flexible Workspace Panel* design pattern — depends on #804.
- Concrete CSS / animation tokens (glassmorphism, spring easing, status-indicator pulses) — those need to be applied to a real component before they're worth pinning as standards; tying tokens to unshipped components risks drift.

When #803/#804 land, follow-up docs PR adds those sections with real component references.

## Test plan
- [x] Markdown renders correctly on GitHub.
- [x] All cross-doc links resolve (`UX_PHILOSOPHY.md` ↔ `UX_DECISIONS.md`).

Refs #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)