### PR TITLE
fix(proxy): forward-auth headers + strict-upstream-host land in location block; agent gains sudo write_file

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -2066,15 +2066,47 @@ class Agent:
             elif cmd == 'write_file':
                 path = msg.get('payload', {}).get('path')
                 content = msg.get('payload', {}).get('content')
+                use_sudo = bool(msg.get('payload', {}).get('sudo'))
                 if not path or content is None:
                     reply(error="Missing path or content")
                 else:
                     try:
                         expanded_path = os.path.expanduser(path)
-                        os.makedirs(os.path.dirname(expanded_path), exist_ok=True)
-                        with open(expanded_path, 'w') as f:
-                            f.write(content)
-                        reply(result="ok")
+                        if use_sudo:
+                            # #1000 — paths owned by container UIDs (e.g.
+                            # Authelia's configuration.yml under
+                            # /mnt/data/stacks/auth/...) are not writable
+                            # by `core` directly. FCoS gives `core`
+                            # passwordless sudo by default; -n fails fast
+                            # if that ever changes. tee -a NOT used —
+                            # we want overwrite semantics matching the
+                            # non-sudo branch. Write via stdin so the
+                            # content doesn't appear on the command line
+                            # (no length limit, no quoting hazards, no
+                            # leak via `ps`).
+                            import subprocess
+                            # Ensure the parent dir exists (also via sudo
+                            # so we don't EACCES on `mkdir`).
+                            parent = os.path.dirname(expanded_path)
+                            subprocess.run(
+                                ['sudo', '-n', 'mkdir', '-p', parent],
+                                check=False, timeout=10,
+                            )
+                            proc = subprocess.run(
+                                ['sudo', '-n', 'tee', expanded_path],
+                                input=content.encode('utf-8'),
+                                capture_output=True, timeout=30,
+                            )
+                            if proc.returncode != 0:
+                                err = proc.stderr.decode('utf-8', errors='replace').strip() or 'unknown sudo tee failure'
+                                reply(error=f"sudo write_file failed: {err}")
+                            else:
+                                reply(result="ok")
+                        else:
+                            os.makedirs(os.path.dirname(expanded_path), exist_ok=True)
+                            with open(expanded_path, 'w') as f:
+                                f.write(content)
+                            reply(result="ok")
                     except Exception as e:
                         reply(error=str(e))
             elif cmd == 'read_file':

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -368,6 +368,17 @@ export interface ProxyConfig {
   ssl_forced?: boolean;
   /** Custom nginx directives injected into the server block */
   advanced_config?: string;
+  /**
+   * #999 — Set to true for upstreams that reject requests whose Host
+   * header doesn't match their bind address (uvicorn's TrustedHost
+   * middleware is the canonical example — hermes dashboard). The
+   * proxy-hosts route's post-create patcher inlines NPM's proxy.conf
+   * inside the `location /` block AND appends a `proxy_set_header
+   * Host <forwardHost>:<forwardPort>;` so the upstream sees its own
+   * bind address. Default (false / unset) keeps NPM's `Host $host`,
+   * which is what most upstreams want.
+   */
+  strictUpstreamHost?: boolean;
 }
 
 export interface OidcClientConfig {

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -19,6 +19,24 @@
 export const AUTHELIA_FORWARD_AUTH_SENTINEL = '__authelia_forward_auth__';
 
 /**
+ * #999 — proxy_set_header directives we want on the UPSTREAM request
+ * (Remote-User et al. coming back from Authelia's auth-request). nginx
+ * inheritance drops server-level proxy_set_header when the location /
+ * block has any of its own (which NPM's bundled proxy.conf always
+ * does), so these must land inside `location / { }` to actually reach
+ * the upstream. Used by the post-create reconciler in
+ * `/api/system/nginx/proxy-hosts/route.ts` to patch the generated
+ * .conf via sudo write_file — see #999 for the architectural notes
+ * on why the location is the right place.
+ */
+export const AUTHELIA_LOCATION_HEADERS = [
+  'proxy_set_header Remote-User $user;',
+  'proxy_set_header Remote-Groups $groups;',
+  'proxy_set_header Remote-Name $name;',
+  'proxy_set_header Remote-Email $email;',
+].join('\n    ');
+
+/**
  * The actual nginx config block. References `{{PUBLIC_DOMAIN}}` and
  * `{{AUTHELIA_PORT}}` so it survives the Mustache pass that turns
  * cross-template placeholders into concrete values at install time.

--- a/packages/backend/src/lib/stackInstall/postInstall.ts
+++ b/packages/backend/src/lib/stackInstall/postInstall.ts
@@ -67,6 +67,7 @@ function renderProxyConfig(
   view: Record<string, string>,
 ): VariableMeta['proxyConfig'] | undefined {
   if (!proxyConfig) return proxyConfig;
+  // strictUpstreamHost is a pass-through boolean — no Mustache expansion needed
   if (!proxyConfig.advanced_config) return proxyConfig;
   // Expand the `__authelia_forward_auth__` sentinel into the shared
   // nginx snippet before the Mustache pass so the snippet's own

--- a/packages/frontend/src/app/api/system/authelia/oidc-clients/route.ts
+++ b/packages/frontend/src/app/api/system/authelia/oidc-clients/route.ts
@@ -211,7 +211,18 @@ export const POST = withApiHandler({}, async ({ request }) => {
     autheliaConfig.identity_providers.oidc.clients = existingClients;
 
     const newConfig = yaml.dump(autheliaConfig, { lineWidth: -1, quotingType: "'", forceQuotes: false });
-    await agent.sendCommand('write_file', { path: configFilePath, content: newConfig });
+    // #1000 — configuration.yml is owned by Authelia's in-container UID
+    // (~525287 on the FCoS layout). The `core` user that the agent runs
+    // as can't write it directly → EACCES → the install-time OIDC
+    // reconciler silently failed and SSO clients never got registered
+    // (root cause for the live-box manifestation of #989). The agent's
+    // write_file now accepts a `sudo` flag, same shape as #984/#992's
+    // efibootmgr -n.
+    await agent.sendCommand('write_file', {
+      path: configFilePath,
+      content: newConfig,
+      sudo: true,
+    });
 
     // Restart Authelia to pick up changes
     try {

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -5,6 +5,9 @@ import { getNodeTwins, getNodeTwin } from '@/lib/store/repository';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
+import { agentManager } from '@/lib/agent/manager';
+import { listNodes } from '@/lib/nodes';
+import { AUTHELIA_LOCATION_HEADERS } from '@/lib/stackInstall/forwardAuth';
 
 export const dynamic = 'force-dynamic';
 
@@ -56,6 +59,18 @@ interface ProxyHostRequest {
         ssl_forced?: boolean;
         /** Custom nginx directives injected into the server block */
         advanced_config?: string;
+        /**
+         * #999 — Set to true for upstreams that reject requests whose
+         * Host header doesn't match their bind address (uvicorn's
+         * TrustedHost middleware is the canonical example — hermes
+         * dashboard). When true, the post-create file-patcher inlines
+         * NPM's proxy.conf inside the location / block AND appends a
+         * `proxy_set_header Host <forwardHost>:<forwardPort>;`
+         * directive so the upstream sees its own bind address. Default
+         * (false / unset) keeps NPM's `Host $host` behaviour, which is
+         * what 90% of upstreams want.
+         */
+        strictUpstreamHost?: boolean;
     };
 }
 
