### PR TITLE
fix(install): self-heal three reinstall regressions

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -23,6 +23,7 @@
  * restart by design: any job in an active phase at startup is flipped to
  * `crashed` by `jobStore.markCrashedOnStartup()` (see server.ts).
  */
+import crypto from 'node:crypto';
 import Mustache from 'mustache';
 // Direct lib imports (#600) — the actions.ts wrappers are RPC bridges
 // for client components, not appropriate for server-side lib code.
@@ -831,40 +832,75 @@ async function runJob(jobId: string): Promise<void> {
   }
 
   // Authelia storage self-heal — Authelia encrypts its SQLite storage
-  // with AUTHELIA_STORAGE_ENCRYPTION_KEY. If the wizard regenerates the
-  // key (no saved value to reuse) but the preserved `authelia-data` dir
-  // still holds rows encrypted with the previous install's key,
-  // Authelia comes up returning 500 on every route — including the
-  // readiness probe's OIDC discovery endpoint. Without intervention the
-  // install times out 5 min later with no breadcrumb the operator can
-  // act on.
+  // with AUTHELIA_STORAGE_ENCRYPTION_KEY. If the data dir survives a
+  // reinstall but the new key doesn't match what encrypted that data,
+  // Authelia crashes on startup ("encryption key does not appear to be
+  // valid for this database") and loops indefinitely.
   //
-  // When we detect this case (auth is being deployed, AUTHELIA_STORAGE_
-  // ENCRYPTION_KEY is *not* in the reused-from-saved set, and the data
-  // dir has content), wipe `authelia-data/` only. LLDAP user accounts
-  // at the sibling `auth/lldap` host path are preserved — that's the
-  // identity state operators actually care about. The wizard's
-  // post-deploy re-seeds Authelia's OIDC clients + storage schema from
-  // scratch.
+  // We track a SHA-256 fingerprint of the encryption key in a sidecar
+  // file (`.sb-key-fingerprint`) inside the data dir. On every install
+  // where auth is being deployed:
+  //   - If the fingerprint file matches the new key → keep the data.
+  //   - If it exists and differs → wipe (real mismatch, Authelia would crash).
+  //   - If it's missing → fall back to the legacy heuristic: wipe iff
+  //     the data dir has content AND the key was freshly generated
+  //     (not reused from savedSecrets). This covers pre-fingerprint
+  //     upgrades.
+  // After deciding, write the new fingerprint so the next install can
+  // check it. LLDAP user accounts at the sibling `auth/lldap` host
+  // path are preserved either way.
   const authIncluded = selected.some(s => s.name === 'auth' && !s.alreadyInstalled);
