### PR TITLE
fix(settings): move Access requests panel from Networking to Security

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/networking/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/networking/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import AccessRequestsSection from '../_lib/sections/AccessRequestsSection';
 import GatewaySection from '../_lib/sections/GatewaySection';
 import PortalAccessSection from '../_lib/sections/PortalAccessSection';
 import PublicDomainSection from '../_lib/sections/PublicDomainSection';
@@ -13,7 +12,6 @@ export default function NetworkingSettingsPage() {
       <ReverseProxySection />
       <GatewaySection />
       <PortalAccessSection />
-      <AccessRequestsSection />
     </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/security/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/security/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AccessRequestsSection from '../_lib/sections/AccessRequestsSection';
 import ApiTokensSection from '../_lib/sections/ApiTokensSection';
 import CredentialsSection from '../_lib/sections/CredentialsSection';
 import McpSection from '../_lib/sections/McpSection';
@@ -8,6 +9,7 @@ import PendingSkillsSection from '../_lib/sections/PendingSkillsSection';
 export default function SecuritySettingsPage() {
   return (
     <>
+      <AccessRequestsSection />
       <CredentialsSection />
       <ApiTokensSection />
       <McpSection />


### PR DESCRIPTION
Closes #1605.

## What
Moves the **Access requests** panel from **Settings → Networking** to **Settings → Security**. Approving a request provisions the user in LLDAP and opens their group assignment — that's identity provisioning, not network access, so it belongs next to the other identity/auth controls.

## Decision: PortalAccessSection stays on Networking
The issue asked to consider whether `PortalAccessSection` (who may *reach* `/portal`) should move too. It stays on **Networking** — it's a LAN reachability gate, a genuine network concern. Only `AccessRequestsSection` (approve → LLDAP provision) moves.

## Scope
- `settings/networking/page.tsx` — remove `AccessRequestsSection` import + render
- `settings/security/page.tsx` — add it (rendered first, above Credentials)
- No behaviour/API change — same component, same approve→provision flow.

eslint clean, `check:arch` clean. `AccessRequestsSection` is self-contained (no networking-page dependency).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._