### PR TITLE
docs: reflect OSCAR-as-external-registry world

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -50,6 +50,7 @@ flowchart TD
 │             │ FritzBox password            │ —          │ ✗ secret   │
 ├─────────────┼──────────────────────────────┼────────────┼────────────┤
 │ Registries  │ Enable servicebay-templates  │ y          │ ✓          │
+│             │ Enable mdopp/oscar           │ y          │ ✓          │
 │ Email       │ SMTP host/port/user/pass/TLS │ —          │ partial    │
 │ Backup      │ Restore .tar.gz path         │ —          │ ✗          │
 └─────────────┴──────────────────────────────┴────────────┴────────────┘

--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -562,7 +562,28 @@ registries override built-ins with the same name, so you can ship a
 custom variant of any bundled template by publishing it under the same
 directory name.
 
-### Custom layouts via `servicebay.json` (#1050)
+First-party registries ServiceBay knows about:
+
+- **`mdopp/servicebay-templates`** — the canonical external template
+  set. Operator prompt at FCoS install time defaults to enabled.
+- **`mdopp/oscar`** — the household AI assistant tier (Ollama,
+  Hermes, Hermes WebUI, oscar-household template, plus the OSCAR
+  stack bundling them). Operator prompt at FCoS install time
+  defaults to enabled; decline to keep the install lean.
+
+### Asset directories (`skills/`) on a template
+
+Any template can ship a `skills/` subdirectory; the install runner
+walks it recursively and ships each file to the agent at
+`{{DATA_DIR}}/<template>/skills/<relpath>`. Content goes through
+verbatim — Mustache rendering and the missing-variable sanity check
+are both skipped — because SKILL.md and friends commonly contain
+`{{...}}` tokens as documentation that would otherwise mistakenly
+trigger placeholder substitution. See #1156. First consumer is the
+OSCAR `oscar-household` template's skill pack at
+`templates/oscar-household/skills/` in `mdopp/oscar`.
+
+### Custom layouts via `servicebay.json`
 
 For registries whose top-level layout reflects their own subsystem
 boundaries rather than ServiceBay's expected sparse-checkout shape,
@@ -572,10 +593,10 @@ and stacks live:
 ```json
 {
   "templates": [
-    { "name": "oscar-household", "path": "servicebay-template" }
+    { "name": "my-template", "path": "my-template-dir" }
   ],
   "stacks": [
-    { "name": "household", "path": "stacks/household" }
+    { "name": "my-stack", "path": "stacks/my-stack" }
   ]
 }
 ```
@@ -594,8 +615,8 @@ clone exposes `servicebay.json`, the sync layer re-runs
 the working tree only carries the paths the manifest names plus the
 default `templates/` + `stacks/` fallbacks.
 
-Example use case: `mdopp/oscar` keeps its template, Hermes skill pack,
-Wyoming-bridge image source, and Postgres-schema migrations in clearly
-separated top-level directories, with `servicebay.json` pointing the
-ServiceBay template at `servicebay-template/`. No `templates/` folder
-at the registry root.
+Note: `mdopp/oscar` uses the **legacy** `templates/<name>/` layout (no
+manifest), even though it has multiple subsystems at top level
+(`voice-gatekeeper/`, `database/`, `__init__.py` for the Hermes-plugin
+path). The manifest mechanism stays available for future registries
+where consumer-named top-level dirs make more sense.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,17 +92,17 @@ Four of five intents, substantially, from `pip install` + config. That is the ho
 
 ## Tier 3 — the household deployment
 
-Tier 3 is what the rest of this repo builds: OSCAR as a ServiceBay stack, for a household rather than one person.
+Tier 3 is what the rest of the OSCAR product builds: OSCAR as a ServiceBay-managed deployment, for a household rather than one person. OSCAR lives in its own repo ([`mdopp/oscar`](https://github.com/mdopp/oscar)) as an external ServiceBay registry — enable it at FCoS install time (or via Settings → Registries) and the four OSCAR templates (`ollama`, `hermes`, `hermes-webui`, `oscar-household`) plus the `oscar` stack appear in the wizard.
 
 What Tier 3 adds over Tier 2:
 
-- **Packaged, wizard-driven deploy** — ServiceBay's `ai-stack` (Ollama + Hermes) plus OSCAR's `oscar-household` template, instead of a hand-run `pip install`.
+- **Packaged, wizard-driven deploy** — install the four-template OSCAR stack with one click instead of running `pip install hermes-agent` and configuring each piece by hand.
 - **Cloud-LLM audit** — every cloud call writes a `cloud_audit` row, family-readable via the `oscar-audit-query` skill.
 - **HA Voice PE in the rooms** — the `gatekeeper` container bridges Wyoming-protocol voice pucks to Hermes (Phase 1).
 - **Voice = identity** — speaker-ID maps a voice to an LLDAP resident and the right Honcho peer (Phase 2).
 - **German-household defaults** and the per-resident harness composition.
 
-Walkthrough: [`../stacks/oscar/README.md`](../stacks/oscar/README.md). It depends on ServiceBay's `ai-stack` templates ([mdopp/servicebay#544](https://github.com/mdopp/servicebay/pull/544)).
+Walkthrough: [`mdopp/oscar`'s README](https://github.com/mdopp/oscar#readme). Enable the OSCAR registry during FCoS install (the prompt defaults to `Y`), or add `https://github.com/mdopp/oscar` to Settings → Registries on an existing install.
 
 ---
 


### PR DESCRIPTION
## What
Three docs catch up to the post-OSCAR-migration state:

- **docs/TEMPLATE_AUTHORING.md** — Names the two first-party external registries (\`mdopp/servicebay-templates\` + \`mdopp/oscar\`). Documents the new \`skills/\` asset-directory convention (#1156). Generalises the \`servicebay.json\` manifest example away from \`oscar-household\` since OSCAR ended up using the legacy \`templates/\` layout.
- **docs/INSTALLATION.md** — Adds a row to the FCoS installer prompt table for the new OSCAR-registry y/n.
- **docs/getting-started.md** — Tier 3 had been describing \`ai-stack\` + an in-tree \`oscar-household\` template; reframed as \"enable the \`mdopp/oscar\` external registry, install the \`oscar\` stack\".

## Why
Closes #1160. Companion to #1157 (bootstrap) and #1158 (registry prompt) so operator-facing docs match the deployed reality.

## Risk
None — pure docs. No code paths touched.

## Rollback
\`git revert\`.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] Docs link-target sanity — \`mdopp/oscar\` repo exists at the URL referenced; \`mdopp/servicebay-templates\` referenced where it has always been; no broken internal anchors.