### PR TITLE
fix(dashboards): sort services by displayName not unit name

### DIFF
--- a/packages/api-client/src/serviceView.test.ts
+++ b/packages/api-client/src/serviceView.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { sortServicesByDisplayName } from './serviceView';
+
+describe('sortServicesByDisplayName', () => {
+    it('orders by the user-facing displayName, not the systemd unit name', () => {
+        // `nginx.service` renders as "Reverse Proxy (Nginx)" — it must sort
+        // under R, not under its unit id n. (#1287)
+        const services = [
+            { name: 'nginx.service', displayName: 'Reverse Proxy (Nginx)' },
+            { name: 'authelia.service', displayName: 'Authelia' },
+            { name: 'vaultwarden.service', displayName: 'Vaultwarden' },
+        ];
+        const sorted = sortServicesByDisplayName(services).map(s => s.displayName);
+        expect(sorted).toEqual(['Authelia', 'Reverse Proxy (Nginx)', 'Vaultwarden']);
+    });
+
+    it('does not mutate the input array', () => {
+        const services = [
+            { name: 'b.service', displayName: 'Bravo' },
+            { name: 'a.service', displayName: 'Alpha' },
+        ];
+        const snapshot = [...services];
+        sortServicesByDisplayName(services);
+        expect(services).toEqual(snapshot);
+    });
+
+    it('sorts case-insensitively per locale rules', () => {
+        const services = [
+            { name: 'z.service', displayName: 'zebra' },
+            { name: 'a.service', displayName: 'Apple' },
+        ];
+        const sorted = sortServicesByDisplayName(services).map(s => s.displayName);
+        expect(sorted).toEqual(['Apple', 'zebra']);
+    });
+
+    it('handles an empty list', () => {
+        expect(sortServicesByDisplayName([])).toEqual([]);
+    });
+});

--- a/packages/api-client/src/serviceView.ts
+++ b/packages/api-client/src/serviceView.ts
@@ -65,3 +65,14 @@ export interface ServiceViewModel {
   containerIds?: string[];
   attachedContainers?: EnrichedContainer[];
 }
+
+/** Sort services alphabetically by the user-facing label. Cards render
+ *  `displayName`, so sorting by `name` (the systemd unit id) produces a
+ *  visibly mis-ordered list whenever the backend rewrites the label —
+ *  e.g. `nginx.service` → "Reverse Proxy (Nginx)" sorted under `n`, not
+ *  `R`. Sort by the same field the UI shows. (#1287, see #844) */
+export function sortServicesByDisplayName<T extends Pick<ServiceViewModel, 'displayName'>>(
+    services: readonly T[],
+): T[] {
+    return [...services].sort((a, b) => a.displayName.localeCompare(b.displayName));
+}

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -19,7 +19,7 @@ import ServiceCard from '@/components/ServiceCard';
 import { useServiceActions } from '@/hooks/useServiceActions';
 import { useContainerActions } from '@/hooks/useContainerActions';
 import { buildServiceViewModel } from '@servicebay/api-client';
-import { ServiceViewModel } from '@servicebay/api-client';
+import { ServiceViewModel, sortServicesByDisplayName } from '@servicebay/api-client';
 import ContainerLogsPanel, { ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
 import type { TerminalRef } from '@/components/Terminal';
 import type { EnrichedContainer } from '@servicebay/api-client';
@@ -996,7 +996,7 @@ export default function ServicesDashboard() {
                 (s.nodeName && s.nodeName.toLowerCase().includes(q))
             )
           : services;
-      const sorted = [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+      const sorted = sortServicesByDisplayName(filtered);
       setFilteredServices(sorted);
 
       const filteredBundleList = q


### PR DESCRIPTION
## What
The `/services` list is sorted alphabetically by the user-facing card label (`displayName`) instead of the internal systemd unit id (`name`).

## Why
Closes #1287. Cards render `displayName` (the backend rewrites e.g. `nginx.service` → "Reverse Proxy (Nginx)"), but the list sorted by `name`, so any service whose label diverged from its unit id landed in the wrong alphabetical slot. The `ServiceViewModel` contract (#844) already documents that the UI must never use `name` directly. Sort logic extracted to a tested `sortServicesByDisplayName` helper in `api-client`, next to that contract.

## Risk
Low — pure presentation reordering. Swaps the sort key from one already-present view-model field to the field the UI already renders; no runtime/data-path change. Covered by 4 unit tests.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 401 warnings — unchanged baseline)
- [x] npm run check:arch
- [x] npm test (1480 passed)
- [ ] /verify on FCoS box — **path-mandated** (`packages/frontend/src/dashboards/`) but needs a browser to read the rendered card order; no browser tooling is available in the autonomous dev env. Left for a human browser glance at `/services` before merge.

> Autoloop note: not auto-merged. The fix is CI-green and unit-test-covered, but the path-mandated `/verify` for a frontend-render change can only be done by viewing the page in a browser, which the loop can't do here.