### PR TITLE
feat(tui): Home Assistant backup extract + manifest-filter in Go

### DIFF
--- a/tools/sb-tui/internal/habackup/habackup.go
+++ b/tools/sb-tui/internal/habackup/habackup.go
@@ -1,0 +1,135 @@
+// Package habackup turns a Home Assistant OS (Supervisor) backup into the
+// ServiceBay on-NAS config format entirely client-side — so the TUI can FTP the
+// result straight to the FritzBox without the box's server ever touching the
+// file (the server-side import-ha/upload routes are bypassed by design).
+//
+// A Supervisor backup is a tar holding backup.json, homeassistant.tar.gz, and
+// per-add-on core_*.tar.gz. The dockerized HA only needs the core config under
+// the inner archive's data/ dir. We stream the inner archive and keep ONLY the
+// manifest include paths (never the 150 MB+ DB or HACS frontend), emitting a
+// plain tar of those files at root — byte-for-byte the shape the box's restore
+// flow expects at sb-backup/<service>.tar.
+package habackup
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	innerArchive = "homeassistant.tar.gz"
+	dataPrefix   = "data/"
+)
+
+// HomeAssistantIncludes mirrors the home-assistant manifest in
+// packages/backend/src/lib/externalBackup/serviceManifest.ts (the source of
+// truth). Keep the two in sync — TestHomeAssistantIncludesMatchManifest guards
+// against drift by parsing the TS file.
+var HomeAssistantIncludes = []string{
+	"automations.yaml", "scripts.yaml", "scenes.yaml", "configuration.yaml",
+	".storage/core.config_entries", ".storage/core.device_registry",
+	".storage/core.entity_registry", ".storage/core.area_registry",
+	".storage/lovelace", ".storage/lovelace_dashboards",
+	".storage/zwave_js",
+}
+
+// normalize strips a leading "./" and any trailing "/" from a tar member name.
+func normalize(name string) string {
+	name = strings.TrimPrefix(name, "./")
+	return strings.TrimRight(name, "/")
+}
+
+// wanted reports whether an inner member (relative to data/) is covered by one
+// of the include paths — either the include itself (a file) or anything beneath
+// it (a dir include).
+func wanted(rel string, includes []string) bool {
+	for _, inc := range includes {
+		if rel == inc || strings.HasPrefix(rel, inc+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractAndFilter reads the Supervisor backup at haBackupPath and returns a
+// plain (uncompressed) tar containing only the include files, at root with the
+// data/ prefix stripped. Returns an error if the file isn't an HA backup or has
+// none of the include files.
+func ExtractAndFilter(haBackupPath string, includes []string) ([]byte, error) {
+	f, err := os.Open(haBackupPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Locate the inner homeassistant.tar.gz member in the outer tar; tr is then
+	// positioned at its content so we can stream it without buffering ~70 MB.
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("not a Home Assistant backup: %s not found", innerArchive)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if normalize(hdr.Name) == innerArchive {
+			break
+		}
+	}
+
+	gz, err := gzip.NewReader(tr)
+	if err != nil {
+		return nil, fmt.Errorf("inner %s is not gzip: %w", innerArchive, err)
+	}
+	defer gz.Close()
+
+	var out bytes.Buffer
+	tw := tar.NewWriter(&out)
+	kept := 0
+	itr := tar.NewReader(gz)
+	for {
+		ihdr, err := itr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if ihdr.Typeflag != tar.TypeReg { // files only — no dirs/symlinks reach the NAS
+			continue
+		}
+		norm := normalize(ihdr.Name)
+		if !strings.HasPrefix(norm, dataPrefix) {
+			continue
+		}
+		rel := strings.TrimPrefix(norm, dataPrefix)
+		if !wanted(rel, includes) {
+			continue
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     rel,
+			Mode:     0o644,
+			Size:     ihdr.Size,
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(tw, itr); err != nil {
+			return nil, err
+		}
+		kept++
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if kept == 0 {
+		return nil, fmt.Errorf("Home Assistant backup has no recognised config files under %s", dataPrefix)
+	}
+	return out.Bytes(), nil
+}

--- a/tools/sb-tui/internal/habackup/habackup_test.go
+++ b/tools/sb-tui/internal/habackup/habackup_test.go
@@ -1,0 +1,168 @@
+package habackup
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// buildFakeHaBackup writes a minimal Supervisor backup tar: an outer tar with
+// backup.json + homeassistant.tar.gz, whose inner archive has files under data/.
+func buildFakeHaBackup(t *testing.T, innerFiles map[string]string) string {
+	t.Helper()
+
+	// inner tar.gz (data/ layout)
+	var innerTar bytes.Buffer
+	itw := tar.NewWriter(&innerTar)
+	for name, content := range innerFiles {
+		if err := itw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := itw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := itw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var innerGz bytes.Buffer
+	gw := gzip.NewWriter(&innerGz)
+	if _, err := gw.Write(innerTar.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// outer tar
+	path := filepath.Join(t.TempDir(), "ha-backup.tar")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	otw := tar.NewWriter(f)
+	writeMember := func(name string, data []byte) {
+		if err := otw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := otw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeMember("backup.json", []byte(`{"version":2}`))
+	writeMember(innerArchive, innerGz.Bytes())
+	if err := otw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// readTar returns the regular-file entries of a tar as name->content.
+func readTar(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(tr); err != nil {
+			t.Fatal(err)
+		}
+		out[hdr.Name] = buf.String()
+	}
+	return out
+}
+
+func TestExtractAndFilter_KeepsIncludesDropsBulk(t *testing.T) {
+	backup := buildFakeHaBackup(t, map[string]string{
+		"data/configuration.yaml":            "default_config:",
+		"data/.storage/zwave_js":             `{"keys":"MESH"}`,
+		"data/.storage/core.entity_registry": "{}",
+		"data/home-assistant_v2.db":          "BIGDB",          // not an include
+		"data/custom_components/hacs/x.js":   "frontend-bloat", // not an include
+		"data/home-assistant.log":            "noise",          // not an include
+	})
+
+	out, err := ExtractAndFilter(backup, HomeAssistantIncludes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := readTar(t, out)
+
+	if files["configuration.yaml"] != "default_config:" {
+		t.Errorf("configuration.yaml missing/wrong: %q", files["configuration.yaml"])
+	}
+	if files[".storage/zwave_js"] != `{"keys":"MESH"}` {
+		t.Errorf(".storage/zwave_js missing/wrong: %q", files[".storage/zwave_js"])
+	}
+	for _, gone := range []string{"home-assistant_v2.db", "custom_components/hacs/x.js", "home-assistant.log"} {
+		if _, present := files[gone]; present {
+			t.Errorf("bulk file %q should not be in the filtered tar", gone)
+		}
+	}
+}
+
+func TestExtractAndFilter_RejectsNonHaBackup(t *testing.T) {
+	// An outer tar with no homeassistant.tar.gz member.
+	path := filepath.Join(t.TempDir(), "not-ha.tar")
+	f, _ := os.Create(path)
+	tw := tar.NewWriter(f)
+	_ = tw.WriteHeader(&tar.Header{Name: "random.txt", Mode: 0o644, Size: 1, Typeflag: tar.TypeReg})
+	_, _ = tw.Write([]byte("x"))
+	_ = tw.Close()
+	_ = f.Close()
+
+	if _, err := ExtractAndFilter(path, HomeAssistantIncludes); err == nil {
+		t.Fatal("expected an error for a non-HA backup")
+	}
+}
+
+func TestExtractAndFilter_RejectsNoConfigFiles(t *testing.T) {
+	backup := buildFakeHaBackup(t, map[string]string{
+		"data/home-assistant_v2.db": "BIGDB", // present but not an include
+	})
+	if _, err := ExtractAndFilter(backup, HomeAssistantIncludes); err == nil {
+		t.Fatal("expected an error when no include files are present")
+	}
+}
+
+// TestHomeAssistantIncludesMatchManifest guards against the Go include list
+// drifting from the TS manifest (the source of truth). Skips if the repo file
+// isn't reachable from the test's working dir.
+func TestHomeAssistantIncludesMatchManifest(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "..", "..", "packages", "backend", "src", "lib", "externalBackup", "serviceManifest.ts")
+	src, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Skipf("manifest not reachable (%v) — skipping drift guard", err)
+	}
+	// Grab the home-assistant block's include: [ ... ] and pull single-quoted strings.
+	block := regexp.MustCompile(`(?s)service:\s*'home-assistant'.*?include:\s*\[(.*?)\]`).FindSubmatch(src)
+	if block == nil {
+		t.Fatal("could not locate home-assistant include block in serviceManifest.ts")
+	}
+	tsIncludes := regexp.MustCompile(`'([^']+)'`).FindAllStringSubmatch(string(block[1]), -1)
+	got := map[string]bool{}
+	for _, m := range tsIncludes {
+		got[m[1]] = true
+	}
+	for _, inc := range HomeAssistantIncludes {
+		if !got[inc] {
+			t.Errorf("Go include %q is not in the TS manifest — drift", inc)
+		}
+		delete(got, inc)
+	}
+	for leftover := range got {
+		t.Errorf("TS manifest include %q is missing from the Go list — drift", leftover)
+	}
+}


### PR DESCRIPTION
## What
Ports the server's HA-backup extract + manifest-filter to Go (`internal/habackup`), so the TUI can build the small `sb-backup/<service>.tar` locally — the foundational, client-side piece of the direct-FTP upload.

## Why
Part of #1367. The server's upload path is blocked by the Next `/api/*` ~10 MB request-body cap; doing the extract client-side + (next) FTP straight to the FritzBox sidesteps it. `ExtractAndFilter` keeps only the manifest include paths (never the 150 MB+ DB / HACS frontend) and emits the exact on-NAS shape the restore flow (#1363) reads back. The include-list is drift-guarded against `serviceManifest.ts` by a test.

## Risk
Low — new, unused-until-wired Go package (no consumer yet); pure tar transform, 4 unit tests incl. the drift guard.

## Rollback
`git revert` is enough.

## Verification
- [x] go build / vet / gofmt clean
- [x] go test ./internal/habackup (4 pass)
- [ ] npm run lint / check:arch / npm test — N/A (Go-only, `tools/sb-tui`; not path-mandated → no `/verify`)

Follow-up: FTP client + credential prompt + panel wiring (the UX-heavy part, to design with the operator).