### PR TITLE
feat(tui): surface and attach to a running install from the launcher

### DIFF
--- a/packages/frontend/src/app/api/install/abort/route.ts
+++ b/packages/frontend/src/app/api/install/abort/route.ts
@@ -14,9 +14,13 @@ const Body = z.object({ jobId: z.string().min(1) });
  * credentials prompt. The deploy loop transitions the job's phase to
  * `aborted` cleanly. Idempotent — calling on an already-aborted job
  * is a no-op.
+ *
+ * `tokenScope: 'lifecycle'` lets the sb-tui install panel abort a stuck
+ * job with its scoped `sb_` token — the same scope `/api/install/start`
+ * already holds, and strictly less powerful (it only stops an install).
  */
 export const POST = withApiHandler<z.infer<typeof Body>>(
-  { body: Body },
+  { body: Body, tokenScope: 'lifecycle' },
   async ({ body }) => {
     try {
       abortJob(body.jobId);

--- a/packages/frontend/src/app/api/install/current/route.ts
+++ b/packages/frontend/src/app/api/install/current/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getCurrentJob } from '@/lib/install/jobStore';
+import { apiError } from '@/lib/api/errors';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Token-readable, sanitized summary of the *currently active* install job
+ * (running / needs_credentials), or `{ job: null }` when none is active.
+ *
+ * This exists so the sb-tui launcher can show "install in progress" on a
+ * reachable box and offer to reattach to it — without knowing the jobId up
+ * front (a fresh launch has no job in memory).
+ *
+ * Why a new route rather than `/api/install/status`: `/status` returns the
+ * full job, including `input.variables` (operator-supplied passwords), so it
+ * is deliberately cookie-only. This endpoint returns ONLY non-secret progress
+ * fields (id, phase, currentItem, counts) — the same sanitisation `/progress`
+ * uses — so it is safe to expose to a scoped `read` token. The returned `id`
+ * is then used with the public jobId-gated `/api/install/progress` for logs.
+ */
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
+  try {
+    const job = await getCurrentJob();
+    if (!job) {
+      return NextResponse.json({ job: null, jobIsActive: false });
+    }
+    return NextResponse.json({
+      job: {
+        id: job.id,
+        phase: job.phase,
+        progress: {
+          currentItem: job.progress.currentItem,
+          deployedNames: job.progress.deployedNames,
+          totalCount: job.progress.totalCount,
+        },
+      },
+      jobIsActive: job.phase === 'running' || job.phase === 'needs_credentials',
+    });
+  } catch (error) {
+    return apiError(error, { tag: 'api:install:current', status: 500 });
+  }
+});

--- a/packages/frontend/src/app/api/install/skip-credentials/route.ts
+++ b/packages/frontend/src/app/api/install/skip-credentials/route.ts
@@ -9,8 +9,13 @@ export const dynamic = 'force-dynamic';
  * Resume a paused install by skipping the NPM credentials prompt.
  * Proxy routes won't be configured in this run; the operator can fix
  * this later via Settings → Integrations.
+ *
+ * `tokenScope: 'lifecycle'` lets the sb-tui install panel resolve a
+ * needs_credentials pause with its scoped `sb_` token — the same scope
+ * that already authorises `/api/install/start`, and strictly less
+ * powerful (it only continues an install the operator already started).
  */
