### PR TITLE
feat(install): persist image store on RAID and skip doomed access-request approvals

### DIFF
--- a/packages/frontend/src/app/api/system/access-requests/existingEmail.test.ts
+++ b/packages/frontend/src/app/api/system/access-requests/existingEmail.test.ts
@@ -12,9 +12,11 @@ function deps(over: Partial<ExistingEmailDeps>): ExistingEmailDeps {
 
 describe('handleExistingEmail', () => {
   it('short-circuits + notifies the owner when the email already exists', async () => {
-    const notifyOwner = vi.fn(async () => {});
+    const notifyOwner = vi.fn<(email: string) => Promise<void>>(async () => {});
     const d = deps({
-      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'alice', email: 'Alice@Example.com' }] })),
+      listUsers: vi.fn(
+        async (): Promise<LldapListUsersResult> => ({ ok: true, users: [{ id: 'alice', email: 'Alice@Example.com' }] }),
+      ),
       notifyOwner,
     });
 
@@ -31,7 +33,9 @@ describe('handleExistingEmail', () => {
   it('does not short-circuit and never emails when the email is new', async () => {
     const notifyOwner = vi.fn(async () => {});
     const d = deps({
-      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'bob', email: 'bob@example.com' }] })),
+      listUsers: vi.fn(
+        async (): Promise<LldapListUsersResult> => ({ ok: true, users: [{ id: 'bob', email: 'bob@example.com' }] }),
+      ),
       notifyOwner,
     });
 
@@ -44,7 +48,9 @@ describe('handleExistingEmail', () => {
   it('fails open (does not short-circuit) when LLDAP is unreachable', async () => {
     const notifyOwner = vi.fn(async () => {});
     const d = deps({
-      listUsers: vi.fn(async () => ({ ok: false, reason: 'network_error', message: 'boom' })),
+      listUsers: vi.fn(
+        async (): Promise<LldapListUsersResult> => ({ ok: false, reason: 'network_error', message: 'boom' }),
+      ),
       notifyOwner,
     });
 
@@ -56,7 +62,9 @@ describe('handleExistingEmail', () => {
 
   it('still short-circuits when the owner notification throws (never enumerates via error)', async () => {
     const d = deps({
-      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'carol', email: 'carol@example.com' }] })),
+      listUsers: vi.fn(
+        async (): Promise<LldapListUsersResult> => ({ ok: true, users: [{ id: 'carol', email: 'carol@example.com' }] }),
+      ),
       notifyOwner: vi.fn(async () => { throw new Error('smtp down'); }),
     });
 
@@ -67,7 +75,12 @@ describe('handleExistingEmail', () => {
 
   it('ignores directory users with no email', async () => {
     const d = deps({
-      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'svc' }, { id: 'dave', email: 'dave@example.com' }] })),
+      listUsers: vi.fn(
+        async (): Promise<LldapListUsersResult> => ({
+          ok: true,
+          users: [{ id: 'svc' }, { id: 'dave', email: 'dave@example.com' }],
+        }),
+      ),
     });
 
     expect((await handleExistingEmail('dave@example.com', d)).shortCircuit).toBe(true);

--- a/packages/frontend/src/app/api/system/access-requests/existingEmail.test.ts
+++ b/packages/frontend/src/app/api/system/access-requests/existingEmail.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleExistingEmail, type ExistingEmailDeps } from './existingEmail';
+import type { LldapListUsersResult } from '@/lib/lldap/client';
+
+function deps(over: Partial<ExistingEmailDeps>): ExistingEmailDeps {
+  return {
+    listUsers: vi.fn(async (): Promise<LldapListUsersResult> => ({ ok: true, users: [] })),
+    notifyOwner: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe('handleExistingEmail', () => {
+  it('short-circuits + notifies the owner when the email already exists', async () => {
+    const notifyOwner = vi.fn(async () => {});
+    const d = deps({
+      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'alice', email: 'Alice@Example.com' }] })),
+      notifyOwner,
+    });
+
+    // Case-insensitive match on a differently-cased submission.
+    const res = await handleExistingEmail(' alice@example.com ', d);
+
+    expect(res.shortCircuit).toBe(true);
+    expect(notifyOwner).toHaveBeenCalledTimes(1);
+    // Notifies the directory address, not the (possibly differently-cased)
+    // submitted one.
+    expect(notifyOwner.mock.calls[0][0]).toBe('Alice@Example.com');
+  });
+
+  it('does not short-circuit and never emails when the email is new', async () => {
+    const notifyOwner = vi.fn(async () => {});
+    const d = deps({
+      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'bob', email: 'bob@example.com' }] })),
+      notifyOwner,
+    });
+
+    const res = await handleExistingEmail('newcomer@example.com', d);
+
+    expect(res.shortCircuit).toBe(false);
+    expect(notifyOwner).not.toHaveBeenCalled();
+  });
+
+  it('fails open (does not short-circuit) when LLDAP is unreachable', async () => {
+    const notifyOwner = vi.fn(async () => {});
+    const d = deps({
+      listUsers: vi.fn(async () => ({ ok: false, reason: 'network_error', message: 'boom' })),
+      notifyOwner,
+    });
+
+    const res = await handleExistingEmail('someone@example.com', d);
+
+    expect(res.shortCircuit).toBe(false);
+    expect(notifyOwner).not.toHaveBeenCalled();
+  });
+
+  it('still short-circuits when the owner notification throws (never enumerates via error)', async () => {
+    const d = deps({
+      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'carol', email: 'carol@example.com' }] })),
+      notifyOwner: vi.fn(async () => { throw new Error('smtp down'); }),
+    });
+
+    const res = await handleExistingEmail('carol@example.com', d);
+
+    expect(res.shortCircuit).toBe(true);
+  });
+
+  it('ignores directory users with no email', async () => {
+    const d = deps({
+      listUsers: vi.fn(async () => ({ ok: true, users: [{ id: 'svc' }, { id: 'dave', email: 'dave@example.com' }] })),
+    });
+
+    expect((await handleExistingEmail('dave@example.com', d)).shortCircuit).toBe(true);
+    expect((await handleExistingEmail('nobody@example.com', d)).shortCircuit).toBe(false);
+  });
+});

