### PR TITLE
fix(install): serialize createJob to close TOCTOU on concurrent installs

### DIFF
--- a/packages/backend/src/lib/install/jobStore.race.test.ts
+++ b/packages/backend/src/lib/install/jobStore.race.test.ts
@@ -1,0 +1,94 @@
+/**
+ * createJob serialization (#1100).
+ *
+ * Without the in-process lock, two parallel POSTs to /api/install/start
+ * could both pass the route's `getCurrentJob()` pre-check and both
+ * write a job — two installs would then race on shared host state
+ * (systemd quadlets, nginx blocks, podman networks) with no operator
+ * visibility. The lock + re-check inside `createJob` ensures the
+ * second parallel caller sees the first's write and throws
+ * `InstallInProgressError`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { vi } from 'vitest';
+
+// Mock DATA_DIR to a process-scoped tmpdir so the test exercises the
+// real filesystem path (no fs mock) without colliding with the dev box.
+vi.mock('@/lib/dirs', () => ({
+  DATA_DIR: path.join(os.tmpdir(), `sb-jobstore-race-${process.pid}`),
+}));
+
+const TEST_DIR = path.join(os.tmpdir(), `sb-jobstore-race-${process.pid}`);
+
+import { createJob, getCurrentJob, InstallInProgressError, type JobInput } from './jobStore';
+
+function mkInput(): JobInput {
+  return {
+    items: [{ name: 'stub', checked: true }],
+    variables: [],
+    cleanInstall: false,
+    cleanInstallConfirm: '',
+    templateSource: 'test',
+    host: 'localhost',
+  };
+}
+
+beforeEach(async () => {
+  await fs.rm(path.join(TEST_DIR, 'install-jobs'), { recursive: true, force: true });
+  await fs.mkdir(path.join(TEST_DIR, 'install-jobs'), { recursive: true });
+});
+
+describe('createJob serialization (#1100)', () => {
+  it('rejects a second concurrent createJob with InstallInProgressError', async () => {
+    const results = await Promise.allSettled([
+      createJob({ source: 'a', input: mkInput() }),
+      createJob({ source: 'b', input: mkInput() }),
+    ]);
+    const fulfilled = results.filter(r => r.status === 'fulfilled');
+    const rejected = results.filter(r => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const failure = rejected[0] as PromiseRejectedResult;
+    expect(failure.reason).toBeInstanceOf(InstallInProgressError);
+    const winner = (fulfilled[0] as PromiseFulfilledResult<{ id: string }>).value;
+    expect((failure.reason as InstallInProgressError).existingJobId).toBe(winner.id);
+  });
+
+  it('lets a fresh createJob succeed once the previous job is no longer active', async () => {
+    const first = await createJob({ source: 'first', input: mkInput() });
+    // Flip the first job out of an active phase. `getCurrentJob` only
+    // considers running / needs_credentials, so a `done` job clears
+    // the gate.
+    const statePath = path.join(TEST_DIR, 'install-jobs', `${first.id}.json`);
+    const raw = JSON.parse(await fs.readFile(statePath, 'utf-8'));
+    raw.phase = 'done';
+    await fs.writeFile(statePath, JSON.stringify(raw));
+    // Drop the mem-cache entry so getCurrentJob re-reads from disk.
+    // (The job-store re-reads via listJobs, which always hits disk —
+    // so this is belt-and-braces.)
+    const second = await createJob({ source: 'second', input: mkInput() });
+    expect(second.id).not.toBe(first.id);
+    const active = await getCurrentJob();
+    expect(active?.id).toBe(second.id);
+  });
+
+  it('survives a thrown error in one createJob without breaking the chain', async () => {
+    // The lock pattern uses .then(fn, fn) + .catch(() => undefined) so
+    // a rejection on one call mustn't strand subsequent calls.
+    const a = await createJob({ source: 'a', input: mkInput() });
+    // A second concurrent call should reject — but a third call
+    // afterwards (with the first job gone) must still succeed.
+    await expect(createJob({ source: 'b', input: mkInput() }))
+      .rejects.toBeInstanceOf(InstallInProgressError);
+    // Mark `a` done so the next caller is allowed through.
+    const statePath = path.join(TEST_DIR, 'install-jobs', `${a.id}.json`);
+    const raw = JSON.parse(await fs.readFile(statePath, 'utf-8'));
+    raw.phase = 'done';
+    await fs.writeFile(statePath, JSON.stringify(raw));
+    const c = await createJob({ source: 'c', input: mkInput() });
+    expect(c.source).toBe('c');
+  });
+});

--- a/packages/backend/src/lib/install/jobStore.ts
+++ b/packages/backend/src/lib/install/jobStore.ts
@@ -132,27 +132,72 @@ async function atomicWrite(p: string, content: string): Promise<void> {
   await fs.rename(tmp, p);
 }
 
+/**
+ * Thrown by `createJob` when an active install job already exists.
+ * Carries the existing job's id so the caller (the /api/install/start
+ * route) can surface it in the 409 response — the wizard reattaches
+ * to that job instead of starting a new one.
+ *
+ * #1100: the route's pre-check (`getCurrentJob() → 409`) was a TOCTOU
+ * — two parallel POSTs could both observe no active job before either
+ * wrote one, then both runners would race on shared host state
+ * (systemd quadlets, nginx blocks, podman networks). This error is
+ * raised from inside the createJob lock so the second caller sees the
+ * first's write deterministically.
+ */
+export class InstallInProgressError extends Error {
+  readonly existingJobId: string;
+  constructor(existingJobId: string) {
+    super(`install already in progress: ${existingJobId}`);
+    this.name = 'InstallInProgressError';
+    this.existingJobId = existingJobId;
+  }
+}
+
+/**
+ * Per-process serialization for `createJob`. Same pattern as
+ * `withConfigLock` in `lib/config.ts`: a Promise chain that serializes
+ * concurrent callers and never breaks on a rejection. Required because
+ * the active-job check and the state-file write must be atomic against
+ * parallel /api/install/start requests (#1100).
+ */
+let createJobQueue: Promise<unknown> = Promise.resolve();
+
+function withCreateJobLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = createJobQueue.then(fn, fn);
+  createJobQueue = next.catch(() => undefined);
+  return next;
+}
+
 export async function createJob(opts: { source: string; input: JobInput }): Promise<JobState> {
-  await ensureDir();
-  await pruneJobs(KEEP_RECENT_JOBS);
-  const now = new Date().toISOString();
-  const job: JobState = {
-    id: randomUUID(),
-    source: opts.source,
-    phase: 'running',
-    startedAt: now,
-    updatedAt: now,
-    input: opts.input,
-    progress: {
-      currentItem: null,
-      deployedNames: [],
-      totalCount: opts.input.items.filter(i => i.checked).length,
-    },
-  };
-  await atomicWrite(statePath(job.id), JSON.stringify(job, null, 2));
-  await fs.writeFile(logPath(job.id), '', 'utf-8');
-  memCache.set(job.id, job);
-  return job;
+  return withCreateJobLock(async () => {
+    await ensureDir();
+    await pruneJobs(KEEP_RECENT_JOBS);
+    // Re-check under the lock: the route's pre-check is a fast path,
+    // not a guarantee. Without this, two parallel POSTs both pass the
+    // route's `getCurrentJob()` check before either createJob writes,
+    // and two installs race on the host's shared state (#1100).
+    const existing = await getCurrentJob();
+    if (existing) throw new InstallInProgressError(existing.id);
+    const now = new Date().toISOString();
+    const job: JobState = {
+      id: randomUUID(),
+      source: opts.source,
+      phase: 'running',
+      startedAt: now,
+      updatedAt: now,
+      input: opts.input,
+      progress: {
+        currentItem: null,
+        deployedNames: [],
+        totalCount: opts.input.items.filter(i => i.checked).length,
+      },
+    };
+    await atomicWrite(statePath(job.id), JSON.stringify(job, null, 2));
+    await fs.writeFile(logPath(job.id), '', 'utf-8');
+    memCache.set(job.id, job);
+    return job;
+  });
 }
 
 export async function getJob(id: string): Promise<JobState | null> {

--- a/packages/frontend/src/app/api/install/start/route.ts
+++ b/packages/frontend/src/app/api/install/start/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createJob, getCurrentJob, type JobInput } from '@/lib/install/jobStore';
+import { createJob, getCurrentJob, InstallInProgressError, type JobInput } from '@/lib/install/jobStore';
 import { startJob } from '@/lib/install/runner';
 import { apiError } from '@/lib/api/errors';
 
