### PR TITLE
fix(home-assistant): write .solaris HA token path + migrate from .solilos

### DIFF
--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -428,11 +428,16 @@ def ensure_auth_oidc_config_block() -> bool:
 # generates. Idempotent: if onboarding is already done OR the token file is
 # already present, the steps are skipped.
 
-HA_LONG_LIVED_TOKEN_PATH = "/.solilos-long-lived-token"  # joined with HA config dir
-# Pre-rename name (OSCAR→Solilos). Already-onboarded boxes have a valid token at
-# this path; we migrate it on disk so the deploy doesn't have to re-mint (and so
-# downstream post-deploys that look for the new name keep working without creds).
-HA_LEGACY_LONG_LIVED_TOKEN_PATH = "/.oscar-long-lived-token"
+HA_LONG_LIVED_TOKEN_PATH = "/.solaris-long-lived-token"  # joined with HA config dir
+# Pre-rename names, newest-first. Already-onboarded boxes have a valid token at
+# one of these legacy paths; we migrate it on disk so the deploy doesn't have to
+# re-mint (and so downstream post-deploys that look for the new name keep working
+# without creds). Two-hop chain: .oscar (OSCAR→Solilos #1769) → .solilos
+# (Solilos→Solaris solbay#408) → .solaris.
+HA_LEGACY_LONG_LIVED_TOKEN_PATHS = [
+    "/.solilos-long-lived-token",
+    "/.oscar-long-lived-token",
+]
 HA_CONTAINER_NAME = "home-assistant-homeassistant"
 HA_CLIENT_ID = "http://127.0.0.1:8123/"
 
@@ -816,20 +821,22 @@ def configure_oscar_ha_onboarding() -> None:
         return
     token_file = os.path.join(_ha_config_dir(), HA_LONG_LIVED_TOKEN_PATH.lstrip("/"))
 
-    # One-time migration for the OSCAR→Solilos rename (#1769). A box onboarded
-    # before the rename has a *valid* token at the legacy path. If the new file
-    # is absent but the legacy one is present, move it across so the existing
-    # token is reused (no re-mint, works without admin creds) and downstream
-    # post-deploys that read the new name keep authenticating.
-    legacy_token_file = os.path.join(
-        _ha_config_dir(), HA_LEGACY_LONG_LIVED_TOKEN_PATH.lstrip("/")
-    )
-    if not os.path.exists(token_file) and os.path.exists(legacy_token_file):
-        try:
-            os.rename(legacy_token_file, token_file)
-            log(f"   Migrated legacy HA token {legacy_token_file} → {token_file} (OSCAR→Solilos rename).")
-        except OSError as e:
-            log(f"   ⚠️ Could not migrate legacy HA token to {token_file}: {e}")
+    # One-time migration for the rename chain (OSCAR→Solilos #1769,
+    # Solilos→Solaris solbay#408). A box onboarded before a rename has a *valid*
+    # token at one of the legacy paths. If the new file is absent but a legacy
+    # one is present, move it across so the existing token is reused (no re-mint,
+    # works without admin creds) and downstream post-deploys that read the new
+    # name keep authenticating. Newest-first so a two-hop box picks .solilos.
+    if not os.path.exists(token_file):
+        for legacy_path in HA_LEGACY_LONG_LIVED_TOKEN_PATHS:
+            legacy_token_file = os.path.join(_ha_config_dir(), legacy_path.lstrip("/"))
+            if os.path.exists(legacy_token_file):
+                try:
+                    os.rename(legacy_token_file, token_file)
+                    log(f"   Migrated legacy HA token {legacy_token_file} → {token_file} (rename chain).")
+                except OSError as e:
+                    log(f"   ⚠️ Could not migrate legacy HA token to {token_file}: {e}")
+                break
 
     # Reconcile an existing token first (#1505). A wipe-configs reinstall can
     # leave a token file behind in HA's kept config dir whose refresh-token

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1355,6 +1355,66 @@ class HomeAssistantScript(unittest.TestCase):
             with mock.patch.object(m, "ZWAVE_BY_ID_DIR", by_id):
                 self.assertIsNone(m._detect_single_usb_serial_device())
 
