### PR TITLE
fix: NAS auto-restore decoupled from cleanInstall + branded proxy error pages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -212,6 +212,18 @@ const eslintConfig = defineConfig([
           argsIgnorePattern: "^_",
         },
       ],
+      // --- Dead-code detection (syntactic + constant-folded). Exact, near
+      // zero false positives; complements knip (module-level unused
+      // files/exports) and branch coverage (semantic / runtime-dead). These
+      // catch code the TS compiler's allowUnreachableCode/
+      // noFallthroughCasesInSwitch don't, e.g. dead arms behind a literalised
+      // flag: `if (x || true)`, `const F = false; if (F) {…}`.
+      "no-unreachable": "error",
+      "no-unreachable-loop": "error",
+      "no-constant-condition": ["error", { checkLoops: false }],
+      "no-constant-binary-expression": "error",
+      "no-unused-private-class-members": "error",
+      "no-fallthrough": "error",
       "sb/no-exec-template-literal": "error",
       // Hard error since the #603 burn-down — every API route verb
       // export must use withApiHandler / withApiHandlerParams. The

--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -131,12 +131,14 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
 
-  it('is a no-op when it is not a clean install (a normal add-a-service install)', async () => {
+  it('restores even when cleanInstall is false, given backup-exists + empty dir (#1584)', async () => {
+    // #1520 retired cleanInstall to a hard-coded false; restore must no longer
+    // depend on it — backup-exists + fresh-dir are the only safe gates.
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
     await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); });
-    expect(await isFreshDataDir(dataDir)).toBe(true); // nothing written
-    expect(logs).toEqual([]);
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
+    expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
 
   it('is a no-op on a remote node (restore primitive is local-fs only)', async () => {
@@ -147,22 +149,24 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     expect(logs).toEqual([]);
   });
 
-  it('is a silent no-op when no backup exists for the service', async () => {
+  it('logs a visible skip breadcrumb (not silent) when no backup exists for the service', async () => {
     mockNas.nasList.mockResolvedValue([]); // empty NAS
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'Local' }, async l => { logs.push(l); });
-    expect(logs).toEqual([]);
+    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); });
+    expect(logs.some(l => l.includes('home-assistant') && l.includes('no config backup'))).toBe(true);
+    expect(logs.some(l => l.includes('restored'))).toBe(false);
   });
 
-  it('never clobbers a non-empty data dir, and never throws', async () => {
+  it('skips a non-empty data dir with a logged reason, never clobbers, never throws (#1584)', async () => {
     await fs.mkdir(dataDir, { recursive: true });
     await fs.writeFile(path.join(dataDir, 'live.yaml'), 'live');
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
     await expect(
-      autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'Local' }, async l => { logs.push(l); }),
+      autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); }),
     ).resolves.toBeUndefined();
     expect(await fs.readFile(path.join(dataDir, 'live.yaml'), 'utf8')).toBe('live'); // untouched
+    expect(logs.some(l => l.includes('not empty') && l.includes('skipping restore'))).toBe(true);
     expect(logs.some(l => l.includes('restored'))).toBe(false);
   });
 });

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -140,14 +140,25 @@ export async function restoreServiceBackup(
 }
 
 /**
- * #1218 entry point 1 — auto-restore a service's config from the NAS during a
- * **reinstall**, before its pod starts. No-op (and never throws) unless:
- *  - this is a clean install / reinstall (`cleanInstall`), AND
+ * #1218 entry point 1 — auto-restore a service's config from the NAS before its
+ * pod starts on any (re)deploy. Gated on its **own safe conditions** rather than
+ * the install mode: it fires when a `<service>.tar` exists on the NAS **and**
+ * the service's data dir is empty/fresh — so it can't clobber live data, yet it
+ * no longer depends on the retired `cleanInstall` flag (#1584: #1520 hard-set
+ * `cleanInstall = false`, which silently disabled restore for every install).
+ *
+ * Conditions (all required to restore):
  *  - the node is Local (the restore primitive uses the backend's own fs), AND
  *  - a `<service>.tar` exists on the NAS, AND
  *  - the service's data dir is empty (`restoreServiceBackup` also refuses a
  *    non-empty dir, so a live service's config is never clobbered).
- * Logs each step through the injected `log` so it shows on the install stream.
+ *
+ * Emits a VISIBLE breadcrumb through the injected `log` for BOTH outcomes —
+ * restore-performed and restore-skipped (with the reason) — so a skipped
+ * restore is never silent (the #1584 root cause was the old silent `return`).
+ * The Local-node short-circuit stays silent: it's an architectural no-op (the
+ * primitive is local-fs only), not a user-facing decision.
+ *
  * Best-effort: a restore failure is logged and swallowed so it can't block the
  * deploy. The install runner calls this from `deployItem` (epic #1190).
  */
