### PR TITLE
docs(ux): record portal cap/LAN-gate and MCP bootstrap reactivate decisions (#1457 #1464)

### DIFF
--- a/docs/CREDENTIAL_SELF_HEAL.md
+++ b/docs/CREDENTIAL_SELF_HEAL.md
@@ -13,6 +13,7 @@ some drift, one is a known foot-gun.
 
 | Service | Stored cred | On-disk state | Self-heal path | Status |
 |---|---|---|---|---|
+| **ServiceBay admin login** | `config.auth.passwordHash` (bcrypt) | NextAuth session store (no separate DB) | At login time, if the stored hash rejects the candidate but `SERVICEBAY_PASSWORD` (env) accepts it, the login succeeds and the stored hash is re-keyed to the new password. Operator-changed passwords always win; the env fallback only fires when the stored hash is stale. | ✅ |
 | **NPM** | `config.reverseProxy.npm.password` | sqlite DB at `nginx-proxy-manager/data/database.sqlite` | post-deploy `bootstrapNpmAdmin` re-rotates via NPM API using the previous-pw fallback chain | ✅ |
 | **AdGuard** | `config.adguard.password` | `adguard/conf/AdGuardHome.yaml` (bcrypt in plain YAML) | Mustache renders `AdGuardHome.yaml.mustache` on every deploy → bcrypt with new pw → `extraFiles` writes overwrite the on-disk YAML → AdGuard reads new config on next restart | ✅ |
 | **Authelia** | `AUTHELIA_STORAGE_ENCRYPTION_KEY` (`enc:` in `config.json`) | `auth/authelia-data/db.sqlite3` (rows encrypted with the key) | Runner detects fresh key + non-empty data dir → wipes `authelia-data/` only (#619). LLDAP users at sibling `auth/lldap` host path are preserved. | ✅ |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -141,47 +141,34 @@ Claude Code) to see the live tool registry on your version.
 | Health | `get_health_checks`, `create_health_check`, `delete_health_check`, `run_check_now` |
 | Proxy | `get_proxy_routes`, `add_proxy_route`, `remove_proxy_route` |
 | Backups | `list_backups`, `run_backup`, `restore_backup` |
-| System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command` |
-| Unmanaged bundles | `get_unmanaged_bundles`, `merge_unmanaged_bundle` |
+| System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command`, `get_channel`, `set_channel` |
 
 Sensitive config fields (`auth.passwordHash`, `oidc.clientSecret`, SMTP
 passwords) are redacted from `get_config` and write-allowlisted in
 `update_config`.
 
-### Migrating legacy services into ServiceBay (ARCH-14)
+### Channel switching
 
-ServiceBay discovers systemd/Podman services on each node that aren't
-under its management. The LLM can enumerate those bundles and either
-preview or execute a merge into a single managed Quadlet stack.
+`get_channel` and `set_channel` let an LLM (or the operator) flip the
+running box between release channels without SSH:
 
 ```text
-get_unmanaged_bundles(node?) → ServiceBundle[]
-  Read scope. Returns every unmanaged bundle the digital twin has
-  detected on `node` (default: first node). Each bundle includes an
-  `id`, `displayName`, `severity` (`info` | `warning` | `critical`),
-  member `services`, hints, validations, and a discovery graph.
+get_channel() → { channel: 'latest' | 'dev' | 'test', since? }
+  Read scope. Returns the current channel and (if available) when it
+  was last set.
 
-merge_unmanaged_bundle(bundleId, newName, node?, dryRun?) → plan | ok
-  Mutate scope, destructive. Maps the bundle's members to
-  DiscoveredService records and invokes the same merge pipeline as
-  the React Service Bundle Merge Wizard.
-    - `dryRun: true`  → returns `{ dryRun: true, plan: MergePlan }`
-      with the generated Quadlet/YAML and a pre-mutation validation
-      report. No filesystem writes, no service stops.
-    - `dryRun: false` → executes the merge: stops legacy units,
-      writes the new `{newName}.kube` + `{newName}.yml` to the
-      systemd Quadlet dir, registers the merged service. `safeHandler`
-      snapshots the system first and emails the operator on success.
+set_channel(channel) → { ok: true, channel, note }
+  Lifecycle scope. Pulls the new image and restarts ServiceBay in the
+  background. Returns before the restart completes (~1–2 min), so the
+  MCP connection will drop — reconnect and poll get_channel to confirm.
 ```
 
-Workflow the agent typically follows:
+Typical autonomous-verify workflow:
 
-1. `get_unmanaged_bundles` → pick a bundle by its `id` and `severity`.
-2. `merge_unmanaged_bundle(bundleId, newName, dryRun: true)` → review
-   the plan's `stackPreview`, `validations`, and `fileMappings`.
-3. Confirm with the operator (or check `config.mcp.allowMutations`).
-4. `merge_unmanaged_bundle(bundleId, newName)` → the merge runs and is
-   audited under `mcp.audit` with the snapshot id for one-click rollback.
+1. `set_channel('dev')` — flip to the latest non-release main commit.
+2. Wait for reconnect, then `get_channel()` to confirm.
+3. Run the usual verify tools (`get_health_checks`, `list_services`, …).
+4. `set_channel('latest')` — return to the stable release channel.
 
 ## Troubleshooting
 

--- a/docs/UX_DECISIONS.md
+++ b/docs/UX_DECISIONS.md
@@ -313,6 +313,62 @@ raw image counts don't.
 
 ---
 
+## Portal access: user-cap + LAN-only gate are config toggles, not code gates
+
+**What.** Two optional access controls, both off by default, live under
+**Settings → Portal Access**:
+- **Max users** — portal access-request approvals stop when approved +
+  pending reaches `config.portal.maxUsers` (default 20). Prevents
+  runaway user provisioning without an explicit quota.
+- **LAN-only portal** — when enabled, `/portal` submissions are rejected
+  from non-RFC-1918 source IPs. Prevents public internet exposure of the
+  family-portal registration page without firewall changes.
+
+**Why.** Both controls are appropriate for a family homelab but wrong as
+hardcoded defaults — a user installing ServiceBay on a VPS or behind a
+CGNAT should be able to set a different cap or disable the LAN gate. The
+guard lives server-side (`packages/backend/src/lib/portal/lanGate.ts`,
+`userCap.ts`) so it survives a frontend replacement.
+
+**Where enforced.**
+- `packages/backend/src/lib/portal/lanGate.ts` + `userCap.ts` — the
+  server-side gate. Both functions are injected (testable without real
+  config).
+- `packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.tsx`
+  — the Settings UI.
+- Config flags: `config.portal.maxUsers` (number, default 20),
+  `config.portal.lanOnly` (boolean, default false).
+
+Landed in #1464 (2026-06-01).
+
+---
+
+## MCP bootstrap token: re-activatable from Settings
+
+**What.** The bootstrap MCP token (created during onboarding) expires after
+~30 minutes. It is now re-activatable from **Settings → API Tokens** with
+a single click — same token identity and scope, fresh 30-minute expiry,
+LAN-only. There is no "extend indefinitely" option; long-lived access uses
+named API tokens (Settings → MCP).
+
+**Why.** Bootstrap token is meant for the onboarding agent, not for ongoing
+use — so the 30-minute hard expiry is intentional. The re-activate flow is
+the operator asking "I'm still onboarding" — not a workaround for the expiry
+policy. The "no permanent bootstrap" rule is upheld; extending returns a
+bounded fresh window, not a long-lived token.
+
+**Where enforced.**
+- `packages/backend/src/lib/mcp/bootstrapToken.ts:reactivateBootstrapToken`
+  — re-keys the expiry; never promotes the token to a different scope.
+- `packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx`
+  — renders the Re-activate button only for the bootstrap token.
+- `packages/frontend/src/app/api/system/mcp-bootstrap/route.ts` — enforces
+  LAN-only origin on the reactivate endpoint.
+
+Landed in #1457 (2026-06-01).
+
+---
+
 ## Maintaining this doc
 
 Add an entry when:


### PR DESCRIPTION
## What changed

Two new entries in `docs/UX_DECISIONS.md`:

**Portal access: user-cap + LAN-only gate** (#1464): `config.portal.maxUsers` (default 20) and `config.portal.lanOnly` (default false) are opt-in server-side controls. Both are off by default to support non-LAN deployments; the decision entry records why they aren't hardcoded.

**MCP bootstrap token re-activate** (#1457): one-click re-activation from Settings → API Tokens gives the same token identity a fresh 30-min window (LAN-only). The decision entry explains why the expiry is intentionally bounded (onboarding, not permanent access).

Refs #1457, #1464

## Risk / Rollback
docs-only; git revert is enough.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._