### PR TITLE
docs: remove stale 'Update Channel' references

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -42,7 +42,6 @@ flowchart TD
 │             │ DNS servers (;-separated)    │ gateway IP │ ✓          │
 ├─────────────┼──────────────────────────────┼────────────┼────────────┤
 │ ServiceBay  │ Port                         │ 3000       │ ✓          │
-│             │ Update channel               │ stable     │ ✓          │
 │             │ Admin username               │ admin      │ ✓          │
 │             │ Admin password               │ —          │ ✗ secret   │
 ├─────────────┼──────────────────────────────┼────────────┼────────────┤

--- a/packages/frontend/src/content/help/system-info.md
+++ b/packages/frontend/src/content/help/system-info.md
@@ -8,7 +8,6 @@ Overview of the host system resources.
 - **OS Info**: Kernel version, uptime, and hostname.
 - **Network**: Interface statistics and IP addresses.
 - **Multi-Server**: View statistics for Local and configured remote nodes.
-- **Update Channel**: Check whether ServiceBay itself has an update pending before you schedule downtime.
 
 ## Tips
 - Snapshot resource graphs right after running a System Backup so you can compare trends before and after changes.


### PR DESCRIPTION
## What
Drop the "Update Channel" bullet in the System Info help panel and the row in the INSTALLATION setup table. The auto-update release channels (stable/test/dev) were removed from the product per `docs/UX_PHILOSOPHY.md:133`; the philosophy entry that documents the removal decision stays.

## Why
Closes #1151.

## Risk
None — pure docs, no code path or build artifact.

## Rollback
git revert.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm run check:arch (pass)