### PR TITLE
feat(frontend): native Hermes maintenance chat panel + /chat route

### DIFF
--- a/packages/frontend/src/app/(dashboard)/chat/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/chat/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+/**
+ * Maintenance chat route (#1755, part B of epic #1704).
+ *
+ * Hosts the native HermesChatPanel behind the standard dashboard chrome.
+ * The entry is gated on `hermes` being installed (the Sidebar only shows the
+ * link when `installedTemplates` contains `hermes`); if an operator reaches
+ * the route directly on a box without Hermes, we show a calm "not installed"
+ * notice instead of a dead chat box.
+ */
+
+import PageHeader from '@/components/PageHeader';
+import HermesChatPanel from '@/components/HermesChatPanel';
+import { useDigitalTwin } from '@/hooks/useDigitalTwin';
+
+export default function ChatPage() {
+  const { data } = useDigitalTwin();
+  // `installedTemplates` is undefined until the first twin snapshot arrives;
+  // treat undefined as "still loading" (show the panel) and only show the
+  // not-installed notice once we have a snapshot that lacks hermes.
+  const templates = data?.installedTemplates;
+  const hermesInstalled = !templates || templates.includes('hermes');
+
+  return (
+    <div className="h-full flex flex-col">
+      <PageHeader title="Maintenance Chat" showBack={false} />
+      {hermesInstalled ? (
+        <div className="flex-1 min-h-0">
+          <HermesChatPanel />
+        </div>
+      ) : (
+        <div className="flex-1 flex items-center justify-center p-6 text-center text-gray-500 dark:text-gray-400">
+          <p className="max-w-sm">
+            The Hermes assistant is not installed on this server. Install the
+            Hermes service to chat with the maintenance assistant.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/HermesChatPanel.test.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * HermesChatPanel tests (#1755, part B of epic #1704).
+ *
+ * Covers: empty state, send -> calls POST /api/system/hermes/chat and shows
+ * the reply, the 503 "Hermes is unavailable" graceful state, and the typing
+ * indicator while a turn is in flight.
+ *
+ * fetch is mocked with mockImplementation returning a FRESH Response per call
+ * (memory feedback_vitest_fetch_response_reuse — a shared Response body can
+ * only be read once, so parallel/sequential reads hang).
+ *
+ * No @testing-library/jest-dom in this repo's setup, so assertions use
+ * toBeDefined/toBeNull/textContent (matching the existing FE test style).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import HermesChatPanel from './HermesChatPanel';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('HermesChatPanel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the empty maintenance-assistant state before any message', () => {
+    render(<HermesChatPanel />);
+    expect(screen.getByText(/Maintenance assistant/i)).toBeDefined();
+    expect(screen.queryByTestId('hermes-msg-user')).toBeNull();
+  });
+
+  it('sends a message to /api/system/hermes/chat and renders the reply', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => jsonResponse(200, { reply: 'Here is your plan.' }));
+
+    render(<HermesChatPanel />);
+    const input = screen.getByTestId('hermes-input');
+    fireEvent.change(input, { target: { value: 'help me' } });
+    fireEvent.click(screen.getByTestId('hermes-send'));
+
+    // The operator's turn renders immediately.
+    expect(screen.getByText('help me')).toBeDefined();
+
+    await waitFor(() => {
+      expect(screen.getByText('Here is your plan.')).toBeDefined();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/system/hermes/chat',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ input: 'help me' }),
+      }),
+    );
+  });
+
+  it('shows the "Hermes is unavailable" notice on a 503 and does not append an assistant turn', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      jsonResponse(503, { error: 'Hermes is unavailable. Is the Hermes service running?' }),
+    );
+
+    render(<HermesChatPanel />);
+    fireEvent.change(screen.getByTestId('hermes-input'), { target: { value: 'are you there?' } });
+    fireEvent.click(screen.getByTestId('hermes-send'));
+
+    await waitFor(() => {
+      const notice = screen.getByTestId('hermes-unavailable');
+      expect(notice.textContent).toMatch(/Hermes is unavailable/i);
+    });
+    // The 503 path must not fabricate an assistant reply (don't mask failures).
+    expect(screen.queryByTestId('hermes-msg-assistant')).toBeNull();
+  });
+
+  it('shows a typing indicator while the reply is in flight', async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    render(<HermesChatPanel />);
+    fireEvent.change(screen.getByTestId('hermes-input'), { target: { value: 'slow one' } });
+    fireEvent.click(screen.getByTestId('hermes-send'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hermes-typing')).toBeDefined();
+    });
+
+    resolveFetch(jsonResponse(200, { reply: 'done' }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('hermes-typing')).toBeNull();
+    });
+    expect(screen.getByText('done')).toBeDefined();
+  });
+});

