### PR TITLE
fix(agent): redact secrets from command result logs too

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -1919,8 +1919,11 @@ class Agent:
             if error:
                 log_error(f"Command {cmd} (ID: {req_id}) failed: {error}")
             else:
-                # Log success but truncate result if large (e.g. logs)
-                res_str = str(result)
+                # Redact secrets (e.g. read_file returns {'content': ...} which
+                # may hold a config file's tokens) before logging, then truncate
+                # — truncation alone would keep the first 100 chars verbatim and
+                # leak a secret near the top of the content (#1211 follow-up).
+                res_str = str(_redact_for_log(result))
                 if len(res_str) > 100: res_str = res_str[:100] + "..."
                 log_info(f"Command {cmd} (ID: {req_id}) completed. Result: {res_str}")
 


### PR DESCRIPTION
## What
Follow-up to #1211. The agent's success-**result** log was only length-truncated (first 100 chars kept verbatim), so a `read_file` result (`{'content': …}`) for a config/env file with a secret near the top still leaked it to journald. Now the result is run through the same `_redact_for_log` before truncation.

## Why
Closes the residual log-leak surface flagged during #1211 review. The data **response** to ServiceBay is unchanged — it must carry the real content.

## Risk
Low — log-output redaction only.

## Verification (live, real surface)
Drove `agent.py` with a `read_file` of `/tmp/sb-secret-file.txt` (`DB_PASSWORD=TOPSECRET_VALUE_xyz` in the first line):
- **stderr (journald):** `Command read_file … completed. Result: {'content': '<45 chars redacted>'}` — secret count **0**.
- **stdout (data response):** content present (1×) — correct; that's the channel returning the file to ServiceBay, not a log.
- py_compile OK; `python3 -m unittest` (agent v4) 12/12.

## Rollback
`git revert`.