### PR TITLE
fix: SystemInfo layout polish + diagnose probe correctness + re-activatable bootstrap token

### DIFF
--- a/packages/backend/src/lib/api/apiTokenRoutes.ts
+++ b/packages/backend/src/lib/api/apiTokenRoutes.ts
@@ -41,8 +41,10 @@ export async function createTokenHandler({ request }: { request: Request }) {
     });
 
     // First user-minted token closes the bootstrap-token bridge (#322).
-    // The operator now has a real, scoped credential — keeping the
-    // bootstrap entry around any longer is just attack surface.
+    // The operator now has a real, scoped credential, so the bootstrap
+    // token is expired (deactivated, not deleted — #1705). It stays
+    // re-activatable from Settings → Security for reconnecting an MCP
+    // client with the same token value (#1419/#1552).
     try {
       await revokeBootstrapToken();
     } catch (e) {

--- a/packages/backend/src/lib/diagnose/diagnoseChecks.ts
+++ b/packages/backend/src/lib/diagnose/diagnoseChecks.ts
@@ -63,11 +63,18 @@ export const DIAGNOSE_INTERVAL_SECONDS = 24 * 60 * 60;
  * just reads the freshly-persisted results back out to return them for
  * the scheduler's `health:update` SSE emit. Called daily by the
  * HealthService scheduler and on-demand by the per-row "run now" action.
+ *
+ * `opts.manual` distinguishes the operator-triggered re-run (the health-page
+ * "Run" button) from the scheduled tick: it threads into reader probes over
+ * expensive checks (`sso_verify`, #1709) so a manual re-run actually
+ * re-executes the verification instead of re-displaying the stored report.
+ * The scheduled path leaves it false → no per-tick ephemeral-user churn.
  */
 export async function runDiagnoseChecks(
   nodeName = 'Local',
+  opts: { manual?: boolean } = {},
 ): Promise<CheckResult[]> {
-  const { probes } = await runDiagnose(nodeName);
+  const { probes } = await runDiagnose(nodeName, { manual: opts.manual });
   const results = probes
     .map(probe => HealthStore.getLastResult(diagnoseCheckId(probe.id)))
     .filter((r): r is CheckResult => r !== null);

--- a/packages/backend/src/lib/diagnose/probes/domainUnreachable.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainUnreachable.test.ts
@@ -40,11 +40,29 @@ vi.mock('@/lib/adguard/rewrites', () => ({
   listRewrites: vi.fn(() => Promise.resolve([])),
 }));
 
-import { dispatchProbeAction, actionsForProbe } from '../actions';
+// dns/promises Resolver — drive resolve4 per-test so we can simulate a
+// timeout (inconclusive) vs. a definitive NXDOMAIN (#1708).
+const resolve4Mock = vi.fn<(domain: string) => Promise<string[]>>();
+let resolve4Impl: (domain: string) => Promise<string[]>;
+vi.mock('dns/promises', () => {
+  class MockResolver {
+    setServers() {}
+    resolve4(domain: string) {
+      return resolve4Mock(domain);
+    }
+  }
+  return { default: { Resolver: MockResolver }, Resolver: MockResolver };
+});
+
+import { dispatchProbeAction, actionsForProbe, type ProbeItem } from '../actions';
+import { checkDomainUnreachable } from './domainUnreachable';
 import './domainUnreachable';
+import { getConfig } from '@/lib/config';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resolve4Impl = async () => ['203.0.113.7']; // default: resolves
+  resolve4Mock.mockImplementation((domain: string) => resolve4Impl(domain));
 });
 
 describe('domain_unreachable.action registration', () => {
@@ -128,5 +146,77 @@ describe('domain_unreachable.show_public_dns_instructions', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/No domain supplied/);
+  });
+});
+
+// #1708 — a DNS *timeout* (inconclusive) must NOT be reported as a missing
+// A-record. Only a definitive NXDOMAIN/empty answer may say "missing".
+describe('domain_unreachable.dns-timeout-vs-nxdomain (#1708)', () => {
+  const publicHost = {
+    domain: 'home.example.com',
+    service: 'home',
+    forwardPort: 8123,
+    created: true,
+    exposure: 'public' as const,
+  };
+
+  function configWith(hosts: unknown[]) {
+    (getConfig as any).mockResolvedValueOnce({
+      reverseProxy: { publicDomain: 'example.com', lanIp: '192.168.1.10', hosts },
+    });
+  }
+
+  it('a DNS timeout falls through to the fetch probe — NOT "A-record missing"', async () => {
+    configWith([publicHost]);
+    // Resolver times out / SERVFAILs → inconclusive (code not in the
+    // definitive-no-record set).
+    resolve4Impl = async () => {
+      const err = new Error('dns timeout') as NodeJS.ErrnoException;
+      err.code = 'ETIMEOUT';
+      throw err;
+    };
+    // The resolver-independent Host-header probe proves reachability: NPM
+    // answers 301 → https://<domain>/ which `diagnoseDomain` treats as healthy.
+    const fetchMock = vi.fn(async () => ({
+      status: 301,
+      text: async () => '',
+      headers: new Headers({ location: 'https://home.example.com/' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await checkDomainUnreachable();
+    // Reachable → no broken rows, no "A-record missing".
+    expect(res.status).toBe('ok');
+    const items = (res.items ?? []) as ProbeItem[];
+    expect(items.find(i => i.id === 'home.example.com')).toBeUndefined();
+    expect(JSON.stringify(res)).not.toMatch(/A-record likely missing/);
+    // The fetch (reachability) probe was actually consulted.
+    expect(fetchMock).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('a definitive NXDOMAIN still reports red "A-record missing"', async () => {
+    configWith([publicHost]);
+    resolve4Impl = async () => {
+      const err = new Error('queryA ENOTFOUND') as NodeJS.ErrnoException;
+      err.code = 'ENOTFOUND';
+      throw err;
+    };
+    const res = await checkDomainUnreachable();
+    expect(res.status).toBe('fail');
+    const items = (res.items ?? []) as ProbeItem[];
+    const row = items.find(i => i.id === 'home.example.com');
+    expect(row).toBeDefined();
+    expect(row!.status).toBe('fail');
+    expect(row!.detail).toMatch(/A-record likely missing/);
+  });
+
+  it('an empty answer (zero A records) is treated as NXDOMAIN', async () => {
+    configWith([publicHost]);
+    resolve4Impl = async () => [];
+    const res = await checkDomainUnreachable();
+    expect(res.status).toBe('fail');
+    const items = (res.items ?? []) as ProbeItem[];
+    expect(items.find(i => i.id === 'home.example.com')!.detail).toMatch(/A-record likely missing/);
   });
 });

--- a/packages/backend/src/lib/diagnose/probes/domainUnreachable.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainUnreachable.ts
@@ -37,7 +37,7 @@
  * `domain_external_reachability` (letsdebug).
  */
 
-import dns from 'dns/promises';
+import { Resolver } from 'dns/promises';
 import { getConfig, type ProxyHostEntry, type AppConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
 import { listRewrites } from '@/lib/adguard/rewrites';
@@ -123,15 +123,50 @@ function actionsForCause(cause: DiagnosisCause): string[] {
   }
 }
 
-async function resolveOrNull(hostname: string): Promise<string[] | null> {
+/**
+ * Outcome of a DNS A-record resolution, with the timeout/SERVFAIL ≠
+ * NXDOMAIN distinction the probe needs (#1708).
+ *
+ *  - `resolved`     — got ≥1 A record.
+ *  - `nxdomain`     — the resolver gave a *definitive* "no such record"
+ *                     answer (NXDOMAIN / NODATA / empty). Only this may be
+ *                     reported as "A-record missing".
+ *  - `inconclusive` — timeout / SERVFAIL / connection-refused / any other
+ *                     transient error. We couldn't tell, so we must NOT
+ *                     conclude "missing" — fall through to the
+ *                     resolver-independent reachability probe instead.
+ */
+type DnsOutcome =
+  | { kind: 'resolved'; addresses: string[] }
+  | { kind: 'nxdomain' }
+  | { kind: 'inconclusive'; detail: string };
+
+/**
+ * Node error codes that mean the resolver gave a *definitive* answer of
+ * "no A record for this name" — as opposed to "I couldn't reach / didn't
+ * hear back from the authoritative server". Anything outside this set
+ * (ETIMEOUT, ESERVFAIL, EREFUSED, ECONNREFUSED, …) is inconclusive.
+ */
+const DEFINITIVE_NO_RECORD_CODES = new Set(['ENOTFOUND', 'ENODATA', 'NXDOMAIN', 'NODATA']);
+
+/**
+ * Resolve a hostname's A records via `dns.resolve4` (a real DNS query
+ * through c-ares — async, NOT bound to the libuv getaddrinfo threadpool,
+ * and it surfaces NXDOMAIN vs timeout distinctly). `dns.lookup` was the
+ * old path; under ~19 concurrent lookups it queued 4-at-a-time on the
+ * threadpool and the tail blew the 3 s race, then a *timeout* was
+ * misreported as a missing A-record (#1708). resolve4 has neither problem.
+ */
+async function resolveA(hostname: string): Promise<DnsOutcome> {
   try {
-    const records = await Promise.race([
-      dns.lookup(hostname, { all: true }),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('dns timeout')), DNS_TIMEOUT_MS)),
-    ]);
-    return records.map(r => r.address);
-  } catch {
-    return null;
+    const resolver = new Resolver({ timeout: DNS_TIMEOUT_MS, tries: 1 });
+    const records = await resolver.resolve4(hostname);
+    if (records.length === 0) return { kind: 'nxdomain' };
+    return { kind: 'resolved', addresses: records };
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code && DEFINITIVE_NO_RECORD_CODES.has(code)) return { kind: 'nxdomain' };
+    return { kind: 'inconclusive', detail: code ?? (e instanceof Error ? e.message : String(e)) };
   }
 }
 
@@ -246,10 +281,15 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
       };
     }
   } else {
-    // Public domain — verify the public resolver returns at least one
-    // address. If it doesn't, the A-record is missing entirely.
-    const ips = await resolveOrNull(domain);
-    if (!ips || ips.length === 0) {
+    // Public domain — verify the resolver returns at least one address.
+    // Crucially (#1708): only a *definitive* NXDOMAIN/empty answer means
+    // the A-record is missing. A DNS timeout / SERVFAIL is inconclusive —
+    // the resolver was slow or contended, not authoritative — so we must
+    // NOT conclude "missing"; we fall through to the resolver-independent
+    // Host-header reachability probe below, which is what actually proves
+    // the domain is reachable.
+    const dnsOutcome = await resolveA(domain);
+    if (dnsOutcome.kind === 'nxdomain') {
       return {
         status: 'fail',
         reason: 'Hostname does not resolve via public DNS. A-record likely missing.',
@@ -257,6 +297,7 @@ async function diagnoseDomain(host: ProxyHostEntry, config: AppConfig): Promise<
         cause: 'public_dns_missing',
       };
     }
+    // 'resolved' or 'inconclusive' → fall through to the Host-header probe.
   }
 
   // 3. Routing test — talk to NPM directly on the LAN IP with

--- a/packages/backend/src/lib/diagnose/probes/ssoVerify.manualRerun.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/ssoVerify.manualRerun.test.ts
@@ -1,0 +1,94 @@
+ 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #1709 — a *manual* re-run of sso_verify must actually re-verify
+// (call verifySso, persist a fresh report) instead of re-displaying the
+// stale stored report. A *scheduled* tick stays read-only (store read,
+// no ephemeral-user churn).
+
+const verifySso = vi.fn();
+const loadSsoVerifyReport = vi.fn();
+const saveSsoVerifyReport = vi.fn();
+
+vi.mock('@/lib/diagnose/ssoVerify', () => ({
+  verifySso: (...args: unknown[]) => verifySso(...args),
+}));
+
+vi.mock('@/lib/diagnose/ssoVerifyStore', () => ({
+  loadSsoVerifyReport: (...args: unknown[]) => loadSsoVerifyReport(...args),
+  saveSsoVerifyReport: (...args: unknown[]) => saveSsoVerifyReport(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { checkSsoVerify } from './ssoVerify';
+import type { SsoVerifyReport } from '@/lib/diagnose/ssoVerify';
+
+const passingReport = (): SsoVerifyReport => ({
+  ok: true,
+  couldNotRun: false,
+  cleanedUp: true,
+  ephemeralUser: 'sb-ssoverify-1-aa',
+  steps: [{ id: 'create_user', status: 'pass', detail: 'created' }],
+  userDomains: [{ domain: 'vault.example.com', status: 'pass', code: 200, detail: 'HTTP 200' }],
+  adminDomains: [{ domain: 'nginx.example.com', status: 'pass', code: 302, detail: 'HTTP 302' }],
+});
+
+const staleStored = {
+  at: '2026-06-04T17:29:00.000Z',
+  report: { ...passingReport(), ok: false },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('checkSsoVerify manual vs scheduled (#1709)', () => {
+  it('manual re-run calls verifySso and persists a FRESH report with a current timestamp', async () => {
+    const fresh = passingReport();
+    verifySso.mockResolvedValueOnce(fresh);
+    const freshAt = new Date().toISOString();
+    saveSsoVerifyReport.mockImplementationOnce(async (report: SsoVerifyReport) => ({ at: freshAt, report }));
+
+    const res = await checkSsoVerify({ manual: true, node: 'Local' });
+
+    // Real verification ran...
+    expect(verifySso).toHaveBeenCalledTimes(1);
+    expect(verifySso).toHaveBeenCalledWith({ node: 'Local' });
+    // ...the fresh report was persisted...
+    expect(saveSsoVerifyReport).toHaveBeenCalledTimes(1);
+    expect(saveSsoVerifyReport).toHaveBeenCalledWith(fresh);
+    // ...the stale store read was NOT used as the source of truth...
+    expect(loadSsoVerifyReport).not.toHaveBeenCalled();
+    // ...and the rendered probe reflects the fresh (passing) report + timestamp.
+    expect(res.status).toBe('ok');
+    expect(res.detail).toContain(freshAt);
+  });
+
+  it('scheduled tick reads the store only — does NOT call verifySso', async () => {
+    loadSsoVerifyReport.mockResolvedValueOnce(staleStored);
+
+    const res = await checkSsoVerify(); // no manual flag → scheduled
+
+    expect(verifySso).not.toHaveBeenCalled();
+    expect(saveSsoVerifyReport).not.toHaveBeenCalled();
+    expect(loadSsoVerifyReport).toHaveBeenCalledTimes(1);
+    // Renders the stored report verbatim.
+    expect(res.status).toBe('fail');
+    expect(res.detail).toContain('2026-06-04T17:29');
+  });
+
+  it('a manual verify failure falls back to the last stored report (row not erased)', async () => {
+    verifySso.mockRejectedValueOnce(new Error('lldap unreachable'));
+    loadSsoVerifyReport.mockResolvedValueOnce(staleStored);
+
+    const res = await checkSsoVerify({ manual: true });
+
+    expect(verifySso).toHaveBeenCalledTimes(1);
+    expect(loadSsoVerifyReport).toHaveBeenCalledTimes(1);
+    // Falls back to the stored (stale) report rather than a bare error.
+    expect(res.status).toBe('fail');
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/ssoVerify.ts
+++ b/packages/backend/src/lib/diagnose/probes/ssoVerify.ts
@@ -151,9 +151,46 @@ export function reportToProbe(stored: StoredSsoVerifyReport | null): SsoVerifyPr
   };
 }
 
-/** Read the persisted report and render it as a probe. Never throws — a
- *  store read error degrades to "not run yet" (info). */
-export async function checkSsoVerify(): Promise<SsoVerifyProbeResult> {
+/** Options threaded from the diagnose orchestrator into this probe.
+ *
+ *  `manual` is the crux of #1709: a *scheduled* diagnose tick reads the
+ *  stored report only (the full create→login→…→delete spine is expensive —
+ *  spinning a real LLDAP user on every poll is unacceptable). A *manual*
+ *  re-run (operator clicks "Run" on the row) must actually re-verify, just
+ *  like the `run_now` action — otherwise the re-run is a UX lie that
+ *  re-displays a stale report while only advancing the timestamp. */
+export interface SsoVerifyProbeOptions {
+  /** True when the operator explicitly re-ran this probe (vs. a scheduled
+   *  tick). Drives the read-cache vs. re-execute decision. */
+  manual?: boolean;
+  /** Node to verify against; passed to `verifySso`. */
+  node?: string;
+}
+
+/** Render the probe. On a *scheduled* tick this reads the persisted report
+ *  (cheap). On a *manual* re-run (#1709) it executes the real `verifySso()`,
+ *  persists the fresh report, and renders that — so re-run actually re-runs.
+ *  Never throws — a store/verify error degrades to an info row. */
+export async function checkSsoVerify(opts: SsoVerifyProbeOptions = {}): Promise<SsoVerifyProbeResult> {
+  if (opts.manual) {
+    try {
+      const report = await verifySso({ node: opts.node ?? 'Local' });
+      const stored = await saveSsoVerifyReport(report);
+      return reportToProbe(stored);
+    } catch (e) {
+      // A live-verify failure must not erase the row — fall back to the
+      // last stored report so the operator still sees the previous result.
+      logger.warn(`diagnose:${PROBE_ID}`, `manual re-verify threw: ${e instanceof Error ? e.message : String(e)}`);
+      try {
+        return reportToProbe(await loadSsoVerifyReport());
+      } catch {
+        return {
+          status: 'info',
+          detail: `SSO re-verification could not run: ${e instanceof Error ? e.message : String(e)}`,
+        };
+      }
+    }
+  }
   try {
     const stored = await loadSsoVerifyReport();
     return reportToProbe(stored);

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -201,6 +201,14 @@ export interface DiagnoseResult {
   probes: DiagnoseProbe[];
 }
 
+/** Options for a diagnose run. `manual` distinguishes an operator-triggered
+ *  re-run (the health-page "Run" button) from a scheduled tick — it threads
+ *  into "reader" probes over expensive checks (e.g. `sso_verify`, #1709) so a
+ *  manual re-run actually re-executes instead of re-displaying the cache. */
+export interface RunDiagnoseOptions {
+  manual?: boolean;
+}
+
 /** Build the consolidated `sso_verify` ("Login / SSO") probe row
  *  (#1455 + #1535).
  *
@@ -219,14 +227,16 @@ export interface DiagnoseResult {
  *
  *  Extracted from the orchestrator so the try/catch + merge shape doesn't
  *  add to `runDiagnose`'s already-large complexity budget. */
-async function buildSsoVerifyProbe(nodeName: string): Promise<DiagnoseProbe> {
+async function buildSsoVerifyProbe(nodeName: string, manual: boolean): Promise<DiagnoseProbe> {
   try {
     const [oidc, sso] = await Promise.all([
       checkOidcProviderReachable(nodeName).catch((e): Awaited<ReturnType<typeof checkOidcProviderReachable>> => ({
         status: 'info',
         detail: `OIDC reachability check skipped: ${e instanceof Error ? e.message : String(e)}`,
       })),
-      checkSsoVerify(),
+      // #1709: a manual re-run actually re-verifies (real verifySso, persist
+      // fresh report); a scheduled tick reads the stored report only.
+      checkSsoVerify({ manual, node: nodeName }),
     ]);
     const rank = { ok: 0, info: 0, warn: 1, fail: 2 } as const;
     // OIDC-provider-down outranks an SSO-report finding: if Authelia
@@ -257,7 +267,8 @@ async function buildSsoVerifyProbe(nodeName: string): Promise<DiagnoseProbe> {
 
 /** Run the diagnose probe battery against `nodeName`. Pure orchestrator —
  *  the route returns this verbatim under NextResponse.json. */
-export async function runDiagnose(nodeName: string = 'Local'): Promise<DiagnoseResult> {
+export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseOptions = {}): Promise<DiagnoseResult> {
+  const manual = opts.manual ?? false;
   const probes: DiagnoseProbe[] = [];
   const exec = async (command: string, timeoutMs = 8000): Promise<ExecResult> => {
     try {
@@ -886,7 +897,7 @@ export async function runDiagnose(nodeName: string = 'Local'): Promise<DiagnoseR
   //     green) and carries the persisted end-to-end login report (real
   //     family-group login reaches every user domain, is blocked from
   //     admin-only ones) with an on-demand "Run SSO check" action.
-  probes.push(await buildSsoVerifyProbe(nodeName));
+  probes.push(await buildSsoVerifyProbe(nodeName, manual));
 
   // 14c) Proxy route create-failures (B12) are now folded into the
   //     consolidated `dangling_proxy` ("Reverse-proxy routes") row above

--- a/packages/backend/src/lib/diagnose/ssoVerifyStore.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerifyStore.ts
@@ -36,8 +36,12 @@ export interface StoredSsoVerifyReport {
  * file. Best-effort: a write failure is logged and swallowed — the
  * verification itself already ran; failing to cache it must not bubble
  * into the install runner or the on-demand action.
+ *
+ * Returns the stored shape (`{ at, report }`) it just persisted so a
+ * caller (e.g. the manual sso_verify re-run, #1709) can render the *fresh*
+ * report — with its current timestamp — without a follow-up read race.
  */
-export async function saveSsoVerifyReport(report: SsoVerifyReport): Promise<void> {
+export async function saveSsoVerifyReport(report: SsoVerifyReport): Promise<StoredSsoVerifyReport> {
   const payload: StoredSsoVerifyReport = { at: new Date().toISOString(), report };
   try {
     await fs.mkdir(DATA_DIR, { recursive: true });
@@ -47,6 +51,7 @@ export async function saveSsoVerifyReport(report: SsoVerifyReport): Promise<void
   } catch (e) {
     logger.warn('ssoVerifyStore', `could not persist SSO verify report: ${e instanceof Error ? e.message : String(e)}`);
   }
+  return payload;
 }
 
 /**

--- a/packages/backend/src/lib/mcp/bootstrapToken.test.ts
+++ b/packages/backend/src/lib/mcp/bootstrapToken.test.ts
@@ -185,7 +185,7 @@ describe('lazyInitializeExpiry', () => {
 });
 
 describe('revokeBootstrapToken', () => {
-  it('removes the bootstrapToken entry from auth', async () => {
+  it('deactivates by expiring in place — KEEPS the hash, sets expiresAt to the past (#1705)', async () => {
     mockGetConfig.mockResolvedValue({
       auth: {
         username: 'admin',
@@ -195,9 +195,10 @@ describe('revokeBootstrapToken', () => {
     });
     expect(await revokeBootstrapToken()).toBe(true);
     const arg = mockUpdateConfig.mock.calls[0][0];
-    expect(arg.auth.bootstrapToken).toBeUndefined();
-    expect(arg.auth.username).toBe('admin');
-    expect(arg.auth.passwordHash).toBe('kept');
+    // Hash is preserved (so it stays re-activatable), but expiresAt is in the past.
+    expect(arg.auth.bootstrapToken.hash).toBe('abc');
+    expect(arg.auth.bootstrapToken.scope).toBe('read');
+    expect(Date.parse(arg.auth.bootstrapToken.expiresAt)).toBeLessThan(Date.now());
   });
 
   it('returns false when nothing to revoke', async () => {
@@ -271,11 +272,56 @@ describe('reactivateBootstrapToken (#1419)', () => {
     expect(Date.parse(arg.auth.bootstrapToken.expiresAt)).toBeGreaterThan(Date.now());
   });
 
-  it('is a no-op (no-bootstrap-token) once the entry was revoked', async () => {
+  it('is a no-op (no-bootstrap-token) only when no entry was ever installed', async () => {
     mockGetConfig.mockResolvedValue({ auth: {} });
     const r = await reactivateBootstrapToken();
     expect(r).toEqual({ ok: false, reason: 'no-bootstrap-token' });
     expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+});
+
+// End-to-end: minting a named token deactivates (but keeps) the bootstrap
+// token, so it stays re-activatable and a configured MCP client reconnects
+// with the SAME token value (#1705 — the regression that #322 deletion caused).
+describe('mint → re-activate → reconnect round-trip (#1705)', () => {
+  const RAW = 'bootstrap-secret';
+
+  // Drive an actual revoke (simulating the first named-token mint), capturing
+  // the written config so a follow-up getConfig sees the deactivated entry.
+  async function deactivateAndCapture() {
+    mockGetConfig.mockResolvedValue({
+      auth: { bootstrapToken: { hash: sha256(RAW), scope: 'read', expiresAt: new Date(Date.now() + 60_000).toISOString() } },
+    });
+    await revokeBootstrapToken();
+    const written = mockUpdateConfig.mock.calls[0][0].auth.bootstrapToken;
+    mockGetConfig.mockResolvedValue({ auth: { bootstrapToken: written } });
+    return written;
+  }
+
+  it('after a mint-revoke, status is present:true / active:false (re-activatable, not gone)', async () => {
+    await deactivateAndCapture();
+    expect(await getBootstrapTokenStatus()).toEqual({ active: false, present: true });
+  });
+
+  it('an un-reactivated (still-expired) bootstrap token stays inert — verify rejects', async () => {
+    await deactivateAndCapture();
+    await expect(verifyBootstrapToken(RAW, '192.168.1.10')).rejects.toThrow('Bootstrap token expired');
+  });
+
+  it('reactivate resets the TTL on the kept hash, then verify succeeds from a LAN IP', async () => {
+    await deactivateAndCapture();
+    mockUpdateConfig.mockClear();
+
+    const r = await reactivateBootstrapToken();
+    expect(r.ok).toBe(true);
+
+    // Persist the reactivation result and verify the ORIGINAL token value works.
+    const written = mockUpdateConfig.mock.calls[0][0].auth.bootstrapToken;
+    expect(written.hash).toBe(sha256(RAW));
+    mockGetConfig.mockResolvedValue({ auth: { bootstrapToken: written } });
+
+    const ctx = await verifyBootstrapToken(RAW, '192.168.1.10');
+    expect(ctx).toEqual({ user: 'bootstrap', scopes: ['read'], tokenId: 'bootstrap' });
   });
 });
 

--- a/packages/backend/src/lib/mcp/bootstrapToken.ts
+++ b/packages/backend/src/lib/mcp/bootstrapToken.ts
@@ -21,9 +21,14 @@
  * Lifecycle (config.auth.bootstrapToken):
  *   install      → { hash, scope: 'read' }
  *   first boot   → above + { expiresAt }   (set by lazyInitializeExpiry)
- *   first user-minted MCP token → entry deleted (revoke from tokens.ts)
- *   manual click → entry deleted (revoke API)
+ *   first user-minted MCP token → expired in place (revoke from apiTokenRoutes.ts)
+ *   manual click → expired in place (revoke API)
  *   30 min later → entry stays, validation rejects (expired)
+ *
+ * "Revoke" expires the token (expiresAt → past) but KEEPS the hash, so the
+ * operator can re-activate it later (#1419/#1552) — same token value, no new
+ * credential. An expired token is already inert (verifyBootstrapToken rejects
+ * on expiry), so deactivating-not-deleting carries no extra attack surface.
  */
 
 import crypto from 'crypto';
@@ -165,32 +170,35 @@ export async function verifyBootstrapToken(
   };
 }
 
-/** Delete the bootstrap-token entry from config. Called from the
+/** Deactivate (expire) the bootstrap-token entry. Called from the
  *  Settings UI, and automatically when the operator mints their first
- *  named MCP token (see tokens.ts createToken). Returns true iff
- *  there was something to revoke. */
+ *  named MCP token (see apiTokenRoutes.ts createTokenHandler). The hash
+ *  is KEPT but `expiresAt` is set to the epoch, so the token is inert
+ *  (verifyBootstrapToken rejects on expiry) yet stays re-activatable
+ *  (#1419/#1552 — reactivateBootstrapToken resets the TTL on the same
+ *  hash). Returns true iff there was something to deactivate. */
 export async function revokeBootstrapToken(): Promise<boolean> {
   const config = await getConfig();
-  if (!config.auth?.bootstrapToken?.hash) return false;
-  // deepMerge in updateConfig only acts on keys present on the source
-  // object, so `delete auth.bootstrapToken` would leave the existing
-  // entry intact. Explicit `undefined` falls through deepMerge's
-  // is-object branch and lands in the result as undefined, which
-  // JSON.stringify drops on save — that's the actual delete.
+  const bt = config.auth?.bootstrapToken;
+  if (!bt?.hash) return false;
+  // Keep the hash; set expiresAt to the epoch so the token is expired
+  // (and therefore rejected by verifyBootstrapToken) but the operator
+  // can still re-activate it from Settings → Security. Deleting the
+  // entry (the old behaviour) made re-activation impossible (#1705).
   await updateConfig({
     auth: {
-      ...config.auth,
-      bootstrapToken: undefined,
+      bootstrapToken: { ...bt, expiresAt: new Date(0).toISOString() },
     },
   });
-  logger.info('mcp:bootstrap', 'Bootstrap MCP token revoked.');
+  logger.info('mcp:bootstrap', 'Bootstrap MCP token deactivated (expired in place; re-activatable).');
   return true;
 }
 
 /** Surface state for the Settings UI. `present` is true whenever the
  *  bootstrap entry still exists (hash set) even if its window has lapsed —
- *  the UI uses it to offer re-activation (#1419). Once a named token is
- *  minted the entry is deleted, so `present` goes false permanently. */
+ *  the UI uses it to offer re-activation (#1419). Minting a named token (or
+ *  a manual revoke) now EXPIRES the token in place rather than deleting it,
+ *  so `present` stays true and the entry remains re-activatable (#1705). */
 export async function getBootstrapTokenStatus(): Promise<
   | { active: false; present: boolean }
   | { active: true; present: true; expiresAt: string | null; minutesRemaining: number | null }
@@ -225,10 +233,11 @@ export async function getBootstrapTokenStatus(): Promise<
 
 /** Re-activate (un-expire) the existing bootstrap token for another TTL_MIN
  *  window — same hash/identity, so an already-configured MCP client keeps
- *  working after it. No-op if the entry was already revoked (the first
- *  named-token mint deletes it). The token stays LAN-only + read-scope: its
- *  own verify gate (isLanIp) is unchanged, so re-activation only resets the
- *  clock. (#1419) */
+ *  working after it. No-op only if no bootstrap entry was ever installed
+ *  (the hash is now KEPT across mint/revoke — they just expire it — so this
+ *  works even after the operator minted named tokens, #1705). The token
+ *  stays LAN-only + read-scope: its own verify gate (isLanIp) is unchanged,
+ *  so re-activation only resets the clock. (#1419) */
 export async function reactivateBootstrapToken(): Promise<
   | { ok: true; expiresAt: string; minutesRemaining: number }
   | { ok: false; reason: 'no-bootstrap-token' }

--- a/packages/frontend/src/app/api/health/checks/[id]/run/route.ts
+++ b/packages/frontend/src/app/api/health/checks/[id]/run/route.ts
@@ -20,9 +20,15 @@ export const POST = withApiHandlerParams<undefined, undefined, Params>(
     // #1423: diagnose rows are synthetic (not in checks.json). Running
     // one re-runs the whole suite on-demand and returns this probe's
     // freshly-persisted result.
+    //
+    // #1709: this is the operator clicking "Run" — a *manual* re-run, so
+    // pass manual:true. That makes reader probes over expensive checks
+    // (sso_verify) actually re-execute the verification rather than
+    // re-displaying a stale stored report. The scheduled tick stays
+    // read-only (it calls runDiagnoseChecks without the flag).
     if (isDiagnoseCheckId(id)) {
       try {
-        const results = await runDiagnoseChecks('Local');
+        const results = await runDiagnoseChecks('Local', { manual: true });
         const result = results.find(r => r.check_id === id);
         if (!result) {
           return NextResponse.json({ error: 'Diagnose probe not found' }, { status: 404 });

--- a/packages/frontend/src/content/help/mcp.md
+++ b/packages/frontend/src/content/help/mcp.md
@@ -9,7 +9,7 @@ YAML, manage proxy routes, run backups, configure health checks, and more.
 
 ### 1. Create an API token (recommended)
 
-Open **Settings → Integrations → MCP Server → API tokens → New token**.
+Open **Settings → Security → API tokens → New token**.
 Pick a name (e.g. `Claude Code on workstation`) and the scopes you want
 this client to have:
 
@@ -30,7 +30,7 @@ claude mcp add --transport http servicebay \
 ```
 
 Replace `<YOUR_SERVICEBAY_URL>` with the URL you used to log in (the same
-one shown in the **MCP Server** card on Settings → Integrations).
+one shown in the **MCP Server** card on Settings → Security).
 
 > **Legacy: session cookie.** Pre-existing MCP setups that pass
 > `Cookie: session=<JWT>` still work and have full scopes. New clients

--- a/packages/frontend/src/dashboards/SystemInfoDashboard.test.tsx
+++ b/packages/frontend/src/dashboards/SystemInfoDashboard.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * SystemInfoContent layout tests (#1706/#1707).
+ *
+ * Asserts the System health "Resources" grid layout after the two operator
+ * UI-polish changes:
+ *  - #1706: DNS resolvers is folded into the single Network Interfaces card as
+ *    a labelled sub-section (no standalone "DNS Resolvers" card), with the
+ *    public-resolver split-horizon warning kept prominent.
+ *  - #1707: Graphics + Network Interfaces cards are half-width (no
+ *    `md:col-span-2`), like Compute/Storage.
+ *
+ * The component is hook-driven (digital twin + socket + server actions), so
+ * those are mocked to feed a deterministic resources snapshot.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const twinRef: { current: unknown } = { current: null };
+
+vi.mock('@/hooks/useDigitalTwin', () => ({
+  useDigitalTwin: () => ({ data: twinRef.current }),
+}));
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => ({ socket: null, isConnected: false }),
+}));
+vi.mock('@/app/actions/nodes', () => ({
+  getNodes: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/app/actions/system', () => ({
+  getSystemUpdates: vi.fn().mockResolvedValue({ count: 0, list: [] }),
+}));
+vi.mock('@/providers/ToastProvider', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+import { SystemInfoContent } from './SystemInfoDashboard';
+
+function makeTwin(dnsServers: string[], boxIp = '192.168.178.100') {
+  return {
+    serverName: 'box',
+    nodes: {
+      Local: {
+        resources: {
+          cpuUsage: 10,
+          memoryUsage: 1_000_000,
+          totalMemory: 8_000_000,
+          cpu: { model: 'Test CPU', cores: 4 },
+          os: {
+            hostname: 'box',
+            platform: 'Fedora CoreOS',
+            arch: 'x86_64',
+            uptime: 3600,
+          },
+          disks: [{ mountpoint: '/', type: 'xfs', total: 100, used: 50 }],
+          network: {
+            eth0: [{ internal: false, family: 'IPv4', address: boxIp }],
+          },
+          gpus: [{ uuid: 'gpu-1', name: 'Test GPU', vendor: 'nvidia' }],
+          dnsResolvers: { servers: dnsServers, source: 'resolvectl' },
+        },
+      },
+    },
+  };
+}
+
+/** The card container <div> that holds the given heading text. */
+function cardFor(headingText: string): HTMLElement {
+  const heading = screen.getByText(headingText);
+  // h3 heading -> parent div is the card container.
+  const card = heading.closest('div');
+  if (!card) throw new Error(`no card container for "${headingText}"`);
+  return card;
+}
+
+describe('SystemInfoContent layout (#1706/#1707)', () => {
+  beforeEach(() => {
+    twinRef.current = null;
+  });
+
+  it('renders ONE Network card with a folded-in DNS resolvers sub-section, no standalone DNS card', () => {
+    twinRef.current = makeTwin(['127.0.0.1', '192.168.178.1']);
+    render(<SystemInfoContent />);
+
+    // Single combined Network card.
+    expect(screen.getByText('Network Interfaces')).toBeDefined();
+    // No standalone "DNS Resolvers" card heading (the old h3).
+    expect(screen.queryByText(/DNS Resolvers \(/)).toBeNull();
+    // The folded-in labelled sub-section heading lives inside the Network card.
+    const dnsSub = screen.getByText(/DNS resolvers \(/);
+    const networkCard = cardFor('Network Interfaces');
+    expect(networkCard.contains(dnsSub)).toBe(true);
+    // Resolver rows + source line render inside the same card.
+    expect(networkCard.textContent).toContain('127.0.0.1');
+    expect(networkCard.textContent).toContain('192.168.178.1');
+    expect(networkCard.textContent).toContain('source: resolvectl');
+  });
+
+  it('keeps the public-resolver split-horizon warning prominent in the folded sub-section', () => {
+    twinRef.current = makeTwin(['8.8.8.8']);
+    render(<SystemInfoContent />);
+
+    const networkCard = cardFor('Network Interfaces');
+    const warning = screen.getByText('A public DNS resolver is configured');
+    expect(networkCard.contains(warning)).toBe(true);
+  });
+
+  it('renders Graphics + Network Interfaces half-width (no md:col-span-2), like Compute/Storage', () => {
+    twinRef.current = makeTwin(['192.168.178.1']);
+    render(<SystemInfoContent />);
+
+    const graphicsCard = cardFor('Graphics (1)');
+    const networkCard = cardFor('Network Interfaces');
+    expect(graphicsCard.className).not.toContain('md:col-span-2');
+    expect(networkCard.className).not.toContain('md:col-span-2');
+  });
+});

--- a/packages/frontend/src/dashboards/SystemInfoDashboard.tsx
+++ b/packages/frontend/src/dashboards/SystemInfoDashboard.tsx
@@ -348,11 +348,11 @@ export function SystemInfoContent() {
             {/* GPUs — only shown when the agent reports at least one. CPU-only
                 hosts get nothing here so the grid stays compact. */}
             {gpus && gpus.length > 0 && (
-                <div className="md:col-span-2 bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
+                <div className="bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
                     <h3 className="text-lg font-medium mb-4 flex items-center gap-2">
                         <Cpu size={20} /> Graphics ({gpus.length})
                     </h3>
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                    <div className="grid grid-cols-1 gap-4">
                         {gpus.map((gpu, i) => {
                             const memUsedFrac = (gpu.memoryUsed != null && gpu.memoryTotal && gpu.memoryTotal > 0)
                                 ? Math.round((gpu.memoryUsed / gpu.memoryTotal) * 100) : null;
@@ -408,19 +408,19 @@ export function SystemInfoContent() {
                 </div>
             )}
 
-            {/* Network Interfaces */}
-            <div className="md:col-span-2 bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
+            {/* Network Interfaces (+ DNS resolvers sub-section, folded in per #1706) */}
+            <div className="bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
                 <h3 className="text-lg font-medium mb-4 flex items-center gap-2">
                     <Network size={20} /> Network Interfaces
                 </h3>
-                
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                     {network && Object.entries(network).map(([ifaceName, addrs]) => (
                         <div key={ifaceName} className="border border-gray-200 dark:border-gray-700 rounded p-3">
                             <div className="font-medium text-sm mb-2 pb-1 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center">
                                 <span>{ifaceName}</span>
-                                {(addrs as NetworkAddr[]).some(a => !a.internal) ? 
-                                    <span className="text-[10px] bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100 px-1.5 py-0.5 rounded">Public</span> : 
+                                {(addrs as NetworkAddr[]).some(a => !a.internal) ?
+                                    <span className="text-[10px] bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100 px-1.5 py-0.5 rounded">Public</span> :
                                     <span className="text-[10px] bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded">Local</span>
                                 }
                             </div>
@@ -440,62 +440,63 @@ export function SystemInfoContent() {
                         <div className="col-span-full text-center text-gray-400 py-4">No network information available</div>
                     )}
                 </div>
-            </div>
 
-            {/* DNS Resolvers — the box's effective resolver list, labelled.
-                A public resolver here is the #1559 split-horizon trap (breaks
-                *.<domain> SSO resolution after reinstall), so it warns. */}
-            <div className="md:col-span-2 bg-white dark:bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700">
-                <h3 className="text-lg font-medium mb-4 flex items-center gap-2">
-                    <Network size={20} /> DNS Resolvers ({dnsSummary.resolvers.length})
-                </h3>
+                {/* DNS resolvers — the box's effective resolver list, labelled.
+                    Folded in here (#1706) rather than its own card. A public
+                    resolver is the #1559 split-horizon trap (breaks *.<domain>
+                    SSO resolution after reinstall), so it stays prominent. */}
+                <div className="mt-6 pt-4 border-t border-gray-100 dark:border-gray-700">
+                    <h4 className="text-sm font-medium mb-3 flex items-center gap-2 text-gray-600 dark:text-gray-300">
+                        <Network size={16} /> DNS resolvers ({dnsSummary.resolvers.length})
+                    </h4>
 
-                {dnsSummary.hasPublicResolver && (
-                    <div className="mb-4 flex items-start gap-2 p-3 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 text-sm">
-                        <AlertTriangle size={18} className="shrink-0 mt-0.5" />
-                        <div>
-                            <div className="font-medium">A public DNS resolver is configured</div>
-                            <div className="text-xs mt-0.5 opacity-90">
-                                Public resolvers don&apos;t know your LAN addresses, so they can silently break
-                                split-horizon resolution of <span className="font-mono">*.&lt;domain&gt;</span> after a
-                                reinstall (SSO logins fail). Point the box at AdGuard / the router instead.
+                    {dnsSummary.hasPublicResolver && (
+                        <div className="mb-3 flex items-start gap-2 p-3 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 text-sm">
+                            <AlertTriangle size={18} className="shrink-0 mt-0.5" />
+                            <div>
+                                <div className="font-medium">A public DNS resolver is configured</div>
+                                <div className="text-xs mt-0.5 opacity-90">
+                                    Public resolvers don&apos;t know your LAN addresses, so they can silently break
+                                    split-horizon resolution of <span className="font-mono">*.&lt;domain&gt;</span> after a
+                                    reinstall (SSO logins fail). Point the box at AdGuard / the router instead.
+                                </div>
                             </div>
                         </div>
-                    </div>
-                )}
+                    )}
 
-                <div className="space-y-2">
-                    {dnsSummary.resolvers.map((r, i) => {
-                        const labelStyles: Record<DnsResolverLabel, string> = {
-                            AdGuard: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100',
-                            router: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100',
-                            public: 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-100',
-                            other: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300',
-                        };
-                        return (
-                            <div key={i} className="flex items-center justify-between gap-2 text-sm border border-gray-100 dark:border-gray-800 rounded px-3 py-2">
-                                <span className="font-mono break-all">{r.address}</span>
-                                <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${labelStyles[r.label]}`}>
-                                    {r.label}
-                                </span>
-                            </div>
-                        );
-                    })}
-                    {dnsSummary.resolvers.length === 0 && (
-                        <div className="text-center text-gray-400 py-4">No DNS resolver information available</div>
+                    <div className="space-y-2">
+                        {dnsSummary.resolvers.map((r, i) => {
+                            const labelStyles: Record<DnsResolverLabel, string> = {
+                                AdGuard: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100',
+                                router: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100',
+                                public: 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-100',
+                                other: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300',
+                            };
+                            return (
+                                <div key={i} className="flex items-center justify-between gap-2 text-sm border border-gray-100 dark:border-gray-800 rounded px-3 py-2">
+                                    <span className="font-mono break-all">{r.address}</span>
+                                    <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${labelStyles[r.label]}`}>
+                                        {r.label}
+                                    </span>
+                                </div>
+                            );
+                        })}
+                        {dnsSummary.resolvers.length === 0 && (
+                            <div className="text-center text-gray-400 py-4">No DNS resolver information available</div>
+                        )}
+                    </div>
+
+                    {dnsSummary.resolvers.length > 0 && !dnsSummary.hasPublicResolver && (
+                        <div className="mt-3 flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
+                            <ShieldCheck size={14} />
+                            <span>All resolvers are local (AdGuard / router) — split-horizon resolution is safe.</span>
+                        </div>
+                    )}
+
+                    {dnsResolvers?.source && dnsResolvers.source !== 'unknown' && (
+                        <div className="mt-2 text-[10px] text-gray-400">source: {dnsResolvers.source}</div>
                     )}
                 </div>
-
-                {dnsSummary.resolvers.length > 0 && !dnsSummary.hasPublicResolver && (
-                    <div className="mt-3 flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
-                        <ShieldCheck size={14} />
-                        <span>All resolvers are local (AdGuard / router) — split-horizon resolution is safe.</span>
-                    </div>
-                )}
-
-                {dnsResolvers?.source && dnsResolvers.source !== 'unknown' && (
-                    <div className="mt-2 text-[10px] text-gray-400">source: {dnsResolvers.source}</div>
-                )}
             </div>
         </div>
       </div>


### PR DESCRIPTION
## What
Three units across the System-health / diagnose / MCP-auth surface:
- **#1706/#1707 (gate=verify)** — SystemInfoDashboard layout: fold DNS Resolvers into the Network Interfaces card (public-resolver warning intact), drop `md:col-span-2` on Graphics + Network so they render half-width (2-per-row at md+).
- **#1708/#1709** — diagnose probe correctness: DNS timeout/SERVFAIL no longer reported as a missing A-record (only NXDOMAIN/empty does), falling through to a resolver-independent reachability probe; sso_verify manual re-run now actually calls `verifySso()` instead of returning the stored report (scheduled tick stays read-only).
- **#1705** — re-activatable bootstrap MCP token: `revokeBootstrapToken()` now expires-in-place (keeps the hash) instead of deleting, so the Security banner shows Re-activate and an already-configured MCP client reconnects; help copy corrected (Settings → Security).

## Why
Closes #1706
Closes #1707
Closes #1705
Closes #1708
Closes #1709

## Risk
Low — frontend layout + diagnose-probe logic + token-lifecycle, all unit-covered; no install/backup path touched beyond the verify-gated dashboard.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2291 passed, 2 skipped)
- [ ] /verify on FCoS :dev box — System health page renders correctly + diagnose/health green (gate=verify #1706/#1707; path-mandated packages/frontend/src/dashboards/)

<!-- sb-ai-comment -->
AI-generated