--- a/packages/frontend/src/components/HermesChatPanel.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+/**
+ * Native maintenance chat panel (#1755, part B of epic #1704).
+ *
+ * A minimal chat surface for operating / maintaining ServiceBay via Hermes.
+ * It talks ONLY to the server-side seam `POST /api/system/hermes/chat`
+ * (#1754) — that route holds the Hermes API key, maps the operator to the
+ * single "ServiceBay administrator for families" maintenance session, and
+ * returns `{ reply }`. The key never reaches the browser.
+ *
+ * Scope, deliberately small: ONE maintenance session, no session picker, no
+ * history browser (the rich multi-session UI is the OSCAR household app, out
+ * of scope here). When the route returns 503 (Hermes not installed / not
+ * running) we show a calm "Hermes is unavailable" notice rather than
+ * crashing or pretending the message went through.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Bot, Send, AlertTriangle, User as UserIcon } from 'lucide-react';
+
+interface ChatMessage {
+  /** Stable key for React; not sent to the server. */
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+let nextMessageId = 1;
+function makeMessage(role: ChatMessage['role'], content: string): ChatMessage {
+  return { id: nextMessageId++, role, content };
+}
+
+function EmptyState() {
+  return (
+    <div className="h-full flex flex-col items-center justify-center text-center text-gray-500 dark:text-gray-400 gap-3">
+      <Bot size={40} className="text-blue-500/70" />
+      <div className="max-w-sm">
+        <p className="font-semibold text-gray-700 dark:text-gray-200">Maintenance assistant</p>
+        <p className="text-sm mt-1">
+          Ask for help operating or maintaining your ServiceBay. It walks you through changes step
+          by step and never touches your data without confirming first.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user';
+  return (
+    <div
+      data-testid={`hermes-msg-${message.role}`}
+      className={`flex gap-2.5 ${isUser ? 'flex-row-reverse' : ''}`}
+    >
+      <div
+        className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+          isUser
+            ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+            : 'bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-300'
+        }`}
+      >
+        {isUser ? <UserIcon size={16} /> : <Bot size={16} />}
+      </div>
+      <div
+        className={`max-w-[75%] px-4 py-2.5 rounded-2xl whitespace-pre-wrap break-words text-sm ${
+          isUser
+            ? 'bg-blue-600 text-white rounded-tr-sm'
+            : 'bg-gray-100 dark:bg-white/[0.04] text-gray-800 dark:text-gray-100 rounded-tl-sm'
+        }`}
+      >
+        {message.content}
+      </div>
+    </div>
+  );
+}
+
+function TypingIndicator() {
+  return (
+    <div data-testid="hermes-typing" className="flex gap-2.5">
+      <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-300">
+        <Bot size={16} />
+      </div>
+      <div className="px-4 py-3 rounded-2xl rounded-tl-sm bg-gray-100 dark:bg-white/[0.04] flex items-center gap-1">
+        <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 animate-bounce [animation-delay:-0.3s]" />
+        <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 animate-bounce [animation-delay:-0.15s]" />
+        <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 animate-bounce" />
+      </div>
+    </div>
+  );
+}
+
+function UnavailableNotice({ message }: { message: string }) {
+  return (
+    <div
+      data-testid="hermes-unavailable"
+      role="alert"
+      className="flex items-start gap-2.5 px-4 py-3 rounded-2xl border border-amber-200/60 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-900/10 text-amber-800 dark:text-amber-300 text-sm"
+    >
+      <AlertTriangle size={18} className="shrink-0 mt-0.5" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+function Composer({
+  value,
+  disabled,
+  onChange,
+  onKeyDown,
+  onSend,
+}: {
+  value: string;
+  disabled: boolean;
+  onChange: (v: string) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSend: () => void;
+}) {
+  return (
+    <div className="flex items-end gap-2 rounded-2xl border border-gray-200/70 dark:border-white/5 bg-white/60 dark:bg-white/[0.02] backdrop-blur p-2">
+      <textarea
+        data-testid="hermes-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        rows={1}
+        placeholder="Ask the maintenance assistant…"
+        aria-label="Message the maintenance assistant"
+        className="flex-1 resize-none bg-transparent px-2 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 focus:outline-none max-h-40"
+      />
+      <button
+        type="button"
+        onClick={onSend}
+        disabled={disabled}
+        aria-label="Send message"
+        data-testid="hermes-send"
+        className="shrink-0 p-2.5 rounded-xl bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <Send size={18} />
+      </button>
+    </div>
+  );
+}
+
+/** Drives the conversation state + the call to the server-side chat seam. */
+function useHermesChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [sending, setSending] = useState(false);
+  // When the route reports 503 the assistant is unavailable — we surface a
+  // banner rather than fabricating a reply (memory feedback_dont_mask_failures).
+  const [unavailable, setUnavailable] = useState<string | null>(null);
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || sending) return;
+
+      setMessages((prev) => [...prev, makeMessage('user', trimmed)]);
+      setSending(true);
+      setUnavailable(null);
+      try {
+        const res = await fetch('/api/system/hermes/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ input: trimmed }),
+        });
+        const body = await res.json().catch(() => ({}));
+        const errorText = typeof body?.error === 'string' ? body.error : null;
+
+        if (res.status === 503) {
+          setUnavailable(errorText ?? 'Hermes is unavailable. Is the Hermes service running?');
+        } else if (!res.ok) {
+          setMessages((prev) => [
+            ...prev,
+            makeMessage(
+              'assistant',
+              errorText
+                ? `Sorry — ${errorText}`
+                : 'Sorry — something went wrong sending that message. Please try again.',
+            ),
+          ]);
+        } else {
+          const reply = typeof body?.reply === 'string' ? body.reply : '';
+          setMessages((prev) => [
+            ...prev,
+            makeMessage('assistant', reply || '(Hermes returned an empty reply.)'),
+          ]);
+        }
+      } catch {
+        // Failure reaching our own route — treat like unavailable, don't crash.
+        setUnavailable('Could not reach the chat service. Please try again.');
+      } finally {
+        setSending(false);
+      }
+    },
+    [sending],
+  );
+
+  return { messages, sending, unavailable, send };
+}
+
+export default function HermesChatPanel() {
+  const { messages, sending, unavailable, send } = useHermesChat();
+  const [input, setInput] = useState('');
+  const logRef = useRef<HTMLDivElement>(null);
+
+  // Keep the newest turn in view as the conversation grows.
+  useEffect(() => {
+    const el = logRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, sending]);
+
+  const submit = useCallback(() => {
+    const text = input;
+    setInput('');
+    void send(text);
+  }, [input, send]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Enter sends; Shift+Enter inserts a newline.
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        submit();
+      }
+    },
+    [submit],
+  );
+
+  const showEmptyState = messages.length === 0 && !sending && !unavailable;
+
+  return (
+    <div className="h-full flex flex-col p-4 gap-4">
+      <div
+        ref={logRef}
+        data-testid="hermes-chat-log"
+        className="flex-1 min-h-0 overflow-y-auto rounded-2xl border border-gray-200/70 dark:border-white/5 bg-white/60 dark:bg-white/[0.02] backdrop-blur p-4 space-y-4"
+      >
+        {showEmptyState && <EmptyState />}
+        {messages.map((m) => (
+          <MessageBubble key={m.id} message={m} />
+        ))}
+        {sending && <TypingIndicator />}
+      </div>
+
+      {unavailable && <UnavailableNotice message={unavailable} />}
+
+      <Composer
+        value={input}
+        disabled={sending || input.trim().length === 0}
+        onChange={setInput}
+        onKeyDown={onKeyDown}
+        onSend={submit}
+      />
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { ChevronLeft, Code, Users, ExternalLink, Sparkles, Home, User as UserIcon, LogOut } from 'lucide-react';
+import { ChevronLeft, Code, Users, ExternalLink, Sparkles, Home, User as UserIcon, LogOut, MessageCircle } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import DomainTag from './DomainTag';
 import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
+import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 
 // Back-compat re-export — MobileNav imports `dashboards` from here.
 // New code should import NAVIGATION_ENTRIES directly from
@@ -22,6 +23,11 @@ export default function Sidebar() {
   const searchParams = useSearchParams();
   const node = searchParams?.get('node');
   const router = useRouter();
+  const { data: twin } = useDigitalTwin();
+  // #1755 — the maintenance chat link only appears once Hermes is installed
+  // (the assistant has nothing to talk to otherwise). Gated on the live
+  // digital-twin installedTemplates, like the rest of the service-aware UI.
+  const hermesInstalled = Boolean(twin?.installedTemplates?.includes('hermes'));
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [showCollapsedNodeLabel, setShowCollapsedNodeLabel] = useState(false);
   const [lldapUrl, setLldapUrl] = useState<string | null>(null);
@@ -174,6 +180,20 @@ export default function Sidebar() {
                     </button>
                 );
             })}
+            {hermesInstalled && (
+                <button
+                    onClick={() => router.push(`/chat${node ? `?node=${node}` : ''}`)}
+                    className={`w-full text-left px-3.5 py-3 rounded-xl flex items-center transition-all border ${
+                        isNavActive(pathname, '/chat')
+                        ? 'bg-blue-50 dark:bg-blue-600/10 border-blue-100 dark:border-blue-500/20 text-blue-600 dark:text-blue-400 font-bold shadow-sm shadow-blue-500/5'
+                        : 'border-transparent hover:bg-gray-200/60 dark:hover:bg-white/[0.02] text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                    } ${isCollapsed ? 'justify-center' : 'gap-3.5'}`}
+                    title={isCollapsed ? 'Maintenance Chat' : ''}
+                >
+                    <MessageCircle size={20} className={`shrink-0 ${isNavActive(pathname, '/chat') ? 'text-blue-500 dark:text-blue-400' : 'text-gray-500 dark:text-gray-500'}`} />
+                    {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">Maintenance Chat</span>}
+                </button>
+            )}
             {lldapUrl && (
                 <a
                     href={lldapUrl}

--- a/tests/frontend/Sidebar.test.tsx
+++ b/tests/frontend/Sidebar.test.tsx
@@ -11,6 +11,14 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush })
 }));
 
