### PR TITLE
fix(health): register domain checks from the live NPM route table

### DIFF
--- a/packages/backend/src/lib/health/domainChecks.test.ts
+++ b/packages/backend/src/lib/health/domainChecks.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig, mockGetProxyState, mockGetChecks, saved, deleted } = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockGetProxyState: vi.fn(),
+  mockGetChecks: vi.fn(),
+  saved: [] as Array<Record<string, unknown>>,
+  deleted: [] as string[],
+}));
+
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+vi.mock('../store/repository', () => ({ getProxyState: () => mockGetProxyState() }));
+vi.mock('./store', () => ({
+  HealthStore: {
+    getChecks: () => mockGetChecks(),
+    saveCheck: (c: Record<string, unknown>) => { saved.push(c); },
+    deleteCheck: (id: string) => { deleted.push(id); },
+  },
+}));
+vi.mock('../logger', () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+
+import { syncDomainChecks } from './domainChecks';
+
+const route = (host: string, targetPort: number, ssl: boolean) =>
+  ({ host, targetService: 'x', targetPort, ssl });
+
+beforeEach(() => {
+  saved.length = 0; deleted.length = 0;
+  mockGetConfig.mockResolvedValue({ reverseProxy: { hosts: [] } });
+  mockGetChecks.mockReturnValue([]);
+  mockGetProxyState.mockReturnValue({ provider: 'nginx', routes: [] });
+});
+
+describe('syncDomainChecks (#1416)', () => {
+  it('registers a check for every FQDN route and skips NPM-internal hosts', async () => {
+    mockGetProxyState.mockReturnValue({ routes: [
+      route('admin.dopp.cloud', 5888, true),
+      route('ldap.dopp.cloud', 17170, true),
+      route('nginxproxymanager', 3000, false),
+      route('localhost-nginx-proxy-manager', 80, true),
+    ]});
+
+    await syncDomainChecks();
+
+    const ids = saved.map(c => c.id);
+    expect(ids).toContain('domain:admin.dopp.cloud');
+    expect(ids).toContain('domain:ldap.dopp.cloud');
+    // NPM-internal hosts (no FQDN / localhost) are never registered.
+    expect(saved.some(c => c.target === 'nginxproxymanager' || c.target === 'localhost-nginx-proxy-manager')).toBe(false);
+
+    const admin = saved.find(c => c.id === 'domain:admin.dopp.cloud') as { domainConfig: Record<string, unknown> };
+    expect(admin.domainConfig.expectedScheme).toBe('https'); // from route.ssl
+    expect(admin.domainConfig.upstreamPort).toBe(5888);
+  });
+
+  it('prefers config exposure over the route TLS flag for known hosts', async () => {
+    mockGetConfig.mockResolvedValue({ reverseProxy: { hosts: [
+      { domain: 'ldap.dopp.cloud', forwardPort: 17170, exposure: 'lan' },
+    ]}});
+    mockGetProxyState.mockReturnValue({ routes: [route('ldap.dopp.cloud', 17170, true)] });
+
+    await syncDomainChecks();
+
+    const ldap = saved.find(c => c.id === 'domain:ldap.dopp.cloud') as { domainConfig: Record<string, unknown> };
+    expect(ldap.domainConfig.isPublic).toBe(false);      // exposure 'lan'
+    expect(ldap.domainConfig.expectedScheme).toBe('http'); // config wins over route.ssl
+  });
+
+  it('does NOT remove existing checks when the route snapshot is empty (transient)', async () => {
+    mockGetChecks.mockReturnValue([
+      { id: 'domain:admin.dopp.cloud', type: 'domain', target: 'admin.dopp.cloud', interval: 60, enabled: true, domainConfig: { expectedScheme: 'https', isPublic: true, upstreamPort: 5888 } },
+    ]);
+    mockGetProxyState.mockReturnValue({ routes: [] });
+
+    await syncDomainChecks();
+
+    expect(deleted).toEqual([]);
+  });
+
+  it('removes a domain check whose host vanished from NPM (non-empty snapshot)', async () => {
+    mockGetChecks.mockReturnValue([
+      { id: 'domain:gone.dopp.cloud', type: 'domain', target: 'gone.dopp.cloud', interval: 60, enabled: true, domainConfig: { expectedScheme: 'https', isPublic: true, upstreamPort: 1 } },
+    ]);
+    mockGetProxyState.mockReturnValue({ routes: [route('admin.dopp.cloud', 5888, true)] });
+
+    await syncDomainChecks();
+
+    expect(deleted).toContain('domain:gone.dopp.cloud');
+  });
+
+  it('does not churn an unchanged existing check', async () => {
+    mockGetChecks.mockReturnValue([
+      { id: 'domain:admin.dopp.cloud', type: 'domain', target: 'admin.dopp.cloud', interval: 60, enabled: true, created_at: 't', nodeName: 'Local', domainConfig: { expectedScheme: 'https', isPublic: true, upstreamPort: 5888 } },
+    ]);
+    mockGetProxyState.mockReturnValue({ routes: [route('admin.dopp.cloud', 5888, true)] });
+
+    await syncDomainChecks();
+
+    expect(saved).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/health/domainChecks.ts
+++ b/packages/backend/src/lib/health/domainChecks.ts
@@ -1,33 +1,33 @@
 /**
- * Auto-managed `domain`-type health checks for every persisted NPM
- * proxy host (`config.reverseProxy.hosts[]`). The health-check
- * runner already does the heavy lifting (60-s schedule, retention,
- * notifications); this helper just keeps the check list in sync
- * with the host list — adds, removes, and updates the `expectedScheme`
- * when an operator swaps LAN ↔ public.
+ * Auto-managed `domain`-type health checks for every reverse-proxy host.
  *
- * Convention: check.id = `domain:<domain>` so the lookup stays
- * deterministic and we never end up with duplicate-but-not-quite
- * checks if the host gets renamed.
+ * Source of truth is the **live NPM route table** (`getProxyState().routes`,
+ * the same list the Services overview / Network map render). Earlier this
+ * synced only from `config.reverseProxy.hosts` — which tracks just the hosts
+ * SB *provisioned itself* — so hosts created via service installs never got a
+ * check and their dots stayed grey (#1416). Config entries are still folded in
+ * (they carry richer `exposure` metadata, and cover the brief window at boot
+ * before the agent has populated the route table).
  *
- * Scheme rule (kept here so the UI and runner agree):
- *   - any host whose domain ends with `.home.arpa` → http
- *     (LAN-only routes, served without TLS)
- *   - anything else → https
- *     (public domain → NPM is meant to terminate TLS)
+ * Convention: check.id = `domain:<domain>` so the lookup stays deterministic
+ * and we never end up with duplicate-but-not-quite checks if a host is renamed.
  *
- * Public hosts also get `isPublic: true`, which the UI uses to
- * render the on-demand "Run external check" button against
- * letsdebug.net.
+ * Scheme rule:
+ *   - config-backed host → exposure-aware (public → https, LAN → http)
+ *   - route-only host     → the route's own TLS flag (`route.ssl`)
  *
- * Idempotent on every call; safe to invoke after each proxy-host
- * write and once at boot to catch entries that pre-date this
- * feature.
+ * Public hosts also get `isPublic: true`, which the UI uses to render the
+ * on-demand "Run external check" button against letsdebug.net.
+ *
+ * Idempotent on every call; safe to invoke after each proxy-host write, once
+ * at boot, and on a periodic timer to catch hosts NPM gained at runtime.
  */
 
 import { HealthStore } from './store';
 import type { CheckConfig } from './types';
 import { getConfig, type ProxyHostEntry } from '../config';
+import { getProxyState } from '../store/repository';
+import type { ProxyRoute } from '../agent/types';
 import { logger } from '../logger';
 
 const DOMAIN_CHECK_INTERVAL_SECONDS = 60;
@@ -38,19 +38,30 @@ function isLanDomain(domain: string): boolean {
 }
 
 /**
+ * Only real FQDNs get a domain check. NPM's own admin entries
+ * ("nginxproxymanager", "localhost-nginx-proxy-manager") and any bare
+ * hostname without a dot are skipped — they aren't user-facing domains.
+ */
+function isCheckableDomain(host: string): boolean {
+  return host.includes('.') && !host.startsWith('localhost');
+}
+
+function isManagedDomainCheck(check: CheckConfig): boolean {
+  return check.type === 'domain' && check.id.startsWith(DOMAIN_CHECK_PREFIX);
+}
+
+/**
  * Source of truth for "is this entry public or LAN-only?":
- *   1. Persisted `entry.exposure` (set since the publicDomain LAN
- *      switch — required because LAN-only hosts can now live on the
- *      same domain as public ones).
- *   2. Fallback to the legacy heuristic for entries persisted before
- *      that schema field existed.
+ *   1. Persisted `entry.exposure` (set since the publicDomain LAN switch).
+ *   2. Fallback to the legacy suffix heuristic for older entries.
  */
 function isPublicExposure(entry: ProxyHostEntry): boolean {
   if (entry.exposure) return entry.exposure === 'public';
   return !isLanDomain(entry.domain);
 }
 
-function buildCheck(entry: ProxyHostEntry, now: string): CheckConfig {
+/** Build a check from an SB-managed config host entry (exposure-aware). */
+function buildCheckFromConfig(entry: ProxyHostEntry, createdAt: string): CheckConfig {
   const isPublic = isPublicExposure(entry);
   return {
     id: `${DOMAIN_CHECK_PREFIX}${entry.domain}`,
@@ -59,7 +70,7 @@ function buildCheck(entry: ProxyHostEntry, now: string): CheckConfig {
     target: entry.domain,
     interval: DOMAIN_CHECK_INTERVAL_SECONDS,
     enabled: true,
-    created_at: now,
+    created_at: createdAt,
     nodeName: 'Local',
     domainConfig: {
       expectedScheme: isPublic ? 'https' : 'http',
@@ -70,49 +81,98 @@ function buildCheck(entry: ProxyHostEntry, now: string): CheckConfig {
 }
 
 /**
- * Walk the configured proxy hosts and ensure every one has a
- * matching domain-type health check. Removes domain checks for
- * hosts that have been deleted from `config.reverseProxy.hosts`.
- *
- * Best-effort: any storage error is logged and swallowed — domain
- * checks are nice-to-have observability, not load-bearing
- * functionality.
+ * Build a check from a live NPM route that has no config entry — derive the
+ * scheme from the route's own TLS flag and the public hint from the domain
+ * suffix (route data carries no exposure metadata).
+ */
+function buildCheckFromRoute(route: ProxyRoute, createdAt: string): CheckConfig {
+  const isPublic = !isLanDomain(route.host);
+  return {
+    id: `${DOMAIN_CHECK_PREFIX}${route.host}`,
+    name: `Domain — ${route.host}`,
+    type: 'domain',
+    target: route.host,
+    interval: DOMAIN_CHECK_INTERVAL_SECONDS,
+    enabled: true,
+    created_at: createdAt,
+    nodeName: 'Local',
+    domainConfig: {
+      expectedScheme: route.ssl ? 'https' : 'http',
+      isPublic,
+      upstreamPort: route.targetPort,
+    },
+  };
+}
+
+/** Operator-visible equality — don't churn the saved record (and bust the
+ *  result history) when nothing the operator sees has changed. */
+function sameDomainCheck(a: CheckConfig, b: CheckConfig): boolean {
+  return a.type === b.type
+    && a.target === b.target
+    && a.interval === b.interval
+    && a.enabled === b.enabled
+    && a.domainConfig?.expectedScheme === b.domainConfig?.expectedScheme
+    && a.domainConfig?.isPublic === b.domainConfig?.isPublic
+    && a.domainConfig?.upstreamPort === b.domainConfig?.upstreamPort;
+}
+
+/**
+ * Union of domains that should have a check: every checkable NPM route host
+ * (live truth), plus any config host (covers the boot window before the agent
+ * has populated the route table). Config wins on overlap — it carries the
+ * exposure metadata a raw route lacks.
+ */
+function computeWantedChecks(
+  routes: ProxyRoute[],
+  configByDomain: Map<string, ProxyHostEntry>,
+  createdAt: (id: string) => string,
+): Map<string, CheckConfig> {
+  const wanted = new Map<string, CheckConfig>();
+  for (const route of routes) {
+    if (!isCheckableDomain(route.host)) continue;
+    const id = `${DOMAIN_CHECK_PREFIX}${route.host}`;
+    const cfg = configByDomain.get(route.host);
+    wanted.set(id, cfg ? buildCheckFromConfig(cfg, createdAt(id)) : buildCheckFromRoute(route, createdAt(id)));
+  }
+  for (const [domain, entry] of configByDomain) {
+    if (!isCheckableDomain(domain)) continue;
+    const id = `${DOMAIN_CHECK_PREFIX}${domain}`;
+    if (!wanted.has(id)) wanted.set(id, buildCheckFromConfig(entry, createdAt(id)));
+  }
+  return wanted;
+}
+
+/**
+ * Ensure every reverse-proxy host has a matching `domain`-type health check,
+ * and remove checks for hosts that no longer exist. Best-effort: any storage
+ * error is logged and swallowed — domain checks are observability, not
+ * load-bearing.
  */
 export async function syncDomainChecks(): Promise<void> {
   try {
     const config = await getConfig();
-    const hosts = config.reverseProxy?.hosts ?? [];
+    const configByDomain = new Map<string, ProxyHostEntry>();
+    for (const h of config.reverseProxy?.hosts ?? []) configByDomain.set(h.domain, h);
+
+    const routes = getProxyState().routes ?? [];
     const existing = HealthStore.getChecks();
-    const wanted = new Map<string, ProxyHostEntry>();
-    for (const h of hosts) wanted.set(`${DOMAIN_CHECK_PREFIX}${h.domain}`, h);
-
     const now = new Date().toISOString();
+    const createdAt = (id: string) => existing.find(c => c.id === id)?.created_at ?? now;
 
-    // Add or refresh
-    for (const [id, host] of wanted) {
-      const current = existing.find(c => c.id === id);
-      const next = buildCheck(host, current?.created_at ?? now);
-      // Don't churn the saved record (and bust the result history) if
-      // the operator-visible state didn't change.
-      if (
-        current
-        && current.type === next.type
-        && current.target === next.target
-        && current.interval === next.interval
-        && current.enabled === next.enabled
-        && current.domainConfig?.expectedScheme === next.domainConfig?.expectedScheme
-        && current.domainConfig?.isPublic === next.domainConfig?.isPublic
-        && current.domainConfig?.upstreamPort === next.domainConfig?.upstreamPort
-      ) continue;
-      HealthStore.saveCheck(next);
+    const wanted = computeWantedChecks(routes, configByDomain, createdAt);
+
+    // Add or refresh.
+    for (const next of wanted.values()) {
+      const current = existing.find(c => c.id === next.id);
+      if (!current || !sameDomainCheck(current, next)) HealthStore.saveCheck(next);
     }
 
-    // Remove orphans
-    for (const check of existing) {
-      if (check.type !== 'domain') continue;
-      if (!check.id.startsWith(DOMAIN_CHECK_PREFIX)) continue;
-      if (!wanted.has(check.id)) {
-        HealthStore.deleteCheck(check.id);
+    // Remove orphans — but ONLY when we actually have a route view. A
+    // transient empty snapshot (agent not yet polled) must never wipe the
+    // existing checks.
+    if (routes.length > 0) {
+      for (const check of existing) {
+        if (isManagedDomainCheck(check) && !wanted.has(check.id)) HealthStore.deleteCheck(check.id);
       }
     }
   } catch (e) {

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -611,19 +611,23 @@ app.prepare().then(() => {
       logger.warn('Server', `Bootstrap-token expiry init failed: ${err instanceof Error ? err.message : String(err)}`),
     );
 
-    // Sync domain-reachability health checks with the configured
-    // proxy hosts. Catches entries that pre-date the feature, and
-    // removes orphans for hosts that were deleted while ServiceBay
-    // was down. Fire-and-forget — failures degrade to "no dot" in
-    // the UI, never block boot.
-    (async () => {
-      try {
-        const { syncDomainChecks } = await import('./lib/health/domainChecks');
-        await syncDomainChecks();
-      } catch (err) {
-        logger.warn('Server', `Domain-check sync failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    })();
+    // Sync domain-reachability health checks with the live NPM route table
+    // (#1416): a check per reverse-proxy host the agent reports, not just the
+    // SB-provisioned ones. Run once at boot and then on a 60s timer — boot-time
+    // routes are usually empty before the agent's first NPM poll, and NPM can
+    // gain hosts at runtime. Fire-and-forget; idempotent; never blocks boot.
+    {
+      const runDomainCheckSync = async () => {
+        try {
+          const { syncDomainChecks } = await import('./lib/health/domainChecks');
+          await syncDomainChecks();
+        } catch (err) {
+          logger.warn('Server', `Domain-check sync failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      };
+      void runDomainCheckSync();
+      setInterval(() => { void runDomainCheckSync(); }, 60_000);
+    }
 
     // Per-public-domain DNS routing health checks (15 min interval).
     // Replaces the old continuous letsdebug sweep (#letsdebug-429) —


### PR DESCRIPTION
## What
Domain health dots showed grey for most hosts because `syncDomainChecks` only iterated `config.reverseProxy.hosts` (the hosts SB provisioned itself) — on the box that's 4 of 16 NPM proxy hosts, so the other 12 had no check at all.

Now sources the check list from the **live NPM route table** (`getProxyState().routes`, what the Services/Network-map UI renders) unioned with config hosts, skipping NPM-internal non-FQDN entries (`nginxproxymanager`, `localhost-*`). Route-only hosts derive scheme from `route.ssl` and port from the route; config-backed hosts keep their exposure-aware behaviour. An empty-route snapshot never deletes existing checks. Also runs the sync on a **60s timer** (not just boot/migrate) so hosts NPM gains at runtime register within a minute — the existing `checks.json` watcher then schedules them.

Diagnosed live on the box (4.69.1): the "runner never executes" half of the report is already resolved — registered checks run green; the live fault was purely under-registration.

## Why
Closes #1416.

## Risk
Low — `lib/health` + a boot timer. Empty-route guard prevents transient wipes; sync stays idempotent (no churn when unchanged).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (392 warnings, 0 errors — no new warnings)
- [x] npm run check:arch (no dependency violations)
- [x] npm test (1524 passed; 5 new tests cover route registration, internal-host skip, config-exposure precedence, empty-route guard, orphan removal, no-churn)
- [ ] Box `:dev` verify — confirm all NPM hosts register a green domain check (batched at end of this autoloop firing)