### PR TITLE
feat(tui): upload a service backup archive to the NAS

### DIFF
--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -57,6 +57,7 @@ const (
 	EditConfig    ActionID = "edit-config"
 	InstallStacks ActionID = "install-stacks"
 	Backups       ActionID = "backups"
+	UploadToNAS   ActionID = "upload-to-nas"
 	BootFromUSB   ActionID = "boot-from-usb"
 	Quit          ActionID = "quit"
 )
@@ -86,6 +87,11 @@ var installStacksAction = Action{InstallStacks, "Install stacks (in-TUI)",
 // is reachable; restore is confirmation-gated in the panel.
 var backupsAction = Action{Backups, "Backups (in-TUI)",
 	"List, create, and restore the box's system backups over the REST API."}
+
+// uploadToNASAction stages a local service config archive on the box's NAS
+// (#1352) so a fresh install pulls it. Only meaningful once the box is reachable.
+var uploadToNASAction = Action{UploadToNAS, "Upload backup to NAS",
+	"Stage a local service config archive on the box's NAS for a fresh install to restore."}
 
 // bootFromUSBAction reinstalls a reachable box: with the freshly-built USB
 // plugged into the server, sign in and set a one-shot UEFI boot to the USB +
@@ -144,6 +150,7 @@ func ActionsFor(s State) []Action {
 			editConfigAction,
 			installStacksAction,
 			backupsAction,
+			uploadToNASAction,
 			bootFromUSBAction,
 			buildAction(s))
 	case Ready:
@@ -153,6 +160,7 @@ func ActionsFor(s State) []Action {
 			editConfigAction,
 			installStacksAction,
 			backupsAction,
+			uploadToNASAction,
 			bootFromUSBAction,
 			buildAction(s))
 	}

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -54,13 +54,13 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{BuildISO, WatchInstall, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: watch + edit-config + install-stacks + backups + boot-from-usb + reinstall, then quit
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, EditConfig, InstallStacks, Backups, BootFromUSB, BuildISO, Quit}) {
+	// installing: watch + edit-config + install-stacks + backups + upload-nas + boot-from-usb + reinstall, then quit
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{WatchInstall, EditConfig, InstallStacks, Backups, UploadToNAS, BootFromUSB, BuildISO, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
-	// ready: edit-config + install-stacks + backups + boot-from-usb + reinstall, then quit
+	// ready: edit-config + install-stacks + backups + upload-nas + boot-from-usb + reinstall, then quit
 	// (no Watch on an up box, no Open-in-browser — URL is shown persistently).
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{EditConfig, InstallStacks, Backups, BootFromUSB, BuildISO, Quit}) {
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{EditConfig, InstallStacks, Backups, UploadToNAS, BootFromUSB, BuildISO, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/rest/upload.go
+++ b/tools/sb-tui/internal/rest/upload.go
@@ -1,0 +1,59 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+)
+
+// UploadServiceBackup stages a local service archive onto the box's NAS via the
+// #1351 route (`POST /api/system/external-backup/upload`). It posts multipart
+// form data — a `service` field + the archive as `file` — authenticated with
+// the scoped token (a valid Bearer bypasses the proxy CSRF gate, so no Origin
+// header is needed). Returns the staged tar name the box reports.
+func (c *Client) UploadServiceBackup(ctx context.Context, service, fileName string, data []byte) (string, error) {
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	if err := w.WriteField("service", service); err != nil {
+		return "", &APIError{Message: err.Error()}
+	}
+	fw, err := w.CreateFormFile("file", fileName)
+	if err != nil {
+		return "", &APIError{Message: err.Error()}
+	}
+	if _, err := fw.Write(data); err != nil {
+		return "", &APIError{Message: err.Error()}
+	}
+	if err := w.Close(); err != nil {
+		return "", &APIError{Message: err.Error()}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/system/external-backup/upload", &body)
+	if err != nil {
+		return "", &APIError{Message: err.Error()}
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return "", &APIError{Message: fmt.Sprintf("cannot reach box: %v", err)}
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", ErrUnauthorized
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", &APIError{Status: resp.StatusCode, Message: serverError(raw, resp.StatusCode)}
+	}
+	var out struct {
+		TarName string `json:"tarName"`
+	}
+	_ = json.Unmarshal(raw, &out)
+	return out.TarName, nil
+}

--- a/tools/sb-tui/internal/rest/upload_test.go
+++ b/tools/sb-tui/internal/rest/upload_test.go
@@ -1,0 +1,59 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUploadServiceBackupPostsMultipart(t *testing.T) {
+	var gotService, gotFileName, gotAuth string
+	var gotFileBytes []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		gotService = r.FormValue("service")
+		f, hdr, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		defer f.Close()
+		gotFileName = hdr.Filename
+		gotFileBytes, _ = io.ReadAll(f)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "tarName": "home-assistant.tar"})
+	}))
+	defer srv.Close()
+
+	tar, err := newTestClient(srv).UploadServiceBackup(context.Background(), "home-assistant", "ha.tar", []byte("TARDATA"))
+	if err != nil {
+		t.Fatalf("UploadServiceBackup: %v", err)
+	}
+	if tar != "home-assistant.tar" {
+		t.Errorf("tarName = %q", tar)
+	}
+	if gotAuth != "Bearer sb_test" {
+		t.Errorf("missing bearer: %q", gotAuth)
+	}
+	if gotService != "home-assistant" || gotFileName != "ha.tar" || string(gotFileBytes) != "TARDATA" {
+		t.Errorf("multipart = service:%q file:%q bytes:%q", gotService, gotFileName, gotFileBytes)
+	}
+}
+
+func TestUploadServiceBackupSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "No backup manifest for service \"nope\""})
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv).UploadServiceBackup(context.Background(), "nope", "x.tar", []byte("data"))
+	apiErr, ok := err.(*APIError)
+	if !ok || apiErr.Status != 400 {
+		t.Fatalf("got %v, want 400 APIError", err)
+	}
+}

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -135,7 +135,7 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // since build is an interactive stdin wizard whose USB flash needs a real TTY.
 func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
 	switch id {
-	case phase.EditConfig, phase.InstallStacks, phase.Backups:
+	case phase.EditConfig, phase.InstallStacks, phase.Backups, phase.UploadToNAS:
 		if m.token == "" {
 			m.pending = id
 			m.screen = appLogin
@@ -181,6 +181,8 @@ func (m App) openPanel(id phase.ActionID) (tea.Model, tea.Cmd) {
 		m.active = NewInstall(client)
 	case phase.Backups:
 		m.active = NewBackup(client)
+	case phase.UploadToNAS:
+		m.active = NewNasUpload(client)
 	default:
 		m.screen, m.active = appMenu, nil
 		return m, nil

--- a/tools/sb-tui/internal/ui/nasupload.go
+++ b/tools/sb-tui/internal/ui/nasupload.go
@@ -1,0 +1,135 @@
+// The Bubble Tea NAS-upload panel (#1352): pick a local, already-container-shaped
+// service archive + the target service and upload it to the box's NAS via the
+// #1351 staging route, so a fresh install pulls it. Reuses the scoped-token rest
+// client + the panel patterns.
+package ui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+type nasUploadResultMsg struct {
+	tarName string
+	err     error
+}
+
+// NasUploadModel collects a service name + local archive path and uploads it.
+type NasUploadModel struct {
+	client        *rest.Client
+	width, height int
+
+	service, path string
+	focus         int // 0 = service, 1 = path
+	submitting    bool
+	status        string // transient result / error line
+}
+
+// NewNasUpload builds the upload panel against an authenticated client.
+func NewNasUpload(client *rest.Client) NasUploadModel { return NasUploadModel{client: client} }
+
+func (m NasUploadModel) uploadCmd() tea.Cmd {
+	client, service, path := m.client, m.service, m.path
+	return func() tea.Msg {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nasUploadResultMsg{err: err}
+		}
+		tar, err := client.UploadServiceBackup(context.Background(), service, filepath.Base(path), data)
+		return nasUploadResultMsg{tarName: tar, err: err}
+	}
+}
+
+// Init is a no-op; idle until the operator types.
+func (m NasUploadModel) Init() tea.Cmd { return nil }
+
+// Update handles editing, submit, and the result.
+func (m NasUploadModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case nasUploadResultMsg:
+		m.submitting = false
+		if msg.err != nil {
+			m.status = "✗ " + friendlyErr(msg.err)
+			return m, nil
+		}
+		m.status = "✓ staged " + msg.tarName + " on the NAS"
+		return m, nil
+	case backMsg:
+		return m, tea.Quit // standalone-only; App intercepts when hosted
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.submitting {
+			return m, nil
+		}
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m NasUploadModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		return m, backCmd()
+	case "tab", "down", "up", "shift+tab":
+		m.focus = (m.focus + 1) % 2
+	case "enter":
+		if m.service != "" && m.path != "" {
+			m.submitting, m.status = true, ""
+			return m, m.uploadCmd()
+		}
+		m.focus = (m.focus + 1) % 2
+	case "backspace":
+		if m.focus == 0 && m.service != "" {
+			m.service = m.service[:len(m.service)-1]
+		} else if m.focus == 1 && m.path != "" {
+			m.path = m.path[:len(m.path)-1]
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			if m.focus == 0 {
+				m.service += string(msg.Runes)
+			} else {
+				m.path += string(msg.Runes)
+			}
+		}
+	}
+	return m, nil
+}
+
+// View renders the form.
+func (m NasUploadModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  upload backup to NAS") + "\n")
+	b.WriteString(phaseStyle.Render("Stage a service config archive on the NAS for a fresh install to restore.") + "\n")
+	b.WriteString(detailStyle.Render("Service must have a backup manifest (e.g. home-assistant, adguard, hermes).") + "\n")
+	b.WriteString(detailStyle.Render("Archive: a local .tar of that service's config dir.") + "\n\n")
+
+	b.WriteString(fieldRow("Service", m.service, m.focus == 0, false) + "\n")
+	b.WriteString(fieldRow("Archive path", m.path, m.focus == 1, false) + "\n")
+
+	if m.submitting {
+		b.WriteString("\n" + detailStyle.Render("Uploading…") + "\n")
+	} else if m.status != "" {
+		style := cfgOKStyle
+		if strings.HasPrefix(m.status, "✗") {
+			style = cfgErrStyle
+		}
+		b.WriteString("\n" + detailStyle.Render(style.Render(m.status)) + "\n")
+	}
+	b.WriteString("\n" + footerStyle.Render("tab switch · type to edit · enter upload · esc back"))
+	return frame(b.String(), m.width, m.height)
+}


### PR DESCRIPTION
## What
An "Upload backup to NAS" panel in sb-tui: pick a target **service** + a local **service config archive** and stage it on the box's NAS via the #1351 route, so a fresh install pulls it.

## Why
Closes #1352 (epic #1350). New `rest.UploadServiceBackup` (multipart, scoped-token auth — a valid Bearer bypasses the proxy CSRF gate) + the in-app panel + menu action, token-gated like the other box-control panels and reachable when the box is up.

## Risk
Low; Go-only (rest client + UI). `gofmt`/`vet`/`go test ./...` clean (multipart POST shape + bearer + error-surface tests).

## Rollback
`git revert`.

## Verification
- [x] go test ./... (rest multipart + error tests; phase/app routing)
- [ ] /verify — n/a (Go binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)