### PR TITLE
chore(autoloop): dependency-update PRs as one standing queue unit

### DIFF
--- a/.claude/skills/autoloop-issues/stages/builder.md
+++ b/.claude/skills/autoloop-issues/stages/builder.md
@@ -54,6 +54,12 @@ A security/sensitive unit rides the batch **like any other unit** — implement 
 ### Lint-sweep unit
 Implement the one file/rule named in the unit. Size guard: **≤2 source files** (+ their `*.test.*`), **≤120 LOC net** (subtractive can be larger), one warning class or one file. If even a bite-size extraction won't fit, park it in `blocked[]` with a structured entry (`{file, blocked_by:"decomposition", reason:"lint-sweep size guard exceeded; needs decomposition ticket", since}`) and return. Lint-sweep commits ride the batch branch like any other unit (no `Closes #`). Append `{file, rule}` context to `lint_sweep[]` at seal time.
 
+### Dep-update unit (`kind:"dep-updates"`)
+**Does NOT ride the batch branch** — Dependabot PRs are independent, already-CI'd PRs. Don't touch `batch`; process them directly, then mark the unit done. For each open `gh pr list --author app/dependabot --state open --json number,title,headRefName,mergeStateStatus`:
+- **Merge** (`gh pr merge <N> --merge --delete-branch`) when CI is green (`mergeStateStatus == CLEAN`) **and** it's a **dev-dependency** (`deps-dev`) or a **CI/github-actions** bump — low blast radius; green CI = lint/build/test pass.
+- **HOLD** (don't merge) + add `{issue:<N>, question, comment_url, since}` to `needs_refinement[]` with a one-line comment (AI marker) for: (a) `googleapis/release-please-action` or anything that changes the release pipeline this repo depends on, (b) a **runtime** (non-dev) dependency major bump, (c) red/`UNSTABLE`/`DIRTY` CI.
+- These merges land on `main` and trigger release-please on their own (dev-dep/action bumps aren't path-mandated → no `box_verify`). Set the unit `status:"built"` (nothing to seal), append `{unit:"dep-update-sweep", merged:[…], held:[…]}` to `completed[]`. Return one line: merged #s + held #s. Idempotent — next run handles whatever's still open.
+
 ---
 
 ## Mode: `seal` — ship the accumulated batch (expensive pipeline, once)

--- a/.claude/skills/autoloop-issues/stages/planner.md
+++ b/.claude/skills/autoloop-issues/stages/planner.md
@@ -80,6 +80,19 @@ A unit sorts into the highest-priority bucket any member would land in:
 4. `docs` / `documentation`
 5. everything else, ascending issue number.
 
+## Step 4.5 — Dependency-update PRs (always, exactly ONE unit)
+
+Dependabot opens one PR per dependency (`servicebay` runs it for npm/gomod/github-actions, #1549). Left alone they pile up. **Every run**, check `gh pr list --author app/dependabot --state open --json number`: if any are open and no `dep-updates` unit is already in `queue[]`/`batch.units`, enqueue **exactly one** unit covering all of them — never one-per-PR:
+
+```
+{ id:"dep-update-sweep", kind:"dep-updates", issues:[], theme:"dependency-update PR sweep",
+  region:"(dependabot PRs)", scope:"merge CI-green dev-dep/CI-action bumps; hold risky ones",
+  acceptance:"green safe bumps merged; release-pipeline/runtime-major/red ones held for review",
+  gate:"normal", security:false, status:"planned", pr:null, notes:"<count> open dependabot PRs" }
+```
+
+This is real maintenance work, not dry-queue filler — enqueue it whenever Dependabot PRs are open, alongside (not instead of) real issues. The builder handles it per §Dep-update unit in `builder.md` (it does NOT ride the batch branch).
+
 ## Step 5 — Queue empty? Choose a filler track
 
 If no build-ready survivors remain, **do not exit and do not auto-default to lint.** Pick one:


### PR DESCRIPTION
Adds a standing `dep-updates` unit to the autoloop: the planner enqueues exactly one (when Dependabot PRs are open), the builder merges CI-green dev-dep/CI-action bumps and holds release-pipeline/runtime-major/red ones for review. Playbook-only change (.claude/skills).

Per user request — dependency updates as one queue item.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._