### PR TITLE
feat(file-share): shared-gid + setgid + default ACL on the notes vault

### DIFF
--- a/templates/file-share/post-deploy.py
+++ b/templates/file-share/post-deploy.py
@@ -19,6 +19,7 @@ See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
 
 from __future__ import annotations
 
+import grp
 import json
 import os
 import subprocess
@@ -26,6 +27,13 @@ import sys
 import time
 import urllib.error
 import urllib.request
+
+
+# Dedicated POSIX group that owns the shared notes vault. Members of this
+# group (incl. cross-stack consumers like OSCAR's Hermes, mapped in on the
+# consumer side) can co-write the vault regardless of which host uid their
+# userns maps them to. See #1311.
+SHARE_GROUP = "file-share"
 
 
 def env(key: str, default: str = "") -> str:
@@ -66,8 +74,115 @@ def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tu
         return 0, None
 
 
+def _notes_dir() -> str:
+    """Host-side path of the shared notes vault. Lives under the
+    `shared-data` hostPath (`{{DATA_DIR}}/file-share/data`) that the pod
+    mounts as /data (samba), /srv (filebrowser) and /var/syncthing/Sync
+    (syncthing). Must stay in sync with the volume in template.yml."""
+    base = env("DATA_DIR", "/mnt/data")
+    return os.path.join(base, "file-share", "data", "notes")
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=30)
+
+
+def _run_priv(cmd: list[str]) -> bool:
+    """Run a mutating command, retrying once with sudo if the unprivileged
+    attempt fails (the notes dir is normally owned by the host user the
+    post-deploy runs as, so the plain attempt usually succeeds; sudo is the
+    fallback when ownership has drifted). Returns True on success."""
+    try:
+        res = _run(cmd)
+        if res.returncode == 0:
+            return True
+        sudo = _run(["sudo", "-n", *cmd])
+        if sudo.returncode == 0:
+            return True
+        log(f"   ⚠️  {' '.join(cmd)} failed: {(res.stderr or sudo.stderr or '').strip()}")
+        return False
+    except (OSError, subprocess.SubprocessError) as exc:
+        log(f"   ⚠️  {' '.join(cmd)} could not run: {exc}")
+        return False
+
+
+def _ensure_share_group() -> int | None:
+    """Ensure the dedicated `file-share` group exists and return its gid.
+    Idempotent: returns the existing gid if the group is already present,
+    otherwise best-effort `groupadd` (needs sudo). Returns None if the
+    group can't be resolved/created — caller logs + skips ACL work then."""
+    try:
+        return grp.getgrnam(SHARE_GROUP).gr_gid
+    except KeyError:
+        pass
+    # Group missing — create it (system group, host-wide). Best-effort.
+    try:
+        created = _run(["sudo", "-n", "groupadd", "--system", SHARE_GROUP])
+        if created.returncode != 0 and "already exists" not in (created.stderr or ""):
+            log(f"   ⚠️  Could not create the '{SHARE_GROUP}' group: {(created.stderr or '').strip()}")
+    except (OSError, subprocess.SubprocessError) as exc:
+        log(f"   ⚠️  groupadd '{SHARE_GROUP}' could not run: {exc}")
+    try:
+        return grp.getgrnam(SHARE_GROUP).gr_gid
+    except KeyError:
+        return None
+
+
+def provision_notes_share() -> None:
+    """Replace the legacy `0777` notes hack with a real access model so the
+    vault is multi-writer across services (and, once a consumer is mapped
+    into the group, across stacks). Idempotent + fail-soft: every step logs
+    on failure and never aborts the deploy. Re-applied each deploy so it
+    survives a backup/restore that resets ownership. See #1311.
+
+      1. dedicated `file-share` gid owns notes/ (chgrp -R)
+      2. setgid (chmod 2775) so new files inherit that group
+      3. default POSIX ACL g:<gid>:rwx so new files are group-rwx
+         regardless of the writer's umask 0022 (the images run as root
+         with no UMASK knob — the directory enforces it instead), plus the
+         same ACL on existing entries.
+    """
+    notes = _notes_dir()
+    log(f"── Provisioning shared notes vault permissions ({notes}) ──")
+    if not os.path.isdir(notes):
+        # DirectoryOrCreate makes the share root, but `notes/` is a
+        # convention subdir — create it so the model applies from deploy 1.
+        try:
+            os.makedirs(notes, exist_ok=True)
+        except OSError as exc:
+            log(f"   ⚠️  notes dir absent and could not be created ({exc}); skipping permission provisioning.")
+            return
+
+    gid = _ensure_share_group()
+    if gid is None:
+        log(f"   ⚠️  '{SHARE_GROUP}' group unavailable; skipping group-own + ACL. The vault keeps its current permissions.")
+        return
+
+    # 1. group-own the tree by the shared gid.
+    if _run_priv(["chgrp", "-R", str(gid), notes]):
+        log(f"   group-owned notes/ by gid {gid} ({SHARE_GROUP}).")
+    # 2. setgid + group-write on the dir so new files inherit the group.
+    if _run_priv(["chmod", "2775", notes]):
+        log("   set mode 2775 (setgid) on notes/.")
+    # 3. default ACL (new files) + apply to existing entries. setfacl is
+    #    only present when the fs supports ACLs (XFS here does); a missing
+    #    binary or unsupported fs just logs and leaves setgid in place.
+    if _run_priv(["setfacl", "-R", "-d", "-m", f"g:{gid}:rwx", notes]):
+        log(f"   set default ACL g:{gid}:rwx on notes/ (new files inherit group-rwx).")
+    if _run_priv(["setfacl", "-R", "-m", f"g:{gid}:rwx", notes]):
+        log(f"   applied ACL g:{gid}:rwx to existing notes/ entries.")
+    log("   ✅ notes vault provisioned (shared gid + setgid + default ACL). "
+        "Cross-stack consumers (e.g. Hermes) must be mapped into the "
+        f"'{SHARE_GROUP}' group on their pod to co-write.")
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
+
+    # ── Shared notes-vault permission model (#1311) ────────────────────
+    # Provision the multi-writer access model before anything else so the
+    # vault is co-editable from this deploy on. Best-effort; never fatal.
+    provision_notes_share()
 
     # ── Syncthing GUI host-check ───────────────────────────────────────
     # Syncthing's GUI rejects Host headers other than the bind address

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -181,6 +181,16 @@ spec:
         name: filebrowser-config
 
   volumes:
