### PR TITLE
feat(mcp): access-request tools and install kube restart on spec change

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -587,6 +587,25 @@ export interface AccessRequest {
   status: 'pending' | 'resolved';
   /** ISO timestamp of when the admin marked it resolved. */
   resolvedAt?: string;
+  /**
+   * Provenance/category for requests filed programmatically via SB-MCP
+   * (#1818) rather than the anonymous portal form — e.g. `resident` for
+   * a Solilos conversational onboarding. Absent for portal submissions
+   * (which are implicitly portal-account requests).
+   */
+  kind?: string;
+  /**
+   * Free-form structured context attached by the MCP caller (#1818) —
+   * e.g. "voice profile enrolled". Surfaced to the admin alongside the
+   * request so they can decide. Capped on the MCP tool side.
+   */
+  payload?: string;
+  /**
+   * Who/what filed the request when it came in over SB-MCP (#1818) —
+   * the calling agent/token identity, for the admin's audit trail.
+   * Absent for anonymous portal submissions.
+   */
+  requestedBy?: string;
 }
 
 export function getOidcCallbackUrl(config: { reverseProxy?: { publicDomain?: string } }): string {

--- a/packages/backend/src/lib/mcp/server.accessRequest.test.ts
+++ b/packages/backend/src/lib/mcp/server.accessRequest.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { AppConfig } from '@/lib/config';
+
+// #1818: access-request / approval MCP tools. Mock the config store with an
+// in-memory document so the file/list/poll round-trip is hermetic (no real
+// config.json on disk) and the cap guard is exercisable.
+let store: Partial<AppConfig>;
+
+vi.mock('@/lib/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/config')>();
+  return {
+    ...actual,
+    getConfig: vi.fn(async () => store as AppConfig),
+    updateConfig: vi.fn(async (updates: Partial<AppConfig>) => {
+      // Mirror config.deepMerge's array-replace semantics for accessRequests.
+      store = { ...store, ...updates };
+      return store as AppConfig;
+    }),
+  };
+});
+
+const { createMcpServer } = await import('./server');
+
+async function connectClient() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+function parse(res: unknown) {
+  const content = (res as { content: { type: string; text: string }[] }).content;
+  return JSON.parse(content[0].text);
+}
+
+describe('access-request MCP tools (#1818)', () => {
+  beforeEach(() => {
+    store = {};
+  });
+
+  it('files a pending request and returns an id that can be polled', async () => {
+    const { client } = await connectClient();
+    const filed = parse(await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'Ada Lovelace', kind: 'resident', payload: 'voice profile enrolled', requested_by: 'solilos-agent' },
+    }));
+    expect(filed.ok).toBe(true);
+    expect(filed.id).toBeTruthy();
+    expect(filed.status).toBe('pending');
+
+    // It landed in the central list with its provenance intact.
+    expect((store.accessRequests ?? []).length).toBe(1);
+    const stored = store.accessRequests![0];
+    expect(stored.name).toBe('Ada Lovelace');
+    expect(stored.kind).toBe('resident');
+    expect(stored.payload).toBe('voice profile enrolled');
+    expect(stored.requestedBy).toBe('solilos-agent');
+    expect(stored.status).toBe('pending');
+
+    // Pollable by id.
+    const status = parse(await client.callTool({
+      name: 'get_access_request_status',
+      arguments: { id: filed.id },
+    }));
+    expect(status.status).toBe('pending');
+    expect(status.subject).toBe('Ada Lovelace');
+    await client.close();
+  });
+
+  it('reflects approval (admin resolves) on the next poll', async () => {
+    const { client } = await connectClient();
+    const filed = parse(await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'Grace Hopper' },
+    }));
+    // Admin approves via the existing flow (mutates the same store).
+    store.accessRequests![0].status = 'resolved';
+    store.accessRequests![0].resolvedAt = new Date().toISOString();
+
+    const status = parse(await client.callTool({
+      name: 'get_access_request_status',
+      arguments: { id: filed.id },
+    }));
+    expect(status.status).toBe('resolved');
+    await client.close();
+  });
+
+  it('returns not-found for an unknown id', async () => {
+    const { client } = await connectClient();
+    const status = parse(await client.callTool({
+      name: 'get_access_request_status',
+      arguments: { id: 'does-not-exist' },
+    }));
+    expect(status.status).toBe('not-found');
+    await client.close();
+  });
+
+  it('list_access_requests filters by status (pending by default)', async () => {
+    const { client } = await connectClient();
+    await client.callTool({ name: 'file_access_request', arguments: { subject: 'Pending One' } });
+    await client.callTool({ name: 'file_access_request', arguments: { subject: 'Resolved One' } });
+    store.accessRequests![1].status = 'resolved';
+
+    const pending = parse(await client.callTool({ name: 'list_access_requests', arguments: {} }));
+    expect(pending.requests.map((r: { subject: string }) => r.subject)).toEqual(['Pending One']);
+
+    const all = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'all' } }));
+    expect(all.requests).toHaveLength(2);
+    await client.close();
+  });
+
+  it('rejects filing once the pending cap is hit', async () => {
+    const { client } = await connectClient();
+    store.accessRequests = Array.from({ length: 50 }, (_, i) => ({
+      id: `r${i}`,
+      requestedAt: new Date().toISOString(),
+      name: `req ${i}`,
+      email: '',
+      status: 'pending' as const,
+    }));
+    const res = await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'one too many' },
+    });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/Too many pending/);
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -19,7 +19,7 @@ import { agentManager } from '@/lib/agent/manager';
 import { HealthStore } from '@/lib/health/store';
 import { CheckRunner } from '@/lib/health/runner';
 import type { CheckConfig, CheckType } from '@/lib/health/types';
