### PR TITLE
docs(adr): renumber tokens-trust ADR 0001→0009 (resolve collision) + index it

### DIFF
--- a/docs/adr/0009-service-tokens-and-trust.md
+++ b/docs/adr/0009-service-tokens-and-trust.md
@@ -1,14 +1,14 @@
-# ADR 0001 — Tokens & trust between services
+# ADR 0009 — Tokens & trust between services
 
 - **Status:** Accepted
 - **Date:** 2026-06-05
 - **Deciders:** @mdopp
 - **Supersedes / relates to:** #322, #565, #780, #1204, #1419, #1552, #1559, #1639, #1667, #1705, #1713
+- **Related ADRs:** [0001](0001-authentication-via-authelia-sso-or-lldap.md) (the operator→service auth decision; §2 here is the credential/trust elaboration), [0002](0002-tiered-backup-nas-config-vs-bulk-drive.md), [0006](0006-authelia-apex-deny-vs-wildcard.md)
 
-> First ADR in the repo. Format: Status / Context / Decision / Consequences, in the
+> Format: Status / Context / Decision / Consequences, in the
 > spirit of [`UX_DECISIONS.md`](../UX_DECISIONS.md) — record the choices that are
 > **not derivable from the code alone**, with the incident that forged them.
-> Subsequent ADRs go in this directory as `NNNN-title.md`.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ ratcheted invariants see [../ARCHITECTURE_INVARIANTS.md](../ARCHITECTURE_INVARIA
 | [0006](0006-authelia-apex-deny-vs-wildcard.md) | Authelia: bare apex is default-deny; only `*.<domain>` is `one_factor` |
 | [0007](0007-container-network-isolation-and-carveouts.md) | App pods move off `hostNetwork`; named carve-outs stay on host networking |
 | [0008](0008-tui-desired-state-and-journey.md) | TUI = desired-state stack editor + numbered setup-journey menu |
+| [0009](0009-service-tokens-and-trust.md) | Tokens & trust between services: per-box identity secrets, SSO, scoped named tokens, the LAN-only bootstrap reconnect bridge, allow-listed host exec |


### PR DESCRIPTION
The planned ADR migration (#1716–#1720: `0001`–`0008` + README) and the tokens-&-trust ADR (#1721) both landed as **ADR 0001**. The planned set predates it and owns `0001`–`0008`, so this moves the tokens-&-trust ADR to **`0009`**, adds it to the README index, and cross-references ADR 0001 (auth via Authelia) — its §2 is the credential/trust elaboration of that decision.

Doc-only, no code change. Resolves the dual-`0001` collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)