### PR TITLE
fix(frontend): upgrade lucide-react to 1.x and reconcile icon imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "bcryptjs": "^3.0.3",
         "jose": "^6.2.3",
         "js-yaml": "^4.2.0",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.17.0",
         "mustache": "^4.2.0",
         "next": "16.2.7",
         "qrcode.react": "^4.2.0",
@@ -9721,9 +9721,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -15232,7 +15232,7 @@
         "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.11.0",
         "diff": "^9.0.0",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.17.0",
         "next": "16.2.7",
         "prismjs": "^1.30.0",
         "react": "19.2.7",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bcryptjs": "^3.0.3",
     "jose": "^6.2.3",
     "js-yaml": "^4.2.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.17.0",
     "mustache": "^4.2.0",
     "next": "16.2.7",
     "qrcode.react": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
   "knip": {
     "ignoreBinaries": [
       "fuser",
-      "python3"
+      "python3",
+      "gofmt"
     ],
     "ignore": [
-      "scripts/check-invariants.ts",
       "packages/frontend/public/mockServiceWorker.js"
     ],
     "ignoreExportsUsedInFile": true,
@@ -109,7 +109,6 @@
           "tests/e2e/**/*.e2e.ts"
         ],
         "ignoreDependencies": [
-          "@servicebay/api-client",
           "lucide-react",
           "react-markdown",
           "socket.io-client"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,7 +9,7 @@
     "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.11.0",
     "diff": "^9.0.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.17.0",
     "next": "16.2.7",
     "prismjs": "^1.30.0",
     "react": "19.2.7",

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
-import { Github, ArrowRight, Loader2, Shield, AlertTriangle } from 'lucide-react';
+import { Code, ArrowRight, Loader2, Shield, AlertTriangle } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 import pkg from '../../../package.json';
 
@@ -175,7 +175,7 @@ export default function LoginPage() {
             rel="noopener noreferrer"
             className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 dark:hover:text-gray-300 transition-colors"
           >
-            <Github size={16} />
+            <Code size={16} />
             <span>View on GitHub</span>
           </a>
         </div>

--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { Github, Settings, Wrench } from 'lucide-react';
+import { Code, Settings, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import DomainTag from './DomainTag';
 import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
@@ -110,7 +110,7 @@ export function MobileTopBar() {
              <Settings size={20} />
           </button>
           <a href="https://github.com/mdopp/servicebay" target="_blank" rel="noreferrer" className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
-             <Github size={20} />
+             <Code size={20} />
           </a>
        </div>
     </div>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { ChevronLeft, Github, Users, ExternalLink, Sparkles, Home, User as UserIcon, LogOut } from 'lucide-react';
+import { ChevronLeft, Code, Users, ExternalLink, Sparkles, Home, User as UserIcon, LogOut } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import DomainTag from './DomainTag';
@@ -262,7 +262,7 @@ export default function Sidebar() {
                 className={`w-full flex items-center px-3.5 py-3 rounded-xl text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-200/60 dark:hover:bg-white/[0.02] transition-all border border-transparent ${isCollapsed ? 'justify-center' : 'gap-3.5'}`}
                 title="View on GitHub"
             >
-                <Github size={20} className="shrink-0" />
+                <Code size={20} className="shrink-0" />
                 {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">GitHub Repo</span>}
             </a>
         </div>


### PR DESCRIPTION
## What
Bumps lucide-react 0.562.0 → 1.17.0 (root + frontend) and reconciles icon imports against the 1.x export list. Of 112 unique imported icon names, only the `Github` brand icon was removed in 1.x; the 3 "View on GitHub" repo-link usages (login footer, MobileNav, Sidebar) are remapped to the generic `Code` glyph. Also unblocks the knip 6 pre-commit hook (config-only) that was failing on a clean tree after the knip 5→6 bump.

## Why
Closes #1578

Supersedes Dependabot PR #1576 (same lucide-react bump, but Dependabot's PR fails typecheck/build because it doesn't fix the renamed/removed icon exports). #1576 will be closed in favour of this.

## Risk
low — icon-import-only frontend change plus a knip config tweak; full gate green (lint 0 errors, check:arch, 1775 tests). Visual icon regression possible only where `Code` now stands in for the old GitHub glyph.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 347 warnings, not increased)
- [x] npm run check:arch
- [x] npm test (full — 230 files / 1775 tests pass)
- [x] npx knip (exits 0 after config fix)
- [ ] /verify on FCoS :dev box — icons render across login footer, sidebar, mobile nav, and the "View on GitHub" glyph (now `Code`); no missing/blank icons (path-mandated: packages/frontend/src/app/(dashboard)/)