### PR TITLE
feat(mcp): add verify_usb_boot reinstall-readiness check

### DIFF
--- a/packages/backend/src/lib/mcp/efibootmgr.test.ts
+++ b/packages/backend/src/lib/mcp/efibootmgr.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
+
+// Representative `efibootmgr -v` output: an OS entry, an active USB entry,
+// and an inactive removable entry. BootCurrent appears after the Boot#### rows.
+const WITH_ACTIVE_USB = `BootNext: 0003
+BootOrder: 0000,0003
+Boot0000* Fedora\tHD(1,GPT,abc)/File(\\EFI\\fedora\\shimx64.efi)
+Boot0003* USB Device\tPciRoot(0x0)/Pci(0x14,0x0)/USB(0,0)
+BootCurrent: 0000`;
+
+const INACTIVE_USB = `BootOrder: 0000
+Boot0000* Fedora\tHD(1,GPT,abc)/File(\\EFI\\fedora\\shimx64.efi)
+Boot0007  Removable Media\tPciRoot(0x0)/USB(1,0)
+BootCurrent: 0000`;
+
+const NO_USB = `BootOrder: 0000
+Boot0000* Fedora\tHD(1,GPT,abc)/File(\\EFI\\fedora\\shimx64.efi)
+BootCurrent: 0000`;
+
+describe('parseEfibootmgr', () => {
+  it('parses entries, BootNext/Current/Order and stamps `current`', () => {
+    const p = parseEfibootmgr(WITH_ACTIVE_USB);
+    expect(p.bootNext).toBe('0003');
+    expect(p.bootCurrent).toBe('0000');
+    expect(p.bootOrder).toEqual(['0000', '0003']);
+    expect(p.entries).toHaveLength(2);
+    expect(p.entries.find(e => e.bootNum === '0000')?.current).toBe(true);
+    expect(p.entries.find(e => e.bootNum === '0003')?.active).toBe(true);
+  });
+
+  it('flags USB-ish entries as candidates', () => {
+    const p = parseEfibootmgr(WITH_ACTIVE_USB);
+    expect(p.candidates.map(c => c.bootNum)).toContain('0003');
+  });
+});
+
+describe('assessUsbBootReadiness', () => {
+  it('ready when an active USB/removable entry exists', () => {
+    const r = assessUsbBootReadiness(parseEfibootmgr(WITH_ACTIVE_USB));
+    expect(r.reinstallReady).toBe(true);
+    expect(r.activeUsbEntries.map(e => e.bootNum)).toEqual(['0003']);
+    expect(r.hint).toBeUndefined();
+  });
+
+  it('not ready + hints to activate when a USB entry exists but is inactive', () => {
+    const r = assessUsbBootReadiness(parseEfibootmgr(INACTIVE_USB));
+    expect(r.reinstallReady).toBe(false);
+    expect(r.usbCandidates.map(e => e.bootNum)).toEqual(['0007']);
+    expect(r.hint).toMatch(/inactive/i);
+  });
+
+  it('not ready + hints to insert media when no USB entry exists', () => {
+    const r = assessUsbBootReadiness(parseEfibootmgr(NO_USB));
+    expect(r.reinstallReady).toBe(false);
+    expect(r.usbCandidates).toHaveLength(0);
+    expect(r.hint).toMatch(/insert the installation usb/i);
+  });
+});

