### PR TITLE
fix(sync): forward to 127.0.0.1 + disable host check on Syncthing (#880)

### DIFF
--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -437,6 +437,17 @@ export interface VariableMeta {
    * from outside the LAN.
    */
   exposure?: 'public' | 'internal' | 'lan';
+  /**
+   * For subdomain type: when true, the service binds **only to the host
+   * loopback** (e.g. Syncthing's `STGUIADDRESS=127.0.0.1:8384`).
+   * NPM today runs `hostNetwork: true` and shares the host netns, so
+   * `forward_host: 127.0.0.1` reaches the loopback-bound upstream
+   * correctly. Default (false) routes through the node's LAN IP, which
+   * is correct for any service binding 0.0.0.0 or the LAN address.
+   * (#880; if #817 ever moves NPM off hostNetwork, the forward target
+   * needs to switch to `host.containers.internal`.)
+   */
+  loopbackOnly?: boolean;
   /** OIDC client to register with Authelia when this service is deployed */
   oidcClient?: OidcClientConfig;
   /** For bcrypt type: name of another variable whose plaintext gets bcrypt-hashed */

--- a/packages/backend/src/lib/stackInstall/postInstall.ts
+++ b/packages/backend/src/lib/stackInstall/postInstall.ts
@@ -112,6 +112,13 @@ export function buildProxyHosts(variables: StackVariable[]): {
     /** 'public' and 'internal' trigger auto-cert; 'lan' skips. */
     exposure: 'public' | 'internal' | 'lan';
     proxyConfig?: VariableMeta['proxyConfig'];
+    /** Target the proxy host forwards to. Defaults (when omitted by
+     *  the proxy-host route) to the node's LAN IP — correct for
+     *  services binding 0.0.0.0 or the LAN interface. Loopback-bound
+     *  services (Syncthing's GUI, etc.) need this set to
+     *  `host.containers.internal` so NPM (in a container) can reach
+     *  the host's loopback. (#880) */
+    forwardHost?: string;
   }[];
 } {
   const domain = variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value;
@@ -143,6 +150,12 @@ export function buildProxyHosts(variables: StackVariable[]): {
       service,
       exposure,
       proxyConfig: renderProxyConfig(sv.meta?.proxyConfig, view),
+      // Loopback-bound services (Syncthing GUI etc.) bind to the host's
+      // 127.0.0.1. NPM today runs `hostNetwork: true` so it shares the
+      // host netns and `127.0.0.1` IS the right forward target. When
+      // #817 eventually moves NPM into its own netns, this needs to
+      // become `host.containers.internal` instead. (#880)
+      ...(sv.meta?.loopbackOnly ? { forwardHost: '127.0.0.1' } : {}),
     }];
   }).filter(h => Number.isFinite(h.forwardPort) && h.forwardPort > 0);
   return { domain, hosts };

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -68,6 +68,33 @@ def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tu
 def main() -> int:
     host = env("HOST", "<server-ip>")
 
+    # ── Syncthing GUI host-check ───────────────────────────────────────
+    # Syncthing's GUI defaults to allowing the bind address only as a
+    # Host: header. NPM forwards `sync.<PUBLIC_DOMAIN>` and Syncthing
+    # rejects with HTTP 403 `Host check error`. STGUIHOSTCHECK isn't a
+    # real env var; only the config.xml `<insecureSkipHostcheck>` child
+    # element disables the check. We patch it idempotently here so a
+    # fresh install or a re-deploy lands the right config without
+    # waiting for the operator to do it manually. (#880)
+    syncthing_config_xml = "/var/syncthing/config/config.xml"
+    patch_syncthing_cmd = (
+        "podman exec file-share-syncthing sh -c "
+        "'grep -q insecureSkipHostcheck " + syncthing_config_xml + " || "
+        "sed -i \"s|<address>127.0.0.1:8384</address>|<address>127.0.0.1:8384</address>"
+        "\\n        <insecureSkipHostcheck>true</insecureSkipHostcheck>|\" "
+        + syncthing_config_xml + "'"
+    )
+    rc = os.system(patch_syncthing_cmd)
+    if rc == 0:
+        # Syncthing reloads config.xml on SIGHUP but not on a plain file
+        # write; restart the container to pick up the new setting. The
+        # subsequent Samba/FileBrowser steps don't depend on Syncthing
+        # so a short window where Syncthing is restarting is harmless.
+        os.system("podman restart file-share-syncthing > /dev/null 2>&1 || true")
+        log("✅ Syncthing GUI host-check disabled (config.xml patched).")
+    else:
+        log("⚠️  Syncthing config patch returned a non-zero exit. The sync.<domain> URL may return 403 'Host check error' — fix manually in /var/syncthing/config/config.xml.")
+
     # ── Samba ──────────────────────────────────────────────────────────
     share_user = env("SHARE_USER", "samba")
     share_password = env("SHARE_PASSWORD")

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -80,6 +80,14 @@ spec:
       # network (hostNetwork=true, so 127.0.0.1 is reachable).
       - name: STGUIADDRESS
         value: "127.0.0.1:8384"
