### PR TITLE
refactor(agent): remove dead SYNC_DIFF handler and message type

### DIFF
--- a/packages/backend/src/lib/agent/types.ts
+++ b/packages/backend/src/lib/agent/types.ts
@@ -194,5 +194,4 @@ export interface NodeStateSnapshot {
 
 export type AgentMessage =
   | { type: 'SYNC_PARTIAL'; payload: Partial<NodeStateSnapshot> & { initialSyncComplete?: boolean } }
-  | { type: 'HEARTBEAT'; timestamp: number }
-  | { type: 'SYNC_DIFF'; payload: Partial<NodeStateSnapshot> }; // Kept for future diff logic
+  | { type: 'HEARTBEAT'; timestamp: number };

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -389,16 +389,6 @@ app.prepare().then(() => {
           // TS "as any" is simplistic but TwinStore handles Partial<NodeTwin> safely.
           const update: Partial<NodeTwin> = { ...message.payload as unknown as Partial<NodeTwin>, health };
           twinStore.updateNode(nodeName, update);
-        } else if (message.type === 'SYNC_DIFF') {
-            const agent = agentManager.getAgent(nodeName);
-            logger.info('Server', `SYNC_DIFF from ${nodeName}${formatAgentIdSuffix(agent)}`);
-         
-         // Add health snapshot from agent
-         const health = agent.getHealth();
-         
-         // TODO: Implement diff patching
-         const update: Partial<NodeTwin> = { ...message.payload as unknown as Partial<NodeTwin>, health };
-         twinStore.updateNode(nodeName, update);
       }
   });
   


### PR DESCRIPTION
## What
Drops the never-used `SYNC_DIFF` branch in `server.ts` and the matching `AgentMessage` variant in `lib/agent/types.ts`. The branch carried a `TODO: Implement diff patching` comment that the issue flagged as stale signal — no agent (Python or TS) ever emits `SYNC_DIFF`, so the handler just duplicated `SYNC_PARTIAL`'s merge path.

## Why
Closes #1094.

## Risk
Low — pure dead-code removal. The protocol union shrinks by one variant that no producer references; the runtime branch is unreachable.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch (all green)
- [x] npm test (1265 passed, 2 skipped)
- [ ] /verify on FCoS box — `packages/backend/src/lib/agent/types.ts` is in the path-mandated set