### PR TITLE
feat(tui): self-report build version

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -59,10 +59,13 @@ jobs:
           arch="${{ matrix.target }}"; arch="${arch#*/}"
           out="sb-tui-${os}-${arch}"
           [ "$os" = windows ] && out="${out}.exe"
+          # Stamp the binary with the repo version so `sb-tui version` and the
+          # launcher footer self-report which release it carries.
+          ver=$(jq -r .version ../../package.json)
           mkdir -p dist
-          echo "Building dist/${out} (GOOS=${os} GOARCH=${arch})"
+          echo "Building dist/${out} (GOOS=${os} GOARCH=${arch}) version=${ver}"
           CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
-            go build -trimpath -ldflags "-s -w" -o "dist/${out}" .
+            go build -trimpath -ldflags "-s -w -X main.version=${ver}" -o "dist/${out}" .
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/tools/sb-tui/internal/ui/menu.go
+++ b/tools/sb-tui/internal/ui/menu.go
@@ -243,7 +243,7 @@ func (m Model) View() string {
 	if m.cursor < len(m.rows) {
 		b.WriteString(detailStyle.Render(m.rows[m.cursor].Action.Detail) + "\n")
 	}
-	b.WriteString(footerStyle.Render("↑/↓ move · enter select · auto-refreshing · ctrl+c quit"))
+	b.WriteString(footerStyle.Render("↑/↓ move · enter select · auto-refreshing · ctrl+c quit  ·  sb-tui " + Version))
 	return frame(b.String(), m.width, m.height)
 }
 

--- a/tools/sb-tui/internal/ui/menu_test.go
+++ b/tools/sb-tui/internal/ui/menu_test.go
@@ -51,6 +51,17 @@ func TestMenuShowsURLWhenReachable(t *testing.T) {
 	}
 }
 
+// TestMenuFooterShowsVersion: the launcher footer self-reports the build version.
+func TestMenuFooterShowsVersion(t *testing.T) {
+	old := Version
+	Version = "9.9.9"
+	defer func() { Version = old }()
+	m := feed(New(readyDetect, "box", "5888"))
+	if v := m.View(); !strings.Contains(v, "sb-tui 9.9.9") {
+		t.Errorf("footer should show the version, got:\n%s", v)
+	}
+}
+
 // TestMenuInstallStatusLine: while installing, a compact live line shows the
 // stage + connectivity dots so the operator sees progress without opening the
 // full monitor.

--- a/tools/sb-tui/internal/ui/version.go
+++ b/tools/sb-tui/internal/ui/version.go
@@ -1,0 +1,6 @@
+package ui
+
+// Version is the released ServiceBay version this build carries, shown in the
+// launcher footer. main sets it from its own -ldflags-injected version at
+// startup; it defaults to "dev" for local builds.
+var Version = "dev"

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -33,6 +33,12 @@ import (
 	"servicebay-tui/internal/watch"
 )
 
+// version is the released ServiceBay version this binary was built from. It
+// defaults to "dev" for local `go run`/`go build` and is overridden at release
+// build time via -ldflags "-X main.version=<x.y.z>" (see release-binaries.yml),
+// so the shipped curl|sh binary self-reports which release it carries.
+var version = "dev"
+
 func detect(ctx context.Context) (bool, phase.BoxStatus) {
 	return probes.ISOBuilt(), probes.BoxStatus(ctx)
 }
@@ -299,8 +305,16 @@ func main() {
 	// Subcommands skip the menu and run one leg directly. `watch` is used by the
 	// install scripts' auto-launch; `build` runs the native ISO-build wizard
 	// (the same path the menu's BuildISO action takes).
+	// Surface the version into the UI layer so the menu can show it.
+	ui.Version = version
+
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
+		case "version", "--version", "-v":
+			// Print and exit before touching the TTY, so `sb-tui version` works
+			// in a pipe / non-interactive shell.
+			fmt.Printf("sb-tui %s\n", version)
+			return
 		case "watch":
 			os.Exit(runWatch())
 		case "build":


### PR DESCRIPTION
## What
Give sb-tui a version string:
- `sb-tui version` / `--version` prints `sb-tui <x.y.z>` and exits (before any TTY use, so it works in a pipe).
- The launcher footer shows `sb-tui <version>`.
- Default is `dev`; release builds inject the real version via `-ldflags "-X main.version=<x.y.z>"`, read from `package.json` in `release-binaries.yml`, so the shipped curl|sh binary self-reports its release.

## Why
The locally-installed binary was stale with no way to tell which build it was. Now operators (and we) can read the version off the tool.

## Risk
Low — confined to `tools/sb-tui` plus the binary-build workflow; no app behavior change beyond the new subcommand + footer text.

## Rollback
`git revert` of the merge.

## Verification
- [x] `gofmt -l`, `go vet ./...`, `go test ./...` (incl. footer-shows-version test)
- [x] `go run . version` → `sb-tui dev`; `-ldflags -X main.version=4.61.0` → `sb-tui 4.61.0`
- [ ] `/verify` on box — N/A (`tools/sb-tui`/workflow only; not path-mandated)