### PR TITLE
feat(backup): import a Home Assistant OS backup into the NAS

### DIFF
--- a/packages/backend/src/lib/externalBackup/haOsImport.test.ts
+++ b/packages/backend/src/lib/externalBackup/haOsImport.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const { mockNas } = vi.hoisted(() => ({
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+}));
+vi.mock('./nasClient', () => mockNas);
+
+import { extractHaConfigDir, importHaOsBackupToNas } from './haOsImport';
+
+let tmpDirs: string[] = [];
+async function mkTmp(): Promise<string> {
+  const d = await fs.mkdtemp(path.join(os.tmpdir(), 'haimport-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+async function write(base: string, rel: string, content: string) {
+  const full = path.join(base, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+async function exists(p: string) {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+
+/**
+ * Build a minimal Home Assistant Supervisor backup tar: an outer tar holding
+ * backup.json + homeassistant.tar.gz, where the inner archive has the config
+ * under data/ (the real layout). Returns the outer tar path.
+ */
+async function buildFakeHaBackup(): Promise<string> {
+  const innerStage = await mkTmp();
+  await write(innerStage, 'homeassistant.json', '{"version":"2026.4.4"}');
+  await write(innerStage, 'data/configuration.yaml', 'default_config:');
+  await write(innerStage, 'data/.storage/zwave_js', '{"keys":"SECRET-MESH"}');
+  await write(innerStage, 'data/.storage/core.entity_registry', '{}');
+  await write(innerStage, 'data/home-assistant_v2.db', 'BINARYDB'); // manifest-excluded
+  await write(innerStage, 'data/home-assistant.log', 'noise');       // manifest-excluded
+
+  const outerStage = await mkTmp();
+  await execFileAsync('tar', ['-czf', path.join(outerStage, 'homeassistant.tar.gz'), '-C', innerStage, '.']);
+  await fs.writeFile(path.join(outerStage, 'backup.json'), '{"version":2,"type":"partial"}');
+
+  const out = await mkTmp();
+  const tarPath = path.join(out, 'ha-backup.tar');
+  await execFileAsync('tar', ['-cf', tarPath, '-C', outerStage, 'homeassistant.tar.gz', 'backup.json']);
+  return tarPath;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNas.nasUpload.mockResolvedValue(undefined);
+});
+afterEach(async () => {
+  await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tmpDirs = [];
+});
+
+describe('extractHaConfigDir', () => {
+  it('extracts the inner data/ config dir', async () => {
+    const backup = await buildFakeHaBackup();
+    const work = await mkTmp();
+    const dataDir = await extractHaConfigDir(backup, work);
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('default_config:');
+    expect(await exists(path.join(dataDir, '.storage/zwave_js'))).toBe(true);
+  });
+
+  it('rejects a tar that is not an HA backup', async () => {
+    const dir = await mkTmp();
+    await write(dir, 'random.txt', 'x');
+    const notHa = path.join(dir, 'not-ha.tar');
+    await execFileAsync('tar', ['-cf', notHa, '-C', dir, 'random.txt']);
+    await expect(extractHaConfigDir(notHa, await mkTmp())).rejects.toThrow(/Home Assistant/);
+  });
+});
+
+describe('importHaOsBackupToNas', () => {
+  it('stages a manifest-filtered home-assistant.tar (config + zwave_js, no DB) to the NAS', async () => {
+    const backup = await buildFakeHaBackup();
+    const res = await importHaOsBackupToNas(backup);
+    expect(res.tarName).toBe('home-assistant.tar');
+
+    const tarCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/home-assistant.tar'))!;
+    expect(tarCall).toBeTruthy();
+
+    // Extract the staged tar and check the manifest filter was applied.
+    const out = await mkTmp();
+    const tarFile = path.join(out, 'staged.tar');
+    await fs.writeFile(tarFile, tarCall[1] as Buffer);
+    const extracted = await mkTmp();
+    await execFileAsync('tar', ['-xf', tarFile, '-C', extracted]);
+    expect(await exists(path.join(extracted, 'configuration.yaml'))).toBe(true);
+    expect(await exists(path.join(extracted, '.storage/zwave_js'))).toBe(true);
+    expect(await exists(path.join(extracted, 'home-assistant_v2.db'))).toBe(false); // excluded
+    expect(await exists(path.join(extracted, 'home-assistant.log'))).toBe(false);   // excluded
+  });
+});

--- a/packages/backend/src/lib/externalBackup/haOsImport.ts
+++ b/packages/backend/src/lib/externalBackup/haOsImport.ts
@@ -1,0 +1,86 @@
+/**
+ * Import a Home Assistant OS (Supervisor) backup into the FritzBox-NAS
+ * config-survival format (#1353, epic #1350).
+ *
+ * A Supervisor backup is a tar containing `backup.json`, `homeassistant.tar.gz`,
+ * and per-add-on `core_*.tar.gz`. The dockerized Home Assistant only needs the
+ * core config, which lives inside `homeassistant.tar.gz` under `data/`
+ * (configuration.yaml, .storage/, …). So we extract that `data/` dir and hand
+ * it to the existing per-service backup producer — which applies the
+ * `home-assistant` manifest (keep config + .storage/zwave_js keys, drop the DB
+ * / logs / media) and writes the canonical `home-assistant.tar` to the NAS.
+ * Reusing the producer keeps the on-NAS format identical to box-side backups
+ * and what the restore flow expects — one source of truth.
+ */
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+// `node:` prefix so a stray browser-polyfill in the SSR graph can't shadow
+// child_process (see systemBackup.ts / producer.ts).
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { backupServiceToNas, type ServiceBackupResult } from './producer';
+
+const execFileAsync = promisify(execFile);
+
+const HA_SERVICE = 'home-assistant';
+const INNER_ARCHIVE = 'homeassistant.tar.gz';
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract the dockerized Home Assistant config dir (the inner
+ * `homeassistant.tar.gz`'s `data/`) from a Supervisor backup tar into workDir,
+ * returning its path. Throws a clear error if the archive isn't an HA backup.
+ * Extraction is into an isolated temp dir (tar refuses `..`/absolute escapes by
+ * default on both GNU and libarchive tar), and the producer then only copies
+ * the manifest's fixed relative paths — so stray archive members can't reach
+ * the NAS. Plain `tar` flags only, for portability across the dev box
+ * (libarchive) and CI / the FCoS box (GNU).
+ */
+export async function extractHaConfigDir(haBackupTarPath: string, workDir: string): Promise<string> {
+  const outerDir = path.join(workDir, 'outer');
+  await fs.mkdir(outerDir, { recursive: true });
+  // Pull just the core HA archive out of the (possibly large) Supervisor tar.
+  try {
+    await execFileAsync('tar', ['-xf', haBackupTarPath, '-C', outerDir, INNER_ARCHIVE]);
+  } catch {
+    throw new Error(`not a Home Assistant backup: ${INNER_ARCHIVE} not found`);
+  }
+  const innerTar = path.join(outerDir, INNER_ARCHIVE);
+  if (!(await exists(innerTar))) {
+    throw new Error(`not a Home Assistant backup: ${INNER_ARCHIVE} not found`);
+  }
+
+  const innerDir = path.join(workDir, 'inner');
+  await fs.mkdir(innerDir, { recursive: true });
+  await execFileAsync('tar', ['-xzf', innerTar, '-C', innerDir]);
+
+  const dataDir = path.join(innerDir, 'data');
+  if (!(await exists(dataDir))) {
+    throw new Error('Home Assistant backup has no data/ config directory');
+  }
+  return dataDir;
+}
+
+/**
+ * Import a Home Assistant OS backup tar: extract its config dir and stage the
+ * manifest-filtered `home-assistant.tar` (+ meta) onto the NAS, ready for a
+ * fresh install's restore. Cleans up its temp work dir.
+ */
+export async function importHaOsBackupToNas(haBackupTarPath: string): Promise<ServiceBackupResult> {
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-haimport-'));
+  try {
+    const configDir = await extractHaConfigDir(haBackupTarPath, workDir);
+    return await backupServiceToNas(HA_SERVICE, { serviceDataDir: configDir });
+  } finally {
+    await fs.rm(workDir, { recursive: true, force: true });
+  }
+}

--- a/packages/frontend/src/app/api/system/external-backup/import-ha/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/import-ha/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import os from 'os';
+import path from 'path';
+import { createWriteStream } from 'fs';
+import fs from 'fs/promises';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { importHaOsBackupToNas } from '@/lib/externalBackup/haOsImport';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST — import a Home Assistant OS (Supervisor) backup (#1353). The raw tar is
+ * the request body (streamed to a temp file rather than buffered, since these
+ * run tens to hundreds of MB); we extract its core config dir and stage the
+ * manifest-filtered `home-assistant.tar` onto the NAS for a fresh install to
+ * restore. `tokenScope: 'lifecycle'` so the sb-tui flow can call it.
+ */
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
+  if (!request.body) {
+    return NextResponse.json({ error: 'request body (the HA backup tar) is required' }, { status: 400 });
+  }
+  const tmpPath = path.join(os.tmpdir(), `sb-haimport-upload-${Date.now()}.tar`);
+  try {
+    await pipeline(Readable.fromWeb(request.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(tmpPath));
+    const result = await importHaOsBackupToNas(tmpPath);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (e) {
+    // A non-HA / corrupt upload throws from the extractor — caller error → 400.
+    return apiError(e, { tag: 'api:system:external-backup:import-ha', status: 400 });
+  } finally {
+    await fs.rm(tmpPath, { force: true });
+  }
+});


### PR DESCRIPTION
## What
`haOsImport` + `POST /api/system/external-backup/import-ha`: take a Home Assistant **Supervisor** backup tar, extract its core config (`homeassistant.tar.gz` → inner `data/`), and stage the manifest-filtered `home-assistant.tar` onto the NAS for a fresh install to restore.

## Why
Closes #1353 (epic #1350). The dockerized HA only needs the config dir; the importer extracts it and hands it to the **existing per-service producer**, so the `home-assistant` manifest applies (keeps `configuration.yaml`, `.storage/core.*`, `.storage/zwave_js` mesh keys; drops the SQLite DB, logs, media) and the on-NAS format stays identical to box-side backups + the restore path. Verified against a real 82 MB Supervisor backup the operator provided.

## Risk
Low–medium. Backend only; not path-mandated (`lib/externalBackup` + `app/api/system`). Untrusted-archive extraction is contained: plain `tar` (refuses `..`/absolute escapes by default on both GNU and libarchive — no GNU-only flags, so it's portable across the dev box and CI/FCoS) into an isolated temp dir, and the producer only copies fixed manifest paths. The import route streams the (large) upload to a temp file rather than buffering.

## Rollback
`git revert`.

## Verification
- [x] npm run lint (0 errors) / check:arch / npm test (1467 pass; +3 haOsImport tests with a synthesized Supervisor-backup fixture)
- [ ] /verify — n/a (not path-mandated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)