### PR TITLE
fix(backups,logger): bound MCP auto-snapshot growth + logs.db retention

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
           "tests/e2e/**/*.e2e.ts"
         ],
         "ignoreDependencies": [
+          "better-sqlite3",
           "lucide-react",
           "react-markdown",
           "socket.io-client"

--- a/packages/backend/src/lib/logger.ts
+++ b/packages/backend/src/lib/logger.ts
@@ -19,6 +19,49 @@ const COLORS = {
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+/**
+ * How many days of log rows to keep in logs.db. Older rows are pruned on
+ * startup and at most once per day thereafter (#1869). Mirrors the 7-day
+ * health-retention window. SQLite does NOT shrink the file on DELETE alone,
+ * so a prune is always followed by a WAL checkpoint + VACUUM.
+ */
+export const LOG_RETENTION_DAYS = 7;
+
+/** Minimum gap between lazy periodic prunes (24h) so VACUUM never runs per-insert. */
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Format a Date as the logger's on-disk timestamp form (`YYYY-MM-DD HH:MM:SS.mmm`,
+ * i.e. ISO with the `T` separator → space and the trailing `Z` removed). The
+ * format is lexicographically ordered, so a string compare against the `timestamp`
+ * column is a valid time comparison.
+ */
+function toLogTimestamp(d: Date): string {
+  return d.toISOString().replace('T', ' ').replace('Z', '');
+}
+
+/**
+ * Delete log rows older than `retentionDays` and reclaim disk space.
+ *
+ * SQLite leaves freed pages in the file after a DELETE, so the 6.4 GB pile
+ * only actually shrinks once we checkpoint the WAL and VACUUM. We only VACUUM
+ * when rows were actually deleted (VACUUM rewrites the whole DB and is
+ * expensive — it must not run on every insert / no-op prune).
+ *
+ * Returns the number of rows deleted.
+ */
+export function pruneLogsDb(db: Database, retentionDays = LOG_RETENTION_DAYS, now: Date = new Date()): number {
+  const cutoff = toLogTimestamp(new Date(now.getTime() - retentionDays * PRUNE_INTERVAL_MS));
+  const info = db.prepare('DELETE FROM logs WHERE timestamp < ?').run(cutoff);
+  const deleted = Number(info.changes);
+  if (deleted > 0) {
+    // Reclaim space: flush + truncate the WAL, then rewrite the DB file.
+    db.pragma('wal_checkpoint(TRUNCATE)');
+    db.exec('VACUUM');
+  }
+  return deleted;
+}
+
 interface LogEntry {
   id?: number;
   timestamp: string;
@@ -51,6 +94,8 @@ class Logger {
   private currentLogLevel: LogLevel = 'info';
   private logLevelPriority: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
   private onLogCallbacks: Set<(entry: LogEntry) => void> = new Set();
+  /** Epoch ms of the last retention prune; gates the lazy periodic prune (#1869). */
+  private lastPruneAt = 0;
 
   constructor() {
     if (isServer) {
@@ -100,6 +145,11 @@ class Logger {
                     this.db!.exec('ALTER TABLE logs ADD COLUMN trace_id TEXT');
                 } catch { /* column already present */ }
                 this.db!.exec('CREATE INDEX IF NOT EXISTS idx_logs_trace ON logs(trace_id, timestamp)');
+
+                // Startup retention prune (#1869): drop rows older than the
+                // retention window + VACUUM. Cuts down the existing multi-GB
+                // logs.db pile on first deploy.
+                this.maybePrune(true);
             } catch (e) {
                 console.error('Failed to initialize SQLite logger:', e);
             }
@@ -171,11 +221,35 @@ class Logger {
 
               // Emit event
               this.onLogCallbacks.forEach(cb => cb(entry));
+
+              // Lazy periodic retention (#1869): at most once per day so the
+              // expensive VACUUM never runs per-insert. The timestamp gate
+              // short-circuits before touching the DB.
+              this.maybePrune();
           } catch (e) {
               console.error('Failed to write log to DB:', e);
           }
       }
       return entry;
+  }
+
+  /**
+   * Run the retention prune at most once per PRUNE_INTERVAL_MS (#1869),
+   * or unconditionally when `force` (the startup prune). The cheap
+   * timestamp check guards the hot insert path so VACUUM is never paid
+   * per-insert; the actual VACUUM inside pruneLogsDb only runs when rows
+   * were deleted.
+   */
+  private maybePrune(force = false): void {
+      if (!this.db) return;
+      const now = Date.now();
+      if (!force && now - this.lastPruneAt < PRUNE_INTERVAL_MS) return;
+      this.lastPruneAt = now;
+      try {
+          pruneLogsDb(this.db);
+      } catch (e) {
+          console.error('Failed to prune logs.db:', e);
+      }
   }
 
   private format(level: LogLevel, tag: string, message: string, args: unknown[]): LogEntry {

--- a/packages/backend/src/lib/mcp/safety.ts
+++ b/packages/backend/src/lib/mcp/safety.ts
@@ -145,14 +145,21 @@ export async function snapshotBeforeMutation(toolName: string, args?: Record<str
   try {
     // Lazy import: keeps the safety module free of the (heavy) backup
     // deps when only the gating helpers are imported.
-    const { createSystemBackup } = await import('@/lib/systemBackup');
+    const { createSystemBackup, autoSnapshotWouldDuplicate } = await import('@/lib/systemBackup');
     const summary = args ? Object.keys(args).slice(0, 4).join(',') : '';
     const label = `pre-mutation:${toolName}${summary ? `(${summary})` : ''}`;
+    // Dedup (#1868): most exec_command calls don't touch config, so skip the
+    // snapshot when the config is byte-identical to the latest auto snapshot.
+    // Mirrors history.ts's latest-snapshot content compare. This keeps the
+    // pre-mutation snapshot pile bounded instead of growing one-per-tool-call.
+    if (await autoSnapshotWouldDuplicate()) {
+      logger.info('mcp:safety', `Snapshot before ${label} skipped (config unchanged vs latest auto snapshot)`);
+      return;
+    }
     logger.info('mcp:safety', `Snapshot before ${label}`);
-    // createSystemBackup ignores extra metadata at the moment; we keep the
-    // label in the log line and rely on the timestamp + adjacency in the
-    // backup list for matching when the user needs to revert.
-    await createSystemBackup();
+    // The snapshot is tagged `auto` (filename suffix `-auto.tar.gz`); these are
+    // the only prune-eligible snapshots (keep newest AUTO_BACKUP_RETENTION).
+    await createSystemBackup('auto');
   } catch (e) {
     logger.warn('mcp:safety', `Pre-mutation snapshot failed (continuing): ${e instanceof Error ? e.message : String(e)}`);
   }

--- a/packages/backend/src/lib/systemBackup.retention.test.ts
+++ b/packages/backend/src/lib/systemBackup.retention.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Covers #1868: persisted `kind` via filename suffix, pre-mutation dedup,
+ * and auto-only retention/prune. Uses a real temp DATA_DIR (mocked `./dirs`)
+ * and real `tar`; mocks the heavy node/service staging deps so the test
+ * exercises only the kind/dedup/prune logic.
+ */
+
+const { dataDir, backupDir } = vi.hoisted(() => {
+    // Runs before static imports init — build paths from string literals only
+    // (no `path`/`os`). TMPDIR covers non-/tmp CI runners.
+    const tmp = (process.env.TMPDIR || '/tmp').replace(/\/+$/, '');
+    const base = `${tmp}/sb-retention-${Date.now()}-${process.pid}`;
+    return { dataDir: base, backupDir: `${base}/backups` };
+});
+
+vi.mock('./dirs', () => ({
+    DATA_DIR: dataDir,
+    SERVICEBAY_BACKUP_DIR: backupDir,
+    SSH_DIR: path.join(dataDir, 'ssh'),
+    getLocalSystemdDir: () => path.join(dataDir, 'no-such-systemd'),
+}));
+
+vi.mock('./nodes', () => ({ listNodes: vi.fn(async () => []) }));
+vi.mock('./config', () => ({ getConfig: vi.fn(async () => ({ installedTemplates: {} })), updateConfig: vi.fn() }));
+// stageServiceConfig pulls these in lazily — return "nothing staged".
+vi.mock('./externalBackup/serviceManifest', () => ({ SERVICE_BACKUP_MANIFESTS: [], getBackupGate: (m: { service: string }) => m.service }));
+vi.mock('./externalBackup/producer', () => ({
+    buildServiceBackupTar: vi.fn(),
+    agentFileBackend: vi.fn(() => ({})),
+    resolveServiceDataDir: vi.fn(),
+    runBackupCollector: vi.fn(),
+}));
+vi.mock('./executor', () => ({ getExecutor: vi.fn(() => ({})) }));
+vi.mock('./ssh/pool', () => ({ SSHConnectionPool: { getInstance: () => ({ getConnection: vi.fn() }) } }));
+
+import {
+    createSystemBackup,
+    listSystemBackups,
+    autoSnapshotWouldDuplicate,
+    AUTO_BACKUP_RETENTION,
+} from './systemBackup';
+
+async function writeConfig(value: string) {
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, 'config.json'), value);
+}
+
+/** Drop a fake snapshot file straight into the backup dir (no real archive). */
+async function seedSnapshot(fileName: string) {
+    await fs.mkdir(backupDir, { recursive: true });
+    await fs.writeFile(path.join(backupDir, fileName), 'x');
+    // Stagger mtimes so newest-first sort is deterministic.
+    await new Promise(r => setTimeout(r, 2));
+}
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    await fs.rm(dataDir, { recursive: true, force: true });
+    await writeConfig('{"version":1}');
+});
+
+afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+});
+
+describe('kind suffix', () => {
+    it('auto snapshots get a -auto suffix, manual get -manual', async () => {
+        const auto = await createSystemBackup('auto');
+        const manual = await createSystemBackup('manual');
+        expect(auto.entry.fileName).toMatch(/-auto\.tar\.gz$/);
+        expect(auto.entry.kind).toBe('auto');
+        expect(manual.entry.fileName).toMatch(/-manual\.tar\.gz$/);
+        expect(manual.entry.kind).toBe('manual');
+    });
+
+    it('listSystemBackups surfaces kind, classifying unsuffixed legacy files as legacy', async () => {
+        await seedSnapshot('servicebay-full-2020-01-01T00-00-00-000Z.tar.gz'); // legacy, no suffix
+        await createSystemBackup('auto');
+        await createSystemBackup('manual');
+        const list = await listSystemBackups();
+        const byKind = (k: string) => list.filter(e => e.kind === k).length;
+        expect(byKind('legacy')).toBe(1);
+        expect(byKind('auto')).toBe(1);
+        expect(byKind('manual')).toBe(1);
+    });
+});
+
+describe('dedup (snapshotBeforeMutation path)', () => {
+    it('skips when config is byte-identical to the latest auto snapshot', async () => {
+        await createSystemBackup('auto');
+        // Config unchanged → a new auto snapshot would duplicate.
+        expect(await autoSnapshotWouldDuplicate()).toBe(true);
+    });
+
+    it('does NOT skip when config changed since the latest auto snapshot', async () => {
+        await createSystemBackup('auto');
+        await writeConfig('{"version":2}');
+        expect(await autoSnapshotWouldDuplicate()).toBe(false);
+    });
+
+    it('does NOT skip when there is no prior auto snapshot (only manual/legacy)', async () => {
+        await seedSnapshot('servicebay-full-2020-01-01T00-00-00-000Z.tar.gz');
+        await createSystemBackup('manual');
+        expect(await autoSnapshotWouldDuplicate()).toBe(false);
+    });
+});
+
+describe('retention / prune', () => {
+    it(`keeps only the newest ${AUTO_BACKUP_RETENTION} auto snapshots`, async () => {
+        // Seed RETENTION+5 auto snapshots, then trigger one more real auto
+        // backup which runs the prune.
+        for (let i = 0; i < AUTO_BACKUP_RETENTION + 5; i++) {
+            await seedSnapshot(`servicebay-full-2020-01-01T00-00-${String(i).padStart(2, '0')}-000Z-auto.tar.gz`);
+        }
+        await createSystemBackup('auto'); // newest; prune runs after write
+        const autos = (await listSystemBackups()).filter(e => e.kind === 'auto');
+        expect(autos).toHaveLength(AUTO_BACKUP_RETENTION);
+    });
+
+    it('never prunes manual snapshots', async () => {
+        for (let i = 0; i < 5; i++) {
+            await seedSnapshot(`servicebay-full-2020-01-01T00-00-${String(i).padStart(2, '0')}-000Z-manual.tar.gz`);
+        }
+        // Far exceed retention with auto snapshots so prune is forced.
+        for (let i = 0; i < AUTO_BACKUP_RETENTION + 5; i++) {
+            await seedSnapshot(`servicebay-full-2020-02-01T00-00-${String(i).padStart(2, '0')}-000Z-auto.tar.gz`);
+        }
+        await createSystemBackup('auto');
+        const list = await listSystemBackups();
+        expect(list.filter(e => e.kind === 'manual')).toHaveLength(5);
+        expect(list.filter(e => e.kind === 'auto')).toHaveLength(AUTO_BACKUP_RETENTION);
+    });
+
+    it('never prunes legacy unsuffixed snapshots', async () => {
+        for (let i = 0; i < 30; i++) {
+            await seedSnapshot(`servicebay-full-2019-01-01T00-00-${String(i).padStart(2, '0')}-000Z.tar.gz`);
+        }
+        for (let i = 0; i < AUTO_BACKUP_RETENTION + 5; i++) {
+            await seedSnapshot(`servicebay-full-2020-02-01T00-00-${String(i).padStart(2, '0')}-000Z-auto.tar.gz`);
+        }
+        await createSystemBackup('auto');
+        const list = await listSystemBackups();
+        // All 30 legacy files survive; the 8203-pile cleanup is out-of-band.
+        expect(list.filter(e => e.kind === 'legacy')).toHaveLength(30);
+        expect(list.filter(e => e.kind === 'auto')).toHaveLength(AUTO_BACKUP_RETENTION);
+    });
+
+    it('manual snapshots do NOT trigger a prune of auto snapshots', async () => {
+        for (let i = 0; i < AUTO_BACKUP_RETENTION + 5; i++) {
+            await seedSnapshot(`servicebay-full-2020-02-01T00-00-${String(i).padStart(2, '0')}-000Z-auto.tar.gz`);
+        }
+        await createSystemBackup('manual'); // manual path must not prune
+        const autos = (await listSystemBackups()).filter(e => e.kind === 'auto');
+        expect(autos).toHaveLength(AUTO_BACKUP_RETENTION + 5);
+    });
+});

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -10,6 +10,7 @@ import os from 'os';
 // the test suite noticing. The prefix is the marker Node's resolver
 // treats as "built-in, do not redirect."
 import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { promisify } from 'node:util';
 import { Client, SFTPWrapper } from 'ssh2';
 import { DATA_DIR, SERVICEBAY_BACKUP_DIR, getLocalSystemdDir } from './dirs';