--- a/packages/frontend/src/app/api/system/access-requests/existingEmail.ts
+++ b/packages/frontend/src/app/api/system/access-requests/existingEmail.ts
@@ -1,0 +1,86 @@
+import { listLldapUsers, type LldapListUsersResult } from '@/lib/lldap/client';
+import { sendTransactionalEmail } from '@/lib/email';
+import { logger } from '@/lib/logger';
+
+/**
+ * Duplicate-email guard for the public access-request endpoint (#1510).
+ *
+ * When someone submits a request with an email that already has an LLDAP
+ * account, the old flow still queued an admin approval that could only ever
+ * fail ("Could not approve — already exists"). This guard catches the
+ * duplicate at submit time:
+ *
+ *   - On a match: notify the *existing account owner* ("someone requested an
+ *     account using your email address") and tell the caller to short-circuit
+ *     — no admin-approval request is queued, no admin notification is sent.
+ *   - The route returns the SAME neutral response either way, so the requester
+ *     can't tell whether the email already exists (no account enumeration).
+ *
+ * Fail-open: if LLDAP is unreachable / not configured / errors, we can't size
+ * the directory, so we let the request proceed normally rather than block a
+ * legitimate submission on an LLDAP hiccup — same best-effort stance the user-
+ * cap guard (`rejectIfCapped`) takes. The downside of a false-negative is only
+ * that the admin sees one doomed approval (the old behaviour), which is
+ * strictly better than dropping a real request.
+ */
+
+export interface ExistingEmailDeps {
+  listUsers: () => Promise<LldapListUsersResult>;
+  notifyOwner: (to: string, subject: string, message: string) => Promise<void>;
+}
+
+const defaultDeps: ExistingEmailDeps = {
+  listUsers: listLldapUsers,
+  notifyOwner: sendTransactionalEmail,
+};
+
+const OWNER_NOTICE_SUBJECT = 'Someone requested access using your email address';
+
+function ownerNoticeBody(email: string): string {
+  return (
+    `Hi,\n\n` +
+    `Someone just requested a new account on this home server using your email ` +
+    `address (${email}). Because this address already has an account, no new ` +
+    `account was created and the request was not sent to the admin.\n\n` +
+    `If this was you — for example you forgot you already have an account — you ` +
+    `can sign in as usual, or use the "Forgot password" link to regain access.\n\n` +
+    `If it wasn't you, you can safely ignore this email; nothing has changed.`
+  );
+}
+
+/**
+ * Returns whether the public POST handler should short-circuit (the email
+ * already belongs to an LLDAP account). When it should, the owner has already
+ * been notified (best-effort) by the time this resolves.
+ */
+export async function handleExistingEmail(
+  email: string,
+  deps: ExistingEmailDeps = defaultDeps,
+): Promise<{ shortCircuit: boolean }> {
+  const listed = await deps.listUsers();
+  if (!listed.ok) {
+    // Fail-open: can't confirm, let the request proceed as before.
+    logger.warn('access-requests', `Could not check LLDAP for existing email (${listed.reason}); proceeding without dedupe.`);
+    return { shortCircuit: false };
+  }
+
+  const target = email.trim().toLowerCase();
+  const match = listed.users.find(u => (u.email ?? '').trim().toLowerCase() === target);
+  if (!match) {
+    return { shortCircuit: false };
+  }
+
+  // Notify the rightful owner at THEIR stored address (not the submitted one —
+  // identical here, but use the directory value as the source of truth).
+  const ownerEmail = (match.email ?? email).trim();
+  try {
+    await deps.notifyOwner(ownerEmail, OWNER_NOTICE_SUBJECT, ownerNoticeBody(ownerEmail));
+  } catch (e) {
+    // sendTransactionalEmail already swallows SMTP errors, but guard anyway so
+    // a notification failure never turns into a 500 (or worse, enumeration via
+    // a differing error response).
+    logger.warn('access-requests', `Owner-notice email failed for an existing-email request: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  logger.info('access-requests', 'Request for an already-registered email — notified owner, skipped admin queue.');
+  return { shortCircuit: true };
+}

--- a/packages/frontend/src/app/api/system/access-requests/route.ts
+++ b/packages/frontend/src/app/api/system/access-requests/route.ts
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import { getConfig, saveConfig, getAdminBaseUrl, type AccessRequest } from '@/lib/config';
 import { sendEmailAlert } from '@/lib/email';
 import { isOverUserLimit, DEFAULT_MAX_USERS } from '@/lib/portal/userCap';
+import { handleExistingEmail } from './existingEmail';
 import { logger } from '@/lib/logger';
 import { withApiHandler } from '@/lib/api/handler';
 
@@ -104,6 +105,18 @@ export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
   const capResponse = await rejectIfCapped(config.maxUsers ?? DEFAULT_MAX_USERS, pending.length);
   if (capResponse) return capResponse;
 
+  // #1510 — if the email already has an LLDAP account, queueing an admin
+  // approval is doomed (it can only fail "already exists"). Short-circuit:
+  // notify the rightful owner and return the SAME neutral success below
+  // (no admin queue, no enumeration). Fails open if LLDAP is unreachable.
+  const { shortCircuit } = await handleExistingEmail(parsed.email);
+  if (shortCircuit) {
+    // Same response shape as a real submission so the requester can't tell
+    // the email already exists. The id is a throwaway UUID — the status
+    // endpoint will report `not-found`, identical to a cleared request.
+    return NextResponse.json({ ok: true, id: crypto.randomUUID() });
+  }
+
   // Compose display name from firstName/lastName when both are
   // provided (new clients); otherwise fall back to the free-text
   // `name` field (old clients). At least one source is required.
@@ -130,22 +143,28 @@ export const POST = withApiHandler({ skipAuth: true }, async ({ request }) => {
   };
   await saveConfig({ ...config, accessRequests: [...existing, newRequest] });
   logger.info('access-requests', `New request from ${parsed.email}`);
+  notifyAdminOfRequest(config, newRequest);
 
-  // Best-effort email notification — sendEmailAlert no-ops when
-  // email isn't configured.
+  return NextResponse.json({ ok: true, id: newRequest.id });
+});
+
+/**
+ * Best-effort "New access request" admin notification — sendEmailAlert
+ * no-ops when email isn't configured. Split out of the POST handler to
+ * keep it under the size/complexity budget.
+ */
+function notifyAdminOfRequest(config: Awaited<ReturnType<typeof getConfig>>, req: AccessRequest): void {
   const adminBase = getAdminBaseUrl(config);
   const deepLink = adminBase ? `${adminBase}/settings/networking#access-requests` : null;
   void sendEmailAlert(
     'New access request',
-    `${parsed.name} (${parsed.email}) has requested access to your home server.\n\n` +
-    (parsed.message ? `Message: ${parsed.message}\n\n` : '') +
+    `${req.name} (${req.email}) has requested access to your home server.\n\n` +
+    (req.message ? `Message: ${req.message}\n\n` : '') +
     (deepLink
       ? `Review and approve: ${deepLink}`
       : 'Open Settings → Access Requests to create the LLDAP user.'),
   );
-
-  return NextResponse.json({ ok: true, id: newRequest.id });
-});
+}
 
 export const GET = withApiHandler({}, async () => {
   const config = await getConfig();

--- a/tests/backend/access_requests.test.ts
+++ b/tests/backend/access_requests.test.ts
@@ -2,7 +2,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-const state: { config: any } = { config: {} };
+const state: { config: any; lldapUsers: Array<{ id: string; email?: string }>; lldapOk: boolean } = {
+  config: {},
+  lldapUsers: [],
+  lldapOk: true,
+};
 
 vi.mock('@/lib/config', async () => {
   const actual = await vi.importActual<any>('@/lib/config');
@@ -12,8 +16,19 @@ vi.mock('@/lib/config', async () => {
     saveConfig: vi.fn(async (cfg: any) => { state.config = cfg; }),
   };
 });
+const sendTransactionalEmail = vi.fn(async () => {});
 vi.mock('@/lib/email', () => ({
   sendEmailAlert: vi.fn(async () => {}),
+  sendTransactionalEmail: (...args: unknown[]) => sendTransactionalEmail(...args as []),
+}));
+// #1510 — the public POST checks LLDAP for the email before queueing. Mock
+// the client so the dedupe path is deterministic without a live directory.
+vi.mock('@/lib/lldap/client', () => ({
+  listLldapUsers: vi.fn(async () =>
+    state.lldapOk
+      ? { ok: true, users: state.lldapUsers }
+      : { ok: false, reason: 'network_error', message: 'mocked unreachable' },
+  ),
 }));
 
 // requireSession bypass for tests (#596) — the PATCH/DELETE routes
@@ -27,6 +42,9 @@ import { PATCH, DELETE } from '@/app/api/system/access-requests/[id]/route';
 
 beforeEach(() => {
   state.config = {};
+  state.lldapUsers = [];
+  state.lldapOk = true;
+  sendTransactionalEmail.mockClear();
 });
 
 const post = (body: unknown, opts?: { rawBody?: string }) =>
@@ -87,6 +105,32 @@ describe('POST /api/system/access-requests', () => {
     }));
     const res = await post({ name: 'Fresh', email: 'fresh@example.com' });
     expect(res.status).toBe(200);
+  });
+
+  // #1510 — an email that already has an LLDAP account must not reach the
+  // admin queue (the approval could only ever fail "already exists"). The
+  // owner is notified instead; the requester gets the same neutral response.
+  it('does not queue an admin approval when the email already exists in LLDAP', async () => {
+    state.lldapUsers = [{ id: 'alice', email: 'Alice@Example.com' }];
+    const res = await post({ name: 'Imposter', email: 'alice@example.com' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // Same shape as a real submission (ok + id) — no enumeration.
+    expect(data.ok).toBe(true);
+    expect(typeof data.id).toBe('string');
+    // Nothing queued for the admin.
+    expect(state.config.accessRequests ?? []).toHaveLength(0);
+    // Owner was notified at the directory address.
+    expect(sendTransactionalEmail).toHaveBeenCalledTimes(1);
+    expect((sendTransactionalEmail.mock.calls[0] as unknown[])[0]).toBe('Alice@Example.com');
+  });
+
+  it('queues normally when LLDAP is unreachable (fail-open)', async () => {
+    state.lldapOk = false;
+    const res = await post({ name: 'Real', email: 'real@example.com' });
+    expect(res.status).toBe(200);
+    expect(state.config.accessRequests).toHaveLength(1);
+    expect(sendTransactionalEmail).not.toHaveBeenCalled();
   });
 });
 

