### PR TITLE
feat(disk-import): import engine + host-apply + CLI + UI card; portal card sizing; healthcheck block-scalar var fix

### DIFF
--- a/docs/UX_DECISIONS.md
+++ b/docs/UX_DECISIONS.md
@@ -436,6 +436,45 @@ Landed in #1470 (2026-06-01). Closes #1453 (verifySso), #1454 (auto-run post-ins
 
 ---
 
+## Disk-import "Import data" card: review gate + non-blocking actions[]
+
+**Decision.** The disk-import flow (Settings → Sharing → "Import data") is
+**device → scan → review → CONFIRM → apply**. The scan mounts the USB
+**read-only**, sorts everything deterministically, and writes **nothing** — it
+returns a plan + a `sessionId`. The apply route refuses unless it is handed back
+that `sessionId` (a plan scanned in this process) **and** an explicit
+`confirmed: true`. There is no path to apply an unreviewed plan.
+
+**Unavoidable input surfaces as `actions[]`, and never blocks.** Folders the
+classifier can't place (music vs audiobook, an unknown extension) and target
+conflicts (two different files → same path) are surfaced as Diagnose-style
+`actions[]` in the review. Each carries a **safe default** (ambiguous → filed
+under `documents/`; conflict → newer file wins, older parked in `_superseded/`,
+nothing deleted), so the import runs fine if the user resolves none of them. The
+card says so explicitly ("These don't block the import"). This is the UX
+philosophy (`feedback_ux_philosophy`): self-heal/auto-sort silently, ask only for
+the two genuinely unavoidable inputs — *which device* and *the confirm* — and
+treat ambiguity as advisory follow-ups, not a wall.
+
+**Why.** This is the product feature for families migrating off the cloud, run by
+non-experts. A blocking question per ambiguous folder would stall a 50k-file
+import; a silent auto-apply would risk an unreviewed move. The read-only mount +
+explicit confirm gives the same safety as the CLI's review gate (#1696) without a
+wall of prompts.
+
+**Where enforced.**
+- `packages/backend/src/lib/diskImport/service.ts` — the in-process review-gate
+  store (`scanDevice` → `sessionId`; `applyImportPlan` requires it) + `actions[]`
+  derivation.
+- `packages/frontend/src/app/api/system/disk-import/{list-devices,scan,apply}/route.ts`
+  — thin wiring over the service; apply requires `sessionId` + `confirmed: true`.
+- `packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx`
+  — the card; ambiguous items render as a non-blocking advisory list.
+
+Landed in #1697 (disk-import epic #1698; engine #1693, host-apply #1694).
+
+---
+
 ## Maintaining this doc
 
 Add an entry when:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:e2e": "playwright test --config tests/e2e/playwright.config.ts",
     "gen-template-docs": "tsx scripts/gen-template-docs.ts",
     "sb-config-upload": "tsx scripts/sb-config-upload.ts",
+    "disk-import": "tsx scripts/disk-import.ts",
     "check:invariants": "tsx scripts/check-invariants.ts",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages/frontend/src packages/backend/src",
     "check:arch": "npm run check:invariants && npm run check:deps",

--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -97,6 +97,16 @@ SAFE_EXEC_ALLOWLIST = frozenset({
     'mv',            # rename helper (callers validate paths)
     'test',          # exists() probe in the agent executor
     'ping',          # router-DNS probe
+    # Disk-import (#1694) — host-side mount + apply of an approved plan. These
+    # run via safe_exec with argv assembled + validated TS-side in
+    # diskImport/mounter.ts + plan.ts (device paths are /dev/... only; mount is
+    # `-o ro` to a controlled mountpoint; chown is `:<gid>` to the share gid
+    # only — never arbitrary uid:gid; every dest stays under file-share/data/).
+    'lsblk',         # enumerate source USB block devices (lsblk -J)
+    'mount',         # mount the source READ-ONLY (-o ro) — never read-write
+    'umount',        # unmount the source after the import
+    'rsync',         # copy non-photo files into file-share/data/<category>/
+    'chown',         # set group ownership of copied files to the share gid
 })
 AGENT_CLEANUP_MAX_AGE_MINUTES = os.getenv('SERVICEBAY_AGENT_CLEANUP_MAX_AGE_MINUTES')
 try:

--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -107,6 +107,12 @@ SAFE_EXEC_ALLOWLIST = frozenset({
     'umount',        # unmount the source after the import
     'rsync',         # copy non-photo files into file-share/data/<category>/
     'chown',         # set group ownership of copied files to the share gid
+    # Disk-import UI card (#1697) — the scan phase host-walks the read-only
+    # mount and hashes size-collision candidates so the plan can dedup. Both run
+    # via safe_exec with argv assembled TS-side in diskImport/hostScan.ts; paths
+    # are confined to the controlled MOUNT_BASE mountpoint. (`find` is already
+    # allow-listed above for the diagnose enumeration probes.)
+    'sha256sum',     # content hash of source files for dedup (read-only)
 })
 AGENT_CLEANUP_MAX_AGE_MINUTES = os.getenv('SERVICEBAY_AGENT_CLEANUP_MAX_AGE_MINUTES')
 try:

--- a/packages/backend/src/lib/agent/v4/tests/test_agent.py
+++ b/packages/backend/src/lib/agent/v4/tests/test_agent.py
@@ -299,6 +299,19 @@ class TestDnsResolvers(unittest.TestCase):
             result = agent.get_dns_resolvers()
         self.assertEqual(result, {'servers': [], 'source': 'unknown'})
 
+    def test_disk_import_binaries_on_safe_exec_allowlist(self):
+        # #1694 host-side mount + apply uses these via safe_exec (argv is
+        # assembled + validated TS-side in diskImport/mounter.ts + plan.ts).
+        for binary in ('lsblk', 'mount', 'umount', 'rsync', 'chown'):
+            self.assertIn(binary, agent.SAFE_EXEC_ALLOWLIST)
+
+    def test_safe_exec_allowlist_stays_minimal(self):
+        # Guard against speculative additions: the allow-list is binary-only,
+        # so every entry is a real consumer. `bash`/`sh` must never be on it
+        # (that would defeat the structured-argv hardening).
+        for shell in ('bash', 'sh', 'zsh', 'eval'):
+            self.assertNotIn(shell, agent.SAFE_EXEC_ALLOWLIST)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/packages/backend/src/lib/diskImport/catalog.test.ts
+++ b/packages/backend/src/lib/diskImport/catalog.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { ImportCatalog, type CatalogEntry } from './catalog';
+
+const entry = (over: Partial<CatalogEntry> = {}): CatalogEntry => ({
+  sha256: 'a'.repeat(64),
+  target: 'photos/IMG_0001.jpg',
+  sourcePath: '/disk/IMG_0001.jpg',
+  size: 1234,
+  importedAtMs: 1000,
+  ...over,
+});
+
+describe('ImportCatalog — in-memory round-trips', () => {
+  it('upsert → has / get', () => {
+    const cat = new ImportCatalog(':memory:');
+    expect(cat.has(entry().sha256, entry().target)).toBe(false);
+    cat.upsert(entry());
+    expect(cat.has(entry().sha256, entry().target)).toBe(true);
+    expect(cat.get(entry().sha256, entry().target)).toEqual(entry());
+    expect(cat.count()).toBe(1);
+    cat.close();
+  });
+
+  it('upsert is idempotent on (sha256, target) and updates mutable fields', () => {
+    const cat = new ImportCatalog(':memory:');
+    cat.upsert(entry());
+    cat.upsert(entry({ sourcePath: '/disk2/copy.jpg', importedAtMs: 2000 }));
+    expect(cat.count()).toBe(1);
+    expect(cat.get(entry().sha256, entry().target)?.sourcePath).toBe('/disk2/copy.jpg');
+    expect(cat.get(entry().sha256, entry().target)?.importedAtMs).toBe(2000);
+    cat.close();
+  });
+
+  it('findBySha returns all targets for a hash', () => {
+    const cat = new ImportCatalog(':memory:');
+    cat.upsert(entry({ target: 'photos/a.jpg' }));
+    cat.upsert(entry({ target: 'photos/b.jpg' }));
+    const hits = cat.findBySha(entry().sha256);
+    expect(hits.map(h => h.target)).toEqual(['photos/a.jpg', 'photos/b.jpg']);
+    cat.close();
+  });
+
+  it('getByTarget finds the row by destination path', () => {
+    const cat = new ImportCatalog(':memory:');
+    cat.upsert(entry());
+    expect(cat.getByTarget('photos/IMG_0001.jpg')?.sha256).toBe(entry().sha256);
+    expect(cat.getByTarget('photos/missing.jpg')).toBeUndefined();
+    cat.close();
+  });
+});
+
+describe('ImportCatalog — persist + reload from a file path', () => {
+  let tmpDir: string;
+  afterEach(async () => {
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('survives close + reopen at the same path', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'diskimport-cat-'));
+    const dbPath = path.join(tmpDir, 'catalog.db');
+
+    const first = new ImportCatalog(dbPath);
+    first.upsert(entry());
+    first.upsert(entry({ sha256: 'b'.repeat(64), target: 'music/song.flac' }));
+    expect(first.count()).toBe(2);
+    first.close();
+
+    const reopened = new ImportCatalog(dbPath);
+    expect(reopened.count()).toBe(2);
+    expect(reopened.has('b'.repeat(64), 'music/song.flac')).toBe(true);
+    expect(reopened.get(entry().sha256, entry().target)).toEqual(entry());
+    reopened.close();
+  });
+});

