### PR TITLE
feat(tui,install): factory-fresh install toggle (#1496)

### DIFF
--- a/tools/sb-tui/internal/build/assets/fedora-coreos.bu
+++ b/tools/sb-tui/internal/build/assets/fedora-coreos.bu
@@ -247,6 +247,24 @@ storage:
           # Check for existing auto-assembled arrays first, then try manual assembly, then create new.
           MD_DEV=""
 
+          # Factory-fresh "wipe-all-data" (#1496): the operator chose a BLANK box in
+          # the build form. Destroy any existing data array + superblock so the
+          # create-new path below reformats the disk from scratch (all service data
+          # gone). Gated entirely on the baked flag — never fires on a normal build.
+          if [[ "${FACTORY_FRESH}" == "wipe-all-data" ]]; then
+            echo "setup-raid: FACTORY_FRESH=wipe-all-data — wiping the entire data disk"
+            for part in "${RAID_DISK}p1" "${RAID_DISK}1" "$RAID_DISK"; do
+              [[ -e "$part" ]] || continue
+              for md in /dev/md[0-9]*; do
+                [[ -e "$md" ]] || continue
+                mdadm --detail "$md" 2>/dev/null | grep -q "$part" && mdadm --stop "$md" 2>/dev/null || true
+              done
+              mdadm --zero-superblock "$part" 2>/dev/null || true
+            done
+            wipefs -a "$RAID_DISK" 2>/dev/null || true
+            # MD_DEV stays empty → step 4 creates + formats a fresh array below.
+          fi
+
           # 1) Check if any md device already uses a partition from RAID_DISK
           for part in "${RAID_DISK}p1" "${RAID_DISK}1" "$RAID_DISK"; do
             [[ -e "$part" ]] || continue
@@ -335,6 +353,22 @@ storage:
 
           # Create data directories (no-op if they already exist)
           mkdir -p "$MOUNT_POINT/servicebay/ssh" "$MOUNT_POINT/stacks"
+
+          # Factory-fresh "wipe-configs" (#1496): clear ServiceBay's own identity
+          # so the install promotes the freshly-baked config instead of merging the
+          # old one back — fresh admin / secret.key / tokens — while KEEPING all
+          # service data under stacks/. (wipe-all-data already reformatted, so the
+          # dir is empty there and this is a no-op.) Gated on the baked flag.
+          if [[ "${FACTORY_FRESH}" == "wipe-configs" ]]; then
+            echo "setup-raid: FACTORY_FRESH=wipe-configs — clearing ServiceBay config/identity (keeping service data)"
+            rm -f "$MOUNT_POINT/servicebay/config.json" \
+                  "$MOUNT_POINT/servicebay/config.iso.json" \
+                  "$MOUNT_POINT/servicebay/secret.key" \
+                  "$MOUNT_POINT/servicebay/.auth-secret.env" \
+                  "$MOUNT_POINT/servicebay/api-tokens.json" 2>/dev/null || true
+            rm -f "$MOUNT_POINT/servicebay"/config.json.*bak* 2>/dev/null || true
+            rm -rf "$MOUNT_POINT/servicebay/quadlet-backup" 2>/dev/null || true
+          fi
 
           # Apply Ignition config into RAID
           if [[ -n "$IGNITION_TMP" && -d "$IGNITION_TMP/servicebay" ]]; then

--- a/tools/sb-tui/internal/build/render.go
+++ b/tools/sb-tui/internal/build/render.go
@@ -36,7 +36,7 @@ var butaneVars = []string{
 	"SERVER_NAME", "HOST_USER", "SSH_AUTHORIZED_KEY", "PASSWORD_HASH", "NET_INTERFACE",
 	"STATIC_IP", "STATIC_PREFIX", "GATEWAY", "DNS_SERVERS", "DATA_ROOT", "SERVICEBAY_PORT",
 	"SERVICEBAY_VERSION", "SERVICEBAY_CONFIG_JSON", "SERVICEBAY_SSH_PUB", "SERVICEBAY_SSH_PRIV",
-	"AUTH_SECRET", "SERVICEBAY_ADMIN_USER", "SERVICEBAY_ADMIN_PASSWORD",
+	"AUTH_SECRET", "SERVICEBAY_ADMIN_USER", "SERVICEBAY_ADMIN_PASSWORD", "FACTORY_FRESH",
 }
 
 func butaneVarSet() map[string]bool {
@@ -180,6 +180,18 @@ func (in RenderInputs) vars() map[string]string {
 		"AUTH_SECRET":               "", // no-op (template self-generates on first boot)
 		"SERVICEBAY_ADMIN_USER":     s.ServicebayAdminUser,
 		"SERVICEBAY_ADMIN_PASSWORD": in.Secrets.AdminPassword,
+		"FACTORY_FRESH":             factoryFreshOrOff(s.FactoryFresh),
+	}
+}
+
+// factoryFreshOrOff normalises the baked factory-fresh flag so the install-time
+// setup-raid script always sees one of off/wipe-configs/wipe-all-data (#1496).
+func factoryFreshOrOff(v string) string {
+	switch v {
+	case "wipe-configs", "wipe-all-data":
+		return v
+	default:
+		return "off"
 	}
 }
 

--- a/tools/sb-tui/internal/build/render_test.go
+++ b/tools/sb-tui/internal/build/render_test.go
@@ -98,6 +98,26 @@ func TestRenderButane_SubstitutesAndPreserves(t *testing.T) {
 	}
 }
 
