### PR TITLE
feat(tui): channel switch in the interactive menu (not just the CLI)

### DIFF
--- a/packages/backend/src/lib/servicebayChannel.test.ts
+++ b/packages/backend/src/lib/servicebayChannel.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const calls: string[][] = [];
 const execMock = vi.fn(async (argv: string[], _opts?: any) => {
   calls.push(argv);
-  if (argv.join(' ').includes('grep')) return { stdout: 'servicebay:dev\n', stderr: '' };
+  if (argv.includes('inspect')) return { stdout: 'ghcr.io/mdopp/servicebay:dev\n', stderr: '' };
   return { stdout: '', stderr: '' };
 });
 

--- a/packages/backend/src/lib/servicebayChannel.ts
+++ b/packages/backend/src/lib/servicebayChannel.ts
@@ -21,21 +21,23 @@ export type Channel = (typeof CHANNELS)[number];
 
 const IMAGE = 'ghcr.io/mdopp/servicebay';
 // $HOME (the box user's home) is resolved by the `sh -c` shell, not us — the
-// quadlet path varies by user, so we don't hardcode it. Scripts are FIXED
-// strings; the only variable (channel) is passed as a positional ($1), never
+// quadlet path varies by user, so we don't hardcode it. The script is a FIXED
+// string; the only variable (channel) is passed as a positional ($1), never
 // interpolated, so there's no shell-injection surface (and it's enum-checked).
-const READ_TAG_SH = 'grep -oE "servicebay:[A-Za-z0-9._-]+" "$HOME/.config/containers/systemd/servicebay.container" | head -1';
 const SWAP_TAG_SH = 'sed -i -E "s#(servicebay):[A-Za-z0-9._-]+#\\1:$1#" "$HOME/.config/containers/systemd/servicebay.container"';
 
 export function isChannel(s: string): s is Channel {
   return (CHANNELS as readonly string[]).includes(s);
 }
 