-import { getConfig, updateConfig, type AppConfig, type ProxyHostEntry } from '@/lib/config';
+import { getConfig, updateConfig, type AppConfig, type ProxyHostEntry, type AccessRequest } from '@/lib/config';
 import {
   getBackupHistory,
   runBackup as runBackupService,
@@ -68,6 +68,7 @@ const MUTATING_TOOLS = new Set([
   'deploy_service', 'delete_service', 'rename_service', 'update_service_yaml',
   'restore_trashed_service', 'purge_trashed_service',
   'add_proxy_route', 'remove_proxy_route',
+  'file_access_request',
   'create_health_check', 'delete_health_check', 'run_check_now',
   'run_backup', 'restore_backup',
   'update_config', 'exec_command', 'refresh_agent',
@@ -103,6 +104,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   list_trashed_services: 'read',
   get_unmanaged_bundles: 'read',
   get_channel: 'read',
+  list_access_requests: 'read', get_access_request_status: 'read',
   // lifecycle
   start_service: 'lifecycle', stop_service: 'lifecycle', restart_service: 'lifecycle',
   run_check_now: 'lifecycle', refresh_agent: 'lifecycle',
@@ -112,6 +114,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   deploy_service: 'mutate', update_service_yaml: 'mutate', rename_service: 'mutate',
   add_proxy_route: 'mutate', create_health_check: 'mutate',
   restore_trashed_service: 'mutate',
+  file_access_request: 'mutate',
   // mutate (config writes, allow-listed to safe keys — see update_config tool)
   update_config: 'mutate',
   // destroy
@@ -1351,6 +1354,98 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         if (err instanceof StackResetError) return errorResult(err.message);
         return errorResult(err instanceof Error ? err.message : String(err));
       }
+    },
+  );
+
+  // --- Access requests / approval workflow (#1818) ---
+  // Programmatic surface over the same `config.accessRequests` list the
+  // family portal feeds and the admin Settings page resolves. Lets an
+  // agent (e.g. Solilos resident-onboarding, mdopp/solbay #355) file a
+  // pending approval the admin acts on in the existing flow, then poll
+  // its status to react on approval.
+  //
+  // Anti-spam cap mirrors the public POST route's MAX_PENDING (50).
+  const MAX_PENDING_ACCESS_REQUESTS = 50;
+
+  server.tool(
+    'file_access_request',
+    'File a pending access/approval request to the admin\'s central access-request list (the same list the family portal feeds and Settings resolves). Returns the request id; poll it with get_access_request_status. Use for programmatic approvals (e.g. registering a new resident) — the admin approves or denies in the existing flow.',
+    {
+      subject: z.string().trim().min(1).max(120).describe('Human-readable label for who/what is being requested (e.g. the candidate resident\'s name).'),
+      kind: z.string().trim().min(1).max(40).optional().describe('Category/provenance of the request (e.g. "resident"). Free-form; helps the admin triage.'),
+      payload: z.string().trim().max(1000).optional().describe('Structured context for the admin (e.g. "voice profile enrolled").'),
+      requested_by: z.string().trim().max(120).optional().describe('Who/what is filing the request — the calling agent or token identity, for the audit trail.'),
+      email: z.email().max(200).optional().describe('Contact email for the subject, if known. Feeds the LLDAP user when the admin approves.'),
+    },
+    async ({ subject, kind, payload, requested_by, email }) => {
+      const config = await getConfig();
+      const existing = config.accessRequests ?? [];
+      const pending = existing.filter(r => r.status === 'pending');
+      if (pending.length >= MAX_PENDING_ACCESS_REQUESTS) {
+        return errorResult(
+          `Too many pending access requests (${pending.length}/${MAX_PENDING_ACCESS_REQUESTS}). The admin needs to resolve existing ones first.`,
+        );
+      }
+      const newRequest: AccessRequest = {
+        id: randomUUID(),
+        requestedAt: new Date().toISOString(),
+        name: subject,
+        email: email ?? '',
+        message: payload,
+        status: 'pending',
+        ...(kind ? { kind } : {}),
+        ...(payload ? { payload } : {}),
+        ...(requested_by ? { requestedBy: requested_by } : {}),
+      };
+      await updateConfig({ accessRequests: [...existing, newRequest] });
+      return textResult({ ok: true, id: newRequest.id, status: newRequest.status });
+    },
+  );
+
+  server.tool(
+    'list_access_requests',
+    'List access/approval requests on the admin\'s central list. Defaults to pending only; pass status="all" to include resolved.',
+    {
+      status: z.enum(['pending', 'resolved', 'all']).optional().default('pending').describe('Filter by status. Default: pending.'),
+    },
+    async ({ status }) => {
+      const config = await getConfig();
+      const all = config.accessRequests ?? [];
+      const filtered = status === 'all' ? all : all.filter(r => r.status === status);
+      return textResult({
+        requests: filtered.map(r => ({
+          id: r.id,
+          status: r.status,
+          subject: r.name,
+          kind: r.kind,
+          payload: r.payload,
+          requestedBy: r.requestedBy,
+          email: r.email || undefined,
+          requestedAt: r.requestedAt,
+          resolvedAt: r.resolvedAt,
+        })),
+      });
+    },
+  );
+
+  server.tool(
+    'get_access_request_status',
+    'Poll the status of one access request by id (as returned by file_access_request). Returns "pending", "resolved", or "not-found".',
+    {
+      id: z.string().min(1).describe('Request id returned by file_access_request.'),
+    },
+    async ({ id }) => {
+      const config = await getConfig();
+      const req = (config.accessRequests ?? []).find(r => r.id === id);
+      if (!req) return textResult({ id, status: 'not-found' as const });
+      return textResult({
+        id: req.id,
+        status: req.status,
+        subject: req.name,
+        kind: req.kind,
+        requestedAt: req.requestedAt,
+        resolvedAt: req.resolvedAt,
+      });
     },
   );
 

