### PR TITLE
feat(ollama): OLLAMA_SUBDOMAIN — internal NPM host gated by Authelia

### DIFF
--- a/scripts/smoke/sso-verify.sh
+++ b/scripts/smoke/sso-verify.sh
@@ -75,7 +75,7 @@ ssh_cmd() {
 RESOLVE_FLAGS=""
 build_resolve_flags() {
   local hosts=(auth ldap admin nginx dns)
-  hosts+=(vault photos music books home files caldav sync hermes zwave www)
+  hosts+=(vault photos music books home files caldav sync hermes ollama zwave www)
   hosts+=("")  # bare apex
   RESOLVE_FLAGS=""
   for h in "${hosts[@]}"; do
@@ -320,6 +320,11 @@ declare -A USER_APPS=(
   # is the literal dashboard title so the test also catches a "200 with
   # wrong content" regression (proxy half-broken).
   [hermes]="Hermes Agent"
+  # Ollama API behind Authelia forward-auth (#1003). The browser-flow
+  # session reaches /api/tags via NPM; non-LAN IPs get 403 from the
+  # access list. No content signature — Ollama responds with JSON that
+  # changes per installed-model set.
+  [ollama]=""
 )
 
 for h in "${!USER_APPS[@]}"; do

--- a/templates/ollama/variables.json
+++ b/templates/ollama/variables.json
@@ -23,5 +23,19 @@
     "type": "text",
     "description": "How long post-deploy waits for the first model pull to finish. Multi-GB models on a slow connection can take 10+ minutes; the default leaves slack. Tune down for tiny models on fast links if you want faster install feedback.",
     "default": "600"
+  },
+  "OLLAMA_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for the Ollama API. Internal exposure — gets a cert and a LAN-only access list, plus Authelia forward-auth on top because Ollama itself ships no auth. Use https://<OLLAMA_SUBDOMAIN>.<PUBLIC_DOMAIN>/api/generate from any LAN client; mobile/external clients get a 403 from NPM and a 302-to-Authelia from any in-LAN unauthenticated request.",
+    "default": "ollama",
+    "exposure": "internal",
+    "proxyPort": "OLLAMA_PORT",
+    "loopbackOnly": true,
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": true,
+      "advanced_config": "__authelia_forward_auth__"
+    }
   }
 }


### PR DESCRIPTION
Closes #1003.

Adds the `OLLAMA_SUBDOMAIN` block to `templates/ollama/variables.json` (mirrors hermes' pattern: `exposure: internal`, `loopbackOnly: true`, `__authelia_forward_auth__`). Operator can now reach the Ollama API from any LAN client after Authelia SSO; external IPs hit NPM's LAN-only access list.

Also adds `ollama` to the smoke test so this surface doesn't regress silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)