### PR TITLE
feat(tui): guided Express setup for the pre-boot happy path

### DIFF
--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -51,6 +51,7 @@ func Detect(isoBuilt bool, status BoxStatus) State {
 type ActionID string
 
 const (
+	Express       ActionID = "express"
 	BuildISO      ActionID = "build-iso"
 	WatchInstall  ActionID = "watch-install"
 	OpenBox       ActionID = "open-box"
@@ -60,6 +61,14 @@ const (
 	Refresh       ActionID = "refresh"
 	Quit          ActionID = "quit"
 )
+
+// expressAction is the guided happy-path entry (#1233): chain the
+// auto-sequenceable pre-boot legs — build + flash the ISO, prompt the operator
+// to boot, then watch the install — behind one confirm screen. The post-boot
+// restore + stack-install steps are token-gated, so they stay as the dedicated
+// panels reached once the box is up. Offered when no box is reachable yet.
+var expressAction = Action{Express, "Express setup — build, boot, watch",
+	"Guided happy path: build + flash the install ISO, boot the box, and watch the install through to the setup wizard."}
 
 // editConfigAction is the in-TUI box-control entry (#1275): edit allow-listed
 // config over the authenticated REST API without leaving the launcher. Only
@@ -111,8 +120,9 @@ func ActionsFor(s State) []Action {
 	var a []Action
 	switch s.Phase {
 	case NoISO:
-		// Nothing built and no box — the only move is to bake an installer.
-		a = append(a, buildAction(s))
+		// Nothing built and no box — express (guided) is the recommended path,
+		// with a plain build available for operators who want only the ISO.
+		a = append(a, expressAction, buildAction(s))
 	case ISOReady:
 		// ISO baked, box not up yet — rebuild, or boot-then-watch.
 		a = append(a,

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -45,8 +45,8 @@ func TestDetect(t *testing.T) {
 }
 
 func TestActionsFor(t *testing.T) {
-	// no-iso: build only, then refresh/quit
-	if got := ids(ActionsFor(Detect(false, BoxStatus{}))); !eq(got, []ActionID{BuildISO, Refresh, Quit}) {
+	// no-iso: express (recommended) + build, then refresh/quit
+	if got := ids(ActionsFor(Detect(false, BoxStatus{}))); !eq(got, []ActionID{Express, BuildISO, Refresh, Quit}) {
 		t.Fatalf("no-iso actions = %v", got)
 	}
 	// iso-ready: build + watch, then refresh/quit
@@ -80,7 +80,8 @@ func TestEveryActionHasLabelAndDetail(t *testing.T) {
 }
 
 func TestBuildLabelFlipsOnRebuild(t *testing.T) {
-	fresh := ActionsFor(Detect(false, BoxStatus{}))[0]
+	// NoISO leads with Express; the plain build action follows at index 1.
+	fresh := ActionsFor(Detect(false, BoxStatus{}))[1]
 	rebuilt := ActionsFor(Detect(true, BoxStatus{}))[0]
 	if fresh.Label != "Build install ISO + flash USB" {
 		t.Fatalf("fresh label = %q", fresh.Label)

--- a/tools/sb-tui/internal/ui/express.go
+++ b/tools/sb-tui/internal/ui/express.go
@@ -1,0 +1,86 @@
+// The Bubble Tea model for the Express-setup confirm screen (#1233). Express
+// chains the auto-sequenceable pre-boot legs — build + flash the ISO, boot the
+// box, then watch the install — behind one preview/confirm screen. The actual
+// sequencing happens in the entrypoint (runExpress) because the build leg is an
+// interactive stdin wizard, not a Bubble Tea program; this model only renders
+// the plan and reports the operator's confirm/cancel choice.
+//
+// The post-boot restore + stack-install steps are deliberately NOT chained
+// here: they need a reachable box and a minted SB_TOKEN that only exist after
+// first boot, so they stay as the dedicated panels (#1276/#1277).
+package ui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ExpressModel renders the Express plan and captures confirm/cancel.
+type ExpressModel struct {
+	host, port    string
+	width, height int
+	// Confirmed is set when the operator accepts the plan; the entrypoint reads
+	// it after the program exits to decide whether to run the sequence.
+	Confirmed bool
+}
+
+// NewExpress builds the confirm model. host/port are the resolved target (may
+// be empty before any ISO is built — the build leg establishes them).
+func NewExpress(host, port string) ExpressModel {
+	return ExpressModel{host: host, port: port}
+}
+
+// Init is a no-op; the screen is static until a key is pressed.
+func (m ExpressModel) Init() tea.Cmd { return nil }
+
+// Update handles confirm/cancel.
+func (m ExpressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			m.Confirmed = true
+			return m, tea.Quit
+		case "q", "esc", "ctrl+c":
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+// View renders the plan + confirm prompt.
+func (m ExpressModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  express setup") + "\n")
+	b.WriteString(phaseStyle.Render("Guided happy path. Express will, in order:") + "\n\n")
+
+	steps := []string{
+		"Build + flash a ServiceBay install ISO to a USB stick",
+		"Pause so you can boot the box from that USB",
+		"Watch the install live until the setup wizard takes over",
+	}
+	for i, s := range steps {
+		b.WriteString(normalStyle.Render("  "+stepNum(i+1)+" "+s) + "\n")
+	}
+
+	target := "discovered from the ISO build"
+	if m.host != "" {
+		target = m.host + ":" + m.port
+	}
+	b.WriteString(detailStyle.Render("Target: "+target) + "\n")
+	b.WriteString(detailStyle.Render(cfgEmptyStyle.Render("After first boot, use Edit config / Install stacks / Backups to finish setup.")) + "\n\n")
+	b.WriteString(footerStyle.Render("enter start · q cancel"))
+	return frame(b.String(), m.width, m.height)
+}
+
+func stepNum(n int) string {
+	return string(rune('0'+n)) + "."
+}

--- a/tools/sb-tui/internal/ui/express_test.go
+++ b/tools/sb-tui/internal/ui/express_test.go
@@ -1,0 +1,40 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestExpressConfirm(t *testing.T) {
+	m := NewExpress("192.168.1.10", "5888")
+	// Enter confirms the plan and quits.
+	mi, cmd := m.Update(namedKey(tea.KeyEnter))
+	m = mi.(ExpressModel)
+	if !m.Confirmed || cmd == nil {
+		t.Fatalf("enter should confirm + quit, confirmed=%v", m.Confirmed)
+	}
+}
+
+func TestExpressCancel(t *testing.T) {
+	m := NewExpress("", "")
+	mi, cmd := m.Update(runeKey('q'))
+	m = mi.(ExpressModel)
+	if m.Confirmed || cmd == nil {
+		t.Fatalf("q should cancel (not confirm) + quit, confirmed=%v", m.Confirmed)
+	}
+}
+
+func TestExpressViewShowsPlanAndTarget(t *testing.T) {
+	v := NewExpress("box.local", "5888").View()
+	for _, want := range []string{"express setup", "Build", "Watch", "box.local:5888"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("view missing %q", want)
+		}
+	}
+	// With no host yet, the target falls back to a discovery hint.
+	if !strings.Contains(NewExpress("", "").View(), "discovered") {
+		t.Error("empty-target view should show the discovery hint")
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -109,6 +110,36 @@ func boxClient() (*rest.Client, int) {
 	return client, 0
 }
 
+// runExpress runs the guided Express setup (#1233): a confirm screen, then the
+// auto-sequenceable pre-boot legs — build + flash, a boot pause, then watch.
+// The post-boot restore/install steps stay as the dedicated panels since they
+// need a reachable box + token. Any leg failing aborts the sequence.
+func runExpress() int {
+	t := probes.ResolveTarget()
+	final, err := tea.NewProgram(ui.NewExpress(t.Host, t.Port), tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	em, ok := final.(ui.ExpressModel)
+	if !ok || !em.Confirmed {
+		return 0 // operator cancelled the plan
+	}
+
+	// 1) Build + flash the ISO (the buildflow wizard does both).
+	if code := runBuild(); code != 0 {
+		return code
+	}
+
+	// 2) Boot pause — the physical step Express can't do for the operator.
+	fmt.Print("\n→ Boot the box from the USB stick now.\n")
+	fmt.Print("   Press Enter once it's powering on to watch the install… ")
+	_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+
+	// 3) Watch the install through to the wizard handoff.
+	return runWatch()
+}
+
 // runConfig opens the edit-config panel (#1275).
 func runConfig() int {
 	client, code := boxClient()
@@ -174,6 +205,8 @@ func main() {
 			os.Exit(runWatch())
 		case "build":
 			os.Exit(runBuild())
+		case "express":
+			os.Exit(runExpress())
 		case "config":
 			os.Exit(runConfig())
 		case "install":
@@ -196,6 +229,8 @@ func main() {
 	}
 
 	switch m.Chosen {
+	case phase.Express:
+		os.Exit(runExpress())
 	case phase.BuildISO:
 		os.Exit(runBuild())
 	case phase.WatchInstall:


### PR DESCRIPTION
## What
A guided **Express setup** entry in the launcher (#1233) that chains the auto-sequenceable pre-boot legs behind one confirm/preview screen: **build + flash the ISO → pause to boot the box → watch the install** through to the setup-wizard handoff.

## Why
Part of #1233. Previously standing up a box meant running each leg by hand in the right order; Express does the happy path with one confirm.

## Scope decision (deliberate)
Express chains only the **pre-boot** legs. The restore + stack-install steps the epic also mentions need a reachable box *and* a minted `SB_TOKEN`, which only exist **after** first boot — they can't run unattended across the physical boot. So they stay as the dedicated panels (#1276/#1277), reachable from the menu once the box is up, and the Express confirm screen points the operator there. This is why #1233 stays open rather than closed — see the issue comment.

Implementation notes:
- `ExpressModel` renders the plan + confirm; the actual sequencing lives in `runExpress` because the build leg is an interactive stdin wizard, not a Bubble Tea program.
- Offered as the recommended first action in the `NoISO` phase; the plain build-only action remains available.

## Risk
Low. New Go code + one menu entry; reuses the existing build and watch legs unchanged. A failing leg aborts the sequence with its own error.

## Rollback
`git revert` is enough.

## Verification
- [x] gofmt / go vet / go test ./... (confirm/cancel model; phase ordering)
- [ ] /verify n/a — Go-only, no install/config/auth/portal backend path touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)