+// Sidebar consumes the digital twin (#1755 gates the Maintenance Chat link on
+// installedTemplates). These tests render Sidebar outside a DigitalTwinProvider,
+// so stub the hook with a mutable snapshot the per-test setup can vary.
+const twinRef: { current: { installedTemplates?: string[] } | null } = { current: null };
+vi.mock('@/hooks/useDigitalTwin', () => ({
+  useDigitalTwin: () => ({ data: twinRef.current, isConnected: false, lastUpdate: 0, isNodeSynced: () => false }),
+}));
+
 describe('Sidebar', () => {
     let fetchSpy: ReturnType<typeof vi.spyOn>;
     // Route-aware mock. `mockResolvedValue` would hand back the same Response
@@ -40,6 +48,7 @@ describe('Sidebar', () => {
         window.dispatchEvent(new Event('resize'));
 
         lldapResponse.url = null;
+        twinRef.current = null;
         fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((url) => Promise.resolve(mockFetch(url)));
     });
 
@@ -144,5 +153,17 @@ describe('Sidebar', () => {
         const buttons = screen.getAllByRole('button');
         const navTexts = buttons.map(b => b.textContent).filter(Boolean);
         expect(navTexts).not.toContain('Users & Groups');
+    });
+
+    it('hides the Maintenance Chat link when hermes is not installed (#1755)', () => {
+        twinRef.current = { installedTemplates: ['auth', 'media'] };
+        render(<Sidebar />);
+        expect(screen.queryByText('Maintenance Chat')).toBeNull();
+    });
+
+    it('shows the Maintenance Chat link when hermes is installed (#1755)', () => {
+        twinRef.current = { installedTemplates: ['auth', 'hermes'] };
+        render(<Sidebar />);
+        expect(screen.getByText('Maintenance Chat')).toBeDefined();
     });
 });

