### PR TITLE
fix(claude-dev): make LDAP login work with LLDAP 0.6.x (auth-only model)

### DIFF
--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -49,20 +49,26 @@ RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
 RUN useradd --create-home --home-dir /workspace --shell /bin/bash dev
 
 # LDAP auth wiring (nss-pam-ldapd), baked deterministically at build time.
-# NSS resolves LLDAP users; PAM verifies their password by binding to LLDAP.
-# The entrypoint writes /etc/nslcd.conf from the LLDAP_* env and starts nslcd
-# only when LLDAP_ADMIN_PASSWORD is set, so a box without the auth stack (or
-# with the vars blank) still boots with just the local `dev` break-glass user.
-#   - nsswitch: resolve from local `files` FIRST (root + dev stay fast and
-#     independent of LDAP), then fall back to `ldap`.
-#   - pam_ldap in the common-* stacks (via pam-auth-update), plus pam_mkhomedir
-#     so each LDAP user's home under /workspace/home/<uid> is created on first
-#     login from /etc/skel.
+#
+# LLDAP (0.6.x) is an auth directory, not a POSIX/NSS source: it serves no
+# uidNumber/gidNumber/homeDirectory and groups carry DN `member`s, not
+# `memberUid`/`gidNumber`. So NSS can't resolve LLDAP users the normal way.
+# Instead we use LDAP for AUTHENTICATION only: PAM (pam_ldap) verifies a
+# password by binding to LLDAP as the user's DN, and the entrypoint
+# auto-provisions a matching LOCAL account per group member so NSS (files)
+# can resolve them. nslcd is the daemon pam_ldap talks to; it's configured
+# and started by the entrypoint only when LLDAP_ADMIN_PASSWORD is set, so a
+# box without the auth stack still boots with just the `dev` break-glass user.
+#   - nsswitch stays `files`-only — local accounts (root, dev, provisioned
+#     LDAP users) resolve fast and independently of the directory.
+#   - pam_ldap in the common-* stacks (via pam-auth-update) does the
+#     bind-as-user auth + group authz; pam_mkhomedir seeds each user's home
+#     under /workspace/home/<uid> on first login from /etc/skel.
 RUN set -eux; \
     printf '%s\n' \
-      'passwd:         files ldap' \
-      'group:          files ldap' \
-      'shadow:         files ldap' \
+      'passwd:         files' \
+      'group:          files' \
+      'shadow:         files' \
       'hosts:          files dns' \
       'networks:       files' \
       'protocols:      db files' \

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -31,25 +31,34 @@ SSH host keys all survive a container restart.
 | `CLAUDE_DEV_SSH_PASSWORD` | Auto-generated password for the local `dev` break-glass user; surfaced as a credential after install. |
 | `CLAUDE_DEV_SSH_AUTHORIZED_KEY` | Optional SSH public key for the `dev` user; enables key-based login (recommended when the box is reachable from outside the LAN). |
 | `LLDAP_ADMIN_PASSWORD` | LLDAP bind password. **Not asked for** — reused automatically from the value the `auth` stack generated. Empty ⇒ LDAP login off, `dev` only. |
-| `CLAUDE_DEV_LDAP_GROUP` | LLDAP group whose members may SSH in (default `lldap_admin`). |
+| `CLAUDE_DEV_LDAP_GROUP` | LLDAP group whose members may SSH in (default `admins`). |
 | `LLDAP_HOST` / `LLDAP_LDAP_PORT` / `LLDAP_BASE_DN` | LLDAP coordinates; default to the `auth` stack's defaults (`localhost` / `3890` / `dc=dopp,dc=cloud`). |
 
 ## Logging in as your own LDAP user
 
 When the `auth` stack is installed, the container authenticates SSH logins
-against the box's **LLDAP** via `nss-pam-ldapd`, so you sign in as your real
-LDAP user (e.g. `mdopp`) with your LLDAP password — no shared `dev` account:
+against the box's **LLDAP**, so you sign in as your real LDAP user (e.g.
+`mdopp`) with your LLDAP password — no shared `dev` account:
 
 ```sh
 ssh -p 2222 mdopp@<server-ip>      # password = your LLDAP password
 ```
 
