### PR TITLE
feat(install): auto re-key NPM admin during install when creds are stale

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/npmDataStale.ts
+++ b/packages/backend/src/lib/diagnose/probes/npmDataStale.ts
@@ -25,13 +25,12 @@
 
 import { agentManager } from '@/lib/agent/manager';
 import { updateConfig } from '@/lib/config';
-import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
 import { HealthStore } from '@/lib/health/store';
 import { NPM_AUTH_MESSAGE_PREFIX } from '@/lib/health/runner';
 import { registerRefreshNow } from './refreshHealthCheck';
-import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+import { findNpmAdminUrl, npmTokenStatus, rekeyNpmAdmin } from '@/lib/reverseProxy/npmAdminRekey';
 
 export interface NpmDataStaleResult {
   /** undefined when not applicable (no nginx-web, or NPM not reachable). */
@@ -98,28 +97,8 @@ export async function checkNpmDataStale(): Promise<NpmDataStaleResult> {
 
 // ─── Action handlers (kept in the probe file) ───────────────────────────
 //
-// Local copy of `findNpmAdminUrl` so the click-time action paths don't
-// depend on health/runner internals.  Mirrors the helper in
-// `src/lib/health/probes/npmAdmin.ts` — kept duplicated because the
-// action handlers run with a different lifecycle (one-shot, operator
-// click) and we don't want to entangle them with the runner's import
-// graph.
-async function findNpmAdminUrl(node: string): Promise<string | null> {
-  try {
-    const services = await ServiceManager.listServices(node);
-    const nginx = services.find(
-      s => s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
-    );
-    if (!nginx?.active) return null;
-    const ports = (nginx.ports ?? [])
-      .map(p => parseInt(String(p.host ?? ''), 10))
-      .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
-    const adminPort = ports[0] ?? 81;
-    return `http://localhost:${adminPort}`;
-  } catch {
-    return null;
-  }
-}
+// `findNpmAdminUrl` / `npmTokenStatus` / `rekeyNpmAdmin` are shared with
+// the install-runner self-heal via `@/lib/reverseProxy/npmAdminRekey`.
 
 /** Action: stop nginx-web, wipe its data volume, restart it. NPM's
  *  next start re-seeds the admin user from the
@@ -204,8 +183,13 @@ async function useExistingNpmCreds({
       refresh: false,
     };
   }
-  const failure = await verifyNpmCreds(adminUrl, email, password);
-  if (failure) return failure;
+  const status = await npmTokenStatus(adminUrl, email, password);
+  if (status === 'unauthorized') {
+    return { ok: false, message: 'NPM still rejected those credentials — double-check the password and try again. (Nothing was saved.)', refresh: false };
+  }
+  if (status !== 'ok') {
+    return { ok: false, message: `Could not verify the credentials against NPM at ${adminUrl} (it was unreachable). Nothing was saved.`, refresh: false };
+  }
   await updateConfig({
     reverseProxy: {
       npm: { email, password },
@@ -217,44 +201,6 @@ async function useExistingNpmCreds({
     message: 'Credentials verified and saved. Future installs and proxy syncs will use these.',
     refresh: true,
   };
-}
-
-/**
- * POST the given admin creds to NPM's /api/tokens to confirm they work, without
- * persisting. Returns a failure ProbeActionResult, or null when NPM accepts
- * them. Extracted from useExistingNpmCreds to keep it under the line limit.
- */
-async function verifyNpmCreds(
-  adminUrl: string,
-  email: string,
-  password: string,
-): Promise<ProbeActionResult | null> {
-  let res: Response;
-  try {
-    res = await fetch(`${adminUrl}/api/tokens`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ identity: email, secret: password }),
-      signal: AbortSignal.timeout(4000),
-    });
-  } catch (e) {
-    return {
-      ok: false,
-      message: `Could not reach NPM at ${adminUrl}: ${e instanceof Error ? e.message : String(e)}`,
-      refresh: false,
-    };
-  }
-  if (res.status === 401) {
-    return {
-      ok: false,
-      message: 'NPM still rejected those credentials — double-check the password and try again. (Nothing was saved.)',
-      refresh: false,
-    };
-  }
-  if (!res.ok) {
-    return { ok: false, message: `NPM returned HTTP ${res.status} during verification.`, refresh: false };
-  }
-  return null;
 }
 
 registerProbeAction(
@@ -284,73 +230,14 @@ registerProbeAction(
   useExistingNpmCreds,
 );
 
-// ─── Non-destructive auto re-key (credential-reconciliation, inc. 2) ─────
-//
-// The third recovery path, and the one for the most common reinstall
-// case: NPM's DB persisted from a prior install with an admin password
-// ServiceBay no longer knows (its stored one went empty/diverged). Unlike
-// `use_existing` (needs the operator to KNOW the password) and
-// `reset_volume` (wipes all proxy hosts), this re-keys NPM's admin to a
-// fresh generated password IN PLACE — keeping every proxy route — by
-// rewriting the bcrypt hash directly in NPM's SQLite, then persisting the
-// new password. An admin login secret isn't an encryption key, so this is
-// safe to do silently (the "auto-rekey when safe" path).
-//
-// Run inside the NPM container so we use NPM's own bundled bcrypt (cost
-// 13, matching the `$2b$13$` hashes it writes) + better-sqlite3, and
-// operate on the container-relative /data/database.sqlite — robust to the
-// host data-dir name. Validated live before shipping.
-const NPM_REKEY_JS = [
-  "const bcrypt=require('/app/node_modules/bcrypt');",
-  "const Database=require('/app/node_modules/better-sqlite3');",
-  "const db=Database('/data/database.sqlite');",
-  "const u=db.prepare(\"SELECT id,email FROM user WHERE is_deleted=0 ORDER BY id LIMIT 1\").get();",
-  "if(!u){process.stdout.write('noadmin');process.exit(0);}",
-  "const hash=bcrypt.hashSync(process.env.NEWPW,13);",
-  "const r=db.prepare(\"UPDATE auth SET secret=?, modified_on=datetime('now') WHERE user_id=? AND type='password'\").run(hash,u.id);",
-  "process.stdout.write('email='+u.email+';updated='+r.changes);",
-].join('\n');
-
-async function rekeyNpmAdmin({ node }: { node: string }): Promise<ProbeActionResult> {
-  const adminUrl = await findNpmAdminUrl(node);
-  if (!adminUrl) {
-    return { ok: false, message: 'Nginx Proxy Manager is not deployed/active on this node — nothing to re-key.', refresh: false };
-  }
-  const agent = await agentManager.ensureAgent(node);
-  // Locate the running NPM container (jc21 image) to exec into.
-  const find = await agent.sendCommand('exec', {
-    command: `podman ps --format '{{.Names}} {{.Image}}' | awk '/proxy-manager/{print $1; exit}'`,
-  }, { timeoutMs: 15_000 });
-  const container = ((find as { stdout?: string }).stdout || '').trim().split(/\s+/)[0];
-  if (!container) {
-    return { ok: false, message: 'Could not find the running NPM container to re-key.', refresh: false };
-  }
-  const newPassword = generateRandomSecret(32);
-  const b64 = Buffer.from(NPM_REKEY_JS).toString('base64');
-  // base64 the script in to avoid quoting hell; password via env, never on argv.
-  const rewrite = await agent.sendCommand('exec', {
-    command: `echo ${b64} | base64 -d | podman exec -i -e NEWPW=${newPassword} ${container} node -`,
-  }, { timeoutMs: 30_000 });
-  const out = ((rewrite as { stdout?: string }).stdout || '').trim();
-  const m = out.match(/email=(.*);updated=(\d+)/);
-  if ((rewrite as { code?: number }).code !== 0 || !m || m[2] === '0') {
-    return {
-      ok: false,
-      message: `Could not re-key the NPM admin password: ${(rewrite as { stderr?: string }).stderr || out || 'unknown error'}`,
-      refresh: false,
-    };
-  }
-  const email = m[1];
-  // Prove the new password works before persisting — never store creds we can't verify.
-  const failure = await verifyNpmCreds(adminUrl, email, newPassword);
-  if (failure) return failure;
-  await updateConfig({ reverseProxy: { npm: { email, password: newPassword } } });
-  logger.info('diagnose:npm_data_stale', `Re-keyed NPM admin password for ${email} (non-destructive; proxy hosts preserved)`);
-  return {
-    ok: true,
-    message: 'NPM admin password re-keyed and saved — all proxy routes were preserved. ServiceBay can manage NPM again.',
-    refresh: true,
-  };
+// Non-destructive auto re-key (credential-reconciliation): the no-loss
+// fix for the common reinstall case where NPM's DB persisted but
+// ServiceBay's stored password went empty/diverged. The mechanic lives in
+// `@/lib/reverseProxy/npmAdminRekey` (shared with the install-runner
+// self-heal); this just adapts it to a ProbeActionResult.
+async function rekeyNpmAdminAction({ node }: { node: string }): Promise<ProbeActionResult> {
+  const r = await rekeyNpmAdmin(node);
+  return { ok: r.ok, message: r.message, refresh: r.ok };
 }
 
 registerProbeAction(
@@ -361,7 +248,7 @@ registerProbeAction(
     description:
       "Generates a fresh NPM admin password, writes it straight into NPM's database, and saves it — WITHOUT wiping any proxy routes. The no-data-loss fix for when the stored password no longer works and you don't know the current one.",
   },
-  rekeyNpmAdmin,
+  rekeyNpmAdminAction,
 );
 
 registerRefreshNow(PROBE_ID, CHECK_ID, 'NPM auth');

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -44,6 +44,7 @@ import {
 } from '@/lib/stackInstall/postInstall';
 import { buildCredentialsManifest, mergeCredentials, type Credential } from '@/lib/stackInstall/credentialsManifest';
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
+import { npmAdminCredStatus, rekeyNpmAdmin } from '@/lib/reverseProxy/npmAdminRekey';
 import { getCapabilityBus } from '@/lib/capabilities/bus';
 import { getStoreSnapshot } from '@/lib/store/repository';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
@@ -1349,6 +1350,27 @@ async function runJob(jobId: string): Promise<void> {
   // containers, which on a fresh install reported a misleading failure
   // (the proxy/DNS *were* being installed, just not up yet).
   await settleWait(jobId, ctx.deployed, input.node || 'Local');
+
+  // NPM admin self-heal (credential-reconciliation, ARCH-15). If nginx is
+  // in this install and its persisted DB holds an admin password
+  // ServiceBay can't authenticate with (empty/diverged across a
+  // reinstall), re-key it in place — non-destructive, every proxy route
+  // preserved — so the portal provisioning below can actually manage NPM.
+  // Best-effort; never fatal (the npm_data_stale diagnose action is the
+  // manual fallback).
+  if (selected.some(s => s.name === 'nginx' && !s.alreadyInstalled)) {
+    try {
+      const node = input.node || 'Local';
+      const status = await npmAdminCredStatus(node);
+      if (status === 'rejected' || status === 'no-creds') {
+        await log(jobId, '🔑 NPM is rejecting/missing the stored admin credentials — re-keying in place (proxy routes preserved)…');
+        const r = await rekeyNpmAdmin(node);
+        await log(jobId, (r.ok ? '✅ ' : '⚠️ ') + r.message);
+      }
+    } catch (e) {
+      await log(jobId, `(note) NPM admin reconcile skipped: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
 
   // Portal routing — apex + wildcard rewrites for the active domain.
   // Always runs after a successful install (#707). Pre-fix this was

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
@@ -1,0 +1,67 @@
+/**
+ * npmAdminCredStatus — the detection the install-runner self-heal gates
+ * on (re-key only when NPM rejects/lacks the stored admin creds, never
+ * when they work or NPM is unreachable). The rekey mechanic itself was
+ * validated live + is covered through the diagnose action test.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  services: [] as any[],
+  config: {} as any,
+  fetchStatus: 200,
+  fetchThrows: false,
+};
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(async () => state.services) },
+}));
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => state.config),
+  updateConfig: vi.fn(async () => {}),
+}));
+vi.mock('@/lib/agent/manager', () => ({ agentManager: { ensureAgent: vi.fn() } }));
+
+vi.stubGlobal('fetch', vi.fn(async () => {
+  if (state.fetchThrows) throw new Error('refused');
+  return { ok: state.fetchStatus < 400, status: state.fetchStatus } as Response;
+}));
+
+import { npmAdminCredStatus } from './npmAdminRekey';
+
+const ACTIVE_NGINX = [{ name: 'nginx-web', active: true, ports: [{ host: '81', container: '81' }] }];
+
+beforeEach(() => {
+  state.services = ACTIVE_NGINX;
+  state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
+  state.fetchStatus = 200;
+  state.fetchThrows = false;
+});
+
+describe('npmAdminCredStatus', () => {
+  it("returns 'unknown' when nginx isn't deployed/active (skip — can't tell)", async () => {
+    state.services = [{ name: 'nginx-web', active: false }];
+    expect(await npmAdminCredStatus('Local')).toBe('unknown');
+  });
+
+  it("returns 'no-creds' when NPM is up but no admin password is stored", async () => {
+    state.config = { reverseProxy: { npm: { email: 'a@b.c', password: '' } } };
+    expect(await npmAdminCredStatus('Local')).toBe('no-creds');
+  });
+
+  it("returns 'ok' when NPM accepts the stored creds", async () => {
+    state.fetchStatus = 200;
+    expect(await npmAdminCredStatus('Local')).toBe('ok');
+  });
+
+  it("returns 'rejected' when NPM 401s the stored creds (→ re-key)", async () => {
+    state.fetchStatus = 401;
+    expect(await npmAdminCredStatus('Local')).toBe('rejected');
+  });
+
+  it("returns 'unknown' when NPM is unreachable (skip, don't re-key blindly)", async () => {
+    state.fetchThrows = true;
+    expect(await npmAdminCredStatus('Local')).toBe('unknown');
+  });
+});

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
@@ -1,0 +1,147 @@
+/**
+ * Non-destructive NPM admin re-key (credential-reconciliation).
+ *
+ * The reinstall-over-persisted-data trap for Nginx Proxy Manager: NPM's
+ * SQLite survives a reinstall with an admin password ServiceBay no longer
+ * knows (its stored one went empty / diverged), so ServiceBay can't
+ * authenticate to NPM's admin API and can't manage proxy routes.
+ *
+ * An admin login secret isn't an encryption key, so we re-key it in place
+ * to a fresh generated password — keeping every proxy host — instead of
+ * wiping (`reset_volume`) or needing the operator to know it
+ * (`use_existing`). This is the "auto-rekey when safe" path; it backs both
+ * the `npm_data_stale` diagnose action and the install-runner self-heal.
+ *
+ * The hash rewrite runs INSIDE the NPM container so it uses NPM's own
+ * bundled bcrypt (cost 13, matching the `$2b$13$` hashes it writes) +
+ * better-sqlite3, against the container-relative /data/database.sqlite —
+ * robust to whatever the host data-dir is named.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig, updateConfig } from '@/lib/config';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { logger } from '@/lib/logger';
+import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+
+const LOG = 'reverseProxy:npmRekey';
+
+/** Resolve NPM's admin API base URL from the running nginx service, or
+ *  null when NPM isn't deployed/active. */
+export async function findNpmAdminUrl(node: string): Promise<string | null> {
+  try {
+    const services = await ServiceManager.listServices(node);
+    const nginx = services.find(
+      s => s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
+    );
+    if (!nginx?.active) return null;
+    const ports = (nginx.ports ?? [])
+      .map(p => parseInt(String(p.host ?? ''), 10))
+      .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
+    const adminPort = ports[0] ?? 81;
+    return `http://localhost:${adminPort}`;
+  } catch {
+    return null;
+  }
+}
+
+/** POST creds to NPM's /api/tokens. 'ok' = accepted, 'unauthorized' = 401,
+ *  'error' = unreachable/other. */
+export async function npmTokenStatus(
+  adminUrl: string,
+  email: string,
+  password: string,
+): Promise<'ok' | 'unauthorized' | 'error'> {
+  try {
+    const res = await fetch(`${adminUrl}/api/tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identity: email, secret: password }),
+      signal: AbortSignal.timeout(4000),
+    });
+    if (res.ok) return 'ok';
+    if (res.status === 401) return 'unauthorized';
+    return 'error';
+  } catch {
+    return 'error';
+  }
+}
+
+/**
+ * Whether ServiceBay's stored NPM admin creds currently work.
+ *  - 'ok'       — they authenticate; nothing to do.
+ *  - 'rejected' — NPM 401s them (stale/diverged) → re-key.
+ *  - 'no-creds' — none stored (lost on reinstall) but NPM is up → re-key.
+ *  - 'unknown'  — NPM not deployed/reachable → can't tell, skip.
+ */
+export async function npmAdminCredStatus(node: string): Promise<'ok' | 'rejected' | 'no-creds' | 'unknown'> {
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) return 'unknown';
+  const cfg = await getConfig();
+  const npm = cfg.reverseProxy?.npm;
+  if (!npm?.email || !npm?.password) return 'no-creds';
+  const status = await npmTokenStatus(adminUrl, npm.email, npm.password);
+  if (status === 'ok') return 'ok';
+  if (status === 'unauthorized') return 'rejected';
+  return 'unknown';
+}
+
+// Runs inside the NPM container. Reads NEWPW from env; re-keys the first
+// non-deleted admin user's password hash. Prints `email=<x>;updated=<n>`.
+const NPM_REKEY_JS = [
+  "const bcrypt=require('/app/node_modules/bcrypt');",
+  "const Database=require('/app/node_modules/better-sqlite3');",
+  "const db=Database('/data/database.sqlite');",
+  "const u=db.prepare(\"SELECT id,email FROM user WHERE is_deleted=0 ORDER BY id LIMIT 1\").get();",
+  "if(!u){process.stdout.write('noadmin');process.exit(0);}",
+  "const hash=bcrypt.hashSync(process.env.NEWPW,13);",
+  "const r=db.prepare(\"UPDATE auth SET secret=?, modified_on=datetime('now') WHERE user_id=? AND type='password'\").run(hash,u.id);",
+  "process.stdout.write('email='+u.email+';updated='+r.changes);",
+].join('\n');
+
+export interface RekeyResult {
+  ok: boolean;
+  message: string;
+  email?: string;
+}
+
+/**
+ * Re-key NPM's admin to a fresh generated password in place (proxy hosts
+ * preserved), verify it, and persist it to `reverseProxy.npm`. Never
+ * persists creds it can't prove against /api/tokens.
+ */
+export async function rekeyNpmAdmin(node: string): Promise<RekeyResult> {
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return { ok: false, message: 'Nginx Proxy Manager is not deployed/active on this node — nothing to re-key.' };
+  }
+  const agent = await agentManager.ensureAgent(node);
+  const find = await agent.sendCommand('exec', {
+    command: `podman ps --format '{{.Names}} {{.Image}}' | awk '/proxy-manager/{print $1; exit}'`,
+  }, { timeoutMs: 15_000 });
+  const container = ((find as { stdout?: string }).stdout || '').trim().split(/\s+/)[0];
+  if (!container) {
+    return { ok: false, message: 'Could not find the running NPM container to re-key.' };
+  }
+  const newPassword = generateRandomSecret(32);
+  const b64 = Buffer.from(NPM_REKEY_JS).toString('base64');
+  const rewrite = await agent.sendCommand('exec', {
+    command: `echo ${b64} | base64 -d | podman exec -i -e NEWPW=${newPassword} ${container} node -`,
+  }, { timeoutMs: 30_000 });
+  const out = ((rewrite as { stdout?: string }).stdout || '').trim();
+  const m = out.match(/email=(.*);updated=(\d+)/);
+  if ((rewrite as { code?: number }).code !== 0 || !m || m[2] === '0') {
+    return {
+      ok: false,
+      message: `Could not re-key the NPM admin password: ${(rewrite as { stderr?: string }).stderr || out || 'unknown error'}`,
+    };
+  }
+  const email = m[1];
+  const status = await npmTokenStatus(adminUrl, email, newPassword);
+  if (status !== 'ok') {
+    return { ok: false, message: `Re-keyed the hash but NPM still rejected the new password (status: ${status}). Nothing was saved.` };
+  }
+  await updateConfig({ reverseProxy: { npm: { email, password: newPassword } } });
+  logger.info(LOG, `Re-keyed NPM admin password for ${email} (non-destructive; proxy hosts preserved)`);
+  return { ok: true, message: 'NPM admin password re-keyed and saved — all proxy routes were preserved. ServiceBay can manage NPM again.', email };
+}


### PR DESCRIPTION
## Increment 2b — make NPM self-heal automatically (parity with LLDAP)

Inc 2 added the `rekey_admin` diagnose action (one click). This makes it **automatic during install**, so the operator never has to notice the `proxy:failed`.

- **Extract** the NPM admin re-key into `@/lib/reverseProxy/npmAdminRekey` (shared):
  - `rekeyNpmAdmin()` — rewrite the admin bcrypt hash in NPM's SQLite **in place** → verify via `/api/tokens` → persist. Proxy hosts preserved.
  - `npmAdminCredStatus()` — `ok` / `rejected` / `no-creds` / `unknown`, the gate the runner uses.
  - `npmTokenStatus` / `findNpmAdminUrl` helpers.
  - `npmDataStale`'s `rekey_admin` + `use_existing` actions now **delegate** here (no behaviour change).
- **`runner.ts`**: after `settleWait`, when nginx is in the install and NPM **rejects/lacks** the stored admin creds, re-key in place **before** portal provisioning — so it can actually manage NPM. **Best-effort, never fatal**; the diagnose action stays as the manual fallback.

## Inc 3 deliberately skipped (not built)
The generic "enter old secret / wipe + accept loss" prompt has **no consumer**: authelia's `STORAGE_ENCRYPTION_KEY` — the only encrypt-at-rest secret in core — is already auto-healed by the runner's fingerprint-wipe (which preserves LLDAP identities), and authelia can't re-encrypt with an old key anyway. Building it now would be speculative dead code (skip-dead-flags). The framework's encryption-key branch is left as a documented hook for when a real consumer appears.

## Tests / gates
- `npmAdminRekey.test.ts`: `npmAdminCredStatus` across ok/rejected/no-creds/unknown(unreachable). The rekey mechanic is covered through the diagnose-action test + was validated live (`npm_auth → ok`, routes intact).
- `npm run lint` (0 errors), `check:arch`, `npm test` (1508 passing), backend `tsc` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)