### PR TITLE
fix(auth): portable LLDAP-readiness probe + Phase 2 OIDC reconcile heal-action

### DIFF
--- a/packages/backend/src/lib/capabilities/authelia.ts
+++ b/packages/backend/src/lib/capabilities/authelia.ts
@@ -58,6 +58,46 @@ async function listOidcClientIds(template: string): Promise<string[]> {
   return ids;
 }
 
+/**
+ * ADR 0009 Phase 2 (#1741) — build the `templates[] + variables` payload for a
+ * standalone OIDC reconcile triggered by the `sso_verify` diagnose heal-action.
+ *
+ * Unlike the install path (which receives the live `StackVariable[]` from the
+ * job), an on-demand reconcile has no job context — it must reconstruct the
+ * payload from durable state:
+ *   - `PUBLIC_DOMAIN` ← `config.reverseProxy.publicDomain` (the apex the wizard
+ *     persisted; without it there are no OIDC clients to reconcile).
+ *   - each subdomain value ← the template's `variables.json` `default`. Subdomain
+ *     overrides aren't persisted anywhere readable post-install, and the default
+ *     is the canonical value every OIDC client was registered against; the POST
+ *     endpoint is reconcile-first and skips already-registered client_ids, so a
+ *     stale subdomain just no-ops on the existing client (never rotates a secret).
+ *
+ * Returns `null` when there's nothing to reconcile (no public domain, or no
+ * installed template declares an OIDC client) so the caller can short-circuit.
+ */
+export async function buildOidcReconcilePayload(opts: {
+  installedTemplates: string[];
+  publicDomain: string | undefined;
+}): Promise<{ templates: { name: string }[]; variables: Record<string, string> } | null> {
+  if (!opts.publicDomain) return null;
+  const variables: Record<string, string> = { PUBLIC_DOMAIN: opts.publicDomain };
+  const templates: { name: string }[] = [];
+  for (const name of opts.installedTemplates) {
+    const meta = await getTemplateVariables(name).catch(() => null);
+    if (!meta) continue;
+    let hasOidc = false;
+    for (const [varName, varMeta] of Object.entries(meta)) {
+      if (varMeta.type !== 'subdomain' || !varMeta.oidcClient?.client_id) continue;
+      hasOidc = true;
+      if (varMeta.default) variables[varName] = varMeta.default;
+    }
+    if (hasOidc) templates.push({ name });
+  }
+  if (templates.length === 0) return null;
+  return { templates, variables };
+}
+
 export async function handleInstalled(event: FeatureInstalledEvent): Promise<HandlerResult> {
   const ids = await listOidcClientIds(event.template);
   if (ids.length === 0) return { ok: true };

--- a/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.ts
+++ b/packages/backend/src/lib/diagnose/probes/oidcProviderReachable.ts
@@ -45,6 +45,8 @@
 import { agentManager } from '@/lib/agent/manager';
 import { getConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
+import { internalFetch } from '@/lib/api/internalFetch';
+import { buildOidcReconcilePayload } from '@/lib/capabilities/authelia';
 import { registerProbeAction, type ProbeActionResult } from '../actions';
 
 // #1535 — folded into the consolidated `sso_verify` ("Login / SSO")
@@ -336,6 +338,82 @@ async function restartAuthelia({ node }: { node: string }): Promise<ProbeActionR
     };
   }
 }
