### PR TITLE
feat(backup): FTP NAS client for the FritzBox (reuses gateway creds)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@servicebay/api-client": "*",
         "@tailwindcss/typography": "^0.5.19",
         "@xyflow/react": "^12.10.0",
+        "basic-ftp": "^6.0.1",
         "bcryptjs": "^3.0.3",
         "jose": "^6.1.3",
         "js-yaml": "^4.1.1",
@@ -1873,19 +1874,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -4844,6 +4832,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/basic-ftp": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-6.0.1.tgz",
+      "integrity": "sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -5011,15 +5008,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/buildcheck": {
       "version": "0.0.7",
@@ -12193,18 +12181,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -12212,19 +12188,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -12669,36 +12632,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@servicebay/api-client": "*",
     "@tailwindcss/typography": "^0.5.19",
     "@xyflow/react": "^12.10.0",
+    "basic-ftp": "^6.0.1",
     "bcryptjs": "^3.0.3",
     "jose": "^6.1.3",
     "js-yaml": "^4.1.1",

--- a/packages/backend/src/lib/externalBackup/nasClient.test.ts
+++ b/packages/backend/src/lib/externalBackup/nasClient.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockClient, mockGetConfig } = vi.hoisted(() => ({
+  mockClient: {
+    access: vi.fn(),
+    pwd: vi.fn(),
+    ensureDir: vi.fn(),
+    uploadFrom: vi.fn(),
+    downloadTo: vi.fn(),
+    list: vi.fn(),
+    remove: vi.fn(),
+    close: vi.fn(),
+  },
+  mockGetConfig: vi.fn(),
+}));
+
+vi.mock('basic-ftp', () => ({ Client: vi.fn(function () { return mockClient; }) }));
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+
+import { getNasTarget, testNasConnection, nasUpload, nasDownload, nasList, nasRemove } from './nasClient';
+
+const GW = { gateway: { type: 'fritzbox', host: '192.168.178.1', username: 'fritz9746', password: 'pw' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockResolvedValue(GW);
+  mockClient.access.mockResolvedValue(undefined);
+  mockClient.pwd.mockResolvedValue('/');
+  mockClient.ensureDir.mockResolvedValue(undefined);
+  mockClient.uploadFrom.mockResolvedValue(undefined);
+  mockClient.downloadTo.mockImplementation(async (sink: NodeJS.WritableStream) => { sink.write(Buffer.from('hello')); });
+  mockClient.list.mockResolvedValue([{ name: 'x.tar', size: 10 }]);
+  mockClient.remove.mockResolvedValue(undefined);
+});
+
+describe('getNasTarget', () => {
+  it('maps the FritzBox gateway config to an FTP target', async () => {
+    expect(await getNasTarget()).toEqual({ host: '192.168.178.1', user: 'fritz9746', password: 'pw', secure: false });
+  });
+  it('returns null when gateway credentials are incomplete', async () => {
+    mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', host: 'h' } });
+    expect(await getNasTarget()).toBeNull();
+  });
+  it('returns null when there is no gateway', async () => {
+    mockGetConfig.mockResolvedValue({});
+    expect(await getNasTarget()).toBeNull();
+  });
+});
+
+describe('nas operations', () => {
+  it('uploads into a created parent dir using gateway creds', async () => {
+    await nasUpload('sb-backup/authelia.tar', Buffer.from('data'));
+    expect(mockClient.access).toHaveBeenCalledWith(
+      expect.objectContaining({ host: '192.168.178.1', user: 'fritz9746', secure: false }),
+    );
+    expect(mockClient.ensureDir).toHaveBeenCalledWith('sb-backup');
+    expect(mockClient.uploadFrom).toHaveBeenCalledWith(expect.anything(), 'authelia.tar');
+    expect(mockClient.close).toHaveBeenCalled();
+  });
+  it('uploads a root-level file without ensureDir', async () => {
+    await nasUpload('top.txt', Buffer.from('x'));
+    expect(mockClient.ensureDir).not.toHaveBeenCalled();
+    expect(mockClient.uploadFrom).toHaveBeenCalledWith(expect.anything(), 'top.txt');
+  });
+  it('downloads to a buffer', async () => {
+    const buf = await nasDownload('sb-backup/x.tar');
+    expect(buf.toString()).toBe('hello');
+    expect(mockClient.downloadTo).toHaveBeenCalled();
+  });
+  it('lists a directory', async () => {
+    expect(await nasList('sb-backup')).toEqual([{ name: 'x.tar', size: 10 }]);
+    expect(mockClient.list).toHaveBeenCalledWith('sb-backup');
+  });
+  it('removes a file idempotently', async () => {
+    await nasRemove('/sb-backup/x.tar');
+    expect(mockClient.remove).toHaveBeenCalledWith('sb-backup/x.tar', true);
+  });
+  it('closes the client even when an op throws', async () => {
+    mockClient.uploadFrom.mockRejectedValueOnce(new Error('boom'));
+    await expect(nasUpload('a/b.txt', Buffer.from('x'))).rejects.toThrow('boom');
+    expect(mockClient.close).toHaveBeenCalled();
+  });
+});
+
+describe('testNasConnection', () => {
+  it('ok when access + pwd succeed', async () => {
+    expect(await testNasConnection()).toEqual({ ok: true });
+  });
+  it('reports not-configured', async () => {
+    mockGetConfig.mockResolvedValue({});
+    const r = await testNasConnection();
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/not configured/i);
+  });
+  it('reports an auth/connect failure', async () => {
+    mockClient.access.mockRejectedValueOnce(new Error('530 Login incorrect'));
+    const r = await testNasConnection();
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/Login incorrect/);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/nasClient.ts
+++ b/packages/backend/src/lib/externalBackup/nasClient.ts
@@ -1,0 +1,114 @@
+/**
+ * Userspace client for the FritzBox USB NAS, used by the config-survival
+ * backup feature (#1190 / #1215).
+ *
+ * Transport: **FTP** via `basic-ftp` (pure JS — no native deps, no system
+ * binary, no kernel `cifs` mount, no `cap_admin`). We landed on FTP because
+ * the FritzBox's SMB is off by default and the maintained JS SMB libraries
+ * fail on Node 20+ (their NTLM dependency uses DES, disabled by OpenSSL 3),
+ * whereas the FritzBox's FTP works cleanly with a pure-JS client.
+ *
+ * Credentials reuse `config.gateway` — the FritzBox USB NAS is the same
+ * device and the same FritzBox user as the gateway, so there's one source of
+ * truth for the host + login rather than duplicated NAS fields.
+ */
+import { Client, type FileInfo } from 'basic-ftp';
+import { Readable, Writable } from 'stream';
+import { getConfig } from '../config';
+
+export interface NasTarget {
+  host: string;
+  user: string;
+  password: string;
+  /** Explicit FTPS (AUTH TLS). Default false — plain FTP on the LAN. */
+  secure: boolean;
+}
+
+const CONNECT_TIMEOUT_MS = 15_000;
+
+/** Resolve FTP connection details from the configured FritzBox gateway, or
+ *  null when the gateway isn't configured with credentials. */
+export async function getNasTarget(): Promise<NasTarget | null> {
+  const gw = (await getConfig()).gateway;
+  if (gw?.type !== 'fritzbox' || !gw.host || !gw.username || !gw.password) return null;
+  return { host: gw.host, user: gw.username, password: gw.password, secure: false };
+}
+
+async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const target = await getNasTarget();
+  if (!target) {
+    throw new Error('FritzBox NAS not configured — set the gateway (host + credentials) in Settings → Integrations.');
+  }
+  const client = new Client(CONNECT_TIMEOUT_MS);
+  // Never enable client.ftp.verbose: it logs the FTP command stream including
+  // the cleartext `PASS` line (the #1211 credential-leak class).
+  try {
+    await client.access({
+      host: target.host,
+      user: target.user,
+      password: target.password,
+      secure: target.secure,
+    });
+    return await fn(client);
+  } finally {
+    client.close();
+  }
+}
+
+/** Probe connectivity + auth without transferring anything. */
+export async function testNasConnection(): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await withClient(client => client.pwd());
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function splitRemote(remotePath: string): { dir: string; base: string } {
+  const clean = remotePath.replace(/^\/+/, '');
+  const slash = clean.lastIndexOf('/');
+  return slash < 0 ? { dir: '', base: clean } : { dir: clean.slice(0, slash), base: clean.slice(slash + 1) };
+}
+
+/** Upload a buffer or stream to `remotePath` (relative to the NAS root),
+ *  creating parent directories as needed. */
+export async function nasUpload(remotePath: string, data: Buffer | Readable): Promise<void> {
+  const { dir, base } = splitRemote(remotePath);
+  const source = Buffer.isBuffer(data) ? Readable.from(data) : data;
+  await withClient(async client => {
+    // ensureDir creates the full path and changes into it; the upload target
+    // is then the basename relative to that working directory.
+    if (dir) await client.ensureDir(dir);
+    await client.uploadFrom(source, base);
+  });
+}
+
+/** Download `remotePath` (relative to the NAS root) into a Buffer. */
+export async function nasDownload(remotePath: string): Promise<Buffer> {
+  const clean = remotePath.replace(/^\/+/, '');
+  return withClient(async client => {
+    const chunks: Buffer[] = [];
+    const sink = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(Buffer.from(chunk));
+        cb();
+      },
+    });
+    await client.downloadTo(sink, clean);
+    return Buffer.concat(chunks);
+  });
+}
+
+/** List a directory (relative to the NAS root). */
+export async function nasList(dir = ''): Promise<FileInfo[]> {
+  const clean = dir.replace(/^\/+/, '');
+  return withClient(client => client.list(clean || undefined));
+}
+
+/** Remove a file (relative to the NAS root). Idempotent — a missing file
+ *  resolves rather than throwing. */
+export async function nasRemove(remotePath: string): Promise<void> {
+  const clean = remotePath.replace(/^\/+/, '');
+  await withClient(client => client.remove(clean, true));
+}


