### PR TITLE
refactor(util): extract humanizeMessagePattern from humanizeError

### DIFF
--- a/packages/backend/src/lib/util/humanizeError.ts
+++ b/packages/backend/src/lib/util/humanizeError.ts
@@ -73,20 +73,9 @@ const SERVER_RX = /\b(50\d|internal server error)\b/i;
 const SSH_KEY_RX = /(no key|permission denied \(publickey\)|ssh key|host key verification)/i;
 const AGENT_RX = /(agent not connected|agent disconnected|agent unreachable)/i;
 
-export function humanizeError(err: unknown, fallbackTitle = 'Something went wrong'): HumanizedError {
-  // Typed-error fast path (#598). Wording-independent.
-  if (isDomainError(err)) {
-    const typed = humanizeDomainError(err);
-    if (typed) return typed;
-  }
-
-  const raw = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
-  const message = raw.trim();
-
-  if (!message) {
-    return { title: fallbackTitle, detail: 'An unexpected error occurred. Try again or check the server logs.' };
-  }
-
+/** Match an opaque error message against the known patterns. Returns null
+ *  when nothing matches so the caller can fall back to the raw message. */
+function humanizeMessagePattern(message: string): HumanizedError | null {
   if (UNAUTHORIZED_RX.test(message)) {
     return { title: 'Session expired', detail: 'Please sign in again to continue.' };
   }
@@ -126,6 +115,22 @@ export function humanizeError(err: unknown, fallbackTitle = 'Something went wron
       detail: `${message}. The server logged a problem — check Settings → Logs for details.`,
     };
   }
+  return null;
+}
 
-  return { title: fallbackTitle, detail: message };
+export function humanizeError(err: unknown, fallbackTitle = 'Something went wrong'): HumanizedError {
+  // Typed-error fast path (#598). Wording-independent.
+  if (isDomainError(err)) {
+    const typed = humanizeDomainError(err);
+    if (typed) return typed;
+  }
+
+  const raw = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  const message = raw.trim();
+
+  if (!message) {
+    return { title: fallbackTitle, detail: 'An unexpected error occurred. Try again or check the server logs.' };
+  }
+
+  return humanizeMessagePattern(message) ?? { title: fallbackTitle, detail: message };
 }


### PR DESCRIPTION
## What
Lint sweep on `packages/backend/src/lib/util/humanizeError.ts`. Moves the opaque-message regex matching chain out of `humanizeError` into a `humanizeMessagePattern` helper that returns `null` when nothing matches, leaving `humanizeError` to own the typed-error fast path (#598) and the raw-message fallback. Clears `humanizeError`'s `max-lines-per-function` warning.

## Why
Drive the ESLint warning count down. Total warnings 405 → 404. No behaviour change — the pattern order and every title/detail string are preserved verbatim.

## Risk
Low — faithful cut-paste of the if-chain into a helper; the typed path and the fallback-to-raw-message behaviour are unchanged.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors; 404 warnings, down from 405)
- [x] npm run check:arch
- [x] npm test (1338 passed)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — not applicable: `lib/util/` is not in the path-mandated `/verify` list.