### PR TITLE
feat(tui-go): FCoS ISO download and version picker

### DIFF
--- a/tools/sb-tui/internal/iso/iso.go
+++ b/tools/sb-tui/internal/iso/iso.go
@@ -1,0 +1,170 @@
+// Package iso is the Fedora CoreOS ISO version-picker for the native build leg
+// (#1292, child of #1278). It mirrors the bash select_fedora_coreos_iso /
+// fetch_fcos_stream_images / detect_host_arch in install-fedora-coreos.sh (and
+// the Ink port in packages/tui/src/isoPicker.ts): parse upstream stream
+// metadata, merge it with on-disk ISOs, mark the host arch, pick a sensible
+// default, and build the coreos-installer download argv. This file is the pure
+// decision model; the network/fs/exec IO lives in probes.go so the picker stays
+// unit-testable.
+package iso
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Streams are the FCoS streams the picker offers, newest-cadence last.
+var Streams = []string{"stable", "testing", "next"}
+
+// DetectHostArch maps a `uname -m` value to the arch label FCoS uses.
+func DetectHostArch(machine string) string {
+	switch machine {
+	case "x86_64":
+		return "x86_64"
+	case "aarch64", "arm64":
+		return "aarch64"
+	default:
+		return machine
+	}
+}
+
+// StreamImage is one metal-ISO build advertised for a stream, per architecture.
+type StreamImage struct {
+	Arch     string
+	Release  string
+	Location string
+}
+
+// StreamImages pairs a stream name with its available builds.
+type StreamImages struct {
+	Stream string
+	Images []StreamImage
+}
+
+// ParseStreamImages parses a streams/<stream>.json body into its per-arch metal
+// ISO builds. Tolerant of missing keys: an arch without a metal ISO artifact is
+// skipped rather than failing, so a partial/old stream degrades gracefully.
+// Results are sorted by arch for deterministic ordering (Go map iteration is
+// randomised, unlike jq's to_entries).
+func ParseStreamImages(raw []byte) ([]StreamImage, error) {
+	var doc struct {
+		Architectures map[string]struct {
+			Artifacts struct {
+				Metal struct {
+					Release string `json:"release"`
+					Formats struct {
+						ISO struct {
+							Disk struct {
+								Location string `json:"location"`
+							} `json:"disk"`
+						} `json:"iso"`
+					} `json:"formats"`
+				} `json:"metal"`
+			} `json:"artifacts"`
+		} `json:"architectures"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	images := make([]StreamImage, 0, len(doc.Architectures))
+	for arch, v := range doc.Architectures {
+		release := v.Artifacts.Metal.Release
+		location := v.Artifacts.Metal.Formats.ISO.Disk.Location
+		if release != "" && location != "" {
+			images = append(images, StreamImage{Arch: arch, Release: release, Location: location})
+		}
+	}
+	sort.Slice(images, func(i, j int) bool { return images[i].Arch < images[j].Arch })
+	return images, nil
+}
+
+// LocalISO is an ISO already on disk. Date is the mtime as YYYY-MM-DD ("" when
+// unknown).
+type LocalISO struct {
+	Path string
+	Name string
+	Date string
+}
+
+// Choice is a selectable image in the picker — either an on-disk ISO (Path set)
+// or a remote build to download (Stream/Arch/Location set).
+type Choice struct {
+	Kind       string // "local" | "remote"
+	Label      string
+	Path       string
+	Stream     string
+	Arch       string
+	Location   string
+	IsHostArch bool
+}
+
+func localLabel(iso LocalISO) string {
+	date := iso.Date
+	if date == "" {
+		date = "?"
+	}
+	return fmt.Sprintf("%s  (local, %s)", iso.Name, date)
+}
+
+func remoteLabel(stream string, img StreamImage, isHostArch bool) string {
+	marker := ""
+	if isHostArch {
+		marker = "  ← host arch"
+	}
+	return fmt.Sprintf("%-8s %-8s %s%s", stream, img.Arch, img.Release, marker)
+}
+
+// BuildChoices combines local ISOs (first, in the order given) with the remote
+// builds for each stream, marking the host arch.
+func BuildChoices(local []LocalISO, remote []StreamImages, hostArch string) []Choice {
+	choices := make([]Choice, 0, len(local)+len(remote)*2)
+	for _, iso := range local {
+		choices = append(choices, Choice{Kind: "local", Label: localLabel(iso), Path: iso.Path})
+	}
+	for _, si := range remote {
+		for _, img := range si.Images {
+			isHost := img.Arch == hostArch
+			choices = append(choices, Choice{
+				Kind:       "remote",
+				Label:      remoteLabel(si.Stream, img, isHost),
+				Stream:     si.Stream,
+				Arch:       img.Arch,
+				Location:   img.Location,
+				IsHostArch: isHost,
+			})
+		}
+	}
+	return choices
+}
+
+// DefaultChoiceIndex returns the index to pre-select: the first local ISO, else
+// the stable build for the host arch, else the first choice. Returns -1 when
+// there are no choices at all.
+func DefaultChoiceIndex(choices []Choice, hostArch string) int {
+	if len(choices) == 0 {
+		return -1
+	}
+	for i, c := range choices {
+		if c.Kind == "local" {
+			return i
+		}
+	}
+	for i, c := range choices {
+		if c.Kind == "remote" && c.Stream == "stable" && c.Arch == hostArch {
+			return i
+		}
+	}
+	return 0
+}
+
+// StreamURL is the upstream metadata URL for one stream.
+func StreamURL(stream string) string {
+	return fmt.Sprintf("https://builds.coreos.fedoraproject.org/streams/%s.json", stream)
+}
+
+// DownloadArgs builds the `coreos-installer download` argv that fetches the
+// chosen remote build's metal ISO into buildDir.
+func DownloadArgs(stream, arch, buildDir string) []string {
+	return []string{"download", "-s", stream, "-a", arch, "-p", "metal", "-f", "iso", "-C", buildDir}
+}

--- a/tools/sb-tui/internal/iso/iso_test.go
+++ b/tools/sb-tui/internal/iso/iso_test.go
@@ -1,0 +1,163 @@
+package iso
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectHostArch(t *testing.T) {
+	cases := map[string]string{
+		"x86_64":  "x86_64",
+		"aarch64": "aarch64",
+		"arm64":   "aarch64",
+		"riscv64": "riscv64", // unknown passes through
+	}
+	for in, want := range cases {
+		if got := DetectHostArch(in); got != want {
+			t.Errorf("DetectHostArch(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseStreamImages(t *testing.T) {
+	raw := []byte(`{
+      "architectures": {
+        "x86_64": {"artifacts": {"metal": {"release": "40.1", "formats": {"iso": {"disk": {"location": "https://x/x86.iso"}}}}}},
+        "aarch64": {"artifacts": {"metal": {"release": "40.1", "formats": {"iso": {"disk": {"location": "https://x/arm.iso"}}}}}},
+        "s390x": {"artifacts": {"metal": {"release": "40.1", "formats": {"iso": {"disk": {}}}}}}
+      }
+    }`)
+	images, err := ParseStreamImages(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// s390x has no location -> skipped; remaining sorted by arch.
+	want := []StreamImage{
+		{Arch: "aarch64", Release: "40.1", Location: "https://x/arm.iso"},
+		{Arch: "x86_64", Release: "40.1", Location: "https://x/x86.iso"},
+	}
+	if !reflect.DeepEqual(images, want) {
+		t.Errorf("ParseStreamImages = %+v, want %+v", images, want)
+	}
+}
+
+func TestParseStreamImages_Tolerant(t *testing.T) {
+	if imgs, err := ParseStreamImages([]byte(`{}`)); err != nil || len(imgs) != 0 {
+		t.Errorf("empty doc: got %+v err %v, want []", imgs, err)
+	}
+	if imgs, err := ParseStreamImages([]byte(`{"architectures": null}`)); err != nil || len(imgs) != 0 {
+		t.Errorf("null architectures: got %+v err %v, want []", imgs, err)
+	}
+	if _, err := ParseStreamImages([]byte(`not json`)); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestBuildChoices(t *testing.T) {
+	local := []LocalISO{{Path: "/b/a.iso", Name: "a.iso", Date: "2026-05-01"}}
+	remote := []StreamImages{
+		{Stream: "stable", Images: []StreamImage{
+			{Arch: "x86_64", Release: "40.1", Location: "u1"},
+			{Arch: "aarch64", Release: "40.1", Location: "u2"},
+		}},
+	}
+	choices := BuildChoices(local, remote, "x86_64")
+	if len(choices) != 3 {
+		t.Fatalf("expected 3 choices, got %d", len(choices))
+	}
+	if choices[0].Kind != "local" || !strings.Contains(choices[0].Label, "a.iso") {
+		t.Errorf("first choice should be the local ISO, got %+v", choices[0])
+	}
+	if !choices[1].IsHostArch || choices[1].Arch != "x86_64" {
+		t.Errorf("x86_64 remote should be marked host arch, got %+v", choices[1])
+	}
+	if !strings.Contains(choices[1].Label, "← host arch") {
+		t.Errorf("host-arch label missing marker: %q", choices[1].Label)
+	}
+	if choices[2].IsHostArch {
+		t.Errorf("aarch64 should not be host arch on x86_64, got %+v", choices[2])
+	}
+}
+
+func TestDefaultChoiceIndex(t *testing.T) {
+	if got := DefaultChoiceIndex(nil, "x86_64"); got != -1 {
+		t.Errorf("empty -> %d, want -1", got)
+	}
+	// first local wins
+	withLocal := []Choice{
+		{Kind: "remote", Stream: "stable", Arch: "x86_64"},
+		{Kind: "local"},
+	}
+	if got := DefaultChoiceIndex(withLocal, "x86_64"); got != 1 {
+		t.Errorf("first-local -> %d, want 1", got)
+	}
+	// no local -> stable host arch
+	remoteOnly := []Choice{
+		{Kind: "remote", Stream: "testing", Arch: "x86_64"},
+		{Kind: "remote", Stream: "stable", Arch: "aarch64"},
+		{Kind: "remote", Stream: "stable", Arch: "x86_64"},
+	}
+	if got := DefaultChoiceIndex(remoteOnly, "x86_64"); got != 2 {
+		t.Errorf("stable-host -> %d, want 2", got)
+	}
+	// no local, no stable host -> 0
+	noMatch := []Choice{{Kind: "remote", Stream: "testing", Arch: "aarch64"}}
+	if got := DefaultChoiceIndex(noMatch, "x86_64"); got != 0 {
+		t.Errorf("fallback -> %d, want 0", got)
+	}
+}
+
+func TestStreamURLAndDownloadArgs(t *testing.T) {
+	if got := StreamURL("stable"); got != "https://builds.coreos.fedoraproject.org/streams/stable.json" {
+		t.Errorf("StreamURL = %q", got)
+	}
+	want := []string{"download", "-s", "next", "-a", "aarch64", "-p", "metal", "-f", "iso", "-C", "/build/fcos"}
+	if got := DownloadArgs("next", "aarch64", "/build/fcos"); !reflect.DeepEqual(got, want) {
+		t.Errorf("DownloadArgs = %v, want %v", got, want)
+	}
+}
+
+func TestListLocalISOs(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(name string, age time.Duration) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mt := time.Now().Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	newest := mustWrite("new.iso", 1*time.Hour)
+	oldest := mustWrite("old.iso", 48*time.Hour)
+	mustWrite(customISO, 0)   // excluded
+	mustWrite("notes.txt", 0) // non-iso, ignored
+	sub := filepath.Join(dir, "sub")
+	_ = os.Mkdir(sub, 0o755) // dirs ignored even if .iso-suffixed elsewhere
+
+	got := ListLocalISOs([]string{dir})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 ISOs (custom + txt excluded), got %d: %+v", len(got), got)
+	}
+	if got[0].Path != newest || got[1].Path != oldest {
+		t.Errorf("expected newest-first ordering, got %+v", got)
+	}
+	for _, i := range got {
+		if i.Name == customISO {
+			t.Error("customised ISO must be excluded")
+		}
+		if len(i.Date) != 10 {
+			t.Errorf("date not YYYY-MM-DD: %q", i.Date)
+		}
+	}
+	// missing dir is tolerated
+	if got := ListLocalISOs([]string{filepath.Join(dir, "nope")}); len(got) != 0 {
+		t.Errorf("missing dir should yield no ISOs, got %+v", got)
+	}
+}

--- a/tools/sb-tui/internal/iso/probes.go
+++ b/tools/sb-tui/internal/iso/probes.go
@@ -1,0 +1,162 @@
+package iso
+
+// Concrete IO for the ISO picker (#1292): host-arch detection, fetching
+// upstream FCoS stream metadata over HTTP, enumerating on-disk ISOs, and
+// invoking coreos-installer to download a remote build. Kept apart from iso.go
+// so the picker model stays pure. Mirrors packages/tui/src/isoProbes.ts.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+)
+
+const (
+	streamFetchTimeout = 15 * time.Second
+	customISO          = "fedora-coreos-custom.iso"
+	maxStreamBody      = 8 << 20 // 8 MiB — stream JSON is tiny; cap defensively
+)
+
+// HostArch returns the FCoS arch label for the running host.
+func HostArch() string {
+	machine := runtime.GOARCH
+	switch machine {
+	case "amd64":
+		machine = "x86_64"
+	case "arm64":
+		machine = "aarch64"
+	}
+	return DetectHostArch(machine)
+}
+
+// FetchStreamImages fetches the metal-ISO builds for one stream. Returns nil on
+// any network/parse failure so the picker degrades to whatever else is
+// reachable (matching the bash silent-failure contract).
+func FetchStreamImages(ctx context.Context, stream string) []StreamImage {
+	reqCtx, cancel := context.WithTimeout(ctx, streamFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, StreamURL(stream), nil)
+	if err != nil {
+		return nil
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxStreamBody))
+	if err != nil {
+		return nil
+	}
+	images, err := ParseStreamImages(body)
+	if err != nil {
+		return nil
+	}
+	return images
+}
+
+// FetchAllStreams fetches every stream's builds in parallel, dropping the empty
+// ones, preserving the Streams order.
+func FetchAllStreams(ctx context.Context) []StreamImages {
+	results := make([][]StreamImage, len(Streams))
+	done := make(chan int, len(Streams))
+	for i, stream := range Streams {
+		go func(i int, stream string) {
+			results[i] = FetchStreamImages(ctx, stream)
+			done <- i
+		}(i, stream)
+	}
+	for range Streams {
+		<-done
+	}
+	out := make([]StreamImages, 0, len(Streams))
+	for i, stream := range Streams {
+		if len(results[i]) > 0 {
+			out = append(out, StreamImages{Stream: stream, Images: results[i]})
+		}
+	}
+	return out
+}
+
+// ListLocalISOs enumerates ISOs across the given dirs, newest first, excluding
+// the customised install ISO and de-duplicating by absolute path.
+func ListLocalISOs(dirs []string) []LocalISO {
+	type dated struct {
+		LocalISO
+		mtime time.Time
+	}
+	byPath := map[string]dated{}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || filepath.Ext(name) != ".iso" || name == customISO {
+				continue
+			}
+			full := filepath.Join(dir, name)
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			byPath[full] = dated{
+				LocalISO: LocalISO{Path: full, Name: name, Date: info.ModTime().UTC().Format("2006-01-02")},
+				mtime:    info.ModTime(),
+			}
+		}
+	}
+	all := make([]dated, 0, len(byPath))
+	for _, d := range byPath {
+		all = append(all, d)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].mtime.After(all[j].mtime) })
+	out := make([]LocalISO, len(all))
+	for i, d := range all {
+		out[i] = d.LocalISO
+	}
+	return out
+}
+
+// Download fetches the chosen remote build into buildDir via coreos-installer,
+// streaming the installer's progress to stdout/stderr, and returns the path of
+// the downloaded ISO. Mirrors the remote branch of select_fedora_coreos_iso.
+func Download(ctx context.Context, stream, arch, buildDir string) (string, error) {
+	before := isoSet(buildDir)
+	cmd := exec.CommandContext(ctx, "coreos-installer", DownloadArgs(stream, arch, buildDir)...)
+	cmd.Dir = buildDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	// Prefer the ISO that appeared during this run; fall back to newest.
+	isos := ListLocalISOs([]string{buildDir})
+	for _, i := range isos {
+		if !before[i.Path] {
+			return i.Path, nil
+		}
+	}
+	if len(isos) > 0 {
+		return isos[0].Path, nil
+	}
+	return "", &os.PathError{Op: "download", Path: buildDir, Err: os.ErrNotExist}
+}
+
+func isoSet(dir string) map[string]bool {
+	set := map[string]bool{}
+	for _, i := range ListLocalISOs([]string{dir}) {
+		set[i.Path] = true
+	}
+	return set
+}


### PR DESCRIPTION
## What
New `internal/iso` Go package porting the Fedora CoreOS ISO version-picker to the native build leg:
- **`iso.go` (pure):** `DetectHostArch`, `ParseStreamImages` (tolerant of partial/old streams), `BuildChoices` (local-first, host-arch marked), `DefaultChoiceIndex` (first-local → stable-host → 0), `StreamURL`, `DownloadArgs`.
- **`probes.go` (IO):** `HostArch` (from `runtime.GOARCH`), `FetchStreamImages`/`FetchAllStreams` (HTTP, parallel, nil on failure so the picker degrades), `ListLocalISOs` (newest-first, de-duped, excludes `fedora-coreos-custom.iso`), `Download` (invokes `coreos-installer`, returns the new ISO path).

## Why
Closes #1292 (child of native ISO-build leg #1278 / epic #1272). Mirrors `select_fedora_coreos_iso` / `fetch_fcos_stream_images` / `detect_host_arch` in `install-fedora-coreos.sh` and the Ink port `packages/tui/src/isoPicker.ts`.

## Risk
Low — additive, pure module + IO wrappers; not yet wired into the build action (consumed by the ISO bake #1293). The pure decision tree has 7 unit tests incl. a temp-dir `ListLocalISOs`; the HTTP fetch and `coreos-installer` exec degrade gracefully.

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt -l . (clean), go vet ./..., go build ./..., go test ./... (iso package: ok)
- [x] CI `tui-go` job gates this module
- [ ] /verify on FCoS box — N/A (Go module outside the npm workspace; not path-mandated; no runtime wiring yet)