### PR TITLE
feat(mcp): add reboot_node tool with SSH fallback

### DIFF
--- a/packages/backend/src/lib/agent/handler.ts
+++ b/packages/backend/src/lib/agent/handler.ts
@@ -706,6 +706,45 @@ export class AgentHandler extends EventEmitter {
       await this.start();
     }
 
+  /**
+   * Reboot the underlying node now (#1235). Distinct from `restart()`, which
+   * only restarts the agent process, and from `set_boot_next_usb`, which
+   * changes boot order. The reboot tears its own transport down, so we fire
+   * the command and report which path was used rather than awaiting a reply
+   * that will never arrive.
+   *
+   * Primary path is the agent's `exec` channel. When the agent process is
+   * unreachable but the box itself is up — the recovery case the launcher
+   * (#1231) needs — fall back to a direct SSH exec via the connection pool.
+   */
+  public async rebootNode(): Promise<{ via: 'agent' | 'ssh' }> {
+      if (this.isConnected) {
+          this.sendCommand('exec', { command: 'sudo -n systemctl reboot' })
+              .catch(() => { /* connection drop mid-reboot is expected */ });
+          this.log(this.nodeName, 'info', 'Reboot initiated via agent exec.');
+          return { via: 'agent' };
+      }
+      this.log(this.nodeName, 'warn', 'Agent not connected; rebooting via direct SSH.');
+      await this.rebootViaSsh();
+      return { via: 'ssh' };
+  }
+
+  private async rebootViaSsh(): Promise<void> {
+      const conn = await SSHConnectionPool.getInstance().getConnection(this.nodeName);
+      await new Promise<void>((resolve, reject) => {
+          conn.exec('sudo -n systemctl reboot', (err, stream) => {
+              if (err) { reject(err); return; }
+              // The reboot drops the link, so resolve on close/error rather
+              // than waiting for a clean exit, with a short timeout so a stuck
+              // channel can't hang the caller.
+              const done = () => resolve();
+              stream.on('close', done);
+              stream.on('error', done);
+              setTimeout(done, 5000);
+          });
+      });
+  }
+
   public disconnect() {
       if (this.channel) {
           this.channel.close(); // sends EOF

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -69,7 +69,7 @@ const MUTATING_TOOLS = new Set([
   'run_backup', 'restore_backup',
   'update_config', 'exec_command', 'refresh_agent',
   'merge_unmanaged_bundle',
-  'set_boot_next_usb',
+  'set_boot_next_usb', 'reboot_node',
 ]);
 
 /**
@@ -110,7 +110,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   delete_service: 'destroy', delete_health_check: 'destroy',
   remove_proxy_route: 'destroy', restore_backup: 'destroy',
   purge_trashed_service: 'destroy',
-  set_boot_next_usb: 'destroy',
+  set_boot_next_usb: 'destroy', reboot_node: 'destroy',
   // exec (shell — own scope so tokens can grant config writes without it)
   exec_command: 'exec',
 };
@@ -1148,6 +1148,33 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
           success: true,
           bootNum: targetBootNum,
           message: reboot ? 'One-shot BootNext set. System is rebooting.' : 'One-shot BootNext set successfully.',
+        });
+      } catch (err: unknown) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  // --- Reboot Node (#1235) ---
+  // Plain node reboot, distinct from set_boot_next_usb (no boot-order change).
+  // Gated under 'destroy' scope + allowMutations. Not in DESTRUCTIVE_TOOLS: a
+  // reboot doesn't mutate disk, so a pre-mutation snapshot would be wasted work
+  // and would delay the reboot. The agent layer falls back to a direct SSH
+  // reboot when the agent process itself is unreachable.
+  server.tool(
+    'reboot_node',
+    'Reboot a node now. Distinct from set_boot_next_usb — this does not change boot order. Falls back to a direct SSH reboot when the agent process is unreachable but the box is up.',
+    { node: nodeParam },
+    async ({ node }) => {
+      const nodeName = await resolveNode(node);
+      try {
+        const agent = agentManager.getAgent(nodeName);
+        const { via } = await agent.rebootNode();
+        return textResult({
+          success: true,
+          node: nodeName,
+          via,
+          message: `Reboot initiated on ${nodeName} (via ${via}). The node will be unreachable for a short while.`,
         });
       } catch (err: unknown) {
         return errorResult(err instanceof Error ? err.message : String(err));

--- a/tests/backend/mcp_token_scopes.test.ts
+++ b/tests/backend/mcp_token_scopes.test.ts
@@ -29,6 +29,10 @@ describe('MCP scope mapping (#591)', () => {
     expect(TOOL_SCOPES.set_boot_next_usb).toBe('destroy');
   });
 
+  it('reboot_node is destroy (#1235)', () => {
+    expect(TOOL_SCOPES.reboot_node).toBe('destroy');
+  });
+
   it('every entry uses one of the five known scopes', () => {
     const known: ReadonlySet<ApiScope> = new Set<ApiScope>(['read', 'lifecycle', 'mutate', 'destroy', 'exec']);
     for (const [tool, scope] of Object.entries(TOOL_SCOPES)) {


### PR DESCRIPTION
## What
A dedicated `reboot_node` MCP tool. `AgentHandler.rebootNode` reboots via the agent `exec` channel when connected, and falls back to a direct SSH exec (via the connection pool) when the agent process is unreachable but the box is up. Gated under `destroy` scope + `allowMutations`.

## Why
Closes #1235. Today a reboot only happens as a side effect of `set_boot_next_usb` or via `exec_command "systemctl reboot"`. The launcher (#1231) and LLM-driven recovery need a plain, intent-clear reboot.

## Risk
Medium — it reboots the node. Not in `DESTRUCTIVE_TOOLS` (a reboot doesn't mutate disk, so a pre-mutation snapshot would be wasted work + delay the reboot); it's still gated behind the strongest scope (`destroy`) + the `allowMutations` switch, and audit-logged.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 401 — no increase)
- [x] npm run check:arch
- [x] npm test (1463 passed; reboot_node pinned as `destroy` in the scope test)
- [ ] /verify on FCoS box — **path-mandated (lib/mcp/ + lib/agent/), and the verify is an actual node reboot.** Pending operator go-ahead on timing (production box). Will confirm: agent-path reboot succeeds + the node comes back.