### PR TITLE
fix(tui): auto-install missing build-host tools instead of dead-ending

### DIFF
--- a/tools/sb-tui/internal/buildflow/tools.go
+++ b/tools/sb-tui/internal/buildflow/tools.go
@@ -1,6 +1,12 @@
 package buildflow
 
-import "os/exec"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
 
 // requiredTools are the build-host executables the native ISO build shells out
 // to: openssl (password hash), ssh-keygen (container->host key), butane
@@ -8,7 +14,7 @@ import "os/exec"
 var requiredTools = []string{"openssl", "ssh-keygen", "butane", "coreos-installer"}
 
 // MissingTools returns the required build-host tools not found on PATH, so the
-// caller can fail fast with an actionable message before starting the wizard.
+// caller can offer to install them before starting the wizard.
 func MissingTools() []string {
 	var missing []string
 	for _, t := range requiredTools {
@@ -17,4 +23,127 @@ func MissingTools() []string {
 		}
 	}
 	return missing
+}
+
+// butaneArch maps Go's GOARCH to the arch token in butane's release asset name.
+func butaneArch(goarch string) string {
+	if goarch == "arm64" {
+		return "aarch64"
+	}
+	return "x86_64" // amd64 (and anything else falls back to the common case)
+}
+
+// butaneDownloadURL is the GitHub "latest" static-binary URL for the host arch.
+// butane isn't in distro repos, so (like the old install-fedora-coreos.sh) we
+// fetch the release binary directly.
+func butaneDownloadURL(goarch string) string {
+	return fmt.Sprintf(
+		"https://github.com/coreos/butane/releases/latest/download/butane-%s-unknown-linux-gnu",
+		butaneArch(goarch),
+	)
+}
+
+// pkgManager is a detected system package manager and how it installs a package.
+type pkgManager struct {
+	name        string
+	installArgs []string          // command prefix, e.g. ["sudo","dnf","install","-y"]
+	pkgName     map[string]string // tool -> this distro's package name (when it differs)
+}
+
+// detectPkgManager picks the first supported package manager on PATH. look is
+// injectable for tests; nil uses exec.LookPath.
+func detectPkgManager(look func(string) (string, error)) *pkgManager {
+	if look == nil {
+		look = exec.LookPath
+	}
+	has := func(cmd string) bool { _, err := look(cmd); return err == nil }
+	switch {
+	case has("dnf"):
+		return &pkgManager{"dnf", []string{"sudo", "dnf", "install", "-y"}, map[string]string{"ssh-keygen": "openssh-clients"}}
+	case has("apt-get"):
+		return &pkgManager{"apt-get", []string{"sudo", "apt-get", "install", "-y"}, map[string]string{"ssh-keygen": "openssh-client"}}
+	case has("pacman"):
+		return &pkgManager{"pacman", []string{"sudo", "pacman", "-S", "--noconfirm"}, map[string]string{"ssh-keygen": "openssh"}}
+	case has("zypper"):
+		return &pkgManager{"zypper", []string{"sudo", "zypper", "install", "-y"}, map[string]string{"ssh-keygen": "openssh"}}
+	}
+	return nil
+}
+
+// toolPackage returns the distro package name that provides a tool.
+func (p *pkgManager) toolPackage(tool string) string {
+	if n, ok := p.pkgName[tool]; ok {
+		return n
+	}
+	return tool // openssl, coreos-installer share their tool name as the package
+}
+
+// InstallMissingTools installs each missing build-host tool, mirroring the old
+// install-fedora-coreos.sh: butane from its GitHub release binary, everything
+// else via the detected package manager (coreos-installer falls back to cargo
+// on apt, where it has no package). Output streams to stdout/err; the caller is
+// expected to have already confirmed with the operator (it runs sudo).
+func InstallMissingTools(missing []string, logf func(string, ...any)) error {
+	pm := detectPkgManager(nil)
+	for _, tool := range missing {
+		switch tool {
+		case "butane":
+			if err := installButane(logf); err != nil {
+				return fmt.Errorf("install butane: %w", err)
+			}
+		case "coreos-installer":
+			if err := installCoreosInstaller(pm, logf); err != nil {
+				return fmt.Errorf("install coreos-installer: %w", err)
+			}
+		default: // openssl, ssh-keygen
+			if pm == nil {
+				return fmt.Errorf("no supported package manager found to install %q — install it manually", tool)
+			}
+			if err := runCmd(logf, append(append([]string{}, pm.installArgs...), pm.toolPackage(tool))...); err != nil {
+				return fmt.Errorf("install %s via %s: %w", tool, pm.name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func installButane(logf func(string, ...any)) error {
+	url := butaneDownloadURL(runtime.GOARCH)
+	const dest = "/usr/local/bin/butane"
+	logf("Installing butane from %s\n", url)
+	switch {
+	case hasCmd("curl"):
+		if err := runCmd(logf, "sudo", "curl", "-sSL", "-o", dest, url); err != nil {
+			return err
+		}
+	case hasCmd("wget"):
+		if err := runCmd(logf, "sudo", "wget", "-qO", dest, url); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("neither curl nor wget is available to download butane")
+	}
+	return runCmd(logf, "sudo", "chmod", "+x", dest)
+}
+
+func installCoreosInstaller(pm *pkgManager, logf func(string, ...any)) error {
+	// dnf/pacman/zypper ship a coreos-installer package; apt does not.
+	if pm != nil && pm.name != "apt-get" {
+		return runCmd(logf, append(append([]string{}, pm.installArgs...), "coreos-installer")...)
+	}
+	if !hasCmd("cargo") {
+		return fmt.Errorf("coreos-installer has no package on this distro and cargo isn't installed — " +
+			"install Rust (https://rustup.rs), then re-run, or run `cargo install coreos-installer` manually")
+	}
+	logf("Installing coreos-installer via cargo (no distro package available)…\n")
+	return runCmd(logf, "cargo", "install", "coreos-installer")
+}
+
+func hasCmd(cmd string) bool { _, err := exec.LookPath(cmd); return err == nil }
+
+func runCmd(logf func(string, ...any), args ...string) error {
+	logf("  $ %s\n", strings.Join(args, " "))
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, os.Stdin
+	return cmd.Run()
 }

--- a/tools/sb-tui/internal/buildflow/tools_test.go
+++ b/tools/sb-tui/internal/buildflow/tools_test.go
@@ -1,0 +1,59 @@
+package buildflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestButaneDownloadURL(t *testing.T) {
+	if got := butaneDownloadURL("amd64"); got != "https://github.com/coreos/butane/releases/latest/download/butane-x86_64-unknown-linux-gnu" {
+		t.Errorf("amd64 URL = %q", got)
+	}
+	if got := butaneDownloadURL("arm64"); !strings.Contains(got, "butane-aarch64-unknown-linux-gnu") {
+		t.Errorf("arm64 URL = %q, want aarch64 asset", got)
+	}
+}
+
+func lookOnly(present ...string) func(string) (string, error) {
+	set := map[string]bool{}
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(cmd string) (string, error) {
+		if set[cmd] {
+			return "/usr/bin/" + cmd, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func TestDetectPkgManager(t *testing.T) {
+	cases := []struct {
+		present  []string
+		wantName string
+		sshPkg   string
+	}{
+		{[]string{"dnf"}, "dnf", "openssh-clients"},
+		{[]string{"apt-get"}, "apt-get", "openssh-client"},
+		{[]string{"pacman"}, "pacman", "openssh"},
+		{[]string{"zypper"}, "zypper", "openssh"},
+		{[]string{"dnf", "apt-get"}, "dnf", "openssh-clients"}, // dnf wins (ordered)
+	}
+	for _, tc := range cases {
+		pm := detectPkgManager(lookOnly(tc.present...))
+		if pm == nil || pm.name != tc.wantName {
+			t.Fatalf("present %v → %v, want %s", tc.present, pm, tc.wantName)
+		}
+		if got := pm.toolPackage("ssh-keygen"); got != tc.sshPkg {
+			t.Errorf("%s ssh-keygen pkg = %q, want %q", pm.name, got, tc.sshPkg)
+		}
+		// Tools without a distro-specific name map to themselves.
+		if got := pm.toolPackage("openssl"); got != "openssl" {
+			t.Errorf("%s openssl pkg = %q, want openssl", pm.name, got)
+		}
+	}
+	if pm := detectPkgManager(lookOnly("brew" /* unsupported */)); pm != nil {
+		t.Errorf("no supported manager → want nil, got %v", pm)
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -90,10 +90,42 @@ func generateSSHKey() (string, error) {
 // runExecute runs a confirmed build Plan in the normal terminal: the bake
 // streams output and the USB flash needs sudo + a real TTY, so this runs after
 // any alt-screen program has exited.
+// ensureBuildTools checks for the build-host tools and, when some are missing,
+// OFFERS to auto-install them (butane from its GitHub release binary, the rest
+// via the package manager / cargo) rather than dead-ending with "install them
+// by hand" — restoring the old install-fedora-coreos.sh behaviour (#1327).
+// Returns true when every tool is present.
+func ensureBuildTools() bool {
+	missing := buildflow.MissingTools()
+	if len(missing) == 0 {
+		return true
+	}
+	fmt.Fprintf(os.Stderr, "Missing build-host tools: %v\n", missing)
+	fmt.Fprint(os.Stderr, "Install them now? (curl-fetches butane + uses your package manager; needs sudo) [Y/n] ")
+	if !readYes() {
+		fmt.Fprintln(os.Stderr, "Skipped. Install manually (Fedora: sudo dnf install butane coreos-installer openssl openssh) and retry.")
+		return false
+	}
+	if err := buildflow.InstallMissingTools(missing, func(f string, a ...any) { fmt.Fprintf(os.Stderr, f, a...) }); err != nil {
+		fmt.Fprintln(os.Stderr, "install failed:", err)
+		return false
+	}
+	if still := buildflow.MissingTools(); len(still) > 0 {
+		fmt.Fprintf(os.Stderr, "Still missing after install: %v — check the output above.\n", still)
+		return false
+	}
+	return true
+}
+
+// readYes reads a Y/n answer from stdin, defaulting to yes on empty input.
+func readYes() bool {
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "" || line == "y" || line == "yes"
+}
+
 func runExecute(plan buildflow.Plan) int {
-	if missing := buildflow.MissingTools(); len(missing) > 0 {
-		fmt.Fprintf(os.Stderr, "Cannot build an ISO — missing build-host tools: %v\n", missing)
-		fmt.Fprintln(os.Stderr, "Install them and retry (Fedora: sudo dnf install butane coreos-installer openssl openssh).")
+	if !ensureBuildTools() {
 		return 2
 	}
 	if err := buildflow.Execute(plan, buildflow.Options{BuildDir: probes.BuildDir(), Deps: buildflow.DefaultDeps()},
@@ -108,9 +140,7 @@ func runExecute(plan buildflow.Plan) int {
 // the full-screen form gathers a Plan, then runExecute runs it. The menu's
 // BuildISO action instead hosts the form in-app so esc returns to the menu.
 func runBuild() int {
-	if missing := buildflow.MissingTools(); len(missing) > 0 {
-		fmt.Fprintf(os.Stderr, "Cannot build an ISO — missing build-host tools: %v\n", missing)
-		fmt.Fprintln(os.Stderr, "Install them and retry (Fedora: sudo dnf install butane coreos-installer openssl openssh).")
+	if !ensureBuildTools() {
 		return 2
 	}
 	cfg := buildConfig()


### PR DESCRIPTION
## What
When `sb-tui`'s ISO build finds missing build-host tools, **offer to install them** (Y/n) instead of erroring with "install them by hand."

## Why
Closes #1327 — a regression from the deleted `install-fedora-coreos.sh`, which auto-installed butane/coreos-installer/openssl/ssh-keygen so a reinstall "just worked" on a fresh laptop. The Go port only *detected* them, dead-ending the exact reinstall path the TUI owns.

Mirrors the old `install_packages()`:
- **butane** → GitHub "latest" static binary (not in distro repos),
- **coreos-installer** → dnf/pacman/zypper package, or `cargo` on apt (no package),
- **openssl/ssh-keygen** → detected package manager (dnf/apt/pacman/zypper).

If cargo is absent on apt, it prints the exact next step rather than silently pulling rustup.

## Risk
Low-medium — runs `sudo` package installs, but only after an explicit Y/n and in the normal build terminal (not alt-screen). Pure helpers (butane URL per arch, PM detection + per-distro package names) are unit-tested; the actual install can't be exercised in the dev container (no FCoS build host) — verified by the operator on a real build.

## Rollback
`git revert`.

## Verification
- [x] go build / vet / gofmt clean; go test ./... (all pass, incl. new tools_test)
- [ ] /verify — N/A (`tools/sb-tui`, not path-mandated); real install confirmed on the next fresh-machine build