### PR TITLE
feat(tui): full-screen launcher + complete lifecycle menu + auto-launch

### DIFF
--- a/install-sb-tui.sh
+++ b/install-sb-tui.sh
@@ -81,4 +81,16 @@ case ":${PATH}:" in
   *) echo "Note: ${INSTALL_DIR} is not on your PATH — add it:" >&2
      echo "  export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2 ;;
 esac
-echo "Run '${BIN}' to open the ServiceBay lifecycle launcher."
+
+# Launch the launcher straight away. Even via `curl … | sh` (stdin is the
+# piped script, not a keyboard) the controlling terminal is still reachable at
+# /dev/tty, so hand it to the TUI. SB_TUI_NO_LAUNCH=1 opts out (CI / scripted
+# installs); if there's no tty we just print the run hint.
+if [ "${SB_TUI_NO_LAUNCH:-}" = "1" ]; then
+  echo "Run '${BIN}' to open the ServiceBay lifecycle launcher."
+elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+  echo "Launching the ServiceBay lifecycle launcher…"
+  exec "$dest" < /dev/tty > /dev/tty 2>&1
+else
+  echo "Run '${BIN}' to open the ServiceBay lifecycle launcher."
+fi

--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -53,41 +53,71 @@ type ActionID string
 const (
 	BuildISO     ActionID = "build-iso"
 	WatchInstall ActionID = "watch-install"
+	OpenBox      ActionID = "open-box"
 	Refresh      ActionID = "refresh"
 	Quit         ActionID = "quit"
 )
 
-// Action is one selectable menu entry.
+// Action is one selectable menu entry: a short Label plus a one-line Detail
+// rendered with the selection so the operator always knows what each does.
 type Action struct {
-	ID    ActionID
-	Label string
+	ID     ActionID
+	Label  string
+	Detail string
 }
 
-// ActionsFor returns the menu entries relevant to a phase.
-//
-// Note vs the Ink original: the "Choose / download a Fedora CoreOS ISO" entry
-// (the ISO picker sub-screen) is intentionally deferred to the build/flash
-// leg (#1278), which owns the picker. The build + watch handoffs shell to the
-// existing bash scripts for now; #1274 / #1278 replace those with native Go
-// and delete the scripts.
+// buildAction returns the build/reinstall entry, with the verb adapted to the
+// phase: a fresh "Build" when nothing exists, "Rebuild" once an ISO is baked,
+// and "Reinstall" framing once the box is up.
+func buildAction(s State) Action {
+	switch {
+	case s.BoxReachable:
+		return Action{BuildISO, "Reinstall — build install ISO + flash USB",
+			"Bake a fresh ServiceBay installer and write it to a USB stick to reinstall this box from scratch."}
+	case s.ISOBuilt:
+		return Action{BuildISO, "Rebuild install ISO + flash USB",
+			"Re-bake the installer ISO with fresh secrets / config and flash it to a USB stick."}
+	default:
+		return Action{BuildISO, "Build install ISO + flash USB",
+			"Bake a ServiceBay installer ISO from Fedora CoreOS and write it to a USB stick."}
+	}
+}
+
+// ActionsFor returns the menu entries relevant to a phase. The list is
+// comprehensive — every action that makes sense in the phase is shown, with
+// the recommended next step first — rather than a single-action stub.
 func ActionsFor(s State) []Action {
 	var a []Action
-	switch {
-	case !s.BoxReachable:
-		label := "Build install ISO + flash USB"
-		if s.ISOBuilt {
-			label = "Rebuild install ISO + flash USB"
-		}
-		a = append(a, Action{BuildISO, label})
-		if s.ISOBuilt {
-			a = append(a, Action{WatchInstall, "Boot the USB, then watch the install"})
-		}
-	case s.Phase == Installing:
-		a = append(a, Action{WatchInstall, "Watch install progress"})
-	default:
-		a = append(a, Action{WatchInstall, "Watch a reinstall"})
+	switch s.Phase {
+	case NoISO:
+		// Nothing built and no box — the only move is to bake an installer.
+		a = append(a, buildAction(s))
+	case ISOReady:
+		// ISO baked, box not up yet — rebuild, or boot-then-watch.
+		a = append(a,
+			buildAction(s),
+			Action{WatchInstall, "Boot the USB, then watch the install",
+				"Power on the box from the USB stick; this live-tracks the install until the setup wizard is up."})
+	case Installing:
+		// Box is up mid-install — watch it, jump to the wizard, or reinstall.
+		a = append(a,
+			Action{WatchInstall, "Watch install progress",
+				"Live-track the running install until ServiceBay's setup wizard takes over."},
+			Action{OpenBox, "Open ServiceBay in your browser",
+				"Open the setup wizard / dashboard URL for this box."},
+			buildAction(s))
+	case Ready:
+		// Box is fully up — manage it via the browser, or reinstall.
+		a = append(a,
+			Action{OpenBox, "Open ServiceBay in your browser",
+				"Open this box's dashboard to manage services, users, and settings."},
+			Action{WatchInstall, "Watch a reinstall in progress",
+				"Live-track an install if you're reinstalling this box."},
+			buildAction(s))
 	}
-	a = append(a, Action{Refresh, "Refresh status"}, Action{Quit, "Quit"})
+	a = append(a,
+		Action{Refresh, "Refresh status", "Re-probe the box and ISO state."},
+		Action{Quit, "Quit", "Exit the launcher."})
 	return a
 }
 

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -53,13 +53,29 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{BuildISO, WatchInstall, Refresh, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: watch only
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, Refresh, Quit}) {
+	// installing: watch + open-box + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, BuildISO, Refresh, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: watch (reinstall)
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{WatchInstall, Refresh, Quit}) {
+	// ready: open-box + watch + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, WatchInstall, BuildISO, Refresh, Quit}) {
 		t.Fatalf("ready actions = %v", got)
+	}
+}
+
+func TestEveryActionHasLabelAndDetail(t *testing.T) {
+	phases := []State{
+		Detect(false, BoxStatus{}),
+		Detect(true, BoxStatus{}),
+		Detect(true, BoxStatus{Reachable: true}),
+		Detect(true, BoxStatus{Reachable: true, WizardDone: true}),
+	}
+	for _, s := range phases {
+		for _, a := range ActionsFor(s) {
+			if a.Label == "" || a.Detail == "" {
+				t.Fatalf("phase %q action %q missing label/detail", s.Phase, a.ID)
+			}
+		}
 	}
 }
 

