### PR TITLE
fix(boot): sudo -n efibootmgr in reinstall wizard

### DIFF
--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1051,7 +1051,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         const agent = agentManager.getAgent(nodeName);
         
         if (action === 'clear') {
-          const res = await agent.sendCommand('exec', { command: 'efibootmgr -N' }) as { code?: number; stderr?: string };
+          const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -N' }) as { code?: number; stderr?: string };
           if (res.code !== 0) {
             return errorResult(`Failed to clear BootNext: ${res.stderr}`);
           }
@@ -1059,7 +1059,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         }
         
         if (action === 'list') {
-          const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+          const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
           if (res.code !== 0) {
             return errorResult('Failed to query efibootmgr');
           }
@@ -1105,7 +1105,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         // action === 'set'
         let targetBootNum = bootNum;
         if (!targetBootNum) {
-          const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+          const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
           if (res.code === 0) {
             const stdout = res.stdout ?? '';
             const lines = stdout.split('\n');
@@ -1129,8 +1129,8 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
           return errorResult('No USB boot entry found or specified');
         }
         
-        await agent.sendCommand('exec', { command: `efibootmgr -A -b ${targetBootNum}` });
-        const resBootNext = await agent.sendCommand('exec', { command: `efibootmgr -n ${targetBootNum}` }) as { code?: number; stderr?: string };
+        await agent.sendCommand('exec', { command: `sudo -n efibootmgr -A -b ${targetBootNum}` });
+        const resBootNext = await agent.sendCommand('exec', { command: `sudo -n efibootmgr -n ${targetBootNum}` }) as { code?: number; stderr?: string };
         if (resBootNext.code !== 0) {
           return errorResult(`Failed to set BootNext: ${resBootNext.stderr}`);
         }

--- a/packages/frontend/src/app/api/system/boot/usb-next/route.ts
+++ b/packages/frontend/src/app/api/system/boot/usb-next/route.ts
@@ -16,7 +16,7 @@ async function getAgent() {
 export const GET = withApiHandler({}, async () => {
   try {
     const agent = await getAgent();
-    const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+    const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
     if (res.code !== 0) {
       return NextResponse.json({ error: 'Failed to query efibootmgr' }, { status: 500 });
     }
@@ -86,7 +86,7 @@ export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
     let bootNum = body.bootNum;
     
     if (!bootNum) {
-      const res = await agent.sendCommand('exec', { command: 'efibootmgr -v' }) as { code?: number; stdout?: string };
+      const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
       if (res.code === 0) {
         const stdout = res.stdout ?? '';
         const lines = stdout.split('\n');
@@ -111,10 +111,10 @@ export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
     }
     
     logger.info('api:system:boot:usb-next', `Activating UEFI boot entry Boot${bootNum}`);
-    await agent.sendCommand('exec', { command: `efibootmgr -A -b ${bootNum}` });
-    
+    await agent.sendCommand('exec', { command: `sudo -n efibootmgr -A -b ${bootNum}` });
+
     logger.info('api:system:boot:usb-next', `Setting UEFI BootNext to ${bootNum}`);
-    const resBootNext = await agent.sendCommand('exec', { command: `efibootmgr -n ${bootNum}` }) as { code?: number; stderr?: string };
+    const resBootNext = await agent.sendCommand('exec', { command: `sudo -n efibootmgr -n ${bootNum}` }) as { code?: number; stderr?: string };
     if (resBootNext.code !== 0) {
       return NextResponse.json({ error: `Failed to set BootNext: ${resBootNext.stderr}` }, { status: 500 });
     }
@@ -140,7 +140,7 @@ export const DELETE = withApiHandler({}, async () => {
   try {
     const agent = await getAgent();
     logger.info('api:system:boot:usb-next', 'Clearing UEFI BootNext setting');
-    const res = await agent.sendCommand('exec', { command: 'efibootmgr -N' }) as { code?: number; stderr?: string };
+    const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -N' }) as { code?: number; stderr?: string };
     if (res.code !== 0) {
       return NextResponse.json({ error: `Failed to clear BootNext: ${res.stderr}` }, { status: 500 });
     }


### PR DESCRIPTION
## Summary
- Prepend \`sudo -n\` to all 8 \`efibootmgr\` invocations: 4 in \`api/system/boot/usb-next/route.ts\`, 4 in MCP \`set_boot_next_usb\` tool.
- Read-only \`-v\` calls also get \`sudo -n\` so behavior is symmetric with the writers.
- FCoS gives \`core\` passwordless \`sudo\` by default; \`-n\` makes it fail-fast instead of prompting.

Fixes #984

## Test plan
- [ ] On a live FCoS box, hit Settings → Updates → Reinstall → "Boot from USB on next reboot" and verify it no longer returns \`Permission denied\`.
- [ ] MCP \`set_boot_next_usb\` action: \`list\` / \`set\` / \`clear\` all succeed.
- [ ] \`npm run check:arch\` (already verified locally, no new violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)