### PR TITLE
fix(dashboard): hide servicebay-splash from implicit-services path too

### DIFF
--- a/packages/backend/src/lib/services/ServiceManager.test.ts
+++ b/packages/backend/src/lib/services/ServiceManager.test.ts
@@ -190,9 +190,9 @@ spec:
         // detector ("servicebay" keyword match), so this path was
         // re-introducing it after the file-driven filter.
         mockNodes['local'].files = {};
-        mockNodes['local'].services = [
-            { name: 'servicebay', activeState: 'active', isServiceBay: true } as any,
-            { name: 'servicebay-splash', activeState: 'inactive', isServiceBay: true } as any,
+        (mockNodes['local'] as any).services = [
+            { name: 'servicebay', activeState: 'active', isServiceBay: true },
+            { name: 'servicebay-splash', activeState: 'inactive', isServiceBay: true },
         ];
         const services = await ServiceManager.listServices('local');
         const names = services.map(s => s.name);

--- a/packages/backend/src/lib/services/ServiceManager.test.ts
+++ b/packages/backend/src/lib/services/ServiceManager.test.ts
@@ -158,7 +158,7 @@ spec:
         expect(svc.volumes[0]).toEqual({ host: '/mnt/data', container: '/var/lib/mysql' });
     });
 
-    it('hides servicebay-splash from listServices', async () => {
+    it('hides servicebay-splash from listServices (file-driven path)', async () => {
         // The boot-time splash Quadlet (#775) sits on disk next to
         // `servicebay.container` and the operator can't / shouldn't
         // manage it. listServices must skip it so the dashboard's
@@ -179,6 +179,24 @@ spec:
         const services = await ServiceManager.listServices('local');
         const names = services.map(s => s.name);
         expect(names).toContain('vaultwarden');
+        expect(names).not.toContain('servicebay-splash');
+    });
+
+    it('hides servicebay-splash from the implicit-services path too', async () => {
+        // Second code path in listServices: services flagged
+        // `isServiceBay` (or `isReverseProxy`) get appended even when
+        // they don't have a `.container` on disk. The splash unit
+        // gets flagged isServiceBay by the twin's name-based
+        // detector ("servicebay" keyword match), so this path was
+        // re-introducing it after the file-driven filter.
+        mockNodes['local'].files = {};
+        mockNodes['local'].services = [
+            { name: 'servicebay', activeState: 'active', isServiceBay: true } as any,
+            { name: 'servicebay-splash', activeState: 'inactive', isServiceBay: true } as any,
+        ];
+        const services = await ServiceManager.listServices('local');
+        const names = services.map(s => s.name);
+        expect(names).toContain('servicebay');
         expect(names).not.toContain('servicebay-splash');
     });
 

--- a/packages/backend/src/lib/services/serviceListing.ts
+++ b/packages/backend/src/lib/services/serviceListing.ts
@@ -328,8 +328,14 @@ export class ServiceListing {
         // but we still want to visualize them if they are detected by the Agent.
         
         const processedIds = new Set(services.map(s => s.id));
-        const specialServices = twin.services.filter(s => 
+        const specialServices = twin.services.filter(s =>
             (s.isReverseProxy || s.isServiceBay) && !processedIds.has(s.name)
+            // Skip ServiceBay-internal helpers (boot splash, etc.) here too —
+            // they're flagged isServiceBay by the twin detector because the
+            // unit name contains "servicebay", but they're not user-managed
+            // and shouldn't show up in the dashboard's services count.
+            && !HIDDEN_SERVICE_BASENAMES.has(s.name)
+            && !HIDDEN_SERVICE_BASENAMES.has(s.name.replace(/\.service$/, ''))
         );
 
         for (const serviceUnit of specialServices) {


### PR DESCRIPTION
## Summary
PR #885 added `HIDDEN_SERVICE_BASENAMES` filtering to the file-driven listing path but missed a second code path: services flagged `isReverseProxy` or `isServiceBay` in `twin.services` get appended to the result even when they don't have a `.container` on disk.

The splash unit's name contains "servicebay", so the twin's name-based detector flags it `isServiceBay: true`, and the implicit-services loop re-introduces it after the file-driven filter had correctly skipped it. Result: dashboard still showed "12 of 13 running" after #885 deployed.

## Fix
Apply the same `HIDDEN_SERVICE_BASENAMES` check (with and without `.service` suffix to cover both how the twin stores the name) to that second path.

## Test plan
- [x] New test case in `ServiceManager.test.ts` for the implicit-services path with both `servicebay` and `servicebay-splash` in `twin.services`.
- [x] `tsc --noEmit` + vitest — 8 pass (1 new).
- [ ] Verify after deploy that `/api/services` no longer contains the splash entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)