### PR TITLE
feat: wipe-configs UX, BasicSync portal, domain-check collapse, backup-sync sources

### DIFF
--- a/packages/backend/src/lib/backup/service.ts
+++ b/packages/backend/src/lib/backup/service.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { BackupConfig, BackupRunResult, BackupTarget } from './types';
+import { BackupConfig, BackupRunResult, BackupSource, BackupTarget, resolveBackupSources } from './types';
 import { getConfig, updateConfig } from '../config';
 import { logger } from '../logger';
 import { DATA_DIR } from '../dirs';
@@ -56,7 +56,25 @@ async function appendHistory(result: BackupRunResult): Promise<void> {
 
 // ─── Target Resolution ───────────────────────────────────────────────
 
-function buildRsyncArgs(source: string, target: BackupTarget, excludePatterns: string[]): { args: string[]; mountPath?: string; cleanup?: () => Promise<void> } {
+function withTrailingSlash(p: string): string {
+    return p.endsWith('/') ? p : `${p}/`;
+}
+
+// Append a per-source subfolder to a target path. With a single source we
+// keep the legacy flat layout (subFolder undefined) so existing backups
+// aren't orphaned; with multiple sources each gets its own subdirectory so
+// rsync `--delete` can't wipe a sibling source's data.
+function joinTargetPath(base: string, subFolder?: string): string {
+    return subFolder ? path.posix.join(base, subFolder) : base;
+}
+
+function buildRsyncArgs(
+    source: string,
+    target: BackupTarget,
+    excludePatterns: string[],
+    subFolder?: string,
+    mountPath?: string,
+): { args: string[]; mountPath?: string } {
     const args = [
         '-az',
         '--delete',
@@ -70,28 +88,30 @@ function buildRsyncArgs(source: string, target: BackupTarget, excludePatterns: s
     }
 
     // Ensure source ends with /
-    const src = source.endsWith('/') ? source : `${source}/`;
+    const src = withTrailingSlash(source);
 
     switch (target.type) {
         case 'local': {
-            args.push(src, target.path.endsWith('/') ? target.path : `${target.path}/`);
+            args.push(src, withTrailingSlash(joinTargetPath(target.path, subFolder)));
             return { args };
         }
         case 'ssh': {
             const sshCmd = buildSSHCommand(target);
             args.push('-e', sshCmd);
-            const remotePath = target.path.endsWith('/') ? target.path : `${target.path}/`;
+            const remotePath = withTrailingSlash(joinTargetPath(target.path, subFolder));
             args.push(src, `${target.user}@${target.host}:${remotePath}`);
             return { args };
         }
         case 'smb':
         case 'nfs': {
-            // These get mounted first; rsync targets the mount point
-            const mountPath = path.join(SMB_MOUNT_BASE, `backup-${Date.now()}`);
-            const subPath = target.type === 'smb' ? target.path : target.path;
-            const fullTarget = subPath ? path.join(mountPath, subPath) : mountPath;
-            args.push(src, fullTarget.endsWith('/') ? fullTarget : `${fullTarget}/`);
-            return { args, mountPath };
+            // These get mounted first; rsync targets the mount point. The
+            // mount is shared across sources within one run (passed in).
+            const resolvedMount = mountPath ?? path.join(SMB_MOUNT_BASE, `backup-${Date.now()}`);
+            const subPath = target.path;
+            const baseTarget = subPath ? path.join(resolvedMount, subPath) : resolvedMount;
+            const fullTarget = joinTargetPath(baseTarget, subFolder);
+            args.push(src, withTrailingSlash(fullTarget));
+            return { args, mountPath: resolvedMount };
         }
     }
 }
@@ -184,67 +204,52 @@ async function ensureTargetDir(target: BackupTarget): Promise<void> {
 
 // ─── Main Run ────────────────────────────────────────────────────────
 
-async function executeRsyncBackup(
-    args: string[],
-    config: BackupConfig,
-    startedAt: Date,
-    mountPath?: string,
-    previousStatus?: 'success' | 'error'
-): Promise<{ result: BackupRunResult; mountCleanup?: () => Promise<void> }> {
-    let mountCleanup: (() => Promise<void>) | undefined;
-
-    try {
-        // Mount if needed
-        if (mountPath && (config.target.type === 'smb' || config.target.type === 'nfs')) {
-            logger.info('Backup', `Mounting ${config.target.type} target at ${mountPath}`);
-            await mountTarget(config.target, mountPath);
-            mountCleanup = () => unmountTarget(mountPath);
-        }
-
-        // Ensure target directory exists
-        await ensureTargetDir(config.target);
-
-        // Run rsync
-        logger.info('Backup', `Running: rsync ${args.join(' ')}`);
-        const { stdout, stderr } = await execFileAsync('rsync', args, {
-            timeout: 24 * 60 * 60 * 1000, // 24h max
-            maxBuffer: 10 * 1024 * 1024, // 10MB
-        });
-
-        const completedAt = new Date();
-        const duration = Math.round((completedAt.getTime() - startedAt.getTime()) / 1000);
-        const stats = parseRsyncStats(stdout);
-
-        if (stderr && stderr.trim()) {
-            logger.warn('Backup', `rsync stderr: ${stderr.trim()}`);
-        }
-
-        const result: BackupRunResult = {
-            success: true,
-            startedAt: startedAt.toISOString(),
-            completedAt: completedAt.toISOString(),
-            duration,
-            message: `Backup completed. ${stats.filesTransferred ?? '?'} files synced.`,
-            ...stats,
-        };
-
-        logger.info('Backup', result.message);
-        await appendHistory(result);
-        await updateBackupStatus(true, result.message, duration);
-
-        // Send recovery email if previous run failed
-        if (previousStatus === 'error') {
-            sendEmailAlert(
-                'Backup Recovered',
-                `Backup sync has recovered.\n\n${result.message}\nDuration: ${duration}s\nTarget: ${describeTarget(config.target)}`
-            ).catch(e => logger.warn('Backup', `Failed to send recovery email: ${e}`));
-        }
-
-        return { result, mountCleanup };
-    } catch (error) {
-        if (mountCleanup) await mountCleanup();
-        throw error;
+// Assign each source a stable, unique subfolder name under the target.
+// With a single source we keep the legacy flat layout (no subfolder).
+// With multiple sources we use the basename, disambiguating collisions
+// (e.g. two `data` dirs) with a numeric suffix.
+export function assignSourceSubFolders(sources: BackupSource[]): { source: BackupSource; subFolder?: string }[] {
+    if (sources.length <= 1) {
+        return sources.map(source => ({ source }));
     }
+    const used = new Set<string>();
+    return sources.map(source => {
+        const base = path.basename(source.path.replace(/\/+$/, '')) || 'root';
+        let name = base;
+        let n = 2;
+        while (used.has(name)) {
+            name = `${base}-${n++}`;
+        }
+        used.add(name);
+        return { source, subFolder: name };
+    });
+}
+
+// Run rsync for one source and return its parsed stats. Mounting and the
+// shared mount cleanup are the caller's responsibility.
+async function rsyncOneSource(
+    source: BackupSource,
+    target: BackupTarget,
+    subFolder: string | undefined,
+    mountPath: string | undefined,
+): Promise<{ bytesTransferred?: number; filesTransferred?: number }> {
+    try {
+        await fs.access(source.path);
+    } catch {
+        throw new Error(`Source path does not exist: ${source.path}`);
+    }
+
+    const { args } = buildRsyncArgs(source.path, target, source.excludePatterns || [], subFolder, mountPath);
+
+    logger.info('Backup', `Running: rsync ${args.join(' ')}`);
+    const { stdout, stderr } = await execFileAsync('rsync', args, {
+        timeout: 24 * 60 * 60 * 1000, // 24h max
+        maxBuffer: 10 * 1024 * 1024, // 10MB
+    });
+    if (stderr && stderr.trim()) {
+        logger.warn('Backup', `rsync stderr: ${stderr.trim()}`);
+    }
+    return parseRsyncStats(stdout);
 }
 
 async function runBackupItems(
@@ -252,29 +257,73 @@ async function runBackupItems(
     startedAt: Date,
     previousStatus: 'success' | 'error' | undefined
 ): Promise<BackupRunResult> {
-    logger.info('Backup', `Starting backup: ${config.sourcePath} → ${describeTarget(config.target)}`);
+    const sources = resolveBackupSources(config);
+    if (sources.length === 0) {
+        throw new Error('No backup sources configured');
+    }
+    logger.info('Backup', `Starting backup: ${sources.map(s => s.path).join(', ')} → ${describeTarget(config.target)}`);
 
-    // Verify source exists
-    try {
-        await fs.access(config.sourcePath);
-    } catch {
-        throw new Error(`Source path does not exist: ${config.sourcePath}`);
+    const assigned = assignSourceSubFolders(sources);
+
+    // Mount once per run (smb/nfs); reused across every source.
+    let mountCleanup: (() => Promise<void>) | undefined;
+    let sharedMountPath: string | undefined;
+    if (config.target.type === 'smb' || config.target.type === 'nfs') {
+        sharedMountPath = path.join(SMB_MOUNT_BASE, `backup-${Date.now()}`);
+        logger.info('Backup', `Mounting ${config.target.type} target at ${sharedMountPath}`);
+        await mountTarget(config.target, sharedMountPath);
+        mountCleanup = () => unmountTarget(sharedMountPath!);
     }
 
-    // Build rsync command
-    const { args, mountPath } = buildRsyncArgs(
-        config.sourcePath,
-        config.target,
-        config.excludePatterns || []
-    );
-
-    const { result, mountCleanup } = await executeRsyncBackup(args, config, startedAt, mountPath, previousStatus);
-
     try {
-        return result;
+        await ensureTargetDir(config.target);
+
+        let totalBytes = 0;
+        let totalFiles = 0;
+        for (const { source, subFolder } of assigned) {
+            const stats = await rsyncOneSource(source, config.target, subFolder, sharedMountPath);
+            totalBytes += stats.bytesTransferred ?? 0;
+            totalFiles += stats.filesTransferred ?? 0;
+        }
+
+        return await recordBackupSuccess(config, startedAt, sources.length, totalBytes, totalFiles, previousStatus);
     } finally {
         if (mountCleanup) await mountCleanup();
     }
+}
+
+async function recordBackupSuccess(
+    config: BackupConfig,
+    startedAt: Date,
+    sourceCount: number,
+    totalBytes: number,
+    totalFiles: number,
+    previousStatus: 'success' | 'error' | undefined,
+): Promise<BackupRunResult> {
+    const completedAt = new Date();
+    const duration = Math.round((completedAt.getTime() - startedAt.getTime()) / 1000);
+    const result: BackupRunResult = {
+        success: true,
+        startedAt: startedAt.toISOString(),
+        completedAt: completedAt.toISOString(),
+        duration,
+        message: `Backup completed. ${totalFiles} files synced from ${sourceCount} source${sourceCount === 1 ? '' : 's'}.`,
+        bytesTransferred: totalBytes,
+        filesTransferred: totalFiles,
+    };
+
+    logger.info('Backup', result.message);
+    await appendHistory(result);
+    await updateBackupStatus(true, result.message, duration);
+
+    if (previousStatus === 'error') {
+        sendEmailAlert(
+            'Backup Recovered',
+            `Backup sync has recovered.\n\n${result.message}\nDuration: ${duration}s\nTarget: ${describeTarget(config.target)}`
+        ).catch(e => logger.warn('Backup', `Failed to send recovery email: ${e}`));
+    }
+
+    return result;
 }
 
 async function loadBackupConfig(config?: BackupConfig): Promise<{ config: BackupConfig; previousStatus?: 'success' | 'error' }> {

--- a/packages/backend/src/lib/backup/service.ts
+++ b/packages/backend/src/lib/backup/service.ts
@@ -68,7 +68,7 @@ function joinTargetPath(base: string, subFolder?: string): string {
     return subFolder ? path.posix.join(base, subFolder) : base;
 }
 
-function buildRsyncArgs(
+export function buildRsyncArgs(
     source: string,
     target: BackupTarget,
     excludePatterns: string[],

--- a/packages/backend/src/lib/backup/sources.test.ts
+++ b/packages/backend/src/lib/backup/sources.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Multi-source Backup Sync (#1554): the config carries an operator-editable
+ * `sources[]` list (dirs + per-source .gitignore-style excludes). Older
+ * configs carry the legacy single `sourcePath`/`excludePatterns` pair, which
+ * must fold into a one-element list. Multiple sources rsync into distinct
+ * subfolders under the target so per-source `--delete` can't collide.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveBackupSources, type BackupConfig } from './types';
+import { assignSourceSubFolders } from './service';
+
+const base: Omit<BackupConfig, 'sources' | 'sourcePath' | 'excludePatterns'> = {
+  enabled: true,
+  schedule: 'daily',
+  time: '02:00',
+  target: { type: 'local', path: '/mnt/backup' },
+};
+
+describe('resolveBackupSources', () => {
+  it('returns the new sources[] when present', () => {
+    const config: BackupConfig = {
+      ...base,
+      sources: [
+        { path: '/mnt/data', excludePatterns: ['*.tmp'] },
+        { path: '/mnt/media' },
+      ],
+    };
+    expect(resolveBackupSources(config)).toEqual([
+      { path: '/mnt/data', excludePatterns: ['*.tmp'] },
+      { path: '/mnt/media' },
+    ]);
+  });
+
+  it('migrates the legacy single sourcePath/excludePatterns pair', () => {
+    const config: BackupConfig = {
+      ...base,
+      sourcePath: '/mnt/data',
+      excludePatterns: ['*.log'],
+    };
+    expect(resolveBackupSources(config)).toEqual([
+      { path: '/mnt/data', excludePatterns: ['*.log'] },
+    ]);
+  });
+
+  it('drops blank source paths and returns [] when nothing is configured', () => {
+    expect(resolveBackupSources({ ...base, sources: [{ path: '  ' }] })).toEqual([]);
+    expect(resolveBackupSources({ ...base })).toEqual([]);
+  });
+});
+
+describe('assignSourceSubFolders', () => {
+  it('keeps a single source flat (no subfolder) for backward compatibility', () => {
+    const assigned = assignSourceSubFolders([{ path: '/mnt/data' }]);
+    expect(assigned).toEqual([{ source: { path: '/mnt/data' } }]);
+  });
+
+  it('gives each source its own basename subfolder when there is more than one', () => {
+    const assigned = assignSourceSubFolders([
+      { path: '/mnt/data' },
+      { path: '/mnt/media/' },
+    ]);
+    expect(assigned.map(a => a.subFolder)).toEqual(['data', 'media']);
+  });
+
+  it('disambiguates colliding basenames with a numeric suffix', () => {
+    const assigned = assignSourceSubFolders([
+      { path: '/mnt/data' },
+      { path: '/srv/data' },
+      { path: '/var/data' },
+    ]);
+    expect(assigned.map(a => a.subFolder)).toEqual(['data', 'data-2', 'data-3']);
+  });
+});

--- a/packages/backend/src/lib/backup/sources.test.ts
+++ b/packages/backend/src/lib/backup/sources.test.ts
@@ -6,8 +6,8 @@
  * subfolders under the target so per-source `--delete` can't collide.
  */
 import { describe, it, expect } from 'vitest';
-import { resolveBackupSources, type BackupConfig } from './types';
-import { assignSourceSubFolders } from './service';
+import { resolveBackupSources, type BackupConfig, type BackupTarget } from './types';
+import { assignSourceSubFolders, buildRsyncArgs } from './service';
 
 const base: Omit<BackupConfig, 'sources' | 'sourcePath' | 'excludePatterns'> = {
   enabled: true,
@@ -69,5 +69,57 @@ describe('assignSourceSubFolders', () => {
       { path: '/var/data' },
     ]);
     expect(assigned.map(a => a.subFolder)).toEqual(['data', 'data-2', 'data-3']);
+  });
+});
+
+describe('buildRsyncArgs', () => {
+  const flags = ['-az', '--delete', '--stats', '--human-readable', '--timeout=300'];
+
+  it('always opens with the standard rsync flags and a trailing-slash source', () => {
+    const { args } = buildRsyncArgs('/mnt/data', { type: 'local', path: '/mnt/backup' }, []);
+    expect(args.slice(0, flags.length)).toEqual(flags);
+    // source is normalised to end with a slash (rsync dir-contents semantics)
+    expect(args).toContain('/mnt/data/');
+  });
+
+  it('injects an --exclude pair per pattern', () => {
+    const { args } = buildRsyncArgs('/mnt/data', { type: 'local', path: '/mnt/backup' }, ['*.tmp', 'cache/']);
+    expect(args).toContain('--exclude');
+    expect(args.filter(a => a === '--exclude')).toHaveLength(2);
+    expect(args).toContain('*.tmp');
+    expect(args).toContain('cache/');
+  });
+
+  it('local target: appends the subfolder and trailing slash, no mountPath', () => {
+    const flat = buildRsyncArgs('/mnt/data', { type: 'local', path: '/mnt/backup' }, []);
+    expect(flat.args[flat.args.length - 1]).toBe('/mnt/backup/');
+    expect(flat.mountPath).toBeUndefined();
+
+    const sub = buildRsyncArgs('/mnt/data', { type: 'local', path: '/mnt/backup' }, [], 'data');
+    expect(sub.args[sub.args.length - 1]).toBe('/mnt/backup/data/');
+  });
+
+  it('ssh target: builds the user@host:path destination with an -e ssh command', () => {
+    const target: BackupTarget = { type: 'ssh', host: 'nas.local', user: 'sb', path: '/srv/bk', port: 2222 };
+    const { args } = buildRsyncArgs('/mnt/data', target, [], 'media');
+    expect(args).toContain('-e');
+    const sshCmd = args[args.indexOf('-e') + 1];
+    expect(sshCmd).toContain('ssh');
+    expect(sshCmd).toContain('-p 2222');
+    expect(args[args.length - 1]).toBe('sb@nas.local:/srv/bk/media/');
+  });
+
+  it('smb target: targets the shared mount point + optional sub-path + subfolder, returns mountPath', () => {
+    const target: BackupTarget = { type: 'smb', host: 'nas', share: 'backups', path: 'sb' };
+    const { args, mountPath } = buildRsyncArgs('/mnt/data', target, [], 'data', '/tmp/mnt-1');
+    expect(mountPath).toBe('/tmp/mnt-1');
+    expect(args[args.length - 1]).toBe('/tmp/mnt-1/sb/data/');
+  });
+
+  it('nfs target without a sub-path: rsyncs straight into the mount + subfolder', () => {
+    const target: BackupTarget = { type: 'nfs', host: 'nas', export: '/export/bk' };
+    const { args, mountPath } = buildRsyncArgs('/mnt/media/', target, [], undefined, '/tmp/mnt-2');
+    expect(mountPath).toBe('/tmp/mnt-2');
+    expect(args[args.length - 1]).toBe('/tmp/mnt-2/');
   });
 });

--- a/packages/backend/src/lib/backup/types.ts
+++ b/packages/backend/src/lib/backup/types.ts
@@ -8,6 +8,16 @@ export type BackupTarget =
 
 export type BackupSchedule = 'hourly' | 'daily' | 'weekly' | 'monthly';
 
+/**
+ * A single sync source: a directory to back up plus .gitignore-style
+ * exclude patterns scoped to that directory. Each source rsyncs into its
+ * own subfolder under the target so per-source `--delete` can't collide.
+ */
+export interface BackupSource {
+    path: string;            // e.g. /mnt/data
+    excludePatterns?: string[];
+}
+
 export interface BackupConfig {
     enabled: boolean;
     schedule: BackupSchedule;
@@ -15,12 +25,31 @@ export interface BackupConfig {
     dayOfWeek?: number; // 0-6 (Sun-Sat), for weekly
     dayOfMonth?: number; // 1-28, for monthly
     target: BackupTarget;
-    sourcePath: string; // e.g. /mnt/data
+    /** Operator-configurable list of source dirs + per-source excludes. */
+    sources?: BackupSource[];
+    /** @deprecated legacy single-source fields; migrated to `sources` on read. */
+    sourcePath?: string; // e.g. /mnt/data
+    /** @deprecated legacy single-source excludes; migrated to `sources` on read. */
     excludePatterns?: string[];
     lastRun?: string;
     lastStatus?: 'success' | 'error';
     lastMessage?: string;
     lastDuration?: number; // seconds
+}
+
+/**
+ * Normalize a config to its source list. New configs carry `sources`;
+ * configs written before the multi-source change carry the legacy
+ * `sourcePath`/`excludePatterns` pair — fold those into a one-element list.
+ */
+export function resolveBackupSources(config: BackupConfig): BackupSource[] {
+    if (config.sources && config.sources.length > 0) {
+        return config.sources.filter(s => s.path && s.path.trim());
+    }
+    if (config.sourcePath && config.sourcePath.trim()) {
+        return [{ path: config.sourcePath, excludePatterns: config.excludePatterns }];
+    }
+    return [];
 }
 
 export interface BackupRunResult {

--- a/packages/backend/src/lib/diagnose/probes/domainExternalReachability.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainExternalReachability.test.ts
@@ -63,15 +63,18 @@ const NOW = Date.UTC(2026, 4, 15, 12, 0, 0);
 const isoNow = () => new Date(NOW).toISOString();
 const isoAgo = (ms: number) => new Date(NOW - ms).toISOString();
 
-function makeDnsRoutingCheck(domain: string): CheckConfig {
+// #1564 — the per-domain dns_routing rows collapsed into the canonical
+// `domain` check, which carries the DoH DNS-routing payload on its result.
+function makeDomainCheck(domain: string): CheckConfig {
   return {
-    id: `dns_routing:${domain}`,
-    name: `DNS routing — ${domain}`,
-    type: 'dns_routing',
+    id: `domain:${domain}`,
+    name: `Domain — ${domain}`,
+    type: 'domain',
     target: domain,
-    interval: 900,
+    interval: 60,
     enabled: true,
     created_at: isoNow(),
+    domainConfig: { expectedScheme: 'https', isPublic: true },
   };
 }
 
@@ -95,8 +98,8 @@ beforeEach(() => {
     },
   };
   state.checks = [
-    makeDnsRoutingCheck('one.example.com'),
-    makeDnsRoutingCheck('two.example.com'),
+    makeDomainCheck('one.example.com'),
+    makeDomainCheck('two.example.com'),
   ];
   state.results.clear();
   state.runOutcome = { status: 'ok', message: '', payload: undefined };
@@ -132,14 +135,14 @@ describe('checkDomainExternalReachability', () => {
   });
 
   it('omits healthy rows when DNS matches the gateway IP and reports overall ok', async () => {
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -151,14 +154,14 @@ describe('checkDomainExternalReachability', () => {
   });
 
   it('flags a domain whose A record points at a different IP as fail', async () => {
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(60_000),
       status: 'fail',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['198.51.100.7'], matched: false }),
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -172,14 +175,14 @@ describe('checkDomainExternalReachability', () => {
   });
 
   it('flags a domain with no public A record as fail', async () => {
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(60_000),
       status: 'fail',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: [], matched: false }),
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -191,14 +194,14 @@ describe('checkDomainExternalReachability', () => {
   });
 
   it('surfaces transport errors (no payload, fail status) as info rows', async () => {
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(30_000),
       status: 'fail',
       message: 'DoH lookup failed: connect ETIMEDOUT',
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(30_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -211,14 +214,14 @@ describe('checkDomainExternalReachability', () => {
 
   it('#611 — flags DNS-green + HTTP-fail combo (the v4.0.x outage shape)', async () => {
     // DNS is healthy for both domains.
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -243,14 +246,14 @@ describe('checkDomainExternalReachability', () => {
 
   it('#611 — accepts 302 → auth.<publicDomain> as a healthy redirect (forward-auth)', async () => {
     state.config.reverseProxy.publicDomain = 'example.com';
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -264,8 +267,8 @@ describe('checkDomainExternalReachability', () => {
   });
 
   it('appends letsdebug summary to a flagged row when one exists', async () => {
-    state.results.set('dns_routing:one.example.com', {
-      check_id: 'dns_routing:one.example.com',
+    state.results.set('domain:one.example.com', {
+      check_id: 'domain:one.example.com',
       timestamp: isoAgo(60_000),
       status: 'fail',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['198.51.100.7'], matched: false }),
@@ -276,8 +279,8 @@ describe('checkDomainExternalReachability', () => {
       status: 'fail',
       payload: letsdebugPayload([{ name: 'ANotWorking', explanation: 'port 80 unreachable', severity: 'fatal' }]),
     });
-    state.results.set('dns_routing:two.example.com', {
-      check_id: 'dns_routing:two.example.com',
+    state.results.set('domain:two.example.com', {
+      check_id: 'domain:two.example.com',
       timestamp: isoAgo(60_000),
       status: 'ok',
       payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
@@ -323,14 +326,14 @@ describe('refresh_now action (DoH)', () => {
   });
 
   it('reports ok:false when the matching check does not exist', async () => {
-    state.checks = state.checks.filter(c => c.id !== 'dns_routing:one.example.com');
+    state.checks = state.checks.filter(c => c.id !== 'domain:one.example.com');
     const r = await dispatchProbeAction({
       probeId: 'domain_unreachable',
       actionId: 'refresh_now', node: 'Local',
       itemId: 'one.example.com',
     });
     expect(r.ok).toBe(false);
-    expect(r.message).toMatch(/No DNS routing check found/);
+    expect(r.message).toMatch(/No domain check found/);
   });
 });
 

--- a/packages/backend/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -2,10 +2,11 @@
  * `domain_external_reachability` probe — surfaces the external view
  * of every public-exposure domain. Composed of two layers:
  *
- *   1. **Continuous: DoH-based DNS routing** (the `dns_routing` health
- *      check). Cheap, free, no third-party rate limits — answers
- *      "does public DNS resolve this domain to my known public IP?"
- *      every 15 min via Cloudflare 1.1.1.1.
+ *   1. **Continuous: DoH-based DNS routing** (carried on the canonical
+ *      `domain` health check since #1564). Cheap, free, no third-party
+ *      rate limits — answers "does public DNS resolve this domain to my
+ *      known public IP?" each time the domain check runs (~every minute)
+ *      via Cloudflare 1.1.1.1.
  *   2. **On-demand: letsdebug.net** (`run_letsdebug` action below).
  *      The full taxonomy — CAA records, port-80 HTTP-01 simulation,
  *      DNSSEC drift, ACME readiness — for when DNS looks right but
@@ -39,7 +40,10 @@ import { logger } from '@/lib/logger';
 // "Refresh DNS check" / "Run letsdebug" deep-check actions. Both register
 // under the canonical `domain_unreachable` probe id.
 const PROBE_ID = 'domain_unreachable';
-const DNS_ROUTING_CHECK_PREFIX = 'dns_routing:';
+// #1564 — the per-domain `dns_routing:<domain>` rows were collapsed into
+// the canonical `domain:<domain>` health check, which now carries the
+// DoH DNS-routing payload on its result. Read from the domain check.
+const DOMAIN_CHECK_PREFIX = 'domain:';
 const LETSDEBUG_CHECK_PREFIX = 'letsdebug:';
 
 export interface DomainExternalReachabilityResult {
@@ -248,16 +252,16 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   let pendingCount = 0;
 
   for (const domain of publicDomains) {
-    const dnsResult: CheckResult | null = HealthStore.getLastResult(`${DNS_ROUTING_CHECK_PREFIX}${domain}`);
+    const dnsResult: CheckResult | null = HealthStore.getLastResult(`${DOMAIN_CHECK_PREFIX}${domain}`);
     const letsdebugResult: CheckResult | null = HealthStore.getLastResult(`${LETSDEBUG_CHECK_PREFIX}${domain}`);
 
-    // First-check pending — the dns_routing tick hasn't fired yet.
+    // First-check pending — the domain check tick hasn't fired yet.
     if (!dnsResult) {
       pendingCount++;
       items.push({
         id: domain,
         label: domain,
-        detail: '⏳ First check pending — runs within ~15 min of boot. Click Refresh now to skip the wait.',
+        detail: '⏳ First check pending — runs within ~1 min of boot. Click Refresh now to skip the wait.',
         status: 'info',
         actionIds: ['refresh_now', 'run_letsdebug'],
       });
@@ -267,7 +271,7 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     const dnsAge = ` · Last checked ${formatRelativeAge(Date.parse(dnsResult.timestamp))}`;
     const dnsPayload = decodeDnsRouting(dnsResult.payload);
 
-    // dns_routing transport error → plaintext message, no payload. Surface as info row.
+    // DNS-routing transport error → plaintext message, no payload. Surface as info row.
     if (!dnsPayload && dnsResult.status === 'fail') {
       pendingCount++;
       items.push({
@@ -379,27 +383,27 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
   return {
     status: pendingCount > 0 && overall === 'ok' ? 'info' : overall,
     detail: `${parts.join(' · ')} of ${publicDomains.length} public domain${publicDomains.length === 1 ? '' : 's'}.`,
-    hint: 'DNS routing is checked every 15 min via Cloudflare DoH (no rate limits). For the full ACME / port-80 / CAA taxonomy click "Run letsdebug" on a row — that hits letsdebug.net once on demand.',
+    hint: 'DNS routing is checked on the canonical domain check (~every minute) via Cloudflare DoH (no rate limits). For the full ACME / port-80 / CAA taxonomy click "Run letsdebug" on a row — that hits letsdebug.net once on demand.',
     items,
   };
 }
 
 /**
  * `refresh_now` — operator-initiated single-domain re-probe of the
- * DoH-based `dns_routing` check. Synchronous (sub-second under normal
- * conditions); the UI's auto-refresh picks up the new state without
- * a second click.
+ * canonical `domain` check (which carries the DoH DNS-routing payload
+ * since #1564). Synchronous (sub-second under normal conditions); the
+ * UI's auto-refresh picks up the new state without a second click.
  */
 async function refreshNow({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
   if (!itemId) {
     return { ok: false, message: 'No domain supplied — nothing to refresh.', refresh: false };
   }
-  const checkId = `${DNS_ROUTING_CHECK_PREFIX}${itemId}`;
+  const checkId = `${DOMAIN_CHECK_PREFIX}${itemId}`;
   const check = HealthStore.getChecks().find(c => c.id === checkId);
   if (!check) {
     return {
       ok: false,
-      message: `No DNS routing check found for ${itemId}. It should appear automatically — try reloading.`,
+      message: `No domain check found for ${itemId}. It should appear automatically — try reloading.`,
       refresh: true,
     };
   }

--- a/packages/backend/src/lib/health/dnsRoutingChecks.ts
+++ b/packages/backend/src/lib/health/dnsRoutingChecks.ts
@@ -1,106 +1,34 @@
 /**
- * Auto-managed `dns_routing`-type health checks for every public NPM
- * proxy host. Replaces `letsdebugChecks.ts` as the *continuous*
- * external view; letsdebug stays available as a per-row on-demand
- * action when the operator wants the full CAA / port-80 / ACME
- * simulation taxonomy.
+ * DNS-routing-check migration (#1564).
  *
- * Why we moved off continuous letsdebug:
- *   - letsdebug.net rate-limits by source IP; behind a carrier-NAT
- *     LAN it 429s in practice even at our 4 h cadence (#letsdebug-429).
- *   - The two things operators actually care about continuously are
- *     "does the public DNS still point at me?" and "is my IP
- *     reachable?". DoH answers the first; LE-renewal status (already
- *     covered by `cert_request_failure` / `cert_expiry` checks)
- *     proves the second.
+ * The per-domain `dns_routing:<domain>` rows have been collapsed into the
+ * canonical `domain:<domain>` check (see `domainChecks.ts` + the `domain`
+ * probe), which now subsumes both NPM routing and DoH DNS routing in a
+ * single row per domain. This sync no longer *creates* any checks — it
+ * only prunes the now-defunct `dns_routing:*` rows (and the older
+ * `letsdebug:*` rows) so operators upgrading don't keep stale duplicate
+ * rows in Settings → Health.
  *
- * Convention:
- *   - check.id = `dns_routing:<domain>` so lookups stay deterministic.
- *   - Only public hosts get a check.
- *   - 15-minute interval is plenty cheap — Cloudflare DoH absorbs
- *     household-grade traffic without complaint and the answer
- *     doesn't change minute-to-minute. Operators who want sooner
- *     confirmation click "Refresh now".
- *
- * Cleanup migration: any pre-existing `letsdebug:<domain>` checks
- * are deleted on first sync, so operators upgrading from earlier
- * versions don't end up with stale red rows in Settings → Health.
+ * Best-effort: storage errors are logged and swallowed.
  */
 
 import { HealthStore } from './store';
-import type { CheckConfig } from './types';
-import { getConfig, type ProxyHostEntry } from '../config';
 import { logger } from '../logger';
 
-const DNS_ROUTING_CHECK_INTERVAL_SECONDS = 15 * 60; // 15 min
 const DNS_ROUTING_CHECK_PREFIX = 'dns_routing:';
 const LEGACY_LETSDEBUG_PREFIX = 'letsdebug:';
 
-function isLanDomain(domain: string): boolean {
-  return domain.endsWith('.home.arpa') || domain.endsWith('.local');
-}
-
-function isPublicExposure(entry: ProxyHostEntry): boolean {
-  if (entry.exposure) return entry.exposure === 'public';
-  return !isLanDomain(entry.domain);
-}
-
-function buildCheck(entry: ProxyHostEntry, now: string): CheckConfig {
-  return {
-    id: `${DNS_ROUTING_CHECK_PREFIX}${entry.domain}`,
-    name: `DNS routing — ${entry.domain}`,
-    type: 'dns_routing',
-    target: entry.domain,
-    interval: DNS_ROUTING_CHECK_INTERVAL_SECONDS,
-    enabled: true,
-    created_at: now,
-    nodeName: 'Local',
-  };
-}
-
 /**
- * Walk configured proxy hosts and ensure every public one has a
- * matching `dns_routing` check. Removes checks for hosts that have
- * been deleted or flipped to LAN-only. Also one-shots the cleanup of
- * any legacy `letsdebug:*` checks left over from earlier versions.
- *
- * Best-effort: storage errors are logged and swallowed —
- * external-reachability checks are nice-to-have observability, not
- * load-bearing functionality.
+ * Remove every auto-created `dns_routing:*` check (now subsumed by the
+ * `domain` check) and any leftover legacy `letsdebug:*` check.
  */
-function checkNeedsRefresh(current: CheckConfig, next: CheckConfig): boolean {
-  return !(
-    current.type === next.type
-    && current.target === next.target
-    && current.interval === next.interval
-    && current.enabled === next.enabled
-  );
-}
-
 export async function syncDnsRoutingChecks(): Promise<void> {
   try {
-    const config = await getConfig();
-    const hosts = config.reverseProxy?.hosts ?? [];
     const existing = HealthStore.getChecks();
-    const wanted = new Map<string, ProxyHostEntry>();
-    for (const h of hosts) {
-      if (isPublicExposure(h)) {
-        wanted.set(`${DNS_ROUTING_CHECK_PREFIX}${h.domain}`, h);
-      }
-    }
-
-    const now = new Date().toISOString();
-
-    for (const [id, host] of wanted) {
-      const current = existing.find(c => c.id === id);
-      const next = buildCheck(host, current?.created_at ?? now);
-      if (current && !checkNeedsRefresh(current, next)) continue;
-      HealthStore.saveCheck(next);
-    }
-
     for (const check of existing) {
       if (check.type === 'dns_routing' && check.id.startsWith(DNS_ROUTING_CHECK_PREFIX)) {
-        if (!wanted.has(check.id)) HealthStore.deleteCheck(check.id);
+        logger.info('dnsRoutingChecks', `Pruning collapsed dns_routing check ${check.id} (#1564 — subsumed by domain check)`);
+        HealthStore.deleteCheck(check.id);
         continue;
       }
       if (check.type === 'letsdebug' && check.id.startsWith(LEGACY_LETSDEBUG_PREFIX)) {

--- a/packages/backend/src/lib/health/probes/dnsRouting.ts
+++ b/packages/backend/src/lib/health/probes/dnsRouting.ts
@@ -1,50 +1,64 @@
 /**
- * `dns_routing` probe — resolves the target domain via Cloudflare DoH
- * and compares the A record to twin.gateway.publicIp. Replaces the
- * continuous letsdebug sweep for "does my domain still point at me?".
+ * DoH-based DNS-routing logic — resolves a domain via Cloudflare DoH
+ * and compares the A record to twin.gateway.publicIp ("does my domain
+ * still point at me?").
+ *
+ * As of #1564 this no longer registers its own `dns_routing` health
+ * check type. The per-domain `dns_routing:<domain>` rows were collapsed
+ * into the canonical `domain:<domain>` check (one row per domain that
+ * subsumes both NPM-routing and DNS-routing). The reusable
+ * `resolveDnsRouting` helper below is called by the `domain` probe for
+ * public domains; its payload rides the `domain` check's result.
  */
 
-import { registerProbe } from './registry';
+/** Combined DNS-routing outcome attached to a `domain` check payload. */
+export interface DnsRoutingPayload {
+  expected: string | null;
+  resolved: string[];
+  matched: boolean;
+}
 
-registerProbe({
-  type: 'dns_routing',
-  async run(check) {
-    const domain = check.target;
-    if (!domain) return { status: 'fail', message: 'dns_routing check has no target domain.' };
+export interface DnsRoutingOutcome {
+  status: 'ok' | 'fail';
+  payload?: DnsRoutingPayload;
+  /** Transport-level error (DoH unreachable / non-200) — no payload. */
+  message?: string;
+}
 
-    const { getGateway } = await import('../../store/repository');
-    const expectedIp = getGateway()?.publicIp ?? '';
-    const haveExpected = !!expectedIp && expectedIp !== '0.0.0.0';
+/**
+ * Resolve `domain` via Cloudflare DoH and compare the A record(s) to the
+ * gateway's known public IP. `ok` when the public IP isn't known yet
+ * (nothing to compare), when the record matches, otherwise `fail`. A
+ * transport failure returns `{ status:'fail', message }` with no payload.
+ */
+export async function resolveDnsRouting(domain: string): Promise<DnsRoutingOutcome> {
+  if (!domain) return { status: 'fail', message: 'dns_routing check has no target domain.' };
 
-    let answers: string[];
-    try {
-      const url = `https://1.1.1.1/dns-query?name=${encodeURIComponent(domain)}&type=A`;
-      const res = await fetch(url, {
-        headers: { Accept: 'application/dns-json' },
-        signal: AbortSignal.timeout(5000),
-      });
-      if (!res.ok) return { status: 'fail', message: `DoH lookup HTTP ${res.status}` };
-      const body = (await res.json()) as { Answer?: { type: number; data: string }[] };
-      answers = (body.Answer ?? []).filter(a => a.type === 1).map(a => a.data);
-    } catch (e) {
-      return { status: 'fail', message: `DoH lookup failed: ${e instanceof Error ? e.message : String(e)}` };
-    }
+  const { getGateway } = await import('../../store/repository');
+  const expectedIp = getGateway()?.publicIp ?? '';
+  const haveExpected = !!expectedIp && expectedIp !== '0.0.0.0';
 
-    const payload: { expected: string | null; resolved: string[]; matched: boolean } = {
-      expected: haveExpected ? expectedIp : null,
-      resolved: answers,
-      matched: haveExpected && answers.includes(expectedIp),
-    };
+  let answers: string[];
+  try {
+    const url = `https://1.1.1.1/dns-query?name=${encodeURIComponent(domain)}&type=A`;
+    const res = await fetch(url, {
+      headers: { Accept: 'application/dns-json' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return { status: 'fail', message: `DoH lookup HTTP ${res.status}` };
+    const body = (await res.json()) as { Answer?: { type: number; data: string }[] };
+    answers = (body.Answer ?? []).filter(a => a.type === 1).map(a => a.data);
+  } catch (e) {
+    return { status: 'fail', message: `DoH lookup failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
 
-    if (!haveExpected) {
-      return { status: 'ok', payload };
-    }
-    if (answers.length === 0) {
-      return { status: 'fail', payload };
-    }
-    return {
-      status: payload.matched ? 'ok' : 'fail',
-      payload,
-    };
-  },
-});
+  const payload: DnsRoutingPayload = {
+    expected: haveExpected ? expectedIp : null,
+    resolved: answers,
+    matched: haveExpected && answers.includes(expectedIp),
+  };
+
+  if (!haveExpected) return { status: 'ok', payload };
+  if (answers.length === 0) return { status: 'fail', payload };
+  return { status: payload.matched ? 'ok' : 'fail', payload };
+}

--- a/packages/backend/src/lib/health/probes/domain.test.ts
+++ b/packages/backend/src/lib/health/probes/domain.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CheckConfig } from '../types';
+
+const state = {
+  lanIp: '192.168.1.10' as string | undefined,
+  publicIp: '203.0.113.5' as string,
+};
+
+vi.mock('../../config', () => ({
+  getConfig: () => Promise.resolve({ reverseProxy: { lanIp: state.lanIp } }),
+}));
+
+// resolveDnsRouting imports getGateway lazily from store/repository.
+vi.mock('../../store/repository', () => ({
+  getGateway: () => ({ publicIp: state.publicIp }),
+}));
+
+import { getProbe } from './registry';
+// Side-effect: registers the `domain` probe.
+import './domain';
+
+const probe = () => {
+  const p = getProbe('domain');
+  if (!p) throw new Error('domain probe not registered');
+  return p;
+};
+
+const ctx = { executor: {} as never };
+
+function makeCheck(domain: string, isPublic: boolean): CheckConfig {
+  return {
+    id: `domain:${domain}`,
+    name: `Domain — ${domain}`,
+    type: 'domain',
+    target: domain,
+    interval: 60,
+    enabled: true,
+    created_at: new Date().toISOString(),
+    domainConfig: { expectedScheme: isPublic ? 'https' : 'http', isPublic },
+  };
+}
+
+/** First fetch call = NPM routing (http://lanIp:80/); subsequent = DoH. */
+function mockFetch(npm: Response, doh?: Response) {
+  let n = 0;
+  vi.spyOn(globalThis, 'fetch').mockImplementation((async () => {
+    n += 1;
+    return n === 1 ? npm : (doh ?? new Response('', { status: 200 }));
+  }) as typeof fetch);
+}
+
+function dohAnswer(ips: string[]): Response {
+  return new Response(
+    JSON.stringify({ Answer: ips.map(ip => ({ type: 1, data: ip })) }),
+    { status: 200, headers: { 'content-type': 'application/dns-json' } },
+  );
+}
+
+describe('domain probe (#1564 — merged NPM routing + DNS routing)', () => {
+  beforeEach(() => {
+    state.lanIp = '192.168.1.10';
+    state.publicIp = '203.0.113.5';
+    vi.restoreAllMocks();
+  });
+
+  it('LAN domain: runs NPM routing only, no DNS payload', async () => {
+    mockFetch(new Response('', { status: 200 }));
+    const res = await probe().run(makeCheck('home.arpa.lan', false), ctx) as { status: string; payload?: unknown };
+    expect(res.status).toBe('ok');
+    expect(res.payload).toBeUndefined();
+  });
+
+  it('public domain: NPM ok + DNS matches gateway → ok with payload', async () => {
+    mockFetch(new Response('', { status: 200 }), dohAnswer(['203.0.113.5']));
+    const res = await probe().run(makeCheck('one.example.com', true), ctx) as {
+      status: string; payload?: { matched: boolean; expected: string | null };
+    };
+    expect(res.status).toBe('ok');
+    expect(res.payload?.matched).toBe(true);
+    expect(res.payload?.expected).toBe('203.0.113.5');
+  });
+
+  it('public domain: NPM ok but DNS points elsewhere → fail with payload', async () => {
+    mockFetch(new Response('', { status: 200 }), dohAnswer(['198.51.100.7']));
+    const res = await probe().run(makeCheck('one.example.com', true), ctx) as {
+      status: string; payload?: { matched: boolean; resolved: string[] };
+    };
+    expect(res.status).toBe('fail');
+    expect(res.payload?.matched).toBe(false);
+    expect(res.payload?.resolved).toEqual(['198.51.100.7']);
+  });
+
+  it('public domain: NPM "not configured" → throws (CheckRunner reports fail)', async () => {
+    mockFetch(new Response('<h1>Congratulations</h1>', { status: 404 }));
+    await expect(probe().run(makeCheck('ghost.example.com', true), ctx)).rejects.toThrow(/not configured/);
+  });
+
+  it('throws when reverseProxy.lanIp is missing', async () => {
+    state.lanIp = undefined;
+    await expect(probe().run(makeCheck('one.example.com', true), ctx)).rejects.toThrow(/lanIp not configured/);
+  });
+});

--- a/packages/backend/src/lib/health/probes/domain.ts
+++ b/packages/backend/src/lib/health/probes/domain.ts
@@ -1,15 +1,27 @@
 /**
- * `domain` probe — talks to local NPM with a `Host:` header rather
- * than resolving the domain name, so RFC 8375 `.home.arpa` zones work
- * from inside ServiceBay's container even when its own resolver
- * doesn't know about them. See runner.ts for the full rationale
- * (preserved here in a shorter form).
+ * `domain` probe — the single canonical per-domain health check (#1564).
  *
- * No SSRF guard: hitting our own LAN IP is the point.
+ * One `domain:<domain>` check per reverse-proxy host now subsumes BOTH
+ * concerns that used to be two separate rows:
+ *
+ *   1. **NPM routing** (every domain): talks to local NPM with a `Host:`
+ *      header rather than resolving the name, so RFC 8375 `.home.arpa`
+ *      zones work from inside ServiceBay's container even when its own
+ *      resolver doesn't know about them. No SSRF guard — hitting our own
+ *      LAN IP is the point.
+ *   2. **DNS routing** (public domains only): the DoH-based "does public
+ *      DNS still point at me?" check that previously lived in its own
+ *      `dns_routing:<domain>` row. Resolved via `resolveDnsRouting`; its
+ *      structured payload rides this check's result so the diagnose
+ *      `domain_unreachable` reader picks it up unchanged.
+ *
+ * Result status is the worst of the two layers. The dns_routing payload
+ * (when public) is attached to `payload` so consumers can decode it.
  */
 
 import { registerProbe } from './registry';
 import { getConfig } from '../../config';
+import { resolveDnsRouting, type DnsRoutingPayload } from './dnsRouting';
 
 async function checkNpmRouting(lanIp: string, target: string, expectedScheme?: string) {
   const url = `http://${lanIp}:80/`;
@@ -31,17 +43,27 @@ async function checkNpmRouting(lanIp: string, target: string, expectedScheme?: s
 
     if (expectedScheme === 'https' && (res.status === 301 || res.status === 302)) {
       const loc = res.headers.get('location') || '';
-      if (loc.startsWith('https://')) return { message: `routed via NPM, ssl_forced redirect to ${loc}` };
-      return { message: `routed via NPM, redirect ${res.status} to ${loc || '(empty)'}` };
+      if (loc.startsWith('https://')) return `routed via NPM, ssl_forced redirect to ${loc}`;
+      return `routed via NPM, redirect ${res.status} to ${loc || '(empty)'}`;
     }
 
     if (res.status >= 200 && res.status < 400) {
-      return { message: `routed via NPM, HTTP ${res.status}` };
+      return `routed via NPM, HTTP ${res.status}`;
     }
     throw new Error(`NPM returned HTTP ${res.status}`);
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/** One-line DNS-routing summary for the combined `domain` message. */
+function summariseDns(dns: { status: 'ok' | 'fail'; payload?: DnsRoutingPayload; message?: string }): string {
+  if (!dns.payload) return `DNS: ${dns.message ?? 'lookup failed'}`;
+  const { expected, resolved, matched } = dns.payload;
+  if (expected === null) return `DNS resolves to ${resolved.join(', ') || '(no A record)'} (public IP not yet known)`;
+  if (resolved.length === 0) return 'DNS: no public A record';
+  if (matched) return `DNS → ${expected} (matches gateway)`;
+  return `DNS → ${resolved.join(', ')} (expected ${expected})`;
 }
 
 registerProbe({
@@ -52,6 +74,21 @@ registerProbe({
     const config = await getConfig();
     const lanIp = config.reverseProxy?.lanIp;
     if (!lanIp) throw new Error('reverseProxy.lanIp not configured — cannot probe NPM');
-    return checkNpmRouting(lanIp, check.target, cfg.expectedScheme);
+
+    const npmMessage = await checkNpmRouting(lanIp, check.target, cfg.expectedScheme);
+
+    // LAN-only domains have no public DNS to route — NPM routing is the
+    // whole story, no payload to attach.
+    if (!cfg.isPublic) return { status: 'ok' as const, message: npmMessage };
+
+    // Public domain: fold in the DoH DNS-routing layer. The probe row
+    // fails if DNS doesn't point at us even when NPM routing is healthy.
+    const dns = await resolveDnsRouting(check.target);
+    const message = `${npmMessage} · ${summariseDns(dns)}`;
+    return {
+      status: dns.status,
+      message,
+      ...(dns.payload ? { payload: dns.payload } : {}),
+    };
   },
 });

--- a/packages/backend/src/lib/health/probes/index.ts
+++ b/packages/backend/src/lib/health/probes/index.ts
@@ -14,4 +14,6 @@ import './lanIpDrift';
 import './npmAuthProbe';
 import './certExpiry';
 import './certRequestFailure';
-import './dnsRouting';
+// dnsRouting no longer self-registers a probe type (#1564 collapsed the
+// per-domain `dns_routing` rows into the canonical `domain` check). Its
+// `resolveDnsRouting` helper is imported directly by the `domain` probe.

--- a/packages/backend/src/lib/portal/assets.test.ts
+++ b/packages/backend/src/lib/portal/assets.test.ts
@@ -162,4 +162,9 @@ describe('resolveSetupAsset', () => {
     expect(out?.kind).toBe('syncthing_qr');
     expect(out?.data).toBe(VALID);
   });
+
+  it('returns null for basicsync_install_qr (rendered client-side, no server artifact)', async () => {
+    const out = await resolveSetupAsset('basicsync_install_qr', 'file-share');
+    expect(out).toBeNull();
+  });
 });

--- a/packages/backend/src/lib/portal/assets.ts
+++ b/packages/backend/src/lib/portal/assets.ts
@@ -217,6 +217,11 @@ export async function resolveSetupAsset(
       const deviceId = await fetchSyncthingDeviceId('Local');
       return deviceId ? { kind, data: deviceId } : null;
     }
+    case 'basicsync_install_qr':
+      // Pure client-side render — the portal builds the QR from the
+      // static `/api/system/downloads/basicsync` URL, no server
+      // artifact to resolve. Nothing to fetch here.
+      return null;
   }
 }
 

--- a/packages/backend/src/lib/portal/userGuide.test.ts
+++ b/packages/backend/src/lib/portal/userGuide.test.ts
@@ -147,6 +147,23 @@ setup_assets:
     expect(result!.frontmatter.setup_assets?.[1].kind).toBe('audiobookshelf_deeplink');
   });
 
+  it('parses the basicsync_install_qr setup-asset kind', () => {
+    const raw = `---
+setup_assets:
+  - kind: "basicsync_install_qr"
+    label: "Install BasicSync"
+    description: "Scan to download the app."
+---
+`;
+    const result = parseUserGuide(raw, 'file-share');
+    expect(result!.frontmatter.setup_assets).toHaveLength(1);
+    expect(result!.frontmatter.setup_assets?.[0]).toEqual({
+      kind: 'basicsync_install_qr',
+      label: 'Install BasicSync',
+      description: 'Scan to download the app.',
+    });
+  });
+
   it('drops setup_assets entries with non-string kind', () => {
     const raw = `---
 setup_assets:

--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -59,17 +59,27 @@ export interface RecommendedApp {
  *    - `audiobookshelf_deeplink` — `abs://` URL the official
  *      Audiobookshelf app picks up to pre-configure the server.
  *    - `syncthing_qr` — encodes the file-share container's
- *      device ID into a QR; the Android Syncthing app's "Add
- *      Device" → "Scan QR" reads it directly. The server fetches
- *      the device ID at request time via `podman exec` against the
- *      running syncthing container.
+ *      device ID into a QR; the BasicSync (Syncthing-compatible)
+ *      app's "Add Device" → "Scan QR" reads it directly. The server
+ *      fetches the device ID at request time via `podman exec`
+ *      against the running syncthing container.
+ *    - `basicsync_install_qr` — a QR/link to the BasicSync APK
+ *      download so the operator can install the recommended sync
+ *      client straight onto the phone (point the phone camera at it
+ *      → the APK download opens). Pure client-side render of the
+ *      `/api/system/downloads/basicsync` URL — no server round-trip.
  */
-export type SetupAssetKind = 'ios_calendar_profile' | 'audiobookshelf_deeplink' | 'syncthing_qr';
+export type SetupAssetKind =
+  | 'ios_calendar_profile'
+  | 'audiobookshelf_deeplink'
+  | 'syncthing_qr'
+  | 'basicsync_install_qr';
 
 const KNOWN_ASSET_KINDS: ReadonlySet<SetupAssetKind> = new Set([
   'ios_calendar_profile',
   'audiobookshelf_deeplink',
   'syncthing_qr',
+  'basicsync_install_qr',
 ]);
 
 export interface SetupAsset {

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -633,12 +633,12 @@ app.prepare().then(() => {
       setInterval(() => { void runDomainCheckSync(); }, 60_000);
     }
 
-    // Per-public-domain DNS routing health checks (15 min interval).
-    // Replaces the old continuous letsdebug sweep (#letsdebug-429) —
-    // uses Cloudflare DoH for a free, rate-limit-free "does my domain
-    // still point at me?" signal. Boot-time sync creates a
-    // `dns_routing:<domain>` check per public proxy host AND cleans
-    // up any legacy `letsdebug:<domain>` checks from prior versions.
+    // #1564 — the per-domain `dns_routing:<domain>` rows were collapsed
+    // into the canonical `domain` check (which now runs the DoH
+    // "does my domain still point at me?" logic itself). This boot-time
+    // call is now migration-only: it prunes any leftover `dns_routing:*`
+    // rows and legacy `letsdebug:*` rows so upgraders don't keep stale
+    // duplicate rows in Settings → Health.
     (async () => {
       try {
         const { syncDnsRoutingChecks } = await import('./lib/health/dnsRoutingChecks');

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
@@ -75,7 +75,10 @@ export default function FactoryResetSection() {
         <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
           <p>This deletes every installed service (photos, vault, identity, proxy, all of it) and clears the saved credentials in ServiceBay&apos;s config. The next wizard run goes through the full first-install flow with no pre-filled values.</p>
           <p className="font-medium text-red-700 dark:text-red-400">
-            Not what you want for a normal re-install. Use Clean install in the wizard for that — it&apos;s granular.
+            Not what you want for a normal re-install. To rebuild from a USB stick, pick a Factory-fresh option in the build form instead — &quot;wipe-configs&quot; keeps your app data on disk; this button does not.
+          </p>
+          <p className="text-xs text-gray-700 dark:text-gray-300">
+            Your app data (Home Assistant&apos;s <span className="font-mono">.storage</span>, Z-Wave, the Immich library) is <span className="font-semibold">not</span> pulled back automatically — restore it from a System Backup (include and select Service Data) afterwards, or services come up blank.
           </p>
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Family members will need to re-create their LLDAP accounts. NPM&apos;s Let&apos;s Encrypt certs are wiped (LE has a rate limit on re-issuance, so don&apos;t do this repeatedly).

--- a/packages/frontend/src/app/(dashboard)/settings/backups/_lib/useBackupState.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/_lib/useBackupState.ts
@@ -22,6 +22,13 @@ type RestoreSelectionState = {
   serviceData: Record<string, Record<string, boolean>>;
 };
 
+// One editable source row. `excludePatterns` is a newline-delimited string
+// while editing; it's split into a string[] on save.
+export type BackupSourceDraft = {
+  path: string;
+  excludePatterns: string;
+};
+
 type BackupSyncState = {
   enabled: boolean;
   schedule: 'hourly' | 'daily' | 'weekly' | 'monthly';
@@ -43,8 +50,7 @@ type BackupSyncState = {
   nfsHost: string;
   nfsExport: string;
   nfsPath: string;
-  sourcePath: string;
-  excludePatterns: string;
+  sources: BackupSourceDraft[];
   lastRun?: string;
   lastStatus?: 'success' | 'error';
   lastMessage?: string;
@@ -83,8 +89,7 @@ export function useBackupState() {
     sshHost: '', sshPort: '22', sshUser: 'root', sshPath: '/backup', sshIdentityFile: '/app/data/ssh/id_rsa',
     smbHost: '', smbShare: '', smbPath: '', smbUsername: '', smbPassword: '',
     nfsHost: '', nfsExport: '', nfsPath: '',
-    sourcePath: '/mnt/data',
-    excludePatterns: '',
+    sources: [{ path: '/mnt/data', excludePatterns: '' }],
   });
   const [backupSyncHistory, setBackupSyncHistory] = useState<Array<{ success: boolean; startedAt: string; completedAt: string; duration: number; message: string; filesTransferred?: number }>>([]);
   const [backupSyncRunning, setBackupSyncRunning] = useState(false);
@@ -128,6 +133,15 @@ export function useBackupState() {
       if (data.config) {
         const c = data.config;
         const t = c.target || { type: 'local', path: '/mnt/backup' };
+        // New configs carry `sources`; pre-multi-source configs carry the
+        // legacy single `sourcePath`/`excludePatterns` pair — fold it into a
+        // one-element list so the editor always renders a source row.
+        const sources: BackupSourceDraft[] = Array.isArray(c.sources) && c.sources.length > 0
+          ? c.sources.map((s: { path: string; excludePatterns?: string[] }) => ({
+              path: s.path ?? '',
+              excludePatterns: (s.excludePatterns || []).join('\n'),
+            }))
+          : [{ path: c.sourcePath ?? '/mnt/data', excludePatterns: (c.excludePatterns || []).join('\n') }];
         setBackupSync(prev => ({
           ...prev,
           enabled: c.enabled ?? false,
@@ -135,8 +149,7 @@ export function useBackupState() {
           time: c.time ?? '02:00',
           dayOfWeek: c.dayOfWeek,
           dayOfMonth: c.dayOfMonth,
-          sourcePath: c.sourcePath ?? '/mnt/data',
-          excludePatterns: (c.excludePatterns || []).join('\n'),
+          sources,
           targetType: t.type ?? 'local',
           localPath: t.type === 'local' ? t.path : prev.localPath,
           sshHost: t.type === 'ssh' ? t.host : prev.sshHost,

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -1387,6 +1387,9 @@ export default function BackupsSettingsPage() {
                       </button>
                       {restoreExpandedSections.serviceData && (
                         <div className="px-4 pb-4 pt-1 border-t border-gray-100 dark:border-gray-800/50 space-y-3">
+                          <p className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md px-3 py-2">
+                            This is your actual app data — Home Assistant&apos;s <span className="font-mono">.storage</span>, Z-Wave, the Immich library, and so on. A &quot;configs löschen&quot; / wipe-configs reinstall keeps it on disk but does <span className="font-semibold">not</span> pull it back automatically. Select it here to recover it, or services come up blank.
+                          </p>
                           {restorePreview.serviceData.map(sd => {
                             const label = sd.name.replace(/-/g, '/').replace(/^\//, '');
                             const fileCategories = groupServiceDataFiles(sd.files);

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -27,6 +27,7 @@ import {
   Network,
   Folder,
   Cloud,
+  Plus,
 } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 import ConfirmModal from '@/components/ConfirmModal';
@@ -134,8 +135,12 @@ export default function BackupsSettingsPage() {
         dayOfWeek: backupSync.schedule === 'weekly' ? backupSync.dayOfWeek : undefined,
         dayOfMonth: backupSync.schedule === 'monthly' ? backupSync.dayOfMonth : undefined,
         target: buildBackupTarget(),
-        sourcePath: backupSync.sourcePath,
-        excludePatterns: backupSync.excludePatterns.split('\n').map(s => s.trim()).filter(Boolean),
+        sources: backupSync.sources
+          .map(src => ({
+            path: src.path.trim(),
+            excludePatterns: src.excludePatterns.split('\n').map(p => p.trim()).filter(Boolean),
+          }))
+          .filter(src => src.path),
       };
       const res = await fetch('/api/settings/backup-sync', {
         method: 'POST',
@@ -151,6 +156,16 @@ export default function BackupsSettingsPage() {
       setBackupSyncSaving(false);
     }
   };
+
+  const addBackupSource = () =>
+    setBackupSync(prev => ({ ...prev, sources: [...prev.sources, { path: '', excludePatterns: '' }] }));
+  const removeBackupSource = (index: number) =>
+    setBackupSync(prev => ({ ...prev, sources: prev.sources.filter((_, i) => i !== index) }));
+  const updateBackupSource = (index: number, patch: Partial<{ path: string; excludePatterns: string }>) =>
+    setBackupSync(prev => ({
+      ...prev,
+      sources: prev.sources.map((src, i) => (i === index ? { ...src, ...patch } : src)),
+    }));
 
   const handleTestBackupSync = async () => {
     setBackupSyncTesting(true);
@@ -954,9 +969,52 @@ export default function BackupsSettingsPage() {
         </div>
 
         <div className="p-4 space-y-4">
+          {/* Sources — an operator-configurable list of directories, each with
+              its own .gitignore-style exclude patterns. Each source rsyncs into
+              its own subfolder under the target. */}
           <div>
-            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Source Path</label>
-            <input type="text" className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white" value={backupSync.sourcePath} onChange={e => setBackupSync(prev => ({ ...prev, sourcePath: e.target.value }))} placeholder="/mnt/data" />
+            <div className="flex items-center justify-between mb-2">
+              <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">Source Directories</label>
+              <button type="button" onClick={addBackupSource} className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 dark:text-blue-300 hover:text-blue-700 dark:hover:text-blue-200">
+                <Plus size={14} /> Add source
+              </button>
+            </div>
+            <div className="space-y-3">
+              {backupSync.sources.length === 0 && (
+                <p className="text-[11px] text-gray-500 dark:text-gray-400 italic">No sources configured. Add at least one directory to sync.</p>
+              )}
+              {backupSync.sources.map((src, i) => (
+                <div key={i} className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-900/30 p-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      className="flex-1 px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                      value={src.path}
+                      onChange={e => updateBackupSource(i, { path: e.target.value })}
+                      placeholder="/mnt/data"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeBackupSource(i)}
+                      aria-label="Remove source"
+                      className="p-2 rounded-lg border border-red-200 text-red-600 dark:text-red-400 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                  <div>
+                    <label className="block text-[11px] font-medium text-gray-500 dark:text-gray-400 mb-1">Exclude patterns (one per line)</label>
+                    <textarea
+                      className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono"
+                      rows={2}
+                      value={src.excludePatterns}
+                      onChange={e => updateBackupSource(i, { excludePatterns: e.target.value })}
+                      placeholder="*.tmp&#10;cache/"
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
 
           {/* Target picker — radio cards. The previous version used a row of
@@ -1088,11 +1146,6 @@ export default function BackupsSettingsPage() {
                 <input type="number" min={1} max={28} className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white" value={backupSync.dayOfMonth ?? 1} onChange={e => setBackupSync(prev => ({ ...prev, dayOfMonth: parseInt(e.target.value) || 1 }))} />
               </div>
             )}
-          </div>
-
-          <div>
-            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Exclude Patterns (one per line)</label>
-            <textarea className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono" rows={2} value={backupSync.excludePatterns} onChange={e => setBackupSync(prev => ({ ...prev, excludePatterns: e.target.value }))} placeholder="*.tmp&#10;*.log" />
           </div>
 
           {backupSyncTestResult && (

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -9,7 +9,7 @@
  * path directly by passing a card with `manualPairing` populated.
  */
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import PortalGrid from './PortalGrid';
 import type { PortalCard } from '@/lib/portal/services';
 
@@ -118,5 +118,36 @@ describe('PortalGrid', () => {
     expect(screen.getByText('cmd-two')).toBeDefined();
     // Two copy buttons — one per step.
     expect(screen.getAllByRole('button', { name: /copy command/i })).toHaveLength(2);
+  });
+
+  describe('BasicSync install QR asset (#1560)', () => {
+    const basicSyncCard: PortalCard = {
+      ...baseCard,
+      id: 'file-share:SYNCTHING_SUBDOMAIN',
+      name: 'file-share',
+      label: 'File Share',
+      setupAssets: [{ kind: 'basicsync_install_qr', description: 'Open-source Syncthing client.' }],
+    };
+
+    it('renders the install button (closed by default, no modal)', () => {
+      render(<PortalGrid cards={[basicSyncCard]} />);
+      expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
+      expect(screen.getByText('Open-source Syncthing client.')).toBeDefined();
+      // Modal heading is not present until the button is clicked.
+      expect(screen.queryByRole('heading', { name: /install basicsync/i })).toBeNull();
+    });
+
+    it('opens the QR modal on click and closes it on backdrop click', () => {
+      render(<PortalGrid cards={[basicSyncCard]} />);
+      fireEvent.click(screen.getByRole('button', { name: /install basicsync on your phone/i }));
+      // Modal now shows: heading + the direct-download link.
+      expect(screen.getByRole('heading', { name: /install basicsync/i })).toBeDefined();
+      const link = screen.getByRole('link', { name: /open the download link directly/i });
+      expect(link.getAttribute('href')).toContain('/api/system/downloads/basicsync');
+
+      // Clicking the backdrop (the outermost overlay div) closes the modal.
+      fireEvent.click(screen.getByRole('heading', { name: /install basicsync/i }).closest('div')!.parentElement!);
+      expect(screen.queryByRole('heading', { name: /install basicsync/i })).toBeNull();
+    });
   });
 });

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -61,6 +61,7 @@ const ASSET_LABELS: Record<SetupAssetKind, { label: string; icon: IconComponent 
   ios_calendar_profile: { label: 'Add to iPhone (Calendar + Contacts)', icon: Download },
   audiobookshelf_deeplink: { label: 'Open in Audiobookshelf app', icon: Smartphone },
   syncthing_qr: { label: 'Pair Syncthing device', icon: QrCode },
+  basicsync_install_qr: { label: 'Install BasicSync on your phone', icon: Download },
 };
 
 /** Coarse user-agent sniff for iOS devices — iPhone / iPad / iPod.
@@ -225,6 +226,11 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                     if (asset.kind === 'syncthing_qr') {
                       return (
                         <SyncthingQrButton key={asset.kind} card={card} label={label} description={asset.description} Icon={Icon} />
+                      );
+                    }
+                    if (asset.kind === 'basicsync_install_qr') {
+                      return (
+                        <BasicSyncInstallQrButton key={asset.kind} label={label} description={asset.description} Icon={Icon} />
                       );
                     }
                     return null;
@@ -475,11 +481,88 @@ function DeepLinkButton({
 }
 
 /**
+ * BasicSync install QR. Opens a modal with a QR encoding the static
+ * `/api/system/downloads/basicsync` URL so the operator can point a
+ * phone camera at it and download the recommended sync client APK
+ * directly — no app-store hunt, no server round-trip. This is the
+ * "install the app" step; the SyncthingQrButton below is the
+ * separate "pair the device" step.
+ */
+const BASICSYNC_INSTALL_URL = '/api/system/downloads/basicsync?abi=arm64-v8a';
+
+function BasicSyncInstallQrButton({
+  label,
+  description,
+  Icon,
+}: {
+  label: string;
+  description?: string;
+  Icon: typeof Download;
+}) {
+  const [open, setOpen] = useState(false);
+  // The QR needs an absolute URL — a phone scanning it has no notion
+  // of the portal's origin. Resolve against the current location at
+  // render time (the portal is served from the box's public host).
+  const absoluteUrl =
+    typeof window !== 'undefined'
+      ? new URL(BASICSYNC_INSTALL_URL, window.location.origin).toString()
+      : BASICSYNC_INSTALL_URL;
+
+  return (
+    <>
+      <div>
+        <button
+          onClick={() => setOpen(true)}
+          className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+        >
+          <Icon size={14} /> {label}
+        </button>
+        {description && (
+          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 leading-snug text-center">{description}</p>
+        )}
+      </div>
+
+      {open && <BasicSyncInstallModal qrUrl={absoluteUrl} onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+/** The QR modal opened by {@link BasicSyncInstallQrButton}. Split out
+ *  to keep the button under the per-function line budget. */
+function BasicSyncInstallModal({ qrUrl, onClose }: { qrUrl: string; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-sm w-full p-6 text-center" onClick={e => e.stopPropagation()}>
+        <h2 className="text-lg font-bold text-gray-900 dark:text-white">Install BasicSync</h2>
+        <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+          Point your phone camera at this QR to download the BasicSync app — a trusted, open-source Syncthing client. Once it&apos;s installed, use the <strong>Pair this device</strong> button to connect.
+        </p>
+
+        <div className="mt-5 flex justify-center">
+          <div className="bg-white p-4 rounded-lg">
+            <QRCodeSVG value={qrUrl} size={192} level="M" />
+          </div>
+        </div>
+
+        <a
+          href={BASICSYNC_INSTALL_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 inline-block text-xs text-blue-700 dark:text-blue-300 hover:underline break-all"
+        >
+          Or open the download link directly
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/**
  * Syncthing QR pairing button. Fetches the server's device ID
  * lazily on click (it's a podman-exec round-trip, so we don't
  * pre-fetch it on every card render) and opens a modal with the QR
- * code rendered client-side. The Android Syncthing app's "Add
- * Device → Scan QR" reads it directly.
+ * code rendered client-side. The BasicSync app's "Add Device →
+ * Scan QR" reads it directly.
  */
 function SyncthingQrButton({
   card,

--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -16,18 +16,17 @@ cards:
     lucide_icon: "refresh-cw"
     tagline: "Keep folders on your phone and laptop in sync with the home server — automatic two-way."
     setup_assets:
+      - kind: "basicsync_install_qr"
+        label: "Install BasicSync on your phone"
+        description: "Point your phone camera at this QR to download the BasicSync app (a trusted, open-source Syncthing client). Step 1: install it. Then use the pairing QR below to connect."
       - kind: "syncthing_qr"
-        label: "Pair this Syncthing device"
-        description: "Shows a QR code with the home server's device ID. The Android Syncthing app's \"Add Device → Scan QR\" picks it up directly."
+        label: "Pair this device"
+        description: "Shows a QR code with the home server's device ID. In BasicSync, tap \"Add Device → Scan QR\" to pick it up directly. Step 2 — after BasicSync is installed."
     recommended_apps:
-      - name: "Syncthing"
-        url: "https://syncthing.net/downloads/"
-        platforms: ["desktop"]
-        note: "Two-way folder sync between your computer and the home server."
       - name: "BasicSync"
         url: "/api/system/downloads/basicsync?abi=arm64-v8a"
         platforms: ["android"]
-        note: "Actively-maintained Android Syncthing client. This link always grabs the latest build for arm64 phones — for older or x86 devices change ?abi= to armeabi-v7a, x86_64 or x86."
+        note: "The recommended Android sync client — trusted, open-source, actively maintained. This link always grabs the latest build for arm64 phones; for older or x86 devices change ?abi= to armeabi-v7a, x86_64 or x86. (Or just scan the install QR above.)"
       - name: "Möbius Sync"
         url: "https://apps.apple.com/app/m%C3%B6bius-sync/id1539203216"
         platforms: ["ios"]
@@ -70,12 +69,12 @@ The username + password are the family ones. Once mounted, drag files in/out as 
 
 Best for: working with large files (video, photos), where uploading through a browser would be slow.
 
-## On your phone (Syncthing)
+## On your phone (BasicSync)
 
-Syncthing keeps a folder on your phone in sync with the home server in both directions. Photos you take, documents you save — they appear on the server within minutes.
+BasicSync keeps a folder on your phone in sync with the home server in both directions. Photos you take, documents you save — they appear on the server within minutes. It's a trusted, open-source Syncthing-compatible client — no need to hunt for an app in the store.
 
-1. Install **Syncthing** (Android) or **Möbius Sync** (iOS) from the links above.
-2. The app shows a *device ID*. Open the **Syncthing** card and scan the QR code (it carries the home server's device ID).
+1. **Install the app.** On Android, scan the *Install BasicSync on your phone* QR on the **Syncthing** card (or tap the BasicSync link) — it downloads the APK directly. On iOS, install **Möbius Sync** from the link.
+2. **Pair the device.** Open the **Syncthing** card, tap *Pair this device*, and in BasicSync use *Add Device → Scan QR* to scan it (the QR carries the home server's device ID).
 3. Pick which folders on your phone to sync.
 
 Best for: continuous backup of phone documents, two-way sync between phone and laptop.

--- a/tests/backend/health_probe_registry.test.ts
+++ b/tests/backend/health_probe_registry.test.ts
@@ -13,10 +13,14 @@ import { registeredProbeTypes, getProbe } from '@/lib/health/probes/registry';
 import '@/lib/health/probes';
 
 describe('Probe registry (#592)', () => {
+  // `dns_routing` is intentionally absent (#1564): the per-domain
+  // dns_routing rows were collapsed into the canonical `domain` check,
+  // which now runs the DoH DNS-routing logic itself. No standalone
+  // `dns_routing` probe registers any more.
   const EXPECTED_TYPES = [
     'http', 'ping', 'script', 'podman', 'service', 'systemd', 'node', 'agent',
     'fritzbox', 'backup', 'domain', 'letsdebug', 'lan_ip_drift', 'npm_auth',
-    'cert_expiry', 'cert_request_failure', 'dns_routing',
+    'cert_expiry', 'cert_request_failure',
   ];
 
   it('every legacy check type has a probe registered', () => {

--- a/tools/sb/internal/ui/buildform.go
+++ b/tools/sb/internal/ui/buildform.go
@@ -94,7 +94,7 @@ var settingsFields = []sfield{
 	{label: "Admin username", help: "Login for the ServiceBay web dashboard (and the in-TUI sign-in).",
 		get: func(s *build.Settings) string { return s.ServicebayAdminUser }, set: func(s *build.Settings, v string) { s.ServicebayAdminUser = v }},
 	{label: "Factory-fresh install", kind: fChoice, options: []string{"off", "wipe-configs", "wipe-all-data"},
-		help: "DESTRUCTIVE. off = normal reinstall (keeps config + data). wipe-configs = fresh ServiceBay (new admin/secrets/tokens), KEEPS service data. wipe-all-data = reformat the whole data disk (BLANK box, all service data gone).",
+		help: "DESTRUCTIVE. off = normal reinstall (keeps config + data). wipe-configs = fresh ServiceBay config (new admin/secrets/tokens); KEEPS service data on disk (HA .storage, Z-Wave, Immich library in DATA_DIR) but does NOT auto-pull it back from NAS — restore service data explicitly afterwards or services come up blank. wipe-all-data = reformat the whole data disk (BLANK box, ALL service data gone, restore everything from backup).",
 		get:  func(s *build.Settings) string { return ffOrOff(s.FactoryFresh) }, set: func(s *build.Settings, v string) { s.FactoryFresh = v }},
 	{label: "Public domain", help: "Optional external domain for reverse-proxy/TLS. Blank to skip.",
 		get: func(s *build.Settings) string { return s.PublicDomain }, set: func(s *build.Settings, v string) { s.PublicDomain = v }},


### PR DESCRIPTION
## What
Four point-of-choice / backend-data units:
- **#1558** wipe-configs lifecycle copy made unmistakable across the build form (Go), `FactoryResetSection`, and the Service-Data restore section — what is kept (HA/Z-Wave/Immich data in DATA_DIR) vs wiped, and that data is not auto-restored.
- **#1560** file-share portal recommends **BasicSync** (install QR for the arm64 APK) instead of the store Syncthing app; the existing pairing QR is kept as step 2.
- **#1564** collapse per-domain health checks — one canonical `domain:<domain>` check subsumes domain-reachability + DNS-routing; `dns_routing:*` probe dropped, migration prunes the legacy rows.
- **#1554** Backup Sync gets an operator-configurable source list with per-source exclude patterns and L&F parity with System Backups (config-store is deliberately not a source).

## Why
Closes #1558
Closes #1560
Closes #1564
Closes #1554

## Risk
Medium — #1564 changes how health rows are stored/migrated and #1554 changes backup source iteration/subfoldering; both have new unit coverage. #1558/#1560 are copy/portal-render only.

## Rollback
git revert is enough (no data migration is destructive; the dns_routing prune only removes defunct rows that the new domain check replaces).

## Verification
- [x] npm run lint (0 errors, 347 warnings)
- [x] npm run check:arch
- [x] npm test (full — 1767 passed, 2 skipped)
- [ ] Go gates for tools/sb buildform.go (run in CI — Go not in dev env)
- [ ] /verify on FCoS :dev box (path-mandated — see box_verify)