### PR TITLE
fix(security): harden XFF rate-limit key, SSH exec, NPM rekey, CIFS mount

### DIFF
--- a/packages/backend/src/lib/auth/rateLimit.ts
+++ b/packages/backend/src/lib/auth/rateLimit.ts
@@ -145,9 +145,17 @@ export function _resetForTests() {
 
 /**
  * Extract a stable client identifier from request headers.
- * Honors X-Forwarded-For (first hop) when present — ServiceBay sits behind
- * NPM in production. Falls back to a literal "unknown" so absence still
- * collapses to a single bucket rather than bypassing the limiter.
+ *
+ * ServiceBay sits behind NPM (nginx) in production. We must derive the bucket
+ * key from a value the *proxy* controls, not one the client can set — NPM
+ * overwrites `X-Real-IP` with nginx's authoritative `$remote_addr`, and the
+ * LAST `X-Forwarded-For` hop is the one nginx appended. We never take the
+ * left-most XFF entry: a client can prepend an arbitrary value there and, by
+ * rotating it per request, would otherwise rotate its rate-limit bucket and
+ * dodge the login brute-force limit. Mirrors the trusted-last-hop convention
+ * in mcp/bootstrapToken.ts's clientIpForLanGate. Falls back to a literal
+ * "unknown" so absence still collapses to a single bucket rather than
+ * bypassing the limiter.
  */
 export function clientKeyFromHeaders(headers: Headers | Record<string, string | string[] | undefined>): string {
   const get = (name: string): string | undefined => {
@@ -156,12 +164,15 @@ export function clientKeyFromHeaders(headers: Headers | Record<string, string | 
     if (Array.isArray(v)) return v[0];
     return v;
   };
+  const real = get('x-real-ip');
+  if (real) {
+    const trimmed = real.trim();
+    if (trimmed) return trimmed;
+  }
   const xff = get('x-forwarded-for');
   if (xff) {
-    const first = xff.split(',')[0]?.trim();
-    if (first) return first;
+    const hops = xff.split(',').map(s => s.trim()).filter(Boolean);
+    if (hops.length) return hops[hops.length - 1];
   }
-  const real = get('x-real-ip');
-  if (real) return real.trim();
   return 'unknown';
 }

--- a/packages/backend/src/lib/backup/cifsCredentials.test.ts
+++ b/packages/backend/src/lib/backup/cifsCredentials.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import nodeFs from 'node:fs';
+
+/**
+ * CIFS mount must never inline the password into the comma-joined `-o` options
+ * (a comma in the password would terminate the value and inject an arbitrary
+ * mount option, e.g. uid=0). It writes a 0600 `credentials=` file instead and
+ * passes only `credentials=<path>`. The file is removed after the mount call.
+ *
+ * We exercise the real `mountTarget` code path via `testBackupTarget`'s `smb`
+ * case and capture, at mount time, the credentials file's contents + mode.
+ */
+
+const execCalls: { cmd: string; args: string[] }[] = [];
+// Snapshot of the credentials file captured by the mocked `mount` call,
+// because the production code deletes it again right after mount returns.
+let credFileSnapshot: { path: string; content: string; mode: number } | null = null;
+
+vi.mock('node:child_process', () => {
+    // `nodeFs` (a top-level import of the real fs) is referenced lazily inside
+    // the callback, which only runs during a test — long after top-level
+    // imports have resolved — so the hoisted factory can safely close over it.
+    const execFile = (
+        cmd: string,
+        args: string[],
+        callback: (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
+    ) => {
+        execCalls.push({ cmd, args: Array.isArray(args) ? [...args] : [] });
+        // For a CIFS mount, read the credentials file referenced in `-o` so we
+        // can assert its perms/content before the caller cleans it up.
+        if (cmd === 'sudo' && args[0] === 'mount' && args.includes('cifs')) {
+            const oIdx = args.indexOf('-o');
+            const optsStr = oIdx >= 0 ? args[oIdx + 1] : '';
+            const credOpt = optsStr.split(',').find((o) => o.startsWith('credentials='));
+            if (credOpt) {
+                const credPath = credOpt.slice('credentials='.length);
+                const st = nodeFs.statSync(credPath);
+                credFileSnapshot = {
+                    path: credPath,
+                    content: nodeFs.readFileSync(credPath, 'utf-8'),
+                    mode: st.mode & 0o777,
+                };
+            }
+        }
+        callback(null, '', '');
+    };
+    return { execFile, default: { execFile } };
+});
+
+describe('mountTarget — CIFS credentials handling (comma-in-password injection)', () => {
+    beforeEach(() => {
+        execCalls.length = 0;
+        credFileSnapshot = null;
+        vi.resetModules();
+    });
+
+    it('mounts a comma-laden password via a 0600 credentials file, never inline in -o', async () => {
+        const { testBackupTarget } = await import('./service');
+        const password = 'p,a,s,s=uid=0,gid=0';
+        const res = await testBackupTarget({
+            type: 'smb',
+            host: 'nas.local',
+            share: 'backup',
+            username: 'alice',
+            password,
+            domain: 'WORKGROUP',
+        });
+
+        expect(res.success).toBe(true);
+
+        const mountCall = execCalls.find((c) => c.cmd === 'sudo' && c.args[0] === 'mount');
+        expect(mountCall).toBeDefined();
+        const oIdx = mountCall!.args.indexOf('-o');
+        const opts = mountCall!.args[oIdx + 1];
+
+        // The password (and the comma-injected option it carries) must NOT
+        // appear anywhere in the joined -o string.
+        expect(opts).not.toContain('password=');
+        expect(opts).not.toContain(password);
+        // Only a credentials= option references the secret material.
+        expect(opts.split(',').some((o) => o.startsWith('credentials='))).toBe(true);
+
+        // The credentials file existed at mount time, was 0600, and held the
+        // password verbatim (commas intact).
+        expect(credFileSnapshot).not.toBeNull();
+        expect(credFileSnapshot!.mode).toBe(0o600);
+        expect(credFileSnapshot!.content).toContain('username=alice');
+        expect(credFileSnapshot!.content).toContain(`password=${password}`);
+        expect(credFileSnapshot!.content).toContain('domain=WORKGROUP');
+    });
+
+    it('removes the credentials file after the mount completes', async () => {
+        const fs = await import('fs/promises');
+        const { testBackupTarget } = await import('./service');
+        await testBackupTarget({
+            type: 'smb',
+            host: 'nas.local',
+            share: 'backup',
+            username: 'bob',
+            password: 'plainpw',
+        });
+
+        expect(credFileSnapshot).not.toBeNull();
+        // The file (and its private temp dir) must be gone post-mount.
+        await expect(fs.stat(credFileSnapshot!.path)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('uses guest (no credentials file) when no username is given', async () => {
+        const { testBackupTarget } = await import('./service');
+        const res = await testBackupTarget({
+            type: 'smb',
+            host: 'nas.local',
+            share: 'public',
+        });
+
+        expect(res.success).toBe(true);
+        expect(credFileSnapshot).toBeNull();
+        const mountCall = execCalls.find((c) => c.cmd === 'sudo' && c.args[0] === 'mount');
+        const opts = mountCall!.args[mountCall!.args.indexOf('-o') + 1];
+        expect(opts.split(',')).toContain('guest');
+        expect(opts).not.toContain('credentials=');
+    });
+
+    it('mounts NFS with no credentials option (unaffected by the CIFS change)', async () => {
+        const { testBackupTarget } = await import('./service');
+        const res = await testBackupTarget({
+            type: 'nfs',
+            host: 'nas.local',
+            export: '/exports/backup',
+        });
+
+        expect(res.success).toBe(true);
+        expect(credFileSnapshot).toBeNull();
+        const mountCall = execCalls.find((c) => c.cmd === 'sudo' && c.args[0] === 'mount');
+        expect(mountCall!.args).toContain('nfs');
+        // NFS has no -o credentials path at all.
+        expect(mountCall!.args.join(' ')).not.toContain('credentials=');
+    });
+});

--- a/packages/backend/src/lib/backup/service.ts
+++ b/packages/backend/src/lib/backup/service.ts
@@ -131,16 +131,49 @@ function buildSSHArgv(target: { host: string; port?: number; user?: string; iden
     return argv;
 }
 
+// Write a mount.cifs `credentials=` file (username/password/domain lines) into
+// a private 0700 temp dir, with the file itself at 0600. Returns its absolute
+// path. Using a credentials file — rather than `password=<pw>` inline in the
+// comma-joined `-o` options — means a password containing commas, newlines or
+// `=` is passed verbatim and cannot inject extra mount options.
+async function writeCifsCredentialsFile(
+    username: string,
+    password?: string,
+    domain?: string,
+): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'servicebay-cifs-'));
+    const file = path.join(dir, 'credentials');
+    const lines = [`username=${username}`];
+    if (password) lines.push(`password=${password}`);
+    if (domain) lines.push(`domain=${domain}`);
+    // mode 0600 from creation; the enclosing mkdtemp dir is already 0700.
+    await fs.writeFile(file, `${lines.join('\n')}\n`, { mode: 0o600 });
+    return file;
+}
+
+async function removeCifsCredentialsFile(file: string): Promise<void> {
+    try {
+        await fs.rm(path.dirname(file), { recursive: true, force: true });
+    } catch (e) {
+        logger.warn('Backup', `Failed to remove CIFS credentials file: ${e}`);
+    }
+}
+
 async function mountTarget(target: BackupTarget, mountPath: string): Promise<void> {
     await fs.mkdir(mountPath, { recursive: true });
 
     if (target.type === 'smb') {
         const share = `//${target.host}/${target.share}`;
         const opts: string[] = [];
+        // Credentials never go inline in the comma-joined `-o` options: a comma
+        // (or newline) in a password would terminate the value and let an
+        // attacker inject arbitrary mount options (e.g. uid=0). Instead we hand
+        // mount.cifs a 0600 `credentials=` file — the standard mechanism — so
+        // the password is passed verbatim and can't break out of the option list.
+        let credentialsFile: string | undefined;
         if (target.username) {
-            opts.push(`username=${target.username}`);
-            if (target.password) opts.push(`password=${target.password}`);
-            if (target.domain) opts.push(`domain=${target.domain}`);
+            credentialsFile = await writeCifsCredentialsFile(target.username, target.password, target.domain);
+            opts.push(`credentials=${credentialsFile}`);
         } else {
             opts.push('guest');
         }
@@ -148,7 +181,14 @@ async function mountTarget(target: BackupTarget, mountPath: string): Promise<voi
         opts.push(`gid=${process.getgid?.() ?? 1000}`);
         opts.push('file_mode=0664', 'dir_mode=0775');
 
-        await execFileAsync('sudo', ['mount', '-t', 'cifs', share, mountPath, '-o', opts.join(',')]);
+        try {
+            await execFileAsync('sudo', ['mount', '-t', 'cifs', share, mountPath, '-o', opts.join(',')]);
+        } finally {
+            // The credentials file is only needed for the duration of the mount
+            // call; mount.cifs reads it synchronously, so remove it immediately
+            // (along with its private temp dir) regardless of success/failure.
+            if (credentialsFile) await removeCifsCredentialsFile(credentialsFile);
+        }
     } else if (target.type === 'nfs') {
         const nfsPath = `${target.host}:${target.export}`;
         await execFileAsync('sudo', ['mount', '-t', 'nfs', nfsPath, mountPath]);

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
@@ -22,14 +22,17 @@ vi.mock('@/lib/config', () => ({
   getConfig: vi.fn(async () => state.config),
   updateConfig: vi.fn(async () => {}),
 }));
-vi.mock('@/lib/agent/manager', () => ({ agentManager: { ensureAgent: vi.fn() } }));
+const sendCommand = vi.fn();
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: vi.fn(async () => ({ sendCommand })) },
+}));
 
 vi.stubGlobal('fetch', vi.fn(async () => {
   if (state.fetchThrows) throw new Error('refused');
   return { ok: state.fetchStatus < 400, status: state.fetchStatus, json: async () => state.fetchBody } as unknown as Response;
 }));
 
-import { npmAdminCredStatus } from './npmAdminRekey';
+import { npmAdminCredStatus, rekeyNpmAdmin } from './npmAdminRekey';
 
 const ACTIVE_NGINX = [{ name: 'nginx-web', active: true, ports: [{ host: '81', container: '81' }] }];
 
@@ -39,6 +42,7 @@ beforeEach(() => {
   state.fetchStatus = 200;
   state.fetchThrows = false;
   state.fetchBody = {};
+  sendCommand.mockReset();
 });
 
 describe('npmAdminCredStatus', () => {
@@ -77,5 +81,31 @@ describe('npmAdminCredStatus', () => {
   it("returns 'unknown' when NPM is unreachable (skip, don't re-key blindly)", async () => {
     state.fetchThrows = true;
     expect(await npmAdminCredStatus('Local')).toBe('unknown');
+  });
+});
+
+describe('rekeyNpmAdmin — container-name injection guard', () => {
+  it('rejects a metacharacter-laden container name instead of executing it', async () => {
+    // First exec is the `podman ps` lookup; return a malicious name.
+    sendCommand.mockResolvedValueOnce({ stdout: 'npm$(touch /pwn) jc21/proxy-manager', code: 0 });
+    const res = await rekeyNpmAdmin('Local');
+    expect(res.ok).toBe(false);
+    expect(res.message).toMatch(/not a valid podman name/i);
+    // Only the lookup ran — the rewrite exec must never fire.
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the rewrite with the container name and password shell-quoted for a normal name', async () => {
+    sendCommand
+      .mockResolvedValueOnce({ stdout: 'npm-app jc21/proxy-manager', code: 0 }) // lookup
+      .mockResolvedValueOnce({ stdout: 'email=a@b.c;updated=1', code: 0 }); // rewrite
+    state.fetchStatus = 200; // token check accepts the new password
+    const res = await rekeyNpmAdmin('Local');
+    expect(res.ok).toBe(true);
+    const rewriteCmd = sendCommand.mock.calls[1][1].command as string;
+    // Container name appears as a discrete, plainly-quoted token (safe chars
+    // need no quotes via shellQuote) and the env value is present.
+    expect(rewriteCmd).toContain('npm-app node -');
+    expect(rewriteCmd).toContain('-e NEWPW=');
   });
 });

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
@@ -23,8 +23,14 @@ import { getConfig, updateConfig } from '@/lib/config';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+import { shellQuote } from '@/lib/util/shellQuote';
 
 const LOG = 'reverseProxy:npmRekey';
+
+/** Container names podman accepts — letters, digits, and `_.-`. We reject
+ *  anything else so a name parsed from `podman ps` stdout can never carry
+ *  shell metacharacters into the rekey exec command. */
+const CONTAINER_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
 
 /** Resolve NPM's admin API base URL from the running nginx service, or
  *  null when NPM isn't deployed/active. */
@@ -136,10 +142,19 @@ export async function rekeyNpmAdmin(node: string): Promise<RekeyResult> {
   if (!container) {
     return { ok: false, message: 'Could not find the running NPM container to re-key.' };
   }
+  // Defence-in-depth: the container name comes from `podman ps` stdout and is
+  // interpolated into a shell command below. Reject anything that isn't a
+  // plain podman name so no metacharacter can break out of the command.
+  if (!CONTAINER_NAME_RE.test(container)) {
+    return { ok: false, message: 'Refusing to re-key: the detected NPM container name is not a valid podman name.' };
+  }
   const newPassword = generateRandomSecret(32);
   const b64 = Buffer.from(NPM_REKEY_JS).toString('base64');
+  // The pipe (base64 -d → podman exec) requires shell form, so every
+  // interpolated value is shell-quoted. NEWPW is also quoted so the generated
+  // password is never re-split by the shell.
   const rewrite = await agent.sendCommand('exec', {
-    command: `echo ${b64} | base64 -d | podman exec -i -e NEWPW=${newPassword} ${container} node -`,
+    command: `echo ${b64} | base64 -d | podman exec -i -e NEWPW=${shellQuote(newPassword)} ${shellQuote(container)} node -`,
   }, { timeoutMs: 30_000 });
   const out = ((rewrite as { stdout?: string }).stdout || '').trim();
   const m = out.match(/email=(.*);updated=(\d+)/);

--- a/packages/backend/src/lib/ssh.ts
+++ b/packages/backend/src/lib/ssh.ts
@@ -2,16 +2,26 @@ import * as pty from 'node-pty';
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'util';
 import { SSH_DIR } from './dirs';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export async function verifySSHConnection(host: string, port: number, user: string, identityFile: string): Promise<boolean> {
   try {
-    const cmd = `ssh -i "${identityFile}" -p ${port} -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5 ${user}@${host} exit`;
-    await execAsync(cmd);
+    // Use execFile with an args array (no shell) so host/user/identityFile/port
+    // cannot inject shell commands. Mirrors backup/service.ts:buildSSHArgv.
+    const args = [
+      '-i', identityFile,
+      '-p', String(port),
+      '-o', 'BatchMode=yes',
+      '-o', 'StrictHostKeyChecking=no',
+      '-o', 'ConnectTimeout=5',
+      `${user}@${host}`,
+      'exit',
+    ];
+    await execFileAsync('ssh', args);
     return true;
   } catch {
     return false;
@@ -51,8 +61,9 @@ export async function setupSSHKey(host: string, port: number, user: string, pass
     if (!fs.existsSync(sshDir)) fs.mkdirSync(sshDir, { recursive: true, mode: 0o700 });
     
     try {
-        // Generate key if missing (non-interactive)
-        await execAsync(`ssh-keygen -t rsa -b 4096 -f "${privKeyPath}" -N ""`);
+        // Generate key if missing (non-interactive). execFile + args array (no
+        // shell) so the on-disk key path can't be interpolated into a command.
+        await execFileAsync('ssh-keygen', ['-t', 'rsa', '-b', '4096', '-f', privKeyPath, '-N', '']);
         logs.push('SSH key generated.');
     } catch (e) {
         logs.push(`Failed to generate SSH key: ${e}`);

--- a/tests/backend/auth_ratelimit.test.ts
+++ b/tests/backend/auth_ratelimit.test.ts
@@ -55,14 +55,31 @@ describe('rate limiter', () => {
 });
 
 describe('clientKeyFromHeaders', () => {
-  it('uses the first hop of x-forwarded-for', () => {
+  it('uses the LAST (nginx-appended, trusted) hop of x-forwarded-for, not the first', () => {
     const h = new Headers({ 'x-forwarded-for': '203.0.113.1, 10.0.0.1' });
-    expect(clientKeyFromHeaders(h)).toBe('203.0.113.1');
+    expect(clientKeyFromHeaders(h)).toBe('10.0.0.1');
   });
 
-  it('falls back to x-real-ip', () => {
+  it('prefers x-real-ip (set authoritatively by NPM) over x-forwarded-for', () => {
+    const h = new Headers({ 'x-real-ip': '198.51.100.7', 'x-forwarded-for': '203.0.113.1, 10.0.0.1' });
+    expect(clientKeyFromHeaders(h)).toBe('198.51.100.7');
+  });
+
+  it('falls back to x-real-ip when no XFF is present', () => {
     const h = new Headers({ 'x-real-ip': '198.51.100.7' });
     expect(clientKeyFromHeaders(h)).toBe('198.51.100.7');
+  });
+
+  it('a spoofed left-most XFF does not rotate the rate-limit bucket key', () => {
+    // An attacker behind the proxy rotates the client-controllable first hop
+    // per request to dodge the brute-force limit; the trusted last hop (the
+    // one nginx appends) is constant, so every request collapses to one key.
+    const trustedHop = '10.0.0.1';
+    const k1 = clientKeyFromHeaders(new Headers({ 'x-forwarded-for': `1.1.1.1, ${trustedHop}` }));
+    const k2 = clientKeyFromHeaders(new Headers({ 'x-forwarded-for': `2.2.2.2, ${trustedHop}` }));
+    const k3 = clientKeyFromHeaders(new Headers({ 'x-forwarded-for': `evil, ${trustedHop}` }));
+    expect(k1).toBe(trustedHop);
+    expect(new Set([k1, k2, k3]).size).toBe(1);
   });
 
   it('returns "unknown" when no client header is present', () => {

--- a/tests/backend/ssh_verify.test.ts
+++ b/tests/backend/ssh_verify.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Capture every execFile invocation so we can assert ssh runs with NO shell
+// (discrete argv entries), not a single interpolated command string.
+const execCalls: { cmd: string; args: string[] }[] = [];
+let nextError: NodeJS.ErrnoException | null = null;
+
+vi.mock('node:child_process', () => {
+  const execFile = (
+    cmd: string,
+    args: string[],
+    callback: (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
+  ) => {
+    execCalls.push({ cmd, args: Array.isArray(args) ? [...args] : [] });
+    if (nextError) {
+      callback(nextError, '', '');
+    } else {
+      callback(null, '', '');
+    }
+  };
+  return { execFile, default: { execFile } };
+});
+
+describe('verifySSHConnection', () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    nextError = null;
+    vi.resetModules();
+  });
+
+  it('runs ssh via execFile with discrete argv entries (no shell string)', async () => {
+    const { verifySSHConnection } = await import('../../packages/backend/src/lib/ssh');
+    const ok = await verifySSHConnection('host.example', 22, 'core', '/keys/id_rsa');
+    expect(ok).toBe(true);
+
+    expect(execCalls).toHaveLength(1);
+    const { cmd, args } = execCalls[0];
+    // First argument is the bare binary, never a "ssh ..." shell line.
+    expect(cmd).toBe('ssh');
+    expect(cmd).not.toContain(' ');
+    // host/user/identityFile/port live as their own argv entries.
+    expect(args).toContain('-i');
+    expect(args).toContain('/keys/id_rsa');
+    expect(args).toContain('-p');
+    expect(args).toContain('22');
+    expect(args).toContain('core@host.example');
+    expect(args).toContain('exit');
+    // No single arg smuggles the whole command as a shell string.
+    expect(args.some((a) => a.includes('ssh -i'))).toBe(false);
+  });
+
+  it('does not let a metacharacter host inject a separate command', async () => {
+    const { verifySSHConnection } = await import('../../packages/backend/src/lib/ssh');
+    const evil = 'h; rm -rf /';
+    await verifySSHConnection(evil, 22, 'core', '/keys/id_rsa');
+    // The malicious host is one opaque argv entry; ssh receives it verbatim,
+    // the shell never sees it.
+    expect(execCalls[0].args).toContain(`core@${evil}`);
+    expect(execCalls[0].cmd).toBe('ssh');
+  });
+
+  it('returns false when ssh exits non-zero', async () => {
+    nextError = Object.assign(new Error('exit 255'), { code: 255 });
+    const { verifySSHConnection } = await import('../../packages/backend/src/lib/ssh');
+    const ok = await verifySSHConnection('host.example', 22, 'core', '/keys/id_rsa');
+    expect(ok).toBe(false);
+  });
+});

--- a/tests/backend/ssh_verify.test.ts
+++ b/tests/backend/ssh_verify.test.ts
@@ -60,7 +60,7 @@ describe('verifySSHConnection', () => {
   });
 
   it('returns false when ssh exits non-zero', async () => {
-    nextError = Object.assign(new Error('exit 255'), { code: 255 });
+    nextError = Object.assign(new Error('exit 255'), { code: 'EEXIT' });
     const { verifySSHConnection } = await import('../../packages/backend/src/lib/ssh');
     const ok = await verifySSHConnection('host.example', 22, 'core', '/keys/id_rsa');
     expect(ok).toBe(false);


### PR DESCRIPTION
## What
Four input-handling security fixes across auth and setup/reinstall-critical paths: the auth rate limiter now keys off the trusted last X-Forwarded-For hop (not the spoofable first hop); SSH connection-verify and ssh-keygen run via execFile with an argv array (no shell); NPM admin rekey validates the podman-derived container name and shell-quotes interpolated values; and CIFS backup mounts pass the password via a 0600 credentials file so a comma in the password can't inject mount options.

## Why
Closes #1852
Closes #1853
Closes #1854
Closes #1855

## Risk
Medium — ssh.ts and npmAdminRekey.ts run in the box setup/reinstall credential paths; behavior is unchanged for valid inputs but the exec mechanics changed.

## Rollback
git revert is enough (four atomic commits, no schema/migration change).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2516 passed)
- [ ] /verify on FCoS :dev box (ssh.ts SSH verify/keygen + npmAdminRekey.ts NPM rekey are path-mandated)

AI-generated
<!-- sb-ai-comment -->