### PR TITLE
fix: nginx proxy-host template ownership + executor trace wrapper no-op

### DIFF
--- a/packages/backend/src/lib/agent/executor.trace.test.ts
+++ b/packages/backend/src/lib/agent/executor.trace.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+
+// Capture the command line the agent is asked to run.
+const sent: { command: string }[] = [];
+
+const stubHandler = {
+  nodeName: 'Local',
+  start: vi.fn(async () => {}),
+  // Simulate the agent: actually run the command line through a real shell
+  // (the agent runs it via SSH on the host), so a wrapper that comments out
+  // the command would show up as empty stdout / exit 0 here too.
+  sendCommand: vi.fn(async (_op: string, payload: { command: string }) => {
+    sent.push({ command: payload.command });
+    try {
+      const stdout = execFileSync('/bin/sh', ['-c', payload.command], {
+        encoding: 'utf8',
+      });
+      return { code: 0, stdout, stderr: '' };
+    } catch (e) {
+      const err = e as { status?: number; stdout?: string; stderr?: string };
+      return { code: err.status ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+    }
+  }),
+};
+
+vi.mock('./manager', () => ({
+  AgentManager: {
+    getInstance: () => ({ getAgent: () => stubHandler }),
+  },
+}));
+
+import { AgentExecutor } from './executor';
+import { runWithTrace } from '../util/traceContext';
+
+describe('AgentExecutor trace wrapper (#1877)', () => {
+  beforeEach(() => {
+    sent.length = 0;
+  });
+
+  it('runs the real command and returns its stdout when inside a trace frame', async () => {
+    const exec = new AgentExecutor('Local');
+    const { stdout } = await runWithTrace(
+      () => exec.exec('echo hello-traced'),
+      'deadbeef',
+    );
+    // The command actually executed — not swallowed by a leading `: #` comment.
+    expect(stdout.trim()).toBe('hello-traced');
+  });
+
+  it('propagates the real exit code under a trace frame', async () => {
+    const exec = new AgentExecutor('Local');
+    await expect(
+      runWithTrace(() => exec.exec('exit 3'), 'cafef00d'),
+    ).rejects.toMatchObject({ code: 3 });
+  });
+
+  it('keeps the SB_TRACE tag greppable on the command line', async () => {
+    const exec = new AgentExecutor('Local');
+    await runWithTrace(() => exec.exec('echo hi'), 'abc12345');
+    expect(sent[0].command).toContain('SB_TRACE=abc12345');
+    // Tag is a trailing comment, not a leading one that swallows the command.
+    expect(sent[0].command).toMatch(/echo hi\s+# SB_TRACE=abc12345$/);
+  });
+
+  it('does not tag the command outside a trace frame', async () => {
+    const exec = new AgentExecutor('Local');
+    const { stdout } = await exec.exec('echo plain');
+    expect(stdout.trim()).toBe('plain');
+    expect(sent[0].command).toBe('echo plain');
+    expect(sent[0].command).not.toContain('SB_TRACE');
+  });
+});

--- a/packages/backend/src/lib/agent/executor.ts
+++ b/packages/backend/src/lib/agent/executor.ts
@@ -33,12 +33,14 @@ export class AgentExecutor implements Executor {
 
   async exec(command: string, options: { timeoutMs?: number } = {}): Promise<{ stdout: string; stderr: string }> {
     await this.ensureConnected();
-    // Prefix with a trace-ID shell comment when the call originates
-    // from a tracked HTTP request (#594). `: # …` is a shell noop, so
-    // the agent runs the same command — but `ps -ef` on the host and
-    // the agent's exec log carry the trace ID for end-to-end grep.
+    // Append a trace-ID shell comment when the call originates from a
+    // tracked HTTP request (#594). A *trailing* `# SB_TRACE=…` is ignored
+    // by the shell — the command runs unchanged — but `ps -ef` on the host
+    // and the agent's exec log carry the trace ID for end-to-end grep.
+    // (#1877: a *leading* `: # SB_TRACE=…; <cmd>` started a comment that
+    // swallowed the rest of the line, so <cmd> never ran under any trace.)
     const traceId = currentTraceId();
-    const taggedCommand = traceId ? `: # SB_TRACE=${traceId}; ${command}` : command;
+    const taggedCommand = traceId ? `${command}  # SB_TRACE=${traceId}` : command;
     const truncatedCmd = taggedCommand.length > 100 ? taggedCommand.substring(0, 100) + '...' : taggedCommand;
     logger.info(`Executor:${this.agent.nodeName}`, `Executing: ${truncatedCmd}`);
 

--- a/packages/backend/src/lib/capabilities/nginx.test.ts
+++ b/packages/backend/src/lib/capabilities/nginx.test.ts
@@ -35,6 +35,42 @@ function subdomainVar(template: string, varName: string, sub: string): StackVari
   };
 }
 
+/** A subdomain var whose declaring template (`templateName`) differs
+ *  from the stem of its variable name — e.g. template `solaris` declares
+ *  `CHAT_SUBDOMAIN`, so the derived `service` is `'chat'` (≠ template).
+ *  Ownership must follow `templateName`, not the derived name. (#1862) */
+function subdomainVarNamed(
+  template: string,
+  varName: string,
+  sub: string,
+): StackVariable {
+  return {
+    name: varName,
+    value: sub,
+    meta: {
+      type: 'subdomain',
+      templateName: template,
+      proxyPort: '8787',
+      exposure: 'public',
+    } as StackVariable['meta'],
+  };
+}
+
+/** Same as above but WITHOUT a `templateName` — simulates the older
+ *  assembler path / hand-built variables where ownership must fall back
+ *  to the derived `service` (variable-name stem). */
+function subdomainVarNoTemplate(varName: string, sub: string): StackVariable {
+  return {
+    name: varName,
+    value: sub,
+    meta: {
+      type: 'subdomain',
+      proxyPort: '2283',
+      exposure: 'public',
+    } as StackVariable['meta'],
+  };
+}
+
 const PUB_DOMAIN: StackVariable = { name: 'PUBLIC_DOMAIN', value: 'dopp.cloud' };
 
 beforeEach(() => {
@@ -79,6 +115,50 @@ describe('nginx.handleInstalled', () => {
     expect(body.publicDomain).toBe('dopp.cloud');
     expect(body.hosts).toHaveLength(1);
     expect(body.hosts[0].domain).toBe('photos.dopp.cloud');
+    expect(body.hosts[0].service).toBe('immich');
+  });
+
+  it('owns a host whose subdomain-var name differs from its declaring template (#1862)', async () => {
+    // Template `solaris` declares `CHAT_SUBDOMAIN`. Ownership must follow
+    // the DECLARING template (`templateName`), not the variable-name
+    // stem — `handleInstalled` must NOT exit early, so the proxy-host PUT
+    // (which carries solaris's SSE advanced_config) actually runs.
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ created: ['chat.dopp.cloud'] }), { status: 200 }));
+    const r = await handleInstalled({
+      kind: 'feature.installed', template: 'solaris', manifest: MANIFEST,
+      variables: [PUB_DOMAIN, subdomainVarNamed('solaris', 'CHAT_SUBDOMAIN', 'chat')],
+    });
+    expect(r.ok).toBe(true);
+    // The PUT must run — handleInstalled does NOT exit early.
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const body = JSON.parse(String(fetchSpy.mock.calls[0][1]!.body));
+    expect(body.hosts).toHaveLength(1);
+    expect(body.hosts[0].domain).toBe('chat.dopp.cloud');
+    expect(body.hosts[0].templateName).toBe('solaris');
+  });
+
+  it('does NOT own a host declared by another template (templateName takes precedence)', async () => {
+    // solaris-declared chat host must not fire on a different template's
+    // install event, even one named after the subdomain stem ('chat').
+    const r = await handleInstalled({
+      kind: 'feature.installed', template: 'chat', manifest: MANIFEST,
+      variables: [PUB_DOMAIN, subdomainVarNamed('solaris', 'CHAT_SUBDOMAIN', 'chat')],
+    });
+    expect(r.ok).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the derived service when templateName is absent (no regression)', async () => {
+    // No `templateName` on the var → ownership falls back to the derived
+    // `service` (variable-name stem). `IMMICH_SUBDOMAIN` → 'immich'.
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ created: ['photos.dopp.cloud'] }), { status: 200 }));
+    const r = await handleInstalled({
+      kind: 'feature.installed', template: 'immich', manifest: MANIFEST,
+      variables: [PUB_DOMAIN, subdomainVarNoTemplate('IMMICH_SUBDOMAIN', 'photos')],
+    });
+    expect(r.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const body = JSON.parse(String(fetchSpy.mock.calls[0][1]!.body));
     expect(body.hosts[0].service).toBe('immich');
   });
 
