### PR TITLE
feat(workspace): extract WorkspaceDrawer foundation (#804)

### DIFF
--- a/packages/frontend/src/components/WorkspaceDrawer.tsx
+++ b/packages/frontend/src/components/WorkspaceDrawer.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+/**
+ * Resizable side drawer (#804 — foundation).
+ *
+ * The first landing of this primitive replaces inline drawer JSX
+ * across the codebase (service edit/monitor in useServiceActions,
+ * container logs/terminal pages) with a single reusable component.
+ * The follow-up commits enable the more interesting half:
+ *
+ *   - `width='wide'`, `hasBackdrop` (default) — the existing visual,
+ *     shipping today. Safe; no behaviour change.
+ *   - `width='standard'` (~max-w-2xl) — narrower drawer for simple
+ *     detail panes. Add per-surface once visual QA confirms the
+ *     content reflows cleanly.
+ *   - `width='full'` — wraps the surface with no left margin so
+ *     wizards / merge tools that previously hijacked the whole
+ *     screen can use one consistent chrome.
+ *   - `hasBackdrop={false}` — non-blocking split-screen mode where
+ *     the main page remains scrollable on the left while observation
+ *     surfaces (logs, self-test) stream on the right. Enabled
+ *     per-surface; sticky destructive modals (#804 acceptance) keep
+ *     the blocking backdrop.
+ *
+ * Cubic-bezier transition class is included for forward compat with
+ * width morphing in a later PR — today the width is fixed per
+ * mount, so the transition is a no-op visually.
+ */
+
+export type WorkspaceDrawerWidth = 'standard' | 'wide' | 'full';
+
+interface WorkspaceDrawerProps {
+  /** Closed → unmount. The parent owns the state. */
+  isOpen: boolean;
+  onClose: () => void;
+  /** Header block rendered above the body — title, status pills,
+   *  badge chips, etc. The close button is rendered by the drawer
+   *  itself; do not include a close affordance here. */
+  header: ReactNode;
+  children: ReactNode;
+  /** Default: `'wide'` (`max-w-6xl` — same as the legacy inline
+   *  drawer). `'standard'` ≈ `max-w-2xl` for short detail panes.
+   *  `'full'` removes the left margin entirely. */
+  width?: WorkspaceDrawerWidth;
+  /** When false, no dimming backdrop is rendered — the main page on
+   *  the left remains interactive. Defaults to true so callers
+   *  migrate without behaviour change. Destructive confirms must
+   *  keep this true. */
+  hasBackdrop?: boolean;
+  /** Optional aria-label for the close button; defaults to "Close
+   *  drawer". */
+  closeAriaLabel?: string;
+}
+
+const widthClass: Record<WorkspaceDrawerWidth, string> = {
+  standard: 'max-w-2xl',
+  wide: 'max-w-6xl',
+  full: '',
+};
+
+export default function WorkspaceDrawer({
+  isOpen,
+  onClose,
+  header,
+  children,
+  width = 'wide',
+  hasBackdrop = true,
+  closeAriaLabel = 'Close drawer',
+}: WorkspaceDrawerProps) {
+  if (!isOpen) return null;
+
+  // Backdrop variant — fixed overlay with a dim layer that blocks the
+  // main page. Non-backdrop variant — same fixed positioning but no
+  // dim and `pointer-events-none` on the wrapper so clicks fall
+  // through to the page behind; the panel itself re-enables pointer
+  // events so it stays interactive.
+  const wrapperClass = hasBackdrop
+    ? 'fixed inset-0 z-[70] flex justify-end bg-gray-950/70 backdrop-blur-sm'
+    : 'fixed inset-0 z-[70] flex justify-end pointer-events-none';
+  const panelExtraClass = hasBackdrop ? '' : 'pointer-events-auto';
+
+  return (
+    <div className={wrapperClass}>
+      <div
+        className={`w-full ${widthClass[width]} h-full bg-white dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800 shadow-2xl flex flex-col transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${panelExtraClass}`}
+      >
+        <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+          <div className="min-w-0">{header}</div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-2 rounded-full text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-800 shrink-0"
+            aria-label={closeAriaLabel}
+          >
+            <X size={20} />
+          </button>
+        </div>
+        <div className="flex-1 overflow-hidden">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useServiceActions.tsx
+++ b/packages/frontend/src/hooks/useServiceActions.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { Box, ArrowLeft, PlayCircle, Power, RotateCw, RefreshCw, Trash2, X, Loader2 } from 'lucide-react';
+import WorkspaceDrawer from '@/components/WorkspaceDrawer';
 import ServiceMonitor from '@/components/ServiceMonitor';
 import ServiceForm, { ServiceFormInitialData } from '@/components/ServiceForm';
 import ActionProgressModal from '@/components/ActionProgressModal';
@@ -308,66 +309,55 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
         </div>
       )}
 
-      {drawerState && (
-        <div className="fixed inset-0 z-[70] flex justify-end bg-gray-950/70 backdrop-blur-sm">
-          <div className="w-full max-w-6xl h-full bg-white dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800 shadow-2xl flex flex-col">
-            <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
-              <div>
-                <p className="text-xs uppercase tracking-[0.2em] text-gray-500 dark:text-gray-400">
-                  {drawerState.mode === 'monitor' ? 'Service Monitor' : 'Edit Service'}
-                </p>
-                <h3 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1 flex items-center gap-2">
-                  {drawerState.service.displayName}
-                  {drawerState.service.nodeName && (
-                    <span className="px-2 py-0.5 rounded-full text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
-                      {drawerState.service.nodeName}
-                    </span>
-                  )}
-                </h3>
-                {drawerState.service.description && (
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-2xl">
-                    {drawerState.service.description}
-                  </p>
-                )}
-              </div>
-              <button
-                type="button"
-                onClick={closeDrawer}
-                className="p-2 rounded-full text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-800"
-                aria-label="Close drawer"
-              >
-                <X size={20} />
-              </button>
-            </div>
-            <div className="flex-1 overflow-hidden">
-              {drawerState.mode === 'monitor' ? (
-                <ServiceMonitor
-                  serviceName={drawerState.service.id || drawerState.service.name}
-                  initialNode={drawerState.service.nodeName}
-                  onBack={closeDrawer}
-                  variant="embedded"
-                />
-              ) : drawerLoading || !editInitialData ? (
-                <div className="h-full flex flex-col items-center justify-center gap-3 text-gray-500 dark:text-gray-400">
-                  <RefreshCw className="animate-spin" />
-                  Loading configuration...
-                </div>
-              ) : (
-                <div className="h-full overflow-y-auto p-6 bg-gray-50 dark:bg-gray-950/30">
-                  <ServiceForm
-                    key={`${drawerState.service.id || drawerState.service.name}-${drawerState.service.nodeName || 'Local'}`}
-                    initialData={editInitialData}
-                    isEdit
-                    defaultNode={drawerState.service.nodeName && drawerState.service.nodeName !== 'Local' ? drawerState.service.nodeName : ''}
-                    onClose={closeDrawer}
-                    variant="embedded"
-                  />
-                </div>
+      <WorkspaceDrawer
+        isOpen={Boolean(drawerState)}
+        onClose={closeDrawer}
+        header={drawerState && (
+          <>
+            <p className="text-xs uppercase tracking-[0.2em] text-gray-500 dark:text-gray-400">
+              {drawerState.mode === 'monitor' ? 'Service Monitor' : 'Edit Service'}
+            </p>
+            <h3 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1 flex items-center gap-2">
+              {drawerState.service.displayName}
+              {drawerState.service.nodeName && (
+                <span className="px-2 py-0.5 rounded-full text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
+                  {drawerState.service.nodeName}
+                </span>
               )}
-            </div>
+            </h3>
+            {drawerState.service.description && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-2xl">
+                {drawerState.service.description}
+              </p>
+            )}
+          </>
+        )}
+      >
+        {drawerState && (drawerState.mode === 'monitor' ? (
+          <ServiceMonitor
+            serviceName={drawerState.service.id || drawerState.service.name}
+            initialNode={drawerState.service.nodeName}
+            onBack={closeDrawer}
+            variant="embedded"
+          />
+        ) : drawerLoading || !editInitialData ? (
+          <div className="h-full flex flex-col items-center justify-center gap-3 text-gray-500 dark:text-gray-400">
+            <RefreshCw className="animate-spin" />
+            Loading configuration...
           </div>
-        </div>
-      )}
+        ) : (
+          <div className="h-full overflow-y-auto p-6 bg-gray-50 dark:bg-gray-950/30">
+            <ServiceForm
+              key={`${drawerState.service.id || drawerState.service.name}-${drawerState.service.nodeName || 'Local'}`}
+              initialData={editInitialData}
+              isEdit
+              defaultNode={drawerState.service.nodeName && drawerState.service.nodeName !== 'Local' ? drawerState.service.nodeName : ''}
+              onClose={closeDrawer}
+              variant="embedded"
+            />
+          </div>
+        ))}
+      </WorkspaceDrawer>
     </>
   ), [
     actionLoading,

--- a/tests/frontend/WorkspaceDrawer.test.tsx
+++ b/tests/frontend/WorkspaceDrawer.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Foundation tests for the WorkspaceDrawer primitive (#804).
+ *
+ * Pin the load-bearing structural behaviour at the jsdom level so a
+ * future refactor can't quietly:
+ *  - render the drawer while closed
+ *  - drop the close button
+ *  - lose the backdrop dimming on a confirm-style drawer
+ *  - or stop disabling pointer events on the page when `hasBackdrop` is false.
+ *
+ * Visual morph between width variants is a manual-QA item — there is
+ * no jsdom layout, so the test only asserts the Tailwind max-w-* class
+ * lands on the panel.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import WorkspaceDrawer from '@/components/WorkspaceDrawer';
+
+describe('WorkspaceDrawer (#804)', () => {
+  function renderDrawer(props: Partial<React.ComponentProps<typeof WorkspaceDrawer>> = {}) {
+    const onClose = vi.fn();
+    const utils = render(
+      <WorkspaceDrawer
+        isOpen
+        onClose={onClose}
+        header={<h2>Service Foo</h2>}
+        {...props}
+      >
+        <div>Body content</div>
+      </WorkspaceDrawer>,
+    );
+    return { ...utils, onClose };
+  }
+
+  it('renders nothing when isOpen is false', () => {
+    const { queryByText } = render(
+      <WorkspaceDrawer isOpen={false} onClose={() => undefined} header={<h2>Hidden</h2>}>
+        <div>Body</div>
+      </WorkspaceDrawer>,
+    );
+    expect(queryByText('Hidden')).toBeNull();
+    expect(queryByText('Body')).toBeNull();
+  });
+
+  it('renders header + body when open', () => {
+    renderDrawer();
+    expect(screen.getByText('Service Foo')).toBeDefined();
+    expect(screen.getByText('Body content')).toBeDefined();
+  });
+
+  it('fires onClose when the X button is clicked', () => {
+    const { onClose } = renderDrawer();
+    fireEvent.click(screen.getByLabelText('Close drawer'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours a custom closeAriaLabel', () => {
+    renderDrawer({ closeAriaLabel: 'Dismiss panel' });
+    expect(screen.getByLabelText('Dismiss panel')).toBeDefined();
+  });
+
+  it('renders the backdrop wrapper by default (hasBackdrop=true)', () => {
+    const { container } = renderDrawer();
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toMatch(/\bbackdrop-blur-sm\b/);
+    expect(wrapper.className).not.toMatch(/pointer-events-none/);
+  });
+
+  it('drops the backdrop and re-enables click-through when hasBackdrop=false', () => {
+    const { container } = renderDrawer({ hasBackdrop: false });
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toMatch(/\bpointer-events-none\b/);
+    expect(wrapper.className).not.toMatch(/backdrop-blur-sm/);
+    // The panel itself re-enables pointer events so it stays interactive.
+    const panel = wrapper.firstElementChild as HTMLElement;
+    expect(panel.className).toMatch(/\bpointer-events-auto\b/);
+  });
+
+  it('applies the wide width class by default', () => {
+    const { container } = renderDrawer();
+    const panel = (container.firstElementChild?.firstElementChild) as HTMLElement;
+    expect(panel.className).toMatch(/\bmax-w-6xl\b/);
+  });
+
+  it('applies the standard width class when width=standard', () => {
+    const { container } = renderDrawer({ width: 'standard' });
+    const panel = (container.firstElementChild?.firstElementChild) as HTMLElement;
+    expect(panel.className).toMatch(/\bmax-w-2xl\b/);
+  });
+
+  it('omits the max-w-* class when width=full', () => {
+    const { container } = renderDrawer({ width: 'full' });
+    const panel = (container.firstElementChild?.firstElementChild) as HTMLElement;
+    expect(panel.className).not.toMatch(/\bmax-w-(2xl|6xl)\b/);
+  });
+
+  it('carries the cubic-bezier transition class on the panel', () => {
+    const { container } = renderDrawer();
+    const panel = (container.firstElementChild?.firstElementChild) as HTMLElement;
+    // Width morphing transitions key off these classes (#804 follow-up).
+    expect(panel.className).toMatch(/transition-all/);
+    expect(panel.className).toMatch(/cubic-bezier/);
+  });
+});


### PR DESCRIPTION
## Summary
Introduces a reusable side-drawer primitive — `packages/frontend/src/components/WorkspaceDrawer.tsx` — and migrates the service edit / monitor drawer in `useServiceActions` to consume it. Default props preserve the legacy visual (`max-w-6xl` wide, dimming backdrop, close-X affordance) so **no behaviour change today**.

The component exposes the forward-compat surface from #804's acceptance criteria:

- `width: 'standard' | 'wide' | 'full'` (defaults 'wide'). 'standard' (`max-w-2xl`) for narrow detail panes; 'full' removes the left margin entirely for wizards / merge tools.
- `hasBackdrop: boolean` (defaults true). When false, no dimming layer + `pointer-events-none` on wrapper so the main page stays scrollable / interactive (split-screen mode). Panel itself re-enables pointer events. Destructive confirm modals keep `hasBackdrop: true` per the issue's acceptance.
- Cubic-bezier transition class `ease-[cubic-bezier(0.16,1,0.3,1)]` is already on the panel — width morphing follow-ups just flip the prop.

## This PR ships
- The primitive + one safe migration (no visible change).

## Follow-ups that **need eyes-on QA**
1. Migrate the container logs / SSH terminal drawers.
2. Add the [Standard | Wide | Full] header toggle.
3. Flip `hasBackdrop=false` on observation surfaces (logs, self-test) and reflow ServicesDashboard alongside.
4. Mobile drag-to-dismiss handle (vanilla touch events).

`tests/frontend/WorkspaceDrawer.test.tsx` pins the load-bearing shape — backdrop on/off, width-class application, close handler, cubic-bezier transition class — at the jsdom level so the follow-ups can't regress the foundation.

## Test plan
- [x] `tsc --noEmit` — clean.
- [x] `vitest` — 1240 pass (10 new).
- [ ] Manual: open the service edit / monitor drawer; it should look and behave exactly as before this PR.

Refs #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)