### PR TITLE
fix: forward-auth 403 explainer, orphan-container reconcile, Claude Dev card, DNS-resolvers health UI

### DIFF
--- a/packages/backend/src/lib/agent/types.ts
+++ b/packages/backend/src/lib/agent/types.ts
@@ -29,6 +29,15 @@ export interface SystemResources {
     family: string; // IPv4 or IPv6
     internal: boolean;
   }[]>;
+  /** The box's effective DNS resolvers, read from `resolvectl status`
+   *  (preferred) or `/etc/resolv.conf`. Raw IP list only — the System
+   *  health Networks section labels each (AdGuard / router / public) and
+   *  warns when a public resolver is present (the #1559 split-horizon
+   *  trap). `source` records which file the list came from. */
+  dnsResolvers?: {
+    servers: string[];
+    source: 'resolvectl' | 'resolv.conf' | 'unknown';
+  };
   /** GPUs detected on the host. Empty / undefined on hosts without
    *  one. Memory fields are in bytes (consistent with disks). For now
    *  populated by nvidia-smi only; other vendors can hang off the

--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -150,6 +150,9 @@ class SystemResources:
     os: Optional[Dict[str, Any]] = None
     network: Optional[Dict[str, Any]] = None
     disks: Optional[List[Dict[str, Any]]] = None
+    # Effective DNS resolvers: {'servers': [...ip...], 'source': 'resolvectl'|'resolv.conf'|'unknown'}.
+    # Raw list only — labelling/public-resolver warning happens frontend-side.
+    dnsResolvers: Optional[Dict[str, Any]] = None
     cpu: Optional[Dict[str, Any]] = None
     # GPUs detected via `nvidia-smi --query-gpu=...` when present. Empty
     # list on hosts without NVIDIA (or without the kernel module loaded).
@@ -1527,6 +1530,94 @@ def get_network_interfaces():
     except Exception:
         return {}
 
+def parse_resolvectl_servers(text):
+    """Extract DNS resolver IPs from `resolvectl status` output.
+
+    resolvectl prints both global and per-link 'DNS Servers:' lines, e.g.
+
+        Global
+               DNS Servers: 127.0.0.1
+        Link 2 (eth0)
+               DNS Servers: 192.168.178.1 8.8.8.8
+
+    A 'DNS Servers:' line may be followed by continuation lines (indented,
+    no label) carrying further addresses. We collect every address in
+    first-seen order, de-duplicated. Pure string parsing so it is unit
+    testable without a live systemd-resolved.
+    """
+    servers = []
+    seen = set()
+    collecting = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if 'DNS Servers:' in line:
+            collecting = True
+            line = line.split('DNS Servers:', 1)[1].strip()
+        elif collecting:
+            # Continuation lines are indented and carry only addresses; any
+            # line that introduces a new labelled field ends the run.
+            if not raw.startswith((' ', '\t')) or ':' in line:
+                collecting = False
+                continue
+        else:
+            continue
+        for token in line.split():
+            # Drop systemd's interface-scope suffix (fe80::1%eth0) for labelling.
+            addr = token.split('%', 1)[0]
+            if addr and addr not in seen:
+                seen.add(addr)
+                servers.append(addr)
+    return servers
+
+
+def parse_resolv_conf(text):
+    """Extract nameserver IPs from /etc/resolv.conf content, in order."""
+    servers = []
+    seen = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith('#') or line.startswith(';'):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == 'nameserver':
+            addr = parts[1].split('%', 1)[0]
+            if addr and addr not in seen:
+                seen.add(addr)
+                servers.append(addr)
+    return servers
+
+
+def get_dns_resolvers():
+    """Read the box's effective DNS resolvers.
+
+    Prefers `resolvectl status` (systemd-resolved, the source of truth on
+    Fedora CoreOS) and falls back to /etc/resolv.conf. Routed through the
+    executor so a containerised agent reads the HOST's resolvers (the
+    container's own resolv.conf is irrelevant — #1559 is a host-side
+    split-horizon trap). Labelling/warning is done frontend-side so it is
+    fast-gate (vitest) testable; the agent only reports the raw list.
+    """
+    try:
+        stdout, _, code = _executor.execute(['resolvectl', 'status'], check=False)
+        if code == 0 and stdout.strip():
+            servers = parse_resolvectl_servers(stdout)
+            if servers:
+                return {'servers': servers, 'source': 'resolvectl'}
+    except Exception:
+        pass
+
+    try:
+        stdout, _, code = _executor.execute(['cat', '/etc/resolv.conf'], check=False)
+        if code == 0 and stdout.strip():
+            servers = parse_resolv_conf(stdout)
+            if servers:
+                return {'servers': servers, 'source': 'resolv.conf'}
+    except Exception:
+        pass
+
+    return {'servers': [], 'source': 'unknown'}
+
+
 def get_sys_resources():
     # 1. Memory
     res_mem_total = 0
@@ -1620,7 +1711,12 @@ def get_sys_resources():
     
     # 6. Network
     network_info = get_network_interfaces()
-    
+
+    # 7. DNS resolvers — the box's effective resolver list. Surfaced in the
+    # System health Networks section so a public-resolver fallback (the #1559
+    # split-horizon trap) is visible.
+    dns_resolvers = get_dns_resolvers()
+
     # Use dataclass and return dict
     return asdict(SystemResources(
         cpuUsage=res_cpu_usage,
@@ -1630,6 +1726,7 @@ def get_sys_resources():
         os=os_info,
         disks=disks,
         network=network_info,
+        dnsResolvers=dns_resolvers,
         cpu=res_cpu_info,
         gpus=get_gpus(),
     ))

--- a/packages/backend/src/lib/agent/v4/tests/test_agent.py
+++ b/packages/backend/src/lib/agent/v4/tests/test_agent.py
@@ -229,5 +229,76 @@ class TestAgent(unittest.TestCase):
         finally:
             agent.DEBUG_MODE = original_debug
 
+class TestDnsResolvers(unittest.TestCase):
+    """#1676 — read the box's effective DNS resolvers for the System health
+    Networks section. The agent reports the raw IP list; labelling + the
+    public-resolver warning live frontend-side."""
+
+    def test_parse_resolvectl_global_and_link(self):
+        text = (
+            "Global\n"
+            "         Protocols: -LLMNR\n"
+            "       DNS Servers: 127.0.0.1\n"
+            "Link 2 (eth0)\n"
+            "    Current Scopes: DNS\n"
+            "       DNS Servers: 192.168.178.1 8.8.8.8\n"
+        )
+        self.assertEqual(
+            agent.parse_resolvectl_servers(text),
+            ['127.0.0.1', '192.168.178.1', '8.8.8.8'],
+        )
+
+    def test_parse_resolvectl_continuation_and_dedupe(self):
+        text = (
+            "       DNS Servers: 192.168.178.1\n"
+            "                    8.8.8.8\n"
+            "                    192.168.178.1\n"  # dup, dropped
+            "    Fallback DNS Servers: 1.1.1.1\n"  # a labelled line, not a continuation
+        )
+        servers = agent.parse_resolvectl_servers(text)
+        self.assertEqual(servers[0], '192.168.178.1')
+        self.assertIn('8.8.8.8', servers)
+        # 192.168.178.1 appears once only
+        self.assertEqual(servers.count('192.168.178.1'), 1)
+
+    def test_parse_resolvectl_strips_iface_scope(self):
+        self.assertEqual(
+            agent.parse_resolvectl_servers('       DNS Servers: fe80::1%eth0\n'),
+            ['fe80::1'],
+        )
+
+    def test_parse_resolv_conf(self):
+        text = (
+            "# generated\n"
+            "; comment\n"
+            "nameserver 192.168.178.1\n"
+            "nameserver 8.8.8.8\n"
+            "search lan\n"
+        )
+        self.assertEqual(agent.parse_resolv_conf(text), ['192.168.178.1', '8.8.8.8'])
+
+    def test_get_dns_resolvers_prefers_resolvectl(self):
+        with patch.object(agent, '_executor') as mock_exec:
+            mock_exec.execute.return_value = ('       DNS Servers: 127.0.0.1\n', '', 0)
+            result = agent.get_dns_resolvers()
+        self.assertEqual(result, {'servers': ['127.0.0.1'], 'source': 'resolvectl'})
+
+    def test_get_dns_resolvers_falls_back_to_resolv_conf(self):
+        def fake_execute(cmd, check=True):
+            if cmd[0] == 'resolvectl':
+                return ('', 'not found', 1)
+            return ('nameserver 192.168.178.1\n', '', 0)
+        with patch.object(agent, '_executor') as mock_exec:
+            mock_exec.execute.side_effect = fake_execute
+            result = agent.get_dns_resolvers()
+        self.assertEqual(result, {'servers': ['192.168.178.1'], 'source': 'resolv.conf'})
+
+    def test_get_dns_resolvers_unknown_when_nothing_readable(self):
+        with patch.object(agent, '_executor') as mock_exec:
+            mock_exec.execute.return_value = ('', 'err', 1)
+            result = agent.get_dns_resolvers()
+        self.assertEqual(result, {'servers': [], 'source': 'unknown'})
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/packages/backend/src/lib/install/reconcileOrphanContainers.test.ts
+++ b/packages/backend/src/lib/install/reconcileOrphanContainers.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Orphan-container reconcile (#1668).
+ *
+ * Covers the reconcile filter's strict orphan predicate:
+ *  - a record whose managing unit is GONE + not running  → reconciled (rm);
+ *  - a record whose managing unit is PRESENT             → KEPT;
+ *  - a RUNNING record (incl. a hermes-style managed pod) → KEPT;
+ *  - a record with no PODMAN_SYSTEMD_UNIT label          → KEPT.
+ *
+ * Plus the end-to-end reconcile pass against a mocked podman DB / executor.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetPodmanPs, mockExecutor, mockGetExecutor } = vi.hoisted(() => ({
+  mockGetPodmanPs: vi.fn(),
+  mockExecutor: {
+    exec: vi.fn(),
+    execArgv: vi.fn(),
+  },
+  mockGetExecutor: vi.fn(),
+}));
+
+vi.mock('@/lib/manager', () => ({ getPodmanPs: (...a: unknown[]) => mockGetPodmanPs(...a) }));
+vi.mock('@/lib/executor', () => ({ getExecutor: (...a: unknown[]) => mockGetExecutor(...a) }));
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import type { ContainerRecord } from './reconcileOrphanContainers';
+
+const {
+  isOrphanedContainerRecord,
+  containerDisplayName,
+  reconcileOrphanContainers,
+} = await import('./reconcileOrphanContainers');
+
+beforeEach(() => {
+  mockGetExecutor.mockReturnValue(mockExecutor);
+  mockExecutor.execArgv.mockReset();
+  mockGetPodmanPs.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- The pure orphan predicate (the reconcile filter) ---
+describe('isOrphanedContainerRecord', () => {
+  const ghost = {
+    Id: 'abc123def456',
+    Names: ['/hermes-hermes'],
+    State: 'exited',
+    Labels: { PODMAN_SYSTEMD_UNIT: 'hermes.service' },
+  };
+
+  it('reconciles a record whose unit is GONE and is exited', () => {
+    // unit absent (managingUnitExists=false) + exited → orphan
+    expect(isOrphanedContainerRecord(ghost, false)).toBe(true);
+  });
+
+  it('KEEPS a record whose managing unit is PRESENT', () => {
+    // current hermes-style managed container: unit file present → keep
+    expect(isOrphanedContainerRecord(ghost, true)).toBe(false);
+  });
+
+  it('KEEPS a RUNNING container even if the unit probe says gone', () => {
+    // never remove a running container — the CURRENT hermes must survive
+    const runningHermes = { ...ghost, State: 'running' };
+    expect(isOrphanedContainerRecord(runningHermes, false)).toBe(false);
+  });
+
+  it('KEEPS a record with no PODMAN_SYSTEMD_UNIT label (ad-hoc container)', () => {
+    const adhoc = { Id: 'x', Names: ['/my-adhoc'], State: 'exited', Labels: {} };
+    expect(isOrphanedContainerRecord(adhoc, false)).toBe(false);
+  });
+
+  it('treats unknown/transient states conservatively as running (keep)', () => {
+    const stopping = { ...ghost, State: 'stopping' };
+    expect(isOrphanedContainerRecord(stopping, false)).toBe(false);
+  });
+
+  it.each(['exited', 'stopped', 'created', 'dead'])(
+    'reconciles a dead-state (%s) record whose unit is gone',
+    state => {
+      expect(isOrphanedContainerRecord({ ...ghost, State: state }, false)).toBe(true);
+    },
+  );
+});
+
+describe('containerDisplayName', () => {
+  it('strips the leading slash off the first name', () => {
+    expect(containerDisplayName({ Id: 'deadbeefcafe00', Names: ['/hermes-hermes'] })).toBe('hermes-hermes');
+  });
+  it('falls back to a short id when unnamed', () => {
+    expect(containerDisplayName({ Id: 'deadbeefcafe0011' })).toBe('deadbeefcafe');
+  });
+});
+
+// --- The end-to-end reconcile pass ---
+describe('reconcileOrphanContainers', () => {
+  function systemctlShow(loadState: string, fragmentPath: string) {
+    return { stdout: `LoadState=${loadState}\nFragmentPath=${fragmentPath}\n`, stderr: '' };
+  }
+
+  it('removes the exited ghost whose unit is gone, keeps the running one', async () => {
+    const records: ContainerRecord[] = [
+      // ghost: exited, unit gone
+      { Id: 'ghost1', Names: ['/hermes-hermes'], State: 'exited', Labels: { PODMAN_SYSTEMD_UNIT: 'hermes.service' } },
+      // current hermes: running, unit present — must survive
+      { Id: 'live1', Names: ['/hermes-hermes-new'], State: 'running', Labels: { PODMAN_SYSTEMD_UNIT: 'hermes.service' } },
+    ];
+    mockGetPodmanPs.mockResolvedValue(records);
+    mockExecutor.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'systemctl') return systemctlShow('not-found', '');
+      if (argv[0] === 'podman' && argv[1] === 'rm') return { stdout: '', stderr: '' };
+      throw new Error(`unexpected execArgv: ${argv.join(' ')}`);
+    });
+
+    const result = await reconcileOrphanContainers();
+
+    expect(result.removed).toEqual(['hermes-hermes']);
+    expect(result.failed).toEqual([]);
+    // only the exited record is even inspected (running is skipped)
+    expect(result.inspected).toBe(1);
+    // podman rm called exactly once, on the ghost id
+    const rmCalls = mockExecutor.execArgv.mock.calls.filter(c => c[0][0] === 'podman');
+    expect(rmCalls).toHaveLength(1);
+    expect(rmCalls[0][0]).toEqual(['podman', 'rm', '-f', 'ghost1']);
+  });
+
+  it('keeps an exited record whose managing unit IS still present', async () => {
+    mockGetPodmanPs.mockResolvedValue([
+      { Id: 'kept1', Names: ['/immich-server'], State: 'exited', Labels: { PODMAN_SYSTEMD_UNIT: 'immich.service' } },
+    ]);
+    mockExecutor.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'systemctl') {
+        return systemctlShow('loaded', '/home/core/.config/containers/systemd/immich.service');
+      }
+      throw new Error(`unexpected execArgv: ${argv.join(' ')}`);
+    });
+
+    const result = await reconcileOrphanContainers();
+
+    expect(result.removed).toEqual([]);
+    expect(result.inspected).toBe(1);
+    // no podman rm issued
+    expect(mockExecutor.execArgv.mock.calls.some(c => c[0][0] === 'podman')).toBe(false);
+  });
+
+  it('fails SAFE: keeps the container when the unit probe errors', async () => {
+    mockGetPodmanPs.mockResolvedValue([
+      { Id: 'maybe1', Names: ['/mystery'], State: 'exited', Labels: { PODMAN_SYSTEMD_UNIT: 'mystery.service' } },
+    ]);
+    mockExecutor.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'systemctl') throw new Error('dbus unavailable');
+      throw new Error(`unexpected execArgv: ${argv.join(' ')}`);
+    });
+
+    const result = await reconcileOrphanContainers();
+
+    expect(result.removed).toEqual([]);
+    expect(mockExecutor.execArgv.mock.calls.some(c => c[0][0] === 'podman')).toBe(false);
+  });
+
+  it('records a removal failure without throwing', async () => {
+    mockGetPodmanPs.mockResolvedValue([
+      { Id: 'ghost2', Names: ['/old-stack'], State: 'exited', Labels: { PODMAN_SYSTEMD_UNIT: 'old.service' } },
+    ]);
+    mockExecutor.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'systemctl') return systemctlShow('not-found', '');
+      if (argv[0] === 'podman') throw new Error('container in use');
+      throw new Error(`unexpected execArgv: ${argv.join(' ')}`);
+    });
+
+    const result = await reconcileOrphanContainers();
+
+    expect(result.removed).toEqual([]);
+    expect(result.failed).toEqual([{ name: 'old-stack', error: 'container in use' }]);
+  });
+
+  it('returns empty when podman ps fails (no throw)', async () => {
+    mockGetPodmanPs.mockRejectedValue(new Error('podman down'));
+    const result = await reconcileOrphanContainers();
+    expect(result).toEqual({ removed: [], failed: [], inspected: 0 });
+  });
+});

--- a/packages/backend/src/lib/install/reconcileOrphanContainers.ts
+++ b/packages/backend/src/lib/install/reconcileOrphanContainers.ts
@@ -1,0 +1,171 @@
+/**
+ * Orphan-container reconcile (#1668).
+ *
+ * podman's container DB lives on the preserved RAID
+ * (`/mnt/data/containers/storage`) and survives an OS-disk reinstall, but
+ * the quadlet *units* that managed those containers do not. After a
+ * wipe-and-reinstall the DB can therefore hold stale container records
+ * whose managing `PODMAN_SYSTEMD_UNIT` no longer exists on disk — they
+ * surface in the UI as ghost "Unmanaged Bundle" pods (e.g. an exited
+ * `hermes-hermes` labelled `PODMAN_SYSTEMD_UNIT=hermes.service` where that
+ * unit is gone).
+ *
+ * This module reconciles podman's preserved DB against the present quadlet
+ * units: it `podman rm`s ONLY genuinely-orphaned records.
+ *
+ * CRITICAL GUARDRAIL — the orphan predicate is strict. A record is only an
+ * orphan when ALL of:
+ *   1. it carries a `PODMAN_SYSTEMD_UNIT` label, AND
+ *   2. that managing unit file is ABSENT on disk (a ghost of a prior
+ *      install — `systemctl --user show -p LoadState` reports
+ *      `not-found` / empty `FragmentPath`), AND
+ *   3. the container is NOT running.
+ *
+ * A running container, or one whose managing quadlet/unit IS present, is
+ * NEVER reconciled — that includes the CURRENT, kept hermes/OSCAR service
+ * (running, with its quadlet present). Only the stale `Exited(0)` ghost of
+ * an old install whose unit is gone is removed.
+ *
+ * This is invoked on an explicit reinstall/startup reconcile pass, not as
+ * an aggressive auto-`rm` at arbitrary moments.
+ */
+
+import { getPodmanPs } from '@/lib/manager';
+import { getExecutor } from '@/lib/executor';
+import type { PodmanConnection } from '@/lib/nodes';
+import { logger } from '@/lib/logger';
+
+/** Minimal shape of a `podman ps -a --format json` record we reason about. */
+export interface ContainerRecord {
+  Id: string;
+  Names?: string[];
+  /** podman container state, e.g. `running`, `exited`, `created`. */
+  State?: string;
+  Labels?: Record<string, string> | null;
+}
+
+/** First non-empty container name (with leading `/` stripped), else the id. */
+export function containerDisplayName(record: ContainerRecord): string {
+  const name = (record.Names || [])
+    .map(n => (typeof n === 'string' ? n.replace(/^\//, '') : ''))
+    .find(n => n.length > 0);
+  return name || record.Id.substring(0, 12);
+}
+
+/**
+ * Strict orphan predicate. Returns true only for a genuinely-orphaned
+ * record: it has a managing systemd unit label, that unit's file is ABSENT,
+ * and the container is not running.
+ *
+ * @param record           the podman container record.
+ * @param managingUnitExists whether the unit named by the record's
+ *                           `PODMAN_SYSTEMD_UNIT` label currently exists on
+ *                           disk. Callers resolve this via systemd.
+ */
+export function isOrphanedContainerRecord(
+  record: ContainerRecord,
+  managingUnitExists: boolean,
+): boolean {
+  const unit = record.Labels?.['PODMAN_SYSTEMD_UNIT'];
+  // (1) must be a systemd-managed record — no label means it's an
+  //     ad-hoc container we don't own; never reconcile.
+  if (!unit) return false;
+  // (3) never touch a running container.
+  if (isRunningState(record.State)) return false;
+  // (2) only orphaned when its managing unit is gone.
+  return !managingUnitExists;
+}
+
+function isRunningState(state: string | undefined): boolean {
+  if (!state) return false;
+  const normalized = state.toLowerCase();
+  // `running` and the transient `stopping` both mean a live container; be
+  // conservative and treat anything that isn't a clearly-dead state as
+  // running so we never remove an in-flight container.
+  return normalized !== 'exited'
+    && normalized !== 'stopped'
+    && normalized !== 'created'
+    && normalized !== 'configured'
+    && normalized !== 'dead';
+}
+
+/**
+ * Resolve whether a `*.service` unit currently exists on disk by asking
+ * systemd. A unit that has no fragment and loads as `not-found` is gone.
+ */
+async function unitFileExists(
+  unit: string,
+  executor: ReturnType<typeof getExecutor>,
+): Promise<boolean> {
+  try {
+    const { stdout } = await executor.execArgv([
+      'systemctl', '--user', 'show', '-p', 'LoadState', '-p', 'FragmentPath', unit,
+    ]);
+    const loadState = /^LoadState=(.*)$/m.exec(stdout)?.[1]?.trim() ?? '';
+    const fragmentPath = /^FragmentPath=(.*)$/m.exec(stdout)?.[1]?.trim() ?? '';
+    if (loadState === 'not-found' || loadState === 'masked') return false;
+    // A loaded unit has a FragmentPath; a ghost reports loaded=='' and no
+    // fragment. Require a fragment path to consider the unit present.
+    return fragmentPath.length > 0;
+  } catch (e) {
+    // If we can't determine the unit state, fail SAFE: treat the unit as
+    // present so we never remove a container we're unsure about.
+    logger.warn('reconcileOrphans', `unit existence probe failed for ${unit}: ${e instanceof Error ? e.message : String(e)}`);
+    return true;
+  }
+}
+
+export interface ReconcileOrphanResult {
+  /** Container names removed because their managing unit was gone. */
+  removed: string[];
+  /** Container names that were orphans but failed to remove. */
+  failed: { name: string; error: string }[];
+  /** Total candidate records inspected (labelled + not running). */
+  inspected: number;
+}
+
+/**
+ * Reconcile podman's preserved container DB against the present quadlet
+ * units. `podman rm`s only genuinely-orphaned records (see
+ * {@link isOrphanedContainerRecord}). Best-effort: a probe/removal failure
+ * never throws.
+ */
+export async function reconcileOrphanContainers(
+  connection?: PodmanConnection,
+): Promise<ReconcileOrphanResult> {
+  const executor = getExecutor(connection);
+  const removed: string[] = [];
+  const failed: { name: string; error: string }[] = [];
+  let inspected = 0;
+
+  let containers: ContainerRecord[] = [];
+  try {
+    containers = (await getPodmanPs(connection)) as ContainerRecord[];
+  } catch (e) {
+    logger.warn('reconcileOrphans', `podman ps failed, nothing to reconcile: ${e instanceof Error ? e.message : String(e)}`);
+    return { removed, failed, inspected };
+  }
+
+  for (const record of containers) {
+    const unit = record.Labels?.['PODMAN_SYSTEMD_UNIT'];
+    // Only labelled, non-running records are even candidates — skip the
+    // unit-existence probe for everything else (cheap + safe).
+    if (!unit || isRunningState(record.State)) continue;
+    inspected += 1;
+
+    const exists = await unitFileExists(unit, executor);
+    if (!isOrphanedContainerRecord(record, exists)) continue;
+
+    const name = containerDisplayName(record);
+    try {
+      await executor.execArgv(['podman', 'rm', '-f', record.Id]);
+      removed.push(name);
+      logger.info('reconcileOrphans', `Removed orphan container ${name} (managing unit ${unit} is gone).`);
+    } catch (e) {
+      failed.push({ name, error: e instanceof Error ? e.message : String(e) });
+      logger.warn('reconcileOrphans', `Failed to remove orphan container ${name}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return { removed, failed, inspected };
+}

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -753,6 +753,32 @@ async function runJob(jobId: string): Promise<void> {
     await log(jobId, `⚠️ LAN IP capture failed: ${e instanceof Error ? e.message : String(e)}`);
   }
 
+  // #1668 — reconcile orphan container records from podman's preserved DB.
+  //
+  // podman's container DB lives on the preserved RAID and survives an
+  // OS-disk reinstall, but the quadlet units that managed those containers
+  // do not. After a wipe-and-reinstall the DB can hold stale records whose
+  // managing `PODMAN_SYSTEMD_UNIT` no longer exists on disk — they surface
+  // as ghost "Unmanaged Bundle" pods (e.g. an exited `hermes-hermes`
+  // labelled `PODMAN_SYSTEMD_UNIT=hermes.service` where that unit is gone).
+  //
+  // The reconcile is STRICT: it removes only records that are labelled +
+  // not running + whose managing unit file is absent. The CURRENT running
+  // hermes/OSCAR service (running, quadlet present) is never touched.
+  // Best-effort — a failure here must not block the install.
+  try {
+    const { reconcileOrphanContainers } = await import('./reconcileOrphanContainers');
+    const result = await reconcileOrphanContainers(undefined);
+    if (result.removed.length > 0) {
+      await log(jobId, `Reconciled ${result.removed.length} orphan container record(s) from preserved storage: ${result.removed.join(', ')}`);
+    }
+    if (result.failed.length > 0) {
+      await log(jobId, `⚠️ ${result.failed.length} orphan container(s) could not be removed: ${result.failed.map(f => f.name).join(', ')}`);
+    }
+  } catch (e) {
+    await log(jobId, `(note) orphan-container reconcile skipped: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
   const checked = input.items.filter(i => i.checked);
   if (checked.length === 0) {
     await log(jobId, '⚠️ No services selected to install — aborting.');

--- a/packages/backend/src/lib/portal/buildPortalCards.test.ts
+++ b/packages/backend/src/lib/portal/buildPortalCards.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/lib/templateTier', () => ({ parseTemplateTier: () => 'app' }));
 vi.mock('@/lib/templateLabel', () => ({ parseTemplateLabel: () => 'Immich' }));
 vi.mock('./userGuide', () => ({
   parseUserGuide: () => ({ frontmatter: {}, body: 'body' }),
+  DEFAULT_PORTAL_CATEGORY: 'System',
 }));
 
 // fs reads: template.yml (any non-null string) + variables.json (a subdomain var).

--- a/packages/backend/src/lib/portal/claudeDevCard.test.ts
+++ b/packages/backend/src/lib/portal/claudeDevCard.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Integration coverage for the #1682 fixes on the claude-dev appless card:
+ *  - the card carries its declared `category` ("Development"), falling back
+ *    to "System" when the guide declares none;
+ *  - the `external_scheme` VS Code action's `HOST:PORT` placeholder is
+ *    interpolated with the box's real LAN IP + the resolved
+ *    CLAUDE_DEV_SSH_PORT, so no literal `HOST`/`PORT` token survives.
+ *
+ * Unlike buildPortalCards.test.ts this does NOT mock ./userGuide — it runs
+ * the real frontmatter parser so the category + action plumbing is exercised
+ * end to end.
+ */
+
+const listServices = vi.fn();
+const getServices = vi.fn();
+const getLastResult = vi.fn();
+const configState: { config: Record<string, unknown> } = { config: {} };
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => configState.config),
+}));
+vi.mock('@/lib/mode', () => ({
+  getActiveDomain: () => 'home.arpa',
+  getMode: () => 'lan',
+}));
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: (node?: string) => listServices(node) },
+}));
+vi.mock('@/lib/store/repository', () => ({
+  getServices: (node?: string) => getServices(node),
+}));
+vi.mock('@/lib/health/store', () => ({
+  HealthStore: { getLastResult: (id: string) => getLastResult(id) },
+}));
+vi.mock('@/lib/templateTier', () => ({ parseTemplateTier: () => 'app' }));
+vi.mock('@/lib/templateLabel', () => ({ parseTemplateLabel: () => 'Claude Dev' }));
+
+const CLAUDE_DEV_GUIDE = `---
+lucide_icon: "bot"
+category: "Development"
+tagline: "A dev box."
+primary_action:
+  type: "in_app"
+  label: "Open terminal"
+  href: "/terminal?node=Local&container=claude-dev-claude-dev&attach=claude"
+  icon: "bot"
+actions:
+  - type: "external_scheme"
+    label: "Open in VS Code (desktop)"
+    href: "vscode://vscode-remote/ssh-remote+dev@HOST:PORT/workspace"
+    icon: "package"
+---
+body
+`;
+
+vi.mock('@/lib/registry', () => ({
+  getTemplateUserGuide: vi.fn(async () => CLAUDE_DEV_GUIDE),
+}));
+
+// claude-dev has no subdomain var; its variables.json carries CLAUDE_DEV_SSH_PORT.
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: vi.fn(async (p: string) => {
+      if (p.endsWith('variables.json')) {
+        return JSON.stringify({
+          CLAUDE_DEV_SSH_PORT: { type: 'text', default: '2222' },
+        });
+      }
+      return 'apiVersion: v1\n'; // template.yml
+    }),
+  },
+}));
+
+import { buildPortalCards, interpolateActionHref } from './services';
+import type { PortalAction } from './userGuide';
+
+const svc = (name: string, active: boolean) => ({
+  name,
+  active,
+  kubeFile: '',
+  kubePath: '',
+  yamlFile: null,
+  yamlPath: null,
+  status: active ? 'active' : 'inactive',
+  ports: [],
+  volumes: [],
+  labels: {},
+});
+
+describe('claude-dev portal card (#1682)', () => {
+  beforeEach(() => {
+    listServices.mockReset().mockResolvedValue([svc('claude-dev', true)]);
+    getServices.mockReset().mockReturnValue([]);
+    getLastResult.mockReset().mockReturnValue(null);
+    configState.config = { reverseProxy: { hosts: [] }, templateSettings: {}, lanIp: '192.168.178.100' };
+  });
+
+  it('files the appless card under its declared category "Development"', async () => {
+    const cards = await buildPortalCards();
+    expect(cards).toHaveLength(1);
+    expect(cards[0].name).toBe('claude-dev');
+    expect(cards[0].category).toBe('Development');
+  });
+
+  it('interpolates the VS Code href with the box LAN IP + CLAUDE_DEV_SSH_PORT (no literal HOST/PORT)', async () => {
+    const cards = await buildPortalCards();
+    const vscode = cards[0].secondaryActions.find(a => a.type === 'external_scheme');
+    expect(vscode).toBeDefined();
+    expect(vscode!.href).toBe('vscode://vscode-remote/ssh-remote+dev@192.168.178.100:2222/workspace');
+    expect(vscode!.href).not.toContain('HOST');
+    expect(vscode!.href).not.toContain('PORT');
+  });
+
+  it('honours an operator-overridden CLAUDE_DEV_SSH_PORT from templateSettings', async () => {
+    configState.config = {
+      reverseProxy: { hosts: [] },
+      templateSettings: { CLAUDE_DEV_SSH_PORT: '2244' },
+      lanIp: '192.168.178.100',
+    };
+    const cards = await buildPortalCards();
+    const vscode = cards[0].secondaryActions.find(a => a.type === 'external_scheme');
+    expect(vscode!.href).toContain('@192.168.178.100:2244/workspace');
+  });
+
+  it('falls back to the active domain for the host when no lanIp is recorded', async () => {
+    configState.config = { reverseProxy: { hosts: [] }, templateSettings: {} };
+    const cards = await buildPortalCards();
+    const vscode = cards[0].secondaryActions.find(a => a.type === 'external_scheme');
+    expect(vscode!.href).toContain('@home.arpa:2222/workspace');
+  });
+
+  it('keeps the in_app terminal deep-link (no HOST/PORT) untouched, pointing at the real container name', async () => {
+    const cards = await buildPortalCards();
+    expect(cards[0].primaryAction?.href).toBe(
+      '/terminal?node=Local&container=claude-dev-claude-dev&attach=claude',
+    );
+  });
+});
+
+describe('interpolateActionHref (#1682)', () => {
+  const ext = (href: string): PortalAction => ({
+    type: 'external_scheme',
+    label: 'x',
+    href,
+    desktop_only: true,
+  });
+
+  it('substitutes HOST and PORT word-tokens', () => {
+    const out = interpolateActionHref(ext('vscode://r/ssh-remote+dev@HOST:PORT/workspace'), '10.0.0.5', '2222');
+    expect(out.href).toBe('vscode://r/ssh-remote+dev@10.0.0.5:2222/workspace');
+  });
+
+  it('leaves an in_app action untouched', () => {
+    const inApp: PortalAction = { type: 'in_app', label: 'x', href: '/terminal?container=HOSTx', desktop_only: false };
+    expect(interpolateActionHref(inApp, '10.0.0.5', '2222')).toBe(inApp);
+  });
+
+  it('is a no-op when no HOST/PORT token is present', () => {
+    const a = ext('vscode://r/ssh-remote+dev@already:9/workspace');
+    expect(interpolateActionHref(a, '10.0.0.5', '2222')).toBe(a);
+  });
+});

