### PR TITLE
feat(tui): box REST token client + edit-config panel

### DIFF
--- a/packages/frontend/src/app/api/settings/route.ts
+++ b/packages/frontend/src/app/api/settings/route.ts
@@ -31,8 +31,14 @@ export const GET = withApiHandler({ tokenScope: 'read' }, async ({ auth }) => {
  * formats errors with the more detailed `formatConfigErrors` shape the
  * settings UI displays. Re-routing through the handler's Zod path would
  * lose that fidelity.
+ *
+ * `tokenScope: 'mutate'` (#1275) lets a scoped `sb_` API token (the sb-tui
+ * edit-config panel) write config, not just read it via GET. The body is a
+ * Partial<AppConfig> that's merged with the persisted config, so a token
+ * caller sends only the field(s) it changes — it never round-trips the
+ * redacted secrets it received from GET back into the store.
  */
-export const POST = withApiHandler({}, async ({ request }) => {
+export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request }) => {
   let body: unknown;
   try {
     body = await request.json();

--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -54,9 +54,16 @@ const (
 	BuildISO     ActionID = "build-iso"
 	WatchInstall ActionID = "watch-install"
 	OpenBox      ActionID = "open-box"
+	EditConfig   ActionID = "edit-config"
 	Refresh      ActionID = "refresh"
 	Quit         ActionID = "quit"
 )
+
+// editConfigAction is the in-TUI box-control entry (#1275): edit allow-listed
+// config over the authenticated REST API without leaving the launcher. Only
+// meaningful once the box is reachable.
+var editConfigAction = Action{EditConfig, "Edit config (in-TUI)",
+	"View and edit allow-listed box settings (server name, domain, log level) over the REST API."}
 
 // Action is one selectable menu entry: a short Label plus a one-line Detail
 // rendered with the selection so the operator always knows what each does.
@@ -105,12 +112,14 @@ func ActionsFor(s State) []Action {
 				"Live-track the running install until ServiceBay's setup wizard takes over."},
 			Action{OpenBox, "Open ServiceBay in your browser",
 				"Open the setup wizard / dashboard URL for this box."},
+			editConfigAction,
 			buildAction(s))
 	case Ready:
 		// Box is fully up — manage it via the browser, or reinstall.
 		a = append(a,
 			Action{OpenBox, "Open ServiceBay in your browser",
 				"Open this box's dashboard to manage services, users, and settings."},
+			editConfigAction,
 			Action{WatchInstall, "Watch a reinstall in progress",
 				"Live-track an install if you're reinstalling this box."},
 			buildAction(s))

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -53,12 +53,12 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{BuildISO, WatchInstall, Refresh, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: watch + open-box + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, BuildISO, Refresh, Quit}) {
+	// installing: watch + open-box + edit-config + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, EditConfig, BuildISO, Refresh, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: open-box + watch + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, WatchInstall, BuildISO, Refresh, Quit}) {
+	// ready: open-box + edit-config + watch + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, WatchInstall, BuildISO, Refresh, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/probes/probes.go
+++ b/tools/sb-tui/internal/probes/probes.go
@@ -77,6 +77,14 @@ func ResolveTarget() Target {
 	return Target{Host: host, Port: port}
 }
 
+// ResolveToken returns the scoped `sb_…` API token the box-control panels
+// authenticate with (#1275), read from SB_TOKEN. Empty when unset — the panel
+// then shows mint instructions rather than making a doomed 401 call. Mint one
+// in ServiceBay → Settings → API tokens with the `mutate` scope.
+func ResolveToken() string {
+	return strings.TrimSpace(os.Getenv("SB_TOKEN"))
+}
+
 // BoxStatus probes /api/install/status (unauthed). Unreachable host or any
 // transport error reads as not-reachable; a non-2xx reads as reachable but
 // not-done. wizardDone mirrors the Ink probe: no active job and no pending

--- a/tools/sb-tui/internal/rest/config.go
+++ b/tools/sb-tui/internal/rest/config.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// EditableField is one allow-listed config key the edit-config panel exposes.
+// The set is deliberately narrow (#1275): non-sensitive top-level scalars that
+// are safe to read+write through a scoped token. Secrets (password/secret/
+// token/key) are redacted by the box on GET and intentionally not editable
+// here — they round-trip through the web UI, not the TUI.
+type EditableField struct {
+	Key   string // config.json key sent in the POST patch
+	Label string // human label shown in the panel
+	// Allowed, when non-empty, constrains the value to a fixed set (an enum
+	// like logLevel); an empty slice means free-text.
+	Allowed []string
+}
+
+// EditableFields is the curated allow-list, in display order.
+var EditableFields = []EditableField{
+	{Key: "serverName", Label: "Server name"},
+	{Key: "domain", Label: "Domain"},
+	{Key: "logLevel", Label: "Log level", Allowed: []string{"debug", "info", "warn", "error"}},
+}
+
+// Config holds the current values of the allow-listed fields, read from the
+// box. Values are plain strings (the allow-listed keys are all scalar and
+// non-sensitive, so they're never redacted).
+type Config struct {
+	Values map[string]string
+}
+
+// GetConfig fetches the box config and projects out the allow-listed fields.
+// A field absent from the box config reads as the empty string.
+func (c *Client) GetConfig(ctx context.Context) (*Config, error) {
+	raw, err := c.do(ctx, "GET", "/api/settings", nil)
+	if err != nil {
+		return nil, err
+	}
+	// The settings GET returns the config object directly (plus a
+	// templateSettingsSchema sibling we ignore), not the {ok,data} envelope.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, &APIError{Message: "malformed config response: " + err.Error()}
+	}
+	values := make(map[string]string, len(EditableFields))
+	for _, f := range EditableFields {
+		var s string
+		if v, ok := doc[f.Key]; ok {
+			_ = json.Unmarshal(v, &s) // non-string/absent → "" via zero value
+		}
+		values[f.Key] = s
+	}
+	return &Config{Values: values}, nil
+}
+
+// UpdateConfig writes a single allow-listed field. It POSTs a minimal partial
+// ({key: value}) so the box's merge touches only that field and never
+// round-trips redacted secrets back into the store (#1275).
+func (c *Client) UpdateConfig(ctx context.Context, key, value string) error {
+	_, err := c.do(ctx, "POST", "/api/settings", map[string]string{key: value})
+	return err
+}

--- a/tools/sb-tui/internal/rest/rest.go
+++ b/tools/sb-tui/internal/rest/rest.go
@@ -1,0 +1,120 @@
+// Package rest is the sb-tui client for the box's authenticated REST API
+// (#1275). It authenticates with a scoped named API token
+// (`Authorization: Bearer sb_…`, the #1265 foundation) and is the shared HTTP
+// + auth + error-surface layer every box-control panel reuses (edit-config
+// #1275, stack-install #1276, backup #1277). Kept free of any Bubble Tea types
+// so it's unit-testable against an httptest server with no UI.
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// defaultTimeout bounds a single request. Box calls are LAN-local and cheap;
+// a stuck connection should surface as an error rather than hang the panel.
+const defaultTimeout = 10 * time.Second
+
+// ErrNoToken is returned by New when no API token was supplied. Panels surface
+// it with the mint instructions (Settings → API tokens, scope `mutate`).
+var ErrNoToken = errors.New("no API token: set SB_TOKEN to a scoped sb_… token")
+
+// ErrUnauthorized is returned for a 401 — a missing, expired, or
+// insufficiently-scoped token. Distinguished from other API errors so panels
+// can point the operator at re-minting rather than at a transient failure.
+var ErrUnauthorized = errors.New("unauthorized: token missing, expired, or lacks the required scope")
+
+// APIError carries a non-2xx response the server explained in its JSON error
+// envelope ({"error": …} or {"ok":false,"error":…}). Status 0 with a wrapped
+// transport error means the request never completed.
+type APIError struct {
+	Status  int
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e.Status == 0 {
+		return e.Message
+	}
+	return fmt.Sprintf("box returned %d: %s", e.Status, e.Message)
+}
+
+// Client talks to one box's REST API with a bearer token.
+type Client struct {
+	BaseURL string // e.g. http://192.168.178.100:5888
+	Token   string // the sb_… named API token
+	HTTP    *http.Client
+}
+
+// New builds a client for host:port. token is the scoped sb_ token; an empty
+// token yields ErrNoToken so callers fail fast with mint instructions instead
+// of making a doomed 401 round-trip.
+func New(host, port, token string) (*Client, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, ErrNoToken
+	}
+	return &Client{
+		BaseURL: fmt.Sprintf("http://%s:%s", host, port),
+		Token:   token,
+		HTTP:    &http.Client{Timeout: defaultTimeout},
+	}, nil
+}
+
+// do issues a request with the bearer token, returning the decoded JSON body on
+// 2xx or a typed error (ErrUnauthorized / *APIError) otherwise.
+func (c *Client) do(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("encode request body: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, reader)
+	if err != nil {
+		return nil, &APIError{Message: err.Error()}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		// Transport failure (box unreachable, timeout) — never reached the app.
+		return nil, &APIError{Message: fmt.Sprintf("cannot reach box: %v", err)}
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &APIError{Status: resp.StatusCode, Message: serverError(raw, resp.StatusCode)}
+	}
+	return json.RawMessage(raw), nil
+}
+
+// serverError extracts the human-readable message from the box's error
+// envelope, falling back to the raw body or the bare status text.
+func serverError(raw []byte, status int) string {
+	var env struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(raw, &env) == nil && env.Error != "" {
+		return env.Error
+	}
+	if s := strings.TrimSpace(string(raw)); s != "" {
+		return s
+	}
+	return http.StatusText(status)
+}

--- a/tools/sb-tui/internal/rest/rest_test.go
+++ b/tools/sb-tui/internal/rest/rest_test.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewRequiresToken(t *testing.T) {
+	if _, err := New("h", "1", "   "); err != ErrNoToken {
+		t.Fatalf("blank token: got %v, want ErrNoToken", err)
+	}
+	if _, err := New("h", "1", "sb_abc"); err != nil {
+		t.Fatalf("valid token: unexpected error %v", err)
+	}
+}
+
+// newTestClient points a client at a test server, bypassing New's host:port
+// formatting so handlers can assert on the request directly.
+func newTestClient(srv *httptest.Server) *Client {
+	return &Client{BaseURL: srv.URL, Token: "sb_test", HTTP: srv.Client()}
+}
+
+func TestGetConfigProjectsAllowList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer sb_test" {
+			t.Errorf("missing bearer: %q", got)
+		}
+		// The settings GET returns the config object directly, with extra
+		// keys (templateSettingsSchema, redacted secrets) the client ignores.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"serverName":             "homelab",
+			"logLevel":               "debug",
+			"adminPassword":          "__REDACTED__",
+			"templateSettingsSchema": map[string]any{"x": 1},
+			// domain intentionally absent → should read as "".
+		})
+	}))
+	defer srv.Close()
+
+	cfg, err := newTestClient(srv).GetConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	if cfg.Values["serverName"] != "homelab" {
+		t.Errorf("serverName = %q", cfg.Values["serverName"])
+	}
+	if cfg.Values["logLevel"] != "debug" {
+		t.Errorf("logLevel = %q", cfg.Values["logLevel"])
+	}
+	if cfg.Values["domain"] != "" {
+		t.Errorf("absent domain should be empty, got %q", cfg.Values["domain"])
+	}
+	if _, ok := cfg.Values["adminPassword"]; ok {
+		t.Error("non-allow-listed key leaked into Values")
+	}
+}
+
+func TestUpdateConfigSendsMinimalPatch(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"serverName": "newname"})
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).UpdateConfig(context.Background(), "serverName", "newname"); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+	if len(gotBody) != 1 || gotBody["serverName"] != "newname" {
+		t.Errorf("expected minimal {serverName:newname} patch, got %v", gotBody)
+	}
+}
+
+func TestUnauthorizedMapsToSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Authentication required"})
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).GetConfig(context.Background())
+	if err != ErrUnauthorized {
+		t.Fatalf("got %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestServerErrorEnvelopeSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "Invalid settings payload"})
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv).UpdateConfig(context.Background(), "serverName", "x")
+	var apiErr *APIError
+	if !asAPIError(err, &apiErr) {
+		t.Fatalf("got %T (%v), want *APIError", err, err)
+	}
+	if apiErr.Status != 400 || !strings.Contains(apiErr.Message, "Invalid settings payload") {
+		t.Errorf("APIError = %+v", apiErr)
+	}
+}
+
+// asAPIError is a tiny errors.As shim kept local so the test reads top-down.
+func asAPIError(err error, target **APIError) bool {
+	e, ok := err.(*APIError)
+	if ok {
+		*target = e
+	}
+	return ok
+}

