### PR TITLE
fix(immich): disable SELinux relabel on photo-areas hostPath mount

### DIFF
--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -21,6 +21,22 @@ metadata:
       interval: 30s
       timeout: 5s
       startup_timeout: 5m
+    # Disable SELinux relabelling on immich-server's bind mounts. The
+    # `photo-areas` hostPath points at /mnt/data/stacks/file-share/data —
+    # a SHARED, multi-writer tree already consumed by samba, syncthing,
+    # filebrowser, and disk-import. The default `kube play` recursive
+    # relabel walks that whole tree calling `lsetxattr` on every entry.
+    # Files written by other consumers (e.g. `sudo`-owned disk-import
+    # entries) can't be relabelled by the rootless `core` user →
+    # "operation not permitted" → exit 125 crash-loop on every start
+    # (observed on box verify of #1918, audiobooks/book01.m4b blocked it).
+    # The shared tree already carries `container_file_t` from its other
+    # long-lived consumers, so Immich's read-only mount needs no relabel.
+    # Same per-container disable pattern as media/jellyfin (#1731) and
+    # file-share/samba/syncthing/filebrowser. (cf.
+    # feedback_hermes_config_bak_selinux: a root-owned stray in a shared
+    # tree is a relabel footgun.)
+    io.podman.annotations.label/immich-server: "disable"
 spec:
   # #817: Immich runs in its own network namespace (no hostNetwork).
   #   - Only `immich-server` is published to the host, via `hostPort`


### PR DESCRIPTION
## Summary

- **Bug**: Immich crash-loops (exit 125) after the v3 schema upgrade that added the `photo-areas` hostPath mount (`/mnt/data/stacks/file-share/data`). On FCoS + rootless podman, `kube play` attempts a recursive `lsetxattr` on the shared file-share tree before the pod starts. Files written by other consumers (e.g. sudo-owned disk-import entries — confirmed with `audiobooks/book01.m4b` on box) can't be relabelled by the rootless `core` user → "operation not permitted" → crash-loop.
- **Fix**: Add `io.podman.annotations.label/immich-server: "disable"` to skip the relabel for immich-server. Same pattern already used by media/jellyfin (#1731) and file-share/samba/syncthing/filebrowser for the same reason.
- **Caught by**: `:dev` box-verify of PR #1918 (batch/2026-06-17d).

## Test plan

- [ ] `npm test` passes (2764 tests, confirmed locally)
- [ ] `:dev` box-verify: `sb stacks install --stacks cloud --yes` with immich included — immich must start without the SELinux relabel crash
- [ ] Immich `/api/server/ping` returns `{"res":"pong"}` post-install

🤖 _AI-generated, acting for @mdopp._
<!-- sb-ai-comment -->