### PR TITLE
fix(install): cap per-job log file at configured line/byte limits

### DIFF
--- a/packages/backend/src/lib/install/jobStore.logcap.test.ts
+++ b/packages/backend/src/lib/install/jobStore.logcap.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-job log cap (#1098 Phase 2).
+ *
+ * A thrashing install can't unbound the per-job .log file: appendLog
+ * stops persisting after `maxBytes` or `maxLines`, writing one
+ * `[TRUNCATED]` marker and dropping subsequent lines silently. The
+ * runner keeps running; we just stop preserving its chatter.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+
+vi.mock('@/lib/dirs', () => ({
+  DATA_DIR: path.join(os.tmpdir(), `sb-jobstore-logcap-${process.pid}`),
+}));
+
+// Tight caps so the test doesn't have to spam thousands of writes.
+const TEST_LIMITS = { maxJobLogLines: 5, maxJobLogBytes: 100 };
+
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/config')>('@/lib/config');
+  return {
+    ...actual,
+    getConfig: vi.fn(async () => ({ logging: TEST_LIMITS }) as never),
+  };
+});
+
+const TEST_DIR = path.join(os.tmpdir(), `sb-jobstore-logcap-${process.pid}`);
+
+import { createJob, appendLog, readLog, type JobInput } from './jobStore';
+
+function mkInput(): JobInput {
+  return {
+    items: [],
+    variables: [],
+    cleanInstall: false,
+    cleanInstallConfirm: '',
+    templateSource: 'test',
+    host: 'localhost',
+  };
+}
+
+beforeEach(async () => {
+  await fs.rm(path.join(TEST_DIR, 'install-jobs'), { recursive: true, force: true });
+  await fs.mkdir(path.join(TEST_DIR, 'install-jobs'), { recursive: true });
+});
+
+describe('appendLog per-job cap (#1098)', () => {
+  it('writes a [TRUNCATED] marker and drops further lines once maxLines is exceeded', async () => {
+    const job = await createJob({ source: 'cap-lines', input: mkInput() });
+    // maxJobLogLines = 5 → 6th append should be dropped + marker appears.
+    for (let i = 0; i < 8; i++) await appendLog(job.id, `line ${i}`);
+    const { content } = await readLog(job.id);
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines.filter(l => l.startsWith('line ')).length).toBe(5);
+    expect(lines.some(l => l.startsWith('[TRUNCATED:'))).toBe(true);
+    expect(lines.some(l => l === 'line 5' || l === 'line 6' || l === 'line 7')).toBe(false);
+  });
+
+  it('writes a [TRUNCATED] marker once maxBytes is exceeded', async () => {
+    const job = await createJob({ source: 'cap-bytes', input: mkInput() });
+    // maxBytes=100. A 30-byte line × 4 = 120 → the 4th line triggers.
+    for (let i = 0; i < 4; i++) await appendLog(job.id, 'x'.repeat(29));
+    const { content } = await readLog(job.id);
+    expect(content).toContain('[TRUNCATED:');
+    // File size must not blow past the cap by more than the marker.
+    expect(Buffer.byteLength(content, 'utf-8')).toBeLessThan(300);
+  });
+
+  it('emits exactly one [TRUNCATED] marker even after many further appends', async () => {
+    const job = await createJob({ source: 'cap-once', input: mkInput() });
+    for (let i = 0; i < 20; i++) await appendLog(job.id, `line ${i}`);
+    const { content } = await readLog(job.id);
+    const markerCount = (content.match(/\[TRUNCATED:/g) ?? []).length;
+    expect(markerCount).toBe(1);
+  });
+});

--- a/packages/backend/src/lib/install/jobStore.ts
+++ b/packages/backend/src/lib/install/jobStore.ts
@@ -21,6 +21,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { randomUUID } from 'crypto';
 import { DATA_DIR } from '@/lib/dirs';
+import { getConfig, getJobLogLimits, DEFAULT_MAX_JOB_LOG_LINES, DEFAULT_MAX_JOB_LOG_BYTES } from '@/lib/config';
 import type { Credential } from '@/lib/stackInstall/credentialsManifest';
 
 const JOBS_DIR = path.join(DATA_DIR, 'install-jobs');
@@ -196,6 +197,11 @@ export async function createJob(opts: { source: string; input: JobInput }): Prom
     await atomicWrite(statePath(job.id), JSON.stringify(job, null, 2));
     await fs.writeFile(logPath(job.id), '', 'utf-8');
     memCache.set(job.id, job);
+    // Prime the per-job log cap (#1098 Phase 2). Reads the current
+    // config once per createJob so individual `appendLog` calls stay
+    // free of an async config hop on the hot path.
+    const limits = await readLogLimits();
+    logCaps.set(job.id, { bytes: 0, lines: 0, ...limits, truncated: false });
     return job;
   });
 }
@@ -238,8 +244,72 @@ export async function updateJob(
   return next;
 }
 
