### PR TITLE
fix(immich): pod-level SELinux disable for photo-areas volume relabelling

### DIFF
--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -21,22 +21,31 @@ metadata:
       interval: 30s
       timeout: 5s
       startup_timeout: 5m
-    # Disable SELinux relabelling on immich-server's bind mounts. The
-    # `photo-areas` hostPath points at /mnt/data/stacks/file-share/data —
-    # a SHARED, multi-writer tree already consumed by samba, syncthing,
-    # filebrowser, and disk-import. The default `kube play` recursive
-    # relabel walks that whole tree calling `lsetxattr` on every entry.
-    # Files written by other consumers (e.g. `sudo`-owned disk-import
-    # entries) can't be relabelled by the rootless `core` user →
-    # "operation not permitted" → exit 125 crash-loop on every start
-    # (observed on box verify of #1918, audiobooks/book01.m4b blocked it).
+    # Disable SELinux relabelling at the POD level. The `photo-areas`
+    # hostPath points at /mnt/data/stacks/file-share/data — a SHARED,
+    # multi-writer tree already consumed by samba, syncthing, filebrowser,
+    # and disk-import. The default `kube play` recursive relabel walks
+    # that whole tree calling `lsetxattr` on every entry BEFORE any
+    # container starts. Files written by other consumers as root (e.g.
+    # sudo-owned disk-import entries) can't be relabelled by the rootless
+    # `core` user → "operation not permitted" → exit 125 crash-loop on
+    # every start (audiobooks/book01.m4b, confirmed on box verify).
+    #
+    # The per-container annotation (io.podman.annotations.label/<name>)
+    # only disables SELinux for that container's process namespace. The
+    # VOLUME relabelling in `kube play` happens at pod-create time, driven
+    # by the pod's overall security context — it fires even if only one
+    # container mounts the volume and that container has the annotation.
+    # Immich is a multi-container pod (server + machine-learning + redis +
+    # database): the per-container approach used in the initial fix
+    # (PR #1923) left the volume relabelling active. The pod-level form
+    # (no container-name suffix) suppresses it entirely.
+    #
     # The shared tree already carries `container_file_t` from its other
-    # long-lived consumers, so Immich's read-only mount needs no relabel.
-    # Same per-container disable pattern as media/jellyfin (#1731) and
-    # file-share/samba/syncthing/filebrowser. (cf.
-    # feedback_hermes_config_bak_selinux: a root-owned stray in a shared
-    # tree is a relabel footgun.)
-    io.podman.annotations.label/immich-server: "disable"
+    # long-lived consumers, so Immich's read-only photo-areas mount needs
+    # no relabel. (cf. feedback_hermes_config_bak_selinux: a root-owned
+    # stray in a shared tree is a relabel footgun.)
+    io.podman.annotations.label: "disable"
 spec:
   # #817: Immich runs in its own network namespace (no hostNetwork).
   #   - Only `immich-server` is published to the host, via `hostPort`


### PR DESCRIPTION
## Summary

PR #1923 applied `io.podman.annotations.label/immich-server: "disable"` (per-container annotation) to fix the SELinux relabelling crash-loop on the `photo-areas` hostPath. The `:dev` box-verify of efd92a8 found this still red — same exit-125 crash-loop on `audiobooks/book01.m4b` (owned `root:1024`, written by disk-import running as sudo).

**Root cause of the mis-fix:** In a multi-container pod (`immich-server` + `immich-machine-learning` + `redis` + `database`), `kube play` triggers a recursive `lsetxattr` on the `photo-areas` hostPath at **pod-create time**, driven by the pod's overall security context — before any container starts and before per-container annotations apply. The per-container form only disables SELinux for that container's process namespace, not the volume relabelling step.

**Fix:** Switch to the pod-level annotation (no container-name suffix): `io.podman.annotations.label: "disable"`. This suppresses the volume relabelling entirely at pod create time.

Single-container pods like `media` (just `jellyfin`) work with the per-container form because the pod security context is derived from that single container. Immich's four containers required the pod-level form.

## Test plan

- [ ] CI green on this branch
- [ ] `:dev` box-verify: `sb stacks install --stacks cloud --yes` completes with immich-server starting clean (no exit-125), pod-level annotation confirmed in deployed `immich.yml`

🤖 _AI-generated, acting for @mdopp._
<!-- sb-ai-comment -->