### PR TITLE
docs(mcp): sync MCP.md — add channel tools, remove bundle migration (#1460 #1462)

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -141,47 +141,34 @@ Claude Code) to see the live tool registry on your version.
 | Health | `get_health_checks`, `create_health_check`, `delete_health_check`, `run_check_now` |
 | Proxy | `get_proxy_routes`, `add_proxy_route`, `remove_proxy_route` |
 | Backups | `list_backups`, `run_backup`, `restore_backup` |
-| System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command` |
-| Unmanaged bundles | `get_unmanaged_bundles`, `merge_unmanaged_bundle` |
+| System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command`, `get_channel`, `set_channel` |
 
 Sensitive config fields (`auth.passwordHash`, `oidc.clientSecret`, SMTP
 passwords) are redacted from `get_config` and write-allowlisted in
 `update_config`.
 
-### Migrating legacy services into ServiceBay (ARCH-14)
+### Channel switching
 
-ServiceBay discovers systemd/Podman services on each node that aren't
-under its management. The LLM can enumerate those bundles and either
-preview or execute a merge into a single managed Quadlet stack.
+`get_channel` and `set_channel` let an LLM (or the operator) flip the
+running box between release channels without SSH:
 
 ```text
-get_unmanaged_bundles(node?) → ServiceBundle[]
-  Read scope. Returns every unmanaged bundle the digital twin has
-  detected on `node` (default: first node). Each bundle includes an
-  `id`, `displayName`, `severity` (`info` | `warning` | `critical`),
-  member `services`, hints, validations, and a discovery graph.
+get_channel() → { channel: 'latest' | 'dev' | 'test', since? }
+  Read scope. Returns the current channel and (if available) when it
+  was last set.
 
-merge_unmanaged_bundle(bundleId, newName, node?, dryRun?) → plan | ok
-  Mutate scope, destructive. Maps the bundle's members to
-  DiscoveredService records and invokes the same merge pipeline as
-  the React Service Bundle Merge Wizard.
-    - `dryRun: true`  → returns `{ dryRun: true, plan: MergePlan }`
-      with the generated Quadlet/YAML and a pre-mutation validation
-      report. No filesystem writes, no service stops.
-    - `dryRun: false` → executes the merge: stops legacy units,
-      writes the new `{newName}.kube` + `{newName}.yml` to the
-      systemd Quadlet dir, registers the merged service. `safeHandler`
-      snapshots the system first and emails the operator on success.
+set_channel(channel) → { ok: true, channel, note }
+  Lifecycle scope. Pulls the new image and restarts ServiceBay in the
+  background. Returns before the restart completes (~1–2 min), so the
+  MCP connection will drop — reconnect and poll get_channel to confirm.
 ```
 
-Workflow the agent typically follows:
+Typical autonomous-verify workflow:
 
-1. `get_unmanaged_bundles` → pick a bundle by its `id` and `severity`.
-2. `merge_unmanaged_bundle(bundleId, newName, dryRun: true)` → review
-   the plan's `stackPreview`, `validations`, and `fileMappings`.
-3. Confirm with the operator (or check `config.mcp.allowMutations`).
-4. `merge_unmanaged_bundle(bundleId, newName)` → the merge runs and is
-   audited under `mcp.audit` with the snapshot id for one-click rollback.
+1. `set_channel('dev')` — flip to the latest non-release main commit.
+2. Wait for reconnect, then `get_channel()` to confirm.
+3. Run the usual verify tools (`get_health_checks`, `list_services`, …).
+4. `set_channel('latest')` — return to the stable release channel.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What changed

- **Remove** `get_unmanaged_bundles` / `merge_unmanaged_bundle` from the tools table and the entire "Migrating legacy services (ARCH-14)" subsection — both tools were deleted in #1462 (bundle migration feature removed).
- **Add** `get_channel` / `set_channel` to the System tools row and document the channel-switching workflow introduced in #1460.

Refs #1460, #1462

## Risk / Rollback
docs-only; git revert is enough.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._