### PR TITLE
fix(auth): add migrations/v1-to-v2.py to complete the auth schema-v2 chain

### DIFF
--- a/templates/auth/migrations/v1-to-v2.py
+++ b/templates/auth/migrations/v1-to-v2.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Migration: auth v1 → v2 (#1737 LLDAP-readiness gate, #1742 redirect).
+
+What changed between v1 and v2: nothing on disk. The v1→v2 hop is
+config/pod-only — both changes re-render from the template on every
+deploy, so there is no data to move or transform:
+
+  - #1737: the Authelia container now waits for LLDAP's LDAP socket to
+    be reachable before exec'ing Authelia (a bounded `nc -w` connect
+    loop in template.yml), eliminating the fatal LLDAP-startup-race
+    crash on pod restarts. Pure pod-spec change.
+  - #1742: a per-cookie `default_redirection_url` was added to the
+    Authelia session config (configuration.yml.mustache) so a
+    portal-direct login lands on the www landing page. Pure config
+    change, rendered from the mustache template.
+
+What this script does:
+  - Documents the hop for the operator (no on-disk state is touched).
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue;
+    a non-zero exit aborts the deploy before the new yaml lands.
+
+This script is intentionally read-only and idempotent — it just logs
+guidance and returns. The schema-version bump exists so the migration
+chain is complete (the install runner refuses to deploy a v2 template
+with no v1→v2 script); there is no data migration to perform because
+both v2 changes re-render from template.yml / configuration.yml.mustache
+on every deploy.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 1
+  - NEW_SCHEMA_VERSION = 2
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (PUBLIC_DOMAIN, AUTHELIA_PORT, LLDAP_PORT, …)
+  - SB_NODE, SB_API_URL, SB_API_TOKEN (for callbacks into ServiceBay)
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    print("Auth v1 → v2: config/pod-only hop, no on-disk data migration.")
+    print("  #1737: Authelia now waits for LLDAP's LDAP socket before starting")
+    print("         (bounded nc -w connect loop in template.yml) — re-rendered")
+    print("         from the template on every deploy.")
+    print("  #1742: per-cookie default_redirection_url added to the Authelia")
+    print("         session config (configuration.yml.mustache) — re-rendered")
+    print("         from the mustache template on every deploy.")
+    print("  Nothing to move or transform on disk; proceeding.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
Adds `templates/auth/migrations/v1-to-v2.py` as an idempotent, read-only informational no-op (modeled on `templates/home-assistant/migrations/v1-to-v2.py`). #1737 bumped the auth template schema-version 1->2 (LLDAP `nc -w` readiness wait) and #1742 added the per-cookie `default_redirection_url` — both config/pod-only changes that re-render from `template.yml` / `configuration.yml.mustache` on every deploy. There is no on-disk data move, so the v1->v2 migration documents the hop and exits 0.

## Why
Closes #1749

The install runner aborts any auth redeploy with "Migration chain for auth is incomplete: no script for v1->v2 (have none)", which blocks `sb stacks install --stacks basic` and every auth-stack redeploy. This restores the complete migration chain so the auth redeploy path can actually run (prior box-verifies had to manually patch the rendered config because the redeploy itself was blocked by this missing script).

## Risk
Low — new informational no-op migration script only; no on-disk data change, no schema bump (fixes the existing v2 from #1737).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2345 passed)
- [x] npm run build (frontend + backend tsc)
- [ ] /verify on FCoS :dev box — path-mandated (templates/auth/migrations/): an ACTUAL auth redeploy via `sb stacks install --stacks basic` succeeds (migration exit 0, Authelia+LLDAP up, SSO 200)

<!-- sb-ai-comment -->
AI-generated