### PR TITLE
feat(backup): onboarding orphan-backup hint (#1218 entry 2)

### DIFF
--- a/packages/backend/src/lib/externalBackup/orphanBackups.test.ts
+++ b/packages/backend/src/lib/externalBackup/orphanBackups.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockProducer } = vi.hoisted(() => ({ mockProducer: { listServiceBackups: vi.fn() } }));
+vi.mock('./producer', async (orig) => ({
+  ...(await orig<typeof import('./producer')>()),
+  listServiceBackups: mockProducer.listServiceBackups,
+}));
+
+import { selectOrphanBackups, listOrphanServiceBackups } from './orphanBackups';
+
+const entry = (service: string) => ({ service, tarName: `${service}.tar`, size: 1 });
+
+describe('selectOrphanBackups (#1218 entry 2)', () => {
+  it('returns backups for services that are not installed', () => {
+    const nas = [entry('home-assistant'), entry('adguard'), entry('vaultwarden')];
+    expect(selectOrphanBackups(nas, ['adguard']).map(b => b.service)).toEqual(['home-assistant', 'vaultwarden']);
+  });
+
+  it('returns empty when every backup is already installed', () => {
+    expect(selectOrphanBackups([entry('adguard')], ['adguard', 'home-assistant'])).toEqual([]);
+  });
+
+  it('returns all of them on a fresh box (nothing installed)', () => {
+    expect(selectOrphanBackups([entry('home-assistant'), entry('adguard')], [])).toHaveLength(2);
+  });
+});
+
+describe('listOrphanServiceBackups', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists NAS backups minus the installed services', async () => {
+    mockProducer.listServiceBackups.mockResolvedValue([entry('home-assistant'), entry('adguard')]);
+    const orphans = await listOrphanServiceBackups(['adguard']);
+    expect(orphans.map(b => b.service)).toEqual(['home-assistant']);
+  });
+});

--- a/packages/backend/src/lib/externalBackup/orphanBackups.ts
+++ b/packages/backend/src/lib/externalBackup/orphanBackups.ts
@@ -1,0 +1,27 @@
+/**
+ * #1218 entry point 2 — the onboarding "orphan hint" source. After a reinstall
+ * or a foreign-backup seed (#1350), the FritzBox NAS can hold config backups
+ * for services the operator hasn't (re)installed yet. This surfaces those so
+ * the wizard can offer "N service backups available — install them?" (installing
+ * then re-seeds the config via the entry-1 restore). Epic #1190.
+ */
+import { listServiceBackups, type ServiceBackupListEntry } from './producer';
+
+/** NAS service backups whose service is NOT in `installed` — i.e. config sitting
+ *  on the NAS with no running service to own it. Pure; `installed` is any
+ *  iterable of service names. */
+export function selectOrphanBackups(
+  nasBackups: ServiceBackupListEntry[],
+  installed: Iterable<string>,
+): ServiceBackupListEntry[] {
+  const have = new Set(installed);
+  return nasBackups.filter(b => !have.has(b.service));
+}
+
+/** List NAS config backups for services not currently installed (the wizard
+ *  orphan-hint feed). */
+export async function listOrphanServiceBackups(
+  installed: Iterable<string>,
+): Promise<ServiceBackupListEntry[]> {
+  return selectOrphanBackups(await listServiceBackups(), installed);
+}

--- a/packages/frontend/src/app/api/system/external-backup/orphans/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/orphans/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { listOrphanServiceBackups } from '@/lib/externalBackup/orphanBackups';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { listNodes } from '@/lib/nodes';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET — NAS config backups for services NOT currently installed (#1218 entry 2,
+ * epic #1190). Powers the onboarding "N service backups available on the
+ * FritzBox — install them?" hint: a reinstall or a foreign-backup seed (#1350)
+ * can leave config on the NAS with no service to own it; installing one then
+ * re-seeds its config via the entry-1 restore.
+ *
+ * Never errors the wizard — returns `{ orphans: [] }` if the NAS isn't
+ * configured/reachable, so a missing NAS just hides the hint.
+ */
+export const GET = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
+  try {
+    const node = new URL(request.url).searchParams.get('node')
+      || (await listNodes())[0]?.Name
+      || 'Local';
+    const installed = (await ServiceManager.listServices(node)).map(s => s.name);
+    const orphans = await listOrphanServiceBackups(installed);
+    return NextResponse.json({ orphans });
+  } catch {
+    return NextResponse.json({ orphans: [] });
+  }
+});

