### PR TITLE
fix(install): pull registries at install start, not only on boot (#1806)

### DIFF
--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -31,6 +31,7 @@ import {
   getTemplatePostDeployScript,
   getTemplateMigrationScripts,
   getTemplateYaml,
+  syncRegistries,
 } from '@/lib/registry';
 import { parseTemplateSchemaVersion } from '@/lib/templateSchemaVersion';
 import { parseTemplateManifest } from '@/lib/template/contract';
@@ -831,6 +832,24 @@ async function runJob(jobId: string): Promise<void> {
     await log(jobId, '⚠️ No services selected to install — aborting.');
     await patchJob(jobId, { phase: 'done', endedAt: new Date().toISOString(), credentialsManifest: [] });
     return;
+  }
+
+  // #1806 — pull external registries BEFORE resolving any template YAML /
+  // post-deploy script. `syncRegistries()` previously ran only at server
+  // startup (server.ts), so an install fired after a registry commit landed
+  // — without an SB container restart — resolved `getTemplateYaml()` /
+  // `getTemplatePostDeployScript()` from the STALE on-disk clone and silently
+  // ran the old script (caught twice in solbay box-verifies for #314/#315,
+  // worked around by a manual `podman exec servicebay git pull`). Syncing at
+  // the start of every deploy makes the install always run the committed
+  // artifacts. Best-effort: syncRegistries isolates per-registry errors and
+  // no-ops when no external registries are configured, so a transient fetch
+  // failure must not block the install — it falls back to the existing clone.
+  try {
+    await syncRegistries();
+    await log(jobId, 'Refreshed external registries to latest committed templates/scripts.');
+  } catch (e) {
+    await log(jobId, `⚠️ Registry refresh failed (${e instanceof Error ? e.message : String(e)}); installing from the existing on-disk clone.`);
   }
 
   // Topo-sort by install-time dependencies. We also tag each item


### PR DESCRIPTION
## Problem

`syncRegistries()` (git fetch + `reset --hard` on each registered registry) ran **only at server startup** (`server.ts`). The install path (`runner.ts` → `getTemplateYaml()` / `getTemplatePostDeployScript()`) read straight from the already-cloned `REGISTRIES_DIR/<name>/` without pulling.

So a commit pushed to a registry (e.g. `mdopp/solbay`) **after** the SB container last booted was silently ignored: the install ran the **stale** `post-deploy.py` and template YAML. Caught twice in back-to-back solbay box-verifies (#314/#315) — a `post-deploy.py` at `1c37e52` ran instead of `f933103`; the only fix was a manual `podman exec servicebay git pull` before re-running.

## Fix

Call `syncRegistries()` at the **start of every deploy run** in `runJob`, after the no-op guard and **before** any template/script resolution. Now every install runs the committed artifacts.

Best-effort and isolated:
- `syncRegistries()` already wraps each registry in its own try/catch and no-ops when no external registries are configured.
- Wrapped here too: a transient fetch failure logs a warning to the deploy log and **falls back to the existing on-disk clone** rather than blocking the install.

## Verification

- `tsc --noEmit` clean
- `eslint` 0 errors (pre-existing complexity warnings on `runJob`/`deployItem` unchanged)
- `runner.test.ts` + `registry.test.ts` — 13 pass

Box-verify owed: drive a real `sb stacks install` after pushing a registry commit without restarting SB, confirm the new `post-deploy.py` runs.

Closes #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)