### PR TITLE
fix: backup HA-OS import, proxy-host cert re-patch, snapshot config collector, terminal deep-link

### DIFF
--- a/packages/backend/src/lib/backup/mounts.test.ts
+++ b/packages/backend/src/lib/backup/mounts.test.ts
@@ -134,4 +134,43 @@ describe('parseMountCandidates', () => {
     });
     expect(parseMountCandidates(json)).toHaveLength(1);
   });
+
+  it('humanizes integer byte counts from lsblk -b (real-world JSON integers, not strings)', () => {
+    // lsblk -b returns actual JSON integers for size/fsavail, not decimal strings.
+    // Regression: looksLikeBytes missed integer sizes; trim() returned undefined for numbers.
+    const json = JSON.stringify({
+      blockdevices: [
+        {
+          name: 'nvme0n1',
+          path: '/dev/nvme0n1',
+          type: 'disk',
+          size: 2000398934016,       // integer — real lsblk -b output
+          fstype: null,
+          mountpoint: null,
+          children: [
+            {
+              name: 'md127',
+              path: '/dev/md127',
+              type: 'raid1',
+              size: 2000262594560,   // integer
+              fstype: 'xfs',
+              label: 'data',
+              mountpoint: '/var/mnt/data',
+              fsavail: 1892842528768, // integer — was always undefined before fix
+              'fsuse%': '5%',
+            },
+          ],
+        },
+      ],
+    });
+    const out = parseMountCandidates(json);
+    expect(out).toHaveLength(1);
+    const m = out[0];
+    expect(m.device).toBe('/dev/md127');
+    expect(m.mounted).toBe(true);
+    // Both size and fsAvail must be humanized from integer bytes
+    expect(m.size).toBe('1.8T');
+    expect(m.fsAvail).toBe('1.7T');
+    expect(m.fsUsedPct).toBe('5%');
+  });
 });