--- a/packages/frontend/src/components/wizard/steps/FinishStep.tsx
+++ b/packages/frontend/src/components/wizard/steps/FinishStep.tsx
@@ -1,11 +1,54 @@
 'use client';
 
 
-import { CheckCircle, ArrowRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CheckCircle, ArrowRight, DatabaseBackup } from 'lucide-react';
 import { Button } from '../WizardUI';
 
 interface FinishStepProps {
     handleFinish: () => void;
+}
+
+interface OrphanBackup { service: string; tarName: string; size: number }
+
+/**
+ * #1218 entry point 2 — surface NAS config backups for services the operator
+ * didn't (re)install, so they can set them up + re-seed config (entry-1 restore
+ * runs on install). Silent when there are none / the NAS is unreachable.
+ */
+function OrphanBackupsHint() {
+    const [orphans, setOrphans] = useState<OrphanBackup[]>([]);
+    useEffect(() => {
+        let alive = true;
+        fetch('/api/system/external-backup/orphans', { credentials: 'include' })
+            .then(r => (r.ok ? r.json() : { orphans: [] }))
+            .then(d => { if (alive) setOrphans(Array.isArray(d.orphans) ? d.orphans : []); })
+            .catch(() => { /* NAS unreachable — just don't show the hint */ });
+        return () => { alive = false; };
+    }, []);
+
+    if (orphans.length === 0) return null;
+
+    return (
+        <div className="mx-auto max-w-md text-left rounded-2xl border border-blue-500/20 bg-blue-500/5 p-5">
+            <div className="flex items-center gap-2 text-blue-600 dark:text-blue-400">
+                <DatabaseBackup className="w-5 h-5 shrink-0" />
+                <span className="font-semibold">
+                    {orphans.length} service backup{orphans.length === 1 ? '' : 's'} on your FritzBox NAS
+                </span>
+            </div>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Config for {orphans.map(o => o.service).join(', ')} is on the NAS but not installed here.
+                Install {orphans.length === 1 ? 'it' : 'them'} and the saved config is restored automatically.
+            </p>
+            <a
+                href="/services"
+                className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+            >
+                Set them up <ArrowRight className="w-4 h-4" />
+            </a>
+        </div>
+    );
 }
 
 export function FinishStep({ handleFinish }: FinishStepProps) {
@@ -17,7 +60,7 @@ export function FinishStep({ handleFinish }: FinishStepProps) {
                     <CheckCircle className="w-16 h-16 text-emerald-500" />
                 </div>
             </div>
-            
+
             <div className="space-y-3">
                 <h3 className="text-3xl font-extrabold tracking-tight bg-clip-text text-transparent premium-gradient">
                     You&apos;re All Set!
@@ -27,12 +70,14 @@ export function FinishStep({ handleFinish }: FinishStepProps) {
                 </p>
             </div>
 
+            <OrphanBackupsHint />
+
             <div className="pt-4">
                 <Button onClick={handleFinish} className="w-full sm:w-auto px-12 py-4 text-lg">
                     Go to Dashboard <ArrowRight className="w-5 h-5 ml-2" />
                 </Button>
             </div>
-            
+
             <p className="text-[10px] text-gray-400 uppercase tracking-widest font-bold">
                 Setup Complete · Welcome Home
             </p>


### PR DESCRIPTION
Second + final entry point of #1218 (epic #1190). The wizard finish step surfaces NAS config backups for un-installed services (orphans) so a reinstall / foreign-backup seed (#1350) is discoverable — installing re-seeds config via the entry-1 restore. New `selectOrphanBackups`/`listOrphanServiceBackups` + GET `/api/system/external-backup/orphans` (returns `[]` when NAS unreachable) + a FinishStep card. 4 unit tests on the filter; card render/route browser-verified at the next reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)