### PR TITLE
feat(backup): add sb-config-upload CLI to seed the NAS from a non-SB source

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "knip": "knip",
     "test": "vitest run",
     "gen-template-docs": "tsx scripts/gen-template-docs.ts",
+    "sb-config-upload": "tsx scripts/sb-config-upload.ts",
     "check:invariants": "tsx scripts/check-invariants.ts",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages/frontend/src packages/backend/src",
     "check:arch": "npm run check:invariants && npm run check:deps",

--- a/packages/backend/src/lib/externalBackup/configUpload.test.ts
+++ b/packages/backend/src/lib/externalBackup/configUpload.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const { mockBackup } = vi.hoisted(() => ({ mockBackup: vi.fn() }));
+vi.mock('./producer', () => ({ backupServiceToNas: mockBackup }));
+
+import {
+  parseUploadArgs,
+  looksLikeServiceLayout,
+  runConfigUpload,
+  ConfigUploadError,
+  type UploadIO,
+} from './configUpload';
+import { getServiceManifest } from './serviceManifest';
+
+let tmpDirs: string[] = [];
+async function mkTmp(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'configupload-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+async function writeFile(base: string, rel: string, content: string): Promise<void> {
+  const full = path.join(base, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+
+function fakeIO(answers: boolean[] = []): UploadIO & { logs: string[]; questions: string[] } {
+  const logs: string[] = [];
+  const questions: string[] = [];
+  return {
+    logs,
+    questions,
+    log: m => logs.push(m),
+    confirm: async q => {
+      questions.push(q);
+      return answers.shift() ?? false;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBackup.mockResolvedValue({
+    service: 'adguard',
+    tarName: 'adguard.tar',
+    metaName: 'adguard.tar.meta.json',
+    size: 1234,
+    meta: { service: 'adguard', schemaVersion: 1, createdAt: 'now', nodeId: 'box' },
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tmpDirs = [];
+});
+
+describe('parseUploadArgs', () => {
+  it('parses required + optional flags with a default target', () => {
+    expect(parseUploadArgs(['--service', 'adguard', '--from', '/x'])).toEqual({
+      service: 'adguard',
+      from: '/x',
+      target: 'fritzbox',
+      assumeYes: false,
+    });
+  });
+
+  it('honors --target, --yes and the -y/-h short forms', () => {
+    expect(parseUploadArgs(['--service', 's', '--from', '/x', '--target', 't', '-y'])).toEqual({
+      service: 's',
+      from: '/x',
+      target: 't',
+      assumeYes: true,
+    });
+    expect(parseUploadArgs(['-h'])).toEqual({ help: true });
+  });
+
+  it('rejects missing required flags, missing values, and unknown args', () => {
+    expect(() => parseUploadArgs(['--from', '/x'])).toThrow(/--service is required/);
+    expect(() => parseUploadArgs(['--service', 's'])).toThrow(/--from is required/);
+    expect(() => parseUploadArgs(['--service'])).toThrow(/Missing value for --service/);
+    expect(() => parseUploadArgs(['--bogus'])).toThrow(/Unknown argument/);
+  });
+});
+
+describe('looksLikeServiceLayout', () => {
+  it('is true when at least one include path is present', async () => {
+    const dir = await mkTmp();
+    await writeFile(dir, 'conf/AdGuardHome.yaml', 'x');
+    expect(await looksLikeServiceLayout(dir, getServiceManifest('adguard')!)).toBe(true);
+  });
+
+  it('is false for an empty/unrelated directory', async () => {
+    const dir = await mkTmp();
+    await writeFile(dir, 'random.txt', 'x');
+    expect(await looksLikeServiceLayout(dir, getServiceManifest('adguard')!)).toBe(false);
+  });
+});
+
+describe('runConfigUpload', () => {
+  it('uploads a recognized layout without prompting', async () => {
+    const dir = await mkTmp();
+    await writeFile(dir, 'conf/AdGuardHome.yaml', 'x');
+    const io = fakeIO();
+    const result = await runConfigUpload({ service: 'adguard', from: dir, target: 'fritzbox', assumeYes: false }, io);
+    expect(result.tarName).toBe('adguard.tar');
+    expect(io.questions).toEqual([]);
+    expect(mockBackup).toHaveBeenCalledWith('adguard', { serviceDataDir: dir });
+  });
+
+  it('prompts and aborts on an unrecognized layout when the operator declines', async () => {
+    const dir = await mkTmp();
+    await writeFile(dir, 'random.txt', 'x');
+    const io = fakeIO([false]);
+    await expect(
+      runConfigUpload({ service: 'adguard', from: dir, target: 'fritzbox', assumeYes: false }, io),
+    ).rejects.toThrow(/Aborted/);
+    expect(io.questions).toHaveLength(1);
+    expect(mockBackup).not.toHaveBeenCalled();
+  });
+
+  it('uploads an unrecognized layout when the operator confirms', async () => {
+    const dir = await mkTmp();
+    await writeFile(dir, 'random.txt', 'x');
+    const io = fakeIO([true]);
+    await runConfigUpload({ service: 'adguard', from: dir, target: 'fritzbox', assumeYes: false }, io);
+    expect(mockBackup).toHaveBeenCalledWith('adguard', { serviceDataDir: dir });
+  });
+
+  it('skips the prompt entirely with --yes even on an unrecognized layout', async () => {
+    const dir = await mkTmp();
+    const io = fakeIO();
+    await runConfigUpload({ service: 'adguard', from: dir, target: 'fritzbox', assumeYes: true }, io);
+    expect(io.questions).toEqual([]);
+    expect(mockBackup).toHaveBeenCalled();
+  });
+
+  it('rejects an unknown service before touching the filesystem', async () => {
+    const io = fakeIO();
+    await expect(
+      runConfigUpload({ service: 'vaultwarden', from: '/x', target: 'fritzbox', assumeYes: true }, io),
+    ).rejects.toThrow(ConfigUploadError);
+    expect(mockBackup).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported target', async () => {
+    const dir = await mkTmp();
+    await expect(
+      runConfigUpload({ service: 'adguard', from: dir, target: 's3', assumeYes: true }, fakeIO()),
+    ).rejects.toThrow(/Unsupported --target/);
+  });
+
+  it('rejects a --from that is not a directory', async () => {
+    await expect(
+      runConfigUpload({ service: 'adguard', from: '/no/such/dir', target: 'fritzbox', assumeYes: true }, fakeIO()),
+    ).rejects.toThrow(/not a directory/);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/configUpload.ts
+++ b/packages/backend/src/lib/externalBackup/configUpload.ts
@@ -1,0 +1,124 @@
+/**
+ * Core logic for the `sb-config-upload` CLI (#1219): seed the FritzBox NAS with
+ * a service's config from a non-ServiceBay source (a retired HA Yellow, a
+ * community automation pack, a test snapshot).
+ *
+ * It reuses the backup producer (#1216) so the whitelist, stripping rules, and
+ * tar + meta format are identical to what the nightly backup writes and the
+ * restore flow expects — one source of truth, no drift. This module is the
+ * testable core; `scripts/sb-config-upload.ts` is the thin argv + readline shell.
+ */
+import fs from 'fs/promises';
+import path from 'path';
+import { backupServiceToNas, type ServiceBackupResult } from './producer';
+import { getServiceManifest, SERVICE_BACKUP_MANIFESTS, type ServiceBackupManifest } from './serviceManifest';
+
+/** Thrown for user-facing failures (bad args, abort) so the CLI can print a
+ *  clean `error: <message>` instead of a stack trace. */
+export class ConfigUploadError extends Error {}
+
+export interface UploadOptions {
+  service: string;
+  from: string;
+  target: string;
+  /** Skip the unrecognized-layout confirmation prompt. */
+  assumeYes: boolean;
+}
+
+export const USAGE = `Usage: sb-config-upload --service <svc> --from <path> [--target fritzbox] [--yes]
+
+Seed the config-backup NAS with a service's config from an arbitrary directory,
+using the same whitelist, stripping rules, and tar format as the built-in backup.
+
+Options:
+  --service <svc>   Service to upload (${SERVICE_BACKUP_MANIFESTS.map(m => m.service).join(', ')})
+  --from <path>     Directory holding the service's config files
+  --target <name>   Backup target (default: fritzbox)
+  --yes, -y         Don't prompt to confirm an unrecognized source layout
+  --help, -h        Show this help`;
+
+/**
+ * Parse `process.argv.slice(2)`. Returns `{ help: true }` for --help, or a
+ * validated `UploadOptions`. Throws `ConfigUploadError` on malformed input.
+ */
+export function parseUploadArgs(argv: string[]): UploadOptions | { help: true } {
+  const opts: Partial<UploadOptions> & { assumeYes: boolean } = { target: 'fritzbox', assumeYes: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        return { help: true };
+      case '--yes':
+      case '-y':
+        opts.assumeYes = true;
+        break;
+      case '--service':
+      case '--from':
+      case '--target': {
+        const value = argv[++i];
+        if (value === undefined) throw new ConfigUploadError(`Missing value for ${arg}`);
+        if (arg === '--service') opts.service = value;
+        else if (arg === '--from') opts.from = value;
+        else opts.target = value;
+        break;
+      }
+      default:
+        throw new ConfigUploadError(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!opts.service) throw new ConfigUploadError('--service is required');
+  if (!opts.from) throw new ConfigUploadError('--from is required');
+  return { service: opts.service, from: opts.from, target: opts.target!, assumeYes: opts.assumeYes };
+}
+
+/** True when `dir` contains at least one of the service's expected config paths
+ *  — i.e. it plausibly is that service's data dir rather than a wrong folder. */
+export async function looksLikeServiceLayout(dir: string, manifest: ServiceBackupManifest): Promise<boolean> {
+  for (const include of manifest.include) {
+    try {
+      await fs.access(path.join(dir, include));
+      return true;
+    } catch {
+      // keep checking the remaining include paths
+    }
+  }
+  return false;
+}
+
+export interface UploadIO {
+  log: (message: string) => void;
+  /** Ask the operator a yes/no question; resolve true to proceed. */
+  confirm: (question: string) => Promise<boolean>;
+}
+
+/** Validate options, confirm an unrecognized layout, then build + upload the
+ *  service tar via the shared producer. */
+export async function runConfigUpload(opts: UploadOptions, io: UploadIO): Promise<ServiceBackupResult> {
+  const manifest = getServiceManifest(opts.service);
+  if (!manifest) {
+    throw new ConfigUploadError(
+      `Unknown service "${opts.service}". Known services: ${SERVICE_BACKUP_MANIFESTS.map(m => m.service).join(', ')}`,
+    );
+  }
+  if (opts.target !== 'fritzbox') {
+    throw new ConfigUploadError(`Unsupported --target "${opts.target}" (only "fritzbox" is supported)`);
+  }
+  const stat = await fs.stat(opts.from).catch(() => null);
+  if (!stat?.isDirectory()) {
+    throw new ConfigUploadError(`--from is not a directory: ${opts.from}`);
+  }
+
+  if (!opts.assumeYes && !(await looksLikeServiceLayout(opts.from, manifest))) {
+    const proceed = await io.confirm(
+      `"${opts.from}" contains none of ${opts.service}'s expected config files ` +
+        `(${manifest.include.join(', ')}). Upload anyway?`,
+    );
+    if (!proceed) throw new ConfigUploadError('Aborted.');
+  }
+
+  io.log(`Uploading ${opts.service} config from ${opts.from} to the FritzBox NAS…`);
+  const result = await backupServiceToNas(opts.service, { serviceDataDir: opts.from });
+  io.log(`Wrote ${result.tarName} (${result.size} bytes) and ${result.metaName} to NAS sb-backup/.`);
+  return result;
+}

--- a/scripts/sb-config-upload.ts
+++ b/scripts/sb-config-upload.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * `sb-config-upload` CLI (#1219): seed the FritzBox NAS with a service's config
+ * from a non-ServiceBay source. Thin argv + readline shell around the testable
+ * core in packages/backend/src/lib/externalBackup/configUpload.ts.
+ *
+ * Run: `npm run sb-config-upload -- --service adguard --from /path/to/config`
+ */
+import readline from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+import {
+  parseUploadArgs,
+  runConfigUpload,
+  ConfigUploadError,
+  USAGE,
+} from '../packages/backend/src/lib/externalBackup/configUpload.js';
+
+async function main(): Promise<void> {
+  const parsed = parseUploadArgs(process.argv.slice(2));
+  if ('help' in parsed) {
+    console.log(USAGE);
+    return;
+  }
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  try {
+    await runConfigUpload(parsed, {
+      log: message => console.log(message),
+      confirm: async question => {
+        const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+        return answer === 'y' || answer === 'yes';
+      },
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof ConfigUploadError) {
+    console.error(`error: ${error.message}`);
+  } else {
+    console.error(error);
+  }
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What
Standalone CLI `npm run sb-config-upload -- --service <svc> --from <path> [--target fritzbox] [--yes]` that seeds the FritzBox NAS with a service's config from a non-ServiceBay source (a retired HA Yellow, a community automation pack, a test snapshot). It reuses the backup producer (#1216), so the whitelist, stripping rules, and tar + meta format are identical to what the nightly backup writes and the restore flow expects — one source of truth, no drift. Prompts to confirm when `--from` doesn't look like the service's expected layout.

Testable core in `packages/backend/src/lib/externalBackup/configUpload.ts`; `scripts/sb-config-upload.ts` is the thin argv + readline shell.

## Why
Closes #1219. Consumes the merged producer (#1216); part of epic #1190.

Note: the issue suggested `bin/sb-config-upload`, but this repo has no `bin/` dir — every CLI lives in `scripts/*.ts` run via `tsx` + an npm script (see `gen-template-docs`, `check-invariants`). I followed that convention.

## Risk
Low — new module + script, no existing call sites. Writes to the NAS only after validation/confirmation, via the already-tested producer path.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors; 403 warnings, unchanged baseline)
- [x] npm run check:arch
- [x] npm test (1404 passed)
- [x] CLI smoke: `--help` prints usage; missing `--from` prints a clean `error:` and exits non-zero
- [ ] /verify on FCoS box — not path-mandated; live NAS round-trip is the producer's already-verified path (#1215 FTP round-trip live-verified)