--- a/packages/backend/src/lib/backup/mounts.ts
+++ b/packages/backend/src/lib/backup/mounts.ts
@@ -42,16 +42,19 @@ interface RawLsblkNode {
   name?: string;
   path?: string;
   type?: string;
-  size?: string;
+  /** lsblk -b returns integers; lsblk without -b returns human strings. */
+  size?: string | number;
   fstype?: string;
   label?: string;
   mountpoint?: string | null;
-  fsavail?: string;
+  /** lsblk -b returns integers; lsblk without -b returns human strings. */
+  fsavail?: string | number | null;
   'fsuse%'?: string;
   children?: RawLsblkNode[];
 }
 
 const trim = (v: unknown): string | undefined => {
+  if (typeof v === 'number') return isFinite(v) ? String(v) : undefined;
   if (typeof v !== 'string') return undefined;
   const s = v.trim();
   return s.length > 0 ? s : undefined;
@@ -68,10 +71,12 @@ const fmtBytes = (b: number): string => {
   return `${v >= 100 || i === 0 ? Math.round(v) : v.toFixed(1)}${units[i]}`;
 };
 
-// lsblk -b returns byte counts; without -b it returns human strings.
-// Detect by sniffing whether any size leaf is a bare integer.
+// lsblk -b returns byte counts as JSON integers; without -b it returns human
+// strings. Detect by sniffing whether any size leaf is a number or a bare
+// decimal string (both indicate byte mode from -b or recent util-linux).
 const looksLikeBytes = (nodes: RawLsblkNode[]): boolean => {
   for (const n of nodes) {
+    if (typeof n.size === 'number') return true;
     if (typeof n.size === 'string' && /^\d+$/.test(n.size)) return true;
     if (n.children && looksLikeBytes(n.children)) return true;
   }

--- a/packages/backend/src/lib/backup/mounts.ts
+++ b/packages/backend/src/lib/backup/mounts.ts
@@ -83,7 +83,7 @@ const looksLikeBytes = (nodes: RawLsblkNode[]): boolean => {
   return false;
 };
 
-const maybeHuman = (raw: string | undefined, bytes: boolean): string | undefined => {
+const maybeHuman = (raw: string | number | null | undefined, bytes: boolean): string | undefined => {
   const v = trim(raw);
   if (!v) return undefined;
   if (bytes && /^\d+$/.test(v)) return fmtBytes(parseInt(v, 10));

--- a/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
@@ -300,13 +300,12 @@ describe('GOLDEN: importHaOsBackupToNas → manifest-filtered home-assistant.tar
     await write(inner, 'data/.storage/core.entity_registry', '{}');
     await write(inner, 'data/.storage/lovelace.lovelace', '{"dash":"main"}');
     await write(inner, 'data/.storage/hacs.repositories', '[]');
-    // NOTE: this fixture intentionally exercises only FILE includes. The HA
-    // manifest also includes the `custom_components` DIR, but extractHaConfigDir
-    // currently passes intermediate dir members to `tar -x` alongside their
-    // children, which GNU/libarchive tar rejects ("Not found in archive") — a
-    // latent gap tracked separately (#1620). The selective-extraction *atom
-    // shape* this PIN guards is the file-include set; the dir-include path is a
-    // pre-existing bug, not behaviour this regression test should bless.
+    // The HA manifest also includes the `custom_components` DIR (HACS installed
+    // — the common case). The inner tar lists the dir + intermediate dir members
+    // alongside the leaf files; extractHaConfigDir must pass only the leaf files
+    // to `tar -x` or GNU/libarchive tar aborts ("Not found in archive") (#1620).
+    await write(inner, 'data/custom_components/meross_lan/__init__.py', 'CODE');
+    await write(inner, 'data/custom_components/meross_lan/manifest.json', '{"domain":"meross_lan"}');
     // Heavy excluded members — must never be unpacked nor staged (#1353).
     await write(inner, 'data/home-assistant_v2.db', 'HUGE-DB');
     await write(inner, 'data/home-assistant.log', 'noise');
@@ -336,6 +335,8 @@ describe('GOLDEN: importHaOsBackupToNas → manifest-filtered home-assistant.tar
       '.storage/zwave_js',
       'automations.yaml',
       'configuration.yaml',
+      'custom_components/meross_lan/__init__.py',
+      'custom_components/meross_lan/manifest.json',
     ]);
     // The heavy excluded members never make it into the atom.
     expect(files).not.toContain('home-assistant_v2.db');

--- a/packages/backend/src/lib/externalBackup/haOsImport.ts
+++ b/packages/backend/src/lib/externalBackup/haOsImport.ts
@@ -70,10 +70,19 @@ function matchesInclude(rel: string, inc: string): boolean {
  * can find them) whose path under `data/` matches one of the manifest includes
  * — either the include itself (a file), anything beneath a dir include, or a
  * trailing-`*` glob include.
+ *
+ * Only LEAF FILE members are returned, never directory members. A tar listing
+ * of a dir include yields the directory entry (`data/custom_components/`), every
+ * intermediate dir entry, AND the leaf files; passing an intermediate dir member
+ * to `tar -x` alongside its children makes GNU/libarchive tar report the children
+ * as "Not found in archive" and exit non-zero, aborting the whole import (#1620).
+ * Extracting just the leaf files is sufficient — tar recreates the parent dirs.
  */
 function selectWantedMembers(members: string[], includes: string[]): string[] {
   const wanted: string[] = [];
   for (const member of members) {
+    // Directory members list with a trailing slash; skip them (see above).
+    if (/\/$/.test(member)) continue;
     const norm = normaliseMember(member);
     if (!norm.startsWith(DATA_PREFIX)) continue;
     const rel = norm.slice(DATA_PREFIX.length);

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -94,7 +94,7 @@ async function pathExists(target: string): Promise<boolean> {
  * targets; the resulting tar bytes are always returned to the caller (the
  * container) for upload to the NAS.
  */
-interface BackupFileBackend {
+export interface BackupFileBackend {
   /** Directory entries with their type (no recursion). */
   readdirTypes(dir: string): Promise<{ name: string; isDir: boolean; isFile: boolean }[]>;
   exists(target: string): Promise<boolean>;
@@ -150,7 +150,7 @@ const localFileBackend: BackupFileBackend = {
  * bytes cross back into the container (base64 over the agent channel, since the
  * agent's `read_file` is utf-8-only and would corrupt binary config).
  */
-function agentFileBackend(executor: Executor): BackupFileBackend {
+export function agentFileBackend(executor: Executor): BackupFileBackend {
   return {
     async readdirTypes(dir) {
       // `find -maxdepth 1` with a type tag per entry — one round-trip, and it

--- a/packages/backend/src/lib/systemBackup.serviceConfig.test.ts
+++ b/packages/backend/src/lib/systemBackup.serviceConfig.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { Executor } from './executor';
+
+const execFileAsync = promisify(execFile);
+
+const { mockManifest, mockProducer, mockGetExecutor, mockCfg } = vi.hoisted(() => ({
+    mockManifest: { SERVICE_BACKUP_MANIFESTS: [] as unknown[], getBackupGate: vi.fn() },
+    mockProducer: {
+        buildServiceBackupTar: vi.fn(),
+        agentFileBackend: vi.fn(() => ({})),
+        resolveServiceDataDir: vi.fn(),
+        runBackupCollector: vi.fn(),
+    },
+    mockGetExecutor: vi.fn(),
+    mockCfg: { getConfig: vi.fn(), updateConfig: vi.fn() },
+}));
+
+vi.mock('./externalBackup/serviceManifest', () => mockManifest);
+vi.mock('./externalBackup/producer', () => mockProducer);
+vi.mock('./executor', () => ({ getExecutor: (...a: unknown[]) => mockGetExecutor(...a) }));
+vi.mock('./config', () => mockCfg);
+
+import { stageServiceConfig, extractServiceConfigToNode } from './systemBackup';
+
+/** Build a plain tar (manifest atom format) with files at the given relative paths. */
+async function buildTar(files: Record<string, string>): Promise<Buffer> {
+    const stage = await fs.mkdtemp(path.join(os.tmpdir(), 'svc-cfg-stage-'));
+    for (const [rel, content] of Object.entries(files)) {
+        const full = path.join(stage, rel);
+        await fs.mkdir(path.dirname(full), { recursive: true });
+        await fs.writeFile(full, content);
+    }
+    const tarPath = path.join(stage, 'out.tar');
+    await execFileAsync('tar', ['-cf', tarPath, '-C', stage, '.']);
+    const buf = await fs.readFile(tarPath);
+    await fs.rm(stage, { recursive: true, force: true });
+    return buf;
+}
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sysbackup-svccfg-'));
+    mockManifest.SERVICE_BACKUP_MANIFESTS = [];
+    mockManifest.getBackupGate.mockImplementation((m: { service: string }) => m.service);
+    mockProducer.agentFileBackend.mockReturnValue({});
+    mockGetExecutor.mockReturnValue({} as Executor);
+    mockCfg.getConfig.mockResolvedValue({ installedTemplates: {} });
+});
+
+afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('stageServiceConfig', () => {
+    it('stages config for each installed manifest into service-config/<svc>/ and records metadata', async () => {
+        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { 'home-assistant': {}, nginx: {} } });
+        mockManifest.SERVICE_BACKUP_MANIFESTS = [
+            { service: 'home-assistant' },
+            { service: 'nginx' },
+        ];
+        mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
+        mockProducer.buildServiceBackupTar.mockImplementation(async (_dir: string, m: { service: string }) =>
+            buildTar({ [`${m.service}.conf`]: `cfg for ${m.service}` }),
+        );
+
+        const metadata = { version: 3, createdAt: '', nodes: [], configFiles: [] };
+        const logs: unknown[] = [];
+        const staged = await stageServiceConfig(tmpRoot, metadata as never, logs as never, undefined);
+
+        expect(staged).toBe(true);
+        // Files landed under service-config/<svc>/
+        const haFile = path.join(tmpRoot, 'service-config', 'home-assistant', 'home-assistant.conf');
+        const nginxFile = path.join(tmpRoot, 'service-config', 'nginx', 'nginx.conf');
+        await expect(fs.readFile(haFile, 'utf8')).resolves.toBe('cfg for home-assistant');
+        await expect(fs.readFile(nginxFile, 'utf8')).resolves.toBe('cfg for nginx');
+        // The per-service tmp tar is cleaned up.
+        await expect(fs.access(path.join(tmpRoot, 'service-config', 'home-assistant.tar'))).rejects.toThrow();
+        // Metadata records {label, service, sourcePath, nodeName}.
+        expect(metadata).toHaveProperty('serviceData');
+        const sd = (metadata as { serviceData: Array<{ label: string; service: string; sourcePath: string; nodeName: string }> }).serviceData;
+        expect(sd).toEqual([
+            { label: 'home-assistant', service: 'home-assistant', sourcePath: '/mnt/data/stacks/home-assistant', nodeName: 'Local' },
+            { label: 'nginx', service: 'nginx', sourcePath: '/mnt/data/stacks/nginx', nodeName: 'Local' },
+        ]);
+    });
+
+    it('skips manifests whose backup-gate template is not installed', async () => {
+        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { nginx: {} } });
+        mockManifest.SERVICE_BACKUP_MANIFESTS = [
+            { service: 'home-assistant' },
+            { service: 'nginx' },
+        ];
+        mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
+        mockProducer.buildServiceBackupTar.mockResolvedValue(await buildTar({ 'nginx.conf': 'x' }));
+
+        const metadata = { version: 3, createdAt: '', nodes: [], configFiles: [] };
+        await stageServiceConfig(tmpRoot, metadata as never, [], undefined);
+
+        const sd = (metadata as { serviceData: Array<{ service: string }> }).serviceData;
+        expect(sd.map(e => e.service)).toEqual(['nginx']);
+        expect(mockProducer.buildServiceBackupTar).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the collector when the manifest declares one', async () => {
+        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { npm: {} } });
+        const collectedManifest = { service: 'npm', collected: true };
+        mockManifest.SERVICE_BACKUP_MANIFESTS = [{ service: 'npm', collector: 'snapshot' }];
+        mockProducer.resolveServiceDataDir.mockResolvedValue('/mnt/data/stacks/npm');
+        mockProducer.runBackupCollector.mockResolvedValue(collectedManifest);
+        mockProducer.buildServiceBackupTar.mockResolvedValue(await buildTar({ 'npm.conf': 'x' }));
+
+        await stageServiceConfig(tmpRoot, { version: 3, createdAt: '', nodes: [], configFiles: [] } as never, [], undefined);
+
+        expect(mockProducer.runBackupCollector).toHaveBeenCalledWith(
+            expect.objectContaining({ service: 'npm' }),
+            'Local',
+        );
+        // The collector's effective manifest is what gets tarred.
+        expect(mockProducer.buildServiceBackupTar).toHaveBeenCalledWith('/mnt/data/stacks/npm', collectedManifest, expect.anything());
+    });
+
+    it('treats "No config files to back up" as a skip, not an error, and continues', async () => {
+        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { a: {}, b: {} } });
+        mockManifest.SERVICE_BACKUP_MANIFESTS = [{ service: 'a' }, { service: 'b' }];
+        mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
+        mockProducer.buildServiceBackupTar.mockImplementation(async (_dir: string, m: { service: string }) => {
+            if (m.service === 'a') throw new Error('No config files to back up');
+            return buildTar({ 'b.conf': 'x' });
+        });
+
+        const logs: Array<{ status: string; message: string }> = [];
+        const staged = await stageServiceConfig(tmpRoot, { version: 3, createdAt: '', nodes: [], configFiles: [] } as never, logs as never, undefined);
+
+        expect(staged).toBe(true); // b still contributed
+        expect(logs.some(l => l.status === 'skip' && /a: No config files/.test(l.message))).toBe(true);
+        expect(logs.some(l => l.status === 'error')).toBe(false);
+    });
+
+    it('logs an error (not skip) for an unexpected per-service failure and returns false when nothing staged', async () => {
+        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { a: {} } });
+        mockManifest.SERVICE_BACKUP_MANIFESTS = [{ service: 'a' }];
+        mockProducer.resolveServiceDataDir.mockResolvedValue('/mnt/data/stacks/a');
+        mockProducer.buildServiceBackupTar.mockRejectedValue(new Error('disk exploded'));
+
+        const logs: Array<{ status: string; message: string }> = [];
+        const staged = await stageServiceConfig(tmpRoot, { version: 3, createdAt: '', nodes: [], configFiles: [] } as never, logs as never, undefined);
+
+        expect(staged).toBe(false);
+        expect(logs.some(l => l.status === 'error' && /a: disk exploded/.test(l.message))).toBe(true);
+    });
+});
+
+describe('extractServiceConfigToNode', () => {
+    /** A fake host executor backed by a real temp dir, so the host-side
+     *  base64/tar/find/readlink commands operate on actual files. */
+    function fakeHostExecutor(hostRoot: string): Executor {
+        const files = new Map<string, string>();
+        const exec: Partial<Executor> = {
+            writeFile: vi.fn(async (p: string, content: string) => { files.set(p, content); }),
+            execArgv: vi.fn(async (argv: string[]) => {
+                const [cmd, ...rest] = argv;
+                if (cmd === 'mktemp') {
+                    const f = path.join(hostRoot, `mktemp-${Math.random().toString(36).slice(2)}`);
+                    return { stdout: f + '\n', stderr: '' };
+                }
+                if (cmd === 'sh' && rest[0] === '-c') {
+                    // argv: ['sh','-c',<script>,'sh',<b64path>,<tarpath>]
+                    // → rest = ['-c',<script>,'sh',<b64path>,<tarpath>]
+                    const b64Path = rest[3];
+                    const outPath = rest[4];
+                    const b64 = files.get(b64Path) ?? '';
+                    await fs.writeFile(outPath, Buffer.from(b64, 'base64'));
+                    return { stdout: '', stderr: '' };
+                }
+                if (cmd === 'mkdir') {
+                    await fs.mkdir(rest[rest.length - 1], { recursive: true });
+                    return { stdout: '', stderr: '' };
+                }
+                if (cmd === 'tar') {
+                    // tar -xf <hostTar> -C <destDir> ...
+                    const fIdx = argv.indexOf('-xf');
+                    const cIdx = argv.indexOf('-C');
+                    await execFileAsync('tar', ['-xf', argv[fIdx + 1], '-C', argv[cIdx + 1], '--no-same-owner']);
+                    return { stdout: '', stderr: '' };
+                }
+                if (cmd === 'readlink') {
+                    const target = rest[rest.length - 1];
+                    const resolved = await fs.realpath(target).catch(() => target);
+                    return { stdout: resolved + '\n', stderr: '' };
+                }
+                if (cmd === 'find') {
+                    // find <dir> -type l
+                    const dir = rest[0];
+                    const out: string[] = [];
+                    const walk = async (d: string): Promise<void> => {
+                        for (const ent of await fs.readdir(d, { withFileTypes: true })) {
+                            const full = path.join(d, ent.name);
+                            if (ent.isSymbolicLink()) out.push(full);
+                            else if (ent.isDirectory()) await walk(full);
+                        }
+                    };
+                    await walk(dir).catch(() => {});
+                    return { stdout: out.join('\n') + '\n', stderr: '' };
+                }
+                if (cmd === 'rm') {
+                    for (const a of rest) {
+                        if (a.startsWith('/')) await fs.rm(a, { recursive: true, force: true }).catch(() => {});
+                    }
+                    return { stdout: '', stderr: '' };
+                }
+                return { stdout: '', stderr: '' };
+            }),
+        };
+        return exec as Executor;
+    }
+
+    it('extracts a plain config tar onto the node host dir via the agent', async () => {
+        const hostRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'svc-host-'));
+        const destDir = path.join(hostRoot, 'stacks', 'home-assistant');
+        const tar = await buildTar({ 'configuration.yaml': 'default_config:', '.storage/x': 'secret' });
+
+        await extractServiceConfigToNode(fakeHostExecutor(hostRoot), tar, destDir);
+
+        await expect(fs.readFile(path.join(destDir, 'configuration.yaml'), 'utf8')).resolves.toBe('default_config:');
+        await expect(fs.readFile(path.join(destDir, '.storage', 'x'), 'utf8')).resolves.toBe('secret');
+        await fs.rm(hostRoot, { recursive: true, force: true });
+    });
+
+    it('refuses an archive with a traversal entry before touching the host', async () => {
+        // Hand-build a tar carrying a `../escape` member.
+        const stage = await fs.mkdtemp(path.join(os.tmpdir(), 'evil-stage-'));
+        await fs.mkdir(path.join(stage, 'sub'), { recursive: true });
+        await fs.writeFile(path.join(stage, 'sub', 'escape'), 'x');
+        const tarPath = path.join(stage, 'evil.tar');
+        // Add the file under a ../-prefixed name.
+        await execFileAsync('tar', ['-cf', tarPath, '-C', path.join(stage, 'sub'), '--transform', 's,^,../,', 'escape']);
+        const tar = await fs.readFile(tarPath);
+        await fs.rm(stage, { recursive: true, force: true });
+
+        const hostRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'svc-host-'));
+        const exec = fakeHostExecutor(hostRoot);
+        await expect(
+            extractServiceConfigToNode(exec, tar, path.join(hostRoot, 'dest')),
+        ).rejects.toThrow(/traversal/i);
+        // Pre-pass refused before any host write happened.
+        expect(exec.writeFile).not.toHaveBeenCalled();
+        await fs.rm(hostRoot, { recursive: true, force: true });
+    });
+});