--- a/tools/sb-tui/internal/build/assets/fedora-coreos.bu
+++ b/tools/sb-tui/internal/build/assets/fedora-coreos.bu
@@ -354,6 +354,23 @@ storage:
           # Create data directories (no-op if they already exist)
           mkdir -p "$MOUNT_POINT/servicebay/ssh" "$MOUNT_POINT/stacks"
 
+          # Rootless podman image store on the RAID (#1494). The baked
+          # storage.conf points graphroot here; create it BEFORE the user's
+          # linger services come up so the first podman call finds a usable,
+          # correctly-labelled store. The RAID is xfs mounted as mnt_t — a
+          # type rootless podman can't write its overlay store onto — so we
+          # relabel the tree to container_file_t (the type the default
+          # ~/.local/share/containers/storage already carries via FCOS's
+          # file_contexts). chcon (not semanage) because the path is on a
+          # dynamically-created mount with no persistent fcontext rule; the
+          # store is recreated/relabelled on every first boot anyway, and a
+          # reinstall preserves the existing labels on the kept RAID data.
+          STORAGE_ROOT="$MOUNT_POINT/containers/storage"
+          mkdir -p "$STORAGE_ROOT"
+          chown -R "$HOST_USER:$HOST_USER" "$MOUNT_POINT/containers"
+          # Best-effort: a box booted with SELinux disabled has no chcon.
+          chcon -R -t container_file_t "$MOUNT_POINT/containers" 2>/dev/null || true
+
           # Factory-fresh "wipe-configs" (#1496): clear ServiceBay's own identity
           # so the install promotes the freshly-baked config instead of merging the
           # old one back — fresh admin / secret.key / tokens — while KEEPING all
