### PR TITLE
fix(immich): use stdin mode for psql + quote "user" table name (#1928 refix)

### DIFF
--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -158,27 +158,30 @@ def _psql(db_password: str, sql: str, set_vars: dict[str, str] | None = None) ->
     """Run a single SQL statement inside the immich-database container
     as the postgres superuser. Returns (returncode, stripped stdout).
 
-    Uses `podman exec` (the same host-side capability file-share /
+    Uses `podman exec -i` (the same host-side capability file-share /
     home-assistant post-deploys use) and passes the password via
     PGPASSWORD in the container env so it never lands on the host process
-    table. `-tAc` gives one bare value per row, no headers/alignment.
+    table. `-tA` gives one bare value per row, no headers/alignment.
+    SQL is fed via stdin so that psql variable substitution (`:'name'`)
+    works — psql only interpolates variables in stdin/file mode, not in
+    `-c` command-line arguments.
 
     `set_vars` binds psql variables (`-v name=value`); reference them in
     `sql` as `:'name'` so psql does the literal quoting. This keeps an
     arbitrary secret value out of the SQL string entirely — no manual
     escaping, injection-safe whatever bytes the secret contains."""
     cmd = [
-        "podman", "exec",
+        "podman", "exec", "-i",
         "-e", f"PGPASSWORD={db_password}",
         DB_CONTAINER,
-        "psql", "-U", "postgres", "-d", "immich",
+        "psql", "-U", "postgres", "-d", "immich", "-tA",
     ]
     for name, value in (set_vars or {}).items():
         cmd.extend(["-v", f"{name}={value}"])
-    cmd.extend(["-tAc", sql])
     try:
         result = subprocess.run(
             cmd,
+            input=sql,
             capture_output=True,
             text=True,
             check=False,
@@ -307,13 +310,15 @@ def rekey_admin_password_in_db(admin_email: str, new_password: str, db_password:
     report a masked success (feedback_dont_mask_failures)."""
     # Confirm the admin row exists before touching it — a fresh DATA dir has no
     # row yet (admin-sign-up creates it via the API), and we must not invent one.
+    # Immich's schema names the table `user` (singular, a reserved word); we must
+    # double-quote it in SQL so postgres doesn't parse it as a keyword.
     code, found = _psql(
         db_password,
-        "SELECT 1 FROM users WHERE email = :'email' LIMIT 1;",
+        'SELECT 1 FROM "user" WHERE email = :\'email\' LIMIT 1;',
         set_vars={"email": admin_email},
     )
     if code != 0:
-        log("   ⚠️ Could not query the Immich users table — skipping admin password rekey.")
+        log("   ⚠️ Could not query the Immich user table — skipping admin password rekey.")
         return False
     if not found:
         log(f"   ℹ️ No Immich admin row for {admin_email} yet — nothing to rekey "
@@ -327,9 +332,10 @@ def rekey_admin_password_in_db(admin_email: str, new_password: str, db_password:
     # The hash rides in via a psql variable (:'hash') so psql quotes it — no
     # manual escaping. `$2b$...` contains only bcrypt-alphabet chars, but the
     # bound-variable form is injection-safe regardless.
+    # Table is `"user"` (double-quoted reserved word) per Immich's schema.
     code, _ = _psql(
         db_password,
-        "UPDATE users SET password = :'hash' WHERE email = :'email';",
+        'UPDATE "user" SET password = :\'hash\' WHERE email = :\'email\';',
         set_vars={"hash": new_hash, "email": admin_email},
     )
     if code != 0:

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1856,7 +1856,10 @@ class ImmichScript(unittest.TestCase):
         """Return (run_fn, calls) where run_fn fakes `podman exec … psql`.
         SELECT returns `select_value`; UPDATE returns rc 0 and is recorded
         with its bound `-v secret=…` value so the test can assert the
-        new secret was written."""
+        new secret was written.
+
+        SQL is now passed via `input=` kwarg (stdin mode — so psql variable
+        interpolation works); the recorder reads it from `_kw['input']`."""
         calls: list[dict[str, Any]] = []
 
         class _CP:
@@ -1866,7 +1869,7 @@ class ImmichScript(unittest.TestCase):
                 self.stderr = ""
 
         def run_fn(cmd, *_a, **_kw):
-            sql = cmd[-1]
+            sql = _kw.get("input", "")
             secret_var = None
             for i, tok in enumerate(cmd):
                 if tok == "-v" and i + 1 < len(cmd) and cmd[i + 1].startswith("secret="):
@@ -1975,10 +1978,14 @@ class ImmichScript(unittest.TestCase):
 
     def _rekey_recorder(self, *, user_exists=True, bcrypt_ok=True, login_after_rekey="201"):
         """Fake `podman exec` for the rekey path. Distinguishes the three call
-        shapes: the `SELECT 1 FROM users` probe, the in-container `node -e`
-        bcrypt mint, and the `UPDATE users` re-stamp. `login_after_rekey` is
+        shapes: the `SELECT 1 FROM "user"` probe, the in-container `node -e`
+        bcrypt mint, and the `UPDATE "user"` re-stamp. `login_after_rekey` is
         unused by the fake (login is HTTP, mocked separately) but documents
-        intent. Records the UPDATE's bound `hash=` value."""
+        intent. Records the UPDATE's bound `hash=` value.
+
+        SQL is now passed via `input=` kwarg (stdin mode); the recorder reads
+        it from `_kw['input']`. Table is `"user"` (singular, quoted reserved
+        word) — Immich's actual schema name, not the plural `users`."""
         calls: list[dict[str, Any]] = []
 
         class _CP:
@@ -1994,17 +2001,17 @@ class ImmichScript(unittest.TestCase):
                 if not bcrypt_ok:
                     return _CP(1, "")
                 return _CP(0, "$2b$11$" + "x" * 53)
-            sql = cmd[-1]
+            sql = _kw.get("input", "")
             bound = {}
             for i, tok in enumerate(cmd):
                 if tok == "-v" and i + 1 < len(cmd):
                     k, _, v = cmd[i + 1].partition("=")
                     bound[k] = v
             upper = sql.strip().upper()
-            if upper.startswith("SELECT 1 FROM USERS"):
+            if 'SELECT 1 FROM "USER"' in upper:
                 calls.append({"kind": "user_select", "bound": bound})
                 return _CP(0, "1" if user_exists else "")
-            if upper.startswith("UPDATE USERS"):
+            if upper.startswith('UPDATE "USER"'):
                 calls.append({"kind": "user_update", "bound": bound})
                 return _CP(0, "UPDATE 1")
             # Any OIDC-secret SELECT/UPDATE that may still run afterwards.


### PR DESCRIPTION
## Summary

Box-verify RED on SHA 6bd96a1b (4.125.1): the #1928 admin-password rekey failed with `⚠️ Could not query the Immich users table — skipping admin password rekey.` Two bugs found together:

**Bug 1 — wrong table name:** Immich's actual DB schema uses `user` (singular, a SQL reserved word), not `users` (plural). Both the existence probe (`SELECT 1 FROM users`) and the UPDATE in `rekey_admin_password_in_db` referenced the wrong name.

**Bug 2 — psql variable interpolation broken in `-c` mode:** `psql` only interpolates `:'var'` tokens when SQL arrives via **stdin**, not via `-c`/`-tAc` command-line arguments. The `_psql` helper used `-tAc sql`, so all `-v name=val` bindings silently had no effect and `:` triggered a `syntax error`. This also broke the pre-existing `reconcile_oidc_secret_in_db` UPDATE path from #1556.

**Fixes:**
- `_psql`: drop `-tAc`, add `-i` + `input=sql` to `subprocess.run` so variable substitution works.
- `rekey_admin_password_in_db`: quote the table as `"user"` in both SQL statements.
- Tests updated to read SQL from `_kw['input']` and match `"user"` (not `USERS`).

Verified on box: `podman exec -i immich-database psql … -tA` via stdin correctly resolves `:'email'` and `:'hash'` variables; `SELECT 1 FROM "user"` returns the admin row.

## Test plan

- [ ] `npm test` passes (311 test files, 63 Python post-deploy tests)
- [ ] Box-verify: run immich reinstall on preserved pgdata — expect `✅ Rekeyed the preserved Immich admin password` + no 401 + OIDC config runs

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._