### PR TITLE
fix(mcp): resolve real client IP for bootstrap-token LAN gate

### DIFF
--- a/packages/backend/src/lib/mcp/bootstrapToken.test.ts
+++ b/packages/backend/src/lib/mcp/bootstrapToken.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/install/jobStore', () => ({
 
 import {
   isLanIp,
+  clientIpForLanGate,
   lazyInitializeExpiry,
   verifyBootstrapToken,
   revokeBootstrapToken,
@@ -252,5 +253,36 @@ describe('getBootstrapTokenStatus', () => {
     });
     mockWasInstallActiveWithin.mockResolvedValue(true);
     expect(await getBootstrapTokenStatus()).toEqual({ active: true, expiresAt: null, minutesRemaining: null });
+  });
+});
+
+describe('clientIpForLanGate (#1204)', () => {
+  it('returns the socket address unchanged for a direct (non-loopback) peer', () => {
+    expect(clientIpForLanGate({}, '203.0.113.7')).toBe('203.0.113.7');
+  });
+
+  it('ignores proxy headers on a direct connection (no header spoofing)', () => {
+    // A direct internet client cannot fake a LAN IP via headers.
+    expect(clientIpForLanGate({ 'x-real-ip': '192.168.1.5' }, '203.0.113.7')).toBe('203.0.113.7');
+  });
+
+  it('trusts X-Real-IP when the peer is the local proxy (loopback)', () => {
+    expect(clientIpForLanGate({ 'x-real-ip': '203.0.113.7' }, '127.0.0.1')).toBe('203.0.113.7');
+    // and isLanIp then correctly rejects the public client
+    expect(isLanIp(clientIpForLanGate({ 'x-real-ip': '203.0.113.7' }, '127.0.0.1'))).toBe(false);
+  });
+
+  it('uses the RIGHTMOST X-Forwarded-For hop (nginx-appended), not the spoofable left', () => {
+    // Client spoofs a LAN IP; NPM appends the real peer on the right.
+    const xff = '192.168.1.5, 203.0.113.7';
+    expect(clientIpForLanGate({ 'x-forwarded-for': xff }, '::1')).toBe('203.0.113.7');
+  });
+
+  it('prefers X-Real-IP over X-Forwarded-For', () => {
+    expect(clientIpForLanGate({ 'x-real-ip': '203.0.113.7', 'x-forwarded-for': '8.8.8.8' }, '127.0.0.1')).toBe('203.0.113.7');
+  });
+
+  it('falls back to the loopback socket address when no proxy headers are present', () => {
+    expect(clientIpForLanGate({}, '127.0.0.1')).toBe('127.0.0.1');
   });
 });

--- a/packages/backend/src/lib/mcp/bootstrapToken.ts
+++ b/packages/backend/src/lib/mcp/bootstrapToken.ts
@@ -56,6 +56,39 @@ export function isLanIp(addr: string | undefined | null): boolean {
   return false;
 }
 
