### PR TITLE
feat(registry): optional servicebay.json manifest for custom registry layouts

### DIFF
--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -557,6 +557,45 @@ with a justifying comment.
 `config.registries[]` accepts git URLs that follow the same on-disk
 layout (a `templates/` directory at the repo root). The `registry.ts`
 sync clones with `--depth 1 --filter=blob:none --sparse`, then
-`sparse-checkout set templates stacks`. External registries override
-built-ins with the same name, so you can ship a custom variant of any
-bundled template by publishing it under the same directory name.
+`sparse-checkout set templates stacks servicebay.json`. External
+registries override built-ins with the same name, so you can ship a
+custom variant of any bundled template by publishing it under the same
+directory name.
+
+### Custom layouts via `servicebay.json` (#1050)
+
+For registries whose top-level layout reflects their own subsystem
+boundaries rather than ServiceBay's expected sparse-checkout shape,
+ship a `servicebay.json` at the repo root declaring where templates
+and stacks live:
+
+```json
+{
+  "templates": [
+    { "name": "oscar-household", "path": "servicebay-template" }
+  ],
+  "stacks": [
+    { "name": "household", "path": "stacks/household" }
+  ]
+}
+```
+
+Paths are relative to the registry root. When the manifest is present,
+ServiceBay reads `templates[]` and `stacks[]` entries from it instead
+of scanning the legacy `templates/` and `stacks/` directories. A
+registry can ship a manifest declaring `templates[]` only and let
+stacks keep using the legacy convention — the fallback applies per
+type. Manifest entries pointing at missing directories are warned and
+skipped; they don't crash registry enumeration.
+
+The sparse-checkout patterns widen automatically: after the first
+clone exposes `servicebay.json`, the sync layer re-runs
+`sparse-checkout set` to include every path the manifest declares, so
+the working tree only carries the paths the manifest names plus the
+default `templates/` + `stacks/` fallbacks.
+
+Example use case: `mdopp/oscar` keeps its template, Hermes skill pack,
+Wyoming-bridge image source, and Postgres-schema migrations in clearly
+separated top-level directories, with `servicebay.json` pointing the
+ServiceBay template at `servicebay-template/`. No `templates/` folder
+at the registry root.

