### PR TITLE
feat(tui): full-screen build wizard form replacing stdin Q&A

### DIFF
--- a/tools/sb-tui/internal/buildflow/run.go
+++ b/tools/sb-tui/internal/buildflow/run.go
@@ -161,7 +161,7 @@ func externalSecret(p Prompter, envKey, label string, needed bool) (string, erro
 // downloading a remote selection.
 func pickISO(p Prompter, d Deps, buildDir string) (string, error) {
 	hostArch := d.HostArch()
-	local := d.ListLocal(isoSearchDirs(buildDir))
+	local := d.ListLocal(ISOSearchDirs(buildDir))
 	remote := d.FetchStreams(context.Background())
 	choices := iso.BuildChoices(local, remote, hostArch)
 	if len(choices) == 0 {
@@ -198,8 +198,8 @@ func pickISO(p Prompter, d Deps, buildDir string) (string, error) {
 	return path, nil
 }
 
-// isoSearchDirs mirrors the bash search set: repo root, build/, build/fcos.
-func isoSearchDirs(buildDir string) []string {
+// ISOSearchDirs mirrors the bash search set: repo root, build/, build/fcos.
+func ISOSearchDirs(buildDir string) []string {
 	parent := filepath.Dir(buildDir) // build/
 	root := filepath.Dir(parent)     // repo root
 	return []string{root, parent, buildDir}

--- a/tools/sb-tui/internal/buildflow/settings.go
+++ b/tools/sb-tui/internal/buildflow/settings.go
@@ -31,6 +31,28 @@ func defaultSSHKey() string {
 	return "ssh-ed25519 YOUR_KEY_HERE"
 }
 
+// WithDefaults fills any blank field with the standard seed value, so a fresh
+// build form (no saved install-settings.env) starts from sensible defaults
+// rather than empty inputs. Mirrors the per-field defaults gatherSettings used.
+func WithDefaults(s build.Settings) build.Settings {
+	s.ServerName = def(s.ServerName, "servicebay")
+	s.HostUser = def(s.HostUser, "core")
+	s.SSHAuthorizedKey = def(s.SSHAuthorizedKey, defaultSSHKey())
+	s.NetInterface = def(s.NetInterface, "eno1")
+	s.StaticIP = def(s.StaticIP, "192.168.178.99")
+	s.StaticPrefix = def(s.StaticPrefix, "24")
+	s.Gateway = def(s.Gateway, "192.168.178.1")
+	s.DNSServers = def(s.DNSServers, "192.168.178.1;8.8.8.8")
+	s.ServicebayPort = def(s.ServicebayPort, "5888")
+	s.ServicebayChannel = def(s.ServicebayChannel, "stable")
+	s.ServicebayAdminUser = def(s.ServicebayAdminUser, "admin")
+	s.EnableRegistries = def(s.EnableRegistries, "Y")
+	s.EnableOscarRegistry = def(s.EnableOscarRegistry, "N")
+	s.EnableEmail = def(s.EnableEmail, "N")
+	s.EmailPort = def(s.EmailPort, "587")
+	return s
+}
+
 // gatherSettings runs the full interactive prompt sequence, seeding each field's
 // default from the saved settings (prev). Mirrors the bash interactive block.
 func gatherSettings(p Prompter, saved build.Settings) build.Settings {

--- a/tools/sb-tui/internal/ui/buildform.go
+++ b/tools/sb-tui/internal/ui/buildform.go
@@ -1,0 +1,251 @@
+// The Bubble Tea build wizard (#1233/#1272 UX): a real full-screen form — fields
+// with labels, help text, and choices — that replaces the line-oriented stdin
+// Q&A for building an installer ISO. It gathers everything into a
+// buildflow.Plan (no terminal prompts), then the entrypoint hands that to
+// buildflow.Execute, which runs the operations and the sudo USB flash after the
+// form exits (the flash needs a real TTY).
+package ui
+
+import (
+	"regexp"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"servicebay-tui/internal/build"
+	"servicebay-tui/internal/buildflow"
+	"servicebay-tui/internal/iso"
+	"servicebay-tui/internal/usb"
+)
+
+var (
+	helpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).MarginLeft(2)
+	stepStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Bold(true)
+)
+
+var formHostnameRE = regexp.MustCompile(`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+type buildStep int
+
+const (
+	stepSettings buildStep = iota
+	stepImage
+	stepSecrets
+	stepFlash
+	stepReview
+)
+
+type fieldKind int
+
+const (
+	fText   fieldKind = iota
+	fChoice           // cycle among Options (enum / Y-N toggle)
+)
+
+// sfield describes one editable settings field.
+type sfield struct {
+	label   string
+	help    string
+	kind    fieldKind
+	options []string // for fChoice
+	secret  bool     // mask in the value display (none today, kept for symmetry)
+	get     func(*build.Settings) string
+	set     func(*build.Settings, string)
+	visible func(build.Settings) bool // nil → always
+	valid   func(string) string       // "" → ok, else error message
+}
+
+// settingsFields is the ordered, documented field set — the "real config
+// screen" the operator asked for. Conditionals hide irrelevant fields.
+var settingsFields = []sfield{
+	{label: "Server name", help: "Hostname for the box. Lowercase letters/digits/hyphens, 1–63 chars, must start with a letter.",
+		get: func(s *build.Settings) string { return s.ServerName }, set: func(s *build.Settings, v string) { s.ServerName = v },
+		valid: func(v string) string {
+			if !formHostnameRE.MatchString(v) {
+				return "invalid hostname (lowercase, start with a letter, no trailing hyphen)"
+			}
+			return ""
+		}},
+	{label: "Host username", help: "Linux account created on the box for SSH/console login.",
+		get: func(s *build.Settings) string { return s.HostUser }, set: func(s *build.Settings, v string) { s.HostUser = v }},
+	{label: "SSH public key", help: "Authorized key for the host user. Paste a full ssh-ed25519/ssh-rsa public key.",
+		get: func(s *build.Settings) string { return s.SSHAuthorizedKey }, set: func(s *build.Settings, v string) { s.SSHAuthorizedKey = v }},
+	{label: "Network interface", help: "NIC the static IP binds to (e.g. eno1, enp1s0).",
+		get: func(s *build.Settings) string { return s.NetInterface }, set: func(s *build.Settings, v string) { s.NetInterface = v }},
+	{label: "Static IPv4", help: "The box's fixed LAN address.",
+		get: func(s *build.Settings) string { return s.StaticIP }, set: func(s *build.Settings, v string) { s.StaticIP = v }},
+	{label: "IPv4 prefix length", help: "Subnet size in CIDR bits. 24 = a normal 255.255.255.0 home network.",
+		get: func(s *build.Settings) string { return s.StaticPrefix }, set: func(s *build.Settings, v string) { s.StaticPrefix = v }},
+	{label: "Gateway (router)", help: "Your router's LAN IP — the box's default route.",
+		get: func(s *build.Settings) string { return s.Gateway }, set: func(s *build.Settings, v string) { s.Gateway = v }},
+	{label: "DNS servers", help: "Semicolon-separated resolvers, e.g. 192.168.178.1;8.8.8.8.",
+		get: func(s *build.Settings) string { return s.DNSServers }, set: func(s *build.Settings, v string) { s.DNSServers = v }},
+	{label: "ServiceBay port", help: "TCP port the ServiceBay dashboard listens on.",
+		get: func(s *build.Settings) string { return s.ServicebayPort }, set: func(s *build.Settings, v string) { s.ServicebayPort = v }},
+	{label: "ServiceBay channel", help: "Release channel → image tag. stable = :latest (recommended), test = :test, dev = :dev.",
+		kind: fChoice, options: []string{"stable", "test", "dev"},
+		get: func(s *build.Settings) string { return s.ServicebayChannel }, set: func(s *build.Settings, v string) { s.ServicebayChannel = v }},
+	{label: "Admin username", help: "Login for the ServiceBay web dashboard (and the in-TUI sign-in).",
+		get: func(s *build.Settings) string { return s.ServicebayAdminUser }, set: func(s *build.Settings, v string) { s.ServicebayAdminUser = v }},
+	{label: "Public domain", help: "Optional external domain for reverse-proxy/TLS. Blank to skip.",
+		get: func(s *build.Settings) string { return s.PublicDomain }, set: func(s *build.Settings, v string) { s.PublicDomain = v }},
+	{label: "FRITZ!Box host", help: "Optional. Router IP/hostname to enable FRITZ!Box automation. Blank to skip.",
+		get: func(s *build.Settings) string { return s.GWHost }, set: func(s *build.Settings, v string) { s.GWHost = v }},
+	{label: "FRITZ!Box username", help: "Router login user (a password is asked on the Secrets step).",
+		get: func(s *build.Settings) string { return s.GWUser }, set: func(s *build.Settings, v string) { s.GWUser = v },
+		visible: func(s build.Settings) bool { return strings.TrimSpace(s.GWHost) != "" }},
+	{label: "Default template registry", help: "Enable the built-in template catalog.",
+		kind: fChoice, options: []string{"Y", "N"},
+		get: func(s *build.Settings) string { return yn(s.EnableRegistries) }, set: func(s *build.Settings, v string) { s.EnableRegistries = v }},
+	{label: "OSCAR registry", help: "Enable the OSCAR (voice assistant) template registry.",
+		kind: fChoice, options: []string{"Y", "N"},
+		get: func(s *build.Settings) string { return yn(s.EnableOscarRegistry) }, set: func(s *build.Settings, v string) { s.EnableOscarRegistry = v }},
+	{label: "Email notifications", help: "Send install/health emails via SMTP.",
+		kind: fChoice, options: []string{"Y", "N"},
+		get: func(s *build.Settings) string { return yn(s.EnableEmail) }, set: func(s *build.Settings, v string) { s.EnableEmail = v }},
+	{label: "SMTP host", help: "Mail server hostname, e.g. smtp.gmail.com.", visible: emailOn,
+		get: func(s *build.Settings) string { return s.EmailHost }, set: func(s *build.Settings, v string) { s.EmailHost = v }},
+	{label: "SMTP port", help: "Usually 587 (STARTTLS) or 465 (TLS).", visible: emailOn,
+		get: func(s *build.Settings) string { return s.EmailPort }, set: func(s *build.Settings, v string) { s.EmailPort = v }},
+	{label: "SMTP TLS", help: "Use implicit TLS (port 465). Most providers on 587 use STARTTLS → N.", visible: emailOn,
+		kind: fChoice, options: []string{"Y", "N"},
+		get: func(s *build.Settings) string { return yn(s.EmailSecure) }, set: func(s *build.Settings, v string) { s.EmailSecure = v }},
+	{label: "SMTP username", help: "Mailbox login (often the full address).", visible: emailOn,
+		get: func(s *build.Settings) string { return s.EmailUser }, set: func(s *build.Settings, v string) { s.EmailUser = v }},
+	{label: "From address", help: "Envelope From for sent mail.", visible: emailOn,
+		get: func(s *build.Settings) string { return s.EmailFrom }, set: func(s *build.Settings, v string) { s.EmailFrom = v }},
+	{label: "Recipients", help: "Comma-separated notification recipients.", visible: emailOn,
+		get: func(s *build.Settings) string { return s.EmailRecipients }, set: func(s *build.Settings, v string) { s.EmailRecipients = v }},
+}
+
+func emailOn(s build.Settings) bool { return strings.HasPrefix(strings.ToUpper(s.EnableEmail), "Y") }
+
+// yn normalizes a stored flag to "Y"/"N" for the toggle display.
+func yn(v string) string {
+	if strings.HasPrefix(strings.ToUpper(v), "Y") {
+		return "Y"
+	}
+	return "N"
+}
+
+// BuildDeps injects the IO the form needs (so it's testable without network/USB).
+type BuildDeps struct {
+	Images func() ([]iso.Choice, int) // available images + default index
+	USB    func() ([]usb.Device, error)
+}
+
+// BuildFormModel is the multi-step build wizard.
+type BuildFormModel struct {
+	deps          BuildDeps
+	width, height int
+
+	step     buildStep
+	settings build.Settings
+
+	// settings step
+	visible []sfield
+	sCursor int
+	editing bool
+	buf     string
+	sErr    string
+
+	// image step
+	images  []iso.Choice
+	iCursor int
+	imgErr  string
+
+	// secrets step
+	secrets   []secretRow
+	secCursor int
+
+	// flash step
+	devices []usb.Device
+	fCursor int // 0 = skip; 1..len = devices[fCursor-1]
+	devErr  string
+
+	// result — read by the entrypoint after the program exits.
+	Confirmed bool
+}
+
+// secretRow is one external password the build needs.
+type secretRow struct {
+	envLabel string // GW_PASS / EMAIL_PASS — display label
+	value    string
+	target   *string // where to store into the model on edit
+}
+
+type imagesLoadedMsg struct {
+	images []iso.Choice
+	defIdx int
+}
+type devicesLoadedMsg struct {
+	devices []usb.Device
+	err     error
+}
+
+// NewBuildForm builds the wizard seeded from saved settings.
+func NewBuildForm(saved build.Settings, deps BuildDeps) BuildFormModel {
+	m := BuildFormModel{deps: deps, settings: saved, step: stepSettings}
+	m.recomputeVisible()
+	return m
+}
+
+func (m *BuildFormModel) recomputeVisible() {
+	m.visible = m.visible[:0]
+	for _, f := range settingsFields {
+		if f.visible == nil || f.visible(m.settings) {
+			m.visible = append(m.visible, f)
+		}
+	}
+	if m.sCursor >= len(m.visible) {
+		m.sCursor = 0
+	}
+}
+
+// Init loads the image choices in the background.
+func (m BuildFormModel) Init() tea.Cmd {
+	deps := m.deps
+	return func() tea.Msg {
+		imgs, def := deps.Images()
+		return imagesLoadedMsg{images: imgs, defIdx: def}
+	}
+}
+
+// Plan assembles the gathered choices into a buildflow.Plan.
+func (m BuildFormModel) Plan() buildflow.Plan {
+	p := buildflow.Plan{Settings: m.settings}
+	if m.iCursor < len(m.images) {
+		p.Image = m.images[m.iCursor]
+	}
+	for _, sr := range m.secrets {
+		switch sr.envLabel {
+		case "FRITZ!Box password":
+			p.GWPass = sr.value
+		case "SMTP password":
+			p.EmailPass = sr.value
+		}
+	}
+	if m.fCursor >= 1 && m.fCursor-1 < len(m.devices) {
+		p.FlashTo = m.devices[m.fCursor-1].Path
+	}
+	return p
+}
+
+// rebuildSecrets recomputes which external passwords are needed from settings.
+func (m *BuildFormModel) rebuildSecrets() {
+	old := map[string]string{}
+	for _, s := range m.secrets {
+		old[s.envLabel] = s.value
+	}
+	m.secrets = m.secrets[:0]
+	if strings.TrimSpace(m.settings.GWHost) != "" {
+		m.secrets = append(m.secrets, secretRow{envLabel: "FRITZ!Box password", value: old["FRITZ!Box password"]})
+	}
+	if emailOn(m.settings) {
+		m.secrets = append(m.secrets, secretRow{envLabel: "SMTP password", value: old["SMTP password"]})
+	}
+	if m.secCursor >= len(m.secrets) {
+		m.secCursor = 0
+	}
+}

--- a/tools/sb-tui/internal/ui/buildform_test.go
+++ b/tools/sb-tui/internal/ui/buildform_test.go
@@ -1,0 +1,150 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/build"
+	"servicebay-tui/internal/iso"
+	"servicebay-tui/internal/usb"
+)
+
+func noDeps() BuildDeps {
+	return BuildDeps{
+		Images: func() ([]iso.Choice, int) { return nil, 0 },
+		USB:    func() ([]usb.Device, error) { return nil, nil },
+	}
+}
+
+// TestConditionalFieldsHiddenAndRevealed: GW user + email fields are hidden
+// until their gating field is set.
+func TestConditionalFieldsHiddenAndRevealed(t *testing.T) {
+	m := NewBuildForm(build.Settings{}, noDeps())
+	base := len(m.visible)
+	for _, f := range m.visible {
+		if f.label == "FRITZ!Box username" || f.label == "SMTP host" {
+			t.Fatalf("conditional field %q visible with gate off", f.label)
+		}
+	}
+	// Turn email on → SMTP fields appear.
+	m.settings.EnableEmail = "Y"
+	m.recomputeVisible()
+	if len(m.visible) <= base {
+		t.Fatal("enabling email should reveal SMTP fields")
+	}
+	// Set a FRITZ!Box host → username appears.
+	m.settings.GWHost = "192.168.178.1"
+	m.recomputeVisible()
+	found := false
+	for _, f := range m.visible {
+		if f.label == "FRITZ!Box username" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("setting FRITZ!Box host should reveal the username field")
+	}
+}
+
+// TestChannelCycleAndValidation: ←/→ cycles the channel enum; a bad hostname is
+// rejected on commit.
+func TestChannelCycleAndValidation(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServicebayChannel: "stable"}, noDeps())
+	// Cursor 0 is Server name (text). Move to the channel field.
+	for m.visible[m.sCursor].label != "ServiceBay channel" {
+		mi, _ := m.Update(namedKey(tea.KeyDown))
+		m = mi.(BuildFormModel)
+	}
+	mi, _ := m.Update(namedKey(tea.KeyRight))
+	m = mi.(BuildFormModel)
+	if m.settings.ServicebayChannel != "test" {
+		t.Errorf("channel after right = %q, want test", m.settings.ServicebayChannel)
+	}
+
+	// Back to Server name, edit to an invalid hostname → rejected.
+	m.sCursor = 0
+	mi, _ = m.Update(namedKey(tea.KeyEnter)) // start editing
+	m = mi.(BuildFormModel)
+	m.buf = "Bad_Name"
+	mi, _ = m.Update(namedKey(tea.KeyEnter)) // commit
+	m = mi.(BuildFormModel)
+	if m.sErr == "" {
+		t.Error("invalid hostname should be rejected with an error")
+	}
+	if m.settings.ServerName == "Bad_Name" {
+		t.Error("invalid value must not be stored")
+	}
+}
+
+// TestPlanAssembly: the gathered image, flash target, and secrets land in the Plan.
+func TestPlanAssembly(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "box", GWHost: "192.168.178.1"}, noDeps())
+	m.recomputeVisible()
+	m.rebuildSecrets()
+	m.images = []iso.Choice{
+		{Kind: "local", Path: "/a.iso", Label: "A"},
+		{Kind: "remote", Stream: "stable", Arch: "x86_64", Label: "B"},
+	}
+	m.iCursor = 1
+	m.devices = []usb.Device{{Path: "/dev/sdz", SizeBytes: 8 << 30, Model: "Stick"}}
+	m.fCursor = 1 // first real device
+	if len(m.secrets) != 1 || m.secrets[0].envLabel != "FRITZ!Box password" {
+		t.Fatalf("secrets = %+v", m.secrets)
+	}
+	m.secrets[0].value = "gwpw"
+
+	p := m.Plan()
+	if p.Image.Kind != "remote" || p.Image.Stream != "stable" {
+		t.Errorf("plan image = %+v", p.Image)
+	}
+	if p.FlashTo != "/dev/sdz" {
+		t.Errorf("plan FlashTo = %q", p.FlashTo)
+	}
+	if p.GWPass != "gwpw" {
+		t.Errorf("plan GWPass = %q", p.GWPass)
+	}
+	if p.Settings.ServerName != "box" {
+		t.Errorf("plan settings not carried")
+	}
+}
+
+// TestSkipFlash: cursor 0 means skip → no FlashTo.
+func TestSkipFlash(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "box"}, noDeps())
+	m.devices = []usb.Device{{Path: "/dev/sdz", SizeBytes: 8 << 30}}
+	m.fCursor = 0
+	if p := m.Plan(); p.FlashTo != "" {
+		t.Errorf("skip should leave FlashTo empty, got %q", p.FlashTo)
+	}
+}
+
+// TestReviewConfirms: enter on the review step sets Confirmed + quits.
+func TestReviewConfirms(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "box"}, noDeps())
+	m.step = stepReview
+	mi, cmd := m.Update(namedKey(tea.KeyEnter))
+	m = mi.(BuildFormModel)
+	if !m.Confirmed || cmd == nil {
+		t.Fatalf("review enter should confirm+quit, confirmed=%v", m.Confirmed)
+	}
+}
+
+// TestEscCancels: esc anywhere quits without confirming.
+func TestEscCancels(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "box"}, noDeps())
+	mi, cmd := m.Update(namedKey(tea.KeyEsc))
+	m = mi.(BuildFormModel)
+	if m.Confirmed || cmd == nil {
+		t.Fatal("esc should cancel (not confirm) and quit")
+	}
+}
+
+// TestSettingsViewShowsHelp: the focused field's help text renders.
+func TestSettingsViewShowsHelp(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "box"}, noDeps())
+	if !strings.Contains(m.View(), "Hostname for the box") {
+		t.Error("settings view should show the focused field's help")
+	}
+}

--- a/tools/sb-tui/internal/ui/buildform_update.go
+++ b/tools/sb-tui/internal/ui/buildform_update.go
@@ -1,0 +1,360 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Update drives the wizard: per-step field editing + step navigation.
+func (m BuildFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case imagesLoadedMsg:
+		m.images = msg.images
+		if msg.defIdx >= 0 && msg.defIdx < len(msg.images) {
+			m.iCursor = msg.defIdx
+		}
+		if len(m.images) == 0 {
+			m.imgErr = "no local ISOs found and no remote stream metadata reachable (check network)"
+		}
+		return m, nil
+	case devicesLoadedMsg:
+		m.devices = msg.devices
+		if msg.err != nil {
+			m.devErr = msg.err.Error()
+		}
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m BuildFormModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit // cancel
+	}
+	// Editing a text field captures most keys.
+	if m.editing {
+		return m.handleEditKey(msg)
+	}
+	switch msg.String() {
+	case "esc":
+		return m, tea.Quit // cancel the whole wizard
+	case "tab":
+		return m.nextStep()
+	case "shift+tab":
+		return m.prevStep()
+	}
+	switch m.step {
+	case stepSettings:
+		return m.handleSettingsKey(msg)
+	case stepImage:
+		return m.handleListKey(msg, len(m.images), &m.iCursor)
+	case stepSecrets:
+		return m.handleSecretsKey(msg)
+	case stepFlash:
+		return m.handleListKey(msg, len(m.devices)+1, &m.fCursor) // +1 for "skip"
+	case stepReview:
+		if msg.String() == "enter" {
+			m.Confirmed = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+// handleEditKey edits the focused text field (settings or secret).
+func (m BuildFormModel) handleEditKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.editing, m.buf, m.sErr = false, "", ""
+		return m, nil
+	case "enter":
+		return m.commitEdit()
+	case "backspace":
+		if m.buf != "" {
+			m.buf = m.buf[:len(m.buf)-1]
+		}
+		return m, nil
+	default:
+		if msg.Type == tea.KeyRunes {
+			m.buf += string(msg.Runes)
+		}
+		return m, nil
+	}
+}
+
+// commitEdit validates + stores the edit buffer back into settings/secrets.
+func (m BuildFormModel) commitEdit() (tea.Model, tea.Cmd) {
+	if m.step == stepSecrets {
+		m.secrets[m.secCursor].value = m.buf
+		m.editing, m.buf = false, ""
+		return m, nil
+	}
+	f := m.visible[m.sCursor]
+	v := strings.TrimSpace(m.buf)
+	if f.valid != nil {
+		if e := f.valid(v); e != "" {
+			m.sErr = e
+			return m, nil
+		}
+	}
+	f.set(&m.settings, v)
+	m.editing, m.buf, m.sErr = false, "", ""
+	// An edit (e.g. FRITZ!Box host) can change which fields/secrets apply.
+	m.recomputeVisible()
+	m.rebuildSecrets()
+	return m, nil
+}
+
+func (m BuildFormModel) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.visible) == 0 {
+		return m, nil
+	}
+	f := m.visible[m.sCursor]
+	switch msg.String() {
+	case "up", "k":
+		m.sCursor = (m.sCursor - 1 + len(m.visible)) % len(m.visible)
+		m.sErr = ""
+	case "down", "j":
+		m.sCursor = (m.sCursor + 1) % len(m.visible)
+		m.sErr = ""
+	case "left", "right":
+		if f.kind == fChoice {
+			f.set(&m.settings, cycle(f.options, f.get(&m.settings), msg.String() == "right"))
+			m.recomputeVisible()
+			m.rebuildSecrets()
+		}
+	case "enter":
+		if f.kind == fText {
+			m.editing, m.buf, m.sErr = true, f.get(&m.settings), ""
+		}
+	}
+	return m, nil
+}
+
+func (m BuildFormModel) handleSecretsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.secrets) == 0 {
+		return m, nil
+	}
+	switch msg.String() {
+	case "up", "k":
+		m.secCursor = (m.secCursor - 1 + len(m.secrets)) % len(m.secrets)
+	case "down", "j":
+		m.secCursor = (m.secCursor + 1) % len(m.secrets)
+	case "enter":
+		m.editing, m.buf = true, m.secrets[m.secCursor].value
+	}
+	return m, nil
+}
+
+// handleListKey moves a cursor over n items (used for image + flash lists).
+func (m BuildFormModel) handleListKey(msg tea.KeyMsg, n int, cursor *int) (tea.Model, tea.Cmd) {
+	if n == 0 {
+		return m, nil
+	}
+	switch msg.String() {
+	case "up", "k":
+		*cursor = (*cursor - 1 + n) % n
+	case "down", "j":
+		*cursor = (*cursor + 1) % n
+	}
+	return m, nil
+}
+
+// nextStep advances the wizard, running per-step side effects + validation.
+func (m BuildFormModel) nextStep() (tea.Model, tea.Cmd) {
+	switch m.step {
+	case stepSettings:
+		// Block leaving settings with an invalid value on the focused field.
+		m.rebuildSecrets()
+		m.step = stepImage
+	case stepImage:
+		m.step = stepSecrets
+	case stepSecrets:
+		m.step = stepFlash
+		if m.devices == nil && m.devErr == "" {
+			return m, m.loadDevicesCmd()
+		}
+	case stepFlash:
+		m.step = stepReview
+	case stepReview:
+		m.Confirmed = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m BuildFormModel) prevStep() (tea.Model, tea.Cmd) {
+	if m.step > stepSettings {
+		m.step--
+	}
+	return m, nil
+}
+
+func (m BuildFormModel) loadDevicesCmd() tea.Cmd {
+	deps := m.deps
+	return func() tea.Msg {
+		devs, err := deps.USB()
+		return devicesLoadedMsg{devices: devs, err: err}
+	}
+}
+
+// View renders the current step.
+func (m BuildFormModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  build installer") + "\n")
+	b.WriteString(stepStyle.Render(m.stepCrumb()) + "\n\n")
+
+	switch m.step {
+	case stepSettings:
+		m.viewSettings(&b)
+	case stepImage:
+		m.viewImage(&b)
+	case stepSecrets:
+		m.viewSecrets(&b)
+	case stepFlash:
+		m.viewFlash(&b)
+	case stepReview:
+		m.viewReview(&b)
+	}
+
+	b.WriteString("\n" + footerStyle.Render(m.footer()))
+	return frame(b.String(), m.width, m.height)
+}
+
+func (m BuildFormModel) stepCrumb() string {
+	names := []string{"Settings", "Image", "Secrets", "Flash", "Review"}
+	parts := make([]string, len(names))
+	for i, n := range names {
+		if buildStep(i) == m.step {
+			parts[i] = "[" + n + "]"
+		} else {
+			parts[i] = n
+		}
+	}
+	return strings.Join(parts, " › ")
+}
+
+func (m BuildFormModel) footer() string {
+	if m.editing {
+		return "type to edit · enter save · esc cancel"
+	}
+	switch m.step {
+	case stepReview:
+		return "enter build · shift+tab back · esc cancel"
+	case stepSettings:
+		return "↑/↓ move · ←/→ choose · enter edit · tab next · esc cancel"
+	default:
+		return "↑/↓ move · tab next · shift+tab back · esc cancel"
+	}
+}
+
+func (m BuildFormModel) viewSettings(b *strings.Builder) {
+	for i, f := range m.visible {
+		val := f.get(&m.settings)
+		if m.editing && i == m.sCursor {
+			b.WriteString(cfgEditingStyle.Render(f.label+": "+m.buf+"▌") + "\n")
+			continue
+		}
+		rendered := f.label + ": " + valueText(val)
+		if i == m.sCursor {
+			b.WriteString(selectedStyle.Render("❯ "+f.label+": ") + valueText(val) + "\n")
+		} else {
+			b.WriteString(normalStyle.Render("  "+rendered) + "\n")
+		}
+	}
+	if m.sCursor < len(m.visible) {
+		b.WriteString("\n" + helpStyle.Render(m.visible[m.sCursor].help) + "\n")
+	}
+	if m.sErr != "" {
+		b.WriteString(detailStyle.Render(cfgErrStyle.Render("✗ "+m.sErr)) + "\n")
+	}
+}
+
+func (m BuildFormModel) viewImage(b *strings.Builder) {
+	if m.imgErr != "" {
+		b.WriteString(detailStyle.Render(cfgErrStyle.Render(m.imgErr)) + "\n")
+		return
+	}
+	if len(m.images) == 0 {
+		b.WriteString(detailStyle.Render("Loading available images…") + "\n")
+		return
+	}
+	b.WriteString(phaseStyle.Render("Pick the Fedora CoreOS image to build from:") + "\n\n")
+	for i, c := range m.images {
+		line := "  " + c.Label
+		if i == m.iCursor {
+			line = selectedStyle.Render("❯ " + c.Label)
+		}
+		b.WriteString(line + "\n")
+	}
+}
+
+func (m BuildFormModel) viewSecrets(b *strings.Builder) {
+	if len(m.secrets) == 0 {
+		b.WriteString(detailStyle.Render("No external passwords needed — press tab to continue.") + "\n")
+		return
+	}
+	b.WriteString(phaseStyle.Render("External account passwords ServiceBay can't generate:") + "\n\n")
+	for i, sr := range m.secrets {
+		masked := strings.Repeat("•", len(sr.value))
+		if m.editing && i == m.secCursor {
+			b.WriteString(cfgEditingStyle.Render(sr.envLabel+": "+masked+"▌") + "\n")
+			continue
+		}
+		row := sr.envLabel + ": " + valueText(masked)
+		if i == m.secCursor {
+			b.WriteString(selectedStyle.Render("❯ "+sr.envLabel+": ") + valueText(masked) + "\n")
+		} else {
+			b.WriteString(normalStyle.Render("  "+row) + "\n")
+		}
+	}
+}
+
+func (m BuildFormModel) viewFlash(b *strings.Builder) {
+	b.WriteString(phaseStyle.Render("Write the baked ISO to a USB stick? (chosen at Review)") + "\n\n")
+	skip := "  Skip — don't write to USB"
+	if m.fCursor == 0 {
+		skip = selectedStyle.Render("❯ Skip — don't write to USB")
+	}
+	b.WriteString(skip + "\n")
+	if m.devErr != "" {
+		b.WriteString(detailStyle.Render(cfgEmptyStyle.Render("(USB enumeration unavailable: "+m.devErr+")")) + "\n")
+	}
+	for i, d := range m.devices {
+		line := "  " + d.Label()
+		if m.fCursor == i+1 {
+			line = selectedStyle.Render("❯ " + d.Label())
+		}
+		b.WriteString(line + "\n")
+	}
+}
+
+func (m BuildFormModel) viewReview(b *strings.Builder) {
+	s := m.settings
+	b.WriteString(phaseStyle.Render("Review — press enter to build.") + "\n\n")
+	row := func(k, v string) { b.WriteString(normalStyle.Render(fmt.Sprintf("  %-20s %s", k+":", v)) + "\n") }
+	row("Server", s.ServerName)
+	row("Network", s.StaticIP+"/"+s.StaticPrefix+" via "+s.NetInterface)
+	row("Channel", s.ServicebayChannel+"  (→ image tag)")
+	img := "(none)"
+	if m.iCursor < len(m.images) {
+		img = m.images[m.iCursor].Label
+	}
+	row("Image", img)
+	if m.fCursor >= 1 && m.fCursor-1 < len(m.devices) {
+		b.WriteString(warnStyle.Render("  Will ERASE + write: "+m.devices[m.fCursor-1].Label()) + "\n")
+	} else {
+		row("USB", "skip (no write)")
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -16,14 +16,18 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"servicebay-tui/internal/build"
 	"servicebay-tui/internal/buildflow"
+	"servicebay-tui/internal/iso"
 	"servicebay-tui/internal/phase"
 	"servicebay-tui/internal/probes"
 	"servicebay-tui/internal/rest"
 	"servicebay-tui/internal/ui"
+	"servicebay-tui/internal/usb"
 	"servicebay-tui/internal/watch"
 )
 
@@ -31,17 +35,42 @@ func detect(ctx context.Context) (bool, phase.BoxStatus) {
 	return probes.ISOBuilt(), probes.BoxStatus(ctx)
 }
 
-// runBuild runs the native interactive ISO-build wizard (#1295). Build-host
-// tools (butane, coreos-installer, openssl, ssh-keygen) must be on PATH; the
-// wizard surfaces a clear error if a step can't find one.
+// runBuild runs the native ISO-build wizard (#1233): a full-screen Bubble Tea
+// form gathers a build Plan, then buildflow.Execute runs the operations in the
+// normal terminal (the bake streams output and the USB flash needs sudo + a
+// real TTY, so they run after the alt-screen form exits). Build-host tools
+// (butane, coreos-installer, openssl, ssh-keygen) must be on PATH.
 func runBuild() int {
 	if missing := buildflow.MissingTools(); len(missing) > 0 {
 		fmt.Fprintf(os.Stderr, "Cannot build an ISO — missing build-host tools: %v\n", missing)
 		fmt.Fprintln(os.Stderr, "Install them and retry (Fedora: sudo dnf install butane coreos-installer openssl openssh).")
 		return 2
 	}
-	p := buildflow.NewIOPrompter(os.Stdin, os.Stdout)
-	if err := buildflow.Run(p, buildflow.Options{BuildDir: probes.BuildDir(), Deps: buildflow.DefaultDeps()}); err != nil {
+	buildDir := probes.BuildDir()
+	saved, _ := build.Load(filepath.Join(buildDir, "install-settings.env"))
+	deps := ui.BuildDeps{
+		Images: func() ([]iso.Choice, int) {
+			host := iso.HostArch()
+			local := iso.ListLocalISOs(buildflow.ISOSearchDirs(buildDir))
+			remote := iso.FetchAllStreams(context.Background())
+			ch := iso.BuildChoices(local, remote, host)
+			return ch, iso.DefaultChoiceIndex(ch, host)
+		},
+		USB: usb.Enumerate,
+	}
+
+	final, err := tea.NewProgram(ui.NewBuildForm(buildflow.WithDefaults(saved), deps), tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	bf, ok := final.(ui.BuildFormModel)
+	if !ok || !bf.Confirmed {
+		return 0 // operator cancelled the wizard
+	}
+
+	if err := buildflow.Execute(bf.Plan(), buildflow.Options{BuildDir: buildDir, Deps: buildflow.DefaultDeps()},
+		func(f string, a ...any) { fmt.Printf(f, a...) }); err != nil {
 		fmt.Fprintln(os.Stderr, "build failed:", err)
 		return 1
 	}


### PR DESCRIPTION
## What
The build wizard is now a **real full-screen form** — labelled fields, help text, and choices — instead of line-by-line stdin questions (the operator's "I'd prefer a real config screen with text, fields, explanations, choices").

Multi-step: **Settings** (every parameter with a one-line explanation; ServiceBay channel as a choice; conditional FRITZ!Box/email fields appear only when relevant) → **Image** (pick a local or remote Fedora CoreOS image) → **Secrets** (only the external passwords actually needed) → **Flash** (pick a USB target or skip) → **Review** (confirm → build).

Built on the merged `Plan`/`Execute` split: the form gathers a `buildflow.Plan` with **zero terminal prompts**, then `runBuild` hands it to `buildflow.Execute`, which runs the bake + `sudo dd` USB flash in the normal terminal **after** the alt-screen form exits (the flash needs a real TTY). Saved `install-settings.env` seeds the form; blank fields fall back to `WithDefaults`.

## Risk
Medium (new ~570-line UI) but well-isolated and tested: field visibility/conditionals, channel cycling + hostname validation, Plan assembly (image/flash/secrets), skip-flash, review-confirm, esc-cancel, help rendering. `gofmt`/`vet`/`go test ./...` clean. The Prompter-based `Run` stays as a tested reference / non-TTY fallback.

## Verification
- [x] gofmt / go vet / go test ./...
- [ ] On-box: `sb-tui build` → navigate the form, build an ISO, flash a stick.

Part of #1233 / #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)