### PR TITLE
fix(externalBackup): stop nightly NAS backup OOM + honest NPM sqlite fallback

### DIFF
--- a/packages/backend/src/lib/externalBackup/backupAll.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAll.test.ts
@@ -19,6 +19,21 @@ vi.mock('../config', () => mockCfg);
 const stageDirs: string[] = [];
 vi.mock('../executor', () => ({
   getExecutor: () => ({
+    // Bulk plain-copy (#1894): one shell pipe `tar -C src --null -T list -cf - |
+    // tar -C dest -xf -` instead of a cp per file. Emulate it against the local fs.
+    async exec(command: string) {
+      const m = /tar -C (\S+) --null -T (\S+) -cf - \| tar -C (\S+) -xf -/.exec(command);
+      if (!m) throw new Error(`unexpected exec: ${command}`);
+      const unq = (s: string) => s.replace(/^'(.*)'$/, '$1').replace(/'\\''/g, "'");
+      const [, srcRoot, listFile, destRoot] = m.map(unq);
+      const rels = (await fs.readFile(listFile, 'utf8')).split('\0').filter(Boolean);
+      for (const rel of rels) {
+        const dest = path.join(destRoot, rel);
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.copyFile(path.join(srcRoot, rel), dest);
+      }
+      return { stdout: '', stderr: '' };
+    },
     async execArgv(argv: string[]) {
       const [cmd, ...args] = argv;
       if (cmd === 'find') {

--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -49,8 +49,10 @@ import {
   NAS_BACKUP_DIR,
   DEFAULT_BACKUP_RETENTION,
   latestServiceBackupName,
+  agentFileBackend,
 } from './producer';
 import { getServiceManifest, type ServiceBackupManifest } from './serviceManifest';
+import { logger } from '../logger';
 
 /** Match a dated slot tar `<service>-YYYYMMDD-HHMM.tar` (#1865). */
 const datedTarRe = (service: string) => new RegExp(`/${service}-\\d{8}-\\d{4}\\.tar$`);
@@ -281,6 +283,36 @@ describe('runBackupCollector (NPM in-container sqlite snapshot, #1528)', () => {
     const out = await runBackupCollector(npm, 'Local');
     expect(out).toBe(npm);
   });
+
+  it('degrades gracefully (live file) and logs the real reason when sqlite3 is missing from the image (#1894)', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    // The snapshot script probes for sqlite3 and emits the `no-sqlite3` sentinel
+    // (exit 0) when it's absent — NOT a misleading "(unknown)".
+    mockSendCommand
+      .mockResolvedValueOnce({ stdout: 'npm_proxy-manager img', code: 0 })
+      .mockResolvedValueOnce({ stdout: 'no-sqlite3', stderr: '', code: 0 });
+    const out = await runBackupCollector(npm, 'Local');
+    // Degrades to copying the live DB under its canonical name (manifest unchanged).
+    expect(out).toBe(npm);
+    expect(out.include).toContain('data/database.sqlite');
+    const msg = warn.mock.calls.map(c => String(c[1])).join('\n');
+    expect(msg).toMatch(/sqlite3 not present/i);
+    expect(msg).not.toMatch(/unknown/);
+    warn.mockRestore();
+  });
+
+  it('surfaces the container stderr (not "(unknown)") when the snapshot errors (#1894)', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    mockSendCommand
+      .mockResolvedValueOnce({ stdout: 'npm_proxy-manager img', code: 0 })
+      .mockResolvedValueOnce({ stdout: '', stderr: 'sh: 1: sqlite3: Permission denied', code: 1 });
+    const out = await runBackupCollector(npm, 'Local');
+    expect(out).toBe(npm);
+    const msg = warn.mock.calls.map(c => String(c[1])).join('\n');
+    expect(msg).toContain('Permission denied'); // the REAL stderr is logged
+    expect(msg).not.toMatch(/\(unknown\)/);
+    warn.mockRestore();
+  });
 });
 
 describe('buildServiceBackupTar', () => {
@@ -333,8 +365,26 @@ describe('backupServiceToNas via the host agent (#1597)', () => {
   // serviceDataDir override) must route every fs op through the host agent.
   // Here the mocked executor runs the same ops against a REAL local temp dir,
   // exercising the actual agentFileBackend round-trip (incl. tar | base64).
-  function wireExecutorToHostDir(): { stagingDir: string } {
-    const ref = { stagingDir: '' };
+  function wireExecutorToHostDir(): { stagingDir: string; execShellCalls: number } {
+    const ref = { stagingDir: '', execShellCalls: 0 };
+    // The bulk copy (#1894) runs as ONE shell pipe per service via executor.exec:
+    //   tar -C <src> --null -T <listfile> -cf - | tar -C <dest> -xf -
+    // Emulate it against the real local temp dirs and count the calls so a test
+    // can assert "one bulk exec, not a round-trip per file".
+    mockExecutor.exec.mockImplementation(async (command: string) => {
+      const m = /tar -C (\S+) --null -T (\S+) -cf - \| tar -C (\S+) -xf -/.exec(command);
+      if (!m) throw new Error(`unexpected exec: ${command}`);
+      ref.execShellCalls += 1;
+      const unq = (s: string) => s.replace(/^'(.*)'$/, '$1').replace(/'\\''/g, "'");
+      const [, srcRoot, listFile, destRoot] = m.map(unq);
+      const rels = (await fs.readFile(listFile, 'utf8')).split('\0').filter(Boolean);
+      for (const rel of rels) {
+        const dest = path.join(destRoot, rel);
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.copyFile(path.join(srcRoot, rel), dest);
+      }
+      return { stdout: '', stderr: '' };
+    });
     mockExecutor.execArgv.mockImplementation(async (argv: string[]) => {
       const [cmd, ...args] = argv;
       if (cmd === 'find') {
@@ -405,6 +455,30 @@ describe('backupServiceToNas via the host agent (#1597)', () => {
     await execFileAsync('tar', ['-xf', tarFile, '-C', out]);
     expect(await fs.readFile(path.join(out, 'conf/AdGuardHome.yaml'), 'utf8')).toBe('bind_host: 0.0.0.0');
     await expect(fs.access(path.join(out, 'data/querylog.json'))).rejects.toThrow();
+  });
+
+  it('copies a large file tree in ONE host-side bulk exec, not a round-trip per file (#1894)', async () => {
+    const hostStacks = await mkTmp();
+    // A custom_components dir with many plain files — what OOM'd the box when each
+    // was a separate agent cp/mkdir round-trip.
+    for (let i = 0; i < 50; i++) {
+      await writeFile(hostStacks, `demo/custom_components/pkg/file${i}.py`, `x${i}`);
+    }
+    mockGetConfig.mockResolvedValue({ templateSettings: { DATA_DIR: hostStacks } });
+    // A throwaway manifest service that maps to the demo/ dir.
+    const ref = wireExecutorToHostDir();
+
+    const tar = await buildServiceBackupTar(
+      path.join(hostStacks, 'demo'),
+      { service: 'demo', include: ['custom_components'], exclude: [] },
+      // Build the tar directly against the wired agent backend (one bulk exec).
+      agentFileBackend(mockExecutor as unknown as Parameters<typeof agentFileBackend>[0]),
+    );
+    expect(tar.length).toBeGreaterThan(0);
+    // The 50 plain files were copied by a SINGLE bulk shell exec — no per-file cp.
+    expect(ref.execShellCalls).toBe(1);
+    const cpCalls = mockExecutor.execArgv.mock.calls.filter((c: unknown[]) => (c[0] as string[])[0] === 'cp');
+    expect(cpCalls).toHaveLength(0);
   });
 
   it('applies strip rules host-side via the agent (password hashes never leave the box)', async () => {
@@ -630,6 +704,26 @@ describe('manifest integration', () => {
     await writeFile(src, 'data/querylog.json', '[]');
     const staged = await stageServiceBackup(src, getServiceManifest('adguard')!, staging);
     expect(staged).toEqual(['conf/AdGuardHome.yaml']);
+  });
+
+  it('the real HA manifest drops the re-downloadable HACS frontend cache but keeps the rest of custom_components (#1894)', async () => {
+    const src = await mkTmp();
+    const staging = await mkTmp();
+    // A real HACS integration's code (keep) …
+    await writeFile(src, 'custom_components/hacs/__init__.py', 'CODE');
+    await writeFile(src, 'custom_components/meross_lan/manifest.json', '{"domain":"meross_lan"}');
+    // … and the ~2.2k-file re-downloadable static frontend cache (drop).
+    await writeFile(src, 'custom_components/hacs/hacs_frontend/static/locale-data/x.json', '{}');
+    await writeFile(src, 'custom_components/hacs/hacs_frontend/main.js', 'JUNK');
+    await writeFile(src, 'custom_components/hacs_frontend/entrypoint.js', 'JUNK');
+
+    const staged = await stageServiceBackup(src, getServiceManifest('home-assistant')!, staging);
+
+    // The HACS code + other integrations are staged …
+    expect(staged).toContain('custom_components/hacs/__init__.py');
+    expect(staged).toContain('custom_components/meross_lan/manifest.json');
+    // … but no hacs_frontend cache file is — neither the nested nor the sibling one.
+    expect(staged.some(p => p.includes('hacs_frontend'))).toBe(false);
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -24,6 +24,7 @@ import { getConfig } from '../config';
 import { logger } from '../logger';
 import { agentManager } from '../agent/manager';
 import { getExecutor, type Executor } from '../executor';
+import { shellQuote } from '../util/shellQuote';
 import { nasUpload, nasDownload, nasList, nasRemove } from './nasClient';
 import {
   getServiceManifest,
@@ -167,6 +168,16 @@ export interface BackupFileBackend {
   readText(target: string): Promise<string>;
   /** Copy a file byte-for-byte (binary-safe — sqlite, certs, …). */
   copyFile(src: string, dest: string): Promise<void>;
+  /**
+   * Copy MANY files (given as relative paths under `srcRoot`) into `destRoot`,
+   * preserving their relative subdirs, in as few operations as possible. The
+   * host-agent backend does this in a SINGLE exec (one `tar -C srcRoot … | tar
+   * -x -C destRoot`) instead of a `mkdirp`+`copyFile` round-trip per file — a HA
+   * config with HACS is thousands of files, and per-file agent round-trips OOM'd
+   * the box (#1894). `relFiles` are plain copies only; strip/transform/renamed
+   * files are still staged individually (they're few and need a content rewrite).
+   */
+  bulkCopyFiles(srcRoot: string, relFiles: string[], destRoot: string): Promise<void>;
   writeText(dest: string, content: string): Promise<void>;
   mkdirp(dir: string): Promise<void>;
   /** Make a fresh staging dir on this backend's side, return its path. */
@@ -188,6 +199,15 @@ const localFileBackend: BackupFileBackend = {
   },
   readText: target => fs.readFile(target, 'utf8'),
   copyFile: (src, dest) => fs.copyFile(src, dest),
+  async bulkCopyFiles(srcRoot, relFiles, destRoot) {
+    // Local fs: a plain per-file copy is already cheap (no agent round-trips),
+    // so there's nothing to batch — just mkdirp + copy each.
+    for (const rel of relFiles) {
+      const dest = path.join(destRoot, rel);
+      await fs.mkdir(path.dirname(dest), { recursive: true });
+      await fs.copyFile(path.join(srcRoot, rel), dest);
+    }
+  },
   writeText: (dest, content) => fs.writeFile(dest, content),
   mkdirp: async dir => {
     await fs.mkdir(dir, { recursive: true });
@@ -206,6 +226,35 @@ const localFileBackend: BackupFileBackend = {
     await fs.rm(target, { recursive: true, force: true });
   },
 };
+
+/**
+ * Bulk-copy `relFiles` (relative to `srcRoot`) into `destRoot` host-side in ONE
+ * exec (#1894): write the paths NUL-separated to a temp list, then
+ * `tar -C srcRoot --null -T list -cf - | tar -C destRoot -xf -`. The pipe streams
+ * through the host filesystem — no `cp`/`mkdir` round-trip per file, so a HACS HA
+ * config (thousands of files) no longer floods the agent channel and OOMs the
+ * box. NUL separation means a path with spaces/newlines/quotes is taken verbatim
+ * (no tar `-T` unquoting). Both tar invocations + the pipe need a shell, so this
+ * uses `exec` (not execArgv); every interpolated path is shellQuote'd.
+ */
+async function agentBulkCopyFiles(
+  executor: Executor,
+  srcRoot: string,
+  relFiles: string[],
+  destRoot: string,
+): Promise<void> {
+  if (relFiles.length === 0) return;
+  const listFile = `${destRoot}.copylist`;
+  await executor.writeFile(listFile, relFiles.join('\0'));
+  try {
+    const cmd =
+      `tar -C ${shellQuote(srcRoot)} --null -T ${shellQuote(listFile)} -cf - | ` +
+      `tar -C ${shellQuote(destRoot)} -xf -`;
+    await executor.exec(cmd, { timeoutMs: 120_000 });
+  } finally {
+    await executor.execArgv(['rm', '-f', listFile]);
+  }
+}
 
 /**
  * Host-agent backend (#1597) — reads/stages on the HOST via the node agent, so
@@ -241,6 +290,8 @@ export function agentFileBackend(executor: Executor): BackupFileBackend {
     async copyFile(src, dest) {
       await executor.execArgv(['cp', '-p', src, dest]);
     },
+    bulkCopyFiles: (srcRoot, relFiles, destRoot) =>
+      agentBulkCopyFiles(executor, srcRoot, relFiles, destRoot),
     writeText: (dest, content) => executor.writeFile(dest, content),
     async mkdirp(dir) {
       await executor.execArgv(['mkdir', '-p', dir]);
@@ -348,6 +399,12 @@ export async function stageServiceBackup(
   for (const include of manifest.include) {
     includes.push(...(await resolveIncludeGlob(backend, serviceDataDir, include)));
   }
+  // Plain (byte-for-byte) copies are batched into one bulk operation per backend
+  // (#1894) — the agent backend does them in a single host-side tar pipe instead
+  // of a round-trip per file. Files that need a content rewrite (strip/transform)
+  // or a rename are staged individually: they're few, and each needs a per-file
+  // read/write or a distinct dest path that a bulk copy can't express.
+  const plainCopies: string[] = [];
   for (const include of includes) {
     if (isExcluded(include, manifest.exclude)) continue;
     const absInclude = path.join(serviceDataDir, include);
@@ -359,24 +416,34 @@ export async function stageServiceBackup(
       // A collector may stage a snapshot file under a canonical name (e.g.
       // database.sqlite.sb-backup → database.sqlite) so restore lands it right.
       const tarRel = manifest.renames?.[rel] ?? rel;
-      const dest = path.join(stagingDir, tarRel);
-      await backend.mkdirp(path.dirname(dest));
       const needsRewrite =
         manifest.strip?.some(r => r.file === rel) ||
         manifest.transform?.some(r => r.file === rel);
+      const renamed = tarRel !== rel;
       if (needsRewrite) {
         // Only read-as-text the files a strip/transform rule targets; everything
         // else is copied byte-for-byte so binary config (e.g. SQLite-ish blobs)
         // stays intact. Strip (key removal) then transform (value rewrite).
+        const dest = path.join(stagingDir, tarRel);
+        await backend.mkdirp(path.dirname(dest));
         const content = await backend.readText(path.join(serviceDataDir, rel));
         const stripped = applyStripRules(manifest, rel, content);
         await backend.writeText(dest, applyTransformRules(manifest, rel, stripped));
-      } else {
+      } else if (renamed) {
+        // A renamed plain copy can't ride the bulk tar (its tarball path differs
+        // from its source path) — stage it on its own.
+        const dest = path.join(stagingDir, tarRel);
+        await backend.mkdirp(path.dirname(dest));
         await backend.copyFile(path.join(serviceDataDir, rel), dest);
+      } else {
+        plainCopies.push(rel);
       }
       staged.push(tarRel);
     }
   }
+  // One bulk copy for every byte-for-byte file (the OOM-causing bulk, e.g.
+  // custom_components) — relative paths preserved under the staging dir.
+  await backend.bulkCopyFiles(serviceDataDir, plainCopies, stagingDir);
   return staged.sort();
 }
 
@@ -428,6 +495,12 @@ const NPM_SQLITE_SNAPSHOT_SH = [
   'set -e',
   "DB=/data/database.sqlite",
   'if [ ! -f "$DB" ]; then echo "nodb"; exit 0; fi',
+  // Not every NPM image ships sqlite3 (#1894 — the current jc21 image does not).
+  // Probe for it FIRST and report a precise, greppable reason so the producer can
+  // degrade honestly (copy the live file) instead of logging a misleading
+  // "(unknown)". The real `sh: sqlite3: not found` stderr never made it back
+  // before, so this gap was undiagnosable from the logs.
+  'if ! command -v sqlite3 >/dev/null 2>&1; then echo "no-sqlite3"; exit 0; fi',
   // Fold the WAL back into the main DB so the snapshot has no dependence on the
   // -wal/-shm sidecars. Best-effort: ignore a non-zero (busy) checkpoint.
   'sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);" || true',
@@ -466,8 +539,20 @@ export async function runBackupCollector(
       command: `echo ${b64} | base64 -d | podman exec -i ${container} sh -`,
     }, { timeoutMs: 30_000 });
     const out = ((res as { stdout?: string }).stdout || '').trim();
-    if ((res as { code?: number }).code !== 0 || (out !== 'ok' && out !== 'nodb')) {
-      logger.warn('ExternalBackup', `NPM sqlite snapshot failed (${out || 'unknown'}) — backing up database.sqlite as-is`);
+    const errOut = ((res as { stderr?: string }).stderr || '').trim();
+    const code = (res as { code?: number }).code;
+    // sqlite3 isn't in this NPM image — degrade honestly to copying the live DB
+    // (consistent enough since #1679 flips WAL and the live file is read whole),
+    // and say SO in the log rather than a misleading "(unknown)" (#1894).
+    if (out === 'no-sqlite3') {
+      logger.warn('ExternalBackup', 'NPM sqlite snapshot skipped: sqlite3 not present in the NPM container — backing up database.sqlite as-is');
+      return manifest;
+    }
+    if (code !== 0 || (out !== 'ok' && out !== 'nodb')) {
+      // Surface the REAL failure: prefer the container's stderr (the swallowed
+      // `sh: sqlite3: not found` etc.), then any stdout, before "(unknown)".
+      const reason = errOut || out || 'unknown';
+      logger.warn('ExternalBackup', `NPM sqlite snapshot failed (${reason}) — backing up database.sqlite as-is`);
       return manifest;
     }
     // Stage the snapshot in place of the live DB, under the original rel path.

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -182,6 +182,13 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     exclude: [
       'home-assistant_v2.db', 'home-assistant_v2.db-wal', 'home-assistant_v2.db-shm',
       'history', 'logs', 'home-assistant.log', 'tts', 'image', 'www', 'deps',
+      // HACS ships a re-downloadable frontend asset cache (`hacs_frontend` ≈ 2,200
+      // tiny locale/static files that HACS re-fetches on demand). It has no config
+      // or restore value, and per-file staging it OOM'd the box mid-backup (#1894).
+      // The HACS *data store* (`.storage/hacs*`) — what HACS actually manages — is
+      // still backed up; only the disposable static cache is dropped.
+      'custom_components/hacs/hacs_frontend',
+      'custom_components/hacs_frontend',
     ],
     // Large on-RAID artifacts kept through a wipe-config: the recorder history
     // DB (can be many GB) and the Z-Wave mesh DB. The zwave_js *keys* are CONFIG


### PR DESCRIPTION
## What
Nightly NAS config backup no longer OOMs the box on a HACS-laden home-assistant: the per-file agent copy is replaced by a single host-side bulk tar, and HACS re-downloadable static caches (hacs_frontend, etc.) are excluded from the manifest. The NPM DB snapshot now degrades gracefully and logs the real stderr when sqlite3 is absent instead of a misleading "(unknown)".

## Why
Closes #1894

## Risk
Medium — touches the backup producer path; verified on a real box with HACS + an NPM container lacking sqlite3 (gate=verify).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full — 2647 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (operator-gated: real-box OOM only provable with HACS ~2.2k hacs_frontend files + NPM container missing sqlite3)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._