### PR TITLE
fix(diskimport): use shared DATA_DIR from dirs.ts for catalog path

### DIFF
--- a/packages/frontend/src/app/api/system/disk-import/wiring.ts
+++ b/packages/frontend/src/app/api/system/disk-import/wiring.ts
@@ -9,6 +9,7 @@
 
 import { AgentExecutor } from '@/lib/agent/executor';
 import { getNodeIds } from '@/lib/store/repository';
+import { DATA_DIR } from '@/lib/dirs';
 import type { SafeExec } from '@/lib/diskImport/hostExec';
 
 /** Numeric gid that owns file-share data (rootless-podman subgid). */
@@ -16,8 +17,7 @@ export const SHARE_GID = 1024;
 
 /** Persistent import catalog — the resume + cross-disk delta-dedup basis. */
 export function catalogPath(): string {
-  const dataDir = process.env.DATA_DIR ?? '/mnt/data/servicebay';
-  return `${dataDir}/disk-import-catalog.sqlite`;
+  return `${DATA_DIR}/disk-import-catalog.sqlite`;
 }
 
 /** Resolve the node the host commands run on (the first/only node by default). */


### PR DESCRIPTION
## Summary

- `wiring.ts` had its own fallback `'/mnt/data/servicebay'` instead of importing `DATA_DIR` from `@/lib/dirs` (which correctly falls back to `'/app/data'` matching the container's volume mount)
- This caused `ImportCatalog` to throw "Cannot open database because the directory does not exist" on every scan — walk and hash phases succeeded, but the plan step always failed
- Fix: remove the local fallback and use `DATA_DIR` from `'@/lib/dirs'` (same as every other backend file)

Found during box-verify of PR #1902 (disk-import epic #1895: #1893/#1896/#1897/#1898).

## Test plan

- [ ] Scan a device via the disk-import card: session should reach `reviewed` phase (catalog opens at `/app/data/disk-import-catalog.sqlite`)
- [ ] Unit tests: `npx vitest run packages/backend/src/lib/diskImport/` — all pass (128 tests)

🤖 _AI-generated, acting for @mdopp._
<!-- sb-ai-comment -->