### PR TITLE
feat(backups): surface NAS schedule, back-up-now, Created column, and delete

### DIFF
--- a/packages/backend/src/lib/externalBackup/orphanBackups.test.ts
+++ b/packages/backend/src/lib/externalBackup/orphanBackups.test.ts
@@ -8,7 +8,7 @@ vi.mock('./producer', async (orig) => ({
 
 import { selectOrphanBackups, listOrphanServiceBackups } from './orphanBackups';
 
-const entry = (service: string) => ({ service, tarName: `${service}-20260615-0531.tar`, size: 1, stamp: '20260615-0531' });
+const entry = (service: string) => ({ service, tarName: `${service}-20260615-0531.tar`, size: 1, stamp: '20260615-0531', createdAt: '2026-06-15T05:31:00.000Z' });
 
 describe('selectOrphanBackups (#1218 entry 2)', () => {
   it('returns backups for services that are not installed', () => {

--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -44,6 +44,8 @@ import {
   fetchServiceBackup,
   getNextExternalBackupDelayMs,
   scheduleExternalNasBackup,
+  getNasBackupSchedule,
+  deleteServiceBackup,
   NAS_BACKUP_DIR,
   DEFAULT_BACKUP_RETENTION,
   latestServiceBackupName,
@@ -468,11 +470,11 @@ describe('read-back', () => {
     ]);
     const list = await listServiceBackups();
     expect(list).toEqual([
-      // adguard (A→Z) first; its bare slot has a null stamp.
-      { service: 'adguard', tarName: 'adguard.tar', size: 50, stamp: null },
-      // home-assistant newest snapshot first.
-      { service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 100, stamp: '20260615-0531' },
-      { service: 'home-assistant', tarName: 'home-assistant-20260614-0530.tar', size: 90, stamp: '20260614-0530' },
+      // adguard (A→Z) first; its bare slot has a null stamp + null createdAt.
+      { service: 'adguard', tarName: 'adguard.tar', size: 50, stamp: null, createdAt: null },
+      // home-assistant newest snapshot first; createdAt derived from the stamp (#1890).
+      { service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 100, stamp: '20260615-0531', createdAt: '2026-06-15T05:31:00.000Z' },
+      { service: 'home-assistant', tarName: 'home-assistant-20260614-0530.tar', size: 90, stamp: '20260614-0530', createdAt: '2026-06-14T05:30:00.000Z' },
     ]);
     expect(mockNas.nasList).toHaveBeenCalledWith(NAS_BACKUP_DIR);
   });
@@ -721,5 +723,64 @@ describe('scheduleExternalNasBackup', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(setTimeoutSpy).toHaveBeenCalled();
     setTimeoutSpy.mockRestore();
+  });
+});
+
+describe('getNasBackupSchedule (#1890)', () => {
+  it('surfaces the configured time + derived next run when enabled', async () => {
+    mockGetConfig.mockResolvedValue({ externalBackup: { enabled: true, time: '03:30' } });
+    const s = await getNasBackupSchedule(new Date('2026-06-01T01:00:00Z'));
+    // next run = 2h30m after 01:00 = 03:30 same day
+    expect(s).toEqual({ enabled: true, time: '03:30', nextRunAt: '2026-06-01T03:30:00.000Z' });
+  });
+
+  it('rolls the next run to tomorrow when the time already passed today', async () => {
+    mockGetConfig.mockResolvedValue({ externalBackup: { enabled: true, time: '03:30' } });
+    const s = await getNasBackupSchedule(new Date('2026-06-01T04:00:00Z'));
+    expect(s.nextRunAt).toBe('2026-06-02T03:30:00.000Z');
+  });
+
+  it('reports disabled with no next run when externalBackup.enabled is false', async () => {
+    mockGetConfig.mockResolvedValue({ externalBackup: { enabled: false, time: '04:00' } });
+    const s = await getNasBackupSchedule(new Date('2026-06-01T01:00:00Z'));
+    expect(s).toEqual({ enabled: false, time: '04:00', nextRunAt: null });
+  });
+
+  it('defaults to enabled at 03:30 when externalBackup is unset', async () => {
+    mockGetConfig.mockResolvedValue({});
+    const s = await getNasBackupSchedule(new Date('2026-06-01T00:00:00Z'));
+    expect(s).toEqual({ enabled: true, time: '03:30', nextRunAt: '2026-06-01T03:30:00.000Z' });
+  });
+});
+
+describe('deleteServiceBackup (#1890)', () => {
+  it('removes both the tar and its .meta.json sidecar', async () => {
+    mockNas.nasRemove.mockResolvedValue(undefined);
+    const r = await deleteServiceBackup('home-assistant-20260615-0531.tar');
+    expect(r).toEqual({ tarName: 'home-assistant-20260615-0531.tar', metaRemoved: true });
+    expect(mockNas.nasRemove).toHaveBeenNthCalledWith(1, `${NAS_BACKUP_DIR}/home-assistant-20260615-0531.tar`);
+    expect(mockNas.nasRemove).toHaveBeenNthCalledWith(2, `${NAS_BACKUP_DIR}/home-assistant-20260615-0531.tar.meta.json`);
+  });
+
+  it('still succeeds (metaRemoved:false) when the sidecar is absent — a bare legacy slot', async () => {
+    mockNas.nasRemove
+      .mockResolvedValueOnce(undefined) // tar
+      .mockRejectedValueOnce(new Error('550 not found')); // missing sidecar
+    const r = await deleteServiceBackup('adguard.tar');
+    expect(r).toEqual({ tarName: 'adguard.tar', metaRemoved: false });
+    expect(mockNas.nasRemove).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['path separator', 'sub/home-assistant.tar'],
+    ['parent traversal', '../home-assistant.tar'],
+    ['absolute path', '/etc/passwd.tar'],
+    ['backslash', 'a\\b.tar'],
+    ['NUL byte', 'evil\0.tar'],
+    ['not a tar', 'home-assistant.txt'],
+  ])('rejects a %s tarName without touching the NAS', async (_label, name) => {
+    await expect(deleteServiceBackup(name)).rejects.toThrow();
+    expect(mockNas.nasRemove).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -72,6 +72,22 @@ function backupStamp(when: Date): string {
 }
 
 /**
+ * Derive an ISO timestamp from a `YYYYMMDD-HHMM` UTC dated-slot stamp (#1890),
+ * so the UI can show a "Created" column without fetching every `.meta.json`
+ * sidecar. A null stamp (a bare legacy `<service>.tar`) has no embedded date →
+ * null (the UI renders "—"). The sidecar's `createdAt` is the authoritative
+ * source, but it's written from the same `Date` the stamp is, so the stamp is a
+ * faithful, network-free derivation.
+ */
+function createdAtFromStamp(stamp: string | null): string | null {
+  if (!stamp) return null;
+  const m = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})$/.exec(stamp);
+  if (!m) return null;
+  const [, y, mo, d, h, mi] = m;
+  return `${y}-${mo}-${d}T${h}:${mi}:00.000Z`;
+}
+
+/**
  * Parse a NAS tar filename into its service + (optional) dated stamp. A dated
  * slot resolves both; a bare legacy `<service>.tar` resolves the service with a
  * null stamp (so it sorts as the oldest / a valid undated snapshot). A non-tar
@@ -111,6 +127,11 @@ export interface ServiceBackupListEntry {
   /** The `YYYYMMDD-HHMM` UTC stamp parsed from a dated slot, or null for a bare
    *  legacy `<service>.tar` (pre-#1865). Lets the UI label / order snapshots. */
   stamp: string | null;
+  /** ISO timestamp the snapshot was created (#1890). Read from the `.meta.json`
+   *  sidecar's `createdAt` when present; otherwise derived from the dated `stamp`
+   *  (`YYYYMMDD-HHMM` UTC). Null for a bare legacy slot with no sidecar, which the
+   *  UI renders as "—". */
+  createdAt: string | null;
 }
 
 async function pathExists(target: string): Promise<boolean> {
@@ -603,6 +624,31 @@ export function scheduleExternalNasBackup(): void {
     });
 }
 
+/** The nightly NAS-backup schedule, for surfacing the "when" on Settings →
+ *  Backups (#1890). `nextRunAt` is null when disabled. */
+export interface NasBackupSchedule {
+  enabled: boolean;
+  /** Daily run time, 24h `HH:MM` UTC. */
+  time: string;
+  /** ISO timestamp of the next scheduled run, or null when disabled. */
+  nextRunAt: string | null;
+}
+
+/**
+ * Resolve the nightly NAS-backup schedule from config (#1890) so the UI can show
+ * the real configured time + next run instead of a vague "nightly". Derives the
+ * next run from `getNextExternalBackupDelayMs` — the same source the scheduler
+ * uses — so the surfaced time matches what actually fires.
+ */
+export async function getNasBackupSchedule(now: Date = new Date()): Promise<NasBackupSchedule> {
+  const cfg = (await getConfig()).externalBackup;
+  const enabled = cfg?.enabled !== false; // enabled unless explicitly disabled
+  const time = cfg?.time || DEFAULT_EXTERNAL_BACKUP_TIME;
+  if (!enabled) return { enabled: false, time, nextRunAt: null };
+  const nextRunAt = new Date(now.getTime() + getNextExternalBackupDelayMs(time, now)).toISOString();
+  return { enabled: true, time, nextRunAt };
+}
+
 /** Resolve the per-service retention (keep N most-recent) from config (#1865). */
 async function getBackupRetention(): Promise<number> {
   const configured = (await getConfig()).externalBackup?.retention;
@@ -674,6 +720,45 @@ async function writeServiceBackupToNas(service: string, tar: Buffer): Promise<Se
 }
 
 /**
+ * Delete one NAS snapshot — the tar AND its `.meta.json` sidecar (#1890),
+ * mirroring `pruneServiceBackups`' cleanup. `tarName` is operator-supplied (a
+ * NAS path), so it's validated: it must be a bare basename (no directory
+ * separators / `..` traversal / NUL), end in `.tar`, and not be a sidecar
+ * itself. The sidecar remove is best-effort — a legacy bare slot may have none,
+ * and a missing sidecar must not fail the tar delete.
+ */
+export async function deleteServiceBackup(tarName: string): Promise<{ tarName: string; metaRemoved: boolean }> {
+  if (typeof tarName !== 'string' || !tarName) {
+    throw new Error('tarName is required');
+  }
+  // Reject any path component, traversal, or NUL — `tarName` names a file inside
+  // sb-backup/, never a path. basename!==input catches `../`, `a/b`, leading `/`.
+  if (
+    tarName.includes('/') ||
+    tarName.includes('\\') ||
+    tarName.includes('\0') ||
+    path.posix.basename(tarName) !== tarName
+  ) {
+    throw new Error(`Invalid backup name: "${tarName}"`);
+  }
+  if (!tarName.endsWith('.tar')) {
+    throw new Error(`Not a service backup tar: "${tarName}"`);
+  }
+
+  await nasRemove(path.posix.join(NAS_BACKUP_DIR, tarName));
+  let metaRemoved = false;
+  try {
+    await nasRemove(path.posix.join(NAS_BACKUP_DIR, `${tarName}.meta.json`));
+    metaRemoved = true;
+  } catch (e) {
+    // A bare legacy slot has no sidecar — don't fail the delete over it.
+    logger.info('ExternalBackup', `No meta sidecar removed for ${tarName}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  logger.info('ExternalBackup', `Deleted NAS backup ${tarName}${metaRemoved ? ' (+ sidecar)' : ''}`);
+  return { tarName, metaRemoved };
+}
+
+/**
  * Stage an uploaded, already-container-shaped `<service>.tar` onto the NAS in
  * the restore layout (#1351). Lets the TUI / extractors seed a fresh install's
  * NAS from the operator's machine. The service must have a backup manifest (so
@@ -706,7 +791,15 @@ export async function listServiceBackups(): Promise<ServiceBackupListEntry[]> {
     .filter(f => f.name.endsWith('.tar')) // drops `.tar.meta.json` sidecars
     .map(f => {
       const parsed = parseSlotName(f.name);
-      return parsed ? { service: parsed.service, tarName: f.name, size: f.size, stamp: parsed.stamp } : null;
+      return parsed
+        ? {
+            service: parsed.service,
+            tarName: f.name,
+            size: f.size,
+            stamp: parsed.stamp,
+            createdAt: createdAtFromStamp(parsed.stamp),
+          }
+        : null;
     })
     .filter((e): e is ServiceBackupListEntry => e !== null)
     .sort((a, b) =>

--- a/packages/backend/src/lib/externalBackup/registerSource.test.ts
+++ b/packages/backend/src/lib/externalBackup/registerSource.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockGetConfig, mockUpdateConfig, mockTestNas, mockListBackups, mockResolveTarget } = vi.hoisted(() => ({
+const { mockGetConfig, mockUpdateConfig, mockTestNas, mockListBackups, mockResolveTarget, mockSchedule } = vi.hoisted(() => ({
   mockGetConfig: vi.fn(),
   mockUpdateConfig: vi.fn(),
   mockTestNas: vi.fn(),
   mockListBackups: vi.fn(),
   mockResolveTarget: vi.fn(),
+  mockSchedule: vi.fn(),
 }));
 
 vi.mock('../config', () => ({
@@ -16,7 +17,10 @@ vi.mock('./nasClient', () => ({
   testNasConnection: () => mockTestNas(),
   resolveBackupTarget: () => mockResolveTarget(),
 }));
-vi.mock('./producer', () => ({ listServiceBackups: () => mockListBackups() }));
+vi.mock('./producer', () => ({
+  listServiceBackups: () => mockListBackups(),
+  getNasBackupSchedule: () => mockSchedule(),
+}));
 
 import {
   registerNasSource,
@@ -35,8 +39,11 @@ beforeEach(() => {
   // Default: no destination resolves (not configured). Configured tests below
   // set a non-null resolved target.
   mockResolveTarget.mockResolvedValue(null);
-  mockListBackups.mockResolvedValue([{ service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 2_340_000, stamp: '20260615-0531' }]);
+  mockListBackups.mockResolvedValue([{ service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 2_340_000, stamp: '20260615-0531', createdAt: '2026-06-15T05:31:00.000Z' }]);
+  mockSchedule.mockResolvedValue(SCHEDULE);
 });
+
+const SCHEDULE = { enabled: true, time: '03:30', nextRunAt: '2026-06-17T03:30:00.000Z' };
 
 const FTP_TARGET = { transport: 'ftp', host: '192.168.178.1', user: 'fritz9746', password: 'pw', secure: false };
 
@@ -84,19 +91,20 @@ describe('registerNasSource', () => {
 });
 
 describe('getNasBackupOverview', () => {
-  it('reports not-configured when no FritzBox gateway is set', async () => {
+  it('reports not-configured when no FritzBox gateway is set, still surfacing the schedule (#1890)', async () => {
     const o = await getNasBackupOverview();
-    expect(o).toEqual({ configured: false, connection: null, backups: [] });
+    expect(o).toEqual({ configured: false, connection: null, backups: [], schedule: SCHEDULE });
     expect(mockTestNas).not.toHaveBeenCalled();
   });
 
-  it('lists NAS backups when configured and connected', async () => {
+  it('lists NAS backups when configured and connected, with createdAt + schedule (#1890)', async () => {
     mockGetConfig.mockResolvedValue({ gateway: { type: 'fritzbox', ...REG } });
     mockResolveTarget.mockResolvedValue(FTP_TARGET);
     const o = await getNasBackupOverview();
     expect(o.configured).toBe(true);
     expect(o.connection).toEqual({ ok: true });
-    expect(o.backups).toEqual([{ service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 2_340_000, stamp: '20260615-0531' }]);
+    expect(o.backups).toEqual([{ service: 'home-assistant', tarName: 'home-assistant-20260615-0531.tar', size: 2_340_000, stamp: '20260615-0531', createdAt: '2026-06-15T05:31:00.000Z' }]);
+    expect(o.schedule).toEqual(SCHEDULE);
   });
 
   it('surfaces a connection failure with no backups', async () => {

--- a/packages/backend/src/lib/externalBackup/registerSource.ts
+++ b/packages/backend/src/lib/externalBackup/registerSource.ts
@@ -18,7 +18,12 @@
 import { getConfig, updateConfig, type GatewayConfig, type ExternalBackupTarget } from '../config';
 import { logger } from '../logger';
 import { testNasConnection, resolveBackupTarget } from './nasClient';
-import { listServiceBackups, type ServiceBackupListEntry } from './producer';
+import {
+  listServiceBackups,
+  getNasBackupSchedule,
+  type ServiceBackupListEntry,
+  type NasBackupSchedule,
+} from './producer';
 
 /**
  * Settings → Backups destination view (#1525/#1527). Never echoes a stored
@@ -168,6 +173,10 @@ export interface NasBackupOverview {
   /** Service backups staged under `sb-backup/` on the NAS (empty on any error
    *  or when not configured). */
   backups: ServiceBackupListEntry[];
+  /** The nightly NAS-backup schedule (#1890) — when the automatic push runs.
+   *  Always present, independent of whether a destination is reachable, so both
+   *  the System Snapshot and Snapshot-on-NAS sections can show the real "when". */
+  schedule: NasBackupSchedule;
 }
 
 /**
@@ -177,23 +186,26 @@ export interface NasBackupOverview {
  * connection error and offers a retry/verify.
  */
 export async function getNasBackupOverview(): Promise<NasBackupOverview> {
+  // The schedule is surfaced regardless of destination reachability — both
+  // Backups sections show the real "when" (#1890).
+  const schedule = await getNasBackupSchedule();
   // "Configured" now follows the resolved destination (#1527), not just the
   // gateway: a separate FTP/SSH target counts even with no FritzBox gateway.
   const configured = (await resolveBackupTarget()) !== null;
   if (!configured) {
-    return { configured: false, connection: null, backups: [] };
+    return { configured: false, connection: null, backups: [], schedule };
   }
   const connection = await testNasConnection();
   if (!connection.ok) {
-    return { configured: true, connection, backups: [] };
+    return { configured: true, connection, backups: [], schedule };
   }
   try {
     const backups = await listServiceBackups();
-    return { configured: true, connection, backups };
+    return { configured: true, connection, backups, schedule };
   } catch (e) {
     // The probe connected but the listing failed (e.g. sb-backup/ absent on a
     // brand-new NAS) — treat as "connected, nothing staged yet".
     logger.warn('ExternalBackup', `NAS connected but listing failed: ${e instanceof Error ? e.message : String(e)}`);
-    return { configured: true, connection, backups: [] };
+    return { configured: true, connection, backups: [], schedule };
   }
 }

--- a/packages/frontend/src/app/(dashboard)/settings/backups/_lib/useBackupState.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/_lib/useBackupState.ts
@@ -101,11 +101,19 @@ export function useBackupState() {
     configured: boolean;
     connection: { ok: true } | { ok: false; error: string } | null;
     // `stamp` is the dated-snapshot timestamp (null for a bare legacy slot, #1865).
-    backups: { service: string; tarName: string; size: number; stamp?: string | null }[];
+    // `createdAt` is the ISO creation time (null for an undated legacy slot, #1890).
+    backups: { service: string; tarName: string; size: number; stamp?: string | null; createdAt?: string | null }[];
+    // The nightly NAS-backup schedule (#1890) — when the automatic push runs.
+    schedule?: { enabled: boolean; time: string; nextRunAt: string | null };
   } | null>(null);
   const [nasLoading, setNasLoading] = useState(true);
   const [nasRestoring, setNasRestoring] = useState<string | null>(null);
   const [nasRestoreTarget, setNasRestoreTarget] = useState<{ service: string; tarName: string } | null>(null);
+  // NAS "back up now" (#1890) — reuses the existing backup-now route.
+  const [nasBackingUp, setNasBackingUp] = useState(false);
+  // NAS per-row Delete (#1890) — confirm target + in-flight tarName.
+  const [nasDeleteTarget, setNasDeleteTarget] = useState<{ service: string; tarName: string } | null>(null);
+  const [nasDeleting, setNasDeleting] = useState(false);
 
   const fetchBackups = useCallback(async () => {
     setBackupsLoading(true);
@@ -183,7 +191,7 @@ export function useBackupState() {
       const res = await fetch('/api/system/external-backup/list');
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error || 'Unable to read NAS backups');
-      setNasOverview({ configured: data.configured, connection: data.connection, backups: data.backups ?? [] });
+      setNasOverview({ configured: data.configured, connection: data.connection, backups: data.backups ?? [], schedule: data.schedule });
     } catch (error) {
       console.error(error);
       setNasOverview({ configured: false, connection: null, backups: [] });
@@ -222,6 +230,9 @@ export function useBackupState() {
     nasLoading,
     nasRestoring, setNasRestoring,
     nasRestoreTarget, setNasRestoreTarget,
+    nasBackingUp, setNasBackingUp,
+    nasDeleteTarget, setNasDeleteTarget,
+    nasDeleting, setNasDeleting,
     fetchBackups,
     fetchBackupSync,
     fetchNasOverview,

--- a/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/page.tsx
@@ -85,6 +85,9 @@ export default function BackupsSettingsPage() {
     nasLoading,
     nasRestoring, setNasRestoring,
     nasRestoreTarget, setNasRestoreTarget,
+    nasBackingUp, setNasBackingUp,
+    nasDeleteTarget, setNasDeleteTarget,
+    nasDeleting, setNasDeleting,
     fetchBackups,
     fetchBackupSync,
     fetchNasOverview,
@@ -116,6 +119,56 @@ export default function BackupsSettingsPage() {
       setNasRestoreTarget(null);
     }
   }, [nasRestoreTarget, nasRestoring, addToast, setNasRestoring, setNasRestoreTarget]);
+
+  // "Back up to NAS now" (#1890) — reuses the EXISTING backup-now route (no new
+  // endpoint); same progress/result feedback as the System-Snapshot create.
+  const handleNasBackupNow = useCallback(async () => {
+    if (nasBackingUp) return;
+    setNasBackingUp(true);
+    try {
+      const res = await fetch('/api/system/external-backup/backup-now', { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Backup failed');
+      const failed = (data.results ?? []).filter((r: { ok: boolean }) => !r.ok).length;
+      if (data.backedUp === 0 && data.total > 0) {
+        const firstError = (data.results ?? []).find((r: { error?: string }) => r.error)?.error;
+        throw new Error(firstError || 'No services were backed up');
+      }
+      addToast(
+        failed > 0 ? 'info' : 'success',
+        'Backed up to NAS',
+        `${data.backedUp}/${data.total} service${data.total === 1 ? '' : 's'} pushed to the NAS${failed > 0 ? ` (${failed} failed)` : ''}.`,
+      );
+      await fetchNasOverview();
+    } catch (error) {
+      addToast('error', 'NAS backup failed', error instanceof Error ? error.message : 'Unknown error');
+    } finally {
+      setNasBackingUp(false);
+    }
+  }, [nasBackingUp, addToast, setNasBackingUp, fetchNasOverview]);
+
+  // Delete one NAS snapshot — the tar + its .meta.json sidecar (#1890).
+  const confirmDeleteNasBackup = useCallback(async () => {
+    if (!nasDeleteTarget || nasDeleting) return;
+    const { tarName } = nasDeleteTarget;
+    setNasDeleting(true);
+    try {
+      const res = await fetch('/api/system/external-backup/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ service: nasDeleteTarget.service, tarName }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Delete failed');
+      addToast('success', 'NAS backup deleted', `${tarName} has been removed from the NAS.`);
+      await fetchNasOverview();
+    } catch (error) {
+      addToast('error', 'Failed to delete NAS backup', error instanceof Error ? error.message : 'Unknown error');
+    } finally {
+      setNasDeleting(false);
+      setNasDeleteTarget(null);
+    }
+  }, [nasDeleteTarget, nasDeleting, addToast, setNasDeleting, setNasDeleteTarget, fetchNasOverview]);
 
   // ─── Backup Sync handlers ─────────────────────────────────────────
   const buildBackupTarget = () => {
@@ -661,6 +714,16 @@ export default function BackupsSettingsPage() {
     return parts.length > 0 ? parts.join(', ') : 'Nothing selected';
   };
 
+  // The nightly NAS-backup schedule (#1890), surfaced on both sections so the
+  // operator sees the real time + next run instead of a vague "nightly".
+  const schedule = nasOverview?.schedule;
+  const scheduleLine = !schedule
+    ? null
+    : !schedule.enabled
+      ? 'Nightly NAS backup is disabled.'
+      : `Runs nightly at ${schedule.time} UTC` +
+        (schedule.nextRunAt ? ` · next run ${new Date(schedule.nextRunAt).toLocaleString()}` : '');
+
   return (
     <>
       {/* Primary CTA: one-click restore from latest snapshot. The selective
@@ -711,7 +774,12 @@ export default function BackupsSettingsPage() {
             </div>
             <div>
               <h3 className="font-bold text-gray-900 dark:text-white">System Snapshot</h3>
-              <p className="text-xs text-gray-500 dark:text-gray-400">Your setup and per-service config (settings, not bulk data). Download it on demand, and it&apos;s pushed to the NAS nightly and auto-restored on reinstall.</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Your setup and per-service config (settings, not bulk data). Download it on demand; it&apos;s pushed to the NAS on a schedule and auto-restored on reinstall.</p>
+              {scheduleLine && (
+                <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+                  <Clock size={12} /> {scheduleLine}
+                </p>
+              )}
               {backupStatus !== 'idle' && (
                 <div className="mt-1 flex items-center gap-2 text-[11px] text-gray-600 dark:text-gray-300">
                   {backupStatus === 'running' && (
@@ -868,15 +936,31 @@ export default function BackupsSettingsPage() {
             <div>
               <h3 className="font-bold text-gray-900 dark:text-white">Snapshot on NAS</h3>
               <p className="text-xs text-gray-500 dark:text-gray-400">Where the System Snapshot is pushed off-box so a fresh install can auto-restore it — the FritzBox USB NAS by default, or a separate FTP/SSH destination you set below.</p>
+              {scheduleLine && (
+                <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+                  <Clock size={12} /> {scheduleLine}
+                </p>
+              )}
             </div>
           </div>
-          <button
-            onClick={() => void fetchNasOverview()}
-            disabled={nasLoading}
-            className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200 text-sm rounded-lg border border-gray-300 dark:border-gray-700 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
-          >
-            {nasLoading ? <Loader2 className="animate-spin" size={16} /> : <RefreshCw size={16} />} Verify connection
-          </button>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+            <button
+              onClick={handleNasBackupNow}
+              disabled={nasBackingUp || !nasOverview?.configured}
+              className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm rounded-lg shadow-sm hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title={!nasOverview?.configured ? 'Configure a NAS destination below first' : undefined}
+            >
+              {nasBackingUp ? <Loader2 className="animate-spin" size={16} /> : <UploadCloud size={16} />}
+              {nasBackingUp ? 'Backing up…' : 'Back up now'}
+            </button>
+            <button
+              onClick={() => void fetchNasOverview()}
+              disabled={nasLoading}
+              className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200 text-sm rounded-lg border border-gray-300 dark:border-gray-700 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+            >
+              {nasLoading ? <Loader2 className="animate-spin" size={16} /> : <RefreshCw size={16} />} Verify connection
+            </button>
+          </div>
         </div>
         <div className="p-6 space-y-6">
           {/* Destination config (#1525/#1527): FritzBox NAS creds defaulting to
@@ -911,24 +995,41 @@ export default function BackupsSettingsPage() {
                       <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-800">
                         <th className="py-2 font-medium">Service</th>
                         <th className="py-2 font-medium">File</th>
+                        <th className="py-2 font-medium">Created</th>
                         <th className="py-2 font-medium">Size</th>
                         <th className="py-2 font-medium text-right">Actions</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
-                      {nasOverview.backups.map(b => (
+                      {/* Newest-first: `createdAt`/`stamp` desc, undated legacy
+                          slots (null) sort last. The list is already grouped
+                          per-service newest-first; this flattens to a global
+                          newest-first order for the table (#1890). */}
+                      {[...nasOverview.backups]
+                        .sort((a, b) => (b.createdAt ?? b.stamp ?? '').localeCompare(a.createdAt ?? a.stamp ?? ''))
+                        .map(b => (
                         <tr key={b.tarName}>
                           <td className="py-3 text-gray-700 dark:text-gray-200">{b.service}</td>
                           <td className="py-3 font-mono text-xs text-blue-600 dark:text-blue-300 break-all">{b.tarName}</td>
+                          <td className="py-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                            {b.createdAt ? new Date(b.createdAt).toLocaleString() : '—'}
+                          </td>
                           <td className="py-3 text-gray-700 dark:text-gray-300">{formatBytes(b.size)}</td>
                           <td className="py-3">
-                            <div className="flex justify-end">
+                            <div className="flex justify-end gap-2">
                               <button
                                 onClick={() => setNasRestoreTarget({ service: b.service, tarName: b.tarName })}
                                 disabled={nasRestoring !== null}
                                 className="text-xs px-3 py-1.5 rounded-md border border-amber-300 text-amber-700 dark:text-amber-300 dark:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors flex items-center gap-1 disabled:opacity-60"
                               >
                                 {nasRestoring === b.service ? <Loader2 className="animate-spin" size={14} /> : <RotateCcw size={14} />} Restore
+                              </button>
+                              <button
+                                onClick={() => setNasDeleteTarget({ service: b.service, tarName: b.tarName })}
+                                disabled={nasDeleting}
+                                className="text-xs px-3 py-1.5 rounded-md border border-red-200 text-red-600 dark:text-red-400 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors flex items-center gap-1 disabled:opacity-60"
+                              >
+                                <Trash2 size={14} /> Delete
                               </button>
                             </div>
                           </td>
@@ -1202,6 +1303,17 @@ export default function BackupsSettingsPage() {
         isDestructive
         onConfirm={confirmDeleteBackup}
         onCancel={() => !deletingBackup && setDeleteTarget(null)}
+      />
+
+      <ConfirmModal
+        isOpen={!!nasDeleteTarget}
+        title="Delete NAS backup"
+        message={`Delete ${nasDeleteTarget?.tarName ?? 'this backup'} from the FritzBox NAS permanently? This removes the snapshot and its metadata sidecar and cannot be undone.`}
+        confirmText={nasDeleting ? 'Deleting…' : 'Delete backup'}
+        confirmDisabled={nasDeleting}
+        isDestructive
+        onConfirm={confirmDeleteNasBackup}
+        onCancel={() => !nasDeleting && setNasDeleteTarget(null)}
       />
 
       <ConfirmModal

--- a/packages/frontend/src/app/api/system/external-backup/delete/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/delete/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { deleteServiceBackup } from '@/lib/externalBackup/producer';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST { service, tarName } — delete one NAS snapshot and its `.meta.json`
+ * sidecar from `sb-backup/` (#1890). The per-row Delete on Settings → Backups'
+ * Snapshot-on-NAS table. `tarName` is validated in the producer (basename only,
+ * no traversal, must end in `.tar`) since it's a NAS path. `tokenScope: 'mutate'`
+ * mirrors the backup-now route.
+ */
+export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request }) => {
+  try {
+    const body = (await request.json().catch(() => ({}))) as { service?: unknown; tarName?: unknown };
+    if (typeof body.tarName !== 'string' || !body.tarName) {
+      return NextResponse.json({ error: 'tarName field is required' }, { status: 400 });
+    }
+    const result = await deleteServiceBackup(body.tarName);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (e) {
+    // Operator-fixable, curated messages (invalid name, NAS not configured);
+    // surface them like the other external-backup routes.
+    return apiError(e, { tag: 'api:system:external-backup:delete', status: 400, exposeMessage: true });
+  }
+});


### PR DESCRIPTION
## What
Backups page improvements on the NAS/external-backup subsystem: both sections now show the real nightly time + next-run (instead of a vague \"nightly\"); the Snapshot-on-NAS section gets a \"back up to NAS now\" button (wired to the existing backup-now route), a Created column (newest-first), and a per-row Delete (removes the tar + .meta.json sidecar) behind a confirm dialog.

## Why
Closes #1890

## Risk
Low — touches the backups settings page + externalBackup producer/registerSource and adds one new DELETE route; no change to System-Snapshot or NAS Restore/Verify-connection paths. Path-mandated (backups dashboard + externalBackup + new delete route) so box-verify is owed.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full — 2643 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: backups dashboard + externalBackup + delete route)

AI-generated
<!-- sb-ai-comment -->