### PR TITLE
fix(disk-import): create RO mountpoint + use host data dir so the worker launches

### DIFF
--- a/packages/backend/src/lib/dirs.ts
+++ b/packages/backend/src/lib/dirs.ts
@@ -3,6 +3,15 @@ import path from 'path';
 import os from 'os';
 
 export const DATA_DIR = process.env.DATA_DIR || '/app/data';
+
+// HOST-side path of the data volume, as the agent's `safe_exec`/`podman run`
+// see it on the box — NOT the in-container DATA_DIR. The servicebay container
+// mounts `${DATA_ROOT}/servicebay:/app/data` (butane), so a host-side command
+// (e.g. the disk-import worker's `podman run -v <out>:/out` and its `mkdir`)
+// must use `/mnt/data/servicebay`, never `/app/data` (which is read-only on the
+// host). The quadlet sets HOST_DATA_DIR=${DATA_ROOT}/servicebay; it falls back
+// to DATA_DIR for dev/test where host == container.
+export const HOST_DATA_DIR = process.env.HOST_DATA_DIR || DATA_DIR;
 export const SSH_DIR = path.join(DATA_DIR, 'ssh');
 export const SERVICEBAY_BACKUP_DIR = path.join(DATA_DIR, 'backups');
 

--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -25,6 +25,14 @@ describe('launchWorker', () => {
     // device is mounted read-only, with sudo
     const mountCall = calls.find(c => c[0] === 'mount');
     expect(mountCall).toEqual(['mount', '-o', 'ro', '/dev/sda1', expect.any(String)]);
+    const mountpoint = mountCall![4];
+
+    // the RO mountpoint dir is created (sudo) BEFORE the mount — else
+    // "mount point does not exist" and the worker never launches (#1963).
+    const mkdirIdx = calls.findIndex(c => c[0] === 'mkdir' && c[1] === '-p' && c[2] === mountpoint);
+    const mountIdx = calls.findIndex(c => c[0] === 'mount');
+    expect(mkdirIdx).toBeGreaterThanOrEqual(0);
+    expect(mkdirIdx).toBeLessThan(mountIdx);
 
     // the container runs detached, --rm, memory-capped, with the worker image
     const podmanRun = calls.find(c => c[0] === 'podman' && c[1] === 'run')!;

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -46,7 +46,12 @@ export interface ImportDevice {
   display: string;
 }
 
-/** Base dir under DATA for per-run worker out volumes (status.json + plan). */
+/**
+ * Base dir for per-run worker out volumes (status.json + plan). `dataDir` must
+ * be the HOST-side data path (HOST_DATA_DIR), since the out dir is both `mkdir`'d
+ * and bind-mounted (`-v <outDir>:/out`) by host-side commands — the in-container
+ * `/app/data` is read-only on the host.
+ */
 export function workerOutBase(dataDir: string): string {
   return `${dataDir}/disk-import-runs`;
 }
@@ -77,6 +82,10 @@ export async function launchWorker(args: {
   const outDir = `${workerOutBase(dataDir)}/${runId}`;
   const container = containerName(runId);
 
+  // The mountpoint dir must exist before `mount` (same as mounter.mountReadOnly).
+  // It lives under /run (root-owned), so creating it needs sudo — without this
+  // the mount fails with "mount point does not exist" and the worker never runs.
+  await exec(['mkdir', '-p', mountpoint], { sudo: true });
   await exec(['mkdir', '-p', outDir]);
   await exec(['mount', '-o', 'ro', device, mountpoint], { sudo: true });
 

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -11,7 +11,7 @@
 import type { SafeExec } from '@servicebay/disk-import-worker';
 import type { WorkerStatus } from '@servicebay/disk-import-worker';
 
-import { DATA_DIR } from '@/lib/dirs';
+import { HOST_DATA_DIR } from '@/lib/dirs';
 import {
   launchWorker,
   readStatus,
@@ -44,7 +44,10 @@ export async function launchScan(args: {
 }): Promise<{ runId: string }> {
   const runId = randomRunId();
   await ensureWorkerImage(args.exec);
-  const run = await launchWorker({ ...args, runId, dataDir: DATA_DIR });
+  // HOST_DATA_DIR (not DATA_DIR): the worker's out dir is created + bind-mounted
+  // host-side via `podman run`, so it must be the box path (/mnt/data/servicebay),
+  // never the in-container /app/data (read-only on the host).
+  const run = await launchWorker({ ...args, runId, dataDir: HOST_DATA_DIR });
   await setActiveRun(run);
   return { runId: run.runId };
 }

--- a/tools/sb/internal/build/assets/fedora-coreos.bu
+++ b/tools/sb/internal/build/assets/fedora-coreos.bu
@@ -634,6 +634,10 @@ storage:
           Volume=/run/user/1000/podman/podman.sock:/run/podman/podman.sock
           Environment=CONTAINER_HOST=unix:///run/podman/podman.sock
           Volume=${DATA_ROOT}/servicebay:/app/data:Z
+          # HOST-side path of the /app/data volume. Host-side commands the agent
+          # runs (e.g. the disk-import worker's `podman run -v <out>:/out`) must
+          # use this box path, not the in-container /app/data (read-only on host).
+          Environment=HOST_DATA_DIR=${DATA_ROOT}/servicebay
           Environment=PORT=${SERVICEBAY_PORT}
           Environment=NODE_ENV=production
           Environment=HOST_USER=${HOST_USER}


### PR DESCRIPTION
## What
Fix the disk-import worker launcher so the one-shot `podman run --rm --memory` worker actually starts: create the RO mountpoint with `sudo mkdir -p` before the bind-mount, and pass the HOST data dir (`/mnt/data/servicebay`) via a new `HOST_DATA_DIR` to host-side `safe_exec` instead of the container-internal `/app/data`.

## Why
Closes #1963

## Risk
low — fix-forward for the box-verify regression on #1961; touches only the disk-import launcher, dirs helper, and the servicebay quadlet env.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 344 warnings — none added)
- [x] npm run check:arch
- [x] npm test (full — 2772 passed)
- [ ] /verify on FCoS :dev box (path-mandated — backend launcher + quadlet env + worker container launch)

AI-generated
<!-- sb-ai-comment -->