### PR TITLE
feat(backup): diagnose probe for FritzBox NAS backup reachability

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/nasBackupReachable.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/nasBackupReachable.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock hoists above top-level const, so expose mutable state via a closure.
+const state = {
+  target: null as { host: string; user: string; password: string; secure: boolean } | null,
+  conn: { ok: true } as { ok: true } | { ok: false; error: string },
+  uploadThrows: null as Error | null,
+};
+
+vi.mock('@/lib/externalBackup/nasClient', () => ({
+  getNasTarget: vi.fn(() => Promise.resolve(state.target)),
+  testNasConnection: vi.fn(() => Promise.resolve(state.conn)),
+  nasUpload: vi.fn(() => (state.uploadThrows ? Promise.reject(state.uploadThrows) : Promise.resolve())),
+  nasRemove: vi.fn(() => Promise.resolve()),
+  nasDownload: vi.fn(() => Promise.resolve(Buffer.from(''))),
+  nasList: vi.fn(() => Promise.resolve([])),
+}));
+
+import { checkNasBackupReachable } from './nasBackupReachable';
+
+beforeEach(() => {
+  state.target = { host: '192.168.178.1', user: 'fritz', password: 'pw', secure: false };
+  state.conn = { ok: true };
+  state.uploadThrows = null;
+});
+
+describe('checkNasBackupReachable', () => {
+  it('returns info when no NAS is configured', async () => {
+    state.target = null;
+    const r = await checkNasBackupReachable();
+    expect(r.status).toBe('info');
+    expect(r.detail).toMatch(/not configured/);
+  });
+
+  it('warns with a sharing hint when the NAS is unreachable', async () => {
+    state.conn = { ok: false, error: 'connect ECONNREFUSED 192.168.178.1:21' };
+    const r = await checkNasBackupReachable();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/Could not reach/);
+    expect(r.hint).toMatch(/attach a USB drive/i);
+  });
+
+  it('warns with a credentials hint when authentication fails', async () => {
+    state.conn = { ok: false, error: '530 Login incorrect' };
+    const r = await checkNasBackupReachable();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/authentication failed/);
+    expect(r.hint).toMatch(/username\/password/);
+  });
+
+  it('warns when connected but the write test fails (read-only / no drive)', async () => {
+    state.uploadThrows = new Error('550 Permission denied');
+    const r = await checkNasBackupReachable();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/writing to sb-backup\/ failed/);
+    expect(r.detail).toMatch(/Permission denied/);
+    expect(r.hint).toMatch(/attach a USB drive/i);
+  });
+
+  it('returns ok when reachable, authed, and writable', async () => {
+    const r = await checkNasBackupReachable();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/reachable and writable/);
+    expect(r.hint).toBeUndefined();
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/nasBackupReachable.ts
+++ b/packages/backend/src/lib/diagnose/probes/nasBackupReachable.ts
@@ -1,0 +1,79 @@
+/**
+ * `nas_backup_reachable` probe — guards the FritzBox-NAS config-survival
+ * feature (#1224 / #1190). During #1190 verification the FritzBox had file
+ * sharing turned off, so config backups silently never landed and nobody
+ * noticed until a reinstall needed them. This probe surfaces that proactively:
+ * is the backup target configured, reachable + authenticated, and writable?
+ *
+ * Transport is FTP (the feature pivoted away from SMB — see nasClient.ts), so
+ * "reachable + authed" is one FTP access+pwd, and "writable" is a probe-file
+ * round-trip into sb-backup/. Auth failures, plain unreachability, and a
+ * read-only / no-drive target are surfaced distinctly.
+ */
+import { getNasTarget, testNasConnection, nasUpload, nasRemove } from '@/lib/externalBackup/nasClient';
+import { NAS_BACKUP_DIR } from '@/lib/externalBackup/producer';
+import { logger } from '@/lib/logger';
+
+export interface NasBackupProbeResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+}
+
+const ENABLE_SHARING_HINT =
+  'On the FritzBox: attach a USB drive, then enable file sharing under ' +
+  'Heimnetz → Speicher (NAS) → Heimnetzfreigabe (turn on access over FTP). ' +
+  'Confirm the gateway user (Settings → Integrations) is allowed to write to it.';
+
+/** Distinguish a login rejection from a plain connectivity failure so the
+ *  remediation hint points at the right thing. */
+function looksLikeAuthFailure(error: string): boolean {
+  return /530|login|incorrect|denied|credential|password|auth/i.test(error);
+}
+
+export async function checkNasBackupReachable(): Promise<NasBackupProbeResult> {
+  const target = await getNasTarget();
+  if (!target) {
+    return {
+      status: 'info',
+      detail: 'Config-backup NAS not configured — no FritzBox gateway with credentials in Settings → Integrations.',
+      hint: 'Add the FritzBox gateway (host + login) to enable config backups to the NAS.',
+    };
+  }
+
+  const conn = await testNasConnection();
+  if (!conn.ok) {
+    const auth = looksLikeAuthFailure(conn.error);
+    return {
+      status: 'warn',
+      detail: auth
+        ? `Reached ${target.host} but authentication failed: ${conn.error}`
+        : `Could not reach the FritzBox NAS at ${target.host}: ${conn.error}`,
+      hint: auth
+        ? 'Check the gateway username/password in Settings → Integrations match a FritzBox user allowed to access the NAS.'
+        : ENABLE_SHARING_HINT,
+    };
+  }
+
+  // Connected + authed — confirm we can actually write where backups go.
+  // ensureDir + upload + remove exercises the full write path without leaving
+  // anything behind on the share.
+  const probePath = `${NAS_BACKUP_DIR}/.sb-write-test-${process.pid}-${Date.now()}`;
+  try {
+    await nasUpload(probePath, Buffer.from('servicebay-write-test'));
+    await nasRemove(probePath);
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    logger.warn('diagnose:nas_backup_reachable', `write test failed: ${error}`);
+    return {
+      status: 'warn',
+      detail: `Connected to ${target.host}, but writing to ${NAS_BACKUP_DIR}/ failed: ${error}`,
+      hint: ENABLE_SHARING_HINT,
+    };
+  }
+
+  return {
+    status: 'ok',
+    detail: `FritzBox NAS at ${target.host} is reachable and writable — config backups will land in ${NAS_BACKUP_DIR}/.`,
+  };
+}

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -26,6 +26,7 @@ import { checkAdguardRewritesMissing } from '@/lib/diagnose/probes/adguardRewrit
 import { checkDomainExternalReachability } from '@/lib/diagnose/probes/domainExternalReachability';
 import { checkDomainUnreachable } from '@/lib/diagnose/probes/domainUnreachable';
 import { checkOidcProviderReachable } from '@/lib/diagnose/probes/oidcProviderReachable';
