### PR TITLE
feat(tui-go): build-leg install-settings model

### DIFF
--- a/tools/sb-tui/internal/build/settings.go
+++ b/tools/sb-tui/internal/build/settings.go
@@ -1,0 +1,180 @@
+// Package build is the native ISO-build leg of the launcher (#1278), porting
+// install-fedora-coreos.sh to Go in dependency-ordered pieces. This first
+// module is the settings model: the non-secret install configuration that
+// persists across runs in build/fcos/install-settings.env.
+//
+// Secrets (the host console password, the ServiceBay admin password, the MCP
+// bootstrap token) are deliberately NOT modelled here — they're generated
+// fresh on every run (#1284, ported in #1290) so they never touch this file.
+// Mirrors the bash PERSISTED_SETTINGS list + load_setting/save_settings.
+package build
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// Settings is the persisted, non-secret install-build configuration. Field
+// order in fieldBindings mirrors the bash PERSISTED_SETTINGS array so the
+// saved file round-trips byte-stably.
+type Settings struct {
+	ServerName          string
+	HostUser            string
+	SSHAuthorizedKey    string
+	NetInterface        string
+	StaticIP            string
+	StaticPrefix        string
+	Gateway             string
+	DNSServers          string
+	ServicebayPort      string
+	ServicebayChannel   string
+	ServicebayAdminUser string
+	PublicDomain        string
+	GWHost              string
+	GWUser              string
+	EnableRegistries    string
+	EnableOscarRegistry string
+	EnableEmail         string
+	EmailHost           string
+	EmailPort           string
+	EmailSecure         string
+	EmailUser           string
+	EmailFrom           string
+	EmailRecipients     string
+	AuthSecret          string
+}
+
+// DefaultPort is the ServiceBay HTTP port baked into a build when the operator
+// doesn't override it. Matches probes.ResolveTarget's fallback.
+const DefaultPort = "5888"
+
+// DefaultHostUser is the FCoS host/console account name.
+const DefaultHostUser = "core"
+
+// fieldBindings is the single source of truth pairing each env-file key with
+// its struct field, in PERSISTED_SETTINGS order. Add/remove a setting here and
+// the parse + render + the saved round-trip all pick it up — exactly the
+// "touch one place" property the bash schema array had.
+func (s *Settings) fieldBindings() []struct {
+	key string
+	ptr *string
+} {
+	return []struct {
+		key string
+		ptr *string
+	}{
+		{"SERVER_NAME", &s.ServerName},
+		{"HOST_USER", &s.HostUser},
+		{"SSH_AUTHORIZED_KEY", &s.SSHAuthorizedKey},
+		{"NET_INTERFACE", &s.NetInterface},
+		{"STATIC_IP", &s.StaticIP},
+		{"STATIC_PREFIX", &s.StaticPrefix},
+		{"GATEWAY", &s.Gateway},
+		{"DNS_SERVERS", &s.DNSServers},
+		{"SERVICEBAY_PORT", &s.ServicebayPort},
+		{"SERVICEBAY_CHANNEL", &s.ServicebayChannel},
+		{"SERVICEBAY_ADMIN_USER", &s.ServicebayAdminUser},
+		{"PUBLIC_DOMAIN", &s.PublicDomain},
+		{"GW_HOST", &s.GWHost},
+		{"GW_USER", &s.GWUser},
+		{"ENABLE_REGISTRIES", &s.EnableRegistries},
+		{"ENABLE_OSCAR_REGISTRY", &s.EnableOscarRegistry},
+		{"ENABLE_EMAIL", &s.EnableEmail},
+		{"EMAIL_HOST", &s.EmailHost},
+		{"EMAIL_PORT", &s.EmailPort},
+		{"EMAIL_SECURE", &s.EmailSecure},
+		{"EMAIL_USER", &s.EmailUser},
+		{"EMAIL_FROM", &s.EmailFrom},
+		{"EMAIL_RECIPIENTS", &s.EmailRecipients},
+		{"AUTH_SECRET", &s.AuthSecret},
+	}
+}
+
+// ParseSettings reads KEY=value lines into a Settings. Unknown keys are
+// ignored (so a key dropped from the schema is silently forgotten on the next
+// save, matching the bash behaviour); blank lines and `#` comments are
+// skipped. The value is everything after the first `=`, verbatim (no trim) so
+// base64 AUTH_SECRETs and space-bearing SSH keys survive intact.
+func ParseSettings(raw string) Settings {
+	var s Settings
+	index := map[string]*string{}
+	for _, b := range s.fieldBindings() {
+		index[b.key] = b.ptr
+	}
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // SSH keys / certs can be long
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\r")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		if ptr, ok := index[line[:eq]]; ok {
+			*ptr = line[eq+1:]
+		}
+	}
+	return s
+}
+
+// Render serialises the settings as KEY=value lines in PERSISTED_SETTINGS
+// order — an empty field renders `KEY=` (not `KEY`), matching save_settings.
+func (s Settings) Render() string {
+	var b strings.Builder
+	for _, fb := range s.fieldBindings() {
+		b.WriteString(fb.key)
+		b.WriteByte('=')
+		b.WriteString(*fb.ptr)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// Load reads settings from path. A missing file is not an error — it yields a
+// zero Settings (the "no saved settings yet" first-run case); the caller layers
+// defaults/prompts on top.
+func Load(path string) (Settings, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Settings{}, nil
+		}
+		return Settings{}, err
+	}
+	return ParseSettings(string(raw)), nil
+}
+
+// Save writes the settings to path (0600 — it can carry the LAN topology and
+// admin username, and lives next to generated secrets/ISOs in the gitignored
+// build dir).
+func (s Settings) Save(path string) error {
+	return os.WriteFile(path, []byte(s.Render()), 0o600)
+}
+
+// WithDefaults returns a copy with the two stable non-empty defaults applied to
+// any empty field: the host account name and the ServiceBay port. The rest of
+// the settings are gathered interactively (a later #1278 child owns the Go
+// prompt flow), so they have no fixed default here.
+func (s Settings) WithDefaults() Settings {
+	if s.HostUser == "" {
+		s.HostUser = DefaultHostUser
+	}
+	if s.ServicebayPort == "" {
+		s.ServicebayPort = DefaultPort
+	}
+	return s
+}
+
+// Target returns the box address these settings describe: the static IP and
+// the ServiceBay port (falling back to DefaultPort). Host is "" when no static
+// IP is set. This is the file-derived half of probes.ResolveTarget.
+func (s Settings) Target() (host, port string) {
+	port = s.ServicebayPort
+	if port == "" {
+		port = DefaultPort
+	}
+	return s.StaticIP, port
+}

