### PR TITLE
feat(tui): stack-install panel over REST

### DIFF
--- a/packages/frontend/src/app/api/install/assemble/route.ts
+++ b/packages/frontend/src/app/api/install/assemble/route.ts
@@ -14,8 +14,13 @@ export const dynamic = 'force-dynamic';
  * instead of building the manifest itself; the same endpoint is what a
  * future headless / ISO-driven first-boot setup uses to turn baked
  * `config.json` defaults into an installable manifest.
+ *
+ * `tokenScope: 'lifecycle'` (#1276) lets the sb-tui stack-install panel
+ * assemble a manifest with a scoped `sb_` token; the paired
+ * `/api/install/start` carries the same scope so one lifecycle token drives
+ * the whole install.
  */
-export const POST = withApiHandler({}, async ({ request }) => {
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
   try {
     const body = (await request.json()) as {
       items?: { name: string; checked: boolean; alreadyInstalled?: boolean }[];

--- a/packages/frontend/src/app/api/install/start/route.ts
+++ b/packages/frontend/src/app/api/install/start/route.ts
@@ -23,8 +23,12 @@ export const dynamic = 'force-dynamic';
  * active-job re-check and the state-file write — without that lock,
  * two parallel POSTs could both pass this pre-check and start
  * simultaneous installs racing on shared host state.
+ *
+ * `tokenScope: 'lifecycle'` (#1276) lets the sb-tui stack-install panel start
+ * an install with a scoped `sb_` token. Progress is then polled on the public
+ * jobId-gated `/api/install/progress` (no token needed there).
  */
-export const POST = withApiHandler({}, async ({ request }) => {
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
   try {
     const body = (await request.json()) as { source?: string; input?: JobInput };
     const input = body.input;

--- a/packages/frontend/src/app/api/system/stacks/route.ts
+++ b/packages/frontend/src/app/api/system/stacks/route.ts
@@ -6,7 +6,6 @@
  * wizard's stack selection step (Phase 5B+).
  */
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getStackManifest, getTemplates } from '@/lib/registry';
@@ -22,10 +21,10 @@ interface StackSummary {
   health: StackHealth | null;
 }
 
-export const GET = withApiHandler({}, async ({ request }) => {
-  const auth = await requireSession(request);
-  if (auth instanceof NextResponse) return auth;
-
+// `tokenScope: 'read'` (#1276) lets the sb-tui stack-install panel enumerate
+// the installable stack catalog with a scoped `sb_` token; the handler gate
+// also covers the web UI's session cookie.
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
   try {
     // Enumerate stack names from the union of built-in + every external
     // registry. `getTemplates()` returns `Template[]` covering both

--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -51,12 +51,13 @@ func Detect(isoBuilt bool, status BoxStatus) State {
 type ActionID string
 
 const (
-	BuildISO     ActionID = "build-iso"
-	WatchInstall ActionID = "watch-install"
-	OpenBox      ActionID = "open-box"
-	EditConfig   ActionID = "edit-config"
-	Refresh      ActionID = "refresh"
-	Quit         ActionID = "quit"
+	BuildISO      ActionID = "build-iso"
+	WatchInstall  ActionID = "watch-install"
+	OpenBox       ActionID = "open-box"
+	EditConfig    ActionID = "edit-config"
+	InstallStacks ActionID = "install-stacks"
+	Refresh       ActionID = "refresh"
+	Quit          ActionID = "quit"
 )
 
 // editConfigAction is the in-TUI box-control entry (#1275): edit allow-listed
@@ -64,6 +65,12 @@ const (
 // meaningful once the box is reachable.
 var editConfigAction = Action{EditConfig, "Edit config (in-TUI)",
 	"View and edit allow-listed box settings (server name, domain, log level) over the REST API."}
+
+// installStacksAction is the in-TUI stack-install entry (#1276): pick stacks
+// from the box catalog and drive a server-side install over the REST API. Only
+// meaningful once the box is reachable.
+var installStacksAction = Action{InstallStacks, "Install stacks (in-TUI)",
+	"Pick stacks from the box catalog and install them over the REST API, with live progress."}
 
 // Action is one selectable menu entry: a short Label plus a one-line Detail
 // rendered with the selection so the operator always knows what each does.
@@ -113,6 +120,7 @@ func ActionsFor(s State) []Action {
 			Action{OpenBox, "Open ServiceBay in your browser",
 				"Open the setup wizard / dashboard URL for this box."},
 			editConfigAction,
+			installStacksAction,
 			buildAction(s))
 	case Ready:
 		// Box is fully up — manage it via the browser, or reinstall.
@@ -120,6 +128,7 @@ func ActionsFor(s State) []Action {
 			Action{OpenBox, "Open ServiceBay in your browser",
 				"Open this box's dashboard to manage services, users, and settings."},
 			editConfigAction,
+			installStacksAction,
 			Action{WatchInstall, "Watch a reinstall in progress",
 				"Live-track an install if you're reinstalling this box."},
 			buildAction(s))

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -53,12 +53,12 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{BuildISO, WatchInstall, Refresh, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: watch + open-box + edit-config + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, EditConfig, BuildISO, Refresh, Quit}) {
+	// installing: watch + open-box + edit-config + install-stacks + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, EditConfig, InstallStacks, BuildISO, Refresh, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: open-box + edit-config + watch + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, WatchInstall, BuildISO, Refresh, Quit}) {
+	// ready: open-box + edit-config + install-stacks + watch + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, InstallStacks, WatchInstall, BuildISO, Refresh, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/rest/install.go
+++ b/tools/sb-tui/internal/rest/install.go
@@ -1,0 +1,144 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+)
+
+// Stack is one installable stack from the box catalog (GET /api/system/stacks).
+// Tier is "core" or "feature"; Description is best-effort from the manifest.
+type Stack struct {
+	Name        string
+	Tier        string
+	Description string
+	Installed   bool
+}
+
+// ListStacks enumerates the installable stack catalog. Core stacks sort first,
+// then alphabetically — matching the web wizard's ordering.
+func (c *Client) ListStacks(ctx context.Context) ([]Stack, error) {
+	raw, err := c.do(ctx, "GET", "/api/system/stacks", nil)
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		Stacks []struct {
+			Name     string `json:"name"`
+			Manifest *struct {
+				Tier        string `json:"tier"`
+				Description string `json:"description"`
+				DisplayName string `json:"displayName"`
+			} `json:"manifest"`
+			Health *struct {
+				Installed bool `json:"installed"`
+			} `json:"health"`
+		} `json:"stacks"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, &APIError{Message: "malformed stacks response: " + err.Error()}
+	}
+	out := make([]Stack, 0, len(doc.Stacks))
+	for _, s := range doc.Stacks {
+		st := Stack{Name: s.Name, Tier: "feature"}
+		if s.Manifest != nil {
+			if s.Manifest.Tier != "" {
+				st.Tier = s.Manifest.Tier
+			}
+			st.Description = s.Manifest.Description
+			if st.Description == "" {
+				st.Description = s.Manifest.DisplayName
+			}
+		}
+		if s.Health != nil {
+			st.Installed = s.Health.Installed
+		}
+		out = append(out, st)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if (out[i].Tier == "core") != (out[j].Tier == "core") {
+			return out[i].Tier == "core"
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// AssembleManifest turns a stack selection into an installable manifest
+// ({items, variables}) server-side. The returned raw object is fed verbatim to
+// StartInstall as the job input, so the TUI never reimplements manifest
+// assembly. prefilled supplies any variable values up front (may be nil).
+func (c *Client) AssembleManifest(ctx context.Context, names []string, prefilled map[string]string) (json.RawMessage, error) {
+	items := make([]map[string]any, len(names))
+	for i, n := range names {
+		items[i] = map[string]any{"name": n, "checked": true}
+	}
+	body := map[string]any{"items": items}
+	if prefilled != nil {
+		body["prefilled"] = prefilled
+	}
+	return c.do(ctx, "POST", "/api/install/assemble", body)
+}
+
+// StartInstall kicks off a server-side install job for an assembled manifest
+// and returns the jobId to poll. A 409 (install already running) surfaces as an
+// *APIError the panel reports rather than starting a second job.
+func (c *Client) StartInstall(ctx context.Context, manifest json.RawMessage) (string, error) {
+	body := map[string]any{"source": "sb-tui", "input": manifest}
+	raw, err := c.do(ctx, "POST", "/api/install/start", body)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		JobID string `json:"jobId"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil || resp.JobID == "" {
+		return "", &APIError{Message: "install started but no jobId returned"}
+	}
+	return resp.JobID, nil
+}
+
+// Progress is a snapshot of a running install job, polled from the public
+// jobId-gated endpoint.
+type Progress struct {
+	Phase      string
+	Percent    int
+	Error      string
+	Active     bool
+	NewLogs    string
+	NextOffset int
+}
+
+// InstallProgress polls /api/install/progress for a job. sinceOffset is the
+// byte offset returned by the previous poll, so only new log output comes back.
+// It is unauthenticated by design — the jobId is the credential.
+func (c *Client) InstallProgress(ctx context.Context, jobID string, sinceOffset int) (*Progress, error) {
+	q := url.Values{"jobId": {jobID}, "logsSince": {fmt.Sprintf("%d", sinceOffset)}}
+	raw, err := c.doPublic(ctx, "GET", "/api/install/progress?"+q.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		Job struct {
+			Phase    string `json:"phase"`
+			Progress int    `json:"progress"`
+			Error    string `json:"error"`
+		} `json:"job"`
+		Active     bool   `json:"jobIsActive"`
+		Logs       string `json:"logs"`
+		LogsOffset int    `json:"logsOffset"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, &APIError{Message: "malformed progress response: " + err.Error()}
+	}
+	return &Progress{
+		Phase:      doc.Job.Phase,
+		Percent:    doc.Job.Progress,
+		Error:      doc.Job.Error,
+		Active:     doc.Active,
+		NewLogs:    doc.Logs,
+		NextOffset: doc.LogsOffset,
+	}, nil
+}

--- a/tools/sb-tui/internal/rest/install_test.go
+++ b/tools/sb-tui/internal/rest/install_test.go
@@ -1,0 +1,136 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListStacksSortsCoreFirst(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/system/stacks" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"stacks": []any{
+			map[string]any{"name": "zebra", "manifest": map[string]any{"tier": "feature", "description": "Z"}},
+			map[string]any{"name": "core-b", "manifest": map[string]any{"tier": "core"}},
+			map[string]any{"name": "core-a", "manifest": map[string]any{"tier": "core"}, "health": map[string]any{"installed": true}},
+		}})
+	}))
+	defer srv.Close()
+
+	stacks, err := newTestClient(srv).ListStacks(context.Background())
+	if err != nil {
+		t.Fatalf("ListStacks: %v", err)
+	}
+	got := []string{stacks[0].Name, stacks[1].Name, stacks[2].Name}
+	want := []string{"core-a", "core-b", "zebra"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+	if !stacks[0].Installed {
+		t.Error("core-a should be marked installed")
+	}
+	if stacks[2].Description != "Z" {
+		t.Errorf("zebra description = %q", stacks[2].Description)
+	}
+}
+
+func TestAssembleManifestSendsCheckedItems(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer sb_test" {
+			t.Error("assemble must be authenticated")
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}, "variables": []any{}})
+	}))
+	defer srv.Close()
+
+	manifest, err := newTestClient(srv).AssembleManifest(context.Background(), []string{"immich", "vaultwarden"}, nil)
+	if err != nil {
+		t.Fatalf("AssembleManifest: %v", err)
+	}
+	items, _ := body["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("items = %v", body["items"])
+	}
+	first, _ := items[0].(map[string]any)
+	if first["name"] != "immich" || first["checked"] != true {
+		t.Errorf("first item = %v", first)
+	}
+	// The manifest is passed through verbatim to StartInstall.
+	if len(manifest) == 0 {
+		t.Error("manifest should be non-empty raw JSON")
+	}
+}
+
+func TestStartInstallReturnsJobID(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"jobId": "job-123"})
+	}))
+	defer srv.Close()
+
+	id, err := newTestClient(srv).StartInstall(context.Background(), json.RawMessage(`{"items":[],"variables":[]}`))
+	if err != nil {
+		t.Fatalf("StartInstall: %v", err)
+	}
+	if id != "job-123" {
+		t.Errorf("jobId = %q", id)
+	}
+	if body["source"] != "sb-tui" {
+		t.Errorf("source = %v", body["source"])
+	}
+	if _, ok := body["input"]; !ok {
+		t.Error("input manifest not forwarded")
+	}
+}
+
+func TestStartInstallConflictSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "install already in progress"})
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).StartInstall(context.Background(), json.RawMessage(`{}`))
+	apiErr, ok := err.(*APIError)
+	if !ok || apiErr.Status != 409 {
+		t.Fatalf("got %v, want 409 APIError", err)
+	}
+}
+
+// TestInstallProgressIsUnauthenticated guards the deliberate design: the
+// jobId-gated progress endpoint must be polled WITHOUT a bearer, or its
+// AUTH_SECRET-rotation self-heal breaks.
+func TestInstallProgressIsUnauthenticated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("progress poll must NOT send Authorization, got %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Query().Get("jobId") != "job-1" || r.URL.Query().Get("logsSince") != "42" {
+			t.Errorf("query = %s", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"job":         map[string]any{"phase": "running", "progress": 60},
+			"jobIsActive": true,
+			"logs":        "deploying immich\n",
+			"logsOffset":  108,
+		})
+	}))
+	defer srv.Close()
+
+	p, err := newTestClient(srv).InstallProgress(context.Background(), "job-1", 42)
+	if err != nil {
+		t.Fatalf("InstallProgress: %v", err)
+	}
+	if p.Phase != "running" || p.Percent != 60 || !p.Active || p.NextOffset != 108 {
+		t.Errorf("progress = %+v", p)
+	}
+}

--- a/tools/sb-tui/internal/rest/rest.go
+++ b/tools/sb-tui/internal/rest/rest.go
@@ -67,9 +67,21 @@ func New(host, port, token string) (*Client, error) {
 	}, nil
 }
 
-// do issues a request with the bearer token, returning the decoded JSON body on
-// 2xx or a typed error (ErrUnauthorized / *APIError) otherwise.
+// do issues an authenticated request with the bearer token, returning the
+// decoded JSON body on 2xx or a typed error (ErrUnauthorized / *APIError).
 func (c *Client) do(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	return c.doRaw(ctx, method, path, body, true)
+}
+
+// doPublic issues a request WITHOUT the bearer token, for endpoints that are
+// intentionally public + self-gated (the jobId-gated /api/install/progress —
+// adding a token scope there would break its AUTH_SECRET-rotation self-heal,
+// so the TUI must not present a token). Same error surface as do.
+func (c *Client) doPublic(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	return c.doRaw(ctx, method, path, body, false)
+}
+
+func (c *Client) doRaw(ctx context.Context, method, path string, body any, authed bool) (json.RawMessage, error) {
 	var reader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -82,7 +94,9 @@ func (c *Client) do(ctx context.Context, method, path string, body any) (json.Ra
 	if err != nil {
 		return nil, &APIError{Message: err.Error()}
 	}
-	req.Header.Set("Authorization", "Bearer "+c.Token)
+	if authed {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -1,0 +1,331 @@
+// The Bubble Tea model for the stack-install panel (#1276): list the box's
+// installable stack catalog, let the operator select one or more, and drive a
+// server-side install — assemble the manifest, start the job, then poll the
+// public progress endpoint and render a live progress bar + log tail. It reuses
+// the #1275 token client and follows the edit-config panel's shape.
+package ui
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"servicebay-tui/internal/rest"
+)
+
+const installPollInterval = time.Second
+
+var (
+	coreTierStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+	checkedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	barFillStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
+	barEmptyStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	logStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+)
+
+type installStage int
+
+const (
+	stageLoading installStage = iota
+	stageSelect
+	stageStarting
+	stageInstalling
+	stageDone
+	stageError
+)
+
+// InstallModel is the Bubble Tea model for the stack-install panel.
+type InstallModel struct {
+	client        *rest.Client
+	width, height int
+
+	stage   installStage
+	stacks  []rest.Stack
+	checked map[int]bool
+	cursor  int
+
+	jobID   string
+	offset  int
+	phase   string
+	percent int
+	logTail []string
+	failed  bool
+	errMsg  string // populated in stageError / failed
+}
+
+type stacksLoadedMsg struct {
+	stacks []rest.Stack
+	err    error
+}
+type installStartedMsg struct {
+	jobID string
+	err   error
+}
+type progressMsg struct {
+	p   *rest.Progress
+	err error
+}
+type pollTickMsg struct{}
+
+// NewInstall builds the stack-install model against an authenticated client.
+func NewInstall(client *rest.Client) InstallModel {
+	return InstallModel{client: client, stage: stageLoading, checked: map[int]bool{}}
+}
+
+func (m InstallModel) loadCmd() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		s, err := client.ListStacks(context.Background())
+		return stacksLoadedMsg{stacks: s, err: err}
+	}
+}
+
+// startCmd assembles the manifest for the checked stacks and starts the job —
+// two REST calls chained so the panel sees a single started/failed result.
+func (m InstallModel) startCmd(names []string) tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		manifest, err := client.AssembleManifest(context.Background(), names, nil)
+		if err != nil {
+			return installStartedMsg{err: err}
+		}
+		jobID, err := client.StartInstall(context.Background(), manifest)
+		return installStartedMsg{jobID: jobID, err: err}
+	}
+}
+
+func (m InstallModel) pollCmd() tea.Cmd {
+	client, jobID, offset := m.client, m.jobID, m.offset
+	return func() tea.Msg {
+		p, err := client.InstallProgress(context.Background(), jobID, offset)
+		return progressMsg{p: p, err: err}
+	}
+}
+
+// Init kicks off the catalog load.
+func (m InstallModel) Init() tea.Cmd { return m.loadCmd() }
+
+// Update folds in load/start/progress results and handles input.
+func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case stacksLoadedMsg:
+		if msg.err != nil {
+			m.stage, m.errMsg = stageError, friendlyErr(msg.err)
+			return m, nil
+		}
+		m.stacks, m.stage = msg.stacks, stageSelect
+		return m, nil
+	case installStartedMsg:
+		if msg.err != nil {
+			m.stage, m.errMsg = stageError, friendlyErr(msg.err)
+			return m, nil
+		}
+		m.jobID, m.stage = msg.jobID, stageInstalling
+		return m, m.pollCmd()
+	case progressMsg:
+		return m.applyProgress(msg)
+	case pollTickMsg:
+		return m, m.pollCmd()
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m InstallModel) applyProgress(msg progressMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		// A transient poll error shouldn't kill the panel mid-install; surface
+		// it and keep polling.
+		m.errMsg = friendlyErr(msg.err)
+		return m, tea.Tick(installPollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
+	}
+	p := msg.p
+	m.phase, m.percent, m.offset = p.Phase, p.Percent, p.NextOffset
+	if p.NewLogs != "" {
+		for _, line := range strings.Split(strings.TrimRight(p.NewLogs, "\n"), "\n") {
+			if line != "" {
+				m.logTail = append(m.logTail, line)
+			}
+		}
+		if len(m.logTail) > 200 { // bound memory; the view tails the last few
+			m.logTail = m.logTail[len(m.logTail)-200:]
+		}
+	}
+	if !p.Active {
+		m.stage = stageDone
+		if p.Error != "" {
+			m.failed, m.errMsg = true, p.Error
+		}
+		return m, nil
+	}
+	return m, tea.Tick(installPollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
+}
+
+func (m InstallModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "q", "esc":
+		// Quitting mid-install only detaches the watcher; the server job keeps
+		// running. Safe because progress is resumable by jobId.
+		if m.stage != stageStarting {
+			return m, tea.Quit
+		}
+	}
+	if m.stage != stageSelect {
+		return m, nil
+	}
+	switch msg.String() {
+	case "up", "k":
+		if len(m.stacks) > 0 {
+			m.cursor = (m.cursor - 1 + len(m.stacks)) % len(m.stacks)
+		}
+	case "down", "j":
+		if len(m.stacks) > 0 {
+			m.cursor = (m.cursor + 1) % len(m.stacks)
+		}
+	case " ":
+		m.checked[m.cursor] = !m.checked[m.cursor]
+	case "enter":
+		if names := m.selectedNames(); len(names) > 0 {
+			m.stage = stageStarting
+			return m, m.startCmd(names)
+		}
+	}
+	return m, nil
+}
+
+func (m InstallModel) selectedNames() []string {
+	var names []string
+	for i, s := range m.stacks {
+		if m.checked[i] {
+			names = append(names, s.Name)
+		}
+	}
+	return names
+}
+
+// View renders the panel per stage.
+func (m InstallModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  install stacks") + "\n")
+
+	switch m.stage {
+	case stageLoading:
+		b.WriteString(phaseStyle.Render("Loading stack catalog…"))
+	case stageError:
+		b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Couldn't load stacks:")) + "\n")
+		b.WriteString(detailStyle.Render(m.errMsg) + "\n")
+		b.WriteString(footerStyle.Render("q quit"))
+	case stageSelect:
+		m.viewSelect(&b)
+	case stageStarting:
+		b.WriteString(phaseStyle.Render("Assembling manifest and starting install…"))
+	case stageInstalling:
+		m.viewInstalling(&b, width)
+	case stageDone:
+		m.viewDone(&b, width)
+	}
+	return frame(b.String(), m.width, m.height)
+}
+
+func (m InstallModel) viewSelect(b *strings.Builder) {
+	b.WriteString(phaseStyle.Render("Select stacks to install, then press Enter.") + "\n\n")
+	for i, s := range m.stacks {
+		box := "[ ]"
+		if m.checked[i] {
+			box = checkedStyle.Render("[x]")
+		}
+		label := s.Name
+		if s.Tier == "core" {
+			label = coreTierStyle.Render(s.Name + " (core)")
+		}
+		if s.Installed {
+			label += cfgEmptyStyle.Render(" — installed")
+		}
+		line := "  " + box + " " + label
+		if i == m.cursor {
+			line = selectedStyle.Render("❯ "+box+" "+s.Name) + tierSuffix(s)
+		}
+		b.WriteString(line + "\n")
+	}
+	if m.cursor < len(m.stacks) && m.stacks[m.cursor].Description != "" {
+		b.WriteString(detailStyle.Render(m.stacks[m.cursor].Description) + "\n")
+	}
+	b.WriteString(footerStyle.Render("↑/↓ move · space toggle · enter install · q quit"))
+}
+
+// tierSuffix appends the core/installed annotations to the highlighted row
+// without double-styling the selected background.
+func tierSuffix(s rest.Stack) string {
+	var suffix string
+	if s.Tier == "core" {
+		suffix += " (core)"
+	}
+	if s.Installed {
+		suffix += " — installed"
+	}
+	return suffix
+}
+
+func (m InstallModel) viewInstalling(b *strings.Builder, width int) {
+	phase := m.phase
+	if phase == "" {
+		phase = "starting"
+	}
+	b.WriteString(phaseStyle.Render("Installing — "+phase) + "\n")
+	b.WriteString(detailStyle.Render(progressBar(m.percent, min(width-8, 40))) + "\n\n")
+	b.WriteString(logTailView(m.logTail, 10))
+	b.WriteString("\n" + footerStyle.Render("q detach (install keeps running on the box)"))
+}
+
+func (m InstallModel) viewDone(b *strings.Builder, width int) {
+	if m.failed {
+		b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Install failed.")) + "\n")
+		b.WriteString(detailStyle.Render(m.errMsg) + "\n\n")
+	} else {
+		b.WriteString(phaseStyle.Render(cfgOKStyle.Render("✓ Install complete.")) + "\n\n")
+	}
+	b.WriteString(logTailView(m.logTail, 12))
+	b.WriteString("\n" + footerStyle.Render("q quit"))
+}
+
+// progressBar renders an n-wide [####----] bar for a 0–100 percent.
+func progressBar(percent, n int) string {
+	if n < 4 {
+		n = 4
+	}
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	fill := percent * n / 100
+	return barFillStyle.Render(strings.Repeat("█", fill)) +
+		barEmptyStyle.Render(strings.Repeat("░", n-fill)) +
+		"  " + strconv.Itoa(percent) + "%"
+}
+
+// logTailView renders the last n log lines.
+func logTailView(lines []string, n int) string {
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	var sb strings.Builder
+	for _, l := range lines {
+		sb.WriteString(logStyle.Render("  "+l) + "\n")
+	}
+	return sb.String()
+}

--- a/tools/sb-tui/internal/ui/install_test.go
+++ b/tools/sb-tui/internal/ui/install_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+func TestInstallSelectThenStart(t *testing.T) {
+	m := NewInstall(&rest.Client{})
+	mi, _ := m.Update(stacksLoadedMsg{stacks: []rest.Stack{
+		{Name: "immich", Tier: "core"},
+		{Name: "vaultwarden", Tier: "feature"},
+	}})
+	m = mi.(InstallModel)
+	if m.stage != stageSelect {
+		t.Fatalf("stage = %v, want select", m.stage)
+	}
+
+	// Enter with nothing checked must NOT start an install.
+	mi, cmd := m.Update(namedKey(tea.KeyEnter))
+	m = mi.(InstallModel)
+	if cmd != nil || m.stage != stageSelect {
+		t.Fatal("enter with no selection should be a no-op")
+	}
+
+	// Toggle the first stack, then start.
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m = mi.(InstallModel)
+	if !m.checked[0] {
+		t.Fatal("space should check the cursor row")
+	}
+	if names := m.selectedNames(); len(names) != 1 || names[0] != "immich" {
+		t.Fatalf("selectedNames = %v", names)
+	}
+	mi, cmd = m.Update(namedKey(tea.KeyEnter))
+	m = mi.(InstallModel)
+	if m.stage != stageStarting || cmd == nil {
+		t.Fatalf("enter should move to starting with a command, stage=%v", m.stage)
+	}
+}
+
+func TestInstallProgressToDone(t *testing.T) {
+	m := NewInstall(&rest.Client{})
+	mi, _ := m.Update(installStartedMsg{jobID: "job-1"})
+	m = mi.(InstallModel)
+	if m.stage != stageInstalling || m.jobID != "job-1" {
+		t.Fatalf("after start: stage=%v job=%q", m.stage, m.jobID)
+	}
+
+	// An active progress tick keeps installing and appends logs.
+	mi, cmd := m.Update(progressMsg{p: &rest.Progress{Phase: "running", Percent: 30, Active: true, NewLogs: "pulling image\n", NextOffset: 14}})
+	m = mi.(InstallModel)
+	if m.stage != stageInstalling || cmd == nil {
+		t.Fatal("active progress should keep polling")
+	}
+	if m.percent != 30 || m.offset != 14 || len(m.logTail) != 1 {
+		t.Fatalf("progress state: pct=%d off=%d logs=%v", m.percent, m.offset, m.logTail)
+	}
+
+	// A terminal (inactive) progress with no error → done, success.
+	mi, _ = m.Update(progressMsg{p: &rest.Progress{Phase: "completed", Percent: 100, Active: false}})
+	m = mi.(InstallModel)
+	if m.stage != stageDone || m.failed {
+		t.Fatalf("should be done+success, stage=%v failed=%v", m.stage, m.failed)
+	}
+	if !strings.Contains(m.View(), "complete") {
+		t.Error("done view should report completion")
+	}
+}
+
+func TestInstallFailureSurfaces(t *testing.T) {
+	m := NewInstall(&rest.Client{})
+	mi, _ := m.Update(installStartedMsg{jobID: "job-1"})
+	m = mi.(InstallModel)
+	mi, _ = m.Update(progressMsg{p: &rest.Progress{Phase: "failed", Active: false, Error: "image pull failed"}})
+	m = mi.(InstallModel)
+	if m.stage != stageDone || !m.failed {
+		t.Fatalf("should be done+failed, stage=%v failed=%v", m.stage, m.failed)
+	}
+	if !strings.Contains(m.View(), "image pull failed") {
+		t.Error("failure view should show the error")
+	}
+}
+
+func TestInstallStartErrorGoesToErrorStage(t *testing.T) {
+	m := NewInstall(&rest.Client{})
+	mi, _ := m.Update(installStartedMsg{err: rest.ErrUnauthorized})
+	m = mi.(InstallModel)
+	if m.stage != stageError {
+		t.Fatalf("start error should reach error stage, got %v", m.stage)
+	}
+}
+
+func TestProgressBar(t *testing.T) {
+	bar := progressBar(50, 10)
+	if !strings.Contains(bar, "50%") {
+		t.Errorf("bar missing percent: %q", bar)
+	}
+	// 50% of 10 = 5 filled blocks.
+	if strings.Count(bar, "█") != 5 {
+		t.Errorf("expected 5 filled blocks, got %q", bar)
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -90,22 +90,45 @@ func runOpenBox() int {
 	return 0
 }
 
-// runConfig opens the edit-config panel (#1275). It needs a reachable box and a
-// scoped `sb_` API token (SB_TOKEN); both missing-target and missing-token fail
-// with a clear, actionable message rather than a blank panel.
-func runConfig() int {
+// boxClient resolves the box target + scoped `sb_` token (SB_TOKEN) into a REST
+// client shared by the box-control panels. On failure it prints an actionable
+// message and returns a non-zero exit code so the caller can return it directly
+// rather than opening a blank panel.
+func boxClient() (*rest.Client, int) {
 	t := probes.ResolveTarget()
 	if t.Host == "" {
 		fmt.Fprintln(os.Stderr, "no box target — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
-		return 2
+		return nil, 2
 	}
 	client, err := rest.New(t.Host, t.Port, probes.ResolveToken())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, "Mint one in ServiceBay → Settings → API tokens (scope: mutate) and export it as SB_TOKEN.")
-		return 2
+		fmt.Fprintln(os.Stderr, "Mint one in ServiceBay → Settings → API tokens (scopes: mutate + lifecycle) and export it as SB_TOKEN.")
+		return nil, 2
+	}
+	return client, 0
+}
+
+// runConfig opens the edit-config panel (#1275).
+func runConfig() int {
+	client, code := boxClient()
+	if client == nil {
+		return code
 	}
 	if _, err := tea.NewProgram(ui.NewConfig(client), tea.WithAltScreen()).Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// runInstallStacks opens the stack-install panel (#1276).
+func runInstallStacks() int {
+	client, code := boxClient()
+	if client == nil {
+		return code
+	}
+	if _, err := tea.NewProgram(ui.NewInstall(client), tea.WithAltScreen()).Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
@@ -140,6 +163,8 @@ func main() {
 			os.Exit(runBuild())
 		case "config":
 			os.Exit(runConfig())
+		case "install":
+			os.Exit(runInstallStacks())
 		}
 	}
 
@@ -164,5 +189,7 @@ func main() {
 		os.Exit(runOpenBox())
 	case phase.EditConfig:
 		os.Exit(runConfig())
+	case phase.InstallStacks:
+		os.Exit(runInstallStacks())
 	}
 }


### PR DESCRIPTION
## What
The in-TUI **stack-install panel** (#1276): list the box's installable stack catalog, select stacks, then drive a server-side install — assemble the manifest, start the job, and poll progress with a live bar + log tail. Second box-control panel, reusing the #1275 scoped-token client.

## Why
Closes #1276. Part of the lifecycle-TUI rewrite (#1272); the box can now be driven from the binary without the browser.

Details:
- **Client** (`internal/rest/install.go`): `ListStacks`, `AssembleManifest`, `StartInstall` (bearer-authed) + `InstallProgress`. The progress poll uses a new **unauthenticated** request path — the `/api/install/progress` endpoint is intentionally public + jobId-gated, and adding a token scope there would break its AUTH_SECRET-rotation self-heal (see the route's own doc comment).
- **Backend**: opt `GET /api/system/stacks` into `tokenScope: 'read'` (catalog) and `POST /api/install/assemble` + `POST /api/install/start` into `tokenScope: 'lifecycle'` so one scoped token drives the whole flow. Web-UI cookie auth is unchanged (the gate still falls through to the cookie). Removed a now-redundant manual `requireSession` in the stacks route in favor of the handler gate.
- **Menu**: an "Install stacks (in-TUI)" action appears when the box is reachable.

## Risk
Low. The install **runner** (`packages/backend/src/lib/install/`) is untouched — only auth reachability of three thin route wrappers changed, and the Go panel is new code behind a new menu entry. Quitting mid-install only detaches the watcher; the server job continues (resumable by jobId).

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt / go vet / go test ./... (rest client httptest incl. the no-auth progress poll; panel model transitions)
- [ ] npm run lint / check:arch / npm test — via CI
- [ ] Real-box `/verify` deferred: changed files aren't in the path-mandated list (`backend/src/lib/install/`), the change adds no new install logic (reuses the already-tested runner), and is auth-plumbing only — consistent with how the #1325 auth foundation was handled. Will exercise against the box when a scoped token is next minted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)