### PR TITLE
fix(externalBackup): cd-then-list for FritzBox FTP (empty NAS backup list broke reinstall auto-restore)

### DIFF
--- a/packages/backend/src/lib/externalBackup/nasClient.test.ts
+++ b/packages/backend/src/lib/externalBackup/nasClient.test.ts
@@ -8,6 +8,7 @@ const { mockClient, mockGetConfig } = vi.hoisted(() => ({
     uploadFrom: vi.fn(),
     downloadTo: vi.fn(),
     list: vi.fn(),
+    cd: vi.fn(),
     remove: vi.fn(),
     close: vi.fn(),
   },
@@ -30,6 +31,7 @@ beforeEach(() => {
   mockClient.uploadFrom.mockResolvedValue(undefined);
   mockClient.downloadTo.mockImplementation(async (sink: NodeJS.WritableStream) => { sink.write(Buffer.from('hello')); });
   mockClient.list.mockResolvedValue([{ name: 'x.tar', size: 10 }]);
+  mockClient.cd.mockResolvedValue(undefined);
   mockClient.remove.mockResolvedValue(undefined);
 });
 
@@ -67,9 +69,17 @@ describe('nas operations', () => {
     expect(buf.toString()).toBe('hello');
     expect(mockClient.downloadTo).toHaveBeenCalled();
   });
-  it('lists a directory', async () => {
+  it('lists a directory by cd-then-bare-list (FritzBox ignores LIST <path>)', async () => {
     expect(await nasList('sb-backup')).toEqual([{ name: 'x.tar', size: 10 }]);
-    expect(mockClient.list).toHaveBeenCalledWith('sb-backup');
+    // Must cd into the dir then list() with no arg — a path arg returns the
+    // root on FritzBox FTP, which silently hid every staged backup.
+    expect(mockClient.cd).toHaveBeenCalledWith('sb-backup');
+    expect(mockClient.list).toHaveBeenCalledWith();
+  });
+  it('lists the root without a cd when no dir is given', async () => {
+    await nasList();
+    expect(mockClient.cd).not.toHaveBeenCalled();
+    expect(mockClient.list).toHaveBeenCalledWith();
   });
   it('removes a file idempotently', async () => {
     await nasRemove('/sb-backup/x.tar');

--- a/packages/backend/src/lib/externalBackup/nasClient.ts
+++ b/packages/backend/src/lib/externalBackup/nasClient.ts
@@ -100,10 +100,21 @@ export async function nasDownload(remotePath: string): Promise<Buffer> {
   });
 }
 
-/** List a directory (relative to the NAS root). */
+/** List a directory (relative to the NAS root).
+ *
+ * FritzBox's FTP server IGNORES a path argument to `LIST` — `client.list('sb-backup')`
+ * returns the ROOT listing, not the subdir's contents. That silently made every
+ * staged backup invisible (`listServiceBackups` filtered the root for `.tar`,
+ * found none → empty), which in turn meant the reinstall auto-restore (#1218,
+ * gated on `listServiceBackups`) never fired even with a backup present. `cd`
+ * into the directory first, then bare `list()`. `withClient` opens a fresh
+ * connection per call, so there's no working dir to restore afterwards. */
 export async function nasList(dir = ''): Promise<FileInfo[]> {
   const clean = dir.replace(/^\/+/, '');
-  return withClient(client => client.list(clean || undefined));
+  return withClient(async client => {
+    if (clean) await client.cd(clean);
+    return client.list();
+  });
 }
 
 /** Remove a file (relative to the NAS root). Idempotent — a missing file


### PR DESCRIPTION
## The bug
A backup uploaded via `sb` (and visible at `/sb-backup/home-assistant.tar` over raw FTP) showed up as **nothing** on the box: `GET /api/system/external-backup/list` → `backups:[]`. Root cause: **FritzBox's FTP server ignores a path argument to `LIST`** and returns the *root* directory regardless. `nasList('sb-backup')` did `client.list('sb-backup')`, got the root (Bilder, Dokumente, …, sb-backup), filtered for `.tar`, found none → `[]`.

Confirmed against the real FritzBox NAS:
```
list("sb-backup")  -> [Bilder, Dokumente, FRITZ, Musik, Videos, sb-backup]   ← root!
cd("sb-backup")+list() -> [home-assistant.tar, home-assistant.tar.meta.json] ← correct
```

## Why it mattered (beyond a cosmetic empty list)
`autoRestoreServiceOnReinstall` (#1218) gates on `listServiceBackups()`. With the list always empty, **the reinstall auto-restore never fired** — a staged config silently failed to restore on a fresh install, even though `restoreServiceBackup` (fetch-by-name) works fine. Restoring HA's config from the NAS *manually* works; the *automatic* reinstall path was dead.

## The fix
`nasList(dir)` now `cd`s into the directory then calls bare `list()` (a fresh FTP connection per call, so there's no cwd to restore). +2 unit tests pinning cd-then-list and the no-cd root case. Download/upload already used by-path operations that the FritzBox honours, so they were unaffected.

Verified end-to-end: with the NAS source registered on the box, a manual `restore {service:"home-assistant", force:true}` pulled the backup and extracted 9 config files. This fix makes the same backup *discoverable*, so the reinstall auto-restore will fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
