### PR TITLE
refactor(dashboards): extract pure types + helpers from Network + Services monoliths

### DIFF
--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -47,91 +47,18 @@ import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkI
 import PageHeader from '@/components/PageHeader';
 import { useToast } from '@/providers/ToastProvider';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
-
-interface GraphNodeData extends Record<string, unknown> {
-  id?: string;
-  type: string; 
-  label: string;
-  subLabel?: string;
-  node?: string; // Node name
-  hostname?: string;
-  targetHandlePosition?: Position;
-  sourceHandlePosition?: Position;
-  collapsed?: boolean;
-  onToggle?: (id: string, expanded?: boolean) => void;
-  onCreateExternalLink?: (node: GraphNodeData) => void; 
-  status?: string;
-  ip?: string;
-  parentId?: string;
-  summary?: {
-    portMap?: PortMapping[];
-    totalContainers?: number;
-    activeContainers?: number;
-    totalServices?: number;
-    activeServices?: number;
-    status?: string;
-    verifiedDomains?: string[];
-  };
-  metadata?: {
-    nodeIPs?: string[];
-    verifiedDomains?: string[];
-    externalTargetIp?: string;
-    externalTargetPort?: number;
-    description?: string;
-    link?: string;
-    stats?: {
-      externalIP?: string;
-      internalIP?: string;
-      dnsServers?: string[];
-    };
-    [key: string]: unknown;
-  };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rawData?: any;
-}
-
-interface LegacyPortMapping extends PortMapping {
-    IP?: string;
-    host?: number;
-    container?: number;
-}
-
-interface HealthData {
-    connected?: boolean;
-    externalIP?: string;
-    uptime?: number;
-    dnsServers?: string[];
-    deviceLog?: string;
-    [key: string]: unknown;
-}
-
-const deriveNodeNameFromGraph = (node?: GraphNodeData | null): string | undefined => {
-    if (!node) return undefined;
-    const raw = node.rawData as { nodeName?: string; node?: string } | undefined;
-    const candidates = [
-        typeof raw?.nodeName === 'string' ? raw.nodeName : undefined,
-        typeof raw?.node === 'string' ? raw.node : undefined,
-        typeof node.node === 'string' ? node.node : undefined,
-        typeof node.id === 'string' && node.id.includes(':') ? node.id.split(':')[0] : undefined,
-    ];
-
-    const resolved = candidates.find((value): value is string => Boolean(value && value.trim().length > 0));
-    return resolved?.trim();
-};
-
-const buildServiceEditHref = (node: GraphNodeData): string => {
-    const serviceName = typeof node.rawData?.name === 'string' ? node.rawData.name : '';
-    if (!serviceName) return '/services';
-
-    const base = `/edit/${encodeURIComponent(serviceName)}`;
-    const nodeName = deriveNodeNameFromGraph(node);
-
-    if (nodeName && nodeName.toLowerCase() !== 'local') {
-        return `${base}?node=${encodeURIComponent(nodeName)}`;
-    }
-
-    return base;
-};
+import {
+  buildServiceEditHref,
+  DEFAULT_EDGE_COLOR,
+  DOWN_EDGE_COLOR,
+  DOWN_EDGE_DASHES,
+  deriveNodeNameFromGraph,
+  labelForEdgeKind,
+  styleForEdgeKind,
+  type GraphNodeData,
+  type HealthData,
+  type LegacyPortMapping,
+} from './_lib/networkDashboard';
 
 // Custom Edge Component
 const CustomEdge = ({
@@ -723,43 +650,10 @@ const edgeTypes = {
   custom: CustomEdge,
 };
 
-const DEFAULT_EDGE_COLOR = 'rgba(148, 163, 184, 0.2)';
-const DOWN_EDGE_COLOR = '#ef4444';
-const DOWN_EDGE_DASHES = '6 3';
-
-// Edge-kind styling (#813). The backend stamps each edge with `kind`
-// (gateway | proxy | observed | declared | manual). The map must render
-// "I just saw this TCP flow" (observed, solid grey) and "the template
-// author says this exists" (declared, dashed amber) so an operator never
-// confuses the two. Down-target dashes still win — service-down is a
-// stronger signal than provenance.
-const DECLARED_EDGE_COLOR = '#64748b'; // Slate
-const DECLARED_EDGE_DASHES = '4 4';
-const OBSERVED_EDGE_COLOR = '#3b82f6'; // Clean blue
-
-function styleForEdgeKind(kind: string | undefined, base: React.CSSProperties | undefined): React.CSSProperties | undefined {
-    if (kind === 'declared') {
-        return {
-            ...(base || {}),
-            stroke: DECLARED_EDGE_COLOR,
-            strokeDasharray: DECLARED_EDGE_DASHES,
-        };
-    }
-    if (kind === 'observed') {
-        return {
-            ...(base || {}),
-            stroke: OBSERVED_EDGE_COLOR,
-        };
-    }
-    return base;
-}
-
-function labelForEdgeKind(kind: string | undefined, baseLabel: string | undefined): string | undefined {
-    if (kind === 'declared') {
-        return baseLabel ? `${baseLabel} (declared)` : 'declared';
-    }
-    return baseLabel;
-}
+// Edge-kind styling constants and helpers moved to
+// `./_lib/networkDashboard.ts` in #961's first decomposition step.
+// `styleForEdgeKind`, `labelForEdgeKind`, the edge-color tokens, and
+// the DOWN/DECLARED/OBSERVED palette all live in that module now.
 
 type LinkFormState = {
     name: string;

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -29,105 +29,20 @@ import type { EnrichedContainer } from '@servicebay/api-client';
 // SharedData Service is a complex UI object. digital twin ServiceUnit is simple.
 // WE NEED TO MAP TWIN -> UI SERVICE here.
 import { Plus, RefreshCw, Activity, Trash2, Power, Box, Search, X, AlertCircle, FileCode, ArrowRight, ShieldCheck, Terminal as TerminalIcon, Eraser, RotateCcw } from 'lucide-react';
-import { ServiceBundle, BundleValidation, BundleStackArtifacts, BundlePortSummary, BundleContainerSummary, generateBundleStackArtifacts, sanitizeBundleName } from '@servicebay/api-client';
-
-interface MigrationPlan {
-    filesToCreate: string[];
-    filesToBackup: string[];
-    servicesToStop: string[];
-    targetName: string;
-    backupDir: string;
-    backupArchive?: string;
-    stackPreview?: string;
-    validations?: BundleValidation[];
-    fileMappings?: Array<{ source: string; action: 'backup' | 'migrate'; target?: string }>;
-}
-
-type LinkFormState = {
-    name: string;
-    url: string;
-    description: string;
-    monitor: boolean;
-    ipTargetsText?: string;
-};
-
-const bundleWizardSteps: Array<{ key: 'assets' | 'stack' | 'backup'; label: string; description: string; tooltip: string }> = [
-    {
-        key: 'assets',
-        label: 'Assets',
-        description: 'Review linked services, files, and containers',
-        tooltip: 'Verify every unmanaged unit, container, and config before generating the managed stack. See the Merge Workflow guide for full context.'
-    },
-    {
-        key: 'stack',
-        label: 'Stack',
-        description: 'Validate the generated pod stack',
-        tooltip: 'Inspect the synthesized .kube unit, Pod YAML, and config references before dry-running the plan.'
-    },
-    {
-        key: 'backup',
-        label: 'Backup Plan',
-        description: 'Confirm backups and execution plan',
-        tooltip: 'Dry run podman kube play, review tar/gzip backups, and note rollback instructions prior to executing the merge.'
-    }
-];
-
-const dedupeValidations = (entries: BundleValidation[]): BundleValidation[] => {
-    const map = new Map<string, BundleValidation>();
-    entries.forEach(entry => {
-        const key = `${entry.level}-${entry.scope || 'global'}-${entry.message}`;
-        if (!map.has(key)) {
-            map.set(key, entry);
-        }
-    });
-    return Array.from(map.values());
-};
-
-const bundleSeverityClasses: Record<ServiceBundle['severity'], string> = {
-    critical: 'border-red-200 dark:border-red-800',
-    warning: 'border-amber-200 dark:border-amber-800',
-    info: 'border-gray-200 dark:border-gray-800'
-};
-
-const MERGE_HELP_ID = 'merge-wizard';
+import { ServiceBundle, BundleStackArtifacts, BundlePortSummary, BundleContainerSummary, BundleValidation, generateBundleStackArtifacts, sanitizeBundleName } from '@servicebay/api-client';
+import {
+    MERGE_HELP_ID,
+    bundleSeverityClasses,
+    bundleWizardSteps,
+    dedupeValidations,
+    type ApiLinkPayload,
+    type LinkFormState,
+    type MigrationPlan,
+    type RawLinkPort,
+    type RawLinkVolume,
+} from './_lib/servicesDashboard';
 
 const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: false });
-
-type ApiLinkPayload = {
-    id?: string;
-    name: string;
-    nodeName?: string;
-    description?: string;
-    active?: boolean;
-    status?: string;
-    activeState?: string;
-    subState?: string;
-    kubePath?: string;
-    yamlPath?: string | null;
-    type?: string;
-    ports?: RawLinkPort[];
-    volumes?: RawLinkVolume[];
-    monitor?: boolean;
-    url?: string;
-    labels?: Record<string, string>;
-    verifiedDomains?: string[];
-    ipTargets?: string[];
-};
-
-type RawLinkPort = {
-    host?: string | number;
-    hostPort?: string | number;
-    container?: string | number;
-    containerPort?: string | number;
-    hostIp?: string;
-    protocol?: string;
-    source?: string;
-};
-
-type RawLinkVolume = {
-    host?: string;
-    container?: string;
-};
 
 export default function ServicesDashboard() {
     const { data: twin, isConnected, lastUpdate, isNodeSynced } = useDigitalTwin();

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -1,0 +1,165 @@
+/**
+ * Type + helper extraction from NetworkDashboard.tsx (#961, step 2).
+ *
+ * Lifts the pure data shapes, stateless helpers, and edge-kind
+ * styling constants out of the 2,189-LOC monolith. The xyflow
+ * `CustomNode` / `CustomEdge` / `NetworkLegend` components stay in
+ * the dashboard for now — the issue explicitly warns that the
+ * canvas state needs careful split, and we don't take on
+ * render-cycle risk without per-stage validation.
+ */
+import type { CSSProperties } from 'react';
+import type { Position } from '@xyflow/react';
+import type { PortMapping } from '@servicebay/api-client';
+
+/**
+ * The node payload xyflow renders. Carries enough metadata that the
+ * `CustomNode` can decide between gateway / service / internet
+ * visuals, surface verified domains, and toggle expanded-subgraph
+ * state via `onToggle`. Open via `Record<string, unknown>` so the
+ * xyflow type machinery accepts arbitrary extra keys without a cast.
+ */
+export interface GraphNodeData extends Record<string, unknown> {
+  id?: string;
+  type: string;
+  label: string;
+  subLabel?: string;
+  /** Node name (the ServiceBay-managed host, e.g. "Local"). */
+  node?: string;
+  hostname?: string;
+  targetHandlePosition?: Position;
+  sourceHandlePosition?: Position;
+  collapsed?: boolean;
+  onToggle?: (id: string, expanded?: boolean) => void;
+  onCreateExternalLink?: (node: GraphNodeData) => void;
+  status?: string;
+  ip?: string;
+  parentId?: string;
+  summary?: {
+    portMap?: PortMapping[];
+    totalContainers?: number;
+    activeContainers?: number;
+    totalServices?: number;
+    activeServices?: number;
+    status?: string;
+    verifiedDomains?: string[];
+  };
+  metadata?: {
+    nodeIPs?: string[];
+    verifiedDomains?: string[];
+    externalTargetIp?: string;
+    externalTargetPort?: number;
+    description?: string;
+    link?: string;
+    stats?: {
+      externalIP?: string;
+      internalIP?: string;
+      dnsServers?: string[];
+    };
+    [key: string]: unknown;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rawData?: any;
+}
+
+/** Older port-mapping records that pre-date the strict shape, surfaced
+ *  by some agent versions. The dashboard tolerates either shape and
+ *  the rendering side falls back across the alternative names. */
+export interface LegacyPortMapping extends PortMapping {
+  IP?: string;
+  host?: number;
+  container?: number;
+}
+
+/** Gateway / device-level health payload the network dashboard
+ *  consumes alongside the per-node twin state. */
+export interface HealthData {
+  connected?: boolean;
+  externalIP?: string;
+  uptime?: number;
+  dnsServers?: string[];
+  deviceLog?: string;
+  [key: string]: unknown;
+}
+
+/** Derive the ServiceBay-managed node name (e.g. "Local") a graph
+ *  node belongs to. Tries the rawData payload first (canonical),
+ *  then the GraphNodeData.node hint, finally the `<node>:` prefix
+ *  on the id. Returns trimmed string or undefined. */
+export function deriveNodeNameFromGraph(node?: GraphNodeData | null): string | undefined {
+  if (!node) return undefined;
+  const raw = node.rawData as { nodeName?: string; node?: string } | undefined;
+  const candidates = [
+    typeof raw?.nodeName === 'string' ? raw.nodeName : undefined,
+    typeof raw?.node === 'string' ? raw.node : undefined,
+    typeof node.node === 'string' ? node.node : undefined,
+    typeof node.id === 'string' && node.id.includes(':') ? node.id.split(':')[0] : undefined,
+  ];
+
+  const resolved = candidates.find((value): value is string => Boolean(value && value.trim().length > 0));
+  return resolved?.trim();
+}
+
+/** Edit-page URL for a service node. Local-node services get the
+ *  bare `/edit/<name>`; remote-node services keep the explicit
+ *  `?node=<name>` qualifier so the form opens against the right
+ *  managed host. */
+export function buildServiceEditHref(node: GraphNodeData): string {
+  const serviceName = typeof node.rawData?.name === 'string' ? node.rawData.name : '';
+  if (!serviceName) return '/services';
+
+  const base = `/edit/${encodeURIComponent(serviceName)}`;
+  const nodeName = deriveNodeNameFromGraph(node);
+
+  if (nodeName && nodeName.toLowerCase() !== 'local') {
+    return `${base}?node=${encodeURIComponent(nodeName)}`;
+  }
+
+  return base;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Edge-kind styling (#813). The backend stamps each edge with `kind`
+// (gateway | proxy | observed | declared | manual). The map must
+// render "I just saw this TCP flow" (observed, solid blue) and "the
+// template author says this exists" (declared, dashed slate) so an
+// operator never confuses the two. Down-target dashes still win —
+// service-down is a stronger signal than provenance.
+// ────────────────────────────────────────────────────────────────────
+export const DEFAULT_EDGE_COLOR = 'rgba(148, 163, 184, 0.2)';
+export const DOWN_EDGE_COLOR = '#ef4444';
+export const DOWN_EDGE_DASHES = '6 3';
+
+export const DECLARED_EDGE_COLOR = '#64748b'; // Slate
+export const DECLARED_EDGE_DASHES = '4 4';
+export const OBSERVED_EDGE_COLOR = '#3b82f6'; // Clean blue
+
+export function styleForEdgeKind(
+  kind: string | undefined,
+  base: CSSProperties | undefined,
+): CSSProperties | undefined {
+  if (kind === 'declared') {
+    return {
+      ...(base || {}),
+      stroke: DECLARED_EDGE_COLOR,
+      strokeDasharray: DECLARED_EDGE_DASHES,
+    };
+  }
+  if (kind === 'observed') {
+    return {
+      ...(base || {}),
+      stroke: OBSERVED_EDGE_COLOR,
+    };
+  }
+  return base;
+}
+
+export function labelForEdgeKind(
+  kind: string | undefined,
+  baseLabel: string | undefined,
+): string | undefined {
+  if (kind === 'declared') {
+    return baseLabel ? `${baseLabel} (declared)` : 'declared';
+  }
+  return baseLabel;
+}

--- a/packages/frontend/src/dashboards/_lib/servicesDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/servicesDashboard.ts
@@ -1,0 +1,130 @@
+/**
+ * Type + helper extraction from ServicesDashboard.tsx (#961, step 1).
+ *
+ * Lifts the pure data shapes, constants, and stateless helpers out
+ * of the 2,029-LOC monolith so the dashboard component itself drops
+ * a little weight and the contract surface is reviewable in
+ * isolation. The inner `ServiceCard` / `BundleCard` React components
+ * and the form-modal state machines stay in-component for now — the
+ * issue flags the high-risk render-cycle work and we don't take that
+ * on without per-stage validation.
+ */
+import type { BundleValidation, ServiceBundle } from '@servicebay/api-client';
+
+/**
+ * Synthesized migration plan returned by `/api/system/bundles/[name]/plan` —
+ * the dry-run output the merge wizard's Stack + Backup steps render
+ * before the operator commits the merge.
+ */
+export interface MigrationPlan {
+  filesToCreate: string[];
+  filesToBackup: string[];
+  servicesToStop: string[];
+  targetName: string;
+  backupDir: string;
+  backupArchive?: string;
+  stackPreview?: string;
+  validations?: BundleValidation[];
+  fileMappings?: Array<{ source: string; action: 'backup' | 'migrate'; target?: string }>;
+}
+
+/** External-link form state shared by the create + edit flows. */
+export type LinkFormState = {
+  name: string;
+  url: string;
+  description: string;
+  monitor: boolean;
+  ipTargetsText?: string;
+};
+
+/** Steps of the bundle-merge wizard. The order is the visual progression
+ *  in the modal; the `key` is the controlled state value the
+ *  dashboard's `bundleWizardStep` toggles between. */
+export const bundleWizardSteps: Array<{
+  key: 'assets' | 'stack' | 'backup';
+  label: string;
+  description: string;
+  tooltip: string;
+}> = [
+  {
+    key: 'assets',
+    label: 'Assets',
+    description: 'Review linked services, files, and containers',
+    tooltip: 'Verify every unmanaged unit, container, and config before generating the managed stack. See the Merge Workflow guide for full context.',
+  },
+  {
+    key: 'stack',
+    label: 'Stack',
+    description: 'Validate the generated pod stack',
+    tooltip: 'Inspect the synthesized .kube unit, Pod YAML, and config references before dry-running the plan.',
+  },
+  {
+    key: 'backup',
+    label: 'Backup Plan',
+    description: 'Confirm backups and execution plan',
+    tooltip: 'Dry run podman kube play, review tar/gzip backups, and note rollback instructions prior to executing the merge.',
+  },
+];
+
+/** Collapse duplicate validation entries — the bundle API can emit the
+ *  same finding multiple times when several scopes pick it up. Stable
+ *  on first-write so the rendered order matches API order. */
+export function dedupeValidations(entries: BundleValidation[]): BundleValidation[] {
+  const map = new Map<string, BundleValidation>();
+  entries.forEach(entry => {
+    const key = `${entry.level}-${entry.scope || 'global'}-${entry.message}`;
+    if (!map.has(key)) {
+      map.set(key, entry);
+    }
+  });
+  return Array.from(map.values());
+}
+
+/** Border-color tailwind classes per bundle severity. The card body
+ *  reuses these so a row's outline matches its severity icon. */
+export const bundleSeverityClasses: Record<ServiceBundle['severity'], string> = {
+  critical: 'border-red-200 dark:border-red-800',
+  warning: 'border-amber-200 dark:border-amber-800',
+  info: 'border-gray-200 dark:border-gray-800',
+};
+
+export const MERGE_HELP_ID = 'merge-wizard';
+
+/** Raw shape the external-links API returns, before it's mapped into
+ *  the `ServiceViewModel` the dashboard renders. Tolerant on every
+ *  optional field — older entries pre-date some of the columns. */
+export type ApiLinkPayload = {
+  id?: string;
+  name: string;
+  nodeName?: string;
+  description?: string;
+  active?: boolean;
+  status?: string;
+  activeState?: string;
+  subState?: string;
+  kubePath?: string;
+  yamlPath?: string | null;
+  type?: string;
+  ports?: RawLinkPort[];
+  volumes?: RawLinkVolume[];
+  monitor?: boolean;
+  url?: string;
+  labels?: Record<string, string>;
+  verifiedDomains?: string[];
+  ipTargets?: string[];
+};
+
+export type RawLinkPort = {
+  host?: string | number;
+  hostPort?: string | number;
+  container?: string | number;
+  containerPort?: string | number;
+  hostIp?: string;
+  protocol?: string;
+  source?: string;
+};
+
+export type RawLinkVolume = {
+  host?: string;
+  container?: string;
+};


### PR DESCRIPTION
## Summary
- Partial close on #961.
- Pulls the stateless surface out of the two big dashboard files into sibling `_lib/` modules — types, pure helpers, and the edge-kind styling constants. The xyflow `CustomNode` / `CustomEdge` / `NetworkLegend` components stay in `NetworkDashboard.tsx`, and `ServiceCard` / `BundleCard` stay in `ServicesDashboard.tsx`, because the issue explicitly flags the canvas-state + render-cycle work as high risk.

## What lands
- **`dashboards/_lib/networkDashboard.ts`** (new, 165 LOC) — `GraphNodeData` / `LegacyPortMapping` / `HealthData` types, `deriveNodeNameFromGraph`, `buildServiceEditHref`, edge-color tokens (DEFAULT / DOWN / DECLARED / OBSERVED + dash patterns), `styleForEdgeKind`, `labelForEdgeKind`.
- **`dashboards/_lib/servicesDashboard.ts`** (new, 130 LOC) — `MigrationPlan`, `LinkFormState`, `ApiLinkPayload` / `RawLinkPort` / `RawLinkVolume`, `bundleWizardSteps`, `bundleSeverityClasses`, `MERGE_HELP_ID`, `dedupeValidations`.

## Sizes
- NetworkDashboard.tsx: 2189 to 2083 LOC
- ServicesDashboard.tsx: 2029 to 1942 LOC

## Follow-up scope
Next step toward the issue's ratchet target (1500 LOC) is the inner React component extraction. Both directions need a careful prop-surface design and per-stage live validation against the dashboards; tracked as the remaining open scope on #961.

## Test plan
- [x] npm run lint clean
- [x] npm run check:arch green
- [x] npm test — 1260 passing, 2 skipped
- [x] graph.test.ts (9 tests covering the data path the network dashboard renders) green
- [x] husky pre-push typecheck passes