### PR TITLE
feat(health): root-cause-only alerting + service-centered causal-chain email

### DIFF
--- a/packages/backend/src/lib/health/notificationBatcher.test.ts
+++ b/packages/backend/src/lib/health/notificationBatcher.test.ts
@@ -147,3 +147,44 @@ describe('NotificationBatcher', () => {
     expect(NotificationBatcher.enqueue('fail', check('auth'), result('fail'))).toBe(false);
   });
 });
+
+describe('NotificationBatcher root-cause coalescing (#1652)', () => {
+  function svc(name: string): CheckConfig {
+    return { id: `svc-${name}`, name: `Service: ${name}`, type: 'service', target: name, interval: 60, enabled: true, created_at: 't' };
+  }
+  function domain(id: string, target: string): CheckConfig {
+    return { id, name: `Domain — ${id}`, type: 'domain', target, interval: 60, enabled: true, created_at: 't', domainConfig: { expectedScheme: 'https', isPublic: true } };
+  }
+  const gateway: CheckConfig = { id: 'gw', name: 'Internet Gateway', type: 'ping', target: '192.168.178.1', interval: 60, enabled: true, created_at: 't' };
+
+  it('digest collapses the restart cascade to root failures only when the graph is wired', async () => {
+    const serviceDeps = new Map<string, string[]>([
+      ['authelia', []], ['immich', ['authelia']],
+    ]);
+    NotificationBatcher.setRootCauseResolution({
+      serviceDeps,
+      hosts: [{ domain: 'photos.dopp.cloud', service: 'immich', forwardPort: 1, created: true }],
+    });
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    // Whole cascade fails at boot: gateway + Authelia + the photos domain.
+    NotificationBatcher.enqueue('fail', gateway, result('fail'));
+    NotificationBatcher.enqueue('fail', svc('authelia'), result('fail'));
+    NotificationBatcher.enqueue('fail', domain('domain:photos', 'photos.dopp.cloud'), result('fail'));
+    await NotificationBatcher.flush('manual');
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    const body = sendEmailAlertMock.mock.calls[0][1];
+    // Only the gateway (the deepest root) survives; downstream symptoms drop.
+    expect(body).toContain('Internet Gateway');
+    expect(body).not.toContain('photos.dopp.cloud');
+  });
+
+  it('without a wired graph the digest lists every still-failing check (legacy)', async () => {
+    NotificationBatcher.start({ maxMs: 10_000, settleMs: 50 });
+    NotificationBatcher.enqueue('fail', gateway, result('fail'));
+    NotificationBatcher.enqueue('fail', svc('authelia'), result('fail'));
+    await NotificationBatcher.flush('manual');
+    const body = sendEmailAlertMock.mock.calls[0][1];
+    expect(body).toContain('Internet Gateway');
+    expect(body).toContain('Service: authelia');
+  });
+});

--- a/packages/backend/src/lib/health/notificationBatcher.ts
+++ b/packages/backend/src/lib/health/notificationBatcher.ts
@@ -25,6 +25,11 @@
 import type { CheckConfig, CheckResult } from './types';
 import { logger } from '@/lib/logger';
 import { sendEmailAlert } from '@/lib/email';
+import {
+  isRootCause,
+  makePrerequisiteContext,
+  type ServiceDependencyMap,
+} from './prerequisiteChecks';
 
 /** Hard cap on how long we'll hold alerts after boot. Covers the
  *  longest cold-start envelope (NPM + AdGuard + auth pods) plus a
@@ -81,6 +86,26 @@ export class NotificationBatcher {
    *  it — the timer callbacks fire-and-forget. */
   private static flushInFlight: Promise<void> | null = null;
 
+  /**
+   * Root-cause inputs (#1652). Injected by `HealthService.init` so the
+   * boot digest collapses a restart cascade to root failures only — the
+   * same resolution the steady-state alert path uses — without the
+   * batcher importing the registry/config layer directly. When unset the
+   * digest falls back to listing every still-failing check (legacy).
+   */
+  private static serviceDeps: ServiceDependencyMap | null = null;
+  private static hosts: import('../config').ProxyHostEntry[] = [];
+
+  /** Wire the root-cause graph for the boot digest. Called once from
+   *  `HealthService.init` after the dependency graph is built. */
+  static setRootCauseResolution(input: {
+    serviceDeps: ServiceDependencyMap;
+    hosts: import('../config').ProxyHostEntry[];
+  }): void {
+    this.serviceDeps = input.serviceDeps;
+    this.hosts = input.hosts;
+  }
+
   /** Initialise the grace window. Called from `HealthService.init`
    *  once per server start. Repeated calls are no-ops so HMR
    *  reloads in dev don't reset the timer. */
@@ -136,7 +161,15 @@ export class NotificationBatcher {
     // fail (its last observed state).
     const finalState = new Map<string, PendingAlert>();
     for (const a of this.pending) finalState.set(a.check.id, a);
-    const stillFailing = [...finalState.values()].filter(a => a.kind === 'fail');
+    const allFailing = [...finalState.values()].filter(a => a.kind === 'fail');
+    // Root-cause coalescing (#1652): a reboot/internet blip floods the
+    // buffer with the whole cascade. If the dependency graph is wired,
+    // keep only the roots — a check whose prerequisite is also in the
+    // failing set is a downstream symptom, named by its root's chain, not
+    // a separate digest line. Treat the buffered fail set as the "currently
+    // failing" universe (during boot the live per-check status hasn't
+    // settled, so the buffer is the better signal).
+    const stillFailing = this.coalesceToRoots(allFailing);
 
     const total = this.pending.length;
     this.pending = [];
@@ -174,6 +207,24 @@ export class NotificationBatcher {
     }
   }
 
