### PR TITLE
fix(backend): route discovery's systemctl call through execArgv

### DIFF
--- a/packages/backend/src/lib/discovery.ts
+++ b/packages/backend/src/lib/discovery.ts
@@ -102,14 +102,16 @@ export async function discoverSystemdServices(connection?: PodmanConnection): Pr
         const discoveryHints: string[] = [];
 
         try {
-            // Try with the service name as is
-            let cmd = `systemctl --user show -p FragmentPath -p SourcePath "${serviceName}"`;
-            let { stdout } = await executor.exec(cmd);
+            // #1097: route systemctl through execArgv so the shell never
+            // sees serviceName as part of a command-line string. The
+            // upstream regex validator already constrains the input, but
+            // argv-based exec removes the shell-injection class entirely
+            // and matches the convention the rest of the codebase uses.
+            let { stdout } = await executor.execArgv(['systemctl', '--user', 'show', '-p', 'FragmentPath', '-p', 'SourcePath', serviceName]);
 
             // If empty output or properties missing, try appending .service if not present
             if ((!stdout || (!stdout.includes('FragmentPath=') && !stdout.includes('SourcePath='))) && !serviceName.endsWith('.service')) {
-                 cmd = `systemctl --user show -p FragmentPath -p SourcePath "${serviceName}.service"`;
-                 const res = await executor.exec(cmd);
+                 const res = await executor.execArgv(['systemctl', '--user', 'show', '-p', 'FragmentPath', '-p', 'SourcePath', `${serviceName}.service`]);
                  stdout = res.stdout;
             }
 

--- a/tests/backend/discovery.test.ts
+++ b/tests/backend/discovery.test.ts
@@ -17,9 +17,13 @@ describe('Discovery', () => {
 
     it('should identify a .container file in systemd dir as managed', async () => {
         const mockExec = vi.fn();
+        // #1097: systemctl now goes through execArgv. Mock both — exec
+        // is still used for `echo $HOME` (needs shell expansion).
+        const mockExecArgv = vi.fn();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (getExecutor as any).mockReturnValue({
             exec: mockExec,
+            execArgv: mockExecArgv,
             exists: vi.fn(),
         });
 
@@ -33,15 +37,16 @@ describe('Discovery', () => {
             }
         ]);
 
-        // Mock systemctl show to return the Quadlet path
-        mockExec.mockImplementation(async (cmd: string) => {
-            if (cmd.includes('systemctl --user show')) {
-                return { 
+        // Mock systemctl show (via execArgv) to return the Quadlet path
+        mockExecArgv.mockImplementation(async (argv: string[]) => {
+            if (argv[0] === 'systemctl' && argv.includes('show')) {
+                return {
                     stdout: `FragmentPath=/home/user/.config/containers/systemd/servicebay.container\nSourcePath=/home/user/.config/containers/systemd/servicebay.container\n`
                 };
             }
             return { stdout: '' };
         });
+        mockExec.mockResolvedValue({ stdout: '' });
 
         const services = await discoverSystemdServices(MOCK_NODE);
 
@@ -53,9 +58,11 @@ describe('Discovery', () => {
 
     it('should identify a .service file outside systemd dir as unmanaged', async () => {
         const mockExec = vi.fn();
+        const mockExecArgv = vi.fn();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (getExecutor as any).mockReturnValue({
             exec: mockExec,
+            execArgv: mockExecArgv,
             exists: vi.fn(),
         });
 
@@ -68,15 +75,16 @@ describe('Discovery', () => {
             }
         ]);
 
-        mockExec.mockImplementation(async (cmd: string) => {
-            if (cmd.includes('systemctl --user show')) {
+        mockExecArgv.mockImplementation(async (argv: string[]) => {
+            if (argv[0] === 'systemctl' && argv.includes('show')) {
                  // Return a path that is NOT in .config/containers/systemd
-                return { 
+                return {
                     stdout: `FragmentPath=/home/user/.config/systemd/user/manual.service\nSourcePath=/home/user/.config/systemd/user/manual.service\n`
                 };
             }
             return { stdout: '' };
         });
+        mockExec.mockResolvedValue({ stdout: '' });
 
         const services = await discoverSystemdServices(MOCK_NODE);
 


### PR DESCRIPTION
## What
`discovery.ts` built the `systemctl` invocation as a template string (`systemctl --user show -p FragmentPath "${serviceName}"`) and dispatched it through `executor.exec`, which goes through a shell. The serviceName is regex-validated upstream so the call was not currently exploitable, but the project's convention is to route values like this through `executor.execArgv` so the shell never sees them — eliminating the shell-injection class entirely instead of relying on the upstream regex to hold forever.

Two other `executor.exec` call sites in this file are intentional and stay:
- `executor.exec('echo $HOME')` — requires shell expansion of `$HOME`.
- `executor.exec('systemctl --user daemon-reload')` — static string, no interpolation.

## Why
Closes #1097.

## Risk
Low. `execArgv` runs `systemctl` with the same argv the shell would have produced for the unproblematic happy-path values. Output parsing and downstream branching are unchanged.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (0 errors, 432 warnings — unchanged)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1287 passed; `discovery.test.ts` mocks updated to dispatch on `argv[0]` for the new path)
- [ ] /verify on FCoS box — owed before merge: while `discovery.ts` itself is not in the path-mandated set, the security label gates this PR as a draft until a human reviews. Recommended box check: confirm `discoverSystemdServices` still classifies known Quadlets correctly on the live box.

## Security-gate notes (draft until reviewed)
- Opened as a draft because the issue carries the `security` label.
- The change is purely a dispatch-pattern swap; it does not loosen any check.
- After merge, the project's grep for unsafe shell template literals in backend src goes one step closer to zero.