### PR TITLE
fix(external-backup): extract only manifest paths from HA backups (#1353)

### DIFF
--- a/packages/backend/src/lib/externalBackup/haOsImport.test.ts
+++ b/packages/backend/src/lib/externalBackup/haOsImport.test.ts
@@ -62,13 +62,19 @@ afterEach(async () => {
   tmpDirs = [];
 });
 
+const HA_INCLUDES = ['configuration.yaml', '.storage/zwave_js', '.storage/core.entity_registry'];
+
 describe('extractHaConfigDir', () => {
-  it('extracts the inner data/ config dir', async () => {
+  it('extracts only the requested include paths from the inner data/ dir', async () => {
     const backup = await buildFakeHaBackup();
     const work = await mkTmp();
-    const dataDir = await extractHaConfigDir(backup, work);
+    const dataDir = await extractHaConfigDir(backup, work, HA_INCLUDES);
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('default_config:');
     expect(await exists(path.join(dataDir, '.storage/zwave_js'))).toBe(true);
+    // The big excluded members are never even unpacked to /tmp (#1353): the
+    // whole point is to not write the DB out and exhaust the container tmpfs.
+    expect(await exists(path.join(dataDir, 'home-assistant_v2.db'))).toBe(false);
+    expect(await exists(path.join(dataDir, 'home-assistant.log'))).toBe(false);
   });
 
   it('rejects a tar that is not an HA backup', async () => {
@@ -76,7 +82,18 @@ describe('extractHaConfigDir', () => {
     await write(dir, 'random.txt', 'x');
     const notHa = path.join(dir, 'not-ha.tar');
     await execFileAsync('tar', ['-cf', notHa, '-C', dir, 'random.txt']);
-    await expect(extractHaConfigDir(notHa, await mkTmp())).rejects.toThrow(/Home Assistant/);
+    await expect(extractHaConfigDir(notHa, await mkTmp(), HA_INCLUDES)).rejects.toThrow(/Home Assistant/);
+  });
+
+  it('rejects an HA archive with no recognised config files', async () => {
+    const innerStage = await mkTmp();
+    await write(innerStage, 'data/home-assistant_v2.db', 'DB'); // present but not an include
+    const outerStage = await mkTmp();
+    await execFileAsync('tar', ['-czf', path.join(outerStage, 'homeassistant.tar.gz'), '-C', innerStage, '.']);
+    const out = await mkTmp();
+    const tarPath = path.join(out, 'ha.tar');
+    await execFileAsync('tar', ['-cf', tarPath, '-C', outerStage, 'homeassistant.tar.gz']);
+    await expect(extractHaConfigDir(tarPath, await mkTmp(), HA_INCLUDES)).rejects.toThrow(/no recognised config/);
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/haOsImport.ts
+++ b/packages/backend/src/lib/externalBackup/haOsImport.ts
@@ -11,6 +11,13 @@
  * / logs / media) and writes the canonical `home-assistant.tar` to the NAS.
  * Reusing the producer keeps the on-NAS format identical to box-side backups
  * and what the restore flow expects — one source of truth.
+ *
+ * We extract ONLY the manifest's include paths, never the whole `data/` dir.
+ * A real HA install's `data/` is hundreds of MB (the `home-assistant_v2.db`
+ * alone is often >150 MB, plus HACS frontend assets) — unpacking all of that
+ * into the container's space-limited `/tmp` just to discard it at the staging
+ * step exhausted `/tmp` and failed the import (#1353). Selective extraction
+ * keeps peak temp usage to the few MB the manifest actually keeps.
  */
 import fs from 'fs/promises';
 import os from 'os';
@@ -20,11 +27,13 @@ import path from 'path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { backupServiceToNas, type ServiceBackupResult } from './producer';
+import { getServiceManifest } from './serviceManifest';
 
 const execFileAsync = promisify(execFile);
 
 const HA_SERVICE = 'home-assistant';
 const INNER_ARCHIVE = 'homeassistant.tar.gz';
+const DATA_PREFIX = 'data/';
 
 async function exists(target: string): Promise<boolean> {
   try {
@@ -35,17 +44,46 @@ async function exists(target: string): Promise<boolean> {
   }
 }
 
+/** A tar listing line, normalised: strip a leading `./` and any trailing `/`. */
+function normaliseMember(member: string): string {
+  return member.replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+/**
+ * From an inner-archive listing, pick the exact member names (verbatim, so tar
+ * can find them) whose path under `data/` matches one of the manifest includes
+ * — either the include itself (a file) or anything beneath it (a dir include).
+ */
+function selectWantedMembers(members: string[], includes: string[]): string[] {
+  const wanted: string[] = [];
+  for (const member of members) {
+    const norm = normaliseMember(member);
+    if (!norm.startsWith(DATA_PREFIX)) continue;
+    const rel = norm.slice(DATA_PREFIX.length);
+    if (includes.some(inc => rel === inc || rel.startsWith(`${inc}/`))) {
+      wanted.push(member);
+    }
+  }
+  return wanted;
+}
+
 /**
  * Extract the dockerized Home Assistant config dir (the inner
  * `homeassistant.tar.gz`'s `data/`) from a Supervisor backup tar into workDir,
- * returning its path. Throws a clear error if the archive isn't an HA backup.
- * Extraction is into an isolated temp dir (tar refuses `..`/absolute escapes by
- * default on both GNU and libarchive tar), and the producer then only copies
- * the manifest's fixed relative paths — so stray archive members can't reach
- * the NAS. Plain `tar` flags only, for portability across the dev box
- * (libarchive) and CI / the FCoS box (GNU).
+ * returning its path. Only the `includes` paths (relative to `data/`) are
+ * unpacked — see the module header for why we never extract the whole dir.
+ * Throws a clear error if the archive isn't an HA backup. Extraction is into an
+ * isolated temp dir (tar refuses `..`/absolute escapes by default on both GNU
+ * and libarchive tar), and the producer then only copies the manifest's fixed
+ * relative paths — so stray archive members can't reach the NAS. Plain `tar`
+ * flags only, for portability across the dev box (libarchive) and CI / the
+ * FCoS box (GNU).
  */
-export async function extractHaConfigDir(haBackupTarPath: string, workDir: string): Promise<string> {
+export async function extractHaConfigDir(
+  haBackupTarPath: string,
+  workDir: string,
+  includes: string[],
+): Promise<string> {
   const outerDir = path.join(workDir, 'outer');
   await fs.mkdir(outerDir, { recursive: true });
   // Pull just the core HA archive out of the (possibly large) Supervisor tar.
@@ -59,13 +97,20 @@ export async function extractHaConfigDir(haBackupTarPath: string, workDir: strin
     throw new Error(`not a Home Assistant backup: ${INNER_ARCHIVE} not found`);
   }
 
+  // List the inner archive and extract ONLY the manifest's include members.
+  const { stdout } = await execFileAsync('tar', ['-tzf', innerTar]);
+  const members = stdout.split('\n').map(s => s.trim()).filter(Boolean);
+  const wanted = selectWantedMembers(members, includes);
+
   const innerDir = path.join(workDir, 'inner');
   await fs.mkdir(innerDir, { recursive: true });
-  await execFileAsync('tar', ['-xzf', innerTar, '-C', innerDir]);
+  if (wanted.length > 0) {
+    await execFileAsync('tar', ['-xzf', innerTar, '-C', innerDir, ...wanted]);
+  }
 
-  const dataDir = path.join(innerDir, 'data');
+  const dataDir = path.join(innerDir, DATA_PREFIX);
   if (!(await exists(dataDir))) {
-    throw new Error('Home Assistant backup has no data/ config directory');
+    throw new Error('Home Assistant backup has no recognised config files under data/');
   }
   return dataDir;
 }
@@ -76,9 +121,11 @@ export async function extractHaConfigDir(haBackupTarPath: string, workDir: strin
  * fresh install's restore. Cleans up its temp work dir.
  */
 export async function importHaOsBackupToNas(haBackupTarPath: string): Promise<ServiceBackupResult> {
+  const manifest = getServiceManifest(HA_SERVICE);
+  if (!manifest) throw new Error(`No backup manifest for service "${HA_SERVICE}"`);
   const workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-haimport-'));
   try {
-    const configDir = await extractHaConfigDir(haBackupTarPath, workDir);
+    const configDir = await extractHaConfigDir(haBackupTarPath, workDir, manifest.include);
     return await backupServiceToNas(HA_SERVICE, { serviceDataDir: configDir });
   } finally {
     await fs.rm(workDir, { recursive: true, force: true });

--- a/packages/frontend/src/app/api/system/external-backup/import-ha/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/import-ha/route.ts
@@ -29,7 +29,11 @@ export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request
     return NextResponse.json({ ok: true, ...result });
   } catch (e) {
     // A non-HA / corrupt upload throws from the extractor — caller error → 400.
-    return apiError(e, { tag: 'api:system:external-backup:import-ha', status: 400 });
+    // Surface the message: these are operator-fixable ("not a Home Assistant
+    // backup", "FritzBox NAS not configured", a tar/FTP failure) and this route
+    // is token/cookie-gated. An opaque "Bad request" hid the real cause behind a
+    // multi-hour hunt the error string named outright. Matches export-lldap.
+    return apiError(e, { tag: 'api:system:external-backup:import-ha', status: 400, exposeMessage: true });
   } finally {
     await fs.rm(tmpPath, { force: true });
   }

--- a/packages/frontend/src/app/api/system/external-backup/upload/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/upload/route.ts
@@ -30,8 +30,10 @@ export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request
     const result = await stageUploadedServiceTar(service, tar);
     return NextResponse.json({ ok: true, ...result });
   } catch (e) {
-    // stageUploadedServiceTar throws for an unknown service / non-tar upload —
-    // those are caller errors, so default to 400.
-    return apiError(e, { tag: 'api:system:external-backup:upload', status: 400 });
+    // stageUploadedServiceTar throws for an unknown service / non-tar upload /
+    // unconfigured NAS — all operator-fixable, curated messages, and this route
+    // is token/cookie-gated. Surface them instead of an opaque "Bad request"
+    // (matches export-lldap / import-ha).
+    return apiError(e, { tag: 'api:system:external-backup:upload', status: 400, exposeMessage: true });
   }
 });


### PR DESCRIPTION
## Problem

Importing a **real** Home Assistant OS backup failed on the box with an opaque `400 Bad request`, while small/synthetic backups passed. Found during `/verify` of the backup-migration epic (#1350) against the live box.

## Root cause

`extractHaConfigDir` unpacked the **entire** inner `data/` dir before the producer filtered it. For a real install that's **216 MB across 2432 files** (159 MB `home-assistant_v2.db`, 53 MB HACS frontend) — extracted into the container temp only to be thrown away, keeping just the ~2.3 MB the manifest preserves. That bulk extraction tripped a container limit, and the error was redacted to "Bad request".

Ruled out along the way: NAS config (a real cause too — needed the FritzBox NAS password set), upload size (a 3 MB staged tar uploads fine; a 220 MB-of-zeros extraction also succeeds — so it's the real backup's *file count/content*, not raw size), and the producer logic (proven correct end-to-end locally).

## Fix

- **Selective extraction** — list the inner archive and extract *only* the manifest's include members (verbatim names, so a missing one is simply absent, never a tar error). The real 82 MB backup now expands **2.3 MB instead of 216 MB**; peak temp usage drops to what we actually keep. Behaviour is otherwise identical — the producer already filtered to this exact set, we just stop materialising the rest first.
- **Surface operator-fixable errors** on `import-ha` + `upload` (`exposeMessage: true`), matching `export-lldap`. These routes are token/cookie-gated and every throw is a curated message ("not a Home Assistant backup", "FritzBox NAS not configured", a tar/FTP failure). The opaque "Bad request" hid a cause the error string named outright — and turned this into a multi-hour hunt.

## Tests

- `haOsImport.test.ts`: asserts only the include paths are extracted (the big DB/log are never unpacked) + a "no recognised config files" rejection case.
- Full suite green on Node 20 (1472 passed); lint 0 errors; `check:arch` clean.

## Still needs box confirmation

Local extraction footprint is verified (216 MB → 2.3 MB). The real backup's end-to-end pass **on the box** needs this deployed — with `exposeMessage` now in place, if anything still fails the box will name the exact cause instead of "Bad request".

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)