### PR TITLE
fix(home-assistant): rename long-lived token oscar→solilos with on-disk migration

### DIFF
--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -428,7 +428,11 @@ def ensure_auth_oidc_config_block() -> bool:
 # generates. Idempotent: if onboarding is already done OR the token file is
 # already present, the steps are skipped.
 
-HA_LONG_LIVED_TOKEN_PATH = "/.oscar-long-lived-token"  # joined with HA config dir
+HA_LONG_LIVED_TOKEN_PATH = "/.solilos-long-lived-token"  # joined with HA config dir
+# Pre-rename name (OSCAR→Solilos). Already-onboarded boxes have a valid token at
+# this path; we migrate it on disk so the deploy doesn't have to re-mint (and so
+# downstream post-deploys that look for the new name keep working without creds).
+HA_LEGACY_LONG_LIVED_TOKEN_PATH = "/.oscar-long-lived-token"
 HA_CONTAINER_NAME = "home-assistant-homeassistant"
 HA_CLIENT_ID = "http://127.0.0.1:8123/"
 
@@ -451,7 +455,7 @@ def _onboard_admin_user(username: str, password: str) -> str | None:
     None on failure. Pre-onboarding endpoint - no auth header needed."""
     body = json.dumps({
         "client_id": HA_CLIENT_ID,
-        "name": "OSCAR Admin",
+        "name": "Solilos Admin",
         "username": username,
         "password": password,
         "language": "en",
@@ -531,7 +535,7 @@ def _mint_long_lived_token(access_token: str) -> str | None:
         "        a = json.loads(await ws.recv())\n"
         "        if a.get('type') != 'auth_ok':\n"
         "            sys.stderr.write('auth fail: ' + json.dumps(a)); sys.exit(1)\n"
-        "        await ws.send(json.dumps({'id': 1, 'type': 'auth/long_lived_access_token', 'client_name': 'oscar-hermes', 'lifespan': 3650}))\n"
+        "        await ws.send(json.dumps({'id': 1, 'type': 'auth/long_lived_access_token', 'client_name': 'solilos-hermes', 'lifespan': 3650}))\n"
         "        r = json.loads(await ws.recv())\n"
         "        if not r.get('success'):\n"
         "            sys.stderr.write('mint fail: ' + json.dumps(r)); sys.exit(1)\n"
@@ -811,6 +815,21 @@ def configure_oscar_ha_onboarding() -> None:
         log("OSCAR_HA_ADMIN_USERNAME / _PASSWORD not set — skipping auto-onboarding.")
         return
     token_file = os.path.join(_ha_config_dir(), HA_LONG_LIVED_TOKEN_PATH.lstrip("/"))
+
+    # One-time migration for the OSCAR→Solilos rename (#1769). A box onboarded
+    # before the rename has a *valid* token at the legacy path. If the new file
+    # is absent but the legacy one is present, move it across so the existing
+    # token is reused (no re-mint, works without admin creds) and downstream
+    # post-deploys that read the new name keep authenticating.
+    legacy_token_file = os.path.join(
+        _ha_config_dir(), HA_LEGACY_LONG_LIVED_TOKEN_PATH.lstrip("/")
+    )
+    if not os.path.exists(token_file) and os.path.exists(legacy_token_file):
+        try:
+            os.rename(legacy_token_file, token_file)
+            log(f"   Migrated legacy HA token {legacy_token_file} → {token_file} (OSCAR→Solilos rename).")
+        except OSError as e:
+            log(f"   ⚠️ Could not migrate legacy HA token to {token_file}: {e}")
 
     # Reconcile an existing token first (#1505). A wipe-configs reinstall can
     # leave a token file behind in HA's kept config dir whose refresh-token

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -47,7 +47,7 @@
   },
   "OSCAR_HA_ADMIN_USERNAME": {
     "type": "text",
-    "description": "OSCAR-managed HA admin user. When set together with OSCAR_HA_ADMIN_PASSWORD on a fresh HA install, post-deploy walks HA's onboarding API (create user → core_config → analytics → integration) and mints a long-lived access token persisted at <config>/.oscar-long-lived-token. Downstream templates (hermes, oscar-household) read that token instead of the random pre-onboarding placeholder, so Hermes' native HA gateway can actually authenticate and #920 ('turn on the kitchen light') works without operator browser steps. Leave blank to skip auto-onboarding and use HA's first-boot wizard manually.",
+    "description": "OSCAR-managed HA admin user. When set together with OSCAR_HA_ADMIN_PASSWORD on a fresh HA install, post-deploy walks HA's onboarding API (create user → core_config → analytics → integration) and mints a long-lived access token persisted at <config>/.solilos-long-lived-token. Downstream templates (hermes, oscar-household) read that token instead of the random pre-onboarding placeholder, so Hermes' native HA gateway can actually authenticate and #920 ('turn on the kitchen light') works without operator browser steps. Leave blank to skip auto-onboarding and use HA's first-boot wizard manually.",
     "default": "oscar"
   },
   "OSCAR_HA_ADMIN_PASSWORD": {

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1421,7 +1421,7 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("Re-provisioning HA long-lived token from kept data", out)
             self.assertEqual(minted.get("access"), "short-lived-tok")
-            token_file = os.path.join(tmp, "home-assistant", "homeassistant", ".oscar-long-lived-token")
+            token_file = os.path.join(tmp, "home-assistant", "homeassistant", ".solilos-long-lived-token")
             self.assertTrue(os.path.isfile(token_file))
             with open(token_file) as fh:
                 self.assertEqual(fh.read().strip(), "long-lived-tok")
@@ -1436,7 +1436,7 @@ class HomeAssistantScript(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = os.path.join(tmp, "home-assistant", "homeassistant")
             os.makedirs(cfg, exist_ok=True)
-            with open(os.path.join(cfg, ".oscar-long-lived-token"), "w") as fh:
+            with open(os.path.join(cfg, ".solilos-long-lived-token"), "w") as fh:
                 fh.write("good-token\n")
             # Stamp so the OIDC install path skips the tarball download.
             oidc = os.path.join(cfg, "custom_components", "auth_oidc")
@@ -1470,6 +1470,61 @@ class HomeAssistantScript(unittest.TestCase):
                     mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
                 rc, out = capture_main(m)
             self.assertEqual(rc, 0)
+            self.assertIn("still authenticates — nothing to reconcile", out)
+
+    def test_legacy_oscar_token_migrated_to_solilos(self):
+        """#1769: a box onboarded before the OSCAR→Solilos rename has a valid
+        token only at the legacy `.oscar-long-lived-token` path. The deploy
+        renames it on disk to `.solilos-long-lived-token` and reuses it — no
+        re-mint, no login flow, even without working admin creds."""
+        import tempfile
+        import urllib.request
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            os.makedirs(cfg, exist_ok=True)
+            legacy_file = os.path.join(cfg, ".oscar-long-lived-token")
+            new_file = os.path.join(cfg, ".solilos-long-lived-token")
+            with open(legacy_file, "w") as fh:
+                fh.write("good-token\n")
+            # Stamp so the OIDC install path skips the tarball download.
+            oidc = os.path.join(cfg, "custom_components", "auth_oidc")
+            os.makedirs(oidc, exist_ok=True)
+            with open(os.path.join(oidc, ".sb_installed_version"), "w") as fh:
+                fh.write("v0.6.0\n")
+
+            def fake_urlopen(req, *_a, **_kw):
+                url = req.full_url if hasattr(req, "full_url") else str(req)
+                if "/auth/login_flow" in url:
+                    raise AssertionError("must not start a login flow after migrating a valid legacy token")
+
+                class _R:
+                    status = 200
+                    def read(self):
+                        return b"<html></html>"
+                    def __enter__(self):
+                        return self
+                    def __exit__(self, *a):
+                        return False
+                return _R()
+
+            env = {
+                "HA_OIDC_AUTH_VERSION": "v0.6.0",
+                "DATA_DIR": tmp,
+                "OSCAR_HA_ADMIN_USERNAME": "oscar",
+                "OSCAR_HA_ADMIN_PASSWORD": "pw",
+            }
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen", fake_urlopen), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertFalse(os.path.exists(legacy_file))
+            self.assertTrue(os.path.isfile(new_file))
+            with open(new_file) as fh:
+                self.assertEqual(fh.read().strip(), "good-token")
+            self.assertIn("Migrated legacy HA token", out)
             self.assertIn("still authenticates — nothing to reconcile", out)
 
     def test_kept_data_state_reported(self):


### PR DESCRIPTION
## What
HA post-deploy now writes/reads the long-lived token at `.solilos-long-lived-token` (admin display name `Solilos Admin`, client_name `solilos-hermes`), matching the OSCAR→Solilos product rename so Hermes finds the token on a fresh install.

## Why
Closes #1769

## Legacy migration
One-time on-disk migration: when the new `.solilos-long-lived-token` is absent but the legacy `.oscar-long-lived-token` exists, it is renamed across — an already-onboarded box keeps its existing token with no re-mint (works even without admin creds set).

## Risk
Low — Python post-deploy template + tests only; covered by the vitest python subprocess suite.

## Rollback
git revert is enough.

## Verification
- [ ] npm run lint
- [ ] npm run check:arch
- [ ] npm test (full, incl. python post-deploy subprocess)
- [ ] /verify on FCoS :dev box (path-mandated install/onboarding path)

AI-generated
<!-- sb-ai-comment -->