### PR TITLE
chore(lint): use vi.fn generic signature instead of named-but-unused mock args

### DIFF
--- a/packages/backend/src/lib/health/notificationBatcher.test.ts
+++ b/packages/backend/src/lib/health/notificationBatcher.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // guarantees the mock and the reference our assertions read are the
 // same vi.fn instance.
 const { sendEmailAlertMock } = vi.hoisted(() => ({
-  sendEmailAlertMock: vi.fn(async (_subject: string, _message: string) => undefined),
+  sendEmailAlertMock: vi.fn<(subject: string, message: string) => Promise<undefined>>(async () => undefined),
 }));
 vi.mock('@/lib/email', () => ({
   sendEmailAlert: sendEmailAlertMock,

--- a/tests/backend/migrateToPublic.test.ts
+++ b/tests/backend/migrateToPublic.test.ts
@@ -80,7 +80,7 @@ function makeDeps(opts: {
     if (patch.domain_names) host.domain_names = patch.domain_names.slice();
     if (typeof patch.certificate_id === 'number') host.certificate_id = patch.certificate_id;
   });
-  const writeConfig = vi.fn(async (_node: string, _path: string, _content: string) => undefined);
+  const writeConfig = vi.fn<(node: string, path: string, content: string) => Promise<undefined>>(async () => undefined);
   const requestCert = vi.fn(async (_url: string, _t: string, domain: string) => {
     if (opts.failApplyCertFor === domain) throw new Error(`forced cert-request failure for ${domain}`);
     return 999 + Math.floor(Math.random() * 100);


### PR DESCRIPTION
## What
Five lint warnings across two test files cleared by switching `vi.fn` mocks to use the generic-signature form that the rest of the suite already uses (see `stackRunner.test.ts:12`, `manifestAssembler.test.ts:12-14`).

Before:
\`\`\`ts
vi.fn(async (_node: string, _path: string, _content: string) => undefined)
\`\`\`
After:
\`\`\`ts
vi.fn<(node: string, path: string, content: string) => Promise<undefined>>(async () => undefined)
\`\`\`

Same type safety on the call surface, no body args, no `@typescript-eslint/no-unused-vars` complaint (the test-file ESLint config doesn't configure `argsIgnorePattern: "^_"`, so the underscore prefix didn't help here).

## Why
Second lint-sweep PR in this autoloop iteration. These five warnings were the next-largest in-scope bucket after #1123. Aligning the two outliers with the project's existing mock-typing convention.

## Risk
Trivially low. The mock's externally-visible signature is unchanged; the body never accessed the args. CI tests (1287 passing) confirm.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (443 → 438 warnings, 0 errors)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1287 passed)
- [ ] /verify on FCoS box — N/A: test-file-only change.