### PR TITLE
refactor(stackInstall): extract computeEffectiveDeps from topoSortByDependencies

### DIFF
--- a/packages/backend/src/lib/stackInstall/dependencies.ts
+++ b/packages/backend/src/lib/stackInstall/dependencies.ts
@@ -57,6 +57,37 @@ export type TopoSortResult<T> =
   | { ok: false; reason: 'cycle'; involved: string[] };
 
 /**
+ * Compute the effective dependency edges used by the topological sort:
+ * - each item's declared `servicebay.dependencies` that are in the set
+ * - PLUS implicit "every feature depends on every infra in this set" so
+ *   the order surfaces all infrastructure before any feature. Without
+ *   this, an unrelated feature (`ollama`, `hermes`) that declares no deps
+ *   can sneak in front of nginx/auth and register subdomain proxy hosts
+ *   against NPM data the install runner is about to wipe and recreate
+ *   (#796).
+ */
+function computeEffectiveDeps<T extends DependencyAwareItem>(
+  items: T[],
+  namesInSet: Set<string>,
+): Map<string, string[]> {
+  const infraNames = items
+    .filter(it => it.tier === 'infrastructure')
+    .map(it => it.name);
+  const effectiveDeps = new Map<string, string[]>();
+  for (const it of items) {
+    const tier = it.tier ?? 'feature';
+    const explicit = it.dependencies.filter(d => namesInSet.has(d));
+    if (tier === 'infrastructure') {
+      effectiveDeps.set(it.name, explicit);
+    } else {
+      const implicit = infraNames.filter(n => n !== it.name);
+      effectiveDeps.set(it.name, [...new Set([...explicit, ...implicit])]);
+    }
+  }
+  return effectiveDeps;
+}
+
+/**
  * Topologically sort `items` so every entry's dependencies appear
  * earlier in the result. Items whose dependencies aren't in
  * `candidates` (typically `selectedNames`) return `missing`; cycles
@@ -86,28 +117,7 @@ export function topoSortByDependencies<T extends DependencyAwareItem>(
     }
   }
 
-  // Compute the effective dependency edges:
-  // - each item's declared `servicebay.dependencies`
-  // - PLUS implicit "every feature depends on every infra in this set"
-  //   so the topological order surfaces all infrastructure before any
-  //   feature. Without this, an unrelated feature (`ollama`, `hermes`)
-  //   that declares no deps can sneak in front of nginx/auth and
-  //   register subdomain proxy hosts against NPM data that the
-  //   install runner is about to wipe and recreate (#796).
-  const infraNames = items
-    .filter(it => it.tier === 'infrastructure')
-    .map(it => it.name);
-  const effectiveDeps = new Map<string, string[]>();
-  for (const it of items) {
-    const tier = it.tier ?? 'feature';
-    const explicit = it.dependencies.filter(d => namesInSet.has(d));
-    if (tier === 'infrastructure') {
-      effectiveDeps.set(it.name, explicit);
-    } else {
-      const implicit = infraNames.filter(n => n !== it.name);
-      effectiveDeps.set(it.name, [...new Set([...explicit, ...implicit])]);
-    }
-  }
+  const effectiveDeps = computeEffectiveDeps(items, namesInSet);
 
   // Kahn's algorithm with a stable tiebreaker (input order).
   const indeg = new Map<string, number>();


### PR DESCRIPTION
## What
Lint sweep on `packages/backend/src/lib/stackInstall/dependencies.ts`. Pulls the effective-dependency-edge computation (each item's declared deps plus the implicit infra-before-feature edges from #796) out of `topoSortByDependencies` into a `computeEffectiveDeps` helper, dropping the caller under the 50-line limit and clearing its `max-lines-per-function` warning.

## Why
Drive the ESLint warning count down. Total warnings 407 → 405. No behaviour change.

## Risk
Low — pure extraction of a self-contained computation; the 16 existing `dependencies.test.ts` cases (missing/cycle/stable-order/infra-first) all pass unchanged.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors; 405 warnings, down from 407)
- [x] npm run check:arch
- [x] npm test (1338 passed; dependencies.test.ts 16/16)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — not applicable: `lib/stackInstall/` is not in the path-mandated `/verify` list.