### PR TITLE
chore(types): clear as-any clusters in 4 backend modules + ratchet

### DIFF
--- a/packages/backend/src/lib/logger.ts
+++ b/packages/backend/src/lib/logger.ts
@@ -220,29 +220,25 @@ class Logger {
   debug(tag: string, message: string, ...args: unknown[]) {
       if (!this.shouldLog('debug')) return;
       const entry = this.format('debug', tag, message, args);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.debug(...(this.formatConsole('debug', entry) as any[]));
+      console.debug(...this.formatConsole('debug', entry));
   }
 
   info(tag: string, message: string, ...args: unknown[]) {
       if (!this.shouldLog('info')) return;
       const entry = this.format('info', tag, message, args);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.info(...(this.formatConsole('info', entry) as any[]));
+      console.info(...this.formatConsole('info', entry));
   }
 
   warn(tag: string, message: string, ...args: unknown[]) {
       if (!this.shouldLog('warn')) return;
       const entry = this.format('warn', tag, message, args);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.warn(...(this.formatConsole('warn', entry) as any[]));
+      console.warn(...this.formatConsole('warn', entry));
   }
 
   error(tag: string, message: string, ...args: unknown[]) {
       // Always log errors
       const entry = this.format('error', tag, message, args);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.error(...(this.formatConsole('error', entry) as any[]));
+      console.error(...this.formatConsole('error', entry));
   }
 
   /**
@@ -331,8 +327,19 @@ class Logger {
     }
     
     try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const rows = this.db.prepare(query).all(...params) as any[];
+        interface LogRow {
+            id: number;
+            // SQLite returns the column as either number or string depending
+            // on column affinity; LogEntry's contract is string. Cast at
+            // mapping.
+            timestamp: string;
+            level: string;
+            tag: string;
+            message: string;
+            args: string | null;
+            trace_id: string | null;
+        }
+        const rows = this.db.prepare(query).all(...params) as LogRow[];
         return rows.map(row => ({
             id: row.id,
             timestamp: row.timestamp,

--- a/packages/backend/src/lib/network/layout.ts
+++ b/packages/backend/src/lib/network/layout.ts
@@ -167,9 +167,13 @@ function calculateNodeHeight(node: Node): number | undefined {
     // Details Grid
     // We need to replicate the logic from NetworkDashboard.tsx to count rows
     let detailRows = 0;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const raw = (data.rawData as any) || {};
-    
+    // #969 — rawData / metadata carry per-node-kind discriminated shapes
+    // (container / service / router / link). Type as Record<string, unknown>;
+    // every field access narrows at the call site with a typeof / truthiness
+    // check, so we don't need (and don't have) a discriminated union here.
+    const raw = (data.rawData as Record<string, unknown> | undefined) ?? {};
+    const metadata = (data.metadata as Record<string, unknown> | undefined) ?? {};
+
     if (node.data.type === 'container') {
         // Created, Status (1 row) + Network (optional)
         detailRows = 1;
@@ -184,16 +188,15 @@ function calculateNodeHeight(node: Node): number | undefined {
     } else if (node.data.type === 'router') {
         // Ext IP, Int IP (1 row) + Uptime (1 row) + DNS (optional 1 row)
         detailRows = 2;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        if ((data.metadata as any)?.dnsServers && (data.metadata as any).dnsServers.length > 0) detailRows += 1;
+        const dnsServers = metadata.dnsServers;
+        if (Array.isArray(dnsServers) && dnsServers.length > 0) detailRows += 1;
     }
-    
+
     // Each detail row is approx 40px (label + value + gap)
     height += detailRows * 40;
 
     // Verified Domains (Nginx / Router)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const domains = (data.metadata as any)?.verifiedDomains as string[];
+    const domains = Array.isArray(metadata.verifiedDomains) ? metadata.verifiedDomains as string[] : undefined;
     if (domains && domains.length > 0) {
         height += 25; // Header "Verified Domains"
         height += domains.length * 36; // Each domain row approximation
@@ -204,8 +207,7 @@ function calculateNodeHeight(node: Node): number | undefined {
     if (data.hostname) height += 28;
 
     // Description (line-clamp-2 -> max ~36px)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((data.metadata as any)?.description && node.data.type !== 'link') height += 40;
+    if (metadata.description && node.data.type !== 'link') height += 40;
     
     // Footer (Ports)
     const ports = (data.ports as string[]) || [];
@@ -244,8 +246,8 @@ function calculateNodeWidth(node: Node): number {
     }
 
     // Verified Domains
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const domains = (data.metadata as any)?.verifiedDomains as string[];
+    const metadata = (data.metadata as Record<string, unknown> | undefined) ?? {};
+    const domains = Array.isArray(metadata.verifiedDomains) ? metadata.verifiedDomains as string[] : undefined;
     if (domains && domains.length > 0) {
         const maxDomainLen = Math.max(...domains.map(d => d.length));
         if (maxDomainLen > 40) {

--- a/packages/backend/src/lib/ssh.ts
+++ b/packages/backend/src/lib/ssh.ts
@@ -81,8 +81,12 @@ export async function setupSSHKey(host: string, port: number, user: string, pass
         logs.push(`Warning: Could not create ${homeSshDir}: ${e}`);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const env = { ...process.env } as any;
+    // Filter undefined values so the shape matches node-pty's
+    // IPtyForkOptions.env (`{ [key: string]: string }`) without an as-any.
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === 'string') env[k] = v;
+    }
 
     const proc = pty.spawn(cmd, args, {
       name: 'xterm-color',

--- a/packages/backend/src/lib/terminal/sessionManager.ts
+++ b/packages/backend/src/lib/terminal/sessionManager.ts
@@ -129,13 +129,19 @@ export class TerminalSessionManager {
     logger.info('Server', `Spawning PTY: ${spec.shell} ${spec.args.join(' ')}`);
 
     const cwd = resolveHomeDir();
+    // node-pty's IPtyForkOptions.env is `{ [key: string]: string }`. process.env
+    // is `NodeJS.ProcessEnv` (string | undefined values). Filter the
+    // `undefined`s here so the shape matches without an as-any.
+    const env: Record<string, string> = { TERM: 'xterm-256color' };
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === 'string') env[k] = v;
+    }
     const ptyProcess = pty.spawn(spec.shell, spec.args, {
       name: 'xterm-256color',
       cols,
       rows,
       cwd,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      env: { ...process.env, TERM: 'xterm-256color' } as any,
+      env,
     });
     logger.info('Server', `Spawned new PTY process for ${id} (PID: ${ptyProcess.pid})`);
 

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -128,6 +128,49 @@ async function checkSecurityAnyBudget() {
 }
 
 // ---------------------------------------------------------------------------
+// 2b. Backend-wide `as any` budget OUTSIDE the security paths.
+//
+// Forward-only ratchet (#969). Tightened from the 79 + uncounted baseline
+// after the cleanup PR landed the 5 module clusters (network/layout,
+// logger, terminal/sessionManager, ssh, plus the test/test.ts/exclusions).
+// Drop this number when each subsequent cluster lands — never raise it
+// without a justification + an issue.
+// ---------------------------------------------------------------------------
+const BACKEND_AS_ANY_BUDGET = 22;
+
+async function checkBackendAnyBudget() {
+    let count = 0;
+    const offenders: string[] = [];
+    const root = path.join(REPO_ROOT, 'packages/backend/src');
+    let files: string[];
+    try {
+        files = await walk(root, isTs);
+    } catch {
+        return;
+    }
+    for (const file of files) {
+        if (isTestFile(file)) continue;
+        const rel = path.relative(REPO_ROOT, file);
+        // Skip files counted by the security ratchet so we don't double-count.
+        if (SECURITY_PATHS.some(p => rel.startsWith(`packages/backend/${p}`) || rel === `packages/backend/${p}`)) {
+            continue;
+        }
+        const content = await readFile(file, 'utf-8');
+        const hits = content.match(/\bas any\b/g)?.length ?? 0;
+        if (hits > 0) {
+            count += hits;
+            offenders.push(`${rel} (${hits})`);
+        }
+    }
+    if (count > BACKEND_AS_ANY_BUDGET) {
+        violations.push({
+            check: 'backend-as-any-budget',
+            detail: `${count} \`as any\` in packages/backend/src (budget ${BACKEND_AS_ANY_BUDGET}). New violations need to be cleared or the budget bumped with a justification. Offenders: ${offenders.join(', ')}`,
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 3. executor.exec template-literal interpolation count.
 //
 // The safe path is `executor.execArgv([...])` via shellQuoteAll. Template
@@ -245,6 +288,7 @@ async function main() {
     await Promise.all([
         checkFileSize(),
         checkSecurityAnyBudget(),
+        checkBackendAnyBudget(),
         checkExecTemplateLiterals(),
         checkWithApiHandlerAdoption(),
         checkTwinFanIn(),


### PR DESCRIPTION
Closes #969.

Cleared all 13 as-any sites the issue called out in network/layout.ts (6), logger.ts (5), terminal/sessionManager.ts (1), ssh.ts (1).

- network/layout.ts → typed as `Record<string, unknown>` with per-field Array.isArray + typeof narrowing
- logger.ts → drop cast (formatConsole returns unknown[]; spreads into console.X cleanly); LogRow interface for the SQLite reader
- sessionManager.ts + ssh.ts → filter undefined from process.env so the shape matches node-pty's `Record<string, string>` natively

New `BACKEND_AS_ANY_BUDGET = 22` ratchet in check-invariants.ts caps the as-any count outside security paths. Forward-only — every new `as any` either gets cleared or the budget bumped with justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)