### PR TITLE
fix(install): count already-deployed templates as satisfying install-time deps

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -34,7 +34,7 @@ import {
 } from '@/lib/registry';
 import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
 import { parseTemplateManifest } from '@/lib/template/contract';
-import { topoSortByDependencies } from '@/lib/stackInstall/dependencies';
+import { topoSortByDependencies, resolveAlreadyInstalled } from '@/lib/stackInstall/dependencies';
 import { parseTemplateTier } from '@/lib/templateTier';
 import { selectMigrationChain } from '@/lib/stackInstall/migrations';
 import {
@@ -712,6 +712,12 @@ async function runJob(jobId: string): Promise<void> {
   // gate, an unrelated feature with no declared deps (ollama, hermes)
   // races nginx and ends up registering NPM proxy hosts that the
   // late-running NPM credentials self-heal then wipes.
+  // A dependency is satisfied by anything already deployed on the node, not
+  // just by items re-selected in this batch. Fold the live twin's service
+  // names in (node-scoped) so installing e.g. `hermes` isn't wrongly blocked
+  // on `home-assistant` when HA is already running but wasn't re-checked.
+  const installNode = input.node || 'Local';
+  const deployedOnNode = (getStoreSnapshot().nodes?.[installNode]?.services ?? []).map(s => s.name);
   const sortResult = topoSortByDependencies(
     checked.map(i => ({
       name: i.name,
@@ -722,7 +728,7 @@ async function runJob(jobId: string): Promise<void> {
       dependencies: i.dependencies ?? [],
       tier: i.yaml ? parseTemplateTier(i.yaml) : 'feature',
     })),
-    { alreadyInstalled: new Set(input.items.filter(i => i.alreadyInstalled).map(i => i.name)) },
+    { alreadyInstalled: resolveAlreadyInstalled(input.items, deployedOnNode) },
   );
   if (!sortResult.ok) {
     const msg = sortResult.reason === 'missing'

--- a/packages/backend/src/lib/stackInstall/dependencies.test.ts
+++ b/packages/backend/src/lib/stackInstall/dependencies.test.ts
@@ -1,5 +1,32 @@
 import { describe, it, expect } from 'vitest';
-import { parseTemplateDependencies, topoSortByDependencies } from './dependencies';
+import { parseTemplateDependencies, topoSortByDependencies, resolveAlreadyInstalled } from './dependencies';
+
+describe('resolveAlreadyInstalled', () => {
+  it('counts node-deployed templates as satisfiers even when not re-selected', () => {
+    // The hermes → home-assistant case: HA is deployed on the node but not in
+    // this install batch. It must still satisfy the dependency.
+    const set = resolveAlreadyInstalled(
+      [{ name: 'hermes' }, { name: 'ollama' }],
+      ['home-assistant', 'nginx', 'auth'],
+    );
+    expect(set.has('home-assistant')).toBe(true);
+
+    const result = topoSortByDependencies(
+      [{ name: 'hermes', dependencies: ['home-assistant'] }],
+      { alreadyInstalled: set },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('also folds in batch items flagged alreadyInstalled', () => {
+    const set = resolveAlreadyInstalled(
+      [{ name: 'auth', alreadyInstalled: true }, { name: 'vaultwarden' }],
+      [],
+    );
+    expect(set.has('auth')).toBe(true);
+    expect(set.has('vaultwarden')).toBe(false);
+  });
+});
 
 describe('parseTemplateDependencies', () => {
   it('returns empty array when annotation missing', () => {

--- a/packages/backend/src/lib/stackInstall/dependencies.ts
+++ b/packages/backend/src/lib/stackInstall/dependencies.ts
@@ -88,6 +88,25 @@ function computeEffectiveDeps<T extends DependencyAwareItem>(
 }
 
 /**
+ * Build the set of dependency-satisfying names for an install: everything
+ * already deployed on the target node, plus anything the operator flagged as
+ * already-installed in this batch. Pass the result as `topoSortByDependencies`'
+ * `alreadyInstalled`. Without the node set, a dependency on something that's
+ * installed but not re-selected (e.g. `hermes` → `home-assistant`) is wrongly
+ * reported missing just because it wasn't in the current selection.
+ */
+export function resolveAlreadyInstalled(
+  batchItems: ReadonlyArray<{ name: string; alreadyInstalled?: boolean }>,
+  deployedOnNode: Iterable<string>,
+): Set<string> {
+  const set = new Set<string>(deployedOnNode);
+  for (const item of batchItems) {
+    if (item.alreadyInstalled) set.add(item.name);
+  }
+  return set;
+}
+
+/**
  * Topologically sort `items` so every entry's dependencies appear
  * earlier in the result. Items whose dependencies aren't in
  * `candidates` (typically `selectedNames`) return `missing`; cycles


### PR DESCRIPTION
## What
The install runner's dependency check only treated templates **in the current install batch** (or flagged `alreadyInstalled` by the frontend) as dependency satisfiers. Templates already deployed on the node but not re-selected were ignored.

Result (reported by operator installing the OSCAR stack):
> ❌ Cannot install hermes: it depends on home-assistant, which is not selected.

…even though `home-assistant` was already installed and running. The curated-stack path (`stackRunner`) already folds in the live twin; the general `runner` did not.

## Fix
- New `resolveAlreadyInstalled(batchItems, deployedOnNode)` helper in `stackInstall/dependencies.ts` — unions the node's deployed templates with the batch's `alreadyInstalled` items.
- `runner.ts` now reads the node's live twin service names (`getStoreSnapshot().nodes[node].services`) and feeds them into `topoSortByDependencies`' `alreadyInstalled` set.

## Why
Closes the false-positive dependency block. A dependency should be satisfied by anything already deployed on the node, not only by what's re-checked in the current selection.

## Risk
Low. Only *widens* what counts as a satisfied dependency (never blocks more); node-scoped via the twin so it can't over-satisfy across nodes. The topo logic itself is unchanged + already tested.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 warnings = baseline)
- [x] npx tsc --noEmit (clean)
- [x] npm run check:arch
- [x] npm test (1444 passed; new `resolveAlreadyInstalled` tests incl. the hermes→home-assistant case)
- [x] **Real-box check**: confirmed `home-assistant` is present in the node's twin service list (`GET /api/services`), so the fix's data source resolves the dependency. (Logic validated against live box state; not redeployed onto the box.)