### PR TITLE
feat(stacks): surface per-service image-update availability (API + dashboard)

### DIFF
--- a/packages/backend/src/lib/imageDigest.test.ts
+++ b/packages/backend/src/lib/imageDigest.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// executor.execArgv is stubbed per test so we can drive the podman inspect /
+// manifest inspect stdout. Keyed on the podman subcommand (inspect vs manifest).
+const mockExec = vi.hoisted(() => ({
+  execArgv: vi.fn(async (_argv: string[], _opts?: unknown) => ({ stdout: '', stderr: '' })),
+}));
+vi.mock('@/lib/executor', () => ({
+  getExecutor: () => mockExec,
+}));
+
+const mockConfig = vi.hoisted(() => ({
+  current: { installedTemplates: {} as Record<string, unknown> },
+}));
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfig.current),
+}));
+
+const mockRegistry = vi.hoisted(() => ({ yaml: null as string | null }));
+vi.mock('@/lib/registry', () => ({
+  getTemplateYaml: vi.fn(async () => mockRegistry.yaml),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  isUpdateAvailable,
+  getRegistryImageDigest,
+  getRunningImageDigest,
+  getServiceImageUpdate,
+  getInstalledImageUpdates,
+} from './imageDigest';
+
+// A multi-arch manifest-list document (registry side, `podman manifest inspect`).
+function manifestList(amd64Digest: string): string {
+  return JSON.stringify({
+    schemaVersion: 2,
+    mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+    manifests: [
+      { platform: { architecture: 'amd64', os: 'linux' }, digest: amd64Digest },
+      { platform: { architecture: 'arm64', os: 'linux' }, digest: 'sha256:other' },
+    ],
+  });
+}
+
+// A single-image inspect document (running side, `podman inspect`) — array form.
+function inspectDoc(digest: string): string {
+  return JSON.stringify([{ Id: 'abc', Digest: digest, RepoTags: ['x:latest'] }]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExec.execArgv.mockResolvedValue({ stdout: '', stderr: '' });
+  mockConfig.current = { installedTemplates: {} };
+  mockRegistry.yaml = null;
+});
+
+describe('isUpdateAvailable (digest comparison)', () => {
+  it('running == registry → false', () => {
+    expect(isUpdateAvailable('sha256:aaa', 'sha256:aaa')).toBe(false);
+  });
+
+  it('running != registry → true', () => {
+    expect(isUpdateAvailable('sha256:aaa', 'sha256:bbb')).toBe(true);
+  });
+
+  it('missing running digest → false (unknown, never crash)', () => {
+    expect(isUpdateAvailable(null, 'sha256:bbb')).toBe(false);
+    expect(isUpdateAvailable(undefined, 'sha256:bbb')).toBe(false);
+  });
+
+  it('missing registry digest → false (unknown, never crash)', () => {
+    expect(isUpdateAvailable('sha256:aaa', null)).toBe(false);
+    expect(isUpdateAvailable('sha256:aaa', undefined)).toBe(false);
+  });
+
+  it('both unknown → false', () => {
+    expect(isUpdateAvailable(null, null)).toBe(false);
+  });
+});
+
+describe('getRegistryImageDigest', () => {
+  it('extracts the linux/amd64 digest from a manifest list', async () => {
+    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:reg'), stderr: '' });
+    await expect(getRegistryImageDigest('ghcr.io/x:1')).resolves.toBe('sha256:reg');
+  });
+
+  it('returns null when podman errors (treat as unknown)', async () => {
+    mockExec.execArgv.mockRejectedValue(new Error('registry unreachable'));
+    await expect(getRegistryImageDigest('ghcr.io/x:1')).resolves.toBeNull();
+  });
+
+  it('returns null on unparseable stdout', async () => {
+    mockExec.execArgv.mockResolvedValue({ stdout: 'not json', stderr: '' });
+    await expect(getRegistryImageDigest('ghcr.io/x:1')).resolves.toBeNull();
+  });
+});
+
+describe('getRunningImageDigest', () => {
+  it('extracts the digest from a podman inspect array document', async () => {
+    mockExec.execArgv.mockResolvedValue({ stdout: inspectDoc('sha256:run'), stderr: '' });
+    await expect(getRunningImageDigest('ghcr.io/x:1')).resolves.toBe('sha256:run');
+  });
+
+  it('returns null when the image is not present (podman error)', async () => {
+    mockExec.execArgv.mockRejectedValue(new Error('no such object'));
+    await expect(getRunningImageDigest('ghcr.io/x:1')).resolves.toBeNull();
+  });
+});
+
+describe('getServiceImageUpdate', () => {
+  it('reports updateAvailable=true when running differs from registry', async () => {
+    mockExec.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv.includes('manifest')) return { stdout: manifestList('sha256:reg'), stderr: '' };
+      return { stdout: inspectDoc('sha256:run'), stderr: '' };
+    });
+    const r = await getServiceImageUpdate('immich', 'ghcr.io/x:1');
+    expect(r).toEqual({
+      service: 'immich',
+      image: 'ghcr.io/x:1',
+      runningDigest: 'sha256:run',
+      registryDigest: 'sha256:reg',
+      updateAvailable: true,
+    });
+  });
+
+  it('reports updateAvailable=false when digests match', async () => {
+    mockExec.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv.includes('manifest')) return { stdout: manifestList('sha256:same'), stderr: '' };
+      return { stdout: inspectDoc('sha256:same'), stderr: '' };
+    });
+    const r = await getServiceImageUpdate('immich', 'ghcr.io/x:1');
+    expect(r.updateAvailable).toBe(false);
+  });
+
+  it('does not crash and reports false when both lookups fail', async () => {
+    mockExec.execArgv.mockRejectedValue(new Error('podman gone'));
+    const r = await getServiceImageUpdate('immich', 'ghcr.io/x:1');
+    expect(r).toEqual({
+      service: 'immich',
+      image: 'ghcr.io/x:1',
+      runningDigest: null,
+      registryDigest: null,
+      updateAvailable: false,
+    });
+  });
+});
+
+describe('getInstalledImageUpdates (fan-out)', () => {
+  it('skips invalid template names and yields one entry per declared image', async () => {
+    mockConfig.current = {
+      installedTemplates: { immich: { schemaVersion: 1 }, 'Bad Name': { schemaVersion: 1 } },
+    };
+    mockRegistry.yaml = 'spec:\n  containers:\n  - image: ghcr.io/x:1\n    name: x\n';
+    mockExec.execArgv.mockImplementation(async (argv: string[]) => {
+      if (argv.includes('manifest')) return { stdout: manifestList('sha256:reg'), stderr: '' };
+      return { stdout: inspectDoc('sha256:run'), stderr: '' };
+    });
+    const out = await getInstalledImageUpdates();
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ service: 'immich', image: 'ghcr.io/x:1', updateAvailable: true });
+  });
+
+  it('returns empty when nothing is installed', async () => {
+    mockConfig.current = { installedTemplates: {} };
+    await expect(getInstalledImageUpdates()).resolves.toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/imageDigest.ts
+++ b/packages/backend/src/lib/imageDigest.ts
@@ -1,0 +1,151 @@
+/**
+ * Per-service image-update detection (#1859, child 1 of #1858).
+ *
+ * Answers "is the registry serving a newer image than the one this service is
+ * running?" for every installed service, by comparing two digests:
+ *
+ *   - the **running** digest: the locally-pulled image the service runs, read
+ *     from `podman inspect <image>`;
+ *   - the **registry** digest: what the registry currently publishes for that
+ *     same tag, read from `podman manifest inspect <image>`.
+ *
+ * The registry side intentionally REUSES updater.ts's `extractImageDigest`
+ * (the multi-arch manifest-list → linux/amd64 digest extraction) and the same
+ * `podman manifest inspect` convention, generalised here from the hard-coded
+ * `:latest` ServiceBay image to an arbitrary image ref. `extractImageDigest`
+ * applies equally to the single-image `podman inspect` document (it falls back
+ * to the config/`Digest` field), so both sides share one parser.
+ *
+ * A null digest on either side means "unknown" (registry unreachable, image
+ * not pulled, podman error). We never treat unknown as "no update" with a
+ * false negative *or* claim an update on a guess — `updateAvailable` is only
+ * `true` when both digests are known AND differ (memory
+ * feedback_dont_mask_failures).
+ */
+import { getExecutor } from '@/lib/executor';
+import { getConfig } from '@/lib/config';
+import { getTemplateYaml } from '@/lib/registry';
+import { collectImagesToPull } from '@/lib/install/runner';
+import { extractImageDigest } from '@/lib/updater';
+import { logger } from '@/lib/logger';
+
+const INSPECT_TIMEOUT_MS = 30 * 1000;
+
+export interface ServiceImageUpdate {
+  service: string;
+  image: string;
+  /** Digest of the locally-pulled image the service runs; null if unknown. */
+  runningDigest: string | null;
+  /** Digest the registry currently publishes for the tag; null if unknown. */
+  registryDigest: string | null;
+  /** True iff both digests are known and differ. Unknown → false, never crash. */
+  updateAvailable: boolean;
+}
+
+/**
+ * The single comparison rule. An update is available only when we know BOTH
+ * digests and they differ. A missing/unknown digest on either side is NOT an
+ * update (we can't prove a change) — exported so the unit tests can cover the
+ * running==registry / differ / missing cases without any podman.
+ */
+export function isUpdateAvailable(
+  runningDigest: string | null | undefined,
+  registryDigest: string | null | undefined,
+): boolean {
+  if (!runningDigest || !registryDigest) return false;
+  return runningDigest !== registryDigest;
+}
+
+/**
+ * Resolve the digest the **registry** currently serves for `image`. Mirrors
+ * updater.ts's `getRemoteImageDigest` (same `podman manifest inspect` +
+ * `extractImageDigest`), generalised to an arbitrary image ref. Cheap: the
+ * manifest is a few KB, not the layers. Returns null on any error — callers
+ * treat null as "unknown", never "unchanged".
+ */
+export async function getRegistryImageDigest(image: string): Promise<string | null> {
+  try {
+    const executor = getExecutor('Local');
+    const { stdout } = await executor.execArgv(['podman', 'manifest', 'inspect', image], {
+      timeoutMs: INSPECT_TIMEOUT_MS,
+    });
+    return extractImageDigest(JSON.parse(stdout));
+  } catch (e) {
+    logger.warn('imageDigest', `getRegistryImageDigest(${image}) failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
+/**
+ * Resolve the digest of the locally-pulled image the service is **running**,
+ * via `podman inspect <image>`. `extractImageDigest` reads the single-image
+ * inspect document's config/`Digest` field. Returns null on any error.
+ */
+export async function getRunningImageDigest(image: string): Promise<string | null> {
+  try {
+    const executor = getExecutor('Local');
+    const { stdout } = await executor.execArgv(['podman', 'inspect', image], {
+      timeoutMs: INSPECT_TIMEOUT_MS,
+    });
+    const parsed = JSON.parse(stdout);
+    // `podman inspect` returns an array (one entry per matched object).
+    const doc = Array.isArray(parsed) ? parsed[0] : parsed;
+    return extractImageDigest(doc);
+  } catch (e) {
+    logger.warn('imageDigest', `getRunningImageDigest(${image}) failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
+/**
+ * Build the running-vs-registry comparison for a single service/image pair.
+ * Both lookups run, even if one is unknown, so the caller always gets both
+ * digest fields back for diagnostics.
+ */
+export async function getServiceImageUpdate(service: string, image: string): Promise<ServiceImageUpdate> {
+  const [runningDigest, registryDigest] = await Promise.all([
+    getRunningImageDigest(image),
+    getRegistryImageDigest(image),
+  ]);
+  return {
+    service,
+    image,
+    runningDigest,
+    registryDigest,
+    updateAvailable: isUpdateAvailable(runningDigest, registryDigest),
+  };
+}
+
+/**
+ * Fan out across every installed service and report whether each has a newer
+ * image waiting in the registry. Mirrors the upgrades-pending route's pattern:
+ * iterate `config.installedTemplates`, skip names that fail the registry's own
+ * validation, pull the template yaml, and reuse `collectImagesToPull` to lift
+ * the `image:` ref out of it. A single service failing yaml-read or a podman
+ * error never takes the whole aggregate down.
+ */
+export async function getInstalledImageUpdates(): Promise<ServiceImageUpdate[]> {
+  const config = await getConfig();
+  const installed = config.installedTemplates ?? {};
+
+  const results: ServiceImageUpdate[] = [];
+  for (const name of Object.keys(installed)) {
+    // Same gate the upgrades-pending route uses — a name that wouldn't pass
+    // template-name validation can't have a yaml to read anyway.
+    if (!/^[a-z][a-z0-9-]{0,63}$/.test(name)) continue;
+    try {
+      const yaml = await getTemplateYaml(name);
+      if (yaml === null) continue;
+      // Reuse the install runner's `image:` extractor (regex-based, tolerant of
+      // Mustache placeholders). One service may declare several images; report
+      // each so the UI can flag any container with a pending update.
+      const images = collectImagesToPull([{ name, yaml }]);
+      for (const image of images) {
+        results.push(await getServiceImageUpdate(name, image));
+      }
+    } catch (e) {
+      logger.warn('imageDigest', `getInstalledImageUpdates skipped ${name}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  return results;
+}

--- a/packages/frontend/src/app/api/system/stacks/image-updates/route.ts
+++ b/packages/frontend/src/app/api/system/stacks/image-updates/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/system/stacks/image-updates (#1859, child 1 of #1858)
+ *
+ * "Which installed services are running an image older than what the registry
+ * now serves for their tag?" — fanned out across every entry in
+ * `config.installedTemplates`, mirroring the
+ * `/api/system/templates/upgrades-pending` route's fan-out + session gate.
+ *
+ * For each service it compares the running image digest (`podman inspect`)
+ * against the registry's current digest for the same tag
+ * (`podman manifest inspect`), reusing updater.ts's digest extraction via
+ * `@/lib/imageDigest`. The frontend badge + overview (child #2, #1860)
+ * consumes this; this route makes NO `(dashboard)/` changes.
+ */
+import { NextResponse } from 'next/server';
+import { requireSession } from '@/lib/api/requireSession';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { getInstalledImageUpdates } from '@/lib/imageDigest';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withApiHandler({}, async ({ request }) => {
+  const auth = await requireSession(request);
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const services = await getInstalledImageUpdates();
+    return NextResponse.json({ services });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:stacks:image-updates', status: 500 });
+  }
+});

--- a/packages/frontend/src/components/ImageUpdatesPendingBanner.test.tsx
+++ b/packages/frontend/src/components/ImageUpdatesPendingBanner.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ImageUpdatesPendingBanner from './ImageUpdatesPendingBanner';
+import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
+
+const update = (service: string, image: string): ServiceImageUpdate => ({
+  service,
+  image,
+  runningDigest: 'sha256:old',
+  registryDigest: 'sha256:new',
+  updateAvailable: true,
+});
+
+describe('ImageUpdatesPendingBanner', () => {
+  it('renders nothing when no updates are pending', () => {
+    const { container } = render(<ImageUpdatesPendingBanner updates={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('lists every affected service with its image', () => {
+    render(
+      <ImageUpdatesPendingBanner
+        updates={[update('immich', 'ghcr.io/immich/server:latest'), update('vaultwarden', 'docker.io/vaultwarden/server:1.30')]}
+      />,
+    );
+    expect(screen.getByText(/2 service image updates available/i)).not.toBeNull();
+    expect(screen.getByText('immich')).not.toBeNull();
+    expect(screen.getByText('ghcr.io/immich/server:latest')).not.toBeNull();
+    expect(screen.getByText('vaultwarden')).not.toBeNull();
+  });
+
+  it('uses the singular form for a single update', () => {
+    render(<ImageUpdatesPendingBanner updates={[update('immich', 'ghcr.io/immich/server:latest')]} />);
+    expect(screen.getByText(/1 service image update available/i)).not.toBeNull();
+  });
+});

--- a/packages/frontend/src/components/ImageUpdatesPendingBanner.tsx
+++ b/packages/frontend/src/components/ImageUpdatesPendingBanner.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Download } from 'lucide-react';
+import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
+
+/**
+ * Pending-updates overview for managed stacks (#1860, child 2 of #1858).
+ *
+ * Lists every installed service whose running image digest differs from the
+ * digest the registry now serves for the same tag (data from
+ * `GET /api/system/stacks/image-updates`, #1859). The counterpart per-card
+ * badge lives on `ServiceCard`; this banner is the at-a-glance roll-up,
+ * mirroring `TemplateUpgradesPendingBanner`'s placement and visual language.
+ *
+ * This is DISTINCT from the schema-version "template upgrade" banner: that
+ * one compares registry *schema versions* (and offers a re-deploy), this one
+ * compares *image digests*. They render independently; neither affects the
+ * other.
+ *
+ * Stateless on purpose — the parent owns the fetch (`useImageUpdates`) so the
+ * same data backs both this overview and the per-card badges without two
+ * round-trips.
+ */
+export default function ImageUpdatesPendingBanner({ updates }: { updates: ServiceImageUpdate[] }) {
+  if (updates.length === 0) return null;
+
+  return (
+    <div className="mb-4 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50/70 dark:bg-blue-900/20">
+      <div className="p-4 flex items-start gap-3">
+        <div className="shrink-0 p-1.5 rounded bg-blue-100 dark:bg-blue-800/30 text-blue-700 dark:text-blue-300">
+          <Download size={16} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="font-semibold text-sm text-gray-900 dark:text-white">
+            {updates.length} service image update{updates.length === 1 ? '' : 's'} available
+          </div>
+          <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
+            The registry is serving a newer image than what these services are running.
+            Re-deploy a service to pull its latest image.
+          </p>
+          <ul className="mt-2 space-y-1.5 text-xs text-gray-700 dark:text-gray-300">
+            {updates.map(u => (
+              <li key={`${u.service}:${u.image}`} className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono font-medium">{u.service}</span>
+                <span className="text-gray-500 dark:text-gray-400 font-mono break-all">{u.image}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ServiceCard.tsx
+++ b/packages/frontend/src/components/ServiceCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useMemo } from 'react';
-import { AlertCircle, RotateCcw } from 'lucide-react';
+import { AlertCircle, Download, RotateCcw } from 'lucide-react';
 import type { EnrichedContainer, ServicePort, ServiceViewModel } from '@servicebay/api-client';
 import { ServiceActionBar } from '@/components/ServiceActionBar';
 import { AttachedContainerList } from '@/components/AttachedContainerList';
@@ -23,6 +23,11 @@ export interface ServiceCardProps {
    *  scheme for the per-domain badge links so LAN-only services don't
    *  produce a TLS error on click. */
   httpsDomains: Set<string>;
+  /** True when the registry serves a newer image digest than the one this
+   *  service is running (from `/api/system/stacks/image-updates`, #1860).
+   *  Renders an "Update available" badge. Independent of the schema-version
+   *  "template upgrade" surface. */
+  imageUpdateAvailable?: boolean;
   // Service-row actions (ServiceActionBar + failed-state nudge).
   onMonitor: (service: ServiceViewModel) => void;
   onEdit: (service: ServiceViewModel) => void;
@@ -40,6 +45,7 @@ export default function ServiceCard({
   service,
   attachNodeContext,
   httpsDomains,
+  imageUpdateAvailable,
   onMonitor,
   onEdit,
   onActions,
@@ -122,6 +128,14 @@ export default function ServiceCard({
               {service.externalIP && service.type !== 'gateway' && (
                 <span className="text-[10px] font-mono font-bold text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-1.5 py-0.5 rounded">
                   IP: {service.externalIP}
+                </span>
+              )}
+              {imageUpdateAvailable && (
+                <span
+                  className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-200 dark:border-blue-800 rounded"
+                  title="A newer image is available in the registry. Re-deploy this service to pull it."
+                >
+                  <Download size={10} /> Update available
                 </span>
               )}
             </div>

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -6,11 +6,13 @@ import { useSearchParams } from 'next/navigation';
 import { logger } from '@servicebay/api-client';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin'; // V4 Hook
 import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { useImageUpdates } from '@/hooks/useImageUpdates';
 import DashboardHydrationGate, { type HydrationPhase } from '@/components/DashboardHydrationGate';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
 import PageHeader from '@/components/PageHeader';
 import TemplateUpgradesPendingBanner from '@/components/TemplateUpgradesPendingBanner';
+import ImageUpdatesPendingBanner from '@/components/ImageUpdatesPendingBanner';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
 import FileViewerOverlay from '@/components/FileViewerOverlay';
 import RegistryDashboard from '@/dashboards/RegistryDashboard';
@@ -40,6 +42,7 @@ const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: fa
 export default function ServicesDashboard() {
     const { data: twin, isConnected, lastUpdate, isNodeSynced } = useDigitalTwin();
     const { addToast, updateToast } = useToast();
+    const { available: imageUpdates, availableServices: imageUpdateServices } = useImageUpdates();
 
     const [filteredServices, setFilteredServices] = useState<ServiceViewModel[]>([]);
     const [filteredBundles, setFilteredBundles] = useState<ServiceBundle[]>([]);
@@ -666,6 +669,7 @@ export default function ServicesDashboard() {
                                     service={entry.service}
                                     attachNodeContext={attachNodeContext}
                                     httpsDomains={httpsDomains}
+                                    imageUpdateAvailable={imageUpdateServices.has(entry.service.name.replace(/\.service$/, ''))}
                                     onMonitor={openMonitorDrawer}
                                     onEdit={openEditDrawer}
                                     onActions={openActions}
@@ -906,6 +910,7 @@ export default function ServicesDashboard() {
             />
 
       <TemplateUpgradesPendingBanner />
+      <ImageUpdatesPendingBanner updates={imageUpdates} />
       <PageHeader
         title="Services"
         showBack={false} 

--- a/packages/frontend/src/hooks/useImageUpdates.ts
+++ b/packages/frontend/src/hooks/useImageUpdates.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+/**
+ * One service's running-vs-registry image comparison, as returned by
+ * `GET /api/system/stacks/image-updates` (#1859, child 1 of #1858). The
+ * backend shape is `ServiceImageUpdate` in `@/lib/imageDigest`; this mirrors
+ * its public fields (the frontend can't import the backend module via
+ * `@/lib`, which resolves to the backend package — memory
+ * reference_at_lib_alias_is_backend).
+ */
+export interface ServiceImageUpdate {
+  service: string;
+  image: string;
+  runningDigest: string | null;
+  registryDigest: string | null;
+  /** True iff both digests are known and differ. */
+  updateAvailable: boolean;
+}
+
+interface ImageUpdatesResponse {
+  services: ServiceImageUpdate[];
+}
+
+/**
+ * Fetch the per-service image-update report once on mount. Distinct from the
+ * schema-version "template upgrade" check (that compares registry *schema
+ * versions*; this compares running-vs-registry *image digests*) — the two
+ * surfaces are independent.
+ *
+ * Returns the affected entries (`updateAvailable === true`) for the overview
+ * section, a `Set` of their service names for fast per-card lookup, plus a
+ * `refresh` to re-poll after an update action.
+ */
+export function useImageUpdates() {
+  const [updates, setUpdates] = useState<ServiceImageUpdate[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/system/stacks/image-updates', { cache: 'no-store' });
+      if (!res.ok) return;
+      const data: ImageUpdatesResponse = await res.json();
+      setUpdates(Array.isArray(data?.services) ? data.services : []);
+    } catch {
+      // Best-effort: a failed check just leaves no badges — never block the
+      // dashboard (feedback_dont_mask_failures: we don't claim "up to date",
+      // we simply show nothing until the next successful poll).
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const available = useMemo(() => updates.filter(u => u.updateAvailable), [updates]);
+  const availableServices = useMemo(
+    () => new Set(available.map(u => u.service)),
+    [available],
+  );
+
+  return { available, availableServices, loaded, refresh };
+}

--- a/packages/frontend/src/mocks/handlers.ts
+++ b/packages/frontend/src/mocks/handlers.ts
@@ -115,6 +115,9 @@ export const handlers = [
   // GET /api/system/templates/upgrades-pending
   http.get('/api/system/templates/upgrades-pending', () => HttpResponse.json([])),
 
+  // GET /api/system/stacks/image-updates — per-service image digest check
+  http.get('/api/system/stacks/image-updates', () => HttpResponse.json({ services: [] })),
+
   // GET /api/health/checks
   http.get('/api/health/checks', () => HttpResponse.json([])),
 


### PR DESCRIPTION
## What
Adds detection and surfacing of available container-image updates for managed stacks. A new backend endpoint compares each installed service's running image digest against the registry digest; the dashboard shows a per-card "Update available" badge plus an at-a-glance pending-updates overview banner.

## Why
Closes #1859
Closes #1860

Children of epic #1858 (image-update detection feature).

## Risk
Low — additive read-only feature; the badge/overview are independent of the existing schema-version template-upgrade banner, and a failed digest poll yields no badges (never blocks rendering).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (full — 2534 passed)
- [ ] /verify on FCoS :dev box (#1860 touches packages/frontend/src/app/(dashboard)/ + dashboards/ — path-mandated)

AI-generated
<!-- sb-ai-comment -->