### PR TITLE
batch: install self-heal, network-map grouping, sidebar dedup, MCP token re-activate, access cap

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -397,6 +397,12 @@ export interface AppConfig {
    */
   accessRequests?: AccessRequest[];
   /**
+   * Max users allowed = approved LLDAP users + pending access requests.
+   * New portal access requests are rejected once the count reaches this.
+   * Default 20 when unset; set lower (e.g. 5) for a small household. (#1426)
+   */
+  maxUsers?: number;
+  /**
    * Per-job log caps (#1098 Phase 1). Long-running installs and noisy
    * mass deploys can balloon `logs.db` without bound; these limits
    * give the logger a hard ceiling per job. Phase 2 wires the rotation

--- a/packages/backend/src/lib/config/schema.ts
+++ b/packages/backend/src/lib/config/schema.ts
@@ -67,6 +67,7 @@ const AppConfigSchema = z.object({
   serviceMigrations: z.record(z.string(), looseArray).optional(),
   installManifest: looseObject.optional(),
   accessRequests: looseArray.optional(),
+  maxUsers: z.number().int().positive().max(100000).optional(),
 }).strict();
 
 /**

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -1326,6 +1326,30 @@ async function runJob(jobId: string): Promise<void> {
     }
   }
 
+  // NPM admin self-heal (#1268, credential-reconciliation ARCH-15) — must run
+  // BEFORE proxy-host + portal provisioning (both need a working NPM admin
+  // login) and on EVERY install, not just when nginx is freshly installed.
+  // The failing case (#1268): a new stack with an internal subdomain installed
+  // onto a box whose nginx was already present with an empty/diverged NPM
+  // password — the old gate (fresh-nginx only, and positioned after this step)
+  // skipped the heal, so per-service proxy hosts + portal routing failed with
+  // no recovery on every (re)install. npmAdminCredStatus self-skips ('unknown')
+  // when NPM isn't reachable, so this is a cheap no-op for NPM-less installs.
+  // Best-effort; never fatal (the npm_data_stale diagnose action is the manual
+  // fallback). rekeyNpmAdmin writes NPM's admin hash directly, so it recovers
+  // even when ServiceBay's stored password is empty.
+  try {
+    const npmNode = input.node || 'Local';
+    const status = await npmAdminCredStatus(npmNode);
+    if (status === 'rejected' || status === 'no-creds') {
+      await log(jobId, '🔑 NPM is rejecting/missing the stored admin credentials — re-keying in place (proxy routes preserved)…');
+      const r = await rekeyNpmAdmin(npmNode);
+      await log(jobId, (r.ok ? '✅ ' : '⚠️ ') + r.message);
+    }
+  } catch (e) {
+    await log(jobId, `(note) NPM admin reconcile skipped: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
   // #807 — guarantee every service subdomain has an NPM proxy host,
   // regardless of whether each per-template `feature.installed` emit
   // created its own. Idempotent: re-creating an existing host no-ops.
@@ -1381,27 +1405,6 @@ async function runJob(jobId: string): Promise<void> {
   // containers, which on a fresh install reported a misleading failure
   // (the proxy/DNS *were* being installed, just not up yet).
   await settleWait(jobId, ctx.deployed, input.node || 'Local');
-
-  // NPM admin self-heal (credential-reconciliation, ARCH-15). If nginx is
-  // in this install and its persisted DB holds an admin password
-  // ServiceBay can't authenticate with (empty/diverged across a
-  // reinstall), re-key it in place — non-destructive, every proxy route
-  // preserved — so the portal provisioning below can actually manage NPM.
-  // Best-effort; never fatal (the npm_data_stale diagnose action is the
-  // manual fallback).
-  if (selected.some(s => s.name === 'nginx' && !s.alreadyInstalled)) {
-    try {
-      const node = input.node || 'Local';
-      const status = await npmAdminCredStatus(node);
-      if (status === 'rejected' || status === 'no-creds') {
-        await log(jobId, '🔑 NPM is rejecting/missing the stored admin credentials — re-keying in place (proxy routes preserved)…');
-        const r = await rekeyNpmAdmin(node);
-        await log(jobId, (r.ok ? '✅ ' : '⚠️ ') + r.message);
-      }
-    } catch (e) {
-      await log(jobId, `(note) NPM admin reconcile skipped: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
 
   // Portal routing — apex + wildcard rewrites for the active domain.
   // Always runs after a successful install (#707). Pre-fix this was

--- a/packages/backend/src/lib/mcp/bootstrapToken.test.ts
+++ b/packages/backend/src/lib/mcp/bootstrapToken.test.ts
@@ -18,6 +18,7 @@ import {
   verifyBootstrapToken,
   revokeBootstrapToken,
   getBootstrapTokenStatus,
+  reactivateBootstrapToken,
 } from './bootstrapToken';
 import { getConfig, updateConfig } from '@/lib/config';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
@@ -209,7 +210,7 @@ describe('revokeBootstrapToken', () => {
 describe('getBootstrapTokenStatus', () => {
   it('returns inactive when no token', async () => {
     mockGetConfig.mockResolvedValue({ auth: {} });
-    expect(await getBootstrapTokenStatus()).toEqual({ active: false });
+    expect(await getBootstrapTokenStatus()).toEqual({ active: false, present: false });
   });
 
   it('returns active + minutes remaining when within window', async () => {
@@ -238,7 +239,7 @@ describe('getBootstrapTokenStatus', () => {
         },
       },
     });
-    expect(await getBootstrapTokenStatus()).toEqual({ active: false });
+    expect(await getBootstrapTokenStatus()).toEqual({ active: false, present: true });
   });
 
   it('returns active when expired but a setup job was active recently', async () => {
@@ -252,7 +253,29 @@ describe('getBootstrapTokenStatus', () => {
       },
     });
     mockWasInstallActiveWithin.mockResolvedValue(true);
-    expect(await getBootstrapTokenStatus()).toEqual({ active: true, expiresAt: null, minutesRemaining: null });
+    expect(await getBootstrapTokenStatus()).toEqual({ active: true, present: true, expiresAt: null, minutesRemaining: null });
+  });
+});
+
+describe('reactivateBootstrapToken (#1419)', () => {
+  it('re-issues the same token with a fresh ~30 min window', async () => {
+    mockGetConfig.mockResolvedValue({ auth: { bootstrapToken: { hash: 'abc', scope: 'read', expiresAt: new Date(Date.now() - 60_000).toISOString() } } });
+    const r = await reactivateBootstrapToken();
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.minutesRemaining).toBe(30);
+      expect(Date.parse(r.expiresAt)).toBeGreaterThan(Date.now());
+    }
+    const arg = mockUpdateConfig.mock.calls[0][0];
+    expect(arg.auth.bootstrapToken.hash).toBe('abc');
+    expect(Date.parse(arg.auth.bootstrapToken.expiresAt)).toBeGreaterThan(Date.now());
+  });
+
+  it('is a no-op (no-bootstrap-token) once the entry was revoked', async () => {
+    mockGetConfig.mockResolvedValue({ auth: {} });
+    const r = await reactivateBootstrapToken();
+    expect(r).toEqual({ ok: false, reason: 'no-bootstrap-token' });
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/lib/mcp/bootstrapToken.ts
+++ b/packages/backend/src/lib/mcp/bootstrapToken.ts
@@ -187,16 +187,19 @@ export async function revokeBootstrapToken(): Promise<boolean> {
   return true;
 }
 
-/** Surface state for the Settings UI. */
+/** Surface state for the Settings UI. `present` is true whenever the
+ *  bootstrap entry still exists (hash set) even if its window has lapsed —
+ *  the UI uses it to offer re-activation (#1419). Once a named token is
+ *  minted the entry is deleted, so `present` goes false permanently. */
 export async function getBootstrapTokenStatus(): Promise<
-  | { active: false }
-  | { active: true; expiresAt: string | null; minutesRemaining: number | null }
+  | { active: false; present: boolean }
+  | { active: true; present: true; expiresAt: string | null; minutesRemaining: number | null }
 > {
   const config = await getConfig();
   const bt = config.auth?.bootstrapToken;
-  if (!bt?.hash) return { active: false };
+  if (!bt?.hash) return { active: false, present: false };
   if (!bt.expiresAt) {
-    return { active: true, expiresAt: null, minutesRemaining: null };
+    return { active: true, present: true, expiresAt: null, minutesRemaining: null };
   }
   const remainingMs = Date.parse(bt.expiresAt) - Date.now();
   if (remainingMs <= 0) {
@@ -206,14 +209,35 @@ export async function getBootstrapTokenStatus(): Promise<
       const { wasInstallActiveWithin } = await import('@/lib/install/jobStore');
       const isRecent = await wasInstallActiveWithin(30 * 60 * 1000);
       if (isRecent) {
-        return { active: true, expiresAt: null, minutesRemaining: null };
+        return { active: true, present: true, expiresAt: null, minutesRemaining: null };
       }
     } catch {}
-    return { active: false };
+    // Hash still present but the window lapsed — re-activatable.
+    return { active: false, present: true };
   }
   return {
     active: true,
+    present: true,
     expiresAt: bt.expiresAt,
     minutesRemaining: Math.floor(remainingMs / 60_000),
   };
+}
+
+/** Re-activate (un-expire) the existing bootstrap token for another TTL_MIN
+ *  window — same hash/identity, so an already-configured MCP client keeps
+ *  working after it. No-op if the entry was already revoked (the first
+ *  named-token mint deletes it). The token stays LAN-only + read-scope: its
+ *  own verify gate (isLanIp) is unchanged, so re-activation only resets the
+ *  clock. (#1419) */
+export async function reactivateBootstrapToken(): Promise<
+  | { ok: true; expiresAt: string; minutesRemaining: number }
+  | { ok: false; reason: 'no-bootstrap-token' }
+> {
+  const config = await getConfig();
+  const bt = config.auth?.bootstrapToken;
+  if (!bt?.hash) return { ok: false, reason: 'no-bootstrap-token' };
+  const expiresAt = new Date(Date.now() + TTL_MIN * 60 * 1000).toISOString();
+  await updateConfig({ auth: { bootstrapToken: { ...bt, expiresAt } } });
+  logger.info('mcp:bootstrap', `Re-activated bootstrap token; expiresAt=${expiresAt} (${TTL_MIN} min).`);
+  return { ok: true, expiresAt, minutesRemaining: TTL_MIN };
 }

