### PR TITLE
fix(install): reconcile NPM proxy advanced_config on redeploy + fix #1872 MCP read tools

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -83,6 +83,9 @@ SAFE_EXEC_ALLOWLIST = frozenset({
     'df',            # disk-usage probe
     'du',            # "show largest dirs" diagnose action
     'find',          # cert-archive + dangling-file enumeration
+    'realpath',      # MCP read_file/list_dir symlink-escape guard (#1872) —
+                     # `realpath -m` resolves a jailed path on the box so the
+                     # path-jail can confirm it stays inside JAIL_ROOT.
     'echo',          # health-check + agent-ok ping
     'hostname',      # initial-sync identity probe
     'uptime',        # diagnose's crash-loop boot-grace gate

--- a/packages/backend/src/lib/agent/v4/tests/test_agent.py
+++ b/packages/backend/src/lib/agent/v4/tests/test_agent.py
@@ -305,6 +305,14 @@ class TestDnsResolvers(unittest.TestCase):
         for binary in ('lsblk', 'mount', 'umount', 'rsync', 'chown'):
             self.assertIn(binary, agent.SAFE_EXEC_ALLOWLIST)
 
+    def test_mcp_read_tool_binaries_on_safe_exec_allowlist(self):
+        # #1872 typed read tools drive the box via safe_exec: read_file/list_dir
+        # confirm the symlink-escape guard with `realpath -m`, and container_exec
+        # runs `podman exec`. Both binaries MUST be allowlisted or the tools
+        # crash on the box ("not in SAFE_EXEC_ALLOWLIST" — the box-verify RED).
+        for binary in ('realpath', 'podman'):
+            self.assertIn(binary, agent.SAFE_EXEC_ALLOWLIST)
+
     def test_safe_exec_allowlist_stays_minimal(self):
         # Guard against speculative additions: the allow-list is binary-only,
         # so every entry is a real consumer. `bash`/`sh` must never be on it

--- a/packages/backend/src/lib/mcp/server.readTools.test.ts
+++ b/packages/backend/src/lib/mcp/server.readTools.test.ts
@@ -97,6 +97,13 @@ describe('read_file (#1872)', () => {
     const res = await client.callTool({ name: 'read_file', arguments: { path: 'stacks/auth/config.yml' } });
     expect(res.isError).toBeFalsy();
     expect(readFile).toHaveBeenCalledWith(`${JAIL_ROOT}/stacks/auth/config.yml`);
+    // The symlink-escape guard runs `realpath` via safe_exec — `realpath` MUST
+    // be on the agent SAFE_EXEC_ALLOWLIST or this crashes on the box (#1872
+    // box-verify RED). Assert the call shape so a regression that drops the
+    // realpath safe_exec (or routes it through a non-allowlisted path) is caught.
+    expect(execSafe).toHaveBeenCalledWith(
+      expect.arrayContaining(['realpath', '-m', '--', `${JAIL_ROOT}/stacks/auth/config.yml`]),
+    );
     expect(snapshotBeforeMutation).not.toHaveBeenCalled();
     await client.close();
   });
@@ -159,14 +166,26 @@ describe('disk_usage (#1872)', () => {
 });
 
 describe('container_exec (#1872)', () => {
-  it('passes an argv array (no shell string) and never snapshots', async () => {
+  it('runs `podman exec` via safe_exec and returns the real stdout', async () => {
+    // Regression guard for the box-verify RED: container_exec used execArgv,
+    // whose legacy-exec trace wrapper (`: # SB_TRACE=…; <cmd>`) commented the
+    // command out and always returned empty stdout. It must use execSafe
+    // (safe_exec, `podman` allowlisted) and surface the container's output.
+    execSafe.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'podman') return { stdout: 'NAME=fedora\nID=fedora', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    });
     const { client } = await connectClient();
     const res = await client.callTool({
       name: 'container_exec',
       arguments: { container: 'media-jellyfin', args: ['cat', '/etc/os-release'] },
     });
     expect(res.isError).toBeFalsy();
-    expect(execArgv).toHaveBeenCalledWith(['podman', 'exec', 'media-jellyfin', 'cat', '/etc/os-release']);
+    expect(execSafe).toHaveBeenCalledWith(['podman', 'exec', 'media-jellyfin', 'cat', '/etc/os-release']);
+    // NOT the broken legacy-exec path.
+    expect(execArgv).not.toHaveBeenCalled();
+    const text = (res.content as { text: string }[])[0].text;
+    expect(text).toMatch(/NAME=fedora/);
     expect(snapshotBeforeMutation).not.toHaveBeenCalled();
     await client.close();
   });
@@ -178,6 +197,7 @@ describe('container_exec (#1872)', () => {
       arguments: { container: 'bad; rm -rf /', args: ['ls'] },
     });
     expect(res.isError).toBe(true);
+    expect(execSafe).not.toHaveBeenCalled();
     expect(execArgv).not.toHaveBeenCalled();
     await client.close();
   });

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1532,14 +1532,19 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       const nodeName = await resolveNode(node);
       try {
         const exec = new AgentExecutor(nodeName);
-        // argv form end-to-end: `podman exec <name> <args…>` with every token
-        // shell-quoted, so a metacharacter in args can never start a new host
-        // command. The container name is already regex-validated by the schema.
+        // argv form end-to-end via safe_exec: the agent runs `podman exec
+        // <name> <args…>` without a host shell, so a metacharacter in args can
+        // never start a new host command (the container name is also
+        // regex-validated by the schema). NOT execArgv — that routes through
+        // the legacy `exec` path, whose trace wrapper (`: # SB_TRACE=…; <cmd>`)
+        // comments the real command out and returns empty stdout (#1872).
+        // `podman` is on the agent SAFE_EXEC_ALLOWLIST.
         const argv = ['podman', 'exec', container, ...args];
-        const res = await exec.execArgv(argv);
+        const res = await exec.execSafe(argv);
         return textResult({
           container,
           command: argv.map(shellQuote).join(' '),
+          exitCode: res.code,
           stdout: redactLogText(res.stdout ?? ''),
           stderr: redactLogText(res.stderr ?? ''),
         });

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/decideAdvancedConfigReconcile.test.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/decideAdvancedConfigReconcile.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { decideAdvancedConfigReconcile, patchProxyHostAdvancedConfig } from './route';
+
+vi.mock('@/lib/logger', () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// The forward-auth snippet (abbreviated) is what marks a host as
+// ServiceBay-OWNED — the install runner expands the
+// `__authelia_forward_auth__` sentinel into this before it reaches NPM.
+const FORWARD_AUTH = 'auth_request /authelia;\nerror_page 401 =302 $redirect;';
+const SSE_EXTRAS = 'proxy_buffering off;\nproxy_read_timeout 600s;';
+
+describe('decideAdvancedConfigReconcile', () => {
+    it('skips when the rendered config is empty', () => {
+        expect(decideAdvancedConfigReconcile('anything', '')).toEqual({ skip: true });
+    });
+
+    it('skips when live and rendered are identical', () => {
+        expect(decideAdvancedConfigReconcile(FORWARD_AUTH, FORWARD_AUTH)).toEqual({ skip: true });
+    });
+
+    // #1862 — the regression: an existing host that ALREADY has forward-auth
+    // but whose template now appends SSE/timeout extras. The old guard only
+    // fired when forward-auth was *missing*, so these extras were dropped.
+    it('lands the rendered config when appended extras differ on an existing forward-auth host (#1862)', () => {
+        const live = FORWARD_AUTH;
+        const rendered = `${FORWARD_AUTH}\n${SSE_EXTRAS}`;
+        const res = decideAdvancedConfigReconcile(live, rendered);
+        expect('write' in res).toBe(true);
+        const written = (res as { write: string }).write;
+        // The new directives land verbatim...
+        expect(written).toContain('proxy_buffering off;');
+        expect(written).toContain('proxy_read_timeout 600s;');
+        // ...and forward-auth stays intact (no regression).
+        expect(written).toContain('auth_request /authelia;');
+        expect(written).toBe(rendered);
+    });
+
+    it('lands the full rendered config when forward-auth is newly added (legacy #991)', () => {
+        const res = decideAdvancedConfigReconcile('client_max_body_size 0;', `${FORWARD_AUTH}\n${SSE_EXTRAS}`);
+        expect('write' in res).toBe(true);
+        expect((res as { write: string }).write).toBe(`${FORWARD_AUTH}\n${SSE_EXTRAS}`);
+    });
+
+    // The manual-edit preservation guarantee: a host WITHOUT forward-auth in
+    // its rendered config is NOT SB-owned — we never clobber operator edits.
+    it('preserves manual edits on a non-SB-owned host (no forward-auth, no explainer)', () => {
+        const live = 'proxy_set_header X-Custom 1;\nclient_max_body_size 0;';
+        const rendered = 'client_max_body_size 100m;';
+        expect(decideAdvancedConfigReconcile(live, rendered)).toEqual({ skip: true });
+    });
+
+    // #1415 — the LAN-only explainer is the one thing we append (not clobber)
+    // onto a non-SB-owned host whose config predates it.
+    it('appends the LAN explainer to an existing non-forward-auth host, preserving its edits (#1415)', () => {
+        const live = 'client_max_body_size 0;';
+        const rendered = 'servicebay-lan-only-explainer\nclient_max_body_size 0;';
+        const res = decideAdvancedConfigReconcile(live, rendered);
+        expect('write' in res).toBe(true);
+        const written = (res as { write: string }).write;
+        // withLanDeniedPage appends the explainer onto the EXISTING config,
+        // so the operator's directive survives.
+        expect(written).toContain('client_max_body_size 0;');
+        expect(written).toContain('servicebay-lan-only-explainer');
+    });
+});
+
+describe('patchProxyHostAdvancedConfig (NPM PUT wrapper)', () => {
+    const FORWARD_AUTH = 'auth_request /authelia;\nerror_page 401 =302 $redirect;';
+    const RENDERED = `${FORWARD_AUTH}\nproxy_buffering off;\nproxy_read_timeout 600s;`;
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it('skips the PUT entirely when the decision is skip (no diff)', async () => {
+        const res = await patchProxyHostAdvancedConfig('http://npm', 'tok', 7, FORWARD_AUTH, FORWARD_AUTH, 'chat.dopp.cloud');
+        expect(res).toEqual({ updated: false });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('PUTs the reconciled config and reports updated on success (#1862)', async () => {
+        fetchMock.mockResolvedValue({ ok: true, status: 200 } as Response);
+        const res = await patchProxyHostAdvancedConfig('http://npm', 'tok', 7, FORWARD_AUTH, RENDERED, 'chat.dopp.cloud');
+        expect(res).toEqual({ updated: true });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, opts] = fetchMock.mock.calls[0];
+        expect(url).toBe('http://npm/api/nginx/proxy-hosts/7');
+        expect((opts as RequestInit).method).toBe('PUT');
+        // The appended SSE/timeout extras reach NPM verbatim.
+        const body = JSON.parse((opts as RequestInit).body as string);
+        expect(body.advanced_config).toBe(RENDERED);
+    });
+
+    it('reports not-updated when NPM returns a non-ok status', async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 500 } as Response);
+        const res = await patchProxyHostAdvancedConfig('http://npm', 'tok', 7, FORWARD_AUTH, RENDERED, 'chat.dopp.cloud');
+        expect(res).toEqual({ updated: false });
+    });
+
+    it('swallows a fetch error and reports not-updated (non-fatal)', async () => {
+        fetchMock.mockRejectedValue(new Error('network down'));
+        const res = await patchProxyHostAdvancedConfig('http://npm', 'tok', 7, FORWARD_AUTH, RENDERED, 'chat.dopp.cloud');
+        expect(res).toEqual({ updated: false });
+    });
+});

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -388,22 +388,83 @@ async function reconcileProxyHostUpstream(
 }
 
 /**
- * #991 — Reconcile an existing NPM proxy host's `advanced_config` with
- * what the template's `variables.json` currently declares. The legacy
- * "exists → return as-is" path leaves a stale config in place when a
- * template is updated post-install (e.g. file-share added Authelia
- * forward-auth in v3 → existing host has no `Remote-User` rewrite →
- * filebrowser logs "username is empty"). This narrow update keeps
- * manual operator customisations untouched: we only PUT when the
- * existing config does NOT already contain `auth_request` AND the new
- * config does. Anything else (manual edits, hosts that legitimately
- * shouldn't carry forward-auth) is left alone.
+ * Pure decision for `patchProxyHostAdvancedConfig`: given the live
+ * config and the template-rendered config, decide whether (and what) to
+ * PUT back to NPM. Exported so the SB-owned-vs-manual-edit policy can be
+ * unit-tested without mocking NPM's HTTP API.
+ *
+ * The distinction this encodes:
+ *
+ * - A rendered config that contains `auth_request /authelia` is a
+ *   **ServiceBay-OWNED** host — the whole `advanced_config` is template
+ *   territory (forward-auth snippet + any appended extras the template
+ *   ships via the `__authelia_forward_auth__\n<extras>` sentinel form,
+ *   e.g. `proxy_buffering off` / `proxy_read_timeout 600s`). When the
+ *   rendered value differs from live we land the rendered value verbatim
+ *   — whether forward-auth is being ADDED for the first time (legacy
+ *   #991) OR the extras changed on a host that already had forward-auth
+ *   (#1862: the chat SSE directives were silently dropped because the
+ *   old guard only fired when forward-auth was *missing*). The rendered
+ *   config already carries the LAN explainer / proxy-error page wiring
+ *   the POST loop injected, so adopting it wholesale is correct.
+ *
+ * - A rendered config WITHOUT forward-auth is NOT treated as owning the
+ *   live config. We only ever **append** the LAN-only 403 explainer when
+ *   the live host predates it (#1415) — genuine manual operator edits on
+ *   such hosts are preserved (we never clobber).
+ *
+ * Returns `{ write, reason }` to PUT, or `{ skip }` to leave live alone.
+ */
+export function decideAdvancedConfigReconcile(
+    existingAdvancedConfig: string,
+    newAdvancedConfig: string,
+): { write: string; reason: string } | { skip: true } {
+    if (!newAdvancedConfig) return { skip: true };
+    if (existingAdvancedConfig === newAdvancedConfig) return { skip: true };
+    const hasForwardAuth = (s: string) => /auth_request\s+\/authelia/.test(s);
+    // #1415 — backfill the LAN-only 403 explainer onto an existing host
+    // whose config predates it (the marker is the idempotency key).
+    const hasLanExplainer = (s: string) => s.includes('servicebay-lan-only-explainer');
+    // #1862 — the rendered config carrying forward-auth marks this host as
+    // ServiceBay-owned, so land it on ANY diff (not just when forward-auth
+    // is newly added). This covers the appended-extras case where the host
+    // already had forward-auth but the template's extra nginx directives
+    // changed and were previously dropped.
+    const ownedByTemplate = hasForwardAuth(newAdvancedConfig);
+    const addsExplainer = hasLanExplainer(newAdvancedConfig) && !hasLanExplainer(existingAdvancedConfig);
+    // Nothing to land → leave the existing config (and any manual edits) alone.
+    if (!ownedByTemplate && !addsExplainer) return { skip: true };
+    // SB-owned host: adopt the template's full rendered config (forward-auth
+    // snippet + appended extras + the explainer/error-page wiring the POST
+    // loop already folded into `newAdvancedConfig`). When the host is NOT
+    // SB-owned and only the explainer is missing, append it to the EXISTING
+    // config so manual operator edits are preserved.
+    if (ownedByTemplate) {
+        const addedForwardAuth = !hasForwardAuth(existingAdvancedConfig);
+        return {
+            write: newAdvancedConfig,
+            reason: addedForwardAuth
+                ? 'added Authelia forward-auth missing on the existing host'
+                : 'reconciled template-owned advanced_config (forward-auth + appended extras) on the existing host',
+        };
+    }
+    return { write: withLanDeniedPage(existingAdvancedConfig), reason: 'added LAN-only 403 explainer missing on the existing host' };
+}
+
+/**
+ * #991 / #1862 — Reconcile an existing NPM proxy host's `advanced_config`
+ * with what the template's `variables.json` currently declares. The
+ * legacy "exists → return as-is" path leaves a stale config in place when
+ * a template is updated post-install (e.g. file-share added Authelia
+ * forward-auth, or the chat host's SSE directives changed). The
+ * SB-owned-vs-manual-edit policy lives in `decideAdvancedConfigReconcile`
+ * above (and is unit-tested there).
  *
  * Failures are logged but non-fatal — install proceeds with the stale
  * config in place, the diagnose probe surfaces the drift, operator can
  * retry from Settings → Self-Diagnose → Reprovision.
  */
-async function patchProxyHostAdvancedConfig(
+export async function patchProxyHostAdvancedConfig(
     baseUrl: string,
     token: string,
     hostId: number,
@@ -411,24 +472,9 @@ async function patchProxyHostAdvancedConfig(
     newAdvancedConfig: string,
     domain: string,
 ): Promise<{ updated: boolean }> {
-    if (!newAdvancedConfig) return { updated: false };
-    if (existingAdvancedConfig === newAdvancedConfig) return { updated: false };
-    const hasForwardAuth = (s: string) => /auth_request\s+\/authelia/.test(s);
-    // #1415 — also backfill the LAN-only 403 explainer onto an existing host
-    // whose config predates it (the marker is the idempotency key).
-    const hasLanExplainer = (s: string) => s.includes('servicebay-lan-only-explainer');
-    const addsForwardAuth = hasForwardAuth(newAdvancedConfig) && !hasForwardAuth(existingAdvancedConfig);
-    const addsExplainer = hasLanExplainer(newAdvancedConfig) && !hasLanExplainer(existingAdvancedConfig);
-    // Nothing new to land → leave the existing config (and any manual edits) alone.
-    if (!addsForwardAuth && !addsExplainer) return { updated: false };
-    // When forward-auth is being added we adopt the template's full config
-    // (the legacy #991 behaviour); `newAdvancedConfig` already carries the
-    // explainer for LAN hosts (injected in the POST loop). When ONLY the
-    // explainer is missing, append it to the EXISTING config so manual
-    // operator edits are preserved.
-    const configToWrite = addsForwardAuth
-        ? newAdvancedConfig
-        : withLanDeniedPage(existingAdvancedConfig);
+    const decision = decideAdvancedConfigReconcile(existingAdvancedConfig, newAdvancedConfig);
+    if ('skip' in decision) return { updated: false };
+    const configToWrite = decision.write;
     try {
         const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts/${hostId}`, {
             method: 'PUT',
@@ -437,14 +483,13 @@ async function patchProxyHostAdvancedConfig(
             signal: AbortSignal.timeout(10_000),
         });
         if (!res.ok) {
-            logger.warn('ProxyHosts', `Failed to backfill advanced_config for ${domain} (NPM PUT returned ${res.status})`);
+            logger.warn('ProxyHosts', `Failed to reconcile advanced_config for ${domain} (NPM PUT returned ${res.status})`);
             return { updated: false };
         }
-        const added = [addsForwardAuth ? 'Authelia forward-auth' : null, addsExplainer ? 'LAN-only 403 explainer' : null].filter(Boolean).join(' + ');
-        logger.info('ProxyHosts', `Backfilled advanced_config for ${domain} (added ${added} missing on the existing host)`);
+        logger.info('ProxyHosts', `Reconciled advanced_config for ${domain} (${decision.reason})`);
         return { updated: true };
     } catch (e) {
-        logger.warn('ProxyHosts', `Failed to backfill advanced_config for ${domain}: ${e instanceof Error ? e.message : String(e)}`);
+        logger.warn('ProxyHosts', `Failed to reconcile advanced_config for ${domain}: ${e instanceof Error ? e.message : String(e)}`);
         return { updated: false };
     }
 }
@@ -611,10 +656,12 @@ async function patchProxyHostConfFile(
 async function createProxyHost(baseUrl: string, token: string, host: ProxyHostRequest, accessListId: number = 0) {
     const existing = await findProxyHostByDomain(baseUrl, token, host.domain);
     if (existing) {
-        // #991 — Reconcile advanced_config when the template now ships
-        // forward-auth but the live host predates that change. Narrow
-        // policy in patchProxyHostAdvancedConfig leaves manual edits
-        // alone.
+        // #991 / #1862 — Reconcile advanced_config for a ServiceBay-owned
+        // host (one whose rendered config carries forward-auth) when the
+        // template's rendered value differs from live — whether forward-auth
+        // is newly added or its appended extras (SSE/timeout directives)
+        // changed. decideAdvancedConfigReconcile leaves genuine manual edits
+        // on non-SB-owned hosts alone.
         await patchProxyHostAdvancedConfig(
             baseUrl,
             token,


### PR DESCRIPTION
## What
Two fix-forward changes shipping together so one box re-verify covers both:
- **#1862** — Install runner now reconciles a template-owned existing NPM proxy host's `advanced_config` on redeploy when the rendered value differs from live (previously `reconcileAdvancedConfig()` only updated for forward-auth/explainer additions and dropped appended sentinel-form extras like `proxy_buffering off` / `proxy_read_timeout 600s`).
- **#1872** (fix-forward for the box-verify RED on the original PR #1874) — MCP read tools repaired: `realpath` added to the agent `SAFE_EXEC_ALLOWLIST` so `read_file`/`list_dir` realpath symlink-jail check works; `container_exec` switched from the broken `execArgv` trace wrapper to `execSafe(['podman','exec',...])` so it surfaces real stdout + exit code.

## Why
Closes #1862

References #1872 — the #1872 MCP-read-tools fix rides here (the broken tools landed on main via PR #1874; #1872 stays closed, this lands the fix so 4.120.0 ships green).

## Risk
Medium — touches the install runner reconcile path and the MCP agent exec allowlist; both are path-mandated and re-verified on the :dev box.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2602 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (NPM proxy install path + MCP tools — path-mandated)

<!-- sb-ai-comment -->
AI-generated