### PR TITLE
feat(voice): optional openWakeWord custom-models slot

### DIFF
--- a/templates/voice/CHANGELOG.md
+++ b/templates/voice/CHANGELOG.md
@@ -43,3 +43,16 @@
   unchanged: piper stays their sole TTS on :10200. No schema change — the
   piper container remains in `template.yml` for the CPU path; this is a
   runtime teardown, not a pod-structure change.
+
+## v2.3 (#1832)
+
+- New optional `OPENWAKEWORD_CUSTOM_MODELS_DIR` variable (empty by
+  default). When set, `template.yml` mounts that host directory into the
+  openWakeWord container at `/custom_models` and passes
+  `--custom-model-dir /custom_models`, so wyoming-openwakeword scans it for
+  custom `.tflite` wake-word models that then appear as selectable wake
+  words in Home Assistant. `post-deploy.py` creates the directory on deploy
+  and logs where to drop model files. Platform slot only — no model file is
+  shipped. Empty/unset renders with neither the mount nor the arg, so
+  CPU/stock-model-only boxes are unaffected. No schema change — purely
+  additive, no data migration.

--- a/templates/voice/post-deploy.py
+++ b/templates/voice/post-deploy.py
@@ -360,6 +360,38 @@ def stop_pod_piper() -> None:
     log("   piper: stopped on GPU box — GPU TTS (voice-tts-bridge :10203) is active (#1833).")
 
 
+# ── custom wake-word models slot (#1832) ─────────────────────────────────────
+
+
+def setup_custom_models_dir() -> None:
+    """Prepare the optional openWakeWord custom-models directory (#1832).
+
+    Platform mechanism only — ships no model file. When the operator sets
+    OPENWAKEWORD_CUSTOM_MODELS_DIR, template.yml mounts that host path into
+    the openwakeword container at /custom_models and passes
+    `--custom-model-dir /custom_models` (the wyoming-openwakeword flag that
+    makes it scan a directory for custom .tflite wake-word models). Here we
+    just make sure the host path exists (so the bind mount + container start
+    don't fail on a missing dir) and tell the operator where to drop models.
+
+    Empty/unset → no-op: the box uses the built-in wake words only and the
+    container gets neither the mount nor the arg, so CPU-only boxes are
+    unaffected.
+    """
+    custom_dir = env("OPENWAKEWORD_CUSTOM_MODELS_DIR")
+    if not custom_dir:
+        return
+    try:
+        os.makedirs(custom_dir, exist_ok=True)
+    except OSError as e:
+        log(f"   ⚠️ openwakeword: could not create custom models dir {custom_dir}: {e}")
+        return
+    log(
+        f"   openwakeword: custom models dir mounted at {custom_dir} — drop "
+        ".tflite/.onnx files here for wake-word selection in HA."
+    )
+
+
 # ── legacy data migration (#348) ─────────────────────────────────────────────
 
 
@@ -403,6 +435,9 @@ def main() -> int:
         log("Migrating voice data from the legacy in-HA-pod paths (#348)...")
         migrate_dir(legacy_whisper, new_whisper, "Faster Whisper models")
         migrate_dir(legacy_piper, new_piper, "Piper voices")
+
+    # Optional custom wake-word models slot (#1832) — no-op when unset.
+    setup_custom_models_dir()
 
     # Whisper companion unit (#1809) — GPU when CDI is registered.
     install_whisper_unit(data_dir)

--- a/templates/voice/template.yml
+++ b/templates/voice/template.yml
@@ -63,9 +63,30 @@ spec:
     args:
     - --uri
     - tcp://0.0.0.0:10400