--- a/tools/sb-tui/internal/ui/config.go
+++ b/tools/sb-tui/internal/ui/config.go
@@ -1,0 +1,278 @@
+// The Bubble Tea model for the edit-config panel (#1275): the first box-control
+// panel and the template the others (stack-install #1276, backup #1277) follow.
+// It reads the box's allow-listed config via the authenticated rest client,
+// lets the operator edit a field in place, and writes a minimal partial back.
+// All HTTP + auth + error surfacing lives in internal/rest; this is the thin
+// Bubble Tea shell, mirroring how watch.go wraps the watch package.
+package ui
+
+import (
+	"context"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"servicebay-tui/internal/rest"
+)
+
+var (
+	cfgValueStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	cfgEmptyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Italic(true)
+	cfgEditingStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("231")).Background(lipgloss.Color("63"))
+	cfgErrStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	cfgOKStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+)
+
+// ConfigModel is the Bubble Tea model for the edit-config panel.
+type ConfigModel struct {
+	client        *rest.Client
+	fields        []rest.EditableField
+	values        map[string]string
+	cursor        int
+	width, height int
+
+	loading bool
+	editing bool
+	buf     string // edit buffer for the field being edited
+
+	status string // transient status / error line
+	loadEr error  // a load/auth error that blocks the whole panel
+}
+
+// configLoadedMsg carries the result of the initial (or refreshed) GET.
+type configLoadedMsg struct {
+	cfg *rest.Config
+	err error
+}
+
+// configSavedMsg carries the result of a POST for one field.
+type configSavedMsg struct {
+	key, value string
+	err        error
+}
+
+// NewConfig builds the edit-config model against an authenticated client.
+func NewConfig(client *rest.Client) ConfigModel {
+	return ConfigModel{
+		client:  client,
+		fields:  rest.EditableFields,
+		values:  map[string]string{},
+		loading: true,
+	}
+}
+
+func (m ConfigModel) loadCmd() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		cfg, err := client.GetConfig(context.Background())
+		return configLoadedMsg{cfg: cfg, err: err}
+	}
+}
+
+func (m ConfigModel) saveCmd(key, value string) tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		err := client.UpdateConfig(context.Background(), key, value)
+		return configSavedMsg{key: key, value: value, err: err}
+	}
+}
+
+// Init kicks off the first config load.
+func (m ConfigModel) Init() tea.Cmd { return m.loadCmd() }
+
+// Update folds in load/save results and handles input.
+func (m ConfigModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case configLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.loadEr = msg.err
+			return m, nil
+		}
+		m.loadEr = nil
+		m.values = msg.cfg.Values
+		return m, nil
+	case configSavedMsg:
+		m.editing = false
+		if msg.err != nil {
+			m.status = "✗ " + friendlyErr(msg.err)
+			return m, nil
+		}
+		m.values[msg.key] = msg.value
+		m.status = "✓ saved " + msg.key
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m ConfigModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+	if m.editing {
+		return m.handleEditKey(msg)
+	}
+	// A blocking load error leaves only quit/refresh meaningful.
+	if m.loadEr != nil {
+		switch msg.String() {
+		case "q", "esc":
+			return m, tea.Quit
+		case "r":
+			m.loading, m.loadEr = true, nil
+			return m, m.loadCmd()
+		}
+		return m, nil
+	}
+	if m.loading || len(m.fields) == 0 {
+		return m, nil
+	}
+	switch msg.String() {
+	case "q", "esc":
+		return m, tea.Quit
+	case "up", "k":
+		m.cursor = (m.cursor - 1 + len(m.fields)) % len(m.fields)
+		m.status = ""
+	case "down", "j":
+		m.cursor = (m.cursor + 1) % len(m.fields)
+		m.status = ""
+	case "r":
+		m.loading, m.status = true, ""
+		return m, m.loadCmd()
+	case "enter":
+		m.editing = true
+		m.buf = m.values[m.fields[m.cursor].Key]
+		m.status = ""
+	}
+	return m, nil
+}
+
+// handleEditKey drives the in-place editor. Enum fields (logLevel) cycle
+// through their allowed values with ←/→; free-text fields take typed runes.
+func (m ConfigModel) handleEditKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	f := m.fields[m.cursor]
+	switch msg.String() {
+	case "esc":
+		m.editing = false
+		m.status = ""
+		return m, nil
+	case "enter":
+		return m, m.saveCmd(f.Key, strings.TrimSpace(m.buf))
+	case "left", "right":
+		if len(f.Allowed) > 0 {
+			m.buf = cycle(f.Allowed, m.buf, msg.String() == "right")
+		}
+		return m, nil
+	case "backspace":
+		if len(f.Allowed) == 0 && m.buf != "" {
+			m.buf = m.buf[:len(m.buf)-1]
+		}
+		return m, nil
+	default:
+		// Free-text fields take printable runes; enum fields ignore typing.
+		if len(f.Allowed) == 0 && msg.Type == tea.KeyRunes {
+			m.buf += string(msg.Runes)
+		}
+		return m, nil
+	}
+}
+
+// cycle returns the value before/after cur in vals (wrapping). An unknown cur
+// starts at the first value.
+func cycle(vals []string, cur string, forward bool) string {
+	idx := 0
+	for i, v := range vals {
+		if v == cur {
+			idx = i
+			break
+		}
+	}
+	if forward {
+		idx = (idx + 1) % len(vals)
+	} else {
+		idx = (idx - 1 + len(vals)) % len(vals)
+	}
+	return vals[idx]
+}
+
+// friendlyErr maps the rest client's typed errors to a one-line operator hint.
+func friendlyErr(err error) string {
+	switch {
+	case err == rest.ErrUnauthorized:
+		return "token rejected — mint one with the `mutate` scope (Settings → API tokens) and set SB_TOKEN."
+	case err == rest.ErrNoToken:
+		return rest.ErrNoToken.Error()
+	default:
+		return err.Error()
+	}
+}
+
+// View renders the panel.
+func (m ConfigModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  edit config") + "\n")
+
+	if m.loading {
+		b.WriteString(phaseStyle.Render("Loading config…"))
+		return frame(b.String(), m.width, m.height)
+	}
+	if m.loadEr != nil {
+		b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Couldn't load config:")) + "\n")
+		b.WriteString(detailStyle.Render(friendlyErr(m.loadEr)) + "\n")
+		b.WriteString(footerStyle.Render("r retry · q quit"))
+		return frame(b.String(), m.width, m.height)
+	}
+
+	b.WriteString(phaseStyle.Render("Edit allow-listed config. Secrets are managed in the web UI.") + "\n\n")
+	for i, f := range m.fields {
+		val := m.values[f.Key]
+		var rendered string
+		switch {
+		case m.editing && i == m.cursor:
+			rendered = cfgEditingStyle.Render(f.Label + ": " + m.buf + "▌")
+		case i == m.cursor:
+			rendered = selectedStyle.Render("❯ " + f.Label + ": " + valueText(val))
+		default:
+			rendered = normalStyle.Render("  " + f.Label + ": " + valueText(val))
+		}
+		b.WriteString(rendered + "\n")
+	}
+
+	if m.status != "" {
+		style := cfgOKStyle
+		if strings.HasPrefix(m.status, "✗") {
+			style = cfgErrStyle
+		}
+		b.WriteString("\n" + detailStyle.Render(style.Render(m.status)) + "\n")
+	}
+
+	b.WriteString("\n")
+	if m.editing {
+		if len(m.fields[m.cursor].Allowed) > 0 {
+			b.WriteString(footerStyle.Render("←/→ choose · enter save · esc cancel"))
+		} else {
+			b.WriteString(footerStyle.Render("type to edit · enter save · esc cancel"))
+		}
+	} else {
+		b.WriteString(footerStyle.Render("↑/↓ move · enter edit · r refresh · q quit"))
+	}
+	return frame(b.String(), m.width, m.height)
+}
+
+// valueText renders a config value, marking the empty string as unset rather
+// than showing a blank.
+func valueText(v string) string {
+	if v == "" {
+		return cfgEmptyStyle.Render("(unset)")
+	}
+	return cfgValueStyle.Render(v)
+}

