### PR TITLE
feat(tui): USB-boot status on the watch dashboard + u to enable

### DIFF
--- a/packages/frontend/src/app/api/system/boot/usb-next/route.ts
+++ b/packages/frontend/src/app/api/system/boot/usb-next/route.ts
@@ -13,7 +13,10 @@ async function getAgent() {
   return agentManager.getAgent(nodeName);
 }
 
-export const GET = withApiHandler({}, async () => {
+// `tokenScope: 'read'` so the sb-tui launcher can poll USB-boot readiness with
+// its scoped token (show "would the box boot from USB?" beside ping/webserver)
+// without an extra cookie login.
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
   try {
     const agent = await getAgent();
     const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
@@ -79,7 +82,10 @@ const PostBody = z.object({
   reboot: z.boolean().optional().default(false),
 });
 
-export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
+// `tokenScope: 'mutate'` — sets the firmware's one-shot BootNext (and optionally
+// reboots), so the sb-tui "ensure USB boot" action can enable it with a scoped
+// token, matching the frontend's enable button.
+export const POST = withApiHandler({ body: PostBody, tokenScope: 'mutate' }, async ({ body }) => {
   try {
     const agent = await getAgent();
     
@@ -136,7 +142,7 @@ export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
   }
 });
 
-export const DELETE = withApiHandler({}, async () => {
+export const DELETE = withApiHandler({ tokenScope: 'mutate' }, async () => {
   try {
     const agent = await getAgent();
     logger.info('api:system:boot:usb-next', 'Clearing UEFI BootNext setting');

--- a/tools/sb-tui/internal/rest/boot.go
+++ b/tools/sb-tui/internal/rest/boot.go
@@ -1,0 +1,102 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// usbBootEntry is one UEFI boot entry as reported by the box's usb-next GET
+// (parsed from `efibootmgr -v` server-side).
+type usbBootEntry struct {
+	BootNum     string `json:"bootNum"`
+	Active      bool   `json:"active"`
+	Description string `json:"description"`
+	Current     bool   `json:"current"`
+}
+
+// usbBootResponse is the GET /api/system/boot/usb-next payload.
+type usbBootResponse struct {
+	Entries    []usbBootEntry `json:"entries"`
+	Candidates []usbBootEntry `json:"candidates"`
+	BootNext   string         `json:"bootNext"`
+	BootOrder  []string       `json:"bootOrder"`
+}
+
+// USBBootReadiness summarises whether the box can / will boot from USB, for the
+// status row shown beside ping + webserver.
+type USBBootReadiness struct {
+	// Known is false when the box couldn't be queried (gray dot).
+	Known bool
+	// Ready: an ACTIVE USB/removable UEFI entry exists → firmware CAN boot USB.
+	Ready bool
+	// WillBoot: BootNext points at a USB candidate → the NEXT boot is from USB.
+	WillBoot bool
+	// Summary is the one-line human status for the dashboard row.
+	Summary string
+}
+
+// assessUSBBoot derives readiness from the box's usb-next payload. Pure; mirrors
+// assessUsbBootReadiness in packages/backend/.../mcp/efibootmgr.ts (Ready ==
+// "reinstallReady": at least one removable/USB entry that is active).
+func assessUSBBoot(r usbBootResponse) USBBootReadiness {
+	activeCandidates := 0
+	for _, c := range r.Candidates {
+		if c.Active {
+			activeCandidates++
+		}
+	}
+	willBoot := false
+	if r.BootNext != "" {
+		for _, c := range r.Candidates {
+			if strings.EqualFold(strings.TrimSpace(c.BootNum), strings.TrimSpace(r.BootNext)) {
+				willBoot = true
+				break
+			}
+		}
+	}
+	switch {
+	case len(r.Candidates) == 0:
+		return USBBootReadiness{Known: true, Summary: "no USB boot entry — insert the install USB"}
+	case activeCandidates == 0:
+		return USBBootReadiness{Known: true, Summary: "USB entry present but inactive — enable it"}
+	case willBoot:
+		return USBBootReadiness{Known: true, Ready: true, WillBoot: true, Summary: "will boot from USB on next reboot"}
+	default:
+		return USBBootReadiness{Known: true, Ready: true, Summary: "can boot from USB (enable to use it next reboot)"}
+	}
+}
+
+// USBBootStatus queries the box for its UEFI boot entries and returns whether it
+// can / will boot from USB. Uses the scoped token (GET needs 'read').
+func (c *Client) USBBootStatus(ctx context.Context) (USBBootReadiness, error) {
+	raw, err := c.do(ctx, http.MethodGet, "/api/system/boot/usb-next", nil)
+	if err != nil {
+		return USBBootReadiness{}, err
+	}
+	var r usbBootResponse
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return USBBootReadiness{}, &APIError{Message: err.Error()}
+	}
+	return assessUSBBoot(r), nil
+}
+
+// EnableUSBBoot activates the box's USB boot entry and sets a one-shot UEFI
+// BootNext WITHOUT rebooting (reboot:false), so the operator confirms before the
+// box restarts. Uses the scoped token (POST needs 'mutate'). Returns the box's
+// confirmation message.
+func (c *Client) EnableUSBBoot(ctx context.Context) (string, error) {
+	raw, err := c.do(ctx, http.MethodPost, "/api/system/boot/usb-next", map[string]any{"reboot": false})
+	if err != nil {
+		return "", err
+	}
+	var out struct {
+		Message string `json:"message"`
+	}
+	_ = json.Unmarshal(raw, &out)
+	if strings.TrimSpace(out.Message) == "" {
+		out.Message = "One-shot USB boot set for the next reboot."
+	}
+	return out.Message, nil
+}

--- a/tools/sb-tui/internal/rest/boot_test.go
+++ b/tools/sb-tui/internal/rest/boot_test.go
@@ -1,0 +1,56 @@
+package rest
+
+import "testing"
+
+func TestAssessUSBBoot(t *testing.T) {
+	usb := usbBootEntry{BootNum: "0003", Active: true, Description: "USB HDD"}
+	usbInactive := usbBootEntry{BootNum: "0003", Active: false, Description: "USB HDD"}
+
+	cases := []struct {
+		name           string
+		in             usbBootResponse
+		ready, willBoot bool
+	}{
+		{
+			name: "no candidates — USB not detected",
+			in:   usbBootResponse{Entries: []usbBootEntry{{BootNum: "0000", Active: true, Description: "Fedora"}}},
+		},
+		{
+			name: "candidate present but inactive",
+			in:   usbBootResponse{Candidates: []usbBootEntry{usbInactive}},
+		},
+		{
+			name:  "active candidate, no BootNext — can boot, won't next",
+			in:    usbBootResponse{Candidates: []usbBootEntry{usb}},
+			ready: true,
+		},
+		{
+			name:     "active candidate + BootNext set to it — will boot next",
+			in:       usbBootResponse{Candidates: []usbBootEntry{usb}, BootNext: "0003"},
+			ready:    true,
+			willBoot: true,
+		},
+		{
+			name:  "BootNext points elsewhere — ready but won't boot USB next",
+			in:    usbBootResponse{Candidates: []usbBootEntry{usb}, BootNext: "0000"},
+			ready: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := assessUSBBoot(tc.in)
+			if !got.Known {
+				t.Errorf("Known = false, want true (assess always knows)")
+			}
+			if got.Ready != tc.ready {
+				t.Errorf("Ready = %v, want %v (summary: %q)", got.Ready, tc.ready, got.Summary)
+			}
+			if got.WillBoot != tc.willBoot {
+				t.Errorf("WillBoot = %v, want %v", got.WillBoot, tc.willBoot)
+			}
+			if got.Summary == "" {
+				t.Errorf("Summary is empty")
+			}
+		})
+	}
+}

--- a/tools/sb-tui/internal/rest/boot_test.go
+++ b/tools/sb-tui/internal/rest/boot_test.go
@@ -7,8 +7,8 @@ func TestAssessUSBBoot(t *testing.T) {
 	usbInactive := usbBootEntry{BootNum: "0003", Active: false, Description: "USB HDD"}
 
 	cases := []struct {
-		name           string
-		in             usbBootResponse
+		name            string
+		in              usbBootResponse
 		ready, willBoot bool
 	}{
 		{

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -107,7 +107,7 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case openReinstallWatchMsg:
 		// USB-boot flow succeeded; the box is rebooting → watch the reinstall.
-		m.active = NewWatchReinstall(msg.host, msg.port)
+		m.active = NewWatchReinstall(msg.host, msg.port, m.token)
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
 
@@ -144,7 +144,7 @@ func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
 		}
 		return m.openPanel(id)
 	case phase.WatchInstall:
-		m.active = NewWatch(m.host, m.port)
+		m.active = NewWatch(m.host, m.port, m.token)
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
 	case phase.BuildISO:

--- a/tools/sb-tui/internal/ui/watch.go
+++ b/tools/sb-tui/internal/ui/watch.go
@@ -6,20 +6,28 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"servicebay-tui/internal/rest"
 	"servicebay-tui/internal/watch"
 )
 
 const watchInterval = time.Second
 
+// usbInterval throttles the authed USB-boot query — `efibootmgr` runs via an
+// agent exec on the box, so we re-check readiness only every few seconds rather
+// than on every 1s poll tick.
+const usbInterval = 6 * time.Second
+
 // WatchModel is the Bubble Tea model for the install-watch dashboard.
 type WatchModel struct {
 	host, port string
+	token      string // scoped token for the USB-boot query/enable; "" disables it
 	tracker    *watch.Tracker
 	last       watch.Probe
 	width      int
@@ -31,25 +39,86 @@ type WatchModel struct {
 	// live is set once the box is up — the dashboard switches to the "✓ live"
 	// landing and stops polling, staying until the operator leaves.
 	live bool
+	// usb is the last observed USB-boot readiness (gray until first answered).
+	usb watch.USBState
+	// usbBusy guards against overlapping USB queries; lastUSB throttles them.
+	usbBusy bool
+	lastUSB time.Time
+	// usbMsg is a transient line shown after pressing u to enable USB boot.
+	usbMsg string
 	// Takeover is set when the box's real app replaced the splash; the
 	// entrypoint reads it after the program exits to print the handoff banner.
 	Takeover bool
 }
 
 // NewWatch builds a watch model targeting host:port (fresh-boot watch — takeover
-// counts as soon as the real app serves).
-func NewWatch(host, port string) WatchModel {
+// counts as soon as the real app serves). token authenticates the USB-boot
+// readiness query/enable; pass "" to disable it (the dot then stays gray).
+func NewWatch(host, port, token string) WatchModel {
 	now := time.Now()
-	return WatchModel{host: host, port: port, tracker: watch.NewTracker(now), width: 80, now: now}
+	return WatchModel{host: host, port: port, token: token, tracker: watch.NewTracker(now), width: 80, now: now}
 }
 
 // NewWatchReinstall builds a watch that waits for the box to reboot first, so a
 // reinstall of an already-up box doesn't instantly report "done" before the
 // operator has booted the USB.
-func NewWatchReinstall(host, port string) WatchModel {
-	m := NewWatch(host, port)
+func NewWatchReinstall(host, port, token string) WatchModel {
+	m := NewWatch(host, port, token)
 	m.requireReboot = true
 	return m
+}
+
+// usbStatusMsg carries a USB-boot readiness query result.
+type usbStatusMsg struct{ state watch.USBState }
+
+// usbEnableResultMsg carries the result of pressing u to enable USB boot.
+type usbEnableResultMsg struct {
+	msg string
+	err error
+}
+
+// mapUSB folds the rest client's readiness into the dashboard glyph state.
+func mapUSB(r rest.USBBootReadiness) watch.USBState {
+	switch {
+	case !r.Known:
+		return watch.USBUnknown
+	case r.WillBoot:
+		return watch.USBWillBoot
+	case r.Ready:
+		return watch.USBReady
+	default:
+		return watch.USBNotReady
+	}
+}
+
+// usbQueryCmd asks the box whether it would boot from USB. Any error (box
+// offline, route missing, efibootmgr failure) resolves to Unknown → gray dot.
+func (m WatchModel) usbQueryCmd() tea.Cmd {
+	host, port, token := m.host, m.port, m.token
+	return func() tea.Msg {
+		client, err := rest.New(host, port, token)
+		if err != nil {
+			return usbStatusMsg{state: watch.USBUnknown}
+		}
+		r, err := client.USBBootStatus(context.Background())
+		if err != nil {
+			return usbStatusMsg{state: watch.USBUnknown}
+		}
+		return usbStatusMsg{state: mapUSB(r)}
+	}
+}
+
+// usbEnableCmd sets the one-shot BootNext to USB (without rebooting).
+func (m WatchModel) usbEnableCmd() tea.Cmd {
+	host, port, token := m.host, m.port, m.token
+	return func() tea.Msg {
+		client, err := rest.New(host, port, token)
+		if err != nil {
+			return usbEnableResultMsg{err: err}
+		}
+		msg, err := client.EnableUSBBoot(context.Background())
+		return usbEnableResultMsg{msg: msg, err: err}
+	}
 }
 
 type watchTickMsg struct {
@@ -77,6 +146,8 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case watchTickMsg:
 		m.now = msg.at
 		m.tracker.Apply(msg.probe, msg.at)
+		// Observe is anonymous and leaves USB unset; carry our last queried state.
+		msg.probe.USB = m.usb
 		m.last = msg.probe
 		// In reinstall mode, ignore "takeover" until the box has actually
 		// rebooted (≥1 observed reboot) — otherwise the still-running old install
@@ -89,7 +160,27 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.live = true
 			return m, nil
 		}
-		return m, tea.Tick(watchInterval, func(time.Time) tea.Msg { return scheduledPoll{} })
+		cmds := []tea.Cmd{tea.Tick(watchInterval, func(time.Time) tea.Msg { return scheduledPoll{} })}
+		// While the box is reachable, re-check USB-boot readiness on a throttle
+		// (only it can answer efibootmgr, and only when the port is open).
+		if m.token != "" && msg.probe.TCP && !m.usbBusy && msg.at.Sub(m.lastUSB) >= usbInterval {
+			m.usbBusy, m.lastUSB = true, msg.at
+			cmds = append(cmds, m.usbQueryCmd())
+		}
+		return m, tea.Batch(cmds...)
+	case usbStatusMsg:
+		m.usb = msg.state
+		m.last.USB = msg.state
+		m.usbBusy = false
+		return m, nil
+	case usbEnableResultMsg:
+		if msg.err != nil {
+			m.usbMsg = cfgErrStyle.Render("✗ USB enable failed: " + friendlyErr(msg.err))
+			return m, nil
+		}
+		m.usbMsg = cfgOKStyle.Render("✓ " + msg.msg)
+		m.lastUSB = time.Time{} // force a refresh on the next tick
+		return m, m.usbQueryCmd()
 	case scheduledPoll:
 		return m, m.pollCmd()
 	case backMsg:
@@ -103,6 +194,12 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "q", "esc":
 			return m, backCmd()
+		case "u":
+			// Enable one-shot USB boot (no reboot) when the box can answer.
+			if m.token != "" && m.last.TCP && !m.live {
+				m.usbMsg = detailStyle.Render("Setting USB boot…")
+				return m, m.usbEnableCmd()
+			}
 		}
 	}
 	return m, nil
@@ -113,7 +210,11 @@ func (m WatchModel) View() string {
 	if m.live {
 		return frame(liveView(m.host, m.port, m.tracker), m.width, 0)
 	}
-	return watch.Render(m.host, m.port, m.tracker, m.last, m.now, m.width)
+	out := watch.Render(m.host, m.port, m.tracker, m.last, m.now, m.width)
+	if m.usbMsg != "" {
+		out += "  " + m.usbMsg + "\n"
+	}
+	return out
 }
 
 // liveView is the post-takeover landing: the box is up, the install is done,

--- a/tools/sb-tui/internal/ui/watch_ui_test.go
+++ b/tools/sb-tui/internal/ui/watch_ui_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"servicebay-tui/internal/watch"
 )
 
 // TestWatchReinstallWaitsForReboot: a reinstall watch ignores takeover until the
 // box has rebooted (so the still-running old install isn't mistaken for done).
 func TestWatchReinstallWaitsForReboot(t *testing.T) {
-	m := NewWatchReinstall("h", "5888")
+	m := NewWatchReinstall("h", "5888", "")
 	now := time.Now()
 
 	// Box currently up + "takeover" — must be ignored (no reboot yet).
@@ -33,10 +35,39 @@ func TestWatchReinstallWaitsForReboot(t *testing.T) {
 // TestWatchFreshTakesOverImmediately: a normal (non-reinstall) watch takes over
 // as soon as the app serves.
 func TestWatchFreshTakesOverImmediately(t *testing.T) {
-	m := NewWatch("h", "5888")
+	m := NewWatch("h", "5888", "")
 	mi, _ := m.Update(watchTickMsg{probe: watch.Probe{ICMP: true, TCP: true}, takeover: true, at: time.Now()})
 	m = mi.(WatchModel)
 	if !m.Takeover {
 		t.Fatal("fresh watch should take over immediately on takeover")
+	}
+}
+
+// TestWatchUSBStatusUpdatesGlyph: a usbStatusMsg updates both the stored state
+// and the last probe (so the next render shows the new glyph).
+func TestWatchUSBStatusUpdatesGlyph(t *testing.T) {
+	m := NewWatch("h", "5888", "sb_token")
+	mi, _ := m.Update(usbStatusMsg{state: watch.USBReady})
+	m = mi.(WatchModel)
+	if m.usb != watch.USBReady {
+		t.Fatalf("usb = %v, want USBReady", m.usb)
+	}
+	if m.last.USB != watch.USBReady {
+		t.Error("last probe USB should reflect the new state for rendering")
+	}
+}
+
+// TestWatchUEnableGated: pressing u enables USB boot only with a token + an open
+// port; otherwise it's a no-op (no command fired).
+func TestWatchUEnableGated(t *testing.T) {
+	withTok := NewWatch("h", "5888", "sb_token")
+	withTok.last = watch.Probe{TCP: true}
+	if _, cmd := withTok.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")}); cmd == nil {
+		t.Error("u with token + open port should fire the enable cmd")
+	}
+	noTok := NewWatch("h", "5888", "")
+	noTok.last = watch.Probe{TCP: true}
+	if _, cmd := noTok.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")}); cmd != nil {
+		t.Error("u without a token should be a no-op")
 	}
 }

--- a/tools/sb-tui/internal/watch/watch.go
+++ b/tools/sb-tui/internal/watch/watch.go
@@ -23,7 +23,33 @@ var (
 	upStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
 	warnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	downStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	grayStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 )
+
+// USBState is the box's USB-boot readiness for the dashboard glyph: would the
+// firmware boot from USB on the next reboot? Unknown when we couldn't query the
+// box (offline mid-reboot, or no token) → gray dot.
+type USBState int
+
+const (
+	USBUnknown  USBState = iota // not queried / box offline — gray
+	USBNotReady                 // no active USB/removable UEFI entry — red
+	USBReady                    // an active USB entry exists (firmware can boot USB) — green
+	USBWillBoot                 // BootNext points at USB (will boot USB next) — green
+)
+
+// usbGlyph renders the USB-boot dot: green when the box can/will boot from USB,
+// red when it can't (no/inactive entry), gray when unknown.
+func usbGlyph(s USBState) string {
+	switch s {
+	case USBReady, USBWillBoot:
+		return upStyle.Render("●")
+	case USBNotReady:
+		return downStyle.Render("●")
+	default:
+		return grayStyle.Render("○")
+	}
+}
 
 // Status is one decoded /status.txt line. The splash writes a single
 // tab-separated line: an RFC3339 UTC timestamp, the current install stage
@@ -84,10 +110,11 @@ func IsTakeover(rootTitle string) bool {
 
 // Probe is one tick's worth of observed facts about the box.
 type Probe struct {
-	ICMP   bool    // host answers ping
-	TCP    bool    // the ServiceBay port accepts a connection
-	Status *Status // decoded /status.txt, nil when unavailable or not-yet-TSV
-	Log    string  // /log.txt body (only fetched when Status is present)
+	ICMP   bool     // host answers ping
+	TCP    bool     // the ServiceBay port accepts a connection
+	Status *Status  // decoded /status.txt, nil when unavailable or not-yet-TSV
+	Log    string   // /log.txt body (only fetched when Status is present)
+	USB    USBState // USB-boot readiness; set by the UI layer (authed query), not Observe
 }
 
 // ConnLevel is the connection-badge state derived from a probe.
@@ -245,8 +272,16 @@ func Render(host, port string, t *Tracker, p Probe, now time.Time, width int) st
 	b.WriteString("\n")
 
 	// Status + meta rows.
-	fmt.Fprintf(&b, "  Status   %s ping   %s :%s   [%s]\n",
-		glyph(p.ICMP), glyph(p.TCP), port, badge(t.Conn(p)))
+	fmt.Fprintf(&b, "  Status   %s ping   %s :%s   %s usb-boot   [%s]\n",
+		glyph(p.ICMP), glyph(p.TCP), port, usbGlyph(p.USB), badge(t.Conn(p)))
+	switch p.USB {
+	case USBNotReady:
+		b.WriteString("           " + warnStyle.Render("USB boot not ready — insert the USB stick, then press u to enable") + "\n")
+	case USBReady:
+		b.WriteString("           " + grayStyle.Render("can boot from USB — press u to set it for the next reboot") + "\n")
+	case USBWillBoot:
+		b.WriteString("           " + upStyle.Render("✓ will boot from USB on the next reboot") + "\n")
+	}
 	meta := "  Meta     elapsed " + FmtDur(now.Sub(t.Start))
 	if t.Stage != "" {
 		meta += "   |   at stage " + FmtDur(now.Sub(t.StageStart))

--- a/tools/sb-tui/internal/watch/watch_test.go
+++ b/tools/sb-tui/internal/watch/watch_test.go
@@ -166,3 +166,19 @@ func TestLastLinesAndTruncate(t *testing.T) {
 		t.Error("truncate(max<=0) should be empty")
 	}
 }
+
+func TestRenderUSBBoot(t *testing.T) {
+	now := time.Now()
+	tr := NewTracker(now)
+	will := Render("h", "5888", tr, Probe{ICMP: true, TCP: true, USB: USBWillBoot}, now, 80)
+	if !strings.Contains(will, "usb-boot") {
+		t.Error("status row should include the usb-boot label")
+	}
+	if !strings.Contains(will, "will boot from USB") {
+		t.Error("USBWillBoot should show the will-boot hint")
+	}
+	notReady := Render("h", "5888", tr, Probe{ICMP: true, TCP: true, USB: USBNotReady}, now, 80)
+	if !strings.Contains(notReady, "not ready") {
+		t.Error("USBNotReady should show the not-ready hint")
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -136,7 +136,7 @@ func runWatch() int {
 		fmt.Fprintln(os.Stderr, "no target host — set SB_HOST (and SB_PORT), or build an ISO first so build/fcos/install-settings.env exists.")
 		return 2
 	}
-	return watchTarget(ui.NewWatch(t.Host, t.Port), t.Host, t.Port)
+	return watchTarget(ui.NewWatch(t.Host, t.Port, probes.ResolveToken(t.Host)), t.Host, t.Port)
 }
 
 // watchTarget runs a watch dashboard model and prints the handoff banner on a
@@ -318,5 +318,5 @@ func runBuildThenWatch(plan buildflow.Plan) int {
 	fmt.Printf("      (On a running ServiceBay box you can instead use Settings → Boot →\n")
 	fmt.Printf("       \"boot from USB next\", which sets a one-shot UEFI entry and reboots.)\n\n")
 	fmt.Printf("   Watching %s:%s — offline → reboot → install → live. Ctrl+C to stop.\n\n", host, port)
-	return watchTarget(ui.NewWatchReinstall(host, port), host, port)
+	return watchTarget(ui.NewWatchReinstall(host, port, probes.ResolveToken(host)), host, port)
 }


### PR DESCRIPTION
Shows **"would the box boot from USB?"** in the sb-tui install-watch dashboard, beside the existing ping/webserver dots, with `u` to enable it — so before/around a reinstall you can confirm the box will actually boot the USB instead of the internal disk again.

## Watch dashboard (the user-facing bit)
```
  Status   ● ping   ● :5888   ● usb-boot   [connected]
           ✓ will boot from USB on the next reboot
```
- Third glyph in the Status row: **green** = active USB/removable UEFI entry exists (or BootNext already points at it), **red** = no/inactive entry, **gray** = box offline / not yet queried.
- A hint line spells out the state; pressing **`u`** sets a one-shot BootNext to USB **without rebooting**, so the operator confirms before restarting.
- The readiness query is throttled to every 6s and only runs while the port is open (it's an `efibootmgr` agent-exec on the box); any error → gray. This also catches the FCoS "USB still in boot order" reinstall-stall after a reinstall completes.

## Plumbing
- **Scope `/api/system/boot/usb-next`**: `GET → 'read'`, `POST`/`DELETE → 'mutate'`, so the TUI's scoped token (`read|lifecycle|mutate|destroy`) can query/enable without a cookie login. The frontend already drives this via cookie; this just lets a scoped-token client reach it. `POST` reboots only on explicit `reboot:true` (default false).
- **TUI rest client** (`rest/boot.go`): `USBBootStatus()` + `EnableUSBBoot()` + `assessUSBBoot` (mirrors `assessUsbBootReadiness` in `mcp/efibootmgr.ts`). Unit-tested.
- **watch package**: `USBState` + `usbGlyph` + `Probe.USB`, rendered in `Render`'s Status row (signature unchanged — `Observe` is anonymous and leaves USB unset; the UI layer fills it from the authed query). Token threaded through `NewWatch`/`NewWatchReinstall` and all callers.

## Tests
Go: `assessUSBBoot` table test, `Render` USB-row test, `usbStatusMsg` updates the glyph, `u` gated on token + open port. All green; `gofmt` clean; `go vet` clean.

## Scope note
Grants `mutate`-scoped tokens the ability to set BootNext + reboot — a deliberate capability for the trusted operator TUI, consistent with `mutate` already covering config writes. Not a new privilege class.

## Needs box `/verify`
Once on a box that has this, confirm the dot reflects real `efibootmgr` state and `u` sets BootNext. (The scope change must be deployed first — the box is on 4.57.0, which predates it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
