### PR TITLE
fix(tui): parse the install progress object so the monitor advances

### DIFF
--- a/tools/sb-tui/internal/rest/install.go
+++ b/tools/sb-tui/internal/rest/install.go
@@ -101,14 +101,19 @@ func (c *Client) StartInstall(ctx context.Context, manifest json.RawMessage) (st
 }
 
 // Progress is a snapshot of a running install job, polled from the public
-// jobId-gated endpoint.
+// jobId-gated endpoint. Percent is derived from deployed/total (the box reports
+// no percentage of its own — job.progress is {currentItem, deployedNames,
+// totalCount}).
 type Progress struct {
-	Phase      string
-	Percent    int
-	Error      string
-	Active     bool
-	NewLogs    string
-	NextOffset int
+	Phase       string
+	CurrentItem string // the item the runner is deploying right now ("" between items)
+	Deployed    int    // count of items deployed so far
+	Total       int    // total items in this job
+	Percent     int    // deployed/total as 0–100
+	Error       string
+	Active      bool
+	NewLogs     string
+	NextOffset  int
 }
 
 // InstallProgress polls /api/install/progress for a job. sinceOffset is the
@@ -123,8 +128,12 @@ func (c *Client) InstallProgress(ctx context.Context, jobID string, sinceOffset 
 	var doc struct {
 		Job struct {
 			Phase    string `json:"phase"`
-			Progress int    `json:"progress"`
 			Error    string `json:"error"`
+			Progress struct {
+				CurrentItem   string   `json:"currentItem"`
+				DeployedNames []string `json:"deployedNames"`
+				TotalCount    int      `json:"totalCount"`
+			} `json:"progress"`
 		} `json:"job"`
 		Active     bool   `json:"jobIsActive"`
 		Logs       string `json:"logs"`
@@ -133,12 +142,20 @@ func (c *Client) InstallProgress(ctx context.Context, jobID string, sinceOffset 
 	if err := json.Unmarshal(raw, &doc); err != nil {
 		return nil, &APIError{Message: "malformed progress response: " + err.Error()}
 	}
+	deployed, total := len(doc.Job.Progress.DeployedNames), doc.Job.Progress.TotalCount
+	percent := 0
+	if total > 0 {
+		percent = deployed * 100 / total
+	}
 	return &Progress{
-		Phase:      doc.Job.Phase,
-		Percent:    doc.Job.Progress,
-		Error:      doc.Job.Error,
-		Active:     doc.Active,
-		NewLogs:    doc.Logs,
-		NextOffset: doc.LogsOffset,
+		Phase:       doc.Job.Phase,
+		CurrentItem: doc.Job.Progress.CurrentItem,
+		Deployed:    deployed,
+		Total:       total,
+		Percent:     percent,
+		Error:       doc.Job.Error,
+		Active:      doc.Active,
+		NewLogs:     doc.Logs,
+		NextOffset:  doc.LogsOffset,
 	}, nil
 }

--- a/tools/sb-tui/internal/rest/install_test.go
+++ b/tools/sb-tui/internal/rest/install_test.go
@@ -117,8 +117,18 @@ func TestInstallProgressIsUnauthenticated(t *testing.T) {
 		if r.URL.Query().Get("jobId") != "job-1" || r.URL.Query().Get("logsSince") != "42" {
 			t.Errorf("query = %s", r.URL.RawQuery)
 		}
+		// Mirror the real backend shape: job.progress is an OBJECT
+		// {currentItem, deployedNames, totalCount}, not a number. Percent is
+		// derived (3 of 5 deployed → 60%).
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"job":         map[string]any{"phase": "running", "progress": 60},
+			"job": map[string]any{
+				"phase": "running",
+				"progress": map[string]any{
+					"currentItem":   "immich",
+					"deployedNames": []string{"a", "b", "c"},
+					"totalCount":    5,
+				},
+			},
 			"jobIsActive": true,
 			"logs":        "deploying immich\n",
 			"logsOffset":  108,
@@ -130,7 +140,7 @@ func TestInstallProgressIsUnauthenticated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InstallProgress: %v", err)
 	}
-	if p.Phase != "running" || p.Percent != 60 || !p.Active || p.NextOffset != 108 {
+	if p.Phase != "running" || p.Percent != 60 || p.CurrentItem != "immich" || p.Deployed != 3 || p.Total != 5 || !p.Active || p.NextOffset != 108 {
 		t.Errorf("progress = %+v", p)
 	}
 }

--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -7,6 +7,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -48,13 +49,16 @@ type InstallModel struct {
 	checked map[int]bool
 	cursor  int
 
-	jobID   string
-	offset  int
-	phase   string
-	percent int
-	logTail []string
-	failed  bool
-	errMsg  string // populated in stageError / failed
+	jobID    string
+	offset   int
+	phase    string
+	current  string // item being deployed right now
+	deployed int
+	total    int
+	percent  int
+	logTail  []string
+	failed   bool
+	errMsg   string // populated in stageError / failed
 }
 
 type stacksLoadedMsg struct {
@@ -151,6 +155,7 @@ func (m InstallModel) applyProgress(msg progressMsg) (tea.Model, tea.Cmd) {
 	m.errMsg = "" // a successful poll clears any earlier transient poll error
 	p := msg.p
 	m.phase, m.percent, m.offset = p.Phase, p.Percent, p.NextOffset
+	m.current, m.deployed, m.total = p.CurrentItem, p.Deployed, p.Total
 	if p.NewLogs != "" {
 		for _, line := range strings.Split(strings.TrimRight(p.NewLogs, "\n"), "\n") {
 			if line != "" {
@@ -283,7 +288,14 @@ func tierSuffix(s rest.Stack) string {
 }
 
 func (m InstallModel) viewInstalling(b *strings.Builder, width int) {
-	b.WriteString(phaseStyle.Render("Installing — "+phaseLabel(m.phase)) + "\n")
+	head := "Installing — " + phaseLabel(m.phase)
+	if m.current != "" {
+		head += ": " + m.current
+	}
+	if m.total > 0 {
+		head += fmt.Sprintf("  (%d/%d)", m.deployed, m.total)
+	}
+	b.WriteString(phaseStyle.Render(head) + "\n")
 	b.WriteString(detailStyle.Render(progressBar(m.percent, min(width-8, 40))) + "\n\n")
 
 	// The box paused for config (passwords/variables) the TUI can't collect yet.


### PR DESCRIPTION
## What
The stack-install monitor parsed `job.progress` as an `int`, but the box returns it as an **object** `{currentItem, deployedNames, totalCount}`. Every progress poll failed to unmarshal (`cannot unmarshal object into Go struct field .job.progress of type int`), so the monitor sat at `Installing — starting / 0%` with no logs — while the install was actually running on the box.

- Parse the real shape; derive percent from `deployed/total`.
- Show the current item + count: `running: immich  (2/5)`, alongside the live log tail.
- Fix the rest test fixture, which was fabricated as a number (how the mismatch slipped through) — it now mirrors the real response.

## Why
Root cause of the "install stays at 0% forever" report. Pairs with the prior PR that surfaced the (previously swallowed) unmarshal error.

## Risk
Low — parsing + display in the install panel; no change to start/poll control flow.

## Rollback
`git revert` of the merge.

## Verification
- [x] `gofmt`, `go vet`, `go test ./...` (rest progress fixture = real object shape → percent/currentItem/deployed/total)
- [ ] `/verify` on box — N/A (`tools/sb-tui` only). Live retry now shows real progress + logs.