### PR TITLE
fix(media): finish ABS retirement + drop shared-tree SELinux relabel; managed-Quadlet detection; MCP self-description

### DIFF
--- a/packages/backend/src/lib/agent/types.ts
+++ b/packages/backend/src/lib/agent/types.ts
@@ -117,7 +117,7 @@ export interface ServiceUnit {
   active?: boolean;
   isReverseProxy?: boolean;
   isServiceBay?: boolean;
-  isManaged?: boolean; // True if backed by a .kube file (ServiceBay Stack)
+  isManaged?: boolean; // True if backed by a .kube/.container Quadlet (ServiceBay Stack), or whose base name is in config.installedTemplates (#1733 — single-container GPU Quadlets like ollama.container).
   isPrimaryProxy?: boolean; // Managed by TwinStore (Consistency)
   associatedContainerIds?: string[]; // IDs of containers managed by this service (SINGLE SOURCE OF TRUTH)
   ports?: PortMapping[];

--- a/packages/backend/src/lib/mcp/server.test.ts
+++ b/packages/backend/src/lib/mcp/server.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from './server';
+
+// #1732: the MCP server describes itself — a top-level `instructions` string
+// teaching the node → service → container model, and the four
+// service/container/log tools mention that model in their descriptions.
+// Verified end-to-end through the SDK initialize + tools/list handshake.
+async function connectClient() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+  return { client, server };
+}
+
+describe('createMcpServer self-description (#1732)', () => {
+  it('returns an instructions string covering the service↔container model on initialize', async () => {
+    const { client } = await connectClient();
+    const instructions = client.getInstructions();
+    expect(instructions, 'initialize handshake must return instructions').toBeTruthy();
+    expect(instructions).toMatch(/node\s*→\s*service\s*→\s*container/);
+    // Tells the agent how to find an app's logs and to resolve names itself.
+    expect(instructions).toMatch(/list_services/);
+    expect(instructions).toMatch(/get_container_logs/);
+    expect(instructions).toMatch(/resolve.*names?.*yourself|rather than asking the user/i);
+    await client.close();
+  });
+
+  it('the service/container/log tool descriptions mention the naming model', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const byName = Object.fromEntries(tools.map(t => [t.name, t.description ?? '']));
+
+    expect(byName.list_services).toMatch(/container/i);
+    expect(byName.list_services).toMatch(/associatedContainerIds/);
+    expect(byName.list_containers).toMatch(/<service>-<app>/);
+    expect(byName.get_service_logs).toMatch(/get_container_logs/);
+    expect(byName.get_container_logs).toMatch(/<service>-<app>/);
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -242,10 +242,32 @@ function safeHandler(
 }
 
 export function createMcpServer(opts?: { auth?: McpAuthContext }) {
-  const baseServer = new McpServer({
-    name: 'servicebay',
-    version: '1.0.0',
-  });
+  const baseServer = new McpServer(
+    {
+      name: 'servicebay',
+      version: '1.0.0',
+    },
+    {
+      instructions: [
+        'ServiceBay manages a node (host) running self-hosted apps. The naming model is:',
+        'node → service → container. A *service* is a systemd unit (e.g. `media`). Each',
+        'service runs one or more *containers* named `<service>-<app>` (e.g. `media-jellyfin`,',
+        '`media-audiobookshelf`). An app and its service often share a name when the service',
+        'runs a single container, but a multi-app service (like `media`) does NOT — the app is',
+        'a container inside it.',
+        '',
+        "To find an app's logs, resolve the names yourself instead of asking the user:",
+        '1. `list_services` — find the owning service and its `associatedContainerIds`.',
+        '2. `list_containers` — find the `<service>-<app>` container name (e.g. `media-jellyfin`).',
+        '3. `get_container_logs(id)` — fetch that container\'s logs.',
+        'For whole-unit (systemd) logs use `get_service_logs(name)` instead of per-container logs.',
+        '',
+        'Always resolve service/container names and ids from `list_services` / `list_containers`',
+        'rather than asking the user for them. Use `diagnose`, `get_health_checks`, and',
+        '`get_service_files` when you need more depth on a service.',
+      ].join('\n'),
+    },
+  );
   // Wrap every tool registration so the safety layer applies uniformly.
   // Read-only tools pass through unchanged; mutating tools land in the
   // gates defined above. The auth context is closed over per-server so
@@ -279,13 +301,13 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   });
 
   // --- List Services ---
-  server.tool('list_services', 'List services on a node with status, ports, volumes', { node: nodeParam }, async ({ node }) => {
+  server.tool('list_services', 'List logical services (systemd units) on a node with status, ports, volumes. A service may bundle multiple containers (see `associatedContainerIds`); to target a specific app, resolve its `<service>-<app>` container via list_containers.', { node: nodeParam }, async ({ node }) => {
     const nodeName = await resolveNode(node);
     return textResult(getServices(nodeName));
   });
 
   // --- List Containers ---
-  server.tool('list_containers', 'List running containers with image, state, ports', { node: nodeParam }, async ({ node }) => {
+  server.tool('list_containers', 'List running containers with image, state, ports. Container names follow `<service>-<app>` (e.g. `media-jellyfin`); use the resolved name with get_container_logs.', { node: nodeParam }, async ({ node }) => {
     const nodeName = await resolveNode(node);
     return textResult(getContainers(nodeName));
   });
@@ -293,7 +315,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Get Service Logs ---
   server.tool(
     'get_service_logs',
-    'Fetch systemd journal logs for a service. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
+    'Fetch systemd journal logs for a whole service (the systemd unit). For a single app inside a multi-container service, use get_container_logs with the `<service>-<app>` name instead. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
     {
       name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').describe('Service name'),
       node: nodeParam,
@@ -326,7 +348,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Get Container Logs ---
   server.tool(
     'get_container_logs',
-    'Fetch container stdout/stderr logs. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
+    'Fetch container stdout/stderr logs. `id` is the `<service>-<app>` container name (e.g. `media-jellyfin`); resolve it via list_containers. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
     {
       id: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid container id').describe('Container ID or name'),
       node: nodeParam,

--- a/packages/backend/src/lib/services/serviceViewModel.test.ts
+++ b/packages/backend/src/lib/services/serviceViewModel.test.ts
@@ -87,3 +87,62 @@ describe('buildServiceViewModel — display fields (#844)', () => {
     expect(vm?.yamlBasename).toBeNull();
   });
 });
+
+describe('buildServiceViewModel — managed detection for .container Quadlets (#1733)', () => {
+  // A single-container .container Quadlet (the ollama GPU fixup, #1026) has no
+  // .kube/pod, so the agent may not flag it managed. When its base name is in
+  // installedTemplates it must still resolve as a managed service, not fall
+  // through to null (which would group it under Standalone Containers).
+  function makeContainerUnit(overrides: Partial<ServiceUnit> = {}): ServiceUnit {
+    return makeUnit({
+      name: 'ollama.service',
+      path: '/var/home/core/.config/containers/systemd/ollama.container',
+      isManaged: false,
+      ...overrides,
+    });
+  }
+
+  it('resolves managed when base name is in installedTemplates even with isManaged=false and no .kube', () => {
+    const vm = buildServiceViewModel({
+      unit: makeContainerUnit(),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+      installedTemplates: ['ollama'],
+    });
+    expect(vm).not.toBeNull();
+    expect(vm?.isManaged).toBe(true);
+    expect(vm?.type).toBe('kube');
+    expect(vm?.displayName).toBe('ollama');
+  });
+
+  it('still returns null for an unflagged .container unit NOT in installedTemplates', () => {
+    const vm = buildServiceViewModel({
+      unit: makeContainerUnit({ name: 'stray.service' }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+      installedTemplates: ['ollama'],
+    });
+    expect(vm).toBeNull();
+  });
+
+  it('still resolves managed via the agent isManaged flag with no installedTemplates passed', () => {
+    const vm = buildServiceViewModel({
+      unit: makeContainerUnit({ isManaged: true }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+    });
+    expect(vm).not.toBeNull();
+    expect(vm?.isManaged).toBe(true);
+  });
+
+  it('is generic — any installedTemplates base name resolves, not just ollama', () => {
+    const vm = buildServiceViewModel({
+      unit: makeContainerUnit({ name: 'whisper.service', path: '/x/whisper.container' }),
+      nodeName: 'Local',
+      nodeState: makeTwin(),
+      installedTemplates: ['whisper'],
+    });
+    expect(vm).not.toBeNull();
+    expect(vm?.isManaged).toBe(true);
+  });
+});

--- a/packages/backend/src/lib/services/serviceViewModel.ts
+++ b/packages/backend/src/lib/services/serviceViewModel.ts
@@ -10,6 +10,14 @@ interface BuildServiceViewModelArgs {
   nodeName: string;
   nodeState: NodeTwin;
   proxyRoutes?: ProxyRoute[];
+  /**
+   * Base names of services ServiceBay installed (config.installedTemplates
+   * keys). #1733: a unit whose base name is in this set is treated as managed
+   * even when it isn't backed by a `.kube`/pod — e.g. a single-container
+   * `.container` Quadlet (the ollama GPU fixup), which would otherwise be
+   * classified Standalone/unmanaged.
+   */
+  installedTemplates?: Iterable<string>;
 }
 
 const formatPort = (port?: { hostPort?: number; containerPort?: number }): ServicePort => ({
@@ -22,15 +30,21 @@ const cloneContainerWithNode = (container: EnrichedContainer, nodeName: string):
   nodeName,
 });
 
-export function buildServiceViewModel({ unit, nodeName, nodeState, proxyRoutes }: BuildServiceViewModelArgs): ServiceViewModel | null {
-  const isManaged = Boolean(unit.isManaged);
+export function buildServiceViewModel({ unit, nodeName, nodeState, proxyRoutes, installedTemplates }: BuildServiceViewModelArgs): ServiceViewModel | null {
+  const fileKeys = Object.keys(nodeState.files || {});
+  const baseName = unit.name.replace('.service', '');
+
+  // #1733: managed if the agent flagged it (.kube/.container) OR its base name
+  // is one ServiceBay installed. The latter rescues a single-container
+  // .container Quadlet (ollama GPU fixup) with no pod from being treated as a
+  // bare container in the UI.
+  const installedSet = installedTemplates ? new Set(installedTemplates) : null;
+  const isManaged = Boolean(unit.isManaged) || Boolean(installedSet?.has(baseName));
 
   if (!isManaged && !unit.isReverseProxy && !unit.isServiceBay) {
     return null;
   }
 
-  const fileKeys = Object.keys(nodeState.files || {});
-  const baseName = unit.name.replace('.service', '');
   let yamlPath: string | null = null;
 
   if (isManaged) {
@@ -47,6 +61,15 @@ export function buildServiceViewModel({ unit, nodeName, nodeState, proxyRoutes }
             yamlPath = yamlKey;
           }
         }
+      }
+    } else {
+      // #1733: no .kube chain — a single-container .container Quadlet (e.g.
+      // ollama). Fall back to the .yml/.yaml pod manifest if one happens to
+      // sit alongside (label/port hints); the .container itself has no
+      // servicebay.label so displayName stays the base name.
+      const fallbackYaml = fileKeys.find(key => key.endsWith(`/${baseName}.yml`) || key.endsWith(`/${baseName}.yaml`));
+      if (fallbackYaml) {
+        yamlPath = fallbackYaml;
       }
     }
   } else {

--- a/packages/backend/src/lib/store/twin.test.ts
+++ b/packages/backend/src/lib/store/twin.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DigitalTwinStore } from '@/lib/store/twin';
+
+// #1733: installedTemplates feeds the bundle builder so a single-container
+// .container Quadlet whose base name is an installed template is treated as a
+// managed service instead of a Standalone container. These tests cover the
+// thin setInstalledTemplates wrapper (set + change-detection + rebuild).
+describe('DigitalTwinStore.setInstalledTemplates (#1733)', () => {
+  let store: DigitalTwinStore;
+
+  beforeEach(() => {
+    store = DigitalTwinStore.getInstance();
+    store.nodes = {};
+    store.installedTemplates = new Set();
+  });
+
+  afterEach(() => {
+    // Singleton store: restore spies so call records don't bleed across tests.
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to an empty set and exposes it on the snapshot', () => {
+    expect([...store.installedTemplates]).toEqual([]);
+    expect(store.getSnapshot().installedTemplates).toEqual([]);
+  });
+
+  it('stores the names and surfaces them on the snapshot', () => {
+    store.setInstalledTemplates(['ollama', 'immich']);
+    expect([...store.installedTemplates].sort()).toEqual(['immich', 'ollama']);
+    expect(store.getSnapshot().installedTemplates.sort()).toEqual(['immich', 'ollama']);
+  });
+
+  it('rebuilds bundles for every node when the set changes', () => {
+    store.registerNode('node-a');
+    store.registerNode('node-b');
+    const spy = vi.spyOn(store, 'rebuildBundlesNow');
+
+    store.setInstalledTemplates(['ollama']);
+
+    expect(spy).toHaveBeenCalledWith('node-a');
+    expect(spy).toHaveBeenCalledWith('node-b');
+  });
+
+  it('does NOT rebuild when the set is unchanged (no churn on every config read)', () => {
+    store.registerNode('node-a');
+    store.setInstalledTemplates(['ollama', 'immich']);
+
+    const spy = vi.spyOn(store, 'rebuildBundlesNow');
+    // Same members, different iteration order — must be treated as unchanged.
+    store.setInstalledTemplates(['immich', 'ollama']);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds when a name is added or removed', () => {
+    store.registerNode('node-a');
+    store.setInstalledTemplates(['ollama']);
+
+    const spy = vi.spyOn(store, 'rebuildBundlesNow');
+    store.setInstalledTemplates(['ollama', 'immich']); // added
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    store.setInstalledTemplates(['immich']); // removed ollama
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/lib/store/twin.ts
+++ b/packages/backend/src/lib/store/twin.ts
@@ -353,7 +353,7 @@ export class DigitalTwinStore {
     public rebuildBundlesNow(nodeId: string): void {
         const node = this.nodes[nodeId];
         if (!node) return;
-        const built = buildServiceBundlesForNode({ nodeName: nodeId, services: node.services, containers: node.containers, files: node.files });
+        const built = buildServiceBundlesForNode({ nodeName: nodeId, services: node.services, containers: node.containers, files: node.files, installedTemplates: this.installedTemplates });
         const dismissed = new Set(node.dismissedBundles || []);
         node.unmanagedBundles = dismissed.size > 0 ? built.filter(b => !dismissed.has(b.id)) : built;
         this.notifyListeners();
@@ -979,10 +979,29 @@ export class DigitalTwinStore {
       this.notifyListeners();
   }
 
+  // #1733: base names of services ServiceBay installed (config.installedTemplates
+  // keys). Fed by the server on config load/sync so the bundle builder can treat
+  // a single-container .container Quadlet (no pod, e.g. the ollama GPU fixup) as
+  // managed instead of a Standalone container.
+  public installedTemplates: Set<string> = new Set();
+
+  public setInstalledTemplates(names: Iterable<string>): void {
+      const next = new Set(names);
+      // Rebuild bundles only when the set actually changed — avoids churn on
+      // every config read.
+      const changed = next.size !== this.installedTemplates.size
+          || [...next].some(n => !this.installedTemplates.has(n));
+      this.installedTemplates = next;
+      if (changed) {
+          Object.keys(this.nodes).forEach(nodeId => this.rebuildBundlesNow(nodeId));
+      }
+  }
+
   public getSnapshot() {
       return {
           instanceId: this.instanceId,
           serverName: this.serverName,
+          installedTemplates: [...this.installedTemplates],
           nodes: this.nodes,
           gateway: this.gateway,
           proxyState: this.proxyState

--- a/packages/backend/src/lib/unmanaged/bundleBuilder.test.ts
+++ b/packages/backend/src/lib/unmanaged/bundleBuilder.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { buildServiceBundlesForNode } from './bundleBuilder';
+import type { ServiceUnit, EnrichedContainer } from '@/lib/agent/types';
+
+function makeService(overrides: Partial<ServiceUnit> = {}): ServiceUnit {
+  return {
+    name: 'ollama.service',
+    active: true,
+    activeState: 'active',
+    subState: 'running',
+    loadState: 'loaded',
+    description: '',
+    path: '/var/home/core/.config/containers/systemd/ollama.container',
+    fragmentPath: '/var/home/core/.config/containers/systemd/ollama.container',
+    isManaged: false,
+    associatedContainerIds: ['c-ollama'],
+    ports: [],
+    ...overrides,
+  };
+}
+
+function makeContainer(overrides: Partial<EnrichedContainer> = {}): EnrichedContainer {
+  return {
+    id: 'c-ollama',
+    names: ['ollama'],
+    image: 'docker.io/ollama/ollama:latest',
+    state: 'running',
+    status: 'Up',
+    ports: [],
+    labels: { PODMAN_SYSTEMD_UNIT: 'ollama.service' },
+    ...overrides,
+  } as unknown as EnrichedContainer;
+}
+
+describe('buildServiceBundlesForNode — installedTemplates managed detection (#1733)', () => {
+  it('does NOT bundle a single-container .container Quadlet whose base name is in installedTemplates', () => {
+    const bundles = buildServiceBundlesForNode({
+      nodeName: 'Local',
+      services: [makeService()],
+      containers: [makeContainer()],
+      files: {},
+      installedTemplates: new Set(['ollama']),
+    });
+    // installedTemplates says ollama is a managed service -> it must not show up
+    // in the Standalone/unmanaged bundle list.
+    const ollamaBundle = bundles.find(b => b.services?.some(s => s.serviceName === 'ollama.service'));
+    expect(ollamaBundle).toBeUndefined();
+  });
+
+  it('DOES bundle the same unit when its base name is NOT in installedTemplates', () => {
+    const bundles = buildServiceBundlesForNode({
+      nodeName: 'Local',
+      services: [makeService()],
+      containers: [makeContainer()],
+      files: {},
+      installedTemplates: new Set(['something-else']),
+    });
+    const ollamaBundle = bundles.find(b => b.services?.some(s => s.serviceName === 'ollama.service'));
+    expect(ollamaBundle).toBeDefined();
+  });
+
+  it('still bundles an unmanaged unit when no installedTemplates set is supplied', () => {
+    const bundles = buildServiceBundlesForNode({
+      nodeName: 'Local',
+      services: [makeService()],
+      containers: [makeContainer()],
+      files: {},
+    });
+    const ollamaBundle = bundles.find(b => b.services?.some(s => s.serviceName === 'ollama.service'));
+    expect(ollamaBundle).toBeDefined();
+  });
+
+  it('respects the agent isManaged flag regardless of installedTemplates', () => {
+    const bundles = buildServiceBundlesForNode({
+      nodeName: 'Local',
+      services: [makeService({ isManaged: true })],
+      containers: [makeContainer()],
+      files: {},
+      installedTemplates: new Set(),
+    });
+    const ollamaBundle = bundles.find(b => b.services?.some(s => s.serviceName === 'ollama.service'));
+    expect(ollamaBundle).toBeUndefined();
+  });
+});

--- a/packages/backend/src/lib/unmanaged/bundleBuilder.ts
+++ b/packages/backend/src/lib/unmanaged/bundleBuilder.ts
@@ -22,6 +22,15 @@ interface BundleBuildInput {
   services: ServiceUnit[];
   containers: EnrichedContainer[];
   files: Record<string, WatchedFile>;
+  /**
+   * Base names (the `installedTemplates` keys) of services ServiceBay
+   * installed on this node. A running unit whose base name is in this set
+   * is treated as managed even when it isn't backed by a `.kube`/pod —
+   * #1733: a single-container `.container` Quadlet (the ollama GPU fixup
+   * from #1026) has no pod manifest, so without this it falls through to
+   * the Standalone/unmanaged bundle despite being a declared service.
+   */
+  installedTemplates?: Set<string>;
 }
 
 const EXCLUDED_UNITS = new Set([
@@ -471,9 +480,19 @@ const mergeBundlesByPod = (bundles: Map<string, ServiceBundle>): Map<string, Ser
   return merged;
 };
 
-export const buildServiceBundlesForNode = ({ nodeName, services = [], containers = [], files = {} }: BundleBuildInput): ServiceBundle[] => {
+export const buildServiceBundlesForNode = ({ nodeName, services = [], containers = [], files = {}, installedTemplates }: BundleBuildInput): ServiceBundle[] => {
   const containerMap = new Map<string, EnrichedContainer>();
   containers.forEach(container => containerMap.set(container.id, container));
+
+  // #1733: a unit is managed if the agent flagged it (.kube/.container) OR
+  // its base name is one ServiceBay installed (installedTemplates). The
+  // latter catches a single-container .container Quadlet (ollama GPU fixup)
+  // running under an older agent, or any managed service with no pod.
+  const isManagedUnit = (svc: ServiceUnit): boolean => {
+    if (svc.isManaged) return true;
+    if (!installedTemplates || installedTemplates.size === 0) return false;
+    return installedTemplates.has(svc.name.replace(/\.service$/, ''));
+  };
 
   const drafts = new Map<string, ServiceBundle>();
   const servicePodKeys = new Map<string, Set<string>>();
@@ -553,7 +572,7 @@ export const buildServiceBundlesForNode = ({ nodeName, services = [], containers
   // Group unmanaged services by pod reference
   const servicesByPod = new Map<string, ServiceUnit[]>();
   services
-    .filter(s => !s.isManaged && !s.isServiceBay && !s.isReverseProxy && !EXCLUDED_UNITS.has(s.name))
+    .filter(s => !isManagedUnit(s) && !s.isServiceBay && !s.isReverseProxy && !EXCLUDED_UNITS.has(s.name))
     .forEach(service => {
       const podRef = service.podReference || 'ungrouped';
       if (!servicesByPod.has(podRef)) {
@@ -564,11 +583,11 @@ export const buildServiceBundlesForNode = ({ nodeName, services = [], containers
 
   // Log ALL services available for grouping
   const allServiceNames = services
-    .filter(s => !s.isManaged && !s.isServiceBay && !s.isReverseProxy && !EXCLUDED_UNITS.has(s.name))
+    .filter(s => !isManagedUnit(s) && !s.isServiceBay && !s.isReverseProxy && !EXCLUDED_UNITS.has(s.name))
     .map(s => s.name);
 
   services
-    .filter(service => !service.isManaged && !service.isServiceBay && !service.isReverseProxy && !EXCLUDED_UNITS.has(service.name))
+    .filter(service => !isManagedUnit(service) && !service.isServiceBay && !service.isReverseProxy && !EXCLUDED_UNITS.has(service.name))
     .forEach(service => {
       // Skip if already processed as a dependency of another service
       if (processedRoots.has(service.name)) return;
@@ -866,7 +885,7 @@ export const buildServiceBundlesForNode = ({ nodeName, services = [], containers
   // --- Merge bundles that share the same pod reference ---
   const mergedDrafts = mergeBundlesByPod(drafts);
   const baseBundles = Array.from(mergedDrafts.values());
-  const orphanPodBundles = buildSyntheticPodBundles(nodeName, baseBundles, services, containers, files, containerMap);
+  const orphanPodBundles = buildSyntheticPodBundles(nodeName, baseBundles, services, containers, files, containerMap, isManagedUnit);
   const allBundles = [...baseBundles, ...orphanPodBundles];
 
   return allBundles.sort((a, b) => {
@@ -884,7 +903,8 @@ export const buildServiceBundlesForNode = ({ nodeName, services = [], containers
     services: ServiceUnit[],
     containers: EnrichedContainer[],
     files: Record<string, WatchedFile>,
-    containerMap: Map<string, EnrichedContainer>
+    containerMap: Map<string, EnrichedContainer>,
+    isManagedUnit: (svc: ServiceUnit) => boolean
   ): ServiceBundle[] => {
     const podsToContainers = new Map<string, {
       normalized: string;
@@ -920,7 +940,7 @@ export const buildServiceBundlesForNode = ({ nodeName, services = [], containers
 
     const podsWithManagedService = new Set<string>();
     services.forEach(service => {
-      if (!service.isManaged) return;
+      if (!isManagedUnit(service)) return;
       collectPodKeysForService(service, containerMap).forEach(key => podsWithManagedService.add(key));
     });
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -311,11 +311,12 @@ app.prepare().then(() => {
 
   const twinStore = DigitalTwinStore.getInstance();
 
-  // Load serverName from config into twin store
+  // Load serverName + installedTemplates from config into twin store
   getConfig().then(config => {
     if (config.serverName) {
       twinStore.setServerName(config.serverName);
     }
+    twinStore.setInstalledTemplates(Object.keys(config.installedTemplates ?? {}));
   }).catch(() => { /* ignore */ });
 
   // Logging: Broadcast new logs to 'logs:live' room
@@ -393,6 +394,16 @@ app.prepare().then(() => {
           // TS "as any" is simplistic but TwinStore handles Partial<NodeTwin> safely.
           const update: Partial<NodeTwin> = { ...message.payload as unknown as Partial<NodeTwin>, health };
           twinStore.updateNode(nodeName, update);
+
+          // #1733: keep the managed-detection set fresh so a service installed
+          // after startup (which triggers a sync) is recognized as managed on
+          // its next bundle rebuild. Non-blocking; setInstalledTemplates no-ops
+          // when the set is unchanged.
+          if ('services' in (message.payload || {})) {
+            getConfig()
+              .then(config => twinStore.setInstalledTemplates(Object.keys(config.installedTemplates ?? {})))
+              .catch(() => { /* ignore */ });
+          }
       }
   });
   

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -1171,6 +1171,7 @@ export default function NetworkDashboard() {
               unit: selectedNodeData.rawData as ServiceUnit,
               nodeName: selectedNodeName,
               nodeState,
+              installedTemplates: twin?.installedTemplates,
           });
       } catch {
           return null;

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -271,7 +271,8 @@ export default function ServicesDashboard() {
                     unit,
                     nodeName,
                     nodeState,
-                    proxyRoutes: twin.proxyState?.routes
+                    proxyRoutes: twin.proxyState?.routes,
+                    installedTemplates: twin.installedTemplates
                 });
                 if (viewModel) {
                     servicesList.push(viewModel);

--- a/packages/frontend/src/providers/DigitalTwinProvider.tsx
+++ b/packages/frontend/src/providers/DigitalTwinProvider.tsx
@@ -8,6 +8,10 @@ import { logger } from '@servicebay/api-client';
 export interface DigitalTwinSnapshot {
   instanceId?: string;
   serverName?: string | null;
+  // #1733: base names ServiceBay installed (config.installedTemplates keys);
+  // lets the service view treat a single-container .container Quadlet (no pod)
+  // as managed rather than a Standalone container.
+  installedTemplates?: string[];
   nodes: Record<string, NodeTwin>;
   gateway: GatewayState;
   proxyState: ProxyState;

--- a/templates/media/CHANGELOG.md
+++ b/templates/media/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Media (Jellyfin) — template changelog
 
+## v6 (breaking) — #1730 + #1731
+
+**Finish the Audiobookshelf retirement + stop the shared-tree SELinux
+relabel crash.** Non-destructive — no Audiobookshelf data is touched.
+
+### Why
+
+#1725 retired Audiobookshelf for fresh installs but only stopped
+*shipping* the ABS container in the pod — on an existing box the
+already-running `media-audiobookshelf` container kept running,
+`books.<domain>` still routed to ABS's dead port (13378), and the
+`audiobookshelf` OIDC client was re-registered on every deploy (#1730).
+Separately, Jellyfin's `/media` mount points at the shared, multi-writer
+`file-share/data` tree and the default kube recursive SELinux relabel
+crash-looped the whole media pod when a single root-owned stray existed
+anywhere under it — e.g. left by disk-import's privileged write (#1731).
+
+### What changed
+
+- `template.yml`: added `io.podman.annotations.label/jellyfin: "disable"`
+  so Jellyfin's bind mounts (notably the shared `/media` tree) are not
+  recursively relabelled — a root-owned stray under `file-share/data`
+  can no longer fail the rootless `lsetxattr` and brick a media restart
+  (#1731). The shared tree already carries `container_file_t` from its
+  long-lived writers, so the read-only mount needs no relabel. Same
+  per-container disable pattern `file-share` itself uses. Schema bumped
+  to `6`.
+- `variables.json`: `ABS_SUBDOMAIN.proxyPort` `ABS_PORT` (13378) →
+  `JELLYFIN_PORT` (8096) — `books.<domain>` now serves Jellyfin (the
+  operator keeps the `books` URL; audiobooks are Jellyfin's
+  `/media/audiobooks` Books library). The `audiobookshelf` `oidcClient`
+  block is dropped — Jellyfin authenticates via LLDAP (#1718), not a
+  per-service OIDC secret — so the dead client is no longer re-registered
+  on redeploy. `books` inherits Jellyfin's 100 MB upload `advanced_config`
+  (cover-art import) (#1730).
+- `migrations/v5-to-v6.py`: tears down the orphaned `media-audiobookshelf`
+  container left running by #1725 (`podman rm -f`, best-effort, never
+  blocks the deploy). **Data-preserving** — the on-disk ABS data dirs are
+  left in place; only the disposable container is removed.
+
+### Required action for existing installs
+
+Nothing manual is required — the migration removes the stale ABS
+container and `books.<domain>` repoints to Jellyfin automatically on the
+next deploy. The ABS OIDC client + data dirs are left on disk; delete
+them on your own schedule (`rm -rf ${DATA_DIR}/media/audiobookshelf-*`)
+once you've confirmed your audiobooks play from Jellyfin.
+
 ## v5 (breaking) — #1725
 
 **Audiobookshelf retired for fresh installs; audiobooks served by

--- a/templates/media/migrations/v5-to-v6.py
+++ b/templates/media/migrations/v5-to-v6.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Migration: media v5 → v6 (#1730 + #1731).
+
+Two fixes shipped together (both in templates/media/):
+
+  #1730 — finish the Audiobookshelf retirement #1725 left half-done.
+  #1731 — stop the jellyfin /media mount recursively relabelling the
+          shared file-share/data tree.
+
+### #1730 — tear down the orphaned Audiobookshelf container
+
+#1725 dropped the `audiobookshelf` container from the pod but left the
+already-running `media-audiobookshelf` container alive on the host (a
+plain `kube play --replace` of the new pod doesn't remove a container
+that's no longer *in* the pod). It kept holding host ports 8096/13378
+and `books.<domain>` kept hitting it, bypassing Jellyfin. v6 also
+repoints `books.<domain>` → Jellyfin and drops the `audiobookshelf`
+OIDC client (variables.json), so the lingering container must go.
+
+This script removes the orphaned `media-audiobookshelf` container if it
+exists. It is **NON-DESTRUCTIVE to data**: the on-disk ABS data dirs
+(`${DATA_DIR}/media/audiobookshelf-config`, `-metadata`, and the
+audiobooks/podcasts library paths under file-share/data) are left
+exactly where they are. Only the container (a disposable runtime
+object) is torn down. Idempotent: a no-op if the container is already
+gone (fresh install, or a re-run of this migration).
+
+### #1731 — no code action here, template.yml carries the fix
+
+The SELinux relabel fix is the `io.podman.annotations.label/jellyfin:
+"disable"` annotation in template.yml (the jellyfin /media mount no
+longer recursively `lsetxattr`s the shared multi-writer tree). Nothing
+to migrate on disk — this note just records why v6 is the schema bump.
+
+Exit 0 (migrations MUST exit 0 to let the deploy continue — the
+container teardown is best-effort and never blocks the new pod).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ABS_CONTAINER = "media-audiobookshelf"
+
+
+def container_exists(name: str) -> bool:
+    """True if a container with this exact name exists (running or stopped)."""
+    try:
+        result = subprocess.run(
+            ["podman", "container", "exists", name],
+            capture_output=True,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"   (note) Could not probe for {name}: {exc}. Skipping teardown.")
+        return False
+
+
+def teardown_abs_container() -> None:
+    """Remove the orphaned media-audiobookshelf container (data left intact)."""
+    if not container_exists(ABS_CONTAINER):
+        print(f"   No `{ABS_CONTAINER}` container present — nothing to tear down.")
+        return
+
+    print(f"   Found orphaned `{ABS_CONTAINER}` container (left running by")
+    print("   #1725, which only stopped shipping ABS in the pod). Removing it")
+    print("   so `books.<domain>` → Jellyfin takes effect and the dead port")
+    print("   13378 is freed. Its on-disk data is preserved.")
+    try:
+        subprocess.run(
+            ["podman", "rm", "-f", "-t", "10", ABS_CONTAINER],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        print(f"   ✅ Removed `{ABS_CONTAINER}`.")
+    except subprocess.CalledProcessError as exc:
+        # Best-effort: don't fail the deploy. Orphan-reconcile (#1668) and
+        # the operator can still clear it; the new pod deploys regardless.
+        print(f"   ⚠️ Could not remove `{ABS_CONTAINER}` ({exc.stderr.strip() if exc.stderr else exc}); "
+              "the new media pod still deploys. Remove it by hand with "
+              f"`podman rm -f {ABS_CONTAINER}` if it lingers.")
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"   ⚠️ podman rm failed unexpectedly ({exc}); the new media pod "
+              "still deploys.")
+
+
+def main() -> int:
+    print("Media v5 → v6: finishing Audiobookshelf retirement (#1730) +")
+    print("fixing the shared-tree SELinux relabel crash (#1731).")
+    print()
+    print("#1730 — books.<domain> now serves Jellyfin (was the dead ABS port")
+    print("13378), the `audiobookshelf` OIDC client is dropped, and the stale")
+    print("ABS container is torn down. Audiobooks live in Jellyfin's")
+    print("/media/audiobooks library under the LLDAP house login.")
+    print()
+    print("#1731 — Jellyfin's /media mount no longer recursively relabels the")
+    print("shared file-share/data tree, so a root-owned stray (e.g. from")
+    print("disk-import) can no longer crash-loop the media stack on restart.")
+    print()
+
+    teardown_abs_container()
+
+    data_dir = os.environ.get("DATA_DIR", "/mnt/data/stacks")
+    abs_config = Path(data_dir) / "media" / "audiobookshelf-config"
+    if abs_config.exists():
+        print()
+        print("ℹ️  Existing Audiobookshelf DATA left UNTOUCHED (non-destructive):")
+        print(f"    {abs_config} (and its sibling -metadata + library dirs).")
+        print(f"    `rm -rf {Path(data_dir) / 'media'}/audiobookshelf-*` once")
+        print("    you've confirmed your audiobooks play from Jellyfin.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -7,13 +7,27 @@ metadata:
     servicebay.role: media
   annotations:
     servicebay.label: "Movies & TV"
-    servicebay.schema-version: "5"
+    servicebay.schema-version: "6"
     # Jellyfin's public URL routes through nginx, and its LDAP-Auth
     # plugin binds LLDAP from the `auth` stack — both prerequisites.
     # (#1725: Audiobookshelf retired for fresh installs; audiobooks are
     # served by Jellyfin's /media/audiobooks library now.)
     servicebay.dependencies: "nginx,auth"
     servicebay.ports: "{{JELLYFIN_PORT}}/tcp"
+    # #1731: Disable SELinux relabelling on jellyfin's bind mounts. The
+    # /media mount points at the SHARED, multi-writer file-share/data tree
+    # (samba/syncthing/filebrowser/disk-import all write there). The default
+    # kube recursive relabel walks that whole tree calling `lsetxattr` on
+    # every entry — and a single root-owned stray (e.g. left by disk-import's
+    # privileged `sudo mkdir`, #1713) makes the rootless `core` relabel fail
+    # `operation not permitted`, crash-looping the entire media pod on a
+    # routine stop/start. The shared tree already carries `container_file_t`
+    # from its other (long-lived) consumers, so Jellyfin's read-only mount
+    # needs no relabel — disabling it is correct, not a workaround. Same
+    # per-container disable pattern file-share itself uses. (cf.
+    # feedback_hermes_config_bak_selinux: a root-owned stray in a shared
+    # tree is a relabel footgun.)
+    io.podman.annotations.label/jellyfin: "disable"
     # Continuous health probe (#628). Jellyfin's /System/Info/Public
     # returns 200 once the server is up; it's the only container in the
     # pod now, so pod-up == Jellyfin-up. #618's UserManager-init race is
@@ -38,12 +52,15 @@ spec:
   #   - post-deploy.py runs in the host netns (not the pod), so its
   #     `127.0.0.1:9091` Authelia probe and `127.0.0.1:<JELLYFIN_PORT>`
   #     Jellyfin probe keep working — the latter via the hostPort.
-  #   - #1725: Audiobookshelf retired for fresh installs. An upgrade from
-  #     an older media install leaves the existing ABS container + its
-  #     {{DATA_DIR}}/media/audiobookshelf-* data dirs untouched on disk;
-  #     this pod simply no longer (re)starts ABS. Audiobooks are served
-  #     by Jellyfin's /media/audiobooks library (registered in
-  #     post-deploy.py).
+  #   - #1725/#1730: Audiobookshelf fully retired. This pod no longer runs
+  #     ABS, `books.<domain>` is repointed to Jellyfin (variables.json:
+  #     ABS_SUBDOMAIN.proxyPort → JELLYFIN_PORT), and the `audiobookshelf`
+  #     OIDC client is dropped. On an upgrade the v5→v6 migration tears
+  #     down the now-orphaned `media-audiobookshelf` container (left
+  #     `Up` by #1725, which only stopped *shipping* it in the pod) but
+  #     leaves its {{DATA_DIR}}/media/audiobookshelf-* data dirs untouched
+  #     on disk (non-destructive). Audiobooks are served by Jellyfin's
+  #     /media/audiobooks library (registered in post-deploy.py).
   hostAliases:
     - ip: "{{HOST_GATEWAY_IP}}"
       hostnames:

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -34,22 +34,15 @@
   },
   "ABS_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for Audiobookshelf",
+    "description": "Subdomain for audiobooks. Audiobookshelf is retired (#1725/#1730); `books.<domain>` now serves Jellyfin's /media/audiobooks library — the operator keeps the `books` URL but it routes to Jellyfin (JELLYFIN_PORT). No OIDC client: Jellyfin authenticates via LLDAP (#1718), not a per-service OIDC secret.",
     "default": "books",
     "exposure": "public",
-    "proxyPort": "ABS_PORT",
+    "proxyPort": "JELLYFIN_PORT",
     "proxyConfig": {
       "allow_websocket_upgrade": true,
       "block_exploits": true,
-      "ssl_forced": true
-    },
-    "oidcClient": {
-      "client_id": "audiobookshelf",
-      "client_name": "Audiobookshelf",
-      "authorization_policy": "one_factor",
-      "redirect_uris": ["/auth/openid/callback", "/auth/openid/mobile-redirect"],
-      "scopes": ["openid", "profile", "email", "groups"],
-      "clientSecretVar": "ABS_OIDC_SECRET"
+      "ssl_forced": true,
+      "advanced_config": "# Jellyfin needs a higher body limit for chunked uploads (cover\n# art replacement, library imports). Default NPM cap of 1MB rejects\n# those.\nclient_max_body_size 100M;"
     }
   },
   "JELLYFIN_PORT": {

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -386,15 +386,15 @@ describe('Media template: Audiobookshelf retired for fresh installs (#1725)', ()
     expect(JSON.stringify(pod)).not.toMatch(/audiobookshelf-config|abs-audiobooks|abs-podcasts/);
   });
 
-  it('schema-version is bumped to 5 with a matching CHANGELOG section', () => {
-    expect(media.yamlContent).toMatch(/servicebay\.schema-version:\s*"5"/);
+  it('schema-version is bumped to 6 with a matching CHANGELOG section', () => {
+    expect(media.yamlContent).toMatch(/servicebay\.schema-version:\s*"6"/);
     const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'media', 'CHANGELOG.md'), 'utf-8');
-    expect(changelog).toMatch(/##\s*v5\b/);
+    expect(changelog).toMatch(/##\s*v6\b/);
   });
 
-  it('the v4-to-v5 migration is non-destructive (leaves ABS data on disk)', () => {
+  it('the v5-to-v6 migration is non-destructive (leaves ABS data on disk)', () => {
     const mig = fs.readFileSync(
-      path.join(TEMPLATES_DIR, 'media', 'migrations', 'v4-to-v5.py'), 'utf-8',
+      path.join(TEMPLATES_DIR, 'media', 'migrations', 'v5-to-v6.py'), 'utf-8',
     );
     // The migration must NOT delete/move the ABS data dirs — it only informs.
     expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);


### PR DESCRIPTION
## What
Three media/backend/MCP fixes from one batch:
- **media template** finishes the Audiobookshelf retirement (drop the dead `books.dopp.cloud`→13378 route + the re-registered ABS OIDC client, tear down the orphan `media-audiobookshelf` container on upgrade) and stops the shared-tree SELinux relabel that crash-looped the media pod when a root-owned stray sat under `file-share/data`. Schema bumped v5→v6 with a non-destructive `v5-to-v6.py` migration.
- **service detection** now groups a running single-container `.container` Quadlet (e.g. `ollama.service`) under its managed service when its base name is in `installedTemplates`, instead of dumping it under Standalone Containers.
- **MCP server** gains a top-level `instructions` string (node→service→container model, how to find an app's logs, resolve-names-yourself) and richer descriptions on the four service/container/log tools. Strings only, no behaviour change.

## Why
Closes #1730
Closes #1731
Closes #1732
Closes #1733

## Risk
Medium — the media template + migration is path-mandated (install/template path); requires a real-box verify on the next reinstall/upgrade. Backend detection + MCP changes are low blast radius.

## Rollback
git revert is enough (no data migration is destructive; v5-to-v6.py only informs/teardown-reconciles).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2319 pass)
- [ ] /verify on FCoS :dev box — media template + migration are path-mandated (box_verify owed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
