### PR TITLE
refactor(diagnose): extract performProxyHostDelete from deleteRoute

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/danglingProxy.ts
+++ b/packages/backend/src/lib/diagnose/probes/danglingProxy.ts
@@ -131,6 +131,18 @@ async function deleteRoute({
       refresh: true,
     };
   }
+  return performProxyHostDelete(adminUrl, token, id, itemId);
+}
+
+/** Issue the NPM DELETE for a resolved proxy host id and map the outcome
+ *  to a ProbeActionResult. Split out of deleteRoute to keep it under the
+ *  function-length budget. */
+async function performProxyHostDelete(
+  adminUrl: string,
+  token: string,
+  id: number,
+  itemId: string,
+): Promise<ProbeActionResult> {
   try {
     const res = await fetch(`${adminUrl}/api/nginx/proxy-hosts/${id}`, {
       method: 'DELETE',


### PR DESCRIPTION
## What
Lint sweep on `packages/backend/src/lib/diagnose/probes/danglingProxy.ts`. Moves the NPM DELETE call and its outcome mapping out of `deleteRoute` into a `performProxyHostDelete` helper, leaving `deleteRoute` to own the precondition guards (itemId / admin URL / token / id resolution). Clears `deleteRoute`'s `max-lines-per-function` warning.

## Why
Drive the ESLint warning count down. Total warnings 404 → 403. No behaviour change.

## Risk
Low — pure extraction; the existing `danglingProxy.test.ts` (5 cases) passes unchanged.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors; 403 warnings, down from 404)
- [x] npm run check:arch
- [x] npm test (1338 passed; danglingProxy.test.ts 5/5)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — not applicable: `lib/diagnose/` is not in the path-mandated `/verify` list.