### PR TITLE
feat(external-backup): on-demand back-up-all-services-to-NAS endpoint

### DIFF
--- a/packages/backend/src/lib/externalBackup/backupAll.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAll.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const { mockNas, mockCfg } = vi.hoisted(() => ({
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+  mockCfg: { getConfig: vi.fn() },
+}));
+vi.mock('./nasClient', () => mockNas);
+vi.mock('../config', () => mockCfg);
+
+import { backupInstalledServicesToNas } from './producer';
+
+let tmpRoot: string;
+
+async function write(rel: string, content: string) {
+  const full = path.join(tmpRoot, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockNas.nasUpload.mockResolvedValue(undefined);
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'backupall-'));
+});
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('backupInstalledServicesToNas', () => {
+  it('backs up only installed manifest services, skipping the rest', async () => {
+    // adguard is installed (with a manifest config file); home-assistant is NOT.
+    await write('adguard/conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+    mockCfg.getConfig.mockResolvedValue({
+      templateSettings: { DATA_DIR: tmpRoot },
+      installedTemplates: { adguard: { schemaVersion: 1, installedAt: 'x' } },
+    });
+
+    const results = await backupInstalledServicesToNas();
+
+    // Only adguard ran; home-assistant/authelia/etc. are not installed → not attempted.
+    expect(results.map(r => r.service)).toEqual(['adguard']);
+    expect(results[0]).toMatchObject({ service: 'adguard', ok: true, tarName: 'adguard.tar' });
+    // The tar + meta were uploaded to the NAS.
+    const uploaded = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
+    expect(uploaded).toContain('sb-backup/adguard.tar');
+  });
+
+  it('captures a per-service failure without aborting the run', async () => {
+    // adguard installed but its data dir is missing its config → produces no
+    // files → backupServiceToNas throws; the run records it as ok:false.
+    mockCfg.getConfig.mockResolvedValue({
+      templateSettings: { DATA_DIR: tmpRoot },
+      installedTemplates: { adguard: { schemaVersion: 1, installedAt: 'x' } },
+    });
+
+    const results = await backupInstalledServicesToNas();
+    expect(results).toHaveLength(1);
+    expect(results[0].service).toBe('adguard');
+    expect(results[0].ok).toBe(false);
+    expect(results[0].error).toBeTruthy();
+  });
+
+  it('returns empty when nothing with a manifest is installed', async () => {
+    mockCfg.getConfig.mockResolvedValue({ installedTemplates: { 'some-unmanaged-thing': {} } });
+    expect(await backupInstalledServicesToNas()).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -26,6 +26,7 @@ import { nasUpload, nasDownload, nasList } from './nasClient';
 import {
   getServiceManifest,
   applyStripRules,
+  SERVICE_BACKUP_MANIFESTS,
   type ServiceBackupManifest,
 } from './serviceManifest';
 
@@ -182,6 +183,37 @@ export async function backupServiceToNas(
   const serviceDataDir = opts.serviceDataDir ?? (await resolveServiceDataDir(service));
   const tar = await buildServiceBackupTar(serviceDataDir, manifest);
   return writeServiceBackupToNas(service, tar);
+}
+
+/** One service's outcome in an on-demand backup-all run. */
+export interface ServiceBackupRunEntry {
+  service: string;
+  ok: boolean;
+  tarName?: string;
+  size?: number;
+  error?: string;
+}
+
+/**
+ * On-demand "back up now" (#1217): back up every INSTALLED service that has a
+ * backup manifest to the NAS, in one pass. Per-service failures are captured in
+ * the result (one bad service doesn't abort the rest) — a NAS-not-configured /
+ * connection error surfaces on the first attempt and repeats per service, which
+ * the caller can detect (all `ok:false` with the same error).
+ */
+export async function backupInstalledServicesToNas(): Promise<ServiceBackupRunEntry[]> {
+  const installed = new Set(Object.keys((await getConfig()).installedTemplates ?? {}));
+  const results: ServiceBackupRunEntry[] = [];
+  for (const manifest of SERVICE_BACKUP_MANIFESTS) {
+    if (!installed.has(manifest.service)) continue;
+    try {
+      const r = await backupServiceToNas(manifest.service);
+      results.push({ service: manifest.service, ok: true, tarName: r.tarName, size: r.size });
+    } catch (e) {
+      results.push({ service: manifest.service, ok: false, error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return results;
 }
 
 /**

--- a/packages/frontend/src/app/api/system/external-backup/backup-now/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/backup-now/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { backupInstalledServicesToNas } from '@/lib/externalBackup/producer';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST — on-demand "back up config now" (#1217, epic #1190): back up every
+ * installed service that has a backup manifest to the FritzBox NAS in one pass.
+ * Per-service failures are reported in the result rather than aborting the run.
+ * `tokenScope: 'mutate'` so the sb-tui flow can trigger it with a scoped token.
+ *
+ * This is the backend half; the nightly cron + the per-service Settings button
+ * are the path-mandated remainder of #1217.
+ */
+export const POST = withApiHandler({ tokenScope: 'mutate' }, async () => {
+  try {
+    const results = await backupInstalledServicesToNas();
+    const ok = results.filter(r => r.ok).length;
+    return NextResponse.json({ ok: true, backedUp: ok, total: results.length, results });
+  } catch (e) {
+    // Whole-run failure (e.g. NAS not configured) — operator-fixable, curated;
+    // surface it like the other external-backup routes.
+    return apiError(e, { tag: 'api:system:external-backup:backup-now', status: 400, exposeMessage: true });
+  }
+});


### PR DESCRIPTION
## What
`POST /api/system/external-backup/backup-now` (`tokenScope: mutate`) — backs up every installed service that has a backup manifest to the FritzBox NAS in one pass, via a new `backupInstalledServicesToNas()` producer helper.

## Why
Part of #1217 (nightly + on-demand backup triggers). This is the **backend half** — the part that's buildable + verifiable without a browser. Per-service failures are captured in the result (one bad service doesn't abort the run); whole-run errors (e.g. NAS not configured) surface like the sibling external-backup routes.

## Risk
Low — composes the existing, tested producer; new endpoint is additive (`tokenScope: mutate`). 3 unit tests (installed-only selection, per-service failure capture, empty case).

## Rollback
`git revert` is enough.

## Verification
- [x] npm test (externalBackup: 60 pass incl. 3 new)
- [x] npm run lint (0 errors), check:arch (clean)
- [ ] /verify — N/A (not path-mandated: `lib/externalBackup` + an api route)

Remaining #1217: nightly cron (config.ts schedule + scheduler) and the per-service Settings button — both path-mandated.