### PR TITLE
feat(oscar): consolidate oscar repository into servicebay

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,102 @@
+name: build-images
+
+# Build and publish container images for OSCAR-owned components.
+#
+# - On push to `main` and tags `v*`: builds + pushes to GHCR.
+# - On pull requests touching image sources: builds without pushing,
+#   so the Dockerfile is validated before merge.
+#
+# Matrix entries are deliberately permissive: each step checks that the
+# Dockerfile actually exists before building, so this workflow can land
+# on main before the image-bearing PRs do without breaking subsequent
+# pushes.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'gatekeeper/**'
+      - 'schema/**'
+      - '.github/workflows/build-images.yml'
+  pull_request:
+    paths:
+      - 'gatekeeper/**'
+      - 'schema/**'
+      - '.github/workflows/build-images.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: oscar-gatekeeper
+            dockerfile: gatekeeper/Dockerfile
+            description: "OSCAR Wyoming-to-Hermes bridge — STT/TTS pipeline orchestration, Phase-2 speaker ID. Runs as a container inside oscar-household; reaches ServiceBay's voice template via host loopback (both pods hostNetwork)."
+          - image: oscar-household-init
+            dockerfile: schema/Dockerfile
+            description: "OSCAR schema-init sidecar — runs alembic upgrade head against oscar-household's local SQLite (oscar.db) on every pod start. Idempotent."
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Dockerfile exists
+        id: check
+        run: |
+          if [ -f "${{ matrix.dockerfile }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::${{ matrix.dockerfile }} not present on this ref; skipping ${{ matrix.image }} build."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.check.outputs.exists == 'true' && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        if: steps.check.outputs.exists == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build (and push on main/tags)
+        if: steps.check.outputs.exists == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          platforms: linux/amd64

--- a/gatekeeper/Dockerfile
+++ b/gatekeeper/Dockerfile
@@ -1,0 +1,23 @@
+FROM docker.io/python:3.12-slim
+
+WORKDIR /app
+
+# System deps kept minimal. Wyoming is pure Python; httpx wheel is pre-built.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY gatekeeper/pyproject.toml gatekeeper/README.md /app/
+COPY gatekeeper/src /app/src
+
+RUN pip install --no-cache-dir /app
+
+ENV PYTHONUNBUFFERED=1 \
+    OSCAR_COMPONENT=gatekeeper
+
+# Wyoming pipeline endpoint that satellites (HA Voice PE, wyoming-satellite
+# CLI, etc.) connect to. The Wyoming-internal whisper/piper services are
+# reached via 127.0.0.1 inside the same pod.
+EXPOSE 10700
+
+ENTRYPOINT ["python", "-m", "gatekeeper"]

--- a/gatekeeper/README.md
+++ b/gatekeeper/README.md
@@ -1,0 +1,68 @@
+# Gatekeeper
+
+OSCAR-published Python image that bridges Wyoming-protocol satellites (HA Voice PE, `wyoming-satellite` CLI) to Hermes. Runs as a container inside OSCAR's `oscar-household` pod; reaches ServiceBay's unchanged `voice` template (Whisper + Piper + openWakeWord) via host loopback. Both pods are `hostNetwork: true`, sharing the host netns. The `GATEKEEPER_IMAGE` variable on `oscar-household` picks which image tag to run.
+
+## What it does
+
+A Wyoming-protocol server. One inbound connection = one half-duplex pipeline turn:
+
+```
+Satellite (HA Voice PE / wyoming-satellite CLI)
+  → AudioStart + AudioChunk* + AudioStop
+Gatekeeper
+  → Whisper (local, GPU): transcribe
+  → Hermes (HTTP, oscar-household neighbour pod): converse(text, uid, endpoint, trace_id)
+  → Piper (local): synthesize response
+  → AudioStart + AudioChunk* + AudioStop back to the satellite
+```
+
+Plus an outbound `POST /push` endpoint (port 10750, pod-internal) so Hermes' cron and proactive deliveries can address a specific Voice PE device by name.
+
+The gatekeeper terminates the Wyoming connection after each turn. Multi-turn / barge-in / streaming responses are Phase 4 topics.
+
+## Phase mapping
+
+| Phase | What this code does |
+|---|---|
+| **0 / 1 (now)** | Pass-through. `uid` hardcoded to `DEFAULT_UID`, `endpoint = voice-pe:<connection-id>`. No speaker ID. |
+| **2** | SpeechBrain ECAPA-TDNN extracts a 256-d embedding from the audio buffer; brute-force cosine k-NN against `voice_embeddings` in `oscar.db` (3–10 rows) resolves the LLDAP `uid`. |
+| **4** | Multi-room routing (response goes to the satellite the user is closest to), voice-tone sensor parallel to STT, custom "Oscar" wakeword. |
+
+Long-term target: contribute the Phase 0/1 pass-through path to Hermes as a generic `hermes gateway voice`. The Phase 2+ logic (speaker ID, multi-room, voice-tone) stays here.
+
+## Configuration (env vars)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `GATEKEEPER_URI` | `tcp://0.0.0.0:10700` | Wyoming endpoint for satellite connections |
+| `WHISPER_URI` | `tcp://127.0.0.1:10300` | Wyoming Whisper service (provided by ServiceBay's `voice` template) |
+| `PIPER_URI` | `tcp://127.0.0.1:10200` | Wyoming Piper service (same pod) |
+| `OPENWAKEWORD_URI` | `tcp://127.0.0.1:10400` | openWakeWord (advertised in Info; Phase 0 lets the satellite do wakeword on-device) |
+| `HERMES_URL` | `http://127.0.0.1:8642` | Base URL of Hermes' HTTP API (matches ServiceBay `hermes` template default; both pods use hostNetwork) |
+| `HERMES_TOKEN` | empty | Bearer for Hermes (matches its `API_SERVER_KEY` / surfaced by ServiceBay's `hermes` template as `HERMES_API_KEY`) |
+| `DEFAULT_UID` | `michael` | Hardcoded uid until Phase 2 speaker ID lands |
+| `OSCAR_DB_PATH` | `/var/lib/oscar/oscar.db` | SQLite file (Phase 2: `voice_embeddings` lookup) |
+| `OSCAR_DEBUG_MODE` | `false` | Initial verbose-mode default (runtime override comes from `system_settings.debug_mode` in `oscar.db`) |
+
+## Local development
+
+```bash
+pip install -e ./gatekeeper
+
+# Pretend Whisper / Piper / Hermes are running on the expected URIs
+HERMES_URL=http://localhost:8642 OSCAR_DEBUG_MODE=true gatekeeper
+```
+
+Test from another shell with a tiny Wyoming client (`wyoming-satellite` CLI or the `example_event_client.py` shipped with that package). For pure protocol smoke-testing without audio hardware, feed a WAV file through `python -m wyoming.tools.wav` → the gatekeeper.
+
+## Image
+
+Built from this directory by [`.github/workflows/build-images.yml`](../.github/workflows/build-images.yml) on every push to `main` and on tags. Published as `ghcr.io/mdopp/oscar-gatekeeper:latest`. To rebuild locally: `podman build -t ghcr.io/mdopp/oscar-gatekeeper:latest -f gatekeeper/Dockerfile .` (from the repo root).
+
+## Open points
+
+- **HA Voice PE pairing** — HA Voice PE devices speak HA's WebSocket protocol natively, not the Wyoming-satellite protocol. Either patch the device firmware to use wyoming-satellite + point its `--event-uri` at this gatekeeper, or run HA's voice pipeline as a thin bridge with the conversation step pointing here. Validation needed at first deploy.
+- **Server-side wakeword orchestration** — Phase 0 trusts the satellite to do wakeword (HA Voice PE does it locally). For software clients without VAD, the gatekeeper needs an extra event flow that connects to `OPENWAKEWORD_URI`.
+- **Logging contract** — the inlined `gatekeeper.logging` helper is a placeholder until [`mdopp/servicebay`](https://github.com/mdopp/servicebay) ships a platform-wide structured-logging contract every template can follow.
+
+Architecture: [`../oscar-architecture.md`](../oscar-architecture.md) → "gatekeeper (OSCAR-published image)".

--- a/gatekeeper/pyproject.toml
+++ b/gatekeeper/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oscar-gatekeeper"
+version = "0.1.0"
+description = "OSCAR Wyoming-to-Hermes bridge — Wyoming server that drives Whisper/Piper and hands off conversation to Hermes."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Michael Dopp", email = "mdopp79@gmail.com" }]
+dependencies = [
+  "wyoming>=1.5.0",
+  "httpx>=0.27",
+  "aiohttp>=3.9",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=7",
+  "pytest-asyncio>=0.23",
+  "pytest-aiohttp>=1.0",
+]
+
+[project.scripts]
+gatekeeper = "gatekeeper.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/mdopp/oscar"
+Spec = "https://github.com/mdopp/oscar/blob/main/gatekeeper/README.md"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["gatekeeper*"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/gatekeeper/src/gatekeeper/__init__.py
+++ b/gatekeeper/src/gatekeeper/__init__.py
@@ -1,0 +1,10 @@
+"""OSCAR gatekeeper — voice-pipeline orchestrator.
+
+Listens for Wyoming-protocol connections from satellites (HA Voice PE or
+wyoming-satellite clients), drives whisper for STT and piper for TTS, and
+hands off the conversation step to HERMES.
+
+Spec: gatekeeper/README.md
+"""
+
+__version__ = "0.1.0"

--- a/gatekeeper/src/gatekeeper/__main__.py
+++ b/gatekeeper/src/gatekeeper/__main__.py
@@ -1,0 +1,101 @@
+"""Gatekeeper entry point — start the Wyoming server + push-HTTP server.
+
+Both run as concurrent tasks under one asyncio loop. If either crashes,
+the process exits so the pod restarts and recovers a consistent state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from gatekeeper.logging import log
+from wyoming.info import AsrModel, AsrProgram, Attribution, Info, TtsProgram
+from wyoming.server import AsyncServer
+
+from .config import settings
+from .handler import GatekeeperHandler
+from .push import serve as serve_push
+
+
+def _info() -> Info:
+    """Self-describe so satellites can introspect what we offer.
+
+    Phase 0 advertises the gatekeeper as a combined ASR+TTS pipeline server.
+    The underlying models are configured via env vars (Whisper + Piper);
+    satellite clients see one logical endpoint here.
+    """
+    return Info(
+        asr=[
+            AsrProgram(
+                name="oscar-gatekeeper-asr",
+                description="OSCAR gatekeeper — ASR via internal Whisper",
+                attribution=Attribution(
+                    name="OSCAR", url="https://github.com/mdopp/oscar"
+                ),
+                installed=True,
+                models=[
+                    AsrModel(
+                        name="oscar-gatekeeper",
+                        description="Gatekeeper pipeline (Whisper -> HERMES -> Piper)",
+                        attribution=Attribution(
+                            name="OSCAR", url="https://github.com/mdopp/oscar"
+                        ),
+                        installed=True,
+                        languages=["de", "en"],
+                    )
+                ],
+            )
+        ],
+        tts=[
+            TtsProgram(
+                name="oscar-gatekeeper-tts",
+                description="OSCAR gatekeeper — TTS via internal Piper",
+                attribution=Attribution(
+                    name="OSCAR", url="https://github.com/mdopp/oscar"
+                ),
+                installed=True,
+                voices=[],
+            )
+        ],
+    )
+
+
+async def _serve_wyoming() -> None:
+    server = AsyncServer.from_uri(settings.gatekeeper_uri)
+    log.info("gatekeeper.boot", uri=settings.gatekeeper_uri)
+    await server.run(lambda r, w: GatekeeperHandler(r, w, _info()))
+
+
+async def _serve() -> None:
+    wyoming = asyncio.create_task(_serve_wyoming(), name="wyoming")
+    push = asyncio.create_task(
+        serve_push(
+            settings.push_host,
+            settings.push_port,
+            piper_uri=settings.piper_uri,
+            devices=settings.voice_pe_devices,
+            push_token=settings.push_token,
+        ),
+        name="push",
+    )
+    done, pending = await asyncio.wait(
+        {wyoming, push}, return_when=asyncio.FIRST_COMPLETED
+    )
+    for task in pending:
+        task.cancel()
+    for task in done:
+        if task.exception():
+            log.error(
+                "gatekeeper.task.crashed",
+                task=task.get_name(),
+                error=str(task.exception()),
+            )
+            raise task.exception()  # propagate so the pod restarts
+
+
+def main() -> None:
+    asyncio.run(_serve())
+
+
+if __name__ == "__main__":
+    main()

--- a/gatekeeper/src/gatekeeper/config.py
+++ b/gatekeeper/src/gatekeeper/config.py
@@ -1,0 +1,56 @@
+"""Env-driven configuration for the gatekeeper.
+
+Phase 0 keeps the surface small. Phase 2 will add speaker-ID model paths
+and the `gatekeeper_voice_embeddings` DSN.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Settings:
+    gatekeeper_uri: str
+    whisper_uri: str
+    piper_uri: str
+    openwakeword_uri: str
+    hermes_url: str
+    hermes_token: str
+    default_uid: str
+    push_host: str
+    push_port: int
+    push_token: str
+    voice_pe_devices: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        raw_devices = os.environ.get("VOICE_PE_DEVICES", "")
+        devices: dict[str, str] = {}
+        if raw_devices.strip():
+            try:
+                parsed = json.loads(raw_devices)
+                if isinstance(parsed, dict):
+                    devices = {str(k): str(v) for k, v in parsed.items()}
+            except json.JSONDecodeError:
+                devices = {}
+        return cls(
+            gatekeeper_uri=os.environ.get("GATEKEEPER_URI", "tcp://0.0.0.0:10700"),
+            whisper_uri=os.environ.get("WHISPER_URI", "tcp://127.0.0.1:10300"),
+            piper_uri=os.environ.get("PIPER_URI", "tcp://127.0.0.1:10200"),
+            openwakeword_uri=os.environ.get(
+                "OPENWAKEWORD_URI", "tcp://127.0.0.1:10400"
+            ),
+            hermes_url=os.environ["HERMES_URL"],
+            hermes_token=os.environ.get("HERMES_TOKEN", ""),
+            default_uid=os.environ.get("DEFAULT_UID", "michael"),
+            push_host=os.environ.get("PUSH_HOST", "0.0.0.0"),
+            push_port=int(os.environ.get("PUSH_PORT", "10750")),
+            push_token=os.environ.get("PUSH_TOKEN", ""),
+            voice_pe_devices=devices,
+        )
+
+
+settings = Settings.from_env()

--- a/gatekeeper/src/gatekeeper/handler.py
+++ b/gatekeeper/src/gatekeeper/handler.py
@@ -1,0 +1,126 @@
+"""Wyoming event handler for the gatekeeper.
+
+One handler instance per inbound connection. The Phase-0 contract:
+
+  Client → AudioStart, AudioChunk*, AudioStop
+  Gatekeeper:
+    1. Stream the buffered audio to whisper, await Transcript
+    2. POST transcript to HERMES with (uid, endpoint, trace_id)
+    3. Send response text to piper, stream the resulting AudioChunks back
+       to the original client
+
+The connection closes after one pipeline turn (Phase 0 is half-duplex per
+turn, like HA's voice pipeline). Multi-turn / streaming is a Phase 4 topic.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from gatekeeper.logging import log
+from wyoming.asr import Transcribe, Transcript
+from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.client import AsyncClient
+from wyoming.event import Event
+from wyoming.server import AsyncEventHandler
+
+from .config import settings
+from .hermes import HermesClient
+from .tts import synthesize_to_writer
+
+
+class GatekeeperHandler(AsyncEventHandler):
+    """One connection = one pipeline turn."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.trace_id = str(uuid.uuid4())
+        self._audio_start: AudioStart | None = None
+        self._audio_buffer: list[AudioChunk] = []
+        self._hermes = HermesClient(settings.hermes_url, settings.hermes_token)
+        log.info("gatekeeper.session.open", trace_id=self.trace_id)
+
+    async def handle_event(self, event: Event) -> bool:
+        if AudioStart.is_type(event.type):
+            self._audio_start = AudioStart.from_event(event)
+            self._audio_buffer = []
+            log.info(
+                "gatekeeper.audio.start",
+                trace_id=self.trace_id,
+                rate=self._audio_start.rate,
+                width=self._audio_start.width,
+                channels=self._audio_start.channels,
+            )
+            return True
+
+        if AudioChunk.is_type(event.type):
+            self._audio_buffer.append(AudioChunk.from_event(event))
+            return True
+
+        if AudioStop.is_type(event.type):
+            log.info(
+                "gatekeeper.audio.stop",
+                trace_id=self.trace_id,
+                chunks=len(self._audio_buffer),
+            )
+            await self._process_pipeline()
+            return False
+
+        # Unknown event types are dropped silently; debug-mode shows them.
+        log.debug("gatekeeper.event.unhandled", trace_id=self.trace_id, type=event.type)
+        return True
+
+    async def _process_pipeline(self) -> None:
+        if not self._audio_buffer or self._audio_start is None:
+            log.warn("gatekeeper.audio.empty", trace_id=self.trace_id)
+            return
+
+        try:
+            transcript = await self._transcribe()
+        except Exception as exc:  # noqa: BLE001 — error logged below
+            log.error("gatekeeper.stt.error", trace_id=self.trace_id, error=str(exc))
+            return
+
+        if not transcript:
+            log.warn("gatekeeper.transcript.empty", trace_id=self.trace_id)
+            return
+        log.info("gatekeeper.transcript", trace_id=self.trace_id, text=transcript)
+
+        endpoint = f"voice-pe:{self.client_id or 'unknown'}"
+        response = await self._hermes.converse(
+            text=transcript,
+            uid=settings.default_uid,
+            endpoint=endpoint,
+            trace_id=self.trace_id,
+        )
+        if not response:
+            log.warn("gatekeeper.hermes.empty", trace_id=self.trace_id)
+            return
+        log.info("gatekeeper.response", trace_id=self.trace_id, length=len(response))
+
+        try:
+            await self._synthesize_and_stream(response)
+        except Exception as exc:  # noqa: BLE001
+            log.error("gatekeeper.tts.error", trace_id=self.trace_id, error=str(exc))
+            return
+
+        log.info("gatekeeper.session.close", trace_id=self.trace_id)
+
+    async def _transcribe(self) -> str:
+        assert self._audio_start is not None
+        async with AsyncClient.from_uri(settings.whisper_uri) as client:
+            await client.write_event(Transcribe(language=None).event())
+            await client.write_event(self._audio_start.event())
+            for chunk in self._audio_buffer:
+                await client.write_event(chunk.event())
+            await client.write_event(AudioStop().event())
+            while True:
+                evt = await client.read_event()
+                if evt is None:
+                    return ""
+                if Transcript.is_type(evt.type):
+                    return Transcript.from_event(evt).text
+
+    async def _synthesize_and_stream(self, text: str) -> None:
+        await synthesize_to_writer(settings.piper_uri, text, self.write_event)

--- a/gatekeeper/src/gatekeeper/hermes.py
+++ b/gatekeeper/src/gatekeeper/hermes.py
@@ -1,0 +1,51 @@
+"""Thin HTTP client for the HERMES conversation endpoint.
+
+POSTs `(text, uid, endpoint, trace_id)` and returns the response text.
+HERMES's actual schema is upstream — Phase 0 expects a `/converse`-style
+JSON endpoint; adjust the path/keys when validating against a real HERMES
+instance.
+"""
+
+from __future__ import annotations
+
+import httpx
+from gatekeeper.logging import log
+
+
+class HermesClient:
+    def __init__(self, base_url: str, token: str, timeout: float = 30.0):
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+
+    async def converse(
+        self,
+        *,
+        text: str,
+        uid: str,
+        endpoint: str,
+        trace_id: str,
+    ) -> str:
+        url = f"{self._base_url}/converse"
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        payload = {
+            "text": text,
+            "uid": uid,
+            "endpoint": endpoint,
+            "trace_id": trace_id,
+        }
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(url, json=payload, headers=headers)
+        if response.status_code >= 400:
+            log.error(
+                "gatekeeper.hermes.error",
+                trace_id=trace_id,
+                status=response.status_code,
+                body=response.text[:500],
+            )
+            return ""
+        data = response.json()
+        # Tolerate a few shapes — HERMES upstream may pick its own response key.
+        return data.get("text") or data.get("response") or data.get("reply") or ""

--- a/gatekeeper/src/gatekeeper/logging.py
+++ b/gatekeeper/src/gatekeeper/logging.py
@@ -1,0 +1,60 @@
+"""Structured-logging helper for the gatekeeper.
+
+Emits JSON lines on stdout matching ServiceBay's logger contract
+(documented as `docs/TEMPLATE_LOGGING.md` in mdopp/servicebay):
+
+    {"ts": "...", "level": "info|warn|error|debug", "tag": "...", "message": "...", "args": {...}}
+
+Until ServiceBay ships a Python helper package implementing the contract,
+the gatekeeper carries this small module so it can emit machine-parseable
+lines without an external dependency.
+
+Caller pattern:
+
+    from gatekeeper.logging import log
+
+    log.info("gatekeeper.boot", uri=settings.gatekeeper_uri)
+    log.warn("gatekeeper.push.unauthorized", trace_id=trace_id)
+    log.error("gatekeeper.hermes.error", trace_id=trace_id, status=503)
+
+`tag` defaults to `gatekeeper` (overridable via `OSCAR_COMPONENT`).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sys
+from typing import Any
+
+
+class _Logger:
+    def __init__(self, tag: str) -> None:
+        self._tag = tag
+
+    def _emit(self, level: str, message: str, **args: Any) -> None:
+        record = {
+            "ts": datetime.datetime.now().astimezone().isoformat(),
+            "level": level,
+            "tag": self._tag,
+            "message": message,
+            "args": args,
+        }
+        sys.stdout.write(json.dumps(record, default=str) + "\n")
+        sys.stdout.flush()
+
+    def debug(self, message: str, **args: Any) -> None:
+        self._emit("debug", message, **args)
+
+    def info(self, message: str, **args: Any) -> None:
+        self._emit("info", message, **args)
+
+    def warn(self, message: str, **args: Any) -> None:
+        self._emit("warn", message, **args)
+
+    def error(self, message: str, **args: Any) -> None:
+        self._emit("error", message, **args)
+
+
+log = _Logger(os.environ.get("OSCAR_COMPONENT", "gatekeeper"))

--- a/gatekeeper/src/gatekeeper/push.py
+++ b/gatekeeper/src/gatekeeper/push.py
@@ -1,0 +1,149 @@
+"""HTTP push endpoint — make the gatekeeper speak on a named Voice PE device.
+
+Skills can't talk Wyoming directly to a satellite. After a timer or alarm
+fires, HERMES POSTs here with `{endpoint, text}`; we look the endpoint up
+in the configured device map, synthesize via Piper, and forward the
+resulting AudioStart/Chunk*/AudioStop events to the device's Wyoming URI.
+
+Auth: bearer token (`PUSH_TOKEN` env). Empty token disables auth — fine
+for a pod-internal listener since the port isn't routed outside the pod.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from aiohttp import web
+from gatekeeper.logging import log
+from wyoming.client import AsyncClient
+
+from .tts import synthesize_to_writer
+
+
+VOICE_PE_PREFIX = "voice-pe:"
+
+
+def build_app(
+    *,
+    piper_uri: str,
+    devices: dict[str, str],
+    push_token: str = "",
+) -> web.Application:
+    """Construct the aiohttp app. Pure factory so tests can build it standalone."""
+
+    async def push(request: web.Request) -> web.Response:
+        trace_id = request.headers.get("X-Trace-Id") or str(uuid.uuid4())
+
+        if push_token:
+            auth = request.headers.get("Authorization", "")
+            if auth != f"Bearer {push_token}":
+                log.warn("gatekeeper.push.unauthorized", trace_id=trace_id)
+                return web.json_response(
+                    {"ok": False, "reason": "unauthorized"}, status=401
+                )
+
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001 — any malformed JSON
+            return web.json_response(
+                {"ok": False, "reason": "invalid_json"}, status=400
+            )
+
+        endpoint = str(body.get("endpoint") or "")
+        text = str(body.get("text") or "")
+        if not endpoint or not text:
+            return web.json_response(
+                {"ok": False, "reason": "missing_endpoint_or_text"}, status=400
+            )
+        if not endpoint.startswith(VOICE_PE_PREFIX):
+            return web.json_response(
+                {"ok": False, "reason": "unsupported_endpoint"}, status=400
+            )
+
+        device_name = endpoint[len(VOICE_PE_PREFIX) :]
+        device_uri = devices.get(device_name)
+        if not device_uri:
+            log.warn(
+                "gatekeeper.push.unknown_device", trace_id=trace_id, device=device_name
+            )
+            return web.json_response(
+                {"ok": False, "reason": "unknown_device", "device": device_name},
+                status=404,
+            )
+
+        log.info(
+            "gatekeeper.push.start",
+            trace_id=trace_id,
+            device=device_name,
+            chars=len(text),
+        )
+        try:
+            chunks = await _push_to_device(piper_uri, device_uri, text)
+        except Exception as exc:  # noqa: BLE001 — surface as 502
+            log.error(
+                "gatekeeper.push.error",
+                trace_id=trace_id,
+                device=device_name,
+                error=str(exc),
+            )
+            return web.json_response(
+                {"ok": False, "reason": "push_failed", "device": device_name},
+                status=502,
+            )
+
+        log.info(
+            "gatekeeper.push.done",
+            trace_id=trace_id,
+            device=device_name,
+            chunks=chunks,
+        )
+        return web.json_response({"ok": True, "device": device_name, "chunks": chunks})
+
+    async def health(_request: web.Request) -> web.Response:
+        return web.json_response({"ok": True, "devices": sorted(devices.keys())})
+
+    app = web.Application()
+    app.router.add_post("/push", push)
+    app.router.add_get("/health", health)
+    return app
+
+
+async def _push_to_device(piper_uri: str, device_uri: str, text: str) -> int:
+    """Open a Wyoming client to the device, write the synthesized audio."""
+    async with AsyncClient.from_uri(device_uri) as device:
+
+        async def forward(event: Any) -> None:
+            await device.write_event(event)
+
+        return await synthesize_to_writer(piper_uri, text, forward)
+
+
+async def serve(
+    host: str,
+    port: int,
+    *,
+    piper_uri: str,
+    devices: dict[str, str],
+    push_token: str = "",
+) -> None:
+    """Run the aiohttp app forever. Caller composes this with the Wyoming server."""
+    app = build_app(piper_uri=piper_uri, devices=devices, push_token=push_token)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port)
+    await site.start()
+    log.info(
+        "gatekeeper.push.listening",
+        host=host,
+        port=port,
+        devices=sorted(devices.keys()),
+        auth=bool(push_token),
+    )
+    try:
+        # Block forever — aiohttp's TCPSite returns immediately after binding.
+        import asyncio
+
+        await asyncio.Event().wait()
+    finally:
+        await runner.cleanup()

--- a/gatekeeper/src/gatekeeper/tts.py
+++ b/gatekeeper/src/gatekeeper/tts.py
@@ -1,0 +1,47 @@
+"""TTS helper: synthesize a text via Piper, forward audio to a writer.
+
+`synthesize_to_writer` is the one place that talks to Piper. Both the
+Wyoming inbound handler (reply-to-the-caller) and the HTTP push endpoint
+(push-to-a-named-device) call it with their own `write_event` coroutine.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.client import AsyncClient
+from wyoming.event import Event
+from wyoming.tts import Synthesize, SynthesizeVoice
+
+
+WriteEvent = Callable[[Event], Awaitable[None]]
+
+
+async def synthesize_to_writer(
+    piper_uri: str, text: str, write_event: WriteEvent, *, voice: str | None = None
+) -> int:
+    """Render `text` through Piper, forward Audio* events to `write_event`.
+
+    Returns the number of audio chunks forwarded — caller logs that for
+    correlation. Raises on connection / read failures so the caller can
+    decide how to respond (Wyoming caller drops the turn; HTTP push
+    returns 502).
+    """
+    chunks = 0
+    async with AsyncClient.from_uri(piper_uri) as client:
+        await client.write_event(
+            Synthesize(text=text, voice=SynthesizeVoice(name=voice)).event()
+        )
+        while True:
+            evt = await client.read_event()
+            if evt is None:
+                return chunks
+            if AudioStart.is_type(evt.type):
+                await write_event(evt)
+            elif AudioChunk.is_type(evt.type):
+                await write_event(evt)
+                chunks += 1
+            elif AudioStop.is_type(evt.type):
+                await write_event(evt)
+                return chunks

--- a/gatekeeper/tests/conftest.py
+++ b/gatekeeper/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Seed env vars required by gatekeeper.config at module-import time.
+
+gatekeeper.config initializes a singleton `settings = Settings.from_env()`
+at import. The push-endpoint tests don't touch that singleton, but
+collecting any test triggers the import via `gatekeeper.push`. Without
+HERMES_URL the import explodes before pytest reaches the test bodies.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("HERMES_URL", "http://hermes-test:8000")

--- a/gatekeeper/tests/test_config.py
+++ b/gatekeeper/tests/test_config.py
@@ -1,0 +1,59 @@
+"""Tests for the env-driven Settings dataclass."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _fresh_settings(monkeypatch, env: dict[str, str]):
+    """Reload the config module so Settings.from_env() picks up new env."""
+    import gatekeeper.config as cfg_mod
+
+    for key in list(env.keys()):
+        monkeypatch.setenv(key, env[key])
+    importlib.reload(cfg_mod)
+    return cfg_mod.Settings.from_env()
+
+
+def test_voice_pe_devices_parses_json_map(monkeypatch):
+    s = _fresh_settings(
+        monkeypatch,
+        {
+            "HERMES_URL": "http://hermes:8000",
+            "VOICE_PE_DEVICES": '{"office": "tcp://10.0.0.1:10700", "bedroom": "tcp://10.0.0.2:10700"}',
+        },
+    )
+    assert s.voice_pe_devices == {
+        "office": "tcp://10.0.0.1:10700",
+        "bedroom": "tcp://10.0.0.2:10700",
+    }
+
+
+def test_voice_pe_devices_invalid_json_is_empty(monkeypatch):
+    s = _fresh_settings(
+        monkeypatch,
+        {"HERMES_URL": "http://hermes:8000", "VOICE_PE_DEVICES": "not-json"},
+    )
+    assert s.voice_pe_devices == {}
+
+
+def test_voice_pe_devices_empty_when_unset(monkeypatch):
+    monkeypatch.delenv("VOICE_PE_DEVICES", raising=False)
+    s = _fresh_settings(monkeypatch, {"HERMES_URL": "http://hermes:8000"})
+    assert s.voice_pe_devices == {}
+
+
+def test_push_port_default(monkeypatch):
+    monkeypatch.delenv("PUSH_PORT", raising=False)
+    s = _fresh_settings(monkeypatch, {"HERMES_URL": "http://hermes:8000"})
+    assert s.push_port == 10750
+
+
+def test_hermes_url_is_required(monkeypatch):
+    monkeypatch.delenv("HERMES_URL", raising=False)
+    import gatekeeper.config as cfg_mod
+
+    with pytest.raises(KeyError):
+        cfg_mod.Settings.from_env()

--- a/gatekeeper/tests/test_push.py
+++ b/gatekeeper/tests/test_push.py
@@ -1,0 +1,102 @@
+"""Tests for the push HTTP endpoint.
+
+We don't run a real Piper or a real Voice PE Wyoming server — we patch
+`_push_to_device` in the push module to return a fake chunk count. The
+endpoint's auth/validation/routing logic is what we exercise.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gatekeeper.push import build_app
+
+
+@pytest.fixture
+def devices() -> dict[str, str]:
+    return {"office": "tcp://192.168.1.10:10700", "bedroom": "tcp://192.168.1.11:10700"}
+
+
+@pytest.fixture
+async def client(aiohttp_client, devices):
+    app = build_app(piper_uri="tcp://piper:10200", devices=devices, push_token="")
+    return await aiohttp_client(app)
+
+
+async def test_push_happy_path(client):
+    with patch("gatekeeper.push._push_to_device", AsyncMock(return_value=7)):
+        resp = await client.post(
+            "/push", json={"endpoint": "voice-pe:office", "text": "Pizza fertig"}
+        )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body == {"ok": True, "device": "office", "chunks": 7}
+
+
+async def test_push_unknown_device_returns_404(client):
+    resp = await client.post("/push", json={"endpoint": "voice-pe:garage", "text": "x"})
+    assert resp.status == 404
+    body = await resp.json()
+    assert body["reason"] == "unknown_device"
+    assert body["device"] == "garage"
+
+
+async def test_push_rejects_non_voice_pe_endpoint(client):
+    resp = await client.post(
+        "/push", json={"endpoint": "signal:+49151...", "text": "x"}
+    )
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["reason"] == "unsupported_endpoint"
+
+
+async def test_push_rejects_missing_fields(client):
+    resp = await client.post("/push", json={"endpoint": "voice-pe:office"})
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["reason"] == "missing_endpoint_or_text"
+
+
+async def test_push_rejects_invalid_json(client):
+    resp = await client.post("/push", data="not json")
+    assert resp.status == 400
+
+
+async def test_push_502_when_device_unreachable(client):
+    with patch(
+        "gatekeeper.push._push_to_device",
+        AsyncMock(side_effect=ConnectionRefusedError()),
+    ):
+        resp = await client.post(
+            "/push", json={"endpoint": "voice-pe:office", "text": "x"}
+        )
+    assert resp.status == 502
+    body = await resp.json()
+    assert body["reason"] == "push_failed"
+
+
+async def test_health_lists_configured_devices(client):
+    resp = await client.get("/health")
+    assert resp.status == 200
+    body = await resp.json()
+    assert body == {"ok": True, "devices": ["bedroom", "office"]}
+
+
+async def test_push_token_required_when_set(aiohttp_client, devices):
+    app = build_app(piper_uri="tcp://piper:10200", devices=devices, push_token="secret")
+    client = await aiohttp_client(app)
+    with patch("gatekeeper.push._push_to_device", AsyncMock(return_value=1)):
+        bad = await client.post(
+            "/push",
+            json={"endpoint": "voice-pe:office", "text": "x"},
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert bad.status == 401
+        good = await client.post(
+            "/push",
+            json={"endpoint": "voice-pe:office", "text": "x"},
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert good.status == 200

--- a/oscar-architecture.md
+++ b/oscar-architecture.md
@@ -1,0 +1,316 @@
+# O.S.C.A.R. — Architecture
+
+> Living document. May 2026 lean reset: OSCAR is a thin household-identity-and-memory layer on top of [Hermes Agent](https://github.com/NousResearch/hermes-agent) and [ServiceBay](https://github.com/mdopp/servicebay). Everything that is not specifically about *this household* lives in those two projects.
+
+## Vision
+
+OSCAR is a private operating system for the family: voice at home, chat on the road, one assistant, every resident has their own world, nothing leaves the house by accident.
+
+### Five intents
+
+1. **Sovereignty.** Modern AI in the house without exposing the family. All AI runs locally on a household server. Cloud LLMs only on explicit, audited opt-in.
+2. **Long memory.** The household's bookshelf, record collection, documents, photos, appointments, decisions — woven into something the assistant can query.
+3. **One conversation.** Voice at home (Wyoming via HA Voice PE devices), chat on the road (Signal/Telegram/…) — same agent, same memory.
+4. **Per-resident privacy.** Father, mother, child each have their own memory namespace and tool scope. Guests get a smaller, locked-down world. *Voice is identity.*
+5. **Things actually happen.** Lights, heating, scenes, timers, reminders — driven through Home Assistant's MCP server.
+
+## The boundary
+
+Three projects, three jobs. Whenever a capability is generic, it lives in one of the other two and OSCAR consumes it.
+
+### What [Hermes Agent](https://github.com/NousResearch/hermes-agent) gives us
+
+Hermes is the **agent runtime**. Consumed as the upstream container `docker.io/nousresearch/hermes-agent`. As of May 2026 it ships far more than an earlier draft of this document assumed — several things OSCAR planned to build are already native:
+
+- Conversation loop, skill registry, agent-curated skill creation, self-improvement loop, 70+ built-in tools
+- **20+ messaging gateways** (Signal, Telegram, Discord, Slack, WhatsApp, Email, Matrix, …) — paired interactively via `hermes gateway setup`
+- **Native Home Assistant integration** — a gateway plus four device-control tools (`light`, `switch`, `climate`, `cover`, `media_player`, `fan`, `scene`, `script`, …). Setup is a `HASS_TOKEN` long-lived access token. **This fully covers OSCAR intent 5; OSCAR builds nothing for HA control.** ([docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/homeassistant))
+- **Voice mode** — local STT (faster-whisper, zero API keys) + TTS (Edge/NeuTTS local, or cloud). Shapes: CLI voice, gateway voice replies, Discord voice channels. **It does not speak Wyoming and does not drive HA Voice PE devices** — that distributed-satellite path is what OSCAR's gatekeeper adds. ([docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/voice-mode))
+- **Honcho memory** — per-user "peer" profiles with automatic user modelling, semantic search, session strategies. Per-resident memory separation is largely a Honcho-peer concern, not an OSCAR-Qdrant-namespace concern. ([docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/honcho))
+- **Skills ecosystem** — `hermes skills install` against a curated hub (agentskills.io standard, 17 categories, security-scanned). Notably `official/research/qmd`: a local hybrid-retrieval engine (BM25 + vector + LLM rerank) over a markdown knowledge base — relevant to OSCAR intent 2.
+- Cron scheduler for timers, alarms, reminders, recurring tasks
+- MCP client for consuming external tool surfaces
+- LLM-provider abstraction (local via Ollama, cloud via Claude / Gemini / OpenRouter / …)
+
+OSCAR does **not** fork Hermes. Behaviour we miss gets contributed back as a PR or as an MCP server Hermes can mount. **Before building anything, check whether Hermes already ships it** — the surface grows fast. The fastest-path walkthrough in [`docs/getting-started.md`](docs/getting-started.md) shows how much of OSCAR's promise is reachable from a bare `pip install hermes-agent`.
+
+### What [ServiceBay](https://github.com/mdopp/servicebay) gives us
+
+ServiceBay is the **platform**. Consumed as an external template registry. ServiceBay provides:
+
+- Identity: LLDAP + Authelia (full-stack)
+- Smart home: Home Assistant (full-stack, **without** the bundled Wyoming pipeline). Hermes reaches HA through its **native HA integration** (a `HASS_TOKEN`), not through HA's MCP server — simpler, and it makes HA control a property of the `hermes` template's environment, not of OSCAR.
+- Photos / calendar / contacts / audiobooks / music / file-share (full-stack: `immich`, `radicale`, `media`, `file-share`)
+- Reverse proxy + TLS (`nginx`), DNS sinkhole (`adguard`), password manager (`vaultwarden`)
+- Platform MCP control surface (`/mcp`, scopes `read|lifecycle|mutate|destroy`, bearer token)
+- Existing `voice` template (Whisper + Piper + openWakeWord, shipped via [`mdopp/servicebay#348`](https://github.com/mdopp/servicebay/issues/348)) — deployed unchanged alongside `oscar-household` once OSCAR adds voice
+- Structured-logging surface (`src/lib/logger.ts`, SQLite-backed, shape `{ts, level, tag, message, args}`) — OSCAR containers emit one JSON line per event matching this contract
+- Health-check system (v3.35–v3.37, 16 check types, MCP tools `create_health_check` / `get_health_checks` / `run_check_now` / `diagnose`) — OSCAR's `oscar-status` skill consumes those tools instead of implementing its own probes
+- New `ai-stack` walkthrough + new `ollama` and `hermes` templates **to be built** in `mdopp/servicebay` (tracked in [`#538`](https://github.com/mdopp/servicebay/issues/538), [`#539`](https://github.com/mdopp/servicebay/issues/539), [`#540`](https://github.com/mdopp/servicebay/issues/540))
+
+Phase-3a additions (`postgres`, `qdrant`) are deferred to *when* Phase 3a is built; storage choice is re-opened then.
+
+### What's left for OSCAR
+
+After honestly subtracting everything Hermes now ships natively, the irreducible household-specific layer is:
+
+1. **Voice ↔ resident identity.** Speaker embedding (SpeechBrain ECAPA-TDNN) → LLDAP `uid` lookup → the right Honcho peer for that resident. Phase 2. Hermes has no concept of "which human is speaking" — this is the deepest OSCAR-eigen piece.
+2. **The gatekeeper image:** Wyoming-protocol bridge that connects HA Voice PE devices to Hermes. Hermes' own voice mode is CLI/Discord only — it does not speak Wyoming or drive room satellites. Published as `ghcr.io/mdopp/oscar-gatekeeper`, runs inside the `oscar-household` pod (both pods `hostNetwork: true`, gatekeeper reaches `voice`'s Whisper/Piper via host loopback). Long-term target: contribute the pass-through path to Hermes as a generic `hermes gateway voice`.
+3. **Cloud-LLM audit policy.** A small SQLite database (`cloud_audit`, `system_settings`, `voice_embeddings`) plus three skills: `oscar-status`, `oscar-audit-query`, `oscar-debug-set`. "Every cloud call is family-visible" is a policy, not a Hermes feature. SQLite file in the `oscar-household` volume — zero external infrastructure.
+4. **A ServiceBay stack walkthrough + the `oscar-household` template** — German-household defaults, the schema-init sidecar, the gatekeeper container, and the deterministic path from "ServiceBay installed" to a running household assistant.
+
+Everything else from earlier OSCAR drafts is upstreamed, dropped, or postponed: data-plane templating, Hermes-container wrapping, voice-pipeline templating, weather connectors, structured-logging library, health-probe library, **the `oscar-light` skill (Hermes' native HA integration replaces it outright — not even an upstream candidate)**, the connector skeleton. The Phase-3a ingestion module and domain-collection schema are **re-opened**: Hermes' `qmd` skill plus Honcho may cover "long memory" with markdown notes, making a custom database unnecessary — see the Phase 3a section.
+
+## Architecture overview
+
+```
+   SIGNAL / TELEGRAM / DISCORD / …                                 HA Voice PE
+              │                                                           │ Wyoming
+              │  Hermes-native gateway                                    ▼ <host>:10700
+              ▼                                                  ┌──────────────────┐
+   ┌──────────────────────────┐                                  │  oscar-household │
+   │     hermes               │                                  │  (OSCAR)         │
+   │     (ServiceBay)         │◄────────HTTP /converse───────────┤                  │
+   │     wraps nousresearch/  │                                  │  • gatekeeper    │  Wyoming
+   │     hermes-agent         │                                  │    container     │◄──host
+   │                          │                                  │    (Wyoming↔HTTP)│  loop-
+   │  Honcho + FTS5 (SQLite)· │                                  │  • SQLite +      │  back
+   │  cron · skill registry · │                                  │    Alembic       │  ┌─────────────────────┐
+   │  MCP client              │                                  │    (oscar.db)    │  │  voice (ServiceBay) │
+   └──┬──────┬──────────┬─────┘                                  │  • mounts OSCAR  │  │  whisper + piper +  │
+      │      │          │ MCP                                    │    skills        │  │  openwakeword       │
+      │      │                                                  │  • non-interactive  └─────────────────────┘
+      │      │                                                  │    post-deploy    │
+      │      ▼ native HA gateway          ▼ MCP                  │    registers      │
+      │  ┌───────────────┐  ┌─────────────────────────┐         │    ServiceBay-MCP │
+      │  │ Home Assistant│  │  ServiceBay-MCP         │         └──────────────────┘
+      │  │ (HASS_TOKEN — │  │  (services, health,     │
+      │  │  native, not  │  │   logs, diagnostics)    │
+      │  │  an MCP)      │  └─────────────────────────┘
+      │  └───────────────┘
+      │
+      ▼ skills read-mount
+      │   /opt/data/skills/oscar:
+      │     • oscar-status
+      │     • oscar-audit-query
+      │     • oscar-debug-set
+      ▼ Hermes LLM-provider URL
+   ┌─────────────────────────────────┐
+   │  ollama (ServiceBay, ai-stack)  │
+   │  local Gemma                    │
+   └─────────────────────────────────┘
+```
+
+Two templates from ServiceBay's `ai-stack` (`ollama`, `hermes`), one existing ServiceBay template (`voice`, used as-is — Phase 1), one OSCAR template (`oscar-household`). Home Assistant is reached through Hermes' **native HA integration** (`HASS_TOKEN` on the `hermes` template), not via an MCP server. The gatekeeper container — OSCAR-published image — runs **inside the oscar-household pod**, both pods sharing the host netns so the gatekeeper reaches the `voice` template's Whisper/Piper on `127.0.0.1` and Hermes on `127.0.0.1:8642`. OSCAR's three tables live in a SQLite file in `oscar-household`'s volume — no external Postgres for Phase 0–2.
+
+## Components in detail
+
+### gatekeeper (OSCAR-published image)
+
+A Wyoming-protocol server. **Runs as a container inside the `oscar-household` pod**, not as a sidecar of ServiceBay's `voice` template. Both pods are `hostNetwork: true`, sharing the host netns, so the gatekeeper reaches Whisper, Piper, and Hermes through `127.0.0.1`.
+
+One inbound satellite connection = one half-duplex pipeline turn:
+
+1. HA Voice PE (or any `wyoming-satellite` client) connects on `<host>:<GATEKEEPER_PORT>` and streams `AudioStart` + `AudioChunk*` + `AudioStop`.
+2. The gatekeeper calls the `voice` template's Whisper container at `tcp://127.0.0.1:10300` for STT.
+3. *Phase 0/1:* `uid = DEFAULT_UID`. *Phase 2:* SpeechBrain ECAPA-TDNN extracts a 256-d voice embedding; lookup against `voice_embeddings` in OSCAR's SQLite (3–10 vectors per family — brute-force cosine in Python) resolves it to an LLDAP `uid`; unknown → `guest`.
+4. The gatekeeper POSTs `(text, uid, endpoint, trace_id)` to Hermes' API at `HERMES_URL` (default `http://127.0.0.1:8642`).
+5. Hermes' response text goes to Piper at `tcp://127.0.0.1:10200`; synthesised audio streams back to the satellite.
+6. Outbound: `POST /push {endpoint: "voice-pe:<name>", text}` lets Hermes' cron and proactive deliveries address a specific Voice PE device by name (resolved against `VOICE_PE_DEVICES`).
+
+Voice embeddings live in OSCAR's SQLite (`voice_embeddings` table in `oscar.db`, mounted into the gatekeeper container at `/var/lib/oscar/oscar.db`, FK to LLDAP `uid`); **never** in LLDAP — biometric PII.
+
+Long term, the Phase-0 pass-through path (steps 1, 2, 4, 5) should land in Hermes as a generic `hermes gateway voice`. The OSCAR-specific Phase 2+ logic (speaker ID, multi-room routing, voice-tone analysis) stays in `oscar-household`.
+
+### oscar-household (OSCAR template)
+
+The one ServiceBay template OSCAR ships. Pod with two containers (`oscar-household-init`, `gatekeeper`), shared volume `/var/lib/oscar`, `hostNetwork: true`, declares `servicebay.dependencies: "hermes,voice"`. Responsibilities:
+
+- **Schema init.** One-shot Alembic container (`ghcr.io/mdopp/oscar-household-init`) runs on every pod start against `oscar.db` in the bind-mounted volume; creates `cloud_audit`, `system_settings`, `voice_embeddings` and, in Phase 3a, the domain-collection tables. Idempotent.
+- **Skill mount.** OSCAR's `skills/` directory (cloned with the OSCAR registry into the same volume) is mounted into the Hermes container at `/opt/data/skills/oscar` by ServiceBay's `hermes` template, sharing the hostPath. The OSCAR skills read `oscar.db` directly from `/var/lib/oscar/oscar.db`.
+- **Voice gatekeeper.** Long-running container with the OSCAR-published `gatekeeper` image. Reaches the `voice` template's Wyoming services and Hermes via host loopback (both pods are hostNetwork). Speaks Wyoming to satellites on `<host>:<GATEKEEPER_PORT>`.
+- **MCP wiring.** Non-interactive `post-deploy.py` reads `${DATA_DIR}/hermes/config.yaml` (the file ServiceBay's `hermes` template wrote with the `model:` block), splices in an `mcp_servers:` block for ServiceBay-MCP, writes back, then `POST /api/services/hermes/action {action: "restart"}` so Hermes picks up the new config. Sources: [Hermes MCP Config Reference](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference), [Hermes Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration). **HA is *not* wired here** — it's a native Hermes gateway driven by a `HASS_TOKEN`, which belongs in the ServiceBay `hermes` template's environment (open coordination point with `mdopp/servicebay#544`: the `hermes` template should grow optional `HASS_TOKEN` / `HASS_URL` variables). Caveat: re-deploying the `hermes` template rewrites `config.yaml` with just the `model:` block, so re-deploy `oscar-household` to restore the `mcp_servers:` block.
+- **Audit hook (pending).** Once `mcp-audit-proxy` ships as its own MCP server, the post-deploy will also register it with Hermes so every cloud-LLM call writes a `cloud_audit` row.
+- **Variables.** Wizard-prompted (see `templates/oscar-household/variables.json`): `DEFAULT_UID`, `GATEKEEPER_IMAGE`, `GATEKEEPER_PORT`, `WHISPER_URI` / `PIPER_URI` / `OPENWAKEWORD_URI`, `VOICE_PE_DEVICES`, `HERMES_API_PORT` / `HERMES_API_KEY` (paste from the ServiceBay `hermes` template's `__SB_CREDENTIAL__` banner), `PUSH_TOKEN`, `SERVICEBAY_MCP_URL` / `SERVICEBAY_MCP_TOKEN`, `LLDAP_GROUP`, `OSCAR_DEBUG_MODE`, `TZ`. *(The `HA_MCP_*` variables from an earlier draft are dropped — HA is the `hermes` template's `HASS_TOKEN`, not OSCAR's concern.)*
+
+### The three skills
+
+| Skill | Reads | Purpose |
+|---|---|---|
+| `oscar-status` | ServiceBay-MCP `get_health_checks` / `diagnose` + an `oscar.db` probe | "Is OSCAR alive?" — answered by the platform's health surface. |
+| `oscar-audit-query` | `cloud_audit` table | "What did the cloud connector send today?" — natural-language read over the audit table. |
+| `oscar-debug-set` | `system_settings.debug_mode` row | Admin only. Voice toggle for verbose mode with a TTL ("debug on for four hours"). |
+
+Each skill is a small Hermes skill (Markdown spec + Python tool calls), tracked in `skills/` and read-mounted via `oscar-household`.
+
+### The schema
+
+Three tables in Phase 0–2, all in a single SQLite file (`oscar.db` in the `oscar-household` volume):
+
+| Table | Owner | Notes |
+|---|---|---|
+| `cloud_audit` | OSCAR | One row per Hermes cloud-LLM call: timestamp, uid, trace_id, vendor, model, prompt-hash, prompt-length, response-length, cost, router score, escalation reason. Full text gated by `system_settings.debug_mode`. Tens of rows per day; thousands per year. |
+| `system_settings` | OSCAR | A single row with global flags: `debug_mode.active`, `debug_mode.verbose_until` (TTL), `debug_mode.latency_annotations`. Read by every component on every audit event (no caching > 5 s). |
+| `voice_embeddings` | OSCAR | 256-d ECAPA-TDNN vectors per LLDAP uid + enrolment metadata. Phase 2. FK to LLDAP `uid` (string). 3–10 rows total — k-NN done brute-force in Python, no vector index needed. |
+
+Phase 3a **re-opens** the domain-collection question entirely (see the Phase 3a roadmap section). Hermes' `qmd` skill already does local hybrid retrieval over a markdown knowledge base — a "book I read" or "decision we made" can be a markdown note `qmd` indexes, with no `books`/`records`/`documents` tables at all. A custom schema only earns its place if structured queries (filter by ISBN, rating, status) turn out to matter more than free-text retrieval. That is a Phase-3a decision, made with real usage in hand, not now.
+
+Alembic migrations live in `schema/`; the migration container is part of `oscar-household`. The migration model is portable to Postgres should a Phase-3a schema ever require it — one-day migration with `INSERT … SELECT`.
+
+## Identity and harness (Phase 2)
+
+Three harness types compose at runtime: **System** (always active) ∪ (**Personal** | **Guest**). One YAML per LLDAP `uid` (e.g. `michael.yaml`), checked in once Phase 2 starts and the directory layout is decided. Five fields per harness: `context`, `tools`, `guides`, `sensors`, `permissions`.
+
+Until Phase 2 ships, harness composition is layered on top of Hermes' own user/skill knobs by the gatekeeper at turn-handoff time, with `uid = DEFAULT_UID` as the placeholder.
+
+Whether harness composition becomes a Hermes-upstream feature (so any multi-user Hermes deployment can use it) or stays an OSCAR-side wrapper is a Phase-2 decision.
+
+## Memory layers
+
+| Layer | Storage | Where | Owner |
+|---|---|---|---|
+| Conversation history + per-resident user modelling | Honcho (per-user **peers**) + FTS5 SQLite | Hermes container's data volume | Hermes |
+| Document / note retrieval | `qmd` skill's local index (BM25 + vector + rerank) over a markdown folder | Hermes container's data volume | Hermes skill |
+| OSCAR audit | SQLite (`oscar.db`) | `oscar-household` container's volume | OSCAR |
+
+Per-resident memory separation is largely a **Honcho-peer** concern: once the gatekeeper resolves which resident is speaking (Phase 2), it hands Hermes the matching peer and Honcho keeps the worlds apart on its own. OSCAR does not build a Qdrant-namespace layer for this. A dedicated vector store enters the picture only if a Phase-3a structured-collection design needs it — see the schema section.
+
+## Cross-cutting concerns
+
+### Debug mode
+
+Global switch in the `system_settings.debug_mode` row in `oscar.db`. While building OSCAR (Phase 0–2) it defaults to `on`; productive household use flips it to `off`.
+
+When `active = true`:
+
+- All components log full text (prompts, responses, tool args, connector bodies) instead of metadata only
+- Retention policies on audit tables are suspended
+- With `latency_annotations: true`, voice responses carry "STT 230ms · router 80ms → local 12B · 1.4s" annotations (filtered to admin uids)
+
+TTL via `verbose_until`. Components re-query the row on every audit event (no caching > 5 s). Voice toggle via the `oscar-debug-set` skill: *"Debug mode on for four hours"* → sets `active=true, verbose_until=now()+4h`.
+
+### Cloud-LLM audit policy
+
+Every Hermes cloud-LLM call generates a `cloud_audit` row. The audit mechanism is an MCP audit-proxy (small project, separate repo — *see upstream work*). The *policy* — "every cloud call is family-visible" — is OSCAR-eigen: it shows up in the `oscar-audit-query` skill, in the family's view of what the assistant has been doing, and in the per-harness cloud opt-in.
+
+### Logging
+
+Operational: container stdout JSON → journald → ServiceBay's logger (`src/lib/logger.ts`, SQLite-backed). ServiceBay already shapes logs as `{ts, level, tag, message, args}`, queryable via `/api/logs/query?level=…&tag=…&search=…`. OSCAR containers emit one JSON line per event matching that contract; the doc is [`mdopp/servicebay#542`](https://github.com/mdopp/servicebay/issues/542).
+
+Domain audit: SQLite tables in `oscar.db`, read via the `oscar-audit-query` skill.
+
+Conversation: Hermes-native under its data volume.
+
+Correlation via `trace_id` per turn.
+
+**Health checks:** ServiceBay shipped a full health system in v3.35–v3.37 (16 check types: `http`, `ping`, `script`, `podman`, `service`, `systemd`, …). Model is outside-in — templates declare what should be probed; the platform polls and aggregates. The OSCAR `oscar-status` skill calls ServiceBay-MCP's `get_health_checks` / `diagnose` tools; no per-container `/health` endpoint needed. Doc gap tracked in [`mdopp/servicebay#543`](https://github.com/mdopp/servicebay/issues/543).
+
+## Phase roadmap
+
+> **Tiered entry point.** [`docs/getting-started.md`](docs/getting-started.md) splits "running assistant" into three tiers. Tier 1 (Hermes alone) and Tier 2 (Hermes + native HA + `qmd` + Signal + voice) deliver four of the five intents from a bare `pip install`, with no OSCAR code and no ServiceBay template. Phase 0 below *is* Tier 3 — the packaged household deployment. Validate Tiers 1–2 hands-on first; findings there can shrink the phases below.
+
+### Phase 0 — Household deployment (chat + HA control)
+
+**Prereqs.** ServiceBay v3.16+ with the full-stack deployed. `mdopp/servicebay#348` merged (HA without bundled Wyoming) — *only needed once voice is added*. `mdopp/servicebay#443` merged (`git` in ServiceBay's container) so the OSCAR registry can be cloned.
+
+**Deliverables.** ServiceBay's `ollama` and `hermes` templates exist and are wizard-deployable. OSCAR's `oscar-household` template exists and ships its own SQLite. `ai-stack` walkthrough plus OSCAR's stack walkthrough together produce a working setup. The `hermes` template carries `HASS_TOKEN` / `HASS_URL` so Hermes' **native HA integration** is live on first boot — device control needs no OSCAR code. Operator pairs Signal once via `podman exec -it hermes signal-cli link -n "HermesAgent"` (genuinely interactive — QR scan). `oscar-household`'s post-deploy registers ServiceBay-MCP via a `config.yaml` merge + restart, and initialises `oscar.db`.
+
+**Result.** Family chat in Signal, full HA device control, conversation memory, cloud-call audit. No room-voice path yet (Discord-voice works as the Tier-2 interim).
+
+### Phase 1 — Voice path
+
+**Prereqs.** ServiceBay's existing `voice` template (Whisper + Piper + openWakeWord, shipped via [`mdopp/servicebay#348`](https://github.com/mdopp/servicebay/issues/348)) deployed alongside `oscar-household`. Both pods are `hostNetwork: true` so the gatekeeper container in `oscar-household` reaches Whisper/Piper through the host loopback. OSCAR's gatekeeper image published to `ghcr.io/mdopp/oscar-gatekeeper`.
+
+**Deliverables.** HA Voice PE in the office, configured against `<host>:<GATEKEEPER_PORT>` (the port the gatekeeper container in `oscar-household` exposes). Gatekeeper in pass-through mode (`DEFAULT_UID`). Whisper-large-v3 on GPU (≤50 ms for 3 s audio). Piper for German voice.
+
+**Result.** Spoken conversation at home, single-user. Same agent and same memory as the Signal channel.
+
+### Phase 2 — Speaker ID + per-resident namespaces
+
+**Deliverables.** SpeechBrain ECAPA-TDNN in the gatekeeper. `voice_embeddings` table populated via an enrolment wizard. Harness YAML schema. `system.yaml` + `michael.yaml` + `guest.yaml`. The gatekeeper resolves uid per turn; Hermes runs under that uid's memory namespace and tool scope.
+
+**Result.** Per-resident privacy. Voice is identity.
+
+### Phase 3a — Streaming ingestion (design re-opened)
+
+**The premise has changed.** An earlier draft specified custom domain-collection tables (`books`, `records`, `documents`, `audiobooks`, `experiences`) plus a Qdrant index. Hermes' `qmd` skill now does local hybrid retrieval (BM25 + vector + LLM rerank) over a markdown knowledge base out of the box. So the **first question of Phase 3a is no longer "what schema" — it's "do we need a schema at all"**:
+
+- *qmd-first path:* household material becomes markdown notes in a `qmd`-indexed folder. A book is a note; a receipt is a note with its key facts. Ingestion = "turn an inbound photo/file into a markdown note." No tables, no Qdrant, no Alembic domain migrations. Retrieval is `qmd`.
+- *Schema path:* only if structured queries (filter by ISBN / rating / status, join across collections) prove to matter more than free-text retrieval. Then — and only then — the `books`/`records`/… tables and a vector store come back.
+
+**Deliverables (qmd-first, the working assumption).** An ingestion flow: trigger from Hermes messaging-gateway attachments **or** a Syncthing-watched per-uid inbox; classify + extract with the local multimodal model; write a structured markdown note; let `qmd` index it. Confirmation dialogue before filing. Encrypted material store for originals on a dedicated mount.
+
+**Result.** Long memory begins — measured against `qmd` retrieval quality before any database is built.
+
+### Phase 3b — Bulk import + MCP wrappers
+
+Signal/Telegram history import. Google Takeout. Audiobookshelf, Immich, Radicale wrappers as MCP tools Hermes consumes.
+
+### Phase 4 — Active extensions
+
+Voice-tone analysis as a parallel gatekeeper sensor. Multi-room voice routing (≥2 rooms). Custom "Oscar" wakeword. Proactive Hermes-driven memo creation. TuneIn / internet-radio MCP. Multi-household.
+
+## Upstream work tracked from OSCAR
+
+| Where | What | Phase | Status |
+|---|---|---|---|
+| [`mdopp/servicebay#538`](https://github.com/mdopp/servicebay/issues/538) | New `ollama` template with optional GPU passthrough (default-bind `127.0.0.1` + NPM/Authelia for remote access) | 0 | Open, amended |
+| [`mdopp/servicebay#539`](https://github.com/mdopp/servicebay/issues/539) | New `hermes` template wrapping `docker.io/nousresearch/hermes-agent`. Non-interactive setup (no `podman exec`), `dependencies: ollama` annotation, dashboard default-binds `127.0.0.1` | 0 | Open, amended |
+| [`mdopp/servicebay#540`](https://github.com/mdopp/servicebay/issues/540) | New `ai-stack` walkthrough bundling Ollama + Hermes | 0 | Open |
+| [`mdopp/servicebay#541`](https://github.com/mdopp/servicebay/issues/541) | ~~Extend `voice` template with `GATEKEEPER_IMAGE` sidecar~~ | ~~1~~ | **Closed** — gatekeeper lives in `oscar-household` instead |
+| [`mdopp/servicebay#542`](https://github.com/mdopp/servicebay/issues/542) | `docs/TEMPLATE_LOGGING.md` describing the existing `{ts, level, tag, message, args}` shape (ServiceBay's logger already produces it) | any | Open, doc-only |
+| [`mdopp/servicebay#543`](https://github.com/mdopp/servicebay/issues/543) | `docs/TEMPLATE_AUTHORING.md` health-checks section pointing at the existing 16-check-type system (v3.35–v3.37) | any | Open, doc-only |
+| `mdopp/servicebay` | New `postgres` + `qdrant` templates | 3a (conditional) | Not yet filed — only if Phase 3a chooses migration off SQLite |
+| `mdopp/servicebay` | `hermes` template grows optional `HASS_TOKEN` / `HASS_URL` variables so Hermes' native HA integration is live on first boot | 0 | Not yet filed — coordinate on `#544` |
+| `NousResearch/hermes-agent` | Voice gateway: contribute the Phase-1 gatekeeper pass-through path as `hermes gateway voice` | 1+ | Not yet filed (waits for Phase-1 deploy validation) |
+| New separate repo | `mcp-audit-proxy` — generic cloud-LLM auditing MCP; OSCAR provides only the policy + schema | 0 | Not yet created |
+
+The `smart-home/home-assistant` skill that an earlier draft planned to upstream is **dropped** — Hermes ships a native HA integration that supersedes it. `oscar-light` is deleted, not contributed.
+
+Tracking issue [`mdopp/oscar#70`](https://github.com/mdopp/oscar/issues/70) links to all of the above.
+
+## Key decisions
+
+| Topic | Decision |
+|---|---|
+| **Agent runtime** | Hermes Agent (`docker.io/nousresearch/hermes-agent`), unforked, deployed via ServiceBay's `hermes` template |
+| **Platform** | ServiceBay v3.16+ on Podman Quadlet, Fedora CoreOS host |
+| **AI infrastructure** | ServiceBay `ai-stack` (Ollama + Hermes for Phase 0; Postgres + Qdrant conditional in Phase 3a); not OSCAR's job to deploy |
+| **Storage** | SQLite for Phase 0–2 — single `oscar.db` in `oscar-household`'s volume. Consistent with how Hermes stores Honcho. Postgres + Qdrant is a Phase-3a decision, not a baked-in dependency. |
+| **Identity** | LLDAP `uid` + groups from ServiceBay's `auth` pod; SSO via Authelia OIDC for any OSCAR web UI |
+| **Voice pipeline** | ServiceBay's unchanged `voice` template (Whisper + Piper + openWakeWord) deployed alongside `oscar-household`. The gatekeeper container lives **inside** `oscar-household`, not as a sidecar of `voice` — both pods are `hostNetwork: true` so the gatekeeper reaches Wyoming services through the host loopback. |
+| **Voice identity** | Speaker embedding in the gatekeeper → uid lookup in OSCAR's SQLite `voice_embeddings` table → never in LLDAP |
+| **Messaging gateways** | Hermes-native (Signal, Telegram, Discord, Slack, WhatsApp, Email, +14 more). Paired via `hermes gateway setup`. No OSCAR-side gateway code. |
+| **HA device control** | Hermes' **native** HA integration (`HASS_TOKEN` on the `hermes` template) — a gateway + four device-control tools. Not HA-MCP, not an OSCAR skill. The `oscar-light` skill is deleted. |
+| **Document / note memory** | Hermes' `qmd` skill (local BM25 + vector + rerank over markdown). A custom Phase-3a database is re-opened as a question, not a given. |
+| **Timers / alarms / reminders** | Hermes-native cron scheduler. No OSCAR table. |
+| **Memory** | Hermes Honcho (conversation + per-resident peers) + `qmd` (documents) in Hermes' volume; OSCAR's `oscar.db` (audit only) in `oscar-household`'s volume. |
+| **Cloud LLM** | Off by default; opt-in per harness. Every call writes to `cloud_audit`. Family-visible via `oscar-audit-query`. |
+| **Audit-proxy mechanic** | Separate repo / package (`mcp-audit-proxy`), not OSCAR-eigen; OSCAR contributes only the policy + the schema |
+| **Hardware** | GPU server (RTX 4070 or comparable, ≥12 GB VRAM). No CPU-only path for live voice. |
+| **Hermes core modding** | None. Capabilities we miss get PR'd upstream or added as MCP servers. |
+| **OSCAR template count** | One (`oscar-household`). Anything more is a smell that we're rebuilding ServiceBay or Hermes. |
+| **gatekeeper home** | OSCAR-published image; long-term target is to land the Phase-0 pass-through path in Hermes |
+| **Phase 0 trigger** | Working Signal chat with HA control. Voice path is Phase 1, not Phase 0. |
+| **Entry point** | [`docs/getting-started.md`](docs/getting-started.md) — Tiers 1–2 (`pip install hermes-agent` + config) reach four of five intents with no OSCAR code; Phase 0 is the packaged Tier-3 household deployment. |
+
+## Open points
+
+1. **Gatekeeper migration path.** Once the voice gateway lands in Hermes upstream, the gatekeeper image shrinks to "OSCAR-specific extensions" only (speaker ID, multi-room, voice-tone). Timeline depends on Nous review cadence.
+2. **harness composition home.** Phase-2 question: does the system + uid + guest composition layer live in OSCAR (a small service the gatekeeper consults before posting to Hermes) or as a contributed feature in Hermes itself?
+3. **Material-store encryption.** Phase 3a. LUKS container vs. filesystem-layer (gocryptfs). Key management (TPM, boot-time passphrase, Authelia-protected unlock UI?).
+4. **MCP wrappers for ServiceBay stack apps.** Phase 3b. Do `immich-search`, `radicale-cal`, `audiobookshelf-list` live in OSCAR or as standalone MCP servers in their own repos?
+
+## Sources
+
+- Hermes Agent — <https://github.com/NousResearch/hermes-agent>
+- Hermes Agent docs — <https://hermes-agent.nousresearch.com/docs/>
+- ServiceBay — <https://github.com/mdopp/servicebay>
+- agentskills.io — <https://agentskills.io/>
+- Wyoming Protocol — <https://github.com/rhasspy/wyoming>
+- HA MCP server — <https://www.home-assistant.io/integrations/mcp_server/>
+- Harness engineering (Böckeler/Fowler) — <https://martinfowler.com/articles/harness-engineering.html>
+- LLDAP — <https://github.com/lldap/lldap>
+- Authelia — <https://www.authelia.com/>
+- Honcho — <https://github.com/plastic-labs/honcho>
+- Model Context Protocol — <https://modelcontextprotocol.io/>

--- a/schema/Dockerfile
+++ b/schema/Dockerfile
@@ -1,0 +1,27 @@
+# Migration sidecar for the oscar-household ServiceBay template.
+# Runs `alembic upgrade head` against /var/lib/oscar/oscar.db on every
+# pod start. Idempotent.
+#
+# Image: ghcr.io/mdopp/oscar-household-init
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    OSCAR_DB_URL=sqlite:////var/lib/oscar/oscar.db
+
+WORKDIR /opt/oscar-schema
+
+# Install runtime deps. No application package — we only need Alembic +
+# SQLAlchemy to drive op.execute() against SQLite. The migration files
+# themselves are baked in below.
+COPY schema/pyproject.toml ./
+RUN pip install --no-cache-dir alembic>=1.13 sqlalchemy>=2.0
+
+COPY schema/alembic.ini ./
+COPY schema/migrations ./migrations
+
+# Default entrypoint runs the upgrade. The pod manifest may override
+# with `args: ["downgrade", "base"]` etc.; default is idempotent upgrade.
+ENTRYPOINT ["alembic"]
+CMD ["upgrade", "head"]

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,30 @@
+# OSCAR schema
+
+Alembic migrations for the three OSCAR-owned tables, kept in a single SQLite file (`oscar.db`) in the `oscar-household` template's volume.
+
+| Table | Purpose | Phase |
+|---|---|---|
+| `system_settings` | Single-row global flags (`debug_mode.active`, `debug_mode.verbose_until`, `debug_mode.latency_annotations`). Read by every component on every audit event. | 0 |
+| `cloud_audit` | Append-only — one row per Hermes cloud-LLM call: timestamp, uid, trace_id, vendor, model, prompt/response hash + length, cost, router score, escalation reason. Full text gated by `system_settings.debug_mode`. | 0 |
+| `voice_embeddings` | 256-d ECAPA-TDNN voice embedding per LLDAP `uid`, plus enrolment metadata. 3–10 rows; brute-force cosine in Python — no vector index. | 2 (table created up-front, populated in Phase 2) |
+
+## Storage choice
+
+SQLite. Rationale: OSCAR's tables are a few-rows-of-config job (tens of audit rows per day; one settings row; ten embedding rows). Hermes itself uses SQLite for Honcho + FTS5. Phase 3a re-opens the storage choice when domain collections (`books`, `records`, `documents`, `audiobooks`, `experiences`) land. See [`../oscar-architecture.md`](../oscar-architecture.md) → "The schema".
+
+Migrations are written with hand-rolled SQL via `op.execute(...)`, so a future move to Postgres (if Phase 3a calls for it) is a one-day swap of the DDL strings.
+
+## Running the migration
+
+The `oscar-household` ServiceBay template runs the migration container on every pod start, against `/var/lib/oscar/oscar.db` in the bind-mounted volume. Idempotent.
+
+Manual run (development):
+
+```bash
+cd schema
+alembic -x dburl=sqlite:////tmp/oscar.db upgrade head
+```
+
+## Image
+
+Built from `Dockerfile`; published as `ghcr.io/mdopp/oscar-household-init:latest` by `.github/workflows/build-images.yml`.

--- a/schema/alembic.ini
+++ b/schema/alembic.ini
@@ -1,0 +1,42 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+version_path_separator = os
+
+# DSN is supplied at runtime via `-x dburl=...` or the OSCAR_DB_URL env var
+# (see migrations/env.py). Default to a local file for local-dev convenience.
+sqlalchemy.url = sqlite:///oscar.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/schema/migrations/env.py
+++ b/schema/migrations/env.py
@@ -1,0 +1,61 @@
+"""Alembic env — minimal SQLite config.
+
+Hand-written SQL via `op.execute(...)`, no SQLAlchemy ORM models, no
+autogenerate. Migrations are portable to Postgres should Phase 3a
+require it — see schema/README.md.
+
+DSN resolution (in order):
+  1. `-x dburl=...` on the alembic command line
+  2. `OSCAR_DB_URL` environment variable
+  3. the sqlalchemy.url default in alembic.ini
+"""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+
+config = context.config
+
+x_args = context.get_x_argument(as_dictionary=True)
+override = x_args.get("dburl") or os.environ.get("OSCAR_DB_URL")
+if override:
+    config.set_main_option("sqlalchemy.url", override)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/schema/migrations/script.py.mako
+++ b/schema/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/schema/migrations/versions/20260516_0001_baseline.py
+++ b/schema/migrations/versions/20260516_0001_baseline.py
@@ -1,0 +1,103 @@
+"""baseline: system_settings + cloud_audit + voice_embeddings (SQLite)
+
+Revision ID: 0001_baseline
+Revises:
+Create Date: 2026-05-16
+
+Phase 0 baseline for OSCAR's three SQLite tables. The voice_embeddings
+table is created up front so Phase 2 enrolment can fill it without a
+migration step; it stays empty until then.
+
+Storage choice rationale: see schema/README.md.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0001_baseline"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # system_settings — single-row global flags.
+    # `value` is JSON-as-TEXT (SQLite has no JSONB; the json1 extension
+    # is built into mainline SQLite and lets the skills query json_extract).
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS system_settings (
+          key        TEXT PRIMARY KEY,
+          value      TEXT NOT NULL,
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO system_settings (key, value) VALUES
+          ('debug_mode',
+           '{"active": true, "verbose_until": null, "latency_annotations": false}')
+        ON CONFLICT(key) DO NOTHING
+        """
+    )
+
+    # cloud_audit — one row per Hermes cloud-LLM call. Append-only.
+    # id stored as TEXT(uuid) for cross-store portability (vs SQLite's
+    # implicit INTEGER PK rowid). Caller provides the UUID.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS cloud_audit (
+          id                 TEXT PRIMARY KEY,
+          ts                 TEXT NOT NULL DEFAULT (datetime('now')),
+          trace_id           TEXT NOT NULL,
+          uid                TEXT NOT NULL,
+          vendor             TEXT NOT NULL,
+          model              TEXT,
+          prompt_hash        TEXT NOT NULL,
+          prompt_length      INTEGER NOT NULL,
+          response_length    INTEGER NOT NULL,
+          latency_ms         INTEGER NOT NULL,
+          cost_usd_micro     INTEGER,
+          router_score       REAL,
+          escalation_reason  TEXT,
+          prompt_fulltext    TEXT,
+          response_fulltext  TEXT
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS cloud_audit_ts_idx ON cloud_audit (ts DESC)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS cloud_audit_uid_idx ON cloud_audit (uid, ts DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS cloud_audit_trace_idx ON cloud_audit (trace_id)"
+    )
+
+    # voice_embeddings — Phase 2; created up front so enrolment can fill
+    # it without a follow-up migration. 256-d float32 stored as BLOB
+    # (256 * 4 = 1024 bytes). Brute-force cosine in Python over 3–10
+    # rows — no vector index, no SQLite extension required.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS voice_embeddings (
+          uid              TEXT PRIMARY KEY,
+          embedding        BLOB NOT NULL,
+          enrolled_at      TEXT NOT NULL DEFAULT (datetime('now')),
+          enrolled_via     TEXT NOT NULL,
+          sample_count     INTEGER NOT NULL DEFAULT 1,
+          last_seen_at     TEXT
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Baseline migration is one-way: a downgrade would destroy audit
+    # history and voice enrolments. Drop the SQLite file and re-run
+    # upgrade instead.
+    raise NotImplementedError(
+        "Baseline migration is one-way. Delete oscar.db and re-run upgrade."
+    )

--- a/schema/migrations/versions/20260525_0002_add_token_counts.py
+++ b/schema/migrations/versions/20260525_0002_add_token_counts.py
@@ -1,0 +1,37 @@
+"""add token counts to cloud_audit
+
+Revision ID: 0002_add_token_counts
+Revises: 0001_baseline
+Create Date: 2026-05-25
+
+Adds prompt_tokens, completion_tokens, and total_tokens to the cloud_audit table
+to allow direct SQL-native analytical insights on LLM and cloud token usage.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0002_add_token_counts"
+down_revision = "0001_baseline"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add columns to cloud_audit.
+    # SQLite does not support adding multiple columns in one ALTER TABLE,
+    # so we execute them as three separate ALTER TABLE statements.
+    op.execute("ALTER TABLE cloud_audit ADD COLUMN prompt_tokens INTEGER")
+    op.execute("ALTER TABLE cloud_audit ADD COLUMN completion_tokens INTEGER")
+    op.execute("ALTER TABLE cloud_audit ADD COLUMN total_tokens INTEGER")
+
+
+def downgrade() -> None:
+    # SQLite does not support dropping columns easily, raising NotImplementedError
+    # or using a temporary table would be needed. Since this is a lightweight schema,
+    # raising NotImplementedError matches the baseline's pattern.
+    raise NotImplementedError(
+        "Downgrade is not supported. Delete oscar.db and re-run upgrade if needed."
+    )

--- a/schema/pyproject.toml
+++ b/schema/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oscar-schema"
+version = "0.1.0"
+description = "Alembic migrations for OSCAR's SQLite schema (cloud_audit, system_settings, voice_embeddings)."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+dependencies = [
+  "alembic>=1.13",
+  "sqlalchemy>=2.0",
+]
+
+[tool.setuptools]
+# No installable Python package — this project is migrations only.
+packages = []

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,29 @@
+# OSCAR skills
+
+Household-specific skills consumed by [Hermes Agent](https://github.com/NousResearch/hermes-agent).
+
+Hermes provides the agent loop, skill registry, cron, messaging gateways, and the self-improvement loop natively. OSCAR contributes only the **household-specific** procedures tied to *our* SQLite schema (`oscar.db`) or *our* policy choices (cloud audit).
+
+The `oscar-household` ServiceBay template bind-mounts this directory into the Hermes container at `/opt/data/skills/oscar`, alongside the path to `oscar.db`. Hermes loads everything here on startup.
+
+## Currently registered skills
+
+| Directory | `name:` | Phase | One-liner |
+|---|---|---|---|
+| `status/` | `oscar-status` | 0 | Pings every OSCAR dependency (`oscar.db`, Hermes, Ollama, Home Assistant, ServiceBay-MCP; voice probes once Phase 1 voice is deployed) and returns per-component status. Read-only. |
+| `audit-query/` | `oscar-audit-query` | 0 | Read-only query over `cloud_audit` (and future Phase-3a household-domain tables) in `oscar.db`. |
+| `debug-set/` | `oscar-debug-set` | 0 | Admin: toggle `system_settings.debug_mode` row in `oscar.db` (verbose logging on demand, TTL-bounded). |
+
+> **TODO.** All three skill specs were written against the pre-lean-reset world (shared `oscar_db`/`oscar_audit`/`oscar_health` libraries + Postgres backend). The skills carry a `TODO (rewrite)` banner pointing at the inline-SQLite implementation that needs to land. The agentskills.io frontmatter and the operating-sequence prose have been updated for the SQLite world; the actual Python tool calls inside each skill are the follow-up.
+
+## What's *not* a skill in OSCAR
+
+| Capability | Lives in |
+|---|---|
+| Lights / heating / scenes | Hermes Skills Hub — `smart-home/home-assistant` skill (PR'd from OSCAR's removed `light/`) |
+| Help (`/skills`, `/help`) | Hermes native |
+| Timers / alarms / reminders / recurring tasks | Hermes cron |
+| Skill management, authorship, review, revert | Hermes' built-in skill management + self-improvement loop |
+| Messaging-gateway pairing, identity-link | Hermes' messaging-gateway pairing |
+
+Context: [`../oscar-architecture.md`](../oscar-architecture.md).

--- a/skills/audit-query/SKILL.md
+++ b/skills/audit-query/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: oscar-audit-query
+description: Use when the user asks "what happened today?", "show me errors in the last hour", "what did the cloud connector cost yesterday?". Reads from OSCAR's SQLite tables (cloud_audit, system_settings) in oscar.db. Read-only — never mutates state.
+version: 0.3.0
+author: OSCAR
+license: MIT
+---
+
+# OSCAR — audit.query
+
+## Overview
+
+Generic filter over OSCAR's domain-audit tables in `oscar.db`. One query returns a JSON page of rows; the agent summarises in natural language for the user.
+
+> **TODO (rewrite).** This skill was written against the deleted `shared/oscar_audit` library + Postgres backend. The intent below is correct; the Python implementation needs to land as inline SQLite queries in this skill or as a small companion script in `oscar-household`. The references to `python -m oscar_audit` are stale.
+
+Currently one stream:
+- `cloud_audit` — every cloud-LLM call (timestamp, uid, trace_id, vendor, lengths, latency, cost-estimate, router score + reason; prompt/response fulltext only when debug-mode is on)
+
+More streams plug into the same dispatch as Phase 3+ tables land (book/record/document collections, ingestion_classifications, etc.).
+
+## When to use
+
+- "What did OSCAR send to the cloud today?"
+- "Wieviel hat das gestern gekostet?"
+- "Show me errors in the last hour."
+- "Find every event tied to trace_id <X>."
+
+Out of scope:
+- Anything that mutates state (use `oscar-debug-set` for the debug-mode flag).
+- Reading **operational** logs (stdout-JSON). Those go through ServiceBay-MCP `get_container_logs` — different mechanism entirely.
+- Conversation history / messaging gateway state — Hermes owns those (SQLite + its own admin commands).
+
+## Operating sequence
+
+1. Parse the user request into:
+   - `stream` (which table): currently always `cloud_audit`.
+   - `since` / `until`: parse natural-language time. "today" → `today`. "last hour" → `1h`. "yesterday evening" → ISO timestamp.
+   - filter fields (`uid`, `vendor`, `trace_id`, `min_cost_micro_usd`) as they apply.
+2. Open `oscar.db` (path from `OSCAR_DB_PATH`, default `/var/lib/oscar/oscar.db`) and run a parameterised SELECT against `cloud_audit` with the filters above. Apply `LIMIT` (default 50, max 200).
+3. Shape the result as:
+   ```
+   {"ok": true, "stream": "cloud_audit", "count": 7, "rows": [...]}
+   ```
+4. Summarise verbally in 1–3 sentences. **Don't read UUIDs or hashes aloud.** Aggregate when sensible: "Heute 7 Cloud-Anfragen, alle Claude Sonnet, Gesamt ~12 Cent, längste 2.3 s."
+
+## Filter cheat sheet
+
+| Stream | Useful filters |
+|---|---|
+| `cloud_audit` | `--since`, `--uid`, `--vendor`, `--trace-id`, `--min-cost-micro-usd` |
+
+`--limit` defaults to 50; bump to 200 for trends but don't read all rows back, summarise.
+
+## Failure paths
+
+- `oscar.db` missing or unreadable → brief: "Ich kann das Audit-Log gerade nicht lesen."
+- Unknown stream → "Den Audit-Stream gibt's nicht." (Should never happen with proper parsing.)
+- Empty result → "Heute hat OSCAR nichts an die Cloud geschickt."
+
+## PII
+
+`cloud_audit.prompt_fulltext` / `response_fulltext` are returned only when `system_settings.debug_mode.active = true` (read live from `oscar.db`). Otherwise the rows return the metadata (lengths, hash, latency, cost) and the fulltext columns are nulled out — make the masking explicit in the summary if it matters. **Don't try to reconstruct prompts from hashes.**
+
+For deep debugging of a specific failure: instruct the user to flip debug-mode for a short window via `oscar-debug-set`, re-run the failing query, then turn debug-mode off.
+
+## Phase mapping
+
+| Phase | Streams |
+|---|---|
+| **0 (now)** | cloud_audit |
+| **2** | + gatekeeper_decisions (speaker-ID confidence, harness chosen, embedding distance) |
+| **3a** | + ingestion_classifications (Gemma vision class, confidence, final domain) |

--- a/skills/debug-set/SKILL.md
+++ b/skills/debug-set/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: oscar-debug-set
+description: Use when an admin asks to turn debug-mode on or off, or to enable verbose logging for a bounded window. Writes `system_settings.debug_mode` in oscar.db. Components that re-query the row on every audit event pick the change up within ~5 seconds. Admin-only — never invoke without explicit admin authorization.
+version: 0.3.0
+author: OSCAR
+license: MIT
+---
+
+# OSCAR — debug.set
+
+## Overview
+
+Cluster-wide debug-mode toggle. When on, OSCAR-owned containers log full prompts / responses / tool args / connector bodies; audit-table retention policies are suspended; cloud-LLM-fulltext fields are returned by `audit-query` instead of redacted.
+
+Source of truth is the `debug_mode` row in `system_settings` in `oscar.db` (the SQLite file in `oscar-household`'s volume, default `/var/lib/oscar/oscar.db`). This skill rewrites that row; components re-query `system_settings` on every audit event (no caching > 5 s), so the change propagates within ~5 seconds without restarts.
+
+> **TODO (rewrite).** This skill was written against the deleted `shared/oscar_logging.admin` CLI + Postgres backend. The intent below is correct; the Python implementation needs to land as inline SQLite queries in this skill or as a small companion script in `oscar-household`. The references to `python -m oscar_logging.admin` are stale.
+
+## When to use
+
+- "Schalt mal Debug-Mode an für eine Stunde."
+- "Turn debug logging on while we investigate this."
+- "Turn debug-mode off, we're done."
+- "Is debug mode on right now?" → read the row, return its current value.
+
+## Hard guards
+
+- **Admin gate.** Before any DB write: confirm the active harness includes the `admins` group. If not, refuse with "Only an admin can change debug mode."
+- **Always show what was set.** After every write, read back the row and confirm verbally: "Debug-Mode an bis 14:30 Uhr." or "Debug-Mode aus." Don't say "set" without the resulting state.
+- **Defaults that protect.** When the user says "on" without a duration, suggest a TTL ("Eine Stunde okay?") rather than leaving it on indefinitely. The architecture's intent is that bounded-window is the normal case; unbounded-on is the build-phase default and a deliberate choice once productive.
+
+## Operating sequence
+
+### Set
+
+Update the `system_settings` row keyed `debug_mode` with a JSON value:
+
+```json
+{"active": true, "verbose_until": "2026-05-16T15:30:00+00:00", "latency_annotations": false}
+```
+
+- `active`: bool — global on/off switch
+- `verbose_until`: ISO-8601 timestamp or `null` — TTL after which `effective = false`
+- `latency_annotations`: bool — adds "STT 230ms · router 80ms → 12B local · 1.4s" markers on voice responses (Phase 1+; relevant only for admin uids, hide from family members)
+
+### Show
+
+`SELECT value, updated_at FROM system_settings WHERE key='debug_mode'`, then derive the effective state:
+
+```
+effective_active = value.active AND (value.verbose_until IS NULL OR now() < value.verbose_until)
+```
+
+## Privacy reminder
+
+When the user asks to turn debug-mode on, OSCAR will start writing full conversation content (prompts and responses) to `cloud_audit` and to stdout-JSON. Mention this briefly the first time in a session — "Debug-Mode loggt jetzt auch Volltexte." — so the household isn't surprised.
+
+## Failure paths
+
+- `oscar.db` unreachable → "Ich kann debug-mode gerade nicht ändern." Don't retry in a loop.
+- Past `verbose_until` value (in the past) → reject as nonsense, ask back.
+
+## Phase mapping
+
+| Phase | Behaviour |
+|---|---|
+| **0 (now)** | Writes `system_settings.debug_mode` row in `oscar.db`. Components re-query on every audit event (no caching > 5 s). |
+| **1+** | Voice components (gatekeeper) honour `latency_annotations` in synthesised responses. |
+
+## Related
+
+- `oscar-audit-query` to inspect what happened while debug-mode was on.
+- Architecture spec for debug-mode semantics: [`../../oscar-architecture.md`](../../oscar-architecture.md) → "Cross-cutting: Debug mode".

--- a/skills/dynamic-skills/SKILL.md
+++ b/skills/dynamic-skills/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: oscar-dynamic-skills
+description: Use when the user requests OSCAR to learn a new capability, write down a fact/note, configure an agent, or when OSCAR needs to self-enhance its knowledge, skills, or peer agent behaviors dynamically. Implements the Phase 4 self-improvement loop.
+version: 1.0.0
+author: OSCAR
+license: MIT
+---
+
+# OSCAR — Dynamic Skills, Agents, and Knowledge Self-Enhancement
+
+## Overview
+
+This skill defines the operating procedures for **OSCAR Phase 4** (the Self-Enhancement Loop). It equips the Hermes Agent with instructions to perform:
+1. **Dynamic Knowledge Writing**: Writing or updating structured facts and markdown notes in `/opt/data/notes/` so the hybrid-retrieval system picks them up.
+2. **Dynamic Skill Compiler**: Authoring new skill specifications, sandboxing Python or JavaScript execution to verify them, writing `/opt/data/skills/oscar/<skill-name>/SKILL.md`, and reloading the Hermes service via ServiceBay-MCP.
+3. **Dynamic Agent Configuration**: Direct conversational feedback rules that update Honcho peer templates and custom instructions.
+
+---
+
+## 1. Dynamic Knowledge Writing
+
+When the user shares household facts, preferences, or notes (e.g., "Remember that the garden key is under the blue pot"), OSCAR must write them down so they are permanently indexed.
+
+### Rules:
+- **Global Notes File**: Write general household facts and memory states into `/opt/data/notes/SOUL.md`.
+- **Domain-Specific Notes**: Write topic-specific notes into structured files under `/opt/data/notes/fact_<topic>.md` (e.g., `/opt/data/notes/fact_garden.md` or `/opt/data/notes/fact_server_network.md`).
+- **Instant Retrieval**: The native `qmd` hybrid-retrieval engine automatically scans `/opt/data/notes/` and will retrieve these files for contextual prompt injection.
+
+### Operating Sequence:
+1. Formulate a clean Markdown block summarizing the new facts, including tags and date updated.
+2. Read the existing note file using `view_file` if it exists.
+3. Append or rewrite the file using `write_to_file` (or `replace_file_content` for edits) under `/opt/data/notes/`.
+4. Inform the user: *"Ich habe mir das notiert in <filename>."*
+
+---
+
+## 2. Dynamic Skill Compiler
+
+When a user requests a new automation or capability (e.g., "Learn how to parse local weather warnings from this specific API"), OSCAR can write a brand-new skill.
+
+### Rules & Sandboxing:
+- **Location**: Write the new skill file to `/opt/data/skills/oscar/<skill-name>/SKILL.md`.
+- **Sandboxing & Testing**:
+  - Before finalizing any custom shell script or python routine, write it to a temporary sandbox file inside `/opt/data/skills/oscar/<skill-name>/scratch/test_run.py`.
+  - Run the test script using `run_command` in a non-interactive sandbox shell.
+  - Verify that the API calls work, standard outputs are correct, and all dependencies are resolved.
+- **Reloading Hermes**:
+  - Once the skill `SKILL.md` is successfully written and verified, trigger a service reload.
+  - Call the ServiceBay-MCP tool `restart_service` with the argument `{"service": "hermes"}`. This forces Hermes to reload all active skills on-the-fly without system downtime.
+
+### Example SKILL.md Structure to Generate:
+```markdown
+---
+name: oscar-custom-<name>
+description: <detailed description for LLM router>
+version: 1.0.0
+author: OSCAR Dynamic Compiler
+license: MIT
+---
+
+# OSCAR — Custom Skill <Name>
+
+## When to use
+- <Use-case triggers>
+
+## Operating sequence
+1. <Step-by-step instructions>
+```
+
+---
+
+## 3. Dynamic Agent Configuration
+
+OSCAR operates with peer agents and templates managed under Honcho. When performance gaps or stylistic desires are noted, OSCAR can modify the instructions of its peer agents.
+
+### Rules:
+- **Honcho Peer Templates**: Read and update agent prompt templates in `/opt/data/agents/` or via Honcho configuration tables in `oscar.db`.
+- **Peer Coordination**: When a peer's prompt is modified, trigger a refresh of the Honcho agent cache.
+- **Verification**: Always review peer instruction changes to ensure they remain safe, ethical, and do not introduce loops or rule conflicts.
+
+---
+
+## Failure Paths & Safety Guards
+
+- **Strict Path Sandboxing**: Never write or edit files outside `/opt/data/` or the designated project workspaces.
+- **Testing Before Merging**: Never write a complex `SKILL.md` without running a validation probe or test execution of the underlying command/API first.
+- **Error Recovery**: If a service reload of `hermes` fails or causes a crash, check logs using `journalctl -u hermes` via ServiceBay-MCP, revert the changes in `SKILL.md`, and reload again.

--- a/skills/media-ingestion-multimodal/SKILL.md
+++ b/skills/media-ingestion-multimodal/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: media-ingestion-multimodal
+description: Triggers automatically when a resident uploads an image or photo attachment (such as a book cover, physical document, receipt, or music album art) via Signal, Telegram, Discord, or any other messaging gateway, or explicitly asks to ingest or scan a photographed item. Extracts structured metadata (ISBN, Title, Author, Artist, Tracklist, or Document Summary) and full OCR transcripts using multimodal LLMs. Writes the formatted, Obsidian-compatible structured Markdown note directly into the '/opt/data/notes/' folder (which is synced via Syncthing) so that the native 'qmd' skill can automatically index and retrieve it.
+version: 1.0.0
+author: OSCAR
+license: MIT
+---
+
+# OSCAR — Multimodal Ingestion Pipeline
+
+## Overview
+
+Processes physical media, documents, and books sent as image attachments by family members. Extracts rich structured metadata and OCR transcriptions using a multimodal model (local Qwen-VL/LLaVA on the 16GB GPU, or opted-in cloud models), compiles the result into a beautiful, standard Markdown note in the Syncthing-synchronized `/opt/data/notes/` folder, and makes it searchable via the native `qmd` skill.
+
+No custom database migrations or schema alterations required.
+
+---
+
+## When to use
+
+- When a resident sends an image attachment of a **book cover**, **music album cover**, or **physical document page** via Signal, Telegram, or Discord.
+- When a user explicitly says:
+  - "OSCAR, process this book picture."
+  - "Nimm dieses Dokument in mein Gedächtnis auf."
+  - "Füge dieses Album meiner Sammlung hinzu."
+  - "Hier ist ein Foto von der Quittung."
+
+Do **not** trigger on plain text messages that do not contain an image attachment or references to a photographic scan.
+
+---
+
+## Operating Sequence
+
+### 1. Identify and Fetch Image
+- Retrieve the uploaded image attachment from the messaging gateway context.
+- Confirm receipt of the image to the user: "Ich habe dein Bild erhalten und analysiere es..."
+
+### 2. Multi-Modal Analysis & OCR Extraction
+- Call your multimodal LLM capability (or the `vision_analyze` tool) with the image.
+- Instruct the model to perform both **OCR (text extraction)** and **Structured Metadata Extraction** with the following prompt:
+  ```
+  Perform optical character recognition (OCR) on this image.
+  Classify the object as one of: [Book, Music Album, Document, Receipt, Other].
+  Extract all relevant metadata:
+  - For Books: Title, Author(s), Publisher, Year of Publication, ISBN, Language, Genre, Key Topics.
+  - For Music Albums: Album Title, Artist/Band, Release Year, Genre, Tracklist (if visible).
+  - For Documents/Receipts: Document Type, Subject, Date, Sender, Recipient, Key figures (like total price for receipts), Summary.
+  Provide the result in clear JSON format, along with the full transcribed raw text.
+  ```
+
+### 3. Compile Premium Obsidian-Compatible Markdown
+- Structure the resulting note as a standardized Markdown file.
+- **YAML Frontmatter**:
+  - `type`: `book`, `album`, `document`, or `receipt`
+  - `tags`: `#oscar/ingested` combined with `#type/book`, `#type/album`, `#type/document`, or `#type/receipt`
+  - `added_by`: the current resident `uid` (default `guest` if unresolved)
+  - `added_at`: current ISO-8601 timestamp
+  - `isbn` / `artist` / `document_date` (specific extracted fields)
+- **Document Body**:
+  - `# <Title / Document Subject>`
+  - Section for **Extracted Metadata** (in a clean table format)
+  - Section for **Summary & Key Facts**
+  - Section for **OCR Transcript** (under an expandable folding block if long)
+
+### 4. Write Markdown to the Sync Folder
+- Create a safe, sanitized filename to avoid name collisions:
+  - Books: `book_<sanitized_title>.md`
+  - Albums: `album_<sanitized_artist>_<sanitized_title>.md`
+  - Documents: `doc_<sanitized_subject>_<date>.md`
+- Write the compiled Markdown note into `/opt/data/notes/<filename>` using the file system `write_file` or `terminal` tool.
+- Ensure the `/opt/data/notes` parent directory is created if not already present.
+
+### 5. Proactive Resident Confirmation
+- Summarize the extraction results to the user in a natural, premium tone.
+- **Example**:
+  > "Ich habe das Buch '**Dune**' von **Frank Herbert** (ISBN: 978-0441172719) erkannt und als Notiz `book_dune.md` in deinen Syncthing-Notizen abgelegt. Es wurde sofort indexiert und steht dir im Langzeitgedächtnis zur Verfügung."
+
+### 6. Automatic Indexing
+- The native `qmd` skill periodically (or on reload) scans `/opt/data/notes/` using its BM25 hybrid-retrieval engine. The note is now searchable across all channels!
+
+---
+
+## Obsidian-Compatible Note Templates
+
+### Book Template
+```markdown
+---
+type: book
+tags:
+  - oscar/ingested
+  - type/book
+added_by: {{uid}}
+added_at: {{timestamp}}
+isbn: "{{isbn}}"
+title: "{{title}}"
+author: "{{author}}"
+publisher: "{{publisher}}"
+year: {{year}}
+---
+
+# {{title}}
+
+## Metadaten
+| Feld | Wert |
+|---|---|
+| **Titel** | {{title}} |
+| **Autor** | {{author}} |
+| **Verlag** | {{publisher}} |
+| **Jahr** | {{year}} |
+| **ISBN** | {{isbn}} |
+
+## Inhaltszusammenfassung
+{{summary}}
+
+## Roher Text (OCR)
+```
+{{ocr_text}}
+```
+```
+
+### Music Album Template
+```markdown
+---
+type: album
+tags:
+  - oscar/ingested
+  - type/album
+added_by: {{uid}}
+added_at: {{timestamp}}
+album_title: "{{title}}"
+artist: "{{artist}}"
+year: {{year}}
+genre: "{{genre}}"
+---
+
+# {{title}} — {{artist}}
+
+## Album-Details
+| Feld | Wert |
+|---|---|
+| **Album** | {{title}} |
+| **Künstler** | {{artist}} |
+| **Jahr** | {{year}} |
+| **Genre** | {{genre}} |
+
+## Trackliste
+{{tracklist}}
+
+## Roher Text (OCR)
+```
+{{ocr_text}}
+```
+```
+
+### Document/Receipt Template
+```markdown
+---
+type: {{doc_type}}
+tags:
+  - oscar/ingested
+  - type/{{doc_type}}
+added_by: {{uid}}
+added_at: {{timestamp}}
+doc_date: "{{doc_date}}"
+subject: "{{subject}}"
+---
+
+# {{subject}} ({{doc_date}})
+
+## Dokumenten-Details
+| Feld | Wert |
+|---|---|
+| **Typ** | {{doc_type}} |
+| **Datum** | {{doc_date}} |
+| **Betreff** | {{subject}} |
+
+## Wichtige Fakten & Beträge
+{{facts}}
+
+## Roher Text (OCR)
+```
+{{ocr_text}}
+```
+```
+
+---
+
+## Verification Checklist
+
+To verify correctness:
+1. Upload an image of a book cover or document page via Signal or Telegram.
+2. Verify that `media-ingestion-multimodal` triggers and correctly runs the vision analysis.
+3. Check `/opt/data/notes/` inside the container or `{{DATA_DIR}}/file-share/data/notes` on the host to ensure the Markdown file exists and is populated correctly.
+4. Ask Hermes: "Erzähl mir von dem Buch, das ich heute hinzugefügt habe" and confirm the native `qmd` skill retrieves it.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: oscar-status
+description: Use when the user asks "is OSCAR alive?", "is everything working?", "why isn't the light responding?", or any other "health-check" style question. Probes the configured OSCAR dependencies (oscar.db, Ollama, Hermes, Home Assistant, ServiceBay-MCP) and reports per-component status. Read-only.
+version: 0.3.0
+author: OSCAR
+license: MIT
+---
+
+# OSCAR — status
+
+## Overview
+
+Quick "is everything OK?" probe across every OSCAR dependency. Read-only — no state changes.
+
+> **TODO (rewrite).** The implementation needs to call ServiceBay-MCP's `get_health_checks` and `diagnose` tools, **not** run inline probes. ServiceBay shipped a 16-check-type health system in v3.35–v3.37 — templates declare what should be probed (via `create_health_check` at deploy time, registered by `oscar-household`'s `post-deploy.py`), the platform polls outside-in, this skill just reads the aggregated state. Contract doc tracked in [`mdopp/servicebay#543`](https://github.com/mdopp/servicebay/issues/543). The env-var probe table below is vestigial from before the platform's health system was discovered — once the rewrite lands, this skill becomes ~10 lines that call two MCP tools and summarise.
+
+## When to use
+
+- "OSCAR, bist du da?" / "Bist du wach?"
+- "Funktioniert alles?" / "Geht das Licht gerade nicht?"
+- "Ist Home Assistant erreichbar?"
+- "Wo hakt's gerade?"
+- As the **first** diagnostic step before deeper drill-down — if `oscar-status` says everything's green, the bug is application-side, not infrastructure.
+
+## Operating sequence
+
+1. Call ServiceBay-MCP `get_health_checks` to retrieve the platform's aggregated health state.
+2. For each result, the platform returns the canonical shape:
+   ```json
+   {
+     "ok": false,
+     "results": [
+       {"name": "ollama", "ok": true, "latency_ms": 8, "type": "http"},
+       {"name": "hermes-api", "ok": true, "latency_ms": 12, "type": "http"},
+       {"name": "home-assistant", "ok": false, "latency_ms": 3000, "type": "http", "detail": "ConnectError: ..."},
+       {"name": "oscar.db", "ok": true, "latency_ms": 1, "type": "script"}
+     ]
+   }
+   ```
+3. If a result needs deeper context (specific error chain, last successful run, history), call `diagnose <check-id>` for that one check.
+4. Summarise verbally:
+   - **All green** → "Alles ok." or "Alles grün."
+   - **One red** → name it: "Home Assistant antwortet nicht — ich erreiche die Haussteuerung gerade nicht."
+   - **Multiple red** → group by impact: "Hermes und Ollama sind beide down — das ist ernst."
+
+## What gets probed
+
+This skill **does not** define what gets probed. The set of health checks is **declared at deploy time** by each template's `post-deploy.py` via `create_health_check` against ServiceBay-MCP. `oscar-household` registers:
+
+| Check | Type | Purpose |
+|---|---|---|
+| `oscar.db` | `script` | SQLite open + `SELECT 1` on `cloud_audit` — OSCAR's audit state readable |
+| `hermes-api` | `http` | Hermes' `/health` endpoint reachable with the token |
+| `ollama` | `http` | Local LLM responding to `/api/tags` |
+| `home-assistant` | `http` | Home Assistant reachable (Hermes native HA gateway target) |
+| `servicebay-mcp` | `http` | Platform control surface reachable |
+| `gatekeeper` *(Phase 1)* | `http` | Gatekeeper container's internal `/push/health` |
+| `voice-whisper` *(Phase 1)* | `podman` | Whisper container running |
+| `voice-piper` *(Phase 1)* | `podman` | Piper container running |
+
+ServiceBay's existing templates (`home-assistant`, `media`, …) register their own checks the same way. The full check set lives in ServiceBay's HealthStore.
+
+## What this does NOT cover
+
+- **Skill correctness** — we know Hermes is reachable, not that a specific skill behaves. For that, `oscar-audit-query` over `cloud_audit` and the relevant SKILL events.
+- **Voice latency** — `podman`/`http` checks say the service is up, not that it's fast. For latency hunting, `oscar-debug-set` + the gatekeeper's `gatekeeper.transcript` / `gatekeeper.response` timestamps.
+- **HA device state** — "is the office light actually on?" is a Hermes HA-tool query, not a status probe.
+
+## Failure paths
+
+- ServiceBay-MCP unreachable → respond "Ich kann das gerade selbst nicht prüfen — ServiceBay antwortet nicht." Points at something fundamentally broken at the platform level (network, auth, ServiceBay itself).
+
+## Phase mapping
+
+| Phase | Checks registered by oscar-household's post-deploy |
+|---|---|
+| **0 (now)** | oscar.db, hermes-api, ollama, home-assistant, servicebay-mcp |
+| **1** | + gatekeeper, voice-whisper, voice-piper |
+| **2** | + gatekeeper-speaker-id (model loaded? embeddings table populated?) |
+| **3a** | + ingestion-pipeline backlog (rows in incoming state) |

--- a/stacks/oscar/README.md
+++ b/stacks/oscar/README.md
@@ -136,6 +136,6 @@ The full observe-first matrix lives in [`mdopp/oscar#70`](https://github.com/mdo
 - [ ] Signal/Telegram round-trip → Hermes responds in German
 - [ ] Light command turns the light on/off (Hermes' native HA integration)
 - [ ] Timer command creates a Hermes cron job and fires on schedule
-- [ ] Cloud-LLM call (e.g. complex question) writes a `cloud_audit` row
+* [ ] Cloud-LLM call (e.g. complex question) writes a `cloud_audit` row
 - [ ] `oscar-audit-query` returns the row when asked
 - [ ] (Phase 1) Voice round-trip via HA Voice PE works under 1.5 s end-to-end

--- a/stacks/oscar/README.md
+++ b/stacks/oscar/README.md
@@ -1,0 +1,141 @@
+# OSCAR stack
+
+End-to-end install for the **household deployment** of OSCAR on a ServiceBay full-stack host.
+
+> **Want the fast path first?** [`../../docs/getting-started.md`](../../docs/getting-started.md) shows how to reach chat + native HA control + memory + document retrieval + voice from a bare `pip install hermes-agent` — no ServiceBay templates, no OSCAR code. Do that (Tiers 1–2) to validate Hermes on your hardware before committing to the packaged deployment below (Tier 3).
+
+A ServiceBay stack is **documentation-only** — there's no programmatic "deploy these N" button. The OSCAR stack walks through:
+
+1. ServiceBay's `ai-stack` walkthrough — `ollama` + `hermes`
+2. OSCAR's `oscar-household` template — the household-specific glue (schema init + skill mount + voice gatekeeper + non-interactive MCP wiring)
+3. (Optional, Phase 1) ServiceBay's unchanged `voice` template, deployed alongside `oscar-household`
+
+> **Status**: the `ai-stack` templates are upstream work in `mdopp/servicebay` ([#538](https://github.com/mdopp/servicebay/issues/538), [#539](https://github.com/mdopp/servicebay/issues/539), [#540](https://github.com/mdopp/servicebay/issues/540)). Until they land, Step 1 below is aspirational — marked **TODO ServiceBay**.
+
+## Prerequisites
+
+- **ServiceBay v3.16+** on a Fedora CoreOS host with the **full-stack** deployed (auth, nginx, home-assistant, …).
+- **[mdopp/servicebay#443](https://github.com/mdopp/servicebay/issues/443)** merged so ServiceBay can sync external git registries.
+- **[mdopp/servicebay#348](https://github.com/mdopp/servicebay/issues/348)** merged — only needed once you add voice (Phase 1); lets you deploy HA with `VOICE_BUILTIN=disabled` so Wyoming ports don't collide with ServiceBay's `voice` template.
+- A **Home Assistant long-lived access token** (Profile → Security → Long-lived access tokens). Hermes' native HA integration consumes it as `HASS_TOKEN` — no HA-MCP integration needed.
+- A **ServiceBay-MCP** bearer token (Settings → Integrations → MCP → Generate token, scope `read+lifecycle`).
+- For **gpu-local** mode: `nvidia-container-toolkit` + CDI on the host. For **cpu-local** / **cloud-only** modes: nothing extra.
+
+## Step 0 — Add the OSCAR registry
+
+ServiceBay → Settings → Registries → Add:
+
+- Name: `oscar`
+- URL: `https://github.com/mdopp/oscar.git`
+
+After save, the `oscar-household` template appears in the wizard.
+
+## Step 1 — Walk through ServiceBay's `ai-stack`
+
+**TODO ServiceBay** — Phase 0 depends on these landing.
+
+The end-state walkthrough:
+
+1. **`ollama`** ([mdopp/servicebay#538](https://github.com/mdopp/servicebay/issues/538)) — choose model (`gemma3:4b` default; bump once GPU passthrough works), enable GPU passthrough if you have a CDI-registered NVIDIA GPU. Defaults to `OLLAMA_HOST=127.0.0.1` — remote access goes through NPM + Authelia. First start pulls the model.
+2. **`hermes`** ([mdopp/servicebay#539](https://github.com/mdopp/servicebay/issues/539)) — wraps `docker.io/nousresearch/hermes-agent`. Wizard prompts: `HERMES_API_KEY` (auto-generated, surfaced as `__SB_CREDENTIAL__`), `HERMES_LLM_PROVIDER_URL` (defaults to the `ollama` template's port). **Set `HASS_TOKEN` + `HASS_URL` here** — that turns on Hermes' native Home Assistant integration (device control out of the box; no HA-MCP, no OSCAR skill). Hermes ships its own SQLite for Honcho — no external Postgres needed. **Setup runs non-interactively**; no `podman exec hermes setup` step.
+
+(`postgres` and `qdrant` enter the picture only if Phase 3a decides to migrate off SQLite — see [`oscar-architecture.md`](../../oscar-architecture.md) → "Phase 3a — Streaming ingestion". For Phase 0–2, neither is needed.)
+
+## Step 2 — Pair the messaging gateway
+
+Hermes' messaging gateways (Signal, Telegram, Discord, Slack, WhatsApp, Email) need an **interactive** pairing because the underlying messenger protocols require it. ServiceBay's deploy-time hooks are non-interactive by contract (`docs/UX_PHILOSOPHY.md` §2) — pairing therefore happens as a **one-off post-install operator step**, then env-var wiring becomes scriptable.
+
+### Signal (the OSCAR-recommended channel)
+
+Source: [Hermes Signal setup](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal).
+
+```bash
+ssh <oscar-host>
+podman exec -it hermes signal-cli link -n "HermesAgent"
+# A QR code is printed. Scan it with your phone's Signal app:
+#   Settings → Linked devices → Link new device → scan QR
+```
+
+After the link is established, the rest is env-driven — `SIGNAL_HTTP_URL`, `SIGNAL_ACCOUNT`, `SIGNAL_ALLOWED_USERS`, etc. land in `${DATA_DIR}/hermes/.env`. A future iteration can drive those writes from this stack; for now the operator pastes them into Hermes' wizard or into the `.env` file directly, then restarts the `hermes` service.
+
+### Telegram / Discord / Slack / WhatsApp / Email
+
+Same pattern — Hermes' docs ([Messaging gateways](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/)) cover the per-channel setup. All boil down to: get a token / scan a QR / pair once, then env-vars in `.env`, then restart.
+
+> ServiceBay's `hermes` template plans to surface "channel not paired" as a `diagnose` probe with a structured `actions[]` button that pops the link command. Until that lands, the manual step above is the path.
+
+## Step 3 — Deploy OSCAR's `oscar-household`
+
+ServiceBay wizard → `oscar-household` → fill in:
+
+- `DEFAULT_UID` — household admin's LLDAP uid (default `michael`)
+- `HERMES_API_PORT` — defaults to `8642` (matches the ServiceBay `hermes` template's default; reached via host loopback)
+- `HERMES_API_KEY` — paste the value the `hermes` template surfaced as `__SB_CREDENTIAL__` (Step 1 surfaces it in the SAVE-THESE-NOW banner)
+- `SERVICEBAY_MCP_URL` + `SERVICEBAY_MCP_TOKEN` — ServiceBay-MCP bearer
+
+  (No `HA_MCP_*` — Home Assistant is wired natively in the `hermes` template via `HASS_TOKEN`, not as an MCP.)
+- `GATEKEEPER_PORT` — default `10700`, host port for HA Voice PE
+- `GATEKEEPER_IMAGE` — leave default (`ghcr.io/mdopp/oscar-gatekeeper:latest`)
+- `WHISPER_URI` / `PIPER_URI` — default to `127.0.0.1:10300` / `10200` (matches ServiceBay's `voice` template's published ports; only relevant once voice is added)
+- `VOICE_PE_DEVICES` — `{}` for now (populate once devices are paired)
+- `LLDAP_GROUP` — defaults to `family`
+- `OSCAR_DEBUG_MODE` — `true` while building, `false` for productive household
+
+The template doesn't ask for a database DSN — it ships its own SQLite (`oscar.db`) in the pod's volume.
+
+Deploy. The template:
+
+- Runs Alembic against the local `oscar.db`, creating `cloud_audit`, `system_settings`, `voice_embeddings` (idempotent)
+- Starts the gatekeeper container (long-running, idle until you point a Voice PE at it)
+- Non-interactive post-deploy: reads `${DATA_DIR}/hermes/config.yaml`, splices in an `mcp_servers:` block for ServiceBay-MCP, writes back, then `POST /api/services/hermes/action {action: "restart"}` so Hermes picks up the new config. **No `podman exec` needed.** (HA isn't here — it's the `hermes` template's native `HASS_TOKEN` integration.) Sources: [Hermes MCP Config Reference](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference), [Hermes Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration).
+
+> **Caveat.** Re-deploying the ServiceBay `hermes` template rewrites `config.yaml` with just its `model:` block. Re-deploy `oscar-household` afterwards to restore the `mcp_servers:` block.
+
+## Step 4 — Smoke-test
+
+Talk to OSCAR through whichever gateway you paired:
+
+```
+You (Signal):    bist du da?
+OSCAR:           ja, alles ok. ollama, oscar.db, home-assistant und servicebay-mcp antworten.
+You:             mach das wohnzimmerlicht an
+OSCAR:           ok, wohnzimmer ist an.
+You:             stell einen timer auf 5 minuten
+OSCAR:           ok, fünf minuten.
+You:             was kostete der gestrige cloud-call?
+OSCAR:           gestern abend einer um 21:14, anthropic claude-haiku, 0,0023 €.
+```
+
+If anything answers "nein", run `oscar-status` first — it calls ServiceBay-MCP's `get_health_checks` / `diagnose` and returns the per-component state.
+
+## Step 5 — Add voice (Phase 1, optional)
+
+Once Phase 0 works, add voice by deploying ServiceBay's **unchanged** `voice` template alongside `oscar-household`. Both pods are `hostNetwork: true`, so the gatekeeper container in `oscar-household` reaches the `voice` template's Whisper/Piper via `127.0.0.1`.
+
+1. Make sure HA was redeployed with `VOICE_BUILTIN=disabled` (otherwise HA's bundled Wyoming containers collide with the `voice` template on ports 10300/10200/10400).
+2. Walk through ServiceBay's `voice` template:
+   - `STT_GPU_PASSTHROUGH=yes` for `large-v3`; `WHISPER_MODEL=large-v3` (or `small` / `base` on CPU)
+   - `WHISPER_LANGUAGE=de`, `PIPER_VOICE=de_DE-thorsten-medium`
+3. Point HA Voice PE devices at the host's `:10700` (Wyoming, the port `oscar-household` exposes).
+
+The gatekeeper in `oscar-household` immediately picks it up — no re-deploy of `oscar-household` needed.
+
+## Step 6 — Connectors (optional)
+
+If you want weather, news, or other external information, register a third-party MCP server with Hermes. Same non-interactive pattern as Step 3 (the `hermes` template's UI surfaces an "add MCP server" form; behind the scenes it's an HTTP call to Hermes' API).
+
+OSCAR no longer ships its own weather/news connectors — Hermes' MCP ecosystem is rich enough that we consume third-party MCPs instead of duplicating them.
+
+The one exception is the **cloud-LLM audit proxy** (planned separate repo `mcp-audit-proxy`). Once published, register it the same way; `oscar-household`'s post-deploy will then route Hermes' cloud calls through it so every call writes a `cloud_audit` row.
+
+## After install — smoke-test checklist
+
+The full observe-first matrix lives in [`mdopp/oscar#70`](https://github.com/mdopp/oscar/issues/70). Work through it after install and file gaps as separate issues:
+
+- [ ] `oscar-status` returns green for all probes
+- [ ] Signal/Telegram round-trip → Hermes responds in German
+- [ ] Light command turns the light on/off (Hermes' native HA integration)
+- [ ] Timer command creates a Hermes cron job and fires on schedule
+- [ ] Cloud-LLM call (e.g. complex question) writes a `cloud_audit` row
+- [ ] `oscar-audit-query` returns the row when asked
+- [ ] (Phase 1) Voice round-trip via HA Voice PE works under 1.5 s end-to-end


### PR DESCRIPTION
Consolidates all OSCAR application components (skills, schema migrations, gatekeeper, architecture documents) into the main servicebay repository to streamline local testing and monorepo deployments. Includes the new prompt_tokens, completion_tokens, and total_tokens columns in the SQLite cloud_audit migration table.