### PR TITLE
fix(actions): require admin session on sensitive Server Actions

### DIFF
--- a/packages/frontend/src/app/actions/_session.test.ts
+++ b/packages/frontend/src/app/actions/_session.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCookieGet = vi.fn();
+const mockGetConfig = vi.fn();
+const mockDecrypt = vi.fn();
+
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => ({ get: mockCookieGet })) }));
+vi.mock('@/lib/config', () => ({ getConfig: () => mockGetConfig() }));
+vi.mock('@/lib/auth/session', () => ({ decrypt: (t: string) => mockDecrypt(t) }));
+
+import { assertAdminSession } from './_session';
+
+describe('assertAdminSession', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('allows unauthenticated calls during onboarding (!setupCompleted)', async () => {
+    mockGetConfig.mockResolvedValue({ setupCompleted: false });
+    mockCookieGet.mockReturnValue(undefined);
+    await expect(assertAdminSession()).resolves.toBeUndefined();
+  });
+
+  it('throws when setup is complete and no session cookie is present', async () => {
+    mockGetConfig.mockResolvedValue({ setupCompleted: true });
+    mockCookieGet.mockReturnValue(undefined);
+    await expect(assertAdminSession()).rejects.toThrow(/Unauthorized/);
+  });
+
+  it('throws when the session token is invalid', async () => {
+    mockGetConfig.mockResolvedValue({ setupCompleted: true });
+    mockCookieGet.mockReturnValue({ value: 'bad-token' });
+    mockDecrypt.mockResolvedValue(null);
+    await expect(assertAdminSession()).rejects.toThrow(/Unauthorized/);
+  });
+
+  it('passes with a valid authenticated session', async () => {
+    mockGetConfig.mockResolvedValue({ setupCompleted: true });
+    mockCookieGet.mockReturnValue({ value: 'good-token' });
+    mockDecrypt.mockResolvedValue({ user: 'admin' });
+    await expect(assertAdminSession()).resolves.toBeUndefined();
+  });
+});

--- a/packages/frontend/src/app/actions/_session.ts
+++ b/packages/frontend/src/app/actions/_session.ts
@@ -1,0 +1,26 @@
+import { cookies } from 'next/headers';
+import { decrypt } from '@/lib/auth/session';
+import { getConfig } from '@/lib/config';
+
+/**
+ * Authorization guard for sensitive Server Actions.
+ *
+ * Server Actions are routed on page paths, so the `/api/*`-only auth gate in
+ * `proxy.ts` does NOT cover them — each sensitive action must assert the
+ * session itself (#1203). Unauthenticated calls are allowed ONLY while
+ * onboarding is incomplete (`!setupCompleted`), so the first-run setup flow
+ * still works before any user/credentials exist.
+ *
+ * Throws `Unauthorized` on a missing/invalid session; callers should let it
+ * propagate so the action never runs for an unauthenticated client.
+ */
+export async function assertAdminSession(): Promise<void> {
+  const config = await getConfig();
+  if (!config.setupCompleted) return;
+
+  const token = (await cookies()).get('session')?.value;
+  const session = token ? await decrypt(token) : null;
+  if (!session || typeof session.user !== 'string') {
+    throw new Error('Unauthorized');
+  }
+}

--- a/packages/frontend/src/app/actions/nodes.ts
+++ b/packages/frontend/src/app/actions/nodes.ts
@@ -7,12 +7,15 @@ import { revalidatePath } from 'next/cache';
 import * as fs from 'fs';
 import * as os from 'os';
 import crypto from 'crypto';
