### PR TITLE
feat(tui-go): bootstrap secret generation and Bitwarden CSV

### DIFF
--- a/tools/sb-tui/internal/build/secrets.go
+++ b/tools/sb-tui/internal/build/secrets.go
@@ -1,0 +1,223 @@
+package build
+
+// Bootstrap-secret generation, ported from install-fedora-coreos.sh (#1284,
+// child #1290 of the native ISO-build leg #1278). ServiceBay owns three
+// secrets per build: the ServiceBay admin password, the host console password,
+// and the optional MCP bootstrap token. They are generated fresh on every run
+// (so they never persist into install-settings.env — see settings.go), unless
+// the operator pre-seeds a memorable value via env. Only the token's SHA-256
+// hash lands in config.json; the cleartext is surfaced once via the credentials
+// summary + a Bitwarden/Vaultwarden CSV so the operator can save it.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// secretHexBytes mirrors `openssl rand -hex 24` for the admin + host
+	// passwords (48 hex chars). Hex is login-safe and never contains the
+	// characters the install pipeline rejects.
+	secretHexBytes = 24
+	// tokenHexBytes mirrors `openssl rand -hex 32` for the MCP bootstrap
+	// token (64 hex chars).
+	tokenHexBytes = 32
+)
+
+// SecretInputs is the operator-controlled input to secret resolution: values
+// pre-seeded via env / install-settings.env (empty means "generate"), plus the
+// SB_NO_BOOTSTRAP_TOKEN opt-out.
+type SecretInputs struct {
+	AdminPassword    string // pre-seeded SERVICEBAY_ADMIN_PASSWORD
+	HostPassword     string // pre-seeded HOST_PASSWORD
+	BootstrapToken   string // pre-seeded SERVICEBAY_BOOTSTRAP_TOKEN
+	NoBootstrapToken bool   // SB_NO_BOOTSTRAP_TOKEN=1
+}
+
+// Secrets is the resolved set of bootstrap secrets for one build run. The
+// *Generated flags record which values were freshly generated (vs pre-seeded),
+// so the caller surfaces only the ones the operator hasn't already seen — a
+// pre-seeded password is never echoed back. BootstrapTokenHash is the only
+// value that goes into config.json; the cleartext token stays local.
+type Secrets struct {
+	AdminPassword      string
+	AdminGenerated     bool
+	HostPassword       string
+	HostGenerated      bool
+	BootstrapToken     string // cleartext; "" when skipped via SB_NO_BOOTSTRAP_TOKEN
+	BootstrapTokenHash string // SHA-256 hex; "" when there is no token
+	BootstrapGenerated bool
+}
+
+// pipelineUnsafe reports whether a pre-seeded secret contains a character the
+// install pipeline rejects (newline, double-quote, backslash, $, backtick).
+// Mirrors the guard in secret_or_generate.
+func pipelineUnsafe(s string) bool {
+	return strings.ContainsAny(s, "\n\"\\$`")
+}
+
+// randHex reads n random bytes from rnd and returns their hex encoding.
+func randHex(rnd io.Reader, n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(rnd, buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// resolveSecret returns the pre-seeded value (validated) when present, else a
+// freshly generated hex secret flagged as generated. Ports secret_or_generate.
+func resolveSecret(preseed, name string, rnd io.Reader) (value string, generated bool, err error) {
+	if preseed != "" {
+		if pipelineUnsafe(preseed) {
+			return "", false, fmt.Errorf("pre-seeded %s contains characters that break the install pipeline (newline, quote, backslash, $ or backtick)", name)
+		}
+		return preseed, false, nil
+	}
+	v, err := randHex(rnd, secretHexBytes)
+	if err != nil {
+		return "", false, err
+	}
+	return v, true, nil
+}
+
+// GenerateSecrets resolves the three ServiceBay-owned bootstrap secrets for one
+// build run, reading randomness from rnd (callers pass crypto/rand.Reader;
+// tests pass a deterministic reader). Pre-seeded admin/host passwords win and
+// are validated; the bootstrap token honours SB_NO_BOOTSTRAP_TOKEN (opt-out)
+// then a pre-seeded value, else mints a fresh token. Ports secret_or_generate +
+// mint_bootstrap_token.
+func GenerateSecrets(in SecretInputs, rnd io.Reader) (Secrets, error) {
+	var s Secrets
+	var err error
+
+	if s.AdminPassword, s.AdminGenerated, err = resolveSecret(in.AdminPassword, "SERVICEBAY_ADMIN_PASSWORD", rnd); err != nil {
+		return Secrets{}, err
+	}
+	if s.HostPassword, s.HostGenerated, err = resolveSecret(in.HostPassword, "HOST_PASSWORD", rnd); err != nil {
+		return Secrets{}, err
+	}
+
+	// Bootstrap token: opt-out wins over pre-seed wins over generate. The
+	// bash mint_bootstrap_token does not validate a pre-seeded token (the
+	// cleartext only ever flows through sha256 + CSV quoting), so neither do
+	// we — kept faithful to the source.
+	switch {
+	case in.NoBootstrapToken:
+		// leave the token empty — no bootstrapToken block in config.json
+	case in.BootstrapToken != "":
+		s.BootstrapToken = in.BootstrapToken
+	default:
+		if s.BootstrapToken, err = randHex(rnd, tokenHexBytes); err != nil {
+			return Secrets{}, err
+		}
+		s.BootstrapGenerated = true
+	}
+	if s.BootstrapToken != "" {
+		sum := sha256.Sum256([]byte(s.BootstrapToken))
+		s.BootstrapTokenHash = hex.EncodeToString(sum[:])
+	}
+	return s, nil
+}
+
+// CredentialContext is the non-secret context for rendering the credentials
+// summary + CSV: where the box lives and the account names.
+type CredentialContext struct {
+	ServerName string
+	AdminUser  string
+	HostUser   string
+	IP         string
+	Port       string
+}
+
+// withDefaults fills the placeholders the bash summary used for empty fields.
+func (c CredentialContext) withDefaults() CredentialContext {
+	if c.ServerName == "" {
+		c.ServerName = "ServiceBay"
+	}
+	if c.AdminUser == "" {
+		c.AdminUser = "admin"
+	}
+	if c.HostUser == "" {
+		c.HostUser = DefaultHostUser
+	}
+	if c.IP == "" {
+		c.IP = "<server-ip>"
+	}
+	if c.Port == "" {
+		c.Port = DefaultPort
+	}
+	return c
+}
+
+func (c CredentialContext) url() string { return fmt.Sprintf("http://%s:%s", c.IP, c.Port) }
+
+// AnyGenerated reports whether any secret was freshly generated this run. When
+// false, there is nothing to surface — everything was pre-seeded or skipped.
+func (s Secrets) AnyGenerated() bool {
+	return s.AdminGenerated || s.HostGenerated || s.BootstrapGenerated
+}
+
+// csvField RFC4180-quotes a CSV value (always wrapped, internal quotes
+// doubled). Mirrors the bash csv_field helper.
+func csvField(v string) string {
+	return `"` + strings.ReplaceAll(v, `"`, `""`) + `"`
+}
+
+const bitwardenHeader = "folder,favorite,type,name,notes,fields,reprompt,login_uri,login_username,login_password,login_totp"
+
+// BitwardenCSV renders a Bitwarden/Vaultwarden-importable CSV containing only
+// the secrets GENERATED this run — pre-seeded values are omitted because the
+// operator already holds them. Returns "" when nothing was generated. Ports the
+// CSV half of emit_generated_credentials.
+func (s Secrets) BitwardenCSV(ctx CredentialContext) string {
+	if !s.AnyGenerated() {
+		return ""
+	}
+	c := ctx.withDefaults()
+	var b strings.Builder
+	b.WriteString(bitwardenHeader)
+	b.WriteByte('\n')
+	row := func(name, notes, uri, user, pass string) {
+		fmt.Fprintf(&b, ",,login,%s,%s,,0,%s,%s,%s,\n",
+			csvField(name), csvField(notes), csvField(uri), csvField(user), csvField(pass))
+	}
+	if s.AdminGenerated {
+		row("ServiceBay Admin — "+c.ServerName, "ServiceBay web admin login.", c.url(), c.AdminUser, s.AdminPassword)
+	}
+	if s.HostGenerated {
+		row("ServiceBay Host console — "+c.ServerName, "Console / SSH login for the Fedora CoreOS host user.", "ssh://"+c.IP, c.HostUser, s.HostPassword)
+	}
+	if s.BootstrapGenerated {
+		row("ServiceBay MCP bootstrap token — "+c.ServerName, "Read-only, LAN-only, 30 minutes from first boot.", c.url(), "", s.BootstrapToken)
+	}
+	return b.String()
+}
+
+// Summary renders the human-readable "save these now" block for the secrets
+// generated this run. Returns "" when nothing was generated. Ports the terminal
+// half of emit_generated_credentials.
+func (s Secrets) Summary(ctx CredentialContext) string {
+	if !s.AnyGenerated() {
+		return ""
+	}
+	c := ctx.withDefaults()
+	var b strings.Builder
+	b.WriteString("================ SAVE THESE CREDENTIALS NOW ================\n")
+	b.WriteString("ServiceBay generated these secrets for this build. They are NOT stored\n")
+	b.WriteString("anywhere else — save them to your password manager now.\n\n")
+	if s.AdminGenerated {
+		fmt.Fprintf(&b, "  ServiceBay admin   %s / %s\n                     %s\n", c.AdminUser, s.AdminPassword, c.url())
+	}
+	if s.HostGenerated {
+		fmt.Fprintf(&b, "  Host console       %s / %s\n                     ssh %s@%s\n", c.HostUser, s.HostPassword, c.HostUser, c.IP)
+	}
+	if s.BootstrapGenerated {
+		fmt.Fprintf(&b, "  MCP bootstrap      %s\n                     read-only, LAN-only, 30 min from first boot\n", s.BootstrapToken)
+	}
+	b.WriteString("===========================================================\n")
+	return b.String()
+}

--- a/tools/sb-tui/internal/build/secrets_test.go
+++ b/tools/sb-tui/internal/build/secrets_test.go
@@ -1,0 +1,168 @@
+package build
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// seqReader yields bytes 0,1,2,... so generated secrets are deterministic and
+// the three draws (admin/host/token) differ from each other.
+func seqBytes(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+func TestGenerateSecrets_AllGenerated(t *testing.T) {
+	seq := seqBytes(secretHexBytes*2 + tokenHexBytes)
+	s, err := GenerateSecrets(SecretInputs{}, bytes.NewReader(seq))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantAdmin := hex.EncodeToString(seq[:secretHexBytes])
+	wantHost := hex.EncodeToString(seq[secretHexBytes : secretHexBytes*2])
+	wantToken := hex.EncodeToString(seq[secretHexBytes*2:])
+	if s.AdminPassword != wantAdmin || !s.AdminGenerated {
+		t.Errorf("admin = %q gen=%v, want %q gen=true", s.AdminPassword, s.AdminGenerated, wantAdmin)
+	}
+	if s.HostPassword != wantHost || !s.HostGenerated {
+		t.Errorf("host = %q gen=%v, want %q gen=true", s.HostPassword, s.HostGenerated, wantHost)
+	}
+	if s.BootstrapToken != wantToken || !s.BootstrapGenerated {
+		t.Errorf("token = %q gen=%v, want %q gen=true", s.BootstrapToken, s.BootstrapGenerated, wantToken)
+	}
+	if len(s.AdminPassword) != secretHexBytes*2 || len(s.BootstrapToken) != tokenHexBytes*2 {
+		t.Errorf("unexpected hex lengths: admin=%d token=%d", len(s.AdminPassword), len(s.BootstrapToken))
+	}
+	sum := sha256.Sum256([]byte(wantToken))
+	if s.BootstrapTokenHash != hex.EncodeToString(sum[:]) {
+		t.Errorf("token hash = %q, want sha256 of token", s.BootstrapTokenHash)
+	}
+}
+
+func TestGenerateSecrets_PreseedWins(t *testing.T) {
+	in := SecretInputs{AdminPassword: "pinned-admin", HostPassword: "pinned-host"}
+	s, err := GenerateSecrets(in, bytes.NewReader(seqBytes(tokenHexBytes)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.AdminPassword != "pinned-admin" || s.AdminGenerated {
+		t.Errorf("admin = %q gen=%v, want pinned not generated", s.AdminPassword, s.AdminGenerated)
+	}
+	if s.HostPassword != "pinned-host" || s.HostGenerated {
+		t.Errorf("host = %q gen=%v, want pinned not generated", s.HostPassword, s.HostGenerated)
+	}
+	// token still minted from the reader (no pre-seed)
+	if !s.BootstrapGenerated || s.BootstrapToken == "" {
+		t.Errorf("token should still be generated when only passwords pre-seeded")
+	}
+}
+
+func TestGenerateSecrets_PreseedPipelineUnsafe(t *testing.T) {
+	for _, bad := range []string{"has\nnewline", `has"quote`, `back\slash`, "dollar$", "tick`"} {
+		_, err := GenerateSecrets(SecretInputs{AdminPassword: bad}, bytes.NewReader(seqBytes(64)))
+		if err == nil {
+			t.Errorf("expected error for unsafe pre-seed %q", bad)
+		}
+	}
+}
+
+func TestGenerateSecrets_NoBootstrapToken(t *testing.T) {
+	s, err := GenerateSecrets(SecretInputs{NoBootstrapToken: true}, bytes.NewReader(seqBytes(secretHexBytes*2)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.BootstrapToken != "" || s.BootstrapTokenHash != "" || s.BootstrapGenerated {
+		t.Errorf("SB_NO_BOOTSTRAP_TOKEN should leave the token empty, got %q/%q gen=%v",
+			s.BootstrapToken, s.BootstrapTokenHash, s.BootstrapGenerated)
+	}
+}
+
+func TestGenerateSecrets_PreseedBootstrapToken(t *testing.T) {
+	s, err := GenerateSecrets(SecretInputs{BootstrapToken: "pinned-token"}, bytes.NewReader(seqBytes(secretHexBytes*2)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.BootstrapToken != "pinned-token" || s.BootstrapGenerated {
+		t.Errorf("token = %q gen=%v, want pinned not generated", s.BootstrapToken, s.BootstrapGenerated)
+	}
+	sum := sha256.Sum256([]byte("pinned-token"))
+	if s.BootstrapTokenHash != hex.EncodeToString(sum[:]) {
+		t.Errorf("hash mismatch for pre-seeded token")
+	}
+}
+
+func TestGenerateSecrets_ShortReader(t *testing.T) {
+	_, err := GenerateSecrets(SecretInputs{}, bytes.NewReader(seqBytes(10)))
+	if err == nil {
+		t.Error("expected error when the random source is exhausted")
+	}
+}
+
+func TestSecrets_BitwardenCSV_Golden(t *testing.T) {
+	s := Secrets{
+		AdminPassword: "adminpw", AdminGenerated: true,
+		HostPassword: "hostpw", HostGenerated: true,
+		BootstrapToken: "tok123", BootstrapGenerated: true,
+	}
+	ctx := CredentialContext{ServerName: "OSCAR", AdminUser: "admin", HostUser: "core", IP: "192.168.178.100", Port: "5888"}
+	got := s.BitwardenCSV(ctx)
+	want := strings.Join([]string{
+		bitwardenHeader,
+		`,,login,"ServiceBay Admin — OSCAR","ServiceBay web admin login.",,0,"http://192.168.178.100:5888","admin","adminpw",`,
+		`,,login,"ServiceBay Host console — OSCAR","Console / SSH login for the Fedora CoreOS host user.",,0,"ssh://192.168.178.100","core","hostpw",`,
+		`,,login,"ServiceBay MCP bootstrap token — OSCAR","Read-only, LAN-only, 30 minutes from first boot.",,0,"http://192.168.178.100:5888","","tok123",`,
+		"",
+	}, "\n")
+	if got != want {
+		t.Errorf("CSV mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestSecrets_BitwardenCSV_OmitsPreseeded(t *testing.T) {
+	// admin pre-seeded (not generated) → must not appear; only host generated.
+	s := Secrets{
+		AdminPassword: "preadmin", AdminGenerated: false,
+		HostPassword: "hostpw", HostGenerated: true,
+	}
+	got := s.BitwardenCSV(CredentialContext{})
+	if strings.Contains(got, "preadmin") || strings.Contains(got, "ServiceBay Admin") {
+		t.Errorf("pre-seeded admin leaked into CSV:\n%s", got)
+	}
+	if !strings.Contains(got, "Host console") || !strings.Contains(got, "hostpw") {
+		t.Errorf("generated host missing from CSV:\n%s", got)
+	}
+}
+
+func TestSecrets_BitwardenCSV_EmptyWhenNothingGenerated(t *testing.T) {
+	s := Secrets{AdminPassword: "pre", HostPassword: "pre", BootstrapToken: "pre"} // all pre-seeded
+	if got := s.BitwardenCSV(CredentialContext{}); got != "" {
+		t.Errorf("expected empty CSV when nothing generated, got %q", got)
+	}
+	if s.AnyGenerated() {
+		t.Error("AnyGenerated should be false when all pre-seeded")
+	}
+}
+
+func TestCSVField_QuotesEmbeddedQuotes(t *testing.T) {
+	if got := csvField(`a"b`); got != `"a""b"` {
+		t.Errorf("csvField = %q, want %q", got, `"a""b"`)
+	}
+}
+
+func TestSecrets_Summary(t *testing.T) {
+	none := Secrets{AdminPassword: "pre"} // pre-seeded, nothing generated
+	if none.Summary(CredentialContext{}) != "" {
+		t.Error("summary should be empty when nothing generated")
+	}
+	s := Secrets{AdminPassword: "adminpw", AdminGenerated: true}
+	out := s.Summary(CredentialContext{AdminUser: "admin", IP: "10.0.0.1", Port: "5888"})
+	if !strings.Contains(out, "adminpw") || !strings.Contains(out, "SAVE THESE CREDENTIALS NOW") {
+		t.Errorf("summary missing content:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What
Ports the auto-generated ServiceBay-owned bootstrap secrets (#1284) to the native Go ISO-build leg. New `internal/build/secrets.go`:
- `GenerateSecrets` resolves the admin password, host console password, and optional MCP bootstrap token. Pre-seeded values (env / install-settings.env) win and are validated for pipeline-unsafe chars; otherwise a fresh hex secret is minted from an injected random source. Honours `SB_NO_BOOTSTRAP_TOKEN`. SHA-256-hashes the token (only the hash lands in config.json).
- `Secrets.BitwardenCSV` / `Secrets.Summary` surface **only freshly-generated** values (pre-seeded ones are never echoed), matching `emit_generated_credentials`.

## Why
Closes #1290 (child of the native ISO-build leg #1278 / epic #1272). Mirrors `secret_or_generate`, `mint_bootstrap_token`, `csv_field`, `emit_generated_credentials` in `install-fedora-coreos.sh`.

## Risk
Low — additive, pure module with an injected randomness source; not yet wired into the build flow (consumed by the config.json builder #1291 and ISO bake #1293). 13 unit tests incl. a golden CSV.

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt -l . (clean), go vet ./..., go build ./..., go test ./... (build package: ok)
- [x] CI `tui-go` job gates this module
- [ ] /verify on FCoS box — N/A (Go module outside the npm workspace; not in the path-mandated set; no runtime wiring yet)