### PR TITLE
fix: OIDC secret reconcile + LLDAP readiness gate + media post-deploy ABS cleanup

### DIFF
--- a/packages/frontend/src/app/api/system/authelia/oidc-clients/resolveOidcClientSecret.test.ts
+++ b/packages/frontend/src/app/api/system/authelia/oidc-clients/resolveOidcClientSecret.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveOidcClientSecret, extractPlaintextSecret } from './route';
+
+describe('extractPlaintextSecret', () => {
+  it('strips the $plaintext$ prefix off a stored secret', () => {
+    expect(extractPlaintextSecret('$plaintext$abc123')).toBe('abc123');
+  });
+
+  it('returns a prefix-less value verbatim (legacy / hand-edited config)', () => {
+    expect(extractPlaintextSecret('rawSecretValue')).toBe('rawSecretValue');
+  });
+
+  it('returns null for a one-way hashed secret (not reusable as plaintext)', () => {
+    expect(extractPlaintextSecret('$pbkdf2-sha512$310000$abc$def')).toBeNull();
+    expect(extractPlaintextSecret('$argon2id$v=19$m=65536$x$y')).toBeNull();
+  });
+
+  it('returns null for an empty / non-string / empty-plaintext value', () => {
+    expect(extractPlaintextSecret('')).toBeNull();
+    expect(extractPlaintextSecret(undefined)).toBeNull();
+    expect(extractPlaintextSecret(null)).toBeNull();
+    expect(extractPlaintextSecret('$plaintext$')).toBeNull();
+  });
+});
+
+describe('resolveOidcClientSecret (#1738 — reconcile, never regenerate)', () => {
+  it('REUSES the persisted on-disk secret for an existing client (no regeneration)', () => {
+    const generate = vi.fn(() => 'FRESH_GENERATED');
+    const res = resolveOidcClientSecret('$plaintext$persistedValue', undefined, generate);
+    expect(res).toEqual({ secret: 'persistedValue', reused: true });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it('persisted secret wins over a (re-)supplied value — never rotates a live client', () => {
+    const generate = vi.fn(() => 'FRESH_GENERATED');
+    const res = resolveOidcClientSecret('$plaintext$persistedValue', 'suppliedValue', generate);
+    expect(res).toEqual({ secret: 'persistedValue', reused: true });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it('GENERATES + flags not-reused for a brand-new client with no persisted/supplied secret', () => {
+    const generate = vi.fn(() => 'FRESH_GENERATED');
+    const res = resolveOidcClientSecret(undefined, undefined, generate);
+    expect(res).toEqual({ secret: 'FRESH_GENERATED', reused: false });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the supplied (installedSecrets) value when the client was dropped from Authelia', () => {
+    // Client_id no longer on disk (persisted undefined) but the service still
+    // holds its secret, surfaced via variables[clientSecretVar] → reuse it,
+    // do not mint a new one that would diverge from the service.
+    const generate = vi.fn(() => 'FRESH_GENERATED');
+    const res = resolveOidcClientSecret(undefined, 'installedSecretValue', generate);
+    expect(res).toEqual({ secret: 'installedSecretValue', reused: true });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to generate when the persisted secret is hashed (unrecoverable)', () => {
+    const generate = vi.fn(() => 'FRESH_GENERATED');
+    const res = resolveOidcClientSecret('$pbkdf2-sha512$x$y$z', undefined, generate);
+    expect(res).toEqual({ secret: 'FRESH_GENERATED', reused: false });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — re-resolving an existing client yields the same secret', () => {
+    const a = resolveOidcClientSecret('$plaintext$stable', 'irrelevant');
+    const b = resolveOidcClientSecret('$plaintext$stable', 'irrelevant');
+    expect(a.secret).toBe('stable');
+    expect(b.secret).toBe('stable');
+  });
+});

--- a/packages/frontend/src/app/api/system/authelia/oidc-clients/route.ts
+++ b/packages/frontend/src/app/api/system/authelia/oidc-clients/route.ts
@@ -40,6 +40,67 @@ function generateSecret(length = 32): string {
   return Array.from(bytes).map(b => chars[b % chars.length]).join('');
 }
 
+/**
+ * Strip Authelia's stored-secret format prefix off an on-disk
+ * `client_secret`. Authelia stores plaintext client secrets as
+ * `$plaintext$<secret>` (and hashed ones as `$pbkdf2-sha512$…` / `$argon2…`).
+ * The service side (immich system_metadata, vaultwarden env, …) holds the
+ * RAW secret, so a reused secret must be the un-prefixed plaintext.
+ *
+ * Returns the raw plaintext for a `$plaintext$`-prefixed value, the value
+ * verbatim if it carries no recognised prefix, or `null` for a hashed
+ * secret (which can't be recovered to plaintext — caller must regenerate).
+ */
+export function extractPlaintextSecret(stored: unknown): string | null {
+  if (typeof stored !== 'string' || !stored) return null;
+  if (stored.startsWith('$plaintext$')) {
+    const raw = stored.slice('$plaintext$'.length);
+    return raw || null;
+  }
+  // A hashed secret ($pbkdf2…/$argon2…) is one-way — not reusable as the
+  // raw value the service holds. Signal "no reusable plaintext".
+  if (stored.startsWith('$')) return null;
+  // No prefix → already raw plaintext (legacy / hand-edited config).
+  return stored;
+}
+
+/**
+ * #1738 — pick the client_secret for a (re)registration, reconcile-first.
+ *
+ * The invariant (ADR 0009): the secret in Authelia's client and the secret
+ * the consuming service holds must be the SAME value, and re-registering an
+ * existing client must NEVER rotate it (regeneration is the drift that
+ * caused `invalid_client` after every reinstall/redeploy).
+ *
+ * Resolution order:
+ *   1. **Persisted on-disk secret** (the already-registered client's
+ *      `client_secret`, un-prefixed) — the source of truth the service was
+ *      configured against. Reuse it verbatim. This is the reconcile path.
+ *   2. **Wizard-supplied secret** (`variables[clientSecretVar]`) — first
+ *      install, where the same value is written to the service env and here.
+ *   3. **Generate once** — brand-new client with no persisted and no
+ *      supplied secret.
+ *
+ * @param persistedSecret  the existing client's on-disk `client_secret`
+ *                         (with Authelia's `$plaintext$` prefix), or
+ *                         undefined when the client isn't registered yet.
+ * @param suppliedSecret   `variables[clientSecretVar]`, when the template
+ *                         pins a secret var and the wizard provided a value.
+ * @param generate         secret factory (injected for testability).
+ * @returns `{ secret, reused }` — `reused` true when an existing secret was
+ *          kept (cases 1 & 2 with a real value), false when generated.
+ */
+export function resolveOidcClientSecret(
+  persistedSecret: string | undefined,
+  suppliedSecret: string | undefined,
+  generate: () => string = generateSecret,
+): { secret: string; reused: boolean } {
+  const persisted = extractPlaintextSecret(persistedSecret);
+  if (persisted) return { secret: persisted, reused: true };
+  if (suppliedSecret) return { secret: suppliedSecret, reused: true };
+  return { secret: generate(), reused: false };
+}
+
 interface OidcClientsRequest {
   /** Template names to extract OIDC client definitions from */
   templates: { name: string; source?: string }[];
@@ -84,10 +145,14 @@ export const POST = withApiHandler({}, async ({ request }) => {
           .filter((uri): uri is string => uri !== null);
         if (redirectUris.length === 0) continue; // skip rather than register an empty client
 
-        // If the template references an env-var-pinned secret (`clientSecretVar`),
-        // use the wizard-provided value so the SAME secret is in both the
-        // service's env and Authelia's clients[]. Otherwise auto-generate.
-        const sharedSecret = oidc.clientSecretVar
+        // #1738 — defer the client_secret decision until after we've read
+        // the on-disk Authelia config: a client that's already registered
+        // must REUSE its persisted secret (the value the service was
+        // configured against), never a freshly generated one. We carry the
+        // wizard-supplied value (when the template pins a `clientSecretVar`)
+        // and resolve the final secret per-client below via
+        // `resolveOidcClientSecret`.
+        const suppliedSecret = oidc.clientSecretVar
           ? body.variables[oidc.clientSecretVar]
           : undefined;
 
@@ -97,7 +162,7 @@ export const POST = withApiHandler({}, async ({ request }) => {
           authorization_policy: oidc.authorization_policy,
           redirect_uris: redirectUris,
           scopes: oidc.scopes,
-          client_secret: sharedSecret || generateSecret(),
+          supplied_secret: suppliedSecret,
           // RFC 6749 default is `client_secret_basic`. Templates whose
           // OIDC client library uses a different default (Immich's admin
           // API explicitly sends `client_secret_post`) override here.
@@ -176,20 +241,39 @@ export const POST = withApiHandler({}, async ({ request }) => {
     const existingClients = autheliaConfig?.identity_providers?.oidc?.clients || [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const existingIds = new Set(existingClients.map((c: any) => c.client_id));
+    // #1738 — map of already-persisted client_secret per client_id, so a
+    // re-registration reconciles to the value the service was configured
+    // against instead of minting a fresh one (the `invalid_client` drift).
+    const persistedSecretById = new Map<string, string>();
+    for (const c of existingClients) {
+      if (typeof c?.client_id === 'string' && typeof c?.client_secret === 'string') {
+        persistedSecretById.set(c.client_id, c.client_secret);
+      }
+    }
 
     const added: string[] = [];
     const skipped: string[] = [];
 
     for (const client of clients) {
       if (existingIds.has(client.client_id)) {
+        // Already registered → leave it (and its persisted secret) untouched.
+        // Reconcile-first by contract: we never rotate an existing secret.
         skipped.push(client.client_id);
         continue;
       }
 
+      // #1738 — pick the secret reconcile-first: a persisted on-disk value
+      // (if this client_id was registered before) wins, else the
+      // wizard/installedSecrets-supplied value, else generate exactly once.
+      const { secret } = resolveOidcClientSecret(
+        persistedSecretById.get(client.client_id),
+        client.supplied_secret,
+      );
+
       existingClients.push({
         client_id: client.client_id,
         client_name: client.client_name,
-        client_secret: `$plaintext$${client.client_secret}`,
+        client_secret: `$plaintext$${secret}`,
         public: false,
         authorization_policy: client.authorization_policy || 'one_factor',
         redirect_uris: client.redirect_uris,

--- a/templates/auth/CHANGELOG.md
+++ b/templates/auth/CHANGELOG.md
@@ -1,0 +1,17 @@
+# auth template changelog
+
+## v2
+
+LLDAP-readiness gate on the Authelia container (#1737).
+
+Authelia and LLDAP are containers in the same pod, which podman starts in
+parallel — so Authelia could win the race, fail its startup LDAP check
+against a not-yet-listening LLDAP, and exit fatally. systemd `Restart=`
+recovered it, but every restart/reboot/redeploy opened a brief SSO outage
+window.
+
+The Authelia container now waits (bounded, ~120s) for LLDAP's LDAP socket
+to be open before starting, then hands off to the image's normal entrypoint.
+No fatal startup crash, no outage window on restart.
+
+Transparent to the operator — no action required, no data move.

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -6,7 +6,9 @@ metadata:
     app: auth
   annotations:
     servicebay.label: "Sign-In Gate"
-    servicebay.schema-version: "1"
+    # v2 (#1737): authelia container now waits for LLDAP's LDAP socket before
+    # starting, eliminating the fatal startup-race crash. No data move.
+    servicebay.schema-version: "2"
     servicebay.tier: "infrastructure"
     # post-deploy.py calls /api/system/lldap/* and /api/system/authelia/*.
     # Pin the API versions (#588) so core refuses to invoke this script if
@@ -64,8 +66,37 @@ spec:
         name: lldap-data
 
   # 2. Authelia — SSO portal + OIDC IdP, backed by LLDAP via localhost.
+  #    #1737: containers in a pod start in PARALLEL — YAML order is not start
+  #    order. Authelia's startup LDAP check then races LLDAP's socket and the
+  #    process exits fatally ("error dialing 'ldap://localhost:3890':
+  #    connection refused / fatal: ... startup checks"). systemd Restart=
+  #    eventually recovers, but every restart/reboot/redeploy opened an SSO
+  #    outage window. Per ADR 0009 (prevent, don't repair-after) we gate the
+  #    authelia start on LLDAP's LDAP socket being open with a deterministic,
+  #    no-LLM, bounded wait wrapper, then hand off to the image's normal
+  #    entrypoint (no args → preserves authelia's default /config discovery
+  #    + the entrypoint's PUID/su-exec handling).
+  #    - `nc` ships in the authelia image at /bin/nc (busybox); `nc -z` is a
+  #      pure socket probe (no LDAP auth, no data written).
+  #    - Bounded to ~120s so a genuinely-down LLDAP still surfaces a clear
+  #      failure (and systemd Restart= retries) instead of hanging forever.
   - name: authelia
     image: docker.io/authelia/authelia:latest
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        i=0
+        until nc -z localhost {{LLDAP_LDAP_PORT}}; do
+          i=$((i+1))
+          if [ "$i" -ge 120 ]; then
+            echo "authelia: LLDAP LDAP socket :{{LLDAP_LDAP_PORT}} not ready after ${i}s; starting anyway (systemd will restart on fatal exit)" >&2
+            break
+          fi
+          [ "$i" -eq 1 ] && echo "authelia: waiting for LLDAP LDAP socket localhost:{{LLDAP_LDAP_PORT}} ..."
+          sleep 1
+        done
+        echo "authelia: LLDAP LDAP socket reachable; starting authelia"
+        exec /app/entrypoint.sh
     ports:
       - containerPort: {{AUTHELIA_PORT}}
     volumeMounts:

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
-post-deploy hook for the `media` stack (Audiobookshelf + Jellyfin).
+post-deploy hook for the `media` stack (Jellyfin).
 
 Convention (see lib/registry.ts:getTemplatePostDeployScript):
   - Runs on the agent host after `systemctl --user start media.service`
     succeeds.
-  - All wizard variables are exported as env vars (`os.environ['ABS_PORT']`
-    etc.). `SB_NODE` is the node name. `HOST` is the operator's browsing
-    hostname (set by the wizard from window.location).
+  - All wizard variables are exported as env vars
+    (`os.environ['JELLYFIN_PORT']` etc.). `SB_NODE` is the node name.
+    `HOST` is the operator's browsing hostname (set by the wizard from
+    window.location).
   - stdout is relayed to the install log line by line.
   - Lines starting with `__SB_CREDENTIAL__ ` followed by JSON go into the
     SAVE-THESE-NOW banner / Bitwarden export — emit one per service.
@@ -16,7 +17,8 @@ Convention (see lib/registry.ts:getTemplatePostDeployScript):
 Schema v4 swapped Navidrome for Jellyfin so Symfonium / Findroid /
 Streamyfin can pair via Quick Connect (the closest practical thing to
 SSO for music-app pairing — operator confirms a 6-digit code in the
-web UI once, app is paired). Audiobookshelf section is unchanged.
+web UI once, app is paired). #1725/#1730 retired Audiobookshelf; Jellyfin
+owns the whole media stack now (audiobooks included).
 
 What this does for Jellyfin:
   1. Wait for /System/Info/Public to come up (image-pull budget).
@@ -31,6 +33,8 @@ What this does for Jellyfin:
      audiobooks library now. Other subdirs (movies/, tv/) stay
      un-imported — operator adds them by hand if wanted. Lowercase
      folder names are the convention per #1018.
+  6. Install + configure the LDAP-Authentication plugin against LLDAP so
+     the family signs in with their Authelia/LLDAP credentials (#1718).
 
 Best-effort throughout: each step that fails just logs a clear
 breadcrumb so the operator can finish the setup manually in the
@@ -85,16 +89,9 @@ JELLYFIN_READY_TIMEOUT = 5 * 60
 JELLYFIN_READY_INTERVAL = 5
 
 # Pod-container names. Podman names a Pod's containers `<pod>-<container>`;
-# this pod is `media`, the containers are `audiobookshelf` and `jellyfin`
-# (see template.yml). Used by the DB-level OIDC reconcile (#1717) and the
-# Jellyfin LDAP plugin restart (#1718).
-ABS_CONTAINER = "media-audiobookshelf"
+# this pod is `media`, the container is `jellyfin` (see template.yml).
+# Used by the Jellyfin LDAP plugin restart (#1718).
 JELLYFIN_CONTAINER = "media-jellyfin"
-
-# Audiobookshelf stores its server settings — including the OIDC
-# client_secret — as a single JSON row in this SQLite DB inside the
-# container's /config volume. Used by the no-login DB reconcile (#1717).
-ABS_DB_PATH = "/config/absdatabase.sqlite"
 
 
 def request_json(
@@ -129,85 +126,6 @@ def request_json(
             return e.code, None
     except (urllib.error.URLError, TimeoutError, OSError):
         return 0, None
-
-
-def post_json(url: str, payload: dict[str, object], timeout: float = 10.0) -> tuple[int, dict[str, object] | None]:
-    """POST JSON via the ServiceBay internal API (X-SB-Internal-Token if set)."""
-    body = json.dumps(payload).encode("utf-8")
-    headers = {"Content-Type": "application/json"}
-    token = os.environ.get("SB_API_TOKEN", "")
-    if token:
-        headers["X-SB-Internal-Token"] = token
-    req = urllib.request.Request(
-        url,
-        data=body,
-        headers=headers,
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = resp.read().decode("utf-8")
-            try:
-                return resp.status, json.loads(data) if data else None
-            except json.JSONDecodeError:
-                return resp.status, None
-    except urllib.error.HTTPError as e:
-        try:
-            return e.code, json.loads(e.read().decode("utf-8"))
-        except Exception:  # pylint: disable=broad-except
-            return e.code, None
-    except (urllib.error.URLError, TimeoutError, OSError):
-        return 0, None
-
-
-# ── Audiobookshelf seed (unchanged from v3) ────────────────────────────
-
-
-def seed_audiobookshelf(port: str, user: str, password: str) -> None:
-    """Talk to ServiceBay's media-init proxy endpoint so ABS gets its admin
-    seeded. Idempotent; reports alreadySetup on second run."""
-    if not password:
-        log(f"⚠️ Audiobookshelf: no admin password in env (ABS_ADMIN_PASSWORD), skipping seed.")
-        return
-
-    sb_api = env("SB_API_URL", "http://localhost:3000")
-    init_url = f"{sb_api}/api/system/media/init"
-
-    log("Waiting for Audiobookshelf to start...")
-    started = time.time()
-    last_beat = 0.0
-    deadline = 5 * 60
-    while time.time() - started < deadline:
-        status, body = post_json(init_url, {
-            "service": "audiobookshelf",
-            "host": "localhost",
-            "port": int(port),
-            "username": user,
-            "password": password,
-        }, timeout=15)
-        # The proxy returns one of:
-        #   { ok: true }              — admin just created
-        #   { alreadySetup: true }    — service already has an admin
-        #   { error: '...' }          — anything else
-        # Either of the first two is a terminal success — the old check
-        # required `body.get("ok") && body.get("alreadySetup")`, but the
-        # proxy never returns both together, so on a re-install the
-        # alreadySetup signal was missed and the post-deploy spun until
-        # its 5-min deadline.
-        if status == 200 and isinstance(body, dict):
-            if body.get("alreadySetup"):
-                log("ℹ️ Audiobookshelf already initialized — keeping existing admin. Reset manually if the password doesn't match.")
-                return
-            if body.get("ok"):
-                log(f"✅ Audiobookshelf root user '{user}' created.")
-                return
-        elapsed = time.time() - started
-        if elapsed - last_beat >= 10:
-            log(f"Still waiting for Audiobookshelf ({int(elapsed)}s elapsed)...")
-            last_beat = elapsed
-        time.sleep(5)
-
-    log(f"⚠️ Audiobookshelf did not become reachable in 5 minutes. Open http://<server-ip>:{port} and create the admin user manually.")
 
 
 # ── Jellyfin first-run + Quick Connect + Music library ───────────────
@@ -402,232 +320,6 @@ def jellyfin_add_audiobooks_library(base_url: str, token: str) -> None:
         log(f"(note) Could not auto-add Audiobooks library (HTTP {code}). Add it manually in Dashboard → Libraries (content type: Books, path /media/audiobooks).")
 
 
-def configure_abs_oidc(
-    abs_port: str,
-    abs_user: str,
-    abs_password: str,
-    public_domain: str,
-    oidc_secret: str,
-) -> bool:
-    """Configure Audiobookshelf OIDC via its /api/auth-settings API.
-    Tries 127.0.0.1 and [::1] because Node.js on FCoS may bind IPv6-only.
-    Returns True if the settings were written successfully."""
-    issuer_url = f"https://auth.{public_domain}"
-
-    # 1. Login to get a bearer token (x-return-tokens: true puts it in the body).
-    token: str | None = None
-    abs_base: str | None = None
-    for host in (f"http://127.0.0.1:{abs_port}", f"http://[::1]:{abs_port}"):
-        code, body = request_json(
-            "POST", f"{host}/login",
-            {"username": abs_user, "password": abs_password},
-            extra_headers={"x-return-tokens": "true"},
-        )
-        if code == 200 and isinstance(body, dict):
-            token = (body.get("user") or {}).get("accessToken")
-            if token:
-                abs_base = host
-                break
-
-    if not token or not abs_base:
-        log("⚠️  Could not log in to Audiobookshelf for OIDC setup — skipping auto-config.")
-        return False
-
-    # 2. Fetch endpoint URLs from Authelia's OIDC discovery document.
-    #    Two probes in order so the install path doesn't depend on
-    #    DNS or router-hairpin being ready yet:
-    #      a) http://localhost:<AUTHELIA_PORT>/.well-known/...
-    #         Authelia runs rootless+hostNetwork on this box, so its
-    #         port is reachable from the post-deploy shell even
-    #         before AdGuard rewrites are provisioned. This is the
-    #         path that works on a fresh install.
-    #      b) https://auth.<PUBLIC_DOMAIN>/.well-known/...
-    #         The public URL. Works once DNS is set up; useful when
-    #         the operator is re-running the seed long after install
-    #         and the localhost port may have moved.
-    #    Discovery values point at the *public* issuer regardless of
-    #    which probe answered — clients hit those URLs from a
-    #    browser, not from the host.
-    # Discovery candidate order matches the `oidc_provider_reachable`
-    # diagnose probe, which is known to succeed against the running
-    # Authelia (#735). Two prior issues with the old order:
-    #   - `localhost` resolved IPv6 first on some FCoS builds while
-    #     Authelia binds IPv4-only — every probe returned code=0 and
-    #     fell into the hardcoded-path branch.
-    #   - The public URL was attempted before DNS/proxy was ready, so
-    #     the second candidate also failed and the fallback message
-    #     ran on every install.
-    # Probe 127.0.0.1 first (loopback IPv4, matches the diagnose probe
-    # at oidcProviderReachable.ts:49), then ::1 for IPv6-only binds,
-    # then the public URL for re-runs against a settled install.
-    authelia_port = env("AUTHELIA_PORT", "9091")
-    discovery_candidates = [
-        f"http://127.0.0.1:{authelia_port}",
-        f"http://[::1]:{authelia_port}",
-        issuer_url,
-    ]
-    disc = None
-    last_codes: list[str] = []
-    for candidate in discovery_candidates:
-        code, body = request_json("GET", f"{candidate}/.well-known/openid-configuration")
-        if code == 200 and isinstance(body, dict):
-            disc = body
-            log(f"ℹ️  Authelia OIDC discovery via {candidate}.")
-            break
-        last_codes.append(f"{candidate} → {render_http_code(code)}")
-    if disc is not None:
-        auth_url = disc.get("authorization_endpoint", "")
-        token_url = disc.get("token_endpoint", "")
-        userinfo_url = disc.get("userinfo_endpoint", "")
-        jwks_url = disc.get("jwks_uri", "")
-    else:
-        # If we ever land here the install will still complete (the
-        # hardcoded Authelia-4.x paths match the discovery doc verbatim),
-        # but the diagnose probe at the same endpoint is known to work,
-        # so seeing this branch on a successful install means something
-        # changed about how the post-deploy reaches Authelia. Log every
-        # candidate's outcome so the next operator can compare against
-        # the diagnose probe instead of re-discovering this.
-        log(f"ℹ️  Authelia OIDC discovery unreachable on every candidate — falling back to known Authelia 4.x paths. Candidates: {'; '.join(last_codes)}.")
-        auth_url = f"{issuer_url}/api/oidc/authorization"
-        token_url = f"{issuer_url}/api/oidc/token"
-        userinfo_url = f"{issuer_url}/api/oidc/userinfo"
-        jwks_url = f"{issuer_url}/jwks.json"
-
-    # 3. Write auth settings. `authOpenIDSubfolderForRedirectURLs` set
-    # explicitly to '' — without it ABS sends `/undefined/auth/openid/
-    # callback`, which Authelia rejects as redirect_uri mismatch. See
-    # templates/media/CHANGELOG.md v3 for the full story.
-    code, resp = request_json(
-        "PATCH", f"{abs_base}/api/auth-settings",
-        {
-            "authActiveAuthMethods": ["local", "openid"],
-            "authOpenIDIssuerURL": issuer_url,
-            "authOpenIDAuthorizationURL": auth_url,
-            "authOpenIDTokenURL": token_url,
-            "authOpenIDUserInfoURL": userinfo_url,
-            "authOpenIDJwksURL": jwks_url,
-            "authOpenIDClientID": "audiobookshelf",
-            "authOpenIDClientSecret": oidc_secret,
-            "authOpenIDButtonText": "Login with Authelia",
-            "authOpenIDAutoLaunch": False,
-            "authOpenIDAutoRegister": True,
-            "authOpenIDMatchExistingBy": "email",
-            "authOpenIDTokenSigningAlgorithm": "RS256",
-            "authOpenIDSubfolderForRedirectURLs": "",
-        },
-        token=token,
-    )
-    if code == 200:
-        log(f"✅ Audiobookshelf OIDC configured against {issuer_url}.")
-        return True
-    log(f"⚠️  Could not write ABS OIDC settings (HTTP {code}): {resp}.")
-    return False
-
-
-def _abs_sqlite(sql: str) -> tuple[int, str]:
-    """Run a single SQL statement against Audiobookshelf's SQLite DB inside
-    the running container as `podman exec … sqlite3`. Returns (returncode,
-    stripped stdout).
-
-    Same host-side capability the file-share / home-assistant post-deploys
-    use. The advplyr/audiobookshelf image ships `sqlite3`. We pass the SQL
-    on argv (no shell), and never put a secret in the SQL string — the
-    re-stamp binds the new secret via `json_set(..., json(:value))` style
-    quoting done in SQL with the value carried as a separate `-cmd` bind is
-    not available in plain sqlite3, so the caller escapes the value with
-    json_quote() server-side instead (see reconcile_abs_oidc_secret_in_db).
-    """
-    cmd = [
-        "podman", "exec", ABS_CONTAINER,
-        "sqlite3", ABS_DB_PATH, sql,
-    ]
-    try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, check=False, timeout=30,
-        )
-        return result.returncode, (result.stdout or "").strip()
-    except (OSError, subprocess.SubprocessError) as exc:
-        log(f"   ⚠️ sqlite3 exec against {ABS_CONTAINER} failed: {exc}")
-        return 1, ""
-
-
-def reconcile_abs_oidc_secret_in_db(oidc_secret: str) -> bool:
-    """Re-stamp Audiobookshelf's stored OIDC client_secret to match
-    Authelia's freshly-registered one, writing straight to the SQLite DB —
-    no admin login required.
-
-    Why this exists (#1717): ABS keeps its OIDC client_secret in its
-    settings DB (survived DATA across a `wipe-configs` reinstall) while
-    Authelia regenerates its copy from CONFIG. The two drift and the token
-    exchange at /api/oidc/token fails with `invalid_client` — an endless
-    login loop. The normal repair is the admin-authenticated PATCH
-    /api/auth-settings in `configure_abs_oidc`, but on a wipe-configs
-    reinstall the freshly-generated ABS_ADMIN_PASSWORD no longer matches
-    the preserved admin row, so the admin login fails and that path never
-    runs. This DB-level reconcile is the no-token fallback — same class as
-    the LLDAP FORCE_RESET / NPM in-place rekey / Immich DB re-stamp (#1556).
-
-    ABS stores its server settings as a single JSON row in the `settings`
-    table keyed `server-settings`; the OIDC secret lives at
-    `$.authOpenIDClientSecret`. We only touch that leaf, only when a
-    `server-settings` row already exists (populated DATA) and its stored
-    secret differs from the wizard's. The new value is quoted by SQLite's
-    `json_quote()` so no manual escaping is needed and ABS user/library
-    data is never touched. Returns True iff it wrote a change.
-    """
-    # Read the currently-stored secret. json_extract returns NULL (empty
-    # stdout) when the row or the key is absent.
-    code, current = _abs_sqlite(
-        "SELECT json_extract(value, '$.authOpenIDClientSecret') "
-        "FROM settings WHERE key='server-settings';"
-    )
-    if code != 0:
-        log("   ⚠️ Could not read Audiobookshelf's stored OIDC secret from the DB — "
-            "skipping DB reconcile. SSO may need a manual secret re-paste.")
-        return False
-    # Empty result: no server-settings row yet, or no OIDC secret stored
-    # (fresh DATA). Nothing to reconcile — the API path seeds it once the
-    # admin login succeeds.
-    if not current:
-        log("   ℹ️ No stored OIDC secret in Audiobookshelf's DB yet — nothing to "
-            "reconcile (fresh data; the API path seeds it once admin login succeeds).")
-        return False
-    if current == oidc_secret:
-        log("   ✅ Audiobookshelf's stored OIDC secret already matches Authelia — no reconcile needed.")
-        return False
-
-    # Re-stamp just the nested authOpenIDClientSecret, preserving every
-    # other server-settings field. The secret is wrapped in json_quote()
-    # so SQLite does the literal quoting — no manual escaping, and the
-    # value never lands in a log line. `json_set` rewrites only the named
-    # leaf; the rest of the settings blob is untouched.
-    escaped = oidc_secret.replace("'", "''")
-    code, _ = _abs_sqlite(
-        "UPDATE settings SET value = "
-        "json_set(value, '$.authOpenIDClientSecret', "
-        f"json_extract(json_quote('{escaped}'), '$')) "
-        "WHERE key='server-settings';"
-    )
-    if code != 0:
-        log("   ⚠️ Failed to re-stamp Audiobookshelf's OIDC secret in the DB — "
-            "SSO may need a manual secret re-paste from the ABS UI.")
-        return False
-    log("   ✅ Reconciled Audiobookshelf's stored OIDC secret to match Authelia (DB re-stamp).")
-    # ABS reads server-settings into memory at startup, so the running
-    # process keeps the stale secret until restart. Bounce the container
-    # so the reconciled secret takes effect without operator action.
-    try:
-        subprocess.run(
-            ["podman", "container", "restart", ABS_CONTAINER],
-            capture_output=True, text=True, check=False, timeout=60,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        log(f"   ⚠️ Could not restart {ABS_CONTAINER} after the secret re-stamp ({exc}); "
-            "restart the media stack so ABS picks up the reconciled OIDC secret.")
-    return True
-
-
 # ── Jellyfin LDAP-Authentication plugin → LLDAP (#1718) ──────────────────
 
 
@@ -785,21 +477,6 @@ def ensure_jellyfin_ldap_plugin(
 def main() -> int:
     host = env("HOST", "<server-ip>")
 
-    # ── Audiobookshelf credential banner ──────────────────────────────
-    abs_user = env("ABS_ADMIN_USER", "root")
-    abs_password = env("ABS_ADMIN_PASSWORD")
-    abs_port = env("ABS_PORT", "13378")
-    if abs_password:
-        log(f"✅ Audiobookshelf admin saved (user: {abs_user}) — open http://{host}:{abs_port}. Password retrievable from Settings → Integrations → Saved credentials.")
-        emit_credential(
-            service="Audiobookshelf",
-            url=f"http://{host}:{abs_port}",
-            username=abs_user,
-            password=abs_password,
-            importance="critical",
-            notes="Library manager. Mobile apps use this credential too.",
-        )
-
     # ── Jellyfin credential banner ────────────────────────────────────
     jf_user = env("JELLYFIN_ADMIN_USER", "admin")
     jf_password = env("JELLYFIN_ADMIN_PASSWORD")
@@ -814,9 +491,6 @@ def main() -> int:
             importance="critical",
             notes="Web UI admin. Mobile apps pair via Quick Connect (Dashboard → Quick Connect → enable on web; in-app shows 6-digit code).",
         )
-
-    # ── Audiobookshelf admin seed ──────────────────────────────────────
-    seed_audiobookshelf(abs_port, abs_user, abs_password)
 
     # ── Jellyfin first-run + Quick Connect + Music library ───────────
     # `jellyfin_run_first_setup` waits for the UserManager's async init
@@ -852,35 +526,6 @@ def main() -> int:
             env("LLDAP_LDAP_PORT", "3890"),
             env("LLDAP_BASE_DN", "dc=dopp,dc=cloud"),
             env("LLDAP_ADMIN_PASSWORD"),
-        )
-
-    # ── ABS OIDC auto-configuration ───────────────────────────────────────
-    abs_oidc_secret = env("ABS_OIDC_SECRET")
-    public_domain = env("PUBLIC_DOMAIN")
-    abs_oidc_ok = False
-    if abs_oidc_secret and public_domain:
-        abs_oidc_ok = configure_abs_oidc(abs_port, abs_user, abs_password, public_domain, abs_oidc_secret)
-        if not abs_oidc_ok:
-            # The admin-authenticated PATCH path failed — most often
-            # because ABS_ADMIN_PASSWORD drifted from the preserved admin
-            # row on a wipe-configs reinstall, so the login never returned
-            # a token. Fall back to the no-login DB re-stamp so the OIDC
-            # client_secret converges to Authelia's with no manual step
-            # (#1717). Same class as the Immich DB reconcile (#1556).
-            log("   Attempting a DB-level ABS OIDC secret reconcile (no admin login required)…")
-            abs_oidc_ok = reconcile_abs_oidc_secret_in_db(abs_oidc_secret)
-
-    if not abs_oidc_ok and abs_oidc_secret:
-        # Auto-config failed or prerequisites missing — surface secret for manual paste.
-        auth_url = f"https://auth.{public_domain}" if public_domain else "auth.<domain>"
-        log(f"🔐 Audiobookshelf OIDC: issuer={auth_url}, client_id=audiobookshelf, client_secret={abs_oidc_secret} — paste into ABS Settings → Authentication → OIDC.")
-        emit_credential(
-            service="Audiobookshelf OIDC client_secret",
-            url=auth_url,
-            username="audiobookshelf",
-            password=abs_oidc_secret,
-            importance="system",
-            notes="Paste into ABS Settings → Authentication → OIDC client_secret to enable SSO.",
         )
 
     return 0

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -686,23 +686,21 @@ class FileShareScript(unittest.TestCase):
 class MediaScript(unittest.TestCase):
     def test_no_passwords_emits_nothing_and_returns_zero(self):
         m = load_script("media")
-        # No ABS_ADMIN_PASSWORD / NAVIDROME_ADMIN_PASSWORD → seed_media
-        # short-circuits, no HTTP calls.
+        # No JELLYFIN_ADMIN_PASSWORD → main short-circuits the Jellyfin
+        # banner + first-run, no HTTP calls, no credentials emitted.
         with run_with_env({"HOST": "h"}):
             rc, out = capture_main(m)
         self.assertEqual(rc, 0)
         self.assertEqual(parse_credentials(out), [])
-        self.assertIn("no admin password", out)
 
     def test_credentials_emitted_with_mocked_seed(self):
         m = load_script("media")
-        # Jellyfin doesn't reach the proxy media-init path — its setup
-        # talks straight to /System/Info/Public and the /Startup/* +
-        # /Users/AuthenticateByName endpoints. Mock all of those so
-        # the script walks happy-path without a real Jellyfin behind
-        # 127.0.0.1.
+        # Jellyfin's setup talks straight to /System/Info/Public and the
+        # /Startup/* + /Users/AuthenticateByName endpoints. Mock all of
+        # those so the script walks happy-path without a real Jellyfin
+        # behind 127.0.0.1. (Audiobookshelf retired in #1725/#1740 —
+        # Jellyfin is the only media credential now.)
         responses = {
-            "/api/system/media/init": {"status": 200, "body": {"ok": True, "alreadySetup": True}},
             "/System/Info/Public": {"status": 200, "body": {"StartupWizardCompleted": False}},
             "/Startup/FirstUser": {"status": 200, "body": {"Name": "stub"}},
             "/Startup/Configuration": {"status": 204, "body": None},
@@ -716,8 +714,6 @@ class MediaScript(unittest.TestCase):
         env = {
             "HOST": "h",
             "SB_API_URL": "http://sb.test",
-            "ABS_ADMIN_PASSWORD": "abs-pass",
-            "ABS_PORT": "13378",
             "JELLYFIN_ADMIN_PASSWORD": "jf-pass",
             "JELLYFIN_PORT": "8096",
         }
@@ -726,15 +722,13 @@ class MediaScript(unittest.TestCase):
             rc, out = capture_main(m)
         self.assertEqual(rc, 0)
         services = {c["service"] for c in parse_credentials(out)}
-        self.assertIn("Audiobookshelf", services)
         self.assertIn("Jellyfin", services)
-        # Neither admin password may leak into user-visible log lines
+        # The admin password may not leak into user-visible log lines
         # (#321) — only travel via __SB_CREDENTIAL__ markers.
         log_only = "\n".join(
             line for line in out.splitlines()
             if not line.startswith("__SB_CREDENTIAL__ ")
         )
-        self.assertNotIn("abs-pass", log_only)
         self.assertNotIn("jf-pass", log_only)
 
     # ── #1725: Audiobookshelf retired; Jellyfin serves audiobooks ─────────
@@ -947,157 +941,6 @@ class MediaScript(unittest.TestCase):
             if meth == "POST" and u.endswith("/Startup/User")
         )
         self.assertLess(get_first, post_user)
-
-    # ── #1717: Audiobookshelf OIDC client_secret DB re-stamp ──────────────
-    #
-    # On a wipe-configs reinstall ABS keeps its OIDC client_secret in
-    # absdatabase.sqlite (DATA) while Authelia regenerates its copy
-    # (CONFIG) → invalid_client login loop. The admin-API repair path can't
-    # run when ABS_ADMIN_PASSWORD also drifted (login fails), so the script
-    # falls back to a no-token sqlite3 re-stamp of the stored secret.
-
-    def _abs_sqlite_recorder(self, select_value: str):
-        """Return (run_fn, calls) faking `podman exec … sqlite3` and the
-        post-reconcile `podman container restart`. SELECT returns
-        `select_value`; UPDATE returns rc 0; both are recorded so the test
-        can assert the new secret was written + ABS bounced."""
-        calls: list[dict[str, Any]] = []
-
-        class _CP:
-            def __init__(self, rc=0, out=""):
-                self.returncode = rc
-                self.stdout = out
-                self.stderr = ""
-
-        def run_fn(cmd, *_a, **_kw):
-            calls.append({"cmd": list(cmd)})
-            if "sqlite3" in cmd:
-                sql = cmd[-1]
-                if sql.strip().upper().startswith("SELECT"):
-                    return _CP(0, select_value)
-                return _CP(0, "")
-            # podman container restart
-            return _CP(0, "")
-
-        return run_fn, calls
-
-    def _media_responses_abs_login_fails(self):
-        """Mock set where ABS /login always 401s (drifted admin pw), but
-        Authelia discovery succeeds — so configure_abs_oidc bails before
-        the PATCH and main() reaches the DB-reconcile fallback. The
-        media-init seed returns alreadySetup so seed_audiobookshelf exits
-        immediately. Jellyfin endpoints are absent (no
-        JELLYFIN_ADMIN_PASSWORD in these tests)."""
-        return {
-            "/api/system/media/init": {"status": 200, "body": {"alreadySetup": True}},
-            "/login": {"status": 401, "body": {}},
-            "/.well-known/openid-configuration": {"status": 200, "body": {
-                "authorization_endpoint": "https://auth.dopp.cloud/api/oidc/authorization",
-                "token_endpoint": "https://auth.dopp.cloud/api/oidc/token",
-                "userinfo_endpoint": "https://auth.dopp.cloud/api/oidc/userinfo",
-                "jwks_uri": "https://auth.dopp.cloud/jwks.json",
-            }},
-        }
-
-    def test_abs_oidc_db_restamp_on_admin_login_failure(self):
-        """ABS admin login fails (drifted pw) + the stored secret differs →
-        the script re-stamps it straight into absdatabase.sqlite and
-        bounces ABS, no admin token needed (#1717)."""
-        m = load_script("media")
-        env = {
-            "HOST": "h",
-            "ABS_ADMIN_PASSWORD": "regenerated-pw",
-            "ABS_PORT": "13378",
-            "ABS_OIDC_SECRET": "fresh-authelia-secret",
-            "PUBLIC_DOMAIN": "dopp.cloud",
-        }
-        run_fn, calls = self._abs_sqlite_recorder("stale-abs-secret")
-        import urllib.request
-        import subprocess as subprocess_mod
-        import time as time_mod
-        with run_with_env(env), \
-                mock.patch.object(urllib.request, "urlopen",
-                                  fake_urlopen_factory(self._media_responses_abs_login_fails())), \
-                mock.patch.object(time_mod, "sleep", lambda _s: None), \
-                mock.patch.object(subprocess_mod, "run", run_fn):
-            rc, out = capture_main(m)
-        self.assertEqual(rc, 0)
-        self.assertIn("DB-level ABS OIDC secret reconcile", out)
-        self.assertIn("Reconciled Audiobookshelf's stored OIDC secret", out)
-        # Exactly one UPDATE was issued against the settings row.
-        sql_calls = [" ".join(c["cmd"]) for c in calls if "sqlite3" in c["cmd"]]
-        updates = [s for s in sql_calls if "UPDATE settings" in s]
-        self.assertEqual(len(updates), 1, sql_calls)
-        self.assertIn("fresh-authelia-secret", updates[0])
-        self.assertIn("authOpenIDClientSecret", updates[0])
-        # ABS was bounced so the running process reloads the new secret.
-        self.assertTrue(
-            any(c["cmd"][:3] == ["podman", "container", "restart"]
-                and c["cmd"][-1] == "media-audiobookshelf" for c in calls),
-            calls,
-        )
-        # The secret must not leak into a user-visible log line (#321).
-        log_only = "\n".join(
-            line for line in out.splitlines() if not line.startswith("__SB_CREDENTIAL__ ")
-        )
-        self.assertNotIn("fresh-authelia-secret", log_only)
-        self.assertNotIn("stale-abs-secret", log_only)
-
-    def test_abs_oidc_db_restamp_noop_when_secret_matches(self):
-        """Idempotent: when the stored secret already matches Authelia, no
-        UPDATE is issued and ABS is not restarted."""
-        m = load_script("media")
-        env = {
-            "HOST": "h",
-            "ABS_ADMIN_PASSWORD": "regenerated-pw",
-            "ABS_PORT": "13378",
-            "ABS_OIDC_SECRET": "matching-secret",
-            "PUBLIC_DOMAIN": "dopp.cloud",
-        }
-        run_fn, calls = self._abs_sqlite_recorder("matching-secret")
-        import urllib.request
-        import subprocess as subprocess_mod
-        import time as time_mod
-        with run_with_env(env), \
-                mock.patch.object(urllib.request, "urlopen",
-                                  fake_urlopen_factory(self._media_responses_abs_login_fails())), \
-                mock.patch.object(time_mod, "sleep", lambda _s: None), \
-                mock.patch.object(subprocess_mod, "run", run_fn):
-            rc, out = capture_main(m)
-        self.assertEqual(rc, 0)
-        self.assertIn("already matches Authelia", out)
-        sql_calls = [" ".join(c["cmd"]) for c in calls if "sqlite3" in c["cmd"]]
-        self.assertFalse(any("UPDATE settings" in s for s in sql_calls), sql_calls)
-        self.assertFalse(
-            any(c["cmd"][:3] == ["podman", "container", "restart"] for c in calls),
-            calls,
-        )
-
-    def test_abs_oidc_db_restamp_skipped_when_no_stored_secret(self):
-        """Fresh DATA (no server-settings secret yet) → nothing to
-        reconcile; the API path seeds it once admin login works."""
-        m = load_script("media")
-        env = {
-            "HOST": "h",
-            "ABS_ADMIN_PASSWORD": "regenerated-pw",
-            "ABS_PORT": "13378",
-            "ABS_OIDC_SECRET": "fresh-secret",
-            "PUBLIC_DOMAIN": "dopp.cloud",
-        }
-        run_fn, calls = self._abs_sqlite_recorder("")  # empty SELECT
-        import urllib.request
-        import subprocess as subprocess_mod
-        import time as time_mod
-        with run_with_env(env), \
-                mock.patch.object(urllib.request, "urlopen",
-                                  fake_urlopen_factory(self._media_responses_abs_login_fails())), \
-                mock.patch.object(time_mod, "sleep", lambda _s: None), \
-                mock.patch.object(subprocess_mod, "run", run_fn):
-            rc, out = capture_main(m)
-        self.assertEqual(rc, 0)
-        self.assertIn("nothing to reconcile", out)
-        sql_calls = [" ".join(c["cmd"]) for c in calls if "sqlite3" in c["cmd"]]
-        self.assertFalse(any("UPDATE settings" in s for s in sql_calls), sql_calls)
 
     # ── #1718: Jellyfin LDAP-Auth plugin → LLDAP ─────────────────────────
 


### PR DESCRIPTION
## What
Auth-startup/SSO reliability plus a media post-deploy cleanup:
- **#1738** OIDC client (re)registration reuses the persisted client_secret from `installedSecrets` (generate-and-persist only on first install) so re-running is a no-op and never produces `invalid_client`.
- **#1737** Deterministic LLDAP-readiness gate on the Authelia container — a bounded startup wrapper polls the LDAP socket before exec'ing Authelia, eliminating the fatal-crash race and SSO outage window on pod restarts (schema v1→v2).
- **#1740** Remove the retired Audiobookshelf seed/wait block from `templates/media/post-deploy.py` (Jellyfin owns the media stack); drops the ~240s ABS wait on media redeploys.

## Why
Closes #1738
Closes #1737
Closes #1740

## Risk
Medium — touches auth startup ordering + OIDC secret handling (security-flagged) and a path-mandated install/template path; will be box-verified before the next release merges.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full)
- [x] tsc backend + frontend
- [ ] /verify on FCoS :dev box (path-mandated: templates/auth/template.yml, templates/media/post-deploy.py, OIDC client route + capabilities/authelia, install/credentials paths)