### PR TITLE
fix(frontend): show signed-in user + working logout on LAN-direct access

### DIFF
--- a/packages/backend/src/lib/auth.ts
+++ b/packages/backend/src/lib/auth.ts
@@ -27,3 +27,15 @@ export async function login(username: string, secure: boolean) {
     path: '/',
   });
 }
+
+/** Clear the ServiceBay session cookie. Mirrors `login`'s name + path so the
+ *  browser actually drops it (a Set-Cookie with a different path won't). */
+export async function logout() {
+  const cookieStore = await cookies();
+  cookieStore.set('session', '', {
+    expires: new Date(0),
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+  });
+}

--- a/packages/frontend/src/app/api/auth/logout/route.ts
+++ b/packages/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { logout } from '@/lib/auth';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/auth/logout — clear the ServiceBay session cookie.
+ *
+ * skipAuth: clearing the cookie must work even when the session is already
+ * invalid (e.g. after an AUTH_SECRET rotation leaves a stale cookie the user
+ * can't otherwise drop). Logging out is harmless and idempotent, so it doesn't
+ * need a valid session to proceed. The Authelia-gated path uses auth.<domain>/
+ * logout instead; this is for LAN-direct ServiceBay sessions.
+ */
+export const POST = withApiHandler({ skipAuth: true }, async () => {
+  await logout();
+  return NextResponse.json({ success: true });
+});

--- a/packages/frontend/src/app/api/auth/me/route.ts
+++ b/packages/frontend/src/app/api/auth/me/route.ts
@@ -1,24 +1,26 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { withApiHandler } from '@/lib/api/handler';
+import { getSessionFromCookieHeader } from '@/lib/auth/session';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * GET /api/auth/me — current-user introspection from forward-auth headers.
+ * GET /api/auth/me — current-user introspection.
  *
- * #1001. NPM's forward-auth snippet (#999) lays down `Remote-User`,
- * `Remote-Name`, `Remote-Email`, `Remote-Groups` on every request to a
- * gated service domain. We just read them back here so the sidebar +
- * portal can render the user chip + Logout without round-tripping to
- * auth.<domain>.
+ * #1001. When ServiceBay is reached through the Authelia forward-auth chain,
+ * NPM's snippet (#999) lays down `Remote-User`/`Remote-Name`/`Remote-Email`/
+ * `Remote-Groups`; we read those back so the sidebar + portal can render the
+ * user chip + Logout without round-tripping to auth.<domain>.
  *
- * When the request doesn't carry the headers (LAN-direct access,
- * dev mode, mock mode), returns `{ authenticated: false }`. Callers
- * render "Not signed in" + a Login link.
+ * On LAN-direct access those headers don't exist — but the operator still has
+ * a ServiceBay *session* (the cookie set by /api/auth/login). Fall back to it
+ * so the sidebar shows who's signed in and offers a Logout that clears the
+ * ServiceBay session. `source` tells the client which logout path to use.
  *
