### PR TITLE
feat(backup): export lldap users/groups and stage them on the NAS

### DIFF
--- a/packages/backend/src/lib/externalBackup/lldapStage.test.ts
+++ b/packages/backend/src/lib/externalBackup/lldapStage.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockNas } = vi.hoisted(() => ({
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+}));
+vi.mock('./nasClient', () => mockNas);
+
+import { stageLldapDirectoryToNas, LLDAP_DIRECTORY_FILE } from './lldapStage';
+import { NAS_BACKUP_DIR } from './producer';
+import type { LldapDirectory } from '../lldap/client';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNas.nasUpload.mockResolvedValue(undefined);
+});
+
+describe('stageLldapDirectoryToNas', () => {
+  it('writes the directory JSON to sb-backup/ with user/group counts', async () => {
+    const dir: LldapDirectory = {
+      exportedAt: '2026-05-30T00:00:00Z',
+      groups: ['admins', 'family'],
+      users: [
+        { id: 'alice', email: 'a@x', displayName: 'Alice', groups: ['admins', 'family'] },
+        { id: 'bob', groups: [] },
+      ],
+    };
+    const res = await stageLldapDirectoryToNas(dir);
+
+    expect(res).toEqual({ file: LLDAP_DIRECTORY_FILE, users: 2, groups: 2 });
+    const [pathArg, buf] = mockNas.nasUpload.mock.calls[0];
+    expect(pathArg).toBe(`${NAS_BACKUP_DIR}/${LLDAP_DIRECTORY_FILE}`);
+    const parsed = JSON.parse(String(buf));
+    expect(parsed.groups).toEqual(['admins', 'family']);
+    expect(parsed.users).toHaveLength(2);
+    // No password field ever leaves — OPAQUE can't be migrated.
+    expect(JSON.stringify(parsed)).not.toContain('password');
+  });
+});

--- a/packages/backend/src/lib/externalBackup/lldapStage.ts
+++ b/packages/backend/src/lib/externalBackup/lldapStage.ts
@@ -1,0 +1,32 @@
+/**
+ * Stage an exported LLDAP directory onto the FritzBox NAS for the
+ * config-survival feature (#1354, epic #1350).
+ *
+ * Unlike the file-based per-service backups (`producer.ts`), LLDAP keeps its
+ * data in a DB and is re-populated programmatically over GraphQL — so the
+ * "backup" is a JSON directory dump (users + groups + memberships, no
+ * passwords) rather than a `<service>.tar`. It lands beside the service tars in
+ * `sb-backup/` so the restore flow can find and re-seed it on a fresh install.
+ */
+import path from 'path';
+import { nasUpload } from './nasClient';
+import { NAS_BACKUP_DIR } from './producer';
+import { logger } from '../logger';
+import type { LldapDirectory } from '../lldap/client';
+
+/** File on the NAS holding the exported LLDAP directory. */
+export const LLDAP_DIRECTORY_FILE = 'lldap-directory.json';
+
+export interface LldapStageResult {
+  file: string;
+  users: number;
+  groups: number;
+}
+
+/** Write the exported directory to `sb-backup/lldap-directory.json` on the NAS. */
+export async function stageLldapDirectoryToNas(directory: LldapDirectory): Promise<LldapStageResult> {
+  const buf = Buffer.from(JSON.stringify(directory, null, 2));
+  await nasUpload(path.posix.join(NAS_BACKUP_DIR, LLDAP_DIRECTORY_FILE), buf);
+  logger.info('ExternalBackup', `Staged LLDAP directory to NAS (${directory.users.length} users, ${directory.groups.length} groups)`);
+  return { file: LLDAP_DIRECTORY_FILE, users: directory.users.length, groups: directory.groups.length };
+}

--- a/packages/backend/src/lib/lldap/client.export.test.ts
+++ b/packages/backend/src/lib/lldap/client.export.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig } = vi.hoisted(() => ({ mockGetConfig: vi.fn() }));
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+
+import { exportLldapDirectory } from './client';
+
+beforeEach(() => {
+  mockGetConfig.mockResolvedValue({ lldap: { url: 'http://lldap:17170', username: 'admin', password: 'pw' } });
+  vi.restoreAllMocks();
+});
+
+describe('exportLldapDirectory', () => {
+  it('returns users (with groups) + the group list, no passwords', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) }) // /auth/simple/login
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            users: [{ id: 'alice', email: 'a@x', displayName: 'Alice', groups: [{ displayName: 'admins' }] }],
+            groups: [{ displayName: 'admins' }, { displayName: 'family' }],
+          },
+        }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await exportLldapDirectory();
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.directory.users).toEqual([
+        { id: 'alice', email: 'a@x', displayName: 'Alice', groups: ['admins'] },
+      ]);
+      expect(res.directory.groups).toEqual(['admins', 'family']);
+      expect(res.directory.exportedAt).toBeTruthy();
+    }
+  });
+
+  it('surfaces a GraphQL error', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ errors: [{ message: 'boom' }] }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await exportLldapDirectory();
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('graphql_error');
+    }
+  });
+
+  it('reports not_configured when LLDAP creds are missing', async () => {
+    mockGetConfig.mockResolvedValue({});
+    const res = await exportLldapDirectory();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('not_configured');
+  });
+});

--- a/packages/backend/src/lib/lldap/client.ts
+++ b/packages/backend/src/lib/lldap/client.ts
@@ -34,6 +34,17 @@ const LIST_USERS_QUERY = `
   }
 `;
 
