### PR TITLE
fix(registry): reset registry refresh to FETCH_HEAD so install reaches remote HEAD

### DIFF
--- a/packages/backend/src/lib/registry.test.ts
+++ b/packages/backend/src/lib/registry.test.ts
@@ -43,6 +43,8 @@ vi.mock('./config', async (importOriginal) => ({
   }),
 }));
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { syncRegistries } from './registry';
 
 describe('syncRegistries #1796 self-heal', () => {
@@ -57,5 +59,21 @@ describe('syncRegistries #1796 self-heal', () => {
     const renameArgs = fsMock.rename.mock.calls[0] as [string, string];
     expect(renameArgs[0]).not.toMatch(/\.broken-/); // the live tree…
     expect(renameArgs[1]).toMatch(/\.broken-\d+$/); // …moved aside, so the re-clone has a clean path
+  });
+});
+
+describe('syncRegistries #1836 refresh reaches remote HEAD', () => {
+  // A shallow `git fetch --depth 1 origin <branch>` (bare branch name) only
+  // advances FETCH_HEAD — it does NOT update the remote-tracking ref
+  // `origin/<branch>`, which stays pinned at the clone-time SHA. Resetting to
+  // `origin/<branch>` therefore stranded the checkout at the stale revision
+  // (box at d556247 while remote HEAD was 1fa1717). The update path must reset
+  // to FETCH_HEAD so a single refresh always reaches the freshly-fetched HEAD.
+  // (The fetch+reset commands run in a real subprocess that the unit-test mock
+  // can't observe, so this asserts the resolved command on the source.)
+  it('hard-resets to FETCH_HEAD, not to the stale origin/<branch> ref', () => {
+    const src = readFileSync(join(__dirname, 'registry.ts'), 'utf8');
+    expect(src).toContain('git reset --hard FETCH_HEAD');
+    expect(src).not.toMatch(/git reset --hard origin\/\$\{branch\}/);
   });
 });

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -388,8 +388,17 @@ export async function syncRegistries() {
                 logger.info('registry', `Updating registry ${reg.name}...`);
                 const branch = reg.branch || 'main';
                 try {
+                    // #1836: `git fetch --depth 1 origin <branch>` with a bare
+                    // branch name only moves FETCH_HEAD — it does NOT update the
+                    // remote-tracking ref `refs/remotes/origin/<branch>` on a
+                    // shallow/sparse clone, which was pinned at clone time. So
+                    // `git reset --hard origin/<branch>` reset to the *stale*
+                    // clone-time SHA, leaving the checkout behind remote HEAD
+                    // (box stranded at d556247 while HEAD was 1fa1717). Reset to
+                    // FETCH_HEAD — exactly what we just fetched — so a single
+                    // refresh always reaches remote HEAD.
                     await execAsync(`git fetch --depth 1 origin ${branch}`, { cwd: regPath, env: GIT_ENV });
-                    await execAsync(`git reset --hard origin/${branch}`, { cwd: regPath, env: GIT_ENV });
+                    await execAsync('git reset --hard FETCH_HEAD', { cwd: regPath, env: GIT_ENV });
                 } catch (updateErr) {
                     // #1796: a `git reset --hard` that can't unlink the working
                     // tree — e.g. root-owned files written into the bind mount by


### PR DESCRIPTION
## What
On a shallow/sparse registry clone, `syncRegistries()` reset to the stale clone-time `origin/<branch>` SHA instead of what was just fetched. Reset to `FETCH_HEAD` so a single `sb stacks install` always deploys the latest committed SHA.

## Why
Closes #1836

## Risk
low — single-line change to the registry fetch/reset path, covered by a new unit test; no schema/install/config surface touched.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2492 passed)
- [ ] /verify on FCoS :dev box — not path-mandated (registry.ts is outside the path-mandated list), no box verify owed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._