### PR TITLE
style: clear react-hooks/exhaustive-deps + unused-vars in backups page, health init, channel test

### DIFF
--- a/packages/backend/src/lib/health/init.ts
+++ b/packages/backend/src/lib/health/init.ts
@@ -64,7 +64,7 @@ function isOrphanTemplateCheck(c: { id: string; type: string }, deployed: Set<st
   return true;
 }
 
-async function addServiceChecks(existingChecks: ReturnType<typeof HealthStore.getChecks>, exists: (type: string, target: string) => boolean) {
+async function addServiceChecks(existingChecks: ReturnType<typeof HealthStore.getChecks>, _exists: (type: string, target: string) => boolean) {
   try {
     const services = await ServiceManager.listServices('Local');
     const deployed = new Set(services.map(s => s.name));

--- a/packages/backend/src/lib/servicebayChannel.test.ts
+++ b/packages/backend/src/lib/servicebayChannel.test.ts
@@ -8,7 +8,7 @@ const execMock = vi.fn(async (argv: string[]) => {
   return { stdout: '', stderr: '' };
 });
 
-vi.mock('@/lib/executor', () => ({ getExecutor: () => ({ execArgv: (a: string[], o?: any) => execMock(a, o) }) }));
+vi.mock('@/lib/executor', () => ({ getExecutor: () => ({ execArgv: (a: string[]) => execMock(a) }) }));
 vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), error: vi.fn() } }));
 
 import { getServicebayChannel, setServicebayChannel, isChannel } from './servicebayChannel';

--- a/packages/backend/src/lib/servicebayChannel.test.ts
+++ b/packages/backend/src/lib/servicebayChannel.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const calls: string[][] = [];
-const execMock = vi.fn(async (argv: string[], _opts?: any) => {
+const execMock = vi.fn(async (argv: string[]) => {
   calls.push(argv);
   if (argv.includes('inspect')) return { stdout: 'ghcr.io/mdopp/servicebay:dev\n', stderr: '' };
   return { stdout: '', stderr: '' };

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -112,7 +112,7 @@ export default function BackupsSettingsPage() {
       setNasRestoring(null);
       setNasRestoreTarget(null);
     }
-  }, [nasRestoreTarget, nasRestoring, addToast]);
+  }, [nasRestoreTarget, nasRestoring, addToast, setNasRestoring, setNasRestoreTarget]);
 
   // ─── Backup Sync handlers ─────────────────────────────────────────
   const buildBackupTarget = () => {
@@ -335,7 +335,7 @@ export default function BackupsSettingsPage() {
       targetNodes,
       serviceData: serviceDataState,
     });
-  }, [nodes]);
+  }, [nodes, setRestoreSelectionState]);
 
   const openRestoreOverlay = (reset = false) => {
     if (reset) {
@@ -360,7 +360,7 @@ export default function BackupsSettingsPage() {
     setRestoreSelectionState(null);
     setRestoreFilePreview(null);
     setRestoreFilePreviewError(null);
-  }, [restoringBackup]);
+  }, [restoringBackup, setRestoreOverlayOpen, setRestorePreview, setRestoreSource, setRestoreUploadError, setRestoreSelectionState, setRestoreFilePreview, setRestoreFilePreviewError]);
 
   useEscapeKey(closeRestoreOverlay, restoreOverlayOpen, true);
   useEscapeKey(() => setRestoreFilePreview(null), Boolean(restoreFilePreview), true);
@@ -424,7 +424,7 @@ export default function BackupsSettingsPage() {
       setRestoreFilePreviewError(message);
       setRestoreFilePreview({ nodeName, relativePath, content: '', loading: false });
     }
-  }, [restoreSource]);
+  }, [restoreSource, setRestoreFilePreview, setRestoreFilePreviewError]);
 
   const handleRestoreRequest = (entry: SystemBackupEntrySummary) => {
     void handleRestorePreviewRequest({ fileName: entry.fileName });
@@ -501,7 +501,7 @@ export default function BackupsSettingsPage() {
     } finally {
       setRestoringBackup(false);
     }
-  }, [addToast, closeRestoreOverlay, fetchBackups, restorePreview, restoreSelectionState, restoreSource, restoringBackup]);
+  }, [addToast, closeRestoreOverlay, fetchBackups, restorePreview, restoreSelectionState, restoreSource, restoringBackup, setRestoringBackup]);
 
   const selectAllRestoreItems = useCallback(() => {
     if (!restorePreview || !restoreSelectionState) return;
@@ -526,7 +526,7 @@ export default function BackupsSettingsPage() {
       targetNodes: restoreSelectionState.targetNodes,
       serviceData: Object.fromEntries((restorePreview.serviceData || []).map(sd => [sd.name, Object.fromEntries(sd.files.map(f => [f, true]))])),
     });
-  }, [restorePreview, restoreSelectionState]);
+  }, [restorePreview, restoreSelectionState, setRestoreSelectionState]);
 
   const confirmDeleteBackup = async () => {
     if (!deleteTarget || deletingBackup) return;
@@ -572,7 +572,7 @@ export default function BackupsSettingsPage() {
       setRestoringLatest(false);
       setConfirmRestoreLatestOpen(false);
     }
-  }, [backups, restoringLatest, addToast, fetchBackups]);
+  }, [backups, restoringLatest, addToast, fetchBackups, setRestoringLatest, setConfirmRestoreLatestOpen]);
 
   const availableRestoreTargets = Array.from(new Set(['Local', ...nodes.map(node => node.Name)]));
 


### PR DESCRIPTION
## What
Mechanical lint cleanup: 7 react-hooks/exhaustive-deps warnings in backups/page.tsx resolved by adding the missing stable useState setters to useCallback dep arrays; 2 unused-var warnings in health/init.ts and servicebayChannel.test.ts fixed by _-prefixing / dropping unused params. Total warning count 347 → 338 (-9).

## Why
Lint-sweep batch/2026-06-03e — mechanical style/no-op fixes only.

## Risk
low — useState setters are React-guaranteed stable refs; adding them to dep arrays is a runtime no-op. The _-prefix renames are cosmetic.

## Rollback
git revert is enough

## Verification
- [x] npm run lint (0 errors, 338 warnings — down from 347)
- [x] npm run check:arch (719 modules, 0 violations)
- [x] npm test (231 files / 1835 tests passed)
- [ ] /verify on FCoS :dev box (not required — no path-mandated files)