+// Full directory dump for the config-survival export (#1354): users (with their
+// group memberships) + the group list. Passwords are intentionally absent —
+// LLDAP uses OPAQUE, so they can't be exported/restored; migrated users set a
+// new password on first login.
+const EXPORT_DIRECTORY_QUERY = `
+  query Directory {
+    users { id email displayName groups { displayName } }
+    groups { displayName }
+  }
+`;
+
 interface LldapCredentials {
   url: string;
   username: string;
@@ -184,6 +195,64 @@ export async function listLldapUsers(): Promise<LldapListUsersResult> {
       return { ok: false, reason: 'graphql_error', message: data.errors[0]?.message ?? 'Unknown LLDAP error.' };
     }
     return { ok: true, users: data.data?.users ?? [] };
+  } catch (e) {
+    return { ok: false, reason: 'network_error', message: e instanceof Error ? e.message : 'Network error talking to LLDAP.' };
+  }
+}
+
+/** One exported user — group memberships by displayName; no password (OPAQUE). */
+export interface LldapDirectoryUser {
+  id: string;
+  email?: string;
+  displayName?: string;
+  groups: string[];
+}
+
+/** A point-in-time dump of the LLDAP directory for config-survival (#1354). */
+export interface LldapDirectory {
+  exportedAt: string;
+  groups: string[];
+  users: LldapDirectoryUser[];
+}
+
+export type LldapExportResult =
+  | { ok: true; directory: LldapDirectory }
+  | { ok: false; reason: 'not_configured' | 'unreachable' | 'auth_failed' | 'graphql_error' | 'network_error'; message: string };
+
+/**
+ * Export the full LLDAP directory — every user (with their group memberships)
+ * plus the group list — for staging onto the NAS so a fresh install can re-seed
+ * the same accounts (#1354). Passwords are NOT included (LLDAP uses OPAQUE, so
+ * they can't leave over GraphQL); migrated users set a new password on first
+ * login. Reuses the same auth + GraphQL path as the other client calls.
+ */
+export async function exportLldapDirectory(): Promise<LldapExportResult> {
+  const auth = await authenticateWithLldap();
+  if (!auth.ok) {
+    return { ok: false, reason: auth.reason, message: auth.message };
+  }
+  try {
+    const res = await fetch(`${auth.baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${auth.token}` },
+      body: JSON.stringify({ query: EXPORT_DIRECTORY_QUERY }),
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+    const data = await res.json().catch(() => ({})) as {
+      data?: { users?: Array<{ id: string; email?: string; displayName?: string; groups?: Array<{ displayName: string }> }>; groups?: Array<{ displayName: string }> };
+      errors?: Array<{ message?: string }>;
+    };
+    if (data.errors?.length) {
+      return { ok: false, reason: 'graphql_error', message: data.errors[0]?.message ?? 'Unknown LLDAP error.' };
+    }
+    const users: LldapDirectoryUser[] = (data.data?.users ?? []).map(u => ({
+      id: u.id,
+      email: u.email,
+      displayName: u.displayName,
+      groups: (u.groups ?? []).map(g => g.displayName),
+    }));
+    const groups = (data.data?.groups ?? []).map(g => g.displayName);
+    return { ok: true, directory: { exportedAt: new Date().toISOString(), groups, users } };
   } catch (e) {
     return { ok: false, reason: 'network_error', message: e instanceof Error ? e.message : 'Network error talking to LLDAP.' };
   }

--- a/packages/frontend/src/app/api/system/external-backup/export-lldap/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/export-lldap/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { exportLldapDirectory } from '@/lib/lldap/client';
+import { stageLldapDirectoryToNas } from '@/lib/externalBackup/lldapStage';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST — export the configured LLDAP's users + groups and stage them on the NAS
+ * (#1354), so a fresh install can re-seed the same accounts. No body: it uses
+ * the stored LLDAP admin credentials. Passwords are not exported (OPAQUE);
+ * migrated users set a new password on first login. `tokenScope: 'lifecycle'`
+ * so the sb-tui flow can trigger it with a scoped token.
+ */
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async () => {
+  try {
+    const result = await exportLldapDirectory();
+    if (!result.ok) {
+      // not_configured / auth_failed / unreachable are operator-fixable → 400/502.
+      const status = result.reason === 'unreachable' || result.reason === 'network_error' ? 502 : 400;
+      return NextResponse.json({ error: result.message, reason: result.reason }, { status });
+    }
+    const staged = await stageLldapDirectoryToNas(result.directory);
+    return NextResponse.json({ ok: true, ...staged });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:external-backup:export-lldap', status: 500 });
+  }
+});


### PR DESCRIPTION
## What
`exportLldapDirectory` + `stageLldapDirectoryToNas` + `POST /api/system/external-backup/export-lldap`: dump the configured LLDAP's users (with group memberships) + groups via GraphQL and write them to `sb-backup/lldap-directory.json` on the NAS, so a fresh install can re-seed the same accounts.

## Why
Closes #1354 (epic #1350, last child). LLDAP is DB-backed and re-populated programmatically (the seed route already creates groups/users over GraphQL), so the "backup" is a JSON **directory dump**, not a `<service>.tar`. **Passwords are not exported** — LLDAP uses OPAQUE, so they can't leave over GraphQL; migrated users set a new password on first login (matching the existing seed flow's behaviour).

## Risk
Low. Backend only; not path-mandated (`lib/lldap`, `lib/externalBackup`, `app/api/system`). Read-only export + a single NAS write. The install-time *consumption* (re-seeding from the staged directory) is the restore side (#1218).

## Rollback
`git revert`.

## Verification
- [x] npm run lint (0 errors) / check:arch / npm test (1471 pass; +4 tests — export shape/error/not-configured + NAS staging, asserts no `password` leaks)
- [ ] /verify — n/a (not path-mandated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)