### PR TITLE
fix(open-webui): route chat through Hermes (not direct to Ollama)

### DIFF
--- a/templates/open-webui/CHANGELOG.md
+++ b/templates/open-webui/CHANGELOG.md
@@ -1,0 +1,46 @@
+# open-webui — template changelog
+
+## v2 (breaking) — #1030 follow-up
+
+Routes Open WebUI through Hermes' OpenAI-compatible API instead of
+talking directly to Ollama. The v1 wiring sent chats straight at
+`OLLAMA_BASE_URL=http://127.0.0.1:OLLAMA_PORT` — that gave the
+family a working chat surface, but every request bypassed Hermes'
+agent loop, so:
+
+- No `cloud_audit` rows for any chat (#921 audit logging was inert
+  for this path).
+- No holographic / honcho memory (intent #2 + #4 of #926
+  unrealized for the chat surface).
+- No OSCAR skill set available to the chat.
+
+### What changed
+
+- `template.yml`:
+  - `OPENAI_API_BASE_URL=http://127.0.0.1:{{HERMES_API_PORT}}/v1`
+    and `OPENAI_API_KEY={{HERMES_API_KEY}}` — Open WebUI now treats
+    Hermes as a standard OpenAI-compatible backend.
+  - `OLLAMA_BASE_URL=""` + `ENABLE_OLLAMA_API=false` — direct
+    Ollama integration disabled so a stray Ollama tile in the
+    settings UI can't re-create the bypass.
+  - `servicebay.dependencies` adds `hermes` (was just
+    `ollama,nginx,auth`).
+- `README.md` updated to match.
+
+### Required action for existing installs
+
+None on disk — data (sessions, sessions, prompt presets) lives in
+`/app/backend/data` (= `{{DATA_DIR}}/open-webui` on the host) and
+is unaffected.
+
+Re-deploying the template via the wizard's Configure → Save flow
+re-renders `template.yml` with the new env, restarts the pod, and
+the chat surface comes back routed through Hermes. Pre-existing
+chat history stays visible; new turns flow through Hermes from
+that point on.
+
+## v1 — #1030
+
+Initial release. Open WebUI behind NPM + Authelia at
+`chat.<publicDomain>`, talking directly to Ollama. Replaced in
+v2 by the Hermes-routed wiring above.

--- a/templates/open-webui/README.md
+++ b/templates/open-webui/README.md
@@ -12,12 +12,21 @@ or Signal gateways.
 1. **Runs Open WebUI's pod** behind NPM + Authelia at the operator's
    `<OPEN_WEBUI_SUBDOMAIN>` (default `chat`). One-factor login via
    Authelia is enough — there's no second auth wall once you're in.