--- a/tools/sb-tui/internal/ui/menu.go
+++ b/tools/sb-tui/internal/ui/menu.go
@@ -1,15 +1,18 @@
 // Package ui is the Bubble Tea presentation layer for the launcher (#1273,
 // porting packages/tui/src/App.tsx). Thin over the phase package: detect the
 // phase, render the relevant actions, and report a terminal choice (build /
-// watch) back to the entrypoint, which hands off. Quit + Refresh are handled
-// here.
+// watch / open-box) back to the entrypoint, which hands off. Quit + Refresh
+// are handled here. Runs full-screen (alt-screen) so it owns the terminal like
+// a real installer.
 package ui
 
 import (
-	"context"
 	"strings"
 
+	"context"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"servicebay-tui/internal/phase"
 )
@@ -20,14 +23,28 @@ type DetectFunc func(context.Context) (isoBuilt bool, status phase.BoxStatus)
 
 type phaseMsg struct{ state phase.State }
 
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("231")).
+			Background(lipgloss.Color("63")).
+			Padding(0, 1)
+	phaseStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("250")).MarginTop(1)
+	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("231")).Background(lipgloss.Color("63"))
+	normalStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	detailStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).MarginLeft(4).MarginTop(1)
+	footerStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).MarginTop(1)
+)
+
 // Model is the Bubble Tea model for the launcher menu.
 type Model struct {
-	detect  DetectFunc
-	state   *phase.State
-	actions []phase.Action
-	cursor  int
-	// Chosen is set to a handoff action (build/watch) when the operator picks
-	// one; the entrypoint reads it after the program exits.
+	detect        DetectFunc
+	state         *phase.State
+	actions       []phase.Action
+	cursor        int
+	width, height int
+	// Chosen is set to a handoff action (build/watch/open-box) when the operator
+	// picks one; the entrypoint reads it after the program exits.
 	Chosen phase.ActionID
 }
 
@@ -52,6 +69,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = &s
 		m.actions = phase.ActionsFor(s)
 		m.cursor = 0
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
 		return m, nil
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
@@ -82,22 +103,42 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// View renders the menu.
+// View renders the full-screen menu.
 func (m Model) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	title := titleStyle.Width(width).Render("ServiceBay  ·  lifecycle launcher")
+
 	var b strings.Builder
-	b.WriteString("ServiceBay — lifecycle launcher\n\n")
+	b.WriteString(title + "\n")
 	if m.state == nil {
-		b.WriteString("Detecting phase…\n")
-		return b.String()
+		b.WriteString(phaseStyle.Render("Detecting box + ISO state…"))
+		return frame(b.String(), m.width, m.height)
 	}
