### PR TITLE
test(shellQuote): cover POSIX edge cases — NUL, nested $(`...`), bang, glob

### DIFF
--- a/tests/backend/shell_quote.test.ts
+++ b/tests/backend/shell_quote.test.ts
@@ -28,4 +28,90 @@ describe('shellQuote', () => {
   it('shellQuoteAll concatenates with spaces', () => {
     expect(shellQuoteAll(['ping', '-c', '1', '1.1.1.1; ls'])).toBe(`ping -c 1 '1.1.1.1; ls'`);
   });
+
+  // POSIX edge cases (#1087). The contract: every value, no matter how
+  // weird, becomes a single shell token whose value, when expanded by the
+  // shell, is byte-for-byte identical to the input. Single-quoting is the
+  // only POSIX escape that suppresses ALL expansion ($, `, \, !, history,
+  // glob), so we lean on it for anything not in the safe-char allowlist.
+
+  it('preserves newlines literally inside single quotes', () => {
+    expect(shellQuote('a\nb')).toBe("'a\nb'");
+    expect(shellQuote('line1\nline2\n')).toBe("'line1\nline2\n'");
+  });
+
+  it('preserves tabs and carriage returns literally', () => {
+    expect(shellQuote('a\tb')).toBe("'a\tb'");
+    expect(shellQuote('a\rb')).toBe("'a\rb'");
+  });
+
+  it('escapes backticks nested inside $(...)', () => {
+    // Single quotes block both layers of expansion at once, so the
+    // classic "thought I escaped it but $() re-parses" bug cannot occur.
+    expect(shellQuote('$(`whoami`)')).toBe("'$(`whoami`)'");
+    expect(shellQuote('$(echo `id`)')).toBe("'$(echo `id`)'");
+  });
+
+  it('escapes history-expansion bang', () => {
+    expect(shellQuote('!sudo')).toBe("'!sudo'");
+    expect(shellQuote('foo!bar')).toBe("'foo!bar'");
+  });
+
+  it('escapes glob metacharacters', () => {
+    expect(shellQuote('*.sh')).toBe("'*.sh'");
+    expect(shellQuote('?ile')).toBe("'?ile'");
+    expect(shellQuote('[abc]')).toBe("'[abc]'");
+    expect(shellQuote('{a,b}')).toBe("'{a,b}'");
+  });
+
+  it('escapes redirection and process-substitution metacharacters', () => {
+    expect(shellQuote('a>b')).toBe("'a>b'");
+    expect(shellQuote('a<b')).toBe("'a<b'");
+    expect(shellQuote('<(cat /etc/shadow)')).toBe("'<(cat /etc/shadow)'");
+    expect(shellQuote('a&b')).toBe("'a&b'");
+    expect(shellQuote('a&&b')).toBe("'a&&b'");
+  });
+
+  it('passes leading hyphen through unquoted — argv-parsing is the caller s problem', () => {
+    // Hyphen is in the safe-char allowlist because every flag uses it.
+    // shellQuote is a *shell-quoting* primitive, not an argv-parsing one:
+    // a value of `-rf` will be interpreted as a flag by the receiving
+    // program whether or not it was single-quoted, because the shell has
+    // already split argv before the program sees it. Callers handling
+    // untrusted input MUST use the `--` separator (`rm -- "$arg"`) or
+    // `execFile(['cmd', '--', arg])`. Test pins the current behaviour so
+    // any future change is intentional.
+    expect(shellQuote('-rf')).toBe('-rf');
+    expect(shellQuote('-')).toBe('-');
+    expect(shellQuote('--help')).toBe('--help');
+  });
+
+  it('quotes NUL byte rather than truncating the value', () => {
+    // Most POSIX shells truncate argv at NUL because argv is a C string.
+    // shellQuote can't prevent that — it only guarantees the *string* it
+    // emits is single-quoted. Pin the behaviour: NUL goes inside the
+    // single quotes verbatim; what the receiving shell does with it is
+    // outside this primitive's contract.
+    expect(shellQuote('a\0b')).toBe("'a\0b'");
+    expect(shellQuote('\0')).toBe("'\0'");
+  });
+
+  it('quotes a value that is itself a single quote', () => {
+    expect(shellQuote("'")).toBe(`''\\'''`);
+  });
+
+  it('keeps the escape sequence intact next to other quoted content', () => {
+    expect(shellQuote(`foo'$bar`)).toBe(`'foo'\\''$bar'`);
+    expect(shellQuote(`a'b'c`)).toBe(`'a'\\''b'\\''c'`);
+  });
+
+  it('shellQuoteAll on empty argv returns empty string', () => {
+    expect(shellQuoteAll([])).toBe('');
+  });
+
+  it('shellQuoteAll preserves order and handles mixed safe/unsafe args', () => {
+    expect(shellQuoteAll(['ssh', 'user@host', '--', 'rm -rf /'])).toBe(
+      `ssh user@host -- 'rm -rf /'`,
+    );
+  });
 });


### PR DESCRIPTION
## What
Adds 12 unit-test cases to `tests/backend/shell_quote.test.ts` covering the POSIX edge cases #1087 called out that the original 5-test file did not exercise:

- newlines, tabs, carriage returns (preserved verbatim inside single quotes)
- nested command substitution + backticks: `$(`whoami`)`, `$(echo \`id\`)`
- history-expansion bang
- glob metas: `*`, `?`, `[abc]`, `{a,b}`
- redirection / process substitution: `>`, `<`, `<(…)`, `&`, `&&`
- leading hyphen — intentionally NOT quoted (in the safe-char allowlist), with a comment pinning that decision so a future "tighten this" PR is a deliberate contract change rather than a drive-by
- NUL byte — preserved verbatim; what the receiving shell does with it is outside this primitive's contract
- value that is itself a single quote: `'` → `''\\'''`
- escape sequence intact next to other quoted content
- `shellQuoteAll([])` → empty string
- `shellQuoteAll` mixed safe/unsafe order preservation

## Why
Closes #1087. The issue body claimed there was no test file at all; that was true when filed but the file exists today with 5 basic cases. This PR fills in the edge-case coverage the issue specifically named (NUL, `$()` nesting, leading `-`, embedded quotes, empty args) plus the obvious neighbours.

## Risk
None — additions only, no runtime code changes. Existing contract holds for every new case; we are documenting it, not changing it.

## Rollback
`git revert` is enough.

## Verification
- [x] `npx vitest run tests/backend/shell_quote.test.ts` → **17 tests passed** (5 existing + 12 new)
- [x] `npm run lint` → 0 errors, 446 warnings (unchanged)
- [x] `npm run check:arch` → all green
- [ ] /verify on FCoS box — N/A: test file, no runtime surface
- **Note on the security gate:** opened as draft because the issue carries the `security` label. The change is test-only (no shipping code touched), so the merge-side risk is essentially nil — but the gate stays per the autoloop rule. Reviewer can flip to ready-to-merge once they've eyeballed the assertions match the intended contract.