### PR TITLE
fix(claude-dev): share /workspace across dev + LDAP users (writable checkouts)

### DIFF
--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -46,7 +46,13 @@ RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
 # and gh auth all survive container restarts. --create-home seeds the
 # skeleton; the runtime bind mount then takes over and the entrypoint
 # re-scaffolds it.
-RUN useradd --create-home --home-dir /workspace --shell /bin/bash dev
+# `devshare` is the shared-workspace group: `dev` plus every provisioned LDAP
+# user belong to it so they can collaborate on the same /workspace checkouts.
+# umask 002 (login shells) makes new files group-writable; paired with the
+# setgid bit the entrypoint puts on /workspace, new clones stay shared.
+RUN groupadd devshare \
+ && useradd --create-home --home-dir /workspace --shell /bin/bash -G devshare dev \
+ && printf '%s\n' 'umask 002' > /etc/profile.d/claude-dev-umask.sh
 
 # LDAP auth wiring (nss-pam-ldapd), baked deterministically at build time.
 #

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -23,6 +23,13 @@ Built from [`Dockerfile`](./Dockerfile) (published as
 checkouts, Claude Code session history (`~/.claude`), `gh` auth and the
 SSH host keys all survive a container restart.
 
+It's also a **shared working area**: `dev` and every provisioned LDAP user
+(see below) belong to the `devshare` group, and `/workspace` is `dev:devshare`
+mode `2775` (setgid) with login shells defaulting to `umask 002`. So checkouts
+cloned by one user are writable by the others — you log in as `mdopp` and work
+on the same `/workspace/servicebay` clone regardless of who cloned it. Per-user
+homes under `/workspace/home/<user>` stay private (mode `700`).
+
 ## Variables
 
 | Variable | Purpose |

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -11,12 +11,19 @@ SSH_PORT="${CLAUDE_DEV_SSH_PORT:-2222}"
 DEV_HOME=/workspace
 HOSTKEY_DIR="$DEV_HOME/.ssh/host_keys"
 
-# /workspace is a fresh, root-owned bind mount on first install. Make it
-# the dev user's home and lay down the .ssh scaffolding. The chown is
-# non-recursive on purpose — the operator's own checkouts inside are
-# created as `dev` already, and a recursive chown over a large repo
-# tree on every restart would be wasteful.
-chown dev:dev "$DEV_HOME"
+# /workspace is a fresh, root-owned bind mount on first install. It's a
+# SHARED working area: the `dev` break-glass user plus every provisioned LDAP
+# user (e.g. mdopp) collaborate on the same checkouts here. Own it
+# `dev:devshare` with the setgid bit (2775) so new clones inherit the shared
+# group and group members can write each other's files (paired with umask 002,
+# set via /etc/profile.d). Per-user homes under /workspace/home stay private
+# (mode 700). Non-recursive on purpose — existing checkouts persist on the
+# volume; a recursive chown over a large repo tree on every restart would be
+# wasteful, and setgid + umask cover anything created from now on.
+groupadd -f devshare
+usermod -aG devshare dev 2>/dev/null || true
+chown dev:devshare "$DEV_HOME"
+chmod 2775 "$DEV_HOME"
 install -d -o dev -g dev -m 700 "$DEV_HOME/.ssh"
 install -d -o dev -g dev -m 700 "$HOSTKEY_DIR"
 
@@ -101,9 +108,13 @@ EOF
     for u in $members; do
       case "$u" in admin|root|dev|''|*[!a-z0-9_-]*) continue;; esac
       if ! id "$u" >/dev/null 2>&1; then
+        # `ldapusers` gates SSH; `devshare` lets them write the shared
+        # /workspace checkouts alongside `dev` and each other.
         useradd --no-create-home --home-dir "$DEV_HOME/home/$u" \
-                --shell /bin/bash -G ldapusers "$u" \
+                --shell /bin/bash -G ldapusers,devshare "$u" \
           && provisioned=$((provisioned + 1))
+      else
+        usermod -aG devshare "$u" 2>/dev/null || true
       fi
     done
     echo "claude-dev: LDAP login enabled — members of group '${CLAUDE_DEV_LDAP_GROUP}' sign in with their LLDAP password (bind ${ldap_uri}; ${provisioned} new local account(s) provisioned)."


### PR DESCRIPTION
After the LDAP-login change, logging in as `mdopp` (uid ≠ dev) hit permission
errors: the entrypoint chowned `/workspace` to `dev:dev` 755, so repos cloned
by `dev` were read-only to `mdopp`, and mdopp couldn't create files there —
claude/git writes failed.

Make `/workspace` a shared working area:
- New `devshare` group; `dev` + every provisioned LDAP user are members.
- Entrypoint owns `/workspace` `dev:devshare` mode `2775` (setgid) instead of
  `dev:dev`; login shells default to `umask 002`. Per-user homes under
  `/workspace/home` stay private (`700`).
- Existing checkouts persist on the volume; setgid + umask cover new content,
  so no costly recursive chown per start.

Already applied live on the box (mdopp can write now); this bakes it in so it
survives restarts/reinstalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)