### PR TITLE
feat(install): ship template skills/ directories to agent via existing extraFiles transport

### DIFF
--- a/packages/backend/src/lib/install/jobStore.ts
+++ b/packages/backend/src/lib/install/jobStore.ts
@@ -55,7 +55,7 @@ export interface JobInputItem {
   checked: boolean;
   alreadyInstalled?: boolean;
   yaml?: string;
-  configFiles?: { filename: string; content: string; targetPath?: string }[];
+  configFiles?: { filename: string; content: string; targetPath?: string; renderContent?: boolean }[];
   dependencies?: string[];
 }
 

--- a/packages/backend/src/lib/install/manifestAssembler.test.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.test.ts
@@ -12,11 +12,13 @@ import type { VariableMeta } from '@/lib/registry';
 const getTemplateYaml = vi.fn<(n: string, s?: string) => Promise<string | null>>();
 const getTemplateVariables = vi.fn<(n: string, s?: string) => Promise<Record<string, VariableMeta> | null>>();
 const getTemplateConfigFiles = vi.fn<(n: string, s?: string) => Promise<{ filename: string; content: string }[]>>();
+const getTemplateAssetFiles = vi.fn<(n: string, s?: string) => Promise<{ filename: string; content: string; targetPath?: string; renderContent?: boolean }[]>>();
 const getTemplateSettingsSchema = vi.fn<() => Promise<Record<string, { default: string; description?: string }>>>();
 vi.mock('@/lib/registry', () => ({
   getTemplateYaml: (n: string, s?: string) => getTemplateYaml(n, s),
   getTemplateVariables: (n: string, s?: string) => getTemplateVariables(n, s),
   getTemplateConfigFiles: (n: string, s?: string) => getTemplateConfigFiles(n, s),
+  getTemplateAssetFiles: (n: string, s?: string) => getTemplateAssetFiles(n, s),
   getTemplateSettingsSchema: () => getTemplateSettingsSchema(),
 }));
 
