### PR TITLE
feat(tui): backup list/create/restore panel over REST

### DIFF
--- a/packages/frontend/src/app/api/settings/backups/restore/route.ts
+++ b/packages/frontend/src/app/api/settings/backups/restore/route.ts
@@ -14,7 +14,10 @@ const PostBody = z.object({
   selection: z.unknown().optional(),
 });
 
-export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+// tokenScope: 'destroy' (#1277) — restore overwrites the box's config/state, so
+// it requires the most privileged scope. The sb-tui backup panel confirms
+// before calling this; the web UI's cookie path is unchanged.
+export const POST = withApiHandler({ body: PostBody, tokenScope: 'destroy' }, async ({ body }) => {
   const { fileName, uploadToken } = body;
   const selection = body.selection as BackupRestoreSelection | undefined;
 

--- a/packages/frontend/src/app/api/settings/backups/route.ts
+++ b/packages/frontend/src/app/api/settings/backups/route.ts
@@ -5,7 +5,9 @@ import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
-export const GET = withApiHandler({}, async () => {
+// tokenScope: 'read' (#1277) lets the sb-tui backup panel list backups with a
+// scoped `sb_` token; the handler gate still covers the web UI's cookie.
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
   const backups = await listSystemBackups();
   const payload = backups.map(({ fileName, createdAt, size }) => ({ fileName, createdAt, size }));
   return NextResponse.json(payload);
@@ -15,8 +17,11 @@ export const GET = withApiHandler({}, async () => {
  * POST — create a new system backup. Streams progress as NDJSON. Body
  * deliberately unused; `withApiHandler` skips body parsing when
  * `options.body` isn't set.
+ *
+ * tokenScope: 'lifecycle' (#1277) lets the sb-tui backup panel trigger a
+ * backup with a scoped `sb_` token.
  */
-export const POST = withApiHandler({}, async () => {
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async () => {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     start(controller) {

--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -56,6 +56,7 @@ const (
 	OpenBox       ActionID = "open-box"
 	EditConfig    ActionID = "edit-config"
 	InstallStacks ActionID = "install-stacks"
+	Backups       ActionID = "backups"
 	Refresh       ActionID = "refresh"
 	Quit          ActionID = "quit"
 )
@@ -71,6 +72,12 @@ var editConfigAction = Action{EditConfig, "Edit config (in-TUI)",
 // meaningful once the box is reachable.
 var installStacksAction = Action{InstallStacks, "Install stacks (in-TUI)",
 	"Pick stacks from the box catalog and install them over the REST API, with live progress."}
+
+// backupsAction is the in-TUI backup entry (#1277): list, create, and restore
+// system backups over the authenticated REST API. Only meaningful once the box
+// is reachable; restore is confirmation-gated in the panel.
+var backupsAction = Action{Backups, "Backups (in-TUI)",
+	"List, create, and restore the box's system backups over the REST API."}
 
 // Action is one selectable menu entry: a short Label plus a one-line Detail
 // rendered with the selection so the operator always knows what each does.
@@ -121,6 +128,7 @@ func ActionsFor(s State) []Action {
 				"Open the setup wizard / dashboard URL for this box."},
 			editConfigAction,
 			installStacksAction,
+			backupsAction,
 			buildAction(s))
 	case Ready:
 		// Box is fully up — manage it via the browser, or reinstall.
@@ -129,6 +137,7 @@ func ActionsFor(s State) []Action {
 				"Open this box's dashboard to manage services, users, and settings."},
 			editConfigAction,
 			installStacksAction,
+			backupsAction,
 			Action{WatchInstall, "Watch a reinstall in progress",
 				"Live-track an install if you're reinstalling this box."},
 			buildAction(s))

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -53,12 +53,12 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{BuildISO, WatchInstall, Refresh, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: watch + open-box + edit-config + install-stacks + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, EditConfig, InstallStacks, BuildISO, Refresh, Quit}) {
+	// installing: watch + open-box + edit-config + install-stacks + backups + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, EditConfig, InstallStacks, Backups, BuildISO, Refresh, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: open-box + edit-config + install-stacks + watch + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, InstallStacks, WatchInstall, BuildISO, Refresh, Quit}) {
+	// ready: open-box + edit-config + install-stacks + backups + watch + reinstall, then refresh/quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, InstallStacks, Backups, WatchInstall, BuildISO, Refresh, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/rest/backup.go
+++ b/tools/sb-tui/internal/rest/backup.go
@@ -1,0 +1,71 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// Backup is one system backup archive on the box.
+type Backup struct {
+	FileName  string `json:"fileName"`
+	CreatedAt string `json:"createdAt"`
+	Size      int64  `json:"size"`
+}
+
+// ListBackups returns the box's system backups, newest-first as the box
+// reports them.
+func (c *Client) ListBackups(ctx context.Context) ([]Backup, error) {
+	raw, err := c.do(ctx, "GET", "/api/settings/backups", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out []Backup
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, &APIError{Message: "malformed backups response: " + err.Error()}
+	}
+	return out, nil
+}
+
+// CreateBackup triggers a new system backup. The endpoint streams NDJSON
+// progress and closes when done; we read the whole stream and return the
+// terminal `done` backup entry (or the `error` event as an *APIError).
+func (c *Client) CreateBackup(ctx context.Context) (*Backup, error) {
+	raw, err := c.do(ctx, "POST", "/api/settings/backups", nil)
+	if err != nil {
+		return nil, err
+	}
+	var created *Backup
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Type    string  `json:"type"`
+			Message string  `json:"message"`
+			Backup  *Backup `json:"backup"`
+		}
+		if json.Unmarshal([]byte(line), &ev) != nil {
+			continue
+		}
+		switch ev.Type {
+		case "error":
+			return nil, &APIError{Message: ev.Message}
+		case "done":
+			created = ev.Backup
+		}
+	}
+	if created == nil {
+		return nil, &APIError{Message: "backup stream ended without a result"}
+	}
+	return created, nil
+}
+
+// RestoreBackup restores a named system backup. This is destructive — it
+// overwrites the box's config/state — so callers must confirm first. The token
+// needs the `destroy` scope.
+func (c *Client) RestoreBackup(ctx context.Context, fileName string) error {
+	_, err := c.do(ctx, "POST", "/api/settings/backups/restore", map[string]string{"fileName": fileName})
+	return err
+}

--- a/tools/sb-tui/internal/rest/backup_test.go
+++ b/tools/sb-tui/internal/rest/backup_test.go
@@ -1,0 +1,79 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListBackups(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"fileName": "backup-2026-05-29.tar.gz", "createdAt": "2026-05-29T10:00:00Z", "size": 2048},
+		})
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(srv).ListBackups(context.Background())
+	if err != nil {
+		t.Fatalf("ListBackups: %v", err)
+	}
+	if len(got) != 1 || got[0].FileName != "backup-2026-05-29.tar.gz" || got[0].Size != 2048 {
+		t.Fatalf("backups = %+v", got)
+	}
+}
+
+// TestCreateBackupParsesNdjsonStream covers the multi-line NDJSON contract:
+// log lines are ignored, the terminal `done` carries the result.
+func TestCreateBackupParsesNdjsonStream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"log","entry":"archiving config"}` + "\n"))
+		_, _ = w.Write([]byte(`{"type":"log","entry":"compressing"}` + "\n"))
+		_, _ = w.Write([]byte(`{"type":"done","backup":{"fileName":"new.tar.gz","createdAt":"now","size":99}}` + "\n"))
+	}))
+	defer srv.Close()
+
+	b, err := newTestClient(srv).CreateBackup(context.Background())
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if b.FileName != "new.tar.gz" || b.Size != 99 {
+		t.Fatalf("backup = %+v", b)
+	}
+}
+
+func TestCreateBackupStreamErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"type":"log","entry":"starting"}` + "\n"))
+		_, _ = w.Write([]byte(`{"type":"error","message":"disk full"}` + "\n"))
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).CreateBackup(context.Background())
+	apiErr, ok := err.(*APIError)
+	if !ok || apiErr.Message != "disk full" {
+		t.Fatalf("got %v, want APIError disk full", err)
+	}
+}
+
+func TestRestoreBackupSendsFileName(t *testing.T) {
+	var body map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/settings/backups/restore" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).RestoreBackup(context.Background(), "old.tar.gz"); err != nil {
+		t.Fatalf("RestoreBackup: %v", err)
+	}
+	if body["fileName"] != "old.tar.gz" {
+		t.Errorf("fileName = %q", body["fileName"])
+	}
+}

