### PR TITLE
chore(lint): drop more named-but-unused mock and handler args

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.test.ts
@@ -80,7 +80,7 @@ describe('oidc_provider_reachable probe', () => {
   // proxied traffic.
   it('sends X-Forwarded-Proto: https and Host: auth.<publicDomain>', async () => {
     vi.mocked(getConfig).mockResolvedValue(baseConfig as never);
-    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async () =>
       new Response(JSON.stringify(validDiscovery), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },

--- a/packages/frontend/src/app/api/system/storage/route.ts
+++ b/packages/frontend/src/app/api/system/storage/route.ts
@@ -95,7 +95,7 @@ const GetQuery = z.object({ node: z.string().min(1) });
 
 export const GET = withApiHandler<undefined, z.infer<typeof GetQuery>>(
   { query: GetQuery },
-  async ({ query, request }) => {
+  async ({ query }) => {
   const nodeName = query.node;
 
   try {


### PR DESCRIPTION
## What
Two small lint cleanups from the autoloop's sweep step:

- **`oidcProviderReachable.test.ts`** — convert the fetch-mock to the project's `vi.fn<Sig>(impl)` generic shape (same pattern just landed in #1124 for `notificationBatcher` and `migrateToPublic`).
- **`api/system/storage/route.ts`** — the `GET` handler never reads `request`; drop it from the destructuring (`withApiHandler` accepts partial extracts).

Two files, 4 in-scope warnings cleared.

## Why
Third lint-sweep PR in this iteration. Bundled because they share the "named-but-unused arg" theme and one PR keeps the merge-queue lighter.

## Risk
Trivially low. Mock signature unchanged externally; route handler still receives the request through `withApiHandler`'s closure — just not destructured.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (438 → 434 warnings, 0 errors)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1287 passed)
- [ ] /verify on FCoS box — N/A: test file + a route-handler arg-shape change with no behaviour delta.