--- a/packages/backend/src/lib/mcp/efibootmgr.ts
+++ b/packages/backend/src/lib/mcp/efibootmgr.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure parsing + readiness assessment for `efibootmgr -v` output (#1236).
+ *
+ * Extracted from the inline parsing in the `set_boot_next_usb` MCP tool so
+ * both that tool's `list` action and the new `verify_usb_boot` readiness
+ * check share one implementation — and so the (fiddly) parsing is unit
+ * testable without an agent or a real UEFI box.
+ */
+
+export interface EfiBootEntry {
+  bootNum: string;
+  name: string;
+  active: boolean;
+  description: string;
+  current: boolean;
+}
+
+export interface ParsedEfibootmgr {
+  entries: EfiBootEntry[];
+  candidates: EfiBootEntry[];
+  bootNext: string | null;
+  bootCurrent: string | null;
+  bootOrder: string[];
+}
+
+/** A boot entry that looks like it boots from removable/USB media. */
+export function isUsbBootEntry(description: string): boolean {
+  const d = description.toLowerCase();
+  return d.includes('usb') ||
+    d.includes('removable') ||
+    d.includes('disk') ||
+    description.includes('\\EFI\\boot\\');
+}
+
+/** Tighter than `isUsbBootEntry` — removable media only, excluding the
+ *  broad `disk`/`\EFI\boot\` heuristics — used for the reinstall-ready
+ *  verdict so an internal disk entry doesn't read as "USB ready". */
+export function isRemovableBootEntry(description: string): boolean {
+  const d = description.toLowerCase();
+  return d.includes('usb') || d.includes('removable');
+}
+
+export function parseEfibootmgr(stdout: string): ParsedEfibootmgr {
+  const entries: EfiBootEntry[] = [];
+  let bootNext: string | null = null;
+  let bootCurrent: string | null = null;
+  let bootOrder: string[] = [];
+
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('BootNext:')) {
+      bootNext = line.replace('BootNext:', '').trim();
+    } else if (line.startsWith('BootCurrent:')) {
+      bootCurrent = line.replace('BootCurrent:', '').trim();
+    } else if (line.startsWith('BootOrder:')) {
+      bootOrder = line.replace('BootOrder:', '').trim().split(',').filter(Boolean);
+    } else if (line.startsWith('Boot')) {
+      const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
+      if (match) {
+        const [, num, star, description] = match;
+        entries.push({
+          bootNum: num,
+          name: description.split('\t')[0] || description,
+          active: star === '*',
+          description,
+          current: bootCurrent === num,
+        });
+      }
+    }
+  }
+
+  // `current` is resolved against bootCurrent, which may appear after the
+  // Boot#### lines — re-stamp once we've seen the whole table.
+  for (const e of entries) e.current = bootCurrent === e.bootNum;
+
+  const candidates = entries.filter(e => isUsbBootEntry(e.description));
+  return { entries, candidates, bootNext, bootCurrent, bootOrder };
+}
+
+export interface UsbBootReadiness {
+  reinstallReady: boolean;
+  activeUsbEntries: EfiBootEntry[];
+  usbCandidates: EfiBootEntry[];
+  hint?: string;
+}
+
+/**
+ * Decide whether the firmware can actually boot from USB for a reinstall.
+ * Ready means: at least one removable/USB UEFI entry exists AND is active
+ * (the `*` flag) — an inactive entry won't be booted.
+ */
+export function assessUsbBootReadiness(parsed: ParsedEfibootmgr): UsbBootReadiness {
+  const usbCandidates = parsed.entries.filter(e => isRemovableBootEntry(e.description));
+  const activeUsbEntries = usbCandidates.filter(e => e.active);
+  const reinstallReady = activeUsbEntries.length > 0;
+
+  let hint: string | undefined;
+  if (usbCandidates.length === 0) {
+    hint = 'No USB/removable UEFI boot entry found. Insert the installation USB and re-check; the firmware only lists removable entries when media is present.';
+  } else if (!reinstallReady) {
+    const nums = usbCandidates.map(e => e.bootNum).join(', ');
+    hint = `A USB boot entry exists (Boot${nums}) but is inactive. Activate it with \`efibootmgr -a -b <num>\` before relying on a reinstall, or use set_boot_next_usb which activates + sets BootNext.`;
+  }
+
+  return { reinstallReady, activeUsbEntries, usbCandidates, hint };
+}

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -32,6 +32,7 @@ import { recordAudit } from './audit';
 import { notifyDestructiveOp } from './notify';
 import { redactLogText, redactServiceFiles } from './redact';
 import type { ApiScope } from './tokens';
