### PR TITLE
feat(external-backup): restore a service config backup from the NAS (#1218)

### DIFF
--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const { mockNas, mockCfg } = vi.hoisted(() => ({
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+  mockCfg: { getConfig: vi.fn() },
+}));
+vi.mock('./nasClient', () => mockNas);
+vi.mock('../config', () => mockCfg);
+
+import { restoreServiceBackup, isFreshDataDir } from './restore';
+import { NAS_BACKUP_DIR } from './producer';
+
+let tmpRoot: string;
+let dataDir: string;
+
+/** Build a plain service tar like the producer writes: manifest files at root. */
+async function buildServiceTar(files: Record<string, string>): Promise<Buffer> {
+  const stage = await fs.mkdtemp(path.join(os.tmpdir(), 'svc-stage-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(stage, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+  const tarPath = path.join(stage, 'out.tar');
+  await execFileAsync('tar', ['-cf', tarPath, '-C', stage, '.']);
+  const buf = await fs.readFile(tarPath);
+  await fs.rm(stage, { recursive: true, force: true });
+  return buf;
+}
+
+/** Mock nasDownload to serve `tar` for home-assistant.tar, 404 the sidecar. */
+function serveTar(tar: Buffer) {
+  mockNas.nasDownload.mockImplementation(async (p: string) => {
+    if (p === `${NAS_BACKUP_DIR}/home-assistant.tar`) return tar;
+    throw new Error('not found'); // no meta sidecar — restore still works
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'restore-test-'));
+  mockCfg.getConfig.mockResolvedValue({ templateSettings: { DATA_DIR: tmpRoot } });
+  dataDir = path.join(tmpRoot, 'home-assistant');
+});
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('restoreServiceBackup', () => {
+  it('extracts the NAS tar into a fresh service data dir', async () => {
+    serveTar(await buildServiceTar({
+      'configuration.yaml': 'default_config:',
+      '.storage/zwave_js': '{"keys":"MESH"}',
+    }));
+
+    const res = await restoreServiceBackup('home-assistant');
+    expect(res.service).toBe('home-assistant');
+    expect(res.dataDir).toBe(dataDir);
+    expect(res.files).toBe(2);
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('default_config:');
+    expect(await fs.readFile(path.join(dataDir, '.storage/zwave_js'), 'utf8')).toBe('{"keys":"MESH"}');
+  });
+
+  it('refuses a non-empty data dir without force (never clobbers a live service)', async () => {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'existing.yaml'), 'live');
+    serveTar(await buildServiceTar({ 'configuration.yaml': 'incoming' }));
+
+    await expect(restoreServiceBackup('home-assistant')).rejects.toThrow(/already has data/);
+    expect(await fs.readFile(path.join(dataDir, 'existing.yaml'), 'utf8')).toBe('live'); // untouched
+  });
+
+  it('overwrites a populated data dir when force is set', async () => {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'old');
+    serveTar(await buildServiceTar({ 'configuration.yaml': 'new' }));
+
+    const res = await restoreServiceBackup('home-assistant', { force: true });
+    expect(res.files).toBeGreaterThanOrEqual(1);
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('new');
+  });
+
+  it('rejects a service with no backup manifest', async () => {
+    await expect(restoreServiceBackup('not-a-service')).rejects.toThrow(/No backup manifest/);
+  });
+});
+
+describe('isFreshDataDir', () => {
+  it('is true for absent or empty dirs, false once populated', async () => {
+    expect(await isFreshDataDir(path.join(tmpRoot, 'absent'))).toBe(true);
+    const empty = path.join(tmpRoot, 'empty');
+    await fs.mkdir(empty);
+    expect(await isFreshDataDir(empty)).toBe(true);
+    await fs.writeFile(path.join(empty, 'f'), 'x');
+    expect(await isFreshDataDir(empty)).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -1,0 +1,91 @@
+/**
+ * Restore a per-service config backup from the FritzBox NAS back into its
+ * on-disk data dir — the consumer half of the config-survival feature
+ * (#1218, epic #1190). The producer (`producer.ts`) writes
+ * `sb-backup/<service>.tar`; this fetches it and safely extracts the manifest
+ * config files into `<DATA_DIR>/<service>`, so a fresh install / reinstall
+ * re-seeds the same config.
+ *
+ * Guard: by default we only restore into an EMPTY or absent data dir, so a
+ * restore never clobbers a live service's config. The reinstall auto-detect
+ * (#1218 entry point 1) relies on this default; pass `force: true` for a
+ * deliberate operator-triggered overwrite.
+ *
+ * Extraction goes through `safeTarExtract` (the #580 hardened restore path:
+ * refuses absolute paths / `..` traversal / link escapes) — our service tars
+ * are plain (uncompressed), hence `gzip: false`.
+ */
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { fetchServiceBackup, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
+import { getServiceManifest } from './serviceManifest';
+import { safeTarExtract } from '../systemBackup';
+import { logger } from '../logger';
+
+export interface RestoreResult {
+  service: string;
+  dataDir: string;
+  files: number;
+  meta: ServiceBackupMeta | null;
+}
+
+/** True if `dir` is empty or doesn't exist — the safe-to-seed condition. */
+export async function isFreshDataDir(dir: string): Promise<boolean> {
+  try {
+    const entries = await fs.readdir(dir);
+    return entries.length === 0;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return true;
+    throw e;
+  }
+}
+
+/** Count regular files under `dir` (recursively) — for the restore summary. */
+async function countFiles(dir: string): Promise<number> {
+  let total = 0;
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) total += await countFiles(full);
+    else if (entry.isFile()) total += 1;
+  }
+  return total;
+}
+
+/**
+ * Restore `<service>.tar` from the NAS into the service's data dir.
+ * Refuses a non-empty data dir unless `force` is set. Returns the data dir,
+ * the number of files restored, and the backup's meta sidecar (if present).
+ */
+export async function restoreServiceBackup(
+  service: string,
+  opts: { force?: boolean } = {},
+): Promise<RestoreResult> {
+  if (!getServiceManifest(service)) {
+    throw new Error(`No backup manifest for service "${service}"`);
+  }
+  const dataDir = await resolveServiceDataDir(service);
+  if (!opts.force && !(await isFreshDataDir(dataDir))) {
+    throw new Error(
+      `Refusing to restore "${service}": ${dataDir} already has data. Restore ` +
+      `only seeds a fresh/empty data dir; pass force to overwrite a live service.`,
+    );
+  }
+
+  const { tar, meta } = await fetchServiceBackup(`${service}.tar`);
+
+  // safeTarExtract reads from a path, so stage the fetched tar to a temp file.
+  const tmp = path.join(os.tmpdir(), `sb-restore-${service}-${Date.now()}.tar`);
+  try {
+    await fs.writeFile(tmp, tar);
+    await fs.mkdir(dataDir, { recursive: true });
+    await safeTarExtract(tmp, dataDir, { gzip: false });
+  } finally {
+    await fs.rm(tmp, { force: true });
+  }
+
+  const files = await countFiles(dataDir);
+  logger.info('ExternalBackup', `Restored "${service}" from NAS into ${dataDir} (${files} files)`);
+  return { service, dataDir, files, meta };
+}

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -217,10 +217,10 @@ async function runTar(args: string[]) {
  *
  * `assertNoSymlinkEscape` (local path only) stays as defense in depth.
  */
-async function assertSafeArchiveEntries(archivePath: string): Promise<void> {
+async function assertSafeArchiveEntries(archivePath: string, gzip = true): Promise<void> {
     let stdout: string;
     try {
-        const result = await execFileAsync('tar', ['-tvzf', archivePath]);
+        const result = await execFileAsync('tar', [gzip ? '-tvzf' : '-tvf', archivePath]);
         // Default to empty string for the mocked-test path where
         // execFileAsync is stubbed to return no stdout. Production
         // tar always emits the listing on stdout.
@@ -325,8 +325,13 @@ async function assertNoSymlinkEscape(dir: string): Promise<void> {
  *      resolved target escapes `destination`. On refusal, the partial
  *      extraction is cleaned up.
  */
-export async function safeTarExtract(archivePath: string, destination: string): Promise<void> {
-    await assertSafeArchiveEntries(archivePath);
+export async function safeTarExtract(
+    archivePath: string,
+    destination: string,
+    opts: { gzip?: boolean } = {},
+): Promise<void> {
+    const gzip = opts.gzip ?? true;
+    await assertSafeArchiveEntries(archivePath, gzip);
     await fs.mkdir(destination, { recursive: true });
     // Note: GNU tar's default behaviour already strips leading `/` —
     // an explicit `--no-absolute-names` flag doesn't exist (the opt-in
@@ -335,7 +340,7 @@ export async function safeTarExtract(archivePath: string, destination: string): 
     // `assertSafeArchiveEntries` pre-pass as the primary defence and
     // the flags below as belt-and-suspenders.
     await runTar([
-        '-xzf', archivePath,
+        gzip ? '-xzf' : '-xf', archivePath,
         '-C', destination,
         '--no-same-owner',
         '--no-overwrite-dir',

--- a/packages/frontend/src/app/api/system/external-backup/restore/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/restore/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { restoreServiceBackup } from '@/lib/externalBackup/restore';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST { service, force? } — restore a service's config backup from the
+ * FritzBox NAS back into its data dir (#1218, epic #1190). The consumer half
+ * of the backup-survival loop: `import-ha`/`upload`/`export-lldap` put backups
+ * on the NAS; this pulls one back. Refuses a non-empty data dir unless `force`
+ * is set, so it never clobbers a live service. `tokenScope: 'lifecycle'` so the
+ * sb-tui flow can trigger it with a scoped `sb_` token.
+ */
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
+  try {
+    const body = (await request.json().catch(() => ({}))) as { service?: unknown; force?: unknown };
+    if (typeof body.service !== 'string' || !body.service) {
+      return NextResponse.json({ error: 'service field is required' }, { status: 400 });
+    }
+    const result = await restoreServiceBackup(body.service, { force: body.force === true });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (e) {
+    // Operator-fixable, curated messages (unknown service, non-empty data dir,
+    // NAS not configured, a refused/corrupt archive); surface them rather than
+    // an opaque "Bad request" — same rationale as import-ha/upload.
+    return apiError(e, { tag: 'api:system:external-backup:restore', status: 400, exposeMessage: true });
+  }
+});


### PR DESCRIPTION
First, foundational slice of **#1218** (restore-from-NAS) — the consumer half of the config-survival loop (epic #1190). The producer side (`import-ha`/`upload`/`export-lldap`, #1351–#1354 + the #1361 fix) puts backups on the FritzBox NAS; **nothing read them back until now.**

## What this adds

- **`restoreServiceBackup(service, { force? })`** — fetch `sb-backup/<service>.tar` from the NAS and extract it into `<DATA_DIR>/<service>`. Guards on a **fresh/empty data dir by default** so a restore never clobbers a live service; `force` overrides for a deliberate operator-triggered overwrite.
- **`POST /api/system/external-backup/restore`** (`{ service, force? }`, `tokenScope: 'lifecycle'`) — on-demand restore the sb-tui flow can trigger with a scoped token. Surfaces curated errors (`exposeMessage`), like import-ha/upload.
- **Generalised `safeTarExtract`** with a `gzip` option (default `true`, back-compat) — service backups are plain `.tar`, so restore **reuses the #580 hardened extraction** (refuses absolute paths / `..` traversal / symlink+hardlink escapes) rather than re-implementing the security.

## Tests

`restore.test.ts` (5): fresh-dir restore lands the files; non-empty dir is **refused** without force (live config untouched); `force` overwrites; unknown service rejected; `isFreshDataDir` edge cases. Full safeTarExtract callers re-run green (incl. `backup_restore_security`). Lint 0 errors, check:arch clean.

## Scope / follow-ups

This is the **on-demand primitive**. The two auto-detect entry points from #1218 build on it next:
1. reinstall post-deploy hook (`install/runner.ts`) — empty data dir + matching NAS tar → auto-restore;
2. onboarding orphan hint — "N service backups available on FritzBox — install them?".

## Needs box `/verify`

Touches `systemBackup.ts` + adds an install-adjacent route → path-mandated real-box `/verify`. Deferred to the **combined deploy** with #1361 (avoids updating the box twice): once the box runs both, I'll verify the whole loop end-to-end — write the real HA backup, then restore it.

Part of #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)