### PR TITLE
feat(claude-dev): LLDAP SSH login + fix dev-box mislabel as 'ServiceBay System'

### DIFF
--- a/packages/backend/src/lib/store/twin.test.ts
+++ b/packages/backend/src/lib/store/twin.test.ts
@@ -64,3 +64,78 @@ describe('DigitalTwinStore.setInstalledTemplates (#1733)', () => {
     expect(spy).toHaveBeenCalledTimes(2);
   });
 });
+
+// The `isServiceBay` flag overrides a service's dashboard label to
+// "ServiceBay System" / category "System". The detector must not confuse the
+// dockerised Claude Code dev box (image `ghcr.io/mdopp/servicebay-claude-dev`)
+// with the management system (image `ghcr.io/mdopp/servicebay`) just because
+// the image names share the `servicebay` prefix.
+describe('DigitalTwinStore.isServiceBay detection — servicebay-claude-dev must not be mis-flagged', () => {
+  let store: DigitalTwinStore;
+
+  beforeEach(() => {
+    store = DigitalTwinStore.getInstance();
+    store.nodes = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const service = (over: Record<string, any>): any => ({
+    name: 'svc.service',
+    activeState: 'active',
+    subState: 'running',
+    loadState: 'loaded',
+    description: '',
+    path: '',
+    ...over,
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const container = (over: Record<string, any>): any => ({
+    id: 'c1',
+    names: ['c1'],
+    image: '',
+    state: 'running',
+    status: 'Up',
+    created: 0,
+    ports: [],
+    mounts: [],
+    labels: {},
+    networks: [],
+    ...over,
+  });
+
+  const isServiceBayFor = (svc: unknown, ctr: unknown): boolean | undefined => {
+    store.updateNode('node-x', { services: [svc as never], containers: [ctr as never] });
+    return store.nodes['node-x'].services?.[0]?.isServiceBay;
+  };
+
+  it('does NOT flag the claude-dev container (servicebay-claude-dev image)', () => {
+    const svc = service({ name: 'claude-dev.service', associatedContainerIds: ['cd'] });
+    const ctr = container({
+      id: 'cd',
+      names: ['claude-dev-claude-dev'],
+      image: 'ghcr.io/mdopp/servicebay-claude-dev:latest',
+    });
+    expect(isServiceBayFor(svc, ctr)).toBe(false);
+  });
+
+  it('DOES flag the real management image (servicebay) by image alone', () => {
+    const svc = service({ name: 'sb.service', associatedContainerIds: ['mgmt'] });
+    const ctr = container({
+      id: 'mgmt',
+      names: ['servicebay'],
+      image: 'ghcr.io/mdopp/servicebay:latest',
+    });
+    expect(isServiceBayFor(svc, ctr)).toBe(true);
+  });
+
+  it('DOES flag the management unit by its name (servicebay.service)', () => {
+    const svc = service({ name: 'servicebay.service' });
+    const ctr = container({ id: 'other', names: ['other'], image: 'nginx:latest' });
+    expect(isServiceBayFor(svc, ctr)).toBe(true);
+  });
+});

--- a/packages/backend/src/lib/store/twin.ts
+++ b/packages/backend/src/lib/store/twin.ts
@@ -477,7 +477,17 @@ export class DigitalTwinStore {
 
     private static readonly KNOWN_PROXY_KEYWORDS = ['nginx', 'nginx', 'haproxy', 'traefik', 'caddy', 'envoy'];
     private static readonly PROXY_EXCLUDE_KEYWORDS = ['mpris-proxy'];
-    private static readonly SERVICEBAY_KEYWORDS = ['servicebay', 'service-bay', 'service_bay'];
+    // Match a ServiceBay keyword only when it stands alone as a token, NOT
+    // when it's the prefix of a larger compound like `servicebay-claude-dev`.
+    // That image (`ghcr.io/mdopp/servicebay-claude-dev`) is the dockerised
+    // Claude Code dev box — a separate feature service — which merely shares
+    // the `servicebay` prefix with the management image (`.../servicebay`).
+    // A loose `includes('servicebay')` mis-flagged it as the system unit, so
+    // the dashboard rendered it as "ServiceBay System" / "System".
+    // The negative lookahead rejects a trailing word char or hyphen, so
+    // `servicebay:latest` / `servicebay.service` still match but
+    // `servicebay-claude-dev` does not.
+    private static readonly SERVICEBAY_KEYWORD_RE = /(?:servicebay|service-bay|service_bay)(?![\w-])/;
 
     private isReverseProxyService(service: ServiceUnit, containers: EnrichedContainer[]): boolean {
           const nameCandidates = this.buildServiceNameCandidates(service);
@@ -574,8 +584,7 @@ export class DigitalTwinStore {
 
     private matchesServiceBayKeyword(value?: string): boolean {
           if (!value) return false;
-          const normalized = value.toLowerCase();
-          return DigitalTwinStore.SERVICEBAY_KEYWORDS.some(keyword => normalized.includes(keyword));
+          return DigitalTwinStore.SERVICEBAY_KEYWORD_RE.test(value.toLowerCase());
       }
 
     private hasServiceBayKeyword(candidates: Set<string>): boolean {

--- a/stacks/claude-dev/stack.yml
+++ b/stacks/claude-dev/stack.yml
@@ -8,6 +8,8 @@ metadata:
 spec:
   # Single-template stack: a long-lived dev container so a coding
   # session against this repo can be driven from the Claude Code mobile
-  # app without keeping a laptop awake. No depends-on-stacks — the dev
-  # box is self-contained and needs neither the reverse proxy nor SSO.
+  # app without keeping a laptop awake. It needs no reverse proxy (no
+  # subdomain), but the template declares a `servicebay.dependencies: auth`
+  # so SSH logins can authenticate against the box's LLDAP — the operator
+  # signs in as their real LDAP user instead of the shared `dev` account.
   templates: [claude-dev]

--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -17,12 +17,17 @@ FROM node:20-bookworm-slim
 #   - procps/iproute2        : ps/ss for debugging from inside a session
 #   - tmux                   : persistent session that survives disconnects
 #   - curl/ca-certificates/gnupg : fetch the GitHub CLI apt key
+#   - nslcd/libnss-ldapd/libpam-ldapd : authenticate SSH logins against the
+#       box's LLDAP so the operator signs in as their real LDAP user (e.g.
+#       `mdopp`) instead of the shared local `dev` account. ldap-utils ships
+#       `ldapsearch` for on-box debugging of the bind.
 # The GitHub CLI (`gh`) is not in Debian's repos, so add its apt source.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       openssh-server openssh-client git bash \
       make gcc g++ python3 \
       podman procps iproute2 tmux \
       curl ca-certificates gnupg \
+      nslcd libnss-ldapd libpam-ldapd ldap-utils \
   && install -m 0755 -d /etc/apt/keyrings \
   && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -42,6 +47,32 @@ RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
 # skeleton; the runtime bind mount then takes over and the entrypoint
 # re-scaffolds it.
 RUN useradd --create-home --home-dir /workspace --shell /bin/bash dev
+
+# LDAP auth wiring (nss-pam-ldapd), baked deterministically at build time.
+# NSS resolves LLDAP users; PAM verifies their password by binding to LLDAP.
+# The entrypoint writes /etc/nslcd.conf from the LLDAP_* env and starts nslcd
+# only when LLDAP_ADMIN_PASSWORD is set, so a box without the auth stack (or
+# with the vars blank) still boots with just the local `dev` break-glass user.
+#   - nsswitch: resolve from local `files` FIRST (root + dev stay fast and
+#     independent of LDAP), then fall back to `ldap`.
+#   - pam_ldap in the common-* stacks (via pam-auth-update), plus pam_mkhomedir
+#     so each LDAP user's home under /workspace/home/<uid> is created on first
+#     login from /etc/skel.
+RUN set -eux; \
+    printf '%s\n' \
+      'passwd:         files ldap' \
+      'group:          files ldap' \
+      'shadow:         files ldap' \
+      'hosts:          files dns' \
+      'networks:       files' \
+      'protocols:      db files' \
+      'services:       db files' \
+      'ethers:         db files' \
+      'rpc:            db files' \
+      > /etc/nsswitch.conf; \
+    DEBIAN_FRONTEND=noninteractive pam-auth-update --package --enable ldap; \
+    grep -q pam_mkhomedir /etc/pam.d/common-session \
+      || echo 'session optional pam_mkhomedir.so skel=/etc/skel umask=0077' >> /etc/pam.d/common-session
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -28,8 +28,32 @@ SSH host keys all survive a container restart.
 | Variable | Purpose |
 |---|---|
 | `CLAUDE_DEV_SSH_PORT` | Host port sshd listens on (default `2222`). |
-| `CLAUDE_DEV_SSH_PASSWORD` | Auto-generated password for the `dev` user; surfaced as a credential after install. |
-| `CLAUDE_DEV_SSH_AUTHORIZED_KEY` | Optional SSH public key; enables key-based login (recommended when the box is reachable from outside the LAN). |
+| `CLAUDE_DEV_SSH_PASSWORD` | Auto-generated password for the local `dev` break-glass user; surfaced as a credential after install. |
+| `CLAUDE_DEV_SSH_AUTHORIZED_KEY` | Optional SSH public key for the `dev` user; enables key-based login (recommended when the box is reachable from outside the LAN). |
+| `LLDAP_ADMIN_PASSWORD` | LLDAP bind password. **Not asked for** — reused automatically from the value the `auth` stack generated. Empty ⇒ LDAP login off, `dev` only. |
+| `CLAUDE_DEV_LDAP_GROUP` | LLDAP group whose members may SSH in (default `lldap_admin`). |
+| `LLDAP_HOST` / `LLDAP_LDAP_PORT` / `LLDAP_BASE_DN` | LLDAP coordinates; default to the `auth` stack's defaults (`localhost` / `3890` / `dc=dopp,dc=cloud`). |
+
+## Logging in as your own LDAP user
+
+When the `auth` stack is installed, the container authenticates SSH logins
+against the box's **LLDAP** via `nss-pam-ldapd`, so you sign in as your real
+LDAP user (e.g. `mdopp`) with your LLDAP password — no shared `dev` account:
+
+```sh
+ssh -p 2222 mdopp@<server-ip>      # password = your LLDAP password
+```
+
+- Only members of the `CLAUDE_DEV_LDAP_GROUP` (default `lldap_admin`) may log
+  in — enforced by sshd `AllowGroups` + an nslcd `pam_authz_search` filter.
+- Each LDAP user gets a persistent home at `/workspace/home/<user>` (created
+  on first login), so their `~/.claude` history and `gh` auth survive
+  restarts independently.
+- LLDAP doesn't store `homeDirectory`/`loginShell`; nslcd synthesizes them.
+- The local **`dev`** account stays as a break-glass path (its password/key
+  still work), so a directory outage or LDAP misconfig can't lock you out.
+- LDAP is **opt-in**: with `LLDAP_ADMIN_PASSWORD` blank (auth not installed)
+  the container skips all LDAP wiring and behaves exactly as before.
 
 ## Reaching it from a phone
 
@@ -77,4 +101,6 @@ attached, so automation isn't trapped in tmux.
 - Running the full ServiceBay test suite *inside* this container
   (podman-in-podman / CI parity) — a later phase can add the e2e harness.
 - Auto-cloning a repo on container start — the operator clones manually.
-- Multi-user / multi-session concurrency.
+- Heavy multi-user concurrency. LDAP login gives each operator their own
+  identity + home, but the box is still sized for one person at a time
+  (a single shared `/workspace` checkout area, no per-user resource limits).

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -38,8 +38,58 @@ if [ -n "${CLAUDE_DEV_SSH_PASSWORD:-}" ]; then
   password_auth=yes
   echo "claude-dev: password SSH login enabled for user 'dev'."
 fi
-if [ "$password_auth" = no ] && [ -z "${CLAUDE_DEV_SSH_AUTHORIZED_KEY:-}" ]; then
-  echo "claude-dev: WARNING — no SSH password or authorized key set; nobody can log in." >&2
+if [ "$password_auth" = no ] && [ -z "${CLAUDE_DEV_SSH_AUTHORIZED_KEY:-}" ] && [ -z "${LLDAP_ADMIN_PASSWORD:-}" ]; then
+  echo "claude-dev: WARNING — no SSH password, authorized key, or LDAP set; nobody can log in." >&2
+fi
+
+# LDAP login (nss-pam-ldapd). When the LLDAP bind password is present, wire
+# nslcd against the box's LLDAP so the operator signs in as their real LDAP
+# user (e.g. `mdopp`) with their LLDAP credentials, instead of the shared
+# `dev` account. The `dev` user is kept as a break-glass path so a misconfig
+# here can never lock everyone out. Opt-in: with the var blank, this whole
+# block is skipped and the box behaves exactly as before.
+ldap_enabled=no
+if [ -n "${LLDAP_ADMIN_PASSWORD:-}" ]; then
+  LLDAP_HOST="${LLDAP_HOST:-localhost}"
+  LLDAP_LDAP_PORT="${LLDAP_LDAP_PORT:-3890}"
+  LLDAP_BASE_DN="${LLDAP_BASE_DN:-dc=dopp,dc=cloud}"
+  CLAUDE_DEV_LDAP_GROUP="${CLAUDE_DEV_LDAP_GROUP:-lldap_admin}"
+
+  # Per-user homes live under the persistent /workspace volume so each LDAP
+  # user's git checkouts, ~/.claude history and gh auth survive a restart.
+  install -d -o root -g root -m 0755 "$DEV_HOME/home"
+
+  # LLDAP serves uid/uidNumber/gidNumber/memberOf but NOT homeDirectory or
+  # loginShell — synthesize them via nslcd maps. pam_authz_search gates login
+  # on membership of the configured LLDAP group. The file holds the bind
+  # password, so keep it root-readable only.
+  umask 077
+  cat > /etc/nslcd.conf <<EOF
+uid nslcd
+gid nslcd
+uri ldap://${LLDAP_HOST}:${LLDAP_LDAP_PORT}
+base ${LLDAP_BASE_DN}
+base passwd ou=people,${LLDAP_BASE_DN}
+base group ou=groups,${LLDAP_BASE_DN}
+binddn uid=admin,ou=people,${LLDAP_BASE_DN}
+bindpw ${LLDAP_ADMIN_PASSWORD}
+scope sub
+map passwd homeDirectory "${DEV_HOME}/home/\$uid"
+map passwd loginShell    "/bin/bash"
+pam_authz_search (&(uid=\$username)(memberof=cn=${CLAUDE_DEV_LDAP_GROUP},ou=groups,${LLDAP_BASE_DN}))
+EOF
+  chown root:nslcd /etc/nslcd.conf
+  chmod 640 /etc/nslcd.conf
+  umask 022
+
+  rm -f /run/nslcd/socket
+  install -d -o nslcd -g nslcd -m 755 /run/nslcd
+  if /usr/sbin/nslcd; then
+    ldap_enabled=yes
+    echo "claude-dev: LDAP login enabled — sign in as an LLDAP user in group '${CLAUDE_DEV_LDAP_GROUP}' (bind ldap://${LLDAP_HOST}:${LLDAP_LDAP_PORT})."
+  else
+    echo "claude-dev: WARNING — nslcd failed to start; LDAP login disabled, local 'dev' account still works." >&2
+  fi
 fi
 
 # Start the long-lived `claude` tmux session as the dev user BEFORE we
@@ -58,11 +108,34 @@ else
 fi
 
 mkdir -p /run/sshd
-echo "claude-dev: starting sshd on port ${SSH_PORT}."
-exec /usr/sbin/sshd -D -e \
-  -p "$SSH_PORT" \
-  -o "PasswordAuthentication=${password_auth}" \
-  -o "PubkeyAuthentication=yes" \
-  -o "PermitRootLogin=no" \
-  -o "HostKey=${HOSTKEY_DIR}/ssh_host_ed25519_key" \
+
+# Base sshd options. The local `dev` account authenticates with its own
+# password/key exactly as before.
+sshd_opts=(
+  -D -e
+  -p "$SSH_PORT"
+  -o "PubkeyAuthentication=yes"
+  -o "PermitRootLogin=no"
+  -o "HostKey=${HOSTKEY_DIR}/ssh_host_ed25519_key"
   -o "HostKey=${HOSTKEY_DIR}/ssh_host_rsa_key"
+)
+
+if [ "$ldap_enabled" = yes ]; then
+  # PAM drives LLDAP password verification (pam_ldap). Password auth must be
+  # on for LDAP users to authenticate even when the `dev` password is unset.
+  # AllowGroups restricts logins to the local `dev` break-glass group plus the
+  # configured LLDAP group — without it, every resolvable LDAP user could log
+  # in regardless of group, since pam_authz_search alone wouldn't bound NSS.
+  sshd_opts+=(
+    -o "UsePAM=yes"
+    -o "PasswordAuthentication=yes"
+    -o "KbdInteractiveAuthentication=yes"
+    -o "AllowGroups=dev ${CLAUDE_DEV_LDAP_GROUP}"
+  )
+  echo "claude-dev: starting sshd on port ${SSH_PORT} (LDAP + local 'dev')."
+else
+  sshd_opts+=( -o "PasswordAuthentication=${password_auth}" )
+  echo "claude-dev: starting sshd on port ${SSH_PORT} (local 'dev' only)."
+fi
+
+exec /usr/sbin/sshd "${sshd_opts[@]}"

--- a/templates/claude-dev/post-deploy.py
+++ b/templates/claude-dev/post-deploy.py
@@ -35,10 +35,20 @@ def main() -> int:
     ssh_port = env("CLAUDE_DEV_SSH_PORT", "2222")
     ssh_password = env("CLAUDE_DEV_SSH_PASSWORD")
     has_key = bool(env("CLAUDE_DEV_SSH_AUTHORIZED_KEY"))
+    ldap_enabled = bool(env("LLDAP_ADMIN_PASSWORD"))
+    ldap_group = env("CLAUDE_DEV_LDAP_GROUP", "lldap_admin")
 
-    auth_hint = "SSH key" if has_key else "the password below"
-    log(f"✅ Claude Dev container is up — SSH in on port {ssh_port} as user 'dev' ({auth_hint}).")
-    log(f"   Attach:  ssh -p {ssh_port} dev@{host}")
+    log(f"✅ Claude Dev container is up — SSH in on port {ssh_port}.")
+    if ldap_enabled:
+        log(f"   Primary login: your LLDAP account (e.g. mdopp), if you're in group '{ldap_group}':")
+        log(f"     ssh -p {ssh_port} <your-ldap-user>@{host}     # password = your LLDAP password")
+        log(f"   Break-glass:   local 'dev' account still works ({'SSH key' if has_key else 'password below'}):")
+        log(f"     ssh -p {ssh_port} dev@{host}")
+        log("   Each LDAP user gets a persistent home under /workspace/home/<user>.")
+    else:
+        auth_hint = "SSH key" if has_key else "the password below"
+        log(f"   Log in as user 'dev' ({auth_hint}):  ssh -p {ssh_port} dev@{host}")
+        log("   (LDAP login appears once the `auth` stack is installed and claude-dev is reinstalled.)")
     log("   First session — clone a repo into the persistent volume and start Claude Code:")
     log("     git clone https://github.com/<you>/<repo> /workspace/<repo>")
     log("     cd /workspace/<repo> && claude")

--- a/templates/claude-dev/template.yml
+++ b/templates/claude-dev/template.yml
@@ -8,6 +8,11 @@ metadata:
     servicebay.label: "Claude Dev (Claude Code CLI + toolchain)"
     servicebay.schema-version: "1"
     servicebay.ports: "{{CLAUDE_DEV_SSH_PORT}}/tcp"
+    # LLDAP (the `auth` stack) provides the directory the SSH login binds
+    # against, and installing auth first means claude-dev inherits the
+    # already-saved LLDAP_ADMIN_PASSWORD (savedSecrets is keyed by var name).
+    # The dependency also topo-orders the deploy so LLDAP is healthy first.
+    servicebay.dependencies: "auth"
     # Continuous health probe (#628). A raw TCP connect to the SSH port
     # proves sshd accepted the listener — a dev box has no
     # unauthenticated HTTP surface to probe.
@@ -39,6 +44,20 @@ spec:
         value: "{{CLAUDE_DEV_SSH_PASSWORD}}"
       - name: CLAUDE_DEV_SSH_AUTHORIZED_KEY
         value: "{{CLAUDE_DEV_SSH_AUTHORIZED_KEY}}"
+      # LLDAP bind for SSH logins as a real LDAP user (e.g. mdopp). These
+      # mirror the `auth` template's variable names so LLDAP_ADMIN_PASSWORD is
+      # reused from savedSecrets (the value auth generated) rather than asked
+      # for again. Blank LLDAP_ADMIN_PASSWORD ⇒ LDAP off, local `dev` only.
+      - name: LLDAP_HOST
+        value: "{{LLDAP_HOST}}"
+      - name: LLDAP_LDAP_PORT
+        value: "{{LLDAP_LDAP_PORT}}"
+      - name: LLDAP_BASE_DN
+        value: "{{LLDAP_BASE_DN}}"
+      - name: LLDAP_ADMIN_PASSWORD
+        value: "{{LLDAP_ADMIN_PASSWORD}}"
+      - name: CLAUDE_DEV_LDAP_GROUP
+        value: "{{CLAUDE_DEV_LDAP_GROUP}}"
     ports:
       - containerPort: {{CLAUDE_DEV_SSH_PORT}}
     volumeMounts:

--- a/templates/claude-dev/user-guide.md
+++ b/templates/claude-dev/user-guide.md
@@ -79,14 +79,27 @@ your SSH key if you supplied `CLAUDE_DEV_SSH_AUTHORIZED_KEY`).
 
 ## Connect over SSH (terminal / mobile app)
 
-The same `dev@<host>:<port>` works from any terminal or the Claude Code
-mobile app. `sshd` binds the port directly on the host, so on the LAN you
-connect straight to it; from outside, add a FritzBox port-forward for that
-port first.
+When the **Authelia/LLDAP** stack is installed, you sign in with your **own
+LLDAP account** (e.g. `mdopp`) and your LLDAP password — the box authenticates
+against the directory, so there's no shared account to hand around:
+
+```sh
+ssh -p <port> <your-ldap-user>@<host>
+```
+
+Only members of the configured LLDAP group (default `lldap_admin`) may log in.
+Each LDAP user gets their own persistent home at `/workspace/home/<user>`.
+
+A local **`dev`** account stays available as a break-glass fallback (its
+password is on the post-install credentials banner, or use your SSH key), so a
+directory hiccup can't lock you out:
 
 ```sh
 ssh -p <port> dev@<host>
 ```
+
+`sshd` binds the port directly on the host, so on the LAN you connect straight
+to it; from outside, add a FritzBox port-forward for that port first.
 
 Every interactive login auto-attaches to the persistent `claude` tmux
 session, so a closed phone or a network blip never kills your work. Detach

--- a/templates/claude-dev/variables.json
+++ b/templates/claude-dev/variables.json
@@ -12,5 +12,29 @@
     "type": "text",
     "description": "Optional SSH public key (one line, e.g. `ssh-ed25519 AAAA... you@phone`). When set, key-based login is enabled for the `dev` user — recommended over the password for a box reachable from outside the LAN. Leave blank to use the password only.",
     "default": ""
+  },
+  "LLDAP_HOST": {
+    "type": "text",
+    "description": "LLDAP host the SSH login binds against. Always localhost — the `auth` stack runs hostNetwork, so LLDAP's LDAP port is reachable on the loopback of this hostNetwork container.",
+    "default": "localhost"
+  },
+  "LLDAP_LDAP_PORT": {
+    "type": "text",
+    "description": "LLDAP LDAP-protocol port. Must match the `auth` stack's LLDAP_LDAP_PORT.",
+    "default": "3890"
+  },
+  "LLDAP_BASE_DN": {
+    "type": "text",
+    "description": "LDAP base DN, e.g. dc=dopp,dc=cloud. Must match the `auth` stack's LLDAP_BASE_DN. Users resolve under ou=people, groups under ou=groups.",
+    "default": "dc=dopp,dc=cloud"
+  },
+  "LLDAP_ADMIN_PASSWORD": {
+    "type": "secret",
+    "description": "LLDAP admin bind password. Not asked for here — reused automatically from the value the `auth` stack generated (savedSecrets is keyed by variable name). When empty (auth never installed) LDAP login is skipped and only the local `dev` account works."
+  },
+  "CLAUDE_DEV_LDAP_GROUP": {
+    "type": "text",
+    "description": "Only LLDAP users in this group may SSH in. Defaults to the built-in LLDAP admin group so the box operator can log in immediately. Create a dedicated LLDAP group and point this at it to grant dev-box access without making someone a full LLDAP admin.",
+    "default": "lldap_admin"
   }
 }


### PR DESCRIPTION
## What

Two changes to the `claude-dev` dev box, batched into one release.

### 1. `fix(twin)` — dev box mislabeled as "ServiceBay System"

The `isServiceBay` detector matched any image whose name *contains*
`servicebay` via a loose `includes()`. The claude-dev image
`ghcr.io/mdopp/servicebay-claude-dev` shares that prefix, so the dev box was
flagged as the management system and rendered as **ServiceBay System** /
category **System** on the services dashboard (exactly the symptom reported:
`:2222`, container `claude-dev-claude-dev`, labeled "ServiceBay System").

Fix: match the keyword as a standalone token with a negative lookahead that
rejects a trailing word char or hyphen — `servicebay:latest` /
`servicebay.service` still match, `servicebay-claude-dev` does not.
Regression tests added.

### 2. `feat(claude-dev)` — log in as your real LLDAP user (Closes #1827)

SSH logins now authenticate against the box's **LLDAP** via `nss-pam-ldapd`,
so the operator signs in as e.g. `mdopp` with their LLDAP password instead of
a shared `dev` account.

- Login gated by membership of `CLAUDE_DEV_LDAP_GROUP` (default `lldap_admin`)
  — sshd `AllowGroups` + nslcd `pam_authz_search`.
- Per-user persistent home at `/workspace/home/<user>`.
- Local `dev` account kept as **break-glass** — no lockout risk.
- **Opt-in**: with `LLDAP_ADMIN_PASSWORD` blank the container behaves exactly
  as before. The var mirrors the `auth` template's name, so it's reused from
  `savedSecrets` with no re-prompt; the template now `depends on auth`.

## Verification

- `npm test` — 2491 passed / 2 skipped
- `npm run lint` — 0 errors
- `npm run check:arch` — invariants + dep-cruiser clean
- `bash -n` / `py_compile` / template-consistency suite — green

## Box-verify owed (cannot be tested in CI)

LDAP auth correctness (nslcd maps, group filter, PAM) is only provable on the
box against the real LLDAP. Plan: merge → `claude-dev-image.yml` rebuilds the
image → release → `sb stacks install --stacks claude-dev` → SSH in as `mdopp`.
The `dev` break-glass guarantees access even if the nslcd config needs a
tweak. Schema-version intentionally stays `1` (optional vars, no data move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
