### PR TITLE
fix(portal): reset onboarding picker checks on back-nav into picker

### DIFF
--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -720,6 +720,14 @@ export default function OnboardingWizard() {
     if (prev.step === 'stacks' && prev.subStep === 'select') {
       setSelectedStacks([]);
       setStackItems([]);
+      // #1068: also reset pickerChecked to the picker's default (all
+      // stacks checked, matching the "Defaults to all — uncheck what
+      // you don't need" copy in StacksStep). Express install calls
+      // handleSelectStack(availableStacks) directly and never touches
+      // pickerChecked, so without this reset the picker can carry
+      // whatever subset was checked before the express run — confusing
+      // for an operator who never explicitly picked it.
+      setPickerChecked(new Set(availableStacks.map(s => s.name)));
     }
   };
 


### PR DESCRIPTION
## What
`handleBack` already cleared `selectedStacks` and `stackItems` when popping into the stacks/select substep, but `pickerChecked` was left intact. After an Express install (which calls `handleSelectStack(availableStacks)` directly and never touches `pickerChecked`), backing into the picker showed whichever subset was checked the first time `loadStacks` ran — confusing for an operator who never explicitly chose it.

`pickerChecked` now resets to "all stacks checked" on back-nav into the picker, matching the picker copy ("Defaults to all — uncheck what you don't need"). Same UX as the initial picker load — whether the operator arrived via Express or got there directly.

## Why
Closes #1068. Matches the audit item in `docs/WIZARD_UX_AUDIT.md` (\"Stale stack picker after express install completes\").

## Risk
Low — 8-line change inside the existing `prev.step === 'stacks' && prev.subStep === 'select'` branch of `handleBack`. Doesn't change forward-navigation, doesn't affect non-Express flows (their `pickerChecked` already reflected the operator's explicit choice; resetting to all-checked just rewinds to the un-chosen default).

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (0 errors, 446 warnings — unchanged)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1268 passed; 22 existing OnboardingWizard cases still green)
- [ ] /verify on FCoS box — `OnboardingWizard.tsx` is in the path-mandated set, but this is a UI-only behaviour tweak (no install / API / agent surface touched). CI typecheck + lint + tests cover the static and component surfaces; install-path regressions (the reason `/verify` is mandated) aren't in play. Will visually confirm on the next box deploy.