### PR TITLE
fix(auth): land portal-direct login on www via default_redirection_url

### DIFF
--- a/templates/auth/CHANGELOG.md
+++ b/templates/auth/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## v2
 
+Portal-direct login now has a landing page (#1742).
+
+Added a per-cookie `session.cookies[].default_redirection_url` pointing at
+`https://www.<domain>/`. Without it, a login started from the portal itself
+(logout then login, with no originating `rd` parameter) had nowhere to go
+after 1FA/2FA and left the user sitting on the portal. The target is a
+`*.<domain>` subdomain authorized for `group:family` under the wildcard
+access_control rule — not the bare apex, which is default-deny (ADR 0006) and
+would 403. App-originated logins that carry an `rd` parameter still honour it;
+`default_redirection_url` is only the no-`rd` fallback, so this is
+non-regressive. Config-only — no pod/variable/data change, no schema bump.
+
 LLDAP-readiness gate on the Authelia container (#1737).
 
 Authelia and LLDAP are containers in the same pod, which podman starts in

--- a/templates/auth/configuration.yml.mustache
+++ b/templates/auth/configuration.yml.mustache
@@ -33,6 +33,14 @@ session:
   cookies:
     - domain: '{{PUBLIC_DOMAIN}}'
       authelia_url: 'https://auth.{{PUBLIC_DOMAIN}}'
+      # Fallback landing page for a portal-direct login (logout then login,
+      # no originating `rd` param) — otherwise the user sits on the portal
+      # after 1FA/2FA. Targets a `*.{{PUBLIC_DOMAIN}}` subdomain that is
+      # one_factor/group:family under the wildcard access_control rule, so the
+      # signed-in user is authorized. NOT the bare apex (ADR 0006: apex is
+      # default-deny → 403). App-originated logins with `rd` still honour `rd`;
+      # this is only the no-`rd` fallback (non-regressive).
+      default_redirection_url: 'https://www.{{PUBLIC_DOMAIN}}/'
 
 storage:
   encryption_key: '{{AUTHELIA_STORAGE_ENCRYPTION_KEY}}'


### PR DESCRIPTION
## What
Add a per-cookie `default_redirection_url` (`https://www.{{PUBLIC_DOMAIN}}/`) to the Authelia `session.cookies[]` entry so a portal-direct login (logout then login, no `rd` param) lands on the www subdomain after 1FA/2FA instead of sitting on the portal.

## Why
Closes #1742

## Risk
low — config-only template change; targets a `*.{{PUBLIC_DOMAIN}}` one_factor subdomain under the existing wildcard access_control rule, never the apex (ADR 0006 default-deny). `rd`-originated logins still honour `rd`; the new key is the no-`rd` fallback only. Non-regressive across the public migration (autheliaRewrite only mutates per-cookie domain+authelia_url and re-serializes).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2345 passing)
- [x] npm run build (both tsc)
- [ ] /verify on FCoS :dev box (path-mandated template — owed)