### PR TITLE
fix(diskImport): use absolute sourcePath as rsync/immich src

### DIFF
--- a/packages/backend/src/lib/diskImport/plan.test.ts
+++ b/packages/backend/src/lib/diskImport/plan.test.ts
@@ -32,8 +32,11 @@ function sudoFor(calls: string[][], opts: ({ sudo?: boolean } | undefined)[], bi
   return i === -1 ? undefined : opts[i]?.sudo;
 }
 
+// sourcePath is what scanMount's `find %p` emits: an ABSOLUTE path that already
+// includes the mountpoint. Fixtures must reflect that so apply asserts the src is
+// used verbatim (no `<mount>/<mount>/…` doubling, #1906).
 function record(over: Partial<ImportRecord> = {}): ImportRecord {
-  return { sourcePath: '/song.mp3', size: 100, mtimeMs: 0, ext: 'mp3', name: 'song.mp3', ...over };
+  return { sourcePath: `${MOUNT}/song.mp3`, size: 100, mtimeMs: 0, ext: 'mp3', name: 'song.mp3', ...over };
 }
 
 function item(over: Partial<ImportPlanItem> = {}): ImportPlanItem {
@@ -59,6 +62,10 @@ describe('applyPlan — copy + chown', () => {
     const dest = resolveShareTarget('music/song.mp3');
     const rsync = calls.find(c => c[0] === 'rsync')!;
     expect(rsync).toEqual(['rsync', '-a', `${MOUNT}/song.mp3`, dest]);
+    // The rsync src is the record's absolute sourcePath verbatim — NOT the
+    // mountpoint re-prefixed onto it (that doubled `<mount>/<mount>/…`, #1906).
+    expect(rsync[2]).toBe('/run/servicebay/disk-import/sda1/song.mp3');
+    expect(rsync[2].startsWith(`${MOUNT}/${MOUNT}`)).toBe(false);
     // Source is under the read-only mount; dest is under the share root.
     expect(rsync[2].startsWith(MOUNT + '/')).toBe(true);
     expect(rsync[3].startsWith('/mnt/data/stacks/file-share/data/')).toBe(true);
@@ -96,7 +103,7 @@ describe('applyPlan — batched mkdir/chown (#1898)', () => {
     const catalog = new ImportCatalog(':memory:');
     const n = 8;
     const items = Array.from({ length: n }, (_, i) =>
-      item({ record: record({ sourcePath: `/f${i}.mp3`, name: `f${i}.mp3` }), target: `music/f${i}.mp3` }),
+      item({ record: record({ sourcePath: `${MOUNT}/f${i}.mp3`, name: `f${i}.mp3` }), target: `music/f${i}.mp3` }),
     );
     const res = await applyPlan(planOf(...items), baseOpts(exec, catalog, hashConst('a'.repeat(64))));
 
@@ -126,7 +133,7 @@ describe('applyPlan — conflict routes to _superseded', () => {
   it('moves the existing target into _superseded/<date>/ before copying the newer file', async () => {
     const { exec, calls, opts } = mockExec();
     const catalog = new ImportCatalog(':memory:');
-    const conflict = item({ action: 'conflict', target: 'documents/report.pdf', record: record({ sourcePath: '/report.pdf', name: 'report.pdf', ext: 'pdf' }), category: 'documents' });
+    const conflict = item({ action: 'conflict', target: 'documents/report.pdf', record: record({ sourcePath: `${MOUNT}/report.pdf`, name: 'report.pdf', ext: 'pdf' }), category: 'documents' });
 
     const res = await applyPlan(planOf(conflict), baseOpts(exec, catalog, hashConst('b'.repeat(64))));
 
@@ -146,7 +153,7 @@ describe('applyPlan — photos go to Immich, not file-share', () => {
   it('runs the immich CLI and never rsyncs photos into the share', async () => {
     const { exec, calls, opts } = mockExec();
     const catalog = new ImportCatalog(':memory:');
-    const photo = item({ category: 'photos', target: 'photos/IMG_1.jpg', record: record({ sourcePath: '/IMG_1.jpg', name: 'img_1.jpg', ext: 'jpg' }) });
+    const photo = item({ category: 'photos', target: 'photos/IMG_1.jpg', record: record({ sourcePath: `${MOUNT}/IMG_1.jpg`, name: 'img_1.jpg', ext: 'jpg' }) });
 
     const res = await applyPlan(planOf(photo), {
       ...baseOpts(exec, catalog, hashConst('c'.repeat(64))),
@@ -155,6 +162,8 @@ describe('applyPlan — photos go to Immich, not file-share', () => {
 
     const podman = calls.find(c => c[0] === 'podman')!;
     expect(podman).toContain('upload');
+    // The bind-mount source is the absolute sourcePath verbatim — not doubled (#1906).
+    expect(podman).toContain(`${MOUNT}/IMG_1.jpg:/import/IMG_1.jpg:ro`);
     // Immich upload runs through ROOTLESS podman as `core` — must NOT escalate.
     expect(sudoFor(calls, opts, 'podman')).not.toBe(true);
     expect(podman.join(' ')).toContain('IMMICH_INSTANCE_URL=http://immich:2283');
@@ -172,8 +181,8 @@ describe('applyPlan — resumability', () => {
     const catalog = new ImportCatalog(':memory:');
     const hashOf = hashConst('d'.repeat(64));
     const plan = planOf(
-      item({ record: record({ sourcePath: '/a.mp3', name: 'a.mp3' }), target: 'music/a.mp3' }),
-      item({ record: record({ sourcePath: '/b.mp3', name: 'b.mp3' }), target: 'music/b.mp3' }),
+      item({ record: record({ sourcePath: `${MOUNT}/a.mp3`, name: 'a.mp3' }), target: 'music/a.mp3' }),
+      item({ record: record({ sourcePath: `${MOUNT}/b.mp3`, name: 'b.mp3' }), target: 'music/b.mp3' }),
     );
 
     // First pass: rsync of b.mp3 "fails" (interruption) after a.mp3 is done.
@@ -196,8 +205,8 @@ describe('applyPlan — resumability', () => {
 
     const rsyncs = exec2.calls.filter(c => c[0] === 'rsync').map(c => c[2]);
     expect(rsyncs).toEqual([`${MOUNT}/b.mp3`]); // a.mp3 NOT re-copied
-    expect(res.items.find(i => i.sourcePath === '/a.mp3')?.outcome).toBe('skipped-cataloged');
-    expect(res.items.find(i => i.sourcePath === '/b.mp3')?.outcome).toBe('copied');
+    expect(res.items.find(i => i.sourcePath === `${MOUNT}/a.mp3`)?.outcome).toBe('skipped-cataloged');
+    expect(res.items.find(i => i.sourcePath === `${MOUNT}/b.mp3`)?.outcome).toBe('copied');
     expect(catalog.has('d'.repeat(64), 'music/b.mp3')).toBe(true);
     catalog.close();
   });
@@ -220,7 +229,7 @@ describe('applyPlan — dry run + skips', () => {
     const res = await applyPlan(
       planOf(
         item({ action: 'skip-junk', target: null }),
-        item({ action: 'skip-dupe', record: record({ sourcePath: '/dup.mp3', name: 'dup.mp3' }), target: 'music/dup.mp3' }),
+        item({ action: 'skip-dupe', record: record({ sourcePath: `${MOUNT}/dup.mp3`, name: 'dup.mp3' }), target: 'music/dup.mp3' }),
       ),
       baseOpts(exec, catalog, hashConst('f'.repeat(64))),
     );
@@ -234,7 +243,7 @@ describe('applyPlan — path traversal is refused', () => {
   it('a malicious category/filename target cannot escape the share root', async () => {
     const { exec, calls } = mockExec();
     const catalog = new ImportCatalog(':memory:');
-    const evil = item({ target: '../../../../etc/cron.d/payload', record: record({ sourcePath: '/x', name: 'x' }) });
+    const evil = item({ target: '../../../../etc/cron.d/payload', record: record({ sourcePath: `${MOUNT}/x`, name: 'x' }) });
     await expect(applyPlan(planOf(evil), baseOpts(exec, catalog, hashConst('0'.repeat(64))))).rejects.toThrow(/traversal/);
     // Nothing was written to the host.
     expect(calls.some(c => c[0] === 'rsync' || c[0] === 'mv' || c[0] === 'chown')).toBe(false);

--- a/packages/backend/src/lib/diskImport/plan.ts
+++ b/packages/backend/src/lib/diskImport/plan.ts
@@ -121,9 +121,9 @@ function assertShareGid(gid: number): void {
  * can simply be re-run.
  */
 export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<ApplyResult> {
-  const { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun = false, now = Date.now, onProgress } = opts;
+  const { exec, catalog, shareGid, hashOf, immich, dryRun = false, now = Date.now, onProgress } = opts;
   assertShareGid(shareGid);
-  const ctx: ItemCtx = { exec, mountpoint, catalog, shareGid, hashOf, immich, dryRun, now };
+  const ctx: ItemCtx = { exec, catalog, shareGid, hashOf, immich, dryRun, now };
 
   const results: ApplyResultItem[] = [];
   // Items that need a host copy (`copied`/`superseded`) are queued and flushed in
@@ -159,7 +159,6 @@ export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<A
 
 interface ItemCtx {
   exec: SafeExec;
-  mountpoint: string;
   catalog: ImportCatalog;
   shareGid: number;
   hashOf: HashResolver;
@@ -220,7 +219,10 @@ async function classifyItem(
 
   // Validate the destination stays under file-share/data/ BEFORE any host I/O.
   const dest = resolveShareTarget(target);
-  const src = `${ctx.mountpoint}/${stripLeadingSlash(item.record.sourcePath)}`;
+  // `sourcePath` is already absolute incl. the mountpoint (scanMount's `find %p`),
+  // and is the verbatim key fed to the host hasher + stored in the catalog — use
+  // it directly so rsync reads the real file (no `<mount>/<mount>/…` doubling).
+  const src = item.record.sourcePath;
 
   let outcome: 'copied' | 'superseded' = 'copied';
   if (item.action === 'conflict') {
@@ -310,7 +312,8 @@ async function uploadPhoto(record: ImportRecord, ctx: ItemCtx): Promise<void> {
     throw new Error('disk-import: photo in plan but no immich config provided');
   }
   const { serverUrl, apiKey, image = DEFAULT_IMMICH_IMAGE } = ctx.immich;
-  const src = `${ctx.mountpoint}/${stripLeadingSlash(record.sourcePath)}`;
+  // Already-absolute source path (see classifyItem) — no mountpoint re-prefixing.
+  const src = record.sourcePath;
   // Mount the source file read-only into the CLI container; pass the API key
   // via env (-e), never on the argv (so it can't leak into a process listing).
   await runOk(


### PR DESCRIPTION
## What
Disk-import apply built the rsync/immich source path as `${mountpoint}/${stripLeadingSlash(sourcePath)}`, but `record.sourcePath` (from scanMount's `find %p`) is already absolute including the mountpoint — producing `<mp>/<mp>/...` doubling. Now uses `item.record.sourcePath` directly as `src` in both `classifyItem` and `uploadPhoto`. `sourcePath` is left untouched as the hash key / catalog correlation key (Option 2, not stripping in scanMount).

## Why
Closes #1906

## Risk
Low — single-file source fix plus test fixture updates; the apply path was already broken on real disks (no doubling means files actually land in the canonical folders).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2676 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (disk-import APPLY path — real-disk-observable)

<!-- sb-ai-comment -->
AI-generated