### PR TITLE
feat: typed non-destructive MCP read tools + Home Diagnose status card

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/disk.ts
+++ b/packages/backend/src/lib/diagnose/probes/disk.ts
@@ -14,17 +14,30 @@ import { registerProbeAction, type ProbeActionResult } from '../actions';
 
 const PROBE_ID = 'disk';
 
-async function showLargestDirs({ node }: { node: string }): Promise<ProbeActionResult> {
+/**
+ * The single source of the "what's eating /mnt/data" measurement, shared
+ * by the `show_largest_dirs` probe action and the `disk_usage` MCP tool
+ * (#1872) so there is exactly ONE `du` invocation in the codebase.
+ *
+ * -x keeps du within /mnt/data's filesystem (don't traverse podman
+ * bind-mounts to host overlays). 2>/dev/null swallows the
+ * permission-denied lines from rootless container subdirs that du can't
+ * read; the survivors are still the meaningful candidates.
+ *
+ * Returns the raw `du -shx … | sort -hr | head -N` block (size<TAB>path
+ * per line), trimmed; empty string when nothing is found.
+ */
+export async function largestDirsUnderDataDir(node: string, top = 10): Promise<string> {
   const agent = await agentManager.ensureAgent(node);
-  // -x keeps du within /mnt/data's filesystem (don't traverse podman
-  // bind-mounts to host overlays). 2>/dev/null swallows the
-  // permission-denied lines from rootless container subdirs that du
-  // can't read; the survivors are still the meaningful candidates.
+  const n = Math.max(1, Math.min(50, Math.floor(top)));
   const res = await agent.sendCommand('exec', {
-    command: 'du -shx /mnt/data/* 2>/dev/null | sort -hr | head -10',
+    command: `du -shx /mnt/data/* 2>/dev/null | sort -hr | head -${n}`,
   }, { timeoutMs: 30_000 }) as { code?: number; stdout?: string; stderr?: string };
+  return (res.stdout ?? '').trim();
+}
 
-  const out = (res.stdout ?? '').trim();
+async function showLargestDirs({ node }: { node: string }): Promise<ProbeActionResult> {
+  const out = await largestDirsUnderDataDir(node, 10);
   if (!out) {
     return {
       ok: true,

--- a/packages/backend/src/lib/mcp/pathJail.test.ts
+++ b/packages/backend/src/lib/mcp/pathJail.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { jailPath, JAIL_ROOT } from './pathJail';
+
+// #1872: the read_file / list_dir MCP tools must never read outside the
+// /mnt/data jail. The lexical gate rejects `..`-escape, absolute-escape and
+// NUL; the server pairs it with a server-side realpath check for symlinks.
+describe('jailPath (#1872)', () => {
+  it('accepts the root itself', () => {
+    const r = jailPath(JAIL_ROOT);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(JAIL_ROOT);
+  });
+
+  it('anchors a relative path under the root', () => {
+    const r = jailPath('stacks/auth/config.yml');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(`${JAIL_ROOT}/stacks/auth/config.yml`);
+  });
+
+  it('accepts an absolute path already inside the root', () => {
+    const r = jailPath(`${JAIL_ROOT}/backups/x.tar.gz`);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(`${JAIL_ROOT}/backups/x.tar.gz`);
+  });
+
+  it('collapses harmless interior `..` that stays in the jail', () => {
+    const r = jailPath('stacks/../backups/x');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(`${JAIL_ROOT}/backups/x`);
+  });
+
+  it('rejects a `..` sequence that climbs out of the jail', () => {
+    const r = jailPath('../../etc/passwd');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/escapes the allowed root/);
+  });
+
+  it('rejects an absolute path outside the jail', () => {
+    const r = jailPath('/etc/shadow');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/escapes the allowed root/);
+  });
+
+  it('rejects a sibling-prefix path (/mnt/data-evil)', () => {
+    const r = jailPath('/mnt/data-evil/secret');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a NUL byte', () => {
+    const r = jailPath('ok\0/../../etc/passwd');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/NUL/);
+  });
+
+  it('rejects an empty path', () => {
+    expect(jailPath('').ok).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/mcp/pathJail.ts
+++ b/packages/backend/src/lib/mcp/pathJail.ts
@@ -1,0 +1,73 @@
+/**
+ * Path-jail for the read-oriented MCP file tools (read_file / list_dir).
+ *
+ * These tools name a path on the *remote node* (the box), not the
+ * backend container's own filesystem — so the jail is a purely lexical
+ * check against a fixed remote root (`/mnt/data`, the box's data
+ * volume). We resolve `.`/`..` segments ourselves (POSIX, `path.posix`)
+ * and reject anything that climbs out of the root, plus obvious escape
+ * shapes (a non-/mnt/data absolute path, embedded NUL).
+ *
+ * Lexical normalization catches `..`-escape and absolute-escape, but
+ * NOT a symlink inside the jail that points outside it — that can only
+ * be checked on the box. The caller pairs this with a server-side
+ * `realpath` confirmation before reading (see server.ts), so a symlink
+ * escape is rejected too. This module is the cheap, deterministic,
+ * unit-testable first gate.
+ */
+import path from 'path';
+
+/** The only root MCP read tools may touch on a node. */
+export const JAIL_ROOT = '/mnt/data';
+
+export interface JailOk {
+  ok: true;
+  /** Absolute, normalized path guaranteed to be inside JAIL_ROOT. */
+  path: string;
+}
+export interface JailErr {
+  ok: false;
+  error: string;
+}
+export type JailResult = JailOk | JailErr;
+
+/**
+ * Resolve `input` against JAIL_ROOT and confirm it stays inside it.
+ * A relative input is taken relative to the root; an absolute input
+ * must already be under the root. `..` segments are collapsed
+ * lexically and rejected if they escape.
+ */
+export function jailPath(input: string): JailResult {
+  if (typeof input !== 'string' || input.length === 0) {
+    return { ok: false, error: 'Path is required.' };
+  }
+  // A NUL byte truncates the path at the syscall layer — refuse outright.
+  if (input.includes('\0')) {
+    return { ok: false, error: 'Path contains a NUL byte.' };
+  }
+  // Resolve against the root: an absolute input is honoured as-is, a
+  // relative one is anchored under the root. Either way path.posix.resolve
+  // collapses `.`/`..` segments lexically.
+  const resolved = path.posix.resolve(JAIL_ROOT, input);
+  // After collapsing, the result must be the root itself or a descendant.
+  if (resolved !== JAIL_ROOT && !resolved.startsWith(`${JAIL_ROOT}/`)) {
+    return {
+      ok: false,
+      error: `Path escapes the allowed root ${JAIL_ROOT}: "${input}" resolves to "${resolved}".`,
+    };
+  }
+  return { ok: true, path: resolved };
+}
+
+/**
+ * True if a resolved real path (e.g. the output of `realpath -m` on the
+ * box) is the jail root itself or a descendant of it. An empty string
+ * (realpath produced nothing) is treated as inside — the lexical
+ * jailPath() gate already vetted the requested path, and a missing
+ * realpath result shouldn't block a legitimate read.
+ */
+export function realPathInJail(realPath: string): boolean {
+  const p = realPath.trim();
+  if (!p) return true;
+  return p === JAIL_ROOT || p.startsWith(`${JAIL_ROOT}/`);
+}

--- a/packages/backend/src/lib/mcp/server.readTools.test.ts
+++ b/packages/backend/src/lib/mcp/server.readTools.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { JAIL_ROOT } from './pathJail';
+
+// #1872: typed non-destructive MCP read tools (read_file/list_dir/disk_usage/
+// container_exec). These tests assert: all four are registered + callable;
+// read_file/list_dir reject a path-escape; container_exec passes an argv array
+// (no shell); disk_usage delegates to the disk probe's single du source; and
+// crucially that NONE of them trigger snapshotBeforeMutation (non-destructive).
+
+// Mock the agent executor — every read tool drives the box through it.
+const execSafe = vi.fn();
+const execArgv = vi.fn();
+const readFile = vi.fn();
+vi.mock('@/lib/agent/executor', () => ({
+  AgentExecutor: class {
+    execSafe(...a: unknown[]) { return execSafe(...a); }
+    execArgv(...a: unknown[]) { return execArgv(...a); }
+    readFile(...a: unknown[]) { return readFile(...a); }
+  },
+}));
+
+// Spy snapshotBeforeMutation while keeping the real gate helpers permissive.
+const snapshotBeforeMutation = vi.fn(async (..._a: unknown[]) => undefined);
+vi.mock('./safety', () => ({
+  guardMutation: vi.fn(async () => null),
+  guardExec: vi.fn(async () => null),
+  snapshotBeforeMutation: (...a: unknown[]) => snapshotBeforeMutation(...a),
+}));
+
+// disk_usage must REUSE the disk probe's du helper, not reimplement du.
+const largestDirsUnderDataDir = vi.fn(async (..._a: unknown[]) => '1.2G\t/mnt/data/media\n300M\t/mnt/data/backups');
+vi.mock('@/lib/diagnose/probes/disk', () => ({
+  largestDirsUnderDataDir: (...a: unknown[]) => largestDirsUnderDataDir(...a),
+}));
+
+// resolveNode calls listNodes; give it one node so we don't need a real store.
+vi.mock('@/lib/nodes', () => ({
+  listNodes: vi.fn(async () => [{ Name: 'box', URI: '', Default: true }]),
+  getNodeConnection: vi.fn(),
+}));
+
+async function connectClient() {
+  const { createMcpServer } = await import('./server');
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+  return { client };
+}
+
+beforeEach(() => {
+  execSafe.mockReset();
+  execArgv.mockReset();
+  readFile.mockReset();
+  snapshotBeforeMutation.mockReset();
+  largestDirsUnderDataDir.mockClear();
+  // Default realpath/stat: identity inside the jail, regular file.
+  execSafe.mockImplementation(async (argv: string[]) => {
+    const cmd = argv[0];
+    if (cmd === 'realpath') return { stdout: argv[argv.length - 1], stderr: '', code: 0 };
+    if (cmd === 'stat') return { stdout: 'regular 42', stderr: '', code: 0 };
+    if (cmd === 'find') return { stdout: 'f\t10\t1700000000\ta.txt\nd\t4096\t1700000001\tsub', stderr: '', code: 0 };
+    return { stdout: '', stderr: '', code: 0 };
+  });
+  readFile.mockResolvedValue('hello world');
+  execArgv.mockResolvedValue({ stdout: 'NAME=fedora', stderr: '' });
+});
+
+describe('read tools registration (#1872)', () => {
+  it('registers all four tools at the read/exec scopes (none destructive)', async () => {
+    const { TOOL_SCOPES } = await import('./server');
+    expect(TOOL_SCOPES.read_file).toBe('read');
+    expect(TOOL_SCOPES.list_dir).toBe('read');
+    expect(TOOL_SCOPES.disk_usage).toBe('read');
+    expect(TOOL_SCOPES.container_exec).toBe('exec');
+  });
+
+  it('lists all four via the MCP tools/list handshake', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const names = tools.map(t => t.name);
+    for (const n of ['read_file', 'list_dir', 'disk_usage', 'container_exec']) {
+      expect(names, `${n} must be registered`).toContain(n);
+    }
+    await client.close();
+  });
+});
+
+describe('read_file (#1872)', () => {
+  it('reads a jailed file and never snapshots', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'read_file', arguments: { path: 'stacks/auth/config.yml' } });
+    expect(res.isError).toBeFalsy();
+    expect(readFile).toHaveBeenCalledWith(`${JAIL_ROOT}/stacks/auth/config.yml`);
+    expect(snapshotBeforeMutation).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('rejects a `..`-escape before touching the agent', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'read_file', arguments: { path: '../../etc/passwd' } });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/escapes the allowed root/);
+    expect(readFile).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('rejects a symlink that resolves out of the jail (server-side realpath)', async () => {
+    execSafe.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'realpath') return { stdout: '/etc/shadow', stderr: '', code: 0 };
+      return { stdout: 'regular 42', stderr: '', code: 0 };
+    });
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'read_file', arguments: { path: 'evil-link' } });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/symlink/);
+    expect(readFile).not.toHaveBeenCalled();
+    await client.close();
+  });
+});
+
+describe('list_dir (#1872)', () => {
+  it('lists entries with type/size/mtime and never snapshots', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'list_dir', arguments: { path: 'stacks' } });
+    expect(res.isError).toBeFalsy();
+    const text = (res.content as { text: string }[])[0].text;
+    expect(text).toMatch(/"name": "a.txt"/);
+    expect(text).toMatch(/"type": "file"/);
+    expect(text).toMatch(/"type": "dir"/);
+    expect(snapshotBeforeMutation).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('rejects an absolute-escape path', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'list_dir', arguments: { path: '/etc' } });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+});
+
+describe('disk_usage (#1872)', () => {
+  it('reuses the disk probe du helper (no duplicate du) and never snapshots', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'disk_usage', arguments: { top: 5 } });
+    expect(res.isError).toBeFalsy();
+    expect(largestDirsUnderDataDir).toHaveBeenCalledWith('box', 5);
+    const text = (res.content as { text: string }[])[0].text;
+    expect(text).toMatch(/\/mnt\/data\/media/);
+    expect(snapshotBeforeMutation).not.toHaveBeenCalled();
+    await client.close();
+  });
+});
+
+describe('container_exec (#1872)', () => {
+  it('passes an argv array (no shell string) and never snapshots', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({
+      name: 'container_exec',
+      arguments: { container: 'media-jellyfin', args: ['cat', '/etc/os-release'] },
+    });
+    expect(res.isError).toBeFalsy();
+    expect(execArgv).toHaveBeenCalledWith(['podman', 'exec', 'media-jellyfin', 'cat', '/etc/os-release']);
+    expect(snapshotBeforeMutation).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('rejects an invalid container name via the schema', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({
+      name: 'container_exec',
+      arguments: { container: 'bad; rm -rf /', args: ['ls'] },
+    });
+    expect(res.isError).toBe(true);
+    expect(execArgv).not.toHaveBeenCalled();
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -35,6 +35,10 @@ import { redactLogText, redactServiceFiles } from './redact';
 import type { ApiScope } from '@/lib/auth/apiScope';
 import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
 import { performStackReset, StackResetError } from '@/lib/install/performStackReset';
+import { jailPath, realPathInJail, JAIL_ROOT } from './pathJail';
+import { largestDirsUnderDataDir } from '@/lib/diagnose/probes/disk';
+import { AgentExecutor } from '@/lib/agent/executor';
+import { shellQuote } from '@/lib/util/shellQuote';
 
 interface McpAuthContext {
   user: string;
@@ -60,6 +64,48 @@ function errorResult(msg: string) {
 }
 
 /**
+ * Confirm a jailed path's REAL path (after symlink resolution on the box)
+ * is still inside JAIL_ROOT. Returns an error message string if it
+ * escapes, else null. Shared by read_file + list_dir (#1872) so the
+ * symlink-escape guard lives in one place.
+ */
+async function assertRealpathInJail(
+  exec: AgentExecutor,
+  jailedPath: string,
+  reqPath: string,
+): Promise<string | null> {
+  const real = await exec.execSafe(['realpath', '-m', '--', jailedPath]);
+  if (realPathInJail(real.stdout ?? '')) return null;
+  return `Path escapes the allowed root ${JAIL_ROOT}: "${reqPath}" resolves (via symlink) to "${(real.stdout ?? '').trim()}".`;
+}
+
+/**
+ * Stat a jailed file and confirm it is a regular file within `limit`
+ * bytes (rejects device nodes, dirs, and oversized blobs before we slurp
+ * them through the agent). Returns an error message string, else null.
+ */
+async function assertReadableRegularFile(
+  exec: AgentExecutor,
+  jailedPath: string,
+  reqPath: string,
+  limit: number,
+): Promise<string | null> {
+  const stat = await exec.execSafe(['stat', '-Lc', '%F %s', '--', jailedPath]);
+  if (stat.code !== 0) {
+    return `Cannot stat "${reqPath}": ${(stat.stderr ?? '').trim() || `exit ${stat.code}`}`;
+  }
+  const [kind, sizeStr] = (stat.stdout ?? '').trim().split(/\s+/);
+  if (kind !== 'regular' && kind !== 'regular_empty_file') {
+    return `Refusing to read "${reqPath}": not a regular file (${kind}).`;
+  }
+  const size = Number(sizeStr);
+  if (Number.isFinite(size) && size > limit) {
+    return `File "${reqPath}" is ${size} bytes, over the ${limit}-byte cap. Raise maxBytes or use exec_command.`;
+  }
+  return null;
+}
+
+/**
  * Tools that mutate state. Calls are gated on `config.mcp.allowMutations`
  * (true | absent ⇒ allowed; false ⇒ blocked).
  */
@@ -71,7 +117,7 @@ const MUTATING_TOOLS = new Set([
   'file_access_request',
   'create_health_check', 'delete_health_check', 'run_check_now',
   'run_backup', 'restore_backup',
-  'update_config', 'exec_command', 'refresh_agent',
+  'update_config', 'exec_command', 'container_exec', 'refresh_agent',
   'set_boot_next_usb', 'reboot_node', 'factory_reset',
   'set_channel',
 ]);
@@ -105,6 +151,8 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   get_unmanaged_bundles: 'read',
   get_channel: 'read',
   list_access_requests: 'read', get_access_request_status: 'read',
+  // read-oriented file/disk tools (#1872) — jailed reads, no mutation
+  read_file: 'read', list_dir: 'read', disk_usage: 'read',
   // lifecycle
   start_service: 'lifecycle', stop_service: 'lifecycle', restart_service: 'lifecycle',
   run_check_now: 'lifecycle', refresh_agent: 'lifecycle',
@@ -129,6 +177,12 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   reboot_node: 'reboot',
   // exec (shell — own scope so tokens can grant config writes without it)
   exec_command: 'exec',
+  // container_exec (#1872): runs a command inside a named container via an
+  // argv array (no host shell). It executes code, so it requires the `exec`
+  // scope like exec_command — but it's a scoped container exec, not the host
+  // escape hatch, and is read-oriented per the issue, so it is deliberately
+  // NOT in DESTRUCTIVE_TOOLS (no pre-mutation host snapshot).
+  container_exec: 'exec',
 };
 
 /**
@@ -1353,6 +1407,144 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       } catch (err: unknown) {
         if (err instanceof StackResetError) return errorResult(err.message);
         return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  // --- Read-oriented file / disk / container tools (#1872) ---
+  // These replace ad-hoc `exec_command` calls (cat/ls/find/du/podman exec)
+  // with typed, path-jailed handlers. All four are NON-destructive: none is
+  // in DESTRUCTIVE_TOOLS, so calling them never fires snapshotBeforeMutation
+  // (no servicebay-full-*-auto.tar.gz). read_file/list_dir are jailed to
+  // JAIL_ROOT (/mnt/data) lexically AND confirmed server-side with realpath
+  // (catches a symlink that points out of the jail). disk_usage reuses the
+  // disk probe's single du source. container_exec takes an argv array, so the
+  // host shell never parses the payload.
+
+  server.tool(
+    'read_file',
+    `Read a UTF-8 text file on a node, jailed to ${JAIL_ROOT} (service data dirs live here). Use this instead of \`exec_command cat …\`. The path is resolved and rejected if it escapes the jail (\`..\`, an absolute path outside it, or a symlink pointing out). Returns the file content (size-capped). For binary or huge files use exec_command deliberately.`,
+    {
+      path: z.string().min(1).describe(`File path; relative paths are anchored at ${JAIL_ROOT}. Must resolve inside ${JAIL_ROOT}.`),
+      maxBytes: z.number().int().min(1).max(5_000_000).optional().describe('Max bytes to read (default 1 MiB). Larger files are rejected — narrow with exec_command if you truly need them.'),
+      node: nodeParam,
+    },
+    async ({ path: reqPath, maxBytes, node }) => {
+      const jailed = jailPath(reqPath);
+      if (!jailed.ok) return errorResult(jailed.error);
+      const limit = maxBytes ?? 1_048_576;
+      const nodeName = await resolveNode(node);
+      try {
+        const exec = new AgentExecutor(nodeName);
+        // Symlink-escape guard, then regular-file/size guard. Lexical
+        // jailPath() can't see a symlink that points out of the jail;
+        // `realpath -m` resolves it on the box. argv form — no shell parsing.
+        const escape = await assertRealpathInJail(exec, jailed.path, reqPath);
+        if (escape) return errorResult(escape);
+        const bad = await assertReadableRegularFile(exec, jailed.path, reqPath, limit);
+        if (bad) return errorResult(bad);
+        const content = await exec.readFile(jailed.path);
+        return textResult({ path: jailed.path, bytes: content.length, content: redactLogText(content) });
+      } catch (err) {
+        return errorResult(`Error reading file: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  server.tool(
+    'list_dir',
+    `List the entries of a directory on a node, jailed to ${JAIL_ROOT}. Use this instead of \`exec_command ls/find/wc -l\`. Each entry has name, type (file|dir|symlink|other), size (bytes) and mtime (Unix seconds). The path is rejected if it escapes the jail.`,
+    {
+      path: z.string().min(1).optional().describe(`Directory path; relative paths are anchored at ${JAIL_ROOT}. Defaults to ${JAIL_ROOT}.`),
+      node: nodeParam,
+    },
+    async ({ path: reqPath, node }) => {
+      const jailed = jailPath(reqPath ?? JAIL_ROOT);
+      if (!jailed.ok) return errorResult(jailed.error);
+      const nodeName = await resolveNode(node);
+      try {
+        const exec = new AgentExecutor(nodeName);
+        const escape = await assertRealpathInJail(exec, jailed.path, reqPath ?? JAIL_ROOT);
+        if (escape) return errorResult(escape);
+        // `find -maxdepth 1` lists the dir's immediate children, one per line
+        // with tab-separated type/size/mtime/name fields.
+        const res = await exec.execSafe([
+          'find', jailed.path, '-maxdepth', '1', '-mindepth', '1',
+          '-printf', '%y\t%s\t%T@\t%f\n',
+        ]);
+        if (res.code !== 0) {
+          return errorResult(`Cannot list "${jailed.path}": ${(res.stderr ?? '').trim() || `exit ${res.code}`}`);
+        }
+        const typeMap: Record<string, string> = { f: 'file', d: 'dir', l: 'symlink' };
+        const entries = (res.stdout ?? '')
+          .split('\n')
+          .filter(Boolean)
+          .map(line => {
+            const [y, size, mtime, ...rest] = line.split('\t');
+            return {
+              name: rest.join('\t'),
+              type: typeMap[y] ?? 'other',
+              size: Number(size),
+              mtime: Math.floor(Number(mtime)),
+            };
+          });
+        return textResult({ path: jailed.path, count: entries.length, entries });
+      } catch (err) {
+        return errorResult(`Error listing directory: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  server.tool(
+    'disk_usage',
+    `Show the largest directories under ${JAIL_ROOT} (top-N by size). Use this instead of \`exec_command du\`. Reuses the same measurement as the disk diagnose probe's "show largest directories" action — there is one du implementation. Returns the raw \`du\` breakdown (size + path per line) and a parsed list.`,
+    {
+      top: z.number().int().min(1).max(50).optional().describe('How many directories to return (default 10).'),
+      node: nodeParam,
+    },
+    async ({ top, node }) => {
+      const nodeName = await resolveNode(node);
+      try {
+        const breakdown = await largestDirsUnderDataDir(nodeName, top ?? 10);
+        const entries = breakdown
+          .split('\n')
+          .filter(Boolean)
+          .map(line => {
+            const [size, ...rest] = line.split('\t');
+            return { size: size?.trim() ?? '', path: rest.join('\t').trim() };
+          });
+        return textResult({ root: JAIL_ROOT, breakdown, entries });
+      } catch (err) {
+        return errorResult(`Error measuring disk usage: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  );
+
+  server.tool(
+    'container_exec',
+    'Run a command inside a named container via `podman exec`, passing an argv array (no host shell string). Use this instead of an ad-hoc `exec_command podman exec …`. The container name is validated; args are passed as a list so the host shell never parses them. Non-destructive by default — scoped to one container, not the host.',
+    {
+      container: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid container name').describe('Container name or id (e.g. media-jellyfin).'),
+      args: z.array(z.string()).min(1).describe('Command + arguments as an argv array, e.g. ["cat", "/etc/os-release"]. Passed verbatim — no shell interpolation.'),
+      node: nodeParam,
+    },
+    async ({ container, args, node }) => {
+      const nodeName = await resolveNode(node);
+      try {
+        const exec = new AgentExecutor(nodeName);
+        // argv form end-to-end: `podman exec <name> <args…>` with every token
+        // shell-quoted, so a metacharacter in args can never start a new host
+        // command. The container name is already regex-validated by the schema.
+        const argv = ['podman', 'exec', container, ...args];
+        const res = await exec.execArgv(argv);
+        return textResult({
+          container,
+          command: argv.map(shellQuote).join(' '),
+          stdout: redactLogText(res.stdout ?? ''),
+          stderr: redactLogText(res.stderr ?? ''),
+        });
+      } catch (err) {
+        return errorResult(`Error running container command: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
   );

--- a/packages/frontend/src/dashboards/OverviewDashboard.diagnose.test.ts
+++ b/packages/frontend/src/dashboards/OverviewDashboard.diagnose.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Home Overview Diagnose card breakdown (#1873).
+ *
+ * The Diagnose OverviewCard surfaces the LATEST PERSISTED diagnose run from
+ * GET /api/health/checks (same endpoint HealthDashboard polls) — no diagnose
+ * run is triggered on render. These tests cover the two pure helpers that
+ * derive the card's counts + tone from the enriched check rows:
+ *  - summarizeDiagnoseRows: filter to `diagnose:*` rows, bucket by the
+ *    four-way diagnose.status (ok→healthy, warn→warning, fail→failure,
+ *    info/none→unknown).
+ *  - diagnoseCardView: metric/description/tone with worst-status tone.
+ */
+import { describe, it, expect } from 'vitest';
+import { summarizeDiagnoseRows, diagnoseCardView } from './OverviewDashboard';
+
+describe('summarizeDiagnoseRows', () => {
+  it('buckets the four-way diagnose.status and ignores non-diagnose rows', () => {
+    const rows = [
+      { id: 'diagnose:agent', diagnose: { status: 'ok' } },
+      { id: 'diagnose:dns', diagnose: { status: 'warn' } },
+      { id: 'diagnose:cert', diagnose: { status: 'fail' } },
+      { id: 'diagnose:sso', diagnose: { status: 'info' } },
+      { id: 'diagnose:legacy', diagnose: { status: undefined } },
+      // Non-diagnose check rows must not be counted.
+      { id: 'http-portal', status: 'ok' },
+      { id: 'ping-router', status: 'fail' },
+    ];
+    expect(summarizeDiagnoseRows(rows)).toEqual({
+      healthy: 1,
+      warning: 1,
+      failure: 1,
+      unknown: 2, // info + missing-status
+      total: 5,
+    });
+  });
+
+  it('falls back to the row status when diagnose field is absent', () => {
+    const rows = [
+      { id: 'diagnose:a', status: 'ok' },
+      { id: 'diagnose:b', status: 'fail' },
+    ];
+    expect(summarizeDiagnoseRows(rows)).toEqual({
+      healthy: 1,
+      warning: 0,
+      failure: 1,
+      unknown: 0,
+      total: 2,
+    });
+  });
+
+  it('returns all-zero for zero diagnose rows (never run)', () => {
+    expect(summarizeDiagnoseRows([{ id: 'http-x', status: 'ok' }])).toEqual({
+      healthy: 0,
+      warning: 0,
+      failure: 0,
+      unknown: 0,
+      total: 0,
+    });
+  });
+});
+
+describe('diagnoseCardView', () => {
+  const base = { healthy: 0, warning: 0, failure: 0, unknown: 0, total: 0, loaded: true };
+
+  it('is neutral "Reading…" while not loaded', () => {
+    const v = diagnoseCardView({ ...base, loaded: false });
+    expect(v.tone).toBe('neutral');
+  });
+
+  it('renders "Not run yet" / neutral when no persisted results', () => {
+    const v = diagnoseCardView({ ...base, total: 0 });
+    expect(v.metric).toBe('Not run yet');
+    expect(v.tone).toBe('neutral');
+  });
+
+  it('tone is bad when any failure present', () => {
+    const v = diagnoseCardView({ ...base, healthy: 3, warning: 1, failure: 2, total: 6 });
+    expect(v.tone).toBe('bad');
+    expect(v.metric).toBe('3 healthy · 1 warning · 2 failure');
+  });
+
+  it('tone is warn when warnings but no failures', () => {
+    const v = diagnoseCardView({ ...base, healthy: 4, warning: 1, failure: 0, total: 5 });
+    expect(v.tone).toBe('warn');
+  });
+
+  it('tone is good when run with no warnings or failures', () => {
+    const v = diagnoseCardView({ ...base, healthy: 5, total: 5 });
+    expect(v.tone).toBe('good');
+    expect(v.description).toBe('All probes healthy');
+  });
+});

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -1,10 +1,116 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { Box, Network, Activity, Terminal, Settings, ArrowRight, AlertCircle, CheckCircle2, Wrench } from 'lucide-react';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
 import InstallProgressCard from '@/components/InstallProgressCard';
 import { useCoreHealth } from '@/hooks/useCoreHealth';
+
+/**
+ * Latest persisted diagnose breakdown for the Home card (#1873).
+ *
+ * Reads GET /api/health/checks — the SAME endpoint HealthDashboard already
+ * polls — which returns the enriched check rows including the synthetic
+ * `diagnose:*` probe rows persisted by the daily self-diagnose run
+ * (getDiagnoseChecksEnriched). This is a pure read of the LAST persisted
+ * results: it does NOT trigger a diagnose run (no POST /api/system/diagnose).
+ * A fresh box with no persisted results returns zero diagnose rows → the
+ * card renders "Not run yet" / neutral.
+ */
+export interface DiagnoseBreakdown {
+  healthy: number;
+  warning: number;
+  failure: number;
+  unknown: number;
+  total: number;
+  loaded: boolean;
+}
+
+interface EnrichedCheckRow {
+  id: string;
+  status?: string;
+  diagnose?: { status?: string };
+}
+
+/** Map a diagnose row to one of the four buckets. The four-way status lives
+ *  on `diagnose.status` (ok/warn/fail/info); the row-level `status` only
+ *  carries the folded binary ok/fail, so we prefer the diagnose field and
+ *  fall back to it when absent. Per #1873: ok→healthy, warn→warning,
+ *  fail→failure, info/none/unknown→unknown. */
+function bucketForDiagnoseRow(row: EnrichedCheckRow): keyof Omit<DiagnoseBreakdown, 'total' | 'loaded'> {
+  const status = row.diagnose?.status ?? row.status;
+  if (status === 'ok') return 'healthy';
+  if (status === 'warn') return 'warning';
+  if (status === 'fail') return 'failure';
+  return 'unknown';
+}
+
+export function summarizeDiagnoseRows(rows: EnrichedCheckRow[]): Omit<DiagnoseBreakdown, 'loaded'> {
+  const breakdown = { healthy: 0, warning: 0, failure: 0, unknown: 0, total: 0 };
+  for (const row of rows) {
+    if (!row.id?.startsWith('diagnose:')) continue;
+    breakdown[bucketForDiagnoseRow(row)] += 1;
+    breakdown.total += 1;
+  }
+  return breakdown;
+}
+
+function useDiagnoseOverview(): DiagnoseBreakdown {
+  const [breakdown, setBreakdown] = useState<DiagnoseBreakdown>({
+    healthy: 0,
+    warning: 0,
+    failure: 0,
+    unknown: 0,
+    total: 0,
+    loaded: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/health/checks');
+        if (!res.ok) return;
+        const rows = (await res.json()) as EnrichedCheckRow[];
+        if (cancelled) return;
+        setBreakdown({ ...summarizeDiagnoseRows(rows), loaded: true });
+      } catch (error) {
+        // Background read — keep the card neutral on failure rather than
+        // surfacing a transient fetch blip as a diagnose state.
+        console.error('[OverviewDashboard] Failed to read diagnose results', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return breakdown;
+}
+
+/** Card metric/description/tone from the persisted diagnose breakdown.
+ *  Tone mirrors the other OverviewCards (worst status wins):
+ *  any failure → bad, else any warning → warn, else a run with no issues →
+ *  good, else (never run) → neutral. */
+export function diagnoseCardView(b: DiagnoseBreakdown): {
+  metric: string;
+  description: string;
+  tone: 'good' | 'warn' | 'bad' | 'neutral';
+} {
+  if (!b.loaded) return { metric: '…', description: 'Reading diagnose status…', tone: 'neutral' };
+  if (b.total === 0) {
+    return { metric: 'Not run yet', description: 'Run probes, view system logs, inspect raw containers', tone: 'neutral' };
+  }
+  const metric = `${b.healthy} healthy · ${b.warning} warning · ${b.failure} failure`;
+  if (b.failure > 0) {
+    return { metric, description: `${b.failure} probe${b.failure === 1 ? '' : 's'} failing`, tone: 'bad' };
+  }
+  if (b.warning > 0) {
+    return { metric, description: `${b.warning} probe${b.warning === 1 ? '' : 's'} warning`, tone: 'warn' };
+  }
+  return { metric, description: 'All probes healthy', tone: 'good' };
+}
 
 /**
  * Home / Overview dashboard (#803).
@@ -48,6 +154,10 @@ export default function OverviewDashboard() {
   // contradicted the banner's "Core stack unhealthy". Reading core-health
   // directly keeps the headline and the banner in agreement.
   const { unhealthy: coreUnhealthy } = useCoreHealth();
+
+  // Latest persisted diagnose breakdown (#1873) — read-only, no run kicked off.
+  const diagnose = useDiagnoseOverview();
+  const diagnoseView = diagnoseCardView(diagnose);
 
   const healthHeadline = (() => {
     if (!hasFirstSnapshot) return { tone: 'neutral' as const, text: 'Reading status…' };
@@ -135,10 +245,10 @@ export default function OverviewDashboard() {
           <OverviewCard
             href="/health"
             title="Diagnostics"
-            metric="Self-test"
-            description="Run probes, view system logs, inspect raw containers"
+            metric={diagnoseView.metric}
+            description={diagnoseView.description}
             icon={Activity}
-            tone="neutral"
+            tone={diagnoseView.tone}
           />
           <OverviewCard
             href="/terminal"


### PR DESCRIPTION
## What
Adds four typed, non-destructive MCP read tools (read_file/list_dir/disk_usage/container_exec) with a /mnt/data path-jail and argv-only container exec, and replaces the static Home Overview Diagnostics card with a live status breakdown (healthy/warning/failure/unknown) sourced from the last persisted diagnose run.

## Why
Closes #1872
Closes #1873

## Risk
Low — new MCP tools are read-only and excluded from DESTRUCTIVE_TOOLS (no auto-snapshot); the dashboard card is a presentational change reading an existing endpoint, no new diagnose run on render.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full, 2596 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: mcp/server.ts + frontend/src/dashboards/)