### PR TITLE
feat(ollama): pre-pull extras + verify model post-pull

### DIFF
--- a/templates/ollama/CHANGELOG.md
+++ b/templates/ollama/CHANGELOG.md
@@ -1,0 +1,9 @@
+## v2
+
+- New `OLLAMA_EXTRA_MODELS` variable (CSV) — additional models pre-pulled at install time on top of `OLLAMA_DEFAULT_MODEL`. Default ships a quantized 26B model that fits 100% on a 16 GB GPU, giving the operator a one-click "smarter but slower" choice in Hermes' Models tab without a fresh download (#1046).
+- `OLLAMA_DEFAULT_MODEL` default bumped from `gemma3:4b` to `gemma4:e4b` — same VRAM class, newer architecture, native tool-call support.
+- `pull_model` now verifies the tag is present in `/api/tags` *after* the streaming pull reports success. The CLI and the HTTP streaming endpoint both occasionally report success while manifest write fails silently (e.g. `library/<namespace>/` left root-owned by an earlier rootful run); the unverified happy path left operators with a `HTTP 404: model not found` on first chat. Now we fail loud (#1047).
+
+## v1
+
+- Initial template — single model pull (`OLLAMA_DEFAULT_MODEL`), optional vision model (`OLLAMA_VISION_MODEL`), GPU passthrough toggle.

--- a/templates/ollama/CHANGELOG.md
+++ b/templates/ollama/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## v2
 
-- New `OLLAMA_EXTRA_MODELS` variable (CSV) — additional models pre-pulled at install time on top of `OLLAMA_DEFAULT_MODEL`. Default ships a quantized 26B model that fits 100% on a 16 GB GPU, giving the operator a one-click "smarter but slower" choice in Hermes' Models tab without a fresh download (#1046).
-- `OLLAMA_DEFAULT_MODEL` default bumped from `gemma3:4b` to `gemma4:e4b` — same VRAM class, newer architecture, native tool-call support.
+- New `OLLAMA_EXTRA_MODELS` variable (CSV) — additional models pre-pulled at install time on top of `OLLAMA_DEFAULT_MODEL`. Default ships a quantized 26B model that fits 100% on a 16 GB GPU, giving the operator a one-click "smarter but slower" choice in Hermes' Models tab without a fresh download (#1046). Note: the 26B-VRAM variant is text-only — multimodal stays on `gemma4:e4b`.
+- `OLLAMA_DEFAULT_MODEL` default bumped from `gemma3:4b` to `gemma4:e4b` — same VRAM class, newer architecture, AND native multimodal (`ollama show gemma4:e4b` reports `completion, vision, audio, tools, thinking`). The default bump alone gets a fresh install most of the way through #923 / #938: vision-capable LLM on disk without needing a separate `OLLAMA_VISION_MODEL` pull.
+- `OLLAMA_VISION_MODEL` demoted to "only set if you've changed the default to a text-only tag"; description updated accordingly.
 - `pull_model` now verifies the tag is present in `/api/tags` *after* the streaming pull reports success. The CLI and the HTTP streaming endpoint both occasionally report success while manifest write fails silently (e.g. `library/<namespace>/` left root-owned by an earlier rootful run); the unverified happy path left operators with a `HTTP 404: model not found` on first chat. Now we fail loud (#1047).
 
 ## v1

--- a/templates/ollama/README.md
+++ b/templates/ollama/README.md
@@ -12,21 +12,29 @@ networking.
 
 - `OLLAMA_PORT` — host port. Default `11434`. Bound to loopback.
 - `OLLAMA_DEFAULT_MODEL` — primary model. The tag Hermes' `model.model`
-  points at after install. Default `gemma4:e4b` (~10 GB, fits 100% on
-  a 16 GB GPU, fast). Any Ollama library tag works, plus user-namespaced
-  tags like `VladimirGav/gemma4-26b-16GB-VRAM:latest`.
+  points at after install. Default `gemma4:e4b` — 8B params @ Q4_K_M,
+  ~10 GB on disk, fits 100% on a 16 GB GPU, AND ships native multimodal
+  (`ollama show gemma4:e4b` reports `completion, vision, audio, tools,
+  thinking`). That single default backs OSCAR's multimodal-ingestion
+  path without a separate vision pull. Any Ollama library tag works,
+  plus user-namespaced tags like `VladimirGav/gemma4-26b-16GB-VRAM:latest`.
 - `OLLAMA_EXTRA_MODELS` — comma-separated list of additional models
-  pre-pulled at install time on top of the default. The point is to
-  give the operator one-click switchable choices in Hermes' Models tab
-  without a fresh download. Default ships
-  `VladimirGav/gemma4-26b-16GB-VRAM:latest` — a quantized 26B that
-  still fits 100% on a 16 GB GPU, complementing the smaller default.
-  Each extra adds 10–20 minutes to the install on a typical home link.
-  Set to empty string to skip.
-- `OLLAMA_VISION_MODEL` — optional second model for image-aware
-  skills (e.g. OSCAR's `media-ingestion-multimodal`). Blank by
-  default; set to `qwen2.5vl:7b`, `llava:13b`, or `bakllava:7b`
-  to enable multimodal flows.
+  pre-pulled at install time on top of the default. Gives the operator
+  one-click switchable choices in Hermes' Models tab without a fresh
+  download. Default ships `VladimirGav/gemma4-26b-16GB-VRAM:latest` —
+  a quantized 26B that still fits 100% on a 16 GB GPU, complementing
+  the smaller default for harder text reasoning. **Caveat:** the 16
+  GB quant strips vision and audio from its `Capabilities` block — it's
+  text-only. Switching the active model to it drops multimodal; switch
+  back to `gemma4:e4b` (or pull plain `gemma4:26b` ~17 GB with partial
+  CPU offload) for OCR / voice-note flows. Each extra adds 10–20
+  minutes to the install on a typical home link. Set to empty string
+  to skip.
+- `OLLAMA_VISION_MODEL` — historical, mostly unused now that the
+  default `gemma4:e4b` ships vision + audio natively. Set this only if
+  you've changed `OLLAMA_DEFAULT_MODEL` to a text-only tag and still
+  want a vision backend for OSCAR's `media-ingestion-multimodal` skill.
+  Suggested non-default tags: `qwen2.5vl:7b`, `llava:13b`, `bakllava:7b`.
 - `OLLAMA_GPU_PASSTHROUGH` — leave blank for CPU; set non-blank
   for NVIDIA GPU passthrough via CDI.
 - `OLLAMA_READINESS_TIMEOUT_SECONDS` — post-deploy model-pull
@@ -79,20 +87,24 @@ API exposes every loaded model to anyone who reaches it.
 Idempotent — a second deploy with the same models finds them already
 cached and skips the pulls.
 
-## Multimodal (vision) inference
+## Multimodal (vision + audio) inference
 
-OSCAR's `media-ingestion-multimodal` skill needs a vision-capable
-model to OCR book covers, transcribe photos of documents, etc.
-The default `gemma3:4b` is text-only — sending it an image yields
-an unhelpful "I can't see images" response.
+The default `OLLAMA_DEFAULT_MODEL=gemma4:e4b` is natively multimodal —
+`ollama show gemma4:e4b` reports `completion, vision, audio, tools,
+thinking`. OSCAR's `media-ingestion-multimodal` skill calls into it
+without a separate vision pull.
 
-Set `OLLAMA_VISION_MODEL` at install time (or via the wizard's
-reconfigure flow) to pull a vision model alongside the default.
-The model pulls in series after the default; both share the
-`OLLAMA_READINESS_TIMEOUT_SECONDS` budget. Suggested tags:
+Where the tag matters: the `OLLAMA_EXTRA_MODELS` default ships
+`VladimirGav/gemma4-26b-16GB-VRAM:latest`, which **drops vision and
+audio** in its 16 GB quant. An operator who switches Hermes' active
+model to that tag for "smarter text reasoning" gives up multimodal
+until they switch back to `gemma4:e4b` (or pull plain `gemma4:26b`,
+~17 GB with partial CPU offload, which keeps vision).
 
-- `qwen2.5vl:7b` — Apache-2.0, ~6 GB quantised, fits a 16 GB GPU
-  alongside `gemma3:4b`.
+`OLLAMA_VISION_MODEL` is the explicit override for setups where the
+default has been changed to a text-only tag. Suggested alternatives:
+
+- `qwen2.5vl:7b` — Apache-2.0, ~6 GB quantised, fits a 16 GB GPU.
 - `llava:13b` — older but well-tested, ~8 GB.
 - `bakllava:7b` — Mistral-based LLaVA variant, ~5 GB.
 

--- a/templates/ollama/README.md
+++ b/templates/ollama/README.md
@@ -11,8 +11,18 @@ networking.
 ## Variables
 
 - `OLLAMA_PORT` — host port. Default `11434`. Bound to loopback.
-- `OLLAMA_DEFAULT_MODEL` — model pulled on first install. Default
-  `gemma3:4b` (small, CPU-friendly). Any Ollama library tag works.
+- `OLLAMA_DEFAULT_MODEL` — primary model. The tag Hermes' `model.model`
+  points at after install. Default `gemma4:e4b` (~10 GB, fits 100% on
+  a 16 GB GPU, fast). Any Ollama library tag works, plus user-namespaced
+  tags like `VladimirGav/gemma4-26b-16GB-VRAM:latest`.
+- `OLLAMA_EXTRA_MODELS` — comma-separated list of additional models
+  pre-pulled at install time on top of the default. The point is to
+  give the operator one-click switchable choices in Hermes' Models tab
+  without a fresh download. Default ships
+  `VladimirGav/gemma4-26b-16GB-VRAM:latest` — a quantized 26B that
+  still fits 100% on a 16 GB GPU, complementing the smaller default.
+  Each extra adds 10–20 minutes to the install on a typical home link.
+  Set to empty string to skip.
 - `OLLAMA_VISION_MODEL` — optional second model for image-aware
   skills (e.g. OSCAR's `media-ingestion-multimodal`). Blank by
   default; set to `qwen2.5vl:7b`, `llava:13b`, or `bakllava:7b`
@@ -20,8 +30,9 @@ networking.
 - `OLLAMA_GPU_PASSTHROUGH` — leave blank for CPU; set non-blank
   for NVIDIA GPU passthrough via CDI.
 - `OLLAMA_READINESS_TIMEOUT_SECONDS` — post-deploy model-pull
-  deadline. Default `600`. Shared across both default and vision
-  pulls; bump it if you pull two large models on a slow link.
+  deadline. Default `600`. Shared per-pull (not summed across the
+  default + extras + vision); bump it if you pull large models on a
+  slow link.
 
 ## CPU vs. GPU
 

--- a/templates/ollama/post-deploy.py
+++ b/templates/ollama/post-deploy.py
@@ -98,8 +98,35 @@ def wait_for_ready(ollama_url: str, deadline_sec: int) -> bool:
     return False
 
 
+def model_present(ollama_url: str, model: str) -> bool:
+    """Return True iff Ollama's /api/tags lists `model` (exact match against
+    `name`). Used as a defensive post-pull check (#1047): the `ollama pull`
+    CLI is known to exit 0 even when manifest write fails, and the HTTP
+    /api/pull streaming endpoint can also report `success` while leaving
+    the manifest unwritten if the underlying filesystem perms are wrong
+    (e.g. a `library/<namespace>/` dir left root-owned by an earlier
+    rootful run, biting the next rootless pull). Always re-check via
+    /api/tags before declaring a pull successful."""
+    try:
+        with urllib.request.urlopen(f"{ollama_url}/api/tags", timeout=10) as resp:
+            payload = json.loads(resp.read().decode("utf-8") or "{}")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        jlog("warn", "ollama:verify", "/api/tags probe failed", error=str(e))
+        return False
+    for entry in payload.get("models", []) or []:
+        if str(entry.get("name") or "") == model:
+            return True
+    return False
+
+
 def pull_model(ollama_url: str, model: str, deadline_sec: int) -> bool:
-    """Trigger a streaming pull and wait for the done line."""
+    """Trigger a streaming pull and wait for the done line.
+
+    Post-pull verifies via /api/tags (#1047) — neither the CLI nor the
+    HTTP streaming endpoint reliably surfaces manifest-write failures.
+    A pull that reports `success` but never lands the model in /api/tags
+    is treated as a failure here so callers can fall back / fail loud
+    instead of leaving the operator with a 404-on-first-chat box."""
     body = json.dumps({"name": model, "stream": True}).encode("utf-8")
     req = urllib.request.Request(
         f"{ollama_url}/api/pull",
@@ -126,11 +153,19 @@ def pull_model(ollama_url: str, model: str, deadline_sec: int) -> bool:
                 if chunk.get("error"):
                     jlog("error", "ollama:pull", "pull error", model=model, error=str(chunk.get("error")))
                     return False
-        jlog("info", "ollama:pull", "model ready", model=model, elapsed_sec=int(time.time() - started))
-        return True
     except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as e:
         jlog("error", "ollama:pull", "pull failed", model=model, error=str(e))
         return False
+    if not model_present(ollama_url, model):
+        jlog(
+            "error",
+            "ollama:pull",
+            "stream reported success but model is not in /api/tags — manifest write likely failed silently (#1047). Check `ls -la /mnt/data/stacks/ollama/models/manifests/registry.ollama.ai/library/` for non-`core:core` ownership on the host.",
+            model=model,
+        )
+        return False
+    jlog("info", "ollama:pull", "model ready", model=model, elapsed_sec=int(time.time() - started))
+    return True
 
 
 def register_http_check(sb_api: str, sb_token: str, ollama_url: str) -> None:
@@ -304,7 +339,9 @@ def install_gpu_quadlet_fallback(port: str, data_dir: str) -> bool:
 
 def main() -> int:
     port = env("OLLAMA_PORT", "11434")
-    model = env("OLLAMA_DEFAULT_MODEL", "gemma3:4b")
+    model = env("OLLAMA_DEFAULT_MODEL", "gemma4:e4b")
+    extra_models_raw = env("OLLAMA_EXTRA_MODELS", "")
+    extra_models = [m.strip() for m in extra_models_raw.split(",") if m.strip()]
     vision_model = env("OLLAMA_VISION_MODEL", "")
     timeout = int(env("OLLAMA_READINESS_TIMEOUT_SECONDS", "600"))
     sb_api = env("SB_API_URL", "http://localhost:3000")
@@ -352,6 +389,22 @@ def main() -> int:
                 model=model,
             )
 
+    # Extras (#1046): one-click-switchable alternatives the operator can
+    # pick from Hermes' Models tab without a fresh download. Failures are
+    # warn-not-fatal — the default model is the only one the install
+    # depends on; extras enrich the choice set.
+    for extra in extra_models:
+        if extra == model:
+            continue  # already covered above
+        jlog("info", "ollama:pull", "starting extra-model pull", model=extra)
+        if not pull_model(ollama_url, extra, deadline_sec=remaining_budget()):
+            jlog(
+                "warn",
+                "ollama:pull",
+                "extra-model pull did not complete; it will not be selectable from Hermes' Models tab until pulled manually. Run `curl -X POST http://127.0.0.1:%s/api/pull -d '{\"name\":\"%s\"}'`." % (port, extra),
+                model=extra,
+            )
+
     if vision_model:
         jlog("info", "ollama:pull", "starting vision-model pull", model=vision_model)
         ok = pull_model(ollama_url, vision_model, deadline_sec=remaining_budget())
@@ -366,6 +419,8 @@ def main() -> int:
     register_http_check(sb_api, sb_token, ollama_url)
 
     print(f"✅ Ollama is running on 127.0.0.1:{port}. Default model: {model}.")
+    if extra_models:
+        print(f"   Extra models pulled: {', '.join(extra_models)}.")
     if vision_model:
         print(f"   Vision model: {vision_model} (multimodal-capable).")
     print(f"   Other ServiceBay templates (hermes, oscar-household) can reach it at http://127.0.0.1:{port}.")

--- a/templates/ollama/template.yml
+++ b/templates/ollama/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: ollama
   annotations:
     servicebay.label: "Ollama (Local LLM Server)"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     servicebay.ports: "{{OLLAMA_PORT}}/tcp"
     # No `servicebay.tier` — Ollama is opt-in AI infrastructure, not a
     # platform foundation. Bind it to 127.0.0.1 by default (see

--- a/templates/ollama/variables.json
+++ b/templates/ollama/variables.json
@@ -6,8 +6,13 @@
   },
   "OLLAMA_DEFAULT_MODEL": {
     "type": "text",
-    "description": "Model pulled on first start. Use any tag from the Ollama library (https://ollama.com/library). Small CPU-friendly default; bump to a larger model once you have GPU passthrough working. The pull runs once per fresh install — subsequent starts find the model already cached and skip the download.",
-    "default": "gemma3:4b"
+    "description": "Primary model — the one Hermes' `model.model` points at after install. Use any tag from the Ollama library (https://ollama.com/library) or a user-namespaced tag like `VladimirGav/gemma4-26b-16GB-VRAM:latest`. Default `gemma4:e4b` is a small/fast everyday model (~10 GB, fits 100% on a 16 GB GPU). The pull runs once per fresh install — subsequent starts find the model already cached and skip the download.",
+    "default": "gemma4:e4b"
+  },
+  "OLLAMA_EXTRA_MODELS": {
+    "type": "text",
+    "description": "Additional models to pre-pull on first install (comma-separated tags), on top of OLLAMA_DEFAULT_MODEL. Default includes a quantized 26B model that still fits 100% on a 16 GB GPU — gives the operator a 'smarter but slower' choice that's switchable in one click via Hermes' Models tab, without a fresh download. Set to empty string to skip extras. Each pull is gated by OLLAMA_READINESS_TIMEOUT_SECONDS so a slow link doesn't stall install indefinitely.",
+    "default": "VladimirGav/gemma4-26b-16GB-VRAM:latest"
   },
   "OLLAMA_VISION_MODEL": {
     "type": "text",

--- a/templates/ollama/variables.json
+++ b/templates/ollama/variables.json
@@ -6,17 +6,17 @@
   },
   "OLLAMA_DEFAULT_MODEL": {
     "type": "text",
-    "description": "Primary model — the one Hermes' `model.model` points at after install. Use any tag from the Ollama library (https://ollama.com/library) or a user-namespaced tag like `VladimirGav/gemma4-26b-16GB-VRAM:latest`. Default `gemma4:e4b` is a small/fast everyday model (~10 GB, fits 100% on a 16 GB GPU). The pull runs once per fresh install — subsequent starts find the model already cached and skip the download.",
+    "description": "Primary model — the tag Hermes' `model.model` points at after install. Use any Ollama library tag (https://ollama.com/library) or a user-namespaced tag like `VladimirGav/gemma4-26b-16GB-VRAM:latest`. Default `gemma4:e4b` is the household-stack sweet spot: 8B params at Q4_K_M, ~10 GB on disk, fits 100% on a 16 GB GPU, AND ships native multimodal capabilities (`ollama show gemma4:e4b` reports `completion, vision, audio, tools, thinking`). That single tag covers what we used to need a separate vision pull for (#923 / #938).",
     "default": "gemma4:e4b"
   },
   "OLLAMA_EXTRA_MODELS": {
     "type": "text",
-    "description": "Additional models to pre-pull on first install (comma-separated tags), on top of OLLAMA_DEFAULT_MODEL. Default includes a quantized 26B model that still fits 100% on a 16 GB GPU — gives the operator a 'smarter but slower' choice that's switchable in one click via Hermes' Models tab, without a fresh download. Set to empty string to skip extras. Each pull is gated by OLLAMA_READINESS_TIMEOUT_SECONDS so a slow link doesn't stall install indefinitely.",
+    "description": "Additional models to pre-pull on first install (comma-separated tags), on top of OLLAMA_DEFAULT_MODEL. The point is to give the operator one-click switchable alternatives in Hermes' Models tab without a fresh download. Default ships `VladimirGav/gemma4-26b-16GB-VRAM:latest` — a quantized 26B that still fits 100% on a 16 GB GPU, complementing the smaller default for harder text reasoning. CAVEAT: the aggressive quantization strips vision and audio from its `Capabilities` block (it reports `completion, tools, thinking` only). Switching the active model to this tag gives up multimodal — keep `gemma4:e4b` for OCR / voice-note flows, or pull plain `gemma4:26b` (~17 GB, partial CPU offload) which retains vision. Set to empty string to skip extras.",
     "default": "VladimirGav/gemma4-26b-16GB-VRAM:latest"
   },
   "OLLAMA_VISION_MODEL": {
     "type": "text",
-    "description": "Optional second model pulled on first start for image-aware skills (e.g. OSCAR's media-ingestion-multimodal skill). Leave blank to skip — the default text model has no vision capability and a multimodal request will get an unhelpful 'I can't see images' answer. Suggested tags: `qwen2.5vl:7b` (Apache-2, fits a 16GB GPU alongside gemma3:4b), `llava:13b` (older but well-tested), `bakllava:7b`. Pulled after the default model; both pulls share OLLAMA_READINESS_TIMEOUT_SECONDS.",
+    "description": "Optional second model pulled on first start, mainly historical now that the default OLLAMA_DEFAULT_MODEL (`gemma4:e4b`) ships vision + audio natively. Leave blank in normal household installs — only set this if you've changed OLLAMA_DEFAULT_MODEL to a text-only tag and still want OSCAR's `media-ingestion-multimodal` skill to have a vision backend. Suggested non-default tags: `qwen2.5vl:7b` (Apache-2, ~6 GB), `llava:13b` (~8 GB), `bakllava:7b` (~5 GB).",
     "default": ""
   },
   "OLLAMA_GPU_PASSTHROUGH": {


### PR DESCRIPTION
Closes #1046, closes #1047.

## Summary
- `OLLAMA_EXTRA_MODELS` CSV var pre-pulls additional models alongside `OLLAMA_DEFAULT_MODEL`. Default includes `VladimirGav/gemma4-26b-16GB-VRAM:latest`.
- `OLLAMA_DEFAULT_MODEL` default → `gemma4:e4b` (gemma3:4b → gemma4:e4b).
- `pull_model` verifies the tag is in `/api/tags` after the stream reports success — catches silent manifest-write failures (#1047). Reproduced 2026-05-26 on `192.168.178.100`.
- `schema-version: 2` + CHANGELOG seeded.

## Test plan
- [ ] Reinstall ollama from this branch — confirm both `gemma4:e4b` and `VladimirGav/gemma4-26b-16GB-VRAM:latest` appear in `ollama list`.
- [ ] Reproduce the silent-pull bug by chowning a manifest namespace dir to root and re-pulling — post-deploy now fails loud with "stream reported success but model is not in /api/tags".
- [ ] Pre-existing installs upgrade cleanly (schema v1 → v2; no data migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)