+    # Optional custom wake-word models (#1832). When the operator sets
+    # OPENWAKEWORD_CUSTOM_MODELS_DIR, the host path is mounted at
+    # /custom_models and wyoming-openwakeword scans it for .tflite models,
+    # which then show up as selectable wake words in Home Assistant. Empty
+    # by default → this section renders to nothing, so CPU/stock-model-only
+    # boxes are unaffected (same conditional pattern as HA's ZWAVE_DEVICE).
+    {{#OPENWAKEWORD_CUSTOM_MODELS_DIR}}
+    - --custom-model-dir
+    - /custom_models
+    {{/OPENWAKEWORD_CUSTOM_MODELS_DIR}}
+    {{#OPENWAKEWORD_CUSTOM_MODELS_DIR}}
+    volumeMounts:
+    - mountPath: /custom_models
+      name: openwakeword-custom-models
+    {{/OPENWAKEWORD_CUSTOM_MODELS_DIR}}
 
   volumes:
   - name: piper-data
     hostPath:
       path: {{DATA_DIR}}/voice/piper
       type: DirectoryOrCreate
+  {{#OPENWAKEWORD_CUSTOM_MODELS_DIR}}
+  - name: openwakeword-custom-models
+    hostPath:
+      path: {{OPENWAKEWORD_CUSTOM_MODELS_DIR}}
+      type: DirectoryOrCreate
+  {{/OPENWAKEWORD_CUSTOM_MODELS_DIR}}

--- a/templates/voice/variables.json
+++ b/templates/voice/variables.json
@@ -53,5 +53,10 @@
       "ru_RU-denis-medium"
     ],
     "default": "de_DE-thorsten-high"
+  },
+  "OPENWAKEWORD_CUSTOM_MODELS_DIR": {
+    "type": "string",
+    "description": "Optional host directory of custom wake-word models for openWakeWord. Leave empty to use the built-in wake words only (default — CPU/stock boxes are unaffected). When set, the directory is mounted into the openWakeWord container and scanned for .tflite models, which then appear as selectable wake words in Home Assistant. The directory is created on deploy if it doesn't exist; drop your model files there afterwards.",
+    "default": ""
   }
 }

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1968,5 +1968,58 @@ class ImmichScript(unittest.TestCase):
         self.assertIn("Immich OIDC configured", out)
 
 
+class VoiceScript(unittest.TestCase):
+    """openWakeWord custom-models slot (#1832). The whisper/tts/piper paths
+    shell out to systemctl/podman, so the tests target the pure-ish
+    setup_custom_models_dir() directly rather than main()."""
+
+    def _capture(self, fn) -> str:
+        buf = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = buf
+        try:
+            fn()
+        finally:
+            sys.stdout = old_stdout
+        return buf.getvalue()
+
+    def test_creates_dir_and_logs_slot_when_set(self):
+        import tempfile
+
+        m = load_script("voice")
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "custom-models")
+            env = {"OPENWAKEWORD_CUSTOM_MODELS_DIR": target}
+            with run_with_env(env):
+                out = self._capture(m.setup_custom_models_dir)
+            self.assertTrue(os.path.isdir(target))
+        self.assertIn("custom models dir mounted at", out)
+        self.assertIn(target, out)
+
+    def test_idempotent_when_dir_already_exists(self):
+        import tempfile
+
+        m = load_script("voice")
+        with tempfile.TemporaryDirectory() as tmp:
+            # tmp itself already exists — re-running must not error.
+            env = {"OPENWAKEWORD_CUSTOM_MODELS_DIR": tmp}
+            with run_with_env(env):
+                out = self._capture(m.setup_custom_models_dir)
+            self.assertTrue(os.path.isdir(tmp))
+        self.assertIn("custom models dir mounted at", out)
+
+    def test_noop_when_unset(self):
+        m = load_script("voice")
+        with run_with_env({}):
+            out = self._capture(m.setup_custom_models_dir)
+        self.assertEqual(out, "")
+
+    def test_noop_when_empty(self):
+        m = load_script("voice")
+        with run_with_env({"OPENWAKEWORD_CUSTOM_MODELS_DIR": ""}):
+            out = self._capture(m.setup_custom_models_dir)
+        self.assertEqual(out, "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
Adds an optional `OPENWAKEWORD_CUSTOM_MODELS_DIR` variable to the voice template. When set, the openWakeWord container mounts the host dir at `/custom_models:Z` and receives `--custom-model-dir /custom_models`, so `.tflite`/`.onnx` files dropped there appear as selectable wake-word entities in HA. post-deploy.py creates the dir if missing and logs the slot location. Empty/unset (the default) renders no mount and no arg — CPU/stock-model boxes are unaffected. No model file shipped; no Solaris hard-coding in platform code.

## Why
Closes #1832

## Risk
Low — additive, optional, empty-by-default; both rendered forms (set/unset) YAML-validated.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2505 passed)
- [ ] /verify on FCoS :dev box (templates/voice/ is path-mandated)