### PR TITLE
fix(media): accept alreadySetup as a terminal success

### DIFF
--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -169,12 +169,22 @@ def seed_audiobookshelf(port: str, user: str, password: str) -> None:
             "username": user,
             "password": password,
         }, timeout=15)
-        if status == 200 and body and body.get("ok"):
+        # The proxy returns one of:
+        #   { ok: true }              — admin just created
+        #   { alreadySetup: true }    — service already has an admin
+        #   { error: '...' }          — anything else
+        # Either of the first two is a terminal success — the old check
+        # required `body.get("ok") && body.get("alreadySetup")`, but the
+        # proxy never returns both together, so on a re-install the
+        # alreadySetup signal was missed and the post-deploy spun until
+        # its 5-min deadline.
+        if status == 200 and isinstance(body, dict):
             if body.get("alreadySetup"):
                 log("ℹ️ Audiobookshelf already initialized — keeping existing admin. Reset manually if the password doesn't match.")
-            else:
+                return
+            if body.get("ok"):
                 log(f"✅ Audiobookshelf root user '{user}' created.")
-            return
+                return
         elapsed = time.time() - started
         if elapsed - last_beat >= 10:
             log(f"Still waiting for Audiobookshelf ({int(elapsed)}s elapsed)...")


### PR DESCRIPTION
## Symptom

Even after #915 made the \`/api/system/media/init\` proxy correctly return \`{alreadySetup:true}\` (probing ABS \`/status\` first), the install still spun for 5 minutes on every re-install:

\`\`\`
Waiting for Audiobookshelf to start...
Still waiting for Audiobookshelf (10s elapsed)...
…
Still waiting for Audiobookshelf (291s elapsed)...
⚠️ Audiobookshelf did not become reachable in 5 minutes.
\`\`\`

Verified the proxy is fine — \`curl /api/system/media/init … → {"alreadySetup":true}\` ✓.

## Root cause

Pre-existing bug in \`templates/media/post-deploy.py:172\`:

\`\`\`python
if status == 200 and body and body.get("ok"):
    if body.get("alreadySetup"):
        log("ℹ️ Audiobookshelf already initialized …")
\`\`\`

The proxy returns the two outcomes as **mutually exclusive**:
- \`{ok: true}\` — admin just created
- \`{alreadySetup: true}\` — admin pre-existed

The compound \`ok && alreadySetup\` only matched a response shape the proxy never produces. The \`alreadySetup\` branch was unreachable; the loop spun until its 5-minute deadline every time.

## Fix

Split into two terminal checks — either signal ends the loop.

\`\`\`python
if body.get("alreadySetup"):
    log("ℹ️ Audiobookshelf already initialized …")
    return
if body.get("ok"):
    log(f"✅ Audiobookshelf root user '{user}' created.")
    return
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)