### PR TITLE
feat(diagnose): non-destructive NPM admin re-key (keep proxy routes)

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/npmDataStale.rekey.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/npmDataStale.rekey.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `rekey_admin` action — the non-destructive NPM admin re-key
+ * (credential-reconciliation increment 2). Generates a fresh password,
+ * rewrites NPM's bcrypt hash in place (proxy routes preserved), verifies
+ * it, and persists it. The mechanic was validated live before shipping;
+ * these tests pin the orchestration + failure handling.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  services: [{ name: 'nginx-web', active: true, ports: [{ host: '81', container: '81' }] }] as any[],
+  exec: vi.fn(),
+  updated: undefined as any,
+  fetchStatus: 200,
+};
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(async () => ({ sendCommand: (...a: any[]) => state.exec(...a) })) },
+}));
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(async () => state.services) },
+}));
+vi.mock('@/lib/config', () => ({
+  updateConfig: vi.fn(async (patch: any) => { state.updated = patch; }),
+}));
+vi.mock('@/lib/health/store', () => ({ HealthStore: { getLastResult: () => null, getChecks: () => [] } }));
+vi.mock('@/lib/health/runner', () => ({ NPM_AUTH_MESSAGE_PREFIX: 'npm_auth:' }));
+
+const fetchMock = vi.fn(async () => ({ ok: state.fetchStatus < 400, status: state.fetchStatus } as Response));
+vi.stubGlobal('fetch', fetchMock);
+
+import { dispatchProbeAction } from '../actions';
+import { updateConfig } from '@/lib/config';
+import './npmDataStale';
+
+// First exec call = locate container; second = the bcrypt rewrite.
+function wireExec(rewriteOut: string, rewriteCode = 0) {
+  state.exec.mockReset();
+  state.exec
+    .mockResolvedValueOnce({ code: 0, stdout: 'nginx-nginx-proxy-manager docker.io/jc21/nginx-proxy-manager:latest\n', stderr: '' })
+    .mockResolvedValueOnce({ code: rewriteCode, stdout: rewriteOut, stderr: '' });
+}
+
+beforeEach(() => {
+  state.services = [{ name: 'nginx-web', active: true, ports: [{ host: '81', container: '81' }] }];
+  state.updated = undefined;
+  state.fetchStatus = 200;
+  fetchMock.mockClear();
+  (updateConfig as any).mockClear?.();
+});
+
+const run = () => dispatchProbeAction({ probeId: 'npm_data_stale', actionId: 'rekey_admin', node: 'Local' });
+
+describe('rekey_admin (NPM admin auto re-key)', () => {
+  it('rewrites the hash, verifies, and persists the fresh password (no wipe)', async () => {
+    wireExec('email=mdopp79@gmail.com;updated=1');
+    const res = await run();
+    expect(res.ok).toBe(true);
+    // Persisted under reverseProxy.npm with the DB's authoritative email + a fresh 32-char secret.
+    expect(state.updated?.reverseProxy?.npm?.email).toBe('mdopp79@gmail.com');
+    expect((state.updated?.reverseProxy?.npm?.password || '').length).toBe(32);
+    // Verified against NPM before persisting.
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT persist if NPM rejects the freshly-set password (401)', async () => {
+    wireExec('email=a@b.c;updated=1');
+    state.fetchStatus = 401;
+    const res = await run();
+    expect(res.ok).toBe(false);
+    expect(state.updated).toBeUndefined();
+  });
+
+  it('fails cleanly when there is no admin row to re-key', async () => {
+    wireExec('noadmin');
+    const res = await run();
+    expect(res.ok).toBe(false);
+    expect(state.updated).toBeUndefined();
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/npmDataStale.ts
+++ b/packages/backend/src/lib/diagnose/probes/npmDataStale.ts
@@ -31,6 +31,7 @@ import { registerProbeAction, type ProbeActionResult } from '../actions';
 import { HealthStore } from '@/lib/health/store';
 import { NPM_AUTH_MESSAGE_PREFIX } from '@/lib/health/runner';
 import { registerRefreshNow } from './refreshHealthCheck';
+import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
 
 export interface NpmDataStaleResult {
   /** undefined when not applicable (no nginx-web, or NPM not reachable). */
@@ -281,6 +282,86 @@ registerProbeAction(
     ],
   },
   useExistingNpmCreds,
+);
+
+// ─── Non-destructive auto re-key (credential-reconciliation, inc. 2) ─────
+//
+// The third recovery path, and the one for the most common reinstall
+// case: NPM's DB persisted from a prior install with an admin password
+// ServiceBay no longer knows (its stored one went empty/diverged). Unlike
+// `use_existing` (needs the operator to KNOW the password) and
+// `reset_volume` (wipes all proxy hosts), this re-keys NPM's admin to a
+// fresh generated password IN PLACE — keeping every proxy route — by
+// rewriting the bcrypt hash directly in NPM's SQLite, then persisting the
+// new password. An admin login secret isn't an encryption key, so this is
+// safe to do silently (the "auto-rekey when safe" path).
+//
+// Run inside the NPM container so we use NPM's own bundled bcrypt (cost
+// 13, matching the `$2b$13$` hashes it writes) + better-sqlite3, and
+// operate on the container-relative /data/database.sqlite — robust to the
+// host data-dir name. Validated live before shipping.
+const NPM_REKEY_JS = [
+  "const bcrypt=require('/app/node_modules/bcrypt');",
+  "const Database=require('/app/node_modules/better-sqlite3');",
+  "const db=Database('/data/database.sqlite');",
+  "const u=db.prepare(\"SELECT id,email FROM user WHERE is_deleted=0 ORDER BY id LIMIT 1\").get();",
+  "if(!u){process.stdout.write('noadmin');process.exit(0);}",
+  "const hash=bcrypt.hashSync(process.env.NEWPW,13);",
+  "const r=db.prepare(\"UPDATE auth SET secret=?, modified_on=datetime('now') WHERE user_id=? AND type='password'\").run(hash,u.id);",
+  "process.stdout.write('email='+u.email+';updated='+r.changes);",
+].join('\n');
+
+async function rekeyNpmAdmin({ node }: { node: string }): Promise<ProbeActionResult> {
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return { ok: false, message: 'Nginx Proxy Manager is not deployed/active on this node — nothing to re-key.', refresh: false };
+  }
+  const agent = await agentManager.ensureAgent(node);
+  // Locate the running NPM container (jc21 image) to exec into.
+  const find = await agent.sendCommand('exec', {
+    command: `podman ps --format '{{.Names}} {{.Image}}' | awk '/proxy-manager/{print $1; exit}'`,
+  }, { timeoutMs: 15_000 });
+  const container = ((find as { stdout?: string }).stdout || '').trim().split(/\s+/)[0];
+  if (!container) {
+    return { ok: false, message: 'Could not find the running NPM container to re-key.', refresh: false };
+  }
+  const newPassword = generateRandomSecret(32);
+  const b64 = Buffer.from(NPM_REKEY_JS).toString('base64');
+  // base64 the script in to avoid quoting hell; password via env, never on argv.
+  const rewrite = await agent.sendCommand('exec', {
+    command: `echo ${b64} | base64 -d | podman exec -i -e NEWPW=${newPassword} ${container} node -`,
+  }, { timeoutMs: 30_000 });
+  const out = ((rewrite as { stdout?: string }).stdout || '').trim();
+  const m = out.match(/email=(.*);updated=(\d+)/);
+  if ((rewrite as { code?: number }).code !== 0 || !m || m[2] === '0') {
+    return {
+      ok: false,
+      message: `Could not re-key the NPM admin password: ${(rewrite as { stderr?: string }).stderr || out || 'unknown error'}`,
+      refresh: false,
+    };
+  }
+  const email = m[1];
+  // Prove the new password works before persisting — never store creds we can't verify.
+  const failure = await verifyNpmCreds(adminUrl, email, newPassword);
+  if (failure) return failure;
+  await updateConfig({ reverseProxy: { npm: { email, password: newPassword } } });
+  logger.info('diagnose:npm_data_stale', `Re-keyed NPM admin password for ${email} (non-destructive; proxy hosts preserved)`);
+  return {
+    ok: true,
+    message: 'NPM admin password re-keyed and saved — all proxy routes were preserved. ServiceBay can manage NPM again.',
+    refresh: true,
+  };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'rekey_admin',
+    label: 'Re-key NPM admin (keep data)',
+    description:
+      "Generates a fresh NPM admin password, writes it straight into NPM's database, and saves it — WITHOUT wiping any proxy routes. The no-data-loss fix for when the stored password no longer works and you don't know the current one.",
+  },
+  rekeyNpmAdmin,
 );
 
 registerRefreshNow(PROBE_ID, CHECK_ID, 'NPM auth');

--- a/packages/backend/src/lib/health/probes/npmAuthProbe.ts
+++ b/packages/backend/src/lib/health/probes/npmAuthProbe.ts
@@ -48,7 +48,7 @@ registerProbe({
           return encode({
             status: 'fail',
             detail: 'Nginx Proxy Manager is rejecting the stored admin credentials. This usually means a previous install left an admin password in the NPM database that no longer matches.',
-            hint: 'If you know the password NPM is actually using, click "Use existing password" below to save it (no data loss). Otherwise "Reset NPM data" wipes the database and re-seeds with the wizard credentials.',
+            hint: 'Click "Re-key NPM admin (keep data)" to set a fresh password in place — no proxy routes are lost and you don\'t need the current one. (If you DO know the password NPM is using, "Use existing password" saves it; "Reset NPM data" is the last resort — it wipes the database.)',
           });
         }
         return encode({ status: 'info', detail: `NPM auth probe returned HTTP ${res.status} — assuming transient.` });


### PR DESCRIPTION
## Increment 2 of the credential-reconciliation framework — NPM

When NPM's DB persisted from a prior install with an admin password ServiceBay no longer knows (its stored one **went empty / diverged** across reinstalls — exactly @mdopp's box: `pwlen=0`), the two existing recoveries were both unsatisfying:
- **`use_existing`** — needs the operator to *know* the current password (they don't; it was generated by an old install and lost).
- **`reset_volume`** — wipes the database → loses every proxy route.

Neither is no-loss for the common case. This adds the missing **"auto-rekey when safe"** path (an admin login secret isn't an encryption key, so re-keying it loses nothing):

### `rekey_admin` — "Re-key NPM admin (keep data)"
- Generates a fresh password, rewrites NPM's admin **bcrypt hash directly in its SQLite, in place** (all proxy hosts preserved), then **verifies** against `/api/tokens` before persisting.
- Runs **inside the NPM container** so it uses NPM's own bundled `bcrypt` (cost 13, matching the `$2b$13$` hashes it writes) + `better-sqlite3`, operating on the container-relative `/data/database.sqlite` — robust to the host data-dir name. Targets the first non-deleted admin user and stores *that user's* authoritative email. Never persists creds it can't verify.
- `npmAuthProbe` now recommends this no-loss action first; **"Reset NPM data" demoted to last resort.**

## Validated live
Re-keyed @mdopp's stale NPM on the box: `npm_auth` → **ok** ("NPM accepts the stored admin credentials"), all proxy routes intact. The exact mechanic shipped here.

## Tests / gates
- `npmDataStale.rekey.test.ts`: rewrite→verify→persist happy path (fresh 32-char secret, authoritative email); does NOT persist on a 401; clean fail when there's no admin row.
- `npm run lint` (0 errors), `check:arch`, `npm test` (1503 passing), backend `tsc` — all green.

## Follow-ups
- **inc 2b:** auto-invoke this re-key during install when NPM deploys over a persisted DB with failing creds (fully automatic, like the LLDAP fix).
- **inc 3:** the encryption-keyed "enter old secret / wipe + accept loss" prompt path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)