--- a/tests/frontend/responsive-layout.test.tsx
+++ b/tests/frontend/responsive-layout.test.tsx
@@ -26,6 +26,13 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, replace: mockPush }),
 }));
 
+// Sidebar consumes the digital twin (#1755 gates the Maintenance Chat link on
+// installedTemplates). These structural tests render Sidebar bare, outside a
+// DigitalTwinProvider, so stub the hook to a no-twin snapshot.
+vi.mock('@/hooks/useDigitalTwin', () => ({
+  useDigitalTwin: () => ({ data: null, isConnected: false, lastUpdate: 0, isNodeSynced: () => false }),
+}));
+
 const withToast = (ui: React.ReactNode) => render(<ToastProvider>{ui}</ToastProvider>);
 
 function setViewport(width: number) {


### PR DESCRIPTION
## What
Native maintenance-chat panel (part B of #1704): a `HermesChatPanel.tsx` component (scrolling user/assistant log, composer, typing indicator, graceful 503 notice) hosted at a new `(dashboard)/chat/page.tsx` route, with a conditional Sidebar "Maintenance Chat" link gated on `hermes` being in `installedTemplates`. The panel POSTs only to the server-side seam `/api/system/hermes/chat` (#1754) and never holds the Hermes API key.

Placement note: gated Sidebar link (least intrusive — top-level `NAVIGATION_ENTRIES` has no per-entry gating), no always-on nav entry.

## Why
Closes #1755

## Risk
Low — frontend-only (new component + route + conditional nav link + tests); no install/backup/auth/template/mcp/config paths touched. The backend seam it calls already shipped (#1754) and degrades to a 503 notice when Hermes is unreachable.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 351 warnings — no increase)
- [x] npm run check:arch
- [x] npm test (full — 2366 passed / 2 skipped)
- [x] npm run build (/chat + /api/system/hermes/chat in route manifest)