### PR TITLE
fix(fcos): drop double-dollar escape in install-nvidia.sh template

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -744,7 +744,7 @@ ${SERVICEBAY_SSH_PRIV}
               exit 0
           fi
 
-          FEDORA_VERSION=$$(/usr/bin/rpm -E %fedora)
+          FEDORA_VERSION=$(/usr/bin/rpm -E %fedora)
 
           # Stage 1: layer the packages. RPM Fusion ships the driver
           # build; `nvidia-container-toolkit` provides `nvidia-ctk` for
@@ -755,8 +755,8 @@ ${SERVICEBAY_SSH_PRIV}
           if [ ! -f /var/lib/install-nvidia-driver-done ]; then
               echo "install-nvidia: layering NVIDIA driver + container toolkit..."
               /usr/bin/rpm-ostree install --idempotent --allow-inactive \
-                  "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$${FEDORA_VERSION}.noarch.rpm" \
-                  "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$${FEDORA_VERSION}.noarch.rpm"
+                  "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VERSION}.noarch.rpm" \
+                  "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VERSION}.noarch.rpm"
               /usr/bin/rpm-ostree install --idempotent --allow-inactive \
                   kmod-nvidia-open-dkms \
                   xorg-x11-drv-nvidia-cuda \
@@ -773,7 +773,7 @@ ${SERVICEBAY_SSH_PRIV}
           # generate the CDI config that podman reads for GPU passthrough.
           if [ ! -f /var/lib/install-nvidia-cdi-done ]; then
               echo "install-nvidia: stage 2 — checking nvidia kernel module..."
-              for i in $$(/usr/bin/seq 1 30); do
+              for i in $(/usr/bin/seq 1 30); do
                   if /usr/sbin/lsmod | grep -q '^nvidia '; then break; fi
                   sleep 2
               done


### PR DESCRIPTION
## Symptom

On the live RTX 2000 Ada box, after FCOS first boot:

\`\`\`
[systemd] Failed Units: 1
  install-nvidia.service
\`\`\`

\`journalctl -u install-nvidia.service\`:

\`\`\`
/usr/local/bin/install-nvidia.sh: line 13: syntax error near unexpected token \`(\`
install-nvidia.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
\`\`\`

Net effect: no driver layered, no \`nvidia-container-toolkit\`, no \`/etc/cdi/nvidia.yaml\`, kernel module never loads — the RTX 2000 Ada is invisible to podman even though \`lspci\` sees it.

## Root cause

\`install-fedora-coreos.sh\` emits the entire .bu via \`cat <<'EOF'\` (single-quoted heredoc → literal text) and renders it with \`envsubst\` using a whitelist that doesn't include \`FEDORA_VERSION\`. Both stages pass \`$$\` through unchanged, so the on-disk script is \`$$(/usr/bin/rpm -E %fedora)\` — bash reads \`$$\` as the PID, then \`(\` is unexpected.

Other inline scripts in the same heredoc (\`install-python.sh\`, \`setup-raid.sh\`, \`usb-mount.sh\`, \`install-nginx.sh\`) all use plain \`$\` and work; only this one over-escaped.

\`scripts/enable-nvidia.sh\` (the one-shot recovery for existing hosts) already uses plain \`$\` correctly.

## Fix

Replace \`$$\` with \`$\` in the four affected lines of the \`install-nvidia.sh\` inline content.

## Verification

- Local: \`grep '\$\$' install-fedora-coreos.sh\` in the install-nvidia block returns nothing.
- Live host (this RTX 2000 Ada): tracked separately — running \`scripts/enable-nvidia.sh\` to recover the existing install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)