+  /** Collapse a buffered fail set to root causes only (#1652). When the
+   *  dependency graph isn't wired, returns the input unchanged (legacy
+   *  behaviour). The failing universe is the buffer itself. */
+  private static coalesceToRoots(failing: PendingAlert[]): PendingAlert[] {
+    if (!this.serviceDeps || failing.length <= 1) return failing;
+    const failingIds = new Set(failing.map(a => a.check.id));
+    const ctx = makePrerequisiteContext({
+      checks: failing.map(a => a.check),
+      serviceDeps: this.serviceDeps,
+      config: { reverseProxy: { hosts: this.hosts } },
+      isFailing: (id: string) => failingIds.has(id),
+    });
+    const roots = failing.filter(a => isRootCause(a.check, ctx));
+    // Defensive: never collapse to nothing (a pure cycle would) — fall
+    // back to the full set so the operator always gets the digest.
+    return roots.length > 0 ? roots : failing;
+  }
+
   /** Test-only: reset module state so each test starts clean. */
   static _resetForTesting(): void {
     if (this.settleTimer) clearTimeout(this.settleTimer);
@@ -182,6 +233,8 @@ export class NotificationBatcher {
     this.maxGraceTimer = null;
     this.pending = [];
     this.active = false;
+    this.serviceDeps = null;
+    this.hosts = [];
   }
 
   /** Test-only: peek at the pending buffer. */

--- a/packages/backend/src/lib/health/prerequisiteChecks.test.ts
+++ b/packages/backend/src/lib/health/prerequisiteChecks.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildServiceDependencyMap,
+  makePrerequisiteContext,
+  resolvePrerequisiteChecks,
+  resolvePrerequisitesTransitive,
+  isRootCause,
+  enumerateDownstreamFailing,
+  renderCausalChainEmail,
+  type ServiceDependencyMap,
+} from './prerequisiteChecks';
+import type { CheckConfig, CheckResult } from './types';
+import type { ProxyHostEntry } from '../config';
+
+const chk = (over: Partial<CheckConfig> & Pick<CheckConfig, 'id' | 'type'>): CheckConfig => ({
+  name: over.id,
+  target: '',
+  interval: 60,
+  enabled: true,
+  created_at: 't',
+  ...over,
+});
+
+// Mirror the real topology: gateway ping, NPM, Authelia container, two
+// public-domain feature services (immich, vaultwarden) each fronted by SSO.
+const gateway = chk({ id: 'gw', type: 'ping', name: 'Internet Gateway', target: '192.168.178.1' });
+const npmAuth = chk({ id: 'npm_auth', type: 'npm_auth', target: 'Local', name: 'NPM admin auth' });
+const autheliaSvc = chk({ id: 'svc-authelia', type: 'service', target: 'authelia', name: 'Service: authelia' });
+const immichSvc = chk({ id: 'svc-immich', type: 'service', target: 'immich', name: 'Service: immich' });
+const immichDomain = chk({
+  id: 'domain:photos.dopp.cloud', type: 'domain', target: 'photos.dopp.cloud', name: 'Domain — photos',
+  domainConfig: { expectedScheme: 'https', isPublic: true },
+});
+const vaultDomain = chk({
+  id: 'domain:vault.dopp.cloud', type: 'domain', target: 'vault.dopp.cloud', name: 'Domain — vault',
+  domainConfig: { expectedScheme: 'https', isPublic: true },
+});
+
+const hosts: ProxyHostEntry[] = [
+  { domain: 'photos.dopp.cloud', service: 'immich', forwardPort: 1, created: true },
+  { domain: 'vault.dopp.cloud', service: 'vaultwarden', forwardPort: 2, created: true },
+];
+
+const serviceDeps: ServiceDependencyMap = buildServiceDependencyMap([
+  { name: 'authelia', tier: 'infrastructure' },
+  { name: 'nginx', tier: 'infrastructure' },
+  { name: 'immich', tier: 'feature', dependencies: [] },
+  { name: 'vaultwarden', tier: 'feature', dependencies: [] },
+]);
+
+const allChecks = [gateway, npmAuth, autheliaSvc, immichSvc, immichDomain, vaultDomain];
+
+const ctxWith = (failingIds: string[]) =>
+  makePrerequisiteContext({
+    checks: allChecks,
+    serviceDeps,
+    config: { reverseProxy: { hosts } },
+    isFailing: (id) => failingIds.includes(id),
+  });
+
+describe('buildServiceDependencyMap', () => {
+  it('gives every feature an implicit edge to every infra stack', () => {
+    expect(serviceDeps.get('immich')?.sort()).toEqual(['authelia', 'nginx']);
+    expect(serviceDeps.get('authelia')).toEqual([]); // infra has no implicit edges
+  });
+});
+
+describe('resolvePrerequisiteChecks', () => {
+  it('maps a public domain → gateway + NPM + Authelia + its container + dep containers', () => {
+    const prereqs = resolvePrerequisiteChecks(immichDomain, ctxWith([]));
+    expect(prereqs).toContain('gw');           // internet (technical edge)
+    expect(prereqs).toContain('npm_auth');     // public domain → NPM
+    expect(prereqs).toContain('svc-authelia'); // SSO + infra dep
+    expect(prereqs).toContain('svc-immich');   // its own container
+    expect(prereqs).not.toContain(immichDomain.id);
+  });
+
+  it('npm_auth depends on Authelia', () => {
+    expect(resolvePrerequisiteChecks(npmAuth, ctxWith([]))).toContain('svc-authelia');
+  });
+
+  it('the gateway ping has no prerequisites (it is a true root)', () => {
+    expect(resolvePrerequisiteChecks(gateway, ctxWith([]))).toEqual([]);
+  });
+});
+
+describe('isRootCause', () => {
+  it('a domain check is NOT a root when the gateway is also failing', () => {
+    expect(isRootCause(immichDomain, ctxWith(['gw', immichDomain.id]))).toBe(false);
+  });
+
+  it('the gateway IS the root when everything downstream is failing', () => {
+    expect(isRootCause(gateway, ctxWith(['gw', immichDomain.id, vaultDomain.id]))).toBe(true);
+  });
+
+  it('a domain check IS a root when no prerequisite is failing', () => {
+    expect(isRootCause(immichDomain, ctxWith([immichDomain.id]))).toBe(true);
+  });
+
+  it('Authelia is the root, the SSO domains are suppressed', () => {
+    const ctx = ctxWith(['svc-authelia', immichDomain.id, vaultDomain.id]);
+    expect(isRootCause(autheliaSvc, ctx)).toBe(true);
+    expect(isRootCause(immichDomain, ctx)).toBe(false);
+    expect(isRootCause(vaultDomain, ctx)).toBe(false);
+  });
+});
+
+describe('cycle safety', () => {
+  it('does not loop on a self/mutual cycle', () => {
+    const a = chk({ id: 'a', type: 'service', target: 'a' });
+    const b = chk({ id: 'b', type: 'service', target: 'b' });
+    const cyclic: ServiceDependencyMap = new Map([['a', ['b']], ['b', ['a']]]);
+    const ctx = makePrerequisiteContext({
+      checks: [a, b], serviceDeps: cyclic, config: undefined, isFailing: () => true,
+    });
+    expect(() => resolvePrerequisitesTransitive(a, ctx)).not.toThrow();
+    expect(resolvePrerequisitesTransitive(a, ctx).has('b')).toBe(true);
+    expect(() => isRootCause(a, ctx)).not.toThrow();
+  });
+});
+
+describe('enumerateDownstreamFailing + renderCausalChainEmail', () => {
+  it('walks edges downward from the gateway to the failing leaf services', () => {
+    const ctx = ctxWith(['gw', immichDomain.id, vaultDomain.id]);
+    const downstream = enumerateDownstreamFailing('gw', ctx).map(c => c.id);
+    expect(downstream).toContain(immichDomain.id);
+    expect(downstream).toContain(vaultDomain.id);
+  });
+
+  it('renders a service-centered causal-chain email for an internet outage', () => {
+    const ctx = ctxWith(['gw', immichDomain.id, vaultDomain.id]);
+    const result: CheckResult = { check_id: 'gw', status: 'fail', timestamp: '2026-06-04T14:32:10Z', message: 'no route' };
+    const { subject, body } = renderCausalChainEmail(gateway, result, ctx);
+    expect(subject).toContain('root cause: no internet');
+    expect(subject).toMatch(/2 services unreachable/);
+    expect(body).toContain('Affected:');
+    expect(body).toContain('immich');
+    expect(body).toContain('vaultwarden');
+    expect(body).toContain('the Internet Gateway (ping 192.168.178.1)');
+    expect(body).toContain('since 14:32');
+  });
+
+  it('attributes an SSO outage to Authelia', () => {
+    const ctx = ctxWith(['svc-authelia', immichDomain.id, vaultDomain.id]);
+    const result: CheckResult = { check_id: 'svc-authelia', status: 'fail', timestamp: '2026-06-04T09:00:00Z' };
+    const { subject, body } = renderCausalChainEmail(autheliaSvc, result, ctx);
+    expect(subject).toContain('Authelia (SSO) down');
+    expect(body).toContain('Authelia (SSO)');
+  });
+});

