### PR TITLE
feat(tui): unified app shell + in-TUI sign-in

### DIFF
--- a/tools/sb-tui/internal/probes/probes.go
+++ b/tools/sb-tui/internal/probes/probes.go
@@ -78,11 +78,38 @@ func ResolveTarget() Target {
 }
 
 // ResolveToken returns the scoped `sb_…` API token the box-control panels
-// authenticate with (#1275), read from SB_TOKEN. Empty when unset — the panel
-// then shows mint instructions rather than making a doomed 401 call. Mint one
-// in ServiceBay → Settings → API tokens with the `mutate` scope.
-func ResolveToken() string {
-	return strings.TrimSpace(os.Getenv("SB_TOKEN"))
+// authenticate with (#1275): SB_TOKEN env wins (CI / power users), otherwise the
+// token the TUI minted for this host on a previous in-TUI login. Empty when
+// neither exists — the launcher then runs the login flow rather than dead-ending.
+func ResolveToken(host string) string {
+	if t := strings.TrimSpace(os.Getenv("SB_TOKEN")); t != "" {
+		return t
+	}
+	if b, err := os.ReadFile(tokenPath(host)); err == nil {
+		return strings.TrimSpace(string(b))
+	}
+	return ""
+}
+
+// SaveToken persists a minted token for host so future launches skip the login
+// step. Stored 0600 under the user config dir, one file per host.
+func SaveToken(host, token string) error {
+	p := tokenPath(host)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(strings.TrimSpace(token)+"\n"), 0o600)
+}
+
+// tokenPath is ~/.config/servicebay/<host>.token (honoring XDG_CONFIG_HOME).
+func tokenPath(host string) string {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, _ := os.UserHomeDir()
+		dir = filepath.Join(home, ".config")
+	}
+	safe := strings.NewReplacer("/", "_", ":", "_").Replace(host)
+	return filepath.Join(dir, "servicebay", safe+".token")
 }
 
 // BoxStatus probes /api/install/status (unauthed). Unreachable host or any

--- a/tools/sb-tui/internal/rest/auth.go
+++ b/tools/sb-tui/internal/rest/auth.go
@@ -1,0 +1,91 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"time"
+)
+
+// tuiTokenName is the name the self-minted token is created under, so it's
+// recognizable in the box's Settings → API tokens list.
+const tuiTokenName = "sb-tui"
+
+// tuiScopes is the scope set the TUI mints for itself — everything its panels
+// need: read (config/catalog/backups), lifecycle (install), mutate (config
+// write), destroy (backup restore). Not exec.
+var tuiScopes = []string{"read", "lifecycle", "mutate", "destroy"}
+
+// ErrLoginRejected is returned when the box rejects the username/password.
+var ErrLoginRejected = fmt.Errorf("login rejected: wrong username or password")
+
+// Login authenticates against the box with an operator username/password and
+// mints a scoped `sb_…` API token for the TUI, returning the token secret. It
+// is the in-TUI replacement for "go to the web UI and paste a token": log in
+// once, the TUI mints + persists its own credential. The session cookie is held
+// only for the mint call and never stored.
+func Login(ctx context.Context, host, port, username, password string) (string, error) {
+	jar, _ := cookiejar.New(nil)
+	httpc := &http.Client{Timeout: defaultTimeout, Jar: jar}
+	base := fmt.Sprintf("http://%s:%s", host, port)
+
+	// 1) Log in — the Set-Cookie session lands in the jar.
+	if err := postJSON(ctx, httpc, base+"/api/auth/login",
+		map[string]string{"username": username, "password": password}, nil); err != nil {
+		if ae, ok := err.(*APIError); ok && ae.Status == http.StatusUnauthorized {
+			return "", ErrLoginRejected
+		}
+		return "", err
+	}
+
+	// 2) Mint a scoped token using the session cookie the jar now carries.
+	var minted struct {
+		Secret string `json:"secret"`
+	}
+	body := map[string]any{
+		"name":   tuiTokenName,
+		"scopes": tuiScopes,
+		// Long-lived: the TUI is a trusted local operator tool. A year out.
+		"expiresAt": time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339),
+	}
+	if err := postJSON(ctx, httpc, base+"/api/system/api-tokens", body, &minted); err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(minted.Secret, "sb_") {
+		return "", &APIError{Message: "login succeeded but the box returned no usable token"}
+	}
+	return minted.Secret, nil
+}
+
+// postJSON POSTs body as JSON on httpc (carrying its cookie jar) and decodes a
+// 2xx response into out (when non-nil), or returns a typed error.
+func postJSON(ctx context.Context, httpc *http.Client, url string, body, out any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return &APIError{Message: err.Error()}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(raw)))
+	if err != nil {
+		return &APIError{Message: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpc.Do(req)
+	if err != nil {
+		return &APIError{Message: fmt.Sprintf("cannot reach box: %v", err)}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf := make([]byte, 4096)
+		n, _ := resp.Body.Read(buf)
+		return &APIError{Status: resp.StatusCode, Message: serverError(buf[:n], resp.StatusCode)}
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return &APIError{Message: "malformed response: " + err.Error()}
+		}
+	}
+	return nil
+}

