### PR TITLE
fix(tui): coherent build-form interaction + esc returns to menu

### DIFF
--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -14,6 +14,7 @@ package ui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 
+	"servicebay-tui/internal/buildflow"
 	"servicebay-tui/internal/phase"
 	"servicebay-tui/internal/rest"
 )
@@ -48,22 +49,25 @@ type App struct {
 	host, port    string
 	token         string // current credential, "" until logged in
 	save          TokenSaver
+	build         BuildConfig
 	width, height int
 
 	screen  appScreen
 	menu    Model
-	active  tea.Model      // login or a panel, when screen != appMenu
+	active  tea.Model      // login, a panel, or the build form, when screen != appMenu
 	pending phase.ActionID // panel to open once authenticated
 
-	// Chosen is set to a handoff leg (build/express/watch/open-box) when the
-	// operator picks one; the entrypoint reads it after the App exits.
-	Chosen phase.ActionID
+	// Chosen is set to a handoff leg (express) when the operator picks one;
+	// BuildPlan is set when the in-app build form is confirmed. The entrypoint
+	// reads both after the App exits.
+	Chosen    phase.ActionID
+	BuildPlan *buildflow.Plan
 }
 
 // NewApp builds the root model. token may be a pre-resolved credential (env or
 // the saved per-host file); empty means the box-control views will log in first.
-func NewApp(detect DetectFunc, host, port, token string, save TokenSaver) App {
-	return App{host: host, port: port, token: token, save: save, screen: appMenu, menu: New(detect, host, port)}
+func NewApp(detect DetectFunc, host, port, token string, save TokenSaver, build BuildConfig) App {
+	return App{host: host, port: port, token: token, save: save, build: build, screen: appMenu, menu: New(detect, host, port)}
 }
 
 // Init starts the menu's phase detection.
@@ -91,6 +95,15 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.save(m.host, msg.token)
 		}
 		return m.openPanel(m.pending)
+
+	case buildConfirmedMsg:
+		// The in-app build form confirmed: stash the plan and quit so the
+		// entrypoint runs the bake + flash in the normal terminal (sudo dd
+		// needs a real TTY, so it can't run inside the alt-screen app).
+		plan := msg.plan
+		m.BuildPlan = &plan
+		m.Chosen = phase.BuildISO
+		return m, tea.Quit
 
 	case backMsg:
 		// Pop back to the menu and re-detect so its phase/actions refresh.
@@ -128,8 +141,14 @@ func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
 		m.active = NewWatch(m.host, m.port)
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
+	case phase.BuildISO:
+		// In-app so esc returns to the menu; on confirm it quits via
+		// buildConfirmedMsg and the entrypoint runs the build.
+		m.active = NewBuildForm(m.build.Saved, m.build.Deps)
+		m.screen = appPanel
+		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
 	default:
-		// build / express — hand back to the entrypoint.
+		// express — hand back to the entrypoint (it runs its own sequence).
 		m.Chosen = id
 		return m, tea.Quit
 	}

--- a/tools/sb-tui/internal/ui/app_test.go
+++ b/tools/sb-tui/internal/ui/app_test.go
@@ -6,6 +6,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"servicebay-tui/internal/build"
+	"servicebay-tui/internal/buildflow"
+	"servicebay-tui/internal/iso"
 	"servicebay-tui/internal/phase"
 )
 
@@ -13,10 +16,14 @@ func testDetect(context.Context) (bool, phase.BoxStatus) {
 	return true, phase.BoxStatus{Reachable: true, WizardDone: true}
 }
 
+func buildflowPlanStub() buildflow.Plan {
+	return buildflow.Plan{Settings: build.Settings{ServerName: "box"}, Image: iso.Choice{Kind: "local", Path: "/x.iso"}}
+}
+
 func newTestApp(token string) (App, *[]string) {
 	var saved []string
 	save := func(host, tok string) error { saved = append(saved, host+"="+tok); return nil }
-	return NewApp(testDetect, "box", "5888", token, save), &saved
+	return NewApp(testDetect, "box", "5888", token, save, BuildConfig{}), &saved
 }
 
 // TestRouteToLoginWhenNoToken: picking a box-control action with no token opens
@@ -80,17 +87,44 @@ func TestBackReturnsToMenu(t *testing.T) {
 	}
 }
 
