### PR TITLE
fix(tui): expand selected stacks into their templates before install

### DIFF
--- a/tools/sb-tui/internal/rest/install.go
+++ b/tools/sb-tui/internal/rest/install.go
@@ -10,11 +10,16 @@ import (
 
 // Stack is one installable stack from the box catalog (GET /api/system/stacks).
 // Tier is "core" or "feature"; Description is best-effort from the manifest.
+// Templates is the stack's constituent template names (`spec.templates`) — the
+// units the install pipeline actually deploys. A stack name itself is NOT a
+// deployable template (the assembler resolves templates, not stacks), so the
+// install flow must expand a selected stack into these before assembling.
 type Stack struct {
 	Name        string
 	Tier        string
 	Description string
 	Installed   bool
+	Templates   []string
 }
 
 // ListStacks enumerates the installable stack catalog. Core stacks sort first,
@@ -28,9 +33,10 @@ func (c *Client) ListStacks(ctx context.Context) ([]Stack, error) {
 		Stacks []struct {
 			Name     string `json:"name"`
 			Manifest *struct {
-				Tier        string `json:"tier"`
-				Description string `json:"description"`
-				DisplayName string `json:"displayName"`
+				Tier        string   `json:"tier"`
+				Description string   `json:"description"`
+				DisplayName string   `json:"displayName"`
+				Templates   []string `json:"templates"`
 			} `json:"manifest"`
 			Health *struct {
 				Installed bool `json:"installed"`
@@ -51,6 +57,7 @@ func (c *Client) ListStacks(ctx context.Context) ([]Stack, error) {
 			if st.Description == "" {
 				st.Description = s.Manifest.DisplayName
 			}
+			st.Templates = s.Manifest.Templates
 		}
 		if s.Health != nil {
 			st.Installed = s.Health.Installed

--- a/tools/sb-tui/internal/rest/install_test.go
+++ b/tools/sb-tui/internal/rest/install_test.go
@@ -16,7 +16,7 @@ func TestListStacksSortsCoreFirst(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"stacks": []any{
 			map[string]any{"name": "zebra", "manifest": map[string]any{"tier": "feature", "description": "Z"}},
 			map[string]any{"name": "core-b", "manifest": map[string]any{"tier": "core"}},
-			map[string]any{"name": "core-a", "manifest": map[string]any{"tier": "core"}, "health": map[string]any{"installed": true}},
+			map[string]any{"name": "core-a", "manifest": map[string]any{"tier": "core", "templates": []string{"nginx", "auth", "adguard"}}, "health": map[string]any{"installed": true}},
 		}})
 	}))
 	defer srv.Close()
@@ -37,6 +37,10 @@ func TestListStacksSortsCoreFirst(t *testing.T) {
 	}
 	if stacks[2].Description != "Z" {
 		t.Errorf("zebra description = %q", stacks[2].Description)
+	}
+	// core-a's spec.templates must be parsed so the install flow can expand it.
+	if got := stacks[0].Templates; len(got) != 3 || got[0] != "nginx" || got[2] != "adguard" {
+		t.Errorf("core-a templates = %v, want [nginx auth adguard]", got)
 	}
 }
 

--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -265,22 +265,41 @@ func (m InstallModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case " ":
 		m.checked[m.cursor] = !m.checked[m.cursor]
 	case "enter":
-		if names := m.selectedNames(); len(names) > 0 {
+		// Assemble against the selected stacks' TEMPLATES, not the stack
+		// names: the box assembler resolves templates (getTemplateYaml), and a
+		// stack name isn't a template — sending stack names silently assembled
+		// an empty manifest and installed nothing.
+		if templates := m.selectedTemplates(); len(templates) > 0 {
 			m.stage = stageStarting
-			return m, m.startCmd(names)
+			return m, m.startCmd(templates)
 		}
 	}
 	return m, nil
 }
 
