### PR TITLE
feat(backup): per-service config manifest + stripping rules for externalBackup

### DIFF
--- a/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  SERVICE_BACKUP_MANIFESTS,
+  getServiceManifest,
+  stripYamlKeys,
+  applyStripRules,
+} from './serviceManifest';
+
+describe('service backup manifests', () => {
+  it('covers the #1190 services and excludes vaultwarden', () => {
+    const names = SERVICE_BACKUP_MANIFESTS.map(m => m.service);
+    expect(names).toEqual(
+      expect.arrayContaining(['home-assistant', 'authelia', 'adguard', 'syncthing', 'hermes']),
+    );
+    expect(getServiceManifest('vaultwarden')).toBeUndefined();
+  });
+
+  it('keeps the zwave_js network keys in home-assistant (needed to recover the mesh)', () => {
+    expect(getServiceManifest('home-assistant')!.include).toContain('.storage/zwave_js');
+  });
+
+  it('excludes the recorder DB from home-assistant', () => {
+    expect(getServiceManifest('home-assistant')!.exclude).toContain('home-assistant_v2.db');
+  });
+});
+
+describe('stripYamlKeys', () => {
+  it('drops password hashes from an authelia users_database while keeping the rest', () => {
+    const src = `users:
+  michael:
+    displayname: Michael
+    password: $argon2id$v=19$secrethash
+    email: m@example.com
+    groups:
+      - admins
+`;
+    const out = stripYamlKeys(src, ['password']);
+    const parsed = yaml.load(out) as { users: Record<string, Record<string, unknown>> };
+    expect(parsed.users.michael.password).toBeUndefined();
+    expect(parsed.users.michael.displayname).toBe('Michael');
+    expect(parsed.users.michael.email).toBe('m@example.com');
+    expect(parsed.users.michael.groups).toEqual(['admins']);
+    expect(out).not.toContain('secrethash');
+  });
+
+  it('returns the original content unchanged when it is not valid YAML', () => {
+    const garbage = '\t: : not: yaml: [unclosed';
+    expect(stripYamlKeys(garbage, ['password'])).toBe(garbage);
+  });
+});
+
+describe('applyStripRules', () => {
+  it('strips a targeted file and passes other files through untouched', () => {
+    const authelia = getServiceManifest('authelia')!;
+    const stripped = applyStripRules(authelia, 'users_database.yml', 'users:\n  a:\n    password: x\n');
+    expect(stripped).not.toContain('password');
+    const passthrough = applyStripRules(authelia, 'some-other-file.yml', 'password: keep\n');
+    expect(passthrough).toBe('password: keep\n');
+  });
+});

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -1,0 +1,125 @@
+/**
+ * The single source of truth for "what counts as per-service config" in the
+ * FritzBox-NAS config-survival feature (#1190). Both the backup producer and
+ * the `sb-config-upload` CLI consume this, so the include/exclude/strip rules
+ * live in exactly one place.
+ *
+ * Pure data + pure helpers — no I/O. The producer resolves these relative
+ * paths against a service's on-disk data dir.
+ */
+import yaml from 'js-yaml';
+
+export interface StripRule {
+  /** Config file (relative to the service data dir) the rule applies to. */
+  file: string;
+  /** YAML keys to remove wherever they appear — e.g. `password` hashes. */
+  dropYamlKeys: string[];
+}
+
+export interface ServiceBackupManifest {
+  /** ServiceBay template/service name. */
+  service: string;
+  /** Relative paths/dirs that ARE config worth preserving across a reinstall. */
+  include: string[];
+  /** Relative paths/dirs to never back up — bulk data, logs, caches, and
+   *  secrets with no restore value. Conceptually excludes win over includes. */
+  exclude: string[];
+  /** Per-file transforms applied before a file enters the tarball. */
+  strip?: StripRule[];
+}
+
+/**
+ * Per-service config scope, transcribed from the table in #1190.
+ * vaultwarden is intentionally absent — its vault DB has no reset path and
+ * needs its own user-exported backup story, out of scope for this feature.
+ */
+export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
+  {
+    service: 'home-assistant',
+    include: [
+      'automations.yaml', 'scripts.yaml', 'scenes.yaml', 'configuration.yaml',
+      '.storage/core.config_entries', '.storage/core.device_registry',
+      '.storage/core.entity_registry', '.storage/core.area_registry',
+      '.storage/lovelace', '.storage/lovelace_dashboards',
+      // zwave_js network keys ARE needed to recover the mesh after a reinstall.
+      '.storage/zwave_js',
+    ],
+    exclude: [
+      'home-assistant_v2.db', 'home-assistant_v2.db-wal', 'home-assistant_v2.db-shm',
+      'history', 'logs', 'home-assistant.log', 'tts', 'image', 'www', 'deps',
+    ],
+  },
+  {
+    service: 'authelia',
+    include: ['users_database.yml'],
+    exclude: [],
+    // Usernames, groups, email, display name only — password hashes are
+    // stripped; operators reset via email-forgotten after a restore.
+    strip: [{ file: 'users_database.yml', dropYamlKeys: ['password'] }],
+  },
+  {
+    service: 'adguard',
+    // clients (device→tag map), blocklists, DNS rewrites, retention setting.
+    include: ['conf/AdGuardHome.yaml'],
+    exclude: ['data/querylog.json', 'data/stats.db', 'data/sessions.db', 'data/filters'],
+  },
+  {
+    service: 'syncthing',
+    // device list + folder-share definitions; the synced data re-syncs from peers.
+    include: ['config.xml'],
+    exclude: ['index-v0.14.0.db', 'index'],
+  },
+  {
+    service: 'hermes',
+    // model selection, prompts, household persona, MCP endpoint list,
+    // installed-skills git URLs, household-member personalization.
+    include: ['config.yaml'],
+    exclude: ['vectordb', 'embeddings', 'conversations', 'history'],
+    // LLM API keys are re-entered after a restore.
+    strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
+  },
+];
+
+export function getServiceManifest(service: string): ServiceBackupManifest | undefined {
+  return SERVICE_BACKUP_MANIFESTS.find(m => m.service === service);
+}
+
+/**
+ * Remove `dropKeys` from a YAML document wherever they appear (the top-level
+ * mapping and every nested mapping — e.g. each user under authelia's `users:`).
+ * Best-effort: returns the original text unchanged if it doesn't parse as YAML.
+ */
+export function stripYamlKeys(content: string, dropKeys: string[]): string {
+  let doc: unknown;
+  try {
+    doc = yaml.load(content);
+  } catch {
+    return content;
+  }
+  if (doc === undefined || doc === null) return content;
+  const drop = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(drop);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      const rec = node as Record<string, unknown>;
+      for (const k of dropKeys) delete rec[k];
+      for (const v of Object.values(rec)) drop(v);
+    }
+  };
+  drop(doc);
+  return yaml.dump(doc);
+}
+
+/** Apply a manifest's strip rules to one file's content. Returns the content
+ *  unchanged when no rule targets `file`. */
+export function applyStripRules(
+  manifest: ServiceBackupManifest,
+  file: string,
+  content: string,
+): string {
+  const rule = manifest.strip?.find(r => r.file === file);
+  if (!rule) return content;
+  return stripYamlKeys(content, rule.dropYamlKeys);
+}


### PR DESCRIPTION
## What
The DRY source of truth for "what counts as per-service config" in the FritzBox-NAS config-survival feature (#1190): a declarative `SERVICE_BACKUP_MANIFESTS` (include/exclude paths per service — home-assistant, authelia, adguard, syncthing, hermes; vaultwarden deliberately out of scope) plus pure `stripYamlKeys`/`applyStripRules` helpers that drop password hashes / API keys before a config file enters a backup. No I/O — the producer (#1216) and the `sb-config-upload` CLI (#1219) both consume it.

## Why
Closes #1214 (first foundation of epic #1190).

## Risk
Low — new pure-data/helper module, nothing imports it yet. Path strings are best-effort from #1190's table and will be confirmed against the box when the producer (#1216) is built/verified.

## Rollback
`git revert`.

## Verification
- [x] npm run lint (0 errors, 403 warnings)
- [x] npm run check:arch
- [x] npm test (1353 pass; +6 manifest/strip tests incl. authelia password-strip + non-YAML passthrough)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — n/a: `lib/externalBackup/` is not in the path-mandated list