### PR TITLE
fix(agent): remove function-local subprocess re-import shadowing module-level

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -2091,7 +2091,19 @@ class Agent:
                             # content doesn't appear on the command line
                             # (no length limit, no quoting hazards, no
                             # leak via `ps`).
-                            import subprocess
+                            # NOTE: do NOT re-`import subprocess` here.
+                            # The module-level `import subprocess` at the
+                            # top of the file is already in scope; a
+                            # function-local `import subprocess` would
+                            # make Python treat `subprocess` as a local
+                            # name throughout `handle_command`, which
+                            # then UnboundLocalErrors the earlier
+                            # `subprocess.Popen` call in the exec_stream
+                            # branch. That broke every post-deploy that
+                            # used exec_stream — observed live on
+                            # 192.168.178.100 today, every Open WebUI
+                            # install attempt died with "cannot access
+                            # local variable 'subprocess'".
                             # Ensure the parent dir exists (also via sudo
                             # so we don't EACCES on `mkdir`).
                             parent = os.path.dirname(expanded_path)

--- a/packages/backend/src/lib/agent/v4/agent.test.ts
+++ b/packages/backend/src/lib/agent/v4/agent.test.ts
@@ -51,4 +51,33 @@ describe('Python Agent V4', () => {
         expect(Array.isArray(serviceMsg.payload.services)).toBe(true);
         expect(Array.isArray(volumeMsg.payload.volumes)).toBe(true);
     }, 30000); // 30s timeout — spawning python3 + podman ps under parallel-test load can take >10s on a loaded host
+
+    it('handle_command must not shadow the module-level subprocess import', async () => {
+        // Regression for the bug observed live on 192.168.178.100 today:
+        // a function-local `import subprocess` inside handle_command made
+        // Python treat `subprocess` as a local name throughout the
+        // function, so the earlier `subprocess.Popen` in the exec_stream
+        // branch UnboundLocalError'd on every post-deploy that used
+        // exec_stream. Every install of open-webui died with "cannot
+        // access local variable 'subprocess'".
+        //
+        // The only legitimate import is the module-level one at the top
+        // of agent.py. Any other `import subprocess` line anywhere in
+        // the file is a regression that breaks post-deploy.
+        const fs = await import('node:fs/promises');
+        const content = await fs.readFile(agentScript, 'utf-8');
+        const lines = content.split('\n');
+        const importLines: Array<{ lineNum: number; line: string }> = [];
+        lines.forEach((line, idx) => {
+            // Match `import subprocess` or `from subprocess import ...`,
+            // tolerate any leading whitespace (would catch function-scope
+            // re-imports) — but the module-level one starts at column 0.
+            if (/^\s*(import\s+subprocess|from\s+subprocess\s+import)\b/.test(line)) {
+                importLines.push({ lineNum: idx + 1, line: line.trim() });
+            }
+        });
+        // Exactly one import expected, and it must be unindented (module-level).
+        expect(importLines.length, `Found ${importLines.length} subprocess imports — only the module-level one at line 4 should exist. Extras: ${JSON.stringify(importLines)}`).toBe(1);
+        expect(/^import subprocess/.test(importLines[0].line), `subprocess import must be at module-level (no leading whitespace). Got: ${JSON.stringify(importLines[0])}`).toBe(true);
+    });
 });


### PR DESCRIPTION
## Symptom

Every post-deploy that used `exec_stream` died with:

\`\`\`
cannot access local variable 'subprocess' where it is not associated with a value
\`\`\`

Observed live on 192.168.178.100 today trying to install open-webui. The template's post-deploy.py is one `print()` call; the failure was 100% in the agent's `exec_stream` handler.

## Root cause

`handle_command` had a stray `import subprocess` inside the sudo branch of `write_file` (introduced for #1000's container-UID-owned file writes — line 2094). Python's local-variable rule: any assignment to a name in a function scope, **including `import`**, makes that name local for the *entire function*. The earlier `exec_stream` branch (line ~2025) then called `subprocess.Popen`, which Python now sees as a reference to the (not-yet-assigned) local `subprocess`, and raises `UnboundLocalError`.

The bug only manifests when both branches are reachable in a single `handle_command` invocation — which is exactly the case for every post-deploy. `exec_stream` runs first, hits the shadowed name, crashes before reaching the local import.

## Fix

Drop the redundant `import subprocess` at line 2094. The module-level import at line 4 has been in scope all along. Comment block at the deletion site documents *why* you must not re-add it.

## Regression test

`agent.test.ts` grows a new check that asserts there's exactly one `import subprocess` line in `agent.py` and it lives at column 0 (module level). Any future function-scope re-import is caught at CI time.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` green
- [x] `npm test` — 1265 passing (was 1264; +1 for the new regression test), 2 skipped
- [ ] FCoS validation: re-trigger the open-webui install on the box once v4.33.x lands with this patch — should reach `✅ Open WebUI is live at ...` instead of dying at exec_stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)