### PR TITLE
fix(immich): set -w /usr/src/app/server so bcrypt resolves in the rekey exec (#1928)

### DIFF
--- a/templates/immich/post-deploy.py
+++ b/templates/immich/post-deploy.py
@@ -267,9 +267,15 @@ def _bcrypt_hash(password: str) -> str:
         "const b=require('bcrypt');"
         "process.stdout.write(b.hashSync(process.env.SB_NEW_PW,11));"
     )
+    # `-w /usr/src/app/server` so Node resolves modules from immich-server's
+    # app dir where `bcrypt` lives (node_modules/); without it Node resolves
+    # from `/root` and `require('bcrypt')` fails with "Cannot find module"
+    # (rc=1). The `-w <dir>` is a `podman exec` flag, so it must precede the
+    # container name (arg order: `podman exec [flags] CONTAINER CMD...`).
     cmd = [
         "podman", "exec",
         "-e", f"SB_NEW_PW={password}",
+        "-w", "/usr/src/app/server",
         SERVER_CONTAINER,
         "node", "-e", node_src,
     ]

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1995,9 +1995,9 @@ class ImmichScript(unittest.TestCase):
                 self.stderr = ""
 
         def run_fn(cmd, *_a, **_kw):
-            # bcrypt mint: `podman exec -e SB_NEW_PW=… <ctr> node -e <src>`
+            # bcrypt mint: `podman exec -e SB_NEW_PW=… -w <dir> <ctr> node -e <src>`
             if "node" in cmd and "-e" in cmd:
-                calls.append({"kind": "bcrypt"})
+                calls.append({"kind": "bcrypt", "cmd": list(cmd)})
                 if not bcrypt_ok:
                     return _CP(1, "")
                 return _CP(0, "$2b$11$" + "x" * 53)
@@ -2056,6 +2056,20 @@ class ImmichScript(unittest.TestCase):
         kinds = [c["kind"] for c in calls]
         self.assertIn("user_select", kinds)
         self.assertIn("bcrypt", kinds)
+        # The bcrypt mint must run with `-w /usr/src/app/server` so Node
+        # resolves `bcrypt` from immich-server's app node_modules; without it
+        # `require('bcrypt')` fails "Cannot find module" (rc=1). The `-w <dir>`
+        # is a `podman exec` flag, so it must precede the container name
+        # (arg order: `podman exec [flags] CONTAINER CMD...`).
+        bcrypt_cmd = next(c for c in calls if c["kind"] == "bcrypt")["cmd"]
+        self.assertIn("-w", bcrypt_cmd)
+        w_idx = bcrypt_cmd.index("-w")
+        self.assertEqual(bcrypt_cmd[w_idx + 1], "/usr/src/app/server")
+        self.assertIn("immich-immich-server", bcrypt_cmd)
+        self.assertLess(
+            w_idx, bcrypt_cmd.index("immich-immich-server"),
+            "the -w workdir flag must precede the container name",
+        )
         update = next(c for c in calls if c["kind"] == "user_update")
         self.assertTrue(update["bound"].get("hash", "").startswith("$2"))
         self.assertEqual(update["bound"].get("email"), "op@example.com")


### PR DESCRIPTION
## What
Adds `-w /usr/src/app/server` to the `podman exec` that mints the admin-password bcrypt hash inside `immich-immich-server`, so Node resolves the `bcrypt` module from immich-server's app `node_modules`.

## Why (root cause)
The #1928 admin-password DB rekey runs:
```
podman exec immich-immich-server node -e '...require("bcrypt")...'
```
with no working directory. Node then resolves modules from `/root` and fails with `Cannot find module 'bcrypt'` (rc=1) — so `_bcrypt_hash()` returns `''`, the rekey aborts, and the preserved-pgdata admin login never recovers (no OIDC config, no External-Library API key mint).

`bcrypt` lives in the container at `/usr/src/app/server/node_modules`. Box-verify confirmed on-box that the same exec with `-w /usr/src/app/server` makes `require('bcrypt')` succeed and produce a valid `$2b$11$...` hash. The `-w <dir>` is a `podman exec` flag, so it precedes the container name (`podman exec [flags] CONTAINER CMD...`).

This is the only remaining failure in 4.125.1 (#1934) — the psql + `"user"` table-name fixes (#1935) already work. No other change (psql code, table name, bcrypt cost-11 invocation all correct). It's the only `podman exec ... node ...` call in the script.

## Risk
Low — one flag added to one exec; the bcrypt mint already fully unit-tested.

## Rollback
`git revert` is enough.

## Verification
- [x] `python3 -m unittest tests.templates.test_post_deploy` (63 pass; ImmichScript 7/7), test extended to assert `-w /usr/src/app/server` precedes the container name
- [x] npm run lint (0 errors, 339 warnings)
- [x] npm run check:arch
- [ ] /verify on FCoS :dev box — re-verify owed (4th attempt, immich rekey)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._