### PR TITLE
feat(tui): after build, guide boot + watch the install (reinstall-aware)

### DIFF
--- a/tools/sb-tui/internal/ui/watch.go
+++ b/tools/sb-tui/internal/ui/watch.go
@@ -22,15 +22,29 @@ type WatchModel struct {
 	last       watch.Probe
 	width      int
 	now        time.Time
+	// requireReboot gates takeover on first observing the box go offline — for a
+	// REINSTALL, the box is currently up (old install) and we must wait for it to
+	// reboot into the installer before "the app is serving" means the new box.
+	requireReboot bool
 	// Takeover is set when the box's real app replaced the splash; the
 	// entrypoint reads it after the program exits to print the handoff banner.
 	Takeover bool
 }
 
-// NewWatch builds a watch model targeting host:port.
+// NewWatch builds a watch model targeting host:port (fresh-boot watch — takeover
+// counts as soon as the real app serves).
 func NewWatch(host, port string) WatchModel {
 	now := time.Now()
 	return WatchModel{host: host, port: port, tracker: watch.NewTracker(now), width: 80, now: now}
+}
+
+// NewWatchReinstall builds a watch that waits for the box to reboot first, so a
+// reinstall of an already-up box doesn't instantly report "done" before the
+// operator has booted the USB.
+func NewWatchReinstall(host, port string) WatchModel {
+	m := NewWatch(host, port)
+	m.requireReboot = true
+	return m
 }
 
 type watchTickMsg struct {
@@ -59,7 +73,10 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.now = msg.at
 		m.tracker.Apply(msg.probe, msg.at)
 		m.last = msg.probe
-		if msg.takeover {
+		// In reinstall mode, ignore "takeover" until the box has actually
+		// rebooted (≥1 observed reboot) — otherwise the still-running old install
+		// would be mistaken for the finished new one before the USB even boots.
+		if msg.takeover && (!m.requireReboot || m.tracker.Reboots >= 1) {
 			// Box is up — leave the dashboard. Hosted by App this pops back to
 			// the menu (which re-detects → now a manageable box); standalone
 			// (`sb-tui watch`) the model's own backMsg case quits and main

--- a/tools/sb-tui/internal/ui/watch_ui_test.go
+++ b/tools/sb-tui/internal/ui/watch_ui_test.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"servicebay-tui/internal/watch"
+)
+
+// TestWatchReinstallWaitsForReboot: a reinstall watch ignores takeover until the
+// box has rebooted (so the still-running old install isn't mistaken for done).
+func TestWatchReinstallWaitsForReboot(t *testing.T) {
+	m := NewWatchReinstall("h", "5888")
+	now := time.Now()
+
+	// Box currently up + "takeover" — must be ignored (no reboot yet).
+	mi, _ := m.Update(watchTickMsg{probe: watch.Probe{ICMP: true, TCP: true}, takeover: true, at: now})
+	m = mi.(WatchModel)
+	if m.Takeover {
+		t.Fatal("reinstall watch must not take over before a reboot")
+	}
+	// Box goes offline (reboot into installer) → one reboot observed.
+	mi, _ = m.Update(watchTickMsg{probe: watch.Probe{ICMP: false}, at: now})
+	m = mi.(WatchModel)
+	// New box up + takeover → now it counts.
+	mi, _ = m.Update(watchTickMsg{probe: watch.Probe{ICMP: true, TCP: true}, takeover: true, at: now})
+	m = mi.(WatchModel)
+	if !m.Takeover {
+		t.Fatal("reinstall watch should take over after a reboot")
+	}
+}
+
+// TestWatchFreshTakesOverImmediately: a normal (non-reinstall) watch takes over
+// as soon as the app serves.
+func TestWatchFreshTakesOverImmediately(t *testing.T) {
+	m := NewWatch("h", "5888")
+	mi, _ := m.Update(watchTickMsg{probe: watch.Probe{ICMP: true, TCP: true}, takeover: true, at: time.Now()})
+	m = mi.(WatchModel)
+	if !m.Takeover {
+		t.Fatal("fresh watch should take over immediately on takeover")
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -136,7 +136,13 @@ func runWatch() int {
 		fmt.Fprintln(os.Stderr, "no target host — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
 		return 2
 	}
-	final, err := tea.NewProgram(ui.NewWatch(t.Host, t.Port), tea.WithAltScreen()).Run()
+	return watchTarget(ui.NewWatch(t.Host, t.Port), t.Host, t.Port)
+}
+
+// watchTarget runs a watch dashboard model and prints the handoff banner on a
+// takeover exit. Shared by runWatch and the post-build reinstall continuation.
+func watchTarget(model ui.WatchModel, host, port string) int {
+	final, err := tea.NewProgram(model, tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -144,8 +150,8 @@ func runWatch() int {
 	if wm, ok := final.(ui.WatchModel); ok && wm.Takeover {
 		elapsed, reboots := wm.Stats()
 		fmt.Printf("\n→ ServiceBay wizard is live\n\n")
-		fmt.Printf("   Setup wizard:  http://%s:%s/setup\n", t.Host, t.Port)
-		fmt.Printf("   Dashboard:     http://%s:%s/\n\n", t.Host, t.Port)
+		fmt.Printf("   Setup wizard:  http://%s:%s/setup\n", host, port)
+		fmt.Printf("   Dashboard:     http://%s:%s/\n\n", host, port)
 		fmt.Printf("   Total: %s, %d reboot(s) observed.\n\n", watch.FmtDur(elapsed), reboots)
 	}
 	return 0
@@ -285,8 +291,27 @@ func main() {
 	// terminal), and Express's guided sequence.
 	switch {
 	case res.BuildPlan != nil:
-		os.Exit(runExecute(*res.BuildPlan))
+		os.Exit(runBuildThenWatch(*res.BuildPlan))
 	case res.Chosen == phase.Express:
 		os.Exit(runExpress())
 	}
+}
+
+// runBuildThenWatch runs a confirmed build Plan, then — instead of stopping —
+// keeps going: it tells the operator to boot the server from the USB and opens
+// the install-watch dashboard on the target box (offline → reboot → install →
+// live). Reinstall mode waits for the box to reboot first, so the still-running
+// old install isn't mistaken for the finished new one.
+func runBuildThenWatch(plan buildflow.Plan) int {
+	if code := runExecute(plan); code != 0 {
+		return code
+	}
+	host, port := plan.Settings.StaticIP, plan.Settings.ServicebayPort
+	if host == "" {
+		return 0 // nothing to watch (no target); build is done
+	}
+	fmt.Printf("\n→ USB is ready. Take it to the server and boot from it now.\n")
+	fmt.Printf("  Watching %s:%s — it'll show offline → reboot → install progress → live.\n", host, port)
+	fmt.Printf("  (Ctrl+C to stop watching; the install continues on the box regardless.)\n\n")
+	return watchTarget(ui.NewWatchReinstall(host, port), host, port)
 }


### PR DESCRIPTION
## What
Closes the workflow gap an operator hit: after building/flashing the ISO the program **stopped**, dumping them back to a shell — but at that moment they want to take the USB to the server, boot it, and **watch the install**.

Now the build flow **continues**: once the ISO is built/flashed, the launcher prints "take the USB to the server and boot from it now" and opens the **install-watch dashboard** on the target box — offline → reboot → install progress → live — exactly the "watch with me" the operator asked for.

**Reinstall-aware:** the box being reinstalled is currently *up*, so a naive watch would instantly report "done." New `NewWatchReinstall` gates takeover on first observing the box go offline (a reboot), so it correctly waits for the USB boot.

## Honest constraint (point 1 from the feedback)
The **bake + `sudo dd` flash still run in the normal terminal** — `dd` needs a real TTY for the sudo prompt and shows a live byte-progress bar, and the ISO download streams progress. Those genuinely can't live inside the alt-screen without fighting the TTY. So the journey is: full-screen form → (terminal: build + flash) → full-screen watch. The UI now wraps the whole thing and never dead-ends.

## Risk
Low; Go-only. `gofmt`/`vet`/`go test ./...` clean; tests for reboot-gated vs immediate takeover.

Part of #1233 / #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)