### PR TITLE
fix(auth): reconcile stored admin hash with new SERVICEBAY_PASSWORD on reinstall

### DIFF
--- a/packages/frontend/src/app/api/auth/login/reconcile.test.ts
+++ b/packages/frontend/src/app/api/auth/login/reconcile.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reconcileLogin, type ReconcileDeps } from './reconcile';
+
+// Fake scrypt-like primitives: a "hash" is just `h:<plain>`, and verify checks
+// the plaintext against the encoded plaintext. Lets the policy be asserted
+// without real crypto.
+function fakeDeps(): ReconcileDeps {
+  return {
+    hashPassword: vi.fn(async (plain: string) => `h:${plain}`),
+    verifyPassword: vi.fn(async (plain: string, encoded: string) => encoded === `h:${plain}`),
+  };
+}
+
+describe('reconcileLogin', () => {
+  it('accepts the stored password and does NOT re-key (operator-changed pw wins)', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'operator-pw', storedHash: 'h:operator-pw', bootstrapPassword: 'new-env-pw' },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: true });
+    expect(res.newStoredHash).toBeUndefined();
+  });
+
+  it('reconciles on reinstall: stored hash rejects, env password accepts and re-keys', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'new-env-pw', storedHash: 'h:old-install-pw', bootstrapPassword: 'new-env-pw' },
+      deps,
+    );
+    expect(res.authenticated).toBe(true);
+    expect(res.newStoredHash).toBe('h:new-env-pw');
+  });
+
+  it('does not let the env password win while a stored hash still authenticates the request', async () => {
+    // Wrong candidate: neither the stored nor the env password matches.
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'guess', storedHash: 'h:operator-pw', bootstrapPassword: 'new-env-pw' },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: false });
+  });
+
+  it('rejects when stored hash rejects and there is no bootstrap password', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'whatever', storedHash: 'h:operator-pw', bootstrapPassword: null },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: false });
+  });
+
+  it('seeds the stored hash from the env password on a first login with no stored hash', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'env-pw', storedHash: null, bootstrapPassword: 'env-pw' },
+      deps,
+    );
+    expect(res.authenticated).toBe(true);
+    expect(res.newStoredHash).toBe('h:env-pw');
+  });
+
+  it('rejects when nothing is configured (no stored hash, no bootstrap)', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'x', storedHash: null, bootstrapPassword: null },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: false });
+  });
+
+  it('tries the stored hash before the env password (precedence order)', async () => {
+    const order: string[] = [];
+    const deps: ReconcileDeps = {
+      hashPassword: async (p) => `h:${p}`,
+      verifyPassword: async (_p, encoded) => {
+        order.push(encoded);
+        return false; // force fall-through so both verifies run
+      },
+    };
+    await reconcileLogin(
+      { candidate: 'c', storedHash: 'h:stored', bootstrapPassword: 'env' },
+      deps,
+    );
+    expect(order).toEqual(['h:stored', 'h:env']);
+  });
+});

