### PR TITLE
feat(tui-go): USB device enumeration and ISO flash

### DIFF
--- a/tools/sb-tui/internal/usb/flash.go
+++ b/tools/sb-tui/internal/usb/flash.go
@@ -1,0 +1,79 @@
+package usb
+
+// Platform enumeration + the sudo dd write. These are the thin IO wrappers
+// around the pure parsers in usb.go.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+)
+
+// ErrUnsupportedOS is returned by Enumerate on platforms without a flash path.
+var ErrUnsupportedOS = fmt.Errorf("USB flashing is only supported on Linux and macOS")
+
+// Enumerate lists removable, writable USB devices on the current platform.
+// Returns ErrUnsupportedOS on anything other than Linux/macOS.
+func Enumerate() ([]Device, error) {
+	switch runtime.GOOS {
+	case "linux":
+		devs, err := scanLinuxSysfs(sysfsBlockDir)
+		if err != nil {
+			return nil, err
+		}
+		sortDevices(devs)
+		return devs, nil
+	case "darwin":
+		return enumerateDarwin()
+	default:
+		return nil, ErrUnsupportedOS
+	}
+}
+
+func sortDevices(devs []Device) {
+	sort.Slice(devs, func(i, j int) bool { return devs[i].Path < devs[j].Path })
+}
+
+// enumerateDarwin shells out to diskutil and pairs the external physical disks
+// with their size/model.
+func enumerateDarwin() ([]Device, error) {
+	listOut, err := exec.Command("diskutil", "list", "external", "physical").Output()
+	if err != nil {
+		return nil, fmt.Errorf("diskutil list: %w", err)
+	}
+	var devs []Device
+	for _, id := range parseDiskutilExternal(string(listOut)) {
+		infoOut, err := exec.Command("diskutil", "info", id).Output()
+		if err != nil {
+			continue
+		}
+		size, model := parseDiskutilInfo(string(infoOut))
+		if size <= 0 {
+			continue
+		}
+		devs = append(devs, Device{Path: id, SizeBytes: size, Model: model})
+	}
+	sortDevices(devs)
+	return devs, nil
+}
+
+// Flash writes isoPath to device via `sudo dd …`, streaming dd's progress to
+// the process stdio. The caller is responsible for operator confirmation
+// (IsConfirmed) before calling this — it performs the destructive write
+// unconditionally. Returns an error if the source ISO is missing.
+func Flash(isoPath, device string) error {
+	if _, err := os.Stat(isoPath); err != nil {
+		return fmt.Errorf("source ISO not readable: %w", err)
+	}
+	args := append([]string{}, FlashArgs(isoPath, device)...)
+	cmd := exec.Command("sudo", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("dd write failed: %w", err)
+	}
+	return nil
+}

