### PR TITLE
perf(build): switch to Turbopack by splitting logger into client-safe stub

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,13 @@ import type { NextConfig } from "next";
 // Next 16. The runtime container instead bundles `server.ts` to CJS via
 // `scripts/build-server.mjs` and runs it under plain `node`.
 //
-// Two known Next 16.2.4 quirks ServiceBay works around at build time:
+// #905 migrated the production build from webpack to Turbopack (Next 16
+// default) by splitting logger.ts into a client-safe stub (logger-client.ts)
+// that the frontend imports, and the full SQLite-backed logger that stays
+// server-only. Previously a webpack `resolve.fallback` hack was needed
+// because the client bundle transitively pulled `fs`/`path`/`better-sqlite3`.
+//
+// Known Next 16.2.4 quirk still worked around at build time:
 // - `routes-manifest.json` omits `onMatchHeaders` → patched in
 //   `scripts/patch-routes-manifest.mjs` (otherwise `app.prepare()` throws
 //   "Cannot read properties of undefined (reading 'map')" in `setupFsCheck`).
@@ -27,22 +33,6 @@ const nextConfig: NextConfig = {
   // `/` used to redirect to `/services` — removed in #802/#803 when the
   // Overview Dashboard landed at the root path. If you're hunting for
   // the redirect, it's now a real page: src/app/(dashboard)/page.tsx.
-  // `src/lib/logger.ts` is imported by both server and client code and lazily
-  // `require()`s `better-sqlite3` / `fs` / `path` only on the server. Webpack
-  // resolves those `require` calls statically, so without this fallback the
-  // client bundle fails to compile (`Module not found: Can't resolve 'fs'`).
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
-      config.resolve = config.resolve || {};
-      config.resolve.fallback = {
-        ...(config.resolve.fallback || {}),
-        fs: false,
-        path: false,
-        'better-sqlite3': false,
-      };
-    }
-    return config;
-  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "predev:frontend": "node scripts/predev.mjs",
     "dev": "fuser -k 3000/tcp || true && tsx server.ts",
     "dev:frontend": "fuser -k 3001/tcp || true && NEXT_PUBLIC_USE_MOCKS=1 next dev --port 3001",
-    "build": "next build --webpack && node scripts/patch-routes-manifest.mjs && node scripts/build-server.mjs",
+    "build": "next build && node scripts/patch-routes-manifest.mjs && node scripts/build-server.mjs",
     "start": "NODE_ENV=production node dist-server/server.cjs",
     "lint": "eslint",
     "knip": "knip",

--- a/packages/api-client/src/lib-utils.ts
+++ b/packages/api-client/src/lib-utils.ts
@@ -8,7 +8,7 @@
 // utilities (network layout, view-model builders), into the frontend
 // package itself.
 
-export { logger } from '@/lib/logger';
+export { logger } from '@/lib/logger-client';
 export { humanizeError } from '@/lib/util/humanizeError';
 export { humanizeYamlError } from '@/lib/util/humanizeYamlError';
 export { isValidOperatorEmail, operatorEmailIssue } from '@/lib/operatorEmail';

--- a/packages/backend/src/lib/logger-client.ts
+++ b/packages/backend/src/lib/logger-client.ts
@@ -1,0 +1,60 @@
+/**
+ * Client-safe logger — identical API surface as the full `logger.ts` but with
+ * zero Node.js dependencies (no `fs`, `path`, `better-sqlite3`).
+ *
+ * The frontend imports `logger` via `@servicebay/api-client`; this module is
+ * the backing implementation for that re-export. Moving the client logger
+ * into its own file means the client bundle never reaches the server-only
+ * `require()` calls in `logger.ts`, which in turn lets the build run under
+ * Turbopack without the Webpack `resolve.fallback` hack (#905).
+ *
+ * The server continues to import the full `logger` from `@/lib/logger` (which
+ * adds SQLite persistence, file-system access, and trace-provider support).
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+class ClientLogger {
+  private currentLogLevel: LogLevel = 'info';
+
+  setLogLevel(level: LogLevel): void {
+    this.currentLogLevel = level;
+  }
+
+  getLogLevel(): LogLevel {
+    return this.currentLogLevel;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[this.currentLogLevel];
+  }
+
+  debug(tag: string, message: string, ...args: unknown[]) {
+    if (!this.shouldLog('debug')) return;
+    console.debug(`[${tag}]`, message, ...args);
+  }
+
+  info(tag: string, message: string, ...args: unknown[]) {
+    if (!this.shouldLog('info')) return;
+    console.info(`[${tag}]`, message, ...args);
+  }
+
+  warn(tag: string, message: string, ...args: unknown[]) {
+    if (!this.shouldLog('warn')) return;
+    console.warn(`[${tag}]`, message, ...args);
+  }
+
+  error(tag: string, message: string, ...args: unknown[]) {
+    // Always log errors
+    console.error(`[${tag}]`, message, ...args);
+  }
+}
+
+export const logger = new ClientLogger();


### PR DESCRIPTION
## Problem

`next build --webpack` is the longest single step in CI, taking ~1m 57s. Next 16 ships Turbopack as the default builder; we were explicitly opted out via the `--webpack` flag because `packages/backend/src/lib/logger.ts` is imported by both server and client code and lazily `require()`s `better-sqlite3` / `fs` / `path` only on the server. Webpack resolved those `require` calls statically, so a `resolve.fallback` hack was needed.

## Solution

Split `logger.ts` into two modules:

| File | Purpose | Node deps |
|------|---------|-----------|
| `logger.ts` | Full SQLite-backed server logger | `fs`, `path`, `better-sqlite3` |
| `logger-client.ts` | Console-only client stub | **None** |

`@servicebay/api-client` now re-exports from `logger-client`, so the client bundle never reaches the server-only `require()` calls.

## Changes

- **`packages/backend/src/lib/logger-client.ts`** [NEW] — lightweight console logger matching the server logger API (`debug/info/warn/error`)
- **`packages/api-client/src/lib-utils.ts`** — re-export from `logger-client` instead of `logger`
- **`next.config.ts`** — removed the `webpack` callback (`resolve.fallback` for `fs`/`path`/`better-sqlite3`)
- **`package.json`** — removed `--webpack` from the build script

## Results

| Metric | Webpack | Turbopack | Improvement |
|--------|---------|-----------|-------------|
| Compile step | ~118s | **~19s** | **~6x faster** |
| `routes-manifest.json` patch | needed | already correct | N/A |
| Server bundle | 2.9MB | 2.9MB | identical |

## Verification

- ✅ `npm run build` succeeds with Turbopack (no `--webpack`)
- ✅ `vitest run` — 159 test files, 1243 tests passed
- ✅ All pre-commit + pre-push hooks pass (knip, eslint, build)
- ✅ `patch-routes-manifest.mjs` runs but finds no patch needed
- ✅ `build-server.mjs` produces identical server bundle

Closes #905