### PR TITLE
feat: maintenance-chat markdown + MCP reboot-scope split + MCP approval gate + SSO login smoke

### DIFF
--- a/.claude/skills/autoloop-issues/stages/box-verify.md
+++ b/.claude/skills/autoloop-issues/stages/box-verify.md
@@ -22,6 +22,17 @@ The verify gate is two-sided and you own the second side:
 1. **Flip to dev.** `sb channel dev` (or `POST /api/system/channel`). Invocation/payload: `tools/sb/internal/rest/channel.go`, `tools/sb/internal/ui/channel.go`, `packages/backend/src/lib/servicebayChannel.ts`.
 2. **Wait (bounded) for the dev image to land.** Poll the box's running image/version until it matches the newest merged SHA. **Timeout ≤15 min** (release.yml build + box pull + restart). If it never lands, treat as a verify failure (step 5, reason "dev image didn't land").
 3. **Verify.** Run `/verify` against `<SERVICEBAY_BOX>`, exercising the merged path-mandated changes (`box_verify.detail` names which paths). Sweep stray `*.bak` before reinstall-style checks (memory `feedback_hermes_config_bak_selinux`).
+   - **SSO login smoke (mandatory release gate, #1561).** Whenever the verify covers an **auth / install / OIDC** path — i.e. `box_verify.detail` touches `lib/install/`, `lib/config.ts`, anything under auth/Authelia/OIDC/LLDAP, or this is a reinstall-style verify — you **must** drive the real per-service login flow and assert it passes. Two layers, both required:
+     - **Server-side spine:** run the `sso_verify` probe (the create→login→per-domain→admin-reject→delete spine, `lib/diagnose/ssoVerify.ts`) against the box — e.g. the diagnose `run_now` action or `verifySso({ node })`. A `report.ok === false` (a real login/domain failure, not a `couldNotRun` setup warn) is a **RED verify** — it blocks the release. This is the gate the #1559 reinstall lacked: a green `:dev` verify shipped while a reinstall was red.
+     - **Browser smoke:** read `reverseProxy.publicDomain` + the installed OIDC services off the box, then run the headless per-service login spec:
+       ```bash
+       SB_PUBLIC_DOMAIN=<publicDomain> \
+       SB_USERNAME=<admin-user> SB_PASSWORD=<admin-pass> \
+       SB_SSO_SERVICES=<installed OIDC subdomains, e.g. vault,photos,books> \
+       npm run test:e2e -- sso-login
+       ```
+       It drives the actual Authelia redirect → authenticate → authenticated-landing per service (`tests/e2e/sso-login.e2e.ts`, on the #1473 harness). A failed login on **any** service is a **RED verify**. Point login probes at a subdomain (`<svc>.<domain>` / `auth.<domain>`), never the apex (memory `reference_authelia_apex_deny_vs_wildcard`).
+     - "login works per service" is now a **mandatory assertion** — `service: up` / "page renders" is not sufficient (it passed while every login was broken in #1559). A reinstall that breaks logins must verify RED, never green.
 4. **Always flip back.** `sb channel latest` — on success, failure, **and** timeout. The box must never be left on `:dev`. If the flip-back itself fails, that's a **hard exit**: alert the user, don't leave the box stranded.
 5. **On verify red:** the change is already on `main`. Identify the culprit (a cluster keeps it attributable to one theme; an unrelated dev-box batch needs a bisect), open a **revert PR**, merge it on CI-green, and re-run this verify. (Merging a revert to `main` is safe to do here — it only republishes `:dev`; the builder is build-ahead on its own branch and doesn't touch `main` until its own seal.) Write `box-verify.json` with `status:"red"` so the orchestrator holds the release PR until it's green again.
 6. **On verify green:** write `box-verify.json` with `status:"green"` and `verified_at`. The release PR is clear for the orchestrator to merge next preflight.

--- a/packages/backend/src/lib/auth/apiScope.ts
+++ b/packages/backend/src/lib/auth/apiScope.ts
@@ -10,5 +10,17 @@
  * for the type, and the cycle is gone.
  */
 
-export type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'destroy' | 'exec';
-export const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'destroy', 'exec'];
+/**
+ * Risk tiers, least→most destructive:
+ *   read      lookups + diagnose + log readers
+ *   lifecycle start/stop/restart + run_check_now + refresh + run_backup
+ *   mutate    create/update/add + config writes — additive changes
+ *   reboot    reboot_node — transient & recoverable host restart (#1765);
+ *             split out of `destroy` so a token can grant operate+reboot
+ *             WITHOUT also granting irreversible delete/wipe. `destroy`
+ *             implies `reboot` (see tokenHasScope).
+ *   destroy   delete/restore/purge/factory_reset — irreversible state edits
+ *   exec      exec_command — shell access
+ */
+export type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'reboot' | 'destroy' | 'exec';
+export const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'reboot', 'destroy', 'exec'];

--- a/packages/backend/src/lib/mcp/approvalGate.test.ts
+++ b/packages/backend/src/lib/mcp/approvalGate.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Approval gate (#1766): a TOKEN-authenticated MCP caller can PROPOSE a
+// destroy-tier tool but cannot execute it — the call parks for a human
+// confirm. A COOKIE caller (no token auth ⇒ `auth` undefined) executes
+// inline as before. The confirm route runs the stored call. Tested at the
+// server/safeHandler seam with the underlying mutation + side-effects mocked.
+
+// guardMutation reads config.mcp.allowMutations — allow it.
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn().mockResolvedValue({ mcp: { allowMutations: true } }),
+  updateConfig: vi.fn(),
+}));
+// Pre-mutation snapshot — make it a cheap no-op so the test doesn't try to back up.
+vi.mock('./safety', async (orig) => {
+  const actual = await orig<typeof import('./safety')>();
+  return { ...actual, snapshotBeforeMutation: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock('./audit', () => ({ recordAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./notify', () => ({ notifyDestructiveOp: vi.fn().mockResolvedValue(undefined) }));
+
+const deleteService = vi.fn().mockResolvedValue(undefined);
+const listTrashedServices = vi.fn().mockResolvedValue([]);
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: {
+    deleteService: (...a: unknown[]) => deleteService(...a),
+    listTrashedServices: (...a: unknown[]) => listTrashedServices(...a),
+  },
+}));
+vi.mock('@/lib/nodes', () => ({
+  listNodes: vi.fn().mockResolvedValue([{ Name: 'Local' }]),
+  getNodeConnection: vi.fn(),
+}));
+
+import { createMcpServer } from './server';
+import {
+  listPendingApprovals,
+  approvePendingApproval,
+  __clearPendingApprovalsForTest,
+} from './pendingApprovals';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+async function connect(opts?: Parameters<typeof createMcpServer>[0]) {
+  const server = createMcpServer(opts);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+const TOKEN_AUTH = { user: 'token:ci-bot', scopes: ['read', 'lifecycle', 'mutate', 'destroy'] as const, tokenId: 't1' };
+
+describe('MCP destructive approval gate (#1766)', () => {
+  beforeEach(() => {
+    __clearPendingApprovalsForTest();
+    deleteService.mockClear();
+  });
+
+  it('a token caller PROPOSES a destroy-tier tool — it parks, does not execute', async () => {
+    const { client } = await connect({ auth: { ...TOKEN_AUTH, scopes: [...TOKEN_AUTH.scopes] } });
+    const res = await client.callTool({ name: 'delete_service', arguments: { name: 'immich' } });
+    const text = (res.content as { text: string }[])[0].text;
+    const parsed = JSON.parse(text);
+
+    expect(parsed.status).toBe('pending_approval');
+    expect(parsed.pendingId).toBeTruthy();
+    expect(parsed.toolName).toBe('delete_service');
+    // The real mutation must NOT have run.
+    expect(deleteService).not.toHaveBeenCalled();
+    // It is now listed as pending.
+    const pending = listPendingApprovals();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].caller).toBe('token:ci-bot');
+    await client.close();
+  });
+
+  it('approving the parked call executes the stored mutation', async () => {
+    const { client } = await connect({ auth: { ...TOKEN_AUTH, scopes: [...TOKEN_AUTH.scopes] } });
+    await client.callTool({ name: 'delete_service', arguments: { name: 'immich' } });
+    const [pending] = listPendingApprovals();
+
+    expect(deleteService).not.toHaveBeenCalled();
+    await approvePendingApproval(pending.pendingId);
+    // Now the real mutation has run, with the original args.
+    expect(deleteService).toHaveBeenCalledTimes(1);
+    expect(deleteService).toHaveBeenCalledWith('Local', 'immich');
+    // Single-use: gone from the list.
+    expect(listPendingApprovals()).toHaveLength(0);
+    await client.close();
+  });
+
+  it('a COOKIE caller (no token auth) executes a destroy-tier tool inline — no gate', async () => {
+    // No `auth` ⇒ cookie path. The mutation runs immediately, nothing parks.
+    const { client } = await connect();
+    await client.callTool({ name: 'delete_service', arguments: { name: 'immich' } });
+    expect(deleteService).toHaveBeenCalledTimes(1);
+    expect(listPendingApprovals()).toHaveLength(0);
+    await client.close();
+  });
+
+  it('a non-destroy tool from a token caller is NOT gated (e.g. mutate-tier)', async () => {
+    // restart_service is lifecycle-tier — should pass straight through, not park.
+    // (delete is the destroy-tier case above; here we assert the gate is scoped.)
+    const { client } = await connect({ auth: { ...TOKEN_AUTH, scopes: [...TOKEN_AUTH.scopes] } });
+    // Use a tool we can observe didn't park: list_trashed_services is read-tier.
+    const res = await client.callTool({ name: 'list_trashed_services', arguments: {} });
+    expect((res as { isError?: boolean }).isError).toBeFalsy();
+    expect(listPendingApprovals()).toHaveLength(0);
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/pendingApprovals.test.ts
+++ b/packages/backend/src/lib/mcp/pendingApprovals.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  createPendingApproval,
+  listPendingApprovals,
+  getPendingApproval,
+  approvePendingApproval,
+  ApprovalExpiredError,
+  APPROVAL_TTL_MS,
+  __clearPendingApprovalsForTest,
+} from './pendingApprovals';
+
+describe('pendingApprovals store (#1766)', () => {
+  beforeEach(() => {
+    __clearPendingApprovalsForTest();
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('parks a proposed call and returns a handle without executing it', () => {
+    const execute = vi.fn().mockResolvedValue('ran');
+    const view = createPendingApproval({
+      toolName: 'delete_service',
+      args: { name: 'immich' },
+      caller: 'token:ci-bot',
+      execute,
+    });
+    expect(view.pendingId).toBeTruthy();
+    expect(view.toolName).toBe('delete_service');
+    expect(view.args).toEqual({ name: 'immich' });
+    expect(view.caller).toBe('token:ci-bot');
+    expect(view.expiresAt).toBeGreaterThan(Date.now());
+    // Crucially: proposing does NOT run the deferred call.
+    expect(execute).not.toHaveBeenCalled();
+    // And the handle never leaks the execute thunk to callers.
+    expect((view as unknown as Record<string, unknown>).execute).toBeUndefined();
+  });
+
+  it('lists pending approvals and looks one up by id (view only, no thunk)', () => {
+    const view = createPendingApproval({ toolName: 'factory_reset', args: {}, execute: vi.fn() });
+    const list = listPendingApprovals();
+    expect(list).toHaveLength(1);
+    expect(list[0].pendingId).toBe(view.pendingId);
+    expect((list[0] as unknown as Record<string, unknown>).execute).toBeUndefined();
+    const got = getPendingApproval(view.pendingId);
+    expect(got?.toolName).toBe('factory_reset');
+  });
+
+  it('confirm runs the deferred call and returns its result', async () => {
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const { pendingId } = createPendingApproval({ toolName: 'purge_trashed_service', args: { id: 't1' }, execute });
+    const result = await approvePendingApproval(pendingId);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('is single-use — a second confirm of the same id throws and does not re-run', async () => {
+    const execute = vi.fn().mockResolvedValue('ran');
+    const { pendingId } = createPendingApproval({ toolName: 'delete_service', args: {}, execute });
+    await approvePendingApproval(pendingId);
+    await expect(approvePendingApproval(pendingId)).rejects.toBeInstanceOf(ApprovalExpiredError);
+    expect(execute).toHaveBeenCalledTimes(1);
+    // It is also gone from the listing.
+    expect(listPendingApprovals()).toHaveLength(0);
+  });
+
+  it('throws ApprovalExpiredError for an unknown id', async () => {
+    await expect(approvePendingApproval('does-not-exist')).rejects.toBeInstanceOf(ApprovalExpiredError);
+  });
+
+  it('expires a parked call after the TTL — confirm and listing both drop it', async () => {
+    vi.useFakeTimers();
+    const execute = vi.fn().mockResolvedValue('ran');
+    const { pendingId } = createPendingApproval({ toolName: 'restore_backup', args: {}, execute });
+    expect(listPendingApprovals()).toHaveLength(1);
+    // Advance past the TTL.
+    vi.advanceTimersByTime(APPROVAL_TTL_MS + 1000);
+    expect(listPendingApprovals()).toHaveLength(0);
+    await expect(approvePendingApproval(pendingId)).rejects.toBeInstanceOf(ApprovalExpiredError);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('honours a custom ttl', () => {
+    vi.useFakeTimers();
+    const before = Date.now();
+    const view = createPendingApproval({ toolName: 'delete_service', args: {}, execute: vi.fn(), ttlMs: 1000 });
+    expect(view.expiresAt).toBe(before + 1000);
+  });
+});

--- a/packages/backend/src/lib/mcp/pendingApprovals.ts
+++ b/packages/backend/src/lib/mcp/pendingApprovals.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'crypto';
+
+/**
+ * Native per-tool approval gate for destructive MCP tools (#1766).
+ *
+ * Token-authenticated MCP callers (the "agent") can *propose* a destructive
+ * tool call but cannot *execute* it: the call is parked here as a pending
+ * approval and the agent gets back a handle instead of a result. A human,
+ * authenticated with a session **cookie** (never a Bearer token — see the
+ * confirm route), then approves the specific pending call and it runs. The
+ * proposing token holder has no path to self-approve.
+ *
+ * The store is intentionally in-memory and single-process:
+ *   - approvals are short-lived (TTL ~5 min) and don't survive a restart by
+ *     design — a stale, abandoned destructive proposal should evaporate, not
+ *     linger on disk to be approved hours later.
+ *   - single-use: claiming an approval removes it, so a confirmed call can't
+ *     be replayed.
+ *
+ * `execute` is the deferred tail of `safeHandler` (snapshot → real handler →
+ * audit/notify side-effects), captured as a thunk at propose time so the
+ * approved call runs through exactly the same safety path it would have run
+ * inline, just gated on the human confirm.
+ */
+
+/** Default time a pending approval stays claimable before it expires. */
+export const APPROVAL_TTL_MS = 5 * 60 * 1000;
+
+export interface PendingApproval {
+  pendingId: string;
+  toolName: string;
+  /** The arguments the tool was invoked with (for the human to review). */
+  args: Record<string, unknown>;
+  /** Who proposed it — e.g. `token:ci-bot`. */
+  caller?: string;
+  /** Epoch ms at which the approval expires and can no longer be claimed. */
+  expiresAt: number;
+  /**
+   * The deferred call. Runs the snapshot + real handler + audit/notify tail
+   * exactly as the inline path would have. Resolves to the tool result.
+   */
+  execute: () => Promise<unknown>;
+}
+
+/** Public view of a pending approval — never exposes the `execute` thunk. */
+export interface PendingApprovalView {
+  pendingId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  caller?: string;
+  expiresAt: number;
+}
+
+const store = new Map<string, PendingApproval>();
+
+function isExpired(entry: PendingApproval, now: number): boolean {
+  return entry.expiresAt <= now;
+}
+
+/** Drop every expired entry. Called opportunistically on each access. */
+function sweep(now: number = Date.now()): void {
+  for (const [id, entry] of store) {
+    if (isExpired(entry, now)) store.delete(id);
+  }
+}
+
+function toView(entry: PendingApproval): PendingApprovalView {
+  return {
+    pendingId: entry.pendingId,
+    toolName: entry.toolName,
+    args: entry.args,
+    caller: entry.caller,
+    expiresAt: entry.expiresAt,
+  };
+}
+
+/**
+ * Register a destructive tool call as pending human approval. Returns the
+ * handle the proposing (token) caller gets back in place of a tool result.
+ */
+export function createPendingApproval(input: {
+  toolName: string;
+  args: Record<string, unknown>;
+  caller?: string;
+  execute: () => Promise<unknown>;
+  ttlMs?: number;
+}): PendingApprovalView {
+  sweep();
+  const pendingId = randomUUID();
+  const entry: PendingApproval = {
+    pendingId,
+    toolName: input.toolName,
+    args: input.args,
+    caller: input.caller,
+    expiresAt: Date.now() + (input.ttlMs ?? APPROVAL_TTL_MS),
+    execute: input.execute,
+  };
+  store.set(pendingId, entry);
+  return toView(entry);
+}
+
+/** List the currently-claimable pending approvals (expired ones swept out). */
+export function listPendingApprovals(): PendingApprovalView[] {
+  sweep();
+  return [...store.values()].map(toView);
+}
+
+/** Look up a single pending approval without claiming it. */
+export function getPendingApproval(pendingId: string): PendingApprovalView | undefined {
+  sweep();
+  const entry = store.get(pendingId);
+  return entry ? toView(entry) : undefined;
+}
+
+export class ApprovalExpiredError extends Error {
+  constructor(public readonly pendingId: string) {
+    super(`Approval ${pendingId} has expired or does not exist`);
+    this.name = 'ApprovalExpiredError';
+  }
+}
+
+/**
+ * Approve and run a pending call. Single-use: the entry is removed before the
+ * deferred handler runs, so it can't be confirmed twice or replayed even if
+ * the underlying call is slow. Throws {@link ApprovalExpiredError} when the id
+ * is unknown or expired.
+ */
+export async function approvePendingApproval(pendingId: string): Promise<unknown> {
+  sweep();
+  const entry = store.get(pendingId);
+  if (!entry || isExpired(entry, Date.now())) {
+    store.delete(pendingId);
+    throw new ApprovalExpiredError(pendingId);
+  }
+  // Claim (single-use) BEFORE executing so a concurrent confirm can't double-run.
+  store.delete(pendingId);
+  return entry.execute();
+}
+
+/** Test-only: clear all pending approvals. */
+export function __clearPendingApprovalsForTest(): void {
+  store.clear();
+}

--- a/packages/backend/src/lib/mcp/server.test.ts
+++ b/packages/backend/src/lib/mcp/server.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createMcpServer } from './server';
+import { createMcpServer, TOOL_SCOPES, tokenHasScope } from './server';
+import { ALL_SCOPES } from '@/lib/auth/apiScope';
 
 // #1732: the MCP server describes itself — a top-level `instructions` string
 // teaching the node → service → container model, and the four
@@ -89,5 +90,43 @@ describe('update_service_yaml / get_service_files field-name footgun (#1752)', (
     const text = JSON.stringify(res.content);
     expect(text).toMatch(/Quadlet|Pod[- ]spec/i);
     await client.close();
+  });
+});
+
+// #1765: reboot_node is split out of the `destroy` tier into its own
+// `reboot` tier — a reboot is transient/recoverable and must NOT require
+// granting irreversible delete/wipe via `destroy`. `destroy` keeps
+// implying `reboot` for legacy-token back-compat.
+describe('reboot scope split (#1765)', () => {
+  it('classifies reboot_node as the reboot tier, not destroy', () => {
+    expect(TOOL_SCOPES.reboot_node).toBe('reboot');
+  });
+
+  it('keeps the irreversible tools in destroy', () => {
+    expect(TOOL_SCOPES.delete_service).toBe('destroy');
+    expect(TOOL_SCOPES.factory_reset).toBe('destroy');
+    expect(TOOL_SCOPES.purge_trashed_service).toBe('destroy');
+    // set_boot_next_usb stays destroy — it can arm a USB-installer reboot.
+    expect(TOOL_SCOPES.set_boot_next_usb).toBe('destroy');
+  });
+
+  it('exposes reboot as a mintable scope', () => {
+    expect(ALL_SCOPES).toContain('reboot');
+  });
+
+  it('lets an operate token reboot but refuses delete/factory_reset', () => {
+    const operate = ['read', 'lifecycle', 'mutate', 'reboot'] as const;
+    expect(tokenHasScope(operate, TOOL_SCOPES.restart_service)).toBe(true);
+    expect(tokenHasScope(operate, TOOL_SCOPES.reboot_node)).toBe(true);
+    expect(tokenHasScope(operate, TOOL_SCOPES.delete_service)).toBe(false);
+    expect(tokenHasScope(operate, TOOL_SCOPES.factory_reset)).toBe(false);
+  });
+
+  it('lets a legacy destroy token still reboot (back-compat)', () => {
+    expect(tokenHasScope(['read', 'destroy'], 'reboot')).toBe(true);
+  });
+
+  it('does not let a reboot grant imply destroy', () => {
+    expect(tokenHasScope(['reboot'], 'destroy')).toBe(false);
   });
 });

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -81,7 +81,10 @@ const MUTATING_TOOLS = new Set([
  *   read       lookups + diagnose + log readers
  *   lifecycle  start/stop/restart + run_check_now + refresh + run_backup
  *   mutate     create/update/add + config writes — additive changes
- *   destroy    delete/restore/purge — irreversible state edits
+ *   reboot     reboot_node — transient, recoverable host restart (#1765),
+ *              split off `destroy` so a token can operate+reboot without
+ *              also granting irreversible delete/wipe. `destroy` implies it.
+ *   destroy    delete/restore/purge/factory_reset — irreversible state edits
  *   exec       exec_command — split off from `destroy` (#591) so a token
  *              can grant config writes without shell access
  */
@@ -114,17 +117,23 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   delete_service: 'destroy', delete_health_check: 'destroy',
   remove_proxy_route: 'destroy', restore_backup: 'destroy',
   purge_trashed_service: 'destroy',
-  set_boot_next_usb: 'destroy', reboot_node: 'destroy',
+  // set_boot_next_usb stays `destroy`: it can arm a USB-installer boot, a
+  // reinstall path that risks data loss — higher-risk than a plain reboot.
+  set_boot_next_usb: 'destroy',
   factory_reset: 'destroy',
+  // reboot — transient, recoverable; split out of destroy (#1765)
+  reboot_node: 'reboot',
   // exec (shell — own scope so tokens can grant config writes without it)
   exec_command: 'exec',
 };
 
 /**
  * Decide whether a token with `tokenScopes` may call a tool that
- * requires `required`. Encapsulates the back-compat rule (#591) that
- * tokens issued before the split — when `exec_command` was tagged as
- * `destroy` — still get exec via their `destroy` grant.
+ * requires `required`. Encapsulates the back-compat rules:
+ *   - tokens issued before the exec split (#591) — when `exec_command`
+ *     was tagged `destroy` — still get exec via their `destroy` grant.
+ *   - `destroy` implies `reboot` (#1765): the reboot tier was carved out
+ *     of `destroy`, so a legacy `destroy` token can still reboot a node.
  *
  * Exported pure helper so the scope semantics are testable without
  * spinning up the whole MCP server.
@@ -132,6 +141,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
 export function tokenHasScope(tokenScopes: readonly ApiScope[], required: ApiScope): boolean {
   if (tokenScopes.includes(required)) return true;
   if (required === 'exec' && tokenScopes.includes('destroy')) return true;
+  if (required === 'reboot' && tokenScopes.includes('destroy')) return true;
   return false;
 }
 

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -30,6 +30,7 @@ import { getServicebayChannel, setServicebayChannel } from '@/lib/servicebayChan
 import { guardMutation, guardExec, snapshotBeforeMutation } from './safety';
 import { recordAudit } from './audit';
 import { notifyDestructiveOp } from './notify';
+import { createPendingApproval } from './pendingApprovals';
 import { redactLogText, redactServiceFiles } from './redact';
 import type { ApiScope } from '@/lib/auth/apiScope';
 import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
@@ -176,42 +177,38 @@ const DESTRUCTIVE_TOOLS = new Set([
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolResult = any;
-function safeHandler(
+
+/**
+ * `destroy`-tier tools (delete/purge/restore/factory_reset/set_boot_next_usb)
+ * are the ones a token caller may *propose* but not *execute* without a human
+ * confirm (#1766). Derived from TOOL_SCOPES so the gate predicate stays in
+ * lockstep with the scope map — adding a tool at the `destroy` tier
+ * automatically routes it through the approval gate.
+ */
+function isDestroyTierTool(toolName: string): boolean {
+  return TOOL_SCOPES[toolName] === 'destroy';
+}
+
+/**
+ * Run the snapshot → real handler → audit/notify tail for one tool call.
+ * This is the part of the safety flow that actually executes the mutation,
+ * factored out so it can run either inline OR deferred behind a human
+ * approval (#1766) without duplicating the snapshot/audit/notify logic.
+ */
+function runToolWithSideEffects(
   toolName: string,
+  args: Record<string, unknown>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handler: (...handlerArgs: any[]) => Promise<ToolResult>,
-  auth?: McpAuthContext,
-) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return async (...handlerArgs: any[]): Promise<ToolResult> => {
-    const args = (handlerArgs[0] && typeof handlerArgs[0] === 'object') ? handlerArgs[0] : {};
+  handlerArgs: any[],
+  auth?: McpAuthContext,
+): Promise<ToolResult> {
+  return (async () => {
     const start = Date.now();
     let outcome: 'ok' | 'error' | 'blocked' = 'ok';
     let errorMessage: string | undefined;
     try {
-      // Scope check (token auth only — cookie has all scopes by design).
-      const required = TOOL_SCOPES[toolName] ?? 'read';
-      if (auth && !tokenHasScope(auth.scopes, required)) {
-        outcome = 'blocked';
-        errorMessage = `Token scope '${required}' required for ${toolName}; this token has [${auth.scopes.join(',')}]`;
-        return { content: [{ type: 'text' as const, text: errorMessage }], isError: true as const };
-      }
-      if (MUTATING_TOOLS.has(toolName)) {
-        const blocked = await guardMutation(toolName);
-        if (blocked) {
-          outcome = 'blocked';
-          errorMessage = blocked.content[0]?.text;
-          return blocked;
-        }
-      }
-      if (toolName === 'exec_command' && typeof args.command === 'string') {
-        const denied = await guardExec(args.command);
-        if (denied) {
-          outcome = 'blocked';
-          errorMessage = denied.content[0]?.text;
-          return denied;
-        }
-      }
       if (DESTRUCTIVE_TOOLS.has(toolName)) {
         // Best-effort: don't block the mutation if the snapshot fails.
         await snapshotBeforeMutation(toolName, args);
@@ -248,6 +245,72 @@ function safeHandler(
         void notifyDestructiveOp({ tool: toolName, caller: auth?.user, args, ts }).catch(() => undefined);
       }
     }
+  })();
+}
+
+function safeHandler(
+  toolName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (...handlerArgs: any[]) => Promise<ToolResult>,
+  auth?: McpAuthContext,
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return async (...handlerArgs: any[]): Promise<ToolResult> => {
+    const args = (handlerArgs[0] && typeof handlerArgs[0] === 'object') ? handlerArgs[0] : {};
+    // Scope check (token auth only — cookie has all scopes by design).
+    const required = TOOL_SCOPES[toolName] ?? 'read';
+    if (auth && !tokenHasScope(auth.scopes, required)) {
+      const msg = `Token scope '${required}' required for ${toolName}; this token has [${auth.scopes.join(',')}]`;
+      void recordAudit({ ts: new Date().toISOString(), tool: toolName, caller: auth.user, outcome: 'blocked', durationMs: 0, args, errorMessage: msg });
+      return { content: [{ type: 'text' as const, text: msg }], isError: true as const };
+    }
+    if (MUTATING_TOOLS.has(toolName)) {
+      const blocked = await guardMutation(toolName);
+      if (blocked) {
+        void recordAudit({ ts: new Date().toISOString(), tool: toolName, caller: auth?.user, outcome: 'blocked', durationMs: 0, args, errorMessage: blocked.content[0]?.text });
+        return blocked;
+      }
+    }
+    if (toolName === 'exec_command' && typeof args.command === 'string') {
+      const denied = await guardExec(args.command);
+      if (denied) {
+        void recordAudit({ ts: new Date().toISOString(), tool: toolName, caller: auth?.user, outcome: 'blocked', durationMs: 0, args, errorMessage: denied.content[0]?.text });
+        return denied;
+      }
+    }
+
+    // Approval gate (#1766): a TOKEN caller (the agent) may *propose* a
+    // destroy-tier tool but not execute it — park the call for an
+    // out-of-band human confirm and hand back a pending handle instead of a
+    // result. Cookie callers (no `auth`) bypass the gate and execute
+    // inline, same as before: the human IS the operator. The gate lands
+    // here, AFTER the scope + mutation/exec guards (so the agent still
+    // learns immediately if the call would be refused) but BEFORE the
+    // snapshot/handler, which are deferred into the approval's `execute`.
+    if (auth && isDestroyTierTool(toolName)) {
+      const pending = createPendingApproval({
+        toolName,
+        args,
+        caller: auth.user,
+        execute: () => runToolWithSideEffects(toolName, args, handler, handlerArgs, auth),
+      });
+      void recordAudit({ ts: new Date().toISOString(), tool: toolName, caller: auth.user, outcome: 'blocked', durationMs: 0, args, errorMessage: `pending human approval (${pending.pendingId})` });
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            status: 'pending_approval',
+            pendingId: pending.pendingId,
+            toolName: pending.toolName,
+            args: pending.args,
+            expiresAt: new Date(pending.expiresAt).toISOString(),
+            message: `Destructive tool "${toolName}" requires human approval before it runs. A ServiceBay admin must approve pending request ${pending.pendingId} from the dashboard (Settings → MCP). This token cannot self-approve. The request expires at ${new Date(pending.expiresAt).toISOString()}.`,
+          }, null, 2),
+        }],
+      };
+    }
+
+    return runToolWithSideEffects(toolName, args, handler, handlerArgs, auth);
   };
 }
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { Check, Copy, Key, Plus, Trash2 } from 'lucide-react';
 import { copyToClipboard } from '../clipboard';
 
-type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'destroy' | 'exec';
-const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'destroy', 'exec'];
+type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'reboot' | 'destroy' | 'exec';
+const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'reboot', 'destroy', 'exec'];
 
 interface TokenView {
   id: string;
@@ -26,6 +26,7 @@ const SCOPE_BADGE: Record<ApiScope, string> = {
   destroy: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300',
   exec: 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300',
   mutate: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300',
+  reboot: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
   lifecycle: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
   read: 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
 };
@@ -153,7 +154,7 @@ function CreateTokenForm(props: CreateTokenFormProps) {
             </label>
           ))}
         </div>
-        <p className="text-[10px] text-gray-400 mt-1">read = list/get only. lifecycle = start/stop/restart. mutate = create/update/config-edit. destroy = delete/restore/purge. exec = exec_command (shell). Tokens with destroy also implicitly grant exec for back-compat (#591).</p>
+        <p className="text-[10px] text-gray-400 mt-1">read = list/get only. lifecycle = start/stop/restart. mutate = create/update/config-edit. reboot = reboot the node (transient, recoverable). destroy = delete/restore/purge/factory-reset. exec = exec_command (shell). Tokens with destroy also implicitly grant reboot and exec for back-compat.</p>
       </div>
       {props.error && <p className="text-xs text-red-600">{props.error}</p>}
       <div className="flex gap-2">

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Bot, Check, Copy, ShieldAlert, History, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { Bot, Check, Copy, ShieldAlert, History, RefreshCw, ShieldCheck } from 'lucide-react';
 import SectionHelp from '@/components/SectionHelp';
 import { copyToClipboard } from '../clipboard';
 
@@ -110,6 +110,78 @@ function McpSafetyToggles(props: SafetyTogglesProps) {
   );
 }
 
+interface PendingApproval {
+  pendingId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  caller?: string;
+  expiresAt: number;
+}
+
+function PendingApprovalRow({ entry, busy, onApprove }: { entry: PendingApproval; busy: boolean; onApprove: (id: string) => void }) {
+  // Absolute expiry time (not a Date.now()-derived countdown) so render stays
+  // pure; the 15s poll drops expired entries off the list anyway.
+  const expiresAtLabel = new Date(entry.expiresAt).toLocaleTimeString();
+  return (
+    <li className="text-xs rounded-md border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 p-2">
+      <div className="flex items-center gap-2">
+        <span className="font-mono font-semibold text-amber-700 dark:text-amber-300">{entry.toolName}</span>
+        {entry.caller && <span className="text-gray-500">from {entry.caller}</span>}
+        <span className="text-gray-400 ml-auto">expires {expiresAtLabel}</span>
+      </div>
+      <pre className="mt-1 whitespace-pre-wrap break-words text-[11px] text-gray-600 dark:text-gray-300 font-mono">{JSON.stringify(entry.args, null, 2)}</pre>
+      <div className="mt-1.5 flex justify-end">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onApprove(entry.pendingId)}
+          className="px-2.5 py-1 rounded bg-amber-600 hover:bg-amber-700 text-white disabled:opacity-50 flex items-center gap-1"
+        >
+          <ShieldCheck size={12} />
+          {busy ? 'Approving…' : 'Approve & run'}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function McpPendingApprovals({ pending, busyId, error, onRefresh, onApprove }: {
+  pending: PendingApproval[] | null;
+  busyId: string | null;
+  error: string | null;
+  onRefresh: () => void;
+  onApprove: (id: string) => void;
+}) {
+  if (!pending || pending.length === 0) return null;
+  return (
+    <div className="mt-5 pt-4 border-t border-gray-100 dark:border-gray-800">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1.5">
+          <ShieldAlert size={14} className="text-amber-500 shrink-0" />
+          Pending destructive approvals
+          <span className="text-xs font-normal text-gray-500">({pending.length})</span>
+        </p>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="text-xs flex items-center gap-1 px-2 py-1 rounded border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          <RefreshCw size={12} /> Refresh
+        </button>
+      </div>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        An MCP agent proposed these destructive tool calls. They run only after you approve them here — the agent cannot approve its own request.
+      </p>
+      {error && <p className="text-xs text-red-600 dark:text-red-400 mb-2">{error}</p>}
+      <ul className="space-y-2">
+        {pending.map(p => (
+          <PendingApprovalRow key={p.pendingId} entry={p} busy={busyId === p.pendingId} onApprove={onApprove} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 function McpAuditFeed({ entries, loading, onRefresh }: { entries: AuditEntry[] | null; loading: boolean; onRefresh: () => void }) {
   return (
     <div className="mt-3 space-y-2">
@@ -147,6 +219,33 @@ export default function McpSection() {
   const [audit, setAudit] = useState<AuditEntry[] | null>(null);
   const [auditLoading, setAuditLoading] = useState(false);
   const [auditOpen, setAuditOpen] = useState(false);
+  const [pending, setPending] = useState<PendingApproval[] | null>(null);
+  const [approveBusyId, setApproveBusyId] = useState<string | null>(null);
+  const [approveError, setApproveError] = useState<string | null>(null);
+
+  const loadPending = useCallback(() => {
+    fetch('/api/system/mcp/approve')
+      .then(r => r.ok ? r.json() : { pending: [] })
+      .then((data: { pending?: PendingApproval[] }) => setPending(data.pending ?? []))
+      .catch(() => setPending([]));
+  }, []);
+
+  const approvePending = useCallback(async (id: string) => {
+    setApproveBusyId(id);
+    setApproveError(null);
+    try {
+      const res = await fetch(`/api/system/mcp/approve/${id}`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      loadPending();
+    } catch (e) {
+      setApproveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setApproveBusyId(null);
+    }
+  }, [loadPending]);
 
   const loadAudit = () => {
     setAuditLoading(true);
@@ -161,6 +260,14 @@ export default function McpSection() {
     // Read window.location after mount to avoid SSR/hydration mismatch.
     setMcpUrl(`${window.location.origin}/mcp`);
   }, []);
+
+  // Poll for pending destructive-tool approvals (#1766). In-memory + short TTL,
+  // so a light poll keeps the badge fresh without a socket channel.
+  useEffect(() => {
+    loadPending();
+    const t = setInterval(loadPending, 15000);
+    return () => clearInterval(t);
+  }, [loadPending]);
 
   useEffect(() => {
     let cancelled = false;
@@ -259,6 +366,18 @@ export default function McpSection() {
         saveError={saveError}
         onToggleMutations={() => persistMcp({ allowMutations: !allowMutations, ...(allowMutations ? { allowDangerousExec: false } : {}) })}
         onToggleDangerous={() => persistMcp({ allowDangerousExec: !allowDangerousExec })}
+      />
+
+      {/* Pending destructive-tool approvals (#1766). An MCP token caller can
+          propose a destroy-tier tool (delete/purge/restore/factory_reset/USB
+          boot) but cannot execute it — it parks here for a logged-in human to
+          approve. Only renders when something is pending. */}
+      <McpPendingApprovals
+        pending={pending}
+        busyId={approveBusyId}
+        error={approveError}
+        onRefresh={loadPending}
+        onApprove={approvePending}
       />
 
       {/* Recent MCP activity. Toggleable so the section stays compact for

--- a/packages/frontend/src/app/api/system/mcp/approve/[pendingId]/route.test.ts
+++ b/packages/frontend/src/app/api/system/mcp/approve/[pendingId]/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * POST /api/system/mcp/approve/{pendingId} (#1766) — the cookie-only confirm.
+ *
+ * The whole security property of the approval gate lives here: the route
+ * carries NO `tokenScope`, so a `Bearer sb_…` token (the proposing agent) is
+ * IGNORED by requireSession and 401s. Only a logged-in human (session cookie)
+ * can approve. We drive the REAL withApiHandlerParams → requireSession path and
+ * mock only the auth primitives + the pending-approvals store.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const store = vi.hoisted(() => ({
+  approve: vi.fn(),
+}));
+
+vi.mock('@/lib/mcp/pendingApprovals', () => {
+  class ApprovalExpiredError extends Error {
+    constructor(public readonly pendingId: string) {
+      super(`Approval ${pendingId} has expired or does not exist`);
+      this.name = 'ApprovalExpiredError';
+    }
+  }
+  return {
+    approvePendingApproval: store.approve,
+    ApprovalExpiredError,
+  };
+});
+
+// requireSession's three credential sources.
+const auth = vi.hoisted(() => ({
+  internalToken: 'internal-secret',
+  session: null as null | { user: string; expires: Date },
+  token: null as null | { name: string; scopes: string[] },
+}));
+
+vi.mock('@/lib/auth/internalToken', () => ({
+  getInternalApiToken: () => auth.internalToken,
+}));
+vi.mock('@/lib/auth/session', () => ({
+  getSessionFromCookieHeader: vi.fn(async () => auth.session),
+}));
+vi.mock('@/lib/auth/apiTokens', () => ({
+  verifyToken: vi.fn(async () => auth.token),
+}));
+
+import { POST } from './route';
+import { ApprovalExpiredError } from '@/lib/mcp/pendingApprovals';
+
+function reqWith(headers: Record<string, string>): NextRequest {
+  return new NextRequest('http://localhost/api/system/mcp/approve/abc', {
+    method: 'POST',
+    headers,
+  });
+}
+const ctx = { params: Promise.resolve({ pendingId: 'abc' }) };
+
+describe('POST /api/system/mcp/approve/{pendingId} (#1766)', () => {
+  beforeEach(() => {
+    store.approve.mockReset();
+    auth.session = null;
+    auth.token = null;
+  });
+
+  it('REJECTS a Bearer-token caller with 401 — the agent cannot self-approve', async () => {
+    // A valid token with destroy scope is presented…
+    auth.token = { name: 'ci-bot', scopes: ['read', 'destroy'] };
+    const res = await POST(reqWith({ authorization: 'Bearer sb_token' }), ctx);
+    expect(res.status).toBe(401);
+    // …and the stored call is NEVER executed.
+    expect(store.approve).not.toHaveBeenCalled();
+  });
+
+  it('a cookie session (a logged-in human) approves and runs the call', async () => {
+    auth.session = { user: 'admin', expires: new Date(Date.now() + 60_000) };
+    store.approve.mockResolvedValue({ content: [{ type: 'text', text: 'deleted' }] });
+    const res = await POST(reqWith({ cookie: 'sb_session=valid' }), ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(store.approve).toHaveBeenCalledWith('abc');
+  });
+
+  it('an unauthenticated caller (no cookie, no token) 401s', async () => {
+    const res = await POST(reqWith({}), ctx);
+    expect(res.status).toBe(401);
+    expect(store.approve).not.toHaveBeenCalled();
+  });
+
+  it('an expired / unknown pending id returns 410 Gone for a cookie session', async () => {
+    auth.session = { user: 'admin', expires: new Date(Date.now() + 60_000) };
+    store.approve.mockRejectedValue(new ApprovalExpiredError('abc'));
+    const res = await POST(reqWith({ cookie: 'sb_session=valid' }), ctx);
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/expired|already used/i);
+  });
+});

--- a/packages/frontend/src/app/api/system/mcp/approve/[pendingId]/route.ts
+++ b/packages/frontend/src/app/api/system/mcp/approve/[pendingId]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { approvePendingApproval, ApprovalExpiredError } from '@/lib/mcp/pendingApprovals';
+import { withApiHandlerParams } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Confirm (approve) a pending destructive MCP tool call (#1766) — the human
+ * half of the propose → confirm → execute gate.
+ *
+ * SECURITY (the whole point of the feature): this route deliberately carries
+ * NO `tokenScope`. A POST is a mutating verb, so withApiHandler runs the
+ * requireSession gate; with no `tokenScope` set, requireSession *ignores* any
+ * `Authorization: Bearer sb_…` and 401s a token caller (see
+ * packages/backend/src/lib/api/requireSession.ts). Only a valid session
+ * **cookie** (a logged-in human) is accepted. The agent that proposed the
+ * call holds a token, so it can never self-approve its own request.
+ *
+ * On success the stored call executes through the same safety path
+ * (snapshot → handler → audit/notify) it would have run inline, and the tool
+ * result is returned. Single-use: the pending entry is claimed before it runs,
+ * so it can't be confirmed twice. An expired/unknown id returns 410 Gone.
+ */
+export const POST = withApiHandlerParams<undefined, undefined, { pendingId: string }>(
+  {},
+  async ({ params }) => {
+    try {
+      const result = await approvePendingApproval(params.pendingId);
+      return NextResponse.json({ ok: true, result });
+    } catch (e) {
+      if (e instanceof ApprovalExpiredError) {
+        return NextResponse.json(
+          { ok: false, error: 'This approval has expired or was already used. Ask the agent to propose the action again.' },
+          { status: 410 },
+        );
+      }
+      throw e;
+    }
+  },
+);

--- a/packages/frontend/src/app/api/system/mcp/approve/route.ts
+++ b/packages/frontend/src/app/api/system/mcp/approve/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { listPendingApprovals } from '@/lib/mcp/pendingApprovals';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * List pending MCP destructive-tool approvals (#1766). A token-authenticated
+ * agent can *propose* a destroy-tier tool call; it parks here awaiting a human
+ * confirm. The dashboard reads this to show the operator what is waiting.
+ *
+ * This GET carries no `tokenScope`, so the only Bearer token that would even
+ * reach the handler still 401s at requireSession — the list, like the confirm,
+ * is cookie-session only. (A GET with no Bearer is gate-skipped, but the proxy
+ * is the primary gate for the dashboard origin.)
+ */
+export const GET = withApiHandler(
+  {},
+  async () => {
+    return NextResponse.json({ pending: listPendingApprovals() });
+  },
+);

--- a/packages/frontend/src/components/HermesChatPanel.test.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.test.tsx
@@ -1,9 +1,14 @@
 /**
- * HermesChatPanel tests (#1755, part B of epic #1704; #1760 history reload).
+ * HermesChatPanel tests (#1755, part B of epic #1704; #1760 history reload;
+ * #1767 drop avatar icons; #1768 assistant Markdown rendering).
  *
  * Covers: mount-time history load (GET) + empty state, send -> calls POST
  * /api/system/hermes/chat and shows the reply, the 503 "Hermes is unavailable"
- * graceful state, and the typing indicator while a turn is in flight.
+ * graceful state, the typing indicator while a turn is in flight, that message
+ * bubbles carry no per-message avatar icon (#1767), and that assistant content
+ * renders as Markdown — headings/lists/bold/inline + fenced ```json code
+ * blocks — while plain text still renders fine and no raw HTML is injected
+ * (#1768).
  *
  * fetch is mocked with mockImplementation returning a FRESH Response per call
  * (memory feedback_vitest_fetch_response_reuse — a shared Response body can
@@ -163,5 +168,85 @@ describe('HermesChatPanel', () => {
       expect(screen.queryByTestId('hermes-typing')).toBeNull();
     });
     expect(screen.getByText('done')).toBeDefined();
+  });
+
+  // #1767 — per-message avatar icons removed; turns stay distinguishable by
+  // alignment/colour only. lucide icons render as <svg>, so assert the bubble
+  // wrapper carries no svg (the EmptyState/Composer svgs live outside the log
+  // entries, so we scope to the message testids).
+  it('renders message bubbles with no per-message avatar icon (#1767)', async () => {
+    mockFetch({
+      get: () =>
+        jsonResponse(200, {
+          messages: [
+            { role: 'user', text: 'hi there' },
+            { role: 'assistant', text: 'hello, how can I help?' },
+          ],
+        }),
+    });
+    render(<HermesChatPanel />);
+    await waitFor(() => expect(screen.getByText('hi there')).toBeDefined());
+
+    expect(screen.getByTestId('hermes-msg-user').querySelector('svg')).toBeNull();
+    expect(screen.getByTestId('hermes-msg-assistant').querySelector('svg')).toBeNull();
+  });
+
+  // #1768 — assistant content renders as Markdown.
+  it('renders assistant Markdown: heading, list, bold, inline code, and a json fenced block (#1768)', async () => {
+    const md = [
+      '# Plan',
+      '',
+      'Here is **what** to do and some `inline code`:',
+      '',
+      '- first step',
+      '- second step',
+      '',
+      '```json',
+      '{ "ok": true }',
+      '```',
+    ].join('\n');
+    mockFetch({ get: () => jsonResponse(200, { messages: [{ role: 'assistant', text: md }] }) });
+
+    render(<HermesChatPanel />);
+    const bubble = await screen.findByTestId('hermes-msg-assistant');
+
+    // Heading element, not literal "# Plan".
+    expect(bubble.querySelector('h1')?.textContent).toBe('Plan');
+    expect(bubble.querySelector('h1')?.textContent).not.toContain('#');
+    // Bold + inline code render as elements.
+    expect(bubble.querySelector('strong')?.textContent).toBe('what');
+    expect(bubble.querySelector('code')).not.toBeNull();
+    // List items.
+    const items = Array.from(bubble.querySelectorAll('li')).map((li) => li.textContent);
+    expect(items).toContain('first step');
+    expect(items).toContain('second step');
+    // Fenced json block renders inside a <pre>.
+    const pre = bubble.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('"ok": true');
+  });
+
+  it('renders plain-text assistant content unchanged as Markdown (#1768)', async () => {
+    mockFetch({
+      get: () =>
+        jsonResponse(200, { messages: [{ role: 'assistant', text: 'just a plain sentence.' }] }),
+    });
+    render(<HermesChatPanel />);
+    await waitFor(() => expect(screen.getByText('just a plain sentence.')).toBeDefined());
+  });
+
+  it('does not inject raw HTML from assistant content (no XSS) (#1768)', async () => {
+    mockFetch({
+      get: () =>
+        jsonResponse(200, {
+          messages: [{ role: 'assistant', text: 'before <img src=x onerror=alert(1)> after' }],
+        }),
+    });
+    render(<HermesChatPanel />);
+    const bubble = await screen.findByTestId('hermes-msg-assistant');
+    // react-markdown does not parse raw HTML (no rehype-raw) -> no <img> node;
+    // the tag is rendered as escaped text instead.
+    expect(bubble.querySelector('img')).toBeNull();
+    expect(bubble.textContent).toContain('<img');
   });
 });

--- a/packages/frontend/src/components/HermesChatPanel.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.tsx
@@ -22,7 +22,9 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Bot, Send, AlertTriangle, User as UserIcon } from 'lucide-react';
+import { Bot, Send, AlertTriangle } from 'lucide-react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface ChatMessage {
   /** Stable key for React; not sent to the server. */
@@ -51,30 +53,92 @@ function EmptyState() {
   );
 }
 
+/**
+ * Tailwind-styled element overrides for assistant Markdown (#1768). Keeps the
+ * bubble readable: tight spacing, formatted headings/lists, inline + fenced
+ * code blocks (incl. ```json) with a mono surface and horizontal scroll, and
+ * links that open in a new tab with rel="noreferrer".
+ */
+const markdownComponents: Components = {
+  p: ({ children }) => <p className="my-1 first:mt-0 last:mb-0">{children}</p>,
+  h1: ({ children }) => <h1 className="text-base font-semibold mt-2 mb-1">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-base font-semibold mt-2 mb-1">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-sm font-semibold mt-2 mb-1">{children}</h3>,
+  ul: ({ children }) => <ul className="list-disc pl-5 my-1 space-y-0.5">{children}</ul>,
+  ol: ({ children }) => <ol className="list-decimal pl-5 my-1 space-y-0.5">{children}</ol>,
+  li: ({ children }) => <li className="marker:text-gray-400">{children}</li>,
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="underline underline-offset-2 hover:opacity-80"
+    >
+      {children}
+    </a>
+  ),
+  code: ({ className, children, ...props }) => {
+    // react-markdown gives inline code no language className; fenced blocks get
+    // `language-*`. Render inline code as a small chip, fenced code is handled
+    // by `pre` below (this just styles the inner <code>).
+    const isBlock = typeof className === 'string' && className.startsWith('language-');
+    if (isBlock) {
+      return (
+        <code className={`${className} font-mono text-xs`} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code
+        className="font-mono text-[0.85em] px-1 py-0.5 rounded bg-black/5 dark:bg-white/10"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => (
+    <pre className="my-1.5 p-3 rounded-lg overflow-x-auto bg-gray-900/90 dark:bg-black/40 text-gray-100 text-xs">
+      {children}
+    </pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-gray-300 dark:border-white/20 pl-3 my-1 italic">
+      {children}
+    </blockquote>
+  ),
+};
+
+/**
+ * Assistant content rendered as Markdown (#1768). react-markdown is safe by
+ * default — it does NOT parse raw HTML (no rehype-raw here), so model output
+ * cannot inject markup; no dangerouslySetInnerHTML. remark-gfm adds tables,
+ * task lists, autolinks. Plain text passes through unchanged.
+ */
+function AssistantMarkdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+      {content}
+    </ReactMarkdown>
+  );
+}
+
 function MessageBubble({ message }: { message: ChatMessage }) {
   const isUser = message.role === 'user';
   return (
     <div
       data-testid={`hermes-msg-${message.role}`}
-      className={`flex gap-2.5 ${isUser ? 'flex-row-reverse' : ''}`}
+      className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
     >
       <div
-        className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+        className={`max-w-[78%] px-4 py-2.5 rounded-2xl break-words text-sm ${
           isUser
-            ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
-            : 'bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-300'
-        }`}
-      >
-        {isUser ? <UserIcon size={16} /> : <Bot size={16} />}
-      </div>
-      <div
-        className={`max-w-[75%] px-4 py-2.5 rounded-2xl whitespace-pre-wrap break-words text-sm ${
-          isUser
-            ? 'bg-blue-600 text-white rounded-tr-sm'
+            ? 'bg-blue-600 text-white rounded-tr-sm whitespace-pre-wrap'
             : 'bg-gray-100 dark:bg-white/[0.04] text-gray-800 dark:text-gray-100 rounded-tl-sm'
         }`}
       >
-        {message.content}
+        {isUser ? message.content : <AssistantMarkdown content={message.content} />}
       </div>
     </div>
   );

--- a/tests/backend/mcp_token_scopes.test.ts
+++ b/tests/backend/mcp_token_scopes.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { TOOL_SCOPES, tokenHasScope } from '@/lib/mcp/server';
-import type { ApiScope } from '@/lib/auth/apiScope';
+import { ALL_SCOPES, type ApiScope } from '@/lib/auth/apiScope';
 
 describe('MCP scope mapping (#591)', () => {
   it('update_config is mutate, not destroy', () => {
@@ -29,16 +29,18 @@ describe('MCP scope mapping (#591)', () => {
     expect(TOOL_SCOPES.set_boot_next_usb).toBe('destroy');
   });
 
-  it('reboot_node is destroy (#1235)', () => {
-    expect(TOOL_SCOPES.reboot_node).toBe('destroy');
+  it('reboot_node is reboot, not destroy (#1765)', () => {
+    // A reboot is transient/recoverable — split out of `destroy` so a token
+    // can operate+reboot without also granting irreversible delete/wipe.
+    expect(TOOL_SCOPES.reboot_node).toBe('reboot');
   });
 
   it('factory_reset is destroy (#1237)', () => {
     expect(TOOL_SCOPES.factory_reset).toBe('destroy');
   });
 
-  it('every entry uses one of the five known scopes', () => {
-    const known: ReadonlySet<ApiScope> = new Set<ApiScope>(['read', 'lifecycle', 'mutate', 'destroy', 'exec']);
+  it('every entry uses one of the known scopes', () => {
+    const known: ReadonlySet<ApiScope> = new Set<ApiScope>(ALL_SCOPES);
     for (const [tool, scope] of Object.entries(TOOL_SCOPES)) {
       expect(known.has(scope), `${tool} has unknown scope ${scope}`).toBe(true);
     }
@@ -72,6 +74,19 @@ describe('tokenHasScope — least-privilege check', () => {
     expect(tokenHasScope(scopes, 'mutate')).toBe(false);
     expect(tokenHasScope(scopes, 'lifecycle')).toBe(false);
     expect(tokenHasScope(scopes, 'read')).toBe(false);
+  });
+
+  // #1765: the reboot tier was carved out of destroy, so legacy destroy
+  // tokens must still be able to reboot a node.
+  it('[destroy] token implicitly gets reboot (back-compat with pre-#1765 tokens)', () => {
+    expect(tokenHasScope(['destroy'], 'reboot')).toBe(true);
+    expect(tokenHasScope(['destroy'], TOOL_SCOPES.reboot_node)).toBe(true);
+  });
+
+  it('[reboot] alone does not imply destroy actions', () => {
+    expect(tokenHasScope(['reboot'], TOOL_SCOPES.reboot_node)).toBe(true);
+    expect(tokenHasScope(['reboot'], TOOL_SCOPES.delete_service)).toBe(false);
+    expect(tokenHasScope(['reboot'], TOOL_SCOPES.factory_reset)).toBe(false);
   });
 
   it('[exec] alone is sufficient for exec_command but not for destroy actions', () => {

--- a/tests/e2e/helpers/portal.ts
+++ b/tests/e2e/helpers/portal.ts
@@ -44,6 +44,132 @@ export async function login(page: Page): Promise<void> {
 }
 
 /**
+ * The public domain the box's SSO services live under (e.g. `dopp.cloud`), read
+ * fresh from the environment. Services are reached at `https://<svc>.<domain>/`
+ * and Authelia's portal at `https://auth.<domain>/`. Must be a real subdomain
+ * host — the bare apex is Authelia default-deny (403, no identity), only
+ * `*.<domain>` is `one_factor` (memory `reference_authelia_apex_deny_vs_wildcard`).
+ */
+export function publicDomain(): string {
+  const domain = process.env.SB_PUBLIC_DOMAIN
+  if (!domain) {
+    throw new Error(
+      'SB_PUBLIC_DOMAIN must be set to the box public domain (e.g. dopp.cloud) ' +
+        'so the SSO login smoke can reach <svc>.<domain> and auth.<domain>. ' +
+        'Read it off the box config (reverseProxy.publicDomain).',
+    )
+  }
+  return domain
+}
+
+/**
+ * Drive the real Authelia login portal for an SSO-protected service and assert
+ * an authenticated landing back on the service (#1561).
+ *
+ * Flow — the genuine end-user SSO path:
+ *   1. navigate to the service subdomain (`https://<svc>.<domain>/`);
+ *   2. Authelia forward-auth / the OIDC client bounces an anonymous visitor to
+ *      the Authelia portal (`auth.<domain>`) — if it does NOT, the service is
+ *      either unprotected or already authed; we still assert we did not land on
+ *      an error/401/403;
+ *   3. fill + submit the Authelia first-factor form;
+ *   4. assert we are redirected BACK onto the service host (not parked on the
+ *      auth portal, not a 401/403/5xx) — i.e. login actually succeeded.
+ *
+ * A failed login (wrong redirect, stuck on the portal, OAuth error, error page)
+ * throws — making the spec RED. This is the assertion #1559 needed: a reinstall
+ * that breaks every login can no longer ship a green verify.
+ *
+ * Credentials are the box admin LLDAP user (`SB_USERNAME`/`SB_PASSWORD`), the
+ * same fresh-off-the-box creds the portal helper uses.
+ */
+export async function ssoLogin(
+  page: Page,
+  service: string,
+): Promise<void> {
+  const { username, password } = credentials()
+  const domain = publicDomain()
+  const serviceHost = `${service}.${domain}`
+  const authHost = `auth.${domain}`
+  const serviceUrl = `https://${serviceHost}/`
+
+  // 1. Hit the protected service as an anonymous visitor.
+  const resp = await page.goto(serviceUrl, { waitUntil: 'domcontentloaded' })
+  // A transport-level failure (DNS / cert / upstream down) is an immediate fail.
+  if (resp && resp.status() >= 500) {
+    throw new Error(`SSO[${service}]: ${serviceHost} returned HTTP ${resp.status()} before login`)
+  }
+
+  // 2. We should be on the Authelia portal (forward-auth or OIDC redirect). If
+  //    the page never reached the portal AND we're not already on the service,
+  //    something redirected us somewhere unexpected.
+  const onAuthPortal = () => new URL(page.url()).host === authHost
+  const onService = () => new URL(page.url()).host === serviceHost
+
+  if (onAuthPortal()) {
+    // 3. Drive the Authelia first-factor form. Authelia's React portal labels
+    //    its inputs by id; match on the accessible username/password fields.
+    const userField = page
+      .getByLabel(/username/i)
+      .or(page.locator('input#username'))
+      .first()
+    const passField = page
+      .getByLabel(/password/i)
+      .or(page.locator('input#password'))
+      .first()
+    await userField.fill(username)
+    await passField.fill(password)
+    await page
+      .getByRole('button', { name: /sign in|log in|login/i })
+      .first()
+      .click()
+
+    // 4. Authelia must redirect back off its own portal onto the service.
+    await page.waitForURL(
+      (url) => new URL(url).host !== authHost,
+      { timeout: 30_000 },
+    )
+  }
+
+  // Final assertion: we landed on the service host (authenticated), NOT parked
+  // on the auth portal and NOT on an OAuth/error surface. Staying on the portal
+  // or a *.error.* host means the login failed.
+  if (onAuthPortal()) {
+    throw new Error(
+      `SSO[${service}]: still on the Authelia portal (${page.url()}) after submitting credentials — login did not complete`,
+    )
+  }
+  if (!onService()) {
+    throw new Error(
+      `SSO[${service}]: after login landed on ${page.url()}, not the service host ${serviceHost} — OIDC/redirect chain is broken`,
+    )
+  }
+  // The service rendered something other than an Authelia/OAuth error.
+  const errorIndicator = page.getByText(
+    /invalid_client|server_error|access_denied|authentication failed|forbidden|not authorized/i,
+  )
+  await expect(errorIndicator).not.toBeVisible({ timeout: 5_000 })
+}
+
+/**
+ * The SSO services to smoke-login, in order. Defaults to the OIDC-backed apps
+ * the box ships (`vault`/`photos`/`books`, mirroring `ssoVerify.ts`
+ * `OIDC_CLIENT_SUBDOMAINS`); override per box via `SB_SSO_SERVICES` (a
+ * comma-separated subdomain list) so an install with a different service set
+ * verifies exactly what it has.
+ */
+export function ssoServices(): string[] {
+  const raw = process.env.SB_SSO_SERVICES
+  if (raw && raw.trim()) {
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+  return ['vault', 'photos', 'books']
+}
+
+/**
  * Assert a named UI surface rendered. `urlPattern` guards the route landed and
  * `heading` (optional) pins a visible heading/text on it. Returns once both hold.
  */

--- a/tests/e2e/sso-login.e2e.ts
+++ b/tests/e2e/sso-login.e2e.ts
@@ -1,0 +1,50 @@
+import { test } from '@playwright/test'
+import { ssoLogin, ssoServices, publicDomain } from './helpers/portal'
+
+/**
+ * Per-service SSO login smoke (#1561) — the verify-coverage gap that let a
+ * `wipe-configs` reinstall ship green while EVERY login was broken (#1559).
+ *
+ * Unit tests can't cover functional login; `service: up` / "page renders" both
+ * pass on a box where the Authelia/OIDC handshake is dead. This spec drives the
+ * REAL end-user login flow per SSO-protected service against the `:dev` box:
+ *
+ *   navigate to <svc>.<domain>  →  follow the Authelia redirect  →
+ *   authenticate  →  assert an authenticated landing back on the service.
+ *
+ * A broken login on ANY installed service makes this spec RED — so the
+ * Box-Verify stage can no longer green-light a reinstall that broke logins.
+ *
+ * It reuses the #1473 harness (Playwright config + the portal helpers); it does
+ * NOT build a parallel framework. The service set is `SB_SSO_SERVICES` (default
+ * the OIDC-backed apps that mirror `ssoVerify.ts` `OIDC_CLIENT_SUBDOMAINS`).
+ *
+ * Invocation (Box-Verify, from repo root, against the `:dev`-flipped box):
+ *   SB_PUBLIC_DOMAIN=dopp.cloud \
+ *   SB_USERNAME=<admin-user> SB_PASSWORD=<admin-pass> \
+ *   SB_SSO_SERVICES=vault,photos,books \
+ *   npm run test:e2e -- sso-login
+ *
+ * Authelia note: the login flow targets a SUBDOMAIN (<svc>.<domain> /
+ * auth.<domain>), never the bare apex — the apex is default-deny with no
+ * identity (memory `reference_authelia_apex_deny_vs_wildcard`).
+ */
+
+const services = ssoServices()
+
+test.describe('SSO login smoke per service (#1561)', () => {
+  test.beforeAll(() => {
+    // Surface the resolved target up front so a verify run logs exactly what it
+    // exercised — a green run that silently tested nothing is the failure mode
+    // this issue exists to prevent.
+    console.log(
+      `SSO login smoke: domain=${publicDomain()} services=[${services.join(', ')}]`,
+    )
+  })
+
+  for (const service of services) {
+    test(`login succeeds through Authelia for ${service}`, async ({ page }) => {
+      await ssoLogin(page, service)
+    })
+  }
+})


### PR DESCRIPTION
## What
Four built units sealed onto one batch: maintenance-chat UI polish (drop avatar icons + render assistant Markdown), an MCP token-scope split that moves `reboot_node` out of the destroy tier into its own `reboot` tier, a native per-tool approval gate for destructive MCP tools (propose -> human confirm -> execute, no self-approve), and a per-service SSO login smoke spec wired into box-verify.

## Why
Closes #1767
Closes #1768
Closes #1765
Closes #1766
Closes #1561

## Risk
Medium — #1765 reclassifies destructive-tool authorization (legacy `destroy` keeps `reboot` via implication, back-compat tested) and #1766 adds a new destructive-tool approval boundary; both are `security:true` and on the post-deploy review list. #1767/#1768 are frontend-only; #1561 adds an e2e spec that only runs at box-verify.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 354 warnings — baseline)
- [x] npm run check:arch (invariants + depcruise, 814 modules, no violations)
- [x] npm test (full suite — 284 files / 2427 passed, 2 skipped)
- [ ] /verify on FCoS :dev box — path-mandated: packages/backend/src/lib/mcp/** (#1765 reboot scope tier, #1766 approval gate) + tests/e2e/sso-login.e2e.ts (#1561 SSO login smoke)

AI-generated
<!-- sb-ai-comment -->