### PR TITLE
feat: backup-target hardening, portal SSO + appless cards, claude-dev tmux

### DIFF
--- a/packages/backend/src/lib/backup/mounts.test.ts
+++ b/packages/backend/src/lib/backup/mounts.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { parseMountCandidates } from './mounts';
+
+describe('parseMountCandidates', () => {
+  it('returns mounted filesystems with size/free/mountpoint (byte sizes humanized)', () => {
+    const json = JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sda',
+          path: '/dev/sda',
+          type: 'disk',
+          size: '4000787030016',
+          children: [
+            {
+              name: 'sda1',
+              path: '/dev/sda1',
+              type: 'part',
+              size: '4000785981440',
+              fstype: 'ext4',
+              label: 'backup',
+              mountpoint: '/mnt/backup',
+              fsavail: '3865470566400',
+              'fsuse%': '3%',
+            },
+          ],
+        },
+      ],
+    });
+    const out = parseMountCandidates(json);
+    expect(out).toHaveLength(1);
+    const m = out[0];
+    expect(m.device).toBe('/dev/sda1');
+    expect(m.label).toBe('backup');
+    expect(m.fstype).toBe('ext4');
+    expect(m.mountpoint).toBe('/mnt/backup');
+    expect(m.mounted).toBe(true);
+    // -b byte counts get humanized
+    expect(m.size).toBe('3.6T');
+    expect(m.fsAvail).toBe('3.5T');
+    expect(m.fsUsedPct).toBe('3%');
+  });
+
+  it('includes unmounted filesystems flagged mounted:false with no free-space fields', () => {
+    const json = JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sdb1',
+          path: '/dev/sdb1',
+          type: 'part',
+          size: '64000000000',
+          fstype: 'vfat',
+          label: 'USB',
+          mountpoint: null,
+          fsavail: null,
+          'fsuse%': null,
+        },
+      ],
+    });
+    const [m] = parseMountCandidates(json);
+    expect(m.device).toBe('/dev/sdb1');
+    expect(m.mounted).toBe(false);
+    expect(m.mountpoint).toBeNull();
+    expect(m.fsAvail).toBeUndefined();
+    expect(m.fsUsedPct).toBeUndefined();
+    expect(m.fstype).toBe('vfat');
+  });
+
+  it('skips RAID/LVM member pseudo-filesystems but keeps the mounted md device', () => {
+    const json = JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sdc',
+          path: '/dev/sdc',
+          type: 'disk',
+          size: '4000787030016',
+          fstype: 'linux_raid_member', // member — not a target
+          mountpoint: null,
+          children: [
+            {
+              name: 'md127',
+              path: '/dev/md127',
+              type: 'raid1',
+              size: '4000000000000',
+              fstype: 'xfs',
+              label: 'data',
+              mountpoint: '/mnt/data',
+              fsavail: '1000000000000',
+              'fsuse%': '75%',
+            },
+          ],
+        },
+      ],
+    });
+    const out = parseMountCandidates(json);
+    expect(out.map(m => m.device)).toEqual(['/dev/md127']);
+    expect(out[0].mounted).toBe(true);
+    expect(out[0].mountpoint).toBe('/mnt/data');
+  });
+
+  it('handles human-readable lsblk output (no -b) without re-humanizing', () => {
+    const json = JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sda1',
+          type: 'part',
+          size: '3.6T',
+          fstype: 'ext4',
+          mountpoint: '/mnt/backup',
+        },
+      ],
+    });
+    const [m] = parseMountCandidates(json);
+    expect(m.device).toBe('/dev/sda1');
+    expect(m.size).toBe('3.6T');
+  });
+
+  it('returns [] for empty, malformed, or device-only (no filesystem) output', () => {
+    expect(parseMountCandidates('{"blockdevices":[]}')).toEqual([]);
+    expect(parseMountCandidates('not json')).toEqual([]);
+    expect(parseMountCandidates('')).toEqual([]);
+    // a bare disk with no fstype and no mountpoint is not a target
+    const noFs = JSON.stringify({
+      blockdevices: [{ name: 'sde', type: 'disk', size: '1000', mountpoint: null }],
+    });
+    expect(parseMountCandidates(noFs)).toEqual([]);
+  });
+
+  it('dedupes a device that appears more than once', () => {
+    const json = JSON.stringify({
+      blockdevices: [
+        { name: 'sda1', path: '/dev/sda1', type: 'part', fstype: 'ext4', mountpoint: '/mnt/backup' },
+        { name: 'sda1', path: '/dev/sda1', type: 'part', fstype: 'ext4', mountpoint: '/mnt/backup' },
+      ],
+    });
+    expect(parseMountCandidates(json)).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/lib/backup/mounts.ts
+++ b/packages/backend/src/lib/backup/mounts.ts
@@ -1,0 +1,182 @@
+/**
+ * Mount-candidate enumeration for the Backup Sync "Local / USB" target
+ * picker (#1613).
+ *
+ * Backup Sync runs inside the servicebay container, where `/mnt` block
+ * devices and external USB disks aren't visible. So — like the install
+ * wizard's storage detection (`api/system/storage`) — we enumerate the
+ * host's block devices via the agent's `lsblk -J`, not from in-container
+ * `df`. The result is a flat list of filesystem-bearing leaves the user
+ * can pick as a backup target: each carries device, label, size, free
+ * space, mountpoint, and whether it's currently mounted.
+ *
+ * Unmounted filesystems are still returned (flagged `mounted:false`) so
+ * the UI can show a disabled "not mounted — mount a disk here first" row
+ * instead of the user typing a path blind.
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { getDefaultNodeName } from '@/lib/nodes';
+import { logger } from '@/lib/logger';
+
+export interface MountCandidate {
+  /** Block-device path, e.g. /dev/sda1 or /dev/md127. */
+  device: string;
+  /** Filesystem label, when present. */
+  label?: string;
+  /** Filesystem type, e.g. ext4 / xfs / vfat. */
+  fstype?: string;
+  /** Human-readable device/partition size, e.g. "3.6T". */
+  size?: string;
+  /** Current mountpoint, or null when not mounted. */
+  mountpoint: string | null;
+  /** Human-readable free space when mounted. */
+  fsAvail?: string;
+  /** Used-percentage string when mounted, e.g. "23%". */
+  fsUsedPct?: string;
+  /** True when the filesystem is currently mounted (selectable as a target). */
+  mounted: boolean;
+}
+
+interface RawLsblkNode {
+  name?: string;
+  path?: string;
+  type?: string;
+  size?: string;
+  fstype?: string;
+  label?: string;
+  mountpoint?: string | null;
+  fsavail?: string;
+  'fsuse%'?: string;
+  children?: RawLsblkNode[];
+}
+
+const trim = (v: unknown): string | undefined => {
+  if (typeof v !== 'string') return undefined;
+  const s = v.trim();
+  return s.length > 0 ? s : undefined;
+};
+
+const fmtBytes = (b: number): string => {
+  const units = ['B', 'K', 'M', 'G', 'T', 'P'];
+  let v = b;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v >= 100 || i === 0 ? Math.round(v) : v.toFixed(1)}${units[i]}`;
+};
+
+// lsblk -b returns byte counts; without -b it returns human strings.
+// Detect by sniffing whether any size leaf is a bare integer.
+const looksLikeBytes = (nodes: RawLsblkNode[]): boolean => {
+  for (const n of nodes) {
+    if (typeof n.size === 'string' && /^\d+$/.test(n.size)) return true;
+    if (n.children && looksLikeBytes(n.children)) return true;
+  }
+  return false;
+};
+
+const maybeHuman = (raw: string | undefined, bytes: boolean): string | undefined => {
+  const v = trim(raw);
+  if (!v) return undefined;
+  if (bytes && /^\d+$/.test(v)) return fmtBytes(parseInt(v, 10));
+  return v;
+};
+
+/**
+ * Flatten `lsblk -J` JSON into the picker's mount candidates. Pure — the
+ * agent round-trip lives in {@link listLocalMountCandidates}, so this is
+ * unit-testable against captured lsblk output.
+ *
+ * A node is a candidate when it carries a filesystem type (`fstype`),
+ * excluding RAID-member / LVM-member / swap pseudo-types that aren't
+ * mountable as a backup target. Mounted candidates expose free space;
+ * unmounted ones are still returned so the UI can disable them with a
+ * "mount a disk here first" hint.
+ */
+export function parseMountCandidates(lsblkJson: string): MountCandidate[] {
+  let parsed: { blockdevices?: RawLsblkNode[] };
+  try {
+    parsed = JSON.parse(lsblkJson || '{"blockdevices":[]}');
+  } catch {
+    return [];
+  }
+  const roots = Array.isArray(parsed.blockdevices) ? parsed.blockdevices : [];
+  const bytes = looksLikeBytes(roots);
+
+  // Pseudo-filesystem types that are containers for another layer, not a
+  // mountable target. A real backup target is a plain filesystem.
+  const NON_TARGET_FSTYPES = new Set([
+    'linux_raid_member',
+    'lvm2_member',
+    'swap',
+    'crypto_luks',
+    'isw_raid_member',
+  ]);
+
+  const out: MountCandidate[] = [];
+  const seen = new Set<string>();
+
+  const walk = (node: RawLsblkNode) => {
+    const name = (node.name ?? '').toString();
+    const device = node.path ?? (name.startsWith('/') ? name : `/dev/${name}`);
+    const fstype = trim(node.fstype);
+    const mountpoint = node.mountpoint ?? null;
+
+    // A leaf is a candidate if it holds a usable filesystem (or is already
+    // mounted). Skip pseudo-member types — their child layer is the real fs.
+    const isTargetable =
+      (!!fstype && !NON_TARGET_FSTYPES.has(fstype.toLowerCase())) || mountpoint !== null;
+
+    if (isTargetable && device && !seen.has(device)) {
+      seen.add(device);
+      out.push({
+        device,
+        label: trim(node.label),
+        fstype,
+        size: maybeHuman(node.size, bytes),
+        mountpoint,
+        fsAvail: mountpoint !== null ? maybeHuman(node.fsavail, bytes) : undefined,
+        fsUsedPct: mountpoint !== null ? trim(node['fsuse%']) : undefined,
+        mounted: mountpoint !== null,
+      });
+    }
+
+    for (const child of node.children ?? []) {
+      walk(child);
+    }
+  };
+
+  for (const root of roots) walk(root);
+  return out;
+}
+
+/**
+ * Enumerate the host's filesystem mount candidates for the Backup Sync
+ * Local/USB picker. Resolves the default node and queries it with the
+ * same column set the install-wizard storage probe uses, falling back to
+ * a leaner column set on older util-linux, then to an empty result so a
+ * missing tool never crashes the picker.
+ */
+export async function listLocalMountCandidates(nodeName?: string): Promise<MountCandidate[]> {
+  const node = nodeName ?? (await getDefaultNodeName());
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    const res = (await agent.sendCommand(
+      'exec',
+      {
+        command:
+          `lsblk -J -b -o NAME,PATH,TYPE,SIZE,FSTYPE,LABEL,MOUNTPOINT,FSAVAIL,FSUSE% 2>/dev/null ` +
+          `|| lsblk -J -o NAME,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT 2>/dev/null ` +
+          `|| echo '{"blockdevices":[]}'`,
+      },
+      { timeoutMs: 10_000 },
+    )) as { code?: number; stdout?: string };
+    return parseMountCandidates(res.stdout ?? '');
+  } catch (e) {
+    logger.warn('backup:mounts', `mount enumeration failed: ${e instanceof Error ? e.message : String(e)}`);
+    return [];
+  }
+}

--- a/packages/backend/src/lib/backup/service.ts
+++ b/packages/backend/src/lib/backup/service.ts
@@ -193,9 +193,45 @@ function parseRsyncStats(output: string): { bytesTransferred?: number; filesTran
     return result;
 }
 
-async function ensureTargetDir(target: BackupTarget): Promise<void> {
+/**
+ * Validate a Local/USB target. Shared by Test Connection and Run so the two
+ * can never diverge (#1612). The target must ALREADY exist and be a directory
+ * — we never `mkdir` it, because a silently-created dir means a non-mounted
+ * mountpoint, which rsyncs straight onto the OS/boot disk. When `sources` are
+ * supplied we additionally refuse a target on the same filesystem/device as
+ * any source: a same-disk "backup" is pointless and is exactly what the old
+ * silent mkdir produced.
+ */
+async function validateLocalTarget(targetPath: string, sources?: BackupSource[]): Promise<void> {
+    let targetStats;
+    try {
+        targetStats = await fs.stat(targetPath);
+    } catch {
+        throw new Error(`ENOENT: no such file or directory, access '${targetPath}'`);
+    }
+    if (!targetStats.isDirectory()) {
+        throw new Error(`${targetPath} is not a directory`);
+    }
+    if (!sources || sources.length === 0) return;
+    for (const source of sources) {
+        let sourceStats;
+        try {
+            sourceStats = await fs.stat(source.path);
+        } catch {
+            continue; // a missing source is rsyncOneSource's problem, not ours
+        }
+        if (sourceStats.dev === targetStats.dev) {
+            throw new Error(
+                `Backup target ${targetPath} is on the same filesystem as source ${source.path} ` +
+                `(likely nothing is mounted there) — refusing to back up onto the same disk.`
+            );
+        }
+    }
+}
+
+async function ensureTargetDir(target: BackupTarget, sources?: BackupSource[]): Promise<void> {
     if (target.type === 'local') {
-        await fs.mkdir(target.path, { recursive: true });
+        await validateLocalTarget(target.path, sources);
     } else if (target.type === 'ssh') {
         const [sshBin, ...sshArgs] = buildSSHArgv(target);
         await execFileAsync(sshBin, [...sshArgs, `${target.user}@${target.host}`, 'mkdir', '-p', target.path]);
@@ -276,7 +312,7 @@ async function runBackupItems(
     }
 
     try {
-        await ensureTargetDir(config.target);
+        await ensureTargetDir(config.target, sources);
 
         let totalBytes = 0;
         let totalFiles = 0;
@@ -491,15 +527,11 @@ export function isBackupRunning(): boolean {
 
 // ─── Test Connection ────────────────────────────────────────────────
 
-export async function testBackupTarget(target: BackupTarget): Promise<{ success: boolean; message: string }> {
+export async function testBackupTarget(target: BackupTarget, sources?: BackupSource[]): Promise<{ success: boolean; message: string }> {
     try {
         switch (target.type) {
             case 'local': {
-                await fs.access(target.path);
-                const stats = await fs.stat(target.path);
-                if (!stats.isDirectory()) {
-                    return { success: false, message: `${target.path} is not a directory` };
-                }
+                await validateLocalTarget(target.path, sources);
                 // Test write access
                 const testFile = path.join(target.path, '.servicebay-backup-test');
                 await fs.writeFile(testFile, 'test');

--- a/packages/backend/src/lib/backup/validateTarget.test.ts
+++ b/packages/backend/src/lib/backup/validateTarget.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Local-target validation parity between Test Connection and Run (#1612).
+ *
+ * The old `ensureTargetDir` did `fs.mkdir(target.path, { recursive: true })`
+ * on the Run path, silently creating a non-mounted mountpoint as a plain dir
+ * on the OS/boot disk and rsyncing everything onto the same machine. Test and
+ * Run now share `validateLocalTarget` (exercised here via `testBackupTarget`):
+ *   - the target must already exist and be a directory (no mkdir),
+ *   - and may not sit on the same filesystem/device as a source.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { testBackupTarget } from './service';
+import type { BackupTarget, BackupSource } from './types';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-backup-validate-'));
+});
+
+afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('testBackupTarget — local target validation (#1612)', () => {
+    it('fails (ENOENT) when the target path does not exist — never creates it', async () => {
+        const missing = path.join(tmpRoot, 'not-mounted');
+        const target: BackupTarget = { type: 'local', path: missing };
+
+        const res = await testBackupTarget(target);
+
+        expect(res.success).toBe(false);
+        expect(res.message).toMatch(/ENOENT|no such file/i);
+        // Critically: the path must NOT have been created.
+        await expect(fs.stat(missing)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('fails when the target exists but is a file, not a directory', async () => {
+        const filePath = path.join(tmpRoot, 'afile');
+        await fs.writeFile(filePath, 'x');
+        const target: BackupTarget = { type: 'local', path: filePath };
+
+        const res = await testBackupTarget(target);
+
+        expect(res.success).toBe(false);
+        expect(res.message).toMatch(/not a directory/i);
+    });
+
+    it('refuses a target on the same filesystem as a source (same-disk backup)', async () => {
+        // Two dirs under the same tmp root share a device → must be refused.
+        const targetDir = path.join(tmpRoot, 'target');
+        const sourceDir = path.join(tmpRoot, 'source');
+        await fs.mkdir(targetDir);
+        await fs.mkdir(sourceDir);
+        const target: BackupTarget = { type: 'local', path: targetDir };
+        const sources: BackupSource[] = [{ path: sourceDir }];
+
+        const res = await testBackupTarget(target, sources);
+
+        expect(res.success).toBe(false);
+        expect(res.message).toMatch(/same filesystem|same disk/i);
+    });
+
+    it('passes for an existing, writable directory when no sources are given (device check skipped)', async () => {
+        const targetDir = path.join(tmpRoot, 'target');
+        await fs.mkdir(targetDir);
+        const target: BackupTarget = { type: 'local', path: targetDir };
+
+        const res = await testBackupTarget(target);
+
+        expect(res.success).toBe(true);
+        // The write-probe sentinel must have been cleaned up.
+        await expect(fs.stat(path.join(targetDir, '.servicebay-backup-test'))).rejects.toMatchObject({
+            code: 'ENOENT',
+        });
+    });
+});

--- a/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Phase-0 regression PINS for the per-service NAS-tar atom (epic #1607, #1608).
+ *
+ * The System-Snapshot unification (#1609+) refactors backup *collection* and the
+ * restore engine. The per-service tar `sb-backup/<svc>.tar` is the canonical atom
+ * that four producers feed (box-side producer, the `sb-config-upload` CLI, the
+ * HA-OS importer, and the upload route), and the pre-install seed flow depends on
+ * it byte-for-byte. These tests LOCK the behaviour that must not change so the
+ * merge can't silently regress that path — they assert NO new behaviour, only the
+ * existing contract:
+ *
+ *   1. `stageServiceBackup` selection against the REAL manifests — the golden
+ *      include/exclude/glob/strip/transform/rename spec the Snapshot's
+ *      service-config section must reproduce.
+ *   2. `runConfigUpload` (`sb-config-upload --service/--from`) end-to-end with the
+ *      REAL producer (only the NAS mocked): the on-NAS `<svc>.tar` + `.meta.json`
+ *      shape matches the box-side producer, whitelist + strip applied.
+ *   3. `importHaOsBackupToNas` (haOsImport.ts): a Supervisor backup → a
+ *      `home-assistant.tar` of ONLY the manifest includes (selective extraction).
+ *   4. `stageUploadedServiceTar` + its route: unknown-service / sub-512 rejects,
+ *      canonical layout, and the `tokenScope:'lifecycle'` contract on the route.
+ *
+ * If a Phase-1 change needs to alter any assertion here, that is a deliberate
+ * format break — update this file in the same commit and call it out.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const { mockNas } = vi.hoisted(() => ({
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+}));
+vi.mock('./nasClient', () => mockNas);
+// configUpload + the producer's box path read config; keep DATA_DIR unset so the
+// CLI's explicit serviceDataDir is the only source (the local fs backend).
+vi.mock('../config', () => ({ getConfig: vi.fn(async () => ({ templateSettings: {} })) }));
+
+import { stageServiceBackup } from './producer';
+import { runConfigUpload, type UploadIO } from './configUpload';
+import { importHaOsBackupToNas } from './haOsImport';
+import { getServiceManifest } from './serviceManifest';
+
+let tmpDirs: string[] = [];
+async function mkTmp(prefix = 'atomreg-'): Promise<string> {
+  const d = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+async function write(base: string, rel: string, content: string): Promise<void> {
+  const full = path.join(base, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+async function extractTar(tar: Buffer): Promise<string> {
+  const out = await mkTmp('atomreg-extract-');
+  const tarFile = path.join(out, 'a.tar');
+  await fs.writeFile(tarFile, tar);
+  await execFileAsync('tar', ['-xf', tarFile, '-C', out]);
+  await fs.rm(tarFile, { force: true });
+  return out;
+}
+/** Sorted list of every regular file (posix-relative) under `dir`. */
+async function listFilesRel(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(rel: string): Promise<void> {
+    const entries = await fs.readdir(path.join(dir, rel), { withFileTypes: true });
+    for (const e of entries) {
+      const r = path.posix.join(rel, e.name);
+      if (e.isDirectory()) await walk(r);
+      else if (e.isFile()) out.push(r);
+    }
+  }
+  await walk('');
+  return out.sort();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNas.nasUpload.mockResolvedValue(undefined);
+});
+afterEach(async () => {
+  await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tmpDirs = [];
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Golden selection spec — stageServiceBackup against the REAL manifests.
+//    This is the exact staged-file set each service's atom MUST contain; the
+//    Snapshot's service-config section has to reproduce it (#1608 acceptance).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GOLDEN: stageServiceBackup selection per real manifest', () => {
+  it('adguard — keeps only conf/AdGuardHome.yaml, drops querylog/stats/sessions/filters', async () => {
+    const src = await mkTmp();
+    await write(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+    await write(src, 'data/querylog.json', '[]');
+    await write(src, 'data/stats.db', 'STATS');
+    await write(src, 'data/sessions.db', 'SESS');
+    await write(src, 'data/filters/0.txt', 'rules');
+    const staging = await mkTmp();
+    const staged = await stageServiceBackup(src, getServiceManifest('adguard')!, staging);
+    expect(staged).toEqual(['conf/AdGuardHome.yaml']);
+  });
+
+  it('authelia — keeps users_database.yml with password hashes STRIPPED, identity kept', async () => {
+    const src = await mkTmp();
+    await write(
+      src,
+      'users_database.yml',
+      'users:\n  alice:\n    password: $argon2id$SECRET\n    displayname: Alice\n    email: a@x\n    groups:\n      - admins\n',
+    );
+    const staging = await mkTmp();
+    const staged = await stageServiceBackup(src, getServiceManifest('authelia')!, staging);
+    expect(staged).toEqual(['users_database.yml']);
+    const out = await fs.readFile(path.join(staging, 'users_database.yml'), 'utf8');
+    expect(out).not.toContain('SECRET');
+    expect(out).not.toMatch(/password:/);
+    expect(out).toContain('a@x');
+    expect(out).toContain('Alice');
+    expect(out).toContain('admins');
+  });
+
+  it('home-assistant — globs (lovelace*/hacs*) + custom_components dir + config-entries transform; DB/logs excluded', async () => {
+    const src = await mkTmp();
+    // Manifest includes
+    await write(src, 'automations.yaml', '[]');
+    await write(src, 'scripts.yaml', '{}');
+    await write(src, 'scenes.yaml', '[]');
+    await write(src, 'configuration.yaml', 'default_config:');
+    await write(src, '.storage/core.device_registry', '{}');
+    await write(src, '.storage/core.entity_registry', '{}');
+    await write(src, '.storage/core.area_registry', '{}');
+    await write(src, '.storage/lovelace', '{"sidebar":true}');
+    await write(src, '.storage/lovelace.lovelace', '{"dash":"main"}');
+    await write(src, '.storage/lovelace.map', '{"dash":"map"}');
+    await write(src, '.storage/zwave_js', '{"keys":"MESH"}');
+    await write(src, '.storage/hacs.repositories', '[]');
+    await write(src, '.storage/hacs.data', '{}');
+    await write(src, 'custom_components/meross_lan/__init__.py', 'CODE');
+    await write(src, 'custom_components/meross_lan/manifest.json', '{"domain":"meross_lan"}');
+    // The config-entries file the transform rewrites: a zwave_js add-on entry +
+    // a Supervisor-only `hassio` entry that must be dropped.
+    await write(
+      src,
+      '.storage/core.config_entries',
+      JSON.stringify({
+        data: {
+          entries: [
+            { domain: 'zwave_js', data: { use_addon: true, integration_created_addon: true, url: 'ws://core-zwave-js:3000' } },
+            { domain: 'hassio', data: {} },
+            { domain: 'light', data: { keep: true } },
+          ],
+        },
+      }),
+    );
+    // Excluded heavy data / logs
+    await write(src, 'home-assistant_v2.db', 'DB');
+    await write(src, 'home-assistant_v2.db-wal', 'WAL');
+    await write(src, 'home-assistant.log', 'noise');
+    await write(src, 'logs/today.log', 'noise');
+    await write(src, 'www/photo.jpg', 'IMG');
+    await write(src, 'deps/lib.py', 'dep');
+
+    const staging = await mkTmp();
+    const staged = await stageServiceBackup(src, getServiceManifest('home-assistant')!, staging);
+
+    expect(staged).toEqual([
+      '.storage/core.area_registry',
+      '.storage/core.config_entries',
+      '.storage/core.device_registry',
+      '.storage/core.entity_registry',
+      '.storage/hacs.data',
+      '.storage/hacs.repositories',
+      '.storage/lovelace',
+      '.storage/lovelace.lovelace',
+      '.storage/lovelace.map',
+      '.storage/zwave_js',
+      'automations.yaml',
+      'configuration.yaml',
+      'custom_components/meross_lan/__init__.py',
+      'custom_components/meross_lan/manifest.json',
+      'scenes.yaml',
+      'scripts.yaml',
+    ]);
+    // Transform PIN: zwave_js add-on entry rewritten to in-pod localhost, the
+    // Supervisor-only `hassio` entry dropped, the unrelated `light` entry kept.
+    const entries = (
+      JSON.parse(await fs.readFile(path.join(staging, '.storage/core.config_entries'), 'utf8')) as {
+        data: { entries: { domain: string; data: Record<string, unknown> }[] };
+      }
+    ).data.entries;
+    const domains = entries.map(e => e.domain);
+    expect(domains).toEqual(['zwave_js', 'light']);
+    expect(entries[0].data.use_addon).toBe(false);
+    expect(entries[0].data.url).toBe('ws://localhost:3001');
+  });
+
+  it('home-assistant-zwave (sibling store #1594) — keeps settings.json + sb-external-settings.json verbatim, drops logs/store.jsonl', async () => {
+    const src = await mkTmp();
+    await write(src, 'settings.json', '{"securityKeys":{"S2_Authenticated":"KEY"}}');
+    await write(src, 'sb-external-settings.json', '{"serverPort":3001}');
+    await write(src, 'store.jsonl', '{"node":1}');
+    await write(src, 'logs/zwave.log', 'noise');
+    const manifest = getServiceManifest('home-assistant-zwave')!;
+    const staging = await mkTmp();
+    const staged = await stageServiceBackup(src, manifest, staging);
+    expect(staged).toEqual(['sb-external-settings.json', 'settings.json']);
+    // No strip on this manifest — keys are kept verbatim.
+    expect(await fs.readFile(path.join(staging, 'settings.json'), 'utf8')).toContain('KEY');
+  });
+
+  it('nginx — keeps db + letsencrypt + custom_ssl, drops renewal logs / regenerated nginx conf', async () => {
+    const src = await mkTmp();
+    await write(src, 'data/database.sqlite', 'SQLITE');
+    await write(src, 'letsencrypt/accounts/acme.json', '{}');
+    await write(src, 'letsencrypt/logs/letsencrypt.log', 'noise');
+    await write(src, 'data/custom_ssl/cert.pem', 'PEM');
+    await write(src, 'data/nginx/proxy_host/1.conf', 'server {}');
+    await write(src, 'data/logs/access.log', 'noise');
+    const staging = await mkTmp();
+    // No collector runs here (stageServiceBackup is the pure selection step).
+    const staged = await stageServiceBackup(src, getServiceManifest('nginx')!, staging);
+    expect(staged).toEqual([
+      'data/custom_ssl/cert.pem',
+      'data/database.sqlite',
+      'letsencrypt/accounts/acme.json',
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. sb-config-upload end-to-end with the REAL producer (NAS mocked).
+//    Existing configUpload.test.ts mocks the producer, so the on-NAS atom shape
+//    is unpinned there. This locks that `--service/--from` writes the SAME
+//    canonical `<svc>.tar` + `.meta.json` the box-side producer does.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GOLDEN: runConfigUpload writes the canonical on-NAS atom (real producer)', () => {
+  function silentIO(): UploadIO {
+    return { log: () => {}, confirm: async () => true };
+  }
+
+  it('produces sb-backup/authelia.tar (whitelist + strip) + .meta.json sidecar', async () => {
+    const from = await mkTmp();
+    await write(
+      from,
+      'users_database.yml',
+      'users:\n  bob:\n    password: $argon2$NOPE\n    email: b@x\n',
+    );
+    await write(from, 'ignored.txt', 'not in the manifest');
+
+    const result = await runConfigUpload(
+      { service: 'authelia', from, target: 'fritzbox', assumeYes: true },
+      silentIO(),
+    );
+
+    // Result contract.
+    expect(result.tarName).toBe('authelia.tar');
+    expect(result.metaName).toBe('authelia.tar.meta.json');
+    expect(result.meta.service).toBe('authelia');
+    expect(result.meta.schemaVersion).toBe(1);
+
+    // Canonical NAS layout: both files under sb-backup/.
+    const uploadPaths = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
+    expect(uploadPaths).toContain('sb-backup/authelia.tar');
+    expect(uploadPaths).toContain('sb-backup/authelia.tar.meta.json');
+
+    // The tar carries the stripped whitelist file only — same as a box backup.
+    const tarBuf = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/authelia.tar'))![1] as Buffer;
+    const extracted = await extractTar(tarBuf);
+    expect(await listFilesRel(extracted)).toEqual(['users_database.yml']);
+    const body = await fs.readFile(path.join(extracted, 'users_database.yml'), 'utf8');
+    expect(body).not.toContain('NOPE');
+    expect(body).toContain('b@x');
+
+    // Sidecar JSON shape.
+    const metaBuf = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('.meta.json'))![1] as Buffer;
+    const meta = JSON.parse(metaBuf.toString('utf8'));
+    expect(meta.service).toBe('authelia');
+    expect(meta.schemaVersion).toBe(1);
+    expect(typeof meta.createdAt).toBe('string');
+    expect(typeof meta.nodeId).toBe('string');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. HA-OS import → home-assistant.tar (selective extraction; manifest includes
+//    only). Pins that the Supervisor-backup path produces the SAME atom layout
+//    a box-side HA backup would, never unpacking the heavy data/ DB.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GOLDEN: importHaOsBackupToNas → manifest-filtered home-assistant.tar', () => {
+  async function buildSupervisorBackup(): Promise<string> {
+    const inner = await mkTmp();
+    await write(inner, 'data/configuration.yaml', 'default_config:');
+    await write(inner, 'data/automations.yaml', '[]');
+    await write(inner, 'data/.storage/zwave_js', '{"keys":"MESH"}');
+    await write(inner, 'data/.storage/core.entity_registry', '{}');
+    await write(inner, 'data/.storage/lovelace.lovelace', '{"dash":"main"}');
+    await write(inner, 'data/.storage/hacs.repositories', '[]');
+    // NOTE: this fixture intentionally exercises only FILE includes. The HA
+    // manifest also includes the `custom_components` DIR, but extractHaConfigDir
+    // currently passes intermediate dir members to `tar -x` alongside their
+    // children, which GNU/libarchive tar rejects ("Not found in archive") — a
+    // latent gap tracked separately (#1620). The selective-extraction *atom
+    // shape* this PIN guards is the file-include set; the dir-include path is a
+    // pre-existing bug, not behaviour this regression test should bless.
+    // Heavy excluded members — must never be unpacked nor staged (#1353).
+    await write(inner, 'data/home-assistant_v2.db', 'HUGE-DB');
+    await write(inner, 'data/home-assistant.log', 'noise');
+
+    const outer = await mkTmp();
+    await execFileAsync('tar', ['-czf', path.join(outer, 'homeassistant.tar.gz'), '-C', inner, '.']);
+    await fs.writeFile(path.join(outer, 'backup.json'), '{"version":2,"type":"partial"}');
+
+    const out = await mkTmp();
+    const tarPath = path.join(out, 'ha-backup.tar');
+    await execFileAsync('tar', ['-cf', tarPath, '-C', outer, 'homeassistant.tar.gz', 'backup.json']);
+    return tarPath;
+  }
+
+  it('stages only the HA manifest includes — never the DB or logs', async () => {
+    const backup = await buildSupervisorBackup();
+    const res = await importHaOsBackupToNas(backup);
+    expect(res.tarName).toBe('home-assistant.tar');
+
+    const tarBuf = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/home-assistant.tar'))![1] as Buffer;
+    const extracted = await extractTar(tarBuf);
+    const files = await listFilesRel(extracted);
+    expect(files).toEqual([
+      '.storage/core.entity_registry',
+      '.storage/hacs.repositories',
+      '.storage/lovelace.lovelace',
+      '.storage/zwave_js',
+      'automations.yaml',
+      'configuration.yaml',
+    ]);
+    // The heavy excluded members never make it into the atom.
+    expect(files).not.toContain('home-assistant_v2.db');
+    expect(files).not.toContain('home-assistant.log');
+
+    // Canonical sidecar written alongside.
+    const uploadPaths = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
+    expect(uploadPaths).toContain('sb-backup/home-assistant.tar');
+    expect(uploadPaths).toContain('sb-backup/home-assistant.tar.meta.json');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Upload route contract: stageUploadedServiceTar rejects + the route's
+//    tokenScope:'lifecycle' gate (the scoped sb_ token the TUI uses). The
+//    behavioural rejects are exercised against the real producer; the route's
+//    token scope is pinned as a source contract (no frontend test harness here).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GOLDEN: upload route + stageUploadedServiceTar contract', () => {
+  it("the upload route enforces tokenScope: 'lifecycle'", async () => {
+    // vitest runs with cwd at the repo root (the workspace root, not the package).
+    const routePath = path.join(
+      process.cwd(),
+      'packages/frontend/src/app/api/system/external-backup/upload/route.ts',
+    );
+    const src = await fs.readFile(routePath, 'utf8');
+    // The scoped sb_ token the TUI seed flow (#1352) presents is a lifecycle
+    // token; a downgrade here would break or over-expose the upload endpoint.
+    expect(src).toMatch(/withApiHandler\(\s*\{\s*tokenScope:\s*'lifecycle'\s*\}/);
+  });
+});

--- a/packages/backend/src/lib/nodes.ts
+++ b/packages/backend/src/lib/nodes.ts
@@ -225,3 +225,15 @@ export async function getNodeConnection(name?: string): Promise<PodmanConnection
   const target = normalizeName(name);
   return nodes.find(n => normalizeName(n.Name) === target);
 }
+
+/**
+ * Resolve the name of the home node — the one ServiceBay itself runs on.
+ * Prefers the `Default`-flagged node, falls back to the first node, then
+ * to the built-in `Local` name. Used by host-side probes (e.g. the
+ * Backup Sync mount picker) that need a node to query but aren't tied to
+ * a user-selected one.
+ */
+export async function getDefaultNodeName(): Promise<string> {
+  const nodes = await loadNodes();
+  return (nodes.find(n => n.Default) ?? nodes[0])?.Name ?? 'Local';
+}

--- a/packages/backend/src/lib/portal/auth.test.ts
+++ b/packages/backend/src/lib/portal/auth.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
+vi.mock('@/lib/logger', () => ({ logger: { debug: vi.fn() } }));
+
+import { getConfig } from '@/lib/config';
+import { verifyAutheliaSession } from './auth';
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+function autheliaResponse(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, { status, headers });
+}
+
+describe('verifyAutheliaSession', () => {
+  beforeEach(() => {
+    mockedGetConfig.mockResolvedValue({
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+    } as unknown as Awaited<ReturnType<typeof getConfig>>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns anonymous without a cookie (no Authelia call)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await expect(verifyAutheliaSession(null)).resolves.toEqual({ user: null, name: null });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('probes the www.<domain> subdomain, NOT the bare apex (#1606)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(autheliaResponse(200, { 'remote-user': 'alice', 'remote-name': 'Alice Doe' }));
+
+    await verifyAutheliaSession('authelia_session=abc');
+
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const original = (init.headers as Record<string, string>)['X-Original-URL'];
+    expect(original).toBe('https://www.dopp.cloud/');
+    expect(original).not.toContain('/portal');
+  });
+
+  it('maps a 200 + identity headers to the signed-in visitor', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      autheliaResponse(200, { 'remote-user': 'alice', 'remote-name': 'Alice Doe' }),
+    );
+    await expect(verifyAutheliaSession('authelia_session=abc')).resolves.toEqual({
+      user: 'alice',
+      name: 'Alice Doe',
+    });
+  });
+
+  it('falls back to anonymous on a non-ok response (e.g. 401/403)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(autheliaResponse(403));
+    await expect(verifyAutheliaSession('authelia_session=abc')).resolves.toEqual({ user: null, name: null });
+  });
+
+  it('falls back to anonymous when Authelia is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(verifyAutheliaSession('authelia_session=abc')).resolves.toEqual({ user: null, name: null });
+  });
+});

--- a/packages/backend/src/lib/portal/auth.ts
+++ b/packages/backend/src/lib/portal/auth.ts
@@ -57,7 +57,14 @@ export async function verifyAutheliaSession(cookieHeader: string | null): Promis
   const config = await getConfig();
   const port = config.templateSettings?.AUTHELIA_PORT ?? DEFAULT_AUTHELIA_PORT;
   const publicDomain = config.reverseProxy?.publicDomain ?? config.reverseProxy?.lanDomain ?? '';
-  const originalUrl = publicDomain ? `https://${publicDomain}/portal` : '';
+  // Probe with the `www.<domain>` subdomain, NOT the bare apex. The apex
+  // (`dopp.cloud/portal`) matches no Authelia `access_control` rule, so it
+  // falls through to `default_policy: deny` → 403 with no identity headers,
+  // and a signed-in visitor is always seen as anonymous (#1606, #417, #1001).
+  // `www.<domain>` is provisioned alongside the apex (portal/provisioner.ts)
+  // and is covered by the `*.<domain>` `one_factor` wildcard rule, so an
+  // authenticated cookie returns 200 + `Remote-User` / `Remote-Name`.
+  const originalUrl = publicDomain ? `https://www.${publicDomain}/` : '';
 
   const res = await fetchAutheliaVerify(port, cookieHeader, originalUrl);
   if (!res) {
@@ -66,7 +73,7 @@ export async function verifyAutheliaSession(cookieHeader: string | null): Promis
 
   if (!res.ok) {
     if (res.status === 403) {
-      logger.debug('portal:auth', `Authelia verify returned 403 (X-Original-URL=${originalUrl || '<unset>'}). Check session.cookies[].domain covers the public domain.`);
+      logger.debug('portal:auth', `Authelia verify returned 403 (X-Original-URL=${originalUrl || '<unset>'}). Expected the *.<domain> one_factor rule to match; check session.cookies[].domain covers the public domain and the wildcard access_control rule exists.`);
     }
     return { user: null, name: null };
   }

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -27,7 +27,7 @@ import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getTemplateUserGuide } from '@/lib/registry';
 import { logger } from '@/lib/logger';
-import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAsset, type ManualPairing } from './userGuide';
+import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAsset, type ManualPairing, type PortalAction } from './userGuide';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
@@ -50,8 +50,17 @@ export interface PortalCard {
   /** Legacy emoji icon */
   icon: string;
   tagline: string;
-  /** External URL the "Open" button should point at. */
+  /** External URL the "Open" button should point at. Empty string for
+   *  an appless card (no subdomain) — the CTA falls back to
+   *  `primaryAction` instead (#1618). */
   url: string;
+  /** Primary action for a URL-less service (#1618). When `url` is empty
+   *  this is the card's CTA (a terminal deep-link, a `vscode://` link,
+   *  …). Null for ordinary Open-URL cards. */
+  primaryAction: PortalAction | null;
+  /** Secondary actions rendered as extra buttons. Desktop-only ones
+   *  (e.g. `vscode://`) carry `desktop_only` so the phone UI hides them. */
+  secondaryActions: PortalAction[];
   /** Markdown body shared across all cards from the same template
    *  (the template's `user-guide.md` body). */
   body: string;
@@ -179,45 +188,69 @@ export async function resolveServiceUrl(
   return `${scheme}://${sub}.${getActiveDomain(config)}`;
 }
 
+interface PortalCardDef {
+  subdomain_var: string;
+  label?: string;
+  lucide_icon?: PortalIconName;
+  icon?: string;
+  tagline?: string;
+  recommended_apps?: RecommendedApp[];
+  setup_assets?: SetupAsset[];
+  manual_pairing?: ManualPairing[];
+  primary_action?: PortalAction;
+  actions?: PortalAction[];
+}
+
+/** Assemble the PortalCard payload once the URL + subdomainVar are
+ *  resolved. Pure — no I/O — so the branching `buildPortalCardEntry`
+ *  stays lean. */
+function assemblePortalCard(
+  def: PortalCardDef,
+  serviceName: string,
+  templateLabel: string,
+  url: string | null,
+  subdomainVar: string,
+  parsedBody: string,
+): PortalCard {
+  return {
+    id: `${serviceName}:${subdomainVar || 'default'}`,
+    name: serviceName,
+    subdomainVar,
+    label: def.label ?? templateLabel,
+    lucideIcon: def.lucide_icon ?? null,
+    icon: def.icon ?? '',
+    tagline: def.tagline ?? '',
+    url: url ?? '',
+    primaryAction: def.primary_action ?? null,
+    secondaryActions: def.actions ?? [],
+    body: parsedBody,
+    recommendedApps: def.recommended_apps ?? [],
+    setupAssets: def.setup_assets ?? [],
+    manualPairing: def.manual_pairing ?? [],
+  };
+}
+
 /**
  * Build a single portal card entry from a parsed definition.
  */
 async function buildPortalCardEntry(
   config: AppConfig,
   svc: Awaited<ReturnType<typeof ServiceManager.listServices>>[number],
-  def: {
-    subdomain_var: string;
-    label?: string;
-    lucide_icon?: PortalIconName;
-    icon?: string;
-    tagline?: string;
-    recommended_apps?: RecommendedApp[];
-    setup_assets?: SetupAsset[];
-    manual_pairing?: ManualPairing[];
-  },
+  def: PortalCardDef,
   templateLabel: string,
   parsedBody: string,
 ): Promise<PortalCard | null> {
   const url = await resolveServiceUrl(config, svc.name, def.subdomain_var || undefined);
-  if (!url) {
-    logger.warn('portal', `Template ${svc.name} card (subdomain_var=${def.subdomain_var || '<auto>'}) couldn't resolve a URL — skipping`);
+  // No subdomain URL: an appless card still renders *iff* the guide
+  // declares an explicit primary action (#1618) — that becomes the CTA
+  // in place of the Open-URL button. Without one, there's nothing to
+  // act on, so we skip as before.
+  if (!url && !def.primary_action) {
+    logger.warn('portal', `Template ${svc.name} card (subdomain_var=${def.subdomain_var || '<auto>'}) couldn't resolve a URL and has no primary_action — skipping`);
     return null;
   }
   const subdomainVar = def.subdomain_var || (await firstSubdomainVar(svc.name)) || '';
-  return {
-    id: `${svc.name}:${subdomainVar || 'default'}`,
-    name: svc.name,
-    subdomainVar,
-    label: def.label ?? templateLabel,
-    lucideIcon: def.lucide_icon ?? null,
-    icon: def.icon ?? '',
-    tagline: def.tagline ?? '',
-    url,
-    body: parsedBody,
-    recommendedApps: def.recommended_apps ?? [],
-    setupAssets: def.setup_assets ?? [],
-    manualPairing: def.manual_pairing ?? [],
-  };
+  return assemblePortalCard(def, svc.name, templateLabel, url, subdomainVar, parsedBody);
 }
 
 /**
@@ -261,6 +294,8 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
         recommended_apps: parsed.frontmatter.recommended_apps,
         setup_assets: parsed.frontmatter.setup_assets,
         manual_pairing: parsed.frontmatter.manual_pairing,
+        primary_action: parsed.frontmatter.primary_action,
+        actions: parsed.frontmatter.actions,
       }];
 
     for (const def of cardDefs) {

--- a/packages/backend/src/lib/portal/userGuide.test.ts
+++ b/packages/backend/src/lib/portal/userGuide.test.ts
@@ -256,3 +256,166 @@ body
     expect(result).toBeNull();
   });
 });
+
+describe('parseUserGuide — action links (#1618)', () => {
+  it('parses a top-level in_app primary_action (terminal deep-link)', () => {
+    const raw = `---
+primary_action:
+  type: "in_app"
+  label: "Open terminal"
+  href: "/terminal?node=Local&container=claude-dev"
+  icon: "bot"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'claude-dev');
+    expect(result).not.toBeNull();
+    const pa = result!.frontmatter.primary_action;
+    expect(pa).toEqual({
+      type: 'in_app',
+      label: 'Open terminal',
+      href: '/terminal?node=Local&container=claude-dev',
+      icon: 'bot',
+      desktop_only: false, // in_app defaults to not desktop-only
+    });
+  });
+
+  it('parses an external_scheme action and defaults desktop_only to true', () => {
+    const raw = `---
+actions:
+  - type: "external_scheme"
+    label: "Open in VS Code"
+    href: "vscode://vscode-remote/ssh-remote+box/workspace"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'claude-dev');
+    expect(result!.frontmatter.actions).toEqual([
+      {
+        type: 'external_scheme',
+        label: 'Open in VS Code',
+        href: 'vscode://vscode-remote/ssh-remote+box/workspace',
+        desktop_only: true,
+      },
+    ]);
+  });
+
+  it('honours an explicit desktop_only override', () => {
+    const raw = `---
+primary_action:
+  type: "external_scheme"
+  label: "Open in Zed"
+  href: "zed://open"
+  desktop_only: false
+---
+body
+`;
+    const result = parseUserGuide(raw, 'svc');
+    expect(result!.frontmatter.primary_action?.desktop_only).toBe(false);
+  });
+
+  it('rejects an in_app href that is not root-relative (scheme / protocol-relative)', () => {
+    const cases = [
+      'https://evil.example/x',
+      '//evil.example/x',
+      'javascript:alert(1)',
+      'terminal',
+    ];
+    for (const href of cases) {
+      const raw = `---
+primary_action:
+  type: "in_app"
+  label: "X"
+  href: "${href}"
+---
+body
+`;
+      const result = parseUserGuide(raw, 'svc');
+      expect(result!.frontmatter.primary_action).toBeUndefined();
+    }
+  });
+
+  it('rejects an external_scheme href whose scheme is not allowlisted', () => {
+    const cases = ['javascript://x', 'data://x', 'http://x', 'ftp://x'];
+    for (const href of cases) {
+      const raw = `---
+primary_action:
+  type: "external_scheme"
+  label: "X"
+  href: "${href}"
+---
+body
+`;
+      const result = parseUserGuide(raw, 'svc');
+      expect(result!.frontmatter.primary_action).toBeUndefined();
+    }
+  });
+
+  it('drops an action missing label or href, or with an unknown type', () => {
+    const raw = `---
+actions:
+  - type: "in_app"
+    href: "/terminal"
+  - type: "in_app"
+    label: "No href"
+  - type: "bogus"
+    label: "X"
+    href: "/x"
+  - type: "in_app"
+    label: "Good"
+    href: "/good"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'svc');
+    expect(result!.frontmatter.actions).toEqual([
+      { type: 'in_app', label: 'Good', href: '/good', desktop_only: false },
+    ]);
+  });
+
+  it('drops an unknown icon name but keeps the action', () => {
+    const raw = `---
+primary_action:
+  type: "in_app"
+  label: "Open terminal"
+  href: "/terminal"
+  icon: "not-a-real-icon"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'svc');
+    expect(result!.frontmatter.primary_action).toEqual({
+      type: 'in_app',
+      label: 'Open terminal',
+      href: '/terminal',
+      desktop_only: false,
+    });
+  });
+
+  it('parses primary_action + actions inside a cards[] entry', () => {
+    const raw = `---
+cards:
+  - subdomain_var: "CLAUDE_DEV_SUBDOMAIN"
+    label: "Claude Dev"
+    primary_action:
+      type: "in_app"
+      label: "Open terminal"
+      href: "/terminal?container=claude-dev"
+    actions:
+      - type: "external_scheme"
+        label: "Open in VS Code"
+        href: "vscode://x"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'claude-dev');
+    const card = result!.frontmatter.cards?.[0];
+    expect(card?.primary_action?.href).toBe('/terminal?container=claude-dev');
+    expect(card?.actions?.[0]).toEqual({
+      type: 'external_scheme',
+      label: 'Open in VS Code',
+      href: 'vscode://x',
+      desktop_only: true,
+    });
+  });
+});

--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -120,6 +120,45 @@ export interface ManualPairing {
 }
 
 /**
+ * A primary/secondary card action for a service that has no Open-URL
+ * (#1618). The canonical case is claude-dev: no subdomain/proxy host,
+ * so the card can't offer an "Open" button — instead it offers a
+ * deep-link action (open the web terminal at `/terminal?...`) or an
+ * external-scheme link (`vscode://...`). Distinct from `manual_pairing`
+ * (a copyable command) and `setup_assets` (a server-generated artifact).
+ *
+ * Two link shapes are recognized:
+ *   - `in_app`: a root-relative path served from the same origin
+ *     (e.g. `/terminal?node=Local&container=claude-dev`). Rendered as
+ *     a normal in-app link.
+ *   - `external_scheme`: a custom-scheme URI the OS hands off to a
+ *     desktop app (`vscode://`, `zed://`, …). Inherently desktop-only,
+ *     so it carries `desktop_only:true` by default and the phone UI
+ *     hides/disables it.
+ */
+export type PortalActionType = 'in_app' | 'external_scheme';
+
+/** External URI schemes a card action may use. Allowlisted so a
+ *  template author can't smuggle `javascript:`/`data:` into an action
+ *  link. Each is a registered desktop-app handoff scheme. */
+const KNOWN_ACTION_SCHEMES = ['vscode', 'vscode-insiders', 'zed', 'jetbrains'] as const;
+
+export interface PortalAction {
+  type: PortalActionType;
+  /** Button label, e.g. "Open terminal" or "Open in VS Code". */
+  label: string;
+  /** The link target: a root-relative `/path?...` for `in_app`, or a
+   *  `<scheme>://...` URI for `external_scheme`. */
+  href: string;
+  /** Optional Lucide icon for the button (from the portal allowlist). */
+  icon?: PortalIconName;
+  /** When true, the phone UI hides/disables this action (the target
+   *  needs a desktop app, e.g. `vscode://`). Defaults true for
+   *  `external_scheme`, false for `in_app`. */
+  desktop_only?: boolean;
+}
+
+/**
  * Curated allowlist of Lucide icon names usable on portal cards.
  * Lucide is the same line-art icon set the dashboard sidebar uses,
  * so picking from this set keeps the portal visually consistent
@@ -168,6 +207,11 @@ export interface UserGuideCard {
   recommended_apps?: RecommendedApp[];
   setup_assets?: SetupAsset[];
   manual_pairing?: ManualPairing[];
+  /** Primary action when this card has no Open-URL (#1618). When set,
+   *  the card renders even without a resolvable subdomain. */
+  primary_action?: PortalAction;
+  /** Additional actions rendered as secondary buttons. */
+  actions?: PortalAction[];
 }
 
 export interface UserGuideFrontmatter {
@@ -198,6 +242,12 @@ export interface UserGuideFrontmatter {
    *  hand (e.g. `signal-cli link` QR pairing). Surfaced as a static
    *  "manual action required" panel — informational only (#1253). */
   manual_pairing?: ManualPairing[];
+  /** Primary card action for a URL-less service (#1618). When present,
+   *  the portal renders the card even without a resolvable subdomain;
+   *  the CTA becomes this action instead of an Open-URL button. */
+  primary_action?: PortalAction;
+  /** Secondary actions rendered as extra buttons below the CTA. */
+  actions?: PortalAction[];
 }
 
 export interface ParsedUserGuide {
@@ -288,6 +338,49 @@ function parseManualPairing(input: unknown): ManualPairing[] {
     .filter((e): e is ManualPairing => e !== null);
 }
 
+/** Validate a single action link (#1618). Returns null when the entry
+ *  is malformed or the href fails the per-type safety check:
+ *    - `in_app`: a same-origin root-relative path (`/...`, not `//`).
+ *    - `external_scheme`: a `<scheme>://...` URI whose scheme is in the
+ *      allowlist (`vscode`, `zed`, …) — blocks `javascript:`/`data:`.
+ *  `desktop_only` defaults to true for external-scheme links (they
+ *  hand off to a desktop app) and false for in-app links. */
+function isValidActionHref(type: PortalActionType, href: string): boolean {
+  if (type === 'in_app') {
+    // Root-relative same-origin path only; reject `//host` and any scheme.
+    return href.startsWith('/') && !href.startsWith('//');
+  }
+  const m = /^([a-z][a-z0-9+.-]*):\/\//i.exec(href);
+  return !!m && (KNOWN_ACTION_SCHEMES as readonly string[]).includes(m[1].toLowerCase());
+}
+
+function parsePortalAction(entry: unknown): PortalAction | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = entry as Record<string, unknown>;
+  if (e.type !== 'in_app' && e.type !== 'external_scheme') return null;
+  if (typeof e.label !== 'string' || !e.label.trim()) return null;
+  if (typeof e.href !== 'string' || !e.href.trim()) return null;
+  const type = e.type;
+  const href = e.href.trim();
+  if (!isValidActionHref(type, href)) return null;
+  const out: PortalAction = { type, label: e.label.trim(), href };
+  if (typeof e.icon === 'string' && PORTAL_ICON_SET.has(e.icon)) {
+    out.icon = e.icon as PortalIconName;
+  }
+  // Explicit desktop_only wins; otherwise default by link type.
+  out.desktop_only =
+    typeof e.desktop_only === 'boolean' ? e.desktop_only : type === 'external_scheme';
+  return out;
+}
+
+/** Parse the optional secondary `actions[]` list. */
+function parsePortalActions(input: unknown): PortalAction[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map(parsePortalAction)
+    .filter((a): a is PortalAction => a !== null);
+}
+
 /** Parse a `setup_assets[]` list down to whitelisted-kind entries.
  *  Shared by the top-level frontmatter and the per-card `cards[]`
  *  path. Unknown/non-string kinds drop silently. */
@@ -308,6 +401,19 @@ function parseSetupAssets(input: unknown): SetupAsset[] {
 
 /** Parse one `cards[]` entry (per-subdomain card). Returns null when
  *  the entry is malformed or lacks a valid `*_SUBDOMAIN` var. */
+function applyCardLists(card: UserGuideCard, e: Record<string, unknown>): void {
+  const apps = parseRecommendedApps(e.recommended_apps);
+  if (apps.length > 0) card.recommended_apps = apps;
+  const assets = parseSetupAssets(e.setup_assets);
+  if (assets.length > 0) card.setup_assets = assets;
+  const pairing = parseManualPairing(e.manual_pairing);
+  if (pairing.length > 0) card.manual_pairing = pairing;
+  const primaryAction = parsePortalAction(e.primary_action);
+  if (primaryAction) card.primary_action = primaryAction;
+  const actions = parsePortalActions(e.actions);
+  if (actions.length > 0) card.actions = actions;
+}
+
 function parseCardEntry(entry: unknown): UserGuideCard | null {
   if (!entry || typeof entry !== 'object') return null;
   const e = entry as Record<string, unknown>;
@@ -321,12 +427,7 @@ function parseCardEntry(entry: unknown): UserGuideCard | null {
     card.lucide_icon = e.lucide_icon as PortalIconName;
   }
   if (typeof e.tagline === 'string') card.tagline = e.tagline;
-  const apps = parseRecommendedApps(e.recommended_apps);
-  if (apps.length > 0) card.recommended_apps = apps;
-  const assets = parseSetupAssets(e.setup_assets);
-  if (assets.length > 0) card.setup_assets = assets;
-  const pairing = parseManualPairing(e.manual_pairing);
-  if (pairing.length > 0) card.manual_pairing = pairing;
+  applyCardLists(card, e);
   return card;
 }
 
@@ -361,6 +462,11 @@ function parseUserGuideSection(data: Record<string, unknown>): UserGuideFrontmat
 
   const pairing = parseManualPairing(data.manual_pairing);
   if (pairing.length > 0) fm.manual_pairing = pairing;
+
+  const primaryAction = parsePortalAction(data.primary_action);
+  if (primaryAction) fm.primary_action = primaryAction;
+  const actions = parsePortalActions(data.actions);
+  if (actions.length > 0) fm.actions = actions;
 
   return fm;
 }

--- a/packages/frontend/src/app/(dashboard)/settings/backups/_lib/LocalTargetPicker.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/_lib/LocalTargetPicker.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, RefreshCw, HardDrive, Usb, CheckCircle2 } from 'lucide-react';
+import type { MountCandidate } from '@/lib/backup/mounts';
+
+const REMOVABLE_FSTYPES = new Set(['vfat', 'exfat', 'ntfs']);
+
+function rowClass(active: boolean, selectable: boolean): string {
+  const base = 'w-full flex items-start gap-2 px-3 py-2 text-left rounded-lg border-2 transition-colors';
+  if (active) return `${base} bg-blue-50 dark:bg-blue-900/20 border-blue-500 dark:border-blue-400`;
+  if (selectable) return `${base} border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 hover:border-gray-300 dark:hover:border-gray-600`;
+  return `${base} border-gray-200 dark:border-gray-700 opacity-60 cursor-not-allowed`;
+}
+
+/** The second line of a row — free space when mounted, hint when not. */
+function MountDetail({ mount }: { mount: MountCandidate }) {
+  if (mount.mounted && mount.mountpoint) {
+    return (
+      <div className="text-[11px] text-gray-500 dark:text-gray-400">
+        <span className="font-mono">{mount.mountpoint}</span>
+        {mount.fsAvail && <span> · {mount.fsAvail} free{mount.fsUsedPct ? ` (${mount.fsUsedPct} used)` : ''}</span>}
+        {mount.fstype && <span> · {mount.fstype}</span>}
+      </div>
+    );
+  }
+  return (
+    <div className="text-[11px] text-amber-600 dark:text-amber-400">
+      Not mounted — mount a disk here first{mount.fstype ? ` (${mount.fstype})` : ''}
+    </div>
+  );
+}
+
+/** One row in the mount picker — a single block device / mountpoint. */
+function MountRow({
+  mount,
+  active,
+  onSelect,
+}: {
+  mount: MountCandidate;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const selectable = mount.mounted && !!mount.mountpoint;
+  const Icon = REMOVABLE_FSTYPES.has(mount.fstype ?? '') ? Usb : HardDrive;
+  return (
+    <button type="button" disabled={!selectable} onClick={onSelect} aria-pressed={active} className={rowClass(active, selectable)}>
+      <Icon size={16} className={`mt-0.5 flex-shrink-0 ${active ? 'text-blue-600 dark:text-blue-300' : 'text-gray-400'}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className={`text-xs font-semibold ${active ? 'text-blue-700 dark:text-blue-300' : 'text-gray-700 dark:text-gray-200'}`}>
+            {mount.label || mount.device}
+          </span>
+          <span className="text-[11px] font-mono text-gray-400">{mount.device}</span>
+          {mount.size && <span className="text-[11px] text-gray-400">· {mount.size}</span>}
+          {active && <CheckCircle2 size={12} className="text-blue-600 dark:text-blue-300" />}
+        </div>
+        <MountDetail mount={mount} />
+      </div>
+    </button>
+  );
+}
+
+/** The scan results: a list of pickable disks, or an empty-state hint. */
+function MountList({
+  mounts,
+  value,
+  error,
+  onChange,
+}: {
+  mounts: MountCandidate[];
+  value: string;
+  error: string | null;
+  onChange: (path: string) => void;
+}) {
+  if (mounts.length === 0) {
+    return (
+      <p className="text-[11px] text-gray-500 dark:text-gray-400 py-1">
+        {error
+          ? `Couldn't list disks: ${error}. Enter a path manually below.`
+          : 'No mounted disks detected. Mount a USB/external drive, then Rescan — or enter a path manually below.'}
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-1.5">
+      {mounts.map(m => (
+        <MountRow
+          key={m.device}
+          mount={m}
+          active={m.mounted && m.mountpoint === value}
+          onSelect={() => m.mountpoint && onChange(m.mountpoint)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Free-text fallback path, revealed behind the "advanced" toggle. */
+function AdvancedPath({ value, onChange }: { value: string; onChange: (path: string) => void }) {
+  return (
+    <div>
+      <input
+        type="text"
+        className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="/mnt/backup"
+      />
+      <p className="text-[11px] text-gray-400 mt-1">
+        Advanced: an explicit path. The disk must already be mounted here — Backup Sync refuses an unmounted target so it never writes to the OS disk.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Local / USB backup-target picker (#1613). Replaces the old free-text
+ * `/mnt/backup` box: enumerates the host's real mounted block devices
+ * (device, label, size, free space, mountpoint) so the user picks a disk
+ * instead of typing a path blind and hitting ENOENT.
+ *
+ * Unmounted filesystems are shown disabled with a "not mounted" hint.
+ * A free-text path remains available behind an "advanced" toggle as a
+ * fallback for paths the enumeration can't see (or when the picker fails
+ * to load at all).
+ */
+function useMounts() {
+  const [mounts, setMounts] = useState<MountCandidate[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/settings/backup-sync/mounts');
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Unable to enumerate mounts (${res.status})`);
+      }
+      const data = await res.json();
+      setMounts(Array.isArray(data.mounts) ? data.mounts : []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load mounts');
+      setMounts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { mounts, loading, error, load };
+}
+
+export default function LocalTargetPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (path: string) => void;
+}) {
+  const { mounts, loading, error, load } = useMounts();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // If the configured path isn't one of the enumerated mountpoints, the
+  // user is on a custom path — keep the advanced free-text box open so
+  // their value stays visible and editable.
+  const selectedIsKnownMount = !!mounts?.some(m => m.mounted && m.mountpoint === value);
+  const advancedOpen = showAdvanced || (!!value && mounts !== null && !selectedIsKnownMount);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">Target disk</label>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className="flex items-center gap-1 text-[11px] text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 disabled:opacity-50"
+        >
+          {loading ? <Loader2 size={11} className="animate-spin" /> : <RefreshCw size={11} />} Rescan
+        </button>
+      </div>
+
+      {loading && mounts === null ? (
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 py-2">
+          <Loader2 size={12} className="animate-spin" /> Scanning disks…
+        </div>
+      ) : (
+        <>
+          <MountList mounts={mounts ?? []} value={value} error={error} onChange={onChange} />
+
+          <button
+            type="button"
+            onClick={() => setShowAdvanced(v => !v)}
+            className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {advancedOpen ? 'Hide advanced path' : 'Advanced: enter a path manually'}
+          </button>
+
+          {advancedOpen && <AdvancedPath value={value} onChange={onChange} />}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -48,6 +48,7 @@ import {
   type SystemBackupEntrySummary,
 } from '../_lib/helpers';
 import ExternalBackupDestinationSection from '../_lib/sections/ExternalBackupDestinationSection';
+import LocalTargetPicker from './_lib/LocalTargetPicker';
 
 export default function BackupsSettingsPage() {
   const { addToast } = useToast();
@@ -1065,11 +1066,10 @@ export default function BackupsSettingsPage() {
             </div>
 
           {backupSync.targetType === 'local' && (
-            <div>
-              <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Target Path</label>
-              <input type="text" className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white" value={backupSync.localPath} onChange={e => setBackupSync(prev => ({ ...prev, localPath: e.target.value }))} placeholder="/mnt/backup" />
-              <p className="text-[11px] text-gray-400 mt-1">Mount your USB/external drive here first.</p>
-            </div>
+            <LocalTargetPicker
+              value={backupSync.localPath}
+              onChange={path => setBackupSync(prev => ({ ...prev, localPath: path }))}
+            />
           )}
 
           {backupSync.targetType === 'ssh' && (

--- a/packages/frontend/src/app/api/settings/backup-sync/mounts/route.ts
+++ b/packages/frontend/src/app/api/settings/backup-sync/mounts/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listLocalMountCandidates } from '@/lib/backup/mounts';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET — Enumerate host filesystem mount candidates for the Backup Sync
+ * Local/USB target picker (#1613). Optional `node` query overrides the
+ * default (home) node. Always returns a list (possibly empty) so the
+ * picker can fall back to the advanced free-text path on its own.
+ */
+const GetQuery = z.object({ node: z.string().min(1).optional() });
+
+export const GET = withApiHandler<undefined, z.infer<typeof GetQuery>>(
+  { query: GetQuery },
+  async ({ query }) => {
+    const mounts = await listLocalMountCandidates(query.node);
+    return NextResponse.json({ mounts });
+  },
+);

--- a/packages/frontend/src/app/api/settings/backup-sync/route.ts
+++ b/packages/frontend/src/app/api/settings/backup-sync/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getConfig, updateConfig } from '@/lib/config';
 import { runBackup, getBackupHistory, isBackupRunning, testBackupTarget, scheduleBackup } from '@/lib/backup/service';
 import type { BackupConfig, BackupTarget } from '@/lib/backup/types';
+import { resolveBackupSources } from '@/lib/backup/types';
 import { HealthStore } from '@/lib/health/store';
 import { withApiHandler } from '@/lib/api/handler';
 import crypto from 'crypto';
@@ -79,7 +80,11 @@ export const POST = withApiHandler({ body: PostBody }, async ({ body }) => {
       if (!target) {
         return NextResponse.json({ error: 'target is required' }, { status: 400 });
       }
-      const result = await testBackupTarget(target);
+      // Resolve the configured sources so Test applies the same same-device
+      // guard Run does (#1612) — a target on the source's filesystem is refused.
+      const cfg = await getConfig();
+      const sources = cfg.backup ? resolveBackupSources(cfg.backup) : [];
+      const result = await testBackupTarget(target, sources);
       return NextResponse.json(result);
     }
   }

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -23,6 +23,8 @@ const baseCard: PortalCard = {
   icon: '',
   tagline: 'Auto-backup your family photos.',
   url: 'https://photos.home.arpa',
+  primaryAction: null,
+  secondaryActions: [],
   body: '',
   recommendedApps: [],
   setupAssets: [],
@@ -148,6 +150,85 @@ describe('PortalGrid', () => {
       // Clicking the backdrop (the outermost overlay div) closes the modal.
       fireEvent.click(screen.getByRole('heading', { name: /install basicsync/i }).closest('div')!.parentElement!);
       expect(screen.queryByRole('heading', { name: /install basicsync/i })).toBeNull();
+    });
+  });
+
+  describe('appless cards + action links (#1618)', () => {
+    const applessCard: PortalCard = {
+      ...baseCard,
+      id: 'claude-dev:default',
+      name: 'claude-dev',
+      label: 'Claude Dev',
+      url: '', // no subdomain → no Open-URL button
+      primaryAction: {
+        type: 'in_app',
+        label: 'Open terminal',
+        href: '/terminal?node=Local&container=claude-dev',
+        desktop_only: false,
+      },
+    };
+
+    it('renders the primary action as the CTA when there is no URL', () => {
+      render(<PortalGrid cards={[applessCard]} />);
+      // No "Open" link (no url), but the primary action link is present.
+      expect(screen.queryByRole('link', { name: /^open$/i })).toBeNull();
+      const cta = screen.getByRole('link', { name: /open terminal/i });
+      expect(cta.getAttribute('href')).toBe('/terminal?node=Local&container=claude-dev');
+    });
+
+    it('keeps in-app deep-links in the same tab (no target=_blank)', () => {
+      render(<PortalGrid cards={[applessCard]} />);
+      const cta = screen.getByRole('link', { name: /open terminal/i });
+      expect(cta.getAttribute('target')).toBeNull();
+    });
+
+    it('renders secondary actions as extra buttons', () => {
+      const card: PortalCard = {
+        ...applessCard,
+        secondaryActions: [
+          { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://vscode-remote/ssh-remote+box', desktop_only: true },
+        ],
+      };
+      render(<PortalGrid cards={[card]} />);
+      const vscode = screen.getByRole('link', { name: /open in vs code/i });
+      expect(vscode.getAttribute('href')).toBe('vscode://vscode-remote/ssh-remote+box');
+      // External scheme opens in a new tab/handoff.
+      expect(vscode.getAttribute('target')).toBe('_blank');
+    });
+
+    it('shows desktop-only actions on desktop (default jsdom UA)', () => {
+      const card: PortalCard = {
+        ...applessCard,
+        primaryAction: { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://x', desktop_only: true },
+      };
+      render(<PortalGrid cards={[card]} />);
+      // jsdom's default UA is non-mobile → desktop-only action is visible.
+      expect(screen.getByRole('link', { name: /open in vs code/i })).toBeDefined();
+    });
+
+    it('hides a desktop-only primary action on a phone UA', () => {
+      const original = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148',
+        configurable: true,
+      });
+      try {
+        const card: PortalCard = {
+          ...applessCard,
+          primaryAction: { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://x', desktop_only: true },
+        };
+        render(<PortalGrid cards={[card]} />);
+        expect(screen.queryByRole('link', { name: /open in vs code/i })).toBeNull();
+        // A graceful "available on desktop" hint replaces it.
+        expect(screen.getByText(/available on desktop/i)).toBeDefined();
+      } finally {
+        Object.defineProperty(navigator, 'userAgent', { value: original, configurable: true });
+      }
+    });
+
+    it('still shows the Open-URL button for ordinary URL-based cards', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      expect(screen.getByRole('link', { name: /^open$/i })).toBeDefined();
     });
   });
 });

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -4,16 +4,17 @@ import { useEffect, useState, useSyncExternalStore } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
-  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, Copy,
+  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, Code, Copy,
   Download, ExternalLink, Files, Film, Folder, FolderOpen, Globe,
   Headphones, House, Image as ImageIcon, Images, KeyRound, Lightbulb,
   Lightbulb as LightbulbIcon, Loader2, Lock, Mail, MessageSquare,
-  Music, Package, QrCode, RefreshCw, Router, Shield, Smartphone, Terminal, Video,
+  Music, Package, QrCode, RefreshCw, Router, Shield, Smartphone,
+  Terminal, TerminalSquare, Video,
   Sparkles, X,
 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import type { PortalCard } from '@/lib/portal/services';
-import type { AppPlatform, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
+import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
 
 type IconComponent = typeof Camera;
 
@@ -176,17 +177,13 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
               </p>
             </div>
 
-            {/* Open button — at fixed offset from card top thanks to
-                the clamped header above. Consistent Y across cards. */}
-            <div className="px-6">
-              <a
-                href={card.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center gap-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors"
-              >
-                Open <ExternalLink size={16} />
-              </a>
+            {/* CTA — at fixed offset from card top thanks to the
+                clamped header above. Consistent Y across cards. An
+                Open-URL card shows the blue "Open" button; a URL-less
+                appless card (#1618) shows its primary action instead,
+                followed by any secondary action buttons. */}
+            <div className="px-6 space-y-2">
+              <CardCta card={card} isMobile={isMobile} />
             </div>
 
             {/* Variable content below — fills the rest of the card so
@@ -300,6 +297,84 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
       <CardHelpModal card={activeCard} onClose={() => setActiveCardId(null)} />
     )}
     </>
+  );
+}
+
+/**
+ * Card call-to-action (#1618). An ordinary Open-URL card renders the
+ * blue "Open" button pointing at the resolved subdomain. A URL-less
+ * appless card (e.g. claude-dev — no subdomain/proxy host) has an
+ * empty `url` and a `primaryAction` instead: that action becomes the
+ * CTA. Secondary actions render underneath as smaller buttons.
+ *
+ * Desktop-only actions (`desktop_only`, e.g. `vscode://` which needs a
+ * desktop app installed) are hidden on a phone/tablet so the mobile
+ * visitor isn't offered a link that can't open.
+ */
+function CardCta({ card, isMobile }: { card: PortalCard; isMobile: boolean }) {
+  if (card.url) {
+    return (
+      <a
+        href={card.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-center gap-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors"
+      >
+        Open <ExternalLink size={16} />
+      </a>
+    );
+  }
+  // Appless card: primary action as the CTA, secondaries below.
+  const primaryHidden = card.primaryAction?.desktop_only && isMobile;
+  return (
+    <>
+      {card.primaryAction && !primaryHidden && (
+        <ActionButton action={card.primaryAction} variant="primary" />
+      )}
+      {card.primaryAction && primaryHidden && (
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 text-center leading-snug">
+          {card.primaryAction.label} is available on desktop.
+        </p>
+      )}
+      {card.secondaryActions
+        .filter(a => !(a.desktop_only && isMobile))
+        .map(a => (
+          <ActionButton key={a.href} action={a} variant="secondary" />
+        ))}
+    </>
+  );
+}
+
+/**
+ * Renders one {@link PortalAction} as a button/link. `in_app` actions
+ * are root-relative same-origin links (open in the same tab — they're
+ * other ServiceBay surfaces like the web terminal); `external_scheme`
+ * actions (`vscode://`, …) hand off to a desktop app, so they open via
+ * a plain anchor the OS intercepts.
+ */
+function ActionButton({
+  action,
+  variant,
+}: {
+  action: PortalAction;
+  variant: 'primary' | 'secondary';
+}) {
+  const Icon = action.icon ? PORTAL_ICON_MAP[action.icon] : action.type === 'external_scheme' ? Code : TerminalSquare;
+  const className =
+    variant === 'primary'
+      ? 'flex items-center justify-center gap-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors'
+      : 'flex items-center justify-center gap-2 w-full bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-100 text-sm font-medium py-2 rounded-lg transition-colors';
+  // in_app links stay in the tab (same-origin app surface); external
+  // schemes open via the same anchor — the OS intercepts the scheme.
+  const sameTab = action.type === 'in_app';
+  return (
+    <a
+      href={action.href}
+      {...(sameTab ? {} : { target: '_blank', rel: 'noopener noreferrer' })}
+      className={className}
+    >
+      <Icon size={variant === 'primary' ? 16 : 14} /> {action.label}
+    </a>
   );
 }
 

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -1,6 +1,7 @@
 import { headers } from 'next/headers';
+import { Settings } from 'lucide-react';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
-import { getConfig } from '@/lib/config';
+import { getConfig, getAdminBaseUrl } from '@/lib/config';
 import { buildPortalCards } from '@/lib/portal/services';
 import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
@@ -57,6 +58,11 @@ export default async function PortalPage() {
   const isLoggedIn = Boolean(visitor.user);
   const displayName = visitor.name?.trim() || visitor.user || null;
   const firstName = displayName?.split(/\s+/)[0] ?? null;
+  // Link to the ServiceBay admin dashboard at admin.<domain>. The apex →
+  // /portal rewrite otherwise hides any path to the admin UI (#1606). admin.
+  // has its own app-layer login (not Authelia forward-auth), so it's safe to
+  // surface the link to anyone — the admin login still gates access.
+  const adminUrl = getAdminBaseUrl(config);
 
   return (
     <main className="relative max-w-6xl mx-auto px-6 py-12">
@@ -74,6 +80,18 @@ export default async function PortalPage() {
             : 'Pick a service below to get started.'}
         </p>
         {isLoggedIn && <PortalLogoutLink />}
+        {adminUrl && (
+          <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+            <a
+              href={adminUrl}
+              className="inline-flex items-center gap-1.5 text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline-offset-2 hover:underline"
+            >
+              <Settings size={14} />
+              Admin dashboard
+            </a>
+            <span className="ml-1.5 text-gray-400 dark:text-gray-500">(separate login)</span>
+          </p>
+        )}
       </header>
 
       {!isLoggedIn && (

--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -15,12 +15,13 @@ FROM node:20-bookworm-slim
 #   - make/gcc/g++/python3   : native-module builds (better-sqlite3, …)
 #   - podman                 : run the repo's container e2e scripts
 #   - procps/iproute2        : ps/ss for debugging from inside a session
+#   - tmux                   : persistent session that survives disconnects
 #   - curl/ca-certificates/gnupg : fetch the GitHub CLI apt key
 # The GitHub CLI (`gh`) is not in Debian's repos, so add its apt source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       openssh-server openssh-client git bash \
       make gcc g++ python3 \
-      podman procps iproute2 \
+      podman procps iproute2 tmux \
       curl ca-certificates gnupg \
   && install -m 0755 -d /etc/apt/keyrings \
   && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -44,6 +45,22 @@ RUN useradd --create-home --home-dir /workspace --shell /bin/bash dev
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Interactive login shells (an SSH session, the web terminal, the mobile
+# app) attach to the long-lived `claude` tmux session the entrypoint
+# starts on boot, so every connection lands in the SAME live session and
+# detaching/disconnecting leaves it running. Guarded on an interactive
+# shell ($- has i) and not-already-inside-tmux, so a non-interactive
+# `podman exec` (scripts / health probes) is never trapped. Lives in the
+# image layer (not under the /workspace bind mount that takes over $HOME),
+# and `exec`s so the tmux client becomes the login shell. `new -A` creates
+# the session if the boot-time one is somehow gone.
+RUN printf '%s\n' \
+      '# claude-dev: attach interactive logins to the persistent tmux session.' \
+      'if [ -z "${TMUX:-}" ] && [ -n "${SSH_CONNECTION:-}" ] && case "$-" in *i*) true;; *) false;; esac; then' \
+      '  exec tmux new -A -s claude' \
+      'fi' \
+      > /etc/profile.d/claude-dev-tmux.sh
 
 # Informational — the real port is set at runtime via CLAUDE_DEV_SSH_PORT.
 EXPOSE 2222

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -55,6 +55,23 @@ claude
 The clone only has to be done once — `/workspace` persists, so later
 sessions just `cd /workspace/servicebay && claude`.
 
+## Persistent session (tmux)
+
+The container boots a detached `tmux` session named **`claude`** as the
+`dev` user, and every interactive SSH login (the terminal, the mobile
+app) automatically **attaches** to it. That means a closed phone or a
+network blip no longer kills `claude`: the session keeps running on the
+box, and the next connection lands right back in it.
+
+- Re-attach manually (or from a non-login shell): `tmux new -A -s claude`
+- Detach without killing it: `Ctrl-b d` (the session stays live).
+- After a container restart, the entrypoint re-creates the session;
+  `claude --continue` resumes the prior conversation from the persisted
+  `~/.claude` on `/workspace`.
+
+A non-interactive `podman exec` (scripts, health probes) is **not**
+attached, so automation isn't trapped in tmux.
+
 ## Non-goals (first iteration)
 
 - Running the full ServiceBay test suite *inside* this container

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -42,6 +42,21 @@ if [ "$password_auth" = no ] && [ -z "${CLAUDE_DEV_SSH_AUTHORIZED_KEY:-}" ]; the
   echo "claude-dev: WARNING — no SSH password or authorized key set; nobody can log in." >&2
 fi
 
+# Start the long-lived `claude` tmux session as the dev user BEFORE we
+# exec sshd, so it's already running before anyone connects (incl. after
+# a container restart — `claude --continue` then resumes the prior
+# conversation from the persisted ~/.claude on /workspace). The tmux
+# server daemonizes, so sshd stays PID 1 — do NOT regress that. Idempotent:
+# `has-session` skips re-creating it if one somehow already exists. The
+# session runs as `dev` with /workspace as $HOME so its working dir + any
+# `claude` auth/history match an interactive login's.
+if su -s /bin/bash dev -c 'tmux has-session -t claude' 2>/dev/null; then
+  echo "claude-dev: tmux session 'claude' already running."
+else
+  su -s /bin/bash dev -c "cd '$DEV_HOME' && HOME='$DEV_HOME' tmux new-session -d -s claude"
+  echo "claude-dev: started detached tmux session 'claude' for user 'dev'."
+fi
+
 mkdir -p /run/sshd
 echo "claude-dev: starting sshd on port ${SSH_PORT}."
 exec /usr/sbin/sshd -D -e \


### PR DESCRIPTION
## What
Six-unit batch across backup-sync, the portal, and claude-dev: harden Local/USB backup targets (validate-on-Run + mount picker), recognize signed-in SSO users on /portal and render appless action-cards for URL-less services, pin backup-atom regression tests ahead of the snapshot-merge epic, and add a persistent tmux session to the claude-dev container.

## Why
Closes #1612
Closes #1606
Closes #1608
Closes #1613
Closes #1616
Closes #1618

## Risk
Medium — #1606/#1613/#1618 touch path-mandated portal/ and settings/backups areas (on-box /verify owed); the rest is test-only or template-only.

## Rollback
git revert is enough (no migrations, no version/release-manifest changes).

## Verification
- [x] npm run lint (0 errors, 339 warnings — baseline)
- [x] npm run check:arch (invariants + 726-module depcruise clean)
- [x] npm test (full — 235 files, 1872 passed, 2 skipped)
- [ ] /verify on FCoS :dev box — portal SSO chip + admin link (#1606), backup mount picker + Run/Test validation (#1613), appless action-card render (#1618)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
