### PR TITLE
fix(frontend): make the Home health headline agree with the core-stack banner

### DIFF
--- a/packages/frontend/src/components/CoreHealthBanner.tsx
+++ b/packages/frontend/src/components/CoreHealthBanner.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import Link from 'next/link';
+import { useCoreHealth } from '@/hooks/useCoreHealth';
 
 /**
  * Core-stack health banner (#627 / Phase 3B, enriched in #635 /
@@ -10,35 +11,17 @@ import Link from 'next/link';
  *
  * Shows at the top of every dashboard page when any `tier: core` stack
  * reports `health.ready !== true`. Sourced from the live stack
- * manifests via `/api/system/core-health` so the membership list isn't
- * hardcoded anymore.
+ * manifests via `/api/system/core-health` (shared with the Home
+ * dashboard's health headline through {@link useCoreHealth}, so the two
+ * can't disagree).
  *
- * Polls every 15s, dismissable per browser session (sessionStorage).
+ * Dismissable per browser session (sessionStorage).
  */
 
-const POLL_INTERVAL_MS = 15_000;
 const DISMISS_KEY = 'sb:core-health-banner-dismissed';
 
-interface UnhealthyCause {
-  summary: string;
-  action?: { label: string; href: string };
-}
-
-interface DegradedNotReady {
-  template: string;
-  state: 'unhealthy' | 'unknown';
-  /** Populated when a known config-side cause matches (#665 — S5). */
-  cause?: UnhealthyCause;
-}
-
-interface DegradedEntry {
-  stack: string;
-  label: string;
-  notReady: DegradedNotReady[];
-}
-
 export default function CoreHealthBanner() {
-  const [degraded, setDegraded] = useState<DegradedEntry[]>([]);
+  const { degraded } = useCoreHealth();
   // Read once at construct time. sessionStorage is synchronous; only the
   // server side has to guard against it being undefined. Doing this in
   // useState's initialiser avoids the synchronous-setState-in-effect
@@ -46,25 +29,6 @@ export default function CoreHealthBanner() {
   const [dismissed, setDismissed] = useState<boolean>(() =>
     typeof window !== 'undefined' && sessionStorage.getItem(DISMISS_KEY) === '1',
   );
-
-  useEffect(() => {
-    if (dismissed) return;
-    let cancelled = false;
-    const tick = async () => {
-      try {
-        const res = await fetch('/api/system/core-health');
-        if (!res.ok) return;
-        const data = await res.json() as { degraded: DegradedEntry[] };
-        if (cancelled) return;
-        setDegraded(Array.isArray(data.degraded) ? data.degraded : []);
-      } catch {
-        /* keep previous state */
-      }
-    };
-    void tick();
-    const id = setInterval(tick, POLL_INTERVAL_MS);
-    return () => { cancelled = true; clearInterval(id); };
-  }, [dismissed]);
 
   if (dismissed || degraded.length === 0) return null;
 

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Box, Network, Activity, Terminal, Settings, ArrowRight, AlertCircle, CheckCircle2, Wrench } from 'lucide-react';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
 import InstallProgressCard from '@/components/InstallProgressCard';
+import { useCoreHealth } from '@/hooks/useCoreHealth';
 
 /**
  * Home / Overview dashboard (#803).
@@ -41,8 +42,16 @@ export default function OverviewDashboard() {
 
   const gatewayUp = data?.gateway?.upstreamStatus === 'up';
 
+  // Same signal the CoreHealthBanner uses. The twin only carries systemd
+  // `activeState`, so a core service that's "active" but crash-looping
+  // (e.g. authelia failing its LDAP bind) counted as healthy here — which
+  // contradicted the banner's "Core stack unhealthy". Reading core-health
+  // directly keeps the headline and the banner in agreement.
+  const { unhealthy: coreUnhealthy } = useCoreHealth();
+
   const healthHeadline = (() => {
     if (!hasFirstSnapshot) return { tone: 'neutral' as const, text: 'Reading status…' };
+    if (coreUnhealthy) return { tone: 'bad' as const, text: 'Core services need attention' };
     if (failedCount > 0) return { tone: 'bad' as const, text: `${failedCount} service${failedCount === 1 ? '' : 's'} need${failedCount === 1 ? 's' : ''} attention` };
     if (totalCount === 0) return { tone: 'neutral' as const, text: 'No services installed yet' };
     if (!gatewayUp) return { tone: 'warn' as const, text: 'Internet gateway is unreachable' };

--- a/packages/frontend/src/hooks/useCoreHealth.test.ts
+++ b/packages/frontend/src/hooks/useCoreHealth.test.ts
@@ -1,0 +1,47 @@
+/**
+ * useCoreHealth — the shared core-stack readiness signal behind both the
+ * CoreHealthBanner and the Home dashboard's health headline (so the two
+ * can't disagree, as they did in the "auth unhealthy" vs "Everything
+ * looks healthy" contradiction).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCoreHealth } from './useCoreHealth';
+
+function mockFetch(body: unknown, ok = true) {
+  return vi.fn(async () => new Response(JSON.stringify(body), {
+    status: ok ? 200 : 500,
+    headers: { 'content-type': 'application/json' },
+  }));
+}
+
+afterEach(() => { vi.restoreAllMocks(); vi.useRealTimers(); });
+beforeEach(() => { vi.restoreAllMocks(); });
+
+describe('useCoreHealth', () => {
+  it('flags unhealthy when a core stack has an unhealthy template', async () => {
+    global.fetch = mockFetch({
+      degraded: [{ stack: 'auth', label: 'Core services', notReady: [{ template: 'authelia', state: 'unhealthy' }] }],
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useCoreHealth());
+    await waitFor(() => expect(result.current.unhealthy).toBe(true));
+    expect(result.current.labels).toContain('Core services');
+  });
+
+  it('does NOT flag unhealthy for pure unknown (no healthcheck annotation)', async () => {
+    global.fetch = mockFetch({
+      degraded: [{ stack: 'media', label: 'Media', notReady: [{ template: 'jellyfin', state: 'unknown' }] }],
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useCoreHealth());
+    await waitFor(() => expect(result.current.degraded.length).toBe(1));
+    expect(result.current.unhealthy).toBe(false);
+  });
+
+  it('is healthy when nothing is degraded', async () => {
+    global.fetch = mockFetch({ degraded: [] }) as unknown as typeof fetch;
+    const { result } = renderHook(() => useCoreHealth());
+    await waitFor(() => expect(result.current.unhealthy).toBe(false));
+  });
+});

--- a/packages/frontend/src/hooks/useCoreHealth.ts
+++ b/packages/frontend/src/hooks/useCoreHealth.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Shape of GET /api/system/core-health. Shared by the CoreHealthBanner
+// and the Home dashboard's health headline so the two can't disagree —
+// the headline used to read only the twin's systemd `activeState` (a
+// crash-looping-but-"active" pod counted as healthy), which contradicted
+// the banner's readiness signal.
+
+export interface CoreUnhealthyCause {
+  summary: string;
+  action?: { label: string; href: string };
+}
+
+export interface CoreNotReady {
+  template: string;
+  state: 'unhealthy' | 'unknown';
+  /** Populated when a known config-side cause matches (#665 — S5). */
+  cause?: CoreUnhealthyCause;
+}
+
+export interface CoreDegradedEntry {
+  stack: string;
+  label: string;
+  notReady: CoreNotReady[];
+}
+
+const POLL_INTERVAL_MS = 15_000;
+
+/**
+ * Polls `/api/system/core-health` for `tier: core` stacks that aren't
+ * ready. Returns the raw `degraded` list plus a derived view that counts
+ * only stacks with a concrete `unhealthy` signal (pure `unknown` —
+ * template lacks a healthcheck annotation — doesn't warrant a red
+ * verdict, matching the banner's gate).
+ */
+export function useCoreHealth(): {
+  degraded: CoreDegradedEntry[];
+  unhealthy: boolean;
+  labels: string[];
+} {
+  const [degraded, setDegraded] = useState<CoreDegradedEntry[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch('/api/system/core-health');
+        if (!res.ok) return;
+        const data = (await res.json()) as { degraded?: CoreDegradedEntry[] };
+        if (cancelled) return;
+        setDegraded(Array.isArray(data.degraded) ? data.degraded : []);
+      } catch {
+        /* keep previous state */
+      }
+    };
+    void tick();
+    const id = setInterval(tick, POLL_INTERVAL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
+
+  const unhealthyEntries = degraded.filter(d => d.notReady.some(n => n.state === 'unhealthy'));
+  return {
+    degraded,
+    unhealthy: unhealthyEntries.length > 0,
+    labels: unhealthyEntries.map(d => d.label),
+  };
+}


