### PR TITLE
refactor(store): extract port-extraction helpers to twinPortExtraction

### DIFF
--- a/packages/backend/src/lib/store/twin.ts
+++ b/packages/backend/src/lib/store/twin.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import yaml from 'js-yaml';
 import { EnrichedContainer, ServiceUnit, ServiceHealth, SystemResources, Volume, WatchedFile, ProxyRoute, PortMapping } from '../agent/types';
 import { logger } from '../logger';
 import type { AgentHealth } from '../agent/handler';
@@ -7,6 +6,10 @@ import type { ServiceBundle } from '../unmanaged/bundleShared';
 import { sanitizeBundleName } from '../unmanaged/bundleShared';
 import { buildServiceBundlesForNode } from '../unmanaged/bundleBuilder';
 import { NodeTwinUpdateSchema } from './schema';
+import {
+  extractPortsFromKubeYaml,
+  extractPortsFromQuadletContainer,
+} from './twinPortExtraction';
 
 const normalizeNameToken = (value?: string | null): string | null => {
     if (!value) return null;
@@ -839,42 +842,10 @@ export class DigitalTwinStore {
       const files = node.files;
       if (kubeEntry) {
           const [kubePath, kubeFile] = kubeEntry;
-          if (kubeFile.content) {
-              const match = kubeFile.content.match(/^Yaml=(.+)$/m);
-              if (match) {
-                  const yamlRef = match[1].trim();
-                  const yamlContent = this.getYamlContent(files, kubePath, yamlRef);
-                  if (yamlContent) {
-                      try {
-                          const docs = yaml.loadAll(yamlContent) as unknown[];
-                          docs.forEach(doc => {
-                              if (!doc || typeof doc !== 'object') return;
-                              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                              const spec = (doc as any).spec;
-                              if (!spec) return;
-                              const hostNetwork = Boolean(spec.hostNetwork);
-                              const containers = Array.isArray(spec.containers) ? spec.containers : [];
-                              containers.forEach((containerDoc: unknown) => {
-                                  if (!containerDoc || typeof containerDoc !== 'object') return;
-                                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                  const portsDef = Array.isArray((containerDoc as any).ports) ? (containerDoc as any).ports : [];
-                                  portsDef.forEach((portDef: unknown) => {
-                                      if (!portDef || typeof portDef !== 'object') return;
-                                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                      const descriptor = portDef as any;
-                                      const containerPort = this.safeParsePort(descriptor.containerPort ?? descriptor.container_port ?? descriptor.port);
-                                      if (!containerPort) return;
-                                      let hostPort = this.safeParsePort(descriptor.hostPort ?? descriptor.host_port);
-                                      if (!hostPort && hostNetwork) hostPort = containerPort;
-                                      pushPort(hostPort, containerPort, descriptor.protocol);
-                                  });
-                              });
-                          });
-                      } catch (err) {
-                          logger.warn('TwinStore', `Failed to parse YAML for ${service.name}`, err);
-                      }
-                  }
-              }
+          const match = kubeFile.content?.match(/^Yaml=(.+)$/m);
+          if (match) {
+              const yamlContent = this.getYamlContent(files, kubePath, match[1].trim());
+              if (yamlContent) extractPortsFromKubeYaml(yamlContent, service.name, pushPort);
           }
           if (ports.length > 0) {
               this.staticPortsCache.set(baseName, { contentKey, ports });
@@ -885,43 +856,7 @@ export class DigitalTwinStore {
       if (containerEntry) {
           const [, containerFile] = containerEntry;
           if (containerFile.content) {
-              let hostNetwork = false;
-              const lines = containerFile.content.split('\n');
-              for (const line of lines) {
-                  const trimmed = line.trim();
-                  if (trimmed.length === 0) continue;
-                  if (trimmed.startsWith('Network=')) {
-                      hostNetwork = trimmed.split('=')[1]?.trim() === 'host';
-                      continue;
-                  }
-                  if (trimmed.startsWith('PublishPort=')) {
-                      const definition = trimmed.substring('PublishPort='.length);
-                      const [portPart, protoPart] = definition.split('/');
-                      const segments = portPart.split(':').filter(Boolean);
-                      let ip: string | undefined;
-                      let hostStr: string | undefined;
-                      let containerStr: string | undefined;
-
-                      if (segments.length === 3) {
-                          [ip, hostStr, containerStr] = segments;
-                      } else if (segments.length === 2) {
-                          [hostStr, containerStr] = segments;
-                      } else if (segments.length === 1) {
-                          hostStr = segments[0];
-                          containerStr = segments[0];
-                      }
-
-                      const containerPort = this.safeParsePort(containerStr);
-                      let hostPort = this.safeParsePort(hostStr);
-                      if (!hostPort && hostNetwork && containerPort) {
-                          hostPort = containerPort;
-                      }
-
-                      if (containerPort || hostPort) {
-                          pushPort(hostPort, containerPort ?? hostPort, protoPart, ip);
-                      }
-                  }
-              }
+              extractPortsFromQuadletContainer(containerFile.content, pushPort);
           }
       }
 
@@ -941,19 +876,6 @@ export class DigitalTwinStore {
       }
       const fallbackKey = Object.keys(files).find((filePath) => filePath.endsWith(`/${relative}`));
       return fallbackKey ? files[fallbackKey].content : null;
-  }
-
-  private safeParsePort(value: unknown): number | undefined {
-      if (typeof value === 'number' && Number.isFinite(value)) {
-          return value;
-      }
-      if (typeof value === 'string') {
-          const parsed = parseInt(value, 10);
-          if (!Number.isNaN(parsed)) {
-              return parsed;
-          }
-      }
-      return undefined;
   }
 
   public recordMigrationEvent(nodeId: string, event: MigrationHistoryEntry) {

--- a/packages/backend/src/lib/store/twinPortExtraction.ts
+++ b/packages/backend/src/lib/store/twinPortExtraction.ts
@@ -1,0 +1,106 @@
+import yaml from 'js-yaml';
+import { logger } from '../logger';
+
+/**
+ * Port-mapping extraction helpers used by `TwinStore.extractStaticPortsForService`.
+ *
+ * Split out from `twin.ts` to keep that file under the file-lines lint
+ * ceiling. These don't depend on any TwinStore state — they just walk
+ * static file content and call back into `pushPort` for each mapping
+ * they find.
+ */
+
+export type PushPortFn = (
+  hostPort?: number,
+  containerPort?: number,
+  protocol?: string,
+  hostIp?: string,
+) => void;
+
+export function safeParsePort(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+/** Walk a `kube` YAML document for `spec.containers[].ports[]` entries. */
+export function extractPortsFromKubeYaml(
+  yamlContent: string,
+  serviceName: string | undefined,
+  pushPort: PushPortFn,
+): void {
+  try {
+    const docs = yaml.loadAll(yamlContent) as unknown[];
+    docs.forEach(doc => {
+      if (!doc || typeof doc !== 'object') return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const spec = (doc as any).spec;
+      if (!spec) return;
+      const hostNetwork = Boolean(spec.hostNetwork);
+      const containers = Array.isArray(spec.containers) ? spec.containers : [];
+      containers.forEach((containerDoc: unknown) => {
+        if (!containerDoc || typeof containerDoc !== 'object') return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const portsDef = Array.isArray((containerDoc as any).ports) ? (containerDoc as any).ports : [];
+        portsDef.forEach((portDef: unknown) => {
+          if (!portDef || typeof portDef !== 'object') return;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const descriptor = portDef as any;
+          const containerPort = safeParsePort(descriptor.containerPort ?? descriptor.container_port ?? descriptor.port);
+          if (!containerPort) return;
+          let hostPort = safeParsePort(descriptor.hostPort ?? descriptor.host_port);
+          if (!hostPort && hostNetwork) hostPort = containerPort;
+          pushPort(hostPort, containerPort, descriptor.protocol);
+        });
+      });
+    });
+  } catch (err) {
+    logger.warn('TwinStore', `Failed to parse YAML for ${serviceName}`, err);
+  }
+}
+
+/** Walk a Quadlet `.container` file for `Network=` + `PublishPort=` directives. */
+export function extractPortsFromQuadletContainer(content: string, pushPort: PushPortFn): void {
+  let hostNetwork = false;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    if (trimmed.startsWith('Network=')) {
+      hostNetwork = trimmed.split('=')[1]?.trim() === 'host';
+      continue;
+    }
+    if (!trimmed.startsWith('PublishPort=')) continue;
+
+    const definition = trimmed.substring('PublishPort='.length);
+    const [portPart, protoPart] = definition.split('/');
+    const segments = portPart.split(':').filter(Boolean);
+    let ip: string | undefined;
+    let hostStr: string | undefined;
+    let containerStr: string | undefined;
+
+    if (segments.length === 3) {
+      [ip, hostStr, containerStr] = segments;
+    } else if (segments.length === 2) {
+      [hostStr, containerStr] = segments;
+    } else if (segments.length === 1) {
+      hostStr = segments[0];
+      containerStr = segments[0];
+    }
+
+    const containerPort = safeParsePort(containerStr);
+    let hostPort = safeParsePort(hostStr);
+    if (!hostPort && hostNetwork && containerPort) {
+      hostPort = containerPort;
+    }
+    if (containerPort || hostPort) {
+      pushPort(hostPort, containerPort ?? hostPort, protoPart, ip);
+    }
+  }
+}


### PR DESCRIPTION
## What
Move `extractPortsFromKubeYaml`, `extractPortsFromQuadletContainer`, and
the local `safeParsePort` out of `TwinStore` into a sibling pure-function
module `twinPortExtraction.ts`. `extractStaticPortsForService` now reads
top-down: cache check → `pushPort` closure → kube branch → container
branch → cache set.

## Why
Lint-sweep step. Two warnings on `twin.ts` cleared:
- `max-lines-per-function` on `extractStaticPortsForService` (107 → ~50)
- `max-lines` on the file (1083 → 974 raw lines, below the 800 counted threshold)

`extractStaticPortsForService`'s complexity dropped from 35 → 20 but stays
above 15 — the remaining contributor is the inline `pushPort` closure plus
the cache lookup. Worth its own follow-up. Total: 419 → 418.

## Risk
low — pure code motion, no behaviour change. All 568 backend unit tests pass.
The two helpers were already self-contained (took `pushPort` as callback);
the only adjustment was making `safeParsePort` an exported function instead
of an instance method.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (419 → 418)
- [x] npm run check:arch
- [x] npm test (store/ + tests/backend/, 568 passed)
- [ ] /verify on FCoS box — N/A, `store/` is not in the mandated path list