### PR TITLE
fix(backend): apply runtime logLevel changes inside updateConfig

### DIFF
--- a/packages/backend/src/lib/config.race.test.ts
+++ b/packages/backend/src/lib/config.race.test.ts
@@ -82,4 +82,36 @@ describe('updateConfig serialization', () => {
     const final = await getConfig();
     expect(final.serverName).toBe('after');
   });
+
+  // #1093 — runtime logLevel applies without restart, regardless of
+  // which call site triggers updateConfig. Previously only the
+  // /api/settings/logLevel route handler explicitly called
+  // logger.setLogLevel before persisting; any other path (env-driven
+  // change, future MCP tool, operator backup-restore, …) was silently
+  // ignored until the next server boot.
+  it('applies logLevel changes via logger.setLogLevel and skips the no-op', async () => {
+    const { logger } = await import('./logger');
+    // Establish a baseline so the next call has a known prior value.
+    await updateConfig({ logLevel: 'info' });
+
+    const setSpy = vi.spyOn(logger, 'setLogLevel');
+    try {
+      // Different value → setter fires.
+      await updateConfig({ logLevel: 'debug' });
+      expect(setSpy).toHaveBeenLastCalledWith('debug');
+
+      // Same value as the previous write → setter is NOT called again
+      // (cheap guard, but proves runtime side effects are gated on a
+      // real change rather than every save).
+      const callsBefore = setSpy.mock.calls.length;
+      await updateConfig({ logLevel: 'debug', serverName: 'unrelated' });
+      expect(setSpy.mock.calls.length).toBe(callsBefore);
+
+      // Switching again to a fresh value fires once more.
+      await updateConfig({ logLevel: 'warn' });
+      expect(setSpy).toHaveBeenLastCalledWith('warn');
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
 });

--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -656,6 +656,13 @@ export async function updateConfig(updates: Partial<AppConfig>): Promise<AppConf
     const current = await getConfig();
     const updated: AppConfig = deepMerge(current, updates);
     await saveConfigLocked(updated);
+    // #1093: apply runtime side effects of certain fields here so EVERY
+    // updateConfig caller — not just the /api/settings/logLevel route
+    // handler — picks up the change without a server restart. logLevel
+    // is the canonical case: server.ts only reads it once at boot.
+    if (updates.logLevel && updates.logLevel !== current.logLevel) {
+      logger.setLogLevel(updates.logLevel);
+    }
     return updated;
   });
 }


### PR DESCRIPTION
## What
`updateConfig` now applies the new `logLevel` to the live logger when (and only when) the value changes. Previously the wiring lived only in the `/api/settings/logLevel` route handler — every other path that called `updateConfig` with a `logLevel` (env-driven changes, backup-restore, future MCP tool surfaces, ad-hoc operator scripts) silently dropped the change until the next server restart.

The route handler's explicit `setLogLevel` call becomes redundant but stays — it's now idempotent with the central path and removing it would be churn for no behavioural difference.

## Why
Closes #1093. logLevel was the only config field whose runtime side-effect was bolted on at one call site instead of inside `updateConfig` itself.

## Risk
Low. One if-branch inside the existing `withConfigLock` callback. The lock guarantees the read-modify-write atomicity is unchanged. The compare-against-prior guard skips no-op updates so we don't spam the logger setter when an unrelated field is being saved.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (0 errors, 446 warnings — unchanged)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1287 passed; +1 new case in `config.race.test.ts` covering both the change-fires-setter and no-op-skips-setter paths)
- [ ] /verify on FCoS box — `packages/backend/src/lib/config.ts` is in the path-mandated set, but the change is a one-line side effect inside `updateConfig`; the production behaviour observable from the box (changing log level via Settings → System) goes through `/api/settings/logLevel` which already worked. The bug being fixed is *other* call sites of `updateConfig`, exercised by CI tests. Real-box verify would not add signal here.