### PR TITLE
feat(tui): lifecycle launcher shell with phase detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2889,6 +2889,10 @@
       "resolved": "packages/frontend",
       "link": true
     },
+    "node_modules/@servicebay/tui": {
+      "resolved": "packages/tui",
+      "link": true
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -4738,6 +4742,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5214,7 +5230,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
       "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "slice-ansi": "^7.1.0",
@@ -5321,6 +5336,18 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5403,6 +5430,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -6055,7 +6091,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6244,6 +6279,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -7337,10 +7382,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "dev": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7887,6 +7931,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -8166,7 +8222,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
@@ -8219,6 +8274,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally": {
@@ -10166,6 +10236,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -10819,6 +10898,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11249,6 +11337,21 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-refresh": {
@@ -12086,7 +12189,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -12103,7 +12205,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12230,6 +12331,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -12294,14 +12416,13 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
-      "dev": true,
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -12441,7 +12562,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -12457,7 +12577,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12576,7 +12695,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -12631,6 +12749,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -12927,7 +13057,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
       "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -13754,6 +13883,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -13768,7 +13912,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -13786,7 +13929,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13799,14 +13941,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -13992,6 +14132,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -14104,6 +14250,194 @@
         "react-markdown": "^10.1.0",
         "react-simple-code-editor": "^0.14.1",
         "socket.io-client": "^4.8.3"
+      }
+    },
+    "packages/tui": {
+      "name": "@servicebay/tui",
+      "version": "0.0.0",
+      "dependencies": {
+        "ink": "^6.8.0"
+      }
+    },
+    "packages/tui/node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/tui/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/tui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/tui/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/tui/node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/tui/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/tui/node_modules/ink": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^8.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "packages/tui/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/tui/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/tui/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "packages/tui/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "gen-template-docs": "tsx scripts/gen-template-docs.ts",
     "sb-config-upload": "tsx scripts/sb-config-upload.ts",
+    "tui": "tsx packages/tui/src/index.tsx",
     "check:invariants": "tsx scripts/check-invariants.ts",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages/frontend/src packages/backend/src",
     "check:arch": "npm run check:invariants && npm run check:deps",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@servicebay/tui",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Unified lifecycle launcher TUI (#1231): one front door for ISO build → boot → restore → install.",
+  "type": "module",
+  "main": "src/index.tsx",
+  "dependencies": {
+    "ink": "^6.8.0"
+  }
+}

