### PR TITLE
fix(disk-import): self-heal pre-#1912 catalog missing `area` column (#1940)

### DIFF
--- a/packages/backend/src/lib/diskImport/catalog.test.ts
+++ b/packages/backend/src/lib/diskImport/catalog.test.ts
@@ -78,6 +78,66 @@ describe('ImportCatalog — in-memory round-trips', () => {
   });
 });
 
+describe('ImportCatalog — self-heals a pre-#1912 schema (no `area` column)', () => {
+  let tmpDir: string;
+  afterEach(async () => {
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('adds the missing `area` column on open and dedup then works', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'diskimport-cat-old-'));
+    const dbPath = path.join(tmpDir, 'catalog.db');
+
+    // Build the ORIGINAL (#1693) catalog shape — no `area`, PK (sha256, target) —
+    // and seed a row, exactly like a box created before #1912.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    const raw = new Database(dbPath);
+    raw.exec(`
+      CREATE TABLE import_catalog (
+        sha256          TEXT NOT NULL,
+        target          TEXT NOT NULL,
+        source_path     TEXT NOT NULL,
+        size            INTEGER NOT NULL,
+        imported_at_ms  INTEGER NOT NULL,
+        PRIMARY KEY (sha256, target)
+      );
+    `);
+    raw
+      .prepare(
+        'INSERT INTO import_catalog (sha256, target, source_path, size, imported_at_ms) VALUES (?, ?, ?, ?, ?)',
+      )
+      .run('a'.repeat(64), 'photos/IMG_0001.jpg', '/disk/IMG_0001.jpg', 1234, 1000);
+    // Sanity: the old table really has no `area` column.
+    const before = (raw.prepare('PRAGMA table_info(import_catalog)').all() as { name: string }[]).map(
+      c => c.name,
+    );
+    expect(before).not.toContain('area');
+    raw.close();
+
+    // Opening through ImportCatalog must self-heal — no `no such column: area`.
+    const cat = new ImportCatalog(dbPath);
+
+    // The legacy row is preserved and backfilled to the default area.
+    expect(cat.count()).toBe(1);
+    expect(cat.get('a'.repeat(64), 'photos/IMG_0001.jpg')?.area).toBe('shared');
+    // Area-scoped dedup queries (which reference the new column) work.
+    expect(cat.has('a'.repeat(64), 'photos/IMG_0001.jpg', 'shared')).toBe(true);
+    expect(cat.getByTarget('photos/IMG_0001.jpg', 'shared')?.area).toBe('shared');
+
+    // A fresh area-bearing insert/lookup round-trips post-migration.
+    cat.upsert(entry({ area: 'cdopp', target: 'photos/IMG_0002.jpg' }));
+    expect(cat.has(entry().sha256, 'photos/IMG_0002.jpg', 'cdopp')).toBe(true);
+    expect(cat.has(entry().sha256, 'photos/IMG_0002.jpg', 'mdopp')).toBe(false);
+    cat.close();
+
+    // Reopening an already-migrated catalog is a no-op (idempotent).
+    const reopened = new ImportCatalog(dbPath);
+    expect(reopened.count()).toBe(2);
+    reopened.close();
+  });
+});
+
 describe('ImportCatalog — persist + reload from a file path', () => {
   let tmpDir: string;
   afterEach(async () => {

--- a/packages/backend/src/lib/diskImport/catalog.ts
+++ b/packages/backend/src/lib/diskImport/catalog.ts
@@ -69,6 +69,11 @@ export class ImportCatalog {
     const Database = require('better-sqlite3');
     this.db = new Database(dbPath) as BetterSqliteDatabase;
     this.db.pragma('journal_mode = WAL');
+    // Bring a pre-existing (possibly pre-#1912) catalog up to the current shape
+    // BEFORE creating the table or any `area`-referencing index — a fresh DB is a
+    // no-op here. CREATE TABLE IF NOT EXISTS never touches an existing table, so
+    // migration is the only path that fixes an old one.
+    this.selfHealSchema();
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS import_catalog (
         sha256          TEXT NOT NULL,
@@ -82,6 +87,105 @@ export class ImportCatalog {
       CREATE INDEX IF NOT EXISTS idx_catalog_sha         ON import_catalog(sha256);
       CREATE INDEX IF NOT EXISTS idx_catalog_area_target ON import_catalog(area, target);
     `);
+  }
+
+  /**
+   * Forward-only, idempotent self-migration for a catalog created before #1912
+   * (issue #1940). The catalog is a PERSISTENT SQLite on the box: #1912 added
+   * `area TEXT NOT NULL DEFAULT 'shared'` to the dedup key AND moved the PRIMARY
+   * KEY from `(sha256, target)` to `(sha256, area, target)`. A pre-#1912 catalog
+   * has neither, so the area-scoped dedup queries throw `no such column: area`
+   * and the upsert's `ON CONFLICT(sha256, area, target)` finds no matching key.
+   *
+   * SQLite's `ALTER TABLE ADD COLUMN` can backfill the column but cannot change a
+   * PRIMARY KEY, so a stale-PK catalog needs the full table-rebuild ("12-step")
+   * pattern. We therefore: (1) skip entirely if the table is absent (fresh DB —
+   * CREATE TABLE in the ctor makes the current shape); (2) rebuild if the live
+   * PRIMARY KEY differs from the current one, copying every row and backfilling
+   * the default `area` for legacy rows; (3) otherwise ADD COLUMN any columns the
+   * engine queries that a same-PK-but-older table is missing. The rebuilt/altered
+   * table is byte-identical to a freshly created one (same column types/defaults,
+   * same PK), so a migrated and a fresh catalog converge.
+   */
+  private selfHealSchema(): void {
+    const tableExists =
+      this.db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='import_catalog'`)
+        .get() !== undefined;
+    if (!tableExists) return; // Fresh DB — the ctor's CREATE TABLE makes the current shape.
+
+    const cols = this.db.prepare('PRAGMA table_info(import_catalog)').all() as {
+      name: string;
+      pk: number;
+    }[];
+    const existing = new Set(cols.map(c => c.name));
+    // The live PRIMARY KEY, in declared order.
+    const livePk = cols
+      .filter(c => c.pk > 0)
+      .sort((a, b) => a.pk - b.pk)
+      .map(c => c.name)
+      .join(',');
+    const wantPk = 'sha256,area,target';
+
+    if (livePk !== wantPk) {
+      // PRIMARY KEY changed (pre-#1912). ADD COLUMN can't change a PK, so rebuild.
+      this.rebuildWithCurrentSchema(existing.has('area'));
+      return; // Rebuilt table already has every current column.
+    }
+
+    // Same PK but possibly missing a later-added column. (column → DDL fragment)
+    // for every column added after the #1912 shape; defaults are constants so
+    // SQLite can backfill existing rows. Keep byte-identical to CREATE TABLE.
+    const addedColumns: ReadonlyArray<readonly [string, string]> = [
+      ['area', `TEXT NOT NULL DEFAULT 'shared'`], // #1912 — owner-derived dedup area
+    ];
+    for (const [name, ddl] of addedColumns) {
+      if (existing.has(name)) continue;
+      // Hardcoded column DDL (not user input); SQLite db.exec, not a shell call.
+      this.db.exec('ALTER TABLE import_catalog ADD COLUMN ' + name + ' ' + ddl);
+    }
+  }
+
+  /**
+   * SQLite "12-step" table rebuild used when the live PRIMARY KEY differs from the
+   * current `(sha256, area, target)` (a pre-#1912 catalog keyed on `(sha256,
+   * target)`). Copies every row into a freshly created current-shape table inside
+   * a transaction, backfilling `area` to the pre-#1912 default `'shared'` for
+   * legacy rows that lack the column, then swaps the table in. `INSERT OR IGNORE`
+   * collapses any rows that would collide under the new wider key.
+   */
+  private rebuildWithCurrentSchema(hasArea: boolean): void {
+    // The area source for the copy: the legacy column when present, else the
+    // pre-#1912 default. Both branches are hardcoded SQL (not user input); this
+    // is a SQLite db.exec, not a shell executor.
+    const areaExpr = hasArea ? 'area' : `'shared'`;
+    const copySql =
+      'INSERT OR IGNORE INTO import_catalog__new ' +
+      '(sha256, area, target, source_path, size, imported_at_ms) ' +
+      'SELECT sha256, ' +
+      areaExpr +
+      ', target, source_path, size, imported_at_ms FROM import_catalog;';
+    this.db.exec('BEGIN');
+    try {
+      this.db.exec(`
+        CREATE TABLE import_catalog__new (
+          sha256          TEXT NOT NULL,
+          area            TEXT NOT NULL DEFAULT 'shared',
+          target          TEXT NOT NULL,
+          source_path     TEXT NOT NULL,
+          size            INTEGER NOT NULL,
+          imported_at_ms  INTEGER NOT NULL,
+          PRIMARY KEY (sha256, area, target)
+        );
+      `);
+      this.db.exec(copySql);
+      this.db.exec('DROP TABLE import_catalog;');
+      this.db.exec('ALTER TABLE import_catalog__new RENAME TO import_catalog;');
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
   }
 
   /** True if this exact content has already been written to this area+target. */


### PR DESCRIPTION
## Root cause
The disk-import catalog is a **persistent SQLite on the box** (`DATA_DIR`) that backs cross-run dedup. #1912 added `area TEXT NOT NULL DEFAULT 'shared'` to the dedup key **and** moved the catalog's `PRIMARY KEY` from `(sha256, target)` to `(sha256, area, target)` — but it was marked "no migration needed" because it read as a pure-engine change.

`CREATE TABLE IF NOT EXISTS` never alters an existing table, so a box whose catalog predates #1912 keeps the old shape. The moment a scan reaches the area-scoped plan/dedup step it crashes with `no such column: area`, and the upsert's `ON CONFLICT(sha256, area, target)` no longer matches the live primary key. Surfaced live on the operator's box during the #1937 real-disk box-verify (review-first ordering reaches the catalog earlier) and was worked around with a manual `ALTER TABLE … ADD COLUMN area` — but the code has to self-heal.

## Fix
`ImportCatalog` now runs a **forward-only, idempotent self-migration on open**, *before* the `CREATE TABLE` / `area` index (so the index never references a not-yet-added column):

- **No table** (fresh box) → skip; `CREATE TABLE` makes the current shape, the migration is a no-op.
- **Live `PRIMARY KEY` ≠ `(sha256, area, target)`** (pre-#1912) → SQLite "12-step" table rebuild: create the current-shape table, copy every row backfilling `area` to `'shared'` for legacy rows, swap it in (inside a transaction). `ALTER TABLE ADD COLUMN` cannot change a primary key, so a rebuild is required here.
- **Same PK but a missing later-added column** → `ALTER TABLE … ADD COLUMN` with the **exact type/default from `CREATE TABLE`** (`area TEXT NOT NULL DEFAULT 'shared'`), so a migrated old catalog and a freshly created one are byte-identical.

Missing columns are detected via `PRAGMA table_info` / `sqlite_master` (robust check), **not** by catching the error. The migration is driven by a column table so any further unmigrated catalog columns get the same self-heal — auditing the current schema vs the dedup queries, `area` is the only one #1912/#1913/#1914 added.

## Default for legacy rows
`'shared'` — the pre-#1912 single-area behaviour and the engine's `DEFAULT_AREA`. Existing rows can't be classified to an owner, so `shared` is the correct, engine-safe default (and matches #1912's column default).

## Tests
Added a test that builds a catalog with the **original (#1693) schema** (no `area`, PK `(sha256, target)`), seeds a legacy row, then opens it through `ImportCatalog`:
- the `area` column is auto-added (no `no such column: area`),
- the legacy row survives and reads back as `area = 'shared'`,
- area-scoped dedup insert/lookup work post-migration,
- reopening an already-migrated catalog is a no-op (idempotent).

All existing dedup/catalog tests stay green.

## Gates
- `npm run lint` → 0 errors, 339 warnings (≤339)
- `npm run check:arch` → all checks passed, no dependency violations
- diskImport vitest suites → 228 passed; `vitest --changed` → 78 passed
- backend typecheck → clean

Closes #1940.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
