### PR TITLE
fix(install): portal routing reports skipped, not failed, when AdGuard is absent

### DIFF
--- a/packages/backend/src/lib/portal/provisioner.test.ts
+++ b/packages/backend/src/lib/portal/provisioner.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// State the mocks read, reset per test.
+const state = {
+  config: {} as any,
+  services: [] as any[],
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(() => Promise.resolve(state.services)) },
+}));
+
+const ensureWildcardRewrite = vi.fn();
+vi.mock('@/lib/adguard/rewrites', () => ({
+  ensureWildcardRewrite: (...args: any[]) => ensureWildcardRewrite(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { provisionPortalRouting } from './provisioner';
+
+const PUBLIC_CONFIG = {
+  reverseProxy: { lanIp: '192.168.178.100', publicDomain: 'dopp.cloud' },
+};
+
+beforeEach(() => {
+  state.config = JSON.parse(JSON.stringify(PUBLIC_CONFIG));
+  state.services = [];
+  ensureWildcardRewrite.mockReset();
+  mockFetch.mockReset();
+});
+
+describe('provisionPortalRouting', () => {
+  it('reports skipped (not failed) on a fresh install with no nginx and no AdGuard', async () => {
+    // Nothing deployed: no nginx → proxy skipped; no AdGuard service +
+    // no creds → rewrites skipped. The "did not provision" alarm must
+    // NOT fire on a healthy minimal box.
+    const res = await provisionPortalRouting();
+    expect(res.ok).toBe(true);
+    expect(res.proxyHost).toBe('skipped');
+    expect(Object.values(res.rewrites!)).toEqual(['skipped', 'skipped', 'skipped']);
+    expect(res.detail).toMatch(/nothing to wire up/i);
+    expect(ensureWildcardRewrite).not.toHaveBeenCalled();
+  });
+
+  it('reports failed (worth retrying) when AdGuard is up but its creds are not written yet', async () => {
+    // AdGuard deployed and active, but no creds in config → a real,
+    // transient cold-start condition the retry loop should keep hitting.
+    state.services = [{ name: 'adguard', active: true }];
+    const res = await provisionPortalRouting();
+    expect(res.ok).toBe(false);
+    expect(Object.values(res.rewrites!)).toEqual(['failed', 'failed', 'failed']);
+    expect(res.detail).toContain('dopp.cloud:failed');
+  });
+
+  it('writes the apex/www/wildcard rewrites once AdGuard creds are present', async () => {
+    state.config.adguard = { password: 'pw', username: 'admin', adminUrl: 'http://localhost:8083' };
+    ensureWildcardRewrite.mockResolvedValue('added');
+    const res = await provisionPortalRouting();
+    expect(res.ok).toBe(true);
+    expect(ensureWildcardRewrite).toHaveBeenCalledTimes(3);
+    expect(ensureWildcardRewrite).toHaveBeenCalledWith(
+      expect.objectContaining({ password: 'pw' }),
+      'dopp.cloud',
+      '192.168.178.100',
+    );
+    expect(res.rewrites).toEqual({ 'dopp.cloud': 'added', 'www.dopp.cloud': 'added', '*.dopp.cloud': 'added' });
+  });
+});

--- a/packages/backend/src/lib/portal/provisioner.ts
+++ b/packages/backend/src/lib/portal/provisioner.ts
@@ -32,7 +32,7 @@ import { logger } from '@/lib/logger';
 
 const LOG = 'portal:provisioner';
 
-type RewriteResult = 'added' | 'updated' | 'unchanged' | 'failed';
+type RewriteResult = 'added' | 'updated' | 'unchanged' | 'failed' | 'skipped';
 
 interface ProvisionResult {
   ok: boolean;
@@ -161,14 +161,25 @@ async function provisionNpmProxyHost(domain: string): Promise<ProvisionResult['p
   }
 }
 
-async function provisionAdguardRewrite(name: string, lanIp: string): Promise<'added' | 'updated' | 'unchanged' | 'failed'> {
-  const creds = await findAdguardCreds();
-  if (!creds) return 'failed';
-  return ensureWildcardRewrite({
-    adminUrl: creds.adminUrl,
-    username: creds.username,
-    password: creds.password,
-  }, name, lanIp);
+/** Whether an AdGuard service is actually deployed and running on this
+ *  node. Mirrors the nginx check in {@link provisionNpmProxyHost}: it
+ *  lets us tell "AdGuard isn't part of this install" (→ rewrites are
+ *  'skipped', nothing to do) apart from "AdGuard is up but the rewrite
+ *  POST failed / its creds aren't written yet" (→ 'failed', worth a
+ *  retry + warning). Without this split a minimal install that never
+ *  deployed AdGuard reported every rewrite as 'failed' and lit up the
+ *  alarming "Portal routing did not fully provision" warning on a
+ *  perfectly healthy fresh box. */
+async function isAdguardDeployed(): Promise<boolean> {
+  try {
+    const services = await ServiceManager.listServices('Local');
+    return services.some(s =>
+      (s.name === 'adguard' || s.name === 'adguardhome' || (s.name.includes('adguard') && !s.name.startsWith('install-')))
+      && s.active,
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -211,20 +222,32 @@ export async function provisionPortalRouting(): Promise<ProvisionResult> {
     rewriteDomains.add('home.arpa');
   }
 
+  // Resolve AdGuard once: present creds → write rewrites; no creds but
+  // AdGuard is up → 'failed' (transient cold-start, retry); no creds and
+  // no AdGuard service → 'skipped' (nothing to wire up on this install).
+  const creds = await findAdguardCreds();
+  const adguardDeployed = creds !== null || (await isAdguardDeployed());
   const rewrites: Record<string, RewriteResult> = {};
   for (const d of rewriteDomains) {
-    rewrites[d] = await provisionAdguardRewrite(d, lanIp);
-    rewrites[`www.${d}`] = await provisionAdguardRewrite(`www.${d}`, lanIp);
-    rewrites[`*.${d}`] = await provisionAdguardRewrite(`*.${d}`, lanIp);
+    for (const name of [d, `www.${d}`, `*.${d}`]) {
+      rewrites[name] = creds
+        ? await ensureWildcardRewrite(creds, name, lanIp)
+        : adguardDeployed ? 'failed' : 'skipped';
+    }
   }
 
   const anyRewriteFailed = Object.values(rewrites).some(r => r === 'failed');
   const ok = proxyHost !== 'failed' && !anyRewriteFailed;
-  const summary = `proxy:${proxyHost} rewrites=${Object.entries(rewrites).map(([k, v]) => `${k}:${v}`).join(',')}`;
+  // On a fresh install neither the reverse proxy nor AdGuard need be
+  // present — say so plainly instead of dumping a row of `:skipped`s.
+  const allSkipped = proxyHost === 'skipped' && Object.values(rewrites).every(r => r === 'skipped');
+  const detail = allSkipped
+    ? 'nothing to wire up yet (no reverse proxy or AdGuard installed)'
+    : `proxy:${proxyHost} rewrites=${Object.entries(rewrites).map(([k, v]) => `${k}:${v}`).join(',')}`;
   if (ok) {
-    logger.info(LOG, `Portal routing provisioned for ${activeDomain} (${summary})`);
+    logger.info(LOG, `Portal routing provisioned for ${activeDomain} (${detail})`);
   } else {
-    logger.warn(LOG, `Portal routing provisioning had failures for ${activeDomain} (${summary})`);
+    logger.warn(LOG, `Portal routing provisioning had failures for ${activeDomain} (${detail})`);
   }
-  return { ok, detail: summary, proxyHost, rewrites };
+  return { ok, detail, proxyHost, rewrites };
 }


### PR DESCRIPTION
## Problem (raised mid-session by @mdopp)

On a **fresh public-domain install** that hasn't deployed a reverse proxy / AdGuard yet, the install monitor showed:

```
Provisioning AdGuard DNS rewrites + portal routing...
⏳ Portal routing attempt 1/4: proxy:skipped rewrites=dopp.cloud:failed,www.dopp.cloud:failed,*.dopp.cloud:failed
...
⚠️ Portal routing did not fully provision after retries. Open Settings → Self-Diagnose → Reprovision if rewrites are missing.
```

The box is healthy — there's simply **no nginx / AdGuard to wire the domain into yet**. But the provisioner classified every DNS rewrite as `failed` (because `findAdguardCreds()` returned `null`), which forced `ok=false` and fired the alarming "did not fully provision" warning.

## Root cause

`provisionAdguardRewrite` returned `'failed'` whenever there were no AdGuard credentials — conflating two very different situations:
1. **AdGuard genuinely up but the rewrite POST failed / creds not written yet** → a real, transient cold-start condition the retry loop should keep hitting.
2. **AdGuard not part of this install at all** → nothing to do; not a failure.

The **proxy** step already handles this correctly by returning `'skipped'` when nginx isn't active.

## Fix

Mirror the proxy `'skipped'` semantics for AdGuard:

- Add `isAdguardDeployed()` — checks for an active `adguard` service.
- No creds **+ AdGuard not deployed** → `'skipped'` (nothing to wire up; `ok` stays true).
- No creds **+ AdGuard up** → `'failed'` (retry loop still kicks in — original behaviour preserved).
- Creds present → write the apex/www/wildcard rewrites exactly as before.
- When the whole step is a no-op, `detail` reads `nothing to wire up yet (no reverse proxy or AdGuard installed)` instead of a row of `:skipped`s.

Net effect: a fresh minimal box logs a calm `✅ Portal routing: nothing to wire up yet …` instead of a red herring.

## Tests / gates

- New `provisioner.test.ts`: fresh box → skipped; AdGuard-up-no-creds → failed (retryable); creds present → 3 rewrites written.
- Existing `portalProvision.test.ts` (retry helper) unchanged + passing.
- `npm run lint` (0 errors), `check:arch`, `npm test` (1487 passing), backend `tsc --noEmit` — all green.

## Verify note

Touches the post-install portal-routing path — path-mandated `/verify` on the box on the next reinstall to a build carrying this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)