### PR TITLE
fix(install): provision portal routing after services settle; honest skip + edit-config Domain field

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -1316,6 +1316,15 @@ async function runJob(jobId: string): Promise<void> {
     await log(jobId, `(note) couldn't persist the credentials manifest: ${e instanceof Error ? e.message : String(e)}`);
   }
 
+  // Settle-wait against the in-process digital twin FIRST, so the
+  // services portal routing depends on (nginx, AdGuard) are actually
+  // active — and AdGuard's post-deploy hook has had a chance to write
+  // its admin creds — before we try to provision. Running portal
+  // provisioning ahead of this fired it against not-yet-healthy
+  // containers, which on a fresh install reported a misleading failure
+  // (the proxy/DNS *were* being installed, just not up yet).
+  await settleWait(jobId, ctx.deployed, input.node || 'Local');
+
   // Portal routing — apex + wildcard rewrites for the active domain.
   // Always runs after a successful install (#707). Pre-fix this was
   // gated on `adguard ∈ newlyDeployed`, which meant a feature-only
@@ -1323,12 +1332,10 @@ async function runJob(jobId: string): Promise<void> {
   // host) silently skipped DNS-rewrite provisioning even though new
   // subdomains were being created. Now run it whenever the
   // prerequisites (publicDomain + AdGuard reachable) are met; the
-  // provisioner internally no-ops when AdGuard isn't installed yet.
+  // provisioner reports a calm skip only when nginx/AdGuard aren't
+  // part of this install at all.
   await log(jobId, 'Provisioning AdGuard DNS rewrites + portal routing...');
   await provisionPortalWithRetries((line: string) => { void log(jobId, line); });
-
-  // Settle-wait against the in-process digital twin.
-  await settleWait(jobId, ctx.deployed, input.node || 'Local');
 
   await patchJob(jobId, {
     phase: 'done',

--- a/packages/backend/src/lib/portal/provisioner.test.ts
+++ b/packages/backend/src/lib/portal/provisioner.test.ts
@@ -53,14 +53,26 @@ describe('provisionPortalRouting', () => {
     expect(ensureWildcardRewrite).not.toHaveBeenCalled();
   });
 
-  it('reports failed (worth retrying) when AdGuard is up but its creds are not written yet', async () => {
-    // AdGuard deployed and active, but no creds in config → a real,
-    // transient cold-start condition the retry loop should keep hitting.
-    state.services = [{ name: 'adguard', active: true }];
+  it('reports failed (worth retrying) when AdGuard is part of the install but not ready yet', async () => {
+    // AdGuard deployed but still cold-starting (active:false) and no creds
+    // written yet → a real, transient condition the retry loop should keep
+    // hitting. Existence, not active-state, is what marks it as "ours".
+    state.services = [{ name: 'adguard', active: false }];
     const res = await provisionPortalRouting();
     expect(res.ok).toBe(false);
     expect(Object.values(res.rewrites!)).toEqual(['failed', 'failed', 'failed']);
     expect(res.detail).toContain('dopp.cloud:failed');
+    expect(res.detail).not.toMatch(/nothing to wire up/i);
+  });
+
+  it('reports proxy failed (not skipped) when nginx is installed but not yet active', async () => {
+    // The reverse proxy was installed but is still starting — must not be
+    // reported as "nothing to wire up".
+    state.services = [{ name: 'nginx', active: false }];
+    const res = await provisionPortalRouting();
+    expect(res.ok).toBe(false);
+    expect(res.proxyHost).toBe('failed');
+    expect(res.detail).not.toMatch(/nothing to wire up/i);
   });
 
   it('writes the apex/www/wildcard rewrites once AdGuard creds are present', async () => {

--- a/packages/backend/src/lib/portal/provisioner.ts
+++ b/packages/backend/src/lib/portal/provisioner.ts
@@ -111,9 +111,12 @@ async function provisionNpmProxyHost(domain: string): Promise<ProvisionResult['p
     const nginx = services.find(s =>
       s.name === 'nginx' || s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
     );
-    if (!nginx?.active) {
-      return 'skipped';
-    }
+    // No nginx in this install → nothing to wire up ('skipped'). nginx
+    // deployed but not up yet → 'failed' so the retry loop keeps trying
+    // and an honest warning fires if it never comes up — we must not
+    // pretend there's nothing to do when the operator installed it.
+    if (!nginx) return 'skipped';
+    if (!nginx.active) return 'failed';
   } catch {
     return 'skipped';
   }
@@ -161,21 +164,23 @@ async function provisionNpmProxyHost(domain: string): Promise<ProvisionResult['p
   }
 }
 
-/** Whether an AdGuard service is actually deployed and running on this
- *  node. Mirrors the nginx check in {@link provisionNpmProxyHost}: it
- *  lets us tell "AdGuard isn't part of this install" (→ rewrites are
- *  'skipped', nothing to do) apart from "AdGuard is up but the rewrite
- *  POST failed / its creds aren't written yet" (→ 'failed', worth a
- *  retry + warning). Without this split a minimal install that never
- *  deployed AdGuard reported every rewrite as 'failed' and lit up the
- *  alarming "Portal routing did not fully provision" warning on a
- *  perfectly healthy fresh box. */
+/** Whether an AdGuard service is part of this install at all — i.e. a
+ *  matching service *exists*, regardless of whether it's active yet.
+ *  Mirrors the nginx check in {@link provisionNpmProxyHost}: it lets us
+ *  tell "AdGuard isn't part of this install" (→ rewrites 'skipped',
+ *  nothing to do) apart from "AdGuard is being installed but isn't ready
+ *  yet / its creds aren't written" (→ 'failed', worth a retry + an
+ *  honest warning).
+ *
+ *  Existence — NOT `active` — is the right signal: during a fresh
+ *  install AdGuard is deployed but may still be cold-starting when this
+ *  runs, and treating that as "not installed" would falsely report
+ *  "nothing to wire up" for an install that explicitly included it. */
 async function isAdguardDeployed(): Promise<boolean> {
   try {
     const services = await ServiceManager.listServices('Local');
     return services.some(s =>
-      (s.name === 'adguard' || s.name === 'adguardhome' || (s.name.includes('adguard') && !s.name.startsWith('install-')))
-      && s.active,
+      s.name === 'adguard' || s.name === 'adguardhome' || (s.name.includes('adguard') && !s.name.startsWith('install-')),
     );
   } catch {
     return false;

--- a/packages/frontend/src/app/api/settings/route.ts
+++ b/packages/frontend/src/app/api/settings/route.ts
@@ -63,6 +63,16 @@ export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request })
       ...currentConfig.notifications,
       ...validated.notifications,
     } : currentConfig.notifications,
+    // Deep-merge reverseProxy (same one-level merge as notifications) so a
+    // caller sending a single nested field — e.g. the sb-tui edit-config
+    // panel writing `{ reverseProxy: { publicDomain } }` — doesn't blow
+    // away the rest of the block (npm creds, lanDomain, lanIp). The web UI
+    // edits the domain via its own server action / /api/system/mode, not
+    // here, so this never narrows an existing caller.
+    reverseProxy: validated.reverseProxy ? {
+      ...currentConfig.reverseProxy,
+      ...validated.reverseProxy,
+    } : currentConfig.reverseProxy,
   };
 
   await saveConfig(newConfig);

--- a/tools/sb-tui/internal/rest/config.go
+++ b/tools/sb-tui/internal/rest/config.go
@@ -11,17 +11,32 @@ import (
 // token/key) are redacted by the box on GET and intentionally not editable
 // here — they round-trip through the web UI, not the TUI.
 type EditableField struct {
-	Key   string // config.json key sent in the POST patch
+	Key   string // stable identifier: values-map key + status label
 	Label string // human label shown in the panel
+	// Path is the field's location in the config object, for both the GET
+	// projection and the POST patch. Empty means top-level []string{Key}.
+	// The domain lives nested at reverseProxy.publicDomain (what the web UI
+	// and /api/system/mode use), NOT at the dead top-level `domain` display
+	// field — reading the latter showed "(unset)" on a box that had a
+	// domain set.
+	Path []string
 	// Allowed, when non-empty, constrains the value to a fixed set (an enum
 	// like logLevel); an empty slice means free-text.
 	Allowed []string
 }
 
+// path is the field's config location, defaulting to a top-level key.
+func (f EditableField) path() []string {
+	if len(f.Path) > 0 {
+		return f.Path
+	}
+	return []string{f.Key}
+}
+
 // EditableFields is the curated allow-list, in display order.
 var EditableFields = []EditableField{
 	{Key: "serverName", Label: "Server name"},
-	{Key: "domain", Label: "Domain"},
+	{Key: "domain", Label: "Domain", Path: []string{"reverseProxy", "publicDomain"}},
 	{Key: "logLevel", Label: "Log level", Allowed: []string{"debug", "info", "warn", "error"}},
 }
 
@@ -33,7 +48,9 @@ type Config struct {
 }
 
 // GetConfig fetches the box config and projects out the allow-listed fields.
-// A field absent from the box config reads as the empty string.
+// A field absent from the box config (or at a non-string leaf) reads as the
+// empty string. Nested fields (e.g. domain → reverseProxy.publicDomain) are
+// resolved by walking their Path.
 func (c *Client) GetConfig(ctx context.Context) (*Config, error) {
 	raw, err := c.do(ctx, "GET", "/api/settings", nil)
 	if err != nil {
@@ -41,25 +58,64 @@ func (c *Client) GetConfig(ctx context.Context) (*Config, error) {
 	}
 	// The settings GET returns the config object directly (plus a
 	// templateSettingsSchema sibling we ignore), not the {ok,data} envelope.
-	var doc map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &doc); err != nil {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
 		return nil, &APIError{Message: "malformed config response: " + err.Error()}
 	}
 	values := make(map[string]string, len(EditableFields))
 	for _, f := range EditableFields {
-		var s string
-		if v, ok := doc[f.Key]; ok {
-			_ = json.Unmarshal(v, &s) // non-string/absent → "" via zero value
-		}
-		values[f.Key] = s
+		values[f.Key] = stringAtPath(obj, f.path())
 	}
 	return &Config{Values: values}, nil
 }
 
+// stringAtPath walks a nested map by key, returning the string leaf or "" if
+// any segment is missing or the leaf isn't a string.
+func stringAtPath(obj map[string]any, path []string) string {
+	var cur any = obj
+	for _, key := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = m[key]
+	}
+	if s, ok := cur.(string); ok {
+		return s
+	}
+	return ""
+}
+
 // UpdateConfig writes a single allow-listed field. It POSTs a minimal partial
-// ({key: value}) so the box's merge touches only that field and never
-// round-trips redacted secrets back into the store (#1275).
+// nested at the field's Path (e.g. {reverseProxy:{publicDomain:value}}) so the
+// box's one-level merge touches only that field and never round-trips redacted
+// secrets back into the store (#1275). The backend deep-merges `reverseProxy`
+// (like `notifications`), so a nested write preserves the rest of the block.
 func (c *Client) UpdateConfig(ctx context.Context, key, value string) error {
-	_, err := c.do(ctx, "POST", "/api/settings", map[string]string{key: value})
+	path := []string{key}
+	for _, f := range EditableFields {
+		if f.Key == key {
+			path = f.path()
+			break
+		}
+	}
+	_, err := c.do(ctx, "POST", "/api/settings", nestPartial(path, value))
 	return err
+}
+
+// nestPartial builds a nested object placing value at path
+// (["reverseProxy","publicDomain"], "x" → {"reverseProxy":{"publicDomain":"x"}}).
+func nestPartial(path []string, value string) map[string]any {
+	root := map[string]any{}
+	cur := root
+	for i, key := range path {
+		if i == len(path)-1 {
+			cur[key] = value
+			break
+		}
+		next := map[string]any{}
+		cur[key] = next
+		cur = next
+	}
+	return root
 }

--- a/tools/sb-tui/internal/rest/rest_test.go
+++ b/tools/sb-tui/internal/rest/rest_test.go
@@ -32,11 +32,13 @@ func TestGetConfigProjectsAllowList(t *testing.T) {
 		// The settings GET returns the config object directly, with extra
 		// keys (templateSettingsSchema, redacted secrets) the client ignores.
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"serverName":             "homelab",
-			"logLevel":               "debug",
-			"adminPassword":          "__REDACTED__",
+			"serverName":    "homelab",
+			"logLevel":      "debug",
+			"adminPassword": "__REDACTED__",
+			// The domain lives nested at reverseProxy.publicDomain — the
+			// same field the web UI edits — not the dead top-level `domain`.
+			"reverseProxy":           map[string]any{"publicDomain": "dopp.cloud", "lanDomain": "home.arpa"},
 			"templateSettingsSchema": map[string]any{"x": 1},
-			// domain intentionally absent → should read as "".
 		})
 	}))
 	defer srv.Close()
