### PR TITLE
fix(tui): colour watch status dots + guide booting FROM the USB

### DIFF
--- a/tools/sb-tui/internal/watch/watch.go
+++ b/tools/sb-tui/internal/watch/watch.go
@@ -13,6 +13,16 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Status colours for the connection glyphs/badge: green = up, amber =
+// reconnecting/transitional, red = down.
+var (
+	upStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
+	warnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	downStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
 )
 
 // Status is one decoded /status.txt line. The splash writes a single
@@ -153,12 +163,26 @@ func connLabel(l ConnLevel) string {
 	}
 }
 
-// glyph renders a filled/hollow dot for an up/down state.
+// glyph renders a filled/hollow dot for an up/down state: green ● when up, red
+// ○ when down.
 func glyph(up bool) string {
 	if up {
-		return "●"
+		return upStyle.Render("●")
 	}
-	return "○"
+	return downStyle.Render("○")
+}
+
+// badge renders the connection label coloured by level: green connected, amber
+// reconnecting, red offline.
+func badge(l ConnLevel) string {
+	switch l {
+	case Connected:
+		return upStyle.Render(connLabel(l))
+	case Reconnecting:
+		return warnStyle.Render(connLabel(l))
+	default:
+		return downStyle.Render(connLabel(l))
+	}
 }
 
 // truncate cuts s to at most max runes (no ellipsis), so a long line can't
@@ -222,7 +246,7 @@ func Render(host, port string, t *Tracker, p Probe, now time.Time, width int) st
 
 	// Status + meta rows.
 	fmt.Fprintf(&b, "  Status   %s ping   %s :%s   [%s]\n",
-		glyph(p.ICMP), glyph(p.TCP), port, connLabel(t.Conn(p)))
+		glyph(p.ICMP), glyph(p.TCP), port, badge(t.Conn(p)))
 	meta := "  Meta     elapsed " + FmtDur(now.Sub(t.Start))
 	if t.Stage != "" {
 		meta += "   |   at stage " + FmtDur(now.Sub(t.StageStart))

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -310,8 +310,13 @@ func runBuildThenWatch(plan buildflow.Plan) int {
 	if host == "" {
 		return 0 // nothing to watch (no target); build is done
 	}
-	fmt.Printf("\n→ USB is ready. Take it to the server and boot from it now.\n")
-	fmt.Printf("  Watching %s:%s — it'll show offline → reboot → install progress → live.\n", host, port)
-	fmt.Printf("  (Ctrl+C to stop watching; the install continues on the box regardless.)\n\n")
+	fmt.Printf("\n→ USB is ready. Now make the SERVER boot FROM this USB stick:\n\n")
+	fmt.Printf("   1. Plug the USB into the server.\n")
+	fmt.Printf("   2. Boot it FROM the USB — pick the stick in the firmware boot menu\n")
+	fmt.Printf("      (often F12/F11/Esc right after power-on), or set USB first in BIOS\n")
+	fmt.Printf("      boot order. A plain reboot just boots the existing install again.\n")
+	fmt.Printf("      (On a running ServiceBay box you can instead use Settings → Boot →\n")
+	fmt.Printf("       \"boot from USB next\", which sets a one-shot UEFI entry and reboots.)\n\n")
+	fmt.Printf("   Watching %s:%s — offline → reboot → install → live. Ctrl+C to stop.\n\n", host, port)
 	return watchTarget(ui.NewWatchReinstall(host, port), host, port)
 }


### PR DESCRIPTION
## What
- **Coloured status** in the watch dashboard: the ping/port `●`/`○` dots and the `[connected]`/`[reconnecting]`/`[OFFLINE]` badge are now green / amber / red instead of flat grey.
- **Boot-from-USB guidance** after a build: explicitly tells the operator to make the server boot **from the USB** (firmware boot menu / BIOS order, or a running box's one-shot UEFI "boot from USB next"). A plain reboot boots the existing install again — which is exactly why a reinstall can look like "it only restarted, didn't install."

## Risk
Low; Go-only (watch colours + a printed message). `gofmt`/`vet`/`go test ./...` clean.

Part of #1233 / #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)