### PR TITLE
fix(install): sudo-retry asset write when hostPath is owned by another uid

### DIFF
--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -26,6 +26,60 @@ import type { PodLikeDoc, PodLikeVolumeMount } from './containerNameMatcher';
 
 const SYSTEMD_DIR = '.config/containers/systemd';
 
+/** Minimal agent shape needed to ship files to a node. */
+interface FileWritingAgent {
+    sendCommand(action: string, params?: unknown): Promise<unknown>;
+}
+
+/**
+ * Write a template's rendered config + asset files to the node, creating
+ * parent dirs first.
+ *
+ * Failures are FATAL — the previous behaviour was to log a warning and
+ * continue, which produced the radicale crash-loop class of bug: the
+ * service starts, finds its config file missing, dies, and the operator
+ * has no breadcrumb back to the silent write_file failure during deploy.
+ * Throwing surfaces the problem at deploy time with a useful path.
+ *
+ * #1171 — a write target can sit under a hostPath pre-provisioned by a
+ * consumer container (owned by its uid, not the agent's `core`/uid-1000),
+ * e.g. the asset-transport `skills/` dir on a volume the hermes/syncthing
+ * pod created. The plain write EACCESes there, so a failed write is
+ * retried once via the agent's #1000 privileged path (`core` has
+ * passwordless sudo on FCoS) before being recorded as a failure.
+ */
+export async function writeExtraConfigFiles(
+    agent: FileWritingAgent,
+    serviceName: string,
+    extraFiles: { path: string; content: string }[],
+): Promise<void> {
+    const failures: string[] = [];
+    for (const f of extraFiles) {
+        // Ensure parent directory exists.
+        const dir = f.path.substring(0, f.path.lastIndexOf('/'));
+        if (dir) {
+            await agent.sendCommand('exec', { command: `mkdir -p ${dir}` });
+        }
+        let res = await agent.sendCommand('write_file', { path: f.path, content: f.content });
+        if (res !== 'ok') {
+            logger.warn('ServiceManager', `write_file for ${f.path} failed (${JSON.stringify(res)}); retrying with sudo.`);
+            res = await agent.sendCommand('write_file', { path: f.path, content: f.content, sudo: true });
+        }
+        if (res !== 'ok') {
+            failures.push(f.path);
+            logger.error('ServiceManager', `Failed to write extra file ${f.path}: agent returned ${JSON.stringify(res)}`);
+        } else {
+            logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
+        }
+    }
+    if (failures.length > 0) {
+        throw new Error(
+            `Failed to write ${failures.length} required config file(s) for service "${serviceName}":\n  ${failures.join('\n  ')}\n\n` +
+            `The service was not started. Re-run the deploy or check the agent's write permissions on the target paths.`,
+        );
+    }
+}
+
 /** Extract string content from agent read_file response. */
 function extractFileContent(res: unknown): string {
     if (typeof res === 'string') return res;
@@ -664,36 +718,11 @@ export class ServiceLifecycle {
             logger.debug('ServiceManager', 'Could not verify template configFiles parity:', e);
         }
 
-        // Write extra config files (e.g. Authelia configuration.yml) to the node filesystem.
-        // Failures here are FATAL — the previous behaviour was to log a warning
-        // and continue, which produced the radicale crash-loop class of bug:
-        // service starts, looks for a config file that's not there, dies, and
-        // the operator has no breadcrumb back to the real cause (the silent
-        // write_file failure during deploy). Raising here surfaces the
-        // problem at deploy time with a useful path.
+        // Write extra config files (e.g. Authelia configuration.yml) to the
+        // node filesystem. Failures are FATAL (see writeExtraConfigFiles).
         if (extraFiles?.length) {
             const agent = await agentManager.ensureAgent(nodeName);
-            const failures: string[] = [];
-            for (const f of extraFiles) {
-                // Ensure parent directory exists
-                const dir = f.path.substring(0, f.path.lastIndexOf('/'));
-                if (dir) {
-                    await agent.sendCommand('exec', { command: `mkdir -p ${dir}` });
-                }
-                const res = await agent.sendCommand('write_file', { path: f.path, content: f.content });
-                if (res !== 'ok') {
-                    failures.push(f.path);
-                    logger.error('ServiceManager', `Failed to write extra file ${f.path}: agent returned ${JSON.stringify(res)}`);
-                } else {
-                    logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
-                }
-            }
-            if (failures.length > 0) {
-                throw new Error(
-                    `Failed to write ${failures.length} required config file(s) for service "${name}":\n  ${failures.join('\n  ')}\n\n` +
-                    `The service was not started. Re-run the deploy or check the agent's write permissions on the target paths.`,
-                );
-            }
+            await writeExtraConfigFiles(agent, name, extraFiles);
         }
 
         // Ensure unprivileged port binding if any port < 1024 is used

--- a/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { writeExtraConfigFiles } from './serviceLifecycle';
+
+vi.mock('../logger', () => ({
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+type CmdParams = { path?: string; content?: string; sudo?: boolean; command?: string } | undefined;
+type Cmd = { action: string; params: CmdParams };
+
+/** Fake agent that records every sendCommand and replies via `responder`. */
+function makeAgent(responder: (action: string, params: CmdParams) => unknown) {
+    const calls: Cmd[] = [];
+    const agent = {
+        calls,
+        sendCommand: vi.fn(async (action: string, params?: unknown) => {
+            const p = params as CmdParams;
+            calls.push({ action, params: p });
+            return responder(action, p);
+        }),
+    };
+    return agent;
+}
+
+const file = { path: '/mnt/data/stacks/oscar-household/skills/README.md', content: '# skills' };
+
+describe('writeExtraConfigFiles', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('writes without sudo when the plain write_file succeeds', async () => {
+        const agent = makeAgent((action) => (action === 'exec' ? { code: 0 } : 'ok'));
+        await writeExtraConfigFiles(agent, 'oscar-household', [file]);
+
+        const writes = agent.calls.filter(c => c.action === 'write_file');
+        expect(writes).toHaveLength(1);
+        expect(writes[0].params.sudo).toBeUndefined();
+    });
+
+    it('retries with sudo when the plain write_file fails (EACCES on container-owned dir)', async () => {
+        // #1171 — first (unprivileged) write fails because the hostPath is
+        // owned by a consumer container's uid; the sudo retry succeeds.
+        const agent = makeAgent((action, params) => {
+            if (action === 'exec') return { code: 0 };
+            return params?.sudo ? 'ok' : { error: "[Errno 13] Permission denied: '" + file.path + "'" };
+        });
+
+        await expect(writeExtraConfigFiles(agent, 'oscar-household', [file])).resolves.toBeUndefined();
+
+        const writes = agent.calls.filter(c => c.action === 'write_file');
+        expect(writes).toHaveLength(2);
+        expect(writes[0].params.sudo).toBeUndefined();
+        expect(writes[1].params.sudo).toBe(true);
+    });
+
+    it('throws (deploy fails) when both the plain and sudo writes fail', async () => {
+        const agent = makeAgent((action) => (action === 'exec' ? { code: 0 } : { error: 'disk full' }));
+
+        await expect(writeExtraConfigFiles(agent, 'oscar-household', [file]))
+            .rejects.toThrow(/Failed to write 1 required config file/);
+
+        const writes = agent.calls.filter(c => c.action === 'write_file');
+        expect(writes).toHaveLength(2);
+        expect(writes[1].params.sudo).toBe(true);
+    });
+});

--- a/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
@@ -33,7 +33,7 @@ describe('writeExtraConfigFiles', () => {
 
         const writes = agent.calls.filter(c => c.action === 'write_file');
         expect(writes).toHaveLength(1);
-        expect(writes[0].params.sudo).toBeUndefined();
+        expect(writes[0].params?.sudo).toBeUndefined();
     });
 
     it('retries with sudo when the plain write_file fails (EACCES on container-owned dir)', async () => {
@@ -48,8 +48,8 @@ describe('writeExtraConfigFiles', () => {
 
         const writes = agent.calls.filter(c => c.action === 'write_file');
         expect(writes).toHaveLength(2);
-        expect(writes[0].params.sudo).toBeUndefined();
-        expect(writes[1].params.sudo).toBe(true);
+        expect(writes[0].params?.sudo).toBeUndefined();
+        expect(writes[1].params?.sudo).toBe(true);
     });
 
     it('throws (deploy fails) when both the plain and sudo writes fail', async () => {
@@ -60,6 +60,6 @@ describe('writeExtraConfigFiles', () => {
 
         const writes = agent.calls.filter(c => c.action === 'write_file');
         expect(writes).toHaveLength(2);
-        expect(writes[1].params.sudo).toBe(true);
+        expect(writes[1].params?.sudo).toBe(true);
     });
 });


### PR DESCRIPTION
## What
The install runner ships a template's rendered config + asset files (#1156) to the node via the agent's `write_file`. The agent runs as `core` (uid 1000), so a write into a hostPath that was pre-provisioned by a consumer container — owned by that container's uid, e.g. the asset-transport `skills/` dir under a hermes/syncthing-owned volume — fails with `EACCES` and the whole deploy aborts.

This extracts the `extraFiles` write loop into a small `writeExtraConfigFiles` helper and retries a failed write **once** via the agent's existing privileged path (`sudo` write_file, the #1000 mechanism; `core` has passwordless sudo on FCoS) before recording it as a failure. Successful unprivileged writes are unchanged — no `sudo` on the happy path.

## Why
Closes #1171.

## Risk
Low — additive fallback only; the happy path (plain write succeeds) is byte-for-byte unchanged, and a genuine failure (both writes fail) still throws exactly as before.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 410 warnings — unchanged baseline)
- [x] npm run check:arch
- [x] npm test (1338 passed; 3 new focused tests for the sudo-retry)
- [ ] /verify on FCoS box — **not run**: `serviceLifecycle.ts` is in `lib/services/` (not in the path-mandated `/verify` list), and the exact uid-mismatch repro requires the OSCAR registry (#1156/#1157 + mdopp/oscar) which isn't live on the box yet. Real-box confirmation should happen once OSCAR migration lands.