### PR TITLE
fix: box-DNS resolution, monitoring trust, sb launcher/boot, SQLite WAL, nginx config-valid probe

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.test.ts
@@ -11,8 +11,11 @@ vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-vi.mock('dns/promises', () => ({
-  default: { resolve4: (h: string) => resolve4(h) },
+// The probe now resolves via the LAN path (AdGuard) rather than the OS
+// resolver — mock that helper. The mock returns A-records by hostname so
+// the per-call assertions below still pin which domains were looked up.
+vi.mock('@/lib/router/lanResolver', () => ({
+  resolve4ViaLan: (h: string) => resolve4(h),
 }));
 
 import { checkDomainResolvesToBox } from './domainResolvesToBox';
@@ -58,7 +61,8 @@ describe('domain_resolves_to_box', () => {
     getConfig.mockResolvedValue({
       reverseProxy: { publicDomain: 'dopp.cloud', lanIp: '192.168.178.100', hosts: [] },
     });
-    resolve4.mockRejectedValue(new Error('ENOTFOUND'));
+    // resolve4ViaLan swallows resolver errors and returns null — mirror that.
+    resolve4.mockResolvedValue(null);
     const r = await checkDomainResolvesToBox();
     expect(r.status).toBe('fail');
     expect(r.detail).toContain('does not resolve');
@@ -74,6 +78,23 @@ describe('domain_resolves_to_box', () => {
     expect(r.status).toBe('fail');
     expect(r.detail).toContain('expected 192.168.178.100');
     expect(r.hint).toContain('DHCP DNS');
+  });
+
+  it('resolves via the LAN/AdGuard path (not the OS resolver) — passes the box lanIp through', async () => {
+    const lanSpy = vi.fn().mockResolvedValue(['192.168.178.100']);
+    const mod = await import('@/lib/router/lanResolver');
+    const orig = mod.resolve4ViaLan;
+    // Re-point the mocked helper to a spy that records the (host, lanIp) pair.
+    (resolve4 as unknown as { mockImplementation: (f: (h: string) => unknown) => void }).mockImplementation(
+      (h: string) => lanSpy(h, '192.168.178.100'),
+    );
+    getConfig.mockResolvedValue({
+      reverseProxy: { publicDomain: 'dopp.cloud', lanIp: '192.168.178.100', hosts: [] },
+    });
+    const r = await checkDomainResolvesToBox();
+    expect(r.status).toBe('ok');
+    expect(lanSpy).toHaveBeenCalledWith('auth.dopp.cloud', '192.168.178.100');
+    void orig;
   });
 
   it('skips LAN-only hosts (resolved via AdGuard rewrites, not the box resolver)', async () => {

--- a/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.ts
@@ -34,12 +34,11 @@
  * reinstall, #1559).
  */
 
-import dns from 'dns/promises';
 import { getConfig, type ProxyHostEntry, type AppConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
+import { resolve4ViaLan } from '@/lib/router/lanResolver';
 
 const PROBE_ID = 'domain_resolves_to_box';
-const DNS_TIMEOUT_MS = 3000;
 
 /** SSO-precondition subdomains under `publicDomain` that always need to
  *  resolve to the box, whether or not a proxy host is recorded for them
@@ -82,21 +81,6 @@ function buildCoreDomains(config: AppConfig): string[] {
   return Array.from(new Set(domains));
 }
 
-/** Resolve a hostname's IPv4 A-records via the OS resolver, with a hard
- *  timeout. Returns null on NXDOMAIN / SERVFAIL / timeout / any error —
- *  the caller treats null as "does not resolve". */
-async function resolve4OrNull(hostname: string): Promise<string[] | null> {
-  try {
-    const records = await Promise.race([
-      dns.resolve4(hostname),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('dns timeout')), DNS_TIMEOUT_MS)),
-    ]);
-    return records.length > 0 ? records : null;
-  } catch {
-    return null;
-  }
-}
-
 export async function checkDomainResolvesToBox(): Promise<DomainResolvesToBoxResult> {
   const config = await getConfig();
   const lanIp = config.reverseProxy?.lanIp;
@@ -117,7 +101,11 @@ export async function checkDomainResolvesToBox(): Promise<DomainResolvesToBoxRes
 
   const resolutions: DomainResolution[] = await Promise.all(
     domains.map(async (domain): Promise<DomainResolution> => {
-      const addresses = await resolve4OrNull(domain);
+      // Resolve via the LAN path (AdGuard), not the OS resolver — the OS
+      // resolver may carry a public fallback that answers with the box's
+      // PUBLIC IP (split-horizon the LAN doesn't see), false-reding a box
+      // whose LAN clients all resolve correctly through AdGuard (#1672/#1675).
+      const addresses = await resolve4ViaLan(domain, lanIp);
       return {
         domain,
         addresses,

--- a/packages/backend/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
@@ -17,7 +17,9 @@ vi.mock('@/lib/router/dnsConfig', () => ({
   reconnectFritzBox: vi.fn(() => Promise.resolve(state.reconnectResult)),
 }));
 
-const lanResolve = vi.fn(() => Promise.resolve(null as string[] | null));
+const lanResolve = vi.fn(
+  (_host: string, _ip: string): Promise<string[] | null> => Promise.resolve(null),
+);
 vi.mock('@/lib/router/lanResolver', () => ({
   resolve4ViaLan: (h: string, ip: string) => lanResolve(h, ip),
 }));

--- a/packages/backend/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/routerDnsNotPointing.test.ts
@@ -5,6 +5,10 @@ const state = {
   setResult: { result: 'ok' } as any,
   reconnectResult: { result: 'ok' } as any,
   setWanResult: { result: 'ok' } as any,
+  config: {
+    reverseProxy: { lanIp: '192.168.1.10', publicDomain: 'dopp.cloud' },
+    gateway: { type: 'fritzbox', host: '192.168.1.1', username: 'admin', password: 'secret' },
+  } as any,
 };
 
 vi.mock('@/lib/router/dnsConfig', () => ({
@@ -13,11 +17,13 @@ vi.mock('@/lib/router/dnsConfig', () => ({
   reconnectFritzBox: vi.fn(() => Promise.resolve(state.reconnectResult)),
 }));
 
+const lanResolve = vi.fn(() => Promise.resolve(null as string[] | null));
+vi.mock('@/lib/router/lanResolver', () => ({
+  resolve4ViaLan: (h: string, ip: string) => lanResolve(h, ip),
+}));
+
 vi.mock('@/lib/config', () => ({
-  getConfig: vi.fn(() => Promise.resolve({
-    reverseProxy: { lanIp: '192.168.1.10' },
-    gateway: { type: 'fritzbox', host: '192.168.1.1', username: 'admin', password: 'secret' },
-  })),
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
   updateConfig: vi.fn(() => Promise.resolve()),
 }));
 
@@ -27,11 +33,21 @@ vi.mock('@/lib/logger', () => ({
 
 import { dispatchProbeAction } from '../actions';
 import './routerDnsNotPointing';
+import { checkRouterDnsNotPointing } from './routerDnsNotPointing';
 
 beforeEach(() => {
   state.setResult = { result: 'ok' };
   state.reconnectResult = { result: 'ok' };
   state.setWanResult = { result: 'ok' };
+  state.config = {
+    reverseProxy: { lanIp: '192.168.1.10', publicDomain: 'dopp.cloud' },
+    gateway: { type: 'fritzbox', host: '192.168.1.1', username: 'admin', password: 'secret' },
+  };
+  lanResolve.mockReset();
+  lanResolve.mockResolvedValue(null);
+  // Default: TR-064 reads + AdGuard query-log fetches all fail fast so the
+  // only positive signal in the LAN-path tests is `resolve4ViaLan`.
+  vi.spyOn(globalThis, 'fetch').mockReset().mockRejectedValue(new Error('no network in test'));
 });
 
 describe('router_dns_not_pointing.reconnect_fritzbox', () => {
@@ -123,5 +139,75 @@ describe('router_dns_not_pointing.configure_fritzbox_upstream', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.message).toContain('rejected the TR-064 credentials');
+  });
+
+  it('treats an unsupported TR-064 model as actionable success (manual DNS, not a red)', async () => {
+    state.setWanResult = {
+      result: 'unsupported',
+      detail: "This FritzBox doesn't support setting DNS over TR-064 (UPnP 401 — Invalid Action). Set the upstream DNS manually...",
+    };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'configure_fritzbox_upstream',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/doesn't support setting DNS over TR-064/);
+    expect(result.refresh).toBe(true);
+  });
+});
+
+describe('router_dns_not_pointing.configure_fritzbox (DHCP) unsupported model', () => {
+  it('treats an unsupported DHCP write as actionable success', async () => {
+    state.setResult = {
+      result: 'unsupported',
+      detail: "This FritzBox doesn't support setting DNS over TR-064 (UPnP 501). Set the DHCP DNS server manually...",
+    };
+    const result = await dispatchProbeAction({
+      probeId: 'router_dns_not_pointing',
+      actionId: 'configure_fritzbox',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/UPnP 501/);
+    expect(result.refresh).toBe(true);
+  });
+});
+
+describe('checkRouterDnsNotPointing — effective LAN-path signal (#1672)', () => {
+  it('reads GREEN when *.<domain> resolves to the box via AdGuard, even though TR-064 reads fail', async () => {
+    // All TR-064/AdGuard signals negative (fetch rejects); only the LAN
+    // resolution path is positive — a manually/DHCP-correct box.
+    lanResolve.mockImplementation((host: string) =>
+      host === 'auth.dopp.cloud' ? Promise.resolve(['192.168.1.10']) : Promise.resolve(null),
+    );
+    const r = await checkRouterDnsNotPointing();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/effective LAN DNS path is correct/);
+    expect(lanResolve).toHaveBeenCalledWith('auth.dopp.cloud', '192.168.1.10');
+  });
+
+  it('reads WARN when neither TR-064, AdGuard query log, nor the LAN path confirm the box', async () => {
+    lanResolve.mockResolvedValue(['203.0.113.9']); // resolves, but to a non-box IP
+    const r = await checkRouterDnsNotPointing();
+    expect(r.status).toBe('warn');
+  });
+
+  it('does not run the LAN-path resolution when a TR-064/query-log signal is already positive', async () => {
+    // AdGuard creds present + the query log returns a LAN client → adguardOk
+    // short-circuits, so the LAN-path resolution never runs.
+    state.config = {
+      reverseProxy: { lanIp: '192.168.1.10', publicDomain: 'dopp.cloud' },
+      gateway: { type: 'fritzbox', host: '192.168.1.1' }, // no creds → TR-064 reads skipped
+      adguard: { adminUrl: 'http://localhost:8083', username: 'admin', password: 'pw' },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ client: '192.168.1.55', T: new Date().toISOString() }] }),
+      text: async () => '',
+    } as any);
+    const r = await checkRouterDnsNotPointing();
+    expect(r.status).toBe('ok');
+    expect(lanResolve).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/diagnose/probes/routerDnsNotPointing.ts
+++ b/packages/backend/src/lib/diagnose/probes/routerDnsNotPointing.ts
@@ -31,6 +31,7 @@
 import { getConfig, updateConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
 import { reconnectFritzBox, setFritzBoxDhcpDns, setFritzBoxWanDns } from '@/lib/router/dnsConfig';
+import { resolve4ViaLan } from '@/lib/router/lanResolver';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
 
 const PROBE_ID = 'router_dns_not_pointing';
@@ -210,13 +211,35 @@ async function gatewayDnsHasLanIp(
   return { dns, ok };
 }
 
+// lanPathResolvesToBox checks the EFFECTIVE DHCP-DNS by resolving a core
+// service domain through AdGuard (the LAN path) and confirming the answer
+// is the box's LAN IP. This is the source-of-truth for a manually- or
+// DHCP-correctly-configured box where the TR-064 *read* fails or isn't
+// supported (#1672): if `*.<publicDomain>` resolves to the box via AdGuard,
+// the DNS handout is working regardless of what TR-064 reports.
+async function lanPathResolvesToBox(
+  publicDomain: string | undefined,
+  lanIp: string,
+  resolve: (host: string, lanIp: string) => Promise<string[] | null> = resolve4ViaLan,
+): Promise<boolean> {
+  const domain = publicDomain?.trim();
+  if (!domain) return false;
+  const addresses = await resolve(`auth.${domain}`, lanIp);
+  return !!addresses && addresses.includes(lanIp);
+}
+
 // okRoutingDetail explains which valid DNS topology is in effect, for the OK message.
-function okRoutingDetail(dhcpOk: boolean, upstreamOk: boolean, lanIp: string): string {
+function okRoutingDetail(dhcpOk: boolean, upstreamOk: boolean, lanPathOk: boolean, lanIp: string): string {
   const detail = ['Router DNS routing is working.'];
   if (dhcpOk) {
     detail.push(`Pattern: AdGuard as LAN DNS — FritzBox hands out ServiceBay (${lanIp}) via DHCP option 6, so LAN clients query AdGuard directly.`);
   } else if (upstreamOk) {
     detail.push(`Pattern: FritzBox stays as LAN DNS, AdGuard is upstream — FritzBox's own resolver queries ServiceBay (${lanIp}). All LAN queries flow client → FritzBox → AdGuard → internet.`);
+  } else if (lanPathOk) {
+    // The effective LAN path works even though TR-064 didn't confirm it —
+    // a manual/DHCP-correct setup (e.g. a FritzBox model that doesn't expose
+    // SetDNSServers over TR-064). Resolution is the source of truth.
+    detail.push(`Your service domains resolve to ServiceBay (${lanIp}) via AdGuard — the effective LAN DNS path is correct (verified by resolution, not just a TR-064 read).`);
   } else {
     // adguardOk alone — AdGuard sees client traffic (non-FritzBox setup or
     // TR-064 unreachable); the traffic signal is the source of truth.
@@ -279,8 +302,16 @@ export async function checkRouterDnsNotPointing(): Promise<RouterDnsProbeResult>
   const upstreamOk = upstream.ok;
   const upstreamDns = upstream.dns;
 
-  if (dhcpOk || upstreamOk || adguardOk) {
-    return { status: 'ok', detail: okRoutingDetail(dhcpOk, upstreamOk, lanIp) };
+  // Effective-path signal: a manually/DHCP-correctly configured box where
+  // the TR-064 read fails or is unsupported still reads green if a core
+  // service domain resolves to the box via AdGuard (#1672).
+  const lanPathOk =
+    dhcpOk || upstreamOk || adguardOk
+      ? false
+      : await lanPathResolvesToBox(config.reverseProxy?.publicDomain, lanIp);
+
+  if (dhcpOk || upstreamOk || adguardOk || lanPathOk) {
+    return { status: 'ok', detail: okRoutingDetail(dhcpOk, upstreamOk, lanPathOk, lanIp) };
   }
 
   const detail = await buildWarnDetail(config, lanIp, dhcpDns, upstreamDns, adguard);
@@ -304,6 +335,16 @@ async function configureFritzbox(): Promise<ProbeActionResult> {
     return {
       ok: true,
       message: `✅ FritzBox DHCP DNS set to ${lanIp}. Devices will pick up the new server when their lease renews (usually within an hour; restart Wi-Fi for an immediate refresh).`,
+      refresh: true,
+    };
+  }
+  if (result.result === 'unsupported') {
+    // The model doesn't expose the TR-064 write — that's not a failure,
+    // the operator just sets DNS by hand. The probe re-verifies via the
+    // LAN resolution path, so a manual setup still reads green (#1672).
+    return {
+      ok: true,
+      message: `ℹ️ ${result.detail ?? `This FritzBox can't set DHCP DNS over TR-064 — set the DHCP DNS server to ${lanIp} manually in the FritzBox UI.`}`,
       refresh: true,
     };
   }
@@ -331,6 +372,13 @@ async function configureFritzboxUpstream(): Promise<ProbeActionResult> {
     return {
       ok: true,
       message: `✅ FritzBox upstream DNS set to ${lanIp}. FritzBox keeps handing itself out as your LAN's DNS, but now forwards every query through AdGuard — household-wide filtering with no client-side changes. Takes effect immediately on the box.`,
+      refresh: true,
+    };
+  }
+  if (result.result === 'unsupported') {
+    return {
+      ok: true,
+      message: `ℹ️ ${result.detail ?? `This FritzBox can't set upstream DNS over TR-064 — set it to ${lanIp} manually under Internet → Account Information → DNS Server.`}`,
       refresh: true,
     };
   }

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -351,10 +351,22 @@ export async function resolveServiceDataDir(service: string): Promise<string> {
 // /data/database.sqlite to /data/database.sqlite.sb-backup using sqlite3's
 // online `.backup`, then `mv` over the canonical name so the file-copy producer
 // reads a torn-free copy. NPM's image bundles sqlite3.
+//
+// Since #1679 the live DB runs in WAL mode (the auth/nginx post-deploys flip
+// `journal_mode=WAL`), so committed writes can sit in the `-wal` sidecar rather
+// than the main file. We first `wal_checkpoint(TRUNCATE)` to fold the WAL back
+// into the main DB and truncate the sidecar — so even a plain reader of
+// database.sqlite would be consistent — then take the online `.backup` (itself
+// WAL-aware) into a single self-contained file the producer stages under the
+// canonical name. The checkpoint is best-effort (a busy DB may not fully
+// checkpoint); `.backup` guarantees consistency regardless.
 const NPM_SQLITE_SNAPSHOT_SH = [
   'set -e',
   "DB=/data/database.sqlite",
   'if [ ! -f "$DB" ]; then echo "nodb"; exit 0; fi',
+  // Fold the WAL back into the main DB so the snapshot has no dependence on the
+  // -wal/-shm sidecars. Best-effort: ignore a non-zero (busy) checkpoint.
+  'sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);" || true',
   // `.backup` produces a transactionally-consistent copy even mid-write.
   'sqlite3 "$DB" ".backup \'$DB.sb-snap\'"',
   'mv -f "$DB.sb-snap" "$DB.sb-backup"',

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -284,9 +284,14 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // expensive/impossible to regenerate (Let's Encrypt rate limits, access
     // lists) — consistent with HA keeping its zwave_js keys.
 
-    // database.sqlite is WAL-mode and live; a plain file-copy can tear it, so
-    // the producer takes a consistent in-container `sqlite3 .backup` snapshot
-    // over the same exec path npmAdminRekey uses.
+    // database.sqlite is WAL-mode (since #1679 the nginx post-deploy flips
+    // `journal_mode=WAL`) and live; a plain file-copy can tear it AND would miss
+    // committed writes still sitting in the `-wal` sidecar. The producer's
+    // collector handles both: it `wal_checkpoint(TRUNCATE)`s the WAL into the
+    // main DB, then takes a consistent in-container `sqlite3 .backup` snapshot
+    // (over the same exec path npmAdminRekey uses) and stages that single
+    // self-contained file under the canonical name. The `-wal`/`-shm` sidecars
+    // are never staged (they're not in `include`), so the restored DB is whole.
     collector: { kind: 'npm-sqlite' },
   },
 ];

--- a/packages/backend/src/lib/health/alertDecision.ts
+++ b/packages/backend/src/lib/health/alertDecision.ts
@@ -40,6 +40,10 @@ export const DEFAULT_FAILURE_THRESHOLDS: Partial<Record<CheckType, number>> = {
   backup: 1,
   cert_expiry: 1,
   cert_request_failure: 1,
+  // An invalid on-disk nginx config is true the instant `nginx -t`
+  // observes it — and it will brick the proxy on the next reboot — so
+  // alert immediately rather than waiting for consecutive fails (#1678).
+  nginx_config_valid: 1,
 };
 
 /**

--- a/packages/backend/src/lib/health/init.ts
+++ b/packages/backend/src/lib/health/init.ts
@@ -147,6 +147,7 @@ function addDefaultPhase3bChecks(exists: (type: string, target: string) => boole
     { id: 'npm_auth', name: 'NPM admin auth', interval: 900 },
     { id: 'cert_expiry', name: 'TLS certificate expiry', interval: 3600 },
     { id: 'cert_request_failure', name: 'Let\'s Encrypt cert requests', interval: 600 },
+    { id: 'nginx_config_valid', name: 'Nginx config validity', interval: 300 },
   ];
   for (const cfg of phase3bChecks) {
     if (!exists(cfg.id, 'Local')) {
@@ -154,7 +155,7 @@ function addDefaultPhase3bChecks(exists: (type: string, target: string) => boole
       HealthStore.saveCheck({
         id: cfg.id,
         name: cfg.name,
-        type: cfg.id as 'lan_ip_drift' | 'npm_auth' | 'cert_expiry' | 'cert_request_failure',
+        type: cfg.id as 'lan_ip_drift' | 'npm_auth' | 'cert_expiry' | 'cert_request_failure' | 'nginx_config_valid',
         target: 'Local',
         interval: cfg.interval,
         enabled: true,

--- a/packages/backend/src/lib/health/probes/basic.ts
+++ b/packages/backend/src/lib/health/probes/basic.ts
@@ -17,7 +17,7 @@ import { getConfig } from '../../config';
 registerProbe({
   type: 'http',
   async run(check) {
-    await assertHttpTargetAllowed(check.target);
+    await assertHttpTargetAllowed(check.target, { systemCheck: check.systemCheck });
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
     try {

--- a/packages/backend/src/lib/health/probes/index.ts
+++ b/packages/backend/src/lib/health/probes/index.ts
@@ -14,6 +14,7 @@ import './lanIpDrift';
 import './npmAuthProbe';
 import './certExpiry';
 import './certRequestFailure';
+import './nginxConfigValid';
 // dnsRouting no longer self-registers a probe type (#1564 collapsed the
 // per-domain `dns_routing` rows into the canonical `domain` check). Its
 // `resolveDnsRouting` helper is imported directly by the `domain` probe.

--- a/packages/backend/src/lib/health/probes/nginxConfigValid.test.ts
+++ b/packages/backend/src/lib/health/probes/nginxConfigValid.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Keep id→domain resolution inert by default; the parse/fail tests don't
+// depend on it, and individual tests override the NPM API fetch as needed.
+vi.mock('./npmAdmin', () => ({
+  findNpmAdminUrl: vi.fn(async () => ({ kind: 'url', url: 'http://localhost:81' })),
+  getNpmToken: vi.fn(async () => 'tok'),
+}));
+
+import { parseNginxTestOutput } from './nginxConfigValid';
+import './nginxConfigValid';
+import { getProbe } from './registry';
+import type { CheckConfig } from '../types';
+
+const EMERG =
+  'nginx: [emerg] invalid port in upstream "127.0.0.1:/api/authz/auth-request" in /data/nginx/proxy_host/19.conf:60';
+
+const OK_OUTPUT =
+  'nginx: the configuration file /etc/nginx/nginx.conf syntax is ok\n' +
+  'nginx: configuration file /etc/nginx/nginx.conf test is successful';
+
+const check = (): CheckConfig => ({
+  id: 'nginx_config_valid',
+  name: 'Nginx config validity',
+  type: 'nginx_config_valid',
+  target: 'Local',
+  interval: 300,
+  enabled: true,
+  created_at: new Date().toISOString(),
+  nodeName: 'Local',
+});
+
+describe('parseNginxTestOutput', () => {
+  it('exit 0 → ok, no emerg, no host id', () => {
+    expect(parseNginxTestOutput(OK_OUTPUT, 0)).toEqual({ ok: true });
+  });
+
+  it('exit != 0 with invalid-port emerg → not ok, surfaces emerg line + host id 19', () => {
+    const r = parseNginxTestOutput(EMERG, 1);
+    expect(r.ok).toBe(false);
+    expect(r.emergLine).toBe(
+      'nginx: [emerg] invalid port in upstream "127.0.0.1:/api/authz/auth-request" in /data/nginx/proxy_host/19.conf:60',
+    );
+    expect(r.hostId).toBe(19);
+  });
+
+  it('exit != 0 without a proxy_host file leaves hostId undefined', () => {
+    const r = parseNginxTestOutput('nginx: [emerg] unexpected end of file', 2);
+    expect(r.ok).toBe(false);
+    expect(r.emergLine).toBe('nginx: [emerg] unexpected end of file');
+    expect(r.hostId).toBeUndefined();
+  });
+});
+
+describe('nginx_config_valid probe.run', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeCtx = (nginxResult: () => Promise<{ stdout: string; stderr: string }>) => ({
+    executor: {
+      // Container discovery uses exec (pipe/awk needs a shell).
+      exec: vi.fn(async () => ({ stdout: 'nginx-nginx-proxy-manager docker.io/jc21/nginx-proxy-manager\n', stderr: '' })),
+      // `nginx -t` runs via execArgv (no shell).
+      execArgv: vi.fn(async () => nginxResult()),
+    } as never,
+  });
+
+  it('green when nginx -t exits 0', async () => {
+    const probe = getProbe('nginx_config_valid')!;
+    const ctx = makeCtx(async () => ({ stdout: '', stderr: OK_OUTPUT }));
+    const res = (await probe.run(check(), ctx)) as { status: string; payload: { status: string; detail: string } };
+    expect(res.status).toBe('ok');
+    expect(res.payload.status).toBe('ok');
+  });
+
+  it('red with the emerg line + host id surfaced when nginx -t exits != 0', async () => {
+    // The executor throws a CommandError-shaped error carrying code + stderr.
+    const probe = getProbe('nginx_config_valid')!;
+    const ctx = makeCtx(async () => {
+      throw Object.assign(new Error('Command failed'), { code: 1, stdout: '', stderr: EMERG });
+    });
+    // No real NPM behind the id→domain lookup → resolveHostDomain returns undefined.
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false } as Response)));
+
+    const res = (await probe.run(check(), ctx)) as { status: string; payload: { status: string; detail: string; hostId?: number } };
+    expect(res.status).toBe('fail');
+    expect(res.payload.status).toBe('fail');
+    expect(res.payload.hostId).toBe(19);
+    expect(res.payload.detail).toContain('proxy_host/19.conf');
+    expect(res.payload.detail).toContain('[emerg] invalid port');
+  });
+
+  it('maps host id → domain when the NPM API resolves it', async () => {
+    const probe = getProbe('nginx_config_valid')!;
+    const ctx = makeCtx(async () => {
+      throw Object.assign(new Error('Command failed'), { code: 1, stdout: '', stderr: EMERG });
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => [{ id: 19, domain_names: ['ollama.dopp.cloud'] }],
+      } as unknown as Response)),
+    );
+
+    const res = (await probe.run(check(), ctx)) as { status: string; payload: { domain?: string; detail: string } };
+    expect(res.payload.domain).toBe('ollama.dopp.cloud');
+    expect(res.payload.detail).toContain('ollama.dopp.cloud');
+  });
+
+  it('info (not fail) when no NPM container is running', async () => {
+    const probe = getProbe('nginx_config_valid')!;
+    const ctx = {
+      executor: {
+        exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+      } as never,
+    };
+    const res = (await probe.run(check(), ctx)) as { status: string; payload: { status: string } };
+    expect(res.status).toBe('ok');
+    expect(res.payload.status).toBe('info');
+  });
+});

--- a/packages/backend/src/lib/health/probes/nginxConfigValid.ts
+++ b/packages/backend/src/lib/health/probes/nginxConfigValid.ts
@@ -1,0 +1,132 @@
+/**
+ * `nginx_config_valid` probe (#1678) — runs `nginx -t` inside the NPM
+ * (reverse-proxy) container on the node and fails when the *on-disk*
+ * nginx config is invalid, even though nginx may still be serving fine
+ * on an older, already-loaded config.
+ *
+ * This is the early-warning half of the #1677 defense: a single
+ * malformed proxy-host config (e.g. ollama's empty Authelia port
+ * `proxy_pass http://127.0.0.1:/api/authz/...` → `nginx: [emerg]
+ * invalid port`) is tolerated by the *running* config but CRASHES the
+ * entire proxy on the next reload/reboot. `nginx -t` validates the
+ * on-disk config and surfaces the drift while nginx is still up — so a
+ * silent landmine becomes a red check + alert now, not a full-proxy
+ * outage on the next boot.
+ *
+ * The check parses the `[emerg]` line and the offending
+ * `proxy_host/<id>.conf`, and (cheaply, best-effort) maps that numeric
+ * id back to the host's primary domain via the NPM API.
+ */
+
+import { registerProbe } from './registry';
+import { findNpmAdminUrl, getNpmToken } from './npmAdmin';
+
+type Payload = { status: 'ok' | 'fail' | 'info'; detail: string; hint?: string; hostId?: number; domain?: string };
+
+const encode = (payload: Payload) => ({
+  status: payload.status === 'fail' ? ('fail' as const) : ('ok' as const),
+  payload,
+});
+
+export interface NginxTestParse {
+  ok: boolean;
+  /** The `nginx: [emerg] ...` line, when one is present. */
+  emergLine?: string;
+  /** Numeric proxy_host id parsed from `.../proxy_host/<id>.conf`. */
+  hostId?: number;
+}
+
+/**
+ * Parse the combined stdout+stderr of `nginx -t` plus its exit code.
+ * Exit 0 → valid. Non-zero → invalid; pull out the first `[emerg]`
+ * line and, when the offending file is a `proxy_host/<id>.conf`, the
+ * numeric host id.
+ *
+ * Pure + exported so the fail/parse logic is unit-tested without a node.
+ */
+export function parseNginxTestOutput(output: string, exitCode: number): NginxTestParse {
+  if (exitCode === 0) return { ok: true };
+  const text = output ?? '';
+  const emergMatch = text.match(/nginx:\s*\[emerg\].*/);
+  const emergLine = emergMatch ? emergMatch[0].trim() : undefined;
+  const hostMatch = text.match(/proxy_host\/(\d+)\.conf/);
+  const hostId = hostMatch ? Number(hostMatch[1]) : undefined;
+  return { ok: false, emergLine, hostId };
+}
+
+/** Best-effort id→domain map via the NPM API. Returns the host's primary
+ *  domain for the parsed proxy_host id, or undefined when it can't resolve
+ *  (NPM unreachable / id not found) — the check still reds either way. */
+async function resolveHostDomain(node: string, hostId: number): Promise<string | undefined> {
+  try {
+    const admin = await findNpmAdminUrl(node);
+    if (admin.kind !== 'url') return undefined;
+    const token = await getNpmToken(admin.url);
+    if (!token) return undefined;
+    const res = await fetch(`${admin.url}/api/nginx/proxy-hosts`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!res.ok) return undefined;
+    const hosts = (await res.json()) as Array<{ id?: number; domain_names?: string[] }>;
+    if (!Array.isArray(hosts)) return undefined;
+    const host = hosts.find(h => h.id === hostId);
+    return host?.domain_names?.[0];
+  } catch {
+    return undefined;
+  }
+}
+
+registerProbe({
+  type: 'nginx_config_valid',
+  async run(check, ctx) {
+    const node = check.nodeName ?? 'Local';
+    try {
+      // Locate the running NPM container (same discovery the rekey path
+      // uses — match the proxy-manager image, take the first name).
+      const find = await ctx.executor.exec(
+        `podman ps --format '{{.Names}} {{.Image}}' | awk '/proxy-manager/{print $1; exit}'`,
+        { timeoutMs: 15_000 },
+      );
+      const container = (find.stdout || '').trim().split(/\s+/)[0];
+      if (!container) {
+        return encode({ status: 'info', detail: 'Nginx Proxy Manager not running on this node — nothing to validate.' });
+      }
+
+      let output = '';
+      let exitCode = 0;
+      try {
+        // execArgv quotes each arg (shellQuoteAll) — `container` comes from
+        // `podman ps` output but is never shell-interpolated.
+        const res = await ctx.executor.execArgv(['podman', 'exec', container, 'nginx', '-t'], { timeoutMs: 20_000 });
+        // `nginx -t` writes its "syntax is ok" banner to stderr even on success.
+        output = `${res.stdout}\n${res.stderr}`;
+      } catch (e) {
+        const err = e as { code?: number; stdout?: string; stderr?: string; message?: string };
+        exitCode = typeof err.code === 'number' ? err.code : 1;
+        output = `${err.stdout ?? ''}\n${err.stderr ?? ''}\n${err.message ?? ''}`;
+      }
+
+      const parsed = parseNginxTestOutput(output, exitCode);
+      if (parsed.ok) {
+        return encode({ status: 'ok', detail: 'On-disk nginx config is valid (`nginx -t` passed).' });
+      }
+
+      const domain = parsed.hostId !== undefined ? await resolveHostDomain(node, parsed.hostId) : undefined;
+      const hostLabel = parsed.hostId !== undefined
+        ? `proxy_host/${parsed.hostId}.conf${domain ? ` (${domain})` : ''}`
+        : 'an unidentified config file';
+      const emerg = parsed.emergLine || 'nginx reported a config error (no [emerg] line captured).';
+
+      return encode({
+        status: 'fail',
+        detail: `On-disk nginx config is INVALID — it will brick the proxy on the next reload/reboot. nginx is still serving on the old config for now. Offending file: ${hostLabel}. ${emerg}`,
+        hint: 'Fix or remove the bad proxy host in Nginx Proxy Manager before the next reboot. A common cause is a forward-auth `proxy_pass` with a missing port (e.g. `http://127.0.0.1:/...`). Do NOT reboot until `nginx -t` passes.',
+        hostId: parsed.hostId,
+        domain,
+      });
+    } catch (e) {
+      return { status: 'fail', message: `nginx_config_valid error: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  },
+});

--- a/packages/backend/src/lib/health/ssrfGuard.test.ts
+++ b/packages/backend/src/lib/health/ssrfGuard.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  assertHttpTargetAllowed,
+  isKnownLocalSystemTarget,
+  isPrivateAddress,
+} from './ssrfGuard';
+
+describe('ssrfGuard', () => {
+  const savedEnv = process.env.MONITORING_ALLOW_INTERNAL;
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.MONITORING_ALLOW_INTERNAL;
+    else process.env.MONITORING_ALLOW_INTERNAL = savedEnv;
+  });
+
+  describe('isKnownLocalSystemTarget', () => {
+    it('recognises the HA and Ollama loopback endpoints', () => {
+      expect(isKnownLocalSystemTarget('http://127.0.0.1:8123/')).toBe(true);
+      expect(isKnownLocalSystemTarget('http://127.0.0.1:11434/')).toBe(true);
+      expect(isKnownLocalSystemTarget('http://localhost:8123/')).toBe(true);
+      expect(isKnownLocalSystemTarget('http://[::1]:8123/')).toBe(true);
+    });
+
+    it('rejects a loopback host on an unrecognised port', () => {
+      expect(isKnownLocalSystemTarget('http://127.0.0.1:9000/')).toBe(false);
+      expect(isKnownLocalSystemTarget('http://127.0.0.1/')).toBe(false); // port 80
+    });
+
+    it('rejects a known service port on a non-loopback host', () => {
+      // A LAN host or public host on 8123 is NOT a self-check.
+      expect(isKnownLocalSystemTarget('http://192.168.178.50:8123/')).toBe(false);
+      expect(isKnownLocalSystemTarget('http://evil.example.com:8123/')).toBe(false);
+    });
+
+    it('rejects non-http(s) and malformed URLs', () => {
+      expect(isKnownLocalSystemTarget('file:///etc/passwd')).toBe(false);
+      expect(isKnownLocalSystemTarget('not a url')).toBe(false);
+    });
+  });
+
+  describe('assertHttpTargetAllowed — systemCheck bypass (#1670)', () => {
+    it('allows a system self-check of a known-local service', async () => {
+      delete process.env.MONITORING_ALLOW_INTERNAL;
+      await expect(
+        assertHttpTargetAllowed('http://127.0.0.1:8123/', { systemCheck: true }),
+      ).resolves.toBeUndefined();
+      await expect(
+        assertHttpTargetAllowed('http://127.0.0.1:11434/', { systemCheck: true }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('still blocks the same loopback target when NOT a system check', async () => {
+      delete process.env.MONITORING_ALLOW_INTERNAL;
+      await expect(
+        assertHttpTargetAllowed('http://127.0.0.1:8123/'),
+      ).rejects.toThrow(/Internal address blocked/);
+    });
+
+    it('still blocks a user-supplied internal (RFC1918) target even with the systemCheck flag', async () => {
+      // The flag is not a blanket bypass: the target must itself be a
+      // recognised loopback service. A LAN host never qualifies.
+      delete process.env.MONITORING_ALLOW_INTERNAL;
+      await expect(
+        assertHttpTargetAllowed('http://192.168.178.50:8123/', { systemCheck: true }),
+      ).rejects.toThrow(/Internal address blocked/);
+    });
+
+    it('does not let systemCheck bypass an unrecognised loopback port', async () => {
+      delete process.env.MONITORING_ALLOW_INTERNAL;
+      await expect(
+        assertHttpTargetAllowed('http://127.0.0.1:9000/', { systemCheck: true }),
+      ).rejects.toThrow(/Internal address blocked/);
+    });
+  });
+
+  describe('assertHttpTargetAllowed — base behaviour', () => {
+    it('honours MONITORING_ALLOW_INTERNAL=1 for any target', async () => {
+      process.env.MONITORING_ALLOW_INTERNAL = '1';
+      await expect(
+        assertHttpTargetAllowed('http://127.0.0.1:9000/'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects localhost when not allowed', async () => {
+      delete process.env.MONITORING_ALLOW_INTERNAL;
+      await expect(
+        assertHttpTargetAllowed('http://localhost:9000/'),
+      ).rejects.toThrow(/Internal hostname blocked/);
+    });
+
+    it('rejects a disallowed protocol', async () => {
+      delete process.env.MONITORING_ALLOW_INTERNAL;
+      await expect(
+        assertHttpTargetAllowed('ftp://example.com/'),
+      ).rejects.toThrow(/Disallowed protocol/);
+    });
+  });
+
+  describe('isPrivateAddress', () => {
+    it('classifies loopback and RFC1918 as private', () => {
+      expect(isPrivateAddress('127.0.0.1')).toBe(true);
+      expect(isPrivateAddress('192.168.178.50')).toBe(true);
+      expect(isPrivateAddress('10.0.0.1')).toBe(true);
+      expect(isPrivateAddress('::1')).toBe(true);
+    });
+
+    it('classifies a public address as not private', () => {
+      expect(isPrivateAddress('8.8.8.8')).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/lib/health/ssrfGuard.ts
+++ b/packages/backend/src/lib/health/ssrfGuard.ts
@@ -2,15 +2,68 @@ import { lookup } from 'dns/promises';
 import { isIP } from 'net';
 
 /**
+ * Loopback ports of the known-local hostNetwork services ServiceBay
+ * monitors itself (#1670). A stack's post-deploy registers an HTTP health
+ * check against its own loopback endpoint via the internal-token POST
+ * (`home-assistant-api` → `127.0.0.1:8123`, `ollama-api` →
+ * `127.0.0.1:11434`); on the single-node home box those are the box's *own*
+ * services, not a user-supplied target. Keeping the list explicit (rather
+ * than "any loopback") means even a system check can only bypass the guard
+ * for a recognised service port — an internal-token check of some other
+ * loopback port still goes through the normal private-address rejection.
+ */
+const KNOWN_LOCAL_SERVICE_PORTS = new Set<number>([
+  8123, // Home Assistant
+  11434, // Ollama
+]);
+
+const LOOPBACK_HOSTS = new Set<string>(['127.0.0.1', '::1', 'localhost']);
+
+/**
+ * True when `rawUrl` is a ServiceBay self-check of a known-local hostNetwork
+ * service: a loopback host AND a recognised service port (#1670). This — and
+ * only this — is what a `systemCheck` is allowed to bypass the guard for.
+ * User-supplied internal URLs (arbitrary host/port, RFC1918 LAN hosts) return
+ * false here and stay subject to the guard.
+ */
+export function isKnownLocalSystemTarget(rawUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  // URL.hostname keeps the brackets around an IPv6 literal (`[::1]`).
+  const host = url.hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  if (!LOOPBACK_HOSTS.has(host) && !host.endsWith('.localhost')) return false;
+  const defaultPort = url.protocol === 'https:' ? 443 : 80;
+  const port = url.port ? Number(url.port) : defaultPort;
+  return KNOWN_LOCAL_SERVICE_PORTS.has(port);
+}
+
+/**
  * Reject targets that resolve to private/loopback/link-local addresses unless
  * MONITORING_ALLOW_INTERNAL=1 is set. Home-lab deploys typically need to
  * monitor RFC1918 hosts, so the env var lets operators opt in explicitly.
  *
+ * `systemCheck` (#1670): a ServiceBay self-created check of a known-local
+ * hostNetwork service bypasses the guard — but only when the target itself is
+ * a recognised loopback service ({@link isKnownLocalSystemTarget}). The guard
+ * exists to stop a *user-supplied* monitoring target from reaching internal
+ * hosts; ServiceBay's own self-checks of HA/Ollama on `127.0.0.1` are not
+ * that, and shouldn't permanently false-red on a healthy box. A user-supplied
+ * internal URL carries no `systemCheck` flag and is still rejected.
+ *
  * Throws a descriptive Error on rejection. Returns the resolved IP string
  * (informational only) on accept.
  */
-export async function assertHttpTargetAllowed(rawUrl: string): Promise<void> {
+export async function assertHttpTargetAllowed(
+  rawUrl: string,
+  opts: { systemCheck?: boolean } = {},
+): Promise<void> {
   if (process.env.MONITORING_ALLOW_INTERNAL === '1') return;
+  if (opts.systemCheck && isKnownLocalSystemTarget(rawUrl)) return;
 
   let url: URL;
   try {
@@ -23,26 +76,32 @@ export async function assertHttpTargetAllowed(rawUrl: string): Promise<void> {
   }
 
   const host = url.hostname;
-  const candidates: string[] = [];
-  if (isIP(host)) {
-    candidates.push(host);
-  } else {
-    const lower = host.toLowerCase();
-    if (lower === 'localhost' || lower.endsWith('.localhost')) {
-      throw new Error('Internal hostname blocked (set MONITORING_ALLOW_INTERNAL=1 to allow)');
-    }
-    try {
-      const addrs = await lookup(host, { all: true });
-      for (const a of addrs) candidates.push(a.address);
-    } catch (e) {
-      throw new Error(`DNS lookup failed for ${host}: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
+  const candidates = await resolveCandidateIps(host);
   for (const ip of candidates) {
     if (isPrivateAddress(ip)) {
       throw new Error(`Internal address blocked: ${host} → ${ip} (set MONITORING_ALLOW_INTERNAL=1 to allow)`);
     }
+  }
+}
+
+/**
+ * Resolve a URL host to the candidate IPs the guard inspects. A literal IP
+ * is its own candidate; a `localhost`/`*.localhost` name is rejected
+ * outright; any other name is DNS-resolved (all records). Split out of
+ * {@link assertHttpTargetAllowed} to keep that function under the complexity
+ * budget.
+ */
+async function resolveCandidateIps(host: string): Promise<string[]> {
+  if (isIP(host)) return [host];
+  const lower = host.toLowerCase();
+  if (lower === 'localhost' || lower.endsWith('.localhost')) {
+    throw new Error('Internal hostname blocked (set MONITORING_ALLOW_INTERNAL=1 to allow)');
+  }
+  try {
+    const addrs = await lookup(host, { all: true });
+    return addrs.map(a => a.address);
+  } catch (e) {
+    throw new Error(`DNS lookup failed for ${host}: ${e instanceof Error ? e.message : String(e)}`);
   }
 }
 

--- a/packages/backend/src/lib/health/types.ts
+++ b/packages/backend/src/lib/health/types.ts
@@ -18,6 +18,11 @@ export type CheckType =
   | 'npm_auth'
   | 'cert_expiry'
   | 'cert_request_failure'
+  // #1678: runs `nginx -t` inside the NPM container on a ~5-min interval
+  // to catch a malformed on-disk proxy-host config (the #1677 landmine)
+  // while nginx is still serving on the old, already-loaded config —
+  // turning a silent crash-on-next-reboot into a red check + alert now.
+  | 'nginx_config_valid'
   // DoH-based external view that replaces the continuous letsdebug
   // sweep. Cheap enough to run every 15 min (no third-party rate
   // limits — Cloudflare's 1.1.1.1 DoH absorbs household-grade traffic

--- a/packages/backend/src/lib/health/types.ts
+++ b/packages/backend/src/lib/health/types.ts
@@ -45,6 +45,19 @@ export interface CheckConfig {
    * used. A value of 1 restores the legacy "alert on first fail" behaviour.
    */
   failureThreshold?: number;
+  /**
+   * A ServiceBay self-created check of a *known-local* hostNetwork service
+   * (#1670) — e.g. the template-registered `home-assistant-api`
+   * (`http://127.0.0.1:8123/`) or `ollama-api` (`http://127.0.0.1:11434/`)
+   * probes a stack's post-deploy registers via the internal-token POST.
+   * These legitimately target loopback, so the monitoring SSRF guard (which
+   * exists to stop a *user-supplied* check from reaching internal hosts) must
+   * not false-red them. Only the internal-token POST path stamps this true,
+   * and the guard still requires the target itself to be a recognised
+   * loopback service — a user-supplied internal URL never carries the flag
+   * and stays blocked.
+   */
+  systemCheck?: boolean;
   // HTTP specific options
   httpConfig?: {
     expectedStatus?: number;

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -1422,6 +1422,24 @@ async function runJob(jobId: string): Promise<void> {
   await log(jobId, 'Provisioning AdGuard DNS rewrites + portal routing...');
   await provisionPortalWithRetries((line: string) => { void log(jobId, line); });
 
+  // #1675 — now that AdGuard is up, re-point the BOX's own resolver at it
+  // (127.0.0.1) with the router as fallback and NO public 8.8.8.8. The
+  // install baked a public fallback for bootstrap (before AdGuard existed);
+  // leaving it in place lets the box resolve `*.<publicDomain>` to the
+  // PUBLIC IP, the #1559 trap one layer down. Best-effort: a failure logs
+  // and never fails the install.
+  try {
+    const { repointBoxResolverToAdguard } = await import('@/lib/router/boxResolverDns');
+    const dnsResult = await repointBoxResolverToAdguard(input.node || 'Local');
+    if (dnsResult.result === 'ok') {
+      await log(jobId, `✅ ${dnsResult.detail}`);
+    } else {
+      await log(jobId, `(note) box resolver re-point skipped/failed: ${dnsResult.detail}`);
+    }
+  } catch (e) {
+    await log(jobId, `(note) box resolver re-point failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
   await patchJob(jobId, {
     phase: 'done',
     endedAt: new Date().toISOString(),

--- a/packages/backend/src/lib/mcp/efibootmgr.test.ts
+++ b/packages/backend/src/lib/mcp/efibootmgr.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
+import {
+  parseEfibootmgr,
+  assessUsbBootReadiness,
+  selectInstallerBootDevice,
+  planUsbBoot,
+} from './efibootmgr';
 
 // Representative `efibootmgr -v` output: an OS entry, an active USB entry,
 // and an inactive removable entry. BootCurrent appears after the Boot#### rows.
@@ -55,5 +60,82 @@ describe('assessUsbBootReadiness', () => {
     expect(r.reinstallReady).toBe(false);
     expect(r.usbCandidates).toHaveLength(0);
     expect(r.hint).toMatch(/insert the installation usb/i);
+  });
+});
+
+// #1674 — a multi-slot card reader: /dev/sda is the internal disk, /dev/sdb is
+// the real FCoS installer USB (fedora-coreos + EFI-SYSTEM labels), /dev/sdc..sde
+// are empty card-reader slots. The mapping must pick /dev/sdb, not a slot.
+const LSBLK_MULTISLOT = JSON.stringify({
+  blockdevices: [
+    {
+      name: 'sda', path: '/dev/sda', type: 'disk', label: null,
+      children: [
+        { name: 'sda1', path: '/dev/sda1', type: 'part', label: 'boot' },
+        { name: 'sda2', path: '/dev/sda2', type: 'part', label: 'root' },
+      ],
+    },
+    {
+      name: 'sdb', path: '/dev/sdb', type: 'disk', label: 'fedora-coreos-installer',
+      children: [
+        { name: 'sdb1', path: '/dev/sdb1', type: 'part', label: 'ISO' },
+        { name: 'sdb2', path: '/dev/sdb2', type: 'part', label: 'EFI-SYSTEM' },
+      ],
+    },
+    { name: 'sdc', path: '/dev/sdc', type: 'disk', label: null }, // empty slot
+    { name: 'sdd', path: '/dev/sdd', type: 'disk', label: null }, // empty slot
+  ],
+});
+
+describe('selectInstallerBootDevice (#1674)', () => {
+  it('picks the disk carrying the fedora-coreos / EFI-SYSTEM labels, not an empty slot', () => {
+    const d = selectInstallerBootDevice(LSBLK_MULTISLOT);
+    expect(d?.disk).toBe('/dev/sdb');
+    expect(d?.efiPartNum).toBe(2);
+    expect(d?.efiPart).toBe('/dev/sdb2');
+  });
+
+  it('returns null when no installer device is present (no media inserted)', () => {
+    const noInstaller = JSON.stringify({
+      blockdevices: [
+        { name: 'sda', path: '/dev/sda', type: 'disk', children: [{ name: 'sda1', type: 'part', label: 'root' }] },
+        { name: 'sdc', path: '/dev/sdc', type: 'disk', label: null }, // empty slot only
+      ],
+    });
+    expect(selectInstallerBootDevice(noInstaller)).toBeNull();
+  });
+
+  it('returns null on malformed lsblk output', () => {
+    expect(selectInstallerBootDevice('not json')).toBeNull();
+  });
+});
+
+describe('planUsbBoot (#1674)', () => {
+  it('creates a direct device entry when the installer device is found', () => {
+    const device = selectInstallerBootDevice(LSBLK_MULTISLOT);
+    const plan = planUsbBoot(parseEfibootmgr(NO_USB), device);
+    expect(plan.mode).toBe('create');
+    expect(plan.device?.disk).toBe('/dev/sdb');
+    expect(plan.warning).toBeUndefined();
+  });
+
+  it('falls back to an ACTIVE existing UEFI entry without warning when no device is found', () => {
+    const plan = planUsbBoot(parseEfibootmgr(WITH_ACTIVE_USB), null);
+    expect(plan.mode).toBe('existingEntry');
+    expect(plan.bootNum).toBe('0003');
+    expect(plan.warning).toBeUndefined();
+  });
+
+  it('WARNS about an empty slot when the only removable entry is inactive', () => {
+    const plan = planUsbBoot(parseEfibootmgr(INACTIVE_USB), null);
+    expect(plan.mode).toBe('existingEntry');
+    expect(plan.bootNum).toBe('0007');
+    expect(plan.warning).toMatch(/empty card-reader slot/i);
+  });
+
+  it('warns with no usable target when neither a device nor a removable entry exists', () => {
+    const plan = planUsbBoot(parseEfibootmgr(NO_USB), null);
+    expect(plan.mode).toBe('none');
+    expect(plan.warning).toMatch(/insert the install usb/i);
   });
 });

--- a/packages/backend/src/lib/mcp/efibootmgr.ts
+++ b/packages/backend/src/lib/mcp/efibootmgr.ts
@@ -83,6 +83,151 @@ export interface UsbBootReadiness {
   hint?: string;
 }
 
+// ---------------------------------------------------------------------------
+// #1674 — map the USB boot to the ACTUAL FCoS installer device.
+//
+// On a multi-slot card reader the firmware exposes one removable UEFI entry per
+// (possibly empty) slot. The old auto-detect picked the FIRST removable/USB-ish
+// entry, which on the operator's box was an EMPTY card-reader slot (Boot0000),
+// not the real installer device — so BootNext armed a slot with no media and the
+// box just booted the existing disk again. The reliable signal is the BLOCK
+// DEVICE: the installer USB carries the Fedora CoreOS labels (`fedora-coreos`
+// and an `EFI-SYSTEM` EFI partition). Find that device, then boot it directly
+// via `\EFI\BOOT\BOOTX64.EFI` rather than trusting a slot description.
+
+/** A block node from `lsblk --json -O` (subset of the fields we use). */
+export interface LsblkNode {
+  name: string;
+  path?: string;
+  type?: string; // disk | part | rom | …
+  label?: string | null;
+  partlabel?: string | null;
+  parttypename?: string | null;
+  pkname?: string | null; // parent kernel name (the disk a partition lives on)
+  children?: LsblkNode[];
+}
+
+export interface InstallerBootDevice {
+  /** The whole disk, e.g. /dev/sdb. */
+  disk: string;
+  /** The EFI System partition number on that disk, e.g. 2 (for -p). */
+  efiPartNum: number;
+  /** The EFI partition device, e.g. /dev/sdb2. */
+  efiPart: string;
+  /** Why this device was chosen (which label matched), for the operator log. */
+  reason: string;
+}
+
+/** A partition looks like the installer's EFI System Partition. */
+function isEfiSystemPart(n: LsblkNode): boolean {
+  const label = (n.label ?? '').toUpperCase();
+  const ptype = (n.parttypename ?? '').toLowerCase();
+  const plabel = (n.partlabel ?? '').toLowerCase();
+  return label === 'EFI-SYSTEM' || label === 'EFI' || ptype.includes('efi system') || plabel.includes('efi');
+}
+
+/** Any node on this device tree carries a fedora-coreos label. */
+function carriesFcosLabel(n: LsblkNode): boolean {
+  const fields = [n.label, n.partlabel].map(s => (s ?? '').toLowerCase());
+  return fields.some(f => f.includes('fedora-coreos') || f.includes('coreos') || f === 'efi-system');
+}
+
+function partNumFromName(name: string): number {
+  const m = name.match(/(\d+)$/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function devPath(n: LsblkNode): string {
+  return n.path ?? `/dev/${n.name}`;
+}
+
+/**
+ * Find the real FCoS installer device from `lsblk --json -O` output: the disk
+ * that carries the fedora-coreos / EFI-SYSTEM labels, plus its EFI System
+ * Partition number (for `efibootmgr -d <disk> -p <num>`). Returns null when no
+ * such device is present (no installer media inserted) — the caller then falls
+ * back to the UEFI-entry heuristic and warns.
+ */
+export function selectInstallerBootDevice(lsblkJson: string): InstallerBootDevice | null {
+  let parsed: { blockdevices?: LsblkNode[] };
+  try {
+    parsed = JSON.parse(lsblkJson) as { blockdevices?: LsblkNode[] };
+  } catch {
+    return null;
+  }
+  for (const disk of parsed.blockdevices ?? []) {
+    if (disk.type && disk.type !== 'disk') continue;
+    const children = disk.children ?? [];
+    // The disk qualifies as the installer only if SOMETHING on it carries a
+    // fedora-coreos label — so we don't grab an unrelated USB stick.
+    const isInstaller = carriesFcosLabel(disk) || children.some(carriesFcosLabel);
+    if (!isInstaller) continue;
+    const efi = children.find(isEfiSystemPart);
+    if (!efi) continue;
+    return {
+      disk: devPath(disk),
+      efiPartNum: partNumFromName(efi.name),
+      efiPart: devPath(efi),
+      reason: `block device ${devPath(disk)} carries the Fedora CoreOS / EFI-SYSTEM label`,
+    };
+  }
+  return null;
+}
+
+/**
+ * The chosen boot target after #1674 mapping: either a direct device entry to
+ * create (`create`), or a fallback to an existing UEFI entry number
+ * (`existingEntry`). `warning` is set when the fallback landed on something that
+ * looks like an empty card-reader slot, so the operator is told the auto-detect
+ * is unreliable here and to insert the installer / pick the device explicitly.
+ */
+export interface UsbBootPlan {
+  mode: 'create' | 'existingEntry' | 'none';
+  device?: InstallerBootDevice;
+  bootNum?: string;
+  warning?: string;
+}
+
+/**
+ * Decide how to arm the next USB boot. Prefers the real installer device (a
+ * fresh `efibootmgr -c` entry straight to `\EFI\BOOT\BOOTX64.EFI`); only falls
+ * back to picking an existing UEFI candidate entry when no installer block
+ * device is found — and WARNS when that fallback entry is an inactive / empty
+ * removable slot (the #1674 trap), since arming it won't boot anything.
+ */
+export function planUsbBoot(
+  parsed: ParsedEfibootmgr,
+  device: InstallerBootDevice | null,
+): UsbBootPlan {
+  if (device) {
+    return { mode: 'create', device };
+  }
+  // No installer device located — fall back to the old UEFI-entry heuristic, but
+  // surface that it's a guess. Prefer an ACTIVE removable entry; an inactive one
+  // is very likely an empty slot.
+  const removable = parsed.entries.filter(e => isUsbBootEntry(e.description));
+  const active = removable.find(e => e.active);
+  if (active) {
+    return { mode: 'existingEntry', bootNum: active.bootNum };
+  }
+  if (removable.length > 0) {
+    const nums = removable.map(e => e.bootNum).join(', ');
+    return {
+      mode: 'existingEntry',
+      bootNum: removable[0].bootNum,
+      warning:
+        `No Fedora CoreOS installer block device was found, and the only removable UEFI entries (Boot${nums}) are inactive — ` +
+        `this is usually an EMPTY card-reader slot, not the installer. Insert the install USB and retry, or pass an explicit bootNum.`,
+    };
+  }
+  return {
+    mode: 'none',
+    warning:
+      'No Fedora CoreOS installer device and no removable UEFI boot entry were found. ' +
+      'Insert the install USB (the firmware only lists removable entries when media is present) and retry.',
+  };
+}
+
 /**
  * Decide whether the firmware can actually boot from USB for a reinstall.
  * Ready means: at least one removable/USB UEFI entry exists AND is active

--- a/packages/backend/src/lib/router/boxResolverDns.test.ts
+++ b/packages/backend/src/lib/router/boxResolverDns.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const sendCommand = vi.fn();
-const ensureAgent = vi.fn(() => Promise.resolve({ sendCommand }));
+const ensureAgent = vi.fn((_name: string) => Promise.resolve({ sendCommand }));
 
 vi.mock('@/lib/agent/manager', () => ({
   agentManager: { ensureAgent: (n: string) => ensureAgent(n) },

--- a/packages/backend/src/lib/router/boxResolverDns.test.ts
+++ b/packages/backend/src/lib/router/boxResolverDns.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sendCommand = vi.fn();
+const ensureAgent = vi.fn(() => Promise.resolve({ sendCommand }));
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: (n: string) => ensureAgent(n) },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+let configValue: any = {
+  reverseProxy: { lanIp: '192.168.178.100' },
+  gateway: { type: 'fritzbox', host: '192.168.178.1' },
+};
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(configValue)),
+}));
+
+import { repointBoxResolverToAdguard } from './boxResolverDns';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  configValue = {
+    reverseProxy: { lanIp: '192.168.178.100' },
+    gateway: { type: 'fritzbox', host: '192.168.178.1' },
+  };
+});
+
+describe('repointBoxResolverToAdguard', () => {
+  it('points DNS at AdGuard (127.0.0.1) with the FritzBox as fallback and NO public resolver', async () => {
+    sendCommand
+      .mockResolvedValueOnce({ stdout: 'Wired connection 1\n', exit_code: 0 }) // find conn
+      .mockResolvedValueOnce({ stdout: '', exit_code: 0 }); // mod + reapply
+    const r = await repointBoxResolverToAdguard('Local');
+    expect(r.result).toBe('ok');
+    const modCmd = sendCommand.mock.calls[1][1].command as string;
+    expect(modCmd).toContain("ipv4.dns '127.0.0.1 192.168.178.1'");
+    expect(modCmd).toContain('ipv4.ignore-auto-dns yes');
+    expect(modCmd).not.toContain('8.8.8.8');
+    expect(modCmd).not.toContain('1.1.1.1');
+  });
+
+  it('derives a .1 router fallback when no gateway host is set', async () => {
+    configValue = { reverseProxy: { lanIp: '192.168.178.100' } };
+    sendCommand
+      .mockResolvedValueOnce({ stdout: 'eno1-conn\n', exit_code: 0 })
+      .mockResolvedValueOnce({ stdout: '', exit_code: 0 });
+    const r = await repointBoxResolverToAdguard('Local');
+    expect(r.result).toBe('ok');
+    expect(sendCommand.mock.calls[1][1].command).toContain("'127.0.0.1 192.168.178.1'");
+  });
+
+  it('returns no_interface when there is no active wired connection', async () => {
+    sendCommand.mockResolvedValueOnce({ stdout: '\n', exit_code: 0 });
+    const r = await repointBoxResolverToAdguard('Local');
+    expect(r.result).toBe('no_interface');
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns failed (best-effort) when nmcli exits non-zero', async () => {
+    sendCommand
+      .mockResolvedValueOnce({ stdout: 'Wired connection 1\n', exit_code: 0 })
+      .mockResolvedValueOnce({ stdout: '', stderr: 'Error: unknown connection', exit_code: 1 });
+    const r = await repointBoxResolverToAdguard('Local');
+    expect(r.result).toBe('failed');
+    expect(r.detail).toMatch(/unknown connection/);
+  });
+
+  it('returns no_agent when the node agent is unreachable', async () => {
+    ensureAgent.mockRejectedValueOnce(new Error('agent offline'));
+    const r = await repointBoxResolverToAdguard('Local');
+    expect(r.result).toBe('no_agent');
+  });
+});

--- a/packages/backend/src/lib/router/boxResolverDns.ts
+++ b/packages/backend/src/lib/router/boxResolverDns.ts
@@ -1,0 +1,107 @@
+/**
+ * Re-point the box's OWN DNS resolver at AdGuard after install (#1675).
+ *
+ * The install bakes the box's NetworkManager DNS to the router + a public
+ * fallback (e.g. `192.168.178.1;8.8.8.8`) so the box can resolve during
+ * bootstrap, BEFORE AdGuard exists. But nothing ever re-points it once
+ * AdGuard is up — so the box keeps a public fallback that resolves
+ * `*.<publicDomain>` to the PUBLIC IP (the #1559 split-horizon trap, one
+ * layer down on the box itself).
+ *
+ * This module runs the live fix that worked on 2026-06-04:
+ *
+ *   nmcli con mod <iface> ipv4.dns "127.0.0.1 <router>" ipv4.ignore-auto-dns yes
+ *   nmcli device reapply <iface>
+ *
+ * → AdGuard (127.0.0.1) first, the router as fallback, NO public resolver.
+ * Idempotent: re-running it just re-asserts the same setting. Best-effort —
+ * a failure logs a warning and never fails the install (the box still
+ * resolves via the baked router/public DNS; this only removes the public
+ * fallback hazard).
+ */
+
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+
+export interface RepointBoxResolverResult {
+  result: 'ok' | 'no_agent' | 'no_interface' | 'failed';
+  detail: string;
+}
+
+/** Find the active NetworkManager connection name for the primary wired
+ *  interface. We ask nmcli for the connection bound to a device whose
+ *  type is `ethernet` and that is `connected` — that's `eno1` on the
+ *  FCoS box, but discovering it avoids hard-coding the NIC name. */
+const FIND_CONNECTION_CMD =
+  "nmcli -t -f NAME,DEVICE,TYPE,STATE connection show --active | awk -F: '$3==\"802-3-ethernet\" && $4==\"activated\" {print $1; exit}'";
+
+/** Router/fallback DNS to keep behind AdGuard. Prefer the configured
+ *  FritzBox gateway host; fall back to deriving the .1 of the box's LAN
+ *  IP (the typical home-router address). Never includes a public resolver. */
+function fallbackResolver(gatewayHost: string | undefined, lanIp: string): string | null {
+  if (gatewayHost && /^\d+\.\d+\.\d+\.\d+$/.test(gatewayHost)) return gatewayHost;
+  const m = /^(\d+\.\d+\.\d+)\.\d+$/.exec(lanIp);
+  return m ? `${m[1]}.1` : null;
+}
+
+/** Build the nmcli re-point command for `connName`: AdGuard (127.0.0.1)
+ *  first, the router as fallback, `ignore-auto-dns yes` so DHCP-supplied
+ *  resolvers (incl. any public fallback) are dropped — then reapply. */
+function buildNmcliRepointCmd(connName: string, fallback: string | null): string {
+  const dnsList = fallback ? `127.0.0.1 ${fallback}` : '127.0.0.1';
+  const escaped = connName.replace(/'/g, "'\\''");
+  return (
+    `nmcli con mod '${escaped}' ipv4.dns '${dnsList}' ipv4.ignore-auto-dns yes && ` +
+    `nmcli device reapply "$(nmcli -t -f GENERAL.DEVICES con show '${escaped}' | head -1)" 2>/dev/null || ` +
+    `nmcli con up '${escaped}'`
+  );
+}
+
+interface NmcliAgent {
+  sendCommand: (action: string, params: Record<string, unknown>) => Promise<{ stdout?: string; stderr?: string; exit_code?: number }>;
+}
+
+/** Find the active wired connection, run the re-point, and classify the
+ *  result. Separated from the config/agent setup so the public entry stays
+ *  under the complexity ceiling. */
+async function runNmcliRepoint(agent: NmcliAgent, fallback: string | null): Promise<RepointBoxResolverResult> {
+  const find = await agent.sendCommand('exec', { command: FIND_CONNECTION_CMD });
+  const connName = (find.stdout || '').trim().split('\n')[0]?.trim();
+  if (!connName) {
+    return { result: 'no_interface', detail: 'No active wired NetworkManager connection found — left the resolver untouched.' };
+  }
+  const res = await agent.sendCommand('exec', { command: buildNmcliRepointCmd(connName, fallback) });
+  const exitCode = typeof res.exit_code === 'number' ? res.exit_code : 0;
+  if (exitCode !== 0) {
+    const stderr = (res.stderr || res.stdout || '').slice(0, 200);
+    return { result: 'failed', detail: `nmcli re-point exited ${exitCode}: ${stderr}` };
+  }
+  logger.info('router:boxResolverDns', `Re-pointed ${connName} DNS to AdGuard (127.0.0.1) + fallback ${fallback ?? 'none'}; ignore-auto-dns on.`);
+  const suffix = fallback ? `, fallback ${fallback}` : '';
+  return { result: 'ok', detail: `Box resolver re-pointed at AdGuard (127.0.0.1)${suffix}, no public DNS.` };
+}
+
+/** Run the nmcli re-point on the box. `node` is the install node name
+ *  (defaults to the local node). */
+export async function repointBoxResolverToAdguard(node: string = 'Local'): Promise<RepointBoxResolverResult> {
+  const config = await getConfig();
+  const lanIp = config.reverseProxy?.lanIp;
+  if (!lanIp) {
+    return { result: 'failed', detail: 'No LAN IP recorded — cannot derive the router fallback resolver.' };
+  }
+  const fallback = fallbackResolver(config.gateway?.host, lanIp);
+
+  let agent: NmcliAgent;
+  try {
+    agent = (await agentManager.ensureAgent(node)) as unknown as NmcliAgent;
+  } catch (e) {
+    return { result: 'no_agent', detail: `Could not reach the node agent: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  try {
+    return await runNmcliRepoint(agent, fallback);
+  } catch (e) {
+    return { result: 'failed', detail: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/packages/backend/src/lib/router/dnsConfig.test.ts
+++ b/packages/backend/src/lib/router/dnsConfig.test.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// dnsConfig pulls the FritzBox client + digest helper transitively; stub the
+// digest fetch so a `reconnect` path never hits the network in these tests.
+vi.mock('@/lib/fritzbox/digest', () => ({
+  fetchWithDigest: vi.fn(),
+}));
+
+let configValue: any = {
+  gateway: { type: 'fritzbox', host: '192.168.1.1', username: 'admin', password: 'secret' },
+  reverseProxy: { lanIp: '192.168.1.10' },
+};
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(configValue)),
+}));
+
+import {
+  parseSoapFault,
+  classifyTr064WriteFailure,
+  setFritzBoxDhcpDns,
+  setFritzBoxWanDns,
+} from './dnsConfig';
+
+const FAULT_401 = `<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body>
+<s:Fault><faultcode>s:Client</faultcode><faultstring>UPnPError</faultstring>
+<detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+<errorCode>401</errorCode><errorDescription>Invalid Action</errorDescription>
+</UPnPError></detail></s:Fault></s:Body></s:Envelope>`;
+
+const FAULT_501 = `<s:Fault><detail><UPnPError><errorCode>501</errorCode><errorDescription>Action Failed</errorDescription></UPnPError></detail></s:Fault>`;
+
+const FAULT_GENERIC = `<s:Fault><detail><UPnPError><errorCode>713</errorCode><errorDescription>SpecifiedArrayIndexInvalid</errorDescription></UPnPError></detail></s:Fault>`;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  configValue = {
+    gateway: { type: 'fritzbox', host: '192.168.1.1', username: 'admin', password: 'secret' },
+    reverseProxy: { lanIp: '192.168.1.10' },
+  };
+});
+
+describe('parseSoapFault', () => {
+  it('extracts errorCode + errorDescription from an AVM UPnP fault', () => {
+    expect(parseSoapFault(FAULT_401)).toEqual({ errorCode: 401, errorDescription: 'Invalid Action' });
+  });
+
+  it('returns null for a non-fault body (HTML error page)', () => {
+    expect(parseSoapFault('<html><body>500 Internal Server Error</body></html>')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseSoapFault('')).toBeNull();
+  });
+});
+
+describe('classifyTr064WriteFailure', () => {
+  it('treats UPnP 401 (Invalid Action) as unsupported → manual DNS success', () => {
+    const r = classifyTr064WriteFailure(500, FAULT_401, 'Set DNS manually.');
+    expect(r.result).toBe('unsupported');
+    expect(r.detail).toMatch(/UPnP 401/);
+    expect(r.detail).toMatch(/Invalid Action/);
+    expect(r.detail).toMatch(/Set DNS manually/);
+  });
+
+  it('treats UPnP 501 (Action Failed) as unsupported', () => {
+    expect(classifyTr064WriteFailure(500, FAULT_501, 'manual').result).toBe('unsupported');
+  });
+
+  it('surfaces the actual SOAP fault on a real (non-unsupported) failure', () => {
+    const r = classifyTr064WriteFailure(500, FAULT_GENERIC, 'manual hint');
+    expect(r.result).toBe('failed');
+    expect(r.detail).toMatch(/713/);
+    expect(r.detail).toMatch(/SpecifiedArrayIndexInvalid/);
+    expect(r.detail).toMatch(/manual hint/);
+  });
+
+  it('does not assert "TR-064 disabled or credentials wrong" when no fault is parseable', () => {
+    const r = classifyTr064WriteFailure(500, '<html>oops</html>', 'manual hint');
+    expect(r.result).toBe('failed');
+    expect(r.detail).not.toMatch(/credentials are wrong/);
+    expect(r.detail).toMatch(/manual hint/);
+  });
+});
+
+describe('setFritzBoxDhcpDns — model where SetDNSServers is unsupported', () => {
+  it('returns unsupported (treat manual as success) on a UPnP 401 fault', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => FAULT_401,
+    } as any);
+    const r = await setFritzBoxDhcpDns('192.168.1.10');
+    expect(r.result).toBe('unsupported');
+    expect(r.detail).toMatch(/manually/);
+  });
+
+  it('bare HTTP 401 with no SOAP fault stays a credentials error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+    } as any);
+    const r = await setFritzBoxDhcpDns('192.168.1.10');
+    expect(r.result).toBe('no_credentials');
+  });
+});
+
+describe('setFritzBoxWanDns — unsupported model', () => {
+  it('returns unsupported when both WAN services fault with UPnP 501', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => FAULT_501,
+    } as any);
+    const r = await setFritzBoxWanDns('192.168.1.10');
+    expect(r.result).toBe('unsupported');
+  });
+});

--- a/packages/backend/src/lib/router/dnsConfig.ts
+++ b/packages/backend/src/lib/router/dnsConfig.ts
@@ -15,11 +15,72 @@ import { logger } from '@/lib/logger';
 /** Outcome of a TR-064 call — shared by every router helper here so
  *  the probe-action layer can show the same status pill regardless of
  *  which call ran. `no_gateway` and `no_credentials` are user-fixable
- *  config gaps (Settings → Gateway); `failed` is everything else. */
+ *  config gaps (Settings → Gateway); `unsupported` means the FritzBox
+ *  model/firmware doesn't expose this TR-064 write action (so the
+ *  operator must set DNS manually — NOT an error, see #1672); `failed`
+ *  is everything else. */
 export type RouterCallResult = {
-  result: 'ok' | 'no_gateway' | 'no_credentials' | 'failed';
+  result: 'ok' | 'no_gateway' | 'no_credentials' | 'unsupported' | 'failed';
   detail?: string;
 };
+
+/** Parsed TR-064 SOAP fault — the `errorCode`/`errorDescription` AVM
+ *  returns inside a `<s:Fault>` body. */
+export interface SoapFault {
+  errorCode: number | null;
+  errorDescription: string;
+}
+
+/** Extract the UPnP `errorCode` + `errorDescription` from a TR-064 SOAP
+ *  fault body. FritzBox returns these inside
+ *  `<s:Fault><detail><UPnPError><errorCode>…`. Returns null when the
+ *  text isn't a recognisable SOAP fault (e.g. an HTML error page). */
+export function parseSoapFault(text: string): SoapFault | null {
+  if (!text || !/<(\w+:)?Fault[\s>]/i.test(text) && !/UPnPError/i.test(text)) return null;
+  const codeMatch = /<errorCode>\s*(\d+)\s*<\/errorCode>/i.exec(text);
+  const descMatch = /<errorDescription>([^<]*)<\/errorDescription>/i.exec(text);
+  const faultStringMatch = /<(?:\w+:)?faultstring>([^<]*)<\/(?:\w+:)?faultstring>/i.exec(text);
+  const errorCode = codeMatch ? parseInt(codeMatch[1], 10) : null;
+  const errorDescription = (descMatch?.[1] ?? faultStringMatch?.[1] ?? '').trim();
+  if (errorCode === null && !errorDescription) return null;
+  return { errorCode, errorDescription };
+}
+
+/** UPnP error codes that mean "this action isn't implemented on this
+ *  device/firmware" rather than a transient failure or a bad request.
+ *  401 = Invalid Action, 501 = Action Failed (AVM returns this for
+ *  SetDNSServers on models that don't expose the write), 602 = Optional
+ *  Action Not Implemented. On any of these we tell the operator to set
+ *  DNS manually and treat that as success — the write path simply isn't
+ *  available on their box (#1672). */
+const UNSUPPORTED_UPNP_CODES = new Set([401, 501, 602]);
+
+/** Decide whether an HTTP status + body from a TR-064 write means the
+ *  action is *unsupported* on this FritzBox (operator must set DNS by
+ *  hand — not an error), returning a structured result, or a real
+ *  failure with the actual SOAP fault surfaced. Shared by the DHCP and
+ *  WAN write helpers so both give the same actionable message. */
+export function classifyTr064WriteFailure(status: number, body: string, manualHint: string): RouterCallResult {
+  const fault = parseSoapFault(body);
+  // A bare HTTP 401 with no SOAP fault = credentials rejected at the
+  // transport layer (not an "Invalid Action" UPnP fault).
+  if (status === 401 && !fault) {
+    return { result: 'no_credentials', detail: 'FritzBox rejected the TR-064 credentials. Re-check Settings → Gateway.' };
+  }
+  if (fault && fault.errorCode !== null && UNSUPPORTED_UPNP_CODES.has(fault.errorCode)) {
+    return {
+      result: 'unsupported',
+      detail: `This FritzBox doesn't support setting DNS over TR-064 (UPnP ${fault.errorCode}${fault.errorDescription ? ` — ${fault.errorDescription}` : ''}). ${manualHint} Once DNS is set, ServiceBay verifies it via the LAN resolution path, so a manual setup reads green.`,
+    };
+  }
+  const faultDetail = fault
+    ? ` SOAP fault: ${fault.errorCode ?? '?'}${fault.errorDescription ? ` ${fault.errorDescription}` : ''}.`
+    : '';
+  return {
+    result: 'failed',
+    detail: `FritzBox declined the DNS write (HTTP ${status}).${faultDetail} ${manualHint}`,
+  };
+}
 
 /**
  * Build the DHCP DNS SOAP payload and credentials for FritzBox.
@@ -90,10 +151,11 @@ export async function setFritzBoxDhcpDns(targetIp: string): Promise<RouterCallRe
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       logger.warn('router:dnsConfig', `TR-064 SetDNSServers HTTP ${res.status}: ${text.slice(0, 200)}`);
-      return {
-        result: 'failed',
-        detail: `FritzBox returned HTTP ${res.status} — likely TR-064 is disabled (Settings → Home Network → FRITZ!Box Network → activate UPnP) or the credentials are wrong.`,
-      };
+      return classifyTr064WriteFailure(
+        res.status,
+        text,
+        `Set the DHCP DNS server to ${targetIp} manually in the FritzBox UI (Home Network → Network → Network Settings → IPv4 Addresses → DHCP server → Local DNS server).`,
+      );
     }
     // Touch the existing client so we know it's still reachable for
     // the next call — best-effort; ignore failures.
@@ -165,6 +227,57 @@ function buildWanDnsSoapBody(targetIp: string, serviceType: string): string {
  * returns HTTP 401 / 501 and we surface that as `failed` with a
  * pointer to the UI toggle.
  */
+/** Outcome of the per-WAN-service write loop: `ok`/`no_credentials` are
+ *  terminal; otherwise the last HTTP status + body are carried out so the
+ *  caller can classify unsupported-vs-failed once both services are tried. */
+interface WanWriteAttemptOutcome {
+  terminal: RouterCallResult | null;
+  lastStatus: number;
+  lastBody: string | null;
+  errors: string[];
+}
+
+async function tryWanDnsWrites(
+  targetIp: string,
+  gateway: { host: string; username?: string; password?: string; ssl?: boolean },
+): Promise<WanWriteAttemptOutcome> {
+  const { scheme, port, auth, attempts } = buildWanDnsPayload(targetIp, gateway);
+  const errors: string[] = [];
+  let lastStatus = 0;
+  let lastBody: string | null = null;
+  for (const a of attempts) {
+    try {
+      const url = `${scheme}://${gateway.host}:${port}${a.controlUrl}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/xml; charset=utf-8',
+          'SOAPAction': `"${a.serviceType}#SetDNSServers"`,
+          'Authorization': auth,
+        },
+        body: buildWanDnsSoapBody(targetIp, a.serviceType),
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (res.ok) {
+        logger.info('router:dnsConfig', `FritzBox SetDNSServers (WAN upstream) accepted via ${a.serviceType}`);
+        return { terminal: { result: 'ok' }, lastStatus, lastBody, errors };
+      }
+      const text = await res.text().catch(() => '');
+      const fault = parseSoapFault(text);
+      if (res.status === 401 && !fault) {
+        return { terminal: { result: 'no_credentials', detail: 'FritzBox rejected the TR-064 credentials. Re-check Settings → Gateway.' }, lastStatus, lastBody, errors };
+      }
+      lastStatus = res.status;
+      lastBody = text;
+      const faultStr = fault ? `${fault.errorCode ?? '?'} ${fault.errorDescription}` : text.slice(0, 120);
+      errors.push(`${a.serviceType}: HTTP ${res.status} ${faultStr.trim()}`);
+    } catch (e) {
+      errors.push(`${a.serviceType}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  return { terminal: null, lastStatus, lastBody, errors };
+}
+
 export async function setFritzBoxWanDns(targetIp: string): Promise<RouterCallResult> {
   const config = await getConfig();
   const gateway = config.gateway;
@@ -178,42 +291,19 @@ export async function setFritzBoxWanDns(targetIp: string): Promise<RouterCallRes
     };
   }
 
-  const { scheme, port, auth, attempts } = buildWanDnsPayload(targetIp, gateway);
-  const errors: string[] = [];
-  for (const a of attempts) {
-    try {
-      const url = `${scheme}://${gateway.host}:${port}${a.controlUrl}`;
-      const body = buildWanDnsSoapBody(targetIp, a.serviceType);
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/xml; charset=utf-8',
-          'SOAPAction': `"${a.serviceType}#SetDNSServers"`,
-          'Authorization': auth,
-        },
-        body,
-        signal: AbortSignal.timeout(8_000),
-      });
-      if (res.ok) {
-        logger.info('router:dnsConfig', `FritzBox SetDNSServers (WAN upstream) accepted via ${a.serviceType}`);
-        return { result: 'ok' };
-      }
-      const text = await res.text().catch(() => '');
-      if (res.status === 401) {
-        return {
-          result: 'no_credentials',
-          detail: 'FritzBox rejected the TR-064 credentials. Re-check Settings → Gateway.',
-        };
-      }
-      errors.push(`${a.serviceType}: HTTP ${res.status} ${text.slice(0, 120)}`);
-    } catch (e) {
-      errors.push(`${a.serviceType}: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
+  const { terminal, lastStatus, lastBody, errors } = await tryWanDnsWrites(targetIp, gateway);
+  if (terminal) return terminal;
   logger.warn('router:dnsConfig', `FritzBox SetDNSServers (WAN upstream) failed: ${errors.join(' | ')}`);
+  if (lastBody !== null) {
+    return classifyTr064WriteFailure(
+      lastStatus,
+      lastBody,
+      'Set the upstream DNS manually in the FritzBox UI: Internet → Account Information → DNS Server → "Use other DNSv4 servers" → ' + targetIp + '. (If it\'s currently "From provider", switch it once and the manual value sticks.)',
+    );
+  }
   return {
     result: 'failed',
-    detail: 'FritzBox declined SetDNSServers on both WAN services. Most common cause: "Internet → Account Information → DNS Server" is set to "From provider" — switch it to "Use other DNSv4 servers" once and retry; subsequent TR-064 writes then succeed.',
+    detail: `FritzBox upstream-DNS write failed before it returned an HTTP status (${errors.join(' | ') || 'no response'}). Check that the FritzBox is reachable and TR-064/UPnP is enabled, or set the upstream DNS to ${targetIp} manually under Internet → Account Information → DNS Server.`,
   };
 }
 
@@ -281,11 +371,12 @@ async function waitForFritzBoxReconnect(
         return { ok: true, errors: [] };
       }
       const text = await res.text().catch(() => '');
-      if (res.status === 401) {
+      const fault = parseSoapFault(text);
+      if (res.status === 401 && !fault) {
         errors.push('401');
         break;
       }
-      errors.push(`${attempt.serviceType}: HTTP ${res.status} ${text.slice(0, 120)}`);
+      errors.push(`${attempt.serviceType}: HTTP ${res.status} ${(fault ? `${fault.errorCode ?? '?'} ${fault.errorDescription}` : text.slice(0, 120)).trim()}`);
     } catch (e) {
       errors.push(`${attempt.serviceType}: ${e instanceof Error ? e.message : String(e)}`);
     }
@@ -340,6 +431,6 @@ export async function reconnectFritzBox(): Promise<RouterCallResult> {
   logger.warn('router:dnsConfig', `FritzBox reconnect failed: ${errors.join(' | ')}`);
   return {
     result: 'failed',
-    detail: `FritzBox declined ForceTermination on both WAN services. Likely TR-064 is disabled (Settings → Home Network → FRITZ!Box Network → activate UPnP).`,
+    detail: `FritzBox declined ForceTermination on both WAN services (${errors.join(' | ') || 'no response'}). Likely TR-064 is disabled (Settings → Home Network → FRITZ!Box Network → activate UPnP), or this model doesn't expose the reconnect action — trigger "Neu verbinden" in the FritzBox UI under Internet → Online-Monitor instead.`,
   };
 }

--- a/packages/backend/src/lib/router/lanResolver.ts
+++ b/packages/backend/src/lib/router/lanResolver.ts
@@ -1,0 +1,58 @@
+/**
+ * LAN-path DNS resolution (#1672) — resolve a hostname the way a LAN
+ * client does: through AdGuard on the box, NOT through the OS resolver.
+ *
+ * Why a dedicated resolver: the box's own `/etc/resolv.conf` historically
+ * carried a public fallback (`8.8.8.8`, #1675). When `domain_resolves_to_box`
+ * or `router_dns_not_pointing` used `dns.resolve4` against the OS resolver,
+ * a public resolver could answer `ldap.<publicDomain>` with the box's
+ * *public* IP (the split-horizon the LAN doesn't have), and the probe
+ * false-red'd even though every LAN device — which queries AdGuard — gets
+ * the box's LAN IP. AdGuard holds the `*.<publicDomain> → <lanIp>` rewrite,
+ * so pointing the lookup at AdGuard reproduces the LAN client's answer.
+ *
+ * We bind a Node `dns.Resolver` to AdGuard's listeners (`127.0.0.1` and the
+ * box's LAN IP, both on :53). No fallback to the system resolver — the
+ * point is to bypass any public fallback entirely.
+ */
+
+import { Resolver } from 'dns/promises';
+
+const DNS_TIMEOUT_MS = 3000;
+
+/** AdGuard listens on :53 on both loopback and the box's LAN IP. We try
+ *  loopback first (always present on the node), then the LAN IP. */
+function adguardServers(lanIp: string): string[] {
+  const servers = ['127.0.0.1'];
+  if (lanIp && lanIp !== '127.0.0.1') servers.push(lanIp);
+  return servers;
+}
+
+/** Resolve a hostname's A-records via AdGuard (the LAN path) with a hard
+ *  timeout. Returns null on NXDOMAIN / SERVFAIL / timeout / any error —
+ *  the caller treats null as "does not resolve via the LAN path".
+ *
+ *  `resolverFactory` is injectable for tests; defaults to a fresh
+ *  AdGuard-bound `Resolver`. */
+export async function resolve4ViaLan(
+  hostname: string,
+  lanIp: string,
+  resolverFactory: (servers: string[]) => Pick<Resolver, 'resolve4'> = defaultLanResolver,
+): Promise<string[] | null> {
+  try {
+    const resolver = resolverFactory(adguardServers(lanIp));
+    const records = await Promise.race([
+      resolver.resolve4(hostname),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('dns timeout')), DNS_TIMEOUT_MS)),
+    ]);
+    return records.length > 0 ? records : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultLanResolver(servers: string[]): Resolver {
+  const resolver = new Resolver({ timeout: DNS_TIMEOUT_MS, tries: 1 });
+  resolver.setServers(servers);
+  return resolver;
+}

--- a/packages/frontend/src/app/api/health/checks/route.ts
+++ b/packages/frontend/src/app/api/health/checks/route.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { withApiHandler } from '@/lib/api/handler';
 import { HealthCheckTarget, NodeName } from '@/lib/api/schemas';
 import { getDiagnoseChecksEnriched } from '@/lib/diagnose/diagnoseChecks';
+import { isKnownLocalSystemTarget } from '@/lib/health/ssrfGuard';
 
 export const GET = withApiHandler({}, async () => {
   const checks = HealthStore.getChecks();
@@ -52,7 +53,18 @@ const CheckPostBody = z.object({
   }).optional(),
 });
 
-export const POST = withApiHandler({ body: CheckPostBody }, async ({ body }) => {
+export const POST = withApiHandler({ body: CheckPostBody }, async ({ body, auth }) => {
+  // #1670: a ServiceBay self-created check of a known-local hostNetwork
+  // service (HA `127.0.0.1:8123`, Ollama `:11434`) bypasses the monitoring
+  // SSRF guard. Only the internal-token path (a stack's post-deploy, `auth.user
+  // === 'internal'`) targeting a recognised loopback service earns the flag —
+  // a user-supplied check (cookie session / UI) never does, so a user can't
+  // self-grant the bypass for an arbitrary internal URL.
+  const systemCheck =
+    auth?.user === 'internal' &&
+    body.type === 'http' &&
+    isKnownLocalSystemTarget(body.target);
+
   const check: CheckConfig = {
     id: body.id || uuidv4(),
     created_at: body.created_at || new Date().toISOString(),
@@ -63,6 +75,7 @@ export const POST = withApiHandler({ body: CheckPostBody }, async ({ body }) => 
     interval: body.interval || 60,
     nodeName: body.nodeName,
     httpConfig: body.httpConfig,
+    ...(systemCheck ? { systemCheck: true } : {}),
   };
 
   HealthStore.saveCheck(check);

--- a/packages/frontend/src/app/api/system/boot/usb-next/route.ts
+++ b/packages/frontend/src/app/api/system/boot/usb-next/route.ts
@@ -4,6 +4,7 @@ import { agentManager } from '@/lib/agent/manager';
 import { listNodes } from '@/lib/nodes';
 import { logger } from '@/lib/logger';
 import { withApiHandler } from '@/lib/api/handler';
+import { parseEfibootmgr, selectInstallerBootDevice, planUsbBoot } from '@/lib/mcp/efibootmgr';
 
 export const dynamic = 'force-dynamic';
 
@@ -82,40 +83,70 @@ const PostBody = z.object({
   reboot: z.boolean().optional().default(false),
 });
 
+type Agent = Awaited<ReturnType<typeof getAgent>>;
+
+// resolveBootNum maps the next USB boot to the REAL FCoS installer device
+// (#1674). On a multi-slot card reader the old description-only heuristic armed
+// an empty slot; this finds the block device carrying the fedora-coreos /
+// EFI-SYSTEM labels and CREATES a direct UEFI entry to its \EFI\BOOT\BOOTX64.EFI
+// (the exact `efibootmgr -c -d <disk> -p <part>` recovery the operator ran by
+// hand). Only when no installer device is found does it fall back to an existing
+// removable UEFI entry — with a warning when that entry looks like an empty slot.
+// Returns the chosen boot number, an optional operator warning, and a `failed`
+// message when the create command itself errored.
+async function resolveBootNum(agent: Agent): Promise<{ bootNum?: string; warning?: string; failed?: string }> {
+  const efiRes = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
+  const parsed = parseEfibootmgr(efiRes.code === 0 ? (efiRes.stdout ?? '') : '');
+
+  const lsblkRes = await agent.sendCommand('exec', { command: 'lsblk --json -O' }) as { code?: number; stdout?: string };
+  const device = lsblkRes.code === 0 ? selectInstallerBootDevice(lsblkRes.stdout ?? '') : null;
+
+  const plan = planUsbBoot(parsed, device);
+  if (plan.warning) {
+    logger.warn('api:system:boot:usb-next', plan.warning);
+  }
+
+  if (plan.mode === 'create' && plan.device) {
+    const { disk, efiPartNum, reason } = plan.device;
+    logger.info('api:system:boot:usb-next', `Creating UEFI entry for installer device ${disk} (${reason})`);
+    const createRes = await agent.sendCommand('exec', {
+      command: `sudo -n efibootmgr -c -d ${disk} -p ${efiPartNum} -L "ServiceBay Installer USB" -l '\\EFI\\BOOT\\BOOTX64.EFI'`,
+    }) as { code?: number; stdout?: string; stderr?: string };
+    if (createRes.code !== 0) {
+      return { failed: `Failed to create installer boot entry: ${createRes.stderr}` };
+    }
+    // efibootmgr prints the new entry; its BootNum is the just-created one.
+    const created = parseEfibootmgr(createRes.stdout ?? '').entries.find(e => e.description.includes('ServiceBay Installer USB'));
+    return { bootNum: created?.bootNum, warning: plan.warning };
+  }
+  return { bootNum: plan.bootNum, warning: plan.warning };
+}
+
 // `tokenScope: 'mutate'` — sets the firmware's one-shot BootNext (and optionally
 // reboots), so the sb "ensure USB boot" action can enable it with a scoped
 // token, matching the frontend's enable button.
 export const POST = withApiHandler({ body: PostBody, tokenScope: 'mutate' }, async ({ body }) => {
   try {
     const agent = await getAgent();
-    
+
     let bootNum = body.bootNum;
-    
+    let warning: string | undefined;
     if (!bootNum) {
-      const res = await agent.sendCommand('exec', { command: 'sudo -n efibootmgr -v' }) as { code?: number; stdout?: string };
-      if (res.code === 0) {
-        const stdout = res.stdout ?? '';
-        const lines = stdout.split('\n');
-        for (const line of lines) {
-          if (line.startsWith('Boot') && !line.startsWith('BootOrder') && !line.startsWith('BootNext') && !line.startsWith('BootCurrent')) {
-            const match = line.match(/^Boot([0-9A-Fa-f]+)(\*?)\s+(.+)$/);
-            if (match) {
-              const num = match[1];
-              const desc = match[3];
-              if (desc.toLowerCase().includes('usb') || desc.toLowerCase().includes('removable') || desc.includes('\\EFI\\boot\\')) {
-                bootNum = num;
-                break;
-              }
-            }
-          }
-        }
+      const resolved = await resolveBootNum(agent);
+      if (resolved.failed) {
+        return NextResponse.json({ error: resolved.failed }, { status: 500 });
       }
+      bootNum = resolved.bootNum;
+      warning = resolved.warning;
     }
-    
+
     if (!bootNum) {
-      return NextResponse.json({ error: 'No USB boot entry found or specified' }, { status: 400 });
+      return NextResponse.json(
+        { error: warning ?? 'No USB boot entry found or specified', warning },
+        { status: 400 },
+      );
     }
-    
+
     logger.info('api:system:boot:usb-next', `Activating UEFI boot entry Boot${bootNum}`);
     await agent.sendCommand('exec', { command: `sudo -n efibootmgr -A -b ${bootNum}` });
 
@@ -124,7 +155,7 @@ export const POST = withApiHandler({ body: PostBody, tokenScope: 'mutate' }, asy
     if (resBootNext.code !== 0) {
       return NextResponse.json({ error: `Failed to set BootNext: ${resBootNext.stderr}` }, { status: 500 });
     }
-    
+
     if (body.reboot) {
       logger.info('api:system:boot:usb-next', 'Rebooting system as requested...');
       // sudo -n: the agent runs as the rootless `core` user, which can't reboot
@@ -138,6 +169,7 @@ export const POST = withApiHandler({ body: PostBody, tokenScope: 'mutate' }, asy
     return NextResponse.json({
       success: true,
       bootNum,
+      warning,
       message: body.reboot ? 'One-shot BootNext set. System is rebooting.' : 'One-shot BootNext set successfully.',
     });
   } catch (err: unknown) {

--- a/packages/frontend/src/components/HealthChecks.tsx
+++ b/packages/frontend/src/components/HealthChecks.tsx
@@ -29,6 +29,21 @@ export function isDiagnoseRow(check: Check): boolean {
   return Boolean((check as Check & { diagnose?: unknown }).diagnose);
 }
 
+/**
+ * "Last checked" cell text for a row (#1671). Synthetic diagnose rows run on
+ * the daily self-diagnose cadence, not the per-minute check poll, so a raw
+ * timestamp on a diagnose row reads as misleadingly "stale" next to every
+ * other (60s-polled) row. Suffix the cadence so a ~20h-old self-diagnose
+ * timestamp is understood as fresh-for-its-schedule rather than broken. Real
+ * checks keep the plain timestamp. `Never` until the first run lands.
+ */
+export function lastCheckedLabel(check: Check): string {
+  if (!check.lastRun) return 'Never';
+  const stamp = new Date(check.lastRun).toLocaleString();
+  if (isDiagnoseRow(check)) return `${stamp} (daily self-diagnose)`;
+  return stamp;
+}
+
 /** Per-row status presentation (icon tint + badge background). Module-level
  *  so the row renderer stays a thin map. */
 const ROW_STATUS_META: Record<RowStatus, { color: string; bg: string; Icon: typeof CheckCircle }> = {
@@ -225,7 +240,7 @@ export default function HealthChecks({
                                     </p>
                                 )}
                                 <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                                    Last checked: {check.lastRun ? new Date(check.lastRun).toLocaleString() : 'Never'}
+                                    Last checked: {lastCheckedLabel(check)}
                                 </p>
                             </div>
                         </div>
@@ -269,14 +284,26 @@ export default function HealthChecks({
                             </button>
                             {isDiagnose ? (
                                 /* Synthetic diagnose row: not editable config — expose the
-                                   self-repair popup instead of Edit/Delete (#1423). */
-                                <button
-                                    onClick={() => handleOpenRepair(check)}
-                                    className="p-2 hover:bg-violet-100 dark:hover:bg-violet-900/30 rounded-lg transition-colors"
-                                    title="Self-repair options"
-                                >
-                                    <Wrench className="w-4 h-4 text-violet-600 dark:text-violet-400" />
-                                </button>
+                                   self-repair popup instead of Edit/Delete (#1423). It still
+                                   gets the History drawer (#1671): its results are persisted
+                                   under the `diagnose:<id>` key just like any other check, so
+                                   the same history view applies — only Edit/Delete don't. */
+                                <>
+                                    <button
+                                        onClick={() => handleViewHistory(check)}
+                                        className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                                        title="View history"
+                                    >
+                                        <History className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                                    </button>
+                                    <button
+                                        onClick={() => handleOpenRepair(check)}
+                                        className="p-2 hover:bg-violet-100 dark:hover:bg-violet-900/30 rounded-lg transition-colors"
+                                        title="Self-repair options"
+                                    >
+                                        <Wrench className="w-4 h-4 text-violet-600 dark:text-violet-400" />
+                                    </button>
+                                </>
                             ) : (
                                 <>
                                     <button

--- a/packages/frontend/src/components/healthChecksRows.test.ts
+++ b/packages/frontend/src/components/healthChecksRows.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #1671 — synthetic diagnose check rows must surface the same history + a
+ * non-misleading last-checked as every other row. These cover the pure row
+ * helpers: a diagnose row is recognised (so it gets the History drawer like
+ * any other check), and its last-checked is qualified with the daily cadence
+ * so a ~20h-old self-diagnose timestamp doesn't read as "stale".
+ */
+import { describe, it, expect } from 'vitest';
+import type { Check } from '@servicebay/api-client';
+import { isDiagnoseRow, lastCheckedLabel } from './HealthChecks';
+
+function makeCheck(over: Partial<Check>): Check {
+  return {
+    id: 'c1',
+    name: 'Check',
+    type: 'http',
+    target: 'http://example.com',
+    interval: 60,
+    enabled: true,
+    created_at: new Date(0).toISOString(),
+    status: 'ok',
+    lastRun: null,
+    lastResult: null,
+    history: [],
+    ...over,
+  } as Check;
+}
+
+describe('isDiagnoseRow', () => {
+  it('is true when the row carries a diagnose payload', () => {
+    const row = makeCheck({ id: 'diagnose:agent', diagnose: { status: 'ok' } } as Partial<Check>);
+    expect(isDiagnoseRow(row)).toBe(true);
+  });
+
+  it('is false for a regular check', () => {
+    expect(isDiagnoseRow(makeCheck({}))).toBe(false);
+  });
+});
+
+describe('lastCheckedLabel', () => {
+  it('returns Never when the row has not run', () => {
+    expect(lastCheckedLabel(makeCheck({ lastRun: null }))).toBe('Never');
+  });
+
+  it('shows a plain timestamp for a normal check', () => {
+    const ts = '2026-06-05T10:00:00.000Z';
+    const label = lastCheckedLabel(makeCheck({ lastRun: ts }));
+    expect(label).toBe(new Date(ts).toLocaleString());
+    expect(label).not.toContain('self-diagnose');
+  });
+
+  it('qualifies a diagnose row timestamp with the daily cadence', () => {
+    const ts = '2026-06-04T14:00:00.000Z';
+    const label = lastCheckedLabel(
+      makeCheck({ id: 'diagnose:agent', lastRun: ts, diagnose: { status: 'ok' } } as Partial<Check>),
+    );
+    expect(label).toContain(new Date(ts).toLocaleString());
+    expect(label).toContain('daily self-diagnose');
+  });
+});

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import sys
 import time
 import urllib.error
@@ -56,6 +57,86 @@ def emit_credential(**fields: object) -> None:
 def log(msg: str) -> None:
     sys.stdout.write(msg + "\n")
     sys.stdout.flush()
+
+
+# SQLite header magic — the first 16 bytes of every valid sqlite3 file are
+# "SQLite format 3\0". We check this before touching the file so a half-written
+# / corrupt / non-sqlite path can never be opened-and-mutated (a WAL switch on a
+# garbage file would only add confusing -wal/-shm sidecars). #1679.
+SQLITE_HEADER = b"SQLite format 3\x00"
+
+
+def ensure_sqlite_wal(db_path: str, label: str, busy_timeout_ms: int = 30000) -> bool:
+    """Switch a SQLite DB to WAL journal mode (idempotent, host-side).
+
+    Why (#1679): Authelia (and NPM) ship their SQLite DB in the default
+    `journal_mode=delete` rollback journal, where a writer takes an EXCLUSIVE
+    lock that blocks every concurrent reader. On this box's degraded 1-of-2
+    RAID1, one slow-fsync write holds that lock past the short busy_timeout and
+    concurrent logins fail `database is locked` (firstfactor 401 / OIDC
+    server_error). WAL lets readers run concurrently with a single writer, so a
+    slow write degrades latency, not correctness. Neither app exposes a
+    journal_mode config knob, so we flip it on disk once after deploy — WAL is
+    recorded in the DB header, so it persists and the app adopts it on its next
+    open. Re-running is a no-op (already `wal`).
+
+    Runs on the host (post-deploy runs as root on FCoS) against the bind-mounted
+    DB file — no dependency on a `sqlite3` CLI being present in the service's
+    container image. Fail-soft by contract: a missing file, an invalid sqlite
+    header, or a transient lock is logged and skipped, never raised — the app
+    keeps working with whatever journal mode it has.
+
+    Returns True iff the DB is in WAL mode after the call.
+    """
+    if not os.path.isfile(db_path):
+        # Fresh install: the app hasn't created its DB yet. Nothing to do — the
+        # app will create it in `delete` mode, and the next deploy's post-deploy
+        # run flips it. (We deliberately do NOT pre-create it: an empty file
+        # would have no schema and could confuse the app's own init.)
+        log(f"ℹ️ {label} SQLite DB not present yet at {db_path} — skipping WAL switch (will apply on next deploy).")
+        return False
+
+    # Validate the sqlite header before opening — never mutate a non-sqlite /
+    # torn file.
+    try:
+        with open(db_path, "rb") as fh:
+            header = fh.read(16)
+    except OSError as e:
+        log(f"⚠️ Could not read {label} SQLite DB at {db_path} ({e}) — skipping WAL switch.")
+        return False
+    if header != SQLITE_HEADER:
+        log(f"⚠️ {db_path} is not a valid SQLite database (bad header) — skipping {label} WAL switch.")
+        return False
+
+    try:
+        # A short timeout so we don't hang the deploy if the app is mid-write;
+        # if we can't get in now, the header flip just lands on the next deploy.
+        conn = sqlite3.connect(db_path, timeout=10)
+        try:
+            conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)};")
+            mode = conn.execute("PRAGMA journal_mode=WAL;").fetchone()
+            current = (mode[0] if mode else "").lower()
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        # `database is locked` here is exactly the condition WAL fixes; it's
+        # transient (the app's slow write will finish). Log and let the next
+        # deploy retry rather than failing the install.
+        log(f"⚠️ Could not switch {label} SQLite DB to WAL ({e}) — leaving journal mode as-is; will retry on next deploy.")
+        return False
+
+    if current == "wal":
+        log(f"✅ {label} SQLite DB is in WAL mode (busy_timeout {busy_timeout_ms}ms) — concurrent reads no longer block on the writer.")
+        return True
+    log(f"⚠️ {label} SQLite DB did not switch to WAL (journal_mode={current or 'unknown'}) — likely a live lock; will retry on next deploy.")
+    return False
+
+
+def authelia_db_path() -> str:
+    """Host path of Authelia's SQLite DB. Must track the `authelia-data`
+    hostPath mount in template.yml (`{{DATA_DIR}}/auth/authelia-data`)."""
+    base = env("DATA_DIR", "/mnt/data")
+    return os.path.join(base, "auth", "authelia-data", "db.sqlite3")
 
 
 def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
@@ -126,6 +207,11 @@ def main() -> int:
     sb_api = env("SB_API_URL", "http://localhost:3000")
     public_domain = env("PUBLIC_DOMAIN")
     operator_email = env("OPERATOR_EMAIL")
+
+    # ── Authelia SQLite → WAL (#1679) ────────────────────────────────────
+    # Independent of the LLDAP credential/seed flow below; do it first so a
+    # returning install gets the concurrency fix even if LLDAP env is missing.
+    ensure_sqlite_wal(authelia_db_path(), "Authelia")
 
     lldap_password = env("LLDAP_ADMIN_PASSWORD")
     lldap_port = env("LLDAP_PORT", "17170")

--- a/templates/nginx/post-deploy.py
+++ b/templates/nginx/post-deploy.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import sys
 
 
@@ -35,11 +36,88 @@ def emit_credential(**fields: object) -> None:
     sys.stdout.flush()
 
 
+def log(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+# SQLite header magic — the first 16 bytes of every valid sqlite3 file are
+# "SQLite format 3\0". Checked before we touch the file so a half-written /
+# corrupt / non-sqlite path is never opened-and-mutated. #1679.
+SQLITE_HEADER = b"SQLite format 3\x00"
+
+
+def ensure_sqlite_wal(db_path: str, label: str, busy_timeout_ms: int = 30000) -> bool:
+    """Switch a SQLite DB to WAL journal mode (idempotent, host-side).
+
+    Why (#1679): NPM (and Authelia) ship their SQLite DB in the default
+    `journal_mode=delete` rollback journal, where a writer takes an EXCLUSIVE
+    lock that blocks every concurrent reader. On this box's degraded 1-of-2
+    RAID1, one slow-fsync write holds that lock past the short busy_timeout and
+    concurrent admin-API calls fail `database is locked` (NPM POST /api/tokens
+    → 500). WAL lets readers run concurrently with a single writer, so a slow
+    write degrades latency, not correctness. NPM/knex doesn't expose a
+    journal_mode knob, so we flip it on disk once after deploy — WAL is recorded
+    in the DB header, so it persists and the app adopts it on its next open.
+    Re-running is a no-op (already `wal`).
+
+    Runs on the host (post-deploy runs as root on FCoS) against the bind-mounted
+    DB file — no dependency on a `sqlite3` CLI in the container image. Fail-soft
+    by contract: a missing file, an invalid sqlite header, or a transient lock
+    is logged and skipped, never raised.
+
+    Returns True iff the DB is in WAL mode after the call.
+    """
+    if not os.path.isfile(db_path):
+        log(f"ℹ️ {label} SQLite DB not present yet at {db_path} — skipping WAL switch (will apply on next deploy).")
+        return False
+
+    try:
+        with open(db_path, "rb") as fh:
+            header = fh.read(16)
+    except OSError as e:
+        log(f"⚠️ Could not read {label} SQLite DB at {db_path} ({e}) — skipping WAL switch.")
+        return False
+    if header != SQLITE_HEADER:
+        log(f"⚠️ {db_path} is not a valid SQLite database (bad header) — skipping {label} WAL switch.")
+        return False
+
+    try:
+        conn = sqlite3.connect(db_path, timeout=10)
+        try:
+            conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)};")
+            mode = conn.execute("PRAGMA journal_mode=WAL;").fetchone()
+            current = (mode[0] if mode else "").lower()
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        log(f"⚠️ Could not switch {label} SQLite DB to WAL ({e}) — leaving journal mode as-is; will retry on next deploy.")
+        return False
+
+    if current == "wal":
+        log(f"✅ {label} SQLite DB is in WAL mode (busy_timeout {busy_timeout_ms}ms) — concurrent reads no longer block on the writer.")
+        return True
+    log(f"⚠️ {label} SQLite DB did not switch to WAL (journal_mode={current or 'unknown'}) — likely a live lock; will retry on next deploy.")
+    return False
+
+
+def npm_db_path() -> str:
+    """Host path of NPM's SQLite DB. Must track the `npm-data` hostPath mount in
+    template.yml (`{{DATA_DIR}}/nginx-proxy-manager/data` ← /data)."""
+    base = env("DATA_DIR", "/mnt/data")
+    return os.path.join(base, "nginx-proxy-manager", "data", "database.sqlite")
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
     admin_port = env("NGINX_ADMIN_PORT", "81")
     email = env("NGINX_ADMIN_EMAIL", "admin@servicebay.local")
     password = env("NGINX_ADMIN_PASSWORD")
+
+    # ── NPM SQLite → WAL (#1679) ──────────────────────────────────────────
+    # Runs regardless of whether a fresh admin password was generated — a
+    # returning install (no new password) still needs the concurrency fix.
+    ensure_sqlite_wal(npm_db_path(), "NPM")
 
     if not password:
         # No password generated — bootstrapNpmAdmin will skip too. Nothing

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -185,6 +185,74 @@ class NginxScript(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(parse_credentials(out), [])
 
+    def test_wal_switch_is_idempotent_and_reports_wal(self):
+        """#1679: ensure_sqlite_wal flips a real (delete-mode) sqlite DB to WAL,
+        and a second run is a no-op that still reports WAL — proving the on-disk
+        header persists and re-running never errors."""
+        import sqlite3
+        import tempfile
+        m = load_script("nginx")
+        with tempfile.TemporaryDirectory() as tmp:
+            db = os.path.join(tmp, "database.sqlite")
+            conn = sqlite3.connect(db)
+            conn.execute("PRAGMA journal_mode=DELETE;")
+            conn.execute("CREATE TABLE t (id INTEGER);")
+            conn.commit()
+            conn.close()
+
+            self.assertTrue(m.ensure_sqlite_wal(db, "NPM"))
+            # The header now records WAL.
+            with sqlite3.connect(db) as c:
+                self.assertEqual(c.execute("PRAGMA journal_mode;").fetchone()[0].lower(), "wal")
+            # Idempotent second run.
+            self.assertTrue(m.ensure_sqlite_wal(db, "NPM"))
+
+    def test_wal_switch_skips_missing_db(self):
+        """A fresh install (no DB file yet) is a clean skip, not an error."""
+        import tempfile
+        m = load_script("nginx")
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "database.sqlite")
+            self.assertFalse(m.ensure_sqlite_wal(missing, "NPM"))
+
+    def test_wal_switch_skips_invalid_db(self):
+        """A non-sqlite / torn file is rejected on the header check, never
+        opened-and-mutated (no stray -wal/-shm sidecars)."""
+        import tempfile
+        m = load_script("nginx")
+        with tempfile.TemporaryDirectory() as tmp:
+            junk = os.path.join(tmp, "database.sqlite")
+            with open(junk, "wb") as fh:
+                fh.write(b"not a sqlite db at all")
+            self.assertFalse(m.ensure_sqlite_wal(junk, "NPM"))
+            # No sidecar files were created beside the junk file.
+            self.assertFalse(os.path.exists(junk + "-wal"))
+            self.assertFalse(os.path.exists(junk + "-shm"))
+
+    def test_main_runs_wal_switch_on_the_resolved_db_path(self):
+        """main() calls ensure_sqlite_wal against the template-mounted DB path
+        ({DATA_DIR}/nginx-proxy-manager/data/database.sqlite) even with no admin
+        password — a returning install still gets the concurrency fix."""
+        import sqlite3
+        import tempfile
+        m = load_script("nginx")
+        with tempfile.TemporaryDirectory() as tmp:
+            dbdir = os.path.join(tmp, "nginx-proxy-manager", "data")
+            os.makedirs(dbdir, exist_ok=True)
+            db = os.path.join(dbdir, "database.sqlite")
+            # A real (header-bearing) DB — a bare connect()+close() leaves a
+            # zero-byte file with no sqlite header (header lands on first write).
+            c = sqlite3.connect(db)
+            c.execute("CREATE TABLE t (id INTEGER);")
+            c.commit()
+            c.close()
+            with run_with_env({"DATA_DIR": tmp}):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("NPM SQLite DB is in WAL mode", out)
+            with sqlite3.connect(db) as c:
+                self.assertEqual(c.execute("PRAGMA journal_mode;").fetchone()[0].lower(), "wal")
+
 
 class VaultwardenScript(unittest.TestCase):
     def test_sso_enabled_message(self):
@@ -319,6 +387,60 @@ class AuthScript(unittest.TestCase):
             rc, out = capture_main(m)
         self.assertEqual(rc, 0)
         self.assertIn("Could not fully seed LLDAP groups after 3 attempts", out)
+
+    def test_wal_switch_flips_authelia_db_and_is_idempotent(self):
+        """#1679: ensure_sqlite_wal flips Authelia's db.sqlite3 to WAL and a
+        repeat run stays WAL with no error (persisted header)."""
+        import sqlite3
+        import tempfile
+        m = load_script("auth")
+        with tempfile.TemporaryDirectory() as tmp:
+            db = os.path.join(tmp, "db.sqlite3")
+            conn = sqlite3.connect(db)
+            conn.execute("PRAGMA journal_mode=DELETE;")
+            conn.execute("CREATE TABLE t (id INTEGER);")
+            conn.commit()
+            conn.close()
+            self.assertTrue(m.ensure_sqlite_wal(db, "Authelia"))
+            with sqlite3.connect(db) as c:
+                self.assertEqual(c.execute("PRAGMA journal_mode;").fetchone()[0].lower(), "wal")
+            self.assertTrue(m.ensure_sqlite_wal(db, "Authelia"))
+
+    def test_wal_switch_guards_missing_and_invalid_db(self):
+        """Missing file → clean skip; non-sqlite file → header-rejected, never
+        mutated (no stray sidecars)."""
+        import tempfile
+        m = load_script("auth")
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(m.ensure_sqlite_wal(os.path.join(tmp, "db.sqlite3"), "Authelia"))
+            junk = os.path.join(tmp, "db.sqlite3")
+            with open(junk, "wb") as fh:
+                fh.write(b"garbage")
+            self.assertFalse(m.ensure_sqlite_wal(junk, "Authelia"))
+            self.assertFalse(os.path.exists(junk + "-wal"))
+
+    def test_main_runs_authelia_wal_switch(self):
+        """main() flips the template-mounted Authelia DB
+        ({DATA_DIR}/auth/authelia-data/db.sqlite3) — runs before the LLDAP env
+        gate so it fires even with no LLDAP password."""
+        import sqlite3
+        import tempfile
+        m = load_script("auth")
+        with tempfile.TemporaryDirectory() as tmp:
+            dbdir = os.path.join(tmp, "auth", "authelia-data")
+            os.makedirs(dbdir, exist_ok=True)
+            db = os.path.join(dbdir, "db.sqlite3")
+            c = sqlite3.connect(db)
+            c.execute("CREATE TABLE t (id INTEGER);")
+            c.commit()
+            c.close()
+            # No LLDAP_ADMIN_PASSWORD → main() returns early after the WAL step.
+            with run_with_env({"DATA_DIR": tmp}):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("Authelia SQLite DB is in WAL mode", out)
+            with sqlite3.connect(db) as c:
+                self.assertEqual(c.execute("PRAGMA journal_mode;").fetchone()[0].lower(), "wal")
 
     def test_smtp_notifier_disables_fatal_startup_check(self):
         """Authelia's notifier startup check is fatal on failure, so a

--- a/tools/sb/internal/phase/phase.go
+++ b/tools/sb/internal/phase/phase.go
@@ -20,6 +20,13 @@ const (
 type BoxStatus struct {
 	Reachable  bool
 	WizardDone bool
+	// Unauthorized is true when the box is reachable but rejected our saved
+	// credential with a 401 (#1669). A 401 means the box IS up and serving the
+	// real app behind auth — typically a stale token after a reinstall — so it
+	// must NOT be confused with "not set up yet". The launcher surfaces sign-in
+	// / token-mint and keeps Manage + stack-install reachable, rather than
+	// falling to the fresh-setup phase and forcing a needless USB rebuild.
+	Unauthorized bool
 }
 
 // State is the derived phase plus the raw facts it came from.
@@ -28,13 +35,26 @@ type State struct {
 	ISOBuilt     bool
 	BoxReachable bool
 	WizardDone   bool
+	// NeedsAuth mirrors BoxStatus.Unauthorized: the box is up and manageable but
+	// our credential is stale/absent, so the manage panels will route through
+	// sign-in. The menu uses it to frame the phase as "sign in" rather than
+	// "install running".
+	NeedsAuth bool
 }
 
 // Detect derives the lifecycle phase from the probed facts.
+//
+// Key distinction (#1669): a box that answers 401 is REACHABLE-but-unauthorized,
+// not unreachable and not unset-up. A stale saved token after a reinstall must
+// not drop the launcher to fresh-setup (which greys out Manage/stack-install and
+// forces a USB rebuild). So a reachable box whose wizard is done OR which only
+// rejected our token (Unauthorized) resolves to Ready (manage) — the manage
+// panels then prompt to sign in. Only a reachable box that is genuinely still
+// installing (splash serving, no 401) stays in Installing.
 func Detect(isoBuilt bool, status BoxStatus) State {
 	var p Lifecycle
 	switch {
-	case status.Reachable && status.WizardDone:
+	case status.Reachable && (status.WizardDone || status.Unauthorized):
 		p = Ready
 	case status.Reachable:
 		p = Installing
@@ -43,7 +63,7 @@ func Detect(isoBuilt bool, status BoxStatus) State {
 	default:
 		p = NoISO
 	}
-	return State{Phase: p, ISOBuilt: isoBuilt, BoxReachable: status.Reachable, WizardDone: status.WizardDone}
+	return State{Phase: p, ISOBuilt: isoBuilt, BoxReachable: status.Reachable, WizardDone: status.WizardDone, NeedsAuth: status.Unauthorized}
 }
 
 // ActionID identifies a menu entry. Handoff actions (build/watch) are run by
@@ -249,13 +269,20 @@ func Journey(s State) []JourneyRow {
 			{Action: quitAction},
 		}
 	case Ready:
+		// step-3 signpost: a plain "setup complete" when the wizard is confirmed
+		// done, or a "box is up — sign in" prompt when we only know the box is
+		// reachable because it rejected our token (#1669: reachable-but-unauthorized).
+		step3 := signpost("Install complete — setup wizard finished", "")
+		if s.NeedsAuth {
+			step3 = signpost("Box is up — sign in to manage it (your saved access expired)", "")
+		}
 		return []JourneyRow{
 			phaseHeader(1, h1, true, false),
 			{Action: uploadStep(s), Sub: true},
 			phaseHeader(2, h2, true, false),
 			{Action: buildAction(s), Sub: true},
 			phaseHeader(3, h3, true, false),
-			{Action: signpost("Install complete — setup wizard finished", ""), Sub: true, Done: true},
+			{Action: step3, Sub: true, Done: true},
 			phaseHeader(4, h4, false, false),
 			{Action: installStacksAction, Sub: true, Recommended: true},
 			{Action: editConfigAction, Sub: true},
@@ -292,6 +319,9 @@ func Describe(s State) string {
 	case Installing:
 		return "Box is reachable; an install is actively running."
 	case Ready:
+		if s.NeedsAuth {
+			return "Box is up and reachable — sign in to manage it below."
+		}
 		return "Box is up and reachable — manage it below."
 	default:
 		return ""

--- a/tools/sb/internal/phase/phase_test.go
+++ b/tools/sb/internal/phase/phase_test.go
@@ -1,6 +1,9 @@
 package phase
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func ids(actions []Action) []ActionID {
 	out := make([]ActionID, len(actions))
@@ -34,6 +37,11 @@ func TestDetect(t *testing.T) {
 		{"box up, wizard pending", true, BoxStatus{Reachable: true}, Installing},
 		{"box up, wizard done", true, BoxStatus{Reachable: true, WizardDone: true}, Ready},
 		{"box up wins over no-iso", false, BoxStatus{Reachable: true, WizardDone: true}, Ready},
+		// #1669: a reachable box that only rejected our token (401) is up and
+		// manageable — Ready, NOT fresh-setup — even with no ISO built. A stale
+		// token after a reinstall must not force a USB rebuild.
+		{"box up, stale token (401)", false, BoxStatus{Reachable: true, Unauthorized: true}, Ready},
+		{"box up, 401 wins over no-iso", false, BoxStatus{Reachable: true, Unauthorized: true}, Ready},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -41,6 +49,37 @@ func TestDetect(t *testing.T) {
 				t.Fatalf("Detect = %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+// TestReachableButUnauthorized is the #1669 acceptance: a reachable box with a
+// stale token (401) must surface as the manage phase with sign-in framing, NOT
+// fall to fresh-setup. Manage + stack-install stay selectable; the menu doesn't
+// push the operator to "build a USB".
+func TestReachableButUnauthorized(t *testing.T) {
+	s := Detect(false, BoxStatus{Reachable: true, Unauthorized: true})
+	if s.Phase != Ready {
+		t.Fatalf("401 box phase = %q, want Ready (manage, not fresh-setup)", s.Phase)
+	}
+	if !s.NeedsAuth {
+		t.Fatal("NeedsAuth should be set on a reachable-but-unauthorized box")
+	}
+	got := ids(ActionsFor(s))
+	hasInstall, hasConfig := false, false
+	for _, id := range got {
+		if id == InstallStacks {
+			hasInstall = true
+		}
+		if id == EditConfig {
+			hasConfig = true
+		}
+	}
+	if !hasInstall || !hasConfig {
+		t.Fatalf("manage actions must be reachable on a 401 box; got %v", got)
+	}
+	// The phase summary must prompt sign-in, not claim setup is done/incomplete.
+	if d := Describe(s); !strings.Contains(d, "sign in") {
+		t.Fatalf("Describe(401 box) = %q, want a sign-in prompt", d)
 	}
 }
 

--- a/tools/sb/internal/probes/probes.go
+++ b/tools/sb/internal/probes/probes.go
@@ -6,9 +6,11 @@ package probes
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sb/internal/build"
 	"sb/internal/phase"
@@ -119,6 +121,65 @@ func tokenPath(host string) string {
 	return filepath.Join(dir, "servicebay", safe+".token")
 }
 
+// authStatus is the outcome of an authenticated probe with the saved token.
+type authStatus int
+
+const (
+	authUnknown      authStatus = iota // couldn't tell (no token, transport error)
+	authOK                             // the box accepted our token (2xx)
+	authUnauthorized                   // the box answered 401 — token stale/expired (#1669)
+)
+
+// classifyBoxStatus folds the raw probe facts into a phase.BoxStatus. Pure, so
+// the reachable-but-unauthorized distinction (#1669) is unit-testable without a
+// live box: tcpOpen + appServing come from the unauthenticated probes, auth from
+// the token probe. A 401 from the box means it IS up (serving the real app
+// behind auth) — surfaced as Unauthorized, NOT as "not set up".
+func classifyBoxStatus(tcpOpen, appServing bool, auth authStatus) phase.BoxStatus {
+	if !tcpOpen {
+		return phase.BoxStatus{}
+	}
+	// The box answered 401 to an authenticated request: it's reachable and the
+	// real app is up, just rejecting our (stale) credential. Even if the
+	// unauthenticated title sniff didn't recognise takeover, a 401 is proof the
+	// app is serving — so the box is manageable, pending sign-in.
+	if auth == authUnauthorized {
+		return phase.BoxStatus{Reachable: true, WizardDone: appServing, Unauthorized: true}
+	}
+	return phase.BoxStatus{Reachable: true, WizardDone: appServing}
+}
+
+// probeAuth issues a lightweight authenticated GET with the saved token and
+// classifies the result. /api/settings is read-scoped and cheap. A 401 → stale
+// token (authUnauthorized); a 2xx → authOK; anything else (no token, transport
+// error, 5xx) → authUnknown, so a flaky box never spuriously flips the phase.
+func probeAuth(host, port string) authStatus {
+	token := ResolveToken(host)
+	if token == "" {
+		return authUnknown
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+host+":"+port+"/api/settings", nil)
+	if err != nil {
+		return authUnknown
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return authUnknown
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return authUnauthorized
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return authOK
+	default:
+		return authUnknown
+	}
+}
+
 // BoxStatus classifies the box by what it's actually serving, not by a job
 // record. WizardDone ("up and manageable") keys off whether the REAL app is
 // serving — the same takeover signal the watch dashboard uses — rather than
@@ -128,6 +189,12 @@ func tokenPath(host string) string {
 //   - port closed            → not reachable (pre-boot / rebooting)
 //   - install splash serving → reachable, not done → Installing (watch leads)
 //   - real app serving       → reachable + done   → Ready (manage)
+//   - box answers 401        → reachable + Unauthorized → Ready, prompt sign-in (#1669)
+//
+// A stale saved token after a reinstall used to read as "box not set up"
+// (every authed call 401s → the launcher fell to fresh-setup and greyed out
+// Manage/stack-install, forcing a needless USB rebuild). The auth probe now
+// catches the 401 and keeps the box manageable, pending sign-in.
 func BoxStatus(_ context.Context) phase.BoxStatus {
 	t := ResolveTarget()
 	if t.Host == "" {
@@ -136,5 +203,5 @@ func BoxStatus(_ context.Context) phase.BoxStatus {
 	if !watch.TCPOpen(t.Host, t.Port) {
 		return phase.BoxStatus{}
 	}
-	return phase.BoxStatus{Reachable: true, WizardDone: watch.AppServing(t.Host, t.Port)}
+	return classifyBoxStatus(true, watch.AppServing(t.Host, t.Port), probeAuth(t.Host, t.Port))
 }

--- a/tools/sb/internal/probes/probes_test.go
+++ b/tools/sb/internal/probes/probes_test.go
@@ -2,6 +2,37 @@ package probes
 
 import "testing"
 
+// TestClassifyBoxStatus covers the #1669 fold: a 401 means reachable-but-stale
+// (Unauthorized), never "not set up". A closed port stays unreachable; an OK or
+// unknown auth result doesn't set Unauthorized.
+func TestClassifyBoxStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		tcpOpen    bool
+		appServing bool
+		auth       authStatus
+		wantReach  bool
+		wantDone   bool
+		wantUnauth bool
+	}{
+		{"port closed", false, false, authUnknown, false, false, false},
+		{"port closed ignores 401", false, false, authUnauthorized, false, false, false},
+		{"installing splash, no token", true, false, authUnknown, true, false, false},
+		{"real app serving, token ok", true, true, authOK, true, true, false},
+		{"stale token 401, app sniff missed takeover", true, false, authUnauthorized, true, false, true},
+		{"stale token 401 but app also serving", true, true, authUnauthorized, true, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyBoxStatus(c.tcpOpen, c.appServing, c.auth)
+			if got.Reachable != c.wantReach || got.WizardDone != c.wantDone || got.Unauthorized != c.wantUnauth {
+				t.Fatalf("classifyBoxStatus = %+v, want reach=%v done=%v unauth=%v",
+					got, c.wantReach, c.wantDone, c.wantUnauth)
+			}
+		})
+	}
+}
+
 // TestTokenRoundTripAndDelete: SaveToken persists a per-host token that
 // ResolveToken reads back, and DeleteToken removes it so ResolveToken then
 // returns "" (the no-token path that re-triggers sign-in). #1502.


### PR DESCRIPTION
## What
Five units of reinstall/monitoring-trust fixes:
- **box-dns-domain-resolves** (#1672/#1675): post-install step re-points the box's own resolver at AdGuard (127.0.0.1 + FritzBox fallback, no public 8.8.8.8); `router_dns_not_pointing`/`domain_resolves_to_box` verify the effective LAN/DHCP-DNS path instead of a public resolver or bare TR-064 read; TR-064 write failures surface the SOAP fault and treat unsupported-SetDNSServers models with manual DNS as success.
- **monitoring-false-red** (#1670/#1671, gate=verify): system-created checks for known-local hostNetwork services (HA 127.0.0.1:8123, Ollama :11434) bypass the SSRF guard so they stop false-redding; synthetic `diagnose:<probeId>` rows surface the same history + a current last-checked as the historied self-diagnose row.
- **sb-launcher-boot** (#1669/#1674): the Go launcher distinguishes unreachable from reachable-but-unauthorized (401) and prompts to authenticate instead of "build a USB", keeping Manage + stack-install reachable; `usb-next` maps/creates a direct UEFI boot entry to the real FCoS installer device and warns on empty-slot fallback.
- **sqlite-wal-busytimeout** (#1679): WAL journal mode + ~30s busy_timeout on Authelia and NPM SQLite DBs at install; config-survival backup captures the -wal/-shm sidecars.
- **nginx-config-valid-check** (#1678): new `nginx_config_valid` health probe runs `nginx -t` in the NPM container (~5min), reds on exit!=0 surfacing the [emerg] line + offending proxy-host config.

## Why
Closes #1672
Closes #1675
Closes #1670
Closes #1671
Closes #1669
Closes #1674
Closes #1679
Closes #1678

## Risk
medium — touches install/template + health probes + the Go launcher; per-unit and full suites green, real-box DNS/boot/load proof deferred.

## Rollback
git revert is enough (each unit is an atomic commit).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2086 passed)
- [ ] go test ./... under tools/sb (runs in CI; phase.go/probes.go changed)
- [ ] /verify on FCoS :dev box (verify-gated #1670/#1671 + path-mandated install/template/health/usb-next; real reinstall/load proof REINSTALL-OWED)

AI-generated. <!-- sb-ai-comment -->