### PR TITLE
fix(tui): upload panel finds build-dir backups, robust path entry, boxed fields

### DIFF
--- a/tools/sb-tui/internal/habackup/candidates.go
+++ b/tools/sb-tui/internal/habackup/candidates.go
@@ -24,13 +24,24 @@ type Candidate struct {
 }
 
 const (
-	scanMaxDepth = 2   // how deep below each root to descend
+	scanMaxDepth = 3   // how deep below each root to descend
 	scanMaxFiles = 400 // hard cap on .tar files examined, to bound pathological trees
 	scanMaxPeek  = 40  // only validate the newest N as HA backups (peeking opens the tar)
 )
 
+// buildDir mirrors probes.BuildDir (kept duplicated to avoid an import cycle):
+// SB_BUILD_DIR, else ./build/fcos. It's where ServiceBay stages its own
+// artifacts, and a place operators drop backups, so it's an explicit scan root.
+func buildDir() string {
+	if d := os.Getenv("SB_BUILD_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join("build", "fcos")
+}
+
 // candidateRoots is the set of likely places an operator's backup .tar lives:
-// the browser's download dir, home, the current dir, and removable-media mounts.
+// the browser's download dir, home, the current dir, the ServiceBay build dir,
+// and removable-media mounts.
 func candidateRoots() []string {
 	var roots []string
 	if home, err := os.UserHomeDir(); err == nil {
@@ -39,6 +50,7 @@ func candidateRoots() []string {
 	if cwd, err := os.Getwd(); err == nil {
 		roots = append(roots, cwd)
 	}
+	roots = append(roots, buildDir())
 	return append(roots, "/media", "/run/media", "/mnt")
 }
 

--- a/tools/sb-tui/internal/habackup/candidates_test.go
+++ b/tools/sb-tui/internal/habackup/candidates_test.go
@@ -45,6 +45,19 @@ func TestIsHABackup(t *testing.T) {
 	}
 }
 
+func TestCandidateRootsIncludesBuildDir(t *testing.T) {
+	t.Setenv("SB_BUILD_DIR", "/tmp/sb-build-xyz")
+	found := false
+	for _, r := range candidateRoots() {
+		if r == "/tmp/sb-build-xyz" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("candidateRoots should include SB_BUILD_DIR, got %v", candidateRoots())
+	}
+}
+
 func TestScanDirsNewestFirstAndFlagsHA(t *testing.T) {
 	root := t.TempDir()
 	sub := filepath.Join(root, "sub")

--- a/tools/sb-tui/internal/ui/nasupload.go
+++ b/tools/sb-tui/internal/ui/nasupload.go
@@ -87,7 +87,7 @@ var fieldHints = [nasUploadFields]string{
 }
 
 func (m NasUploadModel) uploadCmd() tea.Cmd {
-	path, host, user, pass := expandHome(m.path.Value()), m.ftpHost.Value(), m.ftpUser.Value(), m.ftpPass.Value()
+	path, host, user, pass := resolvePath(m.path.Value()), m.ftpHost.Value(), m.ftpUser.Value(), m.ftpPass.Value()
 	return func() tea.Msg {
 		tar, err := habackup.ExtractAndFilter(path, habackup.HomeAssistantIncludes)
 		if err != nil {
@@ -255,12 +255,20 @@ func (m NasUploadModel) selectedCandidate() (habackup.Candidate, bool) {
 
 // pathIsFile reports whether v names an existing regular file.
 func pathIsFile(v string) bool {
-	v = strings.TrimSpace(v)
-	if v == "" {
+	if strings.TrimSpace(v) == "" {
 		return false
 	}
-	info, err := os.Stat(expandHome(v))
+	info, err := os.Stat(resolvePath(v))
 	return err == nil && info.Mode().IsRegular()
+}
+
+// resolvePath turns typed text into a path the OS can open: it trims surrounding
+// whitespace, drops a stray leading ":" (never valid at the start of a path — an
+// easy fat-finger), and expands a leading ~ to the home dir.
+func resolvePath(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, ":")
+	return expandHome(v)
 }
 
 // View renders the form.
@@ -342,7 +350,7 @@ func candidateRow(c habackup.Candidate, selected bool) string {
 	if c.IsHA {
 		mark = "✓"
 	}
-	name := filepath.Base(c.Path)
+	name := truncName(filepath.Base(c.Path), 40)
 	meta := fmt.Sprintf("%s · %s · %s", abbrevHome(filepath.Dir(c.Path)), humanSize(c.Size), fmtAge(time.Since(c.Mod)))
 	if selected {
 		return selectedStyle.Render("❯ " + mark + " " + name + "   " + meta)
@@ -369,6 +377,16 @@ func expandHome(p string) string {
 		return filepath.Join(home, p[2:])
 	}
 	return p
+}
+
+// truncName shortens a filename to max runes with a trailing ellipsis, so a long
+// backup name can't wrap the picker row.
+func truncName(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
 }
 
 // fmtAge renders how long ago a file was modified, compactly: "just now",

--- a/tools/sb-tui/internal/ui/nasupload_test.go
+++ b/tools/sb-tui/internal/ui/nasupload_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -8,6 +10,26 @@ import (
 
 	"servicebay-tui/internal/habackup"
 )
+
+// TestResolvePath: typed paths are made openable — whitespace trimmed, a stray
+// leading colon dropped, and ~ expanded (the bug behind "open :~/…: no such file").
+func TestResolvePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	cases := map[string]string{
+		"  ~/x.tar ":  filepath.Join(home, "x.tar"),
+		":~/x.tar":    filepath.Join(home, "x.tar"),
+		"/abs/x.tar":  "/abs/x.tar",
+		":/abs/x.tar": "/abs/x.tar",
+	}
+	for in, want := range cases {
+		if got := resolvePath(in); got != want {
+			t.Errorf("resolvePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
 
 func sampleCandidates() []habackup.Candidate {
 	return []habackup.Candidate{

--- a/tools/sb-tui/internal/ui/textinput.go
+++ b/tools/sb-tui/internal/ui/textinput.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -97,13 +99,18 @@ func (t textInput) display(focused bool) string {
 	return string(disp[:c]) + "▌" + string(disp[c:])
 }
 
-// render draws the field as `label: value` with the caret at the cursor when
-// focused, masking the value when secret. Matches the old fieldRow framing
-// (❯ + highlight when focused) so panels look unchanged apart from the caret.
+// render draws the field as the build form's standard input row — a static,
+// padded label followed by the editable value in an input box (`❯ Label  [ value ]`),
+// with a block caret when focused and bullets when secret. Shared by every
+// simple panel (login, usb-boot, NAS upload) so they match the build wizard.
 func (t textInput) render(label string, focused bool) string {
-	body := label + ": " + t.display(focused)
+	ls, is := labelStyle, inputStyle
 	if focused {
-		return selectedStyle.Render("❯ " + body)
+		ls, is = labelFocused, inputFocused
 	}
-	return normalStyle.Render("  " + body)
+	cursor := "  "
+	if focused {
+		cursor = "❯ "
+	}
+	return cursor + ls.Render(fmt.Sprintf("%-22s", label)) + is.Render(" "+t.display(focused)+" ")
 }


### PR DESCRIPTION
## What
Three fixes to the NAS-upload panel from a live report where the picker missed a staged backup and a typed path errored:

- **Find backups in the build dir**: the scan now includes the ServiceBay build dir (`SB_BUILD_DIR` or `./build/fcos`) and descends one level deeper, so a backup under `build/fcos/` is found instead of missed.
- **Robust path entry**: typed paths are sanitised before opening — trim whitespace, drop a stray leading `:`, expand a leading `~` — fixing `open :~/…: no such file or directory`.
- **Standard input fields**: the shared `textInput` now renders the build wizard's boxed row (`❯ Label  [ value ]`), so login / usb-boot / upload match the build form. Long candidate names are truncated so picker rows don't wrap.

## Why
The upload panel couldn't locate a backup staged in `build/fcos`, manual path entry failed on a fat-fingered `:`/unexpanded `~`, and the fields didn't match the build form's look.

## Risk
Low — confined to `tools/sb-tui` (the launcher); no app/backend behaviour change.

## Rollback
`git revert` of the merge.

## Verification
- [x] `gofmt`, `go vet`, `go test ./...` (resolvePath colon/tilde, build-dir root, scan depth, picker show/filter/select)
- [x] local install reproduces the report and now finds the `build/fcos` backup + accepts the typed path
- [ ] `/verify` on box — N/A (`tools/sb-tui` only; not path-mandated)