### PR TITLE
feat: Hermes maintenance-chat backend + MCP service-files field-swap guard

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -355,6 +355,18 @@ export interface AppConfig {
   setupCompleted?: boolean;
   stackSetupPending?: boolean;
   /**
+   * Hermes maintenance-chat state (#1754, epic #1704). The Hermes API
+   * connection itself (loopback port + bearer key) is NOT stored here —
+   * the port comes from `templateSettings.HERMES_API_PORT` and the key
+   * from `installedSecrets.HERMES_API_KEY` (encrypted at rest, server-side
+   * only, never sent to the browser). This block holds only the id of the
+   * single designated maintenance session so it's stable across calls.
+   */
+  hermes?: {
+    /** Id of the persistent admin-for-families maintenance session. */
+    maintenanceSessionId?: string;
+  };
+  /**
    * Set by `setup-config-merge.service` on re-install when an existing
    * config.json was merged with a freshly-staged ISO config. The
    * dashboard reads `reinstall.completedAt` to show a "Welcome back —

--- a/packages/backend/src/lib/hermes/client.test.ts
+++ b/packages/backend/src/lib/hermes/client.test.ts
@@ -1,0 +1,178 @@
+/**
+ * HermesClient + getOrCreateMaintenanceSession + resolveHermesConnection
+ * (#1754, epic #1704).
+ *
+ * Covers the four acceptance contracts:
+ *   1. createSession posts the admin-for-families persona + returns the id.
+ *   2. getOrCreateMaintenanceSession creates once, persists the id, and
+ *      returns the SAME id on subsequent calls (no recreate).
+ *   3. chat round-trips an input to a reply.
+ *   4. an unreachable Hermes (fetch rejects) surfaces a HermesError; a
+ *      missing key marks the client unconfigured (the route's 503 path).
+ *
+ * fetch is mocked with `mockImplementation` returning a FRESH Response per
+ * call — never a shared Response object — per memory
+ * feedback_vitest_fetch_response_reuse (a reused body's second .json()
+ * rejects and the test hangs).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Coupled config store: getConfig returns what updateConfig last wrote.
+let mockConfigState: Partial<AppConfig> = {};
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfigState as AppConfig),
+  updateConfig: vi.fn(async (updates: Partial<AppConfig>) => {
+    mockConfigState = { ...mockConfigState, ...updates };
+    return mockConfigState as AppConfig;
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import type { AppConfig } from '@/lib/config';
+import {
+  HermesClient,
+  HermesError,
+  MAINTENANCE_PERSONA_PROMPT,
+  getOrCreateMaintenanceSession,
+  resolveHermesConnection,
+} from './client';
+
+const CONN = { baseUrl: 'http://127.0.0.1:8642', apiKey: 'test-key' };
+
+/** Build a fresh JSON Response — one per call, never reused. */
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  mockConfigState = {};
+  vi.restoreAllMocks();
+});
+
+describe('resolveHermesConnection', () => {
+  it('reads the key from installedSecrets and defaults the port to 8642', () => {
+    const conn = resolveHermesConnection({
+      installedSecrets: [{ varName: 'HERMES_API_KEY', password: 'sekret' }],
+    } as unknown as AppConfig);
+    expect(conn.baseUrl).toBe('http://127.0.0.1:8642');
+    expect(conn.apiKey).toBe('sekret');
+  });
+
+  it('honours a HERMES_API_PORT override and an empty key', () => {
+    const conn = resolveHermesConnection({
+      templateSettings: { HERMES_API_PORT: '9999' },
+    } as unknown as AppConfig);
+    expect(conn.baseUrl).toBe('http://127.0.0.1:9999');
+    expect(conn.apiKey).toBe('');
+  });
+});
+
+describe('HermesClient.configured', () => {
+  it('is false when no key is present', () => {
+    expect(new HermesClient({ baseUrl: 'http://127.0.0.1:8642', apiKey: '' }).configured).toBe(false);
+  });
+  it('is true when a key is present', () => {
+    expect(new HermesClient(CONN).configured).toBe(true);
+  });
+});
+
+describe('HermesClient.createSession', () => {
+  it('posts user_id + the persona system_prompt and returns the id', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => jsonResponse({ id: 'sess-1' }));
+
+    const id = await new HermesClient(CONN).createSession('alice', MAINTENANCE_PERSONA_PROMPT);
+    expect(id).toBe('sess-1');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8642/api/sessions');
+    expect(init?.method).toBe('POST');
+    const sent = JSON.parse(String(init?.body));
+    expect(sent.user_id).toBe('alice');
+    expect(sent.system_prompt).toBe(MAINTENANCE_PERSONA_PROMPT);
+    // Bearer key sent server-side; never surfaced to a caller.
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-key');
+  });
+
+  it('throws when Hermes returns no session id', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => jsonResponse({}));
+    await expect(new HermesClient(CONN).createSession('alice')).rejects.toBeInstanceOf(HermesError);
+  });
+});
+
+describe('HermesClient.chat', () => {
+  it('round-trips an input to the reply text', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      jsonResponse({ message: { content: 'hello back' } }),
+    );
+    const reply = await new HermesClient(CONN).chat('sess-1', 'hi');
+    expect(reply).toBe('hello back');
+  });
+
+  it('throws HermesError when fetch rejects (Hermes unreachable)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    await expect(new HermesClient(CONN).chat('sess-1', 'hi')).rejects.toBeInstanceOf(HermesError);
+  });
+
+  it('throws HermesError with status on a non-2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      jsonResponse({ error: 'boom' }, 500),
+    );
+    await expect(new HermesClient(CONN).chat('s', 'hi')).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+describe('getOrCreateMaintenanceSession', () => {
+  it('creates the session once with the persona and persists the id', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => jsonResponse({ id: 'maint-1' }));
+
+    const id = await getOrCreateMaintenanceSession(new HermesClient(CONN), 'alice');
+    expect(id).toBe('maint-1');
+    expect(mockConfigState.hermes?.maintenanceSessionId).toBe('maint-1');
+
+    // Verify the persona overlay was bound at create.
+    const sent = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(sent.system_prompt).toBe(MAINTENANCE_PERSONA_PROMPT);
+  });
+
+  it('returns the persisted id on a subsequent call when it still resolves', async () => {
+    mockConfigState = { hermes: { maintenanceSessionId: 'existing-1' } };
+    // First call: GET /api/sessions/existing-1 -> session found (no create).
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => jsonResponse({ session: { id: 'existing-1' } }));
+
+    const id = await getOrCreateMaintenanceSession(new HermesClient(CONN), 'alice');
+    expect(id).toBe('existing-1');
+    // Only the GET ran — no POST /api/sessions create.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe('GET');
+  });
+
+  it('recreates when the persisted id 404s on Hermes', async () => {
+    mockConfigState = { hermes: { maintenanceSessionId: 'stale-1' } };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      // GET of the stale id 404s; the follow-up POST creates a fresh one.
+      if (init?.method === 'GET') return jsonResponse({}, 404);
+      return jsonResponse({ id: 'fresh-1' });
+    });
+
+    const id = await getOrCreateMaintenanceSession(new HermesClient(CONN), 'alice');
+    expect(id).toBe('fresh-1');
+    expect(mockConfigState.hermes?.maintenanceSessionId).toBe('fresh-1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/lib/hermes/client.ts
+++ b/packages/backend/src/lib/hermes/client.ts
@@ -1,0 +1,277 @@
+/**
+ * Typed client for Hermes' native session API (maintenance chat, #1754 /
+ * epic #1704). Ports the proven `solilos_chat/hermes.py` pattern from
+ * mdopp/solbay.
+ *
+ * Contract (the native session API, NOT the gatekeeper `/converse`):
+ *   - `POST /api/sessions`              -> create a session, returns `{id}`
+ *   - `GET  /api/sessions`              -> `{data:[{id,...}]}` (list)
+ *   - `GET  /api/sessions/{id}`         -> `{session:{...}}` (summary)
+ *   - `POST /api/sessions/{id}/chat`    -> body `{input}`, returns the reply
+ *
+ * Connection: `http://127.0.0.1:${HERMES_API_PORT}` (loopback only — the
+ * Hermes API binds 127.0.0.1; other host pods reach it over loopback,
+ * remote callers go through NPM + Authelia) with `Authorization: Bearer
+ * ${HERMES_API_KEY}`.
+ *
+ * SECURITY: the bearer key (`HERMES_API_KEY`) is held server-side only —
+ * it lives in `config.installedSecrets` (encrypted at rest), is read here
+ * in the backend, and is NEVER logged or returned to the browser. The
+ * frontend reaches this via the loopback `/api/system/hermes/chat` route,
+ * which holds the key server-side.
+ */
+import { getConfig, updateConfig, type AppConfig } from '@/lib/config';
+import { loadSavedSecrets } from '@/lib/install/savedSecrets';
+import { logger } from '@/lib/logger';
+
+/** Raised when Hermes is unreachable or returns a non-2xx response. */
+export class HermesError extends Error {
+  /** HTTP status when the failure was a Hermes non-2xx; undefined on a
+   *  transport error (Hermes not running / loopback refused). */
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'HermesError';
+    this.status = status;
+  }
+}
+
+/** Resolved Hermes connection settings (loopback + bearer key). */
+export interface HermesConnection {
+  /** e.g. `http://127.0.0.1:8642` */
+  baseUrl: string;
+  /** API_SERVER_KEY bearer token; empty string when not installed. */
+  apiKey: string;
+}
+
+/** Template-variable name holding the Hermes HTTP API host port. */
+const HERMES_API_PORT_VAR = 'HERMES_API_PORT';
+/** Template-variable name holding the Hermes API bearer key (secret). */
+const HERMES_API_KEY_VAR = 'HERMES_API_KEY';
+/** Default Hermes API port (matches the hermes template variable default). */
+const DEFAULT_HERMES_API_PORT = 8642;
+
+/**
+ * The "ServiceBay administrator for families" persona, attached as the
+ * `system_prompt` overlay when the maintenance session is born. Hermes
+ * accepts `system_prompt` ONLY at session create (PATCH rejects it), so
+ * the persona is bound once, at birth, and is stable for the session's life.
+ *
+ * Tone/behaviour contract (mixed DE/EN as the family operator speaks):
+ *  - family-focused; speaks to a non-expert operator running a home server
+ *  - gathers knowledge from the tools/sources available rather than relying
+ *    on its own assumptions
+ *  - persistent ("beharrlich") — sees a task through
+ *  - clear, numbered step-by-step plans a non-expert can follow
+ *  - NEVER destroys data without explicit confirmation, and always ensures a
+ *    backup/restore path exists first
+ *  - kind and patient ("geduldig")
+ *  - guiding maxim: just be helpful, make things better, never worse.
+ */
+export const MAINTENANCE_PERSONA_PROMPT = [
+  'You are the ServiceBay administrator for families — the helpful expert',
+  'who looks after a home server for a non-technical household.',
+  '',
+  'Who you help: the family operator. Treat them as a capable beginner, not',
+  'an engineer. Avoid jargon; when a technical term is unavoidable, explain',
+  'it in one plain sentence.',
+  '',
+  'How you work:',
+  '- Gather what you need from the tools and information sources available to',
+  '  you rather than relying on your own assumptions or guessing. If you do',
+  "  not know something, find out — don't invent it.",
+  '- Be persistent (beharrlich): see a task through to a real, verified',
+  '  outcome instead of stopping at the first obstacle.',
+  '- Give clear, numbered, step-by-step plans the operator can follow without',
+  '  prior expertise. One action per step.',
+  '- Be kind and patient (geduldig). The operator may be stressed because',
+  '  something at home is not working — reassure, then guide.',
+  '',
+  'Safety — this is absolute:',
+  '- NEVER destroy, delete, overwrite, or reset data without the explicit',
+  '  confirmation of the operator.',
+  '- Before any destructive or risky step, first ensure a working backup and',
+  '  a restore path exist, and tell the operator what they are.',
+  '- When in doubt, choose the reversible option and ask.',
+  '',
+  'Your guiding maxim: just be helpful, make things better, never worse.',
+].join('\n');
+
+/**
+ * Resolve the Hermes loopback connection from config. The port comes from
+ * the installed hermes template variable (or the default 8642); the bearer
+ * key comes from `installedSecrets` (HERMES_API_KEY), decrypted by getConfig.
+ *
+ * The key may be absent (Hermes not installed / pre-secret config) — the
+ * caller treats an empty key as "unreachable" and surfaces a 503.
+ */
+export function resolveHermesConnection(config: AppConfig): HermesConnection {
+  const secrets = loadSavedSecrets(config);
+  const apiKey = secrets[HERMES_API_KEY_VAR] ?? '';
+
+  // The port is a non-secret variable; honour an operator override stored in
+  // templateSettings, else fall back to the template default. We never log it.
+  const portRaw = config.templateSettings?.[HERMES_API_PORT_VAR];
+  const parsed = portRaw ? Number.parseInt(portRaw, 10) : NaN;
+  const port = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_HERMES_API_PORT;
+
+  return { baseUrl: `http://127.0.0.1:${port}`, apiKey };
+}
+
+/** Reply-envelope shapes Hermes may return — kept tolerant like the Python client. */
+interface ChatReplyEnvelope {
+  message?: { content?: unknown };
+  output?: unknown;
+  reply?: unknown;
+  response?: unknown;
+  text?: unknown;
+}
+
+function extractReply(body: unknown): string {
+  if (!body || typeof body !== 'object') return '';
+  const b = body as ChatReplyEnvelope;
+  const msg = b.message;
+  if (msg && typeof msg === 'object' && 'content' in msg && msg.content) {
+    return String(msg.content);
+  }
+  return String(b.output ?? b.reply ?? b.response ?? b.text ?? '');
+}
+
+function extractSessionId(body: unknown): string {
+  if (!body || typeof body !== 'object') return '';
+  const b = body as Record<string, unknown>;
+  const session =
+    b.session && typeof b.session === 'object' ? (b.session as Record<string, unknown>) : b;
+  return String(session.id ?? session.session_id ?? '');
+}
+
+/**
+ * Thin typed Hermes API client. One instance per request is fine — each
+ * method opens a single `fetch`. The bearer key is captured at construction
+ * and never logged.
+ */
+export class HermesClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+
+  constructor(conn: HermesConnection, timeoutMs = 120_000) {
+    this.baseUrl = conn.baseUrl.replace(/\/+$/, '');
+    this.apiKey = conn.apiKey;
+    this.timeoutMs = timeoutMs;
+  }
+
+  /** True once Hermes is reachable enough to attempt a call (key present). */
+  get configured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) h.Authorization = `Bearer ${this.apiKey}`;
+    return h;
+  }
+
+  /** POST/GET helper. Throws `HermesError` on transport failure or non-2xx. */
+  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method,
+        headers: this.headers(),
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (e) {
+      // Transport failure (Hermes not running, loopback refused, timeout).
+      // Do NOT include the key/headers in the log.
+      logger.warn('hermes', `request ${method} ${path} failed to reach Hermes`, {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      throw new HermesError('Hermes is unreachable');
+    } finally {
+      clearTimeout(timer);
+    }
+    if (resp.status >= 400) {
+      const detail = (await resp.text().catch(() => '')).slice(0, 300);
+      logger.warn('hermes', `request ${method} ${path} returned ${resp.status}`, { detail });
+      throw new HermesError(`Hermes returned ${resp.status}`, resp.status);
+    }
+    return resp.json().catch(() => ({}));
+  }
+
+  /**
+   * Create a session bound to `userId`, optionally with a `system_prompt`
+   * overlay. Hermes accepts `system_prompt` only at create. Returns the id.
+   */
+  async createSession(userId: string, systemPrompt?: string): Promise<string> {
+    const payload: Record<string, unknown> = { user_id: userId };
+    if (systemPrompt) payload.system_prompt = systemPrompt;
+    const body = await this.request('POST', '/api/sessions', payload);
+    const id = extractSessionId(body);
+    if (!id) throw new HermesError('createSession: no session id in response');
+    return id;
+  }
+
+  /** Fetch a session summary, or `null` if Hermes 404s the id. */
+  async getSession(sessionId: string): Promise<Record<string, unknown> | null> {
+    try {
+      const body = await this.request('GET', `/api/sessions/${sessionId}`);
+      if (!body || typeof body !== 'object') return null;
+      const b = body as Record<string, unknown>;
+      const session = b.session && typeof b.session === 'object' ? b.session : b;
+      return session as Record<string, unknown>;
+    } catch (e) {
+      if (e instanceof HermesError && e.status === 404) return null;
+      throw e;
+    }
+  }
+
+  /** List sessions (Hermes returns them under `data`/`sessions`/`items`). */
+  async listSessions(): Promise<Array<Record<string, unknown>>> {
+    const body = await this.request('GET', '/api/sessions');
+    if (Array.isArray(body)) return body as Array<Record<string, unknown>>;
+    if (body && typeof body === 'object') {
+      const b = body as Record<string, unknown>;
+      for (const key of ['sessions', 'items', 'data', 'results']) {
+        const v = b[key];
+        if (Array.isArray(v)) return v as Array<Record<string, unknown>>;
+      }
+    }
+    return [];
+  }
+
+  /** Send one turn to an existing session; return the reply text. */
+  async chat(sessionId: string, input: string): Promise<string> {
+    const body = await this.request('POST', `/api/sessions/${sessionId}/chat`, { input });
+    return extractReply(body);
+  }
+}
+
+/**
+ * Ensure the single designated maintenance session exists and return its id.
+ *
+ * The session is created once, with the admin-for-families persona overlay,
+ * and its id is persisted in `config.hermes.maintenanceSessionId` so it's
+ * stable across calls (and process restarts). If a persisted id no longer
+ * resolves on Hermes (e.g. data was wiped), a fresh session is created and
+ * re-persisted.
+ */
+export async function getOrCreateMaintenanceSession(
+  client: HermesClient,
+  userId: string,
+): Promise<string> {
+  const config = await getConfig();
+  const existing = config.hermes?.maintenanceSessionId;
+  if (existing) {
+    // Confirm it still exists on Hermes; a 404 means we must recreate.
+    const session = await client.getSession(existing);
+    if (session) return existing;
+  }
+  const id = await client.createSession(userId, MAINTENANCE_PERSONA_PROMPT);
+  await updateConfig({ hermes: { ...(config.hermes ?? {}), maintenanceSessionId: id } });
+  return id;
+}

