### PR TITLE
fix(hermes): ship sane defaults — HA token retry, noAutoGenerate gateway secrets, ServiceBay config.yaml

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.test.ts
+++ b/packages/backend/src/lib/agent/v4/agent.test.ts
@@ -50,5 +50,5 @@ describe('Python Agent V4', () => {
         expect(Array.isArray(containerMsg.payload.containers)).toBe(true);
         expect(Array.isArray(serviceMsg.payload.services)).toBe(true);
         expect(Array.isArray(volumeMsg.payload.volumes)).toBe(true);
-    }, 10000); // 10s timeout
+    }, 30000); // 30s timeout — spawning python3 + podman ps under parallel-test load can take >10s on a loaded host
 });

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -309,6 +309,14 @@ export async function assembleManifest(
     if (!value && meta?.type === 'secret') {
       if (storedValues[name]) {
         value = storedValues[name];
+      } else if (meta.noAutoGenerate) {
+        // #1002 — Some `type: secret` variables are operator-supplied
+        // externally (Telegram/Discord bot tokens, HA long-lived
+        // token, etc.). Auto-generating them as random strings
+        // creates garbage that the third-party service rejects on
+        // every reconnect attempt. Leave empty; the consumer
+        // post-deploy must handle absent values gracefully.
+        value = '';
       } else {
         value = generateRandomSecret();
         newlyGenerated.push({ name, value });

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -410,6 +410,17 @@ export interface VariableMeta {
   description?: string;
   default?: string;
   /**
+   * #1002 — For `type: secret`, opt out of the install-time random
+   * auto-generation. Use for operator-supplied externally-issued
+   * secrets (Telegram/Discord bot tokens, HA long-lived tokens) where
+   * a generated random string would be rejected by the third-party
+   * service on every reconnect, creating tight error loops in the
+   * consumer's log. The consumer post-deploy must handle an empty
+   * value gracefully (skip writing the .env entry, don't enable the
+   * gateway, etc.).
+   */
+  noAutoGenerate?: boolean;
+  /**
    * Concrete example value shown next to the input in the Configure
    * step (small grey hint text). Use for fields whose `description`
    * tells the user *what* but not what a *valid value looks like* —

--- a/templates/hermes/post-deploy.py
+++ b/templates/hermes/post-deploy.py
@@ -102,9 +102,22 @@ def write_config_yaml(data_dir: str, provider_url: str, model: str) -> str | Non
     except OSError as e:
         jlog("error", "hermes:config", "could not create config dir", path=config_dir, error=str(e))
         return None
-    # Minimal, idempotent: a single model block targeting the
-    # OpenAI-compatible endpoint. Yaml-by-hand because we don't want a
-    # PyYAML dependency in post-deploy scripts.
+    # #1002 — ServiceBay defaults table. Six overrides on top of
+    # Hermes' upstream defaults that swing the box from "developer
+    # laptop" toward "household appliance" semantics. See the
+    # discussion thread on #1002 for the why of each:
+    #   - memory.provider=holographic — local store, no external deps.
+    #     Switch to honcho when the honcho template lands (#1004).
+    #   - tts.provider=piper — local voice. Falls back to '' (silent)
+    #     when piper isn't installed yet; never the upstream `edge`
+    #     (Microsoft online) default.
+    #   - browser.engine=disabled — agents inside a container almost
+    #     never want a real browser. Skills that need it flip it on.
+    #   - model_catalog.enabled=false — don't phone the upstream
+    #     catalog endpoint every 24h. Privacy-by-default.
+    #   - network.force_ipv4=true — FritzBox + IPv6 has bitten other
+    #     services (#415). Skip AAAA records in aiohttp.
+    #   - display.personality=default — household assistant, not anime.
     content = (
         "# Written by ServiceBay's hermes template post-deploy.py.\n"
         "# Edit via the wizard's reconfigure flow or hand-edit and restart the hermes service.\n"
@@ -113,6 +126,18 @@ def write_config_yaml(data_dir: str, provider_url: str, model: str) -> str | Non
         f"  model: {model}\n"
         f"  base_url: {provider_url}\n"
         f"  api_key: \"none\"\n"
+        "memory:\n"
+        "  provider: holographic\n"
+        "tts:\n"
+        "  provider: piper\n"
+        "browser:\n"
+        "  engine: disabled\n"
+        "model_catalog:\n"
+        "  enabled: false\n"
+        "network:\n"
+        "  force_ipv4: true\n"
+        "display:\n"
+        "  personality: default\n"
     )
     try:
         with open(config_path, "w", encoding="utf-8") as f:
@@ -255,25 +280,71 @@ def write_gateway_env(data_dir: str, entries: dict[str, str]) -> bool:
     return True
 
 
+def _wait_for_ha_token(token_path: str, deadline_secs: int = 90) -> str | None:
+    """#1002 — Poll for the HA long-lived token file. HA's post-deploy
+    auto-onboards the `oscar` user and writes this file near the end of
+    its run; if hermes' post-deploy is racing it (even with
+    servicebay.dependencies: home-assistant) the file may not exist yet
+    on first check. Returns the token once present + non-empty, or None
+    if the deadline passes."""
+    deadline = time.time() + deadline_secs
+    while time.time() < deadline:
+        if os.path.exists(token_path):
+            try:
+                with open(token_path, encoding="utf-8") as f:
+                    token = f.read().strip()
+                if token:
+                    return token
+            except OSError:
+                pass
+        time.sleep(3)
+    return None
+
+
+def _wait_for_ha_api(token: str, timeout_secs: int = 60) -> bool:
+    """#1002 — Probe HA's /api/ with the new token until it answers 200.
+    Avoids the first reconnect-loop iteration where Hermes' HA gateway
+    fires before HA's listener is fully up (the "Cannot connect to host
+    127.0.0.1:8123" error in the v4.29.x install logs). Best-effort —
+    we still restart even on timeout, since Hermes will retry on its
+    own."""
+    deadline = time.time() + timeout_secs
+    last_status = 0
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                "http://127.0.0.1:8123/api/",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                last_status = resp.status
+                if 200 <= resp.status < 300:
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+            pass
+        time.sleep(3)
+    jlog("warn", "hermes:ha-ready", "HA /api/ not 200 within deadline; restart anyway", last_status=last_status, deadline_secs=timeout_secs)
+    return False
+
+
 def adopt_ha_long_lived_token(data_dir: str) -> str | None:
     """When home-assistant's post-deploy has auto-onboarded HA (#934), it
     leaves a long-lived access token at
     `<DATA_DIR>/home-assistant/homeassistant/.oscar-long-lived-token`.
-    Pick that up over the random placeholder `HASS_TOKEN` from assemble
-    and patch the deployed hermes pod yml so Hermes' native HA gateway
-    can actually authenticate. Returns the token on success, or None
-    when the file is absent (operator opted out of auto-onboarding) or
-    the patch was a no-op."""
+    Pick that up over the placeholder `HASS_TOKEN` from assemble and
+    patch the deployed hermes pod yml so Hermes' native HA gateway can
+    actually authenticate. Returns the token on success, or None when
+    the file never appears (operator opted out of auto-onboarding) or
+    the patch was a no-op.
+
+    #1002: now retries (up to 90s) for the token file and probes HA's
+    /api/ before signalling ready. The previous one-shot read missed
+    the file on every install where HA's auto-onboarding hadn't yet
+    written it, leaving HASS_TOKEN as the placeholder."""
     token_path = os.path.join(data_dir, "home-assistant", "homeassistant", ".oscar-long-lived-token")
-    if not os.path.exists(token_path):
-        return None
-    try:
-        with open(token_path, encoding="utf-8") as f:
-            token = f.read().strip()
-    except OSError as e:
-        jlog("warn", "hermes:ha-token", "could not read HA long-lived token", path=token_path, error=str(e))
-        return None
-    if not token:
+    token = _wait_for_ha_token(token_path)
+    if token is None:
+        jlog("info", "hermes:ha-token", "no HA long-lived token after retry — likely operator opted out of HA auto-onboarding", path=token_path)
         return None
     # The hermes pod yml is written by ServiceBay's install runner to the
     # user-Quadlet directory. Patch the HASS_TOKEN env value in-place so a
@@ -306,6 +377,13 @@ def adopt_ha_long_lived_token(data_dir: str) -> str | None:
         jlog("warn", "hermes:ha-token", "could not write patched hermes.yml", path=pod_yml, error=str(e))
         return None
     jlog("info", "hermes:ha-token", "adopted HA long-lived token from home-assistant post-deploy", token_path=token_path)
+
+    # #1002 — Wait for HA's /api/ to answer 200 with this token before
+    # we restart hermes. Without this gate Hermes' first HA-gateway
+    # reconnect lands during HA's startup window and gets
+    # "Cannot connect to host 127.0.0.1:8123" — operator-visible noise
+    # that has nothing to do with the actual config.
+    _wait_for_ha_api(token)
     return token
 
 

--- a/templates/hermes/post-deploy.py
+++ b/templates/hermes/post-deploy.py
@@ -280,15 +280,29 @@ def write_gateway_env(data_dir: str, entries: dict[str, str]) -> bool:
     return True
 
 
-def _wait_for_ha_token(token_path: str, deadline_secs: int = 90) -> str | None:
+# #1002 — Timeouts read lazily so the test suite can shrink them via
+# env without import-order gymnastics. Mirrors the `LLDAP_READY_TIMEOUT`
+# pattern in templates/auth/post-deploy.py.
+def _ha_token_timeout() -> int:
+    return int(os.environ.get("HA_TOKEN_TIMEOUT", "90"))
+
+
+def _ha_api_timeout() -> int:
+    return int(os.environ.get("HA_API_TIMEOUT", "60"))
+
+
+def _wait_for_ha_token(token_path: str, deadline_secs: int | None = None) -> str | None:
     """#1002 — Poll for the HA long-lived token file. HA's post-deploy
     auto-onboards the `oscar` user and writes this file near the end of
     its run; if hermes' post-deploy is racing it (even with
     servicebay.dependencies: home-assistant) the file may not exist yet
     on first check. Returns the token once present + non-empty, or None
-    if the deadline passes."""
+    if the deadline passes. A deadline of 0 means "check once, then
+    give up" — used by the test suite to avoid the polling delay."""
+    if deadline_secs is None:
+        deadline_secs = _ha_token_timeout()
     deadline = time.time() + deadline_secs
-    while time.time() < deadline:
+    while True:
         if os.path.exists(token_path):
             try:
                 with open(token_path, encoding="utf-8") as f:
@@ -297,17 +311,23 @@ def _wait_for_ha_token(token_path: str, deadline_secs: int = 90) -> str | None:
                     return token
             except OSError:
                 pass
+        if time.time() >= deadline:
+            return None
         time.sleep(3)
-    return None
 
 
-def _wait_for_ha_api(token: str, timeout_secs: int = 60) -> bool:
+def _wait_for_ha_api(token: str, timeout_secs: int | None = None) -> bool:
     """#1002 — Probe HA's /api/ with the new token until it answers 200.
     Avoids the first reconnect-loop iteration where Hermes' HA gateway
     fires before HA's listener is fully up (the "Cannot connect to host
     127.0.0.1:8123" error in the v4.29.x install logs). Best-effort —
     we still restart even on timeout, since Hermes will retry on its
-    own."""
+    own. A deadline of 0 means "skip the probe entirely" — used by the
+    test suite."""
+    if timeout_secs is None:
+        timeout_secs = _ha_api_timeout()
+    if timeout_secs <= 0:
+        return False
     deadline = time.time() + timeout_secs
     last_status = 0
     while time.time() < deadline:

--- a/templates/hermes/template.yml
+++ b/templates/hermes/template.yml
@@ -12,7 +12,11 @@ metadata:
     # default port. The wizard topo-sorts based on this annotation so
     # ollama lands first and the http://127.0.0.1:11434 target resolves
     # on first Hermes start.
-    servicebay.dependencies: "ollama"
+    # home-assistant must come up before us so the post-deploy can pick up
+    # `.oscar-long-lived-token` (#1002 fix for the timing race that left
+    # HASS_TOKEN as a placeholder). ollama is the LLM provider Hermes
+    # talks to on startup.
+    servicebay.dependencies: "ollama,home-assistant"
     # Continuous health probe (#628). The Hermes API server requires an
     # API_SERVER_KEY for every endpoint, so an unauthenticated HTTP
     # probe would always get 401. A raw TCP connect proves the listener

--- a/templates/hermes/variables.json
+++ b/templates/hermes/variables.json
@@ -44,11 +44,13 @@
   },
   "HASS_TOKEN": {
     "type": "secret",
-    "description": "Optional: Home Assistant long-lived access token. When set, turns on Hermes' native Home Assistant integration for zero-code device control."
+    "noAutoGenerate": true,
+    "description": "Optional: Home Assistant long-lived access token. Auto-populated from home-assistant's onboarding flow (see post-deploy adoption logic) — leave blank in the wizard. Manually setting a value here pins it and disables the adoption."
   },
   "TELEGRAM_BOT_TOKEN": {
     "type": "secret",
-    "description": "Optional: Telegram bot token from @BotFather. When set, Hermes' Telegram gateway starts and routes inbound chats to OSCAR. Pair with TELEGRAM_ALLOWED_USERS — without an allowlist Hermes denies every message and logs `No user allowlists configured`."
+    "noAutoGenerate": true,
+    "description": "Optional: Telegram bot token from @BotFather. When set, Hermes' Telegram gateway starts and routes inbound chats to OSCAR. Pair with TELEGRAM_ALLOWED_USERS — without an allowlist Hermes denies every message and logs `No user allowlists configured`. Leave blank if you don't use Telegram (post-deploy skips writing the .env entry; gateway stays off)."
   },
   "TELEGRAM_ALLOWED_USERS": {
     "type": "text",
@@ -57,7 +59,8 @@
   },
   "DISCORD_BOT_TOKEN": {
     "type": "secret",
-    "description": "Optional: Discord bot token from the Discord developer portal. When set, Hermes' Discord gateway starts. Pair with DISCORD_ALLOWED_CHANNELS to allowlist the channels Hermes responds in."
+    "noAutoGenerate": true,
+    "description": "Optional: Discord bot token from the Discord developer portal. When set, Hermes' Discord gateway starts. Pair with DISCORD_ALLOWED_CHANNELS to allowlist the channels Hermes responds in. Leave blank if you don't use Discord."
   },
   "DISCORD_ALLOWED_CHANNELS": {
     "type": "text",

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -733,6 +733,10 @@ class HermesScript(unittest.TestCase):
                 "HERMES_LLM_PROVIDER_URL": "http://127.0.0.1:11434/v1",
                 "HERMES_LLM_MODEL": "gemma3:4b",
                 "HERMES_DASHBOARD_PORT": "9119",
+                # #1002 — Tests have no HA token file + no HA running.
+                # Default 90s+60s waits would hang the suite.
+                "HA_TOKEN_TIMEOUT": "0",
+                "HA_API_TIMEOUT": "0",
             }
 
             fake_urlopen = fake_urlopen_factory({
@@ -816,8 +820,10 @@ class HermesScript(unittest.TestCase):
 
             token = m.adopt_ha_long_lived_token(tmp) if hasattr(m, "adopt_ha_long_lived_token") else None
             # Resolve the function via the dynamic loader and call with the
-            # patched HOME so os.path.expanduser hits our fake.
-            with mock.patch.dict(os.environ, {"HOME": str(fake_home)}, clear=False):
+            # patched HOME so os.path.expanduser hits our fake. HA_*_TIMEOUT=0
+            # skips the (real-time, not sleep-mockable) polling loops added
+            # in #1002.
+            with mock.patch.dict(os.environ, {"HOME": str(fake_home), "HA_TOKEN_TIMEOUT": "0", "HA_API_TIMEOUT": "0"}, clear=False):
                 returned = m.adopt_ha_long_lived_token(tmp)
 
             self.assertEqual(returned, "eyJ.real.long.lived.token.value")
@@ -846,7 +852,7 @@ class HermesScript(unittest.TestCase):
                 "      value: \"random-placeholder-from-assemble\"\n"
             )
             pod_yml.write_text(original)
-            with mock.patch.dict(os.environ, {"HOME": str(fake_home)}, clear=False):
+            with mock.patch.dict(os.environ, {"HOME": str(fake_home), "HA_TOKEN_TIMEOUT": "0", "HA_API_TIMEOUT": "0"}, clear=False):
                 returned = m.adopt_ha_long_lived_token(tmp)
             self.assertIsNone(returned)
             self.assertEqual(pod_yml.read_text(), original)


### PR DESCRIPTION
Closes #1002.

Three install-time gaps the live-box debugging surfaced + a follow-on fix to keep the post-deploy unittest suite snappy.

## 1. HA long-lived token race

home-assistant's post-deploy auto-onboards an `oscar` user and writes `.oscar-long-lived-token` near the END of its run. hermes' post-deploy was racing it — the one-shot file read returned None on every install where HA's onboarding hadn't yet completed, leaving HASS_TOKEN as the placeholder and burning hermes' HA gateway in an auth_invalid loop.

Fix:
- `_wait_for_ha_token` polls the token path for up to 90s.
- `_wait_for_ha_api` then probes HA's `/api/` with the new token until 200 (or 60s).
- `servicebay.dependencies` now lists `home-assistant` so the runner topo-sorts HA-before-hermes.

## 2. Optional gateway secrets were auto-generated as garbage

`TELEGRAM_BOT_TOKEN` / `DISCORD_BOT_TOKEN` are operator-supplied (Telegram/Discord-issued). Marking them `type: secret` triggered the install-time random-string generator → Telegram rejected the made-up tokens on every reconnect.

Added `noAutoGenerate: true` to `VariableMeta`. The manifest assembler now skips auto-generation for these fields; consumer post-deploys already handle empty values by not writing the .env entry. Applied to `HASS_TOKEN`, `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`.

## 3. ServiceBay defaults in config.yaml

`write_config_yaml` now lands the six overrides from the #1002 discussion table:

  memory.provider     = holographic   (local store; → honcho via #1004)
  tts.provider        = piper         (local voice; not Microsoft online)
  browser.engine      = disabled      (no browser in containers)
  model_catalog.enabled = false       (no daily upstream phone-home)
  network.force_ipv4  = true          (FritzBox + IPv6 grief — see #415)
  display.personality = default       (household, not anime)

## 4. Test suite stays fast

The new polling loops would otherwise hang the existing post-deploy unittest suite (no token file in tmpdir → 90s real-time wait). `HA_TOKEN_TIMEOUT` and `HA_API_TIMEOUT` env vars (lazy-read, default 90 / 60) let the three hermes tests set both to 0 so they complete in <30ms.

## Test plan
- [x] `python3 -m unittest tests.templates.test_post_deploy.HermesScript` — all 3 pass in 20ms.
- [x] `npm run check:arch` clean.
- [ ] On the live box after merge: redeploy hermes → `.env` no longer has fake Telegram/Discord tokens, HASS_TOKEN matches `.oscar-long-lived-token`, config.yaml has the six overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)