### PR TITLE
feat: post-deploy progress bar consumer and Signal-pairing portal card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ secret.key
 
 # docs-coherence parallel agent worktree (see .claude/skills/docs-coherence)
 .docs-coherence-worktree/
+
+# Playwright e2e run artifacts
+test-results/

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -27,7 +27,7 @@ import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getTemplateUserGuide } from '@/lib/registry';
 import { logger } from '@/lib/logger';
-import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAsset } from './userGuide';
+import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAsset, type ManualPairing } from './userGuide';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
@@ -57,6 +57,10 @@ export interface PortalCard {
   body: string;
   recommendedApps: RecommendedApp[];
   setupAssets: SetupAsset[];
+  /** Static "manual action required" steps — inherently-interactive
+   *  pairing the operator runs by hand (e.g. `signal-cli link`).
+   *  Informational only; the portal shows the command, not a runner. */
+  manualPairing: ManualPairing[];
 }
 
 /** Read a template's variables.json (best-effort, returns empty record on miss).
@@ -189,6 +193,7 @@ async function buildPortalCardEntry(
     tagline?: string;
     recommended_apps?: RecommendedApp[];
     setup_assets?: SetupAsset[];
+    manual_pairing?: ManualPairing[];
   },
   templateLabel: string,
   parsedBody: string,
@@ -211,6 +216,7 @@ async function buildPortalCardEntry(
     body: parsedBody,
     recommendedApps: def.recommended_apps ?? [],
     setupAssets: def.setup_assets ?? [],
+    manualPairing: def.manual_pairing ?? [],
   };
 }
 
@@ -254,6 +260,7 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
         tagline: parsed.frontmatter.tagline,
         recommended_apps: parsed.frontmatter.recommended_apps,
         setup_assets: parsed.frontmatter.setup_assets,
+        manual_pairing: parsed.frontmatter.manual_pairing,
       }];
 
     for (const def of cardDefs) {

--- a/packages/backend/src/lib/portal/userGuide.test.ts
+++ b/packages/backend/src/lib/portal/userGuide.test.ts
@@ -177,6 +177,56 @@ lucide_icon: "<script>"
     expect(result!.frontmatter.lucide_icon).toBeUndefined();
   });
 
+  it('parses manual_pairing with title, command, and optional why', () => {
+    const raw = `---
+manual_pairing:
+  - title: "Pair the Signal account"
+    command: "podman exec -it hermes signal-cli link -n HermesAgent"
+    why: "Scan the QR shown in the terminal with Signal on your phone."
+  - title: "No-why step"
+    command: "podman exec -it hermes do-thing"
+---
+`;
+    const result = parseUserGuide(raw, 'hermes');
+    expect(result!.frontmatter.manual_pairing).toHaveLength(2);
+    expect(result!.frontmatter.manual_pairing?.[0]).toEqual({
+      title: 'Pair the Signal account',
+      command: 'podman exec -it hermes signal-cli link -n HermesAgent',
+      why: 'Scan the QR shown in the terminal with Signal on your phone.',
+    });
+    expect(result!.frontmatter.manual_pairing?.[1].why).toBeUndefined();
+  });
+
+  it('drops manual_pairing entries missing title or command', () => {
+    const raw = `---
+manual_pairing:
+  - title: "Has no command"
+  - command: "has-no-title"
+  - title: "   "
+    command: "blank-title"
+  - title: "Valid"
+    command: "podman exec -it x link"
+---
+`;
+    const result = parseUserGuide(raw, 'x');
+    expect(result!.frontmatter.manual_pairing).toHaveLength(1);
+    expect(result!.frontmatter.manual_pairing?.[0].title).toBe('Valid');
+  });
+
+  it('parses per-card manual_pairing', () => {
+    const raw = `---
+cards:
+  - subdomain_var: "HERMES_SUBDOMAIN"
+    manual_pairing:
+      - title: "Pair Signal"
+        command: "podman exec -it hermes signal-cli link"
+---
+`;
+    const result = parseUserGuide(raw, 'hermes');
+    expect(result!.frontmatter.cards?.[0].manual_pairing).toHaveLength(1);
+    expect(result!.frontmatter.cards?.[0].manual_pairing?.[0].command).toBe('podman exec -it hermes signal-cli link');
+  });
+
   it('returns null on YAML parse error', () => {
     const raw = `---
 icon: "📷

--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -83,6 +83,33 @@ export interface SetupAsset {
 }
 
 /**
+ * A one-off interactive setup step the operator has to run by hand,
+ * surfaced as a static "manual action required" panel on the card
+ * (#1253). The canonical case is Signal pairing for a messaging
+ * gateway: `podman exec -it <hermes> signal-cli link -n HermesAgent`
+ * renders a QR in *that terminal* and can't be driven from the web
+ * (it needs a TTY). We don't try to automate it — we just tell the
+ * operator the step exists, why, and the exact command to copy.
+ *
+ * Distinct from `setup_assets`, which are things the portal can *do*
+ * for the visitor (download a profile, render a QR server-side). A
+ * `manual_pairing` entry is purely informational: copy the command,
+ * run it in a shell.
+ */
+export interface ManualPairing {
+  /** Short heading, e.g. "Pair the Signal account". */
+  title: string;
+  /** The exact shell command to run, e.g.
+   *  `podman exec -it hermes signal-cli link -n HermesAgent`.
+   *  Rendered in a monospace block with a copy button. */
+  command: string;
+  /** Optional one-line "why this is needed / what to expect" note
+   *  (e.g. "Scan the QR shown in the terminal with Signal on your
+   *  phone — Settings → Linked devices → Link new device"). */
+  why?: string;
+}
+
+/**
  * Curated allowlist of Lucide icon names usable on portal cards.
  * Lucide is the same line-art icon set the dashboard sidebar uses,
  * so picking from this set keeps the portal visually consistent
@@ -130,6 +157,7 @@ export interface UserGuideCard {
   tagline?: string;
   recommended_apps?: RecommendedApp[];
   setup_assets?: SetupAsset[];
+  manual_pairing?: ManualPairing[];
 }
 
 export interface UserGuideFrontmatter {
@@ -156,6 +184,10 @@ export interface UserGuideFrontmatter {
   mobile_apps?: { name: string; url: string }[];
   /** Per-template setup artifacts (iOS profile, deep links, …). */
   setup_assets?: SetupAsset[];
