### PR TITLE
feat(tui-go): render Butane template for the native ISO build

### DIFF
--- a/tools/sb-tui/internal/build/assets/fedora-coreos.bu
+++ b/tools/sb-tui/internal/build/assets/fedora-coreos.bu
@@ -1,0 +1,1929 @@
+variant: fcos
+version: 1.5.0
+
+passwd:
+  users:
+    - name: ${HOST_USER}
+      ssh_authorized_keys:
+        - "${SSH_AUTHORIZED_KEY}"
+        - "${SERVICEBAY_SSH_PUB}"
+      groups:
+        - wheel
+      password_hash: "${PASSWORD_HASH}"
+
+storage:
+  directories:
+    # ServiceBay persistence (rootless)
+    - path: ${DATA_ROOT}/servicebay
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+    # Base stack directory (ServiceBay will create subfolders)
+    - path: ${DATA_ROOT}/stacks
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+    
+    # Ensure intermediate directories are owned by user
+    - path: /var/home/${HOST_USER}/.config
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+    - path: /var/home/${HOST_USER}/.config/containers
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+    - path: /var/home/${HOST_USER}/.config/systemd
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+    - path: /var/home/${HOST_USER}/.config/systemd/user
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+    - path: /var/home/${HOST_USER}/.config/systemd/user/sockets.target.wants
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+
+    # ServiceBay SSH directory
+    - path: ${DATA_ROOT}/servicebay/ssh
+      mode: 0700
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+
+    # USB automount root (USB drives mounted as /mnt/usb/<label>)
+    - path: /mnt/usb
+      mode: 0777
+
+    # Quadlet directory for the user
+    - path: /var/home/${HOST_USER}/.config/containers/systemd
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+
+  files:
+    # Hostname
+    - path: /etc/hostname
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: ${SERVER_NAME}
+
+    # Free port 53 for AdGuard Home — disable systemd-resolved's stub listener.
+    # Without this, AdGuard's DNS port collides with the 127.0.0.53:53 stub on
+    # FCOS and the install wizard refuses to bind. /etc/resolv.conf is
+    # repointed below so name resolution still works via systemd-resolved.
+    - path: /etc/systemd/resolved.conf.d/no-stub.conf
+      mode: 0644
+      contents:
+        inline: |
+          [Resolve]
+          DNSStubListener=no
+
+    # USB automount: udev rule to trigger systemd service on USB block device add
+    - path: /etc/udev/rules.d/99-usb-automount.rules
+      mode: 0644
+      contents:
+        inline: |
+          ACTION=="add", SUBSYSTEM=="block", ENV{ID_BUS}=="usb", ENV{DEVTYPE}=="partition", TAG+="systemd", ENV{SYSTEMD_WANTS}="usb-mount@%k.service"
+          ACTION=="remove", SUBSYSTEM=="block", ENV{ID_BUS}=="usb", ENV{DEVTYPE}=="partition", RUN+="/usr/local/bin/usb-mount.sh remove %k"
+
+    # Z-Wave / serial USB passthrough to rootless containers.
+    # /dev/ttyACM* defaults to crw-rw---- root:dialout, which leaves a
+    # rootless podman container's "nobody" user with no read access
+    # (logs as "permission denied opening serial port"). MODE=0666
+    # opens it to everyone — fine on a single-user homelab, and the
+    # only practical option without rebuilding the rootless uid
+    # mapping. The SYMLINK= rule pins the Sigma Designs / Aeotec
+    # Z-Wave stick at /dev/zwave so the home-assistant template can
+    # mount a stable path regardless of which /dev/ttyACM<N> the
+    # kernel assigns this boot.
+    - path: /etc/udev/rules.d/99-zwave.rules
+      mode: 0644
+      contents:
+        inline: |
+          SUBSYSTEM=="tty", KERNEL=="ttyACM*", MODE="0666"
+          SUBSYSTEM=="tty", ATTRS{idVendor}=="0658", ATTRS{idProduct}=="0200", SYMLINK+="zwave"
+
+    # USB automount: mount/unmount script
+    - path: /usr/local/bin/usb-mount.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ACTION="${1:-}"
+          DEVNAME="${2:-}"
+          DEV="/dev/$DEVNAME"
+          USB_ROOT="/mnt/usb"
+
+          case "$ACTION" in
+            add)
+              # Use filesystem label if available, else device name
+              LABEL=$(lsblk -ndo LABEL "$DEV" 2>/dev/null || echo "")
+              [[ -z "$LABEL" ]] && LABEL="$DEVNAME"
+              # Sanitize label for use as directory name
+              LABEL=$(echo "$LABEL" | tr -c 'A-Za-z0-9._-' '_')
+              MOUNT_POINT="$USB_ROOT/$LABEL"
+              mkdir -p "$MOUNT_POINT"
+              mount -o rw,noatime "$DEV" "$MOUNT_POINT"
+              echo "usb-mount: mounted $DEV at $MOUNT_POINT"
+              ;;
+            remove)
+              MOUNT_POINT=$(findmnt -nro TARGET "$DEV" 2>/dev/null || true)
+              if [[ -n "$MOUNT_POINT" && "$MOUNT_POINT" == "$USB_ROOT"/* ]]; then
+                umount -l "$MOUNT_POINT"
+                rmdir "$MOUNT_POINT" 2>/dev/null || true
+                echo "usb-mount: unmounted $DEV from $MOUNT_POINT"
+              fi
+              ;;
+            *)
+              echo "Usage: usb-mount.sh {add|remove} <device>" >&2
+              exit 1
+              ;;
+          esac
+
+    # USB automount: systemd template unit triggered by udev
+    - path: /etc/systemd/system/usb-mount@.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Mount USB device %i
+          After=local-fs.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/usr/local/bin/usb-mount.sh add %i
+          ExecStop=/usr/local/bin/usb-mount.sh remove %i
+
+    # Network: Static IP
+    - path: /etc/NetworkManager/system-connections/${NET_INTERFACE}.nmconnection
+      mode: 0600
+      contents:
+        inline: |
+          [connection]
+          id=${NET_INTERFACE}
+          type=ethernet
+          interface-name=${NET_INTERFACE}
+          autoconnect=true
+          autoconnect-priority=10
+
+          [ipv4]
+          method=manual
+          address1=${STATIC_IP}/${STATIC_PREFIX},${GATEWAY}
+          dns=${DNS_SERVERS}
+
+          [ipv6]
+          method=auto
+
+    # First-boot RAID setup script
+    # Finds the largest non-OS disk, creates a degraded RAID1, formats and mounts it.
+    - path: /usr/local/bin/setup-raid.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          # Best-effort status update — the helper may not exist on very
+          # early boots where this script runs before /usr/local/bin is
+          # writable, hence `|| true`.
+          /usr/local/bin/update-install-status.sh "Setting up data storage" "Detecting + formatting the largest non-OS disk. About 30 seconds." "setup-raid" 2>/dev/null || true
+          MOUNT_POINT="${DATA_ROOT}"
+          HOST_USER="${HOST_USER}"
+
+          # Find the OS disk (the one holding /)
+          # Newer FCOS uses composefs overlay for / — fall back to /sysroot
+          ROOT_SOURCE=$(findmnt -n -o SOURCE /)
+          if ! lsblk "$ROOT_SOURCE" &>/dev/null; then
+            ROOT_SOURCE=$(findmnt -n -o SOURCE /sysroot)
+          fi
+          OS_DISK=$(lsblk -ndo PKNAME "$ROOT_SOURCE" | head -1)
+
+          # Find the largest non-OS, non-removable disk
+          RAID_DISK=""
+          RAID_SIZE=0
+          for dev in $(lsblk -dnpo NAME -I 8,259,254 --sort SIZE); do
+            name=$(basename "$dev")
+            # Skip OS disk and its partitions
+            [[ "$name" == "$OS_DISK"* ]] && continue
+            # Skip removable (USB)
+            [[ "$(cat /sys/block/${name}/removable 2>/dev/null)" == "1" ]] && continue
+            size=$(blockdev --getsize64 "$dev" 2>/dev/null || echo 0)
+            if (( size > RAID_SIZE )); then
+              RAID_SIZE=$size
+              RAID_DISK=$dev
+            fi
+          done
+
+          if [[ -z "$RAID_DISK" ]]; then
+            echo "setup-raid: no suitable disk found for RAID. Skipping." >&2
+            exit 0
+          fi
+
+          echo "setup-raid: OS disk=$OS_DISK, RAID disk=$RAID_DISK ($(( RAID_SIZE / 1073741824 )) GiB)"
+
+          # Find the RAID device — the kernel may auto-assemble it under any /dev/mdN name.
+          # Check for existing auto-assembled arrays first, then try manual assembly, then create new.
+          MD_DEV=""
+
+          # 1) Check if any md device already uses a partition from RAID_DISK
+          for part in "${RAID_DISK}p1" "${RAID_DISK}1" "$RAID_DISK"; do
+            [[ -e "$part" ]] || continue
+            # Find which md device contains this partition
+            for md in /dev/md[0-9]*; do
+              [[ -e "$md" ]] || continue
+              if mdadm --detail "$md" 2>/dev/null | grep -q "$part"; then
+                MD_DEV="$md"
+                echo "setup-raid: found auto-assembled array $MD_DEV containing $part"
+                break 2
+              fi
+            done
+          done
+
+          # 2) Also check /dev/md/data symlink (may exist if we created the array)
+          if [[ -z "$MD_DEV" && -e /dev/md/data ]]; then
+            MD_DEV=$(readlink -f /dev/md/data)
+            echo "setup-raid: found /dev/md/data -> $MD_DEV"
+          fi
+
+          # 3) Try manual assembly if not already active
+          if [[ -z "$MD_DEV" ]]; then
+            for part in "${RAID_DISK}p1" "${RAID_DISK}1" "$RAID_DISK"; do
+              if [[ -e "$part" ]] && mdadm --examine "$part" &>/dev/null; then
+                echo "setup-raid: found RAID superblock on $part, assembling"
+                if mdadm --assemble /dev/md/data "$part" --run 2>/dev/null; then
+                  MD_DEV=$(readlink -f /dev/md/data)
+                  echo "setup-raid: assembled as $MD_DEV"
+                fi
+                break
+              fi
+            done
+          fi
+
+          # 4) Create new array if nothing found
+          if [[ -z "$MD_DEV" ]]; then
+            echo "setup-raid: no existing RAID found, creating new array"
+
+            # Partition the disk
+            wipefs -a "$RAID_DISK"
+            sgdisk -Z -n 1:0:0 -t 1:fd00 -c 1:raid1-ssd1 "$RAID_DISK"
+
+            # Wait for partition to appear
+            udevadm settle
+            PART="${RAID_DISK}1"
+            # For nvme disks the partition is e.g. /dev/nvme0n1p1
+            [[ -e "$PART" ]] || PART="${RAID_DISK}p1"
+
+            # Create degraded RAID1 (second disk missing)
+            mdadm --create /dev/md/data --level=1 --raid-devices=2 --metadata=1.2 \
+              --run "$PART" missing
+
+            # Format
+            mkfs.xfs -L data /dev/md/data
+            MD_DEV=$(readlink -f /dev/md/data)
+          fi
+
+          echo "setup-raid: using RAID device $MD_DEV"
+
+          # Persist mdadm config
+          mdadm --detail --scan >> /etc/mdadm.conf
+
+          # Ignition writes ServiceBay config to the OS disk at $MOUNT_POINT/servicebay.
+          # Before mounting the RAID over $MOUNT_POINT, save those files so we can
+          # copy them into the RAID afterwards.
+          IGNITION_TMP=""
+          if [[ -d "$MOUNT_POINT/servicebay" ]]; then
+            IGNITION_TMP=$(mktemp -d)
+            cp -a "$MOUNT_POINT/servicebay" "$IGNITION_TMP/"
+            echo "setup-raid: saved Ignition config from OS disk"
+          fi
+
+          # Mount RAID directly. We avoid `systemctl start var-mnt-data.mount`
+          # from inside this service because the synchronous systemctl call
+          # used to deadlock against the mount unit's previous After=setup-raid
+          # ordering (now removed, but a direct mount is simpler and faster
+          # anyway). The systemd mount unit still exists and will reattach the
+          # RAID on subsequent boots via its WantedBy=multi-user.target.
+          mkdir -p "$MOUNT_POINT"
+          if findmnt -n "$MOUNT_POINT" >/dev/null 2>&1; then
+            echo "setup-raid: $MOUNT_POINT already mounted, skipping"
+          else
+            mount "$MD_DEV" "$MOUNT_POINT"
+            echo "setup-raid: mounted $MD_DEV at $MOUNT_POINT"
+          fi
+
+          # Create data directories (no-op if they already exist)
+          mkdir -p "$MOUNT_POINT/servicebay/ssh" "$MOUNT_POINT/stacks"
+
+          # Apply Ignition config into RAID
+          if [[ -n "$IGNITION_TMP" && -d "$IGNITION_TMP/servicebay" ]]; then
+            # Always overwrite nodes.json and SSH keys (may change between installs)
+            for f in nodes.json ssh/id_rsa ssh/id_rsa.pub; do
+              if [[ -f "$IGNITION_TMP/servicebay/$f" ]]; then
+                cp "$IGNITION_TMP/servicebay/$f" "$MOUNT_POINT/servicebay/$f"
+              fi
+            done
+            # config.json: stage the new ISO copy alongside the existing
+            # one. setup-config-merge.service does the smart merge once
+            # python3 is available (we run too early here for python).
+            # On a fresh box (no existing config.json) we just rename
+            # the new one into place — no merge needed.
+            if [[ -f "$IGNITION_TMP/servicebay/config.json" ]]; then
+              if [[ -f "$MOUNT_POINT/servicebay/config.json" ]]; then
+                cp "$IGNITION_TMP/servicebay/config.json" "$MOUNT_POINT/servicebay/config.iso.json"
+                echo "setup-raid: existing config.json found, staged ISO copy as config.iso.json (merge runs after python install)"
+              else
+                cp "$IGNITION_TMP/servicebay/config.json" "$MOUNT_POINT/servicebay/config.json"
+                echo "setup-raid: no existing config.json, wrote ISO config directly"
+              fi
+            fi
+            rm -rf "$IGNITION_TMP"
+            echo "setup-raid: applied Ignition config to RAID"
+          fi
+
+          chmod 600 "$MOUNT_POINT/servicebay/ssh/id_rsa" 2>/dev/null || true
+          chown -R "$HOST_USER:$HOST_USER" "$MOUNT_POINT/servicebay" "$MOUNT_POINT/stacks"
+
+          # Restore Quadlet service definitions from RAID backup (reinstall scenario)
+          QUADLET_BACKUP="$MOUNT_POINT/servicebay/quadlet-backup"
+          QUADLET_DIR="/var/home/$HOST_USER/.config/containers/systemd"
+          if [[ -d "$QUADLET_BACKUP" ]] && ls "$QUADLET_BACKUP"/*.{kube,yml,container} &>/dev/null; then
+            echo "setup-raid: restoring Quadlet service definitions from RAID backup..."
+            mkdir -p "$QUADLET_DIR"
+            cp -a "$QUADLET_BACKUP"/*.kube "$QUADLET_DIR/" 2>/dev/null || true
+            cp -a "$QUADLET_BACKUP"/*.yml "$QUADLET_DIR/" 2>/dev/null || true
+            cp -a "$QUADLET_BACKUP"/*.container "$QUADLET_DIR/" 2>/dev/null || true
+            chown -R "$HOST_USER:$HOST_USER" "$QUADLET_DIR"
+            echo "setup-raid: restored $(ls "$QUADLET_DIR"/*.kube 2>/dev/null | wc -l) service(s)"
+          fi
+
+          # Note: nginx config lives directly on RAID at DATA_DIR/nginx/ — no restore needed,
+          # it survives reinstalls by being on the RAID mount itself.
+
+          echo "setup-raid: done. RAID1 mounted at $MOUNT_POINT"
+
+    # Systemd mount unit for RAID at /var/mnt/data (FCOS: /mnt -> /var/mnt)
+    # Uses filesystem label so it works regardless of md device number.
+    # nofail: don't block boot if RAID doesn't exist yet (first boot before setup-raid).
+    #
+    # NB: the previous After=setup-raid.service caused a one-hour first-boot
+    # deadlock — setup-raid.sh calls `systemctl start var-mnt-data.mount`
+    # synchronously, but systemd refused to start the mount until setup-raid
+    # was `active`, and setup-raid wasn't going active until the systemctl
+    # call returned. Relying solely on `Before=var-mnt-data.mount` declared
+    # *on setup-raid.service* (next unit below) preserves correct boot
+    # ordering while letting the explicit start call from inside setup-raid
+    # actually proceed.
+    - path: /etc/systemd/system/var-mnt-data.mount
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Mount RAID data volume
+          After=local-fs.target
+
+          [Mount]
+          What=LABEL=data
+          Where=/var/mnt/data
+          Type=xfs
+          Options=defaults,nofail
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # Systemd unit to run RAID setup on first boot only
+    - path: /etc/systemd/system/setup-raid.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=First-boot RAID1 setup (auto-detect largest disk)
+          ConditionPathExists=!/var/lib/setup-raid-done
+          After=local-fs.target systemd-udevd.service
+          Before=var-mnt-data.mount multi-user.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/bash /usr/local/bin/setup-raid.sh
+          ExecStartPost=/bin/touch /var/lib/setup-raid-done
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # User Linger (enables rootless services at boot)
+    - path: /var/lib/systemd/linger/${HOST_USER}
+      mode: 0644
+
+    # ServiceBay Quadlet (rootless).
+    #
+    # AUTH_SECRET is loaded from an EnvironmentFile on the persistent
+    # data volume (${DATA_ROOT}/servicebay/.auth-secret.env) so it
+    # survives OS reinstalls. Without this, every reinstall would
+    # regenerate AUTH_SECRET → all encrypted values in config.json
+    # (FritzBox password, NPM password, anything else sealed via the
+    # secrets helper) decrypt to garbage. The companion oneshot
+    # `servicebay-auth-secret-init.service` (declared below in
+    # `systemd.units`) writes that file on first boot if missing.
+    # See issue #565.
+    - path: /var/home/${HOST_USER}/.config/containers/systemd/servicebay.container
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          [Unit]
+          Description=ServiceBay Rootless Management Interface
+          After=network-online.target
+          # Don't start until the install chain has finished. The marker
+          # is written by install-nvidia-cdi.sh on GPU boxes (last step
+          # of the install chain) or by install-nvidia.sh stage-0 on
+          # no-GPU boxes (which short-circuits the chain immediately).
+          # Without this gate, servicebay would race the install on the
+          # intermediate boots between NVIDIA stages — pulling the image,
+          # binding 5888, and showing the operator a wizard mid-install
+          # that then gets thrown away by the next reboot. Started by
+          # the path unit servicebay-trigger.path the moment the marker
+          # appears, or directly at boot if the marker already exists.
+          ConditionPathExists=/var/lib/installation-ready
+          # Deliberately NO `Conflicts=servicebay-splash.service` here.
+          # Conflicts= is evaluated statically by systemd's transaction
+          # resolver when default.target is built — BEFORE conditions
+          # are checked at runtime. With both this unit AND splash in
+          # default.target.wants, the resolver drops splash's start job
+          # to satisfy the conflict, even though we wanted splash to
+          # start (because this unit's condition is false during install).
+          # Result on this box, observed live during the 2026-05-25
+          # reinstall: splash never activated, operator saw
+          # ERR_CONNECTION_REFUSED on :${SERVICEBAY_PORT} all through
+          # the install window. Fix is to handle the runtime port-handoff
+          # via ExecStartPre below instead — splash is stopped explicitly
+          # before podman binds the port, no static conflict required.
+          # Deliberately NO Requires=/After=servicebay-auth-secret-init.service.
+          # That unit is in the system instance and is invisible to user
+          # systemd here (a user unit referencing it by name fails to start
+          # with "Unit not found", #586). The ordering is already guaranteed
+          # by the init unit's `Before=user@1000.service` (see below) — by
+          # the time user systemd activates this Quadlet via linger, the
+          # EnvironmentFile is already on disk.
+
+          [Container]
+          Image=ghcr.io/mdopp/servicebay:${SERVICEBAY_VERSION}
+          ContainerName=servicebay
+          AutoUpdate=registry
+          Network=host
+          Volume=/run/user/1000/podman/podman.sock:/run/podman/podman.sock
+          Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
+          Volume=${DATA_ROOT}/servicebay:/app/data:Z
+          Environment=PORT=${SERVICEBAY_PORT}
+          Environment=NODE_ENV=production
+          Environment=HOST_USER=${HOST_USER}
+          EnvironmentFile=${DATA_ROOT}/servicebay/.auth-secret.env
+          Environment=SERVICEBAY_USERNAME=${SERVICEBAY_ADMIN_USER}
+          Environment=SERVICEBAY_PASSWORD=${SERVICEBAY_ADMIN_PASSWORD}
+          SecurityLabelDisable=true
+
+          [Service]
+          # Stop the splash sidecar before podman binds :${SERVICEBAY_PORT}
+          # so the port is free. Replaces the [Unit] Conflicts= directive
+          # that systemd's transaction resolver was dropping splash's
+          # start-job over (see [Unit] comment above). `--no-block` and
+          # the explicit `|| true` cover the case where splash isn't
+          # running (e.g. on a subsequent restart of this unit) — we
+          # don't want servicebay activation to fail just because there's
+          # no splash to stop.
+          ExecStartPre=-/usr/bin/systemctl --user stop servicebay-splash.service
+          # On the first successful servicebay activation, retire the
+          # splash Quadlet so it no longer appears in `systemctl --user
+          # list-units --all` on subsequent boots. The retire script
+          # renames the .container file (Quadlet's generator only
+          # processes files literally named *.container, so a renamed
+          # one is invisible). On reinstall, fresh Ignition writes a
+          # new .container file and splash re-engages — the retirement
+          # is per-install, not persistent across reinstalls.
+          # The leading `-` and the script's own idempotency mean a
+          # second run does nothing and never fails servicebay startup.
+          ExecStartPost=-/bin/bash /usr/local/bin/retire-splash-quadlet.sh
+          # Retry restart if it fails (e.g. socket not ready)
+          Restart=always
+          RestartSec=5
+
+          [Install]
+          WantedBy=default.target
+
+    # Boot/install progress page. Tiny busybox httpd serves three files
+    # from this directory on ${SERVICEBAY_PORT}:
+    #
+    #   index.html  — static SPA shell. Written ONCE by Ignition (this
+    #                 entry) and never rewritten. Has all the JS, polls
+    #                 the two data files below, handles reconnects on
+    #                 reboot, hard-reloads when ServiceBay takes over.
+    #   status.txt  — current stage. Tab-separated single line:
+    #                 <ISO-timestamp>\t<title>\t<description>
+    #                 Atomically rewritten by update-install-status.sh.
+    #   log.txt     — append-only narrative log, capped at ~8 KB.
+    #                 Install scripts tee key command output here.
+    #
+    # The split means a stage change only rewrites a tiny TSV file, the
+    # SPA in the browser persists across the whole install, and the
+    # operator sees both the current stage AND a live tail of activity.
+    # The same status.txt is consumed by the native install-watch dashboard
+    # (tools/sb-tui watch, #1274) on the operator's machine — no HTML scraping.
+    #
+    # Takeover detection: when servicebay.service activates, its
+    # ExecStartPre kills the splash. The SPA's polled fetches start
+    # failing, and after ~5 s of failures it asks for / and checks the
+    # title — if it no longer says "ServiceBay setup", it hard-reloads
+    # so Next.js can take over.
+    - path: /var/home/${HOST_USER}/.config/containers/splash/index.html
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>ServiceBay setup</title>
+          <style>
+          :root { color-scheme: dark light; }
+          html, body { margin: 0; padding: 0; min-height: 100%; }
+          body {
+            background: #0f1115; color: #e6e6e6;
+            font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            padding: 2rem 1rem;
+          }
+          main {
+            max-width: 44rem; margin: 0 auto;
+            padding: 1.5rem 2rem;
+            background: #181b22; border: 1px solid #2a2f3a;
+            border-radius: 14px;
+          }
+          h1 { font-size: 1.25rem; margin: 0 0 .5rem; text-align: center; }
+          .desc { color: #a9b0bc; margin: 0 0 1rem; text-align: center; }
+          .spinner {
+            width: 28px; height: 28px; margin: 1rem auto;
+            border: 3px solid #2a2f3a; border-top-color: #6aa6ff;
+            border-radius: 50%; animation: spin 1s linear infinite;
+          }
+          @keyframes spin { to { transform: rotate(360deg); } }
+          .meta { color: #6b7280; font-size: .8rem; text-align: center; margin: 0 0 1rem; }
+          .meta > span { margin: 0 .25rem; }
+          .badge {
+            display: inline-block; padding: .15rem .5rem; border-radius: 6px;
+            background: #1f2937; color: #9ca3af; font-size: .75rem;
+            font-family: ui-monospace, monospace;
+          }
+          .badge.connected { background: #064e3b; color: #6ee7b7; }
+          .badge.disconnected { background: #7f1d1d; color: #fca5a5; }
+          .log-header {
+            font-size: .75rem; color: #6b7280; margin: 1rem 0 .25rem;
+            text-transform: uppercase; letter-spacing: .05em;
+          }
+          pre {
+            margin: 0; padding: .75rem;
+            max-height: 18rem; overflow-y: auto;
+            background: #0a0c0f; border: 1px solid #2a2f3a; border-radius: 8px;
+            font: 11px/1.45 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+            color: #9ca3af;
+            white-space: pre-wrap; word-break: break-word;
+          }
+          </style>
+          </head>
+          <body>
+          <main>
+          <div class="spinner" aria-hidden="true"></div>
+          <h1 id="title">Booting…</h1>
+          <p class="desc" id="desc">The page refreshes automatically. The box may reboot a few times during setup.</p>
+          <div class="meta">
+            <span id="updated">connecting…</span>
+            <span class="badge" id="conn">offline</span>
+          </div>
+          <div class="log-header">Recent install activity</div>
+          <pre id="log">(waiting for log output)</pre>
+          </main>
+          <script>
+          (function () {
+            var $title = document.getElementById('title');
+            var $desc = document.getElementById('desc');
+            var $updated = document.getElementById('updated');
+            var $conn = document.getElementById('conn');
+            var $log = document.getElementById('log');
+            var lastStatusTs = null;
+            var consecutiveFails = 0;
+            var lastLogText = '';
+
+            function fmtSince(date) {
+              var s = Math.floor((Date.now() - date) / 1000);
+              if (s < 5) return 'just now';
+              if (s < 60) return s + 's ago';
+              if (s < 3600) return Math.floor(s/60) + 'm' + String(s%60).padStart(2,'0') + 's ago';
+              return Math.floor(s/3600) + 'h' + String(Math.floor((s%3600)/60)).padStart(2,'0') + 'm ago';
+            }
+
+            function setBadge(ok) {
+              $conn.textContent = ok ? 'connected' : 'reconnecting…';
+              $conn.className = 'badge ' + (ok ? 'connected' : 'disconnected');
+            }
+
+            async function checkTakeover() {
+              try {
+                var r = await fetch('/', { cache: 'no-store' });
+                if (!r.ok) return false;
+                var html = await r.text();
+                if (html.indexOf('ServiceBay setup') === -1) {
+                  window.location.reload();
+                  return true;
+                }
+              } catch (e) { /* still offline */ }
+              return false;
+            }
+
+            async function fetchStatus() {
+              try {
+                var r = await fetch('/status.txt', { cache: 'no-store' });
+                if (!r.ok) throw new Error('http ' + r.status);
+                var txt = (await r.text()).trim();
+                var parts = txt.split('\t');
+                var ts = parts[0], title = parts[1] || 'Installing…', desc = parts[2] || '';
+                $title.textContent = title;
+                $desc.textContent = desc;
+                if (ts) lastStatusTs = new Date(ts);
+                consecutiveFails = 0;
+                setBadge(true);
+              } catch (e) {
+                consecutiveFails++;
+                setBadge(false);
+                if (consecutiveFails > 5) await checkTakeover();
+              }
+            }
+
+            async function fetchLog() {
+              try {
+                var r = await fetch('/log.txt', { cache: 'no-store' });
+                if (!r.ok) return;
+                var txt = await r.text();
+                if (txt !== lastLogText) {
+                  $log.textContent = txt || '(empty)';
+                  lastLogText = txt;
+                  $log.scrollTop = $log.scrollHeight;
+                }
+              } catch (e) { /* handled by fetchStatus */ }
+            }
+
+            function updateAge() {
+              if (lastStatusTs) $updated.textContent = 'updated ' + fmtSince(lastStatusTs);
+            }
+
+            fetchStatus(); fetchLog();
+            setInterval(fetchStatus, 2000);
+            setInterval(fetchLog, 3000);
+            setInterval(updateAge, 1000);
+          })();
+          </script>
+          </body>
+          </html>
+
+    # Initial status.txt — overwritten by update-install-status.sh as
+    # soon as the first install service calls the helper. Has to exist
+    # at Ignition time so the SPA's first poll succeeds (busybox httpd
+    # returns 404 for missing files, which the SPA handles, but a real
+    # value is friendlier on first paint).
+    - path: /var/home/${HOST_USER}/.config/containers/splash/status.txt
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          1970-01-01T00:00:00Z	Booting…	Install services are starting. This page will fill in shortly.
+
+    # Initial log.txt — append-only narrative. Pre-created (empty plus
+    # a single banner line) so busybox can serve it without 404 on
+    # first SPA fetch.
+    - path: /var/home/${HOST_USER}/.config/containers/splash/log.txt
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          (boot — install activity will be logged below)
+
+    # Status-page helpers. Two scripts:
+    #
+    #   update-install-status.sh "Title" "Description" [component]
+    #     - rewrites status.txt (the SPA's current-stage source) atomically
+    #     - appends a line to log.txt
+    #     - keeps log.txt under ~8 KB by tail-truncating
+    #
+    #   append-install-log.sh "component" "message"
+    #     - appends a single line to log.txt (no status change)
+    #     - same truncation discipline
+    #
+    # Either script's output is plain text only — do not pass user
+    # input or shell metacharacters through them. The TSV format in
+    # status.txt sanitizes tabs/newlines defensively, but the goal is
+    # callers stay simple.
+    - path: /usr/local/bin/update-install-status.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+
+          TITLE="${1:-Installing ServiceBay…}"
+          DESC="${2:-Please leave this window open. The page refreshes automatically.}"
+          COMPONENT="${3:-status}"
+          SPLASH_DIR=/var/home/${HOST_USER}/.config/containers/splash
+          STATUS_FILE="$SPLASH_DIR/status.txt"
+          LOG_FILE="$SPLASH_DIR/log.txt"
+          NOW="$(/usr/bin/date -u +%FT%TZ)"
+
+          # Sanitize: status.txt is single-line TSV, so any tab/newline
+          # in the inputs would break parsing on the SPA side. Replace
+          # both with spaces.
+          TITLE_SAFE=$(printf '%s' "$TITLE" | /usr/bin/tr '\t\n' '  ')
+          DESC_SAFE=$(printf '%s' "$DESC" | /usr/bin/tr '\t\n' '  ')
+
+          # Atomic write of status.txt (temp + rename).
+          TMP="$(/usr/bin/mktemp "$SPLASH_DIR/.status.txt.XXXXXX")"
+          printf '%s\t%s\t%s\n' "$NOW" "$TITLE_SAFE" "$DESC_SAFE" > "$TMP"
+          /usr/bin/chown ${HOST_USER}:${HOST_USER} "$TMP" 2>/dev/null || true
+          /usr/bin/chmod 0644 "$TMP"
+          /usr/bin/mv -f "$TMP" "$STATUS_FILE"
+
+          # Append a line to log.txt (no temp+rename — append is atomic
+          # enough on local disk for our purposes, and busybox httpd
+          # reading mid-append at worst serves a partial last line).
+          printf '%s %s: %s\n' "$NOW" "$COMPONENT" "$TITLE_SAFE" >> "$LOG_FILE"
+
+          # Tail-truncate log.txt to ~8 KB.
+          LOG_SIZE=$(/usr/bin/stat -c %s "$LOG_FILE" 2>/dev/null || echo 0)
+          if [ "$LOG_SIZE" -gt 8192 ]; then
+              TMP2="$(/usr/bin/mktemp "$SPLASH_DIR/.log.txt.XXXXXX")"
+              /usr/bin/tail -c 6144 "$LOG_FILE" > "$TMP2"
+              /usr/bin/chown ${HOST_USER}:${HOST_USER} "$TMP2" 2>/dev/null || true
+              /usr/bin/chmod 0644 "$TMP2"
+              /usr/bin/mv -f "$TMP2" "$LOG_FILE"
+          fi
+
+          echo "install-status: $TITLE_SAFE ($NOW)"
+
+    # Append-to-log helper for install scripts that want to add a line
+    # without changing the headline stage. Useful inside loops or for
+    # arbitrary mid-stage progress notes ("polling lsmod attempt 5/30").
+    - path: /usr/local/bin/append-install-log.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+
+          COMPONENT="${1:-misc}"
+          MESSAGE="${2:-}"
+          SPLASH_DIR=/var/home/${HOST_USER}/.config/containers/splash
+          LOG_FILE="$SPLASH_DIR/log.txt"
+          NOW="$(/usr/bin/date -u +%FT%TZ)"
+          MESSAGE_SAFE=$(printf '%s' "$MESSAGE" | /usr/bin/tr '\n' ' ')
+
+          printf '%s %s: %s\n' "$NOW" "$COMPONENT" "$MESSAGE_SAFE" >> "$LOG_FILE"
+
+          LOG_SIZE=$(/usr/bin/stat -c %s "$LOG_FILE" 2>/dev/null || echo 0)
+          if [ "$LOG_SIZE" -gt 8192 ]; then
+              TMP="$(/usr/bin/mktemp "$SPLASH_DIR/.log.txt.XXXXXX")"
+              /usr/bin/tail -c 6144 "$LOG_FILE" > "$TMP"
+              /usr/bin/chown ${HOST_USER}:${HOST_USER} "$TMP" 2>/dev/null || true
+              /usr/bin/chmod 0644 "$TMP"
+              /usr/bin/mv -f "$TMP" "$LOG_FILE"
+          fi
+
+    # Splash Quadlet — runs the busybox httpd as a rootless container
+    # under the same `core` user as the real servicebay.container so
+    # both share the same image store (saving a duplicate pull). The
+    # `Image=docker.io/library/busybox:stable` is small (~2 MiB) so
+    # even a first-boot pull resolves quickly; once cached, every
+    # subsequent boot starts the splash within a second of linger.
+    - path: /var/home/${HOST_USER}/.config/containers/systemd/servicebay-splash.container
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          [Unit]
+          Description=ServiceBay boot-time splash page (#775)
+          After=network-online.target
+          # Only meaningful while installation is in progress. Once the
+          # install completes (install-nvidia-cdi.sh on GPU boxes, or
+          # install-nvidia.sh stage-0 on no-GPU boxes touches the marker),
+          # there is no install left to show — skip cleanly via
+          # ConditionPathExists so subsequent boots don't briefly start
+          # the splash just to immediately get killed by servicebay's
+          # ExecStartPre. On reinstall, this marker is wiped via the
+          # config-merge / setup-raid path, so splash re-engages.
+          # The unit still appears in `systemctl --user list-units --all`
+          # post-install but as "inactive (dead) / Condition: no" — the
+          # idiomatic systemd state for "this unit's job is done".
+          ConditionPathExists=!/var/lib/installation-ready
+          # Hand off to the real ServiceBay when it becomes available.
+          Before=servicebay.service
+
+          [Container]
+          Image=docker.io/library/busybox:stable
+          ContainerName=servicebay-splash
+          Network=host
+          # Volume mount uses :ro (not :ro,Z) — the :Z flag asks podman
+          # to set a unique-MCS SELinux xattr on the host directory,
+          # which rootless podman cannot do without CAP_SYS_ADMIN and
+          # fails at runtime with `lsetxattr(...): operation not
+          # permitted` (observed live on this box, 2026-05-25 reinstall).
+          # SecurityLabelDisable=true below means the container itself
+          # is unconfined from SELinux, so relabeling the volume is
+          # unnecessary anyway. Plain :ro is the right level of locking.
+          Volume=/var/home/${HOST_USER}/.config/containers/splash:/splash:ro
+          # `-f` keeps httpd in the foreground so podman/systemd sees
+          # process exits accurately. Default port mapping isn't used
+          # because Network=host means the container shares the host
+          # network namespace directly.
+          Exec=httpd -f -v -p ${SERVICEBAY_PORT} -h /splash
+          SecurityLabelDisable=true
+
+          [Service]
+          # Don't restart on exit — when servicebay.container stops us
+          # via Conflicts=, the SIGTERM is intentional and we want to
+          # stay down.
+          Restart=no
+
+          [Install]
+          WantedBy=default.target
+
+    # Splash-quadlet retire helper. Called once via servicebay.service's
+    # ExecStartPost when the install completes (so first successful
+    # start of the real ServiceBay). Renames the .container so the
+    # Quadlet generator stops emitting servicebay-splash.service on
+    # subsequent boots — the unit disappears entirely from
+    # `systemctl --user list-units --all` instead of lingering as
+    # "inactive (dead)" forever.
+    #
+    # Idempotent: a second run finds the renamed file and exits 0.
+    # Reversible: on reinstall, fresh Ignition writes a new .container
+    # file at the original path, so splash re-engages automatically.
+    # Runs as the `core` user (servicebay.service is user-level) so no
+    # sudo or polkit needed — `core` owns its own .config directory.
+    - path: /usr/local/bin/retire-splash-quadlet.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          QUADLET=/var/home/${HOST_USER}/.config/containers/systemd/servicebay-splash.container
+          RETIRED="$QUADLET.retired"
+
+          # servicebay.service's ExecStartPre stopped the splash via
+          # SIGTERM → SIGKILL (status=137), which leaves the unit in the
+          # `failed` state. systemctl daemon-reload doesn't clear that.
+          # Reset it here so `systemctl --user --failed` doesn't keep
+          # surfacing the splash as a problem for the lifetime of the
+          # box — this is the intended end state, not a real failure.
+          # Idempotent: reset-failed against a non-failed / unknown unit
+          # is a no-op + exit 0.
+          /usr/bin/systemctl --user reset-failed servicebay-splash.service 2>/dev/null || true
+
+          if [ ! -f "$QUADLET" ]; then
+              # Already retired (subsequent boots) — nothing left to do
+              # after the reset-failed above.
+              exit 0
+          fi
+
+          /usr/bin/mv -f "$QUADLET" "$RETIRED"
+          /usr/bin/systemctl --user daemon-reload || true
+          echo "retire-splash-quadlet: renamed $QUADLET → $RETIRED"
+
+    # Path unit that waits for /var/lib/installation-ready and starts
+    # servicebay.service the moment it appears. Lives in user systemd
+    # (alongside the servicebay Quadlet) so root and user instances stay
+    # decoupled. When the marker file is created by the last install
+    # step, this unit activates → systemd starts servicebay.service →
+    # ConditionPathExists on servicebay.service evaluates true →
+    # Conflicts= kills the splash → servicebay binds the port.
+    - path: /var/home/${HOST_USER}/.config/systemd/user/servicebay-trigger.path
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          [Unit]
+          Description=Trigger ServiceBay when /var/lib/installation-ready appears
+
+          [Path]
+          # Fires both when the file is created during this boot AND
+          # when this unit is started and the file already exists.
+          PathExists=/var/lib/installation-ready
+          Unit=servicebay.service
+
+          [Install]
+          WantedBy=default.target
+
+    # ServiceBay Initial Config (generated by install script)
+    - path: ${DATA_ROOT}/servicebay/config.json
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+${SERVICEBAY_CONFIG_JSON}
+
+    # ServiceBay nodes config (Local node with correct user)
+    - path: ${DATA_ROOT}/servicebay/nodes.json
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          [
+            {
+              "Name": "Local",
+              "URI": "ssh://${HOST_USER}@127.0.0.1",
+              "Identity": "/app/data/ssh/id_rsa",
+              "Default": true
+            }
+          ]
+
+    # ServiceBay SSH private key (pre-authorized for host access)
+    - path: ${DATA_ROOT}/servicebay/ssh/id_rsa
+      mode: 0600
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+${SERVICEBAY_SSH_PRIV}
+
+    # ServiceBay SSH public key
+    - path: ${DATA_ROOT}/servicebay/ssh/id_rsa.pub
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          ${SERVICEBAY_SSH_PUB}
+
+    # First-boot script to install Python3 (required by ServiceBay agent)
+    - path: /usr/local/bin/install-python.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          LOG_FILE=/var/home/${HOST_USER}/.config/containers/splash/log.txt
+          /usr/local/bin/update-install-status.sh "Installing Python runtime" "Layering python3 for the ServiceBay agent. About 30 seconds." "install-python" || true
+          echo "install-python: installing python3 via rpm-ostree..." | /usr/bin/tee -a "$LOG_FILE"
+          rpm-ostree install --apply-live --allow-inactive python3 2>&1 | /usr/bin/tee -a "$LOG_FILE"
+          echo "install-python: done" | /usr/bin/tee -a "$LOG_FILE"
+
+    # Systemd unit to install Python3 on first boot
+    - path: /etc/systemd/system/install-python.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Install Python3 for ServiceBay agent
+          ConditionPathExists=!/var/lib/install-python-done
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/bash /usr/local/bin/install-python.sh
+          ExecStartPost=/bin/touch /var/lib/install-python-done
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # NVIDIA GPU layer for hosts with an NVIDIA card. Runs at first boot
+    # in two stages — driver install (needs a reboot to load the kmod)
+    # and CDI generation (after the kmod is live). Marker files at
+    # /var/lib/install-nvidia-{driver,cdi}-done suppress re-runs.
+    #
+    # The script is a no-op on hosts without NVIDIA hardware, so it is
+    # safe to bake into every install. Gated by the operator's
+    # `ENABLE_NVIDIA` choice at ISO-build time (#680-followup): we only
+    # ship the unit when they opted in, so CPU-only nodes don't burn
+    # disk + boot time on rpmfusion layering.
+    - path: /usr/local/bin/install-nvidia.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          # Bail cleanly on hosts without an NVIDIA GPU. lspci is the
+          # cheapest detector — module load isn't reliable yet because
+          # the driver may not be present.
+          if ! /usr/sbin/lspci 2>/dev/null | grep -qi 'NVIDIA Corporation'; then
+              echo "install-nvidia: no NVIDIA GPU detected, skipping" >&2
+              # Mark every NVIDIA stage done so we don't keep retrying,
+              # and unlock servicebay startup immediately (no GPU work to
+              # wait on).
+              touch /var/lib/install-nvidia-repos-done /var/lib/install-nvidia-driver-done /var/lib/install-nvidia-cdi-done
+              touch /var/lib/installation-ready
+              /usr/local/bin/update-install-status.sh "Starting ServiceBay…" "Almost done. The wizard will open in a few seconds." "install-nvidia" || true
+              exit 0
+          fi
+
+          FEDORA_VERSION=$(/usr/bin/rpm -E %fedora)
+
+          # Stage 1 — layer the RPM Fusion release packages and drop the
+          # nvidia-container-toolkit repo file. RPM Fusion ships the
+          # nonfree NVIDIA driver; the container toolkit lives in
+          # NVIDIA's own libnvidia-container repo, which we have to add
+          # ourselves (Fedora does not ship it).
+          #
+          # rpm-ostree CANNOT install packages from a repo whose .repo
+          # file is part of a pending (not-yet-active) deployment — so
+          # `rpm-ostree install nvidia-package` in the same script run
+          # fails with "Packages not found". Split repo layering from
+          # driver layering with a reboot between.
+          LOG_FILE=/var/home/${HOST_USER}/.config/containers/splash/log.txt
+
+          if [ ! -f /var/lib/install-nvidia-repos-done ]; then
+              /usr/local/bin/update-install-status.sh "Adding NVIDIA repositories" "Layering RPM Fusion + NVIDIA container-toolkit repos. About 2 minutes, then the box reboots." "install-nvidia" || true
+              echo "install-nvidia: stage 1 — layering RPM Fusion repos + NVIDIA container-toolkit repo..." | /usr/bin/tee -a "$LOG_FILE"
+              # Tee rpm-ostree output to the splash log so the operator sees
+              # download / resolve progress in real time. PIPESTATUS picks up
+              # rpm-ostree's exit even if tee succeeds.
+              /usr/bin/rpm-ostree install --idempotent --allow-inactive \
+                  "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VERSION}.noarch.rpm" \
+                  "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VERSION}.noarch.rpm" 2>&1 | /usr/bin/tee -a "$LOG_FILE"
+              cat > /etc/yum.repos.d/nvidia-container-toolkit.repo <<'NVCT'
+          [nvidia-container-toolkit]
+          name=nvidia-container-toolkit
+          baseurl=https://nvidia.github.io/libnvidia-container/stable/rpm/$basearch
+          enabled=1
+          repo_gpgcheck=1
+          gpgcheck=1
+          gpgkey=https://nvidia.github.io/libnvidia-container/gpgkey
+          NVCT
+              touch /var/lib/install-nvidia-repos-done
+              echo "install-nvidia: RPM Fusion repos staged + nvidia-container-toolkit.repo dropped, scheduling reboot to activate."
+              /usr/bin/systemctl reboot
+              exit 0
+          fi
+
+          # Stage 2 — install the NVIDIA driver + container toolkit.
+          # `akmod-nvidia-open` is RPM Fusion's auto-kmod for NVIDIA's
+          # open kernel modules — the recommended path for Turing+
+          # GPUs including Ada Lovelace (RTX 2000/4000 Ada). Fedora has
+          # no native dkms; akmod rebuilds the module against the
+          # running kernel on first boot.  `nvidia-container-toolkit`
+          # ships `nvidia-ctk` (CDI generator, the podman-NVIDIA bridge
+          # since Container Toolkit ≥1.14) from NVIDIA's own repo
+          # dropped in stage 1.
+          if [ ! -f /var/lib/install-nvidia-driver-done ]; then
+              /usr/local/bin/update-install-status.sh "Installing NVIDIA driver + container toolkit" "Layering akmod-nvidia-open + cuda + container-toolkit. About 4 minutes, then the box reboots so the kernel module can build." "install-nvidia" || true
+              echo "install-nvidia: stage 2 — layering NVIDIA driver + container toolkit..." | /usr/bin/tee -a "$LOG_FILE"
+              /usr/bin/rpm-ostree install --idempotent --allow-inactive \
+                  akmod-nvidia-open \
+                  xorg-x11-drv-nvidia-cuda \
+                  nvidia-container-toolkit 2>&1 | /usr/bin/tee -a "$LOG_FILE"
+              touch /var/lib/install-nvidia-driver-done
+              echo "install-nvidia: driver staged, scheduling reboot to load kmod" | /usr/bin/tee -a "$LOG_FILE"
+              /usr/bin/systemctl reboot
+              exit 0
+          fi
+
+          # Stage 3 (kmod load + CDI generation) used to live here, but it
+          # mixed two very different timescales into one service: the
+          # synchronous rpm-ostree layering above (minutes), and the
+          # asynchronous akmod build that produces the nvidia kernel
+          # module (potentially 10+ min on cold-cache hardware, with
+          # akmods.service condition-skipped on FCoS so we can't even
+          # synchronously wait for it). A single TimeoutStartSec covers
+          # both badly — too short and we miss the late kmod load and
+          # leave CDI ungenerated (#982); too long and operators stare
+          # at "starting…" for the full ceiling on every install.
+          # The kmod-load → CDI-generate phase is now its own service
+          # + timer (install-nvidia-cdi.{service,timer}), which retries
+          # every 60 s until the kmod actually appears, then writes the
+          # markers and skips forever.
+          echo "install-nvidia: driver + container-toolkit layered, CDI handled by install-nvidia-cdi.timer"
+          echo "install-nvidia: done"
+
+    - path: /etc/systemd/system/install-nvidia.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Install NVIDIA driver + container toolkit (idempotent)
+          # Stops running once the driver has been layered (stage 2).
+          # The kmod-load + CDI generation is the separate
+          # install-nvidia-cdi.{service,timer} pair.
+          ConditionPathExists=!/var/lib/install-nvidia-driver-done
+          After=network-online.target install-python.service
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          # Long timeout — rpm-ostree layering itself can take several
+          # minutes on cold-cache, especially on slow ARM / mini-PC
+          # class hardware. (The kmod build no longer lives here.)
+          TimeoutStartSec=900
+          ExecStart=/bin/bash /usr/local/bin/install-nvidia.sh
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # CDI-generation phase, decoupled from install-nvidia.service.
+    #
+    # Why split: the akmod build that produces the nvidia kernel
+    # module runs asynchronously after stage-2's rpm-ostree layering
+    # + reboot. On Fedora CoreOS, akmods.service is intentionally
+    # condition-skipped (`ConditionPathExists=!/run/ostree-booted`),
+    # so we can't synchronously wait on it. The build can finish
+    # anywhere from ~1 min to >10 min after boot depending on cache
+    # warmth and CPU. A single service with a hard timeout will
+    # either give up too early (#982 on RTX 2000 Ada — kmod appeared
+    # at min ~5–60, the 3-min poll missed it) or burn the operator's
+    # patience on every install.
+    #
+    # The service below runs once per timer fire. Each fire does a
+    # short internal poll (60 s) for the kmod; if it's not loaded,
+    # exit 1 and let the timer retry in 60 s. Once CDI is generated,
+    # the unit's ConditionPathExists short-circuits and future timer
+    # fires are free no-ops.
+    - path: /usr/local/bin/install-nvidia-cdi.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+
+          LOG_FILE=/var/home/${HOST_USER}/.config/containers/splash/log.txt
+
+          if [ -f /var/lib/install-nvidia-cdi-done ]; then
+              echo "install-nvidia-cdi: already done, skipping"
+              exit 0
+          fi
+
+          /usr/local/bin/update-install-status.sh "Waiting for NVIDIA kernel module" "akmods compiles the nvidia driver against the running kernel. 1 to 10 minutes depending on hardware." "install-nvidia-cdi" || true
+
+          # Kick akmods --force exactly once if the kmod isn't already
+          # loaded and akmodsbuild isn't already running. On Fedora
+          # CoreOS, akmods.service is condition-skipped
+          # (ConditionPathExists=!/run/ostree-booted) — by design,
+          # because the rootfs is read-only — so nothing auto-builds
+          # the akmod after stage-2's rpm-ostree layering finishes.
+          # Without this kick, the kmod NEVER loads on FCoS, the
+          # `for` loop below polls /proc/modules forever, and the
+          # operator sits at "Waiting for NVIDIA kernel module" until
+          # they SSH in and run akmods themselves. Observed live on
+          # this box, 2026-05-25: 28 minutes of wasted polling.
+          # The build itself takes ~3-4 minutes on RTX-class hardware;
+          # we kick it in the background and let the per-60s timer
+          # retries catch it on the second or third fire.
+          if ! /usr/bin/grep -q '^nvidia ' /proc/modules \
+               && ! /usr/bin/pgrep -af 'akmodsbuild' >/dev/null 2>&1 \
+               && [ ! -f /var/lib/install-nvidia-akmods-kicked ]; then
+              echo "install-nvidia-cdi: kmod not loaded + no akmodsbuild running — kicking akmods --force in background" | /usr/bin/tee -a "$LOG_FILE"
+              /usr/local/bin/append-install-log.sh "install-nvidia-cdi" "akmods --force kicked in background; build takes ~3-5 min" 2>/dev/null || true
+              /usr/bin/touch /var/lib/install-nvidia-akmods-kicked
+              /usr/bin/nohup /usr/sbin/akmods --force >/var/log/install-nvidia-akmods.log 2>&1 &
+              disown 2>/dev/null || true
+          fi
+
+          # Force-load the kmod — udev's GPU-triggered autoload can
+          # race the boot path. modprobe failing here is fine; the
+          # /proc/modules check below is the actual gate.
+          /usr/sbin/modprobe nvidia 2>/dev/null || true
+
+          # IMPORTANT: read /proc/modules directly instead of
+          # `lsmod | grep -q`. With `set -o pipefail` (line 2 above),
+          # `lsmod | grep -q "^nvidia "` returns 141 (SIGPIPE) when
+          # there IS a match: grep -q exits as soon as it sees the
+          # first match, closes its stdin, lsmod gets SIGPIPE mid-write
+          # of its ~165 lines, dies with exit 141, pipefail propagates
+          # that 141 to the whole pipeline, and our `if` treats 141 as
+          # "no match" → the loop never breaks even though the kmod is
+          # loaded. Observed live on this box, 2026-05-25: 28 minutes
+          # of fruitless polling while nvidia was sitting loaded in
+          # lsmod. /proc/modules has no pipe = no SIGPIPE = no bug.
+          # lsmod itself just formats /proc/modules anyway.
+
+          # Short internal poll (1 min) so we don't always burn an
+          # extra timer-fire when the kmod is moments from loading.
+          for i in $(/usr/bin/seq 1 30); do
+              if /usr/bin/grep -q '^nvidia ' /proc/modules; then break; fi
+              sleep 2
+          done
+
+          if ! /usr/bin/grep -q '^nvidia ' /proc/modules; then
+              echo "install-nvidia-cdi: nvidia kmod not loaded yet — retrying via timer in 60 s"
+              exit 1
+          fi
+
+          /usr/local/bin/update-install-status.sh "Configuring GPU passthrough" "Generating CDI descriptor for podman → GPU." "install-nvidia-cdi" || true
+
+          echo "install-nvidia-cdi: nvidia kmod loaded, generating CDI..." | /usr/bin/tee -a "$LOG_FILE"
+          /usr/bin/mkdir -p /etc/cdi
+          if ! /usr/bin/nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>&1 | /usr/bin/tee -a "$LOG_FILE"; then
+              echo "install-nvidia-cdi: nvidia-ctk cdi generate failed — retrying via timer in 60 s" | /usr/bin/tee -a "$LOG_FILE" >&2
+              exit 1
+          fi
+
+          echo "install-nvidia-cdi: CDI config at /etc/cdi/nvidia.yaml" | /usr/bin/tee -a "$LOG_FILE"
+          /usr/bin/nvidia-ctk cdi list 2>&1 | /usr/bin/tee -a "$LOG_FILE" || true
+
+          # Marker for ServiceBay's assembler — when present, the
+          # OLLAMA_GPU_PASSTHROUGH wizard variable defaults to "yes"
+          # so ollama runs on the GPU out of the box without the
+          # operator having to discover the toggle.
+          /usr/bin/mkdir -p /mnt/data/servicebay
+          /usr/bin/touch /mnt/data/servicebay/.has-nvidia-cdi
+
+          # done-marker LAST so a crash mid-script triggers a retry.
+          touch /var/lib/install-nvidia-cdi-done
+
+          # Unlock servicebay.service. The path unit
+          # servicebay-trigger.path observes this file and triggers
+          # servicebay.service, whose ExecStartPre stops the splash
+          # before podman binds the port.
+          /usr/local/bin/update-install-status.sh "Starting ServiceBay…" "GPU ready. Handing off to ServiceBay. The wizard will appear in a few seconds." "install-nvidia-cdi" || true
+          touch /var/lib/installation-ready
+          echo "install-nvidia-cdi: done" | /usr/bin/tee -a "$LOG_FILE"
+
+    - path: /etc/systemd/system/install-nvidia-cdi.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Generate NVIDIA CDI config once the kmod is loaded
+          # Only meaningful once the driver has been layered.
+          ConditionPathExists=/var/lib/install-nvidia-driver-done
+          # Skip forever once CDI is generated.
+          ConditionPathExists=!/var/lib/install-nvidia-cdi-done
+
+          [Service]
+          Type=oneshot
+          # Each attempt is bounded by the script's 1-min internal
+          # poll + the CDI generation step. 5 min is well past that
+          # but small enough to not look like a hang.
+          TimeoutStartSec=300
+          ExecStart=/bin/bash /usr/local/bin/install-nvidia-cdi.sh
+
+    - path: /etc/systemd/system/install-nvidia-cdi.timer
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Retry NVIDIA CDI generation until the kmod is available
+
+          [Timer]
+          # First attempt 30 s into the boot — gives udev a moment to
+          # autoload the module if the build had already finished.
+          OnBootSec=30s
+          # Retry 60 s after the service goes inactive (success or
+          # failure both qualify as "inactive"; on success the
+          # ConditionPathExists makes the next fire a no-op).
+          OnUnitInactiveSec=60s
+          Unit=install-nvidia-cdi.service
+
+          [Install]
+          WantedBy=timers.target
+
+    # Script to disable USB/removable boot entries on first successful SSD boot.
+    # This prevents the BIOS from booting the live USB again on subsequent reboots.
+    - path: /usr/local/bin/disable-usb-boot.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+
+          if [ -f /var/lib/disable-usb-boot-done ]; then
+              echo "disable-usb-boot: already completed, skipping"
+              exit 0
+          fi
+
+          echo "disable-usb-boot: neutralizing USB UEFI boot entries..."
+          # Get all USB/removable boot entries. Plain $-syntax — same envsubst
+          # whitelist + 'EOF' heredoc story as install-python.sh / setup-raid.sh /
+          # usb-mount.sh / install-nginx.sh. (Earlier draft over-escaped with $$
+          # and tripped exactly the bug #910 fixed in install-nvidia.sh.)
+          USB_LIST=$(/usr/bin/efibootmgr -v | /usr/bin/grep -i 'usb\|removable' | /usr/bin/grep -oP 'Boot\K[0-9A-Fa-f]+' || true)
+
+          if [[ -n "$USB_LIST" ]]; then
+            for i in $USB_LIST; do
+              echo "disable-usb-boot: disabling boot entry Boot$i"
+              /usr/bin/efibootmgr -A -b "$i" || true
+            done
+
+            # Also remove them from the current BootOrder
+            CURRENT=$(/usr/bin/efibootmgr | /usr/bin/grep -oP 'BootOrder: \K.*' || true)
+            if [[ -n "$CURRENT" ]]; then
+              NEW_ORDER="$CURRENT"
+              for i in $USB_LIST; do
+                NEW_ORDER=$(echo "$NEW_ORDER" | sed -E "s/,$i|^$i,//; s/$i//")
+              done
+              # Append them to the end so they are technically bootable if selected manually
+              NEW_ORDER=$(echo "$NEW_ORDER" | tr -s ',' | sed 's/^,//; s/,$//')
+              for i in $USB_LIST; do
+                NEW_ORDER="$NEW_ORDER,$i"
+              done
+              NEW_ORDER=$(echo "$NEW_ORDER" | tr -s ',' | sed 's/^,//; s/,$//')
+
+              echo "disable-usb-boot: setting new BootOrder to $NEW_ORDER"
+              /usr/bin/efibootmgr -o "$NEW_ORDER" || true
+            fi
+          else
+            echo "disable-usb-boot: no USB boot entries found"
+          fi
+
+          touch /var/lib/disable-usb-boot-done
+          echo "disable-usb-boot: completed"
+
+    # Systemd unit to run the disable-usb-boot script once on first SSD boot
+    - path: /etc/systemd/system/disable-usb-boot.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Disable USB/removable boot entries on first SSD boot
+          ConditionPathExists=!/var/lib/disable-usb-boot-done
+          After=local-fs.target
+          
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/bash /usr/local/bin/disable-usb-boot.sh
+          
+          [Install]
+          WantedBy=multi-user.target
+
+    # Re-install config-merge script (#331). On a re-install, setup-raid
+    # leaves the existing config.json alone (so runtime-managed values
+    # like encrypted password hashes + LLDAP creds + NPM creds + post-
+    # deploy run history aren't lost) but stages the freshly-rendered
+    # ISO config as `config.iso.json` alongside. This script combines
+    # the two:
+    #   - starts from the new ISO config (operator's current intent)
+    #   - overlays a small whitelist of runtime-managed paths from the
+    #     old config (everything else from the new ISO wins)
+    #   - writes back atomically + removes config.iso.json
+    #
+    # Without this, every new schema field added in a future ServiceBay
+    # release silently fails to land on re-installed boxes.
+    - path: /usr/local/bin/setup-config-merge.py
+      mode: 0755
+      contents:
+        inline: |
+          #!/usr/bin/env python3
+          """Merge a freshly-staged ISO config (config.iso.json) into the
+          existing config.json on a re-install, preserving runtime-managed
+          fields. Idempotent: no-op when config.iso.json doesn't exist."""
+          import json
+          import os
+          import sys
+
+          DIR = "/var/mnt/data/servicebay"
+          OLD = os.path.join(DIR, "config.json")
+          NEW = os.path.join(DIR, "config.iso.json")
+
+          # Paths whose value the runtime owns (not the install prompts).
+          # Everything not on this list takes its value from the new ISO
+          # config — that mirrors what the operator just typed.
+          PRESERVE_PATHS = [
+              ("auth", "password"),
+              ("auth", "passwordHash"),
+              ("lldap",),
+              ("reverseProxy", "npm"),
+              ("reverseProxy", "lanIp"),
+              ("reverseProxy", "lanIpHistory"),
+              ("servicePostDeploy",),
+              ("agent",),
+          ]
+
+          def get_path(obj, path):
+              cur = obj
+              for k in path:
+                  if not isinstance(cur, dict) or k not in cur:
+                      return None, False
+                  cur = cur[k]
+              return cur, True
+
+          def set_path(obj, path, value):
+              cur = obj
+              for k in path[:-1]:
+                  if k not in cur or not isinstance(cur[k], dict):
+                      cur[k] = {}
+                  cur = cur[k]
+              cur[path[-1]] = value
+
+          def main():
+              if not os.path.exists(NEW):
+                  return 0
+              if not os.path.exists(OLD):
+                  os.replace(NEW, OLD)
+                  print("setup-config-merge: no prior config.json, ISO copy promoted in place.")
+                  return 0
+              with open(OLD) as f:
+                  old = json.load(f)
+              with open(NEW) as f:
+                  new = json.load(f)
+              merged = new
+              kept = 0
+              for path in PRESERVE_PATHS:
+                  val, found = get_path(old, path)
+                  if found:
+                      set_path(merged, path, val)
+                      kept += 1
+              # Tag the merge so the dashboard can show a "Welcome
+              # back — services restoring" banner instead of a silent
+              # boot (#337). Only set on the merge path; a true fresh
+              # install (no prior config.json) goes through the
+              # promote-in-place branch above and leaves `reinstall`
+              # unset.
+              import datetime
+              merged["reinstall"] = {"completedAt": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
+              tmp = OLD + ".merge.tmp"
+              with open(tmp, "w") as f:
+                  json.dump(merged, f, indent=2)
+              # ServiceBay runs as the host user (uid 1000, `core`).
+              # This service runs as root, so without explicit chown
+              # the merged config.json ends up root:root and the
+              # container gets EACCES when reading it. getConfig()'s
+              # catch then falls back to DEFAULT_CONFIG, migrateConfig
+              # saves that empty default, and every install-time value
+              # (auth, gateway, bootstrap token, setupCompleted,
+              # stackSetupPending) vanishes silently. Match the
+              # ownership setup-raid uses for everything else in
+              # /var/mnt/data/servicebay.
+              try:
+                  import pwd
+                  core = pwd.getpwnam("core")
+                  os.chown(tmp, core.pw_uid, core.pw_gid)
+              except (KeyError, OSError):
+                  # Static fallback — install-fedora-coreos.sh always
+                  # creates `core` with uid/gid 1000.
+                  os.chown(tmp, 1000, 1000)
+              os.chmod(tmp, 0o600)
+              os.replace(tmp, OLD)
+              os.remove(NEW)
+              print(f"setup-config-merge: merged config.iso.json into config.json (preserved {kept} runtime path(s)).")
+
+              # Wipe install-jobs from the previous OS instance. The
+              # job files survive a re-install (RAID mount), and the
+              # OnboardingWizard's auto-open gates on "no terminal
+              # job exists" — stale jobs from before the re-install
+              # suppress the wizard. They're also useless after a re-
+              # install: their logs reference container IDs and paths
+              # that no longer exist. Drop them so the wizard fires
+              # cleanly on first boot.
+              import shutil
+              jobs_dir = os.path.join(DIR, "install-jobs")
+              if os.path.isdir(jobs_dir):
+                  try:
+                      shutil.rmtree(jobs_dir)
+                      print("setup-config-merge: cleared stale install-jobs from previous OS install.")
+                  except OSError as e:
+                      print(f"setup-config-merge: could not clear install-jobs: {e}", file=sys.stderr)
+              return 0
+
+          if __name__ == "__main__":
+              sys.exit(main())
+
+    # secret.key init — companion to .auth-secret.env. Same first-boot-
+    # only semantics: write 32 random bytes only when the file is
+    # missing, leave any pre-existing key untouched. Without this, a
+    # re-install would regenerate the symmetric key used by
+    # `secrets.ts:encrypt/decrypt` for `SENSITIVE_KEYS` in config.json
+    # — every `enc:v1:…` value already on disk would fail GCM auth-tag
+    # verification, the previous fallback returned the literal
+    # ciphertext as plaintext, and downstream services adopted that
+    # ciphertext as their actual admin password. See #780.
+    - path: /etc/systemd/system/servicebay-secret-key-init.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Initialise persistent secret.key for ServiceBay (#780)
+          DefaultDependencies=no
+          After=var-mnt-data.mount local-fs.target
+          RequiresMountsFor=/var/mnt/data
+          Before=user@1000.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          # `openssl rand 32` writes raw bytes (not hex) — matches the
+          # 32-byte format expected by aes-256-gcm in secrets.ts.
+          # umask 0177 → mode 0600 on creation; chmod after for safety.
+          ExecStart=/usr/bin/sh -c '\
+            install -d -m 0755 -o ${HOST_USER} -g ${HOST_USER} /var/mnt/data/servicebay; \
+            if [ ! -s /var/mnt/data/servicebay/secret.key ]; then \
+              umask 0177; \
+              /usr/bin/openssl rand 32 > /var/mnt/data/servicebay/secret.key; \
+              chmod 0600 /var/mnt/data/servicebay/secret.key; \
+              chown ${HOST_USER}:${HOST_USER} /var/mnt/data/servicebay/secret.key; \
+              echo "secret.key written (fresh install or first migration)"; \
+            else \
+              echo "secret.key preserved from previous install"; \
+            fi'
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # AUTH_SECRET init — generates a fresh secret on first boot if no
+    # persistent one exists yet. Re-installs find the existing file and
+    # leave it alone so encrypted values in config.json keep decrypting.
+    # See #565.
+    - path: /etc/systemd/system/servicebay-auth-secret-init.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Initialise persistent AUTH_SECRET for ServiceBay (#565)
+          DefaultDependencies=no
+          After=var-mnt-data.mount local-fs.target
+          RequiresMountsFor=/var/mnt/data
+          Before=user@1000.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          # mkdir is idempotent; the conditional generation lives in the
+          # shell script so an existing .auth-secret.env survives intact
+          # even when this oneshot re-runs (e.g. after `systemctl daemon-reload`).
+          # systemd treats `%s` in ExecStart= as a specifier ($SHELL) and
+          # substitutes it *before* invoking sh. Pre-fix: the printf format
+          # string was rewritten from "AUTH_SECRET=%s\n" to
+          # "AUTH_SECRET=/bin/bash\n" — so every fresh install wrote that
+          # 9-char nonsense into .auth-secret.env, and ServiceBay's
+          # assertAuthSecret() (≥32 chars required) crashed the container
+          # in a restart loop. Escape with `%%s` so systemd renders it as
+          # literal `%s` before the shell sees it. Same fix anywhere
+          # `printf` is used inside ExecStart=/usr/bin/sh -c.
+          ExecStart=/usr/bin/sh -c '\
+            install -d -m 0755 -o ${HOST_USER} -g ${HOST_USER} /var/mnt/data/servicebay; \
+            if [ ! -s /var/mnt/data/servicebay/.auth-secret.env ]; then \
+              SECRET=$$(/usr/bin/openssl rand -hex 32); \
+              umask 0177; \
+              printf "AUTH_SECRET=%%s\\n" "$$SECRET" > /var/mnt/data/servicebay/.auth-secret.env; \
+              chown ${HOST_USER}:${HOST_USER} /var/mnt/data/servicebay/.auth-secret.env; \
+              echo "AUTH_SECRET written (fresh install or first migration)"; \
+            else \
+              echo "AUTH_SECRET preserved from previous install"; \
+            fi'
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # Systemd unit for the config-merge — runs once after install-python
+    # so python3 is guaranteed available, before servicebay.service.
+    - path: /etc/systemd/system/setup-config-merge.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Merge re-install ISO config into existing config.json (#331)
+          ConditionPathExists=/var/mnt/data/servicebay/config.iso.json
+          After=install-python.service var-mnt-data.mount servicebay-auth-secret-init.service servicebay-secret-key-init.service
+          Requires=install-python.service var-mnt-data.mount
+          # No `Before=servicebay.service` — that unit is in the user
+          # systemd instance (Quadlet under ~/.config/containers/systemd)
+          # and isn't visible to the system bus. The user instance only
+          # starts after the system reaches multi-user.target, which
+          # this oneshot is ordered into via WantedBy below — so the
+          # merge always completes before the container reads config.
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/usr/bin/python3 /usr/local/bin/setup-config-merge.py
+
+          [Install]
+          WantedBy=multi-user.target
+
+    # First-boot script to install Nginx reverse proxy via ServiceBay API
+    - path: /usr/local/bin/install-nginx.sh
+      mode: 0755
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          PORT="${SERVICEBAY_PORT:-3000}"
+          API="http://localhost:$PORT"
+          API_WAIT=1800       # 30 min for ServiceBay API + agent. Earlier
+                              # 5-min cap timed out before the agent came
+                              # up on slow first-boots, leaving the unit in
+                              # `failed` state forever even though NPM was
+                              # later installed cleanly via the wizard.
+          INSTALLED_WAIT=1800 # 30 min for nginx to appear via the onboarding
+                              # wizard before we step in. Avoids racing the
+                              # interactive install which can take a while
+                              # to reach the "Reverse Proxy" step.
+          WAITED=0
+          MARKER=/var/home/${HOST_USER}/.config/install-nginx-done
+
+          # Always touch the marker on EXIT (success OR failure). The marker's
+          # ConditionPathExists in the .service unit then suppresses the unit
+          # on subsequent boots — even if this run gave up because the
+          # operator had already installed NPM via the wizard, we're done
+          # and the wizard owns NPM going forward. Without this trap a
+          # one-time wait timeout produced an permanently-`failed` unit
+          # the operator couldn't get rid of without a manual reset-failed.
+          trap 'mkdir -p "$(dirname "$MARKER")" && touch "$MARKER"' EXIT
+
+          # Helper: returns 0 if NPM is reported as installed, 1 otherwise.
+          is_installed() {
+            curl -sf "$API/api/system/nginx/status" 2>/dev/null \
+              | grep -q '"installed":true'
+          }
+
+          echo "install-nginx: waiting for ServiceBay API on port $PORT (up to ${API_WAIT}s)..."
+          while ! curl -sf "$API/api/system/nginx/status" >/dev/null 2>&1; do
+            sleep 5
+            WAITED=$((WAITED + 5))
+            if (( WAITED >= API_WAIT )); then
+              echo "install-nginx: timeout waiting for ServiceBay API after ${API_WAIT}s — assume the operator will install NPM via the wizard" >&2
+              exit 0
+            fi
+          done
+
+          # Quick win: if NPM is already installed by the time the API is
+          # reachable (interactive wizard finished first), skip everything.
+          if is_installed; then
+            echo "install-nginx: nginx already installed — nothing to do"
+            exit 0
+          fi
+
+          # Wait for at least one agent to be connected (needs python3 first).
+          echo "install-nginx: waiting for agent to connect..."
+          while true; do
+            if is_installed; then
+              echo "install-nginx: nginx came up while we were waiting — done"
+              exit 0
+            fi
+            CONNECTED=$(curl -sf "$API/api/system/health" | grep -o '"isConnected":true' || true)
+            if [[ -n "$CONNECTED" ]]; then break; fi
+            sleep 5
+            WAITED=$((WAITED + 5))
+            if (( WAITED >= API_WAIT )); then
+              echo "install-nginx: timeout waiting for agent after ${API_WAIT}s — operator will install NPM via the wizard" >&2
+              exit 0
+            fi
+          done
+          echo "install-nginx: agent connected"
+
+          # Poll for installed=true. The operator may install NPM via the
+          # onboarding wizard concurrently — don't race it.
+          echo "install-nginx: polling for nginx-web service (up to ${INSTALLED_WAIT}s for the wizard to finish)..."
+          POLL_WAITED=0
+          while (( POLL_WAITED < INSTALLED_WAIT )); do
+            if is_installed; then
+              echo "install-nginx: nginx is installed, nothing to do"
+              exit 0
+            fi
+            sleep 30
+            POLL_WAITED=$((POLL_WAITED + 30))
+          done
+
+          echo "install-nginx: wizard didn't install nginx in ${INSTALLED_WAIT}s, attempting install ourselves..."
+          for attempt in 1 2 3; do
+            if curl -sf -X POST "$API/api/system/nginx/install"; then
+              echo "install-nginx: done"
+              exit 0
+            fi
+            echo "install-nginx: attempt $attempt failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "install-nginx: all attempts failed — install nginx manually from Settings → Reverse Proxy" >&2
+          # Marker still gets touched by the trap so the unit doesn't keep
+          # showing `failed` on every boot. Operator sees the warning above
+          # in journalctl and the diagnose probe surfaces the missing NPM.
+          exit 1
+
+    # Systemd user unit to install Nginx on first boot
+    - path: /var/home/${HOST_USER}/.config/systemd/user/install-nginx.service
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          [Unit]
+          Description=Install Nginx reverse proxy via ServiceBay
+          ConditionPathExists=!/var/home/${HOST_USER}/.config/install-nginx-done
+          After=servicebay.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/bash /usr/local/bin/install-nginx.sh
+          ExecStartPost=/bin/touch /var/home/${HOST_USER}/.config/install-nginx-done
+
+          [Install]
+          WantedBy=default.target
+
+    # First-boot script to restore USB as first boot device (enables reinstall via USB)
+    - path: /usr/local/bin/restore-usb-boot.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          # Restore USB as first boot device so reinserting the USB stick triggers reinstall
+          USB_ENTRY=$(efibootmgr | grep -i -m1 'usb\|UEFI.*USB\|removable' | grep -oP 'Boot\K[0-9A-Fa-f]+')
+          if [[ -n "$USB_ENTRY" ]]; then
+            CURRENT=$(efibootmgr | grep -oP 'BootOrder: \K.*')
+            NEW="$USB_ENTRY,$(echo "$CURRENT" | sed "s/$USB_ENTRY,\?//;s/,$//")"
+            efibootmgr -o "$NEW"
+            echo "restore-usb-boot: boot order set to $NEW (USB first)"
+          else
+            echo "restore-usb-boot: no USB boot entry found, skipping"
+          fi
+
+          # Write GRUB custom menu entry for USB reinstall
+          mount -o remount,rw /boot 2>/dev/null || true
+          cat > /boot/grub2/custom.cfg <<'GRUBCFG'
+          set timeout=3
+          menuentry 'Reinstall from USB' --class usb {
+            insmod chain
+            insmod part_gpt
+            # Try non-primary disks (NVMe OS disk is typically hd0)
+            for i in 1 2 3 4; do
+              for p in 1 2; do
+                if [ -f (hd$i,gpt$p)/EFI/BOOT/BOOTX64.EFI ]; then
+                  chainloader (hd$i,gpt$p)/EFI/BOOT/BOOTX64.EFI
+                  boot
+                fi
+              done
+            done
+            echo "No USB boot device found. Entering UEFI firmware setup..."
+            sleep 3
+            fwsetup
+          }
+          GRUBCFG
+          echo "restore-usb-boot: wrote GRUB custom menu entry"
+
+    # Systemd unit to restore USB-first boot order on first boot
+    - path: /etc/systemd/system/restore-usb-boot.service
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Description=Restore USB-first boot order (enables reinstall via USB)
+          ConditionPathExists=!/var/lib/restore-usb-boot-done
+          After=local-fs.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/usr/local/bin/restore-usb-boot.sh
+          ExecStartPost=/usr/bin/touch /var/lib/restore-usb-boot-done
+
+          [Install]
+          WantedBy=multi-user.target
+
+  links:
+    # Repoint /etc/resolv.conf away from the stub listener (which we disabled
+    # above to free port 53 for AdGuard). systemd-resolved still writes
+    # upstream DNS into /run/systemd/resolve/resolv.conf, so name resolution
+    # on the host keeps working.
+    - path: /etc/resolv.conf
+      target: /run/systemd/resolve/resolv.conf
+      overwrite: true
+
+    # Enable RAID data mount
+    - path: /etc/systemd/system/multi-user.target.wants/var-mnt-data.mount
+      target: /etc/systemd/system/var-mnt-data.mount
+
+    # Enable first-boot RAID setup
+    - path: /etc/systemd/system/multi-user.target.wants/setup-raid.service
+      target: /etc/systemd/system/setup-raid.service
+
+    # Enable Podman Socket for the user (required for ServiceBay to control the host)
+    - path: /var/home/${HOST_USER}/.config/systemd/user/sockets.target.wants/podman.socket
+      target: /usr/lib/systemd/user/podman.socket
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+
+    # Enable Python3 install on first boot
+    - path: /etc/systemd/system/multi-user.target.wants/install-python.service
+      target: /etc/systemd/system/install-python.service
+
+    # Enable NVIDIA driver + container-toolkit layer on first boot.
+    # The script no-ops (and self-marks done) on hosts without an
+    # NVIDIA GPU, so unconditionally wiring this symlink is fine — it
+    # costs one lspci call on CPU-only nodes.
+    - path: /etc/systemd/system/multi-user.target.wants/install-nvidia.service
+      target: /etc/systemd/system/install-nvidia.service
+
+    # Enable AUTH_SECRET init on first boot (#565). The `[Install]
+    # WantedBy=` block in the unit file isn't enough on its own because
+    # Ignition writes the file but doesn't `systemctl enable` it — the
+    # symlink has to be present in the wants/ directory at ignition
+    # time, matching how every other system-level oneshot here is wired.
+    - path: /etc/systemd/system/multi-user.target.wants/servicebay-auth-secret-init.service
+      target: /etc/systemd/system/servicebay-auth-secret-init.service
+
+    # Enable secret.key init on first boot (#780). Same wiring story as
+    # the AUTH_SECRET symlink above — Ignition needs the wants/ entry
+    # to actually activate the oneshot.
+    - path: /etc/systemd/system/multi-user.target.wants/servicebay-secret-key-init.service
+      target: /etc/systemd/system/servicebay-secret-key-init.service
+
+    # Enable setup-config-merge on first boot (#331). Without this
+    # symlink, Ignition drops the unit file at /etc/systemd/system/
+    # but never enables it — systemd ignores the [Install] section
+    # of unit files placed via Ignition, so an explicit
+    # multi-user.target.wants symlink is required, same as the
+    # other first-boot units above.
+    - path: /etc/systemd/system/multi-user.target.wants/setup-config-merge.service
+      target: /etc/systemd/system/setup-config-merge.service
+
+    # Enable Nginx install on first boot (user service)
+    - path: /var/home/${HOST_USER}/.config/systemd/user/default.target.wants/install-nginx.service
+      target: /var/home/${HOST_USER}/.config/systemd/user/install-nginx.service
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+
+    # Enable the ServiceBay trigger path on first boot. Same enablement
+    # story as install-nginx above — user units need an explicit wants/
+    # symlink at Ignition time. Without this, the marker can appear but
+    # servicebay.service would never get triggered (its ConditionPathExists
+    # would skip the boot-time activation forever).
+    - path: /var/home/${HOST_USER}/.config/systemd/user/default.target.wants/servicebay-trigger.path
+      target: /var/home/${HOST_USER}/.config/systemd/user/servicebay-trigger.path
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+
+    # Enable disable-usb-boot on first boot. Same Ignition story as the
+    # other system-level oneshots above — the unit file alone is not
+    # enough, the wants/ symlink has to be present at ignition time.
+    # Without this, BootOrder stays as the live ISO put it and the box
+    # boots the USB again on the next reboot (the #930 loop).
+    - path: /etc/systemd/system/multi-user.target.wants/disable-usb-boot.service
+      target: /etc/systemd/system/disable-usb-boot.service
+
+    # Enable the NVIDIA CDI retry timer. Same Ignition story as the
+    # other wants/ symlinks above — for .timer units the wants/ dir
+    # is timers.target.wants. Without this the timer never starts and
+    # CDI is never generated even though the unit file is present.
+    - path: /etc/systemd/system/timers.target.wants/install-nvidia-cdi.timer
+      target: /etc/systemd/system/install-nvidia-cdi.timer
+
+    # Enable restore-usb-boot on first boot
+    - path: /etc/systemd/system/multi-user.target.wants/restore-usb-boot.service
+      target: /etc/systemd/system/restore-usb-boot.service

--- a/tools/sb-tui/internal/build/assets/post-install.sh
+++ b/tools/sb-tui/internal/build/assets/post-install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Runs from the live-USB environment AFTER coreos-installer has written
+# FCoS to the SSD and registered the new EFI boot entry, BEFORE the
+# system reboots into the installed OS for the first time.
+#
+# Goal: make the FIRST reboot land on installed FCoS, not back into the
+# live USB. Without this, the BIOS happily picks the still-first USB
+# entry from BootOrder, the live ISO runs the install again, the OS
+# reboots, the BIOS picks the USB again, ... — the #930 reboot loop.
+#
+# Strategy (defense in depth):
+#   1. Modify BootOrder so the OS entry is first and USB entries are
+#      pushed to the end. Persistent across reboots.
+#   2. Set BootNext to the OS entry. One-shot override the BIOS
+#      consumes on the next boot — this is the bulletproof guarantee
+#      even if (1) somehow fails or the BIOS reverts NVRAM writes.
+#
+# After we reach the installed OS, disable-usb-boot.service then
+# permanently deactivates USB entries with `efibootmgr -A` so the
+# user can leave the USB plugged in without re-entering the loop.
+#
+# Verbose throughout — any failure visible in the live-ISO console.
+
+set -euo pipefail
+
+echo "post-install: starting (date=$(date -u +%FT%TZ))"
+echo "post-install: efibootmgr -v before:"
+efibootmgr -v || true
+echo "----"
+
+# Find the installed-OS boot entry. Match by EFI loader path first
+# (the most specific signal — entries like \EFI\fedora\shimx64.efi),
+# then fall back to entry-label patterns. Using ERE (-E) throughout
+# to avoid the BRE \(...\) escaping minefield the previous version
+# tripped over.
+ENTRY=$(efibootmgr -v | grep -i -m1 -E '\\EFI\\(fedora|coreos|boot)\\' | grep -oP 'Boot\K[0-9A-Fa-f]+' || true)
+if [[ -z "$ENTRY" ]]; then
+  ENTRY=$(efibootmgr | grep -i -m1 -E 'fedora|coreos|Linux Boot Manager' | grep -oP 'Boot\K[0-9A-Fa-f]+' || true)
+fi
+
+if [[ -z "$ENTRY" ]]; then
+  echo "post-install: WARNING — no OS boot entry detected; nothing to promote." >&2
+  echo "post-install: BootOrder + BootNext unchanged. Operator will need to pick the SSD from the BIOS boot menu on first boot." >&2
+  exit 0
+fi
+
+echo "post-install: OS boot entry = Boot$ENTRY"
+
+# --- BootOrder: OS first, USB last ---
+
+CURRENT=$(efibootmgr | grep -oP 'BootOrder: \K.*' || true)
+if [[ -z "$CURRENT" ]]; then
+  echo "post-install: BootOrder was empty; setting to $ENTRY"
+  efibootmgr -o "$ENTRY"
+else
+  # strip OS entry from current order, then prepend it
+  WITHOUT_ENTRY=$(echo "$CURRENT" | sed -E "s/(^|,)$ENTRY(,|\$)/\1\2/" | sed -E 's/^,+//; s/,+$//; s/,,+/,/g')
+  NEW_ORDER="$ENTRY${WITHOUT_ENTRY:+,$WITHOUT_ENTRY}"
+
+  # collect USB / removable entries
+  USB_LIST=$(efibootmgr -v | grep -i -E 'usb|removable' | grep -oP 'Boot\K[0-9A-Fa-f]+' | tr '\n' ',' | sed 's/,$//' || true)
+  if [[ -n "$USB_LIST" ]]; then
+    DEMOTED=""
+    IFS=',' read -ra USB_ARR <<< "$USB_LIST"
+    for u in "${USB_ARR[@]}"; do
+      if [[ "$u" != "$ENTRY" ]]; then
+        # remove $u from NEW_ORDER if present
+        NEW_ORDER=$(echo "$NEW_ORDER" | sed -E "s/(^|,)$u(,|\$)/\1\2/" | sed -E 's/^,+//; s/,+$//; s/,,+/,/g')
+        DEMOTED="${DEMOTED:+$DEMOTED,}$u"
+      fi
+    done
+    [[ -n "$DEMOTED" ]] && NEW_ORDER="$NEW_ORDER,$DEMOTED"
+  fi
+  NEW_ORDER=$(echo "$NEW_ORDER" | sed -E 's/^,+//; s/,+$//; s/,,+/,/g')
+
+  echo "post-install: setting BootOrder $CURRENT -> $NEW_ORDER"
+  efibootmgr -o "$NEW_ORDER" || echo "post-install: WARNING — efibootmgr -o exited non-zero" >&2
+fi
+
+# --- BootNext: one-shot override for the FIRST reboot ---
+#
+# Even if the BootOrder write above is reverted by the BIOS or another
+# layer, BootNext wins for the next boot. The BIOS clears BootNext
+# automatically after consuming it, so this only redirects the single
+# critical first reboot — subsequent reboots fall through to BootOrder
+# (which we also set above; disable-usb-boot.service will permanently
+# demote USB once we're in installed FCoS).
+echo "post-install: setting BootNext = $ENTRY (one-shot override for first reboot)"
+efibootmgr -n "$ENTRY" || echo "post-install: WARNING — efibootmgr -n exited non-zero" >&2
+
+# --- Verify ---
+VERIFY_ORDER=$(efibootmgr | grep -oP 'BootOrder: \K.*' || true)
+VERIFY_NEXT=$(efibootmgr | grep -oP 'BootNext: \K[0-9A-Fa-f]+' || true)
+echo "post-install: after — BootOrder=$VERIFY_ORDER  BootNext=$VERIFY_NEXT"
+if [[ "${VERIFY_NEXT,,}" == "${ENTRY,,}" ]]; then
+  echo "post-install: BootNext set successfully — first reboot will pick installed FCoS"
+else
+  echo "post-install: WARNING — BootNext does not match expected $ENTRY; operator may need to pick SSD from BIOS boot menu" >&2
+fi
+echo "post-install: done"

--- a/tools/sb-tui/internal/build/assets/pre-install.sh
+++ b/tools/sb-tui/internal/build/assets/pre-install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Set hostname in live environment so the DHCP lease registers the correct name
+# (routers like FritzBox learn the hostname from DHCP and cache it)
+hostnamectl set-hostname "$SERVER_NAME" 2>/dev/null || hostname "$SERVER_NAME"
+
+# Find the smallest non-removable disk (that's not the live USB) for OS install.
+# The live USB is the device backing /run/media or the ISO boot.
+LIVE_DISK=$(lsblk -ndo PKNAME "$(findmnt -n -o SOURCE /run)" 2>/dev/null || echo "")
+
+BEST=""
+BEST_SIZE=0
+
+for dev in $(lsblk -dnpo NAME -I 8,259,254); do
+  name=$(basename "$dev")
+  # Skip live USB
+  [[ "$name" == "$LIVE_DISK" ]] && continue
+  # Skip removable
+  [[ "$(cat /sys/block/${name}/removable 2>/dev/null)" == "1" ]] && continue
+  size=$(blockdev --getsize64 "$dev" 2>/dev/null || echo 0)
+  (( size == 0 )) && continue
+  # Pick smallest
+  if [[ -z "$BEST" ]] || (( size < BEST_SIZE )); then
+    BEST_SIZE=$size
+    BEST=$dev
+  fi
+done
+
+if [[ -z "$BEST" ]]; then
+  echo "pre-install: ERROR: no suitable OS disk found" >&2
+  exit 1
+fi
+
+echo "pre-install: selected $BEST ($(( BEST_SIZE / 1073741824 )) GiB) as OS disk"
+
+# Write dest-device into installer.d so coreos-installer picks it up
+mkdir -p /etc/coreos/installer.d
+cat > /etc/coreos/installer.d/0050-dest-device.yaml <<DISKEOF
+dest-device: $BEST
+DISKEOF

--- a/tools/sb-tui/internal/build/render.go
+++ b/tools/sb-tui/internal/build/render.go
@@ -1,0 +1,202 @@
+package build
+
+// Butane template rendering for the native ISO-build leg (#1293, child of
+// #1278). Ports the envsubst render in install-fedora-coreos.sh: substitute the
+// build-time template variables into the embedded Butane template (and the
+// pre-install script's hostname header), while leaving every other
+// $-reference — the runtime shell vars in embedded units/scripts like
+// ${RAID_DISK}, ${API_WAIT}, $$SECRET — verbatim. The transpile/bake that
+// consumes this output lives in bake.go.
+
+import (
+	_ "embed"
+	"strings"
+)
+
+//go:embed assets/fedora-coreos.bu
+var butaneTemplate string
+
+//go:embed assets/pre-install.sh
+var preInstallTemplate string
+
+//go:embed assets/post-install.sh
+var postInstallScript string
+
+// yamlInlineIndent is the 10-space prefix the bash applied (sed 's/^/.../') to
+// every line of the multi-line values (config.json, SSH private key) so they
+// nest correctly under their Butane inline-block keys.
+const yamlInlineIndent = "          "
+
+// butaneVars is the envsubst allowlist: only these build-time variables are
+// substituted; any other $-reference is left literal. Mirrors the envsubst
+// SHELL-FORMAT in install-fedora-coreos.sh. AUTH_SECRET is listed for fidelity
+// but the template has no live reference — it self-generates on first boot — so
+// its substitution is a no-op.
+var butaneVars = []string{
+	"SERVER_NAME", "HOST_USER", "SSH_AUTHORIZED_KEY", "PASSWORD_HASH", "NET_INTERFACE",
+	"STATIC_IP", "STATIC_PREFIX", "GATEWAY", "DNS_SERVERS", "DATA_ROOT", "SERVICEBAY_PORT",
+	"SERVICEBAY_VERSION", "SERVICEBAY_CONFIG_JSON", "SERVICEBAY_SSH_PUB", "SERVICEBAY_SSH_PRIV",
+	"AUTH_SECRET", "SERVICEBAY_ADMIN_USER", "SERVICEBAY_ADMIN_PASSWORD",
+}
+
+func butaneVarSet() map[string]bool {
+	m := make(map[string]bool, len(butaneVars))
+	for _, v := range butaneVars {
+		m[v] = true
+	}
+	return m
+}
+
+func isIdentStart(b byte) bool {
+	return b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+func isIdentChar(b byte) bool {
+	return isIdentStart(b) || (b >= '0' && b <= '9')
+}
+
+// parseVarRef inspects a $-reference starting at s[i] (which must be '$'). It
+// returns the variable name and the full matched text ("$VAR" or "${VAR}") when
+// s[i:] is a well-formed reference, or ok=false otherwise. Matches the forms
+// GNU envsubst recognises.
+func parseVarRef(s string, i int) (name, raw string, ok bool) {
+	if i+1 >= len(s) {
+		return "", "", false
+	}
+	if s[i+1] == '{' {
+		j := i + 2
+		for j < len(s) && isIdentChar(s[j]) {
+			j++
+		}
+		if j < len(s) && s[j] == '}' && j > i+2 {
+			return s[i+2 : j], s[i : j+1], true
+		}
+		return "", "", false
+	}
+	if isIdentStart(s[i+1]) {
+		j := i + 1
+		for j < len(s) && isIdentChar(s[j]) {
+			j++
+		}
+		return s[i+1 : j], s[i:j], true
+	}
+	return "", "", false
+}
+
+// substituteAllowed replaces $VAR and ${VAR} for names in `allow` with their
+// value from `vals` (empty when the name is unset), leaving every other
+// $-reference verbatim. Matches GNU envsubst invoked with a SHELL-FORMAT
+// allowlist.
+func substituteAllowed(s string, allow map[string]bool, vals map[string]string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '$' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		name, raw, ok := parseVarRef(s, i)
+		if ok && allow[name] {
+			b.WriteString(vals[name])
+			i += len(raw)
+			continue
+		}
+		// Not a substitutable reference: emit the '$' and rescan the rest, so a
+		// non-allowlisted ${RAID_DISK} / $$SECRET survives unchanged.
+		b.WriteByte('$')
+		i++
+	}
+	return b.String()
+}
+
+// indentLines prefixes every line of s with prefix, matching `sed 's/^/prefix/'`
+// — including empty lines, but not a phantom line after a trailing newline.
+func indentLines(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s) + len(prefix))
+	b.WriteString(prefix)
+	for i := 0; i < len(s); i++ {
+		b.WriteByte(s[i])
+		if s[i] == '\n' && i != len(s)-1 {
+			b.WriteString(prefix)
+		}
+	}
+	return b.String()
+}
+
+// VersionFromChannel maps a release channel to the ghcr.io image tag baked into
+// the template (SERVICEBAY_VERSION). Mirrors the bash case statement.
+func VersionFromChannel(channel string) string {
+	switch channel {
+	case "test":
+		return "test"
+	case "dev":
+		return "dev"
+	default:
+		return "latest"
+	}
+}
+
+// RenderInputs is everything needed to render the Butane template: the persisted
+// settings, the per-run secrets, the host password hash, the generated SSH
+// keypair, and the rendered config.json. The bake leg (bake.go) produces the
+// PasswordHash / SSH keys and supplies the config.json.
+type RenderInputs struct {
+	Settings     Settings
+	Secrets      Secrets
+	PasswordHash string // `openssl passwd -6` of the host console password
+	SSHPublic    string // ServiceBay->host public key (single line)
+	SSHPrivate   string // ServiceBay->host private key (multi-line PEM)
+	ConfigJSON   string // ConfigBuild.JSON() output
+	DataRoot     string // defaults to DefaultDataRoot
+}
+
+func (in RenderInputs) vars() map[string]string {
+	s := in.Settings
+	dataRoot := in.DataRoot
+	if dataRoot == "" {
+		dataRoot = DefaultDataRoot
+	}
+	return map[string]string{
+		"SERVER_NAME":               s.ServerName,
+		"HOST_USER":                 s.HostUser,
+		"SSH_AUTHORIZED_KEY":        s.SSHAuthorizedKey,
+		"PASSWORD_HASH":             in.PasswordHash,
+		"NET_INTERFACE":             s.NetInterface,
+		"STATIC_IP":                 s.StaticIP,
+		"STATIC_PREFIX":             s.StaticPrefix,
+		"GATEWAY":                   s.Gateway,
+		"DNS_SERVERS":               s.DNSServers,
+		"DATA_ROOT":                 dataRoot,
+		"SERVICEBAY_PORT":           s.ServicebayPort,
+		"SERVICEBAY_VERSION":        VersionFromChannel(s.ServicebayChannel),
+		"SERVICEBAY_CONFIG_JSON":    indentLines(in.ConfigJSON, yamlInlineIndent),
+		"SERVICEBAY_SSH_PUB":        strings.TrimRight(in.SSHPublic, "\n"),
+		"SERVICEBAY_SSH_PRIV":       indentLines(strings.TrimRight(in.SSHPrivate, "\n"), yamlInlineIndent),
+		"AUTH_SECRET":               "", // no-op (template self-generates on first boot)
+		"SERVICEBAY_ADMIN_USER":     s.ServicebayAdminUser,
+		"SERVICEBAY_ADMIN_PASSWORD": in.Secrets.AdminPassword,
+	}
+}
+
+// Butane renders the Butane config with the build-time variables substituted.
+func (in RenderInputs) Butane() string {
+	return substituteAllowed(butaneTemplate, butaneVarSet(), in.vars())
+}
+
+// PreInstall renders the pre-install script (the smallest-non-removable-disk
+// selector), substituting only SERVER_NAME into its hostname header. Every other
+// $-reference is runtime shell and stays literal.
+func (in RenderInputs) PreInstall() string {
+	return substituteAllowed(preInstallTemplate,
+		map[string]bool{"SERVER_NAME": true},
+		map[string]string{"SERVER_NAME": in.Settings.ServerName})
+}
+
+// PostInstall returns the post-install script verbatim (no build-time
+// substitution — it is a fully static, quoted heredoc in the bash).
+func PostInstall() string { return postInstallScript }

--- a/tools/sb-tui/internal/build/render_test.go
+++ b/tools/sb-tui/internal/build/render_test.go
@@ -1,0 +1,119 @@
+package build
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSubstituteAllowed_Forms(t *testing.T) {
+	allow := map[string]bool{"FOO": true, "BAR": true}
+	vals := map[string]string{"FOO": "foo-val", "BAR": "bar-val"}
+	cases := []struct{ in, want string }{
+		{"${FOO}", "foo-val"},                  // braced, allowlisted
+		{"$FOO", "foo-val"},                    // bare, allowlisted
+		{"x${FOO}y$BAR.", "xfoo-valybar-val."}, // mixed
+		{"${RAID_DISK}", "${RAID_DISK}"},       // braced, NOT allowlisted -> literal
+		{"$RAID_DISK", "$RAID_DISK"},           // bare, NOT allowlisted -> literal
+		{`$$SECRET`, `$$SECRET`},               // $$ escape + non-allowlisted name
+		{"price is $5", "price is $5"},         // $ not a ref
+		{"${FOO", "${FOO"},                     // unterminated brace -> literal
+		{"${}", "${}"},                         // empty name -> literal
+		{"$FOO_BAR", "$FOO_BAR"},               // FOO_BAR not allowlisted (longest ident)
+		{"trailing $", "trailing $"},           // bare $ at EOF
+	}
+	for _, c := range cases {
+		if got := substituteAllowed(c.in, allow, vals); got != c.want {
+			t.Errorf("substituteAllowed(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSubstituteAllowed_UnsetIsEmpty(t *testing.T) {
+	// allowlisted but absent from vals -> empty (matches envsubst).
+	got := substituteAllowed("a${FOO}b", map[string]bool{"FOO": true}, map[string]string{})
+	if got != "ab" {
+		t.Errorf("unset allowlisted var should render empty, got %q", got)
+	}
+}
+
+func TestIndentLines(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"a", "  a"},
+		{"a\nb", "  a\n  b"},
+		{"a\nb\n", "  a\n  b\n"},   // trailing newline: no phantom prefixed line
+		{"a\n\nb", "  a\n  \n  b"}, // empty middle line still prefixed
+	}
+	for _, c := range cases {
+		if got := indentLines(c.in, "  "); got != c.want {
+			t.Errorf("indentLines(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestVersionFromChannel(t *testing.T) {
+	for ch, want := range map[string]string{"test": "test", "dev": "dev", "stable": "latest", "": "latest"} {
+		if got := VersionFromChannel(ch); got != want {
+			t.Errorf("VersionFromChannel(%q) = %q, want %q", ch, got, want)
+		}
+	}
+}
+
+func TestRenderButane_SubstitutesAndPreserves(t *testing.T) {
+	in := RenderInputs{
+		Settings: Settings{
+			ServerName:          "OSCAR",
+			HostUser:            "core",
+			ServicebayChannel:   "stable",
+			ServicebayAdminUser: "admin",
+			ServicebayPort:      "5888",
+		},
+		Secrets:      Secrets{AdminPassword: "adminpw"},
+		PasswordHash: "$6$salt$hash",
+		SSHPublic:    "ssh-rsa AAAApub host\n",
+		SSHPrivate:   "-----BEGIN-----\nkeyline\n-----END-----\n",
+		ConfigJSON:   "{\n  \"serverName\": \"OSCAR\"\n}",
+	}
+	out := in.Butane()
+	// Build-time vars substituted.
+	if !strings.Contains(out, "ghcr.io/mdopp/servicebay:latest") {
+		t.Error("SERVICEBAY_VERSION not substituted to 'latest'")
+	}
+	if strings.Contains(out, "${SERVER_NAME}") || strings.Contains(out, "${SERVICEBAY_PORT}") {
+		t.Error("build-time placeholders left unsubstituted")
+	}
+	// Runtime shell vars preserved (NOT in the allowlist).
+	for _, lit := range []string{"${RAID_DISK}", "${API_WAIT}", "${INSTALLED_WAIT}"} {
+		if !strings.Contains(out, lit) {
+			t.Errorf("runtime shell var %s should be left literal", lit)
+		}
+	}
+	// SSH public key (single-line, trimmed) present.
+	if !strings.Contains(out, "ssh-rsa AAAApub host") {
+		t.Error("SSH public key not substituted")
+	}
+	// config.json indented 10 spaces under its inline-block key.
+	if !strings.Contains(out, yamlInlineIndent+`"serverName": "OSCAR"`) {
+		t.Error("config.json not indented to the inline-block column")
+	}
+}
+
+func TestRenderPreInstall_OnlyServerName(t *testing.T) {
+	in := RenderInputs{Settings: Settings{ServerName: "OSCAR"}}
+	out := in.PreInstall()
+	if !strings.Contains(out, `set-hostname "OSCAR"`) {
+		t.Errorf("SERVER_NAME not substituted into pre-install header:\n%s", out[:200])
+	}
+	// The disk-select body's shell vars must survive.
+	for _, lit := range []string{"${name}", "$BEST", "$dev"} {
+		if !strings.Contains(out, lit) {
+			t.Errorf("pre-install runtime shell var %s should be literal", lit)
+		}
+	}
+}
+
+func TestPostInstall_NonEmpty(t *testing.T) {
+	if !strings.Contains(PostInstall(), "post-install") {
+		t.Error("post-install script missing expected content")
+	}
+}


### PR DESCRIPTION
## What
Ports the `envsubst` render step from `install-fedora-coreos.sh` to the native Go build leg (`internal/build/render.go`):
- Embeds the Butane template + the pre-install disk-selector + post-install scripts as `go:embed` assets.
- `RenderInputs.Butane()` substitutes **only** the 18 build-time template variables (assembled from `Settings` + `Secrets` + the SSH keypair + `config.json`), leaving every other `$`-reference — the runtime shell vars in embedded units like `${RAID_DISK}`, `${API_WAIT}`, `$$SECRET` — **verbatim**.
- Multi-line values (`config.json`, SSH private key) are indented to the YAML inline-block column (`sed 's/^/  …/'` equivalent).
- `substituteAllowed` matches GNU `envsubst` invoked with a SHELL-FORMAT allowlist.

## Why
Part of #1293 (child of native ISO-build leg #1278 / epic #1272). The transpile + `coreos-installer` ISO bake that consume this output land in the follow-up PR that closes #1293.

## Risk
Low — additive, pure module; not yet wired into a build action. The substitution is the subtle part, so it is verified two ways.

## Verification
- [x] gofmt, go vet, go build, go test (`internal/build`: ok) — committed tests cover the substitution forms, indent, channel→version, and template substitute/preserve logic
- **Local end-to-end (tools absent from CI):**
  - [x] **Byte-for-byte parity vs real GNU `envsubst`** on the full 1929-line template (86,021 bytes identical)
  - [x] **`butane --pretty --strict`** transpiles the rendered output cleanly → 47,250 bytes of valid Ignition JSON
- [ ] /verify on FCoS box — N/A (Go module outside the npm workspace; not path-mandated)