### PR TITLE
feat(tui): chain post-boot sign-in + restore + install into Express (#1233)

### DIFF
--- a/tools/sb-tui/internal/ui/express.go
+++ b/tools/sb-tui/internal/ui/express.go
@@ -5,9 +5,10 @@
 // interactive stdin wizard, not a Bubble Tea program; this model only renders
 // the plan and reports the operator's confirm/cancel choice.
 //
-// The post-boot restore + stack-install steps are deliberately NOT chained
-// here: they need a reachable box and a minted SB_TOKEN that only exist after
-// first boot, so they stay as the dedicated panels (#1276/#1277).
+// The post-boot restore + stack-install steps ARE chained too, but by the
+// entrypoint (runExpress) after first boot — they need a reachable box and a
+// minted token that only exist once the box is up, so the sequence signs in,
+// then drives the restore (#1277) and stack-install (#1276) panels in order.
 //
 // One optional pre-boot step IS offered up front: staging an existing backup on
 // the NAS (step ① of the journey). It's toggled here and, when on, the
@@ -91,6 +92,9 @@ func (m ExpressModel) View() string {
 		"Build + flash a ServiceBay install ISO to a USB stick",
 		"Pause so you can boot the box from that USB",
 		"Watch the install live until the setup wizard takes over",
+		"Sign in to the box (one-time — mints a saved token)",
+		"Restore your config from the NAS",
+		"Install your stacks",
 	)
 	for i, s := range steps {
 		b.WriteString(normalStyle.Render("  "+stepNum(i+1)+" "+s) + "\n")
@@ -101,7 +105,7 @@ func (m ExpressModel) View() string {
 		target = m.host + ":" + m.port
 	}
 	b.WriteString(detailStyle.Render("Target: "+target) + "\n")
-	b.WriteString(detailStyle.Render(cfgEmptyStyle.Render("After first boot, use Edit config / Install stacks / Backups to finish setup.")) + "\n\n")
+	b.WriteString(detailStyle.Render(cfgEmptyStyle.Render("Sign-in, restore + install run after first boot, once the box is reachable.")) + "\n\n")
 	b.WriteString(footerStyle.Render("space toggle backup · enter start · q cancel"))
 	return frame(b.String(), m.width, m.height)
 }

--- a/tools/sb-tui/internal/ui/express_test.go
+++ b/tools/sb-tui/internal/ui/express_test.go
@@ -60,3 +60,12 @@ func TestExpressViewShowsPlanAndTarget(t *testing.T) {
 		t.Error("empty-target view should show the discovery hint")
 	}
 }
+
+func TestExpressViewShowsPostBootSteps(t *testing.T) {
+	v := NewExpress("box.local", "5888").View()
+	for _, want := range []string{"Sign in", "Restore your config from the NAS", "Install your stacks"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("express view missing post-boot step %q", want)
+		}
+	}
+}

--- a/tools/sb-tui/internal/ui/loginrun.go
+++ b/tools/sb-tui/internal/ui/loginrun.go
@@ -1,0 +1,54 @@
+// Standalone sign-in runner for the Express post-boot continuation (#1233).
+// The LoginModel is normally an App sub-view: it bubbles authSucceededMsg up to
+// the App, which saves the token and opens the requested panel. Express runs
+// outside the App (a sequence of standalone programs), so it needs its own tiny
+// host that captures the minted token and quits.
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// loginRunner hosts a LoginModel as a root Bubble Tea program, capturing the
+// minted token (authSucceededMsg) or a cancel (backMsg) and quitting.
+type loginRunner struct {
+	login LoginModel
+	token string
+	ok    bool
+}
+
+func (r loginRunner) Init() tea.Cmd { return r.login.Init() }
+
+func (r loginRunner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case authSucceededMsg:
+		r.token, r.ok = msg.token, true
+		return r, tea.Quit
+	case backMsg:
+		return r, tea.Quit // operator hit esc — cancelled, no token
+	}
+	lm, cmd := r.login.Update(msg)
+	r.login = lm.(LoginModel)
+	return r, cmd
+}
+
+func (r loginRunner) View() string { return r.login.View() }
+
+// RunLogin opens a standalone sign-in for host:port and, on success, persists
+// the freshly-minted scoped token via save. Returns true when a token was
+// minted, false when the operator cancelled. Used by the Express post-boot
+// chain so it can reach the token-gated restore + install panels.
+func RunLogin(host, port string, save TokenSaver) (bool, error) {
+	final, err := tea.NewProgram(loginRunner{login: NewLogin(host, port)}, tea.WithAltScreen()).Run()
+	if err != nil {
+		return false, err
+	}
+	r, ok := final.(loginRunner)
+	if !ok || !r.ok || r.token == "" {
+		return false, nil
+	}
+	if save != nil {
+		_ = save(host, r.token)
+	}
+	return true, nil
+}

