### PR TITLE
feat(open-webui): family chat UI at chat.<domain>

### DIFF
--- a/stacks/ai/stack.yml
+++ b/stacks/ai/stack.yml
@@ -3,15 +3,18 @@ kind: Stack
 metadata:
   name: ai
   annotations:
-    servicebay.label: "AI (Ollama + Hermes)"
+    servicebay.label: "AI (Ollama + Hermes + Family chat)"
     servicebay.tier: "feature"
     servicebay.depends-on-stacks: "basic"
   selfHeal:
     ollama: env_override
     hermes: env_override
+    open-webui: env_override
 spec:
-  # Two-template stack: ollama is the LLM runtime, hermes is the
-  # ServiceBay-side chat UI. Install order is derived from each
-  # template's `servicebay.dependencies` annotation — hermes depends on
-  # ollama, so the topo-sort within this stack puts ollama first.
-  templates: [ollama, hermes]
+  # Three-template stack: ollama is the LLM runtime, hermes is the
+  # operator-flavored agent dashboard, open-webui is the family-facing
+  # chat surface at chat.<domain> (#1030). Install order is derived
+  # from each template's `servicebay.dependencies` — ollama first,
+  # then hermes + open-webui (both depend on ollama and on
+  # nginx + auth from the basic stack).
+  templates: [ollama, hermes, open-webui]

--- a/stacks/household/stack.yml
+++ b/stacks/household/stack.yml
@@ -7,5 +7,9 @@ metadata:
     servicebay.tier: "feature"
     servicebay.depends-on-stacks: "basic"
 spec:
-  # Bundled templates: Home Assistant (device control), Voice (STT/TTS puck gateway), Ollama (Local LLM), Hermes (Conversational Agent), Oscar Household (Wyoming Bridge + Speaker-ID)
-  templates: [home-assistant, voice, ollama, hermes, oscar-household]
+  # Bundled templates: Home Assistant (device control), Voice (STT/TTS
+  # puck gateway), Ollama (Local LLM), Hermes (Conversational Agent),
+  # Oscar Household (Wyoming Bridge + Speaker-ID), Open WebUI (family
+  # chat at chat.<domain>, #1030 — gives residents a web chat path
+  # that doesn't require Discord/Telegram/Signal bot tokens).
+  templates: [home-assistant, voice, ollama, hermes, oscar-household, open-webui]

