### PR TITLE
fix(fcos,scripts): split NVIDIA install into 3 stages with reboot between each

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -739,40 +739,53 @@ ${SERVICEBAY_SSH_PRIV}
           # the driver may not be present.
           if ! /usr/sbin/lspci 2>/dev/null | grep -qi 'NVIDIA Corporation'; then
               echo "install-nvidia: no NVIDIA GPU detected, skipping" >&2
-              # Mark both stages done so we don't keep retrying.
-              touch /var/lib/install-nvidia-driver-done /var/lib/install-nvidia-cdi-done
+              # Mark every stage done so we don't keep retrying.
+              touch /var/lib/install-nvidia-repos-done /var/lib/install-nvidia-driver-done /var/lib/install-nvidia-cdi-done
               exit 0
           fi
 
           FEDORA_VERSION=$(/usr/bin/rpm -E %fedora)
 
-          # Stage 1: layer the packages. RPM Fusion ships the driver
-          # build; `nvidia-container-toolkit` provides `nvidia-ctk` for
-          # CDI generation (the standard podman-NVIDIA bridge as of
-          # Container Toolkit ≥1.14). The open kernel modules
-          # (`kmod-nvidia-open-dkms`) are NVIDIA's recommended path
-          # for Turing+ GPUs — covers Ada Lovelace (RTX 2000/4000 Ada).
-          if [ ! -f /var/lib/install-nvidia-driver-done ]; then
-              echo "install-nvidia: layering NVIDIA driver + container toolkit..."
+          # Stage 1 — layer the RPM Fusion release packages. These ship
+          # the repo .repo files for the nonfree NVIDIA driver build.
+          # rpm-ostree CANNOT install packages from a repo whose .repo
+          # file is part of a pending (not-yet-active) deployment — so
+          # `rpm-ostree install nvidia-package` in the same script run
+          # fails with "Packages not found". Split repo layering from
+          # driver layering with a reboot between.
+          if [ ! -f /var/lib/install-nvidia-repos-done ]; then
+              echo "install-nvidia: stage 1 — layering RPM Fusion repos..."
               /usr/bin/rpm-ostree install --idempotent --allow-inactive \
                   "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VERSION}.noarch.rpm" \
                   "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VERSION}.noarch.rpm"
+              touch /var/lib/install-nvidia-repos-done
+              echo "install-nvidia: RPM Fusion repos staged, scheduling reboot to activate."
+              /usr/bin/systemctl reboot
+              exit 0
+          fi
+
+          # Stage 2 — install the NVIDIA driver + container toolkit.
+          # Open kernel modules (`kmod-nvidia-open-dkms`) are NVIDIA's
+          # recommended path for Turing+ GPUs — covers Ada Lovelace
+          # (RTX 2000/4000 Ada). `nvidia-container-toolkit` provides
+          # `nvidia-ctk` for CDI generation (the standard podman-NVIDIA
+          # bridge as of Container Toolkit ≥1.14).
+          if [ ! -f /var/lib/install-nvidia-driver-done ]; then
+              echo "install-nvidia: stage 2 — layering NVIDIA driver + container toolkit..."
               /usr/bin/rpm-ostree install --idempotent --allow-inactive \
                   kmod-nvidia-open-dkms \
                   xorg-x11-drv-nvidia-cuda \
                   nvidia-container-toolkit
               touch /var/lib/install-nvidia-driver-done
-              echo "install-nvidia: packages staged, scheduling reboot to load kmod"
-              # rpm-ostree changes apply on next boot. Stage 2 picks up
-              # there.
+              echo "install-nvidia: driver staged, scheduling reboot to load kmod"
               /usr/bin/systemctl reboot
               exit 0
           fi
 
-          # Stage 2: kernel module should be live now. Verify, then
+          # Stage 3 — kernel module should be live now. Verify, then
           # generate the CDI config that podman reads for GPU passthrough.
           if [ ! -f /var/lib/install-nvidia-cdi-done ]; then
