### PR TITLE
refactor(services): extract chownContainerMounts from fixVolumeOwnership

### DIFF
--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -842,8 +842,36 @@ export class ServiceLifecycle {
     /** Fix volume ownership for containers with explicit runAsUser/runAsGroup.
      *  In rootless podman, host UIDs map differently inside the user namespace.
      *  Uses `podman unshare chown` to translate container UIDs to correct host UIDs. */
+    private static async chownContainerMounts(
+        nodeName: string,
+        container: NonNullable<NonNullable<PodLikeDoc['spec']>['containers']>[number],
+        volumePaths: Map<string, string>,
+    ): Promise<void> {
+        const uid = container.securityContext?.runAsUser;
+        const gid = container.securityContext?.runAsGroup ?? uid;
+        if (uid == null || uid === 0) return; // Skip root or unset
+
+        const mounts = container.volumeMounts || [];
+        for (const mount of mounts) {
+            if (!mount.name) continue;
+            const hostPath = volumePaths.get(mount.name);
+            if (!hostPath || mount.readOnly) continue;
+
+            const agent = await agentManager.ensureAgent(nodeName);
+            try {
+                await agent.sendCommand('exec', {
+                    command: `podman unshare chown -R ${uid}:${gid} ${hostPath}`
+                });
+                logger.info('ServiceManager', `Fixed volume ownership: ${hostPath} -> ${uid}:${gid}`);
+            } catch (e) {
+                logger.warn('ServiceManager', `Failed to fix ownership for ${hostPath}:`, e);
+            }
+        }
+    }
+
     private static async fixVolumeOwnership(nodeName: string, yamlContent: string) {
-        try {            const docs = yaml.loadAll(yamlContent) as PodLikeDoc[];
+        try {
+            const docs = yaml.loadAll(yamlContent) as PodLikeDoc[];
             for (const doc of docs) {
                 if (!doc?.spec) continue;
                 const containers = doc.spec.containers || [];
@@ -858,26 +886,7 @@ export class ServiceLifecycle {
                 }
 
                 for (const container of containers) {
-                    const uid = container.securityContext?.runAsUser;
-                    const gid = container.securityContext?.runAsGroup ?? uid;
-                    if (uid == null || uid === 0) continue; // Skip root or unset
-
-                    const mounts = container.volumeMounts || [];
-                    for (const mount of mounts) {
-                        if (!mount.name) continue;
-                        const hostPath = volumePaths.get(mount.name);
-                        if (!hostPath || mount.readOnly) continue;
-
-                        const agent = await agentManager.ensureAgent(nodeName);
-                        try {
-                            await agent.sendCommand('exec', {
-                                command: `podman unshare chown -R ${uid}:${gid} ${hostPath}`
-                            });
-                            logger.info('ServiceManager', `Fixed volume ownership: ${hostPath} -> ${uid}:${gid}`);
-                        } catch (e) {
-                            logger.warn('ServiceManager', `Failed to fix ownership for ${hostPath}:`, e);
-                        }
-                    }
+                    await this.chownContainerMounts(nodeName, container, volumePaths);
                 }
             }
         } catch (e) {


### PR DESCRIPTION
## What
Pull the per-container chown loop out of `fixVolumeOwnership` into a
private static helper `chownContainerMounts`. The outer method now just
walks YAML docs and delegates each container to the helper.

## Why
Lint-sweep step. `fixVolumeOwnership` was the only `services/serviceLifecycle.ts`
warning that wasn't a multi-page method, so this is a clean one-shot
extraction. Drops complexity warning (23 → under 15). Total: 420 → 419.

## Risk
low — pure code motion, no behaviour change. Inner loop semantics
identical (same continue/return targets after delegation). All 17
services unit tests pass.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (420 → 419)
- [x] npm run check:arch
- [x] npm test (services/, 17 passed)
- [ ] /verify on FCoS box — N/A, `services/` is not in the mandated path list