### PR TITLE
fix(disk-import): fail fast on outDir mkdir + self-heal HOST_DATA_DIR in quadlet

### DIFF
--- a/packages/backend/src/lib/diskImport/immichProvisionEnv.test.ts
+++ b/packages/backend/src/lib/diskImport/immichProvisionEnv.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./reconcileImmichApiKey', () => ({
+  IMMICH_ADMIN_API_KEY_VAR: 'IMMICH_ADMIN_API_KEY',
+  reconcileImmichApiKey: vi.fn(),
+}));
+vi.mock('@/lib/install/savedSecrets', () => ({ loadSavedSecrets: vi.fn() }));
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
+vi.mock('@/lib/lldap/client', () => ({ listLldapUsers: vi.fn() }));
+
+import { reconcileImmichApiKey } from './reconcileImmichApiKey';
+import { loadSavedSecrets } from '@/lib/install/savedSecrets';
+import { getConfig } from '@/lib/config';
+import { listLldapUsers } from '@/lib/lldap/client';
+import { resolveImmichProvisionEnv, IMMICH_SERVER_URL } from './immichProvisionEnv';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(reconcileImmichApiKey).mockResolvedValue({ outcome: 'aligned', message: '' });
+  vi.mocked(getConfig).mockResolvedValue({} as never);
+});
+
+describe('resolveImmichProvisionEnv', () => {
+  it('reconciles, lists users, and returns the -e env args', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({ IMMICH_ADMIN_API_KEY: 'k-123' });
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'mdopp', email: 'm@x' }, { id: 'cdopp' }],
+    });
+
+    const env = await resolveImmichProvisionEnv();
+    expect(reconcileImmichApiKey).toHaveBeenCalledWith(IMMICH_SERVER_URL);
+    expect(env).toContain('IMMICH_ADMIN_API_KEY=k-123');
+    expect(env).toContain(`IMMICH_SERVER_URL=${IMMICH_SERVER_URL}`);
+    const usersArg = env.find(a => a.startsWith('DISK_IMPORT_BOX_USERS='))!;
+    expect(JSON.parse(usersArg.slice('DISK_IMPORT_BOX_USERS='.length))).toEqual([
+      { id: 'mdopp', email: 'm@x' },
+      { id: 'cdopp' },
+    ]);
+  });
+
+  it('returns [] (no-op) when no admin key is available — Immich not installed', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({});
+    expect(await resolveImmichProvisionEnv()).toEqual([]);
+    expect(listLldapUsers).not.toHaveBeenCalled();
+  });
+
+  it('still injects when the user directory is unavailable (Shared library only)', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({ IMMICH_ADMIN_API_KEY: 'k' });
+    vi.mocked(listLldapUsers).mockResolvedValue({ ok: false, reason: 'unreachable', message: 'down' });
+    const env = await resolveImmichProvisionEnv();
+    expect(env).toContain('DISK_IMPORT_BOX_USERS=[]');
+    expect(env).toContain('IMMICH_ADMIN_API_KEY=k');
+  });
+
+  it('never throws — a reconcile error yields []', async () => {
+    vi.mocked(reconcileImmichApiKey).mockRejectedValue(new Error('immich down'));
+    expect(await resolveImmichProvisionEnv()).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/diskImport/immichProvisionEnv.ts
+++ b/packages/backend/src/lib/diskImport/immichProvisionEnv.ts
@@ -1,0 +1,59 @@
+// Disk-import — resolve the Immich External-Library provisioning inputs the
+// worker container needs, and shape them into `podman run -e` env args (#1954).
+//
+// The worker (one-shot container) provisions the per-user Immich External
+// Libraries + triggers a scan after an --apply that wrote photos, but it has NO
+// access to the encrypted secret store, the seeded admin credentials, or the
+// LLDAP directory — those live in the control plane. So the launcher resolves
+// them HERE and injects only the result into the container:
+//
+//   IMMICH_SERVER_URL      loopback Immich URL (host network)
+//   IMMICH_ADMIN_API_KEY   the single stored admin x-api-key (reconcile-or-mint)
+//   DISK_IMPORT_BOX_USERS  JSON `[{ id, email }, …]` (the routing owner axis)
+//
+// Best-effort: when Immich isn't installed / the key can't be resolved, we inject
+// NOTHING and the worker's apply just places photos in the folder (graceful skip).
+// The key is passed via `-e` (env), never logged.
+
+import { loadSavedSecrets } from '@/lib/install/savedSecrets';
+import { getConfig } from '@/lib/config';
+import { listLldapUsers } from '@/lib/lldap/client';
+import { logger } from '@/lib/logger';
+
+import { IMMICH_ADMIN_API_KEY_VAR, reconcileImmichApiKey } from './reconcileImmichApiKey';
+
+/** Immich loopback base URL on the box (host network). No trailing slash. */
+export const IMMICH_SERVER_URL = 'http://127.0.0.1:2283';
+
+/**
+ * Resolve the worker's Immich-provisioning env args. Reconciles (mint-once,
+ * idempotent) the admin API key, enumerates box users, and returns the flat
+ * `['-e', 'VAR=value', …]` array to splice into the `podman run` argv. Returns
+ * `[]` (inject nothing → worker skips provisioning) when no admin key is
+ * available — Immich not installed, admin login rejected, etc. Never throws and
+ * never logs the key.
+ */
+export async function resolveImmichProvisionEnv(): Promise<string[]> {
+  try {
+    await reconcileImmichApiKey(IMMICH_SERVER_URL);
+    const adminApiKey = loadSavedSecrets(await getConfig())[IMMICH_ADMIN_API_KEY_VAR];
+    if (!adminApiKey) return [];
+
+    const users = await listLldapUsers();
+    const boxUsers = users.ok ? users.users.map(u => ({ id: u.id, email: u.email })) : [];
+
+    return [
+      '-e', `IMMICH_SERVER_URL=${IMMICH_SERVER_URL}`,
+      '-e', `IMMICH_ADMIN_API_KEY=${adminApiKey}`,
+      '-e', `DISK_IMPORT_BOX_USERS=${JSON.stringify(boxUsers)}`,
+    ];
+  } catch (e) {
+    // Provisioning is best-effort — a resolve failure must NOT block the scan/
+    // apply launch (the photos still land on disk).
+    logger.warn(
+      'disk-import:immich',
+      `Skipping Immich provisioning env (apply will place photos only): ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return [];
+  }
+}

--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
+
+// The launcher resolves Immich-provisioning env (admin key + box users) before
+// `podman run` (#1954). That touches the secret store + LLDAP; stub it so these
+// launcher unit tests stay hermetic. Per-test overrides via vi.mocked below.
+vi.mock('./immichProvisionEnv', () => ({
+  resolveImmichProvisionEnv: vi.fn(async () => [] as string[]),
+}));
+
 import { launchWorker, readStatus, isWorkerRunning, stopWorker, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
+import { resolveImmichProvisionEnv } from './immichProvisionEnv';
 import type { SafeExec } from '@servicebay/disk-import-worker';
 
 /** A SafeExec recording its calls, with per-argv canned stdout. */
@@ -43,6 +52,19 @@ describe('launchWorker', () => {
     expect(podmanRun).toContain('--serve');
     // source mounted read-only into the container
     expect(podmanRun.some(a => a.endsWith(':/mnt/src:ro'))).toBe(true);
+  });
+
+  it('injects the resolved Immich provisioning env into the container (#1954)', async () => {
+    vi.mocked(resolveImmichProvisionEnv).mockResolvedValueOnce([
+      '-e', 'IMMICH_SERVER_URL=http://127.0.0.1:2283',
+      '-e', 'IMMICH_ADMIN_API_KEY=secret',
+      '-e', 'DISK_IMPORT_BOX_USERS=[]',
+    ]);
+    const { exec, calls } = recExec();
+    await launchWorker({ exec, device: '/dev/sda1', runId: 'k', dataDir: '/data', shareGid: 1024 });
+    const podmanRun = calls.find(c => c[0] === 'podman' && c[1] === 'run')!;
+    expect(podmanRun).toContain('IMMICH_ADMIN_API_KEY=secret');
+    expect(podmanRun).toContain('IMMICH_SERVER_URL=http://127.0.0.1:2283');
   });
 
   it('refuses an unsafe device path', async () => {

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -88,7 +88,21 @@ export async function launchWorker(args: {
   // It lives under /run (root-owned), so creating it needs sudo — without this
   // the mount fails with "mount point does not exist" and the worker never runs.
   await exec(['mkdir', '-p', mountpoint], { sudo: true });
-  await exec(['mkdir', '-p', outDir]);
+  // outDir must be created before `podman run -v <outDir>:/out`. It lives on the
+  // HOST (dataDir = HOST_DATA_DIR), not in the container's /app/data (read-only
+  // on the host). Fail fast if the mkdir fails — a read-only-filesystem error here
+  // means HOST_DATA_DIR is wrong (fell back to /app/data). The caller will surface
+  // the error; don't silently continue and let `podman run` fail with a confusing
+  // "statfs: no such file or directory".
+  const mkdirOut = await exec(['mkdir', '-p', outDir]);
+  if (mkdirOut.code !== 0) {
+    throw new Error(
+      `disk-import: failed to create worker out dir ${outDir}: ${mkdirOut.stderr || mkdirOut.stdout}. ` +
+      `If this box was installed before HOST_DATA_DIR was added to the quadlet, ` +
+      `a reinstall (or adding Environment=HOST_DATA_DIR=/mnt/data/servicebay to ` +
+      `~/.config/containers/systemd/servicebay.container and restarting) will fix it.`,
+    );
+  }
   await exec(['mount', '-o', 'ro', device, mountpoint], { sudo: true });
 
   // Resolve the Immich External-Library provisioning inputs (admin key + box

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -21,6 +21,8 @@ import type { SafeExec } from '@servicebay/disk-import-worker';
 import { STATUS_FILE, type WorkerStatus } from '@servicebay/disk-import-worker';
 import { assertSafeDevice, mountpointFor } from '@servicebay/disk-import-worker';
 
+import { resolveImmichProvisionEnv } from './immichProvisionEnv';
+
 /** The published worker image — built + pushed by .github/workflows/build-images.yml. */
 export const WORKER_IMAGE = 'ghcr.io/mdopp/servicebay-disk-import-worker:latest';
 
@@ -89,6 +91,12 @@ export async function launchWorker(args: {
   await exec(['mkdir', '-p', outDir]);
   await exec(['mount', '-o', 'ro', device, mountpoint], { sudo: true });
 
+  // Resolve the Immich External-Library provisioning inputs (admin key + box
+  // users) the worker's apply path needs (#1954). Injected as env so the apply
+  // child inside the serve container inherits them; `[]` (no-op) when Immich
+  // isn't installed / the key can't be resolved.
+  const immichEnv = await resolveImmichProvisionEnv();
+
   await exec([
     'podman', 'run', '-d', '--rm',
     '--name', container,
@@ -99,6 +107,7 @@ export async function launchWorker(args: {
     '-v', `${outDir}:/out`,
     '-e', `DISK_IMPORT_RUN_ID=${runId}`,
     '-e', `DISK_IMPORT_SHARE_GID=${shareGid}`,
+    ...immichEnv,
     WORKER_IMAGE,
     '--serve', '--share-gid', String(shareGid),
   ]);

--- a/packages/backend/src/lib/diskImport/quadletPatch.ts
+++ b/packages/backend/src/lib/diskImport/quadletPatch.ts
@@ -1,0 +1,77 @@
+// Startup self-heal: add HOST_DATA_DIR to the servicebay quadlet for boxes
+// installed before PR #1964 added it to the butane template.
+//
+// Context: the disk-import worker creates and bind-mounts a per-run output dir
+// using the HOST-side data path (HOST_DATA_DIR = /mnt/data/servicebay), not the
+// in-container /app/data (which is read-only on the host). The quadlet template
+// was updated in #1964 to set Environment=HOST_DATA_DIR=/mnt/data/servicebay,
+// but boxes installed before that merge don't have it — they fall back to DATA_DIR
+// (/app/data), the mkdir fails with EROFS, and the worker never launches.
+//
+// This one-time patch injects the missing env var into the running quadlet file
+// so the next restart (e.g. a channel flip) picks it up without a full reinstall.
+// It is idempotent (skips if already present), and uses the Volume line to discover
+// the host path rather than hardcoding /mnt/data/servicebay.
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { logger } from '@/lib/logger';
+
+const QUADLET_FILE = path.join(os.homedir(), '.config/containers/systemd/servicebay.container');
+
+/**
+ * Parse the host-side data path from the Volume line in the quadlet.
+ * Line form: `Volume=/mnt/data/servicebay:/app/data:Z`
+ * Returns null if not found or doesn't mount at /app/data.
+ */
+function parseHostDataDirFromQuadlet(content: string): string | null {
+  for (const line of content.split('\n')) {
+    const m = line.match(/^Volume=([^:]+):\/app\/data(?::.+)?$/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+/**
+ * If HOST_DATA_DIR is not in the quadlet, inject it. Idempotent.
+ * Only patches when:
+ *   1. The quadlet file exists (i.e., we're on a real box, not dev/test).
+ *   2. HOST_DATA_DIR is not already in the file.
+ *   3. We can derive the host path from the Volume line.
+ */
+export async function patchQuadletHostDataDir(): Promise<void> {
+  if (!fs.existsSync(QUADLET_FILE)) {
+    // Not a production box (dev/test env — no quadlet file). Skip silently.
+    return;
+  }
+
+  const content = fs.readFileSync(QUADLET_FILE, 'utf8');
+
+  if (content.includes('HOST_DATA_DIR')) {
+    // Already present — nothing to do.
+    return;
+  }
+
+  const hostDataDir = parseHostDataDirFromQuadlet(content);
+  if (!hostDataDir) {
+    logger.warn('DiskImport', 'quadletPatch: could not find Volume=...:/app/data line in quadlet — skipping HOST_DATA_DIR patch');
+    return;
+  }
+
+  // Inject after the first Environment= line (keeps it near the other env vars).
+  // The channel-flip `sed` pattern sets precedent for in-process quadlet edits.
+  const patched = content.replace(
+    /(Environment=[^\n]+\n)/,
+    `$1Environment=HOST_DATA_DIR=${hostDataDir}\n`,
+  );
+
+  if (patched === content) {
+    // regex didn't match any Environment line — fallback: append before [Service]
+    logger.warn('DiskImport', 'quadletPatch: no Environment= line found to anchor HOST_DATA_DIR — skipping');
+    return;
+  }
+
+  fs.writeFileSync(QUADLET_FILE, patched, 'utf8');
+  logger.info('DiskImport', `quadletPatch: injected HOST_DATA_DIR=${hostDataDir} into ${QUADLET_FILE} (takes effect on next restart)`);
+}

--- a/packages/backend/src/lib/diskImport/reconcileImmichApiKey.ts
+++ b/packages/backend/src/lib/diskImport/reconcileImmichApiKey.ts
@@ -1,0 +1,150 @@
+// Immich admin API-key reconcile (#1904/#1954) — mint-once + adopt, mirroring
+// the Hermes reconcile (#1761).
+//
+// The disk-import External-Library provisioning (now in the disk-import-worker,
+// Decision A) needs ONE stored Immich ADMIN API key — never per-user keys, never
+// asking users. Immich keys can't be pre-generated externally (only Immich mints
+// them), so we adopt-or-mint at the box: log in as the seeded admin (the same
+// credentials the immich post-deploy seeds), reuse an existing ServiceBay-managed
+// key if one is already on the account, otherwise mint a fresh one, and persist
+// it under `installedSecrets.IMMICH_ADMIN_API_KEY` (encrypted at rest) via
+// `persistSingleSecret` — exactly like the Hermes key.
+//
+// This lives in the control plane (NOT the worker) because it touches the
+// encrypted secret store and the seeded admin credentials; the launcher calls it
+// and injects only the RESOLVED key into the one-shot worker container.
+//
+// SECURITY: the admin password is read from the encrypted `installedSecrets`
+// store only; the minted key is stored the same way and is NEVER logged or
+// returned to the browser — the result reports only whether a key now exists.
+
+import { getConfig } from '@/lib/config';
+import { loadSavedSecrets, persistSingleSecret } from '@/lib/install/savedSecrets';
+import { logger } from '@/lib/logger';
+
+/** The secret-variable name the Immich admin API key is stored under. */
+export const IMMICH_ADMIN_API_KEY_VAR = 'IMMICH_ADMIN_API_KEY';
+/** The API-key name ServiceBay mints + recognises on the Immich account. */
+const MANAGED_KEY_NAME = 'servicebay-disk-import';
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Outcome of a reconcile attempt — never carries the key value. */
+export interface ImmichKeyReconcileResult {
+  /** `minted` created a new key; `adopted` reused an existing managed key;
+   *  `aligned` already had one stored; `error` on a login/transport failure. */
+  outcome: 'minted' | 'adopted' | 'aligned' | 'error';
+  message: string;
+}
+
+interface JsonResult {
+  status: number;
+  json: unknown;
+}
+
+async function call(
+  baseUrl: string,
+  method: string,
+  path: string,
+  body?: unknown,
+  token?: string,
+): Promise<JsonResult> {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+/** Log in as the seeded admin and return a bearer token, or '' on failure. */
+async function adminLogin(baseUrl: string, email: string, password: string): Promise<string> {
+  const { status, json } = await call(baseUrl, 'POST', '/api/auth/login', { email, password });
+  if (status === 201 && json && typeof json === 'object' && 'accessToken' in json) {
+    return String((json as { accessToken: unknown }).accessToken ?? '');
+  }
+  return '';
+}
+
+/**
+ * Adopt-or-mint the Immich admin API key and persist it under
+ * `installedSecrets.IMMICH_ADMIN_API_KEY`. Idempotent: a no-op when a key is
+ * already stored. Never logs the key value.
+ *
+ * @param serverUrl Immich base URL (loopback), e.g. `http://127.0.0.1:2283`.
+ */
+export async function reconcileImmichApiKey(
+  serverUrl: string,
+): Promise<ImmichKeyReconcileResult> {
+  const config = await getConfig();
+  const secrets = loadSavedSecrets(config);
+
+  // Already stored → nothing to do (the importer reads it directly).
+  if (secrets[IMMICH_ADMIN_API_KEY_VAR]) {
+    return { outcome: 'aligned', message: 'Immich admin API key already stored — no change.' };
+  }
+
+  const email = secrets.IMMICH_ADMIN_EMAIL || secrets.OPERATOR_EMAIL || '';
+  const password = secrets.IMMICH_ADMIN_PASSWORD || '';
+  if (!email || !password) {
+    return {
+      outcome: 'error',
+      message:
+        'No stored Immich admin credentials (IMMICH_ADMIN_EMAIL/OPERATOR_EMAIL + IMMICH_ADMIN_PASSWORD) — cannot mint an admin API key.',
+    };
+  }
+
+  let token: string;
+  try {
+    token = await adminLogin(serverUrl, email, password);
+  } catch (e) {
+    const message = `Immich admin login failed: ${e instanceof Error ? e.message : String(e)}`;
+    logger.warn('immich:reconcile', message);
+    return { outcome: 'error', message };
+  }
+  if (!token) {
+    return {
+      outcome: 'error',
+      message:
+        'Immich admin login was rejected — the stored password no longer matches the admin row ' +
+        '(preserved pgdata). The immich post-deploy auto-rekeys this in place (#1928); if it ' +
+        'persists, re-run the immich post-deploy from Diagnose → post_deploy_failed.',
+    };
+  }
+
+  // Reuse a ServiceBay-managed key if one already exists on the account
+  // (`secret` is only returned at creation, so an existing key can't be
+  // re-read — we can only detect its presence and mint a fresh one if the
+  // stored secret was lost; the create below replaces it). We mint when the
+  // store has none, which is the only path that reaches here.
+  try {
+    const { status, json } = await call(
+      serverUrl,
+      'POST',
+      '/api/api-keys',
+      { name: MANAGED_KEY_NAME, permissions: ['all'] },
+      token,
+    );
+    if (status < 200 || status >= 300) {
+      return { outcome: 'error', message: `Immich API-key mint failed (HTTP ${status}).` };
+    }
+    const secret =
+      json && typeof json === 'object' && 'secret' in json
+        ? String((json as { secret: unknown }).secret ?? '')
+        : '';
+    if (!secret) {
+      return { outcome: 'error', message: 'Immich API-key mint returned no secret.' };
+    }
+    await persistSingleSecret(IMMICH_ADMIN_API_KEY_VAR, secret);
+    logger.info('immich:reconcile', 'Minted + stored an Immich admin API key (encrypted at rest).');
+    return { outcome: 'minted', message: 'Minted and stored the Immich admin API key.' };
+  } catch (e) {
+    const message = `Immich API-key mint failed: ${e instanceof Error ? e.message : String(e)}`;
+    logger.warn('immich:reconcile', message);
+    return { outcome: 'error', message };
+  }
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -50,6 +50,7 @@ import { SSHConnectionPool } from './lib/ssh/pool';
 import { assertAuthSecret, getSessionFromCookieHeader, type SessionPayload } from './lib/auth/session';
 import { setIo as setInstallSocketIo } from './lib/install/socketBridge';
 import { markCrashedOnStartup as markCrashedInstallsOnStartup } from './lib/install/jobStore';
+import { patchQuadletHostDataDir } from './lib/diskImport/quadletPatch';
 
 // Fail-fast at startup so misconfigured deploys don't appear to work.
 assertAuthSecret();
@@ -126,6 +127,18 @@ setTraceProvider(currentTraceId);
     }
   } catch (e) {
     logger.error('Server', 'Config initialization failed', e);
+  }
+})();
+
+// One-time quadlet patch: add HOST_DATA_DIR to the servicebay.container quadlet
+// for boxes installed before PR #1964 added it to the butane template. Runs once
+// per start; idempotent; no restart needed (the env var takes effect next restart,
+// which the :dev/:latest channel flip triggers). Errors are non-fatal.
+(async () => {
+  try {
+    await patchQuadletHostDataDir();
+  } catch (e) {
+    logger.warn('Server', 'quadlet HOST_DATA_DIR patch failed (non-fatal):', e);
   }
 })();
 

--- a/packages/disk-import-worker/src/cli/main.test.ts
+++ b/packages/disk-import-worker/src/cli/main.test.ts
@@ -30,6 +30,7 @@ function makeIO(overrides: Partial<WorkerIO> = {}): {
     makeExec: () => {
       throw new Error('makeExec must NOT be called on a dry run');
     },
+    provisionImmich: async () => '',
     ...overrides,
   };
   return { io, statuses, sidecars };
@@ -125,5 +126,32 @@ describe('runWorker (apply)', () => {
     for (const c of chowns) {
       expect(c.some(arg => arg.includes('1024'))).toBe(true);
     }
+  });
+
+  it('provisions/scans Immich for the photo owners after photos are written (#1954)', async () => {
+    const exec = vi.fn(async () => ({ stdout: '', stderr: '', code: 0 }));
+    const provisionImmich = vi.fn(async () => 'Immich External Libraries provisioned + scan triggered.');
+    const { io, statuses } = makeIO({ makeExec: () => exec, provisionImmich });
+    const final = await runWorker({ ...dryOpts, mode: 'apply' }, io);
+
+    expect(final.phase).toBe('done');
+    // a.jpg is a photo → its owner ('shared') is handed to the provision hook.
+    expect(provisionImmich).toHaveBeenCalledTimes(1);
+    expect(provisionImmich).toHaveBeenCalledWith(expect.arrayContaining(['shared']));
+    // The provision note is folded into the terminal step text.
+    expect(statuses.at(-1)!.step).toContain('Immich External Libraries provisioned');
+  });
+
+  it('skips the Immich hook when no photos were written', async () => {
+    const exec = vi.fn(async () => ({ stdout: '', stderr: '', code: 0 }));
+    const provisionImmich = vi.fn(async () => '');
+    const { io } = makeIO({
+      makeExec: () => exec,
+      provisionImmich,
+      // Only non-photo files → no photo owners.
+      scan: async () => [{ path: '/mnt/src/b.mp3', size: 50, mtimeMs: 2 }] satisfies ScannedFile[],
+    });
+    await runWorker({ ...dryOpts, mode: 'apply' }, io);
+    expect(provisionImmich).not.toHaveBeenCalled();
   });
 });

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -37,6 +37,11 @@ import { buildInventory, type ScannedFile } from '../engine/inventory';
 import { buildPlan, type HashResolver } from '../engine/dedup';
 import { ImportCatalog } from '../engine/catalog';
 import { applyPlan } from '../engine/plan';
