### PR TITLE
fix(registry): list Stacks before Templates in the registry browser

### DIFF
--- a/packages/frontend/src/components/RegistryBrowser.tsx
+++ b/packages/frontend/src/components/RegistryBrowser.tsx
@@ -177,19 +177,19 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
                 ))}
             </div>
 
-            {templateItems.length > 0 && (
+            {stackItems.length > 0 && (
                 <>
-                    <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">Templates</div>
-                    {templateItems.map(t => (
+                    <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">Stacks</div>
+                    {stackItems.map(t => (
                         <RegistryListItem key={`${t.source}-${t.name}`} item={t} isSelected={isItemSelected(t)} onClick={() => handleTemplateClick(t)} />
                     ))}
                 </>
             )}
 
-            {stackItems.length > 0 && (
+            {templateItems.length > 0 && (
                 <>
-                    <div className="px-4 py-2 mt-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Stacks</div>
-                    {stackItems.map(t => (
+                    <div className="px-4 py-2 mt-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Templates</div>
+                    {templateItems.map(t => (
                         <RegistryListItem key={`${t.source}-${t.name}`} item={t} isSelected={isItemSelected(t)} onClick={() => handleTemplateClick(t)} />
                     ))}
                 </>


### PR DESCRIPTION
## What
Swaps the two sections in the registry browser so **Stacks** render above **Templates** (the "Create New" section stays at top).

## Why
Operator preference: when adding services, the stacks (higher-level bundles) should come first, then the individual templates. Follow-up to #1254 (which grouped them with Templates first).

## Risk
Low — presentational reorder only, no logic change. Not a path-mandated file.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 = baseline)
- [x] npx tsc --noEmit (clean)
- [x] npm run check:arch
- [x] npm test
- [ ] Browser render not verified (no browser libs on dev box) — presentational section swap.