### PR TITLE
fix(registry): run registry git ops non-interactively so unreachable repos fail fast

### DIFF
--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -11,6 +11,14 @@ import { logger } from './logger';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
+// Registry git runs unattended in the server — never let git try to prompt for
+// credentials. Without this, an unreachable or private registry repo makes
+// `git clone/fetch` attempt an interactive username prompt, which fails with a
+// cryptic "could not read Username for 'https://github.com'" (and can hang in
+// environments that do have a TTY). GIT_TERMINAL_PROMPT=0 makes it fail fast
+// and clearly so the registry is skipped and the others keep syncing.
+const GIT_ENV = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
+
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 const STACKS_PATH = path.join(process.cwd(), 'stacks');
 const CONTAINER_CONFIG_DIR = '/app/.servicebay';
@@ -279,7 +287,7 @@ function getRegistries(config: Awaited<ReturnType<typeof getConfig>>): RegistryC
 
 async function cloneSparse(url: string, dest: string, dirs: string[]) {
     // Shallow clone with sparse checkout — only pull the directories we need
-    await execFileAsync('git', ['clone', '--depth', '1', '--filter=blob:none', '--sparse', url, dest]);
+    await execFileAsync('git', ['clone', '--depth', '1', '--filter=blob:none', '--sparse', url, dest], { env: GIT_ENV });
     await execFileAsync('git', ['sparse-checkout', 'set', ...dirs], { cwd: dest });
 }
 
@@ -359,8 +367,8 @@ export async function syncRegistries() {
                 // Exists — fetch latest and reset (shallow clones can't reliably git pull)
                 logger.info('registry', `Updating registry ${reg.name}...`);
                 const branch = reg.branch || 'main';
-                await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath });
-                await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath });
+                await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath, env: GIT_ENV });
+                await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath, env: GIT_ENV });
             } catch {
                 // Doesn't exist, clone
                 logger.info('registry', `Cloning registry ${reg.name}...`);
@@ -372,7 +380,7 @@ export async function syncRegistries() {
                     await cloneSparse(reg.url, regPath, ['templates', 'stacks', 'servicebay.json']);
                 } catch {
                     // Fallback to full clone if sparse checkout not supported
-                    await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath]);
+                    await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath], { env: GIT_ENV });
                 }
             }
             // Manifest pass: if the registry ships `servicebay.json`, pull


### PR DESCRIPTION
## What
Registry sync ran `git clone/fetch/reset` without disabling git's interactive credential prompt. A registry pointing at a **private or nonexistent** repo (the reporter's default `ServiceBay Templates` → `mdopp/servicebay-templates`) made git try to read a username and fail with a cryptic `could not read Username for 'https://github.com'` (and it can hang where a TTY is present). Set `GIT_TERMINAL_PROMPT=0` on the registry git ops so an unreachable/private registry fails fast and clearly, gets skipped, and the other registries keep syncing.

## Why
Closes #1250. Investigated on a live box: the clone already uses `execFile` argv form, so the reported "unquoted dest / space" word-splitting is **not** the cause — the space is handled fine; the failure is purely a credential prompt on an unreachable repo. (The registry itself only loads once its repo is reachable — that's an operator config fix, noted on the issue.)

## Risk
Low — only changes the environment of git subprocesses to be non-interactive (standard for automation). No behavior change for reachable registries.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 warnings = baseline)
- [x] npx tsc --noEmit (clean)
- [x] npm run check:arch
- [x] npm test (1444 passed)
- [x] **Live box**: `GIT_TERMINAL_PROMPT=0 git clone <private repo>` now fails immediately with `terminal prompts disabled` instead of the cryptic username error. (`registry.ts` is not a path-mandated file; confirmed the behavior on the box anyway.)