### PR TITLE
fix(backup): allow within-root symlinks so NPM cert backups can be created

### DIFF
--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -217,6 +217,20 @@ async function runTar(args: string[]) {
  *
  * `assertNoSymlinkEscape` (local path only) stays as defense in depth.
  */
+/**
+ * Whether a symlink's target points outside the extraction root, given the
+ * link's own path within the archive. Absolute targets always escape; relative
+ * targets are resolved against the link's directory and escape only if they
+ * climb above the root. Internal links (Let's Encrypt's
+ * `live/x/cert.pem -> ../../archive/x/cert1.pem`) stay within root → allowed.
+ */
+function linkTargetEscapes(linkName: string, target: string): boolean {
+    if (!target) return false;
+    if (path.posix.isAbsolute(target)) return true;
+    const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(linkName), target));
+    return resolved === '..' || resolved.startsWith('../');
+}
+
 async function assertSafeArchiveEntries(archivePath: string, gzip = true): Promise<void> {
     let stdout: string;
     try {
@@ -241,21 +255,28 @@ async function assertSafeArchiveEntries(archivePath: string, gzip = true): Promi
         // 4=time, 5+=name (possibly containing spaces + `-> linkname`).
         const nameField = tokens.slice(5).join(' ');
         if (!nameField) continue;
-        if (typeChar === 'l' || typeChar === 'h') {
-            // For l-type the format is `name -> target`; show both so
-            // the operator sees what was attempted.
+        if (typeChar === 'h') {
+            // Hardlinks would create extra references to already-extracted
+            // files; no legitimate purpose in a config payload.
             throw new Error(
-                `Refused archive ${path.basename(archivePath)}: contains ` +
-                `${typeChar === 'l' ? 'symlink' : 'hardlink'} "${nameField}". ` +
-                `Backup payloads are control-plane configs only — links have ` +
-                `no legitimate purpose and would let a crafted archive escape ` +
-                `the extraction directory.`,
+                `Refused archive ${path.basename(archivePath)}: contains hardlink "${nameField}".`,
             );
         }
-        // The bare entry name is the first token of the name field
-        // (everything before ` -> ` for links, which we already
-        // rejected above — but defensive split).
+        // The bare entry name is everything before ` -> ` (for symlinks).
         const entry = nameField.split(' -> ')[0];
+        if (typeChar === 'l') {
+            // Allow symlinks whose target resolves WITHIN the extraction root
+            // — e.g. Let's Encrypt's `live/x/cert.pem -> ../../archive/x/cert.pem`
+            // that NPM ships in its config (#1381). Refuse only escaping links;
+            // assertNoSymlinkEscape re-validates resolved targets post-extract.
+            const target = nameField.slice(nameField.indexOf(' -> ') + 4);
+            if (linkTargetEscapes(entry, target)) {
+                throw new Error(
+                    `Refused archive ${path.basename(archivePath)}: symlink "${entry}" -> "${target}" ` +
+                    `points outside the extraction directory.`,
+                );
+            }
+        }
         if (entry.startsWith('/')) {
             throw new Error(`Refused archive ${path.basename(archivePath)}: contains absolute path "${entry}"`);
         }

--- a/tests/backend/backup_restore_security.test.ts
+++ b/tests/backend/backup_restore_security.test.ts
@@ -121,13 +121,9 @@ tf.close()
     expect(fs.readFileSync(sentinelFile, 'utf8')).toBe('ORIGINAL_CONTENTS');
   });
 
-  maybeIt('refuses any archive containing a symlink (#590 Option B)', async () => {
-    // Backup payloads are control-plane Quadlets + config only —
-    // symlinks have no legitimate purpose. Refusing them at the
-    // pre-check means the local AND remote restore paths get the
-    // same protection. This test used to assert refusal in the
-    // post-extract walk; after #590 it asserts refusal at the
-    // earlier pre-check stage with a clearer message.
+  maybeIt('refuses a symlink with an absolute target', async () => {
+    // Symlinks are allowed only when they resolve within the archive root
+    // (#1381); an absolute target escapes and is refused at the pre-check.
     const src = mktmpDir('symlink-src');
     const linkPath = path.join(src, 'bad-link');
     fs.symlinkSync(sentinelFile, linkPath);
@@ -145,7 +141,7 @@ tf.close()
     expect(fs.readFileSync(sentinelFile, 'utf8')).toBe('ORIGINAL_CONTENTS');
   });
 
-  maybeIt('refuses a relative symlink at pre-check (#590)', async () => {
+  maybeIt('refuses a relative symlink that escapes the root', async () => {
     const src = mktmpDir('relsym-src');
     const upPath = path.relative(src, sentinelFile);
     fs.symlinkSync(upPath, path.join(src, 'rel-link'));
@@ -175,5 +171,21 @@ tf.close()
 
     const dest = mktmpDir('dest-hardlink');
     await expect(safeTarExtract(archive, dest)).rejects.toThrow(/(hardlink|link)/i);
+  });
+
+  maybeIt('allows a symlink whose target stays within the archive (#1381)', async () => {
+    // Let's Encrypt ships `live/<n>/cert.pem -> ../../archive/<n>/certN.pem` in
+    // NPM's config; the target resolves inside the extraction root, so it must
+    // be allowed — else no NPM-cert box could create a backup.
+    const src = mktmpDir('insym-src');
+    fs.mkdirSync(path.join(src, 'archive', 'npm-1'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'archive', 'npm-1', 'cert1.pem'), 'CERT');
+    fs.mkdirSync(path.join(src, 'live', 'npm-1'), { recursive: true });
+    fs.symlinkSync('../../archive/npm-1/cert1.pem', path.join(src, 'live', 'npm-1', 'cert.pem'));
+    const archive = makeArchive({ prefix: 'insym', workingDir: src, entries: ['archive', 'live'] });
+
+    const dest = mktmpDir('dest-insym');
+    await safeTarExtract(archive, dest); // must not throw
+    expect(fs.readFileSync(path.join(dest, 'live', 'npm-1', 'cert.pem'), 'utf8')).toBe('CERT');
   });
 });


### PR DESCRIPTION
## What
`assertSafeArchiveEntries` now refuses a symlink only when its target **escapes** the extraction root; within-root links (NPM's Let's Encrypt `live/ → ../../archive/`) are allowed.

## Why
Closes #1381. The #590 "refuse all symlinks" pre-pass blocked the LE cert layout, so **no box with NPM-issued certs could create a system backup** (`createSystemBackup` safe-extracts the box's `data.tgz` locally). New `linkTargetEscapes` resolves the target against the link's dir; `assertNoSymlinkEscape` still re-validates after extraction (defense in depth); abs/traversal + hardlink refusals unchanged. The LE links are config (local extract), so the SSH-side awk (systemd units) is untouched.

## Risk
Medium — security-sensitive (loosens symlink handling). Mitigated: only within-root links pass the pre-pass, the post-extract walker still catches escapes, and 7 security tests cover absolute-target / relative-escape / hardlink refusals + the new within-root allow case.

## Verification
- [x] backup_restore_security.test.ts (7 pass, incl. the LE within-root allow + escaping-refuse cases); lint clean
- [ ] **real-box /verify** (path-mandated): on the box, Backups → create → succeeds (no "Refused archive … symlink" error), and restore round-trips.