### PR TITLE
fix(tui): accept mixed-case hostnames + in-field caret editing

### DIFF
--- a/tools/sb-tui/internal/ui/buildform.go
+++ b/tools/sb-tui/internal/ui/buildform.go
@@ -24,7 +24,10 @@ var (
 	stepStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Bold(true)
 )
 
-var formHostnameRE = regexp.MustCompile(`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
+// RFC 1123 hostname: letters (either case), digits, hyphens; 1–63 chars; starts
+// with a letter, no trailing hyphen. Case-insensitive per the RFC — mixed case
+// like "atHome-Server" is valid (and is what real boxes run).
+var formHostnameRE = regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$`)
 
 type buildStep int
 
@@ -59,11 +62,11 @@ type sfield struct {
 // settingsFields is the ordered, documented field set — the "real config
 // screen" the operator asked for. Conditionals hide irrelevant fields.
 var settingsFields = []sfield{
-	{label: "Server name", help: "Hostname for the box. Lowercase letters/digits/hyphens, 1–63 chars, must start with a letter.",
+	{label: "Server name", help: "Hostname for the box. Letters/digits/hyphens, 1–63 chars, must start with a letter.",
 		get: func(s *build.Settings) string { return s.ServerName }, set: func(s *build.Settings, v string) { s.ServerName = v },
 		valid: func(v string) string {
 			if !formHostnameRE.MatchString(v) {
-				return "invalid hostname (lowercase, start with a letter, no trailing hyphen)"
+				return "must start with a letter; only letters, digits, hyphens; no trailing hyphen"
 			}
 			return ""
 		}},
@@ -154,6 +157,7 @@ type BuildFormModel struct {
 	// text fields take typed runes, choice fields cycle with ←/→.
 	visible []sfield
 	sCursor int
+	tCursor int // caret position (rune index) within the focused text field
 	sErr    string
 
 	// image step
@@ -199,7 +203,24 @@ type buildConfirmedMsg struct{ plan buildflow.Plan }
 func NewBuildForm(saved build.Settings, deps BuildDeps) BuildFormModel {
 	m := BuildFormModel{deps: deps, settings: saved, step: stepSettings}
 	m.recomputeVisible()
+	m.tCursor = m.focusedRuneLen() // caret at end of the first field
 	return m
+}
+
+// focusedRuneLen is the rune length of the currently-focused editable value
+// (settings text field or secret), used to place/clamp the edit caret.
+func (m BuildFormModel) focusedRuneLen() int {
+	switch m.step {
+	case stepSettings:
+		if m.sCursor < len(m.visible) {
+			return len([]rune(m.visible[m.sCursor].get(&m.settings)))
+		}
+	case stepSecrets:
+		if m.secCursor < len(m.secrets) {
+			return len([]rune(m.secrets[m.secCursor].value))
+		}
+	}
+	return 0
 }
 
 func (m *BuildFormModel) recomputeVisible() {

--- a/tools/sb-tui/internal/ui/buildform_test.go
+++ b/tools/sb-tui/internal/ui/buildform_test.go
@@ -143,6 +143,46 @@ func TestEscCancels(t *testing.T) {
 	}
 }
 
+// TestHostnameAllowsMixedCase: RFC-1123 mixed-case hostnames are valid.
+func TestHostnameAllowsMixedCase(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "atHome-Server"}, noDeps())
+	if e := m.validateSettings(); e != "" {
+		t.Errorf("mixed-case hostname rejected: %q", e)
+	}
+	bad := NewBuildForm(build.Settings{ServerName: "-bad"}, noDeps())
+	if bad.validateSettings() == "" {
+		t.Error("leading-hyphen hostname should still be rejected")
+	}
+}
+
+// TestInFieldCursorEdit: ←/→ move the caret and edits happen at it.
+func TestInFieldCursorEdit(t *testing.T) {
+	m := NewBuildForm(build.Settings{ServerName: "abc"}, noDeps())
+	// Focus is Server name, caret parked at end (3).
+	if m.tCursor != 3 {
+		t.Fatalf("initial caret = %d, want 3", m.tCursor)
+	}
+	// Move left twice → between 'a' and 'b', insert 'X' → "aXbc".
+	mi, _ := m.Update(namedKey(tea.KeyLeft))
+	m = mi.(BuildFormModel)
+	mi, _ = m.Update(namedKey(tea.KeyLeft))
+	m = mi.(BuildFormModel)
+	if m.tCursor != 1 {
+		t.Fatalf("caret after 2×left = %d, want 1", m.tCursor)
+	}
+	mi, _ = m.Update(runeKey('X'))
+	m = mi.(BuildFormModel)
+	if m.settings.ServerName != "aXbc" {
+		t.Errorf("mid-field insert = %q, want aXbc", m.settings.ServerName)
+	}
+	// Backspace deletes before the caret (now at index 2) → "abc".
+	mi, _ = m.Update(namedKey(tea.KeyBackspace))
+	m = mi.(BuildFormModel)
+	if m.settings.ServerName != "abc" {
+		t.Errorf("backspace at caret = %q, want abc", m.settings.ServerName)
+	}
+}
+
 // TestSettingsViewShowsHelp: the focused field's help text renders.
 func TestSettingsViewShowsHelp(t *testing.T) {
 	m := NewBuildForm(build.Settings{ServerName: "box"}, noDeps())

--- a/tools/sb-tui/internal/ui/buildform_update.go
+++ b/tools/sb-tui/internal/ui/buildform_update.go
@@ -70,6 +70,7 @@ func (m BuildFormModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "shift+tab":
 		if m.step > stepSettings {
 			m.step--
+			m.tCursor = m.focusedRuneLen()
 		}
 		return m, nil
 	case "up":
@@ -114,10 +115,12 @@ func (m BuildFormModel) advance() (tea.Model, tea.Cmd) {
 		plan := m.Plan()
 		return m, func() tea.Msg { return buildConfirmedMsg{plan: plan} }
 	}
+	m.tCursor = m.focusedRuneLen() // park caret at end of the new step's field
 	return m, nil
 }
 
-// moveCursor moves the focus within the current step's list.
+// moveCursor moves the focus within the current step's list, and parks the
+// edit caret at the end of the newly-focused editable value.
 func (m *BuildFormModel) moveCursor(d int) {
 	switch m.step {
 	case stepSettings:
@@ -137,30 +140,65 @@ func (m *BuildFormModel) moveCursor(d int) {
 		n := len(m.devices) + 1 // +1 for "skip"
 		m.fCursor = (m.fCursor + d + n) % n
 	}
+	m.tCursor = m.focusedRuneLen()
 }
 
-// editSettings edits the focused settings field live: ←/→ cycles a choice,
-// runes/backspace edit text.
+// editText applies an in-field edit (←/→ move caret, runes insert, backspace
+// delete) to a value at the caret, returning the new value. The caret is
+// updated in place. Rune-based so it's safe for any input.
+func (m *BuildFormModel) editText(msg tea.KeyMsg, value string) (string, bool) {
+	r := []rune(value)
+	if m.tCursor > len(r) {
+		m.tCursor = len(r)
+	}
+	switch msg.String() {
+	case "left":
+		if m.tCursor > 0 {
+			m.tCursor--
+		}
+	case "right":
+		if m.tCursor < len(r) {
+			m.tCursor++
+		}
+	case "home":
+		m.tCursor = 0
+	case "end":
+		m.tCursor = len(r)
+	case "backspace":
+		if m.tCursor > 0 {
+			r = append(r[:m.tCursor-1], r[m.tCursor:]...)
+			m.tCursor--
+			return string(r), true
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			ins := msg.Runes
+			r = append(r[:m.tCursor], append(append([]rune{}, ins...), r[m.tCursor:]...)...)
+			m.tCursor += len(ins)
+			return string(r), true
+		}
+	}
+	return value, false
+}
+
+// editSettings edits the focused settings field live: ←/→ cycles a choice; for
+// text fields ←/→ moves the caret and runes/backspace edit at it.
 func (m BuildFormModel) editSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if len(m.visible) == 0 {
 		return m, nil
 	}
 	f := m.visible[m.sCursor]
-	switch {
-	case f.kind == fChoice && (msg.String() == "left" || msg.String() == "right"):
-		f.set(&m.settings, cycle(f.options, f.get(&m.settings), msg.String() == "right"))
-		// A choice change (email on/off) can reveal/hide other fields + secrets.
-		m.recomputeVisible()
-		m.rebuildSecrets()
-	case f.kind == fText && msg.String() == "backspace":
-		v := f.get(&m.settings)
-		if v != "" {
-			f.set(&m.settings, v[:len(v)-1])
-			m.recomputeVisible() // clearing FRITZ!Box host hides its username
+	if f.kind == fChoice {
+		if msg.String() == "left" || msg.String() == "right" {
+			f.set(&m.settings, cycle(f.options, f.get(&m.settings), msg.String() == "right"))
+			m.recomputeVisible() // email on/off reveals/hides fields
+			m.rebuildSecrets()
 		}
-	case f.kind == fText && msg.Type == tea.KeyRunes:
-		f.set(&m.settings, f.get(&m.settings)+string(msg.Runes))
-		m.recomputeVisible()
+		return m, nil
+	}
+	if v, changed := m.editText(msg, f.get(&m.settings)); changed {
+		f.set(&m.settings, v)
+		m.recomputeVisible() // clearing FRITZ!Box host hides its username
 	}
 	return m, nil
 }
@@ -169,13 +207,8 @@ func (m BuildFormModel) editSecret(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if len(m.secrets) == 0 {
 		return m, nil
 	}
-	switch {
-	case msg.String() == "backspace":
-		if v := m.secrets[m.secCursor].value; v != "" {
-			m.secrets[m.secCursor].value = v[:len(v)-1]
-		}
-	case msg.Type == tea.KeyRunes:
-		m.secrets[m.secCursor].value += string(msg.Runes)
+	if v, changed := m.editText(msg, m.secrets[m.secCursor].value); changed {
+		m.secrets[m.secCursor].value = v
 	}
 	return m, nil
 }
@@ -261,17 +294,25 @@ func (m BuildFormModel) legend() string {
 // fieldRowText renders "Label  [value]" with the value in an input box, so it's
 // clear the label is static and only the value is editable. Focused rows get a
 // caret + highlight.
-func renderField(label, value string, focused, choice bool) string {
+func renderField(label, value string, focused, choice bool, caret int) string {
 	ls, is := labelStyle, inputStyle
 	if focused {
 		ls, is = labelFocused, inputFocused
 	}
 	box := value
-	if focused && !choice {
-		box = value + "▌"
-	}
-	if choice {
+	switch {
+	case choice:
 		box = "‹ " + value + " ›"
+	case focused:
+		// Block caret at the edit position, so ←/→ visibly moves within the text.
+		r := []rune(value)
+		if caret < 0 {
+			caret = 0
+		}
+		if caret > len(r) {
+			caret = len(r)
+		}
+		box = string(r[:caret]) + "▌" + string(r[caret:])
 	}
 	cursor := "  "
 	if focused {
@@ -282,7 +323,7 @@ func renderField(label, value string, focused, choice bool) string {
 
 func (m BuildFormModel) viewSettings(b *strings.Builder) {
 	for i, f := range m.visible {
-		b.WriteString(renderField(f.label, f.get(&m.settings), i == m.sCursor, f.kind == fChoice) + "\n")
+		b.WriteString(renderField(f.label, f.get(&m.settings), i == m.sCursor, f.kind == fChoice, m.tCursor) + "\n")
 	}
 	if m.sCursor < len(m.visible) {
 		b.WriteString("\n" + helpStyle.Render(m.visible[m.sCursor].help) + "\n")
@@ -318,7 +359,8 @@ func (m BuildFormModel) viewSecrets(b *strings.Builder) {
 	}
 	b.WriteString(phaseStyle.Render("External account passwords ServiceBay can't generate:") + "\n\n")
 	for i, sr := range m.secrets {
-		b.WriteString(renderField(sr.envLabel, strings.Repeat("•", len(sr.value)), i == m.secCursor, false) + "\n")
+		masked := strings.Repeat("•", len([]rune(sr.value)))
+		b.WriteString(renderField(sr.envLabel, masked, i == m.secCursor, false, m.tCursor) + "\n")
 	}
 }
 


### PR DESCRIPTION
## What
Two build-form fixes from operator testing:

1. **`atHome-Server` was wrongly rejected.** The server-name validator was lowercase-only; RFC-1123 hostnames are case-insensitive and real boxes run mixed case. Now accepts letters of either case (still must start with a letter, no trailing hyphen). The saved value no longer trips validation.
2. **Couldn't edit within a field.** Text fields now have a moving caret: **←/→** move within the value (home/end too), and typing/backspace **insert/delete at the caret** instead of only at the end. Rune-based (input-safe); the caret parks at the end when focus or step changes. Choice fields still use ←/→ to cycle.

## Risk
Low; Go-only form logic. `gofmt`/`vet`/`go test ./...` clean; added tests for mixed-case acceptance and mid-field insert/delete via the caret.

Part of #1233 / #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)