@@ -27,11 +28,45 @@ const REMOTE_SYSTEMD_DIR = '$HOME/.config/containers/systemd';
 const METADATA_FILE = 'metadata.json';
 const METADATA_VERSION = 2;
 
+/**
+ * How a system backup came to exist:
+ *   - `auto`   — a pre-mutation snapshot taken automatically by the MCP
+ *                safety layer before a destructive tool runs.
+ *   - `manual` — a user-triggered snapshot (Settings → Backups POST route).
+ *
+ * Persisted purely in the filename suffix (`-auto.tar.gz` / `-manual.tar.gz`)
+ * so listing stays a pure readdir with no sidecar/DB.
+ *
+ * `legacy` is a read-only classification for the ~8k pre-existing snapshots
+ * named `servicebay-full-<ISO>.tar.gz` with NO suffix — they predate the
+ * suffix scheme. They are treated as MANUAL for safety (never auto-pruned),
+ * but surfaced with their own kind so the UI/operator can tell them apart.
+ */
+export type SystemBackupKind = 'auto' | 'manual' | 'legacy';
+
+/** How many `auto` (pre-mutation) snapshots to keep. Older auto ones are
+ *  pruned after each new auto snapshot. Manual and legacy are never pruned. */
+export const AUTO_BACKUP_RETENTION = 20;
+
 export interface SystemBackupEntry {
     fileName: string;
     path: string;
     createdAt: string;
     size: number;
+    /** Origin of the snapshot — derived from the filename suffix. */
+    kind: SystemBackupKind;
+}
+
+/**
+ * Classify a backup filename by its suffix. Newly-written snapshots carry an
+ * explicit `-auto`/`-manual` suffix; anything without one is a pre-suffix
+ * legacy file and is treated as NON-prunable.
+ */
+function classifyBackupKind(fileName: string): SystemBackupKind {
+    const base = fileName.slice(0, -'.tar.gz'.length);
+    if (base.endsWith('-auto')) return 'auto';
+    if (base.endsWith('-manual')) return 'manual';
+    return 'legacy';
 }
 
 export type BackupLogStatus = 'info' | 'success' | 'error' | 'skip';
