### PR TITLE
feat(network-map): orthogonal ELK routing + ubiquitous-dep badges + focus/ego mode

### DIFF
--- a/packages/backend/src/lib/network/layout.test.ts
+++ b/packages/backend/src/lib/network/layout.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+
+// #1782 — drive ELK with a deterministic stub so we can assert how the
+// orthogonal routing sections are read back and attached to the React Flow
+// edges. The real elkjs WASM layout is non-deterministic and slow; the
+// contract we care about here is the point extraction + parent offsetting.
+const { layoutMock } = vi.hoisted(() => ({ layoutMock: vi.fn() }));
+
+vi.mock('elkjs/lib/elk.bundled.js', () => {
+  return {
+    default: class {
+      layout = layoutMock;
+    },
+  };
+});
+
+vi.mock('../logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { getLayoutedElements } from './layout';
+
+describe('getLayoutedElements — ELK orthogonal routing (#1782)', () => {
+  it('attaches absolute orthogonal points for a root edge', async () => {
+    layoutMock.mockResolvedValueOnce({
+      id: 'root',
+      children: [
+        { id: 'a', x: 0, y: 0, width: 100, height: 50, children: [] },
+        { id: 'b', x: 300, y: 0, width: 100, height: 50, children: [] },
+      ],
+      edges: [
+        {
+          id: 'e1',
+          sources: ['a'],
+          targets: ['b'],
+          sections: [
+            {
+              id: 's1',
+              startPoint: { x: 100, y: 25 },
+              bendPoints: [{ x: 200, y: 25 }],
+              endPoint: { x: 300, y: 25 },
+            },
+          ],
+        },
+      ],
+    });
+
+    const nodes: Node[] = [
+      { id: 'a', position: { x: 0, y: 0 }, data: { type: 'router' } },
+      { id: 'b', position: { x: 0, y: 0 }, data: { type: 'service' } },
+    ];
+    const edges: Edge[] = [{ id: 'e1', source: 'a', target: 'b' }];
+
+    const result = await getLayoutedElements(nodes, edges);
+    const points = (result.edges[0].data as { points?: { x: number; y: number }[] }).points;
+    expect(points).toEqual([
+      { x: 100, y: 25 },
+      { x: 200, y: 25 },
+      { x: 300, y: 25 },
+    ]);
+  });
+
+  it('offsets points for an edge nested inside a compound parent', async () => {
+    // Edge declared inside group `g` (absolute origin 500,100); its section
+    // coords are relative to the parent and must be shifted to absolute.
+    layoutMock.mockResolvedValueOnce({
+      id: 'root',
+      children: [
+        {
+          id: 'g',
+          x: 500,
+          y: 100,
+          width: 400,
+          height: 200,
+          children: [
+            { id: 'c1', x: 20, y: 20, width: 80, height: 40, children: [] },
+            { id: 'c2', x: 220, y: 20, width: 80, height: 40, children: [] },
+          ],
+          edges: [
+            {
+              id: 'e-nested',
+              sources: ['c1'],
+              targets: ['c2'],
+              sections: [
+                {
+                  id: 's',
+                  startPoint: { x: 100, y: 40 },
+                  endPoint: { x: 220, y: 40 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      edges: [],
+    });
+
+    const nodes: Node[] = [
+      { id: 'g', position: { x: 0, y: 0 }, data: { type: 'group' } },
+      { id: 'c1', parentId: 'g', position: { x: 0, y: 0 }, data: { type: 'container' } },
+      { id: 'c2', parentId: 'g', position: { x: 0, y: 0 }, data: { type: 'container' } },
+    ];
+    const edges: Edge[] = [{ id: 'e-nested', source: 'c1', target: 'c2' }];
+
+    const result = await getLayoutedElements(nodes, edges);
+    const points = (result.edges[0].data as { points?: { x: number; y: number }[] }).points;
+    // Parent absolute origin (500,100) added to relative section points.
+    expect(points).toEqual([
+      { x: 600, y: 140 },
+      { x: 720, y: 140 },
+    ]);
+  });
+
+  it('leaves an edge untouched when ELK produced no section for it', async () => {
+    layoutMock.mockResolvedValueOnce({
+      id: 'root',
+      children: [{ id: 'a', x: 0, y: 0, width: 10, height: 10, children: [] }],
+      edges: [{ id: 'e1', sources: ['a'], targets: ['a'], sections: [] }],
+    });
+
+    const nodes: Node[] = [{ id: 'a', position: { x: 0, y: 0 }, data: { type: 'service' } }];
+    const edges: Edge[] = [{ id: 'e1', source: 'a', target: 'a', data: { kind: 'observed' } }];
+
+    const result = await getLayoutedElements(nodes, edges);
+    expect((result.edges[0].data as { points?: unknown }).points).toBeUndefined();
+    expect((result.edges[0].data as { kind?: string }).kind).toBe('observed');
+  });
+});

--- a/packages/backend/src/lib/network/layout.ts
+++ b/packages/backend/src/lib/network/layout.ts
@@ -14,9 +14,18 @@ const layoutOptions = {
   'elk.layered.spacing.nodeNodeBetweenLayers': '350', // Horizontal spacing between layers
   'elk.hierarchyHandling': 'INCLUDE_CHILDREN', // Crucial for nesting
   'elk.padding': '[top=50,left=50,bottom=50,right=50]', // Padding for groups
-  // Optimization for cleaner lines
+  // #1782 — orthogonal edge routing ("circuit-board" look). The
+  // computed bend points are read back from edge.sections and rendered
+  // verbatim by the frontend custom edge instead of smoothstep.
+  'elk.edgeRouting': 'ORTHOGONAL',
+  // Crossing minimization tuning — BRANDES_KOEPF straightens trunks and
+  // higher thoroughness reduces crossings so the orthogonal routes stay
+  // readable. Extra edge/edge + edge/node spacing keeps parallel runs apart.
   'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-  'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX', // Better centering of parents relative to children
+  'elk.layered.thoroughness': '20',
+  'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
+  'elk.spacing.edgeEdge': '20',
+  'elk.spacing.edgeNode': '30',
 };
 
 export const getLayoutedElements = async (nodes: Node[], edges: Edge[]) => {
@@ -52,6 +61,21 @@ export const getLayoutedElements = async (nodes: Node[], edges: Edge[]) => {
 
     flatten(layoutedGraph);
 
+    // #1782 — collect ELK's orthogonal routing points per edge so the
+    // frontend custom edge can draw a 90° polyline instead of smoothstep.
+    // All edges are declared at the root graph (see buildHierarchy), so the
+    // section coordinates ELK returns are in the root's absolute coordinate
+    // space — the same space React Flow node positions live in. We still
+    // collect any nested edges (sections relative to a parent) and offset
+    // them by the parent's absolute origin so compound graphs keep working.
+    const edgePoints = collectEdgePoints(layoutedGraph);
+
+    const layoutedEdges: Edge[] = edges.map(edge => {
+      const points = edgePoints.get(edge.id);
+      if (!points || points.length < 2) return edge;
+      return { ...edge, data: { ...edge.data, points } };
+    });
+
     // Post-processing: Handle Self-Loops
     // Default: Target Left, Source Right
     // Exception: If a node has a self-loop, move Target to Bottom to allow a clean loop (Right -> Bottom)
@@ -81,12 +105,56 @@ export const getLayoutedElements = async (nodes: Node[], edges: Edge[]) => {
         }
     });
 
-    return { nodes: layoutedNodes, edges };
+    return { nodes: layoutedNodes, edges: layoutedEdges };
   } catch (error) {
     logger.error('layout', 'ELK Layout Error:', error);
     return { nodes, edges };
   }
 };
+
+type Point = { x: number; y: number };
+
+/**
+ * #1782 — walk the laid-out ELK tree and return, per edge id, the ordered
+ * list of absolute points (startPoint → bendPoints → endPoint) of its first
+ * routing section.
+ *
+ * ELK reports an edge's section coordinates relative to the coordinate system
+ * of the node the edge is *declared* in. We declare every edge at the root, so
+ * its sections are already root-absolute. We still accumulate the absolute
+ * origin (`offsetX/offsetY`) of each container as we descend so that any edge
+ * declared inside a compound node would be offset correctly — keeping nested
+ * (compound) graphs robust rather than mis-placing intra-group routes.
+ */
+function collectEdgePoints(graph: ElkNode): Map<string, Point[]> {
+  const result = new Map<string, Point[]>();
+
+  const walk = (node: ElkNode, offsetX: number, offsetY: number) => {
+    node.edges?.forEach(edge => {
+      const section = edge.sections?.[0];
+      if (!section) return;
+      const raw = [
+        section.startPoint,
+        ...(section.bendPoints ?? []),
+        section.endPoint,
+      ];
+      result.set(
+        edge.id,
+        raw.map(p => ({ x: p.x + offsetX, y: p.y + offsetY })),
+      );
+    });
+
+    node.children?.forEach(child => {
+      // Children positions are relative to this node; a child's absolute
+      // origin is this node's absolute origin plus the child's local x/y.
+      walk(child, offsetX + (child.x ?? 0), offsetY + (child.y ?? 0));
+    });
+  };
+
+  // Root has no positional offset of its own.
+  walk(graph, 0, 0);
+  return result;
+}
 
 function buildHierarchy(nodes: Node[], edges: Edge[]): ElkNode {
     const nodeMap = new Map<string, ElkNode>();

--- a/packages/backend/src/lib/network/service.ts
+++ b/packages/backend/src/lib/network/service.ts
@@ -16,6 +16,7 @@ import {
     parseTargetHostPort,
 } from './externalLinks';
 import { buildGlobalInfrastructure } from './topologyAssembler';
+import { suppressUbiquitousDeps } from './ubiquitousDeps';
 import {
     resolvePortNumber,
     type FritzPortMapping,
@@ -289,7 +290,18 @@ export class NetworkService {
     
     allNodes.sort((a, b) => getDepth(a) - getDepth(b));
 
-    return { nodes: allNodes, edges: validEdges };
+    // 5. Ubiquitous-dependency suppression (#1785)
+    // auth (Authelia/LLDAP) and adguard (DNS) are semantic hubs: nearly
+    // every service has a declared/observed edge to them. We drop those
+    // hub-spoke edges and stamp `behindAuth` / `usesDns` / `ubiquitousDeps`
+    // on the source nodes so the FE renders a 🔒 badge instead — the hub
+    // NODES themselves and every other real edge are preserved.
+    const { edges: deUbiquitousEdges, suppressed } = suppressUbiquitousDeps(allNodes, validEdges);
+    if (suppressed > 0) {
+      logger.info('NetworkService', `Suppressed ${suppressed} ubiquitous hub-spoke edge(s) (auth/dns) into node badges`);
+    }
+
+    return { nodes: allNodes, edges: deUbiquitousEdges };
   }
 
   // Helper: Get Global Infrastructure (Internet, Router)

--- a/packages/backend/src/lib/network/ubiquitousDeps.test.ts
+++ b/packages/backend/src/lib/network/ubiquitousDeps.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { suppressUbiquitousDeps } from './ubiquitousDeps';
+import type { NetworkNode, NetworkEdge } from './types';
+
+function svc(id: string): NetworkNode {
+  return { id, type: 'service', label: id, status: 'up' };
+}
+
+function edge(id: string, source: string, target: string, kind?: NetworkEdge['kind']): NetworkEdge {
+  return { id, source, target, protocol: 'tcp', port: 0, state: 'active', kind };
+}
+
+describe('suppressUbiquitousDeps', () => {
+  it('drops declared/observed edges to the auth hub and stamps behindAuth', () => {
+    const nodes = [svc('service-auth'), svc('service-immich'), svc('service-vault')];
+    const edges = [
+      edge('e1', 'service-immich', 'service-auth', 'declared'),
+      edge('e2', 'service-vault', 'service-auth', 'observed'),
+    ];
+
+    const { edges: kept, suppressed } = suppressUbiquitousDeps(nodes, edges);
+
+    expect(suppressed).toBe(2);
+    expect(kept).toHaveLength(0);
+    const immich = nodes.find((n) => n.id === 'service-immich')!;
+    expect(immich.metadata?.behindAuth).toBe(true);
+    expect(immich.metadata?.ubiquitousDeps).toEqual(['auth']);
+  });
+
+  it('drops edges to the adguard DNS hub and stamps usesDns', () => {
+    const nodes = [svc('service-adguard'), svc('service-immich')];
+    const edges = [edge('e1', 'service-immich', 'service-adguard', 'declared')];
+
+    const { edges: kept, suppressed } = suppressUbiquitousDeps(nodes, edges);
+
+    expect(suppressed).toBe(1);
+    expect(kept).toHaveLength(0);
+    const immich = nodes.find((n) => n.id === 'service-immich')!;
+    expect(immich.metadata?.usesDns).toBe(true);
+    expect(immich.metadata?.ubiquitousDeps).toEqual(['dns']);
+  });
+
+  it('keeps the hub NODES and a service OTHER real edges', () => {
+    const nodes = [svc('service-auth'), svc('service-immich'), svc('service-media')];
+    const edges = [
+      edge('hub', 'service-immich', 'service-auth', 'declared'),
+      // Real cross-service flow — must survive.
+      edge('flow', 'service-immich', 'service-media', 'observed'),
+      // Structural spine — must survive even if it points at a hub.
+      edge('gw', 'gateway', 'service-auth'),
+    ];
+
+    const { edges: kept } = suppressUbiquitousDeps(nodes, edges);
+
+    // Hub node still present.
+    expect(nodes.find((n) => n.id === 'service-auth')).toBeDefined();
+    // Cross-flow + gateway-spine kept; only the hub-spoke dropped.
+    expect(kept.map((e) => e.id).sort()).toEqual(['flow', 'gw']);
+  });
+
+  it('does not suppress structural (no-kind / gateway / proxy / manual) edges to a hub', () => {
+    const nodes = [svc('service-auth'), svc('service-immich')];
+    const edges = [
+      edge('plain', 'service-immich', 'service-auth'), // no kind
+      { ...edge('manual', 'service-immich', 'service-auth'), isManual: true },
+    ];
+
+    const { edges: kept, suppressed } = suppressUbiquitousDeps(nodes, edges);
+
+    expect(suppressed).toBe(0);
+    expect(kept).toHaveLength(2);
+  });
+
+  it('handles both auth and dns deps on one node', () => {
+    const nodes = [svc('service-auth'), svc('service-adguard'), svc('service-immich')];
+    const edges = [
+      edge('a', 'service-immich', 'service-auth', 'declared'),
+      edge('d', 'service-immich', 'service-adguard', 'declared'),
+    ];
+
+    const { suppressed } = suppressUbiquitousDeps(nodes, edges);
+
+    expect(suppressed).toBe(2);
+    const immich = nodes.find((n) => n.id === 'service-immich')!;
+    expect(immich.metadata?.behindAuth).toBe(true);
+    expect(immich.metadata?.usesDns).toBe(true);
+    expect((immich.metadata?.ubiquitousDeps as string[]).sort()).toEqual(['auth', 'dns']);
+  });
+
+  it('resolves hubs across remote-node prefixes and .service suffix', () => {
+    const nodes = [svc('box2:service-auth.service'), svc('box2:service-paperless')];
+    const edges = [edge('e', 'box2:service-paperless', 'box2:service-auth.service', 'declared')];
+
+    const { suppressed } = suppressUbiquitousDeps(nodes, edges);
+
+    expect(suppressed).toBe(1);
+    expect(nodes.find((n) => n.id === 'box2:service-paperless')!.metadata?.behindAuth).toBe(true);
+  });
+
+  it('no-ops when there is no hub node in the graph', () => {
+    const nodes = [svc('service-immich'), svc('service-media')];
+    const edges = [edge('e', 'service-immich', 'service-media', 'declared')];
+
+    const { edges: kept, suppressed } = suppressUbiquitousDeps(nodes, edges);
+
+    expect(suppressed).toBe(0);
+    expect(kept).toEqual(edges);
+  });
+});

--- a/packages/backend/src/lib/network/ubiquitousDeps.ts
+++ b/packages/backend/src/lib/network/ubiquitousDeps.ts
@@ -1,0 +1,113 @@
+/**
+ * Ubiquitous-dependency suppression (#1785).
+ *
+ * `auth` (Authelia SSO + the LLDAP directory it bundles) and `adguard`
+ * (DNS) are semantic hubs: almost every managed service has a declared /
+ * observed edge pointing at them. Rendered as graph edges, that fan-out is
+ * the single biggest source of crossings in a flat node-link layout — it
+ * can't be drawn planar.
+ *
+ * Instead of emitting those hub-spoke edges, we OMIT them and stamp a flag
+ * on the source node:
+ *   - `metadata.behindAuth = true`        — service sits behind Authelia/LLDAP
+ *   - `metadata.usesDns = true`           — service depends on the DNS hub
+ *   - `metadata.ubiquitousDeps = ['auth','dns']`  — generic list for the badge
+ *
+ * The hub NODES themselves (auth, adguard) stay — only the inbound fan-out
+ * edges from other services are dropped. A service's OTHER real edges
+ * (gateway, proxy, cross-service flows) are untouched. No information is
+ * lost: the badge + legend convey "behind auth / uses DNS", and the
+ * `kind`-toggle on the frontend can restore the hidden edges on demand.
+ */
+import type { NetworkNode, NetworkEdge } from './types';
+
+/** Edge kinds eligible for suppression. We only ever drop dependency-style
+ *  edges (a template `servicebay.dependencies` entry or an observed flow)
+ *  pointing at a hub — never the infrastructure spine (gateway / proxy /
+ *  manual), which carries distinct, non-ubiquitous meaning. */
+const SUPPRESSIBLE_KINDS = new Set(['declared', 'observed']);
+
+/** Base service names that act as ubiquitous hubs, mapped to the generic
+ *  dependency token surfaced on the node badge. */
+const HUB_BASENAMES: Record<string, 'auth' | 'dns'> = {
+  auth: 'auth',
+  lldap: 'auth',
+  authelia: 'auth',
+  adguard: 'dns',
+};
+
+/** Extract the base service name from a graph node id. Service nodes are
+ *  `service-<name>` optionally prefixed with `<node>:` (remote hosts). The
+ *  trailing `.service` suffix (if present) is stripped. */
+function baseServiceName(nodeId: string): string | null {
+  const afterPrefix = nodeId.includes(':') ? nodeId.slice(nodeId.indexOf(':') + 1) : nodeId;
+  if (!afterPrefix.startsWith('service-')) return null;
+  return afterPrefix.slice('service-'.length).replace(/\.service$/, '');
+}
+
+/** Classify a node as a hub by its id, returning the dependency token
+ *  ('auth' | 'dns') or null. */
+function hubTokenForNode(node: NetworkNode): 'auth' | 'dns' | null {
+  const base = baseServiceName(node.id);
+  if (base && HUB_BASENAMES[base]) return HUB_BASENAMES[base];
+  return null;
+}
+
+export interface SuppressionResult {
+  edges: NetworkEdge[];
+  /** Count of suppressed hub-spoke edges (for logging / verification). */
+  suppressed: number;
+}
+
+/**
+ * Drop ubiquitous hub-spoke edges and stamp the source nodes with badge
+ * flags. Mutates the passed `nodes` (sets metadata flags) and returns a new
+ * filtered edge array — the input edge array is not mutated.
+ */
+export function suppressUbiquitousDeps(
+  nodes: NetworkNode[],
+  edges: NetworkEdge[],
+): SuppressionResult {
+  // Map node id → hub token so an edge lookup is O(1).
+  const hubTokenById = new Map<string, 'auth' | 'dns'>();
+  for (const node of nodes) {
+    const token = hubTokenForNode(node);
+    if (token) hubTokenById.set(node.id, token);
+  }
+
+  if (hubTokenById.size === 0) {
+    return { edges, suppressed: 0 };
+  }
+
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  let suppressed = 0;
+
+  const kept = edges.filter((edge) => {
+    const token = hubTokenById.get(edge.target);
+    // Keep the edge unless it's a suppressible dependency edge pointing at a
+    // hub. A hub's OWN outbound edges, and non-dependency edges (gateway /
+    // proxy / manual), are always kept.
+    if (!token) return true;
+    if (!SUPPRESSIBLE_KINDS.has(edge.kind ?? '')) return true;
+    // Don't suppress a hub→hub edge (e.g. auth↔adguard) — both endpoints are
+    // hubs; collapsing it would lose the only edge between the two hubs.
+    if (hubTokenById.has(edge.source)) return true;
+
+    // Suppress: stamp the source node and drop the edge.
+    const source = nodeById.get(edge.source);
+    if (source) {
+      if (!source.metadata) source.metadata = {};
+      if (token === 'auth') source.metadata.behindAuth = true;
+      if (token === 'dns') source.metadata.usesDns = true;
+      const existing = Array.isArray(source.metadata.ubiquitousDeps)
+        ? (source.metadata.ubiquitousDeps as string[])
+        : [];
+      if (!existing.includes(token)) existing.push(token);
+      source.metadata.ubiquitousDeps = existing;
+    }
+    suppressed += 1;
+    return false;
+  });
+
+  return { edges: kept, suppressed };
+}

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -42,12 +42,13 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { getLayoutedElements } from '@servicebay/api-client';
-import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkIcon, ChevronDown, LayoutGrid, Plus, Terminal as TerminalIcon, RefreshCw, Eraser, ArrowRight, Lock } from 'lucide-react';
+import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkIcon, ChevronDown, LayoutGrid, Plus, Terminal as TerminalIcon, RefreshCw, Eraser, ArrowRight, ArrowLeft, Lock } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { useToast } from '@/providers/ToastProvider';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
 import {
   buildServiceEditHref,
+  computeEgoNodeIds,
   DEFAULT_EDGE_COLOR,
   DOWN_EDGE_COLOR,
   DOWN_EDGE_DASHES,
@@ -58,6 +59,7 @@ import {
   type HealthData,
   type LegacyPortMapping,
 } from './_lib/networkDashboard';
+import type { ReactFlowInstance } from '@xyflow/react';
 
 // #1782 — build an orthogonal SVG path from ELK's routing points. Straight
 // 90° segments with small rounded corners (quadratic `Q`) at each bend so the
@@ -839,6 +841,11 @@ export default function NetworkDashboard() {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<GraphNodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [searchQuery, setSearchQuery] = useState('');
+  // Focus / ego mode (#1786): the id of the node whose neighbourhood the
+  // map is reduced to. `null` ⇒ full map. Clicking a node enters focus;
+  // clicking the canvas, the Back control, or Esc exits it.
+  const [focusNodeId, setFocusNodeId] = useState<string | null>(null);
+  const reactFlowInstance = useRef<ReactFlowInstance<Node<GraphNodeData>, Edge> | null>(null);
   const [selectedNodeData, setSelectedNodeData] = useState<GraphNodeData | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<string | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -1023,7 +1030,7 @@ export default function NetworkDashboard() {
       setNodes((nds) => applyFilter(nds, searchQuery));
   }, [searchQuery, applyFilter, setNodes]);
 
-  const processAndLayout = useCallback(async (nodes: Node<GraphNodeData>[], edges: Edge[], collapsed: Set<string>, search: string) => {
+  const processAndLayout = useCallback(async (nodes: Node<GraphNodeData>[], edges: Edge[], collapsed: Set<string>, search: string, focus: string | null = null) => {
     // 1. Prepare Nodes (Aggregation & toggles)
      
     const processedNodes = nodes.map(node => {
@@ -1129,10 +1136,34 @@ export default function NetworkDashboard() {
         });
     });
     
+    // 3b. Focus / ego mode (#1786). Reduce the visible graph to the
+    // focus node's neighbourhood + the Internet→focus path before
+    // layout, so ELK lays out only the relevant subgraph (crossing-free)
+    // and `fitView` zooms to it. Child nodes of a kept group are kept
+    // too so expanded groups don't lose their members.
+    let layoutNodes = visibleNodes;
+    let layoutEdges = visibleEdges;
+    if (focus) {
+        const ego = computeEgoNodeIds(visibleNodes, visibleEdges, focus);
+        if (ego.size > 0) {
+            const keep = (n: Node<GraphNodeData>) => ego.has(n.id) || (n.parentId ? ego.has(n.parentId) : false);
+            layoutNodes = visibleNodes.filter(keep);
+            const keptIds = new Set(layoutNodes.map(n => n.id));
+            layoutEdges = visibleEdges.filter(e => keptIds.has(e.source) && keptIds.has(e.target));
+        }
+    }
+
     // 4. Layout
-    const layouted = await getLayoutedElements(visibleNodes, visibleEdges);
+    const layouted = await getLayoutedElements(layoutNodes, layoutEdges);
     setNodes(applyFilter(layouted.nodes as Node<GraphNodeData>[], search));
     setEdges(layouted.edges);
+
+    // After a focus re-layout, zoom the viewport to the reduced subgraph.
+    if (focus) {
+        requestAnimationFrame(() => {
+            reactFlowInstance.current?.fitView({ padding: 0.2, duration: 400 });
+        });
+    }
   }, [setNodes, setEdges, applyFilter]);
 
   // #1071 phase 1: data layer (graph fetch + twin-driven auto-refresh
@@ -1350,7 +1381,7 @@ export default function NetworkDashboard() {
 
       const runLayout = async () => {
           try {
-                await processAndLayout(graphData.nodes, graphData.edges, currentCollapsed, searchQuery);
+                await processAndLayout(graphData.nodes, graphData.edges, currentCollapsed, searchQuery, focusNodeId);
                 if (!cancelled) {
                      resolveReloadToast('success', 'Latest network topology is ready');
                 }
@@ -1366,7 +1397,7 @@ export default function NetworkDashboard() {
       return () => {
           cancelled = true;
       };
-  }, [graphData, processAndLayout, collapsedGroups, searchQuery, resolveReloadToast]);
+  }, [graphData, processAndLayout, collapsedGroups, searchQuery, focusNodeId, resolveReloadToast]);
 
   useEffect(() => {
     // Setup SSE for progress updates
@@ -1401,10 +1432,19 @@ export default function NetworkDashboard() {
             setSelectedEdge(null);
         }, []);
 
+        // Exit focus/ego mode (#1786): restore the full map. Used by the
+        // Back control, a canvas (pane) click, and Esc.
+        const exitFocus = useCallback(() => {
+            setFocusNodeId(null);
+        }, []);
+
         useEscapeKey(closeContainerActions, containerActionsOpen, true);
         useEscapeKey(closeContainerDrawer, Boolean(containerDrawerMode), true);
         useEscapeKey(closeNodeDetails, Boolean(selectedNodeData), true);
         useEscapeKey(closeEdgeDetails, Boolean(selectedEdge), true);
+        // Esc exits focus only when no overlay panel is open above it
+        // (the panels' own Esc handlers take precedence via topMostOnly).
+        useEscapeKey(exitFocus, Boolean(focusNodeId) && !selectedNodeData && !selectedEdge && !containerDrawerMode, true);
 
   const handleEditLink = () => {
       if (!selectedNodeData || !selectedNodeData.rawData) return;
@@ -1570,15 +1610,36 @@ export default function NetworkDashboard() {
                 animated: true,
                 style: { stroke: DEFAULT_EDGE_COLOR, strokeWidth: 2 },
             }}
+            onInit={(instance) => { reactFlowInstance.current = instance; }}
             onNodeClick={(_, node) => {
+                // Click = focus the node's neighbourhood (#1786) AND open
+                // its details. Clicking a neighbour re-focuses on it.
                 setSelectedNodeData(node.data);
                 setSelectedEdge(null);
+                setFocusNodeId(node.id);
             }}
             onEdgeClick={(_, edge) => {
                 setSelectedEdge(edge.id);
                 setSelectedNodeData(null);
             }}
+            onPaneClick={() => {
+                // Clicking empty canvas exits focus mode back to the full map.
+                if (focusNodeId) setFocusNodeId(null);
+            }}
         >
+            {focusNodeId && (
+                <Panel position="top-left">
+                    <button
+                        onClick={exitFocus}
+                        data-testid="focus-back"
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                        title="Back to full map (Esc)"
+                    >
+                        <ArrowLeft size={14} />
+                        Full map
+                    </button>
+                </Panel>
+            )}
             <NetworkLegend />
             <Background color="#999" gap={16} size={1} className="opacity-10" />
             <Controls 

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -59,6 +59,52 @@ import {
   type LegacyPortMapping,
 } from './_lib/networkDashboard';
 
+// #1782 — build an orthogonal SVG path from ELK's routing points. Straight
+// 90° segments with small rounded corners (quadratic `Q`) at each bend so the
+// "circuit-board" look reads cleanly without hard pixel corners.
+const ORTHOGONAL_CORNER_RADIUS = 8;
+
+function buildOrthogonalPath(points: { x: number; y: number }[]): {
+  path: string;
+  labelX: number;
+  labelY: number;
+} {
+  const start = points[0];
+  let path = `M ${start.x},${start.y}`;
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1];
+    const corner = points[i];
+    const next = points[i + 1];
+
+    // Stop short of the corner along the incoming segment, round through it,
+    // and resume along the outgoing segment — capped at half each segment so
+    // short legs don't overshoot.
+    const inLen = Math.hypot(corner.x - prev.x, corner.y - prev.y) || 1;
+    const outLen = Math.hypot(next.x - corner.x, next.y - corner.y) || 1;
+    const r = Math.min(ORTHOGONAL_CORNER_RADIUS, inLen / 2, outLen / 2);
+
+    const before = {
+      x: corner.x - ((corner.x - prev.x) / inLen) * r,
+      y: corner.y - ((corner.y - prev.y) / inLen) * r,
+    };
+    const after = {
+      x: corner.x + ((next.x - corner.x) / outLen) * r,
+      y: corner.y + ((next.y - corner.y) / outLen) * r,
+    };
+
+    path += ` L ${before.x},${before.y} Q ${corner.x},${corner.y} ${after.x},${after.y}`;
+  }
+
+  const end = points[points.length - 1];
+  path += ` L ${end.x},${end.y}`;
+
+  // Label at the midpoint of the polyline (by point index — good enough for
+  // the short port labels the map carries).
+  const mid = points[Math.floor(points.length / 2)];
+  return { path, labelX: mid.x, labelY: mid.y };
+}
+
 // Custom Edge Component
 const CustomEdge = ({
   sourceX,
@@ -70,15 +116,32 @@ const CustomEdge = ({
   style = {},
   markerEnd,
   label,
+  data,
 }: EdgeProps) => {
-  const [edgePath, labelX, labelY] = getSmoothStepPath({
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX,
-    targetY,
-    targetPosition,
-  });
+  // #1782 — prefer ELK's orthogonal routing points (attached as data.points
+  // by getLayoutedElements). Fall back to smoothstep when ELK didn't route
+  // this edge (e.g. an edge added before the next layout pass).
+  const elkPoints = (data as { points?: { x: number; y: number }[] } | undefined)?.points;
+
+  let edgePath: string;
+  let labelX: number;
+  let labelY: number;
+
+  if (elkPoints && elkPoints.length >= 2) {
+    const built = buildOrthogonalPath(elkPoints);
+    edgePath = built.path;
+    labelX = built.labelX;
+    labelY = built.labelY;
+  } else {
+    [edgePath, labelX, labelY] = getSmoothStepPath({
+      sourceX,
+      sourceY,
+      sourcePosition,
+      targetX,
+      targetY,
+      targetPosition,
+    });
+  }
 
   if (!label) {
       return <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />;
@@ -1131,7 +1194,10 @@ export default function NetworkDashboard() {
             source: e.source,
             target: e.target,
             label: decoratedLabel,
-            type: 'smoothstep',
+            // #1782 — `custom` edge renders ELK's orthogonal points (attached
+            // by getLayoutedElements) as a 90° polyline; falls back to
+            // smoothstep until the layout pass routes it.
+            type: 'custom',
             markerEnd: {
                 type: MarkerType.ArrowClosed,
             },

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -42,7 +42,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { getLayoutedElements } from '@servicebay/api-client';
-import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkIcon, ChevronDown, LayoutGrid, Plus, Terminal as TerminalIcon, RefreshCw, Eraser, ArrowRight } from 'lucide-react';
+import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkIcon, ChevronDown, LayoutGrid, Plus, Terminal as TerminalIcon, RefreshCw, Eraser, ArrowRight, Lock } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { useToast } from '@/providers/ToastProvider';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
@@ -195,7 +195,13 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
   const renderAsExpandedGroup = isExpandable && !isCollapsed;
 
   const summary = data.summary || {};
-  
+
+  // Ubiquitous-dependency badges (#1785). The backend suppresses the
+  // auth/lldap (SSO/forward-auth) and adguard (DNS) hub-spoke edges and
+  // stamps these flags on the source node instead, so the map stays planar.
+  const behindAuth = data.metadata?.behindAuth === true;
+  const usesDns = data.metadata?.usesDns === true;
+
   const getTypeColors = (): Record<string, string> => ({
     container: 'border-blue-400 dark:border-blue-600 bg-blue-100 dark:bg-blue-900/40',
     service: 'border-purple-400 dark:border-purple-600 bg-purple-100 dark:bg-purple-900/40',
@@ -515,7 +521,27 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                     )}
                     
                     {data.label}
-                    
+
+                    {/* Ubiquitous-dependency badges (#1785) */}
+                    {behindAuth && (
+                        <span
+                            data-testid="badge-behind-auth"
+                            className="shrink-0 inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800"
+                            title="Hinter Authelia/LLDAP (SSO)"
+                        >
+                            <Lock size={10} /> SSO
+                        </span>
+                    )}
+                    {usesDns && (
+                        <span
+                            data-testid="badge-uses-dns"
+                            className="shrink-0 inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800"
+                            title="DNS über AdGuard"
+                        >
+                            <Globe size={10} /> DNS
+                        </span>
+                    )}
+
                     {/* Host IP moved to Header */}
                     {globalIp && (
                          <div className="text-[10px] font-mono font-bold text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 px-1.5 py-0.5 rounded border border-gray-100 dark:border-gray-800 ml-1" title="Host IP">
@@ -748,6 +774,47 @@ function getMiniMapStrokeColor(type: string): string {
   }
 }
 
+// Legend body extracted from NetworkLegend so the panel wrapper stays under
+// the max-lines-per-function budget after the #1785 badge rows landed.
+function LegendBody() {
+    return (
+        <div className="px-3 pb-2 space-y-1.5 border-t border-gray-100 dark:border-gray-800 pt-2">
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-blue-500" /><span>Service / Pod</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-purple-500" /><span>Container</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-orange-500" /><span>Gateway</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-cyan-500" /><span>External Link</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-gray-400" /><span>Group / Node</span></div>
+            <div className="border-t border-gray-100 dark:border-gray-800 pt-1.5 mt-1.5">
+                <div className="flex items-center gap-2"><div className="w-2.5 h-2.5 rounded-full bg-green-500" /><span>Active / Running</span></div>
+                <div className="flex items-center gap-2 mt-1"><div className="w-2.5 h-2.5 rounded-full bg-red-500" /><span>Stopped / Error</span></div>
+            </div>
+            <div className="border-t border-gray-100 dark:border-gray-800 pt-1.5 mt-1.5 space-y-1">
+                <div className="flex items-center gap-2">
+                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#0ea5e9" strokeWidth="2" /></svg>
+                    <span>Observed TCP flow</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#d97706" strokeWidth="2" strokeDasharray="4 4" /></svg>
+                    <span>Declared dependency</span>
+                </div>
+            </div>
+            {/* Ubiquitous-dependency badges (#1785). Hub-spoke edges to
+                auth/LLDAP and AdGuard DNS are collapsed into these node
+                badges to keep the map planar. */}
+            <div className="border-t border-gray-100 dark:border-gray-800 pt-1.5 mt-1.5 space-y-1">
+                <div className="flex items-center gap-2">
+                    <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800"><Lock size={9} /> SSO</span>
+                    <span>Hinter Authelia/LLDAP</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800"><Globe size={9} /> DNS</span>
+                    <span>DNS über AdGuard</span>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function NetworkLegend() {
     const [isOpen, setIsOpen] = useState(false);
     return (
@@ -761,29 +828,7 @@ function NetworkLegend() {
                     Legend
                     <ChevronDown size={12} className={`ml-auto transition-transform ${isOpen ? 'rotate-180' : ''}`} />
                 </button>
-                {isOpen && (
-                    <div className="px-3 pb-2 space-y-1.5 border-t border-gray-100 dark:border-gray-800 pt-2">
-                        <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-blue-500" /><span>Service / Pod</span></div>
-                        <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-purple-500" /><span>Container</span></div>
-                        <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-orange-500" /><span>Gateway</span></div>
-                        <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-cyan-500" /><span>External Link</span></div>
-                        <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-gray-400" /><span>Group / Node</span></div>
-                        <div className="border-t border-gray-100 dark:border-gray-800 pt-1.5 mt-1.5">
-                            <div className="flex items-center gap-2"><div className="w-2.5 h-2.5 rounded-full bg-green-500" /><span>Active / Running</span></div>
-                            <div className="flex items-center gap-2 mt-1"><div className="w-2.5 h-2.5 rounded-full bg-red-500" /><span>Stopped / Error</span></div>
-                        </div>
-                        <div className="border-t border-gray-100 dark:border-gray-800 pt-1.5 mt-1.5 space-y-1">
-                            <div className="flex items-center gap-2">
-                                <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#0ea5e9" strokeWidth="2" /></svg>
-                                <span>Observed TCP flow</span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                                <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#d97706" strokeWidth="2" strokeDasharray="4 4" /></svg>
-                                <span>Declared dependency</span>
-                            </div>
-                        </div>
-                    </div>
-                )}
+                {isOpen && <LegendBody />}
             </div>
         </Panel>
     );

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+import { computeEgoNodeIds } from './networkDashboard';
+
+// Minimal graph mirroring the map's shape:
+//   internet → router → nginx → {hermes, auth, immich}
+//   hermes also talks to ollama (a 1-hop neighbour off the public path)
+//   abs is unrelated (router → nginx → abs)
+const node = (id: string, type = 'service'): Node =>
+  ({ id, type: 'custom', position: { x: 0, y: 0 }, data: { type, label: id } });
+
+const edge = (source: string, target: string): Edge => ({ id: `e-${source}-${target}`, source, target });
+
+const nodes: Node[] = [
+  node('internet', 'internet'),
+  node('router', 'router'),
+  node('nginx', 'proxy'),
+  node('hermes'),
+  node('auth'),
+  node('immich'),
+  node('abs'),
+  node('ollama'),
+];
+
+const edges: Edge[] = [
+  edge('internet', 'router'),
+  edge('router', 'nginx'),
+  edge('nginx', 'hermes'),
+  edge('nginx', 'auth'),
+  edge('nginx', 'immich'),
+  edge('nginx', 'abs'),
+  edge('hermes', 'ollama'),
+];
+
+describe('computeEgoNodeIds', () => {
+  it('returns an empty set when there is no focus', () => {
+    expect(computeEgoNodeIds(nodes, edges, null).size).toBe(0);
+    expect(computeEgoNodeIds(nodes, edges, undefined).size).toBe(0);
+  });
+
+  it('returns an empty set for an unknown focus id', () => {
+    expect(computeEgoNodeIds(nodes, edges, 'does-not-exist').size).toBe(0);
+  });
+
+  it('keeps the focus node, its direct neighbours, and the internet→focus path', () => {
+    const ego = computeEgoNodeIds(nodes, edges, 'hermes');
+    // focus + 1-hop neighbours (nginx, ollama) + internet→hermes path (internet, router, nginx)
+    expect(ego).toEqual(new Set(['hermes', 'nginx', 'ollama', 'internet', 'router']));
+    // unrelated siblings are dropped — this is what makes the hub readable
+    expect(ego.has('auth')).toBe(false);
+    expect(ego.has('immich')).toBe(false);
+    expect(ego.has('abs')).toBe(false);
+  });
+
+  it('keeps every direct sibling when the hub itself is focused', () => {
+    const ego = computeEgoNodeIds(nodes, edges, 'nginx');
+    expect(ego).toEqual(new Set(['nginx', 'router', 'hermes', 'auth', 'immich', 'abs', 'internet']));
+    // ollama is 2 hops from nginx and off the public path → dropped
+    expect(ego.has('ollama')).toBe(false);
+  });
+
+  it('treats edges as undirected (focus reachable via reversed orientation)', () => {
+    // Edge stored target→source relative to flow direction must still link.
+    const reversed: Edge[] = [edge('router', 'internet'), edge('nginx', 'router'), edge('hermes', 'nginx')];
+    const ego = computeEgoNodeIds(nodes, reversed, 'hermes');
+    expect(ego.has('internet')).toBe(true);
+    expect(ego.has('router')).toBe(true);
+    expect(ego.has('nginx')).toBe(true);
+  });
+
+  it('still returns the focus node when there is no internet node', () => {
+    const noInternet = nodes.filter((n) => n.id !== 'internet');
+    const noInternetEdges = edges.filter((e) => e.source !== 'internet' && e.target !== 'internet');
+    const ego = computeEgoNodeIds(noInternet, noInternetEdges, 'hermes');
+    expect(ego.has('hermes')).toBe(true);
+    expect(ego.has('nginx')).toBe(true);
+    expect(ego.has('ollama')).toBe(true);
+  });
+});

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -9,7 +9,7 @@
  * render-cycle risk without per-stage validation.
  */
 import type { CSSProperties } from 'react';
-import type { Position } from '@xyflow/react';
+import type { Position, Node, Edge } from '@xyflow/react';
 import type { PortMapping } from '@servicebay/api-client';
 
 /**
@@ -116,6 +116,94 @@ export function buildServiceEditHref(node: GraphNodeData): string {
   }
 
   return base;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Focus / ego mode (#1786). Clicking a node reduces the map to that
+// node's immediate neighbourhood — itself + its direct (1-hop)
+// neighbours + the Internet→node path — and dims/hides everything
+// else. The reduced subgraph re-layouts crossing-free and is the
+// actual lever for reading a hub's relationships (auth/hermes/nginx
+// are an unreadable knot in the full view).
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the set of node ids that make up the ego-neighbourhood of
+ * `focusId`: the focus node, its direct (1-hop) neighbours, and the
+ * shortest Internet→focus path so the public-facing chain stays
+ * visible. Edges are treated as undirected (the map's source/target
+ * orientation is layout-direction, not reachability).
+ *
+ * Returns the keep-set; an empty set means "no focus" (caller shows
+ * the full map).
+ */
+function buildUndirectedAdjacency(nodes: Node[], edges: Edge[]): Map<string, Set<string>> {
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const adjacency = new Map<string, Set<string>>();
+  const link = (a: string, b: string) => {
+    if (!adjacency.has(a)) adjacency.set(a, new Set());
+    adjacency.get(a)!.add(b);
+  };
+  for (const e of edges) {
+    if (!nodeIds.has(e.source) || !nodeIds.has(e.target)) continue;
+    link(e.source, e.target);
+    link(e.target, e.source);
+  }
+  return adjacency;
+}
+
+/** BFS shortest path between two ids over the adjacency, returned as the
+ *  set of ids on the path (empty if unreachable). */
+function shortestPathIds(
+  adjacency: Map<string, Set<string>>,
+  from: string,
+  to: string,
+): Set<string> {
+  const prev = new Map<string, string>();
+  const seen = new Set<string>([from]);
+  const queue: string[] = [from];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    if (cur === to) break;
+    for (const next of adjacency.get(cur) ?? []) {
+      if (seen.has(next)) continue;
+      seen.add(next);
+      prev.set(next, cur);
+      queue.push(next);
+    }
+  }
+  const path = new Set<string>();
+  if (!seen.has(to)) return path;
+  let step: string | undefined = to;
+  while (step) {
+    path.add(step);
+    step = prev.get(step);
+  }
+  return path;
+}
+
+export function computeEgoNodeIds(
+  nodes: Node[],
+  edges: Edge[],
+  focusId: string | null | undefined,
+): Set<string> {
+  if (!focusId) return new Set();
+  if (!nodes.some((n) => n.id === focusId)) return new Set();
+
+  const adjacency = buildUndirectedAdjacency(nodes, edges);
+
+  const keep = new Set<string>([focusId]);
+  // Direct neighbours (1 hop).
+  for (const n of adjacency.get(focusId) ?? []) keep.add(n);
+
+  // Shortest path Internet→focus (BFS) so the public chain is shown
+  // even when the gateway/proxy hops are >1 away from the focus node.
+  const internet = nodes.find((n) => (n.data as { type?: string } | undefined)?.type === 'internet');
+  if (internet && internet.id !== focusId) {
+    for (const id of shortestPathIds(adjacency, internet.id, focusId)) keep.add(id);
+  }
+
+  return keep;
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/packages/frontend/src/mocks/handlers.ts
+++ b/packages/frontend/src/mocks/handlers.ts
@@ -118,9 +118,39 @@ export const handlers = [
   // GET /api/health/checks
   http.get('/api/health/checks', () => HttpResponse.json([])),
 
-  // GET /api/network/graph — empty topology
+  // GET /api/install/current — active install descriptor (none in mock)
+  http.get('/api/install/current', () => HttpResponse.json({ current: null })),
+
+  // GET /api/system/core-health — core-stack health (all green in mock)
+  http.get('/api/system/core-health', () => HttpResponse.json({
+    healthy: true, checks: [],
+  })),
+
+  // GET /api/stream — SSE event stream stub (empty body, 200)
+  http.get('/api/stream', () => new HttpResponse('', {
+    status: 200, headers: { 'Content-Type': 'text/event-stream' },
+  })),
+
+  // GET /api/network/graph — representative topology demonstrating the
+  // ubiquitous-dependency badge suppression (#1785). The auth (SSO/LLDAP)
+  // and adguard (DNS) hub NODES are present, but the per-service hub-spoke
+  // edges are gone — each protected service instead carries
+  // behindAuth/usesDns/ubiquitousDeps metadata that renders as a badge.
   http.get('/api/network/graph', () => HttpResponse.json({
-    nodes: [], edges: [], metadata: { stats: {} },
+    nodes: [
+      { id: 'gateway', type: 'gateway', label: 'FritzBox', status: 'up', metadata: { stats: { externalIP: '92.252.126.27', internalIP: '192.168.178.1' } } },
+      { id: 'service-auth', type: 'service', label: 'auth', subLabel: 'Authelia / LLDAP', status: 'up', rawData: { name: 'auth', active: true } },
+      { id: 'service-adguard', type: 'service', label: 'adguard', subLabel: 'DNS', status: 'up', rawData: { name: 'adguard', active: true } },
+      { id: 'service-immich', type: 'service', label: 'immich', status: 'up', rawData: { name: 'immich', active: true }, metadata: { behindAuth: true, usesDns: true, ubiquitousDeps: ['auth', 'dns'] } },
+      { id: 'service-vault', type: 'service', label: 'vaultwarden', status: 'up', rawData: { name: 'vaultwarden', active: true }, metadata: { behindAuth: true, usesDns: true, ubiquitousDeps: ['auth', 'dns'] } },
+      { id: 'service-media', type: 'service', label: 'media', status: 'up', rawData: { name: 'media', active: true }, metadata: { behindAuth: true, ubiquitousDeps: ['auth'] } },
+    ],
+    edges: [
+      { id: 'gw-auth', source: 'gateway', target: 'service-auth', protocol: 'https', port: 443, state: 'active' },
+      // Real cross-service flow survives (immich → media), hub-spokes are gone.
+      { id: 'flow-immich-media', source: 'service-immich', target: 'service-media', protocol: 'tcp', port: 8096, state: 'active', kind: 'observed' },
+    ],
+    metadata: { stats: {} },
   })),
 
   // GET /api/system/storage?node=...


### PR DESCRIPTION
## What
Network-map redesign (part of epic #1787): switches edge routing to ELK orthogonal, replaces hub-spoke auth/DNS edges with per-node ubiquitous-dependency badges, and adds a focus/ego mode that reduces the map to a clicked node's neighbourhood.

## Why
Closes #1782 — render ELK orthogonal edge routing in the network map.
Closes #1785 — badge ubiquitous auth/dns deps instead of drawing hub-spoke edges.
Closes #1786 — focus/ego mode reduces the map to a node's neighbourhood on click.

Part of epic #1787.

## Risk
Low — frontend map-rendering plus backend layout/dep-derivation helpers; no install/backup/auth critical path.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2459 passed)
- [x] next build / type check
- [ ] /verify on FCoS :dev box — N/A, no path-mandated files

AI-generated, reviewed by mdopp.
<!-- sb-ai-comment -->