--- a/templates/open-webui/README.md
+++ b/templates/open-webui/README.md
@@ -1,0 +1,70 @@
+# open-webui
+
+[Open WebUI](https://github.com/open-webui/open-webui) — the
+self-hosted, ChatGPT-style frontend that talks to Ollama (and any
+OpenAI-compatible endpoint). Closes #1030: gives every household
+resident a working "chat with the local LLM" path at
+`https://chat.<publicDomain>/` without standing up Discord, Telegram,
+or Signal gateways.
+
+## What it does
+
+1. **Runs Open WebUI's pod** behind NPM + Authelia at the operator's
+   `<OPEN_WEBUI_SUBDOMAIN>` (default `chat`). One-factor login via
+   Authelia is enough — there's no second auth wall once you're in.
+2. **Pre-wires the LLM backend** to the local Ollama on host
+   loopback (`OLLAMA_BASE_URL=http://127.0.0.1:<OLLAMA_PORT>`). The
+   model list in the chat UI mirrors whatever's in `ollama list`.
+3. **Bootstraps the admin account** on first visit — the first user
+   to create an account becomes the in-app admin. Subsequent users
+   are added from Settings → Users.
+
+## Why we ship this
+
+The household stack's first-class chat surface was the Hermes
+dashboard at `hermes.<domain>` (operator-flavored, not the URL a
+family member would guess) plus the messaging gateways (Discord /
+Telegram / Signal — each one a third-party API + bot-token chain
+that can break independently of the home server). Open WebUI sits
+purely inside the box and reuses the Authelia layer every other
+internal service already trusts, so it's the smallest possible
+"works on day one" chat path. See #1030 for the design discussion.
+
+## Variables
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `OPEN_WEBUI_PORT` | text | Host loopback port (default 8081). |
+| `OPEN_WEBUI_SECRET` | secret | WEBUI_SECRET_KEY — signs the session cookie. Auto-generated. |
+| `OPEN_WEBUI_SUBDOMAIN` | subdomain | `chat` by default. Internal exposure via NPM + Authelia forward-auth. |
+
+## Dependencies
+
+- `ollama` (LLM backend)
+- `nginx` (NPM proxy)
+- `auth` (Authelia + LLDAP)
+
+## First-run notes
+
+- On first visit at `https://chat.<publicDomain>/` Authelia challenges
+  for a 1FA login; once authenticated, Open WebUI asks for an admin
+  account name + password. The first account created is the admin.
+- `ENABLE_SIGNUP` is `false` by default, so subsequent visitors can't
+  self-register — the admin adds them from Settings → Users. Flip it
+  back on (env var on the pod) if you want self-service; the
+  Authelia layer still gates the URL either way.
+- The model list inside Open WebUI is whatever `ollama list` returns
+  at the time of the chat session start. Pulling a new model from
+  Ollama (`ollama pull <name>`) makes it available without a UI
+  restart.
+
+## Out of scope
+
+- OIDC integration with Authelia. The forward-auth layer is enough
+  for the "chat at chat.<domain>" use case; OIDC SSO would let Open
+  WebUI auto-create accounts from Authelia, but it's an extra moving
+  part we don't need on day one. Track as a follow-up if anyone
+  wants single-sign-on inside the chat app too.
+- Per-user model permissions. Operator-set today via Open WebUI's
+  Settings → Models UI; the template doesn't pre-seed any
+  per-resident policy.

--- a/templates/open-webui/post-deploy.py
+++ b/templates/open-webui/post-deploy.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+post-deploy hook for the `open-webui` template (#1030).
+
+One responsibility: print a one-liner pointing the operator at the
+admin-bootstrap URL. Open WebUI's first account is the admin; we
+can't pre-seed it (no headless admin-create API at install time),
+so the install log nudges the operator to go visit and create one.
+
+No state writes, no API calls — keep it small.
+
+See lib/registry.ts:getTemplatePostDeployScript for the script
+protocol.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    subdomain = os.environ.get("OPEN_WEBUI_SUBDOMAIN", "chat")
+    public_domain = os.environ.get("PUBLIC_DOMAIN", "")
+    lan_domain = os.environ.get("LAN_DOMAIN", "")
+    domain = public_domain or lan_domain or "<your-domain>"
+    url = f"https://{subdomain}.{domain}/"
+
+    print(f"✅ Open WebUI is live at {url}")
+    print(f"   First visit: Authelia 1FA login → Open WebUI's admin-create form.")
+    print(f"   The first account you create becomes the in-app admin; add family members from Settings → Users.")
+    print(f"   Backend Ollama: http://127.0.0.1:{os.environ.get('OLLAMA_PORT', '11434')} (auto-discovered).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/open-webui/template.yml
+++ b/templates/open-webui/template.yml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: open-webui
+  labels:
+    app: open-webui
+  annotations:
+    servicebay.label: "Open WebUI (Family Chat)"
+    servicebay.schema-version: "1"
+    servicebay.ports: "{{OPEN_WEBUI_PORT}}/tcp"
+    # ollama must be reachable on host loopback for the default
+    # backend wiring (OLLAMA_BASE_URL). Open WebUI starts without it
+    # but the chat list is empty until Ollama responds, which the
+    # operator will read as "broken". Topo-sort the deploy.
+    servicebay.dependencies: "ollama,nginx,auth"
+    servicebay.healthcheck: |
+      url: http://127.0.0.1:{{OPEN_WEBUI_PORT}}/health
+      interval: 30s
+      timeout: 5s
+      startup_timeout: 5m
+spec:
+  # hostNetwork so the bare 127.0.0.1:OLLAMA_PORT call works out of the
+  # box — same pattern hermes uses to reach ollama. NPM proxies the
+  # public-side chat.<domain> down to OPEN_WEBUI_PORT on the host
+  # loopback behind Authelia forward-auth.
+  hostNetwork: true
+  containers:
+  - name: open-webui
+    image: ghcr.io/open-webui/open-webui:main
+    env:
+    # Talk to the local Ollama on host loopback (two hostNetwork pods
+    # share the netns, so 127.0.0.1 resolves to the same host).
+    - name: OLLAMA_BASE_URL
+      value: "http://127.0.0.1:{{OLLAMA_PORT}}"
+    # Bind only to the loopback that NPM proxies. Direct LAN hits to
+    # this port would bypass Authelia, which we explicitly don't want
+    # — chat history surfaces every conversation, treat it like the
+    # Hermes dashboard.
+    - name: HOST
+      value: "127.0.0.1"
+    - name: PORT
+      value: "{{OPEN_WEBUI_PORT}}"
+    # Signed JWT secret for the in-app session cookie. Auto-generated
+    # by the wizard so a teardown + reinstall doesn't reuse a
+    # cracked / leaked value. Operators rarely need to know this.
+    - name: WEBUI_SECRET_KEY
+      value: "{{OPEN_WEBUI_SECRET}}"
+    # Disable signup by default (gives the operator a one-time
+    # admin-bootstrap window via the in-app UI). Family members get
+    # added by the admin from Settings → Users. Flipping this back
+    # on is a deliberate operator decision — Authelia already gates
+    # the URL, so it's safe to re-enable for self-service, but the
+    # default off matches the rest of ServiceBay's "operator
+    # provisions members" model.
+    - name: ENABLE_SIGNUP
+      value: "false"
+    # Telemetry opt-out, matching the rest of the household stack's
+    # privacy-first posture.
+    - name: SCARF_NO_ANALYTICS
+      value: "true"
+    - name: DO_NOT_TRACK
+      value: "true"
+    - name: ANONYMIZED_TELEMETRY
+      value: "false"
+    ports:
+    - containerPort: {{OPEN_WEBUI_PORT}}
+    volumeMounts:
+    - mountPath: /app/backend/data
+      name: open-webui-data
+  volumes:
+  - name: open-webui-data
+    hostPath:
+      path: {{DATA_DIR}}/open-webui
+      type: DirectoryOrCreate

--- a/templates/open-webui/user-guide.md
+++ b/templates/open-webui/user-guide.md
@@ -1,0 +1,52 @@
+---
+lucide_icon: "bot"
+tagline: "Chat with your home server's local LLM — same look as ChatGPT, but the conversations never leave your house."
+recommended_apps:
+  - name: "Open WebUI — installable web app"
+    url: "https://docs.openwebui.com/getting-started/quick-start/"
+    platforms: [browser, ios, android, desktop]
+    note: "Add to home screen on iOS / Android (PWA) for a native-feeling app icon. No download required."
+---
+
+# Family chat
+
+Talk to the home server's AI from any device in the house. Same
+familiar chat interface as ChatGPT or Claude — except the
+conversation goes through your own server, the model runs on your
+own GPU, and nothing leaves the network unless you explicitly ask
+for it.
+
+## First time
+
+1. Open `https://chat.<your-domain>/` on any phone or laptop on the
+   home network.
+2. Log in with your family-server account (the same one you use for
+   Photos, Files, etc).
+3. Pick a model from the dropdown — the default Gemma 4 (26B) is a
+   good all-rounder and runs entirely on the household GPU.
+4. Start chatting.
+
+## What's good for what
+
+- **Quick questions, drafts, summaries**: `gemma4:26b` or whatever
+  the household admin picked as the default.
+- **Long stories, coding help**: ask the admin to pull a bigger or
+  more specialised model; it'll show up in your dropdown.
+- **Sensitive notes** (health, family planning, finances): this is
+  *the* path designed for those — the chat never leaves the box.
+
+## What it can't do
+
+- It doesn't know things that happened after the model's training
+  cut-off.
+- It doesn't browse the web by default. Ask the admin to enable the
+  web-search add-on if you want that.
+- It can't see attachments unless the admin set up a vision-capable
+  model. The dropdown will tell you which.
+
+## Privacy
+
+Conversations are stored on the home server only. The household
+admin can read them if they specifically need to (e.g. troubleshooting
+a stuck response). There's no analytics, no telemetry, no third
+party in the loop.

--- a/templates/open-webui/variables.json
+++ b/templates/open-webui/variables.json
@@ -1,0 +1,25 @@
+{
+  "OPEN_WEBUI_PORT": {
+    "type": "text",
+    "description": "Host loopback port for Open WebUI's HTTP server. Bound to 127.0.0.1; NPM + Authelia forward-auth proxy the public side at https://<OPEN_WEBUI_SUBDOMAIN>.<domain>. Default 8081 to leave 8080 free for other services that grab the convention.",
+    "default": "8081"
+  },
+  "OPEN_WEBUI_SECRET": {
+    "type": "secret",
+    "description": "WEBUI_SECRET_KEY — signs the in-app session cookie. Auto-generated; rotating it logs every active user out, so the wizard handles it transparently and the operator shouldn't need to touch it."
+  },
+  "OPEN_WEBUI_SUBDOMAIN": {
+    "type": "subdomain",
+    "description": "Subdomain for the family chat UI. Internal exposure — NPM binds the LAN-only access list, Authelia forward-auth gates entry, real LE cert. `chat` is the convention family members will guess (see #1030).",
+    "default": "chat",
+    "exposure": "internal",
+    "proxyPort": "OPEN_WEBUI_PORT",
+    "loopbackOnly": true,
+    "proxyConfig": {
+      "allow_websocket_upgrade": true,
+      "block_exploits": true,
+      "ssl_forced": true,
+      "advanced_config": "__authelia_forward_auth__"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #1030.
- Ships `templates/open-webui` — Open WebUI slotted in next to ollama + hermes on the AI / household stacks. Family residents get ChatGPT-style chat at `https://chat.<publicDomain>/` gated by Authelia forward-auth. No Discord / Telegram / Signal bot tokens required.

## What lands
- `templates/open-webui/template.yml` — hostNetwork pod, 127.0.0.1:OPEN_WEBUI_PORT, OLLAMA_BASE_URL pre-wired to the local ollama, `ENABLE_SIGNUP=false` so operator bootstraps the admin. Telemetry off across all upstream toggles.
- `templates/open-webui/variables.json` — `OPEN_WEBUI_PORT` (default 8081), `OPEN_WEBUI_SECRET` (auto-gen WEBUI_SECRET_KEY), `OPEN_WEBUI_SUBDOMAIN` (default `chat`, internal exposure, `__authelia_forward_auth__` sentinel + `loopbackOnly`).
- `templates/open-webui/post-deploy.py` — one-shot operator hint at the URL + "first account becomes admin" reminder.
- `templates/open-webui/README.md` — operator-facing contract.
- `templates/open-webui/user-guide.md` — family-portal card with `lucide_icon: bot`.

## Stack changes
- `stacks/ai/stack.yml` templates: `[ollama, hermes]` → `[ollama, hermes, open-webui]`.
- `stacks/household/stack.yml` appends `open-webui` so OSCAR installs the chat surface end-to-end.

## Dependencies declared
`ollama, nginx, auth` — topo-sorts after the LLM runtime and the proxy/SSO layer.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` green
- [x] `npm test` — 1264 passing (was 1260; +4 from the new template), 2 skipped
- [x] Template-consistency suite picks the new template up + validates it (84 tests, was 80)

## Follow-up (not in this PR)
- OIDC integration with Authelia (skip account-create form for residents). The forward-auth layer is enough for "chat at chat.<domain>" on day one; OIDC SSO is polish.
- Per-user model permissions are operator-set inside Open WebUI today; template doesn't pre-seed any policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)