### PR TITLE
fix(externalBackup): route restore/wipe through host agent + drop HA-OS Supervisor entries

### DIFF
--- a/packages/backend/src/lib/externalBackup/backupRestoreRoundtrip.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupRestoreRoundtrip.test.ts
@@ -61,7 +61,7 @@ describe('backup → restore round-trip (#1218 / #1190)', () => {
     await backupServiceToNas('home-assistant', { serviceDataDir: src });
     expect(nas.has(`${NAS_BACKUP_DIR}/home-assistant.tar`)).toBe(true);
 
-    const { dataDir } = await restoreServiceBackup('home-assistant');
+    const { dataDir } = await restoreServiceBackup('home-assistant', { local: true });
 
     // kept config — including the zwave network keys the operator can't reconstruct
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('default_config:\n');
@@ -87,7 +87,7 @@ describe('backup → restore round-trip (#1218 / #1190)', () => {
     });
 
     await backupServiceToNas('authelia', { serviceDataDir: src });
-    const { dataDir } = await restoreServiceBackup('authelia');
+    const { dataDir } = await restoreServiceBackup('authelia', { local: true });
     const restored = await fs.readFile(path.join(dataDir, 'users_database.yml'), 'utf8');
 
     expect(restored).toContain('alice');
@@ -106,7 +106,7 @@ describe('backup → restore round-trip (#1218 / #1190)', () => {
     // Simulate the reinstall wiping the live data dir to empty, then restoring.
     const dest = path.join(tmpRoot, 'adguard');
     await fs.mkdir(dest, { recursive: true }); // empty dir is the fresh/seedable state
-    const { files } = await restoreServiceBackup('adguard');
+    const { files } = await restoreServiceBackup('adguard', { local: true });
 
     expect(files).toBe(1); // only the included config, not the querylog
     expect(await fs.readFile(path.join(dest, 'conf/AdGuardHome.yaml'), 'utf8')).toContain('home.dopp.cloud');

--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -7,11 +7,12 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-const { mockNas, mockCfg, mockNpmCredStatus, mockRekeyNpm } = vi.hoisted(() => ({
+const { mockNas, mockCfg, mockNpmCredStatus, mockRekeyNpm, mockGetExecutor } = vi.hoisted(() => ({
   mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
   mockCfg: { getConfig: vi.fn() },
   mockNpmCredStatus: vi.fn(),
   mockRekeyNpm: vi.fn(),
+  mockGetExecutor: vi.fn(),
 }));
 vi.mock('./nasClient', () => mockNas);
 vi.mock('../config', () => mockCfg);
@@ -19,6 +20,7 @@ vi.mock('../reverseProxy/npmAdminRekey', () => ({
   npmAdminCredStatus: (...a: unknown[]) => mockNpmCredStatus(...a),
   rekeyNpmAdmin: (...a: unknown[]) => mockRekeyNpm(...a),
 }));
+vi.mock('../executor', () => ({ getExecutor: (...a: unknown[]) => mockGetExecutor(...a) }));
 
 import { restoreServiceBackup, isFreshDataDir, autoRestoreServiceOnReinstall, wipeServiceForReinstall } from './restore';
 import { NAS_BACKUP_DIR } from './producer';
@@ -69,7 +71,7 @@ describe('restoreServiceBackup', () => {
       '.storage/zwave_js': '{"keys":"MESH"}',
     }));
 
-    const res = await restoreServiceBackup('home-assistant');
+    const res = await restoreServiceBackup('home-assistant', { local: true });
     expect(res.service).toBe('home-assistant');
     expect(res.dataDir).toBe(dataDir);
     expect(res.files).toBe(2);
@@ -82,7 +84,7 @@ describe('restoreServiceBackup', () => {
     await fs.writeFile(path.join(dataDir, 'existing.yaml'), 'live');
     serveTar(await buildServiceTar({ 'configuration.yaml': 'incoming' }));
 
-    await expect(restoreServiceBackup('home-assistant')).rejects.toThrow(/already has data/);
+    await expect(restoreServiceBackup('home-assistant', { local: true })).rejects.toThrow(/already has data/);
     expect(await fs.readFile(path.join(dataDir, 'existing.yaml'), 'utf8')).toBe('live'); // untouched
   });
 
@@ -91,7 +93,7 @@ describe('restoreServiceBackup', () => {
     await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'old');
     serveTar(await buildServiceTar({ 'configuration.yaml': 'new' }));
 
-    const res = await restoreServiceBackup('home-assistant', { force: true });
+    const res = await restoreServiceBackup('home-assistant', { force: true, local: true });
     expect(res.files).toBeGreaterThanOrEqual(1);
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('new');
   });
@@ -129,7 +131,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
   it('restores on install into an empty data dir (Local node)', async () => {
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
@@ -139,7 +141,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     // backup-exists + fresh-dir for the plain install path.
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
@@ -155,7 +157,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
   it('logs a visible skip breadcrumb (not silent) when no backup exists for the service', async () => {
     mockNas.nasList.mockResolvedValue([]); // empty NAS
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(logs.some(l => l.includes('home-assistant') && l.includes('no config backup'))).toBe(true);
     expect(logs.some(l => l.includes('restored'))).toBe(false);
   });
@@ -166,7 +168,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
     await expect(
-      autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); }),
+      autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'install', node: 'Local', local: true }, async l => { logs.push(l); }),
     ).resolves.toBeUndefined();
     expect(await fs.readFile(path.join(dataDir, 'live.yaml'), 'utf8')).toBe('live'); // untouched
     expect(logs.some(l => l.includes('not empty') && l.includes('skipping restore'))).toBe(true);
@@ -180,7 +182,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'KEPT-RECORDER-DB');
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('KEPT-RECORDER-DB'); // DATA kept
     expect(logs.some(l => l.includes('wipe-config') && l.includes('restoring config'))).toBe(true);
@@ -189,7 +191,7 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
   it('on wipe-all, restores config into the (now-empty) dir (#1585)', async () => {
     nasHasHomeAssistantBackup();
     const logs: string[] = [];
-    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local' }, async l => { logs.push(l); });
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
@@ -201,7 +203,7 @@ describe('wipeServiceForReinstall (#1585)', () => {
     await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
     await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'data');
     const logs: string[] = [];
-    await wipeServiceForReinstall('home-assistant', { wipeMode: 'install', node: 'Local' }, async l => { logs.push(l); });
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'install', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('cfg');
     expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('data');
     expect(logs).toEqual([]);
@@ -214,7 +216,7 @@ describe('wipeServiceForReinstall (#1585)', () => {
     await fs.writeFile(path.join(dataDir, '.storage/zwave_js'), 'keys'); // CONFIG (mesh keys)
     await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'RECORDER'); // DATA
     const logs: string[] = [];
-    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local', local: true }, async l => { logs.push(l); });
     // CONFIG gone:
     await expect(fs.access(path.join(dataDir, 'configuration.yaml'))).rejects.toThrow();
     await expect(fs.access(path.join(dataDir, 'automations.yaml'))).rejects.toThrow();
@@ -229,7 +231,7 @@ describe('wipeServiceForReinstall (#1585)', () => {
     await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
     await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'RECORDER');
     const logs: string[] = [];
-    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local' }, async l => { logs.push(l); });
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await isFreshDataDir(dataDir)).toBe(true);
     expect(logs.some(l => l.includes('wipe-all') && l.includes('config + data'))).toBe(true);
   });
@@ -245,7 +247,7 @@ describe('wipeServiceForReinstall (#1585)', () => {
 
   it('logs a skip note for a service with no manifest (no classification to wipe)', async () => {
     const logs: string[] = [];
-    await wipeServiceForReinstall('not-a-service', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    await wipeServiceForReinstall('not-a-service', { wipeMode: 'wipe-config', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(logs.some(l => l.includes('no backup manifest'))).toBe(true);
   });
 });
@@ -265,7 +267,7 @@ describe('NPM credential reconcile after restore (#1529)', () => {
     mockNpmCredStatus.mockResolvedValue('rejected');
     mockRekeyNpm.mockResolvedValue({ ok: true, message: 'NPM admin password re-keyed and saved', email: 'a@x' });
 
-    const res = await restoreServiceBackup('nginx');
+    const res = await restoreServiceBackup('nginx', { local: true });
     expect(res.dataDir).toBe(path.join(tmpRoot, 'nginx-proxy-manager'));
     expect(mockRekeyNpm).toHaveBeenCalledWith('Local');
     expect(res.credentialReconcile).toEqual({ ok: true, message: expect.stringContaining('re-keyed') });
@@ -275,7 +277,7 @@ describe('NPM credential reconcile after restore (#1529)', () => {
     await serveNginxTar();
     mockNpmCredStatus.mockResolvedValue('ok');
 
-    const res = await restoreServiceBackup('nginx');
+    const res = await restoreServiceBackup('nginx', { local: true });
     expect(mockRekeyNpm).not.toHaveBeenCalled();
     expect(res.credentialReconcile).toBeUndefined();
   });
@@ -284,7 +286,7 @@ describe('NPM credential reconcile after restore (#1529)', () => {
     await serveNginxTar();
     mockNpmCredStatus.mockResolvedValue('unknown');
 
-    const res = await restoreServiceBackup('nginx');
+    const res = await restoreServiceBackup('nginx', { local: true });
     expect(mockRekeyNpm).not.toHaveBeenCalled();
     expect(res.credentialReconcile).toBeUndefined();
   });
@@ -294,14 +296,103 @@ describe('NPM credential reconcile after restore (#1529)', () => {
     mockNpmCredStatus.mockResolvedValue('no-creds');
     mockRekeyNpm.mockResolvedValue({ ok: false, message: 'Could not find the running NPM container to re-key.' });
 
-    const res = await restoreServiceBackup('nginx');
+    const res = await restoreServiceBackup('nginx', { local: true });
     expect(res.credentialReconcile).toEqual({ ok: false, message: expect.stringContaining('Could not find') });
   });
 
   it('never reconciles for a non-NPM service', async () => {
     serveTar(await buildServiceTar({ 'configuration.yaml': 'x' }));
-    const res = await restoreServiceBackup('home-assistant');
+    const res = await restoreServiceBackup('home-assistant', { local: true });
     expect(mockNpmCredStatus).not.toHaveBeenCalled();
     expect(res.credentialReconcile).toBeUndefined();
+  });
+});
+
+describe('host-agent-routed restore/wipe (#1600 — stacks dir not in container)', () => {
+  // The real host agent runs these argv ops on /mnt/data/stacks, which the
+  // servicebay container can't see. The unit env has no agent, so this Executor
+  // stand-in runs the SAME argv against the test's real temp fs — proving the
+  // routed path actually wipes + extracts (not the in-container no-op of #1600).
+  function makeHostExecutor() {
+    const run = (argv: string[]) => execFileAsync(argv[0], argv.slice(1));
+    const exec: {
+      execArgv: ReturnType<typeof vi.fn>;
+      exists: ReturnType<typeof vi.fn>;
+      writeFile: ReturnType<typeof vi.fn>;
+    } = {
+      execArgv: vi.fn(async (argv: string[]) => {
+        // `sh -c <script> sh <args...>` — run the script with positional args.
+        if (argv[0] === 'sh' && argv[1] === '-c') {
+          const script = argv[2];
+          const rest = argv.slice(3); // [$0, $1, $2, ...]
+          const { stdout, stderr } = await execFileAsync('sh', ['-c', script, ...rest]);
+          return { stdout, stderr };
+        }
+        const { stdout, stderr } = await run(argv);
+        return { stdout, stderr };
+      }),
+      exists: vi.fn(async (p: string) => {
+        try { await fs.access(p); return true; } catch { return false; }
+      }),
+      writeFile: vi.fn(async (p: string, content: string) => { await fs.writeFile(p, content); }),
+    };
+    return exec;
+  }
+
+  beforeEach(() => {
+    mockGetExecutor.mockImplementation(() => makeHostExecutor());
+  });
+
+  it('restore: extracts the NAS tar onto the host (agent), counting host files', async () => {
+    serveTar(await buildServiceTar({ 'configuration.yaml': 'host-restored:', '.storage/zwave_js': '{"k":2}' }));
+    const res = await restoreServiceBackup('home-assistant', { node: 'Local' });
+    expect(mockGetExecutor).toHaveBeenCalledWith('Local');
+    expect(res.files).toBe(2);
+    // Files landed on the (host = temp) data dir, via the agent path.
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('host-restored:');
+    expect(await fs.readFile(path.join(dataDir, '.storage/zwave_js'), 'utf8')).toBe('{"k":2}');
+  });
+
+  it('restore: refuses a non-empty host data dir without force (agent ls -A)', async () => {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'live.yaml'), 'live');
+    serveTar(await buildServiceTar({ 'configuration.yaml': 'incoming' }));
+    await expect(restoreServiceBackup('home-assistant', { node: 'Local' })).rejects.toThrow(/already has data/);
+    expect(await fs.readFile(path.join(dataDir, 'live.yaml'), 'utf8')).toBe('live');
+  });
+
+  it('wipe-config: clears CONFIG paths on the host, keeps DATA (agent rm -rf)', async () => {
+    await fs.mkdir(path.join(dataDir, '.storage'), { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
+    await fs.writeFile(path.join(dataDir, '.storage/zwave_js'), 'keys');
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'RECORDER');
+    const logs: string[] = [];
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    await expect(fs.access(path.join(dataDir, 'configuration.yaml'))).rejects.toThrow();
+    await expect(fs.access(path.join(dataDir, '.storage/zwave_js'))).rejects.toThrow();
+    expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('RECORDER');
+    expect(logs.some(l => l.includes('wipe-config') && l.includes('kept the service data'))).toBe(true);
+  });
+
+  it('wipe-all: clears the whole host data dir (agent rm -rf)', async () => {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'configuration.yaml'), 'cfg');
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'RECORDER');
+    const logs: string[] = [];
+    await wipeServiceForReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local' }, async l => { logs.push(l); });
+    await expect(fs.access(dataDir)).rejects.toThrow();
+    expect(logs.some(l => l.includes('wipe-all'))).toBe(true);
+  });
+
+  it('autoRestore wipe-config: force-restores config over kept host data (agent path)', async () => {
+    mockNas.nasList.mockResolvedValue([{ name: 'home-assistant.tar', size: 1024 }]);
+    serveTar(await buildServiceTar({ 'configuration.yaml': 'reseeded:', '.storage/zwave_js': '{"k":3}' }));
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'home-assistant_v2.db'), 'KEPT-DB');
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-config', node: 'Local' }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('reseeded:');
+    expect(await fs.readFile(path.join(dataDir, 'home-assistant_v2.db'), 'utf8')).toBe('KEPT-DB');
+    expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
   });
 });

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -20,7 +20,8 @@ import os from 'os';
 import path from 'path';
 import { fetchServiceBackup, listServiceBackups, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
 import { getServiceManifest, getConfigPaths } from './serviceManifest';
-import { safeTarExtract } from '../systemBackup';
+import { safeTarExtract, assertSafeArchiveEntries } from '../systemBackup';
+import { getExecutor, type Executor } from '../executor';
 import { logger } from '../logger';
 
 /**
@@ -31,6 +32,169 @@ import { logger } from '../logger';
  * its `JobInput.wipeMode` straight through.
  */
 type WipeMode = 'install' | 'wipe-config' | 'wipe-all';
+
+/**
+ * The few filesystem primitives the restore + wipe logic needs, so the SAME
+ * logic can run against either:
+ *  - the **local** container filesystem (the unit tests / an explicit
+ *    serviceDataDir under /app/data), or
+ *  - the **host** filesystem via the node agent (#1600 — the box reinstall
+ *    operates on `/mnt/data/stacks/<service>`, which is NOT bind-mounted into
+ *    the servicebay container; only the host agent can see it, exactly as the
+ *    producer's box backup does since #1597).
+ *
+ * This is the symmetric consumer-side counterpart to producer.ts's
+ * `BackupFileBackend`: without it, a box (re)install's wipe-config "cleared"
+ * nothing and the restore wrote into a container-only path the real service
+ * never reads (the #1600 silent failure).
+ */
+interface RestoreFsBackend {
+  /** True if `dir` is empty or doesn't exist — the safe-to-seed condition. */
+  isFreshDir(dir: string): Promise<boolean>;
+  /** Count regular files under `dir`, recursively — for the restore summary. */
+  countFiles(dir: string): Promise<number>;
+  mkdirp(dir: string): Promise<void>;
+  /** Recursive force-remove (a file, dir, or absent path). */
+  rmrf(target: string): Promise<void>;
+  /**
+   * Extract `tar` into `destDir`, preserving safeTarExtract's traversal guard
+   * (#580/#590). The traversal/symlink-escape pre-pass always runs in-container
+   * on the fetched tar bytes; only the extraction lands on this backend's side.
+   */
+  extractTar(tar: Buffer, destDir: string): Promise<void>;
+}
+
+/** Local-filesystem backend — the in-container path (tests / explicit dir). */
+const localRestoreBackend: RestoreFsBackend = {
+  async isFreshDir(dir) {
+    try {
+      return (await fs.readdir(dir)).length === 0;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return true;
+      throw e;
+    }
+  },
+  async countFiles(dir) {
+    let total = 0;
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) total += await this.countFiles(full);
+      else if (entry.isFile()) total += 1;
+    }
+    return total;
+  },
+  async mkdirp(dir) {
+    await fs.mkdir(dir, { recursive: true });
+  },
+  async rmrf(target) {
+    await fs.rm(target, { recursive: true, force: true });
+  },
+  async extractTar(tar, destDir) {
+    // safeTarExtract reads from a path, so stage the fetched tar to a temp file.
+    const tmp = path.join(os.tmpdir(), `sb-restore-${Date.now()}-${process.pid}.tar`);
+    try {
+      await fs.writeFile(tmp, tar);
+      await fs.mkdir(destDir, { recursive: true });
+      await safeTarExtract(tmp, destDir, { gzip: false });
+    } finally {
+      await fs.rm(tmp, { force: true });
+    }
+  },
+};
+
+/**
+ * Host-agent backend (#1600) — every fs op runs on the HOST via the node agent,
+ * so it sees `/mnt/data/stacks/<service>` (not mounted into the servicebay
+ * container). Mirrors producer.ts's `agentFileBackend`.
+ */
+function agentRestoreBackend(executor: Executor): RestoreFsBackend {
+  return {
+    async isFreshDir(dir) {
+      if (!(await executor.exists(dir))) return true;
+      // `ls -A` lists entries (incl. dotfiles, excl. . and ..); empty stdout → fresh.
+      const { stdout } = await executor.execArgv(['ls', '-A', dir]);
+      return stdout.trim().length === 0;
+    },
+    async countFiles(dir) {
+      if (!(await executor.exists(dir))) return 0;
+      const { stdout } = await executor.execArgv(['find', dir, '-type', 'f']);
+      return stdout.split('\n').filter(l => l.trim().length > 0).length;
+    },
+    async mkdirp(dir) {
+      await executor.execArgv(['mkdir', '-p', dir]);
+    },
+    async rmrf(target) {
+      await executor.execArgv(['rm', '-rf', target]);
+    },
+    async extractTar(tar, destDir) {
+      // Traversal/symlink-escape guard (#580/#590) runs in-container on the
+      // fetched tar bytes — before anything touches the host.
+      const tmp = path.join(os.tmpdir(), `sb-restore-${Date.now()}-${process.pid}.tar`);
+      try {
+        await fs.writeFile(tmp, tar);
+        await assertSafeArchiveEntries(tmp, false);
+      } finally {
+        await fs.rm(tmp, { force: true });
+      }
+      // Push the validated tar to a host temp file (base64 over the agent's
+      // utf-8-only write_file, so binary config stays intact), then extract
+      // host-side with the SAME hardening flags safeTarExtract uses, and run a
+      // host-side symlink-escape walk as defense in depth (mirrors
+      // assertNoSymlinkEscape).
+      const { stdout } = await executor.execArgv(['mktemp', '-t', 'sb-restore-XXXXXX']);
+      const hostTar = stdout.trim();
+      const hostTarB64 = `${hostTar}.b64`;
+      try {
+        await executor.writeFile(hostTarB64, tar.toString('base64'));
+        await executor.execArgv(['sh', '-c', 'base64 -d "$1" > "$2"', 'sh', hostTarB64, hostTar], { timeoutMs: 120_000 });
+        await executor.execArgv(['mkdir', '-p', destDir]);
+        await executor.execArgv(
+          ['tar', '-xf', hostTar, '-C', destDir, '--no-same-owner', '--no-overwrite-dir', '--no-same-permissions'],
+          { timeoutMs: 120_000 },
+        );
+        await assertNoSymlinkEscapeHost(executor, destDir);
+      } finally {
+        await executor.execArgv(['rm', '-f', hostTarB64, hostTar]);
+      }
+    },
+  };
+}
+
+/**
+ * Host-side equivalent of systemBackup's `assertNoSymlinkEscape` (#580/#590):
+ * after a host extraction, refuse any symlink under `dir` whose resolved target
+ * escapes `dir`. The in-container pre-pass already refused absolute/traversal
+ * link targets in the archive listing; this is defense in depth on the host
+ * where the link's real resolution lives. On refusal the partial extraction is
+ * cleaned up host-side, matching safeTarExtract.
+ */
+async function assertNoSymlinkEscapeHost(executor: Executor, dir: string): Promise<void> {
+  // List every symlink under dir with its resolved real path (-printf %l is the
+  // raw target; readlink -f resolves it). A target that doesn't stay within the
+  // realpath of dir is a refusal.
+  const realRoot = (await executor.execArgv(['readlink', '-f', dir])).stdout.trim();
+  const { stdout } = await executor.execArgv(['find', dir, '-type', 'l']);
+  const links = stdout.split('\n').map(l => l.trim()).filter(Boolean);
+  for (const link of links) {
+    const resolved = (await executor.execArgv(['readlink', '-f', link]).catch(() => ({ stdout: '' }))).stdout.trim();
+    if (!resolved || (resolved !== realRoot && !resolved.startsWith(realRoot + '/'))) {
+      await executor.execArgv(['rm', '-rf', dir]).catch(() => {});
+      throw new Error(`Refused archive: symlink "${link}" → "${resolved}" escapes the extraction directory`);
+    }
+  }
+}
+
+/**
+ * Pick the fs backend for a restore/wipe. A box (re)install operates on the
+ * stacks dir, which is NOT mounted into the servicebay container, so it routes
+ * through the host agent (#1600). A `local: true` opt forces the in-container
+ * path (the unit tests, which stage into a real container-local temp dir).
+ */
+function pickRestoreBackend(opts: { node?: string | null; local?: boolean }): RestoreFsBackend {
+  if (opts.local) return localRestoreBackend;
+  return agentRestoreBackend(getExecutor(opts.node || 'Local'));
+}
 
 export interface RestoreResult {
   service: string;
@@ -81,27 +245,13 @@ async function reconcileNpmCredentialAfterRestore(
   }
 }
 