--- a/packages/backend/src/lib/services/serviceLifecycle.restartOnSpecChange.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.restartOnSpecChange.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #1813 — a re-deploy that changes the pod spec must actually apply the new
+// topology. `systemctl start` is a no-op on an already-active unit, so the
+// deploy path reads the on-disk content before overwriting and, when the
+// render changed AND the unit is live, issues a `restart` instead of a `start`.
+// These tests cover the two seams that decision rides on.
+
+const mockSendCommand = vi.fn();
+vi.mock('../agent/manager', () => ({
+    agentManager: {
+        ensureAgent: async () => ({ sendCommand: mockSendCommand }),
+    },
+}));
+
+import { ServiceLifecycle } from './serviceLifecycle';
+
+beforeEach(() => {
+    mockSendCommand.mockReset();
+});
+
+describe('ServiceLifecycle.isServiceActive (#1813)', () => {
+    it('returns true when systemctl reports "active"', async () => {
+        mockSendCommand.mockResolvedValue({ code: 0, stdout: 'active\n', stderr: '' });
+        await expect(ServiceLifecycle.isServiceActive('local', 'voice')).resolves.toBe(true);
+        expect(mockSendCommand).toHaveBeenCalledWith('exec', {
+            command: 'systemctl --user is-active voice.service',
+        });
+    });
+
+    it('returns false for inactive/unknown (first install)', async () => {
+        mockSendCommand.mockResolvedValue({ code: 3, stdout: 'inactive\n', stderr: '' });
+        await expect(ServiceLifecycle.isServiceActive('local', 'voice')).resolves.toBe(false);
+    });
+
+    it('returns false when the agent call throws (best-effort)', async () => {
+        mockSendCommand.mockRejectedValue(new Error('agent down'));
+        await expect(ServiceLifecycle.isServiceActive('local', 'voice')).resolves.toBe(false);
+    });
+});
+
+describe('ServiceLifecycle.readExistingQuadletFile (#1813)', () => {
+    it('returns the on-disk content (string response)', async () => {
+        mockSendCommand.mockResolvedValue('old yaml content');
+        await expect(ServiceLifecycle.readExistingQuadletFile('local', 'voice.yml')).resolves.toBe('old yaml content');
+        expect(mockSendCommand).toHaveBeenCalledWith('read_file', {
+            path: '~/.config/containers/systemd/voice.yml',
+        });
+    });
+
+    it('returns the on-disk content ({content} response)', async () => {
+        mockSendCommand.mockResolvedValue({ content: 'old kube content' });
+        await expect(ServiceLifecycle.readExistingQuadletFile('local', 'voice.kube')).resolves.toBe('old kube content');
+    });
+
+    it('returns null when the file is missing (read error → first install)', async () => {
+        mockSendCommand.mockRejectedValue(new Error('No such file'));
+        await expect(ServiceLifecycle.readExistingQuadletFile('local', 'voice.yml')).resolves.toBeNull();
+    });
+
+    it('returns null for an unrecognised response shape', async () => {
+        mockSendCommand.mockResolvedValue({ code: 0 });
+        await expect(ServiceLifecycle.readExistingQuadletFile('local', 'voice.yml')).resolves.toBeNull();
+    });
+});
+
+describe('restart-on-spec-change decision (#1813)', () => {
+    // The deploy path computes `specChanged = prevYaml !== yamlContent ||
+    // prevKube !== kubeContent` and restarts only when that is true AND the
+    // unit is active. These assert the branch table the bug fix relies on.
+    const decide = (specChanged: boolean, active: boolean) =>
+        specChanged && active ? 'restart' : 'start';
+
+    it('restarts when the spec changed and the unit is live (the #1813 bug)', () => {
+        expect(decide(true, true)).toBe('restart');
+    });
+
+    it('plain-starts on first install (unit not active) even if content "changed"', () => {
+        expect(decide(true, false)).toBe('start');
+    });
+
+    it('plain-starts a variable-only refresh that produced identical files', () => {
+        expect(decide(false, true)).toBe('start');
+    });
+});

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -236,6 +236,48 @@ export class ServiceLifecycle {
         if (res.code !== 0) throw new Error(res.stderr);
     }
 
