### PR TITLE
feat(install): factory-reset image-wipe level (#1495)

### DIFF
--- a/packages/backend/src/lib/install/performStackReset.test.ts
+++ b/packages/backend/src/lib/install/performStackReset.test.ts
@@ -109,3 +109,17 @@ describe('performStackReset — secrets regen (#1246)', () => {
     ).rejects.toThrow('disk full');
   });
 });
+
+describe('performStackReset — image wipe (#1495 level b)', () => {
+  it('wipes images when wipeImages is set', async () => {
+    const result = await performStackReset({ preserve: ['secrets'], node: 'node-1', wipeImages: true });
+    expect(sentCommands.some(c => c.includes('podman rmi -af'))).toBe(true);
+    expect(result.wipeStepsRun.some(s => s.startsWith('images'))).toBe(true);
+  });
+
+  it('does NOT touch images by default', async () => {
+    const result = await performStackReset({ preserve: ['secrets'], node: 'node-1' });
+    expect(sentCommands.some(c => c.includes('podman rmi'))).toBe(false);
+    expect(result.wipeStepsRun.some(s => s.startsWith('images'))).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/install/performStackReset.ts
+++ b/packages/backend/src/lib/install/performStackReset.ts
@@ -24,6 +24,10 @@ export interface PerformStackResetOptions {
   preserve?: unknown;
   /** Optional node name; defaults to the first node in the twin. */
   node?: string;
+  /** #1495 — also wipe all container images on the node (`podman rmi -af`) so
+   *  the next install re-pulls a fresh set (the escalating factory-reset level
+   *  (b)). Default false. */
+  wipeImages?: boolean;
 }
 
 export interface PerformStackResetResult {
@@ -255,6 +259,17 @@ export async function performStackReset(
       await agent.sendCommand('exec', { command: `rm -rf ${JSON.stringify(p)}` });
     }
     wipeStepsRun.push(`${id} (always-wipe)`);
+  }
+
+  // #1495 — factory-reset level (b): wipe all container images so the next
+  // install re-pulls a fresh, known set. Runs after the service teardown above
+  // (no in-use images left to block removal). Best-effort: a failure here must
+  // not fail the whole reset.
+  if (options.wipeImages) {
+    await agent.sendCommand('exec', {
+      command: 'podman rmi -af 2>/dev/null; podman image prune -af 2>/dev/null || true',
+    });
+    wipeStepsRun.push('images (podman rmi -af — re-pulled on next install)');
   }
 
   return {

--- a/packages/frontend/src/app/api/system/stacks/reset/route.ts
+++ b/packages/frontend/src/app/api/system/stacks/reset/route.ts
@@ -23,10 +23,11 @@ export const dynamic = 'force-dynamic';
 export const POST = withApiHandler({}, async ({ request }) => {
   try {
     const body = await request.json();
-    const { confirm, node: requestedNode, preserve: rawPreserve } = body as {
+    const { confirm, node: requestedNode, preserve: rawPreserve, wipeImages } = body as {
       confirm?: string;
       node?: string;
       preserve?: unknown;
+      wipeImages?: boolean;
     };
 
     if (confirm !== 'RESET') {
@@ -36,7 +37,7 @@ export const POST = withApiHandler({}, async ({ request }) => {
       );
     }
 
-    const result = await performStackReset({ node: requestedNode, preserve: rawPreserve });
+    const result = await performStackReset({ node: requestedNode, preserve: rawPreserve, wipeImages: wipeImages === true });
     return NextResponse.json(result);
   } catch (error) {
     if (error instanceof StackResetError) {


### PR DESCRIPTION
`performStackReset` gains opt-in `wipeImages` (`podman rmi -af` after teardown), plumbed through `/api/system/stacks/reset`. The 3 factory-reset levels are now expressible via preserve + wipeImages. 2 unit tests; tsc/lint/arch clean. Part of epic #1497.