### PR TITLE
feat(api-client): add apiFetch wrapper that handles 401 redirects

### DIFF
--- a/packages/api-client/src/apiFetch.ts
+++ b/packages/api-client/src/apiFetch.ts
@@ -1,0 +1,61 @@
+// #1102 Phase 1: client-side fetch wrapper that handles 401 redirects.
+//
+// Replaces the global window.fetch monkey-patch in DigitalTwinProvider
+// with an opt-in helper. Phase 2 removes the monkey-patch and Phase 3
+// migrates raw fetch('/api/...') call sites onto this wrapper.
+//
+// The 401 → /login redirect logic is preserved one-to-one from the
+// previous monkey-patch (DigitalTwinProvider.tsx:25-50), including:
+//   - the ANONYMOUS_PATHS guard against bouncing /login or /portal
+//     visitors mid-load
+//   - the /portal/* subtree being anonymous-readable (the family
+//     portal is intentionally world-readable)
+//   - the "only redirect for our own /api/ URLs" check so a 401 from
+//     an external fetch doesn't kick the user to login
+//
+// Server-side import is a no-op: the `typeof window === 'undefined'`
+// short-circuit returns the original response unchanged so SSR / route
+// handlers that pull this in transitively don't crash on `window.*`.
+// For JSON validation paired with the fetch, use the sibling
+// `typedFetch` — apiFetch is the Response-returning baseline.
+
+const ANONYMOUS_PATHS = new Set(['/login', '/portal']);
+
+function isAnonymousPathname(pathname: string): boolean {
+  return ANONYMOUS_PATHS.has(pathname) || pathname.startsWith('/portal/');
+}
+
+function extractUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return '';
+}
+
+function isOwnApiUrl(url: string): boolean {
+  if (url.startsWith('/api/')) return true;
+  if (typeof window === 'undefined') return false;
+  return url.startsWith(`${window.location.origin}/api/`);
+}
+
+/**
+ * Drop-in replacement for window.fetch that redirects to /login on a
+ * 401 response from our own /api/* routes. Kept Response-returning so
+ * existing callers can swap `fetch(...)` for `apiFetch(...)` with zero
+ * other changes.
+ */
+export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const response = await fetch(input, init);
+
+  if (response.status !== 401) return response;
+  if (typeof window === 'undefined') return response;
+
+  const pathname = window.location.pathname;
+  if (isAnonymousPathname(pathname)) return response;
+
+  const url = extractUrl(input);
+  if (!isOwnApiUrl(url)) return response;
+
+  window.location.href = '/login';
+  return response;
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -14,5 +14,6 @@ export * from './install';
 export * from './services';
 export * from './serviceView';
 export * from './client';
+export * from './apiFetch';
 export * from './lib-types';
 export * from './lib-utils';

