### PR TITLE
feat(hermes): add user-guide.md so Hermes appears on /portal

### DIFF
--- a/templates/hermes/user-guide.md
+++ b/templates/hermes/user-guide.md
@@ -1,0 +1,67 @@
+---
+lucide_icon: "bot"
+tagline: "A self-improving AI agent that lives on your home server — chat with it on Signal / Telegram / Discord, or via the web dashboard."
+recommended_apps:
+  - name: "Signal"
+    url: "https://signal.org/"
+    platforms: ["ios", "android", "desktop"]
+    note: "Chat with Hermes from any device — the agent runs your local LLM, the chat is end-to-end encrypted on the messaging side. Set up the Signal gateway in the dashboard."
+  - name: "Telegram"
+    url: "https://telegram.org/"
+    platforms: ["ios", "android", "desktop"]
+    note: "Same idea as Signal — talk to Hermes from a chat app you already use. Bridge configured under Gateways in the dashboard."
+---
+
+# Getting started with Hermes
+
+Hermes is an autonomous agent — it remembers conversations, can run
+small scripts, and talks to whichever LLM you point it at. By default
+it points at the **Ollama** container on this server, so everything
+stays local: no cloud LLM bills, no chats leaving the house.
+
+## Open the dashboard
+
+The *Open* button on this card lands at the Hermes web dashboard.
+That's where you:
+
+- pick which LLM model to use (Ollama models you've pulled show up
+  in the dropdown),
+- bridge chat platforms (Signal / Telegram / Discord) so you can
+  message the agent from your phone,
+- see the agent's memory + recent thoughts,
+- get an API key for scripts that want to talk to Hermes directly.
+
+## Bridging a chat platform
+
+The most common setup is **Signal**:
+
+1. In the dashboard, open *Gateways → Signal*.
+2. The dashboard walks you through linking a phone number Hermes can
+   use. Use a number that isn't your personal one — a Twilio number
+   or a free secondary SIM works well.
+3. Once linked, send Hermes a message from your own Signal account.
+   It'll reply within a few seconds.
+
+The same flow works for Telegram and Discord — different chat app,
+same gateway pattern.
+
+## Picking an LLM
+
+Hermes defaults to **`gemma3:4b`** on Ollama — small enough to run on
+a homelab CPU, smart enough to handle daily-driver conversations.
+If you have a GPU and want more capable answers, pull a bigger model
+from the *Models* page on the Ollama portal card and switch Hermes
+to it in *Settings → LLM Provider*.
+
+## Privacy
+
+Everything Hermes processes stays on this server:
+
+- conversation history sits in the local SQLite under
+  `/mnt/data/stacks/hermes`,
+- LLM inference runs in the Ollama container (also local),
+- the chat-platform bridge only talks to Signal/Telegram/Discord
+  on outbound traffic.
+
+No analytics, no third-party telemetry — the agent's own logs are
+the only record.


### PR DESCRIPTION
## Symptom
`hermes` is installed + running + reachable at `hermes.dopp.cloud`, but the family /portal grid was missing its card.

## Why
`buildPortalCards` in `packages/backend/src/lib/portal/services.ts` only emits a card for templates that have a `user-guide.md` (`if (!parsed) continue` at line 195). Hermes shipped without one.

## What this PR ships
A frontmatter + body guide tailored to the operator's first-time experience:

- Tagline + lucide icon (`bot`) in YAML frontmatter so the card has chrome.
- Recommended apps: Signal + Telegram for the chat-bridge flow.
- Body walks through opening the dashboard, bridging a chat platform, picking an LLM model, and the privacy story (all local).

Verified live (cp'd into the running container, no restart needed):
`/portal` now lists `hermes.dopp.cloud` alongside vault / photos / books / files / sync / caldav / zwave.

## Out of scope (separate bugs surfaced while debugging)
- `media` template guide references `NAVIDROME_SUBDOMAIN` but Jellyfin uses `JELLYFIN_SUBDOMAIN` — `music.dopp.cloud` card never appears.
- `home-assistant` user-guide uses the implicit-single-card path; `firstSubdomainVar` picks ZWAVE_SUBDOMAIN over HASS_SUBDOMAIN (alphabetical-ish), so the HA card lands at zwave.dopp.cloud and the main `home.dopp.cloud` is unreachable from the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)