### PR TITLE
feat(docs-coherence): parallel agent to keep docs in sync as PRs land

### DIFF
--- a/.claude/skills/comment-responder/SKILL.md
+++ b/.claude/skills/comment-responder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comment-responder
-description: Draft honest, kind replies to real (human, non-AI) comments on GitHub issues/PRs, looking for how the contributor's input can create project value. Shows each draft for the user to confirm, then posts it with the AI marker. Use when the user wants to answer external comments, clear the autoloop `awaiting_user[]` list, or asks to "reply to the comment on #N".
+description: Draft honest, kind replies to real (human, non-AI) comments on GitHub issues/PRs, looking for how the contributor's input can create project value. Verifies technical claims against the live box/code before drafting, and writes in plain "what happens" language rather than jargon. Shows each draft for the user to confirm, then posts it with the AI marker. Use when the user wants to answer external comments, clear the autoloop `awaiting_user[]` list, or asks to "reply to the comment on #N".
 ---
 
 # Comment responder
@@ -40,6 +40,14 @@ Don't reply to the surface. For each thread:
 - Decide what the comment really is: a correct technical point, a partial point, a misunderstanding, a feature ask, a question, promotional/spam — or some mix (the #1311 example below is advice + a self-promo link).
 - Find the **value angle**: does it surface a real follow-up issue worth filing? A correction we should accept? A suggestion that fits (or clearly doesn't, and why)? Look for it honestly — don't manufacture it.
 
+## Step 2.5 — Verify against the real system before you answer (don't guess)
+
+If the comment makes a technical claim, or your reply would assert how the system behaves, **check the actual state first** — don't reason it out from how things "should" work. The dev env and the running box diverge, and a confident wrong answer to a careful contributor costs more trust than taking ten minutes to look.
+
+- Read the **code** that's actually in play, and — when the claim is about runtime/permissions/config/networking — inspect the **live box** (SSH via `build/fcos/servicebay-ssh/id_rsa`, or the `mcp__servicebay__*` tools: `exec_command`, `get_container_logs`, `diagnose`, `list_containers`). `reference_mcp_servicebay_access` has the connection paths and the reinstall gotchas.
+- Let the findings **change the answer**, including your own earlier framing. The #1311 case below is the cautionary tale: the obvious "set `UMASK=002` on the writers" fix was *wrong* — inspecting the box showed those services run as root with no umask knob, which flipped the recommendation to a default ACL. We'd have shipped bad advice without looking.
+- When the investigation overturns or sharpens what the **issue/PR body** says, fold the corrected facts back into the body (via `gh api -X PATCH repos/mdopp/servicebay/issues/<N> -F body=@file`) so the next reader starts from the truth — then reference it in the reply.
+
 ## Step 3 — Draft the reply
 
 Style (reuse `feedback_concise_answers`):
@@ -47,6 +55,7 @@ Style (reuse `feedback_concise_answers`):
 - **Honest.** Acknowledge what's right. Be straight about disagreement or what we can't/won't do, and why. Never pretend a wrong point is right to be polite.
 - **Kind.** Warm, respectful, genuinely glad they engaged — never condescending or curt, even to spam.
 - **Value-seeking.** Where their input helps, say how, and take the next step (offer to file a follow-up, accept the correction, adopt the suggestion).
+- **Plain-language — explain what *happens*, not a list of flags.** Tell the story: what the system actually does, why, and what it means, in terms a smart reader follows without decoding jargon. Reach for a term like `setgid` or `default ACL` only when the reader needs the exact word, and say what it does in plain words right next to it. A good test: it should read like how you'd explain it out loud to a colleague, not like a man-page excerpt. (This is the lesson from the #1311 thread — the dense flag-soup draft was rejected for the narrative version.)
 - **Short and sharp.** No fillwords, no generic AI boilerplate, no "thanks for your valuable feedback" padding. Lead with substance.
 - **No false endorsement.** If a comment links a product/tool, stay neutral — don't promote it, don't be snarky about it.
 
@@ -72,11 +81,19 @@ After posting, the last word is ours, so the autoloop's exclusion filter clears 
 
 ## Worked example — #1311 (`wenghuiming1987`)
 
-The comment gave a solid shared-group + setgid + `umask 0002` model (which **matches the fix the issue itself proposes**), a correct nitpick that "`0644` is the resulting file mode, not the umask," and a self-promo link to a browser umask calculator (`?ref=github`). A good reply:
+The comment gave a shared-group + setgid + `umask 0002` model, a correct nitpick that "`0644` is the resulting file mode, not the umask," and a self-promo link to a browser umask calculator (`?ref=github`).
 
-> Agreed — and that's exactly the model this issue is moving toward: shared gid, `setgid` on the share dir, and `UMASK=002` on the writers so every consumer (including OSCAR's Hermes at uid 10000) can join the gid and read-write cleanly. You're right that `0644` is the resulting mode rather than the umask; the title's loose there. The real test is the cross-stack writer, which we can only confirm on a live multi-service box — that's why it's parked for a hands-on session rather than guessed in the dev env. Thanks for the careful read.
+The first instinct was to agree wholesale — the umask plan looked right and matched the issue. **Step 2.5 caught it:** inspecting the live box showed the file-share services run as **container-root with umask `0022` and no `UMASK` knob**, so "set `UMASK=002` on the writers" was simply not available. That flipped the answer — a **default ACL** on the folder (not umask) becomes the mechanism — and the corrected facts were folded back into the issue body before replying.
+
+The reply that landed — note it explains *what happens* in plain language, not a flag list:
+
+> Thanks for pushing on this — it sent me to actually look at the box, which was worth doing. Your core instinct is right: put the writers in one shared group and let group permissions do the work. And your wording nitpick is right too — `0644` is the mode a new file ends up with, not the umask.
+>
+> But the real setup changed the picture. The apps sharing this folder don't run as a normal user with a umask we can set — they run as root inside their containers, with no umask knob to turn. What decides who "owns" a file on disk is how each container's user maps to the host, not the app. On this machine they all map to the same host user, so they get along today; the trouble only starts when a different stack (the Hermes gateway) maps to a different host identity and can't write the folder.
+>
+> So the group idea is the backbone, but two things carry it: we let the **folder** enforce sharing — a default ACL that says "every new file here is read/write for the shared group, no matter who created it" — and any outside stack that needs to write gets added to that group through its container setup. Net effect: the folder becomes genuinely co-editable, and we retire the current blunt "world-writable" workaround for a real access model.
 >
 > `<!-- sb-ai-comment -->`
 > `🤖 _AI-generated, acting for @mdopp._`
 
-Note: honest (confirms the model, accepts the nitpick, states the real blocker), kind, value-seeking, and neutral on the linked tool — no endorsement, no snark.
+Note: honest (credits the instinct, accepts the nitpick, openly corrects course), grounded (the reply only exists because the box was checked), plain-language (the story of what happens, jargon only where the reader needs it), and neutral on the linked tool — no endorsement, no snark.

--- a/.claude/skills/docs-coherence/SKILL.md
+++ b/.claude/skills/docs-coherence/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: docs-coherence
+description: Parallel docs/coherence agent — as PRs merge, keep user-facing docs, docs/ARCHITECTURE_INVARIANTS.md, and docs/UX_DECISIONS.md in sync with what shipped, and flag intent drift (a change that contradicts a documented decision) for human review. Runs alongside the autoloop builder on a disjoint fileset via its own git worktree. Use when the user asks to "keep the docs in sync", "run the docs agent", or invokes /loop with this skill.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Skill, TaskCreate, TaskUpdate, TaskList, TaskGet, ScheduleWakeup
+---
+
+# Docs coherence agent
+
+You keep the project's **documentation and stated intent** coherent with the code as PRs land. The autoloop builder (`autoloop-issues`) is heads-down on code; nobody owns whether the user docs, architecture invariants, and UX decisions still match what shipped. That's this loop.
+
+You are a **second loop that runs in parallel** with the builder. Parallelism is only safe because you touch a **disjoint fileset** and work in your **own git worktree** — never the builder's working tree, never the box, never the release train.
+
+The user's recurring rules (in `~/.claude/projects/-home-mdopp-servicebay/memory/MEMORY.md`) override anything in this skill if they conflict. Read it before the first iteration of a fresh /loop run.
+
+## What this loop owns (the disjoint fileset)
+
+You may edit **only** these:
+
+- `docs/**` — user-facing docs (`getting-started.md`, `INSTALLATION.md`, `MCP.md`, `TEMPLATE_AUTHORING.md`, …)
+- `docs/ARCHITECTURE_INVARIANTS.md`
+- `docs/UX_DECISIONS.md` and `docs/UX_PHILOSOPHY.md`
+- `README.md`
+- `mkdocs.yml` (only to add a nav entry for a doc you create)
+
+You may **read** anything (source, tests, diffs, the changelog) to understand a merged change — but you never edit code, tests, templates, or config. If a doc can only be made truthful by changing code, that's a **drift flag** for the builder/human, not your edit (see Step 3).
+
+### Hard boundary against the builder
+
+- **Never touch `packages/**`, `tools/**`, `scripts/**`, `.claude/skills/**`, `.claude/state/autoloop-state.json`, or any file outside the fileset above.** Those are the builder's. Editing them risks a working-tree collision and a lost commit.
+- **Never bump versions / edit `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`.** release-please owns those (memory: *"NEVER manually bump versions"*). You *read* `CHANGELOG.md` to know what shipped; you never write it.
+- **Never merge or touch the builder's in-flight PRs/branches.** You only open and merge your own `docs/*` branches.
+
+## Per-invocation budget
+
+- **At most 4 docs PRs per invocation**, then exit cleanly. `/loop` re-fires you.
+- If a single merged PR's doc impact is too large to land coherently in one docs PR, split by document (one PR per doc area) and stop at the budget.
+- If you've spent >30 minutes on one merged-PR's doc reconciliation without a green PR, post a drift flag (Step 3) and move on.
+
+## Wakeup cadence (dynamic /loop mode)
+
+Every `ScheduleWakeup` from this skill uses **`delaySeconds: 480` (8 minutes) or less**, matching the builder's cadence (memory `feedback_autoloop_wakeup_cap`). The doc backlog tracks merge velocity; long fallbacks let drift accumulate.
+
+## State file
+
+Track progress at `.claude/state/docs-coherence-state.json` (note: a **separate** file from the builder's `autoloop-state.json`, so the two loops never write the same state). Shape:
+
+```json
+{
+  "started": "2026-06-01T03:00:00Z",
+  "last_invocation": "2026-06-01T03:40:00Z",
+  "cursor": { "last_merged_pr": 1431, "last_merged_at": "2026-05-31T22:10:00Z" },
+  "reconciled": [
+    {"pr": 1416, "docs": ["docs/MCP.md"], "docs_pr": "https://github.com/mdopp/servicebay/pull/1440", "merged_at": "..."}
+  ],
+  "no_doc_impact": [1430, 1431],
+  "drift_flags": [
+    {"pr": 1422, "doc": "docs/UX_DECISIONS.md", "decision": "Self-heal first", "comment_url": "https://github.com/mdopp/servicebay/pull/1422#issuecomment-…", "since": "..."}
+  ],
+  "blocked": []
+}
+```
+
+`cursor` is how you avoid re-processing PRs: advance `last_merged_pr` only past PRs you've classified (reconciled, no-impact, or drift-flagged). Update the file at every state transition. If it doesn't exist, create it with empty arrays and `cursor` seeded to the most-recent merged PR at first run (so you start from "now", not the dawn of the repo).
+
+## Comment hygiene (every comment this loop posts)
+
+Every comment — drift flags (Step 3), the >30-min note — ends with the AI marker (memory `feedback_ai_comment_marker`):
+
+```
+<!-- sb-ai-comment -->
+🤖 _AI-generated, acting for @mdopp._
+```
+
+It posts as `mdopp`, so without the marker no one can tell it's AI-written. Keep comments short and sharp (memory `feedback_concise_answers`). This loop **never** replies to external human commenters — that's `/comment-responder`'s job.
+
+## Step 0 — Preflight (every invocation)
+
+1. **Work in your own git worktree** so you never contend with the builder's working tree. The builder exits on a dirty tree; you must not be the one who dirties it.
+   ```bash
+   git fetch origin
+   git worktree add -B docs-coherence-work .docs-coherence-worktree origin/main 2>/dev/null \
+     || git -C .docs-coherence-worktree fetch origin && git -C .docs-coherence-worktree reset --hard origin/main
+   ```
+   Run all subsequent git/file operations inside `.docs-coherence-worktree` (it is git-ignored / auto-cleaned). Never `git checkout` a branch in the primary working tree.
+2. **Lock check.** If `.claude/state/docs-coherence.lock` exists with mtime < 10 min, another docs-coherence invocation is running — exit. Otherwise touch it.
+3. **Read state file.** Establish the `cursor`.
+
+## Step 1 — Find newly-merged PRs to reconcile
+
+```bash
+gh pr list --state merged --base main --limit 30 \
+  --json number,title,mergedAt,labels,files --search "sort:updated"
+```
+
+Process PRs with `number > cursor.last_merged_pr`, oldest first. For each, decide **doc impact** by looking at the PR's changed files and title:
+
+| Changed-files signal | Doc(s) to check |
+|---|---|
+| `packages/backend/src/lib/install/**`, `INSTALLATION`-ish | `docs/INSTALLATION.md`, `docs/getting-started.md` |
+| `packages/backend/src/lib/mcp/**`, MCP tool add/remove/rename | `docs/MCP.md` |
+| `packages/backend/src/templates/**` | `docs/TEMPLATE_AUTHORING.md`, `docs/TEMPLATE_LOGGING.md` |
+| frontend portal/dashboard/onboarding/wizard | `docs/UX_DECISIONS.md`, `docs/UX_PHILOSOPHY.md`, `docs/WIZARD_UX_AUDIT.md` |
+| dependency-cruiser / `scripts/check-invariants.ts` / new module-boundary | `docs/ARCHITECTURE.md`, `docs/ARCHITECTURE_INVARIANTS.md` |
+| credential / self-heal paths | `docs/CREDENTIAL_SELF_HEAL.md` |
+| user-visible CLI/flag/command change | `README.md`, `docs/getting-started.md` |
+
+A PR with **no** mapping (pure lint sweep, internal refactor, test-only) → record in `no_doc_impact[]`, advance the cursor, continue.
+
+## Step 2 — Reconcile the doc
+
+For each PR with doc impact:
+
+1. Read the merged diff (`gh pr diff <N>`) and the mapped doc.
+2. Update the doc so it describes **what actually shipped** — new/renamed/removed commands, flags, MCP tools, install steps, default behaviours. Match the doc's existing voice and altitude; don't rewrite sections that didn't change.
+3. **Scope discipline.** Only edit the sentences/sections the merged change makes stale. No drive-by doc rewrites, no reflowing untouched prose. One merged PR → the minimal doc delta that makes it truthful.
+4. If you created a new doc page, add it to `mkdocs.yml` nav.
+
+If the change is **purely additive intent** that belongs in the decisions/invariants ledger (e.g. a new architecture boundary was ratcheted, or a UX decision was made), append a dated entry in `docs/ARCHITECTURE_INVARIANTS.md` / `docs/UX_DECISIONS.md` in that file's existing entry format — do not invent a new format.
+
+## Step 3 — Drift detection (flag, don't fix)
+
+While reconciling, watch for **intent drift**: a merged change that *contradicts* a documented decision (e.g. a PR re-introduces an expert knob the UX philosophy says to hide; or removes a self-heal the credential doc promises; or violates a stated invariant that the ratchet didn't catch).
+
+When you find drift, **do not silently edit the doc to match the code** — that would launder a regression into "documented behaviour" (memory `feedback_dont_mask_failures`). Instead:
+
+1. Post a short comment on the offending merged PR naming the doc + the decision it contradicts, and what shipped that diverges.
+2. Record it in `state.drift_flags[]` (`{pr, doc, decision, comment_url, since}`).
+3. Advance the cursor (you've classified the PR) and continue. The human decides whether to revert the code or amend the decision; you don't do either.
+
+Drift flags are the high-value output of this loop — surface them clearly.
+
+## Step 4 — Open the docs PR
+
+One PR per merged-PR's reconciliation (or per doc area if you split). Inside `.docs-coherence-worktree`:
+
+```bash
+git checkout -b docs/sync-pr-<N>-<slug>
+git add docs/ README.md mkdocs.yml
+git commit  # conventional commit, see below
+git push -u origin docs/sync-pr-<N>-<slug>
+gh pr create --title "<subject>" --body "<body>"
+```
+
+- **Commit subject:** `docs(<area>): sync <doc> with #<N>` — no parens beyond the conventional `(scope)` (memory `feedback_release_please_commit_parens`).
+- **Body:** What changed, `Refs #<N>` (the merged PR that drove it — *not* `Closes`, since you're not closing a ticket), and a one-line Risk/Rollback (`docs-only; git revert is enough`).
+- No `Closes #` — this loop closes no issue.
+
+### Gates
+
+- `npm run lint && npm run check:arch && npm test` still run in CI; a docs-only change should pass trivially. Run them locally only if your change touched `mkdocs.yml` or a generated-docs input.
+- **No real-box `/verify`** — docs/UX-ledger/README files are never in the install/config/auth/portal path-mandated list. (If you ever find yourself needing the box to verify a docs change, you're editing the wrong file — back out.)
+- Merge gate (main is not branch-protected): `gh pr checks <PR#> --watch`, then on green `gh pr merge <PR#> --merge --delete-branch`. If CI red twice on the same SHA, leave it open, post the failing link, move on.
+
+After merge, advance the cursor past `#<N>`, move the entry to `reconciled[]`, and continue.
+
+## Step 5 — End of invocation
+
+After 4 docs PRs, or when the cursor reaches the newest merged PR, stop and summarize:
+
+```
+Docs-coherence iteration complete.
+  Reconciled: #1416 → docs PR #1440 (docs/MCP.md)
+  No doc impact: #1430, #1431
+  Drift flagged: #1422 (UX_DECISIONS: "Self-heal first")
+Cursor now at #1431.
+```
+
+Then schedule the next firing (`ScheduleWakeup`, ≤480s) unless a hard exit condition hit.
+
+## Hard exit conditions (stop the loop entirely)
+
+1. The cursor is at the newest merged PR and there's nothing to reconcile (no doc drift outstanding) — nothing to do; let `/loop` re-fire later rather than spinning.
+2. CI red twice on the same docs PR with no change between.
+3. `state.drift_flags[]` has >5 unaddressed flags — the human has a decision backlog; stop adding noise until they triage.
+4. The git worktree can't be created/reset cleanly (environment problem) — report and stop.
+
+## Things this skill explicitly does NOT do
+
+- Does not edit code, tests, templates, scripts, other skills, or the builder's state file — docs fileset only.
+- Does not run in the primary working tree — always its own `.docs-coherence-worktree` (so the builder's dirty-tree exit never trips on this loop).
+- Does not bump versions or write `CHANGELOG.md` / `package.json` / the release manifest.
+- Does not silently rewrite a doc to match a regression — contradictions are drift flags for a human, not edits (memory `feedback_dont_mask_failures`).
+- Does not reply to external human commenters — that's `/comment-responder`.
+- Does not post a comment without the AI marker.
+- Does not touch or merge the builder's PRs/branches, or the release-please PR.
+
+## Reference
+
+- Memory index: `~/.claude/projects/-home-mdopp-servicebay/memory/MEMORY.md`
+- Builder loop (runs in parallel): `.claude/skills/autoloop-issues/SKILL.md`
+- UX contract: `docs/UX_PHILOSOPHY.md`, `docs/UX_DECISIONS.md`
+- Architecture invariants: `docs/ARCHITECTURE_INVARIANTS.md`
+- Usage: `/loop /docs-coherence` (alongside `/loop /autoloop-issues`)

--- a/.claude/skills/docs-coherence/USAGE.md
+++ b/.claude/skills/docs-coherence/USAGE.md
@@ -1,0 +1,19 @@
+# Docs-coherence usage
+
+Invoke from the project root, alongside the builder:
+
+```
+/loop /docs-coherence
+```
+
+Runs in parallel with `/loop /autoloop-issues` — safe because it works a **disjoint fileset** (`docs/**`, `README.md`, the architecture/UX ledgers) inside its **own git worktree**, never the builder's working tree or the box.
+
+The skill is resumable — it reads/writes `.claude/state/docs-coherence-state.json` (a separate file from the builder's) and advances a `cursor` over merged PRs.
+
+Each /loop firing:
+- finds PRs merged since the cursor,
+- reconciles the mapped docs with what actually shipped (one docs PR per merged PR),
+- flags **intent drift** (a change that contradicts a documented decision) for a human instead of silently editing the doc to match,
+- then schedules the next firing.
+
+See `SKILL.md` for the full contract.

--- a/.claude/skills/docs-coherence/state-template.json
+++ b/.claude/skills/docs-coherence/state-template.json
@@ -1,0 +1,9 @@
+{
+  "started": null,
+  "last_invocation": null,
+  "cursor": { "last_merged_pr": null, "last_merged_at": null },
+  "reconciled": [],
+  "no_doc_impact": [],
+  "drift_flags": [],
+  "blocked": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ __pycache__/
 !/.claude/skills/
 secret.key
 *.local.json
+
+# docs-coherence parallel agent worktree (see .claude/skills/docs-coherence)
+.docs-coherence-worktree/


### PR DESCRIPTION
## What
New sibling skill `docs-coherence` (a second `/loop` agent) that runs **in parallel** with the `autoloop-issues` builder. On merged PRs it reconciles the mapped user docs / architecture-invariants / UX-decisions with what actually shipped, and flags **intent drift** (a change that contradicts a documented decision) for a human instead of silently editing the doc to match.

Parallel-safe by design: it touches a **disjoint fileset** (`docs/**`, `README.md`, the ledgers, `mkdocs.yml`) inside its **own git worktree** (`.docs-coherence-worktree`, now gitignored), so it never contends with the builder's working tree, the box, or the release train. Separate state file (`docs-coherence-state.json`).

## Why
Closes #1435.

## Risk
Low — adds a new skill + a gitignore line; no code, no existing-skill changes. Worst case the new loop is simply not invoked.

## Rollback
git revert is enough.

## Verification
- [x] Markdown/skill + gitignore only — no TS touched
- [ ] npm run lint (CI)
- [ ] npm run check:arch (CI)
- [ ] npm test (CI)
- [x] /verify not applicable (docs/skill fileset, never an install/config/auth/portal path)