### PR TITLE
fix(diagnose): scope sso_verify probes to installed services

### DIFF
--- a/packages/backend/src/lib/diagnose/ssoVerify.test.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.test.ts
@@ -20,14 +20,25 @@ import {
   extractAutheliaCookie,
   makeEphemeralUsername,
   USER_APP_SIGNATURES,
+  SUBDOMAIN_TEMPLATE,
   ADMIN_ONLY_HOSTS,
+  probeableUserSubdomains,
   type SsoVerifyDeps,
   type DomainProbe,
 } from './ssoVerify';
 
+const tmpl = (n: string) => ({ [n]: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' } });
+
+// A "full" install: auth + every template that backs a user subdomain. Used
+// by the happy-path tests so all USER_APP_SIGNATURES hosts are probed.
+const fullTemplates = Object.assign(
+  { auth: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' } },
+  ...[...new Set(Object.values(SUBDOMAIN_TEMPLATE))].map(tmpl),
+);
+
 const okConfig = {
   reverseProxy: { publicDomain: 'dopp.cloud' },
-  installedTemplates: { auth: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' } },
+  installedTemplates: fullTemplates,
 };
 
 /** Deps where every step succeeds and every domain behaves correctly. */
@@ -157,6 +168,47 @@ describe('verifySso orchestrator', () => {
     expect(deps.createUser).not.toHaveBeenCalled();
   });
 
+  it('only probes installed services on a non-full install — does not false-fail (#1591)', async () => {
+    // Minimal install: auth + home-assistant + file-share. Vaultwarden,
+    // Immich, media, radicale are NOT installed, so their subdomains
+    // (vault/photos/music/books/caldav) must not be probed.
+    mockGetConfig.mockResolvedValue({
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+      installedTemplates: Object.assign(tmpl('auth'), tmpl('home-assistant'), tmpl('file-share')),
+    });
+    const { deps } = happyDeps();
+    // If an uninstalled service WERE probed, NPM's dead host would 404 → fail.
+    deps.probeDomain = vi.fn(async (_pd, host, _c, follow) => {
+      if (!follow) return { code: 302, body: '' };
+      if (['home', 'files', 'sync'].includes(host)) {
+        return { code: 200, body: USER_APP_SIGNATURES[host] || 'ok' };
+      }
+      return { code: 404, body: 'dead host' }; // would fail if probed
+    });
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(true);
+    const probed = report.userDomains.map(d => d.domain).sort();
+    expect(probed).toEqual(['files.dopp.cloud', 'home.dopp.cloud', 'sync.dopp.cloud']);
+    // none of the uninstalled-service subdomains were touched
+    expect(report.userDomains.some(d => /^(vault|photos|music|books|caldav)\./.test(d.domain))).toBe(false);
+  });
+
+  it('passes an auth-only install with zero installed user apps (#1591)', async () => {
+    mockGetConfig.mockResolvedValue({
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+      installedTemplates: tmpl('auth'),
+    });
+    const { deps } = happyDeps();
+
+    const report = await verifySso({ deps });
+
+    expect(report.ok).toBe(true);
+    expect(report.userDomains).toHaveLength(0);
+    expect(report.adminDomains).toHaveLength(ADMIN_ONLY_HOSTS.length);
+  });
+
   it('cleans up even if an injected dep throws unexpectedly', async () => {
     const { deps, calls } = happyDeps();
     deps.autheliaFirstFactor = vi.fn(async () => { throw new Error('kaboom'); });
@@ -166,6 +218,33 @@ describe('verifySso orchestrator', () => {
     expect(report.ok).toBe(false);
     expect(report.steps.some(s => s.id === 'unexpected_error')).toBe(true);
     expect(calls.deleted).toEqual([report.ephemeralUser]);
+  });
+});
+
+describe('probeableUserSubdomains (#1591)', () => {
+  it('returns only subdomains whose backing template is installed', () => {
+    const installed = Object.assign(tmpl('vaultwarden'), tmpl('radicale'));
+    expect(probeableUserSubdomains(installed).sort()).toEqual(['caldav', 'vault']);
+  });
+
+  it('maps file-share to both files and sync when installed', () => {
+    expect(probeableUserSubdomains(tmpl('file-share')).sort()).toEqual(['files', 'sync']);
+  });
+
+  it('is empty when no user-app template is installed', () => {
+    expect(probeableUserSubdomains(tmpl('auth'))).toEqual([]);
+    expect(probeableUserSubdomains({})).toEqual([]);
+  });
+
+  it('every USER_APP_SIGNATURES host has a known backing template', () => {
+    for (const host of Object.keys(USER_APP_SIGNATURES)) {
+      expect(SUBDOMAIN_TEMPLATE[host], `${host} must map to a template`).toBeDefined();
+    }
+  });
+
+  it('no longer includes the untemplated hermes subdomain', () => {
+    expect(USER_APP_SIGNATURES).not.toHaveProperty('hermes');
+    expect(SUBDOMAIN_TEMPLATE).not.toHaveProperty('hermes');
   });
 });
 

--- a/packages/backend/src/lib/diagnose/ssoVerify.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.ts
@@ -52,6 +52,10 @@ const SET_PASSWORD_TIMEOUT_MS = 15_000;
  * body so the check also catches "200 with the wrong content" (a half-broken
  * proxy). Kept in sync with the smoke test's USER_APPS map; ollama is
  * intentionally absent (no auth, opt-in NPM host only — see #1180).
+ *
+ * `hermes` was dropped (#1591): it's an external OSCAR service with no
+ * ServiceBay template, so it has no entry in `installedTemplates` to gate on
+ * and would always 404 a non-OSCAR install into a false `fail`.
  */
 export const USER_APP_SIGNATURES: Readonly<Record<string, string>> = {
   vault: 'Vaultwarden Web',
@@ -62,7 +66,23 @@ export const USER_APP_SIGNATURES: Readonly<Record<string, string>> = {
   files: '',
   sync: '',
   caldav: '',
-  hermes: 'Hermes Agent',
+};
+
+/**
+ * Subdomain prefix → the template whose installation puts that proxy host on
+ * the box (#1591). Only subdomains whose backing template is present in
+ * `cfg.installedTemplates` are probed; an absent service is *not* a failure,
+ * it's simply not installed. `file-share` backs two hosts (files + sync).
+ */
+export const SUBDOMAIN_TEMPLATE: Readonly<Record<string, string>> = {
+  vault: 'vaultwarden',
+  photos: 'immich',
+  music: 'media',
+  books: 'media',
+  home: 'home-assistant',
+  files: 'file-share',
+  sync: 'file-share',
+  caldav: 'radicale',
 };
 
 /**
@@ -308,10 +328,22 @@ interface SsoRun {
   publicDomain: string;
   ephemeralUser: string;
   password: string;
+  /** Templates installed on this node — gates which user subdomains we probe. */
+  installedTemplates: Record<string, unknown>;
   steps: SsoStepResult[];
   userDomains: SsoDomainResult[];
   adminDomains: SsoDomainResult[];
   created: boolean;
+}
+
+/** The user subdomains to probe on this install: only those whose backing
+ *  template is installed. A subdomain with no known template is never probed
+ *  (so an external/untemplated service can't false-fail the run). */
+export function probeableUserSubdomains(installedTemplates: Record<string, unknown>): string[] {
+  return Object.keys(USER_APP_SIGNATURES).filter(host => {
+    const template = SUBDOMAIN_TEMPLATE[host];
+    return template != null && installedTemplates[template] != null;
+  });
 }
 
 /** Create the ephemeral user, set its password, and join `family`. Returns
@@ -349,7 +381,8 @@ async function provisionEphemeralUser(deps: SsoVerifyDeps, run: SsoRun): Promise
 /** Hit every user-facing domain (cookie + follow redirects) and every
  *  admin-only domain (cookie, no redirects), recording per-domain results. */
 async function probeAllDomains(deps: SsoVerifyDeps, run: SsoRun, cookie: string): Promise<void> {
-  for (const [host, signature] of Object.entries(USER_APP_SIGNATURES)) {
+  for (const host of probeableUserSubdomains(run.installedTemplates)) {
+    const signature = USER_APP_SIGNATURES[host] ?? '';
     const probe = await deps.probeDomain(run.publicDomain, host, cookie, true);
     run.userDomains.push(classifyUserDomain(`${host}.${run.publicDomain}`, signature, probe));
   }
@@ -373,7 +406,11 @@ async function finishRun(deps: SsoVerifyDeps, run: SsoRun): Promise<SsoVerifyRep
       run.steps.push({ id: 'cleanup', status: 'fail', detail: `could not delete ${run.ephemeralUser}: ${del.message}` });
     }
   }
-  const ranDomains = run.userDomains.length > 0 && run.adminDomains.length > 0;
+  // The admin-reject probes always run once we reach the domain phase, so a
+  // non-empty adminDomains is the "we got far enough to judge" signal. An
+  // install with no installed user apps (only auth+infra) legitimately probes
+  // zero user domains — that is not a failure (#1591).
+  const ranDomains = run.adminDomains.length > 0;
   const ok = ranDomains
     && run.steps.every(s => s.status !== 'fail')
     && run.userDomains.every(d => d.status !== 'fail')
@@ -392,6 +429,7 @@ export async function verifySso(options: SsoVerifyOptions = {}): Promise<SsoVeri
     publicDomain: '',
     ephemeralUser: makeEphemeralUsername(),
     password: randomBytes(18).toString('hex'), // 36 hex chars, shell-safe
+    installedTemplates: {},
     steps: [],
     userDomains: [],
     adminDomains: [],
@@ -409,6 +447,7 @@ export async function verifySso(options: SsoVerifyOptions = {}): Promise<SsoVeri
     return finishRun(deps, run);
   }
   run.publicDomain = publicDomain;
+  run.installedTemplates = cfg.installedTemplates ?? {};
 
   try {
     if (!(await provisionEphemeralUser(deps, run))) return finishRun(deps, run);


### PR DESCRIPTION
## What
ssoVerify no longer false-fails on non-full installs. USER_APP_SIGNATURES are filtered against `cfg.installedTemplates` before probing via a new `SUBDOMAIN_TEMPLATE` map + exported `probeableUserSubdomains()`; the untemplated `hermes` subdomain (external OSCAR service, no ServiceBay template) is dropped, and `music`/`books` are gated on the `media` template that actually backs them. `finishRun` verdict relaxed so an auth-only / infra-only install with zero installed user apps passes instead of false-failing.

## Why
Closes #1591

## Risk
low — diagnose-only probe logic; consuming probe's isSkipped behaviour preserved, full suite + 2 new orchestrator tests + a probeableUserSubdomains unit block green.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 347 warnings — baseline)
- [x] npm run check:arch
- [x] npm test (full — 231 files / 1811 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — N/A, gate:normal (lib/diagnose not path-mandated)