+import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
 
 interface McpAuthContext {
   user: string;
@@ -93,6 +94,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   get_gateway_status: 'read', get_proxy_routes: 'read', get_config: 'read',
   get_podman_logs: 'read', list_system_services: 'read',
   list_backups: 'read', diagnose: 'read', verify_node_connection: 'read',
+  verify_usb_boot: 'read',
   list_trashed_services: 'read',
   get_unmanaged_bundles: 'read',
   // lifecycle
@@ -1068,43 +1070,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
           if (res.code !== 0) {
             return errorResult('Failed to query efibootmgr');
           }
-          const stdout = res.stdout ?? '';
-          const entries: Array<{ bootNum: string; name: string; active: boolean; description: string; current: boolean }> = [];
-          const lines = stdout.split('\n');
-          let bootNext: string | null = null;
-          let bootCurrent: string | null = null;
-          let bootOrder: string[] = [];
-          
-          for (const line of lines) {
-            if (line.startsWith('BootNext:')) {
-              bootNext = line.replace('BootNext:', '').trim();
-            } else if (line.startsWith('BootCurrent:')) {
-              bootCurrent = line.replace('BootCurrent:', '').trim();
-            } else if (line.startsWith('BootOrder:')) {
-              bootOrder = line.replace('BootOrder:', '').trim().split(',');
-            } else if (line.startsWith('Boot')) {
-              const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
-              if (match) {
-                const num = match[1];
-                const active = match[2] === '*';
-                const description = match[3];
-                entries.push({
-                  bootNum: num,
-                  name: description.split('\t')[0] || description,
-                  active,
-                  description,
-                  current: bootCurrent === num,
-                });
-              }
-            }
-          }
-          const candidates = entries.filter(e => 
-            e.description.toLowerCase().includes('usb') || 
-            e.description.toLowerCase().includes('removable') ||
-            e.description.toLowerCase().includes('disk') ||
-            e.description.includes('\\EFI\\boot\\')
-          );
-          return textResult({ entries, candidates, bootNext, bootCurrent, bootOrder });
+          return textResult(parseEfibootmgr(res.stdout ?? ''));
         }
         
         // action === 'set'
@@ -1148,6 +1114,40 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
           success: true,
           bootNum: targetBootNum,
           message: reboot ? 'One-shot BootNext set. System is rebooting.' : 'One-shot BootNext set successfully.',
+        });
+      } catch (err: unknown) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  // --- Verify USB boot reinstall-readiness (#1236) ---
+  // Read-only: reports whether the firmware has an active USB/removable UEFI
+  // entry to boot from, so the launcher (#1231) can confirm "reinstall-ready"
+  // (and surface a fix when it isn't) BEFORE setting BootNext + rebooting.
+  server.tool(
+    'verify_usb_boot',
+    'Check whether the node can boot from USB for a reinstall: reports if an active USB/removable UEFI boot entry exists, with a fix hint when it does not. Read-only; does not change boot order.',
+    { node: nodeParam },
+    async ({ node }) => {
+      const nodeName = await resolveNode(node);
+      try {
+        const agent = agentManager.getAgent(nodeName);
+        const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
+        if (res.code !== 0) {
+          return errorResult('Failed to query efibootmgr (is this a UEFI node with efibootmgr installed?)');
+        }
+        const parsed = parseEfibootmgr(res.stdout ?? '');
+        const readiness = assessUsbBootReadiness(parsed);
+        return textResult({
+          node: nodeName,
+          reinstallReady: readiness.reinstallReady,
+          activeUsbEntries: readiness.activeUsbEntries,
+          usbCandidates: readiness.usbCandidates,
+          bootNext: parsed.bootNext,
+          bootCurrent: parsed.bootCurrent,
+          bootOrder: parsed.bootOrder,
+          ...(readiness.hint ? { hint: readiness.hint } : {}),
         });
       } catch (err: unknown) {
         return errorResult(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## What
A read-only `verify_usb_boot` MCP tool: parses `efibootmgr -v` and reports whether the firmware has an **active** USB/removable UEFI entry to boot from, with a fix hint when it doesn't. Extracts the parsing (previously inline in `set_boot_next_usb`) into a unit-tested `efibootmgr.ts` helper, reused by `set_boot_next_usb`'s `list`.

## Why
Closes #1236. The launcher (#1231) needs to confirm "reinstall-ready" before setting BootNext + rebooting; nothing verified USB-boot reachability before.

## Risk
Low. Read-only (`read` scope, no mutation); the `set_boot_next_usb` refactor is behaviour-preserving for the `list` action. 5 unit tests on parse + readiness verdicts.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 401 — no increase)
- [x] npm run check:arch
- [x] npm test (1468 passed)
- [ ] /verify on FCoS box — path-mandated (lib/mcp/) but **read-only**: confirm the tool's parse + readiness verdict matches the box's real `efibootmgr -v`.