### PR TITLE
feat(mcp): add guarded factory_reset tool

### DIFF
--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -33,6 +33,7 @@ import { notifyDestructiveOp } from './notify';
 import { redactLogText, redactServiceFiles } from './redact';
 import type { ApiScope } from './tokens';
 import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
+import { performStackReset, StackResetError } from '@/lib/install/performStackReset';
 
 interface McpAuthContext {
   user: string;
@@ -70,7 +71,7 @@ const MUTATING_TOOLS = new Set([
   'run_backup', 'restore_backup',
   'update_config', 'exec_command', 'refresh_agent',
   'merge_unmanaged_bundle',
-  'set_boot_next_usb', 'reboot_node',
+  'set_boot_next_usb', 'reboot_node', 'factory_reset',
 ]);
 
 /**
@@ -113,6 +114,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   remove_proxy_route: 'destroy', restore_backup: 'destroy',
   purge_trashed_service: 'destroy',
   set_boot_next_usb: 'destroy', reboot_node: 'destroy',
+  factory_reset: 'destroy',
   // exec (shell — own scope so tokens can grant config writes without it)
   exec_command: 'exec',
 };
@@ -149,6 +151,7 @@ const DESTRUCTIVE_TOOLS = new Set([
   'update_config', 'exec_command',
   'merge_unmanaged_bundle',
   'set_boot_next_usb',
+  'factory_reset',
 ]);
 
 /**
@@ -1177,6 +1180,41 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
           message: `Reboot initiated on ${nodeName} (via ${via}). The node will be unreachable for a short while.`,
         });
       } catch (err: unknown) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  // --- Factory Reset (#1237) ---
+  // Highest blast radius: wraps performStackReset (the same engine behind
+  // /api/system/stacks/reset, which has caused total data loss). Guards:
+  //   - destroy scope + allowMutations (safeHandler)
+  //   - DESTRUCTIVE_TOOLS ⇒ automatic pre-reset system snapshot + operator email
+  //   - `confirm` must EXACTLY equal the node name, and `node` is required
+  //     (no first-node default) so it can't fire on the wrong/implicit box
+  //   - preserve defaults to performStackReset's safe DEFAULT_PRESERVE; pass
+  //     [] for a full nuke. The engine's own path-whitelist + validation gate
+  //     still apply underneath.
+  server.tool(
+    'factory_reset',
+    'DESTRUCTIVE: reset a node toward factory state via the stack-reset engine — stops and removes all non-protected services and wipes their data under DATA_DIR. `confirm` must exactly equal the node name to proceed. Takes an automatic pre-reset snapshot. `preserve` keeps reset groups (omit for the safe default; pass [] for a full wipe).',
+    {
+      node: z.string().min(1).describe('Node to factory-reset. Required — there is deliberately no default for a node-wide wipe.'),
+      confirm: z.string().describe('Must exactly equal `node` to confirm intent. Any mismatch refuses the reset.'),
+      preserve: z.array(z.string()).optional().describe('Reset groups to preserve. Omit for the safe default-preserve set; pass [] for a full nuke.'),
+    },
+    async ({ node, confirm, preserve }) => {
+      if (confirm !== node) {
+        return errorResult(
+          `Refusing factory reset: \`confirm\` must exactly equal the node name "${node}". ` +
+          `This stops + removes every non-protected service on the node and wipes its data.`,
+        );
+      }
+      try {
+        const result = await performStackReset({ node, preserve });
+        return textResult({ success: true, ...result });
+      } catch (err: unknown) {
+        if (err instanceof StackResetError) return errorResult(err.message);
         return errorResult(err instanceof Error ? err.message : String(err));
       }
     },

--- a/tests/backend/mcp_token_scopes.test.ts
+++ b/tests/backend/mcp_token_scopes.test.ts
@@ -33,6 +33,10 @@ describe('MCP scope mapping (#591)', () => {
     expect(TOOL_SCOPES.reboot_node).toBe('destroy');
   });
 
+  it('factory_reset is destroy (#1237)', () => {
+    expect(TOOL_SCOPES.factory_reset).toBe('destroy');
+  });
+
   it('every entry uses one of the five known scopes', () => {
     const known: ReadonlySet<ApiScope> = new Set<ApiScope>(['read', 'lifecycle', 'mutate', 'destroy', 'exec']);
     for (const [tool, scope] of Object.entries(TOOL_SCOPES)) {


### PR DESCRIPTION
## What
A `factory_reset` MCP tool wrapping the `performStackReset` engine (the wipe behind `/api/system/stacks/reset`) for the launcher (#1231), with guards proportional to the blast radius:
- `destroy` scope + `allowMutations` gate
- `DESTRUCTIVE_TOOLS`: automatic pre-reset system snapshot + operator email
- **`confirm` must exactly equal the node name**, and **`node` is required** (no first-node default) — can't fire on the wrong/implicit box
- `preserve` defaults to the engine's safe `DEFAULT_PRESERVE`; full nuke is an explicit `preserve: []`

## Why
Closes #1237. The only reset path today is the HTTP route; the launcher has no guarded MCP factory-reset intent.

## Risk
**Highest blast radius in the codebase** — this is why it's a `security`-gated **draft** for your review, not auto-merged. The engine's safe-path whitelist + validation gate still apply underneath. Please scrutinize the confirm guard + the default-preserve choice.

## Rollback
`git revert` is enough (no caller invokes it yet).

## Verification
- [x] npm run lint (0 errors, 401 — no increase)
- [x] npm run check:arch (no new dependency cycles; mcp→install allowed)
- [x] npm test (1469 passed; factory_reset pinned `destroy` in the scope test)
- [ ] Real-box /verify — **deliberately NOT run**: verifying a factory reset means nuking the production box. Draft + human review is the gate; exercise on a disposable/reinstall box only.