--- a/packages/backend/src/lib/health/prerequisiteChecks.ts
+++ b/packages/backend/src/lib/health/prerequisiteChecks.ts
@@ -1,0 +1,399 @@
+/**
+ * Prerequisite-check resolution + causal-chain rendering
+ * (#1652, epic #1650 item B).
+ *
+ * The alert subsystem used to treat every check as an island: when the
+ * internet dropped or Authelia restarted, every dependent check failed
+ * and emailed independently — a storm of "immich down", "vaultwarden
+ * down", "sso-X down" when the real story is one root cause.
+ *
+ * This module makes checks aware of each other by **reusing the
+ * dependency graph that already exists** — no new user config, no new
+ * `dependsOn` field. A check's prerequisites compose two existing sources:
+ *
+ *   1. service/stack edges — the templates' `servicebay.dependencies`
+ *      plus the infra-tier implicit edges (the #796 rule: every feature
+ *      depends on every infrastructure stack). This is the SAME graph the
+ *      installer topo-sorts with ({@link buildServiceDependencyMap}
+ *      mirrors `stackInstall/dependencies.ts` `computeEffectiveDeps`).
+ *      Each dep service-name is translated to that service's health checks.
+ *   2. technical edges — derived from {@link CheckType}: domain /
+ *      dns_routing / letsdebug → the Internet Gateway (ping); a public
+ *      domain (`domainConfig.isPublic`) → NPM admin-auth; SSO / npm_auth →
+ *      Authelia; any per-service check → that service's container check.
+ *
+ * Two consumers use this:
+ *   - **Root-cause-only alerting** (`runAndEmit`): a failing check alerts
+ *     only when NONE of its prerequisite checks is currently failing.
+ *     Downstream failures are suppressed *as separate emails* — the data
+ *     still shows per-check in the UI, only the alert is gated.
+ *   - **Service-centered causal-chain email**: the root's alert walks the
+ *     same edges DOWNWARD to enumerate transitive impact and renders
+ *     leaf → root.
+ *
+ * Cycle-safe throughout (every traversal carries a visited set). A check
+ * with no resolvable prerequisites is its own root.
+ */
+
+import type { CheckConfig, CheckResult, CheckType } from './types';
+import type { AppConfig, ProxyHostEntry } from '../config';
+
+/** Canonical infra service names the technical edges point at. These are
+ *  the template names the installer uses; the per-service health check
+ *  carries `target === <serviceName>`. */
+const AUTH_SERVICE = 'authelia';
+const NPM_SERVICE = 'nginx';
+
+/** Check types whose health is gated on the upstream internet path. */
+const INTERNET_DEPENDENT_TYPES: ReadonlySet<CheckType> = new Set<CheckType>([
+  'domain',
+  'dns_routing',
+  'letsdebug',
+]);
+
+/**
+ * Effective service-dependency edges, keyed by service (template) name.
+ * Mirrors `stackInstall/dependencies.ts` `computeEffectiveDeps`: each
+ * service maps to its declared `servicebay.dependencies` PLUS — for
+ * `feature`-tier services — an implicit edge to every `infrastructure`
+ * service. This is the single source of truth the installer topo-sorts
+ * with; we reuse it so the alert graph never drifts from the install graph.
+ */
+export type ServiceDependencyMap = Map<string, string[]>;
+
+/** Minimal template shape we need from the registry. */
+interface TemplateLike {
+  name: string;
+  tier?: 'infrastructure' | 'feature';
+  dependencies?: string[];
+}
+
+/**
+ * Build the effective service→deps map from the template registry.
+ * Async (reads the registry) and intended to be built once and cached by
+ * the caller — the graph only changes when stacks are installed/removed.
+ *
+ * The implicit infra edge matches `computeEffectiveDeps`: a feature
+ * depends on every infrastructure stack so the whole infra block is a
+ * prerequisite of any feature, exactly as #796 specified.
+ */
+export function buildServiceDependencyMap(templates: TemplateLike[]): ServiceDependencyMap {
+  const infraNames = templates
+    .filter(t => t.tier === 'infrastructure')
+    .map(t => t.name);
+  const map: ServiceDependencyMap = new Map();
+  for (const t of templates) {
+    const tier = t.tier ?? 'feature';
+    const explicit = (t.dependencies ?? []).filter(d => d !== t.name);
+    if (tier === 'infrastructure') {
+      map.set(t.name, [...new Set(explicit)]);
+    } else {
+      const implicit = infraNames.filter(n => n !== t.name);
+      map.set(t.name, [...new Set([...explicit, ...implicit])]);
+    }
+  }
+  return map;
+}
+
+/**
+ * Everything the (pure) prerequisite resolver needs. Built once per
+ * resolution pass by the caller from live state; passing it explicitly
+ * keeps {@link resolvePrerequisiteChecks} a pure, unit-testable function.
+ */
+export interface PrerequisiteContext {
+  /** Every configured check (HealthStore.getChecks()). */
+  checks: CheckConfig[];
+  /** Effective service→deps edges (buildServiceDependencyMap). */
+  serviceDeps: ServiceDependencyMap;
+  /** Reverse-proxy hosts, used to map a `domain` check → its service. */
+  hosts: ProxyHostEntry[];
+  /** Current failing-status per check-id (true = currently failing). */
+  isFailing: (checkId: string) => boolean;
+}
+
+/** Build a PrerequisiteContext from raw inputs. */
+export function makePrerequisiteContext(input: {
+  checks: CheckConfig[];
+  serviceDeps: ServiceDependencyMap;
+  config: Pick<AppConfig, 'reverseProxy'> | undefined;
+  isFailing: (checkId: string) => boolean;
+}): PrerequisiteContext {
+  return {
+    checks: input.checks,
+    serviceDeps: input.serviceDeps,
+    hosts: input.config?.reverseProxy?.hosts ?? [],
+    isFailing: input.isFailing,
+  };
+}
+
+/** The owning service name of a check, or null if it isn't service-bound.
+ *  Per-service checks carry `target === <serviceName>` (init.ts); domain
+ *  checks map via `reverseProxy.hosts[]` (domain↔service). */
+export function serviceOfCheck(check: CheckConfig, ctx: PrerequisiteContext): string | null {
+  if (check.type === 'service' || check.type === 'podman' || check.type === 'systemd') {
+    return check.target || null;
+  }
+  if (check.type === 'domain') {
+    const host = ctx.hosts.find(h => h.domain === check.target);
+    return host?.service ?? null;
+  }
+  // Template-registered http/script probes carry an id slug whose leading
+  // segment is the owning service (init.ts isOrphanTemplateCheck). We only
+  // bind one when that leading segment matches a known service container check.
+  return null;
+}
+
+/** The `type:'service'` container check for a service, if one exists. */
+function containerCheckId(service: string, ctx: PrerequisiteContext): string | null {
+  const c = ctx.checks.find(ch => ch.type === 'service' && ch.target === service);
+  return c?.id ?? null;
+}
+
+/** Find a singleton/technical check by predicate. */
+function findCheckId(ctx: PrerequisiteContext, pred: (c: CheckConfig) => boolean): string | null {
+  return ctx.checks.find(pred)?.id ?? null;
+}
+
+/** The Internet Gateway ping check (the configured-gateway ping, init.ts). */
+function gatewayCheckId(ctx: PrerequisiteContext): string | null {
+  return findCheckId(ctx, c => c.type === 'ping' && c.name === 'Internet Gateway');
+}
+
+/** The NPM admin-auth singleton check. */
+function npmCheckId(ctx: PrerequisiteContext): string | null {
+  return (
+    findCheckId(ctx, c => c.type === 'npm_auth') ??
+    containerCheckId(NPM_SERVICE, ctx)
+  );
+}
+
+/** Authelia's check: its container check (a `service`-type targeting the
+ *  authelia stack). */
+function autheliaCheckId(ctx: PrerequisiteContext): string | null {
+  return containerCheckId(AUTH_SERVICE, ctx);
+}
+
+/** True when a domain check is SSO-protected (a public-domain service is
+ *  fronted by Authelia in this codebase). We treat `domainConfig.isPublic`
+ *  as the SSO/NPM signal per the issue. */
+function isPublicDomain(check: CheckConfig): boolean {
+  return check.type === 'domain' && check.domainConfig?.isPublic === true;
+}
+
+/**
+ * Direct prerequisite check-ids for a single check — service/stack edges
+ * + technical edges. Does NOT recurse (the caller walks transitively).
+ * Never returns the check's own id.
+ */
+export function resolvePrerequisiteChecks(check: CheckConfig, ctx: PrerequisiteContext): string[] {
+  const prereqs = new Set<string>();
+  const add = (id: string | null) => {
+    if (id && id !== check.id) prereqs.add(id);
+  };
+
+  // ---- technical edges (CheckType-derived) ----
+  if (INTERNET_DEPENDENT_TYPES.has(check.type)) {
+    add(gatewayCheckId(ctx));
+  }
+  if (isPublicDomain(check)) {
+    add(npmCheckId(ctx));
+    add(autheliaCheckId(ctx));
+  }
+  if (check.type === 'npm_auth') {
+    add(autheliaCheckId(ctx));
+  }
+
+  // any per-service check (domain/http/etc.) → that service's container check
+  const service = serviceOfCheck(check, ctx);
+  if (service) {
+    add(containerCheckId(service, ctx));
+    // SSO-fronted service domain → Authelia.
+    if (isPublicDomain(check)) add(autheliaCheckId(ctx));
+
+    // ---- service/stack edges (template dependency graph) ----
+    for (const depService of ctx.serviceDeps.get(service) ?? []) {
+      add(containerCheckId(depService, ctx));
+    }
+  }
+
+  return [...prereqs];
+}
+
+/** Transitive prerequisite check-ids (cycle-safe). */
+export function resolvePrerequisitesTransitive(check: CheckConfig, ctx: PrerequisiteContext): Set<string> {
+  const seen = new Set<string>();
+  const byId = new Map(ctx.checks.map(c => [c.id, c]));
+  const stack = [...resolvePrerequisiteChecks(check, ctx)];
+  while (stack.length) {
+    const id = stack.pop()!;
+    if (seen.has(id) || id === check.id) continue;
+    seen.add(id);
+    const c = byId.get(id);
+    if (!c) continue;
+    for (const next of resolvePrerequisiteChecks(c, ctx)) {
+      if (!seen.has(next)) stack.push(next);
+    }
+  }
+  return seen;
+}
+
+/**
+ * Root-cause test: a failing check is the root of its cascade only if NONE
+ * of its (transitive) prerequisite checks is currently failing. If an
+ * upstream prerequisite is also failing, THIS check is a downstream symptom
+ * and its alert is suppressed.
+ */
+export function isRootCause(check: CheckConfig, ctx: PrerequisiteContext): boolean {
+  for (const id of resolvePrerequisitesTransitive(check, ctx)) {
+    if (ctx.isFailing(id)) return false;
+  }
+  return true;
+}
+
+/**
+ * Walk the prerequisite edges DOWNWARD from a root check to enumerate
+ * every check that (transitively) depends on it AND is currently failing.
+ * Cycle-safe. Used to attribute the cascade to its root for the email.
+ */
+export function enumerateDownstreamFailing(rootId: string, ctx: PrerequisiteContext): CheckConfig[] {
+  // Build reverse edges: dependent ← prerequisite.
+  const dependents = new Map<string, CheckConfig[]>();
+  for (const c of ctx.checks) {
+    for (const prereq of resolvePrerequisiteChecks(c, ctx)) {
+      const arr = dependents.get(prereq) ?? [];
+      arr.push(c);
+      dependents.set(prereq, arr);
+    }
+  }
+  const seen = new Set<string>([rootId]);
+  const out: CheckConfig[] = [];
+  const stack = [rootId];
+  while (stack.length) {
+    const id = stack.pop()!;
+    for (const dep of dependents.get(id) ?? []) {
+      if (seen.has(dep.id)) continue;
+      seen.add(dep.id);
+      if (ctx.isFailing(dep.id)) out.push(dep);
+      stack.push(dep.id);
+    }
+  }
+  return out;
+}
+
+/** A single rung of the rendered causal chain (root last). */
+export interface CausalChainRung {
+  checkId: string;
+  label: string;
+}
+
+/**
+ * Build the human causal chain from a leaf-most failing downstream check
+ * up to the root, following the first currently-failing prerequisite at
+ * each step. Cycle-safe. Returns rungs ordered leaf → root.
+ */
+export function buildCausalChain(rootCheck: CheckConfig, ctx: PrerequisiteContext): CausalChainRung[] {
+  const byId = new Map(ctx.checks.map(c => [c.id, c]));
+  const rungs: CausalChainRung[] = [];
+  const seen = new Set<string>();
+  let current: CheckConfig | undefined = rootCheck;
+  // Walk UP from root toward deeper roots is unnecessary — rootCheck IS the
+  // root; instead we render root last, prefixed by the nearest failing
+  // downstream symptom layer. The downstream enumeration supplies impact;
+  // here we render the prerequisite spine of the root itself (which, by
+  // definition of root, has no failing prereqs) plus the root.
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id);
+    rungs.unshift({ checkId: current.id, label: describeCheck(current) });
+    // Follow the first currently-failing prerequisite, if any (defensive:
+    // a true root has none, but a near-root may during a race).
+    const next: CheckConfig | undefined = resolvePrerequisiteChecks(current, ctx)
+      .map(id => byId.get(id))
+      .find((c): c is CheckConfig => !!c && ctx.isFailing(c.id));
+    current = next;
+  }
+  return rungs;
+}
+
+/** Human label for a check in the causal chain. */
+function describeCheck(check: CheckConfig): string {
+  switch (check.type) {
+    case 'ping':
+      return check.name === 'Internet Gateway'
+        ? `the Internet Gateway (ping ${check.target})`
+        : `${check.name} (ping ${check.target})`;
+    case 'npm_auth':
+      return 'NPM (reverse proxy)';
+    case 'service':
+    case 'podman':
+    case 'systemd':
+      return check.target === AUTH_SERVICE ? 'Authelia (SSO)' : `${check.target}`;
+    case 'domain':
+      return `${check.target}`;
+    default:
+      return check.name;
+  }
+}
+
+/**
+ * Render the service-centered causal-chain alert for a root failure.
+ *
+ * Subject: `3 services unreachable — root cause: <root summary>`
+ * Body lists the affected services (leaf), then the chain up to the root:
+ *
+ *   Affected: immich, vaultwarden, file-share
+ *     ← because Authelia (SSO) is failing
+ *     ← because the Internet Gateway (ping 192.168.178.1) is down since 14:32
+ */
+export function renderCausalChainEmail(
+  rootCheck: CheckConfig,
+  rootResult: CheckResult,
+  ctx: PrerequisiteContext,
+): { subject: string; body: string } {
+  const downstream = enumerateDownstreamFailing(rootCheck.id, ctx);
+  // Affected services: distinct services owning the downstream failing
+  // checks (plus the root's own service, if any).
+  const affectedServices = new Set<string>();
+  for (const c of downstream) {
+    const svc = serviceOfCheck(c, ctx);
+    if (svc) affectedServices.add(svc);
+  }
+  const services = [...affectedServices];
+
+  const rootSummary = rootCauseSummary(rootCheck);
+  const subject = services.length > 0
+    ? `${services.length} service${services.length === 1 ? '' : 's'} unreachable — root cause: ${rootSummary}`
+    : `${rootCheck.name} failing — root cause: ${rootSummary}`;
+
+  const since = rootResult.timestamp ? ` since ${shortTime(rootResult.timestamp)}` : '';
+  const lines: string[] = [];
+  if (services.length > 0) {
+    lines.push(`Affected: ${services.join(', ')}`);
+  }
+  // Render the spine leaf → root using the chain rungs (root last).
+  const rungs = buildCausalChain(rootCheck, ctx);
+  rungs.forEach((rung, i) => {
+    const isRoot = i === rungs.length - 1;
+    const suffix = isRoot ? `${rung.label} is down${since}` : `${rung.label} is failing`;
+    lines.push(`  ← because ${suffix}`);
+  });
+  if (rootResult.message) lines.push('', `Details: ${rootResult.message}`);
+
+  return { subject, body: lines.join('\n') };
+}
+
+/** Short, human root-cause phrase for the subject line. */
+function rootCauseSummary(check: CheckConfig): string {
+  if (check.type === 'ping' && check.name === 'Internet Gateway') return 'no internet';
+  if (check.target === AUTH_SERVICE) return 'Authelia (SSO) down';
+  if (check.type === 'npm_auth') return 'reverse proxy down';
+  if (check.type === 'service' || check.type === 'podman' || check.type === 'systemd') {
+    return `${check.target} down`;
+  }
+  return `${check.name} failing`;
+}
+
+/** "2026-06-04T14:32:10Z" → "14:32". Falls back to the raw value. */
+function shortTime(timestamp: string): string {
+  const m = /T(\d{2}:\d{2})/.exec(timestamp);
+  return m ? m[1] : timestamp;
+}

