### PR TITLE
fix(install): warn when a pod-YAML variable renders empty

### DIFF
--- a/packages/backend/src/lib/install/findEmptyYamlVars.test.ts
+++ b/packages/backend/src/lib/install/findEmptyYamlVars.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { findEmptyYamlVars } from './runner';
+
+describe('findEmptyYamlVars (#1318)', () => {
+  it('flags a direct {{VAR}} with no value in the view', () => {
+    const yaml = 'image: myapp:{{IMAGE_TAG}}';
+    expect(findEmptyYamlVars(yaml, { IMAGE_TAG: '' })).toEqual(['IMAGE_TAG']);
+  });
+
+  it('flags a direct ref absent from the view entirely', () => {
+    expect(findEmptyYamlVars('port: {{APP_PORT}}', {})).toEqual(['APP_PORT']);
+  });
+
+  it('does not flag a direct ref that has a value', () => {
+    expect(findEmptyYamlVars('port: {{APP_PORT}}', { APP_PORT: '8080' })).toEqual([]);
+  });
+
+  it('flags an empty triple-stache {{{VAR}}}', () => {
+    expect(findEmptyYamlVars('x: {{{RAW}}}', { RAW: '' })).toEqual(['RAW']);
+  });
+
+  it('does NOT flag a var used only as a Mustache section (optional conditional)', () => {
+    const yaml = [
+      '{{#ZWAVE_DEVICE}}',
+      '  devices:',
+      '    - {{ZWAVE_DEVICE}}',
+      '{{/ZWAVE_DEVICE}}',
+    ].join('\n');
+    // ZWAVE_DEVICE is section-guarded — empty is legitimate (no zwave stick).
+    expect(findEmptyYamlVars(yaml, { ZWAVE_DEVICE: '' })).toEqual([]);
+  });
+
+  it('only reports each missing var once and ignores filled ones', () => {
+    const yaml = 'a: {{ONE}}\nb: {{ONE}}\nc: {{TWO}}\nd: {{THREE}}';
+    const out = findEmptyYamlVars(yaml, { ONE: '', TWO: 'set', THREE: '' }).sort();
+    expect(out).toEqual(['ONE', 'THREE']);
+  });
+
+  it('treats whitespace inside the braces the same', () => {
+    expect(findEmptyYamlVars('x: {{  SPACED  }}', { SPACED: '' })).toEqual(['SPACED']);
+  });
+});

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -380,6 +380,25 @@ interface DeployContext {
   reusedSecretNames: Set<string>;
 }
 
+/**
+ * #1318 — find direct `{{VAR}}` interpolations in a pod template that would
+ * render empty against `view`. Mustache turns an unfilled var into '', which
+ * silently deploys a broken pod (empty image tag / env / mount) with no
+ * breadcrumb. Section refs (`{{#VAR}}` / `{{^VAR}}` / `{{/VAR}}`) are
+ * conditionals that are legitimately empty (e.g. `{{#ZWAVE_DEVICE}}`), so a
+ * var used in a section is treated as optional and excluded; only *direct*
+ * interpolations are considered. The caller warns (does not hard-fail) — some
+ * direct refs are legitimately optional (an SSH key OR a password) and the
+ * variable schema carries no `required` flag to tell them apart.
+ */
+export function findEmptyYamlVars(yaml: string, view: Record<string, string>): string[] {
+  const sectionVars = new Set<string>();
+  for (const m of yaml.matchAll(/\{\{\s*[#^/]\s*([A-Z_][A-Z0-9_]*)\s*\}\}/g)) sectionVars.add(m[1]);
+  const directRefs = new Set<string>();
+  for (const m of yaml.matchAll(/\{\{\{?\s*([A-Z_][A-Z0-9_]*)\s*\}{2,3}/g)) directRefs.add(m[1]);
+  return [...directRefs].filter(r => !sectionVars.has(r) && (!(r in view) || view[r] === ''));
+}
+
 /** Deploy a single template via /api/services?stream=1. Returns true on
  *  successful deploy, false on terminal failure. Retries transient
  *  failures up to MAX_DEPLOY_ATTEMPTS. */
@@ -405,6 +424,18 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
   Object.assign(view, authDynamicVars(item.name));
   // Render YAML with unified template renderer
   const yamlContent = renderTemplate(item.yaml, view);
+
+  // #1318 — the pod YAML had no missing-var guard (config files did), so an
+  // unfilled {{VAR}} rendered empty and deployed silently. Surface a
+  // breadcrumb for any direct ref that rendered empty so a crash-looping pod
+  // traces back to the unfilled variable. Warn rather than hard-fail: some
+  // direct refs are legitimately optional and there is no required flag.
+  const emptyYamlVars = findEmptyYamlVars(item.yaml, view);
+  if (emptyYamlVars.length > 0) {
+    await log(jobId, `⚠️ ${item.name}: pod template variable(s) rendered empty: ${emptyYamlVars.join(', ')}. ` +
+      `If any are required, go back to Configure and fill them in (or check the template's variables.json defaults) — an empty value can crash-loop the pod.`);
+  }
+
   const kubeContent =
     `[Kube]\nYaml=${item.name}.yml\nAutoUpdate=registry\n\n[Install]\nWantedBy=default.target`;
 


### PR DESCRIPTION
## What
The install runner's missing-variable guard covered config files but **not the pod YAML** (`runner.ts:407` renders `item.yaml`, but the sanity check only iterated `item.configFiles`). So an unfilled `{{VAR}}` in `template.yml` rendered to `''` and deployed silently — a malformed/crash-looping pod with no breadcrumb back to the unfilled variable.

Adds `findEmptyYamlVars`: scans the pod template for **direct** `{{VAR}}` interpolations that render empty, **excluding Mustache section refs** (`{{#VAR}}`/`{{^VAR}}`/`{{/VAR}}`) which are legitimately-empty conditionals (e.g. `{{#ZWAVE_DEVICE}}`). The deploy logs a clear breadcrumb listing the empty vars.

**Warn, not hard-fail** (config files hard-fail): some direct YAML refs are legitimately optional — e.g. an SSH key *or* a password — and the variable schema has no `required` flag to tell required from optional apart. A blanket hard-fail would false-positive and block valid installs (the exact risk the issue flagged). Warning kills the *silent* failure with zero false-positive risk; a `required`-flag-driven hard-fail can be a follow-up if wanted.

## Why
Closes #1318.

## Risk
Very low — additive log line only; cannot change any deploy's success/failure. Section refs excluded so the one optional-conditional var in the templates (`ZWAVE_DEVICE`) is not flagged.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (392 warnings, 0 errors — no new)
- [x] npm run check:arch (no violations)
- [x] npm test (1531 passed; 7 new tests: direct-empty, absent, valued, triple-stache, section-optional exclusion, dedup, whitespace)
- [x] Box `/verify`: not required — the change is warn-only (a log line), so it cannot block/break an install; the original box-verify concern (false-positive hard-fails) is eliminated by design. Live breadcrumb will appear on the box's next natural install.