### PR TITLE
feat: portal logout + bot/refresh-cw icons + honcho memory template

### DIFF
--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -94,6 +94,7 @@ export interface SetupAsset {
 const PORTAL_ICONS = [
   'camera', 'image', 'images',          // photos / gallery
   'folder', 'folder-open', 'files',     // files / sharing
+  'refresh-cw',                         // sync (Syncthing)
   'calendar', 'calendar-days',          // calendar / contacts
   'music', 'headphones', 'book-open',   // music / audiobooks
   'lock', 'shield', 'key-round',        // passwords / vault
@@ -101,6 +102,7 @@ const PORTAL_ICONS = [
   'globe', 'router',                    // network
   'mail', 'message-square',             // mail / chat
   'video', 'film',                      // video / streaming
+  'bot',                                // AI agent (Hermes / OSCAR)
   'package',                            // generic fallback
 ] as const;
 export type PortalIconName = typeof PORTAL_ICONS[number];

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState, useSyncExternalStore } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
-  BookOpen, Calendar, CalendarDays, Camera,
+  BookOpen, Bot, Calendar, CalendarDays, Camera,
   Download, ExternalLink, Files, Film, Folder, FolderOpen, Globe,
   Headphones, House, Image as ImageIcon, Images, KeyRound, Lightbulb,
   Lightbulb as LightbulbIcon, Loader2, Lock, Mail, MessageSquare,
-  Music, Package, QrCode, Router, Shield, Smartphone, Video,
+  Music, Package, QrCode, RefreshCw, Router, Shield, Smartphone, Video,
   Sparkles, X,
 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
@@ -27,6 +27,7 @@ const PORTAL_ICON_MAP: Record<PortalIconName, IconComponent> = {
   'folder': Folder,
   'folder-open': FolderOpen,
   'files': Files,
+  'refresh-cw': RefreshCw,
   'calendar': Calendar,
   'calendar-days': CalendarDays,
   'music': Music,
@@ -43,6 +44,7 @@ const PORTAL_ICON_MAP: Record<PortalIconName, IconComponent> = {
   'message-square': MessageSquare,
   'video': Video,
   'film': Film,
+  'bot': Bot,
   'package': Package,
 };
 

--- a/packages/frontend/src/app/portal/PortalLogoutLink.tsx
+++ b/packages/frontend/src/app/portal/PortalLogoutLink.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { LogOut } from 'lucide-react';
+
+/**
+ * "Log out" link on /portal for signed-in visitors (#1001).
+ *
+ * Mirrors the sidebar logout flow from Sidebar.tsx: parse the apex
+ * from window.location.host, redirect to https://auth.<apex>/logout.
+ * Falls back to a bare /portal href when we can't derive the apex
+ * (raw IP, single-label host) — the operator can still hit
+ * auth.<domain>/logout by hand.
+ *
+ * useSyncExternalStore (with a no-op subscribe) is the pattern used
+ * elsewhere in /portal to read the window.location at render time
+ * without a setState-in-effect cascade — see useIsIOS in PortalGrid.
+ */
+const noopSubscribe = () => () => {};
+
+function derive(): string {
+  const host = window.location.host;
+  const dotIdx = host.indexOf('.');
+  if (dotIdx < 0) return '/portal';
+  return `https://auth${host.slice(dotIdx)}/logout`;
+}
+
+export default function PortalLogoutLink() {
+  const href = useSyncExternalStore(noopSubscribe, derive, () => '/portal');
+  return (
+    <div className="mt-4">
+      <a
+        href={href}
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        <LogOut size={14} />
+        Log out
+      </a>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -3,6 +3,7 @@ import ServiceBayLogo from '@/components/ServiceBayLogo';
 import { buildPortalCards } from '@/lib/portal/services';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
 import PortalGrid from './PortalGrid';
+import PortalLogoutLink from './PortalLogoutLink';
 import RequestAccessButton from './RequestAccessButton';
 
 export const revalidate = 0;
@@ -40,6 +41,7 @@ export default async function PortalPage() {
             ? `Welcome back, ${firstName} — pick a service below to get started.`
             : 'Pick a service below to get started.'}
         </p>
+        {isLoggedIn && <PortalLogoutLink />}
       </header>
 
       {cards.length === 0 ? (

--- a/templates/hermes/post-deploy.py
+++ b/templates/hermes/post-deploy.py
@@ -90,7 +90,34 @@ def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tu
         return 0, None
 
 
-def write_config_yaml(data_dir: str, provider_url: str, model: str) -> str | None:
+def _honcho_health_timeout() -> int:
+    return int(os.environ.get("HONCHO_PROBE_TIMEOUT", "5"))
+
+
+def detect_honcho(port: str) -> bool:
+    """#1004 — Probe http://127.0.0.1:<HONCHO_PORT>/health. Returns True
+    when reachable + 2xx, False otherwise. Short timeout: the honcho
+    template's own post-deploy already waited for /health, so by the
+    time hermes' post-deploy runs we either get an immediate green
+    answer or we accept that honcho isn't installed."""
+    timeout = _honcho_health_timeout()
+    if timeout <= 0 or not port:
+        return False
+    try:
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/health")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+        return False
+
+
+def write_config_yaml(
+    data_dir: str,
+    provider_url: str,
+    model: str,
+    honcho_port: str = "",
+    honcho_api_key: str = "",
+) -> str | None:
     """Write /opt/data/config.yaml's model: block. Returns the path on
     success, None if the write failed. Best-effort — a failure here
     means Hermes falls back to its default config.yaml (likely empty
@@ -106,8 +133,11 @@ def write_config_yaml(data_dir: str, provider_url: str, model: str) -> str | Non
     # Hermes' upstream defaults that swing the box from "developer
     # laptop" toward "household appliance" semantics. See the
     # discussion thread on #1002 for the why of each:
-    #   - memory.provider=holographic — local store, no external deps.
-    #     Switch to honcho when the honcho template lands (#1004).
+    #   - memory.provider — `honcho` when the honcho template is up
+    #     (#1004 detect-then-configure below); `holographic` otherwise.
+    #     Holographic is local-only with no external deps and is fine
+    #     for a single-operator install. Honcho gives per-LLDAP-user
+    #     memory isolation for multi-resident households.
     #   - tts.provider=piper — local voice. Falls back to '' (silent)
     #     when piper isn't installed yet; never the upstream `edge`
     #     (Microsoft online) default.
@@ -118,6 +148,21 @@ def write_config_yaml(data_dir: str, provider_url: str, model: str) -> str | Non
     #   - network.force_ipv4=true — FritzBox + IPv6 has bitten other
     #     services (#415). Skip AAAA records in aiohttp.
     #   - display.personality=default — household assistant, not anime.
+    honcho_ready = bool(honcho_port) and detect_honcho(honcho_port)
+    if honcho_ready:
+        jlog("info", "hermes:config", "honcho /health reachable — memory.provider=honcho", port=honcho_port)
+        memory_block = (
+            "memory:\n"
+            "  provider: honcho\n"
+            "  honcho:\n"
+            f"    api_url: http://127.0.0.1:{honcho_port}\n"
+            f"    api_key: \"{honcho_api_key}\"\n"
+        )
+    else:
+        memory_block = (
+            "memory:\n"
+            "  provider: holographic\n"
+        )
     content = (
         "# Written by ServiceBay's hermes template post-deploy.py.\n"
         "# Edit via the wizard's reconfigure flow or hand-edit and restart the hermes service.\n"
@@ -126,8 +171,7 @@ def write_config_yaml(data_dir: str, provider_url: str, model: str) -> str | Non
         f"  model: {model}\n"
         f"  base_url: {provider_url}\n"
         f"  api_key: \"none\"\n"
-        "memory:\n"
-        "  provider: holographic\n"
+        + memory_block +
         "tts:\n"
         "  provider: piper\n"
         "browser:\n"
@@ -416,9 +460,15 @@ def main() -> int:
     provider_url = env("HERMES_LLM_PROVIDER_URL", "http://127.0.0.1:11434/v1")
     model = env("HERMES_LLM_MODEL", "gemma3:4b")
     dashboard_port = env("HERMES_DASHBOARD_PORT")
+    honcho_port = env("HONCHO_PORT")
+    honcho_api_key = env("HONCHO_API_KEY")
 
-    # 1. Write config.yaml with the wizard-picked provider + model.
-    config_written = write_config_yaml(data_dir, provider_url, model) is not None
+    # 1. Write config.yaml with the wizard-picked provider + model, and
+    # the memory provider chosen by detect-then-configure (#1004).
+    config_written = write_config_yaml(
+        data_dir, provider_url, model,
+        honcho_port=honcho_port, honcho_api_key=honcho_api_key,
+    ) is not None
 
     # Pick up the real HA long-lived token if home-assistant's post-deploy
     # auto-onboarded HA. Without this Hermes' native HA gateway runs with

--- a/templates/honcho/README.md
+++ b/templates/honcho/README.md
@@ -1,0 +1,48 @@
+# Honcho — per-user memory store for Hermes / OSCAR
+
+[Honcho](https://github.com/plastic-labs/honcho) is a FastAPI service
+that exposes a *peer isolation* API on top of a Postgres + pgvector
+backend. ServiceBay deploys it alongside Hermes so each LLDAP user
+gets a private memory partition — voice + chat sessions for one
+family member never leak context into another's.
+
+## What ships in this template
+
+Two containers in a single hostNetwork pod:
+
+1. **honcho** — `ghcr.io/plastic-labs/honcho:latest`, bound to
+   `127.0.0.1:{{HONCHO_PORT}}` (default `8652`).
+2. **honcho-postgres** — `docker.io/pgvector/pgvector:pg16`, bound to
+   `127.0.0.1:{{HONCHO_POSTGRES_PORT}}` (default `5532`). Honcho is
+   the only consumer.
+
+Both are loopback-only by design. No subdomain, no NPM proxy: the
+intended consumer is Hermes' memory plugin reaching `127.0.0.1` from
+inside another hostNetwork pod on the same box.
+
+## How Hermes picks it up
+
+`templates/hermes/post-deploy.py` probes
+`http://127.0.0.1:{{HONCHO_PORT}}/health` at deploy time:
+
+- **Reachable** → writes `memory.provider: honcho` plus the
+  `honcho:` block (api_url + api_key) into `hermes/config.yaml`.
+- **Unreachable** → falls back to `memory.provider: holographic`
+  (the default, suitable for a single-resident install).
+
+Hermes already supports `memory.provider: honcho` via its own
+`plugins/memory/honcho/` module. ServiceBay's gateway/platforms
+modules inject a per-session `user_id` derived from the Authelia /
+LLDAP claims; the honcho plugin maps that to `peer_id`, so two
+family members chatting in two browser tabs (or two voice
+satellites) get independent memory.
+
+## Out of scope
+
+- **Migration from `holographic`** — first install only. The
+  operator decides whether to wipe the holographic store after
+  switching, since there's no clean per-user mapping in the
+  shared store.
+- **Admin UI for Honcho** — the upstream project doesn't ship one
+  by default. If a future Honcho release adds one, a follow-up
+  template can issue a real subdomain + NPM entry.

--- a/templates/honcho/post-deploy.py
+++ b/templates/honcho/post-deploy.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `honcho` template (#1004).
+
+Two responsibilities:
+
+  1. **Probe /health** until Honcho's FastAPI listener answers 200.
+     The kube unit's pgvector container takes a few seconds to
+     initialise the database on first boot, so polling the health
+     endpoint before declaring success is friendlier than letting
+     the operator wonder why hermes' post-deploy didn't pick it up
+     on the very next deploy.
+
+  2. **Surface HONCHO_API_KEY** as a __SB_CREDENTIAL__ marker so an
+     operator who installs Honcho outside the family stack can paste
+     the token into a custom Hermes deployment. When Honcho is part
+     of the household stack, `templates/hermes/post-deploy.py` reads
+     the same key from the wizard variables and wires it into
+     hermes/config.yaml directly — no copy-paste needed.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script
+protocol.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, default)
+    return val if val else default
+
+
+def jlog(level: str, tag: str, message: str, **args: object) -> None:
+    sys.stdout.write(
+        json.dumps(
+            {
+                "ts": datetime.datetime.now().astimezone().isoformat(),
+                "level": level,
+                "tag": tag,
+                "message": message,
+                "args": args,
+            }
+        )
+        + "\n"
+    )
+    sys.stdout.flush()
+
+
+def emit_credential(**fields: object) -> None:
+    sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
+    sys.stdout.flush()
+
+
+def _health_timeout() -> int:
+    return int(os.environ.get("HONCHO_HEALTH_TIMEOUT", "120"))
+
+
+def wait_for_honcho(port: str, deadline_secs: int | None = None) -> bool:
+    """Poll http://127.0.0.1:<port>/health until it answers 2xx. Returns
+    True when reachable, False when the deadline passes. Best-effort —
+    hermes' post-deploy re-probes the same endpoint, so a missed window
+    here is non-fatal; the only consequence is a delay before hermes
+    flips memory.provider from holographic to honcho."""
+    if deadline_secs is None:
+        deadline_secs = _health_timeout()
+    if deadline_secs <= 0:
+        return False
+    deadline = time.time() + deadline_secs
+    last_status = 0
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(f"http://127.0.0.1:{port}/health")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                last_status = resp.status
+                if 200 <= resp.status < 300:
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+            pass
+        time.sleep(3)
+    jlog("warn", "honcho:health", "/health not 200 within deadline", last_status=last_status, deadline_secs=deadline_secs)
+    return False
+
+
+def main() -> int:
+    api_port = env("HONCHO_PORT", "8652")
+    api_key = env("HONCHO_API_KEY")
+    host = env("HOST", "<server-ip>")
+
+    ready = wait_for_honcho(api_port)
+    if ready:
+        jlog("info", "honcho:health", "Honcho is reachable", port=api_port)
+    else:
+        jlog("warn", "honcho:health", "Honcho health did not come up in time — hermes will retry on its next deploy/restart", port=api_port)
+
+    if api_key:
+        emit_credential(
+            service="Honcho (Per-User Memory)",
+            url=f"http://{host}:{api_port}",
+            username="(bearer token)",
+            password=api_key,
+            importance="optional",
+            notes="Bearer token clients (Hermes' memory plugin, or your own scripts) send as `Authorization: Bearer <key>`. When the household stack deploys hermes alongside honcho, hermes' post-deploy reads this value automatically — copy-paste only needed for external clients.",
+        )
+
+    print(f"✅ Honcho is configured: port={api_port}, ready={ready}.")
+    print(f"   Hermes' memory plugin will reach Honcho at http://127.0.0.1:{api_port} on its next deploy/restart.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/honcho/template.yml
+++ b/templates/honcho/template.yml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: honcho
+  labels:
+    app: honcho
+  annotations:
+    servicebay.label: "Honcho (Per-User Memory for Hermes/OSCAR)"
+    servicebay.schema-version: "1"
+    # Service-to-service only by design (#1004). Honcho exposes a peer
+    # isolation API consumed by Hermes' memory plugin; no operator-facing
+    # UI ships in the default deployment. Bound to 127.0.0.1.
+    servicebay.ports: "{{HONCHO_PORT}}/tcp"
+    # Continuous health probe (#628). Honcho's FastAPI server answers
+    # GET /health with 200 once Postgres is reachable. The hermes
+    # template will probe the same endpoint at post-deploy time to
+    # flip its memory.provider from `holographic` to `honcho` when
+    # this template is installed.
+    servicebay.healthcheck: |
+      kind: http
+      url: http://127.0.0.1:{{HONCHO_PORT}}/health
+      interval: 30s
+      timeout: 5s
+      startup_timeout: 5m
+spec:
+  # hostNetwork so hermes (also hostNetwork) reaches Honcho at
+  # 127.0.0.1:{{HONCHO_PORT}} via the shared host netns — same pattern
+  # the ollama / hermes / oscar-household pods use.
+  hostNetwork: true
+  containers:
+  # 1. Honcho API — FastAPI service exposing /v1/peers/{user_id}/...
+  - name: honcho
+    image: ghcr.io/plastic-labs/honcho:latest
+    env:
+    - name: DATABASE_URL
+      value: "postgresql+psycopg://honcho:{{HONCHO_POSTGRES_PASSWORD}}@127.0.0.1:{{HONCHO_POSTGRES_PORT}}/honcho"
+    - name: HONCHO_API_KEY
+      value: "{{HONCHO_API_KEY}}"
+    - name: PORT
+      value: "{{HONCHO_PORT}}"
+    - name: HOST
+      value: "127.0.0.1"
+    ports:
+    - containerPort: {{HONCHO_PORT}}
+    volumeMounts:
+    - mountPath: /data
+      name: honcho-data
+
+  # 2. Postgres backing store. honcho ships a SQLAlchemy model that
+  # expects Postgres ≥ 14 with the `vector` extension; pgvector's
+  # official image bundles both. Bound to host loopback on a non-default
+  # port so it doesn't collide with operator-installed Postgres.
+  - name: honcho-postgres
+    image: docker.io/pgvector/pgvector:pg16
+    env:
+    - name: POSTGRES_USER
+      value: "honcho"
+    - name: POSTGRES_PASSWORD
+      value: "{{HONCHO_POSTGRES_PASSWORD}}"
+    - name: POSTGRES_DB
+      value: "honcho"
+    - name: PGPORT
+      value: "{{HONCHO_POSTGRES_PORT}}"
+    ports:
+    - containerPort: {{HONCHO_POSTGRES_PORT}}
+    volumeMounts:
+    - mountPath: /var/lib/postgresql/data
+      name: honcho-pgdata
+
+  volumes:
+  - name: honcho-data
+    hostPath:
+      path: {{DATA_DIR}}/honcho/data
+      type: DirectoryOrCreate
+  - name: honcho-pgdata
+    hostPath:
+      path: {{DATA_DIR}}/honcho/pgdata
+      type: DirectoryOrCreate

--- a/templates/honcho/variables.json
+++ b/templates/honcho/variables.json
@@ -1,0 +1,20 @@
+{
+  "HONCHO_PORT": {
+    "type": "text",
+    "description": "Host loopback port for Honcho's FastAPI service. Bound to 127.0.0.1 — Hermes reads from this loopback for per-LLDAP-user memory peers. Default 8642+10=8652 to leave room next to Hermes' API.",
+    "default": "8652"
+  },
+  "HONCHO_POSTGRES_PORT": {
+    "type": "text",
+    "description": "Host loopback port for Honcho's bundled Postgres (pgvector image). Bound to 127.0.0.1; Honcho is the only consumer. Default 5532 to avoid collisions with an operator-installed Postgres on the standard 5432.",
+    "default": "5532"
+  },
+  "HONCHO_API_KEY": {
+    "type": "secret",
+    "description": "Bearer token Hermes' memory plugin sends to Honcho. Auto-generated; the hermes post-deploy reads this back from the credentials manifest and writes it into hermes/config.yaml under memory.honcho.api_key. Regenerate from the wizard if it leaks."
+  },
+  "HONCHO_POSTGRES_PASSWORD": {
+    "type": "secret",
+    "description": "Auto-generated Postgres password for the Honcho database. Never reused — only the honcho + honcho-postgres containers see it via env vars in this pod."
+  }
+}


### PR DESCRIPTION
## Summary
- Closes the remainder of #1001 (portal logout + service icons for hermes / syncthing).
- Ships #1004 — adds the `honcho` template with per-LLDAP-user memory peers for Hermes / OSCAR.
- Wires hermes' post-deploy to detect-then-configure `memory.provider`: probes `127.0.0.1:HONCHO_PORT/health` and writes either the `honcho:` block or the `holographic` fallback into `config.yaml`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` clean
- [x] `npm test` — 1260 passing, 2 skipped, 0 fails
- [x] Template consistency suite (80 tests) green incl. the new honcho template
- [ ] FCoS reinstall against `core@192.168.178.100` once the release-please cut lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)