### PR TITLE
fix(portal): recognize signed-in SSO user + add admin dashboard link

### DIFF
--- a/packages/backend/src/lib/portal/auth.test.ts
+++ b/packages/backend/src/lib/portal/auth.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
+vi.mock('@/lib/logger', () => ({ logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { getConfig } from '@/lib/config';
+import { verifyAutheliaSession } from './auth';
+
+/** Build a minimal Response-like with given status + identity headers. */
+function autheliaResponse(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, { status, headers });
+}
+
+const PUBLIC_CONFIG = {
+  reverseProxy: { publicDomain: 'dopp.cloud' },
+  templateSettings: { AUTHELIA_PORT: '9091' },
+};
+
+const mockGetConfig = vi.mocked(getConfig);
+const mockFetch = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  mockGetConfig.mockResolvedValue(PUBLIC_CONFIG as unknown as Awaited<ReturnType<typeof getConfig>>);
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mockFetch.mockReset();
+});
+
+describe('verifyAutheliaSession (#417 identity detection)', () => {
+  it('returns anonymous immediately when there is no cookie (no Authelia call)', async () => {
+    const result = await verifyAutheliaSession(null);
+    expect(result).toEqual({ user: null, name: null });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('points X-Original-URL at the www subdomain, not the deny-default apex', async () => {
+    mockFetch.mockResolvedValue(
+      autheliaResponse(200, { 'remote-user': 'max', 'remote-name': 'Max Mustermann' }),
+    );
+
+    await verifyAutheliaSession('authelia_session=abc');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    // Hits the 4.38+ nginx forward-auth endpoint, not the deprecated /api/verify.
+    expect(url).toBe('http://127.0.0.1:9091/api/authz/auth-request');
+    // www.<domain> is covered by the *.<domain> one_factor wildcard rule;
+    // the bare apex falls through to default-deny (403) and never carries
+    // identity headers. https scheme is mandatory (Authelia rejects http).
+    expect(headers['X-Original-URL']).toBe('https://www.dopp.cloud/');
+    expect(headers['X-Original-Method']).toBe('GET');
+    expect(headers.Cookie).toBe('authelia_session=abc');
+  });
+
+  it('returns the user + name on a 200 with identity headers', async () => {
+    mockFetch.mockResolvedValue(
+      autheliaResponse(200, { 'remote-user': 'max', 'remote-name': 'Max Mustermann' }),
+    );
+    expect(await verifyAutheliaSession('authelia_session=abc')).toEqual({
+      user: 'max',
+      name: 'Max Mustermann',
+    });
+  });
+
+  it('falls back to anonymous on 401 (no/expired session)', async () => {
+    mockFetch.mockResolvedValue(autheliaResponse(401));
+    expect(await verifyAutheliaSession('authelia_session=stale')).toEqual({ user: null, name: null });
+  });
+
+  it('falls back to anonymous on 403 (access-control rule miss)', async () => {
+    mockFetch.mockResolvedValue(autheliaResponse(403));
+    expect(await verifyAutheliaSession('authelia_session=abc')).toEqual({ user: null, name: null });
+  });
+
+  it('falls back to anonymous when Authelia is unreachable', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    expect(await verifyAutheliaSession('authelia_session=abc')).toEqual({ user: null, name: null });
+  });
+
+  it('treats empty identity headers as anonymous (bypass rule, no user injected)', async () => {
+    mockFetch.mockResolvedValue(autheliaResponse(200));
+    expect(await verifyAutheliaSession('authelia_session=abc')).toEqual({ user: null, name: null });
+  });
+});

--- a/packages/backend/src/lib/portal/auth.ts
+++ b/packages/backend/src/lib/portal/auth.ts
@@ -3,30 +3,44 @@
  *
  * The portal is intentionally anonymous-readable — random visitors
  * on the LAN should still see the service tiles. But when the
- * visitor has an Authelia session (e.g. they signed into FileBrowser
- * earlier and the cookie is shared across the public domain), we
- * can render extra affordances: hide the "Request access" button,
- * greet them by name, etc.
+ * visitor has an Authelia session (e.g. they signed into Home
+ * Assistant earlier and the cookie is shared across the public
+ * domain), we can render extra affordances: hide the "Request access"
+ * button, greet them by name, etc.
  *
- * Implementation: server-side call into Authelia's `/api/verify`
- * forwarding the visitor's `Cookie` header. Authelia returns 200 +
- * `Remote-User` / `Remote-Name` response headers when the cookie is
- * a valid session, or 401 when it isn't (or when there's no cookie
- * at all). Either way we treat it as best-effort — a stale config
- * or unreachable Authelia just falls back to the anonymous render.
+ * Implementation: server-side call into Authelia's
+ * `/api/authz/auth-request` forwarding the visitor's `Cookie` header
+ * plus an `X-Original-URL`. Authelia evaluates its access-control
+ * rules against that URL and, for an authenticated session, returns
+ * 200 with `Remote-User` / `Remote-Name` response headers; an
+ * unauthenticated visitor gets 401. Best-effort — a stale config or
+ * unreachable Authelia just falls back to the anonymous render.
  *