-              echo "install-nvidia: stage 2 — checking nvidia kernel module..."
+              echo "install-nvidia: stage 3 — checking nvidia kernel module..."
               for i in $(/usr/bin/seq 1 30); do
                   if /usr/sbin/lsmod | grep -q '^nvidia '; then break; fi
                   sleep 2

--- a/scripts/enable-nvidia.sh
+++ b/scripts/enable-nvidia.sh
@@ -30,40 +30,56 @@ if ! /usr/sbin/lspci 2>/dev/null | grep -qi 'NVIDIA Corporation'; then
 fi
 
 FEDORA_VERSION="$(/usr/bin/rpm -E %fedora)"
+REPOS_MARKER=/var/lib/install-nvidia-repos-done
 DRIVER_MARKER=/var/lib/install-nvidia-driver-done
 CDI_MARKER=/var/lib/install-nvidia-cdi-done
 
-# Stage 1: layer the packages. RPM Fusion's nonfree repo ships the
-# NVIDIA proprietary driver build; nvidia-container-toolkit provides
-# `nvidia-ctk` for CDI generation (the standard podman-NVIDIA bridge).
-# Open kernel modules (`kmod-nvidia-open-dkms`) are NVIDIA's
-# recommended path for Turing+ GPUs (covers Ada Lovelace).
-if [[ ! -f "$DRIVER_MARKER" ]]; then
-    echo "enable-nvidia: layering RPM Fusion + NVIDIA driver + container toolkit..."
-    /usr/bin/rpm-ostree install --idempotent --allow-inactive \
-        "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VERSION}.noarch.rpm" \
-        "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VERSION}.noarch.rpm"
-    /usr/bin/rpm-ostree install --idempotent --allow-inactive \
-        kmod-nvidia-open-dkms \
-        xorg-x11-drv-nvidia-cuda \
-        nvidia-container-toolkit
-    touch "$DRIVER_MARKER"
+prompt_reboot() {
+    local next_stage="$1"
     echo
-    echo "enable-nvidia: packages staged. REBOOT REQUIRED to load the kmod."
-    echo "After reboot, re-run this script to generate the CDI config:"
-    echo
-    echo "    sudo bash enable-nvidia.sh"
+    echo "enable-nvidia: REBOOT REQUIRED to ${next_stage}."
+    echo "After reboot, re-run:  sudo bash enable-nvidia.sh"
     echo
     read -r -p "Reboot now? [y/N]: " ans
     if [[ "${ans^^}" == "Y" ]]; then
         /usr/bin/systemctl reboot
     fi
     exit 0
+}
+
+# Stage 1 — layer the RPM Fusion release packages. These ship the repo
+# definitions for the nonfree NVIDIA driver build. rpm-ostree CANNOT
+# install packages from a repo whose .repo file is part of a pending
+# (not-yet-active) deployment — `rpm-ostree install nvidia-package` in
+# the same script invocation would fail with "Packages not found", so
+# we split repo layering from driver layering with a reboot between.
+if [[ ! -f "$REPOS_MARKER" ]]; then
+    echo "enable-nvidia: stage 1 — layering RPM Fusion repos..."
+    /usr/bin/rpm-ostree install --idempotent --allow-inactive \
+        "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VERSION}.noarch.rpm" \
+        "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VERSION}.noarch.rpm"
+    touch "$REPOS_MARKER"
+    prompt_reboot "activate the RPM Fusion repos before installing the NVIDIA driver"
 fi
 