-2. **Pre-wires the LLM backend** to the local Ollama on host
-   loopback (`OLLAMA_BASE_URL=http://127.0.0.1:<OLLAMA_PORT>`). The
-   model list in the chat UI mirrors whatever's in `ollama list`.
+2. **Routes through Hermes** via the OpenAI-compatible API:
+   `OPENAI_API_BASE_URL=http://127.0.0.1:<HERMES_API_PORT>/v1` with
+   the auto-generated `HERMES_API_KEY` as the bearer token. Every
+   chat goes through Hermes' agent loop — tool calls, holographic /
+   honcho memory, `cloud_audit` logging (#921), the OSCAR skill
+   set. Hermes in turn talks to the local Ollama; the underlying
+   model is whatever Hermes' `config.yaml` has set.
 3. **Bootstraps the admin account** on first visit — the first user
    to create an account becomes the in-app admin. Subsequent users
    are added from Settings → Users.
+
+The direct-to-Ollama Open WebUI integration is explicitly disabled
+(`ENABLE_OLLAMA_API=false`, `OLLAMA_BASE_URL=""`) so the chat
+surface can't accidentally bypass Hermes — that bypass would skip
+the audit log, the memory layer, and any OSCAR-authored skill.
 
 ## Why we ship this
 
@@ -40,7 +49,8 @@ internal service already trusts, so it's the smallest possible
 
 ## Dependencies
 
-- `ollama` (LLM backend)
+- `hermes` (agent loop; the actual backend Open WebUI talks to)
+- `ollama` (Hermes uses it underneath; included for topo-sort sanity)
 - `nginx` (NPM proxy)
 - `auth` (Authelia + LLDAP)
 
@@ -53,10 +63,11 @@ internal service already trusts, so it's the smallest possible
   self-register — the admin adds them from Settings → Users. Flip it
   back on (env var on the pod) if you want self-service; the
   Authelia layer still gates the URL either way.
-- The model list inside Open WebUI is whatever `ollama list` returns
-  at the time of the chat session start. Pulling a new model from
-  Ollama (`ollama pull <name>`) makes it available without a UI
-  restart.
+- The model dropdown inside Open WebUI surfaces whatever Hermes'
+  `/v1/models` returns — today that's a single `hermes-agent` entry.
+  Hermes' `config.yaml` controls the underlying ollama model; change
+  it via `hermes config set model.model <ollama-tag>` and restart
+  Hermes. The Open WebUI side doesn't need a restart.
 
 ## Out of scope
 

--- a/templates/open-webui/template.yml
+++ b/templates/open-webui/template.yml
@@ -6,13 +6,16 @@ metadata:
     app: open-webui
   annotations:
     servicebay.label: "Open WebUI (Family Chat)"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     servicebay.ports: "{{OPEN_WEBUI_PORT}}/tcp"
-    # ollama must be reachable on host loopback for the default
-    # backend wiring (OLLAMA_BASE_URL). Open WebUI starts without it
-    # but the chat list is empty until Ollama responds, which the
-    # operator will read as "broken". Topo-sort the deploy.
-    servicebay.dependencies: "ollama,nginx,auth"
+    # Open WebUI routes through Hermes' OpenAI-compatible API so every
+    # chat goes through Hermes' agent loop — tool calls, holographic/
+    # honcho memory, cloud_audit logging (#921), the OSCAR skill set.
+    # Hermes in turn talks to the local Ollama. Bypassing Hermes (an
+    # earlier draft pointed OLLAMA_BASE_URL straight at ollama) gave
+    # operators a raw-LLM chat surface that didn't satisfy #926's
+    # sovereignty / memory / privacy intents.
+    servicebay.dependencies: "ollama,hermes,nginx,auth"
     servicebay.healthcheck: |
       url: http://127.0.0.1:{{OPEN_WEBUI_PORT}}/health
       interval: 30s
@@ -28,10 +31,23 @@ spec:
   - name: open-webui
     image: ghcr.io/open-webui/open-webui:main
     env:
-    # Talk to the local Ollama on host loopback (two hostNetwork pods
-    # share the netns, so 127.0.0.1 resolves to the same host).
+    # Route through Hermes' OpenAI-compatible /v1 surface (NOT
+    # straight at ollama) so every chat passes through the agent
+    # loop — see the dependencies comment above. The model dropdown
+    # in the UI surfaces what Hermes' /v1/models returns; today that's
+    # the single `hermes-agent` entry, and Hermes' config.yaml decides
+    # which underlying ollama model handles each turn.
+    - name: OPENAI_API_BASE_URL
+      value: "http://127.0.0.1:{{HERMES_API_PORT}}/v1"
+    - name: OPENAI_API_KEY
+      value: "{{HERMES_API_KEY}}"
+    # Disable Open WebUI's direct-to-Ollama integration; we want the
+    # Hermes path to be the only one. Setting OLLAMA_BASE_URL to an
+    # empty string makes upstream skip the Ollama backend entirely.
     - name: OLLAMA_BASE_URL
-      value: "http://127.0.0.1:{{OLLAMA_PORT}}"
+      value: ""
+    - name: ENABLE_OLLAMA_API
+      value: "false"
     # Bind only to the loopback that NPM proxies. Direct LAN hits to
     # this port would bypass Authelia, which we explicitly don't want
     # — chat history surfaces every conversation, treat it like the


### PR DESCRIPTION
## Summary
The v1 wiring (#1031) pointed `OLLAMA_BASE_URL` straight at Ollama, which made every chat **bypass Hermes**. That defeats #926's audit / memory / OSCAR-skill intents for the chat entry point. Fixing it.

## Why this is a real bug, not just a polish
A family member opening `chat.dopp.cloud` with the v1 wiring would hit:
- ❌ No `cloud_audit` rows — #921 audit logging was inert for this path.
- ❌ No `memory.provider: holographic` / `honcho` peer routing — intents #2 + #4 of #926 unrealized.
- ❌ No OSCAR skill set (dynamic-skills, qmd, etc.) — the chat is raw LLM, the household agent is invisible.

## What changes
- `OPENAI_API_BASE_URL=http://127.0.0.1:{{HERMES_API_PORT}}/v1`
- `OPENAI_API_KEY={{HERMES_API_KEY}}` (cross-template var pickup the wizard's assemble step already handles)
- `OLLAMA_BASE_URL=""` + `ENABLE_OLLAMA_API=false` — explicitly disable the direct path so a future settings-UI tweak can't re-create the bypass.
- `servicebay.dependencies`: `ollama,nginx,auth` → `ollama,hermes,nginx,auth`.
- Schema-version bump `1 → 2`. New `CHANGELOG.md` entry documents the bump + the "no on-disk migration needed" caveat (Open WebUI's persistent data in `/app/backend/data` is unaffected).
- README updated to match the new architecture.

## Hermes already supports this
Verified live tonight: `GET /v1/models` returns `{"id":"hermes-agent",...}` and `POST /v1/chat/completions` works with the bearer token. Open WebUI's OpenAI-compatible backend mode picks both up cleanly.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` green
- [x] Template-consistency suite (84 tests) green
- [ ] FCoS validation: redeploy open-webui via the wizard once v4.33.x lands on the box, confirm chat goes through Hermes (audit row appears + tool-use works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)