### PR TITLE
feat(diskimport): async durable disk-import with live progress + lost+found fix

### DIFF
--- a/packages/backend/src/lib/diskImport/hostScan.test.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.test.ts
@@ -60,6 +60,31 @@ describe('scanMount', () => {
     const { exec } = mockExec({ find: { stdout: '', stderr: 'boom', code: 1 } });
     await expect(scanMount(exec, '/run/servicebay/disk-import/sda1')).rejects.toThrow(/scan walk failed/);
   });
+
+  it('prunes lost+found from the walk', async () => {
+    const { exec, calls } = mockExec({ find: ok('') });
+    await scanMount(exec, '/run/servicebay/disk-import/sda1');
+    const argv = calls[0];
+    expect(argv).toContain('lost+found');
+    expect(argv).toContain('-prune');
+    // -prune comes before the -type f test (it's the first arm of the -o).
+    expect(argv.indexOf('-prune')).toBeLessThan(argv.lastIndexOf('-type'));
+  });
+
+  it('tolerates find exit 1 (permission-denied descent) when stdout still parsed', async () => {
+    // A real ext4 disk with a root-0700 subdir: find prints what it could read
+    // to stdout AND a "Permission denied" line on stderr, then exits 1. We keep
+    // the readable listing instead of failing the whole scan (#1893).
+    const { exec } = mockExec({
+      find: {
+        stdout: '/mnt/x/a.jpg\t10\t1700000000\0',
+        stderr: "find: '/mnt/x/private': Permission denied",
+        code: 1,
+      },
+    });
+    const files = await scanMount(exec, '/run/servicebay/disk-import/sda1');
+    expect(files).toEqual([{ path: '/mnt/x/a.jpg', size: 10, mtimeMs: 1700000000000 }]);
+  });
 });
 
 describe('hashSourceFile', () => {

--- a/packages/backend/src/lib/diskImport/hostScan.test.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { parseFindOutput, scanMount, hashSourceFile, hashRecords } from './hostScan';
+import { parseFindOutput, scanMount, hashSourceFile, hashRecords, hashPaths, HASH_BATCH_SIZE } from './hostScan';
 import type { SafeExec, SafeExecResult } from './hostExec';
 import type { ImportRecord } from './types';
 
@@ -106,15 +106,22 @@ describe('hashSourceFile', () => {
   });
 });
 