- * This is the same `/api/verify` endpoint the standard NPM
- * `auth_request` integration uses (see file-share's `FILEBROWSER_SUBDOMAIN`
- * advanced_config); we just call it ourselves so we don't have to
- * thread `auth_request_set` headers through the portal proxy host
- * (which would require an NPM advanced_config update for the apex
- * and complicates the anonymous-fallback path).
+ * **Why a `www.` subdomain and not the apex/`/portal`:** Authelia's
+ * access_control matches the bare apex (`https://<domain>/…`) against
+ * no rule, so it falls through to `default_policy: deny` and returns
+ * **403 — with no identity headers** even for a valid session. The
+ * `*.<domain>` wildcard rule is `one_factor`, so pointing
+ * `X-Original-URL` at a subdomain (`www.<domain>`, which is itself a
+ * portal host) yields 200 + `Remote-User`/`Remote-Name` for a signed-in
+ * visitor. Verified against the live box 2026-06-03: apex → 403,
+ * `www.<domain>` → 401 anon / 200 + identity when authed. Pointing it
+ * at `/portal` on the apex was why the chip never appeared (#417 / #1001
+ * follow-up).
+ *
+ * `/api/authz/auth-request` is the nginx-flavoured forward-auth
+ * endpoint (Authelia 4.38+) the rest of the proxy integration already
+ * uses (see `forwardAuth.ts`); it keeps the legacy `X-Original-URL` /
+ * `X-Original-Method` header API and returns 401 (not a 302) for the
+ * unauthenticated case. We call it ourselves rather than thread
+ * `auth_request_set` headers through the portal proxy host.
  */
 import { getConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
 
 const VERIFY_TIMEOUT_MS = 3_000;
 const DEFAULT_AUTHELIA_PORT = '9091';
+const AUTH_REQUEST_PATH = '/api/authz/auth-request';
 
 export interface PortalVisitor {
   /** LLDAP username when Authelia recognizes the cookie, otherwise null. */
@@ -37,10 +51,10 @@ export interface PortalVisitor {
 
 async function fetchAutheliaVerify(port: string, cookieHeader: string, originalUrl: string): Promise<Response | null> {
   try {
-    return await fetch(`http://127.0.0.1:${port}/api/verify`, {
+    return await fetch(`http://127.0.0.1:${port}${AUTH_REQUEST_PATH}`, {
       headers: {
         Cookie: cookieHeader,
-        ...(originalUrl ? { 'X-Original-URL': originalUrl } : {}),
+        ...(originalUrl ? { 'X-Original-URL': originalUrl, 'X-Original-Method': 'GET' } : {}),
       },
       signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
@@ -56,8 +70,13 @@ export async function verifyAutheliaSession(cookieHeader: string | null): Promis
   }
   const config = await getConfig();
   const port = config.templateSettings?.AUTHELIA_PORT ?? DEFAULT_AUTHELIA_PORT;
-  const publicDomain = config.reverseProxy?.publicDomain ?? config.reverseProxy?.lanDomain ?? '';
-  const originalUrl = publicDomain ? `https://${publicDomain}/portal` : '';
+  const domain = config.reverseProxy?.publicDomain ?? config.reverseProxy?.lanDomain ?? '';
+  // Point at the `www.` subdomain (covered by the `*.<domain>` one_factor
+  // wildcard rule), NOT the bare apex which evaluates to default-deny → 403
+  // and never carries identity headers. https scheme is mandatory — Authelia
+  // rejects `http://` X-Original-URL with a 400 ("insecure scheme") so the
+  // session cookie is only transmitted over TLS.
+  const originalUrl = domain ? `https://www.${domain}/` : '';
 
   const res = await fetchAutheliaVerify(port, cookieHeader, originalUrl);
   if (!res) {
@@ -66,7 +85,11 @@ export async function verifyAutheliaSession(cookieHeader: string | null): Promis
 
   if (!res.ok) {
     if (res.status === 403) {
-      logger.debug('portal:auth', `Authelia verify returned 403 (X-Original-URL=${originalUrl || '<unset>'}). Check session.cookies[].domain covers the public domain.`);
+      // 403 here means the wildcard one_factor rule we expect on
+      // `www.<domain>` isn't matching — the request fell through to
+      // default-deny. Most likely the access_control rules don't yet
+      // cover this domain (fresh install / pre-SSO).
+      logger.debug('portal:auth', `Authelia auth-request returned 403 (X-Original-URL=${originalUrl || '<unset>'}). Expected a one_factor rule for *.${domain}; falling back to anonymous render.`);
     }
     return { user: null, name: null };
   }

--- a/packages/frontend/src/app/portal/PortalAdminLink.tsx
+++ b/packages/frontend/src/app/portal/PortalAdminLink.tsx
@@ -1,0 +1,25 @@
+import { Settings } from 'lucide-react';
+
+/**
+ * Small, always-visible link to the ServiceBay admin dashboard from the
+ * family portal (admin-card design call, #417 follow-up).
+ *
+ * ServiceBay's admin UI lives on its own `admin.<domain>` host with
+ * app-layer login (not Authelia forward-auth), and the apex → /portal
+ * rewrite means there's otherwise no way to reach it from the portal.
+ * Shown to everyone — it's gated by the ServiceBay login regardless of
+ * who clicks — as a subtle top-left link rather than a service-grid
+ * tile, so it stays out of the family-facing card grid.
+ */
+export default function PortalAdminLink({ href }: { href: string }) {
+  return (
+    <a
+      href={href}
+      className="absolute top-6 left-6 inline-flex items-center gap-1.5 text-xs font-medium text-gray-400 hover:text-blue-600 dark:text-gray-500 dark:hover:text-blue-400 transition-colors"
+      title="ServiceBay admin dashboard — sign in to manage this server"
+    >
+      <Settings size={14} />
+      Admin
+    </a>
+  );
+}

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -1,10 +1,12 @@
 import { headers } from 'next/headers';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
 import { getConfig } from '@/lib/config';
+import { getActiveDomain, getMode } from '@/lib/mode';
 import { buildPortalCards } from '@/lib/portal/services';
 import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
 import PortalGrid from './PortalGrid';
+import PortalAdminLink from './PortalAdminLink';
 import PortalLogoutLink from './PortalLogoutLink';
 import PortalUserChip from './PortalUserChip';
 import AccessRequestStatusCTA from './AccessRequestStatusCTA';
@@ -12,6 +14,12 @@ import RequestAccessButton from './RequestAccessButton';
 
 export const revalidate = 0;
 export const dynamic = 'force-dynamic';
+
+/** ServiceBay admin host (see PortalAdminLink for the design rationale). */
+function adminDashboardUrl(config: Parameters<typeof getMode>[0]): string {
+  const scheme = getMode(config) === 'public' ? 'https' : 'http';
+  return `${scheme}://admin.${getActiveDomain(config)}/`;
+}
 
 /**
  * /portal — read-only card grid surfacing every running, feature-tier
@@ -56,10 +64,9 @@ export default async function PortalPage() {
   ]);
   const isLoggedIn = Boolean(visitor.user);
   const displayName = visitor.name?.trim() || visitor.user || null;
-  const firstName = displayName?.split(/\s+/)[0] ?? null;
-
   return (
     <main className="relative max-w-6xl mx-auto px-6 py-12">
+      <PortalAdminLink href={adminDashboardUrl(config)} />
       {isLoggedIn && displayName && <PortalUserChip displayName={displayName} />}
       <header className="mb-10 text-center">
         <div className="flex items-center justify-center gap-3">
@@ -69,8 +76,8 @@ export default async function PortalPage() {
           </h1>
         </div>
         <p className="mt-3 text-base text-gray-600 dark:text-gray-400">
-          {isLoggedIn && firstName
-            ? `Welcome back, ${firstName} — pick a service below to get started.`
+          {isLoggedIn && displayName
+            ? `Welcome back, ${displayName.split(/\s+/)[0]} — pick a service below to get started.`
             : 'Pick a service below to get started.'}
         </p>
         {isLoggedIn && <PortalLogoutLink />}


### PR DESCRIPTION
Closes #1606.

## Problem
The portal's Authelia soft-auth pointed `X-Original-URL` at the bare apex (`https://<domain>/portal`), which matches no `access_control` rule and falls through to `default_policy: deny` → **403 with no identity headers**. So a signed-in SSO visitor was always rendered anonymous ("Don't have an account yet?") and never greeted by name. There was also no way to reach the admin dashboard from the apex (the apex → `/portal` rewrite hides it).

## Verified against the live box (Authelia :9091)
| X-Original-URL | verdict |
|---|---|
| `https://dopp.cloud/portal` (apex) | 403 — default-deny, no identity |
| `https://www.dopp.cloud/` (subdomain) | 401 anon / 200 + `Remote-User`/`Remote-Name` when authed |

`*.<domain>` is `one_factor`; the bare apex matches nothing.

## Changes
- **`portal/auth.ts`** — point the verify at `https://www.<domain>/` (wildcard-covered subdomain); switch from the deprecated `/api/verify` to the 4.38+ `/api/authz/auth-request` (+ `X-Original-Method`) the rest of the proxy already uses. New `auth.test.ts` covers the URL/endpoint, 200+identity, and 401/403/unreachable fallbacks.
- **`PortalAdminLink.tsx` + `page.tsx`** — small, always-visible "Admin" link to `admin.<domain>` (gated by ServiceBay's own app-layer login regardless of who clicks).

## Notes
- Admin uses app-layer auth, **not** Authelia SSO (deliberate — `admin` is excluded from forward-auth), so the link lands on the ServiceBay login page; SSO won't auto-admit. `admin.<domain>` is a LAN-only host.
- Endpoint behavior verified against the box; the signed-in chip rendering still wants a real-session check on deploy.

Related: #417, #1001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)