### PR TITLE
feat(eslint+registry): React-Compiler rule adoption + persistent local template source

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -248,32 +248,30 @@ const eslintConfig = defineConfig([
       // — any new violation fails CI both via the rule and via
       // scripts/check-invariants.ts.
       "sb/no-fe-backend-import": "error",
-      // --- React-hooks rule contract (pin to the pre-ESLint-10 baseline).
-      // The ESLint 10 migration required bumping eslint-plugin-react-hooks
-      // 7.0.1 -> 7.1.1 (7.0.1 peers ESLint <=9 only). 7.1.1 expanded its
-      // `recommended` preset — which eslint-config-next spreads in — from
-      // {rules-of-hooks, exhaustive-deps} to the full React-Compiler rule
-      // suite (static-components, use-memo, immutability, refs,
-      // set-state-in-effect, purity, …), all at "error". Those 14 rules were
-      // never part of this repo's lint gate; enabling them is a separate,
-      // behaviour-touching adoption effort (tracked in #1910), not part of a
-      // tooling migration. Turn them off here to keep the migration
-      // lint-neutral — rules-of-hooks (error) + exhaustive-deps (warn) stay as
-      // before via the preset.
-      "react-hooks/static-components": "off",
-      "react-hooks/use-memo": "off",
-      "react-hooks/preserve-manual-memoization": "off",
-      "react-hooks/incompatible-library": "off",
-      "react-hooks/immutability": "off",
-      "react-hooks/globals": "off",
-      "react-hooks/refs": "off",
+      // --- React-Compiler rule adoption (#1910 / #1921).
+      // The ESLint 10 migration bumped eslint-plugin-react-hooks
+      // 7.0.1 -> 7.1.1, whose expanded `recommended` preset (spread in by
+      // eslint-config-next) added the React-Compiler rule suite. These 13
+      // low-touch rules are adopted at "error" (#1921) — most are already
+      // "error" in the preset, but incompatible-library and
+      // unsupported-syntax ship as "warn" there, so pin every rule
+      // explicitly to keep the gate deterministic.
+      "react-hooks/static-components": "error",
+      "react-hooks/use-memo": "error",
+      "react-hooks/preserve-manual-memoization": "error",
+      "react-hooks/incompatible-library": "error",
+      "react-hooks/immutability": "error",
+      "react-hooks/globals": "error",
+      "react-hooks/refs": "error",
+      "react-hooks/error-boundaries": "error",
+      "react-hooks/purity": "error",
+      "react-hooks/set-state-in-render": "error",
+      "react-hooks/unsupported-syntax": "error",
+      "react-hooks/config": "error",
+      "react-hooks/gating": "error",
+      // `set-state-in-effect` is adopted separately (#1922); keep it OFF
+      // until that lands so the gate stays clean.
       "react-hooks/set-state-in-effect": "off",
-      "react-hooks/error-boundaries": "off",
-      "react-hooks/purity": "off",
-      "react-hooks/set-state-in-render": "off",
-      "react-hooks/unsupported-syntax": "off",
-      "react-hooks/config": "off",
-      "react-hooks/gating": "off",
       // Maintainability thresholds (#724). Several core modules
       // currently exceed these — flagging them as warn (not error) so
       // CI doesn't break on legacy files while the rule still surfaces

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -269,9 +269,12 @@ const eslintConfig = defineConfig([
       "react-hooks/unsupported-syntax": "error",
       "react-hooks/config": "error",
       "react-hooks/gating": "error",
-      // `set-state-in-effect` is adopted separately (#1922); keep it OFF
-      // until that lands so the gate stays clean.
-      "react-hooks/set-state-in-effect": "off",
+      // `set-state-in-effect` adopted (#1922): redundant useEffect+setState
+      // pairs were removed (derive during render). The remaining unavoidable
+      // cases — async fetch-on-mount / poll loaders and controlled
+      // URL/prop→state syncs — each carry a per-line disable directive with
+      // a written rationale at the call site.
+      "react-hooks/set-state-in-effect": "error",
       // Maintainability thresholds (#724). Several core modules
       // currently exceed these — flagging them as warn (not error) so
       // CI doesn't break on legacy files while the rule still surfaces

--- a/packages/backend/src/lib/registry.local.test.ts
+++ b/packages/backend/src/lib/registry.local.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Persistent local (non-git) template/stack source (#1919).
+ *
+ * `LOCAL_TEMPLATES_DIR` lives under the persisted data mount
+ * (`DATA_DIR/local-templates/{templates,stacks}`). A template dropped
+ * there must:
+ *   - appear in getTemplates() (source = 'Local'),
+ *   - be readable through the per-name resolvers,
+ *   - override a built-in / registry entry of the same name,
+ *   - and a malformed entry must be skipped without crashing enumeration.
+ *
+ * `DATA_DIR` is read at module load from `process.env.DATA_DIR`, so the
+ * hoisted block points it at a temp root before `registry.ts` evaluates
+ * its top-level constants.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+
+const ROOTS = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _os = require('os') as typeof import('os');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _path = require('path') as typeof import('path');
+  const dataRoot = _path.join(_os.tmpdir(), `sb-registry-local-data-${process.pid}`);
+  const cfgRoot = _path.join(_os.tmpdir(), `sb-registry-local-cfg-${process.pid}`);
+  process.env.DATA_DIR = dataRoot;
+  process.env.CONTAINER_CONFIG_DIR = cfgRoot;
+  return { dataRoot, cfgRoot };
+});
+
+// No external registries — isolate the local source from registry sync.
+const mockConfigState = { registries: { enabled: true, items: [] as Array<{ name: string; url: string }> } };
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => mockConfigState),
+}));
+
+import {
+  getTemplates,
+  getReadme,
+  getTemplateYaml,
+  getTemplateVariables,
+  getStackManifest,
+} from './registry';
+
+const LOCAL_DIR = path.join(ROOTS.dataRoot, 'local-templates');
+const LOCAL_TEMPLATES = path.join(LOCAL_DIR, 'templates');
+
+function tmplYaml(name: string, label = name): string {
+  return [
+    'apiVersion: v1',
+    'kind: Pod',
+    'metadata:',
+    `  name: ${name}`,
+    '  annotations:',
+    `    servicebay.label: "${label}"`,
+    '    servicebay.ports: "8080/tcp"',
+    '    servicebay.schema-version: "1"',
+    '',
+  ].join('\n');
+}
+
+async function seedLocal(layout: Record<string, string>): Promise<void> {
+  for (const [relPath, content] of Object.entries(layout)) {
+    const full = path.join(LOCAL_DIR, relPath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+}
+
+beforeEach(async () => {
+  await fs.rm(LOCAL_DIR, { recursive: true, force: true });
+  mockConfigState.registries.items = [];
+});
+
+afterAll(async () => {
+  await fs.rm(ROOTS.dataRoot, { recursive: true, force: true });
+  await fs.rm(ROOTS.cfgRoot, { recursive: true, force: true });
+});
+
+describe('local persistent source (#1919)', () => {
+  it('exposes a file-dropped local template in getTemplates() with source=Local', async () => {
+    await seedLocal({
+      'templates/widget/template.yml': tmplYaml('widget'),
+      'templates/widget/README.md': 'widget readme',
+      'templates/widget/variables.json': JSON.stringify({ FOO: { type: 'text', default: 'bar' } }),
+    });
+
+    const templates = await getTemplates();
+    const widget = templates.find(t => t.name === 'widget' && t.type === 'template');
+    expect(widget).toBeDefined();
+    expect(widget!.source).toBe('Local');
+    expect(widget!.path).toBe(path.join(LOCAL_TEMPLATES, 'widget'));
+
+    // Per-name resolvers find it with no pinned source.
+    expect(await getTemplateYaml('widget')).toContain('name: widget');
+    expect(await getReadme('widget', 'template')).toBe('widget readme');
+    const vars = await getTemplateVariables('widget');
+    expect(vars?.FOO?.default).toBe('bar');
+  });
+
+  it('finds a local stack via getStackManifest + getTemplates', async () => {
+    await seedLocal({
+      'stacks/mystack/stack.yml': 'apiVersion: v1\nkind: Stack\nmetadata:\n  name: mystack\n  annotations:\n    servicebay.label: "My Stack"\nspec:\n  templates: [widget]\n',
+    });
+
+    const templates = await getTemplates();
+    const stack = templates.find(t => t.name === 'mystack' && t.type === 'stack');
+    expect(stack).toBeDefined();
+    expect(stack!.source).toBe('Local');
+
+    const manifest = await getStackManifest('mystack');
+    expect(manifest).not.toBeNull();
+  });
+
+  it('local override wins over built-in by name', async () => {
+    // `vaultwarden` is a built-in template; a local one shadows it.
+    await seedLocal({
+      'templates/vaultwarden/template.yml': tmplYaml('vaultwarden', 'Local Vaultwarden'),
+    });
+
+    const templates = await getTemplates();
+    const vaultwarden = templates.filter(t => t.name === 'vaultwarden' && t.type === 'template');
+    // Exactly one entry, and it is the local override.
+    expect(vaultwarden).toHaveLength(1);
+    expect(vaultwarden[0].source).toBe('Local');
+
+    // The per-name resolver also returns the local copy.
+    const yaml = await getTemplateYaml('vaultwarden');
+    expect(yaml).toContain('Local Vaultwarden');
+  });
+
+  it('skips a malformed local entry with a warning, without crashing enumeration', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await seedLocal({
+      // A good entry…
+      'templates/good/template.yml': tmplYaml('good'),
+      // …and a malformed one (template.yml is not parseable YAML). The
+      // catalog must still enumerate `good` rather than throwing.
+      'templates/broken/template.yml': ':\n  this is not: [valid: yaml',
+    });
+
+    const templates = await getTemplates();
+    const good = templates.find(t => t.name === 'good' && t.source === 'Local');
+    // `good` survives; `broken` is enumerated with default meta (its
+    // malformed manifest only degrades its tier/deps, never the catalog).
+    expect(good).toBeDefined();
+    const broken = templates.find(t => t.name === 'broken' && t.source === 'Local');
+    expect(broken).toBeDefined();
+    expect(broken!.tier).toBe('feature'); // readTemplateMeta default on parse failure
+    warn.mockRestore();
+  });
+
+  it('returns no local items when the local dir is absent', async () => {
+    // Nothing seeded — getTemplates must not throw and built-ins remain.
+    const templates = await getTemplates();
+    const local = templates.filter(t => t.source === 'Local');
+    expect(local).toHaveLength(0);
+    // Built-ins still present.
+    expect(templates.length).toBeGreaterThan(0);
+  });
+
+  it('rejects path-traversal in a request-supplied name (no read outside local root)', async () => {
+    // Plant a sensitive file one level above the local-templates root.
+    const secretPath = path.join(ROOTS.dataRoot, 'secret.txt');
+    await fs.writeFile(secretPath, 'TOP SECRET');
+
+    // A traversal `name` that would resolve to ../secret.txt must NOT read it.
+    // localItemPath fails closed to a nonexistent sentinel, so every resolver
+    // returns null/empty rather than the file outside the source.
+    for (const evil of ['../secret', '../../secret', '..', '.', 'a/b', 'a\\b']) {
+      expect(await getTemplateYaml(evil, 'Local')).toBeNull();
+      expect(await getReadme(evil, 'template', 'Local')).toBeNull();
+      expect(await getTemplateVariables(evil, 'Local')).toBeNull();
+    }
+
+    // And the unpinned (source-undefined) path is equally guarded.
+    expect(await getReadme('../secret', 'template')).not.toBe('TOP SECRET');
+  });
+});

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { exec, execFile } from 'node:child_process';
 import { promisify } from 'util';
 import { getConfig, RegistryConfig } from './config';
+import { DATA_DIR } from './dirs';
 import { readManifestAnnotations } from './template/contract';
 import { parseStackManifest, type StackManifest } from './template/stackContract';
 import { logger } from './logger';
@@ -26,6 +27,29 @@ const REGISTRIES_DIR = path.join(
   process.env.CONTAINER_CONFIG_DIR || CONTAINER_CONFIG_DIR,
   'registries'
 );
+
+/**
+ * Persistent, writable, **non-git** local template/stack source (#1919).
+ *
+ * Unlike `REGISTRIES_DIR` (under the ephemeral config dir) this lives on
+ * the persisted data mount (`DATA_DIR` = `/app/data`, mapped to
+ * `/mnt/data/servicebay` on the box), so a template dropped here survives
+ * a container restart and a reinstall. It is the install target for the
+ * `repo-to-template` skill (and file-drop by hand): no repo change and no
+ * git registry needed.
+ *
+ * Layout mirrors the built-in tree exactly:
+ *   local-templates/templates/<name>/{template.yml,variables.json,…}
+ *   local-templates/stacks/<name>/stack.yml
+ *
+ * Precedence is the **highest** of all sources — local > registry >
+ * built-in — so a local `vaultwarden` shadows both a registry copy and
+ * the bundled one. A malformed local entry is skipped with a warning
+ * (same as a bad registry entry) and never crashes catalog enumeration.
+ */
+const LOCAL_TEMPLATES_DIR = path.join(DATA_DIR, 'local-templates');
+const LOCAL_TEMPLATES_PATH = path.join(LOCAL_TEMPLATES_DIR, 'templates');
+const LOCAL_STACKS_PATH = path.join(LOCAL_TEMPLATES_DIR, 'stacks');
 
 // Default registry: the ServiceBay repo itself (public, no auth needed)
 const DEFAULT_REGISTRY: RegistryConfig = {
@@ -122,6 +146,39 @@ async function resolveRegistryItemPath(
   // Legacy fallback — also the path for manifest-less registries.
   const subdir = type === 'template' ? 'templates' : 'stacks';
   return path.join(REGISTRIES_DIR, regName, subdir, itemName);
+}
+
+/**
+ * The on-disk directory for a `Local`-source template or stack (#1919).
+ * Mirrors the built-in layout under the persisted data mount. Returns
+ * the path even when the dir doesn't exist — callers' fs failure paths
+ * handle "not found" the same way they do for built-in/registry items.
+ *
+ * `name` is request-supplied, so it is constrained to a single safe path
+ * segment (no separators, no `.`/`..`, no NUL) and the joined result is
+ * asserted to stay under its root. An unsafe `name` resolves to a
+ * guaranteed-nonexistent sentinel so every caller's fs path fails closed
+ * to "not found" rather than reading outside the local source
+ * (path-injection guard; CodeQL js/path-injection).
+ */
+function localItemPath(type: 'template' | 'stack', name: string): string {
+  const root = type === 'stack' ? LOCAL_STACKS_PATH : LOCAL_TEMPLATES_PATH;
+  // `name` is request-supplied. Collapse it to a single path component with
+  // path.basename (the recognised path-injection barrier) and reject if that
+  // changed the value or yielded a traversal/empty segment — only a plain,
+  // self-contained directory name is ever joined onto the local root, so the
+  // result can never escape it.
+  const segment = path.basename(name);
+  if (
+    !segment ||
+    segment !== name ||
+    segment === '.' ||
+    segment === '..' ||
+    segment.includes('\0')
+  ) {
+    return path.join(root, '\0nonexistent');
+  }
+  return path.join(root, segment);
 }
 
 export interface Template {
@@ -474,6 +531,24 @@ export async function getTemplates(): Promise<Template[]> {
         }
     }
 
+    // 3. Local persistent source (#1919) — overrides BOTH built-in and
+    // registry by name, so a user-generated/file-dropped template wins.
+    // `fetchDir` returns [] for a missing dir and skips a malformed entry
+    // with a warning, so an empty or partly-broken local-templates dir
+    // never crashes enumeration.
+    const [localStacks, localTemplates] = await Promise.all([
+        fetchDir(LOCAL_STACKS_PATH, 'stack', 'Local'),
+        fetchDir(LOCAL_TEMPLATES_PATH, 'template', 'Local'),
+    ]);
+    for (const item of [...localStacks, ...localTemplates]) {
+        const idx = allTemplates.findIndex(t => t.name === item.name && t.type === item.type);
+        if (idx !== -1) {
+            allTemplates[idx] = item;
+        } else {
+            allTemplates.push(item);
+        }
+    }
+
     return allTemplates;
 }
 
@@ -519,6 +594,15 @@ async function fetchManifestEntries(
 }
 
 export async function getReadme(name: string, type: 'template' | 'stack', source?: string): Promise<string | null> {
+  // Local pinned source (#1919) — read straight from the data mount.
+  if (source === 'Local') {
+    try {
+      return await fs.readFile(path.join(localItemPath(type, name), 'README.md'), 'utf-8');
+    } catch {
+      return null;
+    }
+  }
+
   // If a specific source is given, use it directly
   if (source && source !== 'Built-in') {
     try {
@@ -529,8 +613,12 @@ export async function getReadme(name: string, type: 'template' | 'stack', source
     }
   }
 
-  // Otherwise: check registries first, then fall back to built-in
+  // Otherwise: local persistent source first (#1919), then registries,
+  // then fall back to built-in.
   if (!source) {
+    try {
+      return await fs.readFile(path.join(localItemPath(type, name), 'README.md'), 'utf-8');
+    } catch { /* not in the local source */ }
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -552,6 +640,15 @@ export async function getReadme(name: string, type: 'template' | 'stack', source
 }
 
 export async function getTemplateYaml(name: string, source?: string): Promise<string | null> {
+  // Local pinned source (#1919) — read straight from the data mount.
+  if (source === 'Local') {
+    try {
+      return await fs.readFile(path.join(localItemPath('template', name), 'template.yml'), 'utf-8');
+    } catch {
+      return null;
+    }
+  }
+
   // If a specific source is given, use it directly
   if (source && source !== 'Built-in') {
     try {
@@ -562,8 +659,12 @@ export async function getTemplateYaml(name: string, source?: string): Promise<st
     }
   }
 
-  // Otherwise: check registries first (freshest), then fall back to built-in
+  // Otherwise: local persistent source first (#1919, freshest/user-owned),
+  // then registries, then fall back to built-in.
   if (!source) {
+    try {
+      return await fs.readFile(path.join(localItemPath('template', name), 'template.yml'), 'utf-8');
+    } catch { /* not in the local source */ }
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -732,12 +833,18 @@ export async function getTemplateVariables(name: string, source?: string): Promi
     } catch { return null; }
   };
 
+  if (source === 'Local') {
+    return tryRead(path.join(localItemPath('template', name), 'variables.json'));
+  }
+
   if (source && source !== 'Built-in') {
     const itemDir = await resolveRegistryItemPath(source, 'template', name);
     return tryRead(path.join(itemDir, 'variables.json'));
   }
 
   if (!source) {
+    const local = await tryRead(path.join(localItemPath('template', name), 'variables.json'));
+    if (local) return local;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -783,11 +890,17 @@ export async function getTemplateConfigFiles(name: string, source?: string): Pro
     } catch { return []; }
   };
 
+  if (source === 'Local') {
+    return scanDir(localItemPath('template', name));
+  }
+
   if (source && source !== 'Built-in') {
     return scanDir(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
+    const localFiles = await scanDir(localItemPath('template', name));
+    if (localFiles.length > 0) return localFiles;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -868,11 +981,17 @@ export async function getTemplateAssetFiles(
   const walk = (templateDir: string) =>
     walkSkillsDir(path.join(templateDir, 'skills'), name);
 
+  if (source === 'Local') {
+    return walk(localItemPath('template', name));
+  }
+
   if (source && source !== 'Built-in') {
     return walk(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
+    const localFiles = await walk(localItemPath('template', name));
+    if (localFiles.length > 0) return localFiles;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -909,11 +1028,17 @@ export async function getTemplatePostDeployScript(name: string, source?: string)
     } catch { return null; }
   };
 
+  if (source === 'Local') {
+    return tryRead(localItemPath('template', name));
+  }
+
   if (source && source !== 'Built-in') {
     return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
+    const local = await tryRead(localItemPath('template', name));
+    if (local !== null) return local;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -942,11 +1067,17 @@ export async function getTemplateUserGuide(name: string, source?: string): Promi
     } catch { return null; }
   };
 
+  if (source === 'Local') {
+    return tryRead(localItemPath('template', name));
+  }
+
   if (source && source !== 'Built-in') {
     return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
+    const local = await tryRead(localItemPath('template', name));
+    if (local !== null) return local;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -970,11 +1101,17 @@ export async function getTemplateChangelog(name: string, source?: string): Promi
     } catch { return null; }
   };
 
+  if (source === 'Local') {
+    return tryRead(localItemPath('template', name));
+  }
+
   if (source && source !== 'Built-in') {
     return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
+    const local = await tryRead(localItemPath('template', name));
+    if (local !== null) return local;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -1054,11 +1191,17 @@ export async function getTemplateMigrationScripts(
     return out;
   };
 
+  if (source === 'Local') {
+    return scanDir(localItemPath('template', name));
+  }
+
   if (source && source !== 'Built-in') {
     return scanDir(await resolveRegistryItemPath(source, 'template', name));
   }
 
   if (!source) {
+    const local = await scanDir(localItemPath('template', name));
+    if (local.length > 0) return local;
     const config = await getConfig();
     const registries = getRegistries(config);
     for (const reg of registries) {
@@ -1094,15 +1237,21 @@ export async function getStackManifest(
   };
 
   let yamlText: string | null = null;
-  if (source && source !== 'Built-in') {
+  if (source === 'Local') {
+    yamlText = await tryRead(localItemPath('stack', name));
+  } else if (source && source !== 'Built-in') {
     yamlText = await tryRead(await resolveRegistryItemPath(source, 'stack', name));
   } else {
     if (!source) {
-      const config = await getConfig();
-      const registries = getRegistries(config);
-      for (const reg of registries) {
-        const found = await tryRead(await resolveRegistryItemPath(reg.name, 'stack', name));
-        if (found !== null) { yamlText = found; break; }
+      // Local persistent source first (#1919), then registries.
+      yamlText = await tryRead(localItemPath('stack', name));
+      if (yamlText === null) {
+        const config = await getConfig();
+        const registries = getRegistries(config);
+        for (const reg of registries) {
+          const found = await tryRead(await resolveRegistryItemPath(reg.name, 'stack', name));
+          if (found !== null) { yamlText = found; break; }
+        }
       }
     }
     if (yamlText === null) yamlText = await tryRead(path.join(STACKS_PATH, name));

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/SettingsContext.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/SettingsContext.tsx
@@ -306,7 +306,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [addToast, refreshNodes]);
 
+  // Load persisted settings from the API once on mount. Async fetch that
+  // synchronises React state with an external system (the config file) —
+  // the canonical effect use.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async config load on mount, not a cascading-render anti-pattern
     void refreshConfig();
   }, [refreshConfig]);
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
@@ -67,6 +67,7 @@ export default function FileShareSection() {
   }, [addToast]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async Samba-user load on mount
     void loadUsers();
   }, [loadUsers]);
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -258,6 +258,7 @@ export default function McpSection() {
 
   useEffect(() => {
     // Read window.location after mount to avoid SSR/hydration mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async settings fetch, guarded by a cancelled flag
     setMcpUrl(`${window.location.origin}/mcp`);
   }, []);
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PublicDomainSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PublicDomainSection.tsx
@@ -86,6 +86,9 @@ export default function PublicDomainSection() {
   // Track the polling timer so we can stop it cleanly when the phase
   // moves off `preflight` (operator cancelled, migration started, etc.).
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Holds the latest fetchPreflight so the self-scheduling setTimeout can
+  // recurse without referencing the callback before it is declared.
+  const fetchPreflightRef = useRef<(domain: string) => void>(() => undefined);
 
   useEffect(() => {
     fetch('/api/system/mode')
@@ -135,9 +138,13 @@ export default function PublicDomainSection() {
     // Schedule next tick. The phase check inside the closure guards
     // against firing after the operator backs out.
     pollRef.current = setTimeout(() => {
-      void fetchPreflight(domain);
+      fetchPreflightRef.current(domain);
     }, PREFLIGHT_POLL_MS);
   }, [addToast, stopPolling]);
+
+  useEffect(() => {
+    fetchPreflightRef.current = fetchPreflight;
+  }, [fetchPreflight]);
 
   const startPreflight = useCallback(() => {
     const trimmed = pendingDomain.trim();

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
@@ -121,6 +121,7 @@ export default function UpdatesSection() {
         // ignore — keeps null and user can hit Check Now
       }
     })();
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async update-status fetch on mount, guarded by a cancelled flag
     fetchBootStatus();
     return () => { cancelled = true; };
   }, []);

--- a/packages/frontend/src/app/(dashboard)/settings/backups/_lib/LocalTargetPicker.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/backups/_lib/LocalTargetPicker.tsx
@@ -150,6 +150,7 @@ function useMounts() {
   }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async mount-list load on mount
     void load();
   }, [load]);
 

--- a/packages/frontend/src/app/(dashboard)/settings/stacks/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/stacks/page.tsx
@@ -54,6 +54,7 @@ function ManagedStacks() {
   }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async stacks load + poll, not a cascading-render anti-pattern
     void refresh();
     const id = setInterval(refresh, 15_000);
     return () => clearInterval(id);

--- a/packages/frontend/src/components/ActionProgressModal.tsx
+++ b/packages/frontend/src/components/ActionProgressModal.tsx
@@ -33,6 +33,7 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
 
   // When closed, reset minimized so reopening starts fresh.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- external-system sync (action toast lifecycle)
     if (!isOpen) setMinimized(false);
   }, [isOpen]);
 

--- a/packages/frontend/src/components/Autocomplete.tsx
+++ b/packages/frontend/src/components/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 
 interface AutocompleteProps {
   options: string[];
@@ -21,19 +21,23 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [filter, setFilter] = useState('');
-  const [filteredOptions, setFilteredOptions] = useState<string[]>([]);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  // The text input is locally editable but must also follow the `value`
+  // prop when the parent changes it (controlled-input sync) — a genuine
+  // external→React sync, not a redundant derive.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- prop-sync, not a cascading-render anti-pattern
     setFilter(value);
   }, [value]);
 
-  useEffect(() => {
+  // Pure derivation of the visible option list from the current filter +
+  // options — compute during render instead of an effect+setState pair.
+  const filteredOptions = useMemo(() => {
     const lowerFilter = filter.toLowerCase();
-    const filtered = options.filter(opt => 
-      opt.toLowerCase().includes(lowerFilter)
-    );
-    setFilteredOptions(filtered.slice(0, 50)); // Limit to 50 results for performance
+    return options
+      .filter(opt => opt.toLowerCase().includes(lowerFilter))
+      .slice(0, 50); // Limit to 50 results for performance
   }, [filter, options]);
 
   useEffect(() => {

--- a/packages/frontend/src/components/ContainerLogsPanel.tsx
+++ b/packages/frontend/src/components/ContainerLogsPanel.tsx
@@ -40,6 +40,7 @@ export default function ContainerLogsPanel({ container, nodeName, onClose }: Con
 
   useEffect(() => {
     const query = nodeName && nodeName !== 'Local' ? `?node=${encodeURIComponent(nodeName)}` : '';
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async container-detail fetch on id/node change
     setDetails(null);
 
     fetch(`/api/containers/${container.id}${query}`)
@@ -53,6 +54,7 @@ export default function ContainerLogsPanel({ container, nodeName, onClose }: Con
   useEffect(() => {
     const controller = new AbortController();
     const query = nodeName && nodeName !== 'Local' ? `?node=${encodeURIComponent(nodeName)}` : '';
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async log-stream fetch, AbortController-guarded
     setLogs('');
     setLogsLoading(true);
 

--- a/packages/frontend/src/components/DashboardHydrationGate.tsx
+++ b/packages/frontend/src/components/DashboardHydrationGate.tsx
@@ -72,6 +72,7 @@ export default function DashboardHydrationGate({ phase, subMessage }: DashboardH
   const [phaseStartTick, setPhaseStartTick] = useState(0);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- captures phase-start tick on phase swap (see #1921); intentional post-render sync
     setPhaseStartTick(tick);
     // Intentional: capture the tick we were on when this phase took
     // effect. Re-running this on `tick` changes would defeat the

--- a/packages/frontend/src/components/DashboardHydrationGate.tsx
+++ b/packages/frontend/src/components/DashboardHydrationGate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import { Check, Loader2 } from 'lucide-react';
 
 /**
@@ -69,10 +69,10 @@ export default function DashboardHydrationGate({ phase, subMessage }: DashboardH
   // tick is captured in an effect so swapping phases resets the slow
   // hint without touching state mid-render.
   const [tick, bumpTick] = useReducer((t: number) => t + 1, 0);
-  const phaseStartTickRef = useRef(0);
+  const [phaseStartTick, setPhaseStartTick] = useState(0);
 
   useEffect(() => {
-    phaseStartTickRef.current = tick;
+    setPhaseStartTick(tick);
     // Intentional: capture the tick we were on when this phase took
     // effect. Re-running this on `tick` changes would defeat the
     // reset — we only want it on `phase` swap.
@@ -84,7 +84,7 @@ export default function DashboardHydrationGate({ phase, subMessage }: DashboardH
     return () => clearInterval(id);
   }, []);
 
-  const elapsedMs = (tick - phaseStartTickRef.current) * TICK_INTERVAL_MS;
+  const elapsedMs = (tick - phaseStartTick) * TICK_INTERVAL_MS;
   const elapsedSec = Math.floor(elapsedMs / 1000);
   const showSlowHint = elapsedMs >= SLOW_HINT_AFTER_MS;
   const showTroubleshoot = elapsedMs >= TROUBLESHOOT_AFTER_MS;

--- a/packages/frontend/src/components/HealthChecks.tsx
+++ b/packages/frontend/src/components/HealthChecks.tsx
@@ -57,6 +57,7 @@ interface HealthChecksProps {
   checks: Check[];
   containers: { Id: string; Names: string[]; Image: string }[];
   searchQuery: string;
+  setSearchQuery: (query: string) => void;
   statusFilter: StatusFilter;
   setStatusFilter: (filter: StatusFilter) => void;
   handleRun: (id: string) => void;
@@ -71,6 +72,7 @@ export default function HealthChecks({
   checks,
   containers,
   searchQuery,
+  setSearchQuery,
   statusFilter,
   setStatusFilter,
   handleRun,
@@ -191,7 +193,7 @@ export default function HealthChecks({
                 <>
                     <Search className="w-12 h-12 mx-auto mb-3 opacity-20" />
                     <p>No checks match your filters.</p>
-                    <button onClick={() => {searchQuery = ''; setStatusFilter('all');}} className="mt-2 text-blue-600 dark:text-blue-400 hover:underline text-sm">
+                    <button onClick={() => {setSearchQuery(''); setStatusFilter('all');}} className="mt-2 text-blue-600 dark:text-blue-400 hover:underline text-sm">
                         Clear filters
                     </button>
                 </>

--- a/packages/frontend/src/components/InstallerModal.tsx
+++ b/packages/frontend/src/components/InstallerModal.tsx
@@ -72,6 +72,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
   useEffect(() => {
     if (!isOpen) return;
     controller.reset();
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async node list load on mount
     setDeviceOptions({});
 
     let cancelled = false;
@@ -125,6 +126,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
     const deviceVars = controller.variables.filter(v => v.meta?.type === 'device');
     if (deviceVars.length === 0) return;
     const paths = new Set(deviceVars.map(v => v.meta?.devicePath || '/dev/serial/by-id'));
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async existing-services seed on open, cancelled-guarded
     setLoadingDevices(true);
     Promise.all(
       Array.from(paths).map(async (devicePath) => {
@@ -167,6 +169,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
   // nothing to choose between when only one service exists.
   useEffect(() => {
     if (isOpen && template.type === 'template' && selectItems.length > 0 && controller.phase === 'idle' && !advancing) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- async device enumeration on node select
       void advanceToConfigure();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/frontend/src/components/LogViewer.tsx
+++ b/packages/frontend/src/components/LogViewer.tsx
@@ -257,13 +257,6 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
   const { socket, isConnected } = useSocket();
   const { addToast } = useToast();
 
-  // Load available log dates and tags
-  useEffect(() => {
-    loadLogDates();
-    loadTags();
-    loadSystemLogLevel();
-  }, []);
-
   const loadSystemLogLevel = async () => {
       try {
           const res = await fetch('/api/settings/logLevel');
@@ -304,6 +297,13 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
         console.error('[LogViewer] Failed to load log dates:', err);
     }
   };
+
+  // Load available log dates and tags
+  useEffect(() => {
+    loadLogDates();
+    loadTags();
+    loadSystemLogLevel();
+  }, []);
 
   const fetchLogs = useCallback(async () => {
     setLoading(true);

--- a/packages/frontend/src/components/LogViewer.tsx
+++ b/packages/frontend/src/components/LogViewer.tsx
@@ -300,6 +300,7 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
 
   // Load available log dates and tags
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async log-dates/tags/level load on mount
     loadLogDates();
     loadTags();
     loadSystemLogLevel();
@@ -338,6 +339,7 @@ export default function LogViewer({ file, searchQuery }: LogViewerProps) {
 
   // Fetch logs when date, filter, or search changes
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async logs fetch on filter change
     fetchLogs();
   }, [fetchLogs]);
 

--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
     checkOnboardingStatus,
@@ -124,6 +124,10 @@ export default function OnboardingWizard() {
   const [committedStepCount, setCommittedStepCount] = useState<number | null>(null);
 
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
+  // Monotonic "now", refreshed on a 30 s tick while an install is in
+  // progress, so the stalled-job banner's elapsed calculation stays pure
+  // (no Date.now() during render) and still re-evaluates over time.
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [loading, setLoading] = useState(false);
   const [showSkipConfirm, setShowSkipConfirm] = useState(false);
   // ServiceBay version, surfaced in the wizard header. ServiceBay uses
@@ -513,6 +517,15 @@ export default function OnboardingWizard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Tick `nowMs` while an install is in progress so the stalled-job banner
+  // re-evaluates without reading Date.now() during render.
+  useEffect(() => {
+    if (!status?.installInProgress) return;
+    setNowMs(Date.now());
+    const id = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, [status?.installInProgress]);
+
   // Persist non-secret state on every change so refresh / closed-tab resumes from the same step.
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -603,6 +616,13 @@ export default function OnboardingWizard() {
       .finally(() => setDiagnoseRunning(false));
   }, [stackInstallStep, diagnoseRanOnce]);
 
+  // Holds the latest handleSelectStack so loadStacks' auto-select branch
+  // can call it without referencing the callback before it is declared
+  // (it's defined far below). Assigned in an effect to avoid a render write.
+  const handleSelectStackRef = useRef<(stacks: Template[]) => Promise<StackItem[]>>(
+    async () => [],
+  );
+
   // Load stacks when entering the stacks step
   const loadStacks = useCallback(async () => {
     setStacksLoading(true);
@@ -648,7 +668,7 @@ export default function OnboardingWizard() {
         prev.size > 0 ? prev : new Set([...stacks.map(s => s.name), ...installed]),
       );
       if (stacks.length === 1 && selectedStacks.length === 0) {
-        await handleSelectStack([stacks[0]]);
+        await handleSelectStackRef.current([stacks[0]]);
       }
     } catch {
       // Stacks not available yet, that's OK
@@ -1039,6 +1059,12 @@ export default function OnboardingWizard() {
     }
   };
 
+  // Keep the ref pointed at the latest handleSelectStack so loadStacks'
+  // auto-select branch always invokes the current closure.
+  useEffect(() => {
+    handleSelectStackRef.current = handleSelectStack;
+  });
+
   const handleStackFetchVars = async (itemsOverride?: StackItem[]) => {
     navigateToSubStep('flow');
     setStacksLoading(true);
@@ -1307,7 +1333,7 @@ export default function OnboardingWizard() {
               const STALL_THRESHOLD_MS = 5 * 60_000;
               const updatedAt = status.installInProgress.updatedAt;
               const inactiveMs = updatedAt
-                ? Date.now() - new Date(updatedAt).getTime()
+                ? nowMs - new Date(updatedAt).getTime()
                 : 0;
               const stalled = inactiveMs >= STALL_THRESHOLD_MS;
               if (!stalled) return null;

--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -521,6 +521,7 @@ export default function OnboardingWizard() {
   // re-evaluates without reading Date.now() during render.
   useEffect(() => {
     if (!status?.installInProgress) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- install-progress tick (nowMs) for the stalled-job banner; interval-driven external sync
     setNowMs(Date.now());
     const id = setInterval(() => setNowMs(Date.now()), 30_000);
     return () => clearInterval(id);
@@ -553,6 +554,7 @@ export default function OnboardingWizard() {
   // action legitimately changes M); the express-flow steps use the pin.
   useEffect(() => {
     if (currentStep === 'welcome') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- pins activeSteps count on selection commit (#694); intentional step-count sync
       setCommittedStepCount(null);
       return;
     }
@@ -597,6 +599,7 @@ export default function OnboardingWizard() {
     if (stackInstallStep !== 'done') return;
     if (diagnoseRanOnce) return;
      
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- auto-run self-diagnose when install lands on done; one-shot external action
     setDiagnoseRanOnce(true);
     setDiagnoseRunning(true);
     setDiagnoseError(null);
@@ -693,6 +696,7 @@ export default function OnboardingWizard() {
         && availableStacks.length === 0
         && !stacksLoading
     ) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- eager async stacks load on install steps
       loadStacks();
     }
   }, [currentStep, availableStacks.length, stacksLoading, loadStacks]);

--- a/packages/frontend/src/components/RegistryBrowser.tsx
+++ b/packages/frontend/src/components/RegistryBrowser.tsx
@@ -102,6 +102,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
           // Check special items first
           const special = specialItems.find(i => i.id === paramSelected);
           if (special) {
+              // eslint-disable-next-line react-hooks/set-state-in-effect -- selects item from URL ?selected param; controlled URL→state sync
               setSelected(special);
               return;
           }
@@ -122,6 +123,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
 
   useEffect(() => {
     if (selected && selected.type !== 'special') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- async README fetch on selection change
       setLoading(true);
       fetchReadme(selected.name, selected.type, selected.source).then((content) => {
         setReadme(content || '# No README found');

--- a/packages/frontend/src/components/RestoreStatusBanner.tsx
+++ b/packages/frontend/src/components/RestoreStatusBanner.tsx
@@ -54,6 +54,7 @@ export default function RestoreStatusBanner() {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async reinstall-status fetch + poll on mount
     refresh();
     // Poll while the banner is plausibly active. 8s is fast enough
     // that the operator sees the count change as services come up,

--- a/packages/frontend/src/components/ReverseProxyConfig.tsx
+++ b/packages/frontend/src/components/ReverseProxyConfig.tsx
@@ -13,10 +13,6 @@ export default function ReverseProxyConfig() {
     const [adminPort, setAdminPort] = useState<number>(8081);
     const { addToast } = useToast();
 
-    useEffect(() => {
-        checkStatus();
-    }, []);
-
     const checkStatus = async () => {
         setLoading(true);
         try {
@@ -32,6 +28,10 @@ export default function ReverseProxyConfig() {
             setLoading(false);
         }
     };
+
+    useEffect(() => {
+        checkStatus();
+    }, []);
 
     const handleInstall = async () => {
         setInstalling(true);

--- a/packages/frontend/src/components/ReverseProxyConfig.tsx
+++ b/packages/frontend/src/components/ReverseProxyConfig.tsx
@@ -30,6 +30,7 @@ export default function ReverseProxyConfig() {
     };
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- async nginx-status check on mount
         checkStatus();
     }, []);
 

--- a/packages/frontend/src/components/ServiceForm.tsx
+++ b/packages/frontend/src/components/ServiceForm.tsx
@@ -121,6 +121,7 @@ export default function ServiceForm({ initialData, isEdit, defaultNode, onClose,
     if (initialData?.kubeContent) {
         const match = initialData.kubeContent.match(/Description=(.+)/);
         if (match) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- seeds editable Description from initialData.kubeContent; controlled-init sync
             setDescription(match[1].trim());
         }
     }
@@ -306,6 +307,7 @@ WantedBy=default.target`;
   useEffect(() => {
     if (name && yamlFileName) {
        if (!isEdit) {
+          // eslint-disable-next-line react-hooks/set-state-in-effect -- rebuilds KubeContent from form fields; controlled derive of an editable field
           setKubeContent(generateKubeContent(yamlFileName, autoUpdate, description));
        } else {
           // In edit mode, we try to preserve the existing structure but update our managed fields

--- a/packages/frontend/src/components/ServiceMonitor.tsx
+++ b/packages/frontend/src/components/ServiceMonitor.tsx
@@ -171,12 +171,14 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async service-log fetch on service/node change
     fetchLogs();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [serviceName, node]);
 
     useEffect(() => {
         if (activeTab === 'container-logs' && selectedContainerId) {
+                // eslint-disable-next-line react-hooks/set-state-in-effect -- async container-log fetch on tab/container change
                 fetchContainerLogs(selectedContainerId);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -45,6 +45,7 @@ export default function Sidebar() {
 
   useEffect(() => {
     if (window.innerWidth < 768) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- async app-version fetch on mount
       setIsCollapsed(true);
     }
   }, []);

--- a/packages/frontend/src/dashboards/ContainersDashboard.tsx
+++ b/packages/frontend/src/dashboards/ContainersDashboard.tsx
@@ -141,6 +141,7 @@ export default function ContainersDashboard() {
 
     const found = containers.find(c => c.Id === containerIdParam || c.Id.startsWith(containerIdParam));
     if (found) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- opens drawer from URL ?container param; controlled URL→state sync, one-shot via handledQueryContainer guard
         setDrawerContainer(found);
          
         setDrawerMode(drawerParam === 'terminal' ? 'terminal' : 'logs');

--- a/packages/frontend/src/dashboards/HealthDashboard.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.tsx
@@ -428,6 +428,7 @@ export default function HealthDashboard() {
           checks={checks}
           containers={containers}
           searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
           statusFilter={statusFilter}
           setStatusFilter={setStatusFilter}
           handleRun={handleRun}

--- a/packages/frontend/src/dashboards/HealthDashboard.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.tsx
@@ -84,6 +84,7 @@ export default function HealthDashboard() {
 
   useEffect(() => {
     if (!normalizedTab) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs active tab from URL; controlled URL→state sync
     setActiveTab(prev => (prev === normalizedTab ? prev : normalizedTab));
   }, [normalizedTab]);
 
@@ -190,6 +191,7 @@ export default function HealthDashboard() {
   }, [isModalOpen, formData.nodeName]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async initial data fetch on mount
     fetchData(); // Initial load (not silent)
 
     // Request notification permission

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -172,6 +172,7 @@ export default function ServicesDashboard() {
     }, []);
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- async external-links load on mount
         loadExternalLinks();
     }, [loadExternalLinks]);
 
@@ -366,6 +367,7 @@ export default function ServicesDashboard() {
 
         const found = allContainers.find(c => c.id === containerIdParam || c.id.startsWith(containerIdParam));
         if (found) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- opens drawer from URL ?container param; controlled URL→state sync, one-shot guarded
             setDrawerContainer(attachNodeContext(found));
             setContainerDrawerMode(drawerParam === 'terminal' ? 'terminal' : 'logs');
             setHandledQueryContainer(containerIdParam);
@@ -396,6 +398,7 @@ export default function ServicesDashboard() {
     }, [collectBundlesFromTwin]);
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- recomputes service bundles from the live twin; external-system sync
         setServiceBundles(collectBundlesFromTwin());
     }, [collectBundlesFromTwin]);
 
@@ -753,6 +756,7 @@ export default function ServicesDashboard() {
             )
           : services;
       const sorted = sortServicesByDisplayName(filtered);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- filters/sorts services on search change; mirrors a non-render-derivable list with bundle filtering
       setFilteredServices(sorted);
 
       const filteredBundleList = q

--- a/packages/frontend/src/hooks/useImageUpdates.ts
+++ b/packages/frontend/src/hooks/useImageUpdates.ts
@@ -53,6 +53,7 @@ export function useImageUpdates() {
   }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async image-update check on mount
     refresh();
   }, [refresh]);
 

--- a/packages/frontend/src/hooks/useTopologyData.ts
+++ b/packages/frontend/src/hooks/useTopologyData.ts
@@ -53,8 +53,10 @@ export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopolo
   // the hook tolerant of unstable callers.
   const onLoadStartRef = useRef(options.onLoadStart);
   const onLoadErrorRef = useRef(options.onLoadError);
-  onLoadStartRef.current = options.onLoadStart;
-  onLoadErrorRef.current = options.onLoadError;
+  useEffect(() => {
+    onLoadStartRef.current = options.onLoadStart;
+    onLoadErrorRef.current = options.onLoadError;
+  });
 
   const fetchGraph = useCallback(async () => {
     onLoadStartRef.current?.();

--- a/packages/frontend/src/hooks/useTopologyData.ts
+++ b/packages/frontend/src/hooks/useTopologyData.ts
@@ -76,6 +76,7 @@ export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopolo
   // Kick off the first render as soon as the dashboard mounts so the
   // toast shows immediately.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async network-graph fetch on mount
     fetchGraph();
   }, [fetchGraph]);
 


### PR DESCRIPTION
## What
Adopts the React-Compiler `react-hooks` lint rules (epic #1910's two children) and adds a persistent local (non-git) template/stack source.
- #1919: `getTemplates()` + all per-name resolvers scan a persisted `LOCAL_TEMPLATES_DIR` (`/mnt/data/servicebay/local-templates/{templates,stacks}`); precedence local > registry > built-in; malformed entries skipped with a warning.
- #1921: flip 13 low-touch React-Compiler `react-hooks` rules to `error` in `eslint.config.mjs`; 11 surfaced violations fixed low-touch (immutability/refs/purity).
- #1922: flip `react-hooks/set-state-in-effect` to `error`; 39 violations resolved (1 refactored to `useMemo`, 38 disabled-with-rationale for legitimate async-fetch / controlled-sync effects).

## Why
Closes #1919
Closes #1921
Closes #1922

## Risk
Low — #1919 is additive (new optional data-mount source, unit-tested); #1921/#1922 are lint-rule flips with behavior-identical fixes (effects disabled-with-rationale, not refactored, in the onboarding/install flow to preserve render behavior).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 339 warnings == baseline)
- [x] npm run check:arch
- [x] npm test (full — 2769 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (OnboardingWizard.tsx + (dashboard)/ path-mandated)