### PR TITLE
fix(tui): reachable idle box is manageable; watch + open run in-app

### DIFF
--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -166,9 +166,9 @@ func Describe(s State) string {
 	case ISOReady:
 		return "Install ISO is ready. Boot the box from the USB, then watch the install."
 	case Installing:
-		return "Box is reachable; an install or setup is still in progress."
+		return "Box is reachable; an install is actively running."
 	case Ready:
-		return "Box is up and the setup wizard is complete."
+		return "Box is up and reachable — manage it below."
 	default:
 		return ""
 	}

--- a/tools/sb-tui/internal/probes/probes.go
+++ b/tools/sb-tui/internal/probes/probes.go
@@ -114,8 +114,12 @@ func tokenPath(host string) string {
 
 // BoxStatus probes /api/install/status (unauthed). Unreachable host or any
 // transport error reads as not-reachable; a non-2xx reads as reachable but
-// not-done. wizardDone mirrors the Ink probe: no active job and no pending
-// stack setup.
+// not-done. WizardDone means "the box is up and manageable" — the app is
+// serving and no install job is ACTIVELY running. A box that booted fine but
+// hasn't had its stacks set up yet (stackSetupPending) is still up/manageable:
+// installing stacks is a management action (the in-TUI Install panel), not a
+// reason to push the operator at the watch dashboard. Only an active install
+// job keeps the launcher in the "watch" phase.
 func BoxStatus(ctx context.Context) phase.BoxStatus {
 	t := ResolveTarget()
 	if t.Host == "" {
@@ -136,13 +140,13 @@ func BoxStatus(ctx context.Context) phase.BoxStatus {
 		return phase.BoxStatus{Reachable: true}
 	}
 	var body struct {
-		JobIsActive       *bool `json:"jobIsActive"`
-		StackSetupPending *bool `json:"stackSetupPending"`
+		JobIsActive *bool `json:"jobIsActive"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return phase.BoxStatus{Reachable: true}
 	}
-	done := body.JobIsActive != nil && !*body.JobIsActive &&
-		body.StackSetupPending != nil && !*body.StackSetupPending
+	// Up/manageable unless an install job is actively running. Absent field
+	// (app serving, nothing installing) counts as up.
+	done := body.JobIsActive == nil || !*body.JobIsActive
 	return phase.BoxStatus{Reachable: true, WizardDone: done}
 }

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -111,21 +111,30 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-// route handles a menu selection: box-control views open in-app (after login if
-// needed); bootstrap/watch legs quit the App for the entrypoint to run.
+// route handles a menu selection. Box-control panels open in-app (after login
+// if needed); watch + open-box open in-app too (no auth) and return to the
+// menu; only the build/express bootstrap legs quit the App for the entrypoint,
+// since build is an interactive stdin wizard whose USB flash needs a real TTY.
 func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
 	switch id {
 	case phase.EditConfig, phase.InstallStacks, phase.Backups:
 		if m.token == "" {
 			m.pending = id
 			m.screen = appLogin
-			login := NewLogin(m.host, m.port)
-			m.active = login
+			m.active = NewLogin(m.host, m.port)
 			return m, sizeCmd(m.width, m.height)
 		}
 		return m.openPanel(id)
+	case phase.WatchInstall:
+		m.active = NewWatch(m.host, m.port)
+		m.screen = appPanel
+		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
+	case phase.OpenBox:
+		m.active = NewOpen(m.host, m.port)
+		m.screen = appPanel
+		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
 	default:
-		// build / express / watch / open-box — hand back to the entrypoint.
+		// build / express — hand back to the entrypoint.
 		m.Chosen = id
 		return m, tea.Quit
 	}

--- a/tools/sb-tui/internal/ui/app_test.go
+++ b/tools/sb-tui/internal/ui/app_test.go
@@ -80,8 +80,8 @@ func TestBackReturnsToMenu(t *testing.T) {
 	}
 }
 
-// TestBootstrapLegQuitsApp: build/express/watch/open set Chosen and quit so the
-// entrypoint runs them.
+// TestBootstrapLegQuitsApp: build/express set Chosen and quit so the entrypoint
+// runs them (build is an interactive stdin wizard).
 func TestBootstrapLegQuitsApp(t *testing.T) {
 	app, _ := newTestApp("")
 	mi, cmd := app.Update(menuSelectedMsg{id: phase.BuildISO})
@@ -91,5 +91,26 @@ func TestBootstrapLegQuitsApp(t *testing.T) {
 	}
 	if cmd == nil || cmd() != tea.Quit() {
 		t.Error("bootstrap leg should quit the app")
+	}
+}
+
+// TestWatchAndOpenRunInApp: watch + open-box open as in-app sub-views (no auth)
+// and do NOT set Chosen / quit the app.
+func TestWatchAndOpenRunInApp(t *testing.T) {
+	app, _ := newTestApp("")
+	mi, _ := app.Update(menuSelectedMsg{id: phase.WatchInstall})
+	app = mi.(App)
+	if app.screen != appPanel || app.Chosen != "" {
+		t.Fatalf("watch: screen=%v chosen=%q", app.screen, app.Chosen)
+	}
+	if _, ok := app.active.(WatchModel); !ok {
+		t.Errorf("watch active = %T, want WatchModel", app.active)
+	}
+
+	app2, _ := newTestApp("")
+	mi, _ = app2.Update(menuSelectedMsg{id: phase.OpenBox})
+	app2 = mi.(App)
+	if _, ok := app2.active.(OpenModel); !ok || app2.Chosen != "" {
+		t.Errorf("open active = %T chosen=%q", app2.active, app2.Chosen)
 	}
 }

--- a/tools/sb-tui/internal/ui/openbox.go
+++ b/tools/sb-tui/internal/ui/openbox.go
@@ -1,0 +1,81 @@
+// The Bubble Tea open-box sub-view (#1272 UX): shows the box's dashboard +
+// setup URLs and best-effort launches the system browser, then returns to the
+// menu on a keypress — instead of the launcher exiting to the shell.
+package ui
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// OpenModel renders the box URLs and opens the dashboard in a browser.
+type OpenModel struct {
+	host, port    string
+	width, height int
+}
+
+// NewOpen builds the open-box view for a target.
+func NewOpen(host, port string) OpenModel { return OpenModel{host: host, port: port} }
+
+func (m OpenModel) dashboard() string { return fmt.Sprintf("http://%s:%s/", m.host, m.port) }
+func (m OpenModel) setup() string     { return fmt.Sprintf("http://%s:%s/setup", m.host, m.port) }
+
+// Init best-effort launches the dashboard in the operator's browser.
+func (m OpenModel) Init() tea.Cmd { return openBrowserCmd(m.dashboard()) }
+
+// Update returns to the menu on any of esc/q/enter.
+func (m OpenModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case backMsg:
+		return m, tea.Quit // standalone-only; App intercepts when hosted
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "q", "esc", "enter":
+			return m, backCmd()
+		}
+	}
+	return m, nil
+}
+
+// View renders the URLs.
+func (m OpenModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  open in browser") + "\n")
+	b.WriteString(phaseStyle.Render("Opening the dashboard in your browser…") + "\n\n")
+	b.WriteString(normalStyle.Render("  Dashboard:    ") + cfgValueStyle.Render(m.dashboard()) + "\n")
+	b.WriteString(normalStyle.Render("  Setup wizard: ") + cfgValueStyle.Render(m.setup()) + "\n")
+	b.WriteString("\n" + footerStyle.Render("esc back to menu"))
+	return frame(b.String(), m.width, m.height)
+}
+
+// openBrowserCmd best-effort launches the host's default browser; failures are
+// ignored (the URL is shown for the operator to copy).
+func openBrowserCmd(url string) tea.Cmd {
+	return func() tea.Msg {
+		var name string
+		var args []string
+		switch runtime.GOOS {
+		case "darwin":
+			name, args = "open", []string{url}
+		case "windows":
+			name, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+		default:
+			name, args = "xdg-open", []string{url}
+		}
+		_ = exec.Command(name, args...).Start()
+		return nil
+	}
+}

--- a/tools/sb-tui/internal/ui/watch.go
+++ b/tools/sb-tui/internal/ui/watch.go
@@ -60,19 +60,27 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.tracker.Apply(msg.probe, msg.at)
 		m.last = msg.probe
 		if msg.takeover {
+			// Box is up — leave the dashboard. Hosted by App this pops back to
+			// the menu (which re-detects → now a manageable box); standalone
+			// (`sb-tui watch`) the model's own backMsg case quits and main
+			// prints the handoff banner.
 			m.Takeover = true
-			return m, tea.Quit
+			return m, backCmd()
 		}
 		return m, tea.Tick(watchInterval, func(time.Time) tea.Msg { return scheduledPoll{} })
 	case scheduledPoll:
 		return m, m.pollCmd()
+	case backMsg:
+		return m, tea.Quit // standalone-only; App intercepts when hosted
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
+		case "q", "esc":
+			return m, backCmd()
 		}
 	}
 	return m, nil

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -16,8 +16,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -72,22 +70,6 @@ func runWatch() int {
 		fmt.Printf("   Dashboard:     http://%s:%s/\n\n", t.Host, t.Port)
 		fmt.Printf("   Total: %s, %d reboot(s) observed.\n\n", watch.FmtDur(elapsed), reboots)
 	}
-	return 0
-}
-
-// runOpenBox prints the box's setup + dashboard URLs and best-effort opens the
-// dashboard in the operator's browser (#1272 menu action OpenBox).
-func runOpenBox() int {
-	t := probes.ResolveTarget()
-	if t.Host == "" {
-		fmt.Fprintln(os.Stderr, "no box target — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
-		return 2
-	}
-	dashboard := fmt.Sprintf("http://%s:%s/", t.Host, t.Port)
-	fmt.Printf("\n→ ServiceBay\n\n")
-	fmt.Printf("   Dashboard:     %s\n", dashboard)
-	fmt.Printf("   Setup wizard:  http://%s:%s/setup\n\n", t.Host, t.Port)
-	openBrowser(dashboard)
 	return 0
 }
 
@@ -179,22 +161,6 @@ func runBackups() int {
 	return 0
 }
 
-// openBrowser best-effort launches the host's default browser; failures are
-// ignored (the URLs are already printed for the operator to copy).
-func openBrowser(url string) {
-	var name string
-	var args []string
-	switch runtime.GOOS {
-	case "darwin":
-		name, args = "open", []string{url}
-	case "windows":
-		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
-	default:
-		name, args = "xdg-open", []string{url}
-	}
-	_ = exec.Command(name, args...).Start()
-}
-
 func main() {
 	// Subcommands skip the menu and run one leg directly. `watch` is used by the
 	// install scripts' auto-launch; `build` runs the native ISO-build wizard
@@ -235,14 +201,12 @@ func main() {
 		return
 	}
 
+	// Only the bootstrap legs hand off here; watch + open-box now run inside the
+	// App and return to the menu.
 	switch res.Chosen {
 	case phase.Express:
 		os.Exit(runExpress())
 	case phase.BuildISO:
 		os.Exit(runBuild())
-	case phase.WatchInstall:
-		os.Exit(runWatch())
-	case phase.OpenBox:
-		os.Exit(runOpenBox())
 	}
 }


### PR DESCRIPTION
## What
Two UX bugs an operator hit testing the launcher against a live box:

1. **Mislabeled phase / wrong lead action.** A fully-booted box (dashboard serving) showed *"install or setup is still in progress"* and led with **Watch install progress**, because detection treated `stackSetupPending` (stacks not installed yet) as "still installing." Now the up/manageable check keys off an **actively-running install job only** — a reachable idle box reads as **Ready** and leads with Open / Edit config / Install stacks. Installing stacks is a management action, not a reason to watch.
2. **Watch dumped you to the shell.** Picking Watch on an already-up box detected takeover instantly and exited the whole app.

## How
- `probes.BoxStatus`: `WizardDone` now = `!jobIsActive` (dropped `stackSetupPending`). Describe text softened ("Box is up and reachable — manage it below" / "an install is actively running").
- **Watch + open-box now run inside the unified app** (`ui.WatchModel` returns to the menu on takeover/`q` via `backMsg`; new `ui.OpenModel` shows the URLs, launches the browser, and returns on a keypress). Only **build/express** still hand off to the entrypoint. The `sb-tui watch` subcommand (install-script auto-launch) still quits + prints its banner via the same `backMsg`→quit standalone path.

## Risk
Low; Go-only. `gofmt`/`vet`/`go test ./...` clean (added app-routing tests for in-app watch/open).

## Verification
- [x] gofmt / go vet / go test ./...
- [ ] On-box: with the box up, the menu should now lead with Open/Edit/Install (not Watch), and Watch/Open should return to the menu instead of exiting.

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)