### PR TITLE
docs(adr): ADR 0003–0008 + index — migrate durable architecture decisions from memory

### DIFF
--- a/docs/adr/0003-releases-via-release-please-only.md
+++ b/docs/adr/0003-releases-via-release-please-only.md
@@ -1,0 +1,46 @@
+# ADR 0003 — Versioning and releases go through release-please only; commit subjects stay parser-clean
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Deciders:** operator (mdopp)
+- **Related:** [ADR 0004](0004-installs-are-non-destructive.md), CONTRIBUTING.md
+
+## Context
+
+Versions are owned by **release-please**, which bumps `package.json`,
+`package-lock.json`, `.release-please-manifest.json`, the `CHANGELOG.md`, and
+cuts the GitHub release + tag when its release PR is merged. Two recurring
+failure modes motivated writing this down:
+
+1. **Manual version bumps** drift from release-please's manifest and corrupt
+   the next release PR.
+2. **release-please silently cuts no PR** when a merged commit message can't be
+   parsed: a non-numeric parenthetical like `(#credential-loss)`, or
+   parens-heavy code in the body (`JSON.parse(x.slice(...))`), makes the
+   conventional-commit parser log *"commit could not be parsed … unexpected
+   token '('"* and report `0 commits`. The workflow runs **green** but opens no
+   release PR (hit 2026-05-22, PR #828). GitHub squash-merge of a single-commit
+   PR uses that commit's message verbatim, so a sloppy local subject reaches
+   `main`.
+
+## Decision
+
+1. **Never hand-edit version fields.** release-please is the only path that
+   changes versions/changelog/tags. The only release action is **merging the
+   release-please PR** (branch `release-please--branches--main--components--servicebay`).
+2. **Commit subjects are `type(scope): description`** with at most a **numeric**
+   `(#NNN)` PR reference. No `(#word)` tokens; no parens-heavy code snippets in
+   commit bodies — they break release-please's parser.
+3. **Batch coupled work into one PR/release.** Run CI/release/rebuild gates once
+   at the end and release at the box's reinstall/update boundary, not per step.
+   Split only genuinely independent or risky work.
+
+## Consequences
+
+- If a release PR never appears after a merge to `main`, **check the
+  release-please workflow log for "could not be parsed"** before assuming the
+  merge was fine. `main` is **not** branch-protected, so the fix is to reword
+  the offending commit (`git commit --amend`, parens-free body) and force-push,
+  which re-triggers release-please.
+- Per-step releasing is avoided because the CI + release + sb-tui-rebuild tax
+  dominates for coupled changes.

--- a/docs/adr/0004-installs-are-non-destructive.md
+++ b/docs/adr/0004-installs-are-non-destructive.md
@@ -1,0 +1,45 @@
+# ADR 0004 — Installing/redeploying a service never wipes other services; system-wide reset is factory-reset-only
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Deciders:** operator (mdopp)
+- **Related:** [ADR 0002](0002-tiered-backup-nas-config-vs-bulk-drive.md), CREDENTIAL_SELF_HEAL.md
+
+## Context
+
+The installer's **"Clean install"** toggle called `/api/system/stacks/reset`,
+which wiped **every** service on the node and `rm -rf`'d `/mnt/data/stacks/*` —
+despite the modal title naming a single template ("Install Template:
+file-share"). On **2026-05-15** a single-template redeploy of file-share with
+"Clean install" ticked destroyed the operator's entire stack (nginx, auth,
+adguard, home-assistant, file-share, NPM, LLDAP) with **no backups**. Recovery
+was impossible.
+
+`cleanInstall` was retired (#1520, hard-set `false` server-side). But that flag
+**conflated two features**: the wipe-then-deploy nuke *and* NAS
+auto-restore-on-reinstall (#1218), which was gated on the same
+`if (!opts.cleanInstall)`. Killing the wipe (correctly) also silently disabled
+auto-restore for every install since (#1584).
+
+## Decision
+
+1. **A single-service install/redeploy MUST NOT touch other services' data.**
+   System-wide reset exists **only** as an explicit **Factory Reset**, never as
+   a side effect of installing or redeploying a template.
+2. **Destructive scope must be visually obvious and token-gated** — never trust
+   description text. A "wipe just this template" capability is a **separate
+   endpoint** with a per-item confirm token, not a widened system-wide reset
+   with a scope parameter callers might get wrong.
+3. **Auto-restore is decoupled from any wipe flag.** NAS auto-restore-on-
+   reinstall is gated on its own safe conditions (a backup exists **and** the
+   data dir is empty / `isFreshDataDir`), and logs a visible restore/skip
+   breadcrumb. The NAS resolves from `config.gateway` (FritzBox), not from the
+   optional `config.externalBackup`.
+
+## Consequences
+
+- Core/atomic-wipe stacks (`basic` = NPM + LLDAP/Authelia + AdGuard) can only be
+  wiped via Factory Reset; the TUI/UI blocks unchecking them ([ADR 0008](0008-tui-desired-state-and-journey.md)).
+- A *newer* NAS backup over *non-empty* surviving disk data is still skipped by
+  `isFreshDataDir` — a known follow-up needs a "newer backup exists — restore?"
+  surface rather than silently keeping stale data.

--- a/docs/adr/0005-dns-topology-pattern-a.md
+++ b/docs/adr/0005-dns-topology-pattern-a.md
@@ -1,0 +1,45 @@
+# ADR 0005 — DNS topology: the router hands out AdGuard as the LAN DNS (Pattern A); deterministic resolution beats public fallback
+
+- **Status:** Accepted (reverses an earlier Pattern-B preference, 2026-06-02)
+- **Date:** 2026-06-05
+- **Deciders:** operator (mdopp)
+- **Related:** [ADR 0001](0001-authentication-via-authelia-sso-or-lldap.md), [ADR 0006](0006-authelia-apex-deny-vs-wildcard.md)
+
+## Context
+
+This is a single-server homelab where **every app lives behind
+`*.<domain>`** and those names must resolve to the box for SSO/OIDC callbacks
+and the box→LLDAP fetch (`ldap.<domain>`) to work.
+
+The DNS layout matters more than it looks:
+
+- **Pattern A** — clients get **AdGuard** as their DHCP DNS server (the FritzBox
+  hands out AdGuard's IP); AdGuard resolves `*.<domain>` → box via rewrites, and
+  uses public DNS as its own upstream.
+- **Pattern B** (previously preferred for "resilience") — the FritzBox is the
+  client DNS, AdGuard only its upstream, with public fallback.
+
+The **2026-06-02 reinstall proved Pattern B is a trap**: when the
+FritzBox→AdGuard upstream link dropped, clients silently fell back to **public
+DNS**, which does not resolve `*.<domain>` to the box. Every internal SSO/OIDC
+callback and the box→LLDAP bind failed, and **all app logins broke**
+(vault/immich/jellyfin/audiobookshelf/file-share, #1559) with no obvious cause.
+
+## Decision
+
+1. **Pattern A is the supported default.** The router's DHCP hands out AdGuard
+   as the LAN DNS; AdGuard owns `*.<domain>` → box; public DNS is AdGuard's
+   upstream only. **Deterministic `*.<domain>` → box resolution beats
+   fallback-resilience** for this topology.
+2. The `router_dns_not_pointing` probe's expectation (DHCP-DNS pointed at
+   AdGuard/ServiceBay) is the **correct desired state**; a warn there is a real
+   misconfiguration, not a by-design Pattern B.
+3. `/verify` carries a **blocking** check that service domains resolve to the
+   box — a reinstall must not pass green while `*.<domain>` doesn't.
+
+## Consequences
+
+- The old "public fallback when AdGuard is down" argument is explicitly
+  **rejected**: that fallback is what silently breaks SSO.
+- If outage resilience is wanted, the answer is a **HA AdGuard pair**, not
+  falling back to a resolver that can't see the box's domains.

--- a/docs/adr/0006-authelia-apex-deny-vs-wildcard.md
+++ b/docs/adr/0006-authelia-apex-deny-vs-wildcard.md
@@ -1,0 +1,43 @@
+# ADR 0006 — Authelia: the bare apex is default-deny; only `*.<domain>` subdomains are `one_factor`
+
+- **Status:** Accepted (box-verified 2026-06-03)
+- **Date:** 2026-06-05
+- **Deciders:** operator (mdopp)
+- **Related:** [ADR 0001](0001-authentication-via-authelia-sso-or-lldap.md), [ADR 0005](0005-dns-topology-pattern-a.md)
+
+## Context
+
+Authelia's `access_control` is wildcard-scoped to subdomains. Verified against
+the live Authelia (`192.168.178.100:9091`):
+
+- `https://<domain>/` and `https://<domain>/portal` (**bare apex**) → **403**.
+  The apex matches no `access_control` rule, falls through to
+  `default_policy: deny`, and returns **no `Remote-User`/`Remote-Name`
+  headers** — even for a valid session.
+- `https://www.<domain>/` and any `*.<domain>` subdomain → **401** anon /
+  **200 + identity headers** when authed (the `*.<domain>` `one_factor` rule).
+  Even a nonexistent subdomain returns 401, confirming a true wildcard.
+- `https://auth.<domain>/` → 200 (Authelia's own portal bypass).
+
+This was the root cause of the portal showing "Don't have an account yet?" to
+signed-in SSO users (#1606 / PR #1614): the identity probe was pointed at the
+apex, which never returns identity.
+
+## Decision
+
+1. **Any server-side "who is this visitor" probe MUST set `X-Original-URL` to a
+   subdomain** (e.g. `https://www.<domain>`), **never the apex** — otherwise
+   identity is never returned.
+2. Use the nginx forward-auth endpoint **`/api/authz/auth-request`**
+   (Authelia 4.38+) with `X-Original-URL` + `X-Original-Method`, not the
+   deprecated `/api/verify`. `X-Original-URL` must be **`https://`** (Authelia
+   400s on `http://`).
+3. **ServiceBay's own admin UI (`admin.<domain>`) is app-layer auth, not
+   Authelia forward-auth** — deliberately excluded (`ADMIN_ONLY_HOSTS` in
+   `diagnose/ssoVerify.ts`) and a LAN-only NPM host.
+
+## Consequences
+
+- The apex is intentionally a dead end for identity; don't "fix" a 403 there.
+- Probes and integrations reuse the same `/api/authz/auth-request` path the
+  proxy uses (`stackInstall/forwardAuth.ts`).

--- a/docs/adr/0007-container-network-isolation-and-carveouts.md
+++ b/docs/adr/0007-container-network-isolation-and-carveouts.md
@@ -1,0 +1,45 @@
+# ADR 0007 — App containers move off `hostNetwork` into isolated netns; named carve-outs stay on host networking
+
+- **Status:** Accepted (incremental; epic #817)
+- **Date:** 2026-06-05
+- **Deciders:** operator (mdopp)
+- **Related:** [ADR 0001](0001-authentication-via-authelia-sso-or-lldap.md)
+
+## Context
+
+Running app pods on `spec.hostNetwork` lets a compromised container reach the
+host's other service ports and the ServiceBay control API. The goal (#817) is
+to move non-essential templates into an **isolated bridge netns + per-port
+`hostPort`**, shrinking that blast radius.
+
+A subtlety bit increments 1–2: in **rootless podman an isolated pod cannot
+reach the host's own LAN IP** (TCP refused). Pointing cross-pod refs at
+`{{LAN_IP}}` silently broke vaultwarden/immich/audiobookshelf OIDC discovery and
+radicale's LDAP bind.
+
+## Decision
+
+1. **Default: app templates drop `hostNetwork`**, add `hostPort` to each
+   published `containerPort`, and reach other pods via the hostname
+   **`host.containers.internal`** (podman auto-adds it) — **never `{{LAN_IP}}`**.
+   Server-side OIDC discovery keeps a `hostAliases` entry mapping
+   `auth.{{PUBLIC_DOMAIN}}` → `{{HOST_GATEWAY_IP}}` (default `169.254.1.2`) so
+   the issuer name stays canonical.
+2. **These stay on `hostNetwork` deliberately — do not re-litigate per #817:**
+   - **nginx, adguard, home-assistant, voice** — genuinely need host networking
+     (ingress :80/:443, DNS :53, mDNS/SSDP, Wyoming LAN).
+   - **ollama + hermes** — ollama ships no auth and is loopback-bound by design;
+     a plain `hostPort` would newly LAN-expose it, and isolated hermes can only
+     reach ollama via the host. Revisit only once a host-firewall / private-
+     network story exists.
+   - **file-share** — Samba needs privileged ports 139/445 (hard under rootless)
+     and the Syncthing GUI is loopback-bound. Needs design work first.
+   - **auth** — migrated last, on its own (LLDAP holds all identity data).
+
+## Consequences
+
+- post-deploy scripts run in the **host** netns, so their `127.0.0.1` probes
+  keep working — only in-container references change. No schema bump needed
+  (precedent #824).
+- Increment 1 (vaultwarden + immich) shipped 4.15.0; increment 2 (media +
+  radicale) shipped 4.15.2; increment 3 (file-share) and auth remain.

--- a/docs/adr/0008-tui-desired-state-and-journey.md
+++ b/docs/adr/0008-tui-desired-state-and-journey.md
@@ -1,0 +1,45 @@
+# ADR 0008 — The TUI is a desired-state stack editor and a numbered setup-journey map
+
+- **Status:** Accepted (shipped v4.66.0)
+- **Date:** 2026-06-05
+- **Deciders:** operator (mdopp)
+- **Related:** [ADR 0004](0004-installs-are-non-destructive.md), UX_PHILOSOPHY.md
+
+## Context
+
+The sb-tui needs to present both *what to do next* during setup and *how to
+change what's installed* — without surprising the operator (an earlier version
+silently redeployed an already-installed stack).
+
+## Decision
+
+**1. The stack panel is a desired-state editor, not a fresh-install checklist**
+(`InstallModel.plan()`, pure/unit-tested). It pre-checks what's installed and
+acts on the **diff**:
+- newly checked → **install**
+- installed + `r` → **reinstall** (redeploy)
+- installed, untouched → **no-op** (never silently redeploy)
+- installed, unchecked → **uninstall** — destructive, so it routes through a
+  y/n confirm and a `WIPE-<name>` token (`tokenScope:'destroy'`).
+
+**Core / atomic-wipe stacks (`basic` = NPM + LLDAP/Authelia + AdGuard) cannot be
+unchecked** — the backend hard-refuses (Factory-Reset-only, [ADR 0004](0004-installs-are-non-destructive.md)),
+and the panel blocks the keystroke. Stacks expand to their templates before
+assembling.
+
+**2. The launcher menu is a numbered setup-journey map**, not a flat action
+list. The arc is **① stage backups → ② build install USB → ③ boot + watch
+install → ④ manage**. Future steps render as greyed signposts, done steps get a
+✓, the cursor defaults to the phase's one `Recommended` row.
+- **Pre-install phases lead with "Stage existing backups on the NAS" (①), not
+  Build/Express** — you stage data *before* you wipe so the fresh install
+  restores it. Non-migrators just arrow past it.
+- **`UploadToNAS` is ungated from box login** — it talks only to the FritzBox
+  over FTP, never the ServiceBay box, so it works with no box at all. Don't
+  re-add a token gate.
+
+## Consequences
+
+- Don't "fix" the no-op-on-reinstall or reorder the journey to lead with Build.
+- Config is baked into the USB at build time, so step ④ "tweak config" is
+  explicitly optional.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records (ADRs)
+
+Durable architecture/product decisions that are **not derivable from the code
+alone** — recorded so they're versioned and reviewable, instead of living only
+in tribal memory. Read the relevant ADR before "fixing" something that looks
+deliberate; the weirdness is usually load-bearing.
+
+Each ADR: **Status · Context · Decision · Consequences**. New decisions get the
+next number: `docs/adr/NNNN-title.md`.
+
+For *UX-surface* decisions see [../UX_DECISIONS.md](../UX_DECISIONS.md) and
+[../UX_PHILOSOPHY.md](../UX_PHILOSOPHY.md); for the credential self-heal
+mechanics see [../CREDENTIAL_SELF_HEAL.md](../CREDENTIAL_SELF_HEAL.md); for
+ratcheted invariants see [../ARCHITECTURE_INVARIANTS.md](../ARCHITECTURE_INVARIANTS.md).
+
+## Index
+
+| # | Decision |
+|---|----------|
+| [0001](0001-authentication-via-authelia-sso-or-lldap.md) | Every user-facing service authenticates via Authelia SSO, or at minimum LDAP→LLDAP |
+| [0002](0002-tiered-backup-nas-config-vs-bulk-drive.md) | Tiered backup: critical config + HA-full + vault → NAS; bulk media → large drive |
+| [0003](0003-releases-via-release-please-only.md) | Versioning/releases via release-please only; commit subjects stay parser-clean |
+| [0004](0004-installs-are-non-destructive.md) | Installing a service never wipes others; system-wide reset is factory-reset-only |
+| [0005](0005-dns-topology-pattern-a.md) | DNS: router hands out AdGuard as LAN DNS (Pattern A); deterministic over fallback |
+| [0006](0006-authelia-apex-deny-vs-wildcard.md) | Authelia: bare apex is default-deny; only `*.<domain>` is `one_factor` |
+| [0007](0007-container-network-isolation-and-carveouts.md) | App pods move off `hostNetwork`; named carve-outs stay on host networking |
+| [0008](0008-tui-desired-state-and-journey.md) | TUI = desired-state stack editor + numbered setup-journey menu |


### PR DESCRIPTION
Versions the durable **product/architecture decisions** that previously lived only in agent memory, so they are reviewable and can be replaced by "see the ADRs". Establishes the `docs/adr/` index (README).

- **0003** Versioning/releases via release-please only; parser-clean commit subjects.
- **0004** Installing a service never wipes others; system-wide reset is factory-reset-only (the 2026-05-15 total-data-loss incident).
- **0005** DNS Pattern A — router hands out AdGuard as LAN DNS; deterministic `*.<domain>`→box beats public fallback (the #1559 silent-SSO-outage).
- **0006** Authelia: bare apex is default-deny; only `*.<domain>` is `one_factor`; identity probes target a subdomain.
- **0007** App pods move off `hostNetwork` (#817); ollama/hermes/file-share/nginx/adguard/HA carve-outs stay; cross-pod via `host.containers.internal`.
- **0008** TUI is a desired-state stack editor + numbered setup-journey menu.

Pairs with #1716 (ADR 0001 auth) and #1719 (ADR 0002 backup) — together these eight establish the ADR set. The README index links all of them; cross-links resolve once merged.

Agent-workflow notes (autoloop tuning, lint-sweep cadence, comment markers) intentionally stay in memory — they are not product decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)