### PR TITLE
feat(frontend): add FocusTrap component and wire it into FileViewerOverlay

### DIFF
--- a/packages/frontend/src/components/FileViewerOverlay.tsx
+++ b/packages/frontend/src/components/FileViewerOverlay.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertCircle, FileText, RefreshCw, X } from 'lucide-react';
 import FileViewer from '@/components/FileViewer';
+import FocusTrap from '@/components/FocusTrap';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 
 interface FileViewerOverlayProps {
@@ -106,8 +107,9 @@ export default function FileViewerOverlay({ isOpen, path, nodeName, onClose }: F
   }
 
   return (
-    <div className="fixed inset-0 z-[120] flex items-stretch justify-center p-0 md:p-6" onMouseDown={stopEventPropagation} onClick={stopEventPropagation}>
+    <div className="fixed inset-0 z-[120] flex items-stretch justify-center p-0 md:p-6" onMouseDown={stopEventPropagation} onClick={stopEventPropagation} role="dialog" aria-modal="true" aria-label={`File viewer: ${path}`}>
       <div className="absolute inset-0 bg-gray-950/70 backdrop-blur-sm" onMouseDown={stopEventPropagation} onClick={handleBackdropClick} />
+      <FocusTrap>
       <div className="relative z-10 flex w-full h-full max-w-full flex-col rounded-none border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-2xl md:h-auto md:max-h-[90vh] md:max-w-5xl md:rounded-2xl">
         <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 px-5 py-4">
           <div className="flex flex-col gap-1 text-sm">
@@ -146,6 +148,7 @@ export default function FileViewerOverlay({ isOpen, path, nodeName, onClose }: F
           )}
         </div>
       </div>
+      </FocusTrap>
     </div>
   );
 }

