### PR TITLE
fix(disk-import): idempotent mount + stale-mount sweep so scans never stack (#1941)

### DIFF
--- a/packages/backend/src/lib/agent/v4/agent.py
+++ b/packages/backend/src/lib/agent/v4/agent.py
@@ -106,6 +106,7 @@ SAFE_EXEC_ALLOWLIST = frozenset({
     # `-o ro` to a controlled mountpoint; chown is `:<gid>` to the share gid
     # only — never arbitrary uid:gid; every dest stays under file-share/data/).
     'lsblk',         # enumerate source USB block devices (lsblk -J)
+    'findmnt',       # detect a stale/stacked mount before a fresh `mount` (#1941)
     'mount',         # mount the source READ-ONLY (-o ro) — never read-write
     'umount',        # unmount the source after the import
     'rsync',         # copy non-photo files into file-share/data/<category>/

--- a/packages/backend/src/lib/agent/v4/tests/test_agent.py
+++ b/packages/backend/src/lib/agent/v4/tests/test_agent.py
@@ -302,7 +302,9 @@ class TestDnsResolvers(unittest.TestCase):
     def test_disk_import_binaries_on_safe_exec_allowlist(self):
         # #1694 host-side mount + apply uses these via safe_exec (argv is
         # assembled + validated TS-side in diskImport/mounter.ts + plan.ts).
-        for binary in ('lsblk', 'mount', 'umount', 'rsync', 'chown'):
+        # findmnt (#1941): detect a stale/stacked mount before a fresh `mount` so
+        # idempotent mountReadOnly never stacks read-only layers on the device.
+        for binary in ('lsblk', 'findmnt', 'mount', 'umount', 'rsync', 'chown'):
             self.assertIn(binary, agent.SAFE_EXEC_ALLOWLIST)
 
     def test_mcp_read_tool_binaries_on_safe_exec_allowlist(self):

--- a/packages/backend/src/lib/diskImport/mounter.test.ts
+++ b/packages/backend/src/lib/diskImport/mounter.test.ts
@@ -102,6 +102,48 @@ describe('mountReadOnly', () => {
     expect(sudoFor(calls, opts, 'mount')).toBe(true);
   });
 
+  it('does NOT stack on a stale mount: sweeps existing layer(s) first, then mounts once (#1941)', async () => {
+    // The box failure: prior crashed scans left read-only mounts STACKED on the
+    // device at the same mountpoint. findmnt reports the device/target mounted
+    // until enough umounts have peeled the stack; then the fresh `mount` runs.
+    const mp = `${MOUNT_BASE}/sda1`;
+    let layers = 3; // three stale layers to drain
+    const { exec, calls, opts } = mockExec({
+      // findmnt --source <dev> / --mountpoint <mp>: "mounted" while layers remain.
+      findmnt: () => (layers > 0 ? ok(mp) : ok('')),
+      umount: () => {
+        if (layers > 0) layers -= 1;
+        return ok();
+      },
+    });
+
+    const result = await mountReadOnly(exec, '/dev/sda1');
+    expect(result).toBe(mp);
+
+    // Exactly ONE `mount -o ro`, and it runs AFTER every stale umount (no stack).
+    const mounts = calls.filter(c => c[0] === 'mount');
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0]).toEqual(['mount', '-o', 'ro', '/dev/sda1', mp]);
+
+    // The three stale layers were peeled before the fresh mount.
+    const umounts = calls.filter(c => c[0] === 'umount');
+    expect(umounts).toHaveLength(3);
+    const lastUmountIdx = calls.map(c => c[0]).lastIndexOf('umount');
+    const mountIdx = calls.findIndex(c => c[0] === 'mount');
+    expect(lastUmountIdx).toBeLessThan(mountIdx); // unmount-then-mount sequence
+
+    // The sweep umounts run privileged, same as the mount.
+    expect(sudoFor(calls, opts, 'umount')).toBe(true);
+  });
+
+  it('does not unmount anything when nothing is already mounted (clean device)', async () => {
+    // findmnt reports "not mounted" (empty stdout) → no sweep, just mkdir+mount.
+    const { exec, calls } = mockExec({ findmnt: ok('') });
+    await mountReadOnly(exec, '/dev/sda1');
+    expect(calls.some(c => c[0] === 'umount')).toBe(false);
+    expect(calls.filter(c => c[0] === 'mount')).toHaveLength(1);
+  });
+
   it('throws (no mount) on an unsafe device path — shell metacharacters', async () => {
     const { exec, calls } = mockExec();
     await expect(mountReadOnly(exec, '/dev/sda1; rm -rf /')).rejects.toThrow(/unsafe device/);

--- a/packages/backend/src/lib/diskImport/mounter.ts
+++ b/packages/backend/src/lib/diskImport/mounter.ts
@@ -146,6 +146,13 @@ export async function listBlockDevices(exec: SafeExec): Promise<BlockDevice[]> {
  * return that path. Creates the mountpoint first (`mkdir -p`). The `-o ro` flag
  * is non-negotiable — there is no read-write code path here by design, so the
  * source disk is never written.
+ *
+ * IDEMPOTENT (#1941): before mounting, sweep any pre-existing mount of THIS
+ * device or target mountpoint — including the STACKED case where prior scans
+ * crashed without unmounting and `mount -o ro` layered another mount on the same
+ * spot. Without this sweep, each fresh scan stacked another read-only layer until
+ * the kernel mount blocked and the scan hung at `Starting…`. We always unmount
+ * the stale layer(s) first, then mount exactly once. Never stacks.
  */
 export async function mountReadOnly(
   exec: SafeExec,
@@ -157,10 +164,53 @@ export async function mountReadOnly(
   // (see hostExec.SafeExec); the agent escalates via `sudo -n`. The argv guards
   // above (assertSafeDevice / mountpointFor) are unaffected by privilege.
   await runOk(exec, ['mkdir', '-p', mountpoint], 'mkdir mountpoint', { sudo: true });
+  // Defence-in-depth (#1941): clear any stale/stacked mount of this device or
+  // mountpoint BEFORE mounting, so a fresh scan after a crashed one can't stack.
+  await sweepStaleMounts(exec, device, mountpoint);
   // `-o ro` only. We never pass a caller-supplied option string — the option
   // set is a fixed literal so no `rw`/`exec`/`dev` can be smuggled in.
   await runOk(exec, ['mount', '-o', 'ro', device, mountpoint], 'mount -o ro', { sudo: true });
   return mountpoint;
+}
+
+/**
+ * True if `device` or `mountpoint` currently has at least one mount, per
+ * `findmnt`. `findmnt --source <dev>` / `--mountpoint <mp>` exits non-zero when
+ * nothing matches; we treat any zero exit with non-empty output as "mounted".
+ * Read-only, so it runs unprivileged.
+ */
+async function isMounted(exec: SafeExec, kind: '--source' | '--mountpoint', value: string): Promise<boolean> {
+  // `-n` no header, `-o TARGET` minimal output. A non-zero exit just means "no
+  // match" — not an error we should throw on (the disk may legitimately be
+  // unmounted), so we don't use runOk here.
+  const { code, stdout } = await exec(['findmnt', '-n', '-o', 'TARGET', kind, value]);
+  return code === 0 && stdout.trim().length > 0;
+}
+
+/**
+ * Unmount every stale layer of `device` and `mountpoint` (#1941). Stacked mounts
+ * are the failure mode the box hit: 5 read-only mounts piled on `/dev/sda` at the
+ * same mountpoint because crashed scans never unmounted and each `mount` added a
+ * layer. We unmount-until-clear, capped, scoped to OUR device + controlled
+ * mountpoint — we never touch an unrelated mount. Best-effort: a layer that won't
+ * release (busy) is left for the fresh `mount` to surface rather than throwing
+ * here; the loop's job is to drain the stack we created, not to fight the kernel.
+ */
+async function sweepStaleMounts(exec: SafeExec, device: string, mountpoint: string): Promise<void> {
+  // Cap the drain well above the worst case we saw (5) so a pathological stack
+  // still terminates rather than looping forever.
+  const MAX_LAYERS = 16;
+  for (let i = 0; i < MAX_LAYERS; i++) {
+    const deviceMounted = await isMounted(exec, '--source', device);
+    const targetMounted = await isMounted(exec, '--mountpoint', mountpoint);
+    if (!deviceMounted && !targetMounted) return;
+    // `umount <mountpoint>` peels one layer. We unmount by the controlled
+    // mountpoint (re-validated by `unmount`) so we never act on an arbitrary
+    // path; repeating drains the stack. Tolerate a failing umount — re-check on
+    // the next iteration; if it never clears we bail out of the loop.
+    const { code } = await exec(['umount', mountpoint], { sudo: true });
+    if (code !== 0) return;
+  }
 }
 
 /** Unmount a mountpoint previously returned by {@link mountReadOnly}. */

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -217,6 +217,53 @@ describe('runScan — review-first, background dedup (#1937)', () => {
     expect(calls.some(c => c[0] === 'sha256sum')).toBe(false);
   });
 
+  it('a scan that THROWS still unmounts — the mount never leaks (#1941)', async () => {
+    // `find` exits non-zero → scanMount throws inside runScan. The mount happened
+    // BEFORE the throw, so the `finally` MUST release it or the next scan stacks.
+    const { exec, calls } = mockExec({ find: { stdout: '', stderr: 'boom', code: 2 } });
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+    await waitFor(async () => (await getImportJob(jobId))!.phase === 'error');
+
+    // It mounted, then — despite the throw — unmounted.
+    expect(calls.some(c => c[0] === 'mount' && c.includes('ro'))).toBe(true);
+    expect(calls.some(c => c[0] === 'umount')).toBe(true);
+  });
+
+  it('background dedup unmounts AFTER its read (mount outlives the review), not before (#1941)', async () => {
+    // Two same-size docs → background dedup hashes them off a RE-MOUNT. The mount
+    // must outlive the review render and stay alive WHILE the background read
+    // (sha256sum) runs, then unmount AFTER. We assert the ordering from the full
+    // host-call log once the pass completes: the dedup pass's read (sha256sum) is
+    // followed by an unmount — the mount was held across the read, never before.
+    const find = [
+      '/mnt/docs/a.pdf\t100\t1700000000',
+      '/mnt/docs/b.pdf\t100\t1700000001', // same size → collision candidate
+    ].join('\0') + '\0';
+    const calls: string[][] = [];
+    const exec: SafeExec = vi.fn(async (argv: string[]) => {
+      calls.push([...argv]);
+      if (argv[0] === 'find') return ok(find);
+      if (argv[0] === 'sha256sum') {
+        return ok(argv.slice(1).map((p, i) => `${String(i).repeat(64).slice(0, 63)}0  ${p}`).join('\n') + '\n');
+      }
+      return ok();
+    });
+
+    const { jobId } = await startScan({ exec, device: '/dev/sda1', catalogPath: ':memory:' });
+    // Let the whole flow finish: review render → detached dedup pass mounts,
+    // hashes, re-plans, unmounts → dedup done.
+    await waitFor(async () => (await getImportJob(jobId))!.dedup === 'done', 2000);
+
+    const kinds = calls.map(c => c[0]);
+    const lastHashIdx = kinds.lastIndexOf('sha256sum');
+    const lastUmountIdx = kinds.lastIndexOf('umount');
+    // The background read happened (the candidates were hashed)...
+    expect(lastHashIdx).toBeGreaterThanOrEqual(0);
+    // ...and the dedup pass's unmount lands AFTER its read — the mount was held
+    // across the read (outlived the review), then released. Never unmounted first.
+    expect(lastUmountIdx).toBeGreaterThan(lastHashIdx);
+  });
+
   it('survives a background hash failure: review stays up, dedup → partial (#1937 Part B)', async () => {
     // Two same-size docs collide → hashed. sha256sum fails at every width → the
     // resilient pass skips both, the dedup pass reports `partial`, and the review


### PR DESCRIPTION
Fixes #1941.

## Root cause: stacked stale mounts

A fresh disk-import scan hung forever at `Starting…` (`step: mount`). On the box, `/dev/sda` had **5 stacked read-only mounts** at `/run/servicebay/disk-import/sda`. Two gaps fed each other:

1. **No idempotency** — `mountReadOnly` issued `mount -o ro` without ever checking whether the device/target was already mounted, so each call layered another mount on the same spot.
2. **Leak on failure** — when a scan crashed/timed out, its unmount was skipped, stranding that layer.

Over several attempts (box-verify + the user's crashed runs) the layers piled up until the kernel mount on the over-stacked device blocked, and the next scan never got past `Starting…`. Cleared manually with `sudo umount -A /dev/sda`.

## Fix: idempotent mount + stale sweep + guaranteed cleanup

- **`mountReadOnly` is now idempotent.** Before mounting it sweeps any pre-existing mount of this device or target: `findmnt --source <dev>` / `--mountpoint <mp>` detects a live mount, and we `umount` the controlled mountpoint repeatedly (capped at 16, well above the worst case seen) until it's clear — handling the **stacked** case — then mount **exactly once**. A clean device is a no-op sweep. Never stacks.
- **`findmnt`** added to the agent `safe_exec` allow-list (read-only detection, unprivileged). The sweep `umount`s run privileged like the existing mount/unmount.
- **Guaranteed unmount on error** — `runScan`'s per-scan unmount is already in a `finally`, so a thrown/timed-out scan releases its mount; the #1937 background dedup pass mounts and unmounts itself. Both are now locked in by tests.

The sweep is scoped strictly to the device + controlled `MOUNT_BASE` mountpoint — it never touches an unrelated mount.

## Tests
- stale mount at the target → cleaned up to a single fresh mount (asserts the umount-then-mount sequence + no stacking via the SafeExec call log);
- clean device → no umount, one mount;
- a scan that throws still unmounts (cleanup runs on error);
- background dedup unmounts **after** its read, so the mount outlives the review render (#1937 review-first preserved).

Gates: `npm run lint` (0 err, 339 warn), `npm run check:arch`, diskImport vitest (231) + `--changed` (29) + agent allow-list unittest — all green. Stable across 12 full-suite reruns.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
