### PR TITLE
fix(mcp): intercept approve routes in server.ts to fix store isolation

### DIFF
--- a/packages/backend/src/lib/mcp/approveRoute.test.ts
+++ b/packages/backend/src/lib/mcp/approveRoute.test.ts
@@ -1,0 +1,129 @@
+/**
+ * MCP pending-approval HTTP intercept (#1766) — the LIVE production handler.
+ *
+ * The Next.js route.ts files are kept as dead code (covered by their own
+ * route.test.ts); production actually runs THIS handler, intercepted in
+ * server.ts before Next.js sees the request. These tests exercise the live
+ * security property end-to-end through the real `pendingApprovals` store:
+ *
+ *   - Bearer/anon (no session cookie) → 401, and the call NEVER executes —
+ *     the proposing agent cannot self-approve.
+ *   - a valid cookie session → the pending call executes.
+ *   - an expired/unknown handle → 410.
+ *   - single-use: a confirmed call can't be replayed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { handleMcpApproveRequest, isMcpApprovePath } from './approveRoute';
+import {
+  createPendingApproval,
+  __clearPendingApprovalsForTest,
+} from './pendingApprovals';
+
+const noSession = async () => null;
+const human = async () => ({ user: 'admin', expires: new Date(Date.now() + 60_000) });
+
+beforeEach(() => {
+  __clearPendingApprovalsForTest();
+});
+
+describe('isMcpApprovePath', () => {
+  it('matches the list and the confirm paths, not unrelated paths', () => {
+    expect(isMcpApprovePath('/api/system/mcp/approve')).toBe(true);
+    expect(isMcpApprovePath('/api/system/mcp/approve/abc')).toBe(true);
+    // a trailing slash with no id is not a confirm target
+    expect(isMcpApprovePath('/api/system/mcp/approve/')).toBe(false);
+    expect(isMcpApprovePath('/api/system/mcp')).toBe(false);
+    expect(isMcpApprovePath(undefined)).toBe(false);
+  });
+});
+
+describe('handleMcpApproveRequest (#1766 security property)', () => {
+  it('REJECTS a Bearer/anon caller with 401 and NEVER executes the call', async () => {
+    const execute = vi.fn(async () => 'ran');
+    const { pendingId } = createPendingApproval({
+      toolName: 'destroy_thing',
+      args: {},
+      caller: 'token:ci-bot',
+      execute,
+    });
+
+    const res = await handleMcpApproveRequest({
+      method: 'POST',
+      pathname: `/api/system/mcp/approve/${pendingId}`,
+      resolveSession: noSession, // a Bearer/anon request carries no session cookie
+    });
+
+    expect(res.status).toBe(401);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('a logged-in human (cookie session) approves and the call executes', async () => {
+    const execute = vi.fn(async () => ({ content: [{ type: 'text', text: 'deleted' }] }));
+    const { pendingId } = createPendingApproval({ toolName: 'destroy_thing', args: {}, execute });
+
+    const res = await handleMcpApproveRequest({
+      method: 'POST',
+      pathname: `/api/system/mcp/approve/${pendingId}`,
+      resolveSession: human,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('an expired / unknown handle returns 410 Gone', async () => {
+    const res = await handleMcpApproveRequest({
+      method: 'POST',
+      pathname: '/api/system/mcp/approve/does-not-exist',
+      resolveSession: human,
+    });
+    expect(res.status).toBe(410);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it('an already-claimed (single-use) handle 410s on a replay', async () => {
+    const execute = vi.fn(async () => 'ran');
+    const { pendingId } = createPendingApproval({ toolName: 'destroy_thing', args: {}, execute });
+    const path = `/api/system/mcp/approve/${pendingId}`;
+
+    const first = await handleMcpApproveRequest({ method: 'POST', pathname: path, resolveSession: human });
+    expect(first.status).toBe(200);
+
+    const replay = await handleMcpApproveRequest({ method: 'POST', pathname: path, resolveSession: human });
+    expect(replay.status).toBe(410);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET lists pending approvals for a cookie session', async () => {
+    createPendingApproval({ toolName: 'destroy_thing', args: { id: 1 }, execute: async () => 'x' });
+    const res = await handleMcpApproveRequest({
+      method: 'GET',
+      pathname: '/api/system/mcp/approve',
+      resolveSession: human,
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { pending: Array<{ toolName: string }> };
+    expect(body.pending).toHaveLength(1);
+    expect(body.pending[0]!.toolName).toBe('destroy_thing');
+  });
+
+  it('GET list still requires a session (Bearer/anon → 401, no leak of pending calls)', async () => {
+    createPendingApproval({ toolName: 'destroy_thing', args: {}, execute: async () => 'x' });
+    const res = await handleMcpApproveRequest({
+      method: 'GET',
+      pathname: '/api/system/mcp/approve',
+      resolveSession: noSession,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('an unsupported method on the confirm path is 405', async () => {
+    const res = await handleMcpApproveRequest({
+      method: 'DELETE',
+      pathname: '/api/system/mcp/approve/abc',
+      resolveSession: human,
+    });
+    expect(res.status).toBe(405);
+  });
+});

--- a/packages/backend/src/lib/mcp/approveRoute.ts
+++ b/packages/backend/src/lib/mcp/approveRoute.ts
@@ -1,0 +1,94 @@
+/**
+ * MCP pending-approval HTTP intercept (#1766 fix) — the LIVE production handler.
+ *
+ * This is intercepted in server.ts BEFORE Next.js `handle()` rather than served
+ * by the Next.js API route (`app/api/system/mcp/approve/**`). Next.js Turbopack
+ * bundles a SEPARATE copy of the in-memory `pendingApprovals` store for each
+ * compilation unit, so a destructive call *proposed* via the `/mcp` endpoint
+ * lands in a different Map than the one a Next.js route would read — every
+ * confirm 410'd. Serving the approve routes from the same module graph as the
+ * `/mcp` handler (server.ts) makes propose + confirm share one store.
+ *
+ * Extracted into this module so the security property is unit-testable: the
+ * server.ts request closure isn't, but `handleMcpApproveRequest` is a pure-ish
+ * function over the request primitives.
+ *
+ * SECURITY (the whole point of the gate):
+ *   - Authentication is COOKIE-SESSION ONLY. A `Bearer sb_…` token (the
+ *     proposing agent) carries no session cookie, so `resolveSession` returns
+ *     null → 401, and `approvePendingApproval` is NEVER called. The agent has
+ *     no path to self-approve its own destructive proposal.
+ *   - CSRF: the `session` cookie is `SameSite=Lax` + `httpOnly` (see
+ *     packages/backend/src/lib/auth.ts `login`). A cross-site POST from a
+ *     malicious origin does NOT carry the cookie under Lax (Lax only attaches
+ *     on top-level GET navigations), so a forged confirm can't ride the user's
+ *     session. This matches the protection the superseded Next.js route relied
+ *     on — `requireSession`/`withApiHandler` carried no CSRF token either; both
+ *     paths rest on SameSite=Lax. No protection is dropped by the intercept.
+ */
+import {
+  listPendingApprovals,
+  approvePendingApproval,
+  ApprovalExpiredError,
+  type PendingApprovalView,
+} from './pendingApprovals';
+
+const BASE = '/api/system/mcp/approve';
+const PREFIX = `${BASE}/`;
+
+export interface ApproveResponse {
+  status: number;
+  body: unknown;
+}
+
+/** True for any path this intercept owns (so server.ts can route to it). */
+export function isMcpApprovePath(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  return pathname === BASE || (pathname.startsWith(PREFIX) && pathname.length > PREFIX.length);
+}
+
+/**
+ * Handle a `/api/system/mcp/approve[/:id]` request. `resolveSession` resolves
+ * the caller's session from the cookie header (null for Bearer/anon → 401).
+ * Returns the status + JSON body for server.ts to write.
+ */
+export async function handleMcpApproveRequest(input: {
+  method: string | undefined;
+  pathname: string;
+  resolveSession: () => Promise<unknown>;
+  onError?: (e: unknown) => void;
+}): Promise<ApproveResponse> {
+  const session = await input.resolveSession();
+  if (!session) {
+    // Bearer token or anonymous — 401; the agent must not self-approve.
+    return { status: 401, body: { error: 'Authentication required' } };
+  }
+
+  if (input.method === 'GET' && input.pathname === BASE) {
+    const pending: PendingApprovalView[] = listPendingApprovals();
+    return { status: 200, body: { pending } };
+  }
+
+  if (input.method === 'POST' && input.pathname !== BASE) {
+    const pendingId = input.pathname.slice(PREFIX.length);
+    try {
+      const result = await approvePendingApproval(pendingId);
+      return { status: 200, body: { ok: true, result } };
+    } catch (e) {
+      if (e instanceof ApprovalExpiredError) {
+        return {
+          status: 410,
+          body: {
+            ok: false,
+            error:
+              'This approval has expired or was already used. Ask the agent to propose the action again.',
+          },
+        };
+      }
+      input.onError?.(e);
+      return { status: 500, body: { ok: false, error: 'internal server error' } };
+    }
+  }
+
+  return { status: 405, body: { error: 'Method not allowed' } };
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -39,11 +39,7 @@ import { syncRegistries } from './lib/registry';
 import { reconcileLanIp } from './lib/lanIp';
 import { lazyInitializeExpiry as initBootstrapTokenExpiry } from './lib/mcp/bootstrapToken';
 import { createMcpServer } from './lib/mcp/server';
-import {
-  listPendingApprovals,
-  approvePendingApproval,
-  ApprovalExpiredError,
-} from './lib/mcp/pendingApprovals';
+import { isMcpApprovePath, handleMcpApproveRequest } from './lib/mcp/approveRoute';
 import { scheduleBackup } from './lib/backup/service';
 import { scheduleExternalNasBackup } from './lib/externalBackup/producer';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -278,55 +274,22 @@ app.prepare().then(() => {
         return;
       }
 
-      // MCP pending-approval routes — intercepted here (not via Next.js API routes)
-      // so they share the SAME pendingApprovals module instance as the /mcp handler
-      // above. Next.js Turbopack bundles a separate copy of the in-memory store for
-      // API routes, making proposals and confirms reference different Maps (#1766 fix).
-      //
-      // GET /api/system/mcp/approve — list pending (cookie-session only)
-      // POST /api/system/mcp/approve/:id — confirm a pending call (cookie-session only)
-      //
-      // Security: these routes accept ONLY session cookies, never Bearer tokens.
-      // The proposing token holder (the agent) has no path to self-approve.
-      if (parsedUrl.pathname === '/api/system/mcp/approve' ||
-          (parsedUrl.pathname?.startsWith('/api/system/mcp/approve/') && parsedUrl.pathname.length > '/api/system/mcp/approve/'.length)) {
-        const mcpApproveSession = await getSessionFromCookieHeader(req.headers.cookie);
-        if (!mcpApproveSession) {
-          // Bearer token or anonymous — 401; the agent must not self-approve.
-          res.writeHead(401, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Authentication required' }));
-          return;
-        }
-
-        if (req.method === 'GET' && parsedUrl.pathname === '/api/system/mcp/approve') {
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ pending: listPendingApprovals() }));
-          return;
-        }
-
-        if (req.method === 'POST' && parsedUrl.pathname !== '/api/system/mcp/approve') {
-          // Extract the pendingId from the path: /api/system/mcp/approve/:id
-          const pendingId = parsedUrl.pathname!.slice('/api/system/mcp/approve/'.length);
-          try {
-            const result = await approvePendingApproval(pendingId);
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ ok: true, result }));
-          } catch (e) {
-            if (e instanceof ApprovalExpiredError) {
-              res.writeHead(410, { 'Content-Type': 'application/json' });
-              res.end(JSON.stringify({ ok: false, error: 'This approval has expired or was already used. Ask the agent to propose the action again.' }));
-            } else {
-              logger.error('Server', 'MCP approve error', e);
-              res.writeHead(500, { 'Content-Type': 'application/json' });
-              res.end(JSON.stringify({ ok: false, error: 'internal server error' }));
-            }
-          }
-          return;
-        }
-
-        // Method not allowed
-        res.writeHead(405, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Method not allowed' }));
+      // MCP pending-approval routes — intercepted here (not via Next.js API
+      // routes) so they share the SAME pendingApprovals module instance as the
+      // /mcp handler above. Next.js Turbopack bundles a separate copy of the
+      // in-memory store for API routes, so a proposal made via /mcp would be
+      // invisible to a Next.js confirm route → every approve 410'd (#1766 fix).
+      // The handler is cookie-session ONLY (Bearer/anon → 401); see
+      // lib/mcp/approveRoute.ts for the full security/CSRF rationale.
+      if (isMcpApprovePath(parsedUrl.pathname)) {
+        const { status, body } = await handleMcpApproveRequest({
+          method: req.method,
+          pathname: parsedUrl.pathname!,
+          resolveSession: () => getSessionFromCookieHeader(req.headers.cookie),
+          onError: (e) => logger.error('Server', 'MCP approve error', e),
+        });
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(body));
         return;
       }
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -39,6 +39,11 @@ import { syncRegistries } from './lib/registry';
 import { reconcileLanIp } from './lib/lanIp';
 import { lazyInitializeExpiry as initBootstrapTokenExpiry } from './lib/mcp/bootstrapToken';
 import { createMcpServer } from './lib/mcp/server';
