### PR TITLE
chore(smoke): drop ollama.dopp.cloud check from sso-verify

### DIFF
--- a/scripts/smoke/sso-verify.sh
+++ b/scripts/smoke/sso-verify.sh
@@ -75,7 +75,7 @@ ssh_cmd() {
 RESOLVE_FLAGS=""
 build_resolve_flags() {
   local hosts=(auth ldap admin nginx dns)
-  hosts+=(vault photos music books home files caldav sync hermes ollama zwave www)
+  hosts+=(vault photos music books home files caldav sync hermes zwave www)
   hosts+=("")  # bare apex
   RESOLVE_FLAGS=""
   for h in "${hosts[@]}"; do
@@ -320,11 +320,10 @@ declare -A USER_APPS=(
   # is the literal dashboard title so the test also catches a "200 with
   # wrong content" regression (proxy half-broken).
   [hermes]="Hermes Agent"
-  # Ollama API behind Authelia forward-auth (#1003). The browser-flow
-  # session reaches /api/tags via NPM; non-LAN IPs get 403 from the
-  # access list. No content signature — Ollama responds with JSON that
-  # changes per installed-model set.
-  [ollama]=""
+  # ollama.dopp.cloud intentionally not checked: the ollama template
+  # ships no auth of its own and the wizard requires explicit opt-in
+  # to expose it via NPM. Bare default installs have no proxy host
+  # for ollama.dopp.cloud, so probing it would false-fail. See #1180.
 )
 
 for h in "${!USER_APPS[@]}"; do


### PR DESCRIPTION
## What
Removes \`ollama\` from sso-verify's \`USER_APPS\` and \`hosts\` arrays. Ollama isn't exposed via NPM in the default install — operators opt in by setting \`OLLAMA_SUBDOMAIN\` in the wizard. Probing the domain on a bare default install causes a 1/34 false failure.

## Why
Closes the operator-side rough edge from #1180.

## Risk
Trivial. Smoke-test scope shrinks by one check.

## Verification
- [x] npm run lint (unchanged, 421 warnings)