--- a/tools/sb-tui/internal/usb/usb.go
+++ b/tools/sb-tui/internal/usb/usb.go
@@ -1,0 +1,166 @@
+// Package usb is the USB-flash leg of the native installer (#1294, child of
+// #1278): enumerate removable block devices, let the operator confirm a target,
+// and write the baked ISO to it. Linux (sysfs) and macOS (diskutil) are
+// supported; other platforms get a clear "not supported" message. The
+// BootOrder / "Reinstall from USB" GRUB management is target-side and already
+// lives in the embedded post-install script + first-boot units (#1293) — this
+// package is only the build-host write path.
+//
+// The pure parts (sysfs/diskutil parsing, dd argv) are unit-tested; the actual
+// enumeration syscalls and the sudo dd write are thin wrappers around them.
+package usb
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Device is a removable block device the ISO can be flashed to.
+type Device struct {
+	Path      string // /dev/sdX (Linux) or /dev/diskN (macOS)
+	SizeBytes int64
+	Model     string
+}
+
+// SizeGiB is the device size rounded down to whole GiB, as shown to the operator.
+func (d Device) SizeGiB() int64 { return d.SizeBytes / (1 << 30) }
+
+// Label is the operator-facing one-line description, matching the bash listing.
+func (d Device) Label() string {
+	model := d.Model
+	if model == "" {
+		model = "Unknown"
+	}
+	return fmt.Sprintf("%s %dGiB %s", d.Path, d.SizeGiB(), model)
+}
+
+// sysfsBlockDir is overridable in tests; defaults to the real /sys/block.
+var sysfsBlockDir = "/sys/block"
+
+// sectorBytes — /sys/block/*/size is always in 512-byte units regardless of the
+// physical block size (Documentation/ABI/stable/sysfs-block).
+const sectorBytes = 512
+
+// readTrimmed reads a sysfs file and trims surrounding whitespace; "" on error.
+func readTrimmed(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// scanLinuxSysfs enumerates removable, non-empty block devices under blockDir,
+// mirroring the bash sysfs loop: removable == "1" and size > 0. The non-removable
+// root/data disks are excluded by construction. Sorted by device path.
+func scanLinuxSysfs(blockDir string) ([]Device, error) {
+	entries, err := os.ReadDir(blockDir)
+	if err != nil {
+		return nil, err
+	}
+	var devs []Device
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "sd") {
+			continue
+		}
+		base := filepath.Join(blockDir, name)
+		if readTrimmed(filepath.Join(base, "removable")) != "1" {
+			continue
+		}
+		sectors, err := strconv.ParseInt(readTrimmed(filepath.Join(base, "size")), 10, 64)
+		if err != nil || sectors <= 0 {
+			continue
+		}
+		devs = append(devs, Device{
+			Path:      "/dev/" + name,
+			SizeBytes: sectors * sectorBytes,
+			Model:     readTrimmed(filepath.Join(base, "device", "model")),
+		})
+	}
+	return devs, nil
+}
+
+// parseDiskutilList parses `diskutil list -plist external physical` is overkill;
+// instead we parse the plain `diskutil list external physical` identifiers and
+// pair them with `diskutil info`. To keep this unit-testable without a Mac, the
+// macOS enumeration is built from two pure parsers: parseDiskutilExternal for
+// the device identifiers and parseDiskutilInfo for size+model of one device.
+
+// parseDiskutilExternal extracts /dev/diskN identifiers from the output of
+// `diskutil list external physical`.
+func parseDiskutilExternal(out string) []string {
+	var ids []string
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		// Lines like: "/dev/disk4 (external, physical):" — require "external"
+		// so an internal disk is never offered as a flash target even if the
+		// caller's filter slips.
+		if strings.HasPrefix(line, "/dev/disk") && strings.Contains(line, "external") {
+			id := strings.Fields(line)[0]
+			ids = append(ids, strings.TrimSuffix(id, ":"))
+		}
+	}
+	return ids
+}
+
+// parseDiskutilInfo pulls "Disk Size" bytes and "Device / Media Name" from the
+// output of `diskutil info <id>`.
+func parseDiskutilInfo(out string) (sizeBytes int64, model string) {
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		switch key {
+		case "Disk Size":
+			// "Disk Size: 61.9 GB (61865984000 Bytes) (...)"
+			if i := strings.Index(val, "("); i >= 0 {
+				inner := val[i+1:]
+				if j := strings.Index(inner, "Bytes"); j >= 0 {
+					n, err := strconv.ParseInt(strings.TrimSpace(inner[:j]), 10, 64)
+					if err == nil {
+						sizeBytes = n
+					}
+				}
+			}
+		case "Device / Media Name":
+			if model == "" {
+				model = val
+			}
+		}
+	}
+	return sizeBytes, model
+}
+
+// FlashArgs builds the `dd` argv that writes isoPath to device. Always invoked
+// under sudo by the caller. Mirrors the bash `dd if=ISO of=DEV bs=4M
+// status=progress oflag=sync`.
+func FlashArgs(isoPath, device string) []string {
+	return []string{
+		"dd",
+		"if=" + isoPath,
+		"of=" + device,
+		"bs=4M",
+		"status=progress",
+		"oflag=sync",
+	}
+}
+
+// confirmPhrase is the exact text the operator must type to authorise a write.
+const confirmPhrase = "YES"
+
+// IsConfirmed reports whether the operator's typed input authorises the
+// destructive write (exact, case-sensitive "YES", matching the bash).
+func IsConfirmed(input string) bool {
+	return input == confirmPhrase
+}