@@ -51,11 +53,27 @@ func TestGetConfigProjectsAllowList(t *testing.T) {
 	if cfg.Values["logLevel"] != "debug" {
 		t.Errorf("logLevel = %q", cfg.Values["logLevel"])
 	}
-	if cfg.Values["domain"] != "" {
-		t.Errorf("absent domain should be empty, got %q", cfg.Values["domain"])
+	if cfg.Values["domain"] != "dopp.cloud" {
+		t.Errorf("domain should read reverseProxy.publicDomain, got %q", cfg.Values["domain"])
 	}
 	if _, ok := cfg.Values["adminPassword"]; ok {
 		t.Error("non-allow-listed key leaked into Values")
+	}
+}
+
+func TestGetConfigDomainAbsentReadsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No reverseProxy block at all (LAN-only minimal install).
+		_ = json.NewEncoder(w).Encode(map[string]any{"serverName": "homelab"})
+	}))
+	defer srv.Close()
+
+	cfg, err := newTestClient(srv).GetConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	if cfg.Values["domain"] != "" {
+		t.Errorf("absent domain should be empty, got %q", cfg.Values["domain"])
 	}
 }
 
@@ -75,6 +93,31 @@ func TestUpdateConfigSendsMinimalPatch(t *testing.T) {
 	}
 	if len(gotBody) != 1 || gotBody["serverName"] != "newname" {
 		t.Errorf("expected minimal {serverName:newname} patch, got %v", gotBody)
+	}
+}
+
+func TestUpdateConfigDomainSendsNestedPatch(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).UpdateConfig(context.Background(), "domain", "dopp.cloud"); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+	// Domain must be written nested at reverseProxy.publicDomain so the
+	// backend's one-level deep-merge preserves the rest of the block.
+	rp, ok := gotBody["reverseProxy"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested reverseProxy patch, got %v", gotBody)
+	}
+	if rp["publicDomain"] != "dopp.cloud" {
+		t.Errorf("publicDomain = %v, want dopp.cloud", rp["publicDomain"])
+	}
+	if len(gotBody) != 1 {
+		t.Errorf("patch should carry only reverseProxy, got %v", gotBody)
 	}
 }
 


