### PR TITLE
feat(tui): channel switch — flip the running box to dev/latest/test

### DIFF
--- a/packages/backend/src/lib/servicebayChannel.test.ts
+++ b/packages/backend/src/lib/servicebayChannel.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const calls: string[][] = [];
+const execMock = vi.fn(async (argv: string[], _opts?: any) => {
+  calls.push(argv);
+  if (argv.join(' ').includes('grep')) return { stdout: 'servicebay:dev\n', stderr: '' };
+  return { stdout: '', stderr: '' };
+});
+
+vi.mock('@/lib/executor', () => ({ getExecutor: () => ({ execArgv: (a: string[], o?: any) => execMock(a, o) }) }));
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), error: vi.fn() } }));
+
+import { getServicebayChannel, setServicebayChannel, isChannel } from './servicebayChannel';
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+beforeEach(() => { calls.length = 0; execMock.mockClear(); });
+
+describe('servicebayChannel', () => {
+  it('validates channels', () => {
+    expect(isChannel('latest')).toBe(true);
+    expect(isChannel('dev')).toBe(true);
+    expect(isChannel('test')).toBe(true);
+    expect(isChannel('nightly')).toBe(false);
+  });
+
+  it('reads the running channel from the quadlet image tag', async () => {
+    expect(await getServicebayChannel()).toBe('dev');
+  });
+
+  it('re-points the quadlet tag (channel as $1, not interpolated), then pulls + reloads + restarts', async () => {
+    await setServicebayChannel('dev');
+    await flush(); // let the detached pull/restart run
+    const flat = calls.map(c => c.join(' '));
+    const sed = calls.find(c => c.join(' ').includes('sed'));
+    expect(sed?.includes('dev')).toBe(true); // channel passed as a positional arg
+    expect(flat.some(c => c.includes('podman pull') && c.includes('servicebay:dev'))).toBe(true);
+    expect(flat.some(c => c.includes('daemon-reload'))).toBe(true);
+    expect(flat.some(c => c.includes('restart --no-block servicebay.service'))).toBe(true);
+  });
+
+  it('refuses an unknown channel before touching the box', async () => {
+    await expect(setServicebayChannel('prod' as any)).rejects.toThrow(/Unknown channel/);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/lib/servicebayChannel.ts
+++ b/packages/backend/src/lib/servicebayChannel.ts
@@ -1,0 +1,67 @@
+/**
+ * Switch the *running* ServiceBay container between release channels by
+ * re-pointing its quadlet image tag and restarting.
+ *
+ * The build wizard bakes a channel into the USB (render.go:VersionFromChannel);
+ * this flips an already-installed box at runtime — chiefly so a fix merged to
+ * `main` (auto-published by release.yml as `:dev`) can be verified on the box
+ * WITHOUT cutting a release. A reinstall re-bakes from the wizard's choice, so
+ * a runtime switch is ephemeral.
+ *
+ * Channel → ghcr tag (release.yml):
+ *   - `latest` — the last release.
+ *   - `dev`    — the latest non-release commit on `main`.
+ *   - `test`   — the `test` branch.
+ */
+import { getExecutor } from '@/lib/executor';
+import { logger } from '@/lib/logger';
+
+export const CHANNELS = ['latest', 'dev', 'test'] as const;
+export type Channel = (typeof CHANNELS)[number];
+
+const IMAGE = 'ghcr.io/mdopp/servicebay';
+// $HOME (the box user's home) is resolved by the `sh -c` shell, not us — the
+// quadlet path varies by user, so we don't hardcode it. Scripts are FIXED
+// strings; the only variable (channel) is passed as a positional ($1), never
+// interpolated, so there's no shell-injection surface (and it's enum-checked).
+const READ_TAG_SH = 'grep -oE "servicebay:[A-Za-z0-9._-]+" "$HOME/.config/containers/systemd/servicebay.container" | head -1';
+const SWAP_TAG_SH = 'sed -i -E "s#(servicebay):[A-Za-z0-9._-]+#\\1:$1#" "$HOME/.config/containers/systemd/servicebay.container"';
+
+export function isChannel(s: string): s is Channel {
+  return (CHANNELS as readonly string[]).includes(s);
+}
+
+/** The channel the running box is pinned to, read from its quadlet image tag.
+ *  Falls back to 'latest' if the line can't be parsed. */
+export async function getServicebayChannel(): Promise<string> {
+  const { stdout } = await getExecutor('Local').execArgv(['sh', '-c', READ_TAG_SH]);
+  return stdout.trim().split(':')[1] || 'latest';
+}
+
+/**
+ * Re-point the quadlet to `:<channel>`, then pull + restart in the background.
+ *
+ * The tag swap is awaited (so a bad write surfaces synchronously); the slow
+ * pull + the `--no-block` restart run detached so the caller's HTTP response
+ * returns before the container is replaced (same pattern as `performUpdate`).
+ */
+export async function setServicebayChannel(channel: Channel): Promise<void> {
+  if (!isChannel(channel)) {
+    throw new Error(`Unknown channel "${channel}". Use one of: ${CHANNELS.join(', ')}.`);
+  }
+  const executor = getExecutor('Local');
+  // Swap `…/servicebay:<anything>` → `…/servicebay:<channel>` ($1 = channel).
+  await executor.execArgv(['sh', '-c', SWAP_TAG_SH, 'sh', channel]);
+  // Pull the new tag, reload the unit, restart non-blocking. Detached so the
+  // request can return before ServiceBay (which is serving it) goes down.
+  void (async () => {
+    try {
+      await executor.execArgv(['podman', 'pull', `${IMAGE}:${channel}`], { timeoutMs: 5 * 60 * 1000 });
+      await executor.execArgv(['systemctl', '--user', 'daemon-reload']);
+      await executor.execArgv(['systemctl', '--user', 'restart', '--no-block', 'servicebay.service']);
+      logger.info('channel', `Switched ServiceBay to '${channel}' and triggered restart.`);
+    } catch (e) {
+      logger.error('channel', `Channel switch to '${channel}' failed during pull/restart: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  })();
+}

--- a/packages/frontend/src/app/api/system/channel/route.ts
+++ b/packages/frontend/src/app/api/system/channel/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { getServicebayChannel, setServicebayChannel, CHANNELS } from '@/lib/servicebayChannel';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET — which release channel the running ServiceBay container is pinned to.
+ * POST { channel } — re-point it (`latest`/`dev`/`test`) and restart, so an
+ * unreleased `:dev` build can be verified on the box without cutting a
+ * release. `tokenScope: 'mutate'` lets the sb-tui `channel` command drive it
+ * with its scoped token; the restart is non-blocking so this returns first.
+ */
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
+  try {
+    return NextResponse.json({ channel: await getServicebayChannel() });
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:channel:get', status: 500 });
+  }
+});
+
+const PostBody = z.object({ channel: z.enum(CHANNELS) });
+
+export const POST = withApiHandler<z.infer<typeof PostBody>>({ tokenScope: 'mutate', body: PostBody }, async ({ body }) => {
+  try {
+    await setServicebayChannel(body.channel);
+    return NextResponse.json({
+      ok: true,
+      channel: body.channel,
+      message: `Switching ServiceBay to '${body.channel}'. It will pull the image and restart — reconnect in ~1 minute.`,
+    });
+  } catch (error) {
+    return apiError(error, { tag: 'api:system:channel:post', status: 500 });
+  }
+});

--- a/tools/sb-tui/internal/rest/channel.go
+++ b/tools/sb-tui/internal/rest/channel.go
@@ -1,0 +1,35 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Channels is the set of release channels the running box can be flipped to.
+// latest = last release · dev = latest non-release main commit · test = test branch.
+var Channels = []string{"latest", "dev", "test"}
+
+// GetChannel reports the release channel the running ServiceBay container is
+// pinned to (GET /api/system/channel).
+func (c *Client) GetChannel(ctx context.Context) (string, error) {
+	raw, err := c.do(ctx, "GET", "/api/system/channel", nil)
+	if err != nil {
+		return "", err
+	}
+	var doc struct {
+		Channel string `json:"channel"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return "", &APIError{Message: "malformed channel response: " + err.Error()}
+	}
+	return doc.Channel, nil
+}
+
+// SetChannel re-points the running ServiceBay container at `:<channel>` and
+// restarts it (POST /api/system/channel). The box pulls + restarts in the
+// background, so this returns before it actually flips — poll GetChannel to
+// confirm.
+func (c *Client) SetChannel(ctx context.Context, channel string) error {
+	_, err := c.do(ctx, "POST", "/api/system/channel", map[string]string{"channel": channel})
+	return err
+}

--- a/tools/sb-tui/internal/rest/channel_test.go
+++ b/tools/sb-tui/internal/rest/channel_test.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetChannel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/system/channel" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"channel": "dev"})
+	}))
+	defer srv.Close()
+
+	ch, err := newTestClient(srv).GetChannel(context.Background())
+	if err != nil {
+		t.Fatalf("GetChannel: %v", err)
+	}
+	if ch != "dev" {
+		t.Errorf("channel = %q, want dev", ch)
+	}
+}
+
+func TestSetChannelPostsChannel(t *testing.T) {
+	var body map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": body["channel"]})
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).SetChannel(context.Background(), "latest"); err != nil {
+		t.Fatalf("SetChannel: %v", err)
+	}
+	if body["channel"] != "latest" {
+		t.Errorf("posted channel = %q, want latest", body["channel"])
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -288,6 +289,55 @@ func runInstallStacks() int {
 	return 0
 }
 
+// runChannel is a non-interactive CLI: `sb-tui channel` prints the running
+// box's release channel; `sb-tui channel <latest|dev|test>` flips it (the box
+// re-points its image, pulls, and restarts), then polls until it's back on the
+// new channel. Lets a fix merged to main (auto-published as `:dev`) be verified
+// on the box without cutting a release — and it's scriptable (no TTY).
+func runChannel() int {
+	client, code := boxClient()
+	if client == nil {
+		return code
+	}
+	ctx := context.Background()
+	if len(os.Args) < 3 {
+		ch, err := client.GetChannel(ctx)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Printf("ServiceBay channel: %s\n", ch)
+		fmt.Printf("Switch with: sb-tui channel <%s>\n", strings.Join(rest.Channels, "|"))
+		return 0
+	}
+	target := os.Args[2]
+	valid := false
+	for _, c := range rest.Channels {
+		if c == target {
+			valid = true
+		}
+	}
+	if !valid {
+		fmt.Fprintf(os.Stderr, "unknown channel %q — use one of: %s\n", target, strings.Join(rest.Channels, ", "))
+		return 2
+	}
+	if err := client.SetChannel(ctx, target); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("Switching to '%s' — ServiceBay will pull + restart (~1 min)…\n", target)
+	// The restart drops the API we're talking to; poll until it's back on target.
+	for i := 0; i < 30; i++ {
+		time.Sleep(4 * time.Second)
+		if ch, err := client.GetChannel(ctx); err == nil && ch == target {
+			fmt.Printf("✓ ServiceBay is now on '%s'.\n", target)
+			return 0
+		}
+	}
+	fmt.Println("Still switching — run `sb-tui channel` in a moment to confirm.")
+	return 0
+}
+
 // runBackups opens the backup panel (#1277).
 func runBackups() int {
 	client, code := boxClient()
@@ -329,6 +379,8 @@ func main() {
 			os.Exit(runBackups())
 		case "upload":
 			os.Exit(runNasUpload())
+		case "channel":
+			os.Exit(runChannel())
 		}
 	}
 


### PR DESCRIPTION
## Why
The last verify round was slow because testing a fix meant cutting a full release (→ `:latest` rebuild → box update) *per bug*. `release.yml` already auto-publishes every non-release `main` commit as **`:dev`** — this adds the missing piece: a way to point an already-installed box at a channel **at runtime**, so a merged-but-unreleased fix can be verified on the box, and we cut **one** release only once it's proven.

## What
- **backend** `servicebayChannel.ts` + **`GET/POST /api/system/channel`**:
  - `GET` → the channel the running container's quadlet is pinned to.
  - `POST { channel: latest|dev|test }` → re-points the `Image=` tag, `podman pull`s it, and `systemctl --user restart --no-block`s (response returns before the container is replaced — same pattern as `performUpdate`). `tokenScope: 'mutate'` so sb-tui's scoped token can drive it.
  - Shell scripts are **fixed strings**; the channel is passed as a positional `$1` (never interpolated) and enum-validated → no injection (satisfies `sb/no-exec-template-literal`).
- **sb-tui** `rest.GetChannel/SetChannel` + a non-interactive **`sb-tui channel`** subcommand:
  - `sb-tui channel` → prints the current channel.
  - `sb-tui channel dev` → flips it, then polls until the box is back on the new channel.
  - CLI, no TTY — so an operator *and* automation (me) can use it the same way.

A runtime switch is **ephemeral** — a reinstall re-bakes the wizard's channel choice.

## Tests / gates
- backend: `isChannel`, quadlet-tag parse, tag-swap (channel as `$1`) + pull/reload/restart, invalid-channel rejection.
- sb-tui `rest`: `GetChannel`/`SetChannel` over httptest.
- `gofmt`/`vet`/`build`/`go test ./...`, `npm run lint` (0 errors), `check:arch`, `npm test` (1514) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)