### PR TITLE
fix(install): stream real image-pull progress with cached-layer info

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -118,6 +118,20 @@ def _resolve_timeout_env(var_name: str, default: float) -> Optional[float]:
 
 COMMAND_TIMEOUT_SECONDS = _resolve_timeout_env('SERVICEBAY_COMMAND_TIMEOUT', 20.0)
 
+
+def _split_image_ref(image: str) -> Tuple[str, Optional[str]]:
+    """Split an image ref into (fromImage, tag) for the docker-compat
+    /images/create endpoint. A digest-pinned ref (name@sha256:...) is passed
+    whole as fromImage with no tag. A ':' separates the tag only when it comes
+    after the last '/', so a registry:port host isn't mistaken for a tag."""
+    if '@' in image:
+        return image, None
+    slash = image.rfind('/')
+    colon = image.rfind(':')
+    if colon > slash:
+        return image[:colon], image[colon + 1:]
+    return image, 'latest'
+
 # Import paramiko only if containerized
 if IS_CONTAINERIZED:
     try:
@@ -2193,8 +2207,18 @@ class Agent:
                             sock_path = f"/run/user/{uid}/podman/podman.sock"
                             conn = UnixHTTPConnection(sock_path)
                             from urllib.parse import quote
-                            ref = quote(img, safe='')
-                            conn.request('POST', f'/v5.0.0/libpod/images/pull?reference={ref}')
+                            # docker-compat /images/create streams Docker-style
+                            # per-layer progress (status + progressDetail.current
+                            # /total, plus "Already exists" for cached layers).
+                            # The libpod /images/pull endpoint only emitted opaque
+                            # {"stream": "..."} text with no byte progress, so a
+                            # large layer produced no events for minutes — looking
+                            # hung and tripping the socket read timeout.
+                            from_image, tag = _split_image_ref(img)
+                            qs = f"fromImage={quote(from_image, safe='')}"
+                            if tag:
+                                qs += f"&tag={quote(tag, safe='')}"
+                            conn.request('POST', f'/v1.41/images/create?{qs}')
                             resp = conn.getresponse()
                             if resp.status != 200:
                                 body = resp.read().decode('utf-8', errors='replace')
@@ -2217,24 +2241,33 @@ class Agent:
                                         obj = json.loads(line)
                                     except json.JSONDecodeError:
                                         continue
-                                    if 'error' in obj and obj['error']:
-                                        reply_fn(error=obj['error'])
+                                    err = obj.get('error') or (obj.get('errorDetail') or {}).get('message')
+                                    if err:
+                                        reply_fn(error=err)
                                         return
+                                    status = obj.get('status', '')
+                                    detail = obj.get('progressDetail') or {}
+                                    # Throttle the high-frequency "Downloading"
+                                    # byte updates; forward lifecycle events
+                                    # (fs layer / complete / already-exists)
+                                    # immediately so layer counts stay accurate.
+                                    is_download = status == 'Downloading'
                                     now = time.time() * 1000
-                                    if now - last_push >= throttle_ms:
-                                        progress = {
-                                            'pull_id': pid,
-                                            'image': img,
-                                            'id': obj.get('id', ''),
-                                            'status': obj.get('status', ''),
-                                            'stream': obj.get('stream', ''),
-                                        }
-                                        detail = obj.get('progressDetail') or {}
-                                        if detail.get('current') is not None:
-                                            progress['current'] = detail['current']
-                                        if detail.get('total') is not None:
-                                            progress['total'] = detail['total']
-                                        self.push_state('PULL_PROGRESS', progress)
+                                    if is_download and now - last_push < throttle_ms:
+                                        continue
+                                    progress = {
+                                        'pull_id': pid,
+                                        'image': img,
+                                        'id': obj.get('id', ''),
+                                        'status': status,
+                                        'stream': obj.get('stream', ''),
+                                    }
+                                    if detail.get('current') is not None:
+                                        progress['current'] = detail['current']
+                                    if detail.get('total') is not None:
+                                        progress['total'] = detail['total']
+                                    self.push_state('PULL_PROGRESS', progress)
+                                    if is_download:
                                         last_push = now
                             conn.close()
                             reply_fn(result={'success': True, 'image': img})