--- a/packages/frontend/src/components/FocusTrap.tsx
+++ b/packages/frontend/src/components/FocusTrap.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useRef, ReactNode } from 'react';
+
+// #1090 Phase 1: focus trap for overlay dialogs.
+//
+// Mount-time: remember the previously-focused element, focus the first
+// focusable child of the trap.
+// Unmount-time: restore focus to the previously-focused element.
+// Tab / Shift+Tab while mounted: cycle within the trap so keyboard
+// users can't accidentally land on background controls behind the
+// overlay.
+//
+// Phase 2 will add aria-modal + aria-label wiring at each overlay
+// callsite; this component just owns the focus behaviour.
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+interface FocusTrapProps {
+  /** Whether the trap is currently active. Mounting/unmounting the
+   *  component is the usual on/off; `active=false` is a per-render
+   *  escape hatch for cases where the parent needs to keep the trap
+   *  in the React tree but wants focus to fall through. */
+  active?: boolean;
+  children: ReactNode;
+}
+
+function getFocusable(root: HTMLElement): HTMLElement[] {
+  // We don't filter by visibility (offsetParent / getClientRects) because
+  // jsdom returns null for those even on rendered elements — that would
+  // make the trap untestable. Aria-hidden subtrees are excluded since
+  // those are the conventional "don't focus me" marker in overlay code.
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter(el => el.closest('[aria-hidden="true"]') === null);
+}
+
+export default function FocusTrap({ active = true, children }: FocusTrapProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const root = rootRef.current;
+    if (!root) return;
+
+    // Remember the element that had focus before we mounted so we can
+    // restore it on unmount. document.activeElement is safe to read
+    // even when nothing is focused (it falls back to <body>).
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+
+    const focusables = getFocusable(root);
+    const initial = focusables[0] ?? root;
+    initial.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const currentFocusables = getFocusable(root);
+      if (currentFocusables.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = currentFocusables[0];
+      const last = currentFocusables[currentFocusables.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (activeEl === first || !root.contains(activeEl)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (activeEl === last || !root.contains(activeEl)) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    root.addEventListener('keydown', handleKeyDown);
+    return () => {
+      root.removeEventListener('keydown', handleKeyDown);
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [active]);
+
+  return (
+    <div ref={rootRef} tabIndex={-1} style={{ outline: 'none' }}>
+      {children}
+    </div>
+  );
+}

--- a/tests/frontend/FocusTrap.test.tsx
+++ b/tests/frontend/FocusTrap.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import FocusTrap from '@/components/FocusTrap';
+
+// #1090 Phase 1 — pins the focus-trap contract:
+// - mount focuses the first focusable child
+// - Tab from the last focusable wraps to the first
+// - Shift+Tab from the first wraps to the last
+// - unmount restores focus to the previously-focused element
+
+describe('FocusTrap', () => {
+  it('focuses the first focusable child on mount', () => {
+    render(
+      <FocusTrap>
+        <button>first</button>
+        <button>second</button>
+      </FocusTrap>,
+    );
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'first' }));
+  });
+
+  it('Tab from the last focusable wraps back to the first', () => {
+    render(
+      <FocusTrap>
+        <button>first</button>
+        <button>last</button>
+      </FocusTrap>,
+    );
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(last, { key: 'Tab' });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('Shift+Tab from the first focusable wraps to the last', () => {
+    render(
+      <FocusTrap>
+        <button>first</button>
+        <button>last</button>
+      </FocusTrap>,
+    );
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    first.focus();
+
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('non-Tab keys pass through (no preventDefault)', () => {
+    render(
+      <FocusTrap>
+        <button>only</button>
+      </FocusTrap>,
+    );
+    const button = screen.getByRole('button', { name: 'only' });
+    const evt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    button.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it('restores focus to the previously-focused element on unmount', () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    const { unmount } = render(
+      <FocusTrap>
+        <button>inside</button>
+      </FocusTrap>,
+    );
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'inside' }));
+
+    unmount();
+    expect(document.activeElement).toBe(outside);
+    document.body.removeChild(outside);
+  });
+
+  it('active=false skips the trap (no focus capture, no key handling)', () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+    outside.focus();
+
+    render(
+      <FocusTrap active={false}>
+        <button>inside</button>
+      </FocusTrap>,
+    );
+
+    // Mount did NOT steal focus.
+    expect(document.activeElement).toBe(outside);
+    document.body.removeChild(outside);
+  });
+});


### PR DESCRIPTION
## What
Phase 1 of #1090's a11y scoping plan. Adds `packages/frontend/src/components/FocusTrap.tsx` and wires it into `FileViewerOverlay`.

The trap owns the focus behaviour for overlay dialogs:
- Mount captures the previously-focused element and focuses the first focusable child.
- Tab from the last focusable wraps to the first; Shift+Tab from the first wraps to the last.
- Unmount restores focus to the captured previous element.
- `active=false` skips the trap (escape hatch for parents that keep it mounted but want focus to fall through).

`FileViewerOverlay` now wraps its inner panel in `<FocusTrap>` and adds `role="dialog"` + `aria-modal="true"` + `aria-label` — the bare minimum the trap needs to be meaningful.

## Why
Closes Phase 1 of #1090. Phase 2 (semantic HTML + aria across dashboards) stays open.

## Risk
Low. The trap is opt-in; only FileViewerOverlay uses it. Non-overlay code paths are untouched. The aria-hidden filter uses `closest()` rather than `offsetParent` visibility — jsdom-friendly, and aria-hidden is the conventional don't-focus signal in overlay code anyway.

## Rollback
`git revert` is enough.

## Verification
- [x] `npm run lint` (428 warnings — unchanged)
- [x] `npm run check:arch` (all green)
- [x] `npm test` (1319 passed; +6 new FocusTrap regression cases)
- [ ] /verify on FCoS box — N/A: new helper component + one overlay wiring; not in path-mandated paths.

## Test contract (the 6 new cases)
1. Mount focuses first focusable child
2. Tab from last wraps to first
3. Shift+Tab from first wraps to last
4. Non-Tab keys pass through (no preventDefault)
5. Unmount restores focus to previously-focused element
6. `active=false` skips the trap

## Tracking
Phase 1 of #1090.