### PR TITLE
fix: reconcile install/dashboard/health/tui state after wipe-configs reinstall

### DIFF
--- a/packages/backend/src/lib/health/init.test.ts
+++ b/packages/backend/src/lib/health/init.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CheckConfig } from './types';
+
+// Per-service health checks are gated on actual deployment (#1506):
+// initializeDefaultChecks reconciles the on-disk checks to the set of
+// deployed services (ServiceManager.listServices, which reads the deployed
+// Quadlet files). A service that isn't deployed must lose its check.
+
+const { state } = vi.hoisted(() => ({
+  state: { checks: [] as CheckConfig[], deployed: [] as string[] },
+}));
+
+vi.mock('./store', () => ({
+  HealthStore: {
+    getChecks: () => [...state.checks],
+    saveCheck: (c: CheckConfig) => {
+      const i = state.checks.findIndex(x => x.id === c.id);
+      if (i >= 0) state.checks[i] = c; else state.checks.push(c);
+    },
+    deleteCheck: (id: string) => { state.checks = state.checks.filter(c => c.id !== id); },
+    deleteServiceCheck: (target: string) => {
+      const before = state.checks.length;
+      state.checks = state.checks.filter(c =>
+        !((c.type === 'service' && c.target === target) || c.name === `Service: ${target}`));
+      return before - state.checks.length;
+    },
+  },
+}));
+vi.mock('../services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(async () => state.deployed.map(name => ({ name }))) },
+}));
+vi.mock('../config', () => ({ getConfig: vi.fn(async () => ({ gateway: undefined })) }));
+vi.mock('../nodes', () => ({ listNodes: vi.fn(async () => []) }));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { initializeDefaultChecks } from './init';
+
+const serviceCheck = (target: string): CheckConfig => ({
+  id: `id-${target}`, name: `Service: ${target}`, type: 'service', target,
+  interval: 60, enabled: true, created_at: new Date().toISOString(),
+});
+
+describe('initializeDefaultChecks service-check reconciliation (#1506)', () => {
+  beforeEach(() => { state.checks = []; state.deployed = []; });
+
+  it('prunes a per-service check whose target is no longer deployed', async () => {
+    state.checks = [serviceCheck('ollama'), serviceCheck('vaultwarden')];
+    state.deployed = ['vaultwarden'];
+
+    await initializeDefaultChecks();
+
+    const targets = state.checks.filter(c => c.type === 'service').map(c => c.target);
+    expect(targets).toContain('vaultwarden');
+    expect(targets).not.toContain('ollama');
+  });
+
+  it('keeps the podman.socket singleton even though it is not a deployed stack', async () => {
+    state.deployed = [];
+
+    await initializeDefaultChecks();
+
+    expect(state.checks.some(c => c.type === 'service' && c.target === 'podman.socket')).toBe(true);
+  });
+
+  it('adds a check for a deployed service that has none', async () => {
+    state.deployed = ['immich'];
+
+    await initializeDefaultChecks();
+
+    expect(state.checks.some(c => c.type === 'service' && c.target === 'immich')).toBe(true);
+  });
+});

--- a/packages/backend/src/lib/health/init.ts
+++ b/packages/backend/src/lib/health/init.ts
@@ -20,9 +20,36 @@ async function addGatewayCheck(config: Awaited<ReturnType<typeof getConfig>>, _e
   }
 }
 
+/**
+ * Per-service health checks are gated on actual deployment (#1506):
+ * `listServices` reads the deployed Quadlet files off the digital twin, so
+ * it is the authoritative set of installed stacks. We reconcile the on-disk
+ * checks to that set — add a check for any deployed service that lacks one,
+ * and prune any auto-created `Service:` check whose target is no longer
+ * deployed (an uninstall the box missed, or a stale check from a prior
+ * install). An un-installed service must show no check, never a red
+ * "failing" one. `podman.socket` is a ServiceBay-internal singleton (added
+ * separately) and is exempt from the prune.
+ */
+const SERVICE_CHECK_PRUNE_EXEMPT = new Set<string>(['podman.socket']);
+
 async function addServiceChecks(existingChecks: ReturnType<typeof HealthStore.getChecks>, exists: (type: string, target: string) => boolean) {
   try {
     const services = await ServiceManager.listServices('Local');
+    const deployed = new Set(services.map(s => s.name));
+
+    // Prune auto-created per-service checks for services that are no longer
+    // deployed. Only touches `type:'service'` rows the deploy/discovery path
+    // creates — manual checks of other types are untouched.
+    for (const c of existingChecks) {
+      if (c.type !== 'service') continue;
+      if (SERVICE_CHECK_PRUNE_EXEMPT.has(c.target)) continue;
+      if (!deployed.has(c.target)) {
+        logger.info('Health', `Pruning health check for un-installed service ${c.target}`);
+        HealthStore.deleteServiceCheck(c.target);
+      }
+    }
+
     for (const service of services) {
       const alreadyMonitored = existingChecks.some(c =>
         (c.type === 'service' && c.target === service.name) ||

--- a/packages/backend/src/lib/health/store.test.ts
+++ b/packages/backend/src/lib/health/store.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import type { CheckConfig } from './types';
+
+// Point DATA_DIR at a fresh temp dir BEFORE importing the store (dirs.ts
+// reads process.env.DATA_DIR at module load).
+let tmpDir: string;
+
+const serviceCheck = (target: string): CheckConfig => ({
+  id: `id-${target}`,
+  name: `Service: ${target}`,
+  type: 'service',
+  target,
+  interval: 60,
+  enabled: true,
+  created_at: new Date().toISOString(),
+});
+
+describe('HealthStore.deleteServiceCheck (#1506)', () => {
+  let HealthStore: typeof import('./store').HealthStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'healthstore-'));
+    vi.resetModules();
+    process.env.DATA_DIR = tmpDir;
+    ({ HealthStore } = await import('./store'));
+  });
+
+  afterEach(async () => {
+    delete process.env.DATA_DIR;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes the per-service check matching target and reports the count', () => {
+    HealthStore.saveCheck(serviceCheck('ollama'));
+    HealthStore.saveCheck(serviceCheck('vaultwarden'));
+
+    const removed = HealthStore.deleteServiceCheck('ollama');
+
+    expect(removed).toBe(1);
+    const remaining = HealthStore.getChecks().map(c => c.target);
+    expect(remaining).toEqual(['vaultwarden']);
+  });
+
+  it('matches the legacy "Service: <name>" naming even without a service target', () => {
+    HealthStore.saveCheck({
+      ...serviceCheck('hermes'),
+      type: 'http',
+      target: 'http://localhost:81',
+      name: 'Service: hermes',
+    });
+
+    const removed = HealthStore.deleteServiceCheck('hermes');
+
+    expect(removed).toBe(1);
+    expect(HealthStore.getChecks()).toHaveLength(0);
+  });
+
+  it('does not touch unrelated checks and returns 0 when nothing matches', () => {
+    HealthStore.saveCheck(serviceCheck('immich'));
+    const pingCheck: CheckConfig = {
+      id: 'gw', name: 'Internet Gateway', type: 'ping', target: '192.168.178.1',
+      interval: 60, enabled: true, created_at: new Date().toISOString(),
+    };
+    HealthStore.saveCheck(pingCheck);
+
+    const removed = HealthStore.deleteServiceCheck('not-installed');
+
+    expect(removed).toBe(0);
+    expect(HealthStore.getChecks().map(c => c.target).sort()).toEqual(['192.168.178.1', 'immich']);
+  });
+});

--- a/packages/backend/src/lib/health/store.ts
+++ b/packages/backend/src/lib/health/store.ts
@@ -60,6 +60,30 @@ export class HealthStore {
     fs.writeFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
   }
 
