### PR TITLE
feat(file-share): link the latest BasicSync APK per Android ABI

### DIFF
--- a/packages/backend/src/lib/downloads/basicSync.test.ts
+++ b/packages/backend/src/lib/downloads/basicSync.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  resolveBasicSyncApkUrl,
+  isBasicSyncAbi,
+  DEFAULT_BASICSYNC_ABI,
+  __resetBasicSyncCache,
+} from './basicSync';
+
+vi.mock('../logger', () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+const RELEASE = {
+  tag_name: 'v1.30',
+  assets: [
+    { name: 'BasicSync-1.30-arm64-v8a-release.apk', browser_download_url: 'https://gh/arm64-v8a.apk' },
+    { name: 'BasicSync-1.30-armeabi-v7a-release.apk', browser_download_url: 'https://gh/armeabi-v7a.apk' },
+    { name: 'BasicSync-1.30-x86-release.apk', browser_download_url: 'https://gh/x86.apk' },
+    { name: 'BasicSync-1.30-x86_64-release.apk', browser_download_url: 'https://gh/x86_64.apk' },
+    { name: 'mapping.txt.zst', browser_download_url: 'https://gh/mapping' },
+  ],
+};
+
+function stubFetch(release: unknown, ok = true, status = 200) {
+  const f = vi.fn(async () => ({ ok, status, json: async () => release }));
+  vi.stubGlobal('fetch', f);
+  return f;
+}
+
+beforeEach(() => __resetBasicSyncCache());
+afterEach(() => vi.unstubAllGlobals());
+
+describe('resolveBasicSyncApkUrl', () => {
+  it('resolves the arm64-v8a APK', async () => {
+    stubFetch(RELEASE);
+    expect(await resolveBasicSyncApkUrl('arm64-v8a')).toBe('https://gh/arm64-v8a.apk');
+  });
+
+  it('matches x86 without picking up the x86_64 asset (endsWith guard)', async () => {
+    stubFetch(RELEASE);
+    expect(await resolveBasicSyncApkUrl('x86')).toBe('https://gh/x86.apk');
+    expect(await resolveBasicSyncApkUrl('x86_64')).toBe('https://gh/x86_64.apk');
+  });
+
+  it('caches the release — a second resolve does not re-fetch', async () => {
+    const f = stubFetch(RELEASE);
+    await resolveBasicSyncApkUrl('arm64-v8a');
+    await resolveBasicSyncApkUrl('x86_64');
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when no asset matches the ABI', async () => {
+    stubFetch({ tag_name: 'v1.30', assets: [{ name: 'mapping.txt.zst', browser_download_url: 'x' }] });
+    expect(await resolveBasicSyncApkUrl('arm64-v8a')).toBeNull();
+  });
+
+  it('returns null on an API error with nothing cached', async () => {
+    stubFetch({}, false, 502);
+    expect(await resolveBasicSyncApkUrl('arm64-v8a')).toBeNull();
+  });
+});
+
+describe('isBasicSyncAbi / default', () => {
+  it('accepts known ABIs, rejects others', () => {
+    expect(isBasicSyncAbi('arm64-v8a')).toBe(true);
+    expect(isBasicSyncAbi('mips')).toBe(false);
+    expect(isBasicSyncAbi(null)).toBe(false);
+  });
+  it('defaults to arm64-v8a', () => {
+    expect(DEFAULT_BASICSYNC_ABI).toBe('arm64-v8a');
+  });
+});

--- a/packages/backend/src/lib/downloads/basicSync.ts
+++ b/packages/backend/src/lib/downloads/basicSync.ts
@@ -1,0 +1,70 @@
+/**
+ * Resolve the download URL for the latest BasicSync APK (an actively
+ * maintained Android Syncthing client, https://github.com/chenxiaolong/BasicSync).
+ *
+ * BasicSync's release assets embed the version in their filename
+ * (`BasicSync-1.30-arm64-v8a-release.apk`), so GitHub's stable
+ * `releases/latest/download/<name>` permalink can't target them. We resolve
+ * the per-ABI asset at request time via the releases API instead, so a link
+ * never pins a stale version — "latest for the platform".
+ */
+import { logger } from '../logger';
+
+const REPO = 'chenxiaolong/BasicSync';
+
+/** ABIs BasicSync ships an APK for. `arm64-v8a` covers effectively every
+ *  phone from the last several years; the rest are for older / x86 devices. */
+export const BASICSYNC_ABIS = ['arm64-v8a', 'armeabi-v7a', 'x86_64', 'x86'] as const;
+export type BasicSyncAbi = (typeof BASICSYNC_ABIS)[number];
+export const DEFAULT_BASICSYNC_ABI: BasicSyncAbi = 'arm64-v8a';
+
+export function isBasicSyncAbi(value: string | null | undefined): value is BasicSyncAbi {
+  return !!value && (BASICSYNC_ABIS as readonly string[]).includes(value);
+}
+
+interface GithubAsset { name: string; browser_download_url: string }
+interface GithubRelease { tag_name?: string; assets?: GithubAsset[] }
+
+// GitHub's unauthenticated API allows only ~60 requests/hr per IP, and a
+// download-redirect endpoint can be hit far more often, so cache the
+// latest-release lookup. 1 h keeps "latest" fresh enough for app downloads.
+const TTL_MS = 60 * 60 * 1000;
+let cache: { at: number; release: GithubRelease } | null = null;
+
+async function getLatestRelease(): Promise<GithubRelease | null> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.release;
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'servicebay' },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      logger.warn('BasicSync', `GitHub releases API returned HTTP ${res.status}`);
+      return cache?.release ?? null; // serve stale on a transient API error
+    }
+    const release = (await res.json()) as GithubRelease;
+    cache = { at: Date.now(), release };
+    return release;
+  } catch (e) {
+    logger.warn('BasicSync', `Failed to fetch latest release: ${e instanceof Error ? e.message : String(e)}`);
+    return cache?.release ?? null;
+  }
+}
+
+/**
+ * Resolve the `browser_download_url` of the latest BasicSync APK for `abi`.
+ * Returns null when the release (or a matching asset) can't be found.
+ *
+ * Matches on the `-<abi>-release.apk` suffix; `endsWith` keeps `x86` from
+ * matching the `x86_64` asset.
+ */
+export async function resolveBasicSyncApkUrl(abi: BasicSyncAbi): Promise<string | null> {
+  const release = await getLatestRelease();
+  const asset = release?.assets?.find(a => a.name.endsWith(`-${abi}-release.apk`));
+  return asset?.browser_download_url ?? null;
+}
+
+/** Test-only: drop the cached release so a test can control each fetch. */
+export function __resetBasicSyncCache(): void {
+  cache = null;
+}

