### PR TITLE
fix(services): realign sudo-written asset files to their dir owner

### DIFF
--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -54,7 +54,35 @@ interface FileWritingAgent {
  * 'ok'` check never fired because the await threw first, so the raw
  * `[Errno 13]` propagated straight to the deploy loop and the sudo retry
  * was dead code.
+ *
+ * #1298 — a sudo write lands the new file owned by root (uid 0). But the
+ * only reason the unprivileged write failed is that the asset dir is owned
+ * by the consuming rootless pod's subuid; a root-owned file inside it
+ * breaks the next `podman kube play --replace` of that pod — rootless
+ * podman can't `lsetxattr` (relabel) a path it doesn't own, so the volume
+ * relabel fails and the pod won't restart. After a sudo write we therefore
+ * realign the file's ownership to its parent directory (i.e. the subuid the
+ * siblings already use) so the relabel stays possible. Best-effort: the file
+ * is already written, and an ownership mismatch only bites a later relabel,
+ * so a chown failure is logged but does not fail the deploy.
  */
+/**
+ * #1298 — realign a sudo-written (root-owned) file to its parent dir's owner so
+ * a later rootless `kube play --replace` relabel of the dir can still lsetxattr
+ * it. Best-effort; logged but never fatal (the file is already written, and an
+ * ownership mismatch only bites a later relabel).
+ */
+async function alignOwnershipToDir(agent: FileWritingAgent, path: string, dir: string): Promise<void> {
+    try {
+        const res = await agent.sendCommand('exec', { command: `sudo chown --reference=${dir} ${path}` });
+        if (res && typeof res === 'object' && 'code' in res && (res as { code: unknown }).code !== 0) {
+            logger.warn('ServiceManager', `chown to match ${dir} owner failed for ${path}: ${JSON.stringify(res)}`);
+        }
+    } catch (err) {
+        logger.warn('ServiceManager', `chown to match ${dir} owner failed for ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
 export async function writeExtraConfigFiles(
     agent: FileWritingAgent,
     serviceName: string,
@@ -79,14 +107,22 @@ export async function writeExtraConfigFiles(
             await agent.sendCommand('exec', { command: `mkdir -p ${dir}` });
         }
         let outcome = await attemptWrite(f, false);
+        let usedSudo = false;
         if (outcome !== 'ok') {
             logger.warn('ServiceManager', `write_file for ${f.path} failed (${outcome}); retrying with sudo.`);
             outcome = await attemptWrite(f, true);
+            usedSudo = true;
         }
         if (outcome !== 'ok') {
             failures.push(f.path);
             logger.error('ServiceManager', `Failed to write extra file ${f.path}: ${outcome}`);
         } else {
+            // The plain (core-owned) write lands in a core-owned dir — fine.
+            // Only the sudo path leaves a root-owned file in a subuid-owned
+            // asset dir, which is what #1298 has to repair.
+            if (usedSudo && dir) {
+                await alignOwnershipToDir(agent, f.path, dir);
+            }
             logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
         }
     }

--- a/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.writeExtraConfigFiles.test.ts
@@ -44,6 +44,50 @@ describe('writeExtraConfigFiles', () => {
         expect(writes[0].params?.sudo).toBeUndefined();
     });
 
+    it('does NOT chown when the plain (core-owned) write succeeds', async () => {
+        // #1298 — a core-owned dir needs no realignment; the only exec is the
+        // mkdir, never a chown.
+        const agent = makeAgent((action) => (action === 'exec' ? { code: 0 } : 'ok'));
+        await writeExtraConfigFiles(agent, 'oscar-household', [file]);
+
+        const chowns = agent.calls.filter(c => c.action === 'exec' && /chown/.test(c.params?.command ?? ''));
+        expect(chowns).toHaveLength(0);
+    });
+
+    it('realigns ownership to the parent dir after a sudo write (#1298)', async () => {
+        // A sudo write lands the file root-owned inside a subuid-owned asset
+        // dir, which breaks the next rootless `kube play --replace` relabel.
+        // After the sudo write we `chown --reference=<dir>` so the new file
+        // matches its siblings' (subuid) ownership.
+        const agent = makeAgent((action, params) => {
+            if (action === 'exec') return { code: 0 };
+            if (params?.sudo) return 'ok';
+            throw new Error("[Errno 13] Permission denied: '" + file.path + "'");
+        });
+
+        await writeExtraConfigFiles(agent, 'oscar-household', [file]);
+
+        const dir = file.path.substring(0, file.path.lastIndexOf('/'));
+        const chowns = agent.calls.filter(c => c.action === 'exec' && /chown/.test(c.params?.command ?? ''));
+        expect(chowns).toHaveLength(1);
+        expect(chowns[0].params?.command).toBe(`sudo chown --reference=${dir} ${file.path}`);
+    });
+
+    it('does not fail the deploy when the post-sudo chown fails (#1298)', async () => {
+        // The file is already written; an ownership mismatch only bites a later
+        // relabel, so a chown rejection must be swallowed (logged), not fatal.
+        const agent = makeAgent((action, params) => {
+            if (action === 'exec' && /chown/.test(params?.command ?? '')) {
+                throw new Error('chown: invalid user');
+            }
+            if (action === 'exec') return { code: 0 };
+            if (params?.sudo) return 'ok';
+            throw new Error('[Errno 13] Permission denied');
+        });
+
+        await expect(writeExtraConfigFiles(agent, 'oscar-household', [file])).resolves.toBeUndefined();
+    });
+
     it('retries with sudo when the plain write_file rejects (EACCES on container-owned dir)', async () => {
         // #1171/#1258 — first (unprivileged) write rejects because the
         // hostPath is owned by a consumer container's uid; the agent throws


### PR DESCRIPTION
## What
After a **sudo** write in `writeExtraConfigFiles`, `chown --reference=<dir>` the newly-written file so it matches its parent asset directory's owner (the consuming rootless pod's subuid), instead of being left root-owned.

## Why
Closes #1298.

A sudo write only happens because the asset dir is owned by the consuming pod's subuid (that's why the unprivileged `core` write failed). Leaving the new file root-owned breaks the next `podman kube play --replace` of that pod: rootless podman can't `lsetxattr` (relabel) a path it doesn't own, so the volume relabel fails and the pod won't restart. Observed live with a newly-delivered OSCAR `daily-chronicle` skill blocking a `hermes.service` restart. Same subsystem as #1171/#1258, different manifestation.

## Risk
Low. Only fires on the sudo path (already the exception case); the plain core-owned write is untouched. The chown is best-effort — a failure is logged but never fails the deploy (the file is already written; an ownership mismatch only bites a later relabel).

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 401 warnings = baseline; hoisted the helper to keep the count flat)
- [x] npm run check:arch
- [x] npm test (188 files, 1483 passed) — 4 new/updated `writeExtraConfigFiles` tests: chown fires after a sudo write with the exact `--reference=<dir>` command, does NOT fire on the plain write, and a chown failure is non-fatal.
- [ ] Real-box OSCAR install — `lib/services/` is **not** path-mandated (consistent with #1171/#1258); the live confirm lands at the next OSCAR install that delivers a brand-new skill file.