+  /**
+   * Remove the auto-created per-service health check(s) for a service that
+   * is being uninstalled. Matches the shape `addServiceChecks` /
+   * `deployStack` create: `type:'service'` with `target === serviceName`,
+   * or the legacy `name === 'Service: <serviceName>'` row. Returns the
+   * number of checks removed.
+   *
+   * Per-service checks are gated on actual deployment (#1506): a stack is
+   * the only thing that creates its check (on deploy) and uninstall is the
+   * only thing that removes it. An un-installed service must show no check,
+   * never a red "failing" one.
+   */
+  static deleteServiceCheck(serviceName: string): number {
+    ensureDirs();
+    const all = this.getChecks();
+    const remaining = all.filter(c =>
+      !((c.type === 'service' && c.target === serviceName) ||
+        c.name === `Service: ${serviceName}`));
+    if (remaining.length !== all.length) {
+      fs.writeFileSync(CHECKS_FILE, JSON.stringify(remaining, null, 2));
+    }
+    return all.length - remaining.length;
+  }
+
   static saveResult(result: CheckResult) {
     ensureDirs();
     const resultFile = path.join(RESULTS_DIR, `${result.check_id}.json`);

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -1273,6 +1273,17 @@ export class ServiceLifecycle {
         await ServiceLifecycle.refreshAgent(nodeName);
         ServiceLifecycle.backupQuadlets(nodeName);
 
+        // Drop the per-service health check (#1506). The check is created
+        // on deploy and must be removed on uninstall — otherwise an
+        // un-installed service lingers as a red "failing" row forever.
+        try {
+            const { HealthStore } = await import('../health/store');
+            const removed = HealthStore.deleteServiceCheck(serviceName);
+            if (removed > 0) logger.info('ServiceManager', `Removed ${removed} health check(s) for uninstalled ${serviceName}`);
+        } catch (e) {
+            logger.warn('ServiceManager', `Failed to remove health check for ${serviceName}:`, e);
+        }
+
         logger.info('ServiceManager', `Soft-deleted ${serviceName} on ${nodeName} → ${trashDir}`);
     }
 

--- a/packages/frontend/src/components/OfflineBanner.test.tsx
+++ b/packages/frontend/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import OfflineBanner from './OfflineBanner';
+import { ToastProvider } from '../providers/ToastProvider';
+
+// Both signals the banner reconciles (#1504): the realtime socket state
+// and whether an install poll is currently succeeding.
+let connected = true;
+let installActive = false;
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => ({ socket: null, isConnected: connected }),
+}));
+vi.mock('@/hooks/useInstallMonitor', () => ({
+  useInstallMonitor: () => ({
+    state: installActive ? { jobId: 'j1', phase: 'running' } : null,
+    skipCredentials: vi.fn(),
+  }),
+}));
+
+const renderBanner = () => render(<ToastProvider><OfflineBanner /></ToastProvider>);
+
+describe('OfflineBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    connected = true;
+    installActive = false;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stays hidden while connected', () => {
+    connected = true;
+    renderBanner();
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(screen.queryByText(/Not online/i)).toBeNull();
+  });
+
+  it('shows after the grace once disconnected', () => {
+    connected = false;
+    renderBanner();
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(screen.queryByText(/Not online/i)).not.toBeNull();
+  });
+
+  it('suppresses the banner while an install is actively advancing (#1504)', () => {
+    // Socket reports down, but the install poll is succeeding — the box
+    // is reachable, so the "Not online" alarm must not fire.
+    connected = false;
+    installActive = true;
+    renderBanner();
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(screen.queryByText(/Not online/i)).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/OfflineBanner.tsx
+++ b/packages/frontend/src/components/OfflineBanner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useSocket } from '@/hooks/useSocket';
+import { useInstallMonitor } from '@/hooks/useInstallMonitor';
 import { useToast } from '@/providers/ToastProvider';
 
 /**
@@ -13,9 +14,19 @@ import { useToast } from '@/providers/ToastProvider';
  * space on (that was the old PageHeader ConnectionIndicator, now removed). This
  * component also owns the sticky connection-lost / reconnected toasts that the
  * indicator used to fire.
+ *
+ * During the box's own install the realtime socket can drop transiently (the
+ * server restarts / the box reboots mid-install) while the install-progress
+ * poll keeps succeeding — proving the box IS reachable. Flashing "Not online"
+ * over a clearly-advancing install is a false alarm (#1504), so the banner and
+ * its sticky toast are suppressed whenever an install job is active: a
+ * succeeding `/api/install/progress` poll is a positive liveness signal that
+ * outranks a momentarily-down socket.
  */
 export default function OfflineBanner() {
   const { isConnected } = useSocket();
+  const { state: installState } = useInstallMonitor();
+  const installActive = installState !== null;
   const { addToast, removeToast } = useToast();
   const toastIdRef = useRef<string | null>(null);
   // A short grace so the first-mount "connecting" phase doesn't flash the
@@ -30,13 +41,16 @@ export default function OfflineBanner() {
   }, []);
 
   useEffect(() => {
-    if (isConnected) {
+    // A live install poll proves the box is reachable — clear any sticky
+    // "Connection lost" toast and stay quiet even while the socket is
+    // momentarily down (#1504).
+    if (isConnected || installActive) {
       if (toastIdRef.current) {
         removeToast(toastIdRef.current);
         toastIdRef.current = null;
-        addToast('success', 'Reconnected', 'Live updates resumed.', 3000);
+        if (isConnected) addToast('success', 'Reconnected', 'Live updates resumed.', 3000);
       }
-      hasConnectedRef.current = true;
+      if (isConnected) hasConnectedRef.current = true;
       return;
     }
     if (!hasConnectedRef.current) return; // initial connecting phase, not a drop
@@ -47,9 +61,9 @@ export default function OfflineBanner() {
       'Live updates paused. Trying to reconnect…',
       0,
     );
-  }, [isConnected, addToast, removeToast]);
+  }, [isConnected, installActive, addToast, removeToast]);
 