--- a/packages/backend/src/lib/portal/claudeDevCard.test.ts
+++ b/packages/backend/src/lib/portal/claudeDevCard.test.ts
@@ -94,7 +94,7 @@ describe('claude-dev portal card (#1682)', () => {
     listServices.mockReset().mockResolvedValue([svc('claude-dev', true)]);
     getServices.mockReset().mockReturnValue([]);
     getLastResult.mockReset().mockReturnValue(null);
-    configState.config = { reverseProxy: { hosts: [] }, templateSettings: {}, lanIp: '192.168.178.100' };
+    configState.config = { reverseProxy: { hosts: [], lanIp: '192.168.178.100' }, templateSettings: {} };
   });
 
   it('files the appless card under its declared category "Development"', async () => {
@@ -115,9 +115,8 @@ describe('claude-dev portal card (#1682)', () => {
 
   it('honours an operator-overridden CLAUDE_DEV_SSH_PORT from templateSettings', async () => {
     configState.config = {
-      reverseProxy: { hosts: [] },
+      reverseProxy: { hosts: [], lanIp: '192.168.178.100' },
       templateSettings: { CLAUDE_DEV_SSH_PORT: '2244' },
-      lanIp: '192.168.178.100',
     };
     const cards = await buildPortalCards();
     const vscode = cards[0].secondaryActions.find(a => a.type === 'external_scheme');

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -29,7 +29,7 @@ import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
 import { getTemplateUserGuide } from '@/lib/registry';
 import { logger } from '@/lib/logger';
-import { parseUserGuide, type PortalIconName, type RecommendedApp, type SetupAsset, type ManualPairing, type PortalAction } from './userGuide';
+import { parseUserGuide, DEFAULT_PORTAL_CATEGORY, type PortalIconName, type RecommendedApp, type SetupAsset, type ManualPairing, type PortalAction, type PortalCategory } from './userGuide';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
@@ -47,6 +47,10 @@ export interface PortalCard {
   subdomainVar: string;
   /** User-facing label */
   label: string;
+  /** Grouping bucket (#1682). Falls back to `System` when the guide
+   *  declares no `category:`. Lets the portal file a card under a
+   *  user-facing section (e.g. claude-dev → "Development"). */
+  category: PortalCategory;
   /** Lucide icon name */
   lucideIcon: PortalIconName | null;
   /** Legacy emoji icon */
@@ -150,6 +154,55 @@ export function deriveCardStatus(
     return { status: 'degraded', statusReason: 'Running in a degraded state' };
   }
   return { status: 'ok' };
+}
+
+/**
+ * Resolve the box's reachable host for a desktop-handoff link (#1682).
+ * The VS Code Remote-SSH deep link needs a real host: prefer the
+ * install-detected LAN IP (the same address that serves the portal),
+ * falling back to the active domain when no IP is recorded yet.
+ */
+function resolveBoxHost(config: AppConfig): string {
+  return config.lanIp?.trim() || getActiveDomain(config);
+}
+
+/**
+ * Interpolate `HOST`/`PORT` placeholders in an `external_scheme` action
+ * href (#1682). Template authors ship a literal placeholder href —
+ * `vscode://...ssh-remote+dev@HOST:PORT/workspace` — because the box IP
+ * and the SSH port come from the install, not the template. ServiceBay
+ * knows both, so we substitute them at render time. Word-boundary
+ * matching keeps it from corrupting other URL text. `in_app` actions are
+ * returned unchanged (their hrefs are root-relative paths, no host/port).
+ *
+ * Pure — the caller supplies the resolved `host`/`port`. Returns a new
+ * PortalAction (never mutates the parsed frontmatter object).
+ */
+export function interpolateActionHref(
+  action: PortalAction,
+  host: string,
+  port: string,
+): PortalAction {
+  if (action.type !== 'external_scheme') return action;
+  if (!/\bHOST\b|\bPORT\b/.test(action.href)) return action;
+  const href = action.href
+    .replace(/\bHOST\b/g, host)
+    .replace(/\bPORT\b/g, port);
+  return { ...action, href };
+}
+
+/** Resolve a template variable's effective value (operator override in
+ *  `templateSettings`, else schema default). Used for the SSH port in the
+ *  VS Code deep link. Returns the schema/operator string as-is. */
+function resolveVarValue(
+  config: AppConfig,
+  variables: Record<string, { default?: string }>,
+  varName: string,
+): string | undefined {
+  const override = config.templateSettings?.[varName];
+  if (typeof override === 'string' && override.trim()) return override.trim();
+  const def = variables[varName]?.default;
+  return typeof def === 'string' && def.trim() ? def.trim() : undefined;
 }
 
 /** Read a template's variables.json (best-effort, returns empty record on miss).
@@ -271,6 +324,7 @@ export async function resolveServiceUrl(
 interface PortalCardDef {
   subdomain_var: string;
   label?: string;
+  category?: PortalCategory;
   lucide_icon?: PortalIconName;
   icon?: string;
   tagline?: string;
@@ -298,6 +352,7 @@ function assemblePortalCard(
     name: serviceName,
     subdomainVar,
     label: def.label ?? templateLabel,
+    category: def.category ?? DEFAULT_PORTAL_CATEGORY,
     lucideIcon: def.lucide_icon ?? null,
     icon: def.icon ?? '',
     tagline: def.tagline ?? '',
@@ -345,6 +400,42 @@ export function resolveCardStatus(
   });
 }
 
+/** Resolve the SSH-port substitution for an `external_scheme` deep link
+ *  (#1682). Reads the template's first `*_SSH_PORT` variable (operator
+ *  override > schema default); defaults to "2222" so the link is never
+ *  left with a literal `PORT`. */
+async function resolveSshPort(config: AppConfig, templateName: string): Promise<string> {
+  const variables = await readVariables(templateName);
+  const portVar = Object.keys(variables).find(k => k.endsWith('_SSH_PORT'));
+  const resolved = portVar ? resolveVarValue(config, variables, portVar) : undefined;
+  return resolved ?? '2222';
+}
+
+/** Interpolate any `external_scheme` action hrefs in a card def with the
+ *  real box host + SSH port (#1682), so a `vscode://...HOST:PORT...`
+ *  placeholder becomes a working Remote-SSH deep link. No-op when the
+ *  def carries no host/port placeholders. */
+async function interpolateCardActions(
+  config: AppConfig,
+  templateName: string,
+  def: PortalCardDef,
+): Promise<PortalCardDef> {
+  const hasPlaceholder =
+    (def.primary_action && /\bHOST\b|\bPORT\b/.test(def.primary_action.href)) ||
+    (def.actions ?? []).some(a => /\bHOST\b|\bPORT\b/.test(a.href));
+  if (!hasPlaceholder) return def;
+
+  const host = resolveBoxHost(config);
+  const port = await resolveSshPort(config, templateName);
+  return {
+    ...def,
+    primary_action: def.primary_action
+      ? interpolateActionHref(def.primary_action, host, port)
+      : def.primary_action,
+    actions: def.actions?.map(a => interpolateActionHref(a, host, port)),
+  };
+}
+
 /**
  * Build a single portal card entry from a parsed definition.
  */
@@ -367,7 +458,8 @@ async function buildPortalCardEntry(
   }
   const subdomainVar = def.subdomain_var || (await firstSubdomainVar(svc.name)) || '';
   const status = resolveCardStatus(svc.active, svc.name, url, twinHealthByService);
-  return assemblePortalCard(def, svc.name, templateLabel, url, subdomainVar, parsedBody, status);
+  const resolvedDef = await interpolateCardActions(config, svc.name, def);
+  return assemblePortalCard(resolvedDef, svc.name, templateLabel, url, subdomainVar, parsedBody, status);
 }
 
 /**
@@ -420,6 +512,7 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
       ?? [{
         // Implicit single card — use the first *_SUBDOMAIN variable.
         subdomain_var: '',
+        category: parsed.frontmatter.category,
         lucide_icon: parsed.frontmatter.lucide_icon,
         icon: parsed.frontmatter.icon,
         tagline: parsed.frontmatter.tagline,
@@ -431,7 +524,10 @@ export async function buildPortalCards(node: string = 'Local'): Promise<PortalCa
       }];
 
     for (const def of cardDefs) {
-      const card = await buildPortalCardEntry(config, svc, def, templateLabel, parsed.body, twinHealthByService);
+      // A per-card `category` wins; otherwise inherit the template's
+      // top-level frontmatter category (#1682).
+      const defWithCategory = { ...def, category: def.category ?? parsed.frontmatter.category };
+      const card = await buildPortalCardEntry(config, svc, defWithCategory, templateLabel, parsed.body, twinHealthByService);
       if (card) cards.push(card);
     }
   }

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -163,7 +163,7 @@ export function deriveCardStatus(
  * falling back to the active domain when no IP is recorded yet.
  */
 function resolveBoxHost(config: AppConfig): string {
-  return config.lanIp?.trim() || getActiveDomain(config);
+  return config.reverseProxy?.lanIp?.trim() || getActiveDomain(config);
 }
 
 /**

--- a/packages/backend/src/lib/portal/userGuide.test.ts
+++ b/packages/backend/src/lib/portal/userGuide.test.ts
@@ -419,3 +419,43 @@ body
     });
   });
 });
+
+describe('parseUserGuide — category (#1682)', () => {
+  it('parses a top-level category from the frontmatter', () => {
+    const raw = `---
+category: "Development"
+tagline: "A dev box"
+primary_action:
+  type: "in_app"
+  label: "Open terminal"
+  href: "/terminal?container=claude-dev-claude-dev&attach=claude"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'claude-dev');
+    expect(result!.frontmatter.category).toBe('Development');
+  });
+
+  it('ignores an unknown category value (falls back to default later)', () => {
+    const raw = `---
+category: "Nonsense"
+tagline: "x"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'x');
+    expect(result!.frontmatter.category).toBeUndefined();
+  });
+
+  it('parses a per-card category inside cards[]', () => {
+    const raw = `---
+cards:
+  - subdomain_var: "ABS_SUBDOMAIN"
+    category: "Media"
+---
+body
+`;
+    const result = parseUserGuide(raw, 'media');
+    expect(result!.frontmatter.cards?.[0].category).toBe('Media');
+  });
+});

--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -138,6 +138,28 @@ export interface ManualPairing {
  */
 export type PortalActionType = 'in_app' | 'external_scheme';
 
+/**
+ * Coarse grouping bucket a portal card belongs to (#1682). Lets a
+ * template author file a card under a user-facing section instead of
+ * the implicit "System" default. The canonical case is `claude-dev`:
+ * an appless dev box that should read as **Development**, not infra
+ * "System". Authors set `category:` in the frontmatter; the portal
+ * groups cards by it. Unknown/missing values fall back to `System`.
+ */
+export type PortalCategory = 'System' | 'Development' | 'Media' | 'Home' | 'Files' | 'Productivity';
+const KNOWN_CATEGORIES: ReadonlySet<PortalCategory> = new Set([
+  'System', 'Development', 'Media', 'Home', 'Files', 'Productivity',
+]);
+export const DEFAULT_PORTAL_CATEGORY: PortalCategory = 'System';
+
+/** Validate a frontmatter `category:` value against the allowlist,
+ *  returning undefined for anything unrecognized (the card builder
+ *  then falls back to {@link DEFAULT_PORTAL_CATEGORY}). */
+function parseCategory(input: unknown): PortalCategory | undefined {
+  if (typeof input !== 'string') return undefined;
+  return KNOWN_CATEGORIES.has(input as PortalCategory) ? (input as PortalCategory) : undefined;
+}
+
 /** External URI schemes a card action may use. Allowlisted so a
  *  template author can't smuggle `javascript:`/`data:` into an action
  *  link. Each is a registered desktop-app handoff scheme. */
@@ -201,6 +223,9 @@ export interface UserGuideCard {
   subdomain_var: string;
   /** Optional override label; falls back to the template label. */
   label?: string;
+  /** Grouping bucket (#1682). Falls back to the top-level frontmatter
+   *  category (then `System`) when unset. */
+  category?: PortalCategory;
   lucide_icon?: PortalIconName;
   icon?: string;
   tagline?: string;
@@ -219,6 +244,11 @@ export interface UserGuideFrontmatter {
    *  here. When present, top-level icon/tagline/etc. are ignored and
    *  one PortalCard is emitted per entry. */
   cards?: UserGuideCard[];
+
+  /** Grouping bucket for this template's card(s) (#1682). When unset
+   *  the card builder uses {@link DEFAULT_PORTAL_CATEGORY} (`System`).
+   *  A per-card `category` (in `cards[]`) overrides this. */
+  category?: PortalCategory;
 
   /** Lucide icon name (line-art, matches ServiceBay's dashboard
    *  chrome). Preferred over the legacy emoji `icon` field. Used
@@ -422,6 +452,8 @@ function parseCardEntry(entry: unknown): UserGuideCard | null {
   }
   const card: UserGuideCard = { subdomain_var: e.subdomain_var };
   if (typeof e.label === 'string' && e.label.trim()) card.label = e.label.trim();
+  const cardCategory = parseCategory(e.category);
+  if (cardCategory) card.category = cardCategory;
   if (typeof e.icon === 'string') card.icon = e.icon;
   if (typeof e.lucide_icon === 'string' && PORTAL_ICON_SET.has(e.lucide_icon)) {
     card.lucide_icon = e.lucide_icon as PortalIconName;
@@ -431,24 +463,34 @@ function parseCardEntry(entry: unknown): UserGuideCard | null {
   return card;
 }
 
+/** Resolve the recommended-apps list: prefer `recommended_apps`, fall
+ *  back to lifting legacy `mobile_apps` so older guides keep working.
+ *  Returns undefined when neither yields entries. */
+function resolveRecommendedApps(data: Record<string, unknown>): RecommendedApp[] | undefined {
+  if (Array.isArray(data.recommended_apps)) {
+    const apps = parseRecommendedApps(data.recommended_apps);
+    return apps.length > 0 ? apps : undefined;
+  }
+  if (Array.isArray(data.mobile_apps)) {
+    const lifted = liftMobileApps(data.mobile_apps);
+    return lifted.length > 0 ? lifted : undefined;
+  }
+  return undefined;
+}
+
 /** Extract frontmatter fields from parsed YAML data. */
 function parseUserGuideSection(data: Record<string, unknown>): UserGuideFrontmatter {
   const fm: UserGuideFrontmatter = {};
+  const category = parseCategory(data.category);
+  if (category) fm.category = category;
   if (typeof data.icon === 'string') fm.icon = data.icon;
   if (typeof data.lucide_icon === 'string' && PORTAL_ICON_SET.has(data.lucide_icon)) {
     fm.lucide_icon = data.lucide_icon as PortalIconName;
   }
   if (typeof data.tagline === 'string') fm.tagline = data.tagline;
 
-  // Prefer `recommended_apps` when present; fall back to lifting
-  // legacy `mobile_apps` so older guides keep working.
-  if (Array.isArray(data.recommended_apps)) {
-    const apps = parseRecommendedApps(data.recommended_apps);
-    if (apps.length > 0) fm.recommended_apps = apps;
-  } else if (Array.isArray(data.mobile_apps)) {
-    const lifted = liftMobileApps(data.mobile_apps);
-    if (lifted.length > 0) fm.recommended_apps = lifted;
-  }
+  const recommendedApps = resolveRecommendedApps(data);
+  if (recommendedApps) fm.recommended_apps = recommendedApps;
 
   if (Array.isArray(data.cards)) {
     const cards = data.cards

--- a/packages/backend/src/lib/reverseProxy/forwardAuthDeniedPage.test.ts
+++ b/packages/backend/src/lib/reverseProxy/forwardAuthDeniedPage.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #1684 — forward-auth (Authelia authorization deny) 403 explainer: pure builders.
+ *
+ * A forward-auth host's 403 means "you ARE signed in, but you're not in the
+ * group this service requires" — NOT the LAN-only deny (#1415) or a bare
+ * upstream error (#1583). The explainer must name WHAT'S REQUIRED (the group
+ * derived from the domain's Authelia access_control rule) and WHO the user is
+ * (signed-in $user / $groups, echoed via SSI), and the page/wiring must be
+ * distinct from the LAN-only path so the three branches don't collide.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/agent/manager', () => ({ agentManager: { getAgent: vi.fn() } }));
+vi.mock('@/lib/nodes', () => ({ listNodes: vi.fn(async () => []) }));
+
+import {
+  requiredGroupsForDomain,
+  buildForwardAuthDeniedPageHtml,
+  withForwardAuthDeniedPage,
+  forwardAuthDeniedAdvancedConfig,
+  forwardAuthDeniedContainerPath,
+  forwardAuthDeniedHostPath,
+  // for the cross-branch distinction assertions:
+  LAN_DENIED_PAGE_HTML,
+  withLanDeniedPage,
+} from './lanDeniedPage';
+
+describe('requiredGroupsForDomain', () => {
+  it('maps the admin-only subdomains to the admins group', () => {
+    for (const d of ['admin.dopp.cloud', 'nginx.dopp.cloud', 'dns.dopp.cloud', 'ldap.dopp.cloud']) {
+      expect(requiredGroupsForDomain(d)).toEqual(['admins']);
+    }
+  });
+
+  it('maps everything else to family or admins (the wildcard rule)', () => {
+    expect(requiredGroupsForDomain('ollama.dopp.cloud')).toEqual(['family', 'admins']);
+    expect(requiredGroupsForDomain('photos.dopp.cloud')).toEqual(['family', 'admins']);
+  });
+
+  it('inspects only the leftmost label and is case-insensitive', () => {
+    expect(requiredGroupsForDomain('LDAP.dopp.cloud')).toEqual(['admins']);
+    expect(requiredGroupsForDomain('ldap')).toEqual(['admins']);
+  });
+
+  it('defaults an empty/undefined domain to the wildcard groups', () => {
+    expect(requiredGroupsForDomain(undefined)).toEqual(['family', 'admins']);
+    expect(requiredGroupsForDomain('')).toEqual(['family', 'admins']);
+  });
+});
+
+describe('buildForwardAuthDeniedPageHtml — auth-deny branch', () => {
+  it('names the required group AND the signed-in identity (the acceptance)', () => {
+    const html = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud', 'dopp.cloud');
+    // WHAT'S REQUIRED — the wildcard rule's groups for a non-admin host.
+    expect(html).toContain('<code>family</code>');
+    expect(html).toContain('<code>admins</code>');
+    expect(html).toContain('ollama.dopp.cloud');
+    // WHO YOU ARE — live signed-in identity via nginx SSI.
+    expect(html).toContain('<!--# echo var="user"');
+    expect(html).toContain('<!--# echo var="groups"');
+    expect(html).toMatch(/signed in as/i);
+  });
+
+  it('names only admins for an admin-only host', () => {
+    const html = buildForwardAuthDeniedPageHtml('ldap.dopp.cloud', 'dopp.cloud');
+    expect(html).toContain('<code>admins</code>');
+    expect(html).not.toContain('<code>family</code>');
+  });
+
+  it('points at signing out via auth.<publicDomain> when given a domain', () => {
+    const html = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud', 'dopp.cloud');
+    expect(html).toContain('https://auth.dopp.cloud');
+  });
+
+  it('omits the auth link cleanly when no public domain is known', () => {
+    const html = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud');
+    expect(html).not.toContain('href="https://auth.');
+    // still names the requirement + identity.
+    expect(html).toContain('ollama.dopp.cloud');
+    expect(html).toContain('<!--# echo var="user"');
+  });
+
+  it('is self-contained: inline <style>, no external assets, no JS', () => {
+    const html = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud', 'dopp.cloud');
+    expect(html).toContain('<style>');
+    expect(html).not.toMatch(/<link[^>]+href=/i);
+    expect(html).not.toMatch(/<script\b/i);
+    expect(html).not.toMatch(/src=["']https?:/i);
+  });
+
+  it('brands as ServiceBay in the shared slate palette', () => {
+    const html = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud', 'dopp.cloud');
+    expect(html).toContain('ServiceBay');
+    expect(html).toContain('#0f172a');
+  });
+
+  it('frames it as a permission problem, NOT a network/DNS problem (vs LAN-only)', () => {
+    const html = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud', 'dopp.cloud');
+    expect(html).toMatch(/isn't a network or DNS problem/i);
+    // The LAN-only page's DNS self-heal copy must NOT appear here.
+    expect(html).not.toContain('ipconfig /flushdns');
+    expect(html).not.toContain('LAN-only by design');
+  });
+});
+
+describe('the three 403 branches are distinct', () => {
+  it('auth-deny vs LAN-only render different pages', () => {
+    const authDeny = buildForwardAuthDeniedPageHtml('ollama.dopp.cloud', 'dopp.cloud');
+    // LAN-only is about stale DNS + the client IP; auth-deny is about groups.
+    expect(LAN_DENIED_PAGE_HTML).toContain('remote_addr');
+    expect(LAN_DENIED_PAGE_HTML).not.toContain('<!--# echo var="groups"');
+    expect(authDeny).not.toContain('remote_addr');
+    expect(authDeny).toContain('<!--# echo var="groups"');
+  });
+
+  it('the LAN-only and forward-auth error_page snippets alias different files', () => {
+    const lan = withLanDeniedPage('');
+    const fa = forwardAuthDeniedAdvancedConfig('ollama.dopp.cloud');
+    expect(lan).toContain('servicebay-lan-only');
+    expect(fa).toContain('servicebay-forward-auth-denied');
+    expect(lan).not.toContain('forward-auth-denied');
+    expect(fa).not.toContain('servicebay-lan-only');
+  });
+});
+
+describe('forwardAuthDeniedAdvancedConfig', () => {
+  it('wires error_page 403 to an internal SSI location aliasing the host file', () => {
+    const cfg = forwardAuthDeniedAdvancedConfig('ollama.dopp.cloud');
+    expect(cfg).toContain('error_page 403');
+    expect(cfg).toContain('internal;');
+    expect(cfg).toContain('ssi on;');
+    expect(cfg).toContain(`alias ${forwardAuthDeniedContainerPath('ollama.dopp.cloud')};`);
+  });
+
+  it('preserves the 403 status (no `=` rewrite on error_page)', () => {
+    expect(forwardAuthDeniedAdvancedConfig('ollama.dopp.cloud')).not.toMatch(/error_page\s+403\s*=/);
+  });
+
+  it('aliases a per-host file slugged by domain', () => {
+    expect(forwardAuthDeniedContainerPath('ollama.dopp.cloud')).toContain('forward-auth-denied-ollama.dopp.cloud.html');
+    expect(forwardAuthDeniedHostPath('ldap.dopp.cloud')).toContain('forward-auth-denied-ldap.dopp.cloud.html');
+    // different hosts → different files (no clobber).
+    expect(forwardAuthDeniedContainerPath('a.dopp.cloud')).not.toBe(forwardAuthDeniedContainerPath('b.dopp.cloud'));
+  });
+});
+
+describe('withForwardAuthDeniedPage', () => {
+  it('returns the host snippet alone for an empty/undefined config', () => {
+    expect(withForwardAuthDeniedPage(undefined, 'ollama.dopp.cloud')).toBe(
+      forwardAuthDeniedAdvancedConfig('ollama.dopp.cloud'),
+    );
+    expect(withForwardAuthDeniedPage('   \n  ', 'ollama.dopp.cloud')).toBe(
+      forwardAuthDeniedAdvancedConfig('ollama.dopp.cloud'),
+    );
+  });
+
+  it('appends the snippet, preserving an existing forward-auth config', () => {
+    const existing = 'auth_request /authelia;\nlocation = /authelia { internal; }';
+    const out = withForwardAuthDeniedPage(existing, 'ollama.dopp.cloud');
+    expect(out).toContain(existing);
+    expect(out).toContain('error_page 403');
+  });
+
+  it('is idempotent: a config already carrying the snippet is unchanged', () => {
+    const once = withForwardAuthDeniedPage('proxy_read_timeout 90;', 'ollama.dopp.cloud');
+    const twice = withForwardAuthDeniedPage(once, 'ollama.dopp.cloud');
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/backend/src/lib/reverseProxy/lanDeniedPage.ts
+++ b/packages/backend/src/lib/reverseProxy/lanDeniedPage.ts
@@ -170,6 +170,216 @@ export const LAN_DENIED_PAGE_HTML = `<!DOCTYPE html>
 </html>
 `;
 
+/* -------------------------------------------------------------------------
+ * #1684 — forward-auth (Authelia authorization deny) 403 explainer.
+ *
+ * A forward-auth host's 403 is NOT the LAN-only deny: it's Authelia saying
+ * "you ARE signed in, but you're not in the group this service requires"
+ * (or an upstream-app 403). Routing that 403 to the LAN-only page above is
+ * misleading — the user is on the LAN, signed in, and just missing a group.
+ *
+ * ServiceBay owns the Authelia `access_control.rules` (templates/auth/
+ * configuration.yml.mustache), so it KNOWS each domain's required subject:
+ *   - admin / nginx / dns / ldap     → group `admins`
+ *   - everything else (`*.<domain>`) → group `family` or `admins`
+ * We surface that required group, plus WHO the user is, on the deny page.
+ *
+ * The signed-in identity comes for free: the forward-auth snippet already
+ * runs `auth_request_set $user $upstream_http_remote_user` /
+ * `$groups $upstream_http_remote_groups` (forwardAuth.ts), and Authelia
+ * returns Remote-User/Remote-Groups on the deny response too, so nginx has
+ * `$user` / `$groups` in scope at error_page time. The page echoes them via
+ * SSI — same self-contained, backend-independent mechanism as #1415.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * The forward-auth deny page is HOST-SPECIFIC — it bakes in the required
+ * group for that domain's access_control rule (admin hosts need `admins`,
+ * others `family`/`admins`). So each forward-auth host gets its own file,
+ * slugged by domain, rather than one shared page (which would clobber).
+ */
+function forwardAuthDeniedSlug(domain: string): string {
+  return (domain || 'host').toLowerCase().replace(/[^a-z0-9.-]/g, '_');
+}
+
+/** Path of a host's forward-auth deny explainer INSIDE the NPM container. */
+export function forwardAuthDeniedContainerPath(domain: string): string {
+  return `/data/nginx/servicebay/forward-auth-denied-${forwardAuthDeniedSlug(domain)}.html`;
+}
+
+/** Host-side path of a host's forward-auth deny explainer under NPM's data volume. */
+export function forwardAuthDeniedHostPath(domain: string): string {
+  return `/mnt/data/stacks/nginx-proxy-manager/data/nginx/servicebay/forward-auth-denied-${forwardAuthDeniedSlug(domain)}.html`;
+}
+
+/** Internal URI the forward-auth 403 is re-routed to. */
+const FORWARD_AUTH_DENIED_INTERNAL_URI = '/servicebay-forward-auth-denied';
+
+/** Sentinel marker for idempotent appends / detection. */
+const FORWARD_AUTH_DENIED_MARKER = '# servicebay-forward-auth-denied-explainer (#1684)';
+
+/** Admin-only subdomains per the auth template's access_control rules. */
+const ADMIN_ONLY_SUBDOMAINS = new Set(['admin', 'nginx', 'dns', 'ldap']);
+
+/**
+ * Derive the group(s) that grant access to a domain, from the Authelia
+ * `access_control.rules` ServiceBay generates (templates/auth/
+ * configuration.yml.mustache). Pure + deterministic — mirrors the rule
+ * table so the deny page can name the required group without reading the
+ * live config:
+ *   - admin / nginx / dns / ldap     → `['admins']`
+ *   - anything else                  → `['family', 'admins']`
+ *
+ * `domain` may be a bare host (`ollama.dopp.cloud`) or just the leftmost
+ * label; only the first label is inspected.
+ */
+export function requiredGroupsForDomain(domain: string | undefined): string[] {
+  const label = (domain ?? '').trim().toLowerCase().split('.')[0] ?? '';
+  return ADMIN_ONLY_SUBDOMAINS.has(label) ? ['admins'] : ['family', 'admins'];
+}
+
+/**
+ * The nginx directives that wire a forward-auth host's 403 to the branded
+ * deny page. `ssi on` so the page can echo `$user` / `$groups`. The required
+ * group is baked into the served HTML per-host (so it can be SSI-free), not
+ * into this snippet — keeping the snippet identical across hosts and
+ * idempotent on the marker.
+ *
+ * `error_page 403 /…` (no `=`) preserves the original 403 — the request is
+ * still denied, the user just gets an explanation of WHICH group they need.
+ */
+export function forwardAuthDeniedAdvancedConfig(domain: string): string {
+  return [
+    FORWARD_AUTH_DENIED_MARKER,
+    `error_page 403 ${FORWARD_AUTH_DENIED_INTERNAL_URI};`,
+    `location = ${FORWARD_AUTH_DENIED_INTERNAL_URI} {`,
+    '    internal;',
+    '    ssi on;',
+    '    default_type text/html;',
+    `    alias ${forwardAuthDeniedContainerPath(domain)};`,
+    '}',
+  ].join('\n');
+}
+
+/**
+ * Append the forward-auth deny directives to an existing `advanced_config`.
+ * Idempotent on {@link FORWARD_AUTH_DENIED_MARKER}; preserves any existing
+ * directives (the forward-auth block itself, timeouts, the #1583 proxy-error
+ * block, …). Mirrors {@link withLanDeniedPage}.
+ *
+ * NOTE: a host is EITHER LAN-only (gets {@link withLanDeniedPage}) OR
+ * forward-auth (gets this) for its 403 routing — never both, so the two
+ * `error_page 403` directives never collide on one host.
+ */
+export function withForwardAuthDeniedPage(advancedConfig: string | undefined, domain: string): string {
+  const base = advancedConfig ?? '';
+  if (base.includes(FORWARD_AUTH_DENIED_MARKER)) return base;
+  const snippet = forwardAuthDeniedAdvancedConfig(domain);
+  if (base.trim() === '') return snippet;
+  return `${base.replace(/\s*$/, '')}\n\n${snippet}`;
+}
+
+/** Render the required-group phrase: `family` or `admins`. */
+function renderRequiredGroups(groups: string[]): string {
+  const quoted = groups.map((g) => `<code>${g}</code>`);
+  if (quoted.length <= 1) return quoted[0] ?? '';
+  if (quoted.length === 2) return `${quoted[0]} or ${quoted[1]}`;
+  return `${quoted.slice(0, -1).join(', ')} or ${quoted[quoted.length - 1]}`;
+}
+
+/**
+ * Build the branded forward-auth deny explainer for a specific host. Names
+ * WHAT'S REQUIRED (the group that grants access, baked in from the domain's
+ * access_control rule) and WHO the user is (signed-in `$user` + `$groups`,
+ * echoed live via nginx SSI). Self-contained: inline CSS, no external assets,
+ * no JS, no ServiceBay-backend dependency — renders straight out of nginx.
+ *
+ * Distinct from the LAN-only page (#1415): the user here IS on the network and
+ * IS signed in; they're just missing a group. The copy says exactly that and
+ * points them at asking an admin to add the group.
+ *
+ * @param domain the host this page is served for (e.g. `ollama.dopp.cloud`).
+ * @param publicDomain operator's public domain, used to link `auth.<domain>`.
+ */
+const FORWARD_AUTH_DENIED_CSS = `
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+    line-height: 1.55;
+  }
+  .card {
+    width: 100%;
+    max-width: 560px;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 32px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 16px; color: #f8fafc; }
+  .brand { font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: #94a3b8; margin: 0 0 20px; }
+  p { margin: 0 0 14px; color: #cbd5e1; }
+  .ip, code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    color: #f1f5f9;
+  }
+  .ip {
+    display: inline-block;
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    padding: 2px 8px;
+  }
+  a { color: #60a5fa; }
+  ol { margin: 8px 0 18px; padding-left: 22px; color: #cbd5e1; }
+  ol li { margin: 0 0 8px; }
+  .footer { margin: 18px 0 0; font-size: 0.85rem; color: #64748b; border-top: 1px solid #334155; padding-top: 16px; }`;
+
+export function buildForwardAuthDeniedPageHtml(domain?: string, publicDomain?: string): string {
+  const host = (domain ?? '').trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  const hostLabel = host || 'This service';
+  const requiredPhrase = renderRequiredGroups(requiredGroupsForDomain(host));
+  const pubDomain = (publicDomain ?? '').trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  const authUrl = pubDomain ? `https://auth.${pubDomain}` : '';
+  const signOutLine = authUrl
+    ? `<li>If you signed in with the wrong account, sign out at <a href="${authUrl}">${authUrl}</a> and sign back in.</li>`
+    : '';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>You don't have access to this service</title>
+<style>${FORWARD_AUTH_DENIED_CSS}</style>
+</head>
+<body>
+  <main class="card">
+    <p class="brand">ServiceBay</p>
+    <h1>You don't have access to this service</h1>
+    <p>You're signed in, but your account isn't allowed to open <strong>${hostLabel}</strong>.</p>
+    <p><strong>${hostLabel}</strong> needs group ${requiredPhrase}.</p>
+    <p>You're signed in as <span class="ip"><!--# echo var="user" encoding="none" --></span> with groups <span class="ip"><!--# echo var="groups" encoding="none" --></span>.</p>
+    <p>To get in:</p>
+    <ol>
+      <li><strong>Ask an administrator</strong> to add your account to group ${requiredPhrase}.</li>
+      ${signOutLine}
+    </ol>
+    <p class="footer">This isn't a network or DNS problem &mdash; you reached the right service, your account just lacks the required group.</p>
+  </main>
+</body>
+</html>
+`;
+}
+
 /**
  * Ship the explainer HTML into NPM's data volume so the `alias` in
  * {@link LAN_DENIED_ADVANCED_CONFIG} can serve it. Best-effort: returns
@@ -198,6 +408,42 @@ export async function deployLanDeniedPage(node?: string): Promise<boolean> {
     return true;
   } catch (e) {
     logger.warn('ProxyHosts', `Failed to deploy LAN-only explainer page: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+}
+
+/**
+ * #1684 — Ship the forward-auth (Authelia authorization deny) 403 explainer
+ * into NPM's data volume for a specific host, so the per-host `error_page 403`
+ * → SSI location can serve it. The page is host-specific (it names the
+ * required group derived from that domain's access_control rule), so unlike
+ * the single LAN-only page this is written once per forward-auth host.
+ * Best-effort: a write hiccup just leaves the old bare openresty 403, exactly
+ * the pre-#1684 behaviour, so it must never fail an install.
+ */
+export async function deployForwardAuthDeniedPage(
+  domain: string,
+  publicDomain?: string,
+  node?: string,
+): Promise<boolean> {
+  try {
+    const nodes = await listNodes();
+    const nodeName = node ?? nodes[0]?.Name ?? 'Local';
+    const agent = agentManager.getAgent(nodeName);
+    const hostPath = forwardAuthDeniedHostPath(domain);
+    const res = (await agent.sendCommand('write_file', {
+      path: hostPath,
+      content: buildForwardAuthDeniedPageHtml(domain, publicDomain),
+      sudo: true,
+    })) as { result?: string; error?: string };
+    if (res?.error) {
+      logger.warn('ProxyHosts', `Failed to deploy forward-auth deny explainer for ${domain}: ${res.error}`);
+      return false;
+    }
+    logger.info('ProxyHosts', `Deployed forward-auth 403 explainer for ${domain} to ${hostPath}`);
+    return true;
+  } catch (e) {
+    logger.warn('ProxyHosts', `Failed to deploy forward-auth deny explainer for ${domain}: ${e instanceof Error ? e.message : String(e)}`);
     return false;
   }
 }

--- a/packages/backend/src/lib/terminal/sessionManager.test.ts
+++ b/packages/backend/src/lib/terminal/sessionManager.test.ts
@@ -19,7 +19,7 @@ vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
 
-import { resolvePtySpec, buildContainerInnerCmd } from './sessionManager';
+import { resolvePtySpec, buildContainerInnerCmd, buildContainerExecCmd } from './sessionManager';
 
 beforeEach(() => {
   state.nodes = [];
@@ -63,14 +63,17 @@ describe('resolvePtySpec — container terminals', () => {
     expect(spec.args[spec.args.length - 1]).toContain('xyz789');
   });
 
-  it('falls back to direct podman when no matching node is registered (bare-metal install)', async () => {
+  it('falls back to direct podman (via sh -c, existence-guarded) when no matching node is registered (bare-metal install)', async () => {
     state.nodes = []; // no Local node — bare-metal/dev mode
 
     const spec = await resolvePtySpec('container:local:abc123');
 
-    expect(spec.shell).toBe('podman');
-    expect(spec.args[0]).toBe('exec');
-    expect(spec.args).toContain('abc123');
+    expect(spec.shell).toBe('sh');
+    expect(spec.args[0]).toBe('-c');
+    const cmd = spec.args[1];
+    expect(cmd).toContain('podman container exists abc123');
+    expect(cmd).toContain('podman exec -it');
+    expect(cmd).toContain('abc123');
   });
 
   it('falls back to direct podman when the matched node has a non-ssh URI', async () => {
@@ -82,7 +85,8 @@ describe('resolvePtySpec — container terminals', () => {
 
     const spec = await resolvePtySpec('container:local:abc123');
 
-    expect(spec.shell).toBe('podman');
+    expect(spec.shell).toBe('sh');
+    expect(spec.args[1]).toContain('podman exec -it');
   });
 
   it('throws when the container id is empty', async () => {
@@ -107,7 +111,7 @@ describe('resolvePtySpec — container terminals', () => {
 
     const spec = await resolvePtySpec('container:Local:dev:attach=claude');
 
-    expect(spec.shell).toBe('podman');
+    expect(spec.shell).toBe('sh');
     const inner = spec.args[spec.args.length - 1];
     expect(inner).toContain('tmux new -A -s claude');
   });
@@ -118,13 +122,57 @@ describe('resolvePtySpec — container terminals', () => {
     const spec = await resolvePtySpec('container:Local:my-ctr:attach=sess');
 
     // The attach segment must NOT be mistaken for the container id.
-    expect(spec.args).toContain('my-ctr');
-    expect(spec.args).not.toContain('attach=sess');
+    const cmd = spec.args[spec.args.length - 1];
+    expect(cmd).toContain('my-ctr');
+    expect(cmd).not.toContain('attach=sess');
   });
 
   it('rejects an attach session name with shell metacharacters', async () => {
     await expect(resolvePtySpec("container:Local:dev:attach=foo;rm -rf /"))
       .rejects.toThrow(/Invalid attach session name/);
+  });
+});
+
+describe('container existence guard (#1681)', () => {
+  it('guards the SSH-path exec with `podman container exists` and surfaces an error on a miss (no host fallback)', async () => {
+    state.nodes = [{ Name: 'Local', URI: 'ssh://core@127.0.0.1', Identity: '/k' }];
+
+    // The claude-dev card's real container is `claude-dev-claude-dev`
+    // (pod + container), not `claude-dev`.
+    const spec = await resolvePtySpec('container:Local:claude-dev-claude-dev:attach=claude');
+    const remoteCmd = spec.args[spec.args.length - 1];
+
+    expect(remoteCmd).toContain('podman container exists claude-dev-claude-dev');
+    expect(remoteCmd).toContain('podman exec -it');
+    expect(remoteCmd).toContain('tmux new -A -s claude');
+    // On a miss it errors explicitly and exits — it must NOT drop to a host shell.
+    expect(remoteCmd).toContain('no such container');
+    expect(remoteCmd).toContain('not falling back to the host shell');
+    expect(remoteCmd).toContain('exit 1');
+  });
+
+  it('guards the direct-podman (bare-metal) path with the same existence check', async () => {
+    state.nodes = [];
+
+    const spec = await resolvePtySpec('container:Local:claude-dev-claude-dev:attach=claude');
+    const cmd = spec.args[spec.args.length - 1];
+
+    expect(cmd).toContain('podman container exists claude-dev-claude-dev');
+    expect(cmd).toContain('no such container');
+    expect(cmd).toContain('exit 1');
+  });
+});
+
+describe('buildContainerExecCmd', () => {
+  it('fronts the exec with an existence check and errors (not host-shell) on a miss', () => {
+    const inner = buildContainerInnerCmd('claude');
+    const cmd = buildContainerExecCmd('claude-dev-claude-dev', inner);
+
+    expect(cmd).toContain('podman container exists claude-dev-claude-dev');
+    expect(cmd).toContain('podman exec -it -e TERM=xterm-256color claude-dev-claude-dev');
+    expect(cmd).toContain('tmux new -A -s claude');
+    expect(cmd).toMatch(/no such container.*not falling back to the host shell/);
+    expect(cmd).toContain('exit 1');
   });
 });
 

--- a/packages/backend/src/lib/terminal/sessionManager.ts
+++ b/packages/backend/src/lib/terminal/sessionManager.ts
@@ -210,6 +210,27 @@ export function buildContainerInnerCmd(attachSession?: string): string {
   return `if command -v tmux >/dev/null 2>&1; then exec tmux new -A -s ${attachSession}; else ${BARE_SHELL_CMD}; fi`;
 }
 
+/**
+ * Build the remote/host shell command that execs into a container,
+ * guarded by an existence check (#1681).
+ *
+ * The terminal deep-link targets a container by name (e.g. claude-dev's
+ * real `claude-dev-claude-dev`). If that name is wrong/absent, a bare
+ * `podman exec` errors opaquely — and worse, an upstream caller that
+ * doesn't realise the target is a container can drop the operator onto
+ * the *host* shell, which looks like it "worked" but silently puts them
+ * on the box instead of inside the container. So we front the exec with
+ * `podman container exists <id>`: on a miss we print an explicit
+ * "no such container" line and exit non-zero (the PTY shows the error),
+ * rather than falling through to anything. The container id is validated
+ * by the caller's grammar (`container:<node>:<id>`), so it's safe to
+ * interpolate.
+ */
+export function buildContainerExecCmd(containerId: string, innerCmd: string): string {
+  const exec = `podman exec -it -e TERM=xterm-256color ${containerId} sh -c '${innerCmd}'`;
+  return `if podman container exists ${containerId}; then ${exec}; else echo "Error: no such container: ${containerId} — the terminal deep-link target does not exist (not falling back to the host shell)." >&2; exit 1; fi`;
+}
+
 export async function resolvePtySpec(id: string): Promise<PtySpec> {
   const defaultShell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || 'bash');
 
@@ -263,7 +284,7 @@ export async function resolvePtySpec(id: string): Promise<PtySpec> {
           args.push('-o', 'UserKnownHostsFile=/dev/null');
           args.push('-t');
           args.push(`${uri.username}@${uri.hostname}`);
-          args.push(`podman exec -it -e TERM=xterm-256color ${containerId} sh -c '${innerCmd}'`);
+          args.push(buildContainerExecCmd(containerId, innerCmd));
           return { shell: 'ssh', args, fallbackWarning: '' };
         }
       }
@@ -275,9 +296,13 @@ export async function resolvePtySpec(id: string): Promise<PtySpec> {
     // in PATH. Container-mode installs don't reach this — see the SSH branch
     // above. Kept so a hypothetical `node:` install (or a future packaged
     // binary) still works without a per-node SSH config entry.
+    //
+    // Routed through `sh -c` so the same `podman container exists` guard
+    // (#1681) applies here: a missing/mis-named container surfaces an explicit
+    // error instead of an opaque podman failure (and never a host shell).
     return {
-      shell: 'podman',
-      args: ['exec', '-it', '-e', 'TERM=xterm-256color', containerId, 'sh', '-c', innerCmd],
+      shell: 'sh',
+      args: ['-c', buildContainerExecCmd(containerId, innerCmd)],
       fallbackWarning: '',
     };
   }

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -9,7 +9,12 @@ import { agentManager } from '@/lib/agent/manager';
 import { listNodes } from '@/lib/nodes';
 import { AUTHELIA_LOCATION_HEADERS, sanitizeForwardAuthPort } from '@/lib/stackInstall/forwardAuth';
 import { checkPublicARecord, missingARecordMessage } from '@/lib/reverseProxy/publicDnsCheck';
-import { withLanDeniedPage, deployLanDeniedPage } from '@/lib/reverseProxy/lanDeniedPage';
+import {
+    withLanDeniedPage,
+    deployLanDeniedPage,
+    withForwardAuthDeniedPage,
+    deployForwardAuthDeniedPage,
+} from '@/lib/reverseProxy/lanDeniedPage';
 import { withProxyErrorPage, deployProxyErrorPages } from '@/lib/reverseProxy/proxyErrorPages';
 
 export const dynamic = 'force-dynamic';
@@ -1006,6 +1011,21 @@ export const POST = withApiHandler({}, async ({ request }) => {
                 : wantsStrictHost
                 ? `${host.forwardHost ?? '127.0.0.1'}:${host.forwardPort}`
                 : undefined;
+            // #1684 — A forward-auth host's 403 is an Authelia AUTHORIZATION
+            // deny (signed-in but wrong group), NOT the LAN-only deny. Wire
+            // its `error_page 403` to a branded explainer that names the
+            // required group (derived from this domain's access_control rule)
+            // and echoes the signed-in $user/$groups via SSI — instead of the
+            // misleading LAN-only page. A forward-auth host is not LAN-bound
+            // (it serves https with a cert), so the two `error_page 403`
+            // owners never collide. Best-effort; preserves existing directives.
+            if (wantsForwardAuth && accessListId === 0) {
+                host.proxyConfig = {
+                    ...host.proxyConfig,
+                    advanced_config: withForwardAuthDeniedPage(host.proxyConfig?.advanced_config, host.domain),
+                };
+                await deployForwardAuthDeniedPage(host.domain, errorPageDomain, node);
+            }
             try {
                 createdHost = await createProxyHost(npm.apiUrl, token, host, accessListId);
                 results.push({ domain: host.domain, success: true, lanRestricted: accessListId !== 0 });

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -19,6 +19,7 @@ const baseCard: PortalCard = {
   name: 'immich',
   subdomainVar: 'IMMICH_SUBDOMAIN',
   label: 'Photos',
+  category: 'Media',
   lucideIcon: 'camera',
   icon: '',
   tagline: 'Auto-backup your family photos.',

--- a/packages/frontend/src/dashboards/SystemInfoDashboard.tsx
+++ b/packages/frontend/src/dashboards/SystemInfoDashboard.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { getSystemUpdates } from '@/app/actions/system';
 import { logger } from '@servicebay/api-client';
-import { RefreshCw, Cpu, HardDrive, Network, Server, Package, Copy, Check, Info, Monitor, Settings } from 'lucide-react';
+import { RefreshCw, Cpu, HardDrive, Network, Server, Package, Copy, Check, Info, Monitor, Settings, AlertTriangle, ShieldCheck } from 'lucide-react';
+import { summarizeDnsResolvers, type DnsResolverLabel } from '@/dashboards/_lib/dnsResolvers';
 import { useToast } from '@/providers/ToastProvider';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 import { useSocket } from '@/hooks/useSocket';
@@ -162,7 +163,14 @@ export function SystemInfoContent() {
       );
   }
 
-  const { cpuUsage, memoryUsage, totalMemory, os, disks, network, cpu, gpus } = resources;
+  const { cpuUsage, memoryUsage, totalMemory, os, disks, network, dnsResolvers, cpu, gpus } = resources;
+
+  // The box's own non-internal IPs — a resolver matching one of these is the
+  // box pointing at its own AdGuard.
+  const boxAddresses = network
+    ? Object.values(network).flat().filter(a => !a.internal).map(a => a.address)
+    : [];
+  const dnsSummary = summarizeDnsResolvers(dnsResolvers, boxAddresses);
 
   return (
       <div className="p-4 md:p-6 space-y-6">
@@ -432,6 +440,62 @@ export function SystemInfoContent() {
                         <div className="col-span-full text-center text-gray-400 py-4">No network information available</div>
                     )}
                 </div>
+            </div>
+
+            {/* DNS Resolvers — the box's effective resolver list, labelled.
+                A public resolver here is the #1559 split-horizon trap (breaks
+                *.<domain> SSO resolution after reinstall), so it warns. */}
+            <div className="md:col-span-2 bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
+                <h3 className="text-lg font-medium mb-4 flex items-center gap-2">
+                    <Network size={20} /> DNS Resolvers ({dnsSummary.resolvers.length})
+                </h3>
+
+                {dnsSummary.hasPublicResolver && (
+                    <div className="mb-4 flex items-start gap-2 p-3 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 text-sm">
+                        <AlertTriangle size={18} className="shrink-0 mt-0.5" />
+                        <div>
+                            <div className="font-medium">A public DNS resolver is configured</div>
+                            <div className="text-xs mt-0.5 opacity-90">
+                                Public resolvers don&apos;t know your LAN addresses, so they can silently break
+                                split-horizon resolution of <span className="font-mono">*.&lt;domain&gt;</span> after a
+                                reinstall (SSO logins fail). Point the box at AdGuard / the router instead.
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                <div className="space-y-2">
+                    {dnsSummary.resolvers.map((r, i) => {
+                        const labelStyles: Record<DnsResolverLabel, string> = {
+                            AdGuard: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100',
+                            router: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100',
+                            public: 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-100',
+                            other: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300',
+                        };
+                        return (
+                            <div key={i} className="flex items-center justify-between gap-2 text-sm border border-gray-100 dark:border-gray-800 rounded px-3 py-2">
+                                <span className="font-mono break-all">{r.address}</span>
+                                <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${labelStyles[r.label]}`}>
+                                    {r.label}
+                                </span>
+                            </div>
+                        );
+                    })}
+                    {dnsSummary.resolvers.length === 0 && (
+                        <div className="text-center text-gray-400 py-4">No DNS resolver information available</div>
+                    )}
+                </div>
+
+                {dnsSummary.resolvers.length > 0 && !dnsSummary.hasPublicResolver && (
+                    <div className="mt-3 flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
+                        <ShieldCheck size={14} />
+                        <span>All resolvers are local (AdGuard / router) — split-horizon resolution is safe.</span>
+                    </div>
+                )}
+
+                {dnsResolvers?.source && dnsResolvers.source !== 'unknown' && (
+                    <div className="mt-2 text-[10px] text-gray-400">source: {dnsResolvers.source}</div>
+                )}
             </div>
         </div>
       </div>

--- a/packages/frontend/src/dashboards/_lib/dnsResolvers.test.ts
+++ b/packages/frontend/src/dashboards/_lib/dnsResolvers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { labelResolver, summarizeDnsResolvers } from './dnsResolvers';
+
+describe('labelResolver', () => {
+  it('labels loopback as AdGuard (the box runs AdGuard)', () => {
+    expect(labelResolver('127.0.0.1')).toEqual({ address: '127.0.0.1', label: 'AdGuard', isPublic: false });
+    expect(labelResolver('::1').label).toBe('AdGuard');
+  });
+
+  it("labels the box's own non-internal IP as AdGuard", () => {
+    expect(labelResolver('192.168.178.100', ['192.168.178.100'])).toMatchObject({ label: 'AdGuard', isPublic: false });
+  });
+
+  it('labels RFC1918 LAN addresses as router', () => {
+    expect(labelResolver('192.168.178.1')).toMatchObject({ label: 'router', isPublic: false });
+    expect(labelResolver('10.0.0.1')).toMatchObject({ label: 'router', isPublic: false });
+    expect(labelResolver('172.16.5.4')).toMatchObject({ label: 'router', isPublic: false });
+  });
+
+  it('labels well-known public resolvers as public (the #1559 trap)', () => {
+    for (const ip of ['8.8.8.8', '8.8.4.4', '1.1.1.1', '9.9.9.9', '149.112.112.112']) {
+      expect(labelResolver(ip)).toMatchObject({ label: 'public', isPublic: true });
+    }
+  });
+
+  it('treats an unknown non-private address as public/upstream', () => {
+    expect(labelResolver('203.0.113.7')).toMatchObject({ label: 'public', isPublic: true });
+  });
+
+  it('labels IPv6 unique-local / link-local as router', () => {
+    expect(labelResolver('fd00::1')).toMatchObject({ label: 'router', isPublic: false });
+    expect(labelResolver('fe80::1')).toMatchObject({ label: 'router', isPublic: false });
+  });
+
+  it('labels IPv6 public resolvers as public', () => {
+    expect(labelResolver('2001:4860:4860::8888')).toMatchObject({ label: 'public', isPublic: true });
+  });
+});
+
+describe('summarizeDnsResolvers', () => {
+  it('flags hasPublicResolver when a public resolver is present (the #1559 trap)', () => {
+    const summary = summarizeDnsResolvers({ servers: ['192.168.178.1', '8.8.8.8'], source: 'resolvectl' });
+    expect(summary.hasPublicResolver).toBe(true);
+    expect(summary.resolvers.map(r => r.label)).toEqual(['router', 'public']);
+    expect(summary.source).toBe('resolvectl');
+  });
+
+  it('does not flag when all resolvers are local (AdGuard / router)', () => {
+    const summary = summarizeDnsResolvers(
+      { servers: ['127.0.0.1', '192.168.178.1'], source: 'resolv.conf' },
+      [],
+    );
+    expect(summary.hasPublicResolver).toBe(false);
+    expect(summary.resolvers.map(r => r.label)).toEqual(['AdGuard', 'router']);
+  });
+
+  it('tolerates a missing / empty report', () => {
+    expect(summarizeDnsResolvers(null)).toEqual({ resolvers: [], hasPublicResolver: false, source: 'unknown' });
+    expect(summarizeDnsResolvers({ servers: [] }).resolvers).toHaveLength(0);
+  });
+});

--- a/packages/frontend/src/dashboards/_lib/dnsResolvers.ts
+++ b/packages/frontend/src/dashboards/_lib/dnsResolvers.ts
@@ -1,0 +1,115 @@
+/**
+ * DNS resolver labelling for the System health Networks section.
+ *
+ * The agent reports the box's effective resolver list as raw IPs (read from
+ * `resolvectl status` / `/etc/resolv.conf`). Here we classify each one so the
+ * operator can see at a glance which resolver does what, and — critically —
+ * whether a PUBLIC resolver is configured. A public resolver in the box's
+ * list is the #1559 trap: it silently breaks split-horizon `*.<domain>` SSO
+ * resolution after a reinstall (the box resolves its own subdomains via the
+ * public DNS, which doesn't know the LAN IP). That case must warn.
+ */
+
+export type DnsResolverLabel = 'AdGuard' | 'router' | 'public' | 'other';
+
+export interface LabelledResolver {
+  address: string;
+  label: DnsResolverLabel;
+  /** true for the well-known public resolvers (the #1559 trap) */
+  isPublic: boolean;
+}
+
+export interface DnsResolverSummary {
+  resolvers: LabelledResolver[];
+  /** true when any configured resolver is a public one */
+  hasPublicResolver: boolean;
+  source: string;
+}
+
+/** Well-known public resolvers (Google, Cloudflare, Quad9). */
+const PUBLIC_RESOLVERS = new Set<string>([
+  '8.8.8.8',
+  '8.8.4.4',
+  '1.1.1.1',
+  '1.0.0.1',
+  '9.9.9.9',
+  '149.112.112.112',
+  // IPv6 equivalents
+  '2001:4860:4860::8888',
+  '2001:4860:4860::8844',
+  '2606:4700:4700::1111',
+  '2606:4700:4700::1001',
+  '2620:fe::fe',
+  '2620:fe::9',
+]);
+
+function isLoopback(addr: string): boolean {
+  return addr === '127.0.0.1' || addr.startsWith('127.') || addr === '::1';
+}
+
+/**
+ * RFC1918 / LAN-private ranges — the FritzBox (or any LAN router) lives here.
+ * IPv6 unique-local (fc00::/7) and link-local (fe80::/10) count as LAN too.
+ */
+function isPrivate(addr: string): boolean {
+  if (addr.includes(':')) {
+    const lower = addr.toLowerCase();
+    return (
+      lower.startsWith('fc') ||
+      lower.startsWith('fd') ||
+      lower.startsWith('fe8') ||
+      lower.startsWith('fe9') ||
+      lower.startsWith('fea') ||
+      lower.startsWith('feb')
+    );
+  }
+  const parts = addr.split('.').map(n => parseInt(n, 10));
+  if (parts.length !== 4 || parts.some(n => Number.isNaN(n))) return false;
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+/**
+ * Label a single resolver address.
+ *  - loopback / the box itself → AdGuard (ServiceBay runs AdGuard on the box)
+ *  - well-known public resolver → public (the #1559 trap)
+ *  - RFC1918 / LAN-private → router (the FritzBox)
+ *  - anything else → other
+ *
+ * `boxAddresses` are this node's own non-internal IPs (from `resources.network`);
+ * a resolver matching one of them is the box pointing at its own AdGuard.
+ */
+export function labelResolver(addr: string, boxAddresses: string[] = []): LabelledResolver {
+  if (PUBLIC_RESOLVERS.has(addr)) {
+    return { address: addr, label: 'public', isPublic: true };
+  }
+  if (isLoopback(addr) || boxAddresses.includes(addr)) {
+    return { address: addr, label: 'AdGuard', isPublic: false };
+  }
+  if (isPrivate(addr)) {
+    return { address: addr, label: 'router', isPublic: false };
+  }
+  // A non-private, non-loopback address that isn't a known public resolver is
+  // still effectively a public/upstream resolver from the LAN's point of view.
+  return { address: addr, label: 'public', isPublic: true };
+}
+
+/**
+ * Summarise the raw resolver report into labelled rows + a public-resolver
+ * warning flag. Tolerant of a missing / empty report.
+ */
+export function summarizeDnsResolvers(
+  report: { servers?: string[]; source?: string } | null | undefined,
+  boxAddresses: string[] = [],
+): DnsResolverSummary {
+  const servers = report?.servers ?? [];
+  const resolvers = servers.map(addr => labelResolver(addr, boxAddresses));
+  return {
+    resolvers,
+    hasPublicResolver: resolvers.some(r => r.isPublic),
+    source: report?.source ?? 'unknown',
+  };
+}

--- a/templates/claude-dev/user-guide.md
+++ b/templates/claude-dev/user-guide.md
@@ -1,23 +1,31 @@
 ---
 lucide_icon: "bot"
+category: "Development"
 tagline: "Code against your repos from anywhere — a Claude Code dev box that lives on the home server, no laptop required."
 # claude-dev has no subdomain / proxy host, so there's no "Open" URL.
 # The card renders via the appless path (#1618): the primary action is
 # the web terminal deep-link that attaches to the container's persistent
 # `claude` tmux session (#1617), and the VS Code Remote-SSH handoff is a
 # desktop-only secondary action.
+#
+# The container that `podman play kube` creates is named
+# `<pod>-<container>` = `claude-dev-claude-dev` (pod `claude-dev` +
+# container `claude-dev`), NOT `claude-dev`. The terminal deep-link must
+# target that real container name, or `podman exec` finds no such
+# container (#1681).
 primary_action:
   type: "in_app"
   label: "Open terminal"
-  href: "/terminal?node=Local&container=claude-dev&attach=claude"
+  href: "/terminal?node=Local&container=claude-dev-claude-dev&attach=claude"
   icon: "bot"
 actions:
   # vscode:// hands off to the desktop VS Code app's Remote-SSH. The host
-  # and port can't be baked into this link (they come from the install —
-  # the box's LAN IP and the CLAUDE_DEV_SSH_PORT you set), so the literal
-  # template here is a placeholder; the body documents the real command to
-  # copy. desktop_only defaults true for external_scheme, so the phone UI
-  # hides this button.
+  # and port come from the install (the box's LAN IP and the
+  # CLAUDE_DEV_SSH_PORT you set), so the `HOST`/`PORT` tokens below are
+  # interpolated at render time by the portal card builder (#1682). The
+  # body keeps the copy-the-command fallback for outside-LAN / dyn-DNS.
+  # desktop_only defaults true for external_scheme, so the phone UI hides
+  # this button.
   - type: "external_scheme"
     label: "Open in VS Code (desktop)"
     href: "vscode://vscode-remote/ssh-remote+dev@HOST:PORT/workspace"


### PR DESCRIPTION
## What
Four units across reverse-proxy, install, portal, and health:
- **#1684** forward-auth 403 page now names the required group/role and the signed-in identity instead of a generic LAN-only page (distinguishes an Authelia authorization deny from the actual LAN-restriction case).
- **#1668** reinstall/startup reconciles podman's preserved container DB against installed templates — orphan unmanaged-bundle records (ghost hermes/OSCAR exited-0 pods) are reconciled away.
- **#1681/#1682** Claude Dev portal card: terminal resolves to `claude-dev-claude-dev` and attaches its `claude` tmux session (no silent host-shell fallback); card declares `category: Development`; VS Code href is interpolated with the real box host + `CLAUDE_DEV_SSH_PORT` at render.
- **#1676** System health Networks section surfaces the box's effective DNS resolvers (labelled AdGuard/router/public) and warns when a public resolver (the #1559 trap) is present.

Includes a seal-time fix: `resolveBoxHost` now reads `config.reverseProxy.lanIp` (the field's real location on `AppConfig`); a top-level read passed vitest but failed the pre-push tsc build.

## Why
Closes #1684
Closes #1668
Closes #1681
Closes #1682
Closes #1676

## Risk
Low-medium. #1668 touches the install/runner reconcile path; #1676 adds a read-only health display. Behaviour is unit-tested; real-reinstall reconcile proof is deferred to the next FCoS reinstall.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2145 passed)
- [x] python unittest (agent v4, 24 passed)
- [ ] /verify on FCoS :dev box (#1668 install/runner reconcile + #1676 Networks resolvers UI)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._