### PR TITLE
feat(backup): produce per-service config tarballs and write them to the NAS

### DIFF
--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const { mockNas, mockGetConfig } = vi.hoisted(() => ({
+  mockNas: {
+    nasUpload: vi.fn(),
+    nasDownload: vi.fn(),
+    nasList: vi.fn(),
+  },
+  mockGetConfig: vi.fn(),
+}));
+
+vi.mock('./nasClient', () => mockNas);
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+
+import {
+  stageServiceBackup,
+  buildServiceBackupTar,
+  backupServiceToNas,
+  resolveServiceDataDir,
+  listServiceBackups,
+  fetchServiceBackup,
+  NAS_BACKUP_DIR,
+} from './producer';
+import { getServiceManifest, type ServiceBackupManifest } from './serviceManifest';
+
+let tmpDirs: string[] = [];
+
+async function mkTmp(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'producer-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function writeFile(base: string, rel: string, content: string): Promise<void> {
+  const full = path.join(base, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockResolvedValue({ templateSettings: {} });
+  mockNas.nasUpload.mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tmpDirs = [];
+});
+
+describe('stageServiceBackup', () => {
+  it('stages included files, skips excluded ones, and recurses into included dirs', async () => {
+    const src = await mkTmp();
+    const staging = await mkTmp();
+    await writeFile(src, 'config.yaml', 'model: x');
+    await writeFile(src, '.storage/lovelace', '{"ui":true}');
+    await writeFile(src, '.storage/lovelace_dashboards', '{}');
+    await writeFile(src, 'home-assistant_v2.db', 'BINARYDB');
+    await writeFile(src, 'logs/today.log', 'noise');
+
+    const manifest: ServiceBackupManifest = {
+      service: 'demo',
+      include: ['config.yaml', '.storage', 'missing.yaml'],
+      exclude: ['home-assistant_v2.db', 'logs'],
+    };
+    const staged = await stageServiceBackup(src, manifest, staging);
+
+    expect(staged).toEqual(['.storage/lovelace', '.storage/lovelace_dashboards', 'config.yaml']);
+    expect(await fs.readFile(path.join(staging, 'config.yaml'), 'utf8')).toBe('model: x');
+    // Excluded + missing files never reach the staging dir.
+    await expect(fs.access(path.join(staging, 'home-assistant_v2.db'))).rejects.toThrow();
+    await expect(fs.access(path.join(staging, 'logs'))).rejects.toThrow();
+  });
+
+  it('applies strip rules to the targeted file only', async () => {
+    const src = await mkTmp();
+    const staging = await mkTmp();
+    await writeFile(src, 'users_database.yml', 'users:\n  a:\n    password: $argon2$secret\n    email: a@x\n');
+    await writeFile(src, 'other.yml', 'password: keepme\n');
+
+    const manifest: ServiceBackupManifest = {
+      service: 'demo',
+      include: ['users_database.yml', 'other.yml'],
+      exclude: [],
+      strip: [{ file: 'users_database.yml', dropYamlKeys: ['password'] }],
+    };
+    await stageServiceBackup(src, manifest, staging);
+
+    const stripped = await fs.readFile(path.join(staging, 'users_database.yml'), 'utf8');
+    expect(stripped).not.toContain('secret');
+    expect(stripped).toContain('a@x');
+    // Non-targeted file is copied verbatim — the strip rule must not bleed.
+    expect(await fs.readFile(path.join(staging, 'other.yml'), 'utf8')).toBe('password: keepme\n');
+  });
+});
+
+describe('buildServiceBackupTar', () => {
+  it('produces a tar containing the staged + stripped files', async () => {
+    const src = await mkTmp();
+    await writeFile(src, 'config.yaml', 'a: 1');
+    await writeFile(src, 'users_database.yml', 'users:\n  a:\n    password: SEKRIT\n');
+    await writeFile(src, 'cache/big.bin', 'junk');
+
+    const manifest: ServiceBackupManifest = {
+      service: 'demo',
+      include: ['config.yaml', 'users_database.yml'],
+      exclude: ['cache'],
+      strip: [{ file: 'users_database.yml', dropYamlKeys: ['password'] }],
+    };
+    const tar = await buildServiceBackupTar(src, manifest);
+    expect(tar.length).toBeGreaterThan(0);
+
+    const out = await mkTmp();
+    const tarFile = path.join(out, 'b.tar');
+    await fs.writeFile(tarFile, tar);
+    await execFileAsync('tar', ['-xf', tarFile, '-C', out]);
+
+    expect(await fs.readFile(path.join(out, 'config.yaml'), 'utf8')).toBe('a: 1');
+    expect(await fs.readFile(path.join(out, 'users_database.yml'), 'utf8')).not.toContain('SEKRIT');
+    await expect(fs.access(path.join(out, 'cache'))).rejects.toThrow();
+  });
+
+  it('throws when no config files match', async () => {
+    const src = await mkTmp();
+    const manifest: ServiceBackupManifest = { service: 'empty', include: ['nope.yaml'], exclude: [] };
+    await expect(buildServiceBackupTar(src, manifest)).rejects.toThrow(/No config files/);
+  });
+});
+
+describe('resolveServiceDataDir', () => {
+  it('joins the configured DATA_DIR with the service name', async () => {
+    mockGetConfig.mockResolvedValue({ templateSettings: { DATA_DIR: '/srv/stacks' } });
+    expect(await resolveServiceDataDir('adguard')).toBe('/srv/stacks/adguard');
+  });
+
+  it('falls back to /mnt/data/stacks when DATA_DIR is unset', async () => {
+    mockGetConfig.mockResolvedValue({ templateSettings: {} });
+    expect(await resolveServiceDataDir('adguard')).toBe('/mnt/data/stacks/adguard');
+  });
+});
+
+describe('backupServiceToNas', () => {
+  it('uploads the tar and a meta sidecar under sb-backup/', async () => {
+    const src = await mkTmp();
+    await writeFile(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+
+    const result = await backupServiceToNas('adguard', { serviceDataDir: src });
+
+    expect(result.tarName).toBe('adguard.tar');
+    expect(result.metaName).toBe('adguard.tar.meta.json');
+    expect(result.size).toBeGreaterThan(0);
+    expect(result.meta.schemaVersion).toBe(1);
+    expect(result.meta.service).toBe('adguard');
+    expect(result.meta.nodeId).toBe(os.hostname());
+
+    const uploadPaths = mockNas.nasUpload.mock.calls.map(c => c[0]);
+    expect(uploadPaths).toContain(`${NAS_BACKUP_DIR}/adguard.tar`);
+    expect(uploadPaths).toContain(`${NAS_BACKUP_DIR}/adguard.tar.meta.json`);
+
+    const metaCall = mockNas.nasUpload.mock.calls.find(c => c[0].endsWith('.meta.json'))!;
+    const metaJson = JSON.parse((metaCall[1] as Buffer).toString('utf8'));
+    expect(metaJson.service).toBe('adguard');
+  });
+
+  it('rejects a service with no manifest without touching the NAS', async () => {
+    await expect(backupServiceToNas('vaultwarden')).rejects.toThrow(/No backup manifest/);
+    expect(mockNas.nasUpload).not.toHaveBeenCalled();
+  });
+
+  it('resolves the data dir from config when serviceDataDir is omitted', async () => {
+    const stacks = await mkTmp();
+    await writeFile(stacks, 'adguard/conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+    mockGetConfig.mockResolvedValue({ templateSettings: { DATA_DIR: stacks } });
+
+    const result = await backupServiceToNas('adguard');
+    expect(result.size).toBeGreaterThan(0);
+  });
+});
+
+describe('read-back', () => {
+  it('lists only .tar entries and derives the service name', async () => {
+    mockNas.nasList.mockResolvedValue([
+      { name: 'hermes.tar', size: 100 },
+      { name: 'hermes.tar.meta.json', size: 20 },
+      { name: 'adguard.tar', size: 50 },
+    ]);
+    const list = await listServiceBackups();
+    expect(list).toEqual([
+      { service: 'adguard', tarName: 'adguard.tar', size: 50 },
+      { service: 'hermes', tarName: 'hermes.tar', size: 100 },
+    ]);
+    expect(mockNas.nasList).toHaveBeenCalledWith(NAS_BACKUP_DIR);
+  });
+
+  it('fetches a tar plus its parsed meta sidecar', async () => {
+    mockNas.nasDownload.mockImplementation(async (p: string) =>
+      p.endsWith('.meta.json')
+        ? Buffer.from(JSON.stringify({ service: 'hermes', schemaVersion: 1, createdAt: 'now', nodeId: 'box' }))
+        : Buffer.from('TARBYTES'),
+    );
+    const { tar, meta } = await fetchServiceBackup('hermes.tar');
+    expect(tar.toString()).toBe('TARBYTES');
+    expect(meta?.service).toBe('hermes');
+    expect(mockNas.nasDownload).toHaveBeenCalledWith(`${NAS_BACKUP_DIR}/hermes.tar`);
+  });
+
+  it('returns meta=null when the sidecar is missing', async () => {
+    mockNas.nasDownload.mockImplementation(async (p: string) => {
+      if (p.endsWith('.meta.json')) throw new Error('550 not found');
+      return Buffer.from('TARBYTES');
+    });
+    const { tar, meta } = await fetchServiceBackup('hermes.tar');
+    expect(tar.toString()).toBe('TARBYTES');
+    expect(meta).toBeNull();
+  });
+
+  it('strips any directory component from the requested name and rejects non-tar', async () => {
+    mockNas.nasDownload.mockResolvedValue(Buffer.from('x'));
+    await fetchServiceBackup('../../etc/passwd.tar');
+    expect(mockNas.nasDownload).toHaveBeenCalledWith(`${NAS_BACKUP_DIR}/passwd.tar`);
+    await expect(fetchServiceBackup('hermes.json')).rejects.toThrow(/Not a service backup tar/);
+  });
+});
+
+describe('manifest integration', () => {
+  it('the real adguard manifest excludes querylog while keeping the config', async () => {
+    const src = await mkTmp();
+    const staging = await mkTmp();
+    await writeFile(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+    await writeFile(src, 'data/querylog.json', '[]');
+    const staged = await stageServiceBackup(src, getServiceManifest('adguard')!, staging);
+    expect(staged).toEqual(['conf/AdGuardHome.yaml']);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -1,0 +1,234 @@
+/**
+ * Per-service config-backup producer for the FritzBox-NAS config-survival
+ * feature (#1190 / #1216).
+ *
+ * Given a service, it reads the config files the manifest marks as worth
+ * preserving (include − exclude), applies the strip rules (e.g. drop password
+ * hashes), packs them into `<service>.tar`, and writes the tar plus a
+ * `<service>.tar.meta.json` sidecar to `sb-backup/` on the NAS. The read-back
+ * helpers (list + fetch) are what the restore flow (#1218) builds on.
+ *
+ * The tarball is built from a staging directory we fully control, so the
+ * archive is safe by construction — the hardening that `systemBackup` applies
+ * on *extraction* belongs to the restore path, not here.
+ */
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+// `node:` prefix so a stray browser-polyfill in the SSR module graph can't
+// shadow child_process with a no-op stub (see systemBackup.ts for the full
+// story) — that would make every tar come back empty without tests noticing.
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { getConfig } from '../config';
+import { logger } from '../logger';
+import { nasUpload, nasDownload, nasList } from './nasClient';
+import {
+  getServiceManifest,
+  applyStripRules,
+  type ServiceBackupManifest,
+} from './serviceManifest';
+
+const execFileAsync = promisify(execFile);
+
+/** Directory on the NAS (relative to its root) holding all service backups. */
+export const NAS_BACKUP_DIR = 'sb-backup';
+
+/** Default on-disk location of the per-service stack dirs. */
+const DEFAULT_STACKS_DIR = '/mnt/data/stacks';
+
+/** Sidecar schema version — bump when the meta shape changes. */
+const META_SCHEMA_VERSION = 1;
+
+export interface ServiceBackupMeta {
+  service: string;
+  schemaVersion: number;
+  /** ISO timestamp the tar was produced. */
+  createdAt: string;
+  /** Hostname of the node that produced the backup — survives a reinstall to
+   *  tell the operator which box the config came from. */
+  nodeId: string;
+}
+
+export interface ServiceBackupResult {
+  service: string;
+  tarName: string;
+  metaName: string;
+  /** Tar size in bytes. */
+  size: number;
+  meta: ServiceBackupMeta;
+}
+
+export interface ServiceBackupListEntry {
+  service: string;
+  tarName: string;
+  size: number;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** A relative path is excluded when it equals an exclude entry or lives under
+ *  one (an exclude dir). Excludes always win over includes. */
+function isExcluded(relPath: string, excludes: string[]): boolean {
+  return excludes.some(ex => relPath === ex || relPath.startsWith(ex + '/'));
+}
+
+/** Walk an included directory, returning the relative (posix) paths of every
+ *  file inside it that isn't excluded. */
+async function collectDirFiles(
+  serviceDataDir: string,
+  relDir: string,
+  excludes: string[],
+): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await fs.readdir(path.join(serviceDataDir, relDir), { withFileTypes: true });
+  for (const entry of entries) {
+    const rel = path.posix.join(relDir, entry.name);
+    if (isExcluded(rel, excludes)) continue;
+    if (entry.isDirectory()) {
+      out.push(...(await collectDirFiles(serviceDataDir, rel, excludes)));
+    } else if (entry.isFile()) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+/**
+ * Copy the manifest-selected config files from `serviceDataDir` into
+ * `stagingDir`, applying excludes and strip rules. Returns the sorted list of
+ * relative paths actually staged. Pure filesystem work — no NAS, no tar — so
+ * the selection logic is unit-testable on its own.
+ */
+export async function stageServiceBackup(
+  serviceDataDir: string,
+  manifest: ServiceBackupManifest,
+  stagingDir: string,
+): Promise<string[]> {
+  const staged: string[] = [];
+  for (const include of manifest.include) {
+    if (isExcluded(include, manifest.exclude)) continue;
+    const absInclude = path.join(serviceDataDir, include);
+    if (!(await pathExists(absInclude))) continue;
+    const stat = await fs.stat(absInclude);
+    const relFiles = stat.isDirectory()
+      ? await collectDirFiles(serviceDataDir, include, manifest.exclude)
+      : [include];
+    for (const rel of relFiles) {
+      const dest = path.join(stagingDir, rel);
+      await fs.mkdir(path.dirname(dest), { recursive: true });
+      const hasStrip = manifest.strip?.some(r => r.file === rel);
+      if (hasStrip) {
+        // Only read-as-text the files a strip rule targets; everything else is
+        // copied byte-for-byte so binary config (e.g. SQLite-ish blobs) stays intact.
+        const content = await fs.readFile(path.join(serviceDataDir, rel), 'utf8');
+        await fs.writeFile(dest, applyStripRules(manifest, rel, content));
+      } else {
+        await fs.copyFile(path.join(serviceDataDir, rel), dest);
+      }
+      staged.push(rel);
+    }
+  }
+  return staged.sort();
+}
+
+/** Build a `<service>.tar` buffer from a service's on-disk config dir. */
+export async function buildServiceBackupTar(
+  serviceDataDir: string,
+  manifest: ServiceBackupManifest,
+): Promise<Buffer> {
+  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-svcbackup-'));
+  const tarPath = path.join(os.tmpdir(), `sb-svcbackup-${process.pid}-${Date.now()}.tar`);
+  try {
+    const staged = await stageServiceBackup(serviceDataDir, manifest, stagingDir);
+    if (staged.length === 0) {
+      throw new Error(`No config files to back up for "${manifest.service}" under ${serviceDataDir}`);
+    }
+    await execFileAsync('tar', ['-cf', tarPath, '-C', stagingDir, '.']);
+    return await fs.readFile(tarPath);
+  } finally {
+    await fs.rm(stagingDir, { recursive: true, force: true });
+    await fs.rm(tarPath, { force: true });
+  }
+}
+
+/** Resolve a service's on-disk config dir from the configured DATA_DIR. */
+export async function resolveServiceDataDir(service: string): Promise<string> {
+  const dataDir = (await getConfig()).templateSettings?.DATA_DIR || DEFAULT_STACKS_DIR;
+  return path.join(dataDir, service);
+}
+
+/**
+ * Produce a service's config tarball and write it (plus its meta sidecar) to
+ * the NAS. Pass `serviceDataDir` to back up from an arbitrary location (the
+ * `sb-config-upload` CLI in #1219 seeds from a non-SB source this way);
+ * otherwise the dir is resolved from the configured DATA_DIR.
+ */
+export async function backupServiceToNas(
+  service: string,
+  opts: { serviceDataDir?: string } = {},
+): Promise<ServiceBackupResult> {
+  const manifest = getServiceManifest(service);
+  if (!manifest) {
+    throw new Error(`No backup manifest for service "${service}"`);
+  }
+  const serviceDataDir = opts.serviceDataDir ?? (await resolveServiceDataDir(service));
+  const tar = await buildServiceBackupTar(serviceDataDir, manifest);
+
+  const meta: ServiceBackupMeta = {
+    service,
+    schemaVersion: META_SCHEMA_VERSION,
+    createdAt: new Date().toISOString(),
+    nodeId: os.hostname(),
+  };
+  const tarName = `${service}.tar`;
+  const metaName = `${tarName}.meta.json`;
+
+  await nasUpload(path.posix.join(NAS_BACKUP_DIR, tarName), tar);
+  await nasUpload(
+    path.posix.join(NAS_BACKUP_DIR, metaName),
+    Buffer.from(JSON.stringify(meta, null, 2)),
+  );
+
+  logger.info('ExternalBackup', `Wrote ${tarName} to NAS (${tar.length} bytes)`);
+  return { service, tarName, metaName, size: tar.length, meta };
+}
+
+/** List the service backups currently on the NAS. */
+export async function listServiceBackups(): Promise<ServiceBackupListEntry[]> {
+  const files = await nasList(NAS_BACKUP_DIR);
+  return files
+    .filter(f => f.name.endsWith('.tar'))
+    .map(f => ({ service: f.name.replace(/\.tar$/, ''), tarName: f.name, size: f.size }))
+    .sort((a, b) => a.service.localeCompare(b.service));
+}
+
+/**
+ * Fetch one backup tar (and its meta sidecar, if present) from the NAS for the
+ * restore flow. A missing/corrupt sidecar resolves with `meta: null` rather
+ * than failing — the tar is still restorable.
+ */
+export async function fetchServiceBackup(
+  tarName: string,
+): Promise<{ tar: Buffer; meta: ServiceBackupMeta | null }> {
+  const safeName = path.posix.basename(tarName);
+  if (!safeName.endsWith('.tar')) {
+    throw new Error(`Not a service backup tar: "${tarName}"`);
+  }
+  const tar = await nasDownload(path.posix.join(NAS_BACKUP_DIR, safeName));
+  let meta: ServiceBackupMeta | null = null;
+  try {
+    const metaBuf = await nasDownload(path.posix.join(NAS_BACKUP_DIR, `${safeName}.meta.json`));
+    meta = JSON.parse(metaBuf.toString('utf8')) as ServiceBackupMeta;
+  } catch {
+    meta = null;
+  }
+  return { tar, meta };
+}


### PR DESCRIPTION
## What
Adds the externalBackup **producer**: given a service, it stages the manifest-selected config (include − exclude, with strip rules applied), packs it into `<service>.tar`, and writes the tar plus a `<service>.tar.meta.json` sidecar (timestamp, schema version, originating node id) to `sb-backup/` on the FritzBox NAS. Also adds the read-back path (`listServiceBackups` + `fetchServiceBackup`) the restore flow consumes.

Builds on the already-merged manifest (#1214) and NAS client (#1215). The tar is built from a staging dir we fully control, so the archive is safe by construction — extraction-time hardening belongs to the restore path (#1218).

## Why
Closes #1216. Foundational producer/write unit of epic #1190; unblocks #1217 (triggers), #1218 (restore), #1219 (CLI seed).

## Risk
Low — new module, no existing call sites. Strip rules read targeted files as text; everything else is copied byte-for-byte so binary config stays intact.

## Rollback
`git revert` is enough — nothing else imports it yet.

## Verification
- [x] npm run lint (0 errors; 403 warnings, unchanged baseline)
- [x] npm run check:arch
- [x] npm test (1392 passed)
- [ ] /verify on FCoS box — not path-mandated (`lib/externalBackup/` is outside the mandated list); real-NAS round-trip is exercised by the #1217/#1218 consumers against the live FritzBox.