### PR TITLE
fix(portal): pass X-Original-URL on Authelia /api/verify

### DIFF
--- a/packages/backend/src/lib/portal/auth.ts
+++ b/packages/backend/src/lib/portal/auth.ts
@@ -41,16 +41,33 @@ export async function verifyAutheliaSession(cookieHeader: string | null): Promis
   }
   const config = await getConfig();
   const port = config.templateSettings?.AUTHELIA_PORT ?? DEFAULT_AUTHELIA_PORT;
+  // Authelia 4.39+ requires X-Original-URL on /api/verify (and on the
+  // newer /api/authz/auth-request endpoint) to scope the cookie check
+  // to a known protected URL. Without it, Authelia returns 403 even
+  // when the cookie is valid for the configured session domain, and
+  // the chip never renders. The URL we claim to be at doesn't have
+  // to match exactly — Authelia's access-control rules cover the
+  // whole `*.<publicDomain>` cookie scope — but it has to be well-
+  // formed and within the cookie domain. We assemble it from the
+  // configured public domain.
+  const publicDomain = config.reverseProxy?.publicDomain ?? config.reverseProxy?.lanDomain ?? '';
+  const originalUrl = publicDomain ? `https://${publicDomain}/portal` : '';
   try {
     const res = await fetch(`http://127.0.0.1:${port}/api/verify`, {
-      headers: { Cookie: cookieHeader },
+      headers: {
+        Cookie: cookieHeader,
+        ...(originalUrl ? { 'X-Original-URL': originalUrl } : {}),
+      },
       signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
     if (!res.ok) {
       // 401 (anonymous) is the expected path for unauthenticated
-      // visitors — silent. Other statuses log at debug since we
-      // don't want noise on every portal hit in a misconfigured
-      // install.
+      // visitors — silent. 403 with a cookie indicates the X-Original-URL
+      // is missing or outside the cookie scope — that's a real config
+      // issue worth logging.
+      if (res.status === 403) {
+        logger.debug('portal:auth', `Authelia verify returned 403 (X-Original-URL=${originalUrl || '<unset>'}). Check session.cookies[].domain covers the public domain.`);
+      }
       return { user: null, name: null };
     }
     const user = res.headers.get('remote-user');


### PR DESCRIPTION
## Symptom

Live on 192.168.178.100: signed-in Authelia visitor lands on `/portal` (the redirect-loop fix in #1039 keeps them there now), but the page shows the anonymous "Request access" CTA instead of the user chip + welcome-by-name. The cookie is reaching SB, but Authelia's `/api/verify` is returning 403.

## Root cause

Authelia 4.39 requires `X-Original-URL` on `/api/verify` (and on the newer `/api/authz/auth-request` endpoint) to scope the cookie check to a known protected URL. The portal's `verifyAutheliaSession` was only sending the `Cookie` header.

Verified directly against the live Authelia container:
- `curl /api/verify` (no headers) → 401
- `curl -H "X-Original-URL: ..." /api/verify` (still no cookie) → 403  
- `curl -H Cookie -H X-Original-URL` → 200 + `Remote-User` / `Remote-Name`

## Fix

Assemble `https://<publicDomain>/portal` from config and send it as `X-Original-URL`. The exact path doesn't matter to Authelia's access-control rules (the cookie scope covers the whole `*.dopp.cloud`), but it has to be well-formed and within the cookie scope.

Also adds a debug log line for the 403 case so the next time this breaks we don't have to re-derive it from the silent fall-through.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 1265 passing, 2 skipped
- [ ] Live verify on 192.168.178.100 once v4.33.5 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)