--- a/tools/sb-tui/internal/build/settings_test.go
+++ b/tools/sb-tui/internal/build/settings_test.go
@@ -1,0 +1,121 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSettings(t *testing.T) {
+	raw := strings.Join([]string{
+		"# a comment",
+		"",
+		"SERVER_NAME=oscar",
+		"HOST_USER=core",
+		"STATIC_IP=192.168.178.100",
+		"SERVICEBAY_PORT=5888",
+		"PUBLIC_DOMAIN=home.example.com",
+		"UNKNOWN_KEY=ignored",      // unknown → dropped
+		"AUTH_SECRET=ab=cd+ef/gh=", // value with '=' and base64 chars survives
+		"SSH_AUTHORIZED_KEY=ssh-ed25519 AAAA bob@host", // spaces survive
+	}, "\n")
+
+	s := ParseSettings(raw)
+	if s.ServerName != "oscar" || s.HostUser != "core" || s.StaticIP != "192.168.178.100" {
+		t.Fatalf("core fields wrong: %+v", s)
+	}
+	if s.AuthSecret != "ab=cd+ef/gh=" {
+		t.Errorf("value with = not preserved verbatim: %q", s.AuthSecret)
+	}
+	if s.SSHAuthorizedKey != "ssh-ed25519 AAAA bob@host" {
+		t.Errorf("ssh key with spaces not preserved: %q", s.SSHAuthorizedKey)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	s := Settings{
+		ServerName:     "oscar",
+		HostUser:       "core",
+		StaticIP:       "10.0.0.5",
+		ServicebayPort: "5888",
+		DNSServers:     "1.1.1.1,8.8.8.8",
+	}
+	got := ParseSettings(s.Render())
+	if got != s {
+		t.Fatalf("round-trip mismatch:\n in:  %+v\n out: %+v", s, got)
+	}
+}
+
+func TestRenderOrderAndEmpties(t *testing.T) {
+	out := Settings{ServerName: "x"}.Render()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 24 {
+		t.Fatalf("expected 24 keys, got %d", len(lines))
+	}
+	if lines[0] != "SERVER_NAME=x" {
+		t.Errorf("first line should be SERVER_NAME: %q", lines[0])
+	}
+	if lines[len(lines)-1] != "AUTH_SECRET=" {
+		t.Errorf("last line should be empty AUTH_SECRET=: %q", lines[len(lines)-1])
+	}
+	if !strings.Contains(out, "HOST_USER=\n") {
+		t.Error("empty field should render KEY= (not bare KEY)")
+	}
+}
+
+func TestLoadMissingFileIsZero(t *testing.T) {
+	s, err := Load(filepath.Join(t.TempDir(), "does-not-exist.env"))
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if s != (Settings{}) {
+		t.Errorf("missing file should yield zero Settings, got %+v", s)
+	}
+}
+
+func TestSaveLoadFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "install-settings.env")
+	want := Settings{ServerName: "oscar", HostUser: "core", StaticIP: "10.0.0.9", ServicebayPort: "5888"}
+	if err := want.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("settings file should be 0600, got %v", fi.Mode().Perm())
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got != want {
+		t.Errorf("load mismatch:\n want %+v\n got  %+v", want, got)
+	}
+}
+
+func TestWithDefaults(t *testing.T) {
+	d := Settings{}.WithDefaults()
+	if d.HostUser != DefaultHostUser || d.ServicebayPort != DefaultPort {
+		t.Fatalf("defaults not applied: %+v", d)
+	}
+	// Non-empty values are preserved.
+	keep := Settings{HostUser: "admin", ServicebayPort: "9999"}.WithDefaults()
+	if keep.HostUser != "admin" || keep.ServicebayPort != "9999" {
+		t.Errorf("defaults overrode set values: %+v", keep)
+	}
+}
+
+func TestTarget(t *testing.T) {
+	h, p := Settings{StaticIP: "10.0.0.5", ServicebayPort: "8080"}.Target()
+	if h != "10.0.0.5" || p != "8080" {
+		t.Errorf("target wrong: %s:%s", h, p)
+	}
+	// Empty port falls back to default; empty IP stays empty.
+	h, p = Settings{}.Target()
+	if h != "" || p != DefaultPort {
+		t.Errorf("target fallback wrong: %q:%q", h, p)
+	}
+}