+  /** Manual, inherently-interactive setup steps the operator runs by
+   *  hand (e.g. `signal-cli link` QR pairing). Surfaced as a static
+   *  "manual action required" panel — informational only (#1253). */
+  manual_pairing?: ManualPairing[];
 }
 
 export interface ParsedUserGuide {
@@ -226,6 +258,68 @@ function liftMobileApps(input: unknown): RecommendedApp[] {
     .filter((e): e is RecommendedApp => e !== null);
 }
 
+/** Parse a `manual_pairing[]` list. Each entry needs a non-empty
+ *  `title` + `command` (both template-author strings, rendered as
+ *  text — never executed); `why` is optional. Entries missing either
+ *  required field are dropped so a malformed one doesn't render a
+ *  blank panel. */
+function parseManualPairing(input: unknown): ManualPairing[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((entry: unknown): ManualPairing | null => {
+      if (!entry || typeof entry !== 'object') return null;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.title !== 'string' || !e.title.trim()) return null;
+      if (typeof e.command !== 'string' || !e.command.trim()) return null;
+      const out: ManualPairing = { title: e.title.trim(), command: e.command.trim() };
+      if (typeof e.why === 'string' && e.why.trim()) out.why = e.why.trim();
+      return out;
+    })
+    .filter((e): e is ManualPairing => e !== null);
+}
+
+/** Parse a `setup_assets[]` list down to whitelisted-kind entries.
+ *  Shared by the top-level frontmatter and the per-card `cards[]`
+ *  path. Unknown/non-string kinds drop silently. */
+function parseSetupAssets(input: unknown): SetupAsset[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((entry: unknown): SetupAsset | null => {
+      if (!entry || typeof entry !== 'object') return null;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.kind !== 'string' || !KNOWN_ASSET_KINDS.has(e.kind as SetupAssetKind)) return null;
+      const out: SetupAsset = { kind: e.kind as SetupAssetKind };
+      if (typeof e.label === 'string' && e.label.trim()) out.label = e.label.trim();
+      if (typeof e.description === 'string' && e.description.trim()) out.description = e.description.trim();
+      return out;
+    })
+    .filter((a): a is SetupAsset => a !== null);
+}
+
+/** Parse one `cards[]` entry (per-subdomain card). Returns null when
+ *  the entry is malformed or lacks a valid `*_SUBDOMAIN` var. */
+function parseCardEntry(entry: unknown): UserGuideCard | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = entry as Record<string, unknown>;
+  if (typeof e.subdomain_var !== 'string' || !/^[A-Z][A-Z0-9_]*_SUBDOMAIN$/.test(e.subdomain_var)) {
+    return null;
+  }
+  const card: UserGuideCard = { subdomain_var: e.subdomain_var };
+  if (typeof e.label === 'string' && e.label.trim()) card.label = e.label.trim();
+  if (typeof e.icon === 'string') card.icon = e.icon;
+  if (typeof e.lucide_icon === 'string' && PORTAL_ICON_SET.has(e.lucide_icon)) {
+    card.lucide_icon = e.lucide_icon as PortalIconName;
+  }
+  if (typeof e.tagline === 'string') card.tagline = e.tagline;
+  const apps = parseRecommendedApps(e.recommended_apps);
+  if (apps.length > 0) card.recommended_apps = apps;
+  const assets = parseSetupAssets(e.setup_assets);
+  if (assets.length > 0) card.setup_assets = assets;
+  const pairing = parseManualPairing(e.manual_pairing);
+  if (pairing.length > 0) card.manual_pairing = pairing;
+  return card;
+}
+
 /** Extract frontmatter fields from parsed YAML data. */
 function parseUserGuideSection(data: Record<string, unknown>): UserGuideFrontmatter {
   const fm: UserGuideFrontmatter = {};
@@ -247,58 +341,16 @@ function parseUserGuideSection(data: Record<string, unknown>): UserGuideFrontmat
 
   if (Array.isArray(data.cards)) {
     const cards = data.cards
-      .map((entry: unknown): UserGuideCard | null => {
-        if (!entry || typeof entry !== 'object') return null;
-        const e = entry as Record<string, unknown>;
-        if (typeof e.subdomain_var !== 'string' || !/^[A-Z][A-Z0-9_]*_SUBDOMAIN$/.test(e.subdomain_var)) {
-          return null;
-        }
-        const card: UserGuideCard = { subdomain_var: e.subdomain_var };
-        if (typeof e.label === 'string' && e.label.trim()) card.label = e.label.trim();
-        if (typeof e.icon === 'string') card.icon = e.icon;
-        if (typeof e.lucide_icon === 'string' && PORTAL_ICON_SET.has(e.lucide_icon)) {
-          card.lucide_icon = e.lucide_icon as PortalIconName;
-        }
-        if (typeof e.tagline === 'string') card.tagline = e.tagline;
-        if (Array.isArray(e.recommended_apps)) {
-          const apps = parseRecommendedApps(e.recommended_apps);
-          if (apps.length > 0) card.recommended_apps = apps;
-        }
-        if (Array.isArray(e.setup_assets)) {
-          const assets = (e.setup_assets as unknown[])
-            .map((a): SetupAsset | null => {
-              if (!a || typeof a !== 'object') return null;
-              const ae = a as Record<string, unknown>;
-              if (typeof ae.kind !== 'string' || !KNOWN_ASSET_KINDS.has(ae.kind as SetupAssetKind)) return null;
-              const out: SetupAsset = { kind: ae.kind as SetupAssetKind };
-              if (typeof ae.label === 'string' && ae.label.trim()) out.label = ae.label.trim();
-              if (typeof ae.description === 'string' && ae.description.trim()) out.description = ae.description.trim();
-              return out;
-            })
-            .filter((a): a is SetupAsset => a !== null);
-          if (assets.length > 0) card.setup_assets = assets;
-        }
-        return card;
-      })
+      .map(parseCardEntry)
       .filter((c): c is UserGuideCard => c !== null);
     if (cards.length > 0) fm.cards = cards;
   }
 
-  if (Array.isArray(data.setup_assets)) {
-    const assets = data.setup_assets
-      .map((entry: unknown): SetupAsset | null => {
-        if (!entry || typeof entry !== 'object') return null;
-        const e = entry as Record<string, unknown>;
-        if (typeof e.kind !== 'string') return null;
-        if (!KNOWN_ASSET_KINDS.has(e.kind as SetupAssetKind)) return null;
-        const out: SetupAsset = { kind: e.kind as SetupAssetKind };
-        if (typeof e.label === 'string' && e.label.trim()) out.label = e.label.trim();
-        if (typeof e.description === 'string' && e.description.trim()) out.description = e.description.trim();
-        return out;
-      })
-      .filter((e): e is SetupAsset => e !== null);
-    if (assets.length > 0) fm.setup_assets = assets;
-  }
+  const assets = parseSetupAssets(data.setup_assets);
+  if (assets.length > 0) fm.setup_assets = assets;
+
+  const pairing = parseManualPairing(data.manual_pairing);
+  if (pairing.length > 0) fm.manual_pairing = pairing;
 
   return fm;
 }

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState, useSyncExternalStore } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
-  BookOpen, Bot, Calendar, CalendarDays, Camera,
+  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, Copy,
   Download, ExternalLink, Files, Film, Folder, FolderOpen, Globe,
   Headphones, House, Image as ImageIcon, Images, KeyRound, Lightbulb,
   Lightbulb as LightbulbIcon, Loader2, Lock, Mail, MessageSquare,
