### PR TITLE
refactor(services): extract loadSystemdUnitInfo from getServiceFiles

### DIFF
--- a/packages/backend/src/lib/services/serviceListing.ts
+++ b/packages/backend/src/lib/services/serviceListing.ts
@@ -26,6 +26,32 @@ function extractFileContent(res: unknown): string {
     return '';
 }
 
+/**
+ * Resolve the systemd-generated unit content + on-disk FragmentPath
+ * for `<serviceName>.service`. Returns sentinel content when the unit
+ * hasn't been generated yet — getServiceFiles surfaces this to the
+ * UI without aborting the rest of the read.
+ */
+async function loadSystemdUnitInfo(
+    agent: import('../agent/handler').AgentHandler,
+    serviceName: string,
+): Promise<{ serviceContent: string; servicePath: string }> {
+    const unitNotFound = '# Service unit not found or not generated yet.';
+    try {
+        const catRes = await agent.sendCommand('exec', { command: `systemctl --user cat ${serviceName}.service` });
+        const serviceContent = catRes.code === 0 ? catRes.stdout : unitNotFound;
+        let servicePath = '';
+        const pathRes = await agent.sendCommand('exec', { command: `systemctl --user show -p FragmentPath ${serviceName}.service` });
+        if (pathRes.code === 0) {
+            const match = pathRes.stdout.match(/FragmentPath=(.+)/);
+            if (match) servicePath = match[1].trim();
+        }
+        return { serviceContent, servicePath };
+    } catch {
+        return { serviceContent: unitNotFound, servicePath: '' };
+    }
+}
+
 export interface ServiceInfo {
   name: string;
   kubeFile: string;
@@ -564,19 +590,7 @@ export class ServiceListing {
                 }
             }
 
-            // Get generated service unit content
-            try {
-                const catRes = await agent.sendCommand('exec', { command: `systemctl --user cat ${serviceName}.service` });
-                serviceContent = catRes.code === 0 ? catRes.stdout : '# Service unit not found or not generated yet.';
-
-                const pathRes = await agent.sendCommand('exec', { command: `systemctl --user show -p FragmentPath ${serviceName}.service` });
-                if (pathRes.code === 0) {
-                    const match = pathRes.stdout.match(/FragmentPath=(.+)/);
-                    if (match) servicePath = match[1].trim();
-                }
-            } catch {
-                serviceContent = '# Service unit not found or not generated yet.';
-            }
+            ({ serviceContent, servicePath } = await loadSystemdUnitInfo(agent, serviceName));
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             throw new Error(`Service ${serviceName} not found: ${msg}`);


### PR DESCRIPTION
## What
Bite-sized lint-sweep extraction in `packages/backend/src/lib/services/serviceListing.ts`. `getServiceFiles` was 57 lines, tripping `max-lines-per-function`. Pulling the systemctl `cat` + `FragmentPath` read into a new `loadSystemdUnitInfo` helper brings the parent under 50 and gives the "what unit did systemd actually write?" lookup a name.

## Why
Lint-sweep filler. serviceListing.ts had 5 warnings; the 57-line `getServiceFiles` was the only one tractable in a single bite-sized PR. `listServices` (254 lines, complexity 87) and `extractHostPorts` (complexity 23) need their own dedicated tickets.

## Risk
Low. Pure structural refactor — same systemctl commands, same sentinel content when the unit isn't generated yet, same try/catch boundary. The complexity warning on `getServiceFiles` drops 24 → 20 as a free side effect.

## Rollback
`git revert` is enough — single-file extraction, no API surface change.

## Verification
- [x] npm run lint (0 errors; warning count 426 → 425; file count 5 → 4)
- [x] npm run check:arch (invariants + depcruise green)
- [x] npm test (1331 passed, 2 skipped)