### PR TITLE
fix(disk-import): prune node_modules/junk subtrees at the walk so they're never hashed (#1932)

### DIFF
--- a/packages/backend/src/lib/diskImport/categories.ts
+++ b/packages/backend/src/lib/diskImport/categories.ts
@@ -134,7 +134,12 @@ export const JUNK_EXTENSIONS: ReadonlySet<string> = new Set([
   'tmp', 'temp', 'cache', 'part', 'crdownload', 'bak',
 ]);
 
-/** Path segments (lower-case) that mark a whole subtree as junk/cache. */
+/**
+ * Path segments (lower-case) that mark a whole subtree as junk/cache. These are
+ * also pruned at the host `find` walk (hostScan.ts) so the importer never
+ * descends, enumerates or hashes them — a repo-heavy disk's `node_modules`/`.git`
+ * never enter the inventory (#1932).
+ */
 export const JUNK_PATH_SEGMENTS: ReadonlyArray<string> = [
   '.trash',
   '.trashes',
@@ -143,4 +148,5 @@ export const JUNK_PATH_SEGMENTS: ReadonlyArray<string> = [
   '@eadir', // Synology thumbnail caches
   '__macosx',
   'node_modules',
+  '.git', // git internals are never library content (#1932)
 ];

--- a/packages/backend/src/lib/diskImport/classify.test.ts
+++ b/packages/backend/src/lib/diskImport/classify.test.ts
@@ -4,6 +4,7 @@ import {
   dispositionCategory,
   isVideoDominant,
   buildSubtreeHints,
+  isJunk,
   type ResidueClassifier,
 } from './classify';
 import { toRecord } from './inventory';
@@ -46,6 +47,14 @@ describe('classifyRecord — junk', () => {
     expect(classifyRecord(rec('/disk/@eaDir/song.flac'))).toBe('junk');
     expect(classifyRecord(rec('/disk/__MACOSX/IMG.jpg'))).toBe('junk');
     expect(classifyRecord(rec('.Trash/x.pdf'))).toBe('junk');
+  });
+  it('treats node_modules and .git subtrees as junk (#1932)', () => {
+    expect(classifyRecord(rec('/disk/proj/node_modules/react/index.js'))).toBe('junk');
+    expect(classifyRecord(rec('/disk/proj/.git/objects/ab/cdef'))).toBe('junk');
+    // isJunk (now exported, used by the scan pre-filter) agrees with classify.
+    expect(isJunk(rec('/disk/proj/node_modules/react/index.js'))).toBe(true);
+    expect(isJunk(rec('/disk/proj/.git/config'))).toBe(true);
+    expect(isJunk(rec('/disk/photos/IMG.jpg'))).toBe(false);
   });
 });
 

