### PR TITLE
feat(backend): add schemaVersion field to AppConfig

### DIFF
--- a/packages/backend/src/lib/config.race.test.ts
+++ b/packages/backend/src/lib/config.race.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/lib/secrets', () => ({
 
 const TEST_DIR = path.join(os.tmpdir(), `sb-config-race-${process.pid}`);
 
-import { updateConfig, getConfig, getJobLogLimits, DEFAULT_MAX_JOB_LOG_LINES, DEFAULT_MAX_JOB_LOG_BYTES } from './config';
+import { updateConfig, getConfig, getJobLogLimits, DEFAULT_MAX_JOB_LOG_LINES, DEFAULT_MAX_JOB_LOG_BYTES, getSchemaVersion, CURRENT_SCHEMA_VERSION } from './config';
 
 beforeEach(async () => {
   await fs.mkdir(TEST_DIR, { recursive: true });
@@ -156,5 +156,40 @@ describe('getJobLogLimits (#1098)', () => {
     const limits = getJobLogLimits(config);
     expect(limits.maxLines).toBe(123);
     expect(limits.maxBytes).toBe(4567);
+  });
+});
+
+// #1099 Phase 1 — schemaVersion field on the persisted config document.
+// Phase 2 wires the migration ledger; this PR establishes the baseline.
+describe('getSchemaVersion (#1099)', () => {
+  it('returns 1 (baseline) when the field is absent', () => {
+    expect(getSchemaVersion({ autoUpdate: { enabled: true, schedule: '0 0 * * *' } })).toBe(1);
+  });
+
+  it('returns the persisted value when present', () => {
+    expect(getSchemaVersion({
+      autoUpdate: { enabled: true, schedule: '0 0 * * *' },
+      schemaVersion: 7,
+    })).toBe(7);
+  });
+
+  it('CURRENT_SCHEMA_VERSION is 1 in Phase 1 — Phase 2 bumps this when migrations land', () => {
+    // Pin the current version so a future bump is an intentional act,
+    // not an accidental tweak that drifts past the migration ledger.
+    expect(CURRENT_SCHEMA_VERSION).toBe(1);
+  });
+
+  it('fresh-init configs (no file on disk) include the current schemaVersion', async () => {
+    // Wipe so getConfig returns DEFAULT_CONFIG.
+    await fs.rm(path.join(TEST_DIR, 'config.json'), { force: true });
+    const config = await getConfig();
+    expect(config.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(getSchemaVersion(config)).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it('updateConfig persists schemaVersion and getSchemaVersion reads it back', async () => {
+    await updateConfig({ schemaVersion: 1 });
+    const config = await getConfig();
+    expect(getSchemaVersion(config)).toBe(1);
   });
 });

--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -143,6 +143,19 @@ export interface AgentConfig {
 }
 
 export interface AppConfig {
+  /**
+   * Schema version of the persisted `config.json` document (#1099 Phase 1).
+   * `1` is the baseline — every shape that existed before this field was
+   * introduced. Future breaking changes bump this number and add a
+   * migration step to Phase 2's migration ledger; on startup the ledger
+   * walks from the persisted version to `CURRENT_SCHEMA_VERSION`.
+   *
+   * Optional in the interface because legacy configs persisted before
+   * this PR don't carry the field — the ConfigTransformer below stamps
+   * them with `1` on first read so downstream code can rely on
+   * `getSchemaVersion()` returning a number.
+   */
+  schemaVersion?: number;
   logLevel?: LogLevel;
   serverName?: string; // Custom display name for this server
   domain?: string; // Optional domain for display
@@ -416,6 +429,21 @@ export function getJobLogLimits(config: AppConfig): { maxLines: number; maxBytes
   };
 }
 
+// #1099 Phase 1: schema version of the persisted config document.
+// Phase 2 will introduce a migration ledger that walks `persisted →
+// CURRENT_SCHEMA_VERSION` on startup; this PR establishes the baseline
+// so the ledger has a number to walk from. Legacy configs missing the
+// field are stamped `1` by the ConfigTransformer below, so in-memory
+// configs always carry a value once they've passed through migrateConfig().
+export const CURRENT_SCHEMA_VERSION = 1;
+
+export function getSchemaVersion(config: AppConfig): number {
+  // Fallback to 1 (the baseline) rather than CURRENT — a legacy config
+  // missing the field represents v1 data, regardless of where CURRENT
+  // moves to in the future.
+  return config.schemaVersion ?? 1;
+}
+
 export interface ServicePostDeployRecord {
   /** ISO timestamp of when the script finished (success or failure). */
   lastRunAt: string;
@@ -529,6 +557,7 @@ const normalizeExternalLinks = (links?: ExternalLink[]): ExternalLink[] | undefi
 };
 
 const DEFAULT_CONFIG: AppConfig = {
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   templateSettings: {},
   logLevel: 'info',
   agent: {

--- a/packages/backend/src/lib/config/transformer.test.ts
+++ b/packages/backend/src/lib/config/transformer.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { ConfigTransformer } from './transformer';
+
+let workDir: string;
+let configPath: string;
+
+beforeEach(async () => {
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-config-transformer-'));
+  configPath = path.join(workDir, 'config.json');
+});
+
+afterEach(async () => {
+  await fs.rm(workDir, { recursive: true, force: true });
+});
+
+async function writeConfig(data: unknown) {
+  await fs.writeFile(configPath, JSON.stringify(data));
+}
+
+async function readConfig(): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(configPath, 'utf-8'));
+}
+
+describe('ConfigTransformer (#1099 schema-version-baseline)', () => {
+  it('stamps schemaVersion: 1 on legacy configs missing the field', async () => {
+    await writeConfig({ serverName: 'legacy-box' });
+    const changed = await new ConfigTransformer(configPath).run();
+    expect(changed).toBe(true);
+    const after = await readConfig();
+    expect(after.schemaVersion).toBe(1);
+    expect(after.serverName).toBe('legacy-box');
+  });
+
+  it('leaves existing schemaVersion alone (no overwrite)', async () => {
+    await writeConfig({ schemaVersion: 5, serverName: 'time-traveller' });
+    const changed = await new ConfigTransformer(configPath).run();
+    expect(changed).toBe(false);
+    const after = await readConfig();
+    expect(after.schemaVersion).toBe(5);
+  });
+
+  it('writes nothing back when the config is already at baseline (idempotent)', async () => {
+    await writeConfig({ schemaVersion: 1, serverName: 'fresh-install' });
+    const before = await fs.stat(configPath);
+    const changed = await new ConfigTransformer(configPath).run();
+    expect(changed).toBe(false);
+    const after = await fs.stat(configPath);
+    // Idempotency check: untouched mtime means no .bak backup either,
+    // which is the contract for the no-op path.
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+});

--- a/packages/backend/src/lib/config/transformer.ts
+++ b/packages/backend/src/lib/config/transformer.ts
@@ -34,7 +34,22 @@ const renameExternalLinkTargets: ConfigTransform = {
     }
 };
 
-const transforms: ConfigTransform[] = [renameExternalLinkTargets];
+// #1099 Phase 1: stamp a baseline `schemaVersion: 1` on legacy configs
+// that pre-date the field. Phase 2's migration ledger reads this value
+// to decide which migrations to apply; without the stamp, every legacy
+// box would look like "no version at all" and the ledger would need
+// special-case handling for that. Stamping once at transform time lets
+// the rest of the codebase rely on the field being present.
+const stampSchemaVersion: ConfigTransform = {
+    name: 'schema-version-baseline',
+    run: (config) => {
+        if (typeof config.schemaVersion === 'number') return false;
+        config.schemaVersion = 1;
+        return true;
+    }
+};
+
+const transforms: ConfigTransform[] = [renameExternalLinkTargets, stampSchemaVersion];
 
 export class ConfigTransformer {
     constructor(private readonly configPath: string) {}

--- a/tests/backend/config_transformer.test.ts
+++ b/tests/backend/config_transformer.test.ts
@@ -45,6 +45,10 @@ describe('ConfigTransformer', () => {
 
     it('skips transformation when no legacy data is present', async () => {
         const config = {
+            // schemaVersion present so the #1099 baseline-stamp transform
+            // doesn't fire — this case is "fully migrated config, nothing
+            // to do" and should round-trip identically.
+            schemaVersion: 1,
             externalLinks: [
                 { id: 'modern', name: 'Modern', url: 'https://modern.example.com', ipTargets: ['192.168.1.2:443'] }
             ]


### PR DESCRIPTION
## What
Phase 1 of #1099. Adds optional `schemaVersion: number` to `AppConfig`, sets `CURRENT_SCHEMA_VERSION = 1` on fresh installs, and adds a `schema-version-baseline` ConfigTransformer step that stamps `1` on legacy configs missing the field.

`getSchemaVersion()` falls back to 1 (the baseline) rather than CURRENT so a legacy config keeps representing v1 data after Phase 2 bumps CURRENT to 2.

## Why
Closes #1099.

Phase 2 will introduce a migration ledger that walks `persisted → CURRENT_SCHEMA_VERSION` on startup; this PR is the baseline so the ledger has a number to walk from.

## Risk
Low. Pure additive change: field is optional in the interface, the transformer stamps legacy configs on first read (idempotent), and downstream code can rely on the field being present in-memory after `migrateConfig()` runs. No behavioural change to existing code paths.

## Rollback
`git revert` is enough — `schemaVersion: 1` stamped on existing config.json files is inert without Phase 2's ledger.

## Verification
- [x] npm run lint (0 errors; warnings unchanged on touched files)
- [x] npm run check:arch (invariants + depcruise green)
- [x] npm test (1331 passed, 2 skipped)
- [ ] /verify on FCoS box — config.ts is path-mandated; deferring to the merge gate