### PR TITLE
docs: reflect the Go sb-tui (install, Express, retire stale script refs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,19 @@ Combined: any stolen token has a bounded blast radius; everything is reversible;
 
 ## Quick Start
 
-ServiceBay runs on **Fedora CoreOS** as an immutable, self-updating appliance. See the [Installation Guide](docs/INSTALLATION.md) for the full build pipeline, first-boot sequence, and configuration options.
+ServiceBay runs on **Fedora CoreOS** as an immutable, self-updating appliance. The whole lifecycle is driven by **`sb-tui`** — a single static Go/Bubble Tea binary (no repo clone needed). See the [Installation Guide](docs/INSTALLATION.md) for the full build pipeline, first-boot sequence, and configuration options.
 
 ```bash
-go run ./tools/sb-tui        # lifecycle launcher; pick "Build ISO"
-# or run the build leg directly:
-go run ./tools/sb-tui build
+# Install the lifecycle TUI (auto-detects your OS/arch from GitHub releases):
+curl -fsSL https://raw.githubusercontent.com/mdopp/servicebay/main/install-sb-tui.sh | sh
+
+sb-tui          # launcher — Express setup, or pick an individual leg
+sb-tui build    # just the ISO build + USB-flash wizard
 ```
 
-The installer creates a bootable USB that provisions the entire system: OS, networking, ServiceBay container, SSH keys, and an admin account. First boot drops you into a wizard that deploys the stacks you select, sets up SSO, configures DNS + proxy routes, and hands you the credentials manifest as a Bitwarden-importable CSV.
+**`sb-tui` is the one tool for the whole journey.** Its **Express setup** chains the happy path end-to-end: build + flash the install USB → boot the box → watch the install → sign in → **restore your config from the NAS** → install your stacks. Each leg is also available standalone from the menu (build, watch, edit-config, install stacks, backups, channel switch). Developers working from a clone can run it with `go run ./tools/sb-tui`.
+
+The install USB provisions the entire system: OS, networking, ServiceBay container, SSH keys, and an admin account. First boot drops you into a wizard (web) — or `sb-tui` Express (terminal) — that deploys the stacks you select, sets up SSO, configures DNS + proxy routes, restores any per-service config backups from the FritzBox NAS, and hands you the credentials manifest as a Bitwarden-importable CSV.
 
 ## Technical features
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,8 +4,8 @@
 
 ```mermaid
 flowchart TD
-    subgraph "Developer Workstation"
-        A[run install-fedora-coreos.sh] --> B[Interactive Prompts]
+    subgraph "Your machine — sb-tui"
+        A["sb-tui build (or Express)"] --> B[Build form: settings + secrets]
         B --> C[Generate SSH Keypair<br/>RSA 4096]
         B --> D[Hash Console Password<br/>openssl passwd -6]
         B --> E[Render config.json<br/>auth + gateway + email + registries]
@@ -25,7 +25,9 @@ flowchart TD
     style K fill:#c8e6c9
 ```
 
-## 2. FCOS Installer Prompts
+## 2. Install settings (the `sb-tui build` form)
+
+These are collected by the `sb-tui build` form — a 5-step Bubble Tea wizard (Settings → Image → Secrets → Flash → Review) — and persisted to `build/fcos/install-settings.env`, so a rebuild (and Express) pre-fills them. (The old interactive `install-fedora-coreos.sh` shell prompts were retired with the Go TUI.)
 
 ```
 ┌─────────────┬──────────────────────────────┬────────────┬────────────┐
@@ -409,8 +411,8 @@ doesn't answer — but each has a distinct cause and a different fix.
 **Symptom (from network):** ping cycles UP / DOWN with a ~90-second
 period. The installer keeps re-running.
 
-**Root cause:** `install-fedora-coreos.sh`'s `disable-usb-boot.sh` runs
-under `WantedBy=multi-user.target`, so it only fires *after* the install
+**Root cause:** the `disable-usb-boot.sh` baked into the ISO by `sb-tui build`
+runs under `WantedBy=multi-user.target`, so it only fires *after* the install
 chain finishes. On hardware where `install-nvidia` reboots mid-stage
 (see 13.2), `disable-usb-boot` never runs and the BIOS keeps booting
 from the still-inserted USB.


### PR DESCRIPTION
Brings the docs in line with the Go TUI rewrite. README Quick Start leads with the no-clone `curl … install-sb-tui.sh | sh` install and describes `sb-tui` + Express (build→boot→watch→sign-in→restore→install). INSTALLATION.md's stale `install-fedora-coreos.sh` references (build-pipeline diagram, prompts section, §13.1 gotcha) now point at `sb-tui build`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)