--- a/packages/backend/src/lib/mcp/server.test.ts
+++ b/packages/backend/src/lib/mcp/server.test.ts
@@ -44,3 +44,50 @@ describe('createMcpServer self-description (#1732)', () => {
     await client.close();
   });
 });
+
+describe('update_service_yaml / get_service_files field-name footgun (#1752)', () => {
+  it('the tool descriptions make the reversed field-name mapping unambiguous', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const byName = Object.fromEntries(tools.map(t => [t.name, t.description ?? '']));
+
+    // get_service_files: kubeContent = .kube Quadlet, yamlContent = pod spec,
+    // and the names are flagged as REVERSED from update_service_yaml.
+    expect(byName.get_service_files).toMatch(/kubeContent/);
+    expect(byName.get_service_files).toMatch(/yamlContent/);
+    expect(byName.get_service_files).toMatch(/Quadlet/);
+    expect(byName.get_service_files).toMatch(/Pod[- ]spec/i);
+    expect(byName.get_service_files).toMatch(/REVERSED/);
+
+    // update_service_yaml: its content field is the POD SPEC (the read tool's
+    // yamlContent), explicitly NOT the .kube Quadlet unit.
+    expect(byName.update_service_yaml).toMatch(/[Pp]od[- ][Ss]pec/);
+    expect(byName.update_service_yaml).toMatch(/NOT.*Quadlet|Quadlet.*NOT|not the `?\.kube`?/i);
+    await client.close();
+  });
+
+  it('exposes a clearly-named podSpecContent alias on update_service_yaml', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'update_service_yaml');
+    const props = (tool?.inputSchema?.properties ?? {}) as Record<string, unknown>;
+    expect(props.podSpecContent, 'podSpecContent alias must exist').toBeTruthy();
+    expect(props.kubeContent, 'kubeContent kept for backwards-compat').toBeTruthy();
+    await client.close();
+  });
+
+  it('rejects a verbatim round-trip of the .kube Quadlet unit instead of clobbering the pod spec', async () => {
+    const { client } = await connectClient();
+    // Simulate the footgun: an LLM reads get_service_files and naively passes
+    // the `.kube` Quadlet unit (its kubeContent) back into update_service_yaml.
+    const quadletUnit = '[Kube]\nYaml=demo.yml\nAutoUpdate=registry\n\n[Install]\nWantedBy=default.target';
+    const res = await client.callTool({
+      name: 'update_service_yaml',
+      arguments: { name: 'demo', kubeContent: quadletUnit },
+    });
+    expect(res.isError, 'must error rather than write the Quadlet unit to the .yml').toBe(true);
+    const text = JSON.stringify(res.content);
+    expect(text).toMatch(/Quadlet|Pod[- ]spec/i);
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -438,7 +438,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Get Service Files ---
   server.tool(
     'get_service_files',
-    'Get kube YAML, compose YAML, and systemd unit files for a service',
+    'Get the on-disk files for a service. Returns `kubeContent` = the systemd `.kube` Quadlet unit ([Kube]/[Install] sections), and `yamlContent` = the Kubernetes Pod-spec `.yml` (apiVersion/kind/spec). WARNING: these field names are REVERSED relative to update_service_yaml — to edit and write back the pod spec, pass this tool\'s `yamlContent` into update_service_yaml\'s `kubeContent`/`podSpecContent` param, NOT this tool\'s `kubeContent` (that is the Quadlet unit, which update_service_yaml regenerates on its own).',
     { name: z.string().describe('Service name'), node: nodeParam },
     async ({ name, node }) => {
       const nodeName = await resolveNode(node);
@@ -803,24 +803,42 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Update Service YAML (edit then redeploy) ---
   server.tool(
     'update_service_yaml',
-    'Replace a service\'s kube YAML and redeploy it. Use `get_service_files` first, modify, then call this. The file is written and `systemctl --user daemon-reload` + service restart is triggered.',
+    'Replace a service\'s Kubernetes Pod-spec `.yml` and redeploy it. Use `get_service_files` first, modify, then call this. NOTE the field-name mismatch: the content this tool wants (in `kubeContent`/`podSpecContent`) is the POD SPEC — i.e. the `yamlContent` returned by get_service_files (apiVersion/kind/spec), NOT its `kubeContent` (the `.kube` Quadlet unit). The Quadlet unit is regenerated automatically; do not pass it here. The file is written and `systemctl --user daemon-reload` + service restart is triggered.',
     {
       name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').describe('Service name'),
-      kubeContent: z.string().min(1).describe('Full kube YAML content (replaces existing)'),
+      kubeContent: z.string().min(1).optional().describe('The Pod-spec `.yml` content (the `yamlContent` from get_service_files, apiVersion/kind/spec) — NOT the `.kube` Quadlet unit. Historical name; prefer `podSpecContent`. One of kubeContent / podSpecContent is required.'),
+      podSpecContent: z.string().min(1).optional().describe('Alias for kubeContent — the Pod-spec `.yml` content (apiVersion/kind/spec). Clearer name for the same field; takes precedence if both are given.'),
       yamlContent: z.string().optional().describe('Optional companion compose/config YAML'),
       yamlFileName: z.string().optional().describe('Filename for companion YAML (default: <name>.yaml)'),
       node: nodeParam,
     },
-    async ({ name, kubeContent, yamlFileName, node }) => {
+    async ({ name, kubeContent, podSpecContent, yamlFileName, node }) => {
       const nodeName = await resolveNode(node);
       try {
+        const podSpec = podSpecContent ?? kubeContent;
+        if (!podSpec) {
+          return errorResult('Error updating service: provide the Pod-spec `.yml` content via `podSpecContent` (or `kubeContent`).');
+        }
+        // Field-name footgun guard: get_service_files returns the `.kube`
+        // Quadlet unit under `kubeContent`. If a caller round-trips that field
+        // verbatim into here, the `[Kube]`/`[Unit]` systemd unit would be
+        // written into the Pod-spec `.yml` and clobber the manifest. Reject it
+        // with a pointer to the right field rather than silently swapping the
+        // on-disk files (memory: reference_box_credential_rekey_mechanics).
+        if (/^\s*\[(Unit|Kube|Install|Container|Service)\]/m.test(podSpec)) {
+          return errorResult(
+            'Error updating service: the content looks like a systemd `.kube` Quadlet unit (has a [Kube]/[Unit] section), not a Pod-spec `.yml`. ' +
+            'update_service_yaml expects the POD SPEC — that is the `yamlContent` field from get_service_files (apiVersion/kind/spec), NOT its `kubeContent`. ' +
+            'The Quadlet unit is regenerated automatically; pass the pod spec instead.',
+          );
+        }
         const resolvedYamlFileName = yamlFileName ?? `${name}.yml`;
         const generatedKubeUnit = `[Kube]\nYaml=${resolvedYamlFileName}\nAutoUpdate=registry\n\n[Install]\nWantedBy=default.target`;
         await ServiceManager.deployKubeService(
           nodeName,
           name,
           generatedKubeUnit,
-          kubeContent,
+          podSpec,
           resolvedYamlFileName,
         );
         return textResult(`Service "${name}" updated and redeployed`);

--- a/packages/frontend/src/app/api/system/hermes/chat/route.ts
+++ b/packages/frontend/src/app/api/system/hermes/chat/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { getConfig } from '@/lib/config';
+import {
+  HermesClient,
+  HermesError,
+  getOrCreateMaintenanceSession,
+  resolveHermesConnection,
+} from '@/lib/hermes/client';
+
+/**
+ * Maintenance-chat seam (#1754, epic #1704) — the native chat panel (#1755,
+ * part B) POSTs operator turns here.
+ *
+ * Auth: POST is a mutating verb, so `withApiHandler` runs the requireSession
+ * gate — only an authenticated ServiceBay operator reaches the handler. The
+ * authenticated principal (`auth.user`) is mapped to the Hermes uid.
+ *
+ * SECURITY: the Hermes bearer key (`HERMES_API_KEY`) is read server-side from
+ * config (encrypted at rest) inside the backend client and is NEVER returned
+ * to the browser. Hermes is reached over loopback (127.0.0.1) only. When
+ * Hermes is unreachable (not installed / not running) we return 503 with a
+ * clear, non-leaking message.
+ */
+
+const bodySchema = z.object({
+  input: z.string().min(1, 'input is required'),
+});
+
+export const POST = withApiHandler({ body: bodySchema }, async ({ body, auth }) => {
+  // The session gate guarantees `auth` is set on this mutating route.
+  const userId = auth?.user ?? 'servicebay-operator';
+
+  const config = await getConfig();
+  const conn = resolveHermesConnection(config);
+  const client = new HermesClient(conn);
+
+  if (!client.configured) {
+    return apiError(new Error('Hermes is not configured on this server'), {
+      status: 503,
+      tag: 'hermes',
+      exposeMessage: true,
+    });
+  }
+
+  try {
+    const sessionId = await getOrCreateMaintenanceSession(client, userId);
+    const reply = await client.chat(sessionId, body.input);
+    return NextResponse.json({ reply });
+  } catch (e) {
+    if (e instanceof HermesError) {
+      // Hermes unreachable or returned an error — surface as 503 so the
+      // panel can show "the assistant is unavailable" without leaking the
+      // key or internal detail.
+      return apiError(new Error('Hermes is unavailable. Is the Hermes service running?'), {
+        status: 503,
+        tag: 'hermes',
+        exposeMessage: true,
+      });
+    }
+    return apiError(e, { tag: 'hermes' });
+  }
+});


### PR DESCRIPTION
## What
- **#1752** — MCP `get_service_files`/`update_service_yaml` field-swap footgun fix: clarified descriptions (kubeContent=Quadlet vs yamlContent=pod-spec, names REVERSED between the two tools), added a `podSpecContent` alias on `update_service_yaml`, and a round-trip guard that rejects content whose first section header is `[Unit]`/`[Kube]`/`[Install]`/`[Container]`/`[Service]` (a verbatim read->write of the wrong field) instead of clobbering the pod spec. Correct `apiVersion:`/`kind:` callers unaffected.
- **#1754** (security) — Hermes maintenance-chat backend (part A of #1704): new `packages/backend/src/lib/hermes/client.ts` (HermesClient over `127.0.0.1:${HERMES_API_PORT}` default 8642, Bearer key read server-side, never to the browser), `MAINTENANCE_PERSONA_PROMPT` (admin-for-families persona), `getOrCreateMaintenanceSession` persisting `config.hermes.maintenanceSessionId`, and a new admin-session-gated `POST /api/system/hermes/chat` route returning `{reply}` (503 with a clear non-leaking message when Hermes is unreachable).

## Why
Closes #1752
Closes #1754

## Risk
Low — #1752 is description/validation only (no behaviour change for correct callers); #1754 is additive (new client, new route, new optional `AppConfig.hermes` field), no install/boot behaviour change.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 351 warnings, no increase)
- [x] npm run check:arch
- [x] npm test (full — 2360 passed / 2 skipped)
- [x] backend tsc --noEmit + next build (frontend) clean
- [ ] /verify on FCoS :dev box (path-mandated: lib/mcp/, lib/config.ts) — box_verify owed

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._