-# Stage 2: post-reboot CDI generation.
+# Stage 2 — install the NVIDIA driver + container toolkit. Open kernel
+# modules (`kmod-nvidia-open-dkms`) are NVIDIA's recommended path for
+# Turing+ GPUs (covers Ada Lovelace). nvidia-container-toolkit ships
+# `nvidia-ctk` for CDI generation (the standard podman-NVIDIA bridge).
+if [[ ! -f "$DRIVER_MARKER" ]]; then
+    echo "enable-nvidia: stage 2 — layering NVIDIA driver + container toolkit..."
+    /usr/bin/rpm-ostree install --idempotent --allow-inactive \
+        kmod-nvidia-open-dkms \
+        xorg-x11-drv-nvidia-cuda \
+        nvidia-container-toolkit
+    touch "$DRIVER_MARKER"
+    prompt_reboot "load the nvidia kernel module so CDI generation has something to introspect"
+fi
+
+# Stage 3 — generate the CDI config. nvidia-ctk needs the kmod loaded
+# to enumerate the device.
 if [[ ! -f "$CDI_MARKER" ]]; then
-    echo "enable-nvidia: waiting for nvidia kernel module..."
+    echo "enable-nvidia: stage 3 — waiting for nvidia kernel module..."
     for _ in $(seq 1 30); do
         /usr/sbin/lsmod | grep -q '^nvidia ' && break
         sleep 2


### PR DESCRIPTION
## Symptom

On every fresh install the \`install-nvidia.service\` unit fails at first boot:

\`\`\`
install-nvidia: layering NVIDIA driver + container toolkit...
… RPM Fusion .rpms downloaded and staged …
Changes queued for next boot. Run "systemctl reboot" to start a reboot
… second rpm-ostree install call fires immediately …
error: Packages not found: kmod-nvidia-open-dkms, nvidia-container-toolkit, xorg-x11-drv-nvidia-cuda
\`\`\`

The RTX 2000 Ada on the live box never gets the driver, the kmod never loads, \`/etc/cdi/nvidia.yaml\` is never generated, ollama/immich/hermes run on CPU.

## Root cause

Both \`install-nvidia.sh\` (baked into the ISO via \`install-fedora-coreos.sh\`) and \`scripts/enable-nvidia.sh\` issue two back-to-back \`rpm-ostree install\` calls:

1. \`rpm-ostree install <rpmfusion-free.rpm> <rpmfusion-nonfree.rpm>\`
2. \`rpm-ostree install kmod-nvidia-open-dkms xorg-x11-drv-nvidia-cuda nvidia-container-toolkit\`

rpm-ostree adds the RPM Fusion release packages as a **pending** layer — they don't activate until the next boot. The running root therefore has no knowledge of the \`rpmfusion-free-updates\` / \`rpmfusion-nonfree-updates\` repos when call 2 runs, so its solver fails to find the NVIDIA packages.

Combining both calls into one transaction (tried that today) doesn't help — rpm-ostree doesn't refresh metadata from .rpm URLs inside the same transaction.

## Fix

Restructure both scripts into three explicit stages, each gated by its own marker file:

| Stage | Action | Marker | After |
|---|---|---|---|
| 1 | Layer RPM Fusion repos | \`/var/lib/install-nvidia-repos-done\` | reboot |
| 2 | Layer NVIDIA driver + container-toolkit | \`/var/lib/install-nvidia-driver-done\` | reboot |
| 3 | Verify kmod loaded → \`nvidia-ctk cdi generate\` | \`/var/lib/install-nvidia-cdi-done\` | done |

The systemd unit is already gated only on the \`cdi-done\` marker, so it re-runs after each of the first two reboots and advances exactly one stage per boot. Three reboots from a fresh install to a GPU-ready box, but fully unattended.

The \`scripts/enable-nvidia.sh\` recovery script gets the same 3-stage structure with an interactive \`Reboot now? [y/N]\` prompt between stages.

## Verification

Live box was in the broken state after today's reinstall — I reproduced the exact failure mode. Manual one-shot \`rpm-ostree install\` with both URLs + NVIDIA packages mixed also fails with the same error (confirming the rpm-ostree limitation).

\`bash -n\` passes on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)