--- a/packages/frontend/src/app/api/auth/login/reconcile.ts
+++ b/packages/frontend/src/app/api/auth/login/reconcile.ts
@@ -1,0 +1,90 @@
+// Credential reconciliation for the ServiceBay admin login.
+//
+// `config.auth.passwordHash` lives on /mnt/data, which SURVIVES a reinstall.
+// A reinstall bakes a fresh `SERVICEBAY_PASSWORD` into the quadlet and hands
+// the operator that new password — but a stored hash from a prior install
+// would shadow it, locking the operator out (issue #1438). This is the same
+// reinstall-over-persisted-data credential-lockout class we already auto-heal
+// for LLDAP (FORCE_RESET) and NPM (auto-rekey).
+//
+// Policy (self-heal-when-safe, never mask a failure):
+//   1. The STORED hash is always tried first. A deliberately operator-changed
+//      password keeps working and is never overridden — the env password only
+//      ever wins when the stored credential does NOT authenticate the request.
+//   2. If the stored hash rejects the password but the env bootstrap password
+//      accepts it, the request is at the genuine reinstall/bootstrap boundary:
+//      authenticate AND re-key the stored hash to the env password so the
+//      stored credential converges on what sb-tui showed the operator.
+//   3. With no stored hash, the env password authenticates as before.
+//
+// The verify/hash primitives are injected so this module stays pure and
+// Next.js-free (testable without the route handler).
+
+export interface ReconcileInput {
+  /** The password supplied by the client. */
+  candidate: string;
+  /** Stored hash from config.auth.passwordHash (undefined / invalid => treated as absent). */
+  storedHash: string | null;
+  /** The deploy-time SERVICEBAY_PASSWORD env value, if set. */
+  bootstrapPassword: string | null;
+}
+
+export interface ReconcileDeps {
+  verifyPassword: (plain: string, encoded: string) => Promise<boolean>;
+  hashPassword: (plain: string) => Promise<string>;
+}
+
+export interface ReconcileResult {
+  /** Whether the candidate authenticated. */
+  authenticated: boolean;
+  /**
+   * When set, the stored hash should be (re)written to this value: either the
+   * freshly-minted bootstrap hash on a reinstall reconcile, or the first-login
+   * seed when there was no stored hash yet. Undefined => leave config untouched.
+   */
+  newStoredHash?: string;
+}
+
+/**
+ * Decide whether the candidate password authenticates and whether the stored
+ * hash should be reconciled. Runs verifies in a fixed order so a stored hash
+ * is never silently overridden by the env password unless the stored hash
+ * actually rejects the request.
+ *
+ * The caller is responsible for the username match and the timing-equalization
+ * dummy verify on a username miss; this helper assumes the username matched.
+ */
+export async function reconcileLogin(
+  input: ReconcileInput,
+  deps: ReconcileDeps,
+): Promise<ReconcileResult> {
+  const { candidate, storedHash, bootstrapPassword } = input;
+
+  // 1. Stored credential takes precedence — an operator-changed password keeps
+  //    working and is never overridden by the env password.
+  if (storedHash) {
+    if (await deps.verifyPassword(candidate, storedHash)) {
+      return { authenticated: true };
+    }
+    // Stored hash rejected. Reinstall/bootstrap boundary: the env password may
+    // be the new credential the operator was handed. Allow it to win HERE only,
+    // and re-key the stored hash so the stored credential converges on it.
+    if (bootstrapPassword) {
+      const bootstrapHash = await deps.hashPassword(bootstrapPassword);
+      if (await deps.verifyPassword(candidate, bootstrapHash)) {
+        return { authenticated: true, newStoredHash: bootstrapHash };
+      }
+    }
+    return { authenticated: false };
+  }
+
+  // 2. No stored hash: env password authenticates and seeds the stored hash.
+  if (bootstrapPassword) {
+    const bootstrapHash = await deps.hashPassword(bootstrapPassword);
+    if (await deps.verifyPassword(candidate, bootstrapHash)) {
+      return { authenticated: true, newStoredHash: bootstrapHash };
+    }
+  }
+
+  return { authenticated: false };
+}

--- a/packages/frontend/src/app/api/auth/login/route.ts
+++ b/packages/frontend/src/app/api/auth/login/route.ts
@@ -6,6 +6,7 @@ import { checkRateLimit, recordFailure, clearAttempts, clientKeyFromHeaders } fr
 import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
+import { reconcileLogin } from './reconcile';
 
 // Pre-hashed sentinel used when the supplied username does not match. Verifying
 // against this hash is intentionally indistinguishable in timing from verifying
@@ -70,33 +71,38 @@ export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
 
     // Always run scrypt verify regardless of whether the username matched, so
     // a wrong-username response takes the same wall-clock time as a wrong-password
