### PR TITLE
fix(install): pre-pull renders {{VAR}} image placeholders against wizard variables

### DIFF
--- a/packages/backend/src/lib/install/collectImagesToPull.test.ts
+++ b/packages/backend/src/lib/install/collectImagesToPull.test.ts
@@ -73,4 +73,35 @@ describe('collectImagesToPull', () => {
   it('returns an empty array for empty input', () => {
     expect(collectImagesToPull([])).toEqual([]);
   });
+
+  // ─── view-rendering (#1170) ────────────────────────────────────────
+  it('renders {{VAR}} image refs against the provided view', () => {
+    const items = [
+      {
+        name: 'oscar-household',
+        yaml: 'spec:\n  containers:\n  - image: {{GATEKEEPER_IMAGE}}\n    name: gatekeeper\n',
+      },
+    ];
+    const view = { GATEKEEPER_IMAGE: 'ghcr.io/mdopp/oscar-gatekeeper:latest' };
+    expect(collectImagesToPull(items, view)).toEqual([
+      'ghcr.io/mdopp/oscar-gatekeeper:latest',
+    ]);
+  });
+
+  it('skips images whose template var is unresolved (no value in view)', () => {
+    const items = [
+      { name: 'a', yaml: '  image: {{MISSING}}' },
+      { name: 'b', yaml: '  image: nginx:1.25' },
+    ];
+    expect(collectImagesToPull(items, { OTHER: 'x' })).toEqual(['nginx:1.25']);
+  });
+
+  it('without a view, still returns the literal placeholder (back-compat with callers that pre-render)', () => {
+    const items = [
+      { name: 'a', yaml: '  image: {{GATEKEEPER_IMAGE}}' },
+    ];
+    // No view → no rendering; the placeholder comes through verbatim
+    // so callers that have already rendered keep working.
+    expect(collectImagesToPull(items)).toEqual(['{{GATEKEEPER_IMAGE}}']);
+  });
 });

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -181,14 +181,34 @@ async function waitForCredentials(
  */
 export function collectImagesToPull(
   items: ReadonlyArray<{ name: string; yaml?: string; alreadyInstalled?: boolean }>,
+  view?: Record<string, string>,
 ): string[] {
   const seen = new Set<string>();
   const imageRe = /^[\t ]*-?[\t ]*image:[\t ]*['"]?([^\s'"#]+)['"]?[\t ]*(?:#.*)?$/gm;
   for (const item of items) {
     if (item.alreadyInstalled || !item.yaml) continue;
     for (const m of item.yaml.matchAll(imageRe)) {
-      const image = m[1].trim();
-      if (image) seen.add(image);
+      let image = m[1].trim();
+      if (!image) continue;
+      // Templates may interpolate the image tag via Mustache
+      // (e.g. `image: {{GATEKEEPER_IMAGE}}`). The pre-pull step ran
+      // BEFORE per-item Mustache rendering, so the literal placeholder
+      // hit `agent.pullImage()` and surfaced as
+      //   "(note) pre-pull failed for {{GATEKEEPER_IMAGE}}: parsing
+      //   reference … invalid reference format"
+      // in the install log. Render now when a view is provided. If
+      // the rendered string STILL contains an unresolved `{{...}}`
+      // (no value for that variable), skip the pre-pull for that
+      // image — the deploy-step's sequential pull will handle it
+      // with the proper render context. #1170.
+      if (view) {
+        image = renderTemplate(image, view);
+        // Mustache expands missing vars to '' rather than leaving the
+        // literal `{{...}}` in place, so check both shapes — empty or
+        // still-templated → skip and let the deploy step handle it.
+        if (!image || image.includes('{{')) continue;
+      }
+      seen.add(image);
     }
   }
   return [...seen];
@@ -975,7 +995,14 @@ async function runJob(jobId: string): Promise<void> {
   // subsequent unit start will trigger a sequential retry via Quadlet's
   // own image-pull path; the operator just loses the parallelism
   // benefit for that one image.
-  const imagesToPull = collectImagesToPull(selected);
+  // Render image refs against the wizard variables so templates that
+  // interpolate `image: {{VAR}}` get a real registry reference at
+  // pre-pull time, not the literal placeholder. #1170.
+  const prePullView = (input.variables as StackVariable[]).reduce<Record<string, string>>((acc, v) => {
+    if (typeof v.value === 'string') acc[v.name] = v.value;
+    return acc;
+  }, {});
+  const imagesToPull = collectImagesToPull(selected, prePullView);
   if (imagesToPull.length > 0) {
     await log(jobId, `📦 Pre-pulling ${imagesToPull.length} container image${imagesToPull.length === 1 ? '' : 's'} in parallel...`);
     const node = input.node || 'Local';


### PR DESCRIPTION
## What
\`collectImagesToPull(items, view?)\` now optionally renders captured image strings against the wizard's Mustache view. The install runner builds the view from \`input.variables\` and passes it. Templates that interpolate the image tag via Mustache (\`image: {{GATEKEEPER_IMAGE}}\`) get a real registry reference at pre-pull time instead of the literal placeholder.

## Why
Closes #1170. Discovered live during the OSCAR migration smoke-test on \`core@192.168.178.100\`: redeploying \`oscar-household\` produced \"(note) pre-pull failed for {{GATEKEEPER_IMAGE}}: parsing reference … invalid reference format\" in the install log. Cosmetic at runtime (deploy-step's sequential pull then succeeded with the rendered ref), but misleading for operators reading logs.

## Risk
Low. The new code path only activates when a \`view\` arg is passed. Existing back-compat call shape (no view) returns identical output to before — verified by the new test \`without a view, still returns the literal placeholder\`. An image whose template var has no value (renders to '' or still contains '{{') gets skipped from pre-pull and falls back to the deploy-step's sequential pull.

## Rollback
\`git revert\`. No persistence migrations. The signature change is additive (optional second arg).

## Verification
- [x] npm run lint (421 warnings, unchanged)
- [x] npm run check:arch (606 modules, 0 violations)
- [x] npm test (1333 pass, 2 skipped — includes 3 new cases in \`collectImagesToPull.test.ts\`)
- [ ] /verify against FCoS box — after merge + image build: redeploy oscar-household, expect the \"pre-pull failed for {{GATEKEEPER_IMAGE}}\" log line to be gone and the gatekeeper image to pull in parallel with the schema-init image.