### PR TITLE
feat(hermes): chat history reload, API-key reconcile, and image-gated update availability

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -191,6 +191,15 @@ export interface AppConfig {
      * Written by the in-process notifier; read on every check.
      */
     lastNotifiedVersion?: string;
+    /**
+     * Manifest digest of the `:latest` image that is currently applied (the
+     * one a successful `performUpdate` pull last advanced us to). Used to gate
+     * "update available" on the image actually being newer than what we run —
+     * a release tag is cut *before* the `:latest` image is built+pushed, so a
+     * tag-ahead-but-digest-unchanged state means "new version still building",
+     * not "available". Written after a successful pull; null until first seen.
+     */
+    appliedImageDigest?: string;
   };
   /**
    * Unified auto-update window. ServiceBay manages three independent

--- a/packages/backend/src/lib/diagnose/probes/hermesChat.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/hermesChat.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `hermes_chat` probe (#1761) — verifies it distinguishes an API-KEY
+ * MISMATCH (Hermes 401 → fail + reconcile action) from a genuine outage
+ * (transport error → warn, no false "key mismatch" claim), and skips when
+ * hermes isn't installed. Also checks the reconcile heal-action is registered.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listSessions: vi.fn(),
+  configuredRef: { value: true },
+  reconcile: vi.fn(),
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+}));
+vi.mock('@/lib/hermes/client', () => {
+  class FakeHermesError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    HermesError: FakeHermesError,
+    resolveHermesConnection: vi.fn(() => ({ baseUrl: 'http://127.0.0.1:8642', apiKey: 'k' })),
+    HermesClient: class {
+      get configured() {
+        return mocks.configuredRef.value;
+      }
+      listSessions = mocks.listSessions;
+    },
+  };
+});
+vi.mock('@/lib/hermes/reconcileHermesApiKey', () => ({
+  reconcileHermesApiKey: mocks.reconcile,
+}));
+
+import { checkHermesChat } from './hermesChat';
+import { getConfig } from '@/lib/config';
+import { HermesError } from '@/lib/hermes/client';
+import { actionsForProbe, dispatchProbeAction } from '../actions';
+
+describe('checkHermesChat (#1761)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.configuredRef.value = true;
+    vi.mocked(getConfig).mockResolvedValue({ installedTemplates: { hermes: {} } } as never);
+  });
+
+  it('skips (info) when hermes is not installed', async () => {
+    vi.mocked(getConfig).mockResolvedValue({ installedTemplates: {} } as never);
+    const r = await checkHermesChat();
+    expect(r.status).toBe('info');
+    expect(mocks.listSessions).not.toHaveBeenCalled();
+  });
+
+  it('is ok when Hermes is reachable and authenticates', async () => {
+    mocks.listSessions.mockResolvedValue([]);
+    const r = await checkHermesChat();
+    expect(r.status).toBe('ok');
+  });
+
+  it('fails with a DISTINCT key-mismatch detail on a Hermes 401', async () => {
+    mocks.listSessions.mockRejectedValue(new HermesError('Hermes returned 401', 401));
+    const r = await checkHermesChat();
+    expect(r.status).toBe('fail');
+    expect(r.detail).toMatch(/drifted|401/i);
+    expect(r.hint).toMatch(/reconcile/i);
+  });
+
+  it('warns (not fail, no key-mismatch claim) on a genuine outage', async () => {
+    mocks.listSessions.mockRejectedValue(new HermesError('Hermes is unreachable'));
+    const r = await checkHermesChat();
+    expect(r.status).toBe('warn');
+    expect(r.detail).not.toMatch(/drifted/i);
+    expect(r.hint).toMatch(/connectivity/i);
+  });
+
+  it('warns when installed but no key is stored yet', async () => {
+    mocks.configuredRef.value = false;
+    const r = await checkHermesChat();
+    expect(r.status).toBe('warn');
+    expect(mocks.listSessions).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcile_hermes_api_key heal-action (#1761)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is registered on the hermes_chat probe', () => {
+    const ids = actionsForProbe('hermes_chat').map(a => a.id);
+    expect(ids).toContain('reconcile_hermes_api_key');
+  });
+
+  it('dispatches the reconcile and reports the changed outcome', async () => {
+    mocks.reconcile.mockResolvedValue({ outcome: 'changed', message: 'Adopted the key.' });
+    const res = await dispatchProbeAction({
+      probeId: 'hermes_chat',
+      actionId: 'reconcile_hermes_api_key',
+      node: 'Local',
+    });
+    expect(res.ok).toBe(true);
+    expect(mocks.reconcile).toHaveBeenCalledWith('Local');
+  });
+
+  it('reports a failed outcome (not-found) as ok:false', async () => {
+    mocks.reconcile.mockResolvedValue({ outcome: 'not-found', message: 'no key' });
+    const res = await dispatchProbeAction({
+      probeId: 'hermes_chat',
+      actionId: 'reconcile_hermes_api_key',
+      node: 'Local',
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/hermesChat.ts
+++ b/packages/backend/src/lib/diagnose/probes/hermesChat.ts
@@ -1,0 +1,115 @@
+/**
+ * `hermes_chat` probe (#1761) — surfaces the maintenance-chat assistant's
+ * reachability and, crucially, distinguishes an API-KEY MISMATCH (Hermes
+ * answers 401) from a genuine outage (loopback refused / not installed).
+ *
+ * The painful failure mode (#1761): Hermes is an external OSCAR template
+ * ServiceBay does NOT render, so the engine's `API_SERVER_KEY` and
+ * ServiceBay's stored `HERMES_API_KEY` can drift (each side generated its
+ * own). When they drift the chat route sends the wrong bearer, Hermes
+ * answers 401, and the operator sees "the assistant is unavailable" with no
+ * way to repair it short of a reinstall.
+ *
+ * This probe fires `fail` on a 401 with the dedicated `reconcile_hermes_api_key`
+ * heal-action — a one-click "adopt the running engine's key" that survives a
+ * Hermes redeploy without a reinstall (reconcile-not-generate, ADR 0009 style,
+ * mirroring the OIDC reconcile in #1741). A genuine outage stays a calm
+ * `warn`/`info` with no false "key mismatch" claim.
+ *
+ * Skip cases:
+ *   - No `hermes` template installed → nothing to probe (info).
+ *
+ * SECURITY: the probe reaches Hermes through the same server-side client as
+ * the chat route — the bearer key is read from `installedSecrets` (encrypted
+ * at rest) in the backend and is never logged or surfaced.
+ */
+import { getConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import { HermesClient, HermesError, resolveHermesConnection } from '@/lib/hermes/client';
+import { reconcileHermesApiKey } from '@/lib/hermes/reconcileHermesApiKey';
+import { registerProbeAction, type ProbeActionResult } from '../actions';
+
+const PROBE_ID = 'hermes_chat';
+
+export interface HermesChatResult {
+  status: 'ok' | 'warn' | 'fail' | 'info';
+  detail: string;
+  hint?: string;
+}
+
+/** Probe the maintenance-chat path: classify reachable / 401 / unreachable. */
+export async function checkHermesChat(): Promise<HermesChatResult> {
+  const config = await getConfig();
+  if (!config.installedTemplates?.hermes) {
+    return {
+      status: 'info',
+      detail: 'Hermes template not installed — no maintenance-chat assistant to probe.',
+    };
+  }
+
+  const conn = resolveHermesConnection(config);
+  const client = new HermesClient(conn, 5000);
+  if (!client.configured) {
+    return {
+      status: 'warn',
+      detail: 'Hermes is installed but no API key is stored for it yet.',
+      hint: 'Click "Reconcile Hermes API key" to adopt the running engine\'s key so maintenance chat can authenticate.',
+    };
+  }
+
+  try {
+    // listSessions is a cheap authenticated GET — a 200 proves both
+    // reachability and a matching key.
+    await client.listSessions();
+    return {
+      status: 'ok',
+      detail: 'Maintenance-chat assistant is reachable and authenticating.',
+    };
+  } catch (e) {
+    if (e instanceof HermesError && e.status === 401) {
+      return {
+        status: 'fail',
+        detail:
+          'Hermes rejected the stored API key (401) — ServiceBay\'s key has drifted from the running engine.',
+        hint: 'Click "Reconcile Hermes API key" to adopt the key the running Hermes container actually uses. No reinstall needed.',
+      };
+    }
+    return {
+      status: 'warn',
+      detail: 'Hermes is installed but the maintenance-chat endpoint is not responding.',
+      hint: 'Check that the hermes service is running (Services → hermes). This is a connectivity issue, not a key mismatch.',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Action: adopt the running engine's API key. Reconcile-not-generate — reads
+// the live `API_SERVER_KEY` over the loopback exec seam and stores it. Never
+// regenerates a key (that would break the running engine). Idempotent.
+// ---------------------------------------------------------------------------
+
+async function reconcileHermesKeyAction({ node }: { node: string }): Promise<ProbeActionResult> {
+  const result = await reconcileHermesApiKey(node);
+  switch (result.outcome) {
+    case 'changed':
+      return { ok: true, message: result.message, refresh: true };
+    case 'aligned':
+      return { ok: true, message: result.message, refresh: true };
+    case 'not-found':
+      return { ok: false, message: result.message, refresh: false };
+    default:
+      logger.warn('diagnose:hermes_chat', `reconcile action failed: ${result.message}`);
+      return { ok: false, message: result.message, refresh: false };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'reconcile_hermes_api_key',
+    label: 'Reconcile Hermes API key',
+    description:
+      'Adopts the API key the running Hermes engine actually uses (read over the loopback exec seam) into ServiceBay’s stored secret. Use when maintenance chat fails with an auth/401 error after a Hermes redeploy. Never regenerates a key (that would break the running engine); idempotent — a no-op when the keys already match.',
+  },
+  reconcileHermesKeyAction,
+);

--- a/packages/backend/src/lib/diagnose/probes/register.ts
+++ b/packages/backend/src/lib/diagnose/probes/register.ts
@@ -30,5 +30,6 @@ import './domainUnreachable';
 import './lanIpChanged';
 import './oidcProviderReachable';
 import './ssoVerify';
+import './hermesChat';
 
 export {};

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -30,6 +30,7 @@ import { checkDomainResolvesToBox } from '@/lib/diagnose/probes/domainResolvesTo
 import { checkOidcProviderReachable } from '@/lib/diagnose/probes/oidcProviderReachable';
 import { checkNasBackupReachable } from '@/lib/diagnose/probes/nasBackupReachable';
 import { checkSsoVerify } from '@/lib/diagnose/probes/ssoVerify';
+import { checkHermesChat } from '@/lib/diagnose/probes/hermesChat';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
 import { persistDiagnoseResults, buildProbeHistory, type ProbeHistory } from '@/lib/diagnose/persistDiagnoseResults';
 import '@/lib/diagnose/probes/register';
@@ -90,6 +91,8 @@ const PROBE_GROUP: Record<string, ProbeGroup> = {
   cert_expiry: 'tls',
   // Login / SSO
   sso_verify: 'sso',
+  // Maintenance-chat assistant (Hermes)
+  hermes_chat: 'services',
   // Storage & backups
   disk: 'storage-backups',
   nas_backup_reachable: 'storage-backups',
@@ -1013,6 +1016,29 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     probes.push({
       id: 'nas_backup_reachable',
       label: 'Config backup (FritzBox NAS)',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 19) Maintenance-chat assistant (Hermes) reachability (#1761). Crucially
+  //     distinguishes an API-KEY MISMATCH (Hermes 401 — ServiceBay's stored
+  //     key drifted from the externally-deployed engine's API_SERVER_KEY)
+  //     from a genuine outage, and offers a one-click "Reconcile Hermes API
+  //     key" heal-action so the operator repairs drift without a reinstall.
+  try {
+    const hc = await checkHermesChat();
+    probes.push({
+      id: 'hermes_chat',
+      label: 'Maintenance chat (Hermes)',
+      status: hc.status,
+      detail: hc.detail,
+      hint: hc.hint,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'hermes_chat',
+      label: 'Maintenance chat (Hermes)',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/packages/backend/src/lib/hermes/client.test.ts
+++ b/packages/backend/src/lib/hermes/client.test.ts
@@ -132,6 +132,59 @@ describe('HermesClient.chat', () => {
   });
 });
 
+describe('HermesClient.getMessages', () => {
+  it('maps the {data:[{role,content}]} envelope to the panel {role,text} shape', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      jsonResponse({
+        data: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello back' },
+        ],
+      }),
+    );
+
+    const msgs = await new HermesClient(CONN).getMessages('sess-1');
+    expect(msgs).toEqual([
+      { role: 'user', text: 'hi' },
+      { role: 'assistant', text: 'hello back' },
+    ]);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8642/api/sessions/sess-1/messages');
+    expect(init?.method).toBe('GET');
+  });
+
+  it('collapses non-user roles to assistant and drops empty/invalid turns', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      jsonResponse({
+        data: [
+          { role: 'system', content: 'persona' },
+          { role: 'tool', content: '' },
+          { role: 'user', content: 'q' },
+          { not: 'a message' },
+        ],
+      }),
+    );
+    const msgs = await new HermesClient(CONN).getMessages('s');
+    expect(msgs).toEqual([
+      { role: 'assistant', text: 'persona' },
+      { role: 'user', text: 'q' },
+    ]);
+  });
+
+  it('returns an empty history when the session 404s (wiped session)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => jsonResponse({}, 404));
+    expect(await new HermesClient(CONN).getMessages('gone')).toEqual([]);
+  });
+
+  it('throws HermesError when fetch rejects (Hermes unreachable)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    await expect(new HermesClient(CONN).getMessages('s')).rejects.toBeInstanceOf(HermesError);
+  });
+});
+
 describe('getOrCreateMaintenanceSession', () => {
   it('creates the session once with the persona and persists the id', async () => {
     const fetchMock = vi

--- a/packages/backend/src/lib/hermes/client.ts
+++ b/packages/backend/src/lib/hermes/client.ts
@@ -8,6 +8,7 @@
  *   - `GET  /api/sessions`              -> `{data:[{id,...}]}` (list)
  *   - `GET  /api/sessions/{id}`         -> `{session:{...}}` (summary)
  *   - `POST /api/sessions/{id}/chat`    -> body `{input}`, returns the reply
+ *   - `GET  /api/sessions/{id}/messages`-> `{data:[{role,content,...}]}` (history)
  *
  * Connection: `http://127.0.0.1:${HERMES_API_PORT}` (loopback only — the
  * Hermes API binds 127.0.0.1; other host pods reach it over loopback,
@@ -137,6 +138,40 @@ function extractReply(body: unknown): string {
   return String(b.output ?? b.reply ?? b.response ?? b.text ?? '');
 }
 
+/**
+ * A single persisted conversation turn, mapped to the shape the maintenance
+ * chat panel renders: `role` collapsed to user/assistant, and the text under
+ * `text` (the panel never sees Hermes' raw `content` envelope).
+ */
+export interface HermesMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+/** Pull the text out of a Hermes message `content` (string or `{content}`). */
+function extractMessageText(content: unknown): string {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+  if (typeof content === 'object' && 'content' in (content as Record<string, unknown>)) {
+    return String((content as Record<string, unknown>).content ?? '');
+  }
+  return String(content);
+}
+
+/**
+ * Map a raw Hermes message record to the panel shape. Any non-user role
+ * (assistant/tool/system) collapses to `assistant` — the panel only renders
+ * the two-sided operator/assistant conversation.
+ */
+function toHermesMessage(raw: unknown): HermesMessage | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const role = String(r.role ?? '') === 'user' ? 'user' : 'assistant';
+  const text = extractMessageText(r.content ?? r.text ?? r.message);
+  if (!text) return null;
+  return { role, text };
+}
+
 function extractSessionId(body: unknown): string {
   if (!body || typeof body !== 'object') return '';
   const b = body as Record<string, unknown>;
@@ -249,6 +284,37 @@ export class HermesClient {
     const body = await this.request('POST', `/api/sessions/${sessionId}/chat`, { input });
     return extractReply(body);
   }
+
+  /**
+   * Fetch the persisted conversation for a session, mapped to the panel's
+   * `{role,text}` shape (Hermes returns `{data:[{role,content,...}]}`).
+   * A 404 (session gone) returns an empty history rather than throwing, so a
+   * wiped session shows an empty conversation, not an error.
+   */
+  async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    let body: unknown;
+    try {
+      body = await this.request('GET', `/api/sessions/${sessionId}/messages`);
+    } catch (e) {
+      if (e instanceof HermesError && e.status === 404) return [];
+      throw e;
+    }
+    const raw = extractMessageArray(body);
+    return raw.map(toHermesMessage).filter((m): m is HermesMessage => m !== null);
+  }
+}
+
+/** Pull the message array out of Hermes' envelope (`data`/`messages`/items). */
+function extractMessageArray(body: unknown): unknown[] {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === 'object') {
+    const b = body as Record<string, unknown>;
+    for (const key of ['data', 'messages', 'items', 'results']) {
+      const v = b[key];
+      if (Array.isArray(v)) return v;
+    }
+  }
+  return [];
 }
 
 /**

--- a/packages/backend/src/lib/hermes/reconcileHermesApiKey.test.ts
+++ b/packages/backend/src/lib/hermes/reconcileHermesApiKey.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Hermes API-key reconcile (#1761) — adopt the running engine's
+ * `API_SERVER_KEY` into `installedSecrets.HERMES_API_KEY` without
+ * regenerating it. Tests the read-then-store contract, idempotency, the
+ * not-found path, and that the key is never returned in the result.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn() },
+}));
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+}));
+vi.mock('@/lib/install/savedSecrets', () => ({
+  loadSavedSecrets: vi.fn(),
+  persistSingleSecret: vi.fn(),
+}));
+
+import { reconcileHermesApiKey } from './reconcileHermesApiKey';
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { loadSavedSecrets, persistSingleSecret } from '@/lib/install/savedSecrets';
+
+const ENGINE_KEY = 'engine-real-key-abc123';
+
+/** Build an agent whose exec returns `stdout` for the first container that
+ *  matches `respondFor` (default: the first container queried). */
+function agentReturning(stdout: string): { sendCommand: ReturnType<typeof vi.fn> } {
+  const sendCommand = vi.fn(async () => ({ code: 0, stdout }));
+  return { sendCommand };
+}
+
+describe('reconcileHermesApiKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getConfig).mockResolvedValue({} as never);
+    vi.mocked(loadSavedSecrets).mockReturnValue({});
+    vi.mocked(persistSingleSecret).mockResolvedValue(true);
+  });
+
+  it('reads the running engine key and persists it when stored value is missing', async () => {
+    vi.mocked(agentManager.ensureAgent).mockResolvedValue(
+      agentReturning(`${ENGINE_KEY}\n`) as never,
+    );
+    vi.mocked(loadSavedSecrets).mockReturnValue({}); // nothing stored yet
+
+    const result = await reconcileHermesApiKey('Local');
+
+    expect(result.outcome).toBe('changed');
+    // Reads API_SERVER_KEY over the exec seam (loopback podman exec).
+    const cmd = vi.mocked(agentManager.ensureAgent).mock.results[0].value as Promise<{
+      sendCommand: ReturnType<typeof vi.fn>;
+    }>;
+    const agent = await cmd;
+    expect(agent.sendCommand).toHaveBeenCalledWith(
+      'exec',
+      expect.objectContaining({ command: expect.stringContaining('printenv API_SERVER_KEY') }),
+      expect.anything(),
+    );
+    // Stores the exact trimmed engine key under HERMES_API_KEY.
+    expect(persistSingleSecret).toHaveBeenCalledWith('HERMES_API_KEY', ENGINE_KEY);
+    // Result never carries the key value.
+    expect(JSON.stringify(result)).not.toContain(ENGINE_KEY);
+  });
+
+  it('is a no-op (aligned) when the stored key already matches the engine', async () => {
+    vi.mocked(agentManager.ensureAgent).mockResolvedValue(
+      agentReturning(ENGINE_KEY) as never,
+    );
+    vi.mocked(loadSavedSecrets).mockReturnValue({ HERMES_API_KEY: ENGINE_KEY });
+
+    const result = await reconcileHermesApiKey('Local');
+
+    expect(result.outcome).toBe('aligned');
+    expect(persistSingleSecret).not.toHaveBeenCalled();
+  });
+
+  it('reports not-found and does not write when no container yields a key', async () => {
+    // printenv unset → `|| true` yields empty stdout for every candidate.
+    vi.mocked(agentManager.ensureAgent).mockResolvedValue(agentReturning('') as never);
+
+    const result = await reconcileHermesApiKey('Local');
+
+    expect(result.outcome).toBe('not-found');
+    expect(persistSingleSecret).not.toHaveBeenCalled();
+  });
+
+  it('never regenerates: it only stores the value read from the engine', async () => {
+    const other = 'a-totally-different-engine-key-999';
+    vi.mocked(agentManager.ensureAgent).mockResolvedValue(agentReturning(other) as never);
+    vi.mocked(loadSavedSecrets).mockReturnValue({ HERMES_API_KEY: 'stale-servicebay-key' });
+
+    await reconcileHermesApiKey('Local');
+
+    // Adopts the engine's value verbatim — does NOT invent a new key.
+    expect(persistSingleSecret).toHaveBeenCalledWith('HERMES_API_KEY', other);
+  });
+});

