### PR TITLE
fix(portal): accept Syncthing v2.x 8-group device-ids

### DIFF
--- a/packages/backend/src/lib/portal/assets.ts
+++ b/packages/backend/src/lib/portal/assets.ts
@@ -182,11 +182,14 @@ export async function fetchSyncthingDeviceId(node: string = 'Local'): Promise<st
     }, { timeoutMs: 6_000 }) as { code?: number; stdout?: string };
     if (res.code !== 0) return null;
     const id = (res.stdout ?? '').trim();
-    // Syncthing device IDs are 56 chars in 7 groups of 7 separated
-    // by hyphens (e.g. ABCDEFG-HIJKLMN-...). Lightly validate so
-    // a noisy stdout (warning lines, etc.) doesn't smuggle junk
-    // into the QR.
-    if (!/^[A-Z2-7]{7}(-[A-Z2-7]{7}){6}$/.test(id)) {
+    // Syncthing device IDs use base32 with check digits separated
+    // by hyphens. Syncthing v1.x format: 56 chars in 7 groups of 7.
+    // Syncthing v2.x format (observed live 2026-05-27 on v2.1.0):
+    // 63 chars in 8 groups of 7 (extra check character per group).
+    // Accept either — the QR encoder doesn't care about the group
+    // count, only the operator's Syncthing app does, and that handles
+    // both formats from any version it shipped against.
+    if (!/^[A-Z2-7]{7}(-[A-Z2-7]{7}){6,7}$/.test(id)) {
       logger.warn('portal:assets', `Unexpected syncthing device-id shape: ${id.slice(0, 40)}`);
       return null;
     }


### PR DESCRIPTION
## What
Update the device-id shape regex in \`portal/assets.ts\` to accept both:
- Syncthing v1.x format: 56 chars, 7 groups of 7
- Syncthing v2.x format: 63 chars, 8 groups of 7

Live finding from the UI walk against \`core@192.168.178.100\` — the v2.1.0 container running in \`file-share-syncthing\` emits an 8-group ID; the regex rejected it; the asset resolver returned null; the /portal Pair-this-device modal showed \"Couldn't read the device id (HTTP 404)\". Live log line:
\`WARN [portal:assets] Unexpected syncthing device-id shape: 4WJXOU7-HWI4EW3-U6EXUDS-GEEJU7H-JQI3GD7-\` (40-char log slice of a longer 8-group id).

## Why
Second of two cascading bugs on the Syncthing pairing flow. #1172 fixed the public-mode 404. This fixes the actual resolver-rejection bug behind it. Both together make pairing work end-to-end.

## Risk
Low. The regex now accepts more shapes than before — strict subset of \"more permissive on legitimate inputs\". The 8-group format is what real Syncthing v2.x emits; nothing else generates strings matching that pattern by accident.

## Rollback
\`git revert\`.

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm test (1330 pass)
- [ ] Live: rebuild image, hit /portal pair button on the box, expect QR to render.