### PR TITLE
fix(frontend): add missing runningAction dep to useServiceActions useMemo

### DIFF
--- a/packages/frontend/src/hooks/useServiceActions.tsx
+++ b/packages/frontend/src/hooks/useServiceActions.tsx
@@ -391,6 +391,7 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     handleDelete,
     onRefresh,
     requestDelete,
+    runningAction,
     selectedService,
     serviceToDelete,
     showActions,


### PR DESCRIPTION
The drawer-rendering useMemo at useServiceActions.tsx:378 reads runningAction
to drive ActionButton's running prop, but the dependency array omitted it,
causing the drawer to render with stale per-action spinner state.

fixes #1065
