### PR TITLE
fix(disk-import,file-share): split session store + reap zombies; persist Samba passdb

### DIFF
--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -50,8 +50,11 @@ import {
   setProgress,
   sessionHashes,
   appendLog,
+  getSessionStatus,
+  abortSession,
   type ScanSession,
   type DedupState,
+  type ReviewSummary,
   __clearSessions as clearSessionStore,
 } from './sessionStore';
 import type { SafeExec } from './hostExec';
@@ -315,6 +318,9 @@ async function runScan(sessionId: string, opts: ScanOptions): Promise<ScanResult
       // "checking duplicates…" while the background pass runs.
       dedup: candidates.length === 0 ? 'done' : 'pending',
       dedupTotal: candidates.length,
+      // #1945: persist the COMPACT review summary (counts + capped tree) on the
+      // status doc so the status poll never loads the 145MB record set.
+      summary: buildReviewSummary({ plan: planNoDedup, records, mountpoint, explicit }),
     });
 
     if (candidates.length > 0) {
@@ -372,7 +378,16 @@ async function runBackgroundDedup(args: {
     const hashOf: HashResolver = record => hashes.get(record.sourcePath) ?? uniqueToken(record);
     const allHashed = candidates.every(c => hashes.has(c.sourcePath));
     const plan = buildPlanWithCatalog([...records], hashOf, catalogPath, { hints, routing });
-    await finalizeDedup(sessionId, { plan, hashes, state: allHashed ? 'done' : 'partial' });
+    // #1945: refresh the compact summary — the dedup pass changed skip-dupe
+    // counts (and so the per-category rollup). The explicit/auto rules are
+    // reconstructed from the routing resolution so the tree matches the scan's.
+    const explicit = new Map<string, Rule>(routing.explicit);
+    await finalizeDedup(sessionId, {
+      plan,
+      hashes,
+      state: allHashed ? 'done' : 'partial',
+      summary: buildReviewSummary({ plan, records: [...records], mountpoint, explicit }),
+    });
   } catch (e) {
     // The review is already rendered; a dedup-pass failure must not error the
     // session. Mark dedup `partial` (import un-deduped; apply re-dedups) + log.
@@ -409,6 +424,31 @@ function uniqueToken(record: ImportRecord): string {
 }
 const metadataHashOf: HashResolver = uniqueToken;
 
+/**
+ * Build the COMPACT review summary (#1945) persisted on the status doc: the
+ * counts + per-category rollup + capped routing tree + actions the card renders,
+ * WITHOUT the bulk record set. Derived once at finalize/finalize-dedup time so
+ * the status poll never re-derives it from (or even loads) the 145MB plan. The
+ * store applies the {@link ReviewSummary} tree cap; this produces the full tree.
+ */
+function buildReviewSummary(args: {
+  plan: ImportPlan;
+  records: readonly ImportRecord[];
+  mountpoint: string;
+  explicit: ReadonlyMap<string, Rule>;
+}): ReviewSummary {
+  const { plan, records, mountpoint, explicit } = args;
+  return {
+    totalFiles: plan.items.length,
+    totalBytes: plan.items.reduce((sum, i) => sum + i.record.size, 0),
+    categories: summarizeCategories(plan),
+    actions: buildActions(plan, [...records]),
+    tree: buildReviewTree(records, plan, mountpoint, explicit, 'shared'),
+    boxUsers: [],
+    defaultOwner: 'shared',
+  };
+}
+
 /** Assemble the review {@link ScanResult} the card shows from a finished scan. */
 function buildScanResult(args: {
   sessionId: string;
@@ -420,14 +460,15 @@ function buildScanResult(args: {
   boxUsers: readonly string[];
 }): ScanResult {
   const { sessionId, device, plan, records, mountpoint, explicit, boxUsers } = args;
+  const summary = buildReviewSummary({ plan, records, mountpoint, explicit });
   return {
     sessionId,
     device,
-    totalFiles: plan.items.length,
-    totalBytes: plan.items.reduce((sum, i) => sum + i.record.size, 0),
-    categories: summarizeCategories(plan),
-    actions: buildActions(plan, [...records]),
-    tree: buildReviewTree(records, plan, mountpoint, explicit, 'shared'),
+    totalFiles: summary.totalFiles,
+    totalBytes: summary.totalBytes,
+    categories: summary.categories as CategorySummary[],
+    actions: summary.actions as ImportAction[],
+    tree: summary.tree as FolderNode[],
     boxUsers: [...boxUsers],
     defaultOwner: 'shared',
   };
@@ -606,8 +647,17 @@ export interface ImportJobStatus {
 }
 
 export async function getImportJob(sessionId: string): Promise<ImportJobStatus | null> {
-  const s = await getSession(sessionId);
+  // #1945: the status poll reads ONLY the compact status doc — never the 145MB
+  // plan/hashes sidecar. The review payload is served from the persisted
+  // `summary` (counts + capped tree, derived once at finalize). A reopened card
+  // at any scale loads this in KBs–low MBs, so it never falls back to 'Starting…'.
+  // Reaps a dead-worker session to `error` on read (#1943).
+  const s = await getSessionStatus(sessionId);
   if (!s) return null;
+  // `reviewed` is the only phase that carries a summary; pre-#1945 sessions on
+  // disk reached `reviewed` without one — fall back to rebuilding from the plan
+  // (loads the sidecar) just for those, so an in-flight upgrade isn't dark.
+  const hasReview = s.phase === 'reviewed' || s.phase === 'applying' || s.phase === 'applied';
   const status: ImportJobStatus = {
     sessionId: s.id,
     device: s.device,
@@ -616,31 +666,56 @@ export async function getImportJob(sessionId: string): Promise<ImportJobStatus |
     error: s.error,
     applied: s.applied,
     // A reopened card re-attaches whether dedup is still pending/running or done
-    // (#1937). Pre-#1937 sessions have no `dedup` → treat as already done.
-    dedup: s.plan ? s.dedup ?? 'done' : undefined,
+    // (#1937). Only meaningful once the scan has produced a plan/summary.
+    dedup: hasReview ? s.dedup ?? 'done' : undefined,
     dedupHashed: s.dedupHashed ?? 0,
     dedupTotal: s.dedupTotal ?? 0,
   };
-  if (s.plan) {
-    const records = s.plan.items.map(i => i.record);
-    // Rebuild the review tree (#1915) from the persisted auto-assigned rules +
-    // box-user list so a re-attaching/reloaded card gets the same per-folder
-    // tree it had pre-reload. `mountpoint`/`autoRules` are absent on pre-#1915
-    // sessions — degrade to an empty tree (the per-category view still renders).
-    const explicit = new Map<string, Rule>(Object.entries(s.autoRules ?? {}));
-    status.review = {
-      sessionId: s.id,
-      device: s.device,
-      totalFiles: s.plan.items.length,
-      totalBytes: s.plan.items.reduce((sum, i) => sum + i.record.size, 0),
-      categories: summarizeCategories(s.plan),
-      actions: buildActions(s.plan, records),
-      tree: s.mountpoint ? buildReviewTree(records, s.plan, s.mountpoint, explicit, 'shared') : [],
-      boxUsers: s.boxUsers ?? [],
-      defaultOwner: 'shared',
-    };
+  if (s.summary) {
+    status.review = summaryToReview(s);
+  } else if (hasReview) {
+    // Pre-#1945 session with no persisted summary — rebuild from the plan once.
+    status.review = (await rebuildReviewFromPlan(sessionId)) ?? undefined;
   }
   return status;
+}
+
+/** Project the persisted compact {@link ReviewSummary} (#1945) into the card's
+ *  {@link ScanResult}. No plan load — this is the hot path. */
+function summaryToReview(s: ScanSession): ScanResult {
+  const summary = s.summary!;
+  return {
+    sessionId: s.id,
+    device: s.device,
+    totalFiles: summary.totalFiles,
+    totalBytes: summary.totalBytes,
+    categories: summary.categories as CategorySummary[],
+    actions: summary.actions as ImportAction[],
+    tree: summary.tree as FolderNode[],
+    boxUsers: s.boxUsers ?? summary.boxUsers ?? [],
+    defaultOwner: (summary.defaultOwner as Owner) ?? 'shared',
+  };
+}
+
+/** Backward-compat fallback (#1945): a `reviewed` session persisted before the
+ *  store split has no `summary` — rebuild the review from the plan (loads the
+ *  sidecar). Only hit for sessions on disk across the upgrade. */
+async function rebuildReviewFromPlan(sessionId: string): Promise<ScanResult | null> {
+  const s = await getSession(sessionId);
+  if (!s?.plan) return null;
+  const records = s.plan.items.map(i => i.record);
+  const explicit = new Map<string, Rule>(Object.entries(s.autoRules ?? {}));
+  return {
+    sessionId: s.id,
+    device: s.device,
+    totalFiles: s.plan.items.length,
+    totalBytes: s.plan.items.reduce((sum, i) => sum + i.record.size, 0),
+    categories: summarizeCategories(s.plan),
+    actions: buildActions(s.plan, records),
+    tree: s.mountpoint ? buildReviewTree(records, s.plan, s.mountpoint, explicit, 'shared') : [],
+    boxUsers: s.boxUsers ?? [],
+    defaultOwner: 'shared',
+  };
 }
 
 /**
@@ -663,6 +738,18 @@ async function triggerImmichScan(
       `Immich library scan skipped: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
+}
+
+/**
+ * Abort/dismiss a disk-import session (#1943) — the card's "Start over". Flips a
+ * stuck/unwanted session terminal so it stops re-attaching and the user can begin
+ * a fresh scan. Idempotent + no-op-safe on an unknown id. Returns the session's
+ * resulting phase (or null when the id is unknown).
+ */
+export async function abortImportJob(sessionId: string): Promise<{ phase: ScanSession['phase'] } | null> {
+  const s = await abortSession(sessionId);
+  if (!s) return null;
+  return { phase: s.phase };
 }
 
 /** Test seam: drop all persisted sessions. */

--- a/packages/backend/src/lib/diskImport/sessionStore.test.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.test.ts
@@ -31,10 +31,14 @@ import {
   markError,
   markCrashedOnStartup,
   getSession,
+  getSessionStatus,
+  abortSession,
   markApplied,
   sessionHashes,
   appendLog,
   readLog,
+  STALE_AFTER_MS,
+  MAX_TREE_NODES,
   __clearSessions,
 } from './sessionStore';
 import type { ImportPlan } from './types';
@@ -198,6 +202,113 @@ describe('async job lifecycle (#1897)', () => {
   });
 });
 
+describe('store split — compact status doc vs bulk sidecar (#1945)', () => {
+  it('writes the plan/hashes to a SIDECAR; the status doc carries no records', async () => {
+    const plan = mkPlan('/mnt/docs/a.pdf');
+    const hashes = new Map([['/mnt/docs/a.pdf', 'a'.repeat(64)]]);
+    await createSession({ id: 'split-1', device: '/dev/sda1', plan, hashes, catalogPath: ':memory:' });
+
+    // The bulk sidecar exists and holds the records.
+    const sidecarRaw = await fs.readFile(path.join(SESSIONS_DIR, 'split-1.plan.json'), 'utf-8');
+    expect(JSON.parse(sidecarRaw).plan.items[0].record.sourcePath).toBe('/mnt/docs/a.pdf');
+
+    // The compact status doc on disk does NOT inline the plan or hashes.
+    const statusRaw = JSON.parse(await fs.readFile(path.join(SESSIONS_DIR, 'split-1.json'), 'utf-8'));
+    expect(statusRaw.plan).toBeUndefined();
+    expect(statusRaw.hashes).toBeUndefined();
+  });
+
+  it('getSessionStatus reads ONLY the compact doc (no plan/hashes); getSession rehydrates them', async () => {
+    const plan = mkPlan('/mnt/docs/a.pdf');
+    const hashes = new Map([['/mnt/docs/a.pdf', 'a'.repeat(64)]]);
+    await createSession({
+      id: 'split-2',
+      device: '/dev/sda1',
+      plan,
+      hashes,
+      catalogPath: ':memory:',
+      summary: {
+        totalFiles: 1,
+        totalBytes: 10,
+        categories: [],
+        actions: [],
+        tree: [],
+        boxUsers: [],
+        defaultOwner: 'shared',
+      },
+    });
+
+    const compact = await getSessionStatus('split-2');
+    expect(compact!.phase).toBe('reviewed');
+    expect(compact!.plan).toBeUndefined(); // never loads the sidecar
+    expect(compact!.summary!.totalFiles).toBe(1);
+
+    const full = await getSession('split-2');
+    expect(full!.plan!.items[0].record.sourcePath).toBe('/mnt/docs/a.pdf'); // rehydrated
+    expect(sessionHashes(full!).get('/mnt/docs/a.pdf')).toBe('a'.repeat(64));
+  });
+
+  it('caps the persisted routing tree to MAX_TREE_NODES (#1945)', async () => {
+    const tree = Array.from({ length: MAX_TREE_NODES + 50 }, (_, i) => ({ dir: `d${i}` }));
+    await createScanJob({ id: 'cap-1', device: '/dev/sda1', catalogPath: ':memory:' });
+    await finalizeScan('cap-1', {
+      plan: mkPlan(),
+      hashes: new Map(),
+      summary: { totalFiles: 1, totalBytes: 0, categories: [], actions: [], tree, boxUsers: [], defaultOwner: 'shared' },
+    });
+    const s = await getSessionStatus('cap-1');
+    expect(s!.summary!.tree.length).toBe(MAX_TREE_NODES);
+    expect(s!.summary!.treeTruncated).toBe(true);
+  });
+});
+
+describe('liveness / zombie reaping (#1943)', () => {
+  it('setProgress refreshes the heartbeat', async () => {
+    await createScanJob({ id: 'hb-1', device: '/dev/sda1', catalogPath: ':memory:' });
+    const before = (await getSessionStatus('hb-1'))!.heartbeat!;
+    await new Promise(r => setTimeout(r, 5));
+    await setProgress('hb-1', { step: 'walk', scanned: 10 });
+    const after = (await getSessionStatus('hb-1'))!.heartbeat!;
+    expect(Date.parse(after)).toBeGreaterThan(Date.parse(before));
+  });
+
+  it('reaps a non-terminal session with a stale heartbeat to error on read', async () => {
+    await createScanJob({ id: 'zombie-1', device: '/dev/sda1', catalogPath: ':memory:' });
+    // Backdate the heartbeat past the stale window (simulate a dead worker).
+    const stale = new Date(Date.now() - STALE_AFTER_MS - 60_000).toISOString();
+    await updateSession('zombie-1', { heartbeat: stale });
+    // It was `scanning`; now a status read flips it to error.
+    const s = await getSessionStatus('zombie-1');
+    expect(s!.phase).toBe('error');
+    expect(s!.error).toMatch(/interrupted/i);
+  });
+
+  it('does NOT reap a fresh in-flight session', async () => {
+    await createScanJob({ id: 'alive-1', device: '/dev/sda1', catalogPath: ':memory:' });
+    const s = await getSessionStatus('alive-1');
+    expect(s!.phase).toBe('scanning');
+  });
+
+  it('abortSession flips a stuck session terminal; idempotent on a terminal one', async () => {
+    await createScanJob({ id: 'abort-1', device: '/dev/sda1', catalogPath: ':memory:' });
+    const aborted = await abortSession('abort-1');
+    expect(aborted!.phase).toBe('error');
+    expect(aborted!.error).toMatch(/start a new scan/i);
+    // Idempotent: a second abort leaves it terminal, doesn't re-message.
+    const again = await abortSession('abort-1');
+    expect(again!.phase).toBe('error');
+    expect(await abortSession('ghost')).toBeNull();
+  });
+
+  it('markCrashedOnStartup also reaps an already-stale same-process zombie', async () => {
+    await createScanJob({ id: 'crash-stale', device: '/dev/sda1', catalogPath: ':memory:' });
+    // A scanning job is flipped regardless; verify a non-terminal stale one too.
+    const n = await markCrashedOnStartup();
+    expect(n).toBeGreaterThanOrEqual(1);
+    expect((await getSessionStatus('crash-stale'))!.phase).toBe('error');
+  });
+});
+
 describe('prune to KEEP_RECENT', () => {
   it('keeps only the most-recent sessions, dropping older state + log files', async () => {
     // KEEP_RECENT_SESSIONS is 20; create 23 so 3 of the oldest get pruned on
@@ -224,12 +335,18 @@ describe('prune to KEEP_RECENT', () => {
 
     // prune runs at the START of each createSession (before the new write),
     // exactly like jobStore — so after the last create the count is keep + the
-    // just-written one (21), and the oldest beyond keep are gone.
-    const remaining = (await fs.readdir(SESSIONS_DIR)).filter(f => f.endsWith('.json'));
+    // just-written one (21), and the oldest beyond keep are gone. Count only the
+    // compact status docs (#1945 split: each session also has a `.plan.json`
+    // sidecar, which must NOT be miscounted as a status doc).
+    const remaining = (await fs.readdir(SESSIONS_DIR)).filter(
+      f => f.endsWith('.json') && !f.endsWith('.plan.json'),
+    );
     expect(remaining.length).toBeLessThanOrEqual(21);
-    // The oldest are pruned; the newest survive (and so are their log files).
+    // The oldest are pruned; the newest survive (and so are their log + sidecar files).
     expect(await getSession('prune-00')).toBeNull();
     expect(await getSession('prune-22')).not.toBeNull();
     await expect(fs.stat(path.join(SESSIONS_DIR, 'prune-00.log'))).rejects.toThrow();
+    // The bulk plan sidecar is pruned alongside the status doc (#1945).
+    await expect(fs.stat(path.join(SESSIONS_DIR, 'prune-00.plan.json'))).rejects.toThrow();
   });
 });

--- a/packages/backend/src/lib/diskImport/sessionStore.ts
+++ b/packages/backend/src/lib/diskImport/sessionStore.ts
@@ -8,18 +8,38 @@
  * no way to re-attach to the session it was reviewing, and the apply gate
  * could only ever see sessions created since the last boot.
  *
- * This module persists each session to its own atomic state file under
- * DATA_DIR + an append-only log file, modeled directly on
+ * This module persists each session under DATA_DIR, modeled on
  * `lib/install/jobStore.ts`:
  *
  *   - a reopened card can re-attach to a reviewed plan by session id
  *   - the reviewed plan + apply reference survive a backend restart
  *   - a crash leaves a breadcrumb (PROCESS_STARTED_AT)
  *
- * Session state files are small (a plan over a few thousand records is well
- * under a few hundred KB) so a full read/write per update is fine — this is
- * not a hot path. The store is the only thing this unit changes; async/
- * progress (#1897) and batched host-work (#1898) build on top.
+ * STORE SPLIT (#1945). At 177k files the inline plan + hashes is a ~145MB
+ * monolithic JSON; rewriting it on every progress tick was O(N) per tick and
+ * the status poll shipped the whole blob → the card couldn't load it and fell
+ * back to 'Starting…'. The session is now TWO files:
+ *
+ *   - `<id>.json`       — the COMPACT status doc: phase, progress, dedup
+ *                         counters, heartbeat, and a small derived `summary`
+ *                         (counts + routing tree the card renders). KBs–low MBs.
+ *                         Rewritten on every progress tick.
+ *   - `<id>.plan.json`  — the BULK sidecar: `{ plan, hashes }` (all records
+ *                         inline). Written ONCE at finalize/finalize-dedup,
+ *                         read ONLY at apply. Never touched by progress ticks
+ *                         or the status poll.
+ *
+ * The status route uses {@link getSessionStatus} (reads only the compact doc);
+ * the apply path uses {@link getSession} (rehydrates plan+hashes from the
+ * sidecar). The `ScanSession` shape is unchanged for callers.
+ *
+ * LIVENESS (#1943). A scan whose worker process is killed (restart/crash before
+ * the error handler runs) used to sit at a non-terminal phase forever — the
+ * card re-attached and showed 'Starting…' with no way to dismiss it. Progress
+ * writes now stamp a `heartbeat`; a non-terminal session whose heartbeat is
+ * older than {@link STALE_AFTER_MS} is reaped to `error` on backend start AND
+ * on every status read, and {@link abortSession} lets the card dismiss a stuck
+ * session and start fresh.
  */
 import fs from 'fs/promises';
 import path from 'path';
@@ -42,6 +62,24 @@ export const PROCESS_STARTED_AT = new Date().toISOString();
  *  sessions are cleaned up on each createSession call. Mirrors jobStore's
  *  KEEP_RECENT_JOBS. */
 const KEEP_RECENT_SESSIONS = 20;
+
+/**
+ * Liveness threshold (#1943). A non-terminal session whose `heartbeat` (or, for
+ * a session that never ticked, `updatedAt`) is older than this is treated as a
+ * dead worker and reaped to `error`. A scan's host walk/hash ticks progress far
+ * more often than this; the window is generous enough that a slow-but-alive pass
+ * is never falsely reaped.
+ */
+export const STALE_AFTER_MS = 10 * 60 * 1000;
+
+/**
+ * Largest routing tree the compact status doc carries (#1945). The tree is one
+ * node per directory (not per file), so it's far smaller than the records, but a
+ * pathological disk with hundreds of thousands of dirs could still bloat the
+ * status payload — cap it so the card always loads fast. The per-category table
+ * + totals still reflect the full scan; only the per-folder tree is truncated.
+ */
+export const MAX_TREE_NODES = 2000;
 
 /**
  * Lifecycle of a disk-import job (#1897). A scan and an apply both run in the
@@ -107,20 +145,60 @@ function emptyProgress(): SessionProgress {
 }
 
 /**
+ * The COMPACT review summary the card renders (#1945). Derived once from the
+ * plan at finalize/finalize-dedup time and persisted on the status doc so the
+ * status poll never has to load the 145MB record set. The bulk records live in
+ * the sidecar (read only at apply). This is a plain-data subset — `categories`/
+ * `tree`/`actions` are pre-rendered by `service.ts` (the engine layer), so the
+ * store stays engine-agnostic. The `tree` is capped to {@link MAX_TREE_NODES}.
+ */
+export interface ReviewSummary {
+  totalFiles: number;
+  totalBytes: number;
+  /** Per-category rollup (one row per Category). */
+  categories: unknown[];
+  /** Non-blocking, advisory review actions[] (ambiguous folders / conflicts). */
+  actions: unknown[];
+  /** Per-folder routing tree (one node per directory), capped. */
+  tree: unknown[];
+  /** True when {@link tree} was truncated past {@link MAX_TREE_NODES}. */
+  treeTruncated?: boolean;
+  /** Box users that drive the Owner picker. */
+  boxUsers: string[];
+  /** The disk-default owner seeding the tree root. */
+  defaultOwner: string;
+}
+
+/** The bulk sidecar (#1945): the full plan + hashes, written once and read only
+ *  at apply. Kept OUT of the compact status doc so progress ticks + the status
+ *  poll never touch it. */
+interface PlanSidecar {
+  plan: ImportPlan;
+  /** sourcePath → sha256 hex. Persisted as a plain object (JSON has no Map). */
+  hashes: Record<string, string>;
+}
+
+/**
  * One stored disk-import job. A scan creates it in `scanning`, fills in the
- * `plan` + `hashes` and flips to `reviewed`; the apply gate keys off this (a
- * plan can only be applied via a session that reached `reviewed` and was not
- * yet consumed). `plan`/`hashes` are absent while `scanning`. `hashes` is
+ * `plan` + `hashes` (in the sidecar) and flips to `reviewed`; the apply gate
+ * keys off this (a plan can only be applied via a session that reached
+ * `reviewed` and was not yet consumed). `plan`/`hashes` are absent while
+ * `scanning`, and are loaded from the sidecar by {@link getSession} (the status
+ * poll uses {@link getSessionStatus}, which leaves them undefined). `hashes` is
  * serialized as a plain object (JSON has no Map).
  */
 export interface ScanSession {
   id: string;
   device: string;
-  /** Absent while the scan is still in flight (`scanning`). */
+  /** Absent while the scan is still in flight (`scanning`), and absent on a
+   *  {@link getSessionStatus} read (the status poll never loads the sidecar). */
   plan?: ImportPlan;
-  /** sourcePath → sha256 hex. Persisted as a plain object; rehydrated to a Map
-   *  by `sessionHashes`. Absent while `scanning`. */
+  /** sourcePath → sha256 hex. Persisted in the sidecar; rehydrated to a Map by
+   *  `sessionHashes`. Absent while `scanning` / on a status-only read. */
   hashes?: Record<string, string>;
+  /** The COMPACT review summary the card renders (#1945). Present once
+   *  `reviewed`; on the status doc, not the sidecar. */
+  summary?: ReviewSummary;
   catalogPath: string;
   /**
    * The scan mountpoint (#1915). Stable per device (derived from the device
@@ -156,6 +234,11 @@ export interface ScanSession {
   error?: string;
   createdAt: string;
   updatedAt: string;
+  /** Liveness breadcrumb (#1943): refreshed by every progress tick of an
+   *  in-flight pass. A non-terminal session whose `heartbeat` is older than
+   *  {@link STALE_AFTER_MS} is reaped to `error` (dead worker). Absent on
+   *  pre-#1943 sessions → `updatedAt` is the fallback. */
+  heartbeat?: string;
   /** PROCESS_STARTED_AT of the process that last wrote this session — the
    *  crash/restart breadcrumb. */
   seenBy: string;
@@ -166,6 +249,7 @@ async function ensureDir(): Promise<void> {
 }
 
 const statePath = (id: string) => path.join(SESSIONS_DIR, `${id}.json`);
+const planPath = (id: string) => path.join(SESSIONS_DIR, `${id}.plan.json`);
 const logPath = (id: string) => path.join(SESSIONS_DIR, `${id}.log`);
 
 /**
@@ -179,37 +263,68 @@ async function atomicWrite(p: string, content: string): Promise<void> {
   await fs.rename(tmp, p);
 }
 
+/** Write the bulk plan+hashes sidecar (#1945). Once per finalize/finalize-dedup;
+ *  never on a progress tick. Atomic so a mid-write kill never leaves a partial
+ *  sidecar an apply could read. */
+async function writePlanSidecar(id: string, plan: ImportPlan, hashes: Map<string, string>): Promise<void> {
+  const sidecar: PlanSidecar = { plan, hashes: Object.fromEntries(hashes) };
+  await atomicWrite(planPath(id), JSON.stringify(sidecar));
+}
+
+/** Read the bulk plan+hashes sidecar (#1945). Returns null when absent (a
+ *  `scanning` session, or a pre-split session that never wrote one). */
+async function readPlanSidecar(id: string): Promise<PlanSidecar | null> {
+  try {
+    return JSON.parse(await fs.readFile(planPath(id), 'utf-8')) as PlanSidecar;
+  } catch {
+    return null;
+  }
+}
+
+/** Truncate a routing tree to {@link MAX_TREE_NODES} for the compact status doc
+ *  (#1945). Returns the (possibly truncated) tree + whether it was cut. */
+function capTree(tree: unknown[]): { tree: unknown[]; truncated: boolean } {
+  if (tree.length <= MAX_TREE_NODES) return { tree, truncated: false };
+  return { tree: tree.slice(0, MAX_TREE_NODES), truncated: true };
+}
+
 export interface CreateSessionInput {
   id: string;
   device: string;
   plan: ImportPlan;
   hashes: Map<string, string>;
   catalogPath: string;
+  /** Pre-rendered compact review summary (#1945). Optional for the synchronous /
+   *  test path; the status poll just has no tree until a summary is supplied. */
+  summary?: ReviewSummary;
 }
 
 /** Persist a freshly-reviewed scan (synchronous-scan path / direct create).
- *  Prunes old sessions first, then writes the state file atomically + an empty
- *  log file. The async flow uses {@link createScanJob} + {@link finalizeScan}
- *  instead; this remains for the simple "plan already in hand" case. */
+ *  Prunes old sessions first, then writes the compact state file + the bulk
+ *  plan sidecar (#1945) atomically + an empty log file. The async flow uses
+ *  {@link createScanJob} + {@link finalizeScan} instead; this remains for the
+ *  simple "plan already in hand" case. */
 export async function createSession(input: CreateSessionInput): Promise<ScanSession> {
   await ensureDir();
   await pruneSessions(KEEP_RECENT_SESSIONS);
   const now = new Date().toISOString();
-  const session: ScanSession = {
+  const status: ScanSession = {
     id: input.id,
     device: input.device,
-    plan: input.plan,
-    hashes: Object.fromEntries(input.hashes),
+    summary: input.summary,
     catalogPath: input.catalogPath,
     phase: 'reviewed',
     progress: { ...emptyProgress(), step: 'done', scanned: input.plan.items.length },
     createdAt: now,
     updatedAt: now,
+    heartbeat: now,
     seenBy: PROCESS_STARTED_AT,
   };
-  await atomicWrite(statePath(session.id), JSON.stringify(session, null, 2));
-  await fs.writeFile(logPath(session.id), '', 'utf-8').catch(() => undefined);
-  return session;
+  await writePlanSidecar(input.id, input.plan, input.hashes);
+  await atomicWrite(statePath(input.id), JSON.stringify(status, null, 2));
+  await fs.writeFile(logPath(input.id), '', 'utf-8').catch(() => undefined);
+  // Return the rehydrated full session (plan+hashes inline) for the caller.
+  return { ...status, plan: input.plan, hashes: Object.fromEntries(input.hashes) };
 }
 
 /**
@@ -234,6 +349,7 @@ export async function createScanJob(input: {
     progress: emptyProgress(),
     createdAt: now,
     updatedAt: now,
+    heartbeat: now,
     seenBy: PROCESS_STARTED_AT,
   };
   await atomicWrite(statePath(session.id), JSON.stringify(session, null, 2));
@@ -259,15 +375,28 @@ function withSessionWriteLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
-/** Generic patch of a session (best-effort disk write, mirrors jobStore.updateJob).
- *  Refreshes `updatedAt` + the restart breadcrumb. Returns null if it's gone.
- *  Serialized per id so a trailing progress tick can't clobber a terminal write. */
+/** Read just the COMPACT status doc (#1945) — phase, progress, dedup counters,
+ *  heartbeat, summary. Does NOT load the bulk plan/hashes sidecar, so this stays
+ *  cheap even for a 177k-file scan. The status poll path. Returns null when the
+ *  state file is missing or corrupt. */
+async function readStatusDoc(id: string): Promise<ScanSession | null> {
+  try {
+    return JSON.parse(await fs.readFile(statePath(id), 'utf-8')) as ScanSession;
+  } catch {
+    return null;
+  }
+}
+
+/** Generic patch of the COMPACT status doc (#1945). Refreshes `updatedAt` + the
+ *  restart breadcrumb. Returns null if it's gone. Serialized per id so a
+ *  trailing progress tick can't clobber a terminal write. NEVER touches the
+ *  plan sidecar — bulk writes go through {@link writePlanSidecar}. */
 export async function updateSession(
   id: string,
   partial: Partial<Omit<ScanSession, 'id' | 'createdAt'>>,
 ): Promise<ScanSession | null> {
   return withSessionWriteLock(id, async () => {
-    const current = await getSession(id);
+    const current = await readStatusDoc(id);
     if (!current) return null;
     const next: ScanSession = {
       ...current,
@@ -288,18 +417,21 @@ export async function updateSession(
 /** Patch just the live progress counters of an in-flight pass (#1897). Routed
  *  through the per-id write lock — the read-modify-merge of `progress` happens
  *  INSIDE the lock so concurrent ticks (and the terminal markApplied) don't
- *  clobber each other. */
+ *  clobber each other. Refreshes the liveness `heartbeat` (#1943) so a running
+ *  pass is never reaped as stale. Writes ONLY the compact status doc. */
 export async function setProgress(
   id: string,
   partial: Partial<SessionProgress>,
 ): Promise<void> {
   await withSessionWriteLock(id, async () => {
-    const current = await getSession(id);
+    const current = await readStatusDoc(id);
     if (!current) return;
+    const now = new Date().toISOString();
     const next: ScanSession = {
       ...current,
       progress: { ...current.progress, ...partial },
-      updatedAt: new Date().toISOString(),
+      updatedAt: now,
+      heartbeat: now,
       seenBy: PROCESS_STARTED_AT,
     };
     try {
@@ -310,10 +442,12 @@ export async function setProgress(
   });
 }
 
-/** Background scan completed: attach the reviewed plan + hashes and flip to
- *  `reviewed` so the apply gate accepts it.
+/** Background scan completed: write the bulk plan + hashes to the sidecar
+ *  (#1945) and flip the compact status doc to `reviewed` with the derived
+ *  `summary`, so the apply gate accepts it and the card renders the tree without
+ *  loading the records.
  *
- *  Review-first (#1937): the scan now finalizes on METADATA ONLY (no hashes yet)
+ *  Review-first (#1937): the scan finalizes on METADATA ONLY (no hashes yet)
  *  with `dedup: 'pending'` so the tree renders immediately; the background hash
  *  pass then re-finalizes via {@link finalizeDedup}. A scan with nothing to dedup
  *  passes `dedup: 'done'`. `hashes` is whatever's known so far (empty for the
@@ -328,12 +462,15 @@ export async function finalizeScan(
     autoRules?: Record<string, Rule>;
     dedup?: DedupState;
     dedupTotal?: number;
+    /** The compact review summary (#1945) — counts + capped tree the card renders. */
+    summary?: ReviewSummary;
   },
 ): Promise<ScanSession | null> {
   const dedup = input.dedup ?? 'done';
+  await writePlanSidecar(id, input.plan, input.hashes);
+  const summary = input.summary ? capSummaryTree(input.summary) : undefined;
   return updateSession(id, {
-    plan: input.plan,
-    hashes: Object.fromEntries(input.hashes),
+    summary,
     mountpoint: input.mountpoint,
     boxUsers: input.boxUsers,
     autoRules: input.autoRules,
@@ -341,6 +478,7 @@ export async function finalizeScan(
     dedup,
     dedupHashed: 0,
     dedupTotal: input.dedupTotal ?? 0,
+    heartbeat: new Date().toISOString(),
     progress: {
       step: 'done',
       scanned: input.plan.items.length,
@@ -352,24 +490,38 @@ export async function finalizeScan(
   });
 }
 
+/** Apply the {@link MAX_TREE_NODES} cap to a summary's tree (#1945). */
+function capSummaryTree(summary: ReviewSummary): ReviewSummary {
+  const { tree, truncated } = capTree(summary.tree);
+  return truncated ? { ...summary, tree, treeTruncated: true } : summary;
+}
+
 /** Flip a `reviewed` session's dedup sub-state to `running` (the background hash
  *  pass started, #1937). The tree stays rendered; only the secondary
- *  "checking duplicates…" line changes. */
+ *  "checking duplicates…" line changes. Refreshes the heartbeat (#1943). */
 export async function startDedup(id: string, total: number): Promise<ScanSession | null> {
-  return updateSession(id, { dedup: 'running', dedupHashed: 0, dedupTotal: total });
+  return updateSession(id, {
+    dedup: 'running',
+    dedupHashed: 0,
+    dedupTotal: total,
+    heartbeat: new Date().toISOString(),
+  });
 }
 
 /** Live progress of the background dedup hash pass (#1937). Best-effort, like
- *  {@link setProgress}; a lost tick is non-fatal. */
+ *  {@link setProgress}; a lost tick is non-fatal. Refreshes the heartbeat
+ *  (#1943) and writes ONLY the compact status doc. */
 export async function setDedupProgress(id: string, hashed: number, total: number): Promise<void> {
   await withSessionWriteLock(id, async () => {
-    const current = await getSession(id);
+    const current = await readStatusDoc(id);
     if (!current) return;
+    const now = new Date().toISOString();
     const next: ScanSession = {
       ...current,
       dedupHashed: hashed,
       dedupTotal: total,
-      updatedAt: new Date().toISOString(),
+      updatedAt: now,
+      heartbeat: now,
       seenBy: PROCESS_STARTED_AT,
     };
     try {
@@ -381,17 +533,19 @@ export async function setDedupProgress(id: string, hashed: number, total: number
 }
 
 /** Background dedup pass completed (#1937): replace the metadata-only plan with
- *  the re-deduped plan + the resolved hashes, and mark `done` (all candidates
+ *  the re-deduped plan + the resolved hashes (in the sidecar, #1945), refresh the
+ *  compact `summary` (skip-dupe counts changed), and mark `done` (all candidates
  *  hashed) or `partial` (some files were un-hashable → imported un-deduped).
  *  Stays `reviewed` — this never gates apply, which re-dedups at the catalog. */
 export async function finalizeDedup(
   id: string,
-  input: { plan: ImportPlan; hashes: Map<string, string>; state: DedupState },
+  input: { plan: ImportPlan; hashes: Map<string, string>; state: DedupState; summary?: ReviewSummary },
 ): Promise<ScanSession | null> {
+  await writePlanSidecar(id, input.plan, input.hashes);
   return updateSession(id, {
-    plan: input.plan,
-    hashes: Object.fromEntries(input.hashes),
+    ...(input.summary ? { summary: capSummaryTree(input.summary) } : {}),
     dedup: input.state,
+    heartbeat: new Date().toISOString(),
   });
 }
 
@@ -404,7 +558,11 @@ export async function markDedupPartial(id: string): Promise<ScanSession | null> 
 
 /** Flip a reviewed session into `applying` (the apply background pass started). */
 export async function markApplying(id: string): Promise<ScanSession | null> {
-  return updateSession(id, { phase: 'applying', progress: { ...emptyProgress(), step: 'copy' } });
+  return updateSession(id, {
+    phase: 'applying',
+    progress: { ...emptyProgress(), step: 'copy' },
+    heartbeat: new Date().toISOString(),
+  });
 }
 
 /** Record a background pass failure: phase=error + the message. */
@@ -412,16 +570,70 @@ export async function markError(id: string, message: string): Promise<ScanSessio
   return updateSession(id, { phase: 'error', error: message });
 }
 
-/** Read a session by id. Returns null when the state file is missing or
- *  corrupt — a forged/replayed id can't conjure a plan (the review gate). */
+/**
+ * Abort/dismiss a session (#1943). The card's "Start over" — flips a stuck or
+ * unwanted session terminal so it stops re-attaching and the user can begin a
+ * fresh scan. No-op-safe on a missing id (returns null) and idempotent on an
+ * already-terminal session. Marks `error` with a dismissed message rather than
+ * deleting, so the card can show "cancelled" rather than a bare disappearance.
+ */
+export async function abortSession(id: string): Promise<ScanSession | null> {
+  const current = await readStatusDoc(id);
+  if (!current) return null;
+  if (current.phase === 'applied' || current.phase === 'error') return current;
+  return updateSession(id, { phase: 'error', error: 'Cancelled — start a new scan when ready.' });
+}
+
+/** True when a non-terminal session's heartbeat (or updatedAt fallback) is older
+ *  than {@link STALE_AFTER_MS} — its worker is presumed dead (#1943). */
+function isStale(s: ScanSession, nowMs: number): boolean {
+  const terminal = s.phase === 'reviewed' || s.phase === 'applied' || s.phase === 'error';
+  if (terminal) return false;
+  const last = Date.parse(s.heartbeat ?? s.updatedAt);
+  if (Number.isNaN(last)) return false;
+  return nowMs - last > STALE_AFTER_MS;
+}
+
+/**
+ * Read a session by id (#1896), rehydrating the bulk plan + hashes from the
+ * sidecar (#1945) so the apply path gets a complete {@link ScanSession}. Reaps a
+ * stale non-terminal session to `error` first (#1943) so a re-attaching card
+ * never sees a dead worker as 'Starting…'. Returns null when the state file is
+ * missing or corrupt — a forged/replayed id can't conjure a plan (the review
+ * gate).
+ */
 export async function getSession(id: string): Promise<ScanSession | null> {
-  try {
-    const raw = await fs.readFile(statePath(id), 'utf-8');
-    const parsed = JSON.parse(raw) as ScanSession;
-    return parsed;
-  } catch {
-    return null;
+  const status = await readStatusDoc(id);
+  if (!status) return null;
+  const live = isStale(status, Date.now())
+    ? (await markStale(id)) ?? status
+    : status;
+  const sidecar = await readPlanSidecar(id);
+  if (sidecar) {
+    return { ...live, plan: sidecar.plan, hashes: sidecar.hashes };
   }
+  return live;
+}
+
+/**
+ * Read ONLY the compact status doc (#1945) — phase, progress, dedup counters,
+ * the derived review `summary`, error. Does NOT load the bulk plan/hashes, so
+ * the status poll stays small even for a 177k-file scan. Reaps a stale session
+ * (#1943) on read. The status route uses this; the apply path uses
+ * {@link getSession}. Returns null on a missing/corrupt id.
+ */
+export async function getSessionStatus(id: string): Promise<ScanSession | null> {
+  const status = await readStatusDoc(id);
+  if (!status) return null;
+  return isStale(status, Date.now()) ? (await markStale(id)) ?? status : status;
+}
+
+/** Reap one stale session to `error` (#1943). */
+async function markStale(id: string): Promise<ScanSession | null> {
+  return updateSession(id, {
+    phase: 'error',
+    error: 'Scan interrupted — please retry.',
+  });
 }
 
 /** Convenience: rehydrate the persisted `hashes` object back to the Map the
@@ -435,7 +647,7 @@ export function sessionHashes(session: ScanSession): Map<string, string> {
  *  the status route when the card re-attaches to a finished apply). Returns
  *  null if the session is gone. */
 export async function markApplied(id: string, appliedCount?: number): Promise<ScanSession | null> {
-  const current = await getSession(id);
+  const current = await readStatusDoc(id);
   // Routed through the per-id write lock so a trailing progress tick from the
   // apply pass can't clobber the terminal `applied` phase back to `applying`.
   // `step: 'done'` is the final progress; the count is what the card shows.
@@ -477,11 +689,14 @@ export async function readLog(
 /**
  * Any session left mid-flight (`scanning`/`applying`) belonged to a previous
  * backend process that died — flip it to `error` so a reopened card surfaces a
- * "try again" instead of polling forever for progress that will never come.
- * Mirrors jobStore.markCrashedOnStartup. Returns how many it flipped.
+ * "try again" instead of polling forever for progress that will never come
+ * (#1943). Also reaps any session whose heartbeat is already stale (belt-and-
+ * suspenders for a same-process zombie). Mirrors jobStore.markCrashedOnStartup.
+ * Returns how many it flipped.
  */
 export async function markCrashedOnStartup(): Promise<number> {
   const sessions = await listSessions();
+  const nowMs = Date.now();
   let count = 0;
   for (const s of sessions) {
     if (s.phase === 'scanning' || s.phase === 'applying') {
@@ -489,6 +704,9 @@ export async function markCrashedOnStartup(): Promise<number> {
         phase: 'error',
         error: 'Backend restarted while the disk-import job was running.',
       });
+      count += 1;
+    } else if (isStale(s, nowMs)) {
+      await markStale(s.id);
       count += 1;
     }
   }
@@ -501,7 +719,9 @@ export async function listSessions(): Promise<ScanSession[]> {
     const entries = await fs.readdir(SESSIONS_DIR);
     const sessions: ScanSession[] = [];
     for (const f of entries) {
-      if (!f.endsWith('.json')) continue;
+      // Only the compact status docs — skip the `.plan.json` sidecars (#1945)
+      // and the `.log` files.
+      if (!f.endsWith('.json') || f.endsWith('.plan.json')) continue;
       try {
         const raw = await fs.readFile(path.join(SESSIONS_DIR, f), 'utf-8');
         sessions.push(JSON.parse(raw) as ScanSession);
@@ -521,6 +741,7 @@ async function pruneSessions(keep: number): Promise<void> {
   sessions.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   for (const s of sessions.slice(keep)) {
     await fs.unlink(statePath(s.id)).catch(() => undefined);
+    await fs.unlink(planPath(s.id)).catch(() => undefined);
     await fs.unlink(logPath(s.id)).catch(() => undefined);
   }
 }

--- a/packages/backend/src/lib/fileShare/sambaSync.test.ts
+++ b/packages/backend/src/lib/fileShare/sambaSync.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/lldap/client', () => ({
   listLldapUsers: () => mockListLldapUsers(),
 }));
 
-import { ensureSambaPosixUser, setSambaPassword, parsePdbeditList } from './sambaSync';
+import { ensureSambaPosixUser, setSambaPassword, parsePdbeditList, syncSambaWithLldap } from './sambaSync';
 
 /**
  * Dispatch sendCommand by the `command` string. Each entry is a substring
@@ -136,5 +136,43 @@ describe('parsePdbeditList', () => {
   it('extracts usernames and drops malformed lines', () => {
     const out = 'alice:1001:Alice\nbob:1002:Bob\n\n  \nbad name:1:x';
     expect(parsePdbeditList(out)).toEqual(['alice', 'bob']);
+  });
+});
+
+describe('syncSambaWithLldap — persisted-passdb POSIX reconcile (#1946)', () => {
+  it('re-creates the ephemeral POSIX account for a user already in the persisted passdb', async () => {
+    // After a reboot the smbpasswd entry survives (passdb persisted) but the
+    // /etc/passwd account is gone → getent reports absent, so the sync must
+    // still `useradd` even though the user is NOT in `toAdd`.
+    mockListLldapUsers.mockResolvedValue({ ok: true, users: [{ id: 'alice' }] });
+    wireExec([
+      { match: 'pdbedit -L', code: 0, stdout: 'alice:1001:Alice\n' }, // already in passdb
+      { match: 'getent passwd alice', code: 2, stdout: '' },           // POSIX account wiped
+      { match: 'stat -c %g /data', code: 0, stdout: '1000\n' },
+      { match: 'useradd', code: 0 },
+    ]);
+    const res = await syncSambaWithLldap('Local');
+    expect(res.ok).toBe(true);
+    const commands = mockSendCommand.mock.calls.map(c => c[1].command);
+    // POSIX account re-created for the existing passdb user...
+    expect(commands.some(c => c.includes('useradd') && c.includes('alice'))).toBe(true);
+    // ...without re-running smbpasswd (no password overwrite for existing users).
+    expect(commands.some(c => c.includes('smbpasswd'))).toBe(false);
+    if (res.ok) {
+      expect(res.added).toEqual([]);
+      expect(res.users.find(u => u.id === 'alice')?.presentInSamba).toBe(true);
+    }
+  });
+
+  it('does not useradd when the POSIX account already exists (idempotent reconcile)', async () => {
+    mockListLldapUsers.mockResolvedValue({ ok: true, users: [{ id: 'bob' }] });
+    wireExec([
+      { match: 'pdbedit -L', code: 0, stdout: 'bob:1002:Bob\n' },
+      { match: 'getent passwd bob', code: 0, stdout: 'bob:x:1002:1000::/home/bob:/usr/sbin/nologin' },
+    ]);
+    const res = await syncSambaWithLldap('Local');
+    expect(res.ok).toBe(true);
+    const commands = mockSendCommand.mock.calls.map(c => c[1].command);
+    expect(commands.some(c => c.includes('useradd'))).toBe(false);
   });
 });

--- a/packages/backend/src/lib/fileShare/sambaSync.ts
+++ b/packages/backend/src/lib/fileShare/sambaSync.ts
@@ -177,7 +177,21 @@ async function listSambaUsers(node: string): Promise<string[] | null> {
  *     password (the operator can replace it via Settings → Integrations
  *     → File Share).
  *   - Users in Samba missing from LLDAP: removed via `pdbedit -x`.
- *   - Users present in both: left alone (no password overwrite).
+ *   - Users present in both: password left alone (no overwrite), but the
+ *     POSIX (Unix) account is re-ensured (see below).
+ *
+ * Re-ensuring the POSIX account on every sync is what makes a persisted
+ * passdb (#1946) actually usable after a reboot/redeploy. The passdb file
+ * (`/var/lib/samba/private/smbpasswd`) now lives on the `samba-private`
+ * volume, so the NT-hash (password) entries survive a pod recreate. The
+ * POSIX accounts those entries map to via `getpwnam`, however, live in the
+ * container's ephemeral `/etc/passwd` and are wiped on every restart — so
+ * a passdb user whose POSIX account is gone can't authenticate (`smbpasswd`
+ * / login fail to resolve the uid). This sync (invoked from the template
+ * post-deploy on every deploy) therefore reconciles a POSIX account for
+ * EVERY directory user, not just the newly-added ones, against the
+ * persisted passdb. Idempotent: `ensureSambaPosixUser` is a no-op when the
+ * account already exists.
  *
  * Returns the merged view of who's where so the UI can render a
  * per-user "Set password" affordance.
@@ -199,6 +213,17 @@ export async function syncSambaWithLldap(node: string = 'Local'): Promise<SambaS
 
   const toAdd = lldapUsers.filter(u => !sambaSet.has(u.id));
   const toRemove = sambaUsers.filter(s => !lldapSet.has(s));
+
+  // Re-ensure the ephemeral POSIX account for users already in the persisted
+  // passdb (#1946) — their /etc/passwd entry is gone after a restart even
+  // though the smbpasswd NT-hash survived. Best-effort + idempotent: a
+  // failure here doesn't change the user's presentInSamba state (the passdb
+  // entry already exists), it just means that one user can't authenticate
+  // until the next successful reconcile.
+  const alreadyInSamba = lldapUsers.filter(u => sambaSet.has(u.id));
+  for (const u of alreadyInSamba) {
+    await ensureSambaPosixUser(node, u.id);
+  }
 
   const added: string[] = [];
   for (const u of toAdd) {

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.test.tsx
@@ -362,4 +362,28 @@ describe('DiskImportSection (async flow)', () => {
     expect(window.localStorage.getItem('sb.diskImport.activeJob')).toBeNull();
     window.localStorage.clear();
   });
+
+  it('"Start over" on a stuck scan aborts the session and returns to the picker (#1943)', async () => {
+    // The scan starts but never advances past `scanning` — the zombie case.
+    vi.stubGlobal('fetch', mockAsyncFetch({
+      statuses: [
+        { ok: true, sessionId: 'sess-1', device: '/dev/sda1', phase: 'scanning', progress: { step: 'mount', scanned: 0, hashed: 0, copied: 0, bytes: 0, total: 0 } },
+      ],
+    }));
+    renderSection();
+
+    fireEvent.click(await screen.findByText('Scan disk'));
+    await waitFor(() => expect(screen.getByTestId('disk-import-progress')).toBeDefined());
+
+    // The escape hatch is offered; clicking it POSTs the abort + returns to pick.
+    fireEvent.click(screen.getByTestId('disk-import-start-over'));
+    await waitFor(() => expect(screen.getByText('Scan disk')).toBeDefined());
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const abortCall = fetchMock.mock.calls.find(c => String(c[0]).includes('disk-import/abort'));
+    expect(abortCall).toBeDefined();
+    expect(JSON.parse((abortCall![1] as RequestInit).body as string)).toEqual({ id: 'sess-1' });
+    expect(window.localStorage.getItem('sb.diskImport.activeJob')).toBeNull();
+    window.localStorage.clear();
+  });
 });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/DiskImportSection.tsx
@@ -607,52 +607,59 @@ const STEP_LABEL: Record<JobProgress['step'], string> = {
   done: 'Finishing up…',
 };
 
-/** Live phase + counts while a scan or apply runs in the background (#1897). */
-export function JobProgressView({ status }: { status: JobStatus | null }) {
+/** Live phase + counts while a scan or apply runs in the background (#1897). A
+ *  "Start over" escape (#1943) dismisses a stuck session and begins a fresh scan. */
+export function JobProgressView({
+  status,
+  onStartOver,
+}: {
+  status: JobStatus | null;
+  onStartOver?: () => void;
+}) {
   const p = status?.progress;
-  const isApply = status?.phase === 'applying';
   return (
     <div className="space-y-3" data-testid="disk-import-progress">
       <p className="text-sm text-gray-800 dark:text-gray-200 flex items-center gap-2">
         <Loader2 size={16} className="animate-spin text-blue-600" />
         {p ? STEP_LABEL[p.step] : 'Starting…'}
       </p>
-      {p && (
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
-          {!isApply && (
-            <>
-              <div className="flex justify-between">
-                <dt>Scanned</dt>
-                <dd className="text-gray-800 dark:text-gray-200">{p.scanned}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt>Hashed</dt>
-                <dd className="text-gray-800 dark:text-gray-200">
-                  {p.total > 0 ? `${p.hashed} / ${p.total}` : p.hashed}
-                </dd>
-              </div>
-            </>
-          )}
-          {isApply && (
-            <>
-              <div className="flex justify-between">
-                <dt>Copied</dt>
-                <dd className="text-gray-800 dark:text-gray-200">
-                  {p.total > 0 ? `${p.copied} / ${p.total}` : p.copied}
-                </dd>
-              </div>
-              <div className="flex justify-between">
-                <dt>Bytes</dt>
-                <dd className="text-gray-800 dark:text-gray-200">{formatBytes(p.bytes)}</dd>
-              </div>
-            </>
-          )}
-        </dl>
-      )}
+      {p && <ProgressCounters p={p} isApply={status?.phase === 'applying'} />}
       <p className="text-[11px] text-gray-400">
         This keeps running even if you close the page — reopen this card to check back.
       </p>
+      {onStartOver && <StartOverButton onClick={onStartOver} />}
     </div>
+  );
+}
+
+/** The scan (scanned/hashed) or apply (copied/bytes) counter grid (#1897). */
+function ProgressCounters({ p, isApply }: { p: JobProgress; isApply: boolean }) {
+  const ratio = (n: number) => (p.total > 0 ? `${n} / ${p.total}` : n);
+  const cells: Array<[string, React.ReactNode]> = isApply
+    ? [['Copied', ratio(p.copied)], ['Bytes', formatBytes(p.bytes)]]
+    : [['Scanned', p.scanned], ['Hashed', ratio(p.hashed)]];
+  return (
+    <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+      {cells.map(([label, value]) => (
+        <div key={label} className="flex justify-between">
+          <dt>{label}</dt>
+          <dd className="text-gray-800 dark:text-gray-200">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/** Escape hatch (#1943): dismiss a stuck/zombie scan and return to the picker. */
+function StartOverButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      data-testid="disk-import-start-over"
+      className="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 inline-flex items-center gap-1"
+    >
+      <RefreshCw size={12} /> Stuck? Cancel and start over
+    </button>
   );
 }
 
@@ -805,7 +812,29 @@ function useImportActions(c: {
     c.refreshDevices();
   };
 
-  return { runScan, applyPlan, reset };
+  // #1943: dismiss a stuck/zombie session and return to the picker so the user
+  // can start fresh. Best-effort abort POST, then the local reset frees the card.
+  const startOver = async () => {
+    await postAbort(job.jobId);
+    reset();
+  };
+
+  return { runScan, applyPlan, reset, startOver };
+}
+
+/** Best-effort POST of the disk-import abort route (#1943). Swallows errors —
+ *  the local card reset frees the UI regardless of the network result. */
+async function postAbort(jobId: string | null): Promise<void> {
+  if (!jobId) return;
+  try {
+    await fetch('/api/system/disk-import/abort', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: jobId }),
+    });
+  } catch {
+    /* abort is best-effort */
+  }
 }
 
 export default function DiskImportSection() {
@@ -841,7 +870,7 @@ export default function DiskImportSection() {
     [],
   );
 
-  const { runScan, applyPlan, reset } = useImportActions({
+  const { runScan, applyPlan, reset, startOver } = useImportActions({
     job, selected, review, rules, defaultOwner, addToast, setPhase,
     setReview, setApplied, setSelected, setRules, setDefaultOwner, refreshDevices,
   });
@@ -870,6 +899,7 @@ export default function DiskImportSection() {
       review={reviewProps}
       pick={{ devices, selected, loading: loadingDevices, scanning: false, onSelect: setSelected, onRefresh: refreshDevices, onScan: runScan }}
       done={{ applied: applied ?? 0, onReset: reset }}
+      onStartOver={() => void startOver()}
     />
   );
 }
@@ -882,6 +912,7 @@ function DiskImportBody({
   review,
   pick,
   done,
+  onStartOver,
 }: {
   phase: Phase;
   jobActive: boolean;
@@ -889,6 +920,8 @@ function DiskImportBody({
   review: React.ComponentProps<typeof DiskImportReview> | null | false;
   pick: React.ComponentProps<typeof DevicePicker>;
   done: React.ComponentProps<typeof ImportDone>;
+  /** Dismiss a stuck session + return to the picker (#1943). */
+  onStartOver: () => void;
 }) {
   if (phase === 'review' && review) {
     return (
@@ -905,7 +938,7 @@ function DiskImportBody({
   if (phase === 'scanning' || phase === 'applying' || jobActive) {
     return (
       <Card>
-        <JobProgressView status={jobStatus} />
+        <JobProgressView status={jobStatus} onStartOver={onStartOver} />
       </Card>
     );
   }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/useImportJob.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/useImportJob.ts
@@ -122,6 +122,9 @@ export interface UseImportJob {
   status: JobStatus | null;
   /** True while a background job is being polled. */
   active: boolean;
+  /** The id of the job being polled, or null when idle (#1943 — the card needs
+   *  it to abort a stuck session). */
+  jobId: string | null;
   /** Begin polling a freshly-handed-off job id (from scan/apply). */
   track: (jobId: string, kind: JobKind) => void;
   /** Stop polling + clear the persisted id (e.g. on reset). */
@@ -221,5 +224,5 @@ export function useImportJob(handlers: ImportJobHandlers): UseImportJob {
     });
   }, []);
 
-  return { status, active: jobId !== null, track, clear: stop };
+  return { status, active: jobId !== null, jobId, track, clear: stop };
 }

--- a/packages/frontend/src/app/api/system/disk-import/abort/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/abort/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { abortImportJob } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  /** The job id returned by `scan` / `apply`. */
+  id: z.string().min(1),
+});
+
+/**
+ * POST — abort/dismiss a disk-import job (#1943). The card's "Start over": flips
+ * a stuck or unwanted session terminal so it stops re-attaching and the user can
+ * immediately begin a fresh scan. This is the fix for a killed/orphaned scan that
+ * sat at 'Starting…' forever (a dead worker is also self-reaped on read, but the
+ * user shouldn't have to wait — this dismisses it now). Idempotent + no-op-safe:
+ * an unknown id returns 404; an already-terminal session returns its phase.
+ * Writes only the session store; never touches the imported host.
+ */
+export const POST = withApiHandler<z.infer<typeof Body>>(
+  { body: Body, tokenScope: 'mutate' },
+  async ({ body }) => {
+    try {
+      const result = await abortImportJob(body.id);
+      if (!result) {
+        return NextResponse.json({ ok: false, error: 'unknown job' }, { status: 404 });
+      }
+      return NextResponse.json({ ok: true, phase: result.phase });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:abort', status: 400, exposeMessage: true });
+    }
+  },
+);

--- a/templates/file-share/CHANGELOG.md
+++ b/templates/file-share/CHANGELOG.md
@@ -37,6 +37,17 @@ Required action: redeploy `file-share`. Existing mounts on
 need their Samba password set once via the Settings panel before
 they can mount.
 
+**Passdb persistence (#1946, no schema bump).** The Samba passdb
+(`/var/lib/samba/private/`, holding the smbpasswd NT-hash db) now
+persists on the `samba-private` host volume, so SMB users and their
+UI-set passwords survive a box reboot and a `file-share` redeploy with
+no manual re-provisioning. This is an additive `DirectoryOrCreate`
+mount — existing installs pick it up on their next redeploy (the dir
+starts empty and the post-deploy LLDAP→Samba sync + password-set
+populate it). The auto-sync now also re-creates the ephemeral POSIX
+accounts for every directory user on each deploy, so the persisted
+passwords are usable straight after a restart.
+
 ## v3 (breaking)
 
 **Syncthing GUI behind Authelia.**

--- a/templates/file-share/template.yml
+++ b/templates/file-share/template.yml
@@ -117,6 +117,14 @@ spec:
   # UI, deliberately not derived from the LLDAP password (Argon2/bcrypt →
   # NT-hash is not a reversible operation).
   #
+  # The passdb is persisted on the `samba-private` volume (mounted at
+  # /var/lib/samba/private below) so both the user entries and their
+  # UI-set passwords survive a reboot/redeploy (#1946). The ephemeral
+  # POSIX accounts that smbpasswd needs are re-created on each deploy by
+  # the LLDAP→Samba auto-sync, which now reconciles a POSIX account for
+  # every directory user — not just newly-added ones — against the
+  # persisted passdb (sambaSync.ts).
+  #
   # SHARE_USER + SHARE_PASSWORD remain as a legacy fallback so existing
   # installs keep working until the operator migrates family members
   # onto LLDAP-backed Samba accounts. The share config no longer pins
@@ -133,6 +141,26 @@ spec:
     volumeMounts:
       - mountPath: /data
         name: shared-data
+      # Persist Samba's passdb so SMB users + passwords survive a reboot /
+      # redeploy (#1946). The image's `passdb backend = smbpasswd` keeps the
+      # NT-hash db at /var/lib/samba/private/smbpasswd (verified: smbd -b →
+      # SMB_PASSWD_FILE=/var/lib/samba/private/smbpasswd, PRIVATE_DIR=
+      # /var/lib/samba/private). Without this mount that dir lives in the
+      # ephemeral container fs → every pod recreate wiped both the user
+      # entries AND their UI-set passwords. We persist the whole private/
+      # dir (kept SEPARATE from /etc/samba, which the entrypoint regenerates
+      # from env on every start — persisting that would clobber the rendered
+      # smb.conf). The POSIX accounts smbpasswd needs are still ephemeral;
+      # the LLDAP→Samba auto-sync recreates them on deploy (sambaSync.ts),
+      # and the persisted passdb supplies the passwords those accounts use.
+      #
+      # The dir stays core-owned: samba runs as container root, which under
+      # rootless podman is the host `core` user. It is NOT under the shared
+      # data/ tree that media/jellyfin :Z-relabels, so a non-core file here
+      # can't re-trigger the file-share relabel crash-loop
+      # (feedback_fileshare_relabel_crashloop).
+      - mountPath: /var/lib/samba/private
+        name: samba-private
 
   # 3. FileBrowser — Family-facing web file manager over the shared volume.
   # Binds on 0.0.0.0 — NPM lives in its own pod netns and can't reach the
@@ -209,6 +237,16 @@ spec:
   - name: filebrowser-db
     hostPath:
       path: {{DATA_DIR}}/file-share/filebrowser-db
+      type: DirectoryOrCreate
+  # samba-private holds Samba's passdb (smbpasswd NT-hash db + secrets.tdb).
+  # DirectoryOrCreate auto-provisions it on first deploy, so this is an
+  # additive mount — existing installs pick it up on redeploy with no schema
+  # bump / migration needed (the dir simply starts empty and the next
+  # LLDAP→Samba sync + password-set populate it; from then on it survives a
+  # reboot/redeploy). See the samba container's volumeMounts note (#1946).
+  - name: samba-private
+    hostPath:
+      path: {{DATA_DIR}}/file-share/samba-private
       type: DirectoryOrCreate
   - name: filebrowser-config
     hostPath:


### PR DESCRIPTION
## What
- disk-import: split the session into a compact status/summary doc (phase, counts, capped routing tree, dedup progress) and a bulk records sidecar loaded only at apply, so the status-poll hot path never loads the 145MB record array and progress ticks stop rewriting a 100MB+ JSON per tick. Liveness: every progress tick stamps a heartbeat; a non-terminal session whose heartbeat is stale (>10min) is reaped to `error` on status read and on backend start; new abort endpoint + a "Start over" card button so a zombie session is always dismissable and a fresh scan is always reachable.
- file-share: persist the Samba passdb (`/var/lib/samba/private` smbpasswd NT-hash db + secrets.tdb) on a host volume so SMB users and UI-set passwords survive a reboot/redeploy; kept separate from the env-regenerated smb.conf; passdb stays core-owned (no :Z relabel crash-loop). sambaSync re-creates the ephemeral POSIX account for every persisted passdb user on deploy so a restored user can still authenticate.

## Why
Closes #1945
Closes #1943
Closes #1946

## Risk
medium - touches the disk-import session lifecycle and the file-share template volume mounts; both are additive (no schema bump, no migration) and covered by new unit tests, but want a real :dev box verify.

## Rollback
git revert is enough (additive volume mount + store-split with backward-compat rehydration; no migration).

## Verification
- [x] npm run lint (0 errors, 373 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (full, 311 files / 2802 passed; one local-only stray templates/voice/ artifact not in repo or CI)
- [ ] /verify on FCoS :dev box (disk-import dashboard card + new /api/system/disk-import/abort route; file-share redeploy/reboot pdbedit -L survival)

AI-generated
<!-- sb-ai-comment -->