### PR TITLE
refactor(templates): user-friendly service labels in portal + /services

### DIFF
--- a/packages/backend/src/lib/services/serviceViewModel.ts
+++ b/packages/backend/src/lib/services/serviceViewModel.ts
@@ -1,5 +1,6 @@
 import type { ServiceUnit, EnrichedContainer, ProxyRoute } from '@/lib/agent/types';
 import type { NodeTwin } from '@/lib/store/twin';
+import { parseTemplateLabel } from '@/lib/templateLabel';
 // Direct sub-path import — using the barrel would create a cycle since
 // api-client/index re-exports `buildServiceViewModel` from this file.
 import type { ServiceViewModel, ServicePort } from '@servicebay/api-client/serviceView';
@@ -84,6 +85,18 @@ export function buildServiceViewModel({ unit, nodeName, nodeState, proxyRoutes }
   // Backend-computed display fields (#844 / ARCH-12). The frontend used
   // to derive these with `.replace('.service', '')` and `.split('/').pop()`
   // — those rules belong here so every consumer sees the same answer.
+  //
+  // Label resolution order (most → least specific):
+  //   1. Hard-coded special cases (reverse-proxy / servicebay-system).
+  //   2. `servicebay.label` parsed from the deployed YAML, when it's
+  //      already in the twin's file watcher (kube-managed services).
+  //   3. Fallback to `baseName` (the unit name minus `.service`).
+  //
+  // Step 2 is what makes the /services dashboard render the same
+  // user-friendly labels the portal shows ("Photos" instead of
+  // "immich", "Smart Home (Home Assistant)" instead of "home-assistant").
+  // The YAML content is already in nodeState.files from the file
+  // watcher; no extra I/O.
   let displayName = baseName;
   let legacyName = unit.name;
   if (unit.isReverseProxy) {
@@ -92,6 +105,14 @@ export function buildServiceViewModel({ unit, nodeName, nodeState, proxyRoutes }
   } else if (unit.isServiceBay) {
     displayName = 'ServiceBay System';
     legacyName = displayName;
+  } else if (yamlPath) {
+    const yamlFile = nodeState.files?.[yamlPath];
+    if (yamlFile?.content) {
+      const label = parseTemplateLabel(yamlFile.content);
+      if (label && label.trim()) {
+        displayName = label.trim();
+      }
+    }
   }
 
   const yamlBasename = yamlPath ? (yamlPath.split('/').pop() ?? null) : null;

--- a/templates/adguard/template.yml
+++ b/templates/adguard/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: adguard
     servicebay.role: dns
   annotations:
-    servicebay.label: "AdGuard Home (DNS)"
+    servicebay.label: "Ad Blocker (DNS)"
     servicebay.schema-version: "2"
     servicebay.tier: "infrastructure"
     # NPM proxies `<ADGUARD_SUBDOMAIN>.<PUBLIC_DOMAIN>` through Authelia

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: auth
   annotations:
-    servicebay.label: "Auth (LLDAP + Authelia)"
+    servicebay.label: "Sign-In Gate"
     servicebay.schema-version: "1"
     servicebay.tier: "infrastructure"
     # post-deploy.py calls /api/system/lldap/* and /api/system/authelia/*.

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: file-share
   annotations:
-    servicebay.label: "File Share (Syncthing + Samba + FileBrowser)"
+    servicebay.label: "Files"
     servicebay.schema-version: "4"
     # FileBrowser is fronted by Authelia via the nginx proxy host — both
     # must be running before this template's post-deploy can wire SSO.

--- a/templates/hermes-webui/template.yml
+++ b/templates/hermes-webui/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: hermes-webui
   annotations:
-    servicebay.label: "Hermes Web UI (Family Chat)"
+    servicebay.label: "Chat"
     servicebay.schema-version: "1"
     servicebay.ports: "{{HERMES_WEBUI_PORT}}/tcp"
     # Hermes-native chat surface — talks directly to the local Hermes

--- a/templates/hermes/template.yml
+++ b/templates/hermes/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: hermes
   annotations:
-    servicebay.label: "Hermes Agent"
+    servicebay.label: "AI Assistant (Hermes)"
     servicebay.schema-version: "3"
     servicebay.ports: "{{HERMES_API_PORT}}/tcp,{{HERMES_DASHBOARD_PORT}}/tcp"
     # Hermes' default LLM_PROVIDER_URL points at the `ollama` template's

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: home-assistant
   annotations:
-    servicebay.label: "Home Assistant"
+    servicebay.label: "Smart Home (Home Assistant)"
     servicebay.schema-version: "6"
     # Home Assistant is reached at home.<domain> via nginx, authenticates
     # via Authelia, and talks to Wyoming-protocol STT/TTS on the voice

--- a/templates/honcho/template.yml
+++ b/templates/honcho/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: honcho
   annotations:
-    servicebay.label: "Honcho (Per-User Memory for Hermes/OSCAR)"
+    servicebay.label: "AI Memory"
     servicebay.schema-version: "1"
     # Service-to-service only by design (#1004). Honcho exposes a peer
     # isolation API consumed by Hermes' memory plugin; no operator-facing

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: immich
   annotations:
-    servicebay.label: "Immich (Photos)"
+    servicebay.label: "Photos"
     servicebay.schema-version: "2"
     servicebay.ports: "{{IMMICH_PORT}}/tcp"
     # photos.<domain> is served via nginx; Immich's SSO uses Authelia.

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: media
     servicebay.role: media
   annotations:
-    servicebay.label: "Media (Audiobookshelf + Jellyfin)"
+    servicebay.label: "Movies & TV"
     servicebay.schema-version: "4"
     # Audiobookshelf's post-deploy registers an OIDC client in Authelia
     # and both apps' public URLs route through nginx — both prerequisites.

--- a/templates/nginx/template.yml
+++ b/templates/nginx/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: nginx
     servicebay.role: reverse-proxy
   annotations:
-    servicebay.label: "Nginx Proxy Manager"
+    servicebay.label: "Reverse Proxy"
     servicebay.schema-version: "3"
     servicebay.tier: "infrastructure"
     servicebay.ports: "{{NGINX_PORT}}/tcp,{{NGINX_SSL_PORT}}/tcp,{{NGINX_ADMIN_PORT}}/tcp"

--- a/templates/ollama/template.yml
+++ b/templates/ollama/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ollama
   annotations:
-    servicebay.label: "Ollama (Local LLM Server)"
+    servicebay.label: "AI Engine (Ollama)"
     servicebay.schema-version: "2"
     servicebay.ports: "{{OLLAMA_PORT}}/tcp"
     # No `servicebay.tier` — Ollama is opt-in AI infrastructure, not a

--- a/templates/oscar-household/template.yml
+++ b/templates/oscar-household/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: oscar-household
   annotations:
-    servicebay.label: "OSCAR Household (schema init + skill mount + MCP wiring + voice gatekeeper)"
+    servicebay.label: "AI Skills (OSCAR/household)"
     servicebay.schema-version: "1"
     # Wyoming endpoint for satellites (HA Voice PE, wyoming-satellite CLI).
     # The gatekeeper container is the only consumer that exposes a host

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: radicale
   annotations:
-    servicebay.label: "Radicale (CalDAV + CardDAV)"
+    servicebay.label: "Calendar & Contacts"
     servicebay.schema-version: "1"
     servicebay.ports: "{{RADICALE_PORT}}/tcp"
     # caldav.<domain> goes through nginx; auth is the SSO front.

--- a/templates/vaultwarden/template.yml
+++ b/templates/vaultwarden/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: vaultwarden
   annotations:
-    servicebay.label: "Vaultwarden (Passwords)"
+    servicebay.label: "Passwords"
     servicebay.schema-version: "2"
     servicebay.ports: "{{VAULTWARDEN_PORT}}/tcp"
     # Install order: proxy + SSO foundation needs to land first so the

--- a/templates/voice/template.yml
+++ b/templates/voice/template.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: voice
   annotations:
-    servicebay.label: "Voice (Wyoming: Whisper + Piper + openWakeWord)"
+    servicebay.label: "Smart Home Voice Assist"
     servicebay.schema-version: "1"
     # No `servicebay.tier` — voice is optional plumbing, not platform
     # infrastructure (DNS / proxy / SSO are tier=infrastructure and


### PR DESCRIPTION
## Summary
- Replaces template-implementation names ("immich", "radicale", …) with user-facing labels on the portal AND the /services admin dashboard.
- 15 templates renamed (one-line `servicebay.label` edit per template, no schema bump).
- `serviceViewModel.displayName` now reads the label from the deployed YAML (already in the twin's file cache) instead of falling back to `baseName`.
- Operators still see the unit name via the existing `title=` tooltip on the service card h3.

## Label table

| Slug | New label |
|---|---|
| `hermes-webui` | Chat |
| `immich` | Photos |
| `radicale` | Calendar & Contacts |
| `vaultwarden` | Passwords |
| `home-assistant` | Smart Home (Home Assistant) |
| `voice` | Smart Home Voice Assist |
| `media` | Movies & TV |
| `file-share` | Files |
| `adguard` | Ad Blocker (DNS) |
| `hermes` | AI Assistant (Hermes) |
| `ollama` | AI Engine (Ollama) |
| `oscar-household` | AI Skills (OSCAR/household) |
| `honcho` | AI Memory |
| `nginx` | Reverse Proxy |
| `auth` | Sign-In Gate |

## Test plan
- [ ] Reinstall any one service from this branch — confirm the /services card and the portal tile both show the new label.
- [ ] Hover the service card h3 in /services — tooltip still shows the unit name (e.g. `vaultwarden.service`).
- [ ] No URL or container-name changes (template directory slugs unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)