### PR TITLE
fix(hermes): wire OPENAI_BASE_URL/_KEY env for /v1/chat/completions

### DIFF
--- a/templates/hermes/template.yml
+++ b/templates/hermes/template.yml
@@ -80,6 +80,25 @@ spec:
       value: "{{HASS_URL}}"
     - name: HASS_TOKEN
       value: "{{HASS_TOKEN}}"
+    # OpenAI-compatible inference target for Hermes' API server platform.
+    # The config.yaml `model:` block (provider/base_url/api_key — written
+    # by post-deploy.py) is read by `hermes` CLI / dashboard but NOT by
+    # `gateway run`'s `api_server` platform when resolving credentials
+    # for /v1/chat/completions: `_resolve_runtime_agent_kwargs()` calls
+    # `resolve_runtime_provider(requested=os.getenv('HERMES_INFERENCE_PROVIDER'))`
+    # and that path's `_resolve_named_custom_runtime` short-circuits on
+    # `provider: custom` (config.yaml's value) before ever consulting
+    # `model.base_url`. Without OPENAI_BASE_URL + OPENAI_API_KEY in env,
+    # every chat completion through Open WebUI / OSCAR / external API
+    # hits its auto-detect fallback and raises "No inference provider
+    # configured. Run 'hermes model'…" — observed live 2026-05-26.
+    # Setting these here makes the env path's openrouter-with-custom-
+    # endpoint detection route every API-server chat through Ollama,
+    # matching the `model.base_url` the config.yaml already declares.
+    - name: OPENAI_BASE_URL
+      value: "{{HERMES_LLM_PROVIDER_URL}}"
+    - name: OPENAI_API_KEY
+      value: "ollama"
     ports:
     - containerPort: {{HERMES_API_PORT}}
     volumeMounts:


### PR DESCRIPTION
## Summary
- Hermes' `api_server` platform never reads config.yaml's `model.base_url` when resolving inference credentials. Without `OPENAI_BASE_URL` + `OPENAI_API_KEY` in env, every chat through Open WebUI / OSCAR / the OpenAI-compatible API hits the auto-detect fallback and raises `No inference provider configured. Run 'hermes model'…`.
- Adding both env vars to the template (pointing at `HERMES_LLM_PROVIDER_URL` and a placeholder key) lets the custom-endpoint detection route every API-server chat through Ollama, matching the `model.base_url` config.yaml already declares.
- Discovered live on 192.168.178.100 after #1037 unblocked Open WebUI signup. The manual `.env` workaround is in place on the box so chat works today; this PR persists the fix into the template so a reinstall reproduces the working setup.

## Test plan
- [ ] Reinstall hermes from this branch and confirm `curl -X POST http://127.0.0.1:8642/v1/chat/completions -H "Authorization: Bearer $API_SERVER_KEY" -d '{"model":"hermes-agent","messages":[{"role":"user","content":"ack"}],"max_tokens":12,"stream":false}'` returns a `choices[0].message.content` body (not an error).
- [ ] `podman exec ollama ollama ps` shows the configured model loaded 100% GPU after a chat round-trip.
- [ ] Open WebUI at `chat.<publicDomain>/` can reply through the Hermes path (model dropdown shows `hermes-agent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)