### PR TITLE
fix(tui): drop dead Watch action on an up box; explain the sign-in

### DIFF
--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -141,15 +141,16 @@ func ActionsFor(s State) []Action {
 			backupsAction,
 			buildAction(s))
 	case Ready:
-		// Box is fully up — manage it via the browser, or reinstall.
+		// Box is fully up — manage it in-TUI or via the browser, or reinstall.
+		// No Watch action here: there's nothing to watch on an up box (it would
+		// just bounce straight back), and a reinstall drops the box into the
+		// ISOReady/Installing phases where Watch is offered.
 		a = append(a,
 			Action{OpenBox, "Open ServiceBay in your browser",
 				"Open this box's dashboard to manage services, users, and settings."},
 			editConfigAction,
 			installStacksAction,
 			backupsAction,
-			Action{WatchInstall, "Watch a reinstall in progress",
-				"Live-track an install if you're reinstalling this box."},
 			buildAction(s))
 	}
 	a = append(a,

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -57,8 +57,9 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, OpenBox, EditConfig, InstallStacks, Backups, BuildISO, Refresh, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: open-box + edit-config + install-stacks + backups + watch + reinstall, then refresh/quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, InstallStacks, Backups, WatchInstall, BuildISO, Refresh, Quit}) {
+	// ready: open-box + edit-config + install-stacks + backups + reinstall, then refresh/quit
+	// (no Watch on an up box — nothing to watch).
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{OpenBox, EditConfig, InstallStacks, Backups, BuildISO, Refresh, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/ui/login.go
+++ b/tools/sb-tui/internal/ui/login.go
@@ -115,7 +115,10 @@ func (m LoginModel) View() string {
 	}
 	var b strings.Builder
 	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  sign in") + "\n")
-	b.WriteString(phaseStyle.Render("Sign in to "+m.host+" to manage it. The TUI mints + saves its own token.") + "\n\n")
+	b.WriteString(phaseStyle.Render("Managing the box needs a one-time sign-in.") + "\n")
+	b.WriteString(detailStyle.Render("Use your ServiceBay admin login — the same username + password as the web") + "\n")
+	b.WriteString(detailStyle.Render("dashboard at http://"+m.host+":"+m.port+". The TUI then creates + saves its own") + "\n")
+	b.WriteString(detailStyle.Render("access token for this box, so you won't be asked again.") + "\n\n")
 
 	b.WriteString(fieldRow("Username", m.username, m.focus == 0, false) + "\n")
 	b.WriteString(fieldRow("Password", m.password, m.focus == 1, true) + "\n")


### PR DESCRIPTION
## What
Two operator-reported confusions on a reachable box:

1. **"Watch a reinstall in progress" bounced straight back to the menu** — there's nothing to watch on an up box, so the takeover check returned immediately. Removed it from the **Ready** phase. Watch stays in ISOReady/Installing, where an install is actually running; a reinstall drops the box into those phases anyway.
2. **The sign-in screen didn't explain itself** ("no clue what user/password it wants… and why"). It now states it's a one-time sign-in with your **ServiceBay admin login (same as the web dashboard at http://host:port)**, and that the TUI then mints + saves its own token so you won't be asked again.

## Risk
Low; Go-only (menu list + login copy). `gofmt`/`vet`/`go test ./...` clean; Ready-phase action test updated.

## Verification
- [x] gofmt / go vet / go test ./...
- [ ] On-box: up box no longer lists "Watch a reinstall…"; the sign-in screen reads clearly.

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)