### PR TITLE
fix(install): auto-provision operator LLDAP user + ensure OIDC clients

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -31,6 +31,7 @@ import {
   getTemplatePostDeployScript,
   getTemplateMigrationScripts,
   getTemplateYaml,
+  getTemplateVariables,
 } from '@/lib/registry';
 import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
 import { parseTemplateManifest } from '@/lib/template/contract';
@@ -617,6 +618,81 @@ export async function ensureProxyHosts(
     }
   } catch (e) {
     await log(jobId, `⚠️ Per-service proxy-host creation failed: ${e instanceof Error ? e.message : String(e)}. Settings → Self-Diagnose → Reprovision will retry.`);
+  }
+}
+
+/**
+ *  Last-mile guard for Authelia OIDC clients (#989). Mirrors `ensureProxyHosts`:
+ *  the capability bus already emits `feature.installed` per template and the
+ *  Authelia handler registers that one template's OIDC client(s) — but the
+ *  per-template path is fragile (auth pod is restarting between writes, or
+ *  the emit happens before `auth` is reachable). When a single handler
+ *  invocation under-produces, the operator hits "client not registered" at
+ *  SSO time and ends up editing configuration.yml by hand.
+ *
+ *  This pass walks every template in this install whose variables.json
+ *  declares an `oidcClient` and sends them through `/api/system/authelia/oidc-clients`
+ *  in ONE batched call — the endpoint is idempotent (skips existing
+ *  client_ids), so any client a per-template emit already created is a
+ *  no-op here. Anything missed gets added in this single write + restart.
+ *  The install no longer depends on every per-template emit landing.
+ */
+export async function ensureOidcClients(
+  jobId: string,
+  templateNames: string[],
+  variables: StackVariable[],
+): Promise<void> {
+  const variableMap = variables.reduce<Record<string, string>>((acc, v) => {
+    acc[v.name] = v.value;
+    return acc;
+  }, {});
+  if (!variableMap.PUBLIC_DOMAIN) return; // LAN-only install — no OIDC
+
+  const templatesWithOidc: { name: string }[] = [];
+  for (const name of templateNames) {
+    try {
+      const meta = await getTemplateVariables(name);
+      if (!meta) continue;
+      const hasOidc = Object.values(meta).some(
+        v => v.type === 'subdomain' && v.oidcClient?.client_id,
+      );
+      if (hasOidc) templatesWithOidc.push({ name });
+    } catch {
+      // template not on disk / unparseable — skip it. The per-template
+      // emit would have noticed the same problem and surfaced a diagnose
+      // finding.
+    }
+  }
+  if (templatesWithOidc.length === 0) return;
+
+  try {
+    const res = await apiFetch('/api/system/authelia/oidc-clients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ templates: templatesWithOidc, variables: variableMap }),
+    });
+    if (res.status === 404) {
+      // Authelia not deployed (e.g. feature-only install on a host where
+      // `auth` was never selected). Soft warning — matches the per-template
+      // handler's 404 behaviour.
+      await log(jobId, `(note) Authelia not deployed — skipped OIDC client reconciliation for ${templatesWithOidc.map(t => t.name).join(', ')}.`);
+      return;
+    }
+    const data = await res.json().catch(() => ({} as Record<string, unknown>));
+    if (!res.ok) {
+      const msg = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+      await log(jobId, `⚠️ Could not reconcile Authelia OIDC clients: ${msg}. Settings → Self-Diagnose → Reprovision will retry.`);
+      return;
+    }
+    const added = Array.isArray(data.added) ? (data.added as string[]) : [];
+    const skipped = Array.isArray(data.skipped) ? (data.skipped as string[]) : [];
+    if (added.length > 0) {
+      await log(jobId, `✅ Registered ${added.length} Authelia OIDC client(s): ${added.join(', ')}.`);
+    } else if (skipped.length > 0) {
+      await log(jobId, `✅ All ${skipped.length} Authelia OIDC client(s) already registered.`);
+    }
+  } catch (e) {
+    await log(jobId, `⚠️ Authelia OIDC reconciliation failed: ${e instanceof Error ? e.message : String(e)}. Settings → Self-Diagnose → Reprovision will retry.`);
   }
 }
 