-  const offline = !isConnected && graceOver;
+  const offline = !isConnected && graceOver && !installActive;
   if (!offline) return null;
 
   return (

--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -1218,14 +1218,26 @@ export default function OnboardingWizard() {
               // Stalled-detection (#727): if the runner hasn't touched
               // the job state for STALL_THRESHOLD_MS we treat it as a
               // ghost lock left behind by a crashed session, and offer
-              // resume / start-fresh affordances instead of the
-              // ambiguous force-clear-or-switch-tab copy.
+              // resume / start-fresh affordances.
+              //
+              // We ONLY surface this banner when the job is stalled
+              // (#1503). A *live* install in progress is almost always
+              // the box's own first-boot install, not "another session
+              // racing you" — and the wizard already auto-attaches to any
+              // active job on open (see the status effect above), while
+              // the dashboard renders the live install directly. The old
+              // "Concurrent Pipeline Active / Force-clear lock" copy
+              // false-alarmed on the box's own install and offered a
+              // destructive force-clear over a healthy run, so it's gone:
+              // a non-stalled job shows nothing here and the operator
+              // follows the dashboard's integrated install view.
               const STALL_THRESHOLD_MS = 5 * 60_000;
               const updatedAt = status.installInProgress.updatedAt;
               const inactiveMs = updatedAt
                 ? Date.now() - new Date(updatedAt).getTime()
                 : 0;
               const stalled = inactiveMs >= STALL_THRESHOLD_MS;
+              if (!stalled) return null;
               const inactiveMin = Math.floor(inactiveMs / 60_000);
               return (
                 <div className="mb-10 p-6 rounded-[2rem] border border-amber-500/20 bg-amber-500/5 backdrop-blur-md animate-in slide-in-from-top-4 duration-700">
@@ -1234,47 +1246,42 @@ export default function OnboardingWizard() {
                         <AlertTriangle size={20} />
                     </div>
                     <h4 className="font-bold text-base">
-                      {stalled ? 'Previous install appears stalled' : 'Concurrent Pipeline Active'}
+                      Previous install appears stalled
                     </h4>
                   </div>
                   <p className="text-sm text-amber-200/70 leading-relaxed mb-6">
-                    {stalled
-                      ? `The install runner hasn't written to the job log in ~${inactiveMin} min, which usually means the previous session crashed before the run could finish. You can resume from where it left off, or clear the lock and start fresh.`
-                      : 'Another session is currently driving an installation. Racing two pipelines will corrupt the system state. Switch to the active tab or force-clear if it’s a ghost lock.'}
+                    {`The install runner hasn't written to the job log in ~${inactiveMin} min, which usually means the previous session crashed before the run could finish. You can resume from where it left off, or clear the lock and start fresh.`}
                   </p>
                   <div className="flex flex-wrap items-center gap-2">
-                    {stalled && (
-                      <Button
-                        variant="outline"
-                        className="!py-2 !px-4 !text-xs !border-blue-500/40 hover:!bg-blue-500/10 text-blue-500"
-                        onClick={async () => {
-                          // Resume = attach this tab to the existing
-                          // job. The runner is still the source of
-                          // truth — we just re-subscribe to its log /
-                          // progress stream.
-                          await installFlow.attachToJob(status.installInProgress!.jobId);
-                          // attachToJob hydrates installFlow.phase from
-                          // the server's JobState — phase=running
-                          // drives stackInstallStep='installing' via
-                          // the derived union above.
-                          setCurrentStep('stacks');
-                        }}
-                      >
-                        Resume install
-                      </Button>
-                    )}
+                    <Button
+                      variant="outline"
+                      className="!py-2 !px-4 !text-xs !border-blue-500/40 hover:!bg-blue-500/10 text-blue-500"
+                      onClick={async () => {
+                        // Resume = attach this tab to the existing
+                        // job. The runner is still the source of
+                        // truth — we just re-subscribe to its log /
+                        // progress stream.
+                        await installFlow.attachToJob(status.installInProgress!.jobId);
+                        // attachToJob hydrates installFlow.phase from
+                        // the server's JobState — phase=running
+                        // drives stackInstallStep='installing' via
+                        // the derived union above.
+                        setCurrentStep('stacks');
+                      }}
+                    >
+                      Resume install
+                    </Button>
                     <Button
                       variant="outline"
                       className="!py-2 !px-4 !text-xs !border-amber-500/30 hover:!bg-amber-500/10 text-amber-500"
                       onClick={async () => {
-                        const verb = stalled ? 'Clear the stalled install and start fresh?' : 'Force-clear the install lock?';
-                        if (!confirm(verb)) return;
+                        if (!confirm('Clear the stalled install and start fresh?')) return;
                         await forceClearInstallLock();
                         const fresh = await checkOnboardingStatus();
                         setStatus(fresh);
                       }}
                     >
-                      {stalled ? 'Start fresh' : 'Force-clear lock'}
+                      Start fresh
                     </Button>
                   </div>
                 </div>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,11 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { ChevronLeft, Github, Users, ExternalLink, Sparkles, Home, Wrench, User as UserIcon, LogOut } from 'lucide-react';
+import { ChevronLeft, Github, Users, ExternalLink, Sparkles, Home, User as UserIcon, LogOut } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import DomainTag from './DomainTag';
-import { typedFetch, InstallStatusResponseSchema } from '@servicebay/api-client';
 import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
 
 // Back-compat re-export — MobileNav imports `dashboards` from here.
@@ -22,14 +21,11 @@ export default function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [showCollapsedNodeLabel, setShowCollapsedNodeLabel] = useState(false);
   const [lldapUrl, setLldapUrl] = useState<string | null>(null);
-  // Conditional sidebar entry for /setup. Visible whenever the server
-  // reports an active install job (running / needs_credentials) OR a
-  // recently-finished job that hasn't been acknowledged yet (terminal
-  // phases with stackSetupPending still set). This way "Setup" is a
-  // first-class destination during the 10-minute install window — the
-  // operator can navigate to Services / Terminal / Health and still
-  // come back to watch progress.
-  const [hasActiveInstall, setHasActiveInstall] = useState(false);
+  // The redundant /setup sidebar rider was removed (#1503): setup is now
+  // integrated into the dashboard, which renders the live install
+  // progress directly. The separate rider led operators to the wizard's
+  // "Concurrent Pipeline Active" lock over the box's own install, so it's
+  // gone — the dashboard's integrated install view is the single home.
   // Workspace package.json stays at 0.0.0 (release-please only bumps the
   // root). Read the live version from the API instead. (#812)
   const [appVersion, setAppVersion] = useState<string | null>(null);
@@ -108,35 +104,6 @@ export default function Sidebar() {
       .catch(() => {});
   }, []);
 
-  // Poll the install-job singleton so every connected client picks up
-  // (and drops) the "Setup" entry within 5 s — the operator on a
-  // second tab/phone should see the same affordance as the operator
-  // who clicked Install. Short interval is fine: payload is tiny and
-  // it pauses naturally when there's no active job.
-  //
-  // Visibility rule: show the pill whenever EITHER (a) an install job
-  // is currently running, OR (b) the operator hasn't acknowledged a
-  // terminal install yet (`stackSetupPending: true`). The second case
-  // is what gives the operator a path back to /setup after they
-  // minimised the wizard but never clicked "Finish".
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      try {
-        const data = await typedFetch(
-          '/api/install/status',
-          InstallStatusResponseSchema,
-          { cache: 'no-store' },
-        );
-        if (cancelled) return;
-        setHasActiveInstall(data.jobIsActive);
-      } catch { /* offline / mid-redeploy / schema drift — keep the previous value */ }
-    };
-    void tick();
-    const handle = setInterval(tick, 5000);
-    return () => { cancelled = true; clearInterval(handle); };
-  }, []);
-
   return (
     <div className={`${isCollapsed ? 'w-16' : 'w-64'} flex flex-col sidebar-transition h-full shrink-0`}>
         <div className="h-16 flex items-center justify-between px-4">
@@ -184,33 +151,6 @@ export default function Sidebar() {
             </button>
         )}
         <div className="overflow-y-auto flex-1 p-2 space-y-1">