-	b.WriteString(phase.Describe(*m.state) + "\n\n")
+	b.WriteString(phaseStyle.Render(phase.Describe(*m.state)) + "\n\n")
+
 	for i, a := range m.actions {
-		marker := "  "
 		if i == m.cursor {
-			marker = "❯ "
+			b.WriteString(selectedStyle.Render("❯ "+a.Label) + "\n")
+		} else {
+			b.WriteString(normalStyle.Render("  "+a.Label) + "\n")
 		}
-		b.WriteString(marker + a.Label + "\n")
 	}
-	b.WriteString("\n↑/↓ to move · Enter to select · Ctrl+C to quit\n")
-	return b.String()
+
+	if m.cursor < len(m.actions) {
+		b.WriteString(detailStyle.Render(m.actions[m.cursor].Detail) + "\n")
+	}
+	b.WriteString(footerStyle.Render("↑/↓ move · enter select · ctrl+c quit"))
+	return frame(b.String(), m.width, m.height)
+}
+
+// frame pins the content to the top-left of the alt-screen so the launcher
+// fills the terminal rather than floating mid-scroll.
+func frame(content string, width, height int) string {
+	if width <= 0 || height <= 0 {
+		return content
+	}
+	return lipgloss.NewStyle().Width(width).Height(height).Render(content)
 }

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -71,6 +73,38 @@ func runWatch() int {
 	return 0
 }
 
+// runOpenBox prints the box's setup + dashboard URLs and best-effort opens the
+// dashboard in the operator's browser (#1272 menu action OpenBox).
+func runOpenBox() int {
+	t := probes.ResolveTarget()
+	if t.Host == "" {
+		fmt.Fprintln(os.Stderr, "no box target — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
+		return 2
+	}
+	dashboard := fmt.Sprintf("http://%s:%s/", t.Host, t.Port)
+	fmt.Printf("\n→ ServiceBay\n\n")
+	fmt.Printf("   Dashboard:     %s\n", dashboard)
+	fmt.Printf("   Setup wizard:  http://%s:%s/setup\n\n", t.Host, t.Port)
+	openBrowser(dashboard)
+	return 0
+}
+
+// openBrowser best-effort launches the host's default browser; failures are
+// ignored (the URLs are already printed for the operator to copy).
+func openBrowser(url string) {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{url}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		name, args = "xdg-open", []string{url}
+	}
+	_ = exec.Command(name, args...).Start()
+}
+
 func main() {
 	// Subcommands skip the menu and run one leg directly. `watch` is used by the
 	// install scripts' auto-launch; `build` runs the native ISO-build wizard
@@ -84,7 +118,9 @@ func main() {
 		}
 	}
 
-	final, err := tea.NewProgram(ui.New(detect)).Run()
+	// Full-screen (alt-screen): the launcher owns the terminal like a real
+	// installer rather than scrolling inline.
+	final, err := tea.NewProgram(ui.New(detect), tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -99,5 +135,7 @@ func main() {
 		os.Exit(runBuild())
 	case phase.WatchInstall:
 		os.Exit(runWatch())
+	case phase.OpenBox:
+		os.Exit(runOpenBox())
 	}
 }


### PR DESCRIPTION
## What
Makes `sb-tui` behave like a real installer instead of a thin inline stub:
- **Full-screen** — the menu runs in the alt-screen (`tea.WithAltScreen`) and owns the terminal.
- **Complete menu** — every phase-relevant action is shown with a one-line description, recommended first; adds **Open ServiceBay in your browser** and offers **reinstall** (build ISO + flash USB) from a running box. No more 3-item stub.
- **Styled** — title bar, highlighted selection, detail line, footer.
- **`install-sb-tui.sh` launches the launcher** after install via `/dev/tty`, so the `curl … | sh` one-liner opens it (`SB_TUI_NO_LAUNCH=1` opts out).

## Why
Part of #1272. Addresses operator feedback: the launcher wasn't full-screen and the menu was missing actions.

## Risk
Low. Confined to `tools/sb-tui/` + the root installer; not path-mandated. The build/flash/watch legs are unchanged.

## Rollback
`git revert`.

## Verification
- [x] tui-go: gofmt clean, `go vet`, `go build`, `go test ./...` all pass (phase tests updated for the new action sets + a label/detail-completeness test).
- [x] `sh -n install-sb-tui.sh`
- [ ] Visual check on a real terminal (operator): `go run ./tools/sb-tui` (or the installed binary) opens full-screen with the full menu; Open ServiceBay prints+opens the URL.

Next in the series: #1327 (auto-install build-host tools), then the REST panels (#1275 edit-config, #1276 stacks, #1277 backup).