### PR TITLE
fix(network): declared edges carry target's primary port + HA→voice dep

### DIFF
--- a/packages/backend/src/lib/network/service.ts
+++ b/packages/backend/src/lib/network/service.ts
@@ -2017,21 +2017,57 @@ export class NetworkService {
         serviceByBase.set(base, svc.name);
       }
 
+      // Resolve a service's rendered pod-manifest yaml, following the
+      // .kube → Yaml= → .yml chain (same path serviceViewModel.ts uses).
+      // Returns null if any link in the chain is missing.
+      const readRenderedYaml = (baseName: string): string | null => {
+        const kubeKey = Object.keys(fileMap).find(k => k.endsWith(`/${baseName}.kube`));
+        if (!kubeKey) return null;
+        const kubeContent = fileMap[kubeKey]?.content;
+        if (!kubeContent) return null;
+        const yamlMatch = kubeContent.match(/^Yaml=(.+)$/m);
+        if (!yamlMatch) return null;
+        const yamlFileName = yamlMatch[1].trim();
+        const yamlKey = Object.keys(fileMap).find(k => k.endsWith(`/${yamlFileName}`));
+        if (!yamlKey) return null;
+        return fileMap[yamlKey]?.content ?? null;
+      };
+
+      // Parse the first TCP port out of `servicebay.ports` so a declared
+      // edge carries the port consumers actually talk to. Templates that
+      // expose multiple ports list the consumer-facing one first by
+      // convention (e.g. `auth` puts AUTHELIA_PORT before LLDAP_PORT
+      // because cross-pod consumers are doing OIDC / forward-auth, not
+      // LDAP binds — see templates/auth/template.yml). Returns 0 when
+      // the annotation is missing or has no TCP entry.
+      const readPrimaryTcpPort = (yamlContent: string): number => {
+        const m = yamlContent.match(/servicebay\.ports:\s*['"]?([^\n'"]+)['"]?/);
+        if (!m) return 0;
+        for (const entry of m[1].split(',')) {
+          const [portStr, proto] = entry.trim().split('/');
+          const port = Number.parseInt(portStr, 10);
+          if (Number.isFinite(port) && port > 0 && (!proto || proto === 'tcp')) {
+            return port;
+          }
+        }
+        return 0;
+      };
+
+      // Cache target → port so the inner loop doesn't re-parse for every
+      // dependency declaration pointing at the same target.
+      const portByTargetBase = new Map<string, number>();
+      const portFor = (baseName: string): number => {
+        if (portByTargetBase.has(baseName)) return portByTargetBase.get(baseName)!;
+        const yaml = readRenderedYaml(baseName);
+        const port = yaml ? readPrimaryTcpPort(yaml) : 0;
+        portByTargetBase.set(baseName, port);
+        return port;
+      };
+
       for (const svc of services) {
         if (!svc.isManaged) continue;
         const base = svc.name.replace(/\.service$/, '');
-        // Find the .kube file, follow its Yaml= directive to the rendered
-        // pod manifest — same chain as serviceViewModel.ts.
-        const kubeKey = Object.keys(fileMap).find(k => k.endsWith(`/${base}.kube`));
-        if (!kubeKey) continue;
-        const kubeContent = fileMap[kubeKey]?.content;
-        if (!kubeContent) continue;
-        const yamlMatch = kubeContent.match(/^Yaml=(.+)$/m);
-        if (!yamlMatch) continue;
-        const yamlFileName = yamlMatch[1].trim();
-        const yamlKey = Object.keys(fileMap).find(k => k.endsWith(`/${yamlFileName}`));
-        if (!yamlKey) continue;
-        const yamlContent = fileMap[yamlKey]?.content;
+        const yamlContent = readRenderedYaml(base);
         if (!yamlContent) continue;
 
         const deps = parseTemplateDependencies(yamlContent);
@@ -2046,15 +2082,17 @@ export class NetworkService {
           const dstId = prefix(`service-${depServiceName}`);
           if (!nodeIds.has(dstId)) continue;
           if (srcId === dstId) continue;
+          const targetPort = portFor(depBase);
           mergedEdges.push({
             id: `declared-${srcId}-${dstId}`,
             source: srcId,
             target: dstId,
-            label: 'declared',
+            // Label drives the on-edge text; the FE's `labelForEdgeKind`
+            // adds the "(declared)" suffix when kind === 'declared', so
+            // a non-empty label here becomes e.g. "9091 (declared)".
+            label: targetPort > 0 ? `${targetPort}` : 'declared',
             protocol: 'tcp',
-            // No specific port for an annotation-level "X depends on Y";
-            // the renderer omits the port label for `declared` edges.
-            port: 0,
+            port: targetPort,
             state: 'active',
             kind: 'declared',
           });

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -13,7 +13,12 @@ metadata:
     # a future ServiceBay renames or restructures those endpoints.
     servicebay.requires-api.lldap: "1"
     servicebay.requires-api.authelia: "1"
-    servicebay.ports: "{{LLDAP_PORT}}/tcp,{{LLDAP_LDAP_PORT}}/tcp,{{AUTHELIA_PORT}}/tcp"
+    # AUTHELIA_PORT first because that's the port every cross-pod
+    # consumer talks to (OIDC discovery, forward-auth). When the
+    # network map renders a `declared` edge into `auth`, picking the
+    # first port shows that consumer-facing port instead of the
+    # admin-only LLDAP web UI port. (#880-followup)
+    servicebay.ports: "{{AUTHELIA_PORT}}/tcp,{{LLDAP_PORT}}/tcp,{{LLDAP_LDAP_PORT}}/tcp"
     # Pin the configuration.yml.mustache target to authelia's /config mount —
     # without this the wizard's path resolver would also consider lldap's
     # mounts and pick whichever lands first in the parsed YAML.

--- a/templates/hermes/user-guide.md
+++ b/templates/hermes/user-guide.md
@@ -1,0 +1,67 @@
+---
+lucide_icon: "bot"
+tagline: "A self-improving AI agent that lives on your home server — chat with it on Signal / Telegram / Discord, or via the web dashboard."
+recommended_apps:
+  - name: "Signal"
+    url: "https://signal.org/"
+    platforms: ["ios", "android", "desktop"]
+    note: "Chat with Hermes from any device — the agent runs your local LLM, the chat is end-to-end encrypted on the messaging side. Set up the Signal gateway in the dashboard."
+  - name: "Telegram"
+    url: "https://telegram.org/"
+    platforms: ["ios", "android", "desktop"]
+    note: "Same idea as Signal — talk to Hermes from a chat app you already use. Bridge configured under Gateways in the dashboard."
+---
+
+# Getting started with Hermes
+
+Hermes is an autonomous agent — it remembers conversations, can run
+small scripts, and talks to whichever LLM you point it at. By default
+it points at the **Ollama** container on this server, so everything
+stays local: no cloud LLM bills, no chats leaving the house.
+
+## Open the dashboard
+
+The *Open* button on this card lands at the Hermes web dashboard.
+That's where you:
+
+- pick which LLM model to use (Ollama models you've pulled show up
+  in the dropdown),
+- bridge chat platforms (Signal / Telegram / Discord) so you can
+  message the agent from your phone,
+- see the agent's memory + recent thoughts,
+- get an API key for scripts that want to talk to Hermes directly.
+
+## Bridging a chat platform
+
+The most common setup is **Signal**:
+
+1. In the dashboard, open *Gateways → Signal*.
+2. The dashboard walks you through linking a phone number Hermes can
+   use. Use a number that isn't your personal one — a Twilio number
+   or a free secondary SIM works well.
+3. Once linked, send Hermes a message from your own Signal account.
+   It'll reply within a few seconds.
+
+The same flow works for Telegram and Discord — different chat app,
+same gateway pattern.
+
+## Picking an LLM
+
+Hermes defaults to **`gemma3:4b`** on Ollama — small enough to run on
+a homelab CPU, smart enough to handle daily-driver conversations.
+If you have a GPU and want more capable answers, pull a bigger model
+from the *Models* page on the Ollama portal card and switch Hermes
+to it in *Settings → LLM Provider*.
+
+## Privacy
+
+Everything Hermes processes stays on this server:
+
+- conversation history sits in the local SQLite under
+  `/mnt/data/stacks/hermes`,
+- LLM inference runs in the Ollama container (also local),
+- the chat-platform bridge only talks to Signal/Telegram/Discord
+  on outbound traffic.
+
+No analytics, no third-party telemetry — the agent's own logs are
+the only record.

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -7,9 +7,11 @@ metadata:
   annotations:
     servicebay.label: "Home Assistant"
     servicebay.schema-version: "6"
-    # Home Assistant is reached at home.<domain> via nginx, and (when
-    # the operator enables it) authenticates via Authelia.
-    servicebay.dependencies: "nginx,auth"
+    # Home Assistant is reached at home.<domain> via nginx, authenticates
+    # via Authelia, and talks to Wyoming-protocol STT/TTS on the voice
+    # pod (port 10300). Declaring `voice` makes the network map render
+    # the dependency even before any TCP flow is sampled.
+    servicebay.dependencies: "nginx,auth,voice"
     servicebay.config-mount: "/config"
     servicebay.ports: "8123/tcp,8091/tcp,3001/tcp"
     # Continuous health probe (#628). `/manifest.json` is the PWA


### PR DESCRIPTION
## Symptom

Two regressions on the network map surfaced by the operator post-#813 / #862:

1. **Home Assistant doesn't show a connection to `voice`.** HA talks Wyoming-protocol STT/TTS to the voice pod on port 10300, but HA's `servicebay.dependencies` annotation was only `"nginx,auth"` — voice was omitted, so no `declared` edge appeared until the observed-flow sampler caught the first TCP flow.
2. **Declared edges into multi-port targets (auth) rendered as `(declared)` with no port.** The synthesiser in #862 hard-coded `port: 0` because "X depends on Y" has no single canonical port — but on the map, an edge without a port reads as less informative than the observed half. Operators debugging an OIDC handshake want to see `9091` next to the line.

## Fix

- **`templates/home-assistant/template.yml`** — `servicebay.dependencies` now lists `"nginx,auth,voice"`.
- **`templates/auth/template.yml`** — reorder `servicebay.ports` so `AUTHELIA_PORT` (9091) is first. That's the consumer-facing port for OIDC + forward-auth, while LLDAP_PORT / LLDAP_LDAP_PORT are admin- and intra-pod-only. The "first TCP port" heuristic in the network code picks the first entry; templates already lined up that way by convention (voice's 10300 Wyoming STT first, immich's IMMICH_PORT first, etc.) — auth was the outlier.
- **`packages/backend/src/lib/network/service.ts`** — declared-edge synthesis now reads each target's rendered pod-manifest yaml, parses `servicebay.ports`, and picks the first TCP port as the edge's `port` + `label`. Cached per target so a stack of N templates declaring `auth` as a dep doesn't re-parse `auth.yml` N times. Falls back to the old "no port, label 'declared'" shape when the annotation is missing.

After the change the network map renders `9091 (declared)` for every OIDC / forward-auth consumer → `auth` edge, and HA → voice appears from install onward instead of waiting for the sampler.

## Test plan
- [x] `tsc --noEmit` + full vitest — 1243 pass.
- [ ] Manual after deploy: open /network and confirm `9091 (declared)` on edges into auth + HA → voice edge is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)