### PR TITLE
fix(help): dedupe and de-jargon the What's New changelog

### DIFF
--- a/packages/frontend/src/app/api/help/changelog.test.ts
+++ b/packages/frontend/src/app/api/help/changelog.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { renderChangelogForUsers } from './changelog';
+
+const SAMPLE = `# Changelog
+
+## [4.46.1](https://github.com/mdopp/servicebay/compare/a...b) (2026-05-28)
+
+
+### Bug Fixes
+
+* **install:** stream real image-pull progress with cached-layer info ([154b151](https://github.com/mdopp/servicebay/commit/154b151))
+* **install:** stream real image-pull progress with cached-layer info ([7ed65b0](https://github.com/mdopp/servicebay/commit/7ed65b0))
+* **registry:** list Stacks before Templates in the registry browser ([b7623cf](https://github.com/mdopp/servicebay/commit/b7623cf))
+* **registry:** list Stacks before Templates in the registry browser ([3d314d8](https://github.com/mdopp/servicebay/commit/3d314d8))
+`;
+
+describe('renderChangelogForUsers', () => {
+  it('collapses the duplicate squash/merge commit pairs', () => {
+    const out = renderChangelogForUsers(SAMPLE);
+    const bullets = out.split('\n').filter(l => l.trimStart().startsWith('*'));
+    expect(bullets).toHaveLength(2);
+  });
+
+  it('strips the **scope:** prefix and the trailing hash link', () => {
+    const out = renderChangelogForUsers(SAMPLE);
+    expect(out).toContain('* Stream real image-pull progress with cached-layer info');
+    expect(out).not.toContain('**install:**');
+    expect(out).not.toMatch(/\(\[[0-9a-f]+\]/); // no hash links remain
+  });
+
+  it('preserves version + section headings untouched', () => {
+    const out = renderChangelogForUsers(SAMPLE);
+    expect(out).toContain('## [4.46.1]');
+    expect(out).toContain('### Bug Fixes');
+    expect(out).toContain('# Changelog');
+  });
+
+  it('does not collapse identical subjects separated by a heading', () => {
+    const md = `### Features
+* **a:** same words ([1111111](u))
+
+### Bug Fixes
+* **b:** same words ([2222222](u))`;
+    const out = renderChangelogForUsers(md);
+    const bullets = out.split('\n').filter(l => l.trimStart().startsWith('*'));
+    expect(bullets).toHaveLength(2); // heading between them resets dedupe
+  });
+
+  it('capitalizes the first letter of each entry', () => {
+    const out = renderChangelogForUsers('* **registry:** list Stacks before Templates ([abc1234](u))');
+    expect(out).toBe('* List Stacks before Templates');
+  });
+});

--- a/packages/frontend/src/app/api/help/changelog.ts
+++ b/packages/frontend/src/app/api/help/changelog.ts
@@ -1,0 +1,52 @@
+/**
+ * Turn the raw release-please `CHANGELOG.md` into a user-facing "What's new"
+ * view (#1262). Two problems with serving it verbatim:
+ *
+ *  1. Every change appears twice — the squash-merge commit and the PR-merge
+ *     commit both carry the same conventional-commit subject, so release-please
+ *     emits a duplicate pair (identical text, different hash) per change.
+ *  2. Entries are raw commit subjects: a bold `**scope:**` prefix plus a
+ *     trailing `([hash](link))` that mean nothing to an end user.
+ *
+ * This transform dedupes consecutive identical entries (ignoring the hash) and
+ * strips the scope prefix + hash link, leaving a plain sentence. It only
+ * touches bullet lines; version headings (`## [x.y.z]`) and section headings
+ * (`### Features`) pass through untouched. We never edit CHANGELOG.md itself —
+ * release-please owns it; this is render-time only.
+ */
+
+const BULLET_RE = /^(\s*[*-]\s+)(.*)$/;
+// Trailing commit-hash link: ` ([abc1234](https://…))` or a bare ` (abc1234)`.
+const HASH_LINK_RE = /\s*\(\[[0-9a-f]{6,}\]\([^)]*\)\)\s*$/i;
+const BARE_HASH_RE = /\s*\([0-9a-f]{7,}\)\s*$/i;
+// Conventional-commit scope prefix as release-please renders it: `**scope:**`.
+const SCOPE_PREFIX_RE = /^\*\*[^*]+:\*\*\s*/;
+
+function cleanEntry(text: string): string {
+  let t = text.replace(HASH_LINK_RE, '').replace(BARE_HASH_RE, '').trim();
+  t = t.replace(SCOPE_PREFIX_RE, '').trim();
+  if (t.length > 0) t = t.charAt(0).toUpperCase() + t.slice(1);
+  return t;
+}
+
+export function renderChangelogForUsers(markdown: string): string {
+  const out: string[] = [];
+  // Dedupe is scoped to a run of bullets; a heading or blank line resets it so
+  // an unrelated later release that repeats a subject isn't swallowed.
+  let lastEntry: string | null = null;
+  for (const line of markdown.split('\n')) {
+    const m = line.match(BULLET_RE);
+    if (m) {
+      const entry = cleanEntry(m[2]);
+      if (!entry) continue;
+      const key = entry.toLowerCase();
+      if (key === lastEntry) continue; // duplicate pair — drop the second
+      lastEntry = key;
+      out.push(`${m[1]}${entry}`);
+    } else {
+      lastEntry = null;
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}

--- a/packages/frontend/src/app/api/help/route.ts
+++ b/packages/frontend/src/app/api/help/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import fs from 'fs/promises';
 import path from 'path';
 import { withApiHandler } from '@/lib/api/handler';
+import { renderChangelogForUsers } from './changelog';
 
 const HELP_ALIASES: Record<string, string> = {
   containers: 'container-engine',
@@ -26,7 +27,10 @@ export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
       : path.join(process.cwd(), 'src/content/help', `${normalizedId}.md`);
 
     try {
-      const content = await fs.readFile(filePath, 'utf-8');
+      const raw = await fs.readFile(filePath, 'utf-8');
+      // The changelog is the raw release-please file — dedupe the squash/merge
+      // commit pairs and strip developer noise before showing users (#1262).
+      const content = normalizedId === 'changelog' ? renderChangelogForUsers(raw) : raw;
       return NextResponse.json({ content });
     } catch {
       return NextResponse.json({ error: 'Help content not found' }, { status: 404 });


### PR DESCRIPTION
## What
The What's New panel served the raw release-please `CHANGELOG.md` verbatim. Add a render-time transform (`renderChangelogForUsers`) on the changelog branch of `/api/help`: collapse the duplicate squash/merge commit pairs (identical subject, different hash), strip the `**scope:**` prefix + trailing hash link, and capitalize so each entry reads as a plain sentence. Version + section headings pass through.

## Why
Closes #1262. Every change showed twice and entries read as developer commit subjects.

## Risk
Low. Pure render-time string transform on one endpoint; `CHANGELOG.md` itself is untouched (stays release-please's). Covered by 5 unit tests (dedupe / prefix+hash strip / heading preservation / no cross-heading collapse / capitalization).

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 401 — no increase)
- [x] npm run check:arch
- [x] npm test (1462 passed)
- [ ] /verify on FCoS box — N/A: `app/api/help/` is not path-mandated (not portal/(dashboard)/dashboards); panel just renders the API response.