### PR TITLE
fix(frontend): only highlight Home on the exact root path

### DIFF
--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Github, Settings, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
-import { NAVIGATION_ENTRIES } from '@/config/navigation';
+import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
 import { useToast } from '@/providers/ToastProvider';
 
 const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
@@ -125,7 +125,7 @@ export function MobileBottomBar() {
     <div className="h-[72px] bg-gray-100 dark:bg-black border-t border-gray-200 dark:border-gray-800 flex items-center justify-around px-2 shrink-0 md:hidden z-20 pb-2">
        {bottomDashboards.map(p => {
           const Icon = p.icon;
-          const isActive = pathname?.startsWith(p.path);
+          const isActive = isNavActive(pathname, p.path);
           return (
              <button
                 key={p.id}

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { ChevronLeft, Github, Users, ExternalLink, Sparkles, Home, Wrench, User 
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import { typedFetch, InstallStatusResponseSchema } from '@servicebay/api-client';
-import { NAVIGATION_ENTRIES } from '@/config/navigation';
+import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
 
 // Back-compat re-export — MobileNav imports `dashboards` from here.
 // New code should import NAVIGATION_ENTRIES directly from
@@ -212,7 +212,7 @@ export default function Sidebar() {
             })()}
             {dashboards.map(p => {
                 const Icon = p.icon;
-                const isActive = pathname?.startsWith(p.path) ?? false;
+                const isActive = isNavActive(pathname, p.path);
                 return (
                     <button
                         key={p.id}

--- a/packages/frontend/src/config/navigation.test.ts
+++ b/packages/frontend/src/config/navigation.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { isNavActive } from './navigation';
+
+describe('isNavActive', () => {
+  it('marks Home (root) active ONLY on the exact root path', () => {
+    expect(isNavActive('/', '/')).toBe(true);
+    // The bug: startsWith('/') matched every page, so Home stayed highlighted
+    // alongside the real section.
+    expect(isNavActive('/services', '/')).toBe(false);
+    expect(isNavActive('/settings', '/')).toBe(false);
+  });
+
+  it('marks a section active on its own path and sub-paths', () => {
+    expect(isNavActive('/services', '/services')).toBe(true);
+    expect(isNavActive('/services/immich', '/services')).toBe(true);
+  });
+
+  it('does not match a different section sharing a prefix', () => {
+    expect(isNavActive('/servicesX', '/services')).toBe(false);
+    expect(isNavActive('/health', '/services')).toBe(false);
+  });
+});

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -44,6 +44,18 @@ export interface NavigationEntry {
  * "Primary sidebar is a user-task list, not an infrastructure list"
  * — operators who need the raw podman view know to open Diagnostics.
  */
+/**
+ * Active-route test for a nav entry. The root entry (`/`) must match the
+ * pathname EXACTLY — otherwise `startsWith('/')` is true on every page and
+ * Home looks active alongside the real section (e.g. Home + Settings both
+ * highlighted). Deeper entries match by path segment, so `/services/foo`
+ * still highlights Services while `/servicesX` does not.
+ */
+export function isNavActive(pathname: string, path: string): boolean {
+  if (path === '/') return pathname === '/';
+  return pathname === path || pathname.startsWith(`${path}/`);
+}
+
 export const NAVIGATION_ENTRIES: NavigationEntry[] = [
   { id: 'home', name: 'Home', shortLabel: 'Home', icon: Home, path: '/' },
   { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },


### PR DESCRIPTION
## What
Home (`path: '/'`) shared the `pathname.startsWith(path)` active test with every nav entry, so `startsWith('/')` was true on every page — **Home stayed highlighted alongside the real section** (Home + Settings both looked active).

Add a shared `isNavActive(pathname, path)`: the root entry matches the pathname **exactly**; deeper entries match by path segment (`/services/foo` highlights Services; `/servicesX` does not). Used by both `Sidebar` and `MobileNav` (mobile bar unchanged in behaviour otherwise).

## Why
Reported: "Home and Settings look active at the same time."

## Risk
Low — pure active-state logic, unit-tested; no layout change.

## Verification
- [x] `vitest` navigation.test.ts (root exact-match; section + sub-path; prefix-collision)
- [x] eslint --fix clean
- [ ] `/verify` — visual highlight on the box (low-risk; logic is unit-tested)