### PR TITLE
feat(mcp): add username to file_access_request and surface kind/requestedBy in admin UI

### DIFF
--- a/packages/backend/src/lib/mcp/server.accessRequest.test.ts
+++ b/packages/backend/src/lib/mcp/server.accessRequest.test.ts
@@ -70,6 +70,30 @@ describe('access-request MCP tools (#1818)', () => {
     await client.close();
   });
 
+  it('stores the optional username so the admin gets the auto-approve path', async () => {
+    const { client } = await connectClient();
+    const filed = parse(await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'Ada Lovelace', kind: 'resident', requested_by: 'solilos-agent', username: 'ada.lovelace' },
+    }));
+    expect(filed.ok).toBe(true);
+    const stored = store.accessRequests![0];
+    // canAutoApprove in the admin UI is Boolean(r.username) — it must be set.
+    expect(stored.username).toBe('ada.lovelace');
+    await client.close();
+  });
+
+  it('rejects an invalid username (uppercase/spaces) instead of storing it', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'Bad Login', username: 'Ada Lovelace' },
+    });
+    expect(res.isError).toBe(true);
+    expect(store.accessRequests ?? []).toHaveLength(0);
+    await client.close();
+  });
+
   it('reflects approval (admin resolves) on the next poll', async () => {
     const { client } = await connectClient();
     const filed = parse(await client.callTool({

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1376,8 +1376,9 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       payload: z.string().trim().max(1000).optional().describe('Structured context for the admin (e.g. "voice profile enrolled").'),
       requested_by: z.string().trim().max(120).optional().describe('Who/what is filing the request — the calling agent or token identity, for the audit trail.'),
       email: z.email().max(200).optional().describe('Contact email for the subject, if known. Feeds the LLDAP user when the admin approves.'),
+      username: z.string().trim().regex(/^[a-z0-9._-]{1,60}$/, 'Username must be lowercase letters, digits, ., _ or -, max 60 chars').optional().describe('Desired LLDAP login (uid). Supplying it lets the admin one-click Approve to auto-provision the user; omit to leave provisioning manual.'),
     },
-    async ({ subject, kind, payload, requested_by, email }) => {
+    async ({ subject, kind, payload, requested_by, email, username }) => {
       const config = await getConfig();
       const existing = config.accessRequests ?? [];
       const pending = existing.filter(r => r.status === 'pending');
@@ -1396,6 +1397,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         ...(kind ? { kind } : {}),
         ...(payload ? { payload } : {}),
         ...(requested_by ? { requestedBy: requested_by } : {}),
+        ...(username ? { username } : {}),
       };
       await updateConfig({ accessRequests: [...existing, newRequest] });
       return textResult({ ok: true, id: newRequest.id, status: newRequest.status });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Check, ExternalLink, Loader2, Mail, Send, Trash2, UserCheck, UserPlus } from 'lucide-react';
+import { Bot, Check, ExternalLink, Globe, Loader2, Mail, Send, Trash2, UserCheck, UserPlus } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 
 interface AccessRequest {
@@ -15,6 +15,10 @@ interface AccessRequest {
   lastName?: string;
   status: 'pending' | 'resolved';
   resolvedAt?: string;
+  /** Category for MCP-filed requests (e.g. "resident"); absent for portal submissions. */
+  kind?: string;
+  /** Agent/token identity that filed the request over SB-MCP; absent for portal submissions. */
+  requestedBy?: string;
 }
 
 /**
@@ -214,6 +218,32 @@ export default function AccessRequestsSection() {
   );
 }
 
+/**
+ * Source-of-origin badge: "Via agent" (with the filer id in the tooltip)
+ * for MCP-filed requests (#1818/#1821), "Via portal" for anonymous portal
+ * submissions. Lets the admin tell programmatic requests apart at a glance.
+ */
+function ProvenanceBadge({ requestedBy }: { requestedBy?: string }) {
+  if (requestedBy) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[11px] font-medium rounded bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300"
+        title={`Filed via agent: ${requestedBy}`}
+      >
+        <Bot size={11} /> Via agent
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[11px] font-medium rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+      title="Submitted from the family portal"
+    >
+      <Globe size={11} /> Via portal
+    </span>
+  );
+}
+
 function RequestRow({
   r,
   onApprove,
@@ -244,12 +274,21 @@ function RequestRow({
                 {r.username}
               </span>
             )}
-            <a href={`mailto:${r.email}`} className="inline-flex items-center gap-1 text-blue-700 dark:text-blue-300 hover:underline text-xs">
-              <Mail size={12} /> {r.email}
-            </a>
+            {r.kind && (
+              <span className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded capitalize">
+                {r.kind}
+              </span>
+            )}
+            <ProvenanceBadge requestedBy={r.requestedBy} />
+            {r.email && (
+              <a href={`mailto:${r.email}`} className="inline-flex items-center gap-1 text-blue-700 dark:text-blue-300 hover:underline text-xs">
+                <Mail size={12} /> {r.email}
+              </a>
+            )}
           </div>
           <div className="text-[11px] text-gray-500 dark:text-gray-400">
             Submitted {new Date(r.requestedAt).toLocaleString()}
+            {r.requestedBy && ` · by ${r.requestedBy}`}
             {r.resolvedAt && ` · resolved ${new Date(r.resolvedAt).toLocaleString()}`}
           </div>
           {r.message && (


### PR DESCRIPTION
## What
Adds an optional `username` param to the `file_access_request` MCP tool so agents can supply a desired LLDAP uid, which unlocks the auto-approve Approve button for MCP-filed requests. Extends the admin AccessRequests UI to render a `kind` pill badge and a `requestedBy` provenance label when those fields are present, distinguishing MCP-filed requests from portal requests.

## Why
Closes #1821

## Risk
Low. Additive change: a new optional MCP param and two presence-gated UI fields; no behavior change for existing portal requests.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2487 passed)
- [ ] /verify on FCoS :dev box (not path-mandated; box_verify not owed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)