### PR TITLE
feat(health,portal): per-type alert failureThreshold + portal service status badge

### DIFF
--- a/packages/backend/src/lib/health/alertDecision.test.ts
+++ b/packages/backend/src/lib/health/alertDecision.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Alert-decision threshold tests (#1651).
+ *
+ * A check must see N consecutive fails before it alerts, and may only
+ * "recover" if a fail alert was actually sent. N is a per-type default
+ * (overridable per check). See `alertDecision.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  decideAlert,
+  getFailureThreshold,
+  countConsecutiveFails,
+  DEFAULT_FAILURE_THRESHOLDS,
+  FALLBACK_FAILURE_THRESHOLD,
+} from './alertDecision';
+import { CheckConfig, CheckResult, CheckType } from './types';
+
+function check(type: CheckType, overrides: Partial<CheckConfig> = {}): CheckConfig {
+  return {
+    id: 'c1',
+    name: 'test',
+    type,
+    target: 'x',
+    interval: 60,
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/** Build a newest-first history from a status string like 'ffo' (fail,fail,ok). */
+function history(statuses: string): CheckResult[] {
+  return statuses.split('').map((s, i) => ({
+    check_id: 'c1',
+    timestamp: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+    status: s === 'f' ? 'fail' : 'ok',
+  }));
+}
+
+describe('getFailureThreshold', () => {
+  it('uses per-type defaults', () => {
+    expect(getFailureThreshold(check('domain'))).toBe(3);
+    expect(getFailureThreshold(check('dns_routing'))).toBe(3);
+    expect(getFailureThreshold(check('http'))).toBe(3);
+    expect(getFailureThreshold(check('ping'))).toBe(3);
+    expect(getFailureThreshold(check('service'))).toBe(2);
+    expect(getFailureThreshold(check('podman'))).toBe(2);
+    expect(getFailureThreshold(check('systemd'))).toBe(2);
+    expect(getFailureThreshold(check('backup'))).toBe(1);
+    expect(getFailureThreshold(check('cert_expiry'))).toBe(1);
+    expect(getFailureThreshold(check('cert_request_failure'))).toBe(1);
+  });
+
+  it('falls back for a type without an explicit default', () => {
+    expect(getFailureThreshold(check('script'))).toBe(FALLBACK_FAILURE_THRESHOLD);
+    expect(DEFAULT_FAILURE_THRESHOLDS.script).toBeUndefined();
+  });
+
+  it('honours a per-check override over the type default', () => {
+    expect(getFailureThreshold(check('domain', { failureThreshold: 1 }))).toBe(1);
+    expect(getFailureThreshold(check('backup', { failureThreshold: 5 }))).toBe(5);
+  });
+
+  it('ignores invalid overrides (<1 or non-integer) and uses the default', () => {
+    expect(getFailureThreshold(check('domain', { failureThreshold: 0 }))).toBe(3);
+    expect(getFailureThreshold(check('domain', { failureThreshold: -2 }))).toBe(3);
+    expect(getFailureThreshold(check('domain', { failureThreshold: 2.7 }))).toBe(2);
+  });
+});
+
+describe('countConsecutiveFails', () => {
+  it('counts the leading fail streak (newest-first)', () => {
+    expect(countConsecutiveFails(history('fffo'))).toBe(3);
+    expect(countConsecutiveFails(history('off'))).toBe(0);
+    expect(countConsecutiveFails(history(''))).toBe(0);
+    expect(countConsecutiveFails(history('f'))).toBe(1);
+  });
+});
+
+describe('decideAlert — failure threshold (#1651)', () => {
+  it('does NOT alert on a single fail for a domain check (threshold 3)', () => {
+    const d = decideAlert(check('domain'), history('fo'));
+    expect(d.alertFailure).toBe(false);
+  });
+
+  it('does NOT alert on the second consecutive fail (still below threshold 3)', () => {
+    const d = decideAlert(check('domain'), history('ffo'));
+    expect(d.alertFailure).toBe(false);
+  });
+
+  it('alerts exactly on the third consecutive fail', () => {
+    const d = decideAlert(check('domain'), history('fffo'));
+    expect(d.alertFailure).toBe(true);
+  });
+
+  it('fires the failure alert only once — not on the 4th/5th fail', () => {
+    expect(decideAlert(check('domain'), history('ffffo')).alertFailure).toBe(false);
+    expect(decideAlert(check('domain'), history('fffffo')).alertFailure).toBe(false);
+  });
+
+  it('backup/cert checks alert on the first fail (threshold 1)', () => {
+    expect(decideAlert(check('backup'), history('f')).alertFailure).toBe(true);
+    expect(decideAlert(check('cert_expiry'), history('fo')).alertFailure).toBe(true);
+  });
+
+  it('service checks alert on the second fail (threshold 2)', () => {
+    expect(decideAlert(check('service'), history('fo')).alertFailure).toBe(false);
+    expect(decideAlert(check('service'), history('ffo')).alertFailure).toBe(true);
+  });
+
+  it('a per-check override of 1 restores legacy first-fail behaviour', () => {
+    expect(decideAlert(check('domain', { failureThreshold: 1 }), history('fo')).alertFailure).toBe(true);
+  });
+});
+
+describe('decideAlert — recovery (#1651)', () => {
+  it('does NOT recover if no fail alert was ever sent (single flaky fail)', () => {
+    // domain threshold 3: one fail then ok → never alerted → no recovery.
+    const d = decideAlert(check('domain'), history('off'.replace('ff', 'f') /* 'of' */));
+    expect(d.alertRecovery).toBe(false);
+  });
+
+  it('does NOT recover when the prior fail streak was below threshold', () => {
+    // 2 fails (below 3) then ok → no alert was sent → no recovery email.
+    const d = decideAlert(check('domain'), history('off'));
+    expect(d.alertRecovery).toBe(false);
+  });
+
+  it('recovers when the prior fail streak had reached the threshold', () => {
+    // 3 fails (alerted) then ok → recovery fires.
+    const d = decideAlert(check('domain'), history('offf'));
+    expect(d.alertRecovery).toBe(true);
+    expect(d.alertFailure).toBe(false);
+  });
+
+  it('recovers a backup check after its single-fail alert', () => {
+    expect(decideAlert(check('backup'), history('of')).alertRecovery).toBe(true);
+  });
+
+  it('does not double-recover (second ok after recovery)', () => {
+    // 'ooff…' newest-first: current ok, prev ok → prior fail streak 0.
+    expect(decideAlert(check('domain'), history('ooffff')).alertRecovery).toBe(false);
+  });
+
+  it('first-ever result (ok, no history) does nothing', () => {
+    const d = decideAlert(check('domain'), history('o'));
+    expect(d.alertFailure).toBe(false);
+    expect(d.alertRecovery).toBe(false);
+  });
+
+  it('empty history is inert', () => {
+    expect(decideAlert(check('domain'), [])).toEqual({ alertFailure: false, alertRecovery: false });
+  });
+});

--- a/packages/backend/src/lib/health/alertDecision.ts
+++ b/packages/backend/src/lib/health/alertDecision.ts
@@ -1,0 +1,109 @@
+import { CheckConfig, CheckResult, CheckType } from './types';
+
+/**
+ * Alert-decision logic for health checks (#1651, epic #1650 item A).
+ *
+ * A health check used to email on its very first `ok → fail` tick, so a
+ * single flaky poll (transient DNS, a one-tick timeout) produced a
+ * "Check Failed" email immediately followed by "Recovered" — pure noise.
+ *
+ * The decision now requires N **consecutive** `fail` results before a
+ * check is considered "alerting", where N is a per-type default (or an
+ * optional per-check override). Recovery only alerts if a fail alert was
+ * actually sent for the current failure streak — we never "recover"
+ * something that never alerted.
+ *
+ * Kept as a pure function (no I/O, no side effects) so it stays cheap to
+ * unit-test and easy to extend: #1652 (root-cause / cascade suppression)
+ * layers its decision on top of this same `AlertDecision` shape.
+ */
+
+/**
+ * Consecutive `fail` results required before a check alerts, by type.
+ *
+ *   - domain / dns_routing / http / ping = 3 — network probes are the
+ *     flakiest (a single dropped packet or DoH hiccup is noise).
+ *   - service / podman / systemd = 2 — local container/unit state; a
+ *     one-tick blip during a restart shouldn't page, but two in a row is real.
+ *   - backup / cert_expiry / cert_request_failure = 1 — these are not
+ *     transient by nature (a missed backup or an expiring cert is true
+ *     the instant it's observed), so alert immediately.
+ */
+export const DEFAULT_FAILURE_THRESHOLDS: Partial<Record<CheckType, number>> = {
+  domain: 3,
+  dns_routing: 3,
+  http: 3,
+  ping: 3,
+  service: 2,
+  podman: 2,
+  systemd: 2,
+  backup: 1,
+  cert_expiry: 1,
+  cert_request_failure: 1,
+};
+
+/**
+ * Fallback for any check type without an explicit default above. Two
+ * consecutive fails is a conservative middle ground — stricter than the
+ * legacy first-tick alert, looser than the noisy network probes.
+ */
+export const FALLBACK_FAILURE_THRESHOLD = 2;
+
+/** Effective threshold for a check: per-check override → per-type default → fallback. */
+export function getFailureThreshold(check: CheckConfig): number {
+  if (typeof check.failureThreshold === 'number' && check.failureThreshold >= 1) {
+    return Math.floor(check.failureThreshold);
+  }
+  return DEFAULT_FAILURE_THRESHOLDS[check.type] ?? FALLBACK_FAILURE_THRESHOLD;
+}
+
+/**
+ * Number of consecutive `fail` results at the head of the history.
+ * `history` is newest-first (HealthStore.getResults unshifts), and
+ * `history[0]` is the just-saved current result.
+ */
+export function countConsecutiveFails(history: CheckResult[]): number {
+  let n = 0;
+  for (const r of history) {
+    if (r.status !== 'fail') break;
+    n++;
+  }
+  return n;
+}
+
+export interface AlertDecision {
+  /** Emit a "Check Failed" alert this tick. */
+  alertFailure: boolean;
+  /** Emit a "Service Recovered" alert this tick. */
+  alertRecovery: boolean;
+}
+
+/**
+ * Decide whether the current tick should fire a failure or recovery alert.
+ *
+ * @param check    the check config (supplies type + optional override)
+ * @param history  persisted results, newest-first, with `history[0]` = the
+ *                 just-saved current result.
+ *
+ * Failure alert fires on the tick where the consecutive-fail streak first
+ * **reaches** the threshold (not on every subsequent fail). Recovery fires
+ * on the first `ok` tick only if the prior streak had reached the
+ * threshold — i.e. a fail alert was actually sent.
+ */
+export function decideAlert(check: CheckConfig, history: CheckResult[]): AlertDecision {
+  const threshold = getFailureThreshold(check);
+  const current = history[0];
+  if (!current) return { alertFailure: false, alertRecovery: false };
+
+  if (current.status === 'fail') {
+    const streak = countConsecutiveFails(history);
+    // Fire exactly once, on the tick the streak hits the threshold.
+    return { alertFailure: streak === threshold, alertRecovery: false };
+  }
+
+  // current.status === 'ok' → potential recovery. Recover only if the
+  // immediately-preceding fail streak had reached the alert threshold
+  // (otherwise no fail alert was ever sent, so there's nothing to recover).
+  const priorFailStreak = countConsecutiveFails(history.slice(1));
+  return { alertFailure: false, alertRecovery: priorFailStreak >= threshold };
+}

--- a/packages/backend/src/lib/health/service.test.ts
+++ b/packages/backend/src/lib/health/service.test.ts
@@ -25,8 +25,19 @@ vi.mock('./serviceHealthBootstrap', () => ({
 // Keep the heavy init paths inert — we're only exercising the
 // twin-subscription branch.
 vi.mock('./init', () => ({ initializeDefaultChecks: vi.fn().mockResolvedValue(undefined) }));
+const { getResultsMock, runMock, sendEmailMock } = vi.hoisted(() => ({
+  getResultsMock: vi.fn((_id: string) => [] as unknown[]),
+  runMock: vi.fn((_check: unknown) => undefined as unknown),
+  sendEmailMock: vi.fn((_subject: string, _message: string) => Promise.resolve()),
+}));
 vi.mock('./store', () => ({
-  HealthStore: { getChecks: () => [], getResults: () => [] },
+  HealthStore: { getChecks: () => [], getResults: (id: string) => getResultsMock(id) },
+}));
+vi.mock('./runner', () => ({
+  CheckRunner: { run: (check: unknown) => runMock(check) },
+}));
+vi.mock('@/lib/email', () => ({
+  sendEmailAlert: (subject: string, message: string) => sendEmailMock(subject, message),
 }));
 vi.mock('./notificationBatcher', () => ({
   NotificationBatcher: { start: vi.fn(), enqueue: () => false },
@@ -36,6 +47,7 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import { HealthService } from './service';
+import type { CheckConfig, CheckResult } from './types';
 import { DigitalTwinStore } from '@/lib/store/twin';
 // Pre-warm the dynamic-import path used by `runServiceHealthBootstrap`
 // so the first listener invocation in a test doesn't race
@@ -133,5 +145,66 @@ describe('HealthService bootstrap-on-sync (#935)', () => {
     await flushMicrotasks();
     expect(bootstrapMock).toHaveBeenCalledTimes(1);
     expect(bootstrapMock).toHaveBeenCalledWith('Local');
+  });
+});
+
+describe('HealthService.runAndEmit alert gating (#1651)', () => {
+  const check: CheckConfig = { id: 'domain:photos', name: 'Photos', type: 'domain' } as CheckConfig;
+  const failResult: CheckResult = { check_id: 'domain:photos', status: 'fail', message: 'down', latency: 0, timestamp: 't' };
+  const okResult: CheckResult = { check_id: 'domain:photos', status: 'ok', message: '', latency: 1, timestamp: 't' };
+  // runAndEmit is a private static; reach it via cast (established pattern below).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const runAndEmit = (c: CheckConfig) => (HealthService as any).runAndEmit(c);
+
+  beforeEach(() => {
+    runMock.mockReset();
+    sendEmailMock.mockReset().mockResolvedValue(undefined);
+    getResultsMock.mockReset().mockReturnValue([]);
+    fakeIo.emit.mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HealthService as any).io = fakeIo;
+  });
+
+  it('does not alert on a single fail below the domain threshold (3)', async () => {
+    runMock.mockResolvedValue(failResult);
+    getResultsMock.mockReturnValue([failResult]); // streak of 1
+    await runAndEmit(check);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(fakeIo.emit).not.toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'error' }));
+    // The silent update still broadcasts.
+    expect(fakeIo.emit).toHaveBeenCalledWith('health:update', { checkId: 'domain:photos', result: failResult });
+  });
+
+  it('alerts (emit + email) on the third consecutive fail', async () => {
+    runMock.mockResolvedValue(failResult);
+    getResultsMock.mockReturnValue([failResult, failResult, failResult]); // streak of 3
+    await runAndEmit(check);
+    expect(fakeIo.emit).toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'error' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock.mock.calls[0][0]).toContain('Photos');
+  });
+
+  it('sends a recovery alert only when a prior fail alert was sent', async () => {
+    runMock.mockResolvedValue(okResult);
+    // ok now, preceded by a fail streak that met the threshold.
+    getResultsMock.mockReturnValue([okResult, failResult, failResult, failResult]);
+    await runAndEmit(check);
+    expect(fakeIo.emit).toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'success' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send a recovery alert when the prior fail never reached the threshold', async () => {
+    runMock.mockResolvedValue(okResult);
+    // ok now, only one prior fail (below the 3 threshold) → no alert was sent.
+    getResultsMock.mockReturnValue([okResult, failResult]);
+    await runAndEmit(check);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(fakeIo.emit).not.toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'success' }));
+  });
+
+  it('swallows a CheckRunner failure without throwing', async () => {
+    runMock.mockRejectedValue(new Error('probe blew up'));
+    await expect(runAndEmit(check)).resolves.toBeUndefined();
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/health/service.ts
+++ b/packages/backend/src/lib/health/service.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger';
 import { HealthStore } from './store';
 import { CheckRunner } from './runner';
 import { CheckConfig, CheckResult } from './types';
+import { decideAlert } from './alertDecision';
 import { initializeDefaultChecks } from './init';
 import { sendEmailAlert } from '@/lib/email';
 import { NotificationBatcher } from './notificationBatcher';
@@ -206,13 +207,15 @@ export class HealthService {
   private static async runAndEmit(check: CheckConfig) {
     try {
       const result = await CheckRunner.run(check);
+      // CheckRunner.run has already persisted `result`, so history is
+      // newest-first with history[0] === result.
       const history = HealthStore.getResults(check.id);
-      const prev = history[1]; // [0] is current
-      const failed = result.status === 'fail';
-      const recovered = result.status === 'ok';
-      const enteredFailure = failed && (!prev || prev.status === 'ok');
-      const recoveredNow = recovered && prev && prev.status === 'fail';
-      
+      // Require N consecutive fails before alerting (#1651); recovery
+      // only fires if a fail alert was actually sent. The decision is a
+      // pure function so it stays testable and extensible (#1652).
+      const { alertFailure: enteredFailure, alertRecovery: recoveredNow } =
+        decideAlert(check, history);
+
       // Emit if we have IO
       if (this.io) {
       // Broadcast update event (silent refresh)

--- a/packages/backend/src/lib/health/types.ts
+++ b/packages/backend/src/lib/health/types.ts
@@ -36,6 +36,15 @@ export interface CheckConfig {
   enabled: boolean;
   created_at: string;
   nodeName?: string; // Optional node name for remote execution
+  /**
+   * Consecutive `fail` results required before this check is considered
+   * "alerting" and emits a failure notification (#1651). A single flaky
+   * poll (transient DNS, a one-tick timeout) shouldn't fire an alert —
+   * we wait for N consecutive fails. Optional per-check override; when
+   * unset, the per-type default ({@link DEFAULT_FAILURE_THRESHOLDS}) is
+   * used. A value of 1 restores the legacy "alert on first fail" behaviour.
+   */
+  failureThreshold?: number;
   // HTTP specific options
   httpConfig?: {
     expectedStatus?: number;

--- a/packages/backend/src/lib/portal/serviceStatus.test.ts
+++ b/packages/backend/src/lib/portal/serviceStatus.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { deriveCardStatus } from './services';
+
+describe('deriveCardStatus (#1654)', () => {
+  it('is unknown when there is no signal', () => {
+    expect(deriveCardStatus({})).toEqual({ status: 'unknown' });
+    // pod active but no health/domain signal yet → still unknown
+    expect(deriveCardStatus({ podActive: true })).toEqual({ status: 'unknown' });
+  });
+
+  it('is down when the pod is explicitly inactive', () => {
+    const r = deriveCardStatus({ podActive: false, twinReady: true, domainOk: true });
+    expect(r.status).toBe('down');
+    expect(r.statusReason).toBe('Not running');
+  });
+
+  it('is down when the domain reachability check is failing', () => {
+    const r = deriveCardStatus({ podActive: true, domainOk: false });
+    expect(r.status).toBe('down');
+    expect(r.statusReason).toBe('Not reachable');
+  });
+
+  it('is down when the only health signal is failing', () => {
+    const r = deriveCardStatus({ podActive: true, twinReady: false });
+    expect(r.status).toBe('down');
+    expect(r.statusReason).toBe('Health check failing');
+  });
+
+  it('is down when every present hard signal fails', () => {
+    const r = deriveCardStatus({ twinReady: false, domainOk: false });
+    expect(r.status).toBe('down');
+    // domain failure wins the reason
+    expect(r.statusReason).toBe('Not reachable');
+  });
+
+  it('is degraded when signals disagree (some healthy, some failing)', () => {
+    const r = deriveCardStatus({ twinReady: true, domainOk: false });
+    expect(r.status).toBe('degraded');
+    expect(r.statusReason).toBe('Partially unhealthy');
+  });
+
+  it('is degraded when the service reports a soft-fail', () => {
+    const r = deriveCardStatus({ twinReady: true, twinDegraded: true, domainOk: true });
+    expect(r.status).toBe('degraded');
+    expect(r.statusReason).toBe('Running in a degraded state');
+  });
+
+  it('is ok when every present signal is healthy', () => {
+    expect(deriveCardStatus({ twinReady: true, domainOk: true })).toEqual({ status: 'ok' });
+    expect(deriveCardStatus({ domainOk: true })).toEqual({ status: 'ok' });
+    expect(deriveCardStatus({ twinReady: true })).toEqual({ status: 'ok' });
+  });
+});

--- a/packages/backend/src/lib/portal/serviceStatus.test.ts
+++ b/packages/backend/src/lib/portal/serviceStatus.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { deriveCardStatus } from './services';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getLastResult = vi.fn();
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: { getLastResult: (id: string) => getLastResult(id) },
+}));
+
+import { deriveCardStatus, hostFromUrl, resolveCardStatus } from './services';
 
 describe('deriveCardStatus (#1654)', () => {
   it('is unknown when there is no signal', () => {
@@ -49,5 +55,67 @@ describe('deriveCardStatus (#1654)', () => {
     expect(deriveCardStatus({ twinReady: true, domainOk: true })).toEqual({ status: 'ok' });
     expect(deriveCardStatus({ domainOk: true })).toEqual({ status: 'ok' });
     expect(deriveCardStatus({ twinReady: true })).toEqual({ status: 'ok' });
+  });
+});
+
+describe('hostFromUrl (#1654)', () => {
+  it('extracts the hostname from a valid URL', () => {
+    expect(hostFromUrl('https://photos.home.arpa/login')).toBe('photos.home.arpa');
+    expect(hostFromUrl('http://192.168.1.10:8080')).toBe('192.168.1.10');
+  });
+
+  it('returns null for null or unparseable input', () => {
+    expect(hostFromUrl(null)).toBeNull();
+    expect(hostFromUrl('not a url')).toBeNull();
+  });
+});
+
+describe('resolveCardStatus (#1654) — signal gathering', () => {
+  beforeEach(() => {
+    getLastResult.mockReset();
+    getLastResult.mockReturnValue(null);
+  });
+
+  const twinMap = (
+    entries: Record<string, { ready: boolean; degraded?: boolean }>,
+  ) => new Map(Object.entries(entries));
+
+  it('is down when the pod is inactive regardless of other signals', () => {
+    getLastResult.mockReturnValue({ status: 'ok' });
+    const r = resolveCardStatus(false, 'immich', 'https://photos.home.arpa', twinMap({ immich: { ready: true } }));
+    expect(r.status).toBe('down');
+    expect(r.statusReason).toBe('Not running');
+  });
+
+  it('reads the twin readiness + domain check by host key', () => {
+    getLastResult.mockReturnValue({ status: 'ok' });
+    const r = resolveCardStatus(true, 'immich', 'https://photos.home.arpa', twinMap({ immich: { ready: true } }));
+    expect(getLastResult).toHaveBeenCalledWith('domain:photos.home.arpa');
+    expect(r.status).toBe('ok');
+  });
+
+  it('is down when the domain reachability check is failing', () => {
+    getLastResult.mockReturnValue({ status: 'fail' });
+    const r = resolveCardStatus(true, 'immich', 'https://photos.home.arpa', twinMap({ immich: { ready: true } }));
+    expect(r.status).toBe('degraded'); // twin ok + domain fail → disagree
+    expect(r.statusReason).toBe('Partially unhealthy');
+  });
+
+  it('surfaces the twin soft-fail (degraded) flag', () => {
+    getLastResult.mockReturnValue({ status: 'ok' });
+    const r = resolveCardStatus(true, 'immich', 'https://photos.home.arpa', twinMap({ immich: { ready: true, degraded: true } }));
+    expect(r.status).toBe('degraded');
+    expect(r.statusReason).toBe('Running in a degraded state');
+  });
+
+  it('does not query the HealthStore when there is no URL', () => {
+    const r = resolveCardStatus(true, 'immich', null, twinMap({ immich: { ready: true } }));
+    expect(getLastResult).not.toHaveBeenCalled();
+    expect(r.status).toBe('ok'); // twin-only signal
+  });
+
+  it('is unknown when no twin entry and no domain result exist', () => {
+    const r = resolveCardStatus(true, 'immich', 'https://photos.home.arpa', twinMap({}));
+    expect(r.status).toBe('unknown');
   });
 });

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -316,7 +316,7 @@ function assemblePortalCard(
 /** Extract the bare host (no scheme/path) from a resolved card URL so we
  *  can look up its `domain:<host>` health check. Returns null for an
  *  empty/appless URL. */
-function hostFromUrl(url: string | null): string | null {
+export function hostFromUrl(url: string | null): string | null {
   if (!url) return null;
   try {
     return new URL(url).hostname;
@@ -328,7 +328,7 @@ function hostFromUrl(url: string | null): string | null {
 /** Gather the per-service status signals from the already-available
  *  stores (the twin's service-health side-map + the HealthStore domain
  *  check) and fold them into a coarse status. */
-function resolveCardStatus(
+export function resolveCardStatus(
   podActive: boolean,
   serviceName: string,
   url: string | null,

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -23,6 +23,8 @@ import fs from 'fs/promises';
 import { getConfig, type AppConfig } from '@/lib/config';
 import { getActiveDomain, getMode } from '@/lib/mode';
 import { ServiceManager } from '@/lib/services/ServiceManager';
+import { getServices } from '@/lib/store/repository';
+import { HealthStore } from '@/lib/health/store';
 import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getTemplateUserGuide } from '@/lib/registry';
@@ -70,6 +72,84 @@ export interface PortalCard {
    *  pairing the operator runs by hand (e.g. `signal-cli link`).
    *  Informational only; the portal shows the command, not a runner. */
   manualPairing: ManualPairing[];
+  /** Coarse up/down status (#1654), derived server-side at page load from
+   *  the signals that already exist: the digital twin's per-service
+   *  health probe (`serviceHealth[node][service].ready`), the auto-created
+   *  domain-reachability check in HealthStore, and pod-active state.
+   *    - `down`     — pod inactive OR the reachability/health probe failing.
+   *    - `degraded` — running but some-but-not-all signals are unhealthy
+   *                   (or the service reports `degraded: true`).
+   *    - `ok`       — every present signal is healthy.
+   *    - `unknown`  — no signal yet (no probe registered, no domain check). */
+  status: PortalCardStatus;
+  /** Optional short reason for a non-ok status. Kept generic — the portal
+   *  is anonymous-readable (LAN), so this carries no sensitive detail. */
+  statusReason?: string;
+}
+
+export type PortalCardStatus = 'ok' | 'degraded' | 'down' | 'unknown';
+
+/** The signals `deriveCardStatus` folds into a coarse status. Each is
+ *  optional — a missing signal contributes nothing (it can't make the
+ *  status worse), so a service with no probe + no domain check is
+ *  `unknown` rather than falsely `down`. */
+export interface CardStatusSignals {
+  /** Pod-active state (`ServiceManager.listServices().active`). */
+  podActive?: boolean;
+  /** The twin's `serviceHealth[node][service].ready` (health poller). */
+  twinReady?: boolean;
+  /** The twin's soft-fail flag — running but `degraded: true`. */
+  twinDegraded?: boolean;
+  /** Last domain-reachability check result (`ok`/`fail`); absent when no
+   *  domain check exists for this card's URL. */
+  domainOk?: boolean;
+}
+
+/**
+ * Fold the available signals into a single coarse {@link PortalCardStatus}
+ * (#1654). Pure — no I/O, so it's unit-testable in isolation.
+ *
+ * Rules:
+ *   - `down`     — pod is explicitly inactive, OR a hard signal (domain
+ *                  reachability / twin readiness) is failing.
+ *   - `degraded` — the service reports `degraded: true`, or the signals
+ *                  disagree (some healthy, some failing) without a hard
+ *                  down.
+ *   - `ok`       — at least one signal is present and every present
+ *                  signal is healthy.
+ *   - `unknown`  — no signal at all.
+ */
+export function deriveCardStatus(
+  signals: CardStatusSignals,
+): { status: PortalCardStatus; statusReason?: string } {
+  // A pod that's explicitly not active is unambiguously down.
+  if (signals.podActive === false) {
+    return { status: 'down', statusReason: 'Not running' };
+  }
+
+  const present: boolean[] = [];
+  if (signals.twinReady !== undefined) present.push(signals.twinReady);
+  if (signals.domainOk !== undefined) present.push(signals.domainOk);
+
+  if (present.length === 0) {
+    return { status: 'unknown' };
+  }
+
+  const anyFail = present.some(ok => !ok);
+  const allFail = present.every(ok => !ok);
+
+  if (allFail) {
+    const reason = signals.domainOk === false ? 'Not reachable' : 'Health check failing';
+    return { status: 'down', statusReason: reason };
+  }
+  if (anyFail) {
+    return { status: 'degraded', statusReason: 'Partially unhealthy' };
+  }
+  // Every present hard signal is healthy — soft-fail still shows degraded.
+  if (signals.twinDegraded) {
+    return { status: 'degraded', statusReason: 'Running in a degraded state' };
+  }
+  return { status: 'ok' };
 }
 
 /** Read a template's variables.json (best-effort, returns empty record on miss).
@@ -211,6 +291,7 @@ function assemblePortalCard(
   url: string | null,
   subdomainVar: string,
   parsedBody: string,
+  status: { status: PortalCardStatus; statusReason?: string },
 ): PortalCard {
   return {
     id: `${serviceName}:${subdomainVar || 'default'}`,
@@ -227,7 +308,41 @@ function assemblePortalCard(
     recommendedApps: def.recommended_apps ?? [],
     setupAssets: def.setup_assets ?? [],
     manualPairing: def.manual_pairing ?? [],
+    status: status.status,
+    ...(status.statusReason ? { statusReason: status.statusReason } : {}),
   };
+}
+
+/** Extract the bare host (no scheme/path) from a resolved card URL so we
+ *  can look up its `domain:<host>` health check. Returns null for an
+ *  empty/appless URL. */
+function hostFromUrl(url: string | null): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/** Gather the per-service status signals from the already-available
+ *  stores (the twin's service-health side-map + the HealthStore domain
+ *  check) and fold them into a coarse status. */
+function resolveCardStatus(
+  podActive: boolean,
+  serviceName: string,
+  url: string | null,
+  twinHealthByService: Map<string, { ready: boolean; degraded?: boolean }>,
+): { status: PortalCardStatus; statusReason?: string } {
+  const twin = twinHealthByService.get(serviceName);
+  const host = hostFromUrl(url);
+  const domainResult = host ? HealthStore.getLastResult(`domain:${host}`) : null;
+  return deriveCardStatus({
+    podActive,
+    twinReady: twin?.ready,
+    twinDegraded: twin?.degraded,
+    domainOk: domainResult ? domainResult.status === 'ok' : undefined,
+  });
 }
 
 /**
@@ -239,6 +354,7 @@ async function buildPortalCardEntry(
   def: PortalCardDef,
   templateLabel: string,
   parsedBody: string,
+  twinHealthByService: Map<string, { ready: boolean; degraded?: boolean }>,
 ): Promise<PortalCard | null> {
   const url = await resolveServiceUrl(config, svc.name, def.subdomain_var || undefined);
   // No subdomain URL: an appless card still renders *iff* the guide
@@ -250,7 +366,8 @@ async function buildPortalCardEntry(
     return null;
   }
   const subdomainVar = def.subdomain_var || (await firstSubdomainVar(svc.name)) || '';
-  return assemblePortalCard(def, svc.name, templateLabel, url, subdomainVar, parsedBody);
+  const status = resolveCardStatus(svc.active, svc.name, url, twinHealthByService);
+  return assemblePortalCard(def, svc.name, templateLabel, url, subdomainVar, parsedBody, status);
 }
 
 /**
@@ -267,6 +384,17 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
   if (running.length === 0) return [];
 
   const config = await getConfig();
+
+  // Snapshot the twin's per-service health once (the side-map is
+  // re-attached onto `services[].health` on every agent sync — see
+  // store/twin.ts). Keyed by service name so each card reads its probe
+  // result without re-walking the node.
+  const twinHealthByService = new Map<string, { ready: boolean; degraded?: boolean }>();
+  for (const unit of getServices(node)) {
+    if (unit.health) {
+      twinHealthByService.set(unit.name, { ready: unit.health.ready, degraded: unit.health.degraded });
+    }
+  }
 
   const cards: PortalCard[] = [];
   for (const svc of running) {
@@ -299,7 +427,7 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
       }];
 
     for (const def of cardDefs) {
-      const card = await buildPortalCardEntry(config, svc, def, templateLabel, parsed.body);
+      const card = await buildPortalCardEntry(config, svc, def, templateLabel, parsed.body, twinHealthByService);
       if (card) cards.push(card);
     }
   }

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -23,6 +23,7 @@ const baseCard: PortalCard = {
   icon: '',
   tagline: 'Auto-backup your family photos.',
   url: 'https://photos.home.arpa',
+  status: 'ok',
   primaryAction: null,
   secondaryActions: [],
   body: '',

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -232,4 +232,43 @@ describe('PortalGrid', () => {
       expect(screen.getByRole('link', { name: /^open$/i })).toBeDefined();
     });
   });
+
+  describe('per-service status badge (#1654)', () => {
+    it('renders no down/degraded badge text when status is ok', () => {
+      render(<PortalGrid cards={[{ ...baseCard, status: 'ok' }]} />);
+      // ok renders a subtle dot (aria-label Online), not a text label.
+      expect(screen.getByLabelText('Online')).toBeDefined();
+      expect(screen.queryByText('Down')).toBeNull();
+      expect(screen.queryByText('Degraded')).toBeNull();
+    });
+
+    it('renders nothing for unknown status', () => {
+      render(<PortalGrid cards={[{ ...baseCard, status: 'unknown' }]} />);
+      expect(screen.queryByLabelText('Online')).toBeNull();
+      expect(screen.queryByText('Down')).toBeNull();
+      expect(screen.queryByText('Degraded')).toBeNull();
+    });
+
+    it('renders a red Down badge with the reason as its tooltip', () => {
+      render(
+        <PortalGrid
+          cards={[{ ...baseCard, status: 'down', statusReason: 'Not reachable' }]}
+        />,
+      );
+      const badge = screen.getByText('Down');
+      expect(badge).toBeDefined();
+      expect(badge.closest('span')?.getAttribute('title')).toBe('Not reachable');
+    });
+
+    it('renders an amber Degraded badge', () => {
+      render(
+        <PortalGrid
+          cards={[{ ...baseCard, status: 'degraded', statusReason: 'Partially unhealthy' }]}
+        />,
+      );
+      const badge = screen.getByText('Degraded');
+      expect(badge).toBeDefined();
+      expect(badge.closest('span')?.getAttribute('title')).toBe('Partially unhealthy');
+    });
+  });
 });

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -171,7 +171,10 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                 lands at the same Y on every card in a row. */}
             <div className="p-6 pb-3">
               <CardIcon card={card} />
-              <h2 className="text-xl font-bold text-gray-900 dark:text-white">{card.label}</h2>
+              <div className="flex items-center gap-2">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">{card.label}</h2>
+                <StatusBadge status={card.status} reason={card.statusReason} />
+              </div>
               <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-3 min-h-[3.75rem]">
                 {card.tagline ?? ''}
               </p>
@@ -297,6 +300,44 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
       <CardHelpModal card={activeCard} onClose={() => setActiveCardId(null)} />
     )}
     </>
+  );
+}
+
+/**
+ * Per-service up/down badge (#1654). Server-derived at page load from
+ * the twin health probe + domain reachability check + pod-active state.
+ *   - down     → red dot + "Down"
+ *   - degraded → amber dot + "Degraded"
+ *   - ok       → quiet green dot, no label (the default healthy state
+ *                shouldn't shout — only problems draw the eye).
+ *   - unknown  → nothing (no signal yet — don't imply a verdict).
+ * The portal is anonymous-readable (LAN), so the badge is a bare
+ * up/down indicator; `reason` is a short generic title, no internals.
+ */
+function StatusBadge({ status, reason }: { status: PortalCard['status']; reason?: string }) {
+  if (status === 'unknown') return null;
+  if (status === 'ok') {
+    return (
+      <span
+        title={reason ?? 'Online'}
+        className="inline-block w-2 h-2 rounded-full bg-emerald-500 shrink-0"
+        aria-label="Online"
+      />
+    );
+  }
+  const isDown = status === 'down';
+  const classes = isDown
+    ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300'
+    : 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300';
+  const dot = isDown ? 'bg-red-500' : 'bg-amber-500';
+  return (
+    <span
+      title={reason ?? (isDown ? 'Down' : 'Degraded')}
+      className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded shrink-0 ${classes}`}
+    >
+      <span className={`inline-block w-1.5 h-1.5 rounded-full ${dot}`} />
+      {isDown ? 'Down' : 'Degraded'}
+    </span>
   );
 }
 


### PR DESCRIPTION
## What
- Health: add per-type `CheckConfig.failureThreshold` (domain/dns/http/ping=3, service/podman/systemd=2, backup/cert=1); alert only after N consecutive fails, recovery only if a fail alert was previously sent.
- Portal: derive a per-service `status` ('ok'|'degraded'|'down'|'unknown') and render a small status badge on each portal card (v1 server-rendered at page load, anonymous-readable).

## Why
Closes #1651
Closes #1654

## Risk
Low — health alerting gains a consecutive-fail gate (no false-quiet for sustained fails); portal badge is additive UI derived from existing twin/health state.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 338 warnings — baseline)
- [x] npm run check:arch
- [x] npm test (full — 1932 passed, 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: packages/frontend/src/app/portal/)