- * Groups is a comma-separated list of group names (Authelia's
- * `proxy_set_header Remote-Groups $groups;` joins with `,`). Split
- * to an array for cleaner consumption.
+ * Returns `{ authenticated: false }` only when neither is present.
+ *
+ * Groups is a comma-separated list (Authelia's `Remote-Groups` joins with
+ * `,`). Split to an array for cleaner consumption.
  */
 function readUserFromHeaders(req: NextRequest) {
   const username = req.headers.get('remote-user');
@@ -30,11 +32,25 @@ function readUserFromHeaders(req: NextRequest) {
     displayName: req.headers.get('remote-name') || username,
     email: req.headers.get('remote-email') || '',
     groups: groupsRaw.split(',').map(g => g.trim()).filter(Boolean),
+    source: 'forward-auth' as const,
   };
 }
 
 export const GET = withApiHandler({}, async ({ request }) => {
-  const user = readUserFromHeaders(request);
-  if (user) return NextResponse.json(user);
+  const fromHeaders = readUserFromHeaders(request);
+  if (fromHeaders) return NextResponse.json(fromHeaders);
+
+  const session = await getSessionFromCookieHeader(request.headers.get('cookie') ?? undefined);
+  if (session) {
+    return NextResponse.json({
+      authenticated: true,
+      username: session.user,
+      displayName: session.user,
+      email: '',
+      groups: [],
+      source: 'session',
+    });
+  }
+
   return NextResponse.json({ authenticated: false });
 });

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ export default function Sidebar() {
   const [appVersion, setAppVersion] = useState<string | null>(null);
   // #1001 — Current Authelia user from the forward-auth Remote-* headers.
   // null = not yet fetched, false = no session (LAN-direct or dev).
-  const [currentUser, setCurrentUser] = useState<{ displayName: string; username: string; groups: string[] } | null | false>(null);
+  const [currentUser, setCurrentUser] = useState<{ displayName: string; username: string; groups: string[]; source: 'forward-auth' | 'session' } | null | false>(null);
 
   useEffect(() => {
     if (window.innerWidth < 768) {
@@ -63,6 +63,7 @@ export default function Sidebar() {
             displayName: d.displayName || d.username,
             username: d.username,
             groups: Array.isArray(d.groups) ? d.groups : [],
+            source: d.source === 'session' ? 'session' : 'forward-auth',
           });
         } else {
           setCurrentUser(false);
@@ -82,6 +83,22 @@ export default function Sidebar() {
     if (dotIdx < 0) return '/portal';
     return `https://auth${host.slice(dotIdx)}/logout`;
   })();
+
+  // Two logout paths: a ServiceBay session (LAN-direct) is cleared via the
+  // backend then we bounce to /login; an Authelia forward-auth session is
+  // dropped at auth.<domain>/logout.
+  const handleLogout = async () => {
+    if (currentUser && currentUser.source === 'session') {
+      try {
+        await fetch('/api/auth/logout', { method: 'POST' });
+      } catch {
+        /* clear best-effort; redirect regardless so a stale cookie doesn't trap the user */
+      }
+      window.location.href = '/login';
+      return;
+    }
+    window.location.href = logoutHref;
+  };
 
   useEffect(() => {
     fetch('/api/auth/lldap-url')
@@ -259,20 +276,25 @@ export default function Sidebar() {
                     {!isCollapsed && (
                         <div className="flex flex-col min-w-0 flex-1">
                             <span className="text-sm font-semibold text-gray-800 dark:text-gray-200 truncate">{currentUser.displayName}</span>
-                            <span className="text-xs text-gray-500 dark:text-gray-500 truncate">{currentUser.groups.join(', ') || 'no groups'}</span>
+                            <span className="text-xs text-gray-500 dark:text-gray-500 truncate">
+                                {currentUser.source === 'session'
+                                    ? 'ServiceBay admin'
+                                    : (currentUser.groups.join(', ') || 'no groups')}
+                            </span>
                         </div>
                     )}
                 </div>
             )}
             {currentUser && (
-                <a
-                    href={logoutHref}
+                <button
+                    type="button"
+                    onClick={handleLogout}
                     className={`w-full flex items-center px-3.5 py-2.5 rounded-xl text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-200/60 dark:hover:bg-white/[0.02] transition-all border border-transparent ${isCollapsed ? 'justify-center' : 'gap-3.5'}`}
-                    title="Log out — drops the Authelia session"
+                    title={currentUser.source === 'session' ? 'Log out of ServiceBay' : 'Log out — drops the Authelia session'}
                 >
                     <LogOut size={18} className="shrink-0" />
                     {!isCollapsed && <span className="text-sm font-semibold whitespace-nowrap overflow-hidden">Log out</span>}
-                </a>
+                </button>
             )}
             <div className={isCollapsed ? 'flex justify-center' : ''}>
                 <SectionHelp

--- a/packages/frontend/src/mocks/handlers.ts
+++ b/packages/frontend/src/mocks/handlers.ts
@@ -133,11 +133,16 @@ export const handlers = [
 
   // GET /api/auth/me — current-user introspection (consumed by #1001)
   http.get('/api/auth/me', () => HttpResponse.json({
+    authenticated: true,
     username: 'mockuser',
     displayName: 'Mock User',
     email: 'mock@example.com',
     groups: ['family'],
+    source: 'forward-auth',
   })),
+
+  // POST /api/auth/logout — clears the ServiceBay session
+  http.post('/api/auth/logout', () => HttpResponse.json({ success: true })),
 
   // GET /api/logs/query — log viewer empty result
   http.get('/api/logs/query', () => HttpResponse.json({ success: true, logs: [] })),

--- a/packages/frontend/src/proxy.ts
+++ b/packages/frontend/src/proxy.ts
@@ -29,6 +29,10 @@ type PublicApiRule = {
 
 const PUBLIC_API_RULES: PublicApiRule[] = [
   { prefix: '/api/auth/login' },
+  // Logout just clears the session cookie — public so a user holding a stale
+  // cookie (e.g. after an AUTH_SECRET rotation) can still drop it instead of
+  // being gated out of logging out.
+  { prefix: '/api/auth/logout', methods: new Set(['POST']) },
   { prefix: '/api/auth/oidc' },
   { prefix: '/api/auth/lldap-url' },
   { prefix: '/api/system/access-requests', methods: new Set(['POST']) },

--- a/tests/backend/auth_me.test.ts
+++ b/tests/backend/auth_me.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { NextRequest } from 'next/server';
+
+beforeAll(() => {
+  process.env.AUTH_SECRET = process.env.AUTH_SECRET ||
+    '0123456789abcdef0123456789abcdef0123456789abcdef';
+});
+
+// withApiHandler's per-route session gate (#596) — let it pass so the handler
+// body runs; the body's own header/session logic is what we're testing.
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: vi.fn(async () => ({ user: 'admin', expires: new Date(Date.now() + 86400_000) })),
+}));
+
+import { GET } from '../../packages/frontend/src/app/api/auth/me/route';
+
+describe('GET /api/auth/me', () => {
+  it('reads the user from forward-auth Remote-* headers when present', async () => {
+    const req = new NextRequest('http://test/api/auth/me', {
+      headers: { 'remote-user': 'alice', 'remote-name': 'Alice', 'remote-groups': 'admins, family' },
+    });
+    const data = await (await GET(req)).json();
+    expect(data).toMatchObject({
+      authenticated: true,
+      username: 'alice',
+      displayName: 'Alice',
+      source: 'forward-auth',
+    });
+    expect(data.groups).toEqual(['admins', 'family']);
+  });
+
+  it('falls back to the ServiceBay session when no Remote-* headers (LAN-direct)', async () => {
+    const { encryptSession } = await import('@/lib/auth/session');
+    const token = await encryptSession({ user: 'sbadmin', expires: new Date(Date.now() + 3600_000) });
+    const req = new NextRequest('http://test/api/auth/me', {
+      headers: { cookie: `session=${token}` },
+    });
+    const data = await (await GET(req)).json();
+    expect(data).toMatchObject({ authenticated: true, username: 'sbadmin', source: 'session' });
+    expect(data.groups).toEqual([]);
+  });
+
+  it('reports not-authenticated with neither headers nor a session cookie', async () => {
+    const req = new NextRequest('http://test/api/auth/me');
+    const data = await (await GET(req)).json();
+    expect(data).toEqual({ authenticated: false });
+  });
+});

--- a/tests/backend/route_session_gate.test.ts
+++ b/tests/backend/route_session_gate.test.ts
@@ -24,6 +24,7 @@ const API_ROOT = path.join(REPO_ROOT, 'packages', 'frontend', 'src', 'app', 'api
 interface PublicRule { prefix: string; methods?: ReadonlySet<string> }
 const PUBLIC_RULES: PublicRule[] = [
   { prefix: '/api/auth/login' },
+  { prefix: '/api/auth/logout', methods: new Set(['POST']) },
   { prefix: '/api/auth/oidc' },
   { prefix: '/api/auth/lldap-url' },
   { prefix: '/api/system/access-requests', methods: new Set(['POST']) },


### PR DESCRIPTION
## What
The sidebar user chip + **Logout** (#1001) only appeared when ServiceBay was reached via the Authelia forward-auth chain (which sets `Remote-*` headers). On a **direct LAN hit** (`192.168.178.100:5888`) those headers don't exist, so `/api/auth/me` returned `authenticated:false` and the chip + Logout never rendered — even though the operator has a valid ServiceBay session. There was also no way to clear that session.

- **`/api/auth/me`**: falls back to the ServiceBay session cookie when forward-auth headers are absent → returns the session user + `source:'session'`.
- **`POST /api/auth/logout`** (new): clears the session cookie. Public at the proxy + route layer so a *stale* cookie (e.g. after an `AUTH_SECRET` rotation) can still be dropped.
- **Sidebar**: renders the chip for both sources; Logout clears the ServiceBay session and bounces to `/login` (session) or `auth.<domain>/logout` (forward-auth).
- Fixed the `/api/auth/me` mock (missing `authenticated:true`, so the chip never showed in dev/mocks) and mirrored the logout public-rule in `route_session_gate.test.ts`.

## Why
Operator reported the username + logout button still missing in the UI — they access ServiceBay LAN-direct, the one path the chip never covered.

## Risk
Low. New logout route is additive; `me` only gains a fallback when headers are absent. None of the touched files are install/auth-runtime path-mandated.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 warnings = baseline)
- [x] npx tsc --noEmit (clean)
- [x] npm run check:arch
- [x] npm test (1442 passed; new `auth_me.test.ts` covers header + session-fallback + unauth cases; route-gate test confirms logout is allowlisted)
- [ ] **Browser render NOT verified** — this dev box has no browser libs (known constraint), so the visual sidebar chip/button + logout click weren't exercised in a browser. The `me`-route logic is unit-tested; the visual confirmation happens on deploy.