### PR TITLE
fix(auth): stop LLDAP reset-loop on reinstall and SMTP-fatal auth crashes

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -369,7 +369,13 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
   // Inject dynamic variables for self-healing and template rendering
   if (item.name === 'auth') {
     const isRegenerated = !ctx.reusedSecretNames.has('LLDAP_ADMIN_PASSWORD');
-    view['LLDAP_FORCE_LDAP_USER_PASS_RESET'] = isRegenerated ? 'true' : 'false';
+    // 'always' (not 'true'): in LLDAP 0.6.x the bare `true` is a break-glass
+    // one-shot that resets the admin password and then *exits* asking to be
+    // restarted without the flag — fatal here, where the flag is baked into the
+    // pod env permanently, so LLDAP reset-exits-restart-loops and never serves.
+    // 'always' re-syncs the password to the config secret on every start AND
+    // keeps serving, which is the self-healing behaviour this is meant to give.
+    view['LLDAP_FORCE_LDAP_USER_PASS_RESET'] = isRegenerated ? 'always' : 'false';
   }
   // Render YAML with unified template renderer
   const yamlContent = renderTemplate(item.yaml, view);
@@ -876,7 +882,7 @@ async function runJob(jobId: string): Promise<void> {
   // The pathological combination is "wipe secrets, preserve identity": the wizard
   // generates a fresh LLDAP_ADMIN_PASSWORD, but the LLDAP image does not rotate
   // the admin password from env on subsequent starts. We solve this by dynamically
-  // injecting `LLDAP_FORCE_LDAP_USER_PASS_RESET=true` into the environment, which
+  // injecting `LLDAP_FORCE_LDAP_USER_PASS_RESET=always` into the environment, which
   // forces LLDAP to synchronize its database credentials to the freshly generated
   // password in config.json, avoiding user lockouts.
   //

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -389,7 +389,12 @@ def _smtp_notifier_block(em: dict) -> str:
     submission_uri = f"submissions://{host}:{port}" if secure else f"submission://{host}:{port}"
     lines = [
         "notifier:",
-        "  disable_startup_check: false",
+        # Don't let a flaky/rate-limited SMTP server take down all of auth:
+        # Authelia's notifier startup check is fatal on failure, so a transient
+        # Gmail "454 too many login attempts" (or any SMTP outage) would crash
+        # the whole auth pod and lock everyone out. Degrade instead — emails
+        # just fail to send while authentication keeps working.
+        "  disable_startup_check: true",
         "  smtp:",
         f"    address: {_yaml_quote(submission_uri)}",
         f"    timeout: 10s",

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -320,6 +320,24 @@ class AuthScript(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("Could not fully seed LLDAP groups after 3 attempts", out)
 
+    def test_smtp_notifier_disables_fatal_startup_check(self):
+        """Authelia's notifier startup check is fatal on failure, so a
+        transient or rate-limited SMTP server (e.g. Gmail '454 too many
+        login attempts') would crash the entire auth pod and lock
+        everyone out. The rendered SMTP notifier must disable that check
+        so email problems degrade instead of taking down auth."""
+        m = load_script("auth")
+        block = m._smtp_notifier_block({
+            "host": "smtp.gmail.com",
+            "port": 587,
+            "secure": False,
+            "user": "me@example.com",
+            "pass": "p",
+            "from": "me@example.com",
+        })
+        self.assertIn("disable_startup_check: true", block)
+        self.assertNotIn("disable_startup_check: false", block)
+
 
 class FileShareScript(unittest.TestCase):
     def test_samba_credential_emitted_when_password_set(self):


### PR DESCRIPTION
## What
Fixes two compounding bugs that left the **auth** stack crash-looping on a reinstall, so every service that depends on it (vaultwarden, immich, file-share, media, …) timed out waiting for `auth` to become healthy.

1. **LLDAP reset-loop** (`packages/backend/src/lib/install/runner.ts`): on a reinstall with a regenerated LLDAP secret, the runner set `LLDAP_FORCE_LDAP_USER_PASS_RESET=true`. In LLDAP 0.6.x, bare `true` resets the admin password and then **exits** ("Restart the server without --force-ldap-user-pass-reset to continue"). The env var is permanent, so LLDAP reset→exit→restart-loops and never serves; ports 3890/17170 never open. Changed to `always`, which re-syncs the password every start **and keeps serving** — the self-healing behaviour the code comment already describes.

2. **SMTP-fatal auth** (`templates/auth/post-deploy.py`): the SMTP-notifier rewrite hardcoded `disable_startup_check: false`. Authelia's notifier startup check is fatal, so a transient/rate-limited SMTP server (the restart storm pushed Gmail to `454 too many login attempts`) crashed the whole auth pod. Disabled the check so email problems degrade instead of taking down authentication. Added a unit test on the rendered notifier block.

## Why
Reinstall on the live box (192.168.178.100) hung: LLDAP HTTP API "never became reachable within 5 min", auth never went healthy, all dependents timed out.

## Risk
Low. `always` is documented by the LLDAP image itself; it only re-applies the configured admin password each boot (idempotent). Disabling the notifier startup check trades a fatal-on-boot for a degraded email path.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 warnings = baseline)
- [x] npx tsc --noEmit (clean)
- [x] npm run check:arch
- [x] npm test (1426 passed; new SMTP-notifier test)
- [x] **/verify on FCoS box** — applied the exact resulting values live: LLDAP pod stable, HTTP API 200, LDAP 3890 open; Authelia "Startup complete" + /api/health 200, both containers stable (no restart loop). The code change emits exactly these values.