+func TestRenderButane_FactoryFresh(t *testing.T) {
+	base := RenderInputs{Settings: Settings{ServerName: "OSCAR", HostUser: "core", ServicebayChannel: "stable"}}
+
+	// Default (unset) renders as the safe "off" and leaves no placeholder.
+	off := base.Butane()
+	if strings.Contains(off, "${FACTORY_FRESH}") {
+		t.Error("FACTORY_FRESH placeholder left unsubstituted")
+	}
+	if !strings.Contains(off, `"off" == "wipe-all-data"`) {
+		t.Error("default factory-fresh should render the literal off into the guard")
+	}
+
+	// Chosen level is baked into the install-time guard.
+	in := base
+	in.Settings.FactoryFresh = "wipe-configs"
+	if got := in.Butane(); !strings.Contains(got, `"wipe-configs" == "wipe-configs"`) {
+		t.Error("wipe-configs not substituted into the setup-raid guard")
+	}
+}
+
 func TestRenderPreInstall_OnlyServerName(t *testing.T) {
 	in := RenderInputs{Settings: Settings{ServerName: "OSCAR"}}
 	out := in.PreInstall()

--- a/tools/sb-tui/internal/build/settings.go
+++ b/tools/sb-tui/internal/build/settings.go
@@ -43,6 +43,12 @@ type Settings struct {
 	EmailFrom           string
 	EmailRecipients     string
 	AuthSecret          string
+	// FactoryFresh controls how much of the persistent /mnt/data the install
+	// wipes (#1496). "off" = normal reinstall (config merged back, data kept);
+	// "wipe-configs" = clear ServiceBay's own identity (config.json, secret.key,
+	// tokens) so the box comes up as a fresh ServiceBay, keeping service data;
+	// "wipe-all-data" = reformat the whole data disk (blank box). Defaults off.
+	FactoryFresh string
 }
 
 // DefaultPort is the ServiceBay HTTP port baked into a build when the operator

--- a/tools/sb-tui/internal/ui/buildform.go
+++ b/tools/sb-tui/internal/ui/buildform.go
@@ -93,6 +93,9 @@ var settingsFields = []sfield{
 		get: func(s *build.Settings) string { return s.ServicebayChannel }, set: func(s *build.Settings, v string) { s.ServicebayChannel = v }},
 	{label: "Admin username", help: "Login for the ServiceBay web dashboard (and the in-TUI sign-in).",
 		get: func(s *build.Settings) string { return s.ServicebayAdminUser }, set: func(s *build.Settings, v string) { s.ServicebayAdminUser = v }},
+	{label: "Factory-fresh install", kind: fChoice, options: []string{"off", "wipe-configs", "wipe-all-data"},
+		help: "DESTRUCTIVE. off = normal reinstall (keeps config + data). wipe-configs = fresh ServiceBay (new admin/secrets/tokens), KEEPS service data. wipe-all-data = reformat the whole data disk (BLANK box, all service data gone).",
+		get:  func(s *build.Settings) string { return ffOrOff(s.FactoryFresh) }, set: func(s *build.Settings, v string) { s.FactoryFresh = v }},
 	{label: "Public domain", help: "Optional external domain for reverse-proxy/TLS. Blank to skip.",
 		get: func(s *build.Settings) string { return s.PublicDomain }, set: func(s *build.Settings, v string) { s.PublicDomain = v }},
 	{label: "FRITZ!Box host", help: "Optional. Router IP/hostname to enable FRITZ!Box automation. Blank to skip.",
@@ -132,6 +135,17 @@ func yn(v string) string {
 		return "Y"
 	}
 	return "N"
+}
+
+// ffOrOff normalises the factory-fresh choice for display: an empty/unknown
+// value reads as the safe "off" so the fChoice cycle has a valid starting point.
+func ffOrOff(v string) string {
+	switch v {
+	case "wipe-configs", "wipe-all-data":
+		return v
+	default:
+		return "off"
+	}
 }
 
 // BuildDeps injects the IO the form needs (so it's testable without network/USB).


### PR DESCRIPTION
Adds a **Factory-fresh install** choice to the sb-tui build form — `off` / `wipe-configs` (fresh ServiceBay, keep service data) / `wipe-all-data` (reformat the data disk) — baked into the ISO and acted on by `setup-raid`. Gated entirely on the flag; a normal build is unchanged. Render test + `butane --strict` transpile verified; real-box verify is the next reinstall. Image-wipe deferred (epic #1497 / #1494). Part of #1497, closes the install half of the factory-fresh work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)