+      # GUI Host: header check — disabled via post-deploy.py patching
+      # config.xml's `<insecureSkipHostcheck>` (no equivalent env var
+      # exists in Syncthing). Without that patch the proxied URL
+      # `sync.<PUBLIC_DOMAIN>` returns HTTP 403 `Host check error`
+      # because Syncthing's default allowlist is bind-address only.
+      # The actual gate is Authelia forward-auth + the LAN-only access
+      # list at the proxy layer, so opening this is not an auth bypass.
+      # (#880)
       # Disable Syncthing's UPnP / NAT-PMP NAT-traversal (#415). The
       # FritzBox replies 403 to AddPortMapping on its IPv6 WAN entry
       # (WANIPConn2), which Syncthing then retries on a loop and

--- a/templates/file-share/variables.json
+++ b/templates/file-share/variables.json
@@ -10,10 +10,11 @@
   },
   "SYNCTHING_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for Syncthing Web UI — gated by Authelia forward-auth. The Syncthing mobile/desktop apps use API keys, not the GUI session, so device sync keeps working.",
+    "description": "Subdomain for Syncthing Web UI — gated by Authelia forward-auth. The Syncthing mobile/desktop apps use API keys, not the GUI session, so device sync keeps working. Syncthing's GUI is loopback-only by design (it exposes API keys + folder paths); NPM (hostNetwork=true) forwards to 127.0.0.1:8384 to reach it (#880).",
     "default": "sync",
     "exposure": "internal",
     "proxyPort": "8384",
+    "loopbackOnly": true,
     "proxyConfig": {
       "allow_websocket_upgrade": true,
       "block_exploits": true,

--- a/tests/backend/buildProxyHosts.test.ts
+++ b/tests/backend/buildProxyHosts.test.ts
@@ -185,4 +185,20 @@ describe('buildProxyHosts', () => {
     expect(hosts.find(h => h.domain === 'navi.example.com')?.service).toBe('media');
     expect(hosts.find(h => h.domain === 'foo.example.com')?.service).toBe('foo');
   });
+
+  it('routes loopback-only services through 127.0.0.1 (#880)', () => {
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('SYNC_SUBDOMAIN', 'sync', subdomain('internal', '8384', { loopbackOnly: true })),
+      v('PHOTOS_SUBDOMAIN', 'photos', subdomain('internal', '2283')),
+    ]);
+    const sync = hosts.find(h => h.domain === 'sync.example.com');
+    const photos = hosts.find(h => h.domain === 'photos.example.com');
+    // NPM runs hostNetwork=true, so its 127.0.0.1 IS the host's
+    // loopback where Syncthing's GUI listens.
+    expect(sync?.forwardHost).toBe('127.0.0.1');
+    // Regular services don't override — the proxy-hosts route defaults
+    // forwardHost to the node's LAN IP.
+    expect(photos?.forwardHost).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

`sync.dopp.cloud` was 502'ing because **two** things lined up wrong:

1. NPM forwarded to `192.168.178.100:8384` (the node's LAN IP), but Syncthing's GUI binds `STGUIADDRESS=127.0.0.1:8384` (loopback-only by design — the GUI exposes API keys + folder paths). NPM runs `hostNetwork: true` so its 127.0.0.1 *is* the host's loopback. Correct forward target: `127.0.0.1`.

2. Even after the forward lands, Syncthing returns HTTP 403 `Host check error` because the GUI host-check allowlist only accepts the bind address by default. Proxied request → `Host: sync.<PUBLIC_DOMAIN>` → rejected. No env var disables this; only the config.xml `<insecureSkipHostcheck>` child element of `<gui>`.

## Changes

- `packages/backend/src/lib/registry.ts` — `VariableMeta` gains `loopbackOnly?: boolean`.
- `packages/backend/src/lib/stackInstall/postInstall.ts:buildProxyHosts` — when `loopbackOnly: true`, emits `forwardHost: '127.0.0.1'`. (If #817 ever moves NPM off hostNetwork, this constant becomes `host.containers.internal`.)
- `templates/file-share/variables.json` — SYNCTHING_SUBDOMAIN gains `loopbackOnly: true`.
- `templates/file-share/template.yml` — comment-only update next to STGUIADDRESS pointing at the post-deploy patch.
- `templates/file-share/post-deploy.py` — idempotently patches `<gui>` in Syncthing's config.xml to add `<insecureSkipHostcheck>true</insecureSkipHostcheck>`, then restarts the container. Safe on re-deploy: checks for `insecureSkipHostcheck` first.

## Test plan
- [x] `buildProxyHosts.test.ts` — new case asserting `forwardHost === '127.0.0.1'` for `loopbackOnly: true`.
- [x] `tsc --noEmit` + full vitest — 1241 pass (1 new).
- [x] `python3 -m py_compile templates/file-share/post-deploy.py`.
- [x] Live verification on the box: smoke went 22/24 → 23/24 (sync.dopp.cloud now HTTP 200 with family Authelia cookie).

Closes #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)