### PR TITLE
fix(network-map): focus mode includes badge-suppressed hub deps (#1792)

### DIFF
--- a/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
@@ -78,6 +78,97 @@ describe('computeEgoNodeIds', () => {
   });
 });
 
+// #1792 — ubiquitous-dep suppression (#1785) drops the service→auth /
+// service→dns edges before the graph reaches the frontend, stamping
+// `behindAuth`/`usesDns` flags on the source nodes instead. The ego
+// adjacency must re-derive those hub relationships from the flags so a
+// hub's focus view isn't empty and a badge-only service shows its hubs.
+describe('computeEgoNodeIds — suppressed ubiquitous hub deps (#1792)', () => {
+  // Mirrors the post-suppression graph: NO service→auth / service→dns
+  // edges exist; the dependency lives only in node metadata flags.
+  const svc = (id: string, flags?: { behindAuth?: boolean; usesDns?: boolean }): Node => ({
+    id,
+    type: 'custom',
+    position: { x: 0, y: 0 },
+    data: { type: 'service', label: id, metadata: { ...(flags ?? {}) } },
+  });
+
+  const hubNodes: Node[] = [
+    node('internet', 'internet'),
+    node('router', 'router'),
+    node('service-nginx', 'proxy'),
+    node('service-auth'),
+    node('service-adguard'),
+    svc('service-immich', { behindAuth: true }),
+    svc('service-vault', { behindAuth: true, usesDns: true }),
+    svc('service-abs', { usesDns: true }),
+    svc('service-ollama'), // no hub deps
+  ];
+
+  // Only the infrastructure spine survives suppression — no hub-spoke edges.
+  const hubEdges: Edge[] = [
+    edge('internet', 'router'),
+    edge('router', 'service-nginx'),
+    edge('service-nginx', 'service-auth'),
+    edge('service-nginx', 'service-adguard'),
+    edge('service-nginx', 'service-immich'),
+    edge('service-nginx', 'service-vault'),
+    edge('service-nginx', 'service-abs'),
+    edge('service-nginx', 'service-ollama'),
+  ];
+
+  it('focusing the auth hub pulls in every service carrying the SSO badge', () => {
+    const ego = computeEgoNodeIds(hubNodes, hubEdges, 'service-auth');
+    // The behindAuth services are now visible even though no edge points at auth.
+    expect(ego.has('service-immich')).toBe(true);
+    expect(ego.has('service-vault')).toBe(true);
+    // A DNS-only / no-dep service is NOT pulled in by the auth hub.
+    expect(ego.has('service-abs')).toBe(false);
+    expect(ego.has('service-ollama')).toBe(false);
+    expect(ego.has('service-auth')).toBe(true);
+  });
+
+  it('focusing the dns hub pulls in every service carrying the DNS badge', () => {
+    const ego = computeEgoNodeIds(hubNodes, hubEdges, 'service-adguard');
+    expect(ego.has('service-vault')).toBe(true);
+    expect(ego.has('service-abs')).toBe(true);
+    expect(ego.has('service-immich')).toBe(false); // auth-only
+    expect(ego.has('service-adguard')).toBe(true);
+  });
+
+  it('focusing a badge-only service surfaces the hub(s) it depends on', () => {
+    // immich's only declared dep is auth (suppressed) — auth must appear.
+    const immich = computeEgoNodeIds(hubNodes, hubEdges, 'service-immich');
+    expect(immich.has('service-auth')).toBe(true);
+    expect(immich.has('service-adguard')).toBe(false);
+
+    // vault carries both badges — both hubs must appear.
+    const vault = computeEgoNodeIds(hubNodes, hubEdges, 'service-vault');
+    expect(vault.has('service-auth')).toBe(true);
+    expect(vault.has('service-adguard')).toBe(true);
+  });
+
+  it('a service with no suppressed hub deps gains no extra hub neighbours', () => {
+    const ego = computeEgoNodeIds(hubNodes, hubEdges, 'service-ollama');
+    expect(ego.has('service-auth')).toBe(false);
+    expect(ego.has('service-adguard')).toBe(false);
+  });
+
+  it('handles remote-host prefixed and .service-suffixed hub ids', () => {
+    const remote = computeEgoNodeIds(
+      [
+        node('internet', 'internet'),
+        node('Local:service-lldap.service'),
+        svc('Local:service-immich.service', { behindAuth: true }),
+      ],
+      [],
+      'Local:service-lldap.service',
+    );
+    // lldap maps to the auth token; immich (behindAuth) must be pulled in.
+    expect(remote.has('Local:service-immich.service')).toBe(true);
+  });
+});
+
 describe('buildOrthogonalPath — line-hops (#1784)', () => {
   it('inserts a ∩ arc on a horizontal run at a hop point', () => {
     // Straight horizontal edge 0,50 → 200,50 with a crossing at x=100.

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -182,6 +182,69 @@ function shortestPathIds(
   return path;
 }
 
+/**
+ * Hub classification for ego mode — mirrors the backend's
+ * `ubiquitousDeps.ts` (#1785). The suppression there drops the
+ * hub-spoke edges and stamps `behindAuth`/`usesDns` flags on the
+ * source nodes instead, so the graph that reaches the frontend has no
+ * `service→auth` / `service→dns` edges. Ego adjacency built from those
+ * post-suppression edges therefore can't see the hub fan-in (#1792).
+ * We re-derive the hub relationship from the flags below.
+ *
+ * `service-<name>` ids may carry a `<node>:` remote-host prefix and a
+ * trailing `.service`; strip both to get the base name.
+ */
+const HUB_BASENAMES: Record<string, 'auth' | 'dns'> = {
+  auth: 'auth',
+  lldap: 'auth',
+  authelia: 'auth',
+  adguard: 'dns',
+};
+
+function hubTokenForNodeId(nodeId: string): 'auth' | 'dns' | null {
+  const afterPrefix = nodeId.includes(':') ? nodeId.slice(nodeId.indexOf(':') + 1) : nodeId;
+  if (!afterPrefix.startsWith('service-')) return null;
+  const base = afterPrefix.slice('service-'.length).replace(/\.service$/, '');
+  return HUB_BASENAMES[base] ?? null;
+}
+
+/** Read the suppressed-dependency tokens (#1785) a node carries via its
+ *  `behindAuth` / `usesDns` flags, normalised to the hub token. */
+function suppressedDepTokens(node: Node): Set<'auth' | 'dns'> {
+  const metadata = (node.data as { metadata?: { behindAuth?: unknown; usesDns?: unknown } } | undefined)
+    ?.metadata;
+  const tokens = new Set<'auth' | 'dns'>();
+  if (metadata?.behindAuth === true) tokens.add('auth');
+  if (metadata?.usesDns === true) tokens.add('dns');
+  return tokens;
+}
+
+/**
+ * #1792 — restore the ubiquitous hub relationships that #1785 suppressed
+ * out of the edge list, deriving them from the node flags instead. Adds the
+ * relevant ids to `keep` in place:
+ *  - focus IS a hub (auth/dns): add every service carrying the matching flag
+ *    (its fan-in), so the hub's ego isn't empty.
+ *  - focus is a normal service: add the hub node(s) it depends on via its
+ *    own flags, so a badge-only service isn't isolated.
+ */
+function addSuppressedHubNeighbours(nodes: Node[], focusId: string, keep: Set<string>): void {
+  const focusHubToken = hubTokenForNodeId(focusId);
+  if (focusHubToken) {
+    for (const n of nodes) {
+      if (suppressedDepTokens(n).has(focusHubToken)) keep.add(n.id);
+    }
+    return;
+  }
+  const focusNode = nodes.find((n) => n.id === focusId);
+  const wantedTokens = focusNode ? suppressedDepTokens(focusNode) : new Set<'auth' | 'dns'>();
+  if (wantedTokens.size === 0) return;
+  for (const n of nodes) {
+    const token = hubTokenForNodeId(n.id);
+    if (token && wantedTokens.has(token)) keep.add(n.id);
+  }
+}
+
 export function computeEgoNodeIds(
   nodes: Node[],
   edges: Edge[],
@@ -195,6 +258,8 @@ export function computeEgoNodeIds(
   const keep = new Set<string>([focusId]);
   // Direct neighbours (1 hop).
   for (const n of adjacency.get(focusId) ?? []) keep.add(n);
+
+  addSuppressedHubNeighbours(nodes, focusId, keep);
 
   // Shortest path Internet→focus (BFS) so the public chain is shown
   // even when the gateway/proxy hops are >1 away from the focus node.


### PR DESCRIPTION
Closes #1792

Focus/ego mode now re-derives the badge-suppressed hub dependents (SSO/DNS) so clicking auth (or a badge-only service) yields a populated focus view; fixes a regression from the #1785/#1786 badge-suppression + focus-mode interaction. Frontend-only, browser-verified; full-map planar layout unchanged.

AI-generated
<!-- sb-ai-comment -->