### PR TITLE
feat(frontend): live install-progress card on the Home dashboard

### DIFF
--- a/packages/frontend/src/components/InstallProgressCard.test.tsx
+++ b/packages/frontend/src/components/InstallProgressCard.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * InstallProgressCardView (#A) — the presentational half of the Home
+ * install-progress card. Renders current item, deployed/total, percent,
+ * log tail, and a skip-credentials affordance only on needs_credentials.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InstallProgressCardView } from './InstallProgressCard';
+import type { InstallMonitorState } from '@/hooks/useInstallMonitor';
+
+const base: InstallMonitorState = {
+  jobId: 'job-1',
+  phase: 'running',
+  currentItem: 'immich',
+  deployed: 3,
+  total: 6,
+  percent: 50,
+  needsCredentials: false,
+  logs: ['🔑 Reusing 7 saved secrets', 'Deploying immich…'],
+};
+
+describe('InstallProgressCardView', () => {
+  it('renders the current item, deployed/total and log tail', () => {
+    render(<InstallProgressCardView state={base} onSkipCredentials={() => {}} />);
+    expect(screen.getByText('· immich')).toBeDefined();
+    expect(screen.getByText('3/6')).toBeDefined();
+    expect(screen.getByText('50%')).toBeDefined();
+    expect(screen.getByText(/Reusing 7 saved secrets/)).toBeDefined();
+  });
+
+  it('hides the skip-credentials button unless waiting on credentials', () => {
+    render(<InstallProgressCardView state={base} onSkipCredentials={() => {}} />);
+    expect(screen.queryByText(/skip credentials/i)).toBeNull();
+  });
+
+  it('shows and wires the skip-credentials button on needs_credentials', () => {
+    const onSkip = vi.fn();
+    render(
+      <InstallProgressCardView
+        state={{ ...base, phase: 'needs_credentials', needsCredentials: true }}
+        onSkipCredentials={onSkip}
+      />,
+    );
+    const btn = screen.getByText(/skip credentials/i).closest('button')!;
+    fireEvent.click(btn);
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/frontend/src/components/InstallProgressCard.tsx
+++ b/packages/frontend/src/components/InstallProgressCard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { Loader2, KeyRound } from 'lucide-react';
+import { useInstallMonitor, type InstallMonitorState } from '@/hooks/useInstallMonitor';
+
+/**
+ * Live install-progress card for the Home dashboard (#A). When an
+ * install is running on the box, every connected web client sees the
+ * same thing the sb-tui monitor shows: the current item, deployed/total
+ * count, a percent bar, and a tail of the install log — plus a "skip
+ * credentials" button when the runner pauses on the NPM credentials
+ * prompt.
+ *
+ * Renders nothing when no install is active ({@link useInstallMonitor}
+ * returns `null`).
+ */
+export default function InstallProgressCard() {
+  const { state, skipCredentials } = useInstallMonitor();
+  if (!state) return null;
+  return <InstallProgressCardView state={state} onSkipCredentials={skipCredentials} />;
+}
+
+// phaseLabel maps a raw job phase to a human label — mirrors the sb-tui
+// monitor's phaseLabel so the web and terminal views read the same.
+function phaseLabel(phase: string): string {
+  switch (phase) {
+    case '': return 'starting…';
+    case 'running': return 'Installing';
+    case 'needs_credentials': return 'Waiting for configuration';
+    case 'done':
+    case 'complete': return 'Done';
+    case 'failed':
+    case 'error': return 'Failed';
+    default: return phase;
+  }
+}
+
+export function InstallProgressCardView({
+  state,
+  onSkipCredentials,
+}: {
+  state: InstallMonitorState;
+  onSkipCredentials: () => void;
+}) {
+  const { phase, currentItem, deployed, total, percent, needsCredentials, logs } = state;
+  return (
+    <div className="rounded-2xl p-5 glass-panel border border-blue-500/20 bg-gradient-to-br from-blue-500/10 to-indigo-500/5 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-base font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+          <Loader2 size={18} className="text-blue-500 shrink-0 animate-spin" />
+          {phaseLabel(phase)}
+          {currentItem && <span className="font-medium text-gray-500 dark:text-gray-400">· {currentItem}</span>}
+        </h2>
+        {total > 0 && (
+          <span className="text-sm font-semibold text-blue-600 dark:text-blue-400 shrink-0 tabular-nums">
+            {deployed}/{total}
+          </span>
+        )}
+      </div>
+
+      {/* Percent bar (% = deployed/total). */}
+      <div className="space-y-1">
+        <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-blue-500 transition-[width] duration-500"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">{percent}%</p>
+      </div>
+
+      {/* The runner paused on the NPM credentials prompt. Skipping
+          continues with the auto-generated fallback; proxy routes can
+          be set later in Settings → Integrations. */}
+      {needsCredentials && (
+        <div className="rounded-xl border border-amber-300/60 dark:border-amber-800/50 bg-amber-50/80 dark:bg-amber-950/20 p-3 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <p className="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+            Waiting for reverse-proxy credentials. Skip to continue with auto-generated ones — you can set them later in Settings.
+          </p>
+          <button
+            type="button"
+            onClick={onSkipCredentials}
+            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors"
+          >
+            <KeyRound size={13} /> Skip credentials
+          </button>
+        </div>
+      )}
+
+      {/* Log tail — the last few install-runner lines, monospaced. */}
+      {logs.length > 0 && (
+        <pre className="text-[11px] leading-relaxed font-mono text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-black/30 rounded-xl p-3 overflow-x-auto max-h-44 whitespace-pre-wrap break-words">
+          {logs.join('\n')}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { Box, Network, Activity, Terminal, Settings, ArrowRight, AlertCircle, CheckCircle2, Wrench } from 'lucide-react';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
+import InstallProgressCard from '@/components/InstallProgressCard';
 
 /**
  * Home / Overview dashboard (#803).
@@ -60,6 +61,11 @@ export default function OverviewDashboard() {
             )}
           </p>
         </header>
+
+        {/* Live install monitor — only renders while an install is
+            running, so every web client sees the same progress the
+            sb-tui monitor shows (#A). */}
+        <InstallProgressCard />
 
         {/* Headline status — the single sentence that answers "is everything OK?" */}
         <HealthHeadline tone={healthHeadline.tone} text={healthHeadline.text} />

--- a/packages/frontend/src/hooks/useInstallMonitor.ts
+++ b/packages/frontend/src/hooks/useInstallMonitor.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
+
+// Lenient schemas — only the fields the Home install card reads. The
+// canonical job shape lives in @/lib/install/jobStore; passthrough keeps
+// us resilient to additive drift (cf. the install.ts contract notes).
+const ProgressShapeSchema = z
+  .object({
+    currentItem: z.string().nullish(),
+    deployedNames: z.array(z.string()).default([]),
+    totalCount: z.number().default(0),
+  })
+  .passthrough();
+
+const CurrentSchema = z.object({
+  job: z
+    .object({ id: z.string(), phase: z.string(), progress: ProgressShapeSchema })
+    .passthrough()
+    .nullable(),
+  jobIsActive: z.boolean(),
+});
+
+const ProgressSchema = z.object({
+  job: z
+    .object({
+      phase: z.string(),
+      error: z.string().nullish(),
+      progress: ProgressShapeSchema,
+      needsCredentials: z.boolean().optional(),
+    })
+    .passthrough(),
+  jobIsActive: z.boolean(),
+  logs: z.string().optional(),
+  logsOffset: z.number().optional(),
+});
+
+export interface InstallMonitorState {
+  jobId: string;
+  phase: string;
+  currentItem: string;
+  deployed: number;
+  total: number;
+  percent: number;
+  needsCredentials: boolean;
+  logs: string[];
+}
+
+const ACTIVE_POLL_MS = 1500;
+const IDLE_POLL_MS = 5000;
+const MAX_LOG_LINES = 200;
+
+/**
+ * Live install monitor for every web client (#A). Polls
+ * `GET /api/install/current` to detect an active job and learn its
+ * jobId, then `GET /api/install/progress?jobId=&logsSince=` for the
+ * phase, percent, and incremental log tail.
+ *
+ * Returns `null` whenever nothing is installing (the Home card hides on
+ * `null`). Self-paced: a slow idle poll while there's no job, a faster
+ * poll once one is running. setTimeout-rescheduled (not setInterval) so
+ * a slow fetch never overlaps the next tick.
+ */
+export function useInstallMonitor(): { state: InstallMonitorState | null; skipCredentials: () => Promise<void> } {
+  const [state, setState] = useState<InstallMonitorState | null>(null);
+  const jobIdRef = useRef<string | null>(null);
+  const offsetRef = useRef(0);
+  const logsRef = useRef<string[]>([]);
+
+  const skipCredentials = useCallback(async () => {
+    const jobId = jobIdRef.current;
+    if (!jobId) return;
+    try {
+      await fetch('/api/install/skip-credentials', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jobId }),
+      });
+    } catch { /* the next poll reflects the resumed phase; nothing to do here */ }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const reset = () => {
+      jobIdRef.current = null;
+      offsetRef.current = 0;
+      logsRef.current = [];
+      setState(null);
+    };
+
+    // Find an active job (and its id) when we aren't tracking one yet.
+    const detect = async (): Promise<boolean> => {
+      const res = await fetch('/api/install/current', { cache: 'no-store' });
+      if (!res.ok) return false;
+      const parsed = CurrentSchema.safeParse(await res.json());
+      if (!parsed.success) return false;
+      if (parsed.data.jobIsActive && parsed.data.job) {
+        jobIdRef.current = parsed.data.job.id;
+        offsetRef.current = 0;
+        logsRef.current = [];
+        return true;
+      }
+      if (state !== null) setState(null);
+      return false;
+    };
+
+    const pollProgress = async (jobId: string) => {
+      const url = `/api/install/progress?jobId=${encodeURIComponent(jobId)}&logsSince=${offsetRef.current}`;
+      const res = await fetch(url, { cache: 'no-store' });
+      if (!res.ok) return;
+      const parsed = ProgressSchema.safeParse(await res.json());
+      if (cancelled || !parsed.success) return;
+      const d = parsed.data;
+      if (d.logs) {
+        for (const line of d.logs.split('\n')) if (line.trim()) logsRef.current.push(line);
+        if (logsRef.current.length > MAX_LOG_LINES) logsRef.current = logsRef.current.slice(-MAX_LOG_LINES);
+      }
+      if (typeof d.logsOffset === 'number') offsetRef.current = d.logsOffset;
+      if (!d.jobIsActive) { reset(); return; } // install ended — hide the card
+      const deployed = d.job.progress.deployedNames.length;
+      const total = d.job.progress.totalCount;
+      setState({
+        jobId,
+        phase: d.job.phase,
+        currentItem: d.job.progress.currentItem ?? '',
+        deployed,
+        total,
+        percent: total > 0 ? Math.floor((deployed * 100) / total) : 0,
+        needsCredentials: d.job.phase === 'needs_credentials' || !!d.job.needsCredentials,
+        logs: logsRef.current.slice(-12),
+      });
+    };
+
+    const tick = async () => {
+      try {
+        if (!jobIdRef.current) {
+          if (!(await detect()) || cancelled) return;
+        }
+        if (jobIdRef.current) await pollProgress(jobIdRef.current);
+      } catch { /* offline / mid-redeploy — keep the previous value */ }
+    };
+
+    const loop = async () => {
+      await tick();
+      if (!cancelled) timer = setTimeout(loop, jobIdRef.current ? ACTIVE_POLL_MS : IDLE_POLL_MS);
+    };
+    void loop();
+    return () => { cancelled = true; if (timer) clearTimeout(timer); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { state, skipCredentials };
+}


### PR DESCRIPTION
## What

Adds a **live install-progress card** to the Home / Overview dashboard so **every connected web client** sees an in-flight install — mirroring the sb-tui install monitor — not just the operator who clicked Install.

## Changes

- **`useInstallMonitor()` hook** — polls `GET /api/install/current` to detect an active job and learn its `jobId`, then the public `GET /api/install/progress?jobId=&logsSince=` for phase, percent (`deployed/total`), and an **incremental** log tail. `setTimeout`-rescheduled with a slow idle (5s) / fast active (1.5s) cadence so a slow fetch never overlaps the next tick. Returns `null` when nothing is installing. Exposes `skipCredentials()` → `POST /api/install/skip-credentials`.
- **`InstallProgressCard`** — current item · deployed/total · percent bar · log tail, plus a **"Skip credentials"** affordance shown only on `needs_credentials`. Hidden entirely when no install is active.
- Rendered at the top of `OverviewDashboard`, above the health headline.

## Tests / gates

- New `InstallProgressCard.test.tsx` (render, skip-button visibility + wiring).
- `npm run lint` (0 errors), `npm run check:arch`, `npm test` (1487 passing), frontend `tsc --noEmit`, `knip` — all green.

## Verify note

Touches the `(dashboard)` Home surface — path-mandated `/verify` on the box before merge. `/api/install/current` only exists on **4.62.0+**, so the box must be on that build, and an install must be active to see the card render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)