### PR TITLE
fix: maintenance-chat markdown node attr + MCP .container Quadlet support

### DIFF
--- a/packages/backend/src/lib/mcp/server.containerQuadlet.test.ts
+++ b/packages/backend/src/lib/mcp/server.containerQuadlet.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+// #1778: update_service_yaml must route a single-container `.container`
+// Quadlet (ollama after the GPU fixup) to deployContainerQuadlet — writing the
+// edited unit body straight back — instead of treating it as a `.kube` pod
+// spec and rejecting it via the footgun guard. We mock ServiceManager so the
+// SDK round-trip asserts the wiring without a real agent/box.
+const getServiceFiles = vi.fn();
+const deployContainerQuadlet = vi.fn(async (..._args: unknown[]) => undefined);
+const deployKubeService = vi.fn(async (..._args: unknown[]) => undefined);
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: {
+    getServiceFiles: (...args: unknown[]) => getServiceFiles(...args),
+    deployContainerQuadlet: (...args: unknown[]) => deployContainerQuadlet(...args),
+    deployKubeService: (...args: unknown[]) => deployKubeService(...args),
+  },
+}));
+
+async function connectClient() {
+  const { createMcpServer } = await import('./server');
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+  return { client };
+}
+
+const OLLAMA_BODY = [
+  '[Unit]',
+  'Description=Ollama',
+  '',
+  '[Container]',
+  'Image=docker.io/ollama/ollama:latest',
+  'AddDevice=nvidia.com/gpu=all',
+  'PublishPort=11434:11434',
+].join('\n');
+
+describe('update_service_yaml — .container Quadlet routing (#1778)', () => {
+  beforeEach(() => {
+    getServiceFiles.mockReset();
+    deployContainerQuadlet.mockReset();
+    deployKubeService.mockReset();
+  });
+
+  it('writes the edited .container unit body back via deployContainerQuadlet', async () => {
+    getServiceFiles.mockResolvedValue({
+      kubeContent: OLLAMA_BODY,
+      yamlContent: '',
+      yamlPath: '',
+      quadletKind: 'container',
+      kubePath: '/var/home/core/.config/containers/systemd/ollama.container',
+    });
+    const { client } = await connectClient();
+    const edited = OLLAMA_BODY.replace('11434:11434', '11434:11434\nEnvironment=OLLAMA_DEBUG=1');
+    const res = await client.callTool({
+      name: 'update_service_yaml',
+      arguments: { node: 'local', name: 'ollama', kubeContent: edited },
+    });
+    expect(res.isError).toBeFalsy();
+    expect(deployContainerQuadlet).toHaveBeenCalledTimes(1);
+    expect(deployKubeService).not.toHaveBeenCalled();
+    // Targets the real service name with the edited unit body.
+    expect(deployContainerQuadlet).toHaveBeenCalledWith('local', 'ollama', edited);
+    await client.close();
+  });
+
+  it('does not look up the service for the common .kube pod-spec path (no [Container])', async () => {
+    // A pod spec carries no `[Container]` section, so the .container lookup is
+    // skipped entirely — keeps the hot path off a per-call agent round-trip.
+    getServiceFiles.mockResolvedValue({ quadletKind: 'kube' });
+    const { client } = await connectClient();
+    const res = await client.callTool({
+      name: 'update_service_yaml',
+      arguments: { node: 'local', name: 'vaultwarden', podSpecContent: 'apiVersion: v1\nkind: Pod\nspec:\n  containers: []\n' },
+    });
+    expect(res.isError).toBeFalsy();
+    expect(getServiceFiles).not.toHaveBeenCalled();
+    expect(deployKubeService).toHaveBeenCalledTimes(1);
+    await client.close();
+  });
+
+  it('falls through to the footgun guard when a [Container] body is passed for a .kube service', async () => {
+    getServiceFiles.mockResolvedValue({ quadletKind: 'kube', kubeContent: '[Kube]\nYaml=x.yml' });
+    const { client } = await connectClient();
+    const res = await client.callTool({
+      name: 'update_service_yaml',
+      arguments: { node: 'local', name: 'vaultwarden', kubeContent: '[Container]\nImage=x' },
+    });
+    expect(res.isError).toBe(true);
+    expect(deployContainerQuadlet).not.toHaveBeenCalled();
+    expect(deployKubeService).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('still routes a .kube service through deployKubeService (pod spec)', async () => {
+    getServiceFiles.mockResolvedValue({
+      kubeContent: '[Kube]\nYaml=vaultwarden.yml',
+      yamlContent: 'apiVersion: v1\nkind: Pod\n',
+      yamlPath: '/x/vaultwarden.yml',
+      quadletKind: 'kube',
+      kubePath: '/x/vaultwarden.kube',
+    });
+    const { client } = await connectClient();
+    const res = await client.callTool({
+      name: 'update_service_yaml',
+      arguments: { node: 'local', name: 'vaultwarden', podSpecContent: 'apiVersion: v1\nkind: Pod\nspec:\n  containers: []\n' },
+    });
+    expect(res.isError).toBeFalsy();
+    expect(deployKubeService).toHaveBeenCalledTimes(1);
+    expect(deployContainerQuadlet).not.toHaveBeenCalled();
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -511,7 +511,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Get Service Files ---
   server.tool(
     'get_service_files',
-    'Get the on-disk files for a service. Returns `kubeContent` = the systemd `.kube` Quadlet unit ([Kube]/[Install] sections), and `yamlContent` = the Kubernetes Pod-spec `.yml` (apiVersion/kind/spec). WARNING: these field names are REVERSED relative to update_service_yaml — to edit and write back the pod spec, pass this tool\'s `yamlContent` into update_service_yaml\'s `kubeContent`/`podSpecContent` param, NOT this tool\'s `kubeContent` (that is the Quadlet unit, which update_service_yaml regenerates on its own).',
+    'Get the on-disk files for a service. Returns `kubeContent` = the systemd Quadlet unit, `yamlContent` = the Kubernetes Pod-spec `.yml` (apiVersion/kind/spec), and `quadletKind` = "kube" or "container". For a `.kube` service (quadletKind="kube"): `kubeContent` is the [Kube]/[Install] unit and `yamlContent` is the pod spec; these field names are REVERSED relative to update_service_yaml — to write back the pod spec, pass this tool\'s `yamlContent` into update_service_yaml (the Quadlet unit is regenerated on its own). For a single-container `.container` service (quadletKind="container", e.g. ollama after the GPU fixup): `kubeContent` is the whole `.container` unit ([Container] section) and `yamlContent` is empty — the unit file IS the artifact, so edit `kubeContent` and pass it straight into update_service_yaml.',
     { name: z.string().describe('Service name'), node: nodeParam },
     async ({ name, node }) => {
       const nodeName = await resolveNode(node);
@@ -876,7 +876,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // --- Update Service YAML (edit then redeploy) ---
   server.tool(
     'update_service_yaml',
-    'Replace a service\'s Kubernetes Pod-spec `.yml` and redeploy it. Use `get_service_files` first, modify, then call this. NOTE the field-name mismatch: the content this tool wants (in `kubeContent`/`podSpecContent`) is the POD SPEC — i.e. the `yamlContent` returned by get_service_files (apiVersion/kind/spec), NOT its `kubeContent` (the `.kube` Quadlet unit). The Quadlet unit is regenerated automatically; do not pass it here. The file is written and `systemctl --user daemon-reload` + service restart is triggered.',
+    'Replace a service\'s on-disk definition and redeploy it. Use `get_service_files` first, modify, then call this. For a `.kube` service (quadletKind="kube"): the content this tool wants (in `kubeContent`/`podSpecContent`) is the POD SPEC — i.e. the `yamlContent` returned by get_service_files (apiVersion/kind/spec), NOT its `kubeContent` (the `.kube` Quadlet unit, regenerated automatically). For a single-container `.container` service (quadletKind="container", e.g. ollama): there is no pod spec — pass the edited `.container` unit body (the `kubeContent` from get_service_files, with a [Container] section) and it is written straight back. Either way the file is written and `systemctl --user daemon-reload` + restart is triggered.',
     {
       name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').describe('Service name'),
       kubeContent: z.string().min(1).optional().describe('The Pod-spec `.yml` content (the `yamlContent` from get_service_files, apiVersion/kind/spec) — NOT the `.kube` Quadlet unit. Historical name; prefer `podSpecContent`. One of kubeContent / podSpecContent is required.'),
@@ -891,6 +891,25 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         const podSpec = podSpecContent ?? kubeContent;
         if (!podSpec) {
           return errorResult('Error updating service: provide the Pod-spec `.yml` content via `podSpecContent` (or `kubeContent`).');
+        }
+        // #1778: a single-container `.container` Quadlet (the ollama GPU
+        // fixup) has no separate pod spec — the unit file IS the deploy
+        // artifact, so the read/update contract differs: the caller edits
+        // the `.container` unit body (the `kubeContent` from
+        // get_service_files) and we write it straight back. A `.container`
+        // body is the only legitimate reason to pass a `[Container]`
+        // section, so only then do we look the service up (avoids a per-call
+        // agent round-trip on the common `.kube` pod-spec path); the lookup
+        // confirms the on-disk unit really is a `.container` before writing.
+        if (/^\s*\[Container\]/m.test(podSpec)) {
+          const existing = await ServiceManager.getServiceFiles(nodeName, name).catch(() => null);
+          if (existing?.quadletKind === 'container') {
+            await ServiceManager.deployContainerQuadlet(nodeName, name, podSpec);
+            return textResult(`Service "${name}" (.container Quadlet) updated and redeployed`);
+          }
+          // Not a .container service — fall through to the footgun guard,
+          // which correctly rejects a Quadlet unit passed where a pod spec
+          // is expected.
         }
         // Field-name footgun guard: get_service_files returns the `.kube`
         // Quadlet unit under `kubeContent`. If a caller round-trips that field

--- a/packages/backend/src/lib/services/ServiceManager.test.ts
+++ b/packages/backend/src/lib/services/ServiceManager.test.ts
@@ -22,6 +22,17 @@ vi.mock('../store/twin', () => ({
     }
 }));
 
+// getServiceFiles still calls loadSystemdUnitInfo (systemctl cat / show) via
+// the agent even when the Quadlet body is served from the twin cache. Stub the
+// agent so those exec calls don't blow up; the unit content itself comes from
+// the mocked twin files.
+const mockSendCommand = vi.fn(async () => ({ code: 1, stdout: '', stderr: '' }));
+vi.mock('../agent/manager', () => ({
+    agentManager: {
+        ensureAgent: async () => ({ sendCommand: mockSendCommand }),
+    },
+}));
+
 describe('ServiceManager (V4)', () => {
     beforeEach(() => {
         mockNodes['local'] = {
@@ -216,5 +227,80 @@ Volume=my-vol:/data:Z
         expect(svc.volumes).toHaveLength(2);
         expect(svc.volumes[0]).toEqual({ host: '/host/path', container: '/container/path' });
         expect(svc.volumes[1]).toEqual({ host: 'my-vol', container: '/data' });
+    });
+});
+
+describe('getServiceFiles — .container Quadlet resolution (#1778)', () => {
+    const OLLAMA_PATH = '/var/home/core/.config/containers/systemd/ollama.container';
+    const OLLAMA_BODY = [
+        '[Unit]',
+        'Description=Ollama',
+        '',
+        '[Container]',
+        'Image=docker.io/ollama/ollama:latest',
+        'AddDevice=nvidia.com/gpu=all',
+        'PublishPort=11434:11434',
+        '',
+        '[Install]',
+        'WantedBy=default.target',
+    ].join('\n');
+
+    beforeEach(() => {
+        mockNodes['local'] = {
+            services: [],
+            containers: [],
+            files: {},
+            volumes: [],
+            systemInfo: {},
+            lastUpdate: 0,
+        };
+        mockSendCommand.mockClear();
+    });
+
+    it('resolves a .container service (not "File not found: ollama.kube")', async () => {
+        // Regression for #1778: ollama runs as a single-container .container
+        // Quadlet (the #1026 GPU fixup). The old path constructed
+        // `${name}.kube` and 404'd; it must now serve the real .container body.
+        mockNodes['local'].files = {
+            [OLLAMA_PATH]: { path: OLLAMA_PATH, content: OLLAMA_BODY, modified: 0 },
+        } as any;
+
+        const files = await ServiceManager.getServiceFiles('local', 'ollama');
+        expect(files.quadletKind).toBe('container');
+        // kubeContent surfaces the .container unit body itself.
+        expect(files.kubeContent).toContain('[Container]');
+        expect(files.kubeContent).toContain('AddDevice=nvidia.com/gpu=all');
+        // No separate pod spec for a .container — yamlContent stays empty.
+        expect(files.yamlContent).toBe('');
+        expect(files.yamlPath).toBe('');
+        // kubePath points at the REAL .container path so writes target it.
+        expect(files.kubePath).toBe(OLLAMA_PATH);
+    });
+
+    it('still resolves a .kube service to its pod-spec yaml', async () => {
+        const kubePath = '/var/home/core/.config/containers/systemd/vaultwarden.kube';
+        const yamlPath = '/var/home/core/.config/containers/systemd/vaultwarden.yml';
+        mockNodes['local'].files = {
+            [kubePath]: { path: kubePath, content: 'Yaml=vaultwarden.yml\n', modified: 0 },
+            [yamlPath]: { path: yamlPath, content: 'apiVersion: v1\nkind: Pod\n', modified: 0 },
+        } as any;
+
+        const files = await ServiceManager.getServiceFiles('local', 'vaultwarden');
+        expect(files.quadletKind).toBe('kube');
+        expect(files.kubeContent).toContain('Yaml=vaultwarden.yml');
+        expect(files.yamlContent).toContain('kind: Pod');
+    });
+
+    it('prefers .kube when both extensions somehow exist', async () => {
+        const kubePath = '/x/dual.kube';
+        const containerPath = '/x/dual.container';
+        mockNodes['local'].files = {
+            [containerPath]: { path: containerPath, content: '[Container]\nImage=x', modified: 0 },
+            [kubePath]: { path: kubePath, content: 'Yaml=dual.yml', modified: 0 },
+        } as any;
+
+        const files = await ServiceManager.getServiceFiles('local', 'dual');
+        expect(files.quadletKind).toBe('kube');
+        expect(files.kubePath).toBe(kubePath);
     });
 });

--- a/packages/backend/src/lib/services/ServiceManager.ts
+++ b/packages/backend/src/lib/services/ServiceManager.ts
@@ -56,6 +56,7 @@ export class ServiceManager {
     static ensurePodmanSocket = ServiceLifecycle.ensurePodmanSocket;
     static ensureUnprivilegedPorts = ServiceLifecycle.ensureUnprivilegedPorts;
     static deployKubeService = ServiceLifecycle.deployKubeService;
+    static deployContainerQuadlet = ServiceLifecycle.deployContainerQuadlet;
     static deployService = ServiceLifecycle.deployService;
     static removeService = ServiceLifecycle.removeService;
     static saveService = ServiceLifecycle.saveService;

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -906,6 +906,35 @@ export class ServiceLifecycle {
     }
 
     /**
+     * Write back an edited single-container `.container` Quadlet and
+     * redeploy it (#1778).
+     *
+     * Unlike a `.kube` Quadlet — which is a thin wrapper that
+     * `deployKubeService` regenerates around a separate pod-spec `.yml` —
+     * a `.container` unit IS the deploy artifact (the ollama GPU fixup,
+     * #1026, swaps to `.container` so `AddDevice=nvidia.com/gpu=all`
+     * survives). So the read/update contract for `.container` is: the
+     * caller edits the `.container` unit body itself (the `kubeContent`
+     * from `getServiceFiles`) and we write it straight back, reload the
+     * daemon, and restart. There is no pod spec, no port-collision
+     * pre-flight on a `.yml` (the unit body owns its own `PublishPort=`),
+     * and no schema-version stamping.
+     */
+    static async deployContainerQuadlet(
+        nodeName: string,
+        name: string,
+        containerContent: string,
+    ) {
+        await ServiceLifecycle.writeFile(nodeName, `${name}.container`, containerContent);
+        await ServiceLifecycle.reloadDaemon(nodeName);
+        // Restart so the regenerated unit takes effect. `.container` units
+        // pull their own image on start (Image= directive), so no separate
+        // pre-pull step is needed here.
+        await ServiceLifecycle.restartService(nodeName, name);
+        ServiceLifecycle.backupQuadlets(nodeName);
+    }
+
+    /**
      * Pull every hostPort declared in a kube YAML. Tolerates malformed YAML
      * (returns empty rather than throwing) so a parse error never blocks a
      * deploy via the collision check.

--- a/packages/backend/src/lib/services/serviceListing.ts
+++ b/packages/backend/src/lib/services/serviceListing.ts
@@ -546,17 +546,50 @@ export class ServiceListing {
     // same transform without importing this whole class.
 
     /**
+     * Resolve the on-disk Quadlet unit a service is backed by.
+     *
+     * A service can be backed by either a `<name>.kube` (the common
+     * pod-Quadlet, which references a separate `.yml` pod spec) or a
+     * single-container `<name>.container` Quadlet (the ollama GPU fixup,
+     * #1026 — managed-detection for these landed in #1733 but the
+     * file-read/update path still assumed `.kube`, so `.container`
+     * services 404'd, #1778).
+     *
+     * Returns the twin file key of the unit and its kind. `.kube` takes
+     * precedence when both somehow exist. Returns null when neither is in
+     * the twin (the caller then falls back to a raw `~/<name>.kube` read).
+     */
+    private static resolveQuadletUnit(
+        twin: import('../store/twin').NodeTwin | null | undefined,
+        serviceName: string,
+    ): { path: string; kind: 'kube' | 'container' } | null {
+        if (!twin) return null;
+        const keys = Object.keys(twin.files);
+        const kubeKey = keys.find(p => p.endsWith(`${serviceName}.kube`));
+        if (kubeKey) return { path: kubeKey, kind: 'kube' };
+        const containerKey = keys.find(p => p.endsWith(`${serviceName}.container`));
+        if (containerKey) return { path: containerKey, kind: 'container' };
+        return null;
+    }
+
+    /**
      * Read kube file content from twin cache or agent.
+     *
+     * `unit` is the pre-resolved Quadlet unit (`.kube` or `.container`)
+     * from {@link resolveQuadletUnit}; when present its on-disk content is
+     * returned regardless of extension. When absent we fall back to an
+     * agent read of the constructed `<name>.kube` path (the historical
+     * behaviour for services not yet in the twin file cache).
      */
     private static async readKubeContent(
         agent: import('../agent/handler').AgentHandler,
         twin: import('../store/twin').NodeTwin | null | undefined,
         serviceName: string,
         kubePath: string,
+        unit: { path: string; kind: 'kube' | 'container' } | null,
     ): Promise<string> {
-        const fullKubePath = twin ? Object.keys(twin.files).find(p => p.endsWith(`${serviceName}.kube`)) : null;
-        if (twin && fullKubePath && twin.files[fullKubePath]?.content) {
-            return twin.files[fullKubePath].content;
+        if (twin && unit && twin.files[unit.path]?.content) {
+            return twin.files[unit.path].content;
         }
 
         if (twin && twin.services?.length) {
@@ -593,27 +626,53 @@ export class ServiceListing {
         }
     }
 
-    /** Pre-pull container images so systemd start doesn't timeout */
+    /**
+     * Read a service's on-disk files.
+     *
+     * Returns `kubeContent` = the Quadlet unit, `yamlContent` = the pod
+     * spec it references. The unit may be a `.kube` (pod Quadlet → has a
+     * separate `Yaml=<name>.yml` pod spec) or a `.container` (single-
+     * container Quadlet, the ollama GPU fixup — #1026/#1778). A
+     * `.container` IS the deploy artifact: there is no separate pod spec,
+     * so `yamlContent`/`yamlPath` stay empty and `quadletKind:"container"`
+     * tells the caller to edit the unit file itself rather than a pod spec
+     * (mirrors the `.container` managed-detection from #1733).
+     *
+     * `kubePath` is the constructed default; when the service resolves to a
+     * `.container` in the twin, `kubePath` is the real `.container` path so
+     * writes target the right file.
+     */
     static async getServiceFiles(nodeName: string, serviceName: string) {
         const agent = await agentManager.ensureAgent(nodeName);
-        const kubePath = path.join(SYSTEMD_DIR, `${serviceName}.kube`);
+        let kubePath = path.join(SYSTEMD_DIR, `${serviceName}.kube`);
         let kubeContent = '';
         let yamlContent = '';
         let yamlPath = '';
         let serviceContent = '';
         let servicePath = '';
+        let quadletKind: 'kube' | 'container' = 'kube';
 
         try {
             const { getNodeTwin } = await import('../store/repository');
             const twin = getNodeTwin(nodeName);
 
-            kubeContent = await ServiceListing.readKubeContent(agent, twin, serviceName, kubePath);
+            const unit = ServiceListing.resolveQuadletUnit(twin, serviceName);
+            if (unit) {
+                quadletKind = unit.kind;
+                kubePath = unit.path;
+            }
 
-            const yamlMatch = kubeContent.match(/Yaml=(.+)/);
-            if (yamlMatch) {
-                const yamlFileName = yamlMatch[1].trim();
-                yamlPath = yamlFileName.startsWith('/') ? yamlFileName : path.join(SYSTEMD_DIR, yamlFileName);
-                yamlContent = await ServiceListing.readYamlContent(agent, twin, yamlFileName, yamlPath);
+            kubeContent = await ServiceListing.readKubeContent(agent, twin, serviceName, kubePath, unit);
+
+            // A `.container` Quadlet has no separate pod spec — the unit file
+            // is the whole artifact, so skip the `Yaml=` lookup entirely.
+            if (quadletKind === 'kube') {
+                const yamlMatch = kubeContent.match(/Yaml=(.+)/);
+                if (yamlMatch) {
+                    const yamlFileName = yamlMatch[1].trim();
+                    yamlPath = yamlFileName.startsWith('/') ? yamlFileName : path.join(SYSTEMD_DIR, yamlFileName);
+                    yamlContent = await ServiceListing.readYamlContent(agent, twin, yamlFileName, yamlPath);
+                }
             }
 
             ({ serviceContent, servicePath } = await loadSystemdUnitInfo(agent, serviceName));
@@ -622,7 +681,7 @@ export class ServiceListing {
             throw new Error(`Service ${serviceName} not found: ${msg}`);
         }
 
-        return { kubeContent, yamlContent, yamlPath, serviceContent, kubePath, servicePath };
+        return { kubeContent, yamlContent, yamlPath, serviceContent, kubePath, servicePath, quadletKind };
     }
 
     static async listTrashedServices(nodeName: string): Promise<Array<{

--- a/packages/frontend/src/components/HermesChatPanel.test.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.test.tsx
@@ -226,6 +226,22 @@ describe('HermesChatPanel', () => {
     expect(pre?.textContent).toContain('"ok": true');
   });
 
+  // #1777 — the markdown component overrides must not forward react-markdown's
+  // internal `node` (hast) prop onto DOM elements (it leaked as
+  // node="[object Object]" on every <code>, which is invalid HTML).
+  it('does not leak a `node` attribute onto any rendered element (#1777)', async () => {
+    const md = ['Use `inline code` here:', '', '```json', '{ "ok": true }', '```'].join('\n');
+    mockFetch({ get: () => jsonResponse(200, { messages: [{ role: 'assistant', text: md }] }) });
+
+    const { container } = render(<HermesChatPanel />);
+    const bubble = await screen.findByTestId('hermes-msg-assistant');
+    // Sanity: the inline code + fenced block actually rendered.
+    expect(bubble.querySelector('code')).not.toBeNull();
+    expect(bubble.querySelector('pre')).not.toBeNull();
+    // No element anywhere in the chat log carries a `node` attribute.
+    expect(container.querySelector('[node]')).toBeNull();
+  });
+
   it('renders plain-text assistant content unchanged as Markdown (#1768)', async () => {
     mockFetch({
       get: () =>

--- a/packages/frontend/src/components/HermesChatPanel.tsx
+++ b/packages/frontend/src/components/HermesChatPanel.tsx
@@ -77,7 +77,7 @@ const markdownComponents: Components = {
       {children}
     </a>
   ),
-  code: ({ className, children, ...props }) => {
+  code: ({ node: _node, className, children, ...props }) => {
     // react-markdown gives inline code no language className; fenced blocks get
     // `language-*`. Render inline code as a small chip, fenced code is handled
     // by `pre` below (this just styles the inner <code>).

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -130,6 +130,13 @@ describe('Template ↔ source-name consistency', () => {
     // live in this repo any more, but the service name on the agent
     // is still 'hermes' — the reference is legitimate. See #1159.
     'hermes',
+    // Service identifiers used as getServiceFiles() fixtures in
+    // ServiceManager.test.ts for the .container Quadlet resolution path
+    // (#1778): 'ollama' is a real `.container`-Quadlet service (no
+    // templates/ dir — it ships as an oscar GPU-fixup unit) and 'dual'
+    // is a synthetic fixture name for the both-.kube-and-.container case.
+    'ollama',
+    'dual',
   ]);
 
   // Patterns to scan for in src/ — each captures a template-name string literal.


### PR DESCRIPTION
## What
Closes #1777 — Maintenance chat: stop react-markdown leaking the hast `node` prop onto rendered `<code>` elements and drop the redundant `<p>` margin on single-line replies.
Closes #1778 — MCP service tools now handle `.container` Quadlets: `get_service_files`/`update_service_yaml`/`deployContainerQuadlet` read and write `.container` unit bodies (e.g. ollama) alongside the existing `.kube` pod-spec path.

## Risk
Low — #1777 is frontend-only; #1778 adds a `.container` branch without changing the `.kube` path.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint
- [x] npm run check:arch
- [x] npm test (full)
- [ ] /verify on FCoS :dev box (#1778 path-mandated — lib/mcp + lib/services)

AI-generated
<!-- sb-ai-comment -->