### PR DESCRIPTION
## Why

Two issues @mdopp hit on a live fresh install of `basic` (= **NPM + LLDAP/Authelia + AdGuard**):

### 1. The 4.63.0 portal fix masked a real failure
It reported **`✅ Portal routing: nothing to wire up yet (no reverse proxy or AdGuard installed)`** — but the operator *did* install the reverse proxy and AdGuard. My previous change wrongly equated *"AdGuard isn't active at this instant"* with *"AdGuard isn't installed"*, so it cheerfully skipped instead of wiring up the routing that was requested.

**Root cause is ordering**, not classification: the install loop ran `provisionPortalWithRetries` **before** `settleWait`, firing provisioning against not-yet-active nginx/AdGuard whose admin creds hadn't been written yet. The ~18s retry budget expired before they came up.

**Fix:**
- `runner.ts`: run **`settleWait` first**, then portal provisioning — so nginx + AdGuard are actually active (and AdGuard's post-deploy hook has written its creds) before we provision. It now *actually wires up the routing* instead of reporting a state.
- `provisioner.ts`: base the skip on whether nginx/AdGuard are **part of the install** (service *exists*), not on live-active state. Deployed-but-not-ready → `failed` (retry + honest warning if it truly never comes up); genuinely absent (LAN-only minimal install) → `skipped` (calm). nginx present-but-inactive → `failed`, not a misleading skip.

### 2. sb-tui edit-config "Domain" showed (unset)
The TUI read a dead top-level `domain` key instead of `reverseProxy.publicDomain` (what the web UI and `/api/system/mode` use), so a box *with* a domain showed `(unset)`.

**Fix:**
- `EditableField` gains a nested `Path`; **Domain → `reverseProxy.publicDomain`**. `GetConfig` walks the path; `UpdateConfig` sends a nested partial.
- `/api/settings` POST **deep-merges `reverseProxy`** (same one-level merge as `notifications`) so a nested write preserves npm creds / lanDomain / lanIp. The web UI edits the domain via its own server action, so no existing caller is narrowed.

## Tests / gates
- `provisioner.test.ts`: deployed-but-not-ready → failed (not skipped); nginx-installed-but-inactive → proxy failed; genuinely-absent → calm skip.
- sb-tui `rest`: domain reads nested `reverseProxy.publicDomain`; absent → empty; write sends nested `{reverseProxy:{publicDomain}}` patch.
- `npm run lint` (0 errors), `check:arch`, `npm test` (1494 passing); backend+frontend `tsc`; sb-tui `gofmt`/`vet`/`build`/`test` — all green.

## Verify note
Install-path + edit-config behaviour — path-mandated `/verify` deferred to the next reinstall to a build carrying this. On that reinstall, a `basic` install should now log real provisioning (or an honest retry/warning), **not** "nothing to wire up".

🤖 Generated with [Claude Code](https://claude.com/claude-code)