--- a/packages/backend/src/lib/portal/userGuide.test.ts
+++ b/packages/backend/src/lib/portal/userGuide.test.ts
@@ -74,6 +74,20 @@ recommended_apps:
     expect(result!.frontmatter.recommended_apps?.[0].name).toBe('Real');
   });
 
+  it('accepts same-origin root-relative URLs but rejects protocol-relative ones', () => {
+    const raw = `---
+recommended_apps:
+  - name: "Dynamic download"
+    url: "/api/system/downloads/basicsync?abi=arm64-v8a"
+  - name: "Off-origin"
+    url: "//evil.example/x"
+---
+`;
+    const result = parseUserGuide(raw, 'rel');
+    expect(result!.frontmatter.recommended_apps).toHaveLength(1);
+    expect(result!.frontmatter.recommended_apps?.[0].url).toBe('/api/system/downloads/basicsync?abi=arm64-v8a');
+  });
+
   it('lifts legacy mobile_apps into recommended_apps with inferred platforms', () => {
     const raw = `---
 mobile_apps:

--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -181,7 +181,13 @@ function parseRecommendedApps(input: unknown): RecommendedApp[] {
       if (!entry || typeof entry !== 'object') return null;
       const e = entry as Record<string, unknown>;
       if (typeof e.name !== 'string' || typeof e.url !== 'string') return null;
-      if (!/^https?:\/\//i.test(e.url)) return null;
+      // Accept absolute http(s) links and same-origin root-relative paths
+      // (e.g. `/api/system/downloads/...` for a dynamically-resolved, always-
+      // latest download). Reject protocol-relative `//host` and dangerous
+      // schemes (`javascript:`, `data:`) — these become an `href`.
+      const isHttp = /^https?:\/\//i.test(e.url);
+      const isRootRelative = e.url.startsWith('/') && !e.url.startsWith('//');
+      if (!isHttp && !isRootRelative) return null;
       const out: RecommendedApp = { name: e.name, url: e.url };
       if (Array.isArray(e.platforms)) {
         const platforms = e.platforms

--- a/packages/frontend/src/app/api/system/downloads/basicsync/route.ts
+++ b/packages/frontend/src/app/api/system/downloads/basicsync/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandler } from '@/lib/api/handler';
+import { resolveBasicSyncApkUrl, isBasicSyncAbi, DEFAULT_BASICSYNC_ABI } from '@/lib/downloads/basicSync';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({ abi: z.string().optional() });
+
+/**
+ * GET /api/system/downloads/basicsync?abi=<arm64-v8a|armeabi-v7a|x86_64|x86>
+ *
+ * 302-redirects to the latest BasicSync APK for the requested Android ABI
+ * (default arm64-v8a). Linked from the family-facing portal user guide, so
+ * it's public (see proxy.ts) — it only ever redirects to a public GitHub
+ * release asset, never anything sensitive.
+ */
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+    const abi = isBasicSyncAbi(query.abi) ? query.abi : DEFAULT_BASICSYNC_ABI;
+    const url = await resolveBasicSyncApkUrl(abi);
+    if (!url) {
+      return NextResponse.json(
+        { error: 'Could not resolve the latest BasicSync APK from GitHub. Try again shortly.' },
+        { status: 502 },
+      );
+    }
+    return NextResponse.redirect(url, 302);
+  },
+);