--- a/packages/backend/src/lib/diskImport/classify.ts
+++ b/packages/backend/src/lib/diskImport/classify.ts
@@ -175,7 +175,15 @@ const SPOKEN_GENRES = new Set(['audiobook', 'audio book', 'speech', 'spoken', 's
 /** A long track (> 30 min) is far more likely an audiobook chapter than a song. */
 const LONG_TRACK_SEC = 30 * 60;
 
-function isJunk(record: ImportRecord): boolean {
+/**
+ * Whether a record is junk (skipped, never copied). Matched by junk name
+ * (thumbs.db/.ds_store), junk extension (tmp/cache/…), or a junk path segment
+ * (node_modules/.git/.trash/…). Exported so the scan can DROP junk records
+ * before the expensive size-collision/hash pass (#1932) — junk that the host
+ * `find`-prune can't express (a junk-named file outside a junk dir) is filtered
+ * here, and classify still re-checks it so the plan never copies junk.
+ */
+export function isJunk(record: ImportRecord): boolean {
   if (JUNK_NAMES.has(record.name)) return true;
   if (record.ext && JUNK_EXTENSIONS.has(record.ext)) return true;
   const lowerPath = record.sourcePath.replace(/\\/g, '/').toLowerCase();

--- a/packages/backend/src/lib/diskImport/hostScan.test.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { parseFindOutput, scanMount, hashSourceFile, hashRecords, hashPaths, HASH_BATCH_SIZE } from './hostScan';
+import { parseFindOutput, scanMount, hashSourceFile, hashRecords, hashPaths, HASH_BATCH_SIZE, buildScanFindArgs } from './hostScan';
+import { JUNK_PATH_SEGMENTS } from './categories';
 import type { SafeExec, SafeExecResult } from './hostExec';
 import type { ImportRecord } from './types';
 
@@ -71,6 +72,54 @@ describe('scanMount', () => {
     expect(argv.indexOf('-prune')).toBeLessThan(argv.lastIndexOf('-type'));
   });
 
+  it('prunes node_modules/.git and every junk subtree segment (#1932)', async () => {
+    const { exec, calls } = mockExec({ find: ok('') });
+    await scanMount(exec, '/run/servicebay/disk-import/sda1');
+    const argv = calls[0];
+    // Each junk segment is pruned (single-sourced from JUNK_PATH_SEGMENTS), so
+    // node_modules/.git etc. are never descended → never enumerated or hashed.
+    expect(argv).toContain('node_modules');
+    expect(argv).toContain('.git');
+    for (const seg of JUNK_PATH_SEGMENTS) expect(argv).toContain(seg);
+    // The prune group precedes the -type f test (it's the first -o arm).
+    expect(argv.indexOf('-prune')).toBeLessThan(argv.lastIndexOf('-type'));
+  });
+});
+
+describe('buildScanFindArgs (#1932)', () => {
+  it('wraps the prune names in a \\( … -o … \\) group, pruned before -type f', () => {
+    const argv = buildScanFindArgs('/mnt/x');
+    expect(argv.slice(0, 2)).toEqual(['find', '/mnt/x']);
+    // The pruned dir names live inside a parenthesised -name … -o -name … group.
+    const open = argv.indexOf('(');
+    const close = argv.indexOf(')');
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    const group = argv.slice(open, close + 1);
+    expect(group).toContain('lost+found');
+    expect(group).toContain('node_modules');
+    expect(group).toContain('.git');
+    // -name precedes each pruned name; -o separates them.
+    expect(group.filter(a => a === '-name').length).toBe(1 + JUNK_PATH_SEGMENTS.length);
+    expect(group.filter(a => a === '-o').length).toBe(JUNK_PATH_SEGMENTS.length); // n names → n-1 separators (+ lost+found = n)
+    // -prune is applied to the whole group, before the -type f arm.
+    expect(argv[close + 1]).toBe('-prune');
+    expect(argv.indexOf('-prune')).toBeLessThan(argv.indexOf('-type'));
+    // The NUL-delimited printf output contract is unchanged.
+    expect(argv).toContain('-printf');
+    expect(argv).toContain('%p\t%s\t%T@\\0');
+  });
+
+  it('never descends a pruned subtree: scanMount returns exactly what find streams', async () => {
+    // The real prune happens in `find` itself; here we assert the contract that
+    // scanMount returns exactly what find streams (find having pruned the junk).
+    const { exec } = mockExec({ find: ok('/mnt/real/song.flac\t10\t1700000000\0') });
+    const files = await scanMount(exec, '/run/servicebay/disk-import/sda1');
+    expect(files).toEqual([{ path: '/mnt/real/song.flac', size: 10, mtimeMs: 1700000000000 }]);
+  });
+});
+
+describe('scanMount — partial-walk tolerance', () => {
   it('tolerates find exit 1 (permission-denied descent) when stdout still parsed', async () => {
     // A real ext4 disk with a root-0700 subdir: find prints what it could read
     // to stdout AND a "Permission denied" line on stderr, then exits 1. We keep

--- a/packages/backend/src/lib/diskImport/hostScan.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.ts
@@ -12,9 +12,43 @@
 // `hashSourceFile` (as the dedup `HashResolver`) only for size-collision
 // candidates.
 
+import { JUNK_PATH_SEGMENTS } from './categories';
 import type { ScannedFile } from './inventory';
 import type { SafeExec } from './hostExec';
 import type { ImportRecord } from './types';
+
+/**
+ * The directory names pruned at the `find` walk: `lost+found` (root-0700, useless
+ * to us) plus every junk subtree segment (`node_modules`, `.git`, `.trash`, …).
+ * Single-sourced from {@link JUNK_PATH_SEGMENTS} so the prune list and the engine's
+ * junk classification never drift. Pruning here means a repo-heavy disk's
+ * `node_modules`/`.git` never get enumerated, hashed or imported (#1932) — these
+ * subtrees are near-identical across projects, so unpruned they all size-collide
+ * and the dedup hash pass tries to hash every one ("Checking for duplicates…"
+ * never finishes).
+ */
+const PRUNE_DIR_NAMES: ReadonlyArray<string> = ['lost+found', ...JUNK_PATH_SEGMENTS];
+
+/**
+ * Build the `find` argv that prunes {@link PRUNE_DIR_NAMES} before the `-type f`
+ * test. Shape: `find <mount> \( -name node_modules -o -name .git -o … \) -prune
+ * -o -type f -printf '%p\t%s\t%T@\0'`. The pruned subtrees are never descended,
+ * so they're never enumerated, hashed or imported. The NUL-delimited `-printf`
+ * output contract is unchanged (parseFindOutput depends on it).
+ */
+export function buildScanFindArgs(mountpoint: string): string[] {
+  const pruneGroup: string[] = ['('];
+  PRUNE_DIR_NAMES.forEach((name, i) => {
+    if (i > 0) pruneGroup.push('-o');
+    pruneGroup.push('-name', name);
+  });
+  pruneGroup.push(')');
+  return [
+    'find', mountpoint,
+    ...pruneGroup, '-prune', '-o',
+    '-type', 'f', '-printf', '%p\t%s\t%T@\\0',
+  ];
+}
 
 /** A `\0`-free absolute mountpoint we built ourselves (mounter.ts). */
 function assertMountpoint(mountpoint: string): void {
@@ -33,24 +67,23 @@ function assertMountpoint(mountpoint: string): void {
 export async function scanMount(exec: SafeExec, mountpoint: string): Promise<ScannedFile[]> {
   assertMountpoint(mountpoint);
   // The scan walk runs UNPRIVILEGED on purpose (read-only enumeration never
-  // escalates — see hostExec.ts). On a real ext4 disk that means two things:
+  // escalates — see hostExec.ts). On a real ext4 disk that means three things:
   //
   //  1. `lost+found` is root-owned 0700 and useless to us — prune it from the
-  //     walk so `find` never even tries to descend it (`-path .../lost+found
-  //     -prune`).
-  //  2. Any OTHER root-0700 subdir we hit still makes `find` print a
+  //     walk so `find` never even tries to descend it.
+  //  2. Junk subtrees (`node_modules`, `.git`, `.trash`, …) are pruned the same
+  //     way (#1932): a repo-heavy disk's node_modules is huge and near-identical
+  //     across projects, so unpruned it floods the inventory + the dedup hash
+  //     pass with size-colliding files and "Checking for duplicates…" never
+  //     finishes. Pruned, those subtrees never enter the inventory at all. The
+  //     prune list is single-sourced from JUNK_PATH_SEGMENTS via PRUNE_DIR_NAMES.
+  //  3. Any OTHER root-0700 subdir we hit still makes `find` print a
   //     "Permission denied" line on stderr and exit 1, EVEN THOUGH it already
   //     streamed every readable entry to stdout. Treating that exit 1 as fatal
   //     threw away a perfectly good listing ("Scan disk fails", #1893). So we
   //     tolerate exit 1 WHEN stdout parses into at least one record (a partial
   //     find), and only error on a genuinely failed walk (no usable stdout).
-  const { stdout, code, stderr } = await exec([
-    'find', mountpoint,
-    // Prune the ext4 `lost+found` (root 0700) before any `-type f` test so we
-    // neither descend it nor emit a permission-denied line for it.
-    '-name', 'lost+found', '-prune', '-o',
-    '-type', 'f', '-printf', '%p\t%s\t%T@\\0',
-  ]);
+  const { stdout, code, stderr } = await exec(buildScanFindArgs(mountpoint));
   const files = parseFindOutput(stdout);
   // `find` exits 1 on a permission-denied descent but still lists what it could
   // read. A partial walk (exit 1 WITH parsed records) is a success; only a walk

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -100,6 +100,44 @@ describe('scanDevice', () => {
     expect(result.categories.find(c => c.category === 'photos')?.files).toBe(2);
   });
 
+  it('drops junk records (node_modules/.git/thumbs.db) before hashing AND from the plan (#1932)', async () => {
+    // Two real same-size docs (would size-collide → be hashed) plus a pile of
+    // junk: a node_modules file, a .git file, and a Thumbs.db. The junk must
+    // NOT be hashed and must NOT appear in the plan (no skip-junk item needed —
+    // it's pre-filtered before the engine ever sees it).
+    const find = [
+      '/mnt/docs/a.pdf\t100\t1700000000',
+      '/mnt/docs/b.pdf\t100\t1700000001', // same size as a.pdf → collision candidate
+      '/mnt/proj/node_modules/react/index.js\t100\t1700000002',
+      '/mnt/proj/.git/objects/ab/cdef\t100\t1700000003',
+      '/mnt/docs/Thumbs.db\t100\t1700000004',
+    ].join('\0') + '\0';
+    const hashed: string[] = [];
+    const { exec } = mockExec({
+      find: ok(find),
+      // Distinct hash per path so the two real pdfs are NOT treated as dupes.
+      sha256sum: argv => {
+        const paths = argv.slice(1);
+        hashed.push(...paths);
+        return ok(paths.map((p, i) => `${String(i).repeat(64).slice(0, 63)}0  ${p}`).join('\n') + '\n');
+      },
+    });
+    const result = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    // Only the two real docs are in the plan — junk never entered the inventory.
+    expect(result.totalFiles).toBe(2);
+    // No category is `junk` and the docs category holds exactly the 2 real files.
+    expect(result.categories.some(c => c.category === 'junk')).toBe(false);
+    expect(result.categories.find(c => c.category === 'documents')?.files).toBe(2);
+
+    // The junk paths were never handed to sha256sum (not hashed).
+    const junkPaths = ['/mnt/proj/node_modules/react/index.js', '/mnt/proj/.git/objects/ab/cdef', '/mnt/docs/Thumbs.db'];
+    for (const p of junkPaths) expect(hashed).not.toContain(p);
+    // The two real size-colliding docs WERE hashed (real content still deduped).
+    expect(hashed).toContain('/mnt/docs/a.pdf');
+    expect(hashed).toContain('/mnt/docs/b.pdf');
+  });
+
   it('surfaces the unclassifiable residue as a non-blocking ambiguous-folder action', async () => {
     const { exec } = mockExec({ find: ok(FIND_OUT) });
     const result = await scanDevice({ exec, device: '/dev/sda1', catalogPath: ':memory:' });

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -19,7 +19,7 @@ import { randomUUID } from 'node:crypto';
 import { ImportCatalog } from './catalog';
 import { buildInventory } from './inventory';
 import { buildPlan, type HashResolver } from './dedup';
-import { classifyRecord, buildSubtreeHints } from './classify';
+import { classifyRecord, buildSubtreeHints, isJunk } from './classify';
 import { listBlockDevices, mountReadOnly, unmount, type BlockDevice } from './mounter';
 import { hashPaths, hashRecords, scanMount } from './hostScan';
 import { applyPlan, type ApplyResult } from './plan';
@@ -261,11 +261,22 @@ async function runScan(sessionId: string, opts: ScanOptions): Promise<ScanResult
   try {
     await setProgress(sessionId, { step: 'walk' });
     const files = await scanMount(exec, mountpoint);
-    const records = buildInventory(files);
+    // Drop junk records BEFORE the expensive size-collision/hash pass (#1932).
+    // Junk subtrees (node_modules/.git/…) are already pruned at the `find` walk;
+    // this is belt-and-suspenders for the junk a path-prune can't express —
+    // junk NAMES (thumbs.db/.ds_store) and junk EXTENSIONS (tmp/cache/…), plus
+    // any junk-named file outside a junk dir. The kept set is what the plan
+    // sees, so classification/dedup/counts stay junk-free and consistent (the
+    // plan simply never produces a `skip-junk` item for a pre-filtered record).
+    const records = buildInventory(files).filter(r => !isJunk(r));
+    // `scanned` reflects the KEPT (non-junk) records — the real candidate set.
     await setProgress(sessionId, { step: 'hash', scanned: records.length });
 
     // Pre-hash only the size-collision candidates host-side, then hand dedup a
-    // synchronous resolver over the resulting map (the engine stays sync).
+    // synchronous resolver over the resulting map (the engine stays sync). With
+    // junk pruned the residual real-content candidate set is small, so a single
+    // blocking hash pass suffices; background/non-blocking hashing is a planned
+    // follow-up UX (tracked under #1932) and intentionally NOT done here.
     const candidates = sizeCollisionCandidates(records);
     const hashes = await hashRecords(exec, candidates, (hashed, total) => {
       void setProgress(sessionId, { hashed, total });


### PR DESCRIPTION
## Problem (#1932)

A real user-facing bug hit live on the box: disk-import "Checking for duplicates…" hashes ~all files and **never finishes** on a repo-heavy USB disk (234508 files, ~88% size-colliding).

## Root cause

- `hostScan.ts` `scanMount` pruned only `lost+found` from the `find` walk — it descended into every `node_modules`/`.git` and enumerated all of it.
- `service.ts` `runScan` ran `sizeCollisionCandidates` over the **unfiltered** records and hashed them. `node_modules` files are near-identical across projects, so they all collide on size → all get hashed.
- Junk was only dropped **later** in `buildPlan → classify → isJunk` (action `skip-junk`), AFTER the expensive hashing.

## Fix (two layers, single-sourced)

1. **Prune junk subtrees at the walk** — `hostScan.ts` now builds the `find` argv from `JUNK_PATH_SEGMENTS` (plus `lost+found`): `\( -name node_modules -o -name .git -o … \) -prune -o -type f -printf …`. Those subtrees are never descended, enumerated, hashed or imported. The NUL-delimited `-printf` output contract is unchanged. Added `.git` to `JUNK_PATH_SEGMENTS` (git internals are never library content).
2. **Drop `isJunk` records before the hash pass** — `service.ts` `runScan` filters junk right after `buildInventory`, BEFORE `sizeCollisionCandidates`/`hashRecords`. Belt-and-suspenders for junk a path-prune can't express (junk NAMES like `thumbs.db`/`.DS_Store`, junk EXTENSIONS like `tmp`/`cache`, junk-named files outside a junk dir). The plan sees a junk-free set; `scanned` reflects the kept records; no `skip-junk` item is produced for pre-filtered junk (review category sizing / `actions[]` don't depend on junk records being present). `isJunk` is exported from `classify.ts` and reused (no duplication).

## Follow-up

**Background/non-blocking hashing** (the bigger scan/review refactor — the user's eventual UX) is intentionally **deferred** to a follow-up tracked under #1932. With junk pruned, the residual real-content candidate set is small enough for a single blocking pass. A code comment in `runScan` notes this.

## Tests

- `hostScan`: the constructed `find` args prune `node_modules`/`.git`/every junk segment, in a parenthesised `-name … -o …` group before `-type f`; printf contract intact.
- `classify`: `.git`/`node_modules` classified as junk; exported `isJunk` agrees.
- `service runScan`: a record set with `node_modules`/`.git`/`Thumbs.db` files → those excluded from the hash candidate set AND the plan; real same-size docs still hashed/classified. Path-traversal / owner-clamp / #1919 basename barriers untouched.

## Gates

- `npm run lint` — 0 errors, 339 warnings (baseline)
- `npm run check:arch` — all checks passed, no dependency violations
- diskImport vitest — 216 passed; `vitest --changed` — 162 passed
- backend `tsc --noEmit` — clean

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