@@ -340,6 +355,105 @@ async function patchProxyHostAdvancedConfig(
     } catch (e) {
         logger.warn('ProxyHosts', `Failed to backfill advanced_config for ${domain}: ${e instanceof Error ? e.message : String(e)}`);
         return { updated: false };
+    }
+}
+
+/**
+ * #999 — Inject location-level proxy_set_header directives into the
+ * generated NPM proxy_host config file. nginx's inheritance rules drop
+ * server-level `proxy_set_header` (where NPM's `advanced_config` ends
+ * up) when the `location /` block has any of its own — and NPM's
+ * bundled proxy.conf always sets `Host $host` plus X-Forwarded-*,
+ * which means the Authelia headers from advanced_config never reach
+ * the upstream.
+ *
+ * Live observation (logged in #991, #990): filebrowser saw empty
+ * Remote-User → 500 "username is empty"; hermes' uvicorn TrustedHost
+ * saw `Host: hermes.dopp.cloud` → 400 "Invalid Host header." The
+ * same fix (Remote-* inside `location /`, + for hermes a Host
+ * rewrite that wins over proxy.conf's `Host $host`) made the live box
+ * fully green.
+ *
+ * Patches the .conf via `sudo write_file` (#1000) because NPM's
+ * container writes the file as root from the host's perspective.
+ * Idempotent: skips if Remote-User is already present, or if the
+ * server-level advanced_config doesn't contain `auth_request`.
+ */
+async function patchProxyHostConfFile(
+    hostId: number,
+    domain: string,
+    upstreamHostHeader: string | undefined,
+    node: string | undefined,
+): Promise<{ patched: boolean; reason?: string }> {
+    const confPath = `/mnt/data/stacks/nginx-proxy-manager/data/nginx/proxy_host/${hostId}.conf`;
+    try {
+        const nodes = await listNodes();
+        const nodeName = node ?? nodes[0]?.Name ?? 'Local';
+        const agent = agentManager.getAgent(nodeName);
+        const readRes = await agent.sendCommand('read_file', { path: confPath }) as { content?: string; error?: string };
+        const content = readRes?.content;
+        if (!content) {
+            return { patched: false, reason: `could not read ${confPath}` };
+        }
+        // Skip if not a forward-auth proxy_host.
+        if (!/auth_request\s+\/authelia/.test(content)) {
+            return { patched: false, reason: 'no forward-auth' };
+        }
+        // Skip if Remote-User is already inside the location / block.
+        const locationMatch = content.match(/location\s+\/\s*\{[\s\S]*?\n\s*\}/);
+        if (!locationMatch) {
+            return { patched: false, reason: 'no `location /` block' };
+        }
+        const locationBlock = locationMatch[0];
+        const needsHeaders = !/proxy_set_header\s+Remote-User/.test(locationBlock);
+        const needsHostRewrite = !!upstreamHostHeader && !locationBlock.includes(`proxy_set_header Host ${upstreamHostHeader}`);
+        if (!needsHeaders && !needsHostRewrite) {
+            return { patched: false, reason: 'already patched' };
+        }
+        let patchedLocation = locationBlock;
+        if (needsHeaders) {
+            // Inject before `include conf.d/include/proxy.conf;`. The
+            // include is where NPM lays down Host $host; doing the
+            // Remote-* set BEFORE the include keeps the standard
+            // X-Forwarded-* chain intact and lets nginx's "all
+            // proxy_set_header in this location" rule pick up our
+            // additions.
+            patchedLocation = patchedLocation.replace(
+                /(\s+)(include conf\.d\/include\/proxy\.conf;)/,
+                `$1${AUTHELIA_LOCATION_HEADERS}$1$2`,
+            );
+        }
+        if (needsHostRewrite) {
+            // For uvicorn-style strict-host upstreams (hermes), proxy.conf
+            // sets `Host $host` which conflicts with our override. Strip
+            // proxy.conf's Host line by inlining proxy.conf without it,
+            // then add our Host directive at the end.
+            const PROXY_CONF_INLINE = [
+                '    add_header       X-Served-By $host;',
+                '    proxy_set_header X-Forwarded-Scheme $x_forwarded_scheme;',
+                '    proxy_set_header X-Forwarded-Proto  $x_forwarded_proto;',
+                '    proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;',
+                '    proxy_set_header X-Real-IP          $remote_addr;',
+                '    proxy_pass       $forward_scheme://$server:$port$request_uri;',
+            ].join('\n');
+            patchedLocation = patchedLocation
+                .replace(/(\s+)include conf\.d\/include\/proxy\.conf;/, `$1${PROXY_CONF_INLINE}\n    proxy_set_header Host ${upstreamHostHeader};`);
+        }
+        const newContent = content.replace(locationBlock, patchedLocation);
+        if (newContent === content) {
+            return { patched: false, reason: 'no replacement needed' };
+        }
+        const writeRes = await agent.sendCommand('write_file', { path: confPath, content: newContent, sudo: true }) as { result?: string; error?: string };
+        if (writeRes?.error) {
+            logger.warn('ProxyHosts', `Failed to patch ${confPath} for ${domain}: ${writeRes.error}`);
+            return { patched: false, reason: writeRes.error };
+        }
+        // Reload nginx to pick up the change.
+        await agent.sendCommand('exec', { command: 'podman exec nginx-nginx-proxy-manager nginx -s reload' }).catch(() => {});
+        logger.info('ProxyHosts', `Patched ${domain} location / with forward-auth headers${upstreamHostHeader ? ` + Host=${upstreamHostHeader}` : ''}`);
+        return { patched: true };
+    } catch (e) {
+        return { patched: false, reason: e instanceof Error ? e.message : String(e) };
     }
 }
 
