### PR TITLE
fix(api): replace any with structural types in service action-stream

### DIFF
--- a/packages/frontend/src/app/api/services/[name]/action-stream/route.ts
+++ b/packages/frontend/src/app/api/services/[name]/action-stream/route.ts
@@ -72,20 +72,30 @@ export const POST = withApiHandlerParams<z.infer<typeof Body>, z.infer<typeof Qu
             if (yamlPath) {
               await write(`Found YAML configuration: ${yamlPath}`);
               const content = await executor.readFile(yamlPath);
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const parsed = yaml.load(content) as any;
+              const parsed = yaml.load(content);
+
+              // Minimal structural shape for the recursive image-scan
+              // walk. We only need to peek at four shape-typical fields
+              // (image / containers / initContainers / spec / template);
+              // everything else stays unknown so a malformed YAML can't
+              // tempt us into trusting a field that isn't there.
+              interface KubeNode {
+                  image?: unknown;
+                  containers?: unknown;
+                  initContainers?: unknown;
+                  spec?: unknown;
+                  template?: unknown;
+              }
 
               const images = new Set<string>();
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const findImages = (obj: any) => {
-                  if (!obj) return;
-                  if (obj.image && typeof obj.image === 'string') images.add(obj.image);
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  if (Array.isArray(obj.containers)) obj.containers.forEach((c: any) => findImages(c));
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  if (Array.isArray(obj.initContainers)) obj.initContainers.forEach((c: any) => findImages(c));
-                  if (obj.spec) findImages(obj.spec);
-                  if (obj.template) findImages(obj.template);
+              const findImages = (obj: unknown): void => {
+                  if (!obj || typeof obj !== 'object') return;
+                  const node = obj as KubeNode;
+                  if (typeof node.image === 'string') images.add(node.image);
+                  if (Array.isArray(node.containers)) node.containers.forEach(findImages);
+                  if (Array.isArray(node.initContainers)) node.initContainers.forEach(findImages);
+                  if (node.spec) findImages(node.spec);
+                  if (node.template) findImages(node.template);
               };
               findImages(parsed);
 
@@ -139,10 +149,9 @@ export const POST = withApiHandlerParams<z.infer<typeof Body>, z.infer<typeof Qu
             // and -l for full lines. PTY preserves color codes.
             const { stdout, stderr, promise } = executor.spawn(`systemctl --user status ${name}.service --no-pager -l`, { pty: true, cols: 160 });
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const streamToWriter = async (stream: any) => {
+            const streamToWriter = async (stream: AsyncIterable<unknown>) => {
                 for await (const chunk of stream) {
-                    await writeRaw(chunk.toString());
+                    await writeRaw(String(chunk));
                 }
             };
 


### PR DESCRIPTION
## What
Tightens the type surface in `packages/frontend/src/app/api/services/[name]/action-stream/route.ts`. Removes **5 `any` casts** and the **5 `eslint-disable` directives** that suppressed them — all in one file.

- The recursive image-scan walker (`findImages`) now declares a minimal `KubeNode` shape (image / containers / initContainers / spec / template — all `unknown`) and walks on `unknown` with a `typeof === 'object'` guard at every recursion entry. A malformed YAML can't pretend a field exists.
- The spawn-stream pipe (`streamToWriter`) switches from `(stream: any)` to `(stream: AsyncIterable<unknown>)` and stringifies chunks via `String()` instead of `chunk.toString()`. Same runtime behaviour, no trust in a shape we never validated.

## Why
Phase-1 slice of #1095 (122 `any` uses + 27 `eslint-disable` directives across the frontend). One of the larger single-file clusters; tackling them file-by-file keeps each PR small.

## Risk
Low. Behaviour unchanged — every code path that ran before still runs the same way. The type tightening only narrows what the compiler will let *future* code do; existing callers stay exactly the same on the wire.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (428 warnings — unchanged; `any` uses in this file were already inside `eslint-disable` blocks, so the count won't move until enough files are cleaned to delete the disables)
- [x] `npm test` (1305 passed)
- [ ] /verify on FCoS box — N/A: behaviour-preserving type narrowing, no observable surface change.

## Tracking
Issue #1095 stays open — this is one of the larger any clusters (5 / 122 frontend any uses cleared, 5 / 27 eslint-disable directives cleared). Will comment on #1095 with the running progress.