--- a/tools/sb-tui/internal/rest/auth_test.go
+++ b/tools/sb-tui/internal/rest/auth_test.go
@@ -1,0 +1,82 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestLoginFlow covers the two-step login: POST /api/auth/login sets a session
+// cookie, which the mint call to /api/system/api-tokens must carry back to get
+// the sb_ secret.
+func TestLoginFlow(t *testing.T) {
+	var mintGotCookie bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/login":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["username"] != "admin" || body["password"] != "secret" {
+				w.WriteHeader(http.StatusUnauthorized)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Invalid credentials"})
+				return
+			}
+			http.SetCookie(w, &http.Cookie{Name: "sb_session", Value: "cookie-123", Path: "/"})
+			_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+		case "/api/system/api-tokens":
+			if c, err := r.Cookie("sb_session"); err == nil && c.Value == "cookie-123" {
+				mintGotCookie = true
+			}
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["name"] != tuiTokenName {
+				t.Errorf("mint name = %v", body["name"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"secret": "sb_minted_abc"})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	host, port := hostPort(t, srv)
+	tok, err := Login(context.Background(), host, port, "admin", "secret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if tok != "sb_minted_abc" {
+		t.Errorf("token = %q", tok)
+	}
+	if !mintGotCookie {
+		t.Error("mint call did not carry the session cookie")
+	}
+}
+
+func TestLoginRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Invalid credentials"})
+	}))
+	defer srv.Close()
+
+	host, port := hostPort(t, srv)
+	_, err := Login(context.Background(), host, port, "admin", "wrong")
+	if err != ErrLoginRejected {
+		t.Fatalf("got %v, want ErrLoginRejected", err)
+	}
+}
+
+// hostPort splits an httptest server URL (http://127.0.0.1:PORT) into host+port
+// so Login can rebuild it through its own base-URL formatting.
+func hostPort(t *testing.T, srv *httptest.Server) (string, string) {
+	t.Helper()
+	hp := strings.TrimPrefix(srv.URL, "http://")
+	i := strings.LastIndex(hp, ":")
+	if i < 0 {
+		t.Fatalf("bad test url %q", srv.URL)
+	}
+	return hp[:i], hp[i+1:]
+}

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -1,0 +1,172 @@
+// The root Bubble Tea model that makes the launcher one continuous app instead
+// of a set of programs that exit between steps (#1272 UX). It hosts the phase
+// menu as home and pushes sub-views — login, edit-config, install, backups —
+// that return to the menu on `esc`/`q` rather than quitting the process. The
+// box-control sub-views require auth; the App routes through the login view
+// (which mints + persists a token) the first time, then reuses it.
+//
+// The build / express / watch / open-box legs are NOT hosted here: build is an
+// interactive stdin wizard (and its USB flash needs a real TTY), and the others
+// are natural one-shot handoffs. Selecting one sets Chosen and quits the App so
+// the entrypoint runs it.
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/phase"
+	"servicebay-tui/internal/rest"
+)
+
+// Navigation messages routed by the App.
+type (
+	// menuSelectedMsg is emitted by the menu when the operator picks an action.
+	menuSelectedMsg struct{ id phase.ActionID }
+	// backMsg is emitted by a sub-view to pop back to the menu.
+	backMsg struct{}
+)
+
+// backCmd emits backMsg. A sub-view uses it on esc/q: when hosted by the App it
+// pops to the menu; when run standalone (the `sb-tui config` subcommands) the
+// view's own Update catches backMsg and quits, so the same key works in both.
+func backCmd() tea.Cmd { return func() tea.Msg { return backMsg{} } }
+
+// TokenSaver persists a freshly-minted token so future launches skip login.
+// Injected so the App is testable without touching the filesystem.
+type TokenSaver func(host, token string) error
+
+type appScreen int
+
+const (
+	appMenu appScreen = iota
+	appLogin
+	appPanel
+)
+
+// App is the root model.
+type App struct {
+	host, port    string
+	token         string // current credential, "" until logged in
+	save          TokenSaver
+	width, height int
+
+	screen  appScreen
+	menu    Model
+	active  tea.Model      // login or a panel, when screen != appMenu
+	pending phase.ActionID // panel to open once authenticated
+
+	// Chosen is set to a handoff leg (build/express/watch/open-box) when the
+	// operator picks one; the entrypoint reads it after the App exits.
+	Chosen phase.ActionID
+}
+
+// NewApp builds the root model. token may be a pre-resolved credential (env or
+// the saved per-host file); empty means the box-control views will log in first.
+func NewApp(detect DetectFunc, host, port, token string, save TokenSaver) App {
+	return App{host: host, port: port, token: token, save: save, screen: appMenu, menu: New(detect)}
+}
+
+// Init starts the menu's phase detection.
+func (m App) Init() tea.Cmd { return m.menu.Init() }
+
+// Update routes navigation and delegates everything else to the active view.
+func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		// Size every view so a resize before first render is respected.
+		m.width, m.height = msg.Width, msg.Height
+		mm, _ := m.menu.Update(msg)
+		m.menu = mm.(Model)
+		if m.active != nil {
+			m.active, _ = m.active.Update(msg)
+		}
+		return m, nil
+
+	case menuSelectedMsg:
+		return m.route(msg.id)
+
+	case authSucceededMsg:
+		m.token = msg.token
+		if m.save != nil {
+			_ = m.save(m.host, msg.token)
+		}
+		return m.openPanel(m.pending)
+
+	case backMsg:
+		// Pop back to the menu and re-detect so its phase/actions refresh.
+		m.screen, m.active = appMenu, nil
+		fresh := New(m.menu.detect)
+		m.menu = fresh
+		return m, m.menu.Init()
+	}
+
+	// Delegate to the active view, or the menu when home.
+	if m.screen == appMenu {
+		mm, cmd := m.menu.Update(msg)
+		m.menu = mm.(Model)
+		return m, cmd
+	}
+	var cmd tea.Cmd
+	m.active, cmd = m.active.Update(msg)
+	return m, cmd
+}
+
+// route handles a menu selection: box-control views open in-app (after login if
+// needed); bootstrap/watch legs quit the App for the entrypoint to run.
+func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
+	switch id {
+	case phase.EditConfig, phase.InstallStacks, phase.Backups:
+		if m.token == "" {
+			m.pending = id
+			m.screen = appLogin
+			login := NewLogin(m.host, m.port)
+			m.active = login
+			return m, sizeCmd(m.width, m.height)
+		}
+		return m.openPanel(id)
+	default:
+		// build / express / watch / open-box — hand back to the entrypoint.
+		m.Chosen = id
+		return m, tea.Quit
+	}
+}
+
+// openPanel switches to a box-control panel with an authenticated client.
+func (m App) openPanel(id phase.ActionID) (tea.Model, tea.Cmd) {
+	client, err := rest.New(m.host, m.port, m.token)
+	if err != nil {
+		// Shouldn't happen (token is set here), but fail safe to the menu.
+		m.screen, m.active = appMenu, nil
+		return m, nil
+	}
+	switch id {
+	case phase.EditConfig:
+		m.active = NewConfig(client)
+	case phase.InstallStacks:
+		m.active = NewInstall(client)
+	case phase.Backups:
+		m.active = NewBackup(client)
+	default:
+		m.screen, m.active = appMenu, nil
+		return m, nil
+	}
+	m.screen = appPanel
+	return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
+}
+
+// View renders the active view.
+func (m App) View() string {
+	if m.screen == appMenu || m.active == nil {
+		return m.menu.View()
+	}
+	return m.active.View()
+}
+
+// sizeCmd re-emits the known terminal size so a freshly-opened sub-view lays
+// out immediately instead of waiting for the next resize.
+func sizeCmd(w, h int) tea.Cmd {
+	if w == 0 && h == 0 {
+		return nil
+	}
+	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
+}

