### PR TITLE
chore(lint): drop the never-called fetchOrClassify helper

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/domainUnreachable.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainUnreachable.ts
@@ -168,33 +168,22 @@ async function adguardResolves(domain: string, config: AppConfig): Promise<strin
   }
 }
 
-async function fetchOrClassify(url: string): Promise<{ ok: true; status: number; bodySnippet: string; headers: Headers } | { ok: false; reason: 'tls' | 'refused' | 'timeout' | 'dns' | 'other'; detail: string }> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const res = await fetch(url, { signal: controller.signal, redirect: 'manual' });
-    const body = await res.text().catch(() => '');
-    return { ok: true, status: res.status, bodySnippet: body.slice(0, 256), headers: res.headers };
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(msg)) return { ok: false, reason: 'dns', detail: msg };
-    if (/ECONNREFUSED/i.test(msg)) return { ok: false, reason: 'refused', detail: msg };
-    if (/aborted|timeout|ETIMEDOUT/i.test(msg)) return { ok: false, reason: 'timeout', detail: msg };
-    if (/certificate|TLS|SSL|self-signed|unable to verify/i.test(msg)) return { ok: false, reason: 'tls', detail: msg };
-    return { ok: false, reason: 'other', detail: msg };
-  } finally {
-    clearTimeout(timeout);
-  }
-}
+/** Shared return shape between the (currently sole) fetch helper and any
+ *  future siblings that classify network errors. fetchOrClassify lived
+ *  here previously as a public-DNS counterpart to fetchWithHostHeader;
+ *  it was never wired up and got dropped, leaving the type to document
+ *  the contract. */
+type ClassifiedFetchResult =
+  | { ok: true; status: number; bodySnippet: string; headers: Headers }
+  | { ok: false; reason: 'tls' | 'refused' | 'timeout' | 'dns' | 'other'; detail: string };
 
 /**
  * Probe NPM directly via the LAN IP with a `Host:` header — the
  * only way to test proxy routing without depending on a working
- * resolver. Same shape as `fetchOrClassify`. ServiceBay's container
- * shares the host's network namespace (hostNetwork), so `lanIp:80`
- * is just a TCP socket away.
+ * resolver. ServiceBay's container shares the host's network namespace
+ * (hostNetwork), so `lanIp:80` is just a TCP socket away.
  */
-async function fetchWithHostHeader(npmUrl: string, hostHeader: string): Promise<ReturnType<typeof fetchOrClassify> extends Promise<infer T> ? T : never> {
+async function fetchWithHostHeader(npmUrl: string, hostHeader: string): Promise<ClassifiedFetchResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {


### PR DESCRIPTION
## What
`fetchOrClassify` in `domainUnreachable.ts` was defined as an async function but never invoked — the only reference was the `ReturnType<typeof fetchOrClassify>` trick `fetchWithHostHeader` used to copy its return shape. Replaced the dead async function with a named `ClassifiedFetchResult` type alias that keeps the shape explicit.

## Why
Final lint-sweep PR of this iteration. Per `CLAUDE.md`: *"if you are certain that something is unused, you can delete it completely"* — `grep -rn fetchOrClassify packages/backend/src` confirms no callers anywhere in the tree.

## Risk
None. The deleted function was unreachable code; `fetchWithHostHeader`'s public shape is preserved via the named type.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (434 → 432 warnings, 0 errors)
- [x] `npm run check:arch` (all green)
- [x] `npx vitest run packages/backend/src/lib/diagnose/probes/domainUnreachable.test.ts` (6 passed)
- [ ] /verify on FCoS box — N/A: dead-code removal, no runtime surface.