### PR TITLE
fix(tui): detect box phase by what it serves, not a stale job flag

### DIFF
--- a/tools/sb-tui/internal/probes/probes.go
+++ b/tools/sb-tui/internal/probes/probes.go
@@ -6,18 +6,14 @@ package probes
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"servicebay-tui/internal/build"
 	"servicebay-tui/internal/phase"
+	"servicebay-tui/internal/watch"
 )
-
-const statusTimeout = 3 * time.Second
 
 // BuildDir is where an ISO build leaves its artifacts. Defaults to
 // ./build/fcos (repo-relative, matching the current dev workflow); override
@@ -112,41 +108,22 @@ func tokenPath(host string) string {
 	return filepath.Join(dir, "servicebay", safe+".token")
 }
 
-// BoxStatus probes /api/install/status (unauthed). Unreachable host or any
-// transport error reads as not-reachable; a non-2xx reads as reachable but
-// not-done. WizardDone means "the box is up and manageable" — the app is
-// serving and no install job is ACTIVELY running. A box that booted fine but
-// hasn't had its stacks set up yet (stackSetupPending) is still up/manageable:
-// installing stacks is a management action (the in-TUI Install panel), not a
-// reason to push the operator at the watch dashboard. Only an active install
-// job keeps the launcher in the "watch" phase.
-func BoxStatus(ctx context.Context) phase.BoxStatus {
+// BoxStatus classifies the box by what it's actually serving, not by a job
+// record. WizardDone ("up and manageable") keys off whether the REAL app is
+// serving — the same takeover signal the watch dashboard uses — rather than
+// /api/install/status's jobIsActive, which stays true on a job left stuck in
+// running/needs_credentials from a past install and wrongly pins the launcher
+// in the "watch" phase. So:
+//   - port closed            → not reachable (pre-boot / rebooting)
+//   - install splash serving → reachable, not done → Installing (watch leads)
+//   - real app serving       → reachable + done   → Ready (manage)
+func BoxStatus(_ context.Context) phase.BoxStatus {
 	t := ResolveTarget()
 	if t.Host == "" {
 		return phase.BoxStatus{}
 	}
-	ctx, cancel := context.WithTimeout(ctx, statusTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+t.Host+":"+t.Port+"/api/install/status", nil)
-	if err != nil {
+	if !watch.TCPOpen(t.Host, t.Port) {
 		return phase.BoxStatus{}
 	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return phase.BoxStatus{}
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return phase.BoxStatus{Reachable: true}
-	}
-	var body struct {
-		JobIsActive *bool `json:"jobIsActive"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return phase.BoxStatus{Reachable: true}
-	}
-	// Up/manageable unless an install job is actively running. Absent field
-	// (app serving, nothing installing) counts as up.
-	done := body.JobIsActive == nil || !*body.JobIsActive
-	return phase.BoxStatus{Reachable: true, WizardDone: done}
+	return phase.BoxStatus{Reachable: true, WizardDone: watch.AppServing(t.Host, t.Port)}
 }

--- a/tools/sb-tui/internal/watch/io.go
+++ b/tools/sb-tui/internal/watch/io.go
@@ -75,6 +75,26 @@ func fetchRootTitle(host, port string) string {
 	return strings.TrimSpace(m[1])
 }
 
+// AppServing reports whether the box's REAL app (not the install splash, not a
+// closed port) is serving at host:port — the same "takeover" signal the
+// dashboard exits on, but decoupled from ICMP so it works where ping is
+// blocked. It returns false when the port is closed or the install splash is
+// still up. This is the reliable "box is up and manageable" signal for phase
+// detection — more robust than /api/install/status's jobIsActive, which stays
+// true on a job left stuck in running/needs_credentials from a past install.
+func AppServing(host, port string) bool {
+	if !TCPOpen(host, port) {
+		return false
+	}
+	// Splash still publishing a status TSV → still installing, not the app.
+	if raw, err := httpGet("http://" + host + ":" + port + "/status.txt"); err == nil {
+		if _, ok := ParseStatus(raw); ok {
+			return false
+		}
+	}
+	return IsTakeover(fetchRootTitle(host, port))
+}
+
 // Observe runs one tick of probes against the box and returns the folded facts
 // plus whether ServiceBay has taken over (the caller should then exit). The
 // ladder mirrors install-tui.sh: ping first; only check the port when ping is


### PR DESCRIPTION
## What
A fully-booted box kept showing *"an install is actively running"* and leading with **Watch**, even with nothing installing — because `/api/install/status` reports `jobIsActive: true` whenever a past install job is left stuck in `running`/`needs_credentials`. That state survives reboots and never clears itself, so the launcher was permanently mis-phased.

## How
Stop trusting the job flag. Base phase detection on **what the box actually serves**, reusing the watch dashboard's takeover signal: new `watch.AppServing(host, port)` = port open + root title is the real app (not the `ServiceBay setup…` install splash), decoupled from ICMP. `probes.BoxStatus` now returns:
- port closed → not reachable
- install splash serving → reachable, not done → **Installing** (watch leads)
- real app serving → reachable + done → **Ready** (management leads)

This also drops the `/api/install/status` HTTP+JSON dependency from phase detection entirely.

## Risk
Low; Go-only. `gofmt`/`vet`/`go test ./...` clean. Supersedes the `jobIsActive`-based heuristic from #1336 with the more reliable served-content signal the watch leg already relies on.

## Verification
- [x] gofmt / go vet / go test ./...
- [ ] On-box: with the box up (and a stale job present), the menu should now read "Box is up and reachable" and lead with Open / Edit config / Install stacks.

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)