### PR TITLE
test(smoke): admin.dopp.cloud is app-layer auth, not Authelia (#878 followup)

### DIFF
--- a/scripts/smoke/sso-verify.sh
+++ b/scripts/smoke/sso-verify.sh
@@ -279,7 +279,15 @@ section "6/6 · Access control — family user MUST NOT reach admin domains"
 # These are listed under Authelia's admins-group rule. A family-only
 # user should get redirected back to /auth (302) or refused (403 from
 # Authelia's verify endpoint), NOT 200 from the upstream app.
-for h in admin nginx dns ldap; do
+#
+# `admin.dopp.cloud` is intentionally NOT in this list: ServiceBay
+# has its own login on the application layer, and stacking Authelia
+# forward-auth on top would double-login the operator whose recovery
+# path goes through this UI. The HTML shell at `/` is reachable on
+# admin.dopp.cloud but every API call returns 401 without a
+# ServiceBay session — covered by integration tests on the
+# ServiceBay app itself, not by this smoke test.
+for h in nginx dns ldap; do
   body=$(mktemp -t sb-smoke-svc.XXXXXX)
   # Single follow-on response — don't chase redirects, so a 302 back
   # to auth.dopp.cloud is the SUCCESS signal here.


### PR DESCRIPTION
## Summary
ServiceBay's own login gates every API endpoint on `admin.dopp.cloud` (401 without a SB session). Stacking Authelia forward-auth on top would double-login the operator — explicitly rejected in #878's SERVICEBAY_SUBDOMAIN comment.

The smoke test's section 6 was treating `admin.dopp.cloud` like `nginx` / `dns` / `ldap` (Authelia-gated admin tools), so it flagged the HTML shell's 200 response as an ACL bypass. That's a false positive: the HTML loads but every meaningful action behind it is 401 until the operator logs in to ServiceBay directly.

This PR drops `admin` from the section-6 loop and documents why in the inline comment. `nginx`/`dns`/`ldap` (which DO use Authelia forward-auth) stay.

## Final score
`scripts/smoke/sso-verify.sh` on the live box: **23/23**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)