--- a/tools/sb-tui/internal/ui/app_test.go
+++ b/tools/sb-tui/internal/ui/app_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/phase"
+)
+
+func testDetect(context.Context) (bool, phase.BoxStatus) {
+	return true, phase.BoxStatus{Reachable: true, WizardDone: true}
+}
+
+func newTestApp(token string) (App, *[]string) {
+	var saved []string
+	save := func(host, tok string) error { saved = append(saved, host+"="+tok); return nil }
+	return NewApp(testDetect, "box", "5888", token, save), &saved
+}
+
+// TestRouteToLoginWhenNoToken: picking a box-control action with no token opens
+// the login view, not the panel.
+func TestRouteToLoginWhenNoToken(t *testing.T) {
+	app, _ := newTestApp("")
+	mi, _ := app.Update(menuSelectedMsg{id: phase.EditConfig})
+	app = mi.(App)
+	if app.screen != appLogin {
+		t.Fatalf("screen = %v, want appLogin", app.screen)
+	}
+	if app.pending != phase.EditConfig {
+		t.Errorf("pending = %v", app.pending)
+	}
+	if _, ok := app.active.(LoginModel); !ok {
+		t.Errorf("active = %T, want LoginModel", app.active)
+	}
+}
+
+// TestRouteToPanelWhenTokenPresent: with a token, the panel opens directly.
+func TestRouteToPanelWhenTokenPresent(t *testing.T) {
+	app, _ := newTestApp("sb_existing")
+	mi, _ := app.Update(menuSelectedMsg{id: phase.Backups})
+	app = mi.(App)
+	if app.screen != appPanel {
+		t.Fatalf("screen = %v, want appPanel", app.screen)
+	}
+	if _, ok := app.active.(BackupModel); !ok {
+		t.Errorf("active = %T, want BackupModel", app.active)
+	}
+}
+
+// TestAuthSucceededSavesTokenAndOpensPending: logging in persists the token and
+// opens the panel that was requested before login.
+func TestAuthSucceededSavesTokenAndOpensPending(t *testing.T) {
+	app, saved := newTestApp("")
+	mi, _ := app.Update(menuSelectedMsg{id: phase.InstallStacks})
+	app = mi.(App)
+	mi, _ = app.Update(authSucceededMsg{token: "sb_new"})
+	app = mi.(App)
+	if app.token != "sb_new" {
+		t.Errorf("token = %q", app.token)
+	}
+	if len(*saved) != 1 || (*saved)[0] != "box=sb_new" {
+		t.Errorf("saved = %v", *saved)
+	}
+	if _, ok := app.active.(InstallModel); !ok {
+		t.Errorf("active = %T, want InstallModel after auth", app.active)
+	}
+}
+
+// TestBackReturnsToMenu: a sub-view's backMsg pops to the menu.
+func TestBackReturnsToMenu(t *testing.T) {
+	app, _ := newTestApp("sb_existing")
+	mi, _ := app.Update(menuSelectedMsg{id: phase.EditConfig})
+	app = mi.(App)
+	mi, _ = app.Update(backMsg{})
+	app = mi.(App)
+	if app.screen != appMenu || app.active != nil {
+		t.Fatalf("after back: screen=%v active=%v", app.screen, app.active)
+	}
+}
+
+// TestBootstrapLegQuitsApp: build/express/watch/open set Chosen and quit so the
+// entrypoint runs them.
+func TestBootstrapLegQuitsApp(t *testing.T) {
+	app, _ := newTestApp("")
+	mi, cmd := app.Update(menuSelectedMsg{id: phase.BuildISO})
+	app = mi.(App)
+	if app.Chosen != phase.BuildISO {
+		t.Errorf("Chosen = %v", app.Chosen)
+	}
+	if cmd == nil || cmd() != tea.Quit() {
+		t.Error("bootstrap leg should quit the app")
+	}
+}

