### PR TITLE
feat: Overview Dashboard at /, streamlined sidebar (#802, #803)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,15 +24,9 @@ const nextConfig: NextConfig = {
   devIndicators: {
     position: 'bottom-right',
   },
-  async redirects() {
-    return [
-      {
-        source: '/',
-        destination: '/services',
-        permanent: false,
-      },
-    ];
-  },
+  // `/` used to redirect to `/services` — removed in #802/#803 when the
+  // Overview Dashboard landed at the root path. If you're hunting for
+  // the redirect, it's now a real page: src/app/(dashboard)/page.tsx.
   // `src/lib/logger.ts` is imported by both server and client code and lazily
   // `require()`s `better-sqlite3` / `fs` / `path` only on the server. Webpack
   // resolves those `require` calls statically, so without this fallback the

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -14,7 +14,7 @@
  *      bottom bar doesn't get cluttered (it's still in the top
  *      bar's icon row).
  */
-import { LayoutDashboard, Box, Terminal, Activity, Settings, Network } from 'lucide-react';
+import { Box, Terminal, Activity, Settings, Network, Home } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 export interface NavigationEntry {
@@ -37,11 +37,18 @@ export interface NavigationEntry {
   hiddenOnMobileBottom?: boolean;
 }
 
+/**
+ * Home goes first (#803): it's the operator's landing page after
+ * login, answering "is anything broken?" at a glance. Container
+ * Engine moved into Diagnostics (Health tab) per UX_DECISIONS.md
+ * "Primary sidebar is a user-task list, not an infrastructure list"
+ * — operators who need the raw podman view know to open Diagnostics.
+ */
 export const NAVIGATION_ENTRIES: NavigationEntry[] = [
+  { id: 'home', name: 'Home', shortLabel: 'Home', icon: Home, path: '/' },
   { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
-  { id: 'containers', name: 'Container Engine', shortLabel: 'Containers', icon: LayoutDashboard, path: '/containers' },
   { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
-  { id: 'health', name: 'Health', shortLabel: 'Health', icon: Activity, path: '/health' },
+  { id: 'health', name: 'Diagnostics', shortLabel: 'Health', icon: Activity, path: '/health' },
   { id: 'terminal', name: 'SSH Terminal', shortLabel: 'Terminal', icon: Terminal, path: '/terminal' },
   { id: 'settings', name: 'Settings', shortLabel: 'Settings', icon: Settings, path: '/settings', hiddenOnMobileBottom: true },
 ];

--- a/packages/frontend/src/dashboards/HealthDashboard.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.tsx
@@ -16,6 +16,7 @@ import { PodmanConnection } from '@servicebay/api-client';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { SystemInfoContent } from '@/dashboards/SystemInfoDashboard';
 import SelfDiagnoseSection from '@/app/(dashboard)/settings/_lib/sections/SelfDiagnoseSection';
+import ContainersDashboard from '@/dashboards/ContainersDashboard';
 
 interface Container {
   Id: string;
@@ -30,7 +31,7 @@ interface HistoryItem {
   message?: string;
 }
 
-type HealthTab = 'checks' | 'diagnose' | 'logs' | 'system';
+type HealthTab = 'checks' | 'diagnose' | 'logs' | 'system' | 'containers';
 
 export default function HealthDashboard() {
   const [checks, setChecks] = useState<Check[]>([]);
@@ -59,7 +60,7 @@ export default function HealthDashboard() {
   const searchParams = useSearchParams();
   const searchString = searchParams?.toString() ?? '';
   const tabParam = searchParams?.get('tab');
-  const normalizedTab: HealthTab | null = tabParam === 'logs' || tabParam === 'checks' || tabParam === 'system' || tabParam === 'diagnose' ? (tabParam as HealthTab) : null;
+  const normalizedTab: HealthTab | null = tabParam === 'logs' || tabParam === 'checks' || tabParam === 'system' || tabParam === 'diagnose' || tabParam === 'containers' ? (tabParam as HealthTab) : null;
 
   const closeOverlaysOnEscape = useCallback(() => {
     if (isDeleteModalOpen) return;
@@ -372,6 +373,7 @@ export default function HealthDashboard() {
         {([
           { id: 'checks' as const, label: 'Checks' },
           { id: 'diagnose' as const, label: 'Self-Diagnose' },
+          { id: 'containers' as const, label: 'Containers' },
           { id: 'logs' as const, label: 'Logs' },
           { id: 'system' as const, label: 'System' },
         ]).map(tab => (
@@ -418,6 +420,16 @@ export default function HealthDashboard() {
 
       {activeTab === 'system' && (
         <SystemInfoContent />
+      )}
+
+      {activeTab === 'containers' && (
+        <div className="px-2">
+          {/* Raw Podman container engine — nested here per #802 so the
+              primary sidebar stays user-task shaped. The route /containers
+              still resolves directly for direct-link / muscle-memory
+              navigation. */}
+          <ContainersDashboard />
+        </div>
       )}
       </div>
 

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import Link from 'next/link';
+import { Box, Network, Activity, Terminal, Settings, ArrowRight, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
+
+/**
+ * Home / Overview dashboard (#803).
+ *
+ * The first thing an operator sees when they open ServiceBay. The
+ * design rule from UX_DECISIONS.md "Primary sidebar is a user-task
+ * list" applies here too: this page answers household questions
+ * (*"is anything broken?"*, *"where do I go next?"*) instead of
+ * dumping raw infrastructure counts.
+ *
+ * Backed entirely by the existing DigitalTwinProvider snapshot — no
+ * new endpoints, no new polling loops. When the twin is still syncing
+ * we show the skeleton state and the cards self-update once the
+ * snapshot lands.
+ *
+ * Cards link out to the existing dashboards rather than embedding
+ * full detail, so this stays a navigation surface, not a fourth
+ * place to look for the same data.
+ */
+export default function OverviewDashboard() {
+  const { data, isConnected } = useDigitalTwinContext();
+  // Truthy `data` is the readiness signal — DigitalTwinProvider holds
+  // the snapshot in a useState, so on a fast machine the first render
+  // already sees data and the "Reading status…" headline never shows.
+  // On reconnect after a drop, `data` stays populated from the last
+  // snapshot; `isConnected=false` is what we surface to the user.
+  const hasFirstSnapshot = data !== null && data !== undefined;
+
+  const firstNode = data?.nodes ? Object.values(data.nodes)[0] : undefined;
+  const services = firstNode?.services || [];
+  const managedServices = services.filter(s => s.activeState === 'active' || s.activeState === 'failed' || s.activeState === 'inactive');
+  const activeCount = managedServices.filter(s => s.activeState === 'active').length;
+  const failedCount = managedServices.filter(s => s.activeState === 'failed').length;
+  const totalCount = managedServices.length;
+
+  const gatewayUp = data?.gateway?.upstreamStatus === 'up';
+
+  const healthHeadline = (() => {
+    if (!hasFirstSnapshot) return { tone: 'neutral' as const, text: 'Reading status…' };
+    if (failedCount > 0) return { tone: 'bad' as const, text: `${failedCount} service${failedCount === 1 ? '' : 's'} need${failedCount === 1 ? 's' : ''} attention` };
+    if (totalCount === 0) return { tone: 'neutral' as const, text: 'No services installed yet' };
+    if (!gatewayUp) return { tone: 'warn' as const, text: 'Internet gateway is unreachable' };
+    return { tone: 'good' as const, text: 'Everything looks healthy' };
+  })();
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <header>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Home</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            {data?.serverName || firstNode?.resources?.os?.hostname || 'ServiceBay'}
+            {!isConnected && hasFirstSnapshot && (
+              <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">· reconnecting…</span>
+            )}
+          </p>
+        </header>
+
+        {/* Headline status — the single sentence that answers "is everything OK?" */}
+        <HealthHeadline tone={healthHeadline.tone} text={healthHeadline.text} />
+
+        <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <OverviewCard
+            href="/services"
+            title="Services"
+            metric={hasFirstSnapshot ? `${activeCount} of ${totalCount} running` : '…'}
+            description={
+              failedCount > 0
+                ? `${failedCount} need attention`
+                : totalCount === 0
+                  ? 'No services installed yet'
+                  : 'All services are running'
+            }
+            icon={Box}
+            tone={failedCount > 0 ? 'bad' : totalCount === 0 ? 'neutral' : 'good'}
+          />
+          <OverviewCard
+            href="/network"
+            title="Network Map"
+            metric={gatewayUp ? 'Internet OK' : hasFirstSnapshot ? 'Gateway down' : '…'}
+            description={
+              gatewayUp
+                ? 'See how services talk to each other'
+                : hasFirstSnapshot
+                  ? 'Upstream connection is unreachable'
+                  : 'Reading gateway status…'
+            }
+            icon={Network}
+            tone={gatewayUp ? 'good' : hasFirstSnapshot ? 'warn' : 'neutral'}
+          />
+          <OverviewCard
+            href="/health"
+            title="Diagnostics"
+            metric="Self-test"
+            description="Run probes, view system logs, inspect raw containers"
+            icon={Activity}
+            tone="neutral"
+          />
+          <OverviewCard
+            href="/terminal"
+            title="SSH Terminal"
+            metric="Console"
+            description="A shell on the host for expert tasks"
+            icon={Terminal}
+            tone="neutral"
+          />
+        </section>
+
+        <footer className="pt-4 border-t border-gray-200 dark:border-gray-800 flex justify-end">
+          <Link
+            href="/settings"
+            className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+          >
+            <Settings size={14} /> Settings
+          </Link>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function HealthHeadline({ tone, text }: { tone: 'good' | 'warn' | 'bad' | 'neutral'; text: string }) {
+  const toneClasses: Record<typeof tone, string> = {
+    good: 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800 text-emerald-800 dark:text-emerald-300',
+    warn: 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300',
+    bad: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-300',
+    neutral: 'bg-gray-50 dark:bg-gray-900/40 border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300',
+  };
+  const Icon = tone === 'bad' || tone === 'warn' ? AlertCircle : CheckCircle2;
+  return (
+    <div className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${toneClasses[tone]}`}>
+      <Icon size={20} className="shrink-0" />
+      <span className="text-sm font-medium">{text}</span>
+    </div>
+  );
+}
+
+interface OverviewCardProps {
+  href: string;
+  title: string;
+  metric: string;
+  description: string;
+  icon: typeof Box;
+  tone: 'good' | 'warn' | 'bad' | 'neutral';
+}
+
+function OverviewCard({ href, title, metric, description, icon: Icon, tone }: OverviewCardProps) {
+  const accentClasses: Record<typeof tone, string> = {
+    good: 'text-emerald-600 dark:text-emerald-400',
+    warn: 'text-amber-600 dark:text-amber-400',
+    bad: 'text-red-600 dark:text-red-400',
+    neutral: 'text-blue-600 dark:text-blue-400',
+  };
+  return (
+    <Link
+      href={href}
+      className="group block bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-5 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-sm transition-all"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <Icon size={20} className={accentClasses[tone]} />
+        <ArrowRight size={16} className="text-gray-300 dark:text-gray-700 group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors" />
+      </div>
+      <h2 className="font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
+      <p className={`text-sm font-medium mt-0.5 ${accentClasses[tone]}`}>{metric}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">{description}</p>
+    </Link>
+  );
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import OverviewDashboard from '@/dashboards/OverviewDashboard';
+
+export default function HomePage() {
+  return <OverviewDashboard />;
+}

--- a/tests/frontend/MobileNav.test.tsx
+++ b/tests/frontend/MobileNav.test.tsx
@@ -40,25 +40,26 @@ describe('MobileNav', () => {
 
     it('MobileBottomBar renders dashboards except Settings using shortLabel', () => {
         renderWithToast(<MobileBottomBar />);
-        expect(screen.getByTitle('Container Engine')).toBeDefined();
+        expect(screen.getByTitle('Services')).toBeDefined();
         expect(screen.getByTitle('Network Map')).toBeDefined();
         expect(screen.queryByTitle('Settings')).toBeNull();
-        // shortLabel renders "Containers", not the trimmed-first-word "Container".
-        expect(screen.getByText('Containers')).toBeDefined();
+        // Container Engine moved into Diagnostics (#802) — no longer a
+        // top-level mobile-bottom entry.
+        expect(screen.queryByTitle('Container Engine')).toBeNull();
     });
 
     it('MobileBottomBar highlights active route', () => {
         renderWithToast(<MobileBottomBar />);
         const networkBtn = screen.getByTitle('Network Map');
         expect(networkBtn.className).toContain('text-blue-600');
-        const containersBtn = screen.getByTitle('Container Engine');
-        expect(containersBtn.className).not.toContain('text-blue-600');
+        const servicesBtn = screen.getByTitle('Services');
+        expect(servicesBtn.className).not.toContain('text-blue-600');
     });
 
     it('MobileBottomBar threads ?node= into navigation', () => {
         currentNode = 'edge-1';
         renderWithToast(<MobileBottomBar />);
-        fireEvent.click(screen.getByTitle('Container Engine'));
-        expect(mockPush).toHaveBeenCalledWith('/containers?node=edge-1');
+        fireEvent.click(screen.getByTitle('Services'));
+        expect(mockPush).toHaveBeenCalledWith('/services?node=edge-1');
     });
 });

--- a/tests/frontend/Sidebar.test.tsx
+++ b/tests/frontend/Sidebar.test.tsx
@@ -6,7 +6,7 @@ import Sidebar from '@/components/Sidebar';
 // Mock Next Navigation
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/containers', // Default active
+  usePathname: () => '/services', // Default active
   useSearchParams: () => new URLSearchParams(),
   useRouter: () => ({ push: mockPush })
 }));
@@ -49,7 +49,7 @@ describe('Sidebar', () => {
 
     it('renders expanded by default on desktop', () => {
         render(<Sidebar />);
-        expect(screen.getByText('Container Engine')).toBeDefined();
+        expect(screen.getByText('Services')).toBeDefined();
         expect(screen.getByTitle('Collapse Sidebar')).toBeDefined();
     });
 
@@ -60,7 +60,7 @@ describe('Sidebar', () => {
         fireEvent.click(toggleBtn);
 
         await waitFor(() => {
-             expect(screen.queryByText('Container Engine')).toBeNull();
+             expect(screen.queryByText('Services')).toBeNull();
              expect(screen.getByTitle('Expand Sidebar')).toBeDefined();
         });
     });
@@ -68,7 +68,7 @@ describe('Sidebar', () => {
     it('renders active state', () => {
         render(<Sidebar />);
 
-        const text = screen.getByText('Container Engine');
+        const text = screen.getByText('Services');
         const button = text.closest('button');
         expect(button).toBeDefined();
         expect(button?.className).toContain('text-blue-600');
@@ -88,7 +88,7 @@ describe('Sidebar', () => {
         render(<Sidebar />);
 
         // Should be collapsed initially
-        expect(screen.queryByText('Container Engine')).toBeNull();
+        expect(screen.queryByText('Services')).toBeNull();
         expect(screen.getByTitle('Expand Sidebar')).toBeDefined();
     });
 


### PR DESCRIPTION
## Summary

### #803 — Home / Overview Dashboard
- New `packages/frontend/src/dashboards/OverviewDashboard.tsx`. Headline health sentence ("Everything looks healthy" / "N services need attention" / "Internet gateway is unreachable") followed by four navigation cards (Services, Network Map, Diagnostics, SSH Terminal). All numbers come from the existing `DigitalTwinProvider` snapshot — no new endpoints, no extra polling.
- Cards are **nav surfaces, not duplicated detail**. The dashboard answers "is anything broken?" and "where do I go next?" without retraining the operator to a fifth UI shape.
- Route: `src/app/(dashboard)/page.tsx` renders OverviewDashboard.

### #802 — Sidebar / mobile-nav reorganisation
- `next.config.ts` redirect from `/` → `/services` removed; root is now the Home page.
- `NAVIGATION_ENTRIES` (the #845 schema, just merged) updated:
  - **Home** added as the first entry (`/`).
  - **Container Engine** removed from primary nav — operators who need the raw podman view know to open Diagnostics, per the `UX_DECISIONS.md` "primary sidebar is a user-task list" rule.
  - **Health** renamed to "Diagnostics" (full label); mobile shortLabel stays "Health".
- `HealthDashboard.tsx` grows a `containers` tab that renders `ContainersDashboard` inline. The standalone `/containers` route still resolves directly for direct-link / muscle-memory navigation.
- Tests updated to match the new entry list.

## Test plan
- [x] `tsc --noEmit` — clean.
- [x] `vitest` — 1212 pass.
- [x] `npm run lint` — 0 errors.
- [ ] Manual: `/` lands on the Overview Dashboard; service-count, gateway-status, and headline tone update as the twin reconnects. Diagnostics tab "Containers" matches the standalone `/containers` view.

Closes #802, closes #803.

(PR #866 was auto-closed when the parent PR #864 merged — classic stacked-PR squash-merge pitfall. This is the re-targeted replacement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)