--- a/tools/sb-tui/internal/ui/backup.go
+++ b/tools/sb-tui/internal/ui/backup.go
@@ -1,0 +1,264 @@
+// The Bubble Tea model for the backup panel (#1277): list the box's system
+// backups, trigger a new one, and restore — over the #1275 token client.
+// Restore overwrites the box's config/state, so it is gated behind an explicit
+// y/n confirmation (the operator has a real data-loss footgun otherwise).
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"servicebay-tui/internal/rest"
+)
+
+var (
+	warnStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("231")).Background(lipgloss.Color("160")).Padding(0, 1)
+	backupMeta = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+)
+
+type backupStage int
+
+const (
+	bkLoading backupStage = iota
+	bkBrowse
+	bkCreating
+	bkConfirm
+	bkRestoring
+)
+
+// BackupModel is the Bubble Tea model for the backup panel.
+type BackupModel struct {
+	client        *rest.Client
+	width, height int
+
+	stage   backupStage
+	backups []rest.Backup
+	cursor  int
+
+	status string // transient result / error line
+	loadEr error  // blocking load error
+}
+
+type backupsLoadedMsg struct {
+	backups []rest.Backup
+	err     error
+}
+type backupCreatedMsg struct {
+	backup *rest.Backup
+	err    error
+}
+type backupRestoredMsg struct {
+	fileName string
+	err      error
+}
+
+// NewBackup builds the backup model against an authenticated client.
+func NewBackup(client *rest.Client) BackupModel {
+	return BackupModel{client: client, stage: bkLoading}
+}
+
+func (m BackupModel) loadCmd() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		b, err := client.ListBackups(context.Background())
+		return backupsLoadedMsg{backups: b, err: err}
+	}
+}
+
+func (m BackupModel) createCmd() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		b, err := client.CreateBackup(context.Background())
+		return backupCreatedMsg{backup: b, err: err}
+	}
+}
+
+func (m BackupModel) restoreCmd(fileName string) tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		// Restore can take a while; give it room beyond the default client
+		// timeout via a dedicated context.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		err := client.RestoreBackup(ctx, fileName)
+		return backupRestoredMsg{fileName: fileName, err: err}
+	}
+}
+
+// Init kicks off the backup list load.
+func (m BackupModel) Init() tea.Cmd { return m.loadCmd() }
+
+// Update folds in load/create/restore results and handles input.
+func (m BackupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case backupsLoadedMsg:
+		if msg.err != nil {
+			m.loadEr = msg.err
+			return m, nil
+		}
+		m.loadEr, m.backups, m.stage = nil, msg.backups, bkBrowse
+		if m.cursor >= len(m.backups) {
+			m.cursor = 0
+		}
+		return m, nil
+	case backupCreatedMsg:
+		m.stage = bkBrowse
+		if msg.err != nil {
+			m.status = "✗ " + friendlyErr(msg.err)
+			return m, nil
+		}
+		m.status = "✓ created " + msg.backup.FileName
+		return m, m.loadCmd() // refresh the list to include the new backup
+	case backupRestoredMsg:
+		m.stage = bkBrowse
+		if msg.err != nil {
+			m.status = "✗ restore failed: " + friendlyErr(msg.err)
+			return m, nil
+		}
+		m.status = "✓ restored " + msg.fileName
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m BackupModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+	switch m.stage {
+	case bkConfirm:
+		return m.handleConfirmKey(msg)
+	case bkBrowse:
+		return m.handleBrowseKey(msg)
+	case bkLoading:
+		if m.loadEr != nil {
+			switch msg.String() {
+			case "q", "esc":
+				return m, tea.Quit
+			case "r":
+				m.loadEr = nil
+				return m, m.loadCmd()
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m BackupModel) handleBrowseKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		return m, tea.Quit
+	case "up", "k":
+		if len(m.backups) > 0 {
+			m.cursor = (m.cursor - 1 + len(m.backups)) % len(m.backups)
+		}
+		m.status = ""
+	case "down", "j":
+		if len(m.backups) > 0 {
+			m.cursor = (m.cursor + 1) % len(m.backups)
+		}
+		m.status = ""
+	case "n":
+		m.stage, m.status = bkCreating, ""
+		return m, m.createCmd()
+	case "r", "enter":
+		if len(m.backups) > 0 {
+			m.stage, m.status = bkConfirm, ""
+		}
+	}
+	return m, nil
+}
+
+func (m BackupModel) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		m.stage = bkRestoring
+		return m, m.restoreCmd(m.backups[m.cursor].FileName)
+	case "n", "N", "esc":
+		m.stage = bkBrowse
+	}
+	return m, nil
+}
+
+// View renders the panel per stage.
+func (m BackupModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  backups") + "\n")
+
+	if m.stage == bkLoading {
+		if m.loadEr != nil {
+			b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Couldn't load backups:")) + "\n")
+			b.WriteString(detailStyle.Render(friendlyErr(m.loadEr)) + "\n")
+			b.WriteString(footerStyle.Render("r retry · q quit"))
+			return frame(b.String(), m.width, m.height)
+		}
+		b.WriteString(phaseStyle.Render("Loading backups…"))
+		return frame(b.String(), m.width, m.height)
+	}
+	if m.stage == bkCreating {
+		b.WriteString(phaseStyle.Render("Creating backup…"))
+		return frame(b.String(), m.width, m.height)
+	}
+	if m.stage == bkRestoring {
+		b.WriteString(phaseStyle.Render("Restoring " + m.backups[m.cursor].FileName + " …"))
+		return frame(b.String(), m.width, m.height)
+	}
+
+	b.WriteString(phaseStyle.Render("System backups on the box.") + "\n\n")
+	if len(m.backups) == 0 {
+		b.WriteString(detailStyle.Render(cfgEmptyStyle.Render("(no backups yet)")) + "\n")
+	}
+	for i, bk := range m.backups {
+		meta := backupMeta.Render(fmt.Sprintf("  %s · %s", bk.CreatedAt, humanSize(bk.Size)))
+		if i == m.cursor {
+			b.WriteString(selectedStyle.Render("❯ "+bk.FileName) + meta + "\n")
+		} else {
+			b.WriteString(normalStyle.Render("  "+bk.FileName) + meta + "\n")
+		}
+	}
+
+	if m.stage == bkConfirm {
+		bk := m.backups[m.cursor]
+		b.WriteString("\n" + warnStyle.Render("⚠  Restore OVERWRITES the box's current config and state.") + "\n")
+		b.WriteString(detailStyle.Render("Restore "+bk.FileName+"?  Press y to confirm, n to cancel.") + "\n")
+		return frame(b.String(), m.width, m.height)
+	}
+
+	if m.status != "" {
+		style := cfgOKStyle
+		if strings.HasPrefix(m.status, "✗") {
+			style = cfgErrStyle
+		}
+		b.WriteString("\n" + detailStyle.Render(style.Render(m.status)) + "\n")
+	}
+	b.WriteString("\n" + footerStyle.Render("↑/↓ move · n new backup · r restore · q quit"))
+	return frame(b.String(), m.width, m.height)
+}
+
+// humanSize renders a byte count as a compact human-readable string.
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/tools/sb-tui/internal/ui/backup_test.go
+++ b/tools/sb-tui/internal/ui/backup_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"servicebay-tui/internal/rest"
+)
+
+func loadedBackupModel() BackupModel {
+	m := NewBackup(&rest.Client{})
+	mi, _ := m.Update(backupsLoadedMsg{backups: []rest.Backup{
+		{FileName: "a.tar.gz", CreatedAt: "t1", Size: 1024},
+		{FileName: "b.tar.gz", CreatedAt: "t2", Size: 2048},
+	}})
+	return mi.(BackupModel)
+}
+
+func TestBackupRestoreRequiresConfirmation(t *testing.T) {
+	m := loadedBackupModel()
+	if m.stage != bkBrowse {
+		t.Fatalf("stage = %v", m.stage)
+	}
+	// 'r' must NOT restore immediately — it enters the confirm stage.
+	mi, cmd := m.Update(runeKey('r'))
+	m = mi.(BackupModel)
+	if m.stage != bkConfirm || cmd != nil {
+		t.Fatalf("r should open confirm with no command, stage=%v", m.stage)
+	}
+	if !strings.Contains(m.View(), "OVERWRITES") {
+		t.Error("confirm view must warn about overwrite")
+	}
+	// 'n' cancels back to browse without restoring.
+	mi, cmd = m.Update(runeKey('n'))
+	m = mi.(BackupModel)
+	if m.stage != bkBrowse || cmd != nil {
+		t.Fatalf("n should cancel, stage=%v", m.stage)
+	}
+}
+
+func TestBackupConfirmYesRestores(t *testing.T) {
+	m := loadedBackupModel()
+	mi, _ := m.Update(runeKey('r'))
+	m = mi.(BackupModel)
+	mi, cmd := m.Update(runeKey('y'))
+	m = mi.(BackupModel)
+	if m.stage != bkRestoring || cmd == nil {
+		t.Fatalf("y should start restore, stage=%v cmd=%v", m.stage, cmd)
+	}
+	// Restore result returns to browse with a status.
+	mi, _ = m.Update(backupRestoredMsg{fileName: "a.tar.gz"})
+	m = mi.(BackupModel)
+	if m.stage != bkBrowse || !strings.Contains(m.status, "restored") {
+		t.Fatalf("after restore: stage=%v status=%q", m.stage, m.status)
+	}
+}
+
+func TestBackupCreateRefreshesList(t *testing.T) {
+	m := loadedBackupModel()
+	mi, cmd := m.Update(runeKey('n'))
+	m = mi.(BackupModel)
+	if m.stage != bkCreating || cmd == nil {
+		t.Fatalf("n should start creating, stage=%v", m.stage)
+	}
+	// A successful create returns to browse and re-loads the list.
+	mi, cmd = m.Update(backupCreatedMsg{backup: &rest.Backup{FileName: "new.tar.gz"}})
+	m = mi.(BackupModel)
+	if m.stage != bkBrowse || cmd == nil { // cmd == loadCmd refresh
+		t.Fatalf("create done should refresh, stage=%v cmd=%v", m.stage, cmd)
+	}
+	if !strings.Contains(m.status, "created") {
+		t.Errorf("status = %q", m.status)
+	}
+}
+
+func TestBackupLoadErrorBlocks(t *testing.T) {
+	m := NewBackup(&rest.Client{})
+	mi, _ := m.Update(backupsLoadedMsg{err: rest.ErrUnauthorized})
+	m = mi.(BackupModel)
+	if m.loadEr == nil || !strings.Contains(m.View(), "token") {
+		t.Fatal("auth load error should block with a token hint")
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	cases := map[int64]string{512: "512 B", 2048: "2.0 KiB", 5242880: "5.0 MiB"}
+	for in, want := range cases {
+		if got := humanSize(in); got != want {
+			t.Errorf("humanSize(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -135,6 +135,19 @@ func runInstallStacks() int {
 	return 0
 }
 
+// runBackups opens the backup panel (#1277).
+func runBackups() int {
+	client, code := boxClient()
+	if client == nil {
+		return code
+	}
+	if _, err := tea.NewProgram(ui.NewBackup(client), tea.WithAltScreen()).Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
 // openBrowser best-effort launches the host's default browser; failures are
 // ignored (the URLs are already printed for the operator to copy).
 func openBrowser(url string) {
@@ -165,6 +178,8 @@ func main() {
 			os.Exit(runConfig())
 		case "install":
 			os.Exit(runInstallStacks())
+		case "backups":
+			os.Exit(runBackups())
 		}
 	}
 
@@ -191,5 +206,7 @@ func main() {
 		os.Exit(runConfig())
 	case phase.InstallStacks:
 		os.Exit(runInstallStacks())
+	case phase.Backups:
+		os.Exit(runBackups())
 	}
 }


### PR DESCRIPTION
## What
The in-TUI **backup panel** (#1277): list the box's system backups, trigger a new backup, and restore one — over the #1275 scoped-token client. Third box-control panel; completes the edit-config / install / backup trio.

## Why
Closes #1277. Part of #1272.

Details:
- **Client** (`internal/rest/backup.go`): `ListBackups`, `CreateBackup` (reads the NDJSON progress stream and returns the terminal `done` result, or surfaces the `error` event), `RestoreBackup`.
- **Restore is destructive** — it overwrites the box's config/state. Guarded two ways: an explicit **y/n confirmation** in the panel (with an OVERWRITES warning), and the route now requires the **`destroy`** token scope. List → `read`, create → `lifecycle`.
- **Menu**: a "Backups (in-TUI)" action appears when the box is reachable.

## Risk
Low to add (new Go code + three route token opt-ins; web-UI cookie auth unchanged). The *restore action itself* is inherently destructive, which is why it is confirmation-gated and `destroy`-scoped.

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt / go vet / go test ./... (NDJSON stream parse incl. error event; restore confirmation gate; humanSize)
- [ ] npm run lint / check:arch / npm test — via CI
- [ ] Real-box `/verify` deferred: the restore route imports `lib/systemBackup` but the **diff doesn't touch** `packages/backend/src/lib/systemBackup.ts` (auth-plumbing only, restore logic untouched), so it's not path-mandated; and a real restore on the production box is itself destructive, so it won't be exercised blind. Will verify list+create against the box when a scoped token is minted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)