### PR TITLE
fix(install): apply variables.json defaults on reinstall for newly-added vars

### DIFF
--- a/packages/backend/src/lib/install/applyVariableDefaults.test.ts
+++ b/packages/backend/src/lib/install/applyVariableDefaults.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #1297 — applyVariableDefaults merges variables.json defaults into a (possibly
+// replayed) JobInput. Mock only the template-metadata source; the merge logic
+// is the real code path.
+const { mockReg } = vi.hoisted(() => ({ mockReg: { getTemplateVariables: vi.fn() } }));
+vi.mock('@/lib/registry', async (orig) => ({
+  ...(await orig<typeof import('@/lib/registry')>()),
+  getTemplateVariables: mockReg.getTemplateVariables,
+}));
+
+import { applyVariableDefaults } from './manifestAssembler';
+import type { JobInput } from './jobStore';
+
+function input(partial: Partial<JobInput>): JobInput {
+  const base: JobInput = { items: [], variables: [], cleanInstall: false, cleanInstallConfirm: '', templateSource: 'installed', host: 'localhost' };
+  return { ...base, ...partial };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('applyVariableDefaults (#1297)', () => {
+  it('fills a newly-added variable default that is missing from a replayed manifest', async () => {
+    // OSCAR repro: an older saved manifest has SERVICEBAY_MCP_URL but not the
+    // later-added GATEKEEPER_MCP_URL.
+    mockReg.getTemplateVariables.mockResolvedValue({
+      SERVICEBAY_MCP_URL: { default: 'http://127.0.0.1:5888/mcp' },
+      GATEKEEPER_MCP_URL: { default: 'http://127.0.0.1:10760/mcp' },
+    });
+    const out = await applyVariableDefaults(input({
+      items: [{ name: 'oscar-household', checked: true }],
+      variables: [{ name: 'SERVICEBAY_MCP_URL', value: 'http://custom' }],
+    }));
+    expect(out.variables.find(v => v.name === 'GATEKEEPER_MCP_URL')?.value).toBe('http://127.0.0.1:10760/mcp');
+  });
+
+  it('never overrides a non-empty manifest value (manifest wins)', async () => {
+    mockReg.getTemplateVariables.mockResolvedValue({ SERVICEBAY_MCP_URL: { default: 'http://default' } });
+    const out = await applyVariableDefaults(input({
+      items: [{ name: 'x', checked: true }],
+      variables: [{ name: 'SERVICEBAY_MCP_URL', value: 'http://custom' }],
+    }));
+    expect(out.variables.find(v => v.name === 'SERVICEBAY_MCP_URL')?.value).toBe('http://custom');
+  });
+
+  it('fills an empty existing slot from the default', async () => {
+    mockReg.getTemplateVariables.mockResolvedValue({ FOO: { default: 'bar' } });
+    const out = await applyVariableDefaults(input({
+      items: [{ name: 'x', checked: true }],
+      variables: [{ name: 'FOO', value: '' }],
+    }));
+    expect(out.variables.find(v => v.name === 'FOO')?.value).toBe('bar');
+  });
+
+  it('ignores variables that have no default', async () => {
+    mockReg.getTemplateVariables.mockResolvedValue({ NO_DEFAULT: { type: 'text' }, HAS: { default: 'd' } });
+    const out = await applyVariableDefaults(input({
+      items: [{ name: 'x', checked: true }],
+      variables: [],
+    }));
+    expect(out.variables.find(v => v.name === 'NO_DEFAULT')).toBeUndefined();
+    expect(out.variables.find(v => v.name === 'HAS')?.value).toBe('d');
+  });
+
+  it('skips unchecked / already-installed items and returns the input unchanged when nothing fills', async () => {
+    mockReg.getTemplateVariables.mockResolvedValue({ FOO: { default: 'bar' } });
+    const original = input({
+      items: [{ name: 'x', checked: true, alreadyInstalled: true }, { name: 'y', checked: false }],
+      variables: [{ name: 'FOO', value: 'set' }],
+    });
+    const out = await applyVariableDefaults(original);
+    expect(mockReg.getTemplateVariables).not.toHaveBeenCalled();
+    expect(out).toBe(original); // same reference — no allocation when nothing changed
+  });
+
+  it('does not mutate the caller\'s input', async () => {
+    mockReg.getTemplateVariables.mockResolvedValue({ NEW: { default: 'v' } });
+    const original = input({ items: [{ name: 'x', checked: true }], variables: [] });
+    const out = await applyVariableDefaults(original);
+    expect(original.variables).toHaveLength(0); // untouched
+    expect(out.variables).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -37,7 +37,7 @@ import { readManifestAnnotations } from '@/lib/template/contract';
 import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
 import { getConfig } from '@/lib/config';
 import { loadSavedSecrets, persistSingleSecret } from './savedSecrets';
-import type { JobInputItem, JobInputVariable } from './jobStore';
+import type { JobInput, JobInputItem, JobInputVariable } from './jobStore';
 
 /** A template the caller wants installed. Mirrors the wizard's
  *  `StackItemInput`. */
@@ -432,4 +432,50 @@ export async function assembleManifest(
   }
 
   return { items, variables };
+}
+
+/**
+ * #1297 — fill `variables.json` defaults into a JobInput for any template
+ * variable that's missing or empty. The wizard path resolves defaults inside
+ * `assembleManifest`; the **reinstall** path replays a saved JobInput verbatim
+ * (`jobStore`), so a variable ADDED to a template *after* the manifest was
+ * saved arrives empty and silently drops whatever depended on it (e.g. OSCAR's
+ * `GATEKEEPER_MCP_URL`). Run at the install entry point (`/api/install/start`)
+ * so every path — wizard and replayed reinstall — gets the same defaults
+ * applied. A non-empty manifest value always wins; a default only fills a
+ * missing/empty slot. Returns the input unchanged when nothing needed filling.
+ */
+export async function applyVariableDefaults(
+  input: JobInput,
+  templateSource?: string,
+): Promise<JobInput> {
+  // First template to declare a variable owns its default (mirrors
+  // assembleManifest's grouping), so only record the first non-empty default.
+  const defaults = new Map<string, string>();
+  for (const item of input.items) {
+    if (!item.checked || item.alreadyInstalled) continue;
+    const meta = await getTemplateVariables(item.name, templateSource).catch(() => null);
+    if (!meta) continue;
+    for (const [name, m] of Object.entries(meta)) {
+      if (m.default !== undefined && m.default !== '' && !defaults.has(name)) {
+        defaults.set(name, m.default);
+      }
+    }
+  }
+  if (defaults.size === 0) return input;
+
+  const next: JobInputVariable[] = input.variables.map(v => ({ ...v }));
+  const indexByName = new Map(next.map((v, i) => [v.name, i]));
+  let changed = false;
+  for (const [name, def] of defaults) {
+    const idx = indexByName.get(name);
+    if (idx === undefined) {
+      next.push({ name, value: def });
+      changed = true;
+    } else if (!next[idx].value) {
+      next[idx].value = def;
+      changed = true;
+    }
+  }
+  return changed ? { ...input, variables: next } : input;
 }

--- a/packages/frontend/src/app/api/install/start/route.ts
+++ b/packages/frontend/src/app/api/install/start/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createJob, getCurrentJob, InstallInProgressError, type JobInput } from '@/lib/install/jobStore';
+import { applyVariableDefaults } from '@/lib/install/manifestAssembler';
 import { startJob } from '@/lib/install/runner';
 import { apiError } from '@/lib/api/errors';
 
@@ -43,7 +44,12 @@ export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request
       );
     }
     try {
-      const job = await createJob({ source: body.source ?? 'wizard', input });
+      // #1297 — a reinstall replays a saved JobInput verbatim, so a variable
+      // ADDED to a template after the manifest was saved arrives empty. Merge
+      // variables.json defaults for any missing/empty var (manifest value wins)
+      // so newly-added defaults take effect without a full re-wizard.
+      const withDefaults = await applyVariableDefaults(input);
+      const job = await createJob({ source: body.source ?? 'wizard', input: withDefaults });
       startJob(job.id);
       return NextResponse.json({ jobId: job.id });
     } catch (e) {


### PR DESCRIPTION
Reinstall replays a saved JobInput through `/api/install/start → createJob`, skipping `assembleManifest` — so a variable added to a template after the manifest was saved arrived **empty** (silent partial deploy; OSCAR `GATEKEEPER_MCP_URL` repro). New `applyVariableDefaults` merges `variables.json` defaults at the install entry point for any missing/empty var (manifest value wins; default fills a gap; idempotent on the wizard path). 6 unit tests. Backend logic fully covered; real-box reinstall verify deferred to the next reinstall. Refs #1297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)