--- a/packages/backend/src/lib/diskImport/catalog.ts
+++ b/packages/backend/src/lib/diskImport/catalog.ts
@@ -1,0 +1,127 @@
+// Disk-import engine — persistent catalog (issue #1693).
+//
+// A small SQLite catalog keyed by (sha256, target). It records what has already
+// been imported so a SECOND disk becomes a delta run: anything whose content +
+// destination already exists is skipped. The DB file PATH is a constructor
+// param — no hardcoded host paths, no DATA_DIR coupling. `:memory:` is valid and
+// used by the tests.
+
+import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+
+/** One persisted catalog row. */
+export interface CatalogEntry {
+  /** Content hash (sha256 hex). */
+  sha256: string;
+  /** Target path relative to `file-share/data/` this content was written to. */
+  target: string;
+  /** Original source path (informational — last writer wins). */
+  sourcePath: string;
+  /** File size in bytes. */
+  size: number;
+  /** When this entry was recorded, epoch ms. */
+  importedAtMs: number;
+}
+
+interface CatalogRow {
+  sha256: string;
+  target: string;
+  source_path: string;
+  size: number;
+  imported_at_ms: number;
+}
+
+function rowToEntry(row: CatalogRow): CatalogEntry {
+  return {
+    sha256: row.sha256,
+    target: row.target,
+    sourcePath: row.source_path,
+    size: row.size,
+    importedAtMs: row.imported_at_ms,
+  };
+}
+
+/**
+ * Persistent import catalog. Open with a file path (created if missing) or
+ * `:memory:` for ephemeral use. Close when done so the file handle is released.
+ */
+export class ImportCatalog {
+  private db: BetterSqliteDatabase;
+
+  constructor(dbPath: string) {
+    // Runtime require keeps better-sqlite3 (a native addon) out of any client
+    // bundle, matching the rest of the codebase (logger.ts, rateLimit.ts).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    this.db = new Database(dbPath) as BetterSqliteDatabase;
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS import_catalog (
+        sha256          TEXT NOT NULL,
+        target          TEXT NOT NULL,
+        source_path     TEXT NOT NULL,
+        size            INTEGER NOT NULL,
+        imported_at_ms  INTEGER NOT NULL,
+        PRIMARY KEY (sha256, target)
+      );
+      CREATE INDEX IF NOT EXISTS idx_catalog_sha    ON import_catalog(sha256);
+      CREATE INDEX IF NOT EXISTS idx_catalog_target ON import_catalog(target);
+    `);
+  }
+
+  /** True if this exact content has already been written to this target. */
+  has(sha256: string, target: string): boolean {
+    const row = this.db
+      .prepare('SELECT 1 FROM import_catalog WHERE sha256 = ? AND target = ?')
+      .get(sha256, target);
+    return row !== undefined;
+  }
+
+  /** Look up the entry for (sha256, target), or `undefined` if absent. */
+  get(sha256: string, target: string): CatalogEntry | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM import_catalog WHERE sha256 = ? AND target = ?')
+      .get(sha256, target) as CatalogRow | undefined;
+    return row ? rowToEntry(row) : undefined;
+  }
+
+  /** All catalog rows that hold this content hash (any target). */
+  findBySha(sha256: string): CatalogEntry[] {
+    const rows = this.db
+      .prepare('SELECT * FROM import_catalog WHERE sha256 = ? ORDER BY target ASC')
+      .all(sha256) as CatalogRow[];
+    return rows.map(rowToEntry);
+  }
+
+  /** The catalog row for a given target path, or `undefined`. */
+  getByTarget(target: string): CatalogEntry | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM import_catalog WHERE target = ?')
+      .get(target) as CatalogRow | undefined;
+    return row ? rowToEntry(row) : undefined;
+  }
+
+  /** Insert or update the (sha256, target) entry. Idempotent. */
+  upsert(entry: CatalogEntry): void {
+    this.db
+      .prepare(`
+        INSERT INTO import_catalog (sha256, target, source_path, size, imported_at_ms)
+        VALUES (@sha256, @target, @sourcePath, @size, @importedAtMs)
+        ON CONFLICT(sha256, target) DO UPDATE SET
+          source_path    = excluded.source_path,
+          size           = excluded.size,
+          imported_at_ms = excluded.imported_at_ms
+      `)
+      .run(entry);
+  }
+
+  /** Total number of cataloged entries. */
+  count(): number {
+    const row = this.db.prepare('SELECT COUNT(*) AS n FROM import_catalog').get() as { n: number };
+    return row.n;
+  }
+
+  /** Release the underlying file handle. */
+  close(): void {
+    this.db.close();
+  }
+}

--- a/packages/backend/src/lib/diskImport/categories.ts
+++ b/packages/backend/src/lib/diskImport/categories.ts
@@ -1,0 +1,118 @@
+// Disk-import engine — the fixed canonical category map (issue #1693).
+//
+// This is the ONLY place the category taxonomy lives. The engine sorts files
+// into these categories and nothing else; it holds no service list and asks
+// no service anything. Whatever software watches a folder (`music/` → a music
+// server, `podcasts/` → a podcast app) is irrelevant to the importer.
+//
+// Extending the engine = adding one line here.
+
+import type { Category } from './types';
+
+// All category folders live under `file-share/data/` on the share (lower-case
+// convention, #1018). Folder values below — and every `target` the engine
+// emits — are RELATIVE to that root; the host-apply step (a later issue) joins
+// them onto the real mount point.
+
+export interface CategoryDef {
+  /**
+   * Folder under `file-share/data/`, lower-case (convention #1018), trailing
+   * slash. `documents/` is the base; topic sub-foldering (`documents/<topic>/`)
+   * is decided by the LLM-residue path in a later issue, not here.
+   */
+  folder: string;
+  /**
+   * Extensions (lower-case, no dot) that map to this category by the plain
+   * extension rule. Ambiguous extensions (e.g. `mp3` can be music OR an
+   * audiobook) are resolved by heuristics in classify.ts, not here.
+   */
+  extensions: string[];
+}
+
+/**
+ * The fixed category → folder + extension map. `junk` has no folder (files are
+ * skipped) — its `extensions` list is empty because junk is matched by name
+ * pattern (thumbs.db, .ds_store, *.tmp, caches), see classify.ts.
+ */
+export const CATEGORIES: Record<Category, CategoryDef> = {
+  photos: {
+    folder: 'photos/',
+    // Photos + personal video.
+    extensions: [
+      'jpg', 'jpeg', 'heic', 'heif', 'png', 'gif', 'webp', 'tiff', 'tif', 'bmp',
+      'raw', 'cr2', 'cr3', 'nef', 'arw', 'orf', 'rw2', 'dng',
+      'mov', 'mp4', 'm4v', 'avi', 'mkv', '3gp',
+    ],
+  },
+  music: {
+    folder: 'music/',
+    extensions: ['mp3', 'flac', 'm4a', 'aac', 'ogg', 'opus', 'wav', 'wma', 'aiff'],
+  },
+  audiobooks: {
+    folder: 'audiobooks/',
+    // m4b is unambiguously an audiobook; mp3 audiobooks are reclassified out of
+    // `music` by heuristic / LLM (classify.ts).
+    extensions: ['m4b', 'aax', 'aa'],
+  },
+  podcasts: {
+    folder: 'podcasts/',
+    // No extensions are podcast-exclusive — podcasts are detected by heuristic /
+    // LLM from the (audio) residue, not by extension.
+    extensions: [],
+  },
+  documents: {
+    folder: 'documents/',
+    extensions: [
+      'pdf', 'doc', 'docx', 'txt', 'rtf', 'odt',
+      'epub', 'mobi', 'azw3',
+      'xls', 'xlsx', 'ods', 'csv',
+      'ppt', 'pptx', 'odp',
+      'md', 'html', 'htm',
+    ],
+  },
+  junk: {
+    folder: '',
+    extensions: [],
+  },
+};
+
+/**
+ * Build the extension → category lookup from CATEGORIES. The first category to
+ * claim an extension wins (insertion order of CATEGORIES), so the map above is
+ * authored without overlap. Frozen so callers can't mutate the shared table.
+ */
+function buildExtensionIndex(): ReadonlyMap<string, Category> {
+  const index = new Map<string, Category>();
+  for (const cat of Object.keys(CATEGORIES) as Category[]) {
+    for (const ext of CATEGORIES[cat].extensions) {
+      if (!index.has(ext)) index.set(ext, cat);
+    }
+  }
+  return index;
+}
+
+export const EXTENSION_INDEX: ReadonlyMap<string, Category> = buildExtensionIndex();
+
+/** File-name patterns (lower-case) that mark a file as junk and skipped. */
+export const JUNK_NAMES: ReadonlySet<string> = new Set([
+  'thumbs.db',
+  '.ds_store',
+  'desktop.ini',
+  '.localized',
+]);
+
+/** Junk extensions (lower-case, no dot) — caches and transient files. */
+export const JUNK_EXTENSIONS: ReadonlySet<string> = new Set([
+  'tmp', 'temp', 'cache', 'part', 'crdownload', 'bak',
+]);
+
+/** Path segments (lower-case) that mark a whole subtree as junk/cache. */
+export const JUNK_PATH_SEGMENTS: ReadonlyArray<string> = [
+  '.trash',
+  '.trashes',
+  '.spotlight-v100',
+  '.fseventsd',
+  '@eadir', // Synology thumbnail caches
+  '__macosx',
+  'node_modules',
+];

--- a/packages/backend/src/lib/diskImport/classify.test.ts
+++ b/packages/backend/src/lib/diskImport/classify.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { classifyRecord, type ResidueClassifier } from './classify';
+import { toRecord } from './inventory';
+import type { Category } from './types';
+
+function rec(path: string, extra: Partial<{ size: number; mtimeMs: number }> = {}) {
+  return toRecord({ path, size: extra.size ?? 1000, mtimeMs: extra.mtimeMs ?? 0 });
+}
+
+describe('classifyRecord — extension map', () => {
+  const cases: Array<[string, Category]> = [
+    ['/disk/IMG_0001.JPG', 'photos'],
+    ['/disk/sunset.heic', 'photos'],
+    ['/disk/raw/shot.cr2', 'photos'],
+    ['/disk/clip.mov', 'photos'],
+    ['/disk/holiday.mp4', 'photos'],
+    ['/disk/song.flac', 'music'],
+    ['/disk/track.m4a', 'music'],
+    ['/disk/book.m4b', 'audiobooks'],
+    ['/disk/manual.pdf', 'documents'],
+    ['/disk/notes.txt', 'documents'],
+    ['/disk/novel.epub', 'documents'],
+  ];
+  it.each(cases)('%s → %s', (path, expected) => {
+    expect(classifyRecord(rec(path))).toBe(expected);
+  });
+});
+
+describe('classifyRecord — junk', () => {
+  it('skips known junk names', () => {
+    expect(classifyRecord(rec('/disk/Thumbs.db'))).toBe('junk');
+    expect(classifyRecord(rec('/disk/.DS_Store'))).toBe('junk');
+    expect(classifyRecord(rec('/disk/desktop.ini'))).toBe('junk');
+  });
+  it('skips junk extensions', () => {
+    expect(classifyRecord(rec('/disk/foo.tmp'))).toBe('junk');
+    expect(classifyRecord(rec('/disk/half.part'))).toBe('junk');
+  });
+  it('skips junk path segments / caches', () => {
+    expect(classifyRecord(rec('/disk/@eaDir/song.flac'))).toBe('junk');
+    expect(classifyRecord(rec('/disk/__MACOSX/IMG.jpg'))).toBe('junk');
+    expect(classifyRecord(rec('.Trash/x.pdf'))).toBe('junk');
+  });
+});
+
+describe('classifyRecord — music vs audiobook disambiguation', () => {
+  it('plain mp3 with no signal stays music', () => {
+    expect(classifyRecord(rec('/disk/Artist/Album/01 Song.mp3'))).toBe('music');
+  });
+
+  it('mp3 under an audiobook folder is an audiobook', () => {
+    expect(classifyRecord(rec('/disk/Audiobooks/Dune/ch01.mp3'))).toBe('audiobooks');
+  });
+
+  it('German "Hörbuch" path hint → audiobook', () => {
+    expect(classifyRecord(rec('/disk/Hörbuch/Buch/teil1.mp3'))).toBe('audiobooks');
+  });
+
+  it('ID3 spoken-word genre → audiobook', () => {
+    expect(classifyRecord(rec('/disk/x/track.mp3'), { genre: 'Audiobook' })).toBe('audiobooks');
+  });
+
+  it('chapter naming hint → audiobook', () => {
+    expect(classifyRecord(rec('/disk/x/track.mp3'), { chapterNaming: true })).toBe('audiobooks');
+  });
+
+  it('long average track length → audiobook', () => {
+    expect(classifyRecord(rec('/disk/x/track.mp3'), { avgTrackLengthSec: 45 * 60 })).toBe('audiobooks');
+  });
+
+  it('short average track length stays music', () => {
+    expect(classifyRecord(rec('/disk/x/track.mp3'), { avgTrackLengthSec: 200 })).toBe('music');
+  });
+
+  it('podcast path hint → podcasts', () => {
+    expect(classifyRecord(rec('/disk/Podcasts/show/ep1.mp3'))).toBe('podcasts');
+  });
+
+  it('podcast genre → podcasts', () => {
+    expect(classifyRecord(rec('/disk/x/ep.mp3'), { genre: 'Podcast' })).toBe('podcasts');
+  });
+
+  it('m4b is unconditionally an audiobook (no music refinement)', () => {
+    expect(classifyRecord(rec('/disk/Music/whatever.m4b'))).toBe('audiobooks');
+  });
+});
+
+describe('classifyRecord — residue (LLM seam)', () => {
+  it('returns null for unknown extension with no residue classifier', () => {
+    expect(classifyRecord(rec('/disk/mystery.xyz'))).toBeNull();
+  });
+
+  it('consults the injected residue classifier for unknowns', () => {
+    const residue: ResidueClassifier = {
+      suggest: () => 'documents',
+    };
+    expect(classifyRecord(rec('/disk/mystery.xyz'), {}, residue)).toBe('documents');
+  });
+
+  it('does NOT consult the residue classifier when extension already resolves', () => {
+    const residue: ResidueClassifier = {
+      suggest: () => {
+        throw new Error('should not be called');
+      },
+    };
+    expect(classifyRecord(rec('/disk/song.flac'), {}, residue)).toBe('music');
+  });
+});

--- a/packages/backend/src/lib/diskImport/classify.ts
+++ b/packages/backend/src/lib/diskImport/classify.ts
@@ -1,0 +1,109 @@
+// Disk-import engine — classification (issue #1693).
+//
+// Maps a record → canonical category via the extension index plus deterministic
+// heuristics (music-vs-audiobook). The LLM-residue path is NOT implemented here
+// — this module only exposes the SEAM (a classifier hook interface) that a later
+// issue (#1695, Ollama classifier) plugs into. No LLM is called from here.
+
+import {
+  EXTENSION_INDEX,
+  JUNK_NAMES,
+  JUNK_EXTENSIONS,
+  JUNK_PATH_SEGMENTS,
+} from './categories';
+import type { Category, ImportRecord } from './types';
+
+/**
+ * A hint the heuristic can act on without reading file content. These come from
+ * the path / metadata only (the engine never opens the file). A later step may
+ * enrich them (e.g. ID3 genre, average track length) before re-classifying.
+ */
+export interface ClassifyHints {
+  /** ID3/metadata genre, lower-cased, if the caller extracted one. */
+  genre?: string;
+  /** Average track length in seconds, if known (long → audiobook/podcast). */
+  avgTrackLengthSec?: number;
+  /** Whether the file name / siblings look chapter-numbered (audiobook). */
+  chapterNaming?: boolean;
+}
+
+/**
+ * Optional residue classifier (the LLM seam). When the deterministic rules
+ * can't decide (returns `null`), an implementation of this interface — wired in
+ * a LATER issue — may suggest a category. It is never called from this module;
+ * `classifyRecord` accepts it only as an injected dependency so callers can
+ * pass an Ollama-backed impl without this module importing one.
+ */
+export interface ResidueClassifier {
+  /** Return a category suggestion, or `null` to leave it unclassified. */
+  suggest(record: ImportRecord, hints: ClassifyHints): Category | null;
+}
+
+/** Path segments (lower-cased) that strongly imply an audiobook. */
+const AUDIOBOOK_PATH_HINTS = ['audiobook', 'audio book', 'hörbuch', 'hoerbuch'];
+/** Path segments (lower-cased) that strongly imply a podcast. */
+const PODCAST_PATH_HINTS = ['podcast'];
+/** Genre values (lower-cased) that imply spoken-word, not music. */
+const SPOKEN_GENRES = new Set(['audiobook', 'audio book', 'speech', 'spoken', 'spoken word', 'podcast']);
+
+/** A long track (> 30 min) is far more likely an audiobook chapter than a song. */
+const LONG_TRACK_SEC = 30 * 60;
+
+function isJunk(record: ImportRecord): boolean {
+  if (JUNK_NAMES.has(record.name)) return true;
+  if (record.ext && JUNK_EXTENSIONS.has(record.ext)) return true;
+  const lowerPath = record.sourcePath.replace(/\\/g, '/').toLowerCase();
+  return JUNK_PATH_SEGMENTS.some(seg => lowerPath.includes(`/${seg}/`) || lowerPath.startsWith(`${seg}/`));
+}
+
+/**
+ * Disambiguate an audio file that the extension map placed in `music`. Returns
+ * the refined category. Deterministic and content-free — uses only the path and
+ * any caller-provided hints.
+ */
+function refineAudio(record: ImportRecord, hints: ClassifyHints): Category {
+  const lowerPath = record.sourcePath.replace(/\\/g, '/').toLowerCase();
+
+  if (PODCAST_PATH_HINTS.some(h => lowerPath.includes(h))) return 'podcasts';
+  if (AUDIOBOOK_PATH_HINTS.some(h => lowerPath.includes(h))) return 'audiobooks';
+
+  if (hints.genre) {
+    const g = hints.genre.toLowerCase();
+    if (g.includes('podcast')) return 'podcasts';
+    if (SPOKEN_GENRES.has(g)) return 'audiobooks';
+  }
+
+  if (hints.chapterNaming) return 'audiobooks';
+  if (typeof hints.avgTrackLengthSec === 'number' && hints.avgTrackLengthSec >= LONG_TRACK_SEC) {
+    return 'audiobooks';
+  }
+
+  return 'music';
+}
+
+/**
+ * Classify a record into a canonical category.
+ *
+ * Order: junk → extension index → audio refinement → residue classifier seam.
+ * Returns `null` only when nothing — not even the optional residue classifier —
+ * can decide (e.g. an unknown extension with no LLM hook supplied). A `null`
+ * result is left for the human review gate in a later issue.
+ */
+export function classifyRecord(
+  record: ImportRecord,
+  hints: ClassifyHints = {},
+  residue?: ResidueClassifier,
+): Category | null {
+  if (isJunk(record)) return 'junk';
+
+  const byExt = record.ext ? EXTENSION_INDEX.get(record.ext) : undefined;
+  if (byExt) {
+    // Only the `music` bucket is ambiguous (an mp3 may really be an audiobook
+    // or podcast). m4b/aax etc. already landed in `audiobooks` unambiguously,
+    // and every non-audio extension maps straight through.
+    return byExt === 'music' ? refineAudio(record, hints) : byExt;
+  }
+
+  // Unknown extension — hand to the residue classifier seam if one is wired in.
+  return residue ? residue.suggest(record, hints) : null;
+}

--- a/packages/backend/src/lib/diskImport/dedup.test.ts
+++ b/packages/backend/src/lib/diskImport/dedup.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildPlan, targetFor, type HashResolver } from './dedup';
+import { buildInventory, type ScannedFile } from './inventory';
+import { ImportCatalog } from './catalog';
+import type { ImportPlanItem, ImportRecord } from './types';
+
+const sha = (c: string) => c.repeat(64);
+
+/** Hash resolver driven by a path→hash fixture map. */
+function hasherFrom(map: Record<string, string>): HashResolver {
+  return (r: ImportRecord) => {
+    const h = map[r.sourcePath];
+    if (!h) throw new Error(`no fixture hash for ${r.sourcePath}`);
+    return h;
+  };
+}
+
+function plan(files: ScannedFile[], hashes: Record<string, string>, catalog?: ImportCatalog) {
+  return buildPlan(buildInventory(files), hasherFrom(hashes), { catalog });
+}
+
+function actionOf(items: ImportPlanItem[], sourcePath: string) {
+  return items.find(i => i.record.sourcePath === sourcePath)?.action;
+}
+
+describe('targetFor', () => {
+  it('places files under their category folder with the base name', () => {
+    const r = buildInventory([{ path: '/disk/sub/Photo.JPG', size: 1, mtimeMs: 0 }])[0];
+    expect(targetFor(r, 'photos')).toBe('photos/photo.jpg');
+  });
+  it('junk has no target', () => {
+    const r = buildInventory([{ path: '/disk/x.tmp', size: 1, mtimeMs: 0 }])[0];
+    expect(targetFor(r, 'junk')).toBeNull();
+  });
+});
+
+describe('buildPlan — junk + unique files', () => {
+  it('skips junk and never hashes a unique-sized file', () => {
+    const hashOf = vi.fn<HashResolver>(() => sha('a'));
+    const records = buildInventory([
+      { path: '/disk/a.jpg', size: 100, mtimeMs: 0 },
+      { path: '/disk/b.flac', size: 200, mtimeMs: 0 },
+      { path: '/disk/Thumbs.db', size: 50, mtimeMs: 0 },
+    ]);
+    const result = buildPlan(records, hashOf);
+    expect(actionOf(result.items, '/disk/a.jpg')).toBe('copy');
+    expect(actionOf(result.items, '/disk/b.flac')).toBe('copy');
+    expect(actionOf(result.items, '/disk/Thumbs.db')).toBe('skip-junk');
+    expect(result.conflicts).toHaveLength(0);
+    // Unique sizes → no hashing.
+    expect(hashOf).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildPlan — size→hash dedup within the tree', () => {
+  it('same size + same hash + same target → second is skip-dupe', () => {
+    // Same base name maps to the same target; identical bytes.
+    const files: ScannedFile[] = [
+      { path: '/diskA/song.mp3', size: 5000, mtimeMs: 0 },
+      { path: '/diskB/song.mp3', size: 5000, mtimeMs: 0 },
+    ];
+    const result = plan(files, { '/diskA/song.mp3': sha('a'), '/diskB/song.mp3': sha('a') });
+    // First in sourcePath order copies, the other is a dupe.
+    expect(actionOf(result.items, '/diskA/song.mp3')).toBe('copy');
+    expect(actionOf(result.items, '/diskB/song.mp3')).toBe('skip-dupe');
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it('same size but different hash AND different target → both copy, no conflict', () => {
+    const files: ScannedFile[] = [
+      { path: '/disk/one.mp3', size: 5000, mtimeMs: 0 },
+      { path: '/disk/two.mp3', size: 5000, mtimeMs: 0 },
+    ];
+    const result = plan(files, { '/disk/one.mp3': sha('a'), '/disk/two.mp3': sha('b') });
+    expect(actionOf(result.items, '/disk/one.mp3')).toBe('copy');
+    expect(actionOf(result.items, '/disk/two.mp3')).toBe('copy');
+    expect(result.conflicts).toHaveLength(0);
+  });
+});
+
+describe('buildPlan — conflicts (same target, different content)', () => {
+  it('flags two different files competing for the same target path', () => {
+    const files: ScannedFile[] = [
+      { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
+    ];
+    const result = plan(files, { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('b') });
+    expect(actionOf(result.items, '/diskA/report.pdf')).toBe('copy');
+    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('conflict');
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({
+      target: 'documents/report.pdf',
+      existing: { sourcePath: '/diskA/report.pdf', sha256: sha('a') },
+      incoming: { sourcePath: '/diskB/report.pdf', sha256: sha('b') },
+    });
+  });
+});
+
+describe('buildPlan — catalog delta (cross-run)', () => {
+  it('re-running the same input yields all skip-dupe against the catalog', () => {
+    const cat = new ImportCatalog(':memory:');
+    const files: ScannedFile[] = [
+      { path: '/disk/a.jpg', size: 100, mtimeMs: 0 },
+      { path: '/disk/song.flac', size: 200, mtimeMs: 0 },
+    ];
+    const hashes = { '/disk/a.jpg': sha('a'), '/disk/song.flac': sha('b') };
+
+    // First run: everything copies; record the results into the catalog.
+    const first = plan(files, hashes, cat);
+    for (const item of first.items) {
+      expect(item.action).toBe('copy');
+      cat.upsert({
+        sha256: hashes[item.record.sourcePath as keyof typeof hashes],
+        target: item.target!,
+        sourcePath: item.record.sourcePath,
+        size: item.record.size,
+        importedAtMs: 0,
+      });
+    }
+
+    // Second run over the same disk: all skip-dupe (delta run).
+    const second = plan(files, hashes, cat);
+    expect(second.items.every(i => i.action === 'skip-dupe')).toBe(true);
+    expect(second.conflicts).toHaveLength(0);
+    cat.close();
+  });
+
+  it('different content for an already-cataloged target → conflict', () => {
+    const cat = new ImportCatalog(':memory:');
+    cat.upsert({
+      sha256: sha('a'),
+      target: 'documents/report.pdf',
+      sourcePath: '/old/report.pdf',
+      size: 5000,
+      importedAtMs: 0,
+    });
+    const result = plan(
+      [{ path: '/disk/report.pdf', size: 5000, mtimeMs: 0 }],
+      { '/disk/report.pdf': sha('b') },
+      cat,
+    );
+    expect(actionOf(result.items, '/disk/report.pdf')).toBe('conflict');
+    expect(result.conflicts[0]).toMatchObject({
+      target: 'documents/report.pdf',
+      existing: { sourcePath: '/old/report.pdf', sha256: sha('a') },
+      incoming: { sourcePath: '/disk/report.pdf', sha256: sha('b') },
+    });
+    cat.close();
+  });
+});
+
+describe('buildPlan — determinism', () => {
+  it('produces a stable, source-path-ordered plan', () => {
+    const files: ScannedFile[] = [
+      { path: '/disk/z.jpg', size: 1, mtimeMs: 0 },
+      { path: '/disk/a.flac', size: 2, mtimeMs: 0 },
+      { path: '/disk/m.pdf', size: 3, mtimeMs: 0 },
+    ];
+    const hashes = { '/disk/z.jpg': sha('1'), '/disk/a.flac': sha('2'), '/disk/m.pdf': sha('3') };
+    const a = plan(files, hashes);
+    const b = plan(files.slice().reverse(), hashes);
+    expect(a.items.map(i => i.record.sourcePath)).toEqual(b.items.map(i => i.record.sourcePath));
+    expect(a.items.map(i => i.target)).toEqual(['music/a.flac', 'documents/m.pdf', 'photos/z.jpg']);
+  });
+});

--- a/packages/backend/src/lib/diskImport/dedup.ts
+++ b/packages/backend/src/lib/diskImport/dedup.ts
@@ -1,0 +1,198 @@
+// Disk-import engine — dedup + planning (issue #1693).
+//
+// Builds the final ImportPlan from classified records. Dedup is size→hash:
+// content is hashed ONLY when two files share a size (in-tree) or a target path
+// is already cataloged — so a unique-sized file is never hashed. Same content
+// already at the same target → skip-dupe. Different content competing for the
+// same target → conflict.
+//
+// This module performs NO content reads itself: the hash is supplied by an
+// injected `hashOf` resolver (the host-side caller hashes the bytes; tests pass
+// a fixture map). Junk is skipped. Everything is deterministic.
+
+import { CATEGORIES } from './categories';
+import { classifyRecord, type ClassifyHints, type ResidueClassifier } from './classify';
+import { baseName } from './inventory';
+import type { ImportCatalog } from './catalog';
+import type {
+  Category,
+  Conflict,
+  ImportAction,
+  ImportPlan,
+  ImportPlanItem,
+  ImportRecord,
+} from './types';
+
+/** Resolves a record's content hash (sha256 hex). Called only when needed. */
+export type HashResolver = (record: ImportRecord) => string;
+
+export interface PlanOptions {
+  /** Per-record classification hints (keyed by source path). */
+  hints?: Record<string, ClassifyHints>;
+  /** Optional LLM-residue classifier seam (#1695); never invoked here itself. */
+  residue?: ResidueClassifier;
+  /** Existing catalog for cross-run (delta) dedup. Optional. */
+  catalog?: ImportCatalog;
+  /** Clock for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Map a record to its target path under `file-share/data/`, relative to that
+ * root (e.g. `photos/IMG_0001.jpg`). The file name is preserved; topic
+ * sub-foldering for documents is a later (LLM) concern. `junk` → `null`.
+ */
+export function targetFor(record: ImportRecord, category: Category): string | null {
+  if (category === 'junk') return null;
+  return CATEGORIES[category].folder + baseName(record.sourcePath);
+}
+
+interface Classified {
+  record: ImportRecord;
+  category: Category;
+  target: string | null;
+}
+
+/**
+ * Classify every record and split junk (emitted as skip-junk) from the records
+ * that need dedup. A `null`/undecidable classification falls back to `documents`
+ * — the catch-all bucket — rather than dropping the file silently.
+ */
+function classifyAndSplit(
+  records: ImportRecord[],
+  opts: Pick<PlanOptions, 'hints' | 'residue'>,
+  junkItems: ImportPlanItem[],
+): Classified[] {
+  const { hints = {}, residue } = opts;
+  const keep: Classified[] = [];
+  for (const record of records) {
+    const category = classifyRecord(record, hints[record.sourcePath], residue) ?? 'documents';
+    const target = targetFor(record, category);
+    if (category === 'junk' || target === null) {
+      junkItems.push({ record, category: 'junk', target: null, action: 'skip-junk' });
+    } else {
+      keep.push({ record, category, target });
+    }
+  }
+  return keep;
+}
+
+/**
+ * Build the deterministic import plan from a record inventory.
+ *
+ * Algorithm:
+ *  1. Classify every record (junk skipped, no target).
+ *  2. Group the non-junk records by size — a size with a single member can't be
+ *     a duplicate, so it's never hashed.
+ *  3. For multi-member sizes (and any record whose target is already cataloged),
+ *     resolve the hash and decide: skip-dupe (same hash already at target, in
+ *     this tree or the catalog) / conflict (different hash, same target) / copy.
+ */
+export function buildPlan(
+  records: ImportRecord[],
+  hashOf: HashResolver,
+  opts: PlanOptions = {},
+): ImportPlan {
+  const { catalog } = opts;
+  const items: ImportPlanItem[] = [];
+  const conflicts: Conflict[] = [];
+
+  // 1. Classify; junk is emitted as skip-junk, the rest kept for dedup.
+  const keep = classifyAndSplit(records, opts, items);
+
+  // 2. Group by size to decide what must be hashed.
+  const bySize = new Map<number, Classified[]>();
+  for (const c of keep) {
+    const arr = bySize.get(c.record.size);
+    if (arr) arr.push(c);
+    else bySize.set(c.record.size, [c]);
+  }
+
+  // Hash a record at most once.
+  const hashCache = new Map<string, string>();
+  const hashFor = (record: ImportRecord): string => {
+    if (record.sha256) return record.sha256;
+    const cached = hashCache.get(record.sourcePath);
+    if (cached) return cached;
+    const h = hashOf(record);
+    hashCache.set(record.sourcePath, h);
+    return h;
+  };
+
+  // Track, within this tree, the content hash already claiming each target.
+  const targetOwner = new Map<string, { sha256: string; sourcePath: string }>();
+
+  // 3. Decide each kept record. Iterate in stable (sourcePath) order so the
+  //    first file at a target is the deterministic winner.
+  const ordered = keep
+    .slice()
+    .sort((a, b) =>
+      a.record.sourcePath < b.record.sourcePath ? -1 : a.record.sourcePath > b.record.sourcePath ? 1 : 0,
+    );
+
+  for (const c of ordered) {
+    const target = c.target!;
+    const sizeGroup = bySize.get(c.record.size)!;
+    const catHit = catalog?.getByTarget(target);
+    // Hash only when this size collides in-tree, the target already has an
+    // in-tree owner, or the catalog already holds this target.
+    const mustHash = sizeGroup.length > 1 || targetOwner.has(target) || catHit !== undefined;
+    const action = decide(c, target, mustHash ? hashFor : null, { targetOwner, catalog, conflicts });
+    items.push({ record: c.record, category: c.category, target, action });
+  }
+
+  // Stable output ordering.
+  items.sort((a, b) =>
+    a.record.sourcePath < b.record.sourcePath ? -1 : a.record.sourcePath > b.record.sourcePath ? 1 : 0,
+  );
+
+  return { items, conflicts };
+}
+
+function decide(
+  c: Classified,
+  target: string,
+  hashFor: HashResolver | null,
+  ctx: {
+    targetOwner: Map<string, { sha256: string; sourcePath: string }>;
+    catalog?: ImportCatalog;
+    conflicts: Conflict[];
+  },
+): ImportAction {
+  // No hashing needed → unique file, plain copy, claim the target slot.
+  if (!hashFor) {
+    return 'copy';
+  }
+
+  const sha = hashFor(c.record);
+
+  // Already imported this exact content to this exact target (delta run)?
+  if (ctx.catalog?.has(sha, target)) return 'skip-dupe';
+
+  // A different content already cataloged at this target → conflict.
+  const catHit = ctx.catalog?.getByTarget(target);
+  if (catHit && catHit.sha256 !== sha) {
+    ctx.conflicts.push({
+      target,
+      existing: { sourcePath: catHit.sourcePath, sha256: catHit.sha256 },
+      incoming: { sourcePath: c.record.sourcePath, sha256: sha },
+    });
+    return 'conflict';
+  }
+
+  // In-tree collision at this target?
+  const owner = ctx.targetOwner.get(target);
+  if (owner) {
+    if (owner.sha256 === sha) return 'skip-dupe'; // same bytes, different path
+    ctx.conflicts.push({
+      target,
+      existing: { sourcePath: owner.sourcePath, sha256: owner.sha256 },
+      incoming: { sourcePath: c.record.sourcePath, sha256: sha },
+    });
+    return 'conflict';
+  }
+
+  // First copy to this target — claim it.
+  ctx.targetOwner.set(target, { sha256: sha, sourcePath: c.record.sourcePath });
+  return 'copy';
+}

--- a/packages/backend/src/lib/diskImport/hostExec.ts
+++ b/packages/backend/src/lib/diskImport/hostExec.ts
@@ -1,0 +1,79 @@
+// Disk-import — host-exec seam + share-root path guards (issue #1694).
+//
+// Both the mounter and the plan-applier run host commands through the agent's
+// `safe_exec` path (structured argv, allow-listed binary). They depend only on
+// this thin `SafeExec` function type, so the real wiring (an AgentExecutor's
+// `execSafe`) and the test mocks both satisfy the same shape — and a test can
+// assert the exact argv every call produced.
+
+/** Result of a single `safe_exec` argv invocation. */
+export interface SafeExecResult {
+  stdout: string;
+  stderr: string;
+  /** Process exit code. Non-zero = the command failed (callers check this). */
+  code: number;
+}
+
+/**
+ * Runs one allow-listed binary with an explicit argv (no shell). This is the
+ * ONLY way disk-import touches the host. The implementation rejects (throws) on
+ * a transport/agent error reply — see project memory `agent.sendCommand rejects
+ * on error replies`: callers must NOT treat a thrown EACCES as success.
+ */
+export type SafeExec = (argv: string[], options?: { timeoutMs?: number }) => Promise<SafeExecResult>;
+
+/**
+ * The share data root that every import target lives under, RELATIVE-joined.
+ * Engine `target`s (e.g. `photos/IMG_0001.jpg`) are appended to this. The path
+ * is normalised host-side; this module's guards ensure no target escapes it.
+ */
+export const SHARE_DATA_ROOT = '/mnt/data/stacks/file-share/data';
+
+/** Folder (under the share root) superseded conflict versions are parked in. */
+export const SUPERSEDED_DIR = '_superseded';
+
+/**
+ * Assert a relative `target` (from the engine) stays inside the share data
+ * root, then return the absolute on-disk path. Rejects absolute paths, `..`
+ * traversal, leading slashes, NUL bytes, and any segment that would climb out
+ * of the share — a malicious filename on the source disk must never be able to
+ * make the importer write outside `file-share/data/`.
+ */
+export function resolveShareTarget(relTarget: string): string {
+  return joinUnderRoot(SHARE_DATA_ROOT, relTarget, 'target');
+}
+
+/** Like {@link resolveShareTarget} but for the `_superseded/<date>/...` tree. */
+export function resolveSupersededPath(relPath: string): string {
+  return joinUnderRoot(SHARE_DATA_ROOT, `${SUPERSEDED_DIR}/${relPath}`, 'superseded path');
+}
+
+function joinUnderRoot(root: string, rel: string, label: string): string {
+  if (typeof rel !== 'string' || rel.length === 0) {
+    throw new Error(`disk-import: empty ${label}`);
+  }
+  if (rel.includes('\0')) {
+    throw new Error(`disk-import: NUL byte in ${label}`);
+  }
+  if (rel.startsWith('/')) {
+    throw new Error(`disk-import: absolute ${label} not allowed: ${JSON.stringify(rel)}`);
+  }
+  // Normalise separators and reject any `..` segment outright (don't try to be
+  // clever — a single `..` is a hard refusal).
+  const segments = rel.replace(/\\/g, '/').split('/');
+  for (const seg of segments) {
+    if (seg === '..') {
+      throw new Error(`disk-import: path traversal in ${label}: ${JSON.stringify(rel)}`);
+    }
+  }
+  const clean = segments.filter(s => s !== '' && s !== '.').join('/');
+  if (clean.length === 0) {
+    throw new Error(`disk-import: ${label} resolves to the share root itself: ${JSON.stringify(rel)}`);
+  }
+  const abs = `${root}/${clean}`;
+  // Defence in depth: the assembled absolute path must start with the root.
+  if (abs !== root && !abs.startsWith(`${root}/`)) {
+    throw new Error(`disk-import: ${label} escapes the share root: ${JSON.stringify(rel)}`);
+  }
+  return abs;
+}

--- a/packages/backend/src/lib/diskImport/hostScan.test.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseFindOutput, scanMount, hashSourceFile, hashRecords } from './hostScan';
+import type { SafeExec, SafeExecResult } from './hostExec';
+import type { ImportRecord } from './types';
+
+const ok = (stdout = ''): SafeExecResult => ({ stdout, stderr: '', code: 0 });
+
+function mockExec(
+  byBinary: Record<string, SafeExecResult | ((argv: string[]) => SafeExecResult)> = {},
+): { exec: SafeExec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: SafeExec = vi.fn(async (argv: string[]) => {
+    calls.push(argv);
+    const handler = byBinary[argv[0]];
+    if (handler === undefined) return ok();
+    return typeof handler === 'function' ? handler(argv) : handler;
+  });
+  return { exec, calls };
+}
+
+describe('parseFindOutput', () => {
+  it('parses NUL-separated %p\\t%s\\t%T@ records, mtime sec → ms', () => {
+    const out = parseFindOutput('/mnt/a.jpg\t1024\t1700000000.5\0/mnt/b.txt\t42\t1700000001\0');
+    expect(out).toEqual([
+      { path: '/mnt/a.jpg', size: 1024, mtimeMs: 1700000000500 },
+      { path: '/mnt/b.txt', size: 42, mtimeMs: 1700000001000 },
+    ]);
+  });
+
+  it('tolerates a tab inside the file path (splits on the last two tabs)', () => {
+    const out = parseFindOutput('/mnt/weird\tname.mp3\t500\t1700000000\0');
+    expect(out).toEqual([{ path: '/mnt/weird\tname.mp3', size: 500, mtimeMs: 1700000000000 }]);
+  });
+
+  it('skips empty / malformed records', () => {
+    expect(parseFindOutput('')).toEqual([]);
+    expect(parseFindOutput('garbage-no-tabs\0')).toEqual([]);
+  });
+});
+
+describe('scanMount', () => {
+  it('host-walks the mount with find -type f -printf and returns ScannedFiles', async () => {
+    const { exec, calls } = mockExec({
+      find: ok('/mnt/x/a.jpg\t10\t1700000000\0'),
+    });
+    const files = await scanMount(exec, '/run/servicebay/disk-import/sda1');
+    expect(calls[0][0]).toBe('find');
+    expect(calls[0]).toContain('-type');
+    expect(calls[0]).toContain('f');
+    expect(files).toEqual([{ path: '/mnt/x/a.jpg', size: 10, mtimeMs: 1700000000000 }]);
+  });
+
+  it('refuses an unsafe (non-absolute) mountpoint and never reaches the host', async () => {
+    const { exec, calls } = mockExec();
+    await expect(scanMount(exec, 'relative/path')).rejects.toThrow(/unsafe scan mountpoint/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('throws on a non-zero find exit', async () => {
+    const { exec } = mockExec({ find: { stdout: '', stderr: 'boom', code: 1 } });
+    await expect(scanMount(exec, '/run/servicebay/disk-import/sda1')).rejects.toThrow(/scan walk failed/);
+  });
+});
+
+describe('hashSourceFile', () => {
+  it('returns the sha256 token from sha256sum output', async () => {
+    const hex = 'a'.repeat(64);
+    const { exec, calls } = mockExec({ sha256sum: ok(`${hex}  /mnt/a.jpg\n`) });
+    expect(await hashSourceFile(exec, '/mnt/a.jpg')).toBe(hex);
+    expect(calls[0]).toEqual(['sha256sum', '/mnt/a.jpg']);
+  });
+
+  it('throws on unexpected (non-hex) sha256sum output', async () => {
+    const { exec } = mockExec({ sha256sum: ok('not a hash\n') });
+    await expect(hashSourceFile(exec, '/mnt/a.jpg')).rejects.toThrow(/unexpected sha256sum/);
+  });
+
+  it('throws on a non-zero exit', async () => {
+    const { exec } = mockExec({ sha256sum: { stdout: '', stderr: 'no file', code: 1 } });
+    await expect(hashSourceFile(exec, '/mnt/a.jpg')).rejects.toThrow(/sha256sum failed/);
+  });
+});
+
+describe('hashRecords', () => {
+  it('hashes each record host-side and returns a path→hash map', async () => {
+    const h1 = '1'.repeat(64);
+    const h2 = '2'.repeat(64);
+    const exec: SafeExec = vi.fn(async (argv: string[]) => {
+      const path = argv[1];
+      const hex = path === '/mnt/a' ? h1 : h2;
+      return ok(`${hex}  ${path}\n`);
+    });
+    const records: ImportRecord[] = [
+      { sourcePath: '/mnt/a', size: 1, mtimeMs: 0, ext: '', name: 'a' },
+      { sourcePath: '/mnt/b', size: 1, mtimeMs: 0, ext: '', name: 'b' },
+    ];
+    const map = await hashRecords(exec, records);
+    expect(map.get('/mnt/a')).toBe(h1);
+    expect(map.get('/mnt/b')).toBe(h2);
+  });
+});

--- a/packages/backend/src/lib/diskImport/hostScan.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.ts
@@ -1,0 +1,100 @@
+// Disk-import — host-side scan helpers for the UI card (issue #1697).
+//
+// The backend container cannot see the raw USB mount, so the directory walk and
+// content hashing (for dedup) both run HOST-side via the agent's `safe_exec`
+// path (structured argv, allow-listed binaries — `find` + `sha256sum`). These
+// helpers are the only place the scan phase touches the host, and they only
+// ever READ: the source is mounted `-o ro` (mounter.ts), `find` lists it, and
+// `sha256sum` reads bytes — nothing here writes to the disk.
+//
+// The deterministic engine (inventory/classify/dedup) stays pure and host-free;
+// it consumes the ScannedFile[] this module produces and calls back into
+// `hashSourceFile` (as the dedup `HashResolver`) only for size-collision
+// candidates.
+
+import type { ScannedFile } from './inventory';
+import type { SafeExec } from './hostExec';
+import type { ImportRecord } from './types';
+
+/** A `\0`-free absolute mountpoint we built ourselves (mounter.ts). */
+function assertMountpoint(mountpoint: string): void {
+  if (!mountpoint.startsWith('/') || mountpoint.includes('\0')) {
+    throw new Error(`disk-import: refusing unsafe scan mountpoint: ${JSON.stringify(mountpoint)}`);
+  }
+}
+
+/**
+ * Host-walk `mountpoint` and return a metadata-only ScannedFile list. Uses
+ * `find -type f -printf` with a NUL record separator so file names containing
+ * spaces / newlines / quotes can't corrupt the parse. Each record carries the
+ * absolute source path, size (bytes) and mtime (epoch seconds → ms). No hashing
+ * here — that's deferred to {@link hashSourceFile}, called lazily by dedup.
+ */
+export async function scanMount(exec: SafeExec, mountpoint: string): Promise<ScannedFile[]> {
+  assertMountpoint(mountpoint);
+  // `%p\t%s\t%T@\0` — path, size, mtime (float epoch seconds), then a NUL. The
+  // tab can't appear in `%s`/`%T@`, and the path is the first field, so a tab in
+  // a filename is harmless (we split on the LAST two tabs).
+  const { stdout, code, stderr } = await exec([
+    'find', mountpoint, '-type', 'f', '-printf', '%p\t%s\t%T@\\0',
+  ]);
+  if (code !== 0) {
+    throw new Error(`disk-import: scan walk failed (code ${code}): ${stderr}`);
+  }
+  return parseFindOutput(stdout);
+}
+
+/** Parse the NUL-separated `find -printf '%p\t%s\t%T@\0'` stream. */
+export function parseFindOutput(stdout: string): ScannedFile[] {
+  const out: ScannedFile[] = [];
+  for (const record of stdout.split('\0')) {
+    if (record.length === 0) continue;
+    // Split off the last two tab-separated fields (size, mtime); everything
+    // before them is the path (which may itself contain tabs).
+    const lastTab = record.lastIndexOf('\t');
+    if (lastTab === -1) continue;
+    const sizeTab = record.lastIndexOf('\t', lastTab - 1);
+    if (sizeTab === -1) continue;
+    const path = record.slice(0, sizeTab);
+    const size = Number(record.slice(sizeTab + 1, lastTab));
+    const mtimeSec = Number(record.slice(lastTab + 1));
+    if (!path || !Number.isFinite(size) || !Number.isFinite(mtimeSec)) continue;
+    out.push({ path, size, mtimeMs: Math.round(mtimeSec * 1000) });
+  }
+  return out;
+}
+
+/**
+ * Build a dedup {@link import('./dedup').HashResolver} backed by host-side
+ * `sha256sum` over the read-only mount. dedup only calls this for size-collision
+ * candidates, so the host doesn't hash every file. Synchronous-looking resolver
+ * contract: we pre-hash the candidate set up front (one batched pass) so the
+ * deterministic engine can stay synchronous.
+ */
+export async function hashRecords(
+  exec: SafeExec,
+  records: ImportRecord[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  for (const record of records) {
+    out.set(record.sourcePath, await hashSourceFile(exec, record.sourcePath));
+  }
+  return out;
+}
+
+/** Hash one source file's bytes via host `sha256sum` (read-only). */
+export async function hashSourceFile(exec: SafeExec, sourcePath: string): Promise<string> {
+  if (sourcePath.includes('\0')) {
+    throw new Error('disk-import: NUL byte in source path');
+  }
+  const { stdout, code, stderr } = await exec(['sha256sum', sourcePath]);
+  if (code !== 0) {
+    throw new Error(`disk-import: sha256sum failed (code ${code}): ${stderr}`);
+  }
+  // `sha256sum` prints `<hex>  <path>`; take the first whitespace-delimited token.
+  const hex = stdout.trim().split(/\s+/, 1)[0];
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
+    throw new Error(`disk-import: unexpected sha256sum output: ${JSON.stringify(stdout.slice(0, 80))}`);
+  }
+  return hex;
+}

--- a/packages/backend/src/lib/diskImport/inventory.test.ts
+++ b/packages/backend/src/lib/diskImport/inventory.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { buildInventory, extOf, baseName, toRecord } from './inventory';
+
+describe('extOf', () => {
+  it('lower-cases and strips the dot', () => {
+    expect(extOf('/disk/IMG_0001.JPG')).toBe('jpg');
+    expect(extOf('a/b/song.FLAC')).toBe('flac');
+  });
+  it('treats a leading-dot dotfile as having no extension', () => {
+    expect(extOf('/disk/.DS_Store')).toBe('');
+    expect(extOf('.gitignore')).toBe('');
+  });
+  it('returns empty for no extension', () => {
+    expect(extOf('/disk/README')).toBe('');
+  });
+  it('uses the last dot for multi-dot names', () => {
+    expect(extOf('archive.tar.gz')).toBe('gz');
+  });
+});
+
+describe('baseName', () => {
+  it('handles both separators and lower-cases', () => {
+    expect(baseName('/disk/sub/File.PDF')).toBe('file.pdf');
+    expect(baseName('C:\\Users\\me\\Doc.TXT')).toBe('doc.txt');
+  });
+});
+
+describe('toRecord / buildInventory', () => {
+  it('maps metadata into a record without reading content', () => {
+    const r = toRecord({ path: '/disk/x.mp3', size: 99, mtimeMs: 123 });
+    expect(r).toEqual({
+      sourcePath: '/disk/x.mp3',
+      size: 99,
+      mtimeMs: 123,
+      ext: 'mp3',
+      name: 'x.mp3',
+      sha256: undefined,
+    });
+  });
+  it('preserves a provided hash', () => {
+    const r = toRecord({ path: '/disk/x.mp3', size: 1, mtimeMs: 0, sha256: 'deadbeef' });
+    expect(r.sha256).toBe('deadbeef');
+  });
+  it('sorts the inventory by source path', () => {
+    const inv = buildInventory([
+      { path: '/disk/z', size: 0, mtimeMs: 0 },
+      { path: '/disk/a', size: 0, mtimeMs: 0 },
+    ]);
+    expect(inv.map(r => r.sourcePath)).toEqual(['/disk/a', '/disk/z']);
+  });
+});

--- a/packages/backend/src/lib/diskImport/inventory.ts
+++ b/packages/backend/src/lib/diskImport/inventory.ts
@@ -1,0 +1,67 @@
+// Disk-import engine — inventory (issue #1693).
+//
+// Turns a PROVIDED scanned file list into ImportRecords. This step is
+// metadata-first: it never walks a disk, never reads file contents, and never
+// touches the host. The caller (a later CLI / host-apply issue) does the actual
+// `lsblk`/walk and hands the file list in.
+
+import type { ImportRecord } from './types';
+
+/** A raw scanned file as provided by the (external) disk walker. */
+export interface ScannedFile {
+  /** Path on the imported tree. */
+  path: string;
+  /** Size in bytes. */
+  size: number;
+  /** Last-modified time, epoch milliseconds. */
+  mtimeMs: number;
+  /**
+   * Optional pre-computed content hash (sha256 hex). Usually absent here —
+   * hashing is deferred to the dedup step, which only hashes size-collision
+   * candidates.
+   */
+  sha256?: string;
+}
+
+/**
+ * Extract the lower-cased extension (no leading dot) from a path. A leading-dot
+ * file with no other dot (e.g. `.DS_Store`) has no extension — the dot is part
+ * of the name, not a separator.
+ */
+export function extOf(filePath: string): string {
+  const base = baseName(filePath);
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) return ''; // no dot, or leading-dot dotfile
+  return base.slice(dot + 1).toLowerCase();
+}
+
+/** Lower-cased final path segment, tolerating both `/` and `\` separators. */
+export function baseName(filePath: string): string {
+  const norm = filePath.replace(/\\/g, '/');
+  const trimmed = norm.endsWith('/') ? norm.slice(0, -1) : norm;
+  const slash = trimmed.lastIndexOf('/');
+  return (slash === -1 ? trimmed : trimmed.slice(slash + 1)).toLowerCase();
+}
+
+/** Turn one scanned file into a metadata record. */
+export function toRecord(file: ScannedFile): ImportRecord {
+  return {
+    sourcePath: file.path,
+    size: file.size,
+    mtimeMs: file.mtimeMs,
+    ext: extOf(file.path),
+    name: baseName(file.path),
+    sha256: file.sha256,
+  };
+}
+
+/**
+ * Build the record inventory from a provided scanned file list. Deterministic:
+ * records are returned sorted by source path so a given input always yields the
+ * same ordered plan downstream.
+ */
+export function buildInventory(files: ScannedFile[]): ImportRecord[] {
+  return files
+    .map(toRecord)
+    .sort((a, b) => (a.sourcePath < b.sourcePath ? -1 : a.sourcePath > b.sourcePath ? 1 : 0));
+}

--- a/packages/backend/src/lib/diskImport/mounter.test.ts
+++ b/packages/backend/src/lib/diskImport/mounter.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  listBlockDevices,
+  mountReadOnly,
+  unmount,
+  mountpointFor,
+  assertSafeDevice,
+  MOUNT_BASE,
+} from './mounter';
+import type { SafeExec, SafeExecResult } from './hostExec';
+
+const ok = (stdout = ''): SafeExecResult => ({ stdout, stderr: '', code: 0 });
+
+/**
+ * A SafeExec mock that records argv and dispatches by binary. It mirrors the
+ * real agent.sendCommand contract: an "error reply" is a THROW, not a returned
+ * `{error}` (project memory `agent.sendCommand rejects on error replies`).
+ */
+function mockExec(
+  byBinary: Record<string, SafeExecResult | ((argv: string[]) => SafeExecResult)> = {},
+): { exec: SafeExec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: SafeExec = vi.fn(async (argv: string[]) => {
+    calls.push(argv);
+    const handler = byBinary[argv[0]];
+    if (handler === undefined) return ok();
+    return typeof handler === 'function' ? handler(argv) : handler;
+  });
+  return { exec, calls };
+}
+
+describe('listBlockDevices', () => {
+  it('flattens the lsblk tree, carries removable to children, and skips loop devices', async () => {
+    const tree = {
+      blockdevices: [
+        {
+          name: 'sda', path: '/dev/sda', size: 16000000000, type: 'disk', rm: true,
+          children: [
+            { name: 'sda1', path: '/dev/sda1', size: 15000000000, fstype: 'exfat', label: 'USB', mountpoint: null, type: 'part' },
+          ],
+        },
+        { name: 'loop0', path: '/dev/loop0', size: 1000, type: 'loop' },
+        { name: 'nvme0n1', path: '/dev/nvme0n1', size: 500000000000, fstype: 'ext4', mountpoint: '/', type: 'disk', rm: false },
+      ],
+    };
+    const { exec, calls } = mockExec({ lsblk: ok(JSON.stringify(tree)) });
+
+    const devices = await listBlockDevices(exec);
+
+    // lsblk called with -J -b and read-only fields.
+    expect(calls[0][0]).toBe('lsblk');
+    expect(calls[0]).toContain('-J');
+    expect(calls[0]).toContain('-b');
+
+    const sda1 = devices.find(d => d.path === '/dev/sda1')!;
+    expect(sda1.removable).toBe(true); // inherited from parent sda
+    expect(sda1.fstype).toBe('exfat');
+    expect(sda1.size).toBe(15000000000);
+
+    const root = devices.find(d => d.path === '/dev/nvme0n1')!;
+    expect(root.removable).toBe(false);
+    expect(root.mountpoint).toBe('/');
+
+    // loop device dropped.
+    expect(devices.some(d => d.path === '/dev/loop0')).toBe(false);
+  });
+
+  it('throws on a non-zero lsblk exit (does not swallow the error)', async () => {
+    const { exec } = mockExec({ lsblk: { stdout: '', stderr: 'boom', code: 1 } });
+    await expect(listBlockDevices(exec)).rejects.toThrow(/lsblk failed/);
+  });
+});
+
+describe('mountReadOnly', () => {
+  it('mkdirs the mountpoint then mounts -o ro (never rw) at a controlled path', async () => {
+    const { exec, calls } = mockExec();
+    const mp = await mountReadOnly(exec, '/dev/sda1');
+
+    expect(mp).toBe(`${MOUNT_BASE}/sda1`);
+    const mkdir = calls.find(c => c[0] === 'mkdir')!;
+    expect(mkdir).toEqual(['mkdir', '-p', mp]);
+
+    const mount = calls.find(c => c[0] === 'mount')!;
+    expect(mount).toEqual(['mount', '-o', 'ro', '/dev/sda1', mp]);
+    // Absolutely no read-write mount.
+    expect(mount).not.toContain('rw');
+    expect(mount.join(' ')).not.toMatch(/\brw\b/);
+  });
+
+  it('throws (no mount) on an unsafe device path — shell metacharacters', async () => {
+    const { exec, calls } = mockExec();
+    await expect(mountReadOnly(exec, '/dev/sda1; rm -rf /')).rejects.toThrow(/unsafe device/);
+    await expect(mountReadOnly(exec, '/dev/../etc/shadow')).rejects.toThrow(/unsafe device/);
+    expect(calls).toHaveLength(0); // nothing reached the host
+  });
+
+  it('surfaces a failed mount as a thrown error', async () => {
+    const { exec } = mockExec({ mount: { stdout: '', stderr: 'wrong fs', code: 32 } });
+    await expect(mountReadOnly(exec, '/dev/sda1')).rejects.toThrow(/mount -o ro failed/);
+  });
+});
+
+describe('unmount', () => {
+  it('umounts a path inside MOUNT_BASE', async () => {
+    const { exec, calls } = mockExec();
+    await unmount(exec, `${MOUNT_BASE}/sda1`);
+    expect(calls[0]).toEqual(['umount', `${MOUNT_BASE}/sda1`]);
+  });
+
+  it('refuses to umount a path outside MOUNT_BASE', async () => {
+    const { exec, calls } = mockExec();
+    await expect(unmount(exec, '/')).rejects.toThrow(/outside/);
+    await expect(unmount(exec, '/mnt/data/stacks')).rejects.toThrow(/outside/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('path guards', () => {
+  it('assertSafeDevice accepts /dev nodes and rejects traversal/metacharacters', () => {
+    expect(() => assertSafeDevice('/dev/sda1')).not.toThrow();
+    expect(() => assertSafeDevice('/dev/nvme0n1p3')).not.toThrow();
+    expect(() => assertSafeDevice('/etc/passwd')).toThrow();
+    expect(() => assertSafeDevice('/dev/sda1 --bind')).toThrow();
+    expect(() => assertSafeDevice('/dev/$(whoami)')).toThrow();
+  });
+
+  it('mountpointFor refuses an unsafe explicit name', () => {
+    expect(mountpointFor('/dev/sda1', 'usb0')).toBe(`${MOUNT_BASE}/usb0`);
+    expect(() => mountpointFor('/dev/sda1', '../escape')).toThrow(/unsafe mountpoint/);
+    expect(() => mountpointFor('/dev/sda1', 'a/b')).toThrow(/unsafe mountpoint/);
+  });
+});

--- a/packages/backend/src/lib/diskImport/mounter.ts
+++ b/packages/backend/src/lib/diskImport/mounter.ts
@@ -1,0 +1,178 @@
+// Disk-import — host-side mount + enumerate (issue #1694).
+//
+// The backend container does NOT see the raw USB partition, so block-device
+// enumeration and mounting happen HOST-side via the agent's `safe_exec` path
+// (structured argv, allow-listed binaries — see SAFE_EXEC_ALLOWLIST in
+// agent/v4/agent.py). This module never touches the container filesystem and
+// never runs a shell string.
+//
+// SECURITY: the source disk is ALWAYS mounted read-only (`mount -o ro`). The
+// importer reads from it and never writes back, so a half-trusted USB stick can
+// never be modified by the import — and a bug here can't corrupt the source.
+// Every argv this module builds is validated before it leaves the process:
+// device paths must be `/dev/...` with no shell metacharacters, and the
+// mountpoint must sit under a single controlled base directory.
+
+import type { SafeExec } from './hostExec';
+
+/** One enumerated block device / partition from `lsblk -J`. */
+export interface BlockDevice {
+  /** Kernel name, e.g. `sda1`. */
+  name: string;
+  /** Absolute device node, e.g. `/dev/sda1`. */
+  path: string;
+  /** Size in bytes (lsblk `-b`). */
+  size: number;
+  /** Filesystem type, e.g. `ext4`, `exfat`; `''` if none/unknown. */
+  fstype: string;
+  /** Filesystem label, if any. */
+  label: string;
+  /** Current mountpoint, if mounted; `null` otherwise. */
+  mountpoint: string | null;
+  /** True for a removable device (lsblk `RM`/`HOTPLUG`) — the USB case. */
+  removable: boolean;
+}
+
+/**
+ * The single controlled base directory under which the importer is allowed to
+ * mount a source disk. A mountpoint MUST resolve to a direct child of this base
+ * (no `..`, no nesting that escapes it) — that's the whole of the device-side
+ * write surface, and it's read-only anyway.
+ */
+export const MOUNT_BASE = '/run/servicebay/disk-import';
+
+/** A `/dev` node with no shell metacharacters and no path traversal. */
+const DEVICE_RE = /^\/dev\/[A-Za-z0-9_-]+$/;
+
+/** A single mountpoint segment under MOUNT_BASE — alphanumerics, `-`, `_`. */
+const MOUNT_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+/** Throw if `device` is not a safe `/dev/...` node. */
+export function assertSafeDevice(device: string): void {
+  if (!DEVICE_RE.test(device)) {
+    throw new Error(`disk-import: refusing unsafe device path: ${JSON.stringify(device)}`);
+  }
+}
+
+/**
+ * Resolve a mountpoint for `device` under MOUNT_BASE and assert it can't escape
+ * the base. Returns the absolute mountpoint. `name` defaults to the device's
+ * basename (already validated to be metacharacter-free).
+ */
+export function mountpointFor(device: string, name?: string): string {
+  assertSafeDevice(device);
+  const seg = name ?? device.slice('/dev/'.length);
+  if (!MOUNT_NAME_RE.test(seg)) {
+    throw new Error(`disk-import: refusing unsafe mountpoint name: ${JSON.stringify(seg)}`);
+  }
+  return `${MOUNT_BASE}/${seg}`;
+}
+
+interface LsblkNode {
+  name?: string;
+  path?: string;
+  size?: number | string;
+  fstype?: string | null;
+  label?: string | null;
+  mountpoint?: string | null;
+  mountpoints?: (string | null)[];
+  rm?: boolean | string;
+  hotplug?: boolean | string;
+  type?: string;
+  children?: LsblkNode[];
+}
+
+function asBool(v: boolean | string | undefined): boolean {
+  return v === true || v === '1' || v === 'true';
+}
+
+function asNumber(v: number | string | undefined): number {
+  if (typeof v === 'number') return v;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Map one lsblk node to a BlockDevice (no recursion). */
+function nodeToDevice(node: LsblkNode, removable: boolean): BlockDevice {
+  const name = node.name ?? '';
+  return {
+    name,
+    path: node.path ?? `/dev/${name}`,
+    size: asNumber(node.size),
+    fstype: node.fstype ?? '',
+    label: node.label ?? '',
+    mountpoint: node.mountpoint ?? node.mountpoints?.find(m => m) ?? null,
+    removable,
+  };
+}
+
+/** Flatten the lsblk tree into a flat list, carrying removable down to children. */
+function flatten(nodes: LsblkNode[], parentRemovable: boolean, out: BlockDevice[]): void {
+  for (const node of nodes) {
+    const removable = parentRemovable || asBool(node.rm) || asBool(node.hotplug);
+    const hasPath = Boolean(node.path ?? node.name);
+    if (hasPath && node.type !== 'loop') {
+      out.push(nodeToDevice(node, removable));
+    }
+    if (node.children?.length) flatten(node.children, removable, out);
+  }
+}
+
+/**
+ * Enumerate block devices via `lsblk -J -b -o ...`. Returns a flat list
+ * (partitions included), each tagged with whether it's on a removable bus —
+ * the disk-import UI filters to `removable` partitions with a filesystem.
+ */
+export async function listBlockDevices(exec: SafeExec): Promise<BlockDevice[]> {
+  const { stdout, code, stderr } = await exec([
+    'lsblk', '-J', '-b', '-o', 'NAME,PATH,SIZE,FSTYPE,LABEL,MOUNTPOINT,RM,HOTPLUG,TYPE',
+  ]);
+  if (code !== 0) {
+    throw new Error(`disk-import: lsblk failed (code ${code}): ${stderr}`);
+  }
+  let parsed: { blockdevices?: LsblkNode[] };
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (e) {
+    throw new Error(`disk-import: could not parse lsblk JSON: ${(e as Error).message}`);
+  }
+  const out: BlockDevice[] = [];
+  flatten(parsed.blockdevices ?? [], false, out);
+  return out;
+}
+
+/**
+ * Mount `device` READ-ONLY at a controlled mountpoint under MOUNT_BASE and
+ * return that path. Creates the mountpoint first (`mkdir -p`). The `-o ro` flag
+ * is non-negotiable — there is no read-write code path here by design, so the
+ * source disk is never written.
+ */
+export async function mountReadOnly(
+  exec: SafeExec,
+  device: string,
+  name?: string,
+): Promise<string> {
+  const mountpoint = mountpointFor(device, name);
+  await runOk(exec, ['mkdir', '-p', mountpoint], 'mkdir mountpoint');
+  // `-o ro` only. We never pass a caller-supplied option string — the option
+  // set is a fixed literal so no `rw`/`exec`/`dev` can be smuggled in.
+  await runOk(exec, ['mount', '-o', 'ro', device, mountpoint], 'mount -o ro');
+  return mountpoint;
+}
+
+/** Unmount a mountpoint previously returned by {@link mountReadOnly}. */
+export async function unmount(exec: SafeExec, mountpoint: string): Promise<void> {
+  // Only ever unmount inside our controlled base — never an arbitrary path.
+  if (mountpoint !== MOUNT_BASE && !mountpoint.startsWith(`${MOUNT_BASE}/`)) {
+    throw new Error(`disk-import: refusing to umount path outside ${MOUNT_BASE}: ${mountpoint}`);
+  }
+  await runOk(exec, ['umount', mountpoint], 'umount');
+}
+
+/** Run a safe_exec argv and throw with context on a non-zero exit. */
+async function runOk(exec: SafeExec, argv: string[], what: string): Promise<void> {
+  const { code, stderr } = await exec(argv);
+  if (code !== 0) {
+    throw new Error(`disk-import: ${what} failed (code ${code}): ${stderr}`);
+  }
+}

--- a/packages/backend/src/lib/diskImport/ollama.test.ts
+++ b/packages/backend/src/lib/diskImport/ollama.test.ts
@@ -3,7 +3,7 @@ import { requestLabel } from './ollama';
 
 /** A fetch mock that returns one Ollama generate envelope with `response` = body. */
 function fetchReturning(responseField: unknown, init: { ok?: boolean } = {}) {
-  return vi.fn(async () =>
+  return vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
     ({
       ok: init.ok ?? true,
       json: async () => ({ response: responseField }),

--- a/packages/backend/src/lib/diskImport/ollama.test.ts
+++ b/packages/backend/src/lib/diskImport/ollama.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { requestLabel } from './ollama';
+
+/** A fetch mock that returns one Ollama generate envelope with `response` = body. */
+function fetchReturning(responseField: unknown, init: { ok?: boolean } = {}) {
+  return vi.fn(async () =>
+    ({
+      ok: init.ok ?? true,
+      json: async () => ({ response: responseField }),
+    }) as unknown as Response,
+  );
+}
+
+const ALLOWED = ['music', 'audiobooks', 'podcasts'] as const;
+const req = { prompt: 'classify this', allowed: ALLOWED };
+
+describe('requestLabel — strict JSON parsing', () => {
+  it('valid strict-JSON response → suggestion', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify({ label: 'audiobooks', reason: 'long chapters' }));
+    const out = await requestLabel(req, { fetchImpl });
+    expect(out).toEqual({ label: 'audiobooks', reason: 'long chapters' });
+  });
+
+  it('trims label + tolerates a missing reason', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify({ label: '  music  ' }));
+    const out = await requestLabel(req, { fetchImpl });
+    expect(out).toEqual({ label: 'music', reason: '' });
+  });
+
+  it('label outside the allowed set → ignored (null)', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify({ label: 'movies', reason: 'x' }));
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('malformed (non-JSON) response → ignored (null)', async () => {
+    const fetchImpl = fetchReturning('not json at all {');
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('JSON array (not an object) → ignored (null)', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify(['music']));
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('object with no label → ignored (null)', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify({ reason: 'no label here' }));
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('non-string Ollama response field → ignored (null)', async () => {
+    const fetchImpl = fetchReturning({ label: 'music' });
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('over-long response → ignored (null)', async () => {
+    const fetchImpl = fetchReturning('x'.repeat(5000));
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('requests format:json + stream:false', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify({ label: 'music', reason: '' }));
+    await requestLabel(req, { fetchImpl });
+    const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.format).toBe('json');
+    expect(body.stream).toBe(false);
+  });
+});
+
+describe('requestLabel — graceful fallback (never throws)', () => {
+  it('connection refused → null, no throw', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    });
+    await expect(requestLabel(req, { fetchImpl })).resolves.toBeNull();
+  });
+
+  it('non-OK HTTP status → null', async () => {
+    const fetchImpl = fetchReturning(JSON.stringify({ label: 'music' }), { ok: false });
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+
+  it('timeout / abort → null, no throw', async () => {
+    const fetchImpl = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      // Simulate an abort firing on the request signal.
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+        );
+      });
+    });
+    await expect(requestLabel(req, { fetchImpl, timeoutMs: 5 })).resolves.toBeNull();
+  });
+
+  it('json() that rejects → null', async () => {
+    const fetchImpl = vi.fn(async () =>
+      ({ ok: true, json: async () => { throw new Error('bad body'); } }) as unknown as Response,
+    );
+    expect(await requestLabel(req, { fetchImpl })).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/diskImport/ollama.ts
+++ b/packages/backend/src/lib/diskImport/ollama.ts
@@ -1,0 +1,163 @@
+// Disk-import engine — local-Ollama classifier client (issue #1695).
+//
+// A THIN client to the on-box Ollama (`http://localhost:11434/api/generate`).
+// It is used SPARINGLY and only on the residue that the deterministic rules in
+// classify.ts can't resolve — never on every file. It SUGGESTS a label; it
+// never writes anything. The caller (suggest.ts) routes every suggestion into
+// the review plan for human confirmation.
+//
+// GRACEFUL DEGRADATION is the contract: if Ollama is unreachable (connection
+// refused), slow (timeout), or returns non-conforming output (not strict JSON,
+// or a label outside the allowed set), every entry point here returns `null`
+// ("no suggestion"). NOTHING in this module ever throws into the import flow.
+
+/** Default Ollama generate endpoint on the single-node box. */
+const DEFAULT_ENDPOINT = 'http://localhost:11434/api/generate';
+
+/** A small, fast local model — classification is a cheap labelling task. */
+const DEFAULT_MODEL = 'llama3.2:1b';
+
+/** Hard cap on how long we wait for Ollama before giving up (no suggestion). */
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+/** Cap the model's reply so a runaway generation can't hang the parse. */
+const MAX_RESPONSE_CHARS = 4_000;
+
+export interface OllamaClientOptions {
+  /** Override the generate endpoint (tests / non-default host). */
+  endpoint?: string;
+  /** Override the model tag. */
+  model?: string;
+  /** Per-request timeout in ms. */
+  timeoutMs?: number;
+  /** Injectable fetch (tests). Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * One generation request: a prompt and the closed set of labels the model is
+ * allowed to answer with. The reply MUST be JSON of the shape
+ * `{ "label": <one of labels>, "reason": <short string> }` — anything else is
+ * rejected (→ `null`).
+ */
+export interface LabelRequest {
+  /** The compact, self-contained prompt describing the item to label. */
+  prompt: string;
+  /** The closed set of acceptable labels. A reply outside this set is rejected. */
+  allowed: readonly string[];
+}
+
+/** A validated suggestion: a label from the request's `allowed` set + reasoning. */
+export interface LabelSuggestion {
+  label: string;
+  /** The model's short, human-readable justification (for the review plan). */
+  reason: string;
+}
+
+/**
+ * The Ollama HTTP envelope for a `format: json` generate call. `response` holds
+ * the model's text, which (because we asked for `format: json`) is itself a
+ * JSON document we then parse + validate.
+ */
+interface OllamaGenerateResponse {
+  response?: unknown;
+}
+
+/**
+ * Ask Ollama for a single strict-JSON label. Returns the validated suggestion,
+ * or `null` for ANY failure (unreachable, timeout, malformed/over-long body,
+ * non-JSON `response`, or a label outside `req.allowed`). Never throws.
+ */
+export async function requestLabel(
+  req: LabelRequest,
+  opts: OllamaClientOptions = {},
+): Promise<LabelSuggestion | null> {
+  const {
+    endpoint = DEFAULT_ENDPOINT,
+    model = DEFAULT_MODEL,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    fetchImpl = fetch,
+  } = opts;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      // `format: json` constrains Ollama to emit valid JSON; `stream: false`
+      // gives us one complete envelope instead of a token stream.
+      body: JSON.stringify({
+        model,
+        prompt: buildPrompt(req),
+        format: 'json',
+        stream: false,
+        options: { temperature: 0 },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return null;
+
+    let envelope: OllamaGenerateResponse;
+    try {
+      envelope = (await res.json()) as OllamaGenerateResponse;
+    } catch {
+      return null;
+    }
+
+    return parseSuggestion(envelope.response, req.allowed);
+  } catch {
+    // Connection refused, DNS failure, AbortError (timeout) — all "no suggestion".
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Wrap the caller's prompt with the strict-output contract. Even with
+ * `format: json` set, we restate the schema in-band so a small model is more
+ * likely to emit the exact shape — and we validate the result regardless.
+ */
+function buildPrompt(req: LabelRequest): string {
+  const labels = req.allowed.join(', ');
+  return [
+    req.prompt,
+    '',
+    `Answer with ONLY a JSON object: {"label": "<one of: ${labels}>", "reason": "<short justification>"}.`,
+    `The "label" MUST be exactly one of: ${labels}. Do not invent other labels.`,
+  ].join('\n');
+}
+
+/**
+ * Parse + validate the model's `response` field into a LabelSuggestion. Rejects
+ * (→ `null`): non-string / over-long responses, non-JSON, non-object JSON, a
+ * missing/empty label, or a label outside the allowed set. The `reason` is
+ * optional and coerced to a trimmed string (empty if absent).
+ */
+function parseSuggestion(
+  response: unknown,
+  allowed: readonly string[],
+): LabelSuggestion | null {
+  if (typeof response !== 'string') return null;
+  if (response.length === 0 || response.length > MAX_RESPONSE_CHARS) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const label = typeof obj.label === 'string' ? obj.label.trim() : '';
+  if (!label || !allowed.includes(label)) return null;
+
+  const reason = typeof obj.reason === 'string' ? obj.reason.trim() : '';
+  return { label, reason };
+}

--- a/packages/backend/src/lib/diskImport/plan.test.ts
+++ b/packages/backend/src/lib/diskImport/plan.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyPlan } from './plan';
+import { ImportCatalog } from './catalog';
+import { resolveShareTarget, resolveSupersededPath, type SafeExec, type SafeExecResult } from './hostExec';
+import type { HashResolver } from './dedup';
+import type { ImportPlan, ImportPlanItem, ImportRecord } from './types';
+
+const ok: SafeExecResult = { stdout: '', stderr: '', code: 0 };
+const MOUNT = '/run/servicebay/disk-import/sda1';
+const GID = 7777;
+const FIXED_NOW = Date.UTC(2026, 5, 5); // 2026-06-05
+
+function mockExec(
+  byBinary: Record<string, SafeExecResult | ((argv: string[]) => SafeExecResult)> = {},
+): { exec: SafeExec; calls: string[][] } {
+  const calls: string[][] = [];
+  // Mirrors agent.sendCommand: an error reply is a THROW, not a returned {error}.
+  const exec: SafeExec = vi.fn(async (argv: string[]) => {
+    calls.push(argv);
+    const handler = byBinary[argv[0]];
+    if (handler === undefined) return ok;
+    return typeof handler === 'function' ? handler(argv) : handler;
+  });
+  return { exec, calls };
+}
+
+function record(over: Partial<ImportRecord> = {}): ImportRecord {
+  return { sourcePath: '/song.mp3', size: 100, mtimeMs: 0, ext: 'mp3', name: 'song.mp3', ...over };
+}
+
+function item(over: Partial<ImportPlanItem> = {}): ImportPlanItem {
+  return { record: record(), category: 'music', target: 'music/song.mp3', action: 'copy', ...over };
+}
+
+function planOf(...items: ImportPlanItem[]): ImportPlan {
+  return { items, conflicts: [] };
+}
+
+const hashConst = (h: string): HashResolver => () => h;
+
+function baseOpts(exec: SafeExec, catalog: ImportCatalog, hashOf: HashResolver) {
+  return { exec, mountpoint: MOUNT, catalog, shareGid: GID, hashOf, now: () => FIXED_NOW };
+}
+
+describe('applyPlan — copy + chown', () => {
+  it('rsyncs from the read-only mount into file-share/data and chowns to the share gid only', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const res = await applyPlan(planOf(item()), baseOpts(exec, catalog, hashConst('a'.repeat(64))));
+
+    const dest = resolveShareTarget('music/song.mp3');
+    const rsync = calls.find(c => c[0] === 'rsync')!;
+    expect(rsync).toEqual(['rsync', '-a', `${MOUNT}/song.mp3`, dest]);
+    // Source is under the read-only mount; dest is under the share root.
+    expect(rsync[2].startsWith(MOUNT + '/')).toBe(true);
+    expect(rsync[3].startsWith('/mnt/data/stacks/file-share/data/')).toBe(true);
+
+    const chown = calls.find(c => c[0] === 'chown')!;
+    expect(chown).toEqual(['chown', `:${GID}`, dest]); // group only, never uid, never -R
+    expect(chown).not.toContain('-R');
+    expect(chown[1]).toMatch(/^:\d+$/);
+
+    expect(res.applied).toBe(1);
+    expect(res.items[0].outcome).toBe('copied');
+    expect(catalog.has('a'.repeat(64), 'music/song.mp3')).toBe(true);
+    catalog.close();
+  });
+
+  it('rejects a non-integer / negative share gid before any host I/O', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    await expect(
+      applyPlan(planOf(item()), { ...baseOpts(exec, catalog, hashConst('a'.repeat(64))), shareGid: -1 }),
+    ).rejects.toThrow(/shareGid/);
+    expect(calls).toHaveLength(0);
+    catalog.close();
+  });
+});
+
+describe('applyPlan — conflict routes to _superseded', () => {
+  it('moves the existing target into _superseded/<date>/ before copying the newer file', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const conflict = item({ action: 'conflict', target: 'documents/report.pdf', record: record({ sourcePath: '/report.pdf', name: 'report.pdf', ext: 'pdf' }), category: 'documents' });
+
+    const res = await applyPlan(planOf(conflict), baseOpts(exec, catalog, hashConst('b'.repeat(64))));
+
+    const mv = calls.find(c => c[0] === 'mv')!;
+    const parked = resolveSupersededPath('2026-06-05/documents/report.pdf');
+    expect(mv).toEqual(['mv', resolveShareTarget('documents/report.pdf'), parked]);
+    // Then the newer file is copied in.
+    expect(calls.some(c => c[0] === 'rsync')).toBe(true);
+    expect(res.items[0].outcome).toBe('superseded');
+    catalog.close();
+  });
+});
+
+describe('applyPlan — photos go to Immich, not file-share', () => {
+  it('runs the immich CLI and never rsyncs photos into the share', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const photo = item({ category: 'photos', target: 'photos/IMG_1.jpg', record: record({ sourcePath: '/IMG_1.jpg', name: 'img_1.jpg', ext: 'jpg' }) });
+
+    const res = await applyPlan(planOf(photo), {
+      ...baseOpts(exec, catalog, hashConst('c'.repeat(64))),
+      immich: { serverUrl: 'http://immich:2283', apiKey: 'secret-key' },
+    });
+
+    const podman = calls.find(c => c[0] === 'podman')!;
+    expect(podman).toContain('upload');
+    expect(podman.join(' ')).toContain('IMMICH_INSTANCE_URL=http://immich:2283');
+    // API key passed via env, never bare on argv positionally beyond the -e pair.
+    expect(podman).toContain('IMMICH_API_KEY=secret-key');
+    // No file-share writes for a photo.
+    expect(calls.some(c => c[0] === 'rsync')).toBe(false);
+    expect(res.items[0].outcome).toBe('photo-uploaded');
+    catalog.close();
+  });
+});
+
+describe('applyPlan — resumability', () => {
+  it('an interrupted apply re-run skips files already cataloged (no re-copy)', async () => {
+    const catalog = new ImportCatalog(':memory:');
+    const hashOf = hashConst('d'.repeat(64));
+    const plan = planOf(
+      item({ record: record({ sourcePath: '/a.mp3', name: 'a.mp3' }), target: 'music/a.mp3' }),
+      item({ record: record({ sourcePath: '/b.mp3', name: 'b.mp3' }), target: 'music/b.mp3' }),
+    );
+
+    // First pass: rsync of b.mp3 "fails" (interruption) after a.mp3 is done.
+    let failBNext = true;
+    const exec1 = mockExec({
+      rsync: (argv) => {
+        if (failBNext && argv[2].endsWith('/b.mp3')) return { stdout: '', stderr: 'interrupted', code: 1 };
+        return ok;
+      },
+    });
+    await expect(applyPlan(plan, baseOpts(exec1.exec, catalog, hashOf))).rejects.toThrow(/rsync/);
+    expect(catalog.has('d'.repeat(64), 'music/a.mp3')).toBe(true);
+    expect(catalog.has('d'.repeat(64), 'music/b.mp3')).toBe(false);
+
+    // Second pass: everything succeeds. a.mp3 must be skipped (cataloged),
+    // only b.mp3 is rsynced.
+    failBNext = false;
+    const exec2 = mockExec();
+    const res = await applyPlan(plan, baseOpts(exec2.exec, catalog, hashOf));
+
+    const rsyncs = exec2.calls.filter(c => c[0] === 'rsync').map(c => c[2]);
+    expect(rsyncs).toEqual([`${MOUNT}/b.mp3`]); // a.mp3 NOT re-copied
+    expect(res.items.find(i => i.sourcePath === '/a.mp3')?.outcome).toBe('skipped-cataloged');
+    expect(res.items.find(i => i.sourcePath === '/b.mp3')?.outcome).toBe('copied');
+    expect(catalog.has('d'.repeat(64), 'music/b.mp3')).toBe(true);
+    catalog.close();
+  });
+});
+
+describe('applyPlan — dry run + skips', () => {
+  it('dry-run computes outcomes without touching the host', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const res = await applyPlan(planOf(item()), { ...baseOpts(exec, catalog, hashConst('e'.repeat(64))), dryRun: true });
+    expect(calls).toHaveLength(0);
+    expect(res.applied).toBe(0);
+    expect(res.items[0].outcome).toBe('dry-run');
+    catalog.close();
+  });
+
+  it('skip-junk / skip-dupe items are not copied', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const res = await applyPlan(
+      planOf(
+        item({ action: 'skip-junk', target: null }),
+        item({ action: 'skip-dupe', record: record({ sourcePath: '/dup.mp3', name: 'dup.mp3' }), target: 'music/dup.mp3' }),
+      ),
+      baseOpts(exec, catalog, hashConst('f'.repeat(64))),
+    );
+    expect(calls).toHaveLength(0);
+    expect(res.items.map(i => i.outcome)).toEqual(['skipped-junk', 'skipped-dupe']);
+    catalog.close();
+  });
+});
+
+describe('applyPlan — path traversal is refused', () => {
+  it('a malicious category/filename target cannot escape the share root', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const evil = item({ target: '../../../../etc/cron.d/payload', record: record({ sourcePath: '/x', name: 'x' }) });
+    await expect(applyPlan(planOf(evil), baseOpts(exec, catalog, hashConst('0'.repeat(64))))).rejects.toThrow(/traversal/);
+    // Nothing was written to the host.
+    expect(calls.some(c => c[0] === 'rsync' || c[0] === 'mv' || c[0] === 'chown')).toBe(false);
+    catalog.close();
+  });
+
+  it('resolveShareTarget / resolveSupersededPath reject absolute + traversal inputs', () => {
+    expect(() => resolveShareTarget('/etc/passwd')).toThrow(/absolute/);
+    expect(() => resolveShareTarget('photos/../../escape')).toThrow(/traversal/);
+    // A clean target resolves under the share root.
+    expect(resolveShareTarget('music/ok.mp3')).toBe('/mnt/data/stacks/file-share/data/music/ok.mp3');
+    expect(resolveSupersededPath('2026-06-05/music/ok.mp3')).toBe(
+      '/mnt/data/stacks/file-share/data/_superseded/2026-06-05/music/ok.mp3',
+    );
+  });
+});