--- a/packages/frontend/src/proxy.ts
+++ b/packages/frontend/src/proxy.ts
@@ -51,6 +51,11 @@ const PUBLIC_API_RULES: PublicApiRule[] = [
   // by a wipe-secrets clean install. Returns sanitised progress only
   // — no `input.variables`, no credentials manifest.
   { prefix: '/api/install/progress', methods: new Set(['GET']) },
+  // BasicSync APK download-redirect (file-share user guide → "install the
+  // Android Syncthing client"). GET-only; resolves the latest release asset
+  // for the requested ABI and 302s to a public GitHub URL. Public because
+  // the portal user guide that links it is family-facing — no secrets.
+  { prefix: '/api/system/downloads/basicsync', methods: new Set(['GET']) },
 ];
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);

--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -22,8 +22,12 @@ cards:
     recommended_apps:
       - name: "Syncthing"
         url: "https://syncthing.net/downloads/"
-        platforms: ["desktop", "android"]
-        note: "Two-way folder sync between your devices and the home server."
+        platforms: ["desktop"]
+        note: "Two-way folder sync between your computer and the home server."
+      - name: "BasicSync"
+        url: "/api/system/downloads/basicsync?abi=arm64-v8a"
+        platforms: ["android"]
+        note: "Actively-maintained Android Syncthing client. This link always grabs the latest build for arm64 phones — for older or x86 devices change ?abi= to armeabi-v7a, x86_64 or x86."
       - name: "Möbius Sync"
         url: "https://apps.apple.com/app/m%C3%B6bius-sync/id1539203216"
         platforms: ["ios"]


### PR DESCRIPTION
## What
Recommends **BasicSync** (an actively-maintained Android Syncthing client, `chenxiaolong/BasicSync`) in the file-share user guide — and links the **latest** build for the device's **ABI**, dynamically.

BasicSync's release assets embed the version in the filename (`BasicSync-1.30-arm64-v8a-release.apk`), so GitHub's stable `releases/latest/download/<name>` permalink can't target them. So:
- `packages/backend/src/lib/downloads/basicSync.ts` — cached (1h) resolver over the GitHub releases API → per-ABI `browser_download_url`.
- `GET /api/system/downloads/basicsync?abi=<arm64-v8a|armeabi-v7a|x86_64|x86>` → 302 to the latest APK (default arm64-v8a).
- The recommended-apps parser (`userGuide.ts`) now accepts same-origin root-relative URLs (rejecting protocol-relative `//host` + dangerous schemes), so the guide can link the dynamic endpoint.
- The endpoint is **public** (portal user guide is family-facing) — it only ever redirects to a public GitHub asset.
- `templates/file-share/user-guide.md`: Syncthing narrowed to desktop; BasicSync added as the Android client.

## Why
Per request: BasicSync is the recommended Android Syncthing client, and the link must always resolve to the latest release for the platform — not a pinned/stale version.

## Risk
Low — additive. New lib + read-only redirect endpoint; the parser change only *widens* accepted URLs (still rejects `javascript:`/`data:`/`//host`).

## Rollback
`git revert`.

## Verification
- [x] npm run lint (0 errors, 403 warnings)
- [x] npm run check:arch
- [x] npm test (1347 pass; +7 resolver tests incl. ABI-suffix + cache + error, +2 parser tests for root-relative accept / protocol-relative reject)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — n/a: touched paths (lib/downloads, api/system/downloads, lib/portal, proxy.ts, template doc) aren't in the path-mandated list