@@ -658,6 +772,22 @@ export const POST = withApiHandler({}, async ({ request }) => {
                 createdHost = await createProxyHost(npm.apiUrl, token, host, accessListId);
                 results.push({ domain: host.domain, success: true, lanRestricted: accessListId !== 0 });
                 logger.info('ProxyHosts', `Created proxy host: ${host.domain} → ${host.forwardHost}:${host.forwardPort} (exposure=${host.exposure ?? 'lan'}${accessListId !== 0 ? ', LAN-only via access list' : ''})`);
+                // #999 — When the host needs forward-auth or a strict
+                // upstream Host header, patch the generated .conf file
+                // to land the directives in the LOCATION block where
+                // nginx will actually honour them. The server-level
+                // advanced_config alone is silently dropped by NPM's
+                // location-level proxy.conf include.
+                if (typeof createdHost?.id === 'number') {
+                    const wantsForwardAuth = /auth_request\s+\/authelia|__authelia_forward_auth__/.test(host.proxyConfig?.advanced_config ?? '');
+                    const wantsStrictHost = !!host.proxyConfig?.strictUpstreamHost;
+                    if (wantsForwardAuth || wantsStrictHost) {
+                        const upstreamHostHeader = wantsStrictHost
+                            ? `${host.forwardHost ?? '127.0.0.1'}:${host.forwardPort}`
+                            : undefined;
+                        await patchProxyHostConfFile(createdHost.id, host.domain, upstreamHostHeader, node);
+                    }
+                }
             } catch (e) {
                 const msg = e instanceof Error ? e.message : String(e);
                 results.push({ domain: host.domain, success: false, error: msg });

--- a/templates/hermes/variables.json
+++ b/templates/hermes/variables.json
@@ -34,7 +34,8 @@
       "allow_websocket_upgrade": true,
       "block_exploits": true,
       "ssl_forced": true,
-      "advanced_config": "__authelia_forward_auth__\nproxy_set_header Host 127.0.0.1:{{HERMES_DASHBOARD_PORT}};"
+      "advanced_config": "__authelia_forward_auth__",
+      "strictUpstreamHost": true
     }
   },
   "HASS_URL": {


### PR DESCRIPTION
Closes #999, closes #1000.

## #999 — Authelia headers + Host rewrite at location level

NPM's bundled `proxy.conf` sets `Host $host` inside the location / block. nginx then drops ALL server-level `proxy_set_header` (the AUTHELIA_FORWARD_AUTH_SNIPPET puts Remote-* there) per the inheritance rule. So Remote-User never reached filebrowser (#991's 500), and PR #994's Host rewrite for hermes (#990) was silently ignored too.

