### PR TITLE
fix(dashboard): hide servicebay-splash from the services list

### DIFF
--- a/packages/backend/src/lib/services/ServiceManager.test.ts
+++ b/packages/backend/src/lib/services/ServiceManager.test.ts
@@ -158,6 +158,30 @@ spec:
         expect(svc.volumes[0]).toEqual({ host: '/mnt/data', container: '/var/lib/mysql' });
     });
 
+    it('hides servicebay-splash from listServices', async () => {
+        // The boot-time splash Quadlet (#775) sits on disk next to
+        // `servicebay.container` and the operator can't / shouldn't
+        // manage it. listServices must skip it so the dashboard's
+        // services count doesn't include a deliberately-dormant
+        // helper as "1 of N not running".
+        mockNodes['local'].files = {
+            '/var/home/core/.config/containers/systemd/vaultwarden.container': {
+                path: '/var/home/core/.config/containers/systemd/vaultwarden.container',
+                content: '[Container]\nImage=vaultwarden/server',
+                modified: 0,
+            },
+            '/var/home/core/.config/containers/systemd/servicebay-splash.container': {
+                path: '/var/home/core/.config/containers/systemd/servicebay-splash.container',
+                content: '[Container]\nImage=ghcr.io/mdopp/servicebay-splash',
+                modified: 0,
+            },
+        } as any;
+        const services = await ServiceManager.listServices('local');
+        const names = services.map(s => s.name);
+        expect(names).toContain('vaultwarden');
+        expect(names).not.toContain('servicebay-splash');
+    });
+
     it('should parse Quadlet Volumes correctly', async () => {
         const containerContent = `
 [Container]

--- a/packages/backend/src/lib/services/serviceListing.ts
+++ b/packages/backend/src/lib/services/serviceListing.ts
@@ -46,6 +46,23 @@ export interface ServiceInfo {
   verifiedDomains?: string[];
 }
 
+/**
+ * Quadlet files that are part of ServiceBay's own runtime but aren't
+ * services the operator manages. Excluded from `listServices` so they
+ * never appear in the dashboard's services count / list.
+ *
+ * - `servicebay-splash` is the boot-time placeholder (#775) that binds
+ *   :5888 during cold boot so visitors see "starting up" instead of a
+ *   connection-refused page. It's a one-shot — its success state is
+ *   `inactive (dead)` once the real servicebay.service takes over via
+ *   the `Conflicts=` directive. Showing it as "1 of 14 not running"
+ *   on the dashboard is misleading, since the operator can't fix it
+ *   (nor should they — it's working as designed).
+ */
+const HIDDEN_SERVICE_BASENAMES = new Set<string>([
+  'servicebay-splash',
+]);
+
 export class ServiceListing {
     static async listServices(nodeName: string): Promise<ServiceInfo[]> {
         // V4: Use DigitalTwinStore
@@ -64,6 +81,10 @@ export class ServiceListing {
             const fileName = path.basename(filePath);
             const baseName = filePath.endsWith('.kube') ? fileName.replace('.kube', '') : fileName.replace('.container', '');
             const type = filePath.endsWith('.kube') ? 'kube' : 'container';
+
+            // Skip ServiceBay-internal Quadlets the operator doesn't manage
+            // (boot splash, etc. — see HIDDEN_SERVICE_BASENAMES comment).
+            if (HIDDEN_SERVICE_BASENAMES.has(baseName)) continue;
 
             // Find State
             const unitName = `${baseName}.service`;


### PR DESCRIPTION
## Summary
The boot-time splash Quadlet (#775) sits on disk next to `servicebay.container` and is a one-shot whose success state is `inactive (dead)` — once `servicebay.service` starts it triggers the `Conflicts=servicebay-splash.service` directive and the splash exits. That's working as designed; the operator can't act on it.

Until this commit, `listServices` walked every `.kube` / `.container` file in the twin's `files` map and surfaced both as managed services. The dashboard then counted `servicebay-splash` toward the totals — "13 of 14 services running" on every boot — pulling the operator's eye toward a non-issue.

## Fix
Adds a `HIDDEN_SERVICE_BASENAMES` set in `serviceListing.ts` so internal-only Quadlets are skipped before they enter the result.

## Test plan
- [x] `ServiceManager.test.ts` — new case with both `vaultwarden.container` and `servicebay-splash.container` returns only `vaultwarden`.
- [x] `tsc --noEmit` + full vitest — 1242 pass.
- [ ] Manual after deploy: `/api/services` no longer includes `servicebay-splash`; dashboard reads "13 of 13 running".

🤖 Generated with [Claude Code](https://claude.com/claude-code)