+import {
+  listPendingApprovals,
+  approvePendingApproval,
+  ApprovalExpiredError,
+} from './lib/mcp/pendingApprovals';
 import { scheduleBackup } from './lib/backup/service';
 import { scheduleExternalNasBackup } from './lib/externalBackup/producer';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -270,6 +275,58 @@ app.prepare().then(() => {
           transport.close();
           mcpServer.close();
         });
+        return;
+      }
+
+      // MCP pending-approval routes — intercepted here (not via Next.js API routes)
+      // so they share the SAME pendingApprovals module instance as the /mcp handler
+      // above. Next.js Turbopack bundles a separate copy of the in-memory store for
+      // API routes, making proposals and confirms reference different Maps (#1766 fix).
+      //
+      // GET /api/system/mcp/approve — list pending (cookie-session only)
+      // POST /api/system/mcp/approve/:id — confirm a pending call (cookie-session only)
+      //
+      // Security: these routes accept ONLY session cookies, never Bearer tokens.
+      // The proposing token holder (the agent) has no path to self-approve.
+      if (parsedUrl.pathname === '/api/system/mcp/approve' ||
+          (parsedUrl.pathname?.startsWith('/api/system/mcp/approve/') && parsedUrl.pathname.length > '/api/system/mcp/approve/'.length)) {
+        const mcpApproveSession = await getSessionFromCookieHeader(req.headers.cookie);
+        if (!mcpApproveSession) {
+          // Bearer token or anonymous — 401; the agent must not self-approve.
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Authentication required' }));
+          return;
+        }
+
+        if (req.method === 'GET' && parsedUrl.pathname === '/api/system/mcp/approve') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ pending: listPendingApprovals() }));
+          return;
+        }
+
+        if (req.method === 'POST' && parsedUrl.pathname !== '/api/system/mcp/approve') {
+          // Extract the pendingId from the path: /api/system/mcp/approve/:id
+          const pendingId = parsedUrl.pathname!.slice('/api/system/mcp/approve/'.length);
+          try {
+            const result = await approvePendingApproval(pendingId);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, result }));
+          } catch (e) {
+            if (e instanceof ApprovalExpiredError) {
+              res.writeHead(410, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ ok: false, error: 'This approval has expired or was already used. Ask the agent to propose the action again.' }));
+            } else {
+              logger.error('Server', 'MCP approve error', e);
+              res.writeHead(500, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ ok: false, error: 'internal server error' }));
+            }
+          }
+          return;
+        }
+
+        // Method not allowed
+        res.writeHead(405, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Method not allowed' }));
         return;
       }
 

