### PR TITLE
fix(tui): send same-origin header on login + token mint

### DIFF
--- a/tools/sb-tui/internal/rest/auth.go
+++ b/tools/sb-tui/internal/rest/auth.go
@@ -72,6 +72,12 @@ func postJSON(ctx context.Context, httpc *http.Client, url string, body, out any
 		return &APIError{Message: err.Error()}
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// The box's proxy CSRF-gates mutating POSTs: it 403s ("cross-site request")
+	// unless the Origin host matches the Host header, OR a valid Bearer is
+	// present. Login + token-mint happen BEFORE we have a token, so set a
+	// same-origin header. Go sets Host from the URL, so scheme://URL.Host
+	// matches by construction.
+	req.Header.Set("Origin", req.URL.Scheme+"://"+req.URL.Host)
 	resp, err := httpc.Do(req)
 	if err != nil {
 		return &APIError{Message: fmt.Sprintf("cannot reach box: %v", err)}

--- a/tools/sb-tui/internal/rest/auth_test.go
+++ b/tools/sb-tui/internal/rest/auth_test.go
@@ -15,6 +15,11 @@ import (
 func TestLoginFlow(t *testing.T) {
 	var mintGotCookie bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The proxy CSRF gate needs a same-origin header on these mutating
+		// POSTs; Login must set it or the box 403s "cross-site request".
+		if o := r.Header.Get("Origin"); o != "http://"+r.Host {
+			t.Errorf("Origin = %q, want http://%s", o, r.Host)
+		}
 		switch r.URL.Path {
 		case "/api/auth/login":
 			var body map[string]string


### PR DESCRIPTION
## What
Sign-in failed with **`box returned 403: Forbidden: cross-site request`**. The box's proxy (`proxy.ts:isSameOrigin`) CSRF-gates mutating POSTs: it requires the `Origin` header's host to match `Host`, unless a valid `Bearer` token is present. Login and the token-mint happen *before* the TUI has a token, so they hit the gate — and `rest.Login` wasn't sending `Origin`.

## How
Set `Origin: <scheme>://<URL.Host>` on those POSTs (Go sends `Host` from the same URL, so they match by construction). The Bearer-authenticated panels already bypass the CSRF gate, so only the login/mint path needed this.

## Risk
Minimal; one header. `gofmt`/`vet`/`go test ./...` clean (login test now asserts the same-origin header).

## Verification
- [x] gofmt / go vet / go test ./...
- [ ] On-box: Edit config → sign in with admin creds → token minted + saved, panel loads (no 403).

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)