### PR TITLE
feat(oscar): close OSCAR follow-ups #937 #938 #939 #940

### DIFF
--- a/packages/backend/src/lib/oscar/pendingSkills.ts
+++ b/packages/backend/src/lib/oscar/pendingSkills.ts
@@ -1,0 +1,163 @@
+import path from 'path';
+import { getExecutor } from '../executor';
+import { listNodes } from '../nodes';
+import { getConfig } from '../config';
+import { logger } from '../logger';
+import type { Executor } from '../interfaces';
+
+const TAG = 'oscar:pending-skills';
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export interface PendingSkill {
+  slug: string;
+  description: string | null;
+  version: string | null;
+  bytes: number;
+  createdAt: string | null;
+  preview: string;
+}
+
+interface Locations {
+  pendingRoot: string;
+  activeRoot: string;
+  nodeName: string;
+}
+
+function dataDir(): string {
+  // The two install runners default to '/mnt/data/stacks' when no
+  // operator override is set; keep the same fallback so list/promote
+  // hit the directory the templates actually use on a fresh install.
+  return '/mnt/data/stacks';
+}
+
+async function resolveLocations(requestedNode: string | undefined): Promise<Locations> {
+  const config = await getConfig();
+  const root = config.templateSettings?.DATA_DIR || dataDir();
+
+  let nodeName = requestedNode;
+  if (!nodeName || nodeName === 'Local') {
+    const nodes = await listNodes();
+    nodeName = nodes[0]?.Name || 'Local';
+  }
+
+  return {
+    pendingRoot: path.posix.join(root, 'oscar-household', 'skills-pending'),
+    activeRoot: path.posix.join(root, 'oscar-household', 'skills'),
+    nodeName,
+  };
+}
+
+function assertSlug(slug: string): void {
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(`Invalid skill slug: ${slug}. Must be lowercase alphanumeric + dashes, 1-64 chars, no leading dot.`);
+  }
+}
+
+function parseFrontmatter(text: string): { description: string | null; version: string | null } {
+  if (!text.startsWith('---')) return { description: null, version: null };
+  const closeIdx = text.indexOf('\n---', 3);
+  if (closeIdx < 0) return { description: null, version: null };
+  const block = text.slice(3, closeIdx);
+  let description: string | null = null;
+  let version: string | null = null;
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const sepIdx = line.indexOf(':');
+    if (sepIdx <= 0) continue;
+    const key = line.slice(0, sepIdx).trim().toLowerCase();
+    const value = line.slice(sepIdx + 1).trim().replace(/^["']|["']$/g, '');
+    if (key === 'description' && description === null) description = value;
+    if (key === 'version' && version === null) version = value;
+  }
+  return { description, version };
+}
+
+async function readSkillFile(executor: Executor, pendingRoot: string, slug: string): Promise<string | null> {
+  try {
+    return await executor.readFile(path.posix.join(pendingRoot, slug, 'SKILL.md'));
+  } catch (err) {
+    logger.warn(TAG, `could not read SKILL.md for ${slug}: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+async function listSlugs(executor: Executor, pendingRoot: string): Promise<string[]> {
+  try {
+    if (!(await executor.exists(pendingRoot))) return [];
+    const entries = await executor.readdir(pendingRoot);
+    return entries.filter(entry => SLUG_RE.test(entry));
+  } catch (err) {
+    // The directory exists check above already handled the most common
+    // "not yet created" case. Anything else is a real failure to surface.
+    logger.warn(TAG, `could not list ${pendingRoot}: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+async function statMtime(executor: Executor, target: string): Promise<string | null> {
+  try {
+    const { stdout } = await executor.execArgv(['stat', '-c', '%Y', target]);
+    const epoch = Number(stdout.trim());
+    if (!Number.isFinite(epoch)) return null;
+    return new Date(epoch * 1000).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+export async function listPendingSkills(requestedNode?: string): Promise<PendingSkill[]> {
+  const { pendingRoot, nodeName } = await resolveLocations(requestedNode);
+  const executor = getExecutor(nodeName);
+  const slugs = await listSlugs(executor, pendingRoot);
+  const out: PendingSkill[] = [];
+  for (const slug of slugs) {
+    const skillPath = path.posix.join(pendingRoot, slug, 'SKILL.md');
+    const content = await readSkillFile(executor, pendingRoot, slug);
+    if (content === null) continue;
+    const { description, version } = parseFrontmatter(content);
+    const preview = content.length > 2000 ? content.slice(0, 2000) + '\n…' : content;
+    out.push({
+      slug,
+      description,
+      version,
+      bytes: content.length,
+      createdAt: await statMtime(executor, skillPath),
+      preview,
+    });
+  }
+  out.sort((a, b) => (a.createdAt && b.createdAt ? b.createdAt.localeCompare(a.createdAt) : a.slug.localeCompare(b.slug)));
+  return out;
+}
+
+export async function promotePendingSkill(slug: string, requestedNode?: string): Promise<void> {
+  assertSlug(slug);
+  const { pendingRoot, activeRoot, nodeName } = await resolveLocations(requestedNode);
+  const src = path.posix.join(pendingRoot, slug);
+  const dst = path.posix.join(activeRoot, slug);
+  const executor = getExecutor(nodeName);
+
+  if (!(await executor.exists(path.posix.join(src, 'SKILL.md')))) {
+    throw new Error(`Pending skill not found: ${slug}`);
+  }
+  if (await executor.exists(dst)) {
+    throw new Error(`A skill named ${slug} is already active — rename the pending draft before promoting.`);
+  }
+  await executor.mkdir(activeRoot);
+  await executor.rename(src, dst);
+  logger.info(TAG, `promoted skill ${slug} on node ${nodeName}`);
+}
+
+export async function rejectPendingSkill(slug: string, requestedNode?: string): Promise<void> {
+  assertSlug(slug);
+  const { pendingRoot, nodeName } = await resolveLocations(requestedNode);
+  const target = path.posix.join(pendingRoot, slug);
+  const executor = getExecutor(nodeName);
+  if (!(await executor.exists(target))) {
+    // Idempotent — rejecting an already-deleted draft is fine.
+    return;
+  }
+  await executor.rm(target);
+  logger.info(TAG, `rejected skill ${slug} on node ${nodeName}`);
+}

--- a/src/app/(dashboard)/settings/_lib/sections/PendingSkillsSection.tsx
+++ b/src/app/(dashboard)/settings/_lib/sections/PendingSkillsSection.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Check, ChevronDown, ChevronRight, Loader2, ShieldAlert, Trash2 } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+interface PendingSkill {
+  slug: string;
+  description: string | null;
+  version: string | null;
+  bytes: number;
+  createdAt: string | null;
+  preview: string;
+}
+
+/**
+ * Admin-promotion gate for OSCAR's dynamic-skill compiler (#940).
+ *
+ * OSCAR's `dynamic-skills` skill drafts new SKILL.md files into the
+ * pending directory rather than the active one. This panel lists those
+ * drafts, lets the admin inspect the generated Markdown, and either
+ * promote (move into the active dir + restart Hermes) or reject
+ * (delete). Without the gate, a prompt-injected family-member chat
+ * session could have OSCAR grant itself arbitrary code execution by
+ * writing a malicious skill straight into the loader's scan dir.
+ */
+export default function PendingSkillsSection() {
+  const { addToast } = useToast();
+  const [skills, setSkills] = useState<PendingSkill[]>([]);
+  const [busy, setBusy] = useState<'load' | 'action' | null>('load');
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const load = async () => {
+    try {
+      const res = await fetch('/api/oscar/pending-skills');
+      if (res.ok) {
+        const data = await res.json();
+        setSkills(Array.isArray(data.skills) ? data.skills : []);
+      } else {
+        addToast('error', 'Could not load pending skills', `HTTP ${res.status}`);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const onPromote = async (slug: string) => {
+    if (!window.confirm(`Promote ${slug}? The draft moves into the active skills directory and Hermes is restarted so the loader picks it up. You can roll back by deleting the directory from disk or rejecting before promoting.`)) return;
+    setBusy('action');
+    try {
+      const res = await fetch(`/api/oscar/pending-skills/${encodeURIComponent(slug)}/promote`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        if (data.restarted === false) {
+          addToast('warning', 'Promoted, but Hermes restart failed', data.restartError ?? 'Restart Hermes from the services page to load the new skill.');
+        } else {
+          addToast('success', 'Skill promoted', `${slug} is live. Hermes restarted.`);
+        }
+        await load();
+      } else {
+        addToast('error', 'Could not promote', data.error ?? `HTTP ${res.status}`);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onReject = async (slug: string) => {
+    if (!window.confirm(`Reject ${slug}? The draft directory is deleted. No undo.`)) return;
+    setBusy('action');
+    try {
+      const res = await fetch(`/api/oscar/pending-skills/${encodeURIComponent(slug)}`, { method: 'DELETE' });
+      if (res.ok) {
+        addToast('success', 'Skill rejected', `${slug} removed from pending.`);
+        await load();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        addToast('error', 'Could not reject', data.error ?? `HTTP ${res.status}`);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggleExpand = (slug: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  };
+
+  if (busy === 'load') {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading pending OSCAR skills…
+      </div>
+    );
+  }
+
+  return (
+    <div id="pending-skills" className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full scroll-mt-24">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 bg-amber-100 dark:bg-amber-900/30 rounded-lg text-amber-600 dark:text-amber-400">
+          <ShieldAlert size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">
+            Pending OSCAR skills
+            {skills.length > 0 && (
+              <span className="ml-2 inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold text-white bg-amber-500 rounded-full">
+                {skills.length}
+              </span>
+            )}
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Drafts written by OSCAR&apos;s dynamic-skills compiler. Inspect the SKILL.md, then <span className="font-medium">Promote</span> to make it live (moves into <span className="font-mono">/opt/data/skills/oscar/</span> and restarts Hermes), or <span className="font-medium">Reject</span> to delete the draft.
+          </p>
+        </div>
+      </div>
+
+      <div className="p-6">
+        {skills.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+            No pending drafts. OSCAR will list new skill proposals here when its dynamic-skills compiler runs.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {skills.map(skill => {
+              const isOpen = expanded.has(skill.slug);
+              return (
+                <div key={skill.slug} className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+                  <div className="p-3 flex items-start gap-3">
+                    <button
+                      onClick={() => toggleExpand(skill.slug)}
+                      className="p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+                      title={isOpen ? 'Collapse' : 'Expand SKILL.md'}
+                    >
+                      {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                    </button>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-mono text-sm font-medium text-gray-900 dark:text-white">{skill.slug}</span>
+                        {skill.version && (
+                          <span className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-mono bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded">
+                            v{skill.version}
+                          </span>
+                        )}
+                        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                          {skill.bytes.toLocaleString()} bytes
+                        </span>
+                        {skill.createdAt && (
+                          <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                            · {new Date(skill.createdAt).toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                      {skill.description && (
+                        <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">{skill.description}</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={() => onPromote(skill.slug)}
+                        disabled={busy === 'action'}
+                        className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded disabled:opacity-50"
+                        title="Move into the active skills dir and restart Hermes"
+                      >
+                        <Check size={14} /> Promote
+                      </button>
+                      <button
+                        onClick={() => onReject(skill.slug)}
+                        disabled={busy === 'action'}
+                        className="p-1.5 text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                        title="Delete this draft"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  </div>
+                  {isOpen && (
+                    <pre className="border-t border-gray-200 dark:border-gray-700 p-3 text-xs font-mono text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-gray-950 overflow-x-auto whitespace-pre-wrap break-words max-h-[420px] overflow-y-auto">
+                      {skill.preview}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -6,6 +6,7 @@ import EmailNotificationsSection from '../_lib/sections/EmailNotificationsSectio
 import FileShareSection from '../_lib/sections/FileShareSection';
 import GatewaySection from '../_lib/sections/GatewaySection';
 import McpSection from '../_lib/sections/McpSection';
+import PendingSkillsSection from '../_lib/sections/PendingSkillsSection';
 import PublicDomainSection from '../_lib/sections/PublicDomainSection';
 import ReverseProxySection from '../_lib/sections/ReverseProxySection';
 import TemplateRegistriesSection from '../_lib/sections/TemplateRegistriesSection';
@@ -17,6 +18,7 @@ export default function IntegrationsSettingsPage() {
       <PublicDomainSection />
       <GatewaySection />
       <AccessRequestsSection />
+      <PendingSkillsSection />
       <CredentialsSection />
       <ReverseProxySection />
       <FileShareSection />

--- a/src/app/api/oscar/pending-skills/[slug]/promote/route.ts
+++ b/src/app/api/oscar/pending-skills/[slug]/promote/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { promotePendingSkill } from '@/lib/oscar/pendingSkills';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({ node: z.string().optional() });
+
+export const POST = withApiHandlerParams<undefined, z.infer<typeof Query>, { slug: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+    const slug = decodeURIComponent(params.slug);
+    try {
+      await promotePendingSkill(slug, query.node);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:oscar:pending-skills', `promote ${slug} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    // Restart Hermes so its loader picks up the new skill. The promote
+    // already succeeded — surface a soft warning if the restart fails
+    // rather than rolling back, because the file move is the load-
+    // bearing part. The operator can restart Hermes from the services
+    // page if this nudge doesn't take.
+    const nodeName = query.node || 'Local';
+    try {
+      await ServiceManager.restartService(nodeName, 'hermes');
+      return NextResponse.json({ ok: true, restarted: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.warn('api:oscar:pending-skills', `promote ${slug} ok but hermes restart failed: ${message}`);
+      return NextResponse.json({ ok: true, restarted: false, restartError: message });
+    }
+  },
+);

--- a/src/app/api/oscar/pending-skills/[slug]/route.ts
+++ b/src/app/api/oscar/pending-skills/[slug]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { rejectPendingSkill } from '@/lib/oscar/pendingSkills';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({ node: z.string().optional() });
+
+export const DELETE = withApiHandlerParams<undefined, z.infer<typeof Query>, { slug: string }>(
+  { query: Query },
+  async ({ query, params }) => {
+    try {
+      await rejectPendingSkill(decodeURIComponent(params.slug), query.node);
+      return NextResponse.json({ ok: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:oscar:pending-skills', `reject ${params.slug} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/src/app/api/oscar/pending-skills/route.ts
+++ b/src/app/api/oscar/pending-skills/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandler } from '@/lib/api/handler';
+import { listPendingSkills } from '@/lib/oscar/pendingSkills';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({ node: z.string().optional() });
+
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+    try {
+      const skills = await listPendingSkills(query.node);
+      return NextResponse.json({ skills });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:oscar:pending-skills', 'list failed', error);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  },
+);

--- a/templates/hermes/CHANGELOG.md
+++ b/templates/hermes/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Hermes — template changelog
 
+## v3 — #940
+
+OSCAR's dynamic skill compiler now drafts pending skills into a separate
+host directory that Hermes' loader does not scan. The Hermes pod gets a
+new bind mount, `{{DATA_DIR}}/oscar-household/skills-pending` at
+`/opt/data/skills-pending`, alongside the existing
+`/opt/data/skills/oscar` mount.
+
+Operator impact: none on redeploy. The host directory is auto-created
+(`type: DirectoryOrCreate`) and starts empty. The ServiceBay dashboard
+gains a "Pending OSCAR skills" panel under **Settings → Integrations**
+where the admin promotes or rejects drafts before they go live.
+
+Before v3 the OSCAR `dynamic-skills` skill instructed Hermes to write
+new skills directly under `/opt/data/skills/oscar/...` and to call
+`restart_service hermes`, which auto-activated agent-generated code
+with no human review — a prompt-injection risk. v3 retires that path.
+
 ## v2 — #829
 
 The Hermes web dashboard is now exposed as a real service.

--- a/templates/hermes/README.md
+++ b/templates/hermes/README.md
@@ -47,6 +47,30 @@ and we write the relevant fields ourselves. The Hermes image's
 entrypoint takes care of bootstrapping the rest (Honcho DB,
 FTS5 index, SOUL.md skeleton) idempotently on each start.
 
+## Multimodal (image-bearing) chats
+
+Hermes' generated `config.yaml` writes a single `model:` block, so
+every turn — text-only or image-bearing — goes through the same
+model tag. If you want OSCAR's `media-ingestion-multimodal` skill
+(book covers, document photos) to actually OCR images instead of
+returning "I can't see images", the model you point `HERMES_LLM_MODEL`
+at must itself be vision-capable.
+
+Two ways to get there:
+
+1. **Single multimodal model.** Pull a vision-capable tag in
+   `ollama` (set `OLLAMA_DEFAULT_MODEL=qwen2.5vl:7b` or similar)
+   and set `HERMES_LLM_MODEL` to the same tag. Vision models
+   handle text-only turns fine, so a single model covers both
+   cases. Simplest setup.
+2. **Two models in parallel (text fast, vision on demand).** Keep
+   `OLLAMA_DEFAULT_MODEL=gemma3:4b` for low-latency text turns and
+   set `OLLAMA_VISION_MODEL=qwen2.5vl:7b` to pre-pull the vision
+   model. Routing image-bearing turns to the vision model is
+   pending upstream Hermes support — until then, point
+   `HERMES_LLM_MODEL` at the vision tag when running the media
+   pipeline.
+
 ## Adding MCP servers
 
 Per the upstream

--- a/templates/hermes/README.md
+++ b/templates/hermes/README.md
@@ -28,6 +28,19 @@ ServiceBay pod that:
   dashboard. Default `9119`.
 - `HERMES_SUBDOMAIN` — subdomain for the dashboard. Default
   `hermes`; internal exposure, behind Authelia forward-auth.
+- `TELEGRAM_BOT_TOKEN` / `TELEGRAM_ALLOWED_USERS` — optional;
+  bot token from @BotFather + comma-separated numeric user IDs
+  allowed to chat with Hermes. Both must be set for inbound chats
+  to be served — without the allowlist Hermes denies every message
+  and logs `No user allowlists configured`.
+- `DISCORD_BOT_TOKEN` / `DISCORD_ALLOWED_CHANNELS` — optional;
+  bot token from Discord's developer portal + comma-separated
+  channel IDs Hermes is allowed to respond in.
+- `SIGNAL_ACCOUNT` / `SIGNAL_ALLOWED_USERS` — optional; the
+  E.164 phone number of the linked signal-cli account + the
+  comma-separated allowlist of E.164 numbers that may chat. The
+  pairing step is interactive (QR scan), see below — these
+  variables drive the Hermes-side wiring after pairing.
 
 ## What `post-deploy.py` does
 
@@ -37,8 +50,12 @@ ServiceBay pod that:
    model provider, model name, and base URL. This file is what
    Hermes' main loop reads on every start, so changes apply
    immediately.
-3. Restarts the pod so Hermes picks up the new config.
-4. Surfaces `HERMES_API_KEY` as a `__SB_CREDENTIAL__` for the
+3. Merges the messaging-gateway variables (Telegram / Discord /
+   Signal bot tokens + allowlists) into `${DATA_DIR}/hermes/.env`,
+   leaving unmanaged keys in that file untouched. Idempotent — a
+   re-run with the same values is a no-op.
+4. Restarts the pod so Hermes picks up the new config or .env.
+5. Surfaces `HERMES_API_KEY` as a `__SB_CREDENTIAL__` for the
    install banner.
 
 No `hermes setup` interactive wizard is invoked — the only thing
@@ -96,18 +113,30 @@ so scripted reconfiguration restarts the pod.
 
 ## Connecting messaging gateways (Signal, Telegram, …)
 
-These have **a genuinely interactive step that neither side of a
-ServiceBay deploy can do**. Signal is the clearest case:
+Most of the gateway wiring (bot tokens, per-platform allowlists) is
+collected by the ServiceBay wizard and merged into
+`${DATA_DIR}/hermes/.env` by `post-deploy.py`. See the
+`TELEGRAM_*` / `DISCORD_*` / `SIGNAL_*` variables above.
 
-1. **Operator runs `signal-cli link -n "HermesAgent"`** to generate
-   a linking QR code. The QR has to be scanned by the operator's
-   physical phone via the Signal app. This step is irreducibly
-   manual — no daemon and no script can do it.
-2. **Hermes-side configuration** (SIGNAL_HTTP_URL, SIGNAL_ACCOUNT,
-   SIGNAL_ALLOWED_USERS, …) lands in `${DATA_DIR}/hermes/.env` and
-   *is* env-driven, so it can be scripted by a downstream template
-   (e.g. OSCAR's `oscar-household`) once the operator has done the
-   QR scan.
+Two parts still need an operator action because they're
+irreducibly interactive:
+
+1. **Creating the bot.** Telegram (@BotFather → bot token), Discord
+   (developer portal → application + bot token), and Signal (a
+   real phone number with the Signal app installed) all require a
+   one-time setup outside ServiceBay before you have a token to
+   paste into the wizard.
+2. **Signal account pairing.** Even after the wizard has the
+   `SIGNAL_ACCOUNT` allowlist, `signal-cli` still needs the
+   operator's phone to scan a QR code:
+
+   ```
+   podman exec -it hermes signal-cli link -n "HermesAgent"
+   ```
+
+   The QR has to be scanned by the operator's physical phone via
+   the Signal app. signal-cli writes credentials into the Hermes
+   data volume — they survive subsequent reinstalls.
 
 The boundary is: **pairing is manual, env-var wiring after pairing
 is scriptable.** Downstream templates can drive step 2 but never

--- a/templates/hermes/post-deploy.py
+++ b/templates/hermes/post-deploy.py
@@ -154,6 +154,107 @@ def restart_hermes(sb_api: str) -> bool:
     return False
 
 
+def write_gateway_env(data_dir: str, entries: dict[str, str]) -> bool:
+    """Merge messaging-gateway credentials into `<DATA_DIR>/hermes/.env`.
+
+    Hermes reads its gateway allowlists and bot tokens from this file at
+    start time (the warning Hermes prints on a fresh install names this
+    exact path: `~/.hermes/.env`). The pod mounts `<DATA_DIR>/hermes` at
+    `/opt/data`, and Hermes' default HOME is `/opt/data` → `.env` here is
+    the same file Hermes loads.
+
+    Merge semantics: read existing key/value lines, overwrite the keys
+    we manage, keep everything else untouched. Empty values clear a key
+    (so an operator who removes a token from the wizard actually rotates
+    the credential out). A run with all-empty inputs and no existing
+    file is a no-op.
+
+    Returns True when the .env file changed (signals the caller to
+    restart the pod), False when it was already up to date.
+    """
+    config_dir = os.path.join(data_dir, "hermes")
+    env_path = os.path.join(config_dir, ".env")
+    managed_keys = {
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_ALLOWED_USERS",
+        "DISCORD_BOT_TOKEN",
+        "DISCORD_ALLOWED_CHANNELS",
+        "SIGNAL_ACCOUNT",
+        "SIGNAL_ALLOWED_USERS",
+    }
+    existing: dict[str, str] = {}
+    order: list[str] = []
+    preamble: list[str] = []
+    if os.path.exists(env_path):
+        try:
+            with open(env_path, encoding="utf-8") as f:
+                for raw in f:
+                    line = raw.rstrip("\n")
+                    if not line.strip() or line.lstrip().startswith("#"):
+                        preamble.append(line)
+                        continue
+                    if "=" not in line:
+                        preamble.append(line)
+                        continue
+                    key, _, value = line.partition("=")
+                    key = key.strip()
+                    if not key:
+                        preamble.append(line)
+                        continue
+                    if key in managed_keys:
+                        # Drop existing managed lines; they get rewritten below.
+                        continue
+                    existing[key] = value
+                    order.append(key)
+        except OSError as e:
+            jlog("warn", "hermes:env", "could not read .env, will recreate", path=env_path, error=str(e))
+            existing = {}
+            order = []
+            preamble = []
+
+    # Decide whether anything would actually change.
+    new_managed = {k: v for k, v in entries.items() if v}
+    desired_lines: list[str] = []
+    for line in preamble:
+        desired_lines.append(line)
+    for key in order:
+        desired_lines.append(f"{key}={existing[key]}")
+    if new_managed:
+        if desired_lines and desired_lines[-1] != "":
+            desired_lines.append("")
+        for key in sorted(new_managed):
+            desired_lines.append(f"{key}={new_managed[key]}")
+    new_content = "\n".join(desired_lines).rstrip("\n") + ("\n" if desired_lines else "")
+
+    if not os.path.exists(env_path) and not new_managed:
+        return False
+
+    try:
+        with open(env_path, encoding="utf-8") as f:
+            old_content = f.read()
+    except (FileNotFoundError, OSError):
+        old_content = ""
+    if old_content == new_content:
+        return False
+
+    try:
+        os.makedirs(config_dir, exist_ok=True)
+        with open(env_path, "w", encoding="utf-8") as f:
+            f.write(new_content)
+        os.chmod(env_path, 0o600)
+    except OSError as e:
+        jlog("error", "hermes:env", "could not write .env", path=env_path, error=str(e))
+        return False
+    jlog(
+        "info",
+        "hermes:env",
+        "updated messaging-gateway .env",
+        path=env_path,
+        keys=sorted(new_managed.keys()),
+    )
+    return True
+
+
 def adopt_ha_long_lived_token(data_dir: str) -> str | None:
     """When home-assistant's post-deploy has auto-onboarded HA (#934), it
     leaves a long-lived access token at
@@ -227,9 +328,24 @@ def main() -> int:
     # HA on every call.
     adopt_ha_long_lived_token(data_dir)
 
+    # Merge messaging-gateway credentials (Telegram / Discord / Signal
+    # allowlists + bot tokens) into <DATA_DIR>/hermes/.env. Idempotent —
+    # only signals a restart when something actually changed.
+    env_changed = write_gateway_env(
+        data_dir,
+        {
+            "TELEGRAM_BOT_TOKEN": env("TELEGRAM_BOT_TOKEN"),
+            "TELEGRAM_ALLOWED_USERS": env("TELEGRAM_ALLOWED_USERS"),
+            "DISCORD_BOT_TOKEN": env("DISCORD_BOT_TOKEN"),
+            "DISCORD_ALLOWED_CHANNELS": env("DISCORD_ALLOWED_CHANNELS"),
+            "SIGNAL_ACCOUNT": env("SIGNAL_ACCOUNT"),
+            "SIGNAL_ALLOWED_USERS": env("SIGNAL_ALLOWED_USERS"),
+        },
+    )
+
     # 2. Restart so Hermes picks up the new config (and the new env if we
-    # just patched HASS_TOKEN).
-    if config_written:
+    # just patched HASS_TOKEN or rewrote .env).
+    if config_written or env_changed:
         # Give the pod a few seconds to settle so the restart isn't
         # racing the initial deploy.
         time.sleep(3)

--- a/templates/hermes/template.yml
+++ b/templates/hermes/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: hermes
   annotations:
     servicebay.label: "Hermes Agent"
-    servicebay.schema-version: "2"
+    servicebay.schema-version: "3"
     servicebay.ports: "{{HERMES_API_PORT}}/tcp,{{HERMES_DASHBOARD_PORT}}/tcp"
     # Hermes' default LLM_PROVIDER_URL points at the `ollama` template's
     # default port. The wizard topo-sorts based on this annotation so
@@ -83,6 +83,15 @@ spec:
       name: hermes-data
     - mountPath: /opt/data/skills/oscar
       name: oscar-skills
+    # Drafted skills go here, NOT under /opt/data/skills/oscar. Hermes'
+    # skill loader scans /opt/data/skills/oscar; anything that lands
+    # there is live immediately. OSCAR's dynamic-skills SKILL.md writes
+    # drafts here instead, and an admin promotes them via the
+    # ServiceBay dashboard (issue #940). Keeping the pending dir
+    # outside the loader's scan root is the structural half of that
+    # gate — the SKILL.md is the prompt-level half.
+    - mountPath: /opt/data/skills-pending
+      name: oscar-skills-pending
     - mountPath: /opt/data/notes
       name: syncthing-notes
 
@@ -120,6 +129,10 @@ spec:
   - name: oscar-skills
     hostPath:
       path: {{DATA_DIR}}/oscar-household/skills
+      type: DirectoryOrCreate
+  - name: oscar-skills-pending
+    hostPath:
+      path: {{DATA_DIR}}/oscar-household/skills-pending
       type: DirectoryOrCreate
   - name: syncthing-notes
     hostPath:

--- a/templates/hermes/variables.json
+++ b/templates/hermes/variables.json
@@ -44,5 +44,33 @@
   "HASS_TOKEN": {
     "type": "secret",
     "description": "Optional: Home Assistant long-lived access token. When set, turns on Hermes' native Home Assistant integration for zero-code device control."
+  },
+  "TELEGRAM_BOT_TOKEN": {
+    "type": "secret",
+    "description": "Optional: Telegram bot token from @BotFather. When set, Hermes' Telegram gateway starts and routes inbound chats to OSCAR. Pair with TELEGRAM_ALLOWED_USERS — without an allowlist Hermes denies every message and logs `No user allowlists configured`."
+  },
+  "TELEGRAM_ALLOWED_USERS": {
+    "type": "text",
+    "description": "Optional: comma-separated Telegram user IDs allowed to chat with Hermes (e.g. `123456789,987654321`). Use @userinfobot to find your numeric ID. Empty value means every Telegram message is denied even if TELEGRAM_BOT_TOKEN is set.",
+    "default": ""
+  },
+  "DISCORD_BOT_TOKEN": {
+    "type": "secret",
+    "description": "Optional: Discord bot token from the Discord developer portal. When set, Hermes' Discord gateway starts. Pair with DISCORD_ALLOWED_CHANNELS to allowlist the channels Hermes responds in."
+  },
+  "DISCORD_ALLOWED_CHANNELS": {
+    "type": "text",
+    "description": "Optional: comma-separated Discord channel IDs Hermes is allowed to respond in. Empty means every channel is denied even if DISCORD_BOT_TOKEN is set.",
+    "default": ""
+  },
+  "SIGNAL_ACCOUNT": {
+    "type": "text",
+    "description": "Optional: Signal phone number (E.164, e.g. `+491701234567`) the linked signal-cli account belongs to. Linking itself is interactive (`podman exec -it hermes signal-cli link -n HermesAgent` + scan QR with the operator's phone — see README). Setting this here writes the Hermes-side config; pair with SIGNAL_ALLOWED_USERS.",
+    "default": ""
+  },
+  "SIGNAL_ALLOWED_USERS": {
+    "type": "text",
+    "description": "Optional: comma-separated Signal phone numbers (E.164) allowed to chat with Hermes. Empty means every Signal message is denied even after pairing.",
+    "default": ""
   }
 }

--- a/templates/ollama/README.md
+++ b/templates/ollama/README.md
@@ -13,10 +13,15 @@ networking.
 - `OLLAMA_PORT` — host port. Default `11434`. Bound to loopback.
 - `OLLAMA_DEFAULT_MODEL` — model pulled on first install. Default
   `gemma3:4b` (small, CPU-friendly). Any Ollama library tag works.
+- `OLLAMA_VISION_MODEL` — optional second model for image-aware
+  skills (e.g. OSCAR's `media-ingestion-multimodal`). Blank by
+  default; set to `qwen2.5vl:7b`, `llava:13b`, or `bakllava:7b`
+  to enable multimodal flows.
 - `OLLAMA_GPU_PASSTHROUGH` — leave blank for CPU; set non-blank
   for NVIDIA GPU passthrough via CDI.
 - `OLLAMA_READINESS_TIMEOUT_SECONDS` — post-deploy model-pull
-  deadline. Default `600`.
+  deadline. Default `600`. Shared across both default and vision
+  pulls; bump it if you pull two large models on a slow link.
 
 ## CPU vs. GPU
 
@@ -56,10 +61,32 @@ API exposes every loaded model to anyone who reaches it.
    own readiness signal).
 2. POSTs `/api/pull` with `OLLAMA_DEFAULT_MODEL` so the first model
    is ready before the operator's first request.
-3. Logs progress and emits a final "ready" line.
+3. If `OLLAMA_VISION_MODEL` is set, POSTs a second `/api/pull` for
+   that model (sequential to keep network/disk pressure predictable).
+4. Logs progress and emits a final "ready" line.
 
-Idempotent — a second deploy with the same model finds it already
-cached and skips the pull.
+Idempotent — a second deploy with the same models finds them already
+cached and skips the pulls.
+
+## Multimodal (vision) inference
+
+OSCAR's `media-ingestion-multimodal` skill needs a vision-capable
+model to OCR book covers, transcribe photos of documents, etc.
+The default `gemma3:4b` is text-only — sending it an image yields
+an unhelpful "I can't see images" response.
+
+Set `OLLAMA_VISION_MODEL` at install time (or via the wizard's
+reconfigure flow) to pull a vision model alongside the default.
+The model pulls in series after the default; both share the
+`OLLAMA_READINESS_TIMEOUT_SECONDS` budget. Suggested tags:
+
+- `qwen2.5vl:7b` — Apache-2.0, ~6 GB quantised, fits a 16 GB GPU
+  alongside `gemma3:4b`.
+- `llava:13b` — older but well-tested, ~8 GB.
+- `bakllava:7b` — Mistral-based LLaVA variant, ~5 GB.
+
+Hermes' wiring picks up the new model automatically the next time
+its config is regenerated — see `templates/hermes/README.md`.
 
 ## Storage
 

--- a/templates/ollama/post-deploy.py
+++ b/templates/ollama/post-deploy.py
@@ -161,6 +161,7 @@ def register_http_check(sb_api: str, sb_token: str, ollama_url: str) -> None:
 def main() -> int:
     port = env("OLLAMA_PORT", "11434")
     model = env("OLLAMA_DEFAULT_MODEL", "gemma3:4b")
+    vision_model = env("OLLAMA_VISION_MODEL", "")
     timeout = int(env("OLLAMA_READINESS_TIMEOUT_SECONDS", "600"))
     sb_api = env("SB_API_URL", "http://localhost:3000")
     sb_token = env("SB_API_TOKEN", "")
@@ -176,9 +177,14 @@ def main() -> int:
         )
         return 0
 
+    started = time.time()
+
+    def remaining_budget() -> int:
+        return max(60, timeout - int(time.time() - started))
+
     if model:
         jlog("info", "ollama:pull", "starting model pull", model=model)
-        ok = pull_model(ollama_url, model, deadline_sec=timeout)
+        ok = pull_model(ollama_url, model, deadline_sec=remaining_budget())
         if not ok:
             jlog(
                 "warn",
@@ -187,9 +193,22 @@ def main() -> int:
                 model=model,
             )
 
+    if vision_model:
+        jlog("info", "ollama:pull", "starting vision-model pull", model=vision_model)
+        ok = pull_model(ollama_url, vision_model, deadline_sec=remaining_budget())
+        if not ok:
+            jlog(
+                "warn",
+                "ollama:pull",
+                "vision-model pull did not complete; OSCAR's media-ingestion-multimodal skill will fall back to text-only. Pull manually with `curl -X POST http://127.0.0.1:%s/api/pull -d '{\"name\":\"%s\"}'` or bump OLLAMA_READINESS_TIMEOUT_SECONDS." % (port, vision_model),
+                model=vision_model,
+            )
+
     register_http_check(sb_api, sb_token, ollama_url)
 
     print(f"✅ Ollama is running on 127.0.0.1:{port}. Default model: {model}.")
+    if vision_model:
+        print(f"   Vision model: {vision_model} (multimodal-capable).")
     print(f"   Other ServiceBay templates (hermes, oscar-household) can reach it at http://127.0.0.1:{port}.")
     return 0
 

--- a/templates/ollama/variables.json
+++ b/templates/ollama/variables.json
@@ -9,6 +9,11 @@
     "description": "Model pulled on first start. Use any tag from the Ollama library (https://ollama.com/library). Small CPU-friendly default; bump to a larger model once you have GPU passthrough working. The pull runs once per fresh install — subsequent starts find the model already cached and skip the download.",
     "default": "gemma3:4b"
   },
+  "OLLAMA_VISION_MODEL": {
+    "type": "text",
+    "description": "Optional second model pulled on first start for image-aware skills (e.g. OSCAR's media-ingestion-multimodal skill). Leave blank to skip — the default text model has no vision capability and a multimodal request will get an unhelpful 'I can't see images' answer. Suggested tags: `qwen2.5vl:7b` (Apache-2, fits a 16GB GPU alongside gemma3:4b), `llava:13b` (older but well-tested), `bakllava:7b`. Pulled after the default model; both pulls share OLLAMA_READINESS_TIMEOUT_SECONDS.",
+    "default": ""
+  },
   "OLLAMA_GPU_PASSTHROUGH": {
     "type": "text",
     "description": "Leave blank for CPU-only inference (works everywhere, slower for larger models). Set to any non-blank value (e.g. 'yes') to enable NVIDIA GPU passthrough via CDI — requires a CDI-registered NVIDIA GPU on the host (set up with `nvidia-ctk cdi generate`). When non-blank, the rendered pod manifest gets `resources.limits.nvidia.com/gpu: \"1\"`; podman matches that against the CDI device registry at start time.",

--- a/templates/oscar-household/src/gatekeeper/README.md
+++ b/templates/oscar-household/src/gatekeeper/README.md
@@ -24,8 +24,8 @@ The gatekeeper terminates the Wyoming connection after each turn. Multi-turn / b
 
 | Phase | What this code does |
 |---|---|
-| **0 / 1 (now)** | Pass-through. `uid` hardcoded to `DEFAULT_UID`, `endpoint = voice-pe:<connection-id>`. No speaker ID. |
-| **2** | SpeechBrain ECAPA-TDNN extracts a 256-d embedding from the audio buffer; brute-force cosine k-NN against `voice_embeddings` in `oscar.db` (3–10 rows) resolves the LLDAP `uid`. |
+| **0 / 1 (default)** | Pass-through. `uid` hardcoded to `DEFAULT_UID`, `endpoint = voice-pe:<connection-id>`. No speaker ID. |
+| **2 (framework landed, #937)** | Resolver, k-NN cosine, embeddings store, `POST /enrol` HTTP endpoint, handler wiring all live. ECAPA-TDNN itself is opt-in — see "Enabling Speaker-ID" below. |
 | **4** | Multi-room routing (response goes to the satellite the user is closest to), voice-tone sensor parallel to STT, custom "Oscar" wakeword. |
 
 Long-term target: contribute the Phase 0/1 pass-through path to Hermes as a generic `hermes gateway voice`. The Phase 2+ logic (speaker ID, multi-room, voice-tone) stays here.
@@ -40,9 +40,58 @@ Long-term target: contribute the Phase 0/1 pass-through path to Hermes as a gene
 | `OPENWAKEWORD_URI` | `tcp://127.0.0.1:10400` | openWakeWord (advertised in Info; Phase 0 lets the satellite do wakeword on-device) |
 | `HERMES_URL` | `http://127.0.0.1:8642` | Base URL of Hermes' HTTP API (matches ServiceBay `hermes` template default; both pods use hostNetwork) |
 | `HERMES_TOKEN` | empty | Bearer for Hermes (matches its `API_SERVER_KEY` / surfaced by ServiceBay's `hermes` template as `HERMES_API_KEY`) |
-| `DEFAULT_UID` | `michael` | Hardcoded uid until Phase 2 speaker ID lands |
-| `OSCAR_DB_PATH` | `/var/lib/oscar/oscar.db` | SQLite file (Phase 2: `voice_embeddings` lookup) |
+| `DEFAULT_UID` | `michael` | Fallback uid when speaker-ID is off or doesn't match |
+| `OSCAR_DB_PATH` | `/var/lib/oscar/oscar.db` | SQLite file (Phase 2: `voice_embeddings` read/write) |
+| `OSCAR_SPEAKER_ID_ENABLED` | empty | Set to `1`/`true` to turn on Phase-2 speaker resolution. Off by default — the stock image has no ECAPA model anyway. |
+| `OSCAR_SPEAKER_ID_THRESHOLD` | `0.55` | Cosine similarity threshold above which a k-NN match is accepted. Below it, the resolver falls back to `DEFAULT_UID` (and logs the score). |
+| `OSCAR_SPEAKER_MODEL_CACHE` | `/var/lib/oscar/models/spkrec-ecapa` | Where SpeechBrain caches the pretrained ECAPA weights. ~80 MB on first start. |
 | `OSCAR_DEBUG_MODE` | `false` | Initial verbose-mode default (runtime override comes from `system_settings.debug_mode` in `oscar.db`) |
+
+## Enabling Speaker-ID (Phase 2)
+
+The framework (resolver, store, enrolment endpoint, handler wiring)
+ships in the default image. The ECAPA-TDNN model and its dependencies
+(SpeechBrain + torch, ~1 GB) do **not** ship in the default image —
+adding them would balloon a sidecar that's otherwise ~100 MB.
+
+To activate Phase-2 speaker resolution:
+
+1. Build a custom gatekeeper image that installs the extras:
+
+   ```dockerfile
+   FROM ghcr.io/mdopp/oscar-gatekeeper:latest
+   RUN pip install --no-cache-dir 'oscar-gatekeeper[speaker-id]'
+   ```
+
+2. Point `GATEKEEPER_IMAGE` (the `oscar-household` template variable)
+   at your image tag.
+3. Set `OSCAR_SPEAKER_ID_ENABLED=1` in the wizard.
+4. Enrol each resident through the gatekeeper's HTTP API:
+
+   ```bash
+   curl -X POST http://127.0.0.1:10750/enrol \
+        -H "Authorization: Bearer $PUSH_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+              "uid": "alice",
+              "sample_rate": 16000,
+              "sample_width": 2,
+              "channels": 1,
+              "samples": [
+                "<base64 of 16kHz mono int16 PCM clip 1>",
+                "<base64 of clip 2>",
+                "<base64 of clip 3>"
+              ]
+            }'
+   ```
+
+   3–10 clips. The endpoint averages the per-clip ECAPA embeddings
+   and upserts the result. `GET /enrolments` lists enrolled uids;
+   `DELETE /enrolments/<uid>` removes one.
+
+When the env flag is off, deps are missing, or no enrolments exist,
+the handler short-circuits the resolver and uses `DEFAULT_UID`. The
+conversation pipeline is unaffected.
 
 ## Local development
 

--- a/templates/oscar-household/src/gatekeeper/pyproject.toml
+++ b/templates/oscar-household/src/gatekeeper/pyproject.toml
@@ -21,6 +21,19 @@ test = [
   "pytest>=7",
   "pytest-asyncio>=0.23",
   "pytest-aiohttp>=1.0",
+  "numpy>=1.26",
+]
+# Phase-2 speaker-ID (#937). The stock gatekeeper image does NOT install
+# these — SpeechBrain pulls in torch, which adds ~1 GB to the image and
+# needs a separate CI build. Operators wanting Speaker-ID build a custom
+# image with `pip install /app[speaker-id]` and set
+# OSCAR_SPEAKER_ID_ENABLED=1 in the wizard. With the deps absent the
+# resolver short-circuits to DEFAULT_UID so the conversation pipeline
+# stays unaffected.
+speaker-id = [
+  "speechbrain>=1.0",
+  "torch>=2.1",
+  "numpy>=1.26",
 ]
 
 [project.scripts]

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/__main__.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/__main__.py
@@ -75,6 +75,7 @@ async def _serve() -> None:
             piper_uri=settings.piper_uri,
             devices=settings.voice_pe_devices,
             push_token=settings.push_token,
+            db_path=settings.oscar_db_path if settings.speaker_id_enabled else None,
         ),
         name="push",
     )

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/config.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/config.py
@@ -1,7 +1,8 @@
 """Env-driven configuration for the gatekeeper.
 
-Phase 0 keeps the surface small. Phase 2 will add speaker-ID model paths
-and the `gatekeeper_voice_embeddings` DSN.
+Phase 0 (initial release) kept this tiny. Phase 2 (#937) adds the
+SpeechBrain ECAPA model toggle + threshold and the oscar.db path for
+the voice_embeddings table.
 """
 
 from __future__ import annotations
@@ -23,6 +24,9 @@ class Settings:
     push_host: str
     push_port: int
     push_token: str
+    oscar_db_path: str
+    speaker_id_enabled: bool
+    speaker_id_threshold: float
     voice_pe_devices: dict[str, str] = field(default_factory=dict)
 
     @classmethod
@@ -36,6 +40,11 @@ class Settings:
                     devices = {str(k): str(v) for k, v in parsed.items()}
             except json.JSONDecodeError:
                 devices = {}
+        flag = os.environ.get("OSCAR_SPEAKER_ID_ENABLED", "").strip().lower()
+        try:
+            threshold = float(os.environ.get("OSCAR_SPEAKER_ID_THRESHOLD", "0.55"))
+        except ValueError:
+            threshold = 0.55
         return cls(
             gatekeeper_uri=os.environ.get("GATEKEEPER_URI", "tcp://0.0.0.0:10700"),
             whisper_uri=os.environ.get("WHISPER_URI", "tcp://127.0.0.1:10300"),
@@ -49,6 +58,9 @@ class Settings:
             push_host=os.environ.get("PUSH_HOST", "0.0.0.0"),
             push_port=int(os.environ.get("PUSH_PORT", "10750")),
             push_token=os.environ.get("PUSH_TOKEN", ""),
+            oscar_db_path=os.environ.get("OSCAR_DB_PATH", "/var/lib/oscar/oscar.db"),
+            speaker_id_enabled=flag in {"1", "true", "yes", "on"},
+            speaker_id_threshold=threshold,
             voice_pe_devices=devices,
         )
 

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/embeddings_store.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/embeddings_store.py
@@ -1,0 +1,158 @@
+"""SQLite-backed storage for OSCAR voice embeddings (#937 Phase 2).
+
+The `voice_embeddings` table is provisioned by the baseline Alembic
+migration (`schema/migrations/versions/20260516_0001_baseline.py`):
+one row per resident `uid`, BLOB embedding (256 × float32 = 1024 B),
+`sample_count` averaged over enrolment, and `enrolled_via`.
+
+This module owns the read/write contract; the resolver in
+`speaker.py` calls into it for the k-NN sweep, and the enrolment
+endpoint calls into it to upsert a freshly-averaged embedding.
+
+Design notes:
+
+  * Sync sqlite3. The store is called from async handlers, but each
+    op is millisecond-cheap (read 3–10 rows, write one row).
+    Wrapping it in `asyncio.to_thread` was considered and dropped;
+    the simplicity of sync I/O wins until enrolment rows reach the
+    hundreds, which they never will in a household setting.
+  * Embeddings on disk are little-endian float32. `numpy.tobytes()`
+    produces that on every architecture we target.
+  * If oscar.db does not yet exist (gatekeeper booted before the
+    init container has run), `list_embeddings` returns `[]` and
+    upsert raises. Callers downgrade to default_uid in that case.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+EMBEDDING_DIM = 256
+EMBEDDING_BYTES = EMBEDDING_DIM * 4  # float32
+
+
+@dataclass(frozen=True)
+class VoiceEmbedding:
+    uid: str
+    embedding_bytes: bytes  # raw float32 little-endian
+    sample_count: int
+
+    def as_array(self):
+        # Imported lazily so the module is usable without numpy
+        # (e.g. when speaker-id is disabled and the store is only
+        # exercised by tests of unrelated handlers).
+        import numpy as np
+
+        return np.frombuffer(self.embedding_bytes, dtype="<f4")
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def list_embeddings(db_path: str) -> list[VoiceEmbedding]:
+    """Return every enrolled embedding. Empty list when the DB is
+    missing or the table is empty — callers treat both the same way
+    (fall back to default_uid)."""
+    if not Path(db_path).exists():
+        return []
+    try:
+        with _connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT uid, embedding, sample_count FROM voice_embeddings"
+            ).fetchall()
+    except sqlite3.OperationalError:
+        # Table missing (init container hasn't migrated yet).
+        return []
+    out: list[VoiceEmbedding] = []
+    for row in rows:
+        blob = bytes(row["embedding"])
+        if len(blob) != EMBEDDING_BYTES:
+            # Skip malformed rows rather than throwing; an admin can
+            # re-enrol the affected resident.
+            continue
+        out.append(
+            VoiceEmbedding(
+                uid=row["uid"],
+                embedding_bytes=blob,
+                sample_count=int(row["sample_count"]),
+            )
+        )
+    return out
+
+
+def upsert_embedding(
+    db_path: str,
+    uid: str,
+    embedding_bytes: bytes,
+    *,
+    sample_count: int,
+    enrolled_via: str,
+) -> None:
+    """Insert or replace a resident's voice fingerprint."""
+    if len(embedding_bytes) != EMBEDDING_BYTES:
+        raise ValueError(
+            f"embedding must be {EMBEDDING_BYTES} bytes ({EMBEDDING_DIM} float32), got {len(embedding_bytes)}"
+        )
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO voice_embeddings (uid, embedding, sample_count, enrolled_via)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(uid) DO UPDATE SET
+                embedding    = excluded.embedding,
+                sample_count = excluded.sample_count,
+                enrolled_via = excluded.enrolled_via,
+                enrolled_at  = datetime('now')
+            """,
+            (uid, embedding_bytes, sample_count, enrolled_via),
+        )
+        conn.commit()
+
+
+def touch_last_seen(db_path: str, uid: str) -> None:
+    """Record that this uid was matched on a recent turn. Best-effort —
+    a failure here doesn't break the conversation pipeline."""
+    if not Path(db_path).exists():
+        return
+    try:
+        with _connect(db_path) as conn:
+            conn.execute(
+                "UPDATE voice_embeddings SET last_seen_at = datetime('now') WHERE uid = ?",
+                (uid,),
+            )
+            conn.commit()
+    except sqlite3.OperationalError:
+        return
+
+
+def delete_embedding(db_path: str, uid: str) -> bool:
+    """Remove a resident's enrolment. Used by admin un-enrol flows."""
+    if not Path(db_path).exists():
+        return False
+    try:
+        with _connect(db_path) as conn:
+            cur = conn.execute("DELETE FROM voice_embeddings WHERE uid = ?", (uid,))
+            conn.commit()
+            return cur.rowcount > 0
+    except sqlite3.OperationalError:
+        return False
+
+
+def list_uids(db_path: str) -> list[str]:
+    """Convenience for admin listings; cheaper than loading full BLOBs."""
+    if not Path(db_path).exists():
+        return []
+    try:
+        with _connect(db_path) as conn:
+            rows: Iterable[sqlite3.Row] = conn.execute(
+                "SELECT uid FROM voice_embeddings ORDER BY uid"
+            ).fetchall()
+            return [str(row["uid"]) for row in rows]
+    except sqlite3.OperationalError:
+        return []

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/enrollment.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/enrollment.py
@@ -1,0 +1,155 @@
+"""HTTP enrolment endpoint for Phase 2 Speaker-ID (#937).
+
+Exposes `POST /enrol` so an admin tool can submit N audio samples for
+a resident `uid`, get them embedded, and store the averaged embedding
+in `voice_embeddings`. The request body is JSON; audio is base64-
+encoded little-endian int16 PCM (16 kHz mono).
+
+This is intentionally not a Wyoming flow: a Wyoming-driven "say your
+name 3 times" UX requires a satellite-side dialogue manager we don't
+have yet. The HTTP form lets an operator drive enrolment from a
+small CLI or the ServiceBay dashboard, with audio captured by any
+microphone-aware client they have. The on-disk schema is the same
+either way (one row per uid, averaged embedding).
+
+Auth: shares `PUSH_TOKEN` with the push endpoint — same trust
+boundary (pod-internal HTTP listener that's never exposed off-pod).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import re
+
+from aiohttp import web
+from gatekeeper.logging import log
+
+from .embeddings_store import EMBEDDING_DIM, delete_embedding, list_uids, upsert_embedding
+from .speaker import average_embeddings, get_extractor
+
+_UID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+def _auth_ok(request: web.Request, token: str) -> bool:
+    if not token:
+        return True
+    return request.headers.get("Authorization", "") == f"Bearer {token}"
+
+
+def add_routes(
+    app: web.Application,
+    *,
+    db_path: str,
+    push_token: str,
+    sample_rate_hint: int = 16000,
+    sample_width_hint: int = 2,
+    channels_hint: int = 1,
+    min_samples: int = 3,
+    max_samples: int = 10,
+) -> None:
+    """Attach enrolment endpoints to an existing aiohttp app. Sharing
+    the push app keeps the gatekeeper to a single sidecar HTTP port."""
+
+    async def enrol(request: web.Request) -> web.Response:
+        if not _auth_ok(request, push_token):
+            return web.json_response({"ok": False, "reason": "unauthorized"}, status=401)
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001
+            return web.json_response({"ok": False, "reason": "invalid_json"}, status=400)
+
+        uid = str(body.get("uid") or "").strip()
+        if not _UID_RE.match(uid):
+            return web.json_response({"ok": False, "reason": "invalid_uid"}, status=400)
+
+        samples_b64 = body.get("samples")
+        if not isinstance(samples_b64, list):
+            return web.json_response({"ok": False, "reason": "missing_samples"}, status=400)
+        if not (min_samples <= len(samples_b64) <= max_samples):
+            return web.json_response(
+                {"ok": False, "reason": "sample_count_out_of_range", "min": min_samples, "max": max_samples},
+                status=400,
+            )
+
+        rate = int(body.get("sample_rate", sample_rate_hint))
+        width = int(body.get("sample_width", sample_width_hint))
+        channels = int(body.get("channels", channels_hint))
+
+        extractor = get_extractor()
+        if extractor is None:
+            return web.json_response(
+                {"ok": False, "reason": "speaker_id_disabled", "hint": "set OSCAR_SPEAKER_ID_ENABLED=1 and install [speaker-id] extras"},
+                status=503,
+            )
+
+        try:
+            decoded = [base64.b64decode(s) for s in samples_b64]
+        except Exception:  # noqa: BLE001
+            return web.json_response({"ok": False, "reason": "invalid_base64"}, status=400)
+
+        loop = asyncio.get_running_loop()
+        embeddings: list[bytes] = []
+        for idx, pcm in enumerate(decoded):
+            try:
+                emb = await loop.run_in_executor(
+                    None, extractor.extract, pcm, rate, width, channels
+                )
+            except TypeError:
+                # Older Python: pass kwargs via lambda since run_in_executor
+                # doesn't forward keyword args.
+                emb = await loop.run_in_executor(
+                    None,
+                    lambda p=pcm: extractor.extract(p, rate=rate, width=width, channels=channels),
+                )
+            if emb is None:
+                log.warn("gatekeeper.enrol.sample_skipped", uid=uid, sample=idx)
+                continue
+            if len(emb) != EMBEDDING_DIM * 4:
+                log.warn("gatekeeper.enrol.bad_dim", uid=uid, sample=idx, bytes=len(emb))
+                continue
+            embeddings.append(emb)
+
+        if len(embeddings) < min_samples:
+            return web.json_response(
+                {
+                    "ok": False,
+                    "reason": "not_enough_usable_samples",
+                    "got": len(embeddings),
+                    "needed": min_samples,
+                },
+                status=422,
+            )
+
+        try:
+            averaged = average_embeddings(embeddings)
+        except ValueError as exc:
+            return web.json_response({"ok": False, "reason": str(exc)}, status=422)
+
+        await asyncio.to_thread(
+            upsert_embedding,
+            db_path,
+            uid,
+            averaged,
+            sample_count=len(embeddings),
+            enrolled_via="http",
+        )
+        log.info("gatekeeper.enrol.ok", uid=uid, samples_used=len(embeddings))
+        return web.json_response({"ok": True, "uid": uid, "samples_used": len(embeddings)})
+
+    async def list_enrolments(_request: web.Request) -> web.Response:
+        uids = await asyncio.to_thread(list_uids, db_path)
+        return web.json_response({"uids": uids})
+
+    async def delete_enrolment(request: web.Request) -> web.Response:
+        if not _auth_ok(request, push_token):
+            return web.json_response({"ok": False, "reason": "unauthorized"}, status=401)
+        uid = request.match_info.get("uid", "")
+        if not _UID_RE.match(uid):
+            return web.json_response({"ok": False, "reason": "invalid_uid"}, status=400)
+        removed = await asyncio.to_thread(delete_embedding, db_path, uid)
+        return web.json_response({"ok": True, "removed": removed})
+
+    app.router.add_post("/enrol", enrol)
+    app.router.add_get("/enrolments", list_enrolments)
+    app.router.add_delete("/enrolments/{uid}", delete_enrolment)

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/handler.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/handler.py
@@ -15,6 +15,7 @@ turn, like HA's voice pipeline). Multi-turn / streaming is a Phase 4 topic.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from typing import Any
 
@@ -26,7 +27,9 @@ from wyoming.event import Event
 from wyoming.server import AsyncEventHandler
 
 from .config import settings
+from .embeddings_store import list_embeddings, touch_last_seen
 from .hermes import HermesClient
+from .speaker import get_extractor, resolve_speaker
 from .tts import synthesize_to_writer
 
 
@@ -87,10 +90,11 @@ class GatekeeperHandler(AsyncEventHandler):
             return
         log.info("gatekeeper.transcript", trace_id=self.trace_id, text=transcript)
 
+        uid = await self._resolve_uid()
         endpoint = f"voice-pe:{self.client_id or 'unknown'}"
         response = await self._hermes.converse(
             text=transcript,
-            uid=settings.default_uid,
+            uid=uid,
             endpoint=endpoint,
             trace_id=self.trace_id,
         )
@@ -106,6 +110,48 @@ class GatekeeperHandler(AsyncEventHandler):
             return
 
         log.info("gatekeeper.session.close", trace_id=self.trace_id)
+
+    async def _resolve_uid(self) -> str:
+        """Phase 2 speaker resolution. Falls back to default_uid on any
+        gap (feature disabled, no enrolments, model not loaded, empty
+        buffer, embedding extraction failure). The resolver itself is
+        in `speaker.py`; this method orchestrates the pieces and keeps
+        the conversation pipeline working when the ML path is absent."""
+        if not settings.speaker_id_enabled:
+            return settings.default_uid
+        extractor = get_extractor()
+        if extractor is None or self._audio_start is None or not self._audio_buffer:
+            return settings.default_uid
+        pcm = b"".join(c.audio for c in self._audio_buffer)
+        rate = self._audio_start.rate
+        width = self._audio_start.width
+        channels = self._audio_start.channels
+        try:
+            query = await asyncio.to_thread(
+                extractor.extract, pcm, rate=rate, width=width, channels=channels
+            )
+        except Exception as exc:  # noqa: BLE001 — extraction errors degrade gracefully
+            log.warn("gatekeeper.speaker.extract_error", trace_id=self.trace_id, error=str(exc))
+            return settings.default_uid
+        candidates = await asyncio.to_thread(list_embeddings, settings.oscar_db_path)
+        uid, match = resolve_speaker(
+            query,
+            candidates,
+            threshold=settings.speaker_id_threshold,
+            default_uid=settings.default_uid,
+        )
+        if match is not None:
+            log.info(
+                "gatekeeper.speaker.match",
+                trace_id=self.trace_id,
+                uid=uid,
+                best_uid=match.uid,
+                score=round(match.score, 4),
+                above_threshold=match.above_threshold,
+            )
+        if uid != settings.default_uid:
+            await asyncio.to_thread(touch_last_seen, settings.oscar_db_path, uid)
+        return uid
 
     async def _transcribe(self) -> str:
         assert self._audio_start is not None

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/push.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/push.py
@@ -109,6 +109,27 @@ def build_app(
     return app
 
 
+def build_combined_app(
+    *,
+    piper_uri: str,
+    devices: dict[str, str],
+    push_token: str = "",
+    db_path: str | None = None,
+) -> web.Application:
+    """Build the push app and add Phase-2 speaker-ID enrolment routes.
+
+    Defined here (not in __main__) so tests can construct the full
+    aiohttp surface without spinning up the Wyoming server."""
+    app = build_app(piper_uri=piper_uri, devices=devices, push_token=push_token)
+    if db_path:
+        # Imported here to keep speaker.py / enrollment.py out of the
+        # push-only test path that doesn't care about the ML stack.
+        from .enrollment import add_routes as add_enrolment_routes
+
+        add_enrolment_routes(app, db_path=db_path, push_token=push_token)
+    return app
+
+
 async def _push_to_device(piper_uri: str, device_uri: str, text: str) -> int:
     """Open a Wyoming client to the device, write the synthesized audio."""
     async with AsyncClient.from_uri(device_uri) as device:
@@ -126,9 +147,12 @@ async def serve(
     piper_uri: str,
     devices: dict[str, str],
     push_token: str = "",
+    db_path: str | None = None,
 ) -> None:
     """Run the aiohttp app forever. Caller composes this with the Wyoming server."""
-    app = build_app(piper_uri=piper_uri, devices=devices, push_token=push_token)
+    app = build_combined_app(
+        piper_uri=piper_uri, devices=devices, push_token=push_token, db_path=db_path
+    )
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, host, port)

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/speaker.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/speaker.py
@@ -1,0 +1,226 @@
+"""Speaker-ID resolver — k-NN over voice_embeddings, with a pluggable
+embedding extractor (#937 Phase 2).
+
+Two distinct moving parts live here:
+
+  1. `cosine_match` / `resolve_speaker` — pure-numpy k-NN over the
+     stored embeddings. Always available. Tested with synthetic
+     embeddings (see tests/).
+  2. `get_extractor` / `EmbeddingExtractor` — abstraction over the
+     ECAPA-TDNN model that turns raw PCM into a 256-d vector. The
+     default implementation imports SpeechBrain lazily; when
+     SpeechBrain is not installed (the default image), it raises
+     NotImplementedError on first use. Callers must check
+     `extractor_available()` first and fall back to `default_uid`
+     when the extractor isn't loadable.
+
+The split keeps the resolver (and its tests) free of any ML
+dependency. Operators wanting Phase-2 speaker-ID build a custom
+gatekeeper image with the `speaker-id` extras installed:
+
+    pip install /app[speaker-id]
+
+and flip `OSCAR_SPEAKER_ID_ENABLED=1`. Future work: a CI-built
+`oscar-gatekeeper-ml` image that bakes SpeechBrain in. See #937
+follow-up notes in the gatekeeper README.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+from .embeddings_store import EMBEDDING_DIM, VoiceEmbedding
+
+
+def extractor_available() -> bool:
+    """True iff the modules needed for the default ECAPA extractor
+    are importable in this interpreter. Cheap — runs a couple of
+    `importlib.util.find_spec` calls, no actual import."""
+    for module in ("speechbrain", "torch", "numpy"):
+        if importlib.util.find_spec(module) is None:
+            return False
+    return True
+
+
+@dataclass(frozen=True)
+class SpeakerMatch:
+    uid: str
+    score: float  # cosine similarity in [-1, 1]
+    above_threshold: bool
+
+
+def cosine_match(
+    query_bytes: bytes,
+    candidates: Iterable[VoiceEmbedding],
+    *,
+    threshold: float,
+) -> SpeakerMatch | None:
+    """Brute-force cosine over candidates. Returns the best match
+    (even if below threshold, so callers can log "matched X with
+    low confidence" before falling back). None when there are no
+    candidates."""
+    import numpy as np
+
+    if len(query_bytes) != EMBEDDING_DIM * 4:
+        raise ValueError(
+            f"query embedding must be {EMBEDDING_DIM * 4} bytes, got {len(query_bytes)}"
+        )
+    q = np.frombuffer(query_bytes, dtype="<f4")
+    q_norm = float(np.linalg.norm(q))
+    if q_norm == 0.0:
+        return None
+    q = q / q_norm
+
+    best_uid: str | None = None
+    best_score = -1.0
+    for cand in candidates:
+        c = cand.as_array()
+        c_norm = float(np.linalg.norm(c))
+        if c_norm == 0.0:
+            continue
+        score = float(np.dot(q, c / c_norm))
+        if score > best_score:
+            best_score = score
+            best_uid = cand.uid
+
+    if best_uid is None:
+        return None
+    return SpeakerMatch(uid=best_uid, score=best_score, above_threshold=best_score >= threshold)
+
+
+def resolve_speaker(
+    query_bytes: bytes | None,
+    candidates: Iterable[VoiceEmbedding],
+    *,
+    threshold: float,
+    default_uid: str,
+) -> tuple[str, SpeakerMatch | None]:
+    """Top-level resolver: gives the uid Hermes should be told this
+    turn belongs to, plus the raw match for logging. Falls back to
+    `default_uid` when no query embedding was extracted, no rows
+    are enrolled, or the best match falls below threshold."""
+    if query_bytes is None:
+        return default_uid, None
+    cands = list(candidates)
+    if not cands:
+        return default_uid, None
+    match = cosine_match(query_bytes, cands, threshold=threshold)
+    if match is None:
+        return default_uid, None
+    if not match.above_threshold:
+        return default_uid, match
+    return match.uid, match
+
+
+class EmbeddingExtractor(Protocol):
+    """Turn buffered audio chunks into a 256-d float32 embedding.
+
+    The protocol is sync — extractors are CPU/GPU-bound and the
+    handler calls them from an asyncio.to_thread wrapper. Returning
+    None means "no usable embedding" (silence, too-short clip,
+    extractor disabled) and the caller falls back to default_uid.
+    """
+
+    def extract(self, pcm: bytes, *, rate: int, width: int, channels: int) -> bytes | None: ...
+
+
+class SpeechBrainExtractor:
+    """ECAPA-TDNN embedding via SpeechBrain. Loads the pretrained
+    `speechbrain/spkrec-ecapa-voxceleb` weights on first use; that
+    download is ~80 MB and happens once into the model cache dir.
+
+    Stubbed out at import time so the rest of the gatekeeper still
+    runs when SpeechBrain is unavailable. The handler will check
+    `extractor_available()` before constructing this class.
+    """
+
+    def __init__(self, *, savedir: str | None = None) -> None:
+        if not extractor_available():
+            raise RuntimeError(
+                "SpeechBrain / torch not installed in this image. Build a custom gatekeeper image with the [speaker-id] extras to enable Phase 2."
+            )
+        import torch  # noqa: F401  — import side-effects only
+        from speechbrain.inference.speaker import EncoderClassifier
+
+        self._classifier = EncoderClassifier.from_hparams(
+            source="speechbrain/spkrec-ecapa-voxceleb",
+            savedir=savedir or os.environ.get(
+                "OSCAR_SPEAKER_MODEL_CACHE", "/var/lib/oscar/models/spkrec-ecapa"
+            ),
+            run_opts={"device": "cpu"},  # gatekeeper sidecar has no GPU contract
+        )
+
+    def extract(self, pcm: bytes, *, rate: int, width: int, channels: int) -> bytes | None:
+        import numpy as np
+        import torch
+
+        if not pcm:
+            return None
+        if width != 2 or channels != 1:
+            # ECAPA was trained on 16 kHz mono int16. Resampling/
+            # downmixing here is doable but out of scope for the
+            # framework; the gatekeeper pod only ever sees Wyoming
+            # input from HA Voice PE satellites, which is 16-kHz mono.
+            return None
+
+        samples = np.frombuffer(pcm, dtype="<i2").astype("<f4") / 32768.0
+        if rate != 16000:
+            # Cheap linear-interp resample. Good enough for ECAPA at
+            # the threshold ranges we use; a proper resampler is a
+            # later optimisation.
+            from math import ceil
+
+            ratio = 16000.0 / float(rate)
+            new_len = int(ceil(len(samples) * ratio))
+            idx = np.linspace(0, len(samples) - 1, new_len)
+            samples = np.interp(idx, np.arange(len(samples)), samples).astype("<f4")
+        if len(samples) < 16000:  # < 1 s of audio — too short to embed reliably
+            return None
+
+        tensor = torch.from_numpy(samples).unsqueeze(0)
+        with torch.no_grad():
+            emb = self._classifier.encode_batch(tensor).squeeze().cpu().numpy().astype("<f4")
+        if emb.shape != (EMBEDDING_DIM,):
+            return None
+        return emb.tobytes()
+
+
+_extractor_singleton: EmbeddingExtractor | None = None
+
+
+def get_extractor() -> EmbeddingExtractor | None:
+    """Return the process-wide extractor instance, loading lazily.
+    Returns None when speaker-id is disabled, deps are missing, or
+    the model failed to load."""
+    global _extractor_singleton
+    if _extractor_singleton is not None:
+        return _extractor_singleton
+    if os.environ.get("OSCAR_SPEAKER_ID_ENABLED", "").strip().lower() not in {"1", "true", "yes", "on"}:
+        return None
+    if not extractor_available():
+        return None
+    try:
+        _extractor_singleton = SpeechBrainExtractor()
+    except Exception:  # noqa: BLE001 — extractor init can fail many ways
+        return None
+    return _extractor_singleton
+
+
+def average_embeddings(samples: list[bytes]) -> bytes:
+    """Mean-pool multiple per-utterance embeddings into one enrolment
+    embedding, then renormalise to unit length. Used by the
+    enrolment endpoint after collecting N "say your name" samples."""
+    import numpy as np
+
+    if not samples:
+        raise ValueError("need at least one sample to average")
+    stacked = np.stack([np.frombuffer(b, dtype="<f4") for b in samples])
+    mean = stacked.mean(axis=0)
+    norm = float(np.linalg.norm(mean))
+    if norm == 0.0:
+        raise ValueError("averaged embedding has zero norm — samples likely silence")
+    mean = (mean / norm).astype("<f4")
+    return mean.tobytes()

--- a/templates/oscar-household/src/gatekeeper/tests/test_speaker.py
+++ b/templates/oscar-household/src/gatekeeper/tests/test_speaker.py
@@ -1,0 +1,162 @@
+"""Speaker-ID resolver tests — pure-numpy, no ML deps required (#937)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("numpy") is None:  # pragma: no cover
+    pytest.skip("numpy not installed — speaker tests need numpy", allow_module_level=True)
+
+import numpy as np
+
+from gatekeeper.embeddings_store import (
+    EMBEDDING_DIM,
+    delete_embedding,
+    list_embeddings,
+    list_uids,
+    upsert_embedding,
+)
+from gatekeeper.speaker import (
+    average_embeddings,
+    cosine_match,
+    resolve_speaker,
+)
+
+
+def _norm(vec: np.ndarray) -> np.ndarray:
+    return (vec / np.linalg.norm(vec)).astype("<f4")
+
+
+def _emb(seed: int) -> bytes:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(EMBEDDING_DIM, dtype="<f4")
+    return _norm(v).tobytes()
+
+
+def _seed_db(tmp_path: Path) -> str:
+    db = tmp_path / "oscar.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE voice_embeddings (
+              uid TEXT PRIMARY KEY,
+              embedding BLOB NOT NULL,
+              enrolled_at TEXT NOT NULL DEFAULT (datetime('now')),
+              enrolled_via TEXT NOT NULL,
+              sample_count INTEGER NOT NULL DEFAULT 1,
+              last_seen_at TEXT
+            )
+            """
+        )
+        conn.commit()
+    return str(db)
+
+
+def test_cosine_match_returns_best_candidate(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    a, b = _emb(1), _emb(2)
+    upsert_embedding(db, "alice", a, sample_count=1, enrolled_via="test")
+    upsert_embedding(db, "bob", b, sample_count=1, enrolled_via="test")
+
+    candidates = list_embeddings(db)
+    assert {c.uid for c in candidates} == {"alice", "bob"}
+
+    match = cosine_match(a, candidates, threshold=0.5)
+    assert match is not None
+    assert match.uid == "alice"
+    assert match.score == pytest.approx(1.0, abs=1e-5)
+    assert match.above_threshold is True
+
+
+def test_cosine_match_below_threshold_still_reports_best(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    upsert_embedding(db, "alice", _emb(1), sample_count=1, enrolled_via="test")
+    upsert_embedding(db, "bob", _emb(2), sample_count=1, enrolled_via="test")
+
+    far_query = _emb(99)  # different seed → low similarity
+    match = cosine_match(far_query, list_embeddings(db), threshold=0.99)
+    assert match is not None
+    assert match.above_threshold is False  # 0.99 is impossible for random vectors
+
+
+def test_resolve_speaker_falls_back_to_default(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    # No enrolments — fall back regardless of query
+    uid, match = resolve_speaker(_emb(1), list_embeddings(db), threshold=0.5, default_uid="guest")
+    assert uid == "guest"
+    assert match is None
+
+    # Enrol Alice; her own embedding should resolve to her
+    a = _emb(7)
+    upsert_embedding(db, "alice", a, sample_count=3, enrolled_via="test")
+    uid, match = resolve_speaker(a, list_embeddings(db), threshold=0.5, default_uid="guest")
+    assert uid == "alice"
+    assert match is not None and match.uid == "alice"
+
+    # A different-seed query falls back if below threshold
+    uid, match = resolve_speaker(_emb(8), list_embeddings(db), threshold=0.99, default_uid="guest")
+    assert uid == "guest"
+    assert match is not None and match.above_threshold is False
+
+
+def test_resolve_speaker_handles_missing_query(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    upsert_embedding(db, "alice", _emb(1), sample_count=1, enrolled_via="test")
+    uid, match = resolve_speaker(None, list_embeddings(db), threshold=0.5, default_uid="guest")
+    assert uid == "guest"
+    assert match is None
+
+
+def test_average_embeddings_yields_unit_norm(tmp_path: Path):
+    e1 = _emb(10)
+    e2 = _emb(11)
+    e3 = _emb(12)
+    avg = average_embeddings([e1, e2, e3])
+    arr = np.frombuffer(avg, dtype="<f4")
+    assert arr.shape == (EMBEDDING_DIM,)
+    assert float(np.linalg.norm(arr)) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_average_embeddings_rejects_zero_sum():
+    half = np.ones(EMBEDDING_DIM, dtype="<f4") / np.sqrt(EMBEDDING_DIM)
+    other = (-half).astype("<f4")
+    with pytest.raises(ValueError):
+        average_embeddings([half.tobytes(), other.tobytes()])
+
+
+def test_upsert_rejects_wrong_dim(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    with pytest.raises(ValueError):
+        upsert_embedding(db, "alice", b"\x00" * 17, sample_count=1, enrolled_via="test")
+
+
+def test_list_embeddings_skips_malformed_rows(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    # Manually shove a malformed row in
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT INTO voice_embeddings (uid, embedding, sample_count, enrolled_via) VALUES (?, ?, ?, ?)",
+            ("broken", b"\x00\x00\x00", 1, "test"),
+        )
+        conn.commit()
+    upsert_embedding(db, "alice", _emb(1), sample_count=1, enrolled_via="test")
+
+    embs = list_embeddings(db)
+    assert {e.uid for e in embs} == {"alice"}
+
+
+def test_list_embeddings_empty_when_db_missing(tmp_path: Path):
+    assert list_embeddings(str(tmp_path / "nope.db")) == []
+    assert list_uids(str(tmp_path / "nope.db")) == []
+
+
+def test_delete_embedding_roundtrip(tmp_path: Path):
+    db = _seed_db(tmp_path)
+    upsert_embedding(db, "alice", _emb(1), sample_count=1, enrolled_via="test")
+    assert delete_embedding(db, "alice") is True
+    assert delete_embedding(db, "alice") is False  # idempotent second call
+    assert list_uids(db) == []

--- a/templates/oscar-household/src/skills/dynamic-skills/SKILL.md
+++ b/templates/oscar-household/src/skills/dynamic-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: oscar-dynamic-skills
 description: Use when the user requests OSCAR to learn a new capability, write down a fact/note, configure an agent, or when OSCAR needs to self-enhance its knowledge, skills, or peer agent behaviors dynamically. Implements the Phase 4 self-improvement loop.
-version: 1.0.0
+version: 2.0.0
 author: OSCAR
 license: MIT
 ---
@@ -12,7 +12,7 @@ license: MIT
 
 This skill defines the operating procedures for **OSCAR Phase 4** (the Self-Enhancement Loop). It equips the Hermes Agent with instructions to perform:
 1. **Dynamic Knowledge Writing**: Writing or updating structured facts and markdown notes in `/opt/data/notes/` so the hybrid-retrieval system picks them up.
-2. **Dynamic Skill Compiler**: Authoring new skill specifications, sandboxing Python or JavaScript execution to verify them, writing `/opt/data/skills/oscar/<skill-name>/SKILL.md`, and reloading the Hermes service via ServiceBay-MCP.
+2. **Dynamic Skill Drafting**: Authoring new skill specifications into a **pending** directory; an administrator must promote them from the ServiceBay dashboard before they go live. OSCAR never auto-activates a skill it wrote, and never executes scratch scripts in a regular shell.
 3. **Dynamic Agent Configuration**: Direct conversational feedback rules that update Honcho peer templates and custom instructions.
 
 ---
@@ -34,38 +34,54 @@ When the user shares household facts, preferences, or notes (e.g., "Remember tha
 
 ---
 
-## 2. Dynamic Skill Compiler
+## 2. Dynamic Skill Drafting (admin-promotion gate)
 
-When a user requests a new automation or capability (e.g., "Learn how to parse local weather warnings from this specific API"), OSCAR can write a brand-new skill.
+When a user requests a new automation or capability (e.g., "Learn how to parse local weather warnings from this specific API"), OSCAR drafts a brand-new skill **into the pending directory**. The skill does not go live until an administrator promotes it from the ServiceBay dashboard.
 
-### Rules & Sandboxing:
-- **Location**: Write the new skill file to `/opt/data/skills/oscar/<skill-name>/SKILL.md`.
-- **Sandboxing & Testing**:
-  - Before finalizing any custom shell script or python routine, write it to a temporary sandbox file inside `/opt/data/skills/oscar/<skill-name>/scratch/test_run.py`.
-  - Run the test script using `run_command` in a non-interactive sandbox shell.
-  - Verify that the API calls work, standard outputs are correct, and all dependencies are resolved.
-- **Reloading Hermes**:
-  - Once the skill `SKILL.md` is successfully written and verified, trigger a service reload.
-  - Call the ServiceBay-MCP tool `restart_service` with the argument `{"service": "hermes"}`. This forces Hermes to reload all active skills on-the-fly without system downtime.
+### Hard rules — do NOT skip these:
 
-### Example SKILL.md Structure to Generate:
+- **Write only to `/opt/data/skills-pending/<slug>/SKILL.md`.** Never write to `/opt/data/skills/oscar/...` directly. Hermes auto-discovers skills under `/opt/data/skills/oscar`; auto-writing there would make the new skill live with no human review, which is a prompt-injection risk.
+- **Do not execute the skill's scripts.** No `run_command` against generated Python, JavaScript, or shell. Test scripts may be drafted alongside SKILL.md as *files* (e.g. `<slug>/scratch/test_run.py`) for the admin to inspect, but OSCAR never runs them itself in the current Hermes shell. A sandboxed test runtime is a planned follow-up; until it lands, drafted scripts are inert until promotion.
+- **Do not call `restart_service hermes`.** Promotion triggers the restart from the dashboard. OSCAR's job ends at "wrote the SKILL.md to pending".
+- **Use a safe `<slug>`.** Lowercase letters, digits, dashes; no `/`, `..`, leading dots, or whitespace. Reject names that would escape `/opt/data/skills-pending/`.
+
+### Operating Sequence:
+
+1. Create `/opt/data/skills-pending/<slug>/` (mkdir is fine; the directory is auto-created on first write).
+2. Write the SKILL.md frontmatter and body using `write_to_file`. Include:
+   - `name: oscar-custom-<slug>`
+   - `description:` a clear, single-paragraph LLM-router description.
+   - `version: 1.0.0`, `author: OSCAR Dynamic Compiler`, `license: MIT`.
+3. If the skill needs a scratch script, write it to `<slug>/scratch/<file>` as a normal file. Do **not** execute it.
+4. Tell the user *exactly* this shape: *"Ich habe einen Entwurf für die neue Skill `<slug>` unter den ausstehenden Skills abgelegt. Sobald ein Admin sie im ServiceBay-Dashboard freigibt, lerne ich sie."*
+
+### Example SKILL.md to generate:
+
 ```markdown
 ---
-name: oscar-custom-<name>
-description: <detailed description for LLM router>
+name: oscar-custom-weather-warnings
+description: When the user asks about local weather warnings, fetch the DWD warning feed for the configured WARNCELLID and summarize active warnings.
 version: 1.0.0
 author: OSCAR Dynamic Compiler
 license: MIT
 ---
 
-# OSCAR — Custom Skill <Name>
+# OSCAR — Custom Skill: Weather Warnings
 
 ## When to use
-- <Use-case triggers>
+- The user asks about active local weather warnings, storms, or hazards.
 
 ## Operating sequence
-1. <Step-by-step instructions>
+1. Read `/opt/data/notes/fact_address.md` for the WARNCELLID.
+2. GET https://maps.dwd.de/geoserver/dwd/ows?... (the feed URL).
+3. Parse the warnings JSON and reply with the highest-severity active warning in German.
 ```
+
+### What admin promotion does (for context, not actions you take):
+
+1. The ServiceBay dashboard's *Pending OSCAR skills* section lists every directory under `/opt/data/skills-pending/`.
+2. Admin clicks **Promote**: the directory moves to `/opt/data/skills/oscar/<slug>/`, then ServiceBay restarts the `hermes` service so the new skill is loaded.
+3. Admin clicks **Reject**: the directory is deleted from pending. The skill never goes live.
 
 ---
 
@@ -82,6 +98,7 @@ OSCAR operates with peer agents and templates managed under Honcho. When perform
 
 ## Failure Paths & Safety Guards
 
-- **Strict Path Sandboxing**: Never write or edit files outside `/opt/data/` or the designated project workspaces.
-- **Testing Before Merging**: Never write a complex `SKILL.md` without running a validation probe or test execution of the underlying command/API first.
-- **Error Recovery**: If a service reload of `hermes` fails or causes a crash, check logs using `journalctl -u hermes` via ServiceBay-MCP, revert the changes in `SKILL.md`, and reload again.
+- **Strict Path Sandboxing**: Never write or edit files outside `/opt/data/`. For pending skills, restrict writes to `/opt/data/skills-pending/<slug>/`.
+- **No silent self-activation.** Writing under `/opt/data/skills/oscar/...` from this skill is a bug, not a shortcut. If you find yourself reasoning "I should just put it directly so the user doesn't have to wait", stop — that bypasses the admin gate that exists precisely so a jailbroken or prompt-injected session can't grant itself code execution.
+- **No `run_command` for generated scripts.** Drafted scripts are files for human review; they are not executed in the current Hermes shell. A sandboxed runtime for verifying them is a planned follow-up (see ServiceBay issue #940).
+- **Error Recovery**: If a write fails, surface the error to the user (not to the dashboard) and stop. Do not retry against the active skills directory as a workaround.


### PR DESCRIPTION
## Summary

Closes the four non-postponed OSCAR follow-ups opened during the 2026-05-25 install test.

- **#938** — `OLLAMA_VISION_MODEL` (optional, blank default) → ollama post-deploy pulls a second vision-capable tag in series so OSCAR's `media-ingestion-multimodal` skill can OCR images. README documents the single-model vs. two-model split; Hermes-side routing of image-bearing turns is still upstream-Hermes work.
- **#939** — Wizard variables for Telegram / Discord / Signal tokens + allowlists. Hermes post-deploy now idempotently merges them into `${DATA_DIR}/hermes/.env`, leaving unmanaged keys untouched and only restarting when the file actually changes. Signal account pairing remains interactive (`signal-cli link` + QR), which the README still calls out.
- **#940** — Admin-promotion gate for the dynamic-skill compiler. The Hermes pod gets a new `/opt/data/skills-pending` bind mount outside the loader's scan root (template schema-version bumped to v3 + CHANGELOG entry). The `dynamic-skills` SKILL.md is rewritten to drop the unsafe auto-`restart_service` and shell `run_command` instructions and to direct drafts to the pending dir. ServiceBay grows `GET /api/oscar/pending-skills`, `POST .../[slug]/promote`, `DELETE .../[slug]`, and a "Pending OSCAR skills" panel under Settings → Integrations with Promote / Reject buttons.
- **#937** — Speaker-ID framework for the gatekeeper. New `embeddings_store.py` (SQLite CRUD over `voice_embeddings`), `speaker.py` (numpy cosine resolver + opt-in SpeechBrain extractor), `enrollment.py` (`POST /enrol` accepting 3–10 base64 PCM clips). Handler resolves a per-turn uid via k-NN over enrolments, falling back cleanly to `DEFAULT_UID`. ECAPA-TDNN + torch are an opt-in `[speaker-id]` extra so the stock 100 MB image doesn't balloon to ~1 GB; operators build a custom image and flip `OSCAR_SPEAKER_ID_ENABLED=1`.

Out of scope (filed as follow-ups in the issue bodies):

- gVisor / WASM sandbox for #940 — needs an FCoS base-image change.
- CI build of a pre-baked `oscar-gatekeeper-ml` image with the SpeechBrain stack for #937.
- #936 Hermes MCP-over-SSE handshake — that's a Hermes-upstream bug, not a ServiceBay concern.

## Test plan

- [x] `npm run check:arch` — invariants + dep-cruiser clean
- [x] `npm test` — 1254 passing
- [x] `npx tsc --noEmit` — no type errors
- [x] `python3 -m py_compile` on all touched .py files
- [x] `write_gateway_env` smoke-tested for idempotency (initial write, no-op re-write, external-edit survival, clear)
- [ ] Manual install verification on the ServiceBay box once the release lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)