### PR TITLE
fix(install): assemble walks all registries when source is omitted

### DIFF
--- a/packages/backend/src/lib/install/manifestAssembler.test.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.test.ts
@@ -72,6 +72,18 @@ beforeEach(() => {
 });
 
 describe('assembleManifest', () => {
+  it('omitting templateSource walks every registry (undefined), not a pinned Built-in (#1177)', async () => {
+    getTemplateYaml.mockResolvedValue(tmplYaml('svc', []));
+    getTemplateVariables.mockResolvedValue({});
+
+    await assembleManifest({ items: [{ name: 'svc', checked: true }] });
+
+    // undefined → getTemplateYaml/getTemplateVariables walk registries then
+    // fall back to built-in; a pinned 'Built-in' would skip externals (the bug).
+    expect(getTemplateYaml).toHaveBeenCalledWith('svc', undefined);
+    expect(getTemplateVariables).toHaveBeenCalledWith('svc', undefined);
+  });
+
   it('builds items with parsed dependencies and the fetched yaml', async () => {
     getTemplateYaml.mockImplementation(async (n) =>
       n === 'auth' ? tmplYaml('auth', []) : tmplYaml('media', ['auth', 'nginx']),

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -56,8 +56,11 @@ export interface AssembleManifestInput {
    *  the headless path reads them from the baked `config.json`. */
   prefilled?: Record<string, string>;
   /** Template source — `'Built-in'` for the bundled catalogue, or a
-   *  registry name. */
-  templateSource: string;
+   *  registry name. **Omit (undefined)** to walk every registry then fall
+   *  back to built-in per template, which is what lets a single assemble
+   *  call span multiple sources (#1177). A pinned `'Built-in'` skips the
+   *  registry walk, so external-registry templates resolve to null. */
+  templateSource?: string;
 }
 
 export interface AssembledManifest {

--- a/packages/frontend/src/app/api/install/assemble/route.ts
+++ b/packages/frontend/src/app/api/install/assemble/route.ts
@@ -31,10 +31,15 @@ export const POST = withApiHandler({}, async ({ request }) => {
     const manifest = await assembleManifest({
       items: body.items,
       prefilled: body.prefilled ?? {},
+      // Omitted/empty source → undefined (walk every registry, then
+      // built-in, per template) rather than a pinned 'Built-in' that
+      // skips externals. Lets one assemble call span multiple sources
+      // (#1177). The wizard always sends an explicit source, so its
+      // behaviour is unchanged.
       templateSource:
         typeof body.templateSource === 'string' && body.templateSource
           ? body.templateSource
-          : 'Built-in',
+          : undefined,
     });
     return NextResponse.json(manifest);
   } catch (error) {


### PR DESCRIPTION
## What
`/api/install/assemble` coerced an omitted `templateSource` to `'Built-in'`, which makes `getTemplateYaml(name, 'Built-in')` skip the registry walk — so any template that lives in an external registry (e.g. the migrated OSCAR templates in `mdopp/oscar`) returned `null` and a multi-source install was impossible. Now an omitted/empty source passes `undefined` through, so each per-template lookup walks every registry then falls back to built-in (`registry.ts:524`). `manifestAssembler` accepts an optional `templateSource`.

The wizard (`useStackInstall.ts`) always sends an explicit `templateSource`, so its behaviour is unchanged — only programmatic callers that omit it (the multi-source case) are affected, and walk-all is the intended behaviour there.

## Why
Closes #1177. Unblocked now that `mdopp/oscar` is live and the wizard's explicit-source behaviour is confirmed (resolves the design-fork the issue flagged — Option 2).

## Risk
Medium — changes the default resolution for assemble calls that omit a source.

## Rollback
`git revert` is enough.

## ⚠️ Do not merge until real-box /verify
This touches `lib/install/` (path-mandated `/verify`). I could not run it here — verifying needs a **multi-source assemble on the box with `mdopp/oscar` enabled as a registry**: `POST /api/install/assemble {items:[oscar-household, voice], templateSource omitted}` should return non-null yaml for both. Please `/verify` that before merging.

## Verification
- [x] npm run lint (0 errors, 403 warnings)
- [x] npm run check:arch
- [x] npm test (1339 pass; +1 assembler test asserting undefined→walk-all)
- [x] tsc --noEmit (0 errors)
- [ ] **/verify on the box (multi-source assemble) — REQUIRED before merge, not run here**