--- a/tools/sb-tui/internal/ui/loginrun_test.go
+++ b/tools/sb-tui/internal/ui/loginrun_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import "testing"
+
+func TestLoginRunnerCapturesToken(t *testing.T) {
+	r := loginRunner{login: NewLogin("h", "5888")}
+	mi, cmd := r.Update(authSucceededMsg{token: "sb_abc"})
+	rr := mi.(loginRunner)
+	if !rr.ok || rr.token != "sb_abc" {
+		t.Fatalf("authSucceeded should capture the token: ok=%v token=%q", rr.ok, rr.token)
+	}
+	if cmd == nil {
+		t.Fatal("should quit after capturing the token")
+	}
+}
+
+func TestLoginRunnerCancel(t *testing.T) {
+	r := loginRunner{login: NewLogin("h", "5888")}
+	mi, cmd := r.Update(backMsg{})
+	rr := mi.(loginRunner)
+	if rr.ok || rr.token != "" {
+		t.Fatalf("backMsg should cancel with no token: ok=%v token=%q", rr.ok, rr.token)
+	}
+	if cmd == nil {
+		t.Fatal("should quit on cancel")
+	}
+}

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -214,9 +214,9 @@ func boxClient() (*rest.Client, int) {
 }
 
 // runExpress runs the guided Express setup (#1233): a confirm screen, then the
-// auto-sequenceable pre-boot legs — build + flash, a boot pause, then watch.
-// The post-boot restore/install steps stay as the dedicated panels since they
-// need a reachable box + token. Any leg failing aborts the sequence.
+// pre-boot legs — build + flash, a boot pause, watch — and finally the post-boot
+// legs once the box is reachable: sign in (mint a saved token), restore config
+// from the NAS, and install stacks. Any leg failing aborts the rest.
 func runExpress() int {
 	t := probes.ResolveTarget()
 	final, err := tea.NewProgram(ui.NewExpress(t.Host, t.Port), tea.WithAltScreen()).Run()
@@ -249,7 +249,39 @@ func runExpress() int {
 	_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
 
 	// 3) Watch the install through to the wizard handoff.
-	return runWatch()
+	if code := runWatch(); code != 0 {
+		return code
+	}
+
+	// 4) Post-boot continuation (#1233): the box is up now — sign in (mint a
+	//    saved token if needed), restore config from the NAS, then install the
+	//    stacks. This is the token-gated tail the pre-boot legs couldn't reach.
+	return runExpressPostBoot()
+}
+
+// runExpressPostBoot drives the token-gated tail of Express once the box is
+// reachable: ensure a scoped token (sign in + mint if none is saved), restore
+// NAS config backups, then install stacks. Each leg failing aborts the rest.
+func runExpressPostBoot() int {
+	t := probes.ResolveTarget()
+	if probes.ResolveToken(t.Host) == "" {
+		fmt.Print("\n→ Sign in to the box to finish setup (one-time)…\n")
+		ok, err := ui.RunLogin(t.Host, t.Port, probes.SaveToken)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if !ok {
+			fmt.Println("Sign-in skipped — run `sb-tui` later to restore + install your stacks.")
+			return 0
+		}
+	}
+	// Restore config from the NAS, then install stacks. On a fresh data dir the
+	// install also re-seeds config via the server-side auto-restore (#1218).
+	if code := runBackups(); code != 0 {
+		return code
+	}
+	return runInstallStacks()
 }
 
 // runNasUpload opens the direct-FTP backup-staging panel (#1367). It talks only


### PR DESCRIPTION
Express now runs the **full** build→boot→watch→**sign-in→restore→install** chain instead of stopping at the watch handoff. After first boot, `runExpressPostBoot` mints a scoped token (new `ui.RunLogin` wraps the App's login sub-view as a standalone program) then drives the restore (#1277) + stack-install (#1276) panels in order. Confirm-screen preview updated. Tests cover the preview steps + the login runner's token-capture/cancel. gofmt/vet/build/test clean. Completes the Express capstone (#1272/#1231); real-box verify deferred to reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)