### PR TITLE
fix: defer logs.db VACUUM off boot path + confine approvals move/restart

### DIFF
--- a/packages/backend/src/lib/approvals/index.test.ts
+++ b/packages/backend/src/lib/approvals/index.test.ts
@@ -81,45 +81,49 @@ describe('approvals store', () => {
   });
 });
 
+// Declared move endpoints are confined to the requesting service's jail
+// (`/mnt/data/stacks/<service>`); paths below stay inside svc's jail.
+const SVC_JAIL = '/mnt/data/stacks/svc';
+
 describe('approve', () => {
-  it('runs the declared move action and marks approved', async () => {
-    fakeFs['/src/draft'] = 'content';
+  it('runs the declared move action (inside the service jail) and marks approved', async () => {
+    fakeFs[`${SVC_JAIL}/draft`] = 'content';
     const r = await submitApproval({
       service: 'svc',
       title: 'promote',
-      on_approve: { move: { src: '/src/draft', dst: '/dst/draft' } },
+      on_approve: { move: { src: `${SVC_JAIL}/draft`, dst: `${SVC_JAIL}/published/draft` } },
     });
     const res = await approveApproval(r.id);
     expect(res.request.status).toBe('approved');
-    expect(executor.rename).toHaveBeenCalledWith('/src/draft', '/dst/draft');
-    expect('/dst/draft' in fakeFs).toBe(true);
+    expect(executor.rename).toHaveBeenCalledWith(`${SVC_JAIL}/draft`, `${SVC_JAIL}/published/draft`);
+    expect(`${SVC_JAIL}/published/draft` in fakeFs).toBe(true);
     expect((await getApproval(r.id))?.status).toBe('approved');
   });
 
-  it('restarts the declared service after the move', async () => {
-    fakeFs['/src/x'] = 'c';
+  it('restarts the requesting service after the move', async () => {
+    fakeFs[`${SVC_JAIL}/x`] = 'c';
     const r = await submitApproval({
       service: 'svc',
       title: 't',
-      on_approve: { move: { src: '/src/x', dst: '/dst/x' }, restart: 'my-service' },
+      on_approve: { move: { src: `${SVC_JAIL}/x`, dst: `${SVC_JAIL}/x2` }, restart: 'svc' },
     });
     const res = await approveApproval(r.id);
-    expect(restartService).toHaveBeenCalledWith('box1', 'my-service');
+    expect(restartService).toHaveBeenCalledWith('box1', 'svc');
     expect(res.restarted).toBe(true);
   });
 
   it('surfaces a restart failure as a soft warning without rolling back the move', async () => {
-    fakeFs['/src/y'] = 'c';
+    fakeFs[`${SVC_JAIL}/y`] = 'c';
     restartService.mockRejectedValueOnce(new Error('boom'));
     const r = await submitApproval({
       service: 'svc',
       title: 't',
-      on_approve: { move: { src: '/src/y', dst: '/dst/y' }, restart: 'svc2' },
+      on_approve: { move: { src: `${SVC_JAIL}/y`, dst: `${SVC_JAIL}/y2` }, restart: 'svc' },
     });
     const res = await approveApproval(r.id);
     expect(res.restarted).toBe(false);
     expect(res.restartError).toBe('boom');
-    expect('/dst/y' in fakeFs).toBe(true);
+    expect(`${SVC_JAIL}/y2` in fakeFs).toBe(true);
     expect(res.request.status).toBe('approved');
   });
 
@@ -127,19 +131,19 @@ describe('approve', () => {
     const r = await submitApproval({
       service: 'svc',
       title: 't',
-      on_approve: { move: { src: '/nope', dst: '/dst' } },
+      on_approve: { move: { src: `${SVC_JAIL}/nope`, dst: `${SVC_JAIL}/dst` } },
     });
     await expect(approveApproval(r.id)).rejects.toThrow(/not found/);
     expect((await getApproval(r.id))?.status).toBe('pending');
   });
 
   it('throws when the destination already exists', async () => {
-    fakeFs['/src/z'] = 'c';
-    fakeFs['/dst/z'] = 'old';
+    fakeFs[`${SVC_JAIL}/z`] = 'c';
+    fakeFs[`${SVC_JAIL}/z2`] = 'old';
     const r = await submitApproval({
       service: 'svc',
       title: 't',
-      on_approve: { move: { src: '/src/z', dst: '/dst/z' } },
+      on_approve: { move: { src: `${SVC_JAIL}/z`, dst: `${SVC_JAIL}/z2` } },
     });
     await expect(approveApproval(r.id)).rejects.toThrow(/already exists/);
   });
@@ -157,21 +161,117 @@ describe('approve', () => {
 
 describe('reject', () => {
   it('runs the on_reject action and marks rejected', async () => {
-    fakeFs['/src/d'] = 'c';
+    fakeFs[`${SVC_JAIL}/d`] = 'c';
     const r = await submitApproval({
       service: 'svc',
       title: 't',
-      on_reject: { move: { src: '/src/d', dst: '/trash/d' } },
+      on_reject: { move: { src: `${SVC_JAIL}/d`, dst: `${SVC_JAIL}/trash/d` } },
     });
     const res = await rejectApproval(r.id);
     expect(res.request.status).toBe('rejected');
-    expect('/trash/d' in fakeFs).toBe(true);
+    expect(`${SVC_JAIL}/trash/d` in fakeFs).toBe(true);
   });
 
-  it('rejects with no declared action (pure review gate)', async () => {
+  it('rejects with no declared action (pure review gate) — unaffected by the jail', async () => {
     const r = await submitApproval({ service: 'svc', title: 't' });
     const res = await rejectApproval(r.id);
     expect(res.request.status).toBe('rejected');
     expect(executor.rename).not.toHaveBeenCalled();
+    expect(restartService).not.toHaveBeenCalled();
+  });
+});
+
+describe('move-jail authorization (#1884)', () => {
+  // A jail escape must be refused BEFORE any node side effect — the
+  // executor must never see a src/dst outside /mnt/data/stacks/<service>.
+  async function expectMoveRejected(move: { src: string; dst: string }, pattern: RegExp) {
+    const r = await submitApproval({ service: 'svc', title: 't', on_approve: { move } });
+    await expect(approveApproval(r.id)).rejects.toThrow(pattern);
+    expect(executor.rename).not.toHaveBeenCalled();
+    expect(executor.mkdir).not.toHaveBeenCalled();
+    // The request stays pending — nothing happened.
+    expect((await getApproval(r.id))?.status).toBe('pending');
+  }
+
+  it('rejects a non-absolute src', async () => {
+    await expectMoveRejected({ src: 'draft', dst: `${SVC_JAIL}/published` }, /absolute path/);
+  });
+
+  it('rejects a non-absolute dst', async () => {
+    await expectMoveRejected({ src: `${SVC_JAIL}/draft`, dst: 'published' }, /absolute path/);
+  });
+
+  it('rejects a ../ traversal escape on src', async () => {
+    await expectMoveRejected(
+      { src: `${SVC_JAIL}/../../../etc/passwd`, dst: `${SVC_JAIL}/x` },
+      /escapes the service's data jail/,
+    );
+  });
+
+  it('rejects a dst that resolves into another service jail', async () => {
+    await expectMoveRejected(
+      { src: `${SVC_JAIL}/secret`, dst: '/mnt/data/stacks/nginx-web/data/secret' },
+      /escapes the service's data jail/,
+    );
+  });
+
+  it('rejects a sibling-prefix dst (svc-evil) that is not under the jail', async () => {
+    await expectMoveRejected(
+      { src: `${SVC_JAIL}/x`, dst: '/mnt/data/stacks/svc-evil/x' },
+      /escapes the service's data jail/,
+    );
+  });
+
+  it('rejects an absolute system path outside /mnt/data/stacks entirely', async () => {
+    await expectMoveRejected(
+      { src: `${SVC_JAIL}/x`, dst: '/etc/cron.d/evil' },
+      /escapes the service's data jail/,
+    );
+  });
+});
+
+describe('restart-target authorization (#1884)', () => {
+  it('rejects restarting a load-bearing service (authelia) that is not the requester', async () => {
+    const r = await submitApproval({
+      service: 'svc',
+      title: 't',
+      on_approve: { restart: 'authelia' },
+    });
+    await expect(approveApproval(r.id)).rejects.toThrow(/only restart its own service/);
+    expect(restartService).not.toHaveBeenCalled();
+    expect((await getApproval(r.id))?.status).toBe('pending');
+  });
+
+  it('rejects restarting basic/servicebay (arbitrary target)', async () => {
+    for (const target of ['basic', 'servicebay']) {
+      const r = await submitApproval({
+        service: 'svc',
+        title: 't',
+        on_approve: { restart: target },
+      });
+      await expect(approveApproval(r.id)).rejects.toThrow(/only restart its own service/);
+    }
+    expect(restartService).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid (path-shaped) restart target', async () => {
+    const r = await submitApproval({
+      service: 'svc',
+      title: 't',
+      on_approve: { restart: '../../authelia' },
+    });
+    await expect(approveApproval(r.id)).rejects.toThrow(/not a valid service name/);
+    expect(restartService).not.toHaveBeenCalled();
+  });
+
+  it('allows restarting the requesting service itself', async () => {
+    const r = await submitApproval({
+      service: 'svc',
+      title: 't',
+      on_approve: { restart: 'svc' },
+    });
+    const res = await approveApproval(r.id);
+    expect(restartService).toHaveBeenCalledWith('box1', 'svc');
+    expect(res.restarted).toBe(true);
   });
 });

--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -25,6 +25,75 @@ import { logger } from '@/lib/logger';
 const TAG = 'approvals';
 const STORE_PATH = path.join(DATA_DIR, 'approvals.json');
 
+/**
+ * Canonical per-service data root on the *target node* (the box). A
+ * service's declared move actions are confined to its own subtree under
+ * this root — `/mnt/data/stacks/<service>` — so an approved request can
+ * never read from or write into another service's data, a system path,
+ * or anywhere off the box's data volume.
+ */
+const STACKS_ROOT = '/mnt/data/stacks';
+
+/** A service name must be a single, safe path segment (no separators, no
+ *  traversal). Mirrors the MCP/`npmAdminRekey` container-name guard. */
+const SERVICE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
+
+/** Absolute jail root for `service`'s declared move actions on the box. */
+function serviceJailRoot(service: string): string {
+  return path.posix.join(STACKS_ROOT, service);
+}
+
+/**
+ * Confine a declared move endpoint to the requesting service's jail
+ * (`/mnt/data/stacks/<service>`). Rejects a non-absolute path, a `..`
+ * escape, an embedded NUL, and anything that resolves outside the jail
+ * (a sibling service, a system dir, the volume root). This is the
+ * *authorization* gate — the executor calls themselves are already
+ * args-array/shell-quote-safe, so the risk is path scope, not injection.
+ *
+ * Mirrors the lexical canonicalize-and-boundary approach of
+ * `mcp/pathJail.ts`, but anchored to the per-service root rather than the
+ * whole data volume, and we require the input to be absolute (a move
+ * action names a concrete path on the node, never a relative one).
+ */
+function jailMovePath(label: 'src' | 'dst', input: string, jailRoot: string): string {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new Error(`move.${label} is required.`);
+  }
+  if (input.includes('\0')) {
+    throw new Error(`move.${label} contains a NUL byte.`);
+  }
+  if (!input.startsWith('/')) {
+    throw new Error(`move.${label} must be an absolute path: "${input}".`);
+  }
+  // Collapse `.`/`..` segments lexically, then require the result to stay
+  // inside the service's jail (the root itself or a descendant).
+  const resolved = path.posix.resolve(input);
+  if (resolved !== jailRoot && !resolved.startsWith(`${jailRoot}/`)) {
+    throw new Error(
+      `move.${label} escapes the service's data jail ${jailRoot}: "${input}" resolves to "${resolved}".`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Confine a declared restart target to the requesting service itself. A
+ * request may only bounce its *own* service — never an arbitrary,
+ * load-bearing one (basic/authelia/servicebay/…), where a restart can
+ * wipe SSO/OIDC clients or take the node's gateway down.
+ */
+function assertRestartTarget(target: string, service: string): void {
+  if (typeof target !== 'string' || !SERVICE_NAME_RE.test(target)) {
+    throw new Error(`restart target is not a valid service name: "${target}".`);
+  }
+  if (target !== service) {
+    throw new Error(
+      `restart target "${target}" is not the requesting service "${service}"; a request may only restart its own service.`,
+    );
+  }
+}
+
 /** A declared side effect. Both fields optional so a request can move a
  *  file, restart a service, both, or neither (a pure review gate). */
 export interface ApprovalAction {
@@ -130,9 +199,14 @@ export async function submitApproval(input: SubmitApprovalInput): Promise<Approv
  * a soft warning rather than rolling back the move (the move is the
  * load-bearing part; the restart is a best-effort nudge).
  */
-async function runAction(action: ApprovalAction, node: string): Promise<{ restarted?: boolean; restartError?: string }> {
+async function runAction(action: ApprovalAction, node: string, service: string): Promise<{ restarted?: boolean; restartError?: string }> {
   if (action.move) {
-    const { src, dst } = action.move;
+    // AUTHORIZE both endpoints into the requesting service's jail BEFORE
+    // touching the node — a non-absolute / ../-escape / out-of-jail path
+    // throws here and nothing is moved.
+    const jailRoot = serviceJailRoot(service);
+    const src = jailMovePath('src', action.move.src, jailRoot);
+    const dst = jailMovePath('dst', action.move.dst, jailRoot);
     const executor = getExecutor(node);
     if (!(await executor.exists(src))) {
       throw new Error(`Source path not found: ${src}`);
@@ -144,6 +218,8 @@ async function runAction(action: ApprovalAction, node: string): Promise<{ restar
     await executor.rename(src, dst);
   }
   if (action.restart) {
+    // AUTHORIZE the restart target — must be the requesting service itself.
+    assertRestartTarget(action.restart, service);
     try {
       await ServiceManager.restartService(node, action.restart);
       return { restarted: true };
@@ -165,7 +241,7 @@ async function resolve(id: string, status: 'approved' | 'rejected', action: Appr
   if (request.status !== 'pending') {
     throw new Error(`Approval request ${id} is already ${request.status}`);
   }
-  const result = await runAction(action, request.node);
+  const result = await runAction(action, request.node, request.service);
   request.status = status;
   await writeStore(all);
   logger.info(TAG, `${status} approval ${id} (service ${request.service})`);

--- a/packages/backend/src/lib/logger.ts
+++ b/packages/backend/src/lib/logger.ts
@@ -41,25 +41,38 @@ function toLogTimestamp(d: Date): string {
 }
 
 /**
- * Delete log rows older than `retentionDays` and reclaim disk space.
+ * Reclaim disk space freed by a prune.
  *
- * SQLite leaves freed pages in the file after a DELETE, so the 6.4 GB pile
- * only actually shrinks once we checkpoint the WAL and VACUUM. We only VACUUM
- * when rows were actually deleted (VACUUM rewrites the whole DB and is
- * expensive — it must not run on every insert / no-op prune).
+ * SQLite leaves freed pages in the file after a DELETE, so the file only
+ * actually shrinks once we checkpoint the WAL and VACUUM. VACUUM rewrites the
+ * whole DB and, on a multi-GB logs.db, is *very* expensive — on the box it
+ * blocked the synchronous boot path for ~31 min (#1883), leaving :5888 dark.
+ *
+ * `better-sqlite3` is fully synchronous, so this MUST NOT run on the
+ * module-eval / startup path. Callers run it out-of-band (deferred via
+ * `setImmediate`) after the server is listening; see `Logger.maybePrune`.
+ */
+export function vacuumLogsDb(db: Database): void {
+  // Flush + truncate the WAL, then rewrite the DB file.
+  db.pragma('wal_checkpoint(TRUNCATE)');
+  db.exec('VACUUM');
+}
+
+/**
+ * Delete log rows older than `retentionDays`.
+ *
+ * The DELETE itself is cheap. Space reclamation (the expensive VACUUM that
+ * rewrites the file) is deliberately NOT done here — it's split into
+ * `vacuumLogsDb` so it can run out-of-band off the boot path (#1883). We only
+ * VACUUM when rows were actually deleted, so this returns the deleted count to
+ * let the caller decide whether a reclaim is worth scheduling.
  *
  * Returns the number of rows deleted.
  */
 export function pruneLogsDb(db: Database, retentionDays = LOG_RETENTION_DAYS, now: Date = new Date()): number {
   const cutoff = toLogTimestamp(new Date(now.getTime() - retentionDays * PRUNE_INTERVAL_MS));
   const info = db.prepare('DELETE FROM logs WHERE timestamp < ?').run(cutoff);
-  const deleted = Number(info.changes);
-  if (deleted > 0) {
-    // Reclaim space: flush + truncate the WAL, then rewrite the DB file.
-    db.pragma('wal_checkpoint(TRUNCATE)');
-    db.exec('VACUUM');
-  }
-  return deleted;
+  return Number(info.changes);
 }
 
 interface LogEntry {
@@ -96,6 +109,8 @@ class Logger {
   private onLogCallbacks: Set<(entry: LogEntry) => void> = new Set();
   /** Epoch ms of the last retention prune; gates the lazy periodic prune (#1869). */
   private lastPruneAt = 0;
+  /** True while a deferred space-reclamation VACUUM is queued/in-flight (#1883). */
+  private vacuumScheduled = false;
 
   constructor() {
     if (isServer) {
@@ -147,8 +162,10 @@ class Logger {
                 this.db!.exec('CREATE INDEX IF NOT EXISTS idx_logs_trace ON logs(trace_id, timestamp)');
 
                 // Startup retention prune (#1869): drop rows older than the
-                // retention window + VACUUM. Cuts down the existing multi-GB
-                // logs.db pile on first deploy.
+                // retention window. The DELETE is cheap and runs synchronously
+                // here; the expensive space-reclaiming VACUUM is deferred
+                // out-of-band via setImmediate so a multi-GB logs.db doesn't
+                // freeze the boot path / leave :5888 dark for ~31 min (#1883).
                 this.maybePrune(true);
             } catch (e) {
                 console.error('Failed to initialize SQLite logger:', e);
@@ -236,20 +253,52 @@ class Logger {
   /**
    * Run the retention prune at most once per PRUNE_INTERVAL_MS (#1869),
    * or unconditionally when `force` (the startup prune). The cheap
-   * timestamp check guards the hot insert path so VACUUM is never paid
-   * per-insert; the actual VACUUM inside pruneLogsDb only runs when rows
-   * were deleted.
+   * timestamp check guards the hot insert path so the prune is never paid
+   * per-insert.
+   *
+   * The DELETE runs synchronously (it's cheap). Space reclamation — the
+   * expensive full VACUUM that rewrites the whole file — is scheduled
+   * OUT-OF-BAND via `setImmediate` so it never blocks the synchronous boot
+   * path / event loop (#1883): a multi-GB logs.db VACUUM froze the process
+   * for ~31 min on the box, leaving :5888 dark. The deferred reclaim is
+   * fully non-fatal — a failed (or skipped) VACUUM must never crash the
+   * service; it just leaves the freed pages to be reclaimed next cycle.
    */
   private maybePrune(force = false): void {
       if (!this.db) return;
       const now = Date.now();
       if (!force && now - this.lastPruneAt < PRUNE_INTERVAL_MS) return;
       this.lastPruneAt = now;
+      let deleted = 0;
       try {
-          pruneLogsDb(this.db);
+          deleted = pruneLogsDb(this.db);
       } catch (e) {
           console.error('Failed to prune logs.db:', e);
+          return;
       }
+      if (deleted > 0) this.scheduleVacuum();
+  }
+
+  /**
+   * Schedule the space-reclamation VACUUM off the synchronous boot path
+   * (#1883). `setImmediate` lets the event loop keep serving requests —
+   * critically the first boot, where the constructor's startup prune would
+   * otherwise rewrite a multi-GB file inline and leave :5888 dark for the
+   * whole VACUUM. Coalesces concurrent requests (at most one in flight) and
+   * is fully non-fatal: any failure is logged and swallowed.
+   */
+  private scheduleVacuum(): void {
+      if (!this.db || this.vacuumScheduled) return;
+      this.vacuumScheduled = true;
+      setImmediate(() => {
+          this.vacuumScheduled = false;
+          if (!this.db) return;
+          try {
+              vacuumLogsDb(this.db);
+          } catch (e) {
+              console.error('Failed to reclaim logs.db space (VACUUM):', e);
+          }
+      });
   }
 
   private format(level: LogLevel, tag: string, message: string, args: unknown[]): LogEntry {

--- a/tests/backend/logger_retention.test.ts
+++ b/tests/backend/logger_retention.test.ts
@@ -8,12 +8,12 @@
  * and timestamp format). This is the actual code the Logger constructor
  * (startup prune) and insertLog (lazy periodic prune) call.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type BetterSqlite3 from 'better-sqlite3';
-import { pruneLogsDb, LOG_RETENTION_DAYS } from '@/lib/logger';
+import { pruneLogsDb, vacuumLogsDb, LOG_RETENTION_DAYS } from '@/lib/logger';
 
 // Value import via require to mirror production (logger.ts / rateLimit.ts)
 // and keep knip from flagging better-sqlite3 as an unlisted root dependency
@@ -104,11 +104,11 @@ describe('pruneLogsDb (#1869)', () => {
   const freelist = (d: InstanceType<typeof Database>) =>
     d.pragma('freelist_count', { simple: true }) as number;
 
-  it('VACUUM runs after a prune so freed pages are reclaimed', () => {
-    // Build a fat DB of old rows, checkpoint so the data lands in the main
-    // file. After DELETE the pages sit on the freelist (file does not shrink
-    // on DELETE alone — the bug); only the VACUUM in pruneLogsDb rewrites the
-    // DB and drops the page count back down.
+  it('pruneLogsDb does NOT VACUUM — freed pages stay on the freelist until reclaim (#1883)', () => {
+    // The DELETE is cheap; the expensive VACUUM is split out so it can run
+    // off the boot path. After pruneLogsDb the pages must sit on the freelist
+    // (NOT reclaimed synchronously) — this is what proves the boot path no
+    // longer pays a blocking full VACUUM inline.
     seed(db, daysAgo(20), 20000);
     db.pragma('wal_checkpoint(TRUNCATE)');
     const before = pageCount(db);
@@ -117,21 +117,35 @@ describe('pruneLogsDb (#1869)', () => {
     const deleted = pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
     expect(deleted).toBe(20000);
 
-    // VACUUM reclaimed the freed pages: page count collapsed and the
-    // freelist is empty.
+    // No VACUUM happened: the file did NOT shrink and the freed pages are
+    // parked on the freelist.
+    expect(pageCount(db)).toBe(before);
+    expect(freelist(db)).toBeGreaterThan(0);
+  });
+
+  it('vacuumLogsDb reclaims the freed pages out-of-band (#1883)', () => {
+    seed(db, daysAgo(20), 20000);
+    db.pragma('wal_checkpoint(TRUNCATE)');
+    const before = pageCount(db);
+
+    pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
+    // Now run the deferred reclaim explicitly (production runs this via
+    // setImmediate, off the synchronous boot path).
+    vacuumLogsDb(db);
+
+    // VACUUM rewrote the DB: page count collapsed and the freelist is empty.
     expect(pageCount(db)).toBeLessThan(before / 10);
     expect(freelist(db)).toBe(0);
   });
 
-  it('does not VACUUM when nothing is old (no-op prune leaves the DB untouched)', () => {
+  it('does not delete when nothing is old (no-op prune leaves the DB untouched)', () => {
     seed(db, NOW, 5000);
     db.pragma('wal_checkpoint(TRUNCATE)');
     const before = pageCount(db);
 
     const deleted = pruneLogsDb(db, LOG_RETENTION_DAYS, NOW);
 
-    // No rows deleted -> VACUUM skipped (it is expensive) -> page count and
-    // row count unchanged.
+    // No rows deleted -> page count and row count unchanged.
     expect(deleted).toBe(0);
     expect(pageCount(db)).toBe(before);
     expect(rowCount(db)).toBe(5000);
@@ -149,5 +163,90 @@ describe('pruneLogsDb (#1869)', () => {
     // At the end only the last ~7 days of inserts survive (<= 8 batches).
     expect(rowCount(db)).toBeLessThanOrEqual(8 * 100);
     expect(rowCount(db)).toBeGreaterThan(0);
+  });
+});
+
+describe('Logger startup boot path does not block on VACUUM (#1883)', () => {
+  let cwdDir: string;
+  let realCwd: () => string;
+
+  const pageCount = (d: InstanceType<typeof Database>) =>
+    d.pragma('page_count', { simple: true }) as number;
+  const freelist = (d: InstanceType<typeof Database>) =>
+    d.pragma('freelist_count', { simple: true }) as number;
+
+  beforeEach(() => {
+    // The Logger singleton binds to process.cwd()/data/logs.db at construction.
+    // Stub cwd so a freshly-imported module builds against our pre-seeded DB.
+    cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-logboot-'));
+    fs.mkdirSync(path.join(cwdDir, 'data'), { recursive: true });
+    realCwd = process.cwd;
+    process.cwd = () => cwdDir;
+  });
+
+  afterEach(() => {
+    process.cwd = realCwd;
+    vi.useRealTimers();
+    vi.resetModules();
+    fs.rmSync(cwdDir, { recursive: true, force: true });
+  });
+
+  it('constructor runs the DELETE but defers the full VACUUM off the synchronous boot path', async () => {
+    // Pre-seed a "multi-GB pile" analogue: a fat logs.db of old rows so a
+    // startup VACUUM would be the expensive, event-loop-freezing one.
+    const seedDb = new Database(path.join(cwdDir, 'data', 'logs.db'));
+    seedDb.pragma('journal_mode = WAL');
+    seedDb.exec(TABLE);
+    const old = ts(new Date(Date.now() - 20 * 24 * 60 * 60 * 1000));
+    const insert = seedDb.prepare('INSERT INTO logs (timestamp, level, tag, message) VALUES (?, ?, ?, ?)');
+    const tx = seedDb.transaction(() => {
+      for (let i = 0; i < 20000; i++) insert.run(old, 'info', 'boot', `m-${i}`);
+    });
+    tx();
+    seedDb.pragma('wal_checkpoint(TRUNCATE)');
+    const beforePages = pageCount(seedDb);
+    expect(beforePages).toBeGreaterThan(100);
+    seedDb.close();
+
+    // Fake timers so the deferred setImmediate VACUUM does NOT run until we
+    // explicitly flush it — this is exactly what proves it isn't synchronous.
+    vi.useFakeTimers();
+    vi.resetModules();
+    await import('@/lib/logger');
+
+    // Right after construction the boot DELETE has run (old rows gone) but the
+    // VACUUM has NOT — freed pages still sit on the freelist, file unshrunk.
+    const post = new Database(path.join(cwdDir, 'data', 'logs.db'));
+    expect(rowCount(post)).toBe(0); // 7-day DELETE removed the 20k old rows
+    // No synchronous VACUUM: the file did NOT collapse and the freed pages
+    // are parked on the freelist (a VACUUM would zero the freelist + shrink).
+    expect(pageCount(post)).toBeGreaterThan(beforePages / 2);
+    expect(freelist(post)).toBeGreaterThan(0); // reclaim is still pending
+    post.close();
+
+    // The deferred reclaim is scheduled out-of-band; flush it.
+    await vi.runAllTimersAsync();
+
+    const reclaimed = new Database(path.join(cwdDir, 'data', 'logs.db'));
+    expect(pageCount(reclaimed)).toBeLessThan(beforePages / 10); // VACUUM ran off-band
+    expect(freelist(reclaimed)).toBe(0);
+    reclaimed.close();
+  });
+
+  it('a failed deferred reclaim is non-fatal (does not crash the service)', async () => {
+    const seedDb = new Database(path.join(cwdDir, 'data', 'logs.db'));
+    seedDb.pragma('journal_mode = WAL');
+    seedDb.exec(TABLE);
+    seed(seedDb, new Date(Date.now() - 20 * 24 * 60 * 60 * 1000), 50);
+    seedDb.close();
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+    vi.resetModules();
+    // Constructing must not throw even though the deferred VACUUM will later
+    // run; flushing timers must not throw either.
+    await import('@/lib/logger');
+    await expect(vi.runAllTimersAsync()).resolves.not.toThrow();
+    errSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## What
Two independent backend hardening fixes:
- **logger** (#1883): the singleton startup VACUUM on a multi-GB logs.db ran synchronously on the module-eval boot path (better-sqlite3 is fully synchronous), freezing the process and leaving :5888 dark for ~31min. Split space-reclaim out of the boot path: the cheap 7-day DELETE still runs synchronously, the VACUUM is deferred out-of-band via setImmediate (coalesced, non-fatal).
- **approvals** (#1884, security): service-declared on_approve/on_reject `move` src/dst and the `restart` target were unvalidated. Now the move is confined to the requesting service's data jail (`/mnt/data/stacks/<service>`, rejecting non-absolute, `../`, NUL, and any path resolving outside the jail) and the restart target is restricted to the requesting service itself (no bouncing basic/authelia/servicebay). Pure review-gate requests unaffected.

## Why
Closes #1883
Closes #1884

## Risk
Low — logger reclaim is now deferred/non-fatal; approvals adds rejection guards only (happy-path move/restart to own jail/self unchanged).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full — 2630 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — not required (no path-mandated files touched: logger.ts, approvals lib, api/approvals route)

AI-generated
<!-- sb-ai-comment -->