### PR TITLE
feat(backup): auto-restore service config from NAS on reinstall (#1218 entry 1)

### DIFF
--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -14,7 +14,7 @@ const { mockNas, mockCfg } = vi.hoisted(() => ({
 vi.mock('./nasClient', () => mockNas);
 vi.mock('../config', () => mockCfg);
 
-import { restoreServiceBackup, isFreshDataDir } from './restore';
+import { restoreServiceBackup, isFreshDataDir, autoRestoreServiceOnReinstall } from './restore';
 import { NAS_BACKUP_DIR } from './producer';
 
 let tmpRoot: string;
@@ -100,5 +100,63 @@ describe('isFreshDataDir', () => {
     expect(await isFreshDataDir(empty)).toBe(true);
     await fs.writeFile(path.join(empty, 'f'), 'x');
     expect(await isFreshDataDir(empty)).toBe(false);
+  });
+});
+
+describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
+  /** NAS has a home-assistant.tar; serve its contents on download. */
+  function nasHasHomeAssistantBackup() {
+    mockNas.nasList.mockResolvedValue([{ name: 'home-assistant.tar', size: 1024 }]);
+    serveTar(buildServiceTarSync());
+  }
+  // buildServiceTar is async; pre-build once per test via a small wrapper.
+  let _tar: Buffer;
+  function buildServiceTarSync() { return _tar; }
+
+  beforeEach(async () => {
+    _tar = await buildServiceTar({ 'configuration.yaml': 'restored:', '.storage/zwave_js': '{"k":1}' });
+  });
+
+  it('restores on a clean install into an empty data dir (Local node)', async () => {
+    nasHasHomeAssistantBackup();
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'Local' }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
+    expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
+  });
+
+  it('is a no-op when it is not a clean install (a normal add-a-service install)', async () => {
+    nasHasHomeAssistantBackup();
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); });
+    expect(await isFreshDataDir(dataDir)).toBe(true); // nothing written
+    expect(logs).toEqual([]);
+  });
+
+  it('is a no-op on a remote node (restore primitive is local-fs only)', async () => {
+    nasHasHomeAssistantBackup();
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'edge-node' }, async l => { logs.push(l); });
+    expect(await isFreshDataDir(dataDir)).toBe(true);
+    expect(logs).toEqual([]);
+  });
+
+  it('is a silent no-op when no backup exists for the service', async () => {
+    mockNas.nasList.mockResolvedValue([]); // empty NAS
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'Local' }, async l => { logs.push(l); });
+    expect(logs).toEqual([]);
+  });
+
+  it('never clobbers a non-empty data dir, and never throws', async () => {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'live.yaml'), 'live');
+    nasHasHomeAssistantBackup();
+    const logs: string[] = [];
+    await expect(
+      autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'Local' }, async l => { logs.push(l); }),
+    ).resolves.toBeUndefined();
+    expect(await fs.readFile(path.join(dataDir, 'live.yaml'), 'utf8')).toBe('live'); // untouched
+    expect(logs.some(l => l.includes('restored'))).toBe(false);
   });
 });

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -18,7 +18,7 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { fetchServiceBackup, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
+import { fetchServiceBackup, listServiceBackups, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
 import { getServiceManifest } from './serviceManifest';
 import { safeTarExtract } from '../systemBackup';
 import { logger } from '../logger';
@@ -88,4 +88,36 @@ export async function restoreServiceBackup(
   const files = await countFiles(dataDir);
   logger.info('ExternalBackup', `Restored "${service}" from NAS into ${dataDir} (${files} files)`);
   return { service, dataDir, files, meta };
+}
+
+/**
+ * #1218 entry point 1 — auto-restore a service's config from the NAS during a
+ * **reinstall**, before its pod starts. No-op (and never throws) unless:
+ *  - this is a clean install / reinstall (`cleanInstall`), AND
+ *  - the node is Local (the restore primitive uses the backend's own fs), AND
+ *  - a `<service>.tar` exists on the NAS, AND
+ *  - the service's data dir is empty (`restoreServiceBackup` also refuses a
+ *    non-empty dir, so a live service's config is never clobbered).
+ * Logs each step through the injected `log` so it shows on the install stream.
+ * Best-effort: a restore failure is logged and swallowed so it can't block the
+ * deploy. The install runner calls this from `deployItem` (epic #1190).
+ */
+export async function autoRestoreServiceOnReinstall(
+  service: string,
+  opts: { cleanInstall?: boolean; node?: string | null },
+  log: (line: string) => Promise<void>,
+): Promise<void> {
+  if (!opts.cleanInstall) return;
+  if (opts.node && opts.node !== 'Local') return;
+  try {
+    const hasBackup = (await listServiceBackups()).some(b => b.service === service);
+    if (!hasBackup) return;
+    if (!(await isFreshDataDir(await resolveServiceDataDir(service)))) return;
+    await log(`💾 ${service}: found a config backup on the FritzBox NAS and the data dir is empty — restoring before first start…`);
+    const r = await restoreServiceBackup(service);
+    await log(`✅ ${service}: restored ${r.files} config file(s) from the NAS${r.meta ? ` (backed up ${r.meta.createdAt.slice(0, 10)} from ${r.meta.nodeId})` : ''}.`);
+  } catch (e) {
+    // A restore failure must never block the deploy — log a breadcrumb and continue.
+    await log(`(note) ${service}: NAS config restore skipped — ${e instanceof Error ? e.message : String(e)}.`);
+  }
 }

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -415,6 +415,18 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
     },
   });
 
+  // #1218 entry point 1 — restore this service's config from the NAS before its
+  // pod starts, on a reinstall into an empty data dir. No-op otherwise; never
+  // throws (see autoRestoreServiceOnReinstall). Mirrors the cert-archive restore.
+  {
+    const { autoRestoreServiceOnReinstall } = await import('@/lib/externalBackup/restore');
+    await autoRestoreServiceOnReinstall(
+      item.name,
+      { cleanInstall: input.cleanInstall, node: input.node },
+      line => log(jobId, line),
+    );
+  }
+
   const view = (input.variables as StackVariable[]).reduce<Record<string, string>>((acc, v) => {
     acc[v.name] = v.value;
     return acc;


### PR DESCRIPTION
First slice of **#1218** (epic #1190): the actual "my config comes back after a reinstall" behavior.

On a clean install / reinstall, `deployItem` re-seeds each service's config from its FritzBox NAS backup **before the pod starts**, wiring the existing restore primitive (#1363/#1216) into the install runner via a new exported helper `autoRestoreServiceOnReinstall`.

**Gating (safe by construction):** fires only on `cleanInstall` + Local node + a NAS backup present + an **empty** data dir — `restoreServiceBackup` itself refuses a non-empty dir, so a live service is never clobbered. Best-effort: a restore failure logs a breadcrumb and never blocks the deploy. Mirrors the existing NPM cert-archive restore.

**Tests:** 5 cases (cleanInstall / remote-node / no-backup / non-empty-dir no-ops + happy path). Extracting the helper also trims `deployItem`'s complexity.

**Verification:** path-mandated (`lib/install/`) → needs a real-box reinstall `/verify` before it rides to `:latest`. Entry point 2 (onboarding orphan hint) is a follow-up PR (browser-verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)