+/**
+ * Per-job log-cap tracking (#1098 Phase 2). Hard ceiling on each job's
+ * `.log` file so a thrashing install can't unbound the JOBS_DIR or
+ * crowd the status-route reader. When the cap is hit we write one
+ * `[TRUNCATED]` marker and drop subsequent appends silently — the
+ * runner keeps running, we just stop preserving its chatter.
+ *
+ * Cache survives the lifetime of the job within a process. On server
+ * restart the cache is cold; `initLogCap` reads the existing file's
+ * size + line count once so we don't blow past the cap by reading the
+ * old file as zero-size.
+ */
+interface LogCap {
+  bytes: number;
+  lines: number;
+  maxBytes: number;
+  maxLines: number;
+  truncated: boolean;
+}
+
+const logCaps = new Map<string, LogCap>();
+
+async function readLogLimits(): Promise<{ maxBytes: number; maxLines: number }> {
+  try {
+    return getJobLogLimits(await getConfig());
+  } catch {
+    // Config unreadable at this point is exceptional, but a missing
+    // cap mustn't strand the runner — fall back to the same defaults
+    // the getter would have returned.
+    return { maxBytes: DEFAULT_MAX_JOB_LOG_BYTES, maxLines: DEFAULT_MAX_JOB_LOG_LINES };
+  }
+}
+
+async function initLogCap(id: string): Promise<LogCap> {
+  const limits = await readLogLimits();
+  let bytes = 0;
+  let lines = 0;
+  let truncated = false;
+  try {
+    const buf = await fs.readFile(logPath(id), 'utf-8');
+    bytes = Buffer.byteLength(buf, 'utf-8');
+    // Newline-terminated lines; an empty file is 0 lines.
+    lines = bytes === 0 ? 0 : buf.split('\n').length - (buf.endsWith('\n') ? 1 : 0);
+    truncated = buf.includes('[TRUNCATED:');
+  } catch {
+    // Missing log file is fine — runner hasn't written yet.
+  }
+  const cap: LogCap = { bytes, lines, ...limits, truncated };
+  logCaps.set(id, cap);
+  return cap;
+}
+
 export async function appendLog(id: string, line: string): Promise<void> {
-  await fs.appendFile(logPath(id), line + '\n', 'utf-8').catch(() => undefined);
+  const cap = logCaps.get(id) ?? await initLogCap(id);
+  if (cap.truncated) return;
+  const data = line + '\n';
+  const dataBytes = Buffer.byteLength(data, 'utf-8');
+  if (cap.bytes + dataBytes > cap.maxBytes || cap.lines + 1 > cap.maxLines) {
+    const marker = `[TRUNCATED: log exceeded cap (lines=${cap.maxLines}, bytes=${cap.maxBytes}); further lines dropped]\n`;
+    await fs.appendFile(logPath(id), marker, 'utf-8').catch(() => undefined);
+    cap.truncated = true;
+    return;
+  }
+  await fs.appendFile(logPath(id), data, 'utf-8').catch(() => undefined);
+  cap.bytes += dataBytes;
+  cap.lines += 1;
 }
 
 /** Read log content from `sinceBytes` to end-of-file. Used by the
@@ -357,5 +427,6 @@ async function pruneJobs(keep: number): Promise<void> {
     if (j.phase === 'running' || j.phase === 'needs_credentials') continue;
     await fs.unlink(statePath(j.id)).catch(() => undefined);
     await fs.unlink(logPath(j.id)).catch(() => undefined);
+    logCaps.delete(j.id);
   }
 }


### PR DESCRIPTION
## What
Wire #1098 Phase 1's `getJobLogLimits` into `appendLog`. Each job carries a `{bytes, lines, maxBytes, maxLines, truncated}` cap struct seeded on `createJob`. Once the next append would exceed either cap, write a single `[TRUNCATED:…]` marker and drop subsequent appends silently. `pruneJobs` cleans up the cache; server restart re-initialises from the existing file.

## Why
Closes #1098.

Phase 1 added the config knobs + defaults (10k lines / 5MB). This Phase 2 makes them actually bound the per-job log file so a thrashing install can't unbound `JOBS_DIR`.

## Risk
Low. `appendLog` previously did one `fs.appendFile`; now it does a tiny in-memory check first. Hot path stays free of async config reads (limits seeded once at `createJob` from `getConfig`). Default caps are deliberately roomy (10k/5MB) — normal installs never approach them.

## Rollback
`git revert` is sufficient. State is purely in-memory + a marker line in the log file. No persistence migration.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm run check:arch (invariants + depcruise pass)
- [x] npm test (1337 passed — includes new `jobStore.logcap.test.ts` with 3 cases)
- [x] Local dev run: `maxLines=1` triggers exactly one `[TRUNCATED]` marker after the first line; `maxBytes=80` triggers truncation on the very first oversized append; default config produces no marker and runs normally.