### PR TITLE
refactor(health): extract isReservedIpv4Range from ssrfGuard

### DIFF
--- a/packages/backend/src/lib/health/ssrfGuard.ts
+++ b/packages/backend/src/lib/health/ssrfGuard.ts
@@ -56,6 +56,13 @@ function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number);
   if (parts.length !== 4 || parts.some(p => Number.isNaN(p) || p < 0 || p > 255)) return true;
   const [a, b] = parts;
+  return isReservedIpv4Range(a, b);
+}
+
+// Octet-range classification split out of isPrivateIpv4 to keep that function
+// under the complexity budget. Covers RFC1918 + loopback + "this network" +
+// link-local + CGNAT + multicast/reserved.
+function isReservedIpv4Range(a: number, b: number): boolean {
   if (a === 10) return true;
   if (a === 127) return true;
   if (a === 0) return true;


### PR DESCRIPTION
## What
Extract the IPv4 octet-range classification in `ssrfGuard.isPrivateIpv4` into an `isReservedIpv4Range` helper; the parent keeps the parse/validate guard and delegates.

## Why
Lint sweep — `isPrivateIpv4` was over the complexity budget (17 > 15). Total ESLint warnings 400 → 399.

## Risk
Low. Pure code-motion; the same ranges are checked in the same order (RFC1918 + loopback + 0.x + link-local + CGNAT + multicast/reserved). Covered by `tests/backend/ssrf_guard.test.ts` (24 cases, all pass).

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 399 warnings; `isPrivateIpv4` complexity warning gone)
- [x] npm run check:arch
- [x] npm test (188 files, 1483 passed; ssrf_guard 24/24)
- [ ] /verify — not path-mandated (`lib/health/`).