-func (m InstallModel) selectedNames() []string {
-	var names []string
+// selectedTemplates is the de-duplicated union of every checked stack's
+// templates (`spec.templates`) — the actual deployable units. A stack with no
+// templates in the catalog falls back to its own name (best-effort) so a
+// selection never silently expands to nothing.
+func (m InstallModel) selectedTemplates() []string {
+	seen := map[string]bool{}
+	var out []string
 	for i, s := range m.stacks {
-		if m.checked[i] {
-			names = append(names, s.Name)
+		if !m.checked[i] {
+			continue
+		}
+		tmpls := s.Templates
+		if len(tmpls) == 0 {
+			tmpls = []string{s.Name}
+		}
+		for _, t := range tmpls {
+			if !seen[t] {
+				seen[t] = true
+				out = append(out, t)
+			}
 		}
 	}
-	return names
+	return out
 }
 
 // View renders the panel per stage.

--- a/tools/sb-tui/internal/ui/install_test.go
+++ b/tools/sb-tui/internal/ui/install_test.go
@@ -33,13 +33,33 @@ func TestInstallSelectThenStart(t *testing.T) {
 	if !m.checked[0] {
 		t.Fatal("space should check the cursor row")
 	}
-	if names := m.selectedNames(); len(names) != 1 || names[0] != "immich" {
-		t.Fatalf("selectedNames = %v", names)
+	// immich here has no Templates → selectedTemplates falls back to the name.
+	if names := m.selectedTemplates(); len(names) != 1 || names[0] != "immich" {
+		t.Fatalf("selectedTemplates = %v", names)
 	}
 	mi, cmd = m.Update(namedKey(tea.KeyEnter))
 	m = mi.(InstallModel)
 	if m.stage != stageStarting || cmd == nil {
 		t.Fatalf("enter should move to starting with a command, stage=%v", m.stage)
+	}
+}
+
+// A selected STACK must expand to its constituent templates (deduped across
+// stacks) — not the stack name, which the box assembler would silently drop.
+func TestInstallSelectedTemplatesExpandsStacks(t *testing.T) {
+	m := NewInstall(&rest.Client{})
+	mi, _ := m.Update(stacksLoadedMsg{stacks: []rest.Stack{
+		{Name: "basic", Tier: "core", Templates: []string{"nginx", "auth", "adguard"}},
+		{Name: "cloud", Tier: "feature", Templates: []string{"immich", "nginx"}}, // nginx shared → deduped
+	}})
+	m = mi.(InstallModel)
+	m.checked[0] = true
+	m.checked[1] = true
+
+	got := m.selectedTemplates()
+	want := []string{"nginx", "auth", "adguard", "immich"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("selectedTemplates = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## The actual bug behind "nothing to wire up"

@mdopp kept hitting installs that reported **✓ Install complete** but deployed **0 services / saved 0 credentials**, and portal routing then said "nothing to wire up". Updating the box to 4.63.1 didn't change it — because the real bug is **client-side, in sb-tui**, and upstream of the portal step entirely.

**Root cause:** the install-stacks panel lists **stacks** (`basic`/`cloud`/`home` from `/api/system/stacks`) and passed those **stack names** to `/api/install/assemble`. But the assembler resolves **templates** via `getTemplateYaml` — and a stack isn't a template (`basic` lives in `stacks/`, there's no `templates/basic`). So `getTemplateYaml('basic')` → null → `if (!templateYaml) continue;` silently drops it → **empty manifest → nothing installs.** No nginx/AdGuard ever got deployed, which is why portal routing had nothing to do.

The web wizard avoids this by expanding a stack into its constituent services client-side ("per-service selection"). sb-tui didn't.

## Fix (client-only — no box update needed)

- `ListStacks` now parses each stack's `manifest.templates`.
- The install flow assembles against the **de-duplicated union of the selected stacks' templates** (e.g. `basic` → `nginx`, `auth`, `adguard`), falling back to the stack name only if the catalog carries no templates. The box already deploys template names correctly (it's exactly what the web wizard sends), so rebuilding sb-tui is enough.

With stacks now actually deploying, the **4.63.1 portal-provisioning reorder finally has real services to wire up** — the two fixes are complementary.

## Tests
- `rest`: `ListStacks` parses `manifest.templates`.
- `ui`: a selected stack expands to its templates (deduped across stacks); a template-less entry falls back to its name.
- `gofmt` / `go vet` / `go build` / `go test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)