--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -1,0 +1,104 @@
+/**
+ * Ink menu for the lifecycle launcher (#1231). Thin presentation layer over
+ * phase.ts: detects the phase, renders the relevant actions, and reports a
+ * terminal choice (build-iso / watch-install) back so the entry can hand off
+ * to the bash legs. Quit and Refresh are handled in-component.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import {
+  detectPhase,
+  actionsForPhase,
+  describePhase,
+  type MenuAction,
+  type PhaseProbes,
+  type PhaseState,
+} from './phase';
+
+export interface AppProps {
+  probes: PhaseProbes;
+  /** Called when the operator picks an action that hands off to a bash leg. */
+  onChoose: (action: 'build-iso' | 'watch-install') => void;
+}
+
+function PhaseMenu({
+  state,
+  actions,
+  cursor,
+}: {
+  state: PhaseState;
+  actions: MenuAction[];
+  cursor: number;
+}): React.ReactElement {
+  return (
+    <>
+      <Text color="cyan">{describePhase(state)}</Text>
+      <Box marginTop={1} flexDirection="column">
+        {actions.map((action, i) => (
+          <Text key={action.id} color={i === cursor ? 'green' : undefined}>
+            {i === cursor ? '❯ ' : '  '}
+            {action.label}
+          </Text>
+        ))}
+      </Box>
+      <Box marginTop={1}>
+        <Text color="gray">↑/↓ to move · Enter to select</Text>
+      </Box>
+    </>
+  );
+}
+
+export function App({ probes, onChoose }: AppProps): React.ReactElement {
+  const { exit } = useApp();
+  const [state, setState] = useState<PhaseState | null>(null);
+  const [cursor, setCursor] = useState(0);
+
+  // setState happens only in the promise callbacks, never synchronously in the
+  // effect — that would trip react-hooks/set-state-in-effect.
+  const loadPhase = useCallback(() => {
+    detectPhase(probes).then(
+      next => {
+        setState(next);
+        setCursor(0);
+      },
+      () => {
+        setState({ phase: 'no-iso', isoBuilt: false, boxReachable: false, wizardDone: false });
+        setCursor(0);
+      },
+    );
+  }, [probes]);
+
+  useEffect(() => {
+    loadPhase();
+  }, [loadPhase]);
+
+  const actions: MenuAction[] = state ? actionsForPhase(state) : [];
+
+  useInput((_input, key) => {
+    if (!state || actions.length === 0) return;
+    if (key.upArrow) setCursor(c => (c - 1 + actions.length) % actions.length);
+    else if (key.downArrow) setCursor(c => (c + 1) % actions.length);
+    else if (key.return) {
+      const action = actions[cursor];
+      if (action.id === 'quit') exit();
+      else if (action.id === 'refresh') {
+        setState(null);
+        loadPhase();
+      } else {
+        onChoose(action.id);
+        exit();
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold>ServiceBay — lifecycle launcher</Text>
+      {state ? (
+        <PhaseMenu state={state} actions={actions} cursor={cursor} />
+      ) : (
+        <Text color="gray">Detecting phase…</Text>
+      )}
+    </Box>
+  );
+}

--- a/packages/tui/src/actions.test.ts
+++ b/packages/tui/src/actions.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isoBuildCommand,
+  installWatchCommand,
+  parseInstallSettings,
+  resolveBoxTarget,
+  DEFAULT_SB_PORT,
+} from './actions';
+
+describe('command builders', () => {
+  it('isoBuildCommand shells out to install-fedora-coreos.sh at the repo root', () => {
+    const cmd = isoBuildCommand('/repo');
+    expect(cmd.cmd).toBe('bash');
+    expect(cmd.args).toEqual(['/repo/install-fedora-coreos.sh']);
+  });
+
+  it('installWatchCommand shells out to scripts/install-tui.sh', () => {
+    const cmd = installWatchCommand('/repo');
+    expect(cmd.args).toEqual(['/repo/scripts/install-tui.sh']);
+  });
+});
+
+describe('parseInstallSettings', () => {
+  it('pulls STATIC_IP + SERVICEBAY_PORT out of the env file', () => {
+    const text = 'FOO=bar\nSTATIC_IP=192.168.178.100\nSERVICEBAY_PORT=5888\n';
+    expect(parseInstallSettings(text)).toEqual({ host: '192.168.178.100', port: '5888' });
+  });
+
+  it('returns undefined for absent keys', () => {
+    expect(parseInstallSettings('NOTHING=here')).toEqual({ host: undefined, port: undefined });
+  });
+});
+
+describe('resolveBoxTarget', () => {
+  it('prefers SB_HOST/SB_PORT env over settings', () => {
+    const t = resolveBoxTarget({ host: '10.0.0.1', port: '1000' }, { SB_HOST: '10.0.0.9', SB_PORT: '9999' });
+    expect(t).toEqual({ host: '10.0.0.9', port: '9999' });
+  });
+
+  it('falls back to settings, then the default port', () => {
+    expect(resolveBoxTarget({ host: '10.0.0.1' }, {})).toEqual({ host: '10.0.0.1', port: DEFAULT_SB_PORT });
+  });
+
+  it('host is empty when neither env nor settings provide one', () => {
+    expect(resolveBoxTarget({}, {}).host).toBe('');
+  });
+});

--- a/packages/tui/src/actions.ts
+++ b/packages/tui/src/actions.ts
@@ -1,0 +1,56 @@
+/**
+ * Command + box-target builders for the launcher TUI (#1231).
+ *
+ * Pure helpers — they only build argv / resolve a host:port, so they're
+ * unit-testable. The ISO build and install-watch legs stay shell-outs to the
+ * existing bash pieces (`install-fedora-coreos.sh` needs sudo + a local USB;
+ * `install-tui.sh` is the post-boot watch dashboard), wrapped here so the menu
+ * has one place to hand off to.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+/** packages/tui/src → repo root. */
+export const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+
+/** Default ServiceBay HTTP port on the box. */
+export const DEFAULT_SB_PORT = '5888';
+
+export interface Command {
+  cmd: string;
+  args: string[];
+}
+
+export function isoBuildCommand(root: string = REPO_ROOT): Command {
+  return { cmd: 'bash', args: [path.join(root, 'install-fedora-coreos.sh')] };
+}
+
+export function installWatchCommand(root: string = REPO_ROOT): Command {
+  return { cmd: 'bash', args: [path.join(root, 'scripts', 'install-tui.sh')] };
+}
+
+export interface BoxTarget {
+  host: string;
+  port: string;
+}
+
+/** Parse the host/port out of build/fcos/install-settings.env (the same file
+ *  install-tui.sh reads). Missing keys come back undefined. */
+export function parseInstallSettings(envText: string): { host?: string; port?: string } {
+  const host = envText.match(/^STATIC_IP=(.*)$/m)?.[1]?.trim();
+  const port = envText.match(/^SERVICEBAY_PORT=(.*)$/m)?.[1]?.trim();
+  return { host: host || undefined, port: port || undefined };
+}
+
+/** Resolve the box address: explicit SB_HOST/SB_PORT env wins, else the values
+ *  from install-settings.env, else the default port. Host is '' when unknown. */
+export function resolveBoxTarget(
+  settings: { host?: string; port?: string },
+  env: Record<string, string | undefined>,
+): BoxTarget {
+  return {
+    host: env.SB_HOST || settings.host || '',
+    port: env.SB_PORT || settings.port || DEFAULT_SB_PORT,
+  };
+}

--- a/packages/tui/src/index.tsx
+++ b/packages/tui/src/index.tsx
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Entry for the lifecycle launcher TUI (#1231). Renders the Ink menu, and once
+ * the operator picks a bash-leg action, unmounts Ink and hands the terminal to
+ * that script (ISO build or install-watch) with inherited stdio.
+ *
+ * Run: `npm run tui`
+ */
+import { render } from 'ink';
+import { spawn } from 'node:child_process';
+import { App } from './App.js';
+import { makeProbes } from './probes.js';
+import { isoBuildCommand, installWatchCommand, type Command } from './actions.js';
+
+function runInteractive(command: Command): Promise<number> {
+  return new Promise(resolve => {
+    const child = spawn(command.cmd, command.args, { stdio: 'inherit' });
+    child.on('exit', code => resolve(code ?? 0));
+    child.on('error', () => resolve(1));
+  });
+}
+
+async function main(): Promise<void> {
+  const choice: { value: 'build-iso' | 'watch-install' | null } = { value: null };
+  const app = render(
+    <App
+      probes={makeProbes()}
+      onChoose={action => {
+        choice.value = action;
+      }}
+    />,
+  );
+  await app.waitUntilExit();
+
+  if (choice.value === 'build-iso') {
+    process.exit(await runInteractive(isoBuildCommand()));
+  }
+  if (choice.value === 'watch-install') {
+    process.exit(await runInteractive(installWatchCommand()));
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/tui/src/phase.test.ts
+++ b/packages/tui/src/phase.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectPhase,
+  actionsForPhase,
+  describePhase,
+  type PhaseProbes,
+  type PhaseState,
+} from './phase';
+
+function probes(over: Partial<{ isoBuilt: boolean; reachable: boolean; wizardDone: boolean }>): PhaseProbes {
+  return {
+    isoBuilt: async () => over.isoBuilt ?? false,
+    boxStatus: async () => ({ reachable: over.reachable ?? false, wizardDone: over.wizardDone ?? false }),
+  };
+}
+
+describe('detectPhase', () => {
+  it('is no-iso when nothing is built and the box is down', async () => {
+    expect((await detectPhase(probes({}))).phase).toBe('no-iso');
+  });
+
+  it('is iso-ready when an ISO exists but the box is unreachable', async () => {
+    const s = await detectPhase(probes({ isoBuilt: true }));
+    expect(s.phase).toBe('iso-ready');
+    expect(s.isoBuilt).toBe(true);
+  });
+
+  it('is installing when the box is reachable but the wizard is not done', async () => {
+    const s = await detectPhase(probes({ reachable: true, wizardDone: false }));
+    expect(s.phase).toBe('installing');
+    expect(s.boxReachable).toBe(true);
+  });
+
+  it('is ready when the box is reachable and the wizard is done', async () => {
+    const s = await detectPhase(probes({ reachable: true, wizardDone: true }));
+    expect(s.phase).toBe('ready');
+    expect(s.wizardDone).toBe(true);
+  });
+
+  it('a reachable box wins over a stale local ISO', async () => {
+    const s = await detectPhase(probes({ isoBuilt: true, reachable: true, wizardDone: true }));
+    expect(s.phase).toBe('ready');
+  });
+});
+
+describe('actionsForPhase', () => {
+  const state = (over: Partial<PhaseState>): PhaseState => ({
+    phase: 'no-iso',
+    isoBuilt: false,
+    boxReachable: false,
+    wizardDone: false,
+    ...over,
+  });
+
+  it('no-iso offers Build but not Watch (nothing to watch yet)', () => {
+    const ids = actionsForPhase(state({ phase: 'no-iso' })).map(a => a.id);
+    expect(ids).toContain('build-iso');
+    expect(ids).not.toContain('watch-install');
+    expect(ids).toContain('quit');
+  });
+
+  it('iso-ready offers both Rebuild and Watch', () => {
+    const actions = actionsForPhase(state({ phase: 'iso-ready', isoBuilt: true }));
+    const ids = actions.map(a => a.id);
+    expect(ids).toContain('build-iso');
+    expect(ids).toContain('watch-install');
+    expect(actions.find(a => a.id === 'build-iso')!.label).toMatch(/Rebuild/);
+  });
+
+  it('installing offers Watch but not Build (box is already up)', () => {
+    const ids = actionsForPhase(state({ phase: 'installing', boxReachable: true })).map(a => a.id);
+    expect(ids).toEqual(['watch-install', 'refresh', 'quit']);
+  });
+
+  it('always ends with refresh + quit', () => {
+    for (const phase of ['no-iso', 'iso-ready', 'installing', 'ready'] as const) {
+      const ids = actionsForPhase(state({ phase, boxReachable: phase === 'installing' || phase === 'ready', isoBuilt: phase === 'iso-ready' })).map(a => a.id);
+      expect(ids.slice(-2)).toEqual(['refresh', 'quit']);
+    }
+  });
+});
+
+describe('describePhase', () => {
+  it('returns a distinct sentence per phase', () => {
+    const phases = ['no-iso', 'iso-ready', 'installing', 'ready'] as const;
+    const lines = phases.map(phase =>
+      describePhase({ phase, isoBuilt: false, boxReachable: false, wizardDone: false }),
+    );
+    expect(new Set(lines).size).toBe(phases.length);
+  });
+});

--- a/packages/tui/src/phase.ts
+++ b/packages/tui/src/phase.ts
@@ -1,0 +1,87 @@
+/**
+ * Lifecycle phase detection for the launcher TUI (#1231).
+ *
+ * Pure logic: it takes injected probes (is an ISO built? is the box up? is the
+ * setup wizard finished?) and derives which phase the operator is in and which
+ * menu actions are relevant. Keeping the network/fs probes out of here makes
+ * the whole decision tree unit-testable. The real probes live in probes.ts.
+ */
+
+export type LifecyclePhase =
+  | 'no-iso' // nothing built yet — start by baking an install ISO
+  | 'iso-ready' // ISO built, box not reachable — boot the USB then watch
+  | 'installing' // box reachable but setup/install still in progress
+  | 'ready'; // box up and the setup wizard is complete
+
+export interface BoxStatus {
+  reachable: boolean;
+  wizardDone: boolean;
+}
+
+export interface PhaseProbes {
+  isoBuilt: () => Promise<boolean>;
+  boxStatus: () => Promise<BoxStatus>;
+}
+
+export interface PhaseState {
+  phase: LifecyclePhase;
+  isoBuilt: boolean;
+  boxReachable: boolean;
+  wizardDone: boolean;
+}
+
+export async function detectPhase(probes: PhaseProbes): Promise<PhaseState> {
+  const [isoBuilt, status] = await Promise.all([probes.isoBuilt(), probes.boxStatus()]);
+  const { reachable, wizardDone } = status;
+  const phase: LifecyclePhase = reachable
+    ? wizardDone
+      ? 'ready'
+      : 'installing'
+    : isoBuilt
+      ? 'iso-ready'
+      : 'no-iso';
+  return { phase, isoBuilt, boxReachable: reachable, wizardDone };
+}
+
+export type MenuActionId = 'build-iso' | 'watch-install' | 'refresh' | 'quit';
+
+export interface MenuAction {
+  id: MenuActionId;
+  label: string;
+}
+
+/** The actions offered for a given phase. Runtime actions (edit config, restore
+ *  backups, install stacks) are deferred to later #1231 sub-issues — this shell
+ *  only wraps the ISO build and the install-watch handoff. */
+export function actionsForPhase(state: PhaseState): MenuAction[] {
+  const actions: MenuAction[] = [];
+  if (!state.boxReachable) {
+    actions.push({
+      id: 'build-iso',
+      label: state.isoBuilt ? 'Rebuild install ISO + flash USB' : 'Build install ISO + flash USB',
+    });
+    if (state.isoBuilt) {
+      actions.push({ id: 'watch-install', label: 'Boot the USB, then watch the install' });
+    }
+  } else if (state.phase === 'installing') {
+    actions.push({ id: 'watch-install', label: 'Watch install progress' });
+  } else {
+    actions.push({ id: 'watch-install', label: 'Watch a reinstall' });
+  }
+  actions.push({ id: 'refresh', label: 'Refresh status' });
+  actions.push({ id: 'quit', label: 'Quit' });
+  return actions;
+}
+
+export function describePhase(state: PhaseState): string {
+  switch (state.phase) {
+    case 'no-iso':
+      return 'No install ISO built yet — start by baking one.';
+    case 'iso-ready':
+      return 'Install ISO is ready. Boot the box from the USB, then watch the install.';
+    case 'installing':
+      return 'Box is reachable; an install or setup is still in progress.';
+    case 'ready':
+      return 'Box is up and the setup wizard is complete.';
+  }
+}

--- a/packages/tui/src/probes.ts
+++ b/packages/tui/src/probes.ts
@@ -1,0 +1,60 @@
+/**
+ * Concrete phase probes for the launcher TUI (#1231): a filesystem check for a
+ * built ISO and an HTTP check of the box's install status. Kept separate from
+ * phase.ts so the decision logic stays pure and testable.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { REPO_ROOT, parseInstallSettings, resolveBoxTarget } from './actions';
+import type { BoxStatus, PhaseProbes } from './phase';
+
+const BUILD_DIR = path.join(REPO_ROOT, 'build', 'fcos');
+const SETTINGS_FILE = path.join(BUILD_DIR, 'install-settings.env');
+const STATUS_TIMEOUT_MS = 3000;
+
+async function readSettings(): Promise<{ host?: string; port?: string }> {
+  try {
+    return parseInstallSettings(await fs.readFile(SETTINGS_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/** An ISO build leaves install-settings.env (what install-tui.sh reads) and a
+ *  *.iso under build/fcos — either marker counts as "built". */
+export async function isoBuilt(): Promise<boolean> {
+  try {
+    await fs.access(SETTINGS_FILE);
+    return true;
+  } catch {
+    // fall through to the iso glob
+  }
+  try {
+    const entries = await fs.readdir(BUILD_DIR);
+    return entries.some(e => e.endsWith('.iso'));
+  } catch {
+    return false;
+  }
+}
+
+async function boxStatus(env: Record<string, string | undefined>): Promise<BoxStatus> {
+  const target = resolveBoxTarget(await readSettings(), env);
+  if (!target.host) return { reachable: false, wizardDone: false };
+  try {
+    const res = await fetch(`http://${target.host}:${target.port}/api/install/status`, {
+      signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+    });
+    if (!res.ok) return { reachable: true, wizardDone: false };
+    const data = (await res.json()) as { jobIsActive?: boolean; stackSetupPending?: boolean };
+    return { reachable: true, wizardDone: data.jobIsActive === false && data.stackSetupPending === false };
+  } catch {
+    return { reachable: false, wizardDone: false };
+  }
+}
+
+export function makeProbes(env: Record<string, string | undefined> = process.env): PhaseProbes {
+  return {
+    isoBuilt,
+    boxStatus: () => boxStatus(env),
+  };
+}

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@servicebay/api-client": ["../api-client/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
## What
Adds a new `@servicebay/tui` package: an Ink launcher that detects which lifecycle phase the operator is in (no ISO / ISO ready / installing / ready) and offers the relevant actions, wrapping the existing ISO-build script and the install-tui watch dashboard. Phase detection, the menu/action model, and the command + box-target builders are pure and unit-tested; the Ink component and entry are a thin shell.

## Why
Closes #1232. First sub-issue of the #1231 unified-lifecycle epic.

## Risk
Low — net-new package under `packages/tui/`, no changes to existing runtime paths. Ink pinned to 6.x because 7.x requires Node 22 while this repo targets Node 20.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (1426 passed, incl. new tui phase/actions tests)
- [ ] /verify on FCoS box — N/A, not a path-mandated file (new packages/tui/ package only)

Note: this work was originally committed directly to local main by a prior session; promoted to a proper branch+PR this invocation.