### PR TITLE
test(frontend): cover ErrorActions component (six cases)

### DIFF
--- a/tests/frontend/ErrorActions.test.tsx
+++ b/tests/frontend/ErrorActions.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ErrorActions from '@/components/ErrorActions';
+
+// Project style uses plain Chai matchers (toBeDefined / toBe), not the
+// @testing-library/jest-dom matchers — see ConfirmModal.test.tsx + MobileNav.test.tsx.
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+describe('ErrorActions', () => {
+  const reset = vi.fn();
+
+  beforeEach(() => {
+    reset.mockClear();
+  });
+
+  it('renders the three baseline buttons with the supplied retry label', () => {
+    render(<ErrorActions reset={reset} retryLabel="Try again" />);
+
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Reload page' })).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Run diagnostics' })).toBeDefined();
+
+    // includeGoHome defaults to false — the global error boundary opts in,
+    // the dashboard one does not.
+    expect(screen.queryByRole('link', { name: 'Go home' })).toBeNull();
+  });
+
+  it('renders Go home only when includeGoHome is set', () => {
+    render(<ErrorActions reset={reset} retryLabel="Retry" includeGoHome />);
+    const home = screen.getByRole('link', { name: 'Go home' });
+    expect(home).toBeDefined();
+    expect(home.getAttribute('href')).toBe('/');
+  });
+
+  it('invokes reset() once per click', () => {
+    render(<ErrorActions reset={reset} retryLabel="Try again" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('points "Run diagnostics" at /health', () => {
+    render(<ErrorActions reset={reset} retryLabel="Try again" />);
+    expect(screen.getByRole('link', { name: 'Run diagnostics' }).getAttribute('href')).toBe('/health');
+  });
+
+  it('exposes the consequence of each action via the title attribute (hover discoverability)', () => {
+    render(<ErrorActions reset={reset} retryLabel="Try again" />);
+    expect(screen.getByRole('button', { name: 'Try again' }).getAttribute('title')).toBe('Re-render this view');
+    expect(screen.getByRole('button', { name: 'Reload page' }).getAttribute('title')).toBe('Reload the page from the server');
+    expect(screen.getByRole('link', { name: 'Run diagnostics' }).getAttribute('title')).toBe('Run self-diagnostics to find the root cause');
+  });
+
+  it('reload-page button triggers window.location.reload', () => {
+    const reloadSpy = vi.fn();
+    const original = window.location;
+    // jsdom's window.location.reload is the no-op stub; replace it with a spy.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...original, reload: reloadSpy },
+    });
+    try {
+      render(<ErrorActions reset={reset} retryLabel="Try again" />);
+      fireEvent.click(screen.getByRole('button', { name: 'Reload page' }));
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: original });
+    }
+  });
+});


### PR DESCRIPTION
## What
Phase-2 starter for #1086 frontend test coverage. Adds 6 cases for `ErrorActions.tsx` — the shared CTA component that backs both `error.tsx` boundaries. The component shipped without a test in #1112; this fills that gap.

Cases:
- Baseline buttons render with the supplied retry label
- `includeGoHome` toggles the Go-home link in / out
- `reset()` fires exactly once per Retry click
- "Run diagnostics" link points at `/health`
- Every button carries its consequence-copy `title` attribute (hover discoverability)
- "Reload page" button triggers `window.location.reload`

## Why
Towards #1086. The issue body says "one test file across 256 source files" — current state is actually 19 frontend test files (count via `find tests/frontend packages/frontend -name "*.test.*"`), so the gap is moderate-and-uneven rather than complete-absence. Adding more focused tests per component closes it incrementally. Will comment on #1086 with the current state so it can be rescoped.

## Risk
None — additive test only, no runtime code touched.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (0 errors, 428 warnings — unchanged)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1305 passed, +6 new)
- [ ] /verify on FCoS box — N/A: test file only.

## Notes
- Used plain Chai matchers (`toBeDefined` / `toBe` / `getAttribute`) per project convention; the codebase does not have `@testing-library/jest-dom` wired up.
- This does NOT close #1086 — the ticket targets broad coverage. Just chipping at the surface.