--- a/packages/frontend/src/app/api/system/mcp/approve/[pendingId]/route.ts
+++ b/packages/frontend/src/app/api/system/mcp/approve/[pendingId]/route.ts
@@ -8,18 +8,18 @@ export const dynamic = 'force-dynamic';
  * Confirm (approve) a pending destructive MCP tool call (#1766) — the human
  * half of the propose → confirm → execute gate.
  *
- * SECURITY (the whole point of the feature): this route deliberately carries
- * NO `tokenScope`. A POST is a mutating verb, so withApiHandler runs the
- * requireSession gate; with no `tokenScope` set, requireSession *ignores* any
- * `Authorization: Bearer sb_…` and 401s a token caller (see
- * packages/backend/src/lib/api/requireSession.ts). Only a valid session
- * **cookie** (a logged-in human) is accepted. The agent that proposed the
- * call holds a token, so it can never self-approve its own request.
+ * NOTE: This route is superseded by the server.ts-level intercept (#1766 fix).
+ * See the comment in the adjacent route.ts (GET list) for the full explanation
+ * of WHY the server.ts intercept is necessary (Turbopack module isolation).
+ * server.ts intercepts /api/system/mcp/approve/:id before Next.js sees it,
+ * sharing the same in-memory store as the /mcp endpoint.
  *
- * On success the stored call executes through the same safety path
- * (snapshot → handler → audit/notify) it would have run inline, and the tool
- * result is returned. Single-use: the pending entry is claimed before it runs,
- * so it can't be confirmed twice. An expired/unknown id returns 410 Gone.
+ * SECURITY (preserved in the server.ts intercept): only session-cookie callers
+ * are accepted. Bearer tokens get 401 — the proposing agent cannot self-approve.
+ *
+ * This file is kept as dead code (never reached in production) so the route
+ * tree stays consistent and the unit test (route.test.ts) can still validate
+ * the logic in isolation.
  */
 export const POST = withApiHandlerParams<undefined, undefined, { pendingId: string }>(
   {},

--- a/packages/frontend/src/app/api/system/mcp/approve/route.ts
+++ b/packages/frontend/src/app/api/system/mcp/approve/route.ts
@@ -5,14 +5,18 @@ import { withApiHandler } from '@/lib/api/handler';
 export const dynamic = 'force-dynamic';
 
 /**
- * List pending MCP destructive-tool approvals (#1766). A token-authenticated
- * agent can *propose* a destroy-tier tool call; it parks here awaiting a human
- * confirm. The dashboard reads this to show the operator what is waiting.
+ * List pending MCP destructive-tool approvals (#1766).
  *
- * This GET carries no `tokenScope`, so the only Bearer token that would even
- * reach the handler still 401s at requireSession — the list, like the confirm,
- * is cookie-session only. (A GET with no Bearer is gate-skipped, but the proxy
- * is the primary gate for the dashboard origin.)
+ * NOTE: This route is superseded by the server.ts-level intercept that handles
+ * /api/system/mcp/approve before Next.js sees it. The intercept is required
+ * because Turbopack bundles a SEPARATE copy of the in-memory pendingApprovals
+ * store for each compilation unit — the /mcp endpoint and the Next.js API routes
+ * each get their own Map, so a proposal in /mcp would be invisible to this route.
+ * server.ts intercepts the path first so both the MCP endpoint and the approve
+ * routes share the same module-level store (#1766 fix).
+ *
+ * This file is kept as dead code so the Next.js route tree stays consistent and
+ * tools/tests that import the handler directly still compile.
  */
 export const GET = withApiHandler(
   {},


### PR DESCRIPTION
## Problem

#1766 (destructive-tool approval gate) is non-functional in production. Turbopack compiles `pendingApprovals.ts` into separate bundle chunks for each compilation unit:

- `/mcp` endpoint → `server.cjs` → gets its own `Map` store
- `/api/system/mcp/approve/*` Next.js routes → Next.js bundle → gets a **different** `Map` store

A token caller proposes a `delete_service` and the approval lands in `server.cjs`'s store. The human then POSTs to `/api/system/mcp/approve/:id`, which reads from the **Next.js bundle's empty store** → always 410 Gone.

Caught by box-verify of SHA 21641b58 — proposals created via `/mcp` were immediately invisible to `GET /api/system/mcp/approve`.

## Fix

Intercept `/api/system/mcp/approve` and `/api/system/mcp/approve/:id` directly in `server.ts` before Next.js sees them, using the same `pendingApprovals` module import as the `/mcp` handler. They now share the same in-memory store.

Security is unchanged: Bearer tokens → 401; only session-cookie callers can approve. The Next.js route files are kept but marked as dead code (unreachable in production) so the route tree and unit tests stay consistent.

## Verified

- `POST /mcp` with destroy token → `pending_approval` handle ✓
- `POST /api/system/mcp/approve/:id` with Bearer token → 401 (cannot self-approve) ✓  
- `POST /api/system/mcp/approve/:id` with session cookie → 200 + executes ✓ (after fix)
- All 2427 tests pass (1 pre-existing flaky HTTP mock in health_runner.test.ts, unrelated)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._