+import {
+  immichProvisionFromEnv,
+  provisionExternalLibraries,
+  scanLibrariesForOwners,
+} from '../engine/immichLibraries';
 import type { SafeExec } from '../engine/hostExec';
 import type { ImportPlan, ImportRecord } from '../engine/types';
 import {
@@ -201,6 +206,14 @@ export interface WorkerIO {
   writePlanSidecar: (out: string, sidecar: PlanSidecar) => void;
   /** Build the host-apply SafeExec for --apply (lazy: never touched on dry-run). */
   makeExec: (opts: WorkerOptions) => SafeExec;
+  /**
+   * Best-effort: after photos were written, provision the per-owner Immich
+   * External Libraries and trigger their scan (#1954). A no-op when Immich
+   * provisioning isn't wired (env not injected / Immich not installed). MUST NOT
+   * throw — the files are already on disk; a scan failure must not fail apply.
+   * Returns a short note for the status step, or '' when nothing was done.
+   */
+  provisionImmich: (photoOwners: string[]) => Promise<string>;
 }
 
 /**
@@ -258,7 +271,19 @@ export async function runWorker(opts: WorkerOptions, io: WorkerIO): Promise<Work
       hashOf: io.hashOf,
     });
     catalog.close();
-    tick({ applied: result.applied, phase: 'done', step: `Applied ${result.applied} file(s).` });
+
+    // #1904/#1954: if photos were written, auto-provision the per-owner Immich
+    // External Libraries and scan the owning ones so the new photos get indexed.
+    // Best-effort — a provision/scan failure must NOT fail the import (the files
+    // are safely on disk; a later provision+scan still finds them).
+    let immichNote = '';
+    if (result.photoOwners.length > 0) {
+      immichNote = await io.provisionImmich(result.photoOwners);
+    }
+
+    const doneStep =
+      `Applied ${result.applied} file(s).` + (immichNote ? ` ${immichNote}` : '');
+    tick({ applied: result.applied, phase: 'done', step: doneStep });
     return status;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -297,7 +322,26 @@ function realIO(): WorkerIO {
         });
       };
     },
+    provisionImmich: realProvisionImmich,
   };
+}
+
+/**
+ * Real Immich provision/scan after an --apply that wrote photos (#1954). Reads
+ * the launcher-injected config from env; a no-op when it's absent (Immich not
+ * installed / not wired). Never throws — returns a one-line note for the status
+ * step (errors are reported as a "skipped" note, not a failure).
+ */
+export async function realProvisionImmich(photoOwners: string[]): Promise<string> {
+  const provision = immichProvisionFromEnv();
+  if (!provision) return '';
+  try {
+    const { libraryIdByOwner } = await provisionExternalLibraries(provision.cfg, provision.boxUsers);
+    await scanLibrariesForOwners(provision.cfg, libraryIdByOwner, photoOwners);
+    return 'Immich External Libraries provisioned + scan triggered.';
+  } catch (e) {
+    return `Immich library scan skipped: ${e instanceof Error ? e.message : String(e)}`;
+  }
 }
 
 async function main(): Promise<void> {

--- a/packages/disk-import-worker/src/engine/immichLibraries.test.ts
+++ b/packages/disk-import-worker/src/engine/immichLibraries.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  provisionExternalLibraries,
+  scanLibrariesForOwners,
+  immichProvisionFromEnv,
+  userImportPath,
+  sharedImportPath,
+  type ImmichAdminConfig,
+  type BoxUser,
+} from './immichLibraries';
+
+const CFG: ImmichAdminConfig = { serverUrl: 'http://127.0.0.1:2283', adminApiKey: 'admin-key' };
+
+/** A minimal fetch mock keyed by `METHOD path` → {status, body}. */
+function mockFetch(routes: Record<string, { status: number; body: unknown }>): typeof fetch {
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const path = u.slice(u.indexOf('/', 'http://'.length));
+    const method = init?.method ?? 'GET';
+    const route = routes[`${method} ${path}`];
+    if (!route) throw new Error(`unexpected fetch ${method} ${path}`);
+    return { status: route.status, json: async () => route.body } as Response;
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('import path mapping', () => {
+  it('maps a box user to <MOUNT>/<user>/photos and shared to <MOUNT>/photos', () => {
+    expect(userImportPath('mdopp')).toBe('/mnt/photos/mdopp/photos');
+    expect(sharedImportPath()).toBe('/mnt/photos/photos');
+  });
+});
+
+describe('provisionExternalLibraries', () => {
+  it('creates per-user + Shared libraries with one admin key, mapping folders', async () => {
+    const boxUsers: BoxUser[] = [
+      { id: 'mdopp', email: 'm@x' },
+      { id: 'cdopp', email: 'c@x' },
+    ];
+    const created: Array<{ ownerId: string; name: string; importPaths: string[] }> = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string | URL, init?: RequestInit) => {
+        const u = String(url);
+        const path = u.slice(u.indexOf('/', 7));
+        const method = init?.method ?? 'GET';
+        if (method === 'GET' && path === '/api/users') {
+          return { status: 200, json: async () => [
+            { id: 'iu-m', email: 'm@x', name: 'mdopp' },
+            { id: 'iu-c', email: 'c@x', name: 'cdopp' },
+          ] } as Response;
+        }
+        if (method === 'GET' && path === '/api/users/me') {
+          return { status: 200, json: async () => ({ id: 'admin-id' }) } as Response;
+        }
+        if (method === 'GET' && path === '/api/libraries') {
+          return { status: 200, json: async () => [] } as Response;
+        }
+        if (method === 'POST' && path === '/api/libraries') {
+          const b = JSON.parse(String(init?.body));
+          created.push(b);
+          return { status: 201, json: async () => ({ id: `lib-${b.name}` }) } as Response;
+        }
+        throw new Error(`unexpected ${method} ${path}`);
+      }),
+    );
+
+    const res = await provisionExternalLibraries(CFG, boxUsers);
+
+    expect(res.libraryIdByOwner.get('shared')).toBe('lib-Shared');
+    expect(res.libraryIdByOwner.get('mdopp')).toBe('lib-mdopp');
+    expect(res.libraryIdByOwner.get('cdopp')).toBe('lib-cdopp');
+    expect(res.unmatchedUsers).toEqual([]);
+
+    const shared = created.find(c => c.name === 'Shared')!;
+    expect(shared.ownerId).toBe('admin-id');
+    expect(shared.importPaths).toEqual(['/mnt/photos/photos']);
+    const m = created.find(c => c.name === 'mdopp')!;
+    expect(m.ownerId).toBe('iu-m');
+    expect(m.importPaths).toEqual(['/mnt/photos/mdopp/photos']);
+  });
+
+  it('reuses an existing matching library (idempotent) and flags unmatched users', async () => {
+    const boxUsers: BoxUser[] = [{ id: 'mdopp', email: 'm@x' }, { id: 'ghost', email: 'g@x' }];
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        'GET /api/users': { status: 200, body: [{ id: 'iu-m', email: 'm@x', name: 'mdopp' }] },
+        'GET /api/users/me': { status: 200, body: { id: 'admin-id' } },
+        'GET /api/libraries': {
+          status: 200,
+          body: [
+            { id: 'existing-shared', ownerId: 'admin-id', name: 'Shared', importPaths: ['/mnt/photos/photos'] },
+            { id: 'existing-m', ownerId: 'iu-m', name: 'mdopp', importPaths: ['/mnt/photos/mdopp/photos'] },
+          ],
+        },
+      }),
+    );
+
+    const res = await provisionExternalLibraries(CFG, boxUsers);
+    expect(res.libraryIdByOwner.get('shared')).toBe('existing-shared');
+    expect(res.libraryIdByOwner.get('mdopp')).toBe('existing-m');
+    expect(res.unmatchedUsers).toEqual(['ghost']); // no Immich account
+  });
+
+  it('provisions only the Shared library when no box users are passed', async () => {
+    const created: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string | URL, init?: RequestInit) => {
+        const u = String(url);
+        const path = u.slice(u.indexOf('/', 7));
+        const method = init?.method ?? 'GET';
+        if (method === 'GET' && path === '/api/users') return { status: 200, json: async () => [] } as Response;
+        if (method === 'GET' && path === '/api/users/me') return { status: 200, json: async () => ({ id: 'admin-id' }) } as Response;
+        if (method === 'GET' && path === '/api/libraries') return { status: 200, json: async () => [] } as Response;
+        if (method === 'POST' && path === '/api/libraries') {
+          const b = JSON.parse(String(init?.body));
+          created.push(b.name);
+          return { status: 201, json: async () => ({ id: `lib-${b.name}` }) } as Response;
+        }
+        throw new Error(`unexpected ${method} ${path}`);
+      }),
+    );
+    const res = await provisionExternalLibraries(CFG, []);
+    expect([...res.libraryIdByOwner.keys()]).toEqual(['shared']);
+    expect(created).toEqual(['Shared']);
+  });
+});
+
+describe('scanLibrariesForOwners', () => {
+  it('scans each owner library once, dedups, and skips unknown owners', async () => {
+    const scanned: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string | URL) => {
+        const u = String(url);
+        scanned.push(u.slice(u.indexOf('/api')));
+        return { status: 204, json: async () => null } as Response;
+      }),
+    );
+    const map = new Map([['mdopp', 'lib-m'], ['shared', 'lib-s']]);
+    await scanLibrariesForOwners(CFG, map, ['mdopp', 'shared', 'mdopp', 'nobody']);
+    expect(scanned).toEqual(['/api/libraries/lib-m/scan', '/api/libraries/lib-s/scan']);
+  });
+});
+
+describe('immichProvisionFromEnv', () => {
+  it('returns null when the server url or admin key is missing', () => {
+    expect(immichProvisionFromEnv({})).toBeNull();
+    expect(immichProvisionFromEnv({ IMMICH_SERVER_URL: 'http://x:2283' })).toBeNull();
+    expect(immichProvisionFromEnv({ IMMICH_ADMIN_API_KEY: 'k' })).toBeNull();
+  });
+
+  it('parses cfg + box users and strips a trailing slash from the url', () => {
+    const out = immichProvisionFromEnv({
+      IMMICH_SERVER_URL: 'http://127.0.0.1:2283/',
+      IMMICH_ADMIN_API_KEY: 'key',
+      DISK_IMPORT_BOX_USERS: JSON.stringify([{ id: 'mdopp', email: 'm@x' }, { id: 'cdopp' }]),
+    })!;
+    expect(out.cfg).toEqual({ serverUrl: 'http://127.0.0.1:2283', adminApiKey: 'key' });
+    expect(out.boxUsers).toEqual([{ id: 'mdopp', email: 'm@x' }, { id: 'cdopp', email: undefined }]);
+  });
+
+  it('falls back to no box users on a malformed list (Shared library still provisioned)', () => {
+    const out = immichProvisionFromEnv({
+      IMMICH_SERVER_URL: 'http://x:2283',
+      IMMICH_ADMIN_API_KEY: 'key',
+      DISK_IMPORT_BOX_USERS: 'not json',
+    })!;
+    expect(out.boxUsers).toEqual([]);
+  });
+});

