### PR TITLE
fix(lldap): map UNIQUE-constraint duplicate to a friendly outcome

### DIFF
--- a/packages/backend/src/lib/lldap/client.createUser.test.ts
+++ b/packages/backend/src/lib/lldap/client.createUser.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig } = vi.hoisted(() => ({ mockGetConfig: vi.fn() }));
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+
+import { createLldapUser } from './client';
+
+const input = { id: 'alice', email: 'alice@example.com', displayName: 'Alice' };
+
+beforeEach(() => {
+  mockGetConfig.mockResolvedValue({ lldap: { url: 'http://lldap:17170', username: 'admin', password: 'pw' } });
+  vi.restoreAllMocks();
+});
+
+/** auth/simple/login succeeds, then the graphql call returns `graphqlBody`. */
+function stubFetch(graphqlBody: unknown) {
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => graphqlBody });
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+describe('createLldapUser duplicate handling (#1425)', () => {
+  it('maps a raw SQLite UNIQUE-constraint error on email to a friendly already-exists outcome', async () => {
+    stubFetch({ errors: [{ message: 'Execution Error: error returned from database: (code: 2067) UNIQUE constraint failed: users.lowercase_email' }] });
+
+    const res = await createLldapUser(input);
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('username_taken');
+      // The raw SQLite error must never reach the operator.
+      expect(res.message).not.toMatch(/UNIQUE constraint|code: 2067|database/i);
+      expect(res.message).toContain('alice@example.com');
+    }
+  });
+
+  it('maps a username UNIQUE-constraint error to a friendly username-taken message', async () => {
+    stubFetch({ errors: [{ message: 'UNIQUE constraint failed: users.user_id' }] });
+
+    const res = await createLldapUser(input);
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('username_taken');
+      expect(res.message).not.toMatch(/UNIQUE constraint/i);
+      expect(res.message).toContain('alice');
+    }
+  });
+
+  it('still maps the friendly "already exists" wording to username_taken', async () => {
+    stubFetch({ errors: [{ message: 'User already exists' }] });
+
+    const res = await createLldapUser(input);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('username_taken');
+  });
+
+  it('leaves an unrelated GraphQL error as graphql_error', async () => {
+    stubFetch({ errors: [{ message: 'schema validation failed' }] });
+
+    const res = await createLldapUser(input);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('graphql_error');
+  });
+
+  it('returns the created user on success', async () => {
+    stubFetch({ data: { createUser: { id: 'alice', displayName: 'Alice' } } });
+
+    const res = await createLldapUser(input);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.userId).toBe('alice');
+  });
+});

--- a/packages/backend/src/lib/lldap/client.ts
+++ b/packages/backend/src/lib/lldap/client.ts
@@ -141,8 +141,19 @@ function classifyCreateUserResponse(data: CreateUserResponse, input: CreateUserI
   if (data.errors?.length) {
     const msg = data.errors[0]?.message ?? 'Unknown LLDAP error.';
     const lower = msg.toLowerCase();
-    if (lower.includes('already exists') || lower.includes('duplicate')) {
-      return { ok: false, reason: 'username_taken', message: `The username "${input.id}" is already in use in LLDAP.` };
+    // A duplicate surfaces either as LLDAP's friendly "already exists"/"duplicate"
+    // text or as the raw SQLite UNIQUE-constraint error (e.g.
+    // "UNIQUE constraint failed: users.lowercase_email") — map both to a coherent
+    // "already in use" outcome so the raw DB error never reaches the operator (#1425).
+    if (lower.includes('already exists') || lower.includes('duplicate') || lower.includes('unique constraint')) {
+      const byEmail = lower.includes('email');
+      return {
+        ok: false,
+        reason: 'username_taken',
+        message: byEmail
+          ? `A user with the email "${input.email}" already exists in LLDAP.`
+          : `The username "${input.id}" is already in use in LLDAP.`,
+      };
     }
     return { ok: false, reason: 'graphql_error', message: msg };
   }


### PR DESCRIPTION
## What
Approving an access request whose email already exists in LLDAP leaked the raw SQLite error (`UNIQUE constraint failed: users.lowercase_email`) straight to the operator. The duplicate-detection in `classifyCreateUserResponse` only matched the friendly "already exists"/"duplicate" wording, so the raw constraint error fell through as a `graphql_error` and surfaced in the UI.

Broadens detection to also match `unique constraint` and returns an email- or username-aware "already in use" message. The raw DB error never reaches the UI (no frontend change needed — the API now returns a coherent message the existing UI already displays).

## Why
Closes #1425.

## Risk
Low — one backend error-mapping branch + a new unit test. Pure string-matching on an error path; the success path is unchanged.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, no new warnings)
- [x] npm run check:arch (passed)
- [x] npm test (1519 passed; 5 new tests cover email/username UNIQUE-constraint, friendly-wording, unrelated-error, and success)
- [x] /verify not applicable — `lib/lldap/client.ts` is not in the path-mandated list (no install/config/auth/portal/dashboard path touched)