### PR TITLE
fix(health,portal): alert root-cause correctness + portal down badge

### DIFF
--- a/packages/backend/src/lib/health/alertDecision.test.ts
+++ b/packages/backend/src/lib/health/alertDecision.test.ts
@@ -28,12 +28,20 @@ function check(type: CheckType, overrides: Partial<CheckConfig> = {}): CheckConf
   };
 }
 
-/** Build a newest-first history from a status string like 'ffo' (fail,fail,ok). */
+/**
+ * Build a newest-first history from a status string. Chars:
+ *   'o' = ok, 'f' = fail (not alerted), 'A' = fail that emitted an alert
+ *   (the persisted `alerted` flag #1661 set by runAndEmit on a root failure).
+ * Recovery (#1661) keys on the `alerted` flag, so a fail streak that met the
+ * threshold but was root-cause-suppressed uses 'f', and one that actually
+ * alerted uses 'A'.
+ */
 function history(statuses: string): CheckResult[] {
   return statuses.split('').map((s, i) => ({
     check_id: 'c1',
     timestamp: new Date(2026, 0, 1, 0, 0, i).toISOString(),
-    status: s === 'f' ? 'fail' : 'ok',
+    status: s === 'o' ? 'ok' : 'fail',
+    ...(s === 'A' ? { alerted: true } : {}),
   }));
 }
 
@@ -113,33 +121,42 @@ describe('decideAlert — failure threshold (#1651)', () => {
   });
 });
 