+    def test_fresh_install_persists_solaris_token(self):
+        """#1847 / solbay#408: on a fresh install (onboarding user step not
+        done) the script onboards the admin, mints a long-lived token, and
+        persists it at the new `.solaris-long-lived-token` path that downstream
+        adopt_ha_long_lived_token() reads — otherwise HASS_TOKEN comes up empty."""
+        import tempfile
+        import urllib.request
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            def fake_urlopen(req, *_a, **_kw):
+                url = req.full_url if hasattr(req, "full_url") else str(req)
+                if "github.com" in url:
+                    raise AssertionError(f"unexpected download: {url}")
+
+                class _R:
+                    def __init__(self, status, body):
+                        self.status = status
+                        self._b = json.dumps(body).encode("utf-8") if body is not None else b"<html></html>"
+                    def read(self):
+                        return self._b
+                    def __enter__(self):
+                        return self
+                    def __exit__(self, *a):
+                        return False
+
+                if "/api/onboarding/users" in url:
+                    return _R(200, {"auth_code": "fresh-auth-code"})
+                if "/api/onboarding" in url:
+                    return _R(200, [{"step": "user", "done": False}])
+                if "/auth/token" in url:
+                    return _R(200, {"access_token": "fresh-access-tok"})
+                return _R(200, None)
+
+            def fake_mint(access_token):
+                return "fresh-long-lived"
+
+            env = {
+                "HA_OIDC_AUTH_VERSION": "v0.6.0",
+                "DATA_DIR": tmp,
+                "OSCAR_HA_ADMIN_USERNAME": "oscar",
+                "OSCAR_HA_ADMIN_PASSWORD": "pw",
+            }
+            ha_cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            oidc = os.path.join(ha_cfg, "custom_components", "auth_oidc")
+            os.makedirs(oidc, exist_ok=True)
+            with open(os.path.join(oidc, ".sb_installed_version"), "w") as fh:
+                fh.write("v0.6.0\n")
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen", fake_urlopen), \
+                    mock.patch.object(m, "_mint_long_lived_token", fake_mint), \
+                    mock.patch.object(m, "_complete_remaining_onboarding_steps", lambda *_a, **_k: None), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            token_file = os.path.join(ha_cfg, ".solaris-long-lived-token")
+            self.assertTrue(os.path.isfile(token_file))
+            with open(token_file) as fh:
+                self.assertEqual(fh.read().strip(), "fresh-long-lived")
+
     def test_token_remint_via_login_when_user_already_onboarded(self):
         """#1505: after a wipe-configs reinstall HA's user already exists
         but ServiceBay lost the long-lived token. The script must log in as
@@ -1421,7 +1481,7 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("Re-provisioning HA long-lived token from kept data", out)
             self.assertEqual(minted.get("access"), "short-lived-tok")
-            token_file = os.path.join(tmp, "home-assistant", "homeassistant", ".solilos-long-lived-token")
+            token_file = os.path.join(tmp, "home-assistant", "homeassistant", ".solaris-long-lived-token")
             self.assertTrue(os.path.isfile(token_file))
             with open(token_file) as fh:
                 self.assertEqual(fh.read().strip(), "long-lived-tok")
@@ -1436,7 +1496,7 @@ class HomeAssistantScript(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = os.path.join(tmp, "home-assistant", "homeassistant")
             os.makedirs(cfg, exist_ok=True)
-            with open(os.path.join(cfg, ".solilos-long-lived-token"), "w") as fh:
+            with open(os.path.join(cfg, ".solaris-long-lived-token"), "w") as fh:
                 fh.write("good-token\n")
             # Stamp so the OIDC install path skips the tarball download.
             oidc = os.path.join(cfg, "custom_components", "auth_oidc")
@@ -1472,11 +1532,12 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("still authenticates — nothing to reconcile", out)
 
-    def test_legacy_oscar_token_migrated_to_solilos(self):
-        """#1769: a box onboarded before the OSCAR→Solilos rename has a valid
-        token only at the legacy `.oscar-long-lived-token` path. The deploy
-        renames it on disk to `.solilos-long-lived-token` and reuses it — no
-        re-mint, no login flow, even without working admin creds."""
+    def test_legacy_oscar_token_migrated_to_solaris(self):
+        """#1769 + solbay#408: a box onboarded before the OSCAR→Solilos→Solaris
+        renames has a valid token only at the oldest legacy
+        `.oscar-long-lived-token` path. The deploy renames it on disk to
+        `.solaris-long-lived-token` and reuses it — no re-mint, no login flow,
+        even without working admin creds (two-hop chain in one move)."""
         import tempfile
         import urllib.request
         m = load_script("home-assistant")
@@ -1485,7 +1546,62 @@ class HomeAssistantScript(unittest.TestCase):
             cfg = os.path.join(tmp, "home-assistant", "homeassistant")
             os.makedirs(cfg, exist_ok=True)
             legacy_file = os.path.join(cfg, ".oscar-long-lived-token")
-            new_file = os.path.join(cfg, ".solilos-long-lived-token")
+            new_file = os.path.join(cfg, ".solaris-long-lived-token")
+            with open(legacy_file, "w") as fh:
+                fh.write("good-token\n")
+            # Stamp so the OIDC install path skips the tarball download.
+            oidc = os.path.join(cfg, "custom_components", "auth_oidc")
+            os.makedirs(oidc, exist_ok=True)
+            with open(os.path.join(oidc, ".sb_installed_version"), "w") as fh:
+                fh.write("v0.6.0\n")
+
+            def fake_urlopen(req, *_a, **_kw):
+                url = req.full_url if hasattr(req, "full_url") else str(req)
+                if "/auth/login_flow" in url:
+                    raise AssertionError("must not start a login flow after migrating a valid legacy token")
+
+                class _R:
+                    status = 200
+                    def read(self):
+                        return b"<html></html>"
+                    def __enter__(self):
+                        return self
+                    def __exit__(self, *a):
+                        return False
+                return _R()
+
+            env = {
+                "HA_OIDC_AUTH_VERSION": "v0.6.0",
+                "DATA_DIR": tmp,
+                "OSCAR_HA_ADMIN_USERNAME": "oscar",
+                "OSCAR_HA_ADMIN_PASSWORD": "pw",
+            }
+            with run_with_env(env), \
+                    mock.patch.object(urllib.request, "urlopen", fake_urlopen), \
+                    mock.patch.object(m, "HA_READY_INTERVAL", 0.001):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertFalse(os.path.exists(legacy_file))
+            self.assertTrue(os.path.isfile(new_file))
+            with open(new_file) as fh:
+                self.assertEqual(fh.read().strip(), "good-token")
+            self.assertIn("Migrated legacy HA token", out)
+            self.assertIn("still authenticates — nothing to reconcile", out)
+
+    def test_legacy_solilos_token_migrated_to_solaris(self):
+        """solbay#408: a box onboarded after OSCAR→Solilos but before
+        Solilos→Solaris has a valid token at `.solilos-long-lived-token`. The
+        deploy renames it on disk to `.solaris-long-lived-token` and reuses it —
+        no re-mint, no login flow, even without working admin creds."""
+        import tempfile
+        import urllib.request
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            os.makedirs(cfg, exist_ok=True)
+            legacy_file = os.path.join(cfg, ".solilos-long-lived-token")
+            new_file = os.path.join(cfg, ".solaris-long-lived-token")
             with open(legacy_file, "w") as fh:
                 fh.write("good-token\n")
             # Stamp so the OIDC install path skips the tarball download.


### PR DESCRIPTION
## What
Rename the Home Assistant long-lived token path from `.solilos-long-lived-token` to `.solaris-long-lived-token` (Solilos→Solaris rebrand, solbay#408), and generalize the on-disk legacy migration into a newest-first chain (`.solilos` → `.solaris`, `.oscar` → `.solaris`) so both one-hop and two-hop boxes reuse their existing valid token without a re-mint.

## Why
Downstream `adopt_ha_long_lived_token()` already reads `.solaris-long-lived-token`, but `post-deploy.py` still wrote `.solilos-long-lived-token` — the path mismatch left `HASS_TOKEN` empty on a fresh Solaris install.

Closes #1847

## Risk
Low — a single template post-deploy script; the migration chain is additive and idempotent (existing `.oscar`/`.solilos` tokens are migrated, not discarded).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 2505 passed)
- [x] python template suite (60 tests OK, incl. solaris token-path cases)
- [ ] /verify on FCoS :dev box (path-mandated: templates/home-assistant/post-deploy.py)

<!-- sb-ai-comment -->
AI-generated