--- a/packages/backend/src/lib/registry.manifest.test.ts
+++ b/packages/backend/src/lib/registry.manifest.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Manifest-aware registry resolution (#1050 scaffolding).
+ *
+ * A registry MAY ship a `servicebay.json` at its root declaring where
+ * its templates and stacks live. Registries without a manifest keep
+ * using the legacy `templates/<name>/` / `stacks/<name>/` convention,
+ * so existing `mdopp/servicebay` and `mdopp/servicebay-templates`
+ * keep working untouched.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+
+// REGISTRIES_DIR is computed from CONTAINER_CONFIG_DIR at module load.
+// vi.hoisted runs before the test file's `import`s so the env var is in
+// place by the time registry.ts evaluates its top-level constants.
+const TEST_ROOT = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _os = require('os') as typeof import('os');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _path = require('path') as typeof import('path');
+  const root = _path.join(_os.tmpdir(), `sb-registry-manifest-${process.pid}`);
+  process.env.CONTAINER_CONFIG_DIR = root;
+  return root;
+});
+
+// Mock config so getRegistries returns the test registries without
+// pulling in the on-disk config.json the real getConfig wants.
+const mockConfigState = { registries: { enabled: true, items: [] as Array<{ name: string; url: string }> } };
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfigState),
+}));
+
+import {
+  getTemplates,
+  getReadme,
+  getTemplateYaml,
+  _resetRegistryManifestCacheForTests,
+} from './registry';
+
+const REG_DIR = path.join(TEST_ROOT, 'registries');
+
+async function seed(regName: string, layout: Record<string, string>): Promise<void> {
+  const regRoot = path.join(REG_DIR, regName);
+  for (const [relPath, content] of Object.entries(layout)) {
+    const full = path.join(regRoot, relPath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+}
+
+beforeEach(async () => {
+  await fs.rm(REG_DIR, { recursive: true, force: true });
+  await fs.mkdir(REG_DIR, { recursive: true });
+  mockConfigState.registries.items = [];
+  // Drop the in-process manifest cache so tests reusing a registry
+  // name see the disk content they just seeded, not a stale cached
+  // manifest from a prior case.
+  _resetRegistryManifestCacheForTests();
+});
+
+describe('legacy layout (no manifest)', () => {
+  it('finds templates under templates/<name>/', async () => {
+    await seed('legacy-reg', {
+      'templates/foo/template.yml': 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\n  annotations:\n    servicebay.label: "foo"\n    servicebay.ports: "8080/tcp"\n    servicebay.schema-version: "1"\n',
+      'templates/foo/README.md': 'foo readme',
+    });
+    mockConfigState.registries.items.push({ name: 'legacy-reg', url: 'http://example/legacy.git' });
+
+    const templates = await getTemplates();
+    const foo = templates.find(t => t.name === 'foo' && t.source === 'legacy-reg');
+    expect(foo).toBeDefined();
+    expect(foo!.type).toBe('template');
+
+    const readme = await getReadme('foo', 'template', 'legacy-reg');
+    expect(readme).toBe('foo readme');
+  });
+});
+
+describe('manifest layout (servicebay.json present)', () => {
+  it('resolves a template declared at a custom path', async () => {
+    // OSCAR-shaped layout: servicebay-template/ at root, declared via manifest.
+    await seed('oscar', {
+      'servicebay.json': JSON.stringify({
+        templates: [{ name: 'oscar-household', path: 'servicebay-template' }],
+      }),
+      'servicebay-template/template.yml': 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: oscar-household\n  annotations:\n    servicebay.label: "OSCAR Household"\n    servicebay.ports: "10700/tcp"\n    servicebay.schema-version: "1"\n',
+      'servicebay-template/README.md': 'oscar household readme',
+    });
+    mockConfigState.registries.items.push({ name: 'oscar', url: 'http://example/oscar.git' });
+
+    const templates = await getTemplates();
+    const oh = templates.find(t => t.name === 'oscar-household' && t.source === 'oscar');
+    expect(oh).toBeDefined();
+    expect(oh!.path).toBe(path.join(REG_DIR, 'oscar', 'servicebay-template'));
+
+    const readme = await getReadme('oscar-household', 'template', 'oscar');
+    expect(readme).toBe('oscar household readme');
+
+    const yaml = await getTemplateYaml('oscar-household', 'oscar');
+    expect(yaml).toContain('name: oscar-household');
+  });
+
+  it('does NOT find the same template under the legacy templates/<name>/ path when manifest declares only the custom path', async () => {
+    // Mixed-state guard: a registry author who renames the dir but
+    // forgets to update the manifest shouldn't end up exposing both
+    // shapes. Manifest entries are authoritative when present.
+    await seed('oscar', {
+      'servicebay.json': JSON.stringify({
+        templates: [{ name: 'oscar-household', path: 'servicebay-template' }],
+      }),
+      'servicebay-template/template.yml': 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: oscar-household\n  annotations:\n    servicebay.label: "OSCAR Household"\n    servicebay.ports: "10700/tcp"\n    servicebay.schema-version: "1"\n',
+      // A leftover legacy path that should NOT be picked up since the
+      // manifest names a different location.
+      'templates/oscar-household/README.md': 'leftover from before the move',
+    });
+    mockConfigState.registries.items.push({ name: 'oscar', url: 'http://example/oscar.git' });
+
+    const readme = await getReadme('oscar-household', 'template', 'oscar');
+    // README from the manifest-declared path, not the legacy one
+    expect(readme).not.toBe('leftover from before the move');
+  });
+
+  it('falls back to scanning stacks/ when manifest declares only templates', async () => {
+    // A registry can ship a manifest for templates only and let stacks
+    // keep using the legacy convention.
+    await seed('mixed', {
+      'servicebay.json': JSON.stringify({
+        templates: [{ name: 'foo', path: 'foo-dir' }],
+      }),
+      'foo-dir/template.yml': 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\n  annotations:\n    servicebay.label: "foo"\n    servicebay.ports: "1/tcp"\n    servicebay.schema-version: "1"\n',
+      'stacks/legacy-stack/README.md': 'stack readme',
+    });
+    mockConfigState.registries.items.push({ name: 'mixed', url: 'http://example/mixed.git' });
+
+    const templates = await getTemplates();
+    const foo = templates.find(t => t.name === 'foo' && t.source === 'mixed');
+    const legacyStack = templates.find(t => t.name === 'legacy-stack' && t.source === 'mixed');
+    expect(foo).toBeDefined();
+    expect(legacyStack).toBeDefined();
+    expect(legacyStack!.type).toBe('stack');
+  });
+
+  it('skips a manifest entry that points at a missing directory without crashing the registry', async () => {
+    // Stale manifest survival: declaring a path that doesn't exist on
+    // disk (sparse-checkout glitch, half-applied rename) must NOT take
+    // down enumeration of the other registries.
+    await seed('oscar', {
+      'servicebay.json': JSON.stringify({
+        templates: [
+          { name: 'oscar-household', path: 'servicebay-template' },
+          { name: 'ghost', path: 'never-existed' },
+        ],
+      }),
+      'servicebay-template/template.yml': 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: oscar-household\n  annotations:\n    servicebay.label: "OSCAR Household"\n    servicebay.ports: "10700/tcp"\n    servicebay.schema-version: "1"\n',
+    });
+    mockConfigState.registries.items.push({ name: 'oscar', url: 'http://example/oscar.git' });
+
+    const templates = await getTemplates();
+    const oh = templates.find(t => t.name === 'oscar-household' && t.source === 'oscar');
+    const ghost = templates.find(t => t.name === 'ghost' && t.source === 'oscar');
+    expect(oh).toBeDefined();
+    expect(ghost).toBeUndefined();
+  });
+});

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -25,6 +25,97 @@ const DEFAULT_REGISTRY: RegistryConfig = {
   url: 'https://github.com/mdopp/servicebay.git',
 };
 
+/**
+ * Optional registry-side manifest (#1050) describing where templates
+ * and stacks live within the repo. Registries that don't ship a
+ * `servicebay.json` keep using the legacy convention (`templates/<name>/`,
+ * `stacks/<name>/`), so existing registries — `mdopp/servicebay`,
+ * `mdopp/servicebay-templates` — keep working without change.
+ *
+ * The motivation is registries whose top-level layout reflects their
+ * own subsystem boundaries rather than ServiceBay's expected
+ * sparse-checkout shape — e.g. `mdopp/oscar` with
+ * `servicebay-template/`, `hermes-skills/`, `voice-gatekeeper/`,
+ * `database/` at the root. The manifest tells SB which of those
+ * directories to scan as templates.
+ *
+ * Shape:
+ *   {
+ *     "templates": [{ "name": "oscar-household", "path": "servicebay-template" }],
+ *     "stacks":    [{ "name": "household",       "path": "stacks/household"    }]
+ *   }
+ *
+ * Paths are relative to the registry root; the legacy `templates/` and
+ * `stacks/` directories continue to be scanned as a fallback when the
+ * manifest is missing.
+ */
+interface RegistryManifestEntry {
+  name: string;
+  path: string;
+}
+
+interface RegistryManifest {
+  templates?: RegistryManifestEntry[];
+  stacks?: RegistryManifestEntry[];
+}
+
+/**
+ * Per-registry manifest cache. Cleared on every `syncRegistries` call
+ * so a freshly-pulled manifest is picked up without a server restart.
+ * `null` means "checked the disk, no manifest present" — distinct from
+ * "not yet checked" (key absent).
+ */
+const manifestCache = new Map<string, RegistryManifest | null>();
+
+/**
+ * Test-only escape hatch to drop the manifest cache without invoking
+ * `syncRegistries`. The cache is module-scoped, so unit tests that
+ * reuse a registry name across cases would otherwise pollute each
+ * other. Production code paths reset via `syncRegistries`'s own
+ * `manifestCache.clear()`.
+ */
+export function _resetRegistryManifestCacheForTests(): void {
+  manifestCache.clear();
+}
+
+async function readRegistryManifest(regName: string): Promise<RegistryManifest | null> {
+  if (manifestCache.has(regName)) return manifestCache.get(regName) ?? null;
+  const p = path.join(REGISTRIES_DIR, regName, 'servicebay.json');
+  try {
+    const raw = await fs.readFile(p, 'utf-8');
+    const parsed = JSON.parse(raw) as RegistryManifest;
+    manifestCache.set(regName, parsed);
+    return parsed;
+  } catch {
+    manifestCache.set(regName, null);
+    return null;
+  }
+}
+
+/**
+ * Resolve the on-disk directory for a template or stack in a given
+ * registry, consulting the manifest first and falling back to the
+ * legacy `<type>s/<name>/` convention. Returns the absolute path even
+ * when the directory doesn't exist — caller's existing fs.access /
+ * fs.readFile failure paths handle "not found" the same way they did
+ * before the manifest existed.
+ */
+async function resolveRegistryItemPath(
+  regName: string,
+  type: 'template' | 'stack',
+  itemName: string,
+): Promise<string> {
+  const manifest = await readRegistryManifest(regName);
+  const entries = type === 'template' ? manifest?.templates : manifest?.stacks;
+  if (entries) {
+    const entry = entries.find(e => e.name === itemName);
+    if (entry) return path.join(REGISTRIES_DIR, regName, entry.path);
+  }
+  // Legacy fallback — also the path for manifest-less registries.
+  const subdir = type === 'template' ? 'templates' : 'stacks';
+  return path.join(REGISTRIES_DIR, regName, subdir, itemName);
+}
+
 export interface Template {
   name: string;
   path: string;
@@ -192,6 +283,32 @@ async function cloneSparse(url: string, dest: string, dirs: string[]) {
     await execFileAsync('git', ['sparse-checkout', 'set', ...dirs], { cwd: dest });
 }
 
+/**
+ * Widen an already-sparse clone to include extra paths declared by the
+ * registry's `servicebay.json`. Called after the initial sparse-checkout
+ * exposes the manifest itself — once we read which custom paths it
+ * names, this pulls them in without re-cloning. No-op if the manifest
+ * declares no entries that fall outside the default patterns.
+ */
+async function widenSparseForManifest(regPath: string, manifest: RegistryManifest): Promise<void> {
+    const extra = new Set<string>();
+    for (const e of manifest.templates ?? []) extra.add(e.path);
+    for (const e of manifest.stacks ?? []) extra.add(e.path);
+    if (extra.size === 0) return;
+    // Keep the defaults so legacy `templates/` and `stacks/` co-existence
+    // (a repo that ships some of each shape) still works.
+    const patterns = ['templates', 'stacks', 'servicebay.json', ...extra];
+    try {
+        await execFileAsync('git', ['sparse-checkout', 'set', ...patterns], { cwd: regPath });
+    } catch (e) {
+        // Failure here doesn't strand the registry — the manifest still
+        // points at paths that just won't be present on disk; downstream
+        // `fs.readFile` returns the same "not found" the operator would
+        // see for a stale manifest.
+        logger.warn('registry', `widenSparseForManifest failed for ${regPath}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+}
+
 let gitAvailability: boolean | null = null;
 async function isGitAvailable(): Promise<boolean> {
     if (gitAvailability !== null) return gitAvailability;
@@ -224,6 +341,10 @@ export async function syncRegistries() {
         await fs.mkdir(REGISTRIES_DIR, { recursive: true });
     } catch {}
 
+    // Clear the manifest cache so any servicebay.json updates pulled
+    // this round are picked up. Pre-existing readers will re-read once.
+    manifestCache.clear();
+
     for (const reg of registries) {
         const regPath = path.join(REGISTRIES_DIR, reg.name);
         // Isolate each registry: a single bad URL (a 404'd repo, an
@@ -244,11 +365,23 @@ export async function syncRegistries() {
                 // Doesn't exist, clone
                 logger.info('registry', `Cloning registry ${reg.name}...`);
                 try {
-                    await cloneSparse(reg.url, regPath, ['templates', 'stacks']);
+                    // Default sparse patterns include `servicebay.json` so a
+                    // manifest-using registry exposes it on the first clone;
+                    // `widenSparseForManifest` below then pulls any custom
+                    // paths declared inside.
+                    await cloneSparse(reg.url, regPath, ['templates', 'stacks', 'servicebay.json']);
                 } catch {
                     // Fallback to full clone if sparse checkout not supported
                     await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath]);
                 }
+            }
+            // Manifest pass: if the registry ships `servicebay.json`, pull
+            // any custom paths it declares (e.g. `servicebay-template/`,
+            // `hermes-skills/`) into the sparse working tree so the
+            // resolver helpers find them. No-op for legacy registries.
+            const manifest = await readRegistryManifest(reg.name);
+            if (manifest) {
+                await widenSparseForManifest(regPath, manifest);
             }
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -272,10 +405,20 @@ export async function getTemplates(): Promise<Template[]> {
 
     for (const reg of registries) {
         const regPath = path.join(REGISTRIES_DIR, reg.name);
-        const [regTemplates, regStacks] = await Promise.all([
-            fetchDir(path.join(regPath, 'templates'), 'template', reg.name),
-            fetchDir(path.join(regPath, 'stacks'), 'stack', reg.name)
-        ]);
+        const manifest = await readRegistryManifest(reg.name);
+
+        // Templates: manifest-declared paths if a manifest exists, else
+        // legacy `templates/` scan. Stacks: same. A registry that ships
+        // a manifest declaring `templates[]` but no `stacks[]` falls back
+        // to scanning `stacks/` for the stacks half — that's the most
+        // useful mixed-shape behaviour (most registries have a clear
+        // "templates live here, stacks are conventional" split).
+        const regTemplates: Template[] = manifest?.templates
+            ? await fetchManifestEntries(regPath, manifest.templates, 'template', reg.name)
+            : await fetchDir(path.join(regPath, 'templates'), 'template', reg.name);
+        const regStacks: Template[] = manifest?.stacks
+            ? await fetchManifestEntries(regPath, manifest.stacks, 'stack', reg.name)
+            : await fetchDir(path.join(regPath, 'stacks'), 'stack', reg.name);
 
         // Registry versions override built-in templates with the same name
         const regItems = [...regStacks, ...regTemplates];
@@ -292,14 +435,53 @@ export async function getTemplates(): Promise<Template[]> {
     return allTemplates;
 }
 
-export async function getReadme(name: string, type: 'template' | 'stack', source?: string): Promise<string | null> {
-  const subdir = type === 'stack' ? 'stacks' : 'templates';
+/**
+ * Manifest-aware sibling to `fetchDir`. Where `fetchDir` reads every
+ * subdirectory of a fixed parent (`templates/` or `stacks/`),
+ * `fetchManifestEntries` walks the explicit `{name, path}` list from
+ * `servicebay.json`. Missing dirs are silently dropped — the operator
+ * gets the same "template not visible" symptom they'd get from a
+ * legacy registry with a missing folder, and the consistency lint
+ * catches it at build time.
+ */
+async function fetchManifestEntries(
+  regPath: string,
+  entries: RegistryManifestEntry[],
+  type: 'template' | 'stack',
+  source: string,
+): Promise<Template[]> {
+  const out: Template[] = [];
+  for (const entry of entries) {
+    const itemDir = path.join(regPath, entry.path);
+    try {
+      await fs.access(itemDir);
+    } catch {
+      // Manifest names a path the working tree doesn't have — most
+      // likely a stale manifest or a sparse-checkout that didn't widen.
+      // Skip rather than crash the whole registry's enumeration.
+      logger.warn('registry', `manifest entry ${source}/${entry.name} → ${entry.path} not present on disk`);
+      continue;
+    }
+    const { tier, dependencies } = await readTemplateMeta(itemDir, type, entry.name, source);
+    out.push({
+      name: entry.name,
+      path: itemDir,
+      url: '',
+      type,
+      source,
+      tier,
+      dependencies,
+    });
+  }
+  return out;
+}
 
+export async function getReadme(name: string, type: 'template' | 'stack', source?: string): Promise<string | null> {
   // If a specific source is given, use it directly
   if (source && source !== 'Built-in') {
     try {
-      const filePath = path.join(REGISTRIES_DIR, source, subdir, name, 'README.md');
-      return await fs.readFile(filePath, 'utf-8');
+      const itemDir = await resolveRegistryItemPath(source, type, name);
+      return await fs.readFile(path.join(itemDir, 'README.md'), 'utf-8');
     } catch {
       return null;
     }
@@ -311,8 +493,8 @@ export async function getReadme(name: string, type: 'template' | 'stack', source
     const registries = getRegistries(config);
     for (const reg of registries) {
       try {
-        const filePath = path.join(REGISTRIES_DIR, reg.name, subdir, name, 'README.md');
-        return await fs.readFile(filePath, 'utf-8');
+        const itemDir = await resolveRegistryItemPath(reg.name, type, name);
+        return await fs.readFile(path.join(itemDir, 'README.md'), 'utf-8');
       } catch { /* not in this registry */ }
     }
   }
@@ -331,8 +513,8 @@ export async function getTemplateYaml(name: string, source?: string): Promise<st
   // If a specific source is given, use it directly
   if (source && source !== 'Built-in') {
     try {
-      const filePath = path.join(REGISTRIES_DIR, source, 'templates', name, 'template.yml');
-      return await fs.readFile(filePath, 'utf-8');
+      const itemDir = await resolveRegistryItemPath(source, 'template', name);
+      return await fs.readFile(path.join(itemDir, 'template.yml'), 'utf-8');
     } catch {
       return null;
     }
@@ -344,8 +526,8 @@ export async function getTemplateYaml(name: string, source?: string): Promise<st
     const registries = getRegistries(config);
     for (const reg of registries) {
       try {
-        const filePath = path.join(REGISTRIES_DIR, reg.name, 'templates', name, 'template.yml');
-        return await fs.readFile(filePath, 'utf-8');
+        const itemDir = await resolveRegistryItemPath(reg.name, 'template', name);
+        return await fs.readFile(path.join(itemDir, 'template.yml'), 'utf-8');
       } catch { /* not in this registry */ }
     }
   }
@@ -498,14 +680,16 @@ export async function getTemplateVariables(name: string, source?: string): Promi
   };
 
   if (source && source !== 'Built-in') {
-    return tryRead(path.join(REGISTRIES_DIR, source, 'templates', name, 'variables.json'));
+    const itemDir = await resolveRegistryItemPath(source, 'template', name);
+    return tryRead(path.join(itemDir, 'variables.json'));
   }
 
   if (!source) {
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
-      const result = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'templates', name, 'variables.json'));
+      const itemDir = await resolveRegistryItemPath(reg.name, 'template', name);
+      const result = await tryRead(path.join(itemDir, 'variables.json'));
       if (result) return result;
     }
   }
@@ -536,14 +720,14 @@ export async function getTemplateConfigFiles(name: string, source?: string): Pro
   };
 
   if (source && source !== 'Built-in') {
-    return scanDir(path.join(REGISTRIES_DIR, source, 'templates', name));
+    return scanDir(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
-      const files = await scanDir(path.join(REGISTRIES_DIR, reg.name, 'templates', name));
+      const files = await scanDir(await resolveRegistryItemPath(reg.name, 'template', name));
       if (files.length > 0) return files;
     }
   }
@@ -577,14 +761,14 @@ export async function getTemplatePostDeployScript(name: string, source?: string)
   };
 
   if (source && source !== 'Built-in') {
-    return tryRead(path.join(REGISTRIES_DIR, source, 'templates', name));
+    return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
-      const found = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'templates', name));
+      const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
       if (found !== null) return found;
     }
   }
@@ -610,14 +794,14 @@ export async function getTemplateUserGuide(name: string, source?: string): Promi
   };
 
   if (source && source !== 'Built-in') {
-    return tryRead(path.join(REGISTRIES_DIR, source, 'templates', name));
+    return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
-      const found = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'templates', name));
+      const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
       if (found !== null) return found;
     }
   }
@@ -638,14 +822,14 @@ export async function getTemplateChangelog(name: string, source?: string): Promi
   };
 
   if (source && source !== 'Built-in') {
-    return tryRead(path.join(REGISTRIES_DIR, source, 'templates', name));
+    return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
-      const found = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'templates', name));
+      const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
       if (found !== null) return found;
     }
   }
@@ -722,14 +906,14 @@ export async function getTemplateMigrationScripts(
   };
 
   if (source && source !== 'Built-in') {
-    return scanDir(path.join(REGISTRIES_DIR, source, 'templates', name));
+    return scanDir(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
-      const found = await scanDir(path.join(REGISTRIES_DIR, reg.name, 'templates', name));
+      const found = await scanDir(await resolveRegistryItemPath(reg.name, 'template', name));
       if (found.length > 0) return found;
     }
   }
@@ -762,13 +946,13 @@ export async function getStackManifest(
 
   let yamlText: string | null = null;
   if (source && source !== 'Built-in') {
-    yamlText = await tryRead(path.join(REGISTRIES_DIR, source, 'stacks', name));
+    yamlText = await tryRead(await resolveRegistryItemPath(source, 'stack', name));
   } else {
     if (!source) {
       const config = await getConfig();
       const registries = getRegistries(config);
       for (const reg of registries) {
-        const found = await tryRead(path.join(REGISTRIES_DIR, reg.name, 'stacks', name));
+        const found = await tryRead(await resolveRegistryItemPath(reg.name, 'stack', name));
         if (found !== null) { yamlText = found; break; }
       }
     }


### PR DESCRIPTION
## What
Registries can opt into a `servicebay.json` manifest at the repo root declaring where templates and stacks live, instead of the legacy `templates/<name>/` / `stacks/<name>/` convention:

\`\`\`json
{
  "templates": [{ "name": "oscar-household", "path": "servicebay-template" }],
  "stacks":    [{ "name": "household",       "path": "stacks/household"    }]
}
\`\`\`

Registries without a manifest keep using the legacy scan paths, so existing `mdopp/servicebay` and `mdopp/servicebay-templates` are unchanged.

## Why
Toward #1050 / future external-registry shapes. Lets a registry organise its top-level by its own subsystem boundaries instead of ServiceBay's expected sparse-checkout layout. The pattern matches Helm's `Chart.yaml` and similar manifest-driven plugin systems.

(Note: the `mdopp/oscar` repo we're prepping for OSCAR-as-product ended up choosing the legacy layout, so this PR is no longer a strict prerequisite for that migration. But it remains useful for any future registry that wants a different top-level shape, and the fallback is zero-cost for existing registries.)

## Risk
Low. The new code path only activates when a registry ships `servicebay.json`. The 16 hardcoded `path.join(REGISTRIES_DIR, ..., 'templates'|'stacks', ...)` references were refactored through a single resolver that defaults to the legacy convention. No current registry ships a manifest; behaviour for `mdopp/servicebay` is byte-identical to before.

## Rollback
\`git revert\`. Schema-less change — no migrations.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm run check:arch (invariants + depcruise pass)
- [x] npm test (1342 pass — includes new \`registry.manifest.test.ts\` with 5 cases covering legacy layout, manifest-declared paths, mixed templates+legacy-stacks, ghost-entry skip, and manifest-authoritative-over-stale-leftover).