### PR TITLE
feat(tui): memorable host password + SSH-key guidance/generation

### DIFF
--- a/tools/sb-tui/internal/build/passphrase.go
+++ b/tools/sb-tui/internal/build/passphrase.go
@@ -1,0 +1,53 @@
+package build
+
+import (
+	"fmt"
+	"io"
+)
+
+// passphraseWords is a curated list of short, common, unambiguous lowercase
+// words (no look-alikes like l/1) for generating memorable passphrases. The
+// host-console password is something an operator may have to type at a physical
+// keyboard, so it favours typeability over maximum entropy. Four words from
+// this ~160-word list plus a 2-digit number is ~2^35 — fine for a LAN console
+// login, and far easier to type than a 48-char hex string.
+var passphraseWords = []string{
+	"able", "acid", "aged", "also", "area", "army", "atom", "aunt", "away", "baby",
+	"back", "ball", "band", "bank", "barn", "base", "bath", "bead", "beam", "bean",
+	"bear", "beat", "bell", "belt", "bird", "blue", "boat", "body", "bone", "book",
+	"boot", "boss", "bowl", "bulk", "bush", "cake", "calm", "camp", "cane", "card",
+	"cart", "cash", "cave", "cell", "chef", "chip", "city", "clay", "club", "coal",
+	"coat", "code", "coin", "cold", "comb", "cook", "cool", "cord", "corn", "crew",
+	"crop", "cube", "dawn", "deck", "deep", "deer", "desk", "dime", "dish", "dock",
+	"dome", "door", "dove", "drum", "duck", "dune", "dusk", "earl", "east", "easy",
+	"echo", "edge", "fair", "farm", "fawn", "fern", "film", "fire", "fish", "flag",
+	"foam", "fork", "fort", "frog", "fuel", "gate", "gear", "gift", "glow", "goat",
+	"gold", "good", "gulf", "hall", "hand", "hawk", "herb", "hill", "hive", "home",
+	"hood", "hope", "horn", "iron", "jade", "kelp", "kind", "king", "lake", "lamp",
+	"land", "lane", "leaf", "lion", "loft", "maze", "mild", "mint", "moon", "moss",
+	"nest", "node", "oak", "oats", "palm", "park", "peak", "pine", "pond", "pony",
+	"rain", "reef", "rice", "ring", "road", "rock", "rose", "ruby", "sage", "salt",
+	"sand", "seal", "ship", "snow", "sock", "song", "star", "stem", "tide", "tiger",
+	"vine", "wave", "wind", "wolf", "wood", "yard",
+}
+
+// Passphrase generates a memorable host-console password: four random words
+// from passphraseWords plus a 2-digit number, hyphen-joined (e.g.
+// "river-tiger-maple-stone-47"). It reads randomness from rnd (crypto/rand in
+// production), is pipeline-safe (only lowercase letters, digits, hyphens), and
+// is easy to type at a console.
+func Passphrase(rnd io.Reader) (string, error) {
+	const words = 4
+	buf := make([]byte, words+1)
+	if _, err := io.ReadFull(rnd, buf); err != nil {
+		return "", err
+	}
+	out := ""
+	for i := 0; i < words; i++ {
+		out += passphraseWords[int(buf[i])%len(passphraseWords)]
+		out += "-"
+	}
+	// Final segment: a 2-digit number 10–99 (never leading-zero, so it reads
+	// cleanly and is unambiguously two digits).
+	return fmt.Sprintf("%s%d", out, 10+int(buf[words])%90), nil
+}

--- a/tools/sb-tui/internal/build/passphrase_test.go
+++ b/tools/sb-tui/internal/build/passphrase_test.go
@@ -1,0 +1,26 @@
+package build
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPassphraseShape(t *testing.T) {
+	p, err := Passphrase(bytes.NewReader([]byte{3, 9, 40, 77, 55}))
+	if err != nil {
+		t.Fatalf("Passphrase: %v", err)
+	}
+	parts := strings.Split(p, "-")
+	if len(parts) != 5 {
+		t.Fatalf("want 4 words + a number (5 hyphen parts), got %q", p)
+	}
+	n, err := strconv.Atoi(parts[4])
+	if err != nil || n < 10 || n > 99 {
+		t.Errorf("trailing segment %q is not a 2-digit number", parts[4])
+	}
+	if pipelineUnsafe(p) || p != strings.ToLower(p) {
+		t.Errorf("passphrase %q must be lowercase + pipeline-safe", p)
+	}
+}