--- a/packages/backend/src/lib/health/service.test.ts
+++ b/packages/backend/src/lib/health/service.test.ts
@@ -25,14 +25,30 @@ vi.mock('./serviceHealthBootstrap', () => ({
 // Keep the heavy init paths inert — we're only exercising the
 // twin-subscription branch.
 vi.mock('./init', () => ({ initializeDefaultChecks: vi.fn().mockResolvedValue(undefined) }));
-const { getResultsMock, runMock, sendEmailMock } = vi.hoisted(() => ({
+const { getResultsMock, runMock, sendEmailMock, getChecksMock, getLastResultMock, getConfigMock } = vi.hoisted(() => ({
   getResultsMock: vi.fn((_id: string) => [] as unknown[]),
   runMock: vi.fn((_check: unknown) => undefined as unknown),
   sendEmailMock: vi.fn((_subject: string, _message: string) => Promise.resolve()),
+  getChecksMock: vi.fn(() => [] as unknown[]),
+  getLastResultMock: vi.fn<(id: string) => unknown>(() => null),
+  getConfigMock: vi.fn(
+    () =>
+      Promise.resolve({ reverseProxy: { hosts: [] } }) as Promise<{
+        reverseProxy: {
+          hosts: Array<{ domain: string; service: string; forwardPort: number; created: boolean }>;
+        };
+      }>,
+  ),
 }));
 vi.mock('./store', () => ({
-  HealthStore: { getChecks: () => [], getResults: (id: string) => getResultsMock(id) },
+  HealthStore: {
+    getChecks: () => getChecksMock(),
+    getResults: (id: string) => getResultsMock(id),
+    getLastResult: (id: string) => getLastResultMock(id),
+  },
 }));
+vi.mock('@/lib/registry', () => ({ getTemplates: vi.fn().mockResolvedValue([]) }));
+vi.mock('@/lib/config', () => ({ getConfig: () => getConfigMock() }));
 vi.mock('./runner', () => ({
   CheckRunner: { run: (check: unknown) => runMock(check) },
 }));
@@ -160,9 +176,13 @@ describe('HealthService.runAndEmit alert gating (#1651)', () => {
     runMock.mockReset();
     sendEmailMock.mockReset().mockResolvedValue(undefined);
     getResultsMock.mockReset().mockReturnValue([]);
+    getChecksMock.mockReset().mockReturnValue([]);
+    getLastResultMock.mockReset().mockReturnValue(null);
     fakeIo.emit.mockClear();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (HealthService as any).io = fakeIo;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HealthService as any).serviceDeps = new Map();
   });
 
   it('does not alert on a single fail below the domain threshold (3)', async () => {
@@ -206,5 +226,68 @@ describe('HealthService.runAndEmit alert gating (#1651)', () => {
     runMock.mockRejectedValue(new Error('probe blew up'));
     await expect(runAndEmit(check)).resolves.toBeUndefined();
     expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('HealthService.runAndEmit root-cause gating (#1652)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const runAndEmit = (c: CheckConfig) => (HealthService as any).runAndEmit(c);
+  const cfg = (over: Partial<CheckConfig> & Pick<CheckConfig, 'id' | 'type'>): CheckConfig =>
+    ({ name: over.id, target: '', interval: 60, enabled: true, created_at: 't', ...over });
+
+  const gateway = cfg({ id: 'gw', type: 'ping', name: 'Internet Gateway', target: '192.168.178.1' });
+  const photos = cfg({
+    id: 'domain:photos', type: 'domain', target: 'photos.dopp.cloud', name: 'Domain — photos',
+    domainConfig: { expectedScheme: 'https', isPublic: true },
+  });
+  const failResult: CheckResult = { check_id: 'domain:photos', status: 'fail', message: 'down', timestamp: '2026-06-04T14:32:00Z' };
+
+  beforeEach(() => {
+    runMock.mockReset().mockResolvedValue(failResult);
+    sendEmailMock.mockReset().mockResolvedValue(undefined);
+    // photos is a domain → threshold 3; supply a 3-fail streak so the
+    // #1651 threshold is met and only the #1652 root-cause gate decides.
+    getResultsMock.mockReset().mockReturnValue([failResult, failResult, failResult]);
+    getChecksMock.mockReset().mockReturnValue([gateway, photos]);
+    fakeIo.emit.mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HealthService as any).io = fakeIo;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HealthService as any).serviceDeps = new Map();
+    getConfigMock.mockReset().mockResolvedValue({
+      reverseProxy: { hosts: [{ domain: 'photos.dopp.cloud', service: 'immich', forwardPort: 1, created: true }] },
+    });
+  });
+
+  it('suppresses a downstream symptom when its prerequisite (gateway) is also failing', async () => {
+    // gateway failing → photos is a downstream symptom, not a root.
+    getLastResultMock.mockImplementation((id: string) =>
+      id === 'gw' ? { status: 'fail' } : null);
+    await runAndEmit(photos);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(fakeIo.emit).not.toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'error' }));
+    // Per-check status is still broadcast.
+    expect(fakeIo.emit).toHaveBeenCalledWith('health:update', { checkId: 'domain:photos', result: failResult });
+  });
+
+  it('alerts with a causal-chain email when the check IS the root (no prereq failing)', async () => {
+    getLastResultMock.mockReturnValue(null); // nothing else failing
+    await runAndEmit(photos);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    // Subject is the root-cause chain, not the legacy "Check Failed".
+    expect(sendEmailMock.mock.calls[0][0]).not.toContain('Check Failed');
+    expect(fakeIo.emit).toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'error' }));
+  });
+
+  it('the gateway alerts as the root and names affected services', async () => {
+    const gwFail: CheckResult = { check_id: 'gw', status: 'fail', timestamp: '2026-06-04T14:32:00Z' };
+    runMock.mockResolvedValue(gwFail);
+    getResultsMock.mockReturnValue([gwFail, gwFail, gwFail]); // ping threshold 3
+    getLastResultMock.mockImplementation((id: string) =>
+      id === 'domain:photos' ? { status: 'fail' } : id === 'gw' ? { status: 'fail' } : null);
+    await runAndEmit(gateway);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock.mock.calls[0][0]).toContain('no internet');
+    expect(sendEmailMock.mock.calls[0][1]).toContain('immich');
   });
 });

