### PR TITLE
feat(settings): re-download the credentials CSV from Saved credentials

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -1,17 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Eye, EyeOff, Key, Loader2, Trash2 } from 'lucide-react';
+import { Download, Eye, EyeOff, Key, Loader2, Trash2 } from 'lucide-react';
+import { buildBitwardenCsv, type Credential } from '@servicebay/api-client';
 import { useToast } from '@/providers/ToastProvider';
-
-interface Credential {
-  service: string;
-  url: string;
-  username: string;
-  password: string;
-  importance: 'critical' | 'system';
-  notes?: string;
-}
 
 interface Manifest {
   savedAt: string;
@@ -68,6 +60,17 @@ export default function CredentialsSection() {
     }
   };
 
+  const downloadCsv = () => {
+    if (!manifest || manifest.credentials.length === 0) return;
+    const blob = new Blob([buildBitwardenCsv(manifest.credentials)], { type: 'text/csv' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `servicebay-credentials-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+    addToast('success', 'Credentials CSV downloaded', 'Re-import it into Bitwarden/Vaultwarden, then consider wiping the server copy.');
+  };
+
   if (busy === 'load') {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
@@ -92,15 +95,25 @@ export default function CredentialsSection() {
           </p>
         </div>
         {manifest && manifest.credentials.length > 0 && (
-          <button
-            onClick={onWipe}
-            disabled={busy === 'wipe'}
-            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
-            title="Remove the saved credentials from the server. Useful once you've stored them safely in your password manager."
-          >
-            {busy === 'wipe' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
-            Wipe from server
-          </button>
+          <div className="shrink-0 flex items-center gap-2">
+            <button
+              onClick={downloadCsv}
+              className="inline-flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg"
+              title="Download the saved credentials as a Bitwarden/Vaultwarden-importable CSV."
+            >
+              <Download size={14} />
+              Download CSV
+            </button>
+            <button
+              onClick={onWipe}
+              disabled={busy === 'wipe'}
+              className="inline-flex items-center gap-2 px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+              title="Remove the saved credentials from the server. Useful once you've stored them safely in your password manager."
+            >
+              {busy === 'wipe' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+              Wipe from server
+            </button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## What
The Bitwarden/Vaultwarden credentials CSV was only offered **once**, at install time (the Done step / per-stack flow, behind a "won't be shown again" banner). If the operator dismissed it, there was no way to get it back — even though the credentials are persisted in `config.installManifest.credentials`.

Adds a **"Download CSV"** button to the *Saved credentials* settings section. It rebuilds the CSV **client-side** from the already-loaded manifest via the same `buildBitwardenCsv` helper the install flow uses (imported from `@servicebay/api-client`). No backend change — the section already fetches the full manifest.

## Why
Closes #1286.

## Risk
Low — additive UI button reusing an existing, tested CSV builder + the existing manifest fetch. No new data path.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (392 warnings, 0 errors — no new; the max-lines warning on this component pre-existed)
- [x] npm run check:arch (no violations)
- [x] tsc --noEmit (0 source errors — `Credential` type imported from api-client)
- [x] npm test (1531 passed)
- [ ] Browser `/verify` on `:dev` (path-mandated `settings/(dashboard)`) — confirm the button appears in Saved credentials and downloads a valid CSV; batched with the live check of #1416's domain dots.