### PR TITLE
voice: whisper STT on the GPU via a companion container Quadlet

### DIFF
--- a/templates/voice/CHANGELOG.md
+++ b/templates/voice/CHANGELOG.md
@@ -1,0 +1,22 @@
+# voice template changelog
+
+## v2 (#1809)
+
+- Whisper (STT) moved out of the kube pod into a companion
+  `voice-whisper.container` Quadlet written by `post-deploy.py`:
+  `podman kube play` silently drops CDI GPU device requests (#1026) and
+  `privileged: true` exposes /dev without the host driver libraries, so a
+  GPU whisper is only reachable via the `.container` path (same fixup as
+  ollama). On CDI boxes the unit runs `lscr.io/linuxserver/faster-whisper:gpu`
+  (auto-upgrading a default `base-int8` choice to `medium-int8`); without
+  CDI it runs the previous CPU image with identical args. The Wyoming
+  endpoint stays `tcp://localhost:10300`, so Home Assistant pipelines and
+  the pod healthcheck are unchanged.
+- No data migration: the CPU model cache stays at
+  `${DATA_DIR}/voice/whisper`; the GPU image caches separately under
+  `${DATA_DIR}/voice/whisper-gpu` (different layout, linuxserver `/config`).
+
+## v1
+
+- Initial split out of the home-assistant pod (#348): faster-whisper,
+  piper and openWakeWord as one kube pod on the standard Wyoming ports.

--- a/templates/voice/post-deploy.py
+++ b/templates/voice/post-deploy.py
@@ -2,22 +2,35 @@
 """
 post-deploy hook for the `voice` stack.
 
-Two responsibilities:
+Three responsibilities:
 
-  1. **Data migration from the old in-HA-pod voice setup.** Whisper
-     models and Piper voices used to live under
-     `${DATA_DIR}/home-assistant/whisper` and `…/piper`. The split in
-     #348 moves them to `${DATA_DIR}/voice/whisper` and `…/piper`.
-     On first install we detect leftover content under the old paths
-     and move it to the new location so the operator doesn't have
-     to re-download multi-gigabyte models.
+  1. **Install the `voice-whisper.container` Quadlet** (#1809). Whisper
+     moved out of the pod: on CUDA boxes it should run on the GPU, and
+     the kube path cannot deliver one — `podman kube play` silently
+     drops CDI device requests (#1026), and `privileged: true` exposes
+     /dev but not the host driver libraries (box-verified: "CUDA driver
+     version is insufficient"). So whisper runs as a companion
+     `.container` Quadlet, the same pattern as the ollama GPU fixup:
+     `AddDevice=nvidia.com/gpu=all` + `SecurityLabelDisable=true` when
+     `/etc/cdi/nvidia.yaml` is registered, the plain CPU image
+     otherwise. Same Wyoming endpoint either way (tcp://localhost:10300),
+     so HA's pipeline config never changes.
 
-  2. **Surface the endpoint cheat-sheet** so the operator sees the
+     Box-measured 2026-06-12 (RTX 2000 Ada, 5.5 s German phrase, warm):
+     CPU base-int8 0.83–0.98 s (2.86 s under load) → GPU medium-int8
+     0.38 s at 1.1 GiB VRAM, GPU small 0.15 s at 0.8 GiB.
+
+  2. **Data migration from the old in-HA-pod voice setup** (#348) —
+     legacy `${DATA_DIR}/home-assistant/{whisper,piper}` content moves
+     to `${DATA_DIR}/voice/…` so multi-gigabyte models aren't
+     re-downloaded.
+
+  3. **Surface the endpoint cheat-sheet** so the operator sees the
      three Wyoming URLs they need to paste into HA's voice-assistant
      UI.
 
-Idempotent: a second run sees the new paths already populated and
-the old paths absent, and does nothing.
+Idempotent: re-runs converge (unit rewritten only on content drift,
+migration skips populated targets).
 
 See lib/registry.ts:getTemplatePostDeployScript for the script
 protocol.
@@ -27,6 +40,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import sys
 
 
@@ -38,6 +52,153 @@ def env(key: str, default: str = "") -> str:
 def log(msg: str) -> None:
     sys.stdout.write(msg + "\n")
     sys.stdout.flush()
+
+
+# ── whisper companion unit (#1809) ──────────────────────────────────────────
+
+WHISPER_UNIT = "voice-whisper"
+
+# The wizard default. When the operator left the model on this default AND
+# the box has a GPU, the unit upgrades to medium-int8 automatically — the
+# GPU runs the better model faster than the CPU ran base (box-measured
+# 0.38 s vs 0.83–2.86 s). An operator who explicitly picked a non-default
+# model keeps their choice on both paths (one knob, no GPU-specific knob).
+CPU_DEFAULT_MODEL = "base-int8"
+GPU_DEFAULT_MODEL = "medium-int8"
+
+
+def cdi_available() -> bool:
+    return os.path.exists("/etc/cdi/nvidia.yaml")
+
+
+def render_whisper_unit(data_dir: str, model: str, language: str, gpu: bool) -> str:
+    """Render the voice-whisper `.container` Quadlet (pure — the content
+    diff and the write share one source of truth)."""
+    if gpu:
+        return (
+            "[Unit]\n"
+            "Description=Voice Whisper STT (Wyoming, GPU via CDI #1809)\n"
+            "Wants=network-online.target\n"
+            "After=network-online.target\n"
+            "\n"
+            "[Container]\n"
+            "Image=lscr.io/linuxserver/faster-whisper:gpu\n"
+            f"ContainerName={WHISPER_UNIT}\n"
+            "Network=host\n"
+            f"Environment=WHISPER_MODEL={model}\n"
+            f"Environment=WHISPER_LANG={language}\n"
+            "# Beam 1: greedy decode — the GPU headroom goes into the bigger\n"
+            "# model instead; box-measured accurate at 0.38 s for 5.5 s speech.\n"
+            "Environment=WHISPER_BEAM=1\n"
+            "# CDI device — podman kube play silently drops this when\n"
+            "# expressed as resources.limits (#1026), which is why whisper\n"
+            "# left the pod.\n"
+            "AddDevice=nvidia.com/gpu=all\n"
+            "# SELinux relaxation is required for NVML/CUDA init on FCoS —\n"
+            "# without it the container sees the devices but driver init\n"
+            "# fails (same fixup as ollama, #1026).\n"
+            "SecurityLabelDisable=true\n"
+            "# linuxserver image keeps its model cache under /config.\n"
+            f"Volume={data_dir}/voice/whisper-gpu:/config:Z\n"
+            "AutoUpdate=registry\n"
+            "\n"
+            "[Service]\n"
+            "Restart=on-failure\n"
+            "RestartSec=5\n"
+            "\n"
+            "[Install]\n"
+            "WantedBy=default.target\n"
+        )
+    return (
+        "[Unit]\n"
+        "Description=Voice Whisper STT (Wyoming, CPU #1809)\n"
+        "Wants=network-online.target\n"
+        "After=network-online.target\n"
+        "\n"
+        "[Container]\n"
+        "Image=docker.io/rhasspy/wyoming-whisper:latest\n"
+        f"ContainerName={WHISPER_UNIT}\n"
+        "Network=host\n"
+        f"Exec=--model {model} --language {language}"
+        " --data-dir /data --uri tcp://0.0.0.0:10300\n"
+        f"Volume={data_dir}/voice/whisper:/data:Z\n"
+        "AutoUpdate=registry\n"
+        "\n"
+        "[Service]\n"
+        "Restart=on-failure\n"
+        "RestartSec=5\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def whisper_service_active() -> bool:
+    try:
+        out = subprocess.run(
+            ["systemctl", "--user", "is-active", f"{WHISPER_UNIT}.service"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return False
+    return out.stdout.strip() == "active"
+
+
+def install_whisper_unit(data_dir: str) -> bool:
+    """Write + activate the companion whisper Quadlet. Returns True when
+    the service is (re)started or already active with current content."""
+    gpu = cdi_available()
+    model = env("WHISPER_MODEL", CPU_DEFAULT_MODEL)
+    if gpu and model == CPU_DEFAULT_MODEL:
+        model = GPU_DEFAULT_MODEL
+    language = env("WHISPER_LANGUAGE", "de")
+    unit = render_whisper_unit(data_dir, model, language, gpu)
+
+    systemd_dir = os.path.expanduser("~/.config/containers/systemd")
+    unit_path = os.path.join(systemd_dir, f"{WHISPER_UNIT}.container")
+
+    existing = ""
+    if os.path.exists(unit_path):
+        try:
+            with open(unit_path) as f:
+                existing = f.read()
+        except OSError:
+            existing = ""
+
+    if existing == unit and whisper_service_active():
+        log(f"   whisper: {WHISPER_UNIT}.container current and active — no-op.")
+        return True
+
+    try:
+        os.makedirs(systemd_dir, exist_ok=True)
+        with open(unit_path, "w") as f:
+            f.write(unit)
+        os.chmod(unit_path, 0o644)
+    except OSError as e:
+        log(f"   ⚠️ whisper: could not write {unit_path}: {e}")
+        return False
+
+    subprocess.run(
+        ["systemctl", "--user", "daemon-reload"], check=False, capture_output=True
+    )
+    started = subprocess.run(
+        ["systemctl", "--user", "restart", f"{WHISPER_UNIT}.service"],
+        capture_output=True,
+        text=True,
+    )
+    if started.returncode != 0:
+        log(f"   ⚠️ whisper: systemctl restart failed: {started.stderr[:300]}")
+        return False
+    log(
+        f"   whisper: {WHISPER_UNIT}.container installed — "
+        f"{'GPU (CDI)' if gpu else 'CPU'} path, model {model}."
+    )
+    return True
+
+
+# ── legacy data migration (#348) ─────────────────────────────────────────────
 
 
 def migrate_dir(old_path: str, new_path: str, label: str) -> None:
@@ -80,6 +241,9 @@ def main() -> int:
         log("Migrating voice data from the legacy in-HA-pod paths (#348)...")
         migrate_dir(legacy_whisper, new_whisper, "Faster Whisper models")
         migrate_dir(legacy_piper, new_piper, "Piper voices")
+
+    # Whisper companion unit (#1809) — GPU when CDI is registered.
+    install_whisper_unit(data_dir)
 
     log("✅ Voice pipeline endpoints — paste these into Home Assistant → Settings → Voice Assistants:")
     log("   • Speech-to-text (Wyoming): tcp://localhost:10300")

--- a/templates/voice/template.yml
+++ b/templates/voice/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: voice
   annotations:
     servicebay.label: "Smart Home Voice Assist"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     # No `servicebay.tier` — voice is optional plumbing, not platform
     # infrastructure (DNS / proxy / SSO are tier=infrastructure and
     # auto-included by the wizard; voice should be opt-in). The pod
@@ -16,9 +16,10 @@ metadata:
     servicebay.ports: "10300/tcp,10200/tcp,10400/tcp"
     # Continuous health probe (#628). Wyoming protocol is binary-over-TCP,
     # no HTTP; a successful TCP connect to Whisper's port proves the
-    # primary speech-to-text container is up. The Piper + openWakeWord
-    # siblings share the pod lifecycle (Quadlet kube unit), so if
-    # Whisper is up the rest are too.
+    # primary speech-to-text service is up. Whisper runs as the companion
+    # `voice-whisper.container` Quadlet (written by post-deploy.py, #1809)
+    # — probing ITS port from the pod's healthcheck is deliberate: voice
+    # is not healthy without STT, wherever it runs.
     servicebay.healthcheck: |
       kind: tcp
       host: localhost
@@ -33,21 +34,14 @@ spec:
   # after the split from #348.
   hostNetwork: true
   containers:
-  # 1. Faster Whisper — speech-to-text via Wyoming protocol
-  - name: faster-whisper
-    image: docker.io/rhasspy/wyoming-whisper:latest
-    args:
-    - --model
-    - "{{WHISPER_MODEL}}"
-    - --language
-    - "{{WHISPER_LANGUAGE}}"
-    - --data-dir
-    - /data
-    - --uri
-    - tcp://0.0.0.0:10300
-    volumeMounts:
-    - mountPath: /data
-      name: whisper-data
+  # 1. Faster Whisper (speech-to-text) does NOT live in this pod (#1809):
+  #    it needs the GPU on CUDA-capable boxes, `podman kube play` silently
+  #    drops CDI device requests (#1026), and `privileged: true` exposes
+  #    /dev but not the host driver libraries (box-verified: "CUDA driver
+  #    version is insufficient"). post-deploy.py writes a companion
+  #    `voice-whisper.container` Quadlet instead — GPU image with
+  #    AddDevice=nvidia.com/gpu=all when CDI is registered, the CPU image
+  #    otherwise. Same Wyoming endpoint either way: tcp://localhost:10300.
 
   # 2. Piper — text-to-speech via Wyoming protocol
   - name: piper
@@ -71,10 +65,6 @@ spec:
     - tcp://0.0.0.0:10400
 
   volumes:
-  - name: whisper-data
-    hostPath:
-      path: {{DATA_DIR}}/voice/whisper
-      type: DirectoryOrCreate
   - name: piper-data
     hostPath:
       path: {{DATA_DIR}}/voice/piper

--- a/templates/voice/variables.json
+++ b/templates/voice/variables.json
@@ -1,14 +1,36 @@
 {
   "WHISPER_MODEL": {
     "type": "select",
-    "description": "Faster Whisper speech-to-text model size (int8 variants are faster with minimal quality loss)",
-    "options": ["tiny-int8", "base-int8", "small-int8", "medium-int8", "tiny", "base", "small", "medium"],
+    "description": "Faster Whisper speech-to-text model size (int8 variants are faster with minimal quality loss). On a box with a registered NVIDIA CDI GPU the whisper unit runs the GPU image, and leaving this on the default base-int8 auto-upgrades to medium-int8 there (the GPU runs the better model faster than the CPU ran base — box-measured 0.38s vs up to 2.86s for 5.5s of speech, #1809). An explicit non-default choice is kept as-is on both paths.",
+    "options": [
+      "tiny-int8",
+      "base-int8",
+      "small-int8",
+      "medium-int8",
+      "tiny",
+      "base",
+      "small",
+      "medium"
+    ],
     "default": "base-int8"
   },
   "WHISPER_LANGUAGE": {
     "type": "select",
     "description": "Language for speech recognition",
-    "options": ["de", "en", "fr", "es", "it", "nl", "pl", "pt", "ru", "zh", "ja", "ko"],
+    "options": [
+      "de",
+      "en",
+      "fr",
+      "es",
+      "it",
+      "nl",
+      "pl",
+      "pt",
+      "ru",
+      "zh",
+      "ja",
+      "ko"
+    ],
     "default": "de"
   },
   "PIPER_VOICE": {


### PR DESCRIPTION
Closes #1809.

## What

Whisper (STT) leaves the voice kube pod and becomes a companion `voice-whisper.container` Quadlet written by the template's post-deploy:

- **CDI box** (`/etc/cdi/nvidia.yaml` present): `lscr.io/linuxserver/faster-whisper:gpu` with `AddDevice=nvidia.com/gpu=all` + `SecurityLabelDisable=true` — the same #1026 fixup ollama uses. A default `base-int8` model choice auto-upgrades to `medium-int8` (the GPU runs the better model faster than the CPU ran base); an explicit non-default choice is respected (no new knob).
- **No CDI**: previous CPU image (`rhasspy/wyoming-whisper`) with identical args.

Wyoming endpoint stays `tcp://localhost:10300` → HA pipelines and the pod healthcheck (tcp probe on 10300, intentionally probing the companion unit) are unchanged. Schema-version → 2, CHANGELOG added; no data migration (CPU cache stays at `voice/whisper`, GPU image caches under `voice/whisper-gpu`).

## Why kube can't do this (box-verified)

- `podman kube play` silently drops CDI `resources.limits` device requests (#1026).
- `privileged: true` exposes `/dev/nvidia*` but not the host driver userspace libs → `CUDA failed: driver version is insufficient`.

## Measurements (RTX 2000 Ada, 5.5 s German phrase, warm, wyoming bench client)

| variant | finalize | VRAM |
|---|---|---|
| CPU base-int8 (before) | 0.83–0.98 s (up to **2.86 s** on a real spoken turn) | — |
| GPU small | 0.15 s | 808 MiB |
| **GPU medium-int8 (after)** | **0.38 s** | 1122 MiB |

Real-world effect on the Solilos voice path: a long spoken command drops from 3.86 s → ~1.4 s speech-end-to-answer.

## Verify (will run on the box after merge)

`sb stacks` redeploy of voice → `voice-whisper.service` active on the GPU unit, `nvidia-smi` shows the whisper process, wyoming bench reproduces ≤0.5 s, HA pipeline STT works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)