### PR TITLE
fix(disk-import): review-first scan, resilient hashing, wider junk prune (#1937)

### DIFF
--- a/packages/backend/src/lib/diskImport/categories.ts
+++ b/packages/backend/src/lib/diskImport/categories.ts
@@ -149,4 +149,23 @@ export const JUNK_PATH_SEGMENTS: ReadonlyArray<string> = [
   '__macosx',
   'node_modules',
   '.git', // git internals are never library content (#1932)
+  // Dev / build / cache subtrees (#1937): checked-in dependency trees and
+  // generated/build output that flood a repo-heavy disk's inventory + dedup
+  // hash pass with near-identical, size-colliding files — never library
+  // content. `bower_components` was the biggest single offender on the user's
+  // real disk (~5.6k checked-in Polymer deps).
+  'bower_components',
+  'vendor', // Go/PHP vendored deps
+  'dist',
+  'build',
+  '.next',
+  '.nuxt',
+  '.gradle',
+  '.cache',
+  '__pycache__',
+  '.pytest_cache',
+  '.mypy_cache',
+  '.tox',
+  '.svn', // other VCS internals
+  '.hg',
 ];

--- a/packages/backend/src/lib/diskImport/classify.test.ts
+++ b/packages/backend/src/lib/diskImport/classify.test.ts
@@ -56,6 +56,18 @@ describe('classifyRecord — junk', () => {
     expect(isJunk(rec('/disk/proj/.git/config'))).toBe(true);
     expect(isJunk(rec('/disk/photos/IMG.jpg'))).toBe(false);
   });
+  it('treats the widened dev/build/cache subtrees as junk (#1937)', () => {
+    // bower_components was the single biggest offender on the user's real disk
+    // (~5.6k checked-in Polymer deps); the rest are generated/build/cache trees.
+    for (const seg of [
+      'bower_components', 'vendor', 'dist', 'build', '.next', '.nuxt', '.gradle',
+      '.cache', '__pycache__', '.pytest_cache', '.mypy_cache', '.tox', '.svn', '.hg',
+    ]) {
+      expect(isJunk(rec(`/disk/proj/${seg}/file.js`))).toBe(true);
+    }
+    // A real file outside those trees is NOT junk.
+    expect(isJunk(rec('/disk/docs/report.pdf'))).toBe(false);
+  });
 });
 
 describe('classifyRecord — music vs audiobook disambiguation', () => {

--- a/packages/backend/src/lib/diskImport/hostScan.test.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { parseFindOutput, scanMount, hashSourceFile, hashRecords, hashPaths, HASH_BATCH_SIZE, buildScanFindArgs } from './hostScan';
+import { parseFindOutput, scanMount, hashSourceFile, hashRecords, hashPaths, HASH_BATCH_SIZE, HASH_BATCH_BYTES, buildScanFindArgs } from './hostScan';
 import { JUNK_PATH_SEGMENTS } from './categories';
 import type { SafeExec, SafeExecResult } from './hostExec';
 import type { ImportRecord } from './types';
@@ -183,7 +183,7 @@ describe('hashRecords', () => {
     expect(calls[0]).toEqual(['sha256sum', '/mnt/a', '/mnt/b']);
   });
 
-  it('fires onProgress once per file even within a batched call', async () => {
+  it('fires onProgress per flushed batch with the running hashed/total (#1937)', async () => {
     const { exec } = batchedSha256(() => 'a'.repeat(64));
     const records: ImportRecord[] = [
       { sourcePath: '/mnt/a', size: 1, mtimeMs: 0, ext: '', name: 'a' },
@@ -192,7 +192,9 @@ describe('hashRecords', () => {
     ];
     const ticks: Array<[number, number]> = [];
     await hashRecords(exec, records, (hashed, total) => ticks.push([hashed, total]));
-    expect(ticks).toEqual([[1, 3], [2, 3], [3, 3]]);
+    // All three tiny files fit one batch → one tick at completion. (The card's
+    // "checking duplicates… N / M" line advances per flushed batch, #1937.)
+    expect(ticks).toEqual([[3, 3]]);
   });
 });
 
@@ -224,14 +226,111 @@ describe('hashPaths — batched execution (#1898)', () => {
     expect(map.get('/mnt/od\nd')).toBe(hex);
   });
 
-  it('throws if sha256sum omits a requested path', async () => {
-    const exec: SafeExec = vi.fn(async () => ok(`${'e'.repeat(64)}  /mnt/a\n`));
-    await expect(hashPaths(exec, ['/mnt/a', '/mnt/b'])).rejects.toThrow(/no hash for/);
+  it('SKIPS (does not throw on) a path the tool omits — left un-deduped (#1937)', async () => {
+    // Resilient hashing (#1937): a batch where sha256sum omits a path is retried-
+    // split down to per-file; a file that still has no hash is SKIPPED (absent
+    // from the map → simply not deduped), never thrown. Here `/mnt/b` is omitted
+    // at every width, so `/mnt/a` is hashed and `/mnt/b` is dropped.
+    const exec: SafeExec = vi.fn(async (argv: string[]) =>
+      argv.includes('/mnt/a') && !argv.includes('/mnt/b')
+        ? ok(`${'e'.repeat(64)}  /mnt/a\n`)
+        : argv.includes('/mnt/a')
+          ? ok(`${'e'.repeat(64)}  /mnt/a\n`) // batch [a,b]: only a returned → split
+          : ok(''),
+    );
+    const map = await hashPaths(exec, ['/mnt/a', '/mnt/b']);
+    expect(map.get('/mnt/a')).toBe('e'.repeat(64));
+    expect(map.has('/mnt/b')).toBe(false);
   });
 
   it('refuses a NUL byte in a path before any host call', async () => {
     const { exec, calls } = batchedSha256(() => 'f'.repeat(64));
     await expect(hashPaths(exec, ['/mnt/\0evil'])).rejects.toThrow(/NUL byte/);
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe('hashRecords — byte-aware batching (#1937, THE crash fix)', () => {
+  const rec = (sourcePath: string, size: number): ImportRecord => ({
+    sourcePath, size, mtimeMs: 0, ext: '', name: sourcePath,
+  });
+
+  it('flushes a batch at the BYTE cap, not just the file count — big media → small batches', async () => {
+    // Five "videos" each just over HALF the byte cap: no two fit one batch, so
+    // the byte-aware flush splits them into one-or-two-file sha256sum calls,
+    // keeping each call within the time budget. The OLD 256-file-count cap would
+    // have crammed all five (≈ 5× the cap of bytes) into a single doomed call.
+    const big = Math.ceil(HASH_BATCH_BYTES * 0.6); // two won't fit one batch
+    const records = Array.from({ length: 5 }, (_, i) => rec(`/mnt/v${i}`, big));
+    const { exec, calls } = batchedSha256(p => 'a'.repeat(64).slice(0, 63) + (p.endsWith('0') ? '0' : '1'));
+    const map = await hashRecords(exec, records);
+    expect(map.size).toBe(5);
+    // Each batch carries at most ONE big file (a second would exceed the cap), so
+    // we get 5 sha256sum calls — never one giant call over all five.
+    expect(calls.length).toBe(5);
+    expect(calls.every(c => c.slice(1).length === 1)).toBe(true);
+  });
+
+  it('still batches small files by the file-count cap (no regression)', async () => {
+    const n = HASH_BATCH_SIZE + 10; // tiny files → count cap drives the split
+    const records = Array.from({ length: n }, (_, i) => rec(`/mnt/s${i}`, 4));
+    const { exec, calls } = batchedSha256(() => 'b'.repeat(64));
+    const map = await hashRecords(exec, records);
+    expect(map.size).toBe(n);
+    // ceil(266 / 256) = 2 batches — byte budget never reached for tiny files.
+    expect(calls.length).toBe(2);
+  });
+
+  it('passes an explicit generous timeoutMs on every hash batch (#1937)', async () => {
+    const seen: Array<number | undefined> = [];
+    const exec: SafeExec = vi.fn(async (argv: string[], options?: { timeoutMs?: number }) => {
+      seen.push(options?.timeoutMs);
+      return ok(argv.slice(1).map(p => `${'c'.repeat(64)}  ${p}`).join('\n') + '\n');
+    });
+    await hashRecords(exec, [rec('/mnt/a', 4), rec('/mnt/b', 4)]);
+    // The ~30s safe_exec default is too short for media — we always pass a large
+    // explicit timeout (well over 30s) so a media batch can't spuriously time out.
+    expect(seen.length).toBeGreaterThan(0);
+    for (const t of seen) {
+      expect(t).toBeDefined();
+      expect(t!).toBeGreaterThan(30_000);
+    }
+  });
+
+  it('RETRIES-SPLITS a failing batch and SKIPS a persistently-failing file (never throws)', async () => {
+    // `/mnt/bad` fails (non-zero exit) at EVERY width; the others succeed. The
+    // batch retry halves down to per-file: the good files are hashed, the bad
+    // file is skipped (omitted from the map → just not deduped) — and crucially
+    // the whole call RESOLVES (the scan survives a hashing failure, #1937 Part B).
+    const records = Array.from({ length: 8 }, (_, i) => rec(`/mnt/f${i}`, 4));
+    records[3] = rec('/mnt/bad', 4);
+    const exec: SafeExec = vi.fn(async (argv: string[]) => {
+      const paths = argv.slice(1);
+      if (paths.includes('/mnt/bad')) {
+        return { stdout: '', stderr: 'sha256sum: /mnt/bad: I/O error', code: 1 };
+      }
+      return ok(paths.map(p => `${'d'.repeat(64)}  ${p}`).join('\n') + '\n');
+    });
+    const map = await hashRecords(exec, records);
+    // The bad file is skipped; every other file IS hashed.
+    expect(map.has('/mnt/bad')).toBe(false);
+    for (const r of records) {
+      if (r.sourcePath !== '/mnt/bad') expect(map.get(r.sourcePath)).toBe('d'.repeat(64));
+    }
+  });
+
+  it('survives a batch that TIMES OUT (exec rejects) by splitting + skipping', async () => {
+    // A timeout surfaces as a thrown exec (the agent rejects). The resilient path
+    // catches it, splits, and skips the offending file rather than letting the
+    // throw kill the background pass.
+    const records = [rec('/mnt/ok', 4), rec('/mnt/slow', 4)];
+    const exec: SafeExec = vi.fn(async (argv: string[]) => {
+      const paths = argv.slice(1);
+      if (paths.includes('/mnt/slow')) throw new Error('safe_exec: timed out after 30000ms');
+      return ok(paths.map(p => `${'e'.repeat(64)}  ${p}`).join('\n') + '\n');
+    });
+    const map = await hashRecords(exec, records);
+    expect(map.get('/mnt/ok')).toBe('e'.repeat(64));
+    expect(map.has('/mnt/slow')).toBe(false);
   });
 });

--- a/packages/backend/src/lib/diskImport/hostScan.ts
+++ b/packages/backend/src/lib/diskImport/hostScan.ts
@@ -124,24 +124,98 @@ export function parseFindOutput(stdout: string): ScannedFile[] {
 export const HASH_BATCH_SIZE = 256;
 
 /**
+ * Byte cap for a single `sha256sum` batch (#1937). The fixed 256-file count cap
+ * alone blew up on real media: a batch that lands on a run of large videos
+ * (each GBs) had to read hundreds of GB through `sha256sum` in ONE host call and
+ * blew the exec timeout → the batch threw → the whole scan died ("failed after
+ * ~130k files"). So a batch is flushed at {@link HASH_BATCH_SIZE} files OR when
+ * its accumulated `record.size` reaches this cap, whichever comes first. 768 MB
+ * is comfortably hashable within {@link batchTimeoutMs} even on slow USB media
+ * (a few GB/min), so a batch of big videos contains just a handful of files.
+ * Only the byte-aware {@link hashRecords} path knows sizes; the raw
+ * {@link hashPaths} path (no sizes) keeps the count-only cap.
+ */
+export const HASH_BATCH_BYTES = 768 * 1024 * 1024;
+
+/**
+ * Per-batch exec timeout (#1937). The agent's `safe_exec` default (~30s) is far
+ * too short for a media batch — hashing up to {@link HASH_BATCH_BYTES} off slow
+ * USB at a few GB/min wants minutes, not seconds. We pass an explicit, generous
+ * timeout that scales with the batch's byte budget (a small floor for tiny
+ * batches). A batch that STILL times out is split + retried (never fatal).
+ */
+export const HASH_BATCH_TIMEOUT_FLOOR_MS = 60_000;
+
+/** Generous timeout for a batch carrying `bytes` of content: floor + ~1 min per
+ *  256 MB. Keeps even a worst-case (cap-sized) batch from spuriously timing out
+ *  on slow media, while a tiny batch still gets a sane floor. */
+function batchTimeoutMs(bytes: number): number {
+  return HASH_BATCH_TIMEOUT_FLOOR_MS + Math.ceil(bytes / (256 * 1024 * 1024)) * 60_000;
+}
+
+/**
  * Build a dedup {@link import('./dedup').HashResolver} backed by host-side
  * `sha256sum` over the read-only mount. dedup only calls this for size-collision
  * candidates, so the host doesn't hash every file. Synchronous-looking resolver
  * contract: we pre-hash the candidate set up front (batched passes) so the
  * deterministic engine can stay synchronous.
  *
- * Throughput (#1898): paths are hashed in {@link HASH_BATCH_SIZE} chunks — one
- * `sha256sum <p1> <p2> …` agent round-trip per chunk, not one per file. The
- * hashes are byte-for-byte identical to the per-file path; only the number of
- * round-trips changes. `onProgress` still fires once per file so the card's live
- * `hashed/total` count advances smoothly within a chunk.
+ * Throughput (#1898): paths are hashed in batches — one `sha256sum <p1> <p2> …`
+ * agent round-trip per batch, not one per file.
+ *
+ * Resilience (#1937): this size-aware path flushes a batch at
+ * {@link HASH_BATCH_SIZE} files OR {@link HASH_BATCH_BYTES} bytes (so a batch of
+ * large media stays small + within the time budget), passes an explicit generous
+ * {@link batchTimeoutMs}, and on a batch failure (timeout / non-zero exit) RETRIES
+ * by splitting the batch down to per-file; a file that STILL fails is SKIPPED
+ * (omitted from the map → simply not deduped) with a warning, never thrown. The
+ * caller (a background pass since #1937) must survive a hashing hiccup, so this
+ * degrades dedup gracefully instead of killing the scan.
+ *
+ * `onProgress` still fires once per (attempted) file so the card's live
+ * `hashed/total` count advances smoothly.
  */
 export async function hashRecords(
   exec: SafeExec,
   records: ImportRecord[],
   onProgress?: (hashed: number, total: number) => void,
 ): Promise<Map<string, string>> {
-  return hashPaths(exec, records.map(r => r.sourcePath), onProgress);
+  const out = new Map<string, string>();
+  if (records.length === 0) return out;
+  for (const r of records) {
+    if (r.sourcePath.includes('\0')) throw new Error('disk-import: NUL byte in source path');
+  }
+  const total = records.length;
+  let processed = 0;
+  let batch: ImportRecord[] = [];
+  let batchBytes = 0;
+  const flush = async (): Promise<void> => {
+    if (batch.length === 0) return;
+    const paths = batch.map(r => r.sourcePath);
+    const resolved = await hashBatchResilient(exec, paths, batchTimeoutMs(batchBytes));
+    for (const [p, hex] of resolved) out.set(p, hex);
+    processed += batch.length;
+    onProgress?.(processed, total);
+    batch = [];
+    batchBytes = 0;
+  };
+  for (const r of records) {
+    const size = Math.max(0, r.size);
+    // Flush BEFORE adding when this record would push a NON-EMPTY batch over the
+    // byte cap — so a run of large media yields one-file batches (each comfortably
+    // under the exec timeout) instead of a doomed mega-batch. A single record
+    // larger than the cap still goes alone (it can't be split further).
+    if (batch.length > 0 && batchBytes + size > HASH_BATCH_BYTES) {
+      await flush();
+    }
+    batch.push(r);
+    batchBytes += size;
+    if (batch.length >= HASH_BATCH_SIZE) {
+      await flush();
+    }
+  }
+  await flush();
+  return out;
 }
 
 /**
@@ -153,6 +227,11 @@ export async function hashRecords(
  * escapes `\`→`\\`, `\n`→`\\n`); we undo that escaping so the map keys match the
  * paths we passed in. `onProgress` (optional) fires once per file so a live
  * `hashed/total` count still advances within a chunk. Empty input → no round-trip.
+ *
+ * No `record.size` is available on this raw-path entry (the apply top-up), so it
+ * keeps the count-only batch cap. It still retries-splits a failing batch and
+ * skips a persistently-failing file (#1937) — a missing apply-hash is handled by
+ * the caller's resolver (it only needs hashes for write targets).
  */
 export async function hashPaths(
   exec: SafeExec,
@@ -165,25 +244,68 @@ export async function hashPaths(
     if (p.includes('\0')) throw new Error('disk-import: NUL byte in source path');
   }
   const total = paths.length;
-  let hashed = 0;
+  let processed = 0;
   for (let i = 0; i < paths.length; i += HASH_BATCH_SIZE) {
     const chunk = paths.slice(i, i + HASH_BATCH_SIZE);
-    const byPath = parseSha256sumOutput(await runSha256sum(exec, chunk));
-    for (const p of chunk) {
-      const hex = byPath.get(p);
-      if (hex === undefined) {
-        throw new Error(`disk-import: sha256sum returned no hash for ${JSON.stringify(p)}`);
-      }
-      out.set(p, hex);
-      hashed += 1;
-      onProgress?.(hashed, total);
-    }
+    const resolved = await hashBatchResilient(exec, chunk, batchTimeoutMs(0));
+    for (const [p, hex] of resolved) out.set(p, hex);
+    processed += chunk.length;
+    onProgress?.(processed, total);
   }
   return out;
 }
 
-async function runSha256sum(exec: SafeExec, paths: string[]): Promise<string> {
-  const { stdout, code, stderr } = await exec(['sha256sum', ...paths]);
+/**
+ * Hash one batch of paths resiliently (#1937). One `sha256sum` round-trip with an
+ * explicit `timeoutMs`; a NON-FATAL failure (timeout / non-zero exit / a path the
+ * tool omitted) is recovered by SPLITTING the batch (halve, down to per-file) and
+ * retrying each half. A single path that still fails at width 1 is SKIPPED
+ * (omitted from the returned map → simply not deduped) with a warning. Never
+ * throws for a hashing failure — the scan/review (already rendered, #1937 Part A)
+ * must survive a hash-pass hiccup.
+ */
+async function hashBatchResilient(
+  exec: SafeExec,
+  paths: string[],
+  timeoutMs: number,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (paths.length === 0) return out;
+  try {
+    const byPath = parseSha256sumOutput(await runSha256sum(exec, paths, timeoutMs));
+    let allPresent = true;
+    for (const p of paths) {
+      const hex = byPath.get(p);
+      if (hex === undefined) {
+        allPresent = false;
+        break;
+      }
+      out.set(p, hex);
+    }
+    if (allPresent) return out;
+    // The tool returned but omitted a requested path — fall through to split so
+    // the present paths in this batch still get hashed.
+    out.clear();
+  } catch {
+    // Timeout / non-zero exit / transport error — recover by splitting.
+  }
+
+  if (paths.length === 1) {
+    // A single file that still fails: skip its hash (it just isn't deduped).
+    // eslint-disable-next-line no-console
+    console.warn(`disk-import: skipping un-hashable file (left un-deduped): ${JSON.stringify(paths[0])}`);
+    return out;
+  }
+  const mid = Math.ceil(paths.length / 2);
+  const left = await hashBatchResilient(exec, paths.slice(0, mid), timeoutMs);
+  const right = await hashBatchResilient(exec, paths.slice(mid), timeoutMs);
+  for (const [p, h] of left) out.set(p, h);
+  for (const [p, h] of right) out.set(p, h);
+  return out;
+}
+
+async function runSha256sum(exec: SafeExec, paths: string[], timeoutMs?: number): Promise<string> {
+  const { stdout, code, stderr } = await exec(['sha256sum', ...paths], { timeoutMs });
   if (code !== 0) {
     throw new Error(`disk-import: sha256sum failed (code ${code}): ${stderr}`);
   }
@@ -211,8 +333,19 @@ function parseSha256sumOutput(stdout: string): Map<string, string> {
   return out;
 }
 
-/** Hash one source file's bytes via host `sha256sum` (read-only). */
+/**
+ * Hash one source file's bytes via host `sha256sum` (read-only). STRICT (unlike
+ * the batched {@link hashPaths}/{@link hashRecords}, which skip a persistently-
+ * failing file): a single explicit hash request must succeed or throw, so a
+ * caller asking for exactly one hash gets a clear failure rather than a silent
+ * `undefined`.
+ */
 export async function hashSourceFile(exec: SafeExec, sourcePath: string): Promise<string> {
-  const byPath = await hashPaths(exec, [sourcePath]);
-  return byPath.get(sourcePath)!;
+  if (sourcePath.includes('\0')) throw new Error('disk-import: NUL byte in source path');
+  const byPath = parseSha256sumOutput(await runSha256sum(exec, [sourcePath]));
+  const hex = byPath.get(sourcePath);
+  if (hex === undefined) {
+    throw new Error(`disk-import: sha256sum returned no hash for ${JSON.stringify(sourcePath)}`);
+  }
+  return hex;
 }

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -130,6 +130,9 @@ describe('scanDevice', () => {
     expect(result.categories.some(c => c.category === 'junk')).toBe(false);
     expect(result.categories.find(c => c.category === 'documents')?.files).toBe(2);
 
+    // Hashing now runs in the BACKGROUND (#1937 review-first) — wait for the
+    // dedup pass to finish, then assert WHAT it hashed.
+    await waitFor(async () => (await getImportJob(result.sessionId))!.dedup === 'done');
     // The junk paths were never handed to sha256sum (not hashed).
     const junkPaths = ['/mnt/proj/node_modules/react/index.js', '/mnt/proj/.git/objects/ab/cdef', '/mnt/docs/Thumbs.db'];
     for (const p of junkPaths) expect(hashed).not.toContain(p);
@@ -151,6 +154,89 @@ describe('scanDevice', () => {
     // (defaulted to documents), so the action annotates rather than blocks.
     expect(result.totalFiles).toBe(3);
     expect(result.categories.some(c => c.category === 'documents')).toBe(true);
+  });
+});
+
+describe('runScan — review-first, background dedup (#1937)', () => {
+  it('reaches reviewed WITH the tree BEFORE hashing — dedup is pending while reviewed', async () => {
+    // Two same-size docs size-collide → they're dedup candidates that must be
+    // hashed. We GATE sha256sum so the background hash pass blocks, then assert
+    // the session is already `reviewed` (tree rendered) with `dedup: pending` —
+    // i.e. the review does NOT wait on hashing.
+    const find = [
+      '/mnt/docs/a.pdf\t100\t1700000000',
+      '/mnt/docs/b.pdf\t100\t1700000001', // same size → collision candidate
+    ].join('\0') + '\0';
+    let releaseHash!: () => void;
+    const hashGate = new Promise<void>(r => { releaseHash = r; });
+    let hashCalled = false;
+    const exec: SafeExec = vi.fn(async (argv: string[]) => {
+      if (argv[0] === 'sha256sum') {
+        hashCalled = true;
+        await hashGate; // block the background hash pass until we release it
+        return ok(argv.slice(1).map((p, i) => `${String(i).repeat(64).slice(0, 63)}0  ${p}`).join('\n') + '\n');
+      }
+      if (argv[0] === 'find') return ok(find);
+      return ok();
+    });
+
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+
+    // The scan flips to `reviewed` with the full tree while hashing is STILL
+    // blocked — the review precedes the hash pass.
+    await waitFor(async () => (await getImportJob(jobId))!.phase === 'reviewed');
+    const reviewed = await getImportJob(jobId);
+    expect(reviewed!.phase).toBe('reviewed');
+    expect(reviewed!.review).toBeDefined();
+    expect(reviewed!.review!.totalFiles).toBe(2);
+    expect(reviewed!.review!.tree.length).toBeGreaterThan(0); // tree is rendered
+    // Dedup has NOT completed — it's pending or running, gated on the hash pass.
+    expect(['pending', 'running']).toContain(reviewed!.dedup);
+
+    // Now let the background hash pass proceed → dedup completes to `done`.
+    releaseHash();
+    await waitFor(async () => (await getImportJob(jobId))!.dedup === 'done');
+    expect(hashCalled).toBe(true);
+    const done = await getImportJob(jobId);
+    expect(done!.phase).toBe('reviewed'); // still reviewed, just deduped now
+    expect(done!.dedup).toBe('done');
+  });
+
+  it('marks dedup done immediately when there is nothing to hash (no size collisions)', async () => {
+    // Distinct-size files → no dedup candidates → no background hash pass needed.
+    const find = [
+      '/mnt/docs/a.pdf\t100\t1700000000',
+      '/mnt/docs/b.pdf\t200\t1700000001',
+    ].join('\0') + '\0';
+    const { exec, calls } = mockExec({ find: ok(find) });
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+    await waitFor(async () => (await getImportJob(jobId))!.phase === 'reviewed');
+    const job = await getImportJob(jobId);
+    expect(job!.dedup).toBe('done');
+    // Nothing was hashed (no candidates).
+    expect(calls.some(c => c[0] === 'sha256sum')).toBe(false);
+  });
+
+  it('survives a background hash failure: review stays up, dedup → partial (#1937 Part B)', async () => {
+    // Two same-size docs collide → hashed. sha256sum fails at every width → the
+    // resilient pass skips both, the dedup pass reports `partial`, and the review
+    // is unaffected (the scan does NOT error).
+    const find = [
+      '/mnt/docs/a.pdf\t100\t1700000000',
+      '/mnt/docs/b.pdf\t100\t1700000001',
+    ].join('\0') + '\0';
+    const exec: SafeExec = vi.fn(async (argv: string[]) => {
+      if (argv[0] === 'sha256sum') return { stdout: '', stderr: 'I/O error', code: 1 };
+      if (argv[0] === 'find') return ok(find);
+      return ok();
+    });
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+    await waitFor(async () => ['done', 'partial'].includes((await getImportJob(jobId))!.dedup!));
+    const job = await getImportJob(jobId);
+    // The hash pass failed, but the scan did NOT error — review is intact.
+    expect(job!.phase).toBe('reviewed');
+    expect(job!.review!.totalFiles).toBe(2);
+    expect(job!.dedup).toBe('partial');
   });
 });
 

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -39,6 +39,10 @@ import type { RoutingResolution } from './dedup';
 import {
   createScanJob,
   finalizeScan,
+  finalizeDedup,
+  startDedup,
+  setDedupProgress,
+  markDedupPartial,
   getSession,
   markApplied,
   markApplying,
@@ -47,6 +51,7 @@ import {
   sessionHashes,
   appendLog,
   type ScanSession,
+  type DedupState,
   __clearSessions as clearSessionStore,
 } from './sessionStore';
 import type { SafeExec } from './hostExec';
@@ -250,46 +255,35 @@ export async function startScan(opts: ScanOptions): Promise<{ jobId: string }> {
 }
 
 /**
- * The scan work proper: mount → walk → hash → plan → finalize the session. Runs
- * either inline ({@link scanDevice}) or as the detached body of {@link startScan}.
- * Streams progress into the session as it goes (step + scanned/hashed counts).
+ * The scan work proper. Review-first (#1937): mount → walk → classify + plan on
+ * METADATA ONLY (no hashes, dedup deferred) → finalize the session to `reviewed`
+ * with the routing tree IMMEDIATELY so the card renders in seconds even on a
+ * 177k-file disk; THEN hash the size-collision candidates in the BACKGROUND and
+ * re-finalize the plan with real dedup decisions (the card polls `dedup`). Runs
+ * inline ({@link scanDevice}) or as the detached body of {@link startScan}.
+ *
+ * Why this is safe: the apply path's `topUpHashes` re-hashes copy targets and the
+ * catalog dedups AT APPLY, so deferring scan-time dedup loses nothing — a first/
+ * sparse import dedups correctly when applied. A background hash failure (Part B)
+ * degrades dedup to `partial` rather than killing the already-rendered review.
  */
 async function runScan(sessionId: string, opts: ScanOptions): Promise<ScanResult> {
   const { exec, device, catalogPath } = opts;
   await setProgress(sessionId, { step: 'mount' });
   const mountpoint = await mountReadOnly(exec, device);
+  // Set in the try-body when there are size-collision candidates; the `finally`
+  // releases the mount FIRST, then schedules this background dedup pass (#1937).
+  let pendingDedup: Parameters<typeof runBackgroundDedup>[0] | undefined;
   try {
     await setProgress(sessionId, { step: 'walk' });
     const files = await scanMount(exec, mountpoint);
-    // Drop junk records BEFORE the expensive size-collision/hash pass (#1932).
-    // Junk subtrees (node_modules/.git/…) are already pruned at the `find` walk;
-    // this is belt-and-suspenders for the junk a path-prune can't express —
-    // junk NAMES (thumbs.db/.ds_store) and junk EXTENSIONS (tmp/cache/…), plus
-    // any junk-named file outside a junk dir. The kept set is what the plan
-    // sees, so classification/dedup/counts stay junk-free and consistent (the
-    // plan simply never produces a `skip-junk` item for a pre-filtered record).
+    // Drop junk records BEFORE planning (#1932). Junk subtrees (node_modules/.git
+    // /bower_components/…) are already pruned at the `find` walk; this is belt-
+    // and-suspenders for the junk a path-prune can't express — junk NAMES
+    // (thumbs.db/.ds_store) and junk EXTENSIONS (tmp/cache/…). The kept set is
+    // what the plan sees, so classification/counts stay junk-free.
     const records = buildInventory(files).filter(r => !isJunk(r));
-    // `scanned` reflects the KEPT (non-junk) records — the real candidate set.
-    await setProgress(sessionId, { step: 'hash', scanned: records.length });
-
-    // Pre-hash only the size-collision candidates host-side, then hand dedup a
-    // synchronous resolver over the resulting map (the engine stays sync). With
-    // junk pruned the residual real-content candidate set is small, so a single
-    // blocking hash pass suffices; background/non-blocking hashing is a planned
-    // follow-up UX (tracked under #1932) and intentionally NOT done here.
-    const candidates = sizeCollisionCandidates(records);
-    const hashes = await hashRecords(exec, candidates, (hashed, total) => {
-      void setProgress(sessionId, { hashed, total });
-    });
-    const hashOf: HashResolver = record => {
-      const h = hashes.get(record.sourcePath);
-      if (h === undefined) {
-        throw new Error(`disk-import: missing pre-computed hash for ${record.sourcePath}`);
-      }
-      return h;
-    };
-
-    await setProgress(sessionId, { step: 'plan' });
+    await setProgress(sessionId, { step: 'plan', scanned: records.length });
 
     // #1915: seed the routing tree from the box-user list — a top-level source
     // dir named EXACTLY like a box user is pre-assigned that owner (overridable
@@ -297,32 +291,123 @@ async function runScan(sessionId: string, opts: ScanOptions): Promise<ScanResult
     const boxUsers = opts.boxUsers ?? [];
     const explicit = seedAutoOwners(records, mountpoint, boxUsers);
     const routing = buildRouting(mountpoint, Object.fromEntries(explicit), 'shared');
+    const hints = buildSubtreeHints(records);
 
-    const catalog = new ImportCatalog(catalogPath);
-    let plan: ImportPlan;
-    try {
-      // #1914: tag video-dominant folders so their videos route to `movies/`
-      // (Jellyfin) while camera-roll clips stay `photos`/Immich.
-      const hints = buildSubtreeHints(records);
-      plan = buildPlan(records, hashOf, { catalog, hints, routing });
-    } finally {
-      catalog.close();
-    }
+    // 1. METADATA-ONLY plan (#1937): no hashes yet. `metadataHashOf` hands every
+    //    record a UNIQUE token, so no two files are ever judged identical — dedup
+    //    is effectively off and every kept file is `copy` (a real same-target
+    //    collision still surfaces as a conflict, which doesn't need a hash). This
+    //    is what renders the tree in seconds.
+    const planNoDedup = buildPlanWithCatalog(records, metadataHashOf, catalogPath, { hints, routing });
+
+    // The size-collision candidates are the ONLY files dedup ever hashes. Compute
+    // the set up front so we can both decide the initial dedup state and drive
+    // the background pass.
+    const candidates = sizeCollisionCandidates(records);
 
     await finalizeScan(sessionId, {
-      plan,
-      hashes,
+      plan: planNoDedup,
+      hashes: new Map(),
       mountpoint,
       boxUsers: [...boxUsers],
       autoRules: Object.fromEntries(explicit),
+      // Nothing to hash → dedup is already final; otherwise the card shows
+      // "checking duplicates…" while the background pass runs.
+      dedup: candidates.length === 0 ? 'done' : 'pending',
+      dedupTotal: candidates.length,
     });
 
-    return buildScanResult({ sessionId, device, plan, records, mountpoint, explicit, boxUsers });
+    if (candidates.length > 0) {
+      pendingDedup = { sessionId, exec, device, records, candidates, hints, routing, catalogPath };
+    }
+
+    return buildScanResult({ sessionId, device, plan: planNoDedup, records, mountpoint, explicit, boxUsers });
   } finally {
-    // Always release the read-only mount; a failed scan must not leave it held.
+    // Always release the read-only mount once the walk+metadata plan is done; a
+    // failed scan must not leave it held. The background dedup pass (#1937)
+    // re-mounts the same controlled mountpoint itself to read the bytes, so the
+    // scan's mount lifetime stays self-contained (no cross-task mount ownership).
     await unmount(exec, mountpoint).catch(() => {});
+
+    // BACKGROUND dedup (#1937): hash the candidates, re-plan with real hashes,
+    // re-finalize. Scheduled AFTER the mount is released; it re-mounts read-only
+    // for its own pass. Detached so the review is already returned/rendered; a
+    // hash failure (Part B) degrades dedup to `partial`, never kills the scan.
+    if (pendingDedup) {
+      void runBackgroundDedup(pendingDedup);
+    }
   }
 }
+
+/**
+ * Background dedup pass (#1937). Re-mounts the device read-only, hashes the
+ * size-collision candidates, re-builds the plan with the REAL content hashes (so
+ * skip-dupe decisions resolve), and re-finalizes the reviewed session — all while
+ * the card already shows the tree. ALWAYS unmounts. Resilient: a file the hash
+ * pass couldn't hash (Part B skip) is simply absent from the map, so it routes to
+ * `copy` (un-deduped) and the run is reported `partial`. Never throws into the
+ * void (the review is already rendered; a dedup hiccup is non-fatal).
+ */
+async function runBackgroundDedup(args: {
+  sessionId: string;
+  exec: SafeExec;
+  device: string;
+  records: readonly ImportRecord[];
+  candidates: ImportRecord[];
+  hints: PlanHints;
+  routing: RoutingResolution;
+  catalogPath: string;
+}): Promise<void> {
+  const { sessionId, exec, device, records, candidates, hints, routing, catalogPath } = args;
+  let mountpoint: string | undefined;
+  try {
+    await startDedup(sessionId, candidates.length);
+    mountpoint = await mountReadOnly(exec, device);
+    const hashes = await hashRecords(exec, candidates, (hashed, total) => {
+      void setDedupProgress(sessionId, hashed, total);
+    });
+    // A candidate missing from the map was skipped by the resilient hash pass
+    // (Part B) — route it as a plain copy (un-deduped) rather than throwing. The
+    // run is `partial` when any candidate couldn't be hashed.
+    const hashOf: HashResolver = record => hashes.get(record.sourcePath) ?? uniqueToken(record);
+    const allHashed = candidates.every(c => hashes.has(c.sourcePath));
+    const plan = buildPlanWithCatalog([...records], hashOf, catalogPath, { hints, routing });
+    await finalizeDedup(sessionId, { plan, hashes, state: allHashed ? 'done' : 'partial' });
+  } catch (e) {
+    // The review is already rendered; a dedup-pass failure must not error the
+    // session. Mark dedup `partial` (import un-deduped; apply re-dedups) + log.
+    await appendLog(sessionId, `dedup pass failed (review unaffected): ${e instanceof Error ? e.message : String(e)}`);
+    await markDedupPartial(sessionId);
+  } finally {
+    if (mountpoint) await unmount(exec, mountpoint).catch(() => {});
+  }
+}
+
+/** Build a plan against a freshly-opened catalog (always closed). Shared by the
+ *  metadata-only pass and the background dedup pass. */
+function buildPlanWithCatalog(
+  records: ImportRecord[],
+  hashOf: HashResolver,
+  catalogPath: string,
+  opts: { hints: PlanHints; routing: RoutingResolution },
+): ImportPlan {
+  const catalog = new ImportCatalog(catalogPath);
+  try {
+    return buildPlan(records, hashOf, { catalog, hints: opts.hints, routing: opts.routing });
+  } finally {
+    catalog.close();
+  }
+}
+
+type PlanHints = ReturnType<typeof buildSubtreeHints>;
+
+/** A per-record unique token used where dedup must be effectively OFF (the
+ *  metadata-only plan, and an un-hashable candidate): no two records ever match,
+ *  so everything routes to `copy`. Stable per path so repeated builds agree. */
+function uniqueToken(record: ImportRecord): string {
+  return `nohash:${record.sourcePath}`;
+}
+const metadataHashOf: HashResolver = uniqueToken;
 
 /** Assemble the review {@link ScanResult} the card shows from a finished scan. */
 function buildScanResult(args: {
@@ -506,6 +591,18 @@ export interface ImportJobStatus {
   review?: ScanResult;
   /** Files written this apply, present once `applied`. */
   applied?: number;
+  /**
+   * Background-dedup sub-state (#1937). Once `reviewed`, this tells the card
+   * whether the duplicate check is still running so it can show a non-blocking
+   * "checking duplicates… N / M" line WITHOUT gating the (already-rendered) tree.
+   * `done`/`partial` = the dedup preview is final. Defaults to `done` for a
+   * pre-#1937 session that has no `dedup` field.
+   */
+  dedup?: DedupState;
+  /** Candidate files hashed so far / total candidates for the background dedup
+   *  pass (#1937) — drives the "checking duplicates… N / M" line. */
+  dedupHashed?: number;
+  dedupTotal?: number;
 }
 
 export async function getImportJob(sessionId: string): Promise<ImportJobStatus | null> {
@@ -518,6 +615,11 @@ export async function getImportJob(sessionId: string): Promise<ImportJobStatus |
     progress: s.progress,
     error: s.error,
     applied: s.applied,
+    // A reopened card re-attaches whether dedup is still pending/running or done
+    // (#1937). Pre-#1937 sessions have no `dedup` → treat as already done.
+    dedup: s.plan ? s.dedup ?? 'done' : undefined,
+    dedupHashed: s.dedupHashed ?? 0,
+    dedupTotal: s.dedupTotal ?? 0,
   };
   if (s.plan) {
     const records = s.plan.items.map(i => i.record);

--- a/packages/backend/src/lib/diskImport/sessionStore.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.ts
@@ -69,6 +69,24 @@ export type SessionStep =
   | 'copy'
   | 'done';
 
+/**
+ * Dedup sub-state (#1937). The scan now flips to `reviewed` on METADATA ONLY (so
+ * the routing tree renders in seconds), then hashes the size-collision candidates
+ * in the BACKGROUND to fill in skip-dupe decisions. This tracks that background
+ * pass so the card can show a non-blocking "checking duplicates…" secondary line
+ * WITHOUT gating the already-rendered tree:
+ *
+ *   pending  → reviewed, the background hash/dedup pass hasn't started yet
+ *   running  → hashing candidates now (progress.hashed/total advance)
+ *   done     → dedup complete; the plan's skip-dupe decisions are final
+ *   partial  → dedup finished but some files couldn't be hashed (skipped, #1937
+ *              Part B) — they're imported un-deduped (safe; apply re-dedups)
+ *
+ * A scan with no size-collision candidates (nothing to hash) is `done`
+ * immediately. Absent on pre-#1937 sessions → the card treats that as `done`.
+ */
+export type DedupState = 'pending' | 'running' | 'done' | 'partial';
+
 /** Live progress counters the status route exposes so the card can render a
  *  phase + counts instead of a bare spinner (#1897). All monotonic within a
  *  pass; `total` is the denominator once known (0 until the walk finishes). */
@@ -117,6 +135,19 @@ export interface ScanSession {
    *  with the same pre-assignments. Absent while scanning. */
   autoRules?: Record<string, Rule>;
   phase: SessionPhase;
+  /**
+   * Background-dedup sub-state (#1937). Present once the scan reaches `reviewed`
+   * on metadata only; the background hash pass advances it pending → running →
+   * done/partial. Absent on pre-#1937 sessions (treat as `done`). The
+   * `dedupProgress` pair drives the card's "checking duplicates… N / M" line.
+   */
+  dedup?: DedupState;
+  /** How many candidate files have been hashed in the background dedup pass so
+   *  far (#1937), and the total candidate count. Both 0 when there's nothing to
+   *  hash. Separate from `progress` so the card can show dedup advancing while
+   *  the (already-rendered) tree's `progress.step` stays `done`. */
+  dedupHashed?: number;
+  dedupTotal?: number;
   /** Live progress for the in-flight (or last) pass (#1897). */
   progress: SessionProgress;
   /** How many files the apply wrote/uploaded (set when `applied`). */
@@ -280,7 +311,13 @@ export async function setProgress(
 }
 
 /** Background scan completed: attach the reviewed plan + hashes and flip to
- *  `reviewed` so the apply gate accepts it. */
+ *  `reviewed` so the apply gate accepts it.
+ *
+ *  Review-first (#1937): the scan now finalizes on METADATA ONLY (no hashes yet)
+ *  with `dedup: 'pending'` so the tree renders immediately; the background hash
+ *  pass then re-finalizes via {@link finalizeDedup}. A scan with nothing to dedup
+ *  passes `dedup: 'done'`. `hashes` is whatever's known so far (empty for the
+ *  metadata-only finalize). */
 export async function finalizeScan(
   id: string,
   input: {
@@ -289,8 +326,11 @@ export async function finalizeScan(
     mountpoint?: string;
     boxUsers?: string[];
     autoRules?: Record<string, Rule>;
+    dedup?: DedupState;
+    dedupTotal?: number;
   },
 ): Promise<ScanSession | null> {
+  const dedup = input.dedup ?? 'done';
   return updateSession(id, {
     plan: input.plan,
     hashes: Object.fromEntries(input.hashes),
@@ -298,6 +338,9 @@ export async function finalizeScan(
     boxUsers: input.boxUsers,
     autoRules: input.autoRules,
     phase: 'reviewed',
+    dedup,
+    dedupHashed: 0,
+    dedupTotal: input.dedupTotal ?? 0,
     progress: {
       step: 'done',
       scanned: input.plan.items.length,
@@ -307,6 +350,56 @@ export async function finalizeScan(
       total: input.plan.items.length,
     },
   });
+}
+
+/** Flip a `reviewed` session's dedup sub-state to `running` (the background hash
+ *  pass started, #1937). The tree stays rendered; only the secondary
+ *  "checking duplicates…" line changes. */
+export async function startDedup(id: string, total: number): Promise<ScanSession | null> {
+  return updateSession(id, { dedup: 'running', dedupHashed: 0, dedupTotal: total });
+}
+
+/** Live progress of the background dedup hash pass (#1937). Best-effort, like
+ *  {@link setProgress}; a lost tick is non-fatal. */
+export async function setDedupProgress(id: string, hashed: number, total: number): Promise<void> {
+  await withSessionWriteLock(id, async () => {
+    const current = await getSession(id);
+    if (!current) return;
+    const next: ScanSession = {
+      ...current,
+      dedupHashed: hashed,
+      dedupTotal: total,
+      updatedAt: new Date().toISOString(),
+      seenBy: PROCESS_STARTED_AT,
+    };
+    try {
+      await atomicWrite(statePath(id), JSON.stringify(next, null, 2));
+    } catch {
+      /* best-effort live dedup progress */
+    }
+  });
+}
+
+/** Background dedup pass completed (#1937): replace the metadata-only plan with
+ *  the re-deduped plan + the resolved hashes, and mark `done` (all candidates
+ *  hashed) or `partial` (some files were un-hashable → imported un-deduped).
+ *  Stays `reviewed` — this never gates apply, which re-dedups at the catalog. */
+export async function finalizeDedup(
+  id: string,
+  input: { plan: ImportPlan; hashes: Map<string, string>; state: DedupState },
+): Promise<ScanSession | null> {
+  return updateSession(id, {
+    plan: input.plan,
+    hashes: Object.fromEntries(input.hashes),
+    dedup: input.state,
+  });
+}
+
+/** Mark a session's background dedup pass as `partial` without touching the plan
+ *  (#1937) — used when the whole dedup pass threw. The metadata-only plan stays
+ *  (everything `copy`/un-deduped); apply re-dedups at the catalog. */
+export async function markDedupPartial(id: string): Promise<ScanSession | null> {
+  return updateSession(id, { dedup: 'partial' });
 }
 
 /** Flip a reviewed session into `applying` (the apply background pass started). */

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
@@ -119,6 +119,32 @@ describe('DiskImportReview (presentational)', () => {
     render(<DiskImportReview {...reviewProps} review={review} />);
     expect(screen.queryByTestId('disk-import-tree')).toBeNull();
   });
+
+  it('shows a NON-BLOCKING "checking duplicates…" line while dedup runs (#1937)', () => {
+    render(
+      <DiskImportReview
+        {...reviewProps}
+        review={review}
+        dedup={{ state: 'running', hashed: 7168, total: 155875 }}
+      />,
+    );
+    // The duplicate-check note shows progress, the tree/review is fully rendered,
+    // and Confirm is available — dedup never gates the review.
+    const note = screen.getByTestId('disk-import-dedup');
+    expect(note.textContent).toMatch(/checking for duplicates/i);
+    expect(note.textContent).toContain('7168 / 155875');
+    expect(screen.getByText(/Confirm & import/i)).toBeDefined();
+  });
+
+  it('shows nothing once dedup is done (no noise)', () => {
+    render(<DiskImportReview {...reviewProps} review={review} dedup={{ state: 'done', hashed: 5, total: 5 }} />);
+    expect(screen.queryByTestId('disk-import-dedup')).toBeNull();
+  });
+
+  it('warns when dedup was partial (some files un-checked → imported as-is)', () => {
+    render(<DiskImportReview {...reviewProps} review={review} dedup={{ state: 'partial', hashed: 3, total: 5 }} />);
+    expect(screen.getByTestId('disk-import-dedup').textContent).toMatch(/couldn't be checked/i);
+  });
 });
 
 describe('DiskImportTree (per-folder routing)', () => {

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
@@ -378,6 +378,36 @@ function DefaultOwnerPicker({
 }
 
 /** Presentational review: per-category sizing + the non-blocking actions[]. */
+/**
+ * Non-blocking duplicate-check line under the review header (#1937). Review-first:
+ * the tree is fully usable the moment the scan reviews; this just tells the user
+ * the duplicate preview is still filling in (or is done) — it never gates the
+ * tree or the Confirm button. `done` shows nothing (no noise); `pending`/`running`
+ * shows a "checking duplicates… N / M" note; `partial` notes some files couldn't
+ * be checked (they're imported un-deduped — apply re-dedups, so it's safe).
+ */
+function DedupNote({
+  dedup,
+}: {
+  dedup?: { state: 'pending' | 'running' | 'done' | 'partial'; hashed: number; total: number };
+}) {
+  if (!dedup || dedup.state === 'done') return null;
+  if (dedup.state === 'partial') {
+    return (
+      <p className="text-xs text-amber-600 dark:text-amber-400" data-testid="disk-import-dedup">
+        Some files couldn&apos;t be checked for duplicates — they&apos;ll be imported as-is (de-duplicated
+        on copy).
+      </p>
+    );
+  }
+  const count = dedup.total > 0 ? ` ${dedup.hashed} / ${dedup.total}` : '';
+  return (
+    <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="disk-import-dedup">
+      Checking for duplicates in the background…{count} You can review and import now.
+    </p>
+  );
+}
+
 export function DiskImportReview({
   review,
   rules,
@@ -387,6 +417,7 @@ export function DiskImportReview({
   onConfirm,
   onCancel,
   busy,
+  dedup,
 }: {
   review: ScanReview;
   rules: Record<string, Rule>;
@@ -396,6 +427,10 @@ export function DiskImportReview({
   onConfirm: () => void;
   onCancel: () => void;
   busy: boolean;
+  /** Non-blocking background-dedup status (#1937): the tree is fully reviewable
+   *  while duplicate detection finishes in the background. Omit on a pre-#1937
+   *  backend. */
+  dedup?: { state: 'pending' | 'running' | 'done' | 'partial'; hashed: number; total: number };
 }) {
   const boxUsers = review.boxUsers ?? [];
   return (
@@ -406,6 +441,7 @@ export function DiskImportReview({
           {review.totalFiles} files · {formatBytes(review.totalBytes)} from {review.device}. Nothing has
           been written yet.
         </p>
+        <DedupNote dedup={dedup} />
       </div>
 
       {(review.tree?.length ?? 0) > 0 && (
@@ -810,9 +846,20 @@ export default function DiskImportSection() {
     setReview, setApplied, setSelected, setRules, setDefaultOwner, refreshDevices,
   });
 
+  // Surface the background-dedup status (#1937) so the review shows a non-blocking
+  // "checking duplicates…" line while the tree is already fully usable.
+  const dedup = review && job.status?.phase === 'reviewed'
+    ? {
+        state: job.status.dedup ?? 'done',
+        hashed: job.status.dedupHashed ?? 0,
+        total: job.status.dedupTotal ?? 0,
+      }
+    : undefined;
+
   const reviewProps = review && {
     review, rules, defaultOwner, onRuleChange,
     onDefaultOwnerChange: setDefaultOwner, onConfirm: applyPlan, onCancel: reset, busy: false,
+    dedup,
   };
 
   return (

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/useImportJob.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/useImportJob.ts
@@ -40,6 +40,12 @@ export interface ScanReviewLike {
   defaultOwner?: string;
 }
 
+/** Background-dedup sub-state (#1937). The scan renders the tree at `reviewed`
+ *  immediately and hashes/dedups in the BACKGROUND; this drives a non-blocking
+ *  "checking duplicates… N / M" line WITHOUT gating the tree. Absent on a
+ *  pre-#1937 backend → treat as `done`. */
+export type DedupState = 'pending' | 'running' | 'done' | 'partial';
+
 /** The status-route payload the card polls. */
 export interface JobStatus {
   sessionId: string;
@@ -49,6 +55,10 @@ export interface JobStatus {
   error?: string;
   review?: ScanReviewLike;
   applied?: number;
+  /** Background-dedup sub-state (#1937) + its hashed/total counters. */
+  dedup?: DedupState;
+  dedupHashed?: number;
+  dedupTotal?: number;
 }
 
 /** Which background pass we're tracking — routes a terminal status. */
@@ -122,8 +132,15 @@ export interface UseImportJob {
  *  a TERMINAL phase (the caller stops polling); false to keep polling. */
 function routeStatus(s: JobStatus, kind: JobKind | null, h: ImportJobHandlers): boolean {
   if (s.phase === 'reviewed') {
+    // Review-first (#1937): hand the card the tree the MOMENT the scan reviews,
+    // even though background dedup may still be running. Keep polling while
+    // dedup is pending/running so the "checking duplicates…" line fills in live;
+    // only treat the scan as terminal once dedup is done/partial. (Pre-#1937
+    // backends have no `dedup` → treat as done = terminal immediately.)
     h.onReviewed(s.review ?? null);
-    return kind !== 'applying'; // mid-apply a reviewed re-read isn't terminal
+    if (kind === 'applying') return false; // mid-apply a reviewed re-read isn't terminal
+    const dedup = s.dedup ?? 'done';
+    return dedup === 'done' || dedup === 'partial';
   }
   if (s.phase === 'applied') {
     h.onApplied(s.applied ?? 0);


### PR DESCRIPTION
Fixes #1937. On a real ~177k-file USB the disk-import scan still **blocked** the review on a full up-front hash pass AND **crashed** ("failed after ~130k files") when a `sha256sum` batch hit large media and exceeded the ~30s `safe_exec` timeout. Three independent fixes:

## Part A — review-first (background hashing)
`runScan` now: mount → walk (pruned) → classify + build the routing tree + per-category counts + the plan on **metadata only** (no hashes; dedup deferred) → flip the session to `reviewed` with the tree **immediately**, so the card renders in seconds regardless of file count. The size-collision hash pass then runs **in the background**, re-plans with real hashes, and updates the session.

- New session sub-state `dedup: pending | running | done | partial` (+ `dedupHashed`/`dedupTotal`) drives a **non-blocking** "checking duplicates… N / M" line under the review header — never a gate on the tree or the Confirm button.
- Deferring scan-time dedup is safe: apply's `topUpHashes` re-hashes copy targets and the catalog dedups **at apply**, so a first/sparse import dedups correctly when applied.
- A reopened/reloaded card re-attaches whether dedup is still pending/running or done (`getImportJob` surfaces `dedup`; the poll keeps polling at `reviewed` until dedup is done/partial).

## Part B — resilient hashing (THE crash fix)
- **Byte-aware batching**: `hashRecords` flushes a `sha256sum` batch at `HASH_BATCH_SIZE` files **OR** a ~768 MB byte cap (`record.size`), whichever first — a batch of big videos holds just a handful of files. `hashPaths` (no sizes, apply top-up) keeps the count-only cap.
- **Explicit generous `timeoutMs`**: each batch exec passes a timeout that scales with batch bytes (floor 60s) instead of the ~30s default that's far too short for media.
- **Non-fatal batch failure**: a batch that times out / exits non-zero / omits a path is **retried by splitting** (halve → per-file); a file that still fails is **skipped** (omitted from the hash map → simply not deduped) with a warning, **never thrown**. The hard-throw in `runSha256sum`'s caller no longer kills the scan — the already-rendered review survives a hashing hiccup (run reported `partial`). `hashSourceFile` stays strict (single explicit hash must succeed or throw).

## Part C — wider junk prune
`JUNK_PATH_SEGMENTS` (single-sourced → find-prune + pre-hash `isJunk`) gains: `bower_components` (~5.6k checked-in Polymer deps — biggest on the user's disk), `vendor`, `dist`, `build`, `.next`, `.nuxt`, `.gradle`, `.cache`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.tox`, `.svn`, `.hg`.

## Tests
- `runScan`: session reaches `reviewed` **with the tree** while hashing is still gated (dedup pending/running), then dedup fills in to `done`; no-collision scan is `done` immediately; a background hash failure leaves the review up with `dedup: partial`.
- `hostScan`: byte-aware batching splits big-media records into per-file `sha256sum` calls; explicit `timeoutMs` (> 30s) is passed; a failing/timing-out batch is retried-split and a persistently-failing file is skipped (not thrown).
- `classify`/find-prune: the new junk names are pruned at the walk + dropped before hashing.
- Existing plan/routing/dedup/registry suites unchanged (updated only the two assertions that encoded the old blocking-hash + throw-on-failure behavior).

## Gates
`npm run lint` (0 err, 339 warn ≤ 339), `npm run check:arch`, diskImport vitest suites + frontend DiskImportSection (243 + 16 pass), `vitest run --changed` (202 pass).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
