### PR TITLE
feat: SSO verify, Home polish, portal cap/LAN-gate, NAS backup UI, admin-hash reconcile, diagnose-fold slice

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -403,6 +403,15 @@ export interface AppConfig {
    */
   maxUsers?: number;
   /**
+   * When true, the family `/portal` page only renders for LAN-shaped
+   * clients (loopback / RFC1918 / ULA); public visitors get a short
+   * "available on the home network only" notice instead of the service
+   * grid. App-level gate (the page reads the request's real client IP);
+   * the request-access POST endpoint stays reachable so the cap and
+   * anti-spam guards remain the public surface. Default off. (#1456)
+   */
+  portalLanOnly?: boolean;
+  /**
    * Per-job log caps (#1098 Phase 1). Long-running installs and noisy
    * mass deploys can balloon `logs.db` without bound; these limits
    * give the logger a hard ceiling per job. Phase 2 wires the rotation

--- a/packages/backend/src/lib/config/schema.ts
+++ b/packages/backend/src/lib/config/schema.ts
@@ -68,6 +68,7 @@ const AppConfigSchema = z.object({
   installManifest: looseObject.optional(),
   accessRequests: looseArray.optional(),
   maxUsers: z.number().int().positive().max(100000).optional(),
+  portalLanOnly: z.boolean().optional(),
 }).strict();
 
 /**

--- a/packages/backend/src/lib/diagnose/diagnoseChecks.test.ts
+++ b/packages/backend/src/lib/diagnose/diagnoseChecks.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckResult } from '@/lib/health/types';
+import type { DiagnoseProbe } from '@/lib/diagnose/runDiagnose';
+
+// In-memory result store keyed by check_id, mirroring HealthStore's
+// on-disk file-per-check layout.
+const store = {
+  results: new Map<string, CheckResult[]>(),
+};
+
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: {
+    saveResult: (r: CheckResult) => {
+      const arr = store.results.get(r.check_id) ?? [];
+      arr.unshift(r);
+      store.results.set(r.check_id, arr);
+    },
+    getResults: (id: string) => store.results.get(id) ?? [],
+    getResultCheckIds: () => Array.from(store.results.keys()),
+  },
+}));
+
+const runDiagnoseMock = vi.fn();
+vi.mock('@/lib/diagnose/runDiagnose', () => ({
+  runDiagnose: (node: string) => runDiagnoseMock(node),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  DIAGNOSE_INTERVAL_SECONDS,
+  diagnoseCheckId,
+  isDiagnoseCheckId,
+  diagnoseStatusToCheckStatus,
+  encodeDiagnoseMessage,
+  decodeDiagnoseMessage,
+  runDiagnoseChecks,
+  getDiagnoseChecksEnriched,
+} from './diagnoseChecks';
+
+const probe = (over: Partial<DiagnoseProbe>): DiagnoseProbe => ({
+  id: 'agent',
+  label: 'Agent reachable',
+  status: 'ok',
+  detail: 'fine',
+  ...over,
+});
+
+beforeEach(() => {
+  store.results.clear();
+  runDiagnoseMock.mockReset();
+});
+
+describe('diagnose check ids', () => {
+  it('prefixes probe ids and round-trips', () => {
+    expect(diagnoseCheckId('pods')).toBe('diagnose:pods');
+    expect(isDiagnoseCheckId('diagnose:pods')).toBe(true);
+    expect(isDiagnoseCheckId('some-uuid')).toBe(false);
+  });
+});
+
+describe('diagnoseStatusToCheckStatus', () => {
+  it('maps warn and fail to fail, ok and info to ok', () => {
+    expect(diagnoseStatusToCheckStatus('ok')).toBe('ok');
+    expect(diagnoseStatusToCheckStatus('info')).toBe('ok');
+    expect(diagnoseStatusToCheckStatus('warn')).toBe('fail');
+    expect(diagnoseStatusToCheckStatus('fail')).toBe('fail');
+  });
+});
+
+describe('encode/decode diagnose message', () => {
+  it('round-trips the four-way status + payload', () => {
+    const p = probe({ status: 'warn', detail: 'd', hint: 'h', actions: [{ id: 'a', label: 'A', description: 'x' }] });
+    const decoded = decodeDiagnoseMessage(encodeDiagnoseMessage(p));
+    expect(decoded?.status).toBe('warn');
+    expect(decoded?.detail).toBe('d');
+    expect(decoded?.hint).toBe('h');
+    expect(decoded?.actions?.[0].id).toBe('a');
+  });
+
+  it('returns null for a non-diagnose message', () => {
+    expect(decodeDiagnoseMessage('plain check message')).toBeNull();
+    expect(decodeDiagnoseMessage(null)).toBeNull();
+    expect(decodeDiagnoseMessage(undefined)).toBeNull();
+  });
+
+  it('returns null for a corrupt payload', () => {
+    expect(decodeDiagnoseMessage('diagnose:{not json')).toBeNull();
+  });
+});
+
+describe('runDiagnoseChecks', () => {
+  it('persists one synthetic result per probe with prefixed ids', async () => {
+    runDiagnoseMock.mockResolvedValue({
+      node: 'Local',
+      probes: [probe({ id: 'agent', status: 'ok' }), probe({ id: 'pods', status: 'warn' })],
+    });
+    const results = await runDiagnoseChecks('Local');
+    expect(results.map(r => r.check_id)).toEqual(['diagnose:agent', 'diagnose:pods']);
+    expect(results[0].status).toBe('ok');
+    expect(results[1].status).toBe('fail'); // warn -> fail
+    expect(store.results.get('diagnose:pods')).toHaveLength(1);
+  });
+
+  it('uses the daily interval constant', () => {
+    expect(DIAGNOSE_INTERVAL_SECONDS).toBe(24 * 60 * 60);
+  });
+});
+
+describe('getDiagnoseChecksEnriched', () => {
+  it('reads only diagnose-prefixed result files back as enriched rows', async () => {
+    // Seed a non-diagnose result that must be ignored.
+    store.results.set('some-uuid', [{ check_id: 'some-uuid', timestamp: 't', status: 'ok' }]);
+    runDiagnoseMock.mockResolvedValue({
+      node: 'Local',
+      probes: [probe({ id: 'pods', status: 'warn', label: 'Pods', detail: 'one down' })],
+    });
+    await runDiagnoseChecks('Local');
+
+    const rows = getDiagnoseChecksEnriched();
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.id).toBe('diagnose:pods');
+    expect(row.name).toBe('Self-diagnose: Pods');
+    expect(row.status).toBe('fail');
+    expect(row.lastRun).not.toBeNull();
+    // The four-way diagnose payload is preserved for the popup slice.
+    expect(row.diagnose?.status).toBe('warn');
+    expect(row.diagnose?.detail).toBe('one down');
+  });
+
+  it('returns no rows before any diagnose run', () => {
+    expect(getDiagnoseChecksEnriched()).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/diagnose/diagnoseChecks.ts
+++ b/packages/backend/src/lib/diagnose/diagnoseChecks.ts
@@ -1,0 +1,162 @@
+/**
+ * Diagnose → Checks bridge (#1423, first slice).
+ *
+ * The diagnose/health rework (v3.35–3.37) deliberately split continuous
+ * monitoring (health checks, scheduled + persisted) from on-demand
+ * narratives (the diagnose self-test). #1423 re-folds the diagnose
+ * probes back into the unified Checks list, but keeps them on a *daily*
+ * cadence (the suite shells out to the agent ~10 times, far heavier than
+ * a single http/ping check — running it every 60 s would hammer the box).
+ *
+ * This module is the foundational slice: it runs `runDiagnose` once,
+ * then persists each probe as a synthetic check result keyed by a
+ * deterministic id `diagnose:<probeId>`, so the existing HealthStore /
+ * Checks-list plumbing surfaces them with the same per-row stats
+ * (status, last-run, history sparkline) as any other check. The full
+ * probe payload (warn/info status + self-repair actions) is encoded in
+ * the persisted message behind DIAGNOSE_MESSAGE_PREFIX so a later slice
+ * can render the self-repair popup from the row without re-running the
+ * suite.
+ *
+ * Remaining for #1423 (separate slices): the self-repair popup opened
+ * from a diagnose row, and a Checks-tab counter refactor that
+ * distinguishes warn/info (today they fold into fail/unknown — see
+ * `diagnoseStatusToCheckStatus`).
+ */
+
+import { HealthStore } from '@/lib/health/store';
+import type { CheckResult } from '@/lib/health/types';
+import { runDiagnose, type DiagnoseProbe } from '@/lib/diagnose/runDiagnose';
+import { logger } from '@/lib/logger';
+
+/** Daily — the diagnose suite is heavy (multi-probe agent fan-out), so
+ *  it runs once a day rather than on the per-minute check cadence. */
+export const DIAGNOSE_INTERVAL_SECONDS = 24 * 60 * 60;
+
+/** Synthetic-check id prefix. A probe `agent` becomes check `diagnose:agent`. */
+export const DIAGNOSE_CHECK_ID_PREFIX = 'diagnose:';
+
+/** Message marker so the Checks UI / popup slice can recognise a diagnose
+ *  row's persisted payload and decode the original probe (incl. warn/info
+ *  status + self-repair actions) without re-running the suite. */
+export const DIAGNOSE_MESSAGE_PREFIX = 'diagnose:';
+
+export const isDiagnoseCheckId = (id: string): boolean =>
+  id.startsWith(DIAGNOSE_CHECK_ID_PREFIX);
+
+export const diagnoseCheckId = (probeId: string): string =>
+  `${DIAGNOSE_CHECK_ID_PREFIX}${probeId}`;
+
+/**
+ * Collapse a diagnose probe's four-way status onto the Check store's
+ * three-way `ok | fail | unknown`. The existing Checks tab only knows
+ * those three; until the counter refactor (the #1423 follow-up slice)
+ * lands, `warn`/`fail` both read as a failing row and `info` reads as
+ * `unknown`. The original four-way status is preserved verbatim in the
+ * encoded payload, so no information is lost — only the colour the
+ * legacy counters assign.
+ */
+export function diagnoseStatusToCheckStatus(
+  status: DiagnoseProbe['status'],
+): 'ok' | 'fail' {
+  // CheckResult.status is binary (ok | fail); `info` rows have no
+  // result-level failure but aren't "ok" either — the enrichment layer
+  // maps a missing/absent result to `unknown`, but a diagnose `info`
+  // probe HAS run, so we persist it as `ok` and let the decoded payload
+  // carry the `info` nuance for the row's badge.
+  return status === 'fail' || status === 'warn' ? 'fail' : 'ok';
+}
+
+/** Build the persisted result message for a probe: a JSON payload behind
+ *  the marker so a reader can recover the full four-way status, detail,
+ *  hint and actions. */
+export function encodeDiagnoseMessage(probe: DiagnoseProbe): string {
+  const payload = {
+    status: probe.status,
+    label: probe.label,
+    detail: probe.detail,
+    hint: probe.hint,
+    actions: probe.actions,
+    items: probe.items,
+  };
+  return `${DIAGNOSE_MESSAGE_PREFIX}${JSON.stringify(payload)}`;
+}
+
+/** Inverse of {@link encodeDiagnoseMessage}. Returns null when the
+ *  message isn't a diagnose payload (e.g. a plain check). */
+export function decodeDiagnoseMessage(
+  message: string | null | undefined,
+): Partial<DiagnoseProbe> | null {
+  if (!message || !message.startsWith(DIAGNOSE_MESSAGE_PREFIX)) return null;
+  try {
+    return JSON.parse(message.slice(DIAGNOSE_MESSAGE_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the diagnose suite for `nodeName` and persist one synthetic check
+ * result per probe. Called daily by the HealthService scheduler and
+ * on-demand by the per-row "run now" action. Returns the persisted
+ * results so callers can emit `health:update` for them.
+ */
+export async function runDiagnoseChecks(
+  nodeName = 'Local',
+): Promise<CheckResult[]> {
+  const { probes } = await runDiagnose(nodeName);
+  const now = new Date().toISOString();
+  const results: CheckResult[] = probes.map(probe => ({
+    check_id: diagnoseCheckId(probe.id),
+    timestamp: now,
+    status: diagnoseStatusToCheckStatus(probe.status),
+    latency: 0,
+    message: encodeDiagnoseMessage(probe),
+  }));
+  for (const result of results) {
+    HealthStore.saveResult(result);
+  }
+  logger.info('Diagnose', `Persisted ${results.length} diagnose probe result(s) as checks.`);
+  return results;
+}
+
+/**
+ * Read the diagnose probes back out of the HealthStore as enriched check
+ * rows (the shape `/api/health/checks` returns for real checks). Only
+ * probes that have a persisted result appear — a fresh box shows none
+ * until the first daily run (or an on-demand run) lands.
+ */
+export function getDiagnoseChecksEnriched() {
+  // We can't enumerate probe ids without running the suite, so we list
+  // every persisted result whose id carries the diagnose prefix. The
+  // store keys results by check_id on disk; HealthStore doesn't expose a
+  // "list result files" API, so we reconstruct from the on-disk result
+  // listing via getResultCheckIds.
+  const ids = HealthStore.getResultCheckIds().filter(isDiagnoseCheckId);
+  return ids.map(id => {
+    const results = HealthStore.getResults(id);
+    const last = results[0];
+    const decoded = decodeDiagnoseMessage(last?.message);
+    const history = results.slice(0, 20).map(r => ({
+      status: r.status,
+      latency: r.latency ?? 0,
+      timestamp: r.timestamp,
+    }));
+    return {
+      id,
+      name: decoded?.label ? `Self-diagnose: ${decoded.label}` : id,
+      type: 'script' as const,
+      target: id.slice(DIAGNOSE_CHECK_ID_PREFIX.length),
+      interval: DIAGNOSE_INTERVAL_SECONDS,
+      enabled: true,
+      created_at: new Date(0).toISOString(),
+      status: last ? last.status : ('unknown' as const),
+      lastRun: last ? last.timestamp : null,
+      lastResult: last?.message ?? null,
+      // Surface the four-way diagnose status + self-repair payload for
+      // the row's badge / popup (the popup slice consumes `diagnose`).
+      diagnose: decoded ?? undefined,
+      history,
+    };
+  });
+}

--- a/packages/backend/src/lib/diagnose/ssoVerify.test.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig } = vi.hoisted(() => ({ mockGetConfig: vi.fn() }));
+vi.mock('@/lib/config', () => ({ getConfig: () => mockGetConfig() }));
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+// The agent/lldap real deps are never reached when deps are injected, but
+// the imports must resolve.
+vi.mock('@/lib/agent/manager', () => ({ agentManager: { ensureAgent: vi.fn() } }));
+vi.mock('@/lib/lldap/client', () => ({
+  createLldapUser: vi.fn(),
+  addUserToLldapGroup: vi.fn(),
+  deleteLldapUser: vi.fn(),
+  listLldapGroups: vi.fn(),
+}));
+
+import {
+  verifySso,
+  classifyUserDomain,
+  classifyAdminReject,
+  extractAutheliaCookie,
+  makeEphemeralUsername,
+  USER_APP_SIGNATURES,
+  ADMIN_ONLY_HOSTS,
+  type SsoVerifyDeps,
+  type DomainProbe,
+} from './ssoVerify';
+
+const okConfig = {
+  reverseProxy: { publicDomain: 'dopp.cloud' },
+  installedTemplates: { auth: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' } },
+};
+
+/** Deps where every step succeeds and every domain behaves correctly. */
+function happyDeps(): { deps: SsoVerifyDeps; calls: { deleted: string[] } } {
+  const calls = { deleted: [] as string[] };
+  const deps: SsoVerifyDeps = {
+    listGroups: vi.fn(async () => ({ ok: true as const, groups: [{ id: 2, displayName: 'family' }, { id: 1, displayName: 'admins' }] })),
+    createUser: vi.fn(async () => ({ ok: true as const, userId: 'u', displayName: 'd' })),
+    setPassword: vi.fn(async () => ({ ok: true, message: 'set' })),
+    addToGroup: vi.fn(async () => ({ ok: true as const })),
+    deleteUser: vi.fn(async (id: string) => { calls.deleted.push(id); return { ok: true as const }; }),
+    autheliaFirstFactor: vi.fn(async () => ({ ok: true, cookie: 'authelia_session=abc', detail: 'ok' })),
+    probeDomain: vi.fn(async (_pd: string, host: string, _c: string | null, follow: boolean): Promise<DomainProbe> => {
+      // user apps follow redirects → 200 + matching signature; admin hosts
+      // don't follow → 302 (correctly blocked).
+      if (follow) {
+        const sig = USER_APP_SIGNATURES[host] ?? '';
+        return { code: 200, body: sig || 'anything' };
+      }
+      return { code: 302, body: '' };
+    }),
+  };
+  return { deps, calls };
+}
+
+beforeEach(() => {
+  mockGetConfig.mockReset();
+  mockGetConfig.mockResolvedValue(okConfig);
+});
+
+describe('verifySso orchestrator', () => {
+  it('runs the full flow, passes, and always deletes the ephemeral user', async () => {
+    const { deps, calls } = happyDeps();
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(true);
+    expect(report.cleanedUp).toBe(true);
+    // every user app + every admin host probed
+    expect(report.userDomains).toHaveLength(Object.keys(USER_APP_SIGNATURES).length);
+    expect(report.adminDomains).toHaveLength(ADMIN_ONLY_HOSTS.length);
+    // ephemeral user deleted exactly once, matching the reported username
+    expect(calls.deleted).toEqual([report.ephemeralUser]);
+    expect(deps.deleteUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('GUARANTEES cleanup even when a mid-flow step fails (after create)', async () => {
+    const { deps, calls } = happyDeps();
+    deps.addToGroup = vi.fn(async () => ({ ok: false as const, reason: 'graphql_error' as const, message: 'boom' }));
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(false);
+    // user was created, so it MUST be deleted despite the failure
+    expect(calls.deleted).toEqual([report.ephemeralUser]);
+    expect(report.cleanedUp).toBe(true);
+    expect(report.steps.find(s => s.id === 'join_family')?.status).toBe('fail');
+  });
+
+  it('does not attempt deletion when the user was never created', async () => {
+    const { deps } = happyDeps();
+    deps.createUser = vi.fn(async () => ({ ok: false as const, reason: 'graphql_error' as const, message: 'nope' }));
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(false);
+    expect(report.cleanedUp).toBe(true); // nothing to clean up
+    expect(deps.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('reports cleanedUp=false when the delete itself fails (and still finishes)', async () => {
+    const { deps } = happyDeps();
+    deps.deleteUser = vi.fn(async () => ({ ok: false as const, reason: 'network_error' as const, message: 'unreachable' }));
+
+    const report = await verifySso({ deps });
+
+    expect(report.cleanedUp).toBe(false);
+    expect(report.steps.find(s => s.id === 'cleanup')?.status).toBe('fail');
+  });
+
+  it('fails when a family user can REACH an admin domain (ACL bypass) — and still cleans up', async () => {
+    const { deps, calls } = happyDeps();
+    deps.probeDomain = vi.fn(async (_pd, host, _c, follow) => {
+      if (!follow) return { code: 200, body: 'admin panel' }; // bypass!
+      return { code: 200, body: USER_APP_SIGNATURES[host] || 'ok' };
+    });
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(false);
+    expect(report.adminDomains.every(d => d.status === 'fail')).toBe(true);
+    expect(calls.deleted).toHaveLength(1);
+  });
+
+  it('fails a user domain that returns 200 with the wrong content signature', async () => {
+    const { deps } = happyDeps();
+    deps.probeDomain = vi.fn(async (_pd, host, _c, follow) => {
+      if (!follow) return { code: 302, body: '' };
+      // vault expects 'Vaultwarden Web' but we return junk
+      if (host === 'vault') return { code: 200, body: '<html>error page</html>' };
+      return { code: 200, body: USER_APP_SIGNATURES[host] || 'ok' };
+    });
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(false);
+    expect(report.userDomains.find(d => d.domain === 'vault.dopp.cloud')?.status).toBe('fail');
+  });
+
+  it('skips early (and reports cleanedUp) when publicDomain is not configured', async () => {
+    mockGetConfig.mockResolvedValue({ reverseProxy: {}, installedTemplates: { auth: {} } });
+    const { deps } = happyDeps();
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(false);
+    expect(report.steps[0].id).toBe('config');
+    expect(deps.createUser).not.toHaveBeenCalled();
+  });
+
+  it('skips when the auth template is not installed', async () => {
+    mockGetConfig.mockResolvedValue({ reverseProxy: { publicDomain: 'dopp.cloud' }, installedTemplates: {} });
+    const { deps } = happyDeps();
+
+    const report = await verifySso({ deps });
+
+    expect(report.steps.some(s => s.id === 'config' && s.status === 'skip')).toBe(true);
+    expect(deps.createUser).not.toHaveBeenCalled();
+  });
+
+  it('cleans up even if an injected dep throws unexpectedly', async () => {
+    const { deps, calls } = happyDeps();
+    deps.autheliaFirstFactor = vi.fn(async () => { throw new Error('kaboom'); });
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(false);
+    expect(report.steps.some(s => s.id === 'unexpected_error')).toBe(true);
+    expect(calls.deleted).toEqual([report.ephemeralUser]);
+  });
+});
+
+describe('classifyUserDomain', () => {
+  it('passes 2xx with matching signature', () => {
+    expect(classifyUserDomain('vault.dopp.cloud', 'Vaultwarden Web', { code: 200, body: 'x Vaultwarden Web y' }).status).toBe('pass');
+  });
+  it('passes 3xx with no signature', () => {
+    expect(classifyUserDomain('photos.dopp.cloud', '', { code: 302, body: '' }).status).toBe('pass');
+  });
+  it('fails 2xx missing signature', () => {
+    expect(classifyUserDomain('vault.dopp.cloud', 'Vaultwarden Web', { code: 200, body: 'nope' }).status).toBe('fail');
+  });
+  it('fails 4xx/5xx', () => {
+    expect(classifyUserDomain('vault.dopp.cloud', '', { code: 502, body: '' }).status).toBe('fail');
+  });
+  it('fails transport error', () => {
+    expect(classifyUserDomain('vault.dopp.cloud', '', { code: 0, body: '', error: 'ECONNREFUSED' }).status).toBe('fail');
+  });
+});
+
+describe('classifyAdminReject', () => {
+  it.each([302, 303, 401, 403])('passes blocked code %i', (code) => {
+    expect(classifyAdminReject('ldap.dopp.cloud', { code, body: '' }).status).toBe('pass');
+  });
+  it('fails on 200 (ACL bypassed)', () => {
+    const r = classifyAdminReject('ldap.dopp.cloud', { code: 200, body: '' });
+    expect(r.status).toBe('fail');
+    expect(r.detail).toMatch(/bypass/i);
+  });
+  it('fails on transport error', () => {
+    expect(classifyAdminReject('ldap.dopp.cloud', { code: 0, body: '', error: 'x' }).status).toBe('fail');
+  });
+});
+
+describe('extractAutheliaCookie', () => {
+  it('pulls authelia_session from a Set-Cookie list', () => {
+    expect(extractAutheliaCookie(['authelia_session=abc123; Path=/; HttpOnly', 'other=1']))
+      .toBe('authelia_session=abc123');
+  });
+  it('returns null when absent', () => {
+    expect(extractAutheliaCookie(['session=zzz; Path=/'])).toBeNull();
+  });
+});
+
+describe('makeEphemeralUsername', () => {
+  it('is namespaced, timestamped, and unique across calls', () => {
+    const a = makeEphemeralUsername(1000);
+    const b = makeEphemeralUsername(1000);
+    expect(a).toMatch(/^sb-ssoverify-1000-[0-9a-f]{6}$/);
+    expect(a).not.toBe(b); // random suffix differs
+  });
+});

--- a/packages/backend/src/lib/diagnose/ssoVerify.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.ts
@@ -1,0 +1,426 @@
+/**
+ * In-process SSO end-to-end verification (#1453) — the foundation #1454
+ * (auto-run post-install) and #1455 (one-click UI report) build on.
+ *
+ * Ports the core of `scripts/smoke/sso-verify.sh` into a callable async
+ * function, dropping the dev-SSH-key dependency: the backend already runs
+ * *on the box*, so it talks to LLDAP / Authelia / NPM over localhost and
+ * runs the in-container `lldap_set_password` binary through the agent exec
+ * channel (the same channel the oidc/failed-units probes use), not SSH.
+ *
+ * The flow, mirroring the smoke test's user-facing path:
+ *   1. resolve config (publicDomain, lldap url) + the `family` group id;
+ *   2. create a clearly-namespaced **ephemeral** LLDAP user, password held
+ *      only in memory, joined to `family`;
+ *   3. log it in through Authelia's `/api/firstfactor`, capture the
+ *      session cookie;
+ *   4. hit every user-facing service domain with the cookie, expecting
+ *      2xx/3xx (+ a content signature where one is stable);
+ *   5. confirm the user is **rejected** by admin-only domains (302/401/403,
+ *      never 2xx);
+ *   6. **always** delete the ephemeral user — on success *and* failure.
+ *
+ * Returns a structured per-step / per-domain report. No UI, no scheduling,
+ * no auto-trigger — those are the consumers' job.
+ *
+ * Admin-path (section 7) and box-health / portal-asset (sections 1, 8) of
+ * the bash script are intentionally out of scope for this foundation: the
+ * positive-admin path needs a second user with 2FA semantics, and box
+ * health is already covered by existing health checks. The deliverable is
+ * the user-facing create→login→domain→admin-reject→delete spine.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import {
+  createLldapUser,
+  addUserToLldapGroup,
+  deleteLldapUser,
+  listLldapGroups,
+} from '@/lib/lldap/client';
+
+const AUTHELIA_DEFAULT_PORT = 9091;
+const LLDAP_CONTAINER = 'auth-lldap';
+const HTTP_TIMEOUT_MS = 8000;
+const SET_PASSWORD_TIMEOUT_MS = 15_000;
+
+/**
+ * User-facing service subdomain → optional content signature. An empty
+ * signature means "2xx/3xx is enough"; a non-empty one is grepped in the
+ * body so the check also catches "200 with the wrong content" (a half-broken
+ * proxy). Kept in sync with the smoke test's USER_APPS map; ollama is
+ * intentionally absent (no auth, opt-in NPM host only — see #1180).
+ */
+export const USER_APP_SIGNATURES: Readonly<Record<string, string>> = {
+  vault: 'Vaultwarden Web',
+  photos: '',
+  music: '',
+  books: 'Audiobookshelf',
+  home: '',
+  files: '',
+  sync: '',
+  caldav: '',
+  hermes: 'Hermes Agent',
+};
+
+/**
+ * Admin-only subdomains a `family`-group user must NOT reach. `admin`
+ * (ServiceBay itself) is deliberately excluded — it has app-layer auth, not
+ * Authelia forward-auth (matches the smoke test's reasoning).
+ */
+export const ADMIN_ONLY_HOSTS: readonly string[] = ['nginx', 'dns', 'ldap'];
+
+export type SsoStepStatus = 'pass' | 'fail' | 'skip';
+
+export interface SsoStepResult {
+  /** Stable step id, e.g. `create_user`, `authelia_firstfactor`. */
+  id: string;
+  status: SsoStepStatus;
+  detail: string;
+}
+
+export interface SsoDomainResult {
+  /** Fully-qualified host, e.g. `vault.dopp.cloud`. */
+  domain: string;
+  status: SsoStepStatus;
+  /** HTTP status code observed (0 = transport error). */
+  code: number;
+  detail: string;
+}
+
+export interface SsoVerifyReport {
+  ok: boolean;
+  /** True if the ephemeral user was created and successfully deleted again. */
+  cleanedUp: boolean;
+  /** The ephemeral username that was used (for log correlation). */
+  ephemeralUser: string;
+  steps: SsoStepResult[];
+  userDomains: SsoDomainResult[];
+  adminDomains: SsoDomainResult[];
+}
+
+/** A single domain probe outcome before classification. */
+export interface DomainProbe {
+  code: number;
+  body: string;
+  error?: string;
+}
+
+export interface SsoVerifyDeps {
+  createUser: typeof createLldapUser;
+  addToGroup: typeof addUserToLldapGroup;
+  deleteUser: typeof deleteLldapUser;
+  listGroups: typeof listLldapGroups;
+  /** Set the ephemeral user's password via the in-container binary. */
+  setPassword: (userId: string, password: string) => Promise<{ ok: boolean; message: string }>;
+  /** POST Authelia firstfactor; resolves the session cookie or null. */
+  autheliaFirstFactor: (
+    publicDomain: string,
+    username: string,
+    password: string,
+  ) => Promise<{ ok: boolean; cookie: string | null; detail: string }>;
+  /** Probe one proxied domain, optionally carrying the session cookie. */
+  probeDomain: (
+    publicDomain: string,
+    host: string,
+    cookie: string | null,
+    followRedirects: boolean,
+  ) => Promise<DomainProbe>;
+}
+
+export interface SsoVerifyOptions {
+  node?: string;
+  /** Override deps for testing; defaults wire the real LLDAP/Authelia/NPM. */
+  deps?: Partial<SsoVerifyDeps>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure classifiers (unit-tested directly).
+// ---------------------------------------------------------------------------
+
+/** A unique, clearly-namespaced ephemeral username that won't collide with a
+ *  real account or a concurrent run. */
+export function makeEphemeralUsername(now: number = Date.now()): string {
+  return `sb-ssoverify-${now}-${randomBytes(3).toString('hex')}`;
+}
+
+/** Classify a user-facing domain probe: 2xx/3xx passes (and matches the
+ *  signature if one is given); anything else fails. */
+export function classifyUserDomain(host: string, signature: string, probe: DomainProbe): SsoDomainResult {
+  const domain = host; // caller passes the FQDN
+  if (probe.error || probe.code === 0) {
+    return { domain, status: 'fail', code: 0, detail: `transport error: ${probe.error ?? 'no response'}` };
+  }
+  const reachable = (probe.code >= 200 && probe.code < 400);
+  if (!reachable) {
+    return { domain, status: 'fail', code: probe.code, detail: `HTTP ${probe.code} (auth or upstream broken)` };
+  }
+  if (signature && !probe.body.includes(signature)) {
+    return { domain, status: 'fail', code: probe.code, detail: `HTTP ${probe.code} but body missing signature "${signature}"` };
+  }
+  return { domain, status: 'pass', code: probe.code, detail: `HTTP ${probe.code}${signature ? ` (matched "${signature}")` : ''}` };
+}
+
+/** Classify an admin-only domain probe for a family-only user: a redirect to
+ *  auth (302/303) or an Authelia refusal (401/403) is the PASS signal; a 2xx
+ *  means the ACL was bypassed. */
+export function classifyAdminReject(host: string, probe: DomainProbe): SsoDomainResult {
+  const domain = host;
+  if (probe.error || probe.code === 0) {
+    return { domain, status: 'fail', code: 0, detail: `transport error: ${probe.error ?? 'no response'} (can't judge ACL)` };
+  }
+  if ([302, 303, 401, 403].includes(probe.code)) {
+    return { domain, status: 'pass', code: probe.code, detail: `HTTP ${probe.code} (correctly blocked for family-only user)` };
+  }
+  if (probe.code >= 200 && probe.code < 300) {
+    return { domain, status: 'fail', code: probe.code, detail: `HTTP ${probe.code}: family user got in — ACL bypassed` };
+  }
+  return { domain, status: 'fail', code: probe.code, detail: `HTTP ${probe.code} (unexpected — can't judge ACL)` };
+}
+
+/** Pull the `authelia_session` cookie value out of a Set-Cookie header list. */
+export function extractAutheliaCookie(setCookies: string[]): string | null {
+  for (const sc of setCookies) {
+    const m = /(?:^|;\s*)(authelia_session=[^;]+)/.exec(sc) ?? /^(authelia_session=[^;]+)/.exec(sc.trim());
+    if (m) return m[1];
+  }
+  return null;
+}
+
+function autheliaPort(): number {
+  const p = parseInt(process.env.AUTHELIA_PORT || '', 10);
+  return Number.isFinite(p) && p > 0 ? p : AUTHELIA_DEFAULT_PORT;
+}
+
+// ---------------------------------------------------------------------------
+// Real dependency implementations (the localhost / agent-exec wiring).
+// ---------------------------------------------------------------------------
+
+function realSetPassword(node: string) {
+  // The username/password are module-generated (safe charset) but the
+  // command still runs in a shell, so the password is single-quoted and we
+  // refuse any value that could break out of the quoting.
+  return async (userId: string, password: string): Promise<{ ok: boolean; message: string }> => {
+    if (/['"\\\n`$]/.test(password) || !/^[a-z0-9-]+$/i.test(userId)) {
+      return { ok: false, message: 'ephemeral credentials failed the safe-charset guard' };
+    }
+    const cfg = await getConfig();
+    const lldapUrl = cfg.lldap?.url ?? 'http://localhost:17170';
+    const agent = await agentManager.ensureAgent(node);
+    const res = await agent.sendCommand('exec', {
+      command:
+        `podman exec ${LLDAP_CONTAINER} /app/lldap_set_password ` +
+        `-u ${userId} -p '${password}' --base-url ${lldapUrl} 2>&1`,
+    }, { timeoutMs: SET_PASSWORD_TIMEOUT_MS }) as { code?: number; stdout?: string; stderr?: string };
+    const out = (res.stdout ?? res.stderr ?? '').trim();
+    if (res.code === 0 || /Successfully changed/i.test(out)) {
+      return { ok: true, message: 'password set' };
+    }
+    return { ok: false, message: `lldap_set_password returned ${res.code}: ${out.slice(0, 200) || 'unknown error'}` };
+  };
+}
+
+async function realAutheliaFirstFactor(
+  publicDomain: string,
+  username: string,
+  password: string,
+): Promise<{ ok: boolean; cookie: string | null; detail: string }> {
+  const url = `http://127.0.0.1:${autheliaPort()}/api/firstfactor`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Host: `auth.${publicDomain}`,
+        'X-Forwarded-Proto': 'https',
+        'X-Forwarded-Host': `auth.${publicDomain}`,
+      },
+      body: JSON.stringify({
+        username,
+        password,
+        requestMethod: 'GET',
+        targetURL: `https://vault.${publicDomain}/`,
+      }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    const text = await res.text().catch(() => '');
+    if (res.status !== 200 || !text.includes('"status":"OK"')) {
+      return { ok: false, cookie: null, detail: `firstfactor HTTP ${res.status}: ${text.slice(0, 160)}` };
+    }
+    const cookie = extractAutheliaCookie(res.headers.getSetCookie?.() ?? []);
+    if (!cookie) return { ok: false, cookie: null, detail: 'firstfactor OK but no authelia_session cookie set' };
+    return { ok: true, cookie, detail: 'firstfactor OK, session cookie captured' };
+  } catch (e) {
+    return { ok: false, cookie: null, detail: `firstfactor request failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+/** Probe a proxied service via NPM on the box (localhost:80) with a Host
+ *  header — the in-process analogue of the smoke test's `--resolve`. */
+async function realProbeDomain(
+  publicDomain: string,
+  host: string,
+  cookie: string | null,
+  followRedirects: boolean,
+): Promise<DomainProbe> {
+  const fqdn = `${host}.${publicDomain}`;
+  const headers: Record<string, string> = {
+    Host: fqdn,
+    'X-Forwarded-Proto': 'https',
+    'X-Forwarded-Host': fqdn,
+  };
+  if (cookie) headers['Cookie'] = cookie;
+  try {
+    const res = await fetch('http://127.0.0.1:80/', {
+      method: 'GET',
+      headers,
+      redirect: followRedirects ? 'follow' : 'manual',
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    const body = await res.text().catch(() => '');
+    return { code: res.status, body };
+  } catch (e) {
+    return { code: 0, body: '', error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function buildDeps(node: string, overrides?: Partial<SsoVerifyDeps>): SsoVerifyDeps {
+  return {
+    createUser: createLldapUser,
+    addToGroup: addUserToLldapGroup,
+    deleteUser: deleteLldapUser,
+    listGroups: listLldapGroups,
+    setPassword: realSetPassword(node),
+    autheliaFirstFactor: realAutheliaFirstFactor,
+    probeDomain: realProbeDomain,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator.
+// ---------------------------------------------------------------------------
+
+/** Internal mutable accumulator threaded through the flow helpers. */
+interface SsoRun {
+  publicDomain: string;
+  ephemeralUser: string;
+  password: string;
+  steps: SsoStepResult[];
+  userDomains: SsoDomainResult[];
+  adminDomains: SsoDomainResult[];
+  created: boolean;
+}
+
+/** Create the ephemeral user, set its password, and join `family`. Returns
+ *  false on the first failing step (caller then funnels through cleanup). */
+async function provisionEphemeralUser(deps: SsoVerifyDeps, run: SsoRun): Promise<boolean> {
+  const groups = await deps.listGroups();
+  if (!groups.ok) {
+    run.steps.push({ id: 'list_groups', status: 'fail', detail: `could not read LLDAP groups: ${groups.message}` });
+    return false;
+  }
+  const family = groups.groups.find(g => g.displayName === 'family');
+  if (!family) {
+    run.steps.push({ id: 'family_group', status: 'fail', detail: "no 'family' group in LLDAP — Authelia's user rules expect it." });
+    return false;
+  }
+  run.steps.push({ id: 'family_group', status: 'pass', detail: `'family' group present (id=${family.id})` });
+
+  const create = await deps.createUser({ id: run.ephemeralUser, email: `${run.ephemeralUser}@${run.publicDomain}`, displayName: 'SSO Verify (ephemeral)' });
+  if (!create.ok) {
+    run.steps.push({ id: 'create_user', status: 'fail', detail: `createUser failed: ${create.message}` });
+    return false;
+  }
+  run.created = true;
+  run.steps.push({ id: 'create_user', status: 'pass', detail: `created ${run.ephemeralUser}` });
+
+  const pw = await deps.setPassword(run.ephemeralUser, run.password);
+  run.steps.push({ id: 'set_password', status: pw.ok ? 'pass' : 'fail', detail: pw.ok ? 'password set via lldap_set_password' : pw.message });
+  if (!pw.ok) return false;
+
+  const grp = await deps.addToGroup(run.ephemeralUser, family.id);
+  run.steps.push({ id: 'join_family', status: grp.ok ? 'pass' : 'fail', detail: grp.ok ? 'joined family group' : `addUserToGroup failed: ${grp.message}` });
+  return grp.ok;
+}
+
+/** Hit every user-facing domain (cookie + follow redirects) and every
+ *  admin-only domain (cookie, no redirects), recording per-domain results. */
+async function probeAllDomains(deps: SsoVerifyDeps, run: SsoRun, cookie: string): Promise<void> {
+  for (const [host, signature] of Object.entries(USER_APP_SIGNATURES)) {
+    const probe = await deps.probeDomain(run.publicDomain, host, cookie, true);
+    run.userDomains.push(classifyUserDomain(`${host}.${run.publicDomain}`, signature, probe));
+  }
+  for (const host of ADMIN_ONLY_HOSTS) {
+    const probe = await deps.probeDomain(run.publicDomain, host, cookie, false);
+    run.adminDomains.push(classifyAdminReject(`${host}.${run.publicDomain}`, probe));
+  }
+}
+
+/** Guaranteed teardown + verdict — always deletes a created ephemeral user
+ *  and computes the overall pass/fail. */
+async function finishRun(deps: SsoVerifyDeps, run: SsoRun): Promise<SsoVerifyReport> {
+  let cleanedUp = true;
+  if (run.created) {
+    const del = await deps.deleteUser(run.ephemeralUser);
+    cleanedUp = del.ok;
+    if (del.ok) {
+      run.steps.push({ id: 'cleanup', status: 'pass', detail: `deleted ${run.ephemeralUser}` });
+    } else {
+      logger.warn('ssoVerify', `failed to delete ephemeral user ${run.ephemeralUser}: ${del.message}`);
+      run.steps.push({ id: 'cleanup', status: 'fail', detail: `could not delete ${run.ephemeralUser}: ${del.message}` });
+    }
+  }
+  const ranDomains = run.userDomains.length > 0 && run.adminDomains.length > 0;
+  const ok = ranDomains
+    && run.steps.every(s => s.status !== 'fail')
+    && run.userDomains.every(d => d.status !== 'fail')
+    && run.adminDomains.every(d => d.status !== 'fail');
+  return { ok, cleanedUp, ephemeralUser: run.ephemeralUser, steps: run.steps, userDomains: run.userDomains, adminDomains: run.adminDomains };
+}
+
+/**
+ * Run the full create→login→per-domain→admin-reject→delete SSO verification
+ * and return a structured report. The ephemeral user is **always** deleted —
+ * on the success path and via `finishRun` on any failure or thrown error.
+ */
+export async function verifySso(options: SsoVerifyOptions = {}): Promise<SsoVerifyReport> {
+  const deps = buildDeps(options.node ?? 'Local', options.deps);
+  const run: SsoRun = {
+    publicDomain: '',
+    ephemeralUser: makeEphemeralUsername(),
+    password: randomBytes(18).toString('hex'), // 36 hex chars, shell-safe
+    steps: [],
+    userDomains: [],
+    adminDomains: [],
+    created: false,
+  };
+
+  const cfg = await getConfig();
+  const publicDomain = cfg.reverseProxy?.publicDomain;
+  if (!publicDomain) {
+    run.steps.push({ id: 'config', status: 'fail', detail: 'reverseProxy.publicDomain is not configured — SSO is not set up yet.' });
+    return finishRun(deps, run);
+  }
+  if (!cfg.installedTemplates?.auth) {
+    run.steps.push({ id: 'config', status: 'skip', detail: 'auth template not installed — nothing to verify.' });
+    return finishRun(deps, run);
+  }
+  run.publicDomain = publicDomain;
+
+  try {
+    if (!(await provisionEphemeralUser(deps, run))) return finishRun(deps, run);
+
+    const login = await deps.autheliaFirstFactor(publicDomain, run.ephemeralUser, run.password);
+    run.steps.push({ id: 'authelia_firstfactor', status: login.ok ? 'pass' : 'fail', detail: login.detail });
+    if (!login.ok || !login.cookie) return finishRun(deps, run);
+
+    await probeAllDomains(deps, run, login.cookie);
+    return finishRun(deps, run);
+  } catch (e) {
+    run.steps.push({ id: 'unexpected_error', status: 'fail', detail: e instanceof Error ? e.message : String(e) });
+    return finishRun(deps, run);
+  }
+}

--- a/packages/backend/src/lib/externalBackup/registerSource.test.ts
+++ b/packages/backend/src/lib/externalBackup/registerSource.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig, mockUpdateConfig, mockTestNas, mockListBackups } = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockUpdateConfig: vi.fn(),
+  mockTestNas: vi.fn(),
+  mockListBackups: vi.fn(),
+}));
+
+vi.mock('../config', () => ({
+  getConfig: () => mockGetConfig(),
+  updateConfig: (u: unknown) => mockUpdateConfig(u),
+}));
+vi.mock('./nasClient', () => ({ testNasConnection: () => mockTestNas() }));
+vi.mock('./producer', () => ({ listServiceBackups: () => mockListBackups() }));
+
+import { registerNasSource, getNasBackupOverview } from './registerSource';
+
+const REG = { host: '192.168.178.1', username: 'fritz9746', password: 'pw' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockResolvedValue({});
+  mockUpdateConfig.mockResolvedValue({});
+  mockTestNas.mockResolvedValue({ ok: true });
+  mockListBackups.mockResolvedValue([{ service: 'home-assistant', tarName: 'home-assistant.tar', size: 2_340_000 }]);
+});
+
+describe('registerNasSource', () => {
+  it('writes the FritzBox gateway when none is configured', async () => {
+    const r = await registerNasSource(REG);
+    expect(r.changed).toBe(true);
+    expect(r.gateway).toEqual({ type: 'fritzbox', host: '192.168.178.1', username: 'fritz9746' });
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      gateway: { type: 'fritzbox', host: '192.168.178.1', username: 'fritz9746', password: 'pw' },
+    });
+  });
+
+  it('is a no-op when the same creds are already registered', async () => {
+    mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', ...REG } });
+    const r = await registerNasSource(REG);
+    expect(r.changed).toBe(false);
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('updates a rotated password while preserving other gateway fields', async () => {
+    mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', host: '192.168.178.1', username: 'fritz9746', password: 'old', ssl: true } });
+    const r = await registerNasSource({ ...REG, password: 'new' });
+    expect(r.changed).toBe(true);
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      gateway: { type: 'fritzbox', host: '192.168.178.1', username: 'fritz9746', password: 'new', ssl: true },
+    });
+  });
+
+  it('trims surrounding whitespace on host/username', async () => {
+    await registerNasSource({ host: '  192.168.178.1 ', username: ' fritz9746 ', password: 'pw' });
+    expect(mockUpdateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ gateway: expect.objectContaining({ host: '192.168.178.1', username: 'fritz9746' }) }),
+    );
+  });
+
+  it.each([
+    ['host', { host: '', username: 'u', password: 'p' }],
+    ['username', { host: 'h', username: '', password: 'p' }],
+    ['password', { host: 'h', username: 'u', password: '' }],
+  ])('rejects a missing %s', async (_field, reg) => {
+    await expect(registerNasSource(reg)).rejects.toThrow(/required/);
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('getNasBackupOverview', () => {
+  it('reports not-configured when no FritzBox gateway is set', async () => {
+    const o = await getNasBackupOverview();
+    expect(o).toEqual({ configured: false, connection: null, backups: [] });
+    expect(mockTestNas).not.toHaveBeenCalled();
+  });
+
+  it('lists NAS backups when configured and connected', async () => {
+    mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', ...REG } });
+    const o = await getNasBackupOverview();
+    expect(o.configured).toBe(true);
+    expect(o.connection).toEqual({ ok: true });
+    expect(o.backups).toEqual([{ service: 'home-assistant', tarName: 'home-assistant.tar', size: 2_340_000 }]);
+  });
+
+  it('surfaces a connection failure with no backups', async () => {
+    mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', ...REG } });
+    mockTestNas.mockResolvedValue({ ok: false, error: '530 Login incorrect' });
+    const o = await getNasBackupOverview();
+    expect(o.connection).toEqual({ ok: false, error: '530 Login incorrect' });
+    expect(o.backups).toEqual([]);
+    expect(mockListBackups).not.toHaveBeenCalled();
+  });
+
+  it('treats a connected-but-listing-failed NAS as empty', async () => {
+    mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', ...REG } });
+    mockListBackups.mockRejectedValue(new Error('sb-backup: No such directory'));
+    const o = await getNasBackupOverview();
+    expect(o.connection).toEqual({ ok: true });
+    expect(o.backups).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/registerSource.ts
+++ b/packages/backend/src/lib/externalBackup/registerSource.ts
@@ -1,0 +1,102 @@
+/**
+ * Register the FritzBox NAS as ServiceBay's external-backup source and surface
+ * what's on it (#1440).
+ *
+ * The NAS target isn't a standalone config blob — it's derived from
+ * `config.gateway` (the FritzBox is both the gateway and the USB-NAS host, see
+ * `nasClient.getNasTarget`). So "register the backup source" means: make sure
+ * `config.gateway` carries the FritzBox host + credentials, so the box knows
+ * where its backups live and can list/restore them.
+ *
+ * The sb-tui NAS upload (#1367) pushes a `home-assistant.tar` straight to the
+ * FritzBox over FTP using creds the operator typed locally — but never told the
+ * box, so the upload was invisible to install/restore. This module is the
+ * missing wire-up: the TUI (or Settings) calls `registerNasSource` with those
+ * same creds, and `getNasBackupOverview` then lets Settings → Backups verify
+ * the connection and list the staged tars (incl. `home-assistant.tar`).
+ */
+import { getConfig, updateConfig, type GatewayConfig } from '../config';
+import { logger } from '../logger';
+import { testNasConnection } from './nasClient';
+import { listServiceBackups, type ServiceBackupListEntry } from './producer';
+
+export interface NasRegistration {
+  host: string;
+  username: string;
+  password: string;
+}
+
+export interface RegisterResult {
+  /** True when this call wrote/updated the gateway; false when it was a no-op
+   *  (the same FritzBox creds were already configured). */
+  changed: boolean;
+  gateway: { type: 'fritzbox'; host: string; username: string };
+}
+
+/**
+ * Persist the FritzBox NAS as the external-backup source by recording its
+ * host + credentials in `config.gateway`. Idempotent: re-registering the same
+ * host/user/password is a no-op (`changed:false`). Updating an existing
+ * FritzBox gateway's creds (e.g. a rotated password) is allowed and preserves
+ * its other fields (e.g. `ssl`); we only flip `type` to `fritzbox`.
+ */
+export async function registerNasSource(reg: NasRegistration): Promise<RegisterResult> {
+  const host = reg.host.trim();
+  const username = reg.username.trim();
+  const password = reg.password;
+  if (!host) throw new Error('host is required to register the NAS backup source');
+  if (!username) throw new Error('username is required to register the NAS backup source');
+  if (!password) throw new Error('password is required to register the NAS backup source');
+
+  const existing = (await getConfig()).gateway;
+  const alreadyRegistered =
+    existing?.type === 'fritzbox' &&
+    existing.host === host &&
+    existing.username === username &&
+    existing.password === password;
+  if (alreadyRegistered) {
+    return { changed: false, gateway: { type: 'fritzbox', host, username } };
+  }
+
+  const gateway: GatewayConfig = { ...existing, type: 'fritzbox', host, username, password };
+  await updateConfig({ gateway });
+  logger.info('ExternalBackup', `Registered FritzBox NAS backup source (${host}) from upload`);
+  return { changed: true, gateway: { type: 'fritzbox', host, username } };
+}
+
+export interface NasBackupOverview {
+  /** True when `config.gateway` carries FritzBox creds (the source is known). */
+  configured: boolean;
+  /** Connection probe result — null when not configured (nothing to probe). */
+  connection: { ok: true } | { ok: false; error: string } | null;
+  /** Service backups staged under `sb-backup/` on the NAS (empty on any error
+   *  or when not configured). */
+  backups: ServiceBackupListEntry[];
+}
+
+/**
+ * Read the registered NAS source's status for Settings → Backups: is a source
+ * configured, does it connect, and which backups are sitting on it. A failed
+ * connection yields `backups: []` rather than throwing — the caller renders the
+ * connection error and offers a retry/verify.
+ */
+export async function getNasBackupOverview(): Promise<NasBackupOverview> {
+  const gw = (await getConfig()).gateway;
+  const configured = gw?.type === 'fritzbox' && Boolean(gw.host && gw.username && gw.password);
+  if (!configured) {
+    return { configured: false, connection: null, backups: [] };
+  }
+  const connection = await testNasConnection();
+  if (!connection.ok) {
+    return { configured: true, connection, backups: [] };
+  }
+  try {
+    const backups = await listServiceBackups();
+    return { configured: true, connection, backups };
+  } catch (e) {
+    // The probe connected but the listing failed (e.g. sb-backup/ absent on a
+    // brand-new NAS) — treat as "connected, nothing staged yet".
+    logger.warn('ExternalBackup', `NAS connected but listing failed: ${e instanceof Error ? e.message : String(e)}`);
+    return { configured: true, connection, backups: [] };
+  }
+}

--- a/packages/backend/src/lib/health/service.ts
+++ b/packages/backend/src/lib/health/service.ts
@@ -10,6 +10,7 @@ import { sendEmailAlert } from '@/lib/email';
 import { NotificationBatcher } from './notificationBatcher';
 import { DATA_DIR } from '@/lib/dirs';
 import { getNodeTwins, subscribeToTwin } from '@/lib/store/repository';
+import { runDiagnoseChecks, DIAGNOSE_INTERVAL_SECONDS } from '@/lib/diagnose/diagnoseChecks';
 
 // In-memory interval tracking
 const intervals = new Map<string, NodeJS.Timeout>();
@@ -50,6 +51,13 @@ export class HealthService {
     //     the cold-start race. See NotificationBatcher for the
     //     coalescing rules.
     NotificationBatcher.start();
+
+    // 1c. Daily self-diagnose run (#1423). The diagnose suite is heavy
+    //     (multi-probe agent fan-out), so it runs once a day rather than
+    //     on the per-minute check cadence. Each probe is persisted as a
+    //     synthetic `diagnose:<probeId>` check result so the Checks tab
+    //     surfaces it with the same per-row stats as any other check.
+    this.startDiagnoseSchedule();
 
     // 2. Start initial scheduling
     this.restartAll();
@@ -133,6 +141,32 @@ export class HealthService {
     } catch (e) {
       logger.warn('Health', `Could not start checks.json watcher: ${e instanceof Error ? e.message : String(e)}`);
     }
+  }
+
+  private static diagnoseTimer: NodeJS.Timeout | null = null;
+
+  /** Kick off a daily self-diagnose run (#1423). Runs once shortly after
+   *  init, then every {@link DIAGNOSE_INTERVAL_SECONDS}. The first run is
+   *  deferred a short while so the agent has a chance to connect — an
+   *  eager run on cold boot would just report "agent not reachable". */
+  private static startDiagnoseSchedule() {
+    if (this.diagnoseTimer) return;
+    const tick = async () => {
+      try {
+        const results = await runDiagnoseChecks('Local');
+        if (this.io) {
+          for (const result of results) {
+            this.io.emit('health:update', { checkId: result.check_id, result });
+          }
+        }
+      } catch (e) {
+        logger.error('Health', 'Daily self-diagnose run failed:', e);
+      }
+    };
+    // Defer the first run ~60 s past boot so the agent is connected.
+    const FIRST_RUN_DELAY_MS = 60_000;
+    setTimeout(() => { void tick(); }, FIRST_RUN_DELAY_MS);
+    this.diagnoseTimer = setInterval(() => { void tick(); }, DIAGNOSE_INTERVAL_SECONDS * 1000);
   }
 
   static getChecks() {

--- a/packages/backend/src/lib/health/store.ts
+++ b/packages/backend/src/lib/health/store.ts
@@ -83,6 +83,20 @@ export class HealthStore {
     }
   }
 
+  /** Every check_id that has a persisted result file on disk. Used by
+   *  the diagnose→checks bridge (#1423) to enumerate synthetic
+   *  `diagnose:<probeId>` rows, which never live in checks.json. */
+  static getResultCheckIds(): string[] {
+    if (!fs.existsSync(RESULTS_DIR)) return [];
+    try {
+      return fs.readdirSync(RESULTS_DIR)
+        .filter(f => f.endsWith('.json'))
+        .map(f => f.slice(0, -'.json'.length));
+    } catch {
+      return [];
+    }
+  }
+
   static getResults(checkId: string): CheckResult[] {
     const resultFile = path.join(RESULTS_DIR, `${checkId}.json`);
     if (!fs.existsSync(resultFile)) return [];

--- a/packages/backend/src/lib/lldap/client.groups.test.ts
+++ b/packages/backend/src/lib/lldap/client.groups.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig } = vi.hoisted(() => ({ mockGetConfig: vi.fn() }));
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+
+import { listLldapGroups, addUserToLldapGroup, deleteLldapUser } from './client';
+
+beforeEach(() => {
+  mockGetConfig.mockResolvedValue({ lldap: { url: 'http://lldap:17170', username: 'admin', password: 'pw' } });
+  vi.restoreAllMocks();
+});
+
+/** auth/simple/login succeeds, then the graphql call returns `graphqlBody`. */
+function stubFetch(graphqlBody: unknown) {
+  vi.stubGlobal('fetch', vi.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => graphqlBody }));
+}
+
+describe('listLldapGroups', () => {
+  it('returns the group list', async () => {
+    stubFetch({ data: { groups: [{ id: 1, displayName: 'admins' }, { id: 2, displayName: 'family' }] } });
+    const r = await listLldapGroups();
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.groups.find(g => g.displayName === 'family')?.id).toBe(2);
+  });
+
+  it('surfaces a graphql error', async () => {
+    stubFetch({ errors: [{ message: 'boom' }] });
+    const r = await listLldapGroups();
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('graphql_error');
+  });
+
+  it('fails with not_configured when LLDAP creds are absent', async () => {
+    mockGetConfig.mockResolvedValue({});
+    const r = await listLldapGroups();
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('not_configured');
+  });
+});
+
+describe('addUserToLldapGroup', () => {
+  it('returns ok when LLDAP confirms', async () => {
+    stubFetch({ data: { addUserToGroup: { ok: true } } });
+    const r = await addUserToLldapGroup('alice', 2);
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails when LLDAP does not confirm ok:true', async () => {
+    stubFetch({ data: { addUserToGroup: { ok: false } } });
+    const r = await addUserToLldapGroup('alice', 2);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('deleteLldapUser', () => {
+  it('returns ok when deletion confirmed', async () => {
+    stubFetch({ data: { deleteUser: { ok: true } } });
+    const r = await deleteLldapUser('alice');
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails when LLDAP reports an error (e.g. user already gone)', async () => {
+    stubFetch({ errors: [{ message: 'no such user' }] });
+    const r = await deleteLldapUser('ghost');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('graphql_error');
+  });
+});

--- a/packages/backend/src/lib/lldap/client.ts
+++ b/packages/backend/src/lib/lldap/client.ts
@@ -269,6 +269,120 @@ export async function exportLldapDirectory(): Promise<LldapExportResult> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Group + lifecycle primitives used by the SSO verification module (#1453).
+// These mirror the GraphQL calls scripts/smoke/sso-verify.sh makes against the
+// admin token, but in-process: list the groups (so a caller can resolve the
+// `family`/`admins` group ids Authelia's rules key off), add a user to a
+// group, and delete a user (the smoke test's guaranteed teardown). Same
+// `{ ok, ... }` discriminated-union shape as the rest of the client.
+// ---------------------------------------------------------------------------
+
+const LIST_GROUPS_QUERY = `
+  query Groups {
+    groups { id displayName }
+  }
+`;
+
+const ADD_USER_TO_GROUP_MUTATION = `
+  mutation AddUserToGroup($userId: String!, $groupId: Int!) {
+    addUserToGroup(userId: $userId, groupId: $groupId) { ok }
+  }
+`;
+
+const DELETE_USER_MUTATION = `
+  mutation DeleteUser($userId: String!) {
+    deleteUser(userId: $userId) { ok }
+  }
+`;
+
+type LldapMutationReason =
+  | 'not_configured'
+  | 'unreachable'
+  | 'auth_failed'
+  | 'graphql_error'
+  | 'network_error';
+
+/** Run an authenticated GraphQL request against LLDAP, returning the parsed
+ *  `data`/`errors` body or a discriminated failure. Centralises the auth +
+ *  fetch + error-mapping boilerplate the group/lifecycle calls share. */
+async function runAuthedGraphql<T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<{ ok: true; data: T } | { ok: false; reason: LldapMutationReason; message: string }> {
+  const auth = await authenticateWithLldap();
+  if (!auth.ok) return { ok: false, reason: auth.reason, message: auth.message };
+  try {
+    const res = await fetch(`${auth.baseUrl}/api/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${auth.token}` },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+    const body = await res.json().catch(() => ({})) as { data?: T; errors?: Array<{ message?: string }> };
+    if (body.errors?.length) {
+      return { ok: false, reason: 'graphql_error', message: body.errors[0]?.message ?? 'Unknown LLDAP error.' };
+    }
+    if (body.data === undefined) {
+      return { ok: false, reason: 'graphql_error', message: 'LLDAP response had no data.' };
+    }
+    return { ok: true, data: body.data };
+  } catch (e) {
+    return { ok: false, reason: 'network_error', message: e instanceof Error ? e.message : 'Network error talking to LLDAP.' };
+  }
+}
+
+export interface LldapGroup {
+  id: number;
+  displayName: string;
+}
+
+export type LldapListGroupsResult =
+  | { ok: true; groups: LldapGroup[] }
+  | { ok: false; reason: LldapMutationReason; message: string };
+
+/** List every LLDAP group (id + displayName). Lets a caller resolve the
+ *  numeric group id for `family` / `admins` — Authelia's access rules key
+ *  off membership in those, and `addUserToGroup` takes the numeric id. */
+export async function listLldapGroups(): Promise<LldapListGroupsResult> {
+  const r = await runAuthedGraphql<{ groups?: LldapGroup[] }>(LIST_GROUPS_QUERY);
+  if (!r.ok) return r;
+  return { ok: true, groups: r.data.groups ?? [] };
+}
+
+export type LldapMutationResult =
+  | { ok: true }
+  | { ok: false; reason: LldapMutationReason; message: string };
+
+/** Add an existing user to a group by numeric group id. */
+export async function addUserToLldapGroup(userId: string, groupId: number): Promise<LldapMutationResult> {
+  const r = await runAuthedGraphql<{ addUserToGroup?: { ok?: boolean } }>(
+    ADD_USER_TO_GROUP_MUTATION,
+    { userId, groupId },
+  );
+  if (!r.ok) return r;
+  if (r.data.addUserToGroup?.ok !== true) {
+    return { ok: false, reason: 'graphql_error', message: `LLDAP did not confirm adding ${userId} to group ${groupId}.` };
+  }
+  return { ok: true };
+}
+
+/** Delete an LLDAP user by id. Used as the SSO-verify module's guaranteed
+ *  ephemeral-user teardown — safe to call even if the user was never fully
+ *  provisioned (a missing user surfaces as a graphql_error the caller can
+ *  treat as already-gone). */
+export async function deleteLldapUser(userId: string): Promise<LldapMutationResult> {
+  const r = await runAuthedGraphql<{ deleteUser?: { ok?: boolean } }>(
+    DELETE_USER_MUTATION,
+    { userId },
+  );
+  if (!r.ok) return r;
+  if (r.data.deleteUser?.ok !== true) {
+    return { ok: false, reason: 'graphql_error', message: `LLDAP did not confirm deletion of ${userId}.` };
+  }
+  return { ok: true };
+}
+
 /**
  * LLDAP's web UI URL for a specific user's detail page — used as the
  * deep-link target after auto-create so the admin lands directly on

--- a/packages/backend/src/lib/portal/lanGate.test.ts
+++ b/packages/backend/src/lib/portal/lanGate.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isPortalBlockedForRequest } from './lanGate';
+
+// Production reality: behind NPM the RSC peer is loopback, so the
+// resolver trusts X-Real-IP. These cases pin both the "off" no-op and
+// the LAN/public classification through the proxy headers.
+const loopbackPeer = '127.0.0.1';
+
+describe('isPortalBlockedForRequest (#1456)', () => {
+  it('never blocks when lanOnly is off (undefined/false)', () => {
+    expect(isPortalBlockedForRequest(undefined, { 'x-real-ip': '8.8.8.8' }, loopbackPeer)).toBe(false);
+    expect(isPortalBlockedForRequest(false, { 'x-real-ip': '8.8.8.8' }, loopbackPeer)).toBe(false);
+  });
+
+  it('blocks a public client when lanOnly is on', () => {
+    expect(isPortalBlockedForRequest(true, { 'x-real-ip': '8.8.8.8' }, loopbackPeer)).toBe(true);
+  });
+
+  it('allows a LAN client (RFC1918 X-Real-IP via the proxy)', () => {
+    expect(isPortalBlockedForRequest(true, { 'x-real-ip': '192.168.178.50' }, loopbackPeer)).toBe(false);
+    expect(isPortalBlockedForRequest(true, { 'x-real-ip': '10.0.0.4' }, loopbackPeer)).toBe(false);
+  });
+
+  it('uses the last X-Forwarded-For hop when X-Real-IP is absent', () => {
+    // last hop is nginx-appended (trusted); a spoofed left-most LAN IP must not win.
+    expect(isPortalBlockedForRequest(true, { 'x-forwarded-for': '192.168.1.9, 8.8.8.8' }, loopbackPeer)).toBe(true);
+    expect(isPortalBlockedForRequest(true, { 'x-forwarded-for': '8.8.8.8, 192.168.1.9' }, loopbackPeer)).toBe(false);
+  });
+
+  it('falls back to the socket peer for a direct (non-loopback) connection, ignoring spoofable headers', () => {
+    expect(isPortalBlockedForRequest(true, { 'x-real-ip': '192.168.1.9' }, '8.8.8.8')).toBe(true);
+    expect(isPortalBlockedForRequest(true, {}, '192.168.1.9')).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/portal/lanGate.ts
+++ b/packages/backend/src/lib/portal/lanGate.ts
@@ -1,0 +1,34 @@
+/**
+ * Optional LAN-only gate for the family `/portal` page (#1456).
+ *
+ * When `config.portalLanOnly` is on, the portal renders only for
+ * LAN-shaped clients so the request-access landing page isn't publicly
+ * reachable. This is an app-level gate: the portal page resolves the
+ * real client IP (loopback peer → trust NPM's `X-Real-IP` / last XFF
+ * hop, same rule the MCP bootstrap-token gate uses) and classifies it
+ * with `isLanIp`. A proxy access-list would be stronger, but the issue
+ * scoped the app gate as the simpler, non-`security` choice; the public
+ * request-access POST endpoint keeps its own cap + anti-spam guards.
+ */
+
+import { isLanIp, clientIpForLanGate } from '@/lib/mcp/bootstrapToken';
+
+/**
+ * Decide whether to block the portal render for this request.
+ *
+ *   - `lanOnly` off → never block (returns false regardless of IP).
+ *   - `lanOnly` on  → block when the resolved client IP isn't LAN-shaped.
+ *
+ * `headers` is a plain lower-cased header map (Next's `headers()` is
+ * already lower-cased); `socketAddr` is the TCP peer when known. Pure
+ * and dependency-free so it unit-tests without a request.
+ */
+export function isPortalBlockedForRequest(
+  lanOnly: boolean | undefined,
+  headers: Record<string, string | string[] | undefined>,
+  socketAddr: string | undefined,
+): boolean {
+  if (!lanOnly) return false;
+  const clientIp = clientIpForLanGate(headers, socketAddr);
+  return !isLanIp(clientIp);
+}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Loader2, Save, Users } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+/**
+ * Settings section for the family-portal access limits (#1456):
+ *   - maxUsers      — cap on approved LLDAP users + pending requests.
+ *                     New /portal access requests are rejected once hit.
+ *   - portalLanOnly — serve /portal to LAN clients only (app gate).
+ *
+ * Sits next to the Access requests section since both govern who can
+ * get onto the home server via the portal. Reads/writes config via
+ * /api/system/portal-settings; both knobs survive restart.
+ */
+export default function PortalAccessSection() {
+  const { addToast } = useToast();
+  const [maxUsers, setMaxUsers] = useState(20);
+  const [lanOnly, setLanOnly] = useState(false);
+  const [busy, setBusy] = useState<'load' | 'save' | null>('load');
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/system/portal-settings')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!alive || !data) return;
+        if (typeof data.maxUsers === 'number') setMaxUsers(data.maxUsers);
+        if (typeof data.portalLanOnly === 'boolean') setLanOnly(data.portalLanOnly);
+      })
+      .catch(() => {})
+      .finally(() => { if (alive) setBusy(null); });
+    return () => { alive = false; };
+  }, []);
+
+  const save = async (next: { maxUsers: number; portalLanOnly: boolean }) => {
+    setBusy('save');
+    try {
+      const res = await fetch('/api/system/portal-settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(next),
+      });
+      if (res.ok) {
+        addToast('success', 'Saved', 'Portal access settings updated.');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        addToast('error', 'Could not save', typeof data.error === 'string' ? data.error : `HTTP ${res.status}`);
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onToggleLanOnly = (value: boolean) => {
+    setLanOnly(value);
+    void save({ maxUsers, portalLanOnly: value });
+  };
+
+  const onSaveMaxUsers = () => {
+    if (!Number.isInteger(maxUsers) || maxUsers < 1) {
+      addToast('error', 'Invalid limit', 'Enter a whole number of 1 or more.');
+      return;
+    }
+    void save({ maxUsers, portalLanOnly: lanOnly });
+  };
+
+  if (busy === 'load') {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading portal settings…
+      </div>
+    );
+  }
+
+  return (
+    <div id="portal-access" className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full scroll-mt-24">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
+          <Users size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">Portal access</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Limits for the family portal at <span className="font-mono">/portal</span>.
+          </p>
+        </div>
+      </div>
+
+      <div className="p-6 space-y-6">
+        <div>
+          <label htmlFor="max-users" className="block text-sm font-medium text-gray-900 dark:text-white">
+            Maximum users
+          </label>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            New access requests are blocked once approved users plus pending requests reach this. Lower it for a small household (e.g. 5).
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              id="max-users"
+              type="number"
+              min={1}
+              max={100000}
+              value={maxUsers}
+              onChange={e => setMaxUsers(Number(e.target.value))}
+              disabled={busy === 'save'}
+              className="w-28 px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white disabled:opacity-50"
+            />
+            <button
+              onClick={onSaveMaxUsers}
+              disabled={busy === 'save'}
+              className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50"
+            >
+              {busy === 'save' ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+              Save
+            </button>
+          </div>
+        </div>
+
+        <div className="flex items-start justify-between gap-4 pt-2 border-t border-gray-100 dark:border-gray-700/50">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-gray-900 dark:text-white">LAN-only portal</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Serve <span className="font-mono">/portal</span> to home-network clients only. Visitors from the public internet see a short notice instead of the service grid.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={lanOnly}
+            aria-label="LAN-only portal"
+            onClick={() => onToggleLanOnly(!lanOnly)}
+            disabled={busy === 'save'}
+            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${lanOnly ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'}`}
+          >
+            <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${lanOnly ? 'translate-x-6' : 'translate-x-1'}`} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -143,6 +143,17 @@ export default function BackupsSettingsPage() {
   const [nginxDiag, setNginxDiag] = useState<{ reason: string; debug: string[]; node?: string; confDir?: string } | null>(null);
   const [nginxDiagExpanded, setNginxDiagExpanded] = useState(false);
 
+  // NAS (FritzBox) external-backup source — the config-survival backups the
+  // sb-tui upload stages under sb-backup/ (e.g. home-assistant.tar). #1440.
+  const [nasOverview, setNasOverview] = useState<{
+    configured: boolean;
+    connection: { ok: true } | { ok: false; error: string } | null;
+    backups: { service: string; tarName: string; size: number }[];
+  } | null>(null);
+  const [nasLoading, setNasLoading] = useState(true);
+  const [nasRestoring, setNasRestoring] = useState<string | null>(null);
+  const [nasRestoreTarget, setNasRestoreTarget] = useState<{ service: string; tarName: string } | null>(null);
+
   const fetchBackups = useCallback(async () => {
     setBackupsLoading(true);
     try {
@@ -221,6 +232,46 @@ export default function BackupsSettingsPage() {
   }, []);
 
   useEffect(() => { void checkNginxStatus(); }, [checkNginxStatus]);
+
+  const fetchNasOverview = useCallback(async () => {
+    setNasLoading(true);
+    try {
+      const res = await fetch('/api/system/external-backup/list');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Unable to read NAS backups');
+      setNasOverview({ configured: data.configured, connection: data.connection, backups: data.backups ?? [] });
+    } catch (error) {
+      // A failure here is informational (the source may just not be configured);
+      // show the empty/unconfigured state rather than a blocking toast.
+      console.error(error);
+      setNasOverview({ configured: false, connection: null, backups: [] });
+    } finally {
+      setNasLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void fetchNasOverview(); }, [fetchNasOverview]);
+
+  const confirmRestoreNasBackup = useCallback(async () => {
+    if (!nasRestoreTarget || nasRestoring) return;
+    const { service, tarName } = nasRestoreTarget;
+    setNasRestoring(service);
+    try {
+      const res = await fetch('/api/system/external-backup/restore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ service }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Restore failed');
+      addToast('success', 'Restored from NAS', `${tarName} → ${data.dataDir} (${data.files} files)`);
+    } catch (error) {
+      addToast('error', 'NAS restore failed', error instanceof Error ? error.message : 'Unknown error');
+    } finally {
+      setNasRestoring(null);
+      setNasRestoreTarget(null);
+    }
+  }, [nasRestoreTarget, nasRestoring, addToast]);
 
   // ─── Backup Sync handlers ─────────────────────────────────────────
   const buildBackupTarget = () => {
@@ -1018,6 +1069,88 @@ export default function BackupsSettingsPage() {
         </div>
       </div>
 
+      {/* NAS Backups (FritzBox) — the config-survival source the sb-tui upload
+          stages under sb-backup/, e.g. home-assistant.tar (#1440). */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex flex-col gap-3 md:flex-row md:items-center">
+          <div className="flex items-center gap-3 flex-1">
+            <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-300">
+              <Network size={20} />
+            </div>
+            <div>
+              <h3 className="font-bold text-gray-900 dark:text-white">NAS Backups (FritzBox)</h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Config backups staged on the FritzBox USB NAS — including a Home Assistant backup uploaded from the installer — that a fresh install can restore.</p>
+            </div>
+          </div>
+          <button
+            onClick={() => void fetchNasOverview()}
+            disabled={nasLoading}
+            className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200 text-sm rounded-lg border border-gray-300 dark:border-gray-700 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+          >
+            {nasLoading ? <Loader2 className="animate-spin" size={16} /> : <RefreshCw size={16} />} Verify connection
+          </button>
+        </div>
+        <div className="p-6">
+          {nasLoading ? (
+            <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+              <Loader2 className="animate-spin" size={18} /> Checking NAS…
+            </div>
+          ) : !nasOverview?.configured ? (
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              No NAS backup source registered. Upload a backup from the ServiceBay installer (TUI), or set the FritzBox gateway in{' '}
+              <span className="font-medium">Settings → Integrations</span>, and the box will discover backups staged on the NAS here.
+            </div>
+          ) : nasOverview.connection && !nasOverview.connection.ok ? (
+            <div className="flex items-start gap-2 text-sm text-red-600 dark:text-red-300">
+              <XCircle size={16} className="mt-0.5 shrink-0" />
+              <span>Could not reach the NAS: <span className="font-mono break-all">{nasOverview.connection.error}</span></span>
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center gap-2 text-xs text-emerald-600 dark:text-emerald-300 mb-3">
+                <CheckCircle2 size={14} /> Connected to the FritzBox NAS.
+              </div>
+              {nasOverview.backups.length === 0 ? (
+                <div className="text-sm text-gray-500 dark:text-gray-400 italic">No backups staged on the NAS yet.</div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-800">
+                        <th className="py-2 font-medium">Service</th>
+                        <th className="py-2 font-medium">File</th>
+                        <th className="py-2 font-medium">Size</th>
+                        <th className="py-2 font-medium text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                      {nasOverview.backups.map(b => (
+                        <tr key={b.tarName}>
+                          <td className="py-3 text-gray-700 dark:text-gray-200">{b.service}</td>
+                          <td className="py-3 font-mono text-xs text-blue-600 dark:text-blue-300 break-all">{b.tarName}</td>
+                          <td className="py-3 text-gray-700 dark:text-gray-300">{formatBytes(b.size)}</td>
+                          <td className="py-3">
+                            <div className="flex justify-end">
+                              <button
+                                onClick={() => setNasRestoreTarget({ service: b.service, tarName: b.tarName })}
+                                disabled={nasRestoring !== null}
+                                className="text-xs px-3 py-1.5 rounded-md border border-amber-300 text-amber-700 dark:text-amber-300 dark:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors flex items-center gap-1 disabled:opacity-60"
+                              >
+                                {nasRestoring === b.service ? <Loader2 className="animate-spin" size={14} /> : <RotateCcw size={14} />} Restore
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
       {/* Backup Sync */}
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
         <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
@@ -1297,6 +1430,16 @@ export default function BackupsSettingsPage() {
         isDestructive
         onConfirm={confirmDeleteBackup}
         onCancel={() => !deletingBackup && setDeleteTarget(null)}
+      />
+
+      <ConfirmModal
+        isOpen={!!nasRestoreTarget}
+        title="Restore from NAS"
+        message={`Restore ${nasRestoreTarget?.tarName ?? 'this backup'} from the FritzBox NAS into ${nasRestoreTarget?.service ?? 'the service'}'s data dir? This only seeds a fresh/empty data dir; a service with existing data is left untouched.`}
+        confirmText={nasRestoring ? 'Restoring…' : 'Restore'}
+        confirmDisabled={nasRestoring !== null}
+        onConfirm={confirmRestoreNasBackup}
+        onCancel={() => nasRestoring === null && setNasRestoreTarget(null)}
       />
 
       <ConfirmModal

--- a/packages/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -8,6 +8,7 @@ import FileShareSection from '../_lib/sections/FileShareSection';
 import GatewaySection from '../_lib/sections/GatewaySection';
 import McpSection from '../_lib/sections/McpSection';
 import PendingSkillsSection from '../_lib/sections/PendingSkillsSection';
+import PortalAccessSection from '../_lib/sections/PortalAccessSection';
 import PublicDomainSection from '../_lib/sections/PublicDomainSection';
 import ReverseProxySection from '../_lib/sections/ReverseProxySection';
 import TemplateRegistriesSection from '../_lib/sections/TemplateRegistriesSection';
@@ -19,6 +20,7 @@ export default function IntegrationsSettingsPage() {
       <PublicDomainSection />
       <GatewaySection />
       <AccessRequestsSection />
+      <PortalAccessSection />
       <PendingSkillsSection />
       <CredentialsSection />
       <ReverseProxySection />

--- a/packages/frontend/src/app/api/auth/login/reconcile.test.ts
+++ b/packages/frontend/src/app/api/auth/login/reconcile.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reconcileLogin, type ReconcileDeps } from './reconcile';
+
+// Fake scrypt-like primitives: a "hash" is just `h:<plain>`, and verify checks
+// the plaintext against the encoded plaintext. Lets the policy be asserted
+// without real crypto.
+function fakeDeps(): ReconcileDeps {
+  return {
+    hashPassword: vi.fn(async (plain: string) => `h:${plain}`),
+    verifyPassword: vi.fn(async (plain: string, encoded: string) => encoded === `h:${plain}`),
+  };
+}
+
+describe('reconcileLogin', () => {
+  it('accepts the stored password and does NOT re-key (operator-changed pw wins)', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'operator-pw', storedHash: 'h:operator-pw', bootstrapPassword: 'new-env-pw' },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: true });
+    expect(res.newStoredHash).toBeUndefined();
+  });
+
+  it('reconciles on reinstall: stored hash rejects, env password accepts and re-keys', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'new-env-pw', storedHash: 'h:old-install-pw', bootstrapPassword: 'new-env-pw' },
+      deps,
+    );
+    expect(res.authenticated).toBe(true);
+    expect(res.newStoredHash).toBe('h:new-env-pw');
+  });
+
+  it('does not let the env password win while a stored hash still authenticates the request', async () => {
+    // Wrong candidate: neither the stored nor the env password matches.
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'guess', storedHash: 'h:operator-pw', bootstrapPassword: 'new-env-pw' },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: false });
+  });
+
+  it('rejects when stored hash rejects and there is no bootstrap password', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'whatever', storedHash: 'h:operator-pw', bootstrapPassword: null },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: false });
+  });
+
+  it('seeds the stored hash from the env password on a first login with no stored hash', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'env-pw', storedHash: null, bootstrapPassword: 'env-pw' },
+      deps,
+    );
+    expect(res.authenticated).toBe(true);
+    expect(res.newStoredHash).toBe('h:env-pw');
+  });
+
+  it('rejects when nothing is configured (no stored hash, no bootstrap)', async () => {
+    const deps = fakeDeps();
+    const res = await reconcileLogin(
+      { candidate: 'x', storedHash: null, bootstrapPassword: null },
+      deps,
+    );
+    expect(res).toEqual({ authenticated: false });
+  });
+
+  it('tries the stored hash before the env password (precedence order)', async () => {
+    const order: string[] = [];
+    const deps: ReconcileDeps = {
+      hashPassword: async (p) => `h:${p}`,
+      verifyPassword: async (_p, encoded) => {
+        order.push(encoded);
+        return false; // force fall-through so both verifies run
+      },
+    };
+    await reconcileLogin(
+      { candidate: 'c', storedHash: 'h:stored', bootstrapPassword: 'env' },
+      deps,
+    );
+    expect(order).toEqual(['h:stored', 'h:env']);
+  });
+});