--- a/packages/backend/src/lib/hermes/reconcileHermesApiKey.ts
+++ b/packages/backend/src/lib/hermes/reconcileHermesApiKey.ts
@@ -1,0 +1,146 @@
+/**
+ * Hermes API-key reconcile (#1761) — adopt the bearer key the running
+ * Hermes engine actually uses, rather than generating our own.
+ *
+ * Hermes ships as an external OSCAR template that ServiceBay does NOT
+ * render: the template is deployed with its own `API_SERVER_KEY`, and
+ * ServiceBay separately generates+persists a `HERMES_API_KEY` secret at
+ * install. Those two can diverge — when they do, the maintenance-chat
+ * route sends the wrong bearer, Hermes answers 401, and the route reports
+ * the assistant as "unavailable" even though the engine is healthy.
+ *
+ * The durable fix is reconcile-not-generate (ADR 0009 style, mirroring the
+ * OIDC client reconcile in #1741): read the key the running hermes
+ * container actually uses (`API_SERVER_KEY` from its environment) and write
+ * it into `installedSecrets.HERMES_API_KEY` via `persistSingleSecret`
+ * (encrypted at rest). Idempotent, diff-visible, explicitly triggered — at
+ * hermes deploy detection and as an operator diagnose heal-action. It NEVER
+ * regenerates a key (that would break the running engine).
+ *
+ * SECURITY (#1761): the key is read over the agent/exec loopback seam only
+ * (`podman exec <container> printenv`), stored encrypted via the existing
+ * `installedSecrets` path, and is NEVER logged or returned to the browser —
+ * the result reports only whether the value changed, never the value.
+ */
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { loadSavedSecrets, persistSingleSecret } from '@/lib/install/savedSecrets';
+import { logger } from '@/lib/logger';
+
+/** The secret-variable name ServiceBay stores the Hermes bearer key under. */
+const HERMES_API_KEY_VAR = 'HERMES_API_KEY';
+/**
+ * The env var the hermes (OSCAR) container reads its bearer key from. This
+ * is the engine's source of truth — ServiceBay adopts whatever it holds.
+ */
+const HERMES_ENGINE_KEY_ENV = 'API_SERVER_KEY';
+/**
+ * Candidate container names for the running hermes engine. The OSCAR
+ * template runs as `hermes-hermes` (pod-prefixed); a single-container
+ * deploy may run as plain `hermes`. We try in order and use the first that
+ * yields a non-empty key.
+ */
+const HERMES_CONTAINERS = ['hermes-hermes', 'hermes'];
+const EXEC_TIMEOUT_S = 10;
+
+/** Outcome of a reconcile attempt — diff-visible, never carries the key. */
+export interface HermesKeyReconcileResult {
+  /** `changed` wrote a new value; `aligned` already matched; `not-found`
+   *  couldn't read a key from any candidate container; `error` on a
+   *  transport/exec failure. */
+  outcome: 'changed' | 'aligned' | 'not-found' | 'error';
+  /** One-line, key-free summary suitable for a log line or action toast. */
+  message: string;
+}
+
+interface ExecReply {
+  code?: number;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Read `API_SERVER_KEY` from the first reachable hermes container. Returns
+ * the trimmed value, or `''` when no candidate container yields one (engine
+ * not running, var unset). The key is never logged.
+ */
+async function readEngineKey(node: string): Promise<string> {
+  const agent = await agentManager.ensureAgent(node);
+  for (const container of HERMES_CONTAINERS) {
+    let res: ExecReply;
+    try {
+      res = (await agent.sendCommand(
+        'exec',
+        {
+          // `printenv` exits non-zero when the var is unset, so we tolerate a
+          // non-zero exit and just read stdout. The value never hits the log.
+          command: `podman exec ${container} printenv ${HERMES_ENGINE_KEY_ENV} 2>/dev/null || true`,
+          timeout: EXEC_TIMEOUT_S,
+        },
+        { timeoutMs: EXEC_TIMEOUT_S * 1000 },
+      )) as ExecReply;
+    } catch (e) {
+      // Container missing / not running for this candidate — try the next.
+      logger.info(
+        'hermes:reconcile',
+        `exec against ${container} failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      continue;
+    }
+    const value = (res.stdout ?? '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+/**
+ * Adopt the running Hermes engine's `API_SERVER_KEY` into
+ * `installedSecrets.HERMES_API_KEY`. Idempotent: a no-op when the stored
+ * value already matches. Never regenerates a key, never logs the key.
+ *
+ * @param node agent node name (defaults to the local box).
+ */
+export async function reconcileHermesApiKey(
+  node: string = 'Local',
+): Promise<HermesKeyReconcileResult> {
+  let engineKey: string;
+  try {
+    engineKey = await readEngineKey(node);
+  } catch (e) {
+    const message = `Could not read the Hermes engine key: ${e instanceof Error ? e.message : String(e)}`;
+    logger.warn('hermes:reconcile', message);
+    return { outcome: 'error', message };
+  }
+
+  if (!engineKey) {
+    return {
+      outcome: 'not-found',
+      message:
+        'Could not read API_SERVER_KEY from the running Hermes container — is the hermes service running?',
+    };
+  }
+
+  const config = await getConfig();
+  const stored = loadSavedSecrets(config)[HERMES_API_KEY_VAR] ?? '';
+  if (stored === engineKey) {
+    return {
+      outcome: 'aligned',
+      message: 'Hermes API key already matches the running engine — no change.',
+    };
+  }
+
+  const wrote = await persistSingleSecret(HERMES_API_KEY_VAR, engineKey);
+  logger.info(
+    'hermes:reconcile',
+    wrote
+      ? 'Adopted the running Hermes engine API key into installedSecrets (encrypted at rest).'
+      : 'Hermes API key reconcile resolved to no write.',
+  );
+  return {
+    outcome: wrote ? 'changed' : 'aligned',
+    message: wrote
+      ? 'Adopted the running Hermes engine API key — maintenance chat will now authenticate.'
+      : 'Hermes API key already matches the running engine — no change.',
+  };
+}

--- a/packages/backend/src/lib/install/postInstallDispatcher.ts
+++ b/packages/backend/src/lib/install/postInstallDispatcher.ts
@@ -27,6 +27,7 @@ import { buildProxyHosts, type StackVariable } from '@/lib/stackInstall/postInst
 import { appendLog } from './jobStore';
 import { emitJobLog } from './socketBridge';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
+import { reconcileHermesApiKey } from '@/lib/hermes/reconcileHermesApiKey';
 
 /** Best-effort jobStore log helper — mirrors the private one in runner.ts.
  *  Kept local so neither module has to import the other. */
@@ -159,5 +160,40 @@ export async function ensureOidcClients(
     }
   } catch (e) {
     await log(jobId, `⚠️ Authelia OIDC reconciliation failed: ${e instanceof Error ? e.message : String(e)}. Settings → Self-Diagnose → Reprovision will retry.`);
+  }
+}
+
+/**
+ *  Last-mile guard for the Hermes maintenance-chat API key (#1761). Hermes
+ *  ships as an external OSCAR template ServiceBay does NOT render: it is
+ *  deployed with its own `API_SERVER_KEY`, while ServiceBay separately
+ *  generated+persisted a `HERMES_API_KEY` at install — so the two drift, the
+ *  chat route sends the wrong bearer, and Hermes answers 401.
+ *
+ *  This pass runs only when `hermes` was (re)deployed in this install: it
+ *  reads the key the running hermes container actually uses and adopts it
+ *  into `installedSecrets.HERMES_API_KEY` (reconcile-not-generate, mirroring
+ *  the OIDC reconcile). Idempotent — a no-op when the keys already match.
+ *  Best-effort: a failure is a soft warning (the diagnose heal-action is the
+ *  manual fallback), never fatal. SECURITY: the key is read over the loopback
+ *  exec seam, stored encrypted, and never logged here.
+ */
+export async function ensureHermesApiKey(
+  jobId: string,
+  templateNames: string[],
+  node: string | undefined,
+): Promise<void> {
+  if (!templateNames.includes('hermes')) return;
+  try {
+    const result = await reconcileHermesApiKey(node || 'Local');
+    if (result.outcome === 'changed') {
+      await log(jobId, `🔑 ${result.message}`);
+    } else if (result.outcome === 'aligned') {
+      await log(jobId, `✅ ${result.message}`);
+    } else {
+      await log(jobId, `⚠️ ${result.message} Settings → Self-Diagnose → "Reconcile Hermes API key" will retry.`);
+    }
+  } catch (e) {
+    await log(jobId, `⚠️ Hermes API-key reconcile failed: ${e instanceof Error ? e.message : String(e)}. Settings → Self-Diagnose → "Reconcile Hermes API key" will retry.`);
   }
 }

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -68,6 +68,7 @@ import {
 import {
   ensureProxyHosts,
   ensureOidcClients,
+  ensureHermesApiKey,
 } from './postInstallDispatcher';
 
 // Re-export the surface previously exposed from this module so the
@@ -1436,6 +1437,13 @@ async function runJob(jobId: string): Promise<void> {
   // read), and a missed registration only surfaces when the operator
   // tries to SSO into the affected service.
   await ensureOidcClients(jobId, Array.from(newlyDeployed), variables);
+
+  // #1761 — Hermes ships as an external OSCAR template ServiceBay doesn't
+  // render, so the engine's API_SERVER_KEY and ServiceBay's stored
+  // HERMES_API_KEY drift on (re)deploy → chat route gets 401. When hermes
+  // was deployed in this install, adopt the running engine's key
+  // (reconcile-not-generate). Best-effort; the diagnose heal-action retries.
+  await ensureHermesApiKey(jobId, Array.from(newlyDeployed), input.node);
 
   // Build the final credentials manifest for the Done UI. Handler
   // already persisted per-template entries to `config.installManifest`

--- a/packages/backend/src/lib/updater.test.ts
+++ b/packages/backend/src/lib/updater.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- mocks -----------------------------------------------------------------
+// getConfig / updateConfig are stubbed so we can drive appliedImageDigest and
+// assert what the updater persists.
+const mockConfig = vi.hoisted(() => ({
+  current: { autoUpdate: { enabled: false, schedule: '0 0 * * *' } as Record<string, unknown> },
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfig.current),
+  updateConfig: vi.fn(async (patch: { autoUpdate: Record<string, unknown> }) => {
+    mockConfig.current = { ...mockConfig.current, ...patch };
+  }),
+}));
+
+// executor.exec / execArgv are stubbed per test.
+const mockExec = vi.hoisted(() => ({
+  exec: vi.fn(async (_cmd: string, _opts?: unknown) => ({ stdout: '', stderr: '' })),
+  execArgv: vi.fn(async (_argv: string[], _opts?: unknown) => ({ stdout: '', stderr: '' })),
+}));
+vi.mock('@/lib/executor', () => ({
+  getExecutor: () => mockExec,
+}));
+
+vi.mock('@/lib/email', () => ({ sendEmailAlert: vi.fn() }));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { checkForUpdates, performUpdate, extractImageDigest } from './updater';
+
+// A multi-arch manifest-list document as `podman manifest inspect` returns it.
+function manifestList(amd64Digest: string): string {
+  return JSON.stringify({
+    schemaVersion: 2,
+    mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+    manifests: [
+      { platform: { architecture: 'amd64', os: 'linux' }, digest: amd64Digest },
+      { platform: { architecture: 'unknown', os: 'unknown' }, digest: 'sha256:ignored' },
+    ],
+  });
+}
+
+const ORIG_FETCH = global.fetch;
+
+function mockReleaseTag(tag: string) {
+  global.fetch = vi.fn(async () =>
+    new Response(JSON.stringify({ tag_name: tag, html_url: 'u', published_at: 'd', body: 'notes' }), {
+      status: 200,
+    }),
+  ) as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConfig.current = { autoUpdate: { enabled: false, schedule: '0 0 * * *' } };
+  mockExec.exec.mockResolvedValue({ stdout: '', stderr: '' });
+  mockExec.execArgv.mockResolvedValue({ stdout: '', stderr: '' });
+  global.fetch = ORIG_FETCH;
+  // Pin the running version so semver comparisons are deterministic.
+  vi.spyOn(process, 'cwd').mockReturnValue('/nonexistent-pkg-path');
+});
+
+describe('extractImageDigest', () => {
+  it('picks the linux/amd64 entry from a manifest list', () => {
+    expect(extractImageDigest(JSON.parse(manifestList('sha256:aaa')))).toBe('sha256:aaa');
+  });
+
+  it('falls back to config.digest for a single-arch manifest', () => {
+    expect(extractImageDigest({ config: { digest: 'sha256:bbb' } })).toBe('sha256:bbb');
+  });
+
+  it('returns null when no usable digest is present', () => {
+    expect(extractImageDigest({})).toBeNull();
+    expect(extractImageDigest(null)).toBeNull();
+    expect(extractImageDigest('garbage')).toBeNull();
+  });
+});
+
+describe('checkForUpdates — tag/image reconciliation', () => {
+  // getCurrentVersion reads package.json from cwd; with cwd pinned to a missing
+  // path it returns '0.0.0', so any real release tag is "ahead".
+
+  it('tag ahead AND image newer → update available', async () => {
+    mockReleaseTag('4.104.0');
+    mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:OLD';
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:NEW'), stderr: '' });
+
+    const res = await checkForUpdates();
+    expect(res.hasUpdate).toBe(true);
+    expect(res.imageBuilding).toBeFalsy();
+  });
+
+  it('tag ahead but image digest unchanged → NOT available, building', async () => {
+    mockReleaseTag('4.104.0');
+    mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:SAME';
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:SAME'), stderr: '' });
+
+    const res = await checkForUpdates();
+    expect(res.hasUpdate).toBe(false);
+    expect(res.imageBuilding).toBe(true);
+    expect(res.latest?.version).toBe('4.104.0');
+  });
+
+  it('tag ahead but remote digest unknown (registry unreachable) → falls back to tag (available)', async () => {
+    mockReleaseTag('4.104.0');
+    mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:OLD';
+    mockExec.execArgv.mockRejectedValue(new Error('no registry'));
+
+    const res = await checkForUpdates();
+    expect(res.hasUpdate).toBe(true);
+    expect(res.imageBuilding).toBeFalsy();
+  });
+
+  it('tag ahead with no applied-digest baseline yet → falls back to tag (available)', async () => {
+    mockReleaseTag('4.104.0');
+    // no appliedImageDigest
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:NEW'), stderr: '' });
+
+    const res = await checkForUpdates();
+    expect(res.hasUpdate).toBe(true);
+  });
+
+  it('tag not ahead seeds the applied digest baseline from the registry', async () => {
+    mockReleaseTag('0.0.0'); // equal to the 0.0.0 fallback current → not ahead
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:SEED'), stderr: '' });
+
+    const res = await checkForUpdates();
+    expect(res.hasUpdate).toBe(false);
+    expect(res.imageBuilding).toBeFalsy();
+    expect(mockConfig.current.autoUpdate.appliedImageDigest).toBe('sha256:SEED');
+  });
+});
+
+describe('performUpdate — honest pull result', () => {
+  it('pull unchanged (image not ready) → reports building, does NOT restart', async () => {
+    mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:SAME';
+    mockExec.exec.mockResolvedValue({ stdout: 'up to date', stderr: '' }); // podman pull
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:SAME'), stderr: '' }); // remote digest
+
+    const res = await performUpdate('4.104.0');
+    expect(res.success).toBe(true);
+    expect(res.updated).toBe(false);
+    expect(res.message).toMatch(/still building|latest/i);
+    // never issued the systemctl restart
+    const restarted = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('systemctl'));
+    expect(restarted).toBe(false);
+  });
+
+  it('pull advanced the image → persists new digest and restarts', async () => {
+    mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:OLD';
+    mockExec.exec.mockResolvedValue({ stdout: 'Pulled new layers', stderr: '' });
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:NEW'), stderr: '' });
+
+    const res = await performUpdate('4.104.0');
+    expect(res.success).toBe(true);
+    expect(res.updated).toBe(true);
+    expect(mockConfig.current.autoUpdate.appliedImageDigest).toBe('sha256:NEW');
+    const restarted = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('systemctl'));
+    expect(restarted).toBe(true);
+  });
+});

--- a/packages/backend/src/lib/updater.ts
+++ b/packages/backend/src/lib/updater.ts
@@ -26,12 +26,62 @@ function emitProgress(step: string, progress: number, message: string) {
 }
 
 const REPO = 'mdopp/servicebay';
+const IMAGE = 'ghcr.io/mdopp/servicebay:latest';
 
 interface Release {
   tag_name: string;
   html_url: string;
   published_at: string;
   body: string;
+}
+
+/**
+ * Pull the per-arch (amd64/linux) image digest out of a `podman manifest
+ * inspect` manifest-list document. The list is multi-arch; the amd64/linux
+ * entry's digest is the stable per-image identity that changes exactly when a
+ * new image is pushed to the tag. Exported for unit testing the parsing.
+ */
+export function extractImageDigest(manifest: unknown): string | null {
+  if (!manifest || typeof manifest !== 'object') return null;
+  const m = manifest as Record<string, unknown>;
+
+  // Manifest list (multi-arch): pick the linux/amd64 platform entry.
+  const manifests = m.manifests;
+  if (Array.isArray(manifests)) {
+    const amd64 = manifests.find((entry) => {
+      const platform = (entry as Record<string, unknown>)?.platform as
+        | Record<string, unknown>
+        | undefined;
+      return platform?.os === 'linux' && platform?.architecture === 'amd64';
+    }) as Record<string, unknown> | undefined;
+    const listed = amd64?.digest;
+    if (typeof listed === 'string' && listed.length > 0) return listed;
+  }
+
+  // Single-arch image manifest: the config digest is its stable identity.
+  const config = m.config as Record<string, unknown> | undefined;
+  const single = config?.digest ?? m.Digest ?? m.digest;
+  return typeof single === 'string' && single.length > 0 ? single : null;
+}
+
+/**
+ * Resolve the image digest the **registry** currently publishes for
+ * `:latest`. `podman manifest inspect` fetches only the manifest (a few KB),
+ * not the layers, so this is cheap enough to run on every update check.
+ * Returns null when the registry can't be reached / the tool errors — callers
+ * must treat null as "unknown", never as "unchanged".
+ */
+async function getRemoteImageDigest(): Promise<string | null> {
+  try {
+    const executor = getExecutor('Local');
+    const { stdout } = await executor.execArgv(['podman', 'manifest', 'inspect', IMAGE], {
+      timeoutMs: 30 * 1000,
+    });
+    return extractImageDigest(JSON.parse(stdout));
+  } catch (e) {
+    logger.warn('Updater', `getRemoteImageDigest failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
 }
 
 async function getCurrentVersion(): Promise<string> {
@@ -62,7 +112,27 @@ async function getLatestRelease(): Promise<Release | null> {
   }
 }
 
-export async function checkForUpdates() {
+export interface UpdateCheckResult {
+  hasUpdate: boolean;
+  current: string;
+  /**
+   * True when the release tag is ahead of the running version but the
+   * `:latest` image hasn't been (re)published yet — the release-please tag
+   * lands *before* the Release workflow builds+pushes the image, so for a few
+   * minutes the tag advertises a version no image exists for. We surface this
+   * distinctly instead of a false "update available" that pulls an unchanged
+   * image and reports a misleading success.
+   */
+  imageBuilding?: boolean;
+  latest: {
+    version: string;
+    url: string;
+    date: string;
+    notes: string;
+  } | null;
+}
+
+export async function checkForUpdates(): Promise<UpdateCheckResult> {
   const current = await getCurrentVersion();
   const latest = await getLatestRelease();
 
@@ -80,24 +150,59 @@ export async function checkForUpdates() {
   const versionMatch = latest.tag_name.match(/(\d+\.\d+\.\d+.*)/);
   const latestClean = versionMatch ? versionMatch[0] : latest.tag_name.replace(/^v/, '');
 
-  let hasUpdate = false;
+  let tagAhead = false;
   try {
-      hasUpdate = semver.gt(latestClean, currentClean);
+      tagAhead = semver.gt(latestClean, currentClean);
   } catch (err) {
       logger.warn('Updater', `Invalid version comparison: ${latestClean} vs ${currentClean}`, err);
       return { hasUpdate: false, current, latest: null };
   }
 
-  return {
-    hasUpdate,
-    current,
-    latest: {
-      version: latest.tag_name,
-      url: latest.html_url,
-      date: latest.published_at,
-      notes: latest.body
-    }
+  const latestInfo = {
+    version: latest.tag_name,
+    url: latest.html_url,
+    date: latest.published_at,
+    notes: latest.body,
   };
+
+  const config = await getConfig();
+
+  if (!tagAhead) {
+    // We're current. Record the digest we're running on (if not already) so a
+    // later tag-ahead check has a baseline to reconcile against — the digest
+    // the registry serves now is, by definition, the image this version runs.
+    if (!config.autoUpdate.appliedImageDigest) {
+      const seedDigest = await getRemoteImageDigest();
+      if (seedDigest) {
+        await updateConfig({
+          autoUpdate: { ...config.autoUpdate, appliedImageDigest: seedDigest },
+        });
+      }
+    }
+    return { hasUpdate: false, current, latest: latestInfo };
+  }
+
+  // The release tag is ahead. Reconcile against the *actual* image so we don't
+  // advertise an update that would pull an unchanged image (the tag→image
+  // window). Compare the registry's current `:latest` digest to the digest we
+  // last applied. Equal → the new image isn't published yet → "building".
+  const remoteDigest = await getRemoteImageDigest();
+  const appliedDigest = config.autoUpdate.appliedImageDigest;
+
+  // If we can't resolve the remote digest (registry unreachable / no podman),
+  // fall back to the tag check alone — never block a genuine update on a
+  // transient digest-lookup failure, and never claim "building" on unknown.
+  if (!remoteDigest || !appliedDigest) {
+    return { hasUpdate: true, current, latest: latestInfo };
+  }
+
+  if (remoteDigest === appliedDigest) {
+    // Tag advanced but the image we're running is still what the registry
+    // serves — the new image is still building. Not actionable yet.
+    return { hasUpdate: false, imageBuilding: true, current, latest: latestInfo };
+  }
+
+  return { hasUpdate: true, current, latest: latestInfo };
 }
 
 /**
@@ -164,21 +269,59 @@ export function scheduleUpdateNotifier(): void {
   logger.info('Updater', `Update-notification poll scheduled every ${NOTIFY_INTERVAL_MS / 3600000}h`);
 }
 
-export async function performUpdate(version: string) {
+export interface PerformUpdateResult {
+  success: boolean;
+  /** True when the image actually advanced and a restart was triggered. */
+  updated: boolean;
+  message: string;
+}
+
+export async function performUpdate(version: string): Promise<PerformUpdateResult> {
   try {
     emitProgress('init', 0, 'Initializing update...');
     const executor = getExecutor('Local');
-    
+
+    // Capture the digest we're running on *before* pulling, so we can tell
+    // whether the pull actually advanced us to a new image — never report a
+    // silent success no-op (memory feedback_dont_mask_failures).
+    const config = await getConfig();
+    const beforeDigest = config.autoUpdate.appliedImageDigest ?? null;
+
     // 1. Pull new image
     logger.info('updater', `Pulling new image for version ${version}...`);
     emitProgress('download', 0, 'Pulling new image...');
-    
+
     // Pulls can take time on slower links; extend timeout to avoid premature failure
     const { stdout, stderr } = await executor.exec('podman pull ghcr.io/mdopp/servicebay:latest', { timeoutMs: 5 * 60 * 1000 });
     const pullOutput = [stdout.trim(), stderr.trim()].filter(Boolean).join(' | ');
     const safeOutput = pullOutput.length > 800 ? `${pullOutput.slice(0, 800)}...` : pullOutput;
+
+    // What does the registry serve now, after the pull? If it matches the
+    // digest we were already running, nothing changed — the image isn't ready
+    // yet (the release tag raced ahead of the image push). Report it honestly
+    // and skip the pointless restart.
+    const afterDigest = await getRemoteImageDigest();
+    const imageChanged = afterDigest !== null && afterDigest !== beforeDigest;
+
+    if (afterDigest !== null && !imageChanged) {
+      const message =
+        'Already on the latest image — the new version is still building. Try again shortly.';
+      logger.info('updater', message);
+      emitProgress('download', 100, message);
+      if (global.updaterIO) global.updaterIO.emit('update:noop', { message });
+      return { success: true, updated: false, message };
+    }
+
     const downloadMessage = safeOutput ? `Image pulled successfully. podman pull output: ${safeOutput}` : 'Image pulled successfully.';
     emitProgress('download', 100, downloadMessage);
+
+    // Persist the digest we advanced to so the next availability check knows
+    // what we're actually running (closes the tag→image false-positive window).
+    if (afterDigest) {
+      await updateConfig({
+        autoUpdate: { ...config.autoUpdate, appliedImageDigest: afterDigest },
+      });
+    }
 
     // 2. Restart via systemd instead of auto-update to ensure deterministic restart
     logger.info('updater', 'Restarting service...');
@@ -186,7 +329,7 @@ export async function performUpdate(version: string) {
     await executor.exec('systemctl --user restart --no-block servicebay.service');
     emitProgress('restart', 100, 'Restart triggered. ServiceBay will restart with the new image.');
 
-    return { success: true };
+    return { success: true, updated: true, message: 'Update applied. Service is restarting with the new image.' };
   } catch (e) {
     logger.error('updater', 'Update failed:', e);
     const message = e instanceof Error ? e.message : 'Unknown error';

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/helpers.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/helpers.ts
@@ -19,6 +19,12 @@ export const DEFAULT_TEMPLATE_SCHEMA: Record<string, TemplateSettingsSchemaEntry
 export interface AppUpdateStatus {
   hasUpdate: boolean;
   current: string;
+  /**
+   * Release tag is ahead but the `:latest` image hasn't been published yet
+   * (release-please cuts the tag before the Release workflow pushes the image).
+   * Shown as "new version building" rather than an actionable update.
+   */
+  imageBuilding?: boolean;
   latest: {
     version: string;
     url: string;

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
@@ -13,7 +13,7 @@ export default function UpdatesSection() {
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
 
-  const [updateStatus, setUpdateStatus] = useState<'idle' | 'updating' | 'restarting' | 'error' | 'success'>('idle');
+  const [updateStatus, setUpdateStatus] = useState<'idle' | 'updating' | 'restarting' | 'error' | 'success' | 'building'>('idle');
   const [updateProgress, setUpdateProgress] = useState(0);
   const [updateMessage, setUpdateMessage] = useState('');
   const [updateError, setUpdateError] = useState('');
@@ -135,6 +135,8 @@ export default function UpdatesSection() {
         const latestVer = data.latest?.version || 'Unknown';
         if (data.hasUpdate) {
           addToast('success', 'Update available', `Version ${latestVer} is available.`);
+        } else if (data.imageBuilding) {
+          addToast('info', 'New version building', `Version ${latestVer} was released but its image is still building. Try again shortly.`);
         } else {
           addToast('info', 'System up to date', `You are using the latest version (${latestVer}).`);
         }
@@ -176,6 +178,15 @@ export default function UpdatesSection() {
           setUpdateMessage('Service is restarting. This page will reload automatically...');
           setTimeout(() => { window.location.reload(); }, 5000);
         }
+      });
+
+      socket.on('update:noop', (data: { message: string }) => {
+        // The pull found no newer image (the tag raced ahead of the image
+        // push). Report it honestly instead of leaving the spinner running or
+        // claiming success — no silent no-op (feedback_dont_mask_failures).
+        setUpdateStatus('building');
+        setUpdateMessage(data.message);
+        socket.disconnect();
       });
 
       socket.on('update:error', (data: { error: string }) => {
@@ -273,6 +284,11 @@ export default function UpdatesSection() {
                   <Download size={16} />
                   <span className="text-sm font-medium">New version available: {appUpdate.latest.version}</span>
                 </div>
+              ) : appUpdate.imageBuilding && appUpdate.latest ? (
+                <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                  <Clock size={16} />
+                  <span className="text-sm font-medium">Version {appUpdate.latest.version} released — image still building, try again shortly</span>
+                </div>
               ) : (
                 <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
                   <Clock size={16} />
@@ -312,6 +328,10 @@ export default function UpdatesSection() {
                 <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
                   <XCircle size={32} />
                 </div>
+              ) : updateStatus === 'building' ? (
+                <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 rounded-full flex items-center justify-center mx-auto">
+                  <Clock size={32} />
+                </div>
               ) : updateStatus === 'restarting' ? (
                 <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center mx-auto animate-pulse">
                   <CheckCircle2 size={32} />
@@ -325,8 +345,9 @@ export default function UpdatesSection() {
               <div>
                 <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
                   {updateStatus === 'error' ? 'Update Failed' :
-                    updateStatus === 'restarting' ? 'Update Complete' :
-                      'Updating ServiceBay'}
+                    updateStatus === 'building' ? 'New Version Still Building' :
+                      updateStatus === 'restarting' ? 'Update Complete' :
+                        'Updating ServiceBay'}
                 </h3>
                 <p className="text-gray-500 dark:text-gray-400 text-sm">
                   {updateStatus === 'error' ? updateError : updateMessage}
@@ -339,7 +360,7 @@ export default function UpdatesSection() {
                 </div>
               )}
 
-              {updateStatus === 'error' && (
+              {(updateStatus === 'error' || updateStatus === 'building') && (
                 <button
                   onClick={() => setUpdateStatus('idle')}
                   className="px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors font-medium text-sm"

--- a/packages/frontend/src/app/api/system/hermes/chat/route.test.ts
+++ b/packages/frontend/src/app/api/system/hermes/chat/route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /api/system/hermes/chat (#1760) — the maintenance-chat history seam.
+ *
+ * The GET handler resolves the maintenance session server-side and returns its
+ * persisted conversation so the panel can restore it on mount. The Hermes key
+ * never leaves the backend. Covers the happy path (messages returned) and the
+ * graceful 503 when Hermes is unconfigured / unreachable.
+ *
+ * The backend client (`@/lib/hermes/client`) and config are mocked so the test
+ * exercises the route's wiring (configured guard, session resolve, 503 mapping)
+ * without a live Hermes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getMessages: vi.fn(),
+  getOrCreateMaintenanceSession: vi.fn(),
+  configuredRef: { value: true },
+}));
+const { getMessages, getOrCreateMaintenanceSession, configuredRef } = mocks;
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => ({})),
+}));
+
+vi.mock('@/lib/hermes/client', () => {
+  class FakeHermesError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    HermesError: FakeHermesError,
+    resolveHermesConnection: vi.fn(() => ({ baseUrl: 'http://127.0.0.1:8642', apiKey: 'k' })),
+    HermesClient: class {
+      get configured() {
+        return mocks.configuredRef.value;
+      }
+      getMessages = mocks.getMessages;
+    },
+    getOrCreateMaintenanceSession: mocks.getOrCreateMaintenanceSession,
+  };
+});
+
+import { GET } from './route';
+import { HermesError } from '@/lib/hermes/client';
+
+function req(): NextRequest {
+  return new NextRequest('http://localhost/api/system/hermes/chat');
+}
+
+describe('GET /api/system/hermes/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configuredRef.value = true;
+    getOrCreateMaintenanceSession.mockResolvedValue('maint-1');
+  });
+
+  it('returns the maintenance session messages on the happy path', async () => {
+    getMessages.mockResolvedValue([
+      { role: 'user', text: 'hi' },
+      { role: 'assistant', text: 'hello' },
+    ]);
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.messages).toEqual([
+      { role: 'user', text: 'hi' },
+      { role: 'assistant', text: 'hello' },
+    ]);
+    expect(getOrCreateMaintenanceSession).toHaveBeenCalledTimes(1);
+    expect(getMessages).toHaveBeenCalledWith('maint-1');
+  });
+
+  it('returns a graceful 503 when Hermes is not configured', async () => {
+    configuredRef.value = false;
+    const res = await GET(req());
+    expect(res.status).toBe(503);
+    expect(getOrCreateMaintenanceSession).not.toHaveBeenCalled();
+  });
+
+  it('returns a graceful 503 when Hermes is unreachable', async () => {
+    getMessages.mockRejectedValue(new HermesError('Hermes is unreachable'));
+    const res = await GET(req());
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    // Non-leaking message, no key.
+    expect(JSON.stringify(body)).not.toContain('Bearer');
+    expect(body.error).toMatch(/Hermes is unavailable/i);
+  });
+});

--- a/packages/frontend/src/app/api/system/hermes/chat/route.test.ts
+++ b/packages/frontend/src/app/api/system/hermes/chat/route.test.ts
@@ -15,10 +15,11 @@ import { NextRequest } from 'next/server';
 
 const mocks = vi.hoisted(() => ({
   getMessages: vi.fn(),
+  chat: vi.fn(),
   getOrCreateMaintenanceSession: vi.fn(),
   configuredRef: { value: true },
 }));
-const { getMessages, getOrCreateMaintenanceSession, configuredRef } = mocks;
+const { getMessages, chat, getOrCreateMaintenanceSession, configuredRef } = mocks;
 
 vi.mock('@/lib/config', () => ({
   getConfig: vi.fn(async () => ({})),
@@ -40,16 +41,39 @@ vi.mock('@/lib/hermes/client', () => {
         return mocks.configuredRef.value;
       }
       getMessages = mocks.getMessages;
+      chat = mocks.chat;
     },
     getOrCreateMaintenanceSession: mocks.getOrCreateMaintenanceSession,
   };
 });
 
-import { GET } from './route';
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandler:
+    (_opts: unknown, handler: (ctx: { body?: unknown; auth?: unknown }) => Promise<Response>) =>
+    async (request: NextRequest) => {
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        body = undefined;
+      }
+      return handler({ body, auth: { user: 'op' } });
+    },
+}));
+
+import { GET, POST } from './route';
 import { HermesError } from '@/lib/hermes/client';
 
 function req(): NextRequest {
   return new NextRequest('http://localhost/api/system/hermes/chat');
+}
+
+function postReq(input: string): NextRequest {
+  return new NextRequest('http://localhost/api/system/hermes/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input }),
+  });
 }
 
 describe('GET /api/system/hermes/chat', () => {
@@ -91,5 +115,46 @@ describe('GET /api/system/hermes/chat', () => {
     // Non-leaking message, no key.
     expect(JSON.stringify(body)).not.toContain('Bearer');
     expect(body.error).toMatch(/Hermes is unavailable/i);
+  });
+});
+
+describe('POST /api/system/hermes/chat — 401 vs unreachable distinction (#1761)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configuredRef.value = true;
+    getOrCreateMaintenanceSession.mockResolvedValue('maint-1');
+  });
+
+  it('returns the reply on the happy path', async () => {
+    chat.mockResolvedValue('hi there');
+    const res = await POST(postReq('hello'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reply).toBe('hi there');
+  });
+
+  it('surfaces a DISTINCT key-mismatch message on a Hermes 401', async () => {
+    chat.mockRejectedValue(new HermesError('Hermes returned 401', 401));
+    const res = await POST(postReq('hello'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    // Distinct, actionable message that points at the reconcile heal-action.
+    expect(body.error).toMatch(/authentication failed/i);
+    expect(body.error).toMatch(/reconcile/i);
+    // Must NOT be the generic "is it running?" outage line.
+    expect(body.error).not.toMatch(/is the hermes service running/i);
+    // Never leaks the key.
+    expect(JSON.stringify(body)).not.toContain('Bearer');
+  });
+
+  it('surfaces the generic outage message on a genuine connection failure', async () => {
+    // Transport error → HermesError with no status.
+    chat.mockRejectedValue(new HermesError('Hermes is unreachable'));
+    const res = await POST(postReq('hello'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/is the hermes service running/i);
+    // Must NOT claim an auth failure for a plain outage.
+    expect(body.error).not.toMatch(/authentication failed/i);
   });
 });

--- a/packages/frontend/src/app/api/system/hermes/chat/route.ts
+++ b/packages/frontend/src/app/api/system/hermes/chat/route.ts
@@ -29,6 +29,44 @@ const bodySchema = z.object({
   input: z.string().min(1, 'input is required'),
 });
 
+/**
+ * Load the maintenance session's persisted conversation so the panel can
+ * restore it on mount (#1760). Same server-side seam as POST — the Hermes key
+ * never leaves the backend. GET is non-mutating so it skips the requireSession
+ * gate; `/api/system/*` is gated by the proxy. Returns `{ messages }` on 200,
+ * a graceful 503 when Hermes is not configured / unreachable.
+ */
+export const GET = withApiHandler({}, async ({ auth }) => {
+  const userId = auth?.user ?? 'servicebay-operator';
+
+  const config = await getConfig();
+  const conn = resolveHermesConnection(config);
+  const client = new HermesClient(conn);
+
+  if (!client.configured) {
+    return apiError(new Error('Hermes is not configured on this server'), {
+      status: 503,
+      tag: 'hermes',
+      exposeMessage: true,
+    });
+  }
+
+  try {
+    const sessionId = await getOrCreateMaintenanceSession(client, userId);
+    const messages = await client.getMessages(sessionId);
+    return NextResponse.json({ messages });
+  } catch (e) {
+    if (e instanceof HermesError) {
+      return apiError(new Error('Hermes is unavailable. Is the Hermes service running?'), {
+        status: 503,
+        tag: 'hermes',
+        exposeMessage: true,
+      });
+    }
+    return apiError(e, { tag: 'hermes' });
+  }
+});
+
 export const POST = withApiHandler({ body: bodySchema }, async ({ body, auth }) => {
   // The session gate guarantees `auth` is set on this mutating route.
   const userId = auth?.user ?? 'servicebay-operator';

--- a/packages/frontend/src/app/api/system/hermes/chat/route.ts
+++ b/packages/frontend/src/app/api/system/hermes/chat/route.ts
@@ -11,6 +11,23 @@ import {
 } from '@/lib/hermes/client';
 
 /**
+ * Turn a thrown {@link HermesError} into the right 503 message. A `401`
+ * means Hermes is reachable but rejected the bearer key — ServiceBay's
+ * stored key has drifted from the externally-deployed engine's
+ * `API_SERVER_KEY` (#1761). That is a DISTINCT, actionable failure from a
+ * genuine outage, so it gets a distinct message pointing at the reconcile
+ * heal-action, never the "Is the Hermes service running?" line used for a
+ * real connection failure. Both stay 503 (the assistant is unavailable to
+ * the caller either way) and never leak the key.
+ */
+function hermesUnavailableMessage(e: HermesError): string {
+  if (e.status === 401) {
+    return 'Hermes authentication failed — the stored API key does not match the running engine. Open Settings → Self-Diagnose and run "Reconcile Hermes API key".';
+  }
+  return 'Hermes is unavailable. Is the Hermes service running?';
+}
+
+/**
  * Maintenance-chat seam (#1754, epic #1704) — the native chat panel (#1755,
  * part B) POSTs operator turns here.
  *
@@ -57,7 +74,7 @@ export const GET = withApiHandler({}, async ({ auth }) => {
     return NextResponse.json({ messages });
   } catch (e) {
     if (e instanceof HermesError) {
-      return apiError(new Error('Hermes is unavailable. Is the Hermes service running?'), {
+      return apiError(new Error(hermesUnavailableMessage(e)), {
         status: 503,
         tag: 'hermes',
         exposeMessage: true,
@@ -91,8 +108,10 @@ export const POST = withApiHandler({ body: bodySchema }, async ({ body, auth }) 
     if (e instanceof HermesError) {
       // Hermes unreachable or returned an error — surface as 503 so the
       // panel can show "the assistant is unavailable" without leaking the
-      // key or internal detail.
-      return apiError(new Error('Hermes is unavailable. Is the Hermes service running?'), {
+      // key or internal detail. A 401 (key drift) gets a DISTINCT message
+      // pointing at the reconcile heal-action (#1761), not the generic
+      // "is it running?" line.
+      return apiError(new Error(hermesUnavailableMessage(e)), {
         status: 503,
         tag: 'hermes',
         exposeMessage: true,

--- a/packages/frontend/src/components/HermesChatPanel.test.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.test.tsx
@@ -1,13 +1,14 @@
 /**
- * HermesChatPanel tests (#1755, part B of epic #1704).
+ * HermesChatPanel tests (#1755, part B of epic #1704; #1760 history reload).
  *
- * Covers: empty state, send -> calls POST /api/system/hermes/chat and shows
- * the reply, the 503 "Hermes is unavailable" graceful state, and the typing
- * indicator while a turn is in flight.
+ * Covers: mount-time history load (GET) + empty state, send -> calls POST
+ * /api/system/hermes/chat and shows the reply, the 503 "Hermes is unavailable"
+ * graceful state, and the typing indicator while a turn is in flight.
  *
  * fetch is mocked with mockImplementation returning a FRESH Response per call
  * (memory feedback_vitest_fetch_response_reuse — a shared Response body can
- * only be read once, so parallel/sequential reads hang).
+ * only be read once, so parallel/sequential reads hang). The mount GET and a
+ * subsequent POST are routed by method so each gets its own fresh Response.
  *
  * No @testing-library/jest-dom in this repo's setup, so assertions use
  * toBeDefined/toBeNull/textContent (matching the existing FE test style).
@@ -23,6 +24,23 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+/**
+ * Mock fetch routing GET (mount history) and POST (send) separately, a fresh
+ * Response per call. `get` defaults to an empty history so a test that only
+ * cares about send doesn't have to spell it out.
+ */
+function mockFetch(handlers: {
+  get?: () => Response;
+  post?: () => Response;
+}) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+    if ((init?.method ?? 'GET') === 'GET') {
+      return handlers.get ? handlers.get() : jsonResponse(200, { messages: [] });
+    }
+    return handlers.post ? handlers.post() : jsonResponse(200, { reply: '' });
+  });
+}
+
 describe('HermesChatPanel', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -31,18 +49,55 @@ describe('HermesChatPanel', () => {
     vi.restoreAllMocks();
   });
 
-  it('shows the empty maintenance-assistant state before any message', () => {
+  it('shows the empty maintenance-assistant state when the history loads empty', async () => {
+    mockFetch({ get: () => jsonResponse(200, { messages: [] }) });
     render(<HermesChatPanel />);
-    expect(screen.getByText(/Maintenance assistant/i)).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText(/Maintenance assistant/i)).toBeDefined();
+    });
     expect(screen.queryByTestId('hermes-msg-user')).toBeNull();
   });
 
-  it('sends a message to /api/system/hermes/chat and renders the reply', async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, 'fetch')
-      .mockImplementation(async () => jsonResponse(200, { reply: 'Here is your plan.' }));
+  it('loads and renders the prior conversation on mount (GET history)', async () => {
+    const fetchMock = mockFetch({
+      get: () =>
+        jsonResponse(200, {
+          messages: [
+            { role: 'user', text: 'what is broken?' },
+            { role: 'assistant', text: 'Let me check your services.' },
+          ],
+        }),
+    });
 
     render(<HermesChatPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('what is broken?')).toBeDefined();
+      expect(screen.getByText('Let me check your services.')).toBeDefined();
+    });
+    // The empty state must NOT show once history is present.
+    expect(screen.queryByText(/Maintenance assistant/i)).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/system/hermes/chat',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('falls back to the empty state when the history GET 503s', async () => {
+    mockFetch({ get: () => jsonResponse(503, { error: 'Hermes is unavailable.' }) });
+    render(<HermesChatPanel />);
+    await waitFor(() => {
+      expect(screen.getByText(/Maintenance assistant/i)).toBeDefined();
+    });
+    expect(screen.queryByTestId('hermes-msg-assistant')).toBeNull();
+  });
+
+  it('sends a message to /api/system/hermes/chat and renders the reply', async () => {
+    const fetchMock = mockFetch({ post: () => jsonResponse(200, { reply: 'Here is your plan.' }) });
+
+    render(<HermesChatPanel />);
+    // Wait for the mount history load to settle (empty) before sending.
+    await waitFor(() => expect(screen.getByText(/Maintenance assistant/i)).toBeDefined());
     const input = screen.getByTestId('hermes-input');
     fireEvent.change(input, { target: { value: 'help me' } });
     fireEvent.click(screen.getByTestId('hermes-send'));
@@ -64,11 +119,14 @@ describe('HermesChatPanel', () => {
   });
 
   it('shows the "Hermes is unavailable" notice on a 503 and does not append an assistant turn', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
-      jsonResponse(503, { error: 'Hermes is unavailable. Is the Hermes service running?' }),
-    );
+    // History loads empty; the send POST 503s.
+    mockFetch({
+      post: () =>
+        jsonResponse(503, { error: 'Hermes is unavailable. Is the Hermes service running?' }),
+    });
 
     render(<HermesChatPanel />);
+    await waitFor(() => expect(screen.getByText(/Maintenance assistant/i)).toBeDefined());
     fireEvent.change(screen.getByTestId('hermes-input'), { target: { value: 'are you there?' } });
     fireEvent.click(screen.getByTestId('hermes-send'));
 
@@ -82,14 +140,17 @@ describe('HermesChatPanel', () => {
 
   it('shows a typing indicator while the reply is in flight', async () => {
     let resolveFetch: (r: Response) => void = () => {};
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          resolveFetch = resolve;
-        }),
-    );
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      // Mount history GET resolves immediately (empty); the send POST hangs
+      // until we resolve it, so the typing indicator can be observed.
+      if ((init?.method ?? 'GET') === 'GET') return jsonResponse(200, { messages: [] });
+      return new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+    });
 
     render(<HermesChatPanel />);
+    await waitFor(() => expect(screen.getByText(/Maintenance assistant/i)).toBeDefined());
     fireEvent.change(screen.getByTestId('hermes-input'), { target: { value: 'slow one' } });
     fireEvent.click(screen.getByTestId('hermes-send'));
 

--- a/packages/frontend/src/components/HermesChatPanel.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.tsx
@@ -14,6 +14,11 @@
  * of scope here). When the route returns 503 (Hermes not installed / not
  * running) we show a calm "Hermes is unavailable" notice rather than
  * crashing or pretending the message went through.
