### PR TITLE
feat(system): stop UEFI USB boot loop after FCoS install (#930)

### DIFF
--- a/install-fedora-coreos.sh
+++ b/install-fedora-coreos.sh
@@ -829,6 +829,72 @@ ${SERVICEBAY_SSH_PRIV}
           [Install]
           WantedBy=multi-user.target
 
+    # Script to disable USB/removable boot entries on first successful SSD boot.
+    # This prevents the BIOS from booting the live USB again on subsequent reboots.
+    - path: /usr/local/bin/disable-usb-boot.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+
+          if [ -f /var/lib/disable-usb-boot-done ]; then
+              echo "disable-usb-boot: already completed, skipping"
+              exit 0
+          fi
+
+          echo "disable-usb-boot: neutralizing USB UEFI boot entries..."
+          # Get all USB/removable boot entries
+          USB_LIST=$$(/usr/bin/efibootmgr -v | /usr/bin/grep -i 'usb\|removable' | /usr/bin/grep -oP 'Boot\K[0-9A-Fa-f]+' || true)
+
+          if [[ -n "$$USB_LIST" ]]; then
+            for i in $$USB_LIST; do
+              echo "disable-usb-boot: disabling boot entry Boot$$i"
+              /usr/bin/efibootmgr -A -b "$$i" || true
+            done
+            
+            # Also remove them from the current BootOrder
+            CURRENT=$$(/usr/bin/efibootmgr | /usr/bin/grep -oP 'BootOrder: \K.*' || true)
+            if [[ -n "$$CURRENT" ]]; then
+              NEW_ORDER="$$CURRENT"
+              for i in $$USB_LIST; do
+                NEW_ORDER=$$(echo "$$NEW_ORDER" | sed -E "s/,$$i|^$$i,//; s/$$i//")
+              done
+              # Append them to the end so they are technically bootable if selected manually
+              NEW_ORDER=$$(echo "$$NEW_ORDER" | tr -s ',' | sed 's/^,//; s/,$//')
+              for i in $$USB_LIST; do
+                NEW_ORDER="$$NEW_ORDER,$$i"
+              done
+              NEW_ORDER=$$(echo "$$NEW_ORDER" | tr -s ',' | sed 's/^,//; s/,$$//')
+              
+              echo "disable-usb-boot: setting new BootOrder to $$NEW_ORDER"
+              /usr/bin/efibootmgr -o "$$NEW_ORDER" || true
+            fi
+          else
+            echo "disable-usb-boot: no USB boot entries found"
+          fi
+
+          touch /var/lib/disable-usb-boot-done
+          echo "disable-usb-boot: completed"
+
+    # Systemd unit to run the disable-usb-boot script once on first SSD boot
+    - path: /etc/systemd/system/disable-usb-boot.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Disable USB/removable boot entries on first SSD boot
+          ConditionPathExists=!/var/lib/disable-usb-boot-done
+          After=local-fs.target
+          
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/bash /usr/local/bin/disable-usb-boot.sh
+          
+          [Install]
+          WantedBy=multi-user.target
+
     # Re-install config-merge script (#331). On a re-install, setup-raid
     # leaves the existing config.json alone (so runtime-managed values
     # like encrypted password hashes + LLDAP creds + NPM creds + post-
@@ -2136,12 +2202,46 @@ cat > "$POST_INSTALL" <<'POSTINST'
 #!/usr/bin/env bash
 set -euo pipefail
 # After install: set the installed OS disk as first boot so we don't loop
-ENTRY=$(efibootmgr | grep -i -m1 'fedora\|coreos\|Linux Boot Manager' | grep -oP 'Boot\K[0-9A-Fa-f]+')
+ENTRY=$(efibootmgr -v | grep -i -m1 '\\EFI\\\(fedora\|coreos\|boot\)\\\' | grep -oP 'Boot\K[0-9A-Fa-f]+' || true)
+if [[ -z "$ENTRY" ]]; then
+  ENTRY=$(efibootmgr | grep -i -m1 'fedora\|coreos\|Linux Boot Manager' | grep -oP 'Boot\K[0-9A-Fa-f]+' || true)
+fi
+
 if [[ -n "$ENTRY" ]]; then
-  CURRENT=$(efibootmgr | grep -oP 'BootOrder: \K.*')
-  NEW="$ENTRY,$(echo "$CURRENT" | sed "s/$ENTRY,\?//;s/,$//")"
-  efibootmgr -o "$NEW"
-  echo "post-install: boot order set to $NEW (disk first)"
+  CURRENT=$(efibootmgr | grep -oP 'BootOrder: \K.*' || true)
+  if [[ -n "$CURRENT" ]]; then
+    CURRENT_WITHOUT_ENTRY=$(echo "$CURRENT" | sed -E "s/,$ENTRY|^$ENTRY,//; s/$ENTRY//")
+    NEW_ORDER="$ENTRY,$CURRENT_WITHOUT_ENTRY"
+    
+    USB_LIST=$(efibootmgr -v | grep -i 'usb\|removable' | grep -oP 'Boot\K[0-9A-Fa-f]+' | tr '\n' ',' | sed 's/,$//' || true)
+    if [[ -n "$USB_LIST" ]]; then
+      IFS=',' read -ra ADDR <<< "$USB_LIST"
+      DEMOTED=""
+      for i in "${ADDR[@]}"; do
+        if [[ "$i" != "$ENTRY" ]]; then
+          NEW_ORDER=$(echo "$NEW_ORDER" | sed -E "s/,$i|^$i,//; s/$i//")
+          DEMOTED="$DEMOTED,$i"
+        fi
+      done
+      NEW_ORDER=$(echo "$NEW_ORDER" | tr -s ',' | sed 's/^,//; s/,$//')
+      if [[ -n "$DEMOTED" ]]; then
+        NEW_ORDER="$NEW_ORDER$DEMOTED"
+      fi
+    fi
+    NEW_ORDER=$(echo "$NEW_ORDER" | tr -s ',' | sed 's/^,//; s/,$//')
+    
+    efibootmgr -o "$NEW_ORDER"
+    
+    VERIFY=$(efibootmgr | grep -oP 'BootOrder: \K.*' || true)
+    if [[ "$VERIFY" == "$NEW_ORDER" ]]; then
+      echo "post-install: boot order successfully set and verified to $NEW_ORDER (disk first, USBs demoted)"
+    else
+      echo "post-install: WARNING, boot order verification mismatch. Expected $NEW_ORDER, got $VERIFY"
+    fi
+  else
+    echo "post-install: current BootOrder is empty, setting order to $ENTRY"
+    efibootmgr -o "$ENTRY"
+  fi
 else
   echo "post-install: no OS boot entry found, boot order unchanged"
 fi

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -69,6 +69,7 @@ const MUTATING_TOOLS = new Set([
   'run_backup', 'restore_backup',
   'update_config', 'exec_command', 'refresh_agent',
   'merge_unmanaged_bundle',
+  'set_boot_next_usb',
 ]);
 
 /**
@@ -109,6 +110,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   delete_service: 'destroy', delete_health_check: 'destroy',
   remove_proxy_route: 'destroy', restore_backup: 'destroy',
   purge_trashed_service: 'destroy',
+  set_boot_next_usb: 'destroy',
   // exec (shell — own scope so tokens can grant config writes without it)
   exec_command: 'exec',
 };
@@ -144,6 +146,7 @@ const DESTRUCTIVE_TOOLS = new Set([
   'remove_proxy_route', 'restore_backup',
   'update_config', 'exec_command',
   'merge_unmanaged_bundle',
+  'set_boot_next_usb',
 ]);
 
 /**
@@ -1028,6 +1031,122 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     async ({ bundleId, newName, node, dryRun }) => {
       const nodeName = await resolveNode(node);
       return mergeUnmanagedBundleHandler({ bundleId, newName, nodeName, dryRun });
+    },
+  );
+
+  // --- Set Boot Next USB (#930) ---
+  // Gated under 'destroy' scope. Sets BootNext to a USB UEFI entry and optionally reboots.
+  server.tool(
+    'set_boot_next_usb',
+    'Configure UEFI BootNext one-shot target to boot from the installation USB next reboot, or clear current settings.',
+    {
+      action: z.enum(['list', 'set', 'clear']).optional().default('set').describe('Action: list candidates, set boot next, or clear active boot next'),
+      bootNum: z.string().regex(/^[0-9A-Fa-f]{4}$/, 'Must be a 4-digit hex number').optional().describe('4-digit hex boot number (required for set if auto-detect not desired)'),
+      reboot: z.boolean().optional().default(false).describe('Whether to reboot the system immediately after setting'),
+      node: nodeParam,
+    },
+    async ({ action, bootNum, reboot, node }) => {
+      const nodeName = await resolveNode(node);
+      try {
+        const agent = agentManager.getAgent(nodeName);
+        
+        if (action === 'clear') {
+          const res = await agent.sendCommand('exec', { command: 'efibootmgr -N' }) as { code?: number; stderr?: string };
+          if (res.code !== 0) {
+            return errorResult(`Failed to clear BootNext: ${res.stderr}`);
+          }
+          return textResult({ success: true, message: 'UEFI BootNext cleared successfully.' });
+        }
+        
+        if (action === 'list') {
+          const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+          if (res.code !== 0) {
+            return errorResult('Failed to query efibootmgr');
+          }
+          const stdout = res.stdout ?? '';
+          const entries: Array<{ bootNum: string; name: string; active: boolean; description: string; current: boolean }> = [];
+          const lines = stdout.split('\n');
+          let bootNext: string | null = null;
+          let bootCurrent: string | null = null;
+          let bootOrder: string[] = [];
+          
+          for (const line of lines) {
+            if (line.startsWith('BootNext:')) {
+              bootNext = line.replace('BootNext:', '').trim();
+            } else if (line.startsWith('BootCurrent:')) {
+              bootCurrent = line.replace('BootCurrent:', '').trim();
+            } else if (line.startsWith('BootOrder:')) {
+              bootOrder = line.replace('BootOrder:', '').trim().split(',');
+            } else if (line.startsWith('Boot')) {
+              const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
+              if (match) {
+                const num = match[1];
+                const active = match[2] === '*';
+                const description = match[3];
+                entries.push({
+                  bootNum: num,
+                  name: description.split('\t')[0] || description,
+                  active,
+                  description,
+                  current: bootCurrent === num,
+                });
+              }
+            }
+          }
+          const candidates = entries.filter(e => 
+            e.description.toLowerCase().includes('usb') || 
+            e.description.toLowerCase().includes('removable') ||
+            e.description.toLowerCase().includes('disk') ||
+            e.description.includes('\\EFI\\boot\\')
+          );
+          return textResult({ entries, candidates, bootNext, bootCurrent, bootOrder });
+        }
+        
+        // action === 'set'
+        let targetBootNum = bootNum;
+        if (!targetBootNum) {
+          const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+          if (res.code === 0) {
+            const stdout = res.stdout ?? '';
+            const lines = stdout.split('\n');
+            for (const line of lines) {
+              if (line.startsWith('Boot') && !line.startsWith('BootOrder') && !line.startsWith('BootNext') && !line.startsWith('BootCurrent')) {
+                const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
+                if (match) {
+                  const num = match[1];
+                  const desc = match[3];
+                  if (desc.toLowerCase().includes('usb') || desc.toLowerCase().includes('removable') || desc.includes('\\EFI\\boot\\')) {
+                    targetBootNum = num;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+        }
+        
+        if (!targetBootNum) {
+          return errorResult('No USB boot entry found or specified');
+        }
+        
+        await agent.sendCommand('exec', { command: `efibootmgr -A -b ${targetBootNum}` });
+        const resBootNext = await agent.sendCommand('exec', { command: `efibootmgr -n ${targetBootNum}` }) as { code?: number; stderr?: string };
+        if (resBootNext.code !== 0) {
+          return errorResult(`Failed to set BootNext: ${resBootNext.stderr}`);
+        }
+        
+        if (reboot) {
+          agent.sendCommand('exec', { command: 'systemctl reboot' }).catch(() => {});
+        }
+        
+        return textResult({
+          success: true,
+          bootNum: targetBootNum,
+          message: reboot ? 'One-shot BootNext set. System is rebooting.' : 'One-shot BootNext set successfully.',
+        });
+      } catch (err: unknown) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
     },
   );
 

--- a/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { CheckCircle2, Clock, Download, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import { CheckCircle2, Clock, Download, Loader2, RefreshCw, XCircle, AlertTriangle, Power } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
@@ -18,6 +18,97 @@ export default function UpdatesSection() {
   const [updateMessage, setUpdateMessage] = useState('');
   const [updateError, setUpdateError] = useState('');
 
+  const [bootStatus, setBootStatus] = useState<{
+    entries: Array<{ bootNum: string; name: string; active: boolean; description: string; current: boolean }>;
+    candidates: Array<{ bootNum: string; name: string; active: boolean; description: string; current: boolean }>;
+    bootNext: string | null;
+    bootCurrent: string | null;
+    bootOrder: string[];
+  } | null>(null);
+  const [isReinstallModalOpen, setIsReinstallModalOpen] = useState(false);
+  const [armingBoot, setArmingBoot] = useState(false);
+  const [cancellingBoot, setCancellingBoot] = useState(false);
+  const [rebooting, setRebooting] = useState(false);
+
+  const fetchBootStatus = async () => {
+    try {
+      const res = await fetch('/api/system/boot/usb-next');
+      if (res.ok) {
+        const data = await res.json();
+        setBootStatus(data);
+      }
+    } catch (e) {
+      console.error('Failed to fetch boot status:', e);
+    }
+  };
+
+  const confirmReinstall = async () => {
+    setIsReinstallModalOpen(false);
+    setArmingBoot(true);
+    try {
+      const res = await fetch('/api/system/boot/usb-next', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reboot: true }),
+      });
+      if (res.ok) {
+        addToast('success', 'USB Boot Armed', 'System is rebooting to USB installation medium...');
+        setRebooting(true);
+        setTimeout(() => { window.location.reload(); }, 8000);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'Failed to arm USB Boot');
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      addToast('error', 'Boot Arming Failed', msg);
+    } finally {
+      setArmingBoot(false);
+      fetchBootStatus();
+    }
+  };
+
+  const cancelUsbBoot = async () => {
+    setCancellingBoot(true);
+    try {
+      const res = await fetch('/api/system/boot/usb-next', {
+        method: 'DELETE',
+      });
+      if (res.ok) {
+        addToast('success', 'USB Boot Cancelled', 'One-shot BootNext cleared. SSD boot restored.');
+        fetchBootStatus();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'Failed to clear BootNext');
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      addToast('error', 'Cancellation Failed', msg);
+    } finally {
+      setCancellingBoot(false);
+    }
+  };
+
+  const triggerManualReboot = async () => {
+    setRebooting(true);
+    try {
+      const res = await fetch('/api/system/boot/usb-next', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reboot: true, bootNum: bootStatus?.bootNext || undefined }),
+      });
+      if (res.ok) {
+        addToast('success', 'Rebooting', 'System reboot command sent...');
+      } else {
+        throw new Error('Failed to trigger reboot');
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      addToast('error', 'Reboot Failed', msg);
+      setRebooting(false);
+    }
+  };
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -30,6 +121,7 @@ export default function UpdatesSection() {
         // ignore — keeps null and user can hit Check Now
       }
     })();
+    fetchBootStatus();
     return () => { cancelled = true; };
   }, []);
 
@@ -267,6 +359,93 @@ export default function UpdatesSection() {
         confirmText="Update Now"
         onConfirm={confirmAppUpdate}
         onCancel={() => setIsUpdateModalOpen(false)}
+      />
+
+      {/* Reinstall Operating System Section */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full mt-6">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+          <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg text-red-600 dark:text-red-400">
+            <Power size={20} className={rebooting ? 'animate-pulse' : ''} />
+          </div>
+          <div>
+            <h3 className="font-bold text-gray-900 dark:text-white">Operating System Reinstallation</h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Reinstall or recover the base operating system</p>
+          </div>
+        </div>
+        <div className="p-6 space-y-4">
+          <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+            Configure the server to boot into a connected installation USB to perform a fresh operating system reinstallation. 
+            This process will clear the base system files, but your personal data and stack volumes will be preserved.
+          </p>
+
+          {/* Active BootNext Warning Banner */}
+          {bootStatus?.bootNext && bootStatus.entries.some(e => e.bootNum === bootStatus.bootNext) ? (
+            (() => {
+              const armedEntry = bootStatus.entries.find(e => e.bootNum === bootStatus.bootNext);
+              const armedDesc = armedEntry ? armedEntry.description : `Boot${bootStatus.bootNext}`;
+              return (
+                <div className="p-4 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900/50 rounded-lg flex flex-col sm:flex-row sm:items-center justify-between gap-4 animate-pulse">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
+                    <div>
+                      <h4 className="text-sm font-bold text-amber-800 dark:text-amber-400">USB Installation Boot Armed</h4>
+                      <p className="text-xs text-amber-700 dark:text-amber-500 mt-1">
+                        The system is configured to boot from the installation USB next: <span className="font-semibold font-mono">{armedDesc} ({bootStatus.bootNext})</span>.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      onClick={cancelUsbBoot}
+                      disabled={cancellingBoot || rebooting}
+                      className="px-3 py-1.5 text-xs bg-white dark:bg-gray-800 border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-400 rounded hover:bg-amber-100 dark:hover:bg-amber-900/30 transition disabled:opacity-50"
+                    >
+                      {cancellingBoot ? 'Cancelling...' : 'Cancel USB Boot'}
+                    </button>
+                    <button
+                      onClick={triggerManualReboot}
+                      disabled={cancellingBoot || rebooting}
+                      className="px-3 py-1.5 text-xs bg-amber-600 text-white rounded hover:bg-amber-700 transition disabled:opacity-50"
+                    >
+                      {rebooting ? 'Rebooting...' : 'Reboot Now'}
+                    </button>
+                  </div>
+                </div>
+              );
+            })()
+          ) : (
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pt-2">
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                {bootStatus?.candidates && bootStatus.candidates.length > 0 ? (
+                  <span className="text-green-600 dark:text-green-400 font-medium">
+                    ✓ Detected {bootStatus.candidates.length} bootable installation medium candidate(s).
+                  </span>
+                ) : (
+                  <span className="text-amber-600 dark:text-amber-500 font-medium">
+                    ⚠ No bootable USB installation media detected in UEFI boot entries. Plug in the USB to start.
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={() => setIsReinstallModalOpen(true)}
+                disabled={armingBoot || rebooting || !bootStatus?.candidates || bootStatus.candidates.length === 0}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors shadow-sm font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                <Power size={16} />
+                {armingBoot ? 'Arming...' : 'Arm USB Boot & Reinstall'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <ConfirmModal
+        isOpen={isReinstallModalOpen}
+        title="Reinstall Operating System"
+        message="Are you sure you want to arm the next boot to use the installation USB? The system will reboot immediately to start the installation process."
+        confirmText="Confirm & Reboot"
+        onConfirm={confirmReinstall}
+        onCancel={() => setIsReinstallModalOpen(false)}
       />
     </>
   );

--- a/src/app/api/system/boot/usb-next/route.ts
+++ b/src/app/api/system/boot/usb-next/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { agentManager } from '@/lib/agent/manager';
+import { listNodes } from '@/lib/nodes';
+import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+async function getAgent() {
+  const nodes = await listNodes();
+  const nodeName = nodes[0]?.Name || 'Local';
+  return agentManager.getAgent(nodeName);
+}
+
+export const GET = withApiHandler({}, async () => {
+  try {
+    const agent = await getAgent();
+    const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+    if (res.code !== 0) {
+      return NextResponse.json({ error: 'Failed to query efibootmgr' }, { status: 500 });
+    }
+    
+    const stdout = res.stdout ?? '';
+    const entries: Array<{ bootNum: string; name: string; active: boolean; description: string; current: boolean }> = [];
+    
+    const lines = stdout.split('\n');
+    let bootNext: string | null = null;
+    let bootCurrent: string | null = null;
+    let bootOrder: string[] = [];
+    
+    for (const line of lines) {
+      if (line.startsWith('BootNext:')) {
+        bootNext = line.replace('BootNext:', '').trim();
+      } else if (line.startsWith('BootCurrent:')) {
+        bootCurrent = line.replace('BootCurrent:', '').trim();
+      } else if (line.startsWith('BootOrder:')) {
+        bootOrder = line.replace('BootOrder:', '').trim().split(',');
+      } else if (line.startsWith('Boot')) {
+        const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
+        if (match) {
+          const bootNum = match[1];
+          const active = match[2] === '*';
+          const description = match[3];
+          entries.push({
+            bootNum,
+            name: description.split('\t')[0] || description,
+            active,
+            description,
+            current: bootCurrent === bootNum,
+          });
+        }
+      }
+    }
+    
+    const candidates = entries.filter(e => 
+      e.description.toLowerCase().includes('usb') || 
+      e.description.toLowerCase().includes('removable') ||
+      e.description.toLowerCase().includes('disk') ||
+      e.description.includes('\\EFI\\boot\\')
+    );
+    
+    return NextResponse.json({
+      entries,
+      candidates,
+      bootNext,
+      bootCurrent,
+      bootOrder,
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error('api:system:boot:usb-next', 'GET failed', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+});
+
+const PostBody = z.object({
+  bootNum: z.string().regex(/^[0-9A-Fa-f]{4}$/, 'Must be a 4-digit hex number').optional(),
+  reboot: z.boolean().optional().default(false),
+});
+
+export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+  try {
+    const agent = await getAgent();
+    
+    let bootNum = body.bootNum;
+    
+    if (!bootNum) {
+      const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+      if (res.code === 0) {
+        const stdout = res.stdout ?? '';
+        const lines = stdout.split('\n');
+        for (const line of lines) {
+          if (line.startsWith('Boot') && !line.startsWith('BootOrder') && !line.startsWith('BootNext') && !line.startsWith('BootCurrent')) {
+            const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
+            if (match) {
+              const num = match[1];
+              const desc = match[3];
+              if (desc.toLowerCase().includes('usb') || desc.toLowerCase().includes('removable') || desc.includes('\\EFI\\boot\\')) {
+                bootNum = num;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+    
+    if (!bootNum) {
+      return NextResponse.json({ error: 'No USB boot entry found or specified' }, { status: 400 });
+    }
+    
+    logger.info('api:system:boot:usb-next', `Activating UEFI boot entry Boot${bootNum}`);
+    await agent.sendCommand('exec', { command: `efibootmgr -A -b ${bootNum}` });
+    
+    logger.info('api:system:boot:usb-next', `Setting UEFI BootNext to ${bootNum}`);
+    const resBootNext = await agent.sendCommand('exec', { command: `efibootmgr -n ${bootNum}` }) as { code?: number; stderr?: string };
+    if (resBootNext.code !== 0) {
+      return NextResponse.json({ error: `Failed to set BootNext: ${resBootNext.stderr}` }, { status: 500 });
+    }
+    
+    if (body.reboot) {
+      logger.info('api:system:boot:usb-next', 'Rebooting system as requested...');
+      agent.sendCommand('exec', { command: 'systemctl reboot' }).catch(() => {});
+    }
+    
+    return NextResponse.json({
+      success: true,
+      bootNum,
+      message: body.reboot ? 'One-shot BootNext set. System is rebooting.' : 'One-shot BootNext set successfully.',
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error('api:system:boot:usb-next', 'POST failed', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+});
+
+export const DELETE = withApiHandler({}, async () => {
+  try {
+    const agent = await getAgent();
+    logger.info('api:system:boot:usb-next', 'Clearing UEFI BootNext setting');
+    const res = await agent.sendCommand('exec', { command: 'efibootmgr -N' }) as { code?: number; stderr?: string };
+    if (res.code !== 0) {
+      return NextResponse.json({ error: `Failed to clear BootNext: ${res.stderr}` }, { status: 500 });
+    }
+    return NextResponse.json({ success: true, message: 'UEFI BootNext cleared successfully.' });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error('api:system:boot:usb-next', 'DELETE failed', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+});

--- a/tests/backend/mcp_token_scopes.test.ts
+++ b/tests/backend/mcp_token_scopes.test.ts
@@ -25,6 +25,10 @@ describe('MCP scope mapping (#591)', () => {
     expect(TOOL_SCOPES.exec_command).toBe('exec');
   });
 
+  it('set_boot_next_usb is destroy', () => {
+    expect(TOOL_SCOPES.set_boot_next_usb).toBe('destroy');
+  });
+
   it('every entry uses one of the five known scopes', () => {
     const known: ReadonlySet<ApiScope> = new Set<ApiScope>(['read', 'lifecycle', 'mutate', 'destroy', 'exec']);
     for (const [tool, scope] of Object.entries(TOOL_SCOPES)) {


### PR DESCRIPTION
Fixes #930. Neutralizes USB UEFI boot entries on successful SSD boot, registers the set_boot_next_usb MCP tool, and introduces the Reinstall OS UI.