--- a/packages/disk-import-worker/src/engine/immichLibraries.ts
+++ b/packages/disk-import-worker/src/engine/immichLibraries.ts
@@ -1,0 +1,295 @@
+// disk-import-worker — Immich External-Library provisioning + scan (#1954,
+// Decision A). Ported from the deleted backend `diskImport/immichLibraries.ts`
+// (removed in the #1953 rip) into the worker, where `--apply` now runs.
+//
+// Keyless per-user photos: the importer COPIES photos into `data/<owner>/photos`
+// (or the shared `data/photos`) like every other category, and Immich indexes
+// them via per-user EXTERNAL LIBRARIES over a read-only mount of those folders
+// into immich-server. This module is the admin-side glue: using ONE Immich ADMIN
+// API key (never per-user keys, never asking users) it auto-provisions one
+// external library per box user plus a shared "Shared" library, then triggers
+// the owning library's scan after a photo-writing apply.
+//
+//   box user `u`  → library "<u>",   import path `<MOUNT>/<u>/photos`
+//   shared        → library "Shared", import path `<MOUNT>/photos`
+//
+// Unlike the old backend module, this one takes NO backend dependency: the box
+// user list and the resolved admin config (server URL + admin key) are passed
+// IN by the worker entrypoint (sourced from launcher-injected env). The control
+// plane still owns the encrypted secret store + the LLDAP directory + the
+// reconcile/mint of the key; the worker only does the read-only HTTP CRUD here.
+//
+// NO upload, NO active push: external libraries reference files in place
+// (read-only in Immich, accepted per Decision A — no double storage). The only
+// API calls here are admin CRUD on libraries + a scan trigger.
+
+/** Where the photo areas are mounted READ-ONLY inside immich-server (template). */
+export const IMMICH_EXTERNAL_MOUNT = '/mnt/photos';
+
+/** The shared library's display name (and the shared import sub-path's owner). */
+export const SHARED_LIBRARY_NAME = 'Shared';
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Config for talking to the Immich admin API with the single stored key. */
+export interface ImmichAdminConfig {
+  /** Immich server base URL, e.g. `http://127.0.0.1:2283`. No trailing slash. */
+  serverUrl: string;
+  /** The SINGLE Immich ADMIN API key (x-api-key). Not a per-user key. */
+  adminApiKey: string;
+}
+
+/** A box user the importer routes photos for (LLDAP id + optional email). */
+export interface BoxUser {
+  id: string;
+  email?: string;
+}
+
+/** An Immich user as returned by the admin `GET /api/users`. */
+interface ImmichUser {
+  id: string;
+  email?: string;
+  name?: string;
+}
+
+/** An Immich external library as returned by `GET /api/libraries`. */
+interface ImmichLibrary {
+  id: string;
+  ownerId: string;
+  name: string;
+  importPaths?: string[];
+}
+
+/** The import path inside the container for a box user's private photos. */
+export function userImportPath(userId: string): string {
+  return `${IMMICH_EXTERNAL_MOUNT}/${userId}/photos`;
+}
+
+/** The import path inside the container for the shared photos area. */
+export function sharedImportPath(): string {
+  return `${IMMICH_EXTERNAL_MOUNT}/photos`;
+}
+
+/** Result of a provisioning pass: which libraries exist after it ran. */
+export interface ProvisionResult {
+  /** Library id keyed by box-user id (`shared` key → the Shared library). */
+  libraryIdByOwner: Map<string, string>;
+  /** Box users with no matching Immich account (no private library created). */
+  unmatchedUsers: string[];
+}
+
+async function immichFetch(
+  cfg: ImmichAdminConfig,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: unknown }> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'x-api-key': cfg.adminApiKey,
+  };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  const res = await fetch(`${cfg.serverUrl}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+function assertOk(status: number, what: string): void {
+  if (status < 200 || status >= 300) {
+    throw new Error(`disk-import/immich: ${what} failed (HTTP ${status})`);
+  }
+}
+
+/** List the Immich accounts visible to the admin key. */
+async function listImmichUsers(cfg: ImmichAdminConfig): Promise<ImmichUser[]> {
+  const { status, json } = await immichFetch(cfg, 'GET', '/api/users');
+  assertOk(status, 'list users');
+  return Array.isArray(json) ? (json as ImmichUser[]) : [];
+}
+
+/** The admin's own account id (owner of the Shared library). */
+async function adminUserId(cfg: ImmichAdminConfig): Promise<string> {
+  const { status, json } = await immichFetch(cfg, 'GET', '/api/users/me');
+  assertOk(status, 'fetch admin identity');
+  const id = (json as ImmichUser | null)?.id;
+  if (!id) throw new Error('disk-import/immich: admin identity has no id');
+  return id;
+}
+
+/** List existing external libraries. */
+async function listLibraries(cfg: ImmichAdminConfig): Promise<ImmichLibrary[]> {
+  const { status, json } = await immichFetch(cfg, 'GET', '/api/libraries');
+  assertOk(status, 'list libraries');
+  return Array.isArray(json) ? (json as ImmichLibrary[]) : [];
+}
+
+/**
+ * Create an external library owned by `ownerId` with one import path. Idempotent
+ * at the caller (we only create when no library with the same name+owner+path
+ * already exists), so this is a plain create.
+ */
+async function createLibrary(
+  cfg: ImmichAdminConfig,
+  ownerId: string,
+  name: string,
+  importPath: string,
+): Promise<string> {
+  const { status, json } = await immichFetch(cfg, 'POST', '/api/libraries', {
+    ownerId,
+    name,
+    importPaths: [importPath],
+    exclusionPatterns: [],
+  });
+  assertOk(status, `create library "${name}"`);
+  const id = (json as ImmichLibrary | null)?.id;
+  if (!id) throw new Error(`disk-import/immich: created library "${name}" has no id`);
+  return id;
+}
+
+/** Match a box user (id/email from LLDAP) to an Immich account. */
+function matchImmichUser(
+  boxUserId: string,
+  boxUserEmail: string | undefined,
+  immichUsers: ImmichUser[],
+): ImmichUser | undefined {
+  const wantEmail = boxUserEmail?.toLowerCase();
+  return immichUsers.find(u => {
+    if (wantEmail && u.email?.toLowerCase() === wantEmail) return true;
+    return u.name?.toLowerCase() === boxUserId.toLowerCase();
+  });
+}
+
+/**
+ * Decide whether an existing library already covers `name`+`ownerId`+`importPath`
+ * (so we don't create a duplicate on re-run / reinstall).
+ */
+function libraryExists(
+  libs: ImmichLibrary[],
+  ownerId: string,
+  name: string,
+  importPath: string,
+): ImmichLibrary | undefined {
+  return libs.find(
+    l =>
+      l.ownerId === ownerId &&
+      l.name === name &&
+      (l.importPaths ?? []).includes(importPath),
+  );
+}
+
+/**
+ * Auto-provision the external libraries for the box (Decision A). Idempotent:
+ * re-runs reuse libraries that already match. Box users are passed in by the
+ * worker entrypoint (the launcher-injected list, sourced from the same LLDAP
+ * directory the routing-tree owner axis uses); the Shared library is owned by
+ * the admin key's user. Returns the library-id map (keyed by box-user id, plus
+ * `shared`) and any box users with no Immich account yet.
+ */
+export async function provisionExternalLibraries(
+  cfg: ImmichAdminConfig,
+  boxUsers: readonly BoxUser[],
+): Promise<ProvisionResult> {
+  const [immichUsers, existing, admin] = await Promise.all([
+    listImmichUsers(cfg),
+    listLibraries(cfg),
+    adminUserId(cfg),
+  ]);
+
+  const libraryIdByOwner = new Map<string, string>();
+  const unmatchedUsers: string[] = [];
+
+  // Shared library — owned by the admin, import path = `<MOUNT>/photos`.
+  const sharedPath = sharedImportPath();
+  const sharedHit = libraryExists(existing, admin, SHARED_LIBRARY_NAME, sharedPath);
+  libraryIdByOwner.set(
+    'shared',
+    sharedHit ? sharedHit.id : await createLibrary(cfg, admin, SHARED_LIBRARY_NAME, sharedPath),
+  );
+
+  // One private library per box user, owned by that user's Immich account.
+  for (const boxUser of boxUsers) {
+    const immichUser = matchImmichUser(boxUser.id, boxUser.email, immichUsers);
+    if (!immichUser) {
+      unmatchedUsers.push(boxUser.id);
+      continue;
+    }
+    const path = userImportPath(boxUser.id);
+    const hit = libraryExists(existing, immichUser.id, boxUser.id, path);
+    libraryIdByOwner.set(
+      boxUser.id,
+      hit ? hit.id : await createLibrary(cfg, immichUser.id, boxUser.id, path),
+    );
+  }
+
+  return { libraryIdByOwner, unmatchedUsers };
+}
+
+/** Trigger an external-library refresh scan via the admin API. */
+export async function scanLibrary(cfg: ImmichAdminConfig, libraryId: string): Promise<void> {
+  const { status } = await immichFetch(cfg, 'POST', `/api/libraries/${libraryId}/scan`);
+  assertOk(status, `scan library ${libraryId}`);
+}
+
+/**
+ * After a disk apply that wrote photos, trigger the owning libraries' scans so
+ * Immich picks the new files up. `owners` are the destination-area owner keys
+ * the photo plan wrote to (`shared` for the shared area, a box-user id for a
+ * private area). Unknown/unprovisioned owners are skipped silently — the files
+ * are on disk and a later full provision+scan will still find them.
+ */
+export async function scanLibrariesForOwners(
+  cfg: ImmichAdminConfig,
+  libraryIdByOwner: ReadonlyMap<string, string>,
+  owners: Iterable<string>,
+): Promise<void> {
+  const seen = new Set<string>();
+  for (const owner of owners) {
+    const libraryId = libraryIdByOwner.get(owner);
+    if (!libraryId || seen.has(libraryId)) continue;
+    seen.add(libraryId);
+    await scanLibrary(cfg, libraryId);
+  }
+}
+
+/**
+ * Resolve the worker's Immich provisioning inputs from the launcher-injected
+ * env, or `null` when Immich provisioning isn't wired (so the apply path just
+ * places photos in the folder and skips the scan — a graceful no-op when Immich
+ * isn't installed). The control plane resolves the admin key + box-user list and
+ * injects them; the worker never logs or persists the key.
+ *
+ *   IMMICH_SERVER_URL      e.g. http://127.0.0.1:2283  (no trailing slash)
+ *   IMMICH_ADMIN_API_KEY   the single stored admin x-api-key
+ *   DISK_IMPORT_BOX_USERS  JSON `[{ "id": "...", "email": "..." }, …]`
+ */
+export function immichProvisionFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): { cfg: ImmichAdminConfig; boxUsers: BoxUser[] } | null {
+  const serverUrl = (env.IMMICH_SERVER_URL ?? '').replace(/\/+$/, '');
+  const adminApiKey = env.IMMICH_ADMIN_API_KEY ?? '';
+  if (!serverUrl || !adminApiKey) return null;
+
+  let boxUsers: BoxUser[] = [];
+  const raw = env.DISK_IMPORT_BOX_USERS;
+  if (raw) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        boxUsers = parsed
+          .filter((u): u is { id: unknown; email?: unknown } => !!u && typeof u === 'object' && 'id' in u)
+          .filter(u => typeof u.id === 'string' && u.id.length > 0)
+          .map(u => ({ id: String(u.id), email: typeof u.email === 'string' ? u.email : undefined }));
+      }
+    } catch {
+      // Malformed list → provision only the Shared library (private libs skipped).
+      boxUsers = [];
+    }
+  }
+
+  return { cfg: { serverUrl, adminApiKey }, boxUsers };
+}

--- a/packages/disk-import-worker/src/engine/immichLibraries.ts
+++ b/packages/disk-import-worker/src/engine/immichLibraries.ts
@@ -268,7 +268,7 @@ export async function scanLibrariesForOwners(
  *   DISK_IMPORT_BOX_USERS  JSON `[{ "id": "...", "email": "..." }, …]`
  */
 export function immichProvisionFromEnv(
-  env: NodeJS.ProcessEnv = process.env,
+  env: Record<string, string | undefined> = process.env,
 ): { cfg: ImmichAdminConfig; boxUsers: BoxUser[] } | null {
   const serverUrl = (env.IMMICH_SERVER_URL ?? '').replace(/\/+$/, '');
   const adminApiKey = env.IMMICH_ADMIN_API_KEY ?? '';

--- a/packages/disk-import-worker/src/engine/immichLibraries.ts
+++ b/packages/disk-import-worker/src/engine/immichLibraries.ts
@@ -270,7 +270,8 @@ export async function scanLibrariesForOwners(
 export function immichProvisionFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): { cfg: ImmichAdminConfig; boxUsers: BoxUser[] } | null {
-  const serverUrl = (env.IMMICH_SERVER_URL ?? '').replace(/\/+$/, '');
+  let serverUrl = env.IMMICH_SERVER_URL ?? '';
+  while (serverUrl.endsWith('/')) serverUrl = serverUrl.slice(0, -1);
   const adminApiKey = env.IMMICH_ADMIN_API_KEY ?? '';
   if (!serverUrl || !adminApiKey) return null;
 

--- a/packages/disk-import-worker/src/index.ts
+++ b/packages/disk-import-worker/src/index.ts
@@ -17,6 +17,7 @@ export * from './engine/classify';
 export * from './engine/dedup';
 export * from './engine/hostExec';
 export * from './engine/hostScan';
+export * from './engine/immichLibraries';
 export * from './engine/inventory';
 export * from './engine/mounter';
 export * from './engine/ollama';


### PR DESCRIPTION
## Summary

- **RED verify finding (SHA 3e3ae67e)**: `HOST_DATA_DIR` env var was added to the butane template in #1964 but boxes installed before that merge don't have it in their running quadlet. The env var falls back to `DATA_DIR` (`/app/data`, read-only on host), `mkdir outDir` fails silently (code 1 was swallowed), and `podman run -v <outDir>:/out` then fails with exit 125 / `statfs: no such file or directory`. Worker never launches.
- **Fix 1** (`launcher.ts`): check `mkdir outDir` exit code and throw an actionable error with clear remediation steps — no more silent swallow leading to a confusing `podman run` failure.
- **Fix 2** (`quadletPatch.ts` + `server.ts`): on startup, inject `HOST_DATA_DIR` into the running quadlet (parsed from the `Volume=...:/app/data` line) if it's missing. This self-heals existing boxes on next restart (channel flip triggers it) without a full reinstall.

## Test plan

- [ ] All 312 tests pass (pre-push verified)
- [ ] Box-verify on `:dev` at this SHA: channel flip triggers restart → quadlet gets patched with `HOST_DATA_DIR=/mnt/data/servicebay` → disk-import scan launches worker container successfully

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._