--- a/tests/frontend/apiFetch.test.ts
+++ b/tests/frontend/apiFetch.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { apiFetch } from '@servicebay/api-client';
+
+// #1102 Phase 1 — pin the 401-redirect contract so Phase 3's
+// migration sweep can swap fetch → apiFetch with confidence.
+
+describe('apiFetch', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let originalLocation: Location;
+  let assignedHref: string | null;
+
+  beforeEach(() => {
+    assignedHref = null;
+    originalLocation = window.location;
+    // Replace window.location with a proxy that records href assignments
+    // so we can assert without actually navigating jsdom.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new Proxy({} as Location, {
+        get: (_t, prop) => {
+          if (prop === 'pathname') return assignedHref ?? '/services';
+          if (prop === 'origin') return 'http://localhost:5888';
+          if (prop === 'href') return `http://localhost:5888${assignedHref ?? '/services'}`;
+          return undefined;
+        },
+        set: (_t, prop, value) => {
+          if (prop === 'href') assignedHref = value;
+          return true;
+        },
+      }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchSpy = vi.spyOn(globalThis, 'fetch' as any);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
+  function setPathname(pathname: string) {
+    // The Proxy reads pathname from assignedHref's path; setting it via
+    // a manual override is simpler.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new Proxy({} as Location, {
+        get: (_t, prop) => {
+          if (prop === 'pathname') return pathname;
+          if (prop === 'origin') return 'http://localhost:5888';
+          if (prop === 'href') return `http://localhost:5888${pathname}`;
+          return undefined;
+        },
+        set: (_t, prop, value) => {
+          if (prop === 'href') assignedHref = value;
+          return true;
+        },
+      }),
+    });
+  }
+
+  it('passes 200 responses through untouched', async () => {
+    setPathname('/services');
+    fetchSpy.mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+    const res = await apiFetch('/api/services');
+    expect(res.status).toBe(200);
+    expect(assignedHref).toBeNull();
+  });
+
+  it('redirects to /login on a 401 from our own /api/ URL', async () => {
+    setPathname('/services');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    await apiFetch('/api/services');
+    expect(assignedHref).toBe('/login');
+  });
+
+  it('does NOT redirect when already on /login', async () => {
+    setPathname('/login');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    await apiFetch('/api/services');
+    expect(assignedHref).toBeNull();
+  });
+
+  it('does NOT redirect when on /portal (anonymous root)', async () => {
+    setPathname('/portal');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    await apiFetch('/api/services');
+    expect(assignedHref).toBeNull();
+  });
+
+  it('does NOT redirect when on a /portal/* subpath', async () => {
+    setPathname('/portal/family');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    await apiFetch('/api/services');
+    expect(assignedHref).toBeNull();
+  });
+
+  it('does NOT redirect on a 401 from an external URL', async () => {
+    setPathname('/services');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    await apiFetch('https://example.com/some-route');
+    expect(assignedHref).toBeNull();
+  });
+
+  it('handles absolute-origin /api/ URLs (treated as own)', async () => {
+    setPathname('/services');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    await apiFetch('http://localhost:5888/api/services');
+    expect(assignedHref).toBe('/login');
+  });
+
+  it('accepts a Request object as input', async () => {
+    setPathname('/services');
+    fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    // jsdom's Request constructor requires absolute URLs.
+    await apiFetch(new Request('http://localhost:5888/api/services'));
+    expect(assignedHref).toBe('/login');
+  });
+});


### PR DESCRIPTION
## What
Phase 1 of #1102's scoping plan. Adds `packages/api-client/src/apiFetch.ts` — the opt-in fetch wrapper that will replace the global `window.fetch` monkey-patch DigitalTwinProvider currently installs.

The wrapper lives next to `typedFetch`:
- `typedFetch` — JSON-validated, throws on schema mismatch
- `apiFetch` — Response-returning, handles 401 redirects

Both are exported from `@servicebay/api-client`.

The 401 redirect logic preserves the previous monkey-patch's contract one-to-one:
- `ANONYMOUS_PATHS` guard against bouncing /login or /portal visitors mid-load (#854)
- `/portal/*` subtree anonymous-readable (family portal world-readable)
- Only-our-own-`/api/` URL check so a 401 from an external fetch does NOT redirect

Server-side import is a no-op: the `typeof window === 'undefined'` short-circuit returns the original response unchanged so SSR / route handlers that pull this in transitively don't crash on `window.*`.

## Why
Closes Phase 1 of #1102. Phase 2 (remove the monkeypatch) and Phase 3 (migrate raw `fetch('/api/...')` sites to `apiFetch`) stay open — keeping each phase to its own PR per the scoping plan.

## Risk
Zero in production. **Nothing in the tree calls `apiFetch` yet** — this PR only adds the helper and a test suite. The current monkey-patch keeps protecting every fetch as before. Phase 2 is the actual cutover.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (428 warnings — unchanged)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1313 passed; +8 new `apiFetch` regression cases pin the 401-redirect contract)
- [ ] /verify on FCoS box — N/A: new helper, no caller yet, no observable behaviour change in the app.

## Test contract (the 8 new cases)
1. 200 passes through
2. 401 from `/api/*` → `/login` redirect
3. 401 on `/login` → no redirect
4. 401 on `/portal` → no redirect
5. 401 on `/portal/family` → no redirect
6. 401 on external URL → no redirect
7. 401 on absolute-origin `/api/*` → redirect
8. `Request` object input → redirect

## Tracking
Phase 1 of #1102. Issue stays open.