@@ -1283,6 +1359,12 @@ async function runJob(jobId: string): Promise<void> {
   // regardless of whether each per-template `feature.installed` emit
   // created its own. Idempotent: re-creating an existing host no-ops.
   await ensureProxyHosts(jobId, variables, input.node);
+
+  // #989 — same guarantee for Authelia OIDC clients. Per-template emits
+  // are fragile (auth pod restarts between writes, race against config
+  // read), and a missed registration only surfaces when the operator
+  // tries to SSO into the affected service.
+  await ensureOidcClients(jobId, Array.from(newlyDeployed), variables);
 
   // Build the final credentials manifest for the Done UI. Handler
   // already persisted per-template entries to `config.installManifest`

--- a/packages/frontend/src/app/api/system/lldap/seed/route.ts
+++ b/packages/frontend/src/app/api/system/lldap/seed/route.ts
@@ -28,11 +28,28 @@ const LLDAP_GRAPHQL_USER_GROUPS = `
   }
 `;
 
+const LLDAP_GRAPHQL_CREATE_USER = `
+  mutation CreateUser($user: CreateUserInput!) {
+    createUser(user: $user) { id displayName email }
+  }
+`;
+
 interface SeedRequest {
   host?: string;
   port?: number;
   password: string;
   groups?: string[];
+  /** Optional operator-user spec (#988). When provided, the seed route
+   *  also creates this LLDAP user and adds them to `admins` so the
+   *  operator skips the "log in to LLDAP as admin, find your user,
+   *  add to admins" catch-22 on first run. The password must be set
+   *  separately via the LLDAP UI — LLDAP uses OPAQUE, so passwords
+   *  can't be set over GraphQL. */
+  operator?: {
+    uid: string;
+    email: string;
+    displayName?: string;
+  };
 }
 
 const DEFAULT_GROUPS = ['admins', 'family'];
@@ -163,7 +180,17 @@ export const POST = withApiHandler({}, async ({ request }) => {
     adminGrant = await grantAdminGroup(baseUrl, auth.token);
   }
 
-  return NextResponse.json({ created, existing, failed, adminGrant });
+  // #988 — auto-provision the operator user in `admins` so the operator
+  // can reach every protected domain on first login. Without this they
+  // hit a catch-22: the LLDAP UI (where they'd add themselves to
+  // admins) is itself behind the admin-only Authelia rule. Best-effort:
+  // a failure here is logged but doesn't fail the seed.
+  let operatorProvision: { ok: boolean; uid?: string; created?: boolean; reason?: string } = { ok: false };
+  if (body.operator?.uid && body.operator?.email) {
+    operatorProvision = await provisionOperatorUser(baseUrl, auth.token, body.operator);
+  }
+
+  return NextResponse.json({ created, existing, failed, adminGrant, operatorProvision });
 });
 
 /**
@@ -220,5 +247,102 @@ async function grantAdminGroup(baseUrl: string, token: string): Promise<{ ok: bo
     return { ok: addData?.data?.addUserToGroup?.ok === true };
   } catch (e) {
     return { ok: false, reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * #988 — Provision an LLDAP user for the operator (typically derived
+ * from `OPERATOR_EMAIL` captured in the wizard) and add them to the
+ * `admins` group. Idempotent: a pre-existing user is treated as
+ * success and the group membership is reconciled.
+ *
+ * Password is NOT set here. LLDAP uses the OPAQUE protocol for
+ * passwords; they cannot be set over GraphQL with a plaintext value.
+ * The operator finishes provisioning by clicking their user in the
+ * LLDAP UI and using "Set password" — but the catch-22 (needing
+ * admin-domain access to reach the UI) is gone because the LLDAP
+ * built-in `admin` user is already in `admins` via the seed flow.
+ */
+async function provisionOperatorUser(
+  baseUrl: string,
+  token: string,
+  operator: { uid: string; email: string; displayName?: string },
+): Promise<{ ok: boolean; uid?: string; created?: boolean; reason?: string }> {
+  try {
+    // 1) Create. LLDAP returns a duplicate-key error if the user
+    // already exists — treat that as success-with-created=false.
+    let created = false;
+    const createRes = await fetch(`${baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({
+        query: LLDAP_GRAPHQL_CREATE_USER,
+        variables: {
+          user: {
+            id: operator.uid,
+            email: operator.email,
+            displayName: operator.displayName ?? operator.uid,
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!createRes.ok) {
+      return { ok: false, uid: operator.uid, reason: `createUser HTTP ${createRes.status}` };
+    }
+    const createData = await createRes.json();
+    if (createData?.errors?.length) {
+      const msg: string = createData.errors[0]?.message ?? '';
+      const lower = msg.toLowerCase();
+      if (!(lower.includes('already exists') || lower.includes('duplicate') || lower.includes('unique constraint'))) {
+        return { ok: false, uid: operator.uid, reason: msg };
+      }
+      // user already exists — fall through to group add
+    } else if (createData?.data?.createUser?.id) {
+      created = true;
+    }
+
+    // 2) Add to `admins` (idempotent; reuses the same lookup pattern
+    // as grantAdminGroup above).
+    const memberRes = await fetch(`${baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ query: LLDAP_GRAPHQL_USER_GROUPS, variables: { userId: operator.uid } }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (memberRes.ok) {
+      const data = await memberRes.json();
+      const groupsForUser: Array<{ displayName?: string }> = data?.data?.user?.groups ?? [];
+      if (groupsForUser.some(g => g.displayName === 'admins')) {
+        return { ok: true, uid: operator.uid, created };
+      }
+    }
+    const listRes = await fetch(`${baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ query: LLDAP_GRAPHQL_LIST_GROUPS }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!listRes.ok) return { ok: false, uid: operator.uid, reason: `groups query HTTP ${listRes.status}` };
+    const listData = await listRes.json();
+    const allGroups: Array<{ id: number; displayName: string }> = listData?.data?.groups ?? [];
+    const adminGroup = allGroups.find(g => g.displayName === 'admins');
+    if (!adminGroup) return { ok: false, uid: operator.uid, reason: '`admins` group not found' };
+
+    const addRes = await fetch(`${baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({
+        query: LLDAP_GRAPHQL_ADD_USER_TO_GROUP,
+        variables: { userId: operator.uid, groupId: adminGroup.id },
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!addRes.ok) return { ok: false, uid: operator.uid, reason: `addUserToGroup HTTP ${addRes.status}` };
+    const addData = await addRes.json();
+    if (addData?.errors?.length) return { ok: false, uid: operator.uid, reason: addData.errors[0]?.message ?? 'unknown' };
+    return { ok: addData?.data?.addUserToGroup?.ok === true, uid: operator.uid, created };
+  } catch (e) {
+    return { ok: false, uid: operator.uid, reason: e instanceof Error ? e.message : String(e) };
   }
 }

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -109,10 +109,23 @@ def wait_for_lldap(sb_api: str, port: int) -> bool:
     return False
 
 
+def derive_operator_uid(email: str) -> str:
+    """
+    Derive a safe LLDAP uid from the operator's email local-part.
+    LLDAP user IDs are lowercase alphanumeric + `_`/`.`/`-`; strip
+    anything else and lowercase the rest. Falls back to "operator" if
+    the local-part sanitizes to empty.
+    """
+    local = (email.split("@", 1)[0] if "@" in email else email).lower()
+    cleaned = "".join(ch for ch in local if ch.isalnum() or ch in {"_", ".", "-"})
+    return cleaned or "operator"
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
     sb_api = env("SB_API_URL", "http://localhost:3000")
     public_domain = env("PUBLIC_DOMAIN")
+    operator_email = env("OPERATOR_EMAIL")
 
     lldap_password = env("LLDAP_ADMIN_PASSWORD")
     lldap_port = env("LLDAP_PORT", "17170")
@@ -175,10 +188,28 @@ def main() -> int:
         )
     else:
         log("Seeding LLDAP groups...")
+        # #988 — pass the operator email so seed also pre-creates the
+        # operator's LLDAP user + adds them to `admins`. No password is
+        # set (LLDAP uses OPAQUE) — they finish via "Set password" in
+        # the LLDAP UI on first sign-in.
+        operator_payload: dict[str, object] = {}
+        if operator_email:
+            operator_payload = {
+                "operator": {
+                    "uid": derive_operator_uid(operator_email),
+                    "email": operator_email,
+                    "displayName": "Operator",
+                },
+            }
         for attempt in range(1, SEED_MAX_ATTEMPTS + 1):
             seed_status, seed_body = post_json(
                 f"{sb_api}/api/system/lldap/seed",
-                {"host": "localhost", "port": int(lldap_port), "password": lldap_password},
+                {
+                    "host": "localhost",
+                    "port": int(lldap_port),
+                    "password": lldap_password,
+                    **operator_payload,
+                },
                 timeout=15,
             )
             ok = seed_status == 200 and isinstance(seed_body, dict)
@@ -201,6 +232,40 @@ def main() -> int:
                 else:
                     reason = admin_grant.get("reason", "no reason returned")
                     log(f"⚠️ Could not grant LLDAP `admin` the `admins` group ({reason}). Add it manually in LLDAP's web UI or you'll get HTTP 403 from ldap.<domain>.")
+
+                # #988 — operator user provisioning result
+                op_prov = (seed_body or {}).get("operatorProvision") or {}
+                if operator_email and op_prov.get("ok"):
+                    op_uid = op_prov.get("uid") or derive_operator_uid(operator_email)
+                    state = "created" if op_prov.get("created") else "already present"
+                    log(f"✅ Operator LLDAP user `{op_uid}` ({state}) is in `admins`.")
+                    # Surface the next step as a credential entry. The
+                    # LLDAP URL is `http://{host}:{lldap_port}` here —
+                    # post-install rendering picks up the NPM-mapped
+                    # `https://ldap.{public_domain}/user/{uid}` once the
+                    # subdomain is wired, but we point at LAN here for
+                    # the operator's first run when SSO may not yet be
+                    # fully reachable.
+                    lldap_user_url = f"http://{host}:{lldap_port}/user/{op_uid}"
+                    if public_domain:
+                        lldap_user_url = f"https://ldap.{public_domain}/user/{op_uid}"
+                    emit_credential(
+                        service="Operator LLDAP user (set password to finish)",
+                        url=lldap_user_url,
+                        username=op_uid,
+                        password="(set via LLDAP UI — click your user, then \"Set password\")",
+                        importance="critical",
+                        notes=(
+                            "Your LLDAP user is pre-created and in the `admins` group. "
+                            "LLDAP uses OPAQUE for passwords, so we can't seed one — sign in "
+                            "to LLDAP's web UI as `admin` (see the credential above), open "
+                            "this user, click \"Set password\", then log in to any "
+                            f"{(public_domain or 'service')} subdomain as yourself."
+                        ),
+                    )
+                elif operator_email and op_prov:
+                    reason = op_prov.get("reason", "no reason returned")
+                    log(f"⚠️ Could not auto-provision LLDAP user for OPERATOR_EMAIL ({reason}). Create it manually in LLDAP's web UI and add to the `admins` group.")
                 break
             # The seed endpoint is idempotent (it reports `existing` for
             # groups already present), so retrying a partial/failed run


### PR DESCRIPTION
Closes #988, closes #989.

## #988 — Operator user pre-created in LLDAP \`admins\`

The wizard already captures \`OPERATOR_EMAIL\`. The auth template's
post-deploy now passes it to the LLDAP seed step, which derives a uid
from the email local-part and:

1. Creates the LLDAP user (idempotent).
2. Adds them to the \`admins\` group.
3. Emits a credential row with a deep-link to the user's LLDAP page
   and instructions to set their password.

Password cannot be set programmatically — LLDAP uses OPAQUE — but the
catch-22 (no groups → 403 on ldap.dopp.cloud → can't reach UI to add
self to admins) is **fully eliminated**. The remaining manual step is
one click in LLDAP's "Set password" form.

## #989 — End-of-install OIDC client reconciliation

Per-template \`feature.installed\` emits are fragile against the
configuration.yml read-modify-write + pod restart cycle. Same shape
as the #807 proxy-host fix.

New \`ensureOidcClients\` reconciler runs after the per-template loop,
walks the install's templates for \`oidcClient\` declarations, and
POSTs them in **one batched call**. Endpoint is already idempotent, so
anything per-template handlers already landed is a no-op; anything
missed gets registered here.

## Test plan
- [ ] All 1254 existing tests pass locally (run \`npm test\`).
- [ ] \`npm run check:arch\` clean.
- [ ] On the live FCoS box, redeploy \`auth\` (without my LLDAP user pre-existing) and confirm:
  - LLDAP user \`<email-local-part>\` appears in \`admins\` group.
  - Credential row "Operator LLDAP user (set password to finish)" lands in Settings → Saved credentials.
- [ ] After installing HA + Immich post-merge, verify \`configuration.yml\` has \`homeassistant\` and \`immich\` blocks under \`identity_providers.oidc.clients\`.
- [ ] Existing seed callers without \`operator\` field still work (regression — \`operator\` is optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)