### PR TITLE
refactor(fritzbox): extract buildSoapEnvelope from soapRequest

### DIFF
--- a/packages/backend/src/lib/fritzbox/client.ts
+++ b/packages/backend/src/lib/fritzbox/client.ts
@@ -13,6 +13,29 @@ export interface FritzBoxOptions {
 }
 
 /**
+ * Build the SOAP 1.1 envelope FritzBox's TR-064 endpoints expect.
+ * Pure string assembly — extracted from `soapRequest` so the caller
+ * stays under the complexity ceiling.
+ */
+function buildSoapEnvelope(
+  action: string,
+  serviceType: string,
+  args: Record<string, string | number>,
+): string {
+  const argsXml = Object.entries(args)
+    .map(([key, value]) => `<${key}>${value}</${key}>`)
+    .join('');
+  return `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+<s:Body>
+<u:${action} xmlns:u="${serviceType}">
+${argsXml}
+</u:${action}>
+</s:Body>
+</s:Envelope>`;
+}
+
+/**
  * Validate a FritzBox host string. The gateway is always on the LAN,
  * so reject everything that is NOT a legitimate LAN address (#578, #1069):
  *
@@ -251,20 +274,7 @@ export class FritzBoxClient {
     }
 
     const url = `http://${this.host}:${this.port}${controlUrl}`;
-    
-    let argsXml = '';
-    for (const [key, value] of Object.entries(args)) {
-      argsXml += `<${key}>${value}</${key}>`;
-    }
-
-    const soapBody = `<?xml version="1.0" encoding="utf-8"?>
-<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
-<s:Body>
-<u:${action} xmlns:u="${serviceType}">
-${argsXml}
-</u:${action}>
-</s:Body>
-</s:Envelope>`;
+    const soapBody = buildSoapEnvelope(action, serviceType, args);
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);


### PR DESCRIPTION
## What
Pull the SOAP 1.1 envelope assembly out of `soapRequest` into a
module-level helper `buildSoapEnvelope(action, serviceType, args)`.
`soapRequest`'s remaining concern is the HTTP dispatch + response
handling.

## Why
Lint-sweep step. Drops both warnings on `soapRequest` (51 lines /
complexity 16). Cleans up `fritzbox/client.ts` ahead of the
FritzBox NAS backup work in [#1190](https://github.com/mdopp/servicebay/issues/1190).
Total: 413 → 411.

## Risk
low — pure string-building extracted with no behaviour change. The
envelope output is byte-identical (same template literal, same arg
serialization). All 561 backend tests pass.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (413 → 411)
- [x] npm run check:arch
- [x] npm test (backend, 561 passed)
- [ ] /verify on FCoS box — N/A, `fritzbox/` is not in the mandated path list