### PR TITLE
fix(network): substitute 0.0.0.0 / 127.0.0.1 with the node's reachable IP

### DIFF
--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -259,7 +259,7 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
         let ip: string | null = null;
         let hostPort: number | string | null = null;
         let containerPort: number | string | null = null;
-        
+
         if (isObj) {
             const portObj = p as LegacyPortMapping;
             ip = portObj.hostIp || portObj.IP || null;
@@ -270,6 +270,20 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
             const val = p as unknown as (string | number);
             hostPort = val;
             containerPort = val; // Assume symmetry if simple number
+        }
+
+        // Podman reports `0.0.0.0` (bind-all) and `127.0.0.1` (loopback)
+        // verbatim, but rendering them on the card tells the operator
+        // nothing about where to actually reach the service — and the
+        // dedup-to-globalIp logic below was hoisting `0.0.0.0` up as
+        // the headline IP. Normalize to the node's reachable host
+        // address (LAN IP) at parse time so every downstream display
+        // (`globalIp`, per-port tag label, and the link's hostname)
+        // shows the real address.
+        const nodeHost = typeof data.metadata?.nodeHost === 'string' ? data.metadata.nodeHost as string : null;
+        const fallbackHost = nodeHost || (data.node && data.node !== 'local' && data.node !== 'Local' ? data.node : null);
+        if (fallbackHost && (ip === '0.0.0.0' || ip === '127.0.0.1' || ip === 'localhost')) {
+            ip = fallbackHost;
         }
 
         return {


### PR DESCRIPTION
## Symptom
Network-map cards displayed the headline IP and every per-port tag as `0.0.0.0:<port>`, leaving the operator without a usable address to reach the service.

## Why
Podman reports `HostIp: 0.0.0.0` for any container that doesn't explicitly pin its bind address — which is most of them. The cards' `extractIpInfo` parsed that literal into `globalIp` and per-port `ip` fields. The link `href` already substituted `nodeHost` for `0.0.0.0` (line 635 in the same file), but the visible label was the un-substituted value.

## Fix
`extractIpInfo` now normalizes at parse time: when `hostIp` is `0.0.0.0` / `127.0.0.1` / `localhost` and the node carries a reachable host (`data.metadata.nodeHost`, fallback `data.node`), the parsed `ip` becomes that reachable host. All downstream displays — global IP chip on the card, per-port tag labels, and the link's `href` — now read the same address.

When no node host is known (rare — an unmanaged container on a node ServiceBay can't reach), the original `0.0.0.0` flows through so the operator still sees what podman reported instead of a misleading substitution.

## Test plan
- [x] `tsc --noEmit` + full vitest — 1243 pass.
- [ ] Manual: open /network and confirm every card whose port previously showed `0.0.0.0:<port>` now shows `192.168.178.100:<port>` (or whatever the node's LAN IP is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)