@@ -15,6 +15,14 @@ export const dynamic = 'force-dynamic';
  * Idempotency: refuses to start a second job if one is already in an
  * active phase (running / needs_credentials). The wizard surfaces this
  * via the `installInProgress` banner + reattach flow.
+ *
+ * Two layers of serialization: the pre-check below is a fast path for
+ * the common case (already-running install observed via the
+ * `installInProgress` banner). The authoritative gate is inside
+ * `createJob` (#1100), which holds an in-process lock across the
+ * active-job re-check and the state-file write — without that lock,
+ * two parallel POSTs could both pass this pre-check and start
+ * simultaneous installs racing on shared host state.
  */
 export const POST = withApiHandler({}, async ({ request }) => {
   try {
@@ -30,9 +38,19 @@ export const POST = withApiHandler({}, async ({ request }) => {
         { status: 409 },
       );
     }
-    const job = await createJob({ source: body.source ?? 'wizard', input });
-    startJob(job.id);
-    return NextResponse.json({ jobId: job.id });
+    try {
+      const job = await createJob({ source: body.source ?? 'wizard', input });
+      startJob(job.id);
+      return NextResponse.json({ jobId: job.id });
+    } catch (e) {
+      if (e instanceof InstallInProgressError) {
+        return NextResponse.json(
+          { error: 'install already in progress', jobId: e.existingJobId },
+          { status: 409 },
+        );
+      }
+      throw e;
+    }
   } catch (error) {
     return apiError(error, { tag: 'api:install:start', status: 500 });
   }


### PR DESCRIPTION
## What
Add an in-process lock around `createJob` so the active-install re-check and the state-file write are atomic against parallel `/api/install/start` POSTs. New `InstallInProgressError` carries the existing job id; the start route catches it and surfaces a 409 with that jobId.

## Why
Closes #1100.

The route's `getCurrentJob()` pre-check was a TOCTOU — two parallel POSTs could both observe no active job before either `createJob` wrote one, then two runners would race on shared host state (systemd quadlets, nginx blocks, podman networks) with last-write-wins.

## Risk
Low. Pattern mirrors the existing `withConfigLock` in `lib/config.ts`. The lock is per-process; multi-process deployments aren't a concern here (single Next.js server). The pre-check stays as a fast path so the lock only carries the race-window contention.

## Rollback
`git revert` is sufficient — the change is additive (new error class + new lock helper) plus a catch in one route. No persistence migrations.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm run check:arch (invariants + depcruise pass)
- [x] npm test (1334 passed, 2 skipped — includes new `jobStore.race.test.ts`)
- [x] Manual: dev server + parallel curl pair confirms REQ1=200, REQ2=409 with REQ1's jobId. 5-way burst → all 409 same jobId. After flipping job to `done`, fresh POST → new jobId.