@@ -57,6 +59,8 @@ beforeEach(() => {
   getTemplateVariables.mockReset();
   getTemplateConfigFiles.mockReset();
   getTemplateConfigFiles.mockResolvedValue([]);
+  getTemplateAssetFiles.mockReset();
+  getTemplateAssetFiles.mockResolvedValue([]);
   getTemplateSettingsSchema.mockReset();
   getTemplateSettingsSchema.mockResolvedValue({});
   getConfig.mockReset();

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -28,6 +28,7 @@ import {
   getTemplateYaml,
   getTemplateVariables,
   getTemplateConfigFiles,
+  getTemplateAssetFiles,
   getTemplateSettingsSchema,
   type VariableMeta,
 } from '@/lib/registry';
@@ -244,10 +245,23 @@ export async function assembleManifest(
       for (const cf of cfgFiles) {
         for (const m of cf.content.matchAll(MUSTACHE_VAR_RE)) vars.add(m[1]);
       }
-      item.configFiles = cfgFiles.map(cf => ({
+    }
+
+    // Asset files (#1156) — a template's `skills/` subdirectory ships
+    // to `{{DATA_DIR}}/<template>/skills/<relpath>` on the agent via
+    // the same `extraFiles` transport. `renderContent: false` so
+    // SKILL.md bodies aren't mangled by Mustache. No vars are
+    // discovered from asset content for the same reason — they're
+    // shipped verbatim.
+    const assetFiles = await getTemplateAssetFiles(item.name, templateSource).catch(() => []);
+
+    const allFiles = [...cfgFiles, ...assetFiles];
+    if (allFiles.length > 0) {
+      item.configFiles = allFiles.map(cf => ({
         filename: cf.filename,
         content: cf.content,
         targetPath: cf.targetPath,
+        renderContent: cf.renderContent,
       }));
     }
   }

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -362,6 +362,10 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
   const refRe = /\{\{\s*[#^/{]?\s*([A-Z_][A-Z0-9_]*)\s*\}{1,3}/g;
   for (const cf of (item.configFiles || [])) {
     if (!cf.targetPath) continue;
+    // Asset files (#1156) ship content verbatim, so {{…}} in the body
+    // isn't a placeholder reference — skip the missing-var sanity check
+    // for them.
+    if (cf.renderContent === false) continue;
     const refs = new Set<string>();
     for (const m of cf.content.matchAll(refRe)) refs.add(m[1]);
     const missing = [...refs].filter(r => !(r in view) || view[r] === '');
@@ -377,7 +381,11 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
     .filter(cf => cf.targetPath)
     .map(cf => ({
       path: renderTemplate(cf.targetPath!, view),
-      content: renderTemplate(cf.content, view),
+      // Asset files (#1156) opt out of content rendering — SKILL.md
+      // bodies may contain `{{...}}` literals as documentation that
+      // Mustache would otherwise corrupt. Default-true preserves the
+      // existing `.mustache` behaviour for config files.
+      content: cf.renderContent === false ? cf.content : renderTemplate(cf.content, view),
     }));
 
   // Optional per-template post-deploy.py — server runs it after the unit

--- a/packages/backend/src/lib/registry.assets.test.ts
+++ b/packages/backend/src/lib/registry.assets.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Template asset-file discovery (#1156).
+ *
+ * A template that ships a `skills/` subdirectory under its template
+ * dir gets each file packaged as a `TemplateConfigFile` with
+ * `renderContent: false` and `targetPath` set to
+ * `{{DATA_DIR}}/<template-name>/skills/<relpath>`. The install runner
+ * concatenates these alongside the regular `.mustache` config files
+ * and the existing `extraFiles` transport ships them to the agent.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+
+// REGISTRIES_DIR is computed from CONTAINER_CONFIG_DIR at module load;
+// set it before importing registry.ts. Same pattern as
+// registry.manifest.test.ts.
+const TEST_ROOT = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _os = require('os') as typeof import('os');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _path = require('path') as typeof import('path');
+  const root = _path.join(_os.tmpdir(), `sb-registry-assets-${process.pid}`);
+  process.env.CONTAINER_CONFIG_DIR = root;
+  return root;
+});
+
+const mockConfigState = { registries: { enabled: true, items: [] as Array<{ name: string; url: string }> } };
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfigState),
+}));
+
+import {
+  getTemplateAssetFiles,
+  _resetRegistryManifestCacheForTests,
+} from './registry';
+
+const REG_DIR = path.join(TEST_ROOT, 'registries');
+
+async function seed(regName: string, layout: Record<string, string>): Promise<void> {
+  const regRoot = path.join(REG_DIR, regName);
+  for (const [relPath, content] of Object.entries(layout)) {
+    const full = path.join(regRoot, relPath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+}
+
+beforeEach(async () => {
+  await fs.rm(REG_DIR, { recursive: true, force: true });
+  await fs.mkdir(REG_DIR, { recursive: true });
+  mockConfigState.registries.items = [];
+  _resetRegistryManifestCacheForTests();
+});
+
+describe('getTemplateAssetFiles', () => {
+  it('returns an empty list for a template with no skills/ dir', async () => {
+    await seed('oscar', {
+      'templates/oscar-household/template.yml': 'apiVersion: v1\nkind: Pod\n',
+    });
+    const out = await getTemplateAssetFiles('oscar-household', 'oscar');
+    expect(out).toEqual([]);
+  });
+
+  it('walks skills/ recursively and emits one entry per file', async () => {
+    await seed('oscar', {
+      'templates/oscar-household/template.yml': 'apiVersion: v1\nkind: Pod\n',
+      'templates/oscar-household/skills/audit-query/SKILL.md': '# audit-query\n',
+      'templates/oscar-household/skills/audit-query/helper.py': 'print("hi")\n',
+      'templates/oscar-household/skills/status/SKILL.md': '# status\n',
+    });
+    const out = await getTemplateAssetFiles('oscar-household', 'oscar');
+    const byName = Object.fromEntries(out.map(f => [f.filename, f]));
+    expect(Object.keys(byName).sort()).toEqual([
+      path.join('skills', 'audit-query', 'SKILL.md'),
+      path.join('skills', 'audit-query', 'helper.py'),
+      path.join('skills', 'status', 'SKILL.md'),
+    ]);
+    expect(byName[path.join('skills', 'audit-query', 'SKILL.md')].content).toBe('# audit-query\n');
+  });
+
+  it('sets renderContent: false on every entry (assets ship verbatim)', async () => {
+    await seed('oscar', {
+      'templates/oscar-household/skills/audit-query/SKILL.md': '# audit-query — `{{cost}}` is documentation, not a placeholder\n',
+    });
+    const out = await getTemplateAssetFiles('oscar-household', 'oscar');
+    expect(out).toHaveLength(1);
+    expect(out[0].renderContent).toBe(false);
+  });
+
+  it('resolves targetPath to {{DATA_DIR}}/<template>/skills/<relpath>', async () => {
+    await seed('oscar', {
+      'templates/oscar-household/skills/dynamic-skills/SKILL.md': 'x',
+    });
+    const out = await getTemplateAssetFiles('oscar-household', 'oscar');
+    expect(out[0].targetPath).toBe('{{DATA_DIR}}/oscar-household/skills/dynamic-skills/SKILL.md');
+  });
+
+  it('ignores dotfiles and dot-directories', async () => {
+    await seed('oscar', {
+      'templates/oscar-household/skills/.hidden/SKILL.md': 'should be skipped',
+      'templates/oscar-household/skills/status/.gitkeep': 'should also be skipped',
+      'templates/oscar-household/skills/status/SKILL.md': 'kept',
+    });
+    const out = await getTemplateAssetFiles('oscar-household', 'oscar');
+    const names = out.map(f => f.filename);
+    expect(names).toEqual([path.join('skills', 'status', 'SKILL.md')]);
+  });
+
+  it('walks each configured registry and returns the first match', async () => {
+    await seed('first', {
+      'templates/foo/template.yml': 'apiVersion: v1\nkind: Pod\n',
+    });
+    await seed('second', {
+      'templates/foo/template.yml': 'apiVersion: v1\nkind: Pod\n',
+      'templates/foo/skills/only-here/SKILL.md': 'found in second',
+    });
+    mockConfigState.registries.items.push({ name: 'first', url: 'http://x/first.git' });
+    mockConfigState.registries.items.push({ name: 'second', url: 'http://x/second.git' });
+
+    const out = await getTemplateAssetFiles('foo');
+    expect(out).toHaveLength(1);
+    expect(out[0].content).toBe('found in second');
+  });
+
+  it('respects a pinned source — only that registry is consulted', async () => {
+    await seed('first', {
+      'templates/foo/skills/x/SKILL.md': 'in first',
+    });
+    await seed('second', {
+      'templates/foo/skills/x/SKILL.md': 'in second',
+    });
+    mockConfigState.registries.items.push({ name: 'first', url: 'http://x/first.git' });
+    mockConfigState.registries.items.push({ name: 'second', url: 'http://x/second.git' });
+
+    const fromFirst = await getTemplateAssetFiles('foo', 'first');
+    expect(fromFirst[0].content).toBe('in first');
+    const fromSecond = await getTemplateAssetFiles('foo', 'second');
+    expect(fromSecond[0].content).toBe('in second');
+  });
+});

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -698,12 +698,23 @@ export async function getTemplateVariables(name: string, source?: string): Promi
 }
 
 export interface TemplateConfigFile {
-  /** Filename without .mustache extension (e.g. "configuration.yml") */
+  /** Filename without .mustache extension (e.g. "configuration.yml").
+   *  For asset files this is the path *relative to the template dir*
+   *  (e.g. "skills/audit-query/SKILL.md") so the receiver has a
+   *  meaningful name for diagnostics. */
   filename: string;
-  /** Raw Mustache template content */
+  /** Raw Mustache template content (when `renderContent` is true) or
+   *  verbatim file bytes (when false). */
   content: string;
-  /** Target path hint from template.yml volume mounts (set by caller) */
+  /** Target path on the agent host. Always Mustache-rendered against
+   *  the deploy variables, so `{{DATA_DIR}}` etc. resolve. */
   targetPath?: string;
+  /** When false, `content` is shipped verbatim — Mustache rendering is
+   *  skipped. Used for asset files (Hermes SKILL.md and similar) whose
+   *  body may legitimately contain `{{...}}` literals that aren't
+   *  placeholders. Default: true (current `.mustache` config-file
+   *  behaviour). #1156. */
+  renderContent?: boolean;
 }
 
 /** Find .mustache config files for a template (e.g. authelia/configuration.yml.mustache). */
@@ -733,6 +744,91 @@ export async function getTemplateConfigFiles(name: string, source?: string): Pro
   }
 
   return scanDir(path.join(TEMPLATES_PATH, name));
+}
+
+/**
+ * Walk `<template-dir>/skills/` recursively and return one
+ * `TemplateConfigFile` per file, with `targetPath` pre-set to
+ * `{{DATA_DIR}}/<template-name>/skills/<relative-path>` and
+ * `renderContent: false` so Mustache leaves SKILL.md bodies alone
+ * (they often contain `{{...}}` literals as documentation that
+ * mustache would otherwise corrupt).
+ *
+ * The install runner concatenates the result with the regular
+ * `.mustache` config files; the existing `extraFiles` transport
+ * (`packages/backend/src/lib/services/serviceLifecycle.ts:677`)
+ * writes each one to the agent host via `agent.sendCommand('write_file', …)`.
+ * This is the delivery path that #1025's README claim ("placed there
+ * by ServiceBay's registry sync") was missing. #1156.
+ *
+ * Returns `[]` when the template ships no `skills/` directory —
+ * which is every template today except OSCAR's `oscar-household`
+ * (after migration to `mdopp/oscar`).
+ *
+ * Same registry-fallback semantics as `getTemplateConfigFiles`.
+ * Symlinks are ignored to keep the convention to "files in the
+ * template's own tree only" — operators introducing symlinks should
+ * use an explicit asset annotation if/when one lands.
+ */
+async function walkSkillsDir(skillsDir: string, templateName: string): Promise<TemplateConfigFile[]> {
+  try {
+    const st = await fs.stat(skillsDir);
+    if (!st.isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  const out: TemplateConfigFile[] = [];
+  const stack: string[] = ['.'];
+  while (stack.length > 0) {
+    const rel = stack.pop()!;
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(path.join(skillsDir, rel), { withFileTypes: true });
+    } catch {
+      // Unreadable subdir — skip rather than break the whole walk.
+      continue;
+    }
+    for (const ent of entries) {
+      if (ent.name.startsWith('.')) continue;
+      if (ent.isSymbolicLink()) continue;
+      const childRel = rel === '.' ? ent.name : path.join(rel, ent.name);
+      if (ent.isDirectory()) {
+        stack.push(childRel);
+      } else if (ent.isFile()) {
+        const content = await fs.readFile(path.join(skillsDir, childRel), 'utf-8');
+        out.push({
+          filename: path.join('skills', childRel),
+          content,
+          targetPath: `{{DATA_DIR}}/${templateName}/skills/${childRel}`,
+          renderContent: false,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+export async function getTemplateAssetFiles(
+  name: string,
+  source?: string,
+): Promise<TemplateConfigFile[]> {
+  const walk = (templateDir: string) =>
+    walkSkillsDir(path.join(templateDir, 'skills'), name);
+
+  if (source && source !== 'Built-in') {
+    return walk(await resolveRegistryItemPath(source, 'template', name));
+  }
+
+  if (!source) {
+    const config = await getConfig();
+    const registries = getRegistries(config);
+    for (const reg of registries) {
+      const files = await walk(await resolveRegistryItemPath(reg.name, 'template', name));
+      if (files.length > 0) return files;
+    }
+  }
+
+  return walk(path.join(TEMPLATES_PATH, name));
 }
 
 /**


### PR DESCRIPTION
## What
Templates can now ship a \`skills/\` subdirectory whose contents are walked recursively, packaged as \`TemplateConfigFile\` entries with \`renderContent: false\` and \`targetPath: {{DATA_DIR}}/<template>/skills/<relpath>\`, and shipped to the agent via the existing \`extraFiles\` transport (\`serviceLifecycle.ts:677\`). The runner honours \`renderContent: false\` by passing content verbatim and skipping the missing-var sanity check for asset files.

## Why
Closes #1156. This is the delivery mechanism #1025's README claim (\"placed there by ServiceBay's registry sync\") was always missing. First consumer will be OSCAR's \`oscar-household\` after the mdopp/oscar migration (#1157) — its \`skills/\` directory ships through this path to the Hermes bind-mount target.

## Risk
Low. The new code path only activates when a template ships a \`skills/\` directory. No current template does — verified via \`find templates -type d -name skills\`. Existing templates behave byte-identical to before. The shape change to \`TemplateConfigFile\` adds an optional \`renderContent?: boolean\` (defaults to true = existing behaviour).

## Rollback
\`git revert\`. No persistence migrations; the renderContent flag is added optionally to JobInputItem.configFiles[] so older persisted job state still deserializes correctly.

## Verification
- [x] npm run lint (421 warnings, unchanged from baseline)
- [x] npm run check:arch (invariants + depcruise pass, 606 modules)
- [x] npm test (1349 pass, 2 skipped — includes 7 new cases in \`registry.assets.test.ts\` covering: no skills dir → [], recursive walk, renderContent: false on every entry, targetPath formation, dotfile skipping, registry walk fallback, source-pinned lookup)
- [x] /verify on local dev — planted a fixture skills/ dir under templates/auth/, confirmed (a) regular flow unchanged when no skills/ is present, (b) recursive walk + targetPath/renderContent set correctly when skills/ is present, (c) runner reaches \`Pre-pulling images\` past the sanity-check loop without aborting on \`{{LITERAL}}\` literals in the planted SKILL.md (proving renderContent: false is honoured at the runner layer too).