@@ -128,6 +208,19 @@ describe('nginx.handleUninstalled', () => {
     expect(fetchSpy).toHaveBeenCalledOnce();
     const [url, init] = fetchSpy.mock.calls[0];
     expect(String(url)).toMatch(/\/api\/system\/nginx\/proxy-hosts\?domain=photos\.dopp\.cloud/);
+    expect(init?.method).toBe('DELETE');
+  });
+
+  it('DELETEs a host whose declaring template differs from its derived service name (#1862)', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('{"removed":true}', { status: 200 }));
+    const r = await handleUninstalled({
+      kind: 'feature.uninstalled', template: 'solaris',
+      lastKnownVariables: [PUB_DOMAIN, subdomainVarNamed('solaris', 'CHAT_SUBDOMAIN', 'chat')],
+    });
+    expect(r.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toMatch(/\?domain=chat\.dopp\.cloud/);
     expect(init?.method).toBe('DELETE');
   });
 

--- a/packages/backend/src/lib/capabilities/nginx.ts
+++ b/packages/backend/src/lib/capabilities/nginx.ts
@@ -36,14 +36,40 @@ import type {
 
 const HANDLER_NAME = 'nginx.proxy-host';
 
+type BuiltHost = ReturnType<typeof buildProxyHosts>['hosts'][number];
+
+/**
+ * Does `host` belong to the template whose install/uninstall event fired?
+ *
+ * A host is owned by the template that DECLARED its subdomain variable
+ * (`subdomain.templateName`, injected for every var by the manifest
+ * assembler). We match on that — NOT on the host's `service` field —
+ * because `service` falls back to the variable-name stem when
+ * `templateName` is absent, which silently mis-attributes a host whose
+ * variable name differs from its template: e.g. template `solaris`
+ * declares `CHAT_SUBDOMAIN`, so `service` derives `'chat'` and the old
+ * `service === event.template` guard dropped the host, skipping its
+ * proxy-host PUT (the #1862 SSE-extras-never-land bug).
+ *
+ * Fallback: when `templateName` is genuinely absent (older assembler
+ * paths / hand-built variables), fall back to the derived `service`
+ * string so hosts where the variable name already matches the template
+ * (immich's `IMMICH_SUBDOMAIN`, media's `AUDIOBOOKSHELF_SUBDOMAIN`) keep
+ * matching exactly as before — no regression.
+ */
+function hostOwnedBy(host: BuiltHost, template: string): boolean {
+  return host.templateName != null
+    ? host.templateName === template
+    : host.service === template;
+}
+
 export async function handleInstalled(event: FeatureInstalledEvent): Promise<HandlerResult> {
   const { domain, hosts } = buildProxyHosts(event.variables);
-  // Filter to the hosts this specific template owns. `buildProxyHosts`
-  // walks the full variable list; the `service` field carries the
-  // owning template name (from `subdomain.templateName` or derived from
-  // the variable name). We only want this template's hosts to fire on
-  // its own install event.
-  const ownHosts = hosts.filter(h => h.service === event.template);
+  // Filter to the hosts this specific template owns — matched by the
+  // template that DECLARED each subdomain variable (`templateName`), so a
+  // host whose variable name differs from its template (solaris/`chat`)
+  // still fires on its own install event. (#1862)
+  const ownHosts = hosts.filter(h => hostOwnedBy(h, event.template));
   if (!domain || ownHosts.length === 0) return { ok: true };
 
   try {
@@ -80,7 +106,7 @@ export async function handleUninstalled(event: FeatureUninstalledEvent): Promise
   // template's on-disk metadata may differ from what was actually
   // installed. Variables are the snapshot the handler trusts.
   const { hosts } = buildProxyHosts(event.lastKnownVariables);
-  const ownHosts = hosts.filter(h => h.service === event.template);
+  const ownHosts = hosts.filter(h => hostOwnedBy(h, event.template));
   if (ownHosts.length === 0) return { ok: true };
 
   const failures: string[] = [];

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1543,9 +1543,9 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         // argv form end-to-end via safe_exec: the agent runs `podman exec
         // <name> <args…>` without a host shell, so a metacharacter in args can
         // never start a new host command (the container name is also
-        // regex-validated by the schema). NOT execArgv — that routes through
-        // the legacy `exec` path, whose trace wrapper (`: # SB_TRACE=…; <cmd>`)
-        // comments the real command out and returns empty stdout (#1872).
+        // regex-validated by the schema). Kept on execSafe (not execArgv) so
+        // the argv is never shell-parsed end-to-end (the legacy `exec` trace
+        // wrapper that swallowed the command was fixed in #1877).
         // `podman` is on the agent SAFE_EXEC_ALLOWLIST.
         const argv = ['podman', 'exec', container, ...args];
         const res = await exec.execSafe(argv);

--- a/packages/backend/src/lib/stackInstall/postInstall.ts
+++ b/packages/backend/src/lib/stackInstall/postInstall.ts
@@ -115,6 +115,16 @@ export function buildProxyHosts(variables: StackVariable[]): {
     domain: string;
     forwardPort: number;
     service: string;
+    /** The template that DECLARED this subdomain variable
+     *  (`subdomain.templateName`), or `undefined` when the assembler
+     *  didn't inject it. Distinct from `service`, which falls back to
+     *  the variable-name stem when `templateName` is absent — that
+     *  fallback makes `service` unreliable for ownership matching (a
+     *  `CHAT_SUBDOMAIN` declared by template `solaris` derives
+     *  `service: 'chat'`). Ownership handlers (nginx/adguard) must
+     *  match on `templateName` to bind a host to the template whose
+     *  install/uninstall event fired. (#1862) */
+    templateName?: string;
     /** 'public' and 'internal' trigger auto-cert; 'lan' skips. */
     exposure: 'public' | 'internal' | 'lan';
     proxyConfig?: VariableMeta['proxyConfig'];
@@ -133,6 +143,15 @@ export function buildProxyHosts(variables: StackVariable[]): {
     (acc, v) => { acc[v.name] = v.value; return acc; },
     {},
   );
+  // Derive the `service` name for a host. Prefers the declaring
+  // template (`templateName`, injected by the manifest assembler) and
+  // falls back to the variable-name stem. Note: `service` is NOT a
+  // reliable ownership key — that fallback mis-attributes a host whose
+  // variable name differs from its template (solaris/`CHAT_SUBDOMAIN`).
+  // Ownership handlers match on `templateName` directly. (#1862)
+  const deriveService = (sv: StackVariable): string =>
+    sv.meta?.templateName || sv.name.replace(/_SUBDOMAIN$/, '').toLowerCase();
+
   const subdomainVars = variables.filter(v => v.meta?.type === 'subdomain' && v.value);
   const hosts = subdomainVars.flatMap(sv => {
     // Conservative default: missing/unknown → 'lan'. Templates declare
@@ -148,12 +167,11 @@ export function buildProxyHosts(variables: StackVariable[]): {
     let port = sv.meta?.proxyPort || '';
     const portVar = variables.find(v => v.name === port);
     if (portVar) port = portVar.value;
-    const service = sv.meta?.templateName
-      || sv.name.replace(/_SUBDOMAIN$/, '').toLowerCase();
     return [{
       domain: `${sv.value}.${hostDomain}`,
       forwardPort: parseInt(port, 10),
-      service,
+      service: deriveService(sv),
+      templateName: sv.meta?.templateName,
       exposure,
       proxyConfig: renderProxyConfig(sv.meta?.proxyConfig, view),
       // Loopback-bound services (Syncthing GUI etc.) bind to the host's

--- a/packages/backend/src/lib/util/traceContext.ts
+++ b/packages/backend/src/lib/util/traceContext.ts
@@ -10,7 +10,7 @@
  * via webpack tracing, since `logger` is imported from client
  * dashboards. The trace ID surfaces through:
  *   - the MCP audit log (recordAudit auto-attaches it)
- *   - the agent's SSH command line (`: # SB_TRACE=…`)
+ *   - the agent's SSH command line (trailing `# SB_TRACE=…`)
  *   - the X-Trace-Id response header (UI error toasts paste it)
  *
  * `AsyncLocalStorage` is a no-op when no `runWithTrace` frame is


### PR DESCRIPTION
## What
Two unrelated backend bug fixes batched for one CI pass:
- nginx: own a proxy host by which template *declared* its subdomain var (`meta.templateName`), not by derived-service==template-name string equality — so a solaris install owns its `chat` host and the advanced_config reconcile (#1878) actually fires.
- agent/executor: the `: # SB_TRACE=<id>; <cmd>` trace wrapper commented out the command (bash `:` no-op then `#` ate the line) — every `execArgv` caller under a `runWithTrace` frame silently ran nothing. Moved the trace tag to a trailing comment so the command actually runs.

## Why
Closes #1862
Closes #1877

## Risk
Medium — executor change affects all API-path exec callers (previously silent no-op under traces, now they actually run); nginx ownership match is hardened to be robust to a missing/empty `meta.templateName` at runtime without regressing hosts where service==template.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full — 2617 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (#1862 install-runner reconcile path-mandated; #1877 executor blast radius)

AI-generated
<!-- sb-ai-comment -->