--- a/packages/backend/src/lib/systemBackup.serviceConfig.test.ts
+++ b/packages/backend/src/lib/systemBackup.serviceConfig.test.ts
@@ -42,6 +42,12 @@ async function buildTar(files: Record<string, string>): Promise<Buffer> {
     return buf;
 }
 
+interface SvcDataEntry { label: string; service: string; sourcePath: string; nodeName: string }
+/** A BackupMetadata-shaped object whose serviceData is the new typed-entry form. */
+function makeMeta(): { version: number; createdAt: string; nodes: never[]; configFiles: never[]; serviceData: SvcDataEntry[] } {
+    return { version: 3, createdAt: '', nodes: [], configFiles: [], serviceData: [] };
+}
+
 let tmpRoot: string;
 
 beforeEach(async () => {
@@ -70,7 +76,7 @@ describe('stageServiceConfig', () => {
             buildTar({ [`${m.service}.conf`]: `cfg for ${m.service}` }),
         );
 
-        const metadata = { version: 3, createdAt: '', nodes: [], configFiles: [] };
+        const metadata = makeMeta();
         const logs: unknown[] = [];
         const staged = await stageServiceConfig(tmpRoot, metadata as never, logs as never, undefined);
 
@@ -83,8 +89,7 @@ describe('stageServiceConfig', () => {
         // The per-service tmp tar is cleaned up.
         await expect(fs.access(path.join(tmpRoot, 'service-config', 'home-assistant.tar'))).rejects.toThrow();
         // Metadata records {label, service, sourcePath, nodeName}.
-        expect(metadata).toHaveProperty('serviceData');
-        const sd = (metadata as { serviceData: Array<{ label: string; service: string; sourcePath: string; nodeName: string }> }).serviceData;
+        const sd = metadata.serviceData;
         expect(sd).toEqual([
             { label: 'home-assistant', service: 'home-assistant', sourcePath: '/mnt/data/stacks/home-assistant', nodeName: 'Local' },
             { label: 'nginx', service: 'nginx', sourcePath: '/mnt/data/stacks/nginx', nodeName: 'Local' },
@@ -100,10 +105,10 @@ describe('stageServiceConfig', () => {
         mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
         mockProducer.buildServiceBackupTar.mockResolvedValue(await buildTar({ 'nginx.conf': 'x' }));
 
-        const metadata = { version: 3, createdAt: '', nodes: [], configFiles: [] };
+        const metadata = makeMeta();
         await stageServiceConfig(tmpRoot, metadata as never, [], undefined);
 
-        const sd = (metadata as { serviceData: Array<{ service: string }> }).serviceData;
+        const sd = metadata.serviceData;
         expect(sd.map(e => e.service)).toEqual(['nginx']);
         expect(mockProducer.buildServiceBackupTar).toHaveBeenCalledTimes(1);
     });

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -396,7 +396,7 @@ export async function safeTarExtract(
  * with the same hardening flags `safeTarExtract` uses, followed by a host-side
  * symlink-escape walk.
  */
-async function extractServiceConfigToNode(executor: Executor, tar: Buffer, destDir: string): Promise<void> {
+export async function extractServiceConfigToNode(executor: Executor, tar: Buffer, destDir: string): Promise<void> {
     // In-container traversal/link refusal on the raw tar bytes before anything
     // touches the host.
     const tmp = path.join(os.tmpdir(), `sb-svcconfig-${Date.now()}-${process.pid}.tar`);
@@ -458,7 +458,7 @@ function pushLog(logs: BackupLogEntry[], progress: ProgressCallback | undefined,
  * use. Per-service failures are logged and skipped — one bad service doesn't
  * abort the snapshot.
  */
-async function stageServiceConfig(
+export async function stageServiceConfig(
     stagingDir: string,
     metadata: BackupMetadata,
     logs: BackupLogEntry[],

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -18,6 +18,7 @@ import { listNodes, PodmanConnection } from './nodes';
 import { SSHConnectionPool } from './ssh/pool';
 import { getConfig, updateConfig } from './config';
 import { shellQuote } from './util/shellQuote';
+import type { Executor } from './executor';
 
 const execFileAsync = promisify(execFile);
 const BACKUP_PREFIX = 'servicebay-full';
@@ -155,9 +156,16 @@ interface BackupNodeDescriptor {
 }
 
 interface ServiceDataEntry {
+    /** The on-disk subdir under `service-config/` in the archive — the manifest
+     *  `service` name (e.g. `home-assistant`, `nginx`). Kept named `label` for
+     *  metadata back-compat with v2 backups. */
     label: string;
+    /** Resolved service data dir the config was read from / restores back to. */
     sourcePath: string;
     nodeName: string;
+    /** Manifest `service` name — resolves the restore target dir per node via
+     *  the per-service producer. Absent on legacy (proxy hostPath) backups. */
+    service?: string;
 }
 
 interface BackupMetadata {
@@ -377,6 +385,55 @@ export async function safeTarExtract(
     }
 }
 
+/**
+ * Extract a per-service config tar into `destDir` on a target node's HOST
+ * filesystem via the node agent (#1597/#1600). The services' data dirs
+ * (`/mnt/data/stacks/<svc>`) are NOT bind-mounted into the servicebay
+ * container, so the box restore must go through the agent — mirroring the
+ * unified restore engine's `agentRestoreBackend`. The traversal/link pre-pass
+ * runs in-container on the tar bytes (the primary defence), then the tar is
+ * pushed host-side (base64 over the agent's utf-8-only write) and extracted
+ * with the same hardening flags `safeTarExtract` uses, followed by a host-side
+ * symlink-escape walk.
+ */
+async function extractServiceConfigToNode(executor: Executor, tar: Buffer, destDir: string): Promise<void> {
+    // In-container traversal/link refusal on the raw tar bytes before anything
+    // touches the host.
+    const tmp = path.join(os.tmpdir(), `sb-svcconfig-${Date.now()}-${process.pid}.tar`);
+    try {
+        await fs.writeFile(tmp, tar);
+        await assertSafeArchiveEntries(tmp, false);
+    } finally {
+        await fs.rm(tmp, { force: true });
+    }
+    const { stdout } = await executor.execArgv(['mktemp', '-t', 'sb-svcconfig-XXXXXX']);
+    const hostTar = stdout.trim();
+    const hostTarB64 = `${hostTar}.b64`;
+    try {
+        await executor.writeFile(hostTarB64, tar.toString('base64'));
+        await executor.execArgv(['sh', '-c', 'base64 -d "$1" > "$2"', 'sh', hostTarB64, hostTar], { timeoutMs: 120_000 });
+        await executor.execArgv(['mkdir', '-p', destDir]);
+        await executor.execArgv(
+            ['tar', '-xf', hostTar, '-C', destDir, '--no-same-owner', '--no-overwrite-dir', '--no-same-permissions'],
+            { timeoutMs: 120_000 },
+        );
+        // Host-side symlink-escape walk (defense in depth): refuse any symlink
+        // that resolves outside destDir, cleaning up on refusal.
+        const realRoot = (await executor.execArgv(['readlink', '-f', destDir])).stdout.trim();
+        const links = (await executor.execArgv(['find', destDir, '-type', 'l'])).stdout
+            .split('\n').map(l => l.trim()).filter(Boolean);
+        for (const link of links) {
+            const resolved = (await executor.execArgv(['readlink', '-f', link]).catch(() => ({ stdout: '' }))).stdout.trim();
+            if (!resolved || (resolved !== realRoot && !resolved.startsWith(realRoot + '/'))) {
+                await executor.execArgv(['rm', '-rf', destDir]).catch(() => {});
+                throw new Error(`Refused archive: symlink "${link}" → "${resolved}" escapes the extraction directory`);
+            }
+        }
+    } finally {
+        await executor.execArgv(['rm', '-f', hostTarB64, hostTar]).catch(() => {});
+    }
+}
+
 function pushLog(logs: BackupLogEntry[], progress: ProgressCallback | undefined, entry: Omit<BackupLogEntry, 'timestamp'>) {
     const payload: BackupLogEntry = {
         ...entry,
@@ -384,6 +441,85 @@ function pushLog(logs: BackupLogEntry[], progress: ProgressCallback | undefined,
     };
     logs.push(payload);
     progress?.(payload);
+}
+
+/**
+ * Stage every installed service's CONFIG (not bulk DATA) into the archive's
+ * `service-config/<svc>/` tree, reusing the per-service producer so the bytes
+ * are identical to the NAS atom (epic #1607/#1608 — the same include/exclude/
+ * glob/strip/transform/collector spec, run host-side via the node agent).
+ *
+ * Replaces the old nginx-only `isProxy` hostPath loop: nginx is now just another
+ * manifest atom. Returns true if at least one service contributed config.
+ *
+ * Services run on the box ServiceBay itself manages (the Local node), and
+ * `installedTemplates` is global config; we resolve each service's data dir and
+ * read it through the host agent (#1597), the same path install/restore/deploy
+ * use. Per-service failures are logged and skipped — one bad service doesn't
+ * abort the snapshot.
+ */
+async function stageServiceConfig(
+    stagingDir: string,
+    metadata: BackupMetadata,
+    logs: BackupLogEntry[],
+    progress: ProgressCallback | undefined,
+): Promise<boolean> {
+    const serviceConfigRoot = path.join(stagingDir, 'service-config');
+    metadata.serviceData = [];
+
+    const { SERVICE_BACKUP_MANIFESTS, getBackupGate } = await import('./externalBackup/serviceManifest');
+    const { buildServiceBackupTar, agentFileBackend, resolveServiceDataDir, runBackupCollector } = await import('./externalBackup/producer');
+    const { getExecutor } = await import('./executor');
+
+    const installed = new Set(Object.keys((await getConfig()).installedTemplates ?? {}));
+    const nodeName = 'Local';
+    const backend = agentFileBackend(getExecutor(nodeName));
+    let stagedAny = false;
+
+    for (const manifest of SERVICE_BACKUP_MANIFESTS) {
+        // Sibling-store entries (#1594) gate on their parent template, not their
+        // own synthetic service name.
+        if (!installed.has(getBackupGate(manifest))) continue;
+        const svc = manifest.service;
+        try {
+            const serviceDataDir = await resolveServiceDataDir(svc);
+            // The producer runs any in-container collector (NPM's consistent
+            // sqlite snapshot) itself when given an agent backend + node — but
+            // buildServiceBackupTar takes a resolved manifest, so we mirror
+            // backupServiceToNas's collector step.
+            const effective = manifest.collector
+                ? await runBackupCollector(manifest, nodeName)
+                : manifest;
+            const tar = await buildServiceBackupTar(serviceDataDir, effective, backend);
+
+            const destDir = path.join(serviceConfigRoot, svc);
+            await fs.mkdir(destDir, { recursive: true });
+            const tmpTar = path.join(serviceConfigRoot, `${svc}.tar`);
+            await fs.writeFile(tmpTar, tar);
+            // The producer builds a SAFE-by-construction plain tar from a staging
+            // dir it controls; safeTarExtract (gzip:false) still applies the
+            // standard restore-side hardening as belt-and-suspenders.
+            await safeTarExtract(tmpTar, destDir, { gzip: false });
+            await fs.rm(tmpTar, { force: true });
+
+            (metadata.serviceData as ServiceDataEntry[]).push({
+                label: svc,
+                service: svc,
+                sourcePath: serviceDataDir,
+                nodeName,
+            });
+            stagedAny = true;
+            pushLog(logs, progress, { scope: 'local', status: 'success', node: nodeName, message: `Captured config for ${svc}` });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            // "No config files to back up" just means the service has no
+            // on-disk config yet — a skip, not an error.
+            const status: BackupLogStatus = /No config files to back up/.test(message) ? 'skip' : 'error';
+            pushLog(logs, progress, { scope: 'local', status, node: nodeName, message: `${svc}: ${message}` });
+        }
+    }
+
+    return stagedAny;
 }
 
 async function copyFileIfExists(source: string, destination: string): Promise<boolean> {
@@ -744,117 +880,17 @@ export async function createSystemBackup(progress?: ProgressCallback): Promise<S
             }
         }
 
-        // Stage reverse-proxy bind mounts (nginx config, SSL, etc.) from Digital Twin
-        const serviceDataDir = path.join(stagingDir, 'service-data');
-        metadata.serviceData = [];
-
-        const { getNodeTwin, getProxyState } = await import('./store/repository');
-        const { default: yamlLib } = await import('js-yaml');
-        const allNodes = await listNodes();
-        const sshNodes = allNodes.filter(node => node.URI?.startsWith('ssh://'));
-
-        for (const node of sshNodes) {
-            const twin = getNodeTwin(node.Name);
-            if (!twin) continue;
-
-            // Parse hostPath volumes from reverse-proxy YAML files in twin.files
-            const proxyMounts: { source: string; label: string }[] = [];
-            const proxyState = getProxyState();
-
-            for (const [filePath, file] of Object.entries(twin.files || {})) {
-                if (!filePath.endsWith('.yml') && !filePath.endsWith('.yaml')) continue;
-                if (!file.content) continue;
-
-                try {
-                    const docs = yamlLib.loadAll(file.content) as Record<string, unknown>[];
-                    for (const doc of docs) {
-                        if (!doc?.spec) continue;
-                        const spec = doc.spec as Record<string, unknown>;
-                        const metadata = doc.metadata as Record<string, unknown> | undefined;
-                        const labels = (metadata?.labels || {}) as Record<string, string>;
-                        const podName = (metadata?.name || '') as string;
-
-                        // Check if this is a reverse-proxy pod
-                        const isProxy = labels['servicebay.role'] === 'reverse-proxy'
-                            || /nginx|proxy/i.test(podName)
-                            || (proxyState?.provider === 'nginx' && /nginx/i.test(podName));
-                        if (!isProxy) continue;
-
-                        // Extract hostPath volumes
-                        const volumes = (spec.volumes || []) as Array<Record<string, unknown>>;
-                        const containers = (spec.containers || []) as Array<Record<string, unknown>>;
-                        const mountMap = new Map<string, string>();
-                        for (const ct of containers) {
-                            for (const vm of (ct.volumeMounts || []) as Array<Record<string, string>>) {
-                                if (vm.name && vm.mountPath) mountMap.set(vm.name, vm.mountPath);
-                            }
-                        }
-
-                        for (const vol of volumes) {
-                            const hp = vol.hostPath as Record<string, string> | undefined;
-                            if (!hp?.path) continue;
-                            const volName = vol.name as string;
-                            const containerDest = mountMap.get(volName) || volName;
-                            const label = containerDest.replace(/^\//, '').replace(/\//g, '-');
-                            proxyMounts.push({ source: hp.path, label });
-                        }
-                    }
-                } catch {
-                    // skip unparseable files
-                }
-            }
-
-            if (proxyMounts.length === 0) {
-                pushLog(logs, progress, { scope: 'remote', status: 'skip', node: node.Name, message: 'No reverse-proxy hostPath volumes found in YAML files' });
-                continue;
-            }
-
-            pushLog(logs, progress, { scope: 'remote', status: 'info', node: node.Name, message: `Found ${proxyMounts.length} proxy volume(s): ${proxyMounts.map(m => m.source).join(', ')}` });
-
-            const conn = await SSHConnectionPool.getInstance().getConnection(node.Name);
-            for (const mount of proxyMounts) {
-                // mount.source comes from parsed Quadlet YAML on the remote
-                // node. shellQuote it before any shell-template insertion —
-                // a Volume= entry with shell-metas would otherwise inject.
-                const quotedSource = shellQuote(mount.source);
-                const checkResult = await execRemoteCommand(conn, `test -d ${quotedSource} && ls -A ${quotedSource} 2>/dev/null | head -1`);
-                if (checkResult.code !== 0 || !checkResult.stdout.trim()) {
-                    pushLog(logs, progress, { scope: 'remote', status: 'skip', node: node.Name, message: `${mount.source} is empty` });
-                    continue;
-                }
-
-                const dirName = mount.label;
-                const localDir = path.join(serviceDataDir, dirName);
-                await fs.mkdir(localDir, { recursive: true });
-
-                const tmpArchive = path.join(localDir, 'data.tgz');
-                const script = [
-                    'set -e',
-                    `tmpfile=$(mktemp /tmp/servicebay-svcdata-XXXXXX.tar.gz)`,
-                    `tar -czf "$tmpfile" -C ${quotedSource} .`,
-                    `echo "$tmpfile"`
-                ].join('\n');
-                const archiveResult = await execRemoteCommand(conn, script);
-                if (archiveResult.code !== 0) continue;
-                const remoteTmp = archiveResult.stdout.trim().split('\n').pop();
-                if (!remoteTmp) continue;
-
-                await downloadRemoteFile(conn, remoteTmp, tmpArchive);
-                await execRemoteCommand(conn, `rm -f ${shellQuote(remoteTmp)}`);
-                await safeTarExtract(tmpArchive, localDir);
-                await fs.rm(tmpArchive, { force: true });
-
-                const existing = (metadata.serviceData as ServiceDataEntry[]).find(e => e.label === dirName);
-                if (!existing) {
-                    (metadata.serviceData as ServiceDataEntry[]).push({
-                        label: dirName,
-                        sourcePath: mount.source,
-                        nodeName: node.Name
-                    });
-                }
-                stagedSomething = true;
-                pushLog(logs, progress, { scope: 'remote', status: 'success', node: node.Name, message: `Captured ${mount.source} (${dirName})` });
-            }
+        // Stage per-service CONFIG (not bulk data) from every installed service
+        // that has a backup manifest — HA `.storage`/automations/zwave keys,
+        // adguard, authelia, syncthing, hermes, and nginx (just another atom).
+        // This reuses the per-service producer (`stageServiceBackup` via the
+        // host-agent backend, #1597) so the Snapshot's service-config section is
+        // byte-identical to the NAS atom (epic invariant #1607/#1608). It
+        // retires the old nginx-only `isProxy` hostPath loop. Bulk DATA-class
+        // paths (Immich library, recorder DB, vectordb, zwave mesh db) stay
+        // excluded — those are Backup Sync's job.
+        if (await stageServiceConfig(stagingDir, metadata, logs, progress)) {
+            stagedSomething = true;
         }
 
         if (!stagedSomething) {
@@ -1001,20 +1037,25 @@ export async function previewSystemBackup(archivePath: string): Promise<BackupPr
             }
         }
 
-        // Preview service-data (nginx config etc.)
-        const serviceDataDir = path.join(stagingDir, 'service-data');
+        // Preview per-service config (HA `.storage`/automations/zwave keys,
+        // adguard, authelia, syncthing, hermes, nginx). Falls back to the legacy
+        // `service-data/` dir name so a v2 backup still previews.
+        let serviceConfigDir = path.join(stagingDir, 'service-config');
+        if (!(await pathExists(serviceConfigDir))) {
+            serviceConfigDir = path.join(stagingDir, 'service-data');
+        }
         const serviceData: BackupPreviewServiceData[] = [];
-        if (await pathExists(serviceDataDir)) {
+        if (await pathExists(serviceConfigDir)) {
             const backupMeta = await readMetadata(stagingDir);
             const sdEntries = backupMeta?.serviceData;
             const sdMeta = (sdEntries && sdEntries.length > 0 && typeof sdEntries[0] === 'object')
                 ? sdEntries as ServiceDataEntry[]
                 : undefined;
 
-            const dataDirs = await fs.readdir(serviceDataDir, { withFileTypes: true });
+            const dataDirs = await fs.readdir(serviceConfigDir, { withFileTypes: true });
             for (const dirent of dataDirs) {
                 if (!dirent.isDirectory()) continue;
-                const dirPath = path.join(serviceDataDir, dirent.name);
+                const dirPath = path.join(serviceConfigDir, dirent.name);
                 const files = await listFilesRecursive(dirPath);
                 const metaEntry = sdMeta?.find(e => e.label === dirent.name);
                 serviceData.push({
@@ -1184,11 +1225,19 @@ export async function restoreSystemBackupSelection(archivePath: string, selectio
             }
         }
 
-        // Restore service-data (nginx config etc.) to original host paths
+        // Restore per-service config to each service's resolved data dir. The
+        // staged layout is `service-config/<svc>/` (legacy backups: `service-data/`),
+        // and the per-service producer's manifest defines the target dir, so the
+        // restore writes config back where the live service reads it (#1597) via
+        // the host agent — the same hardened path the unified restore engine uses.
         if (selection.serviceData?.length) {
             const backupMetadata = await readMetadata(stagingDir);
-            const serviceDataDir = path.join(stagingDir, 'service-data');
-            const sshNodes2 = (await listNodes()).filter(n => n.URI?.startsWith('ssh://'));
+            let serviceConfigDir = path.join(stagingDir, 'service-config');
+            if (!(await pathExists(serviceConfigDir))) {
+                serviceConfigDir = path.join(stagingDir, 'service-data');
+            }
+            const { resolveServiceDataDir } = await import('./externalBackup/producer');
+            const { getExecutor } = await import('./executor');
 
             // Normalize selection: support both string[] (all files) and ServiceDataSelection[]
             const normalizedSelections: ServiceDataSelection[] = selection.serviceData.map(item =>
@@ -1197,32 +1246,35 @@ export async function restoreSystemBackupSelection(archivePath: string, selectio
 
             for (const sdSelection of normalizedSelections) {
                 const dirName = sdSelection.name;
-                const localDir = path.join(serviceDataDir, dirName);
+                const localDir = path.join(serviceConfigDir, dirName);
                 if (!(await pathExists(localDir))) continue;
 
-                // Resolve target path from metadata (v2+) or fall back to current twin mounts
-                let remotePath: string | undefined;
-                let targetNodeName: string | undefined;
+                // Resolve the target data dir + node from metadata (manifest-driven
+                // v2+), falling back to re-resolving the service's data dir.
+                let targetPath: string | undefined;
+                let targetNodeName = 'Local';
+                let serviceName = dirName;
 
                 const sdEntries = backupMetadata?.serviceData;
                 if (sdEntries && sdEntries.length > 0 && typeof sdEntries[0] === 'object') {
                     const entry = (sdEntries as ServiceDataEntry[]).find(e => e.label === dirName);
                     if (entry) {
-                        remotePath = entry.sourcePath;
-                        targetNodeName = entry.nodeName;
+                        targetPath = entry.sourcePath;
+                        targetNodeName = entry.nodeName || 'Local';
+                        serviceName = entry.service || dirName;
+                    }
+                }
+                if (!targetPath) {
+                    // No metadata (legacy/missing) — re-resolve from the manifest.
+                    try {
+                        targetPath = await resolveServiceDataDir(serviceName);
+                    } catch {
+                        logger.warn('SystemBackup', `No target path for service-config "${dirName}", skipping`);
+                        continue;
                     }
                 }
 
-                const targetNodes = targetNodeName
-                    ? sshNodes2.filter(n => n.Name === targetNodeName)
-                    : sshNodes2;
-
-                if (!remotePath) {
-                    logger.warn('SystemBackup', `No source path found for service-data "${dirName}", skipping`);
-                    continue;
-                }
-
-                // If specific files requested, create a filtered staging directory
+                // If specific files requested, create a filtered staging directory.
                 let archiveSourceDir = localDir;
                 let filteredDir: string | undefined;
                 if (sdSelection.files && sdSelection.files.length > 0) {
@@ -1240,47 +1292,19 @@ export async function restoreSystemBackupSelection(archivePath: string, selectio
                 }
 
                 try {
-                    for (const node of targetNodes) {
-                        const conn = await SSHConnectionPool.getInstance().getConnection(node.Name);
-                        const tmpArchive = path.join(os.tmpdir(), `servicebay-svcdata-${Date.now()}.tar.gz`);
-                        await runTar(['-czf', tmpArchive, '-C', archiveSourceDir, '.']);
-                        const mktemp = await execRemoteCommand(conn, 'mktemp /tmp/servicebay-svcdata-XXXXXX.tar.gz');
-                        if (mktemp.code !== 0) {
-                            await fs.rm(tmpArchive, { force: true });
-                            continue;
-                        }
-                        const remoteTmp = mktemp.stdout.trim();
-                        await uploadRemoteFile(conn, tmpArchive, remoteTmp);
+                    // Tar the staged config (plain tar — the producer's atom format)
+                    // and extract it host-side via the node agent with the same
+                    // hardened guards (#580/#590) the restore engine applies.
+                    const tmpArchive = path.join(os.tmpdir(), `servicebay-svcconfig-${Date.now()}.tar`);
+                    try {
+                        await runTar(['-cf', tmpArchive, '-C', archiveSourceDir, '.']);
+                        const tarBytes = await fs.readFile(tmpArchive);
+                        await extractServiceConfigToNode(getExecutor(targetNodeName), tarBytes, targetPath);
+                    } finally {
                         await fs.rm(tmpArchive, { force: true });
-                        // Same SSH-side hardening as restoreRemoteSystemd (#580):
-                        // refuse abs/traversal entries first, then extract
-                        // with no-overwrite-dir + no-absolute-names + no-
-                        // same-owner. Service-data restores are the
-                        // highest-risk extract path because they unpack into
-                        // operator-controlled `remotePath` mounts.
-                        // Same SSH-side guard as restoreRemoteSystemd
-                        // (#580 + #590): refuse links, abs paths, traversal.
-                        // remotePath comes from the backup metadata (entry.sourcePath)
-                        // and is user-controlled at restore time — a malicious backup
-                        // could carry a sourcePath like `"$(curl evil…)"` which would
-                        // execute via command substitution even inside double quotes.
-                        // shellQuote forces it through single-quotes (no expansion at all).
-                        const remoteSvcScript = [
-                            'set -e',
-                            `tmp=${shellQuote(remoteTmp)}`,
-                            `target=${shellQuote(remotePath)}`,
-                            `tar -tvzf "$tmp" | awk '/^[lh]/ { print "Refused archive: contains link entry: " $NF > "/dev/stderr"; exit 2 } { for (i=6; i<=NF; i++) name = (i==6 ? $i : name " " $i); if (name ~ /^\\// || name ~ /(^|\\/)\\.\\.($|\\/)/) { print "Refused archive: contains abs/traversal entry: " name > "/dev/stderr"; exit 2 } }'`,
-                            'mkdir -p "$target"',
-                            'tar -xzf "$tmp" -C "$target" --no-same-owner --no-overwrite-dir --no-same-permissions',
-                            'rm -f "$tmp"',
-                        ].join('\n');
-                        const svcExtract = await execRemoteCommand(conn, remoteSvcScript);
-                        if (svcExtract.code !== 0) {
-                            throw new Error(svcExtract.stderr || `Failed to restore ${dirName} on ${node.Name}`);
-                        }
-                        const fileDesc = sdSelection.files ? `${sdSelection.files.length} files from ${dirName}` : dirName;
-                        logger.info('SystemBackup', `Restored ${fileDesc} to ${node.Name}:${remotePath}`);
                     }
+                    const fileDesc = sdSelection.files ? `${sdSelection.files.length} files from ${dirName}` : dirName;
+                    logger.info('SystemBackup', `Restored ${fileDesc} to ${targetNodeName}:${targetPath}`);
                 } finally {
                     if (filteredDir) await fs.rm(filteredDir, { recursive: true, force: true });
                 }

--- a/packages/backend/src/lib/terminal/sessionManager.test.ts
+++ b/packages/backend/src/lib/terminal/sessionManager.test.ts
@@ -19,7 +19,7 @@ vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
 
-import { resolvePtySpec } from './sessionManager';
+import { resolvePtySpec, buildContainerInnerCmd } from './sessionManager';
 
 beforeEach(() => {
   state.nodes = [];
@@ -87,5 +87,58 @@ describe('resolvePtySpec — container terminals', () => {
 
   it('throws when the container id is empty', async () => {
     await expect(resolvePtySpec('container:local:')).rejects.toThrow(/Invalid container ID/);
+  });
+
+  it('attaches to a named tmux session when an attach= segment is present (SSH path)', async () => {
+    state.nodes = [{ Name: 'Local', URI: 'ssh://core@127.0.0.1', Identity: '/k' }];
+
+    const spec = await resolvePtySpec('container:Local:claude-dev:attach=claude');
+
+    expect(spec.shell).toBe('ssh');
+    const remoteCmd = spec.args[spec.args.length - 1];
+    expect(remoteCmd).toContain('podman exec -it');
+    expect(remoteCmd).toContain('claude-dev');
+    expect(remoteCmd).toContain('tmux new -A -s claude');
+    expect(remoteCmd).toContain('command -v tmux');
+  });
+
+  it('attaches to a named session on the direct-podman (bare-metal) path too', async () => {
+    state.nodes = []; // bare-metal
+
+    const spec = await resolvePtySpec('container:Local:dev:attach=claude');
+
+    expect(spec.shell).toBe('podman');
+    const inner = spec.args[spec.args.length - 1];
+    expect(inner).toContain('tmux new -A -s claude');
+  });
+
+  it('parses the container id correctly even with a trailing attach= segment', async () => {
+    state.nodes = [];
+
+    const spec = await resolvePtySpec('container:Local:my-ctr:attach=sess');
+
+    // The attach segment must NOT be mistaken for the container id.
+    expect(spec.args).toContain('my-ctr');
+    expect(spec.args).not.toContain('attach=sess');
+  });
+
+  it('rejects an attach session name with shell metacharacters', async () => {
+    await expect(resolvePtySpec("container:Local:dev:attach=foo;rm -rf /"))
+      .rejects.toThrow(/Invalid attach session name/);
+  });
+});
+
+describe('buildContainerInnerCmd', () => {
+  it('returns a bare bash-or-sh shell when no session is requested', () => {
+    const cmd = buildContainerInnerCmd();
+    expect(cmd).toContain('/bin/bash');
+    expect(cmd).not.toContain('tmux');
+  });
+
+  it('attaches to the named session, falling back to a shell when tmux is absent', () => {
+    const cmd = buildContainerInnerCmd('claude');
+    expect(cmd).toContain('command -v tmux');
+    expect(cmd).toContain('exec tmux new -A -s claude');
+    expect(cmd).toContain('/bin/bash'); // fallback branch
   });
 });

--- a/packages/backend/src/lib/terminal/sessionManager.ts
+++ b/packages/backend/src/lib/terminal/sessionManager.ts
@@ -192,16 +192,53 @@ function resolveHomeDir(): string {
   }
 }
 
+/** Bare shell launched inside a container when no session attach is requested. */
+const BARE_SHELL_CMD = 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi';
+
+/**
+ * The command run inside `podman exec ... sh -c '<cmd>'`.
+ *
+ * With no `attachSession`, opens a plain login shell (bash-or-sh dance). With
+ * one, attaches to (or creates) the named tmux session via `tmux new -A -s
+ * <session>` so the deep-link drops onto the persistent session. If `tmux`
+ * isn't on PATH in that container we fall back to a bare shell rather than
+ * erroring — the deep-link still gives a usable terminal. The session name is
+ * pre-validated by the caller, so it's safe to interpolate.
+ */
+export function buildContainerInnerCmd(attachSession?: string): string {
+  if (!attachSession) return BARE_SHELL_CMD;
+  return `if command -v tmux >/dev/null 2>&1; then exec tmux new -A -s ${attachSession}; else ${BARE_SHELL_CMD}; fi`;
+}
+
 export async function resolvePtySpec(id: string): Promise<PtySpec> {
   const defaultShell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || 'bash');
 
   if (id.startsWith('container:')) {
+    // Session-target grammar:
+    //   container:<node>:<id>                  → bare shell in the container
+    //   container:<node>:<id>:attach=<session> → attach to a named tmux session
+    //   container:<id>                         → legacy 2-part form, node = local
+    // The optional trailing `attach=<session>` segment lets a deep-link drop
+    // the operator straight onto a persistent session (e.g. claude-dev's
+    // `tmux new -A -s claude`) instead of a fresh shell. It is generalised:
+    // the session name is supplied by the caller, never hard-coded.
     const parts = id.split(':');
+    let attachSession: string | undefined;
+    if (parts[parts.length - 1]?.startsWith('attach=')) {
+      attachSession = parts.pop()!.slice('attach='.length) || undefined;
+    }
     const nodeName = parts.length === 3 ? parts[1] : 'local';
     const containerId = parts.length === 3 ? parts[2] : parts[1];
     if (!containerId) {
       throw new Error('Invalid container ID');
     }
+    // Guard the session name so it can't break out of the single-quoted
+    // remote command / `sh -c` argument below (it's interpolated into a
+    // shell string for the SSH path).
+    if (attachSession && !/^[A-Za-z0-9._-]+$/.test(attachSession)) {
+      throw new Error('Invalid attach session name');
+    }
+    const innerCmd = buildContainerInnerCmd(attachSession);
 
     // Always try to resolve the node (incl. `local` → `Local`) and route via
     // SSH when the node has an ssh:// URI. In container-mode installs every
@@ -226,7 +263,7 @@ export async function resolvePtySpec(id: string): Promise<PtySpec> {
           args.push('-o', 'UserKnownHostsFile=/dev/null');
           args.push('-t');
           args.push(`${uri.username}@${uri.hostname}`);
-          args.push(`podman exec -it -e TERM=xterm-256color ${containerId} sh -c 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'`);
+          args.push(`podman exec -it -e TERM=xterm-256color ${containerId} sh -c '${innerCmd}'`);
           return { shell: 'ssh', args, fallbackWarning: '' };
         }
       }
@@ -240,7 +277,7 @@ export async function resolvePtySpec(id: string): Promise<PtySpec> {
     // binary) still works without a per-node SSH config entry.
     return {
       shell: 'podman',
-      args: ['exec', '-it', '-e', 'TERM=xterm-256color', containerId, 'sh', '-c', 'if [ -x /bin/bash ]; then exec /bin/bash; else exec /bin/sh; fi'],
+      args: ['exec', '-it', '-e', 'TERM=xterm-256color', containerId, 'sh', '-c', innerCmd],
       fallbackWarning: '',
     };
   }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
@@ -78,7 +78,7 @@ export default function FactoryResetSection() {
             Not what you want for a normal re-install. To rebuild from a USB stick, pick a Factory-fresh option in the build form instead — &quot;wipe-configs&quot; keeps your app data on disk; this button does not.
           </p>
           <p className="text-xs text-gray-700 dark:text-gray-300">
-            Your app data (Home Assistant&apos;s <span className="font-mono">.storage</span>, Z-Wave, the Immich library) is <span className="font-semibold">not</span> pulled back automatically — restore it from a System Backup (include and select Service Data) afterwards, or services come up blank.
+            Each service&apos;s config (Home Assistant&apos;s automations + <span className="font-mono">.storage</span>, the Z-Wave network keys, AdGuard / Authelia / nginx settings) is <span className="font-semibold">not</span> pulled back automatically — restore it from a System Backup (select Service Config) afterwards, or services come up with default settings. Bulk data (the Immich photo library, recorder history, the Z-Wave mesh DB) is not in the snapshot; it is wiped by a Factory Reset.
           </p>
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Family members will need to re-create their LLDAP accounts. NPM&apos;s Let&apos;s Encrypt certs are wiped (LE has a rate limit on re-issuance, so don&apos;t do this repeatedly).

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -1432,7 +1432,7 @@ export default function BackupsSettingsPage() {
                         {restoreExpandedSections.serviceData ? <ChevronDown size={16} className="text-gray-400 shrink-0" /> : <ChevronRight size={16} className="text-gray-400 shrink-0" />}
                         <Database size={16} className="text-gray-400 shrink-0" />
                         <div className="flex-1 min-w-0">
-                          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">Service Data</span>
+                          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">Service Config</span>
                           <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
                             {Object.values(restoreSelectionState.serviceData).reduce((sum, fm) => sum + Object.values(fm).filter(Boolean).length, 0)} file{Object.values(restoreSelectionState.serviceData).reduce((sum, fm) => sum + Object.values(fm).filter(Boolean).length, 0) !== 1 ? 's' : ''} selected
                           </span>
@@ -1441,7 +1441,7 @@ export default function BackupsSettingsPage() {
                       {restoreExpandedSections.serviceData && (
                         <div className="px-4 pb-4 pt-1 border-t border-gray-100 dark:border-gray-800/50 space-y-3">
                           <p className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md px-3 py-2">
-                            This is your actual app data — Home Assistant&apos;s <span className="font-mono">.storage</span>, Z-Wave, the Immich library, and so on. A &quot;configs löschen&quot; / wipe-configs reinstall keeps it on disk but does <span className="font-semibold">not</span> pull it back automatically. Select it here to recover it, or services come up blank.
+                            This is each service&apos;s <span className="font-semibold">config</span> — Home Assistant&apos;s automations and <span className="font-mono">.storage</span> registries, the Z-Wave network keys, AdGuard / Authelia / Syncthing / nginx settings, and so on. It is <span className="font-semibold">not</span> bulk data (the Immich photo library, the recorder history DB, the Z-Wave mesh DB) — that stays on disk on a wipe-configs reinstall and is Backup Sync&apos;s job. A wipe-configs reinstall does <span className="font-semibold">not</span> pull this config back automatically; select it here to recover it, or services come up with default settings.
                           </p>
                           {restorePreview.serviceData.map(sd => {
                             const label = sd.name.replace(/-/g, '/').replace(/^\//, '');

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -928,25 +928,27 @@ export const POST = withApiHandler({}, async ({ request }) => {
                 advanced_config: withProxyErrorPage(host.proxyConfig?.advanced_config),
             };
             let createdHost: { id?: number } | null = null;
+            // #999 — When the host needs forward-auth or a strict upstream
+            // Host header, the generated .conf must be patched so the
+            // directives land in the LOCATION block where nginx honours
+            // them (the server-level advanced_config alone is silently
+            // dropped by NPM's location-level proxy.conf include). We
+            // compute the need once here and re-apply it after cert-bind
+            // (see #1623): requestPublicCert's certificate_id PUT makes NPM
+            // regenerate the .conf, wiping this location patch. The patch is
+            // idempotent (buildForwardAuthPatch no-ops when already present).
+            const wantsForwardAuth = /auth_request\s+\/authelia|__authelia_forward_auth__/.test(host.proxyConfig?.advanced_config ?? '');
+            const wantsStrictHost = !!host.proxyConfig?.strictUpstreamHost;
+            const wantsConfPatch = wantsForwardAuth || wantsStrictHost;
+            const upstreamHostHeader = wantsStrictHost
+                ? `${host.forwardHost ?? '127.0.0.1'}:${host.forwardPort}`
+                : undefined;
             try {
                 createdHost = await createProxyHost(npm.apiUrl, token, host, accessListId);
                 results.push({ domain: host.domain, success: true, lanRestricted: accessListId !== 0 });
                 logger.info('ProxyHosts', `Created proxy host: ${host.domain} → ${host.forwardHost}:${host.forwardPort} (exposure=${host.exposure ?? 'lan'}${accessListId !== 0 ? ', LAN-only via access list' : ''})`);
-                // #999 — When the host needs forward-auth or a strict
-                // upstream Host header, patch the generated .conf file
-                // to land the directives in the LOCATION block where
-                // nginx will actually honour them. The server-level
-                // advanced_config alone is silently dropped by NPM's
-                // location-level proxy.conf include.
-                if (typeof createdHost?.id === 'number') {
-                    const wantsForwardAuth = /auth_request\s+\/authelia|__authelia_forward_auth__/.test(host.proxyConfig?.advanced_config ?? '');
-                    const wantsStrictHost = !!host.proxyConfig?.strictUpstreamHost;
-                    if (wantsForwardAuth || wantsStrictHost) {
-                        const upstreamHostHeader = wantsStrictHost
-                            ? `${host.forwardHost ?? '127.0.0.1'}:${host.forwardPort}`
-                            : undefined;
-                        await patchProxyHostConfFile(createdHost.id, host.domain, upstreamHostHeader, node);
-                    }
+                if (wantsConfPatch && typeof createdHost?.id === 'number') {
+                    await patchProxyHostConfFile(createdHost.id, host.domain, upstreamHostHeader, node);
                 }
             } catch (e) {
                 const msg = e instanceof Error ? e.message : String(e);
@@ -980,6 +982,14 @@ export const POST = withApiHandler({}, async ({ request }) => {
                             logger.info('ProxyHosts', `Reused existing LE cert ${certResult.certId} for ${host.domain} (re-install survived #534 cert-archive — no ACME call needed)`);
                         } else {
                             logger.info('ProxyHosts', `Issued + bound LE cert ${certResult.certId} for ${host.domain}`);
+                        }
+                        // #1623 — Binding the cert (certificate_id PUT) makes
+                        // NPM regenerate the .conf, discarding the #999
+                        // location-level forward-auth/Host patch applied above.
+                        // Re-apply it so the Remote-* identity headers and the
+                        // strict-host Host rewrite survive cert-bind. Idempotent.
+                        if (wantsConfPatch && typeof createdHost?.id === 'number') {
+                            await patchProxyHostConfFile(createdHost.id, host.domain, upstreamHostHeader, node);
                         }
                     } else {
                         results[results.length - 1].certError = certResult.reason;

--- a/packages/frontend/src/dashboards/TerminalDashboard.tsx
+++ b/packages/frontend/src/dashboards/TerminalDashboard.tsx
@@ -23,6 +23,8 @@ export default function TerminalDashboard() {
     const pathname = usePathname() || '';
     const searchParams = useSearchParams();
     const nodeParam = searchParams?.get('node') ?? null;
+    const containerParam = searchParams?.get('container') ?? null;
+    const attachParam = searchParams?.get('attach') ?? null;
     const queryString = searchParams?.toString() ?? '';
     const storageHydrated = useRef(false);
 
@@ -116,7 +118,19 @@ export default function TerminalDashboard() {
         ];
     }, [nodes, normalizeName]);
 
-    const terminalTarget = selectedNode === 'Local' ? 'host' : `node:${selectedNode}`;
+    // A `?container=<name>` deep-link selects a container terminal directly,
+    // wired to the backend's `container:<node>:<id>` session target. An
+    // optional `?attach=<session>` drops onto a named tmux session inside that
+    // container (e.g. claude-dev's persistent `claude` session) instead of a
+    // fresh shell — generalised, not hard-coded to claude-dev. Without
+    // `container`, the dashboard behaves as before (host / node shell).
+    const terminalTarget = useMemo(() => {
+        if (containerParam) {
+            const base = `container:${selectedNode}:${containerParam}`;
+            return attachParam ? `${base}:attach=${attachParam}` : base;
+        }
+        return selectedNode === 'Local' ? 'host' : `node:${selectedNode}`;
+    }, [containerParam, attachParam, selectedNode]);
 
   return (
     <div className="h-full flex flex-col">


### PR DESCRIPTION
## What
Batch of four built units plus a box-verify-authored fix-forward:
- **#1620** HA-OS import: `selectWantedMembers` skips trailing-slash dir members so `tar -x` only gets leaf files (custom_components/** stages cleanly); regression pin re-enabled.
- **#1623** proxy-hosts route: re-run `patchProxyHostConfFile` after `requestPublicCert` so the #999 Remote-* forward-auth headers + strict-host Host rewrite survive the cert-bind NPM regeneration (idempotent).
- **#1609** (P1) System Snapshot per-service config collector: `stageServiceConfig()` reuses the producer for every installed manifest into `service-config/<svc>/`; retires the nginx-only Service-Data path; restore extracts back host-side via `extractServiceConfigToNode()`; UI copy corrected.
- **#1617** terminal container deep-link: `resolvePtySpec` parses an optional `attach=<session>` segment and attaches via `tmux new -A -s <session>` (validated, injection-guarded, bare-shell fallback) on both SSH and direct-podman exec paths; frontend wires `?container=`/`?attach=`.

Includes the **#1613 mount-picker box-regression fix-forward** (commits 946e2f91 + 0f42703e, from :dev box-verify): `lsblk -b` returns JSON integers but `looksLikeBytes`/`trim()` only handled decimal strings, so `fsAvail` was always absent. `RawLsblkNode.fsavail` typed `string|number|null`, `trim()`/`looksLikeBytes` now handle numbers.

## Why
Closes #1620
Closes #1623
Closes #1609
Closes #1617

## Risk
Medium — touches backup snapshot/restore and the proxy-host cert path (both path-mandated); covered by full suite + #1608 regression pins, box-verify on next reinstall.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 338 warnings)
- [x] npm run check:arch
- [x] npm test (full — 1879 passed, 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: systemBackup/backup producer, proxy-hosts route, TerminalDashboard, mounts)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._