### PR TITLE
fix(registry): self-heal a permission-broken registry tree (#1796)

### DIFF
--- a/packages/backend/src/lib/registry.test.ts
+++ b/packages/backend/src/lib/registry.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Registry sync self-heal (#1796).
+ *
+ * When `git reset --hard` can't unlink the working tree (root-owned files
+ * written into the bind mount by another container; SB runs non-root),
+ * syncRegistries must rename the broken tree aside and re-clone fresh instead
+ * of leaving the registry permanently stale.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fsMock = vi.hoisted(() => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined), // `.git` exists → update path
+  rename: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockRejectedValue(new Error('ENOENT')), // no servicebay.json manifest
+}));
+vi.mock('fs/promises', () => ({ default: fsMock }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    exec: vi.fn((cmd: string, opts: unknown, cb?: (e: Error | null, r?: unknown) => void) => {
+      const done = (typeof opts === 'function' ? opts : cb) as (e: Error | null, r?: unknown) => void;
+      // The root-owned working tree fails the hard reset; fetch succeeds.
+      if (String(cmd).includes('reset --hard')) {
+        done(new Error('error: unable to unlink old solilos-chat/x.py: Permission denied'));
+      } else {
+        done(null, { stdout: '', stderr: '' });
+      }
+    }),
+    execFile: vi.fn((_file: string, _args: string[], opts: unknown, cb?: (e: Error | null, r?: unknown) => void) => {
+      const done = (typeof opts === 'function' ? opts : cb) as (e: Error | null, r?: unknown) => void;
+      done(null, { stdout: '', stderr: '' });
+    }),
+  };
+});
+
+vi.mock('./config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./config')>()),
+  getConfig: vi.fn().mockResolvedValue({
+    registries: [{ name: 'oscar', url: 'https://example.invalid/oscar.git' }],
+  }),
+}));
+
+import { syncRegistries } from './registry';
+
+describe('syncRegistries #1796 self-heal', () => {
+  beforeEach(() => fsMock.rename.mockClear());
+
+  it('renames the broken tree aside (then re-clones) when the hard reset fails on a root-owned tree', async () => {
+    await syncRegistries();
+
+    // The reset failure self-heals by renaming the broken tree aside instead of
+    // being swallowed (which left the registry permanently stale, #1796).
+    expect(fsMock.rename).toHaveBeenCalled();
+    const renameArgs = fsMock.rename.mock.calls[0] as [string, string];
+    expect(renameArgs[0]).not.toMatch(/\.broken-/); // the live tree…
+    expect(renameArgs[1]).toMatch(/\.broken-\d+$/); // …moved aside, so the re-clone has a clean path
+  });
+});

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -329,6 +329,21 @@ async function isGitAvailable(): Promise<boolean> {
     return gitAvailability;
 }
 
+/** Clone a registry into `regPath` (sparse first, full-clone fallback). Shared
+ *  by the initial clone and the #1796 self-heal re-clone. */
+async function cloneRegistry(reg: RegistryConfig, regPath: string): Promise<void> {
+    logger.info('registry', `Cloning registry ${reg.name}...`);
+    try {
+        // Default sparse patterns include `servicebay.json` so a manifest-using
+        // registry exposes it on the first clone; `widenSparseForManifest` then
+        // pulls any custom paths declared inside.
+        await cloneSparse(reg.url, regPath, ['templates', 'stacks', 'servicebay.json']);
+    } catch {
+        // Fallback to full clone if sparse checkout not supported
+        await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath], { env: GIT_ENV });
+    }
+}
+
 export async function syncRegistries() {
     const config = await getConfig();
     const registries = getRegistries(config);
@@ -362,25 +377,35 @@ export async function syncRegistries() {
         // the canonical `mdopp/servicebay` clone. Per-registry try/catch
         // keeps subsequent registries syncing.
         try {
-            try {
-                await fs.access(path.join(regPath, '.git'));
+            const hasGit = await fs
+                .access(path.join(regPath, '.git'))
+                .then(() => true)
+                .catch(() => false);
+            if (!hasGit) {
+                await cloneRegistry(reg, regPath);
+            } else {
                 // Exists — fetch latest and reset (shallow clones can't reliably git pull)
                 logger.info('registry', `Updating registry ${reg.name}...`);
                 const branch = reg.branch || 'main';
-                await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath, env: GIT_ENV });
-                await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath, env: GIT_ENV });
-            } catch {
-                // Doesn't exist, clone
-                logger.info('registry', `Cloning registry ${reg.name}...`);
                 try {
-                    // Default sparse patterns include `servicebay.json` so a
-                    // manifest-using registry exposes it on the first clone;
-                    // `widenSparseForManifest` below then pulls any custom
-                    // paths declared inside.
-                    await cloneSparse(reg.url, regPath, ['templates', 'stacks', 'servicebay.json']);
-                } catch {
-                    // Fallback to full clone if sparse checkout not supported
-                    await execFileAsync('git', ['clone', '--depth', '1', reg.url, regPath], { env: GIT_ENV });
+                    await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath, env: GIT_ENV });
+                    await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath, env: GIT_ENV });
+                } catch (updateErr) {
+                    // #1796: a `git reset --hard` that can't unlink the working
+                    // tree — e.g. root-owned files written into the bind mount by
+                    // another container (SB itself runs non-root) — would leave
+                    // the registry permanently stale, silently serving old
+                    // templates/skills. Self-heal: rename the broken tree aside
+                    // (that needs only write on the SB-owned PARENT dir, NOT
+                    // ownership of the tree) and re-clone fresh as the SB uid.
+                    // If even the parent is root-owned the rename throws and the
+                    // per-registry catch below leaves it stale (a privileged
+                    // chown of REGISTRIES_DIR is then the only recourse) — never
+                    // worse than today's behaviour.
+                    const msg = updateErr instanceof Error ? updateErr.message : String(updateErr);
+                    logger.warn('registry', `Registry ${reg.name} update failed (${msg}); re-cloning fresh (#1796 self-heal).`);
+                    await fs.rename(regPath, `${regPath}.broken-${Date.now()}`);
+                    await cloneRegistry(reg, regPath);
                 }
             }
             // Manifest pass: if the registry ships `servicebay.json`, pull


### PR DESCRIPTION
`syncRegistries` refreshes each registry with `git fetch` + **`git reset --hard`**. When the working tree holds **root-owned** files (written into the bind mount by another container — SB runs non-root), the reset can't unlink them; the whole sync was swallowed as a `warn` and the registry served **stale** templates/skills forever (observed on `/mnt/data/registries/oscar/solilos-chat/**` during a box-verify).

## Fix (self-heal, privilege-free)
On an update failure, rename the broken tree aside (`<regPath>.broken-<ts>`) and re-clone fresh. Rename needs only write on the **SB-owned parent** dir, not ownership of the tree — so no root required. If even the parent is root-owned the rename throws and the per-registry catch leaves it stale **as before** — strictly never-worse, recovered whenever the parent is SB-owned. Clone extracted into a shared `cloneRegistry`.

## Box-verify OWED
This recovers an already-failing path, so it's safe to ship, but the *degree* of recovery on a real root-owned tree needs a box check (my token lacks the `exec` scope). Verify on the box: a registry whose tree is root-owned gets renamed aside + re-cloned on the next sync, and serves fresh artifacts.

## Root cause (solbay-side, separate)
Why the files are root-owned is a solbay concern (a container writing into the registry bind mount as uid 0). Tracked at mdopp/solbay — without that, the heal recurs each boot (harmlessly, but the clean fix is to write as the SB uid).

Closes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)