-/** True if `dir` is empty or doesn't exist — the safe-to-seed condition. */
+/**
+ * True if `dir` is empty or doesn't exist — the safe-to-seed condition.
+ * Standalone local-fs check; the restore/wipe flows resolve their backend
+ * (host agent on a box, local in tests) and call `backend.isFreshDir` instead.
+ */
 export async function isFreshDataDir(dir: string): Promise<boolean> {
-  try {
-    const entries = await fs.readdir(dir);
-    return entries.length === 0;
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return true;
-    throw e;
-  }
-}
-
-/** Count regular files under `dir` (recursively) — for the restore summary. */
-async function countFiles(dir: string): Promise<number> {
-  let total = 0;
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) total += await countFiles(full);
-    else if (entry.isFile()) total += 1;
-  }
-  return total;
+  return localRestoreBackend.isFreshDir(dir);
 }
 
 /**
@@ -111,13 +261,16 @@ async function countFiles(dir: string): Promise<number> {
  */
 export async function restoreServiceBackup(
   service: string,
-  opts: { force?: boolean; node?: string | null } = {},
+  opts: { force?: boolean; node?: string | null; local?: boolean } = {},
 ): Promise<RestoreResult> {
   if (!getServiceManifest(service)) {
     throw new Error(`No backup manifest for service "${service}"`);
   }
+  // The stacks dir isn't mounted into the container, so a box restore runs every
+  // fs op on the host via the agent (#1600); tests force the local backend.
+  const backend = pickRestoreBackend(opts);
   const dataDir = await resolveServiceDataDir(service);
-  if (!opts.force && !(await isFreshDataDir(dataDir))) {
+  if (!opts.force && !(await backend.isFreshDir(dataDir))) {
     throw new Error(
       `Refusing to restore "${service}": ${dataDir} already has data. Restore ` +
       `only seeds a fresh/empty data dir; pass force to overwrite a live service.`,
@@ -125,18 +278,9 @@ export async function restoreServiceBackup(
   }
 
   const { tar, meta } = await fetchServiceBackup(`${service}.tar`);
+  await backend.extractTar(tar, dataDir);
 
-  // safeTarExtract reads from a path, so stage the fetched tar to a temp file.
-  const tmp = path.join(os.tmpdir(), `sb-restore-${service}-${Date.now()}.tar`);
-  try {
-    await fs.writeFile(tmp, tar);
-    await fs.mkdir(dataDir, { recursive: true });
-    await safeTarExtract(tmp, dataDir, { gzip: false });
-  } finally {
-    await fs.rm(tmp, { force: true });
-  }
-
-  const files = await countFiles(dataDir);
+  const files = await backend.countFiles(dataDir);
   logger.info('ExternalBackup', `Restored "${service}" from NAS into ${dataDir} (${files} files)`);
 
   // #1529 — NPM's restored database.sqlite carries its own admin hash, so
@@ -173,7 +317,7 @@ export async function restoreServiceBackup(
  */
 export async function wipeServiceForReinstall(
   service: string,
-  opts: { wipeMode?: WipeMode; node?: string | null },
+  opts: { wipeMode?: WipeMode; node?: string | null; local?: boolean },
   log: (line: string) => Promise<void>,
 ): Promise<void> {
   const mode = opts.wipeMode ?? 'install';
@@ -184,10 +328,13 @@ export async function wipeServiceForReinstall(
     await log(`(note) ${service}: no backup manifest, skipping ${mode} wipe (no config/data classification).`);
     return;
   }
+  // The stacks dir isn't mounted into the container, so the wipe runs on the
+  // host via the agent (#1600); without this it silently cleared nothing.
+  const backend = pickRestoreBackend(opts);
   try {
     const dataDir = await resolveServiceDataDir(service);
     if (mode === 'wipe-all') {
-      await fs.rm(dataDir, { recursive: true, force: true });
+      await backend.rmrf(dataDir);
       await log(`🧹 ${service}: wipe-all — cleared the service data dir (config + data).`);
       return;
     }
@@ -200,7 +347,7 @@ export async function wipeServiceForReinstall(
       // the same invariant the restore path enforces.
       if (!abs.startsWith(dataDir + path.sep)) continue;
       try {
-        await fs.rm(abs, { recursive: true, force: true });
+        await backend.rmrf(abs);
         removed += 1;
       } catch { /* path absent — fine */ }
     }
@@ -235,7 +382,7 @@ export async function wipeServiceForReinstall(
  */
 export async function autoRestoreServiceOnReinstall(
   service: string,
-  opts: { wipeMode?: WipeMode; node?: string | null },
+  opts: { wipeMode?: WipeMode; node?: string | null; local?: boolean },
   log: (line: string) => Promise<void>,
 ): Promise<void> {
   const mode = opts.wipeMode ?? 'install';
@@ -243,13 +390,17 @@ export async function autoRestoreServiceOnReinstall(
   // cleanInstall flag (which #1520 pinned false, silently killing restore).
   if (opts.node && opts.node !== 'Local') return;
   const forceRestore = mode === 'wipe-config' || mode === 'wipe-all';
+  // The stacks dir isn't mounted into the container, so the freshness check (and
+  // the restore it gates) run on the host via the agent (#1600). Without this
+  // the check saw an absent container path → "fresh" → restore wrote nowhere.
+  const backend = pickRestoreBackend(opts);
   try {
     const hasBackup = (await listServiceBackups()).some(b => b.service === service);
     if (!hasBackup) {
       await log(`(note) ${service}: no config backup found on the FritzBox NAS — starting on existing/blank data.`);
       return;
     }
-    if (!forceRestore && !(await isFreshDataDir(await resolveServiceDataDir(service)))) {
+    if (!forceRestore && !(await backend.isFreshDir(await resolveServiceDataDir(service)))) {
       await log(`(note) ${service}: a config backup exists on the NAS, but the data dir is not empty — keeping the on-disk data and skipping restore.`);
       return;
     }
@@ -258,7 +409,7 @@ export async function autoRestoreServiceOnReinstall(
         ? `💾 ${service}: ${mode} — restoring config from the FritzBox NAS over the kept data before first start…`
         : `💾 ${service}: found a config backup on the FritzBox NAS and the data dir is empty — restoring before first start…`,
     );
-    const r = await restoreServiceBackup(service, { node: opts.node, force: forceRestore });
+    const r = await restoreServiceBackup(service, { node: opts.node, force: forceRestore, local: opts.local });
     await log(`✅ ${service}: restored ${r.files} config file(s) from the NAS${r.meta ? ` (backed up ${r.meta.createdAt.slice(0, 10)} from ${r.meta.nodeId})` : ''}.`);
     // On a reinstall the pod isn't up yet, so credentialReconcile is normally
     // a no-op here (the install runner's post-deploy self-heal re-keys NPM once

--- a/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
@@ -188,6 +188,11 @@ describe('translateHaAddonConfigEntries (#1595)', () => {
             domain: 'hue',
             data: { host: '192.168.1.50', use_addon: true },
           },
+          // Supervisor-only family entries (#1601) — dropped on import.
+          { entry_id: 'hassio1', domain: 'hassio', data: {} },
+          { entry_id: 'cloud1', domain: 'cloud', data: {} },
+          { entry_id: 'backup1', domain: 'backup', data: {} },
+          { entry_id: 'dc1', domain: 'default_config', data: {} },
         ],
       },
     });
@@ -221,10 +226,38 @@ describe('translateHaAddonConfigEntries (#1595)', () => {
     expect(hue.url).toBeUndefined();
   });
 
+  it('drops the Supervisor-only family entries (#1601) but keeps user integrations', () => {
+    const out = translateHaAddonConfigEntries(supervisorEntries());
+    const parsed = JSON.parse(out) as {
+      data: { entries: { domain: string }[] };
+    };
+    const domains = parsed.data.entries.map(e => e.domain);
+    expect(domains).not.toContain('hassio');
+    expect(domains).not.toContain('cloud');
+    expect(domains).not.toContain('backup');
+    expect(domains).not.toContain('default_config');
+    // The real integrations are still present.
+    expect(domains).toEqual(expect.arrayContaining(['zwave_js', 'matter', 'hue']));
+  });
+
   it('is idempotent: an already-translated backup is returned byte-stable', () => {
     const once = translateHaAddonConfigEntries(supervisorEntries());
     const twice = translateHaAddonConfigEntries(once);
     expect(twice).toBe(once);
+  });
+
+  it('drops a Supervisor-only entry even when there is nothing to translate', () => {
+    const onlyHassio = JSON.stringify({
+      data: {
+        entries: [
+          { domain: 'hassio', data: {} },
+          { domain: 'hue', data: { host: '10.0.0.2' } },
+        ],
+      },
+    });
+    const out = translateHaAddonConfigEntries(onlyHassio);
+    const parsed = JSON.parse(out) as { data: { entries: { domain: string }[] } };
+    expect(parsed.data.entries.map(e => e.domain)).toEqual(['hue']);
   });
 
   it('returns the content unchanged when there is no add-on entry to translate', () => {

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -48,6 +48,30 @@ const HA_ADDON_ENTRY_TRANSLATIONS: Record<string, { url: string }> = {
 };
 
 /**
+ * Config-entry domains that exist ONLY in the Supervisor (HA-OS) environment and
+ * have no working counterpart on ServiceBay's containerised HA (#1601). A HA-OS
+ * backup's `.storage/core.config_entries` carries a `hassio` entry (the
+ * Supervisor integration itself), plus the `cloud` / `backup` config entries the
+ * Supervisor onboarding creates against it. On the container deploy:
+ *   - `hassio` cannot load at all — there is no Supervisor to talk to.
+ *   - `cloud` and `backup` are core integrations configured via
+ *     `configuration.yaml` (single-instance / YAML-only); a stale
+ *     Supervisor-created config entry makes HA log a non-fatal setup error and
+ *     leaves a broken entry in the UI. They still load via their normal path.
+ *   - `default_config` is a meta-component that has no business owning a config
+ *     entry on the container deploy; one carried from HA-OS just errors.
+ * So we DROP these entries from the array entirely on import — neutralising the
+ * noise without removing any legitimate user integration. Conservative by
+ * design: only these known-broken Supervisor-family domains are dropped.
+ */
+const HA_SUPERVISOR_ONLY_DOMAINS: ReadonlySet<string> = new Set([
+  'hassio',
+  'cloud',
+  'backup',
+  'default_config',
+]);
+
+/**
  * Identifies a service whose backup needs an in-container snapshot step before
  * the file-copy producer reads its data dir — e.g. a live WAL-mode SQLite that
  * a plain `cp` would tear. The producer runs the snapshot inside the service's
@@ -380,6 +404,12 @@ function isHaEntryOnAddon(data: NonNullable<HaConfigEntry['data']>): boolean {
  * to the in-pod localhost address. Every other entry — and any zwave_js/matter
  * entry already pointing at localhost (idempotent re-run) — is left byte-stable.
  *
+ * Additionally (#1601) DROP the Supervisor-only family entries
+ * (`HA_SUPERVISOR_ONLY_DOMAINS`: hassio + the cloud/backup/default_config entries
+ * it spawns) that cannot function on the container deploy — they only produce
+ * non-fatal setup errors and a broken entry in the UI. Dropping is idempotent:
+ * a re-imported (already-cleaned) backup has none left, so it's a no-op.
+ *
  * Best-effort: returns the content unchanged if it doesn't parse as JSON or
  * lacks the expected `data.entries[]` array, so a future HA storage-schema
  * change can't make the backup fail (the worst case is the old, manual fix-up).
@@ -391,7 +421,8 @@ export function translateHaAddonConfigEntries(content: string): string {
   } catch {
     return content;
   }
-  const entries = (doc as { data?: { entries?: unknown } })?.data?.entries;
+  const data = (doc as { data?: { entries?: unknown } })?.data;
+  const entries = data?.entries;
   if (!Array.isArray(entries)) return content;
 
   let changed = false;
@@ -399,14 +430,25 @@ export function translateHaAddonConfigEntries(content: string): string {
     if (!entry || typeof entry !== 'object') continue;
     const translation = entry.domain ? HA_ADDON_ENTRY_TRANSLATIONS[entry.domain] : undefined;
     if (!translation) continue;
-    const data = entry.data;
-    if (!data || typeof data !== 'object') continue;
-    if (!isHaEntryOnAddon(data)) continue;
-    data.use_addon = false;
-    data.integration_created_addon = false;
-    data.url = translation.url;
+    const entryData = entry.data;
+    if (!entryData || typeof entryData !== 'object') continue;
+    if (!isHaEntryOnAddon(entryData)) continue;
+    entryData.use_addon = false;
+    entryData.integration_created_addon = false;
+    entryData.url = translation.url;
     changed = true;
   }
+
+  // Drop the Supervisor-only family entries that can't work on container HA.
+  const kept = (entries as HaConfigEntry[]).filter(
+    e => !(e && typeof e === 'object' && typeof e.domain === 'string'
+      && HA_SUPERVISOR_ONLY_DOMAINS.has(e.domain)),
+  );
+  if (kept.length !== entries.length) {
+    (data as { entries: unknown }).entries = kept;
+    changed = true;
+  }
+
   if (!changed) return content;
   return JSON.stringify(doc, null, 2);
 }

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -231,7 +231,7 @@ function linkTargetEscapes(linkName: string, target: string): boolean {
     return resolved === '..' || resolved.startsWith('../');
 }
 
-async function assertSafeArchiveEntries(archivePath: string, gzip = true): Promise<void> {
+export async function assertSafeArchiveEntries(archivePath: string, gzip = true): Promise<void> {
     let stdout: string;
     try {
         const result = await execFileAsync('tar', [gzip ? '-tvzf' : '-tvf', archivePath]);


### PR DESCRIPTION
## What
Routes the restore/wipe-config path (`wipeServiceForReinstall`, `autoRestoreServiceOnReinstall`, `restoreServiceBackup`, `isFreshDataDir`, `countFiles`) through the host agent so it operates on `/mnt/data/stacks` (not mounted into the servicebay container), mirroring the #1597 producer seam. Also drops known Supervisor-only HA config entries (`hassio`, `cloud`, `backup`, `default_config`) during HA-OS import/staging so HA starts cleanly on the container deploy.

## Why
Closes #1600
Closes #1601

## Risk
Medium — install/restore + HA-OS import critical path; the traversal/wipe-prefix guards are preserved and the config-entry drop is conservative (4 known-broken domains only) and idempotent.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 347 warnings — baseline)
- [x] npm run check:arch
- [x] npm test (full — 231 files, 1835 pass, 2 skip)
- [ ] /verify on FCoS :dev box — REINSTALL-DEFERRED (needs a real FCoS reinstall to exercise restore/wipe + HA-OS import)