### PR TITLE
fix(tui-go): reuse an existing ServiceBay SSH keypair when baking

### DIFF
--- a/tools/sb-tui/internal/build/bake.go
+++ b/tools/sb-tui/internal/build/bake.go
@@ -40,15 +40,21 @@ func HostPasswordHash(password string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// GenerateSSHKeypair creates an RSA-4096 ServiceBay->host keypair under dir via
-// ssh-keygen and returns the public key (authorized_keys line) and private key
-// (PEM). The host disables password auth, so this key is baked into the
-// Ignition for container->host SSH. Mirrors the ssh-keygen call in the bash.
+// GenerateSSHKeypair returns the RSA-4096 ServiceBay->host keypair under dir —
+// the public key (authorized_keys line) and private key (PEM). An existing
+// keypair is reused as-is; otherwise a fresh one is generated with ssh-keygen.
+// The host disables password auth, so this key is baked into the Ignition for
+// container->host SSH. Reusing a present key matches the bash `[[ ! -f id_rsa ]]`
+// guard (and lets an existing FCoS install keep authenticating) — and avoids
+// ssh-keygen's interactive overwrite prompt, which would otherwise hang a
+// non-interactive build.
 func GenerateSSHKeypair(dir string) (pub, priv string, err error) {
 	keyPath := filepath.Join(dir, "id_rsa")
-	cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", "4096", "-f", keyPath, "-N", "", "-q")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", "", fmt.Errorf("ssh-keygen: %w: %s", err, out)
+	if _, statErr := os.Stat(keyPath); statErr != nil {
+		cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", "4096", "-f", keyPath, "-N", "", "-q")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", "", fmt.Errorf("ssh-keygen: %w: %s", err, out)
+		}
 	}
 	pubB, err := os.ReadFile(keyPath + ".pub")
 	if err != nil {

--- a/tools/sb-tui/internal/build/bake_test.go
+++ b/tools/sb-tui/internal/build/bake_test.go
@@ -39,6 +39,27 @@ func TestPatchISOLabel_RejectsLonger(t *testing.T) {
 	}
 }
 
+func TestGenerateSSHKeypair_ReusesExisting(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a pre-existing keypair; GenerateSSHKeypair must reuse it verbatim
+	// rather than prompting to overwrite (which would hang a build).
+	wantPub := "ssh-rsa AAAApre existing@host\n"
+	wantPriv := "-----BEGIN OPENSSH PRIVATE KEY-----\npre-existing\n-----END OPENSSH PRIVATE KEY-----\n"
+	if err := os.WriteFile(filepath.Join(dir, "id_rsa"), []byte(wantPriv), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "id_rsa.pub"), []byte(wantPub), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := GenerateSSHKeypair(dir)
+	if err != nil {
+		t.Fatalf("GenerateSSHKeypair: %v", err)
+	}
+	if pub != wantPub || priv != wantPriv {
+		t.Errorf("existing keypair not reused verbatim:\n pub=%q\npriv=%q", pub, priv)
+	}
+}
+
 func TestCopyFile(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src")


### PR DESCRIPTION
## What
`GenerateSSHKeypair` now reuses an existing `id_rsa`/`id_rsa.pub` in the build dir instead of always running `ssh-keygen`.

## Why
`ssh-keygen` with `-f <existing>` prompts `Overwrite (y/n)?` on stdin — in a non-interactive build that **hangs forever**. The bash original guarded this with `[[ ! -f id_rsa ]]` (reuse-if-present), which also lets an existing FCoS install keep authenticating with the same key across re-runs. The Go port dropped that guard. Caught by running a second real ISO bake into the same `build/fcos` dir.

## Risk
Low — restores the documented bash behaviour; adds a regression test that seeds a keypair and asserts it's returned verbatim.

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt, go vet, go build, go test (`internal/build`: ok)
- [x] Real re-bake into a populated `build/fcos` now succeeds (previously hung); fresh 1006 MiB custom ISO produced
- [x] CI `tui-go` gates the module