### PR TITLE
fix(install): self-heal three more stale-data-dir regressions (#914)

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -1155,18 +1155,23 @@ async function runJob(jobId: string): Promise<void> {
     });
     let bootstrapState: 'ok' | 'needs_credentials' | 'skipped' = bootstrap;
 
-    // Self-heal on clean install with certs preserved (#704). The
-    // operator's data volume kept the OLD admin bcrypt; the wizard's
-    // INITIAL_ADMIN_PASSWORD env never overwrites an existing admin
-    // user. The pre-fix flow paused for the operator to type the old
-    // password — which they typically don't have (forgotten, never
-    // copied off the credentials banner). Auto-wipe the NPM data dir
-    // (admin sqlite + sites table) and retry bootstrap; letsencrypt/
-    // stays untouched so cert files survive — that's the only reason
-    // "preserve certs" exists in the first place.
+    // Self-heal whenever NPM rejects every credential we know about
+    // (#704, broadened in #TBD). The operator's data volume kept the
+    // OLD admin bcrypt; the wizard's INITIAL_ADMIN_PASSWORD env never
+    // overwrites an existing admin user. The pre-fix flow paused for
+    // the operator to type the old password — which they typically
+    // don't have (forgotten, never copied off the credentials banner).
+    // Auto-wipe the NPM data dir (admin sqlite + sites table) and
+    // retry bootstrap; letsencrypt/ stays untouched so cert files
+    // survive — that's the only reason "preserve certs" exists in the
+    // first place.
+    //
+    // Used to be gated on `input.cleanInstall` only — but the same
+    // mismatch happens on a regular re-install over a preserved data
+    // volume (e.g. swap an OS install, redeploy stacks). Both end with
+    // the same prompt-the-operator flow; auto-heal applies equally.
     if (
       bootstrapState === 'needs_credentials'
-      && input.cleanInstall
       && (input.preserve?.includes('certs') ?? true)
     ) {
       const node = input.node || 'Local';

--- a/src/app/api/system/media/init/route.ts
+++ b/src/app/api/system/media/init/route.ts
@@ -48,6 +48,25 @@ export const POST = withApiHandler({}, async ({ request }) => {
 });
 
 async function initAudiobookshelf(host: string, port: number, username: string, password: string) {
+  // Probe /status first — `isInit:true` means a root user already exists.
+  // ABS 2.x returns generic HTTP 500 with body "Internal Server Error" when
+  // /init is hit on an initialised server (the "already has a root user"
+  // log line stays inside the container), so the previous body-text match
+  // missed and the post-deploy spun for 5 minutes before timing out.
+  try {
+    const statusRes = await fetch(`http://${host}:${port}/status`, {
+      method: 'GET',
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (statusRes.ok) {
+      const status = await statusRes.json().catch(() => ({} as Record<string, unknown>));
+      if (status.isInit === true) return NextResponse.json({ alreadySetup: true });
+    }
+  } catch {
+    // /status itself failed — fall through to /init and let that report the
+    // actual error.
+  }
+
   const url = `http://${host}:${port}/init`;
   const res = await fetch(url, {
     method: 'POST',
@@ -56,8 +75,7 @@ async function initAudiobookshelf(host: string, port: number, username: string, 
     signal: AbortSignal.timeout(10_000),
   });
   if (res.ok) return NextResponse.json({ ok: true });
-  // 400/409 with "already" in the body means admin already exists — that's
-  // a normal state on a re-install over an existing data dir, not a failure.
+  // Body-text fallback for non-2.x or upstream message changes.
   const text = await res.text().catch(() => '');
   if (text.toLowerCase().includes('already') || res.status === 409) {
     return NextResponse.json({ alreadySetup: true });

--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -195,7 +195,16 @@ def main() -> int:
     # `admin-sign-up` returns 200/201 the instant the row is written, but
     # Immich's auth path occasionally rejects the immediate follow-up login
     # with HTTP 401 while the user row is still propagating to the auth
-    # cache (observed in #TBD). Short retry loop rides through it.
+    # cache. Short retry loop rides through that.
+    #
+    # A persistent 401 after retries means something different: the admin
+    # row pre-dates this install and was created with a different password
+    # (preserved data dir + freshly-generated IMMICH_ADMIN_PASSWORD that
+    # never made it into savedSecrets). There's no automatic recovery — Immich
+    # has no env-driven password reset and we don't have its DB credentials
+    # to write a new bcrypt. Degrade gracefully: skip OIDC, surface what the
+    # operator needs to know, exit zero (Immich is still reachable via
+    # Authelia forward-auth at the proxy layer).
     code, body, token = 0, None, None
     for attempt in range(8):  # ~20s with 2.5s backoff
         code, body = request_json(
@@ -210,7 +219,13 @@ def main() -> int:
             log(f"   admin login attempt 1 returned HTTP {code} — retrying for ~20s while Immich settles...")
         time.sleep(2.5)
     if code != 201 or not token:
-        log(f"⚠️  Could not log in as admin after 8 attempts (last HTTP {code}). Skipping OIDC config.")
+        log(
+            f"ℹ️  Immich admin login returns HTTP {code} — the admin row pre-dates this install "
+            "and holds a different password than the wizard's value. OIDC config skipped; the "
+            "service stays reachable via Authelia forward-auth. To restore SSO, reset Immich's "
+            "admin from the Immich UI (forgot-password flow) or DROP the user table in the "
+            "immich-database container and re-run this post-deploy from Diagnose."
+        )
         return 0
 
     # 3. Configure OAuth. Read-modify-write so we don't clobber any


### PR DESCRIPTION
## Symptom

Three install-flow regressions surfaced on yesterday's in-place reinstall (logged as #914). Each is the same pattern as the #912 batch: post-deploy generates fresh secrets but the data dir holds the previous install's, and the script doesn't recognise the situation.

## Fix

| Bug | Root cause | Fix |
|---|---|---|
| NPM \`needs_credentials\` fires on every plain reinstall | runner.ts:1167 self-heal (wipe data/, certs preserved, retry) was gated on \`cleanInstall: true\` | drop the gate — same drift happens on regular reinstalls, same recovery applies |
| Audiobookshelf init spins 5 minutes before timing out | media/init proxy detected "already initialised" by matching response body for "already". ABS 2.x returns generic HTTP 500 with body "Internal Server Error" (the "already has a root user" line stays in container logs only) | probe \`/status\` first; \`isInit:true\` short-circuits to \`alreadySetup\`. Body-text path kept as fallback |
| Immich post-deploy warns loudly when admin login can't authenticate | retry loop from #912 handles the propagation race; a *persistent* 401 means the admin row pre-dates this install with a different password — Immich has no env-driven reset, no automatic recovery is possible | degrade gracefully: skip OIDC, log the exact recovery steps, exit zero. Immich stays reachable via Authelia forward-auth at the proxy layer |

## Verification

- \`python3 -m unittest tests/templates/test_post_deploy.py\` — 22 passed in 1.2s
- \`npx vitest run packages/backend/src/lib/install/runner.test.ts\` — 9 passed
- \`npx tsc --noEmit\` — clean

Each was reproducible on yesterday's reinstall; after this PR lands + 4.24.6 deploys, a fresh \`POST /api/install/start\` should complete without any \`needs_credentials\` prompt, without the 5-min ABS timeout, and without the Immich warning.

Closes #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)