### PR TITLE
fix: saved-credential public URLs, portal SSO assets, Samba POSIX user, unified restore engine, claude-dev + Syncthing guides

### DIFF
--- a/packages/api-client/src/lib-types.ts
+++ b/packages/api-client/src/lib-types.ts
@@ -15,7 +15,11 @@ export type { Check, CheckConfig, CheckType } from '@/lib/health/types';
 export type { NodeTwin, GatewayState, ProxyState } from '@/lib/store/twin';
 export type { NetworkGraph } from '@/lib/network/types';
 export type { HistoryEntry } from '@/lib/history';
-export type { Credential } from '@/lib/stackInstall/credentialsManifest';
+export type {
+  Credential,
+  CredentialUrlHost,
+  CredentialUrlContext,
+} from '@/lib/stackInstall/credentialsManifest';
 export type {
   ServiceBundle,
   BundleValidation,

--- a/packages/api-client/src/lib-utils.ts
+++ b/packages/api-client/src/lib-utils.ts
@@ -16,7 +16,11 @@ export { parseTemplateLabel } from '@/lib/templateLabel';
 export { buildServiceViewModel } from '@/lib/services/serviceViewModel';
 export { getLayoutedElements } from '@/lib/network/layout';
 export { groupVariablesByTemplate } from '@/lib/stackInstall/groupVariables';
-export { buildBitwardenCsv } from '@/lib/stackInstall/credentialsManifest';
+export {
+  buildBitwardenCsv,
+  resolveCredentialUrl,
+  isHttpUrl,
+} from '@/lib/stackInstall/credentialsManifest';
 export {
   generateBundleStackArtifacts,
   sanitizeBundleName,

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -20,7 +20,7 @@ import os from 'os';
 import path from 'path';
 import { fetchServiceBackup, listServiceBackups, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
 import { getServiceManifest, getConfigPaths } from './serviceManifest';
-import { safeTarExtract, assertSafeArchiveEntries } from '../systemBackup';
+import { safeTarExtract, extractServiceConfigToNode } from '../systemBackup';
 import { getExecutor, type Executor } from '../executor';
 import { logger } from '../logger';
 
@@ -128,61 +128,15 @@ function agentRestoreBackend(executor: Executor): RestoreFsBackend {
       await executor.execArgv(['rm', '-rf', target]);
     },
     async extractTar(tar, destDir) {
-      // Traversal/symlink-escape guard (#580/#590) runs in-container on the
-      // fetched tar bytes — before anything touches the host.
-      const tmp = path.join(os.tmpdir(), `sb-restore-${Date.now()}-${process.pid}.tar`);
-      try {
-        await fs.writeFile(tmp, tar);
-        await assertSafeArchiveEntries(tmp, false);
-      } finally {
-        await fs.rm(tmp, { force: true });
-      }
-      // Push the validated tar to a host temp file (base64 over the agent's
-      // utf-8-only write_file, so binary config stays intact), then extract
-      // host-side with the SAME hardening flags safeTarExtract uses, and run a
-      // host-side symlink-escape walk as defense in depth (mirrors
-      // assertNoSymlinkEscape).
-      const { stdout } = await executor.execArgv(['mktemp', '-t', 'sb-restore-XXXXXX']);
-      const hostTar = stdout.trim();
-      const hostTarB64 = `${hostTar}.b64`;
-      try {
-        await executor.writeFile(hostTarB64, tar.toString('base64'));
-        await executor.execArgv(['sh', '-c', 'base64 -d "$1" > "$2"', 'sh', hostTarB64, hostTar], { timeoutMs: 120_000 });
-        await executor.execArgv(['mkdir', '-p', destDir]);
-        await executor.execArgv(
-          ['tar', '-xf', hostTar, '-C', destDir, '--no-same-owner', '--no-overwrite-dir', '--no-same-permissions'],
-          { timeoutMs: 120_000 },
-        );
-        await assertNoSymlinkEscapeHost(executor, destDir);
-      } finally {
-        await executor.execArgv(['rm', '-f', hostTarB64, hostTar]);
-      }
+      // #1610 — the host-side per-service tar extraction (in-container
+      // traversal/link pre-pass on the fetched tar bytes → base64 push →
+      // host-side tar with safeTarExtract's hardening flags → host-side
+      // symlink-escape walk) is the SAME engine the guided System-Snapshot
+      // restore uses. Delegate to it so config-survival auto-restore and guided
+      // restore can't fork their safety rails.
+      await extractServiceConfigToNode(executor, tar, destDir);
     },
   };
-}
-
-/**
- * Host-side equivalent of systemBackup's `assertNoSymlinkEscape` (#580/#590):
- * after a host extraction, refuse any symlink under `dir` whose resolved target
- * escapes `dir`. The in-container pre-pass already refused absolute/traversal
- * link targets in the archive listing; this is defense in depth on the host
- * where the link's real resolution lives. On refusal the partial extraction is
- * cleaned up host-side, matching safeTarExtract.
- */
-async function assertNoSymlinkEscapeHost(executor: Executor, dir: string): Promise<void> {
-  // List every symlink under dir with its resolved real path (-printf %l is the
-  // raw target; readlink -f resolves it). A target that doesn't stay within the
-  // realpath of dir is a refusal.
-  const realRoot = (await executor.execArgv(['readlink', '-f', dir])).stdout.trim();
-  const { stdout } = await executor.execArgv(['find', dir, '-type', 'l']);
-  const links = stdout.split('\n').map(l => l.trim()).filter(Boolean);
-  for (const link of links) {
-    const resolved = (await executor.execArgv(['readlink', '-f', link]).catch(() => ({ stdout: '' }))).stdout.trim();
-    if (!resolved || (resolved !== realRoot && !resolved.startsWith(realRoot + '/'))) {
-      await executor.execArgv(['rm', '-rf', dir]).catch(() => {});
-      throw new Error(`Refused archive: symlink "${link}" → "${resolved}" escapes the extraction directory`);
-    }
-  }
 }
 
 /**

--- a/packages/backend/src/lib/fileShare/sambaSync.test.ts
+++ b/packages/backend/src/lib/fileShare/sambaSync.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSendCommand, mockEnsureAgent, mockListLldapUsers } = vi.hoisted(() => ({
+  mockSendCommand: vi.fn(),
+  mockEnsureAgent: vi.fn(),
+  mockListLldapUsers: vi.fn(),
+}));
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: mockEnsureAgent },
+}));
+vi.mock('@/lib/lldap/client', () => ({
+  listLldapUsers: () => mockListLldapUsers(),
+}));
+
+import { ensureSambaPosixUser, setSambaPassword, parsePdbeditList } from './sambaSync';
+
+/**
+ * Dispatch sendCommand by the `command` string. Each entry is a substring
+ * matcher → the result the agent returns. First match wins; unmatched
+ * commands default to a clean exit so unrelated steps don't blow up.
+ */
+function wireExec(rules: Array<{ match: string; code?: number; stdout?: string; stderr?: string }>) {
+  mockEnsureAgent.mockResolvedValue({ sendCommand: mockSendCommand });
+  mockSendCommand.mockImplementation(async (_action: string, args: { command: string }) => {
+    for (const r of rules) {
+      if (args.command.includes(r.match)) {
+        return { code: r.code ?? 0, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+      }
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  });
+}
+
+beforeEach(() => {
+  mockSendCommand.mockReset();
+  mockEnsureAgent.mockReset();
+  mockListLldapUsers.mockReset();
+});
+
+describe('ensureSambaPosixUser', () => {
+  it('is a no-op when the POSIX user already exists (idempotent)', async () => {
+    wireExec([{ match: 'getent passwd alice', code: 0, stdout: 'alice:x:1001:1001::/home/alice:/bin/sh' }]);
+    const res = await ensureSambaPosixUser('Local', 'alice');
+    expect(res.ok).toBe(true);
+    // useradd must NOT have been issued.
+    const calls = mockSendCommand.mock.calls.map(c => c[1].command);
+    expect(calls.some(c => c.includes('useradd'))).toBe(false);
+  });
+
+  it('creates the user with the share gid as primary group when absent', async () => {
+    wireExec([
+      { match: 'getent passwd bob', code: 2, stdout: '' }, // absent
+      { match: 'stat -c %g /data', code: 0, stdout: '1000\n' },
+      { match: 'useradd', code: 0 },
+    ]);
+    const res = await ensureSambaPosixUser('Local', 'bob');
+    expect(res.ok).toBe(true);
+    const useradd = mockSendCommand.mock.calls.map(c => c[1].command).find(c => c.includes('useradd'));
+    expect(useradd).toContain('-M');
+    expect(useradd).toContain('-s /usr/sbin/nologin');
+    expect(useradd).toContain('-g 1000');
+    expect(useradd).toContain('bob');
+  });
+
+  it('still creates the user (no -g) when the share gid cannot be resolved', async () => {
+    wireExec([
+      { match: 'getent passwd carol', code: 2 },
+      { match: 'stat -c %g /data', code: 1, stderr: 'stat: cannot stat' },
+      { match: 'useradd', code: 0 },
+    ]);
+    const res = await ensureSambaPosixUser('Local', 'carol');
+    expect(res.ok).toBe(true);
+    const useradd = mockSendCommand.mock.calls.map(c => c[1].command).find(c => c.includes('useradd'));
+    expect(useradd).not.toContain('-g ');
+    expect(useradd).toContain('carol');
+  });
+
+  it('returns an actionable error when useradd fails', async () => {
+    wireExec([
+      { match: 'getent passwd dave', code: 2 },
+      { match: 'stat -c %g /data', code: 0, stdout: '1000' },
+      { match: 'useradd', code: 1, stderr: 'useradd: permission denied' },
+    ]);
+    const res = await ensureSambaPosixUser('Local', 'dave');
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.message).toContain('Could not create POSIX user');
+      expect(res.message).toContain('useradd: permission denied');
+    }
+  });
+});
+
+describe('setSambaPassword', () => {
+  it('provisions the POSIX user before smbpasswd -a', async () => {
+    mockListLldapUsers.mockResolvedValue({ ok: true, users: [{ id: 'erin' }] });
+    wireExec([
+      { match: 'getent passwd erin', code: 2 }, // absent → triggers useradd
+      { match: 'stat -c %g /data', code: 0, stdout: '1000' },
+      { match: 'useradd', code: 0 },
+      { match: 'smbpasswd', code: 0 },
+    ]);
+    const res = await setSambaPassword('erin', { node: 'Local', password: 'hunter22' });
+    expect(res.ok).toBe(true);
+    const commands = mockSendCommand.mock.calls.map(c => c[1].command);
+    const useraddIdx = commands.findIndex(c => c.includes('useradd'));
+    const smbpasswdIdx = commands.findIndex(c => c.includes('smbpasswd'));
+    expect(useraddIdx).toBeGreaterThanOrEqual(0);
+    expect(smbpasswdIdx).toBeGreaterThan(useraddIdx); // ordering: useradd before smbpasswd
+  });
+
+  it('does not attempt smbpasswd if POSIX user creation fails', async () => {
+    mockListLldapUsers.mockResolvedValue({ ok: true, users: [{ id: 'frank' }] });
+    wireExec([
+      { match: 'getent passwd frank', code: 2 },
+      { match: 'stat -c %g /data', code: 0, stdout: '1000' },
+      { match: 'useradd', code: 1, stderr: 'denied' },
+    ]);
+    const res = await setSambaPassword('frank', { node: 'Local', password: 'pw' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('exec_failed');
+    const commands = mockSendCommand.mock.calls.map(c => c[1].command);
+    expect(commands.some(c => c.includes('smbpasswd'))).toBe(false);
+  });
+
+  it('rejects a user not in LLDAP without touching the container', async () => {
+    mockListLldapUsers.mockResolvedValue({ ok: true, users: [{ id: 'someoneelse' }] });
+    const res = await setSambaPassword('ghost', { node: 'Local', password: 'pw' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('not_in_lldap');
+    expect(mockSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('parsePdbeditList', () => {
+  it('extracts usernames and drops malformed lines', () => {
+    const out = 'alice:1001:Alice\nbob:1002:Bob\n\n  \nbad name:1:x';
+    expect(parsePdbeditList(out)).toEqual(['alice', 'bob']);
+  });
+});

--- a/packages/backend/src/lib/fileShare/sambaSync.ts
+++ b/packages/backend/src/lib/fileShare/sambaSync.ts
@@ -1,9 +1,15 @@
 /**
- * LLDAP → Samba `tdbsam` sync for the file-share template (#494).
+ * LLDAP → Samba passdb sync for the file-share template (#494).
+ *
+ * NOTE on the passdb backend: the design intent was `tdbsam`, but the
+ * `servercontainers/samba` image ships `passdb backend = smbpasswd`
+ * (verify with `testparm -s | grep passdb`). We drive it through the
+ * `smbpasswd` / `pdbedit` CLIs, which work against whichever backend is
+ * configured — so this module is backend-agnostic in practice.
  *
  * Samba can't speak OIDC, and rehashing LLDAP's Argon2/bcrypt password
  * into the NT-hash Samba needs is not possible. The locked design is
- * Option A from the issue: keep per-user Samba accounts in `tdbsam`,
+ * Option A from the issue: keep per-user Samba accounts in the passdb,
  * with passwords set independently by the operator (or randomised at
  * create-time + user resets via the Settings → Integrations UI).
  *
@@ -75,6 +81,71 @@ async function exec(node: string, cmd: string, opts: { stdin?: string; timeout?:
 }
 
 /**
+ * Path of the shared volume *inside* the samba container. The `data`
+ * share is bind-mounted here from the host (`{{DATA_DIR}}/file-share/data`,
+ * owned by the dedicated `file-share` group — see #1311). A Samba user
+ * must be able to write this path, so the on-demand POSIX account we
+ * create is given the share's owning gid as its primary group.
+ */
+const SHARE_MOUNT = '/data';
+
+export type EnsurePosixUserResult =
+  | { ok: true }
+  | { ok: false; message: string };
+
+/**
+ * Idempotently create the POSIX (Unix) account `smbpasswd -a` needs.
+ *
+ * `smbpasswd -a` does NOT create a Unix user — it `getpwnam`s the name to
+ * map a uid and fails ("Failed to add entry for user X") when there is no
+ * matching account (#1630). The `servercontainers/samba` image only
+ * `useradd`s the single legacy `ACCOUNT_<SHARE_USER>` account at startup,
+ * so per-LLDAP-user accounts have nothing to attach to.
+ *
+ * We create the account on demand:
+ *   - skip if `getent passwd <user>` already lists it (idempotent on
+ *     password resets and bulk sync);
+ *   - otherwise `useradd -M -s /usr/sbin/nologin`, with the user's primary
+ *     group set to the gid that owns the share mount so writes to `/data`
+ *     succeed (the share is group-owned + setgid + default-ACL per #1311).
+ *
+ * Best-effort on the group mapping: if the share's owning gid can't be
+ * resolved we still create the user (with a default group) so password
+ * provisioning isn't blocked — a misconfigured mount is a separate fault.
+ */
+export async function ensureSambaPosixUser(node: string, userId: string): Promise<EnsurePosixUserResult> {
+  // Already present → nothing to do (idempotent).
+  const existing = await exec(node, `podman exec ${SAMBA_CONTAINER_NAME} getent passwd ${userId}`, { timeout: 10 });
+  if (existing.code === 0 && existing.stdout.trim()) {
+    return { ok: true };
+  }
+
+  // Resolve the gid that owns the share mount so the new user can write it.
+  // `stat -c %g` prints the numeric group id of /data inside the container.
+  let shareGid: number | null = null;
+  const statRes = await exec(node, `podman exec ${SAMBA_CONTAINER_NAME} stat -c %g ${SHARE_MOUNT}`, { timeout: 10 });
+  if (statRes.code === 0) {
+    const parsed = Number.parseInt(statRes.stdout.trim(), 10);
+    if (Number.isInteger(parsed) && parsed >= 0) shareGid = parsed;
+  }
+
+  // Build the useradd. -M: no home dir. -s /usr/sbin/nologin: no shell.
+  // -g <gid>: primary group = share owner (so /data is writable). When the
+  // gid has no matching group entry, useradd -g <numeric> still works (it
+  // accepts a raw gid), so we don't need to groupadd first.
+  const groupArg = shareGid !== null ? `-g ${shareGid} ` : '';
+  const addCmd = `podman exec ${SAMBA_CONTAINER_NAME} useradd -M -s /usr/sbin/nologin ${groupArg}${userId}`;
+  const addRes = await exec(node, addCmd, { timeout: 10 });
+  if (addRes.code !== 0) {
+    return {
+      ok: false,
+      message: `Could not create POSIX user '${userId}' in ${SAMBA_CONTAINER_NAME} (useradd exit ${addRes.code}): ${(addRes.stderr || addRes.stdout || '').slice(0, 200)}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
  * Parse the output of `pdbedit -L`. Each line looks like
  *   `username:1001:Full Name`
  * but the locked design only relies on the leading username, so we
@@ -131,6 +202,14 @@ export async function syncSambaWithLldap(node: string = 'Local'): Promise<SambaS
 
   const added: string[] = [];
   for (const u of toAdd) {
+    // smbpasswd -a requires an existing POSIX account — create it first
+    // (idempotently) or the add fails with "Failed to add entry" (#1630).
+    const posix = await ensureSambaPosixUser(node, u.id);
+    if (!posix.ok) {
+      // Couldn't provision the Unix account — skip the smbpasswd add. The
+      // user stays presentInSamba=false so the UI surfaces a retry.
+      continue;
+    }
     const pw = generatePassword();
     // smbpasswd -s -a <user>: -s reads stdin (newpass\nnewpass), -a adds.
     // Conservative escape of username via SAFE_USERNAME above; password
@@ -195,9 +274,17 @@ export async function setSambaPassword(
   // — the operator might be fixing a Samba-only outage and we don't
   // want to gate that on LLDAP availability.
 
+  // smbpasswd -a maps the name to a Unix uid via getpwnam — it does NOT
+  // create the POSIX account. Provision it first (idempotently) so the
+  // add succeeds and the account can write the share (#1630).
+  const posix = await ensureSambaPosixUser(node, userId);
+  if (!posix.ok) {
+    return { ok: false, reason: 'exec_failed', message: posix.message };
+  }
+
   const password = options.password ?? generatePassword();
-  // smbpasswd is idempotent: adds the user if not yet present, updates
-  // the password otherwise. Stdin format: newpass\nnewpass\n.
+  // smbpasswd -s -a: -s reads the password from stdin (newpass\nnewpass\n),
+  // -a adds the entry (or updates the password if it already exists).
   const cmd = `podman exec -i ${SAMBA_CONTAINER_NAME} smbpasswd -s -a ${userId}`;
   const res = await exec(node, cmd, { stdin: `${password}\n${password}\n`, timeout: 10 });
   if (res.code !== 0) {

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -638,7 +638,15 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
           if (evt.type === 'progress') {
             if (typeof evt.message === 'string' && evt.message.startsWith('__SB_CREDENTIAL__ ')) {
               try {
-                ctx.scriptCredentials.push(JSON.parse(evt.message.slice('__SB_CREDENTIAL__ '.length)));
+                const captured = JSON.parse(evt.message.slice('__SB_CREDENTIAL__ '.length));
+                // Tag with the owning template so the Saved-credentials UI can
+                // resolve the loopback `url` to the service's public subdomain
+                // (#1626) and per-template uninstall can drop it (#631). The
+                // marker itself doesn't carry the name; the deploy loop does.
+                if (captured && typeof captured === 'object' && captured.template == null) {
+                  captured.template = item.name;
+                }
+                ctx.scriptCredentials.push(captured);
               } catch { /* malformed marker — drop it */ }
               continue;
             }

--- a/packages/backend/src/lib/stackInstall/credentialsManifest.test.ts
+++ b/packages/backend/src/lib/stackInstall/credentialsManifest.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { mergeCredentials, type Credential } from './credentialsManifest';
+import {
+  mergeCredentials,
+  resolveCredentialUrl,
+  isHttpUrl,
+  buildBitwardenCsv,
+  type Credential,
+  type CredentialUrlContext,
+} from './credentialsManifest';
 
 const cred = (service: string, template?: string): Credential => ({
   service,
@@ -43,5 +50,85 @@ describe('mergeCredentials', () => {
     // 'immich' is re-installed but emits no credentials this run
     const merged = mergeCredentials(existing, [cred('lldap', 'auth')], ['auth', 'immich']);
     expect(merged.map(c => c.service)).toEqual(['lldap']);
+  });
+});
+
+describe('isHttpUrl', () => {
+  it('accepts http and https', () => {
+    expect(isHttpUrl('http://localhost:81')).toBe(true);
+    expect(isHttpUrl('https://ldap.dopp.cloud/user/mdopp79')).toBe(true);
+  });
+  it('rejects non-URL hints and other schemes', () => {
+    for (const v of ['env: LLDAP_JWT_SECRET', '\\\\localhost\\data', '(bearer token)', 'ssh://dev@localhost:2222', '<server-ip>', '', undefined]) {
+      expect(isHttpUrl(v as string | undefined)).toBe(false);
+    }
+  });
+});
+
+describe('resolveCredentialUrl', () => {
+  const ctx: CredentialUrlContext = {
+    publicDomain: 'dopp.cloud',
+    hosts: [
+      { service: 'nginx', domain: 'nginx.dopp.cloud' },
+      { service: 'auth', domain: 'ldap.dopp.cloud' },
+      { service: 'adguard', domain: 'dns.dopp.cloud' },
+    ],
+  };
+  const c = (url: string, service: string, template?: string): Credential => ({
+    service, url, username: 'admin', password: 'x', importance: 'critical', template,
+  });
+
+  it('rewrites a loopback URL to the public subdomain via template match', () => {
+    expect(resolveCredentialUrl(c('http://localhost:81', 'Nginx Proxy Manager', 'nginx'), ctx))
+      .toBe('https://nginx.dopp.cloud');
+  });
+
+  it('matches by service-name substring when template is absent', () => {
+    expect(resolveCredentialUrl(c('http://localhost:8083', 'AdGuard Home'), ctx))
+      .toBe('https://dns.dopp.cloud');
+  });
+
+  it('preserves path/query/hash when rewriting', () => {
+    expect(resolveCredentialUrl(c('http://localhost:17170/admin?x=1#y', 'LLDAP', 'auth'), ctx))
+      .toBe('https://ldap.dopp.cloud/admin?x=1#y');
+  });
+
+  it('leaves an already-public http(s) URL untouched', () => {
+    expect(resolveCredentialUrl(c('https://ldap.dopp.cloud/user/mdopp79', 'LLDAP user', 'auth'), ctx))
+      .toBe('https://ldap.dopp.cloud/user/mdopp79');
+  });
+
+  it('passes non-URL values through unchanged', () => {
+    expect(resolveCredentialUrl(c('env: LLDAP_JWT_SECRET', 'LLDAP JWT', 'auth'), ctx))
+      .toBe('env: LLDAP_JWT_SECRET');
+    expect(resolveCredentialUrl(c('ssh://dev@localhost:2222', 'Claude Dev', 'claude-dev'), ctx))
+      .toBe('ssh://dev@localhost:2222');
+  });
+
+  it('returns the original loopback URL when no proxy host matches', () => {
+    expect(resolveCredentialUrl(c('http://localhost:8096', 'Jellyfin', 'media'), ctx))
+      .toBe('http://localhost:8096');
+  });
+});
+
+describe('buildBitwardenCsv login_uri', () => {
+  const ctx: CredentialUrlContext = {
+    hosts: [{ service: 'nginx', domain: 'nginx.dopp.cloud' }],
+  };
+  const c = (url: string, template?: string): Credential => ({
+    service: 'Nginx Proxy Manager', url, username: 'admin', password: 'x', importance: 'critical', template,
+  });
+
+  it('writes the resolved public URL into login_uri', () => {
+    const csv = buildBitwardenCsv([c('http://localhost:81', 'nginx')], ctx);
+    expect(csv).toContain('"https://nginx.dopp.cloud"');
+    expect(csv).not.toContain('localhost:81');
+  });
+
+  it('leaves login_uri empty for non-URL values', () => {
+    const csv = buildBitwardenCsv([{ ...c('env: SECRET', 'auth'), service: 'JWT' }], ctx);
+    const line = csv.trim().split('\n')[1];
+    // login_uri is the 8th column — empty for a non-URL value
+    expect(line.split(',')[7]).toBe('""');
   });
 });

--- a/packages/backend/src/lib/stackInstall/credentialsManifest.ts
+++ b/packages/backend/src/lib/stackInstall/credentialsManifest.ts
@@ -117,10 +117,96 @@ export function mergeCredentials(
 // capability handler persists each template's entries to
 // `config.installManifest`.
 
+/**
+ * Minimal proxy-host shape the URL resolver needs — a subset of the
+ * backend `ProxyHostEntry` (config.ts) so this stays importable from the
+ * api-client/frontend without dragging in the full config types.
+ */
+export interface CredentialUrlHost {
+  /** Full subdomain, e.g. "ldap.dopp.cloud". */
+  domain: string;
+  /** Owning template name, e.g. "auth", "nginx", "adguard". */
+  service: string;
+}
+
+export interface CredentialUrlContext {
+  hosts?: CredentialUrlHost[];
+  publicDomain?: string;
+}
+
+/**
+ * True only for browser-navigable http(s) URLs. Everything else a
+ * post-deploy might stash in the `url` field — `env: LLDAP_JWT_SECRET`,
+ * `\\localhost\data`, `(bearer token)`, `ssh://dev@localhost:2222`,
+ * the `<server-ip>` placeholder — returns false so the UI renders it as
+ * plain text instead of a dead link.
+ */
+export function isHttpUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url.trim());
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '<server-ip>', '[::1]']);
+
+/**
+ * Resolve the admin-reachable URL for a credential row (#1626).
+ *
+ * post-deploy.py scripts emit `http://<HOST>:<port>` where HOST defaults
+ * to the box's loopback — useless from an admin's browser. Every admin
+ * console already has a public subdomain behind Authelia, recorded in
+ * `reverseProxy.hosts[]`. So when a credential points at a loopback host
+ * and we can find the owning service's proxy host, rewrite it to
+ * `https://<subdomain>`.
+ *
+ * - Non-http(s) values (`env:`, `\\…`, `ssh://`, bearer tokens) pass
+ *   through untouched — the caller renders them as plain text.
+ * - http(s) URLs that aren't loopback (already a real subdomain, e.g. the
+ *   LLDAP per-user link) pass through untouched.
+ * - Loopback http(s) URLs are rewritten when a matching proxy host exists
+ *   (by `template`, else by template-name substring of the service label),
+ *   preserving the original path/hash. No match ⇒ original returned.
+ */
+export function resolveCredentialUrl(
+  cred: Pick<Credential, 'url' | 'service' | 'template'>,
+  ctx: CredentialUrlContext,
+): string {
+  const raw = (cred.url ?? '').trim();
+  if (!isHttpUrl(raw)) return raw;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return raw;
+  }
+  if (!LOOPBACK_HOSTS.has(parsed.hostname)) return raw;
+
+  const hosts = ctx.hosts ?? [];
+  if (hosts.length === 0) return raw;
+
+  const serviceLabel = (cred.service ?? '').toLowerCase();
+  const match =
+    (cred.template && hosts.find(h => h.service === cred.template)) ||
+    hosts.find(h => h.service && serviceLabel.includes(h.service.toLowerCase()));
+  if (!match || !match.domain) return raw;
+
+  return `https://${match.domain}${parsed.pathname === '/' ? '' : parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
 /** Build a Bitwarden-import-ready CSV. Bitwarden's importer is forgiving on
  *  column order; we use the canonical set documented at
- *  https://bitwarden.com/help/condition-bitwarden-import/. */
-export function buildBitwardenCsv(manifest: Credential[]): string {
+ *  https://bitwarden.com/help/condition-bitwarden-import/.
+ *
+ *  When a `ctx` is supplied, each row's `login_uri` is run through
+ *  `resolveCredentialUrl` so loopback URLs become the admin-reachable
+ *  public subdomain (#1626) — keeping the CSV import in lock-step with
+ *  what the Saved-credentials table shows. */
+export function buildBitwardenCsv(manifest: Credential[], ctx: CredentialUrlContext = {}): string {
   const escape = (s: string) => `"${(s ?? '').replace(/"/g, '""')}"`;
   const header = [
     'folder', 'favorite', 'type', 'name', 'notes',
@@ -128,19 +214,23 @@ export function buildBitwardenCsv(manifest: Credential[]): string {
     'login_uri', 'login_username', 'login_password', 'login_totp',
   ].join(',');
 
-  const rows = manifest.map(c => [
-    escape('ServiceBay Home'),
-    '',
-    escape('login'),
-    escape(c.service),
-    escape(`${c.notes || ''}${c.importance === 'system' ? '\n[system / DR — usually not needed for daily use]' : ''}`.trim()),
-    '',
-    '',
-    escape(c.url),
-    escape(c.username),
-    escape(c.password),
-    '',
-  ].join(','));
+  const rows = manifest.map(c => {
+    const resolved = resolveCredentialUrl(c, ctx);
+    return [
+      escape('ServiceBay Home'),
+      '',
+      escape('login'),
+      escape(c.service),
+      escape(`${c.notes || ''}${c.importance === 'system' ? '\n[system / DR — usually not needed for daily use]' : ''}`.trim()),
+      '',
+      '',
+      // Only http(s) URLs are valid login_uri values; non-URL hints stay out.
+      escape(isHttpUrl(resolved) ? resolved : ''),
+      escape(c.username),
+      escape(c.password),
+      '',
+    ].join(',');
+  });
 
   return [header, ...rows].join('\n') + '\n';
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -1,13 +1,42 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Download, Eye, EyeOff, Key, Loader2, Trash2 } from 'lucide-react';
-import { buildBitwardenCsv, type Credential } from '@servicebay/api-client';
+import { Download, ExternalLink, Eye, EyeOff, Key, Loader2, Trash2 } from 'lucide-react';
+import {
+  buildBitwardenCsv,
+  isHttpUrl,
+  resolveCredentialUrl,
+  type Credential,
+  type CredentialUrlHost,
+} from '@servicebay/api-client';
 import { useToast } from '@/providers/ToastProvider';
 
 interface Manifest {
   savedAt: string;
   credentials: Credential[];
+}
+
+/** URL cell (#1626): render an admin-reachable http(s) URL as a clickable
+ *  link; render non-URL hints (`env:`, `\\…`, `ssh://`, bearer tokens) as
+ *  plain text. The loopback→public-subdomain rewrite happens in
+ *  `resolveCredentialUrl`. */
+function CredentialUrlCell({ cred, hosts, publicDomain }: {
+  cred: Credential;
+  hosts: CredentialUrlHost[];
+  publicDomain: string | null;
+}) {
+  const resolved = resolveCredentialUrl(cred, { hosts, publicDomain: publicDomain ?? undefined });
+  if (!isHttpUrl(resolved)) return <span className="break-all">{resolved}</span>;
+  return (
+    <a
+      href={resolved}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 dark:text-blue-400 hover:underline break-all"
+    >
+      {resolved}
+    </a>
+  );
 }
 
 /**
@@ -27,6 +56,8 @@ interface Manifest {
 export default function CredentialsSection() {
   const { addToast } = useToast();
   const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [proxyHosts, setProxyHosts] = useState<CredentialUrlHost[]>([]);
+  const [publicDomain, setPublicDomain] = useState<string | null>(null);
   const [busy, setBusy] = useState<'load' | 'wipe' | null>('load');
   const [revealed, setRevealed] = useState<Record<number, boolean>>({});
 
@@ -34,10 +65,25 @@ export default function CredentialsSection() {
     fetch('/api/system/credentials')
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
-        if (data) setManifest(data.manifest ?? null);
+        if (data) {
+          setManifest(data.manifest ?? null);
+          setProxyHosts(Array.isArray(data.proxyHosts) ? data.proxyHosts : []);
+          setPublicDomain(data.publicDomain ?? null);
+        }
       })
       .finally(() => setBusy(null));
   }, []);
+
+  const urlCtx = { hosts: proxyHosts, publicDomain: publicDomain ?? undefined };
+
+  // Vaultwarden import deep-link (#1627): only when vaultwarden is installed
+  // (has a proxy host) and a public domain is configured. Derive the domain
+  // from the proxy host so we don't hardcode `vault`/the public domain.
+  const vaultHost = proxyHosts.find(h => h.service === 'vaultwarden');
+  const vaultwardenImportUrl =
+    publicDomain && vaultHost?.domain
+      ? `https://${vaultHost.domain}/#/tools/import`
+      : null;
 
   const onWipe = async () => {
     if (!window.confirm(
@@ -62,7 +108,7 @@ export default function CredentialsSection() {
 
   const downloadCsv = () => {
     if (!manifest || manifest.credentials.length === 0) return;
-    const blob = new Blob([buildBitwardenCsv(manifest.credentials)], { type: 'text/csv' });
+    const blob = new Blob([buildBitwardenCsv(manifest.credentials, urlCtx)], { type: 'text/csv' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
     a.download = `servicebay-credentials-${new Date().toISOString().slice(0, 10)}.csv`;
@@ -104,6 +150,18 @@ export default function CredentialsSection() {
               <Download size={14} />
               Download CSV
             </button>
+            {vaultwardenImportUrl && (
+              <a
+                href={vaultwardenImportUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-3 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-100 text-sm font-medium rounded-lg"
+                title="Opens the Vaultwarden web-vault import page in a new tab. Download the CSV first, then pick it there. Choose an Organization collection to share entries with other admins (folders are personal)."
+              >
+                <ExternalLink size={14} />
+                Open Vaultwarden import
+              </a>
+            )}
             <button
               onClick={onWipe}
               disabled={busy === 'wipe'}
@@ -148,7 +206,9 @@ export default function CredentialsSection() {
                           <span className="ml-2 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">system</span>
                         )}
                       </td>
-                      <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-mono text-xs">{c.url}</td>
+                      <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-mono text-xs">
+                        <CredentialUrlCell cred={c} hosts={proxyHosts} publicDomain={publicDomain} />
+                      </td>
                       <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-mono text-xs">{c.username}</td>
                       <td className="py-2 pr-3">
                         <div className="flex items-center gap-2">

--- a/packages/frontend/src/app/api/portal/asset/[service]/[kind]/route.ts
+++ b/packages/frontend/src/app/api/portal/asset/[service]/[kind]/route.ts
@@ -6,6 +6,7 @@ import { resolveSetupAsset } from '@/lib/portal/assets';
 import type { SetupAssetKind } from '@/lib/portal/userGuide';
 import { withApiHandlerParams } from '@/lib/api/handler';
 import { requireSession } from '@/lib/api/requireSession';
+import { verifyAutheliaSession } from '@/lib/portal/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,17 +42,31 @@ export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, Params
     const { service, kind } = params;
 
     // LAN-mode installs serve portal assets anonymously (the portal
-    // page is open on the LAN). Public-mode installs require an
-    // authenticated SB session — without that the dashboard's
-    // "Pair device" / "Open in app" buttons would 404 even when an
-    // operator is logged in. Pre-#1172 this used to hard-404 any
-    // public-mode request, which surfaced as "Couldn't read the device
-    // id (HTTP 404)" in the Syncthing pairing modal of every operator
-    // running with a real publicDomain set.
+    // page is open on the LAN). Public-mode installs require *some*
+    // authenticated identity — but a dual gate, because two distinct
+    // surfaces fetch these assets:
+    //
+    //   1. The ServiceBay dashboard's "Pair device" / "Open in app"
+    //      buttons — an operator logged into the SB console
+    //      (requireSession / SB session cookie). #1172 added this.
+    //   2. The family portal at the apex (`dopp.cloud`), which is
+    //      anonymous / Authelia-SSO only and is NOT served behind an SB
+    //      session. A signed-in family member's request to the apex
+    //      already carries the `.<publicDomain>` Authelia cookie, so
+    //      verifyAutheliaSession() can recognize them (#1606, #1628).
+    //
+    // #1172 only checked (1), so every portal visitor — including
+    // SSO-logged-in family members — got 401 ("Couldn't read the device
+    // id (HTTP 401)") in the Syncthing pairing modal. Accept either.
+    // A genuinely anonymous request (no SB session, no SSO cookie)
+    // still falls through to 401.
     const config = await getConfig();
     if (getMode(config) === 'public') {
-      const auth = await requireSession(request);
-      if (auth instanceof NextResponse) return auth;
+      const visitor = await verifyAutheliaSession(request.headers.get('cookie'));
+      if (!visitor.user) {
+        const auth = await requireSession(request);
+        if (auth instanceof NextResponse) return auth;
+      }
     }
 
     if (!KIND_VALUES.includes(kind as SetupAssetKind)) {

--- a/packages/frontend/src/app/api/system/credentials/route.ts
+++ b/packages/frontend/src/app/api/system/credentials/route.ts
@@ -34,8 +34,16 @@ const ManifestBody = z.object({
 export const GET = withApiHandler({}, async () => {
   const config = await getConfig();
   const manifest = config.installManifest;
-  if (!manifest) return NextResponse.json({ manifest: null });
-  return NextResponse.json({ manifest });
+  // Proxy-host map + public domain let the client resolve loopback URLs to
+  // each console's public subdomain (#1626) and surface the Vaultwarden
+  // import deep link (#1627) — without re-deriving any subdomain mapping.
+  const proxyHosts = (config.reverseProxy?.hosts ?? []).map(h => ({
+    domain: h.domain,
+    service: h.service,
+  }));
+  const publicDomain = config.reverseProxy?.publicDomain ?? null;
+  if (!manifest) return NextResponse.json({ manifest: null, proxyHosts, publicDomain });
+  return NextResponse.json({ manifest, proxyHosts, publicDomain });
 });
 
 export const POST = withApiHandler({ body: ManifestBody }, async ({ body }) => {

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -497,6 +497,19 @@ function CommandBlock({ command }: { command: string }) {
 }
 
 /**
+ * Maps a failed setup-asset fetch to a user-facing message. A 401/403
+ * means the visitor isn't signed in (public mode requires an SSO or SB
+ * session — #1628), which is distinct from the service genuinely not
+ * being up yet (the `notReady` text).
+ */
+function assetFetchError(status: number, notReady: string): string {
+  if (status === 401 || status === 403) {
+    return `You don't seem to be signed in (HTTP ${status}). Sign in and try again.`;
+  }
+  return notReady;
+}
+
+/**
  * Deep-link button for setup assets that resolve to a custom-scheme
  * URL (`abs://`, etc.). Fetches the URL from the asset endpoint on
  * click, then sets `window.location` so the browser hands off to the
@@ -521,7 +534,7 @@ function DeepLinkButton({
     try {
       const res = await fetch(`/api/portal/asset/${card.name}/${kind}?subdomain_var=${encodeURIComponent(card.subdomainVar)}`);
       if (!res.ok) {
-        setError(`Couldn't load the link (HTTP ${res.status}).`);
+        setError(assetFetchError(res.status, `Couldn't load the link (HTTP ${res.status}).`));
         return;
       }
       const data = await res.json() as { url?: string };
@@ -663,7 +676,10 @@ function SyncthingQrButton({
     try {
       const res = await fetch(`/api/portal/asset/${card.name}/syncthing_qr?subdomain_var=${encodeURIComponent(card.subdomainVar)}`);
       if (!res.ok) {
-        setError(`Couldn't read the device id (HTTP ${res.status}). The Syncthing container might not be running yet — try again in a minute.`);
+        setError(assetFetchError(
+          res.status,
+          `Couldn't read the device id (HTTP ${res.status}). The Syncthing container might not be running yet — try again in a minute.`,
+        ));
         return;
       }
       const data = await res.json() as { deviceId?: string };

--- a/templates/claude-dev/user-guide.md
+++ b/templates/claude-dev/user-guide.md
@@ -1,0 +1,127 @@
+---
+lucide_icon: "bot"
+tagline: "Code against your repos from anywhere — a Claude Code dev box that lives on the home server, no laptop required."
+# claude-dev has no subdomain / proxy host, so there's no "Open" URL.
+# The card renders via the appless path (#1618): the primary action is
+# the web terminal deep-link that attaches to the container's persistent
+# `claude` tmux session (#1617), and the VS Code Remote-SSH handoff is a
+# desktop-only secondary action.
+primary_action:
+  type: "in_app"
+  label: "Open terminal"
+  href: "/terminal?node=Local&container=claude-dev&attach=claude"
+  icon: "bot"
+actions:
+  # vscode:// hands off to the desktop VS Code app's Remote-SSH. The host
+  # and port can't be baked into this link (they come from the install —
+  # the box's LAN IP and the CLAUDE_DEV_SSH_PORT you set), so the literal
+  # template here is a placeholder; the body documents the real command to
+  # copy. desktop_only defaults true for external_scheme, so the phone UI
+  # hides this button.
+  - type: "external_scheme"
+    label: "Open in VS Code (desktop)"
+    href: "vscode://vscode-remote/ssh-remote+dev@HOST:PORT/workspace"
+    icon: "package"
+---
+
+# Coding from anywhere with Claude Dev
+
+This is a development box that runs on the home server 24/7. It carries the
+**Claude Code** CLI, `git`, the GitHub CLI, and a Node toolchain, with a
+persistent `/workspace` that survives restarts. Drive it from your phone,
+your laptop, or a browser tab — the session keeps running on the box even
+when you close the lid.
+
+There's no website to open here: the card's **Open terminal** button drops
+you straight into the box's terminal, attached to the always-on `claude`
+session.
+
+## Open the terminal (primary)
+
+Click **Open terminal** on the card. It opens the ServiceBay web terminal
+already attached to the container's persistent `claude` tmux session — the
+same session the mobile app and an SSH login land in. Close the tab and the
+session keeps running; re-open it and you're back where you left off.
+
+## Open in VS Code (desktop)
+
+On a desktop with [VS Code](https://code.visualstudio.com/) and the
+**Remote - SSH** extension, you can edit `/workspace` natively. The card's
+**Open in VS Code** button uses this URL scheme — but the host and port
+come from *your* install, so copy the real link with your values filled in:
+
+```
+vscode://vscode-remote/ssh-remote+dev@<host>:<port>/workspace
+```
+
+- `<host>` — the home server's LAN IP (the same address you use to reach
+  ServiceBay), or your dynamic-DNS / public hostname when connecting from
+  outside.
+- `<port>` — the `CLAUDE_DEV_SSH_PORT` you chose at install (default
+  `2222`; shown on the install/credentials screen).
+
+Example on the LAN with the default port:
+
+```
+vscode://vscode-remote/ssh-remote+dev@192.168.1.50:2222/workspace
+```
+
+The `dev` user's password is on the post-install credentials banner (or use
+your SSH key if you supplied `CLAUDE_DEV_SSH_AUTHORIZED_KEY`).
+
+## Connect over SSH (terminal / mobile app)
+
+The same `dev@<host>:<port>` works from any terminal or the Claude Code
+mobile app. `sshd` binds the port directly on the host, so on the LAN you
+connect straight to it; from outside, add a FritzBox port-forward for that
+port first.
+
+```sh
+ssh -p <port> dev@<host>
+```
+
+Every interactive login auto-attaches to the persistent `claude` tmux
+session, so a closed phone or a network blip never kills your work. Detach
+without stopping it with `Ctrl-b d`; re-attach manually with:
+
+```sh
+tmux new -A -s claude
+```
+
+## Log in to Claude (first time)
+
+Inside the session, run Claude once and complete the login — it persists to
+`~/.claude` on the `/workspace` volume, so you only do this once (it survives
+container restarts):
+
+```sh
+claude
+```
+
+Follow the OAuth prompt to sign in. On a headless box where the browser
+hand-off is awkward, mint a token instead and paste it when asked:
+
+```sh
+claude setup-token
+```
+
+After a restart, resume the previous conversation from the persisted history
+with:
+
+```sh
+claude --continue
+```
+
+## Switch repositories
+
+`/workspace` is your persistent home, so you can keep several checkouts side
+by side. Clone a new repo with the GitHub CLI (run `gh auth login` once — it
+also persists), then start Claude in it:
+
+```sh
+cd /workspace && gh repo clone <owner>/<repo>
+cd <repo> && claude
+```
+
+Switching back later is just `cd /workspace/<repo> && claude` — nothing to
+re-clone.

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -107,17 +107,20 @@ spec:
 
   # 2. Samba — SMB/CIFS network shares with per-user authentication.
   #
-  # Per-user accounts are synced from LLDAP into Samba's tdbsam DB by
+  # Per-user accounts are synced from LLDAP into Samba's passdb by
   # ServiceBay's /api/system/file-share/samba/users endpoint and managed
-  # operator-side via Settings → Integrations → File Share. Samba can't
-  # speak OIDC, so the password lives in tdbsam — set/regenerated from
-  # the UI, deliberately not derived from the LLDAP password (Argon2/
-  # bcrypt → NT-hash is not a reversible operation).
+  # operator-side via Settings → Integrations → File Share. (This image
+  # ships `passdb backend = smbpasswd`, not tdbsam — sambaSync.ts drives
+  # it via the smbpasswd/pdbedit CLIs, which are backend-agnostic, and
+  # provisions the POSIX user smbpasswd -a needs.) Samba can't speak
+  # OIDC, so the password lives in the passdb — set/regenerated from the
+  # UI, deliberately not derived from the LLDAP password (Argon2/bcrypt →
+  # NT-hash is not a reversible operation).
   #
   # SHARE_USER + SHARE_PASSWORD remain as a legacy fallback so existing
   # installs keep working until the operator migrates family members
   # onto LLDAP-backed Samba accounts. The share config no longer pins
-  # `valid users` to a single name — any tdbsam user can mount.
+  # `valid users` to a single name — any passdb user can mount.
   - name: samba
     image: docker.io/servercontainers/samba:latest
     env:

--- a/templates/file-share/user-guide.md
+++ b/templates/file-share/user-guide.md
@@ -21,7 +21,7 @@ cards:
         description: "Point your phone camera at this QR to download the BasicSync app (a trusted, open-source Syncthing client). Step 1: install it. Then use the pairing QR below to connect."
       - kind: "syncthing_qr"
         label: "Pair this device"
-        description: "Shows a QR code with the home server's device ID. In BasicSync, tap \"Add Device → Scan QR\" to pick it up directly. Step 2 — after BasicSync is installed."
+        description: "Shows a QR code with the home server's device ID. In BasicSync, tap \"Add Device → Scan QR\" to pick it up directly. Step 2 — after BasicSync is installed. When the server asks where to store a synced folder, use /var/syncthing/Sync/<name> — that's your shared drive (also in Files and the \\\\server\\data network drive). Avoid the default ~/ path and /mnt/data — they're not the shared vault (~/ is config-only; /mnt/data doesn't exist inside the container)."
     recommended_apps:
       - name: "BasicSync"
         url: "/api/system/downloads/basicsync?abi=arm64-v8a"
@@ -76,6 +76,8 @@ BasicSync keeps a folder on your phone in sync with the home server in both dire
 1. **Install the app.** On Android, scan the *Install BasicSync on your phone* QR on the **Syncthing** card (or tap the BasicSync link) — it downloads the APK directly. On iOS, install **Möbius Sync** from the link.
 2. **Pair the device.** Open the **Syncthing** card, tap *Pair this device*, and in BasicSync use *Add Device → Scan QR* to scan it (the QR carries the home server's device ID).
 3. Pick which folders on your phone to sync.
+
+> **Where do synced folders live on the server?** Use `/var/syncthing/Sync/<name>` — that's the shared family drive, the same tree you see in **Files** and the `\\server\data` network drive. When a phone or laptop shares a folder *to* the server, Syncthing prefills the accept-path as `~/<folderid>`; change it to `/var/syncthing/Sync/<name>`. Avoid the `~/` default (that's the config volume — not on Files/Samba and not in the data backup) and `/mnt/data` (it doesn't exist inside the container, so the folder would sync to an empty throwaway dir). This vault is shared with everyone who has file-share access, so keep it for shared, not private, files.
 
 Best for: continuous backup of phone documents, two-way sync between phone and laptop.
 

--- a/tests/backend/sambaSync.test.ts
+++ b/tests/backend/sambaSync.test.ts
@@ -16,9 +16,11 @@ import {
 } from '@/lib/fileShare/sambaSync';
 
 /**
- * Unit coverage for the LLDAP → Samba tdbsam sync (#494). Mocks the
- * agent so `pdbedit -L` / `smbpasswd -a` calls are captured in-process,
- * plus the LLDAP client so the test rig drives both sides.
+ * Unit coverage for the LLDAP → Samba passdb sync (#494/#1630). Mocks the
+ * agent so `getent` / `useradd` / `pdbedit -L` / `smbpasswd -a` calls are
+ * captured in-process, plus the LLDAP client so the test rig drives both
+ * sides. The agent models the container's POSIX accounts so the on-demand
+ * provisioning (#1630) is exercised end-to-end.
  */
 
 interface ExecCall {
@@ -30,10 +32,27 @@ function makeAgent() {
   const calls: ExecCall[] = [];
   const sambaState = new Set<string>();
   const passwords = new Map<string, string>();
+  // POSIX accounts inside the container. smbpasswd -a requires one (#1630),
+  // so ensureSambaPosixUser getent-checks then useradds. Model that here.
+  const posixUsers = new Set<string>();
 
   const sendCommand = vi.fn(async (kind: string, payload: { command: string; stdin?: string }) => {
     if (kind !== 'exec') throw new Error(`unexpected agent command: ${kind}`);
     calls.push({ command: payload.command, stdin: payload.stdin });
+    if (payload.command.includes('getent passwd')) {
+      const match = payload.command.match(/getent passwd ([\w.-]+)/);
+      const user = match?.[1];
+      if (user && posixUsers.has(user)) return { code: 0, stdout: `${user}:x:1000:1000::/:/usr/sbin/nologin`, stderr: '' };
+      return { code: 2, stdout: '', stderr: '' };
+    }
+    if (payload.command.includes('stat -c %g')) {
+      return { code: 0, stdout: '1000\n', stderr: '' };
+    }
+    if (payload.command.includes('useradd')) {
+      const match = payload.command.match(/useradd .*?([\w.-]+)$/);
+      if (match) posixUsers.add(match[1]);
+      return { code: 0, stdout: '', stderr: '' };
+    }
     if (payload.command.includes('pdbedit -L')) {
       const lines = [...sambaState].map(u => `${u}:1000:${u}`).join('\n');
       return { code: 0, stdout: lines, stderr: '' };
@@ -58,7 +77,7 @@ function makeAgent() {
   });
 
   vi.mocked(agentManager.ensureAgent).mockResolvedValue({ sendCommand } as never);
-  return { calls, sambaState, passwords };
+  return { calls, sambaState, passwords, posixUsers };
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## What
Batch of six themed changes: saved-credential rows now render public-subdomain clickable URLs plus a Vaultwarden import deep-link; portal setup assets (Syncthing QR / iOS profile / ABS deeplink) accept a valid SSO session in public mode; Samba password provisioning creates the POSIX user before `smbpasswd -a`; the two per-service restore code-paths are unified onto one engine; and two template user-guides (claude-dev portal card, Syncthing folder-path guidance) are added.

## Why
Closes #1626
Closes #1627
Closes #1628
Closes #1630
Closes #1610
Closes #1619
Closes #1629

## Risk
medium — #1610 unifies the restore engine (config-survival auto-restore path) and #1628 changes the portal asset auth gate; both are path-mandated and box-verified before release.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 338 warnings, net-zero)
- [x] npm run check:arch
- [x] npm test (full — 1904 passed, 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: portal/, systemBackup.ts + externalBackup/restore.ts, settings credentials, samba/file-share)
- [ ] #1610 unified restore engine is REINSTALL-DEFERRED — full verification requires a real FCoS wipe-configs reinstall; :dev box-verify can only confirm the other path-mandated items + that auto-restore wiring isn't obviously broken.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._