+import { assertAdminSession } from './_session';
 
 export async function getNodes(): Promise<PodmanConnection[]> {
+  await assertAdminSession();
   return listNodes();
 }
 
 export async function createNode(name: string, destination: string, identity: string) {
+  await assertAdminSession();
   try {
     // Verify identity file exists
     const resolvedIdentity = identity.replace(/^~(?=$|\/|\\)/, os.homedir());
@@ -65,6 +68,7 @@ export async function createNode(name: string, destination: string, identity: st
 }
 
 export async function editNode(oldName: string, newName: string, destination: string, identity: string) {
+  await assertAdminSession();
   try {
      // Verify identity file exists
      const resolvedIdentity = identity.replace(/^~(?=$|\/|\\)/, os.homedir());
@@ -100,6 +104,7 @@ export async function editNode(oldName: string, newName: string, destination: st
 }
 
 export async function deleteNode(name: string) {
+  await assertAdminSession();
   try {
     await removeNode(name);
     
@@ -121,6 +126,7 @@ export async function deleteNode(name: string) {
 }
 
 export async function setNodeAsDefault(name: string) {
+  await assertAdminSession();
   try {
     await setDefaultNode(name);
     revalidatePath('/settings');

--- a/packages/frontend/src/app/actions/ssh.ts
+++ b/packages/frontend/src/app/actions/ssh.ts
@@ -2,8 +2,10 @@
 
 import { checkTcpConnection, setupSSHKey, verifySSHConnection } from '@/lib/ssh';
 import { SSH_DIR } from '@/lib/dirs';
+import { assertAdminSession } from './_session';
 
 export async function checkConnection(host: string, port: number) {
+    await assertAdminSession();
     try {
         const isOpen = await checkTcpConnection(host, port);
         return { success: true, isOpen };
@@ -13,6 +15,7 @@ export async function checkConnection(host: string, port: number) {
 }
 
 export async function checkFullConnection(host: string, port: number, user: string, identity: string) {
+    await assertAdminSession();
     try {
         const isOpen = await checkTcpConnection(host, port);
         if (!isOpen) return { success: false, stage: 'tcp', error: 'TCP Connection Failed' };
@@ -27,6 +30,7 @@ export async function checkFullConnection(host: string, port: number, user: stri
 }
 
 export async function installSSHKey(host: string, port: number, user: string, pass: string) {
+    await assertAdminSession();
     try {
         const result = await setupSSHKey(host, port, user, pass);
         return result;
@@ -36,6 +40,7 @@ export async function installSSHKey(host: string, port: number, user: string, pa
 }
 
 export async function generateLocalKey() {
+    await assertAdminSession();
     try {
         const fs = await import('fs');
         const path = await import('path');

--- a/packages/frontend/src/app/actions/system.ts
+++ b/packages/frontend/src/app/actions/system.ts
@@ -4,14 +4,17 @@ import { exec } from 'node:child_process';
 import { promisify } from 'util';
 import { getExecutor } from '@/lib/executor';
 import { listNodes, PodmanConnection } from '@/lib/nodes';
+import { assertAdminSession } from './_session';
 
 const execAsync = promisify(exec);
 
 export async function getNodes() {
+  await assertAdminSession();
   return await listNodes();
 }
 
 export async function getSystemUpdates(nodeName?: string): Promise<{ count: number; list: string[] }> {
+  await assertAdminSession();
   if (nodeName && nodeName !== 'Local') {
       return { count: 0, list: [] };
   }
@@ -38,6 +41,7 @@ export async function getSystemUpdates(nodeName?: string): Promise<{ count: numb
 }
 
 export async function readFileContent(path: string, nodeName?: string): Promise<string> {
+  await assertAdminSession();
   let connection: PodmanConnection | undefined;
   if (nodeName && nodeName !== 'Local') {
       const nodes = await listNodes();


### PR DESCRIPTION
## What
Next.js Server Actions are routed on page paths, so the `/api/*`-only auth middleware (`proxy.ts:150`) never gates them. That left `readFileContent` (arbitrary host file read), the node CRUD actions (`createNode`/`editNode`/`deleteNode`/`setNodeAsDefault`), and the SSH actions (`checkConnection`/`checkFullConnection`/`installSSHKey`/`generateLocalKey`) callable by an unauthenticated client.

Adds `assertAdminSession()` (`app/actions/_session.ts`) — reads the `session` cookie, decrypts via `@/lib/auth/session`, requires a `user`; allows unauthenticated calls **only** while onboarding is incomplete (`!config.setupCompleted`) so first-run setup still works. Guards added at the entry of every sensitive action in `system.ts`, `nodes.ts`, `ssh.ts`.

## Why
Closes #1203 (Critical: unauthenticated arbitrary file read + node hijacking).

## Risk
Medium — auth change. The `!setupCompleted` carve-out preserves the onboarding flow; all 1338 existing tests pass + 4 new guard tests. **Opened as draft (security gate) — needs human review before merge.**

## Security note for reviewer
- Scope: I guarded `system.ts`/`nodes.ts`/`ssh.ts` per the issue. `onboarding.ts` is intentionally left open (it IS the pre-auth setup flow; the guard's `!setupCompleted` carve-out would no-op there anyway).
- The guard trusts the `session` cookie JWT exactly like the existing `/api/*` middleware does.

## Verification
- [x] npm run lint (0 errors, 403 warnings — unchanged)
- [x] npm run check:arch
- [x] npm test (1338 pass + 4 new `_session.test.ts`)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — n/a for a draft; `app/actions/` is not in the path-mandated list