### PR TITLE
fix(tui): surface install progress errors and needs-credentials state

### DIFF
--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -148,6 +148,7 @@ func (m InstallModel) applyProgress(msg progressMsg) (tea.Model, tea.Cmd) {
 		m.errMsg = friendlyErr(msg.err)
 		return m, tea.Tick(installPollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
 	}
+	m.errMsg = "" // a successful poll clears any earlier transient poll error
 	p := msg.p
 	m.phase, m.percent, m.offset = p.Phase, p.Percent, p.NextOffset
 	if p.NewLogs != "" {
@@ -282,14 +283,42 @@ func tierSuffix(s rest.Stack) string {
 }
 
 func (m InstallModel) viewInstalling(b *strings.Builder, width int) {
-	phase := m.phase
-	if phase == "" {
-		phase = "starting"
-	}
-	b.WriteString(phaseStyle.Render("Installing — "+phase) + "\n")
+	b.WriteString(phaseStyle.Render("Installing — "+phaseLabel(m.phase)) + "\n")
 	b.WriteString(detailStyle.Render(progressBar(m.percent, min(width-8, 40))) + "\n\n")
+
+	// The box paused for config (passwords/variables) the TUI can't collect yet.
+	// Point the operator at the web UI rather than spinning here forever.
+	if m.phase == "needs_credentials" {
+		b.WriteString(detailStyle.Render(cfgErrStyle.Render("⚠ This stack needs configuration the TUI can't enter yet.")) + "\n")
+		b.WriteString(detailStyle.Render("Finish it in the web UI: "+cfgValueStyle.Render(m.client.BaseURL+"/")) + "\n\n")
+	}
+
 	b.WriteString(logTailView(m.logTail, 10))
+
+	// Error management: a failing progress poll must be visible, not look frozen
+	// at 0%. The job keeps running on the box; this just reports the poll state.
+	if m.errMsg != "" {
+		b.WriteString("\n" + detailStyle.Render(cfgErrStyle.Render("⚠ progress unavailable: "+m.errMsg)) + "\n")
+	}
 	b.WriteString("\n" + footerStyle.Render("q detach (install keeps running on the box)"))
+}
+
+// phaseLabel maps a raw job phase to a human label for the monitor.
+func phaseLabel(phase string) string {
+	switch phase {
+	case "":
+		return "starting…"
+	case "running":
+		return "running"
+	case "needs_credentials":
+		return "waiting for configuration"
+	case "done", "complete":
+		return "done"
+	case "failed", "error":
+		return "failed"
+	default:
+		return phase
+	}
 }
 
 func (m InstallModel) viewDone(b *strings.Builder, width int) {

--- a/tools/sb-tui/internal/ui/install_test.go
+++ b/tools/sb-tui/internal/ui/install_test.go
@@ -105,3 +105,27 @@ func TestProgressBar(t *testing.T) {
 		t.Errorf("expected 5 filled blocks, got %q", bar)
 	}
 }
+
+// TestInstallSurfacesPollError: a failing progress poll must be visible in the
+// installing view, not silently leave it frozen at 0%.
+func TestInstallSurfacesPollError(t *testing.T) {
+	m := InstallModel{client: &rest.Client{BaseURL: "http://box:5888"}, stage: stageInstalling, jobID: "j1"}
+	mi, _ := m.Update(progressMsg{err: &rest.APIError{Status: 404, Message: "job not found"}})
+	m = mi.(InstallModel)
+	v := m.View()
+	if !strings.Contains(v, "progress unavailable") || !strings.Contains(v, "job not found") {
+		t.Errorf("installing view should surface the poll error, got:\n%s", v)
+	}
+}
+
+// TestInstallNeedsCredentials: a needs_credentials phase points the operator at
+// the web UI instead of spinning forever.
+func TestInstallNeedsCredentials(t *testing.T) {
+	m := InstallModel{client: &rest.Client{BaseURL: "http://box:5888"}, stage: stageInstalling, jobID: "j1"}
+	mi, _ := m.Update(progressMsg{p: &rest.Progress{Phase: "needs_credentials", Active: true}})
+	m = mi.(InstallModel)
+	v := m.View()
+	if !strings.Contains(v, "needs configuration") || !strings.Contains(v, "http://box:5888/") {
+		t.Errorf("needs_credentials should point to the web UI, got:\n%s", v)
+	}
+}


### PR DESCRIPTION
## What
Make the stack-install monitor explain itself instead of looking frozen at "Installing — starting / 0%":
- A **failing progress poll** is now shown (`⚠ progress unavailable: <error>`) and cleared on the next good poll — previously `viewInstalling` rendered neither `errMsg` nor the phase, so any poll error left it silently stuck.
- The **job phase** renders with a human label (running / waiting for configuration / done / failed).
- A **needs_credentials** job (the box waiting for per-stack config the TUI can't collect yet) points the operator at the web UI to finish, rather than spinning forever.

## Why
A live install stayed on "Installing — starting / 0%" with no output and no error — the panel was swallowing both the poll error and the phase. This restores visibility (and reveals the actual root cause: a poll error vs. a config-gated job).

## Risk
Low — display/wording only in the install panel; no change to start/poll logic.

## Rollback
`git revert` of the merge.

## Verification
- [x] `gofmt`, `go vet`, `go test ./...` (new: surfaces poll error; needs_credentials points to web UI)
- [ ] `/verify` on box — N/A (`tools/sb-tui` only; not path-mandated). Live retry will now show the real phase/error.

## Follow-up (not in this PR)
The TUI has no per-stack "configure variables" step, so stacks that require config can't be completed in-TUI yet — they now route to the web UI. A native configure step is the real fix for installing those from the TUI.