### PR TITLE
fix(open-webui+portal): ENABLE_SIGNUP=true + CTA above the service grid

### DIFF
--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -26,6 +26,14 @@ export const dynamic = 'force-dynamic';
  *       resolved → "Welcome! Set your password" card
  *       (otherwise) → default Request-access button
  *   - signed in → no request CTA at all, just the user chip + logout
+ *
+ * The CTA + status panel sits between the welcome header and the
+ * service grid. Anonymous visitors land on it first (the whole point
+ * of the page for them is "how do I get access?"), and signed-in
+ * visitors don't see it at all so the grid stays the focal point.
+ * Pre-#1037 the CTA was after the grid; that pushed the
+ * Request-access button below the fold on any portal with more than
+ * a handful of cards.
  */
 export default async function PortalPage() {
   const hdrs = await headers();
@@ -55,6 +63,12 @@ export default async function PortalPage() {
         {isLoggedIn && <PortalLogoutLink />}
       </header>
 
+      {!isLoggedIn && (
+        <div className="mb-10">
+          <AccessRequestStatusCTA fallback={<RequestAccessButton />} />
+        </div>
+      )}
+
       {cards.length === 0 ? (
         <div className="text-center text-gray-500 dark:text-gray-400 py-16">
           <p className="text-lg">No services available yet.</p>
@@ -64,10 +78,6 @@ export default async function PortalPage() {
         </div>
       ) : (
         <PortalGrid cards={cards} />
-      )}
-
-      {!isLoggedIn && (
-        <AccessRequestStatusCTA fallback={<RequestAccessButton />} />
       )}
     </main>
   );

--- a/templates/open-webui/README.md
+++ b/templates/open-webui/README.md
@@ -59,10 +59,11 @@ internal service already trusts, so it's the smallest possible
 - On first visit at `https://chat.<publicDomain>/` Authelia challenges
   for a 1FA login; once authenticated, Open WebUI asks for an admin
   account name + password. The first account created is the admin.
-- `ENABLE_SIGNUP` is `false` by default, so subsequent visitors can't
-  self-register — the admin adds them from Settings → Users. Flip it
-  back on (env var on the pod) if you want self-service; the
-  Authelia layer still gates the URL either way.
+- `ENABLE_SIGNUP` ships **on** because Open WebUI's first-account
+  bootstrap requires it — there's no headless admin-create API.
+  After your admin lands, flip "Enable New Sign Ups" off via the
+  in-app Settings → Users panel if you want the operator-provisions-
+  members policy. The Authelia layer gates the URL regardless.
 - The model dropdown inside Open WebUI surfaces whatever Hermes'
   `/v1/models` returns — today that's a single `hermes-agent` entry.
   Hermes' `config.yaml` controls the underlying ollama model; change

--- a/templates/open-webui/template.yml
+++ b/templates/open-webui/template.yml
@@ -61,15 +61,19 @@ spec:
     # cracked / leaked value. Operators rarely need to know this.
     - name: WEBUI_SECRET_KEY
       value: "{{OPEN_WEBUI_SECRET}}"
-    # Disable signup by default (gives the operator a one-time
-    # admin-bootstrap window via the in-app UI). Family members get
-    # added by the admin from Settings → Users. Flipping this back
-    # on is a deliberate operator decision — Authelia already gates
-    # the URL, so it's safe to re-enable for self-service, but the
-    # default off matches the rest of ServiceBay's "operator
-    # provisions members" model.
+    # Open WebUI's first-account-becomes-admin bootstrap requires
+    # ENABLE_SIGNUP=true at the moment that first signup happens —
+    # there's no headless admin-create API. Setting this to false
+    # before any account exists locks even the operator out of the
+    # initial admin-create form ("You do not have permission to access
+    # this resource" — observed live on 192.168.178.100). Leaving it
+    # true is safe in our threat model because Authelia 1FA gates the
+    # URL: a stranger can't reach the signup form without an LLDAP
+    # account in the first place. After the admin lands, they flip
+    # "Enable New Sign Ups" off via Settings → Users for the
+    # operator-provisions-members policy.
     - name: ENABLE_SIGNUP
-      value: "false"
+      value: "true"
     # Telemetry opt-out, matching the rest of the household stack's
     # privacy-first posture.
     - name: SCARF_NO_ANALYTICS


### PR DESCRIPTION
Two visible UX fixes from tonight's live deploy on 192.168.178.100.

## 1. Open WebUI admin bootstrap was locked

Open WebUI has no headless admin-create API; the first account that signs up is the admin. Shipping `ENABLE_SIGNUP=false` in v4.33.x meant the operator's first visit at `chat.dopp.cloud` got "You do not have permission to access this resource. Please contact your administrator for assistance." — even though the operator IS the administrator.

Fix: ship `ENABLE_SIGNUP=true`. Safe in our threat model because Authelia 1FA gates the URL — strangers can't reach the signup form without an LLDAP account. After the admin lands, they flip "Enable New Sign Ups" off via the in-app **Settings → Users** panel.

## 2. /portal Request-access CTA was below the fold

Pre-fix, the `AccessRequestStatusCTA` + `RequestAccessButton` sat at the very bottom of `/portal`. On any portal with more than a handful of cards (every household install ships at least 5), the CTA fell below the fold — anonymous visitors couldn't see the path to getting an account without scrolling.

Moves the CTA block to sit between the welcome header and the service grid. Signed-in visitors still see only the chip + logout in the top-right.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` green
- [x] `npm test` — 1265 passing, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)