--- a/tools/sb-tui/internal/ui/backup.go
+++ b/tools/sb-tui/internal/ui/backup.go
@@ -125,6 +125,8 @@ func (m BackupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
+	case backMsg:
+		return m, tea.Quit // standalone-only; App intercepts when hosted
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -144,7 +146,7 @@ func (m BackupModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.loadEr != nil {
 			switch msg.String() {
 			case "q", "esc":
-				return m, tea.Quit
+				return m, backCmd()
 			case "r":
 				m.loadEr = nil
 				return m, m.loadCmd()
@@ -157,7 +159,7 @@ func (m BackupModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m BackupModel) handleBrowseKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
-		return m, tea.Quit
+		return m, backCmd()
 	case "up", "k":
 		if len(m.backups) > 0 {
 			m.cursor = (m.cursor - 1 + len(m.backups)) % len(m.backups)

--- a/tools/sb-tui/internal/ui/config.go
+++ b/tools/sb-tui/internal/ui/config.go
@@ -105,6 +105,10 @@ func (m ConfigModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
+	case backMsg:
+		// Standalone (`sb-tui config`): quit. When hosted by App, App intercepts
+		// backMsg first, so this path only fires standalone.
+		return m, tea.Quit
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -118,11 +122,11 @@ func (m ConfigModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.editing {
 		return m.handleEditKey(msg)
 	}
-	// A blocking load error leaves only quit/refresh meaningful.
+	// A blocking load error leaves only back/refresh meaningful.
 	if m.loadEr != nil {
 		switch msg.String() {
 		case "q", "esc":
-			return m, tea.Quit
+			return m, backCmd()
 		case "r":
 			m.loading, m.loadEr = true, nil
 			return m, m.loadCmd()
@@ -134,7 +138,7 @@ func (m ConfigModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.String() {
 	case "q", "esc":
-		return m, tea.Quit
+		return m, backCmd()
 	case "up", "k":
 		m.cursor = (m.cursor - 1 + len(m.fields)) % len(m.fields)
 		m.status = ""

--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -133,6 +133,8 @@ func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
+	case backMsg:
+		return m, tea.Quit // standalone-only; App intercepts when hosted
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -173,10 +175,10 @@ func (m InstallModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c":
 		return m, tea.Quit
 	case "q", "esc":
-		// Quitting mid-install only detaches the watcher; the server job keeps
+		// Leaving mid-install only detaches the watcher; the server job keeps
 		// running. Safe because progress is resumable by jobId.
 		if m.stage != stageStarting {
-			return m, tea.Quit
+			return m, backCmd()
 		}
 	}
 	if m.stage != stageSelect {

--- a/tools/sb-tui/internal/ui/login.go
+++ b/tools/sb-tui/internal/ui/login.go
@@ -1,0 +1,147 @@
+// The Bubble Tea login sub-view (#1272 UX): the in-TUI replacement for "go to
+// the web UI and paste an API token". The operator types the box username +
+// password once; the TUI logs in, mints a scoped token for itself, persists it,
+// and proceeds into the requested panel. No browser, no SB_TOKEN env var.
+package ui
+
+import (
+	"context"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+// authSucceededMsg is emitted to the parent App when login mints a token.
+type authSucceededMsg struct{ token string }
+
+// loginResultMsg carries the outcome of a login attempt.
+type loginResultMsg struct {
+	token string
+	err   error
+}
+
+// LoginModel collects credentials and runs the login+mint flow.
+type LoginModel struct {
+	host, port    string
+	width, height int
+
+	username, password string
+	focus              int // 0 = username, 1 = password
+	submitting         bool
+	errMsg             string
+}
+
+// NewLogin builds the login view for a target box.
+func NewLogin(host, port string) LoginModel {
+	return LoginModel{host: host, port: port}
+}
+
+func (m LoginModel) loginCmd() tea.Cmd {
+	host, port, user, pass := m.host, m.port, m.username, m.password
+	return func() tea.Msg {
+		tok, err := rest.Login(context.Background(), host, port, user, pass)
+		return loginResultMsg{token: tok, err: err}
+	}
+}
+
+// Init is a no-op; the form is idle until the operator types.
+func (m LoginModel) Init() tea.Cmd { return nil }
+
+// Update handles field editing, focus, submit, and the login result. On success
+// it bubbles authSucceededMsg up to the App.
+func (m LoginModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case loginResultMsg:
+		m.submitting = false
+		if msg.err != nil {
+			m.errMsg = friendlyErr(msg.err)
+			m.password = "" // wrong creds: clear the password, keep username
+			m.focus = 1
+			return m, nil
+		}
+		return m, func() tea.Msg { return authSucceededMsg{token: msg.token} }
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.submitting {
+			return m, nil // ignore input while the request is in flight
+		}
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m LoginModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return m, func() tea.Msg { return backMsg{} }
+	case "tab", "down":
+		m.focus = (m.focus + 1) % 2
+	case "shift+tab", "up":
+		m.focus = (m.focus + 1) % 2
+	case "enter":
+		// Submit when both fields are filled; otherwise advance to the next.
+		if m.username != "" && m.password != "" {
+			m.submitting, m.errMsg = true, ""
+			return m, m.loginCmd()
+		}
+		m.focus = (m.focus + 1) % 2
+	case "backspace":
+		if m.focus == 0 && m.username != "" {
+			m.username = m.username[:len(m.username)-1]
+		} else if m.focus == 1 && m.password != "" {
+			m.password = m.password[:len(m.password)-1]
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			if m.focus == 0 {
+				m.username += string(msg.Runes)
+			} else {
+				m.password += string(msg.Runes)
+			}
+		}
+	}
+	return m, nil
+}
+
+// View renders the login form.
+func (m LoginModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  sign in") + "\n")
+	b.WriteString(phaseStyle.Render("Sign in to "+m.host+" to manage it. The TUI mints + saves its own token.") + "\n\n")
+
+	b.WriteString(fieldRow("Username", m.username, m.focus == 0, false) + "\n")
+	b.WriteString(fieldRow("Password", m.password, m.focus == 1, true) + "\n")
+
+	if m.submitting {
+		b.WriteString("\n" + detailStyle.Render("Signing in…") + "\n")
+	} else if m.errMsg != "" {
+		b.WriteString("\n" + detailStyle.Render(cfgErrStyle.Render("✗ "+m.errMsg)) + "\n")
+	}
+	b.WriteString("\n" + footerStyle.Render("tab switch · enter submit · esc back"))
+	return frame(b.String(), m.width, m.height)
+}
+
+// fieldRow renders one labelled input, masking secrets and marking focus.
+func fieldRow(label, value string, focused, secret bool) string {
+	shown := value
+	if secret {
+		shown = strings.Repeat("•", len(value))
+	}
+	caret := ""
+	if focused {
+		caret = "▌"
+	}
+	body := label + ": " + shown + caret
+	if focused {
+		return selectedStyle.Render("❯ " + body)
+	}
+	return normalStyle.Render("  " + body)
+}

--- a/tools/sb-tui/internal/ui/login_test.go
+++ b/tools/sb-tui/internal/ui/login_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+func typeStr(m LoginModel, s string) LoginModel {
+	for _, r := range s {
+		mi, _ := m.Update(runeKey(r))
+		m = mi.(LoginModel)
+	}
+	return m
+}
+
+func TestLoginTypeAndSubmit(t *testing.T) {
+	m := NewLogin("box", "5888")
+	m = typeStr(m, "admin") // focus starts on username
+	mi, _ := m.Update(namedKey(tea.KeyTab))
+	m = mi.(LoginModel)
+	m = typeStr(m, "pw")
+	if m.username != "admin" || m.password != "pw" {
+		t.Fatalf("fields: user=%q pass=%q", m.username, m.password)
+	}
+	// Enter with both filled submits.
+	mi, cmd := m.Update(namedKey(tea.KeyEnter))
+	m = mi.(LoginModel)
+	if !m.submitting || cmd == nil {
+		t.Fatalf("enter should submit, submitting=%v", m.submitting)
+	}
+	// Password must be masked in the view.
+	if strings.Contains(m.View(), "pw") {
+		t.Error("password should be masked in the view")
+	}
+}
+
+func TestLoginSuccessEmitsAuth(t *testing.T) {
+	m := NewLogin("box", "5888")
+	mi, cmd := m.Update(loginResultMsg{token: "sb_ok"})
+	m = mi.(LoginModel)
+	if cmd == nil {
+		t.Fatal("success should emit a command")
+	}
+	if _, ok := cmd().(authSucceededMsg); !ok {
+		t.Errorf("expected authSucceededMsg, got %T", cmd())
+	}
+}
+
+func TestLoginErrorClearsPassword(t *testing.T) {
+	m := NewLogin("box", "5888")
+	m.username, m.password, m.submitting = "admin", "wrong", true
+	mi, _ := m.Update(loginResultMsg{err: rest.ErrLoginRejected})
+	m = mi.(LoginModel)
+	if m.submitting {
+		t.Error("should clear submitting on error")
+	}
+	if m.password != "" {
+		t.Errorf("password should be cleared, got %q", m.password)
+	}
+	if m.username != "admin" {
+		t.Errorf("username should be kept, got %q", m.username)
+	}
+	if !strings.Contains(m.View(), "✗") {
+		t.Error("view should show the error")
+	}
+}
+
+func TestLoginEscGoesBack(t *testing.T) {
+	m := NewLogin("box", "5888")
+	mi, cmd := m.Update(namedKey(tea.KeyEsc))
+	_ = mi
+	if cmd == nil {
+		t.Fatal("esc should emit a command")
+	}
+	if _, ok := cmd().(backMsg); !ok {
+		t.Errorf("esc should emit backMsg, got %T", cmd())
+	}
+}

--- a/tools/sb-tui/internal/ui/menu.go
+++ b/tools/sb-tui/internal/ui/menu.go
@@ -36,16 +36,15 @@ var (
 	footerStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).MarginTop(1)
 )
 
-// Model is the Bubble Tea model for the launcher menu.
+// Model is the Bubble Tea model for the launcher menu. It is hosted by App
+// (app.go): selecting an action emits a menuSelectedMsg the App routes, rather
+// than quitting the program itself, so the launcher stays one continuous app.
 type Model struct {
 	detect        DetectFunc
 	state         *phase.State
 	actions       []phase.Action
 	cursor        int
 	width, height int
-	// Chosen is set to a handoff action (build/watch/open-box) when the operator
-	// picks one; the entrypoint reads it after the program exits.
-	Chosen phase.ActionID
 }
 
 // New builds a launcher model with the given phase-detection function.
@@ -95,8 +94,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.actions = nil
 				return m, m.detectCmd()
 			default:
-				m.Chosen = a.ID
-				return m, tea.Quit
+				// Hand the choice to the App, which routes it (open a panel,
+				// or quit the App so the entrypoint runs a bootstrap leg).
+				id := a.ID
+				return m, func() tea.Msg { return menuSelectedMsg{id: id} }
 			}
 		}
 	}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -101,10 +101,10 @@ func boxClient() (*rest.Client, int) {
 		fmt.Fprintln(os.Stderr, "no box target — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
 		return nil, 2
 	}
-	client, err := rest.New(t.Host, t.Port, probes.ResolveToken())
+	client, err := rest.New(t.Host, t.Port, probes.ResolveToken(t.Host))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, "Mint one in ServiceBay → Settings → API tokens (scopes: mutate + lifecycle) and export it as SB_TOKEN.")
+		fmt.Fprintln(os.Stderr, "Run `sb-tui` (no subcommand) and pick a box-control action to sign in — the TUI mints + saves its own token.")
 		return nil, 2
 	}
 	return client, 0
@@ -216,19 +216,26 @@ func main() {
 		}
 	}
 
-	// Full-screen (alt-screen): the launcher owns the terminal like a real
-	// installer rather than scrolling inline.
-	final, err := tea.NewProgram(ui.New(detect), tea.WithAltScreen()).Run()
+	// Full-screen unified app (alt-screen): the menu, login, and the
+	// box-control panels (edit-config / install / backups) all live in one
+	// program — sub-views return to the menu instead of exiting, and the box
+	// panels sign in + mint a token in-flow rather than dead-ending on a
+	// missing SB_TOKEN. The bootstrap/watch legs below are the only handoffs
+	// that quit the app, because build is an interactive stdin wizard and the
+	// rest are natural one-shots.
+	t := probes.ResolveTarget()
+	app := ui.NewApp(detect, t.Host, t.Port, probes.ResolveToken(t.Host), probes.SaveToken)
+	final, err := tea.NewProgram(app, tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	m, ok := final.(ui.Model)
+	res, ok := final.(ui.App)
 	if !ok {
 		return
 	}
 
-	switch m.Chosen {
+	switch res.Chosen {
 	case phase.Express:
 		os.Exit(runExpress())
 	case phase.BuildISO:
@@ -237,11 +244,5 @@ func main() {
 		os.Exit(runWatch())
 	case phase.OpenBox:
 		os.Exit(runOpenBox())
-	case phase.EditConfig:
-		os.Exit(runConfig())
-	case phase.InstallStacks:
-		os.Exit(runInstallStacks())
-	case phase.Backups:
-		os.Exit(runBackups())
 	}
 }


### PR DESCRIPTION
## What
Fixes the "Frankenstein" UX: the launcher is now **one continuous app**, and the box-control panels **no longer dead-end** at a missing `SB_TOKEN` / the web UI.

Reported symptoms this addresses:
- `Edit config` → `no API token: set SB_TOKEN…` dead-end.
- Each leg was a separate program that exited instead of returning to the menu.

## How
- **In-TUI sign-in** (`rest.Login` + `ui.LoginModel`): picking a box-control action with no token opens a login view. It signs in with the box username/password (`POST /api/auth/login`), mints a scoped `sb_…` token for the TUI (`POST /api/system/api-tokens`, scopes `read,lifecycle,mutate,destroy`), and **persists it per-host** under `$XDG_CONFIG_HOME/servicebay/<host>.token` (0600). No browser, no env var. Subsequent launches reuse it.
- **Unified shell** (`ui.App`): hosts the menu, login, and the edit-config / install / backups panels in one Bubble Tea program. Sub-views emit a `backMsg` on `esc`/`q` that pops back to the (re-detected) menu instead of quitting. The same `backMsg` makes the standalone `sb-tui config|install|backups` subcommands still quit on `q`.
- The **build / express / watch / open-box** legs still hand off to the entrypoint (build is an interactive stdin wizard whose USB flash needs a real TTY).

## Known remaining seam
The **ISO-build wizard is still stdin Q&A**, not a Bubble Tea form — that's the third inconsistency the operator flagged and is a separate, larger rewrite (the bake/flash steps need a real TTY + sudo). Tracked as follow-up.

## Risk
Medium-ish (touches every sub-view's quit path + new auth). Mitigated by unit tests: `rest.Login` two-step cookie→mint flow + rejection (`httptest`); App routing (login-gate, panel open, token save, back-to-menu, bootstrap handoff); login model typing/submit/error/esc. `gofmt`/`vet`/`go test ./...` clean.

## Verification
- [x] gofmt / go vet / go test ./...
- [ ] **Live login against the box** — needs real credentials, so verify on the FCoS box: pick `Edit config`, sign in, confirm a token appears under Settings → API tokens and the panel loads. (No backend path changed, so not auto-`/verify`-mandated.)

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)