+    /**
+     * Whether `<serviceName>.service` is currently active (running). Used by
+     * the deploy path to choose start-vs-restart: `systemctl start` on an
+     * already-active unit is a no-op, so a re-deploy that changed the pod
+     * spec would leave the old topology running (#1813). Best-effort —
+     * any error is treated as "not active" so the deploy falls back to a
+     * plain start.
+     */
+    static async isServiceActive(nodeName: string, serviceName: string): Promise<boolean> {
+        try {
+            const agent = await agentManager.ensureAgent(nodeName);
+            const res = await agent.sendCommand('exec', {
+                command: `systemctl --user is-active ${serviceName}.service`,
+            });
+            return (res?.stdout ?? '').trim() === 'active';
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Read a quadlet/pod file currently on the node, or `null` if it isn't
+     * there yet (first install). Best-effort: any read error → `null`, so
+     * the caller treats it as "no prior content" and the deploy proceeds.
+     */
+    static async readExistingQuadletFile(nodeName: string, filename: string): Promise<string | null> {
+        try {
+            const agent = await agentManager.ensureAgent(nodeName);
+            const res = await agent.sendCommand('read_file', {
+                path: `~/${SYSTEMD_DIR}/${filename}`,
+            });
+            if (typeof res === 'string') return res;
+            if (res && typeof res === 'object' && 'content' in res) {
+                const c = (res as { content?: unknown }).content;
+                return typeof c === 'string' ? c : null;
+            }
+            return null;
+        } catch {
+            return null;
+        }
+    }
+
     static async writeFile(nodeName: string, filename: string, content: string) {
         const agent = await agentManager.ensureAgent(nodeName);
         const targetPath = `~/.config/containers/systemd/${filename}`;
@@ -778,6 +820,18 @@ export class ServiceLifecycle {
             }
         }
 
+        // #1813 — `systemctl start` is a no-op on an already-active unit, so a
+        // re-deploy that changed the pod spec (e.g. a removed container) would
+        // write the new render to disk but keep the OLD topology running until
+        // a manual restart. Capture the on-disk content BEFORE overwriting so
+        // we can tell whether this deploy actually changed the spec and force a
+        // restart in that case. A variable-only refresh that produces identical
+        // files still skips the restart (best-effort: a read failure → treat as
+        // changed, so we err toward applying the new render).
+        const prevYaml = await ServiceLifecycle.readExistingQuadletFile(nodeName, yamlName);
+        const prevKube = await ServiceLifecycle.readExistingQuadletFile(nodeName, `${name}.kube`);
+        const specChanged = prevYaml !== yamlContent || prevKube !== kubeContent;
+
         await ServiceLifecycle.writeFile(nodeName, yamlName, yamlContent);
         await ServiceLifecycle.writeFile(nodeName, `${name}.kube`, kubeContent);
         await ServiceLifecycle.ensurePodmanSocket(nodeName);
@@ -811,9 +865,20 @@ export class ServiceLifecycle {
         // Run pre-start hooks (e.g. initialize databases with known credentials)
         await ServiceLifecycle.runPreStartHooks(nodeName, name, yamlContent);
 
-        // Attempt start, but don't fail deployment if start fails (user can check logs)
+        // Attempt start, but don't fail deployment if start fails (user can check logs).
+        // #1813 — if the rendered spec changed AND the unit is already active,
+        // `start` alone won't re-read the new pod spec (it's a no-op on a live
+        // unit), so restart to actually apply the changed topology. First
+        // install (inactive) or an unchanged re-render falls through to a plain
+        // start.
         try {
-             await ServiceLifecycle.startService(nodeName, name);
+             const alreadyActive = specChanged && (await ServiceLifecycle.isServiceActive(nodeName, name));
+             if (alreadyActive) {
+                 onProgress?.(`Pod spec changed — restarting ${name} to apply the new topology...`);
+                 await ServiceLifecycle.restartService(nodeName, name);
+             } else {
+                 await ServiceLifecycle.startService(nodeName, name);
+             }
         } catch(e) {
              logger.warn('ServiceManager', `Service ${name} deployed but start failed:`, e);
         }


### PR DESCRIPTION
## What
Two units from batch/2026-06-13a: install re-deploys now restart the kube service when the rendered pod spec changed (not just on variable refreshes), and SB-MCP exposes access-request file/list/poll tools for the admin approval workflow.

## Why
Closes #1813
Closes #1818

## Risk
medium - #1813 touches the install re-deploy restart path; #1818 is additive MCP surface gated on the existing admin token.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2485 passed)
- [ ] /verify on FCoS :dev box (install-path change in #1813 - box_verify owed)

AI-generated.
<!-- sb-ai-comment -->