### PR TITLE
feat(auth): make scoped REST tokens reachable + redact config for token callers

### DIFF
--- a/packages/backend/src/lib/api/handler.ts
+++ b/packages/backend/src/lib/api/handler.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { logger } from '@/lib/logger';
 import type { ApiScope } from '@/lib/auth/apiScope';
+import type { SessionPayload } from '@/lib/auth/session';
 
 export interface ApiErrorBody {
   ok: false;
@@ -71,6 +72,14 @@ export interface ParsedRequest<B, Q> {
   body: B;
   query: Q;
   request: NextRequest;
+  /**
+   * The authenticated principal, when the gate ran (mutating verbs, a route
+   * with `tokenScope`, or any request carrying a `Bearer` token). `undefined`
+   * for unauthenticated/public GETs that skip the gate. Routes branch on
+   * `auth?.user` — e.g. `auth?.user.startsWith('token:')` to redact secrets
+   * for a scoped API-token caller (#1275).
+   */
+  auth?: SessionPayload;
 }
 
 export interface ParsedRequestWithParams<B, Q, P> extends ParsedRequest<B, Q> {
@@ -85,15 +94,27 @@ const MUTATING_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
 async function runHandler<B, Q>(
   options: ApiHandlerOptions<B, Q>,
   request: NextRequest,
-  invoke: (parsed: { body: B; query: Q }) => Promise<Response | NextResponse | unknown>,
+  invoke: (parsed: { body: B; query: Q; auth?: SessionPayload }) => Promise<Response | NextResponse | unknown>,
 ): Promise<Response> {
   try {
-    if (!options.skipAuth && MUTATING_METHODS.has(request.method)) {
+    // Run the gate when: a mutating verb (the original #596 check), a route
+    // that opts into token auth, or ANY request carrying a Bearer token. The
+    // last case lets a token reach an opted-in GET (the proxy passes valid
+    // tokens through, #1275) while a Bearer to a route WITHOUT `tokenScope`
+    // still 401s — requireSession ignores Bearer when no scope is set and
+    // falls through to the (absent) cookie. Public GETs with no Bearer skip
+    // the gate exactly as before.
+    let auth: SessionPayload | undefined;
+    const hasBearer = (request.headers.get('authorization') ?? '').startsWith('Bearer ');
+    const needsAuth = !options.skipAuth
+      && (MUTATING_METHODS.has(request.method) || options.tokenScope !== undefined || hasBearer);
+    if (needsAuth) {
       // Lazy import to keep handler.ts free of the cookie-parse import
       // chain when the module is loaded by middleware-adjacent code.
       const { requireSession } = await import('./requireSession');
-      const auth = await requireSession(request, { tokenScope: options.tokenScope });
-      if (auth instanceof NextResponse) return auth;
+      const result = await requireSession(request, { tokenScope: options.tokenScope });
+      if (result instanceof NextResponse) return result;
+      auth = result;
     }
 
     const rawBody = options.body ? await readJsonBody(request) : undefined;
@@ -101,7 +122,7 @@ async function runHandler<B, Q>(
     const rawQuery = searchParamsToObject(request.nextUrl.searchParams);
     const query = options.query ? options.query.parse(rawQuery) : (undefined as Q);
 
-    const result = await invoke({ body, query });
+    const result = await invoke({ body, query, auth });
     if (result instanceof Response) return result;
     return NextResponse.json({ ok: true, data: result });
   } catch (e) {
@@ -145,8 +166,8 @@ export function withApiHandler<B = undefined, Q = undefined>(
   handler: (input: ParsedRequest<B, Q>) => Promise<Response | NextResponse | unknown>,
 ) {
   return async (request: NextRequest): Promise<Response> => {
-    return runHandler(options, request, ({ body, query }) =>
-      handler({ body, query, request }),
+    return runHandler(options, request, ({ body, query, auth }) =>
+      handler({ body, query, request, auth }),
     );
   };
 }
@@ -163,9 +184,9 @@ export function withApiHandlerParams<B = undefined, Q = undefined, P = unknown>(
   handler: (input: ParsedRequestWithParams<B, Q, P>) => Promise<Response | NextResponse | unknown>,
 ) {
   return async (request: NextRequest, ctx: { params: Promise<P> }): Promise<Response> => {
-    return runHandler(options, request, async ({ body, query }) => {
+    return runHandler(options, request, async ({ body, query, auth }) => {
       const params = await ctx.params;
-      return handler({ body, query, request, params });
+      return handler({ body, query, request, params, auth });
     });
   };
 }

--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -617,6 +617,20 @@ function transformConfig(obj: any, keysToTransform: string[], transformFn: (val:
 
 const SENSITIVE_KEYS = ['password', 'secret', 'token', 'key', 'apiKey'];
 
+/** Sentinel a redacted secret value is replaced with (#1275). */
+export const REDACTED_SENTINEL = '__REDACTED__';
+
+/**
+ * Replace every secret-valued field (the same `SENSITIVE_KEYS` set used for
+ * at-rest encryption) with `REDACTED_SENTINEL`, so the config can be handed to
+ * a less-trusted caller — e.g. a scoped `sb_` API token reading GET
+ * /api/settings (#1275). Anything encrypted on disk is therefore also redacted
+ * here. Pure: returns a deep copy, never mutates the input.
+ */
+export function redactSensitiveConfig<T>(config: T): T {
+  return transformConfig(config, SENSITIVE_KEYS, () => REDACTED_SENTINEL) as T;
+}
+
 export async function getConfig(): Promise<AppConfig> {
   let rawConfig: unknown = {};
   try {

--- a/packages/frontend/src/app/api/settings/route.ts
+++ b/packages/frontend/src/app/api/settings/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getConfig, saveConfig, AppConfig } from '@/lib/config';
+import { getConfig, saveConfig, AppConfig, redactSensitiveConfig } from '@/lib/config';
 import { getTemplateSettingsSchema } from '@/lib/registry';
 import { setServerName } from '@/lib/store/repository';
 import { logger } from '@/lib/logger';
@@ -8,12 +8,17 @@ import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export const GET = withApiHandler({}, async () => {
+export const GET = withApiHandler({ tokenScope: 'read' }, async ({ auth }) => {
   const [config, templateSettingsSchema] = await Promise.all([
     getConfig(),
     getTemplateSettingsSchema(),
   ]);
-  return NextResponse.json({ ...config, templateSettingsSchema });
+  // #1275 — a scoped `sb_` API token (Bearer) gets secrets redacted; cookie
+  // (web UI) and internal callers keep plaintext. requireSession tags a token
+  // principal as `token:<name>`, so that prefix is the discriminator.
+  const isToken = auth?.user.startsWith('token:') ?? false;
+  const payload = isToken ? redactSensitiveConfig(config) : config;
+  return NextResponse.json({ ...payload, templateSettingsSchema });
 });
 
 /**

--- a/packages/frontend/src/proxy.ts
+++ b/packages/frontend/src/proxy.ts
@@ -102,6 +102,23 @@ function isInternalCall(request: NextRequest): boolean {
   }
 }
 
+// Named API token presented and valid? Validates the `Authorization: Bearer
+// sb_…` header so a token-bearing request (CLI / TUI / scripts) can bypass the
+// cookie + CSRF gates. Returns false for an absent/malformed/invalid token so
+// the request falls through to the normal session checks. Scope is NOT checked
+// here — that's the per-route handler's job (`requireSession({ tokenScope })`).
+async function isValidBearerToken(request: NextRequest): Promise<boolean> {
+  const authz = request.headers.get('authorization');
+  const bearer = authz?.startsWith('Bearer ') ? authz.slice(7).trim() : undefined;
+  if (!bearer) return false;
+  try {
+    const { verifyToken } = await import('@/lib/auth/apiTokens');
+    return (await verifyToken(bearer)) !== null;
+  } catch {
+    return false;
+  }
+}
+
 // Same-origin CSRF check: for state-changing methods, the request's Origin
 // (or Referer fallback) must match the Host the browser saw. Behind NPM the
 // Host header is the public hostname and the browser's Origin uses that same
@@ -168,6 +185,16 @@ export async function proxy(request: NextRequest) {
   // Internal calls (post-deploy scripts on the agent host) bypass
   // both CSRF and session checks — the token authenticates them.
   if (isInternalCall(request)) return NextResponse.next();
+
+  // Named API token (`Authorization: Bearer sb_…`, #1265/#1275). A *valid*
+  // token bypasses the CSRF + cookie gates exactly like the internal token —
+  // a token-bearing CLI/TUI has no browser Origin or session cookie. Per-route
+  // scope enforcement still happens at the handler (`requireSession` with the
+  // route's `tokenScope`); the proxy only decides reachability. We MUST verify
+  // the token here: passing an unvalidated `Bearer` header through would let an
+  // attacker append `Bearer x` to a cookie'd victim's request to skip the CSRF
+  // check. An invalid/absent Bearer just falls through to the normal checks.
+  if (await isValidBearerToken(request)) return NextResponse.next();
 
   if (!SAFE_METHODS.has(request.method) && !isSameOrigin(request)) {
     return NextResponse.json({ error: 'Forbidden: cross-site request' }, { status: 403 });

--- a/tests/backend/handler_token_auth.test.ts
+++ b/tests/backend/handler_token_auth.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * #1275 — `withApiHandler` must:
+ *  - skip the gate for an ordinary public GET (no Bearer, no tokenScope),
+ *  - run requireSession (and thread the auth payload) when a route opts into
+ *    `tokenScope`, so the route can redact for token callers,
+ *  - run the gate for ANY Bearer-bearing request — so a Bearer GET to a route
+ *    that did NOT opt in still 401s (requireSession ignores Bearer with no
+ *    scope and falls through to the absent cookie). This is what preserves the
+ *    per-route opt-in invariant once proxy.ts passes valid tokens through.
+ */
+const requireSessionMock = vi.fn();
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: (...args: unknown[]) => requireSessionMock(...args),
+}));
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { withApiHandler } from '@/lib/api/handler';
+
+function req(method: string, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/x', { method, headers });
+}
+
+describe('withApiHandler token-auth threading (#1275)', () => {
+  beforeEach(() => requireSessionMock.mockReset());
+
+  it('GET without Bearer or tokenScope skips the gate; auth is undefined', async () => {
+    const handler = withApiHandler({}, async ({ auth }) => ({ sawToken: auth?.user ?? null }));
+    const res = await handler(req('GET'));
+    expect(requireSessionMock).not.toHaveBeenCalled();
+    const json = await res.json();
+    expect(json.data.sawToken).toBeNull();
+  });
+
+  it('GET with tokenScope runs requireSession and threads the auth payload', async () => {
+    requireSessionMock.mockResolvedValue({ user: 'token:tui', scopes: ['read'] });
+    let seen: unknown;
+    const handler = withApiHandler({ tokenScope: 'read' }, async ({ auth }) => { seen = auth; return {}; });
+    await handler(req('GET'));
+    expect(requireSessionMock).toHaveBeenCalledOnce();
+    expect(requireSessionMock).toHaveBeenCalledWith(expect.anything(), { tokenScope: 'read' });
+    expect(seen).toEqual({ user: 'token:tui', scopes: ['read'] });
+  });
+
+  it('Bearer GET to a route WITHOUT tokenScope runs the gate and returns its 401', async () => {
+    requireSessionMock.mockResolvedValue(
+      NextResponse.json({ error: 'Authentication required' }, { status: 401 }),
+    );
+    const handler = withApiHandler({}, async () => ({ ok: true }));
+    const res = await handler(req('GET', { authorization: 'Bearer sb_bad' }));
+    expect(requireSessionMock).toHaveBeenCalledOnce();
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/backend/redact_config.test.ts
+++ b/tests/backend/redact_config.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { redactSensitiveConfig, REDACTED_SENTINEL } from '@/lib/config';
+
+/**
+ * #1275 — a scoped `sb_` API token reading GET /api/settings must never see
+ * plaintext secrets. redactSensitiveConfig reuses the same SENSITIVE_KEYS set
+ * as the at-rest encryption, so anything encrypted on disk is also hidden here.
+ */
+describe('redactSensitiveConfig (#1275)', () => {
+  it('replaces every secret-keyed string with the sentinel, recursively', () => {
+    const cfg = {
+      serverName: 'box',
+      reverseProxy: { npm: { password: 'hunter2', email: 'a@b.c' } },
+      notifications: { email: { password: 'smtp-pw' } },
+      apiKey: 'live-abc',
+      secret: 's3cr3t',
+      token: 'tok',
+      key: 'kkk',
+    };
+    const out = redactSensitiveConfig(cfg);
+
+    expect(out.reverseProxy.npm.password).toBe(REDACTED_SENTINEL);
+    expect(out.notifications.email.password).toBe(REDACTED_SENTINEL);
+    expect(out.apiKey).toBe(REDACTED_SENTINEL);
+    expect(out.secret).toBe(REDACTED_SENTINEL);
+    expect(out.token).toBe(REDACTED_SENTINEL);
+    expect(out.key).toBe(REDACTED_SENTINEL);
+    // Non-secret keys are untouched.
+    expect(out.serverName).toBe('box');
+    expect(out.reverseProxy.npm.email).toBe('a@b.c');
+  });
+
+  it('redacts secret-keyed values inside arrays', () => {
+    const cfg = {
+      installManifest: { credentials: [{ service: 'samba', password: 'p1' }, { service: 'fb', password: 'p2' }] },
+    };
+    const out = redactSensitiveConfig(cfg);
+    expect(out.installManifest.credentials[0].password).toBe(REDACTED_SENTINEL);
+    expect(out.installManifest.credentials[1].password).toBe(REDACTED_SENTINEL);
+    expect(out.installManifest.credentials[0].service).toBe('samba');
+  });
+
+  it('only redacts string values, leaving non-string secret fields as-is', () => {
+    const cfg = { password: 123 as unknown as string, secret: null };
+    const out = redactSensitiveConfig(cfg);
+    expect(out.password).toBe(123);
+    expect(out.secret).toBeNull();
+  });
+
+  it('does not mutate the input (returns a deep copy)', () => {
+    const cfg = { reverseProxy: { npm: { password: 'hunter2' } } };
+    const out = redactSensitiveConfig(cfg);
+    expect(cfg.reverseProxy.npm.password).toBe('hunter2');
+    expect(out).not.toBe(cfg);
+    expect(out.reverseProxy).not.toBe(cfg.reverseProxy);
+  });
+});


### PR DESCRIPTION
## What
The foundation for the Go TUI's authenticated box client (#1275): a valid `sb_` API token can now reach the REST API, and the config-read path redacts secrets for token callers.

- **`proxy.ts`** — a *verified* `Authorization: Bearer sb_…` token bypasses the cookie + CSRF gates (mirrors the internal-token path). Verification happens at the proxy, so an attacker can't append `Bearer x` to a cookie'd victim's request to skip CSRF. Scope enforcement stays per-route.
- **`withApiHandler`** — runs `requireSession` on GET too when a Bearer header is present (or the route sets `tokenScope`), and threads the auth payload into the handler as `auth`. A Bearer GET to a route *without* `tokenScope` still 401s → per-route opt-in preserved.
- **GET `/api/settings`** — opts into `read` and redacts secrets for token callers (`auth.user` starts with `token:`); cookie/internal (web UI) unchanged. New `redactSensitiveConfig` reuses the `SENSITIVE_KEYS` walk.

## Why
Part of #1275 (operator approved the **token-callers-only** redaction model). Critical: this is what makes #1265's Bearer-on-REST mechanism actually reachable — today `proxy.ts` 401s every cookieless request, so a token never reached the handler. Design + rationale in the #1275 issue comment.

**Deferred follow-ups:** POST `/api/settings` editable-key allow-list (`mutate`); the Go REST + token client; the edit-config panel — then unblocks #1276/#1277.

## Risk
**Medium-High — touches the auth middleware.** Opened as a draft for human security review. Key invariant to scrutinise: the proxy passthrough opens reachability for *any* valid token, and the per-route opt-in is re-enforced at the handler (`requireSession` rejects Bearer when a route sets no `tokenScope`). Routes that bypass `withApiHandler` would not get that re-gate — worth a reviewer pass for raw GET routes.

## Rollback
`git revert` — isolated to the 4 files; no migration.

## Verification
- [x] npm run lint (0 errors, 394 warnings = baseline)
- [x] npm run check:arch (no new dep violations; `lib/api`→`lib/auth` already allowed)
- [x] npm test (190 files, 1490 passed) — incl. 4 redaction + 3 handler-token-auth tests
- [x] npm run build (typecheck clean)
- [ ] **Real-box `/verify` (before any merge — auth path):** mint an `sb_` token with `read`; `curl -H "Authorization: Bearer sb_…" /api/settings` returns config with secrets `__REDACTED__`; the web UI GET still shows real values; a Bearer GET to a non-opted route 401s; cookie POST/login flows unaffected.