### PR TITLE
fix(media): lowercase folder convention under file-share/data

### DIFF
--- a/templates/media/CHANGELOG.md
+++ b/templates/media/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Media (Audiobookshelf + Jellyfin) — template changelog
 
+## Pending — #1018
+
+Folder names under the file-share data root are lowercase by convention
+now (`audiobooks/`, `podcasts/`, `music/`, `movies/`, `tv/`, `photos/`)
+so they sit cleanly alongside the existing `notes/` sibling that
+hermes + the OSCAR skills already use. Variable shape is unchanged
+— only the default values flip. Existing installs keep whatever
+path the operator originally accepted; the variable is
+wizard-overridable.
+
+- `variables.json`: `ABS_AUDIOBOOKS_PATH` default
+  `/mnt/data/stacks/file-share/data/Audiobooks` → `/audiobooks`,
+  `ABS_PODCASTS_PATH` default `…/Podcasts` → `/podcasts`.
+- `post-deploy.py`: `jellyfin_add_music_library` now registers
+  `/media/music` (was `/media/Music`); the operator-hint log line
+  spells `movies/tv/photos` lowercase.
+- `README.md` updated to match.
+
+No schema-version bump — variable names are stable, only defaults
+change. Schemata, on-disk layouts, and other templates are
+unaffected.
+
 ## v4 (breaking) — #618
 
 Swapped Navidrome out for Jellyfin. Audiobookshelf is unchanged.

--- a/templates/media/README.md
+++ b/templates/media/README.md
@@ -13,11 +13,13 @@ Both containers default to reading from the **file-share** stack's shared volume
 
 | Variable | Default |
 |---|---|
-| `ABS_AUDIOBOOKS_PATH`  | `/mnt/data/stacks/file-share/data/Audiobooks` |
-| `ABS_PODCASTS_PATH`    | `/mnt/data/stacks/file-share/data/Podcasts` |
+| `ABS_AUDIOBOOKS_PATH`  | `/mnt/data/stacks/file-share/data/audiobooks` |
+| `ABS_PODCASTS_PATH`    | `/mnt/data/stacks/file-share/data/podcasts` |
 | `JELLYFIN_MEDIA_PATH`  | `/mnt/data/stacks/file-share/data` (whole tree, mounted read-only at `/media`) |
 
-Jellyfin's post-deploy auto-adds `/media/Music` as a "Music" library. Other folders (`Movies/`, `TV/`, `Photos/`) you add manually in **Dashboard → Libraries → Add Media Library** — Jellyfin's metadata sources differ per type, so we don't commit to a default.
+Folder names are lowercase by convention so they sit cleanly alongside the existing `notes/` sibling under the same data root — see #1018. Existing installs (pre-#1018) keep whatever path the operator originally accepted; the variable is wizard-overridable.
+
+Jellyfin's post-deploy auto-adds `/media/music` (lowercase, matches the file-share Samba share layout) as a "Music" library. Other folders (`movies/`, `tv/`, `photos/`) you add manually in **Dashboard → Libraries → Add Media Library** — Jellyfin's metadata sources differ per type, so we don't commit to a default.
 
 Override any of the paths in the wizard's Configure step if your media lives elsewhere.
 

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -25,9 +25,10 @@ What this does for Jellyfin:
   3. Authenticate against /Users/AuthenticateByName to get a token.
   4. POST /QuickConnect/Enable so mobile apps can pair without
      shared passwords.
-  5. Add /media/Music as a "Music" virtual folder so the library scan
-     starts immediately. Other subdirs (Movies/, TV/, Audiobooks/)
+  5. Add /media/music as a "Music" virtual folder so the library scan
+     starts immediately. Other subdirs (movies/, tv/, audiobooks/)
      stay un-imported — operator adds them by hand if wanted.
+     Lowercase folder names are the convention per #1018.
 
 Best-effort throughout: each step that fails just logs a clear
 breadcrumb so the operator can finish the setup manually in the
@@ -326,14 +327,16 @@ def jellyfin_enable_quick_connect(base_url: str, token: str) -> None:
 
 
 def jellyfin_add_music_library(base_url: str, token: str, music_path: str) -> None:
-    """Register a 'Music' collection pointing at /media/Music inside the
-    container (which is the mounted host {{JELLYFIN_MEDIA_PATH}}/Music).
+    """Register a 'Music' collection pointing at /media/music inside the
+    container (which is the mounted host {{JELLYFIN_MEDIA_PATH}}/music).
+    Lowercase by convention per #1018 so the folder sits cleanly alongside
+    `audiobooks/`, `podcasts/`, and `notes/` under the same data root.
     Idempotent: a 400 with `LibraryAlreadyExists` is treated as success."""
     # The path that Jellyfin sees — /media is the container-side mount
     # of JELLYFIN_MEDIA_PATH on the host. The wizard's MEDIA_PATH
-    # default is /mnt/data/stacks/file-share/data so /media/Music maps
-    # to /mnt/data/stacks/file-share/data/Music on the host.
-    container_path = "/media/Music"
+    # default is /mnt/data/stacks/file-share/data so /media/music maps
+    # to /mnt/data/stacks/file-share/data/music on the host.
+    container_path = "/media/music"
     qs = f"?name=Music&collectionType=music&paths={container_path}&refreshLibrary=true"
     code, body = request_json(
         "POST", f"{base_url}/Library/VirtualFolders{qs}",
@@ -348,10 +351,11 @@ def jellyfin_add_music_library(base_url: str, token: str, music_path: str) -> No
         log("ℹ️ Music library already registered — leaving as-is.")
     else:
         log(f"(note) Could not auto-add Music library (HTTP {code}). Add it manually in Dashboard → Libraries.")
-    # Operator hint: tell them how to wire Movies/TV/etc. The post-deploy
+    # Operator hint: tell them how to wire movies/tv/etc. The post-deploy
     # doesn't auto-add those — Jellyfin's metadata sources differ per
-    # library type and we don't want to commit to a default.
-    log(f"   (Add Movies/TV/Photos libraries later from Dashboard → Libraries → Add Media Library; mount points live under /media/ inside the container — same tree as {music_path} on the host.)")
+    # library type and we don't want to commit to a default. Lowercase
+    # folder names match the file-share convention (#1018).
+    log(f"   (Add movies/tv/photos libraries later from Dashboard → Libraries → Add Media Library; mount points live under /media/ inside the container — same tree as {music_path} on the host.)")
 
 
 def configure_abs_oidc(

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -20,13 +20,13 @@
   },
   "ABS_AUDIOBOOKS_PATH": {
     "type": "text",
-    "description": "Host path to your audiobook library. Defaults to the file-share Samba volume.",
-    "default": "/mnt/data/stacks/file-share/data/Audiobooks"
+    "description": "Host path to your audiobook library. Defaults to the file-share Samba volume. Folder name is lowercase by convention (matches `notes/` + `podcasts/` siblings) per #1018.",
+    "default": "/mnt/data/stacks/file-share/data/audiobooks"
   },
   "ABS_PODCASTS_PATH": {
     "type": "text",
-    "description": "Host path where Audiobookshelf will download podcast episodes.",
-    "default": "/mnt/data/stacks/file-share/data/Podcasts"
+    "description": "Host path where Audiobookshelf will download podcast episodes. Lowercase by convention — see #1018.",
+    "default": "/mnt/data/stacks/file-share/data/podcasts"
   },
   "ABS_OIDC_SECRET": {
     "type": "secret",


### PR DESCRIPTION
## Summary
- Closes #1018.
- The defaults under `templates/media/variables.json` mixed PascalCase `Audiobooks` + `Podcasts` against the lowercase `notes/` that hermes and the OSCAR skills already write to. Operators saw a mixed-case Syncthing share index without it being a deliberate choice. Per your call: lowercase wins.

## What lands
- `templates/media/variables.json` — `ABS_AUDIOBOOKS_PATH` default `…/Audiobooks` → `…/audiobooks`, `ABS_PODCASTS_PATH` default `…/Podcasts` → `…/podcasts`. Descriptions reference #1018.
- `templates/media/post-deploy.py` — `jellyfin_add_music_library` now registers `/media/music` (was `/media/Music`); operator-hint log line spells `movies/tv/photos` lowercase; header docstring matches.
- `templates/media/README.md` — table + supporting copy match the new defaults.
- `templates/media/CHANGELOG.md` — Pending entry documents the default-only change. No schema-version bump — variable names stable, only defaults flip. Existing installs keep whatever path the operator originally accepted (variable is wizard-overridable).

## What stays
- OSCAR skill prompts already use `/opt/data/notes/` lowercase (no change needed).
- `templates/hermes/template.yml` `syncthing-notes` mount already lowercase.
- Historical `v4` changelog entry keeps its original PascalCase references — those are accurate history, not current state.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` green
- [x] `npm test` — 1260 passing, 2 skipped
- [x] Template-consistency suite (80 tests) green
- [x] `python3 -m py_compile templates/media/post-deploy.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)