+/** A `sha256sum <p1> <p2> …` mock that hashes each arg path deterministically. */
+function batchedSha256(hashOf: (p: string) => string): { exec: SafeExec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: SafeExec = vi.fn(async (argv: string[]) => {
+    calls.push(argv);
+    const lines = argv.slice(1).map(p => `${hashOf(p)}  ${p}`);
+    return ok(lines.join('\n') + '\n');
+  });
+  return { exec, calls };
+}
+
 describe('hashRecords', () => {
-  it('hashes each record host-side and returns a path→hash map', async () => {
+  it('hashes records in ONE batched sha256sum call and returns a path→hash map', async () => {
     const h1 = '1'.repeat(64);
     const h2 = '2'.repeat(64);
-    const exec: SafeExec = vi.fn(async (argv: string[]) => {
-      const path = argv[1];
-      const hex = path === '/mnt/a' ? h1 : h2;
-      return ok(`${hex}  ${path}\n`);
-    });
+    const { exec, calls } = batchedSha256(p => (p === '/mnt/a' ? h1 : h2));
     const records: ImportRecord[] = [
       { sourcePath: '/mnt/a', size: 1, mtimeMs: 0, ext: '', name: 'a' },
       { sourcePath: '/mnt/b', size: 1, mtimeMs: 0, ext: '', name: 'b' },
@@ -122,5 +129,60 @@ describe('hashRecords', () => {
     const map = await hashRecords(exec, records);
     expect(map.get('/mnt/a')).toBe(h1);
     expect(map.get('/mnt/b')).toBe(h2);
+    // Both files hashed in a single agent round-trip (not one per file).
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(['sha256sum', '/mnt/a', '/mnt/b']);
+  });
+
+  it('fires onProgress once per file even within a batched call', async () => {
+    const { exec } = batchedSha256(() => 'a'.repeat(64));
+    const records: ImportRecord[] = [
+      { sourcePath: '/mnt/a', size: 1, mtimeMs: 0, ext: '', name: 'a' },
+      { sourcePath: '/mnt/b', size: 1, mtimeMs: 0, ext: '', name: 'b' },
+      { sourcePath: '/mnt/c', size: 1, mtimeMs: 0, ext: '', name: 'c' },
+    ];
+    const ticks: Array<[number, number]> = [];
+    await hashRecords(exec, records, (hashed, total) => ticks.push([hashed, total]));
+    expect(ticks).toEqual([[1, 3], [2, 3], [3, 3]]);
+  });
+});
+
+describe('hashPaths — batched execution (#1898)', () => {
+  it('drops exec round-trips from N (per-file) to ceil(N / HASH_BATCH_SIZE)', async () => {
+    const n = HASH_BATCH_SIZE * 2 + 5; // forces 3 chunks
+    const paths = Array.from({ length: n }, (_, i) => `/mnt/f${i}`);
+    const { exec, calls } = batchedSha256(() => 'b'.repeat(64));
+    const map = await hashPaths(exec, paths);
+    expect(map.size).toBe(n);
+    // 3 round-trips for 517 files — NOT 517 (the per-file regression #1898).
+    expect(calls).toHaveLength(3);
+    expect(calls.every(c => c[0] === 'sha256sum')).toBe(true);
+  });
+
+  it('returns no round-trip for an empty path list', async () => {
+    const { exec, calls } = batchedSha256(() => 'c'.repeat(64));
+    expect((await hashPaths(exec, [])).size).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('decodes sha256sum backslash-escaped lines (path with a newline)', async () => {
+    const hex = 'd'.repeat(64);
+    // GNU coreutils escapes a path containing a newline: it prefixes the line
+    // with `\` and writes `\n` for the embedded newline. We must map it back to
+    // the EXACT input path so the hash lands on the right record.
+    const exec: SafeExec = vi.fn(async () => ok(`\\${hex}  /mnt/od\\nd\n`));
+    const map = await hashPaths(exec, ['/mnt/od\nd']);
+    expect(map.get('/mnt/od\nd')).toBe(hex);
+  });
+
+  it('throws if sha256sum omits a requested path', async () => {
+    const exec: SafeExec = vi.fn(async () => ok(`${'e'.repeat(64)}  /mnt/a\n`));
+    await expect(hashPaths(exec, ['/mnt/a', '/mnt/b'])).rejects.toThrow(/no hash for/);
+  });
+
+  it('refuses a NUL byte in a path before any host call', async () => {
+    const { exec, calls } = batchedSha256(() => 'f'.repeat(64));
+    await expect(hashPaths(exec, ['/mnt/\0evil'])).rejects.toThrow(/NUL byte/);
+    expect(calls).toHaveLength(0);
   });
 });

--- a/packages/backend/src/lib/diskImport/hostScan.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.ts
@@ -32,16 +32,33 @@ function assertMountpoint(mountpoint: string): void {
  */
 export async function scanMount(exec: SafeExec, mountpoint: string): Promise<ScannedFile[]> {
   assertMountpoint(mountpoint);
-  // `%p\t%s\t%T@\0` — path, size, mtime (float epoch seconds), then a NUL. The
-  // tab can't appear in `%s`/`%T@`, and the path is the first field, so a tab in
-  // a filename is harmless (we split on the LAST two tabs).
+  // The scan walk runs UNPRIVILEGED on purpose (read-only enumeration never
+  // escalates — see hostExec.ts). On a real ext4 disk that means two things:
+  //
+  //  1. `lost+found` is root-owned 0700 and useless to us — prune it from the
+  //     walk so `find` never even tries to descend it (`-path .../lost+found
+  //     -prune`).
+  //  2. Any OTHER root-0700 subdir we hit still makes `find` print a
+  //     "Permission denied" line on stderr and exit 1, EVEN THOUGH it already
+  //     streamed every readable entry to stdout. Treating that exit 1 as fatal
+  //     threw away a perfectly good listing ("Scan disk fails", #1893). So we
+  //     tolerate exit 1 WHEN stdout parses into at least one record (a partial
+  //     find), and only error on a genuinely failed walk (no usable stdout).
   const { stdout, code, stderr } = await exec([
-    'find', mountpoint, '-type', 'f', '-printf', '%p\t%s\t%T@\\0',
+    'find', mountpoint,
+    // Prune the ext4 `lost+found` (root 0700) before any `-type f` test so we
+    // neither descend it nor emit a permission-denied line for it.
+    '-name', 'lost+found', '-prune', '-o',
+    '-type', 'f', '-printf', '%p\t%s\t%T@\\0',
   ]);
-  if (code !== 0) {
+  const files = parseFindOutput(stdout);
+  // `find` exits 1 on a permission-denied descent but still lists what it could
+  // read. A partial walk (exit 1 WITH parsed records) is a success; only a walk
+  // that produced no usable output is fatal.
+  if (code !== 0 && files.length === 0) {
     throw new Error(`disk-import: scan walk failed (code ${code}): ${stderr}`);
   }
-  return parseFindOutput(stdout);
+  return files;
 }
 
 /** Parse the NUL-separated `find -printf '%p\t%s\t%T@\0'` stream. */

--- a/packages/backend/src/lib/diskImport/hostScan.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.ts
@@ -91,10 +91,14 @@ export function parseFindOutput(stdout: string): ScannedFile[] {
 export async function hashRecords(
   exec: SafeExec,
   records: ImportRecord[],
+  onProgress?: (hashed: number, total: number) => void,
 ): Promise<Map<string, string>> {
   const out = new Map<string, string>();
+  let hashed = 0;
   for (const record of records) {
     out.set(record.sourcePath, await hashSourceFile(exec, record.sourcePath));
+    hashed += 1;
+    onProgress?.(hashed, records.length);
   }
   return out;
 }

--- a/packages/backend/src/lib/diskImport/hostScan.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.ts
@@ -82,40 +82,104 @@ export function parseFindOutput(stdout: string): ScannedFile[] {
 }
 
 /**
+ * How many paths to feed a single `sha256sum` invocation. Batching the hash
+ * pass kills the per-file agent round-trip that made a 269k-file disk take
+ * hours (#1898): instead of one `safe_exec` per file we hand `sha256sum` a whole
+ * chunk of paths and parse its per-line output. Chunked (not one giant argv) to
+ * stay clear of the host's `ARG_MAX`/argv limits on a huge disk.
+ */
+export const HASH_BATCH_SIZE = 256;
+
+/**
  * Build a dedup {@link import('./dedup').HashResolver} backed by host-side
  * `sha256sum` over the read-only mount. dedup only calls this for size-collision
  * candidates, so the host doesn't hash every file. Synchronous-looking resolver
- * contract: we pre-hash the candidate set up front (one batched pass) so the
+ * contract: we pre-hash the candidate set up front (batched passes) so the
  * deterministic engine can stay synchronous.
+ *
+ * Throughput (#1898): paths are hashed in {@link HASH_BATCH_SIZE} chunks — one
+ * `sha256sum <p1> <p2> …` agent round-trip per chunk, not one per file. The
+ * hashes are byte-for-byte identical to the per-file path; only the number of
+ * round-trips changes. `onProgress` still fires once per file so the card's live
+ * `hashed/total` count advances smoothly within a chunk.
  */
 export async function hashRecords(
   exec: SafeExec,
   records: ImportRecord[],
   onProgress?: (hashed: number, total: number) => void,
 ): Promise<Map<string, string>> {
+  return hashPaths(exec, records.map(r => r.sourcePath), onProgress);
+}
+
+/**
+ * Hash many source files via host `sha256sum` (read-only), batched in
+ * {@link HASH_BATCH_SIZE} chunks — one `sha256sum <p1> <p2> …` agent round-trip
+ * per chunk, not one per file (#1898). Returns a path→sha256 map keyed by the
+ * EXACT input path. `sha256sum` prints one `<hex>  <path>` line per file (and,
+ * for a path containing a backslash or newline, prefixes the line with `\` and
+ * escapes `\`→`\\`, `\n`→`\\n`); we undo that escaping so the map keys match the
+ * paths we passed in. `onProgress` (optional) fires once per file so a live
+ * `hashed/total` count still advances within a chunk. Empty input → no round-trip.
+ */
+export async function hashPaths(
+  exec: SafeExec,
+  paths: string[],
+  onProgress?: (hashed: number, total: number) => void,
+): Promise<Map<string, string>> {
   const out = new Map<string, string>();
+  if (paths.length === 0) return out;
+  for (const p of paths) {
+    if (p.includes('\0')) throw new Error('disk-import: NUL byte in source path');
+  }
+  const total = paths.length;
   let hashed = 0;
-  for (const record of records) {
-    out.set(record.sourcePath, await hashSourceFile(exec, record.sourcePath));
-    hashed += 1;
-    onProgress?.(hashed, records.length);
+  for (let i = 0; i < paths.length; i += HASH_BATCH_SIZE) {
+    const chunk = paths.slice(i, i + HASH_BATCH_SIZE);
+    const byPath = parseSha256sumOutput(await runSha256sum(exec, chunk));
+    for (const p of chunk) {
+      const hex = byPath.get(p);
+      if (hex === undefined) {
+        throw new Error(`disk-import: sha256sum returned no hash for ${JSON.stringify(p)}`);
+      }
+      out.set(p, hex);
+      hashed += 1;
+      onProgress?.(hashed, total);
+    }
+  }
+  return out;
+}
+
+async function runSha256sum(exec: SafeExec, paths: string[]): Promise<string> {
+  const { stdout, code, stderr } = await exec(['sha256sum', ...paths]);
+  if (code !== 0) {
+    throw new Error(`disk-import: sha256sum failed (code ${code}): ${stderr}`);
+  }
+  return stdout;
+}
+
+/** Parse `sha256sum`'s per-line `<hex>  <path>` output into a path→hex map. */
+function parseSha256sumOutput(stdout: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const line of stdout.split('\n')) {
+    if (line.length === 0) continue;
+    const escaped = line.startsWith('\\');
+    const body = escaped ? line.slice(1) : line;
+    // `<hex><space><space><path>` — the hash is fixed-width, the path follows
+    // exactly two spaces (`sha256sum` text mode). Split off the first token.
+    const sep = body.indexOf('  ');
+    const hex = sep === -1 ? '' : body.slice(0, sep);
+    if (!/^[0-9a-f]{64}$/.test(hex)) {
+      throw new Error(`disk-import: unexpected sha256sum output: ${JSON.stringify(line.slice(0, 80))}`);
+    }
+    let path = body.slice(sep + 2);
+    if (escaped) path = path.replace(/\\n/g, '\n').replace(/\\\\/g, '\\');
+    out.set(path, hex);
   }
   return out;
 }
 
 /** Hash one source file's bytes via host `sha256sum` (read-only). */
 export async function hashSourceFile(exec: SafeExec, sourcePath: string): Promise<string> {
-  if (sourcePath.includes('\0')) {
-    throw new Error('disk-import: NUL byte in source path');
-  }
-  const { stdout, code, stderr } = await exec(['sha256sum', sourcePath]);
-  if (code !== 0) {
-    throw new Error(`disk-import: sha256sum failed (code ${code}): ${stderr}`);
-  }
-  // `sha256sum` prints `<hex>  <path>`; take the first whitespace-delimited token.
-  const hex = stdout.trim().split(/\s+/, 1)[0];
-  if (!/^[0-9a-f]{64}$/.test(hex)) {
-    throw new Error(`disk-import: unexpected sha256sum output: ${JSON.stringify(stdout.slice(0, 80))}`);
-  }
-  return hex;
+  const byPath = await hashPaths(exec, [sourcePath]);
+  return byPath.get(sourcePath)!;
 }

--- a/packages/backend/src/lib/diskImport/plan.test.ts
+++ b/packages/backend/src/lib/diskImport/plan.test.ts
@@ -90,6 +90,38 @@ describe('applyPlan — copy + chown', () => {
   });
 });
 
+describe('applyPlan — batched mkdir/chown (#1898)', () => {
+  it('copies an N-file plan with ONE mkdir + ONE chown (not one per file)', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    const n = 8;
+    const items = Array.from({ length: n }, (_, i) =>
+      item({ record: record({ sourcePath: `/f${i}.mp3`, name: `f${i}.mp3` }), target: `music/f${i}.mp3` }),
+    );
+    const res = await applyPlan(planOf(...items), baseOpts(exec, catalog, hashConst('a'.repeat(64))));
+
+    const mkdirs = calls.filter(c => c[0] === 'mkdir');
+    const rsyncs = calls.filter(c => c[0] === 'rsync');
+    const chowns = calls.filter(c => c[0] === 'chown');
+    // mkdir + chown are batched: one each for the whole batch. rsync stays
+    // per-file (the byte copy + resume granularity).
+    expect(mkdirs).toHaveLength(1);
+    expect(chowns).toHaveLength(1);
+    expect(rsyncs).toHaveLength(n);
+    // The single chown carries every dest, group-only, never -R.
+    expect(chowns[0][0]).toBe('chown');
+    expect(chowns[0][1]).toBe(`:${GID}`);
+    expect(chowns[0]).not.toContain('-R');
+    expect(chowns[0].slice(2)).toEqual(items.map(i => resolveShareTarget(i.target!)));
+    // The single mkdir -p carries the (deduped) dest dir.
+    expect(mkdirs[0]).toEqual(['mkdir', '-p', '/mnt/data/stacks/file-share/data/music']);
+    expect(res.applied).toBe(n);
+    expect(res.items.every(i => i.outcome === 'copied')).toBe(true);
+    expect(items.every(i => catalog.has('a'.repeat(64), i.target!))).toBe(true);
+    catalog.close();
+  });
+});
+
 describe('applyPlan — conflict routes to _superseded', () => {
   it('moves the existing target into _superseded/<date>/ before copying the newer file', async () => {
     const { exec, calls, opts } = mockExec();

--- a/packages/backend/src/lib/diskImport/plan.ts
+++ b/packages/backend/src/lib/diskImport/plan.ts
@@ -92,6 +92,17 @@ export interface ImmichConfig {
 
 const DEFAULT_IMMICH_IMAGE = 'ghcr.io/immich-app/immich-cli';
 
+/**
+ * How many copied files to group into one batched `mkdir`/`chown` flush (#1898).
+ * The apply pass used to issue THREE sudo agent round-trips per copied file
+ * (`mkdir -p`, `rsync`, `chown`); now the dir-creation and ownership are batched
+ * across a chunk (`mkdir -p <dirs…>`, `chown :gid <files…>`) so a big disk no
+ * longer costs one mkdir + one chown round-trip per file. rsync stays per-file
+ * (one byte-copy invocation each) so the catalog row — the resume marker — is
+ * only written once a file is fully copied AND chowned.
+ */
+const COPY_BATCH_SIZE = 256;
+
 /** Map epoch-ms to a stable `YYYY-MM-DD` bucket for the _superseded tree. */
 function dateBucket(ms: number): string {
   return new Date(ms).toISOString().slice(0, 10);
@@ -112,26 +123,38 @@ function assertShareGid(gid: number): void {
 export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<ApplyResult> {
   const { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun = false, now = Date.now, onProgress } = opts;
   assertShareGid(shareGid);
+  const ctx: ItemCtx = { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun, now };
 
   const results: ApplyResultItem[] = [];
-  let applied = 0;
-  let bytes = 0;
-  let done = 0;
+  // Items that need a host copy (`copied`/`superseded`) are queued and flushed in
+  // batches so `mkdir`/`chown` aren't one agent round-trip per file (#1898);
+  // everything else (skips, photos, dry-run, already-cataloged) resolves inline.
+  // The progress cursor is shared across both paths so the live count advances
+  // for every item in plan order.
+  const progress = { applied: 0, bytes: 0, done: 0, total: plan.items.length, onProgress };
+  let pending: CopyJob[] = [];
+
+  const flush = async () => {
+    if (pending.length === 0) return;
+    await copyBatch(pending, ctx, progress, results);
+    pending = [];
+  };
 
   for (const item of plan.items) {
-    const outcome = await applyItem(item, {
-      exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun, now,
-    });
-    results.push({ sourcePath: item.record.sourcePath, target: item.target, outcome });
-    if (outcome === 'copied' || outcome === 'photo-uploaded' || outcome === 'superseded') {
-      applied += 1;
-      bytes += item.record.size;
+    const planned = await classifyItem(item, ctx);
+    if (planned.copy) {
+      pending.push(planned.copy);
+      if (pending.length >= COPY_BATCH_SIZE) await flush();
+      continue;
     }
-    done += 1;
-    onProgress?.({ copied: applied, bytes, done, total: plan.items.length });
+    // Non-copy outcome: record it and advance the cursor inline.
+    results.push({ sourcePath: item.record.sourcePath, target: item.target, outcome: planned.outcome });
+    progress.done += 1;
+    progress.onProgress?.({ copied: progress.applied, bytes: progress.bytes, done: progress.done, total: progress.total });
   }
+  await flush();
 
-  return { items: results, applied };
+  return { items: results, applied: progress.applied };
 }
 
 interface ItemCtx {
@@ -145,57 +168,124 @@ interface ItemCtx {
   now: () => number;
 }
 
-async function applyItem(item: ImportPlanItem, ctx: ItemCtx): Promise<ApplyOutcome> {
-  if (item.action === 'skip-junk') return 'skipped-junk';
-  if (item.action === 'skip-dupe') return 'skipped-dupe';
+/** Shared progress cursor threaded through the inline + batched apply paths. */
+interface ProgressCursor {
+  applied: number;
+  bytes: number;
+  done: number;
+  total: number;
+  onProgress?: ApplyOptions['onProgress'];
+}
+
+/** A queued file copy (resolved + validated) awaiting the batched flush. */
+interface CopyJob {
+  item: ImportPlanItem;
+  target: string;
+  sha: string;
+  src: string;
+  dest: string;
+  outcome: 'copied' | 'superseded';
+}
+
+/**
+ * Decide an item's fate WITHOUT issuing the copy: returns either a terminal
+ * outcome (skip/photo/dry-run/already-cataloged) or a {@link CopyJob} to be
+ * flushed in a batch. Conflict superseding (`mkdir`+`mv` of the existing file)
+ * still happens here, in plan order, BEFORE the newer file is queued — exactly
+ * as before.
+ */
+async function classifyItem(
+  item: ImportPlanItem,
+  ctx: ItemCtx,
+): Promise<{ outcome: ApplyOutcome; copy?: undefined } | { outcome?: undefined; copy: CopyJob }> {
+  if (item.action === 'skip-junk') return { outcome: 'skipped-junk' };
+  if (item.action === 'skip-dupe') return { outcome: 'skipped-dupe' };
 
   // Photos go to Immich, never into file-share.
   if (item.category === 'photos') {
-    if (ctx.dryRun) return 'dry-run';
+    if (ctx.dryRun) return { outcome: 'dry-run' };
     await uploadPhoto(item.record, ctx);
-    return 'photo-uploaded';
+    return { outcome: 'photo-uploaded' };
   }
 
   const target = item.target;
-  if (target === null) return 'skipped-junk';
+  if (target === null) return { outcome: 'skipped-junk' };
 
   const sha = ctx.hashOf(item.record);
 
   // RESUMABILITY: this exact content already at this exact target → done.
-  if (ctx.catalog.has(sha, target)) return 'skipped-cataloged';
+  if (ctx.catalog.has(sha, target)) return { outcome: 'skipped-cataloged' };
 
-  if (ctx.dryRun) return 'dry-run';
+  if (ctx.dryRun) return { outcome: 'dry-run' };
 
   // Validate the destination stays under file-share/data/ BEFORE any host I/O.
   const dest = resolveShareTarget(target);
   const src = `${ctx.mountpoint}/${stripLeadingSlash(item.record.sourcePath)}`;
 
-  let outcome: ApplyOutcome = 'copied';
+  let outcome: 'copied' | 'superseded' = 'copied';
   if (item.action === 'conflict') {
     await supersedeExisting(target, ctx);
     outcome = 'superseded';
   }
 
-  await copyAndOwn(src, dest, ctx);
-  ctx.catalog.upsert(catalogEntry(sha, target, item.record, ctx.now()));
-  return outcome;
+  return { copy: { item, target, sha, src, dest, outcome } };
 }
 
-/** rsync the source file into its destination, then chown to the share gid. */
-async function copyAndOwn(src: string, dest: string, ctx: ItemCtx): Promise<void> {
-  const destDir = dest.slice(0, dest.lastIndexOf('/'));
-  // Privileged (#1713): the file-share data tree under /mnt/data is owned by
-  // container subuids, not `core`, so creating dirs, rsync-copying in, and
-  // chowning all need root. The destination path is validated to stay under
-  // file-share/data/ by resolveShareTarget BEFORE this runs — privilege does
-  // not relax that guard.
-  await runOk(ctx.exec, ['mkdir', '-p', destDir], 'mkdir dest dir', { sudo: true });
-  // `-a` preserves metadata; the source mount is read-only so this only reads
-  // from it. Explicit src/dest argv — no globbing, no `--delete`.
-  await runOk(ctx.exec, ['rsync', '-a', src, dest], 'rsync', { sudo: true });
-  // chown to the share GID ONLY (`:<gid>` leaves the uid untouched). Single
-  // file target — never recursive, never an arbitrary path.
-  await runOk(ctx.exec, ['chown', `:${ctx.shareGid}`, dest], 'chown', { sudo: true });
+/**
+ * Flush a batch of queued copies: one `mkdir -p <dirs…>` for the union of
+ * destination dirs, one `rsync` per file (the byte copy — kept per-file so the
+ * resume marker tracks exactly which files landed), then one `chown :gid
+ * <files…>` + catalog over the files that successfully copied. A file is
+ * cataloged ONLY after it is copied AND chowned, so an interrupted run re-copies
+ * AND re-chowns anything not yet cataloged — resume semantics are unchanged. If
+ * an rsync mid-batch fails, we still chown + catalog the files copied so far
+ * before propagating, so a resumed run skips them (no re-copy). Each file
+ * advances the shared progress cursor as it's copied.
+ */
+async function copyBatch(
+  jobs: CopyJob[],
+  ctx: ItemCtx,
+  progress: ProgressCursor,
+  results: ApplyResultItem[],
+): Promise<void> {
+  // Pre-create every destination directory in one privileged call (#1713 guards
+  // still hold — every dest was resolved under file-share/data/).
+  const dirs = [...new Set(jobs.map(j => j.dest.slice(0, j.dest.lastIndexOf('/'))))];
+  await runOk(ctx.exec, ['mkdir', '-p', ...dirs], 'mkdir dest dirs', { sudo: true });
+
+  // rsync each file (per-file byte copy, no globbing / --delete), advancing the
+  // progress cursor as we go so the live count still ticks within the batch.
+  // Track the files that actually landed so a mid-batch failure still chowns +
+  // catalogs them (resume parity with the old per-file path).
+  const copied: CopyJob[] = [];
+  try {
+    for (const job of jobs) {
+      await runOk(ctx.exec, ['rsync', '-a', job.src, job.dest], 'rsync', { sudo: true });
+      copied.push(job);
+      results.push({ sourcePath: job.item.record.sourcePath, target: job.target, outcome: job.outcome });
+      progress.applied += 1;
+      progress.bytes += job.item.record.size;
+      progress.done += 1;
+      progress.onProgress?.({ copied: progress.applied, bytes: progress.bytes, done: progress.done, total: progress.total });
+    }
+  } finally {
+    await finalizeCopied(copied, ctx);
+  }
+}
+
+/**
+ * chown (group-only) + catalog the files that successfully rsync'd this batch.
+ * Runs even when a mid-batch rsync threw, so every fully-copied file is marked
+ * done before the error propagates (resume skips it next pass).
+ */
+async function finalizeCopied(copied: CopyJob[], ctx: ItemCtx): Promise<void> {
+  if (copied.length === 0) return;
+  // chown to the share GID ONLY (`:<gid>` leaves uid untouched; never recursive,
+  // never an arbitrary path).
+  await runOk(ctx.exec, ['chown', `:${ctx.shareGid}`, ...copied.map(j => j.dest)], 'chown', { sudo: true });
+  for (const job of copied) {
+    ctx.catalog.upsert(catalogEntry(job.sha, job.target, job.item.record, ctx.now()));
+  }
 }
 
 /**

--- a/packages/backend/src/lib/diskImport/plan.ts
+++ b/packages/backend/src/lib/diskImport/plan.ts
@@ -73,6 +73,12 @@ export interface ApplyOptions {
   dryRun?: boolean;
   /** Clock for deterministic dates/tests. */
   now?: () => number;
+  /**
+   * Called after every item is handled so a background apply can stream live
+   * progress (#1897). `copied` counts files written/uploaded this pass,
+   * `bytes` their summed size, `done`/`total` the item cursor.
+   */
+  onProgress?: (p: { copied: number; bytes: number; done: number; total: number }) => void;
 }
 
 export interface ImmichConfig {
@@ -104,11 +110,13 @@ function assertShareGid(gid: number): void {
  * can simply be re-run.
  */
 export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<ApplyResult> {
-  const { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun = false, now = Date.now } = opts;
+  const { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun = false, now = Date.now, onProgress } = opts;
   assertShareGid(shareGid);
 
   const results: ApplyResultItem[] = [];
   let applied = 0;
+  let bytes = 0;
+  let done = 0;
 
   for (const item of plan.items) {
     const outcome = await applyItem(item, {
@@ -117,7 +125,10 @@ export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<A
     results.push({ sourcePath: item.record.sourcePath, target: item.target, outcome });
     if (outcome === 'copied' || outcome === 'photo-uploaded' || outcome === 'superseded') {
       applied += 1;
+      bytes += item.record.size;
     }
+    done += 1;
+    onProgress?.({ copied: applied, bytes, done, total: plan.items.length });
   }
 
   return { items: results, applied };

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+
+// Mock DATA_DIR to a process-scoped tmpdir so the durable session store
+// (#1896) writes to a real fs path without colliding with the dev box.
+vi.mock('@/lib/dirs', () => ({
+  DATA_DIR: path.join(os.tmpdir(), `sb-diskimport-svc-${process.pid}`),
+}));
+
 import {
   listImportDevices,
   scanDevice,
@@ -26,7 +35,9 @@ function mockExec(
   return { exec, calls };
 }
 
-beforeEach(() => __clearSessions());
+beforeEach(async () => {
+  await __clearSessions();
+});
 
 describe('listImportDevices', () => {
   it('keeps only removable partitions that carry a filesystem', async () => {
@@ -107,7 +118,7 @@ describe('applyImportPlan — the review gate', () => {
 
     // No immich config wired → photos throw on apply; use a residue-only disk to
     // prove the copy path runs. Re-scan a docs-only listing.
-    __clearSessions();
+    await __clearSessions();
     const docOut = '/mnt/docs/report.pdf\t10\t1700000000\0';
     const { exec: exec2, calls: calls2 } = mockExec({
       find: ok(docOut),

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -11,10 +11,24 @@ vi.mock('@/lib/dirs', () => ({
 import {
   listImportDevices,
   scanDevice,
+  startScan,
+  startApply,
+  getImportJob,
   applyImportPlan,
   __clearSessions,
 } from './service';
 import type { SafeExec, SafeExecResult } from './hostExec';
+
+/** Spin the event loop until `cond()` is true or we give up. The background
+ *  scan/apply tasks are detached promises; this lets a test await their
+ *  completion without a real timer. */
+async function waitFor(cond: () => Promise<boolean> | boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    if (await cond()) return;
+    await new Promise(r => setImmediate(r));
+  }
+  throw new Error('waitFor: condition not met');
+}
 
 const ok = (stdout = ''): SafeExecResult => ({ stdout, stderr: '', code: 0 });
 
@@ -99,6 +113,77 @@ describe('scanDevice', () => {
     // (defaulted to documents), so the action annotates rather than blocks.
     expect(result.totalFiles).toBe(3);
     expect(result.categories.some(c => c.category === 'documents')).toBe(true);
+  });
+});
+
+describe('startScan / getImportJob — async hand-off + live status (#1897)', () => {
+  it('returns a jobId immediately and the job walks scanning → reviewed with progress + review', async () => {
+    const { exec } = mockExec({ find: ok(FIND_OUT) });
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    // Hand-off is immediate — a job exists and is pollable right away.
+    expect(jobId).toBeTruthy();
+    const first = await getImportJob(jobId);
+    expect(first).not.toBeNull();
+    expect(['scanning', 'reviewed']).toContain(first!.phase);
+
+    // The background scan finishes → phase=reviewed, with the review payload a
+    // re-attaching card renders (this is the re-attach-by-id path).
+    await waitFor(async () => (await getImportJob(jobId))!.phase === 'reviewed');
+    const done = await getImportJob(jobId);
+    expect(done!.phase).toBe('reviewed');
+    expect(done!.review).toBeDefined();
+    expect(done!.review!.totalFiles).toBe(3);
+    expect(done!.progress.step).toBe('done');
+    expect(done!.progress.scanned).toBe(3);
+  });
+
+  it('records a scan failure on the job (phase=error) instead of throwing into the void', async () => {
+    // find exits non-zero with NO stdout → scanMount throws → recorded on the job.
+    const { exec } = mockExec({ find: { stdout: '', stderr: 'boom', code: 2 } });
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+    await waitFor(async () => (await getImportJob(jobId))!.phase === 'error');
+    const failed = await getImportJob(jobId);
+    expect(failed!.phase).toBe('error');
+    expect(failed!.error).toMatch(/scan walk failed/);
+  });
+
+  it('getImportJob returns null for an unknown/forged id', async () => {
+    expect(await getImportJob('nope')).toBeNull();
+  });
+});
+
+describe('startApply — async hand-off, gate checked synchronously (#1897)', () => {
+  it('rejects a forged id synchronously (no background job, no host write)', async () => {
+    const { exec, calls } = mockExec();
+    await expect(
+      startApply({ exec, sessionId: 'forged', shareGid: 1024 }),
+    ).rejects.toThrow(/no reviewed plan/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('returns a jobId, applies in the background, and the job reaches applied with a count', async () => {
+    const docOut = '/mnt/docs/report.pdf\t10\t1700000000\0';
+    const { exec, calls } = mockExec({
+      find: ok(docOut),
+      sha256sum: argv => ok(`${'c'.repeat(64)}  ${argv[1]}\n`),
+    });
+    // Scan synchronously so we have a reviewed session to apply.
+    const scan = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    const { jobId } = await startApply({ exec, sessionId: scan.sessionId, shareGid: 1024 });
+    expect(jobId).toBe(scan.sessionId);
+
+    await waitFor(async () => (await getImportJob(jobId))!.phase === 'applied');
+    const done = await getImportJob(jobId);
+    expect(done!.phase).toBe('applied');
+    expect(done!.applied).toBe(1);
+    expect(calls.some(c => c[0] === 'rsync')).toBe(true);
+
+    // One apply per review: a second startApply is refused (phase is now applied).
+    await expect(
+      startApply({ exec, sessionId: scan.sessionId, shareGid: 1024 }),
+    ).rejects.toThrow(/no reviewed plan/);
   });
 });
 

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -24,10 +24,15 @@ import { listBlockDevices, mountReadOnly, unmount, type BlockDevice } from './mo
 import { hashRecords, hashSourceFile, scanMount } from './hostScan';
 import { applyPlan, type ApplyResult, type ImmichConfig } from './plan';
 import {
-  createSession,
+  createScanJob,
+  finalizeScan,
   getSession,
   markApplied,
+  markApplying,
+  markError,
+  setProgress,
   sessionHashes,
+  type ScanSession,
   __clearSessions as clearSessionStore,
 } from './sessionStore';
 import type { SafeExec } from './hostExec';
@@ -120,18 +125,61 @@ function describeDevice(d: BlockDevice): string {
  * source is `-o ro` and the catalog is opened read-only-in-effect (we only read
  * it for delta dedup here; nothing is upserted until apply). The mount is always
  * unmounted before returning, even on error.
+ *
+ * Synchronous variant (kept for the engine tests + any caller that can wait):
+ * creates its own session id and runs the walk/hash/plan inline. The HTTP route
+ * uses {@link startScan} instead, which returns the id immediately and runs this
+ * same work in the background (#1897) so a large disk never blocks past the HTTP
+ * timeout.
  */
 export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
+  const { device, catalogPath } = opts;
+  const sessionId = randomUUID();
+  await createScanJob({ id: sessionId, device, catalogPath });
+  return runScan(sessionId, opts);
+}
+
+/**
+ * Async entry point (#1897). Open a job in `scanning`, kick off the real scan as
+ * a detached task, and return the id IMMEDIATELY — no 504 on a large disk. The
+ * card polls {@link getImportJob} for live phase + counts and the reviewed
+ * plan. Errors are caught and recorded on the session (never propagate — there
+ * is no caller awaiting them), mirroring `install/runner.startJob`.
+ */
+export async function startScan(opts: ScanOptions): Promise<{ jobId: string }> {
+  const sessionId = randomUUID();
+  await createScanJob({ id: sessionId, device: opts.device, catalogPath: opts.catalogPath });
+  void (async () => {
+    try {
+      await runScan(sessionId, opts);
+    } catch (e) {
+      await markError(sessionId, e instanceof Error ? e.message : String(e));
+    }
+  })();
+  return { jobId: sessionId };
+}
+
+/**
+ * The scan work proper: mount → walk → hash → plan → finalize the session. Runs
+ * either inline ({@link scanDevice}) or as the detached body of {@link startScan}.
+ * Streams progress into the session as it goes (step + scanned/hashed counts).
+ */
+async function runScan(sessionId: string, opts: ScanOptions): Promise<ScanResult> {
   const { exec, device, catalogPath } = opts;
+  await setProgress(sessionId, { step: 'mount' });
   const mountpoint = await mountReadOnly(exec, device);
   try {
+    await setProgress(sessionId, { step: 'walk' });
     const files = await scanMount(exec, mountpoint);
     const records = buildInventory(files);
+    await setProgress(sessionId, { step: 'hash', scanned: records.length });
 
     // Pre-hash only the size-collision candidates host-side, then hand dedup a
     // synchronous resolver over the resulting map (the engine stays sync).
     const candidates = sizeCollisionCandidates(records);
-    const hashes = await hashRecords(exec, candidates);
+    const hashes = await hashRecords(exec, candidates, (hashed, total) => {
+      void setProgress(sessionId, { hashed, total });
+    });
     const hashOf: HashResolver = record => {
       const h = hashes.get(record.sourcePath);
       if (h === undefined) {
@@ -140,6 +188,7 @@ export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
       return h;
     };
 
+    await setProgress(sessionId, { step: 'plan' });
     const catalog = new ImportCatalog(catalogPath);
     let plan: ImportPlan;
     try {
@@ -148,8 +197,7 @@ export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
       catalog.close();
     }
 
-    const sessionId = randomUUID();
-    await createSession({ id: sessionId, device, plan, hashes, catalogPath });
+    await finalizeScan(sessionId, { plan, hashes });
 
     return {
       sessionId,
@@ -174,12 +222,46 @@ export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
  * session is consumed (one apply per review) on success.
  */
 export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> {
-  const { exec, sessionId, shareGid, immich } = opts;
-  const stored = await getSession(sessionId);
-  if (!stored || stored.phase === 'applied') {
+  return runApply(opts);
+}
+
+/**
+ * Async entry point (#1897). Verify the review gate SYNCHRONOUSLY (so a forged/
+ * unreviewed/already-applied id still gets an immediate error), flip the session
+ * to `applying`, kick off the apply as a detached task, and return the id. The
+ * card polls {@link getImportJob} for live copy progress. Errors are recorded on
+ * the session, mirroring `install/runner.startJob`.
+ */
+export async function startApply(opts: ApplyOptions): Promise<{ jobId: string }> {
+  const stored = await getSession(opts.sessionId);
+  if (!stored || stored.phase !== 'reviewed' || !stored.plan) {
     throw new Error('disk-import: no reviewed plan for this session — scan + review before applying');
   }
-  const session = { ...stored, hashes: sessionHashes(stored) };
+  await markApplying(opts.sessionId);
+  void (async () => {
+    try {
+      await runApply(opts, { gateChecked: true });
+    } catch (e) {
+      await markError(opts.sessionId, e instanceof Error ? e.message : String(e));
+    }
+  })();
+  return { jobId: opts.sessionId };
+}
+
+async function runApply(
+  opts: ApplyOptions,
+  ctx: { gateChecked?: boolean } = {},
+): Promise<ApplyResult> {
+  const { exec, sessionId, shareGid, immich } = opts;
+  const stored = await getSession(sessionId);
+  // `startApply` already verified + flipped the gate to `applying`; the inline
+  // path checks `reviewed` here. Either way an unreviewed/forged/consumed id is
+  // refused — there is no path to apply a plan that wasn't scanned + reviewed.
+  const acceptable = ctx.gateChecked ? stored?.phase === 'applying' : stored?.phase === 'reviewed';
+  if (!stored || !acceptable || !stored.plan) {
+    throw new Error('disk-import: no reviewed plan for this session — scan + review before applying');
+  }
+  const session = { ...stored, plan: stored.plan, hashes: sessionHashes(stored) };
 
   // Re-mount read-only for the apply pass (the scan unmounted it).
   const mountpoint = await mountReadOnly(exec, session.device);
@@ -187,15 +269,8 @@ export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> 
   try {
     // applyPlan writes a catalog row (keyed by sha) for EVERY copied/superseded
     // item, so it needs a hash for each — not just the size-collision set the
-    // scan pre-hashed. Top up the map host-side for the to-be-written items
-    // (the source is mounted read-only) so the sync resolver below never misses.
-    const hashes = new Map(session.hashes);
-    for (const item of session.plan.items) {
-      const writes = item.action === 'copy' || item.action === 'conflict';
-      if (writes && item.category !== 'photos' && !hashes.has(item.record.sourcePath)) {
-        hashes.set(item.record.sourcePath, await hashSourceFile(exec, item.record.sourcePath));
-      }
-    }
+    // scan pre-hashed. Top up the map host-side for the to-be-written items.
+    const hashes = await topUpHashes(exec, session.plan, session.hashes);
     const hashOf: HashResolver = record => {
       const h = hashes.get(record.sourcePath);
       if (h === undefined) {
@@ -211,8 +286,16 @@ export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> 
       shareGid,
       hashOf,
       immich,
+      onProgress: p => {
+        void setProgress(sessionId, {
+          step: 'copy',
+          copied: p.copied,
+          bytes: p.bytes,
+          total: p.total,
+        });
+      },
     });
-    await markApplied(sessionId); // one apply per reviewed plan
+    await markApplied(sessionId, result.applied); // one apply per reviewed plan
     return result;
   } finally {
     catalog.close();
@@ -220,9 +303,75 @@ export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> 
   }
 }
 
+/**
+ * Status for a disk-import job (#1897). The poll the card hangs off: returns the
+ * current phase + live progress counts, and — once `reviewed` — the review
+ * payload (per-category sizing + non-blocking actions[]) so a reopened/restarted
+ * card can re-attach to a finished scan, and once `applied` the final count. We
+ * read the deterministic engine functions again here (cheap, in-memory) rather
+ * than persist the derived review, keeping the stored session minimal.
+ */
+export interface ImportJobStatus {
+  sessionId: string;
+  device: string;
+  phase: ScanSession['phase'];
+  progress: ScanSession['progress'];
+  error?: string;
+  /** Present once `reviewed` (or later) — the review payload for the card. */
+  review?: ScanResult;
+  /** Files written this apply, present once `applied`. */
+  applied?: number;
+}
+
+export async function getImportJob(sessionId: string): Promise<ImportJobStatus | null> {
+  const s = await getSession(sessionId);
+  if (!s) return null;
+  const status: ImportJobStatus = {
+    sessionId: s.id,
+    device: s.device,
+    phase: s.phase,
+    progress: s.progress,
+    error: s.error,
+    applied: s.applied,
+  };
+  if (s.plan) {
+    status.review = {
+      sessionId: s.id,
+      device: s.device,
+      totalFiles: s.plan.items.length,
+      totalBytes: s.plan.items.reduce((sum, i) => sum + i.record.size, 0),
+      categories: summarizeCategories(s.plan),
+      actions: buildActions(s.plan, s.plan.items.map(i => i.record)),
+    };
+  }
+  return status;
+}
+
 /** Test seam: drop all persisted sessions. */
 export async function __clearSessions(): Promise<void> {
   await clearSessionStore();
+}
+
+/**
+ * Top up the hash map for the apply pass. The scan only pre-hashed size-
+ * collision candidates; applyPlan needs a hash for every copied/superseded
+ * non-photo item (the catalog row is keyed by sha). The source is mounted
+ * read-only, so this only reads. Returns a fresh map (the session's is left
+ * untouched).
+ */
+async function topUpHashes(
+  exec: SafeExec,
+  plan: ImportPlan,
+  base: Map<string, string>,
+): Promise<Map<string, string>> {
+  const hashes = new Map(base);
+  for (const item of plan.items) {
+    const writes = item.action === 'copy' || item.action === 'conflict';
+    if (writes && item.category !== 'photos' && !hashes.has(item.record.sourcePath)) {
+      hashes.set(item.record.sourcePath, await hashSourceFile(exec, item.record.sourcePath));
+    }
+  }
+  return hashes;
 }
 
 /** Records whose size is shared with another record — the only dedup candidates. */

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -21,7 +21,7 @@ import { buildInventory } from './inventory';
 import { buildPlan, type HashResolver } from './dedup';
 import { classifyRecord } from './classify';
 import { listBlockDevices, mountReadOnly, unmount, type BlockDevice } from './mounter';
-import { hashRecords, hashSourceFile, scanMount } from './hostScan';
+import { hashPaths, hashRecords, scanMount } from './hostScan';
 import { applyPlan, type ApplyResult, type ImmichConfig } from './plan';
 import {
   createScanJob,
@@ -365,12 +365,21 @@ async function topUpHashes(
   base: Map<string, string>,
 ): Promise<Map<string, string>> {
   const hashes = new Map(base);
+  // Collect the still-unhashed write targets, then hash them in ONE batched pass
+  // (#1898) instead of a `sha256sum` round-trip per file. Dedup by path so a
+  // plan that names the same source twice isn't hashed twice.
+  const missing: string[] = [];
+  const seen = new Set<string>();
   for (const item of plan.items) {
     const writes = item.action === 'copy' || item.action === 'conflict';
-    if (writes && item.category !== 'photos' && !hashes.has(item.record.sourcePath)) {
-      hashes.set(item.record.sourcePath, await hashSourceFile(exec, item.record.sourcePath));
+    const p = item.record.sourcePath;
+    if (writes && item.category !== 'photos' && !hashes.has(p) && !seen.has(p)) {
+      seen.add(p);
+      missing.push(p);
     }
   }
+  const fresh = await hashPaths(exec, missing);
+  for (const [p, h] of fresh) hashes.set(p, h);
   return hashes;
 }
 

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -23,6 +23,13 @@ import { classifyRecord } from './classify';
 import { listBlockDevices, mountReadOnly, unmount, type BlockDevice } from './mounter';
 import { hashRecords, hashSourceFile, scanMount } from './hostScan';
 import { applyPlan, type ApplyResult, type ImmichConfig } from './plan';
+import {
+  createSession,
+  getSession,
+  markApplied,
+  sessionHashes,
+  __clearSessions as clearSessionStore,
+} from './sessionStore';
 import type { SafeExec } from './hostExec';
 import type { Category, ImportPlan, ImportRecord } from './types';
 
@@ -88,18 +95,6 @@ export interface ApplyOptions {
   immich?: ImmichConfig;
 }
 
-/** One stored, reviewed-but-not-applied scan. The apply gate keys off this. */
-interface ScanSession {
-  device: string;
-  plan: ImportPlan;
-  hashes: Map<string, string>;
-  catalogPath: string;
-}
-
-// In-process review-gate store. A plan can only be applied via the same backend
-// process that scanned it — a forged/replayed sessionId can't conjure a plan.
-const SESSIONS = new Map<string, ScanSession>();
-
 /**
  * Enumerate removable partitions that carry a filesystem — the only things the
  * card offers as an import source (a whole-disk node or a bare partition with no
@@ -119,7 +114,9 @@ function describeDevice(d: BlockDevice): string {
 
 /**
  * Mount the device READ-ONLY, host-walk it, run the deterministic pipeline, and
- * return the review payload + a session token. Writes NOTHING to the host: the
+ * return the review payload + a session token. The reviewed plan is persisted
+ * to the durable session store (#1896) so it survives a backend restart and a
+ * reopened card can re-attach by id. Writes NOTHING to the imported host: the
  * source is `-o ro` and the catalog is opened read-only-in-effect (we only read
  * it for delta dedup here; nothing is upserted until apply). The mount is always
  * unmounted before returning, even on error.
@@ -152,7 +149,7 @@ export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
     }
 
     const sessionId = randomUUID();
-    SESSIONS.set(sessionId, { device, plan, hashes, catalogPath });
+    await createSession({ id: sessionId, device, plan, hashes, catalogPath });
 
     return {
       sessionId,
@@ -171,15 +168,18 @@ export async function scanDevice(opts: ScanOptions): Promise<ScanResult> {
 /**
  * Apply a previously-scanned plan. REQUIRES a valid `sessionId` from
  * {@link scanDevice} — this is the review gate: there is no path to apply a plan
- * that wasn't scanned + reviewed in this process. Resumable (catalog-backed); the
+ * that wasn't scanned + reviewed. The session is read from the durable store
+ * (#1896), so it survives a backend restart between scan and apply — a forged/
+ * replayed id still can't conjure a plan. Resumable (catalog-backed); the
  * session is consumed (one apply per review) on success.
  */
 export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> {
   const { exec, sessionId, shareGid, immich } = opts;
-  const session = SESSIONS.get(sessionId);
-  if (!session) {
+  const stored = await getSession(sessionId);
+  if (!stored || stored.phase === 'applied') {
     throw new Error('disk-import: no reviewed plan for this session — scan + review before applying');
   }
+  const session = { ...stored, hashes: sessionHashes(stored) };
 
   // Re-mount read-only for the apply pass (the scan unmounted it).
   const mountpoint = await mountReadOnly(exec, session.device);
@@ -212,7 +212,7 @@ export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> 
       hashOf,
       immich,
     });
-    SESSIONS.delete(sessionId); // one apply per reviewed plan
+    await markApplied(sessionId); // one apply per reviewed plan
     return result;
   } finally {
     catalog.close();
@@ -220,9 +220,9 @@ export async function applyImportPlan(opts: ApplyOptions): Promise<ApplyResult> 
   }
 }
 
-/** Test seam: drop all in-memory sessions. */
-export function __clearSessions(): void {
-  SESSIONS.clear();
+/** Test seam: drop all persisted sessions. */
+export async function __clearSessions(): Promise<void> {
+  await clearSessionStore();
 }
 
 /** Records whose size is shared with another record — the only dedup candidates. */

--- a/packages/backend/src/lib/diskImport/sessionStore.test.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.test.ts
@@ -23,6 +23,13 @@ const SESSIONS_DIR = path.join(TEST_DIR, 'disk-import-sessions');
 
 import {
   createSession,
+  createScanJob,
+  finalizeScan,
+  updateSession,
+  setProgress,
+  markApplying,
+  markError,
+  markCrashedOnStartup,
   getSession,
   markApplied,
   sessionHashes,
@@ -67,7 +74,7 @@ describe('createSession + getSession (persistence)', () => {
     expect(got).not.toBeNull();
     expect(got!.device).toBe('/dev/sda1');
     expect(got!.phase).toBe('reviewed');
-    expect(got!.plan.items[0].target).toBe('documents/report.pdf');
+    expect(got!.plan!.items[0].target).toBe('documents/report.pdf');
     expect(sessionHashes(got!).get('/mnt/docs/report.pdf')).toBe('a'.repeat(64));
   });
 
@@ -91,7 +98,7 @@ describe('restart survival', () => {
     expect(got).not.toBeNull();
     expect(got!.device).toBe('/dev/sdb1');
     expect(got!.catalogPath).toBe('/tmp/cat.db');
-    expect(got!.plan.items[0].record.sourcePath).toBe('/mnt/music/track.flac');
+    expect(got!.plan!.items[0].record.sourcePath).toBe('/mnt/music/track.flac');
     expect(fresh.sessionHashes(got!).get('/mnt/music/track.flac')).toBe('b'.repeat(64));
   });
 });
@@ -131,6 +138,63 @@ describe('append/readLog', () => {
     expect(nextOffset).toBeGreaterThan(0);
     // Catch-up read from the offset returns nothing new.
     expect((await readLog('sess-log', nextOffset)).content).toBe('');
+  });
+});
+
+describe('async job lifecycle (#1897)', () => {
+  it('createScanJob opens a scanning job with no plan; finalizeScan attaches the plan + flips to reviewed', async () => {
+    await createScanJob({ id: 'job-1', device: '/dev/sda1', catalogPath: ':memory:' });
+    const opened = await getSession('job-1');
+    expect(opened!.phase).toBe('scanning');
+    expect(opened!.plan).toBeUndefined();
+    expect(opened!.progress.step).toBe('mount');
+
+    const plan = mkPlan();
+    const hashes = new Map([['/mnt/docs/report.pdf', 'd'.repeat(64)]]);
+    await finalizeScan('job-1', { plan, hashes });
+    const reviewed = await getSession('job-1');
+    expect(reviewed!.phase).toBe('reviewed');
+    expect(reviewed!.plan!.items[0].target).toBe('documents/report.pdf');
+    expect(sessionHashes(reviewed!).get('/mnt/docs/report.pdf')).toBe('d'.repeat(64));
+    expect(reviewed!.progress.scanned).toBe(1);
+  });
+
+  it('setProgress patches live counters; markApplying / markError flip phase', async () => {
+    await createScanJob({ id: 'job-2', device: '/dev/sda1', catalogPath: ':memory:' });
+    await setProgress('job-2', { step: 'hash', scanned: 120, hashed: 40, total: 60 });
+    let s = await getSession('job-2');
+    expect(s!.progress).toMatchObject({ step: 'hash', scanned: 120, hashed: 40, total: 60 });
+
+    await markApplying('job-2');
+    s = await getSession('job-2');
+    expect(s!.phase).toBe('applying');
+    expect(s!.progress.step).toBe('copy');
+
+    await markError('job-2', 'rsync blew up');
+    s = await getSession('job-2');
+    expect(s!.phase).toBe('error');
+    expect(s!.error).toBe('rsync blew up');
+  });
+
+  it('markApplied records the written count; updateSession is a no-op on a gone session', async () => {
+    await createSession({ id: 'job-3', device: '/dev/sda1', plan: mkPlan(), hashes: new Map(), catalogPath: ':memory:' });
+    const applied = await markApplied('job-3', 7);
+    expect(applied!.phase).toBe('applied');
+    expect(applied!.applied).toBe(7);
+    expect(await updateSession('ghost', { phase: 'error' })).toBeNull();
+  });
+
+  it('markCrashedOnStartup flips mid-flight jobs to error, leaves terminal ones alone', async () => {
+    await createScanJob({ id: 'crash-scan', device: '/dev/sda1', catalogPath: ':memory:' }); // scanning
+    await createScanJob({ id: 'crash-apply', device: '/dev/sda1', catalogPath: ':memory:' });
+    await markApplying('crash-apply'); // applying
+    await createSession({ id: 'survivor', device: '/dev/sda1', plan: mkPlan(), hashes: new Map(), catalogPath: ':memory:' }); // reviewed
+
+    const n = await markCrashedOnStartup();
+    expect(n).toBe(2);
+    expect((await getSession('crash-scan'))!.phase).toBe('error');
+    expect((await getSession('crash-apply'))!.phase).toBe('error');
+    expect((await getSession('survivor'))!.phase).toBe('reviewed');
   });
 });
 

--- a/packages/backend/src/lib/diskImport/sessionStore.test.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Durable disk-import session store (#1896).
+ *
+ * Mirrors the jobStore persistence contract: a reviewed scan plan is written
+ * to its own atomic state file under DATA_DIR + an append-only log, survives a
+ * simulated backend restart (re-read from a fresh store reference), the apply
+ * reference is one-shot (markApplied), and old sessions are pruned to
+ * KEEP_RECENT.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+
+// Real-fs path scoped to this process so we exercise the actual atomic
+// write/read/prune logic (no fs mock), mirroring jobStore.race.test.ts.
+vi.mock('@/lib/dirs', () => ({
+  DATA_DIR: path.join(os.tmpdir(), `sb-diskimport-store-${process.pid}`),
+}));
+
+const TEST_DIR = path.join(os.tmpdir(), `sb-diskimport-store-${process.pid}`);
+const SESSIONS_DIR = path.join(TEST_DIR, 'disk-import-sessions');
+
+import {
+  createSession,
+  getSession,
+  markApplied,
+  sessionHashes,
+  appendLog,
+  readLog,
+  __clearSessions,
+} from './sessionStore';
+import type { ImportPlan } from './types';
+
+function mkPlan(sourcePath = '/mnt/docs/report.pdf'): ImportPlan {
+  return {
+    items: [
+      {
+        record: { sourcePath, size: 10, mtimeMs: 1700000000000, ext: 'pdf', name: 'report.pdf' },
+        category: 'documents',
+        target: 'documents/report.pdf',
+        action: 'copy',
+      },
+    ],
+    conflicts: [],
+  };
+}
+
+beforeEach(async () => {
+  await __clearSessions();
+});
+
+afterEach(async () => {
+  await __clearSessions();
+});
+
+describe('createSession + getSession (persistence)', () => {
+  it('persists a reviewed session to its own state file and reads it back intact', async () => {
+    const plan = mkPlan();
+    const hashes = new Map([['/mnt/docs/report.pdf', 'a'.repeat(64)]]);
+    await createSession({ id: 'sess-1', device: '/dev/sda1', plan, hashes, catalogPath: ':memory:' });
+
+    // The state file exists on disk (its own per-session file).
+    await expect(fs.stat(path.join(SESSIONS_DIR, 'sess-1.json'))).resolves.toBeTruthy();
+
+    const got = await getSession('sess-1');
+    expect(got).not.toBeNull();
+    expect(got!.device).toBe('/dev/sda1');
+    expect(got!.phase).toBe('reviewed');
+    expect(got!.plan.items[0].target).toBe('documents/report.pdf');
+    expect(sessionHashes(got!).get('/mnt/docs/report.pdf')).toBe('a'.repeat(64));
+  });
+
+  it('returns null for an unknown / forged session id (the review gate)', async () => {
+    expect(await getSession('forged')).toBeNull();
+  });
+});
+
+describe('restart survival', () => {
+  it('a session created then re-read from a fresh store module instance is intact', async () => {
+    const plan = mkPlan('/mnt/music/track.flac');
+    const hashes = new Map([['/mnt/music/track.flac', 'b'.repeat(64)]]);
+    await createSession({ id: 'sess-restart', device: '/dev/sdb1', plan, hashes, catalogPath: '/tmp/cat.db' });
+
+    // Simulate a backend restart: drop the module cache so the next import is
+    // a fresh process-equivalent module (cold caches, new PROCESS_STARTED_AT).
+    vi.resetModules();
+    const fresh = await import('./sessionStore');
+
+    const got = await fresh.getSession('sess-restart');
+    expect(got).not.toBeNull();
+    expect(got!.device).toBe('/dev/sdb1');
+    expect(got!.catalogPath).toBe('/tmp/cat.db');
+    expect(got!.plan.items[0].record.sourcePath).toBe('/mnt/music/track.flac');
+    expect(fresh.sessionHashes(got!).get('/mnt/music/track.flac')).toBe('b'.repeat(64));
+  });
+});
+
+describe('markApplied (one apply per review)', () => {
+  it('flips phase to applied so the apply gate refuses a second apply', async () => {
+    await createSession({
+      id: 'sess-apply',
+      device: '/dev/sda1',
+      plan: mkPlan(),
+      hashes: new Map(),
+      catalogPath: ':memory:',
+    });
+    const applied = await markApplied('sess-apply');
+    expect(applied!.phase).toBe('applied');
+    expect((await getSession('sess-apply'))!.phase).toBe('applied');
+  });
+
+  it('returns null when the session is gone', async () => {
+    expect(await markApplied('nope')).toBeNull();
+  });
+});
+
+describe('append/readLog', () => {
+  it('appends lines and reads them back from an offset', async () => {
+    await createSession({
+      id: 'sess-log',
+      device: '/dev/sda1',
+      plan: mkPlan(),
+      hashes: new Map(),
+      catalogPath: ':memory:',
+    });
+    await appendLog('sess-log', 'scanning');
+    await appendLog('sess-log', 'done');
+    const { content, nextOffset } = await readLog('sess-log');
+    expect(content).toBe('scanning\ndone\n');
+    expect(nextOffset).toBeGreaterThan(0);
+    // Catch-up read from the offset returns nothing new.
+    expect((await readLog('sess-log', nextOffset)).content).toBe('');
+  });
+});
+
+describe('prune to KEEP_RECENT', () => {
+  it('keeps only the most-recent sessions, dropping older state + log files', async () => {
+    // KEEP_RECENT_SESSIONS is 20; create 23 so 3 of the oldest get pruned on
+    // the later createSession calls. createdAt is ISO-second granularity, so
+    // stamp distinct createdAt values to make "most recent" deterministic.
+    const ids: string[] = [];
+    for (let i = 0; i < 23; i++) {
+      const id = `prune-${String(i).padStart(2, '0')}`;
+      ids.push(id);
+      await createSession({
+        id,
+        device: '/dev/sda1',
+        plan: mkPlan(),
+        hashes: new Map(),
+        catalogPath: ':memory:',
+      });
+      // Rewrite createdAt so ordering is strictly by index (writes are too
+      // fast to differ at second granularity otherwise).
+      const p = path.join(SESSIONS_DIR, `${id}.json`);
+      const raw = JSON.parse(await fs.readFile(p, 'utf-8'));
+      raw.createdAt = new Date(1700000000000 + i * 1000).toISOString();
+      await fs.writeFile(p, JSON.stringify(raw));
+    }
+
+    // prune runs at the START of each createSession (before the new write),
+    // exactly like jobStore — so after the last create the count is keep + the
+    // just-written one (21), and the oldest beyond keep are gone.
+    const remaining = (await fs.readdir(SESSIONS_DIR)).filter(f => f.endsWith('.json'));
+    expect(remaining.length).toBeLessThanOrEqual(21);
+    // The oldest are pruned; the newest survive (and so are their log files).
+    expect(await getSession('prune-00')).toBeNull();
+    expect(await getSession('prune-22')).not.toBeNull();
+    await expect(fs.stat(path.join(SESSIONS_DIR, 'prune-00.log'))).rejects.toThrow();
+  });
+});

--- a/packages/backend/src/lib/diskImport/sessionStore.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.ts
@@ -43,22 +43,74 @@ export const PROCESS_STARTED_AT = new Date().toISOString();
  *  KEEP_RECENT_JOBS. */
 const KEEP_RECENT_SESSIONS = 20;
 
-export type SessionPhase = 'reviewed' | 'applied';
+/**
+ * Lifecycle of a disk-import job (#1897). A scan and an apply both run in the
+ * background, so the card polls this phase:
+ *
+ *   scanning  → mount/walk/hash/plan in flight (no plan yet)
+ *   reviewed  → plan ready; awaiting the operator's CONFIRM (the review gate)
+ *   applying  → apply (copy/chown/upload) in flight
+ *   applied   → apply finished; session consumed (one apply per review)
+ *   error     → the background scan or apply threw; `error` carries the message
+ *
+ * The apply gate still keys off `reviewed`: apply is refused unless the session
+ * is in `reviewed` (a `scanning`/`applying`/`applied`/`error` session can't be
+ * applied). Mirrors jobStore's JobPhase.
+ */
+export type SessionPhase = 'scanning' | 'reviewed' | 'applying' | 'applied' | 'error';
+
+/** Which background pass a session is running (#1897). Drives the card's phase
+ *  label + which count set is meaningful. */
+export type SessionStep =
+  | 'mount'
+  | 'walk'
+  | 'hash'
+  | 'plan'
+  | 'copy'
+  | 'done';
+
+/** Live progress counters the status route exposes so the card can render a
+ *  phase + counts instead of a bare spinner (#1897). All monotonic within a
+ *  pass; `total` is the denominator once known (0 until the walk finishes). */
+export interface SessionProgress {
+  /** The host-side pass currently running. */
+  step: SessionStep;
+  scanned: number;
+  hashed: number;
+  copied: number;
+  bytes: number;
+  /** Denominator for the active pass (files to hash, then items to apply). 0
+   *  while still walking (unknown). */
+  total: number;
+}
+
+function emptyProgress(): SessionProgress {
+  return { step: 'mount', scanned: 0, hashed: 0, copied: 0, bytes: 0, total: 0 };
+}
 
 /**
- * One stored, reviewed scan. The apply gate keys off this: a plan can only be
- * applied via a session that was scanned + reviewed (persisted here) and not
- * yet consumed. `hashes` is serialized as a plain object (JSON has no Map).
+ * One stored disk-import job. A scan creates it in `scanning`, fills in the
+ * `plan` + `hashes` and flips to `reviewed`; the apply gate keys off this (a
+ * plan can only be applied via a session that reached `reviewed` and was not
+ * yet consumed). `plan`/`hashes` are absent while `scanning`. `hashes` is
+ * serialized as a plain object (JSON has no Map).
  */
 export interface ScanSession {
   id: string;
   device: string;
-  plan: ImportPlan;
+  /** Absent while the scan is still in flight (`scanning`). */
+  plan?: ImportPlan;
   /** sourcePath → sha256 hex. Persisted as a plain object; rehydrated to a Map
-   *  by `getSession`. */
-  hashes: Record<string, string>;
+   *  by `sessionHashes`. Absent while `scanning`. */
+  hashes?: Record<string, string>;
   catalogPath: string;
   phase: SessionPhase;
+  /** Live progress for the in-flight (or last) pass (#1897). */
+  progress: SessionProgress;
+  /** How many files the apply wrote/uploaded (set when `applied`). */
+  applied?: number;
+  /** Message of the throw that put the session in `error`. */
+  error?: string;
   createdAt: string;
   updatedAt: string;
   /** PROCESS_STARTED_AT of the process that last wrote this session — the
@@ -92,8 +144,10 @@ export interface CreateSessionInput {
   catalogPath: string;
 }
 
-/** Persist a freshly-reviewed scan. Prunes old sessions first, then writes the
- *  state file atomically + an empty log file. */
+/** Persist a freshly-reviewed scan (synchronous-scan path / direct create).
+ *  Prunes old sessions first, then writes the state file atomically + an empty
+ *  log file. The async flow uses {@link createScanJob} + {@link finalizeScan}
+ *  instead; this remains for the simple "plan already in hand" case. */
 export async function createSession(input: CreateSessionInput): Promise<ScanSession> {
   await ensureDir();
   await pruneSessions(KEEP_RECENT_SESSIONS);
@@ -105,6 +159,7 @@ export async function createSession(input: CreateSessionInput): Promise<ScanSess
     hashes: Object.fromEntries(input.hashes),
     catalogPath: input.catalogPath,
     phase: 'reviewed',
+    progress: { ...emptyProgress(), step: 'done', scanned: input.plan.items.length },
     createdAt: now,
     updatedAt: now,
     seenBy: PROCESS_STARTED_AT,
@@ -112,6 +167,135 @@ export async function createSession(input: CreateSessionInput): Promise<ScanSess
   await atomicWrite(statePath(session.id), JSON.stringify(session, null, 2));
   await fs.writeFile(logPath(session.id), '', 'utf-8').catch(() => undefined);
   return session;
+}
+
+/**
+ * Open a new disk-import job in `scanning` (#1897). The scan route calls this
+ * and returns the id IMMEDIATELY; the background scan then fills the plan via
+ * {@link finalizeScan}. There is no plan/hashes yet, so the apply gate refuses
+ * a `scanning` session. Prunes old sessions + opens an empty log file.
+ */
+export async function createScanJob(input: {
+  id: string;
+  device: string;
+  catalogPath: string;
+}): Promise<ScanSession> {
+  await ensureDir();
+  await pruneSessions(KEEP_RECENT_SESSIONS);
+  const now = new Date().toISOString();
+  const session: ScanSession = {
+    id: input.id,
+    device: input.device,
+    catalogPath: input.catalogPath,
+    phase: 'scanning',
+    progress: emptyProgress(),
+    createdAt: now,
+    updatedAt: now,
+    seenBy: PROCESS_STARTED_AT,
+  };
+  await atomicWrite(statePath(session.id), JSON.stringify(session, null, 2));
+  await fs.writeFile(logPath(session.id), '', 'utf-8').catch(() => undefined);
+  return session;
+}
+
+/**
+ * Per-id write serialization. A background pass streams progress via
+ * {@link setProgress} (fire-and-forget) AND ends with a terminal write
+ * ({@link markApplied} / {@link finalizeScan}); both are read-modify-write on
+ * the same state file, so without ordering a late progress write could clobber
+ * the terminal phase back (e.g. `applied` → `applying`). Chaining every
+ * `updateSession` for an id makes the last enqueued write win, deterministically.
+ * Same shape as jobStore's `withCreateJobLock`.
+ */
+const writeQueues = new Map<string, Promise<unknown>>();
+
+function withSessionWriteLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const prev = writeQueues.get(id) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  writeQueues.set(id, next.catch(() => undefined));
+  return next;
+}
+
+/** Generic patch of a session (best-effort disk write, mirrors jobStore.updateJob).
+ *  Refreshes `updatedAt` + the restart breadcrumb. Returns null if it's gone.
+ *  Serialized per id so a trailing progress tick can't clobber a terminal write. */
+export async function updateSession(
+  id: string,
+  partial: Partial<Omit<ScanSession, 'id' | 'createdAt'>>,
+): Promise<ScanSession | null> {
+  return withSessionWriteLock(id, async () => {
+    const current = await getSession(id);
+    if (!current) return null;
+    const next: ScanSession = {
+      ...current,
+      ...partial,
+      updatedAt: new Date().toISOString(),
+      seenBy: PROCESS_STARTED_AT,
+    };
+    try {
+      await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
+    } catch {
+      // Disk write failed (volume gone? permissions?). The background pass keeps
+      // running; worst case a restart loses progress for this job.
+    }
+    return next;
+  });
+}
+
+/** Patch just the live progress counters of an in-flight pass (#1897). Routed
+ *  through the per-id write lock — the read-modify-merge of `progress` happens
+ *  INSIDE the lock so concurrent ticks (and the terminal markApplied) don't
+ *  clobber each other. */
+export async function setProgress(
+  id: string,
+  partial: Partial<SessionProgress>,
+): Promise<void> {
+  await withSessionWriteLock(id, async () => {
+    const current = await getSession(id);
+    if (!current) return;
+    const next: ScanSession = {
+      ...current,
+      progress: { ...current.progress, ...partial },
+      updatedAt: new Date().toISOString(),
+      seenBy: PROCESS_STARTED_AT,
+    };
+    try {
+      await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
+    } catch {
+      /* best-effort live progress; a lost tick is non-fatal */
+    }
+  });
+}
+
+/** Background scan completed: attach the reviewed plan + hashes and flip to
+ *  `reviewed` so the apply gate accepts it. */
+export async function finalizeScan(
+  id: string,
+  input: { plan: ImportPlan; hashes: Map<string, string> },
+): Promise<ScanSession | null> {
+  return updateSession(id, {
+    plan: input.plan,
+    hashes: Object.fromEntries(input.hashes),
+    phase: 'reviewed',
+    progress: {
+      step: 'done',
+      scanned: input.plan.items.length,
+      hashed: input.plan.items.length,
+      copied: 0,
+      bytes: 0,
+      total: input.plan.items.length,
+    },
+  });
+}
+
+/** Flip a reviewed session into `applying` (the apply background pass started). */
+export async function markApplying(id: string): Promise<ScanSession | null> {
+  return updateSession(id, { phase: 'applying', progress: { ...emptyProgress(), step: 'copy' } });
+}
+
+/** Record a background pass failure: phase=error + the message. */
+export async function markError(id: string, message: string): Promise<ScanSession | null> {
+  return updateSession(id, { phase: 'error', error: message });
 }
 
 /** Read a session by id. Returns null when the state file is missing or
@@ -127,30 +311,25 @@ export async function getSession(id: string): Promise<ScanSession | null> {
 }
 
 /** Convenience: rehydrate the persisted `hashes` object back to the Map the
- *  apply path works with. */
+ *  apply path works with. Empty for a session still `scanning`. */
 export function sessionHashes(session: ScanSession): Map<string, string> {
-  return new Map(Object.entries(session.hashes));
+  return new Map(Object.entries(session.hashes ?? {}));
 }
 
 /** Mark a session as applied (one apply per reviewed plan) and refresh its
- *  breadcrumb. Returns null if the session is gone. */
-export async function markApplied(id: string): Promise<ScanSession | null> {
+ *  breadcrumb. `applied` is the count of files written this pass (surfaced by
+ *  the status route when the card re-attaches to a finished apply). Returns
+ *  null if the session is gone. */
+export async function markApplied(id: string, appliedCount?: number): Promise<ScanSession | null> {
   const current = await getSession(id);
-  if (!current) return null;
-  const next: ScanSession = {
-    ...current,
+  // Routed through the per-id write lock so a trailing progress tick from the
+  // apply pass can't clobber the terminal `applied` phase back to `applying`.
+  // `step: 'done'` is the final progress; the count is what the card shows.
+  return updateSession(id, {
     phase: 'applied',
-    updatedAt: new Date().toISOString(),
-    seenBy: PROCESS_STARTED_AT,
-  };
-  try {
-    await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
-  } catch {
-    // Disk write failed (volume gone? permissions?). The apply already
-    // succeeded; worst case a restart re-offers an applied session — the
-    // catalog dedup makes a re-apply a no-op, so this is non-fatal.
-  }
-  return next;
+    applied: appliedCount ?? current?.applied,
+    progress: { ...(current?.progress ?? emptyProgress()), step: 'done' },
+  });
 }
 
 /** Append a line to a session's log file. Best-effort, for #1897's progress
@@ -181,7 +360,28 @@ export async function readLog(
   }
 }
 
-async function listSessions(): Promise<ScanSession[]> {
+/**
+ * Any session left mid-flight (`scanning`/`applying`) belonged to a previous
+ * backend process that died — flip it to `error` so a reopened card surfaces a
+ * "try again" instead of polling forever for progress that will never come.
+ * Mirrors jobStore.markCrashedOnStartup. Returns how many it flipped.
+ */
+export async function markCrashedOnStartup(): Promise<number> {
+  const sessions = await listSessions();
+  let count = 0;
+  for (const s of sessions) {
+    if (s.phase === 'scanning' || s.phase === 'applying') {
+      await updateSession(s.id, {
+        phase: 'error',
+        error: 'Backend restarted while the disk-import job was running.',
+      });
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export async function listSessions(): Promise<ScanSession[]> {
   try {
     await ensureDir();
     const entries = await fs.readdir(SESSIONS_DIR);

--- a/packages/backend/src/lib/diskImport/sessionStore.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.ts
@@ -1,0 +1,217 @@
+/**
+ * File-based persistence for disk-import scan sessions (#1896).
+ *
+ * Why this exists: `service.ts` used to hold reviewed-but-not-applied scan
+ * plans in a process-local `Map` (the review gate — apply requires a session
+ * scanned in THIS process). That meant a backend restart between scan and
+ * apply silently dropped the reviewed plan: a reopened disk-import card had
+ * no way to re-attach to the session it was reviewing, and the apply gate
+ * could only ever see sessions created since the last boot.
+ *
+ * This module persists each session to its own atomic state file under
+ * DATA_DIR + an append-only log file, modeled directly on
+ * `lib/install/jobStore.ts`:
+ *
+ *   - a reopened card can re-attach to a reviewed plan by session id
+ *   - the reviewed plan + apply reference survive a backend restart
+ *   - a crash leaves a breadcrumb (PROCESS_STARTED_AT)
+ *
+ * Session state files are small (a plan over a few thousand records is well
+ * under a few hundred KB) so a full read/write per update is fine — this is
+ * not a hot path. The store is the only thing this unit changes; async/
+ * progress (#1897) and batched host-work (#1898) build on top.
+ */
+import fs from 'fs/promises';
+import path from 'path';
+
+import { DATA_DIR } from '@/lib/dirs';
+
+import type { ImportPlan } from './types';
+
+const SESSIONS_DIR = path.join(DATA_DIR, 'disk-import-sessions');
+
+/** Captured at module load — effectively this backend process's start time.
+ *  A session whose `seenBy` differs from the current process started before
+ *  the last restart; the breadcrumb lets a reopened card tell a survivor
+ *  session from one created in this process, mirroring jobStore's
+ *  PROCESS_STARTED_AT. */
+export const PROCESS_STARTED_AT = new Date().toISOString();
+
+/** Pruning threshold — keep this many most-recent sessions on disk so a
+ *  reopened card can still re-attach to a recently-reviewed plan. Older
+ *  sessions are cleaned up on each createSession call. Mirrors jobStore's
+ *  KEEP_RECENT_JOBS. */
+const KEEP_RECENT_SESSIONS = 20;
+
+export type SessionPhase = 'reviewed' | 'applied';
+
+/**
+ * One stored, reviewed scan. The apply gate keys off this: a plan can only be
+ * applied via a session that was scanned + reviewed (persisted here) and not
+ * yet consumed. `hashes` is serialized as a plain object (JSON has no Map).
+ */
+export interface ScanSession {
+  id: string;
+  device: string;
+  plan: ImportPlan;
+  /** sourcePath → sha256 hex. Persisted as a plain object; rehydrated to a Map
+   *  by `getSession`. */
+  hashes: Record<string, string>;
+  catalogPath: string;
+  phase: SessionPhase;
+  createdAt: string;
+  updatedAt: string;
+  /** PROCESS_STARTED_AT of the process that last wrote this session — the
+   *  crash/restart breadcrumb. */
+  seenBy: string;
+}
+
+async function ensureDir(): Promise<void> {
+  await fs.mkdir(SESSIONS_DIR, { recursive: true }).catch(() => undefined);
+}
+
+const statePath = (id: string) => path.join(SESSIONS_DIR, `${id}.json`);
+const logPath = (id: string) => path.join(SESSIONS_DIR, `${id}.log`);
+
+/**
+ * Atomic write via tmp + rename. Prevents a reopened card (or the apply gate)
+ * from ever reading a partially-written session file even if the process is
+ * killed mid-write. Mirrors jobStore.atomicWrite.
+ */
+async function atomicWrite(p: string, content: string): Promise<void> {
+  const tmp = `${p}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, content, 'utf-8');
+  await fs.rename(tmp, p);
+}
+
+export interface CreateSessionInput {
+  id: string;
+  device: string;
+  plan: ImportPlan;
+  hashes: Map<string, string>;
+  catalogPath: string;
+}
+
+/** Persist a freshly-reviewed scan. Prunes old sessions first, then writes the
+ *  state file atomically + an empty log file. */
+export async function createSession(input: CreateSessionInput): Promise<ScanSession> {
+  await ensureDir();
+  await pruneSessions(KEEP_RECENT_SESSIONS);
+  const now = new Date().toISOString();
+  const session: ScanSession = {
+    id: input.id,
+    device: input.device,
+    plan: input.plan,
+    hashes: Object.fromEntries(input.hashes),
+    catalogPath: input.catalogPath,
+    phase: 'reviewed',
+    createdAt: now,
+    updatedAt: now,
+    seenBy: PROCESS_STARTED_AT,
+  };
+  await atomicWrite(statePath(session.id), JSON.stringify(session, null, 2));
+  await fs.writeFile(logPath(session.id), '', 'utf-8').catch(() => undefined);
+  return session;
+}
+
+/** Read a session by id. Returns null when the state file is missing or
+ *  corrupt — a forged/replayed id can't conjure a plan (the review gate). */
+export async function getSession(id: string): Promise<ScanSession | null> {
+  try {
+    const raw = await fs.readFile(statePath(id), 'utf-8');
+    const parsed = JSON.parse(raw) as ScanSession;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Convenience: rehydrate the persisted `hashes` object back to the Map the
+ *  apply path works with. */
+export function sessionHashes(session: ScanSession): Map<string, string> {
+  return new Map(Object.entries(session.hashes));
+}
+
+/** Mark a session as applied (one apply per reviewed plan) and refresh its
+ *  breadcrumb. Returns null if the session is gone. */
+export async function markApplied(id: string): Promise<ScanSession | null> {
+  const current = await getSession(id);
+  if (!current) return null;
+  const next: ScanSession = {
+    ...current,
+    phase: 'applied',
+    updatedAt: new Date().toISOString(),
+    seenBy: PROCESS_STARTED_AT,
+  };
+  try {
+    await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
+  } catch {
+    // Disk write failed (volume gone? permissions?). The apply already
+    // succeeded; worst case a restart re-offers an applied session — the
+    // catalog dedup makes a re-apply a no-op, so this is non-fatal.
+  }
+  return next;
+}
+
+/** Append a line to a session's log file. Best-effort, for #1897's progress
+ *  stream to build on. */
+export async function appendLog(id: string, line: string): Promise<void> {
+  await fs.appendFile(logPath(id), line + '\n', 'utf-8').catch(() => undefined);
+}
+
+/** Read a session's log from `sinceBytes` to end-of-file, so a reattaching
+ *  card can catch up. Mirrors jobStore.readLog. */
+export async function readLog(
+  id: string,
+  sinceBytes: number = 0,
+): Promise<{ content: string; nextOffset: number }> {
+  try {
+    const stat = await fs.stat(logPath(id));
+    if (sinceBytes >= stat.size) return { content: '', nextOffset: stat.size };
+    const fh = await fs.open(logPath(id), 'r');
+    try {
+      const buf = Buffer.alloc(stat.size - sinceBytes);
+      await fh.read(buf, 0, buf.length, sinceBytes);
+      return { content: buf.toString('utf-8'), nextOffset: stat.size };
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return { content: '', nextOffset: 0 };
+  }
+}
+
+async function listSessions(): Promise<ScanSession[]> {
+  try {
+    await ensureDir();
+    const entries = await fs.readdir(SESSIONS_DIR);
+    const sessions: ScanSession[] = [];
+    for (const f of entries) {
+      if (!f.endsWith('.json')) continue;
+      try {
+        const raw = await fs.readFile(path.join(SESSIONS_DIR, f), 'utf-8');
+        sessions.push(JSON.parse(raw) as ScanSession);
+      } catch {
+        /* skip corrupt files */
+      }
+    }
+    return sessions;
+  } catch {
+    return [];
+  }
+}
+
+async function pruneSessions(keep: number): Promise<void> {
+  const sessions = await listSessions();
+  if (sessions.length <= keep) return;
+  sessions.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  for (const s of sessions.slice(keep)) {
+    await fs.unlink(statePath(s.id)).catch(() => undefined);
+    await fs.unlink(logPath(s.id)).catch(() => undefined);
+  }
+}
+
+/** Test seam: wipe the on-disk session store. */
+export async function __clearSessions(): Promise<void> {
+  await fs.rm(SESSIONS_DIR, { recursive: true, force: true }).catch(() => undefined);
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -50,6 +50,7 @@ import { SSHConnectionPool } from './lib/ssh/pool';
 import { assertAuthSecret, getSessionFromCookieHeader, type SessionPayload } from './lib/auth/session';
 import { setIo as setInstallSocketIo } from './lib/install/socketBridge';
 import { markCrashedOnStartup as markCrashedInstallsOnStartup } from './lib/install/jobStore';
+import { markCrashedOnStartup as markCrashedImportsOnStartup } from './lib/diskImport/sessionStore';
 
 // Fail-fast at startup so misconfigured deploys don't appear to work.
 assertAuthSecret();
@@ -315,6 +316,15 @@ app.prepare().then(() => {
   markCrashedInstallsOnStartup()
     .then((n) => {
       if (n > 0) logger.info('Server', `Marked ${n} crashed install job(s) on startup.`);
+    })
+    .catch(() => { /* best-effort */ });
+
+  // Same recovery for disk-import jobs (#1897): a scan/apply running in the
+  // background when the backend died is flipped to 'error' so a reopened card
+  // re-attaches to a terminal state instead of polling forever.
+  markCrashedImportsOnStartup()
+    .then((n) => {
+      if (n > 0) logger.info('Server', `Marked ${n} crashed disk-import job(s) on startup.`);
     })
     .catch(() => { /* best-effort */ });
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import DiskImportSection, { DiskImportReview, type ScanReview } from './DiskImportSection';
+import DiskImportSection, { DiskImportReview, JobProgressView, type ScanReview } from './DiskImportSection';
 import { ToastProvider } from '@/providers/ToastProvider';
 
 const review: ScanReview = {
@@ -59,42 +59,105 @@ describe('DiskImportReview (presentational)', () => {
   });
 });
 
-/** Fresh Response per call, dispatched by URL (memory: never reuse a Response). */
-function mockFetchByUrl(map: Record<string, () => unknown>) {
+describe('JobProgressView (presentational)', () => {
+  it('shows the scan phase label + scanned/hashed counts', () => {
+    render(
+      <JobProgressView
+        status={{
+          sessionId: 'sess-1',
+          device: '/dev/sda1',
+          phase: 'scanning',
+          progress: { step: 'hash', scanned: 100, hashed: 30, copied: 0, bytes: 0, total: 50 },
+        }}
+      />,
+    );
+    expect(screen.getByText(/Checking for duplicates/i)).toBeDefined();
+    const p = screen.getByTestId('disk-import-progress');
+    expect(p.textContent).toContain('100'); // scanned
+    expect(p.textContent).toContain('30 / 50'); // hashed / total
+  });
+
+  it('shows the apply phase label + copied/bytes counts', () => {
+    render(
+      <JobProgressView
+        status={{
+          sessionId: 'sess-1',
+          device: '/dev/sda1',
+          phase: 'applying',
+          progress: { step: 'copy', scanned: 0, hashed: 0, copied: 2, bytes: 4096, total: 3 },
+        }}
+      />,
+    );
+    expect(screen.getByText(/Copying files/i)).toBeDefined();
+    const p = screen.getByTestId('disk-import-progress');
+    expect(p.textContent).toContain('2 / 3'); // copied / total
+    expect(p.textContent).toContain('4.0 KB'); // bytes
+  });
+});
+
+/**
+ * Stateful fetch mock: scan/apply hand back a jobId immediately, then the
+ * status poll walks scanning → reviewed/applied across calls (#1897). Fresh
+ * Response per call (memory: never reuse a Response).
+ */
+function mockAsyncFetch(opts: {
+  /** Status payloads the poll returns, in order; the last one repeats. */
+  statuses: Array<Record<string, unknown> | { __status: number; body: Record<string, unknown> }>;
+}) {
+  let pollIdx = 0;
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString();
-    const key = Object.keys(map).find(k => url.includes(k));
-    const body = key ? map[key]() : {};
-    return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    let body: Record<string, unknown> = {};
+    let status = 200;
+    if (url.includes('list-devices')) {
+      body = { ok: true, devices: [{ path: '/dev/sda1', display: 'USB (15 GB, exfat)' }] };
+    } else if (url.includes('disk-import/scan')) {
+      body = { ok: true, jobId: 'sess-1' };
+    } else if (url.includes('disk-import/apply')) {
+      body = { ok: true, jobId: 'sess-1' };
+    } else if (url.includes('disk-import/status')) {
+      const next = opts.statuses[Math.min(pollIdx, opts.statuses.length - 1)];
+      pollIdx += 1;
+      if (next && '__status' in next) {
+        const err = next as { __status: number; body: Record<string, unknown> };
+        status = err.__status;
+        body = err.body;
+      } else {
+        body = (next as Record<string, unknown>) ?? {};
+      }
+    }
+    return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
   });
 }
 
 const renderSection = () => render(<ToastProvider><DiskImportSection /></ToastProvider>);
 
-describe('DiskImportSection (flow)', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', mockFetchByUrl({
-      'list-devices': () => ({ ok: true, devices: [{ path: '/dev/sda1', display: 'USB (15 GB, exfat)' }] }),
-      'disk-import/scan': () => ({ ok: true, ...review }),
-      'disk-import/apply': () => ({ ok: true, applied: 3, items: [] }),
-    }));
-  });
+describe('DiskImportSection (async flow)', () => {
   afterEach(() => vi.unstubAllGlobals());
 
-  it('walks device → scan → review → confirm → apply with the apply gated on the reviewed plan', async () => {
+  it('scan returns a jobId, polls to reviewed, confirms, polls to applied — apply gated on the reviewed plan', async () => {
+    vi.stubGlobal('fetch', mockAsyncFetch({
+      statuses: [
+        { ok: true, sessionId: 'sess-1', device: '/dev/sda1', phase: 'scanning', progress: { step: 'walk', scanned: 0, hashed: 0, copied: 0, bytes: 0, total: 0 } },
+        { ok: true, sessionId: 'sess-1', device: '/dev/sda1', phase: 'reviewed', progress: { step: 'done', scanned: 3, hashed: 3, copied: 0, bytes: 0, total: 3 }, review },
+        // after apply starts, the poll resets to these:
+        { ok: true, sessionId: 'sess-1', device: '/dev/sda1', phase: 'applying', progress: { step: 'copy', scanned: 0, hashed: 0, copied: 1, bytes: 1000, total: 3 } },
+        { ok: true, sessionId: 'sess-1', device: '/dev/sda1', phase: 'applied', progress: { step: 'done', scanned: 0, hashed: 0, copied: 3, bytes: 6000, total: 3 }, applied: 3 },
+      ],
+    }));
     renderSection();
 
-    // Device auto-selected (single device); scan it.
+    // Device auto-selected; scan it → background job, progress frame shown.
     const scanBtn = await screen.findByText('Scan disk');
     fireEvent.click(scanBtn);
+    await waitFor(() => expect(screen.getByTestId('disk-import-progress')).toBeDefined());
 
-    // Review appears with the plan + the ambiguous action (non-blocking).
+    // Poll reaches `reviewed` → the review payload renders.
     await waitFor(() => expect(screen.getByTestId('disk-import-review')).toBeDefined());
     expect(screen.getByTestId('disk-import-actions')).toBeDefined();
 
-    // Confirm → apply.
+    // Confirm → apply (background) → progress → done.
     fireEvent.click(screen.getByText(/Confirm & import/i));
-
     await waitFor(() => expect(screen.getByText(/Imported 3 file/i)).toBeDefined());
 
     // The apply call carried the reviewed plan's sessionId + explicit confirm.
@@ -103,5 +166,36 @@ describe('DiskImportSection (flow)', () => {
     expect(applyCall).toBeDefined();
     const sent = JSON.parse((applyCall![1] as RequestInit).body as string);
     expect(sent).toEqual({ sessionId: 'sess-1', confirmed: true });
+  });
+
+  it('re-attaches to a finished scan job left in localStorage after a reload', async () => {
+    window.localStorage.setItem('sb.diskImport.activeJob', 'sess-1');
+    vi.stubGlobal('fetch', mockAsyncFetch({
+      statuses: [
+        { ok: true, sessionId: 'sess-1', device: '/dev/sda1', phase: 'reviewed', progress: { step: 'done', scanned: 3, hashed: 3, copied: 0, bytes: 0, total: 3 }, review },
+      ],
+    }));
+    renderSection();
+
+    // No click — the card re-attaches by id and lands straight on the review.
+    await waitFor(() => expect(screen.getByTestId('disk-import-review')).toBeDefined());
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls.some(c => String(c[0]).includes('disk-import/status?id=sess-1'))).toBe(true);
+    // localStorage cleared once the job reached a terminal phase.
+    expect(window.localStorage.getItem('sb.diskImport.activeJob')).toBeNull();
+    window.localStorage.clear();
+  });
+
+  it('drops a stale localStorage job id when the status route 404s (pruned job)', async () => {
+    window.localStorage.setItem('sb.diskImport.activeJob', 'gone');
+    vi.stubGlobal('fetch', mockAsyncFetch({
+      statuses: [{ __status: 404, body: { ok: false, error: 'unknown job' } }],
+    }));
+    renderSection();
+
+    // Falls back to the device picker; stale id cleared.
+    await waitFor(() => expect(screen.getByText('Scan disk')).toBeDefined());
+    expect(window.localStorage.getItem('sb.diskImport.activeJob')).toBeNull();
+    window.localStorage.clear();
   });
 });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
@@ -16,6 +16,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, HardDrive, AlertCircle, CheckCircle2, RefreshCw, Download } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
+import { useImportJob, type JobProgress, type JobStatus } from '../useImportJob';
 
 interface DeviceView {
   path: string;
@@ -261,6 +262,64 @@ function ImportDone({ applied, onReset }: { applied: number; onReset: () => void
   );
 }
 
+const STEP_LABEL: Record<JobProgress['step'], string> = {
+  mount: 'Mounting the disk…',
+  walk: 'Listing files…',
+  hash: 'Checking for duplicates…',
+  plan: 'Planning the import…',
+  copy: 'Copying files…',
+  done: 'Finishing up…',
+};
+
+/** Live phase + counts while a scan or apply runs in the background (#1897). */
+export function JobProgressView({ status }: { status: JobStatus | null }) {
+  const p = status?.progress;
+  const isApply = status?.phase === 'applying';
+  return (
+    <div className="space-y-3" data-testid="disk-import-progress">
+      <p className="text-sm text-gray-800 dark:text-gray-200 flex items-center gap-2">
+        <Loader2 size={16} className="animate-spin text-blue-600" />
+        {p ? STEP_LABEL[p.step] : 'Starting…'}
+      </p>
+      {p && (
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+          {!isApply && (
+            <>
+              <div className="flex justify-between">
+                <dt>Scanned</dt>
+                <dd className="text-gray-800 dark:text-gray-200">{p.scanned}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Hashed</dt>
+                <dd className="text-gray-800 dark:text-gray-200">
+                  {p.total > 0 ? `${p.hashed} / ${p.total}` : p.hashed}
+                </dd>
+              </div>
+            </>
+          )}
+          {isApply && (
+            <>
+              <div className="flex justify-between">
+                <dt>Copied</dt>
+                <dd className="text-gray-800 dark:text-gray-200">
+                  {p.total > 0 ? `${p.copied} / ${p.total}` : p.copied}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Bytes</dt>
+                <dd className="text-gray-800 dark:text-gray-200">{formatBytes(p.bytes)}</dd>
+              </div>
+            </>
+          )}
+        </dl>
+      )}
+      <p className="text-[11px] text-gray-400">
+        This keeps running even if you close the page — reopen this card to check back.
+      </p>
+    </div>
+  );
+}
+
 export default function DiskImportSection() {
   const { addToast } = useToast();
   const [devices, setDevices] = useState<DeviceView[]>([]);
@@ -293,6 +352,27 @@ export default function DiskImportSection() {
 
   useEffect(fetchDevices, [fetchDevices]);
 
+  // Background-job polling + re-attach (#1897) lives in useImportJob; the card
+  // just wires the terminal transitions into its phase/review/applied UI state.
+  const job = useImportJob({
+    onReviewed: review => {
+      setReview(review as ScanReview | null);
+      setPhase('review');
+    },
+    onApplied: count => {
+      setApplied(count);
+      setPhase('done');
+      addToast('success', 'Import finished');
+    },
+    onError: (kind, message, review) => {
+      const wasApply = kind === 'applying';
+      addToast('error', wasApply ? 'Import failed' : 'Scan failed', message);
+      setReview(review as ScanReview | null);
+      setPhase(wasApply && review ? 'review' : 'pick');
+    },
+    onGone: () => setPhase('pick'),
+  });
+
   const runScan = async () => {
     if (!selected) {
       addToast('error', 'Pick a USB device first');
@@ -306,13 +386,12 @@ export default function DiskImportSection() {
         body: JSON.stringify({ device: selected }),
       });
       const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
+      if (!res.ok || !data.jobId) {
         addToast('error', 'Scan failed', data.error || `HTTP ${res.status}`);
         setPhase('pick');
         return;
       }
-      setReview(data as ScanReview);
-      setPhase('review');
+      job.track(data.jobId, 'scanning'); // start polling
     } catch {
       addToast('error', 'Scan failed');
       setPhase('pick');
@@ -329,14 +408,12 @@ export default function DiskImportSection() {
         body: JSON.stringify({ sessionId: review.sessionId, confirmed: true }),
       });
       const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
+      if (!res.ok || !data.jobId) {
         addToast('error', 'Import failed', data.error || `HTTP ${res.status}`);
         setPhase('review');
         return;
       }
-      setApplied(typeof data.applied === 'number' ? data.applied : 0);
-      setPhase('done');
-      addToast('success', 'Import finished');
+      job.track(data.jobId, 'applying'); // start polling
     } catch {
       addToast('error', 'Import failed');
       setPhase('review');
@@ -347,6 +424,7 @@ export default function DiskImportSection() {
     setReview(null);
     setApplied(null);
     setSelected('');
+    job.clear();
     setPhase('pick');
     refreshDevices();
   };
@@ -359,10 +437,14 @@ export default function DiskImportSection() {
     );
   }
 
-  if (phase === 'applying' && review) {
+  // Background scan or apply in flight: live phase + counts from the poll
+  // (#1897), not a bare spinner. Covers a fresh run, the gap before the first
+  // poll lands, AND a cold re-attach after a reload/restart (a still-running job
+  // is `active` from localStorage before the card's own phase has caught up).
+  if (phase === 'scanning' || phase === 'applying' || job.active) {
     return (
       <Card>
-        <DiskImportReview review={review} onConfirm={() => {}} onCancel={() => {}} busy />
+        <JobProgressView status={job.status} />
       </Card>
     );
   }
@@ -386,7 +468,9 @@ export default function DiskImportSection() {
           devices={devices}
           selected={selected}
           loading={loadingDevices}
-          scanning={phase === 'scanning'}
+          // Reaching here means phase==='pick' (scanning renders the progress
+          // frame above); a scan in flight never shows the picker.
+          scanning={false}
           onSelect={setSelected}
           onRefresh={refreshDevices}
           onScan={runScan}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/useImportJob.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/useImportJob.ts
@@ -1,0 +1,202 @@
+'use client';
+
+// Disk-import async-job polling hook (#1897).
+//
+// Owns the client side of the background scan/apply jobs: it polls
+// `/api/system/disk-import/status?id=` until a job reaches a terminal phase,
+// surfaces live progress, and re-attaches to a job left in localStorage after a
+// reload / navigate-away (the durable store #1896 makes the job survive a
+// backend restart too). Extracted from DiskImportSection so the card component
+// stays a thin render layer.
+//
+// Lives in the feature `_lib/` with a relative import — a frontend util can't
+// use `@/lib` (that alias resolves to the backend; memory
+// `reference_at_lib_alias_is_backend`).
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Live progress from the status poll. Mirrors the backend SessionProgress. */
+export interface JobProgress {
+  step: 'mount' | 'walk' | 'hash' | 'plan' | 'copy' | 'done';
+  scanned: number;
+  hashed: number;
+  copied: number;
+  bytes: number;
+  total: number;
+}
+
+export interface ScanReviewLike {
+  sessionId: string;
+  device: string;
+  totalFiles: number;
+  totalBytes: number;
+  categories: unknown[];
+  actions: unknown[];
+}
+
+/** The status-route payload the card polls. */
+export interface JobStatus {
+  sessionId: string;
+  device: string;
+  phase: 'scanning' | 'reviewed' | 'applying' | 'applied' | 'error';
+  progress: JobProgress;
+  error?: string;
+  review?: ScanReviewLike;
+  applied?: number;
+}
+
+/** Which background pass we're tracking — routes a terminal status. */
+export type JobKind = 'scanning' | 'applying';
+
+/** localStorage key for the in-flight job id so a reopened/reloaded card
+ *  re-attaches to a running or finished disk-import job. */
+export const ACTIVE_JOB_KEY = 'sb.diskImport.activeJob';
+
+function readActiveJob(): string | null {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage.getItem(ACTIVE_JOB_KEY) : null;
+  } catch {
+    return null;
+  }
+}
+function writeActiveJob(id: string | null): void {
+  try {
+    if (typeof window === 'undefined') return;
+    if (id) window.localStorage.setItem(ACTIVE_JOB_KEY, id);
+    else window.localStorage.removeItem(ACTIVE_JOB_KEY);
+  } catch {
+    /* private mode / disabled storage — non-fatal, just lose re-attach */
+  }
+}
+
+const POLL_INTERVAL_MS = 1500;
+
+/** One status fetch. 404 → the job is gone (pruned/forged); a usable body →
+ *  route it; anything else → swallow (the next tick retries). */
+async function pollOnce(
+  jobId: string,
+  cancelled: { current: boolean },
+  onStatus: (s: JobStatus) => void,
+  onGone: () => void,
+): Promise<void> {
+  try {
+    const res = await fetch(`/api/system/disk-import/status?id=${encodeURIComponent(jobId)}`);
+    if (res.status === 404) {
+      if (!cancelled.current) onGone();
+      return;
+    }
+    const data = (await res.json().catch(() => null)) as JobStatus | null;
+    if (!cancelled.current && data && res.ok) onStatus(data);
+  } catch {
+    /* transient network blip — the next tick retries */
+  }
+}
+
+/** Terminal-transition callbacks the card wires its UI state to. */
+export interface ImportJobHandlers {
+  onReviewed: (review: ScanReviewLike | null) => void;
+  onApplied: (applied: number) => void;
+  onError: (kind: JobKind | null, message: string | undefined, review: ScanReviewLike | null) => void;
+  /** A polled job came back 404 (pruned / unknown id) — drop it. */
+  onGone: () => void;
+}
+
+export interface UseImportJob {
+  /** Live status of the polled job, or null when idle. */
+  status: JobStatus | null;
+  /** True while a background job is being polled. */
+  active: boolean;
+  /** Begin polling a freshly-handed-off job id (from scan/apply). */
+  track: (jobId: string, kind: JobKind) => void;
+  /** Stop polling + clear the persisted id (e.g. on reset). */
+  clear: () => void;
+}
+
+/** Route a polled status to the card's handlers. Returns true if the job is in
+ *  a TERMINAL phase (the caller stops polling); false to keep polling. */
+function routeStatus(s: JobStatus, kind: JobKind | null, h: ImportJobHandlers): boolean {
+  if (s.phase === 'reviewed') {
+    h.onReviewed(s.review ?? null);
+    return kind !== 'applying'; // mid-apply a reviewed re-read isn't terminal
+  }
+  if (s.phase === 'applied') {
+    h.onApplied(s.applied ?? 0);
+    return true;
+  }
+  if (s.phase === 'error') {
+    h.onError(kind, s.error, s.review ?? null);
+    return true;
+  }
+  return false; // scanning / applying
+}
+
+/**
+ * Poll a disk-import job to terminal, routing each terminal phase to the card's
+ * handlers. `pendingKindRef` latches which pass we're tracking so the handler
+ * can route without being a poll-effect dependency (which would tear the
+ * interval down each tick). Re-attaches to a localStorage job on mount.
+ */
+export function useImportJob(handlers: ImportJobHandlers): UseImportJob {
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [status, setStatus] = useState<JobStatus | null>(null);
+  const pendingKindRef = useRef<JobKind | null>(null);
+  // Keep the latest handlers in a ref so the poll effect doesn't re-subscribe
+  // when the card re-renders (handlers are inline closures). Updated in an
+  // effect, not during render (refs are write-only-in-effects under the lint).
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  const stop = useCallback(() => {
+    pendingKindRef.current = null;
+    setJobId(null);
+    writeActiveJob(null);
+  }, []);
+
+  const track = useCallback((id: string, kind: JobKind) => {
+    pendingKindRef.current = kind;
+    writeActiveJob(id);
+    setStatus(null);
+    setJobId(id);
+  }, []);
+
+  const handleStatus = useCallback((s: JobStatus) => {
+    setStatus(s);
+    // On any TERMINAL phase, stop polling and route to the card's handler. A
+    // `reviewed` only finalises a scan (mid-apply we keep polling for the
+    // applied result). scanning/applying: stay polling.
+    if (routeStatus(s, pendingKindRef.current, handlersRef.current)) stop();
+  }, [stop]);
+
+  // One interval per jobId; torn down when the job clears or on unmount.
+  useEffect(() => {
+    if (!jobId) return;
+    const cancelled = { current: false };
+    const tick = () =>
+      pollOnce(jobId, cancelled, handleStatus, () => {
+        stop();
+        handlersRef.current.onGone();
+      });
+    void tick();
+    const timer = setInterval(() => void tick(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled.current = true;
+      clearInterval(timer);
+    };
+  }, [jobId, handleStatus, stop]);
+
+  // Re-attach to a job left in localStorage (reload / navigate back). Deferred
+  // to a microtask so the setState doesn't fire synchronously inside the effect
+  // body (the "cascading renders" lint).
+  useEffect(() => {
+    const saved = readActiveJob();
+    if (!saved) return;
+    queueMicrotask(() => {
+      pendingKindRef.current = null; // unknown until the first status; routes by phase
+      setJobId(saved);
+    });
+  }, []);
+
+  return { status, active: jobId !== null, track, clear: stop };
+}

--- a/packages/frontend/src/app/api/system/disk-import/apply/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/apply/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { applyImportPlan } from '@/lib/diskImport/service';
+import { startApply } from '@/lib/diskImport/service';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { makeExec, resolveNode, SHARE_GID } from '../wiring';
@@ -16,22 +16,26 @@ const Body = z.object({
 });
 
 /**
- * POST — apply a previously-scanned + reviewed plan to the host. The review gate:
- * it requires both the `sessionId` of a plan scanned in this process AND an
- * explicit `confirmed: true`, so no unreviewed plan can ever write. Resumable
- * (catalog-backed). Photos go to Immich, the rest into file-share/data/.
+ * POST — start a background apply of a previously-scanned + reviewed plan and
+ * return the `jobId` IMMEDIATELY (#1897). The copy/chown/upload over a large
+ * plan far exceeds the HTTP timeout, so it runs detached and the card polls
+ * `GET ./status?id=<jobId>` for live copy progress. The review gate is checked
+ * SYNCHRONOUSLY before the job is kicked off: it requires both the `sessionId`
+ * of a reviewed (not-yet-applied) plan AND an explicit `confirmed: true`, so no
+ * unreviewed plan can ever write. Resumable (catalog-backed). Photos go to
+ * Immich, the rest into file-share/data/.
  */
 export const POST = withApiHandler<z.infer<typeof Body>>(
   { body: Body, tokenScope: 'mutate' },
   async ({ body }) => {
     try {
       const node = resolveNode(body.node);
-      const result = await applyImportPlan({
+      const { jobId } = await startApply({
         exec: makeExec(node),
         sessionId: body.sessionId,
         shareGid: SHARE_GID,
       });
-      return NextResponse.json({ ok: true, applied: result.applied, items: result.items });
+      return NextResponse.json({ ok: true, jobId });
     } catch (e) {
       return apiError(e, { tag: 'api:system:disk-import:apply', status: 400, exposeMessage: true });
     }

--- a/packages/frontend/src/app/api/system/disk-import/scan/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/scan/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { scanDevice } from '@/lib/diskImport/service';
+import { startScan } from '@/lib/diskImport/service';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { catalogPath, makeExec, resolveNode } from '../wiring';
@@ -14,23 +14,25 @@ const Body = z.object({
 });
 
 /**
- * POST — mount the device READ-ONLY, walk + classify + dedup it into a plan, and
- * return the review payload (per-category sizing, total, and unavoidable
- * `actions[]`) plus a `sessionId`. Writes NOTHING to the host: this is the review
- * step before the confirm + apply. The `sessionId` is the only thing that
- * authorises a later apply of this exact reviewed plan.
+ * POST — start a background scan of the device (mount RO → walk → classify →
+ * dedup → plan) and return a `jobId` IMMEDIATELY (#1897). The walk + per-file
+ * hashing on a large disk far exceeds the HTTP/proxy timeout, so the work runs
+ * detached and the card polls `GET ./status?id=<jobId>` for live phase + counts
+ * and, once reviewed, the plan. Writes NOTHING to the host: this is the review
+ * step before the confirm + apply. The `jobId` is the only thing that authorises
+ * a later apply of this exact reviewed plan.
  */
 export const POST = withApiHandler<z.infer<typeof Body>>(
   { body: Body, tokenScope: 'mutate' },
   async ({ body }) => {
     try {
       const node = resolveNode(body.node);
-      const result = await scanDevice({
+      const { jobId } = await startScan({
         exec: makeExec(node),
         device: body.device,
         catalogPath: catalogPath(),
       });
-      return NextResponse.json({ ok: true, ...result });
+      return NextResponse.json({ ok: true, jobId });
     } catch (e) {
       return apiError(e, { tag: 'api:system:disk-import:scan', status: 400, exposeMessage: true });
     }

--- a/packages/frontend/src/app/api/system/disk-import/status/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/status/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getImportJob } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({
+  /** The job id returned by `scan` / `apply`. */
+  id: z.string().min(1),
+});
+
+/**
+ * GET — poll a disk-import job by id (#1897). The card hangs off this between
+ * the immediate `scan`/`apply` hand-off and the result:
+ *
+ *   - while `scanning`/`applying`: live phase (`progress.step`) + counts
+ *     (scanned / hashed / copied / bytes) so the card shows real progress, not
+ *     a bare spinner;
+ *   - once `reviewed`: the `review` payload (per-category sizing + non-blocking
+ *     actions[]) — a reopened card re-attaches to the finished scan by id;
+ *   - once `applied`: the final `applied` count;
+ *   - `error`: the failure message.
+ *
+ * Read-only; the session store is durable (#1896) so this survives a backend
+ * restart — a reopened card re-attaches to an in-flight or finished job.
+ * `404` when the id is unknown/forged/pruned.
+ */
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query, tokenScope: 'mutate' },
+  async ({ query }) => {
+    try {
+      const status = await getImportJob(query.id);
+      if (!status) {
+        return NextResponse.json({ ok: false, error: 'unknown job' }, { status: 404 });
+      }
+      return NextResponse.json({ ok: true, ...status });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:status', status: 400, exposeMessage: true });
+    }
+  },
+);


### PR DESCRIPTION
## What
Reworks the disk-import feature (epic #1895) to be async and durable: scan/apply return a job handle immediately and run in the background, a file-based session store survives a backend restart, the card shows live progress (scanned/hashed/copied/bytes) and re-attaches by id, and host-side hashing/copy run in batches instead of one agent round-trip per file. Also fixes the ext4 `lost+found` scan failure.

## Why
Closes #1893
Closes #1896
Closes #1897
Closes #1898

(Epic #1895's children are now all shipped, so #1895 closes too.)

## Risk
Medium -- changes the disk-import scan/apply API to async and adds a user-facing progress card; durable store + batched host work are throughput/behavior-preserving but exercised end-to-end only on a real disk.

## Rollback
git revert is enough (feature is self-contained under diskImport/ + the disk-import card; no schema bump, no migration).

## Verification
- [x] npm run lint (0 errors, 339 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full, 2676 passed / 2 skipped)
- [ ] /verify on FCoS :dev box -- real disk scan->plan->apply with live progress + re-attach