--- a/tools/sb-tui/internal/probes/probes.go
+++ b/tools/sb-tui/internal/probes/probes.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
+	"servicebay-tui/internal/build"
 	"servicebay-tui/internal/phase"
 )
 
@@ -49,11 +49,6 @@ func ISOBuilt() bool {
 	return false
 }
 
-var (
-	reStaticIP = regexp.MustCompile(`(?m)^STATIC_IP=(.*)$`)
-	rePort     = regexp.MustCompile(`(?m)^SERVICEBAY_PORT=(.*)$`)
-)
-
 // Target is the resolved box address.
 type Target struct {
 	Host string
@@ -61,26 +56,23 @@ type Target struct {
 }
 
 // ResolveTarget picks the box address: explicit SB_HOST/SB_PORT env wins, else
-// the values parsed from install-settings.env, else the default port. Host is
-// "" when unknown.
+// the values from install-settings.env (parsed via the build-leg settings
+// model, #1289), else the default port. Host is "" when unknown.
 func ResolveTarget() Target {
 	host, port := os.Getenv("SB_HOST"), os.Getenv("SB_PORT")
 	if host == "" || port == "" {
-		if raw, err := os.ReadFile(settingsFile()); err == nil {
+		if s, err := build.Load(settingsFile()); err == nil {
+			fileHost, filePort := s.Target()
 			if host == "" {
-				if m := reStaticIP.FindSubmatch(raw); m != nil {
-					host = strings.TrimSpace(string(m[1]))
-				}
+				host = strings.TrimSpace(fileHost)
 			}
 			if port == "" {
-				if m := rePort.FindSubmatch(raw); m != nil {
-					port = strings.TrimSpace(string(m[1]))
-				}
+				port = strings.TrimSpace(filePort)
 			}
 		}
 	}
 	if port == "" {
-		port = "5888"
+		port = build.DefaultPort
 	}
 	return Target{Host: host, Port: port}
 }


### PR DESCRIPTION
## What
First foundational piece of the native ISO-build port (#1278 → epic #1272). A new `tools/sb-tui/internal/build` package models the non-secret install settings persisted in `build/fcos/install-settings.env`:

- `Settings` struct mirrors the bash `PERSISTED_SETTINGS` array (24 keys), with `fieldBindings` as the single source of truth pairing each env key to its field in order.
- `ParseSettings` / `Render` / `Load` / `Save` round-trip the `KEY=value` file: unknown keys dropped (schema-drop, like the bash), empty fields render `KEY=`, values kept verbatim (base64 `AUTH_SECRET`s and space-bearing SSH keys survive). Save is 0600.
- `WithDefaults` applies the two stable defaults (`HOST_USER=core`, `SERVICEBAY_PORT=5888`); `Target()` returns the file-derived box address.
- `probes.ResolveTarget` now parses via this model (dropping its duplicate `STATIC_IP`/`SERVICEBAY_PORT` regexes) while keeping `SB_HOST`/`SB_PORT` env precedence.

Secrets are deliberately **not** modelled here — they're generated fresh each run (#1284; the Go port lands in #1290).

## Why
Closes #1289. The data spine the rest of the #1278 legs (config.json builder, Butane render) read.

## Risk
Low. Pure Go in `tools/sb-tui` (own `go.mod`, gated by the `tui-go` CI job). The only behavioural touch is `ResolveTarget`, which keeps identical semantics (verified: env wins → file → 5888 fallback) and feeds the watch dashboard shipped in #1274. No JS/backend code touched.

## Rollback
`git revert` is enough.

## Verification
- [x] `tools/sb-tui`: `gofmt -l` clean, `go vet`, `go build`, `go test` (8 new tests) all green
- [x] `npm run check:arch` (depcruise unaffected — package is outside the workspace)
- [x] `bash -n install-fedora-coreos.sh` still parses (untouched this PR)
- [ ] /verify on FCoS box — not path-mandated; no install-runner/portal/backend code touched. The settings model is exercised end-to-end when the native build pipeline is wired in #1295.