### PR TITLE
fix(installer): hide system-wide Clean Install toggle from per-template modal

### DIFF
--- a/packages/frontend/src/components/InstallerModal.tsx
+++ b/packages/frontend/src/components/InstallerModal.tsx
@@ -235,7 +235,15 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
               nodes={nodes}
               selectedNode={selectedNode}
               onSelectNode={setSelectedNode}
-              allowCleanInstall={template.type === 'stack'}
+              // #1150: the "Clean install" toggle wipes EVERY service on
+              // the node (via /api/system/stacks/reset), not just the one
+              // being installed here. Surfacing it in the per-template
+              // modal mismatches the operator's mental model and has
+              // already caused total data loss (memory 2026-05-15). The
+              // toggle still lives in the onboarding wizard's MachineStep
+              // where a system-wide wipe is contextually correct (no
+              // user data yet, Phase 1 boot).
+              allowCleanInstall={false}
               deviceContext={{
                 deviceOptions,
                 loadingDevices,


### PR DESCRIPTION
## What
Force \`allowCleanInstall={false}\` for the per-template \`InstallerModal\`. The amber \"Clean install\" panel calls \`/api/system/stacks/reset\` which wipes every service on the node, not just the template being installed — surfacing it from a per-template tile is the exact data-loss path memory \`feedback_destructive_install_options\` documents (2026-05-15 incident).

The same control stays in the onboarding wizard's \`MachineStep\` where a system-wide wipe is the right context (no user data yet, Phase 1 boot).

## Why
Closes #1150.

## Risk
Low. The JSX consumer in \`StackInstallFlow\` is \`{allowCleanInstall && (<panel/>)}\`, so a literal \`false\` short-circuits the subtree out at render. The \`Install\` button keeps its defensive \`cleanInstall ? 'Reset & Install' : 'Install'\` copy in case a future caller resurrects the toggle.

## Rollback
git revert — single file, single prop flip.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm run check:arch (pass)
- [x] npm test (1337 pass, 2 skipped)
- [ ] /verify on real-box UI — BLOCKED locally: headless browser binaries fail to launch on this WSL host (missing \`libnspr4 libnss3 libnssutil3 libasound.so.2\`; sudo unavailable). Manual spot-check: \`npm run dev:frontend\` → http://localhost:3001/registry → click any stack tile → Continue → confirm no amber \"Clean install\" panel on the configure form. Also confirm the panel still appears in the onboarding wizard's MachineStep.