### PR TITLE
chore(frontend): operator-facing errors → toast + ServiceForm as-any cleanup

### DIFF
--- a/packages/frontend/src/components/LogViewer.tsx
+++ b/packages/frontend/src/components/LogViewer.tsx
@@ -281,7 +281,9 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
               setCurrentSystemLogLevel(data.logLevel);
           }
       } catch (e) {
-          console.error('Failed to fetch system log level', e);
+          // Background prefetch — toast would spam if the API is briefly
+          // unavailable on first render. Keep dev-only.
+          console.error('[LogViewer] Failed to fetch system log level', e);
       }
   };
 
@@ -293,7 +295,8 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
             setAvailableTags(data.tags);
         }
     } catch (err) {
-        console.error('Failed to load tags:', err);
+        // Tag filter is a convenience; failure degrades to free-text only.
+        console.error('[LogViewer] Failed to load tags:', err);
     }
   };
 
@@ -306,7 +309,8 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
         setLogDates(data.files.map((f: {name: string}) => f.name));
       }
     } catch (err) {
-        console.error('Failed to load log dates:', err);
+        // Date picker fallback is empty list — visible to operator.
+        console.error('[LogViewer] Failed to load log dates:', err);
     }
   };
 
@@ -334,7 +338,6 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
         setLogs([]);
       }
     } catch (err) {
-      console.error('Failed to load logs:', err);
       const { title, detail } = humanizeError(err, 'Failed to load logs');
       addToast('error', title, detail);
     } finally {

--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -917,13 +917,13 @@ export default function OnboardingWizard() {
         }
         setStackDeviceOptions(opts);
       } catch (err) {
-        console.error('Failed to fetch devices:', err);
+        addToast('error', 'Could not list devices for the selected node', err instanceof Error ? err.message : String(err));
       } finally {
         setStackLoadingDevices(false);
       }
     };
     fetchDevices();
-  }, [stackSelectedNode]);
+  }, [stackSelectedNode, addToast]);
 
   // RAID detection
   useEffect(() => {
@@ -936,11 +936,11 @@ export default function OnboardingWizard() {
           setRaidArrays((raids || []).filter((r: { mountpoint: string | null }) => !r.mountpoint));
         }
       } catch (err) {
-        console.error('Failed to fetch RAID:', err);
+        addToast('error', 'Could not detect RAID arrays', err instanceof Error ? err.message : String(err));
       }
     };
     fetchRaid();
-  }, [stackSelectedNode]);
+  }, [stackSelectedNode, addToast]);
 
   const handleGenerateKey = async () => {
     setLoading(true);

--- a/packages/frontend/src/components/ServiceForm.tsx
+++ b/packages/frontend/src/components/ServiceForm.tsx
@@ -126,8 +126,16 @@ export default function ServiceForm({ initialData, isEdit, defaultNode, onClose,
     }
   }, [initialData]);
 
