### PR TITLE
refactor(reverseProxy): extract findAutheliaConfigHostPath from locateConfig

### DIFF
--- a/packages/backend/src/lib/reverseProxy/migrateToPublic.ts
+++ b/packages/backend/src/lib/reverseProxy/migrateToPublic.ts
@@ -254,6 +254,27 @@ interface AutheliaDeps {
   restartAuth(node: string): Promise<void>;
 }
 
+/**
+ * Walk parsed auth-pod docs and return the first `hostPath` of a
+ * volume whose name contains "config", or `''` if none exists.
+ * This is where authelia's `configuration.yml` lives on disk on
+ * the node — locateConfig appends `/configuration.yml` to the
+ * returned value.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function findAutheliaConfigHostPath(docs: any[]): string {
+  for (const doc of docs) {
+    const volumes = doc?.spec?.volumes;
+    if (!Array.isArray(volumes)) continue;
+    for (const vol of volumes) {
+      if (vol.name?.includes('config') && vol.hostPath?.path) {
+        return vol.hostPath.path;
+      }
+    }
+  }
+  return '';
+}
+
 async function realAutheliaDeps(): Promise<AutheliaDeps> {
   const { agentManager } = await import('../agent/manager');
   return {
@@ -264,18 +285,7 @@ async function realAutheliaDeps(): Promise<AutheliaDeps> {
           if (!files.yamlContent) continue;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const docs = yaml.loadAll(files.yamlContent) as any[];
-          let configHostPath = '';
-          for (const doc of docs) {
-            const volumes = doc?.spec?.volumes;
-            if (!Array.isArray(volumes)) continue;
-            for (const vol of volumes) {
-              if (vol.name?.includes('config') && vol.hostPath?.path) {
-                configHostPath = vol.hostPath.path;
-                break;
-              }
-            }
-            if (configHostPath) break;
-          }
+          const configHostPath = findAutheliaConfigHostPath(docs);
           if (!configHostPath) continue;
           const configFilePath = `${configHostPath}/configuration.yml`;
           const agent = await agentManager.ensureAgent(nodeName);


### PR DESCRIPTION
## What
Bite-sized lint-sweep extraction in `packages/backend/src/lib/reverseProxy/migrateToPublic.ts`. The `locateConfig` method inside `realAutheliaDeps` had complexity 18, tripping the complexity rule; pulling the "walk doc.spec.volumes for a config-named hostPath" loop into `findAutheliaConfigHostPath` drops the parent below 15 and gives the disk-path lookup a name.

## Why
Lint-sweep filler. migrateToPublic.ts had 7 warnings; locateConfig was the only one tractable in a bite-sized PR. The remaining max-lines warnings (`realNpmDeps`, `planMigrationToPublic`, `applyMigrationToPublic`) are large enough to need their own tickets.

## Risk
Low. Pure structural refactor — same iteration over docs/volumes, same "contains 'config' + has hostPath.path" predicate, same short-circuit on first match. The empty-string sentinel preserves the prior "configHostPath remained '', try next node" flow.

## Rollback
`git revert` is enough — single-file extraction, no API surface change.

## Verification
- [x] npm run lint (0 errors; warning count 425 → 424; file count 7 → 6)
- [x] npm run check:arch (invariants + depcruise green)
- [x] npm test (1331 passed, 2 skipped)
- [x] Targeted: tests/backend/migrateToPublic.test.ts all green