### PR TITLE
refactor(store): extract collectStaticPortsFromUnitFiles from twin

### DIFF
--- a/packages/backend/src/lib/store/twin.ts
+++ b/packages/backend/src/lib/store/twin.ts
@@ -826,6 +826,25 @@ export class DigitalTwinStore {
           return cached.ports;
       }
 
+      const ports = this.collectStaticPortsFromUnitFiles(kubeEntry, containerEntry, node.files, service.name, nodeIPs);
+      this.staticPortsCache.set(baseName, { contentKey, ports });
+      return ports;
+  }
+
+  /**
+   * Parse the `.kube`/`.container` unit files into a port list. Split out
+   * of `extractStaticPortsForService` so that method stays a thin
+   * guard + cache + delegate (its complexity was over budget); the
+   * file-format branches live here. Kube ports take precedence: if the
+   * kube YAML yields any port the container file is not consulted.
+   */
+  private collectStaticPortsFromUnitFiles(
+      kubeEntry: [string, WatchedFile] | undefined,
+      containerEntry: [string, WatchedFile] | undefined,
+      files: Record<string, WatchedFile>,
+      serviceName: string | undefined,
+      nodeIPs: string[],
+  ): PortMapping[] {
       const ports: PortMapping[] = [];
       const pushPort = (hostPort?: number, containerPort?: number, protocol?: string, hostIp?: string) => {
           const normalizedContainer = containerPort ?? hostPort;
@@ -839,18 +858,14 @@ export class DigitalTwinStore {
           });
       };
 
-      const files = node.files;
       if (kubeEntry) {
           const [kubePath, kubeFile] = kubeEntry;
           const match = kubeFile.content?.match(/^Yaml=(.+)$/m);
           if (match) {
               const yamlContent = this.getYamlContent(files, kubePath, match[1].trim());
-              if (yamlContent) extractPortsFromKubeYaml(yamlContent, service.name, pushPort);
+              if (yamlContent) extractPortsFromKubeYaml(yamlContent, serviceName, pushPort);
           }
-          if (ports.length > 0) {
-              this.staticPortsCache.set(baseName, { contentKey, ports });
-              return ports;
-          }
+          if (ports.length > 0) return ports;
       }
 
       if (containerEntry) {
@@ -860,7 +875,6 @@ export class DigitalTwinStore {
           }
       }
 
-      this.staticPortsCache.set(baseName, { contentKey, ports });
       return ports;
   }
 


### PR DESCRIPTION
## What
Extract the `.kube`/`.container` port-parsing branches of `extractStaticPortsForService` into a private `collectStaticPortsFromUnitFiles` helper, leaving the method as a thin guard + cache + delegate.

## Why
Lint sweep — `extractStaticPortsForService` was over the complexity budget (20 > 15). Total ESLint warnings 401 → 400.

## Risk
Low. Pure code-motion; behaviour preserved — kube ports still take precedence over the container file (early-return inside the helper), and the cache is still written exactly once in the parent.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 400 warnings; `extractStaticPortsForService` complexity warning gone)
- [x] npm run check:arch
- [x] npm test (188 files, 1483 passed)
- [ ] /verify — not path-mandated (`lib/store/`).