+
+// Turn the oidc-clients POST response into the action result the diagnose card
+// renders: a one-line summary + the add/skip diff in the details block.
+function reconcileResult(data: { added?: unknown; skipped?: unknown }): ProbeActionResult {
+  const added = Array.isArray(data.added) ? (data.added as string[]) : [];
+  const skipped = Array.isArray(data.skipped) ? (data.skipped as string[]) : [];
+  const summary =
+    added.length > 0
+      ? `Registered ${added.length} OIDC client(s); ${skipped.length} already present.`
+      : `All ${skipped.length} OIDC client(s) already registered — no change.`;
+  const details = [
+    added.length > 0 ? `added: ${added.join(', ')}` : 'added: (none)',
+    skipped.length > 0 ? `skipped: ${skipped.join(', ')}` : 'skipped: (none)',
+  ].join('\n');
+  return { ok: true, message: summary, details, refresh: true };
+}
+
+// reconcileOidcClients re-registers every installed template's OIDC client with
+// Authelia, reusing each client's persisted secret (the POST endpoint is
+// reconcile-first per #1738 — it skips already-registered client_ids and never
+// rotates a secret). Surgical, idempotent, explicitly-triggered only: ADR 0009
+// Phase 2 (#1741). The diff (added[]/skipped[]) is surfaced in the result so the
+// operator sees exactly what changed.
+async function reconcileOidcClients(): Promise<ProbeActionResult> {
+  const cfg = await getConfig();
+  const payload = await buildOidcReconcilePayload({
+    installedTemplates: Object.keys(cfg.installedTemplates ?? {}),
+    publicDomain: cfg.reverseProxy?.publicDomain,
+  });
+  if (!payload) {
+    return {
+      ok: true,
+      message:
+        'Nothing to reconcile — no public domain configured or no installed service declares an OIDC client.',
+      refresh: false,
+    };
+  }
+
+  let res: Response;
+  try {
+    res = await internalFetch('/api/system/authelia/oidc-clients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { ok: false, message: `OIDC reconcile failed: ${message}`, refresh: false };
+  }
+
+  if (res.status === 404) {
+    return {
+      ok: false,
+      message: 'Authelia is not deployed — install the auth stack before reconciling OIDC clients.',
+      refresh: false,
+    };
+  }
+
+  const data = (await res.json().catch(() => ({}))) as { added?: unknown; skipped?: unknown; error?: unknown };
+  if (!res.ok) {
+    const message = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+    return { ok: false, message: `OIDC reconcile failed: ${message}`, refresh: false };
+  }
+  return reconcileResult(data);
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'reconcile_oidc_clients',
+    label: 'Reconcile OIDC clients',
+    description:
+      'Re-registers every installed service’s OIDC client with Authelia, reusing each client’s persisted secret (never regenerating). Use when a single client drifted (manual edit, removed outside ServiceBay) and SSO returns invalid_client — a surgical alternative to a full reinstall. Idempotent: already-registered clients are left untouched.',
+  },
+  reconcileOidcClients,
+);
 
 registerProbeAction(
   PROBE_ID,

--- a/packages/backend/src/lib/diagnose/probes/reconcileOidcClients.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/reconcileOidcClients.test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * ADR 0009 Phase 2 (#1741) — `sso_verify` `reconcile_oidc_clients` heal-action.
+ *
+ * Covers the payload builder (config + template-meta → templates[]/variables map)
+ * and the dispatch path (internalFetch contract, added/skipped diff surfacing,
+ * 404/error handling). The reconcile-first secret guarantee lives in the POST
+ * route (#1738, resolveOidcClientSecret.test.ts) — here we only assert the
+ * action wires installed templates through that path without regenerating.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockConfig: any = {};
+const getTemplateVariablesMock = vi.fn();
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(mockConfig)),
+}));
+vi.mock('@/lib/registry', () => ({
+  getTemplateVariables: (...args: unknown[]) => getTemplateVariablesMock(...args),
+}));
+vi.mock('@/lib/auth/internalToken', () => ({
+  getInternalApiToken: () => 'test-token',
+}));
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn() },
+}));
+
+import { dispatchProbeAction } from '../actions';
+import { buildOidcReconcilePayload } from '@/lib/capabilities/authelia';
+import './oidcProviderReachable';
+
+const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+const OIDC_META = {
+  IMMICH_SUBDOMAIN: {
+    type: 'subdomain',
+    default: 'photos',
+    oidcClient: { client_id: 'immich', client_name: 'Immich' },
+  },
+};
+const NO_OIDC_META = {
+  FOO_SUBDOMAIN: { type: 'subdomain', default: 'foo' },
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  mockConfig = {};
+  getTemplateVariablesMock.mockReset();
+  fetchSpy.mockReset();
+});
+
+describe('buildOidcReconcilePayload', () => {
+  it('returns null when no public domain is configured', async () => {
+    const payload = await buildOidcReconcilePayload({
+      installedTemplates: ['immich'],
+      publicDomain: undefined,
+    });
+    expect(payload).toBeNull();
+    expect(getTemplateVariablesMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no installed template declares an OIDC client', async () => {
+    getTemplateVariablesMock.mockResolvedValue(NO_OIDC_META);
+    const payload = await buildOidcReconcilePayload({
+      installedTemplates: ['media'],
+      publicDomain: 'dopp.cloud',
+    });
+    expect(payload).toBeNull();
+  });
+
+  it('builds templates[] + variables from installed OIDC templates', async () => {
+    getTemplateVariablesMock.mockImplementation((name: string) =>
+      Promise.resolve(name === 'immich' ? OIDC_META : NO_OIDC_META),
+    );
+    const payload = await buildOidcReconcilePayload({
+      installedTemplates: ['immich', 'media'],
+      publicDomain: 'dopp.cloud',
+    });
+    expect(payload).toEqual({
+      templates: [{ name: 'immich' }],
+      variables: { PUBLIC_DOMAIN: 'dopp.cloud', IMMICH_SUBDOMAIN: 'photos' },
+    });
+  });
+
+  it('tolerates a template whose meta fails to load', async () => {
+    getTemplateVariablesMock.mockImplementation((name: string) =>
+      name === 'immich' ? Promise.resolve(OIDC_META) : Promise.reject(new Error('no disk')),
+    );
+    const payload = await buildOidcReconcilePayload({
+      installedTemplates: ['immich', 'broken'],
+      publicDomain: 'dopp.cloud',
+    });
+    expect(payload?.templates).toEqual([{ name: 'immich' }]);
+  });
+});
+
+describe('sso_verify.reconcile_oidc_clients action', () => {
+  it('short-circuits with ok when there is nothing to reconcile', async () => {
+    mockConfig = { installedTemplates: {}, reverseProxy: {} };
+    const result = await dispatchProbeAction({
+      probeId: 'sso_verify',
+      actionId: 'reconcile_oidc_clients',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/nothing to reconcile/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('POSTs installed OIDC templates and surfaces the add/skip diff', async () => {
+    mockConfig = {
+      installedTemplates: { immich: { schemaVersion: 1, installedAt: 'x' } },
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+    };
+    getTemplateVariablesMock.mockResolvedValue(OIDC_META);
+    fetchSpy.mockResolvedValue(jsonResponse(200, { added: ['immich'], skipped: ['vaultwarden'] }));
+
+    const result = await dispatchProbeAction({
+      probeId: 'sso_verify',
+      actionId: 'reconcile_oidc_clients',
+      node: 'Local',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/api/system/authelia/oidc-clients');
+    expect((init as RequestInit).method).toBe('POST');
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.templates).toEqual([{ name: 'immich' }]);
+    expect(sentBody.variables.PUBLIC_DOMAIN).toBe('dopp.cloud');
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/Registered 1 OIDC client/);
+    expect(result.details).toContain('added: immich');
+    expect(result.details).toContain('skipped: vaultwarden');
+    expect(result.refresh).toBe(true);
+  });
+
+  it('reports no-change when every client is already registered', async () => {
+    mockConfig = {
+      installedTemplates: { immich: { schemaVersion: 1, installedAt: 'x' } },
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+    };
+    getTemplateVariablesMock.mockResolvedValue(OIDC_META);
+    fetchSpy.mockResolvedValue(jsonResponse(200, { added: [], skipped: ['immich'] }));
+
+    const result = await dispatchProbeAction({
+      probeId: 'sso_verify',
+      actionId: 'reconcile_oidc_clients',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/already registered/i);
+  });
+
+  it('fails clearly when Authelia is not deployed (404)', async () => {
+    mockConfig = {
+      installedTemplates: { immich: { schemaVersion: 1, installedAt: 'x' } },
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+    };
+    getTemplateVariablesMock.mockResolvedValue(OIDC_META);
+    fetchSpy.mockResolvedValue(jsonResponse(404, { error: 'Authelia is not deployed' }));
+
+    const result = await dispatchProbeAction({
+      probeId: 'sso_verify',
+      actionId: 'reconcile_oidc_clients',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not deployed/i);
+    expect(result.refresh).toBe(false);
+  });
+
+  it('surfaces a server error without masking it as success', async () => {
+    mockConfig = {
+      installedTemplates: { immich: { schemaVersion: 1, installedAt: 'x' } },
+      reverseProxy: { publicDomain: 'dopp.cloud' },
+    };
+    getTemplateVariablesMock.mockResolvedValue(OIDC_META);
+    fetchSpy.mockResolvedValue(jsonResponse(500, { error: 'write_file EACCES' }));
+
+    const result = await dispatchProbeAction({
+      probeId: 'sso_verify',
+      actionId: 'reconcile_oidc_clients',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/EACCES/);
+  });
+});

--- a/templates/auth/CHANGELOG.md
+++ b/templates/auth/CHANGELOG.md
@@ -10,8 +10,13 @@ against a not-yet-listening LLDAP, and exit fatally. systemd `Restart=`
 recovered it, but every restart/reboot/redeploy opened a brief SSO outage
 window.
 
-The Authelia container now waits (bounded, ~120s) for LLDAP's LDAP socket
-to be open before starting, then hands off to the image's normal entrypoint.
+The Authelia container now waits for LLDAP's LDAP socket to be open before
+starting, then hands off to the image's normal entrypoint. The probe is
+`nc -w 1 localhost <port> </dev/null` (the authelia image's BusyBox `nc` has
+no `-z` flag, so the original `nc -z` probe never succeeded and just stalled
+to the cap): it breaks the loop on the first successful connect, so a ready
+LLDAP proceeds in ~1s. Bounded to ~120 attempts so a genuinely-down LLDAP
+surfaces a clear failure (and systemd `Restart=` retries) rather than hanging.
 No fatal startup crash, no outage window on restart.
 
 Transparent to the operator — no action required, no data move.

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -76,20 +76,25 @@ spec:
   #    no-LLM, bounded wait wrapper, then hand off to the image's normal
   #    entrypoint (no args → preserves authelia's default /config discovery
   #    + the entrypoint's PUID/su-exec handling).
-  #    - `nc` ships in the authelia image at /bin/nc (busybox); `nc -z` is a
-  #      pure socket probe (no LDAP auth, no data written).
-  #    - Bounded to ~120s so a genuinely-down LLDAP still surfaces a clear
-  #      failure (and systemd Restart= retries) instead of hanging forever.
+  #    - `nc` ships in the authelia image at /bin/nc (BusyBox v1.37.0). That
+  #      BusyBox build has NO `-z` flag (the old probe always errored, looped
+  #      to the cap, and fell through = a fixed ~120s delay, not a gate). The
+  #      portable probe is `nc -w 1 localhost <port> </dev/null`: `-w 1` caps
+  #      the connect attempt at 1s and `</dev/null` feeds EOF so nc returns
+  #      immediately on a successful connect (exit 0) and non-zero on refused.
+  #    - Bounded to ~120 attempts so a genuinely-down LLDAP still surfaces a
+  #      clear failure (and systemd Restart= retries) instead of hanging
+  #      forever — but a ready LLDAP breaks the loop on the first connect (~1s).
   - name: authelia
     image: docker.io/authelia/authelia:latest
     command: ["/bin/sh", "-c"]
     args:
       - |
         i=0
-        until nc -z localhost {{LLDAP_LDAP_PORT}}; do
+        until nc -w 1 localhost {{LLDAP_LDAP_PORT}} </dev/null; do
           i=$((i+1))
           if [ "$i" -ge 120 ]; then
-            echo "authelia: LLDAP LDAP socket :{{LLDAP_LDAP_PORT}} not ready after ${i}s; starting anyway (systemd will restart on fatal exit)" >&2
+            echo "authelia: LLDAP LDAP socket :{{LLDAP_LDAP_PORT}} not ready after ${i} attempts; starting anyway (systemd will restart on fatal exit)" >&2
             break
           fi
           [ "$i" -eq 1 ] && echo "authelia: waiting for LLDAP LDAP socket localhost:{{LLDAP_LDAP_PORT}} ..."

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -596,6 +596,7 @@ describe('OIDC client_id single source of truth', () => {
     'packages/backend/src/lib/capabilities/authelia.test.ts',               // unit tests use fixture meta to drive the handler
     'packages/backend/src/lib/capabilities/credentials.test.ts',            // unit tests use fixture meta to drive the handler
     'packages/backend/src/lib/capabilities/autheliaClientMerge.test.ts',    // unit tests use fixture client_id literals to drive the merge
+    'packages/backend/src/lib/diagnose/probes/reconcileOidcClients.test.ts', // unit tests use fixture oidcClient meta to drive the reconcile action
   ]);
 
   it('no src/ file hardcodes a client_id / username literal that mirrors an OIDC declaration', () => {


### PR DESCRIPTION
## What
Fix-forward for the #1737 box-verify RED (@17640037): the LLDAP-readiness gate on the Authelia container used `nc -z`, which BusyBox v1.37.0 (authelia:latest) doesn't support — the until-loop never broke, ran all ~120 iterations and fell through, giving a fixed ~120s delay instead of a reactive socket probe. This batch replaces it with a portable `nc -w 1 localhost <port> </dev/null` check (#1745), and lands the ADR 0009 Phase 2 reconciler heal-action (#1741).

## Why
Closes #1745
Closes #1741

## Risk
Low — #1745 is a one-line probe correction on a path-mandated auth template (will be re-box-verified); #1741 is a new, explicitly-triggered diagnose heal-action that reuses the existing #1738 reconcile-not-regenerate secret path.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 351 pre-existing warnings)
- [x] npm run check:arch
- [x] npm test (full — 275 files, 2345 passed, 2 skipped)
- [x] both tsc (backend + frontend) clean
- [ ] /verify on FCoS :dev box — #1745 touches templates/auth/template.yml (path-mandated): Authelia must wait for LLDAP then come up WITHOUT the race crash and proceed in ~1s not ~120s; SSO login 200

<!-- sb-ai-comment -->
AI-generated
