### PR TITLE
chore(autoloop): priority queue overrides (pinned IDs + label)

### DIFF
--- a/.claude/skills/autoloop-issues/SKILL.md
+++ b/.claude/skills/autoloop-issues/SKILL.md
@@ -98,6 +98,10 @@ Two buckets — both produce a code PR; the difference is what happens at merge 
 
 ### Selection order within survivors
 
+0. **Priority overrides — jump the whole queue.** Two ways to pin work ahead of the normal buckets (use either or both; the operator sets these to front-load force-multiplier/infra work that speeds everything after):
+   - **Explicit, ordered:** any open issue whose number is listed in `state.priority[]`, worked **in the order listed there**. The loop does not mutate this list — completed issues simply stop matching (they're no longer open). This is the way to pin a specific sequence, e.g. `"priority": [1433, 1434, 1435]`.
+   - **By label:** any issue carrying the `priority` label, ascending issue number.
+   `state.priority[]` entries come first (in list order), then `priority`-labelled issues, then the buckets below. A priority issue still goes through the normal gates (CI, and `/verify` if it touches an install/config/auth/portal path) and the normal security-draft rule.
 1. `good first issue` label first.
 2. Then `bug` label.
 3. Then `testing` label.


### PR DESCRIPTION
Adds a priority step ahead of the autoloop's normal selection buckets, so force-multiplier/infra issues can jump the queue.

- **`state.priority[]`** — explicit, ordered pin (worked in list order; the loop never mutates it — completed issues just stop matching). e.g. `[1433, 1434, 1435]`.
- **`priority` label** — ascending within the labelled set.

Both still pass the normal gates (CI, real-box `/verify` on box paths, security-draft rule). This lets us front-load the verify-on-box (#1433), clustering (#1434), and docs-agent (#1435) work — the changes that make every later loop iteration cheaper.

`chore` so release-please doesn't cut a version (Claude-config only, no product change). The `state.priority[]` value is already set locally (the state file is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)