### PR TITLE
feat(tui): cross-compiled sb-tui release binaries + curl|sh installer

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,121 @@
+# Cross-compiled sb-tui release binaries (#1279). The Go lifecycle launcher
+# (tools/sb-tui, #1272) is distributed as static, dependency-free binaries so an
+# operator who doesn't clone the repo can `curl … | sh` it (install-sb-tui.sh).
+#
+# This is intentionally a SEPARATE workflow from release.yml (the Docker image
+# publish): a failure here must never break image publishing, and vice versa.
+#
+# Trigger model mirrors release.yml: release-please publishes the GitHub Release
+# via GITHUB_TOKEN, and GitHub's anti-recursion rule means the `release:
+# published` event never fires another workflow run. So the real attach happens
+# on the `push` of the `chore(main): release` merge commit (package.json already
+# carries the new version at that point). `release`/`workflow_dispatch` are kept
+# for manual re-runs.
+name: Release binaries
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'tools/sb-tui/**'
+      - '.github/workflows/release-binaries.yml'
+      - 'install-sb-tui.sh'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  # Always cross-compile the full matrix (also on PRs that touch the launcher),
+  # so a build break in any target is caught before merge. Artifacts are handed
+  # to the publish job for release upload.
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - linux/amd64
+          - linux/arm64
+          - darwin/amd64
+          - darwin/arm64
+          - windows/amd64
+          - windows/arm64
+    defaults:
+      run:
+        working-directory: tools/sb-tui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: tools/sb-tui/go.sum
+      - name: Cross-compile sb-tui
+        run: |
+          os="${{ matrix.target }}"; os="${os%/*}"
+          arch="${{ matrix.target }}"; arch="${arch#*/}"
+          out="sb-tui-${os}-${arch}"
+          [ "$os" = windows ] && out="${out}.exe"
+          mkdir -p dist
+          echo "Building dist/${out} (GOOS=${os} GOARCH=${arch})"
+          CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+            go build -trimpath -ldflags "-s -w" -o "dist/${out}" .
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sb-tui-${{ matrix.target == 'windows/amd64' && 'windows-amd64' || matrix.target == 'windows/arm64' && 'windows-arm64' || matrix.target == 'darwin/amd64' && 'darwin-amd64' || matrix.target == 'darwin/arm64' && 'darwin-arm64' || matrix.target == 'linux/amd64' && 'linux-amd64' || 'linux-arm64' }}
+          path: tools/sb-tui/dist/*
+          if-no-files-found: error
+
+  # Attach the binaries to the GitHub Release on a release commit. Skipped on PRs
+  # and on ordinary pushes to main (the `if` gate below).
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event_name == 'release'
+          || github.event_name == 'workflow_dispatch'
+          || (github.event_name == 'push'
+              && github.ref == 'refs/heads/main'
+              && contains(github.event.head_commit.message, 'chore(main): release')) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve release tag from package.json
+        id: ver
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=servicebay-v${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sb-tui-*
+          merge-multiple: true
+          path: dist
+      - name: Checksums
+        run: |
+          cd dist
+          sha256sum sb-tui-* > SHA256SUMS
+          ls -l
+      - name: Wait for the release to exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.ver.outputs.tag }}"
+          for i in $(seq 1 30); do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "Release $tag is present."
+              exit 0
+            fi
+            echo "Waiting for release $tag to be created ($i/30)…"
+            sleep 10
+          done
+          echo "::error::Release $tag was not created within the timeout."
+          exit 1
+      - name: Upload binaries to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ steps.ver.outputs.tag }}" dist/* --clobber

--- a/install-sb-tui.sh
+++ b/install-sb-tui.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# install-sb-tui.sh — fetch the latest sb-tui binary for this OS/arch from the
+# ServiceBay GitHub releases (#1279). For the operator who doesn't clone the
+# repo:
+#
+#   curl -fsSL https://raw.githubusercontent.com/mdopp/servicebay/main/install-sb-tui.sh | sh
+#
+# Overridable via environment:
+#   SB_TUI_INSTALL_DIR  install location          (default: $HOME/.local/bin)
+#   SB_TUI_VERSION      release tag to install     (default: latest)
+#                       e.g. servicebay-v4.51.1
+set -eu
+
+REPO="mdopp/servicebay"
+BIN="sb-tui"
+INSTALL_DIR="${SB_TUI_INSTALL_DIR:-$HOME/.local/bin}"
+
+die() {
+  echo "install-sb-tui: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+need curl
+need uname
+
+os=$(uname -s)
+case "$os" in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  MINGW* | MSYS* | CYGWIN* | Windows_NT) os=windows ;;
+  *) die "unsupported OS: $os" ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+  x86_64 | amd64) arch=amd64 ;;
+  aarch64 | arm64) arch=arm64 ;;
+  *) die "unsupported architecture: $arch" ;;
+esac
+
+asset="${BIN}-${os}-${arch}"
+if [ "$os" = windows ]; then
+  asset="${asset}.exe"
+fi
+
+# Resolve the release tag. Default to the latest published release.
+tag="${SB_TUI_VERSION:-}"
+if [ -z "$tag" ]; then
+  tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)
+fi
+[ -n "$tag" ] || die "could not determine the latest release tag"
+
+url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
+
+dest="${INSTALL_DIR}/${BIN}"
+if [ "$os" = windows ]; then
+  dest="${dest}.exe"
+fi
+
+echo "Installing ${asset} (${tag}) → ${dest}"
+mkdir -p "$INSTALL_DIR"
+
+# Download to a temp file first so a failed fetch never leaves a half-written
+# binary on PATH.
+tmp=$(mktemp "${INSTALL_DIR}/.${BIN}.XXXXXX")
+trap 'rm -f "$tmp"' EXIT INT TERM
+curl -fSL --progress-bar "$url" -o "$tmp" \
+  || die "download failed: $url (does release ${tag} have a ${asset} asset?)"
+chmod +x "$tmp"
+mv -f "$tmp" "$dest"
+trap - EXIT INT TERM
+
+echo "Installed ${BIN} to ${dest}"
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *) echo "Note: ${INSTALL_DIR} is not on your PATH — add it:" >&2
+     echo "  export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2 ;;
+esac
+echo "Run '${BIN}' to open the ServiceBay lifecycle launcher."

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -6,8 +6,9 @@
 // gone.
 //
 // Run from the repo: `go run ./tools/sb-tui` for the menu, or
-// `go run ./tools/sb-tui watch` to open the install-watch dashboard directly
-// (the distributable binary + curl|sh installer come in #1279).
+// `go run ./tools/sb-tui watch` to open the install-watch dashboard directly.
+// Operators who don't clone the repo install a cross-compiled binary via the
+// curl|sh installer (install-sb-tui.sh) — see .github/workflows/release-binaries.yml.
 package main
 
 import (


### PR DESCRIPTION
## What
Adds distribution for the `sb-tui` Go launcher (#1272): a `release-binaries.yml` workflow that cross-compiles linux/darwin/windows × amd64/arm64 static binaries (+ `SHA256SUMS`) and attaches them to each GitHub release, and a root `install-sb-tui.sh` that detects OS/arch and fetches the latest release binary — the "operator who doesn't clone the repo" path.

## Why
Closes #1279.

Kept as a **separate** workflow from `release.yml` (the Docker image publish) on purpose: a failure in binary packaging must never break image publishing, and vice versa. The publish trigger mirrors the Docker job — release-please publishes via `GITHUB_TOKEN`, so the `release: published` event never fires another run; the attach happens on the `chore(main): release` merge-commit push (package.json already carries the new version), waiting for release-please to create the release before `gh release upload --clobber`.

## Risk
Low. New file, isolated workflow; existing Docker release flow untouched. The matrix `build` job also runs on PRs that touch the launcher, so a cross-compile break is caught before merge. The only unexercised path until the next release is the `publish` upload step.

## Rollback
`git revert` is enough (delete the workflow + script).

## Verification
- [x] npm run lint (0 errors, 401 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (188 files, 1480 passed)
- [x] gofmt + go vet clean (main.go doc-comment touch)
- [x] **Local cross-compile of all 6 targets** with the build job's exact flags (`CGO_ENABLED=0 -trimpath -ldflags "-s -w"`) — produced correct ELF/Mach-O/PE32+ binaries, statically linked + stripped, and a SHA256SUMS file.
- [x] install-sb-tui.sh: `sh -n` clean; OS/arch detection verified to map to the produced asset names.
- [ ] Live release-asset attach — exercised at the next release (publish job; not path-mandated, no real-box dependency).