-  Music, Package, QrCode, RefreshCw, Router, Shield, Smartphone, Video,
+  Music, Package, QrCode, RefreshCw, Router, Shield, Smartphone, Terminal, Video,
   Sparkles, X,
 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
@@ -232,6 +232,10 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                 </div>
               )}
 
+              {card.manualPairing.length > 0 && (
+                <ManualPairingPanel steps={card.manualPairing} />
+              )}
+
               {card.recommendedApps.length > 0 && (
                 <div className="pt-2 space-y-1.5">
                   <div className="text-[11px] uppercase tracking-wide font-medium text-gray-500 dark:text-gray-400">
@@ -343,6 +347,70 @@ function CardHelpModal({ card, onClose }: { card: PortalCard; onClose: () => voi
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Static "manual action required" panel (#1253). Lists the
+ * inherently-interactive setup steps a template declared via
+ * `manual_pairing` (e.g. Signal `signal-cli link` QR pairing — it
+ * needs a TTY, so the web portal can only point at it, not run it).
+ * Each step shows its title, an optional why-note, and the exact
+ * command in a copyable monospace block.
+ */
+function ManualPairingPanel({ steps }: { steps: PortalCard['manualPairing'] }) {
+  return (
+    <div className="pt-2 space-y-2 rounded-lg border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 p-3">
+      <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide font-semibold text-amber-700 dark:text-amber-300">
+        <Terminal size={12} className="shrink-0" /> Manual setup needed
+      </div>
+      {steps.map(step => (
+        <div key={step.title} className="space-y-1">
+          <p className="text-xs font-medium text-amber-900 dark:text-amber-100">{step.title}</p>
+          {step.why && (
+            <p className="text-[11px] text-amber-800/90 dark:text-amber-200/80 leading-snug">{step.why}</p>
+          )}
+          <CommandBlock command={step.command} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Read-only command line for a `manual_pairing` step (#1253) — the
+ * operator has to run an interactive `podman exec -it … signal-cli
+ * link` in a real shell (the QR can't be driven from the web), so we
+ * show the exact command in monospace with a one-click copy. Copy
+ * falls back gracefully when the Clipboard API is unavailable
+ * (non-secure context / older browser): the text stays selectable.
+ */
+function CommandBlock({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable — the command stays selectable for a
+      // manual copy, so we just don't flash the confirmation.
+    }
+  };
+  return (
+    <div className="flex items-stretch gap-1.5">
+      <code className="flex-1 min-w-0 overflow-x-auto rounded bg-amber-100/70 dark:bg-amber-950/40 px-2 py-1.5 text-[11px] font-mono text-amber-900 dark:text-amber-100 whitespace-pre">
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label={copied ? 'Copied' : 'Copy command'}
+        className="shrink-0 inline-flex items-center justify-center w-8 rounded bg-amber-200/70 dark:bg-amber-800/40 text-amber-800 dark:text-amber-200 hover:bg-amber-300/70 dark:hover:bg-amber-700/50 transition-colors"
+      >
+        {copied ? <Check size={14} /> : <Copy size={14} />}
+      </button>
     </div>
   );
 }

--- a/packages/frontend/src/components/InstallProgressCard.test.tsx
+++ b/packages/frontend/src/components/InstallProgressCard.test.tsx
@@ -17,6 +17,7 @@ const base: InstallMonitorState = {
   percent: 50,
   needsCredentials: false,
   logs: ['🔑 Reusing 7 saved secrets', 'Deploying immich…'],
+  postDeployProgress: null,
 };
 
 describe('InstallProgressCardView', () => {
@@ -44,5 +45,36 @@ describe('InstallProgressCardView', () => {
     const btn = screen.getByText(/skip credentials/i).closest('button')!;
     fireEvent.click(btn);
     expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it('renders no post-deploy bar when none is in flight', () => {
+    render(<InstallProgressCardView state={base} onSkipCredentials={() => {}} />);
+    expect(screen.queryByText(/ollama:pull/)).toBeNull();
+    expect(screen.queryByText(/MB/)).toBeNull();
+  });
+
+  it('renders the post-deploy progress bar with tag and MB readout', () => {
+    render(
+      <InstallProgressCardView
+        state={{
+          ...base,
+          postDeployProgress: { tag: 'ollama:pull', percent: 42, completedMb: 4200, totalMb: 10000 },
+        }}
+        onSkipCredentials={() => {}}
+      />,
+    );
+    expect(screen.getByText('ollama:pull')).toBeDefined();
+    expect(screen.getByText('4200 / 10000 MB · 42%')).toBeDefined();
+  });
+
+  it('falls back to percent-only when MB fields are absent', () => {
+    render(
+      <InstallProgressCardView
+        state={{ ...base, postDeployProgress: { tag: 'ollama:pull', percent: 7 } }}
+        onSkipCredentials={() => {}}
+      />,
+    );
+    expect(screen.getByText('7%')).toBeDefined();
+    expect(screen.queryByText(/MB/)).toBeNull();
   });
 });

--- a/packages/frontend/src/components/InstallProgressCard.tsx
+++ b/packages/frontend/src/components/InstallProgressCard.tsx
@@ -42,7 +42,7 @@ export function InstallProgressCardView({
   state: InstallMonitorState;
   onSkipCredentials: () => void;
 }) {
-  const { phase, currentItem, deployed, total, percent, needsCredentials, logs } = state;
+  const { phase, currentItem, deployed, total, percent, needsCredentials, logs, postDeployProgress } = state;
   return (
     <div className="rounded-2xl p-5 glass-panel border border-blue-500/20 bg-gradient-to-br from-blue-500/10 to-indigo-500/5 space-y-4">
       <div className="flex items-center justify-between gap-3">
@@ -68,6 +68,30 @@ export function InstallProgressCardView({
         </div>
         <p className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">{percent}%</p>
       </div>
+
+      {/* Post-deploy progress bar (#1288). A template's post-deploy step
+          (e.g. OSCAR ollama's multi-GB model pull) emits structured
+          progress on the install-log stream; we render it on the same bar
+          as image pulls so the longest install phase no longer looks like
+          a silent hang. Shows only while a tick is in flight. */}
+      {postDeployProgress && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <span className="truncate">{postDeployProgress.tag ?? 'Post-deploy'}</span>
+            <span className="tabular-nums shrink-0">
+              {postDeployProgress.completedMb !== undefined && postDeployProgress.totalMb !== undefined
+                ? `${Math.round(postDeployProgress.completedMb)} / ${Math.round(postDeployProgress.totalMb)} MB · ${postDeployProgress.percent}%`
+                : `${postDeployProgress.percent}%`}
+            </span>
+          </div>
+          <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-indigo-500 transition-[width] duration-500"
+              style={{ width: `${postDeployProgress.percent}%` }}
+            />
+          </div>
+        </div>
+      )}
 
       {/* The runner paused on the NPM credentials prompt. Skipping
           continues with the auto-generated fallback; proxy routes can

--- a/packages/frontend/src/components/postDeployProgress.test.ts
+++ b/packages/frontend/src/components/postDeployProgress.test.ts
@@ -1,0 +1,55 @@
+/**
+ * postDeployProgress (#1288) — parses structured post-deploy progress lines
+ * (jlog `{ts, level, tag, message, args:{percent, completed_mb, total_mb}}`)
+ * out of the install-log tail so the card can render them on a bar.
+ */
+import { describe, it, expect } from 'vitest';
+import { parsePostDeployProgressLine, latestPostDeployProgress } from './postDeployProgress';
+
+const line = (obj: unknown) => JSON.stringify(obj);
+
+describe('parsePostDeployProgressLine', () => {
+  it('extracts percent + MB from an OSCAR ollama:pull progress line', () => {
+    const p = parsePostDeployProgressLine(
+      line({ ts: 1, level: 'info', tag: 'ollama:pull', message: 'pulling model', args: { percent: 42, completed_mb: 4200, total_mb: 10000 } }),
+    );
+    expect(p).toEqual({ tag: 'ollama:pull', message: 'pulling model', percent: 42, completedMb: 4200, totalMb: 10000 });
+  });
+
+  it('accepts a percent-only producer (no MB fields)', () => {
+    const p = parsePostDeployProgressLine(line({ tag: 'seed', args: { percent: 12 } }));
+    expect(p).toEqual({ tag: 'seed', message: undefined, percent: 12, completedMb: undefined, totalMb: undefined });
+  });
+
+  it('clamps percent into 0–100 and rounds', () => {
+    expect(parsePostDeployProgressLine(line({ args: { percent: 142.6 } }))?.percent).toBe(100);
+    expect(parsePostDeployProgressLine(line({ args: { percent: -5 } }))?.percent).toBe(0);
+    expect(parsePostDeployProgressLine(line({ args: { percent: 33.4 } }))?.percent).toBe(33);
+  });
+
+  it('rejects plain log lines, non-JSON, and lines without args.percent', () => {
+    expect(parsePostDeployProgressLine('🔑 Reusing 7 saved secrets')).toBeNull();
+    expect(parsePostDeployProgressLine('Pulling image 1/3: ollama')).toBeNull();
+    expect(parsePostDeployProgressLine('{ not json')).toBeNull();
+    expect(parsePostDeployProgressLine(line({ tag: 'x', args: { completed_mb: 10 } }))).toBeNull();
+    expect(parsePostDeployProgressLine(line({ tag: 'x', message: 'done' }))).toBeNull();
+    expect(parsePostDeployProgressLine(line({ args: { percent: 'NaN' } }))).toBeNull();
+  });
+});
+
+describe('latestPostDeployProgress', () => {
+  it('returns the most recent progress event from the tail', () => {
+    const logs = [
+      line({ tag: 'ollama:pull', args: { percent: 10, completed_mb: 1000, total_mb: 10000 } }),
+      'some interleaved log line',
+      line({ tag: 'ollama:pull', args: { percent: 60, completed_mb: 6000, total_mb: 10000 } }),
+      '✅ ollama deployed',
+    ];
+    expect(latestPostDeployProgress(logs)?.percent).toBe(60);
+  });
+
+  it('returns null when no line carries progress', () => {
+    expect(latestPostDeployProgress(['a', 'b', '{}'])).toBeNull();
+    expect(latestPostDeployProgress([])).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/postDeployProgress.ts
+++ b/packages/frontend/src/components/postDeployProgress.ts
@@ -1,0 +1,77 @@
+/**
+ * Post-deploy progress parsing for the install card (#1288).
+ *
+ * A template's post-deploy script (e.g. OSCAR `ollama`'s model pull) emits
+ * structured progress lines on stdout — JSON objects of the shape
+ * `{ts, level, tag, message, args}` where `args` carries `{percent,
+ * completed_mb, total_mb}` on a progress tick. Those lines stream verbatim
+ * through the install-log channel and land in the monitor's `logs` tail.
+ *
+ * The image-pull phase already gets a user-facing bar; this lets a long
+ * post-deploy phase (often the longest step — a multi-GB model download)
+ * get the same treatment instead of looking like a silent hang. We parse
+ * the most recent progress line out of the log tail and surface it; the
+ * card renders it on the same percent bar.
+ */
+
+export interface PostDeployProgress {
+  /** Producer-supplied tag, e.g. `ollama:pull` — labels the bar. */
+  tag?: string;
+  /** Human message from the same line, if any. */
+  message?: string;
+  /** 0–100, clamped. */
+  percent: number;
+  /** Megabytes downloaded so far, when the producer reports it. */
+  completedMb?: number;
+  /** Total megabytes, when the producer reports it. */
+  totalMb?: number;
+}
+
+const clampPercent = (n: number): number => Math.max(0, Math.min(100, Math.round(n)));
+
+const isFiniteNumber = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+/**
+ * Parse a single log line as a post-deploy progress event, or `null` if it
+ * isn't one. A line qualifies when it JSON-parses to an object whose `args`
+ * carries a numeric `percent` (the canonical progress field). `completed_mb`
+ * / `total_mb` are optional — a percent-only producer still renders a bar.
+ */
+export function parsePostDeployProgressLine(line: string): PostDeployProgress | null {
+  const trimmed = line.trim();
+  // Fast reject — every progress line is a JSON object; skip the plain
+  // emoji/status lines that dominate the log without paying for a parse.
+  if (!trimmed.startsWith('{')) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  const args = obj.args;
+  if (typeof args !== 'object' || args === null) return null;
+  const a = args as Record<string, unknown>;
+  if (!isFiniteNumber(a.percent)) return null;
+  return {
+    tag: typeof obj.tag === 'string' ? obj.tag : undefined,
+    message: typeof obj.message === 'string' ? obj.message : undefined,
+    percent: clampPercent(a.percent),
+    completedMb: isFiniteNumber(a.completed_mb) ? a.completed_mb : undefined,
+    totalMb: isFiniteNumber(a.total_mb) ? a.total_mb : undefined,
+  };
+}
+
+/**
+ * Scan a log tail (oldest→newest) and return the most recent post-deploy
+ * progress event, or `null` if none of the lines carry progress. Newest
+ * wins so the bar tracks the live tick.
+ */
+export function latestPostDeployProgress(logs: readonly string[]): PostDeployProgress | null {
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const p = parsePostDeployProgressLine(logs[i]);
+    if (p) return p;
+  }
+  return null;
+}

--- a/packages/frontend/src/hooks/useInstallMonitor.ts
+++ b/packages/frontend/src/hooks/useInstallMonitor.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
+import { latestPostDeployProgress, type PostDeployProgress } from '@/components/postDeployProgress';
 
 // Lenient schemas — only the fields the Home install card reads. The
 // canonical job shape lives in @/lib/install/jobStore; passthrough keeps
@@ -45,6 +46,13 @@ export interface InstallMonitorState {
   percent: number;
   needsCredentials: boolean;
   logs: string[];
+  /**
+   * Latest structured progress emitted by the current item's post-deploy
+   * script (e.g. an OSCAR `ollama` model pull), parsed out of the log tail.
+   * `null` when no progress line is in flight — the card renders the bar
+   * only while a post-deploy phase is reporting (#1288).
+   */
+  postDeployProgress: PostDeployProgress | null;
 }
 
 const ACTIVE_POLL_MS = 1500;
@@ -131,6 +139,10 @@ export function useInstallMonitor(): { state: InstallMonitorState | null; skipCr
         percent: total > 0 ? Math.floor((deployed * 100) / total) : 0,
         needsCredentials: d.job.phase === 'needs_credentials' || !!d.job.needsCredentials,
         logs: logsRef.current.slice(-12),
+        // Scan the fuller buffer, not just the visible tail: a post-deploy
+        // progress tick is throttled (~15s) and can scroll past the last 12
+        // log lines during a busy model pull, but the bar should persist.
+        postDeployProgress: latestPostDeployProgress(logsRef.current),
       });
     };
 

--- a/tests/e2e/helpers/portal.ts
+++ b/tests/e2e/helpers/portal.ts
@@ -35,8 +35,9 @@ export function credentials(): { username: string; password: string } {
 export async function login(page: Page): Promise<void> {
   const { username, password } = credentials()
   await page.goto('/login')
-  await page.getByLabel('Username').fill(username)
-  await page.getByLabel('Password').fill(password)
+  // The login form uses unassociated <label> elements (no for/id), so match by placeholder.
+  await page.getByPlaceholder('System username').fill(username)
+  await page.getByPlaceholder('System password').fill(password)
   await page.getByRole('button', { name: 'Login' }).click()
   // The login handler pushes to /services on success.
   await page.waitForURL(/\/(services|dashboard)\b/, { timeout: 30_000 })


### PR DESCRIPTION
## What
Two frontend-facing features plus an e2e harness fix:
- Post-deploy progress now renders as a percent bar in the install-log card, reusing the image-pull bar UI.
- Portal surfaces a static "Manual setup needed" card for templates declaring `manual_pairing` (e.g. signal-cli link), with the exact podman exec command and a copy button.
- e2e login helper targets the field placeholder and Playwright artifacts are gitignored.

## Why
Closes #1288
Closes #1253

## Risk
Low — frontend rendering + portal card from existing user-guide frontmatter; no install-runner logic change.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 1647 passed)
- [x] next build (production) clean
- [ ] /verify on FCoS :dev box (path-mandated frontend install card + portal card)