### PR TITLE
feat(tui): stay on live screen + boot-box-from-USB reinstall action

### DIFF
--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -57,6 +57,7 @@ const (
 	EditConfig    ActionID = "edit-config"
 	InstallStacks ActionID = "install-stacks"
 	Backups       ActionID = "backups"
+	BootFromUSB   ActionID = "boot-from-usb"
 	Quit          ActionID = "quit"
 )
 
@@ -85,6 +86,12 @@ var installStacksAction = Action{InstallStacks, "Install stacks (in-TUI)",
 // is reachable; restore is confirmation-gated in the panel.
 var backupsAction = Action{Backups, "Backups (in-TUI)",
 	"List, create, and restore the box's system backups over the REST API."}
+
+// bootFromUSBAction reinstalls a reachable box: with the freshly-built USB
+// plugged into the server, sign in and set a one-shot UEFI boot to the USB +
+// reboot, so the next boot installs from it instead of the existing disk.
+var bootFromUSBAction = Action{BootFromUSB, "Boot box from USB (reinstall)",
+	"With the new USB plugged into the server: set it to boot from USB once and reboot, then watch the reinstall."}
 
 // Action is one selectable menu entry: a short Label plus a one-line Detail
 // rendered with the selection so the operator always knows what each does.
@@ -137,6 +144,7 @@ func ActionsFor(s State) []Action {
 			editConfigAction,
 			installStacksAction,
 			backupsAction,
+			bootFromUSBAction,
 			buildAction(s))
 	case Ready:
 		// Box is fully up — manage it in-TUI, or reinstall. No Watch (nothing to
@@ -145,6 +153,7 @@ func ActionsFor(s State) []Action {
 			editConfigAction,
 			installStacksAction,
 			backupsAction,
+			bootFromUSBAction,
 			buildAction(s))
 	}
 	// Quit closes the launcher. Status auto-refreshes on a timer, so there's no

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -54,13 +54,13 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{BuildISO, WatchInstall, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: watch + edit-config + install-stacks + backups + reinstall, then quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, EditConfig, InstallStacks, Backups, BuildISO, Quit}) {
+	// installing: watch + edit-config + install-stacks + backups + boot-from-usb + reinstall, then quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, EditConfig, InstallStacks, Backups, BootFromUSB, BuildISO, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: edit-config + install-stacks + backups + reinstall, then quit
+	// ready: edit-config + install-stacks + backups + boot-from-usb + reinstall, then quit
 	// (no Watch on an up box, no Open-in-browser — URL is shown persistently).
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{EditConfig, InstallStacks, Backups, BuildISO, Quit}) {
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{EditConfig, InstallStacks, Backups, BootFromUSB, BuildISO, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/rest/auth.go
+++ b/tools/sb-tui/internal/rest/auth.go
@@ -60,6 +60,39 @@ func Login(ctx context.Context, host, port, username, password string) (string, 
 	return minted.Secret, nil
 }
 
+// EnsureUSBBoot logs in with the box admin credentials and sets a one-shot UEFI
+// BootNext to the USB stick (then reboots the box), so the next boot installs
+// from the USB instead of the existing disk. It uses cookie auth — so it works
+// against the CURRENT (possibly old) ServiceBay, which doesn't speak scoped REST
+// tokens. The USB must already be plugged into the server (the box's efibootmgr
+// must see a USB boot entry). Returns the box's confirmation message.
+func EnsureUSBBoot(ctx context.Context, host, port, username, password string) (string, error) {
+	jar, _ := cookiejar.New(nil)
+	httpc := &http.Client{Timeout: defaultTimeout, Jar: jar}
+	base := fmt.Sprintf("http://%s:%s", host, port)
+
+	if err := postJSON(ctx, httpc, base+"/api/auth/login",
+		map[string]string{"username": username, "password": password}, nil); err != nil {
+		if ae, ok := err.(*APIError); ok && ae.Status == http.StatusUnauthorized {
+			return "", ErrLoginRejected
+		}
+		return "", err
+	}
+
+	// reboot:true → set BootNext (auto-detecting the USB entry) and reboot now.
+	var resp struct {
+		Message string `json:"message"`
+	}
+	if err := postJSON(ctx, httpc, base+"/api/system/boot/usb-next",
+		map[string]any{"reboot": true}, &resp); err != nil {
+		return "", err
+	}
+	if resp.Message == "" {
+		resp.Message = "One-shot USB boot set; the box is rebooting."
+	}
+	return resp.Message, nil
+}
+
 // postJSON POSTs body as JSON on httpc (carrying its cookie jar) and decodes a
 // 2xx response into out (when non-nil), or returns a typed error.
 func postJSON(ctx context.Context, httpc *http.Client, url string, body, out any) error {

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -105,6 +105,12 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Chosen = phase.BuildISO
 		return m, tea.Quit
 
+	case openReinstallWatchMsg:
+		// USB-boot flow succeeded; the box is rebooting → watch the reinstall.
+		m.active = NewWatchReinstall(msg.host, msg.port)
+		m.screen = appPanel
+		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
+
 	case backMsg:
 		// Pop back to the menu and re-detect so its phase/actions refresh.
 		m.screen, m.active = appMenu, nil
@@ -147,6 +153,12 @@ func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
 		m.active = NewBuildForm(m.build.Saved, m.build.Deps)
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
+	case phase.BootFromUSB:
+		// Cookie-auth flow (works on the old box); on success it chains into a
+		// reinstall watch via openReinstallWatchMsg.
+		m.active = NewUSBBoot(m.host, m.port)
+		m.screen = appPanel
+		return m, sizeCmd(m.width, m.height)
 	default:
 		// express — hand back to the entrypoint (it runs its own sequence).
 		m.Chosen = id

--- a/tools/sb-tui/internal/ui/usbboot.go
+++ b/tools/sb-tui/internal/ui/usbboot.go
@@ -1,0 +1,128 @@
+// The Bubble Tea "boot from USB + reinstall" flow (#1272 UX). When the operator
+// has plugged the freshly-built USB into a still-running box, this signs in with
+// the box admin credentials and sets a one-shot UEFI BootNext to the USB, then
+// reboots the box — so the next boot installs from the USB instead of the
+// existing disk. It uses cookie auth (rest.EnsureUSBBoot), so it works against
+// the current/old ServiceBay too. On success it hands off to a reinstall watch.
+package ui
+
+import (
+	"context"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+// openReinstallWatchMsg asks the App to open a reinstall-aware watch dashboard.
+type openReinstallWatchMsg struct{ host, port string }
+
+type usbBootResultMsg struct {
+	msg string
+	err error
+}
+
+// USBBootModel collects admin credentials and triggers the one-shot USB boot.
+type USBBootModel struct {
+	host, port    string
+	width, height int
+
+	username, password string
+	focus              int
+	submitting         bool
+	errMsg             string
+}
+
+// NewUSBBoot builds the flow for a target box.
+func NewUSBBoot(host, port string) USBBootModel { return USBBootModel{host: host, port: port} }
+
+func (m USBBootModel) submitCmd() tea.Cmd {
+	host, port, user, pass := m.host, m.port, m.username, m.password
+	return func() tea.Msg {
+		msg, err := rest.EnsureUSBBoot(context.Background(), host, port, user, pass)
+		return usbBootResultMsg{msg: msg, err: err}
+	}
+}
+
+// Init is a no-op; idle until the operator types.
+func (m USBBootModel) Init() tea.Cmd { return nil }
+
+// Update handles editing, submit, and the result. On success it bubbles
+// openReinstallWatchMsg up to the App to start watching the reinstall.
+func (m USBBootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case usbBootResultMsg:
+		m.submitting = false
+		if msg.err != nil {
+			m.errMsg = friendlyErr(msg.err)
+			m.password, m.focus = "", 1
+			return m, nil
+		}
+		host, port := m.host, m.port
+		return m, func() tea.Msg { return openReinstallWatchMsg{host: host, port: port} }
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.submitting {
+			return m, nil
+		}
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m USBBootModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return m, func() tea.Msg { return backMsg{} }
+	case "tab", "down", "up", "shift+tab":
+		m.focus = (m.focus + 1) % 2
+	case "enter":
+		if m.username != "" && m.password != "" {
+			m.submitting, m.errMsg = true, ""
+			return m, m.submitCmd()
+		}
+		m.focus = (m.focus + 1) % 2
+	case "backspace":
+		if m.focus == 0 && m.username != "" {
+			m.username = m.username[:len(m.username)-1]
+		} else if m.focus == 1 && m.password != "" {
+			m.password = m.password[:len(m.password)-1]
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			if m.focus == 0 {
+				m.username += string(msg.Runes)
+			} else {
+				m.password += string(msg.Runes)
+			}
+		}
+	}
+	return m, nil
+}
+
+// View renders the form.
+func (m USBBootModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  boot box from USB") + "\n")
+	b.WriteString(phaseStyle.Render("Reinstall "+m.host+" from the USB you just built.") + "\n")
+	b.WriteString(detailStyle.Render("Make sure the USB stick is plugged into the server first. Sign in with the") + "\n")
+	b.WriteString(detailStyle.Render("box admin login; this sets a one-shot UEFI boot to the USB and reboots it.") + "\n\n")
+
+	b.WriteString(fieldRow("Username", m.username, m.focus == 0, false) + "\n")
+	b.WriteString(fieldRow("Password", m.password, m.focus == 1, true) + "\n")
+
+	if m.submitting {
+		b.WriteString("\n" + detailStyle.Render("Signing in and setting USB boot…") + "\n")
+	} else if m.errMsg != "" {
+		b.WriteString("\n" + detailStyle.Render(cfgErrStyle.Render("✗ "+m.errMsg)) + "\n")
+	}
+	b.WriteString("\n" + footerStyle.Render("tab switch · enter set USB boot + reboot · esc back"))
+	return frame(b.String(), m.width, m.height)
+}

--- a/tools/sb-tui/internal/ui/watch.go
+++ b/tools/sb-tui/internal/ui/watch.go
@@ -6,6 +6,8 @@
 package ui
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -26,6 +28,9 @@ type WatchModel struct {
 	// REINSTALL, the box is currently up (old install) and we must wait for it to
 	// reboot into the installer before "the app is serving" means the new box.
 	requireReboot bool
+	// live is set once the box is up — the dashboard switches to the "✓ live"
+	// landing and stops polling, staying until the operator leaves.
+	live bool
 	// Takeover is set when the box's real app replaced the splash; the
 	// entrypoint reads it after the program exits to print the handoff banner.
 	Takeover bool
@@ -77,12 +82,12 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// rebooted (≥1 observed reboot) — otherwise the still-running old install
 		// would be mistaken for the finished new one before the USB even boots.
 		if msg.takeover && (!m.requireReboot || m.tracker.Reboots >= 1) {
-			// Box is up — leave the dashboard. Hosted by App this pops back to
-			// the menu (which re-detects → now a manageable box); standalone
-			// (`sb-tui watch`) the model's own backMsg case quits and main
-			// prints the handoff banner.
+			// Box is up — stop polling and show a "live" screen. The operator
+			// stays here until they press q/esc (then App pops to the menu, or a
+			// standalone watch quits). It no longer auto-exits to the shell.
 			m.Takeover = true
-			return m, backCmd()
+			m.live = true
+			return m, nil
 		}
 		return m, tea.Tick(watchInterval, func(time.Time) tea.Msg { return scheduledPoll{} })
 	case scheduledPoll:
@@ -103,9 +108,25 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// View renders the dashboard.
+// View renders the live dashboard, or the "✓ live" landing once the box is up.
 func (m WatchModel) View() string {
+	if m.live {
+		return frame(liveView(m.host, m.port, m.tracker), m.width, 0)
+	}
 	return watch.Render(m.host, m.port, m.tracker, m.last, m.now, m.width)
+}
+
+// liveView is the post-takeover landing: the box is up, the install is done,
+// and the operator decides when to leave.
+func liveView(host, port string, t *watch.Tracker) string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("ServiceBay  ·  install complete") + "\n\n")
+	b.WriteString(cfgOKStyle.Render("  ✓ ServiceBay is live") + "\n\n")
+	b.WriteString(normalStyle.Render("  Dashboard:    ") + cfgValueStyle.Render("http://"+host+":"+port+"/") + "\n")
+	b.WriteString(normalStyle.Render("  Setup wizard: ") + cfgValueStyle.Render("http://"+host+":"+port+"/setup") + "\n\n")
+	b.WriteString(detailStyle.Render(fmt.Sprintf("Observed %d reboot(s).", t.Reboots)) + "\n")
+	b.WriteString("\n" + footerStyle.Render("q/esc — back to menu"))
+	return b.String()
 }
 
 // Stats returns elapsed time and observed reboots for the handoff banner.


### PR DESCRIPTION
## What
- **#3 — stay on a live screen.** When the watched box comes up, the dashboard lands on a **"✓ ServiceBay is live"** screen (URLs + reboot count) and stays until the operator presses q/esc (→ menu / quit), instead of auto-exiting to the shell.
- **#4 — "Boot box from USB (reinstall)" action.** When the box is reachable: with the freshly-built USB plugged into the server, sign in with the box admin login → set a one-shot **UEFI BootNext** to the USB + reboot (`/api/system/boot/usb-next`) → then chain into a reinstall watch. A plain reboot boots the *existing* install — this is what makes the box actually boot the USB. Uses **cookie auth** (`rest.EnsureUSBBoot`) so it works against the current/old ServiceBay too.
- **Coloured watch status** dots/badge (green/amber/red).

## Risk
Low–medium; Go-only. `gofmt`/`vet`/`go test ./...` clean (reboot-gated takeover, action ordering). The USB-boot flow needs the USB physically in the server (efibootmgr must see a USB entry; surfaced as an error otherwise).

Part of #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)