+ *
+ * On mount the panel loads the session's prior conversation via GET
+ * /api/system/hermes/chat (#1760) so leaving and returning to the page shows
+ * the history that persists server-side, rather than an empty log. A 503 on
+ * that load falls back to the empty/unavailable state.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -90,6 +95,18 @@ function TypingIndicator() {
   );
 }
 
+function LoadingState() {
+  return (
+    <div
+      data-testid="hermes-loading"
+      className="h-full flex flex-col items-center justify-center text-center text-gray-500 dark:text-gray-400 gap-3"
+    >
+      <Bot size={40} className="text-blue-500/70 animate-pulse" />
+      <p className="text-sm">Loading your conversation…</p>
+    </div>
+  );
+}
+
 function UnavailableNotice({ message }: { message: string }) {
   return (
     <div
@@ -142,13 +159,53 @@ function Composer({
   );
 }
 
+/** One persisted turn as returned by GET /api/system/hermes/chat. */
+interface HistoryMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+/**
+ * On mount, restore the prior conversation that persists server-side (#1760)
+ * via GET /api/system/hermes/chat. A 503 (Hermes down) falls back to the empty
+ * state; a transport failure does too — never crash, never fabricate. Runs
+ * once. `setMessages` populates the log; `setLoading(false)` ends the spinner.
+ */
+function useLoadHistory(setMessages: (m: ChatMessage[]) => void, setLoading: (v: boolean) => void) {
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/system/hermes/chat', { method: 'GET' });
+        if (cancelled || res.status === 503) return;
+        const body = await res.json().catch(() => ({}));
+        if (cancelled || !res.ok) return;
+        const history: HistoryMessage[] = Array.isArray(body?.messages) ? body.messages : [];
+        if (history.length > 0) setMessages(history.map((m) => makeMessage(m.role, m.text)));
+      } catch {
+        // Could not reach our own route — fall back to empty, don't crash.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
 /** Drives the conversation state + the call to the server-side chat seam. */
 function useHermesChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [sending, setSending] = useState(false);
+  // True while the mount-time history load is in flight (before any send).
+  const [loading, setLoading] = useState(true);
   // When the route reports 503 the assistant is unavailable — we surface a
   // banner rather than fabricating a reply (memory feedback_dont_mask_failures).
   const [unavailable, setUnavailable] = useState<string | null>(null);
+
+  useLoadHistory(setMessages, setLoading);
 
   const send = useCallback(
     async (text: string) => {
@@ -196,11 +253,11 @@ function useHermesChat() {
     [sending],
   );
 
-  return { messages, sending, unavailable, send };
+  return { messages, sending, loading, unavailable, send };
 }
 
 export default function HermesChatPanel() {
-  const { messages, sending, unavailable, send } = useHermesChat();
+  const { messages, sending, loading, unavailable, send } = useHermesChat();
   const [input, setInput] = useState('');
   const logRef = useRef<HTMLDivElement>(null);
 
@@ -227,7 +284,8 @@ export default function HermesChatPanel() {
     [submit],
   );
 
-  const showEmptyState = messages.length === 0 && !sending && !unavailable;
+  const showLoading = loading && messages.length === 0;
+  const showEmptyState = !showLoading && messages.length === 0 && !sending && !unavailable;
 
   return (
     <div className="h-full flex flex-col p-4 gap-4">
@@ -236,6 +294,7 @@ export default function HermesChatPanel() {
         data-testid="hermes-chat-log"
         className="flex-1 min-h-0 overflow-y-auto rounded-2xl border border-gray-200/70 dark:border-white/5 bg-white/60 dark:bg-white/[0.02] backdrop-blur p-4 space-y-4"
       >
+        {showLoading && <LoadingState />}
         {showEmptyState && <EmptyState />}
         {messages.map((m) => (
           <MessageBubble key={m.id} message={m} />


### PR DESCRIPTION
## What
- **#1760** /chat panel reloads the prior maintenance conversation on mount via a server-side history GET (key stays server-side); fresh session shows empty; graceful empty on Hermes 503.
- **#1761** (security) Hermes API key reconcile-not-generate at (re)deploy + a new `reconcile_hermes_api_key` diagnose heal-action that reads the running engine's `API_SERVER_KEY` and adopts it into encrypted `installedSecrets`; the chat route now surfaces a distinct "Hermes auth failed — key mismatch" (401) message vs the generic "is the service running?" outage message.
- **#1762** "Update available" is gated on the `:latest` image manifest digest actually being newer than the applied one (not just the release tag, which is cut before the image is pushed); "Update now" compares pulled digest pre/post and reports already-latest / image-still-building instead of a silent success no-op.

## Why
Closes #1760
Closes #1761
Closes #1762

## Risk
Medium — #1761 touches the install credential-capture path (HERMES_API_KEY, reconcile-only, key never logged/returned) and #1762 adds an additive optional `config.autoUpdate.appliedImageDigest` field; both are path-mandated and box-verified after merge.

## Rollback
git revert is enough (additive config field, no data migration; reconcile is idempotent no-op when aligned).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full: 2400 passed / 2 skipped)
- [x] backend + frontend tsc --noEmit clean
- [x] npm run build clean
- [ ] /verify on FCoS :dev box (path-mandated: lib/install/ from #1761, lib/config.ts from #1762)

<!-- sb-ai-comment -->
AI-generated