### PR TITLE
feat(install): per-service config/data split + wipe-mode model

### DIFF
--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -20,7 +20,7 @@ vi.mock('../reverseProxy/npmAdminRekey', () => ({
   rekeyNpmAdmin: (...a: unknown[]) => mockRekeyNpm(...a),
 }));
 
-import { restoreServiceBackup, isFreshDataDir, autoRestoreServiceOnReinstall } from './restore';
+import { restoreServiceBackup, isFreshDataDir, autoRestoreServiceOnReinstall, wipeServiceForReinstall } from './restore';
 import { NAS_BACKUP_DIR } from './producer';
 
 let tmpRoot: string;
@@ -123,20 +123,20 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     _tar = await buildServiceTar({ 'configuration.yaml': 'restored:', '.storage/zwave_js': '{"k":1}' });
   });
 
-  it('restores on a clean install into an empty data dir (Local node)', async () => {
+  it('restores on install into an empty data dir (Local node)', async () => {
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
 
-  it('restores even when cleanInstall is false, given backup-exists + empty dir (#1584)', async () => {
-    // #1520 retired cleanInstall to a hard-coded false; restore must no longer
-    // depend on it — backup-exists + fresh-dir are the only safe gates.
+  it('restores given backup-exists + empty dir even with no wipeMode set (#1584)', async () => {
+    // #1520 retired cleanInstall to a hard-coded false; restore depends only on
+    // backup-exists + fresh-dir for the plain install path.
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { node: 'Local' }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
@@ -144,7 +144,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
   it('is a no-op on a remote node (restore primitive is local-fs only)', async () => {
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: true, node: 'edge-node' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'edge-node' }, async l => { logs.push(l); });
     expect(await isFreshDataDir(dataDir)).toBe(true);
     expect(logs).toEqual([]);
   });
@@ -152,22 +152,98 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
   it('logs a visible skip breadcrumb (not silent) when no backup exists for the service', async () => {
     mockNas.nasList.mockResolvedValue([]); // empty NAS
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); });
     expect(logs.some(l => l.includes('home-assistant') && l.includes('no config backup'))).toBe(true);
     expect(logs.some(l => l.includes('restored'))).toBe(false);
   });
 
-  it('skips a non-empty data dir with a logged reason, never clobbers, never throws (#1584)', async () => {
+  it('on install, skips a non-empty data dir with a logged reason, never clobbers, never throws (#1584)', async () => {
     await fs.mkdir(dataDir, { recursive: true });
     await fs.writeFile(path.join(dataDir, 'live.yaml'), 'live');
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
     await expect(
-      autoRestoreServiceOnReinstall('home-assistant', { cleanInstall: false, node: 'Local' }, async l => { logs.push(l); }),
+      autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); }),
     ).resolves.toBeUndefined();
     expect(await fs.readFile(path.join(dataDir, 'live.yaml'), 'utf8')).toBe('live'); // untouched
     expect(logs.some(l => l.includes('not empty') && l.includes('skipping restore'))).toBe(true);
     expect(logs.some(l => l.includes('restored'))).toBe(false);
+  });
+
+  it('on wipe-config, FORCE-restores config over a non-empty (kept-data) dir (#1585)', async () => {
+    // Simulate post-wipe state: DATA kept, CONFIG cleared. The kept DATA file
+    // must survive; CONFIG must be re-seeded from the NAS over the top.
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'KEPT-RECORDER-DB');
+    nasHasHomeAssistantBackup();
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
+    expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('KEPT-RECORDER-DB'); // DATA kept
+    expect(logs.some(l => l.includes('wipe-config') && l.includes('restoring config'))).toBe(true);
+  });
+
+  it('on wipe-all, restores config into the (now-empty) dir (#1585)', async () => {
+    nasHasHomeAssistantBackup();
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local' }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
+    expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
+  });
+});
+
+describe('wipeServiceForReinstall (#1585)', () => {
+  it('install mode is a no-op (keeps config + data, logs nothing)', async () => {
+    await fs.mkdir(path.join(dataDir, '.storage'), { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'data');
+    const logs: string[] = [];
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('cfg');
+    expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('data');
+    expect(logs).toEqual([]);
+  });
+
+  it('wipe-config clears CONFIG paths, KEEPS DATA paths (#1585 core)', async () => {
+    await fs.mkdir(path.join(dataDir, '.storage'), { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
+    await fs.writeFile(path.join(dataDir, 'automations.yaml'), 'autos');
+    await fs.writeFile(path.join(dataDir, '.storage/zwave_js'), 'keys'); // CONFIG (mesh keys)
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'RECORDER'); // DATA
+    const logs: string[] = [];
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    // CONFIG gone:
+    await expect(fs.access(path.join(dataDir, 'configuration.yaml'))).rejects.toThrow();
+    await expect(fs.access(path.join(dataDir, 'automations.yaml'))).rejects.toThrow();
+    await expect(fs.access(path.join(dataDir, '.storage/zwave_js'))).rejects.toThrow();
+    // DATA kept:
+    expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('RECORDER');
+    expect(logs.some(l => l.includes('wipe-config') && l.includes('kept the service data'))).toBe(true);
+  });
+
+  it('wipe-all clears the entire service data dir (CONFIG + DATA)', async () => {
+    await fs.mkdir(path.join(dataDir, '.storage'), { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'RECORDER');
+    const logs: string[] = [];
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local' }, async l => { logs.push(l); });
+    expect(await isFreshDataDir(dataDir)).toBe(true);
+    expect(logs.some(l => l.includes('wipe-all') && l.includes('config + data'))).toBe(true);
+  });
+
+  it('is a no-op on a remote node', async () => {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
+    const logs: string[] = [];
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'edge-node' }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('cfg'); // untouched
+    expect(logs).toEqual([]);
+  });
+
+  it('logs a skip note for a service with no manifest (no classification to wipe)', async () => {
+    const logs: string[] = [];
+    await wipeServiceForReinstall('not-a-service', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    expect(logs.some(l => l.includes('no backup manifest'))).toBe(true);
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -19,9 +19,18 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { fetchServiceBackup, listServiceBackups, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
-import { getServiceManifest } from './serviceManifest';
+import { getServiceManifest, getConfigPaths } from './serviceManifest';
 import { safeTarExtract } from '../systemBackup';
 import { logger } from '../logger';
+
+/**
+ * Per-service wipe mode (#1585). Structurally identical to
+ * `install/jobStore.ts`'s `WipeMode` but declared locally so this backup module
+ * doesn't import from the install module (the install runner already imports
+ * THIS module — a cross-import would form a cycle). The install runner passes
+ * its `JobInput.wipeMode` straight through.
+ */
+type WipeMode = 'install' | 'wipe-config' | 'wipe-all';
 
 export interface RestoreResult {
   service: string;
@@ -140,48 +149,116 @@ export async function restoreServiceBackup(
 }
 
 /**
- * #1218 entry point 1 — auto-restore a service's config from the NAS before its
- * pod starts on any (re)deploy. Gated on its **own safe conditions** rather than
- * the install mode: it fires when a `<service>.tar` exists on the NAS **and**
- * the service's data dir is empty/fresh — so it can't clobber live data, yet it
- * no longer depends on the retired `cleanInstall` flag (#1584: #1520 hard-set
- * `cleanInstall = false`, which silently disabled restore for every install).
+ * #1585 — per-service wipe before a (re)deploy, under the install `wipeMode`
+ * model. Acts ONLY on this one service's on-disk data dir (never a system-wide
+ * nuke — that's Factory Reset's job):
  *
- * Conditions (all required to restore):
- *  - the node is Local (the restore primitive uses the backend's own fs), AND
- *  - a `<service>.tar` exists on the NAS, AND
- *  - the service's data dir is empty (`restoreServiceBackup` also refuses a
- *    non-empty dir, so a live service's config is never clobbered).
+ *   install      → no-op (keep config + data)
+ *   wipe-config  → delete the service's CONFIG paths (manifest `include`),
+ *                  KEEP its DATA (recorder db, photo library, mesh db, …)
+ *   wipe-all     → delete the whole service data dir (CONFIG + DATA)
  *
- * Emits a VISIBLE breadcrumb through the injected `log` for BOTH outcomes —
+ * After this runs, `autoRestoreServiceOnReinstall` re-seeds CONFIG from the NAS
+ * (the wiped CONFIG paths are gone, so the restore re-creates them over the
+ * kept DATA). ServiceBay-managed bits stamped into the restored
+ * `configuration.yaml` (HA `http: trusted_proxies`, the OIDC client secret) are
+ * re-applied by the existing post-deploy self-heal hooks (serviceLifecycle's
+ * trusted_proxies append + the #989 OIDC dispatcher), which run on every deploy
+ * regardless of the restore — so the documented caveat is honoured without a
+ * second stamping path here.
+ *
+ * Emits a VISIBLE breadcrumb for what it wiped. Best-effort: a wipe failure is
+ * logged and swallowed so it can't block the deploy. Local-node only (the fs
+ * primitive is local); a remote node short-circuits silently.
+ */
+export async function wipeServiceForReinstall(
+  service: string,
+  opts: { wipeMode?: WipeMode; node?: string | null },
+  log: (line: string) => Promise<void>,
+): Promise<void> {
+  const mode = opts.wipeMode ?? 'install';
+  if (mode === 'install') return;
+  if (opts.node && opts.node !== 'Local') return;
+  if (!getServiceManifest(service)) {
+    // No manifest → no declared config/data classes → nothing safe to wipe.
+    await log(`(note) ${service}: no backup manifest, skipping ${mode} wipe (no config/data classification).`);
+    return;
+  }
+  try {
+    const dataDir = await resolveServiceDataDir(service);
+    if (mode === 'wipe-all') {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      await log(`🧹 ${service}: wipe-all — cleared the service data dir (config + data).`);
+      return;
+    }
+    // wipe-config: delete only the manifest's CONFIG paths, keep everything else.
+    const configPaths = getConfigPaths(service);
+    let removed = 0;
+    for (const rel of configPaths) {
+      const abs = path.join(dataDir, rel);
+      // Guard against traversal — the manifest is trusted static data, but keep
+      // the same invariant the restore path enforces.
+      if (!abs.startsWith(dataDir + path.sep)) continue;
+      try {
+        await fs.rm(abs, { recursive: true, force: true });
+        removed += 1;
+      } catch { /* path absent — fine */ }
+    }
+    await log(`🧹 ${service}: wipe-config — cleared ${removed} config path(s), kept the service data on disk.`);
+  } catch (e) {
+    await log(`(note) ${service}: ${mode} wipe skipped — ${e instanceof Error ? e.message : String(e)}.`);
+  }
+}
+
+/**
+ * #1218 entry point 1 / #1585 — auto-restore a service's config from the NAS
+ * before its pod starts on any (re)deploy. Gated on its **own safe conditions**
+ * plus the install `wipeMode`, not the retired `cleanInstall` flag (#1584: #1520
+ * hard-set `cleanInstall = false`, which silently disabled restore).
+ *
+ * Restore conditions by mode:
+ *  - `install`: restore only if the data dir is empty/fresh (config missing) —
+ *    never clobber a live service's config.
+ *  - `wipe-config` / `wipe-all`: the CONFIG paths were just cleared by
+ *    `wipeServiceForReinstall`, so FORCE-restore them from the NAS over the kept
+ *    DATA (the tar contains only CONFIG paths, so this re-seeds config without
+ *    touching the kept recorder db / photo library / mesh db).
+ *
+ * Common preconditions (all modes): the node is Local AND a `<service>.tar`
+ * exists on the NAS. Emits a VISIBLE breadcrumb for BOTH outcomes —
  * restore-performed and restore-skipped (with the reason) — so a skipped
  * restore is never silent (the #1584 root cause was the old silent `return`).
- * The Local-node short-circuit stays silent: it's an architectural no-op (the
- * primitive is local-fs only), not a user-facing decision.
+ * The Local-node short-circuit stays silent: it's an architectural no-op.
  *
  * Best-effort: a restore failure is logged and swallowed so it can't block the
  * deploy. The install runner calls this from `deployItem` (epic #1190).
  */
 export async function autoRestoreServiceOnReinstall(
   service: string,
-  opts: { cleanInstall?: boolean; node?: string | null },
+  opts: { wipeMode?: WipeMode; node?: string | null },
   log: (line: string) => Promise<void>,
 ): Promise<void> {
-  // #1584: deliberately NOT gated on opts.cleanInstall — that flag was retired
-  // to false (#1520) and was the sole gate, which silently killed auto-restore.
+  const mode = opts.wipeMode ?? 'install';
+  // #1584/#1585: gated on the wipeMode + safe conditions, NOT the retired
+  // cleanInstall flag (which #1520 pinned false, silently killing restore).
   if (opts.node && opts.node !== 'Local') return;
+  const forceRestore = mode === 'wipe-config' || mode === 'wipe-all';
   try {
     const hasBackup = (await listServiceBackups()).some(b => b.service === service);
     if (!hasBackup) {
       await log(`(note) ${service}: no config backup found on the FritzBox NAS — starting on existing/blank data.`);
       return;
     }
-    if (!(await isFreshDataDir(await resolveServiceDataDir(service)))) {
+    if (!forceRestore && !(await isFreshDataDir(await resolveServiceDataDir(service)))) {
       await log(`(note) ${service}: a config backup exists on the NAS, but the data dir is not empty — keeping the on-disk data and skipping restore.`);
       return;
     }
-    await log(`💾 ${service}: found a config backup on the FritzBox NAS and the data dir is empty — restoring before first start…`);
-    const r = await restoreServiceBackup(service, { node: opts.node });
+    await log(
+      forceRestore
+        ? `💾 ${service}: ${mode} — restoring config from the FritzBox NAS over the kept data before first start…`
+        : `💾 ${service}: found a config backup on the FritzBox NAS and the data dir is empty — restoring before first start…`,
+    );
+    const r = await restoreServiceBackup(service, { node: opts.node, force: forceRestore });
     await log(`✅ ${service}: restored ${r.files} config file(s) from the NAS${r.meta ? ` (backed up ${r.meta.createdAt.slice(0, 10)} from ${r.meta.nodeId})` : ''}.`);
     // On a reinstall the pod isn't up yet, so credentialReconcile is normally
     // a no-op here (the install runner's post-deploy self-heal re-keys NPM once

--- a/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
@@ -3,6 +3,8 @@ import yaml from 'js-yaml';
 import {
   SERVICE_BACKUP_MANIFESTS,
   getServiceManifest,
+  getConfigPaths,
+  getDataPaths,
   stripYamlKeys,
   applyStripRules,
 } from './serviceManifest';
@@ -63,6 +65,41 @@ describe('stripYamlKeys', () => {
   it('returns the original content unchanged when it is not valid YAML', () => {
     const garbage = '\t: : not: yaml: [unclosed';
     expect(stripYamlKeys(garbage, ['password'])).toBe(garbage);
+  });
+});
+
+describe('config/data classification (#1585)', () => {
+  it('getConfigPaths returns the manifest include set (the CONFIG class)', () => {
+    const ha = getServiceManifest('home-assistant')!;
+    expect(getConfigPaths('home-assistant')).toEqual(ha.include);
+    // CONFIG includes the small restorable bits.
+    expect(getConfigPaths('home-assistant')).toContain('configuration.yaml');
+    expect(getConfigPaths('home-assistant')).toContain('.storage/zwave_js');
+  });
+
+  it('getDataPaths returns the large on-RAID artifacts kept through wipe-config', () => {
+    expect(getDataPaths('home-assistant')).toContain('home-assistant_v2.db');
+    expect(getDataPaths('home-assistant')).toContain('zwave_js_network.db');
+  });
+
+  it('CONFIG and DATA are disjoint for home-assistant (recorder db is DATA, mesh keys are CONFIG)', () => {
+    const config = new Set(getConfigPaths('home-assistant'));
+    const data = getDataPaths('home-assistant');
+    // The heavy recorder DB must NOT be in the CONFIG (backed-up) set.
+    expect(config.has('home-assistant_v2.db')).toBe(false);
+    // No DATA path is also a CONFIG path.
+    for (const d of data) expect(config.has(d)).toBe(false);
+  });
+
+  it('returns empty arrays for a service with no manifest', () => {
+    expect(getConfigPaths('not-a-service')).toEqual([]);
+    expect(getDataPaths('not-a-service')).toEqual([]);
+  });
+
+  it('a service may declare no DATA class (authelia is config-only)', () => {
+    expect(getServiceManifest('authelia')!.data).toBeUndefined();
+    expect(getDataPaths('authelia')).toEqual([]);
+    expect(getConfigPaths('authelia')).toContain('users_database.yml');
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -36,11 +36,33 @@ export interface ServiceBackupManifest {
    *  (NPM ships as template `nginx` but stores under `nginx-proxy-manager/`).
    *  Defaults to `service`. */
   dataSubdir?: string;
-  /** Relative paths/dirs that ARE config worth preserving across a reinstall. */
+  /**
+   * The CONFIG class (#1585): small, backed up to the NAS, restorable.
+   * These relative paths/dirs ARE the per-service config worth preserving
+   * across a reinstall (HA `configuration.yaml`/automations/`.storage`, the
+   * OIDC client, etc.). The backup producer tars exactly these; a
+   * `wipe-config` reinstall deletes exactly these from disk and restores them
+   * from the NAS on startup. `data[]` (below) is KEPT through a wipe-config.
+   */
   include: string[];
   /** Relative paths/dirs to never back up — bulk data, logs, caches, and
    *  secrets with no restore value. Conceptually excludes win over includes. */
   exclude: string[];
+  /**
+   * The DATA class (#1585): large, NEVER backed up, lives on the RAID. These
+   * relative paths/dirs are KEPT on disk through a `wipe-config` reinstall
+   * (HA `home-assistant_v2.db` recorder history, Immich photo library, Z-Wave
+   * mesh db). A `wipe-all` reinstall wipes them; `wipe-config` does not.
+   *
+   * This is a DECLARATION of the heavy on-RAID artifacts, distinct from
+   * `exclude` (which is "don't put this in the backup tarball" — a superset
+   * that also covers logs/caches/sessions). Both can name the same path; the
+   * intent differs. Optional: a service with no large on-RAID artifacts (e.g.
+   * authelia) omits it. Informational/documentary today — wipe-config keeps
+   * everything that isn't a CONFIG path regardless — but it makes the
+   * config↔data split explicit and is the seam for any future per-class wipe.
+   */
+  data?: string[];
   /** Per-file transforms applied before a file enters the tarball. */
   strip?: StripRule[];
   /** Optional in-container snapshot step the producer runs before staging
@@ -72,6 +94,13 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
       'home-assistant_v2.db', 'home-assistant_v2.db-wal', 'home-assistant_v2.db-shm',
       'history', 'logs', 'home-assistant.log', 'tts', 'image', 'www', 'deps',
     ],
+    // Large on-RAID artifacts kept through a wipe-config: the recorder history
+    // DB (can be many GB) and the Z-Wave mesh DB. The zwave_js *keys* are CONFIG
+    // (in `include`) so the mesh re-pairs; the mesh db itself is heavy DATA.
+    data: [
+      'home-assistant_v2.db', 'home-assistant_v2.db-wal', 'home-assistant_v2.db-shm',
+      'zwave_js_network.db',
+    ],
   },
   {
     service: 'authelia',
@@ -92,6 +121,9 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // device list + folder-share definitions; the synced data re-syncs from peers.
     include: ['config.xml'],
     exclude: ['index-v0.14.0.db', 'index'],
+    // The synced-folder index re-syncs from peers, but it's a heavy on-RAID
+    // artifact worth keeping through a wipe-config rather than re-indexing.
+    data: ['index-v0.14.0.db', 'index'],
   },
   {
     service: 'hermes',
@@ -99,6 +131,9 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // installed-skills git URLs, household-member personalization.
     include: ['config.yaml'],
     exclude: ['vectordb', 'embeddings', 'conversations', 'history'],
+    // The vector store + embeddings are large and rebuildable, but kept on the
+    // RAID through a wipe-config (re-embedding is expensive).
+    data: ['vectordb', 'embeddings'],
     // LLM API keys are re-entered after a restore.
     strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
   },
@@ -134,6 +169,25 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
 
 export function getServiceManifest(service: string): ServiceBackupManifest | undefined {
   return SERVICE_BACKUP_MANIFESTS.find(m => m.service === service);
+}
+
+/**
+ * The CONFIG class for a service (#1585): the relative paths a `wipe-config`
+ * reinstall deletes and then restores from the NAS. This is exactly the
+ * manifest's `include` set — the small, backed-up, restorable config. Returns
+ * `[]` for a service with no manifest (nothing classified as config).
+ */
+export function getConfigPaths(service: string): string[] {
+  return [...(getServiceManifest(service)?.include ?? [])];
+}
+
+/**
+ * The DATA class for a service (#1585): the large on-RAID artifacts a
+ * `wipe-config` reinstall KEEPS (and a `wipe-all` wipes). Returns `[]` when the
+ * manifest declares none.
+ */
+export function getDataPaths(service: string): string[] {
+  return [...(getServiceManifest(service)?.data ?? [])];
 }
 
 /**

--- a/packages/backend/src/lib/install/applyVariableDefaults.test.ts
+++ b/packages/backend/src/lib/install/applyVariableDefaults.test.ts
@@ -13,7 +13,7 @@ import { applyVariableDefaults } from './manifestAssembler';
 import type { JobInput } from './jobStore';
 
 function input(partial: Partial<JobInput>): JobInput {
-  const base: JobInput = { items: [], variables: [], cleanInstall: false, cleanInstallConfirm: '', templateSource: 'installed', host: 'localhost' };
+  const base: JobInput = { items: [], variables: [], wipeMode: 'install', templateSource: 'installed', host: 'localhost' };
   return { ...base, ...partial };
 }
 

--- a/packages/backend/src/lib/install/jobStore.logcap.test.ts
+++ b/packages/backend/src/lib/install/jobStore.logcap.test.ts
@@ -34,8 +34,7 @@ function mkInput(): JobInput {
   return {
     items: [],
     variables: [],
-    cleanInstall: false,
-    cleanInstallConfirm: '',
+    wipeMode: 'install',
     templateSource: 'test',
     host: 'localhost',
   };

--- a/packages/backend/src/lib/install/jobStore.race.test.ts
+++ b/packages/backend/src/lib/install/jobStore.race.test.ts
@@ -29,8 +29,7 @@ function mkInput(): JobInput {
   return {
     items: [{ name: 'stub', checked: true }],
     variables: [],
-    cleanInstall: false,
-    cleanInstallConfirm: '',
+    wipeMode: 'install',
     templateSource: 'test',
     host: 'localhost',
   };

--- a/packages/backend/src/lib/install/jobStore.ts
+++ b/packages/backend/src/lib/install/jobStore.ts
@@ -69,17 +69,34 @@ export interface JobInputVariable {
   meta?: unknown;
 }
 
+/**
+ * Per-service wipe mode for an install run (#1585). Replaces the old inert
+ * `cleanInstall` + `cleanInstallConfirm` + `preserve[]` triple (the install
+ * runner must never system-wide-wipe — that's Factory Reset's job). Per the
+ * agreed model, the unit of action is the *service's* config↔data split:
+ *
+ *   mode        | CONFIG | DATA | on startup
+ *   ------------+--------+------+---------------------------
+ *   install     | keep   | keep | restore CONFIG iff missing
+ *   wipe-config | WIPE   | keep | RESTORE CONFIG from NAS
+ *   wipe-all    | WIPE   | WIPE | RESTORE CONFIG from NAS
+ *
+ * CONFIG / DATA paths come from each service's backup manifest
+ * (`externalBackup/serviceManifest.ts`). Distinct from the *build-time*
+ * `FACTORY_FRESH=wipe-configs` flag, which wipes ServiceBay's OWN identity
+ * (config.json/secret.key/tokens) — not a service's config.
+ */
+export type WipeMode = 'install' | 'wipe-config' | 'wipe-all';
+
 export interface JobInput {
   items: JobInputItem[];
   variables: JobInputVariable[];
   node?: string;
-  cleanInstall: boolean;
-  cleanInstallConfirm: string;
-  /** Per-group preserve flags for the clean-install wipe (#568). Each
-   *  entry the operator left checked means "keep this group". Maps to
-   *  `ResetGroup` from `@/lib/install/resetGroups`. Omitted = use the
-   *  API default (keep system-critical: secrets + certs + identity). */
-  preserve?: string[];
+  /** How an install treats each service's on-disk config/data (#1585). The
+   *  install runner never system-wide-wipes; `wipe-config`/`wipe-all` act on
+   *  the per-service config/data paths from the backup manifest. Defaults to
+   *  `install` (keep everything) when absent. */
+  wipeMode?: WipeMode;
   templateSource: string;
   /** `window.location.hostname` captured client-side so the credentials
    *  banner can render reachable URLs without the server having to guess. */

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -415,14 +415,29 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
     },
   });
 
+  // #1585 — per-service wipe under the new wipeMode model. wipe-config clears
+  // only this service's CONFIG paths (keeps DATA); wipe-all clears CONFIG+DATA.
+  // Acts ONLY on this service's data dir — never a system-wide nuke. No-op for
+  // `install` (or absent mode). Best-effort; never throws.
+  {
+    const { wipeServiceForReinstall } = await import('@/lib/externalBackup/restore');
+    await wipeServiceForReinstall(
+      item.name,
+      { wipeMode: input.wipeMode, node: input.node },
+      line => log(jobId, line),
+    );
+  }
+
   // #1218 entry point 1 — restore this service's config from the NAS before its
-  // pod starts, on a reinstall into an empty data dir. No-op otherwise; never
-  // throws (see autoRestoreServiceOnReinstall). Mirrors the cert-archive restore.
+  // pod starts. On `install` it restores only into an empty data dir (config
+  // missing); on `wipe-config`/`wipe-all` the CONFIG paths were just cleared, so
+  // it force-restores them over the kept DATA. No-op otherwise; never throws
+  // (see autoRestoreServiceOnReinstall). Mirrors the cert-archive restore.
   {
     const { autoRestoreServiceOnReinstall } = await import('@/lib/externalBackup/restore');
     await autoRestoreServiceOnReinstall(
       item.name,
-      { cleanInstall: input.cleanInstall, node: input.node },
+      { wipeMode: input.wipeMode, node: input.node },
       line => log(jobId, line),
     );
   }
@@ -673,62 +688,16 @@ async function runJob(jobId: string): Promise<void> {
 
   const scriptCredentials: Credential[] = [];
 
-  // Optional clean-install reset.
-  if (input.cleanInstall && input.cleanInstallConfirm === 'RESET') {
-    // Per-group preserve flags (#568): operator's checkbox state from
-    // the wizard. Omitted entirely → endpoint applies the conservative
-    // default (keep secrets + certs + identity, wipe service-data).
-    const preserve = input.preserve;
-    const previewLabel = preserve === undefined
-      ? 'default (keep secrets/certs/identity, wipe service-data)'
-      : preserve.length === 0
-        ? 'FACTORY RESET — wipe everything'
-        : `keep ${preserve.join(' + ')}`;
-    await log(jobId, `🧹 Clean install — ${previewLabel}…`);
-    try {
-      const res = await apiFetch('/api/system/stacks/reset', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          confirm: 'RESET',
-          node: input.node || undefined,
-          ...(preserve !== undefined ? { preserve } : {}),
-        }),
-      });
-      const data = await res.json();
-      if (res.ok) {
-        const removed = data.deleted?.length ?? 0;
-        const kept = data.preservedServices?.length ?? 0;
-        await log(jobId, `✅ Reset done — removed ${removed} service${removed === 1 ? '' : 's'}${kept ? `, kept ${kept} (${(data.preservedServices ?? []).join(', ')})` : ''}.`);
-        if (data.wipeStepsRun?.length) {
-          await log(jobId, `   Wiped: ${data.wipeStepsRun.join('; ')}.`);
-        }
-        if (data.certArchive) {
-          await log(jobId, `   Archived NPM data to ${data.certArchive} — cert-reuse will pull from it on next install.`);
-        }
-        if (data.failed?.length) {
-          await log(jobId, `⚠️ Some services could not be cleanly removed: ${data.failed.map((f: { name: string }) => f.name).join(', ')}`);
-        }
-      } else {
-        // Pre-fix the runner logged a warning and continued. But the
-        // operator typed RESET to confirm they want a clean slate;
-        // proceeding to deploy on top of un-wiped state silently
-        // violates that promise (existing service data persists,
-        // stale containers count as already-installed in the wizard
-        // UI, the "8/12 deployed" confusion). Hard-fail the install
-        // so the operator can investigate + retry.
-        const detail = data.error || 'unknown error';
-        await log(jobId, `❌ Reset failed: ${detail}. Aborting install — existing service data would persist and counted as already-installed in the next run. Fix the reset cause then retry.`);
-        await patchJob(jobId, { phase: 'error', endedAt: new Date().toISOString(), error: `Reset failed: ${detail}` });
-        return;
-      }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : 'unknown error';
-      await log(jobId, `❌ Reset call failed: ${msg}. Aborting install — clean-install was requested but the wipe didn't run. Check the server log and retry.`);
-      await patchJob(jobId, { phase: 'error', endedAt: new Date().toISOString(), error: `Reset call failed: ${msg}` });
-      return;
-    }
-  }
+  // #1585 — the install runner NEVER system-wide-wipes. The old
+  // `if (input.cleanInstall && cleanInstallConfirm === 'RESET')` branch POSTed
+  // to `/api/system/stacks/reset` (a system-wide nuke of EVERY service on the
+  // node) and was already dead (cleanInstall was hard-pinned `false` in the
+  // start route). It is deleted here. System-wide wipe lives only in the
+  // explicit Factory Reset (`/api/system/factory-reset`, which still uses
+  // `/api/system/stacks/reset`). Per-service wipe under the new `wipeMode`
+  // model happens per-service in `deployItem` (it clears only that service's
+  // CONFIG (wipe-config) or CONFIG+DATA (wipe-all) paths, never other
+  // services' data), then restores CONFIG from the NAS on startup.
 
   // Capture / refresh the host's LAN IP synchronously (#660 — S2).
   //
@@ -827,10 +796,14 @@ async function runJob(jobId: string): Promise<void> {
   // and reinstall", which silently destroys identity state — the
   // opposite of what they ticked.
   //
-  // Conditions for the override:
-  //   - Not a clean install (always reuse saved state on plain re-install), OR
-  //   - Clean install AND `secrets` is in the preserve list (operator
-  //     explicitly chose to keep prior identity).
+  // #1585 — saved secrets are ALWAYS reused. ServiceBay's identity (saved
+  // secret-typed variables, secret.key, tokens) is never wiped by the install
+  // runner under any wipeMode: `wipe-config`/`wipe-all` clear a SERVICE's
+  // config/data, not ServiceBay's own identity. Wiping identity is the
+  // build-time `FACTORY_FRESH=wipe-configs` flag's job — a different mechanism
+  // entirely (see jobStore.WipeMode). So the old `shouldReuseSecrets` (which
+  // already collapsed to constant-true once cleanInstall was pinned false) is
+  // dropped in favour of always reusing.
   //
   // The legacy NPM-specific block below is now subsumed by this general
   // path; kept anyway because it has a specific cert-archive-was-just-
@@ -839,9 +812,7 @@ async function runJob(jobId: string): Promise<void> {
   // Authelia-storage self-heal below reads this to decide whether the
   // encryption key matches existing on-disk Authelia storage or is
   // freshly generated.
-
-  const shouldReuseSecrets = !input.cleanInstall || (input.preserve?.includes('secrets') ?? true);
-  if (shouldReuseSecrets) {
+  {
     try {
       const { getConfig } = await import('@/lib/config');
       const { loadSavedSecrets } = await import('./savedSecrets');
@@ -1217,16 +1188,19 @@ async function runJob(jobId: string): Promise<void> {
     // don't have (forgotten, never copied off the credentials banner).
     // Auto-wipe the NPM data dir (admin sqlite + sites table) and
     // retry bootstrap; letsencrypt/ stays untouched so cert files
-    // survive — that's the only reason "preserve certs" exists in the
-    // first place.
+    // survive — the heal targets only the stale admin DB, never the certs.
     //
-    // Used to be gated on `input.cleanInstall` only — but the same
-    // mismatch happens on a regular re-install over a preserved data
-    // volume (e.g. swap an OS install, redeploy stacks). Both end with
-    // the same prompt-the-operator flow; auto-heal applies equally.
+    // #1585 — re-expressed against the wipeMode model's data-keep semantics.
+    // The heal is intrinsically cert-preserving (it removes only
+    // `nginx-proxy-manager/data`, leaving `letsencrypt/`), so it applies for
+    // any mode that keeps NPM's certs on disk: `install` and `wipe-config`
+    // (both keep DATA, i.e. letsencrypt/). On `wipe-all` the whole NPM dir was
+    // already cleared by the per-service wipe, so there's no stale admin DB to
+    // heal — skip. (Previously gated on the inert `preserve?.includes('certs')`
+    // which collapsed to constant-true.)
     if (
       bootstrapState === 'needs_credentials'
-      && (input.preserve?.includes('certs') ?? true)
+      && input.wipeMode !== 'wipe-all'
     ) {
       const node = input.node || 'Local';
       const dataDir = (await getConfig()).templateSettings?.DATA_DIR || '/mnt/data/stacks';

--- a/packages/frontend/src/app/api/install/start/route.ts
+++ b/packages/frontend/src/app/api/install/start/route.ts
@@ -36,15 +36,16 @@ export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request
     if (!input || !Array.isArray(input.items) || !Array.isArray(input.variables)) {
       return NextResponse.json({ error: 'invalid input' }, { status: 400 });
     }
-    // #1520 — clean-install (wipe-then-deploy) is retired: an install never
-    // wipes existing data. A reinstall is a plain redeploy over the data on
-    // disk (the runner's `!cleanInstall` path: reuse saved secrets, preserve
-    // certs — the safe credential-reconciliation defaults); the only
-    // system-wide wipe is the explicit Factory Reset. Enforce server-side so
-    // no caller (old client, replayed JobInput) can trigger the wipe branch.
-    input.cleanInstall = false;
-    input.cleanInstallConfirm = '';
-    delete input.preserve;
+    // #1585 — wipe-mode model. The install runner never SYSTEM-WIDE wipes (that
+    // is Factory Reset's job); `wipe-config`/`wipe-all` act only on the
+    // PER-SERVICE config/data paths from each backup manifest. Normalise the
+    // field server-side: anything that isn't a known mode (or absent, e.g. an
+    // old client / replayed JobInput) becomes the safe `install` default — keep
+    // config + data, reuse saved secrets, restore config only if missing.
+    const VALID_WIPE_MODES = ['install', 'wipe-config', 'wipe-all'] as const;
+    input.wipeMode = VALID_WIPE_MODES.includes(input.wipeMode as never)
+      ? input.wipeMode
+      : 'install';
     const existing = await getCurrentJob();
     if (existing) {
       return NextResponse.json(

--- a/tools/sb/internal/build/assets/fedora-coreos.bu
+++ b/tools/sb/internal/build/assets/fedora-coreos.bu
@@ -371,11 +371,18 @@ storage:
           # Best-effort: a box booted with SELinux disabled has no chcon.
           chcon -R -t container_file_t "$MOUNT_POINT/containers" 2>/dev/null || true
 
-          # Factory-fresh "wipe-configs" (#1496): clear ServiceBay's own identity
-          # so the install promotes the freshly-baked config instead of merging the
-          # old one back — fresh admin / secret.key / tokens — while KEEPING all
-          # service data under stacks/. (wipe-all-data already reformatted, so the
-          # dir is empty there and this is a no-op.) Gated on the baked flag.
+          # Factory-fresh "wipe-configs" (#1496): clear ServiceBay's own IDENTITY
+          # (config.json / secret.key / admin / API tokens) so the install promotes
+          # the freshly-baked config instead of merging the old one back — while
+          # KEEPING all service data under stacks/.
+          #
+          # NOTE (#1585): "wipe-configs" here is ServiceBay's OWN identity — NOT a
+          # service's config. It is a DIFFERENT axis from the per-service wipeMode
+          # (install | wipe-config | wipe-all) the install runner applies to each
+          # service's CONFIG/DATA paths. This build flag never touches a service's
+          # own config or data under stacks/<service>/; the per-service wipe does.
+          # (wipe-all-data already reformatted, so the dir is empty there and this
+          # is a no-op.) Gated on the baked flag.
           # checks.json + results/ are ServiceBay state (the health-check registry
           # and its history), not service data — they belong on the wiped side, or
           # an un-installed service's check leaks across a reinstall (#1551).

--- a/tools/sb/internal/ui/buildform.go
+++ b/tools/sb/internal/ui/buildform.go
@@ -94,7 +94,7 @@ var settingsFields = []sfield{
 	{label: "Admin username", help: "Login for the ServiceBay web dashboard (and the in-TUI sign-in).",
 		get: func(s *build.Settings) string { return s.ServicebayAdminUser }, set: func(s *build.Settings, v string) { s.ServicebayAdminUser = v }},
 	{label: "Factory-fresh install", kind: fChoice, options: []string{"off", "wipe-configs", "wipe-all-data"},
-		help: "DESTRUCTIVE. off = normal reinstall (keeps config + data). wipe-configs = fresh ServiceBay config (new admin/secrets/tokens); KEEPS service data on disk (HA .storage, Z-Wave, Immich library in DATA_DIR) but does NOT auto-pull it back from NAS — restore service data explicitly afterwards or services come up blank. wipe-all-data = reformat the whole data disk (BLANK box, ALL service data gone, restore everything from backup).",
+		help: "DESTRUCTIVE. Acts on ServiceBay's OWN identity + the data disk — NOT on a service's own settings (that is the per-service wipe-config in the install/stack panel). off = normal reinstall (keeps ServiceBay identity + all service data). wipe-configs = fresh ServiceBay IDENTITY ONLY (new admin / secret.key / API tokens); KEEPS every service's config AND data on disk (HA .storage, Z-Wave mesh, Immich library in DATA_DIR) and does NOT auto-pull from NAS. wipe-all-data = reformat the whole data disk (BLANK box, ALL service config + data gone, restore everything from backup).",
 		get:  func(s *build.Settings) string { return ffOrOff(s.FactoryFresh) }, set: func(s *build.Settings, v string) { s.FactoryFresh = v }},
 	{label: "Public domain", help: "Optional external domain for reverse-proxy/TLS. Blank to skip.",
 		get: func(s *build.Settings) string { return s.PublicDomain }, set: func(s *build.Settings, v string) { s.PublicDomain = v }},


### PR DESCRIPTION
## What
Splits a service's backup manifest into CONFIG (`include`) and DATA (`data[]`) path classes, and replaces the inert `cleanInstall` triple on `JobInput` with a `WipeMode` enum (`install` | `wipe-config` | `wipe-all`). On reinstall, `wipe-config` wipes a service's CONFIG paths, keeps its DATA, and force-restores CONFIG from NAS on startup; `wipe-all` wipes both (then restores CONFIG); `install` keeps both. The dead system-wide `/api/system/stacks/reset` branch in the install runner is deleted (the install runner must never node-wide-nuke; Factory Reset still owns `/stacks/reset`). `fedora-coreos.bu` + `buildform.go` wording is disambiguated so build-time `FACTORY_FRESH` (ServiceBay identity) reads distinctly from a per-service `wipe-config` (a service's own settings).

## Why
Closes #1585

## Risk
Medium — touches the install runner wipe path and the NAS restore-on-reinstall path; both are exercised by unit tests but the real wipe-mode behaviour needs a reinstall to fully confirm.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 347 warnings — not increased)
- [x] npm run check:arch
- [x] npm test (full — 231 files / 1804 passed)
- [x] Go gates: gofmt / vet / build / test (tools/sb)
- [ ] /verify on FCoS :dev box (path-mandated: install runner wipe-mode, backup manifest config/data classification, restore-on-wipe, fedora-coreos.bu + buildform)