### PR TITLE
refactor(migration): extract activateMergedUnit from mergeServices

### DIFF
--- a/packages/backend/src/lib/migration.ts
+++ b/packages/backend/src/lib/migration.ts
@@ -1050,6 +1050,25 @@ WantedBy=default.target
 `;
     await executor.writeFile(targetKubePath, kubeContent);
 
+    await activateMergedUnit({ executor, services, newName, nodeName, backupArchive, initiator });
+}
+
+/**
+ * Stop the legacy units, enable the merged unit, and roll back if the
+ * new unit fails to come up healthy. Records the outcome (success /
+ * rolled_back / failed) in the migration history. Re-throws the
+ * original activation error after recording so the caller still sees
+ * the failure.
+ */
+async function activateMergedUnit(params: {
+    executor: Executor;
+    services: DiscoveredService[];
+    newName: string;
+    nodeName: string;
+    backupArchive?: string;
+    initiator?: string;
+}): Promise<void> {
+    const { executor, services, newName, nodeName, backupArchive, initiator } = params;
     const stoppedServices = await stopLegacyServices(executor, services);
     const targetUnit = `${newName}.service`;
 


### PR DESCRIPTION
## What
Bite-sized lint-sweep extraction in `packages/backend/src/lib/migration.ts`. `mergeServices` was 74 lines, tripping `max-lines-per-function`. Pulling the systemctl enable + rollback-on-failure tail into `activateMergedUnit` brings the parent under 50 and gives the "make the merged unit go live or unwind it" sequence a name.

## Why
Lint-sweep filler. migration.ts had 6 warnings; `mergeServices` was the only one tractable in a bite-sized PR. `buildStackPreviewForService` (126 lines) and `migrateService` (181 lines, complexity 60) need their own dedicated tickets.

## Risk
Low. Pure structural refactor — same stopLegacyServices, same daemon-reload + enable + waitForServiceHealthy, same rollbackManagedService on failure, same recordMigrationHistory entries. The original activation error is re-thrown after history is recorded so the caller still sees it.

## Rollback
`git revert` is enough — single-file extraction, no API surface change.

## Verification
- [x] npm run lint (0 errors; warning count 424 → 423; file count 6 → 5)
- [x] npm run check:arch (invariants + depcruise green)
- [x] npm test (1331 passed, 2 skipped)
- [x] Targeted: tests/backend/template_migrations.test.ts + mcp/mergeUnmanagedBundle.test.ts all green