Fix: post-create file patcher reads the generated .conf via the agent, injects Remote-* directives INSIDE the location / block, and — for templates declaring the new `strictUpstreamHost: true` field — inlines proxy.conf (omitting Host $host) + appends a literal `proxy_set_header Host <forwardHost>:<forwardPort>;`. Idempotent; skips when no forward-auth + no strict upstream.

Hermes template now uses `strictUpstreamHost: true` instead of the ineffective `proxy_set_header Host` in advanced_config.

## #1000 — agent write_file gains sudo

The .conf files (and Authelia's configuration.yml in the OIDC reconciler) are owned by container UIDs on the host → EACCES from the agent's `core` user. `write_file` now accepts `{ sudo: true }` and pipes through `sudo -n tee`. Mirrors the #984/#992 efibootmgr precedent. Wired into:

- `patchProxyHostConfFile` (this PR's #999 patcher)
- `/api/system/authelia/oidc-clients` (recovers OIDC registration without the manual SSH workaround from #989's body)

## Test plan
- [x] `npm test` — 1254 tests pass.
- [x] `npm run check:arch` clean.
- [ ] On the live box: after merge, redeploy hermes + file-share → smoke goes from 33/33 (with my manual sed hack) to 33/33 with the code-driven patcher in place.
- [ ] OIDC reconciler can write configuration.yml on a fresh install without manual sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)