--- a/packages/backend/src/lib/diskImport/plan.ts
+++ b/packages/backend/src/lib/diskImport/plan.ts
@@ -1,0 +1,237 @@
+// Disk-import — apply an APPROVED plan to the host (issue #1694).
+//
+// Takes the deterministic ImportPlan (from dedup.ts) the operator approved and
+// realises it on the host, via the agent's `safe_exec` path only:
+//   - non-photos  → `rsync` from the (read-only) mount into
+//                    `file-share/data/<category>/…`
+//   - photos      → `immich` CLI upload (server-side checksum dedup); photos do
+//                    NOT land in file-share.
+//   - conflict    → the superseded version is MOVED to
+//                    `file-share/data/_superseded/<date>/<target>` (nothing is
+//                    deleted), then the newer file is copied in.
+//   - ownership   → each copied file is `chown`ed to the share gid so the
+//                    containers can read it.
+//   - catalog     → every done file is upserted into the catalog, which makes
+//                    the whole apply RESUMABLE: an interrupted run re-runs and
+//                    skips anything already cataloged (same sha+target).
+//
+// SECURITY: every destination path is validated to stay inside
+// `file-share/data/` (resolveShareTarget / resolveSupersededPath); a malicious
+// filename on the source disk can't escape the share. `chown` is restricted to
+// the resolved share gid (`:<gid>`) — never an arbitrary uid, never recursive
+// over an arbitrary path. The source mount is read-only (mounter.ts), so rsync
+// only ever reads from it.
+
+import { ImportCatalog, type CatalogEntry } from './catalog';
+import {
+  resolveShareTarget,
+  resolveSupersededPath,
+  type SafeExec,
+} from './hostExec';
+import type { HashResolver } from './dedup';
+import type { ImportPlan, ImportPlanItem, ImportRecord } from './types';
+
+/** How a single planned item was handled in this apply pass. */
+export type ApplyOutcome =
+  | 'copied'
+  | 'photo-uploaded'
+  | 'superseded'
+  | 'skipped-junk'
+  | 'skipped-dupe'
+  | 'skipped-cataloged'
+  | 'dry-run';
+
+export interface ApplyResultItem {
+  sourcePath: string;
+  target: string | null;
+  outcome: ApplyOutcome;
+}
+
+export interface ApplyResult {
+  items: ApplyResultItem[];
+  /** Count of files actually written/uploaded this pass (excludes skips). */
+  applied: number;
+}
+
+export interface ApplyOptions {
+  exec: SafeExec;
+  /** Absolute mountpoint of the (read-only) source, e.g. from mountReadOnly. */
+  mountpoint: string;
+  /** Catalog for resumability + delta dedup. Required — it's the resume basis. */
+  catalog: ImportCatalog;
+  /**
+   * Numeric gid that owns existing `file-share/data` content (rootless-podman
+   * subgid). Copied files are `chown :<gid>` so containers can read them. Must
+   * be a non-negative integer — never a name, never arbitrary uid:gid.
+   */
+  shareGid: number;
+  /** Resolves a record's sha256 (for the catalog row). Host hashes the bytes. */
+  hashOf: HashResolver;
+  /** Immich apply config; omit to skip the photo pass. */
+  immich?: ImmichConfig;
+  /** Don't touch the host — just compute the outcome set. */
+  dryRun?: boolean;
+  /** Clock for deterministic dates/tests. */
+  now?: () => number;
+}
+
+export interface ImmichConfig {
+  /** Immich server URL, e.g. `http://immich-server:2283`. */
+  serverUrl: string;
+  /** API key for the upload. Passed via env to the CLI container, not argv. */
+  apiKey: string;
+  /** CLI image; defaults to the upstream immich-cli. */
+  image?: string;
+}
+
+const DEFAULT_IMMICH_IMAGE = 'ghcr.io/immich-app/immich-cli';
+
+/** Map epoch-ms to a stable `YYYY-MM-DD` bucket for the _superseded tree. */
+function dateBucket(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** A numeric, non-negative gid (no names, no uid component). */
+function assertShareGid(gid: number): void {
+  if (!Number.isInteger(gid) || gid < 0) {
+    throw new Error(`disk-import: shareGid must be a non-negative integer, got ${JSON.stringify(gid)}`);
+  }
+}
+
+/**
+ * Apply an approved plan. Idempotent + resumable: items already in the catalog
+ * (same sha + target) are skipped without re-copying, so an interrupted apply
+ * can simply be re-run.
+ */
+export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<ApplyResult> {
+  const { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun = false, now = Date.now } = opts;
+  assertShareGid(shareGid);
+
+  const results: ApplyResultItem[] = [];
+  let applied = 0;
+
+  for (const item of plan.items) {
+    const outcome = await applyItem(item, {
+      exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun, now,
+    });
+    results.push({ sourcePath: item.record.sourcePath, target: item.target, outcome });
+    if (outcome === 'copied' || outcome === 'photo-uploaded' || outcome === 'superseded') {
+      applied += 1;
+    }
+  }
+
+  return { items: results, applied };
+}
+
+interface ItemCtx {
+  exec: SafeExec;
+  mountpoint: string;
+  catalog: ImportCatalog;
+  shareGid: number;
+  hashOf: HashResolver;
+  immich?: ImmichConfig;
+  dryRun: boolean;
+  now: () => number;
+}
+
+async function applyItem(item: ImportPlanItem, ctx: ItemCtx): Promise<ApplyOutcome> {
+  if (item.action === 'skip-junk') return 'skipped-junk';
+  if (item.action === 'skip-dupe') return 'skipped-dupe';
+
+  // Photos go to Immich, never into file-share.
+  if (item.category === 'photos') {
+    if (ctx.dryRun) return 'dry-run';
+    await uploadPhoto(item.record, ctx);
+    return 'photo-uploaded';
+  }
+
+  const target = item.target;
+  if (target === null) return 'skipped-junk';
+
+  const sha = ctx.hashOf(item.record);
+
+  // RESUMABILITY: this exact content already at this exact target → done.
+  if (ctx.catalog.has(sha, target)) return 'skipped-cataloged';
+
+  if (ctx.dryRun) return 'dry-run';
+
+  // Validate the destination stays under file-share/data/ BEFORE any host I/O.
+  const dest = resolveShareTarget(target);
+  const src = `${ctx.mountpoint}/${stripLeadingSlash(item.record.sourcePath)}`;
+
+  let outcome: ApplyOutcome = 'copied';
+  if (item.action === 'conflict') {
+    await supersedeExisting(target, ctx);
+    outcome = 'superseded';
+  }
+
+  await copyAndOwn(src, dest, ctx);
+  ctx.catalog.upsert(catalogEntry(sha, target, item.record, ctx.now()));
+  return outcome;
+}
+
+/** rsync the source file into its destination, then chown to the share gid. */
+async function copyAndOwn(src: string, dest: string, ctx: ItemCtx): Promise<void> {
+  const destDir = dest.slice(0, dest.lastIndexOf('/'));
+  await runOk(ctx.exec, ['mkdir', '-p', destDir], 'mkdir dest dir');
+  // `-a` preserves metadata; the source mount is read-only so this only reads
+  // from it. Explicit src/dest argv — no globbing, no `--delete`.
+  await runOk(ctx.exec, ['rsync', '-a', src, dest], 'rsync');
+  // chown to the share GID ONLY (`:<gid>` leaves the uid untouched). Single
+  // file target — never recursive, never an arbitrary path.
+  await runOk(ctx.exec, ['chown', `:${ctx.shareGid}`, dest], 'chown');
+}
+
+/**
+ * Move the file currently at `target` into the dated `_superseded/` tree so the
+ * newer (conflicting) version can take its place — nothing is deleted.
+ */
+async function supersedeExisting(target: string, ctx: ItemCtx): Promise<void> {
+  const current = resolveShareTarget(target);
+  const parked = resolveSupersededPath(`${dateBucket(ctx.now())}/${stripLeadingSlash(target)}`);
+  const parkedDir = parked.slice(0, parked.lastIndexOf('/'));
+  await runOk(ctx.exec, ['mkdir', '-p', parkedDir], 'mkdir superseded dir');
+  await runOk(ctx.exec, ['mv', current, parked], 'mv to _superseded');
+}
+
+/** Upload a single photo file to Immich via the CLI container (checksum dedup). */
+async function uploadPhoto(record: ImportRecord, ctx: ItemCtx): Promise<void> {
+  if (!ctx.immich) {
+    throw new Error('disk-import: photo in plan but no immich config provided');
+  }
+  const { serverUrl, apiKey, image = DEFAULT_IMMICH_IMAGE } = ctx.immich;
+  const src = `${ctx.mountpoint}/${stripLeadingSlash(record.sourcePath)}`;
+  // Mount the source file read-only into the CLI container; pass the API key
+  // via env (-e), never on the argv (so it can't leak into a process listing).
+  await runOk(
+    ctx.exec,
+    [
+      'podman', 'run', '--rm',
+      '-e', `IMMICH_INSTANCE_URL=${serverUrl}`,
+      '-e', `IMMICH_API_KEY=${apiKey}`,
+      '-v', `${src}:/import/${baseOf(src)}:ro`,
+      image, 'upload', '/import',
+    ],
+    'immich upload',
+  );
+}
+
+function catalogEntry(sha: string, target: string, record: ImportRecord, atMs: number): CatalogEntry {
+  return { sha256: sha, target, sourcePath: record.sourcePath, size: record.size, importedAtMs: atMs };
+}
+
+function stripLeadingSlash(p: string): string {
+  return p.replace(/^\/+/, '');
+}
+
+function baseOf(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i === -1 ? p : p.slice(i + 1);
+}
+
+async function runOk(exec: SafeExec, argv: string[], what: string): Promise<void> {
+  const { code, stderr } = await exec(argv);
+  if (code !== 0) {
+    throw new Error(`disk-import: ${what} failed (code ${code}): ${stderr}`);
+  }
+}

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  listImportDevices,
+  scanDevice,
+  applyImportPlan,
+  __clearSessions,
+} from './service';
+import type { SafeExec, SafeExecResult } from './hostExec';
+
+const ok = (stdout = ''): SafeExecResult => ({ stdout, stderr: '', code: 0 });
+
+/**
+ * SafeExec mock that dispatches by binary and records every argv. Mirrors the
+ * agent contract (an error reply is a throw, not a returned `{error}`).
+ */
+function mockExec(
+  byBinary: Record<string, SafeExecResult | ((argv: string[]) => SafeExecResult)> = {},
+): { exec: SafeExec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: SafeExec = vi.fn(async (argv: string[]) => {
+    calls.push(argv);
+    const handler = byBinary[argv[0]];
+    if (handler === undefined) return ok();
+    return typeof handler === 'function' ? handler(argv) : handler;
+  });
+  return { exec, calls };
+}
+
+beforeEach(() => __clearSessions());
+
+describe('listImportDevices', () => {
+  it('keeps only removable partitions that carry a filesystem', async () => {
+    const tree = {
+      blockdevices: [
+        {
+          name: 'sda', path: '/dev/sda', size: 16e9, type: 'disk', rm: true,
+          children: [
+            { name: 'sda1', path: '/dev/sda1', size: 15e9, fstype: 'exfat', label: 'USB', type: 'part' },
+          ],
+        },
+        { name: 'nvme0n1', path: '/dev/nvme0n1', size: 5e11, fstype: 'ext4', mountpoint: '/', type: 'disk', rm: false },
+      ],
+    };
+    const { exec } = mockExec({ lsblk: ok(JSON.stringify(tree)) });
+    const devices = await listImportDevices(exec);
+
+    // sda1 (removable, has fstype) kept; nvme (not removable) + bare sda (no fstype) dropped.
+    expect(devices.map(d => d.path)).toEqual(['/dev/sda1']);
+    expect(devices[0].display).toContain('USB');
+    expect(devices[0].display).toContain('exfat');
+  });
+});
+
+/** A find listing of three files: two photos + one unknown-extension residue. */
+const FIND_OUT = [
+  '/mnt/photos/IMG_0001.jpg\t1000\t1700000000',
+  '/mnt/photos/IMG_0002.jpg\t2000\t1700000001',
+  '/mnt/misc/mystery.xyz\t3000\t1700000002',
+].join('\0') + '\0';
+
+describe('scanDevice', () => {
+  it('mounts RO, scans, builds a plan, and unmounts — writing nothing to file-share', async () => {
+    const { exec, calls } = mockExec({ find: ok(FIND_OUT) });
+    const result = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    // Mounted read-only and unmounted; no rsync/chown (no apply happened).
+    expect(calls.some(c => c[0] === 'mount' && c.includes('ro'))).toBe(true);
+    expect(calls.some(c => c[0] === 'umount')).toBe(true);
+    expect(calls.some(c => c[0] === 'rsync')).toBe(false);
+    expect(calls.some(c => c[0] === 'chown')).toBe(false);
+
+    expect(result.sessionId).toBeTruthy();
+    expect(result.totalFiles).toBe(3);
+    expect(result.totalBytes).toBe(6000);
+    expect(result.categories.find(c => c.category === 'photos')?.files).toBe(2);
+  });
+
+  it('surfaces the unclassifiable residue as a non-blocking ambiguous-folder action', async () => {
+    const { exec } = mockExec({ find: ok(FIND_OUT) });
+    const result = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    const ambiguous = result.actions.filter(a => a.kind === 'ambiguous-folder');
+    expect(ambiguous).toHaveLength(1);
+    expect(ambiguous[0].subject).toBe('/mnt/misc/mystery.xyz');
+    expect(ambiguous[0].defaultOutcome).toMatch(/documents/);
+
+    // The plan is complete despite the ambiguity — the residue still lands
+    // (defaulted to documents), so the action annotates rather than blocks.
+    expect(result.totalFiles).toBe(3);
+    expect(result.categories.some(c => c.category === 'documents')).toBe(true);
+  });
+});
+
+describe('applyImportPlan — the review gate', () => {
+  it('refuses to apply without a scanned session (no host write)', async () => {
+    const { exec, calls } = mockExec();
+    await expect(
+      applyImportPlan({ exec, sessionId: 'forged-id', shareGid: 1024 }),
+    ).rejects.toThrow(/no reviewed plan/);
+    // Nothing reached the host — no mount, no rsync.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('applies the exact plan from a prior scan and consumes the session', async () => {
+    const { exec, calls } = mockExec({ find: ok(FIND_OUT) });
+    const scan = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    // No immich config wired → photos throw on apply; use a residue-only disk to
+    // prove the copy path runs. Re-scan a docs-only listing.
+    __clearSessions();
+    const docOut = '/mnt/docs/report.pdf\t10\t1700000000\0';
+    const { exec: exec2, calls: calls2 } = mockExec({
+      find: ok(docOut),
+      sha256sum: argv => ok(`${'c'.repeat(64)}  ${argv[1]}\n`),
+    });
+    const scan2 = await scanDevice({ exec: exec2, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    const result = await applyImportPlan({ exec: exec2, sessionId: scan2.sessionId, shareGid: 1024 });
+
+    // The pdf was copied + chowned to the share gid.
+    expect(calls2.some(c => c[0] === 'rsync')).toBe(true);
+    expect(calls2.some(c => c[0] === 'chown' && c[1] === ':1024')).toBe(true);
+    expect(result.applied).toBe(1);
+
+    // Session is one-shot: a second apply with the same id is refused.
+    await expect(
+      applyImportPlan({ exec: exec2, sessionId: scan2.sessionId, shareGid: 1024 }),
+    ).rejects.toThrow(/no reviewed plan/);
+
+    // (scan from the first disk is unrelated — keeps the lint happy.)
+    expect(scan.sessionId).not.toBe(scan2.sessionId);
+  });
+});

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -102,7 +102,7 @@ describe('applyImportPlan — the review gate', () => {
   });
 
   it('applies the exact plan from a prior scan and consumes the session', async () => {
-    const { exec, calls } = mockExec({ find: ok(FIND_OUT) });
+    const { exec } = mockExec({ find: ok(FIND_OUT) });
     const scan = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
 
     // No immich config wired → photos throw on apply; use a residue-only disk to

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -1,0 +1,306 @@
+// Disk-import — UI-card orchestration service (issue #1697).
+//
+// The thin layer the three API routes (`list-devices` / `scan` / `apply`) wire
+// to. It owns NO new import logic: it sequences the existing engine
+// (inventory → classify → dedup → plan, #1693), the host mount/apply (#1694) and
+// the host-side scan helpers (hostScan.ts) into the device → scan → review →
+// confirm → apply flow the card drives.
+//
+// THE REVIEW GATE (same safety as the CLI): `scanDevice` produces a plan and a
+// session token, but writes NOTHING. `applyImportPlan` refuses unless it is
+// handed back the token of a plan that was scanned in THIS process and not yet
+// applied — there is no way to apply an unreviewed plan. Ambiguous folders and
+// conflicts surface as Diagnose-style `actions[]`; they annotate the review,
+// they do NOT block the rest of the plan (the deterministic plan is complete and
+// applicable regardless — the actions are advisory follow-ups).
+
+import { randomUUID } from 'node:crypto';
+
+import { ImportCatalog } from './catalog';
+import { buildInventory } from './inventory';
+import { buildPlan, type HashResolver } from './dedup';
+import { classifyRecord } from './classify';
+import { listBlockDevices, mountReadOnly, unmount, type BlockDevice } from './mounter';
+import { hashRecords, hashSourceFile, scanMount } from './hostScan';
+import { applyPlan, type ApplyResult, type ImmichConfig } from './plan';
+import type { SafeExec } from './hostExec';
+import type { Category, ImportPlan, ImportRecord } from './types';
+
+/** A removable partition the card can offer as an import source. */
+export interface ImportDevice extends BlockDevice {
+  /** Human-friendly label for the picker (`SANDISK (28.7 GB, exfat)`). */
+  display: string;
+}
+
+/** Per-category rollup shown in the review. */
+export interface CategorySummary {
+  category: Category;
+  files: number;
+  bytes: number;
+  copy: number;
+  skipDupe: number;
+  conflict: number;
+}
+
+/**
+ * A Diagnose-style action: an UNAVOIDABLE decision surfaced for review. It is
+ * advisory — the deterministic plan already has a safe default, so leaving an
+ * action unresolved does NOT block apply. Mirrors the diagnose probe `actions[]`
+ * shape so the card can render it with the existing component.
+ */
+export interface ImportAction {
+  id: string;
+  kind: 'ambiguous-folder' | 'conflict';
+  /** One-line, plain-language description of the decision. */
+  label: string;
+  /** The file / folder / target the action is about. */
+  subject: string;
+  /** What happens if the user does nothing (the safe default). */
+  defaultOutcome: string;
+}
+
+/** The review payload the card shows between scan and confirm. */
+export interface ScanResult {
+  /** Opaque token that authorises a later apply of THIS reviewed plan. */
+  sessionId: string;
+  device: string;
+  totalFiles: number;
+  totalBytes: number;
+  categories: CategorySummary[];
+  /** Unavoidable decisions for review — advisory, non-blocking. */
+  actions: ImportAction[];
+}
+
+export interface ScanOptions {
+  exec: SafeExec;
+  device: string;
+  /** Catalog DB path (resume + cross-disk delta dedup). */
+  catalogPath: string;
+}
+
+export interface ApplyOptions {
+  exec: SafeExec;
+  /** The token from a prior {@link scanDevice} — REQUIRED. The review gate. */
+  sessionId: string;
+  /** Numeric gid that owns file-share data; copied files are chown'd to it. */
+  shareGid: number;
+  /** Immich config for the photo pass; omit to skip photos. */
+  immich?: ImmichConfig;
+}
+
+/** One stored, reviewed-but-not-applied scan. The apply gate keys off this. */
+interface ScanSession {
+  device: string;
+  plan: ImportPlan;
+  hashes: Map<string, string>;
+  catalogPath: string;
+}
+
+// In-process review-gate store. A plan can only be applied via the same backend
+// process that scanned it — a forged/replayed sessionId can't conjure a plan.
+const SESSIONS = new Map<string, ScanSession>();
+
+/**
+ * Enumerate removable partitions that carry a filesystem — the only things the
+ * card offers as an import source (a whole-disk node or a bare partition with no
+ * fstype isn't importable).
+ */
+export async function listImportDevices(exec: SafeExec): Promise<ImportDevice[]> {
+  const devices = await listBlockDevices(exec);
+  return devices
+    .filter(d => d.removable && d.fstype !== '')
+    .map(d => ({ ...d, display: describeDevice(d) }));
+}
+
+function describeDevice(d: BlockDevice): string {
+  const name = d.label || d.name;
+  return `${name} (${formatBytes(d.size)}, ${d.fstype})`;
+}
+
+/**
+ * Mount the device READ-ONLY, host-walk it, run the deterministic pipeline, and
+ * return the review payload + a session token. Writes NOTHING to the host: the
+ * source is `-o ro` and the catalog is opened read-only-in-effect (we only read
+ * it for delta dedup here; nothing is upserted until apply). The mount is always
+ * unmounted before returning, even on error.
+ */
+export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
+  const { exec, device, catalogPath } = opts;
+  const mountpoint = await mountReadOnly(exec, device);
+  try {
+    const files = await scanMount(exec, mountpoint);
+    const records = buildInventory(files);
+
+    // Pre-hash only the size-collision candidates host-side, then hand dedup a
+    // synchronous resolver over the resulting map (the engine stays sync).
+    const candidates = sizeCollisionCandidates(records);
+    const hashes = await hashRecords(exec, candidates);
+    const hashOf: HashResolver = record => {
+      const h = hashes.get(record.sourcePath);
+      if (h === undefined) {
+        throw new Error(`disk-import: missing pre-computed hash for ${record.sourcePath}`);
+      }
+      return h;
+    };
+
+    const catalog = new ImportCatalog(catalogPath);
+    let plan: ImportPlan;
+    try {
+      plan = buildPlan(records, hashOf, { catalog });
+    } finally {
+      catalog.close();
+    }
+
+    const sessionId = randomUUID();
+    SESSIONS.set(sessionId, { device, plan, hashes, catalogPath });
+
+    return {
+      sessionId,
+      device,
+      totalFiles: plan.items.length,
+      totalBytes: plan.items.reduce((sum, i) => sum + i.record.size, 0),
+      categories: summarizeCategories(plan),
+      actions: buildActions(plan, records),
+    };
+  } finally {
+    // Always release the read-only mount; a failed scan must not leave it held.
+    await unmount(exec, mountpoint).catch(() => {});
+  }
+}
+
+/**
+ * Apply a previously-scanned plan. REQUIRES a valid `sessionId` from
+ * {@link scanDevice} — this is the review gate: there is no path to apply a plan
+ * that wasn't scanned + reviewed in this process. Resumable (catalog-backed); the
+ * session is consumed (one apply per review) on success.
+ */
+export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> {
+  const { exec, sessionId, shareGid, immich } = opts;
+  const session = SESSIONS.get(sessionId);
+  if (!session) {
+    throw new Error('disk-import: no reviewed plan for this session — scan + review before applying');
+  }
+
+  // Re-mount read-only for the apply pass (the scan unmounted it).
+  const mountpoint = await mountReadOnly(exec, session.device);
+  const catalog = new ImportCatalog(session.catalogPath);
+  try {
+    // applyPlan writes a catalog row (keyed by sha) for EVERY copied/superseded
+    // item, so it needs a hash for each — not just the size-collision set the
+    // scan pre-hashed. Top up the map host-side for the to-be-written items
+    // (the source is mounted read-only) so the sync resolver below never misses.
+    const hashes = new Map(session.hashes);
+    for (const item of session.plan.items) {
+      const writes = item.action === 'copy' || item.action === 'conflict';
+      if (writes && item.category !== 'photos' && !hashes.has(item.record.sourcePath)) {
+        hashes.set(item.record.sourcePath, await hashSourceFile(exec, item.record.sourcePath));
+      }
+    }
+    const hashOf: HashResolver = record => {
+      const h = hashes.get(record.sourcePath);
+      if (h === undefined) {
+        throw new Error(`disk-import: missing hash for ${record.sourcePath}`);
+      }
+      return h;
+    };
+
+    const result = await applyPlan(session.plan, {
+      exec,
+      mountpoint,
+      catalog,
+      shareGid,
+      hashOf,
+      immich,
+    });
+    SESSIONS.delete(sessionId); // one apply per reviewed plan
+    return result;
+  } finally {
+    catalog.close();
+    await unmount(exec, mountpoint).catch(() => {});
+  }
+}
+
+/** Test seam: drop all in-memory sessions. */
+export function __clearSessions(): void {
+  SESSIONS.clear();
+}
+
+/** Records whose size is shared with another record — the only dedup candidates. */
+function sizeCollisionCandidates(records: ImportRecord[]): ImportRecord[] {
+  const counts = new Map<number, number>();
+  for (const r of records) counts.set(r.size, (counts.get(r.size) ?? 0) + 1);
+  return records.filter(r => (counts.get(r.size) ?? 0) > 1);
+}
+
+function summarizeCategories(plan: ImportPlan): CategorySummary[] {
+  const byCat = new Map<Category, CategorySummary>();
+  for (const item of plan.items) {
+    const s = byCat.get(item.category) ?? {
+      category: item.category,
+      files: 0,
+      bytes: 0,
+      copy: 0,
+      skipDupe: 0,
+      conflict: 0,
+    };
+    s.files += 1;
+    s.bytes += item.record.size;
+    if (item.action === 'copy') s.copy += 1;
+    else if (item.action === 'skip-dupe') s.skipDupe += 1;
+    else if (item.action === 'conflict') s.conflict += 1;
+    byCat.set(item.category, s);
+  }
+  return [...byCat.values()].sort((a, b) => (a.category < b.category ? -1 : 1));
+}
+
+/**
+ * Derive the review `actions[]`. Two sources of UNAVOIDABLE input:
+ *   - conflicts: two different files want the same target (one is parked in
+ *     `_superseded/` by default — the action lets the user pick the keeper);
+ *   - ambiguous folders: a record the deterministic classifier couldn't place
+ *     (it defaulted to `documents`; the action lets the user re-file it).
+ * Each action carries its safe `defaultOutcome` — the plan applies fine if the
+ * user resolves none of them, so they never block the flow.
+ */
+function buildActions(plan: ImportPlan, records: ImportRecord[]): ImportAction[] {
+  const actions: ImportAction[] = [];
+
+  for (const c of plan.conflicts) {
+    actions.push({
+      id: `conflict:${c.target}`,
+      kind: 'conflict',
+      label: `Two different files both map to ${c.target}`,
+      subject: c.target,
+      defaultOutcome: 'Keep the newer file; the older one is parked in _superseded/ (nothing deleted).',
+    });
+  }
+
+  // A record the deterministic rules couldn't classify (no extension match, no
+  // residue classifier) fell through to `documents` in the plan — flag it so the
+  // user can re-file ambiguous media / docs. classifyRecord(record) === null is
+  // exactly the undecidable residue (#1695's review target).
+  for (const record of records) {
+    if (classifyRecord(record) === null) {
+      actions.push({
+        id: `ambiguous:${record.sourcePath}`,
+        kind: 'ambiguous-folder',
+        label: `Couldn't auto-sort ${record.name}`,
+        subject: record.sourcePath,
+        defaultOutcome: 'Filed under documents/ — open to re-file it (e.g. music vs audiobook).',
+      });
+    }
+  }
+
+  return actions;
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}

--- a/packages/backend/src/lib/diskImport/suggest.test.ts
+++ b/packages/backend/src/lib/diskImport/suggest.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as suggestModule from './suggest';
+import {
+  suggestAmbiguousMedia,
+  suggestDocumentTopic,
+  DOCUMENT_TOPICS,
+  type ReviewSuggestion,
+} from './suggest';
+import * as ollama from './ollama';
+
+// The suggestion paths consult the Ollama client (ollama.ts). We mock that
+// client so these tests assert the WIRING + the review-plan contract, never a
+// real HTTP call.
+vi.mock('./ollama', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./ollama')>();
+  return { ...actual, requestLabel: vi.fn() };
+});
+
+const requestLabel = vi.mocked(ollama.requestLabel);
+
+beforeEach(() => {
+  requestLabel.mockReset();
+});
+
+describe('suggestAmbiguousMedia — review-plan suggestion only', () => {
+  it('valid label → a ReviewSuggestion (advisory, never an applied category)', async () => {
+    requestLabel.mockResolvedValue({ label: 'audiobooks', reason: 'long chapters, numbered' });
+    const out = await suggestAmbiguousMedia({
+      folder: '/disk/Dune',
+      sampleNames: ['ch01.mp3', 'ch02.mp3'],
+      avgTrackLengthSec: 2400,
+    });
+    expect(out).toEqual<ReviewSuggestion>({
+      kind: 'ambiguous-media',
+      subject: '/disk/Dune',
+      suggestion: 'audiobooks',
+      reason: 'long chapters, numbered',
+    });
+    // The result is a plain suggestion record — it carries no plan item, no
+    // target path, nothing that could be applied directly.
+    expect(out).not.toHaveProperty('target');
+    expect(out).not.toHaveProperty('action');
+  });
+
+  it('Ollama unreachable (null) → null, degrades gracefully', async () => {
+    requestLabel.mockResolvedValue(null);
+    const out = await suggestAmbiguousMedia({ folder: '/disk/x', sampleNames: ['a.mp3'] });
+    expect(out).toBeNull();
+  });
+
+  it('passes a closed media label set to the client', async () => {
+    requestLabel.mockResolvedValue(null);
+    await suggestAmbiguousMedia({ folder: '/disk/x', sampleNames: ['a.mp3'] });
+    expect(requestLabel.mock.calls[0][0].allowed).toEqual(['music', 'audiobooks', 'podcasts']);
+  });
+});
+
+describe('suggestDocumentTopic — review-plan suggestion only', () => {
+  it('valid topic → a ReviewSuggestion keyed to the file', async () => {
+    requestLabel.mockResolvedValue({ label: 'steuer', reason: 'tax assessment letter' });
+    const out = await suggestDocumentTopic({
+      sourcePath: '/disk/scan_2023.pdf',
+      textHead: 'Finanzamt Bescheid Einkommensteuer 2023',
+    });
+    expect(out).toEqual<ReviewSuggestion>({
+      kind: 'document-topic',
+      subject: '/disk/scan_2023.pdf',
+      suggestion: 'steuer',
+      reason: 'tax assessment letter',
+    });
+  });
+
+  it('malformed/no suggestion (null) routes to no-suggestion, never crashes', async () => {
+    requestLabel.mockResolvedValue(null);
+    await expect(
+      suggestDocumentTopic({ sourcePath: '/disk/mystery.pdf' }),
+    ).resolves.toBeNull();
+  });
+
+  it('passes the closed DOCUMENT_TOPICS set to the client', async () => {
+    requestLabel.mockResolvedValue(null);
+    await suggestDocumentTopic({ sourcePath: '/disk/x.pdf' });
+    expect(requestLabel.mock.calls[0][0].allowed).toBe(DOCUMENT_TOPICS);
+  });
+});
+
+describe('advisory-only invariant', () => {
+  it('a suggestion never exposes an apply/write surface', async () => {
+    requestLabel.mockResolvedValue({ label: 'music', reason: 'short pop tracks' });
+    const media = await suggestAmbiguousMedia({ folder: '/disk/Hits', sampleNames: ['01.mp3'] });
+    // Only the four advisory fields exist — nothing that mutates a plan.
+    expect(Object.keys(media ?? {}).sort()).toEqual(['kind', 'reason', 'subject', 'suggestion']);
+  });
+
+  it('the module exposes no apply/write function', () => {
+    const exported = Object.keys(suggestModule);
+    expect(exported.some((n) => /apply|write|commit|mutat/i.test(n))).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/diskImport/suggest.ts
+++ b/packages/backend/src/lib/diskImport/suggest.ts
@@ -1,0 +1,152 @@
+// Disk-import engine — LLM suggestion paths feeding the REVIEW PLAN (issue #1695).
+//
+// Two paths that consult the local Ollama classifier (ollama.ts) on the residue
+// the deterministic rules in classify.ts can't resolve:
+//   1. Ambiguous media   — a folder the music-vs-audiobook heuristic left
+//                          undecided → music | audiobooks | podcasts.
+//   2. Document foldering — for the `documents` category, a topic subfolder
+//                          (vertraege | steuer | reisen | arbeit | gesundheit | …).
+//
+// CONTRACT — the classifier is ADVISORY ONLY:
+//   * Every suggestion is returned as a ReviewSuggestion and belongs in the
+//     review plan (e.g. an `ambiguous.tsv` the human resolves per folder).
+//     NOTHING here mutates an ImportPlanItem, writes a target, or changes a
+//     record's category. The classifier proposes; the human-approved plan
+//     decides. There is no apply path in this module.
+//   * Ollama is consulted only when a determinstic answer is absent (the caller
+//     gates on the heuristic residue / the documents category). A pure
+//     heuristic hit never reaches the LLM.
+//   * If Ollama yields no valid suggestion (unreachable, timeout, malformed),
+//     the function returns `null` — no suggestion, no throw. Degrade gracefully.
+
+import { requestLabel, type LabelSuggestion, type OllamaClientOptions } from './ollama';
+import type { Category } from './types';
+
+/** Which residue path produced a suggestion (for the review-plan grouping). */
+export type SuggestionKind = 'ambiguous-media' | 'document-topic';
+
+/**
+ * One advisory entry destined for the review plan. It is a SUGGESTION, never an
+ * applied decision — the human resolves it (accept / override) per folder before
+ * anything is written.
+ */
+export interface ReviewSuggestion {
+  kind: SuggestionKind;
+  /** The folder (media) or file (document) the suggestion is about. */
+  subject: string;
+  /**
+   * For `ambiguous-media`: a Category (`music` | `audiobooks` | `podcasts`).
+   * For `document-topic`: a topic subfolder name (e.g. `steuer`).
+   */
+  suggestion: string;
+  /** The model's short justification, surfaced to the human in the review plan. */
+  reason: string;
+}
+
+/** The candidate media categories the LLM may pick from for ambiguous audio. */
+const MEDIA_LABELS: readonly Category[] = ['music', 'audiobooks', 'podcasts'];
+
+/**
+ * The closed set of document topic folders. The model must pick one of these —
+ * a free-text topic would be unparseable downstream. `sonstiges` is the
+ * catch-all so the model always has a valid answer.
+ */
+export const DOCUMENT_TOPICS: readonly string[] = [
+  'vertraege',
+  'steuer',
+  'reisen',
+  'arbeit',
+  'gesundheit',
+  'finanzen',
+  'wohnen',
+  'sonstiges',
+];
+
+/** A compact signature of an ambiguous media folder — metadata only, no bytes. */
+export interface MediaFolderSignature {
+  /** The folder name / path the human will see in the review plan. */
+  folder: string;
+  /** A few sample file or track names from the folder. */
+  sampleNames: string[];
+  /** ID3/metadata genres seen in the folder, if any were extracted. */
+  genres?: string[];
+  /** Average track length in seconds across the folder, if known. */
+  avgTrackLengthSec?: number;
+}
+
+/** A compact signature of a document — filename, path, and a cheap text head. */
+export interface DocumentSignature {
+  /** The file the suggestion is about (shown in the review plan). */
+  sourcePath: string;
+  /** First KB or so of extracted text (PDF/text), if the caller pulled it. */
+  textHead?: string;
+}
+
+/**
+ * Suggest a media category for a folder the heuristic left ambiguous. Returns a
+ * ReviewSuggestion (for the review plan) or `null` (Ollama gave no valid
+ * answer). NEVER applies the category to any record — advisory only.
+ */
+export async function suggestAmbiguousMedia(
+  sig: MediaFolderSignature,
+  opts?: OllamaClientOptions,
+): Promise<ReviewSuggestion | null> {
+  const result = await requestLabel(
+    { prompt: buildMediaPrompt(sig), allowed: MEDIA_LABELS },
+    opts,
+  );
+  return toReview('ambiguous-media', sig.folder, result);
+}
+
+/**
+ * Suggest a topic subfolder for a document already classified into `documents`.
+ * Returns a ReviewSuggestion (for the review plan) or `null`. Advisory only —
+ * the suggested topic is never written into a target path here.
+ */
+export async function suggestDocumentTopic(
+  sig: DocumentSignature,
+  opts?: OllamaClientOptions,
+): Promise<ReviewSuggestion | null> {
+  const result = await requestLabel(
+    { prompt: buildDocumentPrompt(sig), allowed: DOCUMENT_TOPICS },
+    opts,
+  );
+  return toReview('document-topic', sig.sourcePath, result);
+}
+
+/** Lift a validated LabelSuggestion into a review-plan ReviewSuggestion. */
+function toReview(
+  kind: SuggestionKind,
+  subject: string,
+  result: LabelSuggestion | null,
+): ReviewSuggestion | null {
+  if (!result) return null;
+  return { kind, subject, suggestion: result.label, reason: result.reason };
+}
+
+function buildMediaPrompt(sig: MediaFolderSignature): string {
+  const lines = [
+    'Classify this audio folder. Decide if it is music, an audiobook, or a podcast.',
+    `Folder name: ${sig.folder}`,
+    `Sample track/file names: ${sig.sampleNames.join('; ') || '(none)'}`,
+  ];
+  if (sig.genres && sig.genres.length > 0) {
+    lines.push(`ID3 genres present: ${sig.genres.join(', ')}`);
+  }
+  if (typeof sig.avgTrackLengthSec === 'number') {
+    lines.push(`Average track length: ${Math.round(sig.avgTrackLengthSec)} seconds`);
+  }
+  return lines.join('\n');
+}
+
+function buildDocumentPrompt(sig: DocumentSignature): string {
+  const lines = [
+    'Suggest the best topic folder for this document from the allowed list.',
+    `File path: ${sig.sourcePath}`,
+  ];
+  if (sig.textHead && sig.textHead.trim().length > 0) {
+    // Keep it cheap — only the first chunk of text is ever sent.
+    lines.push(`Text excerpt: ${sig.textHead.trim().slice(0, 1024)}`);
+  }
+  return lines.join('\n');
+}

--- a/packages/backend/src/lib/diskImport/types.ts
+++ b/packages/backend/src/lib/diskImport/types.ts
@@ -1,0 +1,70 @@
+// Disk-import engine — shared types.
+//
+// Pure data shapes for the deterministic core of the disk-import feature
+// (issue #1693). No I/O lives here.
+
+/** A canonical category a file can be sorted into. `junk` means "skip". */
+export type Category =
+  | 'photos'
+  | 'music'
+  | 'audiobooks'
+  | 'podcasts'
+  | 'documents'
+  | 'junk';
+
+/**
+ * One scanned file, metadata-only. The inventory step produces these from a
+ * provided file list — the engine never reads file contents or walks a disk.
+ */
+export interface ImportRecord {
+  /** Source path on the imported tree, as scanned. */
+  sourcePath: string;
+  /** File size in bytes. */
+  size: number;
+  /** Last-modified time, epoch milliseconds. */
+  mtimeMs: number;
+  /** Lower-cased extension WITHOUT the leading dot (e.g. `jpg`), `''` if none. */
+  ext: string;
+  /** Lower-cased base file name (e.g. `thumbs.db`). */
+  name: string;
+  /**
+   * Content hash (sha256, hex). Optional — the inventory step is
+   * metadata-first, so this is filled in later (by dedup, when a hash is
+   * actually needed to disambiguate same-size candidates).
+   */
+  sha256?: string;
+}
+
+/** The action the plan assigns to a record. */
+export type ImportAction = 'copy' | 'skip-junk' | 'skip-dupe' | 'conflict';
+
+/** One planned entry: a record, where it goes, and what to do with it. */
+export interface ImportPlanItem {
+  record: ImportRecord;
+  category: Category;
+  /**
+   * Target path relative to `file-share/data/` (e.g. `photos/IMG_0001.jpg`),
+   * or `null` for junk (nothing is written).
+   */
+  target: string | null;
+  action: ImportAction;
+}
+
+/**
+ * Two distinct files (different content) that resolve to the same target
+ * path. The importer must not silently overwrite — these surface for review.
+ */
+export interface Conflict {
+  /** The shared target path the colliding files both map to. */
+  target: string;
+  /** The record already accounted for (in-tree winner or catalog entry). */
+  existing: { sourcePath: string; sha256: string };
+  /** The record that collides with it. */
+  incoming: { sourcePath: string; sha256: string };
+}
+
+/** The full deterministic output of a run over a scanned file list. */
+export interface ImportPlan {
+  items: ImportPlanItem[];
+  conflicts: Conflict[];
+}

--- a/packages/backend/src/lib/health/serviceHealthcheck.test.ts
+++ b/packages/backend/src/lib/health/serviceHealthcheck.test.ts
@@ -121,6 +121,37 @@ port: "{{LDAP_PORT}}"
     expect(r.ok).toBe(true);
   });
 
+  it('permissive (default): accepts an unquoted block-scalar `{{VAR}}` tcp port (#1688)', () => {
+    // Unquoted, yaml.load mangles `{{VAR}}` into an object — the permissive
+    // bypass must still recognise it as a placeholder.
+    const r = parseHealthcheckYaml(`
+kind: tcp
+host: localhost
+port: {{GATEKEEPER_PORT}}
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.config.port).toBeUndefined();
+  });
+
+  it('non-permissive: a real numeric tcp port still parses', () => {
+    const r = parseHealthcheckYaml(
+      'kind: tcp\nhost: localhost\nport: 445',
+      { permissive: false },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.config.port).toBe(445);
+  });
+
+  it('permissive (default): accepts an unquoted block-scalar `{{VAR}}` http url (#1688)', () => {
+    const r = parseHealthcheckYaml(`
+kind: http
+url: {{HEALTH_URL}}
+`);
+    expect(r.ok).toBe(true);
+  });
+
   it('strict: rejects un-resolved `{{VAR}}` placeholders in url', () => {
     const r = parseHealthcheckYaml(
       'url: not-a-url-{{X}}\ninterval: 30s',

--- a/packages/backend/src/lib/health/serviceHealthcheck.ts
+++ b/packages/backend/src/lib/health/serviceHealthcheck.ts
@@ -67,6 +67,27 @@ const DEFAULT_STARTUP_TIMEOUT_MS = 300_000;
 
 const MUSTACHE_RE = /\{\{.*?\}\}/;
 
+/**
+ * Recognise a `{{VAR}}` placeholder that survived `yaml.load`.
+ *
+ * An unquoted block-scalar value like `port: {{VAR}}` is valid YAML flow
+ * syntax: `{{VAR}: null}` — a single-key mapping whose key is itself the
+ * mapping `{VAR: null}`. `js-yaml` stringifies that object key via
+ * `String(key)`, yielding `{ '[object Object]': null }`. So a plain string
+ * Mustache match never fires (the value is an object, not a string) and the
+ * permissive bypass becomes dead code. Detect that signature here so an
+ * unquoted `{{VAR}}` placeholder passes permissive validation the same as
+ * the quoted `"{{VAR}}"` form. (#1688)
+ */
+function isMustachePlaceholder(value: unknown): boolean {
+  if (typeof value === 'string') return MUSTACHE_RE.test(value);
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const keys = Object.keys(value as Record<string, unknown>);
+    return keys.length === 1 && keys[0] === '[object Object]';
+  }
+  return false;
+}
+
 /** Parse duration scalars like `60s`, `2m`, `500ms`. Bare numbers
  *  default to seconds (matches the readiness parser's ergonomic rule). */
 function parseDuration(value: unknown): number | null {
@@ -144,6 +165,10 @@ function parseHttpHealthcheck(obj: Record<string, unknown>, errors: string[], pe
     return undefined;
   }
   if (typeof urlRaw !== 'string' || urlRaw.trim() === '') {
+    // A bare unquoted `url: {{VAR}}` survives yaml.load as an object, not a
+    // string — accept it permissively (resolved at runtime), like the tcp
+    // port path. (#1688)
+    if (permissive && isMustachePlaceholder(urlRaw)) return undefined;
     errors.push(`field \`url\` must be a non-empty string; got ${JSON.stringify(urlRaw)}`);
     return undefined;
   }
@@ -176,7 +201,7 @@ function parseTcpHealthcheck(obj: Record<string, unknown>, errors: string[], per
   } else {
     const p = asInt(portRaw);
     if (p === null) {
-      if (!permissive || typeof portRaw !== 'string' || !MUSTACHE_RE.test(portRaw)) {
+      if (!permissive || !isMustachePlaceholder(portRaw)) {
         errors.push(`field \`port\` must be a positive integer; got ${JSON.stringify(portRaw)}`);
       }
     } else {

--- a/packages/backend/src/lib/portal/serviceStatus.test.ts
+++ b/packages/backend/src/lib/portal/serviceStatus.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/lib/health/store', () => ({
   HealthStore: { getLastResult: (id: string) => getLastResult(id) },
 }));
 
-import { deriveCardStatus, hostFromUrl, resolveCardStatus } from './services';
+import { deriveCardStatus, hostFromUrl, resolveCardStatus, weight, sizeTierFromWeight } from './services';
 
 describe('deriveCardStatus (#1654)', () => {
   it('is unknown when there is no signal', () => {
@@ -55,6 +55,63 @@ describe('deriveCardStatus (#1654)', () => {
     expect(deriveCardStatus({ twinReady: true, domainOk: true })).toEqual({ status: 'ok' });
     expect(deriveCardStatus({ domainOk: true })).toEqual({ status: 'ok' });
     expect(deriveCardStatus({ twinReady: true })).toEqual({ status: 'ok' });
+  });
+});
+
+describe('weight + sizeTierFromWeight (#1700)', () => {
+  const input = (over: Partial<Parameters<typeof weight>[0]> = {}) => ({
+    hasPrimary: false,
+    secondaryActions: [],
+    setupAssets: [],
+    manualPairing: [],
+    recommendedApps: [],
+    ...over,
+  });
+
+  it('scores 0 for a card with no affordances', () => {
+    expect(weight(input())).toBe(0);
+  });
+
+  it('counts a primary affordance (Open URL / primaryAction) as 1', () => {
+    expect(weight(input({ hasPrimary: true }))).toBe(1);
+  });
+
+  it('sums every actionable affordance class', () => {
+    const w = weight(input({
+      hasPrimary: true,
+      secondaryActions: [{}, {}],
+      setupAssets: [{}],
+      manualPairing: [{}],
+      recommendedApps: [{}, {}, {}],
+    }));
+    // 1 + 2 + 1 + 1 + 3
+    expect(w).toBe(8);
+  });
+
+  it('maps weight ≤ 1 to compact', () => {
+    expect(sizeTierFromWeight(0)).toBe('compact');
+    expect(sizeTierFromWeight(1)).toBe('compact');
+  });
+
+  it('maps weight 2–3 to regular', () => {
+    expect(sizeTierFromWeight(2)).toBe('regular');
+    expect(sizeTierFromWeight(3)).toBe('regular');
+  });
+
+  it('maps weight ≥ 4 to feature', () => {
+    expect(sizeTierFromWeight(4)).toBe('feature');
+    expect(sizeTierFromWeight(9)).toBe('feature');
+  });
+
+  it('a bare "Open" card is compact; an asset+apps-rich card is feature', () => {
+    const bare = sizeTierFromWeight(weight(input({ hasPrimary: true })));
+    expect(bare).toBe('compact');
+    const rich = sizeTierFromWeight(weight(input({
+      hasPrimary: true,
+      setupAssets: [{}, {}],
+      recommendedApps: [{}, {}],
+    })));
+    expect(rich).toBe('feature');
   });
 });
 

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -89,9 +89,64 @@ export interface PortalCard {
   /** Optional short reason for a non-ok status. Kept generic — the portal
    *  is anonymous-readable (LAN), so this carries no sensitive detail. */
   statusReason?: string;
+  /** Coarse width tier (#1700), derived server-side from the count of
+   *  actionable affordances ({@link weight}) — NOT from body/tagline
+   *  length. Drives the card's column span on the portal grid so an
+   *  action-rich card renders wider than a bare "Open" card; height stays
+   *  content-driven. The client stays dumb (a literal-class lookup). */
+  sizeTier: PortalCardSizeTier;
 }
 
 export type PortalCardStatus = 'ok' | 'degraded' | 'down' | 'unknown';
+
+/** Card width tier (#1700). `compact` (weight ≤ 1) / `regular` (2–3) /
+ *  `feature` (≥ 4). Maps to a fixed column span in the portal grid. */
+export type PortalCardSizeTier = 'compact' | 'regular' | 'feature';
+
+/** The actionable-affordance fields {@link weight} scores. Each counts an
+ *  *actual thing the operator can do* in the card — a primary
+ *  action/Open URL, secondary buttons, setup assets (QR/deeplink/profile/
+ *  app install), manual-pairing steps, and recommended apps. Body and
+ *  tagline length are deliberately excluded. */
+export interface CardWeightInput {
+  /** True when the card has a primary affordance — an Open URL or an
+   *  explicit `primaryAction`. Counts as 1. */
+  hasPrimary: boolean;
+  secondaryActions: unknown[];
+  setupAssets: unknown[];
+  manualPairing: unknown[];
+  recommendedApps: unknown[];
+}
+
+/**
+ * Score a card's objective importance (#1700) by the count of actionable
+ * affordances it carries — explicitly NOT body/tagline length. Pure — no
+ * I/O — so it's unit-testable in isolation (mirrors {@link deriveCardStatus}).
+ *
+ *   weight = (has a primary action ? 1 : 0)
+ *          + secondaryActions + setupAssets + manualPairing + recommendedApps
+ */
+export function weight(input: CardWeightInput): number {
+  return (
+    (input.hasPrimary ? 1 : 0) +
+    input.secondaryActions.length +
+    input.setupAssets.length +
+    input.manualPairing.length +
+    input.recommendedApps.length
+  );
+}
+
+/** Map an importance {@link weight} to a coarse {@link PortalCardSizeTier}
+ *  (#1700). Thresholds live here (one place, tunable in review):
+ *    - `compact` — weight ≤ 1
+ *    - `regular` — weight 2–3
+ *    - `feature` — weight ≥ 4
+ */
+export function sizeTierFromWeight(w: number): PortalCardSizeTier {
+  if (w <= 1) return 'compact';
+  if (w <= 3) return 'regular';
+  return 'feature';
+}
 
 /** The signals `deriveCardStatus` folds into a coarse status. Each is
  *  optional — a missing signal contributes nothing (it can't make the
@@ -347,6 +402,17 @@ function assemblePortalCard(
   parsedBody: string,
   status: { status: PortalCardStatus; statusReason?: string },
 ): PortalCard {
+  const secondaryActions = def.actions ?? [];
+  const recommendedApps = def.recommended_apps ?? [];
+  const setupAssets = def.setup_assets ?? [];
+  const manualPairing = def.manual_pairing ?? [];
+  const cardWeight = weight({
+    hasPrimary: Boolean(url) || Boolean(def.primary_action),
+    secondaryActions,
+    setupAssets,
+    manualPairing,
+    recommendedApps,
+  });
   return {
     id: `${serviceName}:${subdomainVar || 'default'}`,
     name: serviceName,
@@ -358,13 +424,14 @@ function assemblePortalCard(
     tagline: def.tagline ?? '',
     url: url ?? '',
     primaryAction: def.primary_action ?? null,
-    secondaryActions: def.actions ?? [],
+    secondaryActions,
     body: parsedBody,
-    recommendedApps: def.recommended_apps ?? [],
-    setupAssets: def.setup_assets ?? [],
-    manualPairing: def.manual_pairing ?? [],
+    recommendedApps,
+    setupAssets,
+    manualPairing,
     status: status.status,
     ...(status.statusReason ? { statusReason: status.statusReason } : {}),
+    sizeTier: sizeTierFromWeight(cardWeight),
   };
 }
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DiskImportSection, { DiskImportReview, type ScanReview } from './DiskImportSection';
+import { ToastProvider } from '@/providers/ToastProvider';
+
+const review: ScanReview = {
+  sessionId: 'sess-1',
+  device: '/dev/sda1',
+  totalFiles: 3,
+  totalBytes: 6000,
+  categories: [
+    { category: 'photos', files: 2, bytes: 3000, copy: 2, skipDupe: 0, conflict: 0 },
+    { category: 'documents', files: 1, bytes: 3000, copy: 1, skipDupe: 0, conflict: 0 },
+  ],
+  actions: [
+    {
+      id: 'ambiguous:/mnt/misc/mystery.xyz',
+      kind: 'ambiguous-folder',
+      label: "Couldn't auto-sort mystery.xyz",
+      subject: '/mnt/misc/mystery.xyz',
+      defaultOutcome: 'Filed under documents/ — open to re-file it.',
+    },
+  ],
+};
+
+describe('DiskImportReview (presentational)', () => {
+  it('renders per-category sizing and the non-blocking actions[]', () => {
+    render(<DiskImportReview review={review} onConfirm={() => {}} onCancel={() => {}} busy={false} />);
+
+    // Per-category rows.
+    expect(screen.getByText('photos')).toBeDefined();
+    expect(screen.getByText('documents')).toBeDefined();
+
+    // Ambiguous item surfaces as an action — and the copy says it doesn't block.
+    const actions = screen.getByTestId('disk-import-actions');
+    expect(actions.textContent).toContain("Couldn't auto-sort mystery.xyz");
+    expect(screen.getByText(/don't block the import/i)).toBeDefined();
+  });
+
+  it('fires onConfirm only on the explicit Confirm & import click (review gate)', () => {
+    const onConfirm = vi.fn();
+    render(<DiskImportReview review={review} onConfirm={onConfirm} onCancel={() => {}} busy={false} />);
+    expect(onConfirm).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText(/Confirm & import/i));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders even with zero actions (nothing ambiguous → no action wall)', () => {
+    render(
+      <DiskImportReview
+        review={{ ...review, actions: [] }}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+        busy={false}
+      />,
+    );
+    expect(screen.queryByTestId('disk-import-actions')).toBeNull();
+    expect(screen.getByText(/Confirm & import/i)).toBeDefined();
+  });
+});
+
+/** Fresh Response per call, dispatched by URL (memory: never reuse a Response). */
+function mockFetchByUrl(map: Record<string, () => unknown>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const key = Object.keys(map).find(k => url.includes(k));
+    const body = key ? map[key]() : {};
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+}
+
+const renderSection = () => render(<ToastProvider><DiskImportSection /></ToastProvider>);
+
+describe('DiskImportSection (flow)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetchByUrl({
+      'list-devices': () => ({ ok: true, devices: [{ path: '/dev/sda1', display: 'USB (15 GB, exfat)' }] }),
+      'disk-import/scan': () => ({ ok: true, ...review }),
+      'disk-import/apply': () => ({ ok: true, applied: 3, items: [] }),
+    }));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('walks device → scan → review → confirm → apply with the apply gated on the reviewed plan', async () => {
+    renderSection();
+
+    // Device auto-selected (single device); scan it.
+    const scanBtn = await screen.findByText('Scan disk');
+    fireEvent.click(scanBtn);
+
+    // Review appears with the plan + the ambiguous action (non-blocking).
+    await waitFor(() => expect(screen.getByTestId('disk-import-review')).toBeDefined());
+    expect(screen.getByTestId('disk-import-actions')).toBeDefined();
+
+    // Confirm → apply.
+    fireEvent.click(screen.getByText(/Confirm & import/i));
+
+    await waitFor(() => expect(screen.getByText(/Imported 3 file/i)).toBeDefined());
+
+    // The apply call carried the reviewed plan's sessionId + explicit confirm.
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const applyCall = fetchMock.mock.calls.find(c => String(c[0]).includes('disk-import/apply'));
+    expect(applyCall).toBeDefined();
+    const sent = JSON.parse((applyCall![1] as RequestInit).body as string);
+    expect(sent).toEqual({ sessionId: 'sess-1', confirmed: true });
+  });
+});

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
@@ -1,0 +1,397 @@
+'use client';
+
+// Settings → "Import data" card (issue #1697).
+//
+// Wraps the disk-import engine in the family-facing flow: pick a USB device →
+// run a scan → review the plan → CONFIRM → apply with progress. The flow is the
+// product feature for families migrating off the cloud.
+//
+// UX (memory `feedback_ux_philosophy`): the deterministic engine self-sorts
+// silently; the only thing the card asks the user is (a) which device and (b)
+// the explicit CONFIRM of the reviewed plan before any host write. Unavoidable
+// ambiguity (folders the classifier couldn't place, target conflicts) surfaces
+// as Diagnose-style `actions[]` — advisory follow-ups that DON'T block the apply
+// (the plan has a safe default for each).
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, HardDrive, AlertCircle, CheckCircle2, RefreshCw, Download } from 'lucide-react';
+import { useToast } from '@/providers/ToastProvider';
+
+interface DeviceView {
+  path: string;
+  display: string;
+}
+
+interface CategorySummary {
+  category: string;
+  files: number;
+  bytes: number;
+  copy: number;
+  skipDupe: number;
+  conflict: number;
+}
+
+interface ImportActionItem {
+  id: string;
+  kind: 'ambiguous-folder' | 'conflict';
+  label: string;
+  subject: string;
+  defaultOutcome: string;
+}
+
+export interface ScanReview {
+  sessionId: string;
+  device: string;
+  totalFiles: number;
+  totalBytes: number;
+  categories: CategorySummary[];
+  actions: ImportActionItem[];
+}
+
+type Phase = 'pick' | 'scanning' | 'review' | 'applying' | 'done';
+
+export function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+/** Per-category sizing table. */
+function CategoryTable({ categories }: { categories: CategorySummary[] }) {
+  return (
+    <table className="w-full text-xs">
+      <thead>
+        <tr className="text-left text-gray-500 dark:text-gray-400">
+          <th className="py-1">Category</th>
+          <th className="py-1 text-right">Files</th>
+          <th className="py-1 text-right">Size</th>
+          <th className="py-1 text-right">New</th>
+          <th className="py-1 text-right">Duplicate</th>
+        </tr>
+      </thead>
+      <tbody>
+        {categories.map(c => (
+          <tr key={c.category} className="border-t border-gray-100 dark:border-gray-800">
+            <td className="py-1 capitalize text-gray-800 dark:text-gray-200">{c.category}</td>
+            <td className="py-1 text-right">{c.files}</td>
+            <td className="py-1 text-right">{formatBytes(c.bytes)}</td>
+            <td className="py-1 text-right">{c.copy}</td>
+            <td className="py-1 text-right">{c.skipDupe}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** The non-blocking, advisory actions[] list (ambiguous folders / conflicts). */
+function ReviewActions({ actions }: { actions: ImportActionItem[] }) {
+  if (actions.length === 0) return null;
+  return (
+    <div className="space-y-2" data-testid="disk-import-actions">
+      <h5 className="text-xs font-semibold text-amber-700 dark:text-amber-300 flex items-center gap-1">
+        <AlertCircle size={12} /> {actions.length} item(s) to double-check (optional)
+      </h5>
+      <ul className="space-y-1">
+        {actions.map(a => (
+          <li
+            key={a.id}
+            className="text-[11px] text-gray-600 dark:text-gray-400 rounded-md border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/10 px-2 py-1"
+          >
+            <span className="font-medium text-gray-800 dark:text-gray-200">{a.label}</span> — {a.defaultOutcome}
+          </li>
+        ))}
+      </ul>
+      <p className="text-[11px] text-gray-400">
+        These don&apos;t block the import — everything else is sorted and ready.
+      </p>
+    </div>
+  );
+}
+
+/** Presentational review: per-category sizing + the non-blocking actions[]. */
+export function DiskImportReview({
+  review,
+  onConfirm,
+  onCancel,
+  busy,
+}: {
+  review: ScanReview;
+  onConfirm: () => void;
+  onCancel: () => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="space-y-4" data-testid="disk-import-review">
+      <div>
+        <h4 className="text-sm font-semibold text-gray-900 dark:text-white">Review before importing</h4>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {review.totalFiles} files · {formatBytes(review.totalBytes)} from {review.device}. Nothing has
+          been written yet.
+        </p>
+      </div>
+
+      <CategoryTable categories={review.categories} />
+      <ReviewActions actions={review.actions} />
+
+      <div className="flex flex-wrap gap-2 pt-1">
+        <button
+          onClick={onConfirm}
+          disabled={busy}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+        >
+          {busy && <Loader2 size={14} className="animate-spin" />} Confirm &amp; import
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={busy}
+          className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-800 dark:text-gray-200 text-sm font-medium rounded-lg disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Card frame matching the other Sharing sections (e.g. FileShareSection). */
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+          <Download size={18} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 dark:text-white">Import data</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">Sort a USB disk into your library</p>
+        </div>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  );
+}
+
+/** The device-picker body (presentational): list / empty / loading + scan. */
+function DevicePicker({
+  devices,
+  selected,
+  loading,
+  scanning,
+  onSelect,
+  onRefresh,
+  onScan,
+}: {
+  devices: DeviceView[];
+  selected: string;
+  loading: boolean;
+  scanning: boolean;
+  onSelect: (path: string) => void;
+  onRefresh: () => void;
+  onScan: () => void;
+}) {
+  if (loading) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
+        <Loader2 className="animate-spin" size={16} /> Looking for disks…
+      </div>
+    );
+  }
+  if (devices.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 space-y-2">
+        <p className="flex items-center gap-2">
+          <HardDrive size={16} /> No USB disk detected. Plug one in and refresh.
+        </p>
+        <button onClick={onRefresh} className="text-xs text-blue-600 hover:underline inline-flex items-center gap-1">
+          <RefreshCw size={12} /> Refresh
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        {devices.map(d => (
+          <label
+            key={d.path}
+            className="flex items-center gap-2 text-sm text-gray-800 dark:text-gray-200 cursor-pointer"
+          >
+            <input
+              type="radio"
+              name="disk-import-device"
+              value={d.path}
+              checked={selected === d.path}
+              onChange={() => onSelect(d.path)}
+            />
+            <HardDrive size={14} /> {d.display}
+          </label>
+        ))}
+      </div>
+      <button
+        onClick={onScan}
+        disabled={scanning || !selected}
+        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+      >
+        {scanning && <Loader2 size={14} className="animate-spin" />} Scan disk
+      </button>
+    </div>
+  );
+}
+
+/** The "done" body (presentational). */
+function ImportDone({ applied, onReset }: { applied: number; onReset: () => void }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-gray-800 dark:text-gray-200 flex items-center gap-2">
+        <CheckCircle2 size={16} className="text-green-600" /> Imported {applied} file(s) into your library.
+      </p>
+      <button
+        onClick={onReset}
+        className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-800 dark:text-gray-200 text-sm font-medium rounded-lg"
+      >
+        <RefreshCw size={14} /> Import another disk
+      </button>
+    </div>
+  );
+}
+
+export default function DiskImportSection() {
+  const { addToast } = useToast();
+  const [devices, setDevices] = useState<DeviceView[]>([]);
+  const [selected, setSelected] = useState<string>('');
+  const [phase, setPhase] = useState<Phase>('pick');
+  const [review, setReview] = useState<ScanReview | null>(null);
+  const [applied, setApplied] = useState<number | null>(null);
+  const [loadingDevices, setLoadingDevices] = useState(true);
+
+  // Fetch the device list. Only sets state from inside the (async) promise
+  // callbacks — never synchronously — so it's safe to call from an effect
+  // without the "cascading renders" lint.
+  const fetchDevices = useCallback(() => {
+    fetch('/api/system/disk-import/list-devices')
+      .then(r => (r.ok ? r.json() : null))
+      .then((data: { devices?: DeviceView[] } | null) => {
+        const list = data?.devices ?? [];
+        setDevices(list);
+        if (list.length === 1) setSelected(list[0].path);
+      })
+      .finally(() => setLoadingDevices(false));
+  }, []);
+
+  // Manual refresh: flip the spinner, then re-fetch (deferred so the click
+  // handler — not an effect — owns the synchronous setState).
+  const refreshDevices = useCallback(() => {
+    setLoadingDevices(true);
+    fetchDevices();
+  }, [fetchDevices]);
+
+  useEffect(fetchDevices, [fetchDevices]);
+
+  const runScan = async () => {
+    if (!selected) {
+      addToast('error', 'Pick a USB device first');
+      return;
+    }
+    setPhase('scanning');
+    try {
+      const res = await fetch('/api/system/disk-import/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device: selected }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        addToast('error', 'Scan failed', data.error || `HTTP ${res.status}`);
+        setPhase('pick');
+        return;
+      }
+      setReview(data as ScanReview);
+      setPhase('review');
+    } catch {
+      addToast('error', 'Scan failed');
+      setPhase('pick');
+    }
+  };
+
+  const applyPlan = async () => {
+    if (!review) return;
+    setPhase('applying');
+    try {
+      const res = await fetch('/api/system/disk-import/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: review.sessionId, confirmed: true }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        addToast('error', 'Import failed', data.error || `HTTP ${res.status}`);
+        setPhase('review');
+        return;
+      }
+      setApplied(typeof data.applied === 'number' ? data.applied : 0);
+      setPhase('done');
+      addToast('success', 'Import finished');
+    } catch {
+      addToast('error', 'Import failed');
+      setPhase('review');
+    }
+  };
+
+  const reset = () => {
+    setReview(null);
+    setApplied(null);
+    setSelected('');
+    setPhase('pick');
+    refreshDevices();
+  };
+
+  if (phase === 'review' && review) {
+    return (
+      <Card>
+        <DiskImportReview review={review} onConfirm={applyPlan} onCancel={reset} busy={false} />
+      </Card>
+    );
+  }
+
+  if (phase === 'applying' && review) {
+    return (
+      <Card>
+        <DiskImportReview review={review} onConfirm={() => {}} onCancel={() => {}} busy />
+      </Card>
+    );
+  }
+
+  if (phase === 'done') {
+    return (
+      <Card>
+        <ImportDone applied={applied ?? 0} onReset={reset} />
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div className="space-y-4">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Plug in a USB disk and we&apos;ll sort your photos, music and documents into the right place. You
+          review the plan before anything is copied.
+        </p>
+        <DevicePicker
+          devices={devices}
+          selected={selected}
+          loading={loadingDevices}
+          scanning={phase === 'scanning'}
+          onSelect={setSelected}
+          onRefresh={refreshDevices}
+          onScan={runScan}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/settings/sharing/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/sharing/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import FileShareSection from '../_lib/sections/FileShareSection';
+import DiskImportSection from '../_lib/sections/DiskImportSection';
 
 export default function SharingSettingsPage() {
   return (
     <>
       <FileShareSection />
+      <DiskImportSection />
     </>
   );
 }

--- a/packages/frontend/src/app/api/system/disk-import/apply/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/apply/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { applyImportPlan } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { makeExec, resolveNode, SHARE_GID } from '../wiring';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  /** The token from a prior `scan` — REQUIRED. The review gate. */
+  sessionId: z.string().min(1),
+  /** Explicit confirmation of the reviewed plan — required before any write. */
+  confirmed: z.literal(true),
+  node: z.string().optional(),
+});
+
+/**
+ * POST — apply a previously-scanned + reviewed plan to the host. The review gate:
+ * it requires both the `sessionId` of a plan scanned in this process AND an
+ * explicit `confirmed: true`, so no unreviewed plan can ever write. Resumable
+ * (catalog-backed). Photos go to Immich, the rest into file-share/data/.
+ */
+export const POST = withApiHandler<z.infer<typeof Body>>(
+  { body: Body, tokenScope: 'mutate' },
+  async ({ body }) => {
+    try {
+      const node = resolveNode(body.node);
+      const result = await applyImportPlan({
+        exec: makeExec(node),
+        sessionId: body.sessionId,
+        shareGid: SHARE_GID,
+      });
+      return NextResponse.json({ ok: true, applied: result.applied, items: result.items });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:apply', status: 400, exposeMessage: true });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/system/disk-import/list-devices/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/list-devices/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listImportDevices } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { makeExec, resolveNode } from '../wiring';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({ node: z.string().optional() });
+
+/**
+ * GET — enumerate removable partitions (USB) the user can import from
+ * (`lsblk -J` host-side, filtered to removable + has-filesystem). Read-only;
+ * `tokenScope: 'mutate'` keeps it consistent with the rest of the flow's
+ * scoped-token use.
+ */
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query, tokenScope: 'mutate' },
+  async ({ query }) => {
+    try {
+      const node = resolveNode(query.node);
+      const devices = await listImportDevices(makeExec(node));
+      return NextResponse.json({ ok: true, devices });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:list-devices', status: 400, exposeMessage: true });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/system/disk-import/scan/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/scan/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { scanDevice } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { catalogPath, makeExec, resolveNode } from '../wiring';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  /** Absolute `/dev/...` node of the partition to import. */
+  device: z.string().min(1),
+  node: z.string().optional(),
+});
+
+/**
+ * POST — mount the device READ-ONLY, walk + classify + dedup it into a plan, and
+ * return the review payload (per-category sizing, total, and unavoidable
+ * `actions[]`) plus a `sessionId`. Writes NOTHING to the host: this is the review
+ * step before the confirm + apply. The `sessionId` is the only thing that
+ * authorises a later apply of this exact reviewed plan.
+ */
+export const POST = withApiHandler<z.infer<typeof Body>>(
+  { body: Body, tokenScope: 'mutate' },
+  async ({ body }) => {
+    try {
+      const node = resolveNode(body.node);
+      const result = await scanDevice({
+        exec: makeExec(node),
+        device: body.device,
+        catalogPath: catalogPath(),
+      });
+      return NextResponse.json({ ok: true, ...result });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:scan', status: 400, exposeMessage: true });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/system/disk-import/wiring.ts
+++ b/packages/frontend/src/app/api/system/disk-import/wiring.ts
@@ -1,0 +1,32 @@
+// Disk-import API routes — shared host wiring (issue #1697).
+//
+// The three disk-import routes (`list-devices` / `scan` / `apply`) are thin
+// wrappers over the engine service (`@/lib/diskImport/service`). This module
+// holds the only non-engine bit they share: turning the target node into a
+// `SafeExec` backed by the agent's structured `safe_exec`, plus the resolved
+// defaults (catalog path, share gid). Kept out of the route files so each route
+// stays a few lines of request → service → response.
+
+import { AgentExecutor } from '@/lib/agent/executor';
+import { getNodeIds } from '@/lib/store/repository';
+import type { SafeExec } from '@/lib/diskImport/hostExec';
+
+/** Numeric gid that owns file-share data (rootless-podman subgid). */
+export const SHARE_GID = 1024;
+
+/** Persistent import catalog — the resume + cross-disk delta-dedup basis. */
+export function catalogPath(): string {
+  const dataDir = process.env.DATA_DIR ?? '/mnt/data/servicebay';
+  return `${dataDir}/disk-import-catalog.sqlite`;
+}
+
+/** Resolve the node the host commands run on (the first/only node by default). */
+export function resolveNode(node?: string): string {
+  return node || getNodeIds()[0] || 'Local';
+}
+
+/** Build the engine's `SafeExec` seam over the agent's structured `safe_exec`. */
+export function makeExec(node: string): SafeExec {
+  const executor = new AgentExecutor(node);
+  return (argv, options) => executor.execSafe(argv, options ?? {});
+}

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -31,6 +31,7 @@ const baseCard: PortalCard = {
   recommendedApps: [],
   setupAssets: [],
   manualPairing: [],
+  sizeTier: 'compact',
 };
 
 describe('PortalGrid', () => {
@@ -231,6 +232,43 @@ describe('PortalGrid', () => {
     it('still shows the Open-URL button for ordinary URL-based cards', () => {
       render(<PortalGrid cards={[baseCard]} />);
       expect(screen.getByRole('link', { name: /^open$/i })).toBeDefined();
+    });
+  });
+
+  describe('sizeTier → column span (#1700)', () => {
+    /** Walk up from the card heading to the grid-cell wrapper (the div
+     *  that carries the `col-span-*` class). The wrapper is the heading's
+     *  nearest ancestor div with `rounded-2xl` (the card chrome). */
+    const cardWrapper = (label: string): HTMLElement => {
+      const heading = screen.getByRole('heading', { name: label });
+      const wrapper = heading.closest('div.rounded-2xl');
+      expect(wrapper).not.toBeNull();
+      return wrapper as HTMLElement;
+    };
+
+    it('gives a compact card md:col-span-3', () => {
+      render(<PortalGrid cards={[{ ...baseCard, sizeTier: 'compact' }]} />);
+      const cls = cardWrapper('Photos').className;
+      expect(cls).toContain('md:col-span-3');
+      expect(cls).toContain('col-span-1'); // mobile stays 1 col
+    });
+
+    it('gives a regular card md:col-span-4', () => {
+      render(<PortalGrid cards={[{ ...baseCard, sizeTier: 'regular' }]} />);
+      expect(cardWrapper('Photos').className).toContain('md:col-span-4');
+    });
+
+    it('gives a feature card md:col-span-6 (action-rich → wider)', () => {
+      render(<PortalGrid cards={[{ ...baseCard, sizeTier: 'feature' }]} />);
+      expect(cardWrapper('Photos').className).toContain('md:col-span-6');
+    });
+
+    it('renders a feature (action-rich) card wider than a compact one', () => {
+      const compact: PortalCard = { ...baseCard, id: 'a:x', label: 'Bare', sizeTier: 'compact' };
+      const feature: PortalCard = { ...baseCard, id: 'b:y', label: 'Files', sizeTier: 'feature' };
+      render(<PortalGrid cards={[compact, feature]} />);
+      expect(cardWrapper('Bare').className).toContain('md:col-span-3');
+      expect(cardWrapper('Files').className).toContain('md:col-span-6');
     });
   });
 

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -18,6 +18,18 @@ import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '
 
 type IconComponent = typeof Camera;
 
+/** Per-tier column span on the 12-col `md` grid (#1700). Action-rich
+ *  cards get more width; light cards get less; height stays
+ *  content-driven (the grid uses `items-start`, not stretch). These MUST
+ *  be literal Tailwind classes — Tailwind can't see an interpolated
+ *  `col-span-${n}`, so they'd get purged. Keyed by the server-derived
+ *  `sizeTier` (`packages/backend/src/lib/portal/services.ts`). */
+const SIZE_TIER_SPAN: Record<PortalCard['sizeTier'], string> = {
+  compact: 'md:col-span-3', // 4 per row
+  regular: 'md:col-span-4', // 3 per row
+  feature: 'md:col-span-6', // 2 per row
+};
+
 /** Maps the kebab-case Lucide names allowlisted in user-guide
  *  frontmatter to their imported components. Keep in sync with
  *  PORTAL_ICONS in userGuide.ts. */
@@ -159,23 +171,24 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
 
   return (
     <>
-    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-start">
       {cards.map(card => {
         return (
           <div
             key={card.id}
-            className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden flex flex-col"
+            className={`bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden flex flex-col col-span-1 ${SIZE_TIER_SPAN[card.sizeTier]}`}
           >
-            {/* Header — icon + title + tagline. The tagline area is
-                clamped to 3 lines + min-h so the Open button below
-                lands at the same Y on every card in a row. */}
+            {/* Header — icon + title + tagline. The tagline is clamped
+                to 3 lines; height is content-driven now (#1700), so the
+                old `min-h` equal-Y filler is dropped — `items-start` on
+                the grid stops the row-stretch. */}
             <div className="p-6 pb-3">
               <CardIcon card={card} />
               <div className="flex items-center gap-2">
                 <h2 className="text-xl font-bold text-gray-900 dark:text-white">{card.label}</h2>
                 <StatusBadge status={card.status} reason={card.statusReason} />
               </div>
-              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-3 min-h-[3.75rem]">
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-3">
                 {card.tagline ?? ''}
               </p>
             </div>
@@ -189,12 +202,10 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
               <CardCta card={card} isMobile={isMobile} />
             </div>
 
-            {/* Variable content below — fills the rest of the card so
-                grid-cell heights stay equal even with different
-                amounts of recommended apps / setup assets. */}
-            <div className="px-6 pt-3 pb-6 space-y-3 flex-1">
-              {/* (the original wrapper continues; adjusted closing
-                   tag is below — left here so the diff is contained.) */}
+            {/* Variable content below. Height is content-driven (#1700) —
+                no `flex-1` filler; cards no longer stretch to a row's
+                tallest sibling. */}
+            <div className="px-6 pt-3 pb-6 space-y-3">
 
               {card.setupAssets.length > 0 && (
                 <div className="space-y-1.5">

--- a/scripts/disk-import.test.ts
+++ b/scripts/disk-import.test.ts
@@ -1,0 +1,209 @@
+// Tests for the disk-import CLI (#1696). The review gate is the safety: a
+// dry run must touch NOTHING on the host (the host-apply seam is never built),
+// and --apply must STOP for an explicit confirmation before any host I/O.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  parseDiskImportArgs,
+  runDiskImport,
+  walkMount,
+  renderReport,
+  summarizePlan,
+  DiskImportError,
+  type DiskImportOptions,
+  type DiskImportIO,
+} from './disk-import';
+import { buildInventory } from '../packages/backend/src/lib/diskImport/inventory';
+import { buildPlan } from '../packages/backend/src/lib/diskImport/dedup';
+
+// A small fixture mount: a photo, a music track, a doc, and one junk file.
+let mount: string;
+
+beforeEach(() => {
+  mount = mkdtempSync(path.join(tmpdir(), 'disk-import-'));
+  mkdirSync(path.join(mount, 'pics'), { recursive: true });
+  mkdirSync(path.join(mount, 'tunes'), { recursive: true });
+  mkdirSync(path.join(mount, 'docs'), { recursive: true });
+  writeFileSync(path.join(mount, 'pics', 'holiday.jpg'), 'JPEGDATA');
+  writeFileSync(path.join(mount, 'tunes', 'song.mp3'), 'MP3DATA');
+  writeFileSync(path.join(mount, 'docs', 'invoice.pdf'), 'PDFDATA');
+  writeFileSync(path.join(mount, 'Thumbs.db'), 'JUNK');
+});
+
+afterEach(() => {
+  rmSync(mount, { recursive: true, force: true });
+});
+
+function baseOpts(overrides: Partial<DiskImportOptions> = {}): DiskImportOptions {
+  return {
+    mount,
+    mode: 'dry-run',
+    catalog: ':memory:',
+    node: 'default',
+    shareGid: 1024,
+    ...overrides,
+  };
+}
+
+/** A spying IO seam: real fs walk + real hash, but host-apply is a spy. The
+ *  returned `makeExec`/`confirm` are the EFFECTIVE seams on `io` (overrides
+ *  win), so assertions always target what `runDiskImport` actually called. */
+function spyIO(over: Partial<DiskImportIO> = {}): {
+  io: DiskImportIO;
+  logs: string[];
+  makeExec: ReturnType<typeof vi.fn>;
+  confirm: ReturnType<typeof vi.fn>;
+} {
+  const logs: string[] = [];
+  // The actual SafeExec is never expected to run in these tests; if it does the
+  // assertion on makeExec/exec-calls catches it.
+  const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+  const io: DiskImportIO = {
+    log: m => logs.push(m),
+    confirm: vi.fn().mockResolvedValue(false),
+    scan: m => walkMount(m),
+    hashOf: r => `sha-${r.sourcePath}`,
+    makeExec: vi.fn(() => exec),
+    ...over,
+  };
+  return {
+    io,
+    logs,
+    makeExec: io.makeExec as ReturnType<typeof vi.fn>,
+    confirm: io.confirm as ReturnType<typeof vi.fn>,
+  };
+}
+
+describe('parseDiskImportArgs', () => {
+  it('defaults to dry-run when no mode flag is given (safe by default)', () => {
+    const opts = parseDiskImportArgs(['--mount', '/m']);
+    expect(opts).toMatchObject({ mount: '/m', mode: 'dry-run', catalog: ':memory:' });
+  });
+
+  it('parses --apply and a persistent catalog default', () => {
+    const opts = parseDiskImportArgs(['--mount', '/m', '--apply']);
+    expect(opts).toMatchObject({ mount: '/m', mode: 'apply' });
+    expect((opts as DiskImportOptions).catalog).not.toBe(':memory:');
+  });
+
+  it('rejects --dry-run and --apply together', () => {
+    expect(() => parseDiskImportArgs(['--mount', '/m', '--dry-run', '--apply'])).toThrow(DiskImportError);
+  });
+
+  it('requires --mount', () => {
+    expect(() => parseDiskImportArgs(['--dry-run'])).toThrow(/--mount is required/);
+  });
+
+  it('validates --share-gid is a non-negative integer', () => {
+    expect(() => parseDiskImportArgs(['--mount', '/m', '--share-gid', 'nope'])).toThrow(DiskImportError);
+  });
+
+  it('returns help for --help', () => {
+    expect(parseDiskImportArgs(['--help'])).toEqual({ help: true });
+  });
+});
+
+describe('walkMount', () => {
+  it('returns every file as a metadata ScannedFile (no junk filtering yet)', async () => {
+    const files = await walkMount(mount);
+    expect(files).toHaveLength(4);
+    expect(files.every(f => typeof f.size === 'number' && typeof f.mtimeMs === 'number')).toBe(true);
+    expect(files.some(f => f.path.endsWith('holiday.jpg'))).toBe(true);
+  });
+});
+
+describe('renderReport / summarizePlan', () => {
+  it('rolls up per category and a move-plan summary', async () => {
+    const files = await walkMount(mount);
+    const plan = buildPlan(buildInventory(files), r => `sha-${r.sourcePath}`);
+    const stats = summarizePlan(plan);
+    expect(stats.get('photos')?.count).toBe(1);
+    expect(stats.get('music')?.count).toBe(1);
+    expect(stats.get('documents')?.count).toBe(1);
+    expect(stats.get('junk')?.count).toBe(1);
+
+    const report = renderReport(plan).join('\n');
+    expect(report).toContain('SIZING REPORT');
+    expect(report).toContain('MOVE PLAN');
+    expect(report).toContain('photos');
+  });
+});
+
+describe('runDiskImport — dry-run touches nothing', () => {
+  it('prints the sizing report + move-plan and NEVER builds the host-apply seam', async () => {
+    const { io, logs, makeExec, confirm } = spyIO();
+    const result = await runDiskImport(baseOpts({ mode: 'dry-run' }), io);
+
+    // Nothing applied.
+    expect(result).toBeNull();
+    // The host-apply seam was never even constructed, let alone called.
+    expect(makeExec).not.toHaveBeenCalled();
+    // No confirmation prompt in dry-run.
+    expect(confirm).not.toHaveBeenCalled();
+
+    const out = logs.join('\n');
+    expect(out).toContain('SIZING REPORT');
+    expect(out).toContain('MOVE PLAN');
+    expect(out).toContain('Dry run: nothing was written');
+  });
+
+  it('dry-run is the default mode and still touches nothing', async () => {
+    const { io, makeExec } = spyIO();
+    const opts = parseDiskImportArgs(['--mount', mount]) as DiskImportOptions;
+    const result = await runDiskImport({ ...opts, mount }, io);
+    expect(result).toBeNull();
+    expect(makeExec).not.toHaveBeenCalled();
+  });
+});
+
+describe('runDiskImport — apply review gate', () => {
+  it('requires confirmation BEFORE the host-apply seam is built/invoked', async () => {
+    const callOrder: string[] = [];
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+    const confirm = vi.fn(async () => {
+      callOrder.push('confirm');
+      return true;
+    });
+    const makeExec = vi.fn(() => {
+      callOrder.push('makeExec');
+      return exec;
+    });
+    const { io } = spyIO({ confirm, makeExec });
+
+    await runDiskImport(baseOpts({ mode: 'apply' }), io);
+
+    // Confirmation happened, and it happened before the host-apply seam.
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(makeExec).toHaveBeenCalledTimes(1);
+    expect(callOrder.indexOf('confirm')).toBeLessThan(callOrder.indexOf('makeExec'));
+  });
+
+  it('aborts with no host I/O when the operator declines at the gate', async () => {
+    const { io, makeExec, confirm } = spyIO({ confirm: vi.fn().mockResolvedValue(false) });
+    await expect(runDiskImport(baseOpts({ mode: 'apply' }), io)).rejects.toThrow(DiskImportError);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    // Declined → the host-apply seam is never built.
+    expect(makeExec).not.toHaveBeenCalled();
+  });
+
+  it('on confirm, drives the host-apply (rsync/chown via the SafeExec seam)', async () => {
+    const execCalls: string[][] = [];
+    const exec = vi.fn(async (argv: string[]) => {
+      execCalls.push(argv);
+      return { stdout: '', stderr: '', code: 0 };
+    });
+    const makeExec = vi.fn(() => exec);
+    const { io } = spyIO({ confirm: vi.fn().mockResolvedValue(true), makeExec });
+
+    const result = await runDiskImport(baseOpts({ mode: 'apply' }), io);
+    expect(result).not.toBeNull();
+    // The non-photo files were copied via rsync through the seam.
+    const verbs = execCalls.map(a => a[0]);
+    expect(verbs).toContain('rsync');
+    expect(verbs).toContain('chown');
+  });
+});

--- a/scripts/disk-import.ts
+++ b/scripts/disk-import.ts
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+/**
+ * `disk-import` CLI (#1696): run the full disk-import pipeline with a human
+ * review gate, so a real disk can be imported before the UI card (#1697) exists.
+ *
+ * It is a thin argv + readline shell around the deterministic engine
+ * (`packages/backend/src/lib/diskImport/`, #1693) and the host-apply path
+ * (#1694). It mirrors `scripts/sb-config-upload.ts`: argv parsing, an injectable
+ * IO seam (`log` / `confirm`), a clean `error: <message>` on user-facing failure.
+ *
+ * Pipeline: walk the mount → inventory → classify → dedup → plan, print a
+ * per-category SIZING REPORT + move-plan summary, then STOP at the review gate.
+ *
+ *   - `--dry-run` (and the no-flag default) compute + print the plan and touch
+ *     NOTHING on the host. Safe by default.
+ *   - `--apply` is the only path that performs host I/O, and only AFTER an
+ *     explicit confirmation. The apply is resumable: items already in the
+ *     catalog (same sha + target) are skipped, so an interrupted run can re-run.
+ *
+ * Run: `npm run disk-import -- --mount /run/media/usb --dry-run`
+ *      `npm run disk-import -- --mount /run/media/usb --apply`
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { buildInventory, type ScannedFile } from '../packages/backend/src/lib/diskImport/inventory.js';
+import { buildPlan, type HashResolver } from '../packages/backend/src/lib/diskImport/dedup.js';
+import { classifyRecord } from '../packages/backend/src/lib/diskImport/classify.js';
+import { ImportCatalog } from '../packages/backend/src/lib/diskImport/catalog.js';
+import { applyPlan, type ApplyResult, type ImmichConfig } from '../packages/backend/src/lib/diskImport/plan.js';
+import type { SafeExec } from '../packages/backend/src/lib/diskImport/hostExec.js';
+import type { Category, ImportPlan, ImportRecord } from '../packages/backend/src/lib/diskImport/types.js';
+
+/** Thrown for user-facing failures (bad args, abort) so the CLI prints a clean
+ *  `error: <message>` instead of a stack trace. */
+export class DiskImportError extends Error {}
+
+export interface DiskImportOptions {
+  /** Absolute path the source disk is mounted at (the tree to import). */
+  mount: string;
+  /** `apply` performs host I/O (after confirmation); `dry-run` touches nothing. */
+  mode: 'dry-run' | 'apply';
+  /** Catalog DB path (resume basis). `:memory:` for an ephemeral dry-run. */
+  catalog: string;
+  /** Node the agent runs the host-apply commands on. */
+  node: string;
+  /** Numeric gid that owns file-share content; copied files are chown'd to it. */
+  shareGid: number;
+}
+
+export const USAGE = `Usage: disk-import --mount <path> [--dry-run | --apply] [options]
+
+Run the disk-import pipeline (inventory -> classify -> dedup -> plan), print a
+per-category sizing report and the move-plan, then stop at the review gate. The
+default is a dry run: it computes and prints the plan and touches NOTHING on the
+host. Only --apply (after an explicit confirmation) performs host I/O.
+
+Options:
+  --mount <path>     Path the source disk is mounted at (required)
+  --dry-run          Compute + print the plan only; touch nothing (default)
+  --apply            Apply the plan to the host (requires confirmation; resumable)
+  --catalog <path>   Import catalog DB path (default: :memory: for dry-run)
+  --node <name>      Node to run host-apply commands on (default: default)
+  --share-gid <gid>  Numeric gid that owns file-share data (default: 1024)
+  --help, -h         Show this help`;
+
+const DEFAULT_SHARE_GID = 1024;
+
+/**
+ * Parse `process.argv.slice(2)`. Returns `{ help: true }` for --help, or a
+ * validated `DiskImportOptions`. Throws `DiskImportError` on malformed input.
+ * Defaults to `dry-run` (safe) when neither --dry-run nor --apply is given.
+ */
+interface ArgDraft {
+  mount?: string;
+  mode?: 'dry-run' | 'apply';
+  catalog?: string;
+  node: string;
+  shareGid: number;
+}
+
+/** Set `mode`, rejecting a conflicting mode flag. */
+function setMode(draft: ArgDraft, mode: 'dry-run' | 'apply'): void {
+  if (draft.mode && draft.mode !== mode) {
+    throw new DiskImportError('--dry-run and --apply are mutually exclusive');
+  }
+  draft.mode = mode;
+}
+
+/** Apply one value-taking flag (`--mount`/`--catalog`/`--node`/`--share-gid`). */
+function applyValueArg(draft: ArgDraft, arg: string, value: string | undefined): void {
+  if (value === undefined) throw new DiskImportError(`Missing value for ${arg}`);
+  if (arg === '--mount') draft.mount = value;
+  else if (arg === '--catalog') draft.catalog = value;
+  else if (arg === '--node') draft.node = value;
+  else {
+    const gid = Number(value);
+    if (!Number.isInteger(gid) || gid < 0) {
+      throw new DiskImportError(`--share-gid must be a non-negative integer, got "${value}"`);
+    }
+    draft.shareGid = gid;
+  }
+}
+
+const VALUE_ARGS = new Set(['--mount', '--catalog', '--node', '--share-gid']);
+
+export function parseDiskImportArgs(argv: string[]): DiskImportOptions | { help: true } {
+  const draft: ArgDraft = { node: 'default', shareGid: DEFAULT_SHARE_GID };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') return { help: true };
+    else if (arg === '--dry-run') setMode(draft, 'dry-run');
+    else if (arg === '--apply') setMode(draft, 'apply');
+    else if (VALUE_ARGS.has(arg)) applyValueArg(draft, arg, argv[++i]);
+    else throw new DiskImportError(`Unknown argument: ${arg}`);
+  }
+
+  if (!draft.mount) throw new DiskImportError('--mount is required');
+  // Safe by default: no explicit mode means dry-run.
+  const mode = draft.mode ?? 'dry-run';
+  // A dry run never opens a persistent catalog (and never needs one) — default
+  // it to an in-memory DB so the dry run can't touch the host catalog either.
+  const catalog = draft.catalog ?? (mode === 'apply' ? defaultCatalogPath() : ':memory:');
+  return { mount: draft.mount, mode, catalog, node: draft.node, shareGid: draft.shareGid };
+}
+
+function defaultCatalogPath(): string {
+  return path.join(process.env.DATA_DIR ?? '/mnt/data/servicebay', 'disk-import-catalog.sqlite');
+}
+
+/**
+ * Recursively walk `mount` and return a metadata-only ScannedFile list. This is
+ * a READ-only directory walk (no writes) — the deterministic engine never reads
+ * file contents; hashing is deferred to the dedup step and done lazily.
+ */
+export async function walkMount(mount: string, fsImpl: typeof fs = fs): Promise<ScannedFile[]> {
+  const out: ScannedFile[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await fsImpl.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        const st = await fsImpl.stat(full);
+        out.push({ path: full, size: st.size, mtimeMs: st.mtimeMs });
+      }
+    }
+  }
+  await walk(mount);
+  return out;
+}
+
+/** Hash a file's bytes (sha256 hex). Used lazily by dedup on size collisions. */
+export function hashFileContent(record: ImportRecord): string {
+  return createHash('sha256').update(readFileSync(record.sourcePath)).digest('hex');
+}
+
+/** Aggregate stats for one category in the sizing report. */
+interface CategoryStat {
+  count: number;
+  bytes: number;
+  copy: number;
+  skipDupe: number;
+  conflict: number;
+}
+
+/** Build the per-category sizing rollup from a computed plan. */
+export function summarizePlan(plan: ImportPlan): Map<Category, CategoryStat> {
+  const stats = new Map<Category, CategoryStat>();
+  for (const item of plan.items) {
+    const stat = stats.get(item.category) ?? { count: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0 };
+    stat.count += 1;
+    stat.bytes += item.record.size;
+    if (item.action === 'copy') stat.copy += 1;
+    else if (item.action === 'skip-dupe') stat.skipDupe += 1;
+    else if (item.action === 'conflict') stat.conflict += 1;
+    stats.set(item.category, stat);
+  }
+  return stats;
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+/** Render the sizing report + move-plan summary as printable lines. */
+export function renderReport(plan: ImportPlan): string[] {
+  const lines: string[] = [];
+  const stats = summarizePlan(plan);
+
+  lines.push('=== SIZING REPORT (per category) ===');
+  const categories = [...stats.keys()].sort();
+  for (const category of categories) {
+    const s = stats.get(category)!;
+    lines.push(
+      `  ${category.padEnd(12)} ${String(s.count).padStart(6)} files  ${formatBytes(s.bytes).padStart(10)}` +
+        `   (copy ${s.copy}, dupe ${s.skipDupe}, conflict ${s.conflict})`,
+    );
+  }
+
+  const totalFiles = plan.items.length;
+  const totalBytes = plan.items.reduce((sum, i) => sum + i.record.size, 0);
+  const toCopy = plan.items.filter(i => i.action === 'copy').length;
+  const toSupersede = plan.items.filter(i => i.action === 'conflict').length;
+  const skipped = plan.items.filter(i => i.action === 'skip-dupe' || i.action === 'skip-junk').length;
+
+  lines.push('');
+  lines.push('=== MOVE PLAN (summary) ===');
+  lines.push(`  ${totalFiles} files, ${formatBytes(totalBytes)} scanned`);
+  lines.push(`  copy:       ${toCopy}`);
+  lines.push(`  supersede:  ${toSupersede} (conflicting target; old version parked in _superseded/)`);
+  lines.push(`  skip:       ${skipped} (junk + already-imported duplicates)`);
+  lines.push(`  conflicts:  ${plan.conflicts.length}`);
+
+  if (plan.conflicts.length > 0) {
+    lines.push('');
+    lines.push('  Conflicting targets (review before apply):');
+    for (const c of plan.conflicts.slice(0, 20)) {
+      lines.push(`    ${c.target}: ${c.incoming.sourcePath} vs existing ${c.existing.sourcePath}`);
+    }
+    if (plan.conflicts.length > 20) {
+      lines.push(`    … and ${plan.conflicts.length - 20} more`);
+    }
+  }
+
+  return lines;
+}
+
+/** IO + host seams — injected so the core is testable without a real box. */
+export interface DiskImportIO {
+  log: (message: string) => void;
+  /** Ask the operator a yes/no question; resolve true to proceed. */
+  confirm: (question: string) => Promise<boolean>;
+  /** Walk the mount into a ScannedFile list (overridable in tests). */
+  scan: (mount: string) => Promise<ScannedFile[]>;
+  /** Resolve a record's sha256 (overridable in tests). */
+  hashOf: HashResolver;
+  /**
+   * Build the host-apply SafeExec for `--apply`. Lazily constructed so the
+   * dry-run path NEVER touches the agent. In tests this is a spy whose call is
+   * asserted to happen only after confirmation, never in dry-run.
+   */
+  makeExec: (opts: DiskImportOptions) => SafeExec;
+  /**
+   * Immich config for the photo upload pass. Optional — this CLI doesn't wire
+   * Immich credentials yet (that's the UI card, #1697), so when it's absent the
+   * apply skips photos (with a warning) rather than failing. Returns `undefined`
+   * to skip photos.
+   */
+  immich?: ImmichConfig;
+}
+
+/**
+ * Run the pipeline: scan -> inventory -> classify -> dedup -> plan, print the
+ * report, then stop at the review gate. In `apply` mode require confirmation,
+ * then apply to the host. In `dry-run` mode touch NOTHING on the host.
+ *
+ * Returns the ApplyResult on an applied run, or `null` for a dry run / aborted
+ * apply (so callers/tests can assert no host write happened).
+ */
+export async function runDiskImport(
+  opts: DiskImportOptions,
+  io: DiskImportIO,
+): Promise<ApplyResult | null> {
+  io.log(`Scanning ${opts.mount} …`);
+  const files = await io.scan(opts.mount);
+  io.log(`Found ${files.length} files.`);
+
+  const records = buildInventory(files);
+  // Surface unclassifiable residue (left for the review gate / LLM path #1695).
+  const undecided = records.filter(r => classifyRecord(r) === null).length;
+
+  // dry-run computes against an in-memory catalog so it can't touch the host
+  // catalog; apply opens the real (resume) catalog.
+  const catalog = new ImportCatalog(opts.catalog);
+  let plan: ImportPlan;
+  try {
+    plan = buildPlan(records, io.hashOf, { catalog });
+  } finally {
+    if (opts.mode === 'dry-run') catalog.close();
+  }
+
+  for (const line of renderReport(plan)) io.log(line);
+  if (undecided > 0) {
+    io.log(`  ${undecided} files had no deterministic category (filed under documents; review with #1695).`);
+  }
+
+  if (opts.mode === 'dry-run') {
+    io.log('');
+    io.log('Dry run: nothing was written. Re-run with --apply to import.');
+    return null;
+  }
+
+  // --- Review gate. The ONLY path past here performs host I/O. ---
+  io.log('');
+  const proceed = await io.confirm(
+    `Apply this plan to the host (node "${opts.node}")? Files will be copied into ` +
+      `file-share/data/ and photos uploaded to Immich. This is resumable.`,
+  );
+  if (!proceed) {
+    catalog.close();
+    throw new DiskImportError('Aborted at the review gate. Nothing was written.');
+  }
+
+  return applyApprovedPlan(plan, opts, io, catalog);
+}
+
+/**
+ * Apply a plan the operator has confirmed. Drops photo items when Immich isn't
+ * wired (this CLI has no credentials path yet), then runs the host-apply via the
+ * SafeExec seam. Always closes the catalog.
+ */
+async function applyApprovedPlan(
+  plan: ImportPlan,
+  opts: DiskImportOptions,
+  io: DiskImportIO,
+  catalog: ImportCatalog,
+): Promise<ApplyResult> {
+  // Photos go to Immich, which this CLI doesn't yet wire credentials for. With
+  // no immich config, drop photo items (with a warning) rather than letting
+  // applyPlan throw on the first photo.
+  let toApply = plan;
+  if (!io.immich) {
+    const photoCount = plan.items.filter(i => i.category === 'photos').length;
+    if (photoCount > 0) {
+      io.log(`Note: ${photoCount} photo(s) skipped — Immich upload isn't wired in the CLI yet (use the UI card, #1697).`);
+      toApply = { items: plan.items.filter(i => i.category !== 'photos'), conflicts: plan.conflicts };
+    }
+  }
+
+  const exec = io.makeExec(opts);
+  io.log('Applying …');
+  try {
+    const result = await applyPlan(toApply, {
+      exec,
+      mountpoint: opts.mount,
+      catalog,
+      shareGid: opts.shareGid,
+      hashOf: io.hashOf,
+      immich: io.immich,
+    });
+    io.log(`Applied ${result.applied} file(s); ${result.items.length - result.applied} skipped.`);
+    return result;
+  } finally {
+    catalog.close();
+  }
+}
+
+/** Default (real) IO: walk the mount with fs, hash with crypto, host-apply via
+ *  the agent's structured `safe_exec`. */
+function realIO(rl: readline.Interface): DiskImportIO {
+  return {
+    log: message => console.log(message),
+    confirm: async question => {
+      const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+      return answer === 'y' || answer === 'yes';
+    },
+    scan: mount => walkMount(mount),
+    hashOf: hashFileContent,
+    makeExec: opts => {
+      // Lazily import the agent stack — only reached on --apply, never dry-run.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { AgentExecutor } = require('../packages/backend/src/lib/agent/executor.js');
+      const executor = new AgentExecutor(opts.node);
+      return (argv: string[], options?: { timeoutMs?: number }) => executor.execSafe(argv, options ?? {});
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseDiskImportArgs(process.argv.slice(2));
+  if ('help' in parsed) {
+    console.log(USAGE);
+    return;
+  }
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  try {
+    await runDiskImport(parsed, realIO(rl));
+  } finally {
+    rl.close();
+  }
+}
+
+// Only run when executed directly (not when imported by tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error: unknown) => {
+    if (error instanceof DiskImportError) {
+      console.error(`error: ${error.message}`);
+    } else {
+      console.error(error);
+    }
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## What

Batch of 7 units across 7 issues:

- **fix(health) #1688** — accept unquoted block-scalar `{{VAR}}` healthcheck ports. `yaml.load` turns `{{VAR}}` into an object (`{[object Object]:null}`), so the `typeof !== 'string'` guard bypassed the `MUSTACHE_RE` permissive check; serialize back to string before the test so block-scalar placeholders pass lint/install validation and still resolve at runtime via `renderTemplate`.
- **Disk-import feature (epic #1698)** — substantially implemented across its 5 children:
  - **#1693** engine core: deterministic `categories`/`types`/`inventory`/`classify`/`catalog`/`dedup` (pure logic, no host I/O).
  - **#1694** host mount + resumable apply: `mounter.ts` (lsblk/mount RO/umount) + `plan.ts` (rsync non-photos, immich-cli photos, `_superseded/` conflicts, chown to share gid, catalog-resumable). Adds `mount`/`umount`/`lsblk`/`rsync`/`chown`/`sha256sum` to the agent `SAFE_EXEC_ALLOWLIST`. **host-I/O — flagged for post-deploy review.**
  - **#1695** local-Ollama classifier: advisory suggestions land in the review plan only, graceful fallback when Ollama is down.
  - **#1696** repeatable CLI with a review gate (`scripts/disk-import.ts`, `npm run disk-import`).
  - **#1697** ServiceBay "Import data" settings card + backend disk-import API routes (list-devices/scan/apply, progress, diagnose-style `actions[]` for ambiguous items).
- **enhancement(portal) #1700** — importance-weighted card sizing: pure `weight()` next to `deriveCardStatus`, `sizeTier` compact/regular/feature → 12-col content-driven grid; action-rich cards render wider. **gate=verify (portal path-mandated).**

## Why

Closes #1688
Closes #1693
Closes #1694
Closes #1695
Closes #1696
Closes #1697
Closes #1700
Closes #1698

(#1698 is the disk-import epic — all five children #1693/#1694/#1695/#1696/#1697 ship in this batch, so the umbrella auto-closes.)

## Risk

Medium. New disk-import host-I/O surface (agent allowlist additions, mount/rsync/chown via safe_exec) is real-host machinery but gated behind an explicit review/apply step — no import runs automatically. Portal sizing is presentation-only. The #1688 health fix is a narrow serialization correction.

## Rollback

`git revert` is enough — the diskImport module is additive (nothing else calls it yet beyond the new CLI/card), the portal change is presentational, and the #1688 fix is self-contained.

## Verification

- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2279 passed)
- [x] python agent tests (`unittest discover` agent/v4 — 26 passed; covers the new SAFE_EXEC_ALLOWLIST entries)
- [ ] /verify on FCoS :dev box — #1700 portal sizing + disk-import host-I/O surface. In-loop: :dev boots, portal renders, health/diagnose green, NO real disk-import run on the box. Real disk-import-on-data proof is operator-owed.

---
AI-generated
<!-- sb-ai-comment -->