### PR TITLE
feat(backup): route to stage an uploaded service backup onto the NAS

### DIFF
--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -23,6 +23,7 @@ import {
   stageServiceBackup,
   buildServiceBackupTar,
   backupServiceToNas,
+  stageUploadedServiceTar,
   resolveServiceDataDir,
   listServiceBackups,
   fetchServiceBackup,
@@ -237,5 +238,34 @@ describe('manifest integration', () => {
     await writeFile(src, 'data/querylog.json', '[]');
     const staged = await stageServiceBackup(src, getServiceManifest('adguard')!, staging);
     expect(staged).toEqual(['conf/AdGuardHome.yaml']);
+  });
+});
+
+describe('stageUploadedServiceTar', () => {
+  it('writes the uploaded tar + meta to the NAS in restore layout', async () => {
+    const tar = Buffer.alloc(1024, 7); // >=512 bytes, written verbatim
+    const res = await stageUploadedServiceTar('adguard', tar);
+
+    const paths = mockNas.nasUpload.mock.calls.map(c => c[0]);
+    expect(paths).toContain(`${NAS_BACKUP_DIR}/adguard.tar`);
+    expect(paths).toContain(`${NAS_BACKUP_DIR}/adguard.tar.meta.json`);
+    expect(res.tarName).toBe('adguard.tar');
+
+    const tarCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/adguard.tar'))!;
+    expect(tarCall[1]).toEqual(tar); // bytes passed through unchanged
+    const metaCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('.meta.json'))!;
+    expect(JSON.parse(String(metaCall[1])).service).toBe('adguard');
+  });
+
+  it('rejects a service with no backup manifest', async () => {
+    await expect(stageUploadedServiceTar('not-a-real-service', Buffer.alloc(1024)))
+      .rejects.toThrow(/manifest/);
+    expect(mockNas.nasUpload).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty / non-tar upload', async () => {
+    await expect(stageUploadedServiceTar('adguard', Buffer.alloc(10)))
+      .rejects.toThrow(/empty|tar/);
+    expect(mockNas.nasUpload).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -181,7 +181,16 @@ export async function backupServiceToNas(
   }
   const serviceDataDir = opts.serviceDataDir ?? (await resolveServiceDataDir(service));
   const tar = await buildServiceBackupTar(serviceDataDir, manifest);
+  return writeServiceBackupToNas(service, tar);
+}
 
+/**
+ * Write an already-built `<service>.tar` buffer to the NAS in the canonical
+ * restore layout (`sb-backup/<service>.tar` + `.meta.json`). Shared by the
+ * dir-based producer (`backupServiceToNas`) and the upload route (#1351) so the
+ * on-NAS format has a single source of truth.
+ */
+async function writeServiceBackupToNas(service: string, tar: Buffer): Promise<ServiceBackupResult> {
   const meta: ServiceBackupMeta = {
     service,
     schemaVersion: META_SCHEMA_VERSION,
@@ -199,6 +208,26 @@ export async function backupServiceToNas(
 
   logger.info('ExternalBackup', `Wrote ${tarName} to NAS (${tar.length} bytes)`);
   return { service, tarName, metaName, size: tar.length, meta };
+}
+
+/**
+ * Stage an uploaded, already-container-shaped `<service>.tar` onto the NAS in
+ * the restore layout (#1351). Lets the TUI / extractors seed a fresh install's
+ * NAS from the operator's machine. The service must have a backup manifest (so
+ * the restore flow knows how to consume it); the bytes are written verbatim
+ * (box-side backups apply the whitelist/strip via the producer, while uploaded
+ * archives are shaped by their own producer — e.g. the HA-OS extractor #1353).
+ */
+export async function stageUploadedServiceTar(service: string, tar: Buffer): Promise<ServiceBackupResult> {
+  if (!getServiceManifest(service)) {
+    throw new Error(`No backup manifest for service "${service}"`);
+  }
+  // A valid (GNU/ustar) tar is at least one 512-byte record; reject obviously
+  // non-tar uploads early rather than writing garbage to the NAS.
+  if (tar.length < 512) {
+    throw new Error('uploaded archive is empty or not a tar');
+  }
+  return writeServiceBackupToNas(service, tar);
 }
 
 /** List the service backups currently on the NAS. */

--- a/packages/frontend/src/app/api/system/external-backup/upload/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/upload/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { stageUploadedServiceTar } from '@/lib/externalBackup/producer';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST multipart/form-data — stage an uploaded `<service>.tar` onto the FritzBox
+ * NAS in the restore layout (#1351), so a fresh install pulls it. The HTTP
+ * counterpart of the `sb-config-upload` CLI (#1219): it lets the sb-tui upload
+ * flow (#1352) and the per-source extractors (#1353+) seed the NAS from the
+ * operator's machine instead of from an on-box directory.
+ *
+ * Fields: `service` (must have a backup manifest) + `file` (the service tar).
+ * `tokenScope: 'lifecycle'` so the TUI can call it with a scoped `sb_` token.
+ */
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
+  try {
+    const form = await request.formData();
+    const service = form.get('service');
+    const file = form.get('file');
+    if (typeof service !== 'string' || !service) {
+      return NextResponse.json({ error: 'service field is required' }, { status: 400 });
+    }
+    if (!(file instanceof Blob)) {
+      return NextResponse.json({ error: 'file field (the service tar) is required' }, { status: 400 });
+    }
+    const tar = Buffer.from(await file.arrayBuffer());
+    const result = await stageUploadedServiceTar(service, tar);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (e) {
+    // stageUploadedServiceTar throws for an unknown service / non-tar upload —
+    // those are caller errors, so default to 400.
+    return apiError(e, { tag: 'api:system:external-backup:upload', status: 400 });
+  }
+});


### PR DESCRIPTION
## What
`POST /api/system/external-backup/upload` — accepts a multipart `service` + `file` (a `<service>.tar`) and writes it to `sb-backup/<service>.tar` + `.meta.json` on the FritzBox NAS, in exactly the layout the restore-from-NAS flow consumes.

## Why
Closes #1351 (foundation of epic #1350). The HTTP counterpart of the `sb-config-upload` CLI — it lets the TUI (#1352) and the per-source extractors (#1353+) seed a fresh install's NAS from the operator's machine. Factors the NAS-write half of `backupServiceToNas` into a shared `writeServiceBackupToNas`; adds `stageUploadedServiceTar` (requires a known service manifest + rejects a non-tar upload). `tokenScope: 'lifecycle'` so the sb-tui flow can call it with a scoped token.

## Risk
Low. Backend only; reuses the existing producer NAS format (single source of truth with the restore path). Bytes are written verbatim — uploaded archives are shaped by their producer (box-side backups still apply the whitelist/strip).

## Rollback
`git revert` is enough (new route + additive lib function).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (1464 pass; +3 new `stageUploadedServiceTar` tests)
- [ ] /verify — n/a (not a path-mandated area; `lib/externalBackup` + `app/api/system`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)