### PR TITLE
fix(gatekeeper): add version arg to AsrProgram/AsrModel/TtsProgram

### DIFF
--- a/templates/oscar-household/src/gatekeeper/pyproject.toml
+++ b/templates/oscar-household/src/gatekeeper/pyproject.toml
@@ -11,7 +11,13 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Michael Dopp", email = "mdopp79@gmail.com" }]
 dependencies = [
-  "wyoming>=1.5.0",
+  # wyoming>=1.6 made `version` a required positional on AsrProgram /
+  # AsrModel / TtsProgram. The previous `>=1.5.0` open pin meant fresh
+  # image builds installed 1.9.x and the missing kwarg crashed every
+  # connection (#1024). Pin to >=1.9 explicitly so the constructor
+  # contract matches the call sites in __main__.py; widen back when a
+  # 2.x release stabilises the shape.
+  "wyoming>=1.9.0,<2.0",
   "httpx>=0.27",
   "aiohttp>=3.9",
 ]

--- a/templates/oscar-household/src/gatekeeper/src/gatekeeper/__main__.py
+++ b/templates/oscar-household/src/gatekeeper/src/gatekeeper/__main__.py
@@ -12,6 +12,7 @@ from gatekeeper.logging import log
 from wyoming.info import AsrModel, AsrProgram, Attribution, Info, TtsProgram
 from wyoming.server import AsyncServer
 
+from . import __version__ as GATEKEEPER_VERSION
 from .config import settings
 from .handler import GatekeeperHandler
 from .push import serve as serve_push
@@ -23,6 +24,12 @@ def _info() -> Info:
     Phase 0 advertises the gatekeeper as a combined ASR+TTS pipeline server.
     The underlying models are configured via env vars (Whisper + Piper);
     satellite clients see one logical endpoint here.
+
+    `version` is required by wyoming>=1.6 on AsrProgram, AsrModel, and
+    TtsProgram. Before that release it was Optional and the call sites
+    here omitted it; the image now pins wyoming>=1.9 (see pyproject.toml)
+    so the omission would be a TypeError on every Wyoming connection —
+    see #1024 for the live failure mode it caused.
     """
     return Info(
         asr=[
@@ -33,6 +40,7 @@ def _info() -> Info:
                     name="OSCAR", url="https://github.com/mdopp/servicebay"
                 ),
                 installed=True,
+                version=GATEKEEPER_VERSION,
                 models=[
                     AsrModel(
                         name="oscar-gatekeeper",
@@ -41,6 +49,7 @@ def _info() -> Info:
                             name="OSCAR", url="https://github.com/mdopp/servicebay"
                         ),
                         installed=True,
+                        version=GATEKEEPER_VERSION,
                         languages=["de", "en"],
                     )
                 ],
@@ -54,6 +63,7 @@ def _info() -> Info:
                     name="OSCAR", url="https://github.com/mdopp/servicebay"
                 ),
                 installed=True,
+                version=GATEKEEPER_VERSION,
                 voices=[],
             )
         ],

--- a/templates/oscar-household/src/gatekeeper/tests/test_info.py
+++ b/templates/oscar-household/src/gatekeeper/tests/test_info.py
@@ -1,0 +1,39 @@
+"""Regression test for #1024 — gatekeeper Wyoming Info advertisement.
+
+Wyoming's `AsrProgram` / `AsrModel` / `TtsProgram` dataclasses gained a
+required `version` field between 1.5 and 1.9. The gatekeeper's
+constructor calls in `__main__._info()` omitted it for 1.5.x, which was
+backward-compatible at the time but became a TypeError on every
+satellite connection once a fresh image rebuilt against 1.9.x.
+
+This test imports + invokes `_info()` end-to-end so any future change
+to those Wyoming dataclasses (a renamed field, a new required arg) is
+caught by `pytest` before the image ships.
+"""
+
+from __future__ import annotations
+
+
+def test_info_constructs_without_error() -> None:
+    """Crashes pre-#1024 with `TypeError: AsrModel.__init__() missing 1
+    required positional argument: 'version'`."""
+    from gatekeeper.__main__ import _info
+
+    info = _info()
+    assert info.asr, "_info must advertise at least one ASR program"
+    assert info.tts, "_info must advertise at least one TTS program"
+
+
+def test_info_versions_populated() -> None:
+    """Every advertised program/model carries a non-empty `version`
+    so satellites can pin against gatekeeper releases. Catches a
+    future refactor that drops the field back to None."""
+    from gatekeeper.__main__ import _info
+
+    info = _info()
+    for program in info.asr:
+        assert program.version, f"AsrProgram {program.name} missing version"
+        for model in program.models:
+            assert model.version, f"AsrModel {model.name} missing version"
+    for program in info.tts:
+        assert program.version, f"TtsProgram {program.name} missing version"


### PR DESCRIPTION
## Summary
- Closes #1024.
- Wyoming 1.6 promoted `version` to a required positional on every Info-payload dataclass; the gatekeeper's `_info()` omitted it, and the lower-bound-only `wyoming>=1.5.0` pin let fresh image builds resolve to 1.9.x → every satellite connection died with `TypeError: AsrModel.__init__() missing 1 required positional argument: 'version'`.

## Changes
- `src/gatekeeper/__main__.py` — pass `version=GATEKEEPER_VERSION` (the package's own `__version__`) to `AsrProgram`, `AsrModel`, `TtsProgram`.
- `pyproject.toml` — tighten the wyoming pin to `>=1.9.0,<2.0` so the constructor contract is locked to a known-compatible range.
- `tests/test_info.py` — new regression test that imports + invokes `_info()` and asserts every advertised program/model carries a non-empty version. Catches the next API drift before it ships.

## Verification
Patched `__main__.py` mounted into the live `ghcr.io/mdopp/oscar-gatekeeper:latest` image (wyoming 1.9.0):
```
$ podman run --rm --entrypoint='' -e HERMES_URL=http://test:8000 \\
  -v /tmp/gatekeeper_main_fixed.py:/.../gatekeeper/__main__.py:Z \\
  ghcr.io/mdopp/oscar-gatekeeper:latest python -c \\
  'from gatekeeper.__main__ import _info; print(_info())'
ASR: oscar-gatekeeper-asr v=0.1.0 model: oscar-gatekeeper v=0.1.0
TTS: oscar-gatekeeper-tts v=0.1.0
```
No more TypeError.

## Rollout
`build-images.yml` rebuilds + pushes the gatekeeper image on merge. The next `household` stack install (or `oscar-household` re-deploy on existing boxes) pulls the fixed image. The live box still has the broken image until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)