### PR TITLE
refactor(nginx): extract createLanAccessList from ensureLanAccessList

### DIFF
--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -221,37 +221,13 @@ function lanCidrFromIp(ip: string): string | null {
  * internet. The wizard's "Access Restrictions (recommended)" manual
  * instruction was the bandaid for this gap.
  */
-async function ensureLanAccessList(baseUrl: string, token: string, nodeIp: string): Promise<number | null> {
-    const cidr = lanCidrFromIp(nodeIp);
-    if (!cidr) {
-        logger.warn('ProxyHosts', `Could not derive LAN CIDR from node IP ${nodeIp}; skipping access-list setup.`);
-        return null;
-    }
-
-    // 1) Look for an existing list by name. expand=clients gives us the
-    //    rule list so we can detect drift and patch instead of duplicating.
-    try {
-        const listRes = await fetch(`${baseUrl}/api/nginx/access-lists?expand=clients`, {
-            headers: { 'Authorization': `Bearer ${token}` },
-            signal: AbortSignal.timeout(10_000),
-        });
-        if (listRes.ok) {
-            const lists = (await listRes.json()) as Array<{
-                id: number;
-                name: string;
-                clients?: Array<{ address: string; directive: string }>;
-            }>;
-            const existing = Array.isArray(lists) ? lists.find(l => l.name === LAN_ACCESS_LIST_NAME) : undefined;
-            if (existing) return existing.id;
-        }
-    } catch (e) {
-        logger.warn('ProxyHosts', `LAN access-list lookup failed: ${e instanceof Error ? e.message : String(e)}`);
-        // fall through to create — worst case we'll get a duplicate-name 400
-    }
-
-    // 2) Create the list. nginx access rules are evaluated top-to-bottom
-    //    and first-match-wins; allow LAN + localhost, then explicit
-    //    deny-all so the rejection is unambiguous in NPM's logs.
+/**
+ * POST a new LAN-only access list to NPM. Returns the new list's id, or
+ * null on any failure (logged). The list's rules are evaluated top-down
+ * with first-match-wins, so the allow-LAN/allow-localhost/deny-all order
+ * is load-bearing.
+ */
+async function createLanAccessList(baseUrl: string, token: string, cidr: string): Promise<number | null> {
     try {
         const createRes = await fetch(`${baseUrl}/api/nginx/access-lists`, {
             method: 'POST',
@@ -285,6 +261,37 @@ async function ensureLanAccessList(baseUrl: string, token: string, nodeIp: strin
         logger.warn('ProxyHosts', `LAN access-list create failed: ${e instanceof Error ? e.message : String(e)}`);
         return null;
     }
+}
+
+async function ensureLanAccessList(baseUrl: string, token: string, nodeIp: string): Promise<number | null> {
+    const cidr = lanCidrFromIp(nodeIp);
+    if (!cidr) {
+        logger.warn('ProxyHosts', `Could not derive LAN CIDR from node IP ${nodeIp}; skipping access-list setup.`);
+        return null;
+    }
+
+    // Look for an existing list by name. expand=clients gives us the
+    // rule list so we can detect drift and patch instead of duplicating.
+    try {
+        const listRes = await fetch(`${baseUrl}/api/nginx/access-lists?expand=clients`, {
+            headers: { 'Authorization': `Bearer ${token}` },
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (listRes.ok) {
+            const lists = (await listRes.json()) as Array<{
+                id: number;
+                name: string;
+                clients?: Array<{ address: string; directive: string }>;
+            }>;
+            const existing = Array.isArray(lists) ? lists.find(l => l.name === LAN_ACCESS_LIST_NAME) : undefined;
+            if (existing) return existing.id;
+        }
+    } catch (e) {
+        logger.warn('ProxyHosts', `LAN access-list lookup failed: ${e instanceof Error ? e.message : String(e)}`);
+        // fall through to create — worst case we'll get a duplicate-name 400
+    }
+
+    return createLanAccessList(baseUrl, token, cidr);
 }
 
 /**


### PR DESCRIPTION
## What
Pull the POST-new-list branch out of `ensureLanAccessList` into a
sibling helper `createLanAccessList`. `ensureLanAccessList` stays the
single entry point: derive CIDR → look up existing → delegate to
create when absent. `createLanAccessList` is now also reusable from a
future reconcile / drift-patch path.

## Why
Lint-sweep step. Drops `ensureLanAccessList`'s line warning (57 → ~32).
Total: 411 → 410.

## Risk
low — pure code motion. The lookup-then-create flow is unchanged; the
helper takes the already-derived `cidr` as an arg so the null-guard
on `lanCidrFromIp` still runs in the parent. All 702 unit tests pass.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (411 → 410)
- [x] npm run check:arch
- [x] npm test (702 passed)
- [ ] /verify on FCoS box — N/A, `app/api/` is not in the mandated path list
  (mandated is `app/portal/` and `app/(dashboard)/`)