--- a/packages/backend/src/lib/health/service.ts
+++ b/packages/backend/src/lib/health/service.ts
@@ -6,6 +6,16 @@ import { HealthStore } from './store';
 import { CheckRunner } from './runner';
 import { CheckConfig, CheckResult } from './types';
 import { decideAlert } from './alertDecision';
+import {
+  buildServiceDependencyMap,
+  makePrerequisiteContext,
+  isRootCause,
+  renderCausalChainEmail,
+  type ServiceDependencyMap,
+  type PrerequisiteContext,
+} from './prerequisiteChecks';
+import { getTemplates } from '@/lib/registry';
+import { getConfig } from '@/lib/config';
 import { initializeDefaultChecks } from './init';
 import { sendEmailAlert } from '@/lib/email';
 import { NotificationBatcher } from './notificationBatcher';
@@ -60,6 +70,12 @@ export class HealthService {
     //     surfaces it with the same per-row stats as any other check.
     this.startDiagnoseSchedule();
 
+    // 1d. Build the service-dependency graph used by root-cause-only
+    //     alerting (#1652). Reused from the install topo-sort graph; fire
+    //     and forget — the resolver degrades to technical (CheckType)
+    //     edges until it lands.
+    void this.refreshServiceDeps();
+
     // 2. Start initial scheduling
     this.restartAll();
 
@@ -84,6 +100,53 @@ export class HealthService {
   private static checksWatcherDebounce: NodeJS.Timeout | null = null;
   private static bootstrappedNodes = new Set<string>();
   private static twinUnsubscribe: (() => void) | null = null;
+
+  /**
+   * Cached effective service→deps graph (#1652). Built from the template
+   * registry — the SAME graph the installer topo-sorts with — and only
+   * changes when stacks are installed/removed. Refreshed on init and on
+   * every checks.json change (a deploy rewrites both). Empty until first
+   * build, in which case prerequisite resolution falls back to the
+   * technical (CheckType) edges alone.
+   */
+  private static serviceDeps: ServiceDependencyMap = new Map();
+
+  /** (Re)build the cached service-dependency graph from the registry.
+   *  Best-effort: a registry read failure leaves the prior map in place so
+   *  root-cause resolution degrades to technical edges, never throws. */
+  private static async refreshServiceDeps(): Promise<void> {
+    try {
+      const templates = await getTemplates();
+      this.serviceDeps = buildServiceDependencyMap(templates);
+      // Hand the boot digest the same graph so its post-restart summary
+      // also collapses to root causes (#1652).
+      let hosts: import('@/lib/config').ProxyHostEntry[] = [];
+      try {
+        hosts = (await getConfig()).reverseProxy?.hosts ?? [];
+      } catch { /* config unavailable — digest falls back to legacy listing */ }
+      NotificationBatcher.setRootCauseResolution({ serviceDeps: this.serviceDeps, hosts });
+    } catch (e) {
+      logger.warn('Health', `Could not refresh service-dependency graph: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  /** Assemble the prerequisite-resolution context from live state. Pure
+   *  inputs → the resolver stays unit-testable; this gathers them. */
+  private static async buildPrereqContext(): Promise<PrerequisiteContext> {
+    const checks = HealthStore.getChecks();
+    let config: Awaited<ReturnType<typeof getConfig>> | undefined;
+    try {
+      config = await getConfig();
+    } catch {
+      config = undefined;
+    }
+    return makePrerequisiteContext({
+      checks,
+      serviceDeps: this.serviceDeps,
+      config,
+      isFailing: (id: string) => HealthStore.getLastResult(id)?.status === 'fail',
+    });
+  }
 
   private static async runServiceHealthBootstrap(nodeName: string): Promise<void> {
     if (this.bootstrappedNodes.has(nodeName)) return;
@@ -132,6 +195,9 @@ export class HealthService {
         this.checksWatcherDebounce = setTimeout(() => {
           this.checksWatcherDebounce = null;
           logger.info('Health', 'checks.json changed — re-scheduling.');
+          // A deploy/uninstall rewrites both checks.json and the installed
+          // stack set, so refresh the dependency graph alongside (#1652).
+          void this.refreshServiceDeps();
           this.restartAll();
         }, 250);
       });
@@ -204,6 +270,48 @@ export class HealthService {
     intervals.set(check.id, timer);
   }
 
+  /**
+   * Root-cause-only alerting decision (#1652). A check that has met its
+   * consecutive-fail threshold (#1651) still alerts ONLY when none of its
+   * prerequisite checks is currently failing — a downstream symptom
+   * (immich down *because* the internet is down) keeps its real per-check
+   * status in the UI but is suppressed as a separate email; the root's
+   * causal-chain alert already names it. On any resolution failure we fall
+   * back to a direct alert (treat as root) so a real alert is never
+   * swallowed.
+   */
+  private static async resolveRootAlert(
+    check: CheckConfig,
+    result: CheckResult,
+  ): Promise<{ isRoot: boolean; chainEmail: { subject: string; body: string } | null }> {
+    try {
+      const ctx = await this.buildPrereqContext();
+      const isRoot = isRootCause(check, ctx);
+      return { isRoot, chainEmail: isRoot ? renderCausalChainEmail(check, result, ctx) : null };
+    } catch (e) {
+      logger.warn('Health', `Root-cause resolution failed for ${check.name}, alerting directly: ${e instanceof Error ? e.message : String(e)}`);
+      return { isRoot: true, chainEmail: null };
+    }
+  }
+
+  /** Broadcast the per-check status (always) plus any fail/recovery toast. */
+  private static emitAlerts(
+    check: CheckConfig,
+    result: CheckResult,
+    opts: { enteredFailure: boolean; recoveredNow: boolean; failTitle: string },
+  ) {
+    if (!this.io) return;
+    // Per-check status broadcast — always, regardless of alert gating, so
+    // the UI stays truthful.
+    this.io.emit('health:update', { checkId: check.id, result });
+    if (opts.enteredFailure) {
+      this.io.emit('health:alert', { type: 'error', title: opts.failTitle, message: result.message || 'Service is down' });
+    }
+    if (opts.recoveredNow) {
+      this.io.emit('health:alert', { type: 'success', title: `Service Recovered: ${check.name}`, message: 'Service is back online' });
+    }
+  }
+
   private static async runAndEmit(check: CheckConfig) {
     try {
       const result = await CheckRunner.run(check);
@@ -211,51 +319,23 @@ export class HealthService {
       // newest-first with history[0] === result.
       const history = HealthStore.getResults(check.id);
       // Require N consecutive fails before alerting (#1651); recovery
-      // only fires if a fail alert was actually sent. The decision is a
-      // pure function so it stays testable and extensible (#1652).
-      const { alertFailure: enteredFailure, alertRecovery: recoveredNow } =
+      // only fires if a fail alert was actually sent.
+      const { alertFailure: thresholdMet, alertRecovery: recoveredNow } =
         decideAlert(check, history);
 
-      // Emit if we have IO
-      if (this.io) {
-      // Broadcast update event (silent refresh)
-      this.io.emit('health:update', { checkId: check.id, result });
-        
-      if (enteredFailure) {
-         this.io.emit('health:alert', {
-           type: 'error',
-           title: `Check Failed: ${check.name}`,
-           message: result.message || 'Service is down'
-         });
-      }
-        
-      if (recoveredNow) {
-        this.io.emit('health:alert', {
-          type: 'success',
-          title: `Service Recovered: ${check.name}`,
-          message: 'Service is back online'
-        });
-      }
-      }
+      const { isRoot, chainEmail } = thresholdMet
+        ? await this.resolveRootAlert(check, result)
+        : { isRoot: false, chainEmail: null };
+      const enteredFailure = thresholdMet && isRoot;
+      const failTitle = chainEmail?.subject ?? `Check Failed: ${check.name}`;
 
-      if (enteredFailure) {
-        const buffered = NotificationBatcher.enqueue('fail', check, result);
-        if (!buffered) {
-          await sendEmailAlert(
-            `Check Failed: ${check.name}`,
-            formatAlertMessage('fail', check, result)
-          );
-        }
-      }
+      this.emitAlerts(check, result, { enteredFailure, recoveredNow, failTitle });
 
-      if (recoveredNow) {
-        const buffered = NotificationBatcher.enqueue('recovery', check, result);
-        if (!buffered) {
-          await sendEmailAlert(
-            `Service Recovered: ${check.name}`,
-            formatAlertMessage('recovery', check, result)
-          );
-        }
+      if (enteredFailure && !NotificationBatcher.enqueue('fail', check, result)) {
+        await sendEmailAlert(failTitle, chainEmail?.body ?? formatAlertMessage('fail', check, result));
+      }
+      if (recoveredNow && !NotificationBatcher.enqueue('recovery', check, result)) {
+        await sendEmailAlert(`Service Recovered: ${check.name}`, formatAlertMessage('recovery', check, result));
       }
     } catch (e) {
       logger.error('Health', `Error running check ${check.name}:`, e);


### PR DESCRIPTION
## What
Adds root-cause-only alerting (epic #1650 item B): a failing health check only emails an alert when none of its prerequisites are also failing, so an Authelia/internet outage collapses an alert storm into a single root-cause email. The email is service-centered and walks the dependency edges downward to render a causal chain (root failure + transitive leaf services). Boot/restart digest in the notification batcher likewise collapses to root causes only.

Reuses the existing `servicebay.dependencies` graph (installer `computeEffectiveDeps` via `buildServiceDependencyMap`) plus per-`CheckType` technical (type-inherent) dependency edges; resolution is cycle-safe.

## Why
Closes #1652

Part of epic #1650 (item B). Builds on `decideAlert`/`getFailureThreshold` from #1651. Unblocks #1653.

## Risk
low — per-check UI status is unchanged (gating only affects whether an alert email is emitted); resolution is cycle-safe; new logic is unit-covered (prerequisite resolution + gating + chain render).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 342 warnings — baseline)
- [x] npm run check:arch
- [x] npm test (full — 1966 passed)
- [ ] /verify on FCoS :dev box — N/A (lib/health/ alert-email behaviour, not path-mandated; unit-tested only)