--- a/packages/frontend/src/app/api/auth/login/reconcile.ts
+++ b/packages/frontend/src/app/api/auth/login/reconcile.ts
@@ -1,0 +1,90 @@
+// Credential reconciliation for the ServiceBay admin login.
+//
+// `config.auth.passwordHash` lives on /mnt/data, which SURVIVES a reinstall.
+// A reinstall bakes a fresh `SERVICEBAY_PASSWORD` into the quadlet and hands
+// the operator that new password — but a stored hash from a prior install
+// would shadow it, locking the operator out (issue #1438). This is the same
+// reinstall-over-persisted-data credential-lockout class we already auto-heal
+// for LLDAP (FORCE_RESET) and NPM (auto-rekey).
+//
+// Policy (self-heal-when-safe, never mask a failure):
+//   1. The STORED hash is always tried first. A deliberately operator-changed
+//      password keeps working and is never overridden — the env password only
+//      ever wins when the stored credential does NOT authenticate the request.
+//   2. If the stored hash rejects the password but the env bootstrap password
+//      accepts it, the request is at the genuine reinstall/bootstrap boundary:
+//      authenticate AND re-key the stored hash to the env password so the
+//      stored credential converges on what sb-tui showed the operator.
+//   3. With no stored hash, the env password authenticates as before.
+//
+// The verify/hash primitives are injected so this module stays pure and
+// Next.js-free (testable without the route handler).
+
+export interface ReconcileInput {
+  /** The password supplied by the client. */
+  candidate: string;
+  /** Stored hash from config.auth.passwordHash (undefined / invalid => treated as absent). */
+  storedHash: string | null;
+  /** The deploy-time SERVICEBAY_PASSWORD env value, if set. */
+  bootstrapPassword: string | null;
+}
+
+export interface ReconcileDeps {
+  verifyPassword: (plain: string, encoded: string) => Promise<boolean>;
+  hashPassword: (plain: string) => Promise<string>;
+}
+
+export interface ReconcileResult {
+  /** Whether the candidate authenticated. */
+  authenticated: boolean;
+  /**
+   * When set, the stored hash should be (re)written to this value: either the
+   * freshly-minted bootstrap hash on a reinstall reconcile, or the first-login
+   * seed when there was no stored hash yet. Undefined => leave config untouched.
+   */
+  newStoredHash?: string;
+}
+
+/**
+ * Decide whether the candidate password authenticates and whether the stored
+ * hash should be reconciled. Runs verifies in a fixed order so a stored hash
+ * is never silently overridden by the env password unless the stored hash
+ * actually rejects the request.
+ *
+ * The caller is responsible for the username match and the timing-equalization
+ * dummy verify on a username miss; this helper assumes the username matched.
+ */
+export async function reconcileLogin(
+  input: ReconcileInput,
+  deps: ReconcileDeps,
+): Promise<ReconcileResult> {
+  const { candidate, storedHash, bootstrapPassword } = input;
+
+  // 1. Stored credential takes precedence — an operator-changed password keeps
+  //    working and is never overridden by the env password.
+  if (storedHash) {
+    if (await deps.verifyPassword(candidate, storedHash)) {
+      return { authenticated: true };
+    }
+    // Stored hash rejected. Reinstall/bootstrap boundary: the env password may
+    // be the new credential the operator was handed. Allow it to win HERE only,
+    // and re-key the stored hash so the stored credential converges on it.
+    if (bootstrapPassword) {
+      const bootstrapHash = await deps.hashPassword(bootstrapPassword);
+      if (await deps.verifyPassword(candidate, bootstrapHash)) {
+        return { authenticated: true, newStoredHash: bootstrapHash };
+      }
+    }
+    return { authenticated: false };
+  }
+
+  // 2. No stored hash: env password authenticates and seeds the stored hash.
+  if (bootstrapPassword) {
+    const bootstrapHash = await deps.hashPassword(bootstrapPassword);
+    if (await deps.verifyPassword(candidate, bootstrapHash)) {
+      return { authenticated: true, newStoredHash: bootstrapHash };
+    }
+  }
+
+  return { authenticated: false };
+}