@@ -156,12 +167,19 @@ export async function autoRestoreServiceOnReinstall(
   opts: { cleanInstall?: boolean; node?: string | null },
   log: (line: string) => Promise<void>,
 ): Promise<void> {
-  if (!opts.cleanInstall) return;
+  // #1584: deliberately NOT gated on opts.cleanInstall — that flag was retired
+  // to false (#1520) and was the sole gate, which silently killed auto-restore.
   if (opts.node && opts.node !== 'Local') return;
   try {
     const hasBackup = (await listServiceBackups()).some(b => b.service === service);
-    if (!hasBackup) return;
-    if (!(await isFreshDataDir(await resolveServiceDataDir(service)))) return;
+    if (!hasBackup) {
+      await log(`(note) ${service}: no config backup found on the FritzBox NAS — starting on existing/blank data.`);
+      return;
+    }
+    if (!(await isFreshDataDir(await resolveServiceDataDir(service)))) {
+      await log(`(note) ${service}: a config backup exists on the NAS, but the data dir is not empty — keeping the on-disk data and skipping restore.`);
+      return;
+    }
     await log(`💾 ${service}: found a config backup on the FritzBox NAS and the data dir is empty — restoring before first start…`);
     const r = await restoreServiceBackup(service, { node: opts.node });
     await log(`✅ ${service}: restored ${r.files} config file(s) from the NAS${r.meta ? ` (backed up ${r.meta.createdAt.slice(0, 10)} from ${r.meta.nodeId})` : ''}.`);

--- a/packages/backend/src/lib/reverseProxy/proxyErrorPages.test.ts
+++ b/packages/backend/src/lib/reverseProxy/proxyErrorPages.test.ts
@@ -1,0 +1,138 @@
+/**
+ * #1583 — branded proxy error pages: pure builders.
+ *
+ * Two dead-ends generalise the #1415 mechanism: an unknown subdomain (default
+ * server) and a bare 401/502/504 on a configured host. Both pages must be
+ * self-contained, brand as ServiceBay, and point at a next step. The wiring
+ * snippets must alias the shipped files and preserve the original status, and
+ * the per-host append helper must be idempotent and non-clobbering.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/agent/manager', () => ({ agentManager: { getAgent: vi.fn() } }));
+vi.mock('@/lib/nodes', () => ({ listNodes: vi.fn(async () => []) }));
+
+import {
+  buildUnknownHostPageHtml,
+  buildProxyErrorPageHtml,
+  withProxyErrorPage,
+  DEAD_HOST_CUSTOM_CONF,
+  PROXY_ERROR_ADVANCED_CONFIG,
+  UNKNOWN_HOST_PAGE_CONTAINER_PATH,
+  PROXY_ERROR_PAGE_CONTAINER_PATH,
+} from './proxyErrorPages';
+
+function assertSelfContained(html: string) {
+  expect(html).toContain('<style>');
+  expect(html).not.toMatch(/<link[^>]+href=/i);
+  expect(html).not.toMatch(/<script\b/i);
+  expect(html).not.toMatch(/src=["']https?:/i);
+}
+
+describe('buildUnknownHostPageHtml', () => {
+  it('brands the page and explains the host is not a configured service', () => {
+    const html = buildUnknownHostPageHtml('dopp.cloud');
+    expect(html).toContain('ServiceBay');
+    expect(html).toContain('#0f172a'); // slate palette, matches #1415
+    expect(html).toMatch(/isn't set up here|isn&#39;t set up here|configured/i);
+  });
+
+  it('is self-contained: inline <style>, no external assets, no JS', () => {
+    assertSelfContained(buildUnknownHostPageHtml('dopp.cloud'));
+  });
+
+  it('links the dashboard and suggests checking spelling / AdGuard rewrites', () => {
+    const html = buildUnknownHostPageHtml('dopp.cloud');
+    expect(html).toContain('https://dopp.cloud');
+    expect(html).toMatch(/spelling/i);
+    expect(html).toMatch(/AdGuard/i);
+  });
+
+  it('degrades gracefully with no domain (no URL, generic dashboard wording)', () => {
+    const html = buildUnknownHostPageHtml();
+    expect(html).not.toMatch(/href="https:\/\//);
+    expect(html).toContain('your ServiceBay dashboard');
+  });
+
+  it('normalises a domain passed with scheme / trailing slash', () => {
+    const html = buildUnknownHostPageHtml('https://dopp.cloud/');
+    expect(html).toContain('https://dopp.cloud<');
+    expect(html).not.toContain('https://https://');
+  });
+});
+
+describe('buildProxyErrorPageHtml', () => {
+  it('brands the page and shows the live status via nginx SSI', () => {
+    const html = buildProxyErrorPageHtml('dopp.cloud');
+    expect(html).toContain('ServiceBay');
+    expect(html).toContain('<!--# echo var="status"');
+  });
+
+  it('is self-contained: inline <style>, no external assets, no JS', () => {
+    assertSelfContained(buildProxyErrorPageHtml('dopp.cloud'));
+  });
+
+  it('points 401 at the auth portal and 502/504 at "starting/offline"', () => {
+    const html = buildProxyErrorPageHtml('dopp.cloud');
+    expect(html).toContain('https://auth.dopp.cloud');
+    expect(html).toMatch(/starting or offline|502\/503\/504/i);
+  });
+
+  it('degrades the sign-in hint with no domain', () => {
+    const html = buildProxyErrorPageHtml();
+    expect(html).not.toMatch(/href="https:\/\//);
+    expect(html).toMatch(/login page/i);
+  });
+});
+
+describe('DEAD_HOST_CUSTOM_CONF (default/dead-host server include)', () => {
+  it('re-routes the catch-all errors to the unknown-host page via an internal alias', () => {
+    expect(DEAD_HOST_CUSTOM_CONF).toContain('error_page');
+    expect(DEAD_HOST_CUSTOM_CONF).toContain('internal;');
+    expect(DEAD_HOST_CUSTOM_CONF).toContain(`alias ${UNKNOWN_HOST_PAGE_CONTAINER_PATH};`);
+  });
+
+  it('covers the bare codes the default server can emit (401/404 included)', () => {
+    expect(DEAD_HOST_CUSTOM_CONF).toMatch(/error_page[^;]*\b401\b/);
+    expect(DEAD_HOST_CUSTOM_CONF).toMatch(/error_page[^;]*\b404\b/);
+  });
+
+  it('preserves the original status (no `=` rewrite on error_page)', () => {
+    expect(DEAD_HOST_CUSTOM_CONF).not.toMatch(/error_page\s+[\d\s]*=/);
+  });
+});
+
+describe('PROXY_ERROR_ADVANCED_CONFIG (per-configured-host snippet)', () => {
+  it('wires 401/502/504 to an internal SSI location aliasing the shipped file', () => {
+    expect(PROXY_ERROR_ADVANCED_CONFIG).toMatch(/error_page[^;]*\b401\b/);
+    expect(PROXY_ERROR_ADVANCED_CONFIG).toMatch(/error_page[^;]*\b502\b/);
+    expect(PROXY_ERROR_ADVANCED_CONFIG).toMatch(/error_page[^;]*\b504\b/);
+    expect(PROXY_ERROR_ADVANCED_CONFIG).toContain('ssi on;');
+    expect(PROXY_ERROR_ADVANCED_CONFIG).toContain(`alias ${PROXY_ERROR_PAGE_CONTAINER_PATH};`);
+  });
+
+  it('does NOT claim 403 (that is the #1415 LAN-denied path)', () => {
+    expect(PROXY_ERROR_ADVANCED_CONFIG).not.toMatch(/error_page[^;]*\b403\b/);
+  });
+});
+
+describe('withProxyErrorPage', () => {
+  it('returns the snippet alone for an empty/undefined config', () => {
+    expect(withProxyErrorPage(undefined)).toBe(PROXY_ERROR_ADVANCED_CONFIG);
+    expect(withProxyErrorPage('')).toBe(PROXY_ERROR_ADVANCED_CONFIG);
+    expect(withProxyErrorPage('   \n  ')).toBe(PROXY_ERROR_ADVANCED_CONFIG);
+  });
+
+  it('appends, preserving an existing config (e.g. the #1415 LAN-denied block)', () => {
+    const existing = 'error_page 403 /servicebay-lan-only;';
+    const out = withProxyErrorPage(existing);
+    expect(out).toContain(existing);
+    expect(out).toMatch(/error_page[^;]*\b401\b/);
+  });
+
+  it('is idempotent: a config already carrying the snippet is unchanged', () => {
+    const once = withProxyErrorPage('proxy_read_timeout 90;');
+    const twice = withProxyErrorPage(once);
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/backend/src/lib/reverseProxy/proxyErrorPages.ts
+++ b/packages/backend/src/lib/reverseProxy/proxyErrorPages.ts
@@ -1,0 +1,302 @@
+/**
+ * Branded, solution-pointing proxy error pages (#1583).
+ *
+ * Generalises the #1415 LAN-only 403 explainer mechanism to two more
+ * dead-ends a user can hit on a `*.dopp.cloud` host, both of which otherwise
+ * surface as a bare, unbranded openresty error page:
+ *
+ *   1. **Unknown / unconfigured subdomain.** A typo (e.g. `lldap.dopp.cloud`
+ *      with two L's) or a never-configured host resolves to the box via the
+ *      AdGuard wildcard, hits NPM's catch-all "dead host" server, and gets a
+ *      raw `404`/`Authorization Required`. We serve a branded explainer that
+ *      says the host isn't a configured service, links the dashboard, and
+ *      suggests checking the spelling / AdGuard rewrites.
+ *
+ *   2. **Bare proxy error that leaks to the user on a *configured* host.** A
+ *      `401` where the Authelia login redirect didn't fire, or a `502`/`504`
+ *      when the upstream is down — openresty's default body says nothing. We
+ *      serve a branded page that states what happened and the next step
+ *      (sign in at `auth.<domain>`, or "this service is starting / offline").
+ *
+ * Mechanism mirrors {@link ./lanDeniedPage} exactly (it is the proven #1415
+ * pattern): ship small, self-contained HTML files into NPM's `/data` volume
+ * and wire `error_page` directives at it, so the page renders straight out of
+ * nginx even when the ServiceBay backend is down.
+ *
+ *   - The unknown-host page is wired into NPM's **default/dead-host** server
+ *     via the documented `/data/nginx/custom/server_dead.conf` include (the
+ *     catch-all for any host without a matching proxy_host).
+ *   - The bare-proxy-error page is wired per-configured-host via the same
+ *     `advanced_config` append path #1415 uses, generalised to 401/502/504.
+ *
+ * `error_page <code> /…` (no `=`) preserves the original status code — the
+ * request still failed, the user just gets an explanation instead of a wall.
+ */
+import { agentManager } from '@/lib/agent/manager';
+import { listNodes } from '@/lib/nodes';
+import { logger } from '@/lib/logger';
+
+/** Paths INSIDE the NPM container (its `/data` volume). */
+export const UNKNOWN_HOST_PAGE_CONTAINER_PATH = '/data/nginx/servicebay/unknown-host.html';
+export const PROXY_ERROR_PAGE_CONTAINER_PATH = '/data/nginx/servicebay/proxy-error.html';
+
+/**
+ * Host-side paths under NPM's bind-mounted data volume. Mirrors the
+ * proxy_host conf root the route already writes, so a single hard-coded data
+ * root keeps every writer consistent (same as {@link ./lanDeniedPage}).
+ */
+const NPM_DATA_ROOT = '/mnt/data/stacks/nginx-proxy-manager/data/nginx';
+export const UNKNOWN_HOST_PAGE_HOST_PATH = `${NPM_DATA_ROOT}/servicebay/unknown-host.html`;
+export const PROXY_ERROR_PAGE_HOST_PATH = `${NPM_DATA_ROOT}/servicebay/proxy-error.html`;
+
+/**
+ * Host-side path of NPM's documented dead-host custom include. NPM includes
+ * this file inside the catch-all "dead host" server block (the one that
+ * serves any host without a matching proxy_host), so it is the hook for the
+ * default server.
+ */
+export const DEAD_HOST_CUSTOM_CONF_HOST_PATH = `${NPM_DATA_ROOT}/custom/server_dead.conf`;
+
+/** Internal URIs the error_pages re-route to. Kept distinct from real paths. */
+const UNKNOWN_HOST_INTERNAL_URI = '/servicebay-unknown-host';
+const PROXY_ERROR_INTERNAL_URI = '/servicebay-proxy-error';
+
+/** Sentinel markers for idempotent appends / detection. */
+const UNKNOWN_HOST_MARKER = '# servicebay-unknown-host-explainer (#1583)';
+const PROXY_ERROR_MARKER = '# servicebay-proxy-error-explainer (#1583)';
+
+/**
+ * The dead-host server include: re-route the catch-all's errors to the
+ * branded unknown-host page. The default dead host normally returns a bare
+ * 404 (NPM) / 401 (openresty); covering 401/403/404/500/502/503/504 here
+ * means any unconfigured host renders the explainer regardless of which raw
+ * code the default server would have produced.
+ */
+export const DEAD_HOST_CUSTOM_CONF = [
+  UNKNOWN_HOST_MARKER,
+  `error_page 401 403 404 500 502 503 504 ${UNKNOWN_HOST_INTERNAL_URI};`,
+  `location = ${UNKNOWN_HOST_INTERNAL_URI} {`,
+  '    internal;',
+  '    default_type text/html;',
+  `    alias ${UNKNOWN_HOST_PAGE_CONTAINER_PATH};`,
+  '}',
+].join('\n');
+
+/**
+ * Per-configured-host `advanced_config` snippet: wire bare 401/502/504 to the
+ * branded proxy-error page. `ssi on` so the page can echo `$status`.
+ *
+ * 401 — Authelia login redirect didn't fire (e.g. forward-auth misconfig);
+ * 502/504 — the upstream service is down or starting. 403 is deliberately
+ * NOT covered here: the LAN-only deny path owns 403 (#1415).
+ */
+export const PROXY_ERROR_ADVANCED_CONFIG = [
+  PROXY_ERROR_MARKER,
+  `error_page 401 502 503 504 ${PROXY_ERROR_INTERNAL_URI};`,
+  `location = ${PROXY_ERROR_INTERNAL_URI} {`,
+  '    internal;',
+  '    ssi on;',
+  '    default_type text/html;',
+  `    alias ${PROXY_ERROR_PAGE_CONTAINER_PATH};`,
+  '}',
+].join('\n');
+
+/**
+ * Append the branded proxy-error directives to an existing `advanced_config`
+ * (which may carry forward-auth, the LAN-denied #1415 block, timeouts, …).
+ * Idempotent: a config already carrying the marker is returned unchanged.
+ */
+export function withProxyErrorPage(advancedConfig: string | undefined): string {
+  const base = advancedConfig ?? '';
+  if (base.includes(PROXY_ERROR_MARKER)) return base;
+  if (base.trim() === '') return PROXY_ERROR_ADVANCED_CONFIG;
+  return `${base.replace(/\s*$/, '')}\n\n${PROXY_ERROR_ADVANCED_CONFIG}`;
+}
+
+/**
+ * Build the branded "this host isn't a configured service" explainer. Links
+ * the dashboard and the auth portal under the operator's public domain so a
+ * user who fat-fingered a subdomain has a one-click way back. Self-contained:
+ * inline CSS, no external assets, no JS, no backend dependency.
+ *
+ * @param publicDomain e.g. `dopp.cloud`. When empty, links are omitted and
+ *   the copy degrades to "open your ServiceBay dashboard" without a URL.
+ */
+export function buildUnknownHostPageHtml(publicDomain?: string): string {
+  const domain = (publicDomain ?? '').trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  const dashboardUrl = domain ? `https://${domain}` : '';
+  const authUrl = domain ? `https://auth.${domain}` : '';
+  const dashboardLink = dashboardUrl
+    ? `<a href="${dashboardUrl}">${dashboardUrl}</a>`
+    : 'your ServiceBay dashboard';
+  const authLine = authUrl
+    ? `<li>If you meant to sign in, go to <a href="${authUrl}">${authUrl}</a>.</li>`
+    : '';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>This service isn't set up here</title>
+<style>${PAGE_CSS}</style>
+</head>
+<body>
+  <main class="card">
+    <p class="brand">ServiceBay</p>
+    <h1>This service isn't set up here</h1>
+    <p>The address you opened doesn't match any service configured on this ServiceBay. It's most often a small typo in the subdomain.</p>
+    <p>Try this:</p>
+    <ol>
+      <li><strong>Check the spelling</strong> of the part before the dot (for example <code>ldap</code>, not <code>lldap</code>).</li>
+      <li><strong>Open ${dashboardLink}</strong> to see the services that actually exist and pick the right one.</li>
+      ${authLine}
+      <li>If you just added this service, make sure its <strong>AdGuard DNS rewrite</strong> exists and its proxy host is configured, then reload.</li>
+    </ol>
+    <p class="footer">You reached the ServiceBay reverse proxy, but no service answers for this hostname.</p>
+  </main>
+</body>
+</html>
+`;
+}
+
+/**
+ * Build the branded bare-proxy-error page (401 / 502 / 503 / 504 leaking
+ * through a configured host). Shows the live status via nginx SSI and lists
+ * the next step for each case. Self-contained.
+ *
+ * @param publicDomain used to link `auth.<domain>` for the 401 case.
+ */
+export function buildProxyErrorPageHtml(publicDomain?: string): string {
+  const domain = (publicDomain ?? '').trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  const authUrl = domain ? `https://auth.${domain}` : '';
+  const signInLink = authUrl
+    ? `sign in at <a href="${authUrl}">${authUrl}</a>`
+    : 'sign in through your ServiceBay login page';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>This service couldn't be reached</title>
+<style>${PAGE_CSS}</style>
+</head>
+<body>
+  <main class="card">
+    <p class="brand">ServiceBay</p>
+    <h1>This service couldn't be reached</h1>
+    <p>The proxy answered with an error (HTTP <span class="ip"><!--# echo var="status" encoding="none" --></span>) before the service could respond.</p>
+    <p>What to try next:</p>
+    <ol>
+      <li><strong>If you weren't signed in</strong> (error 401): ${signInLink}, then reopen this page.</li>
+      <li><strong>If the service is starting or offline</strong> (error 502/503/504): wait about a minute and reload &mdash; it may still be coming up. If it stays down, check the service in your ServiceBay dashboard.</li>
+    </ol>
+    <p class="footer">The address is correct &mdash; the service behind it just didn't respond successfully.</p>
+  </main>
+</body>
+</html>
+`;
+}
+
+/**
+ * Shared inline stylesheet (matches the #1415 LAN-denied page's slate
+ * palette so all three branded pages look like one family).
+ */
+const PAGE_CSS = `
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+    line-height: 1.55;
+  }
+  .card {
+    width: 100%;
+    max-width: 560px;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 32px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 16px; color: #f8fafc; }
+  .brand { font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: #94a3b8; margin: 0 0 20px; }
+  p { margin: 0 0 14px; color: #cbd5e1; }
+  .ip {
+    display: inline-block;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    padding: 2px 8px;
+    color: #f1f5f9;
+  }
+  a { color: #60a5fa; }
+  ol { margin: 8px 0 18px; padding-left: 22px; color: #cbd5e1; }
+  ol li { margin: 0 0 8px; }
+  .footer { margin: 18px 0 0; font-size: 0.85rem; color: #64748b; border-top: 1px solid #334155; padding-top: 16px; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #f1f5f9; }`;
+
+/**
+ * Ship a single file into NPM's data volume via the agent's sudo write
+ * (NPM's container writes `/data` as root, same as #1415). Best-effort:
+ * returns `false` (logged) on any failure rather than throwing, so a write
+ * hiccup never fails an install — the worst case is the old bare openresty
+ * page, exactly the pre-#1583 behaviour.
+ */
+async function shipFile(node: string | undefined, path: string, content: string, label: string): Promise<boolean> {
+  try {
+    const nodes = await listNodes();
+    const nodeName = node ?? nodes[0]?.Name ?? 'Local';
+    const agent = agentManager.getAgent(nodeName);
+    const res = (await agent.sendCommand('write_file', {
+      path,
+      content,
+      sudo: true,
+    })) as { result?: string; error?: string };
+    if (res?.error) {
+      logger.warn('ProxyHosts', `Failed to deploy ${label}: ${res.error}`);
+      return false;
+    }
+    logger.info('ProxyHosts', `Deployed ${label} to ${path}`);
+    return true;
+  } catch (e) {
+    logger.warn('ProxyHosts', `Failed to deploy ${label}: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+}
+
+/**
+ * Deploy all branded proxy error pages + wire the default/dead-host server.
+ * Ships the two HTML files and the dead-host custom include in one go.
+ * Best-effort throughout; returns `true` only if every write succeeded.
+ *
+ * Call once per install batch (like {@link ./lanDeniedPage#deployLanDeniedPage}).
+ */
+export async function deployProxyErrorPages(publicDomain?: string, node?: string): Promise<boolean> {
+  const unknownOk = await shipFile(
+    node,
+    UNKNOWN_HOST_PAGE_HOST_PATH,
+    buildUnknownHostPageHtml(publicDomain),
+    'unknown-host explainer page',
+  );
+  const errorOk = await shipFile(
+    node,
+    PROXY_ERROR_PAGE_HOST_PATH,
+    buildProxyErrorPageHtml(publicDomain),
+    'branded proxy-error page',
+  );
+  const deadHostOk = await shipFile(
+    node,
+    DEAD_HOST_CUSTOM_CONF_HOST_PATH,
+    `${DEAD_HOST_CUSTOM_CONF}\n`,
+    'default/dead-host error_page include',
+  );
+  return unknownOk && errorOk && deadHostOk;
+}

--- a/packages/backend/src/lib/util/humanizeError.ts
+++ b/packages/backend/src/lib/util/humanizeError.ts
@@ -51,8 +51,9 @@ function humanizeDomainError(err: DomainError): HumanizedError | null {
           };
         case 'other':
           return { title: 'SSH connection failed', detail: e.message };
+        default:
+          return null;
       }
-      return null;
     }
     case 'agent_timeout':
       return {

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -9,6 +9,7 @@ import { agentManager } from '@/lib/agent/manager';
 import { listNodes } from '@/lib/nodes';
 import { AUTHELIA_LOCATION_HEADERS } from '@/lib/stackInstall/forwardAuth';
 import { withLanDeniedPage, deployLanDeniedPage } from '@/lib/reverseProxy/lanDeniedPage';
+import { withProxyErrorPage, deployProxyErrorPages } from '@/lib/reverseProxy/proxyErrorPages';
 
 export const dynamic = 'force-dynamic';
 
@@ -885,6 +886,17 @@ export const POST = withApiHandler({}, async ({ request }) => {
             await deployLanDeniedPage(node);
         }
 
+        // #1583 — Ship the branded unknown-subdomain explainer + bare-proxy-error
+        // page into NPM's data volume and wire the catch-all "dead host" server
+        // at the explainer, so an unconfigured *.dopp.cloud host (typically a
+        // typo) renders a self-explaining page instead of the raw openresty 401.
+        // Unconditional (unlike the LAN-denied page): the default server fires
+        // for ANY unknown host regardless of access lists. The per-host 401/502/504
+        // error_page is wired below in the create loop. Best-effort — a write
+        // hiccup just leaves the old bare openresty page in place.
+        const errorPageDomain = publicDomain ?? config.reverseProxy?.publicDomain;
+        await deployProxyErrorPages(errorPageDomain, node);
+
         const results: { domain: string; success: boolean; error?: string; certIssued?: boolean; certError?: string; lanRestricted?: boolean }[] = [];
 
         for (const host of hosts) {
@@ -906,6 +918,15 @@ export const POST = withApiHandler({}, async ({ request }) => {
                     advanced_config: withLanDeniedPage(host.proxyConfig?.advanced_config),
                 };
             }
+            // #1583 — Wire the branded bare-proxy-error page (401/502/503/504)
+            // into every configured host. A 401 here means the Authelia login
+            // redirect didn't fire; 502/504 means the upstream is down/starting.
+            // Idempotent; preserves any existing directives (incl. the #1415
+            // LAN-denied block, which owns 403 separately).
+            host.proxyConfig = {
+                ...host.proxyConfig,
+                advanced_config: withProxyErrorPage(host.proxyConfig?.advanced_config),
+            };
             let createdHost: { id?: number } | null = null;
             try {
                 createdHost = await createProxyHost(npm.apiUrl, token, host, accessListId);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "skipLibCheck": true,
     "strict": true,
     "noUnusedLocals": true,
+    "allowUnreachableCode": false,
+    "noFallthroughCasesInSwitch": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## What
- #1584: `autoRestoreServiceOnReinstall` no longer gates on the retired `cleanInstall` flag (which #1520 hard-set to `false`, silently disabling all NAS auto-restore). Restore now fires on its own safe conditions — a `<service>.tar` exists on the NAS **and** the data dir is empty — and emits a visible install-stream breadcrumb for both the restore-performed and the restore-skipped (with reason) paths.
- #1583: New `reverseProxy/proxyErrorPages.ts` generalises the #1415 LAN-denied mechanism. An unknown/unconfigured `*.dopp.cloud` subdomain now serves a branded explainer (not raw openresty) via NPM's catch-all dead-host server; bare 401/502/503/504 on a configured host render a branded page with next-step hints (401 → sign in at auth.<domain>, 502/503/504 → service starting/offline).
- Seal-fix: folded the dead trailing `return null` in `humanizeDomainError` into a `default:` case — #1583 widens the frontend type-check graph to reach that file, surfacing a latent tsc "unreachable code" error in `next build`.

## Why
Closes #1584
Closes #1583

## Risk
Medium — both paths are install/reverse-proxy critical and need an on-box reinstall verify.

## Rollback
git revert is enough (proxy-error writes are best-effort; restore decoupling is additive-safe).

## Verification
- [x] npm run lint (0 errors, 347 warnings, not increased)
- [x] npm run check:arch
- [x] npm test (full — 231 files / 1792 passed)
- [ ] /verify on FCoS :dev box (path-mandated: lib/externalBackup + lib/reverseProxy + NPM config injection)

AI-generated
<!-- sb-ai-comment -->