### PR TITLE
chore(eslint): disable @typescript-eslint/no-unused-vars (unused-imports owns it)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -212,6 +212,10 @@ const eslintConfig = defineConfig([
           argsIgnorePattern: "^_",
         },
       ],
+      // @typescript-eslint/no-unused-vars comes from nextTs preset without
+      // varsIgnorePattern/argsIgnorePattern; unused-imports/no-unused-vars is
+      // the authoritative owner with ^_ ignores, so disable the base rule.
+      "@typescript-eslint/no-unused-vars": "off",
       // --- Dead-code detection (syntactic + constant-folded). Exact, near
       // zero false positives; complements knip (module-level unused
       // files/exports) and branch coverage (semantic / runtime-dead). These


### PR DESCRIPTION
## Summary
Disable the `@typescript-eslint/no-unused-vars` base rule from the `nextTs` preset, which lacks `varsIgnorePattern`/`argsIgnorePattern` and conflicts with `unused-imports/no-unused-vars` which has the `^_` ignore patterns. The unused-imports plugin's recommended setup is to be the single owner of unused-variable detection.

This clears ~15 false-positive warnings on intentionally underscore-prefixed unused parameters (mostly in `.test.ts` mocks).

<!-- sb-ai-comment -->