-/** The channel the running box is pinned to, read from its quadlet image tag.
- *  Falls back to 'latest' if the line can't be parsed. */
+/** The channel actually in effect — read from the RUNNING container's image
+ *  tag, not the quadlet (which can already show a pending switch before the
+ *  restart lands). So a caller polling this only sees the new channel once the
+ *  box has restarted onto it. Falls back to 'latest' if unparseable. */
 export async function getServicebayChannel(): Promise<string> {
-  const { stdout } = await getExecutor('Local').execArgv(['sh', '-c', READ_TAG_SH]);
-  return stdout.trim().split(':')[1] || 'latest';
+  const { stdout } = await getExecutor('Local').execArgv(['podman', 'inspect', 'servicebay', '--format', '{{.ImageName}}']);
+  const tag = stdout.trim().match(/:([A-Za-z0-9._-]+)$/);
+  return tag ? tag[1] : 'latest';
 }
 
 /**

--- a/tools/sb-tui/internal/phase/phase.go
+++ b/tools/sb-tui/internal/phase/phase.go
@@ -58,6 +58,7 @@ const (
 	EditConfig    ActionID = "edit-config"
 	InstallStacks ActionID = "install-stacks"
 	Backups       ActionID = "backups"
+	SwitchChannel ActionID = "switch-channel"
 	UploadToNAS   ActionID = "upload-to-nas"
 	BootFromUSB   ActionID = "boot-from-usb"
 	Quit          ActionID = "quit"
@@ -88,6 +89,13 @@ var installStacksAction = Action{InstallStacks, "Install a stack on the server",
 // is reachable; restore is confirmation-gated in the panel.
 var backupsAction = Action{Backups, "Create / restore server backups",
 	"List, create, and restore the box's full system backups (config + service data)."}
+
+// switchChannelAction is the in-TUI update-channel switch: run a different
+// release channel on this server (latest / dev / test). Re-points the
+// ServiceBay image + restarts; reverts on reinstall. Mainly to try an
+// unreleased `:dev` build. Only meaningful once the box is reachable.
+var switchChannelAction = Action{SwitchChannel, "Switch update channel (latest / dev / test)",
+	"Run a different release channel on this server — e.g. `dev` to try the latest unreleased build. Pulls the image and restarts ServiceBay; reverts to the baked channel on reinstall."}
 
 // uploadToNASAction stages a local service config archive on the box's NAS
 // (#1352) so a fresh install pulls it. Only meaningful once the box is reachable.
@@ -211,6 +219,7 @@ func Journey(s State) []JourneyRow {
 			{Action: editConfigAction},
 			{Action: installStacksAction},
 			{Action: backupsAction},
+			{Action: switchChannelAction},
 			{Action: bootFromUSBAction},
 			{Action: quitAction},
 		}
@@ -223,6 +232,7 @@ func Journey(s State) []JourneyRow {
 			{Action: installStacksAction, Recommended: true},
 			{Action: editConfigAction},
 			{Action: backupsAction},
+			{Action: switchChannelAction},
 			{Action: bootFromUSBAction},
 			{Action: quitAction},
 		}

--- a/tools/sb-tui/internal/phase/phase_test.go
+++ b/tools/sb-tui/internal/phase/phase_test.go
@@ -55,13 +55,13 @@ func TestActionsFor(t *testing.T) {
 	if got := ids(ActionsFor(Detect(true, BoxStatus{}))); !eq(got, []ActionID{UploadToNAS, BuildISO, WatchInstall, Quit}) {
 		t.Fatalf("iso-ready actions = %v", got)
 	}
-	// installing: stage + reinstall + watch + manage children (config/stacks/backups/boot-usb), then quit.
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{UploadToNAS, BuildISO, WatchInstall, EditConfig, InstallStacks, Backups, BootFromUSB, Quit}) {
+	// installing: stage + reinstall + watch + manage children (config/stacks/backups/channel/boot-usb), then quit.
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true}))); !eq(got, []ActionID{UploadToNAS, BuildISO, WatchInstall, EditConfig, InstallStacks, Backups, SwitchChannel, BootFromUSB, Quit}) {
 		t.Fatalf("installing actions = %v", got)
 	}
 	// ready: stage + reinstall + manage children, then quit. No Watch on an up box
 	// (step 3 is a done signpost); no Open-in-browser — URL is shown persistently.
-	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{UploadToNAS, BuildISO, InstallStacks, EditConfig, Backups, BootFromUSB, Quit}) {
+	if got := ids(ActionsFor(Detect(true, BoxStatus{Reachable: true, WizardDone: true}))); !eq(got, []ActionID{UploadToNAS, BuildISO, InstallStacks, EditConfig, Backups, SwitchChannel, BootFromUSB, Quit}) {
 		t.Fatalf("ready actions = %v", got)
 	}
 }

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -158,7 +158,7 @@ func (m App) route(id phase.ActionID, jobID string) (tea.Model, tea.Cmd) {
 		m.active = NewNasUpload()
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
-	case phase.EditConfig, phase.InstallStacks, phase.Backups:
+	case phase.EditConfig, phase.InstallStacks, phase.Backups, phase.SwitchChannel:
 		if m.token == "" {
 			m.pending = id
 			m.screen = appLogin
@@ -204,6 +204,8 @@ func (m App) openPanel(id phase.ActionID) (tea.Model, tea.Cmd) {
 		m.active = NewInstall(client)
 	case phase.Backups:
 		m.active = NewBackup(client)
+	case phase.SwitchChannel:
+		m.active = NewChannel(client)
 	default:
 		m.screen, m.active = appMenu, nil
 		return m, nil

--- a/tools/sb-tui/internal/ui/channel.go
+++ b/tools/sb-tui/internal/ui/channel.go
@@ -1,0 +1,200 @@
+// The Bubble Tea model for the update-channel panel: show which release
+// channel the server is running and switch it (latest / dev / test). Switching
+// re-points the box's ServiceBay image and restarts it, so the panel polls
+// until the box is back on the chosen channel. Mainly lets an operator try an
+// unreleased `:dev` build without a full reinstall; mirrors the edit-config /
+// install panels' shape and reuses the #1275 token client.
+package ui
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"servicebay-tui/internal/rest"
+)
+
+type channelStage int
+
+const (
+	chanLoading channelStage = iota
+	chanSelect
+	chanSwitching
+	chanDone
+	chanError
+)
+
+const chanMaxPolls = 40 // ~80s at 2s/poll — covers a cold image pull + restart
+
+// ChannelModel is the Bubble Tea model for the update-channel panel.
+type ChannelModel struct {
+	client        *rest.Client
+	width, height int
+	stage         channelStage
+	current       string   // channel actually running now
+	choices       []string // rest.Channels
+	cursor        int
+	target        string // channel being switched to
+	polls         int
+	errMsg        string
+}
+
+type channelLoadedMsg struct {
+	channel string
+	err     error
+}
+type channelSetMsg struct{ err error }
+type channelPollMsg struct {
+	channel string
+	err     error
+}
+type channelTickMsg struct{}
+
+// NewChannel builds the update-channel model against an authenticated client.
+func NewChannel(client *rest.Client) ChannelModel {
+	return ChannelModel{client: client, stage: chanLoading, choices: rest.Channels}
+}
+
+func (m ChannelModel) loadCmd() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		ch, err := client.GetChannel(context.Background())
+		return channelLoadedMsg{channel: ch, err: err}
+	}
+}
+
+func (m ChannelModel) setCmd(target string) tea.Cmd {
+	client := m.client
+	return func() tea.Msg { return channelSetMsg{err: client.SetChannel(context.Background(), target)} }
+}
+
+func (m ChannelModel) pollCmd() tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		ch, err := client.GetChannel(context.Background())
+		return channelPollMsg{channel: ch, err: err}
+	}
+}
+
+func tick2s() tea.Cmd {
+	return tea.Tick(2*time.Second, func(time.Time) tea.Msg { return channelTickMsg{} })
+}
+
+// Init reads the current channel.
+func (m ChannelModel) Init() tea.Cmd { return m.loadCmd() }
+
+// Update folds in load/set/poll results and handles input.
+func (m ChannelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case channelLoadedMsg:
+		if msg.err != nil {
+			m.stage, m.errMsg = chanError, friendlyErr(msg.err)
+			return m, nil
+		}
+		m.current, m.stage = msg.channel, chanSelect
+		for i, c := range m.choices {
+			if c == m.current {
+				m.cursor = i
+			}
+		}
+		return m, nil
+	case channelSetMsg:
+		if msg.err != nil {
+			m.stage, m.errMsg = chanError, friendlyErr(msg.err)
+			return m, nil
+		}
+		return m, tick2s() // the box is restarting; start polling for the flip
+	case channelTickMsg:
+		return m, m.pollCmd()
+	case channelPollMsg:
+		m.polls++
+		if msg.err == nil && msg.channel == m.target {
+			m.current, m.stage = msg.channel, chanDone
+			return m, nil
+		}
+		if m.polls >= chanMaxPolls {
+			m.stage, m.errMsg = chanError, "Timed out waiting for the server to come back — it may still be restarting. Reopen this panel to check."
+			return m, nil
+		}
+		return m, tick2s()
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case backMsg:
+		return m, tea.Quit // standalone-only; App intercepts when hosted
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m ChannelModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "q", "esc":
+		// Don't bail mid-switch (the box is restarting); otherwise pop back.
+		if m.stage != chanSwitching {
+			return m, backCmd()
+		}
+	}
+	if m.stage != chanSelect {
+		return m, nil
+	}
+	switch msg.String() {
+	case "up", "k":
+		m.cursor = (m.cursor - 1 + len(m.choices)) % len(m.choices)
+	case "down", "j":
+		m.cursor = (m.cursor + 1) % len(m.choices)
+	case "enter":
+		m.target = m.choices[m.cursor]
+		if m.target == m.current {
+			return m, backCmd() // already on it — nothing to do
+		}
+		m.stage = chanSwitching
+		return m, m.setCmd(m.target)
+	}
+	return m, nil
+}
+
+// View renders the panel per stage.
+func (m ChannelModel) View() string {
+	width := m.width
+	if width <= 0 {
+		width = 72
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Width(width).Render("ServiceBay  ·  update channel") + "\n")
+
+	switch m.stage {
+	case chanLoading:
+		b.WriteString(phaseStyle.Render("Reading the current channel…"))
+	case chanError:
+		b.WriteString(phaseStyle.Render(cfgErrStyle.Render("Channel error:")) + "\n")
+		b.WriteString(detailStyle.Render(m.errMsg) + "\n")
+		b.WriteString(footerStyle.Render("q back"))
+	case chanSelect:
+		b.WriteString(phaseStyle.Render("Pick the channel this server runs. `dev` = the latest unreleased build; switching pulls the image and restarts ServiceBay.") + "\n\n")
+		for i, c := range m.choices {
+			suffix := ""
+			if c == m.current {
+				suffix = cfgEmptyStyle.Render("  (current)")
+			}
+			if i == m.cursor {
+				b.WriteString(selectedStyle.Render("❯ "+c) + suffix + "\n")
+			} else {
+				b.WriteString("  " + c + suffix + "\n")
+			}
+		}
+		b.WriteString("\n" + footerStyle.Render("↑/↓ move · enter switch · q back"))
+	case chanSwitching:
+		b.WriteString(phaseStyle.Render("Switching to '"+m.target+"' — pulling the image and restarting ServiceBay…") + "\n")
+		b.WriteString(detailStyle.Render("The server drops briefly during the restart; waiting for it to come back on the new channel."))
+	case chanDone:
+		b.WriteString(phaseStyle.Render(cfgOKStyle.Render("✓ ServiceBay is now on '"+m.current+"'.")) + "\n")
+		b.WriteString(footerStyle.Render("q back"))
+	}
+	return frame(b.String(), m.width, m.height)
+}


### PR DESCRIPTION
Follow-up to #1417 (the `sb-tui channel` CLI): surface the same switch **in the launcher's interactive menu**, where an operator actually lives — alongside edit-config / install / backups under "Manage your server".

## What
- **`ui/channel.go`** — a Bubble Tea panel: shows the channel the server is running, lets you pick **latest / dev / test**, then switches (re-point image → pull → restart) and **polls until the box is back** on the chosen channel. Same token-gated in-app flow as the other box-control panels; `esc` → back.
- **`phase.go`** — `SwitchChannel` action added to the **Installing** and **Ready** journeys; **`app.go`** opens `NewChannel(client)` after the login/token step.
- **`getServicebayChannel`** now reads the **running container's** image tag (`podman inspect`) instead of the quadlet — the quadlet shows a pending switch immediately, so polling it would report "done" before the restart actually landed. Reading the running tag makes the panel's "✓ now on X" truthful.

So both audiences are covered: operators switch from the menu; I (and scripts) use `sb-tui channel dev`.

## Tests / gates
- `phase_test.go` updated for the new manage-group action.
- backend `servicebayChannel.test.ts` updated for the inspect-based read.
- `gofmt`/`vet`/`build`/`go test ./...`, `npm run lint` (0 errors), `check:arch`, `npm test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)