### PR TITLE
fix(network): break infinite-render loop in useTopologyData by stabilising fetchGraph

### DIFF
--- a/packages/frontend/src/hooks/useTopologyData.test.ts
+++ b/packages/frontend/src/hooks/useTopologyData.test.ts
@@ -1,0 +1,85 @@
+/**
+ * useTopologyData — callback-stability tests (#1175).
+ *
+ * The NetworkDashboard route used to crash with React error #185 (max
+ * update depth exceeded) because this hook accepted `onLoadStart` /
+ * `onLoadError` as direct useCallback deps. Callers passing inline
+ * arrows produced a fresh `fetchGraph` ref every render → the two
+ * auto-fetch effects re-fired → each fetch's setRawData re-rendered →
+ * fresh callbacks again → infinite loop.
+ *
+ * These tests pin the contract: fetchGraph keeps a stable identity
+ * across renders, even when the option callbacks come from inline
+ * arrows that change every time.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// useTopologyData reads twin state via useDigitalTwin. Stub it so the
+// hook doesn't try to wire up the real socket.io provider.
+vi.mock('@/hooks/useDigitalTwin', () => ({
+  useDigitalTwin: () => ({ data: null }),
+}));
+
+import { useTopologyData } from './useTopologyData';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ nodes: [], edges: [] }),
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useTopologyData callback stability (#1175)', () => {
+  it('returns a stable fetchGraph across renders even when callers pass fresh inline arrows', () => {
+    const { result, rerender } = renderHook(() =>
+      useTopologyData({
+        onLoadStart: () => { /* fresh arrow every render */ },
+        onLoadError: (msg) => { void msg; /* fresh arrow every render */ },
+      }),
+    );
+
+    const firstFetchGraph = result.current.fetchGraph;
+    rerender();
+    rerender();
+    rerender();
+    expect(result.current.fetchGraph).toBe(firstFetchGraph);
+  });
+
+  it('still calls the LATEST onLoadStart / onLoadError when fetchGraph runs after a re-render', async () => {
+    // Caller updates the callbacks every render. The hook must dispatch
+    // to the most recent ones, not the originals captured at mount.
+    let latestErr: string | null = null;
+    let calls = 0;
+
+    const { result, rerender } = renderHook(
+      ({ tag }: { tag: string }) =>
+        useTopologyData({
+          onLoadStart: () => { calls += 1; },
+          onLoadError: (msg) => { latestErr = `${tag}: ${msg}`; },
+        }),
+      { initialProps: { tag: 'first' } },
+    );
+
+    // Wait for the initial-mount fetch to complete
+    await waitFor(() => expect(calls).toBeGreaterThan(0));
+
+    // Re-render with a new tag — the callbacks change closure values.
+    rerender({ tag: 'second' });
+
+    // Force a failing fetch this time
+    fetchMock.mockRejectedValueOnce(new Error('boom'));
+    await act(async () => {
+      await result.current.fetchGraph();
+    });
+    expect(latestErr).toBe('second: boom');
+  });
+});

--- a/packages/frontend/src/hooks/useTopologyData.ts
+++ b/packages/frontend/src/hooks/useTopologyData.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 import type { DigitalTwinSnapshot } from '@/providers/DigitalTwinProvider';
 import type { NetworkGraph } from '@servicebay/api-client';
@@ -40,12 +40,24 @@ interface UseTopologyDataResult {
  * has no dependency on the toast provider so it stays testable.
  */
 export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopologyDataResult {
-  const { onLoadStart, onLoadError } = options;
   const { data: twin } = useDigitalTwin();
   const [rawData, setRawData] = useState<NetworkGraph | null>(null);
 
+  // #1175 — keep `onLoadStart` / `onLoadError` in refs so callers can
+  // pass inline arrow functions without churning `fetchGraph`'s
+  // identity. Without this, `useCallback([onLoadStart, onLoadError])`
+  // saw a new ref every render, both effects below re-fired on every
+  // render, and the NetworkDashboard hit React error #185 (max update
+  // depth — fetch → setRawData → re-render → fresh callbacks → fresh
+  // fetchGraph → effects re-fire → fetch …). The ref pattern keeps
+  // the hook tolerant of unstable callers.
+  const onLoadStartRef = useRef(options.onLoadStart);
+  const onLoadErrorRef = useRef(options.onLoadError);
+  onLoadStartRef.current = options.onLoadStart;
+  onLoadErrorRef.current = options.onLoadError;
+
   const fetchGraph = useCallback(async () => {
-    onLoadStart?.();
+    onLoadStartRef.current?.();
     try {
       const res = await fetch('/api/network/graph');
       if (!res.ok) {
@@ -55,9 +67,9 @@ export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopolo
       setRawData(data);
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unable to reload network map';
-      onLoadError?.(message);
+      onLoadErrorRef.current?.(message);
     }
-  }, [onLoadStart, onLoadError]);
+  }, []);
 
   // Kick off the first render as soon as the dashboard mounts so the
   // toast shows immediately.


### PR DESCRIPTION
## What
\`useTopologyData\` now keeps \`onLoadStart\` / \`onLoadError\` in refs so \`fetchGraph\`'s identity stays stable across the caller's renders. The hook still dispatches to the LATEST callbacks at call-time — standard ref-based pattern for tolerating unstable callers.

## Why
Closes #1175. NetworkDashboard hit React error #185 (\"Maximum update depth exceeded\") on every visit. Caller passed an inline arrow as \`onLoadError\` → fetchGraph's useCallback saw a fresh ref every render → both auto-fetch effects re-fired → setRawData re-rendered → fresh arrow again → loop.

## Risk
Low. \`fetchGraph\`'s contract is unchanged from callers' perspective — it still triggers \`onLoadStart\` on every call and \`onLoadError\` on every failure. The only behaviour change: callbacks are read via refs (always the latest closure) instead of captured at useCallback creation. Two regression tests pin the contract: identity stability + latest-closure dispatch.

## Rollback
\`git revert\`.

## Verification
- [x] npm run lint (421 warnings, unchanged from baseline)
- [x] npm run check:arch (607 modules, 0 violations)
- [x] npm test (1335 pass, 2 skipped — includes 2 new cases in useTopologyData.test.ts)
- [ ] /verify against FCoS box — after merge + image build: open /network in the dashboard, expect the page to render without the React error #185 console log + the Network Map to actually appear.