--- a/packages/backend/src/lib/agent/v4/test_pull.py
+++ b/packages/backend/src/lib/agent/v4/test_pull.py
@@ -1,0 +1,40 @@
+import unittest
+import sys
+import os
+from unittest.mock import patch
+
+# Add current dir to path to import agent
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# Mock shutil.which before import (agent checks for 'ss' at import time).
+with patch('shutil.which', return_value='/bin/ss'):
+    import agent
+
+
+class TestSplitImageRef(unittest.TestCase):
+    """`_split_image_ref` feeds the docker-compat /images/create endpoint,
+    which takes fromImage + tag separately."""
+
+    def test_registry_repo_tag(self):
+        self.assertEqual(agent._split_image_ref('docker.io/ollama/ollama:latest'),
+                         ('docker.io/ollama/ollama', 'latest'))
+
+    def test_defaults_tag_to_latest_when_absent(self):
+        self.assertEqual(agent._split_image_ref('docker.io/library/alpine'),
+                         ('docker.io/library/alpine', 'latest'))
+
+    def test_registry_port_is_not_mistaken_for_tag(self):
+        self.assertEqual(agent._split_image_ref('localhost:5000/foo/bar:1.2'),
+                         ('localhost:5000/foo/bar', '1.2'))
+
+    def test_registry_port_without_tag(self):
+        self.assertEqual(agent._split_image_ref('localhost:5000/foo'),
+                         ('localhost:5000/foo', 'latest'))
+
+    def test_digest_pin_passes_whole_ref_with_no_tag(self):
+        ref = 'ghcr.io/mdopp/servicebay@sha256:' + 'a' * 64
+        self.assertEqual(agent._split_image_ref(ref), (ref, None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/backend/src/lib/install/pullProgress.test.ts
+++ b/packages/backend/src/lib/install/pullProgress.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { PullTracker, describePull, type PullEvent } from './pullProgress';
+
+// Trivial byte formatter so the assertions stay readable.
+const fmt = (n: number) => `${n}B`;
+
+describe('PullTracker', () => {
+  it('counts cached ("Already exists") layers separately from downloads', () => {
+    // Shape captured from podman docker-compat /images/create.
+    const events: PullEvent[] = [
+      { id: 'a', status: 'Already exists' },
+      { id: 'b', status: 'Pulling fs layer' },
+      { id: 'b', status: 'Downloading', current: 50, total: 100 },
+    ];
+    const t = new PullTracker();
+    events.forEach(e => t.update(e));
+    const s = t.summary();
+    expect(s.cached).toBe(1);
+    expect(s.totalLayers).toBe(2);
+    expect(s.bytesCurrent).toBe(50);
+    expect(s.bytesTotal).toBe(100);
+  });
+
+  it('credits a completed layer its full size even though the done event has no bytes', () => {
+    const t = new PullTracker();
+    t.update({ id: 'b', status: 'Downloading', current: 60, total: 100 });
+    t.update({ id: 'b', status: 'Download complete' }); // empty progressDetail
+    const s = t.summary();
+    expect(s.bytesCurrent).toBe(100);
+    expect(s.bytesTotal).toBe(100);
+    expect(s.complete).toBe(1);
+  });
+
+  it('aggregates byte progress across multiple downloading layers', () => {
+    const t = new PullTracker();
+    t.update({ id: 'x', status: 'Downloading', current: 1_000_000, total: 2_000_000 });
+    t.update({ id: 'y', status: 'Downloading', current: 500_000, total: 4_000_000 });
+    const s = t.summary();
+    expect(s.bytesCurrent).toBe(1_500_000);
+    expect(s.bytesTotal).toBe(6_000_000);
+  });
+
+  it('ignores events without a layer id', () => {
+    const t = new PullTracker();
+    t.update({ status: 'Trying to pull …' });
+    expect(t.summary().totalLayers).toBe(0);
+  });
+});
+
+describe('describePull', () => {
+  it('shows percent + bytes + cached count once sizes are known', () => {
+    const t = new PullTracker();
+    t.update({ id: 'a', status: 'Already exists' });
+    t.update({ id: 'b', status: 'Downloading', current: 25, total: 100 });
+    expect(describePull('ollama', t.summary(), fmt)).toBe('Pulling ollama: 25% (25B / 100B) · 1 layer already cached');
+  });
+
+  it('shows a preparing heartbeat before any byte sizes arrive', () => {
+    const t = new PullTracker();
+    t.update({ id: 'a', status: 'Already exists' });
+    t.update({ id: 'b', status: 'Pulling fs layer' });
+    expect(describePull('ollama', t.summary(), fmt)).toBe('Pulling ollama: preparing 2 layers · 1 layer already cached…');
+  });
+
+  it('returns null before any layer is seen', () => {
+    expect(describePull('ollama', new PullTracker().summary(), fmt)).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/install/pullProgress.ts
+++ b/packages/backend/src/lib/install/pullProgress.ts
@@ -1,0 +1,82 @@
+/**
+ * Aggregates an image pull's per-layer progress events into a single
+ * human-readable summary line.
+ *
+ * Podman's docker-compat `/images/create` stream emits one event per layer:
+ *   { id, status: 'Already exists' | 'Pulling fs layer' | 'Downloading' |
+ *                 'Download complete' | 'Pull complete' | …,
+ *     progressDetail: { current, total } }   // current/total only while Downloading
+ *
+ * The install runner feeds every event here and periodically logs `describe()`,
+ * so the operator always sees forward motion — including how many layers were
+ * already cached on the box — instead of a silent multi-GB pull that looks hung.
+ * Pure (no IO) so it's unit-testable against the real event shapes.
+ */
+export interface PullEvent {
+  id?: string;
+  status?: string;
+  current?: number;
+  total?: number;
+}
+
+export interface PullSummary {
+  totalLayers: number;
+  cached: number; // "Already exists" — already on the box
+  complete: number; // finished downloading/extracting this run
+  bytesCurrent: number; // downloaded so far across layers with known sizes
+  bytesTotal: number; // known total across those layers
+}
+
+const COMPLETE_STATUSES = new Set(['Download complete', 'Pull complete', 'Already exists']);
+
+export class PullTracker {
+  private readonly layers = new Map<string, { status: string; current: number; total: number }>();
+
+  update(ev: PullEvent): void {
+    if (!ev.id) return;
+    const layer = this.layers.get(ev.id) ?? { status: '', current: 0, total: 0 };
+    if (ev.status) layer.status = ev.status;
+    if (typeof ev.total === 'number' && ev.total > 0) layer.total = ev.total;
+    if (typeof ev.current === 'number') layer.current = ev.current;
+    this.layers.set(ev.id, layer);
+  }
+
+  summary(): PullSummary {
+    let cached = 0;
+    let complete = 0;
+    let bytesCurrent = 0;
+    let bytesTotal = 0;
+    for (const layer of this.layers.values()) {
+      if (layer.status === 'Already exists') {
+        cached += 1;
+        continue;
+      }
+      const done = COMPLETE_STATUSES.has(layer.status);
+      if (done) complete += 1;
+      if (layer.total > 0) {
+        bytesTotal += layer.total;
+        // A finished layer reports empty progressDetail, so credit its full size.
+        bytesCurrent += done ? layer.total : Math.min(layer.current, layer.total);
+      }
+    }
+    return { totalLayers: this.layers.size, cached, complete, bytesCurrent, bytesTotal };
+  }
+}
+
+/** Render a one-line summary. `fmtBytes` formats a byte count (injected so this
+ *  stays free of the runner's private humanBytes). Returns null before any
+ *  layer has been seen. */
+export function describePull(
+  image: string,
+  s: PullSummary,
+  fmtBytes: (n: number) => string,
+): string | null {
+  if (s.totalLayers === 0) return null;
+  const cachedNote = s.cached > 0 ? ` · ${s.cached} layer${s.cached === 1 ? '' : 's'} already cached` : '';
+  if (s.bytesTotal > 0) {
+    const pct = Math.min(100, Math.round((s.bytesCurrent / s.bytesTotal) * 100));
+    return `Pulling ${image}: ${pct}% (${fmtBytes(s.bytesCurrent)} / ${fmtBytes(s.bytesTotal)})${cachedNote}`;
+  }
+  // No byte sizes yet — layers are being enumerated / extracted.
+  return `Pulling ${image}: preparing ${s.totalLayers} layer${s.totalLayers === 1 ? '' : 's'}${cachedNote}…`;
+}

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -35,6 +35,7 @@ import {
 import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
 import { parseTemplateManifest } from '@/lib/template/contract';
 import { topoSortByDependencies, resolveAlreadyInstalled } from '@/lib/stackInstall/dependencies';
+import { PullTracker, describePull } from './pullProgress';
 import { parseTemplateTier } from '@/lib/templateTier';
 import { selectMigrationChain } from '@/lib/stackInstall/migrations';
 import {
@@ -1021,23 +1022,23 @@ async function runJob(jobId: string): Promise<void> {
     try {
       const { agentManager } = await import('@/lib/agent/manager');
       const agent = await agentManager.ensureAgent(node);
-      // Per-image progress throttle (#805). The agent emits
-      // PULL_PROGRESS every ~250ms per layer; multiply by N parallel
-      // images and the log floods. We coalesce per-image: one line
-      // every ~2s with the slowest-still-downloading layer's bytes.
-      // Skip events without total bytes (status-only updates like
-      // "Pull complete") so the line is always informative.
+      // Per-image progress (#805). The agent emits PULL_PROGRESS per layer
+      // (docker-compat stream: status + byte progress + "Already exists" for
+      // cached layers). A PullTracker aggregates layers into one coalesced
+      // line every ~2s — bytes + percent once known, otherwise a "preparing"
+      // heartbeat — so a large pull never looks hung and the operator sees how
+      // many layers were already on the box.
+      const trackers = new Map<string, PullTracker>();
       const lastEmit = new Map<string, number>();
-      const onProgress = (image: string) => (ev: { current?: number; total?: number; status?: string }) => {
-        if (!ev.total || ev.current === undefined) return;
+      const onProgress = (image: string) => (ev: { id?: string; status?: string; current?: number; total?: number }) => {
+        let tracker = trackers.get(image);
+        if (!tracker) { tracker = new PullTracker(); trackers.set(image, tracker); }
+        tracker.update(ev);
         const now = Date.now();
-        const prev = lastEmit.get(image) ?? 0;
-        if (now - prev < 2000 && ev.current < ev.total) return;
+        if (now - (lastEmit.get(image) ?? 0) < 2000) return;
         lastEmit.set(image, now);
-        const pct = Math.round((ev.current / ev.total) * 100);
-        const cur = humanBytes(ev.current);
-        const tot = humanBytes(ev.total);
-        void log(jobId, `  Pulling ${image}: ${pct}% (${cur} / ${tot})`);
+        const line = describePull(image, tracker.summary(), humanBytes);
+        if (line) void log(jobId, `  ${line}`);
       };
       const results = await Promise.allSettled(
         imagesToPull.map(image => agent.pullImage(image, onProgress(image))),
@@ -1057,7 +1058,11 @@ async function runJob(jobId: string): Promise<void> {
       });
       await log(jobId, `✅ Pulled ${okCount}/${imagesToPull.length} image${imagesToPull.length === 1 ? '' : 's'}.`);
       for (const f of failures) {
-        await log(jobId, `(note) pre-pull failed for ${f.image}: ${f.reason} — will be retried during deploy.`);
+        const s = trackers.get(f.image)?.summary();
+        const got = s && s.bytesTotal > 0
+          ? ` (reached ${humanBytes(s.bytesCurrent)}/${humanBytes(s.bytesTotal)}${s.cached ? `, ${s.cached} cached` : ''})`
+          : '';
+        await log(jobId, `(note) pre-pull failed for ${f.image}: ${f.reason}${got} — will be retried during deploy.`);
       }
     } catch (e) {
       await log(jobId, `(note) parallel pre-pull skipped: ${e instanceof Error ? e.message : String(e)} — deploy will pull sequentially as usual.`);


### PR DESCRIPTION
## What
Pre-pulling a large image (e.g. `ollama`, multi-GB) showed **no progress** then "timed out", and the un-cached image then had to be pulled during deploy — blowing past systemd's start timeout (the ollama bootstrap failure the operator saw).

**Root cause:** the agent pulled via podman's libpod `/images/pull`, which emits only opaque `{"stream": "..."}` text — no byte progress, and *no events at all* while a big blob downloads. The UI (which needs byte totals) showed nothing, and the agent's socket read-timeout tripped on the silence.

**Fix:** switch the agent to podman's **docker-compat `/images/create`** endpoint, which streams Docker-style per-layer progress (`status` + `progressDetail.current/total`, plus `"Already exists"` for cached layers). A new `PullTracker` aggregates per-layer events into one coalesced line every ~2s (percent + bytes once known, else a "preparing N layers" heartbeat) and surfaces **how many layers were already cached on the box** (the thing you asked for). Frequent events keep the socket alive, so an actively-downloading pull no longer false-times-out — only a real stall does. Failed pre-pulls now report how far they got.

## Why
Operator hit a silent timeout on a 100mb line; `ollama` (Docker Hub-throttled, multi-GB) is the worst case. Surfacing progress + cached layers + not false-timing-out also means the image actually gets pre-cached, so the deploy-time start no longer races systemd's timeout.

## Risk
Medium — changes the agent's image-pull path (install-path). Mitigated: docker-compat `/images/create` is a stable podman API; pure aggregation logic is unit-tested; behavior verified on the live box.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 403 = baseline)
- [x] npx tsc --noEmit (clean)
- [x] npm run check:arch
- [x] npm test (1451 passed; new `pullProgress` TS tests + `_split_image_ref` python test)
- [x] **Live box** (path-mandated): ran a faithful replica of the new `_do_pull` against the real podman socket — `/images/create` returned HTTP 200, emitted `Downloading` events with `current/total` (byte progress = true), `Already exists` for cached layers, and completed with no error. Confirms the exact parse/split logic the agent now uses.

## Follow-up
The `ollama.service` start-timeout (the `#1026` GPU fixup path) is a separate concern, but this fix removes its main trigger by making the pre-pull actually succeed (cached before deploy).