### PR TITLE
feat(health): enrich restart/update digest (epic #1650 item C)

### DIFF
--- a/packages/backend/src/lib/health/bootState.ts
+++ b/packages/backend/src/lib/health/bootState.ts
@@ -1,0 +1,70 @@
+/**
+ * Persisted boot state for the restart/update digest (#1653, epic #1650
+ * item C).
+ *
+ * The boot-grace digest ({@link NotificationBatcher}) wants to frame a
+ * restart with context the running process can't derive from memory alone:
+ *   - **version change** — was this a plain restart, or did we come up on a
+ *     new release? Needs the *previous* boot's version, which only survives
+ *     across the restart if it's on disk.
+ *   - **recovery duration** — how long was the box down + recovering? Needs
+ *     the timestamp of the last healthy moment before the restart.
+ *
+ * Both are persisted to a tiny JSON file in {@link DATA_DIR}. It lives
+ * alongside `checks.json` so it survives an app restart (same volume) but
+ * is intentionally NOT part of the config document — it's ephemeral runtime
+ * breadcrumbs, not operator config, and a missing/corrupt file degrades
+ * gracefully (first boot ⇒ no prior version ⇒ "restarted, no version
+ * change").
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { DATA_DIR } from '../dirs';
+import { logger } from '../logger';
+
+const BOOT_STATE_FILE = path.join(DATA_DIR, 'boot-state.json');
+
+export interface BootState {
+  /** The app version recorded at the previous boot (or last heartbeat). */
+  lastSeenVersion?: string;
+  /** Epoch ms of the last time the running process wrote a heartbeat.
+   *  Approximates "the last healthy moment before this restart", so the
+   *  digest can report downtime + recovery as a single duration. */
+  lastSeenAt?: number;
+}
+
+/** Read the persisted boot state. Returns `{}` on first boot or any read /
+ *  parse error — the digest treats an empty state as "no prior version". */
+export function readBootState(): BootState {
+  try {
+    if (!fs.existsSync(BOOT_STATE_FILE)) return {};
+    return JSON.parse(fs.readFileSync(BOOT_STATE_FILE, 'utf-8')) as BootState;
+  } catch (e) {
+    logger.warn('BootState', `Could not read boot state: ${e instanceof Error ? e.message : String(e)}`);
+    return {};
+  }
+}
+
+/** Persist the current version + heartbeat timestamp. Best-effort: a write
+ *  failure is logged, never thrown (the digest is non-critical). */
+export function writeBootState(state: BootState): void {
+  try {
+    if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(BOOT_STATE_FILE, JSON.stringify(state, null, 2));
+  } catch (e) {
+    logger.warn('BootState', `Could not write boot state: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/** Read the app version from package.json at the process cwd. Falls back to
+ *  `0.0.0` if unreadable (matches the updater's resolution). */
+export function readAppVersion(): string {
+  try {
+    const pkgPath = path.join(process.cwd(), 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}

--- a/packages/backend/src/lib/health/changelogHighlights.test.ts
+++ b/packages/backend/src/lib/health/changelogHighlights.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { extractChangelogHighlights } from './changelogHighlights';
+
+const SAMPLE = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [4.94.0](https://github.com/mdopp/servicebay/compare/servicebay-v4.93.1...servicebay-v4.94.0) (2026-06-04)
+
+
+### Features
+
+* **health:** per-type failureThreshold before alerting ([6a2aa29](https://github.com/mdopp/servicebay/commit/6a2aa29)), closes [#1651](https://github.com/mdopp/servicebay/issues/1651)
+* **portal:** per-service up/down status badge on each card ([84fc192](https://github.com/mdopp/servicebay/commit/84fc192)), closes [#1654](https://github.com/mdopp/servicebay/issues/1654)
+
+## [4.93.1](https://github.com/mdopp/servicebay/compare/servicebay-v4.93.0...servicebay-v4.93.1) (2026-06-03)
+
+
+### Bug Fixes
+
+* **portal:** migrate Authelia soft-auth off deprecated /api/verify ([6b9a7a6](https://github.com/mdopp/servicebay/commit/6b9a7a6))
+
+## [4.93.0](https://github.com/mdopp/servicebay/compare/servicebay-v4.92.0...servicebay-v4.93.0) (2026-06-03)
+
+
+### Features
+
+* **backup:** relabel Backups page to System Snapshot + Backup Sync ([b0fae9b](https://github.com/mdopp/servicebay/commit/b0fae9b))
+`;
+
+describe('extractChangelogHighlights', () => {
+  it('returns the toVersion bullets, stripped of commit + closes link noise', () => {
+    const hl = extractChangelogHighlights(SAMPLE, '4.94.0', '4.93.1');
+    expect(hl).toEqual([
+      '**health:** per-type failureThreshold before alerting',
+      '**portal:** per-service up/down status badge on each card',
+    ]);
+  });
+
+  it('spans multiple versions when the box jumped several releases', () => {
+    const hl = extractChangelogHighlights(SAMPLE, '4.94.0', '4.93.0');
+    // 4.94.0 + 4.93.1 sections, not the 4.93.0 section (the floor).
+    expect(hl).toContain('**health:** per-type failureThreshold before alerting');
+    expect(hl).toContain('**portal:** migrate Authelia soft-auth off deprecated /api/verify');
+    expect(hl).not.toContain('**backup:** relabel Backups page to System Snapshot + Backup Sync');
+  });
+
+  it('returns only the toVersion section when fromVersion is unknown', () => {
+    const hl = extractChangelogHighlights(SAMPLE, '4.94.0', '9.9.9');
+    expect(hl).toEqual([
+      '**health:** per-type failureThreshold before alerting',
+      '**portal:** per-service up/down status badge on each card',
+    ]);
+  });
+
+  it('returns [] when toVersion has no section (dev build ahead of changelog)', () => {
+    expect(extractChangelogHighlights(SAMPLE, '5.0.0', '4.94.0')).toEqual([]);
+  });
+
+  it('respects the max cap', () => {
+    const hl = extractChangelogHighlights(SAMPLE, '4.94.0', '4.93.0', { max: 1 });
+    expect(hl).toHaveLength(1);
+  });
+
+  it('returns [] for an empty changelog', () => {
+    expect(extractChangelogHighlights('', '4.94.0', undefined)).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/health/changelogHighlights.ts
+++ b/packages/backend/src/lib/health/changelogHighlights.ts
@@ -1,0 +1,90 @@
+/**
+ * Changelog-highlights extraction for the restart/update digest
+ * (#1653, epic #1650 item C).
+ *
+ * When the box comes up on a new version, the digest wants a few
+ * human-readable highlights of what changed — not the whole release-please
+ * CHANGELOG.md, just the headline Features/Fixes for the versions crossed.
+ *
+ * The file is release-please's "Keep a Changelog" format:
+ *
+ *     ## [4.94.0](…compare…) (2026-06-04)
+ *     ### Features
+ *     * **health:** per-type failureThreshold before alerting ([6a2aa29](…)), closes [#1651](…)
+ *     ### Bug Fixes
+ *     * **portal:** migrate Authelia soft-auth off …
+ *
+ * We parse the entries between the new version's header and the previous
+ * version's header (so an update that jumps several releases shows all of
+ * them), strip the trailing commit/issue link noise, and return a short
+ * bulleted list. Pure string work — no I/O here so it stays unit-testable;
+ * the caller passes the file contents.
+ */
+
+const VERSION_HEADER = /^##\s+\[(\d+\.\d+\.\d+[^\]]*)\]/;
+
+/** Strip a changelog bullet down to its readable summary: drop the leading
+ *  `* `, the trailing `([sha](url))`, and any `, closes [#N](url)` tail. */
+function cleanBullet(line: string): string {
+  return line
+    .replace(/^\*\s+/, '')
+    .replace(/\s*\(\[[0-9a-f]+\]\([^)]*\)\)/g, '') // ([sha](url))
+    .replace(/,?\s*closes?\s+(\[#\d+\]\([^)]*\)\s*)+/gi, '') // closes [#N](url)…
+    .trim();
+}
+
+export interface ChangelogHighlightsOptions {
+  /** Cap on how many bullets to include (newest-first). */
+  max?: number;
+}
+
+/**
+ * Extract changelog highlights for the versions in the half-open range
+ * `(fromVersion, toVersion]`. When `fromVersion` is undefined or not found,
+ * returns just the `toVersion` section. Returns `[]` if `toVersion` has no
+ * section (e.g. a dev build not yet in the changelog) or the file is empty.
+ */
+export function extractChangelogHighlights(
+  changelog: string,
+  toVersion: string,
+  fromVersion: string | undefined,
+  opts: ChangelogHighlightsOptions = {},
+): string[] {
+  const max = opts.max ?? 8;
+  const lines = changelog.split('\n');
+
+  // Find the line index of each version header in file order (newest first
+  // in release-please output).
+  const headerAt: Array<{ version: string; idx: number }> = [];
+  lines.forEach((l, idx) => {
+    const m = l.match(VERSION_HEADER);
+    if (m) headerAt.push({ version: m[1], idx });
+  });
+
+  const startHeader = headerAt.findIndex(h => h.version === toVersion);
+  if (startHeader === -1) return [];
+
+  // Collect bullets from the toVersion section down to (but not including)
+  // the fromVersion section. If fromVersion isn't in the file, just take
+  // the single toVersion section.
+  const endHeader =
+    fromVersion !== undefined
+      ? headerAt.findIndex(h => h.version === fromVersion)
+      : startHeader + 1;
+  const sliceEnd =
+    endHeader > startHeader ? headerAt[endHeader].idx : (headerAt[startHeader + 1]?.idx ?? lines.length);
+
+  const bullets: string[] = [];
+  for (let i = headerAt[startHeader].idx + 1; i < sliceEnd; i++) {
+    const line = lines[i];
+    if (/^\*\s+/.test(line.trim())) {
+      const cleaned = cleanBullet(line.trim());
+      // Skip the generated catch-all rollup bullets (no conventional
+      // `**scope:**` prefix and very long) — they duplicate the per-scope
+      // ones; keep scoped bullets which are the useful highlights.
+      if (cleaned) bullets.push(cleaned);
+    }
+    if (bullets.length >= max) break;
+  }
+  return bullets;
+}

--- a/packages/backend/src/lib/health/notificationBatcher.test.ts
+++ b/packages/backend/src/lib/health/notificationBatcher.test.ts
@@ -129,7 +129,7 @@ describe('NotificationBatcher', () => {
     await NotificationBatcher._awaitFlushForTesting();
 
     expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
-    expect(sendEmailAlertMock.mock.calls[0][0]).toMatch(/3 health checks failing/);
+    expect(sendEmailAlertMock.mock.calls[0][0]).toMatch(/3 checks still failing/);
   });
 
   it('repeated start() calls are no-ops during an active window', () => {
@@ -186,5 +186,74 @@ describe('NotificationBatcher root-cause coalescing (#1652)', () => {
     const body = sendEmailAlertMock.mock.calls[0][1];
     expect(body).toContain('Internet Gateway');
     expect(body).toContain('Service: authelia');
+  });
+});
+
+describe('NotificationBatcher restart/update digest (#1653)', () => {
+  const baseRestart = {
+    currentVersion: '4.94.0',
+    previousVersion: '4.93.1',
+    versionChanged: true,
+    bootAt: Date.now() - 192_000, // ~3m12s ago
+    lastSeenAt: Date.now() - 192_000,
+    changelog: ['**health:** per-type failureThreshold before alerting'],
+  };
+
+  it('subject leads with the version change and lists still-failing checks', async () => {
+    NotificationBatcher._setRestartContextForTesting({ ...baseRestart });
+    NotificationBatcher.start({ maxMs: 60_000, settleMs: 1000 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.enqueue('fail', check('adguard'), result('fail'));
+    await NotificationBatcher.flush('manual');
+    const [subject, body] = sendEmailAlertMock.mock.calls[0];
+    expect(subject).toContain('updated to v4.94.0');
+    expect(subject).toMatch(/2 checks still failing \(nginx, adguard\)/);
+    expect(body).toContain('Updated to v4.94.0 (was v4.93.1)');
+    expect(body).toMatch(/Recovered in \d/);
+    expect(body).toContain('per-type failureThreshold');
+  });
+
+  it('sends on a version change even when nothing is still failing', async () => {
+    NotificationBatcher._setRestartContextForTesting({ ...baseRestart });
+    NotificationBatcher.start({ maxMs: 60_000, settleMs: 1000 });
+    // Everything came back cleanly — but the version changed, so we still
+    // tell the operator "we updated".
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.enqueue('recovery', check('nginx'), result('ok'));
+    await NotificationBatcher.flush('manual');
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    const [subject, body] = sendEmailAlertMock.mock.calls[0];
+    expect(subject).toContain('updated to v4.94.0');
+    expect(body).toContain('All health checks recovered cleanly');
+  });
+
+  it('stays silent on a plain no-version-change clean restart', async () => {
+    NotificationBatcher._setRestartContextForTesting({
+      ...baseRestart,
+      previousVersion: '4.94.0',
+      versionChanged: false,
+      changelog: [],
+    });
+    NotificationBatcher.start({ maxMs: 60_000, settleMs: 1000 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    NotificationBatcher.enqueue('recovery', check('nginx'), result('ok'));
+    await NotificationBatcher.flush('manual');
+    expect(sendEmailAlertMock).not.toHaveBeenCalled();
+  });
+
+  it('sends on remaining failure even with no version change', async () => {
+    NotificationBatcher._setRestartContextForTesting({
+      ...baseRestart,
+      previousVersion: '4.94.0',
+      versionChanged: false,
+      changelog: [],
+    });
+    NotificationBatcher.start({ maxMs: 60_000, settleMs: 1000 });
+    NotificationBatcher.enqueue('fail', check('nginx'), result('fail'));
+    await NotificationBatcher.flush('manual');
+    expect(sendEmailAlertMock).toHaveBeenCalledTimes(1);
+    const [subject, body] = sendEmailAlertMock.mock.calls[0];
+    expect(subject).toContain('1 check still failing');
+    expect(body).toContain('no version change');
   });
 });

--- a/packages/backend/src/lib/health/notificationBatcher.ts
+++ b/packages/backend/src/lib/health/notificationBatcher.ts
@@ -22,6 +22,8 @@
  * email path with no behaviour change.
  */
 
+import fs from 'fs';
+import path from 'path';
 import type { CheckConfig, CheckResult } from './types';
 import { logger } from '@/lib/logger';
 import { sendEmailAlert } from '@/lib/email';
@@ -30,6 +32,8 @@ import {
   makePrerequisiteContext,
   type ServiceDependencyMap,
 } from './prerequisiteChecks';
+import { readBootState, writeBootState, readAppVersion } from './bootState';
+import { extractChangelogHighlights } from './changelogHighlights';
 
 /** Hard cap on how long we'll hold alerts after boot. Covers the
  *  longest cold-start envelope (NPM + AdGuard + auth pods) plus a
@@ -51,6 +55,38 @@ interface PendingAlert {
   check: CheckConfig;
   result: CheckResult;
   queuedAt: number;
+}
+
+/** Restart framing captured at boot (#1653): did the version change across
+ *  this restart, and how long was the box down + recovering. */
+interface RestartContext {
+  /** Version the process is now running. */
+  currentVersion: string;
+  /** Version recorded at the previous boot — undefined on first boot. */
+  previousVersion?: string;
+  /** True when `currentVersion !== previousVersion` (and we knew a prior). */
+  versionChanged: boolean;
+  /** Epoch ms of this process's boot (when `start()` ran). */
+  bootAt: number;
+  /** Epoch ms of the last healthy heartbeat before this restart, if known —
+   *  the start of the downtime+recovery window. */
+  lastSeenAt?: number;
+  /** Changelog highlights for the versions crossed (empty if no change). */
+  changelog: string[];
+}
+
+/** Default location of the repo CHANGELOG.md, read for update highlights. */
+const CHANGELOG_PATH = path.join(process.cwd(), 'CHANGELOG.md');
+
+/** Humanise a millisecond span as e.g. "3m12s" / "45s" / "1h02m". */
+function formatDuration(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h${String(m).padStart(2, '0')}m`;
+  if (m > 0) return `${m}m${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
 }
 
 /** Format the same body the per-event path uses, kept inline so the
@@ -96,6 +132,18 @@ export class NotificationBatcher {
   private static serviceDeps: ServiceDependencyMap | null = null;
   private static hosts: import('../config').ProxyHostEntry[] = [];
 
+  /** Restart framing captured once at `start()` (#1653). Null until the
+   *  grace window opens. Drives the version-change / recovery-duration /
+   *  changelog lines and the "when to send" rule. */
+  private static restart: RestartContext | null = null;
+
+  /** Test seam: inject the restart context instead of reading package.json /
+   *  boot-state / CHANGELOG.md from disk. */
+  private static restartOverride: RestartContext | null = null;
+  static _setRestartContextForTesting(ctx: RestartContext | null): void {
+    this.restartOverride = ctx;
+  }
+
   /** Wire the root-cause graph for the boot digest. Called once from
    *  `HealthService.init` after the dependency graph is built. */
   static setRootCauseResolution(input: {
@@ -106,6 +154,49 @@ export class NotificationBatcher {
     this.hosts = input.hosts;
   }
 
+  /** Read the prior boot-state from disk, diff the version, load changelog
+   *  highlights when it changed, then persist the new boot-state so the
+   *  *next* restart can diff against this one. Best-effort: any failure
+   *  yields a minimal context (no version change, no changelog) rather than
+   *  throwing during boot. */
+  private static captureRestartContext(): RestartContext {
+    const bootAt = Date.now();
+    const currentVersion = readAppVersion();
+    const prior = readBootState();
+    const previousVersion = prior.lastSeenVersion;
+    const versionChanged = previousVersion !== undefined && previousVersion !== currentVersion;
+
+    let changelog: string[] = [];
+    if (versionChanged) {
+      try {
+        const text = fs.readFileSync(CHANGELOG_PATH, 'utf-8');
+        changelog = extractChangelogHighlights(text, currentVersion, previousVersion, { max: 6 });
+      } catch {
+        /* changelog unreadable — digest still reports the version change */
+      }
+    }
+
+    // Persist the new state immediately so a crash before flush still leaves
+    // the next boot a version to diff against.
+    writeBootState({ lastSeenVersion: currentVersion, lastSeenAt: bootAt });
+
+    return {
+      currentVersion,
+      previousVersion,
+      versionChanged,
+      bootAt,
+      lastSeenAt: prior.lastSeenAt,
+      changelog,
+    };
+  }
+
+  /** Refresh the persisted heartbeat so the *next* restart can measure
+   *  downtime as `now − lastSeenAt`. Called periodically by the health
+   *  poller from steady state. No-op-safe if boot-state is unwritable. */
+  static heartbeat(): void {
+    writeBootState({ lastSeenVersion: readAppVersion(), lastSeenAt: Date.now() });
+  }
+
   /** Initialise the grace window. Called from `HealthService.init`
    *  once per server start. Repeated calls are no-ops so HMR
    *  reloads in dev don't reset the timer. */
@@ -113,6 +204,7 @@ export class NotificationBatcher {
     if (this.active) return;
     this.active = true;
     this.pending = [];
+    this.restart = this.restartOverride ?? this.captureRestartContext();
     const maxMs = opts.maxMs ?? BOOT_GRACE_MAX_MS;
     this.settleMs = opts.settleMs ?? SETTLE_WINDOW_MS;
     this.maxGraceTimer = setTimeout(() => {
@@ -174,30 +266,29 @@ export class NotificationBatcher {
     const total = this.pending.length;
     this.pending = [];
 
-    if (stillFailing.length === 0) {
+    const restart = this.restart;
+    const versionChanged = restart?.versionChanged ?? false;
+
+    // When-to-send (#1653): send on a version change OR any remaining root
+    // failure. Stay silent only on a plain no-version-change clean restart —
+    // the uneventful case where nothing's failing and we're on the same
+    // version as before.
+    if (stillFailing.length === 0 && !versionChanged) {
       logger.info(
         'NotificationBatcher',
-        `Boot grace ${reason}: ${total} transient event${total === 1 ? '' : 's'} settled cleanly, no email sent.`,
+        `Boot grace ${reason}: ${total} transient event${total === 1 ? '' : 's'} settled cleanly, no version change, no email sent.`,
       );
       return;
     }
 
-    const subject =
-      stillFailing.length === 1
-        ? `Health check failing after boot: ${stillFailing[0].check.name}`
-        : `${stillFailing.length} health checks failing after boot`;
-
-    const summary = `ServiceBay boot grace window (${reason === 'settled' ? 'stabilised early' : 'max duration reached'}). `
-      + `${stillFailing.length} of ${finalState.size} unique check${finalState.size === 1 ? '' : 's'} `
-      + `that changed state during the window ${stillFailing.length === 1 ? 'is' : 'are'} still failing.`;
-
-    const body = `${summary}\n\n${stillFailing.map(a => formatAlert(a.kind, a.check, a.result)).join('\n---\n')}`;
+    const subject = this.buildSubject(stillFailing, restart);
+    const body = this.buildBody(stillFailing, finalState.size, reason, restart);
 
     try {
       await sendEmailAlert(subject, body);
       logger.info(
         'NotificationBatcher',
-        `Sent digest for ${stillFailing.length} still-failing check(s) after boot (${reason}).`,
+        `Sent restart digest (${reason}): ${stillFailing.length} still-failing root(s), versionChanged=${versionChanged}.`,
       );
     } catch (e) {
       logger.warn(
@@ -205,6 +296,74 @@ export class NotificationBatcher {
         `Digest email failed: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
+  }
+
+  /** Subject line (#1653). Leads with the restart framing — version change
+   *  if any — then the count of still-failing roots:
+   *    `ServiceBay restarted — updated to v4.94.0, 2 checks still failing (a, b)` */
+  private static buildSubject(
+    stillFailing: PendingAlert[],
+    restart: RestartContext | null,
+  ): string {
+    const head = restart?.versionChanged
+      ? `ServiceBay restarted — updated to v${restart.currentVersion}`
+      : `ServiceBay restarted`;
+
+    if (stillFailing.length === 0) {
+      // Reached only on a version change with a clean recovery.
+      return `${head}, all checks healthy`;
+    }
+    const names = stillFailing.map(a => a.check.name);
+    const shown = names.slice(0, 3).join(', ');
+    const more = names.length > 3 ? `, +${names.length - 3} more` : '';
+    const plural = stillFailing.length === 1 ? 'check' : 'checks';
+    return `${head}, ${stillFailing.length} ${plural} still failing (${shown}${more})`;
+  }
+
+  /** Digest body (#1653): restart framing (version change, recovery
+   *  duration, changelog highlights) followed by the still-failing roots. */
+  private static buildBody(
+    stillFailing: PendingAlert[],
+    uniqueChanged: number,
+    reason: 'settled' | 'max-grace-elapsed' | 'manual',
+    restart: RestartContext | null,
+  ): string {
+    const sections: string[] = [];
+
+    if (restart) {
+      const framing: string[] = [];
+      if (restart.versionChanged) {
+        framing.push(`Updated to v${restart.currentVersion} (was v${restart.previousVersion}).`);
+      } else {
+        framing.push(`Restarted on v${restart.currentVersion} — no version change.`);
+      }
+      // Recovery duration: from the last healthy heartbeat before the
+      // restart (downtime start) through to now (all settled). Falls back to
+      // boot→now when no prior heartbeat is known (first boot).
+      const recoveredFrom = restart.lastSeenAt ?? restart.bootAt;
+      framing.push(`Recovered in ${formatDuration(Date.now() - recoveredFrom)}.`);
+      sections.push(framing.join(' '));
+
+      if (restart.changelog.length > 0) {
+        sections.push(
+          `What changed:\n${restart.changelog.map(h => `  • ${h}`).join('\n')}`,
+        );
+      }
+    }
+
+    if (stillFailing.length === 0) {
+      sections.push('All health checks recovered cleanly after the restart.');
+      return sections.join('\n\n');
+    }
+
+    const summary =
+      `Boot grace window (${reason === 'settled' ? 'stabilised early' : reason === 'max-grace-elapsed' ? 'max duration reached' : 'flushed'}). `
+      + `${stillFailing.length} of ${uniqueChanged} unique check${uniqueChanged === 1 ? '' : 's'} `
+      + `that changed state during the window ${stillFailing.length === 1 ? 'is' : 'are'} still failing (root cause${stillFailing.length === 1 ? '' : 's'} only).`;
+    sections.push(summary);
+    sections.push(stillFailing.map(a => formatAlert(a.kind, a.check, a.result)).join('\n---\n'));
+
+    return sections.join('\n\n');
   }
 
   /** Collapse a buffered fail set to root causes only (#1652). When the
@@ -235,6 +394,8 @@ export class NotificationBatcher {
     this.active = false;
     this.serviceDeps = null;
     this.hosts = [];
+    this.restart = null;
+    this.restartOverride = null;
   }
 
   /** Test-only: peek at the pending buffer. */

--- a/packages/backend/src/lib/health/service.ts
+++ b/packages/backend/src/lib/health/service.ts
@@ -28,6 +28,11 @@ const intervals = new Map<string, NodeJS.Timeout>();
 
 const CHECKS_FILE = path.join(DATA_DIR, 'checks.json');
 
+/** How often the boot-state heartbeat is refreshed (#1653) so the next
+ *  restart can diff the version + measure downtime. 60 s matches the
+ *  default check cadence and stays well inside the boot-grace window. */
+const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+
 export class HealthService {
   private static io: Server | null = null;
 
@@ -62,6 +67,17 @@ export class HealthService {
     //     the cold-start race. See NotificationBatcher for the
     //     coalescing rules.
     NotificationBatcher.start();
+
+    // 1b-ii. Periodic boot-state heartbeat (#1653). Persists "we are up on
+    //     vX right now" so the NEXT restart can report the version change and
+    //     measure downtime as `now − lastSeenAt`. Cheap (one small JSON
+    //     write) and well under the boot-grace window so an unclean crash
+    //     still leaves a recent healthy timestamp.
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = setInterval(() => {
+      NotificationBatcher.heartbeat();
+    }, HEARTBEAT_INTERVAL_MS);
+    if (typeof this.heartbeatTimer.unref === 'function') this.heartbeatTimer.unref();
 
     // 1c. Daily self-diagnose run (#1423). The diagnose suite is heavy
     //     (multi-probe agent fan-out), so it runs once a day rather than
@@ -98,6 +114,7 @@ export class HealthService {
 
   private static checksWatcher: fs.FSWatcher | null = null;
   private static checksWatcherDebounce: NodeJS.Timeout | null = null;
+  private static heartbeatTimer: NodeJS.Timeout | null = null;
   private static bootstrappedNodes = new Set<string>();
   private static twinUnsubscribe: (() => void) | null = null;
 


### PR DESCRIPTION
## What
Enriches the boot-grace restart/update digest: it now frames a restart instead of just listing still-failing checks. Persists last-seen version + a periodic heartbeat to a small boot-state file, so on the next boot it reports the version change, measures recovery duration, and pulls CHANGELOG.md highlights when the version moved. Still-failing checks collapse to root causes via the #1652 resolver. Send rule: on a version change OR any remaining root failure; silent only on a plain no-version-change clean restart.

This **completes epic #1650** (alert-storm reduction). All three children shipped:
- #1651 — per-type failure thresholds (alert only after N consecutive fails)
- #1652 — root-cause-only alerting + service-centered causal-chain email
- #1653 — restart digest enrichment (this PR)

## Why
Closes #1653

## Risk
Low — alert-email/digest behaviour only; no install/backup/config path touched. Per-check UI status unchanged.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 1976 passed)
- [ ] /verify on FCoS :dev box — N/A (health/notificationBatcher.ts not path-mandated; digest is unit-tested, not :dev-box-verifiable)