+  # shared-data is the multi-writer vault (mounted as /data, /srv and
+  # /var/syncthing/Sync above). Its `notes/` subdir is provisioned by
+  # post-deploy.py with a real access model — owned by a dedicated
+  # `file-share` group, setgid (mode 2775) so new files inherit that group,
+  # and a default POSIX ACL (g:<gid>:rwx) so every new file is group-rwx
+  # regardless of the writer's umask. This replaces the old blunt `0777`
+  # workaround: cross-stack consumers (e.g. OSCAR's Hermes, mapped to a
+  # different host uid) co-write by being added to the `file-share` group on
+  # their own pod (supplementalGroups / --group-add) rather than by making
+  # the dir world-writable. See #1311.
   - name: shared-data
     hostPath:
       path: {{DATA_DIR}}/file-share/data

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -389,6 +389,133 @@ class FileShareScript(unittest.TestCase):
         )
         self.assertNotIn("shar3", log_only)
 
+    def test_provisions_notes_share_acl(self):
+        """#1311: provision_notes_share() must own the notes vault by the
+        shared `file-share` gid, set the setgid bit (mode 2775), and apply
+        a default + existing POSIX ACL granting g:<gid>:rwx — replacing the
+        old 0777 hack with a real access model. Commands are recorded
+        (subprocess mocked) and asserted against the real tempdir path."""
+        import tempfile
+        import grp as grp_mod
+        m = load_script("file-share")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            notes = os.path.join(tmp, "file-share", "data", "notes")
+            calls: list[list[str]] = []
+
+            class _OK:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            def record_run(cmd, *_a, **_kw):
+                calls.append(list(cmd))
+                return _OK()
+
+            class _Grp:
+                gr_gid = 6000
+
+            env = {"DATA_DIR": tmp}
+            import subprocess as subprocess_mod
+            with run_with_env(env), \
+                    mock.patch.object(subprocess_mod, "run", record_run), \
+                    mock.patch.object(grp_mod, "getgrnam", lambda _n: _Grp()):
+                m.provision_notes_share()
+
+            # The notes subdir is created if absent so the model applies
+            # from the first deploy.
+            self.assertTrue(os.path.isdir(notes))
+
+            # Group already resolvable → no groupadd needed.
+            self.assertFalse(any("groupadd" in c for c in calls),
+                             "should not groupadd when the group already exists")
+
+            joined = [" ".join(c) for c in calls]
+            # 1. chgrp -R <gid> on notes
+            self.assertTrue(any(c == ["chgrp", "-R", "6000", notes] for c in calls), joined)
+            # 2. setgid mode 2775
+            self.assertTrue(any(c == ["chmod", "2775", notes] for c in calls), joined)
+            # 3. default ACL g:<gid>:rwx (new files) + existing entries
+            self.assertTrue(any(c == ["setfacl", "-R", "-d", "-m", "g:6000:rwx", notes] for c in calls), joined)
+            self.assertTrue(any(c == ["setfacl", "-R", "-m", "g:6000:rwx", notes] for c in calls), joined)
+
+    def test_provision_notes_share_fail_soft_when_group_unavailable(self):
+        """If the `file-share` group can't be resolved or created, the
+        provisioning logs and skips the ACL work without raising — a
+        permission step must never abort the deploy (#1311)."""
+        import tempfile
+        import grp as grp_mod
+        m = load_script("file-share")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            calls: list[list[str]] = []
+
+            class _OK:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            def record_run(cmd, *_a, **_kw):
+                calls.append(list(cmd))
+                return _OK()
+
+            env = {"DATA_DIR": tmp}
+            import subprocess as subprocess_mod
+            # getgrnam always raises KeyError → group never resolvable even
+            # after groupadd. Must skip chgrp/chmod/setfacl, log, return.
+            with run_with_env(env), \
+                    mock.patch.object(subprocess_mod, "run", record_run), \
+                    mock.patch.object(grp_mod, "getgrnam",
+                                      mock.Mock(side_effect=KeyError("no group"))):
+                m.provision_notes_share()  # must not raise
+
+            self.assertFalse(any("chgrp" in c for c in calls))
+            self.assertFalse(any("setfacl" in c for c in calls))
+
+    def test_provision_notes_share_creates_group_when_missing(self):
+        """When the group doesn't exist yet, provision runs `groupadd`
+        (idempotent system group), then resolves the freshly-created gid
+        and proceeds with the ACL provisioning."""
+        import tempfile
+        import grp as grp_mod
+        m = load_script("file-share")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            notes = os.path.join(tmp, "file-share", "data", "notes")
+            calls: list[list[str]] = []
+
+            class _OK:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            def record_run(cmd, *_a, **_kw):
+                calls.append(list(cmd))
+                return _OK()
+
+            class _Grp:
+                gr_gid = 6001
+
+            # First getgrnam raises (missing) → groupadd → second resolves.
+            seq = [KeyError("missing"), _Grp()]
+
+            def fake_getgrnam(_n):
+                v = seq.pop(0)
+                if isinstance(v, Exception):
+                    raise v
+                return v
+
+            env = {"DATA_DIR": tmp}
+            import subprocess as subprocess_mod
+            with run_with_env(env), \
+                    mock.patch.object(subprocess_mod, "run", record_run), \
+                    mock.patch.object(grp_mod, "getgrnam", fake_getgrnam):
+                m.provision_notes_share()
+
+            self.assertTrue(any("groupadd" in c for c in calls),
+                            "groupadd must run when the group is missing")
+            self.assertTrue(any(c == ["chgrp", "-R", "6001", notes] for c in calls))
+
     def test_returns_nonzero_when_seed_times_out(self):
         """If /api/system/filebrowser/init never accepts the seed within
         the 3-minute budget, the script must exit non-zero so the


### PR DESCRIPTION
## What
Replace the blunt `0777` notes hack in the `file-share` template with a real multi-writer access model, provisioned in the post-deploy self-heal pass: a dedicated `file-share` group owns `notes/`, the setgid bit (mode 2775) makes new files inherit that group, and a default + existing POSIX ACL `g:<gid>:rwx` forces group-rwx on every new file regardless of the writer's umask `0022`. Idempotent and fail-soft: each step logs on failure and never aborts the deploy, and it re-applies every deploy so it survives a backup/restore.

## Why
Refs #1311 — this ships the agreed shared-gid + setgid + default-ACL provisioning slice. The cross-stack divergent-uid write path (OSCAR Hermes, host uid 10000) stays gated on a real multi-service box verify, so #1311 stays open.

## Risk
Low — template-only, self-heal pass is best-effort/fail-soft and on this box every pod maps container-root to host uid 1000 (the cross-uid case isn't reproducible here), so the change is inert at worst.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 1692 passed)
- [x] python file-share template tests (unittest)
- [ ] /verify on FCoS :dev box — owed: real-deploy stat/getfacl on notes/ + Hermes uid-10000 cross-stack multi-writer write

AI-generated
<!-- sb-ai-comment -->