--- a/tools/sb-tui/internal/build/secrets.go
+++ b/tools/sb-tui/internal/build/secrets.go
@@ -69,20 +69,25 @@ func randHex(rnd io.Reader, n int) (string, error) {
 }
 
 // resolveSecret returns the pre-seeded value (validated) when present, else a
-// freshly generated hex secret flagged as generated. Ports secret_or_generate.
-func resolveSecret(preseed, name string, rnd io.Reader) (value string, generated bool, err error) {
+// freshly generated secret flagged as generated. gen produces the fresh value
+// (hex for the admin password; a memorable passphrase for the host console).
+// Ports secret_or_generate.
+func resolveSecret(preseed, name string, rnd io.Reader, gen func(io.Reader) (string, error)) (value string, generated bool, err error) {
 	if preseed != "" {
 		if pipelineUnsafe(preseed) {
 			return "", false, fmt.Errorf("pre-seeded %s contains characters that break the install pipeline (newline, quote, backslash, $ or backtick)", name)
 		}
 		return preseed, false, nil
 	}
-	v, err := randHex(rnd, secretHexBytes)
+	v, err := gen(rnd)
 	if err != nil {
 		return "", false, err
 	}
 	return v, true, nil
 }
+
+// hexSecret generates the 48-char hex admin password (openssl rand -hex 24).
+func hexSecret(rnd io.Reader) (string, error) { return randHex(rnd, secretHexBytes) }
 
 // GenerateSecrets resolves the three ServiceBay-owned bootstrap secrets for one
 // build run, reading randomness from rnd (callers pass crypto/rand.Reader;
@@ -94,10 +99,13 @@ func GenerateSecrets(in SecretInputs, rnd io.Reader) (Secrets, error) {
 	var s Secrets
 	var err error
 
-	if s.AdminPassword, s.AdminGenerated, err = resolveSecret(in.AdminPassword, "SERVICEBAY_ADMIN_PASSWORD", rnd); err != nil {
+	// Admin password stays a strong 48-char hex (used via password manager / the
+	// in-TUI sign-in paste). The host-console password is a memorable passphrase
+	// — it's the one an operator may type at a physical keyboard.
+	if s.AdminPassword, s.AdminGenerated, err = resolveSecret(in.AdminPassword, "SERVICEBAY_ADMIN_PASSWORD", rnd, hexSecret); err != nil {
 		return Secrets{}, err
 	}
-	if s.HostPassword, s.HostGenerated, err = resolveSecret(in.HostPassword, "HOST_PASSWORD", rnd); err != nil {
+	if s.HostPassword, s.HostGenerated, err = resolveSecret(in.HostPassword, "HOST_PASSWORD", rnd, Passphrase); err != nil {
 		return Secrets{}, err
 	}
 

--- a/tools/sb-tui/internal/build/secrets_test.go
+++ b/tools/sb-tui/internal/build/secrets_test.go
@@ -19,19 +19,24 @@ func seqBytes(n int) []byte {
 }
 
 func TestGenerateSecrets_AllGenerated(t *testing.T) {
-	seq := seqBytes(secretHexBytes*2 + tokenHexBytes)
+	const passphraseBytes = 5 // Passphrase consumes 4 word bytes + 1 number byte
+	seq := seqBytes(secretHexBytes + passphraseBytes + tokenHexBytes)
 	s, err := GenerateSecrets(SecretInputs{}, bytes.NewReader(seq))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	// Admin = strong hex; host = memorable passphrase; token = hex after both.
 	wantAdmin := hex.EncodeToString(seq[:secretHexBytes])
-	wantHost := hex.EncodeToString(seq[secretHexBytes : secretHexBytes*2])
-	wantToken := hex.EncodeToString(seq[secretHexBytes*2:])
+	wantHost, _ := Passphrase(bytes.NewReader(seq[secretHexBytes : secretHexBytes+passphraseBytes]))
+	wantToken := hex.EncodeToString(seq[secretHexBytes+passphraseBytes:])
 	if s.AdminPassword != wantAdmin || !s.AdminGenerated {
 		t.Errorf("admin = %q gen=%v, want %q gen=true", s.AdminPassword, s.AdminGenerated, wantAdmin)
 	}
 	if s.HostPassword != wantHost || !s.HostGenerated {
 		t.Errorf("host = %q gen=%v, want %q gen=true", s.HostPassword, s.HostGenerated, wantHost)
+	}
+	if !strings.Contains(s.HostPassword, "-") || strings.ToLower(s.HostPassword) != s.HostPassword {
+		t.Errorf("host password %q is not a memorable lowercase passphrase", s.HostPassword)
 	}
 	if s.BootstrapToken != wantToken || !s.BootstrapGenerated {
 		t.Errorf("token = %q gen=%v, want %q gen=true", s.BootstrapToken, s.BootstrapGenerated, wantToken)

--- a/tools/sb-tui/internal/ui/buildform.go
+++ b/tools/sb-tui/internal/ui/buildform.go
@@ -57,6 +57,7 @@ type sfield struct {
 	set     func(*build.Settings, string)
 	visible func(build.Settings) bool // nil → always
 	valid   func(string) string       // "" → ok, else error message
+	genSSH  bool                      // offer Ctrl+G to generate an SSH keypair
 }
 
 // settingsFields is the ordered, documented field set — the "real config
@@ -72,8 +73,9 @@ var settingsFields = []sfield{
 		}},
 	{label: "Host username", help: "Linux account created on the box for SSH/console login.",
 		get: func(s *build.Settings) string { return s.HostUser }, set: func(s *build.Settings, v string) { s.HostUser = v }},
-	{label: "SSH public key", help: "Authorized key for the host user. Paste a full ssh-ed25519/ssh-rsa public key.",
-		get: func(s *build.Settings) string { return s.SSHAuthorizedKey }, set: func(s *build.Settings, v string) { s.SSHAuthorizedKey = v }},
+	{label: "SSH public key", genSSH: true,
+		help: "Public key for SSH login to the box (ssh user@ip). Auto-filled from ~/.ssh/*.pub. No key? Press Ctrl+G to generate an ed25519 keypair into ~/.ssh/id_ed25519.",
+		get:  func(s *build.Settings) string { return s.SSHAuthorizedKey }, set: func(s *build.Settings, v string) { s.SSHAuthorizedKey = v }},
 	{label: "Network interface", help: "NIC the static IP binds to (e.g. eno1, enp1s0).",
 		get: func(s *build.Settings) string { return s.NetInterface }, set: func(s *build.Settings, v string) { s.NetInterface = v }},
 	{label: "Static IPv4", help: "The box's fixed LAN address.",
@@ -136,6 +138,9 @@ func yn(v string) string {
 type BuildDeps struct {
 	Images func() ([]iso.Choice, int) // available images + default index
 	USB    func() ([]usb.Device, error)
+	// GenerateSSHKey ensures a local SSH keypair exists and returns the public
+	// key (Ctrl+G on the SSH field). nil disables the generate option.
+	GenerateSSHKey func() (string, error)
 }
 
 // BuildConfig is what the App needs to open the build form in-app: the IO deps
@@ -192,6 +197,12 @@ type imagesLoadedMsg struct {
 type devicesLoadedMsg struct {
 	devices []usb.Device
 	err     error
+}
+
+// sshKeyGeneratedMsg carries the result of a Ctrl+G SSH-key generation.
+type sshKeyGeneratedMsg struct {
+	pub string
+	err error
 }
 
 // buildConfirmedMsg is emitted when the operator confirms the Review step. It

--- a/tools/sb-tui/internal/ui/buildform_test.go
+++ b/tools/sb-tui/internal/ui/buildform_test.go
@@ -183,6 +183,28 @@ func TestInFieldCursorEdit(t *testing.T) {
 	}
 }
 
+// TestSSHKeyGenerate: Ctrl+G on the SSH field runs GenerateSSHKey and fills the
+// field with the returned public key.
+func TestSSHKeyGenerate(t *testing.T) {
+	deps := noDeps()
+	deps.GenerateSSHKey = func() (string, error) { return "ssh-ed25519 AAAAGEN test@host", nil }
+	m := NewBuildForm(build.Settings{}, deps)
+	for m.visible[m.sCursor].label != "SSH public key" {
+		mi, _ := m.Update(namedKey(tea.KeyDown))
+		m = mi.(BuildFormModel)
+	}
+	mi, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = mi.(BuildFormModel)
+	if cmd == nil {
+		t.Fatal("ctrl+g on the SSH field should issue a generate command")
+	}
+	mi, _ = m.Update(cmd()) // deliver sshKeyGeneratedMsg
+	m = mi.(BuildFormModel)
+	if m.settings.SSHAuthorizedKey != "ssh-ed25519 AAAAGEN test@host" {
+		t.Errorf("generated key not stored: %q", m.settings.SSHAuthorizedKey)
+	}
+}
+
 // TestSettingsViewShowsHelp: the focused field's help text renders.
 func TestSettingsViewShowsHelp(t *testing.T) {
 	m := NewBuildForm(build.Settings{ServerName: "box"}, noDeps())

--- a/tools/sb-tui/internal/ui/buildform_update.go
+++ b/tools/sb-tui/internal/ui/buildform_update.go
@@ -45,6 +45,21 @@ func (m BuildFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.devErr = msg.err.Error()
 		}
 		return m, nil
+	case sshKeyGeneratedMsg:
+		if msg.err != nil {
+			m.sErr = "SSH key generation failed: " + msg.err.Error()
+			return m, nil
+		}
+		// Drop the generated public key into the SSH field.
+		for i, f := range m.visible {
+			if f.genSSH {
+				f.set(&m.settings, msg.pub)
+				m.sCursor = i
+				m.tCursor = m.focusedRuneLen()
+				m.sErr = ""
+			}
+		}
+		return m, nil
 	case buildConfirmedMsg:
 		// Standalone (`sb-tui build`): quit so the entrypoint reads Plan back.
 		// When hosted by App, App intercepts this first and never forwards it.
@@ -78,6 +93,18 @@ func (m BuildFormModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "down":
 		m.moveCursor(+1)
+		return m, nil
+	case "ctrl+g":
+		// Generate an SSH keypair when the focused field offers it.
+		if m.step == stepSettings && m.sCursor < len(m.visible) &&
+			m.visible[m.sCursor].genSSH && m.deps.GenerateSSHKey != nil {
+			gen := m.deps.GenerateSSHKey
+			m.sErr = "generating SSH key…"
+			return m, func() tea.Msg {
+				pub, err := gen()
+				return sshKeyGeneratedMsg{pub: pub, err: err}
+			}
+		}
 		return m, nil
 	}
 	// Field-specific edits on the focused row.
@@ -285,7 +312,11 @@ func (m BuildFormModel) legend() string {
 	base := "↑/↓ move · enter continue · shift+tab back · esc menu"
 	switch m.step {
 	case stepSettings:
-		return "↑/↓ move · ←/→ change choice · type to edit · enter continue · esc menu"
+		s := "↑/↓ move · ←/→ change choice · type to edit · enter continue · esc menu"
+		if m.sCursor < len(m.visible) && m.visible[m.sCursor].genSSH {
+			s = "ctrl+g generate key · " + s
+		}
+		return s
 	default:
 		return base
 	}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -16,7 +16,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -51,9 +53,38 @@ func buildConfig() ui.BuildConfig {
 				ch := iso.BuildChoices(local, remote, host)
 				return ch, iso.DefaultChoiceIndex(ch, host)
 			},
-			USB: usb.Enumerate,
+			USB:            usb.Enumerate,
+			GenerateSSHKey: generateSSHKey,
 		},
 	}
+}
+
+// generateSSHKey returns the operator's SSH public key, generating an ed25519
+// keypair at ~/.ssh/id_ed25519 if none exists yet (Ctrl+G in the build form).
+// An existing key is reused, never overwritten.
+func generateSSHKey() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	priv := filepath.Join(sshDir, "id_ed25519")
+	pub := priv + ".pub"
+	if b, err := os.ReadFile(pub); err == nil {
+		return strings.TrimSpace(string(b)), nil // already have one — reuse
+	}
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		return "", err
+	}
+	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", priv, "-C", "servicebay")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out)))
+	}
+	b, err := os.ReadFile(pub)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
 }
 
 // runExecute runs a confirmed build Plan in the normal terminal: the bake


### PR DESCRIPTION
## What
Two build-form quality-of-life fixes:

1. **Memorable host-console password.** The host password is now a passphrase — four short words + a 2-digit number (e.g. `river-tiger-maple-stone-47`) — instead of a 48-char hex string. It's the credential an operator may type at a physical console, so it favours typeability; the **admin** password stays strong hex (used via password manager / the in-TUI sign-in). New `build.Passphrase` + a curated unambiguous wordlist.
2. **SSH key guidance + generation.** The SSH public-key field now explains what it's for and where keys live, and offers **Ctrl+G** to generate an `ed25519` keypair into `~/.ssh/id_ed25519` (reuses an existing key, never overwrites) and auto-fill the field. Wired via `BuildDeps.GenerateSSHKey` + `ssh-keygen` (already a required build tool).

## Risk
Low; Go-only. `gofmt`/`vet`/`go test ./...` clean; tests for passphrase shape/safety, the shifted secret stream, and the Ctrl+G generate flow.

Part of #1233 / #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)