### PR TITLE
fix(boot): sudo the reinstall reboot so it actually reboots

### DIFF
--- a/packages/frontend/src/app/api/system/boot/usb-next/route.ts
+++ b/packages/frontend/src/app/api/system/boot/usb-next/route.ts
@@ -127,7 +127,12 @@ export const POST = withApiHandler({ body: PostBody, tokenScope: 'mutate' }, asy
     
     if (body.reboot) {
       logger.info('api:system:boot:usb-next', 'Rebooting system as requested...');
-      agent.sendCommand('exec', { command: 'systemctl reboot' }).catch(() => {});
+      // sudo -n: the agent runs as the rootless `core` user, which can't reboot
+      // the host without it (a plain `systemctl reboot` is polkit-denied for a
+      // non-session service, so it silently no-ops — the box stays armed but
+      // never reboots). `core` has passwordless sudo (same as the efibootmgr
+      // calls above), so this is the working path. (#usb-next-reboot)
+      agent.sendCommand('exec', { command: 'sudo -n systemctl reboot' }).catch(() => {});
     }
     
     return NextResponse.json({


### PR DESCRIPTION
## What
`usb-next` reboot now runs `sudo -n systemctl reboot` instead of a bare `systemctl reboot`.

## Why
The route armed UEFI BootNext (via `sudo -n efibootmgr`) but the reboot had no `sudo` — and the rootless `core` agent can't reboot the host that way (polkit denies a non-session service), so it **silently no-ops**: the box reports "USB boot armed" but never reboots, and the operator must reboot by hand. **Observed live 2026-05-30** during a reinstall. `core` has passwordless sudo (same as the efibootmgr calls), so this is the working path.

## Risk
Low — one command, matches the `sudo -n` pattern already used for efibootmgr in this route.

## Verification
- [x] eslint (0 errors; 2 pre-existing warnings in the file, unchanged)
- [ ] **box /verify** (needs a reboot): once a box is up on this build, POST `usb-next {reboot:true}` (or "Boot from USB") and confirm it actually goes down — not just "armed". (Couldn't unit-test: it's a fire-and-forget agent exec.)