### PR TITLE
fix: quiet recurring log noise (FritzBox DNS, cold-boot refresh) + portal Jellyfin card

### DIFF
--- a/packages/backend/src/lib/agent/handler.ts
+++ b/packages/backend/src/lib/agent/handler.ts
@@ -369,8 +369,14 @@ export class AgentHandler extends EventEmitter {
           this.flushDeferredCommands();
           this.emit('connected');
           
-          // Trigger a refresh on connect/reconnect so initialSyncComplete fires again for the twin (#894)
-          void this.sendCommand('refresh', {}).catch(err => {
+          // Trigger a refresh on connect/reconnect so initialSyncComplete fires again for the twin (#894).
+          // Generous timeout: the *first* refresh after a cold boot gathers full
+          // state for every stack (podman inspect per container) over the single
+          // SSH channel, which legitimately exceeds the default 30s on a box with
+          // many services — that produced a one-off "Command timeout for 'refresh'"
+          // on every boot. It's fire-and-forget and the periodic poller retries
+          // anyway, so 90s just stops the spurious cold-start error.
+          void this.sendCommand('refresh', {}, { timeoutMs: 90_000 }).catch(err => {
               this.log(this.nodeName, 'error', `Failed to send automatic refresh command on connect: ${err.message}`);
           });
 

--- a/packages/backend/src/lib/fritzbox/client.ts
+++ b/packages/backend/src/lib/fritzbox/client.ts
@@ -491,17 +491,26 @@ export class FritzBoxClient {
             dnsServers.push(luaDns);
         }
 
-        // 1. Try GetInfo (WAN)
-        // console.log('[FritzBox] Fetching DNS servers via GetInfo...');
-        const infoXml = await this.soapRequest('GetInfo');
-        if (infoXml) {
-            // console.log('[FritzBox] GetInfo Response:', infoXml);
-            const dnsStr = this.extractValue(infoXml, 'NewDNSServers');
-            // console.log('[FritzBox] Extracted NewDNSServers:', dnsStr);
-            if (dnsStr) {
-                const servers = dnsStr.split(',').map(s => s.trim()).filter(s => s);
-                dnsServers.push(...servers);
+        // 1. Try GetInfo (WAN). Some FritzBox firmwares reject GetInfo on
+        //    the detected WAN service with UPnP 401 "Invalid Action". This
+        //    must stay self-contained: when the call threw straight to the
+        //    outer catch it skipped the AVM + LAN fallbacks below (steps
+        //    2/3) entirely AND logged "Failed to get DNS servers" on every
+        //    poll (once a minute). It's also redundant — the Lua interface
+        //    (step 0) already yields the upstream DNS on those boxes — so a
+        //    miss here is silent and we fall through to the other methods.
+        try {
+            const infoXml = await this.soapRequest('GetInfo', {}, undefined, undefined, true);
+            if (infoXml) {
+                const dnsStr = this.extractValue(infoXml, 'NewDNSServers');
+                if (dnsStr) {
+                    const servers = dnsStr.split(',').map(s => s.trim()).filter(s => s);
+                    dnsServers.push(...servers);
+                }
             }
+        } catch {
+            // GetInfo unsupported on this service/firmware — fall through to
+            // X_AVM-DE_GetDNSServer (step 2) and LANHostConfigManagement (step 3).
         }
 
         // 2. Try X_AVM-DE_GetDNSServer (WAN) - if available
@@ -563,10 +572,13 @@ export class FritzBoxClient {
         // Deduplicate
         dnsServers = Array.from(new Set(dnsServers));
         
+        // Steady-state poll value (gateway poller runs this once a minute) —
+        // the servers are surfaced in the network twin/UI, so log at debug to
+        // avoid a recurring journal line either way.
         if (dnsServers.length > 0) {
-            logger.info('FritzBox', `Found DNS Servers: ${dnsServers.join(', ')}`);
+            logger.debug('FritzBox', `Found DNS Servers: ${dnsServers.join(', ')}`);
         } else {
-            logger.warn('FritzBox', 'No DNS servers found via discover service.');
+            logger.debug('FritzBox', 'No DNS servers found via discover service.');
         }
 
     } catch (e) {

--- a/templates/media/user-guide.md
+++ b/templates/media/user-guide.md
@@ -1,6 +1,6 @@
 ---
 # The `media` template hosts two services on different subdomains —
-# Audiobookshelf at <books>.<domain> and Navidrome at <music>.<domain>.
+# Audiobookshelf at <books>.<domain> and Jellyfin at <music>.<domain>.
 # One card per service so the family-portal "Open" button per row
 # routes to the right place.
 cards:
@@ -18,30 +18,30 @@ cards:
         platforms: ["ios", "android"]
         note: "Official audiobook + podcast player. Bookmarks + progress sync between phone and tablet."
 
-  - subdomain_var: "NAVIDROME_SUBDOMAIN"
+  - subdomain_var: "MEDIA_SUBDOMAIN"
     label: "Music"
     lucide_icon: "music"
-    tagline: "Stream your music collection — works with every Subsonic-compatible client."
+    tagline: "Stream your music collection — pair mobile apps with Quick Connect, no shared password needed."
     recommended_apps:
       - name: "Symfonium"
         url: "https://symfonium.app/"
         platforms: ["android"]
-        note: "Best Subsonic-compatible music client on Android — paid, but worth it for car audio + offline play."
-      - name: "play:Sub"
-        url: "https://apps.apple.com/app/play-sub-music-streamer/id955329386"
+        note: "Polished music client with first-class Jellyfin support — great for car audio + offline play. Paid, but worth it."
+      - name: "Streamyfin"
+        url: "https://apps.apple.com/app/streamyfin/id6593660679"
         platforms: ["ios"]
-        note: "Highly-rated Subsonic music client for iPhone — the iOS counterpart to Symfonium."
-      - name: "Sonixd"
-        url: "https://github.com/jeffvli/sonixd"
-        platforms: ["desktop"]
-        note: "Cross-platform Subsonic desktop client — great for big libraries on a laptop."
+        note: "Native Jellyfin client for iPhone — music and video, with Quick Connect pairing."
+      - name: "Findroid"
+        url: "https://github.com/jarnedemeulemeester/findroid"
+        platforms: ["android"]
+        note: "Clean open-source Jellyfin client focused on video — pairs with the same Quick Connect flow."
 ---
 
 # Getting started with Media
 
 Two services live behind this card:
 - **Audiobookshelf** for audiobooks and podcasts.
-- **Navidrome** for music.
+- **Jellyfin** for music (and optionally video and photos later).
 
 Both have polished mobile apps that work offline once content is downloaded.
 
@@ -54,21 +54,21 @@ Both have polished mobile apps that work offline once content is downloaded.
 
 Bookmarks, playback position, and listening history sync between devices — start in the car, finish on the couch.
 
-## Music (Navidrome)
+## Music (Jellyfin)
 
-Navidrome serves your music collection over a protocol called **Subsonic**, which means dozens of apps work with it. Recommended:
+Jellyfin serves your music collection (and video/photos if you add those libraries). Pick a client and pair it with **Quick Connect** — no shared password to type on the phone:
 
-- **Symfonium** (Android) — fast, polished, plays nicely with Bluetooth car audio. Paid app but worth it.
-- **play:Sub** (iOS) — most-recommended Subsonic client on iPhone.
-- **Browser** — Navidrome's web UI is good and works on every device without an app install.
+- **Symfonium** (Android) — fast, polished music client with great Jellyfin support and Bluetooth car audio. Paid app but worth it.
+- **Streamyfin** (iOS) — native Jellyfin client for iPhone, music and video.
+- **Browser** — Jellyfin's web UI works on every device without an app install.
 
-In the app, configure a **Subsonic** server with the URL from the *Open* button (e.g. `http://music.home.arpa`) and the family credentials.
+**Pairing with Quick Connect:** open the Jellyfin app → *Quick Connect* → the app shows a 6-digit code → open Jellyfin web (signed in) → *Dashboard → Quick Connect* → enter the code. The app is paired — no password shared. (For SSO on the web login, the admin can install `jellyfin-plugin-sso` later.)
 
 ## Adding content
 
-The admin drops audiobooks/podcasts into the server's **Audiobookshelf library folder** (browse via the *Files* card / Samba) and music into the **Navidrome music folder**. Both services pick up new files within a minute or two — no manual import.
+The admin drops audiobooks/podcasts into the server's **Audiobookshelf library folder** and music into the **file-share `music/` folder** (browse via the *Files* card / Samba). Jellyfin's library scan picks up `music/` automatically; Audiobookshelf picks up new files within a minute or two — no manual import. Other folders (`movies/`, `tv/`, `photos/`) the admin adds as Jellyfin libraries under *Dashboard → Libraries*.
 
 ## Tips
 
-- **Offline downloads are per-device.** Downloading a book on your phone doesn't take it off the server; it's just cached locally.
+- **Offline downloads are per-device.** Downloading a book or album on your phone doesn't take it off the server; it's just cached locally.
 - **Multiple users keep separate progress.** Each family member's listening position, bookmarks, and finished/unfinished list is private to them.


### PR DESCRIPTION
Three log-noise / portal-correctness fixes surfaced by reading the live box logs (all benign today, but each spams the journal or hides a real value).

### `fix(fritzbox)` — stop the per-minute "Failed to get DNS servers" SOAP 500
The WAN `GetInfo` DNS probe threw straight to the outer catch on this firmware (UPnP 401 *Invalid Action*), which (a) skipped the AVM + LAN DNS fallbacks entirely and (b) logged a WARN **once a minute** (315× over ~5h). It's also redundant — the Lua interface (step 0) already returns the upstream DNS, which is what the network twin/UI shows. Now silent + self-contained; steady-state DNS result log dropped to `debug`.

### `fix(agent)` — 90s timeout for the cold-boot reconnect refresh
The first `refresh` after a cold boot gathers full state for every stack (`podman inspect` per container) over the single SSH channel, which legitimately exceeds the default 30s on a box with ~14 services → a one-off `Command timeout for 'refresh'` on every boot. It's fire-and-forget and the poller retries, so 90s just removes the spurious cold-start error.

### `fix(media)` — portal user-guide Navidrome → Jellyfin
The v3→v4 music-server swap updated `template.yml`/`variables.json`/`README.md` but **missed `user-guide.md`**, which still declared a `NAVIDROME_SUBDOMAIN` portal card. That variable no longer exists, so the portal logged `couldn't resolve a URL — skipping` on every render. Card now points at `MEDIA_SUBDOMAIN`; prose rewritten for Jellyfin + Quick Connect.

**Tests:** lint 0 errors; `template_consistency` (65), `buildProxyHosts` (13), portal suites (45) all green.

**Separately (not in this PR):** removed the dead `mdopp/servicebay-templates` registry from the box's stored `config.json` (the boot-time `git clone` 404 — the code already stopped seeding it; this was stale persisted state). `oscar` registry kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