-// TestBootstrapLegQuitsApp: build/express set Chosen and quit so the entrypoint
-// runs them (build is an interactive stdin wizard).
-func TestBootstrapLegQuitsApp(t *testing.T) {
+// TestExpressQuitsApp: Express hands off to the entrypoint (sets Chosen + quits).
+func TestExpressQuitsApp(t *testing.T) {
 	app, _ := newTestApp("")
-	mi, cmd := app.Update(menuSelectedMsg{id: phase.BuildISO})
+	mi, cmd := app.Update(menuSelectedMsg{id: phase.Express})
 	app = mi.(App)
-	if app.Chosen != phase.BuildISO {
+	if app.Chosen != phase.Express {
 		t.Errorf("Chosen = %v", app.Chosen)
 	}
 	if cmd == nil || cmd() != tea.Quit() {
-		t.Error("bootstrap leg should quit the app")
+		t.Error("Express should quit the app")
+	}
+}
+
+// TestBuildOpensFormInApp: BuildISO opens the build form in-app (esc → menu),
+// it does NOT immediately set Chosen / quit.
+func TestBuildOpensFormInApp(t *testing.T) {
+	app, _ := newTestApp("")
+	mi, _ := app.Update(menuSelectedMsg{id: phase.BuildISO})
+	app = mi.(App)
+	if app.screen != appPanel || app.Chosen != "" {
+		t.Fatalf("build: screen=%v chosen=%q", app.screen, app.Chosen)
+	}
+	if _, ok := app.active.(BuildFormModel); !ok {
+		t.Errorf("active = %T, want BuildFormModel", app.active)
+	}
+}
+
+// TestBuildConfirmedHandsOffPlan: the form's confirm sets the BuildPlan + Chosen
+// and quits so the entrypoint runs the bake/flash.
+func TestBuildConfirmedHandsOffPlan(t *testing.T) {
+	app, _ := newTestApp("")
+	mi, cmd := app.Update(buildConfirmedMsg{plan: buildflowPlanStub()})
+	app = mi.(App)
+	if app.BuildPlan == nil || app.Chosen != phase.BuildISO {
+		t.Fatalf("expected BuildPlan + Chosen=BuildISO, got %v / %q", app.BuildPlan, app.Chosen)
+	}
+	if cmd == nil || cmd() != tea.Quit() {
+		t.Error("confirm should quit the app to run the build")
 	}
 }
 

--- a/tools/sb-tui/internal/ui/buildform.go
+++ b/tools/sb-tui/internal/ui/buildform.go
@@ -135,6 +135,13 @@ type BuildDeps struct {
 	USB    func() ([]usb.Device, error)
 }
 
+// BuildConfig is what the App needs to open the build form in-app: the IO deps
+// plus the seeded settings (saved install-settings.env merged with defaults).
+type BuildConfig struct {
+	Deps  BuildDeps
+	Saved build.Settings
+}
+
 // BuildFormModel is the multi-step build wizard.
 type BuildFormModel struct {
 	deps          BuildDeps
@@ -143,11 +150,10 @@ type BuildFormModel struct {
 	step     buildStep
 	settings build.Settings
 
-	// settings step
+	// settings step. The focused field is edited live — no separate edit mode:
+	// text fields take typed runes, choice fields cycle with ←/→.
 	visible []sfield
 	sCursor int
-	editing bool
-	buf     string
 	sErr    string
 
 	// image step
@@ -184,6 +190,11 @@ type devicesLoadedMsg struct {
 	err     error
 }
 
+// buildConfirmedMsg is emitted when the operator confirms the Review step. It
+// carries the assembled Plan so the App (in-app hosting) can run the build, or
+// the standalone `sb-tui build` program can quit and read it back.
+type buildConfirmedMsg struct{ plan buildflow.Plan }
+
 // NewBuildForm builds the wizard seeded from saved settings.
 func NewBuildForm(saved build.Settings, deps BuildDeps) BuildFormModel {
 	m := BuildFormModel{deps: deps, settings: saved, step: stepSettings}
@@ -206,6 +217,9 @@ func (m *BuildFormModel) recomputeVisible() {
 // Init loads the image choices in the background.
 func (m BuildFormModel) Init() tea.Cmd {
 	deps := m.deps
+	if deps.Images == nil {
+		return nil
+	}
 	return func() tea.Msg {
 		imgs, def := deps.Images()
 		return imagesLoadedMsg{images: imgs, defIdx: def}

--- a/tools/sb-tui/internal/ui/buildform_test.go
+++ b/tools/sb-tui/internal/ui/buildform_test.go
@@ -48,11 +48,11 @@ func TestConditionalFieldsHiddenAndRevealed(t *testing.T) {
 	}
 }
 
-// TestChannelCycleAndValidation: ←/→ cycles the channel enum; a bad hostname is
-// rejected on commit.
+// TestChannelCycleAndValidation: ←/→ cycles the channel enum; Enter (advance) is
+// blocked while a field is invalid.
 func TestChannelCycleAndValidation(t *testing.T) {
 	m := NewBuildForm(build.Settings{ServicebayChannel: "stable"}, noDeps())
-	// Cursor 0 is Server name (text). Move to the channel field.
+	// Move focus to the channel field and cycle it with →.
 	for m.visible[m.sCursor].label != "ServiceBay channel" {
 		mi, _ := m.Update(namedKey(tea.KeyDown))
 		m = mi.(BuildFormModel)
@@ -63,18 +63,20 @@ func TestChannelCycleAndValidation(t *testing.T) {
 		t.Errorf("channel after right = %q, want test", m.settings.ServicebayChannel)
 	}
 
-	// Back to Server name, edit to an invalid hostname → rejected.
+	// Type an invalid hostname into Server name (live), then Enter must NOT
+	// advance — it surfaces the validation error and stays on Settings.
 	m.sCursor = 0
-	mi, _ = m.Update(namedKey(tea.KeyEnter)) // start editing
-	m = mi.(BuildFormModel)
-	m.buf = "Bad_Name"
-	mi, _ = m.Update(namedKey(tea.KeyEnter)) // commit
-	m = mi.(BuildFormModel)
-	if m.sErr == "" {
-		t.Error("invalid hostname should be rejected with an error")
+	for _, r := range "Bad_Name" {
+		mi, _ := m.Update(runeKey(r))
+		m = mi.(BuildFormModel)
 	}
-	if m.settings.ServerName == "Bad_Name" {
-		t.Error("invalid value must not be stored")
+	if m.settings.ServerName != "Bad_Name" {
+		t.Fatalf("live edit should update the value, got %q", m.settings.ServerName)
+	}
+	mi, _ = m.Update(namedKey(tea.KeyEnter))
+	m = mi.(BuildFormModel)
+	if m.sErr == "" || m.step != stepSettings {
+		t.Errorf("invalid hostname should block advance: err=%q step=%v", m.sErr, m.step)
 	}
 }
 

--- a/tools/sb-tui/internal/ui/buildform_update.go
+++ b/tools/sb-tui/internal/ui/buildform_update.go
@@ -5,9 +5,29 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"servicebay-tui/internal/usb"
 )
 
-// Update drives the wizard: per-step field editing + step navigation.
+// One coherent interaction model across every step:
+//
+//	↑/↓    move between fields / list rows
+//	←/→    change the focused choice field (Y/N, channel)
+//	type   edit the focused text field in place (the label is static)
+//	enter  Continue ▸ (next step; on Review, build)
+//	s-tab  ◂ back a step
+//	esc    back to the launcher menu
+var (
+	inputStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("231")).Background(lipgloss.Color("236"))
+	inputFocused = lipgloss.NewStyle().Foreground(lipgloss.Color("231")).Background(lipgloss.Color("63"))
+	labelStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
+	labelFocused = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("231"))
+	contIdle     = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	contStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("231")).Background(lipgloss.Color("63")).Padding(0, 1)
+)
+
+// Update drives the wizard.
 func (m BuildFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case imagesLoadedMsg:
@@ -25,6 +45,10 @@ func (m BuildFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.devErr = msg.err.Error()
 		}
 		return m, nil
+	case buildConfirmedMsg:
+		// Standalone (`sb-tui build`): quit so the entrypoint reads Plan back.
+		// When hosted by App, App intercepts this first and never forwards it.
+		return m, tea.Quit
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
@@ -35,143 +59,45 @@ func (m BuildFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m BuildFormModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == "ctrl+c" {
-		return m, tea.Quit // cancel
-	}
-	// Editing a text field captures most keys.
-	if m.editing {
-		return m.handleEditKey(msg)
-	}
 	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
 	case "esc":
-		return m, tea.Quit // cancel the whole wizard
-	case "tab":
-		return m.nextStep()
+		// Back to the launcher menu (App intercepts backMsg); standalone quits.
+		return m, backCmd()
+	case "enter":
+		return m.advance()
 	case "shift+tab":
-		return m.prevStep()
+		if m.step > stepSettings {
+			m.step--
+		}
+		return m, nil
+	case "up":
+		m.moveCursor(-1)
+		return m, nil
+	case "down":
+		m.moveCursor(+1)
+		return m, nil
 	}
+	// Field-specific edits on the focused row.
 	switch m.step {
 	case stepSettings:
-		return m.handleSettingsKey(msg)
-	case stepImage:
-		return m.handleListKey(msg, len(m.images), &m.iCursor)
+		return m.editSettings(msg)
 	case stepSecrets:
-		return m.handleSecretsKey(msg)
-	case stepFlash:
-		return m.handleListKey(msg, len(m.devices)+1, &m.fCursor) // +1 for "skip"
-	case stepReview:
-		if msg.String() == "enter" {
-			m.Confirmed = true
-			return m, tea.Quit
-		}
+		return m.editSecret(msg)
 	}
 	return m, nil
 }
 
-// handleEditKey edits the focused text field (settings or secret).
-func (m BuildFormModel) handleEditKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
-		m.editing, m.buf, m.sErr = false, "", ""
-		return m, nil
-	case "enter":
-		return m.commitEdit()
-	case "backspace":
-		if m.buf != "" {
-			m.buf = m.buf[:len(m.buf)-1]
-		}
-		return m, nil
-	default:
-		if msg.Type == tea.KeyRunes {
-			m.buf += string(msg.Runes)
-		}
-		return m, nil
-	}
-}
-
-// commitEdit validates + stores the edit buffer back into settings/secrets.
-func (m BuildFormModel) commitEdit() (tea.Model, tea.Cmd) {
-	if m.step == stepSecrets {
-		m.secrets[m.secCursor].value = m.buf
-		m.editing, m.buf = false, ""
-		return m, nil
-	}
-	f := m.visible[m.sCursor]
-	v := strings.TrimSpace(m.buf)
-	if f.valid != nil {
-		if e := f.valid(v); e != "" {
+// advance moves to the next step (Enter = Continue), validating settings first;
+// on the Review step it confirms the build.
+func (m BuildFormModel) advance() (tea.Model, tea.Cmd) {
+	switch m.step {
+	case stepSettings:
+		if e := m.validateSettings(); e != "" {
 			m.sErr = e
 			return m, nil
 		}
-	}
-	f.set(&m.settings, v)
-	m.editing, m.buf, m.sErr = false, "", ""
-	// An edit (e.g. FRITZ!Box host) can change which fields/secrets apply.
-	m.recomputeVisible()
-	m.rebuildSecrets()
-	return m, nil
-}
-
-func (m BuildFormModel) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if len(m.visible) == 0 {
-		return m, nil
-	}
-	f := m.visible[m.sCursor]
-	switch msg.String() {
-	case "up", "k":
-		m.sCursor = (m.sCursor - 1 + len(m.visible)) % len(m.visible)
-		m.sErr = ""
-	case "down", "j":
-		m.sCursor = (m.sCursor + 1) % len(m.visible)
-		m.sErr = ""
-	case "left", "right":
-		if f.kind == fChoice {
-			f.set(&m.settings, cycle(f.options, f.get(&m.settings), msg.String() == "right"))
-			m.recomputeVisible()
-			m.rebuildSecrets()
-		}
-	case "enter":
-		if f.kind == fText {
-			m.editing, m.buf, m.sErr = true, f.get(&m.settings), ""
-		}
-	}
-	return m, nil
-}
-
-func (m BuildFormModel) handleSecretsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if len(m.secrets) == 0 {
-		return m, nil
-	}
-	switch msg.String() {
-	case "up", "k":
-		m.secCursor = (m.secCursor - 1 + len(m.secrets)) % len(m.secrets)
-	case "down", "j":
-		m.secCursor = (m.secCursor + 1) % len(m.secrets)
-	case "enter":
-		m.editing, m.buf = true, m.secrets[m.secCursor].value
-	}
-	return m, nil
-}
-
-// handleListKey moves a cursor over n items (used for image + flash lists).
-func (m BuildFormModel) handleListKey(msg tea.KeyMsg, n int, cursor *int) (tea.Model, tea.Cmd) {
-	if n == 0 {
-		return m, nil
-	}
-	switch msg.String() {
-	case "up", "k":
-		*cursor = (*cursor - 1 + n) % n
-	case "down", "j":
-		*cursor = (*cursor + 1) % n
-	}
-	return m, nil
-}
-
-// nextStep advances the wizard, running per-step side effects + validation.
-func (m BuildFormModel) nextStep() (tea.Model, tea.Cmd) {
-	switch m.step {
-	case stepSettings:
-		// Block leaving settings with an invalid value on the focused field.
 		m.rebuildSecrets()
 		m.step = stepImage
 	case stepImage:
@@ -185,16 +111,85 @@ func (m BuildFormModel) nextStep() (tea.Model, tea.Cmd) {
 		m.step = stepReview
 	case stepReview:
 		m.Confirmed = true
-		return m, tea.Quit
+		plan := m.Plan()
+		return m, func() tea.Msg { return buildConfirmedMsg{plan: plan} }
 	}
 	return m, nil
 }
 
-func (m BuildFormModel) prevStep() (tea.Model, tea.Cmd) {
-	if m.step > stepSettings {
-		m.step--
+// moveCursor moves the focus within the current step's list.
+func (m *BuildFormModel) moveCursor(d int) {
+	switch m.step {
+	case stepSettings:
+		if n := len(m.visible); n > 0 {
+			m.sCursor = (m.sCursor + d + n) % n
+			m.sErr = ""
+		}
+	case stepImage:
+		if n := len(m.images); n > 0 {
+			m.iCursor = (m.iCursor + d + n) % n
+		}
+	case stepSecrets:
+		if n := len(m.secrets); n > 0 {
+			m.secCursor = (m.secCursor + d + n) % n
+		}
+	case stepFlash:
+		n := len(m.devices) + 1 // +1 for "skip"
+		m.fCursor = (m.fCursor + d + n) % n
+	}
+}
+
+// editSettings edits the focused settings field live: ←/→ cycles a choice,
+// runes/backspace edit text.
+func (m BuildFormModel) editSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.visible) == 0 {
+		return m, nil
+	}
+	f := m.visible[m.sCursor]
+	switch {
+	case f.kind == fChoice && (msg.String() == "left" || msg.String() == "right"):
+		f.set(&m.settings, cycle(f.options, f.get(&m.settings), msg.String() == "right"))
+		// A choice change (email on/off) can reveal/hide other fields + secrets.
+		m.recomputeVisible()
+		m.rebuildSecrets()
+	case f.kind == fText && msg.String() == "backspace":
+		v := f.get(&m.settings)
+		if v != "" {
+			f.set(&m.settings, v[:len(v)-1])
+			m.recomputeVisible() // clearing FRITZ!Box host hides its username
+		}
+	case f.kind == fText && msg.Type == tea.KeyRunes:
+		f.set(&m.settings, f.get(&m.settings)+string(msg.Runes))
+		m.recomputeVisible()
 	}
 	return m, nil
+}
+
+func (m BuildFormModel) editSecret(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.secrets) == 0 {
+		return m, nil
+	}
+	switch {
+	case msg.String() == "backspace":
+		if v := m.secrets[m.secCursor].value; v != "" {
+			m.secrets[m.secCursor].value = v[:len(v)-1]
+		}
+	case msg.Type == tea.KeyRunes:
+		m.secrets[m.secCursor].value += string(msg.Runes)
+	}
+	return m, nil
+}
+
+// validateSettings returns the first field error (or "").
+func (m BuildFormModel) validateSettings() string {
+	for _, f := range m.visible {
+		if f.valid != nil {
+			if e := f.valid(strings.TrimSpace(f.get(&m.settings))); e != "" {
+				return f.label + ": " + e
+			}
+		}
+	}
+	return ""
 }
 
 func (m BuildFormModel) loadDevicesCmd() tea.Cmd {
@@ -205,7 +200,8 @@ func (m BuildFormModel) loadDevicesCmd() tea.Cmd {
 	}
 }
 
-// View renders the current step.
+// View renders the current step with a consistent header, body, Continue
+// button, and key legend.
 func (m BuildFormModel) View() string {
 	width := m.width
 	if width <= 0 {
@@ -228,7 +224,14 @@ func (m BuildFormModel) View() string {
 		m.viewReview(&b)
 	}
 
-	b.WriteString("\n" + footerStyle.Render(m.footer()))
+	// The Continue button makes "what advances the wizard" visible — Enter
+	// activates it (tab is not required / not the only way).
+	label := "Continue ▸"
+	if m.step == stepReview {
+		label = "Build ▸"
+	}
+	b.WriteString("\n" + contStyle.Render(label) + contIdle.Render("  (Enter)") + "\n")
+	b.WriteString(footerStyle.Render(m.legend()))
 	return frame(b.String(), m.width, m.height)
 }
 
@@ -245,33 +248,41 @@ func (m BuildFormModel) stepCrumb() string {
 	return strings.Join(parts, " › ")
 }
 
-func (m BuildFormModel) footer() string {
-	if m.editing {
-		return "type to edit · enter save · esc cancel"
-	}
+func (m BuildFormModel) legend() string {
+	base := "↑/↓ move · enter continue · shift+tab back · esc menu"
 	switch m.step {
-	case stepReview:
-		return "enter build · shift+tab back · esc cancel"
 	case stepSettings:
-		return "↑/↓ move · ←/→ choose · enter edit · tab next · esc cancel"
+		return "↑/↓ move · ←/→ change choice · type to edit · enter continue · esc menu"
 	default:
-		return "↑/↓ move · tab next · shift+tab back · esc cancel"
+		return base
 	}
+}
+
+// fieldRowText renders "Label  [value]" with the value in an input box, so it's
+// clear the label is static and only the value is editable. Focused rows get a
+// caret + highlight.
+func renderField(label, value string, focused, choice bool) string {
+	ls, is := labelStyle, inputStyle
+	if focused {
+		ls, is = labelFocused, inputFocused
+	}
+	box := value
+	if focused && !choice {
+		box = value + "▌"
+	}
+	if choice {
+		box = "‹ " + value + " ›"
+	}
+	cursor := "  "
+	if focused {
+		cursor = "❯ "
+	}
+	return cursor + ls.Render(fmt.Sprintf("%-22s", label)) + is.Render(" "+box+" ")
 }
 
 func (m BuildFormModel) viewSettings(b *strings.Builder) {
 	for i, f := range m.visible {
-		val := f.get(&m.settings)
-		if m.editing && i == m.sCursor {
-			b.WriteString(cfgEditingStyle.Render(f.label+": "+m.buf+"▌") + "\n")
-			continue
-		}
-		rendered := f.label + ": " + valueText(val)
-		if i == m.sCursor {
-			b.WriteString(selectedStyle.Render("❯ "+f.label+": ") + valueText(val) + "\n")
-		} else {
-			b.WriteString(normalStyle.Render("  "+rendered) + "\n")
-		}
+		b.WriteString(renderField(f.label, f.get(&m.settings), i == m.sCursor, f.kind == fChoice) + "\n")
 	}
 	if m.sCursor < len(m.visible) {
 		b.WriteString("\n" + helpStyle.Render(m.visible[m.sCursor].help) + "\n")
@@ -290,59 +301,53 @@ func (m BuildFormModel) viewImage(b *strings.Builder) {
 		b.WriteString(detailStyle.Render("Loading available images…") + "\n")
 		return
 	}
-	b.WriteString(phaseStyle.Render("Pick the Fedora CoreOS image to build from:") + "\n\n")
+	b.WriteString(phaseStyle.Render("Choose the Fedora CoreOS image (↑/↓), then Enter:") + "\n\n")
 	for i, c := range m.images {
-		line := "  " + c.Label
 		if i == m.iCursor {
-			line = selectedStyle.Render("❯ " + c.Label)
+			b.WriteString(selectedStyle.Render("❯ "+c.Label) + cfgOKStyle.Render("  ● will be used") + "\n")
+		} else {
+			b.WriteString(normalStyle.Render("  "+c.Label) + "\n")
 		}
-		b.WriteString(line + "\n")
 	}
 }
 
 func (m BuildFormModel) viewSecrets(b *strings.Builder) {
 	if len(m.secrets) == 0 {
-		b.WriteString(detailStyle.Render("No external passwords needed — press tab to continue.") + "\n")
+		b.WriteString(detailStyle.Render("No external passwords needed — press Enter to continue.") + "\n")
 		return
 	}
 	b.WriteString(phaseStyle.Render("External account passwords ServiceBay can't generate:") + "\n\n")
 	for i, sr := range m.secrets {
-		masked := strings.Repeat("•", len(sr.value))
-		if m.editing && i == m.secCursor {
-			b.WriteString(cfgEditingStyle.Render(sr.envLabel+": "+masked+"▌") + "\n")
-			continue
-		}
-		row := sr.envLabel + ": " + valueText(masked)
-		if i == m.secCursor {
-			b.WriteString(selectedStyle.Render("❯ "+sr.envLabel+": ") + valueText(masked) + "\n")
-		} else {
-			b.WriteString(normalStyle.Render("  "+row) + "\n")
-		}
+		b.WriteString(renderField(sr.envLabel, strings.Repeat("•", len(sr.value)), i == m.secCursor, false) + "\n")
 	}
 }
 
 func (m BuildFormModel) viewFlash(b *strings.Builder) {
-	b.WriteString(phaseStyle.Render("Write the baked ISO to a USB stick? (chosen at Review)") + "\n\n")
-	skip := "  Skip — don't write to USB"
-	if m.fCursor == 0 {
-		skip = selectedStyle.Render("❯ Skip — don't write to USB")
+	b.WriteString(phaseStyle.Render("Write the baked ISO to a USB stick? (↑/↓ choose, Enter continue)") + "\n\n")
+	rows := append([]string{"Skip — don't write to USB"}, deviceLabels(m.devices)...)
+	for i, label := range rows {
+		if i == m.fCursor {
+			b.WriteString(selectedStyle.Render("❯ "+label) + "\n")
+		} else {
+			b.WriteString(normalStyle.Render("  "+label) + "\n")
+		}
 	}
-	b.WriteString(skip + "\n")
 	if m.devErr != "" {
 		b.WriteString(detailStyle.Render(cfgEmptyStyle.Render("(USB enumeration unavailable: "+m.devErr+")")) + "\n")
 	}
-	for i, d := range m.devices {
-		line := "  " + d.Label()
-		if m.fCursor == i+1 {
-			line = selectedStyle.Render("❯ " + d.Label())
-		}
-		b.WriteString(line + "\n")
+}
+
+func deviceLabels(devs []usb.Device) []string {
+	out := make([]string, len(devs))
+	for i, d := range devs {
+		out[i] = d.Label()
 	}
+	return out
 }
 
 func (m BuildFormModel) viewReview(b *strings.Builder) {
 	s := m.settings
-	b.WriteString(phaseStyle.Render("Review — press enter to build.") + "\n\n")
+	b.WriteString(phaseStyle.Render("Review — press Enter to build.") + "\n\n")
 	row := func(k, v string) { b.WriteString(normalStyle.Render(fmt.Sprintf("  %-20s %s", k+":", v)) + "\n") }
 	row("Server", s.ServerName)
 	row("Network", s.StaticIP+"/"+s.StaticPrefix+" via "+s.NetInterface)

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -35,31 +35,55 @@ func detect(ctx context.Context) (bool, phase.BoxStatus) {
 	return probes.ISOBuilt(), probes.BoxStatus(ctx)
 }
 
-// runBuild runs the native ISO-build wizard (#1233): a full-screen Bubble Tea
-// form gathers a build Plan, then buildflow.Execute runs the operations in the
-// normal terminal (the bake streams output and the USB flash needs sudo + a
-// real TTY, so they run after the alt-screen form exits). Build-host tools
-// (butane, coreos-installer, openssl, ssh-keygen) must be on PATH.
+// buildConfig assembles the build form's seeded settings + IO deps, shared by
+// the in-app build form (menu BuildISO) and the standalone runBuild path
+// (Express + the `build` subcommand).
+func buildConfig() ui.BuildConfig {
+	buildDir := probes.BuildDir()
+	saved, _ := build.Load(filepath.Join(buildDir, "install-settings.env"))
+	return ui.BuildConfig{
+		Saved: buildflow.WithDefaults(saved),
+		Deps: ui.BuildDeps{
+			Images: func() ([]iso.Choice, int) {
+				host := iso.HostArch()
+				local := iso.ListLocalISOs(buildflow.ISOSearchDirs(buildDir))
+				remote := iso.FetchAllStreams(context.Background())
+				ch := iso.BuildChoices(local, remote, host)
+				return ch, iso.DefaultChoiceIndex(ch, host)
+			},
+			USB: usb.Enumerate,
+		},
+	}
+}
+
+// runExecute runs a confirmed build Plan in the normal terminal: the bake
+// streams output and the USB flash needs sudo + a real TTY, so this runs after
+// any alt-screen program has exited.
+func runExecute(plan buildflow.Plan) int {
+	if missing := buildflow.MissingTools(); len(missing) > 0 {
+		fmt.Fprintf(os.Stderr, "Cannot build an ISO — missing build-host tools: %v\n", missing)
+		fmt.Fprintln(os.Stderr, "Install them and retry (Fedora: sudo dnf install butane coreos-installer openssl openssh).")
+		return 2
+	}
+	if err := buildflow.Execute(plan, buildflow.Options{BuildDir: probes.BuildDir(), Deps: buildflow.DefaultDeps()},
+		func(f string, a ...any) { fmt.Printf(f, a...) }); err != nil {
+		fmt.Fprintln(os.Stderr, "build failed:", err)
+		return 1
+	}
+	return 0
+}
+
+// runBuild runs the build wizard standalone (the `build` subcommand + Express):
+// the full-screen form gathers a Plan, then runExecute runs it. The menu's
+// BuildISO action instead hosts the form in-app so esc returns to the menu.
 func runBuild() int {
 	if missing := buildflow.MissingTools(); len(missing) > 0 {
 		fmt.Fprintf(os.Stderr, "Cannot build an ISO — missing build-host tools: %v\n", missing)
 		fmt.Fprintln(os.Stderr, "Install them and retry (Fedora: sudo dnf install butane coreos-installer openssl openssh).")
 		return 2
 	}
-	buildDir := probes.BuildDir()
-	saved, _ := build.Load(filepath.Join(buildDir, "install-settings.env"))
-	deps := ui.BuildDeps{
-		Images: func() ([]iso.Choice, int) {
-			host := iso.HostArch()
-			local := iso.ListLocalISOs(buildflow.ISOSearchDirs(buildDir))
-			remote := iso.FetchAllStreams(context.Background())
-			ch := iso.BuildChoices(local, remote, host)
-			return ch, iso.DefaultChoiceIndex(ch, host)
-		},
-		USB: usb.Enumerate,
-	}
-
-	final, err := tea.NewProgram(ui.NewBuildForm(buildflow.WithDefaults(saved), deps), tea.WithAltScreen()).Run()
+	cfg := buildConfig()
+	final, err := tea.NewProgram(ui.NewBuildForm(cfg.Saved, cfg.Deps), tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -68,13 +92,7 @@ func runBuild() int {
 	if !ok || !bf.Confirmed {
 		return 0 // operator cancelled the wizard
 	}
-
-	if err := buildflow.Execute(bf.Plan(), buildflow.Options{BuildDir: buildDir, Deps: buildflow.DefaultDeps()},
-		func(f string, a ...any) { fmt.Printf(f, a...) }); err != nil {
-		fmt.Fprintln(os.Stderr, "build failed:", err)
-		return 1
-	}
-	return 0
+	return runExecute(bf.Plan())
 }
 
 // runWatch opens the native install-watch dashboard against the resolved box
@@ -219,7 +237,7 @@ func main() {
 	// that quit the app, because build is an interactive stdin wizard and the
 	// rest are natural one-shots.
 	t := probes.ResolveTarget()
-	app := ui.NewApp(detect, t.Host, t.Port, probes.ResolveToken(t.Host), probes.SaveToken)
+	app := ui.NewApp(detect, t.Host, t.Port, probes.ResolveToken(t.Host), probes.SaveToken, buildConfig())
 	final, err := tea.NewProgram(app, tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -230,12 +248,14 @@ func main() {
 		return
 	}
 
-	// Only the bootstrap legs hand off here; watch + open-box now run inside the
-	// App and return to the menu.
-	switch res.Chosen {
-	case phase.Express:
+	// Watch / edit-config / install / backups / the build form all run inside
+	// the App and return to the menu. Only these need a post-exit handoff: the
+	// build form's confirmed Plan (bake + sudo flash run in the normal
+	// terminal), and Express's guided sequence.
+	switch {
+	case res.BuildPlan != nil:
+		os.Exit(runExecute(*res.BuildPlan))
+	case res.Chosen == phase.Express:
 		os.Exit(runExpress())
-	case phase.BuildISO:
-		os.Exit(runBuild())
 	}
 }


### PR DESCRIPTION
## What
Reworks the build wizard around **one coherent interaction model** and hosts it **in-app**, addressing operator feedback that it felt "alien":

| Complaint | Fix |
|---|---|
| esc quits the whole program to bash | Form runs **in-app** now; esc → back to the launcher menu. On confirm it hands the Plan to the entrypoint to run the bake + `sudo dd` flash. |
| Editing selected whole lines / let you edit caption+value | Label is static; only the **value box** is editable (rendered as a distinct input). |
| "Y/N with arrows but everything else with enter" — incoherent | **One model:** ↑/↓ move · ←/→ change a choice · **type** to edit the focused text field live · **Enter = Continue** · shift+tab = back · esc = menu. |
| Tab to advance is easy to miss | Visible **`[ Continue ▸ ]` button** (Enter), plus a per-step key legend. |
| Image list — "can't do anything" | ↑/↓ highlights, the highlight is marked **`● will be used`**, Enter continues. |

Express + the `build` subcommand keep the standalone `runBuild` path (the form's `backMsg`/`buildConfirmedMsg` work both in-app and standalone, same pattern as the panels).

## Risk
Medium (interaction rewrite) but tested: live-edit + validation-blocks-advance, choice cycling, in-app routing, confirm-hands-off-plan, esc-cancel. `gofmt`/`vet`/`go test ./...` clean.

Part of #1233 / #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)