-  const updateCursorPosition = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
-    const textarea = e.currentTarget;
+  // react-simple-code-editor types onSelect/onClick/onKeyUp against its
+  // wrapper <div>, but the underlying focus target is the inner textarea.
+  // Walk to it via the event-source DOM rather than asserting element
+  // types — that lets the three handlers share one signature without
+  // `as any` while still pulling selection state off the textarea.
+  const updateCursorPosition = (e: React.SyntheticEvent) => {
+    const root = e.currentTarget as HTMLElement | null;
+    const textarea = root instanceof HTMLTextAreaElement
+        ? root
+        : root?.querySelector('textarea') ?? null;
     if (textarea) {
         const val = textarea.value.substr(0, textarea.selectionStart);
         const line = val.split('\n').length;
@@ -713,12 +721,9 @@ WantedBy=default.target`;
                         }}
                         textareaClassName="focus:outline-none"
                         placeholder="apiVersion: v1&#10;kind: Pod&#10;metadata:&#10;  name: my-service..."
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        onSelect={updateCursorPosition as any}
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        onClick={updateCursorPosition as any}
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        onKeyUp={updateCursorPosition as any}
+                        onSelect={updateCursorPosition}
+                        onClick={updateCursorPosition}
+                        onKeyUp={updateCursorPosition}
                         />
                             </div>
                         </div>

--- a/packages/frontend/src/dashboards/HealthDashboard.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.tsx
@@ -123,8 +123,10 @@ export default function HealthDashboard() {
       if (checksRes.ok) setChecks(await checksRes.json());
       setNodes(nodeList);
     } catch (error) {
-      console.error('Failed to fetch data', error);
-      // addToast('error', 'Failed to fetch health data'); // Suppress error toast on bg sync?
+      // Background sync — toast intentionally suppressed (would spam on
+      // every poll if the server briefly blips). Operator sees the
+      // staleness via the dashboard's own "last updated" indicator.
+      console.error('[HealthDashboard] Failed to fetch data', error);
     } finally {
       // if (!silent) setLoading(false);
       isFetchingRef.current = false;
@@ -171,7 +173,9 @@ export default function HealthDashboard() {
                 setSystemServices(system.map((s: { unit: string }) => s.unit));
             }
         } catch (e) {
-            console.error('Failed to fetch node resources', e);
+            // Background resources fetch — keep silent (the panel
+            // shows its own "no data" state when this fails).
+            console.error('[HealthDashboard] Failed to fetch node resources', e);
         } finally {
             setResourcesLoading(false);
         }
@@ -324,8 +328,7 @@ export default function HealthDashboard() {
       if (res.ok) {
         setHistoryData(await res.json());
       }
-    } catch (error) {
-      console.error('Failed to fetch history', error);
+    } catch {
       addToast('error', 'Failed to fetch history');
     } finally {
       setHistoryLoading(false);

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -340,6 +340,10 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
 
   // Helper to get display details based on type
   const getDetails = (): DetailItem[] => {
+      // rawData carries a discriminated union of per-node-kind shapes
+      // (container / service / link / gateway / device). Until the
+      // backend's GraphNode types are exported as a union, we keep the
+      // cast — see #976 reader API refactor for the proper fix.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const raw = (data.rawData || {}) as any;
       const common: DetailItem[] = [];
@@ -1150,7 +1154,6 @@ export default function NetworkDashboard() {
          const data = await res.json();
          setRawData(data);
      } catch (e) {
-         console.error('Failed to fetch graph', e);
          const message = e instanceof Error ? e.message : 'Unable to reload network map';
          resolveReloadToast('error', message);
      }
@@ -1377,8 +1380,7 @@ export default function NetworkDashboard() {
                 if (!cancelled) {
                      resolveReloadToast('success', 'Latest network topology is ready');
                 }
-          } catch (error) {
-                console.error('Failed to process network graph', error);
+          } catch {
                 if (!cancelled) {
                      resolveReloadToast('error', 'Unable to render network map');
                 }
@@ -1487,8 +1489,7 @@ export default function NetworkDashboard() {
                  }
              });
         }
-    } catch (error) {
-        console.error('Failed to update link', error);
+    } catch {
         addToast('error', 'Failed to update link');
     }
   };


### PR DESCRIPTION
Closes #967, closes #970.

## #970 — ServiceForm as-any cleanup

Three \`as any\` casts in ServiceForm.tsx (lines 717/719/721) were silencing a real type mismatch: react-simple-code-editor's \`onSelect/onClick/onKeyUp\` are typed against its wrapper \`<div>\`, but \`updateCursorPosition\` expected \`SyntheticEvent<HTMLTextAreaElement>\`.

\`updateCursorPosition\` now accepts the broader \`SyntheticEvent\` and walks to the inner \`<textarea>\` via the event target — no cast needed.

NetworkDashboard's remaining \`as any\` (line 344, \`data.rawData\` discriminated union) is documented with an eslint-disable + a pointer to #976 (DigitalTwinStore reader API). Properly typing it requires a discriminated GraphNode union from the backend that's out of scope for this PR.

## #967 — Frontend console.* sweep (operator-facing sites)

Decision rubric per the issue's UX_PHILOSOPHY rule:
- Already surfaces a toast → console.error is redundant, **remove**.
- Background sync / transient blip — toast would spam → **keep with \`[ComponentName]\` prefix**.
- Silent failure leaves operator stuck → **forward to addToast**.

| Site | Before | After |
| --- | --- | --- |
| NetworkDashboard 1153/1381/1491 | console.error + toast | toast (console removed) |
| HealthDashboard 126 | console.error (bg sync) | console.error with \`[HealthDashboard]\` prefix |
| HealthDashboard 174 | console.error (bg fetch) | console.error with \`[HealthDashboard]\` prefix |
| HealthDashboard 328 | console.error + toast | toast (console removed) |
| LogViewer 284 | console.error | \`[LogViewer]\` prefix |
| LogViewer 296 | console.error | \`[LogViewer]\` prefix |
| LogViewer 309 | console.error | \`[LogViewer]\` prefix |
| LogViewer 337 | console.error + toast | toast (console removed) |
| OnboardingWizard 920 | silent | addToast |
| OnboardingWizard 939 | silent | addToast |

## Test plan
- [x] \`npm test\` — 1254 tests pass.
- [x] \`npm run build\` — succeeds.
- [x] \`npm run lint\` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)