--- a/tools/sb-tui/internal/usb/usb_test.go
+++ b/tools/sb-tui/internal/usb/usb_test.go
@@ -1,0 +1,107 @@
+package usb
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeFakeBlock creates a /sys/block-style device dir under root.
+func writeFakeBlock(t *testing.T, root, name, removable, size, model string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Join(dir, "device"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustW := func(p, v string) {
+		if err := os.WriteFile(p, []byte(v+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustW(filepath.Join(dir, "removable"), removable)
+	mustW(filepath.Join(dir, "size"), size)
+	if model != "" {
+		mustW(filepath.Join(dir, "device", "model"), model)
+	}
+}
+
+func TestScanLinuxSysfs_ExcludesRootDiskAndEmptyReader(t *testing.T) {
+	root := t.TempDir()
+	// Mirrors the real WSL layout this was developed against:
+	writeFakeBlock(t, root, "sdd", "0", "2000409264", "Virtual Disk")   // 1TB root disk, NOT removable
+	writeFakeBlock(t, root, "sde", "1", "0", "SD/MMC")                  // empty card-reader slot, size 0
+	writeFakeBlock(t, root, "sdf", "1", "124735488", "SD/MMC/MS/MSPRO") // the USB stick (~59.5GiB)
+
+	devs, err := scanLinuxSysfs(root)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if len(devs) != 1 {
+		t.Fatalf("expected exactly the USB stick, got %d: %+v", len(devs), devs)
+	}
+	d := devs[0]
+	if d.Path != "/dev/sdf" {
+		t.Errorf("wrong device selected: %q (must never be the non-removable root disk)", d.Path)
+	}
+	if d.SizeGiB() != 59 {
+		t.Errorf("size = %d GiB, want 59", d.SizeGiB())
+	}
+	if d.Model != "SD/MMC/MS/MSPRO" {
+		t.Errorf("model = %q", d.Model)
+	}
+}
+
+func TestScanLinuxSysfs_SortedAndLabeled(t *testing.T) {
+	root := t.TempDir()
+	writeFakeBlock(t, root, "sdg", "1", "2097152", "Zee") // 1GiB
+	writeFakeBlock(t, root, "sdb", "1", "2097152", "")    // 1GiB, no model
+	devs, _ := scanLinuxSysfs(root)
+	sortDevices(devs)
+	if len(devs) != 2 || devs[0].Path != "/dev/sdb" || devs[1].Path != "/dev/sdg" {
+		t.Fatalf("expected sorted [sdb, sdg], got %+v", devs)
+	}
+	if got := devs[0].Label(); got != "/dev/sdb 1GiB Unknown" {
+		t.Errorf("label = %q, want /dev/sdb 1GiB Unknown", got)
+	}
+}
+
+func TestFlashArgs(t *testing.T) {
+	want := []string{"dd", "if=/tmp/x.iso", "of=/dev/sdf", "bs=4M", "status=progress", "oflag=sync"}
+	if got := FlashArgs("/tmp/x.iso", "/dev/sdf"); !reflect.DeepEqual(got, want) {
+		t.Errorf("FlashArgs = %v, want %v", got, want)
+	}
+}
+
+func TestIsConfirmed(t *testing.T) {
+	for in, want := range map[string]bool{"YES": true, "yes": false, "Y": false, "": false, " YES": false} {
+		if got := IsConfirmed(in); got != want {
+			t.Errorf("IsConfirmed(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestParseDiskutilExternal(t *testing.T) {
+	out := `/dev/disk0 (internal, physical):
+/dev/disk4 (external, physical):
+   #:                       TYPE NAME                    SIZE       IDENTIFIER
+/dev/disk5 (external, physical):`
+	got := parseDiskutilExternal(out)
+	want := []string{"/dev/disk4", "/dev/disk5"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseDiskutilExternal = %v, want %v", got, want)
+	}
+}
+
+func TestParseDiskutilInfo(t *testing.T) {
+	out := `   Device Identifier:        disk4
+   Device / Media Name:      SanDisk Ultra USB
+   Disk Size:                61.9 GB (61865984000 Bytes) (exactly 120832000 512-Byte-Units)`
+	size, model := parseDiskutilInfo(out)
+	if size != 61865984000 {
+		t.Errorf("size = %d, want 61865984000", size)
+	}
+	if model != "SanDisk Ultra USB" {
+		t.Errorf("model = %q, want SanDisk Ultra USB", model)
+	}
+}


### PR DESCRIPTION
## What
New `internal/usb` package porting the USB-flash leg of `install-fedora-coreos.sh`:
- **`Enumerate()`** — removable, writable devices. Linux reads sysfs (`removable == "1"` and `size > 0`); macOS parses `diskutil list external physical` + `diskutil info`. Non-removable root/data disks are excluded by construction. Non-Linux/macOS → `ErrUnsupportedOS`.
- **`Flash()`** — `sudo dd if=ISO of=DEV bs=4M status=progress oflag=sync`, after the caller confirms via `IsConfirmed` (exact, case-sensitive `YES`).
- The pure parsers (sysfs/diskutil) and the `dd` argv are unit-tested.

The BootOrder / "Reinstall from USB" GRUB entry is **target-side** and already ships in the embedded post-install script + first-boot units (#1293), so it is not duplicated here.

## Why
Closes #1294 (child of native ISO-build leg #1278 / epic #1272).

## Risk
Medium — it performs a destructive `sudo dd`. Mitigated: the operator must type `YES`; enumeration can only ever surface removable, non-zero devices; the write target comes from that list, never free text.

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt, go vet, go build, go test (`internal/usb`: ok)
- **Real hardware (verified on the attached stick):**
  - [x] `Enumerate()` against the live `/sys/block` returned **only** `/dev/sdf` (59 GiB) — the 1 TB WSL root disk (`/dev/sdd`, non-removable) and the empty card-reader slot (`/dev/sde`, size 0) were both correctly excluded. A unit test pins this exact layout.
  - [x] `Flash()` wrote a freshly-baked custom ISO to `/dev/sdf` via the real code path: `sudo dd` copied **1,054,867,456 bytes** (byte-exact match to the baked ISO); the stick re-reads as a bootable layout — `sdf1` ISO9660 `fedora-coreos-44.20260419.3.1` + `sdf2` `EFI-SYSTEM` (vfat).
- [ ] /verify on FCoS box — N/A (Go module outside the npm workspace; not path-mandated)