+/**
+ * Resolve the real client IP for the LAN-only gate (#1204).
+ *
+ * Behind a reverse proxy (NPM forwards to 127.0.0.1) `socket.remoteAddress`
+ * is always loopback, so `isLanIp()` would pass for every caller — including
+ * the public internet if the dashboard is exposed. So: when the socket peer
+ * IS loopback we trust the proxy's authoritative client-IP headers — NPM sets
+ * `X-Real-IP` to nginx's `$remote_addr` (overwriting any client-sent value),
+ * and the LAST `X-Forwarded-For` hop is the one nginx appended. When the peer
+ * is NOT loopback (a direct connection) the headers are attacker-controllable,
+ * so we ignore them and use the socket address. We never take the left-most
+ * XFF entry, which a direct client could spoof with a fake LAN IP.
+ */
+export function clientIpForLanGate(
+  headers: Record<string, string | string[] | undefined>,
+  socketAddr: string | undefined,
+): string | undefined {
+  const loopback = socketAddr === '127.0.0.1' || socketAddr === '::1' || socketAddr === '::ffff:127.0.0.1';
+  if (!loopback) return socketAddr;
+
+  const realRaw = headers['x-real-ip'];
+  const real = (Array.isArray(realRaw) ? realRaw[0] : realRaw)?.trim();
+  if (real) return real;
+
+  const xffRaw = headers['x-forwarded-for'];
+  const xff = Array.isArray(xffRaw) ? xffRaw[0] : xffRaw;
+  if (xff) {
+    const hops = xff.split(',').map(s => s.trim()).filter(Boolean);
+    if (hops.length) return hops[hops.length - 1];
+  }
+  return socketAddr;
+}
+
 function sha256(s: string): string {
   return crypto.createHash('sha256').update(s).digest('hex');
 }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -212,7 +212,7 @@ app.prepare().then(() => {
         // Token path is preferred; cookie kept for back-compat with clients
         // that connected before tokens existed.
         const { verifyToken } = await import('./lib/mcp/tokens');
-        const { verifyBootstrapToken } = await import('./lib/mcp/bootstrapToken');
+        const { verifyBootstrapToken, clientIpForLanGate } = await import('./lib/mcp/bootstrapToken');
         const authHeader = req.headers.authorization || '';
         const bearerMatch = authHeader.match(/^Bearer\s+(\S+)$/i);
         let auth: { user: string; scopes: import('./lib/mcp/tokens').ApiScope[]; tokenId?: string } | null = null;
@@ -226,7 +226,10 @@ app.prepare().then(() => {
             // LAN-only, always TTL'd. The verifier handles all three
             // gates — server.ts just hands off remoteAddress.
             if (!auth) {
-              const remoteIp = (req.socket?.remoteAddress) ?? undefined;
+              // Behind NPM the socket peer is always loopback; resolve the
+              // true client IP from proxy headers so the LAN gate can't be
+              // bypassed from the internet (#1204).
+              const remoteIp = clientIpForLanGate(req.headers, req.socket?.remoteAddress ?? undefined);
               const bt = await verifyBootstrapToken(bearerMatch[1], remoteIp);
               if (bt) auth = bt;
             }


### PR DESCRIPTION
## What
The LAN-only bootstrap-token gate checks `isLanIp(req.socket.remoteAddress)`. Behind NPM the socket peer is always `127.0.0.1`, so the check passed for **every** caller — if the dashboard is exposed publicly, the `/mcp` bootstrap-token gate could be hit from the internet (#1204).

Adds `clientIpForLanGate(headers, socketAddr)` in `bootstrapToken.ts`: when the socket peer is loopback (i.e. the request came via the local proxy), it trusts the proxy's authoritative client-IP headers; otherwise it uses the socket address and ignores headers. `server.ts` feeds the resolved IP to `verifyBootstrapToken`.

## Security note for reviewer (differs from the issue's proposed patch)
The issue suggested `x-forwarded-for.split(',')[0]` (leftmost). That is **spoofable** — a direct client can send `X-Forwarded-For: 192.168.1.5` and NPM appends the real peer to the right, so leftmost is attacker-controlled. This PR instead:
- only trusts headers when the socket peer is **loopback** (request came through the local proxy);
- prefers **`X-Real-IP`** (nginx overwrites it with `$remote_addr`);
- falls back to the **rightmost** XFF hop (the one nginx appended);
- on a direct (non-loopback) connection, ignores headers entirely.

## Why
Closes #1204.

## Risk
Medium — changes how the bootstrap-token LAN gate identifies clients. **Draft (security gate) — needs human review.** Behaviour for a genuine LAN client via NPM is unchanged (X-Real-IP is their LAN IP → `isLanIp` true).

## Verification
- [x] npm run lint (0 errors, 403 warnings)
- [x] npm run check:arch
- [x] npm test (1344 pass; +6 `clientIpForLanGate` cases incl. spoof attempts)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — n/a for a draft (and full check needs a real NPM-fronted box)