### PR TITLE
fix(portal): stop bouncing anonymous /portal visits to /login

### DIFF
--- a/packages/frontend/src/hooks/useSocket.ts
+++ b/packages/frontend/src/hooks/useSocket.ts
@@ -4,6 +4,13 @@ import io, { Socket } from 'socket.io-client';
 
 let socket: Socket;
 
+/** Pathnames where an `unauthorized` socket error must NOT bounce the
+ *  browser to /login. /login itself (the redirect target) and /portal
+ *  (anonymous-readable family surface) — every other path is admin-
+ *  flavored and the bounce is desirable. Kept in sync with the REST
+ *  401 handler in DigitalTwinProvider. */
+const ANONYMOUS_PATHS = new Set(['/login', '/portal']);
+
 export const useSocket = () => {
   const [isConnected, setIsConnected] = useState(false);
 
@@ -31,15 +38,20 @@ export const useSocket = () => {
     // re-authenticates. Only the auth error redirects; transient network
     // `connect_error`s must keep retrying silently.
     //
-    // The path guard prevents an infinite reload loop on /login itself:
-    // the root layout mounts DigitalTwinProvider unconditionally, so the
-    // socket also connects from the login page; without the guard, every
-    // failed connect would redirect the browser back to /login (#854).
+    // The path guard prevents an infinite reload loop on /login itself
+    // (#854) AND prevents the family portal from bouncing anonymous
+    // visitors to the admin login: /portal is intentionally
+    // anonymous-readable, but the root layout still mounts
+    // DigitalTwinProvider, which opens a socket connection that fails
+    // `unauthorized` for visitors without an SB session cookie. Without
+    // the /portal guard here, every anonymous /portal visit got
+    // redirected to /login a few hundred ms after landing.
     function onConnectError(err: Error) {
       if (
         err?.message === 'unauthorized' &&
         typeof window !== 'undefined' &&
-        window.location.pathname !== '/login'
+        !ANONYMOUS_PATHS.has(window.location.pathname) &&
+        !window.location.pathname.startsWith('/portal/')
       ) {
         window.location.href = '/login';
       }

--- a/packages/frontend/src/providers/DigitalTwinProvider.tsx
+++ b/packages/frontend/src/providers/DigitalTwinProvider.tsx
@@ -24,15 +24,21 @@ const DigitalTwinContext = createContext<DigitalTwinContextType | undefined>(und
 // Intercept 401 responses from API calls and redirect to login.
 // This handles session expiry gracefully instead of showing JSON parse errors.
 //
-// The pathname guard prevents an infinite reload loop on /login itself:
-// the login page calls /api/auth/oidc/status (and similar pre-auth probes)
-// which can transiently 401; without the guard, every 401 from /login would
-// hard-reload the page back to /login forever (#854).
+// The pathname guard prevents an infinite reload loop on /login itself
+// (#854) AND keeps the family portal from bouncing anonymous visitors
+// to the admin login: /portal is intentionally anonymous-readable,
+// but the root layout mounts this provider unconditionally — so a 401
+// from any background fetch on /portal would silently relocate the
+// visitor to /login a few hundred ms after landing. Kept in sync with
+// the socket handler in useSocket.ts.
+const ANONYMOUS_PATHS = new Set(['/login', '/portal']);
 if (typeof window !== 'undefined') {
     const originalFetch = window.fetch.bind(window);
     window.fetch = async (...args: Parameters<typeof fetch>) => {
         const response = await originalFetch(...args);
-        if (response.status === 401 && window.location.pathname !== '/login') {
+        const pathname = window.location.pathname;
+        const isAnonymousPage = ANONYMOUS_PATHS.has(pathname) || pathname.startsWith('/portal/');
+        if (response.status === 401 && !isAnonymousPage) {
             const url = typeof args[0] === 'string' ? args[0] : args[0] instanceof Request ? args[0].url : '';
             // Only redirect for our own API calls, not external fetches
             if (url.startsWith('/api/') || url.startsWith(window.location.origin + '/api/')) {


### PR DESCRIPTION
## Symptom

Live on 192.168.178.100: signed-in Authelia user navigates to `https://dopp.cloud/`. The apex rewrite serves /portal, the page paints for a fraction of a second, then the browser snaps to /login showing the ServiceBay username/password form. The PortalUserChip + the welcome card never get a chance to render.

## Root cause

Two redirect-on-401 sites in the frontend, both anchored at the `/login` path guard from #854:

- `packages/frontend/src/hooks/useSocket.ts:42` — when the Socket.IO middleware in `server.ts` rejects the connection with `Error('unauthorized')`, redirect to /login.
- `packages/frontend/src/providers/DigitalTwinProvider.tsx:35` — `window.fetch` interceptor that redirects on any `/api/*` 401.

Both guards say "don't redirect if we're already on /login". They miss the family-portal case: `/portal` is intentionally anonymous-readable, but the **root layout** mounts `DigitalTwinProvider` unconditionally. An anonymous visitor lands on /portal, the socket connects, the SB session check fails (the visitor has an Authelia cookie, not an SB session — those are separate auth systems), `onConnectError` fires, and `window.location.href = '/login'` runs.

That's why the user reported "/portal redirects to /login" tonight.

## Fix

Extend both path guards to also skip the redirect on `/portal` (and any sub-path under `/portal/`). One shared `ANONYMOUS_PATHS` constant per file, kept in sync via a cross-reference comment.

## Follow-up scope

A structural fix would be to move `DigitalTwinProvider` out of the root layout into `(dashboard)/layout.tsx` so `/portal` doesn't pay the socket/twin cost at all. That's a bigger refactor touching every dashboard page. This PR is the minimal surgical patch.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check:arch` green
- [x] `npm test` — 1265 passing, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)