-- Only members of the `CLAUDE_DEV_LDAP_GROUP` (default `lldap_admin`) may log
-  in — enforced by sshd `AllowGroups` + an nslcd `pam_authz_search` filter.
-- Each LDAP user gets a persistent home at `/workspace/home/<user>` (created
-  on first login), so their `~/.claude` history and `gh` auth survive
-  restarts independently.
-- LLDAP doesn't store `homeDirectory`/`loginShell`; nslcd synthesizes them.
+How it works — LLDAP 0.6.x is an *auth* directory, not a POSIX/NSS source (it
+serves no `uidNumber`/`gidNumber`, and groups carry DN `member`s rather than
+`memberUid`). So the container uses LDAP for **authentication only**:
+
+- `pam_ldap` (via `nslcd`) verifies the password by **binding to LLDAP as the
+  user's DN** — no POSIX attributes required.
+- On start, the entrypoint reads the members of `CLAUDE_DEV_LDAP_GROUP`
+  (default `admins`) and **provisions a matching local account** for each, so
+  the OS can resolve them. The password is never stored locally — every login
+  is checked against LLDAP. New group members appear after a container
+  restart.
+- Login is gated twice: an nslcd `pam_authz_search` `memberof` filter **and**
+  sshd `AllowGroups` (the local `ldapusers` group).
+- Each user gets a persistent home at `/workspace/home/<user>`, so their
+  `~/.claude` history and `gh` auth survive restarts independently.
 - The local **`dev`** account stays as a break-glass path (its password/key
   still work), so a directory outage or LDAP misconfig can't lock you out.
 - LDAP is **opt-in**: with `LLDAP_ADMIN_PASSWORD` blank (auth not installed)

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -42,41 +42,41 @@ if [ "$password_auth" = no ] && [ -z "${CLAUDE_DEV_SSH_AUTHORIZED_KEY:-}" ] && [
   echo "claude-dev: WARNING — no SSH password, authorized key, or LDAP set; nobody can log in." >&2
 fi
 
-# LDAP login (nss-pam-ldapd). When the LLDAP bind password is present, wire
-# nslcd against the box's LLDAP so the operator signs in as their real LDAP
-# user (e.g. `mdopp`) with their LLDAP credentials, instead of the shared
-# `dev` account. The `dev` user is kept as a break-glass path so a misconfig
-# here can never lock everyone out. Opt-in: with the var blank, this whole
-# block is skipped and the box behaves exactly as before.
+# LDAP login. When the LLDAP bind password is present, let the operator sign
+# in as their real LLDAP user (e.g. `mdopp`) with their LLDAP password instead
+# of the shared `dev` account. LLDAP 0.6.x is an auth directory with no POSIX
+# attributes, so we use it for AUTHENTICATION only: pam_ldap verifies the
+# password by binding to LLDAP as the user's DN (via nslcd), and we provision
+# a matching LOCAL account per group member so NSS (files) can resolve them.
+# `dev` stays as a break-glass path so a misconfig here can't lock everyone
+# out. Opt-in: with the var blank the whole block is skipped.
 ldap_enabled=no
 if [ -n "${LLDAP_ADMIN_PASSWORD:-}" ]; then
   LLDAP_HOST="${LLDAP_HOST:-localhost}"
   LLDAP_LDAP_PORT="${LLDAP_LDAP_PORT:-3890}"
   LLDAP_BASE_DN="${LLDAP_BASE_DN:-dc=dopp,dc=cloud}"
-  CLAUDE_DEV_LDAP_GROUP="${CLAUDE_DEV_LDAP_GROUP:-lldap_admin}"
+  CLAUDE_DEV_LDAP_GROUP="${CLAUDE_DEV_LDAP_GROUP:-admins}"
+  ldap_uri="ldap://${LLDAP_HOST}:${LLDAP_LDAP_PORT}"
+  admin_dn="uid=admin,ou=people,${LLDAP_BASE_DN}"
+  group_dn="cn=${CLAUDE_DEV_LDAP_GROUP},ou=groups,${LLDAP_BASE_DN}"
 
-  # Per-user homes live under the persistent /workspace volume so each LDAP
-  # user's git checkouts, ~/.claude history and gh auth survive a restart.
-  install -d -o root -g root -m 0755 "$DEV_HOME/home"
-
-  # LLDAP serves uid/uidNumber/gidNumber/memberOf but NOT homeDirectory or
-  # loginShell — synthesize them via nslcd maps. pam_authz_search gates login
-  # on membership of the configured LLDAP group. The file holds the bind
-  # password, so keep it root-readable only.
+  # nslcd config — AUTH-ONLY. `$username` is expanded by nslcd at runtime, so
+  # it must stay literal (escaped from this heredoc). pam_authz_search gates
+  # login on group membership; LLDAP supports the memberof search filter.
+  # pam_authc_search is disabled — LLDAP restricts a user reading other
+  # entries, so the default post-bind self-search can wrongly deny auth.
   umask 077
   cat > /etc/nslcd.conf <<EOF
 uid nslcd
 gid nslcd
-uri ldap://${LLDAP_HOST}:${LLDAP_LDAP_PORT}
+uri ${ldap_uri}
 base ${LLDAP_BASE_DN}
-base passwd ou=people,${LLDAP_BASE_DN}
-base group ou=groups,${LLDAP_BASE_DN}
-binddn uid=admin,ou=people,${LLDAP_BASE_DN}
+binddn ${admin_dn}
 bindpw ${LLDAP_ADMIN_PASSWORD}
-scope sub
-map passwd homeDirectory "${DEV_HOME}/home/\$uid"
-map passwd loginShell    "/bin/bash"
-pam_authz_search (&(uid=\$username)(memberof=cn=${CLAUDE_DEV_LDAP_GROUP},ou=groups,${LLDAP_BASE_DN}))
+base passwd ou=people,${LLDAP_BASE_DN}
+filter passwd (objectClass=person)
+pam_authc_search NONE
+pam_authz_search (&(uid=\$username)(memberof=${group_dn}))
 EOF
   chown root:nslcd /etc/nslcd.conf
   chmod 640 /etc/nslcd.conf
@@ -86,7 +86,27 @@ EOF
   install -d -o nslcd -g nslcd -m 755 /run/nslcd
   if /usr/sbin/nslcd; then
     ldap_enabled=yes
-    echo "claude-dev: LDAP login enabled — sign in as an LLDAP user in group '${CLAUDE_DEV_LDAP_GROUP}' (bind ldap://${LLDAP_HOST}:${LLDAP_LDAP_PORT})."
+    # Provision a local account for each member of the allowed group so NSS
+    # (files) resolves them; their password is never stored locally — PAM
+    # checks it against LLDAP on each login. Idempotent: re-runs every start
+    # to pick up new members, skips users that already exist. Homes live on
+    # the persistent /workspace volume.
+    install -d -o root -g root -m 0755 "$DEV_HOME/home"
+    groupadd -f ldapusers
+    members="$(ldapsearch -x -LLL -o ldif-wrap=no \
+                 -H "$ldap_uri" -D "$admin_dn" -w "$LLDAP_ADMIN_PASSWORD" \
+                 -b "$group_dn" '(objectClass=*)' member 2>/dev/null \
+               | sed -n 's/^member: uid=\([^,]*\),.*/\1/p' | sort -u)"
+    provisioned=0
+    for u in $members; do
+      case "$u" in admin|root|dev|''|*[!a-z0-9_-]*) continue;; esac
+      if ! id "$u" >/dev/null 2>&1; then
+        useradd --no-create-home --home-dir "$DEV_HOME/home/$u" \
+                --shell /bin/bash -G ldapusers "$u" \
+          && provisioned=$((provisioned + 1))
+      fi
+    done
+    echo "claude-dev: LDAP login enabled — members of group '${CLAUDE_DEV_LDAP_GROUP}' sign in with their LLDAP password (bind ${ldap_uri}; ${provisioned} new local account(s) provisioned)."
   else
     echo "claude-dev: WARNING — nslcd failed to start; LDAP login disabled, local 'dev' account still works." >&2
   fi
