### PR TITLE
feat(mcp): distinguish approved vs denied access requests

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -584,8 +584,19 @@ export interface AccessRequest {
   firstName?: string;
   /** Family name — feeds LLDAP `lastName` when the admin approves. */
   lastName?: string;
-  status: 'pending' | 'resolved';
-  /** ISO timestamp of when the admin marked it resolved. */
+  /**
+   * Lifecycle state.
+   *   pending  — awaiting an admin decision.
+   *   approved — admin provisioned/accepted the request (one-click
+   *              Approve or "Mark resolved").
+   *   denied   — admin dismissed the request; nothing was provisioned.
+   *
+   * Legacy entries written before #1824 carry the old `'resolved'`
+   * value, which always meant the approve path. Read those as
+   * `'approved'`; never write `'resolved'` going forward.
+   */
+  status: 'pending' | 'approved' | 'denied' | 'resolved';
+  /** ISO timestamp of when the admin resolved (approved/denied) it. */
   resolvedAt?: string;
   /**
    * Provenance/category for requests filed programmatically via SB-MCP

--- a/packages/backend/src/lib/mcp/server.accessRequest.test.ts
+++ b/packages/backend/src/lib/mcp/server.accessRequest.test.ts
@@ -94,13 +94,44 @@ describe('access-request MCP tools (#1818)', () => {
     await client.close();
   });
 
-  it('reflects approval (admin resolves) on the next poll', async () => {
+  it('reports approved vs denied distinctly on the next poll (#1824)', async () => {
     const { client } = await connectClient();
-    const filed = parse(await client.callTool({
+    const approvedReq = parse(await client.callTool({
       name: 'file_access_request',
       arguments: { subject: 'Grace Hopper' },
     }));
-    // Admin approves via the existing flow (mutates the same store).
+    const deniedReq = parse(await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'Margaret Hamilton' },
+    }));
+    // Admin approves one (POST .../approve) and denies the other (PATCH).
+    store.accessRequests![0].status = 'approved';
+    store.accessRequests![0].resolvedAt = new Date().toISOString();
+    store.accessRequests![1].status = 'denied';
+    store.accessRequests![1].resolvedAt = new Date().toISOString();
+
+    const approved = parse(await client.callTool({
+      name: 'get_access_request_status',
+      arguments: { id: approvedReq.id },
+    }));
+    expect(approved.status).toBe('approved');
+
+    const denied = parse(await client.callTool({
+      name: 'get_access_request_status',
+      arguments: { id: deniedReq.id },
+    }));
+    expect(denied.status).toBe('denied');
+    await client.close();
+  });
+
+  it('surfaces a legacy "resolved" entry as "approved" (#1824 back-compat)', async () => {
+    const { client } = await connectClient();
+    const filed = parse(await client.callTool({
+      name: 'file_access_request',
+      arguments: { subject: 'Legacy Entry' },
+    }));
+    // Old PATCH route wrote 'resolved'; the approve path was the only
+    // historical resolution, so it must read back as 'approved'.
     store.accessRequests![0].status = 'resolved';
     store.accessRequests![0].resolvedAt = new Date().toISOString();
 
@@ -108,7 +139,7 @@ describe('access-request MCP tools (#1818)', () => {
       name: 'get_access_request_status',
       arguments: { id: filed.id },
     }));
-    expect(status.status).toBe('resolved');
+    expect(status.status).toBe('approved');
     await client.close();
   });
 
@@ -122,17 +153,29 @@ describe('access-request MCP tools (#1818)', () => {
     await client.close();
   });
 
-  it('list_access_requests filters by status (pending by default)', async () => {
+  it('list_access_requests filters by status (pending by default, approved/denied/all)', async () => {
     const { client } = await connectClient();
     await client.callTool({ name: 'file_access_request', arguments: { subject: 'Pending One' } });
-    await client.callTool({ name: 'file_access_request', arguments: { subject: 'Resolved One' } });
-    store.accessRequests![1].status = 'resolved';
+    await client.callTool({ name: 'file_access_request', arguments: { subject: 'Approved One' } });
+    await client.callTool({ name: 'file_access_request', arguments: { subject: 'Denied One' } });
+    await client.callTool({ name: 'file_access_request', arguments: { subject: 'Legacy Resolved' } });
+    store.accessRequests![1].status = 'approved';
+    store.accessRequests![2].status = 'denied';
+    store.accessRequests![3].status = 'resolved'; // legacy → approved
 
     const pending = parse(await client.callTool({ name: 'list_access_requests', arguments: {} }));
     expect(pending.requests.map((r: { subject: string }) => r.subject)).toEqual(['Pending One']);
 
+    const approved = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'approved' } }));
+    expect(approved.requests.map((r: { subject: string }) => r.subject)).toEqual(['Approved One', 'Legacy Resolved']);
+    // Legacy 'resolved' is normalized in the response too.
+    expect(approved.requests.every((r: { status: string }) => r.status === 'approved')).toBe(true);
+
+    const denied = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'denied' } }));
+    expect(denied.requests.map((r: { subject: string }) => r.subject)).toEqual(['Denied One']);
+
     const all = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'all' } }));
-    expect(all.requests).toHaveLength(2);
+    expect(all.requests).toHaveLength(4);
     await client.close();
   });
 

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1404,20 +1404,26 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     },
   );
 
+  // Legacy entries written before #1824 carry the old `'resolved'`
+  // status, which always meant the approve path — surface them as
+  // `'approved'` so callers only ever see pending|approved|denied.
+  const normalizeStatus = (s: AccessRequest['status']): 'pending' | 'approved' | 'denied' =>
+    s === 'resolved' ? 'approved' : s;
+
   server.tool(
     'list_access_requests',
-    'List access/approval requests on the admin\'s central list. Defaults to pending only; pass status="all" to include resolved.',
+    'List access/approval requests on the admin\'s central list. Defaults to pending only; pass status="approved", "denied", or "all".',
     {
-      status: z.enum(['pending', 'resolved', 'all']).optional().default('pending').describe('Filter by status. Default: pending.'),
+      status: z.enum(['pending', 'approved', 'denied', 'all']).optional().default('pending').describe('Filter by status. Default: pending.'),
     },
     async ({ status }) => {
       const config = await getConfig();
       const all = config.accessRequests ?? [];
-      const filtered = status === 'all' ? all : all.filter(r => r.status === status);
+      const filtered = status === 'all' ? all : all.filter(r => normalizeStatus(r.status) === status);
       return textResult({
         requests: filtered.map(r => ({
           id: r.id,
-          status: r.status,
+          status: normalizeStatus(r.status),
           subject: r.name,
           kind: r.kind,
           payload: r.payload,
@@ -1432,7 +1438,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   server.tool(
     'get_access_request_status',
-    'Poll the status of one access request by id (as returned by file_access_request). Returns "pending", "resolved", or "not-found".',
+    'Poll the status of one access request by id (as returned by file_access_request). Returns "pending" (awaiting an admin decision), "approved" (admin provisioned the user — proceed), "denied" (admin dismissed it — provision nothing and drop any captured data), or "not-found".',
     {
       id: z.string().min(1).describe('Request id returned by file_access_request.'),
     },
@@ -1442,7 +1448,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       if (!req) return textResult({ id, status: 'not-found' as const });
       return textResult({
         id: req.id,
-        status: req.status,
+        status: normalizeStatus(req.status),
         subject: req.name,
         kind: req.kind,
         requestedAt: req.requestedAt,

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -13,7 +13,9 @@ interface AccessRequest {
   username?: string;
   firstName?: string;
   lastName?: string;
-  status: 'pending' | 'resolved';
+  // `approved`/`denied` since #1824; `resolved` is the legacy value
+  // (always meant approved) still present on older entries.
+  status: 'pending' | 'approved' | 'denied' | 'resolved';
   resolvedAt?: string;
   /** Category for MCP-filed requests (e.g. "resident"); absent for portal submissions. */
   kind?: string;
@@ -125,7 +127,7 @@ export default function AccessRequestsSection() {
   };
 
   const pending = requests.filter(r => r.status === 'pending');
-  const resolved = requests.filter(r => r.status === 'resolved').sort((a, b) => (b.resolvedAt ?? '').localeCompare(a.resolvedAt ?? ''));
+  const resolved = requests.filter(r => r.status !== 'pending').sort((a, b) => (b.resolvedAt ?? '').localeCompare(a.resolvedAt ?? ''));
 
   if (busy === 'load') {
     return (
@@ -316,7 +318,7 @@ function RequestRow({
               <Check size={16} />
             </button>
           )}
-          {r.status === 'resolved' && canResendWelcome && (
+          {r.status !== 'pending' && r.status !== 'denied' && canResendWelcome && (
             <button
               onClick={onResendWelcome}
               disabled={busy}

--- a/packages/frontend/src/app/api/system/access-requests/[id]/approve/route.ts
+++ b/packages/frontend/src/app/api/system/access-requests/[id]/approve/route.ts
@@ -71,7 +71,7 @@ export const POST = withApiHandlerParams<undefined, undefined, Params>(
 
     requests[idx] = {
       ...req,
-      status: 'resolved',
+      status: 'approved',
       resolvedAt: new Date().toISOString(),
     };
     await saveConfig({ ...config, accessRequests: requests });

--- a/packages/frontend/src/app/api/system/access-requests/[id]/route.ts
+++ b/packages/frontend/src/app/api/system/access-requests/[id]/route.ts
@@ -8,8 +8,11 @@ export const dynamic = 'force-dynamic';
  * Per-request actions for the family portal access-request flow
  * (#242 follow-up).
  *
- *   PATCH  — mark a pending request resolved (admin clicked "create
- *            user" or "ignore").
+ *   PATCH  — deny/dismiss a pending request (admin clicked "ignore").
+ *            Marks it `denied` so a programmatic requester polling via
+ *            SB-MCP (#1824) can clean up — nothing is provisioned. The
+ *            approve path lives in the sibling `approve/route.ts`, which
+ *            sets `approved` after provisioning the LLDAP user.
  *   DELETE — drop the request entirely. Used for spam cleanup.
  *
  * Both endpoints require a session — proxy.ts only allows
@@ -31,7 +34,7 @@ export const PATCH = withApiHandlerParams<undefined, undefined, Params>(
     }
     requests[idx] = {
       ...requests[idx],
-      status: 'resolved',
+      status: 'denied',
       resolvedAt: new Date().toISOString(),
     };
     await saveConfig({ ...config, accessRequests: requests });

--- a/packages/frontend/src/app/api/system/access-requests/[id]/status/route.ts
+++ b/packages/frontend/src/app/api/system/access-requests/[id]/status/route.ts
@@ -57,6 +57,13 @@ export const GET = withApiHandlerParams<undefined, undefined, Params>(
         requestedAt: req.requestedAt,
       });
     }
+    // A denied request provisions nothing — fall back silently to the
+    // default Request-access CTA rather than the "account ready" block.
+    if (req.status === 'denied') {
+      return NextResponse.json({ status: 'not-found' } as const);
+    }
+    // `approved` (and legacy `resolved`, which always meant the approve
+    // path before #1824) → the "set your password" CTA.
     const urls = await getWelcomeEmailUrls();
     return NextResponse.json({
       status: 'resolved' as const,

--- a/tests/backend/access_requests.test.ts
+++ b/tests/backend/access_requests.test.ts
@@ -154,7 +154,7 @@ describe('GET /api/system/access-requests', () => {
 });
 
 describe('PATCH /api/system/access-requests/[id]', () => {
-  it('marks a request resolved', async () => {
+  it('marks a request denied (#1824)', async () => {
     state.config.accessRequests = [
       { id: 'r1', requestedAt: '2026-01-01', name: 'A', email: 'a@b.c', status: 'pending' },
     ];
@@ -163,7 +163,7 @@ describe('PATCH /api/system/access-requests/[id]', () => {
       { params: Promise.resolve({ id: 'r1' }) },
     );
     expect(res.status).toBe(200);
-    expect(state.config.accessRequests[0].status).toBe('resolved');
+    expect(state.config.accessRequests[0].status).toBe('denied');
     expect(state.config.accessRequests[0].resolvedAt).toBeDefined();
   });
 


### PR DESCRIPTION
## What
Extends `AccessRequest.status` from pending/resolved to pending/approved/denied so the MCP `get_access_request_status` tool reports the actual outcome. Approve route writes `approved`, deny/ignore route writes `denied`, public portal status route treats `approved` like the old `resolved` CTA, and `list_access_requests` accepts the new status filters. Legacy `resolved` entries are surfaced as `approved` for backward compatibility.

## Why
Closes #1824

## Risk
low - additive status values with backward-compat reads for legacy `resolved`; no path-mandated install/backup/config surfaces changed.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint
- [x] npm run check:arch
- [x] npm test (full)