### PR TITLE
fix(agent): redact secret env values from command-payload logs

### DIFF
--- a/packages/backend/src/lib/agent/handler.redact.test.ts
+++ b/packages/backend/src/lib/agent/handler.redact.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { redactCommandPayloadForLog } from './handler';
+
+describe('redactCommandPayloadForLog (#1211)', () => {
+  it('replaces write_file content (the rendered pod YAML) with a size marker', () => {
+    const yaml = 'env:\n- name: HERMES_TOKEN\n  value: super-secret\n'.padEnd(500, ' ');
+    const out = redactCommandPayloadForLog({ path: '/svc.yml', content: yaml });
+    expect(out.path).toBe('/svc.yml');
+    expect(out.content).toBe(`<${yaml.length} chars redacted>`);
+    expect(JSON.stringify(out)).not.toContain('super-secret');
+  });
+
+  it('masks secret-looking keys', () => {
+    const out = redactCommandPayloadForLog({ PUSH_TOKEN: 'abc', api_key: 'k', name: 'svc' });
+    expect(out.PUSH_TOKEN).toBe('***');
+    expect(out.api_key).toBe('***');
+    expect(out.name).toBe('svc');
+  });
+
+  it('leaves non-secret payloads intact', () => {
+    const out = redactCommandPayloadForLog({ command: 'ls -la', timeout: 30 });
+    expect(out).toEqual({ command: 'ls -la', timeout: 30 });
+  });
+});

--- a/packages/backend/src/lib/agent/handler.ts
+++ b/packages/backend/src/lib/agent/handler.ts
@@ -158,6 +158,30 @@ export interface AgentHealth {
  */
 const BOOTSTRAP_WINDOW_MS = 60 * 1000;
 
+const SECRET_KEY_RE = /(TOKEN|SECRET|PASSWORD|API_KEY)/i;
+
+/**
+ * Redact secret material from a command payload before it is logged.
+ *
+ * The rendered pod YAML shipped to the agent via `write_file` carries
+ * plaintext `env` secrets (HERMES_TOKEN, …); logging the payload verbatim
+ * leaked live credentials into the journal (#1211). Replace any `content`
+ * blob with a size marker and mask the value of any secret-looking key.
+ */
+export function redactCommandPayloadForLog(params: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (key === 'content' && typeof value === 'string') {
+      out[key] = `<${value.length} chars redacted>`;
+    } else if (SECRET_KEY_RE.test(key) && typeof value === 'string') {
+      out[key] = '***';
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 export class AgentHandler extends EventEmitter {
   public nodeName: string;
   private channel: ClientChannel | null = null;
@@ -566,7 +590,7 @@ export class AgentHandler extends EventEmitter {
     const payloadPreview = (() => {
       if (!params || Object.keys(params).length === 0) return '{}';
       try {
-        const serialized = JSON.stringify(params);
+        const serialized = JSON.stringify(redactCommandPayloadForLog(params));
         return serialized.length > 400 ? `${serialized.slice(0, 400)}…` : serialized;
       } catch {
         return '[unserializable payload]';

--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -192,6 +192,30 @@ def log_structured(event: str, payload: Any):
     sys.stderr.write(json.dumps(structured) + "\n")
     sys.stderr.flush()
 
+_SECRET_KEY_RE = re.compile(r'(TOKEN|SECRET|PASSWORD|API_KEY)', re.IGNORECASE)
+
+
+def _redact_for_log(payload):
+    """Redact secret material from a command payload before it hits the logs.
+
+    The rendered pod YAML shipped via `write_file` carries plaintext `env`
+    secrets (HERMES_TOKEN, …); logging the payload verbatim leaked live
+    credentials into the journal (#1211). Replace any `content` blob with a
+    size marker and mask the value of any secret-looking key.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    out = {}
+    for key, value in payload.items():
+        if key == 'content' and isinstance(value, str):
+            out[key] = f'<{len(value)} chars redacted>'
+        elif isinstance(key, str) and _SECRET_KEY_RE.search(key) and isinstance(value, str):
+            out[key] = '***'
+        else:
+            out[key] = value
+    return out
+
+
 def _extract_session_id(cmdline: str) -> Optional[str]:
     if not cmdline:
         return None
@@ -1887,7 +1911,7 @@ class Agent:
         req_id = msg.get('id')
         payload = msg.get('payload', {})
         
-        log_info(f"Received command: {cmd} (ID: {req_id}, Payload: {json.dumps(payload)})")
+        log_info(f"Received command: {cmd} (ID: {req_id}, Payload: {json.dumps(_redact_for_log(payload))})")
         sys.stderr.flush()
 
         # Fallback response helper

--- a/packages/backend/src/lib/agent/v4/tests/test_redact.py
+++ b/packages/backend/src/lib/agent/v4/tests/test_redact.py
@@ -1,0 +1,30 @@
+import unittest
+import sys
+import os
+
+# Import the agent module the same way test_agent.py does.
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import agent  # noqa: E402
+
+
+class TestRedactForLog(unittest.TestCase):
+    def test_redacts_write_file_content(self):
+        # The rendered pod YAML (with plaintext env secrets) rides in `content`.
+        out = agent._redact_for_log({'path': '/x.yml', 'content': 'a' * 500})
+        self.assertEqual(out['path'], '/x.yml')
+        self.assertEqual(out['content'], '<500 chars redacted>')
+        self.assertNotIn('aaaa', str(out))
+
+    def test_masks_secret_keys(self):
+        out = agent._redact_for_log({'PUSH_TOKEN': 'abc', 'api_key': 'k', 'name': 'svc'})
+        self.assertEqual(out['PUSH_TOKEN'], '***')
+        self.assertEqual(out['api_key'], '***')
+        self.assertEqual(out['name'], 'svc')
+
+    def test_non_dict_passthrough(self):
+        self.assertEqual(agent._redact_for_log('hi'), 'hi')
+        self.assertEqual(agent._redact_for_log(None), None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What
The agent logged every received command's **full payload** at INFO (`agent.py` "Received command … Payload: {json}"), and the client logged a 400-char payload preview (`handler.ts`). For `write_file`, the payload `content` is the fully-rendered pod YAML — including `env:` entries with **plaintext secrets** (HERMES_TOKEN, PUSH_TOKEN, …) — so live credentials leaked into journald.

Adds a redactor on both sides that replaces a `content` blob with a `<N chars redacted>` marker and masks the value of any secret-looking key (`*TOKEN*`, `*SECRET*`, `*PASSWORD*`, `*API_KEY*`) before logging.

## Why
Closes #1211 (credential exposure). Found during OSCAR end-to-end verification (mdopp/oscar#80).

## Risk
Low — log-output redaction only; no change to what the agent actually executes. **Opened as a security-gate draft** — touches `lib/agent/` (path-mandated `/verify`) and is credential-sensitive, so it wants human review + a real-box `/verify` (deploy the agent, confirm `journalctl` no longer prints env secrets and deploys still work) before merge.

## Note for reviewer
- Scope is the command-**payload** log (the reported pod-YAML leak). The success-result log is already truncated to 100 chars; tightening that further (e.g. `read_file` results) is a reasonable follow-up but out of scope here.
- Rotate any tokens that may have already been exposed in existing journals.

## Verification
- [x] npm run lint (0 errors, 403 warnings)
- [x] npm run check:arch
- [x] npm test (1350 pass; +3 handler redaction tests) + python unittest (12 pass; +3 `_redact_for_log` tests)
- [x] tsc --noEmit (0 errors)
- [ ] /verify on the box (agent redeploy; confirm no secret leak in journald) — REQUIRED before merge, not run here