-describe('decideAlert — recovery (#1651)', () => {
+describe('decideAlert — recovery (#1661)', () => {
   it('does NOT recover if no fail alert was ever sent (single flaky fail)', () => {
-    // domain threshold 3: one fail then ok → never alerted → no recovery.
-    const d = decideAlert(check('domain'), history('off'.replace('ff', 'f') /* 'of' */));
+    // one fail then ok → never alerted → no recovery.
+    const d = decideAlert(check('domain'), history('of'));
     expect(d.alertRecovery).toBe(false);
   });
 
-  it('does NOT recover when the prior fail streak was below threshold', () => {
-    // 2 fails (below 3) then ok → no alert was sent → no recovery email.
+  it('does NOT recover when the prior fail streak was never alerted', () => {
+    // fails that were never flagged `alerted` (below threshold OR root-cause
+    // suppressed) → no alert was sent → no recovery email.
     const d = decideAlert(check('domain'), history('off'));
     expect(d.alertRecovery).toBe(false);
   });
 
-  it('recovers when the prior fail streak had reached the threshold', () => {
-    // 3 fails (alerted) then ok → recovery fires.
-    const d = decideAlert(check('domain'), history('offf'));
+  it('recovers when the prior fail streak actually alerted', () => {
+    // fails reaching the alert (one flagged 'A') then ok → recovery fires.
+    const d = decideAlert(check('domain'), history('offA'));
     expect(d.alertRecovery).toBe(true);
     expect(d.alertFailure).toBe(false);
   });
 
+  it('does NOT recover a downstream symptom suppressed by root-cause (#1661)', () => {
+    // The fail streak reached the per-type threshold (3 fails) but was
+    // root-cause-suppressed, so none carry the `alerted` flag. Symmetric with
+    // the failure side: no fail email was sent, so no recovery email either.
+    const d = decideAlert(check('domain'), history('offf'));
+    expect(d.alertRecovery).toBe(false);
+  });
+
   it('recovers a backup check after its single-fail alert', () => {
-    expect(decideAlert(check('backup'), history('of')).alertRecovery).toBe(true);
+    expect(decideAlert(check('backup'), history('oA')).alertRecovery).toBe(true);
   });
 
   it('does not double-recover (second ok after recovery)', () => {
-    // 'ooff…' newest-first: current ok, prev ok → prior fail streak 0.
-    expect(decideAlert(check('domain'), history('ooffff')).alertRecovery).toBe(false);
+    // 'ooA…' newest-first: current ok, prev ok → no fail in the prior streak.
+    expect(decideAlert(check('domain'), history('ooAAAA')).alertRecovery).toBe(false);
   });
 
   it('first-ever result (ok, no history) does nothing', () => {

--- a/packages/backend/src/lib/health/alertDecision.ts
+++ b/packages/backend/src/lib/health/alertDecision.ts
@@ -87,8 +87,15 @@ export interface AlertDecision {
  *
  * Failure alert fires on the tick where the consecutive-fail streak first
  * **reaches** the threshold (not on every subsequent fail). Recovery fires
- * on the first `ok` tick only if the prior streak had reached the
- * threshold — i.e. a fail alert was actually sent.
+ * on the first `ok` tick only if a failure alert was actually emitted during
+ * the immediately-preceding fail streak — i.e. some result in that streak
+ * carries the persisted `alerted` flag (#1661). The flag is the single
+ * source of truth for "did the operator see a failure email": it is set only
+ * after BOTH the #1651 threshold and the #1652 root-cause gate passed, so a
+ * downstream symptom that was suppressed as a cascade leaf (streak met the
+ * threshold but it wasn't the root) never recovers. Falling back to a bare
+ * streak≥threshold check would re-introduce the recovery-side storm this
+ * decision exists to prevent.
  */
 export function decideAlert(check: CheckConfig, history: CheckResult[]): AlertDecision {
   const threshold = getFailureThreshold(check);
@@ -102,8 +109,20 @@ export function decideAlert(check: CheckConfig, history: CheckResult[]): AlertDe
   }
 
   // current.status === 'ok' → potential recovery. Recover only if the
-  // immediately-preceding fail streak had reached the alert threshold
-  // (otherwise no fail alert was ever sent, so there's nothing to recover).
-  const priorFailStreak = countConsecutiveFails(history.slice(1));
-  return { alertFailure: false, alertRecovery: priorFailStreak >= threshold };
+  // immediately-preceding fail streak actually emitted a failure alert
+  // (some result in it is flagged `alerted`). A streak that merely reached
+  // the threshold but was root-cause-suppressed (#1652) carries no flag, so
+  // it stays silent — keeping the failure and recovery sides symmetric.
+  const priorStreak = priorFailStreakResults(history);
+  return { alertFailure: false, alertRecovery: priorStreak.some(r => r.alerted === true) };
+}
+
+/** The contiguous fail results immediately preceding the head `ok` result. */
+function priorFailStreakResults(history: CheckResult[]): CheckResult[] {
+  const streak: CheckResult[] = [];
+  for (const r of history.slice(1)) {
+    if (r.status !== 'fail') break;
+    streak.push(r);
+  }
+  return streak;
 }

--- a/packages/backend/src/lib/health/prerequisiteChecks.test.ts
+++ b/packages/backend/src/lib/health/prerequisiteChecks.test.ts
@@ -7,6 +7,7 @@ import {
   isRootCause,
   enumerateDownstreamFailing,
   renderCausalChainEmail,
+  serviceOfCheck,
   type ServiceDependencyMap,
 } from './prerequisiteChecks';
 import type { CheckConfig, CheckResult } from './types';
@@ -102,6 +103,55 @@ describe('isRootCause', () => {
     expect(isRootCause(autheliaSvc, ctx)).toBe(true);
     expect(isRootCause(immichDomain, ctx)).toBe(false);
     expect(isRootCause(vaultDomain, ctx)).toBe(false);
+  });
+});
+
+describe('serviceOfCheck — template http/script slug binding (#1663)', () => {
+  // home-assistant ships an `http` API probe whose id slug leads with the
+  // service name; the service itself has a container check.
+  const haSvc = chk({ id: 'svc-home-assistant', type: 'service', target: 'home-assistant', name: 'Service: home-assistant' });
+  const haApi = chk({ id: 'home-assistant-api', type: 'http', target: 'http://ha:8123', name: 'home-assistant-api' });
+  const ollamaSvc = chk({ id: 'svc-ollama', type: 'service', target: 'ollama', name: 'Service: ollama' });
+  const ollamaApi = chk({ id: 'ollama-api', type: 'http', target: 'http://ollama:11434', name: 'ollama-api' });
+  const bareScript = chk({ id: 'ollama', type: 'script', target: 'echo', name: 'ollama' });
+  const orphanApi = chk({ id: 'nonexistent-api', type: 'http', target: 'http://x', name: 'nonexistent-api' });
+
+  const ctx = makePrerequisiteContext({
+    checks: [haSvc, haApi, ollamaSvc, ollamaApi, bareScript, orphanApi],
+    serviceDeps: new Map(),
+    config: undefined,
+    isFailing: () => false,
+  });
+
+  it('binds an http probe to its owning service via the longest slug prefix', () => {
+    // home-assistant-api → home-assistant (not "home"); the hyphenated
+    // service name must win the longest-prefix match.
+    expect(serviceOfCheck(haApi, ctx)).toBe('home-assistant');
+    expect(serviceOfCheck(ollamaApi, ctx)).toBe('ollama');
+  });
+
+  it('binds a bare-slug script probe to a same-named service', () => {
+    expect(serviceOfCheck(bareScript, ctx)).toBe('ollama');
+  });
+
+  it('returns null when no container-checked service owns the slug', () => {
+    expect(serviceOfCheck(orphanApi, ctx)).toBeNull();
+  });
+
+  it('an http probe gets its service container check as a prerequisite', () => {
+    expect(resolvePrerequisiteChecks(haApi, ctx)).toContain('svc-home-assistant');
+  });
+
+  it('a container outage makes the http probe a downstream symptom, not a root', () => {
+    const failingCtx = makePrerequisiteContext({
+      checks: [haSvc, haApi],
+      serviceDeps: new Map(),
+      config: undefined,
+      isFailing: (id) => id === 'svc-home-assistant' || id === 'home-assistant-api',
+    });
+    // container check is the root; the API probe collapses under it.
+    expect(isRootCause(haApi, failingCtx)).toBe(false);
+    expect(isRootCause(haSvc, failingCtx)).toBe(true);
   });
 });
 

--- a/packages/backend/src/lib/health/prerequisiteChecks.ts
+++ b/packages/backend/src/lib/health/prerequisiteChecks.ts
@@ -137,10 +137,35 @@ export function serviceOfCheck(check: CheckConfig, ctx: PrerequisiteContext): st
     const host = ctx.hosts.find(h => h.domain === check.target);
     return host?.service ?? null;
   }
-  // Template-registered http/script probes carry an id slug whose leading
-  // segment is the owning service (init.ts isOrphanTemplateCheck). We only
-  // bind one when that leading segment matches a known service container check.
+  // Template-registered http/script/tcp probes carry an id slug whose leading
+  // segment is the owning service (init.ts isOrphanTemplateCheck): the id is
+  // `<service>` or `<service>-<suffix>`, e.g. `home-assistant-api`,
+  // `ollama-api`. Bind one to its service when the leading slug segment(s)
+  // match a service that has a container (`type:'service'`) check — so a
+  // container outage suppresses the probe's separate alert (#1663). Service
+  // names can themselves contain hyphens (`home-assistant`), so we
+  // longest-match against the known container-check targets, not the first
+  // segment alone.
+  if (check.type === 'http' || check.type === 'script' || check.type === 'tcp') {
+    return serviceFromTemplateSlug(check.id, ctx);
+  }
   return null;
+}
+
+/** Resolve a template-check id slug to its owning service by longest-prefix
+ *  match against services that have a container check. `home-assistant-api`
+ *  binds to `home-assistant` (not `home`); a bare `<service>` slug binds to
+ *  that service. Returns null when no container-checked service owns the slug. */
+function serviceFromTemplateSlug(id: string, ctx: PrerequisiteContext): string | null {
+  let best: string | null = null;
+  for (const c of ctx.checks) {
+    if (c.type !== 'service' || !c.target) continue;
+    const svc = c.target;
+    if (id === svc || id.startsWith(`${svc}-`)) {
+      if (!best || svc.length > best.length) best = svc;
+    }
+  }
+  return best;
 }
 
 /** The `type:'service'` container check for a service, if one exists. */

--- a/packages/backend/src/lib/health/prerequisiteChecks.ts
+++ b/packages/backend/src/lib/health/prerequisiteChecks.ts
@@ -137,7 +137,7 @@ export function serviceOfCheck(check: CheckConfig, ctx: PrerequisiteContext): st
     const host = ctx.hosts.find(h => h.domain === check.target);
     return host?.service ?? null;
   }
-  // Template-registered http/script/tcp probes carry an id slug whose leading
+  // Template-registered http/script probes carry an id slug whose leading
   // segment is the owning service (init.ts isOrphanTemplateCheck): the id is
   // `<service>` or `<service>-<suffix>`, e.g. `home-assistant-api`,
   // `ollama-api`. Bind one to its service when the leading slug segment(s)
@@ -146,7 +146,7 @@ export function serviceOfCheck(check: CheckConfig, ctx: PrerequisiteContext): st
   // names can themselves contain hyphens (`home-assistant`), so we
   // longest-match against the known container-check targets, not the first
   // segment alone.
-  if (check.type === 'http' || check.type === 'script' || check.type === 'tcp') {
+  if (check.type === 'http' || check.type === 'script') {
     return serviceFromTemplateSlug(check.id, ctx);
   }
   return null;

--- a/packages/backend/src/lib/health/service.test.ts
+++ b/packages/backend/src/lib/health/service.test.ts
@@ -40,11 +40,15 @@ const { getResultsMock, runMock, sendEmailMock, getChecksMock, getLastResultMock
       }>,
   ),
 }));
+const { markAlertedMock } = vi.hoisted(() => ({
+  markAlertedMock: vi.fn((_id: string) => undefined),
+}));
 vi.mock('./store', () => ({
   HealthStore: {
     getChecks: () => getChecksMock(),
     getResults: (id: string) => getResultsMock(id),
     getLastResult: (id: string) => getLastResultMock(id),
+    markLastResultAlerted: (id: string) => markAlertedMock(id),
   },
 }));
 vi.mock('@/lib/registry', () => ({ getTemplates: vi.fn().mockResolvedValue([]) }));
@@ -167,6 +171,8 @@ describe('HealthService bootstrap-on-sync (#935)', () => {
 describe('HealthService.runAndEmit alert gating (#1651)', () => {
   const check: CheckConfig = { id: 'domain:photos', name: 'Photos', type: 'domain' } as CheckConfig;
   const failResult: CheckResult = { check_id: 'domain:photos', status: 'fail', message: 'down', latency: 0, timestamp: 't' };
+  // A fail that actually emitted an alert carries the persisted #1661 flag.
+  const alertedFail: CheckResult = { ...failResult, alerted: true };
   const okResult: CheckResult = { check_id: 'domain:photos', status: 'ok', message: '', latency: 1, timestamp: 't' };
   // runAndEmit is a private static; reach it via cast (established pattern below).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -178,6 +184,7 @@ describe('HealthService.runAndEmit alert gating (#1651)', () => {
     getResultsMock.mockReset().mockReturnValue([]);
     getChecksMock.mockReset().mockReturnValue([]);
     getLastResultMock.mockReset().mockReturnValue(null);
+    markAlertedMock.mockReset();
     fakeIo.emit.mockClear();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (HealthService as any).io = fakeIo;
@@ -195,19 +202,22 @@ describe('HealthService.runAndEmit alert gating (#1651)', () => {
     expect(fakeIo.emit).toHaveBeenCalledWith('health:update', { checkId: 'domain:photos', result: failResult });
   });
 
-  it('alerts (emit + email) on the third consecutive fail', async () => {
+  it('alerts (emit + email) on the third consecutive fail and flags the result alerted', async () => {
     runMock.mockResolvedValue(failResult);
     getResultsMock.mockReturnValue([failResult, failResult, failResult]); // streak of 3
     await runAndEmit(check);
     expect(fakeIo.emit).toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'error' }));
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
     expect(sendEmailMock.mock.calls[0][0]).toContain('Photos');
+    // #1661: the emitted failure persists the `alerted` flag so its recovery
+    // can later fire symmetrically.
+    expect(markAlertedMock).toHaveBeenCalledWith('domain:photos');
   });
 
-  it('sends a recovery alert only when a prior fail alert was sent', async () => {
+  it('sends a recovery alert only when a prior fail actually alerted', async () => {
     runMock.mockResolvedValue(okResult);
-    // ok now, preceded by a fail streak that met the threshold.
-    getResultsMock.mockReturnValue([okResult, failResult, failResult, failResult]);
+    // ok now, preceded by a fail streak that emitted an alert (#1661 flag).
+    getResultsMock.mockReturnValue([okResult, alertedFail, failResult, failResult]);
     await runAndEmit(check);
     expect(fakeIo.emit).toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'success' }));
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
@@ -217,6 +227,16 @@ describe('HealthService.runAndEmit alert gating (#1651)', () => {
     runMock.mockResolvedValue(okResult);
     // ok now, only one prior fail (below the 3 threshold) → no alert was sent.
     getResultsMock.mockReturnValue([okResult, failResult]);
+    await runAndEmit(check);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(fakeIo.emit).not.toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'success' }));
+  });
+
+  it('does not recover a downstream symptom whose fail was root-cause-suppressed (#1661)', async () => {
+    runMock.mockResolvedValue(okResult);
+    // The prior streak met the threshold (3 fails) but was suppressed as a
+    // cascade leaf, so none carry the `alerted` flag → no recovery email.
+    getResultsMock.mockReturnValue([okResult, failResult, failResult, failResult]);
     await runAndEmit(check);
     expect(sendEmailMock).not.toHaveBeenCalled();
     expect(fakeIo.emit).not.toHaveBeenCalledWith('health:alert', expect.objectContaining({ type: 'success' }));

--- a/packages/backend/src/lib/health/service.ts
+++ b/packages/backend/src/lib/health/service.ts
@@ -346,6 +346,14 @@ export class HealthService {
       const enteredFailure = thresholdMet && isRoot;
       const failTitle = chainEmail?.subject ?? `Check Failed: ${check.name}`;
 
+      // Persist that THIS failure actually alerted (#1661), so the recovery
+      // side stays symmetric: a downstream symptom suppressed as a cascade
+      // leaf never gets the flag and therefore never emits a standalone
+      // "Service Recovered". Only the root's failure is flagged here.
+      if (enteredFailure) {
+        HealthStore.markLastResultAlerted(check.id);
+      }
+
       this.emitAlerts(check, result, { enteredFailure, recoveredNow, failTitle });
 
       if (enteredFailure && !NotificationBatcher.enqueue('fail', check, result)) {

--- a/packages/backend/src/lib/health/store.test.ts
+++ b/packages/backend/src/lib/health/store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
-import type { CheckConfig } from './types';
+import type { CheckConfig, CheckResult } from './types';
 
 // Point DATA_DIR at a fresh temp dir BEFORE importing the store (dirs.ts
 // reads process.env.DATA_DIR at module load).
@@ -70,5 +70,43 @@ describe('HealthStore.deleteServiceCheck (#1506)', () => {
 
     expect(removed).toBe(0);
     expect(HealthStore.getChecks().map(c => c.target).sort()).toEqual(['192.168.178.1', 'immich']);
+  });
+});
+
+describe('HealthStore.markLastResultAlerted (#1661)', () => {
+  let HealthStore: typeof import('./store').HealthStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'healthstore-'));
+    vi.resetModules();
+    process.env.DATA_DIR = tmpDir;
+    ({ HealthStore } = await import('./store'));
+  });
+
+  afterEach(async () => {
+    delete process.env.DATA_DIR;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Use recent timestamps — saveResult drops anything older than the 7-day
+  // retention window, so a fixed past date would be filtered out on save.
+  const result = (status: 'ok' | 'fail', secondsAgo: number): CheckResult => ({
+    check_id: 'c1', status, timestamp: new Date(Date.now() - secondsAgo * 1000).toISOString(),
+  });
+
+  it('flags the most-recent result and leaves older ones untouched', () => {
+    HealthStore.saveResult(result('fail', 2)); // older
+    HealthStore.saveResult(result('fail', 1)); // newest-first: [1, 2]
+
+    HealthStore.markLastResultAlerted('c1');
+
+    const results = HealthStore.getResults('c1');
+    expect(results[0].alerted).toBe(true);
+    expect(results[1].alerted).toBeUndefined();
+  });
+
+  it('is a no-op when the check has no persisted result', () => {
+    expect(() => HealthStore.markLastResultAlerted('never-run')).not.toThrow();
+    expect(HealthStore.getResults('never-run')).toEqual([]);
   });
 });

--- a/packages/backend/src/lib/health/store.ts
+++ b/packages/backend/src/lib/health/store.ts
@@ -135,4 +135,29 @@ export class HealthStore {
     const results = this.getResults(checkId);
     return results.length > 0 ? results[0] : null;
   }
+
+  /**
+   * Mark the most-recent persisted result for a check as having emitted a
+   * failure alert (#1661). `runAndEmit` calls this after the #1651 threshold
+   * and #1652 root-cause gates both pass, so the recovery side can later tell
+   * an alerted failure (recover) from a suppressed downstream symptom (stay
+   * silent). No-op if there is no persisted result yet.
+   */
+  static markLastResultAlerted(checkId: string): void {
+    const resultFile = path.join(RESULTS_DIR, `${checkId}.json`);
+    if (!fs.existsSync(resultFile)) return;
+    let results: CheckResult[];
+    try {
+      results = JSON.parse(fs.readFileSync(resultFile, 'utf-8'));
+    } catch {
+      return;
+    }
+    if (results.length === 0) return;
+    results[0].alerted = true;
+    try {
+      fs.writeFileSync(resultFile, JSON.stringify(results, null, 2));
+    } catch (e) {
+      logger.error('HealthStore', `Failed to mark alerted for ${checkId}:`, e);
+    }
+  }
 }

--- a/packages/backend/src/lib/health/types.ts
+++ b/packages/backend/src/lib/health/types.ts
@@ -130,6 +130,17 @@ export interface CheckResult {
    * same field — each consumer narrows it.
    */
   payload?: unknown;
+  /**
+   * True when this `fail` result actually emitted a failure alert (#1661).
+   * Set by `runAndEmit` after the #1651 threshold AND the #1652 root-cause
+   * gate both passed — i.e. an operator-visible "Check Failed" / causal-chain
+   * email (or toast) went out for this tick. A downstream symptom suppressed
+   * as a cascade leaf never gets the flag, so the recovery side can stay
+   * symmetric: only a check that actually alerted on failure emits a
+   * standalone "Service Recovered". Absent/false on `ok` results and on
+   * suppressed fails.
+   */
+  alerted?: boolean;
 }
 
 /**

--- a/packages/backend/src/lib/portal/buildPortalCards.test.ts
+++ b/packages/backend/src/lib/portal/buildPortalCards.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Integration coverage for the #1662 fix: a stopped-but-installed feature
+ * service must still produce a portal card (with a `down`/"Not running"
+ * badge) instead of being filtered out before card assembly.
+ */
+
+const listServices = vi.fn();
+const getServices = vi.fn();
+const getLastResult = vi.fn();
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => ({ reverseProxy: { hosts: [] }, templateSettings: {} })),
+}));
+vi.mock('@/lib/mode', () => ({
+  getActiveDomain: () => 'home.arpa',
+  getMode: () => 'lan',
+}));
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: (node?: string) => listServices(node) },
+}));
+vi.mock('@/lib/store/repository', () => ({
+  getServices: (node?: string) => getServices(node),
+}));
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: { getLastResult: (id: string) => getLastResult(id) },
+}));
+vi.mock('@/lib/registry', () => ({
+  getTemplateUserGuide: vi.fn(async () => '# guide\nbody'),
+}));
+vi.mock('@/lib/templateTier', () => ({ parseTemplateTier: () => 'app' }));
+vi.mock('@/lib/templateLabel', () => ({ parseTemplateLabel: () => 'Immich' }));
+vi.mock('./userGuide', () => ({
+  parseUserGuide: () => ({ frontmatter: {}, body: 'body' }),
+}));
+
+// fs reads: template.yml (any non-null string) + variables.json (a subdomain var).
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: vi.fn(async (p: string) => {
+      if (p.endsWith('variables.json')) {
+        return JSON.stringify({
+          IMMICH_SUBDOMAIN: { type: 'subdomain', default: 'photos' },
+        });
+      }
+      return 'apiVersion: v1\n'; // template.yml
+    }),
+  },
+}));
+
+import { buildPortalCards } from './services';
+
+const svc = (name: string, active: boolean) => ({
+  name,
+  active,
+  kubeFile: '',
+  kubePath: '',
+  yamlFile: null,
+  yamlPath: null,
+  status: active ? 'active' : 'inactive',
+  ports: [],
+  volumes: [],
+  labels: {},
+});
+
+describe('buildPortalCards stopped-service down badge (#1662)', () => {
+  beforeEach(() => {
+    listServices.mockReset();
+    getServices.mockReset().mockReturnValue([]);
+    getLastResult.mockReset().mockReturnValue(null);
+  });
+
+  it('renders a stopped installed service with a down/"Not running" badge', async () => {
+    listServices.mockResolvedValue([svc('immich', false)]);
+
+    const cards = await buildPortalCards();
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].name).toBe('immich');
+    expect(cards[0].status).toBe('down');
+    expect(cards[0].statusReason).toBe('Not running');
+  });
+
+  it('keeps a running service with no health signal as unknown (not down)', async () => {
+    listServices.mockResolvedValue([svc('immich', true)]);
+
+    const cards = await buildPortalCards();
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].status).toBe('unknown');
+  });
+});

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -379,9 +379,13 @@ async function buildPortalCardEntry(
  * card assembly.
  */
 export async function buildPortalCards(node: string = 'Local'): Promise<PortalCard[]> {
+  // Build cards for every *installed* service, not just the active ones.
+  // A stopped-but-installed service (`active: false`) must still render a
+  // card so `resolveCardStatus` can surface its `down`/"Not running" badge
+  // (#1662) — filtering to active services here made that branch
+  // unreachable and silently dropped a stopped service from the portal.
   const services = await ServiceManager.listServices(node).catch(() => []);
-  const running = services.filter(s => s.active);
-  if (running.length === 0) return [];
+  if (services.length === 0) return [];
 
   const config = await getConfig();
 
@@ -397,7 +401,7 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
   }
 
   const cards: PortalCard[] = [];
-  for (const svc of running) {
+  for (const svc of services) {
     const yaml = await readTemplateYaml(svc.name);
     if (!yaml) continue; // Service whose template isn't on disk — skip
     const tier = parseTemplateTier(yaml);


### PR DESCRIPTION
## What
Three correctness fixes found by the codebase eval against the alert subsystem (#1652) and portal status badges (#1654): gate recovery alerts through root-cause suppression, bind template http/script probes to their owning service so they collapse under the container check, and build portal cards for stopped feature services so the down/Not-running badge is actually reachable.

## Why
Closes #1661
Closes #1663
Closes #1662

## Risk
Low — #1661/#1663 are backend alert-graph behaviour (unit-tested); #1662 surfaces an already-implemented but dead portal badge branch.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 343 warnings)
- [x] npm run check:arch
- [x] npm test (full — 1987 passed)
- [ ] /verify on FCoS :dev box — #1662 touches path-mandated packages/frontend/src/app/portal/; light :dev confirm a stopped/installed service shows a down/degraded badge on /portal