@@ -794,7 +829,8 @@ export async function listSystemBackups(): Promise<SystemBackupEntry[]> {
             fileName,
             path: archivePath,
             createdAt: stats.mtime.toISOString(),
-            size: stats.size
+            size: stats.size,
+            kind: classifyBackupKind(fileName)
         });
     }
 
@@ -810,7 +846,8 @@ export async function getBackupFileMeta(fileName: string): Promise<SystemBackupE
         fileName: safeName,
         path: archivePath,
         createdAt: stats.mtime.toISOString(),
-        size: stats.size
+        size: stats.size,
+        kind: classifyBackupKind(safeName)
     };
 }
 
@@ -819,7 +856,101 @@ export async function deleteSystemBackup(fileName: string): Promise<void> {
     await fs.unlink(entry.path);
 }
 
-export async function createSystemBackup(progress?: ProgressCallback): Promise<SystemBackupResult> {
+/**
+ * Hash the ServiceBay config files (config.json/nodes.json/checks.json) as
+ * they currently sit in DATA_DIR. Used to dedup auto snapshots: most
+ * `exec_command` calls don't change config, so a pre-mutation snapshot whose
+ * config matches the latest auto snapshot is skippable (#1868). Missing files
+ * contribute nothing — two configs with the same present files + bytes hash
+ * identically.
+ */
+async function hashCurrentConfig(): Promise<string> {
+    const hash = createHash('sha256');
+    for (const fileName of CONFIG_FILES) {
+        const filePath = path.join(DATA_DIR, fileName);
+        try {
+            const buf = await fs.readFile(filePath);
+            hash.update(fileName);
+            hash.update('\0');
+            hash.update(buf);
+            hash.update('\0');
+        } catch {
+            // Missing file — skip; its absence is part of the fingerprint.
+        }
+    }
+    return hash.digest('hex');
+}
+
+/**
+ * Hash the config files stored inside an already-written backup archive
+ * (its `config/` dir), using the same scheme as `hashCurrentConfig`, so the
+ * two are directly comparable. Returns null if the archive can't be read.
+ */
+async function hashSnapshotConfig(archivePath: string): Promise<string | null> {
+    const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'servicebay-dedup-'));
+    try {
+        await safeTarExtract(archivePath, stagingDir);
+        const configDir = path.join(stagingDir, 'config');
+        const hash = createHash('sha256');
+        for (const fileName of CONFIG_FILES) {
+            const filePath = path.join(configDir, fileName);
+            try {
+                const buf = await fs.readFile(filePath);
+                hash.update(fileName);
+                hash.update('\0');
+                hash.update(buf);
+                hash.update('\0');
+            } catch {
+                // Missing file — same treatment as hashCurrentConfig.
+            }
+        }
+        return hash.digest('hex');
+    } catch {
+        return null;
+    } finally {
+        await fs.rm(stagingDir, { recursive: true, force: true });
+    }
+}
+
+/**
+ * Dedup guard for the pre-mutation (auto) path (#1868): true when the current
+ * ServiceBay config is byte-identical to the most recent AUTO snapshot, so a
+ * fresh auto snapshot would be a redundant copy. Mirrors history.ts's
+ * latest-snapshot content compare. Manual/legacy snapshots are ignored here —
+ * dedup only ever compares against the latest auto snapshot.
+ */
+export async function autoSnapshotWouldDuplicate(): Promise<boolean> {
+    const backups = await listSystemBackups();
+    const latestAuto = backups.find(b => b.kind === 'auto'); // list is newest-first
+    if (!latestAuto) return false;
+    const [current, previous] = await Promise.all([
+        hashCurrentConfig(),
+        hashSnapshotConfig(latestAuto.path),
+    ]);
+    return previous !== null && current === previous;
+}
+
+/**
+ * Prune AUTO snapshots beyond AUTO_BACKUP_RETENTION, newest-first. NEVER
+ * touches manual or legacy (unsuffixed) snapshots — a buried legacy file
+ * could be a real manual snapshot, and the ~8k legacy pile is cleaned
+ * out-of-band with operator confirmation. Best-effort: unlink failures log
+ * and don't abort the just-written backup.
+ */
+async function pruneAutoSnapshots(): Promise<void> {
+    const backups = await listSystemBackups();
+    const autos = backups.filter(b => b.kind === 'auto'); // already newest-first
+    const stale = autos.slice(AUTO_BACKUP_RETENTION);
+    for (const entry of stale) {
+        try {
+            await fs.unlink(entry.path);
+        } catch (e) {
+            logger.warn('SystemBackup', `Failed to prune auto snapshot ${entry.fileName}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+}
+
+export async function createSystemBackup(kind: 'auto' | 'manual' = 'manual', progress?: ProgressCallback): Promise<SystemBackupResult> {
     await ensureBackupDir();
     const logs: BackupLogEntry[] = [];
     const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'servicebay-backup-'));
@@ -900,13 +1031,22 @@ export async function createSystemBackup(progress?: ProgressCallback): Promise<S
         await fs.writeFile(path.join(stagingDir, METADATA_FILE), JSON.stringify(metadata, null, 2));
 
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const fileName = `${BACKUP_PREFIX}-${timestamp}.tar.gz`;
+        // Persist the kind in the filename suffix so listing stays a pure
+        // readdir (no sidecar/DB) — see classifyBackupKind / SystemBackupKind.
+        const fileName = `${BACKUP_PREFIX}-${timestamp}-${kind}.tar.gz`;
         const archivePath = path.join(SERVICEBAY_BACKUP_DIR, fileName);
         pushLog(logs, progress, { scope: 'archive', status: 'info', message: 'Creating compressed archive' });
         await runTar(['-czf', archivePath, '-C', stagingDir, '.']);
         pushLog(logs, progress, { scope: 'archive', status: 'success', message: 'Backup archive ready', target: archivePath });
 
         const entry = await getBackupFileMeta(fileName);
+
+        // Retention: after writing a new AUTO snapshot, prune older auto ones
+        // beyond AUTO_BACKUP_RETENTION. Never prunes manual/legacy (#1868).
+        if (kind === 'auto') {
+            await pruneAutoSnapshots();
+        }
+
         return { entry, log: logs };
     } finally {
         await fs.rm(stagingDir, { recursive: true, force: true });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/helpers.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/helpers.ts
@@ -43,6 +43,9 @@ export interface SystemBackupEntrySummary {
   fileName: string;
   createdAt: string;
   size: number;
+  /** Origin of the snapshot: 'auto' (pre-mutation), 'manual' (user-triggered),
+   *  or 'legacy' (pre-suffix file). Absent on older API responses. */
+  kind?: 'auto' | 'manual' | 'legacy';
 }
 
 export type BackupStreamEvent =

--- a/packages/frontend/src/app/api/settings/backups/route.ts
+++ b/packages/frontend/src/app/api/settings/backups/route.ts
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic';
 // scoped `sb_` token; the handler gate still covers the web UI's cookie.
 export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
   const backups = await listSystemBackups();
-  const payload = backups.map(({ fileName, createdAt, size }) => ({ fileName, createdAt, size }));
+  const payload = backups.map(({ fileName, createdAt, size, kind }) => ({ fileName, createdAt, size, kind }));
   return NextResponse.json(payload);
 });
 
@@ -30,7 +30,7 @@ export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async () => {
       };
       (async () => {
         try {
-          const result = await createSystemBackup(entry => push({ type: 'log', entry }));
+          const result = await createSystemBackup('manual', entry => push({ type: 'log', entry }));
           push({
             type: 'done',
             backup: {

--- a/tests/backend/logger_retention.test.ts
+++ b/tests/backend/logger_retention.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+/**
+ * Log-retention prune tests (#1869).
+ *
+ * The Logger singleton binds to process.cwd()/data/logs.db at import time,
+ * so we exercise the extracted, pure `pruneLogsDb(db, days, now)` helper
+ * against a real better-sqlite3 DB on disk (matching the production schema
+ * and timestamp format). This is the actual code the Logger constructor
+ * (startup prune) and insertLog (lazy periodic prune) call.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type BetterSqlite3 from 'better-sqlite3';
+import { pruneLogsDb, LOG_RETENTION_DAYS } from '@/lib/logger';
+
+// Value import via require to mirror production (logger.ts / rateLimit.ts)
+// and keep knip from flagging better-sqlite3 as an unlisted root dependency
+// — it's a backend-package dep, not a root one.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Database: typeof BetterSqlite3 = require('better-sqlite3');
+
+const TABLE = `
+  CREATE TABLE IF NOT EXISTS logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    level TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    message TEXT NOT NULL,
+    args TEXT,
+    trace_id TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs(timestamp);
+`;
+
+// Same format the Logger writes: ISO with the T separator -> space, Z removed.
+function ts(d: Date): string {
+  return d.toISOString().replace('T', ' ').replace('Z', '');
+}
+
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+let dir: string;
+let dbPath: string;
+let db: InstanceType<typeof Database>;
+
+function open(): InstanceType<typeof Database> {
+  const d = new Database(dbPath);
+  d.pragma('journal_mode = WAL');
+  d.exec(TABLE);
+  return d;
+}
+
+function seed(d: InstanceType<typeof Database>, when: Date, count = 1) {
+  const stmt = d.prepare('INSERT INTO logs (timestamp, level, tag, message) VALUES (?, ?, ?, ?)');
+  for (let i = 0; i < count; i++) stmt.run(ts(when), 'info', 'test', `msg-${i}`);
+}
+
+function rowCount(d: InstanceType<typeof Database>): number {
+  return (d.prepare('SELECT COUNT(*) AS c FROM logs').get() as { c: number }).c;
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-logretention-'));
+  dbPath = path.join(dir, 'logs.db');
+  db = open();
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* already closed */ }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('pruneLogsDb (#1869)', () => {
+  it('deletes rows older than the retention window, keeps recent ones (prune-threshold)', () => {
+    seed(db, daysAgo(30), 5); // well outside the window
+    seed(db, daysAgo(8), 3); // just outside (default 7d)
+    seed(db, daysAgo(1), 4); // inside
+    seed(db, NOW, 2); // inside
+    expect(rowCount(db)).toBe(14);
+
+    const deleted = pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
+
+    expect(deleted).toBe(8); // 5 + 3 old rows removed
+    expect(rowCount(db)).toBe(6); // 4 + 2 recent rows kept
+    // No surviving row is older than the cutoff.
+    const oldest = (db.prepare('SELECT MIN(timestamp) AS m FROM logs').get() as { m: string }).m;
+    expect(oldest >= ts(daysAgo(LOG_RETENTION_DAYS))).toBe(true);
+  });
+
+  it('startup prune on an existing pile removes the backlog', () => {
+    // Simulate the existing multi-GB pile: many old rows.
+    seed(db, daysAgo(20), 1000);
+    seed(db, NOW, 5);
+    const deleted = pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
+    expect(deleted).toBe(1000);
+    expect(rowCount(db)).toBe(5);
+  });
+
+  const pageCount = (d: InstanceType<typeof Database>) =>
+    d.pragma('page_count', { simple: true }) as number;
+  const freelist = (d: InstanceType<typeof Database>) =>
+    d.pragma('freelist_count', { simple: true }) as number;
+
+  it('VACUUM runs after a prune so freed pages are reclaimed', () => {
+    // Build a fat DB of old rows, checkpoint so the data lands in the main
+    // file. After DELETE the pages sit on the freelist (file does not shrink
+    // on DELETE alone — the bug); only the VACUUM in pruneLogsDb rewrites the
+    // DB and drops the page count back down.
+    seed(db, daysAgo(20), 20000);
+    db.pragma('wal_checkpoint(TRUNCATE)');
+    const before = pageCount(db);
+    expect(before).toBeGreaterThan(100);
+
+    const deleted = pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
+    expect(deleted).toBe(20000);
+
+    // VACUUM reclaimed the freed pages: page count collapsed and the
+    // freelist is empty.
+    expect(pageCount(db)).toBeLessThan(before / 10);
+    expect(freelist(db)).toBe(0);
+  });
+
+  it('does not VACUUM when nothing is old (no-op prune leaves the DB untouched)', () => {
+    seed(db, NOW, 5000);
+    db.pragma('wal_checkpoint(TRUNCATE)');
+    const before = pageCount(db);
+
+    const deleted = pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
+
+    // No rows deleted -> VACUUM skipped (it is expensive) -> page count and
+    // row count unchanged.
+    expect(deleted).toBe(0);
+    expect(pageCount(db)).toBe(before);
+    expect(rowCount(db)).toBe(5000);
+  });
+
+  it('keeps logs.db bounded across many insert+prune cycles', () => {
+    // Each "day" we insert a batch then prune; the row count must stay
+    // bounded to roughly the retention window's worth, never growing
+    // unbounded.
+    for (let day = 0; day < 60; day++) {
+      const when = new Date(NOW.getTime() - (60 - day) * 24 * 60 * 60 * 1000);
+      seed(db, when, 100);
+      pruneLogsDb(db, LOG_RETENTION_DAYS, when);
+    }
+    // At the end only the last ~7 days of inserts survive (<= 8 batches).
+    expect(rowCount(db)).toBeLessThanOrEqual(8 * 100);
+    expect(rowCount(db)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What
Two disk-hygiene fixes from today's 8500-snapshot / 6.4 GB logs.db incident:
- MCP pre-mutation system snapshots now carry a persisted `kind` (`-auto.`/`-manual.` filename suffix), dedup when config is byte-identical to the latest auto snapshot, and prune to the newest 20 auto snapshots on create (manual snapshots are never pruned).
- The Logger applies 7-day time-based retention (`DELETE` + `wal_checkpoint(TRUNCATE)` + `VACUUM`) on startup and lazily once per day, so `logs.db` stays bounded and actually shrinks.

## Why
Closes #1868
Closes #1869

## Risk
low — both are additive retention/dedup paths; manual snapshots and existing query/restore APIs are untouched.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full, 2569 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (#1868 touches systemBackup.ts + mcp/safety.ts = path-mandated)

<!-- sb-ai-comment -->
AI-generated