+import { checkNasBackupReachable } from '@/lib/diagnose/probes/nasBackupReachable';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
 import '@/lib/diagnose/probes/register';
 
@@ -805,6 +806,28 @@ export async function runDiagnose(nodeName: string = 'Local'): Promise<DiagnoseR
     probes.push({
       id: 'adguard_rewrites_missing',
       label: 'AdGuard DNS rewrites',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 18) Config-backup NAS reachability (#1224). Surfaces a silently-broken
+  //     backup target — the FritzBox had file sharing off during #1190
+  //     verification, so backups never landed and nobody knew until a
+  //     reinstall needed them. info when no NAS is configured.
+  try {
+    const nas = await checkNasBackupReachable();
+    probes.push({
+      id: 'nas_backup_reachable',
+      label: 'Config backup (FritzBox NAS)',
+      status: nas.status,
+      detail: nas.detail,
+      hint: nas.hint,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'nas_backup_reachable',
+      label: 'Config backup (FritzBox NAS)',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });


### PR DESCRIPTION
## What
Adds a `nas_backup_reachable` diagnose probe that proactively surfaces a silently-broken config-backup target. It checks, in layers:
1. **Configured?** — `info` when no FritzBox gateway with credentials is set.
2. **Reachable + authenticated** — one FTP `access`+`pwd` via the NAS client; auth failures vs plain unreachability are reported distinctly with matching hints.
3. **Writable** — a probe-file round-trip into `sb-backup/` that cleans up after itself, catching a read-only or no-USB-drive target.

Wired into `runDiagnose.ts` alongside the other probes.

## Why
Closes #1224. During #1190 verification the FritzBox had file sharing off, so backups silently never landed and nobody knew until a reinstall needed them — this is the guard against that. Part of epic #1190.

Transport note: the issue described a raw `:445` SMB check, but the feature pivoted to FTP (#1215 `nasClient.ts`), so the probe checks the FTP path operators actually use.

## Risk
Low — new probe, wrapped in the same try/catch the other probes use, so a probe error degrades to an `info` row rather than breaking diagnose. The write test removes its probe file.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors; 403 warnings, unchanged baseline)
- [x] npm run check:arch
- [x] npm test (1409 passed)
- [ ] /verify on FCoS box — not path-mandated (`lib/diagnose/`); real-box diagnose can confirm the row once NAS credentials are configured (currently the FritzBox FTP password is operator-held, not stored, so the probe reports `info`/not-configured there).