-  if (authIncluded && !reusedSecretNames.has('AUTHELIA_STORAGE_ENCRYPTION_KEY')) {
+  if (authIncluded) {
     try {
       const { agentManager } = await import('@/lib/agent/manager');
       const { getConfig } = await import('@/lib/config');
       const cfg = await getConfig();
       const dataDir = cfg.templateSettings?.DATA_DIR || '/mnt/data/stacks';
       const autheliaDataPath = `${dataDir}/auth/authelia-data`;
+      const fingerprintPath = `${autheliaDataPath}/.sb-key-fingerprint`;
+      const newKey = input.variables.find(v => v.name === 'AUTHELIA_STORAGE_ENCRYPTION_KEY')?.value || '';
+      const newFp = newKey
+        ? crypto.createHash('sha256').update(newKey).digest('hex')
+        : '';
       const node = input.node || 'Local';
       const agent = await agentManager.ensureAgent(node);
+      // Probe both the fingerprint and any other content in the dir in
+      // one round-trip. Output format: "FP=<hex|>\nCONTENT=<something|>"
       const probe = await agent.sendCommand('exec', {
-        command: `[ -d "${autheliaDataPath}" ] && find "${autheliaDataPath}" -mindepth 1 -maxdepth 1 | head -1 || true`,
+        command:
+          `printf 'FP=%s\\n' "$(cat "${fingerprintPath}" 2>/dev/null || true)"; ` +
+          `printf 'CONTENT=%s\\n' "$([ -d "${autheliaDataPath}" ] && find "${autheliaDataPath}" -mindepth 1 -maxdepth 1 -not -name .sb-key-fingerprint | head -1 || true)"`,
       });
-      const hasContent = !!(probe.stdout || '').trim();
-      if (hasContent) {
-        await log(jobId, `🔄 Wiping Authelia storage at ${autheliaDataPath} — the encryption key is freshly generated and would mismatch the preserved storage (LLDAP users at ${dataDir}/auth/lldap are kept).`);
+      const out = probe.stdout || '';
+      const recordedFp = (out.match(/^FP=([a-f0-9]{64})$/m)?.[1] || '').trim();
+      const hasContent = !!(out.match(/^CONTENT=(.+)$/m)?.[1] || '').trim();
+      let shouldWipe = false;
+      let reason = '';
+      if (recordedFp) {
+        if (newFp && recordedFp !== newFp) {
+          shouldWipe = true;
+          reason = 'encryption-key fingerprint changed since the last successful deploy';
+        }
+      } else if (hasContent && !reusedSecretNames.has('AUTHELIA_STORAGE_ENCRYPTION_KEY')) {
+        // Legacy path: no fingerprint recorded (pre-fix install) but data
+        // exists and the new key isn't from savedSecrets — almost certainly
+        // a key mismatch.
+        shouldWipe = true;
+        reason = 'data dir has content, encryption key was freshly generated, and no fingerprint exists to prove the key matches';
+      }
+      if (shouldWipe) {
+        await log(jobId, `🔄 Wiping Authelia storage at ${autheliaDataPath} — ${reason} (LLDAP users at ${dataDir}/auth/lldap are kept).`);
         await agent.sendCommand('exec', { command: `rm -rf "${autheliaDataPath}"` });
-        await agent.sendCommand('exec', { command: `mkdir -p "${autheliaDataPath}" && chown core:core "${autheliaDataPath}"` });
-        await log(jobId, `✅ Authelia storage cleared and recreated. Authelia will bootstrap fresh on first start.`);
+        await log(jobId, `✅ Authelia storage cleared. Authelia will bootstrap fresh on first start.`);
+      }
+      // Always (re)create the dir and stamp the new fingerprint. Done
+      // after a potential wipe so it lands in the recreated dir.
+      if (newFp) {
+        await agent.sendCommand('exec', {
+          command:
+            `mkdir -p "${autheliaDataPath}" && chown core:core "${autheliaDataPath}" && ` +
+            `printf '%s\\n' "${newFp}" > "${fingerprintPath}"`,
+        });
       }
     } catch (e) {
       // Best-effort: if probe/wipe fails the install will hit the

--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 import urllib.error
@@ -69,31 +70,48 @@ def main() -> int:
     host = env("HOST", "<server-ip>")
 
     # ── Syncthing GUI host-check ───────────────────────────────────────
-    # Syncthing's GUI defaults to allowing the bind address only as a
-    # Host: header. NPM forwards `sync.<PUBLIC_DOMAIN>` and Syncthing
-    # rejects with HTTP 403 `Host check error`. STGUIHOSTCHECK isn't a
-    # real env var; only the config.xml `<insecureSkipHostcheck>` child
-    # element disables the check. We patch it idempotently here so a
-    # fresh install or a re-deploy lands the right config without
-    # waiting for the operator to do it manually. (#880)
+    # Syncthing's GUI rejects Host headers other than the bind address
+    # with HTTP 403 "Host check error" — NPM forwards `sync.<PUBLIC_DOMAIN>`
+    # → instant 403 until the check is disabled.
+    #
+    # Approach in Syncthing v2: wait for config.xml + apikey to exist (the
+    # container creates them on first start, not before), then issue the
+    # change via `syncthing cli config gui insecure-skip-host-check set true`
+    # which writes through the live API. An XML-only edit (sed) lands the
+    # attribute but Syncthing v2 doesn't honour it across restarts;
+    # the CLI is the only reliable path. (#880, fixed for v2 in
+    # follow-up to install-self-heal-batch.)
     syncthing_config_xml = "/var/syncthing/config/config.xml"
-    patch_syncthing_cmd = (
-        "podman exec file-share-syncthing sh -c "
-        "'grep -q insecureSkipHostcheck " + syncthing_config_xml + " || "
-        "sed -i \"s|<address>127.0.0.1:8384</address>|<address>127.0.0.1:8384</address>"
-        "\\n        <insecureSkipHostcheck>true</insecureSkipHostcheck>|\" "
-        + syncthing_config_xml + "'"
-    )
-    rc = os.system(patch_syncthing_cmd)
-    if rc == 0:
-        # Syncthing reloads config.xml on SIGHUP but not on a plain file
-        # write; restart the container to pick up the new setting. The
-        # subsequent Samba/FileBrowser steps don't depend on Syncthing
-        # so a short window where Syncthing is restarting is harmless.
-        os.system("podman restart file-share-syncthing > /dev/null 2>&1 || true")
-        log("✅ Syncthing GUI host-check disabled (config.xml patched).")
+    apikey = ""
+    for _ in range(40):  # ~60s, covers cold-cache first start
+        # Read the apikey out of config.xml in a single shell — sed prints
+        # the captured group when the line is present, or nothing when the
+        # file doesn't yet exist / has no apikey. Empty stdout means
+        # "not ready" and we sleep + retry.
+        probe = subprocess.run(
+            ["podman", "exec", "file-share-syncthing", "sh", "-c",
+             f"sed -n 's|.*<apikey>\\(.*\\)</apikey>.*|\\1|p' {syncthing_config_xml} 2>/dev/null | head -1"],
+            capture_output=True, text=True, check=False,
+        )
+        candidate = (probe.stdout or "").strip()
+        if probe.returncode == 0 and candidate:
+            apikey = candidate
+            break
+        time.sleep(1.5)
+    if not apikey:
+        log("⚠️  Syncthing config.xml + apikey not present after 60s — skipping host-check patch. The sync.<domain> URL may return 403 'Host check error'; re-run this post-deploy from Diagnose once Syncthing is up.")
     else:
-        log("⚠️  Syncthing config patch returned a non-zero exit. The sync.<domain> URL may return 403 'Host check error' — fix manually in /var/syncthing/config/config.xml.")
+        cli = subprocess.run(
+            ["podman", "exec", "file-share-syncthing", "syncthing", "cli",
+             "--gui-address", "http://127.0.0.1:8384",
+             "--gui-apikey", apikey,
+             "config", "gui", "insecure-skip-host-check", "set", "true"],
+            capture_output=True, text=True, check=False,
+        )
+        if cli.returncode == 0:
+            log("✅ Syncthing GUI host-check disabled (live API).")
+        else:
+            log("⚠️  Syncthing CLI returned non-zero. The sync.<domain> URL may return 403 'Host check error' — fix manually with `syncthing cli config gui insecure-skip-host-check set true`.")
 
     # ── Samba ──────────────────────────────────────────────────────────
     share_user = env("SHARE_USER", "samba")

--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -192,14 +192,25 @@ def main() -> int:
         log(f"⚠️  Immich admin sign-up returned HTTP {code}: {body}. Continuing.")
 
     # 2. Log in to fetch a token for the system-config call.
-    code, body = request_json(
-        "POST",
-        f"{base_url}/api/auth/login",
-        {"email": admin_email, "password": admin_password},
-    )
-    token = body.get("accessToken") if isinstance(body, dict) else None
+    # `admin-sign-up` returns 200/201 the instant the row is written, but
+    # Immich's auth path occasionally rejects the immediate follow-up login
+    # with HTTP 401 while the user row is still propagating to the auth
+    # cache (observed in #TBD). Short retry loop rides through it.
+    code, body, token = 0, None, None
+    for attempt in range(8):  # ~20s with 2.5s backoff
+        code, body = request_json(
+            "POST",
+            f"{base_url}/api/auth/login",
+            {"email": admin_email, "password": admin_password},
+        )
+        token = body.get("accessToken") if isinstance(body, dict) else None
+        if code == 201 and token:
+            break
+        if attempt == 0:
+            log(f"   admin login attempt 1 returned HTTP {code} — retrying for ~20s while Immich settles...")
+        time.sleep(2.5)
     if code != 201 or not token:
-        log(f"⚠️  Could not log in as admin (HTTP {code}). Skipping OIDC config.")
+        log(f"⚠️  Could not log in as admin after 8 attempts (last HTTP {code}). Skipping OIDC config.")
         return 0
 
     # 3. Configure OAuth. Read-modify-write so we don't clobber any


### PR DESCRIPTION
## Symptom

Today's live-box reinstall hit three install-flow regressions that each required manual recovery:

1. **Authelia** crashed in a 5097-restart loop: \`the configured encryption key does not appear to be valid for this database\`. Existing auto-wipe logic at \`runner.ts:850\` was supposed to fire but didn't.
2. **Syncthing** \`sync.dopp.cloud\` returned 403 \`Host check error\`. The post-deploy patched \`config.xml\` before \`file-share-syncthing\` had created it; the install logged a warning and moved on.
3. **Immich** OIDC wasn't wired: \`Could not log in as admin (HTTP 401). Skipping OIDC config.\` The login fired the instant after \`admin-sign-up\` returned 201.

## Fix

| Issue | Root cause | Fix |
|---|---|---|
| Authelia stale-DB | wipe gated on a savedSecrets-reuse heuristic that can be wrong | write sha256(key) as a sidecar fingerprint inside \`authelia-data\`; on next install, wipe iff the recorded fingerprint disagrees with the new key. Legacy installs without a fingerprint fall through to the old heuristic. |
| Syncthing v2 race | sed-on-config-xml is fragile, file may not yet exist, attribute isn't honoured across restarts in v2 | poll \`subprocess.run\` for the apikey appearing in config.xml (~60s budget), then issue the change via \`syncthing cli config gui insecure-skip-host-check set true\` |
| Immich admin 401 | the sign-up row hasn't propagated to the auth cache when the immediate follow-up login fires | retry login up to 8× with 2.5s backoff (~20s total) |

## Verification

- \`python3 -m unittest tests/templates/test_post_deploy.py\` — 22 passed in 0.7s
- \`npx vitest run packages/backend/src/lib/install/runner.test.ts\` — 9 passed
- \`npx tsc --noEmit\` — clean

End-to-end: the live box hit all three today; after manual recovery, \`scripts/smoke/sso-verify.sh\` came back 23/23. Next reinstall (with this PR landed) should require zero manual recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)