@@ -469,6 +486,30 @@ storage:
     # User Linger (enables rootless services at boot)
     - path: /var/lib/systemd/linger/${HOST_USER}
       mode: 0644
+
+    # Rootless podman storage on the RAID (#1494). The default rootless
+    # graphroot is /var/home/${HOST_USER}/.local/share/containers/storage
+    # — on the OS disk, which a USB reinstall reformats, so ~38 GB of
+    # images get re-pulled every reinstall. Point graphroot at the data
+    # RAID (${DATA_ROOT}, survives reinstalls) so images persist + are
+    # versioned. setup-raid.sh creates ${DATA_ROOT}/containers/storage
+    # with HOST_USER ownership + a container_file_t SELinux label before
+    # any rootless podman runs (the RAID mounts as xfs with mnt_t, which
+    # rootless podman cannot write its overlay store onto). Only graphroot
+    # is overridden — runroot is left at podman's default (/run/user/$UID/
+    # containers, tmpfs, per-boot scratch); persisting it would only invite
+    # stale lockfiles after an unclean shutdown.
+    - path: /var/home/${HOST_USER}/.config/containers/storage.conf
+      mode: 0644
+      user:
+        name: ${HOST_USER}
+      group:
+        name: ${HOST_USER}
+      contents:
+        inline: |
+          [storage]
+          driver = "overlay"
+          graphroot = "${DATA_ROOT}/containers/storage"
 
     # ServiceBay Quadlet (rootless).
     #


