### PR TITLE
feat(claude-dev): add start-claude — one Claude per directory with Remote Control

### DIFF
--- a/.github/workflows/claude-dev-image.yml
+++ b/.github/workflows/claude-dev-image.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'templates/claude-dev/Dockerfile'
       - 'templates/claude-dev/docker-entrypoint.sh'
+      - 'templates/claude-dev/start-claude.sh'
       - '.github/workflows/claude-dev-image.yml'
   workflow_dispatch:
 

--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -83,6 +83,11 @@ RUN set -eux; \
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+# `start-claude` — manual launcher for one Claude per directory, each with
+# Remote Control on and its own tmux window (survives SSH disconnects).
+COPY start-claude.sh /usr/local/bin/start-claude
+RUN chmod +x /usr/local/bin/start-claude
+
 # Interactive login shells (an SSH session, the web terminal, the mobile
 # app) attach to the long-lived `claude` tmux session the entrypoint
 # starts on boot, so every connection lands in the SAME live session and

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -88,6 +88,25 @@ claude
 The clone only has to be done once — `/workspace` persists, so later
 sessions just `cd /workspace/servicebay && claude`.
 
+## Running several Claudes at once (`start-claude`)
+
+`start-claude` launches one Claude per directory — each with **Remote Control
+enabled** and **named after the directory** (so it's labelled in the mobile
+app / web), in its own window of the shared `claude` tmux session. Because they
+run in tmux, they keep going when you disconnect.
+
+```sh
+# from /workspace (where your clones live)
+start-claude --allow-dangerously-skip-permissions servicebay solbay
+```
+
+- Leading `--flags` are passed through to `claude`; the bare names are
+  directories (relative to the current dir, or absolute).
+- Re-running skips a directory that already has a live window — safe to call
+  again to add more.
+- Switch between them with `Ctrl-b w` (window list) or `Ctrl-b <n>`.
+- It's launched **manually** by design — logging in does not auto-start Claude.
+
 ## Persistent session (tmux)
 
 The container boots a detached `tmux` session named **`claude`** as the

--- a/templates/claude-dev/start-claude.sh
+++ b/templates/claude-dev/start-claude.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# start-claude — launch one Claude Code session per directory.
+#
+# Each directory gets its own Claude with Remote Control enabled and named
+# after the directory (so it shows up labelled in the Claude mobile app / web),
+# running in its own window of a shared tmux session. Because they live in
+# tmux, the sessions keep running when you disconnect — reconnect with
+# `tmux attach -t claude` or just log back in.
+#
+# This is launched MANUALLY (it is deliberately not run on login), so logging
+# in doesn't auto-start Claude for everyone.
+#
+# Usage:
+#   start-claude [CLAUDE_FLAGS...] DIR [DIR...]
+#
+# Example:
+#   start-claude --allow-dangerously-skip-permissions servicebay solbay
+#
+# Leading dash-arguments are passed straight through to `claude`; the remaining
+# bare names are directories (relative to the current dir, or absolute). Use a
+# `--` separator if a directory name would otherwise look like a flag. Flags
+# that take a separate value should use the `--flag=value` form. Re-running
+# skips any directory that already has a live window.
+set -eo pipefail
+
+SESSION="${CLAUDE_TMUX_SESSION:-claude}"
+
+flags=()
+dirs=()
+seen_dir=0
+for arg in "$@"; do
+  if [ "$arg" = "--" ]; then seen_dir=1; continue; fi
+  if [ "$seen_dir" -eq 0 ] && [ "${arg#-}" != "$arg" ]; then
+    flags+=("$arg")
+  else
+    seen_dir=1
+    dirs+=("$arg")
+  fi
+done
+
+if [ "${#dirs[@]}" -eq 0 ]; then
+  echo "usage: start-claude [claude-flags...] DIR [DIR...]" >&2
+  echo "  e.g. start-claude --allow-dangerously-skip-permissions servicebay solbay" >&2
+  exit 2
+fi
+
+command -v tmux   >/dev/null || { echo "start-claude: tmux not found"       >&2; exit 1; }
+command -v claude >/dev/null || { echo "start-claude: claude CLI not found" >&2; exit 1; }
+
+# Pre-render the pass-through flags once, safely quoted for the shell command
+# tmux runs.
+flagstr=""
+for f in "${flags[@]}"; do
+  flagstr+="$(printf '%q ' "$f")"
+done
+
+started=()
+for d in "${dirs[@]}"; do
+  if [ -d "$d" ]; then
+    path="$(cd "$d" && pwd)"
+  else
+    echo "start-claude: skipping '$d' — not a directory (looked under $PWD)" >&2
+    continue
+  fi
+  name="$(basename "$path")"
+
+  # Claude with Remote Control on, named after the directory.
+  cmd="claude ${flagstr}--remote-control $(printf '%q' "$name")"
+
+  if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+    tmux new-session -d -s "$SESSION" -n "$name" -c "$path" "$cmd"
+  elif tmux list-windows -t "$SESSION" -F '#W' 2>/dev/null | grep -qx "$name"; then
+    echo "start-claude: '$name' already running in tmux session '$SESSION' — skipping." >&2
+    continue
+  else
+    tmux new-window -t "$SESSION" -n "$name" -c "$path" "$cmd"
+  fi
+  started+=("$name")
+done
+
+if [ "${#started[@]}" -eq 0 ]; then
+  echo "start-claude: nothing started." >&2
+  exit 1
+fi
+
+echo "start-claude: started ${#started[@]} session(s): ${started[*]}"
+echo "start-claude: windows in tmux '$SESSION': $(tmux list-windows -t "$SESSION" -F '#W' 2>/dev/null | paste -sd' ' -)"
+
+# Land the user in the sessions: attach from outside tmux, or switch to the
+# first new window when already inside it.
+if [ -n "${TMUX:-}" ]; then
+  tmux select-window -t "$SESSION:${started[0]}" 2>/dev/null || true
+else
+  exec tmux attach -t "$SESSION"
+fi


### PR DESCRIPTION
Adds `start-claude`, a manual launcher on the claude-dev box for running
several Claude Code sessions at once — one per directory, each with **Remote
Control enabled** and named after the directory, in its own window of the
shared `claude` tmux session (so they survive SSH disconnects).

```sh
start-claude --allow-dangerously-skip-permissions servicebay solbay
```

- Leading `--flags` pass through to `claude`; bare names are directories.
- Idempotent — re-running skips a directory that already has a live window.
- Deliberately **manual** (not run on login).
- Shipped in the image at `/usr/local/bin/start-claude`; the image workflow
  now also rebuilds when the script changes.

Parsing + window/dedup logic + command construction verified with stubbed
`tmux`/`claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)