### PR TITLE
fix(ha,externalBackup): guard HA on emptied config + rotate NAS backups into dated slots

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -337,6 +337,9 @@ export interface AppConfig {
     enabled: boolean;
     /** Daily run time in 24h `HH:MM` UTC. */
     time?: string;
+    /** How many dated snapshots to keep per service before pruning the oldest
+     *  (#1865). Bounded so the NAS can't fill; defaults to 7 when unset. */
+    retention?: number;
     target?: ExternalBackupTarget;
   };
   /**

--- a/packages/backend/src/lib/diagnose/probes/haAutomationIntegrity.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/haAutomationIntegrity.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock hoists above top-level consts — expose mutable state via a closure.
+const state = {
+  files: {} as Record<string, string>,
+  dirExists: true,
+  backupTarget: { transport: 'ftp' } as unknown as object | null,
+};
+
+const HA_DIR = '/mnt/data/stacks/home-assistant/homeassistant';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve({ templateSettings: {} })),
+}));
+
+vi.mock('@/lib/externalBackup/nasClient', () => ({
+  resolveBackupTarget: vi.fn(() => Promise.resolve(state.backupTarget)),
+}));
+
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: {
+    ensureAgent: vi.fn(() =>
+      Promise.resolve({
+        sendCommand: vi.fn(async (_action: string, params?: { command?: string }) => {
+          const cmd = params?.command ?? '';
+          let m = cmd.match(/^test -d (\S+) && echo yes \|\| echo no$/);
+          if (m) return { code: 0, stdout: state.dirExists ? 'yes' : 'no' };
+          m = cmd.match(/^cat (\S+) 2>\/dev\/null \|\| echo MISSING$/);
+          if (m) {
+            const body = state.files[m[1]];
+            return { code: 0, stdout: body !== undefined ? body : 'MISSING' };
+          }
+          return { code: 0, stdout: '' };
+        }),
+      }),
+    ),
+  },
+}));
+
+import { checkHaAutomationIntegrity } from './haAutomationIntegrity';
+
+const REGISTRY = `${HA_DIR}/.storage/core.entity_registry`;
+
+function registry(entities: { platform: string }[]): string {
+  return JSON.stringify({ data: { entities } });
+}
+
+beforeEach(() => {
+  state.files = {};
+  state.dirExists = true;
+  state.backupTarget = { transport: 'ftp' };
+});
+
+describe('checkHaAutomationIntegrity (#1864)', () => {
+  it('returns info when HA is not installed', async () => {
+    state.dirExists = false;
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('info');
+    expect(r.detail).toMatch(/not installed/);
+  });
+
+  it('returns info when there is no entity registry yet', async () => {
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('info');
+    expect(r.detail).toMatch(/no entity registry/);
+  });
+
+  it('warns on the registry/config mismatch (registry has N, file empty)', async () => {
+    state.files[REGISTRY] = registry([
+      { platform: 'automation' },
+      { platform: 'automation' },
+      { platform: 'script' },
+    ]);
+    state.files[`${HA_DIR}/automations.yaml`] = '[]';
+    state.files[`${HA_DIR}/scripts.yaml`] = '- alias: real'; // script file populated
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/automations\.yaml/);
+    expect(r.detail).toMatch(/registry lists 2 automation/);
+    expect(r.detail).not.toMatch(/scripts\.yaml/); // script matched, not flagged
+    expect(r.hint).toMatch(/Do NOT restart/i);
+  });
+
+  it('warns when a registered config file is missing entirely', async () => {
+    state.files[REGISTRY] = registry([{ platform: 'scene' }]);
+    // scenes.yaml absent → MISSING → treated as 0 entries
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/scenes\.yaml/);
+  });
+
+  it('warns when HA owns entities but no effective backup target resolves', async () => {
+    state.files[REGISTRY] = registry([{ platform: 'automation' }]);
+    state.files[`${HA_DIR}/automations.yaml`] = '- id: morning\n';
+    state.backupTarget = null; // neither gateway nor externalBackup resolves
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('warn');
+    expect(r.detail).toMatch(/no external backup is configured/);
+    expect(r.hint).toMatch(/FritzBox gateway/);
+  });
+
+  it('does NOT warn about backup when the effective (gateway-derived) target resolves', async () => {
+    // externalBackup unset, but resolveBackupTarget returns the gateway-derived
+    // FritzBox target → no false "no backup" warning.
+    state.files[REGISTRY] = registry([{ platform: 'automation' }]);
+    state.files[`${HA_DIR}/automations.yaml`] = '- id: morning\n';
+    state.backupTarget = { transport: 'ftp' };
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/match their config files/);
+  });
+
+  it('returns ok with no entities registered (nothing at risk)', async () => {
+    state.files[REGISTRY] = registry([{ platform: 'sun' }]);
+    state.backupTarget = null; // no backup, but nothing to back up either
+    const r = await checkHaAutomationIntegrity();
+    expect(r.status).toBe('ok');
+    expect(r.detail).toMatch(/nothing at risk/);
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/haAutomationIntegrity.ts
+++ b/packages/backend/src/lib/diagnose/probes/haAutomationIntegrity.ts
@@ -1,0 +1,183 @@
+/**
+ * `ha_automation_integrity` probe (#1864) — guards against the Home Assistant
+ * automations/scripts/scenes data-loss incident.
+ *
+ * Two distinct hazards, surfaced as one row:
+ *
+ *  1. **Registry/config mismatch.** HA's entity registry
+ *     (`<config>/.storage/core.entity_registry`) lists N>0 entities of a
+ *     platform (`automation` / `script` / `scene`) but the corresponding
+ *     include target file (`automations.yaml` / `scripts.yaml` /
+ *     `scenes.yaml`) parses to 0 entries. That is the fingerprint of the
+ *     incident: the registry still references the automations but their YAML
+ *     is empty, so HA is one start away from overwriting the only copy. The
+ *     pre-start hook (`runHomeAssistantHook`) now refuses to start HA in this
+ *     state; this probe surfaces the same condition in diagnose so it's
+ *     visible without a deploy.
+ *
+ *  2. **No effective backup target.** HA owns automations/scripts/scenes but
+ *     no external backup destination resolves — so a future emptying would be
+ *     unrecoverable. Crucially this checks the EFFECTIVE target via
+ *     `resolveBackupTarget()`, which defaults to `config.gateway` (the
+ *     FritzBox) when `config.externalBackup` is unset. A bare null-check on
+ *     `externalBackup` would false-warn on every box that backs up to the
+ *     gateway by default.
+ *
+ * Read-only: the probe never writes, repairs, or deletes anything on the host.
+ */
+import { agentManager } from '@/lib/agent/manager';
+import { getConfig } from '@/lib/config';
+import { resolveBackupTarget } from '@/lib/externalBackup/nasClient';
+import { logger } from '@/lib/logger';
+import yaml from 'js-yaml';
+
+export interface HaAutomationIntegrityResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+}
+
+const DEFAULT_STACKS_DIR = '/mnt/data/stacks';
+
+/** The three UI-editable include targets and the registry platform each maps to. */
+const INCLUDES: { file: string; platform: string }[] = [
+  { file: 'automations.yaml', platform: 'automation' },
+  { file: 'scripts.yaml', platform: 'script' },
+  { file: 'scenes.yaml', platform: 'scene' },
+];
+
+/** Count entity-registry entries for a `platform`. The registry is JSON of the
+ *  shape `{ data: { entities: [{ platform }, ...] } }`. Unparseable → 0. */
+export function countRegistryPlatformEntries(registryJson: string, platform: string): number {
+  try {
+    const parsed = JSON.parse(registryJson) as { data?: { entities?: Array<{ platform?: string }> } };
+    const entities = parsed?.data?.entities;
+    if (!Array.isArray(entities)) return 0;
+    return entities.filter((e) => e?.platform === platform).length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Parse a HA include target file and return its entry count. Automations and
+ *  scenes are YAML lists (`[]` → 0); scripts are a mapping (`{}` → 0). Blank →
+ *  0. Unparseable → null (don't raise a false mismatch on a file we can't read). */
+export function parseHaEntryCount(content: string): number | null {
+  const trimmed = content.trim();
+  if (trimmed === '') return 0;
+  let doc: unknown;
+  try {
+    doc = yaml.load(content);
+  } catch {
+    return null;
+  }
+  if (doc === null || doc === undefined) return 0;
+  if (Array.isArray(doc)) return doc.length;
+  if (typeof doc === 'object') return Object.keys(doc as object).length;
+  return null;
+}
+
+/** Minimal slice of the agent we use here — keeps this file decoupled from
+ *  the full handler type while staying exec-shaped. */
+type ExecAgent = { sendCommand(action: string, params?: { command?: string }): Promise<{ stdout?: string }> };
+
+/** Read `<dir>/<file>` from the host, returning '' for a missing file. */
+async function readFileOrEmpty(agent: ExecAgent, dir: string, file: string): Promise<string> {
+  const res = await agent.sendCommand('exec', { command: `cat ${dir}/${file} 2>/dev/null || echo MISSING` });
+  const raw = res.stdout ?? '';
+  return raw.trim() === 'MISSING' ? '' : raw;
+}
+
+/** Hazard-1 scan: for each include whose registry count is N>0 but whose
+ *  config file parses to 0 entries, return a human-readable mismatch line.
+ *  Also returns the total registered count (used for the backup check). */
+async function scanIncludeMismatches(
+  agent: ExecAgent,
+  haConfigDir: string,
+  registryJson: string,
+): Promise<{ mismatches: string[]; totalRegistered: number }> {
+  const mismatches: string[] = [];
+  let totalRegistered = 0;
+  for (const inc of INCLUDES) {
+    const registered = countRegistryPlatformEntries(registryJson, inc.platform);
+    totalRegistered += registered;
+    if (registered === 0) continue;
+
+    const parsed = parseHaEntryCount(await readFileOrEmpty(agent, haConfigDir, inc.file));
+    if (parsed === null) continue; // unparseable — HA's own error, not ours
+    if (parsed === 0) {
+      mismatches.push(
+        `${inc.file} (registry lists ${registered} ${inc.platform} entit${registered === 1 ? 'y' : 'ies'}, file has 0)`,
+      );
+    }
+  }
+  return { mismatches, totalRegistered };
+}
+
+export async function checkHaAutomationIntegrity(
+  nodeName: string = 'Local',
+): Promise<HaAutomationIntegrityResult> {
+  const config = await getConfig();
+  const stacksDir = config.templateSettings?.DATA_DIR || DEFAULT_STACKS_DIR;
+  const haConfigDir = `${stacksDir}/home-assistant/homeassistant`;
+
+  const agent = await agentManager.ensureAgent(nodeName);
+
+  // Skip cleanly when HA isn't installed on this node.
+  const dirExists = await agent.sendCommand('exec', {
+    command: `test -d ${haConfigDir} && echo yes || echo no`,
+  });
+  if (dirExists.stdout?.trim() !== 'yes') {
+    return { status: 'info', detail: 'Home Assistant is not installed on this node.' };
+  }
+
+  const registryJson = await readFileOrEmpty(agent, haConfigDir, '.storage/core.entity_registry');
+  if (registryJson.trim() === '') {
+    return {
+      status: 'info',
+      detail: 'Home Assistant has no entity registry yet (fresh install) — nothing to check.',
+    };
+  }
+
+  // ── Hazard 1: registry lists entities but the config file is empty. ──
+  const { mismatches, totalRegistered } = await scanIncludeMismatches(agent, haConfigDir, registryJson);
+  if (mismatches.length > 0) return mismatchWarning(mismatches, haConfigDir);
+
+  // ── Hazard 2: HA owns entities but no effective backup target resolves. ──
+  if (totalRegistered > 0 && !(await resolveBackupTarget())) return noBackupWarning(totalRegistered);
+
+  return {
+    status: 'ok',
+    detail:
+      totalRegistered > 0
+        ? `Home Assistant's ${totalRegistered} registered automation/script/scene entit${totalRegistered === 1 ? 'y' : 'ies'} match their config files and an external backup target is configured.`
+        : 'Home Assistant has no automations/scripts/scenes registered — nothing at risk.',
+  };
+}
+
+/** Hazard-1 warn result: registry references entities the config files lack. */
+function mismatchWarning(mismatches: string[], haConfigDir: string): HaAutomationIntegrityResult {
+  logger.warn('diagnose:ha_automation_integrity', `registry/config mismatch: ${mismatches.join('; ')}`);
+  return {
+    status: 'warn',
+    detail:
+      `Home Assistant's entity registry references automations/scripts/scenes that are MISSING from their config files: ${mismatches.join('; ')}. ` +
+      `This is the data-loss fingerprint — the registry remembers them but the YAML is empty.`,
+    hint:
+      'Do NOT restart Home Assistant before recovering this data — a start would overwrite the only remaining copy. ' +
+      `Restore ${haConfigDir} from a backup (or confirm the data really was removed) first.`,
+  };
+}
+
+/** Hazard-2 warn result: HA owns entities but no effective backup destination. */
+function noBackupWarning(totalRegistered: number): HaAutomationIntegrityResult {
+  return {
+    status: 'warn',
+    detail:
+      `Home Assistant has ${totalRegistered} automation/script/scene entit${totalRegistered === 1 ? 'y' : 'ies'} but no external backup is configured — ` +
+      `there is nowhere to recover this config from if it's emptied or a reinstall wipes the box.`,
+    hint:
+      'Add a backup destination: configure the FritzBox gateway (host + login) in Settings → Integrations, ' +
+      'or set an explicit external-backup target. Without one, the automations have no off-box copy.',
+  };
+}

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -29,6 +29,7 @@ import { checkDomainUnreachable } from '@/lib/diagnose/probes/domainUnreachable'
 import { checkDomainResolvesToBox } from '@/lib/diagnose/probes/domainResolvesToBox';
 import { checkOidcProviderReachable } from '@/lib/diagnose/probes/oidcProviderReachable';
 import { checkNasBackupReachable } from '@/lib/diagnose/probes/nasBackupReachable';
+import { checkHaAutomationIntegrity } from '@/lib/diagnose/probes/haAutomationIntegrity';
 import { checkSsoVerify } from '@/lib/diagnose/probes/ssoVerify';
 import { checkHermesChat } from '@/lib/diagnose/probes/hermesChat';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
@@ -1016,6 +1017,29 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     probes.push({
       id: 'nas_backup_reachable',
       label: 'Config backup (FritzBox NAS)',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 18b) Home Assistant automation/script/scene integrity (#1864). Surfaces
+  //      the data-loss fingerprint — the entity registry references N>0
+  //      automations but their config file parses to 0 entries — as a warn,
+  //      and warns when HA owns automations but no EFFECTIVE backup target
+  //      (gateway-or-externalBackup) resolves to recover from.
+  try {
+    const hai = await checkHaAutomationIntegrity(nodeName);
+    probes.push({
+      id: 'ha_automation_integrity',
+      label: 'Home Assistant automations integrity',
+      status: hai.status,
+      detail: hai.detail,
+      hint: hai.hint,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'ha_automation_integrity',
+      label: 'Home Assistant automations integrity',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/packages/backend/src/lib/externalBackup/backupAll.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAll.test.ts
@@ -8,7 +8,7 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 const { mockNas, mockCfg } = vi.hoisted(() => ({
-  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn(), nasRemove: vi.fn() },
   mockCfg: { getConfig: vi.fn() },
 }));
 vi.mock('./nasClient', () => mockNas);
@@ -73,6 +73,9 @@ async function write(rel: string, content: string) {
 beforeEach(async () => {
   vi.clearAllMocks();
   mockNas.nasUpload.mockResolvedValue(undefined);
+  // #1865 — each write prunes (lists then removes); no prior snapshots here.
+  mockNas.nasList.mockResolvedValue([]);
+  mockNas.nasRemove.mockResolvedValue(undefined);
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'backupall-'));
 });
 afterEach(async () => {
@@ -93,10 +96,11 @@ describe('backupInstalledServicesToNas', () => {
 
     // Only adguard ran; home-assistant/authelia/etc. are not installed → not attempted.
     expect(results.map(r => r.service)).toEqual(['adguard']);
-    expect(results[0]).toMatchObject({ service: 'adguard', ok: true, tarName: 'adguard.tar' });
+    expect(results[0]).toMatchObject({ service: 'adguard', ok: true });
+    expect(results[0].tarName).toMatch(/^adguard-\d{8}-\d{4}\.tar$/); // dated slot (#1865)
     // The tar + meta were uploaded to the NAS.
     const uploaded = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
-    expect(uploaded).toContain('sb-backup/adguard.tar');
+    expect(uploaded.some(p => /sb-backup\/adguard-\d{8}-\d{4}\.tar$/.test(p))).toBe(true);
   });
 
   it('captures a per-service failure without aborting the run', async () => {
@@ -136,6 +140,6 @@ describe('backupInstalledServicesToNas', () => {
     expect(services).toContain('home-assistant-zwave');
     expect(results.find(r => r.service === 'home-assistant-zwave')).toMatchObject({ ok: true });
     const uploaded = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
-    expect(uploaded).toContain('sb-backup/home-assistant-zwave.tar');
+    expect(uploaded.some(p => /sb-backup\/home-assistant-zwave-\d{8}-\d{4}\.tar$/.test(p))).toBe(true);
   });
 });

--- a/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
@@ -33,8 +33,10 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 const { mockNas } = vi.hoisted(() => ({
-  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn(), nasRemove: vi.fn() },
 }));
+/** Match a dated slot tar `<service>-YYYYMMDD-HHMM.tar` (#1865). */
+const datedTarRe = (service: string) => new RegExp(`/${service}-\\d{8}-\\d{4}\\.tar$`);
 vi.mock('./nasClient', () => mockNas);
 // configUpload + the producer's box path read config; keep DATA_DIR unset so the
 // CLI's explicit serviceDataDir is the only source (the local fs backend).
@@ -82,6 +84,9 @@ async function listFilesRel(dir: string): Promise<string[]> {
 beforeEach(() => {
   vi.clearAllMocks();
   mockNas.nasUpload.mockResolvedValue(undefined);
+  // #1865 retention prune lists then removes; no prior snapshots here → no-op.
+  mockNas.nasList.mockResolvedValue([]);
+  mockNas.nasRemove.mockResolvedValue(undefined);
 });
 afterEach(async () => {
   await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
@@ -257,19 +262,19 @@ describe('GOLDEN: runConfigUpload writes the canonical on-NAS atom (real produce
       silentIO(),
     );
 
-    // Result contract.
-    expect(result.tarName).toBe('authelia.tar');
-    expect(result.metaName).toBe('authelia.tar.meta.json');
+    // Result contract — a dated slot, not a single overwritten authelia.tar (#1865).
+    expect(result.tarName).toMatch(/^authelia-\d{8}-\d{4}\.tar$/);
+    expect(result.metaName).toBe(`${result.tarName}.meta.json`);
     expect(result.meta.service).toBe('authelia');
     expect(result.meta.schemaVersion).toBe(1);
 
     // Canonical NAS layout: both files under sb-backup/.
     const uploadPaths = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
-    expect(uploadPaths).toContain('sb-backup/authelia.tar');
-    expect(uploadPaths).toContain('sb-backup/authelia.tar.meta.json');
+    expect(uploadPaths).toContain(`sb-backup/${result.tarName}`);
+    expect(uploadPaths).toContain(`sb-backup/${result.metaName}`);
 
     // The tar carries the stripped whitelist file only — same as a box backup.
-    const tarBuf = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/authelia.tar'))![1] as Buffer;
+    const tarBuf = mockNas.nasUpload.mock.calls.find(c => datedTarRe('authelia').test(String(c[0])))![1] as Buffer;
     const extracted = await extractTar(tarBuf);
     expect(await listFilesRel(extracted)).toEqual(['users_database.yml']);
     const body = await fs.readFile(path.join(extracted, 'users_database.yml'), 'utf8');
@@ -323,9 +328,9 @@ describe('GOLDEN: importHaOsBackupToNas → manifest-filtered home-assistant.tar
   it('stages only the HA manifest includes — never the DB or logs', async () => {
     const backup = await buildSupervisorBackup();
     const res = await importHaOsBackupToNas(backup);
-    expect(res.tarName).toBe('home-assistant.tar');
+    expect(res.tarName).toMatch(/^home-assistant-\d{8}-\d{4}\.tar$/); // dated slot (#1865)
 
-    const tarBuf = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/home-assistant.tar'))![1] as Buffer;
+    const tarBuf = mockNas.nasUpload.mock.calls.find(c => datedTarRe('home-assistant').test(String(c[0])))![1] as Buffer;
     const extracted = await extractTar(tarBuf);
     const files = await listFilesRel(extracted);
     expect(files).toEqual([
@@ -342,10 +347,10 @@ describe('GOLDEN: importHaOsBackupToNas → manifest-filtered home-assistant.tar
     expect(files).not.toContain('home-assistant_v2.db');
     expect(files).not.toContain('home-assistant.log');
 
-    // Canonical sidecar written alongside.
+    // Canonical sidecar written alongside the dated slot.
     const uploadPaths = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
-    expect(uploadPaths).toContain('sb-backup/home-assistant.tar');
-    expect(uploadPaths).toContain('sb-backup/home-assistant.tar.meta.json');
+    expect(uploadPaths).toContain(`sb-backup/${res.tarName}`);
+    expect(uploadPaths).toContain(`sb-backup/${res.tarName}.meta.json`);
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/backupRestoreRoundtrip.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupRestoreRoundtrip.test.ts
@@ -11,7 +11,7 @@ import path from 'path';
 // Only the NAS transport is mocked (an in-memory store); everything between is
 // the production code path.
 const { mockNas, mockCfg } = vi.hoisted(() => ({
-  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn(), nasRemove: vi.fn() },
   mockCfg: { getConfig: vi.fn() },
 }));
 vi.mock('./nasClient', () => mockNas);
@@ -23,6 +23,13 @@ import { restoreServiceBackup } from './restore';
 let nas: Map<string, Buffer>;
 let tmpRoot: string;
 
+/** A dated slot tar for `service` currently on the in-memory NAS, if any. */
+function datedSlot(service: string): string | undefined {
+  return [...nas.keys()]
+    .map(k => k.slice(`${NAS_BACKUP_DIR}/`.length))
+    .find(name => new RegExp(`^${service}-\\d{8}-\\d{4}\\.tar$`).test(name));
+}
+
 beforeEach(async () => {
   vi.clearAllMocks();
   nas = new Map();
@@ -32,6 +39,15 @@ beforeEach(async () => {
     if (!b) throw new Error(`NAS 404: ${p}`);
     return b;
   });
+  // Back the listing + removal off the same in-memory store so the dated-slot
+  // round-trip resolves the latest snapshot and pruning works end-to-end (#1865).
+  mockNas.nasList.mockImplementation(async (dir = '') => {
+    const prefix = dir ? `${dir}/` : '';
+    return [...nas.entries()]
+      .filter(([k]) => k.startsWith(prefix))
+      .map(([k, v]) => ({ name: k.slice(prefix.length), size: v.length }));
+  });
+  mockNas.nasRemove.mockImplementation(async (p: string) => { nas.delete(`${NAS_BACKUP_DIR}/${p.split('/').pop()}`); });
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'roundtrip-'));
   mockCfg.getConfig.mockResolvedValue({ templateSettings: { DATA_DIR: tmpRoot } });
 });
@@ -59,7 +75,8 @@ describe('backup → restore round-trip (#1218 / #1190)', () => {
     });
 
     await backupServiceToNas('home-assistant', { serviceDataDir: src });
-    expect(nas.has(`${NAS_BACKUP_DIR}/home-assistant.tar`)).toBe(true);
+    // #1865: a dated slot, not a single overwritten home-assistant.tar.
+    expect(datedSlot('home-assistant')).toBeDefined();
 
     const { dataDir } = await restoreServiceBackup('home-assistant', { local: true });
 

--- a/packages/backend/src/lib/externalBackup/haOsImport.test.ts
+++ b/packages/backend/src/lib/externalBackup/haOsImport.test.ts
@@ -8,9 +8,11 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 const { mockNas } = vi.hoisted(() => ({
-  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
+  mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn(), nasRemove: vi.fn() },
 }));
 vi.mock('./nasClient', () => mockNas);
+// writeServiceBackupToNas reads externalBackup.retention from config (#1865).
+vi.mock('../config', () => ({ getConfig: vi.fn(async () => ({})) }));
 
 import { extractHaConfigDir, importHaOsBackupToNas } from './haOsImport';
 
@@ -59,6 +61,9 @@ async function buildFakeHaBackup(): Promise<string> {
 beforeEach(() => {
   vi.clearAllMocks();
   mockNas.nasUpload.mockResolvedValue(undefined);
+  // #1865 — the producer prunes after writing (lists then removes); empty NAS.
+  mockNas.nasList.mockResolvedValue([]);
+  mockNas.nasRemove.mockResolvedValue(undefined);
 });
 afterEach(async () => {
   await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
@@ -110,9 +115,9 @@ describe('importHaOsBackupToNas', () => {
   it('stages a manifest-filtered home-assistant.tar (config + zwave_js, no DB) to the NAS', async () => {
     const backup = await buildFakeHaBackup();
     const res = await importHaOsBackupToNas(backup);
-    expect(res.tarName).toBe('home-assistant.tar');
+    expect(res.tarName).toMatch(/^home-assistant-\d{8}-\d{4}\.tar$/); // dated slot (#1865)
 
-    const tarCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/home-assistant.tar'))!;
+    const tarCall = mockNas.nasUpload.mock.calls.find(c => /\/home-assistant-\d{8}-\d{4}\.tar$/.test(String(c[0])))!;
     expect(tarCall).toBeTruthy();
 
     // Extract the staged tar and check the manifest filter was applied.

--- a/packages/backend/src/lib/externalBackup/orphanBackups.test.ts
+++ b/packages/backend/src/lib/externalBackup/orphanBackups.test.ts
@@ -8,7 +8,7 @@ vi.mock('./producer', async (orig) => ({
 
 import { selectOrphanBackups, listOrphanServiceBackups } from './orphanBackups';
 
-const entry = (service: string) => ({ service, tarName: `${service}.tar`, size: 1 });
+const entry = (service: string) => ({ service, tarName: `${service}-20260615-0531.tar`, size: 1, stamp: '20260615-0531' });
 
 describe('selectOrphanBackups (#1218 entry 2)', () => {
   it('returns backups for services that are not installed', () => {

--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -12,6 +12,7 @@ const { mockNas, mockGetConfig, mockSendCommand, mockExecutor, mockGetExecutor }
     nasUpload: vi.fn(),
     nasDownload: vi.fn(),
     nasList: vi.fn(),
+    nasRemove: vi.fn(),
   },
   mockGetConfig: vi.fn(),
   mockSendCommand: vi.fn(),
@@ -44,8 +45,13 @@ import {
   getNextExternalBackupDelayMs,
   scheduleExternalNasBackup,
   NAS_BACKUP_DIR,
+  DEFAULT_BACKUP_RETENTION,
+  latestServiceBackupName,
 } from './producer';
 import { getServiceManifest, type ServiceBackupManifest } from './serviceManifest';
+
+/** Match a dated slot tar `<service>-YYYYMMDD-HHMM.tar` (#1865). */
+const datedTarRe = (service: string) => new RegExp(`/${service}-\\d{8}-\\d{4}\\.tar$`);
 
 let tmpDirs: string[] = [];
 
@@ -65,6 +71,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGetConfig.mockResolvedValue({ templateSettings: {} });
   mockNas.nasUpload.mockResolvedValue(undefined);
+  // #1865 — writeServiceBackupToNas prunes after each write (lists then removes);
+  // default to an empty NAS so the per-write tests see no prior snapshots.
+  mockNas.nasList.mockResolvedValue([]);
+  mockNas.nasRemove.mockResolvedValue(undefined);
   mockGetExecutor.mockReturnValue(mockExecutor);
 });
 
@@ -386,7 +396,7 @@ describe('backupServiceToNas via the host agent (#1597)', () => {
     expect(mockGetExecutor).toHaveBeenCalledWith('Local');
     expect(result.size).toBeGreaterThan(0);
     // The tar bytes that came back through the agent contain the config, not the excluded querylog.
-    const tarCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/adguard.tar'))!;
+    const tarCall = mockNas.nasUpload.mock.calls.find(c => datedTarRe('adguard').test(String(c[0])))!;
     const out = await mkTmp();
     const tarFile = path.join(out, 'a.tar');
     await fs.writeFile(tarFile, tarCall[1] as Buffer);
@@ -403,7 +413,7 @@ describe('backupServiceToNas via the host agent (#1597)', () => {
     wireExecutorToHostDir();
 
     const result = await backupServiceToNas('authelia');
-    const tarCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/authelia.tar'))!;
+    const tarCall = mockNas.nasUpload.mock.calls.find(c => datedTarRe('authelia').test(String(c[0])))!;
     const out = await mkTmp();
     const tarFile = path.join(out, 'a.tar');
     await fs.writeFile(tarFile, tarCall[1] as Buffer);
@@ -422,16 +432,17 @@ describe('backupServiceToNas', () => {
 
     const result = await backupServiceToNas('adguard', { serviceDataDir: src });
 
-    expect(result.tarName).toBe('adguard.tar');
-    expect(result.metaName).toBe('adguard.tar.meta.json');
+    // #1865 — a dated slot per run, not a single overwritten adguard.tar.
+    expect(result.tarName).toMatch(/^adguard-\d{8}-\d{4}\.tar$/);
+    expect(result.metaName).toBe(`${result.tarName}.meta.json`);
     expect(result.size).toBeGreaterThan(0);
     expect(result.meta.schemaVersion).toBe(1);
     expect(result.meta.service).toBe('adguard');
     expect(result.meta.nodeId).toBe(os.hostname());
 
     const uploadPaths = mockNas.nasUpload.mock.calls.map(c => c[0]);
-    expect(uploadPaths).toContain(`${NAS_BACKUP_DIR}/adguard.tar`);
-    expect(uploadPaths).toContain(`${NAS_BACKUP_DIR}/adguard.tar.meta.json`);
+    expect(uploadPaths).toContain(`${NAS_BACKUP_DIR}/${result.tarName}`);
+    expect(uploadPaths).toContain(`${NAS_BACKUP_DIR}/${result.metaName}`);
 
     const metaCall = mockNas.nasUpload.mock.calls.find(c => c[0].endsWith('.meta.json'))!;
     const metaJson = JSON.parse((metaCall[1] as Buffer).toString('utf8'));
@@ -448,18 +459,41 @@ describe('backupServiceToNas', () => {
 });
 
 describe('read-back', () => {
-  it('lists only .tar entries and derives the service name', async () => {
+  it('lists dated snapshots grouped per service (newest first), drops sidecars, keeps bare legacy slots (#1865)', async () => {
     mockNas.nasList.mockResolvedValue([
-      { name: 'hermes.tar', size: 100 },
-      { name: 'hermes.tar.meta.json', size: 20 },
-      { name: 'adguard.tar', size: 50 },
+      { name: 'home-assistant-20260615-0531.tar', size: 100 },
+      { name: 'home-assistant-20260615-0531.tar.meta.json', size: 20 }, // sidecar — not a snapshot
+      { name: 'home-assistant-20260614-0530.tar', size: 90 },
+      { name: 'adguard.tar', size: 50 }, // bare legacy single-slot — still listable
     ]);
     const list = await listServiceBackups();
     expect(list).toEqual([
-      { service: 'adguard', tarName: 'adguard.tar', size: 50 },
-      { service: 'hermes', tarName: 'hermes.tar', size: 100 },
+      // adguard (A→Z) first; its bare slot has a null stamp.
+      { service: 'adguard', tarName: 'adguard.tar', size: 50, stamp: null },
+      // home-assistant newest snapshot first.
+      { service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 100, stamp: '20260615-0531' },
+      { service: 'home-assistant', tarName: 'home-assistant-20260614-0530.tar', size: 90, stamp: '20260614-0530' },
     ]);
     expect(mockNas.nasList).toHaveBeenCalledWith(NAS_BACKUP_DIR);
+  });
+
+  it('latestServiceBackupName resolves the most-recent dated slot, preferring it over a bare legacy slot (#1865)', async () => {
+    mockNas.nasList.mockResolvedValue([
+      { name: 'home-assistant.tar', size: 10 }, // bare legacy — oldest
+      { name: 'home-assistant-20260614-0530.tar', size: 90 },
+      { name: 'home-assistant-20260615-0531.tar', size: 100 },
+    ]);
+    expect(await latestServiceBackupName('home-assistant')).toBe('home-assistant-20260615-0531.tar');
+  });
+
+  it('latestServiceBackupName falls back to a bare legacy slot when it is the only snapshot (#1865)', async () => {
+    mockNas.nasList.mockResolvedValue([{ name: 'adguard.tar', size: 50 }]);
+    expect(await latestServiceBackupName('adguard')).toBe('adguard.tar');
+  });
+
+  it('latestServiceBackupName returns null when the service has no backup', async () => {
+    mockNas.nasList.mockResolvedValue([{ name: 'adguard.tar', size: 50 }]);
+    expect(await latestServiceBackupName('home-assistant')).toBeNull();
   });
 
   it('fetches a tar plus its parsed meta sidecar', async () => {
@@ -492,6 +526,100 @@ describe('read-back', () => {
   });
 });
 
+describe('dated rotation + retention pruning (#1865)', () => {
+  // Back the NAS mock with an in-memory store so multiple backup runs accumulate
+  // dated slots and pruning actually removes the oldest, end-to-end.
+  let store: Map<string, Buffer>;
+  beforeEach(() => {
+    store = new Map();
+    mockNas.nasUpload.mockImplementation(async (p: string, data: Buffer) => { store.set(p, Buffer.from(data)); });
+    mockNas.nasList.mockImplementation(async (dir = '') => {
+      const prefix = dir ? `${dir}/` : '';
+      return [...store.entries()].filter(([k]) => k.startsWith(prefix)).map(([k, v]) => ({ name: k.slice(prefix.length), size: v.length }));
+    });
+    mockNas.nasRemove.mockImplementation(async (p: string) => { store.delete(p); });
+  });
+
+  /** The dated tar slots (no sidecars) currently in the store, for a service. */
+  function slots(service: string): string[] {
+    return [...store.keys()]
+      .map(k => k.slice(`${NAS_BACKUP_DIR}/`.length))
+      .filter(n => new RegExp(`^${service}-\\d{8}-\\d{4}\\.tar$`).test(n))
+      .sort();
+  }
+
+  it('each backup run writes a NEW dated file rather than overwriting one slot', async () => {
+    const tar = Buffer.alloc(1024, 1);
+    // Three runs at distinct minutes — distinct dated slots, none overwritten.
+    vi.useFakeTimers();
+    try {
+      for (const t of ['2026-06-13T05:31:00Z', '2026-06-14T05:31:00Z', '2026-06-15T05:31:00Z']) {
+        vi.setSystemTime(new Date(t));
+        await stageUploadedServiceTar('adguard', tar);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(slots('adguard')).toEqual([
+      'adguard-20260613-0531.tar',
+      'adguard-20260614-0531.tar',
+      'adguard-20260615-0531.tar',
+    ]);
+  });
+
+  it('prunes the oldest snapshots beyond the configured retention (keep N), removing sidecars too', async () => {
+    mockGetConfig.mockResolvedValue({ templateSettings: {}, externalBackup: { enabled: true, retention: 2 } });
+    const tar = Buffer.alloc(1024, 2);
+    vi.useFakeTimers();
+    try {
+      for (const t of ['2026-06-12T05:31:00Z', '2026-06-13T05:31:00Z', '2026-06-14T05:31:00Z', '2026-06-15T05:31:00Z']) {
+        vi.setSystemTime(new Date(t));
+        await stageUploadedServiceTar('adguard', tar);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+    // Only the 2 most-recent remain; older ones AND their sidecars are gone.
+    expect(slots('adguard')).toEqual(['adguard-20260614-0531.tar', 'adguard-20260615-0531.tar']);
+    expect(store.has(`${NAS_BACKUP_DIR}/adguard-20260612-0531.tar`)).toBe(false);
+    expect(store.has(`${NAS_BACKUP_DIR}/adguard-20260612-0531.tar.meta.json`)).toBe(false);
+  });
+
+  it('a bare legacy <service>.tar is pruned first (sorts oldest) once retention is reached', async () => {
+    mockGetConfig.mockResolvedValue({ templateSettings: {}, externalBackup: { enabled: true, retention: 1 } });
+    // Seed a pre-#1865 single slot, then one dated run with retention 1.
+    store.set(`${NAS_BACKUP_DIR}/adguard.tar`, Buffer.alloc(512, 9));
+    store.set(`${NAS_BACKUP_DIR}/adguard.tar.meta.json`, Buffer.from('{}'));
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-06-15T05:31:00Z'));
+      await stageUploadedServiceTar('adguard', Buffer.alloc(1024, 3));
+    } finally {
+      vi.useRealTimers();
+    }
+    // The bare legacy slot is gone; only the new dated snapshot survives.
+    expect(store.has(`${NAS_BACKUP_DIR}/adguard.tar`)).toBe(false);
+    expect(slots('adguard')).toEqual(['adguard-20260615-0531.tar']);
+  });
+
+  it('defaults retention to DEFAULT_BACKUP_RETENTION when unset', async () => {
+    expect(DEFAULT_BACKUP_RETENTION).toBe(7);
+    const tar = Buffer.alloc(1024, 4);
+    vi.useFakeTimers();
+    try {
+      // 9 runs, no retention configured → keep 7, prune 2 oldest.
+      for (let d = 1; d <= 9; d++) {
+        vi.setSystemTime(new Date(`2026-06-${String(d).padStart(2, '0')}T05:31:00Z`));
+        await stageUploadedServiceTar('adguard', tar);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(slots('adguard')).toHaveLength(DEFAULT_BACKUP_RETENTION);
+    expect(slots('adguard')[0]).toBe('adguard-20260603-0531.tar'); // oldest kept = day 3
+  });
+});
+
 describe('manifest integration', () => {
   it('the real adguard manifest excludes querylog while keeping the config', async () => {
     const src = await mkTmp();
@@ -509,11 +637,12 @@ describe('stageUploadedServiceTar', () => {
     const res = await stageUploadedServiceTar('adguard', tar);
 
     const paths = mockNas.nasUpload.mock.calls.map(c => c[0]);
-    expect(paths).toContain(`${NAS_BACKUP_DIR}/adguard.tar`);
-    expect(paths).toContain(`${NAS_BACKUP_DIR}/adguard.tar.meta.json`);
-    expect(res.tarName).toBe('adguard.tar');
+    // #1865 — dated slot, not a single overwritten adguard.tar.
+    expect(res.tarName).toMatch(/^adguard-\d{8}-\d{4}\.tar$/);
+    expect(paths).toContain(`${NAS_BACKUP_DIR}/${res.tarName}`);
+    expect(paths).toContain(`${NAS_BACKUP_DIR}/${res.tarName}.meta.json`);
 
-    const tarCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('/adguard.tar'))!;
+    const tarCall = mockNas.nasUpload.mock.calls.find(c => datedTarRe('adguard').test(String(c[0])))!;
     expect(tarCall[1]).toEqual(tar); // bytes passed through unchanged
     const metaCall = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('.meta.json'))!;
     expect(JSON.parse(String(metaCall[1])).service).toBe('adguard');

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -24,7 +24,7 @@ import { getConfig } from '../config';
 import { logger } from '../logger';
 import { agentManager } from '../agent/manager';
 import { getExecutor, type Executor } from '../executor';
-import { nasUpload, nasDownload, nasList } from './nasClient';
+import { nasUpload, nasDownload, nasList, nasRemove } from './nasClient';
 import {
   getServiceManifest,
   getBackupGate,
@@ -44,6 +44,46 @@ const DEFAULT_STACKS_DIR = '/mnt/data/stacks';
 
 /** Sidecar schema version — bump when the meta shape changes. */
 const META_SCHEMA_VERSION = 1;
+
+/**
+ * How many dated snapshots to keep per service when none is configured (#1865).
+ * The producer writes a new dated slot per run and prunes the oldest beyond this
+ * — bounded so the NAS can't fill, but deep enough that a silently-corrupted run
+ * (the HA empty-automations incident) still has a healthy prior copy to recover.
+ */
+export const DEFAULT_BACKUP_RETENTION = 7;
+
+/**
+ * Match a dated snapshot slot `<service>-YYYYMMDD-HHMM.tar` (#1865) and a bare
+ * legacy single-slot `<service>.tar` (pre-#1865 backups, kept restorable so no
+ * existing backup goes invisible). A service name may itself contain hyphens
+ * (`home-assistant`), so the date stamp is anchored to the END of the name.
+ */
+const DATED_TAR_RE = /^(.+)-(\d{8}-\d{4})\.tar$/;
+const BARE_TAR_RE = /^(.+)\.tar$/;
+
+/** Format `Date` → the `YYYYMMDD-HHMM` UTC stamp used in a dated slot name. */
+function backupStamp(when: Date): string {
+  const p = (n: number, w = 2) => String(n).padStart(w, '0');
+  return (
+    `${when.getUTCFullYear()}${p(when.getUTCMonth() + 1)}${p(when.getUTCDate())}` +
+    `-${p(when.getUTCHours())}${p(when.getUTCMinutes())}`
+  );
+}
+
+/**
+ * Parse a NAS tar filename into its service + (optional) dated stamp. A dated
+ * slot resolves both; a bare legacy `<service>.tar` resolves the service with a
+ * null stamp (so it sorts as the oldest / a valid undated snapshot). A non-tar
+ * name returns null.
+ */
+function parseSlotName(name: string): { service: string; stamp: string | null } | null {
+  const dated = DATED_TAR_RE.exec(name);
+  if (dated) return { service: dated[1], stamp: dated[2] };
+  const bare = BARE_TAR_RE.exec(name);
+  if (bare) return { service: bare[1], stamp: null };
+  return null;
+}
 
 export interface ServiceBackupMeta {
   service: string;
@@ -68,6 +108,9 @@ export interface ServiceBackupListEntry {
   service: string;
   tarName: string;
   size: number;
+  /** The `YYYYMMDD-HHMM` UTC stamp parsed from a dated slot, or null for a bare
+   *  legacy `<service>.tar` (pre-#1865). Lets the UI label / order snapshots. */
+  stamp: string | null;
 }
 
 async function pathExists(target: string): Promise<boolean> {
@@ -560,20 +603,63 @@ export function scheduleExternalNasBackup(): void {
     });
 }
 
+/** Resolve the per-service retention (keep N most-recent) from config (#1865). */
+async function getBackupRetention(): Promise<number> {
+  const configured = (await getConfig()).externalBackup?.retention;
+  return typeof configured === 'number' && configured > 0 ? Math.floor(configured) : DEFAULT_BACKUP_RETENTION;
+}
+
 /**
- * Write an already-built `<service>.tar` buffer to the NAS in the canonical
- * restore layout (`sb-backup/<service>.tar` + `.meta.json`). Shared by the
- * dir-based producer (`backupServiceToNas`) and the upload route (#1351) so the
- * on-NAS format has a single source of truth.
+ * Prune dated snapshots for ONE service down to the `keep` most-recent (#1865),
+ * removing each pruned tar's `.meta.json` sidecar too. A bare legacy
+ * `<service>.tar` (pre-#1865) sorts oldest, so once `keep` dated slots exist it
+ * is the first to be pruned — the rotated history supersedes the single slot.
+ * Best-effort: a prune failure is logged, never thrown (it must not fail a
+ * successful backup). Returns the names pruned.
+ */
+async function pruneServiceBackups(service: string, keep: number): Promise<string[]> {
+  try {
+    const all = await listServiceBackups();
+    const mine = all
+      .filter(b => b.service === service)
+      // Newest first: a real dated stamp beats a bare (null) slot; ties (only
+      // possible across bare vs the impossible duplicate stamp) keep bare last.
+      .sort((a, b) => (b.stamp ?? '').localeCompare(a.stamp ?? ''));
+    const stale = mine.slice(keep);
+    const pruned: string[] = [];
+    for (const entry of stale) {
+      await nasRemove(path.posix.join(NAS_BACKUP_DIR, entry.tarName));
+      await nasRemove(path.posix.join(NAS_BACKUP_DIR, `${entry.tarName}.meta.json`));
+      pruned.push(entry.tarName);
+    }
+    if (pruned.length > 0) {
+      logger.info('ExternalBackup', `Pruned ${pruned.length} old ${service} backup(s): ${pruned.join(', ')}`);
+    }
+    return pruned;
+  } catch (e) {
+    logger.warn('ExternalBackup', `Retention prune for "${service}" failed: ${e instanceof Error ? e.message : String(e)}`);
+    return [];
+  }
+}
+
+/**
+ * Write an already-built `<service>.tar` buffer to the NAS as a NEW dated slot
+ * (`sb-backup/<service>-YYYYMMDD-HHMM.tar` + `.meta.json`) rather than
+ * overwriting one slot, then prune to the retention policy (#1865). Keeping
+ * dated/rotated copies is what lets a restore recover from a silently-corrupted
+ * run (the HA empty-automations incident) instead of only the latest state.
+ * Shared by the dir-based producer (`backupServiceToNas`) and the upload route
+ * (#1351) so the on-NAS format has a single source of truth.
  */
 async function writeServiceBackupToNas(service: string, tar: Buffer): Promise<ServiceBackupResult> {
+  const now = new Date();
   const meta: ServiceBackupMeta = {
     service,
     schemaVersion: META_SCHEMA_VERSION,
-    createdAt: new Date().toISOString(),
+    createdAt: now.toISOString(),
     nodeId: os.hostname(),
   };
-  const tarName = `${service}.tar`;
+  const tarName = `${service}-${backupStamp(now)}.tar`;
   const metaName = `${tarName}.meta.json`;
 
   await nasUpload(path.posix.join(NAS_BACKUP_DIR, tarName), tar);
@@ -583,6 +669,7 @@ async function writeServiceBackupToNas(service: string, tar: Buffer): Promise<Se
   );
 
   logger.info('ExternalBackup', `Wrote ${tarName} to NAS (${tar.length} bytes)`);
+  await pruneServiceBackups(service, await getBackupRetention());
   return { service, tarName, metaName, size: tar.length, meta };
 }
 
@@ -606,13 +693,39 @@ export async function stageUploadedServiceTar(service: string, tar: Buffer): Pro
   return writeServiceBackupToNas(service, tar);
 }
 
-/** List the service backups currently on the NAS. */
+/**
+ * List the service backups currently on the NAS — one entry per dated snapshot
+ * (#1865), newest first within each service, services A→Z. A bare legacy
+ * `<service>.tar` (pre-#1865) is surfaced as a valid undated snapshot
+ * (`stamp: null`) so no existing backup goes invisible. Sidecar `.meta.json`
+ * files are not snapshots and are filtered out.
+ */
 export async function listServiceBackups(): Promise<ServiceBackupListEntry[]> {
   const files = await nasList(NAS_BACKUP_DIR);
   return files
-    .filter(f => f.name.endsWith('.tar'))
-    .map(f => ({ service: f.name.replace(/\.tar$/, ''), tarName: f.name, size: f.size }))
-    .sort((a, b) => a.service.localeCompare(b.service));
+    .filter(f => f.name.endsWith('.tar')) // drops `.tar.meta.json` sidecars
+    .map(f => {
+      const parsed = parseSlotName(f.name);
+      return parsed ? { service: parsed.service, tarName: f.name, size: f.size, stamp: parsed.stamp } : null;
+    })
+    .filter((e): e is ServiceBackupListEntry => e !== null)
+    .sort((a, b) =>
+      a.service !== b.service
+        ? a.service.localeCompare(b.service)
+        : (b.stamp ?? '').localeCompare(a.stamp ?? ''), // newest snapshot first
+    );
+}
+
+/**
+ * Resolve the most-recent snapshot tarName for a service from the NAS listing
+ * (#1865) — the "restore latest" default. Returns null when the service has no
+ * backup on the NAS. A dated slot always wins over a bare legacy `<service>.tar`
+ * (which sorts oldest); with only the bare slot present it resolves to that, so
+ * existing single-slot backups stay restorable.
+ */
+export async function latestServiceBackupName(service: string): Promise<string | null> {
+  const mine = (await listServiceBackups()).filter(b => b.service === service);
+  return mine.length > 0 ? mine[0].tarName : null; // listing is already newest-first
 }
 
 /**

--- a/packages/backend/src/lib/externalBackup/registerSource.test.ts
+++ b/packages/backend/src/lib/externalBackup/registerSource.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
   // Default: no destination resolves (not configured). Configured tests below
   // set a non-null resolved target.
   mockResolveTarget.mockResolvedValue(null);
-  mockListBackups.mockResolvedValue([{ service: 'home-assistant', tarName: 'home-assistant.tar', size: 2_340_000 }]);
+  mockListBackups.mockResolvedValue([{ service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 2_340_000, stamp: '20260615-0531' }]);
 });
 
 const FTP_TARGET = { transport: 'ftp', host: '192.168.178.1', user: 'fritz9746', password: 'pw', secure: false };
@@ -96,7 +96,7 @@ describe('getNasBackupOverview', () => {
     const o = await getNasBackupOverview();
     expect(o.configured).toBe(true);
     expect(o.connection).toEqual({ ok: true });
-    expect(o.backups).toEqual([{ service: 'home-assistant', tarName: 'home-assistant.tar', size: 2_340_000 }]);
+    expect(o.backups).toEqual([{ service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 2_340_000, stamp: '20260615-0531' }]);
   });
 
   it('surfaces a connection failure with no backups', async () => {

--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -55,6 +55,11 @@ beforeEach(async () => {
   vi.clearAllMocks();
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'restore-test-'));
   mockCfg.getConfig.mockResolvedValue({ templateSettings: { DATA_DIR: tmpRoot } });
+  // #1865 — restore now resolves the latest snapshot from the listing. Default
+  // to advertising the bare legacy slot (a valid undated snapshot) so the
+  // existing backward-compat restore tests resolve it; tests asserting dated
+  // snapshot selection override this.
+  mockNas.nasList.mockResolvedValue([{ name: 'home-assistant.tar', size: 1024 }]);
   // HA config lives one level down under home-assistant/homeassistant/ (the
   // container's /config) — the manifest dataSubdir (#1597). Restore extracts
   // the producer's bare-rooted tar into exactly this dir.
@@ -100,6 +105,55 @@ describe('restoreServiceBackup', () => {
 
   it('rejects a service with no backup manifest', async () => {
     await expect(restoreServiceBackup('not-a-service')).rejects.toThrow(/No backup manifest/);
+  });
+
+  it('defaults to the MOST-RECENT dated snapshot when no tarName is given (#1865)', async () => {
+    // Two dated snapshots on the NAS — the newer carries the good config, the
+    // older the (later-corrupted) state. Default restore picks the newest.
+    mockNas.nasList.mockResolvedValue([
+      { name: 'home-assistant-20260614-0530.tar', size: 50 },
+      { name: 'home-assistant-20260615-0531.tar', size: 60 },
+    ]);
+    mockNas.nasDownload.mockImplementation(async (p: string) => {
+      if (p === `${NAS_BACKUP_DIR}/home-assistant-20260615-0531.tar`) {
+        return buildServiceTar({ 'configuration.yaml': 'latest:' });
+      }
+      throw new Error(`unexpected download ${p}`);
+    });
+    const res = await restoreServiceBackup('home-assistant', { local: true });
+    expect(res.files).toBe(1);
+    expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('latest:');
+  });
+
+  it('restores a SPECIFIC older snapshot when tarName is given — the recover-from-before-corruption path (#1865)', async () => {
+    mockNas.nasList.mockResolvedValue([
+      { name: 'home-assistant-20260614-0530.tar', size: 50 }, // the good pre-corruption copy
+      { name: 'home-assistant-20260615-0531.tar', size: 60 }, // the corrupted latest
+    ]);
+    mockNas.nasDownload.mockImplementation(async (p: string) => {
+      if (p === `${NAS_BACKUP_DIR}/home-assistant-20260614-0530.tar`) {
+        return buildServiceTar({ 'automations.yaml': '- alias: front door\n' });
+      }
+      throw new Error(`unexpected download ${p}`);
+    });
+    const res = await restoreServiceBackup('home-assistant', { local: true, tarName: 'home-assistant-20260614-0530.tar' });
+    expect(res.files).toBe(1);
+    expect(await fs.readFile(path.join(dataDir, 'automations.yaml'), 'utf8')).toBe('- alias: front door\n');
+  });
+
+  it('rejects a tarName that does not belong to the service (no cross-service restore) (#1865)', async () => {
+    mockNas.nasList.mockResolvedValue([
+      { name: 'home-assistant-20260615-0531.tar', size: 60 },
+      { name: 'adguard-20260615-0531.tar', size: 30 },
+    ]);
+    await expect(
+      restoreServiceBackup('home-assistant', { local: true, tarName: 'adguard-20260615-0531.tar' }),
+    ).rejects.toThrow(/No backup snapshot/);
+  });
+
+  it('errors clearly when the service has no snapshot on the NAS (#1865)', async () => {
+    mockNas.nasList.mockResolvedValue([{ name: 'adguard.tar', size: 30 }]);
+    await expect(restoreServiceBackup('home-assistant', { local: true })).rejects.toThrow(/No config backup found/);
   });
 });
 
@@ -253,9 +307,11 @@ describe('wipeServiceForReinstall (#1585)', () => {
 });
 
 describe('NPM credential reconcile after restore (#1529)', () => {
-  /** Serve an nginx.tar (restored into tmpRoot/nginx-proxy-manager). */
+  /** Serve an nginx.tar (restored into tmpRoot/nginx-proxy-manager). The bare
+   *  slot is a valid undated snapshot the latest-resolver finds (#1865). */
   async function serveNginxTar() {
     const tar = await buildServiceTar({ 'data/database.sqlite': 'RESTORED-DB' });
+    mockNas.nasList.mockResolvedValue([{ name: 'nginx.tar', size: tar.length }]);
     mockNas.nasDownload.mockImplementation(async (p: string) => {
       if (p === `${NAS_BACKUP_DIR}/nginx.tar`) return tar;
       throw new Error('not found');

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -18,7 +18,13 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { fetchServiceBackup, listServiceBackups, resolveServiceDataDir, type ServiceBackupMeta } from './producer';
+import {
+  fetchServiceBackup,
+  latestServiceBackupName,
+  listServiceBackups,
+  resolveServiceDataDir,
+  type ServiceBackupMeta,
+} from './producer';
 import { getServiceManifest, getConfigPaths } from './serviceManifest';
 import { safeTarExtract, extractServiceConfigToNode } from '../systemBackup';
 import { getExecutor, type Executor } from '../executor';
@@ -209,13 +215,19 @@ export async function isFreshDataDir(dir: string): Promise<boolean> {
 }
 
 /**
- * Restore `<service>.tar` from the NAS into the service's data dir.
- * Refuses a non-empty data dir unless `force` is set. Returns the data dir,
- * the number of files restored, and the backup's meta sidecar (if present).
+ * Restore a service's config backup from the NAS into its data dir. By default
+ * restores the MOST-RECENT dated snapshot (#1865); pass `tarName` to restore a
+ * specific snapshot instead (the "restore a chosen one" path — recover from
+ * BEFORE a silently-corrupted run, not just the latest state). A bare legacy
+ * `<service>.tar` (pre-#1865) is a valid snapshot and resolves as latest when
+ * it's the only one — existing single-slot backups stay restorable.
+ *
+ * Refuses a non-empty data dir unless `force` is set. Returns the data dir, the
+ * number of files restored, and the backup's meta sidecar (if present).
  */
 export async function restoreServiceBackup(
   service: string,
-  opts: { force?: boolean; node?: string | null; local?: boolean } = {},
+  opts: { force?: boolean; node?: string | null; local?: boolean; tarName?: string } = {},
 ): Promise<RestoreResult> {
   if (!getServiceManifest(service)) {
     throw new Error(`No backup manifest for service "${service}"`);
@@ -231,7 +243,24 @@ export async function restoreServiceBackup(
     );
   }
 
-  const { tar, meta } = await fetchServiceBackup(`${service}.tar`);
+  // A specific snapshot when asked; otherwise default to the most-recent one.
+  // A requested tarName must belong to this service (and exist), so a caller
+  // can't restore one service's snapshot into another's data dir.
+  let tarName = opts.tarName;
+  if (tarName) {
+    const known = (await listServiceBackups()).find(b => b.service === service && b.tarName === tarName);
+    if (!known) {
+      throw new Error(`No backup snapshot "${tarName}" on the NAS for service "${service}"`);
+    }
+  } else {
+    const latest = await latestServiceBackupName(service);
+    if (!latest) {
+      throw new Error(`No config backup found on the NAS for service "${service}"`);
+    }
+    tarName = latest;
+  }
+
+  const { tar, meta } = await fetchServiceBackup(tarName);
   await backend.extractTar(tar, dataDir);
 
   const files = await backend.countFiles(dataDir);

--- a/packages/backend/src/lib/services/serviceLifecycle.homeAssistantHook.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.homeAssistantHook.test.ts
@@ -53,6 +53,13 @@ function makeHaAgent(initialFiles: Record<string, string>) {
                 return { code: 0 };
             }
 
+            // cat <path> 2>/dev/null || echo MISSING  (integrity-guard reads)
+            m = cmd.match(/^cat (\S+) 2>\/dev\/null \|\| echo MISSING$/);
+            if (m) {
+                const body = files[m[1]];
+                return { code: 0, stdout: body !== undefined ? body : 'MISSING' };
+            }
+
             return { code: 0, stdout: '' };
         }),
     };
@@ -114,5 +121,68 @@ describe('runHomeAssistantHook (#1687 config-survival self-heal)', () => {
         // Only the existence probe ran; no append/seed.
         expect(agent.calls).toEqual([`test -f ${CFG} && echo yes`]);
         expect(agent.files[CFG]).toBeUndefined();
+    });
+
+    const REGISTRY = `${DIR}/.storage/core.entity_registry`;
+    const fullCfg = [
+        'default_config:',
+        'automation: !include automations.yaml',
+        'script: !include scripts.yaml',
+        'scene: !include scenes.yaml',
+        'http:',
+        '  use_x_forwarded_for: true',
+        '',
+    ].join('\n');
+
+    it('#1864: ABORTS loudly when the registry lists automations but automations.yaml is empty', async () => {
+        const agent = makeHaAgent({
+            [CFG]: fullCfg,
+            // Registry remembers 2 automations…
+            [REGISTRY]: JSON.stringify({
+                data: {
+                    entities: [
+                        { platform: 'automation', entity_id: 'automation.morning' },
+                        { platform: 'automation', entity_id: 'automation.night' },
+                        { platform: 'sun', entity_id: 'sun.sun' },
+                    ],
+                },
+            }),
+            // …but the file was emptied (the incident).
+            [`${DIR}/automations.yaml`]: '[]',
+            [`${DIR}/scripts.yaml`]: '{}',
+            [`${DIR}/scenes.yaml`]: '[]',
+        });
+
+        await expect(ServiceLifecycle.runHomeAssistantHook(agent as never, CFG)).rejects.toThrow(
+            /integrity check FAILED/i,
+        );
+        // The guard must NOT mutate the emptied file.
+        expect(agent.files[`${DIR}/automations.yaml`]).toBe('[]');
+    });
+
+    it('#1864: passes silently when registry counts match the populated config files', async () => {
+        const agent = makeHaAgent({
+            [CFG]: fullCfg,
+            [REGISTRY]: JSON.stringify({
+                data: { entities: [{ platform: 'automation', entity_id: 'automation.morning' }] },
+            }),
+            [`${DIR}/automations.yaml`]: '- id: morning\n  alias: Morning\n',
+            [`${DIR}/scripts.yaml`]: '{}',
+            [`${DIR}/scenes.yaml`]: '[]',
+        });
+
+        await expect(
+            ServiceLifecycle.runHomeAssistantHook(agent as never, CFG),
+        ).resolves.toBeUndefined();
+    });
+
+    it('#1864: does not raise when there is no entity registry yet', async () => {
+        const agent = makeHaAgent({
+            [CFG]: fullCfg,
+            [`${DIR}/automations.yaml`]: '[]',
+        });
+        await expect(
+            ServiceLifecycle.runHomeAssistantHook(agent as never, CFG),
+        ).resolves.toBeUndefined();
     });
 });

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -1230,6 +1230,130 @@ export class ServiceLifecycle {
             const block = `${inc.key} !include ${inc.file}`;
             await ServiceLifecycle.appendYamlKeyIfMissing(agent, cfgFile, inc.key, block, `${inc.key} !include`);
         }
+
+        // Integrity guard (#1864): refuse-and-shout when the entity registry
+        // says HA owns N>0 automation/script/scene entities but the include
+        // target file parses to 0 entries. That mismatch is the fingerprint of
+        // the data-loss incident — a restore (or a bad write) left an empty
+        // `automations.yaml` while the registry still references the
+        // automations, so HA would silently start with every automation gone.
+        // The guard does NOT mutate or delete anything: its job is to ABORT
+        // the hook (and therefore the deploy) loudly rather than let HA come
+        // up on top of a hollowed-out config that overwrites the only copy.
+        await ServiceLifecycle.assertHaConfigIntegrity(agent, includeDir, includes);
+    }
+
+    /**
+     * Count entity-registry entries for a given `platform` (e.g. `automation`,
+     * `script`, `scene`). The registry lives at `<config>/.storage/
+     * core.entity_registry` and is JSON of the shape
+     * `{ data: { entities: [{ platform: 'automation', ... }, ...] } }`.
+     * Missing/unreadable/unparseable registry → 0 (we only ever *raise* an
+     * alarm on a positive registry count, so an absent registry is silent).
+     */
+    private static countRegistryPlatformEntries(
+        registryJson: string,
+        platform: string,
+    ): number {
+        try {
+            const parsed = JSON.parse(registryJson) as {
+                data?: { entities?: Array<{ platform?: string }> };
+            };
+            const entities = parsed?.data?.entities;
+            if (!Array.isArray(entities)) return 0;
+            return entities.filter((e) => e?.platform === platform).length;
+        } catch {
+            return 0;
+        }
+    }
+
+    /**
+     * Parse a HA include target file (`automations.yaml` / `scripts.yaml` /
+     * `scenes.yaml`) and return the number of defined entries. Automations and
+     * scenes are YAML lists (`[]` → 0); scripts are a YAML mapping (`{}` → 0).
+     * A blank/missing file is 0. Unparseable content returns `null` so the
+     * caller can avoid raising a false mismatch on a file it can't read.
+     */
+    private static parseHaEntryCount(content: string): number | null {
+        const trimmed = content.trim();
+        if (trimmed === '') return 0;
+        let doc: unknown;
+        try {
+            doc = yaml.load(content);
+        } catch {
+            return null;
+        }
+        if (doc === null || doc === undefined) return 0;
+        if (Array.isArray(doc)) return doc.length;
+        if (typeof doc === 'object') return Object.keys(doc as object).length;
+        // A scalar (shouldn't happen for these files) — treat as unparseable.
+        return null;
+    }
+
+    /**
+     * #1864 integrity guard. Reads the HA entity registry and each include
+     * target file from the host (via the agent) and THROWS — aborting the
+     * pre-start hook and the deploy — when the registry lists N>0 entities of
+     * a platform but the corresponding config file parses to 0 entries. It
+     * never writes, deletes, or repairs anything; the only side effect is a
+     * loud log + a structured Error so the operator notices BEFORE HA starts
+     * on top of an emptied config.
+     */
+    private static async assertHaConfigIntegrity(
+        agent: import('../agent/handler').AgentHandler,
+        includeDir: string,
+        includes: { key: string; file: string; seed: string; platform?: string }[],
+    ): Promise<void> {
+        const registryPath = `${includeDir}/.storage/core.entity_registry`;
+        const regRes = await agent.sendCommand('exec', {
+            command: `cat ${registryPath} 2>/dev/null || echo MISSING`,
+        });
+        const registryJson = regRes.stdout ?? '';
+        // No registry yet (fresh install / first boot) → nothing to compare.
+        if (registryJson.trim() === '' || registryJson.trim() === 'MISSING') return;
+
+        // platform name per include file (drop the trailing `:` from the key).
+        const platformFor: Record<string, string> = {
+            'automations.yaml': 'automation',
+            'scripts.yaml': 'script',
+            'scenes.yaml': 'scene',
+        };
+
+        const mismatches: string[] = [];
+        for (const inc of includes) {
+            const platform = platformFor[inc.file];
+            if (!platform) continue;
+            const registered = ServiceLifecycle.countRegistryPlatformEntries(registryJson, platform);
+            if (registered === 0) continue;
+
+            const fileRes = await agent.sendCommand('exec', {
+                command: `cat ${includeDir}/${inc.file} 2>/dev/null || echo MISSING`,
+            });
+            const raw = fileRes.stdout ?? '';
+            // A genuinely missing file (the include target should always exist
+            // after the seed loop above, but a race or manual delete is the
+            // same hazard) is treated as 0 entries.
+            const content = raw.trim() === 'MISSING' ? '' : raw;
+            const parsed = ServiceLifecycle.parseHaEntryCount(content);
+            // null = unparseable; don't raise a false alarm on a file we can't
+            // read (HA itself would error on it, which is its own signal).
+            if (parsed === null) continue;
+            if (parsed === 0) {
+                mismatches.push(
+                    `${inc.file}: registry lists ${registered} ${platform} entit${registered === 1 ? 'y' : 'ies'} but the file parses to 0 entries`,
+                );
+            }
+        }
+
+        if (mismatches.length > 0) {
+            const summary = mismatches.join('; ');
+            const message =
+                `HA config integrity check FAILED — refusing to start Home Assistant on top of an emptied config. ${summary}. ` +
+                `This is the fingerprint of the automations/scripts/scenes data-loss incident: the entity registry still references these entities but their config file is empty, so starting HA would let it overwrite the only remaining copy. ` +
+                `ServiceBay has NOT modified or deleted anything. Restore ${includeDir} from a backup (or confirm the data really was removed) before redeploying.`;
+            logger.error('ServiceManager', message);
+            throw new Error(message);
+        }
     }
 
     private static async runPreStartHooks(nodeName: string, name: string, yamlContent: string) {

--- a/packages/frontend/src/app/(dashboard)/settings/backups/_lib/useBackupState.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/_lib/useBackupState.ts
@@ -100,7 +100,8 @@ export function useBackupState() {
   const [nasOverview, setNasOverview] = useState<{
     configured: boolean;
     connection: { ok: true } | { ok: false; error: string } | null;
-    backups: { service: string; tarName: string; size: number }[];
+    // `stamp` is the dated-snapshot timestamp (null for a bare legacy slot, #1865).
+    backups: { service: string; tarName: string; size: number; stamp?: string | null }[];
   } | null>(null);
   const [nasLoading, setNasLoading] = useState(true);
   const [nasRestoring, setNasRestoring] = useState<string | null>(null);

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -102,7 +102,9 @@ export default function BackupsSettingsPage() {
       const res = await fetch('/api/system/external-backup/restore', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ service }),
+        // Restore the SPECIFIC snapshot the operator picked (#1865), not just
+        // the latest — recovering from before a silently-corrupted run.
+        body: JSON.stringify({ service, tarName }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error || 'Restore failed');

--- a/packages/frontend/src/app/api/system/external-backup/restore/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/restore/route.ts
@@ -9,17 +9,22 @@ export const dynamic = 'force-dynamic';
  * POST { service, force? } — restore a service's config backup from the
  * FritzBox NAS back into its data dir (#1218, epic #1190). The consumer half
  * of the backup-survival loop: `import-ha`/`upload`/`export-lldap` put backups
- * on the NAS; this pulls one back. Refuses a non-empty data dir unless `force`
- * is set, so it never clobbers a live service. `tokenScope: 'lifecycle'` so the
- * sb flow can trigger it with a scoped `sb_` token.
+ * on the NAS; this pulls one back. Restores the most-recent dated snapshot by
+ * default; pass `tarName` to restore a specific one (#1865). Refuses a non-empty
+ * data dir unless `force` is set, so it never clobbers a live service.
+ * `tokenScope: 'lifecycle'` so the sb flow can trigger it with a scoped `sb_`
+ * token.
  */
 export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
   try {
-    const body = (await request.json().catch(() => ({}))) as { service?: unknown; force?: unknown };
+    const body = (await request.json().catch(() => ({}))) as { service?: unknown; force?: unknown; tarName?: unknown };
     if (typeof body.service !== 'string' || !body.service) {
       return NextResponse.json({ error: 'service field is required' }, { status: 400 });
     }
-    const result = await restoreServiceBackup(body.service, { force: body.force === true });
+    const result = await restoreServiceBackup(body.service, {
+      force: body.force === true,
+      ...(typeof body.tarName === 'string' && body.tarName ? { tarName: body.tarName } : {}),
+    });
     return NextResponse.json({ ok: true, ...result });
   } catch (e) {
     // Operator-fixable, curated messages (unknown service, non-empty data dir,


### PR DESCRIPTION
## What
Two fixes from the HA automations data-loss incident. (1) `runHomeAssistantHook` now aborts loudly when `automations.yaml`/`scripts.yaml`/`scenes.yaml` parses to 0 entries but the HA entity registry lists registered automation/script/scene entities, plus a new `haAutomationIntegrity` diagnose probe that surfaces the mismatch and warns when HA owns entities but no effective NAS/FTP backup target resolves. (2) `writeServiceBackupToNas` now writes dated snapshot slots (`<service>-YYYYMMDD-HHMM.tar`) with retention pruning (default 7) instead of overwriting one slot; `listServiceBackups` enumerates dated snapshots per service, and restore can target a specific snapshot by `tarName` (legacy bare `<service>.tar` stays listable and restorable).

## Why
Closes #1864
Closes #1865

## Risk
Low. serviceLifecycle HA hook only aborts on a genuine registry-vs-empty-file mismatch (no delete/overwrite); backup rotation is additive with backward-compat for legacy single-slot tars.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full, 2555 passed)
- [ ] /verify on FCoS :dev box (no path-mandated files: serviceLifecycle.ts, diagnose/probes/, externalBackup/ are all non-mandated)

AI-generated
<!-- sb-ai-comment -->