### PR DESCRIPTION
## What
Two host/path-level fixes batched together:
- Move rootless podman's image store onto the `/mnt/data` RAID so container images survive a reinstall.
- Short-circuit public access requests for an already-registered email so the admin never sees a dead-end approval.

## Why
Closes #1494
Closes #1510

## Details
- **#1494** (`tools/sb-tui/internal/build/assets/fedora-coreos.bu`, `setup-raid.sh`): bake a rootless `storage.conf` with `graphroot=/mnt/data/containers/storage`; `setup-raid` creates the dir on the RAID, chowns it to the host user, and relabels it `container_file_t` so rootless podman can write its overlay store. runroot stays at the per-boot default. After the first reinstall with the new ISO, images persist on the RAID with no full re-pull on later boots.
- **#1510** (`packages/frontend/src/app/api/system/access-requests/route.ts` + new `existingEmail.ts`): on a public access-request submit, check LLDAP for the email first. On a hit, notify the existing account owner and return the same neutral response as a real submission, without queueing an admin approval and without enumerating account existence. Fail-open if LLDAP is unreachable so a real request is never dropped.

## Risk
Medium. #1494 changes first-boot host setup and the baked Ignition; behaviour is reinstall-only and confirmed via butane transpile + Go render tests. #1510 is on a public route, fail-open, fully unit-tested.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 1692 passed)
- [x] Go gates for sb-tui (gofmt/vet/build/test)
- [ ] /verify on FCoS box: images survive a real reinstall with no re-pull on second boot; submit a portal request for an existing LLDAP email shows no admin-queue row and the owner gets a heads-up

AI-generated
<!-- sb-ai-comment -->