### PR TITLE
refactor(tui): split build wizard into Plan + non-interactive Execute

### DIFF
--- a/tools/sb-tui/internal/buildflow/execute.go
+++ b/tools/sb-tui/internal/buildflow/execute.go
@@ -1,0 +1,125 @@
+package buildflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"servicebay-tui/internal/build"
+	"servicebay-tui/internal/iso"
+)
+
+// Plan is everything the operator chose up front — the result of the build
+// wizard's questions. Separating it from execution lets a Bubble Tea form
+// gather it with no terminal prompts, then hand a complete Plan to Execute,
+// which runs the operations (download / bake / flash) without asking anything.
+type Plan struct {
+	Settings  build.Settings
+	Image     iso.Choice // chosen source image (local path, or a remote stream to download)
+	GWPass    string     // FRITZ!Box password, "" when not configured
+	EmailPass string     // SMTP password, "" when email disabled
+	FlashTo   string     // target device path to write the ISO to; "" = skip flashing
+}
+
+// Logf is the progress sink Execute writes to — printf-style. The terminal
+// runner passes fmt.Printf; a future in-app view can capture lines instead.
+type Logf func(format string, a ...any)
+
+// Execute runs a fully-decided build Plan: persist settings, resolve the source
+// ISO (downloading a remote choice), generate ServiceBay secrets, bake the
+// installer, surface credentials, and optionally flash a USB. It asks nothing —
+// every decision is already in the Plan — so it works behind a form or a script.
+func Execute(plan Plan, opts Options, logf Logf) error {
+	d := opts.Deps
+	buildDir := opts.BuildDir
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		return err
+	}
+
+	settingsPath := filepath.Join(buildDir, "install-settings.env")
+	if err := plan.Settings.Save(settingsPath); err != nil {
+		return fmt.Errorf("save settings: %w", err)
+	}
+	logf("Settings saved to %s\n", settingsPath)
+
+	sourceISO, err := resolveImage(plan.Image, d, buildDir, logf)
+	if err != nil {
+		return err
+	}
+
+	secrets, err := build.GenerateSecrets(build.SecretInputs{
+		AdminPassword:    os.Getenv("SERVICEBAY_ADMIN_PASSWORD"),
+		HostPassword:     os.Getenv("HOST_PASSWORD"),
+		BootstrapToken:   os.Getenv("SERVICEBAY_BOOTSTRAP_TOKEN"),
+		NoBootstrapToken: os.Getenv("SB_NO_BOOTSTRAP_TOKEN") == "1",
+	}, d.Rand)
+	if err != nil {
+		return err
+	}
+
+	logf("\nBaking installer ISO (this runs butane + coreos-installer)…\n")
+	customISO, err := d.Bake(build.ISOBuildInputs{
+		Settings: plan.Settings, Secrets: secrets,
+		GatewayPass: plan.GWPass, EmailPass: plan.EmailPass, SourceISO: sourceISO,
+	}, buildDir)
+	if err != nil {
+		return fmt.Errorf("ISO bake failed: %w", err)
+	}
+	logf("Done! Ready-to-boot ISO:\n  %s\n", customISO)
+
+	emitCredentialsLog(plan.Settings, secrets, buildDir, logf)
+
+	if plan.FlashTo != "" {
+		logf("\nWriting ISO to %s (this will ERASE it)…\n", plan.FlashTo)
+		if err := d.Flash(customISO, plan.FlashTo); err != nil {
+			return fmt.Errorf("USB write failed: %w", err)
+		}
+		logf("Done! USB drive is ready.\n")
+	}
+
+	printBootHelpLog(plan.Settings, logf)
+	return nil
+}
+
+// resolveImage turns a chosen image into a local ISO path, downloading a remote
+// stream selection into buildDir.
+func resolveImage(choice iso.Choice, d Deps, buildDir string, logf Logf) (string, error) {
+	if choice.Kind == "local" {
+		if choice.Path == "" {
+			return "", fmt.Errorf("no source image selected")
+		}
+		return choice.Path, nil
+	}
+	logf("Downloading Fedora CoreOS %s/%s (this may take a few minutes)…\n", choice.Stream, choice.Arch)
+	path, err := d.Download(context.Background(), choice.Stream, choice.Arch, buildDir)
+	if err != nil {
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	logf("Downloaded: %s\n", path)
+	return path, nil
+}
+
+// emitCredentialsLog mirrors emitCredentials but writes via Logf (no Prompter).
+func emitCredentialsLog(s build.Settings, secrets build.Secrets, buildDir string, logf Logf) {
+	if !secrets.AnyGenerated() {
+		return
+	}
+	ctx := build.CredentialContext{
+		ServerName: s.ServerName, AdminUser: s.ServicebayAdminUser, HostUser: s.HostUser,
+		IP: s.StaticIP, Port: s.ServicebayPort,
+	}
+	logf("\n%s\n", secrets.Summary(ctx))
+	csvPath := filepath.Join(buildDir, "servicebay-install-credentials.csv")
+	if err := os.WriteFile(csvPath, []byte(secrets.BitwardenCSV(ctx)), 0o600); err == nil {
+		logf("  Bitwarden/Vaultwarden CSV: %s\n", csvPath)
+		logf("  Import via Vaultwarden → Tools → Import → Bitwarden (csv), then delete the file.\n\n")
+	}
+}
+
+func printBootHelpLog(s build.Settings, logf Logf) {
+	logf("\nBoot the target machine from this USB. It will:\n")
+	logf("  1. Auto-detect the smallest disk and install CoreOS there\n")
+	logf("  2. On first boot, auto-detect the largest disk and create a degraded RAID1\n")
+	logf("  3. Mount RAID at /mnt/data, start ServiceBay on port %s\n\n", s.ServicebayPort)
+}

--- a/tools/sb-tui/internal/buildflow/execute_test.go
+++ b/tools/sb-tui/internal/buildflow/execute_test.go
@@ -1,0 +1,97 @@
+package buildflow
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"servicebay-tui/internal/build"
+	"servicebay-tui/internal/iso"
+)
+
+// execDeps is a minimal Deps for Execute: records the bake inputs + flash, and
+// fakes download.
+func execDeps(rec *recorder) Deps {
+	return Deps{
+		Rand:     bytes.NewReader(bytes.Repeat([]byte{7}, 256)),
+		HostArch: func() string { return "x86_64" },
+		Download: func(_ context.Context, stream, arch, dir string) (string, error) {
+			return filepath.Join(dir, "downloaded-"+stream+"-"+arch+".iso"), nil
+		},
+		Bake: func(in build.ISOBuildInputs, outDir string) (string, error) {
+			rec.baked = in
+			return filepath.Join(outDir, "servicebay-custom.iso"), nil
+		},
+		Flash: func(isoPath, device string) error {
+			rec.flashed = isoPath
+			rec.flashTo = device
+			return nil
+		},
+	}
+}
+
+func TestExecuteLocalImageNoFlash(t *testing.T) {
+	dir := t.TempDir()
+	rec := &recorder{}
+	plan := Plan{
+		Settings: build.Settings{ServerName: "box", ServicebayPort: "5888", ServicebayAdminUser: "admin"},
+		Image:    iso.Choice{Kind: "local", Path: "/isos/fcos.iso"},
+	}
+	var log strings.Builder
+	if err := Execute(plan, Options{BuildDir: dir, Deps: execDeps(rec)}, func(f string, a ...any) {
+		log.WriteString(strings.TrimRight(f, "\n"))
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if rec.baked.SourceISO != "/isos/fcos.iso" {
+		t.Errorf("baked from %q, want the local path", rec.baked.SourceISO)
+	}
+	if rec.flashTo != "" {
+		t.Errorf("should not flash when FlashTo empty, got %q", rec.flashTo)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "install-settings.env")); err != nil {
+		t.Errorf("settings not saved: %v", err)
+	}
+}
+
+func TestExecuteRemoteImageDownloadsThenBakes(t *testing.T) {
+	dir := t.TempDir()
+	rec := &recorder{}
+	plan := Plan{
+		Settings: build.Settings{ServerName: "box", ServicebayPort: "5888"},
+		Image:    iso.Choice{Kind: "remote", Stream: "stable", Arch: "x86_64"},
+	}
+	if err := Execute(plan, Options{BuildDir: dir, Deps: execDeps(rec)}, func(string, ...any) {}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(rec.baked.SourceISO, "downloaded-stable-x86_64.iso") {
+		t.Errorf("expected a downloaded source ISO, got %q", rec.baked.SourceISO)
+	}
+}
+
+func TestExecuteFlashesSelectedDevice(t *testing.T) {
+	dir := t.TempDir()
+	rec := &recorder{}
+	plan := Plan{
+		Settings: build.Settings{ServerName: "box", ServicebayPort: "5888"},
+		Image:    iso.Choice{Kind: "local", Path: "/isos/fcos.iso"},
+		FlashTo:  "/dev/sdz",
+	}
+	if err := Execute(plan, Options{BuildDir: dir, Deps: execDeps(rec)}, func(string, ...any) {}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if rec.flashTo != "/dev/sdz" || !strings.HasSuffix(rec.flashed, "servicebay-custom.iso") {
+		t.Errorf("flash = %q to %q", rec.flashed, rec.flashTo)
+	}
+}
+
+func TestExecuteRejectsEmptyLocalImage(t *testing.T) {
+	rec := &recorder{}
+	plan := Plan{Settings: build.Settings{ServerName: "box"}, Image: iso.Choice{Kind: "local"}}
+	if err := Execute(plan, Options{BuildDir: t.TempDir(), Deps: execDeps(rec)}, func(string, ...any) {}); err == nil {
+		t.Fatal("expected an error for an empty local image path")
+	}
+}

--- a/tools/sb-tui/internal/buildflow/run.go
+++ b/tools/sb-tui/internal/buildflow/run.go
@@ -206,21 +206,9 @@ func isoSearchDirs(buildDir string) []string {
 }
 
 // emitCredentials prints the "save these now" summary and writes the
-// Bitwarden/Vaultwarden CSV for anything generated this run.
+// Bitwarden/Vaultwarden CSV — the Prompter wrapper over emitCredentialsLog.
 func emitCredentials(p Prompter, s build.Settings, secrets build.Secrets, buildDir string) {
-	if !secrets.AnyGenerated() {
-		return
-	}
-	ctx := build.CredentialContext{
-		ServerName: s.ServerName, AdminUser: s.ServicebayAdminUser, HostUser: s.HostUser,
-		IP: s.StaticIP, Port: s.ServicebayPort,
-	}
-	p.Printf("\n%s\n", secrets.Summary(ctx))
-	csvPath := filepath.Join(buildDir, "servicebay-install-credentials.csv")
-	if err := os.WriteFile(csvPath, []byte(secrets.BitwardenCSV(ctx)), 0o600); err == nil {
-		p.Printf("  Bitwarden/Vaultwarden CSV: %s\n", csvPath)
-		p.Printf("  Import via Vaultwarden → Tools → Import → Bitwarden (csv), then delete the file.\n\n")
-	}
+	emitCredentialsLog(s, secrets, buildDir, func(f string, a ...any) { p.Printf(f, a...) })
 }
 
 // flashStep enumerates removable devices and optionally writes the ISO.
@@ -263,8 +251,5 @@ func flashStep(p Prompter, d Deps, customISO string) error {
 }
 
 func printBootHelp(p Prompter, s build.Settings) {
-	p.Printf("\nBoot the target machine from this USB. It will:\n")
-	p.Printf("  1. Auto-detect the smallest disk and install CoreOS there\n")
-	p.Printf("  2. On first boot, auto-detect the largest disk and create a degraded RAID1\n")
-	p.Printf("  3. Mount RAID at /mnt/data, start ServiceBay on port %s\n\n", s.ServicebayPort)
+	printBootHelpLog(s, func(f string, a ...any) { p.Printf(f, a...) })
 }


### PR DESCRIPTION
## What
Foundation for converting the build wizard's stdin Q&A into a Bubble Tea form (the last "Frankenstein" seam an operator flagged).

- **`buildflow.Plan`** — everything chosen up front: settings, source image (`iso.Choice`), FRITZ!Box/SMTP passwords, optional flash target.
- **`buildflow.Execute(plan, opts, logf)`** — runs the operations with no prompting: save settings → resolve/download the source ISO → generate secrets → bake → emit credentials → optional flash. Output goes through a `Logf` sink (terminal now; an in-app view later).
- The existing Prompter-based `Run` (the `build` subcommand) is unchanged behaviorally and now shares the credential + boot-help helpers via `Logf` instead of carrying duplicate copies.

## Why
A clean form can gather a `Plan` with zero terminal prompts, then hand it to `Execute`. Flash's `sudo dd` still runs after the form (it needs a real TTY), so this split keeps the form pure and the privileged op separate. The form PR builds on this.

## Risk
Low; additive + a dedupe. `gofmt`/`vet`/`go test ./...` clean; new Execute tests cover local image, remote download, flash, and the empty-image guard. No behavior change to the shipped build path.

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)