-    // response. We discard the verify result if the username didn't match.
+    // response. On a username miss we verify against a dummy hash and discard it.
     const usernameMatches = username === configUsername;
 
-    let referenceHash: string;
-    let tempBootstrapHash: string | null = null;
-    if (usernameMatches && configHash) {
-      referenceHash = configHash;
-    } else if (usernameMatches && bootstrapPassword) {
-      tempBootstrapHash = await hashPassword(bootstrapPassword);
-      referenceHash = tempBootstrapHash;
+    let authenticated = false;
+    let newStoredHash: string | undefined;
+    if (usernameMatches) {
+      // Reconcile the reinstall-over-persisted-data lockout: a stored hash from
+      // a prior install must not shadow the fresh SERVICEBAY_PASSWORD that
+      // sb-tui handed the operator (issue #1438). The stored hash is tried
+      // first, so an operator-changed password is never overridden — the env
+      // password only wins (and re-keys the stored hash) when the stored
+      // credential rejects the request.
+      const result = await reconcileLogin(
+        { candidate: password, storedHash: configHash ?? null, bootstrapPassword: bootstrapPassword ?? null },
+        { verifyPassword, hashPassword },
+      );
+      authenticated = result.authenticated;
+      newStoredHash = result.newStoredHash;
     } else {
-      referenceHash = await getDummyHash();
+      await verifyPassword(password, await getDummyHash());
     }
 
-    const verifyOk = await verifyPassword(password, referenceHash);
-    const ok = usernameMatches && verifyOk;
-
-    if (!ok) {
+    if (!authenticated) {
       recordFailure(clientKey);
       recordFailure(uKey);
       logger.warn('auth:login', 'failed login', { ip: clientKey, username });
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
     }
 
-    if (tempBootstrapHash) {
+    if (newStoredHash) {
       const { updateConfig } = await import('@/lib/config');
-      await updateConfig({ auth: { username: configUsername, passwordHash: tempBootstrapHash } });
+      await updateConfig({ auth: { username: configUsername, passwordHash: newStoredHash } });
     }
 
     clearAttempts(clientKey);


### PR DESCRIPTION
## What
Login now reconciles the stored ServiceBay admin hash (`config.auth.passwordHash`, which lives on `/mnt/data` and survives a reinstall) with the fresh `SERVICEBAY_PASSWORD` that sb-tui bakes into the quadlet. The stored hash is tried first; only when it rejects the request does the env bootstrap password get to authenticate, and on success the stored hash is re-keyed to it. The decision is an injectable pure helper (`reconcile.ts`) with unit tests.

## Why
Closes #1438

A reinstall-over-persisted-data hands the operator a new password, but the prior install's stored hash shadowed it at login (env password was only consulted when there was *no* stored hash), locking the operator out — the same reinstall-over-persisted-data credential-lockout class already auto-healed for LLDAP (`FORCE_RESET`) and NPM (auto-rekey).

## Security
Auth-credential path. The env password can win **only** when the supplied password fails against the stored hash *and* verifies against `SERVICEBAY_PASSWORD` — i.e. the genuine reinstall/bootstrap boundary. A deliberately operator-changed password still authenticates against the stored hash and is never overridden. Timing-equalization on a username miss is preserved (one dummy verify, as before). No failure is masked: a wrong password still returns 401.

## Risk
Low. Scoped to the login route's reference-hash selection; the reconcile policy is unit-tested for precedence, reinstall reconcile, wrong-password rejection, no-bootstrap rejection, and first-login seeding.

## Rollback
`git revert` is enough — no migrations, no schema/config changes.

## Verification
- [x] npm run lint (0 errors; no new warnings — route complexity dropped 27→25)
- [x] npm run check:arch
- [x] npx vitest run --changed (reconcile.test.ts, 7 passing)
- [ ] Real-box reinstall-over-existing-data: log in with the new sb-tui password on first attempt; confirm stored hash re-keys