--- a/tools/sb-tui/internal/ui/config_test.go
+++ b/tools/sb-tui/internal/ui/config_test.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+// key builds a KeyMsg for a single typed rune.
+func runeKey(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
+func namedKey(t tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: t} }
+
+func TestConfigCycle(t *testing.T) {
+	vals := []string{"debug", "info", "warn", "error"}
+	if got := cycle(vals, "info", true); got != "warn" {
+		t.Errorf("forward from info = %q, want warn", got)
+	}
+	if got := cycle(vals, "info", false); got != "debug" {
+		t.Errorf("back from info = %q, want debug", got)
+	}
+	if got := cycle(vals, "error", true); got != "debug" {
+		t.Errorf("forward wrap = %q, want debug", got)
+	}
+	if got := cycle(vals, "unknown", true); got != "info" {
+		t.Errorf("unknown starts at first then advances, got %q", got)
+	}
+}
+
+// TestConfigEditFlow drives the model through load → edit a free-text field →
+// save, asserting the save command targets the right key/value.
+func TestConfigEditFlow(t *testing.T) {
+	m := NewConfig(&rest.Client{}) // client unused: we feed messages directly
+	// Simulate a completed load.
+	mi, _ := m.Update(configLoadedMsg{cfg: &rest.Config{Values: map[string]string{
+		"serverName": "old", "domain": "", "logLevel": "info",
+	}}})
+	m = mi.(ConfigModel)
+	if m.loading {
+		t.Fatal("still loading after configLoadedMsg")
+	}
+
+	// Cursor starts on serverName (free text). Enter edit, retype.
+	mi, _ = m.Update(namedKey(tea.KeyEnter))
+	m = mi.(ConfigModel)
+	if !m.editing || m.buf != "old" {
+		t.Fatalf("edit mode: editing=%v buf=%q", m.editing, m.buf)
+	}
+	// Backspace the whole buffer, type "new".
+	for range "old" {
+		mi, _ = m.Update(namedKey(tea.KeyBackspace))
+		m = mi.(ConfigModel)
+	}
+	for _, r := range "new" {
+		mi, _ = m.Update(runeKey(r))
+		m = mi.(ConfigModel)
+	}
+	if m.buf != "new" {
+		t.Fatalf("buf after typing = %q", m.buf)
+	}
+
+	// Enter triggers a save command; execute it and feed the result back as if
+	// the POST succeeded.
+	mi, cmd := m.Update(namedKey(tea.KeyEnter))
+	m = mi.(ConfigModel)
+	if cmd == nil {
+		t.Fatal("enter in edit mode should issue a save command")
+	}
+	// We can't run the real command (no server), so simulate its success.
+	mi, _ = m.Update(configSavedMsg{key: "serverName", value: "new"})
+	m = mi.(ConfigModel)
+	if m.editing {
+		t.Error("should leave edit mode after save")
+	}
+	if m.values["serverName"] != "new" {
+		t.Errorf("value not updated: %q", m.values["serverName"])
+	}
+}
+
+func TestConfigEnumIgnoresTyping(t *testing.T) {
+	m := NewConfig(&rest.Client{})
+	mi, _ := m.Update(configLoadedMsg{cfg: &rest.Config{Values: map[string]string{"logLevel": "info"}}})
+	m = mi.(ConfigModel)
+	// Move cursor to logLevel (index 2 in EditableFields).
+	for m.fields[m.cursor].Key != "logLevel" {
+		mi, _ = m.Update(namedKey(tea.KeyDown))
+		m = mi.(ConfigModel)
+	}
+	mi, _ = m.Update(namedKey(tea.KeyEnter))
+	m = mi.(ConfigModel)
+	// Typing a letter must not mutate an enum buffer.
+	mi, _ = m.Update(runeKey('z'))
+	m = mi.(ConfigModel)
+	if m.buf != "info" {
+		t.Errorf("enum buf changed by typing: %q", m.buf)
+	}
+	// ←/→ cycles instead.
+	mi, _ = m.Update(namedKey(tea.KeyRight))
+	m = mi.(ConfigModel)
+	if m.buf != "warn" {
+		t.Errorf("enum cycle right = %q, want warn", m.buf)
+	}
+}
+
+func TestConfigLoadErrorBlocks(t *testing.T) {
+	m := NewConfig(&rest.Client{})
+	mi, _ := m.Update(configLoadedMsg{err: rest.ErrUnauthorized})
+	m = mi.(ConfigModel)
+	if m.loadEr == nil {
+		t.Fatal("load error not recorded")
+	}
+	// 'r' retries (re-enters loading); the view must mention the auth hint.
+	if got := m.View(); got == "" {
+		t.Fatal("error view empty")
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -23,6 +23,7 @@ import (
 	"servicebay-tui/internal/buildflow"
 	"servicebay-tui/internal/phase"
 	"servicebay-tui/internal/probes"
+	"servicebay-tui/internal/rest"
 	"servicebay-tui/internal/ui"
 	"servicebay-tui/internal/watch"
 )
@@ -89,6 +90,28 @@ func runOpenBox() int {
 	return 0
 }
 
+// runConfig opens the edit-config panel (#1275). It needs a reachable box and a
+// scoped `sb_` API token (SB_TOKEN); both missing-target and missing-token fail
+// with a clear, actionable message rather than a blank panel.
+func runConfig() int {
+	t := probes.ResolveTarget()
+	if t.Host == "" {
+		fmt.Fprintln(os.Stderr, "no box target — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
+		return 2
+	}
+	client, err := rest.New(t.Host, t.Port, probes.ResolveToken())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Mint one in ServiceBay → Settings → API tokens (scope: mutate) and export it as SB_TOKEN.")
+		return 2
+	}
+	if _, err := tea.NewProgram(ui.NewConfig(client), tea.WithAltScreen()).Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
 // openBrowser best-effort launches the host's default browser; failures are
 // ignored (the URLs are already printed for the operator to copy).
 func openBrowser(url string) {
@@ -115,6 +138,8 @@ func main() {
 			os.Exit(runWatch())
 		case "build":
 			os.Exit(runBuild())
+		case "config":
+			os.Exit(runConfig())
 		}
 	}
 
@@ -137,5 +162,7 @@ func main() {
 		os.Exit(runWatch())
 	case phase.OpenBox:
 		os.Exit(runOpenBox())
+	case phase.EditConfig:
+		os.Exit(runConfig())
 	}
 }


### PR DESCRIPTION
Closes #1275.

## What

The keystone of the in-TUI box-control leg (#1272): a Go client for the box REST API authenticated with a scoped `sb_…` named API token (`Authorization: Bearer`, the #1265 foundation), plus its first consumer — an **edit-config panel**.

- **`internal/rest`** — the shared HTTP + auth + error-surface layer every box-control panel (#1276 stack-install, #1277 backup) will reuse. Typed errors: `ErrNoToken`, `ErrUnauthorized`, and `APIError` carrying the box's JSON error envelope.
- **Edit-config panel** (`internal/ui/config.go`) — reads an allow-listed set of non-sensitive scalar config keys (server name, domain, log level) and writes a **minimal partial** back, so redacted secrets are never round-tripped into the store. Enum fields cycle with ←/→; free-text fields take typed input.
- **Backend** — opt the `/api/settings` POST into `tokenScope: 'mutate'` so a scoped token can write config, not just read it via GET. GET redaction (#1275 backend, already merged) is unchanged.
- **Menu** — an "Edit config (in-TUI)" action appears when the box is reachable; missing-target and missing-token both fail with actionable hints (mint a `mutate`-scoped token, export `SB_TOKEN`).

## Tests

Self-contained (CI has no box): `internal/rest` against `httptest` (bearer header, allow-list projection, minimal-patch write, 401→`ErrUnauthorized`, error-envelope surfacing); `internal/ui` drives the model through load→edit→save, enum cycling, and the blocking auth-error path. `gofmt`/`go vet`/`go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)