### PR TITLE
fix(services): retry asset write with sudo when the agent rejects on EACCES

### DIFF
--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -47,6 +47,13 @@ interface FileWritingAgent {
  * pod created. The plain write EACCESes there, so a failed write is
  * retried once via the agent's #1000 privileged path (`core` has
  * passwordless sudo on FCoS) before being recorded as a failure.
+ *
+ * #1258 — the agent rejects (the promise throws) when a command replies
+ * with an error, e.g. the EACCES above. The retry therefore has to catch
+ * the thrown error, not inspect a returned value — the original `res !==
+ * 'ok'` check never fired because the await threw first, so the raw
+ * `[Errno 13]` propagated straight to the deploy loop and the sudo retry
+ * was dead code.
  */
 export async function writeExtraConfigFiles(
     agent: FileWritingAgent,
@@ -54,20 +61,31 @@ export async function writeExtraConfigFiles(
     extraFiles: { path: string; content: string }[],
 ): Promise<void> {
     const failures: string[] = [];
+    // Returns 'ok' on success, otherwise the failure reason as a string —
+    // covering both the rejection (agent error reply) and the defensive
+    // non-'ok' return value cases.
+    const attemptWrite = async (target: { path: string; content: string }, sudo: boolean): Promise<string> => {
+        try {
+            const res = await agent.sendCommand('write_file', { path: target.path, content: target.content, ...(sudo ? { sudo: true } : {}) });
+            return res === 'ok' ? 'ok' : JSON.stringify(res);
+        } catch (err) {
+            return err instanceof Error ? err.message : String(err);
+        }
+    };
     for (const f of extraFiles) {
         // Ensure parent directory exists.
         const dir = f.path.substring(0, f.path.lastIndexOf('/'));
         if (dir) {
             await agent.sendCommand('exec', { command: `mkdir -p ${dir}` });
         }
-        let res = await agent.sendCommand('write_file', { path: f.path, content: f.content });
-        if (res !== 'ok') {
-            logger.warn('ServiceManager', `write_file for ${f.path} failed (${JSON.stringify(res)}); retrying with sudo.`);
-            res = await agent.sendCommand('write_file', { path: f.path, content: f.content, sudo: true });
+        let outcome = await attemptWrite(f, false);
+        if (outcome !== 'ok') {
+            logger.warn('ServiceManager', `write_file for ${f.path} failed (${outcome}); retrying with sudo.`);
+            outcome = await attemptWrite(f, true);
         }
-        if (res !== 'ok') {
+        if (outcome !== 'ok') {
             failures.push(f.path);
-            logger.error('ServiceManager', `Failed to write extra file ${f.path}: agent returned ${JSON.stringify(res)}`);
+            logger.error('ServiceManager', `Failed to write extra file ${f.path}: ${outcome}`);
         } else {
             logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
         }

--- a/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
@@ -8,7 +8,15 @@ vi.mock('../logger', () => ({
 type CmdParams = { path?: string; content?: string; sudo?: boolean; command?: string } | undefined;
 type Cmd = { action: string; params: CmdParams };
 
-/** Fake agent that records every sendCommand and replies via `responder`. */
+/**
+ * Fake agent that records every sendCommand and replies via `responder`.
+ *
+ * #1258 — the real `AgentHandler.sendCommand` *rejects* (throws) when the
+ * agent process replies with an `error` field; it does not resolve to an
+ * `{ error }` object. So the responder signals a command failure by
+ * THROWING, mirroring production. The earlier mock returned the error as a
+ * value, which hid the dead-retry bug.
+ */
 function makeAgent(responder: (action: string, params: CmdParams) => unknown) {
     const calls: Cmd[] = [];
     const agent = {
@@ -36,12 +44,15 @@ describe('writeExtraConfigFiles', () => {
         expect(writes[0].params?.sudo).toBeUndefined();
     });
 
-    it('retries with sudo when the plain write_file fails (EACCES on container-owned dir)', async () => {
-        // #1171 — first (unprivileged) write fails because the hostPath is
-        // owned by a consumer container's uid; the sudo retry succeeds.
+    it('retries with sudo when the plain write_file rejects (EACCES on container-owned dir)', async () => {
+        // #1171/#1258 — first (unprivileged) write rejects because the
+        // hostPath is owned by a consumer container's uid; the agent throws
+        // the raw `[Errno 13]`, and the sudo retry then succeeds. The throw
+        // (not a returned value) is the production contract — see makeAgent.
         const agent = makeAgent((action, params) => {
             if (action === 'exec') return { code: 0 };
-            return params?.sudo ? 'ok' : { error: "[Errno 13] Permission denied: '" + file.path + "'" };
+            if (params?.sudo) return 'ok';
+            throw new Error("[Errno 13] Permission denied: '" + file.path + "'");
         });
 
         await expect(writeExtraConfigFiles(agent, 'oscar-household', [file])).resolves.toBeUndefined();
@@ -52,11 +63,29 @@ describe('writeExtraConfigFiles', () => {
         expect(writes[1].params?.sudo).toBe(true);
     });
 
-    it('throws (deploy fails) when both the plain and sudo writes fail', async () => {
-        const agent = makeAgent((action) => (action === 'exec' ? { code: 0 } : { error: 'disk full' }));
+    it('throws (deploy fails) when both the plain and sudo writes reject', async () => {
+        const agent = makeAgent((action) => {
+            if (action === 'exec') return { code: 0 };
+            throw new Error('disk full');
+        });
 
         await expect(writeExtraConfigFiles(agent, 'oscar-household', [file]))
             .rejects.toThrow(/Failed to write 1 required config file/);
+
+        const writes = agent.calls.filter(c => c.action === 'write_file');
+        expect(writes).toHaveLength(2);
+        expect(writes[1].params?.sudo).toBe(true);
+    });
+
+    it('still retries with sudo on a defensive non-ok return value (no throw)', async () => {
+        // Belt-and-braces: if a future agent variant returns an error object
+        // instead of rejecting, the sudo retry must still fire.
+        const agent = makeAgent((action, params) => {
+            if (action === 'exec') return { code: 0 };
+            return params?.sudo ? 'ok' : { error: 'EACCES' };
+        });
+
+        await expect(writeExtraConfigFiles(agent, 'oscar-household', [file])).resolves.toBeUndefined();
 
         const writes = agent.calls.filter(c => c.action === 'write_file');
         expect(writes).toHaveLength(2);


### PR DESCRIPTION
## What
Make the #1171 sudo-retry in `writeExtraConfigFiles` actually fire. `AgentHandler.sendCommand` *rejects* (throws) when the agent replies with an error, so the plain `write_file` threw before the old `res !== 'ok'` check could trigger the sudo fallback — the retry was dead code and the raw `[Errno 13] Permission denied` propagated straight to the deploy-attempt loop. Now the retry catches the rejection.

## Why
Closes #1258. Every install of a template whose asset dir is hostPath-claimed by another pod first (e.g. `oscar-household` `skills/` claimed by `hermes` as a container subuid) failed with EACCES. This unblocks OSCAR install (`mdopp/oscar`).

## Risk
Low. Behaviour is purely additive on the failure path: a write that previously threw now retries via `core`'s passwordless sudo (the path #1171 already intended). The test mock was lying about the agent contract — corrected to throw on an error reply, plus a regression test proving the sudo retry fires on a thrown EACCES.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (1452 passed)
- [ ] /verify on FCoS box — N/A: `lib/services/` is not in the path-mandated list (consistent with #1171/PR #1198). The fix is exercised by a unit test that now models the real reject-on-error contract; full real-box confirmation lands at the next OSCAR install.