-            {/* Setup entry (#696). Only visible when there's an active install OR we are looking at the setup page. */}
-            {(hasActiveInstall || (pathname?.startsWith('/setup') ?? false)) && (() => {
-                const isActive = pathname?.startsWith('/setup') ?? false;
-                const baseClass = `w-full text-left px-3.5 py-3 rounded-xl flex items-center transition-all border ${isCollapsed ? 'justify-center' : 'gap-3.5'} `;
-                const tone = isActive
-                    ? 'bg-blue-50 dark:bg-blue-600/10 border-blue-100 dark:border-blue-500/20 text-blue-600 dark:text-blue-400 font-bold shadow-sm shadow-blue-500/5'
-                    : 'border-blue-100/50 dark:border-blue-500/10 bg-blue-50/50 dark:bg-blue-900/20 hover:bg-blue-100/60 dark:hover:bg-blue-900/40 text-blue-700 dark:text-blue-300';
-                const iconColor = isActive
-                    ? 'text-blue-500 dark:text-blue-400'
-                    : 'text-blue-600 dark:text-blue-400';
-                return (
-                    <button
-                        type="button"
-                        onClick={() => router.push('/setup')}
-                        className={baseClass + tone}
-                        title={isCollapsed ? (hasActiveInstall ? 'Setup in progress' : 'Setup') : ''}
-                    >
-                        <div className="relative shrink-0">
-                            <Wrench size={20} className={`shrink-0 ${iconColor}`} />
-                            {hasActiveInstall && (
-                                <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-                            )}
-                        </div>
-                        {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">Setup</span>}
-                    </button>
-                );
-            })()}
             {dashboards.map(p => {
                 const Icon = p.icon;
                 const isActive = isNavActive(pathname, p.path);

--- a/packages/frontend/src/hooks/useSocket.ts
+++ b/packages/frontend/src/hooks/useSocket.ts
@@ -11,12 +11,21 @@ let socket: Socket;
  *  401 handler in DigitalTwinProvider. */
 const ANONYMOUS_PATHS = new Set(['/login', '/portal']);
 
+/** How long we wait for the *initial* connect to report `connected`
+ *  before forcing a fresh reconnect attempt (#1509). The dashboard's
+ *  hydration gate sits on "Connecting to ServiceBay" until `isConnected`
+ *  flips; a single stalled first connect (stale socket from a prior
+ *  navigation, a connect that never completed the handshake) left it
+ *  hung for 30s+ with only a hard reload as recovery. A bounded kick
+ *  turns that into a few-second self-recovery. */
+const INITIAL_CONNECT_RETRY_MS = 3000;
+
 export const useSocket = () => {
   const [isConnected, setIsConnected] = useState(false);
 
   useEffect(() => {
     if (!socket) {
-        socket = io({ path: '/socket.io' }); 
+        socket = io({ path: '/socket.io' });
     }
 
     function onConnect() {
@@ -63,9 +72,32 @@ export const useSocket = () => {
 
     if (socket.connected) {
         onConnect();
+    } else {
+        // The singleton socket persists across client-side navigations.
+        // If a prior mount left it disconnected (a connect that never
+        // completed, or an explicit disconnect), nothing re-initiates it
+        // on a fresh mount — the gate then hangs on the socket phase
+        // until a hard reload recreates the page. Kick the connect
+        // explicitly; `socket.connect()` is a no-op when already
+        // connecting/connected (#1509).
+        socket.connect();
     }
 
+    // Bounded retry on the *initial* connect: if the handshake hasn't
+    // reported `connected` within the window, force one fresh reconnect
+    // cycle. Socket.IO's own backoff handles repeated transport errors,
+    // but a connect that silently stalls before `connect`/`connect_error`
+    // fires isn't covered by that — this is the missing self-recovery the
+    // hydration gate needs (#1509).
+    const retryTimer = setTimeout(() => {
+      if (!socket.connected) {
+        socket.disconnect();
+        socket.connect();
+      }
+    }, INITIAL_CONNECT_RETRY_MS);
+
     return () => {
+      clearTimeout(retryTimer);
       socket.off('connect', onConnect);
       socket.off('disconnect', onDisconnect);
       socket.off('connect_error', onConnectError);

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -72,6 +72,45 @@ def log(msg: str) -> None:
     sys.stdout.flush()
 
 
+# ── Z-Wave device re-detection (#1511) ─────────────────────────────────────────
+#
+# ZWAVE_DEVICE (the USB stick's /dev/tty* path) lives in ServiceBay's config,
+# which a `wipe-configs` reinstall wipes — while the kept zwave-js node DB +
+# network keys in <DATA_DIR>/home-assistant/zwave-js are stranded because the
+# fresh install never re-collected the device path. When ZWAVE_DEVICE is unset
+# we mirror the installer's "auto-pick when there's exactly one USB-serial
+# device" rule (src/app/api/system/devices/route.ts) right here on the box, so
+# the udev rule + zwave-js wiring re-establish themselves with no operator step.
+
+ZWAVE_BY_ID_DIR = "/dev/serial/by-id"
+
+
+def _detect_single_usb_serial_device() -> str | None:
+    """Resolve the canonical /dev/tty* path of the sole USB-serial stick on
+    the host, or None when there are zero or more than one. Mirrors the
+    installer endpoint: read /dev/serial/by-id symlinks, resolve to their
+    /dev/tty* targets, dedupe (a multi-radio stick has several by-id
+    symlinks pointing at one tty), and only auto-pick when exactly one
+    distinct device remains — guessing between two sticks would be worse
+    than leaving it unset."""
+    try:
+        entries = os.listdir(ZWAVE_BY_ID_DIR)
+    except OSError:
+        return None
+    resolved: set[str] = set()
+    for name in entries:
+        link = os.path.join(ZWAVE_BY_ID_DIR, name)
+        try:
+            target = os.path.realpath(link)
+        except OSError:
+            continue
+        if os.path.exists(target):
+            resolved.add(target)
+    if len(resolved) == 1:
+        return next(iter(resolved))
+    return None
+
+
 # ── udev ──────────────────────────────────────────────────────────────────────
 
 def _device_kernel_pattern(device_path: str) -> str:
@@ -377,6 +416,115 @@ def _mint_long_lived_token(access_token: str) -> str | None:
     return token or None
 
 
+def _token_authenticates(token: str) -> bool:
+    """True iff `token` is accepted by HA's authenticated API. After a
+    wipe-configs reinstall the persisted token file may survive in HA's
+    kept config dir but the matching refresh-token row in HA's auth store
+    could be gone (or the file is stale from an earlier HA instance) — a
+    401 there is exactly the #1505 symptom. We probe /api/ (the lightest
+    authenticated endpoint) and treat 401/403 as 'must re-mint'."""
+    if not token:
+        return False
+    try:
+        req = urllib.request.Request(
+            f"{HA_API}/api/",
+            headers={"Authorization": f"Bearer {token}"},
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except urllib.error.HTTPError as e:
+        return e.code == 200
+    except (urllib.error.URLError, TimeoutError, OSError):
+        # Network blip ≠ bad token; don't churn the token on a transient.
+        # Returning True keeps an existing token in place; the health check
+        # will catch a genuinely-dead one on its own schedule.
+        return True
+
+
+def _login_existing_admin(username: str, password: str) -> str | None:
+    """Authenticate an already-existing HA admin via the login_flow API and
+    exchange the result for an access token. Used to re-mint a long-lived
+    token after a wipe-configs reinstall, where HA's user already exists
+    (so onboarding/users would 409) but ServiceBay lost the token. Returns
+    the short-lived access_token, or None on failure."""
+    start = json.dumps({
+        "client_id": HA_CLIENT_ID,
+        "handler": ["homeassistant", None],
+        "redirect_uri": HA_CLIENT_ID,
+    }).encode("utf-8")
+    try:
+        req = urllib.request.Request(
+            f"{HA_API}/auth/login_flow",
+            data=start,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            flow_id = json.loads(resp.read()).get("flow_id")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        log(f"   ⚠️ HA /auth/login_flow start failed: {e}")
+        return None
+    if not flow_id:
+        log("   ⚠️ HA /auth/login_flow returned no flow_id")
+        return None
+
+    step = json.dumps({
+        "client_id": HA_CLIENT_ID,
+        "username": username,
+        "password": password,
+    }).encode("utf-8")
+    try:
+        req = urllib.request.Request(
+            f"{HA_API}/auth/login_flow/{urllib.parse.quote(flow_id)}",
+            data=step,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            result = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        log(f"   ⚠️ HA /auth/login_flow step failed: {e}")
+        return None
+    auth_code = result.get("result")
+    if result.get("type") != "create_entry" or not auth_code:
+        log("   ⚠️ HA login_flow did not yield an auth code "
+            "(wrong OSCAR_HA_ADMIN_PASSWORD, or the admin user differs?).")
+        return None
+
+    form = urllib.parse.urlencode({
+        "client_id": HA_CLIENT_ID,
+        "grant_type": "authorization_code",
+        "code": auth_code,
+    }).encode("utf-8")
+    try:
+        req = urllib.request.Request(
+            f"{HA_API}/auth/token",
+            data=form,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read()).get("access_token")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        log(f"   ⚠️ HA /auth/token exchange (login) failed: {e}")
+        return None
+
+
+def _mint_and_persist_from_access_token(access_token: str, username: str) -> bool:
+    """Mint a fresh long-lived token from a short-lived access token and
+    persist it. Shared tail of both the fresh-onboarding and the
+    re-mint-after-wipe paths. Returns True on success."""
+    long_lived = _mint_long_lived_token(access_token)
+    if not long_lived:
+        return False
+    path = _persist_long_lived_token(long_lived)
+    if path:
+        log(f"✅ HA long-lived token (re)provisioned for '{username}' at {path}.")
+        return True
+    return False
+
+
 def _persist_long_lived_token(token: str) -> str | None:
     """Write the long-lived token under HA's config dir so downstream
     post-deploys (hermes, oscar-household) can pick it up via a fixed
@@ -392,6 +540,38 @@ def _persist_long_lived_token(token: str) -> str | None:
     return target
 
 
+def report_kept_data_state() -> None:
+    """Distinguish the two #1512 cases out loud so the post-deploy log says
+    which one happened, instead of leaving the operator guessing why HA
+    looks bare after a wipe-configs reinstall:
+
+      (1) kept-data present → integration reconciliation (token + Z-Wave,
+          handled below) re-establishes wiring against the existing data.
+      (2) no kept data → a genuinely fresh first install; nothing to
+          reconcile (and, on a reinstall, a data-keep regression worth a
+          loud warning since service data should never be lost).
+
+    Read-only; never aborts the deploy."""
+    config_dir = _ha_config_dir()
+    # HA writes .storage/ + configuration.yaml as soon as it has ever run.
+    ha_has_data = os.path.isfile(os.path.join(config_dir, "configuration.yaml")) or os.path.isdir(
+        os.path.join(config_dir, ".storage")
+    )
+    zwave_dir = _zwave_store_dir()
+    # zwave-js-ui persists its node DB + network keys under store/; the
+    # presence of settings.json (or any .jsonl node cache) means a mesh
+    # was previously built and its keys are kept.
+    zwave_has_data = os.path.isdir(zwave_dir) and any(
+        os.path.exists(os.path.join(zwave_dir, f)) for f in ("settings.json", "nodes.json")
+    )
+    if ha_has_data:
+        log(f"Home Assistant kept-data found at {config_dir} — reconciling integrations against it (#1512).")
+        if zwave_has_data:
+            log(f"   Z-Wave node DB / keys kept at {zwave_dir} — re-wiring against the existing mesh.")
+    else:
+        log(f"No existing Home Assistant data at {config_dir} — treating as a fresh first install.")
+
+
 def configure_oscar_ha_onboarding() -> None:
     """When OSCAR_HA_ADMIN_USERNAME and OSCAR_HA_ADMIN_PASSWORD are set,
     walk HA's onboarding API on a fresh install and mint a long-lived
@@ -405,28 +585,48 @@ def configure_oscar_ha_onboarding() -> None:
         log("OSCAR_HA_ADMIN_USERNAME / _PASSWORD not set — skipping auto-onboarding.")
         return
     token_file = os.path.join(_ha_config_dir(), HA_LONG_LIVED_TOKEN_PATH.lstrip("/"))
+
+    # Reconcile an existing token first (#1505). A wipe-configs reinstall can
+    # leave a token file behind in HA's kept config dir whose refresh-token
+    # row no longer exists in HA's auth store → a 401 on every authenticated
+    # call. Validate it; only short-circuit when it actually authenticates.
     if os.path.exists(token_file):
-        log(f"✅ HA long-lived token already persisted at {token_file} — skipping onboarding.")
-        return
-    log("Auto-onboarding HA admin user for OSCAR (no operator browser step required)...")
+        try:
+            with open(token_file, encoding="utf-8") as f:
+                existing = f.read().strip()
+        except OSError:
+            existing = ""
+        if _token_authenticates(existing):
+            log(f"✅ HA long-lived token at {token_file} still authenticates — nothing to reconcile.")
+            return
+        log("   Persisted HA long-lived token no longer authenticates (wipe-configs reinstall) — re-provisioning.")
+
     state = _onboarding_state()
     if state is None:
         log("   ⚠️ Could not reach HA /api/onboarding — skipping auto-onboarding.")
         return
+
     if state.get("user") is True:
-        log("   HA user-onboarding step already done — won't create a second admin. "
-            "Operator can mint a long-lived token via the HA UI or set OSCAR_HA_ADMIN_USERNAME='' to silence this.")
+        # HA's data was kept (user already onboarded) but ServiceBay lost the
+        # token. Re-mint by logging in as the existing admin instead of
+        # creating a second user — the LLDAP-FORCE_RESET-style self-heal for
+        # the HA token (#1505). Onboarding steps are already done; skip them.
+        log("Re-provisioning HA long-lived token from kept data (existing admin, no new user)...")
+        access_token = _login_existing_admin(username, password)
+        if not access_token:
+            log("   HA admin already exists but auto-login failed — mint a long-lived token via the "
+                "HA UI (Settings → Security → Long-lived access tokens) or set OSCAR_HA_ADMIN_USERNAME='' to silence this.")
+            return
+        _mint_and_persist_from_access_token(access_token, username)
         return
+
+    log("Auto-onboarding HA admin user for OSCAR (no operator browser step required)...")
     access_token = _onboard_admin_user(username, password)
     if not access_token:
         return
     _complete_remaining_onboarding_steps(access_token)
-    long_lived = _mint_long_lived_token(access_token)
-    if not long_lived:
-        return
-    path = _persist_long_lived_token(long_lived)
-    if path:
-        log(f"✅ HA admin '{username}' created + long-lived token persisted at {path}.")
+    if _mint_and_persist_from_access_token(access_token, username):
+        log(f"✅ HA admin '{username}' created + long-lived token persisted.")
 
 
 def _strip_first_component(member_path: str) -> str | None:
@@ -613,12 +813,21 @@ def configure_auth_oidc() -> None:
 def main() -> int:
     zwave_device = env("ZWAVE_DEVICE")
 
+    if not zwave_device:
+        # ZWAVE_DEVICE is lost on a wipe-configs reinstall (#1511). Re-detect
+        # the stick on the box so the kept node DB + keys re-attach without an
+        # operator browser step. Only auto-picks an unambiguous single stick.
+        detected = _detect_single_usb_serial_device()
+        if detected:
+            zwave_device = detected
+            log(f"ZWAVE_DEVICE unset but a single USB-serial stick is present — re-detected {detected}.")
+
     if zwave_device:
         log(f"Z-Wave stick configured ({zwave_device}) — ensuring host udev permissions...")
         ensure_udev_rule(zwave_device)
         log("✅ Z-Wave JS will have device access after each system boot.")
     else:
-        log("No ZWAVE_DEVICE set — skipping udev rule.")
+        log("No ZWAVE_DEVICE set and no single USB-serial stick detected — skipping udev rule.")
 
     log(f"Seeding Z-Wave JS WS server config (port {ZWAVEJS_WS_PORT})...")
     if ensure_zwave_external_settings():
@@ -627,9 +836,11 @@ def main() -> int:
 
     configure_auth_oidc()
 
-    # OSCAR auto-onboarding: only fires when OSCAR_HA_ADMIN_USERNAME +
-    # OSCAR_HA_ADMIN_PASSWORD are both set and HA isn't onboarded yet.
-    # No-op for operators using HA's first-boot UI wizard manually.
+    # wipe-configs reconciliation: HA's data is kept but the config that
+    # wired it (token, ZWAVE_DEVICE, integrations) lives in ServiceBay's
+    # wiped config. Report which case we're in (#1512), then re-provision
+    # the HA long-lived token from the kept data (#1505).
+    report_kept_data_state()
     if _wait_ha_ready():
         configure_oscar_ha_onboarding()
     else:

--- a/tests/frontend/useSocket.test.tsx
+++ b/tests/frontend/useSocket.test.tsx
@@ -8,6 +8,8 @@ const fakeSocket = {
   connected: false,
   on: vi.fn((event: string, cb: (arg?: any) => void) => { handlers[event] = cb; }),
   off: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
 };
 vi.mock('socket.io-client', () => ({
   default: vi.fn(() => fakeSocket),
@@ -18,6 +20,9 @@ import { useSocket } from '@/hooks/useSocket';
 describe('useSocket — connect_error handling', () => {
   beforeEach(() => {
     for (const k of Object.keys(handlers)) delete handlers[k];
+    fakeSocket.connected = false;
+    fakeSocket.connect.mockClear();
+    fakeSocket.disconnect.mockClear();
   });
 
   it('redirects to /login on an unauthorized rejection, ignores transient errors', () => {
@@ -63,6 +68,29 @@ describe('useSocket — connect_error handling', () => {
       Object.defineProperty(window, 'location', {
         value: originalLocation, writable: true, configurable: true,
       });
+    }
+  });
+
+  it('kicks the connect on mount when the persisted socket is disconnected (#1509)', () => {
+    fakeSocket.connected = false;
+    renderHook(() => useSocket());
+    // The singleton can persist across navigations disconnected; the hook
+    // must re-initiate the connect rather than hang the hydration gate.
+    expect(fakeSocket.connect).toHaveBeenCalled();
+  });
+
+  it('forces a fresh reconnect if the initial connect stalls (#1509)', () => {
+    vi.useFakeTimers();
+    try {
+      fakeSocket.connected = false;
+      renderHook(() => useSocket());
+      fakeSocket.connect.mockClear();
+      // Still not connected after the bounded window → recycle the socket.
+      vi.advanceTimersByTime(3000);
+      expect(fakeSocket.disconnect).toHaveBeenCalled();
+      expect(fakeSocket.connect).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
     }
   });
 });

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -698,6 +698,219 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertIn("already installed", out)
             self.assertIn("/auth/oidc/welcome answered", out)
 
+    def test_zwave_device_redetected_when_unset(self):
+        """#1511: a wipe-configs reinstall loses ZWAVE_DEVICE. When it's
+        unset but exactly one USB-serial stick is on the box, the script
+        re-detects it and writes the udev rule against the resolved path —
+        no operator step."""
+        m = load_script("home-assistant")
+        import urllib.error
+        import urllib.request
+
+        # Exactly one resolved device → auto-pick fires.
+        with mock.patch.object(m, "_detect_single_usb_serial_device", lambda: "/dev/ttyACM0"):
+            captured = {}
+
+            def fake_ensure(dev):
+                captured["dev"] = dev
+
+            env = {"HA_OIDC_AUTH_VERSION": "v0.6.0"}
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen",
+                                      lambda *_a, **_kw: (_ for _ in ()).throw(urllib.error.URLError("nope"))), \
+                    mock.patch.object(m, "ensure_udev_rule", fake_ensure), \
+                    mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured.get("dev"), "/dev/ttyACM0")
+        self.assertIn("re-detected /dev/ttyACM0", out)
+
+    def test_zwave_device_not_redetected_when_ambiguous(self):
+        """Two sticks → don't guess; skip the udev rule. (Mirrors the
+        installer's 'auto-pick only when exactly one' rule.)"""
+        m = load_script("home-assistant")
+        import urllib.error
+        import urllib.request
+
+        with mock.patch.object(m, "_detect_single_usb_serial_device", lambda: None):
+            env = {"HA_OIDC_AUTH_VERSION": "v0.6.0"}
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen",
+                                      lambda *_a, **_kw: (_ for _ in ()).throw(urllib.error.URLError("nope"))), \
+                    mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+        self.assertEqual(rc, 0)
+        self.assertIn("no single USB-serial stick detected", out)
+
+    def test_detect_single_usb_serial_resolves_and_dedupes(self):
+        """A multi-radio stick has several by-id symlinks pointing at one
+        tty — the resolver must collapse them to a single device and pick
+        it; two distinct ttys must yield None."""
+        import tempfile
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tty = os.path.join(tmp, "ttyACM0")
+            open(tty, "w").close()
+            by_id = os.path.join(tmp, "by-id")
+            os.makedirs(by_id)
+            os.symlink(tty, os.path.join(by_id, "usb-Foo-if00"))
+            os.symlink(tty, os.path.join(by_id, "usb-Foo-if01"))
+            with mock.patch.object(m, "ZWAVE_BY_ID_DIR", by_id):
+                self.assertEqual(m._detect_single_usb_serial_device(), os.path.realpath(tty))
+
+            # Add a second distinct device → ambiguous → None.
+            tty2 = os.path.join(tmp, "ttyUSB0")
+            open(tty2, "w").close()
+            os.symlink(tty2, os.path.join(by_id, "usb-Bar-if00"))
+            with mock.patch.object(m, "ZWAVE_BY_ID_DIR", by_id):
+                self.assertIsNone(m._detect_single_usb_serial_device())
+
+    def test_token_remint_via_login_when_user_already_onboarded(self):
+        """#1505: after a wipe-configs reinstall HA's user already exists
+        but ServiceBay lost the long-lived token. The script must log in as
+        the existing admin (no second user) and mint + persist a fresh
+        token."""
+        import tempfile
+        import urllib.request
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            def fake_urlopen(req, *_a, **_kw):
+                url = req.full_url if hasattr(req, "full_url") else str(req)
+                if "github.com" in url:
+                    raise AssertionError(f"unexpected download: {url}")
+
+                class _R:
+                    def __init__(self, status, body):
+                        self.status = status
+                        self._b = json.dumps(body).encode("utf-8") if body is not None else b"<html></html>"
+                    def read(self):
+                        return self._b
+                    def __enter__(self):
+                        return self
+                    def __exit__(self, *a):
+                        return False
+
+                if "/api/onboarding" in url:
+                    return _R(200, [{"step": "user", "done": True}])
+                if "/auth/login_flow/" in url:
+                    return _R(200, {"type": "create_entry", "result": "auth-code-xyz"})
+                if "/auth/login_flow" in url:
+                    return _R(200, {"flow_id": "flow-123"})
+                if "/auth/token" in url:
+                    return _R(200, {"access_token": "short-lived-tok"})
+                if "/auth/oidc/welcome" in url or url.rstrip("/").endswith("8123"):
+                    return _R(200, None)
+                # HA-readiness probe (GET /) + everything else → 200 html.
+                return _R(200, None)
+
+            minted = {}
+
+            def fake_mint(access_token):
+                minted["access"] = access_token
+                return "long-lived-tok"
+
+            env = {
+                "HA_OIDC_AUTH_VERSION": "v0.6.0",
+                "DATA_DIR": tmp,
+                "OSCAR_HA_ADMIN_USERNAME": "oscar",
+                "OSCAR_HA_ADMIN_PASSWORD": "pw",
+            }
+            # Pre-create the config dir + auth_oidc stamp so the OIDC install
+            # path short-circuits (no tarball download in the test).
+            ha_cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            oidc = os.path.join(ha_cfg, "custom_components", "auth_oidc")
+            os.makedirs(oidc, exist_ok=True)
+            with open(os.path.join(oidc, ".sb_installed_version"), "w") as fh:
+                fh.write("v0.6.0\n")
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen", fake_urlopen), \
+                    mock.patch.object(m, "_mint_long_lived_token", fake_mint), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("Re-provisioning HA long-lived token from kept data", out)
+            self.assertEqual(minted.get("access"), "short-lived-tok")
+            token_file = os.path.join(tmp, "home-assistant", "homeassistant", ".oscar-long-lived-token")
+            self.assertTrue(os.path.isfile(token_file))
+            with open(token_file) as fh:
+                self.assertEqual(fh.read().strip(), "long-lived-tok")
+
+    def test_valid_existing_token_short_circuits_remint(self):
+        """If the persisted token still authenticates, the reconcile is a
+        no-op — no login_flow, no re-mint."""
+        import tempfile
+        import urllib.request
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            os.makedirs(cfg, exist_ok=True)
+            with open(os.path.join(cfg, ".oscar-long-lived-token"), "w") as fh:
+                fh.write("good-token\n")
+            # Stamp so the OIDC install path skips the tarball download.
+            oidc = os.path.join(cfg, "custom_components", "auth_oidc")
+            os.makedirs(oidc, exist_ok=True)
+            with open(os.path.join(oidc, ".sb_installed_version"), "w") as fh:
+                fh.write("v0.6.0\n")
+
+            def fake_urlopen(req, *_a, **_kw):
+                url = req.full_url if hasattr(req, "full_url") else str(req)
+                if "/auth/login_flow" in url:
+                    raise AssertionError("must not start a login flow when the token is valid")
+
+                class _R:
+                    status = 200
+                    def read(self):
+                        return b"<html></html>"
+                    def __enter__(self):
+                        return self
+                    def __exit__(self, *a):
+                        return False
+                return _R()
+
+            env = {
+                "HA_OIDC_AUTH_VERSION": "v0.6.0",
+                "DATA_DIR": tmp,
+                "OSCAR_HA_ADMIN_USERNAME": "oscar",
+                "OSCAR_HA_ADMIN_PASSWORD": "pw",
+            }
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen", fake_urlopen), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("still authenticates — nothing to reconcile", out)
+
+    def test_kept_data_state_reported(self):
+        """#1512: the script states whether HA kept-data was found, so the
+        operator isn't left guessing why HA looks bare."""
+        import tempfile
+        import urllib.error
+        import urllib.request
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            os.makedirs(os.path.join(cfg, ".storage"), exist_ok=True)
+            zwave = os.path.join(tmp, "home-assistant", "zwave-js")
+            os.makedirs(zwave, exist_ok=True)
+            open(os.path.join(zwave, "settings.json"), "w").close()
+
+            env = {"HA_OIDC_AUTH_VERSION": "v0.6.0", "DATA_DIR": tmp}
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen",
+                                      lambda *_a, **_kw: (_ for _ in ()).throw(urllib.error.URLError("nope"))), \
+                    mock.patch.object(m, "HA_READY_TIMEOUT", 0.01), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("kept-data found", out)
+            self.assertIn("re-wiring against the existing mesh", out)
+
 
 class ClaudeDevScript(unittest.TestCase):
     def test_emits_ssh_credential_when_password_set(self):

--- a/tools/sb-tui/internal/probes/probes.go
+++ b/tools/sb-tui/internal/probes/probes.go
@@ -97,6 +97,17 @@ func SaveToken(host, token string) error {
 	return os.WriteFile(p, []byte(strings.TrimSpace(token)+"\n"), 0o600)
 }
 
+// DeleteToken removes the persisted per-host token. Called when the box rejects
+// the saved token (401) — after a reinstall the file holds a stale credential,
+// so dropping it lets the next launch fall through to the in-TUI sign-in instead
+// of dead-ending. A missing file is not an error (already clear).
+func DeleteToken(host string) error {
+	if err := os.Remove(tokenPath(host)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 // tokenPath is ~/.config/servicebay/<host>.token (honoring XDG_CONFIG_HOME).
 func tokenPath(host string) string {
 	dir := os.Getenv("XDG_CONFIG_HOME")

--- a/tools/sb-tui/internal/probes/probes_test.go
+++ b/tools/sb-tui/internal/probes/probes_test.go
@@ -1,0 +1,46 @@
+package probes
+
+import "testing"
+
+// TestTokenRoundTripAndDelete: SaveToken persists a per-host token that
+// ResolveToken reads back, and DeleteToken removes it so ResolveToken then
+// returns "" (the no-token path that re-triggers sign-in). #1502.
+func TestTokenRoundTripAndDelete(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("SB_TOKEN", "") // env must not shadow the per-host file
+
+	const host = "192.168.178.100"
+	if err := SaveToken(host, "sb_minted"); err != nil {
+		t.Fatalf("SaveToken: %v", err)
+	}
+	if got := ResolveToken(host); got != "sb_minted" {
+		t.Fatalf("ResolveToken after save = %q, want sb_minted", got)
+	}
+	if err := DeleteToken(host); err != nil {
+		t.Fatalf("DeleteToken: %v", err)
+	}
+	if got := ResolveToken(host); got != "" {
+		t.Fatalf("ResolveToken after delete = %q, want empty", got)
+	}
+}
+
+// TestDeleteTokenMissingIsNoError: deleting an absent token file is a no-op, not
+// an error — re-auth shouldn't fail just because nothing was saved.
+func TestDeleteTokenMissingIsNoError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := DeleteToken("never-saved"); err != nil {
+		t.Fatalf("DeleteToken on missing file: %v", err)
+	}
+}
+
+// TestSBTokenEnvWinsOverFile: SB_TOKEN takes precedence over the persisted file
+// (CI / power users) — and is unaffected by DeleteToken, which only touches the
+// file.
+func TestSBTokenEnvWinsOverFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("SB_TOKEN", "sb_env")
+	if got := ResolveToken("box"); got != "sb_env" {
+		t.Fatalf("ResolveToken = %q, want sb_env", got)
+	}
+}

--- a/tools/sb-tui/internal/ui/app.go
+++ b/tools/sb-tui/internal/ui/app.go
@@ -29,6 +29,13 @@ type (
 	}
 	// backMsg is emitted by a sub-view to pop back to the menu.
 	backMsg struct{}
+	// reauthRequiredMsg is emitted by a box-control panel when the box rejects
+	// its token (rest.ErrUnauthorized). The App drops the stale credential and
+	// re-opens sign-in for the panel that failed, instead of letting the panel
+	// dead-end on a terminal "token rejected" message. This is the same
+	// destination as the no-token path; the difference is the persisted token is
+	// stale (e.g. after a reinstall) rather than absent.
+	reauthRequiredMsg struct{}
 )
 
 // backCmd emits backMsg. A sub-view uses it on esc/q: when hosted by the App it
@@ -36,9 +43,17 @@ type (
 // view's own Update catches backMsg and quits, so the same key works in both.
 func backCmd() tea.Cmd { return func() tea.Msg { return backMsg{} } }
 
+// reauthCmd emits reauthRequiredMsg. A box-control panel returns it (instead of
+// surfacing a terminal error) when the box answers rest.ErrUnauthorized.
+func reauthCmd() tea.Cmd { return func() tea.Msg { return reauthRequiredMsg{} } }
+
 // TokenSaver persists a freshly-minted token so future launches skip login.
 // Injected so the App is testable without touching the filesystem.
 type TokenSaver func(host, token string) error
+
+// TokenDeleter removes the persisted per-host token when the box rejects it, so
+// a re-auth replaces the stale file. Injected for the same testability reason.
+type TokenDeleter func(host string) error
 
 type appScreen int
 
@@ -53,6 +68,7 @@ type App struct {
 	host, port    string
 	token         string // current credential, "" until logged in
 	save          TokenSaver
+	del           TokenDeleter
 	build         BuildConfig
 	width, height int
 
@@ -70,8 +86,8 @@ type App struct {
 
 // NewApp builds the root model. token may be a pre-resolved credential (env or
 // the saved per-host file); empty means the box-control views will log in first.
-func NewApp(detect DetectFunc, host, port, token string, save TokenSaver, build BuildConfig) App {
-	return App{host: host, port: port, token: token, save: save, build: build, screen: appMenu, menu: New(detect, host, port, token)}
+func NewApp(detect DetectFunc, host, port, token string, save TokenSaver, del TokenDeleter, build BuildConfig) App {
+	return App{host: host, port: port, token: token, save: save, del: del, build: build, screen: appMenu, menu: New(detect, host, port, token)}
 }
 
 // Init starts the menu's phase detection.
@@ -114,6 +130,20 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.active = NewWatchReinstall(msg.host, msg.port, m.token)
 		m.screen = appPanel
 		return m, tea.Batch(m.active.Init(), sizeCmd(m.width, m.height))
+
+	case reauthRequiredMsg:
+		// The open panel's call came back 401: the saved token is stale (typically
+		// after a reinstall). Drop it (in-memory + the persisted per-host file) and
+		// re-open sign-in for the same panel — the no-token path, just reached from
+		// a rejected token instead of an absent one. m.pending already names the
+		// panel (openPanel set it), so authSucceededMsg resumes into it.
+		m.token = ""
+		if m.del != nil {
+			_ = m.del(m.host)
+		}
+		m.screen = appLogin
+		m.active = NewLogin(m.host, m.port)
+		return m, sizeCmd(m.width, m.height)
 
 	case backMsg:
 		// Pop back to the menu and re-detect so its phase/actions refresh.
@@ -204,6 +234,9 @@ func (m App) openPanel(id phase.ActionID) (tea.Model, tea.Cmd) {
 		m.screen, m.active = appMenu, nil
 		return m, nil
 	}
+	// Remember the panel so a mid-panel re-auth (reauthRequiredMsg) re-opens the
+	// right one after sign-in.
+	m.pending = id
 	switch id {
 	case phase.EditConfig:
 		m.active = NewConfig(client)

--- a/tools/sb-tui/internal/ui/app_test.go
+++ b/tools/sb-tui/internal/ui/app_test.go
@@ -21,9 +21,15 @@ func buildflowPlanStub() buildflow.Plan {
 }
 
 func newTestApp(token string) (App, *[]string) {
-	var saved []string
+	app, saved, _ := newTestAppWithDelete(token)
+	return app, saved
+}
+
+func newTestAppWithDelete(token string) (App, *[]string, *[]string) {
+	var saved, deleted []string
 	save := func(host, tok string) error { saved = append(saved, host+"="+tok); return nil }
-	return NewApp(testDetect, "box", "5888", token, save, BuildConfig{}), &saved
+	del := func(host string) error { deleted = append(deleted, host); return nil }
+	return NewApp(testDetect, "box", "5888", token, save, del, BuildConfig{}), &saved, &deleted
 }
 
 // TestRouteToLoginWhenNoToken: picking a box-control action with no token opens
@@ -84,6 +90,42 @@ func TestBackReturnsToMenu(t *testing.T) {
 	app = mi.(App)
 	if app.screen != appMenu || app.active != nil {
 		t.Fatalf("after back: screen=%v active=%v", app.screen, app.active)
+	}
+}
+
+// TestReauthRequiredDropsStaleTokenAndReopensLogin: a panel reporting a rejected
+// token (reauthRequiredMsg) drops the in-memory + persisted token and re-opens
+// sign-in for the same panel, instead of dead-ending. Signing in then resumes
+// into the originally-requested panel. This is the post-reinstall stale-token
+// recovery (#1502).
+func TestReauthRequiredDropsStaleTokenAndReopensLogin(t *testing.T) {
+	app, _, deleted := newTestAppWithDelete("sb_stale")
+	// Open a panel (records pending=InstallStacks) — the box would 401 on its
+	// first call; the panel returns reauthRequiredMsg.
+	mi, _ := app.Update(menuSelectedMsg{id: phase.InstallStacks})
+	app = mi.(App)
+	mi, _ = app.Update(reauthRequiredMsg{})
+	app = mi.(App)
+	if app.screen != appLogin {
+		t.Fatalf("screen = %v, want appLogin after reauth", app.screen)
+	}
+	if app.token != "" {
+		t.Errorf("stale token not dropped: %q", app.token)
+	}
+	if len(*deleted) != 1 || (*deleted)[0] != "box" {
+		t.Errorf("persisted token not deleted: %v", *deleted)
+	}
+	if _, ok := app.active.(LoginModel); !ok {
+		t.Errorf("active = %T, want LoginModel", app.active)
+	}
+	// A fresh sign-in resumes into the panel that 401'd.
+	mi, _ = app.Update(authSucceededMsg{token: "sb_fresh"})
+	app = mi.(App)
+	if app.token != "sb_fresh" {
+		t.Errorf("token = %q after re-auth", app.token)
+	}
+	if _, ok := app.active.(InstallModel); !ok {
+		t.Errorf("active = %T, want InstallModel resumed after re-auth", app.active)
 	}
 }
 

--- a/tools/sb-tui/internal/ui/backup.go
+++ b/tools/sb-tui/internal/ui/backup.go
@@ -99,6 +99,9 @@ func (m BackupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case backupsLoadedMsg:
 		if msg.err != nil {
 			m.loadEr = msg.err
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.loadEr, m.backups, m.stage = nil, msg.backups, bkBrowse
@@ -110,6 +113,9 @@ func (m BackupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.stage = bkBrowse
 		if msg.err != nil {
 			m.status = "✗ " + friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.status = "✓ created " + msg.backup.FileName
@@ -118,6 +124,9 @@ func (m BackupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.stage = bkBrowse
 		if msg.err != nil {
 			m.status = "✗ restore failed: " + friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.status = "✓ restored " + msg.fileName

--- a/tools/sb-tui/internal/ui/channel.go
+++ b/tools/sb-tui/internal/ui/channel.go
@@ -91,6 +91,9 @@ func (m ChannelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case channelLoadedMsg:
 		if msg.err != nil {
 			m.stage, m.errMsg = chanError, friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.current, m.stage = msg.channel, chanSelect
@@ -103,6 +106,9 @@ func (m ChannelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case channelSetMsg:
 		if msg.err != nil {
 			m.stage, m.errMsg = chanError, friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		return m, tick2s() // the box is restarting; start polling for the flip

--- a/tools/sb-tui/internal/ui/config.go
+++ b/tools/sb-tui/internal/ui/config.go
@@ -88,6 +88,11 @@ func (m ConfigModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		if msg.err != nil {
 			m.loadEr = msg.err
+			// A rejected token isn't a dead-end: ask the App to drop it + re-auth.
+			// Standalone (no App) drops the msg and the stored error shows as before.
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.loadEr = nil
@@ -97,6 +102,9 @@ func (m ConfigModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.editing = false
 		if msg.err != nil {
 			m.status = "✗ " + friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.values[msg.key] = msg.value

--- a/tools/sb-tui/internal/ui/install.go
+++ b/tools/sb-tui/internal/ui/install.go
@@ -230,6 +230,9 @@ func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case stacksLoadedMsg:
 		if msg.err != nil {
 			m.stage, m.errMsg = stageError, friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.stacks, m.stage = msg.stacks, stageSelect
@@ -257,6 +260,9 @@ func (m InstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.pollCmd()
 			}
 			m.stage, m.errMsg = stageError, friendlyErr(msg.err)
+			if msg.err == rest.ErrUnauthorized {
+				return m, reauthCmd()
+			}
 			return m, nil
 		}
 		m.jobID, m.stage = msg.jobID, stageInstalling

--- a/tools/sb-tui/main.go
+++ b/tools/sb-tui/main.go
@@ -424,7 +424,7 @@ func main() {
 	// that quit the app, because build is an interactive stdin wizard and the
 	// rest are natural one-shots.
 	t := probes.ResolveTarget()
-	app := ui.NewApp(detect, t.Host, t.Port, probes.ResolveToken(t.Host), probes.SaveToken, buildConfig())
+	app := ui.NewApp(detect, t.Host, t.Port, probes.ResolveToken(t.Host), probes.SaveToken, probes.DeleteToken, buildConfig())
 	final, err := tea.NewProgram(app, tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## What
Batch of four themed fixes around reinstall/connection robustness:

- **Home Assistant wipe-configs reconciliation** (#1505, #1511, #1512) — after a config-wipe reinstall with kept HA data, the HA post-deploy now re-mints an invalid long-lived token (mirrors the LLDAP FORCE_RESET self-heal), auto-detects an unambiguous single Z-Wave USB stick when `ZWAVE_DEVICE` is unset, and logs kept-data-present vs bare so integrations are re-established instead of coming up empty.
- **Dashboard connect/banner/setup cleanup** (#1503, #1504, #1509) — `useSocket` kicks a stale singleton on mount + bounded 3s retry (turns the 30s "Connecting to ServiceBay" hang into a few-second self-recovery); offline banner reads `useInstallMonitor` so a live install's progress poll suppresses the false banner/toast; the misleading "Concurrent Pipeline Active" lock and the redundant `/setup` sidebar rider are removed.
- **Health-check deploy gating** (#1506) — per-service health checks are now removed on uninstall and stale auto-created `Service:` rows are pruned on boot, so an un-installed service no longer shows a red "failing" row.
- **sb-tui stale-token re-auth** (#1502) — a rejected (stale) persisted token now drops the token and re-opens sign-in for the panel that 401'd (resuming into it after a fresh mint) instead of dead-ending.

## Why
Closes #1505
Closes #1511
Closes #1512
Closes #1503
Closes #1504
Closes #1509
Closes #1506
Closes #1502

## Risk
Medium — touches install-time HA reconciliation and frontend dashboard connection logic; both are path-mandated and box-verified on a real wipe-configs reinstall before release.

## Rollback
git revert is enough (no schema/migration changes).

## Verification
- [x] npm run lint (0 errors, 347 baseline warnings)
- [x] npm run check:arch
- [x] next build
- [x] npm test (full, 1685 passed)
- [x] Go gates for sb-tui (gofmt/vet/build/test)
- [ ] /verify on FCoS :dev box — wipe-configs reinstall (HA token/Z-Wave/integrations) + browser-verify (no concurrent lock, no Setup rider, no false offline banner, gate advances without hard reload)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._