### PR TITLE
fix(tui): clearer install monitor — connectivity badge and USB-boot steps

### DIFF
--- a/tools/sb-tui/internal/ui/watch.go
+++ b/tools/sb-tui/internal/ui/watch.go
@@ -214,6 +214,12 @@ func (m WatchModel) View() string {
 	if m.usbMsg != "" {
 		out += "  " + m.usbMsg + "\n"
 	}
+	// Reinstall, box still up, no reboot yet: the install hasn't started — the
+	// box is serving the OLD install. Spell out what to do so the green dots +
+	// "connected" badge don't read as "done".
+	if m.requireReboot && m.tracker.Reboots == 0 && m.last.TCP {
+		out += "\n" + detailStyle.Render("This is still your CURRENT install — the reinstall hasn't started yet. To begin: plug the USB into THIS server, press u to arm USB boot, then reboot the box (or pick the USB in the box's firmware boot menu). This monitor takes over automatically once the box reboots into the installer.") + "\n"
+	}
 	return out
 }
 

--- a/tools/sb-tui/internal/watch/watch.go
+++ b/tools/sb-tui/internal/watch/watch.go
@@ -166,11 +166,15 @@ func (t *Tracker) Apply(p Probe, now time.Time) {
 	t.icmpUp = p.ICMP
 }
 
-// Conn derives the connection-badge level for a probe given the tracker's
-// current consecutive-failure count.
+// Conn derives the connection-badge level from raw reachability: an open port is
+// "connected", ping-only (port closed, e.g. mid-reboot) is "reconnecting", and
+// neither is "offline". It deliberately does NOT key off whether an install
+// status is being published — a box serving its real app (no splash status) is
+// still connected, not "reconnecting". Status freshness is shown separately by
+// the "updated … ago" meta line.
 func (t *Tracker) Conn(p Probe) ConnLevel {
 	switch {
-	case t.ConsecutiveFails == 0 && p.TCP:
+	case p.TCP:
 		return Connected
 	case p.ICMP:
 		return Reconnecting
@@ -276,11 +280,11 @@ func Render(host, port string, t *Tracker, p Probe, now time.Time, width int) st
 		glyph(p.ICMP), glyph(p.TCP), port, usbGlyph(p.USB), badge(t.Conn(p)))
 	switch p.USB {
 	case USBNotReady:
-		b.WriteString("           " + warnStyle.Render("USB boot not ready — insert the USB stick, then press u to enable") + "\n")
+		b.WriteString("           " + warnStyle.Render("no USB detected — plug the install USB into THIS server, then press u") + "\n")
 	case USBReady:
-		b.WriteString("           " + grayStyle.Render("can boot from USB — press u to set it for the next reboot") + "\n")
+		b.WriteString("           " + grayStyle.Render("USB detected — press u to arm one-shot USB boot, then reboot the box") + "\n")
 	case USBWillBoot:
-		b.WriteString("           " + upStyle.Render("✓ will boot from USB on the next reboot") + "\n")
+		b.WriteString("           " + upStyle.Render("✓ USB boot armed — reboot the box now to boot the installer from USB") + "\n")
 	}
 	meta := "  Meta     elapsed " + FmtDur(now.Sub(t.Start))
 	if t.Stage != "" {
@@ -307,6 +311,10 @@ func Render(host, port string, t *Tracker, p Probe, now time.Time, width int) st
 	} else {
 		b.WriteString("  (no log content yet — splash quadlet may still be starting)\n")
 	}
-	b.WriteString("\nCtrl+C to exit\n")
+	foot := "q quit"
+	if p.USB != USBUnknown {
+		foot = "u arm USB boot  ·  " + foot
+	}
+	b.WriteString("\n" + foot + "\n")
 	return b.String()
 }

--- a/tools/sb-tui/internal/watch/watch_test.go
+++ b/tools/sb-tui/internal/watch/watch_test.go
@@ -128,6 +128,11 @@ func TestConnLevels(t *testing.T) {
 	if tr.Conn(Probe{ICMP: true, TCP: false}) != Reconnecting {
 		t.Error("want Reconnecting when ping up but port/status not ready")
 	}
+	// Port open is "connected" even with no fresh install status (e.g. the box
+	// serving its real app) — connectivity, not splash presence, drives the badge.
+	if tr.Conn(Probe{ICMP: true, TCP: true}) != Connected {
+		t.Error("want Connected when the port is open regardless of status freshness")
+	}
 }
 
 func TestRenderContent(t *testing.T) {
@@ -174,11 +179,11 @@ func TestRenderUSBBoot(t *testing.T) {
 	if !strings.Contains(will, "usb-boot") {
 		t.Error("status row should include the usb-boot label")
 	}
-	if !strings.Contains(will, "will boot from USB") {
-		t.Error("USBWillBoot should show the will-boot hint")
+	if !strings.Contains(will, "armed") || !strings.Contains(will, "reboot the box") {
+		t.Error("USBWillBoot should tell the operator it's armed and to reboot")
 	}
 	notReady := Render("h", "5888", tr, Probe{ICMP: true, TCP: true, USB: USBNotReady}, now, 80)
-	if !strings.Contains(notReady, "not ready") {
-		t.Error("USBNotReady should show the not-ready hint")
+	if !strings.Contains(notReady, "no USB detected") {
+		t.Error("USBNotReady should show the no-USB-detected hint")
 	}
 }


### PR DESCRIPTION
## What
Make the install monitor unambiguous during a reinstall:
- **Connection badge reflects reachability, not splash presence.** It read `reconnecting` while ping/port/usb were all green, because it keyed off whether an install-splash status was being published — and a box serving its real app (the old install, pre-reboot) has none. Now: open port = `connected`, ping-only = `reconnecting`, neither = `offline`.
- **USB-boot hints say what to do next** — `press u to arm one-shot USB boot, then reboot the box`, and once armed `✓ armed — reboot the box now`. Footer gains a `u arm USB boot` hint.
- **Reinstall pre-reboot guidance**: the monitor now states it's still the current install and how to start the reinstall (plug the USB into the server, arm USB boot, reboot), so the green dots don't read as "done".

## Why
A live reinstall showed `reconnecting` with everything green and gave no clear next step — operators couldn't tell whether to press `u`, reboot, or both. (`u` arms a one-shot UEFI BootNext; it does not reboot.)

## Risk
Low — display/wording only, plus the badge derivation; no change to the poll/takeover logic or the `u` action.

## Rollback
`git revert` of the merge.

## Verification
- [x] `gofmt`, `go vet`, `go test ./...` (Conn levels incl. open-port=connected; USB-boot hint wording)
- [ ] `/verify` on box — N/A (`tools/sb-tui` only; not path-mandated)