--- a/packages/frontend/src/app/api/auth/login/route.ts
+++ b/packages/frontend/src/app/api/auth/login/route.ts
@@ -6,6 +6,7 @@ import { checkRateLimit, recordFailure, clearAttempts, clientKeyFromHeaders } fr
 import { isRequestSecure } from '@/lib/auth/requestSecurity';
 import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
+import { reconcileLogin } from './reconcile';
 
 // Pre-hashed sentinel used when the supplied username does not match. Verifying
 // against this hash is intentionally indistinguishable in timing from verifying
@@ -70,33 +71,38 @@ export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
 
     // Always run scrypt verify regardless of whether the username matched, so
     // a wrong-username response takes the same wall-clock time as a wrong-password
-    // response. We discard the verify result if the username didn't match.
+    // response. On a username miss we verify against a dummy hash and discard it.
     const usernameMatches = username === configUsername;
 
-    let referenceHash: string;
-    let tempBootstrapHash: string | null = null;
-    if (usernameMatches && configHash) {
-      referenceHash = configHash;
-    } else if (usernameMatches && bootstrapPassword) {
-      tempBootstrapHash = await hashPassword(bootstrapPassword);
-      referenceHash = tempBootstrapHash;
+    let authenticated = false;
+    let newStoredHash: string | undefined;
+    if (usernameMatches) {
+      // Reconcile the reinstall-over-persisted-data lockout: a stored hash from
+      // a prior install must not shadow the fresh SERVICEBAY_PASSWORD that
+      // sb-tui handed the operator (issue #1438). The stored hash is tried
+      // first, so an operator-changed password is never overridden — the env
+      // password only wins (and re-keys the stored hash) when the stored
+      // credential rejects the request.
+      const result = await reconcileLogin(
+        { candidate: password, storedHash: configHash ?? null, bootstrapPassword: bootstrapPassword ?? null },
+        { verifyPassword, hashPassword },
+      );
+      authenticated = result.authenticated;
+      newStoredHash = result.newStoredHash;
     } else {
-      referenceHash = await getDummyHash();
+      await verifyPassword(password, await getDummyHash());
     }
 
-    const verifyOk = await verifyPassword(password, referenceHash);
-    const ok = usernameMatches && verifyOk;
-
-    if (!ok) {
+    if (!authenticated) {
       recordFailure(clientKey);
       recordFailure(uKey);
       logger.warn('auth:login', 'failed login', { ip: clientKey, username });
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
     }
 
-    if (tempBootstrapHash) {
+    if (newStoredHash) {
       const { updateConfig } = await import('@/lib/config');
-      await updateConfig({ auth: { username: configUsername, passwordHash: tempBootstrapHash } });
+      await updateConfig({ auth: { username: configUsername, passwordHash: newStoredHash } });
     }
 
     clearAttempts(clientKey);

--- a/packages/frontend/src/app/api/health/checks/[id]/run/route.ts
+++ b/packages/frontend/src/app/api/health/checks/[id]/run/route.ts
@@ -4,6 +4,7 @@ import { CheckRunner } from '@/lib/health/runner';
 import { CheckIdString } from '@/lib/api/schemas';
 import { apiError } from '@/lib/api/errors';
 import { withApiHandlerParams } from '@/lib/api/handler';
+import { isDiagnoseCheckId, runDiagnoseChecks } from '@/lib/diagnose/diagnoseChecks';
 
 type Params = { id: string };
 
@@ -15,6 +16,23 @@ export const POST = withApiHandlerParams<undefined, undefined, Params>(
       return NextResponse.json({ error: 'invalid id' }, { status: 400 });
     }
     const id = check.data;
+
+    // #1423: diagnose rows are synthetic (not in checks.json). Running
+    // one re-runs the whole suite on-demand and returns this probe's
+    // freshly-persisted result.
+    if (isDiagnoseCheckId(id)) {
+      try {
+        const results = await runDiagnoseChecks('Local');
+        const result = results.find(r => r.check_id === id);
+        if (!result) {
+          return NextResponse.json({ error: 'Diagnose probe not found' }, { status: 404 });
+        }
+        return NextResponse.json(result);
+      } catch (e: unknown) {
+        return apiError(e, { tag: 'api:health:run:diagnose', status: 500 });
+      }
+    }
+
     const checks = HealthStore.getChecks();
     const target = checks.find(c => c.id === id);
 

--- a/packages/frontend/src/app/api/health/checks/route.ts
+++ b/packages/frontend/src/app/api/health/checks/route.ts
@@ -5,6 +5,7 @@ import { CheckConfig } from '@/lib/health/types';
 import { v4 as uuidv4 } from 'uuid';
 import { withApiHandler } from '@/lib/api/handler';
 import { HealthCheckTarget, NodeName } from '@/lib/api/schemas';
+import { getDiagnoseChecksEnriched } from '@/lib/diagnose/diagnoseChecks';
 
 export const GET = withApiHandler({}, async () => {
   const checks = HealthStore.getChecks();
@@ -28,7 +29,11 @@ export const GET = withApiHandler({}, async () => {
       history
     };
   });
-  return NextResponse.json(enrichedChecks);
+  // #1423: fold the daily self-diagnose probes into the unified Checks
+  // list. They live as synthetic `diagnose:<probeId>` result rows (never
+  // in checks.json), so merge them in at read time.
+  const diagnoseChecks = getDiagnoseChecksEnriched();
+  return NextResponse.json([...enrichedChecks, ...diagnoseChecks]);
 });
 
 const CheckPostBody = z.object({

--- a/packages/frontend/src/app/api/system/external-backup/list/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/list/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { getNasBackupOverview } from '@/lib/externalBackup/registerSource';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET — the NAS backup source overview for Settings → Backups (#1440): is a
+ * FritzBox NAS source registered, does it connect, and which service backups
+ * (incl. `home-assistant.tar`) are staged under `sb-backup/`. Read-only; the
+ * restore happens via the existing `/external-backup/restore` route.
+ * `tokenScope: 'read'` so the sb-tui flow can poll it with a scoped token; a
+ * browser session cookie is also accepted.
+ */
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
+  try {
+    const overview = await getNasBackupOverview();
+    return NextResponse.json({ ok: true, ...overview });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:external-backup:list', status: 400, exposeMessage: true });
+  }
+});

--- a/packages/frontend/src/app/api/system/external-backup/register/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/register/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { registerNasSource } from '@/lib/externalBackup/registerSource';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST { host, username, password } — register the FritzBox NAS as the
+ * external-backup source by recording its creds in `config.gateway` (#1440).
+ * The sb-tui NAS upload calls this after pushing `home-assistant.tar`, so the
+ * box knows where its backups live and the upload is discoverable by
+ * install/restore (it was previously invisible — the box's gateway was empty).
+ * Idempotent. `tokenScope: 'mutate'` (it writes config) so the sb-tui flow can
+ * trigger it with a scoped `sb_` token; a browser session cookie also works.
+ */
+export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request }) => {
+  try {
+    const body = (await request.json().catch(() => ({}))) as {
+      host?: unknown;
+      username?: unknown;
+      password?: unknown;
+    };
+    if (typeof body.host !== 'string' || typeof body.username !== 'string' || typeof body.password !== 'string') {
+      return NextResponse.json({ error: 'host, username and password (strings) are required' }, { status: 400 });
+    }
+    const result = await registerNasSource({ host: body.host, username: body.username, password: body.password });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (e) {
+    // registerNasSource throws curated, operator-fixable messages (missing
+    // field); surface them like the sibling external-backup routes.
+    return apiError(e, { tag: 'api:system:external-backup:register', status: 400, exposeMessage: true });
+  }
+});

--- a/packages/frontend/src/app/api/system/portal-settings/route.ts
+++ b/packages/frontend/src/app/api/system/portal-settings/route.ts
@@ -1,0 +1,36 @@
+/**
+ * GET + PUT /api/system/portal-settings (#1456).
+ *
+ * Admin surface for the two family-portal knobs:
+ *   - maxUsers     — cap on approved LLDAP users + pending requests
+ *                    (enforced in access-requests POST; default 20).
+ *   - portalLanOnly — serve /portal to LAN clients only (app gate).
+ *
+ * Both persist to config.json and survive restart (getConfig/updateConfig).
+ */
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getConfig, updateConfig } from '@/lib/config';
+import { DEFAULT_MAX_USERS } from '@/lib/portal/userCap';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+const BodySchema = z.object({
+  maxUsers: z.number().int().positive().max(100000),
+  portalLanOnly: z.boolean(),
+});
+
+export const GET = withApiHandler({}, async () => {
+  const config = await getConfig();
+  return NextResponse.json({
+    maxUsers: config.maxUsers ?? DEFAULT_MAX_USERS,
+    portalLanOnly: config.portalLanOnly ?? false,
+    defaultMaxUsers: DEFAULT_MAX_USERS,
+  });
+});
+
+export const PUT = withApiHandler({ body: BodySchema }, async ({ body }) => {
+  await updateConfig({ maxUsers: body.maxUsers, portalLanOnly: body.portalLanOnly });
+  return NextResponse.json({ maxUsers: body.maxUsers, portalLanOnly: body.portalLanOnly });
+});

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -74,33 +74,6 @@ body {
   box-shadow: 0 12px 20px -8px rgba(0, 0, 0, 0.15);
 }
 
-@keyframes pulseGlowEmerald {
-  0%, 100% { box-shadow: 0 0 4px rgba(16, 185, 129, 0.2); }
-  50% { box-shadow: 0 0 12px rgba(16, 185, 129, 0.5); }
-}
-
-@keyframes pulseGlowRose {
-  0%, 100% { box-shadow: 0 0 4px rgba(239, 68, 68, 0.2); }
-  50% { box-shadow: 0 0 12px rgba(239, 68, 68, 0.5); }
-}
-
-@keyframes pulseGlowAmber {
-  0%, 100% { box-shadow: 0 0 4px rgba(245, 158, 11, 0.2); }
-  50% { box-shadow: 0 0 12px rgba(245, 158, 11, 0.5); }
-}
-
-.pulse-glow-emerald {
-  animation: pulseGlowEmerald 2s infinite ease-in-out;
-}
-
-.pulse-glow-rose {
-  animation: pulseGlowRose 2s infinite ease-in-out;
-}
-
-.pulse-glow-amber {
-  animation: pulseGlowAmber 2s infinite ease-in-out;
-}
-
 .step-transition-enter {
   opacity: 0;
   transform: translateY(10px);

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -1,6 +1,8 @@
 import { headers } from 'next/headers';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
+import { getConfig } from '@/lib/config';
 import { buildPortalCards } from '@/lib/portal/services';
+import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
 import PortalGrid from './PortalGrid';
 import PortalLogoutLink from './PortalLogoutLink';
@@ -37,6 +39,17 @@ export const dynamic = 'force-dynamic';
  */
 export default async function PortalPage() {
   const hdrs = await headers();
+  const config = await getConfig();
+
+  // LAN-only gate (#1456): behind NPM the RSC's TCP peer is always
+  // loopback, so passing '127.0.0.1' makes the resolver trust the
+  // proxy's X-Real-IP / last-XFF hop (same rule as the MCP gate).
+  const headerMap: Record<string, string> = {};
+  hdrs.forEach((v, k) => { headerMap[k] = v; });
+  if (isPortalBlockedForRequest(config.portalLanOnly, headerMap, '127.0.0.1')) {
+    return <PortalLanOnlyNotice />;
+  }
+
   const [cards, visitor] = await Promise.all([
     buildPortalCards('Local'),
     verifyAutheliaSession(hdrs.get('cookie')),
@@ -79,6 +92,25 @@ export default async function PortalPage() {
       ) : (
         <PortalGrid cards={cards} />
       )}
+    </main>
+  );
+}
+
+/** Shown instead of the portal when `config.portalLanOnly` is on and the
+ *  visitor isn't on the home network (#1456). */
+function PortalLanOnlyNotice() {
+  return (
+    <main className="relative max-w-2xl mx-auto px-6 py-24 text-center">
+      <div className="flex items-center justify-center gap-3 mb-6">
+        <ServiceBayLogo size={36} className="text-blue-600 dark:text-blue-400 shrink-0" />
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Home</h1>
+      </div>
+      <p className="text-lg text-gray-700 dark:text-gray-300">
+        This page is available on the home network only.
+      </p>
+      <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+        Connect to the home Wi-Fi (or its VPN) and reload to request access or open a service.
+      </p>
     </main>
   );
 }

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -81,13 +81,13 @@ export default function OverviewDashboard() {
 
         {/* Setup wizard CTA banner shown when nothing has been installed yet (#902 followup) */}
         {hasFirstSnapshot && totalCount === 0 && (
-          <div className="rounded-2xl p-6 glass-panel premium-hover-card flex flex-col md:flex-row justify-between items-start md:items-center gap-4 bg-gradient-to-br from-blue-500/10 to-indigo-500/5 border border-blue-500/20 pulse-glow-emerald">
+          <div className="rounded-2xl p-6 premium-hover-card flex flex-col md:flex-row justify-between items-start md:items-center gap-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900/50">
             <div className="space-y-1">
               <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
                 <Wrench className="text-blue-500 shrink-0" size={22} />
                 Welcome to ServiceBay!
               </h2>
-              <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 font-medium max-w-xl leading-relaxed">
+              <p className="text-xs sm:text-sm text-gray-600 dark:text-gray-300 font-medium max-w-xl leading-relaxed">
                 You haven&apos;t installed any services yet. Start the setup wizard to configure your network, OIDC identity pool, SMTP notifications, and deploy your first home server stacks.
               </p>
             </div>
@@ -165,10 +165,10 @@ export default function OverviewDashboard() {
 
 function HealthHeadline({ tone, text }: { tone: 'good' | 'warn' | 'bad' | 'neutral'; text: string }) {
   const toneClasses: Record<typeof tone, string> = {
-    good: 'bg-emerald-50/80 dark:bg-emerald-950/20 border-emerald-200/50 dark:border-emerald-900/50 text-emerald-800 dark:text-emerald-300 backdrop-blur-md pulse-glow-emerald',
-    warn: 'bg-amber-50/80 dark:bg-amber-950/20 border-amber-200/50 dark:border-amber-900/50 text-amber-800 dark:text-amber-300 backdrop-blur-md pulse-glow-amber',
-    bad: 'bg-red-50/80 dark:bg-red-950/20 border-red-200/50 dark:border-red-900/50 text-red-800 dark:text-red-300 backdrop-blur-md pulse-glow-rose',
-    neutral: 'bg-gray-50/80 dark:bg-gray-900/40 border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300 backdrop-blur-md',
+    good: 'bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-900/50 text-emerald-800 dark:text-emerald-300',
+    warn: 'bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-900/50 text-amber-800 dark:text-amber-300',
+    bad: 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900/50 text-red-800 dark:text-red-300',
+    neutral: 'bg-gray-50 dark:bg-gray-900/40 border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300',
   };
   const Icon = tone === 'bad' || tone === 'warn' ? AlertCircle : CheckCircle2;
   return (
@@ -198,7 +198,7 @@ function OverviewCard({ href, title, metric, description, icon: Icon, tone }: Ov
   return (
     <Link
       href={href}
-      className="group block rounded-xl p-5 glass-panel premium-hover-card"
+      className="group block rounded-xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 premium-hover-card"
     >
       <div className="flex items-start justify-between gap-3 mb-3">
         <Icon size={20} className={accentClasses[tone]} />
@@ -206,7 +206,7 @@ function OverviewCard({ href, title, metric, description, icon: Icon, tone }: Ov
       </div>
       <h2 className="font-bold text-gray-900 dark:text-gray-100 tracking-wide text-base">{title}</h2>
       <p className={`text-sm font-semibold mt-1 ${accentClasses[tone]}`}>{metric}</p>
-      <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 font-medium leading-relaxed">{description}</p>
+      <p className="text-xs text-gray-600 dark:text-gray-300 mt-2 font-medium leading-relaxed">{description}</p>
     </Link>
   );
 }

--- a/tools/sb-tui/internal/rest/register.go
+++ b/tools/sb-tui/internal/rest/register.go
@@ -1,0 +1,22 @@
+package rest
+
+import "context"
+
+// RegisterNasSource tells the box that the FritzBox NAS is its external-backup
+// source (#1440), by POSTing the FritzBox host + credentials to
+// `/api/system/external-backup/register`. The box records them in
+// `config.gateway`, so an upload staged straight on the NAS over FTP (the
+// NasUpload panel, #1367) becomes discoverable by install/restore instead of
+// being invisible.
+//
+// Best-effort by design: the upload itself goes FTP-direct and may happen
+// before any box exists, so callers ignore an error here (no box / no token)
+// and fall back to registering from Settings. Idempotent on the box side.
+func (c *Client) RegisterNasSource(ctx context.Context, host, username, password string) error {
+	_, err := c.do(ctx, "POST", "/api/system/external-backup/register", map[string]string{
+		"host":     host,
+		"username": username,
+		"password": password,
+	})
+	return err
+}

--- a/tools/sb-tui/internal/rest/register_test.go
+++ b/tools/sb-tui/internal/rest/register_test.go
@@ -1,0 +1,50 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterNasSourcePostsCreds(t *testing.T) {
+	var got map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/system/external-backup/register" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sb_test" {
+			t.Errorf("missing bearer: %q", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "changed": true})
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).RegisterNasSource(context.Background(), "192.168.178.1", "fritz9746", "pw"); err != nil {
+		t.Fatalf("RegisterNasSource: %v", err)
+	}
+	if got["host"] != "192.168.178.1" || got["username"] != "fritz9746" || got["password"] != "pw" {
+		t.Errorf("posted creds = %+v", got)
+	}
+}
+
+func TestRegisterNasSourceSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "host is required"})
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv).RegisterNasSource(context.Background(), "", "u", "p")
+	if err == nil {
+		t.Fatal("expected an error for a 400 response")
+	}
+	var apiErr *APIError
+	if !asAPIError(err, &apiErr) || apiErr.Status != 400 {
+		t.Fatalf("want *APIError status 400, got %v", err)
+	}
+}

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -154,8 +154,15 @@ func (m App) route(id phase.ActionID, jobID string) (tea.Model, tea.Cmd) {
 	case phase.UploadToNAS:
 		// FTP-only: the upload talks straight to the FritzBox NAS, never the
 		// ServiceBay box — so it needs no token and no login, and works even
-		// before any box exists (the pre-install backup-staging step).
-		m.active = NewNasUpload()
+		// before any box exists (the pre-install backup-staging step). When a
+		// token IS present, attach a registrar so the upload also tells the box
+		// where its backup lives (#1440), making it discoverable by install/
+		// restore; without a token that registration happens later from Settings.
+		upload := NewNasUpload()
+		if client, err := rest.New(m.host, m.port, m.token); err == nil {
+			upload = upload.WithRegistrar(client)
+		}
+		m.active = upload
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
 	case phase.EditConfig, phase.InstallStacks, phase.Backups, phase.SwitchChannel:

--- a/tools/sb-tui/internal/ui/nasupload.go
+++ b/tools/sb-tui/internal/ui/nasupload.go
@@ -6,6 +6,7 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,15 @@ import (
 	"servicebay-tui/internal/fritz"
 	"servicebay-tui/internal/habackup"
 )
+
+// nasRegistrar registers the FritzBox NAS as the box's external-backup source
+// after an upload, so the staged backup is discoverable by install/restore
+// (#1440). Best-effort: nil (no box / no token yet) or an error is non-fatal —
+// the FTP upload already succeeded and the source can be registered later from
+// Settings → Backups. The rest.Client satisfies this via RegisterNasSource.
+type nasRegistrar interface {
+	RegisterNasSource(ctx context.Context, host, username, password string) error
+}
 
 // haServiceTar is the on-NAS name the box's restore flow (#1363) reads back.
 const haServiceTar = "sb-backup/home-assistant.tar"
@@ -51,6 +61,10 @@ type NasUploadModel struct {
 	filtered   []habackup.Candidate // those matching the current path filter
 	candCursor int
 	scanning   bool
+
+	// registrar, when non-nil, registers the NAS as the box's backup source
+	// after a successful upload so install/restore can find it (#1440).
+	registrar nasRegistrar
 }
 
 const nasUploadFields = 4
@@ -72,6 +86,15 @@ func NewNasUpload() NasUploadModel {
 	}
 }
 
+// WithRegistrar wires a box client so a successful upload also registers the
+// NAS as the box's external-backup source (#1440). Optional: when the upload
+// runs before a box exists (or without a token) the registrar is left nil and
+// registration happens later from Settings → Backups.
+func (m NasUploadModel) WithRegistrar(r nasRegistrar) NasUploadModel {
+	m.registrar = r
+	return m
+}
+
 // scanCmd runs the backup-file discovery off the UI thread.
 func scanCmd() tea.Cmd {
 	return func() tea.Msg { return candidatesMsg{list: habackup.FindCandidates()} }
@@ -88,6 +111,7 @@ var fieldHints = [nasUploadFields]string{
 
 func (m NasUploadModel) uploadCmd() tea.Cmd {
 	path, host, user, pass := resolvePath(m.path.Value()), m.ftpHost.Value(), m.ftpUser.Value(), m.ftpPass.Value()
+	registrar := m.registrar
 	return func() tea.Msg {
 		tar, err := habackup.ExtractAndFilter(path, habackup.HomeAssistantIncludes)
 		if err != nil {
@@ -97,7 +121,18 @@ func (m NasUploadModel) uploadCmd() tea.Cmd {
 			return nasUploadResultMsg{err: err}
 		}
 		_ = fritz.SaveCreds(fritz.Creds{Host: host, User: user, Password: pass})
-		return nasUploadResultMsg{detail: fmt.Sprintf("home-assistant.tar (%d KB)", (len(tar)+1023)/1024)}
+		detail := fmt.Sprintf("home-assistant.tar (%d KB)", (len(tar)+1023)/1024)
+		// Best-effort: tell the box where its backup now lives so install/restore
+		// can find it (#1440). A nil registrar (no box yet) or an error is fine —
+		// the upload succeeded and Settings → Backups can register the source later.
+		if registrar != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := registrar.RegisterNasSource(ctx, host, user, pass); err == nil {
+				detail += " · registered with the box"
+			}
+		}
+		return nasUploadResultMsg{detail: detail}
 	}
 }
 

--- a/tools/sb-tui/internal/ui/nasupload_test.go
+++ b/tools/sb-tui/internal/ui/nasupload_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,30 @@ import (
 
 	"servicebay-tui/internal/habackup"
 )
+
+type fakeRegistrar struct {
+	called                 bool
+	host, username, passwd string
+}
+
+func (f *fakeRegistrar) RegisterNasSource(_ context.Context, host, username, password string) error {
+	f.called, f.host, f.username, f.passwd = true, host, username, password
+	return nil
+}
+
+// TestNasUploadWithRegistrar: WithRegistrar attaches a registrar that the
+// upload command will call after a successful push (#1440); without it the
+// field stays nil (the FTP-only pre-install path).
+func TestNasUploadWithRegistrar(t *testing.T) {
+	if NewNasUpload().registrar != nil {
+		t.Error("registrar should be nil by default (FTP-only path)")
+	}
+	r := &fakeRegistrar{}
+	m := NewNasUpload().WithRegistrar(r)
+	if m.registrar == nil {
+		t.Fatal("WithRegistrar should attach the registrar")
+	}
+}
 
 // TestResolvePath: typed paths are made openable — whitespace trimmed, a stray
 // leading colon dropped, and ~ expanded (the bug behind "open :~/…: no such file").


### PR DESCRIPTION
## What
Five user-facing features plus one auth-reconcile fix, accumulated atomically on one batch branch:
- **SSO verify module** (#1453): in-process ephemeral-user end-to-end SSO verification (create namespaced LLDAP user → Authelia firstfactor → per-domain cookie check → admin-domain reject → guaranteed cleanup), returning a structured per-domain result. Unblocks #1454/#1455.
- **Home dashboard polish** (#1420): Home cards + health banner now use the app's standard slate/contrast tokens (matching Services); removed the bespoke animated pulse-glow halos and low-contrast washed-out surfaces.
- **Admin-hash reconcile** (#1438): on reinstall, reconcile the stored admin password hash with a new `SERVICEBAY_PASSWORD` so a fresh secret no longer locks out the persisted login.
- **Portal user-cap + LAN-only** (#1456): Settings UI to view/set `maxUsers`, plus a LAN-only `/portal` toggle (app gate) that restricts portal access to home-network clients; both survive restart.
- **NAS backup source + restore UI** (#1440): sb-tui NAS upload now registers the FritzBox NAS as a backup source (via `config.gateway`); Settings → Backups gets a NAS card that verifies the connection, lists staged tars (incl. `home-assistant.tar`), and offers per-file restore.
- **Diagnose → Checks fold, first slice** (#1423, partial): backend bridge that runs the diagnose suite daily and persists each probe as a synthetic `diagnose:*` CheckResult merged into the unified Checks list; `/run` re-runs the suite for a diagnose id. Follow-up slices (#3 self-repair popup, #4 counter-filter, tab removal) remain.

## Why
Closes #1453
Closes #1420
Closes #1438
Closes #1456
Closes #1440
Refs #1423

## Risk
Medium — touches dashboards, auth login reconcile, portal access gating, and external backup/restore; all behind existing routes, default behaviour unchanged when new config flags are unset.

## Rollback
`git revert` of the merge is enough; commits are atomic per issue. No schema/data migration involved (config flags are additive + optional).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 1594 passed)
- [ ] /verify on FCoS :dev box — frontend dashboards (#1420), auth login reconcile (#1438), portal user-cap/LAN-gate (#1456), external-backup NAS (#1440)