### PR TITLE
fix: two bugs surfaced by on-box 4.66.0 verification

### DIFF
--- a/packages/backend/src/lib/health/probes/npmAuthProbe.ts
+++ b/packages/backend/src/lib/health/probes/npmAuthProbe.ts
@@ -8,6 +8,7 @@
 import { registerProbe } from './registry';
 import { getConfig } from '../../config';
 import { findNpmAdminUrl } from './npmAdmin';
+import { isInvalidAuth } from '@/lib/reverseProxy/npmAdminRekey';
 
 export const NPM_AUTH_MESSAGE_PREFIX = 'npm_auth:';
 
@@ -44,7 +45,10 @@ registerProbe({
           signal: AbortSignal.timeout(4000),
         });
         if (res.ok) return encode({ status: 'ok', detail: 'NPM accepts the stored admin credentials.' });
-        if (res.status === 401) {
+        // NPM (jc21) returns HTTP 400 `error.invalid-auth` — NOT 401 — for a
+        // wrong password. Treat either as the stale-credentials failure;
+        // otherwise a real stale-creds box never flags (found via on-box verify).
+        if (res.status === 401 || (res.status === 400 && (await isInvalidAuth(res)))) {
           return encode({
             status: 'fail',
             detail: 'Nginx Proxy Manager is rejecting the stored admin credentials. This usually means a previous install left an admin password in the NPM database that no longer matches.',

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
@@ -12,6 +12,7 @@ const state = {
   config: {} as any,
   fetchStatus: 200,
   fetchThrows: false,
+  fetchBody: {} as any,
 };
 
 vi.mock('@/lib/services/ServiceManager', () => ({
@@ -25,7 +26,7 @@ vi.mock('@/lib/agent/manager', () => ({ agentManager: { ensureAgent: vi.fn() } }
 
 vi.stubGlobal('fetch', vi.fn(async () => {
   if (state.fetchThrows) throw new Error('refused');
-  return { ok: state.fetchStatus < 400, status: state.fetchStatus } as Response;
+  return { ok: state.fetchStatus < 400, status: state.fetchStatus, json: async () => state.fetchBody } as unknown as Response;
 }));
 
 import { npmAdminCredStatus } from './npmAdminRekey';
@@ -37,6 +38,7 @@ beforeEach(() => {
   state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
   state.fetchStatus = 200;
   state.fetchThrows = false;
+  state.fetchBody = {};
 });
 
 describe('npmAdminCredStatus', () => {
@@ -58,6 +60,18 @@ describe('npmAdminCredStatus', () => {
   it("returns 'rejected' when NPM 401s the stored creds (→ re-key)", async () => {
     state.fetchStatus = 401;
     expect(await npmAdminCredStatus('Local')).toBe('rejected');
+  });
+
+  it("returns 'rejected' on NPM's HTTP 400 'error.invalid-auth' (jc21 uses 400, not 401)", async () => {
+    state.fetchStatus = 400;
+    state.fetchBody = { error: { code: 400, message: 'Invalid email or password', message_i18n: 'error.invalid-auth' } };
+    expect(await npmAdminCredStatus('Local')).toBe('rejected');
+  });
+
+  it("returns 'unknown' on a malformed-request 400 (not an auth rejection)", async () => {
+    state.fetchStatus = 400;
+    state.fetchBody = { error: { code: 400, message: 'secret must NOT have fewer than 1 characters' } };
+    expect(await npmAdminCredStatus('Local')).toBe('unknown');
   });
 
   it("returns 'unknown' when NPM is unreachable (skip, don't re-key blindly)", async () => {

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
@@ -61,10 +61,23 @@ export async function npmTokenStatus(
     });
     if (res.ok) return 'ok';
     if (res.status === 401) return 'unauthorized';
+    // NPM (jc21) returns HTTP 400 — NOT 401 — for a wrong password, with
+    // `error.message_i18n: 'error.invalid-auth'`. Treat that as a credential
+    // rejection (→ re-key), distinct from a genuinely malformed request
+    // (e.g. empty secret), which stays 'error'. Found via on-box verify.
+    if (res.status === 400 && (await isInvalidAuth(res))) return 'unauthorized';
     return 'error';
   } catch {
     return 'error';
   }
+}
+
+/** True iff an NPM /api/tokens 400 body is the "invalid email or password"
+ *  rejection (rather than a malformed-request 400). */
+export async function isInvalidAuth(res: Response): Promise<boolean> {
+  const body = (await res.json().catch(() => null)) as { error?: { message_i18n?: string; message?: string } } | null;
+  const err = body?.error;
+  return err?.message_i18n === 'error.invalid-auth' || /invalid email or password/i.test(err?.message ?? '');
 }
 
 /**

--- a/tools/sb-tui/internal/rest/install.go
+++ b/tools/sb-tui/internal/rest/install.go
@@ -48,7 +48,11 @@ func (c *Client) ListStacks(ctx context.Context) ([]Stack, error) {
 				Lifecycle   string   `json:"lifecycle"`
 			} `json:"manifest"`
 			Health *struct {
-				Installed bool `json:"installed"`
+				// `hasAnySignal` (NOT a nonexistent `installed` field) is the
+				// box's installed signal — true once any of the stack's
+				// templates has a health signal in the twin. The web UI's
+				// "Not installed" badge is exactly `!hasAnySignal`.
+				HasAnySignal bool `json:"hasAnySignal"`
 			} `json:"health"`
 		} `json:"stacks"`
 	}
@@ -70,7 +74,7 @@ func (c *Client) ListStacks(ctx context.Context) ([]Stack, error) {
 			st.Lifecycle = s.Manifest.Lifecycle
 		}
 		if s.Health != nil {
-			st.Installed = s.Health.Installed
+			st.Installed = s.Health.HasAnySignal
 		}
 		out = append(out, st)
 	}

--- a/tools/sb-tui/internal/rest/install_test.go
+++ b/tools/sb-tui/internal/rest/install_test.go
@@ -16,7 +16,7 @@ func TestListStacksSortsCoreFirst(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"stacks": []any{
 			map[string]any{"name": "zebra", "manifest": map[string]any{"tier": "feature", "description": "Z"}},
 			map[string]any{"name": "core-b", "manifest": map[string]any{"tier": "core"}},
-			map[string]any{"name": "core-a", "manifest": map[string]any{"tier": "core", "templates": []string{"nginx", "auth", "adguard"}}, "health": map[string]any{"installed": true}},
+			map[string]any{"name": "core-a", "manifest": map[string]any{"tier": "core", "templates": []string{"nginx", "auth", "adguard"}}, "health": map[string]any{"hasAnySignal": true}},
 		}})
 	}))
 	defer srv.Close()


### PR DESCRIPTION
Reinstalling/updating the box to 4.66.0 and exercising the deferred checks turned up two bugs that only show against live data.

## 1. Desired-state TUI panel pre-checked nothing
`ListStacks` parsed `health.installed` — but `/api/system/stacks` doesn't return that. The install signal is **`health.hasAnySignal`** (the web UI's "Not installed" badge is literally `!hasAnySignal`). So on a real box every stack looked uninstalled → the install/reinstall/**uninstall** diff was meaningless. **Fix:** parse `hasAnySignal`.

## 2. NPM auto-rekey never fired on a real stale-creds box
NPM (jc21) returns **HTTP 400** `error.invalid-auth` — **not 401** — for a wrong password (verified live). But `npmTokenStatus` / `npmAdminCredStatus` **and** the pre-existing `npmAuthProbe` all keyed off 401, so a rejection read as "transient/unknown" → the install-path auto-rekey **skipped** and the health probe **never flagged** the stale creds. (That's why the box's NPM breakage earlier never surfaced as a probe failure.) **Fix:** `isInvalidAuth()` (400 + `error.invalid-auth` / "Invalid email or password") → treat as a rejection in both the rekey detection and the probe; a genuinely malformed 400 (empty secret) stays `error`.

## Verified GREEN on the box (4.66.0)
- LLDAP self-heal fires on auth deploy: log `…FORCE_LDAP_USER_PASS_RESET=always`, `auth.yml` renders `="always"`, auth stays ready (no crash loop).
- `settleWait` runs **before** portal (`All 1 services active after 20s → Provisioning … portal`).
- Portal provisions for real: `proxy:created rewrites=…:unchanged` (not `proxy:failed` / "nothing to wire up").
- Stack-wipe route accepts the scoped token **and** refuses `atomic-wipe` (`basic` → HTTP 400 "use Factory Reset").

These two fixes close the gap so the desired-state panel + NPM auto-rekey actually work on a real box.

## Tests / gates
- `npmAdminRekey.test.ts`: 400-`error.invalid-auth` → `rejected`; malformed 400 → `unknown`. sb-tui `rest` test updated to `hasAnySignal`.
- `gofmt`/`vet`/`build`/`go test ./...`, `npm run lint` (0 errors), `check:arch`, `npm test` (1510) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)