-export const POST = withApiHandler({}, async ({ request }) => {
+export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
   try {
     const body = (await request.json()) as { jobId?: string };
     if (!body.jobId) {

--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -54,6 +54,7 @@ const (
 	Express       ActionID = "express"
 	BuildISO      ActionID = "build-iso"
 	WatchInstall  ActionID = "watch-install"
+	AttachInstall ActionID = "attach-install"
 	EditConfig    ActionID = "edit-config"
 	InstallStacks ActionID = "install-stacks"
 	Backups       ActionID = "backups"

--- a/tools/sb-tui/internal/rest/install.go
+++ b/tools/sb-tui/internal/rest/install.go
@@ -82,13 +82,31 @@ func (c *Client) AssembleManifest(ctx context.Context, names []string, prefilled
 	return c.do(ctx, "POST", "/api/install/assemble", body)
 }
 
+// InstallInProgressError signals that the box already has an active install
+// (the start route's 409). It carries that job's id so the panel can reattach
+// to it instead of dead-ending.
+type InstallInProgressError struct{ JobID string }
+
+func (e *InstallInProgressError) Error() string {
+	return "an install is already in progress on the box"
+}
+
 // StartInstall kicks off a server-side install job for an assembled manifest
-// and returns the jobId to poll. A 409 (install already running) surfaces as an
-// *APIError the panel reports rather than starting a second job.
+// and returns the jobId to poll. A 409 (install already running) is returned as
+// an *InstallInProgressError carrying the existing jobId, so the panel reattaches
+// rather than starting a second job.
 func (c *Client) StartInstall(ctx context.Context, manifest json.RawMessage) (string, error) {
 	body := map[string]any{"source": "sb-tui", "input": manifest}
 	raw, err := c.do(ctx, "POST", "/api/install/start", body)
 	if err != nil {
+		if ae, ok := err.(*APIError); ok && ae.Status == 409 {
+			var r struct {
+				JobID string `json:"jobId"`
+			}
+			if json.Unmarshal(ae.Body, &r) == nil && r.JobID != "" {
+				return "", &InstallInProgressError{JobID: r.JobID}
+			}
+		}
 		return "", err
 	}
 	var resp struct {
@@ -98,6 +116,66 @@ func (c *Client) StartInstall(ctx context.Context, manifest json.RawMessage) (st
 		return "", &APIError{Message: "install started but no jobId returned"}
 	}
 	return resp.JobID, nil
+}
+
+// CurrentJob is the sanitized summary of the active install job (if any), from
+// GET /api/install/current — id + phase + progress counts, no secrets.
+type CurrentJob struct {
+	ID          string
+	Phase       string
+	Active      bool
+	CurrentItem string
+	Deployed    int
+	Total       int
+}
+
+// CurrentInstall returns the active install job summary, or nil when none is
+// running. Lets the launcher surface + reattach to a running install without
+// already knowing the jobId.
+func (c *Client) CurrentInstall(ctx context.Context) (*CurrentJob, error) {
+	raw, err := c.do(ctx, "GET", "/api/install/current", nil)
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		Job *struct {
+			ID       string `json:"id"`
+			Phase    string `json:"phase"`
+			Progress struct {
+				CurrentItem   string   `json:"currentItem"`
+				DeployedNames []string `json:"deployedNames"`
+				TotalCount    int      `json:"totalCount"`
+			} `json:"progress"`
+		} `json:"job"`
+		Active bool `json:"jobIsActive"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, &APIError{Message: "malformed current-install response: " + err.Error()}
+	}
+	if doc.Job == nil {
+		return nil, nil
+	}
+	return &CurrentJob{
+		ID:          doc.Job.ID,
+		Phase:       doc.Job.Phase,
+		Active:      doc.Active,
+		CurrentItem: doc.Job.Progress.CurrentItem,
+		Deployed:    len(doc.Job.Progress.DeployedNames),
+		Total:       doc.Job.Progress.TotalCount,
+	}, nil
+}
+
+// AbortInstall stops a running install job.
+func (c *Client) AbortInstall(ctx context.Context, jobID string) error {
+	_, err := c.do(ctx, "POST", "/api/install/abort", map[string]string{"jobId": jobID})
+	return err
+}
+
+// SkipCredentials resolves a needs_credentials pause, continuing the install
+// with the auto-generated fallback NPM credentials.
+func (c *Client) SkipCredentials(ctx context.Context, jobID string) error {
+	_, err := c.do(ctx, "POST", "/api/install/skip-credentials", map[string]string{"jobId": jobID})
+	return err
 }
 
 // Progress is a snapshot of a running install job, polled from the public

--- a/tools/sb-tui/internal/rest/rest.go
+++ b/tools/sb-tui/internal/rest/rest.go
@@ -37,6 +37,7 @@ var ErrUnauthorized = errors.New("unauthorized: token missing, expired, or lacks
 type APIError struct {
 	Status  int
 	Message string
+	Body    json.RawMessage // the raw error body, for callers that parse extra fields (e.g. a 409's jobId)
 }
 
 func (e *APIError) Error() string {
@@ -113,7 +114,7 @@ func (c *Client) doRaw(ctx context.Context, method, path string, body any, authe
 		return nil, ErrUnauthorized
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &APIError{Status: resp.StatusCode, Message: serverError(raw, resp.StatusCode)}
+		return nil, &APIError{Status: resp.StatusCode, Message: serverError(raw, resp.StatusCode), Body: json.RawMessage(raw)}
 	}
 	return json.RawMessage(raw), nil
 }

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -22,7 +22,11 @@ import (
 // Navigation messages routed by the App.
 type (
 	// menuSelectedMsg is emitted by the menu when the operator picks an action.
-	menuSelectedMsg struct{ id phase.ActionID }
+	// jobID is set only for AttachInstall (the active install's id to reattach to).
+	menuSelectedMsg struct {
+		id    phase.ActionID
+		jobID string
+	}
 	// backMsg is emitted by a sub-view to pop back to the menu.
 	backMsg struct{}
 )
@@ -67,7 +71,7 @@ type App struct {
 // NewApp builds the root model. token may be a pre-resolved credential (env or
 // the saved per-host file); empty means the box-control views will log in first.
 func NewApp(detect DetectFunc, host, port, token string, save TokenSaver, build BuildConfig) App {
-	return App{host: host, port: port, token: token, save: save, build: build, screen: appMenu, menu: New(detect, host, port)}
+	return App{host: host, port: port, token: token, save: save, build: build, screen: appMenu, menu: New(detect, host, port, token)}
 }
 
 // Init starts the menu's phase detection.
@@ -87,7 +91,7 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case menuSelectedMsg:
-		return m.route(msg.id)
+		return m.route(msg.id, msg.jobID)
 
 	case authSucceededMsg:
 		m.token = msg.token
@@ -114,7 +118,7 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case backMsg:
 		// Pop back to the menu and re-detect so its phase/actions refresh.
 		m.screen, m.active = appMenu, nil
-		m.menu = New(m.menu.detect, m.host, m.port)
+		m.menu = New(m.menu.detect, m.host, m.port, m.token)
 		return m, m.menu.Init()
 	}
 
@@ -133,8 +137,20 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // if needed); watch + open-box open in-app too (no auth) and return to the
 // menu; only the build/express bootstrap legs quit the App for the entrypoint,
 // since build is an interactive stdin wizard whose USB flash needs a real TTY.
-func (m App) route(id phase.ActionID) (tea.Model, tea.Cmd) {
+func (m App) route(id phase.ActionID, jobID string) (tea.Model, tea.Cmd) {
 	switch id {
+	case phase.AttachInstall:
+		// Reattach to the install already running on the box — straight to live
+		// progress (the menu only offers this when a token-polled job is active,
+		// so a token is present).
+		client, err := rest.New(m.host, m.port, m.token)
+		if err != nil {
+			m.screen, m.active = appMenu, nil
+			return m, nil
+		}
+		m.active = NewInstallAttach(client, jobID)
+		m.screen = appPanel
+		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
 	case phase.UploadToNAS:
 		// FTP-only: the upload talks straight to the FritzBox NAS, never the
 		// ServiceBay box — so it needs no token and no login, and works even

--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -58,7 +58,9 @@ type InstallModel struct {
 	percent  int
 	logTail  []string
 	failed   bool
+	attached bool   // reattached to a pre-existing job (skip the catalog/select step)
 	errMsg   string // populated in stageError / failed
+	note     string // transient action note (abort/skip in flight or rejected)
 }
 
 type stacksLoadedMsg struct {
@@ -75,9 +77,21 @@ type progressMsg struct {
 }
 type pollTickMsg struct{}
 
+// actionResultMsg carries the outcome of an abort / skip-credentials action.
+type actionResultMsg struct {
+	verb string
+	err  error
+}
+
 // NewInstall builds the stack-install model against an authenticated client.
 func NewInstall(client *rest.Client) InstallModel {
 	return InstallModel{client: client, stage: stageLoading, checked: map[int]bool{}}
+}
+
+// NewInstallAttach builds the panel reattached to an already-running job: it
+// skips the catalog/select step and goes straight to live progress for jobID.
+func NewInstallAttach(client *rest.Client, jobID string) InstallModel {
+	return InstallModel{client: client, stage: stageInstalling, jobID: jobID, attached: true, checked: map[int]bool{}}
 }
 
 func (m InstallModel) loadCmd() tea.Cmd {
@@ -110,8 +124,30 @@ func (m InstallModel) pollCmd() tea.Cmd {
 	}
 }
 
-// Init kicks off the catalog load.
-func (m InstallModel) Init() tea.Cmd { return m.loadCmd() }
+// Init kicks off the catalog load, or jumps straight to polling when reattached
+// to an existing job.
+func (m InstallModel) Init() tea.Cmd {
+	if m.attached {
+		return m.pollCmd()
+	}
+	return m.loadCmd()
+}
+
+// abortCmd stops the running job; skipCredsCmd resolves a needs_credentials
+// pause with the generated fallback. Both report via actionResultMsg.
+func (m InstallModel) abortCmd() tea.Cmd {
+	client, jobID := m.client, m.jobID
+	return func() tea.Msg {
+		return actionResultMsg{verb: "abort", err: client.AbortInstall(context.Background(), jobID)}
+	}
+}
+
+func (m InstallModel) skipCredsCmd() tea.Cmd {
+	client, jobID := m.client, m.jobID
+	return func() tea.Msg {
+		return actionResultMsg{verb: "skip", err: client.SkipCredentials(context.Background(), jobID)}
+	}
+}
 
 // Update folds in load/start/progress results and handles input.
 func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -125,6 +161,12 @@ func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case installStartedMsg:
 		if msg.err != nil {
+			// An install is already running — reattach to it instead of erroring.
+			if inProgress, ok := msg.err.(*rest.InstallInProgressError); ok {
+				m.jobID, m.stage = inProgress.JobID, stageInstalling
+				m.note = "Reattached to an install already running on the box."
+				return m, m.pollCmd()
+			}
 			m.stage, m.errMsg = stageError, friendlyErr(msg.err)
 			return m, nil
 		}
@@ -132,6 +174,15 @@ func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.pollCmd()
 	case progressMsg:
 		return m.applyProgress(msg)
+	case actionResultMsg:
+		if msg.err != nil {
+			m.note = "✗ " + msg.verb + " failed: " + friendlyErr(msg.err)
+		} else if msg.verb == "abort" {
+			m.note = "Aborting…"
+		} else {
+			m.note = "Skipped — continuing with generated credentials."
+		}
+		return m, m.pollCmd() // reflect the new phase on the next poll
 	case pollTickMsg:
 		return m, m.pollCmd()
 	case tea.WindowSizeMsg:
@@ -186,6 +237,18 @@ func (m InstallModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.stage != stageStarting {
 			return m, backCmd()
 		}
+	case "a":
+		// Abort the running job.
+		if m.stage == stageInstalling && m.jobID != "" {
+			m.note = "Aborting…"
+			return m, m.abortCmd()
+		}
+	case "s":
+		// Skip the NPM credentials prompt (continue with the generated fallback).
+		if m.stage == stageInstalling && m.phase == "needs_credentials" && m.jobID != "" {
+			m.note = "Skipping credentials…"
+			return m, m.skipCredsCmd()
+		}
 	}
 	if m.stage != stageSelect {
 		return m, nil
@@ -233,7 +296,7 @@ func (m InstallModel) View() string {
 	case stageLoading:
 		b.WriteString(phaseStyle.Render("Loading stack catalog…"))
 	case stageError:
-		b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Couldn't load stacks:")) + "\n")
+		b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Install panel error:")) + "\n")
 		b.WriteString(detailStyle.Render(m.errMsg) + "\n")
 		b.WriteString(footerStyle.Render("q quit"))
 	case stageSelect:
@@ -298,11 +361,11 @@ func (m InstallModel) viewInstalling(b *strings.Builder, width int) {
 	b.WriteString(phaseStyle.Render(head) + "\n")
 	b.WriteString(detailStyle.Render(progressBar(m.percent, min(width-8, 40))) + "\n\n")
 
-	// The box paused for config (passwords/variables) the TUI can't collect yet.
-	// Point the operator at the web UI rather than spinning here forever.
+	// The box paused on the NPM credentials prompt. Skipping continues with the
+	// auto-generated fallback (proxy routes can be set later in the web UI).
 	if m.phase == "needs_credentials" {
-		b.WriteString(detailStyle.Render(cfgErrStyle.Render("⚠ This stack needs configuration the TUI can't enter yet.")) + "\n")
-		b.WriteString(detailStyle.Render("Finish it in the web UI: "+cfgValueStyle.Render(m.client.BaseURL+"/")) + "\n\n")
+		b.WriteString(detailStyle.Render(cfgErrStyle.Render("⚠ Waiting for NPM credentials. Press s to skip and continue with generated ones.")) + "\n")
+		b.WriteString(detailStyle.Render("(Or set them in the web UI: "+cfgValueStyle.Render(m.client.BaseURL+"/")+")") + "\n\n")
 	}
 
 	b.WriteString(logTailView(m.logTail, 10))
@@ -312,7 +375,14 @@ func (m InstallModel) viewInstalling(b *strings.Builder, width int) {
 	if m.errMsg != "" {
 		b.WriteString("\n" + detailStyle.Render(cfgErrStyle.Render("⚠ progress unavailable: "+m.errMsg)) + "\n")
 	}
-	b.WriteString("\n" + footerStyle.Render("q detach (install keeps running on the box)"))
+	if m.note != "" {
+		b.WriteString("\n" + detailStyle.Render(m.note) + "\n")
+	}
+	foot := "a abort · q detach (install keeps running)"
+	if m.phase == "needs_credentials" {
+		foot = "s skip credentials · a abort · q detach"
+	}
+	b.WriteString("\n" + footerStyle.Render(foot))
 }
 
 // phaseLabel maps a raw job phase to a human label for the monitor.

--- a/tools/sb-tui/internal/ui/install_test.go
+++ b/tools/sb-tui/internal/ui/install_test.go
@@ -118,14 +118,25 @@ func TestInstallSurfacesPollError(t *testing.T) {
 	}
 }
 
-// TestInstallNeedsCredentials: a needs_credentials phase points the operator at
-// the web UI instead of spinning forever.
+// TestInstallNeedsCredentials: a needs_credentials phase offers the in-TUI skip
+// (and the web UI as an alternative) instead of spinning forever.
 func TestInstallNeedsCredentials(t *testing.T) {
 	m := InstallModel{client: &rest.Client{BaseURL: "http://box:5888"}, stage: stageInstalling, jobID: "j1"}
 	mi, _ := m.Update(progressMsg{p: &rest.Progress{Phase: "needs_credentials", Active: true}})
 	m = mi.(InstallModel)
 	v := m.View()
-	if !strings.Contains(v, "needs configuration") || !strings.Contains(v, "http://box:5888/") {
-		t.Errorf("needs_credentials should point to the web UI, got:\n%s", v)
+	if !strings.Contains(v, "NPM credentials") || !strings.Contains(v, "skip") || !strings.Contains(v, "http://box:5888/") {
+		t.Errorf("needs_credentials should offer skip + web UI, got:\n%s", v)
+	}
+}
+
+// TestInstallReattachOn409: a start that hits "install already in progress"
+// reattaches to the existing job rather than erroring out.
+func TestInstallReattachOn409(t *testing.T) {
+	m := InstallModel{client: &rest.Client{BaseURL: "http://box:5888"}, stage: stageStarting, checked: map[int]bool{}}
+	mi, cmd := m.Update(installStartedMsg{err: &rest.InstallInProgressError{JobID: "existing-1"}})
+	m = mi.(InstallModel)
+	if m.stage != stageInstalling || m.jobID != "existing-1" || cmd == nil {
+		t.Fatalf("409 should reattach: stage=%v jobID=%q", m.stage, m.jobID)
 	}
 }

--- a/tools/sb-tui/internal/ui/menu.go
+++ b/tools/sb-tui/internal/ui/menu.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"servicebay-tui/internal/phase"
+	"servicebay-tui/internal/rest"
 	"servicebay-tui/internal/watch"
 )
 
@@ -50,6 +51,10 @@ type autoRefreshMsg struct{}
 // port) for the compact live line shown during the Installing phase.
 type installStatusMsg struct{ probe watch.Probe }
 
+// currentInstallMsg carries the active stack-install job summary (or nil) from
+// the token-gated poll on a reachable box.
+type currentInstallMsg struct{ job *rest.CurrentJob }
+
 // Model is the Bubble Tea model for the launcher menu. It is hosted by App
 // (app.go): selecting an action emits a menuSelectedMsg the App routes, rather
 // than quitting the program itself, so the launcher stays one continuous app.
@@ -58,6 +63,7 @@ type installStatusMsg struct{ probe watch.Probe }
 type Model struct {
 	detect        DetectFunc
 	host, port    string
+	token         string // scoped token, for polling the running-install summary
 	state         *phase.State
 	rows          []phase.JourneyRow
 	cursor        int
@@ -67,12 +73,16 @@ type Model struct {
 	// one Enter away on the Watch row). Nil outside Installing / before the first
 	// probe answers.
 	installStatus *watch.Probe
+	// installJob is the active stack-install job on an up box (token-polled), so
+	// the menu can surface "install in progress" + offer to attach to it.
+	installJob *rest.CurrentJob
 }
 
 // New builds a launcher model with the phase-detection function and the box
-// target (host/port, shown as the dashboard URL when reachable).
-func New(detect DetectFunc, host, port string) Model {
-	return Model{detect: detect, host: host, port: port}
+// target (host/port, shown as the dashboard URL when reachable). token (may be
+// empty) authenticates the running-install poll.
+func New(detect DetectFunc, host, port, token string) Model {
+	return Model{detect: detect, host: host, port: port, token: token}
 }
 
 func (m Model) detectCmd() tea.Cmd {
@@ -96,6 +106,48 @@ func installProbeCmd(host, port string) tea.Cmd {
 	}
 }
 
+// currentInstallCmd polls the box for an active stack-install job (token-gated,
+// sanitized). Errors resolve to "no job" — the line just doesn't show.
+func (m Model) currentInstallCmd() tea.Cmd {
+	host, port, token := m.host, m.port, m.token
+	return func() tea.Msg {
+		client, err := rest.New(host, port, token)
+		if err != nil {
+			return currentInstallMsg{}
+		}
+		job, err := client.CurrentInstall(context.Background())
+		if err != nil {
+			return currentInstallMsg{}
+		}
+		return currentInstallMsg{job: job}
+	}
+}
+
+// rebuildRows recomputes the menu rows from the current phase + any active
+// install job: when an install is running it prepends a recommended "Watch the
+// running install" row. Resets the cursor only when the row set changes.
+func (m *Model) rebuildRows() {
+	if m.state == nil {
+		return
+	}
+	rows := phase.Journey(*m.state)
+	if m.installJob != nil && m.installJob.Active {
+		attach := phase.JourneyRow{
+			Action: phase.Action{
+				ID:     phase.AttachInstall,
+				Label:  "Watch the running install",
+				Detail: "Connect to the install already running on the box and see live progress (abort or skip from there).",
+			},
+			Recommended: true,
+		}
+		rows = append([]phase.JourneyRow{attach}, rows...)
+	}
+	if !sameRowIDs(m.rows, rows) || m.cursor >= len(rows) {
+		m.cursor = defaultCursor(rows)
+	}
+	m.rows = rows
+}
+
 // Init kicks off the first phase detection.
 func (m Model) Init() tea.Cmd { return m.detectCmd() }
 
@@ -104,25 +156,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case phaseMsg:
 		s := msg.state
-		next := phase.Journey(s)
-		// Preserve the cursor across silent auto-refreshes when the row set is
-		// unchanged, so a periodic re-probe doesn't yank the selection while the
-		// operator is navigating; otherwise land on the recommended next step.
-		if !sameRowIDs(m.rows, next) || m.cursor >= len(next) {
-			m.cursor = defaultCursor(next)
-		}
 		m.state = &s
-		m.rows = next
-		// While an install is running, also fetch a lightweight status probe so
-		// the menu shows a compact live line; clear it in every other phase.
+		m.rebuildRows()
+		cmds := []tea.Cmd{tickCmd()}
+		// While the initial system install runs (splash), fetch a lightweight
+		// ping/port/stage probe for the compact line; clear it otherwise.
 		if s.Phase == phase.Installing && m.host != "" {
-			return m, tea.Batch(tickCmd(), installProbeCmd(m.host, m.port))
+			cmds = append(cmds, installProbeCmd(m.host, m.port))
+		} else {
+			m.installStatus = nil
 		}
-		m.installStatus = nil
-		return m, tickCmd()
+		// On a reachable box with a token, poll for an active stack-install job.
+		if s.BoxReachable && m.token != "" {
+			cmds = append(cmds, m.currentInstallCmd())
+		} else {
+			m.installJob = nil
+		}
+		return m, tea.Batch(cmds...)
 	case installStatusMsg:
 		p := msg.probe
 		m.installStatus = &p
+		return m, nil
+	case currentInstallMsg:
+		m.installJob = msg.job
+		m.rebuildRows()
 		return m, nil
 	case autoRefreshMsg:
 		return m, m.detectCmd()
@@ -154,9 +211,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			// Hand the choice to the App, which routes it (open a panel, or
-			// quit the App so the entrypoint runs a bootstrap leg).
-			id := a.ID
-			return m, func() tea.Msg { return menuSelectedMsg{id: id} }
+			// quit the App so the entrypoint runs a bootstrap leg). AttachInstall
+			// carries the active jobId so the App can reattach to it.
+			sel := menuSelectedMsg{id: a.ID}
+			if a.ID == phase.AttachInstall && m.installJob != nil {
+				sel.jobID = m.installJob.ID
+			}
+			return m, func() tea.Msg { return sel }
 		}
 	}
 	return m, nil
@@ -234,6 +295,11 @@ func (m Model) View() string {
 	if m.state.Phase == phase.Installing && m.installStatus != nil {
 		b.WriteString(detailStyle.Render(installStatusLine(*m.installStatus, m.port, time.Now())) + "\n")
 	}
+	// A stack install running on the up box — surface it + offer to attach (the
+	// "Watch the running install" row, prepended by rebuildRows).
+	if m.installJob != nil && m.installJob.Active {
+		b.WriteString(detailStyle.Render(installJobLine(m.installJob)) + "\n")
+	}
 	b.WriteString("\n")
 
 	for i, r := range m.rows {
@@ -245,6 +311,24 @@ func (m Model) View() string {
 	}
 	b.WriteString(footerStyle.Render("↑/↓ move · enter select · auto-refreshing · ctrl+c quit  ·  sb-tui " + Version))
 	return frame(b.String(), m.width, m.height)
+}
+
+// installJobLine renders the "install in progress" glance for a stack install
+// running on an up box: the current template and deployed/total count, or a
+// paused-for-credentials note.
+func installJobLine(j *rest.CurrentJob) string {
+	if j.Phase == "needs_credentials" {
+		return cfgErrStyle.Render("● install paused") + " — waiting for NPM credentials (attach to skip)"
+	}
+	item := j.CurrentItem
+	if item == "" {
+		item = "starting…"
+	}
+	line := cfgOKStyle.Render("● install in progress") + " — " + item
+	if j.Total > 0 {
+		line += fmt.Sprintf("  (%d/%d)", j.Deployed, j.Total)
+	}
+	return line
 }
 
 // installStatusLine renders the compact one-line install glance for the menu:

--- a/tools/sb-tui/internal/ui/menu_test.go
+++ b/tools/sb-tui/internal/ui/menu_test.go
@@ -28,7 +28,7 @@ func feed(m Model) Model {
 // TestMenuAutoRefreshPreservesCursor: a silent re-probe with an unchanged action
 // set must not yank the cursor back to the top.
 func TestMenuAutoRefreshPreservesCursor(t *testing.T) {
-	m := feed(New(readyDetect, "box", "5888"))
+	m := feed(New(readyDetect, "box", "5888", ""))
 	m.cursor = 1 // a selectable row (step 2 / reinstall)
 	m = feed(m)  // simulate an auto-refresh tick with identical rows
 	if m.cursor != 1 {
@@ -39,7 +39,7 @@ func TestMenuAutoRefreshPreservesCursor(t *testing.T) {
 // TestMenuShowsURLWhenReachable: the dashboard URL is rendered persistently
 // once the box is reachable, replacing the old Open-in-browser action.
 func TestMenuShowsURLWhenReachable(t *testing.T) {
-	m := feed(New(readyDetect, "192.168.1.5", "5888"))
+	m := feed(New(readyDetect, "192.168.1.5", "5888", ""))
 	v := m.View()
 	if !strings.Contains(v, "http://192.168.1.5:5888/") {
 		t.Error("reachable menu should show the dashboard URL")
@@ -56,7 +56,7 @@ func TestMenuFooterShowsVersion(t *testing.T) {
 	old := Version
 	Version = "9.9.9"
 	defer func() { Version = old }()
-	m := feed(New(readyDetect, "box", "5888"))
+	m := feed(New(readyDetect, "box", "5888", ""))
 	if v := m.View(); !strings.Contains(v, "sb-tui 9.9.9") {
 		t.Errorf("footer should show the version, got:\n%s", v)
 	}
@@ -66,7 +66,7 @@ func TestMenuFooterShowsVersion(t *testing.T) {
 // stage + connectivity dots so the operator sees progress without opening the
 // full monitor.
 func TestMenuInstallStatusLine(t *testing.T) {
-	m := feed(New(installingDetect, "192.168.178.100", "5888"))
+	m := feed(New(installingDetect, "192.168.178.100", "5888", ""))
 	// Before any probe answers, no stale line; after one, it renders the stage.
 	if strings.Contains(m.View(), "Installing ·") {
 		t.Error("status line should be absent until a probe answers")


### PR DESCRIPTION
## What
Make a running stack-install visible and recoverable from the TUI (and lay the groundwork for showing it on the web Home).

- New sanitized, token-readable `GET /api/install/current` (id + phase + progress counts, **no secrets**) — distinct from cookie-only `/api/install/status` which carries operator variables.
- Launcher polls it on a reachable box and shows `● install in progress — <item> (x/y)` under the dashboard URL, with a recommended **Watch the running install** action that reattaches to live progress.
- A start that hits **409 install-already-in-progress** now reattaches to the existing job (the 409 body's `jobId`) instead of dead-ending.
- Install monitor gains **abort (a)** and **skip-credentials (s)**; `/api/install/abort` and `/api/install/skip-credentials` are widened to the **`lifecycle`** token scope (the same `start` already holds, strictly less powerful) so the TUI can recover a stuck/paused job with its token.
- Error screen no longer mislabels every failure as "Couldn't load stacks".

## Why
A running install was invisible in the TUI and a second start just 409'd with no recourse (the situation a user hit live).

## Risk
Low–medium: adds a read-only route + widens two lifecycle-scoped POSTs (abort/skip) that are less powerful than `start`. No secret exposure (the new route is sanitized; `/status` stays cookie-only).

## Rollback
`git revert` of the merge.

## Verification
- [x] `gofmt`, `go vet`, `go test ./...` (reattach-on-409, needs-creds skip, current-job parse)
- [x] new routes typecheck; eslint --fix clean
- [ ] `/verify` on box — the new route/scopes ship next release; the box must be on a build that includes them for the menu line / abort / skip to work (the 409-reattach works against the current box already).