### PR TITLE
fix(home): remove duplicate / route that broke the client manifest (#879)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,0 @@
-export default function RootPage() {
-  return null;
-}


### PR DESCRIPTION
## Summary

`src/app/page.tsx` was the legacy stub that returned `null` back when `next.config.ts` redirected `/` → `/services` at the edge. The redirect was removed in #867 when the OverviewDashboard landed at `src/app/(dashboard)/page.tsx` — but the stub was left behind.

Next.js route groups are URL-transparent: both `src/app/page.tsx` and `src/app/(dashboard)/page.tsx` claim the `/` URL, and the production build emits an inconsistent client reference manifest between them. The runtime then throws on every request to `/`:

```
⨯ Error [InvariantError]: Invariant: The client reference
  manifest for route "/" does not exist. This is a bug in Next.js.
```

Direct hit on `:5888/login` worked, but the homepage and anything proxied through `admin.dopp.cloud` returned 500. Surfaced by the smoke test in #877 once #878 unblocked the admin SNI handshake.

Deleting the empty stub leaves a single canonical `/` route (the OverviewDashboard inside the `(dashboard)` group, which carries the Sidebar + MobileNav chrome the operator expects).

## Test plan
- [x] `tsc --noEmit` — clean after `rm -rf .next/types` (stale build cache referenced the deleted file).
- [x] `npm run build` — production build emits a single `/` route entry, no manifest collision.
- [x] `vitest` — 1240 pass.
- [ ] Manual: after deploy, `admin.dopp.cloud` should reach the OverviewDashboard instead of 500.

Closes #879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)