### PR DESCRIPTION
## The contradiction (@mdopp's screenshot)

The Home dashboard showed a red **"Core stack unhealthy: auth (unhealthy)"** banner *and*, at the same time, a green **"Everything looks healthy"** headline + "12 of 12 running."

**Why:** the headline derived health from the digital twin's systemd `activeState` only. Authelia's pod was `active` (so it counted as healthy/running) even though the `authelia` container was crash-looping on its LDAP bind. The banner reads *real* readiness from `/api/system/core-health` — so the two signals disagreed.

## Fix
- **`useCoreHealth()`** — extracts the shared core-stack readiness signal (the `degraded` list + an `unhealthy` flag that, like the banner, counts only concrete `unhealthy` states, not pure `unknown`).
- **`CoreHealthBanner`** now consumes it (single source of truth; keeps its per-session dismiss).
- **`OverviewDashboard`** headline reports **"Core services need attention"** (tone: bad) when core is unhealthy — so it can no longer contradict the banner.

## Tests / gates
- New `useCoreHealth.test.ts` (unhealthy / unknown-not-flagged / healthy).
- `npm run lint` (0 errors), `npm test` (1497 passing), frontend `tsc --noEmit`, `knip` — all green.

Found while diagnosing the live `auth` crash-loop; the underlying LLDAP credential mismatch was fixed separately on the box, and a credential-reconciliation framework is the follow-up so it stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)