--- a/packages/backend/src/lib/portal/userCap.test.ts
+++ b/packages/backend/src/lib/portal/userCap.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockListLldapUsers } = vi.hoisted(() => ({ mockListLldapUsers: vi.fn() }));
+vi.mock('@/lib/lldap/client', () => ({ listLldapUsers: () => mockListLldapUsers() }));
+
+import { isOverUserLimit, DEFAULT_MAX_USERS } from './userCap';
+
+const usersOk = (n: number) => ({ ok: true, users: Array.from({ length: n }, (_, i) => ({ id: `u${i}` })) });
+
+beforeEach(() => vi.restoreAllMocks());
+
+describe('isOverUserLimit (#1426)', () => {
+  it('default cap is 20', () => {
+    expect(DEFAULT_MAX_USERS).toBe(20);
+  });
+
+  it('is over when approved users + pending reach the limit', async () => {
+    mockListLldapUsers.mockResolvedValue(usersOk(4));
+    expect(await isOverUserLimit(5, 1)).toBe(true);  // 4 + 1 >= 5
+    expect(await isOverUserLimit(5, 2)).toBe(true);  // 4 + 2 >  5
+  });
+
+  it('is under when there is room', async () => {
+    mockListLldapUsers.mockResolvedValue(usersOk(3));
+    expect(await isOverUserLimit(5, 1)).toBe(false); // 3 + 1 < 5
+  });
+
+  it('counts pending requests against the limit (blocks before approval)', async () => {
+    mockListLldapUsers.mockResolvedValue(usersOk(0));
+    expect(await isOverUserLimit(3, 3)).toBe(true);  // 0 users but 3 pending == 3
+  });
+
+  it('fails open (false) when LLDAP is unreachable — cannot size the cap', async () => {
+    mockListLldapUsers.mockResolvedValue({ ok: false, reason: 'unreachable', message: 'down' });
+    expect(await isOverUserLimit(1, 99)).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/portal/userCap.ts
+++ b/packages/backend/src/lib/portal/userCap.ts
@@ -1,0 +1,19 @@
+import { listLldapUsers } from '@/lib/lldap/client';
+
+/** Default max users (approved LLDAP users + pending access requests) when
+ *  `config.maxUsers` is unset. A small household can set it lower (#1426). */
+export const DEFAULT_MAX_USERS = 20;
+
+/**
+ * Is the server at/over its user cap? Denominator = approved LLDAP users +
+ * pending access requests (#1426).
+ *
+ * Best-effort on the LLDAP count: if LLDAP is unreachable we can't size the
+ * cap, so this returns `false` (the caller falls back to the pending-request
+ * guard rather than block legitimate requests on an LLDAP hiccup).
+ */
+export async function isOverUserLimit(maxUsers: number, pendingCount: number): Promise<boolean> {
+  const usersResult = await listLldapUsers();
+  if (!usersResult.ok) return false;
+  return usersResult.users.length + pendingCount >= maxUsers;
+}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -19,8 +19,8 @@ interface TokenView {
 }
 
 type BootstrapStatus =
-  | { active: false }
-  | { active: true; expiresAt: string | null; minutesRemaining: number | null };
+  | { active: false; present?: boolean }
+  | { active: true; present?: boolean; expiresAt: string | null; minutesRemaining: number | null };
 
 const SCOPE_BADGE: Record<ApiScope, string> = {
   destroy: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300',
@@ -30,27 +30,38 @@ const SCOPE_BADGE: Record<ApiScope, string> = {
   read: 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
 };
 
-function BootstrapBanner({ status, revoking, onRevoke }: { status: BootstrapStatus; revoking: boolean; onRevoke: () => void }) {
-  if (!status.active) return null;
+function BootstrapBanner({ status, revoking, reactivating, onRevoke, onReactivate }: { status: BootstrapStatus; revoking: boolean; reactivating: boolean; onRevoke: () => void; onReactivate: () => void }) {
+  // Show whenever the bootstrap entry still exists — including after its
+  // window lapsed — so an expired token can be re-activated (#1419).
+  if (!status.active && !status.present) return null;
+  const btnClass = 'text-xs font-medium px-3 py-1.5 rounded-lg border border-amber-300 dark:border-amber-700 text-amber-900 dark:text-amber-100 bg-white dark:bg-amber-900/40 hover:bg-amber-100 dark:hover:bg-amber-900/60 disabled:opacity-50';
   return (
     <div className="mt-4 rounded-lg border border-amber-200 dark:border-amber-700/40 bg-amber-50/80 dark:bg-amber-900/20 px-4 py-3 flex items-start justify-between gap-4">
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-amber-900 dark:text-amber-200">Bootstrap token active</p>
+        <p className="text-sm font-medium text-amber-900 dark:text-amber-200">{status.active ? 'Bootstrap token active' : 'Bootstrap token expired'}</p>
         <p className="text-xs text-amber-800/90 dark:text-amber-200/80 mt-0.5">
-          {status.minutesRemaining !== null
-            ? `LAN-only, read scope, ${status.minutesRemaining} min remaining.`
-            : 'LAN-only, read scope. Expiry will be set on next server boot.'}
+          {status.active
+            ? (status.minutesRemaining !== null
+                ? `LAN-only, read scope, ${status.minutesRemaining} min remaining.`
+                : 'LAN-only, read scope. Expiry will be set on next server boot.')
+            : 'LAN-only, read scope. Re-activate to reconnect an MCP client for ~30 min — same token, no new credential.'}
           {' '}Auto-revokes when you mint your first regular token below.
         </p>
       </div>
-      <button
-        type="button"
-        disabled={revoking}
-        onClick={onRevoke}
-        className="shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg border border-amber-300 dark:border-amber-700 text-amber-900 dark:text-amber-100 bg-white dark:bg-amber-900/40 hover:bg-amber-100 dark:hover:bg-amber-900/60 disabled:opacity-50"
-      >
-        {revoking ? 'Revoking…' : 'Revoke now'}
-      </button>
+      <div className="shrink-0 flex items-center gap-2">
+        <button
+          type="button"
+          disabled={reactivating}
+          onClick={onReactivate}
+          className={btnClass}
+          title="Re-issue the existing LAN-only bootstrap token for another ~30 minutes so an MCP client can reconnect — same token value."
+        >
+          {reactivating ? 'Re-activating…' : 'Re-activate (30 min)'}
+        </button>
+        <button type="button" disabled={revoking} onClick={onRevoke} className={btnClass}>
+          {revoking ? 'Revoking…' : 'Revoke now'}
+        </button>
+      </div>
     </div>
   );
 }
@@ -171,6 +182,7 @@ function CreateTokenForm(props: CreateTokenFormProps) {
 export default function ApiTokensSection() {
   const [bootstrap, setBootstrap] = useState<BootstrapStatus | null>(null);
   const [revokingBootstrap, setRevokingBootstrap] = useState(false);
+  const [reactivatingBootstrap, setReactivatingBootstrap] = useState(false);
   const [tokens, setTokens] = useState<TokenView[] | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
@@ -209,6 +221,18 @@ export default function ApiTokensSection() {
       loadBootstrap();
     } finally {
       setRevokingBootstrap(false);
+    }
+  };
+
+  // Re-issue the existing bootstrap token for another ~30 min (#1419) — same
+  // token value, so an MCP client reconnects without a fresh credential.
+  const reactivateBootstrap = async () => {
+    setReactivatingBootstrap(true);
+    try {
+      await fetch('/api/system/mcp-bootstrap', { method: 'POST' });
+      loadBootstrap();
+    } finally {
+      setReactivatingBootstrap(false);
     }
   };
 
@@ -271,7 +295,7 @@ export default function ApiTokensSection() {
         </div>
       </div>
 
-      {bootstrap && <BootstrapBanner status={bootstrap} revoking={revokingBootstrap} onRevoke={revokeBootstrap} />}
+      {bootstrap && <BootstrapBanner status={bootstrap} revoking={revokingBootstrap} reactivating={reactivatingBootstrap} onRevoke={revokeBootstrap} onReactivate={reactivateBootstrap} />}
 
       <div className="mt-4 space-y-3">
         <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/packages/frontend/src/app/api/system/access-requests/route.ts
+++ b/packages/frontend/src/app/api/system/access-requests/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import crypto from 'crypto';
 import { getConfig, saveConfig, getAdminBaseUrl, type AccessRequest } from '@/lib/config';
 import { sendEmailAlert } from '@/lib/email';
+import { isOverUserLimit, DEFAULT_MAX_USERS } from '@/lib/portal/userCap';
 import { logger } from '@/lib/logger';
 import { withApiHandler } from '@/lib/api/handler';
 
@@ -54,6 +55,31 @@ const PostBody = z.object({
   lastName: z.string().trim().min(1).max(60).optional(),
 });
 
+/**
+ * Rate-limit / capacity guard for the public access-request endpoint (#1426).
+ * Returns a 429 response when either cap is hit, else null:
+ *   - MAX_PENDING pending requests (anti-spam, config-free), or
+ *   - approved LLDAP users + pending >= config.maxUsers (default 20). The
+ *     LLDAP count is best-effort: if LLDAP is unreachable we can't size the
+ *     user cap, so we fall back to the pending guard rather than block
+ *     legitimate requests on an LLDAP hiccup.
+ */
+async function rejectIfCapped(maxUsers: number, pendingCount: number): Promise<NextResponse | null> {
+  if (pendingCount >= MAX_PENDING) {
+    return NextResponse.json(
+      { error: 'Too many pending requests right now. The family admin needs to review the existing ones first.' },
+      { status: 429 },
+    );
+  }
+  if (await isOverUserLimit(maxUsers, pendingCount)) {
+    return NextResponse.json(
+      { error: `This home server has reached its user limit (${maxUsers}). Ask the admin to remove an inactive account or raise the limit in Settings.` },
+      { status: 429 },
+    );
+  }
+  return null;
+}
+
 export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
   // Cap raw body size so a hostile client can't push gigabytes.
   // Next.js doesn't enforce this by default for route handlers.
@@ -75,12 +101,8 @@ export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
   const config = await getConfig();
   const existing = config.accessRequests ?? [];
   const pending = existing.filter(r => r.status === 'pending');
-  if (pending.length >= MAX_PENDING) {
-    return NextResponse.json(
-      { error: 'Too many pending requests right now. The family admin needs to review the existing ones first.' },
-      { status: 429 },
-    );
-  }
+  const capResponse = await rejectIfCapped(config.maxUsers ?? DEFAULT_MAX_USERS, pending.length);
+  if (capResponse) return capResponse;
 
   // Compose display name from firstName/lastName when both are
   // provided (new clients); otherwise fall back to the free-text

--- a/packages/frontend/src/app/api/system/mcp-bootstrap/route.ts
+++ b/packages/frontend/src/app/api/system/mcp-bootstrap/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getBootstrapTokenStatus, revokeBootstrapToken } from '@/lib/mcp/bootstrapToken';
+import { getBootstrapTokenStatus, revokeBootstrapToken, reactivateBootstrapToken } from '@/lib/mcp/bootstrapToken';
 import { withApiHandler } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
@@ -17,4 +17,21 @@ export const GET = withApiHandler({}, async () => {
 export const DELETE = withApiHandler({}, async () => {
   const removed = await revokeBootstrapToken();
   return NextResponse.json({ ok: true, removed });
+});
+
+/**
+ * POST = re-activate (un-expire) the existing bootstrap token for another
+ * ~30 min window (#1419). Same token identity, so an already-configured MCP
+ * client reconnects without a fresh mint. Admin-session gated by
+ * withApiHandler; the token itself stays LAN-only + read-scope (its verify
+ * gate is unchanged). 409 when there's no bootstrap entry to re-activate
+ * (revoked after the first named-token mint).
+ */
+export const POST = withApiHandler({}, async () => {
+  const result = await reactivateBootstrapToken();
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, reason: result.reason }, { status: 409 });
+  }
+  const status = await getBootstrapTokenStatus();
+  return NextResponse.json({ ok: true, expiresAt: result.expiresAt, minutesRemaining: result.minutesRemaining, status });
 });

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -286,10 +286,12 @@ export default function Sidebar() {
                     )}
                 </div>
             )}
-            {/* Where this ServiceBay lives — "<user> on <domain>" (#249,
-                relocated here from the page header's ModeBadge). */}
+            {/* Where this ServiceBay lives — just the domain. The signed-in
+                username is already shown in the chip above, so pass null to drop
+                the redundant "<user> on " prefix (#1424). Explicit null is
+                honoured (no self-fetch). */}
             <div className={isCollapsed ? '' : 'px-3.5 py-0.5'}>
-                <DomainTag username={currentUser ? currentUser.username : null} collapsed={isCollapsed} />
+                <DomainTag username={null} collapsed={isCollapsed} />
             </div>
             {currentUser && (
                 <button

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -233,11 +233,25 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
     const dedupedPorts = Array.from(uniquePortsMap.values());
 
     const uniqueIps = Array.from(new Set(dedupedPorts.map((p) => p.ip).filter(Boolean))) as string[];
-    // If exactly one unique IP is found across all ports, show it globally. 
-    // Otherwise (0 or >1), show IPs on tags individually.
+    // If exactly one unique IP is found across all ports, show it globally.
+    // Otherwise (0 or >1) we tag IPs per port — but #1428: when a node's ports
+    // span multiple bind addresses (e.g. file-share's mix of localhost + LAN),
+    // showing the prefix on EVERY port balloons the card. Group ports by IP and
+    // show each prefix once per group: sort to cluster groups, mark the first
+    // port of each group with `showIp`. No info lost (loopback vs LAN still clear).
     const globalIp = uniqueIps.length === 1 ? uniqueIps[0] : null;
 
-    return { globalIp, portMap: dedupedPorts };
+    const sortedPorts = globalIp
+      ? dedupedPorts
+      : [...dedupedPorts].sort((a, b) => String(a.ip ?? '').localeCompare(String(b.ip ?? '')));
+    let prevIp: string | null | undefined;
+    const portMap = sortedPorts.map((pp) => {
+      const showIp = pp.ip != null && pp.ip !== prevIp;
+      prevIp = pp.ip;
+      return { ...pp, showIp };
+    });
+
+    return { globalIp, portMap };
   };
 
   const { globalIp, portMap } = extractIpInfo();
@@ -427,7 +441,7 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                                 hostname = data.node;
                             }
 
-                            const showIpInTag = !globalIp && p.ip;
+                            const showIpInTag = !globalIp && p.ip && p.showIp;
 
                             return (
                                 <div key={idx} className="px-2 py-0.5 rounded text-[10px] font-mono bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 shadow-sm flex items-center gap-1">
@@ -584,7 +598,7 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                                 }
                             }
 
-                            const showIpInTag = !globalIp && p.ip;
+                            const showIpInTag = !globalIp && p.ip && p.showIp;
                             const link = `http://${hostname}:${p.host}`;
 
                             const content = (


### PR DESCRIPTION
First **batch** under the enforced batch model (#1434/#1433): five related-ish fixes accumulated on one integration branch → **one** CI run → one release → one `:dev` verify, instead of five separate pipeline cycles.

## Fixes
- **fix(install)** — self-heal an empty/diverged NPM admin password *before* proxy-host + portal provisioning, on every install (was gated on fresh-nginx-only and ran too late). Closes #1268.
- **fix(network-map)** — group ports by host so multi-IP cards (file-share) don't balloon; prefix once per host. Closes #1428.
- **fix(sidebar)** — drop the duplicated username from the account widget. Closes #1424.
- **feat(mcp)** — re-activate the bootstrap token from Settings (same identity, fresh ~30 min, LAN-only). Closes #1419.
- **feat(portal)** — cap access requests at a configurable max-users limit (default 20; approved users + pending). Refs #1426 (cap only; settings UI + LAN-only `/portal` split to #1456).

## Why batched
The eligible quick-queue was drained (the rest of the backlog is epics needing split, box/destructive, or cross-repo), so per "8 or queue empty" this batch finalizes at 5 to ship the value now.

## Risk
Low–medium. Frontend changes (network-map, sidebar) are cosmetic; backend changes (NPM self-heal, bootstrap reactivate, access cap) reuse tested paths and ship with unit tests.

## Rollback
git revert per-commit (the branch keeps them separate for bisect).

## Verification
- [x] npm run lint (392, 0 errors), check:arch (clean), npm test (1538 passed; new tests for bootstrap reactivate, access cap, network-map grouping)
- [ ] One CI run (this PR)
- [ ] Batched `:dev` box-verify after merge (network-map + sidebar render; bootstrap Re-activate; install NPM self-heal) — covers all path-mandated changes in one flip