### PR DESCRIPTION
## What
The userspace NAS client for epic #1190 (#1215) — **transport pivoted SMB → FTP**:
- The FritzBox's **SMB is off by default**, and the maintained JS SMB libs (`@marsaud/smb2`) **fail on Node 20+** — their NTLM dep computes the LM hash with DES, which OpenSSL 3 disabled (`ERR_OSSL_EVP_UNSUPPORTED`), and even with `--openssl-legacy-provider` the session hangs against FritzOS.
- **FTP works cleanly** with a pure-JS client. So this adds `basic-ftp` + `nasClient.ts` (`testConnection` / `nasUpload` / `nasDownload` / `nasList` / `nasRemove`, with parent-dir creation).

Credentials/host **reuse `config.gateway`** (the FritzBox USB NAS is the same device + same FritzBox user as the gateway), so there's one source of truth and **no `config.ts` change** and **no new image dependency** (pure JS).

## Why
Closes #1215. (Issue titled "SMB client"; transport changed to FTP per the FritzBox's actual config — SMB locked, FTP enabled.)

## Verification (live, against the real FritzBox NAS at the gateway)
- Confirmed FTP auth + a full **upload → list → download(compare) → delete → rmdir round-trip** against `FRITZ.NAS` (via `curl` *and* `basic-ftp` directly) before building. The wrapper itself is unit-tested with `basic-ftp` mocked.
- Credentials are never logged (no `client.ftp.verbose`), consistent with the #1211 fix.
- [x] npm run lint (0 errors, 403 warnings)
- [x] npm run check:arch
- [x] npm test (1365 pass; +12 nasClient tests)
- [x] tsc --noEmit (0 errors)
- [ ] /verify — n/a: no path-mandated files touched (reuses `config.gateway`; `lib/externalBackup/` is not in the list). FTP transport already live-verified above.

## Next
Unblocks #1216 (producer writes tarballs via this client) and #1224's auth-layer NAS-reachability check.