@@ -123,14 +143,14 @@ sshd_opts=(
 if [ "$ldap_enabled" = yes ]; then
   # PAM drives LLDAP password verification (pam_ldap). Password auth must be
   # on for LDAP users to authenticate even when the `dev` password is unset.
-  # AllowGroups restricts logins to the local `dev` break-glass group plus the
-  # configured LLDAP group — without it, every resolvable LDAP user could log
-  # in regardless of group, since pam_authz_search alone wouldn't bound NSS.
+  # AllowGroups restricts logins to the local `dev` break-glass account and the
+  # `ldapusers` group every provisioned LDAP account is a member of — a second
+  # belt on top of pam_authz_search's group gate.
   sshd_opts+=(
     -o "UsePAM=yes"
     -o "PasswordAuthentication=yes"
     -o "KbdInteractiveAuthentication=yes"
-    -o "AllowGroups=dev ${CLAUDE_DEV_LDAP_GROUP}"
+    -o "AllowGroups=dev ldapusers"
   )
   echo "claude-dev: starting sshd on port ${SSH_PORT} (LDAP + local 'dev')."
 else

--- a/templates/claude-dev/post-deploy.py
+++ b/templates/claude-dev/post-deploy.py
@@ -36,7 +36,7 @@ def main() -> int:
     ssh_password = env("CLAUDE_DEV_SSH_PASSWORD")
     has_key = bool(env("CLAUDE_DEV_SSH_AUTHORIZED_KEY"))
     ldap_enabled = bool(env("LLDAP_ADMIN_PASSWORD"))
-    ldap_group = env("CLAUDE_DEV_LDAP_GROUP", "lldap_admin")
+    ldap_group = env("CLAUDE_DEV_LDAP_GROUP", "admins")
 
     log(f"✅ Claude Dev container is up — SSH in on port {ssh_port}.")
     if ldap_enabled:

--- a/templates/claude-dev/user-guide.md
+++ b/templates/claude-dev/user-guide.md
@@ -87,8 +87,10 @@ against the directory, so there's no shared account to hand around:
 ssh -p <port> <your-ldap-user>@<host>
 ```
 
-Only members of the configured LLDAP group (default `lldap_admin`) may log in.
-Each LDAP user gets their own persistent home at `/workspace/home/<user>`.
+Only members of the configured LLDAP group (default `admins`) may log in —
+the container provisions a local login account for each member, but every
+login's password is checked against LLDAP. Each user gets their own
+persistent home at `/workspace/home/<user>`.
 
 A local **`dev`** account stays available as a break-glass fallback (its
 password is on the post-install credentials banner, or use your SSH key), so a

--- a/templates/claude-dev/variables.json
+++ b/templates/claude-dev/variables.json
@@ -34,7 +34,7 @@
   },
   "CLAUDE_DEV_LDAP_GROUP": {
     "type": "text",
-    "description": "Only LLDAP users in this group may SSH in. Defaults to the built-in LLDAP admin group so the box operator can log in immediately. Create a dedicated LLDAP group and point this at it to grant dev-box access without making someone a full LLDAP admin.",
-    "default": "lldap_admin"
+    "description": "Only LLDAP users in this group may SSH in. Defaults to `admins`, the group your operator account belongs to. The entrypoint provisions a local login account for each member of this group; point it at a dedicated group to grant dev-box access without making someone a full admin.",
+    "default": "admins"
   }
 }


### PR DESCRIPTION
## Why

The 4.115.0 LDAP feature used full NSS-LDAP (`nss-pam-ldapd` resolving users
+ groups from the directory). Deployed to the box, **no LDAP user could log
in** — verified live. Root cause: LLDAP 0.6.x is an *auth* directory, not a
POSIX/NSS source. It serves no `uidNumber`/`gidNumber`/`homeDirectory`, and
groups carry DN `member`s, not `memberUid`/`gidNumber`. `getent passwd mdopp`
returned nothing.

## Fix — LDAP for authentication only

- `nsswitch` stays **files-only**. `pam_ldap` (via nslcd) verifies the
  password by **binding as the user's DN** — no POSIX attrs required.
- Entrypoint **provisions a local account per member** of
  `CLAUDE_DEV_LDAP_GROUP` so the OS resolves them; password never stored
  locally, re-synced each start.
- Gated by nslcd `pam_authz_search` `memberof` filter + sshd `AllowGroups`
  (local `ldapusers`). `pam_authc_search` disabled (LLDAP restricts
  cross-entry reads).
- Default group → **`admins`** (operator's group); `lldap_admin` only holds
  the service account.

## Verified against the live LLDAP

Admin bind ✓, user DN lookup ✓, and the `memberof` authz filter returns
`mdopp` for `admins` and correctly excludes `cdopp` ✓. The final pam_ldap
user-bind is exercised by the operator's real login after redeploy. `dev`
break-glass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)