### PR TITLE
feat(backup-worker): run external/config backup in a capped one-shot worker

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -15,6 +15,7 @@ on:
     tags: ['v*']
     paths:
       - 'packages/disk-import-worker/**'
+      - 'packages/backup-worker/**'
       - 'packages/api-client/**'
       - 'package.json'
       - 'package-lock.json'
@@ -23,6 +24,7 @@ on:
   pull_request:
     paths:
       - 'packages/disk-import-worker/**'
+      - 'packages/backup-worker/**'
       - '.github/workflows/build-images.yml'
   workflow_dispatch:
 
@@ -41,6 +43,9 @@ jobs:
           - image: disk-import-worker
             dockerfile: packages/disk-import-worker/Containerfile
             description: "Resource-capped one-shot disk-import worker (walk/hash/classify/dedup/plan/apply); servicebay launches it via podman run --memory=… and reads its status.json (#1949)."
+          - image: backup-worker
+            dockerfile: packages/backup-worker/Containerfile
+            description: "Resource-capped one-shot config-backup worker (walk/copy/tar each installed service's config per the backup manifest); servicebay launches it via podman run --memory=… and reads its status.json (#1955/#1949)."
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -3075,6 +3075,10 @@
       "resolved": "packages/backend",
       "link": true
     },
+    "node_modules/@servicebay/backup-worker": {
+      "resolved": "packages/backup-worker",
+      "link": true
+    },
     "node_modules/@servicebay/disk-import-worker": {
       "resolved": "packages/disk-import-worker",
       "link": true
@@ -14486,6 +14490,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/backup-worker": {
+      "name": "@servicebay/backup-worker",
+      "version": "0.0.0",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "backup-worker": "src/cli/main.ts"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9"
       }
     },
     "packages/disk-import-worker": {

--- a/packages/backend/src/lib/backupWorker/launcher.test.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  launchBackupWorker,
+  readBackupStatus,
+  isBackupWorkerRunning,
+  stopBackupWorker,
+  readBackupTar,
+  BACKUP_WORKER_IMAGE,
+  BACKUP_WORKER_MEMORY,
+  type SafeExec,
+} from './launcher';
+
+/** A SafeExec recording its calls, with per-argv canned stdout. */
+function recExec(responses: Record<string, { stdout?: string; code?: number }> = {}) {
+  const calls: string[][] = [];
+  const exec: SafeExec = vi.fn(async (argv: string[]) => {
+    calls.push(argv);
+    const key = argv.join(' ');
+    const match = Object.entries(responses).find(([k]) => key.includes(k));
+    return { stdout: match?.[1].stdout ?? '', stderr: '', code: match?.[1].code ?? 0 };
+  });
+  return { exec, calls };
+}
+
+describe('launchBackupWorker', () => {
+  it('creates the out dir then runs the worker container, memory-capped, stacks RO', async () => {
+    const { exec, calls } = recExec();
+    const run = await launchBackupWorker({
+      exec, services: ['adguard', 'nginx'], runId: 'abc', dataDir: '/data', stacksDir: '/mnt/data/stacks',
+    });
+
+    expect(run.container).toBe('backup-worker-abc');
+    expect(run.outDir).toBe('/data/backup-runs/abc');
+
+    // outDir is created BEFORE `podman run -v <outDir>:/out` (else statfs error).
+    const mkdirIdx = calls.findIndex(c => c[0] === 'mkdir' && c[2] === '/data/backup-runs/abc');
+    const runIdx = calls.findIndex(c => c[0] === 'podman' && c[1] === 'run');
+    expect(mkdirIdx).toBeGreaterThanOrEqual(0);
+    expect(mkdirIdx).toBeLessThan(runIdx);
+
+    const podmanRun = calls[runIdx];
+    expect(podmanRun).toContain('-d');
+    expect(podmanRun).toContain('--rm');
+    expect(podmanRun).toContain(`--memory=${BACKUP_WORKER_MEMORY}`);
+    expect(podmanRun).toContain(BACKUP_WORKER_IMAGE);
+    // stacks mounted read-only
+    expect(podmanRun.some(a => a === '/mnt/data/stacks:/mnt/stacks:ro')).toBe(true);
+    // services passed through
+    const sIdx = podmanRun.indexOf('--services');
+    expect(podmanRun[sIdx + 1]).toBe('adguard,nginx');
+  });
+
+  it('fails fast with a HOST_DATA_DIR hint when the out mkdir errors (EROFS)', async () => {
+    const { exec } = recExec({ 'mkdir -p': { code: 1, stdout: 'Read-only file system' } });
+    await expect(
+      launchBackupWorker({ exec, services: ['adguard'], runId: 'x', dataDir: '/app/data', stacksDir: '/s' }),
+    ).rejects.toThrow(/HOST_DATA_DIR/);
+  });
+
+  it('refuses an empty service list', async () => {
+    const { exec } = recExec();
+    await expect(
+      launchBackupWorker({ exec, services: [], runId: 'x', dataDir: '/d', stacksDir: '/s' }),
+    ).rejects.toThrow(/no services/);
+  });
+});
+
+describe('readBackupStatus', () => {
+  const run = { runId: 'r', outDir: '/out/r', container: 'backup-worker-r' };
+
+  it('parses the compact status.json', async () => {
+    const { exec } = recExec({ 'cat /out/r/status.json': { stdout: JSON.stringify({ phase: 'done', processed: 3 }) } });
+    expect(await readBackupStatus(exec, run)).toMatchObject({ phase: 'done', processed: 3 });
+  });
+
+  it('returns null before the worker has written anything', async () => {
+    const { exec } = recExec({ cat: { stdout: '', code: 1 } });
+    expect(await readBackupStatus(exec, run)).toBeNull();
+  });
+});
+
+describe('isBackupWorkerRunning', () => {
+  const run = { runId: 'r', outDir: '/o', container: 'backup-worker-r' };
+  it('is true when podman ps lists the container', async () => {
+    const { exec } = recExec({ 'podman ps': { stdout: 'backup-worker-r\n' } });
+    expect(await isBackupWorkerRunning(exec, run)).toBe(true);
+  });
+  it('is false when the container is gone', async () => {
+    const { exec } = recExec({ 'podman ps': { stdout: '' } });
+    expect(await isBackupWorkerRunning(exec, run)).toBe(false);
+  });
+});
+
+describe('stopBackupWorker', () => {
+  it('force-removes the container', async () => {
+    const { exec, calls } = recExec();
+    await stopBackupWorker(exec, { runId: 'r', outDir: '/o', container: 'backup-worker-r' });
+    expect(calls).toContainEqual(['podman', 'rm', '-f', 'backup-worker-r']);
+  });
+});
+
+describe('readBackupTar', () => {
+  const run = { runId: 'r', outDir: '/out/r', container: 'backup-worker-r' };
+  it('decodes the base64 tar bytes', async () => {
+    const tar = Buffer.from('hello tar');
+    const { exec } = recExec({ 'base64 /out/r/adguard.tar': { stdout: tar.toString('base64') } });
+    expect((await readBackupTar(exec, run, 'adguard.tar')).equals(tar)).toBe(true);
+  });
+  it('throws on a read failure', async () => {
+    const { exec } = recExec({ base64: { code: 1, stdout: 'no such file' } });
+    await expect(readBackupTar(exec, run, 'x.tar')).rejects.toThrow(/failed to read/);
+  });
+});

--- a/packages/backend/src/lib/backupWorker/launcher.test.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.test.ts
@@ -51,11 +51,11 @@ describe('launchBackupWorker', () => {
     expect(podmanRun[sIdx + 1]).toBe('adguard,nginx');
   });
 
-  it('fails fast with a HOST_DATA_DIR hint when the out mkdir errors (EROFS)', async () => {
+  it('fails fast with a resolveHostDataDir hint when the out mkdir errors (EROFS)', async () => {
     const { exec } = recExec({ 'mkdir -p': { code: 1, stdout: 'Read-only file system' } });
     await expect(
       launchBackupWorker({ exec, services: ['adguard'], runId: 'x', dataDir: '/app/data', stacksDir: '/s' }),
-    ).rejects.toThrow(/HOST_DATA_DIR/);
+    ).rejects.toThrow(/resolveHostDataDir/);
   });
 
   it('refuses an empty service list', async () => {

--- a/packages/backend/src/lib/backupWorker/launcher.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.ts
@@ -1,0 +1,165 @@
+// External/config backup — worker-container launcher (#1955, slice of #1949).
+//
+// THIS REPLACES THE IN-PROCESS HEAVY PATH. Previously servicebay walked + copied
+// each service's config file-by-file through the agent channel and held every tar
+// in its own Node process (externalBackup/producer.ts), which OOM'd the control
+// plane on a HACS HA config (~5.3 GB, #1894 — feedback_control_plane_vs_worker).
+// Now the heavy walk/copy/tar runs in a resource-capped worker CONTAINER:
+// servicebay only launches it, reads the compact status.json it writes, and
+// streams the per-service tars it produced to the NAS one at a time.
+//
+//   servicebay ──"Back up config"──▶ podman run --rm --memory=2g <worker> --stacks …
+//      reads status.json (compact)        (stacks ro at /mnt/stacks, out volume /out)
+//      streams <service>.tar → NAS        (one tar at a time, bounded I/O)
+//
+// The control plane never holds all the tars at once — an OOM/kill of the worker
+// kills the JOB, not servicebay/UI/HA. Liveness is `podman ps`, not in-memory
+// bookkeeping. The worker mounts the stacks dir READ-ONLY and writes only into
+// /out — it never writes back into a stack (feedback_fileshare_relabel_crashloop).
+
+import type { WorkerStatus } from '@servicebay/backup-worker';
+import { STATUS_FILE } from '@servicebay/backup-worker';
+
+/** Result of one structured `safe_exec` argv invocation (the agent seam). */
+export interface SafeExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** The host-exec seam the launcher runs `podman`/`mkdir`/`cat`/`base64` through —
+ *  the agent's structured `safe_exec` (no shell). Mirrors the disk-import worker's
+ *  SafeExec shape; defined locally so backup-worker doesn't depend on the
+ *  disk-import worker package. */
+export type SafeExec = (argv: string[], options?: { timeoutMs?: number; sudo?: boolean }) => Promise<SafeExecResult>;
+
+/** The published worker image — built + pushed by .github/workflows/build-images.yml. */
+export const BACKUP_WORKER_IMAGE = 'ghcr.io/mdopp/servicebay-backup-worker:latest';
+
+/** Hard memory cap for the worker container — a big config OOMs it, not the box.
+ *  Larger than the disk-import worker's 1g: a service tar (NPM certs, HA custom
+ *  components) can be a few hundred MB and tar buffers it. */
+export const BACKUP_WORKER_MEMORY = '2g';
+
+/** Where the host stacks dir is mounted (read-only) inside the worker. */
+const STACKS_MOUNT = '/mnt/stacks';
+
+/** A launched backup-worker run servicebay tracks by container name + out dir. */
+export interface BackupWorkerRun {
+  /** Opaque run id (also the container name suffix + out-dir name). */
+  runId: string;
+  /** Host dir bind-mounted to the container's /out — where status.json + tars land. */
+  outDir: string;
+  /** The container name (`backup-worker-<runId>`). */
+  container: string;
+}
+
+function containerName(runId: string): string {
+  return `backup-worker-${runId}`;
+}
+
+/**
+ * Base dir for per-run worker out volumes. `dataDir` MUST be the HOST-side data
+ * path (HOST_DATA_DIR), since the out dir is both `mkdir`'d and bind-mounted
+ * host-side by `podman run` — the in-container /app/data is read-only on the host
+ * (the disk-import worker's exit-125 lesson, #1963/#1965).
+ */
+export function backupWorkerOutBase(dataDir: string): string {
+  return `${dataDir}/backup-runs`;
+}
+
+/**
+ * Launch the backup worker over the stacks dir, read-only. Creates the per-run
+ * out dir host-side first (fail-fast if it can't — that means HOST_DATA_DIR is
+ * wrong / fell back to /app/data), then runs `podman run -d --rm --memory=…`. The
+ * stacks dir is already host-readable, so it's bind-mounted directly (no `mkdir`
+ * of a /run mountpoint like the disk-import device path needs). Returns the run
+ * handle; the worker writes status.json + <service>.tar into outDir.
+ */
+export async function launchBackupWorker(args: {
+  exec: SafeExec;
+  services: string[];
+  runId: string;
+  /** HOST-side data dir (HOST_DATA_DIR) — where the out volume is created. */
+  dataDir: string;
+  /** HOST-side stacks root (e.g. /mnt/data/stacks) bind-mounted RO into the worker. */
+  stacksDir: string;
+}): Promise<BackupWorkerRun> {
+  const { exec, services, runId, dataDir, stacksDir } = args;
+  if (services.length === 0) throw new Error('backup-worker: no services to back up');
+  const outDir = `${backupWorkerOutBase(dataDir)}/${runId}`;
+  const container = containerName(runId);
+
+  // outDir must exist before `podman run -v <outDir>:/out`. It lives on the HOST
+  // (dataDir = HOST_DATA_DIR), not in the container's /app/data (read-only on the
+  // host). Fail fast: a read-only-filesystem error here means HOST_DATA_DIR is
+  // wrong — surface it rather than letting `podman run` fail with a confusing statfs.
+  const mkdirOut = await exec(['mkdir', '-p', outDir]);
+  if (mkdirOut.code !== 0) {
+    throw new Error(
+      `backup-worker: failed to create worker out dir ${outDir}: ${mkdirOut.stderr || mkdirOut.stdout}. ` +
+      `If this box was installed before HOST_DATA_DIR was added to the quadlet, a reinstall ` +
+      `(or adding Environment=HOST_DATA_DIR=/mnt/data/servicebay to the servicebay.container ` +
+      `quadlet and restarting) will fix it.`,
+    );
+  }
+
+  await exec([
+    'podman', 'run', '-d', '--rm',
+    '--name', container,
+    `--memory=${BACKUP_WORKER_MEMORY}`,
+    `--memory-swap=${BACKUP_WORKER_MEMORY}`,
+    '-v', `${stacksDir}:${STACKS_MOUNT}:ro`,
+    '-v', `${outDir}:/out`,
+    '-e', `BACKUP_RUN_ID=${runId}`,
+    BACKUP_WORKER_IMAGE,
+    '--stacks', STACKS_MOUNT,
+    '--out', '/out',
+    '--services', services.join(','),
+    '--run-id', runId,
+  ]);
+
+  return { runId, outDir, container };
+}
+
+/**
+ * Read the COMPACT status.json the worker writes — the ONLY heavy-job state the
+ * control plane loads (never the tar bytes). Returns null before the worker has
+ * written anything (or if the file is unreadable mid-write).
+ */
+export async function readBackupStatus(exec: SafeExec, run: BackupWorkerRun): Promise<WorkerStatus | null> {
+  try {
+    const { stdout, code } = await exec(['cat', `${run.outDir}/${STATUS_FILE}`]);
+    if (code !== 0 || !stdout.trim()) return null;
+    return JSON.parse(stdout) as WorkerStatus;
+  } catch {
+    return null;
+  }
+}
+
+/** Liveness via `podman ps` — no in-memory bookkeeping (#1949). */
+export async function isBackupWorkerRunning(exec: SafeExec, run: BackupWorkerRun): Promise<boolean> {
+  const { stdout } = await exec(['podman', 'ps', '--filter', `name=${run.container}`, '--format', '{{.Names}}']);
+  return stdout.split('\n').some(line => line.trim() === run.container);
+}
+
+/** Stop a worker container (best-effort). */
+export async function stopBackupWorker(exec: SafeExec, run: BackupWorkerRun): Promise<void> {
+  await exec(['podman', 'rm', '-f', run.container]).catch(() => {});
+}
+
+/** Ensure the worker image is present on the node (pull if missing). */
+export async function ensureBackupWorkerImage(exec: SafeExec): Promise<void> {
+  await exec(['podman', 'pull', BACKUP_WORKER_IMAGE]);
+}
+
+/** Read one produced tar's bytes from the out volume (host-side, base64 over the
+ *  agent channel — the agent's read path is utf-8-only, so base64 keeps binary
+ *  config intact). servicebay streams these to the NAS one at a time. */
+export async function readBackupTar(exec: SafeExec, run: BackupWorkerRun, tarName: string): Promise<Buffer> {
+  const { stdout, code, stderr } = await exec(['base64', `${run.outDir}/${tarName}`]);
+  if (code !== 0) {
+    throw new Error(`backup-worker: failed to read ${tarName} from ${run.outDir}: ${stderr || stdout}`);
+  }
+  return Buffer.from(stdout.replace(/\s+/g, ''), 'base64');
+}

--- a/packages/backend/src/lib/backupWorker/launcher.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.ts
@@ -98,9 +98,8 @@ export async function launchBackupWorker(args: {
   if (mkdirOut.code !== 0) {
     throw new Error(
       `backup-worker: failed to create worker out dir ${outDir}: ${mkdirOut.stderr || mkdirOut.stdout}. ` +
-      `If this box was installed before HOST_DATA_DIR was added to the quadlet, a reinstall ` +
-      `(or adding Environment=HOST_DATA_DIR=/mnt/data/servicebay to the servicebay.container ` +
-      `quadlet and restarting) will fix it.`,
+      `dataDir should be the HOST-side data dir resolved by resolveHostDataDir() (#1966); a ` +
+      `read-only-filesystem error here means it fell back to the container-internal /app/data.`,
     );
   }
 

--- a/packages/backend/src/lib/backupWorker/service.test.ts
+++ b/packages/backend/src/lib/backupWorker/service.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLauncher, mockCfg, mockCollector, mockExecutor } = vi.hoisted(() => ({
+  mockLauncher: {
+    launchBackupWorker: vi.fn(),
+    readBackupStatus: vi.fn(),
+    isBackupWorkerRunning: vi.fn(),
+    stopBackupWorker: vi.fn(),
+    ensureBackupWorkerImage: vi.fn(),
+    readBackupTar: vi.fn(),
+  },
+  mockCfg: { getConfig: vi.fn() },
+  mockCollector: { runBackupCollector: vi.fn() },
+  mockExecutor: vi.fn(async (argv: string[], opts?: unknown) => { void argv; void opts; return { stdout: '', stderr: '', code: 0 }; }),
+}));
+
+vi.mock('./launcher', () => mockLauncher);
+vi.mock('@/lib/config', () => ({ getConfig: () => mockCfg.getConfig() }));
+vi.mock('@/lib/dirs', () => ({ HOST_DATA_DIR: '/mnt/data/servicebay' }));
+vi.mock('@/lib/agent/executor', () => ({
+  AgentExecutor: class { execSafe = (argv: string[], opts?: unknown) => mockExecutor(argv, opts); },
+}));
+vi.mock('../externalBackup/collector', () => mockCollector);
+
+import {
+  runBackupForServices,
+  runBackupForInstalled,
+  stageInstalledServiceConfigViaWorker,
+} from './service';
+
+const RUN = { runId: 'r', outDir: '/out/r', container: 'backup-worker-r' };
+
+function doneStatus(results: Array<{ service: string; ok: boolean; outcome?: string; detail?: string | null }>) {
+  return {
+    version: 1, runId: 'r', phase: 'done' as const, step: 'done', total: results.length, processed: results.length,
+    results: results.map(r => ({
+      service: r.service, ok: r.ok, tarName: r.ok ? `${r.service}.tar` : null,
+      bytes: 0, files: 0, outcome: r.outcome ?? (r.ok ? 'ok' : 'error'), detail: r.detail ?? null,
+    })),
+    error: null, updatedAt: 0, startedAt: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCfg.getConfig.mockResolvedValue({
+    installedTemplates: { adguard: {}, 'home-assistant': {} },
+    templateSettings: { DATA_DIR: '/mnt/data/stacks' },
+  });
+  mockLauncher.launchBackupWorker.mockResolvedValue(RUN);
+  mockLauncher.ensureBackupWorkerImage.mockResolvedValue(undefined);
+  mockLauncher.isBackupWorkerRunning.mockResolvedValue(true);
+  mockCollector.runBackupCollector.mockResolvedValue({});
+});
+
+describe('runBackupForServices', () => {
+  it('runs collectors, launches one worker over the stacks dir, and returns the completed run', async () => {
+    mockLauncher.readBackupStatus.mockResolvedValue(doneStatus([{ service: 'nginx', ok: true }]));
+
+    const completed = await runBackupForServices(['nginx']);
+
+    // nginx declares an npm-sqlite collector → run host-side before launch.
+    expect(mockCollector.runBackupCollector).toHaveBeenCalledWith(expect.objectContaining({ service: 'nginx' }), 'Local');
+    expect(mockLauncher.launchBackupWorker).toHaveBeenCalledTimes(1);
+    const arg = mockLauncher.launchBackupWorker.mock.calls[0][0];
+    expect(arg.services).toEqual(['nginx']);
+    expect(arg.stacksDir).toBe('/mnt/data/stacks');
+    expect(arg.dataDir).toBe('/mnt/data/servicebay');
+    expect(completed.run).toEqual(RUN);
+    expect(completed.status.results).toHaveLength(1);
+  });
+
+  it('throws (and cleans up) when the run ends in error', async () => {
+    mockLauncher.readBackupStatus.mockResolvedValue({ ...doneStatus([]), phase: 'error', error: 'boom' });
+    await expect(runBackupForServices(['adguard'])).rejects.toThrow(/boom/);
+    // cleanup removed the out dir
+    expect(mockExecutor).toHaveBeenCalledWith(['rm', '-rf', RUN.outDir], expect.anything());
+  });
+
+  it('throws when the worker vanishes without a terminal status', async () => {
+    mockLauncher.readBackupStatus.mockResolvedValue(null);
+    mockLauncher.isBackupWorkerRunning.mockResolvedValue(false);
+    await expect(runBackupForServices(['adguard'])).rejects.toThrow(/without writing a terminal status/);
+  });
+});
+
+describe('runBackupForInstalled', () => {
+  it('selects installed manifest services incl. the zwave sibling and launches once', async () => {
+    mockLauncher.readBackupStatus.mockResolvedValue(
+      doneStatus([{ service: 'adguard', ok: true }, { service: 'home-assistant', ok: true }, { service: 'home-assistant-zwave', ok: true }]),
+    );
+    const completed = await runBackupForInstalled();
+    expect(completed).not.toBeNull();
+    const arg = mockLauncher.launchBackupWorker.mock.calls[0][0];
+    // home-assistant-zwave gates on home-assistant (installed) and rides along.
+    expect(arg.services).toEqual(expect.arrayContaining(['adguard', 'home-assistant', 'home-assistant-zwave']));
+  });
+
+  it('returns null (no launch) when nothing with a manifest is installed', async () => {
+    mockCfg.getConfig.mockResolvedValue({ installedTemplates: { 'unmanaged-thing': {} } });
+    expect(await runBackupForInstalled()).toBeNull();
+    expect(mockLauncher.launchBackupWorker).not.toHaveBeenCalled();
+  });
+});
+
+describe('stageInstalledServiceConfigViaWorker', () => {
+  it('is the installed-run handle for the caller to consume', async () => {
+    mockLauncher.readBackupStatus.mockResolvedValue(doneStatus([{ service: 'adguard', ok: true }]));
+    const staged = await stageInstalledServiceConfigViaWorker();
+    expect(staged).not.toBeNull();
+    expect(staged!.run).toEqual(RUN);
+  });
+
+  it('returns null when nothing is installed', async () => {
+    mockCfg.getConfig.mockResolvedValue({ installedTemplates: {} });
+    expect(await stageInstalledServiceConfigViaWorker()).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/backupWorker/service.ts
+++ b/packages/backend/src/lib/backupWorker/service.ts
@@ -20,7 +20,7 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import { AgentExecutor } from '@/lib/agent/executor';
-import { HOST_DATA_DIR } from '@/lib/dirs';
+import { resolveHostDataDir } from '@/lib/hostDataDir';
 import { getConfig } from '@/lib/config';
 import {
   SERVICE_BACKUP_MANIFESTS,
@@ -105,7 +105,11 @@ async function runWorkerToCompletion(
 ): Promise<BackupRun> {
   await ensureBackupWorkerImage(exec);
   const runId = Math.random().toString(36).slice(2, 14);
-  const run = await launchBackupWorker({ exec, services, runId, dataDir: HOST_DATA_DIR, stacksDir });
+  // Resolve the HOST-side data dir at launch time (env → podman self-inspect of
+  // the /app/data mount source → default), not the container-internal path —
+  // the out volume must be created + bind-mounted on the host (#1966).
+  const dataDir = await resolveHostDataDir(exec);
+  const run = await launchBackupWorker({ exec, services, runId, dataDir, stacksDir });
 
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   for (;;) {

--- a/packages/backend/src/lib/backupWorker/service.ts
+++ b/packages/backend/src/lib/backupWorker/service.ts
@@ -1,0 +1,177 @@
+// External/config backup — worker orchestration (#1955, slice of #1949).
+//
+// The control-plane glue around the resource-capped backup worker. servicebay:
+//   1. picks the installed services with a backup manifest,
+//   2. runs any host-side collector (NPM's consistent sqlite snapshot) — this
+//      must stay in servicebay: it execs INTO the running NPM container, which the
+//      worker can't reach,
+//   3. launches ONE worker container over the RO-mounted stacks dir,
+//   4. polls the compact status.json to completion (liveness via `podman ps`).
+//
+// The CALLER (producer.ts for the NAS push, systemBackup.ts for the archive)
+// reads the produced tars (one at a time, bounded) and cleans up the run. This
+// module never imports producer — the heavy NAS-write helpers stay there, and the
+// launch/poll glue stays here, so there's no producer ↔ service import cycle.
+//
+// The heavy walk/copy/tar runs entirely in the worker's `--memory` cap — servicebay
+// never holds the file lists or all the tars at once (the in-process path did, and
+// OOM'd the box at ~5.3 GB, #1894 / feedback_control_plane_vs_worker).
+
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { AgentExecutor } from '@/lib/agent/executor';
+import { HOST_DATA_DIR } from '@/lib/dirs';
+import { getConfig } from '@/lib/config';
+import {
+  SERVICE_BACKUP_MANIFESTS,
+  getBackupGate,
+  getServiceManifest,
+} from '@servicebay/backup-worker';
+import type { WorkerStatus } from '@servicebay/backup-worker';
+
+import { runBackupCollector } from '../externalBackup/collector';
+import {
+  launchBackupWorker,
+  readBackupStatus,
+  isBackupWorkerRunning,
+  stopBackupWorker,
+  ensureBackupWorkerImage,
+  readBackupTar,
+  type BackupWorkerRun,
+  type SafeExec,
+} from './launcher';
+
+/** Default on-disk location of the per-service stack dirs (HOST path). */
+const DEFAULT_STACKS_DIR = '/mnt/data/stacks';
+
+/** How long to wait between status polls while the worker runs. */
+const POLL_INTERVAL_MS = 2_000;
+
+/** Safety ceiling so a wedged worker can't poll forever. */
+const POLL_TIMEOUT_MS = 30 * 60_000;
+
+/** A completed worker run the caller consumes (reads tars, then cleans up). */
+export interface BackupRun {
+  exec: SafeExec;
+  run: BackupWorkerRun;
+  status: WorkerStatus;
+}
+
+/** Build the launcher's `SafeExec` seam over the agent's structured `safe_exec`. */
+function makeExec(node: string): SafeExec {
+  const executor = new AgentExecutor(node);
+  return (argv, options) => executor.execSafe(argv, options ?? {});
+}
+
+/** The HOST stacks root (honours templateSettings.DATA_DIR). */
+async function resolveStacksDir(): Promise<string> {
+  return (await getConfig()).templateSettings?.DATA_DIR || DEFAULT_STACKS_DIR;
+}
+
+/**
+ * The installed services with a backup manifest, gated correctly (a sibling-store
+ * entry like `home-assistant-zwave` gates on its parent template). Returns the
+ * manifest service names to hand the worker.
+ */
+async function selectInstalledBackupServices(): Promise<string[]> {
+  const installed = new Set(Object.keys((await getConfig()).installedTemplates ?? {}));
+  return SERVICE_BACKUP_MANIFESTS.filter(m => installed.has(getBackupGate(m))).map(m => m.service);
+}
+
+/**
+ * Run every host-side collector for the requested services BEFORE launching the
+ * worker (the only one today is NPM's consistent sqlite snapshot, which execs into
+ * the running NPM container and writes `database.sqlite.sb-backup` on disk; the
+ * worker then stages that under the canonical name). Best-effort: a snapshot
+ * failure is logged inside runBackupCollector, never fatal.
+ */
+async function runHostCollectors(services: string[], node: string): Promise<void> {
+  for (const service of services) {
+    const manifest = getServiceManifest(service);
+    if (manifest?.collector) await runBackupCollector(manifest, node);
+  }
+}
+
+/**
+ * Launch the worker, poll its status.json to a terminal phase, then return the
+ * final status + the run handle. The caller owns cleanup (reading tars + removing
+ * the out dir via {@link cleanupBackupRun}). Throws on launch failure or if the
+ * worker vanishes without writing a terminal status.
+ */
+async function runWorkerToCompletion(
+  exec: SafeExec,
+  services: string[],
+  stacksDir: string,
+): Promise<BackupRun> {
+  await ensureBackupWorkerImage(exec);
+  const runId = Math.random().toString(36).slice(2, 14);
+  const run = await launchBackupWorker({ exec, services, runId, dataDir: HOST_DATA_DIR, stacksDir });
+
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  for (;;) {
+    const status = await readBackupStatus(exec, run);
+    if (status && (status.phase === 'done' || status.phase === 'error')) {
+      return { exec, run, status };
+    }
+    if (!(await isBackupWorkerRunning(exec, run))) {
+      // The container is gone — read one last time in case it wrote a terminal
+      // status just before exiting; otherwise it died mid-run.
+      const final = await readBackupStatus(exec, run);
+      if (final && (final.phase === 'done' || final.phase === 'error')) {
+        return { exec, run, status: final };
+      }
+      throw new Error('backup-worker exited without writing a terminal status');
+    }
+    if (Date.now() > deadline) {
+      await stopBackupWorker(exec, run);
+      throw new Error('backup-worker timed out');
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+/**
+ * Run a worker backup for an explicit service list (collectors first, launch,
+ * poll to completion). Returns the run handle for the caller to read tars + clean
+ * up. Throws if the run ended in an `error` phase (the caller still cleans up).
+ */
+export async function runBackupForServices(services: string[], node = 'Local'): Promise<BackupRun> {
+  const exec = makeExec(node);
+  const stacksDir = await resolveStacksDir();
+  await runHostCollectors(services, node);
+  const result = await runWorkerToCompletion(exec, services, stacksDir);
+  if (result.status.phase === 'error') {
+    await cleanupBackupRun(result.exec, result.run);
+    throw new Error(result.status.error ?? 'backup-worker run failed');
+  }
+  return result;
+}
+
+/**
+ * Run a worker backup for every installed service with a manifest. Returns null
+ * (no launch) when nothing is installed; otherwise the completed run handle.
+ */
+export async function runBackupForInstalled(node = 'Local'): Promise<BackupRun | null> {
+  const services = await selectInstalledBackupServices();
+  if (services.length === 0) return null;
+  return runBackupForServices(services, node);
+}
+
+/**
+ * Stage every installed service's config via the worker for a system-backup
+ * archive (#1955 — replaces systemBackup.stageServiceConfig's in-process agent
+ * file-copy). Same as {@link runBackupForInstalled}; the caller extracts each tar
+ * into the archive (rather than uploading to the NAS) and then calls
+ * {@link cleanupBackupRun}.
+ */
+export async function stageInstalledServiceConfigViaWorker(node = 'Local'): Promise<BackupRun | null> {
+  return runBackupForInstalled(node);
+}
+
+/** Read one produced tar from a completed run (for upload / archive extraction). */
+export { readBackupTar };
+
+/** Remove a completed run's out dir once its tars have been consumed. */
+export async function cleanupBackupRun(exec: SafeExec, run: BackupWorkerRun): Promise<void> {
+  await exec(['rm', '-rf', run.outDir]).catch(() => {});
+}

--- a/packages/backend/src/lib/externalBackup/backupAll.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAll.test.ts
@@ -1,160 +1,85 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import fs from 'fs/promises';
-import os from 'os';
-import path from 'path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const execFileAsync = promisify(execFile);
-
-const { mockNas, mockCfg } = vi.hoisted(() => ({
+// The box "back up all" path launches the resource-capped backup worker (#1955)
+// for every installed manifest service (the heavy walk/copy/tar runs in the worker
+// container, not in this process — the in-process host-agent path OOM'd the box,
+// #1894), then streams each produced tar to the NAS. Here we mock the worker
+// service surface + the NAS client and assert the upload/skip behaviour; the worker
+// launch/poll is covered by backupWorker/service.test.ts.
+const { mockWorker, mockNas, mockCfg } = vi.hoisted(() => ({
+  mockWorker: {
+    runBackupForInstalled: vi.fn(),
+    readBackupTar: vi.fn(),
+    cleanupBackupRun: vi.fn(),
+  },
   mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn(), nasRemove: vi.fn() },
   mockCfg: { getConfig: vi.fn() },
 }));
+vi.mock('../backupWorker/service', () => mockWorker);
 vi.mock('./nasClient', () => mockNas);
 vi.mock('../config', () => mockCfg);
-// The box backup routes through the host agent (#1597). In-process, wire the
-// executor straight to the local fs so the same staging/tar logic runs against
-// the test's real temp dir (and exercises the agent-backend code path).
-const stageDirs: string[] = [];
-vi.mock('../executor', () => ({
-  getExecutor: () => ({
-    // Bulk plain-copy (#1894): one shell pipe `tar -C src --null -T list -cf - |
-    // tar -C dest -xf -` instead of a cp per file. Emulate it against the local fs.
-    async exec(command: string) {
-      const m = /tar -C (\S+) --null -T (\S+) -cf - \| tar -C (\S+) -xf -/.exec(command);
-      if (!m) throw new Error(`unexpected exec: ${command}`);
-      const unq = (s: string) => s.replace(/^'(.*)'$/, '$1').replace(/'\\''/g, "'");
-      const [, srcRoot, listFile, destRoot] = m.map(unq);
-      const rels = (await fs.readFile(listFile, 'utf8')).split('\0').filter(Boolean);
-      for (const rel of rels) {
-        const dest = path.join(destRoot, rel);
-        await fs.mkdir(path.dirname(dest), { recursive: true });
-        await fs.copyFile(path.join(srcRoot, rel), dest);
-      }
-      return { stdout: '', stderr: '' };
+
+import { backupInstalledServicesToNas, NAS_BACKUP_DIR } from './producer';
+
+const RUN = { runId: 'r', outDir: '/out/r', container: 'backup-worker-r' };
+
+function completed(results: Array<{ service: string; ok: boolean; outcome?: string; detail?: string | null }>) {
+  return {
+    exec: vi.fn(),
+    run: RUN,
+    status: {
+      version: 1, runId: 'r', phase: 'done', step: 'done', total: results.length, processed: results.length,
+      results: results.map(r => ({
+        service: r.service, ok: r.ok, tarName: r.ok ? `${r.service}.tar` : null,
+        bytes: 0, files: 0, outcome: r.outcome ?? (r.ok ? 'ok' : 'error'), detail: r.detail ?? null,
+      })),
+      error: null, updatedAt: 0, startedAt: 0,
     },
-    async execArgv(argv: string[]) {
-      const [cmd, ...args] = argv;
-      if (cmd === 'find') {
-        const ents = await fs.readdir(args[0], { withFileTypes: true }).catch(() => []);
-        return {
-          stdout: ents.map(e => `${e.isDirectory() ? 'd' : e.isFile() ? 'f' : 'o'}\t${e.name}`).join('\n'),
-          stderr: '',
-        };
-      }
-      if (cmd === 'test' && args[0] === '-d') {
-        if (!(await fs.stat(args[1]).then(s => s.isDirectory(), () => false))) throw new Error('not a dir');
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'test' && args[0] === '-e') {
-        if (!(await fs.access(args[1]).then(() => true, () => false))) throw new Error('missing');
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'mkdir') { await fs.mkdir(args[1], { recursive: true }); return { stdout: '', stderr: '' }; }
-      if (cmd === 'cp') { await fs.copyFile(args[args.length - 2], args[args.length - 1]); return { stdout: '', stderr: '' }; }
-      if (cmd === 'mktemp') {
-        const d = await fs.mkdtemp(path.join(os.tmpdir(), 'backupall-stage-'));
-        stageDirs.push(d);
-        return { stdout: d, stderr: '' };
-      }
-      if (cmd === 'tar') {
-        await execFileAsync('tar', ['-cf', args[1], '-C', args[3], '.']);
-        stageDirs.push(args[1]);
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'base64') {
-        return { stdout: (await fs.readFile(args[0])).toString('base64'), stderr: '' };
-      }
-      if (cmd === 'rm') return { stdout: '', stderr: '' };
-      throw new Error(`unexpected execArgv: ${argv.join(' ')}`);
-    },
-    exists: (p: string) => fs.access(p).then(() => true, () => false),
-    readFile: (p: string) => fs.readFile(p, 'utf8'),
-    writeFile: (p: string, c: string) => fs.writeFile(p, c),
-  }),
-}));
-
-import { backupInstalledServicesToNas } from './producer';
-
-let tmpRoot: string;
-
-async function write(rel: string, content: string) {
-  const full = path.join(tmpRoot, rel);
-  await fs.mkdir(path.dirname(full), { recursive: true });
-  await fs.writeFile(full, content);
+  };
 }
 
-beforeEach(async () => {
+beforeEach(() => {
   vi.clearAllMocks();
+  mockCfg.getConfig.mockResolvedValue({});
   mockNas.nasUpload.mockResolvedValue(undefined);
-  // #1865 — each write prunes (lists then removes); no prior snapshots here.
-  mockNas.nasList.mockResolvedValue([]);
+  mockNas.nasList.mockResolvedValue([]); // prune lists then removes; empty NAS
   mockNas.nasRemove.mockResolvedValue(undefined);
-  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'backupall-'));
-});
-afterEach(async () => {
-  await fs.rm(tmpRoot, { recursive: true, force: true });
-  await Promise.all(stageDirs.splice(0).map(d => fs.rm(d, { recursive: true, force: true })));
+  mockWorker.readBackupTar.mockResolvedValue(Buffer.from('tarbytes'));
+  mockWorker.cleanupBackupRun.mockResolvedValue(undefined);
 });
 
 describe('backupInstalledServicesToNas', () => {
-  it('backs up only installed manifest services, skipping the rest', async () => {
-    // adguard is installed (with a manifest config file); home-assistant is NOT.
-    await write('adguard/conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
-    mockCfg.getConfig.mockResolvedValue({
-      templateSettings: { DATA_DIR: tmpRoot },
-      installedTemplates: { adguard: { schemaVersion: 1, installedAt: 'x' } },
-    });
+  it('uploads each ok tar as a dated NAS slot and cleans up the run', async () => {
+    mockWorker.runBackupForInstalled.mockResolvedValue(completed([{ service: 'adguard', ok: true }]));
 
     const results = await backupInstalledServicesToNas();
 
-    // Only adguard ran; home-assistant/authelia/etc. are not installed → not attempted.
     expect(results.map(r => r.service)).toEqual(['adguard']);
     expect(results[0]).toMatchObject({ service: 'adguard', ok: true });
     expect(results[0].tarName).toMatch(/^adguard-\d{8}-\d{4}\.tar$/); // dated slot (#1865)
-    // The tar + meta were uploaded to the NAS.
     const uploaded = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
-    expect(uploaded.some(p => /sb-backup\/adguard-\d{8}-\d{4}\.tar$/.test(p))).toBe(true);
+    expect(uploaded.some(p => new RegExp(`${NAS_BACKUP_DIR}/adguard-\\d{8}-\\d{4}\\.tar$`).test(p))).toBe(true);
+    expect(mockWorker.cleanupBackupRun).toHaveBeenCalledTimes(1);
   });
 
-  it('captures a per-service failure without aborting the run', async () => {
-    // adguard installed but its data dir is missing its config → produces no
-    // files → backupServiceToNas throws; the run records it as ok:false.
-    mockCfg.getConfig.mockResolvedValue({
-      templateSettings: { DATA_DIR: tmpRoot },
-      installedTemplates: { adguard: { schemaVersion: 1, installedAt: 'x' } },
-    });
+  it('records a worker skip/error as a per-service failure without uploading it', async () => {
+    mockWorker.runBackupForInstalled.mockResolvedValue(
+      completed([
+        { service: 'adguard', ok: false, outcome: 'skip', detail: 'No config files to back up' },
+        { service: 'nginx', ok: true },
+      ]),
+    );
 
     const results = await backupInstalledServicesToNas();
-    expect(results).toHaveLength(1);
-    expect(results[0].service).toBe('adguard');
-    expect(results[0].ok).toBe(false);
-    expect(results[0].error).toBeTruthy();
+    expect(results.find(r => r.service === 'adguard')).toMatchObject({ ok: false });
+    expect(results.find(r => r.service === 'nginx')).toMatchObject({ ok: true });
+    // Only the ok service was uploaded (1 tar + 1 meta).
+    expect(mockNas.nasUpload).toHaveBeenCalledTimes(2);
   });
 
-  it('returns empty when nothing with a manifest is installed', async () => {
-    mockCfg.getConfig.mockResolvedValue({ installedTemplates: { 'some-unmanaged-thing': {} } });
+  it('returns empty when nothing with a manifest is installed (no launch)', async () => {
+    mockWorker.runBackupForInstalled.mockResolvedValue(null);
     expect(await backupInstalledServicesToNas()).toEqual([]);
-  });
-
-  it('backs up the zwave-js sibling store when home-assistant is installed (#1594)', async () => {
-    // HA config + the sibling zwave-js store (network keys) both present.
-    await write('home-assistant/homeassistant/configuration.yaml', 'default_config:');
-    await write('home-assistant/zwave-js/settings.json', '{"zwave":{"securityKeys":{"S0_Legacy":"deadbeef"}}}');
-    mockCfg.getConfig.mockResolvedValue({
-      templateSettings: { DATA_DIR: tmpRoot },
-      // Only `home-assistant` is an installedTemplates key; `home-assistant-zwave`
-      // is a synthetic gate-on-parent entry that must still get backed up.
-      installedTemplates: { 'home-assistant': { schemaVersion: 1, installedAt: 'x' } },
-    });
-
-    const results = await backupInstalledServicesToNas();
-    const services = results.map(r => r.service);
-    expect(services).toContain('home-assistant');
-    expect(services).toContain('home-assistant-zwave');
-    expect(results.find(r => r.service === 'home-assistant-zwave')).toMatchObject({ ok: true });
-    const uploaded = mockNas.nasUpload.mock.calls.map(c => String(c[0]));
-    expect(uploaded.some(p => /sb-backup\/home-assistant-zwave-\d{8}-\d{4}\.tar$/.test(p))).toBe(true);
+    expect(mockNas.nasUpload).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/externalBackup/collector.ts
+++ b/packages/backend/src/lib/externalBackup/collector.ts
@@ -1,0 +1,97 @@
+/**
+ * Backup collectors — the in-container snapshot step a manifest can declare to
+ * run BEFORE the config is staged (#1894). Extracted from producer.ts so both the
+ * producer (local-seed path) and the backup-worker orchestration can run a
+ * collector without a circular import (producer ↔ backupWorker/service).
+ *
+ * The only collector today is NPM's consistent sqlite snapshot: it execs into the
+ * running NPM container (over the node agent) and writes a torn-free
+ * `database.sqlite.sb-backup` on disk. The worker / producer then stages that file
+ * under the canonical `database.sqlite` name (via the manifest's `renames`).
+ */
+import { agentManager } from '../agent/manager';
+import { logger } from '../logger';
+import type { ServiceBackupManifest } from './serviceManifest';
+
+// Runs inside the NPM container: a consistent snapshot of the live WAL-mode
+// /data/database.sqlite to /data/database.sqlite.sb-backup using sqlite3's online
+// `.backup`, then `mv` over the canonical name. NPM's image bundles sqlite3.
+//
+// Since #1679 the live DB runs in WAL mode, so committed writes can sit in the
+// `-wal` sidecar rather than the main file. We first `wal_checkpoint(TRUNCATE)` to
+// fold the WAL back into the main DB and truncate the sidecar, then take the
+// online `.backup` (itself WAL-aware) into a single self-contained file. The
+// checkpoint is best-effort; `.backup` guarantees consistency regardless.
+const NPM_SQLITE_SNAPSHOT_SH = [
+  'set -e',
+  "DB=/data/database.sqlite",
+  'if [ ! -f "$DB" ]; then echo "nodb"; exit 0; fi',
+  // Not every NPM image ships sqlite3 (#1894 — the current jc21 image does not).
+  // Probe for it FIRST and report a precise, greppable reason so the producer can
+  // degrade honestly (copy the live file) instead of logging a misleading "(unknown)".
+  'if ! command -v sqlite3 >/dev/null 2>&1; then echo "no-sqlite3"; exit 0; fi',
+  // Fold the WAL back into the main DB so the snapshot has no dependence on the
+  // -wal/-shm sidecars. Best-effort: ignore a non-zero (busy) checkpoint.
+  'sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);" || true',
+  // `.backup` produces a transactionally-consistent copy even mid-write.
+  'sqlite3 "$DB" ".backup \'$DB.sb-snap\'"',
+  'mv -f "$DB.sb-snap" "$DB.sb-backup"',
+  'echo "ok"',
+].join('\n');
+
+/**
+ * Run a manifest's `collector` (in-container snapshot) before the config is
+ * staged. For NPM: takes a consistent `sqlite3 .backup` of the live
+ * database.sqlite to `database.sqlite.sb-backup` on disk, then remaps the
+ * manifest's `data/database.sqlite` include to that snapshot path so the consistent
+ * copy is staged under the original name. Returns a possibly-rewritten manifest.
+ * Best-effort: if the snapshot can't be taken the original manifest is returned
+ * (the staging copies the live file and logs).
+ */
+export async function runBackupCollector(
+  manifest: ServiceBackupManifest,
+  node: string,
+): Promise<ServiceBackupManifest> {
+  if (manifest.collector?.kind !== 'npm-sqlite') return manifest;
+  try {
+    const agent = await agentManager.ensureAgent(node);
+    const find = await agent.sendCommand('exec', {
+      command: `podman ps --format '{{.Names}} {{.Image}}' | awk '/proxy-manager/{print $1; exit}'`,
+    }, { timeoutMs: 15_000 });
+    const container = ((find as { stdout?: string }).stdout || '').trim().split(/\s+/)[0];
+    if (!container) {
+      logger.warn('ExternalBackup', 'NPM container not found — backing up database.sqlite as-is (may be inconsistent)');
+      return manifest;
+    }
+    const b64 = Buffer.from(NPM_SQLITE_SNAPSHOT_SH).toString('base64');
+    const res = await agent.sendCommand('exec', {
+      command: `echo ${b64} | base64 -d | podman exec -i ${container} sh -`,
+    }, { timeoutMs: 30_000 });
+    const out = ((res as { stdout?: string }).stdout || '').trim();
+    const errOut = ((res as { stderr?: string }).stderr || '').trim();
+    const code = (res as { code?: number }).code;
+    // sqlite3 isn't in this NPM image — degrade honestly to copying the live DB
+    // (consistent enough since #1679 flips WAL and the live file is read whole),
+    // and say SO in the log rather than a misleading "(unknown)" (#1894).
+    if (out === 'no-sqlite3') {
+      logger.warn('ExternalBackup', 'NPM sqlite snapshot skipped: sqlite3 not present in the NPM container — backing up database.sqlite as-is');
+      return manifest;
+    }
+    if (code !== 0 || (out !== 'ok' && out !== 'nodb')) {
+      // Surface the REAL failure: prefer the container's stderr (the swallowed
+      // `sh: sqlite3: not found` etc.), then any stdout, before "(unknown)".
+      const reason = errOut || out || 'unknown';
+      logger.warn('ExternalBackup', `NPM sqlite snapshot failed (${reason}) — backing up database.sqlite as-is`);
+      return manifest;
+    }
+    // Stage the snapshot in place of the live DB, under the original rel path.
+    return {
+      ...manifest,
+      include: manifest.include.map(p => (p === 'data/database.sqlite' ? 'data/database.sqlite.sb-backup' : p)),
+      renames: { 'data/database.sqlite.sb-backup': 'data/database.sqlite' },
+    };
+  } catch (e) {
+    logger.warn('ExternalBackup', `NPM sqlite snapshot errored (${e instanceof Error ? e.message : String(e)}) — backing up database.sqlite as-is`);
+    return manifest;
+  }
+}

--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -49,7 +49,6 @@ import {
   NAS_BACKUP_DIR,
   DEFAULT_BACKUP_RETENTION,
   latestServiceBackupName,
-  agentFileBackend,
 } from './producer';
 import { getServiceManifest, type ServiceBackupManifest } from './serviceManifest';
 import { logger } from '../logger';
@@ -360,146 +359,14 @@ describe('resolveServiceDataDir', () => {
   });
 });
 
-describe('backupServiceToNas via the host agent (#1597)', () => {
-  // The servicebay container can't see /mnt/data/stacks, so a box backup (no
-  // serviceDataDir override) must route every fs op through the host agent.
-  // Here the mocked executor runs the same ops against a REAL local temp dir,
-  // exercising the actual agentFileBackend round-trip (incl. tar | base64).
-  function wireExecutorToHostDir(): { stagingDir: string; execShellCalls: number } {
-    const ref = { stagingDir: '', execShellCalls: 0 };
-    // The bulk copy (#1894) runs as ONE shell pipe per service via executor.exec:
-    //   tar -C <src> --null -T <listfile> -cf - | tar -C <dest> -xf -
-    // Emulate it against the real local temp dirs and count the calls so a test
-    // can assert "one bulk exec, not a round-trip per file".
-    mockExecutor.exec.mockImplementation(async (command: string) => {
-      const m = /tar -C (\S+) --null -T (\S+) -cf - \| tar -C (\S+) -xf -/.exec(command);
-      if (!m) throw new Error(`unexpected exec: ${command}`);
-      ref.execShellCalls += 1;
-      const unq = (s: string) => s.replace(/^'(.*)'$/, '$1').replace(/'\\''/g, "'");
-      const [, srcRoot, listFile, destRoot] = m.map(unq);
-      const rels = (await fs.readFile(listFile, 'utf8')).split('\0').filter(Boolean);
-      for (const rel of rels) {
-        const dest = path.join(destRoot, rel);
-        await fs.mkdir(path.dirname(dest), { recursive: true });
-        await fs.copyFile(path.join(srcRoot, rel), dest);
-      }
-      return { stdout: '', stderr: '' };
-    });
-    mockExecutor.execArgv.mockImplementation(async (argv: string[]) => {
-      const [cmd, ...args] = argv;
-      if (cmd === 'find') {
-        const dir = args[0];
-        const ents = await fs.readdir(dir, { withFileTypes: true });
-        const lines = ents.map(e => `${e.isDirectory() ? 'd' : e.isFile() ? 'f' : 'o'}\t${e.name}`);
-        return { stdout: lines.join('\n'), stderr: '' };
-      }
-      if (cmd === 'test' && args[0] === '-d') {
-        const ok = await fs.stat(args[1]).then(s => s.isDirectory(), () => false);
-        if (!ok) throw new Error('not a dir');
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'test' && args[0] === '-e') {
-        const ok = await fs.access(args[1]).then(() => true, () => false);
-        if (!ok) throw new Error('missing');
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'mkdir') { await fs.mkdir(args[1], { recursive: true }); return { stdout: '', stderr: '' }; }
-      if (cmd === 'cp') {
-        const src = args[args.length - 2];
-        const dest = args[args.length - 1];
-        await fs.copyFile(src, dest);
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'mktemp') {
-        ref.stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'producer-test-hoststage-'));
-        tmpDirs.push(ref.stagingDir);
-        return { stdout: ref.stagingDir, stderr: '' };
-      }
-      if (cmd === 'tar') {
-        // tar -cf <tarPath> -C <stagingDir> .
-        const tarPath = args[1];
-        const stagingDir = args[3];
-        await execFileAsync('tar', ['-cf', tarPath, '-C', stagingDir, '.']);
-        tmpDirs.push(tarPath);
-        return { stdout: '', stderr: '' };
-      }
-      if (cmd === 'base64') {
-        const buf = await fs.readFile(args[0]);
-        return { stdout: buf.toString('base64'), stderr: '' };
-      }
-      if (cmd === 'rm') return { stdout: '', stderr: '' }; // leave temp for afterEach cleanup
-      throw new Error(`unexpected execArgv: ${argv.join(' ')}`);
-    });
-    mockExecutor.exists.mockImplementation((p: string) => fs.access(p).then(() => true, () => false));
-    mockExecutor.readFile.mockImplementation((p: string) => fs.readFile(p, 'utf8'));
-    mockExecutor.writeFile.mockImplementation((p: string, c: string) => fs.writeFile(p, c));
-    return ref;
-  }
-
-  it('reads + tars the stacks dir host-side and uploads the tar (config-survival is non-functional without this)', async () => {
-    const hostStacks = await mkTmp();
-    await writeFile(hostStacks, 'adguard/conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
-    await writeFile(hostStacks, 'adguard/data/querylog.json', '[]'); // excluded
-    mockGetConfig.mockResolvedValue({ templateSettings: { DATA_DIR: hostStacks } });
-    wireExecutorToHostDir();
-
-    const result = await backupServiceToNas('adguard');
-
-    expect(mockGetExecutor).toHaveBeenCalledWith('Local');
-    expect(result.size).toBeGreaterThan(0);
-    // The tar bytes that came back through the agent contain the config, not the excluded querylog.
-    const tarCall = mockNas.nasUpload.mock.calls.find(c => datedTarRe('adguard').test(String(c[0])))!;
-    const out = await mkTmp();
-    const tarFile = path.join(out, 'a.tar');
-    await fs.writeFile(tarFile, tarCall[1] as Buffer);
-    await execFileAsync('tar', ['-xf', tarFile, '-C', out]);
-    expect(await fs.readFile(path.join(out, 'conf/AdGuardHome.yaml'), 'utf8')).toBe('bind_host: 0.0.0.0');
-    await expect(fs.access(path.join(out, 'data/querylog.json'))).rejects.toThrow();
-  });
-
-  it('copies a large file tree in ONE host-side bulk exec, not a round-trip per file (#1894)', async () => {
-    const hostStacks = await mkTmp();
-    // A custom_components dir with many plain files — what OOM'd the box when each
-    // was a separate agent cp/mkdir round-trip.
-    for (let i = 0; i < 50; i++) {
-      await writeFile(hostStacks, `demo/custom_components/pkg/file${i}.py`, `x${i}`);
-    }
-    mockGetConfig.mockResolvedValue({ templateSettings: { DATA_DIR: hostStacks } });
-    // A throwaway manifest service that maps to the demo/ dir.
-    const ref = wireExecutorToHostDir();
-
-    const tar = await buildServiceBackupTar(
-      path.join(hostStacks, 'demo'),
-      { service: 'demo', include: ['custom_components'], exclude: [] },
-      // Build the tar directly against the wired agent backend (one bulk exec).
-      agentFileBackend(mockExecutor as unknown as Parameters<typeof agentFileBackend>[0]),
-    );
-    expect(tar.length).toBeGreaterThan(0);
-    // The 50 plain files were copied by a SINGLE bulk shell exec — no per-file cp.
-    expect(ref.execShellCalls).toBe(1);
-    const cpCalls = mockExecutor.execArgv.mock.calls.filter((c: unknown[]) => (c[0] as string[])[0] === 'cp');
-    expect(cpCalls).toHaveLength(0);
-  });
-
-  it('applies strip rules host-side via the agent (password hashes never leave the box)', async () => {
-    const hostStacks = await mkTmp();
-    await writeFile(hostStacks, 'authelia/users_database.yml',
-      'users:\n  a:\n    password: $argon2$SEKRIT\n    email: a@x\n');
-    mockGetConfig.mockResolvedValue({ templateSettings: { DATA_DIR: hostStacks } });
-    wireExecutorToHostDir();
-
-    const result = await backupServiceToNas('authelia');
-    const tarCall = mockNas.nasUpload.mock.calls.find(c => datedTarRe('authelia').test(String(c[0])))!;
-    const out = await mkTmp();
-    const tarFile = path.join(out, 'a.tar');
-    await fs.writeFile(tarFile, tarCall[1] as Buffer);
-    await execFileAsync('tar', ['-xf', tarFile, '-C', out]);
-    const stripped = await fs.readFile(path.join(out, 'users_database.yml'), 'utf8');
-    expect(stripped).not.toContain('SEKRIT');
-    expect(stripped).toContain('a@x');
-    expect(result.size).toBeGreaterThan(0);
-  });
-});
+// The box backup (no serviceDataDir) now routes the HEAVY walk/copy/tar through
+// the resource-capped backup worker container (#1955) — the old in-process
+// host-agent backend that OOM'd the box (#1894) is retired. The worker launch +
+// status polling is covered by backupWorker/launcher.test.ts and
+// backupWorker/service.test.ts; the worker's own staging engine (selection /
+// exclude / strip / bulk copy / tar) is covered by the backup-worker package's
+// staging.test.ts. The producer's remaining responsibilities (local-seed staging,
+// NAS write/prune/list/fetch/delete, scheduler) are tested below.
 
 describe('backupServiceToNas', () => {
   it('uploads the tar and a meta sidecar under sb-backup/', async () => {

--- a/packages/backend/src/lib/externalBackup/producer.ts
+++ b/packages/backend/src/lib/externalBackup/producer.ts
@@ -22,18 +22,16 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getConfig } from '../config';
 import { logger } from '../logger';
-import { agentManager } from '../agent/manager';
-import { getExecutor, type Executor } from '../executor';
-import { shellQuote } from '../util/shellQuote';
 import { nasUpload, nasDownload, nasList, nasRemove } from './nasClient';
 import {
   getServiceManifest,
-  getBackupGate,
   applyStripRules,
   applyTransformRules,
-  SERVICE_BACKUP_MANIFESTS,
   type ServiceBackupManifest,
 } from './serviceManifest';
+// Re-exported for back-compat: the collector moved to its own module to break the
+// producer ↔ backupWorker/service import cycle (#1955).
+export { runBackupCollector } from './collector';
 
 const execFileAsync = promisify(execFile);
 
@@ -145,19 +143,16 @@ async function pathExists(target: string): Promise<boolean> {
 }
 
 /**
- * The few filesystem primitives the staging + tar-building logic needs, so the
- * SAME selection/exclude/strip/rename logic can run against either:
- *  - the **local** container filesystem (the `sb-config-upload` CLI seed in
- *    #1219 / the HA-OS import #1353, which extract to a container-local temp
- *    dir), or
- *  - the **host** filesystem via the node agent (#1597 — the box backup reads
- *    `/mnt/data/stacks/<service>`, which is NOT bind-mounted into the
- *    servicebay container; only the host agent can see it, the same way
- *    install/restore/deploy reach the stacks).
+ * The few filesystem primitives the staging + tar-building logic needs. Only the
+ * **local** container-filesystem backend remains (the `sb-config-upload` CLI seed
+ * #1219 / the HA-OS import #1353, which extract a single uploaded archive into a
+ * container-local temp dir — small, no OOM risk). The box backup's HEAVY host-side
+ * walk/copy/tar moved into the resource-capped backup worker container (#1955,
+ * backupWorker/) — the old host-agent backend that held every tar in this process
+ * and OOM'd the box (#1894) is retired.
  *
- * Source reads and the staging dir both live on whichever side the backend
- * targets; the resulting tar bytes are always returned to the caller (the
- * container) for upload to the NAS.
+ * The seam is kept so the local-seed path stays unit-testable; the staging tar
+ * bytes are returned to the caller for upload to the NAS.
  */
 export interface BackupFileBackend {
   /** Directory entries with their type (no recursion). */
@@ -169,13 +164,9 @@ export interface BackupFileBackend {
   /** Copy a file byte-for-byte (binary-safe — sqlite, certs, …). */
   copyFile(src: string, dest: string): Promise<void>;
   /**
-   * Copy MANY files (given as relative paths under `srcRoot`) into `destRoot`,
-   * preserving their relative subdirs, in as few operations as possible. The
-   * host-agent backend does this in a SINGLE exec (one `tar -C srcRoot … | tar
-   * -x -C destRoot`) instead of a `mkdirp`+`copyFile` round-trip per file — a HA
-   * config with HACS is thousands of files, and per-file agent round-trips OOM'd
-   * the box (#1894). `relFiles` are plain copies only; strip/transform/renamed
-   * files are still staged individually (they're few and need a content rewrite).
+   * Copy MANY files (relative paths under `srcRoot`) into `destRoot`, preserving
+   * their relative subdirs. `relFiles` are plain copies only; strip/transform/
+   * renamed files are still staged individually (they need a content rewrite).
    */
   bulkCopyFiles(srcRoot: string, relFiles: string[], destRoot: string): Promise<void>;
   writeText(dest: string, content: string): Promise<void>;
@@ -226,98 +217,6 @@ const localFileBackend: BackupFileBackend = {
     await fs.rm(target, { recursive: true, force: true });
   },
 };
-
-/**
- * Bulk-copy `relFiles` (relative to `srcRoot`) into `destRoot` host-side in ONE
- * exec (#1894): write the paths NUL-separated to a temp list, then
- * `tar -C srcRoot --null -T list -cf - | tar -C destRoot -xf -`. The pipe streams
- * through the host filesystem — no `cp`/`mkdir` round-trip per file, so a HACS HA
- * config (thousands of files) no longer floods the agent channel and OOMs the
- * box. NUL separation means a path with spaces/newlines/quotes is taken verbatim
- * (no tar `-T` unquoting). Both tar invocations + the pipe need a shell, so this
- * uses `exec` (not execArgv); every interpolated path is shellQuote'd.
- */
-async function agentBulkCopyFiles(
-  executor: Executor,
-  srcRoot: string,
-  relFiles: string[],
-  destRoot: string,
-): Promise<void> {
-  if (relFiles.length === 0) return;
-  const listFile = `${destRoot}.copylist`;
-  await executor.writeFile(listFile, relFiles.join('\0'));
-  try {
-    const cmd =
-      `tar -C ${shellQuote(srcRoot)} --null -T ${shellQuote(listFile)} -cf - | ` +
-      `tar -C ${shellQuote(destRoot)} -xf -`;
-    await executor.exec(cmd, { timeoutMs: 120_000 });
-  } finally {
-    await executor.execArgv(['rm', '-f', listFile]);
-  }
-}
-
-/**
- * Host-agent backend (#1597) — reads/stages on the HOST via the node agent, so
- * it sees `/mnt/data/stacks/<service>` (not mounted into the servicebay
- * container). The staging dir + tar are built host-side; only the final tar
- * bytes cross back into the container (base64 over the agent channel, since the
- * agent's `read_file` is utf-8-only and would corrupt binary config).
- */
-export function agentFileBackend(executor: Executor): BackupFileBackend {
-  return {
-    async readdirTypes(dir) {
-      // `find -maxdepth 1` with a type tag per entry — one round-trip, and it
-      // distinguishes files from dirs without a stat-per-entry storm.
-      const { stdout } = await executor.execArgv([
-        'find', dir, '-maxdepth', '1', '-mindepth', '1', '-printf', '%y\t%f\n',
-      ]);
-      return stdout
-        .split('\n')
-        .map(l => l.trim())
-        .filter(Boolean)
-        .map(l => {
-          const [type, ...rest] = l.split('\t');
-          const name = rest.join('\t');
-          return { name, isDir: type === 'd', isFile: type === 'f' };
-        });
-    },
-    exists: target => executor.exists(target),
-    async isDirectory(target) {
-      // `test -d` exits non-zero (→ execArgv throws) for a non-dir.
-      return executor.execArgv(['test', '-d', target]).then(() => true, () => false);
-    },
-    readText: target => executor.readFile(target),
-    async copyFile(src, dest) {
-      await executor.execArgv(['cp', '-p', src, dest]);
-    },
-    bulkCopyFiles: (srcRoot, relFiles, destRoot) =>
-      agentBulkCopyFiles(executor, srcRoot, relFiles, destRoot),
-    writeText: (dest, content) => executor.writeFile(dest, content),
-    async mkdirp(dir) {
-      await executor.execArgv(['mkdir', '-p', dir]);
-    },
-    async makeStagingDir() {
-      const { stdout } = await executor.execArgv(['mktemp', '-d', '-t', 'sb-svcbackup-XXXXXX']);
-      return stdout.trim();
-    },
-    async tarStagingDir(stagingDir) {
-      // Tar host-side to a file, then read it back base64-encoded — no shell
-      // pipe and no exec template-literal (each arg is execArgv-quoted). The
-      // agent's read_file is utf-8-only, so base64 keeps binary config intact.
-      const tarPath = `${stagingDir}.tar`;
-      try {
-        await executor.execArgv(['tar', '-cf', tarPath, '-C', stagingDir, '.'], { timeoutMs: 120_000 });
-        const { stdout } = await executor.execArgv(['base64', tarPath], { timeoutMs: 120_000 });
-        return Buffer.from(stdout.replace(/\s+/g, ''), 'base64');
-      } finally {
-        await executor.execArgv(['rm', '-f', tarPath]);
-      }
-    },
-    async rmrf(target) {
-      await executor.execArgv(['rm', '-rf', target]);
-    },
-  };
-}
 
 /** A relative path is excluded when it equals an exclude entry or lives under
  *  one (an exclude dir). Excludes always win over includes. */
@@ -478,95 +377,6 @@ export async function resolveServiceDataDir(service: string): Promise<string> {
   return path.join(dataDir, subdir);
 }
 
-// Runs inside the NPM container: a consistent snapshot of the live WAL-mode
-// /data/database.sqlite to /data/database.sqlite.sb-backup using sqlite3's
-// online `.backup`, then `mv` over the canonical name so the file-copy producer
-// reads a torn-free copy. NPM's image bundles sqlite3.
-//
-// Since #1679 the live DB runs in WAL mode (the auth/nginx post-deploys flip
-// `journal_mode=WAL`), so committed writes can sit in the `-wal` sidecar rather
-// than the main file. We first `wal_checkpoint(TRUNCATE)` to fold the WAL back
-// into the main DB and truncate the sidecar — so even a plain reader of
-// database.sqlite would be consistent — then take the online `.backup` (itself
-// WAL-aware) into a single self-contained file the producer stages under the
-// canonical name. The checkpoint is best-effort (a busy DB may not fully
-// checkpoint); `.backup` guarantees consistency regardless.
-const NPM_SQLITE_SNAPSHOT_SH = [
-  'set -e',
-  "DB=/data/database.sqlite",
-  'if [ ! -f "$DB" ]; then echo "nodb"; exit 0; fi',
-  // Not every NPM image ships sqlite3 (#1894 — the current jc21 image does not).
-  // Probe for it FIRST and report a precise, greppable reason so the producer can
-  // degrade honestly (copy the live file) instead of logging a misleading
-  // "(unknown)". The real `sh: sqlite3: not found` stderr never made it back
-  // before, so this gap was undiagnosable from the logs.
-  'if ! command -v sqlite3 >/dev/null 2>&1; then echo "no-sqlite3"; exit 0; fi',
-  // Fold the WAL back into the main DB so the snapshot has no dependence on the
-  // -wal/-shm sidecars. Best-effort: ignore a non-zero (busy) checkpoint.
-  'sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);" || true',
-  // `.backup` produces a transactionally-consistent copy even mid-write.
-  'sqlite3 "$DB" ".backup \'$DB.sb-snap\'"',
-  'mv -f "$DB.sb-snap" "$DB.sb-backup"',
-  'echo "ok"',
-].join('\n');
-
-/**
- * Run a manifest's `collector` (in-container snapshot) before the file-copy
- * producer reads the data dir. For NPM: takes a consistent `sqlite3 .backup`
- * of the live database.sqlite to `database.sqlite.sb-backup` on disk, then
- * remaps the manifest's `data/database.sqlite` include to that snapshot path so
- * the producer stages the consistent copy under the original name. Returns a
- * possibly-rewritten manifest. Best-effort: if the snapshot can't be taken the
- * original manifest is returned (the producer copies the live file and logs).
- */
-export async function runBackupCollector(
-  manifest: ServiceBackupManifest,
-  node: string,
-): Promise<ServiceBackupManifest> {
-  if (manifest.collector?.kind !== 'npm-sqlite') return manifest;
-  try {
-    const agent = await agentManager.ensureAgent(node);
-    const find = await agent.sendCommand('exec', {
-      command: `podman ps --format '{{.Names}} {{.Image}}' | awk '/proxy-manager/{print $1; exit}'`,
-    }, { timeoutMs: 15_000 });
-    const container = ((find as { stdout?: string }).stdout || '').trim().split(/\s+/)[0];
-    if (!container) {
-      logger.warn('ExternalBackup', 'NPM container not found — backing up database.sqlite as-is (may be inconsistent)');
-      return manifest;
-    }
-    const b64 = Buffer.from(NPM_SQLITE_SNAPSHOT_SH).toString('base64');
-    const res = await agent.sendCommand('exec', {
-      command: `echo ${b64} | base64 -d | podman exec -i ${container} sh -`,
-    }, { timeoutMs: 30_000 });
-    const out = ((res as { stdout?: string }).stdout || '').trim();
-    const errOut = ((res as { stderr?: string }).stderr || '').trim();
-    const code = (res as { code?: number }).code;
-    // sqlite3 isn't in this NPM image — degrade honestly to copying the live DB
-    // (consistent enough since #1679 flips WAL and the live file is read whole),
-    // and say SO in the log rather than a misleading "(unknown)" (#1894).
-    if (out === 'no-sqlite3') {
-      logger.warn('ExternalBackup', 'NPM sqlite snapshot skipped: sqlite3 not present in the NPM container — backing up database.sqlite as-is');
-      return manifest;
-    }
-    if (code !== 0 || (out !== 'ok' && out !== 'nodb')) {
-      // Surface the REAL failure: prefer the container's stderr (the swallowed
-      // `sh: sqlite3: not found` etc.), then any stdout, before "(unknown)".
-      const reason = errOut || out || 'unknown';
-      logger.warn('ExternalBackup', `NPM sqlite snapshot failed (${reason}) — backing up database.sqlite as-is`);
-      return manifest;
-    }
-    // Stage the snapshot in place of the live DB, under the original rel path.
-    return {
-      ...manifest,
-      include: manifest.include.map(p => (p === 'data/database.sqlite' ? 'data/database.sqlite.sb-backup' : p)),
-      renames: { 'data/database.sqlite.sb-backup': 'data/database.sqlite' },
-    };
-  } catch (e) {
-    logger.warn('ExternalBackup', `NPM sqlite snapshot errored (${e instanceof Error ? e.message : String(e)}) — backing up database.sqlite as-is`);
-    return manifest;
-  }
-}
-
 /**
  * Produce a service's config tarball and write it (plus its meta sidecar) to
  * the NAS. Pass `serviceDataDir` to back up from an arbitrary location (the
@@ -577,25 +387,34 @@ export async function backupServiceToNas(
   service: string,
   opts: { serviceDataDir?: string; node?: string } = {},
 ): Promise<ServiceBackupResult> {
-  let manifest = getServiceManifest(service);
+  const manifest = getServiceManifest(service);
   if (!manifest) {
     throw new Error(`No backup manifest for service "${service}"`);
   }
-  // Run any in-container snapshot collector (e.g. NPM's consistent sqlite copy)
-  // before reading the data dir — only for a live box backup, never for the
-  // arbitrary-dir CLI seed (which has no running container to exec into).
-  if (manifest.collector && !opts.serviceDataDir) {
-    manifest = await runBackupCollector(manifest, opts.node || 'Local');
+  // A box backup (no serviceDataDir) reads the stacks dir host-side — the HEAVY
+  // walk/copy/tar that OOM'd the control plane in-process (#1894). It now runs in
+  // the resource-capped backup worker container (#1955); servicebay only launches
+  // it, polls status, then streams the produced tar to the NAS.
+  if (!opts.serviceDataDir) {
+    const { runBackupForServices } = await import('../backupWorker/service');
+    const completed = await runBackupForServices([service], opts.node || 'Local');
+    const [entry] = await uploadBackupRun(completed);
+    if (!entry || !entry.ok) {
+      throw new Error(entry?.error ?? `No backup produced for "${service}"`);
+    }
+    return {
+      service,
+      tarName: entry.tarName ?? `${service}.tar`,
+      metaName: `${entry.tarName ?? `${service}.tar`}.meta.json`,
+      size: entry.size ?? 0,
+      meta: { service, schemaVersion: META_SCHEMA_VERSION, createdAt: new Date().toISOString(), nodeId: os.hostname() },
+    };
   }
   // An explicit serviceDataDir is a container-local source (CLI seed / HA-OS
-  // import) → local fs backend. A box backup reads the stacks dir, which is NOT
-  // mounted into the servicebay container, so it MUST go through the host agent
-  // (#1597) — same path install/restore/deploy use.
-  const serviceDataDir = opts.serviceDataDir ?? (await resolveServiceDataDir(service));
-  const backend = opts.serviceDataDir
-    ? localFileBackend
-    : agentFileBackend(getExecutor(opts.node || 'Local'));
-  const tar = await buildServiceBackupTar(serviceDataDir, manifest, backend);
+  // import): the dir is already extracted in the servicebay container and is
+  // small (one uploaded archive), so it's staged in-process on the local fs — the
+  // worker can't see a container-local temp dir, and there's no OOM risk here.
+  const tar = await buildServiceBackupTar(opts.serviceDataDir, manifest, localFileBackend);
   return writeServiceBackupToNas(service, tar);
 }
 
@@ -609,27 +428,53 @@ export interface ServiceBackupRunEntry {
 }
 
 /**
- * On-demand "back up now" (#1217): back up every INSTALLED service that has a
- * backup manifest to the NAS, in one pass. Per-service failures are captured in
- * the result (one bad service doesn't abort the rest) — a NAS-not-configured /
- * connection error surfaces on the first attempt and repeats per service, which
- * the caller can detect (all `ok:false` with the same error).
+ * Stream a completed worker run's tars to the NAS, one at a time (bounded I/O —
+ * the control plane never holds them all), then remove the per-run out dir.
+ * Returns the per-service entries (ok services on the NAS + the worker's skip/
+ * error rollup). Shared by the per-service + back-up-all NAS paths (#1955).
  */
-export async function backupInstalledServicesToNas(): Promise<ServiceBackupRunEntry[]> {
-  const installed = new Set(Object.keys((await getConfig()).installedTemplates ?? {}));
+async function uploadBackupRun(
+  completed: import('../backupWorker/service').BackupRun,
+): Promise<ServiceBackupRunEntry[]> {
+  const { readBackupTar, cleanupBackupRun } = await import('../backupWorker/service');
+  const { exec, run, status } = completed;
   const results: ServiceBackupRunEntry[] = [];
-  for (const manifest of SERVICE_BACKUP_MANIFESTS) {
-    // A sibling-store entry (#1594) gates on its parent template, not its own
-    // synthetic service name (which is never an installedTemplates key).
-    if (!installed.has(getBackupGate(manifest))) continue;
-    try {
-      const r = await backupServiceToNas(manifest.service);
-      results.push({ service: manifest.service, ok: true, tarName: r.tarName, size: r.size });
-    } catch (e) {
-      results.push({ service: manifest.service, ok: false, error: e instanceof Error ? e.message : String(e) });
+  try {
+    for (const r of status.results) {
+      if (r.ok && r.tarName) {
+        try {
+          const tar = await readBackupTar(exec, run, r.tarName);
+          const written = await writeServiceBackupToNas(r.service, tar);
+          results.push({ service: r.service, ok: true, tarName: written.tarName, size: written.size });
+        } catch (e) {
+          results.push({ service: r.service, ok: false, error: e instanceof Error ? e.message : String(e) });
+        }
+      } else {
+        // skip (no config on disk yet) or a per-service worker error — mirror the
+        // old producer's per-service failure entry (one bad service doesn't abort).
+        results.push({ service: r.service, ok: false, error: r.detail ?? 'No config files to back up' });
+      }
     }
+  } finally {
+    await cleanupBackupRun(exec, run);
   }
   return results;
+}
+
+/**
+ * On-demand "back up now" (#1217): back up every INSTALLED service that has a
+ * backup manifest to the NAS, in one pass — now worker-backed (#1955). The heavy
+ * multi-service walk/copy/tar runs in ONE backup-worker container; servicebay
+ * launches it, polls the compact status, then streams each produced tar to the
+ * NAS. The old in-process per-service agent file-copy held every tar in the
+ * control plane and OOM'd the box (#1894). Per-service failures are captured in
+ * the result (one bad service doesn't abort the rest).
+ */
+export async function backupInstalledServicesToNas(): Promise<ServiceBackupRunEntry[]> {
+  const { runBackupForInstalled } = await import('../backupWorker/service');
+  const completed = await runBackupForInstalled();
+  if (!completed) return []; // nothing installed with a manifest
+  return uploadBackupRun(completed);
 }
 
 // ─── Nightly scheduler (#1217) ───────────────────────────────────────
@@ -782,7 +627,7 @@ async function pruneServiceBackups(service: string, keep: number): Promise<strin
  * Shared by the dir-based producer (`backupServiceToNas`) and the upload route
  * (#1351) so the on-NAS format has a single source of truth.
  */
-async function writeServiceBackupToNas(service: string, tar: Buffer): Promise<ServiceBackupResult> {
+export async function writeServiceBackupToNas(service: string, tar: Buffer): Promise<ServiceBackupResult> {
   const now = new Date();
   const meta: ServiceBackupMeta = {
     service,

--- a/packages/backend/src/lib/systemBackup.retention.test.ts
+++ b/packages/backend/src/lib/systemBackup.retention.test.ts
@@ -26,13 +26,12 @@ vi.mock('./dirs', () => ({
 
 vi.mock('./nodes', () => ({ listNodes: vi.fn(async () => []) }));
 vi.mock('./config', () => ({ getConfig: vi.fn(async () => ({ installedTemplates: {} })), updateConfig: vi.fn() }));
-// stageServiceConfig pulls these in lazily — return "nothing staged".
-vi.mock('./externalBackup/serviceManifest', () => ({ SERVICE_BACKUP_MANIFESTS: [], getBackupGate: (m: { service: string }) => m.service }));
-vi.mock('./externalBackup/producer', () => ({
-    buildServiceBackupTar: vi.fn(),
-    agentFileBackend: vi.fn(() => ({})),
-    resolveServiceDataDir: vi.fn(),
-    runBackupCollector: vi.fn(),
+// stageServiceConfig pulls the backup worker in lazily — return "nothing staged"
+// (no installed service has a backup manifest) so the snapshot has no service config.
+vi.mock('./backupWorker/service', () => ({
+    stageInstalledServiceConfigViaWorker: vi.fn(async () => null),
+    readBackupTar: vi.fn(),
+    cleanupBackupRun: vi.fn(),
 }));
 vi.mock('./executor', () => ({ getExecutor: vi.fn(() => ({})) }));
 vi.mock('./ssh/pool', () => ({ SSHConnectionPool: { getInstance: () => ({ getConnection: vi.fn() }) } }));

--- a/packages/backend/src/lib/systemBackup.serviceConfig.test.ts
+++ b/packages/backend/src/lib/systemBackup.serviceConfig.test.ts
@@ -8,21 +8,21 @@ import type { Executor } from './executor';
 
 const execFileAsync = promisify(execFile);
 
-const { mockManifest, mockProducer, mockGetExecutor, mockCfg } = vi.hoisted(() => ({
-    mockManifest: { SERVICE_BACKUP_MANIFESTS: [] as unknown[], getBackupGate: vi.fn() },
-    mockProducer: {
-        buildServiceBackupTar: vi.fn(),
-        agentFileBackend: vi.fn(() => ({})),
-        resolveServiceDataDir: vi.fn(),
-        runBackupCollector: vi.fn(),
+// stageServiceConfig now delegates the heavy walk/copy/tar to the resource-capped
+// backup worker (#1955): the worker writes <service>.tar to a shared out dir, and
+// stageServiceConfig reads each tar (via readBackupTar) and safeTarExtracts it
+// into the archive. We mock the worker service so the test drives the worker's
+// status results + tar bytes without launching a container.
+const { mockWorker, mockCfg } = vi.hoisted(() => ({
+    mockWorker: {
+        stageInstalledServiceConfigViaWorker: vi.fn(),
+        readBackupTar: vi.fn(),
+        cleanupBackupRun: vi.fn(),
     },
-    mockGetExecutor: vi.fn(),
     mockCfg: { getConfig: vi.fn(), updateConfig: vi.fn() },
 }));
 
-vi.mock('./externalBackup/serviceManifest', () => mockManifest);
-vi.mock('./externalBackup/producer', () => mockProducer);
-vi.mock('./executor', () => ({ getExecutor: (...a: unknown[]) => mockGetExecutor(...a) }));
+vi.mock('./backupWorker/service', () => mockWorker);
 vi.mock('./config', () => mockCfg);
 
 import { stageServiceConfig, extractServiceConfigToNode } from './systemBackup';
@@ -50,13 +50,34 @@ function makeMeta(): { version: number; createdAt: string; nodes: never[]; confi
 
 let tmpRoot: string;
 
+/** Build a worker status doc with the given per-service results. */
+function workerStatus(results: Array<{ service: string; ok: boolean; tarName?: string | null; outcome?: 'ok' | 'skip' | 'error'; detail?: string | null }>) {
+    return {
+        version: 1, runId: 'r', phase: 'done', step: 'done', total: results.length, processed: results.length,
+        results: results.map(r => ({
+            service: r.service, ok: r.ok, tarName: r.tarName ?? (r.ok ? `${r.service}.tar` : null),
+            bytes: 0, files: 0, outcome: r.outcome ?? (r.ok ? 'ok' : 'error'), detail: r.detail ?? null,
+        })),
+        error: null, updatedAt: 0, startedAt: 0,
+    };
+}
+
+/** Wire the worker mock: status results + per-tar bytes keyed by tarName. */
+function wireWorker(status: ReturnType<typeof workerStatus>, tars: Record<string, Buffer> = {}) {
+    const run = { runId: 'r', outDir: '/out/r', container: 'backup-worker-r' };
+    const exec = vi.fn();
+    mockWorker.stageInstalledServiceConfigViaWorker.mockResolvedValue({ exec, run, status });
+    mockWorker.readBackupTar.mockImplementation(async (_e: unknown, _r: unknown, tarName: string) => {
+        const buf = tars[tarName];
+        if (!buf) throw new Error(`no tar for ${tarName}`);
+        return buf;
+    });
+    mockWorker.cleanupBackupRun.mockResolvedValue(undefined);
+}
+
 beforeEach(async () => {
     vi.clearAllMocks();
     tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sysbackup-svccfg-'));
-    mockManifest.SERVICE_BACKUP_MANIFESTS = [];
-    mockManifest.getBackupGate.mockImplementation((m: { service: string }) => m.service);
-    mockProducer.agentFileBackend.mockReturnValue({});
-    mockGetExecutor.mockReturnValue({} as Executor);
     mockCfg.getConfig.mockResolvedValue({ installedTemplates: {} });
 });
 
@@ -65,15 +86,13 @@ afterEach(async () => {
 });
 
 describe('stageServiceConfig', () => {
-    it('stages config for each installed manifest into service-config/<svc>/ and records metadata', async () => {
-        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { 'home-assistant': {}, nginx: {} } });
-        mockManifest.SERVICE_BACKUP_MANIFESTS = [
-            { service: 'home-assistant' },
-            { service: 'nginx' },
-        ];
-        mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
-        mockProducer.buildServiceBackupTar.mockImplementation(async (_dir: string, m: { service: string }) =>
-            buildTar({ [`${m.service}.conf`]: `cfg for ${m.service}` }),
+    it('extracts each worker-produced tar into service-config/<svc>/ and records metadata', async () => {
+        wireWorker(
+            workerStatus([{ service: 'home-assistant', ok: true }, { service: 'nginx', ok: true }]),
+            {
+                'home-assistant.tar': await buildTar({ 'home-assistant.conf': 'cfg for home-assistant' }),
+                'nginx.tar': await buildTar({ 'nginx.conf': 'cfg for nginx' }),
+            },
         );
 
         const metadata = makeMeta();
@@ -81,64 +100,38 @@ describe('stageServiceConfig', () => {
         const staged = await stageServiceConfig(tmpRoot, metadata as never, logs as never, undefined);
 
         expect(staged).toBe(true);
-        // Files landed under service-config/<svc>/
         const haFile = path.join(tmpRoot, 'service-config', 'home-assistant', 'home-assistant.conf');
         const nginxFile = path.join(tmpRoot, 'service-config', 'nginx', 'nginx.conf');
         await expect(fs.readFile(haFile, 'utf8')).resolves.toBe('cfg for home-assistant');
         await expect(fs.readFile(nginxFile, 'utf8')).resolves.toBe('cfg for nginx');
         // The per-service tmp tar is cleaned up.
         await expect(fs.access(path.join(tmpRoot, 'service-config', 'home-assistant.tar'))).rejects.toThrow();
+        // The worker run's out dir is cleaned up.
+        expect(mockWorker.cleanupBackupRun).toHaveBeenCalledTimes(1);
         // Metadata records {label, service, sourcePath, nodeName}.
         const sd = metadata.serviceData;
         expect(sd).toEqual([
-            { label: 'home-assistant', service: 'home-assistant', sourcePath: '/mnt/data/stacks/home-assistant', nodeName: 'Local' },
-            { label: 'nginx', service: 'nginx', sourcePath: '/mnt/data/stacks/nginx', nodeName: 'Local' },
+            { label: 'home-assistant', service: 'home-assistant', sourcePath: 'home-assistant', nodeName: 'Local' },
+            { label: 'nginx', service: 'nginx', sourcePath: 'nginx', nodeName: 'Local' },
         ]);
     });
 
-    it('skips manifests whose backup-gate template is not installed', async () => {
-        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { nginx: {} } });
-        mockManifest.SERVICE_BACKUP_MANIFESTS = [
-            { service: 'home-assistant' },
-            { service: 'nginx' },
-        ];
-        mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
-        mockProducer.buildServiceBackupTar.mockResolvedValue(await buildTar({ 'nginx.conf': 'x' }));
-
+    it('returns false when no installed service has a backup manifest', async () => {
+        mockWorker.stageInstalledServiceConfigViaWorker.mockResolvedValue(null);
         const metadata = makeMeta();
-        await stageServiceConfig(tmpRoot, metadata as never, [], undefined);
-
-        const sd = metadata.serviceData;
-        expect(sd.map(e => e.service)).toEqual(['nginx']);
-        expect(mockProducer.buildServiceBackupTar).toHaveBeenCalledTimes(1);
+        const staged = await stageServiceConfig(tmpRoot, metadata as never, [], undefined);
+        expect(staged).toBe(false);
+        expect(metadata.serviceData).toEqual([]);
     });
 
-    it('runs the collector when the manifest declares one', async () => {
-        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { npm: {} } });
-        const collectedManifest = { service: 'npm', collected: true };
-        mockManifest.SERVICE_BACKUP_MANIFESTS = [{ service: 'npm', collector: 'snapshot' }];
-        mockProducer.resolveServiceDataDir.mockResolvedValue('/mnt/data/stacks/npm');
-        mockProducer.runBackupCollector.mockResolvedValue(collectedManifest);
-        mockProducer.buildServiceBackupTar.mockResolvedValue(await buildTar({ 'npm.conf': 'x' }));
-
-        await stageServiceConfig(tmpRoot, { version: 3, createdAt: '', nodes: [], configFiles: [] } as never, [], undefined);
-
-        expect(mockProducer.runBackupCollector).toHaveBeenCalledWith(
-            expect.objectContaining({ service: 'npm' }),
-            'Local',
+    it('treats a worker "skip" outcome as a skip log, not an error, and continues', async () => {
+        wireWorker(
+            workerStatus([
+                { service: 'a', ok: false, outcome: 'skip', detail: 'No config files to back up' },
+                { service: 'b', ok: true },
+            ]),
+            { 'b.tar': await buildTar({ 'b.conf': 'x' }) },
         );
-        // The collector's effective manifest is what gets tarred.
-        expect(mockProducer.buildServiceBackupTar).toHaveBeenCalledWith('/mnt/data/stacks/npm', collectedManifest, expect.anything());
-    });
-
-    it('treats "No config files to back up" as a skip, not an error, and continues', async () => {
-        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { a: {}, b: {} } });
-        mockManifest.SERVICE_BACKUP_MANIFESTS = [{ service: 'a' }, { service: 'b' }];
-        mockProducer.resolveServiceDataDir.mockImplementation(async (svc: string) => `/mnt/data/stacks/${svc}`);
-        mockProducer.buildServiceBackupTar.mockImplementation(async (_dir: string, m: { service: string }) => {
-            if (m.service === 'a') throw new Error('No config files to back up');
-            return buildTar({ 'b.conf': 'x' });
-        });
 
         const logs: Array<{ status: string; message: string }> = [];
         const staged = await stageServiceConfig(tmpRoot, { version: 3, createdAt: '', nodes: [], configFiles: [] } as never, logs as never, undefined);
@@ -148,11 +141,8 @@ describe('stageServiceConfig', () => {
         expect(logs.some(l => l.status === 'error')).toBe(false);
     });
 
-    it('logs an error (not skip) for an unexpected per-service failure and returns false when nothing staged', async () => {
-        mockCfg.getConfig.mockResolvedValue({ installedTemplates: { a: {} } });
-        mockManifest.SERVICE_BACKUP_MANIFESTS = [{ service: 'a' }];
-        mockProducer.resolveServiceDataDir.mockResolvedValue('/mnt/data/stacks/a');
-        mockProducer.buildServiceBackupTar.mockRejectedValue(new Error('disk exploded'));
+    it('logs an error (not skip) for a worker error outcome and returns false when nothing staged', async () => {
+        wireWorker(workerStatus([{ service: 'a', ok: false, outcome: 'error', detail: 'disk exploded' }]));
 
         const logs: Array<{ status: string; message: string }> = [];
         const staged = await stageServiceConfig(tmpRoot, { version: 3, createdAt: '', nodes: [], configFiles: [] } as never, logs as never, undefined);

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -502,56 +502,58 @@ export async function stageServiceConfig(
     const serviceConfigRoot = path.join(stagingDir, 'service-config');
     metadata.serviceData = [];
 
-    const { SERVICE_BACKUP_MANIFESTS, getBackupGate } = await import('./externalBackup/serviceManifest');
-    const { buildServiceBackupTar, agentFileBackend, resolveServiceDataDir, runBackupCollector } = await import('./externalBackup/producer');
-    const { getExecutor } = await import('./executor');
-
-    const installed = new Set(Object.keys((await getConfig()).installedTemplates ?? {}));
     const nodeName = 'Local';
-    const backend = agentFileBackend(getExecutor(nodeName));
+    // The heavy per-service walk/copy/tar runs in the resource-capped backup
+    // worker container (#1955) — NOT in this control-plane process, where the old
+    // agent file-copy held every tar in memory and OOM'd the box (#1894). The
+    // worker writes <service>.tar into a shared out dir; we read each tar (one at
+    // a time, bounded), then safeTarExtract it into the archive's
+    // service-config/<svc>/ tree.
+    const { stageInstalledServiceConfigViaWorker, readBackupTar, cleanupBackupRun } =
+        await import('./backupWorker/service');
+
+    const staged = await stageInstalledServiceConfigViaWorker(nodeName);
+    if (!staged) return false; // no installed services with a backup manifest
+
+    const { exec, run, status } = staged;
     let stagedAny = false;
+    try {
+        for (const r of status.results) {
+            const svc = r.service;
+            if (r.ok && r.tarName) {
+                try {
+                    const tar = await readBackupTar(exec, run, r.tarName);
+                    const destDir = path.join(serviceConfigRoot, svc);
+                    await fs.mkdir(destDir, { recursive: true });
+                    const tmpTar = path.join(serviceConfigRoot, `${svc}.tar`);
+                    await fs.writeFile(tmpTar, tar);
+                    // The worker builds a SAFE-by-construction plain tar from a
+                    // staging dir it controls; safeTarExtract (gzip:false) still
+                    // applies the standard restore-side hardening as belt-and-braces.
+                    await safeTarExtract(tmpTar, destDir, { gzip: false });
+                    await fs.rm(tmpTar, { force: true });
 
-    for (const manifest of SERVICE_BACKUP_MANIFESTS) {
-        // Sibling-store entries (#1594) gate on their parent template, not their
-        // own synthetic service name.
-        if (!installed.has(getBackupGate(manifest))) continue;
-        const svc = manifest.service;
-        try {
-            const serviceDataDir = await resolveServiceDataDir(svc);
-            // The producer runs any in-container collector (NPM's consistent
-            // sqlite snapshot) itself when given an agent backend + node — but
-            // buildServiceBackupTar takes a resolved manifest, so we mirror
-            // backupServiceToNas's collector step.
-            const effective = manifest.collector
-                ? await runBackupCollector(manifest, nodeName)
-                : manifest;
-            const tar = await buildServiceBackupTar(serviceDataDir, effective, backend);
-
-            const destDir = path.join(serviceConfigRoot, svc);
-            await fs.mkdir(destDir, { recursive: true });
-            const tmpTar = path.join(serviceConfigRoot, `${svc}.tar`);
-            await fs.writeFile(tmpTar, tar);
-            // The producer builds a SAFE-by-construction plain tar from a staging
-            // dir it controls; safeTarExtract (gzip:false) still applies the
-            // standard restore-side hardening as belt-and-suspenders.
-            await safeTarExtract(tmpTar, destDir, { gzip: false });
-            await fs.rm(tmpTar, { force: true });
-
-            (metadata.serviceData as ServiceDataEntry[]).push({
-                label: svc,
-                service: svc,
-                sourcePath: serviceDataDir,
-                nodeName,
-            });
-            stagedAny = true;
-            pushLog(logs, progress, { scope: 'local', status: 'success', node: nodeName, message: `Captured config for ${svc}` });
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            // "No config files to back up" just means the service has no
-            // on-disk config yet — a skip, not an error.
-            const status: BackupLogStatus = /No config files to back up/.test(message) ? 'skip' : 'error';
-            pushLog(logs, progress, { scope: 'local', status, node: nodeName, message: `${svc}: ${message}` });
+                    (metadata.serviceData as ServiceDataEntry[]).push({
+                        label: svc,
+                        service: svc,
+                        sourcePath: svc,
+                        nodeName,
+                    });
+                    stagedAny = true;
+                    pushLog(logs, progress, { scope: 'local', status: 'success', node: nodeName, message: `Captured config for ${svc}` });
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    pushLog(logs, progress, { scope: 'local', status: 'error', node: nodeName, message: `${svc}: ${message}` });
+                }
+            } else {
+                // skip (no config on disk yet) or a per-service worker error —
+                // neither aborts the snapshot.
+                const status: BackupLogStatus = r.outcome === 'skip' ? 'skip' : 'error';
+                pushLog(logs, progress, { scope: 'local', status, node: nodeName, message: `${svc}: ${r.detail ?? 'no config'}` });
+            }
         }
+    } finally {
+        await cleanupBackupRun(exec, run);
     }
 
     return stagedAny;

--- a/packages/backup-worker/Containerfile
+++ b/packages/backup-worker/Containerfile
@@ -22,6 +22,13 @@
 #     <image> --stacks /mnt/stacks --out /out --services home-assistant,authelia,…
 
 FROM node:20-slim AS base
+# `npm ci` builds the workspace's native modules (node-pty in the backend, etc.) →
+# node-gyp needs a build toolchain even though this worker doesn't use them itself
+# (same constraint as the disk-import worker image).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Workspace-aware install: the root + every member manifest must be present so

--- a/packages/backup-worker/Containerfile
+++ b/packages/backup-worker/Containerfile
@@ -1,0 +1,47 @@
+# backup-worker — resource-capped one-shot config-backup worker (#1955, slice of #1949).
+#
+# The heavy external/config backup (walk every installed service's stacks dir,
+# apply the include/exclude/strip/transform manifest, copy + tar the config) runs
+# HERE, in its own container with a hard `--memory` cap, so a big config (a HACS
+# HA install is thousands of files) OOMs the worker — never the servicebay control
+# plane (feedback_control_plane_vs_worker). The old in-process path copied those
+# files one-by-one through the agent channel and held every tar in Node memory →
+# ~5.3 GB → box-wide crash-loop (#1894). servicebay now launches this one-shot and
+# reads only the compact status.json + the per-service tars it writes to the
+# shared out-volume.
+#
+# Built from the monorepo root context (single pipeline, no second build system):
+#   podman build -f packages/backup-worker/Containerfile -t backup-worker .
+#
+# Run — servicebay launches it one-shot over the read-only stacks dir, into the
+# shared out volume; it writes <service>.tar per service + a compact status.json:
+#   podman run --rm --memory=2g --memory-swap=2g \
+#     -v /mnt/data/stacks:/mnt/stacks:ro \
+#     -v <shared-out-dir>:/out \
+#     -e BACKUP_RUN_ID=<id> \
+#     <image> --stacks /mnt/stacks --out /out --services home-assistant,authelia,…
+
+FROM node:20-slim AS base
+WORKDIR /app
+
+# Workspace-aware install: the root + every member manifest must be present so
+# `npm ci` resolves the workspace graph (same constraint as the disk-import worker).
+COPY package.json package-lock.json* ./
+COPY packages/api-client/package.json ./packages/api-client/package.json
+COPY packages/backend/package.json ./packages/backend/package.json
+COPY packages/frontend/package.json ./packages/frontend/package.json
+COPY packages/disk-import-worker/package.json ./packages/disk-import-worker/package.json
+COPY packages/backup-worker/package.json ./packages/backup-worker/package.json
+RUN npm ci
+
+# The worker is run via tsx (a one-shot CLI, no separate build step). Only the
+# worker's own sources are needed — it carries its own staging engine + manifest.
+COPY tsconfig.json ./tsconfig.json
+COPY packages/backup-worker ./packages/backup-worker
+
+# Non-root by default; the host bind-mounts (stacks ro, out rw) are owned by core
+# on the box. The worker only READS the stacks dir and WRITES tars into /out — it
+# never chowns or writes back into a stack (feedback_fileshare_relabel_crashloop).
+USER node
+
+ENTRYPOINT ["npx", "tsx", "packages/backup-worker/src/cli/main.ts"]

--- a/packages/backup-worker/package.json
+++ b/packages/backup-worker/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@servicebay/backup-worker",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Resource-capped one-shot config-backup worker: walks each installed service's stacks dir, applies the include/exclude/strip/transform manifest, and tars the per-service config into a shared out-volume, writing a compact status.json servicebay polls. Second application of #1949 (heavy jobs run in their own capped container, not the control plane) — replaces the in-process file-by-file copy that OOM'd the box (#1894).",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./contract": "./src/contract/status.ts"
+  },
+  "bin": {
+    "backup-worker": "src/cli/main.ts"
+  },
+  "scripts": {
+    "worker": "tsx src/cli/main.ts"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9"
+  }
+}

--- a/packages/backup-worker/src/cli/main.test.ts
+++ b/packages/backup-worker/src/cli/main.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  parseWorkerArgs,
+  resolveServiceDataDir,
+  applyCollectorRemap,
+  runWorker,
+  WorkerArgError,
+  type WorkerIO,
+} from './main';
+import { getServiceManifest, type ServiceBackupManifest } from '../engine/serviceManifest';
+import type { WorkerStatus } from '../contract/status';
+
+describe('parseWorkerArgs', () => {
+  it('parses the one-shot args', () => {
+    const opts = parseWorkerArgs(['--stacks', '/mnt/stacks', '--out', '/out', '--services', 'a,b,c', '--run-id', 'r1']);
+    expect(opts).toMatchObject({ stacks: '/mnt/stacks', out: '/out', services: ['a', 'b', 'c'], runId: 'r1' });
+  });
+
+  it('trims + drops empty service tokens', () => {
+    const opts = parseWorkerArgs(['--stacks', '/s', '--out', '/o', '--services', 'a, ,b,']);
+    expect('services' in opts && opts.services).toEqual(['a', 'b']);
+  });
+
+  it('requires --stacks, --out, --services', () => {
+    expect(() => parseWorkerArgs(['--out', '/o', '--services', 'a'])).toThrow(WorkerArgError);
+    expect(() => parseWorkerArgs(['--stacks', '/s', '--services', 'a'])).toThrow(WorkerArgError);
+    expect(() => parseWorkerArgs(['--stacks', '/s', '--out', '/o'])).toThrow(WorkerArgError);
+  });
+
+  it('returns help for --help', () => {
+    expect(parseWorkerArgs(['--help'])).toEqual({ help: true });
+  });
+
+  it('rejects an unknown argument', () => {
+    expect(() => parseWorkerArgs(['--bogus'])).toThrow(WorkerArgError);
+  });
+});
+
+describe('resolveServiceDataDir', () => {
+  it('honours the manifest dataSubdir', () => {
+    expect(resolveServiceDataDir('/mnt/stacks', getServiceManifest('nginx')!)).toBe('/mnt/stacks/nginx-proxy-manager');
+    expect(resolveServiceDataDir('/mnt/stacks', getServiceManifest('adguard')!)).toBe('/mnt/stacks/adguard');
+  });
+});
+
+describe('applyCollectorRemap', () => {
+  let tmp: string;
+  beforeEach(async () => { tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'bw-remap-')); });
+  afterEach(async () => { await fs.rm(tmp, { recursive: true, force: true }); });
+
+  it('remaps to the sqlite snapshot when present', async () => {
+    await fs.mkdir(path.join(tmp, 'data'), { recursive: true });
+    await fs.writeFile(path.join(tmp, 'data/database.sqlite.sb-backup'), 'snap');
+    const remapped = await applyCollectorRemap(tmp, getServiceManifest('nginx')!);
+    expect(remapped.include).toContain('data/database.sqlite.sb-backup');
+    expect(remapped.renames).toEqual({ 'data/database.sqlite.sb-backup': 'data/database.sqlite' });
+  });
+
+  it('leaves the manifest unchanged when no snapshot exists', async () => {
+    const m = getServiceManifest('nginx')!;
+    expect(await applyCollectorRemap(tmp, m)).toBe(m);
+  });
+
+  it('is a no-op for a non-collector manifest', async () => {
+    const m = getServiceManifest('adguard')!;
+    expect(await applyCollectorRemap(tmp, m)).toBe(m);
+  });
+});
+
+describe('runWorker', () => {
+  function fakeIO(overrides: Partial<WorkerIO> = {}): { io: WorkerIO; statuses: WorkerStatus[] } {
+    const statuses: WorkerStatus[] = [];
+    const io: WorkerIO = {
+      buildTar: vi.fn(async () => ({ files: 2, bytes: 100 })),
+      writeStatus: (_out, status) => { statuses.push(structuredClone(status)); },
+      ...overrides,
+    };
+    return { io, statuses };
+  }
+  const opts = { stacks: '/mnt/stacks', out: '/out', services: ['adguard', 'authelia'], runId: 'r' };
+
+  it('tars each service and finishes done', async () => {
+    const { io, statuses } = fakeIO();
+    const final = await runWorker(opts, io);
+    expect(final.phase).toBe('done');
+    expect(final.results.map(r => r.service)).toEqual(['adguard', 'authelia']);
+    expect(final.results.every(r => r.ok && r.outcome === 'ok')).toBe(true);
+    expect(io.buildTar).toHaveBeenCalledTimes(2);
+    // status was ticked along the way (never empty)
+    expect(statuses.length).toBeGreaterThan(2);
+  });
+
+  it('records a "No config files" failure as a skip without aborting the run', async () => {
+    const { io } = fakeIO({
+      buildTar: vi.fn(async (_d: string, m: ServiceBackupManifest) => {
+        if (m.service === 'adguard') throw new Error('No config files to back up for "adguard"');
+        return { files: 1, bytes: 50 };
+      }),
+    });
+    const final = await runWorker(opts, io);
+    expect(final.phase).toBe('done');
+    expect(final.results.find(r => r.service === 'adguard')).toMatchObject({ ok: false, outcome: 'skip' });
+    expect(final.results.find(r => r.service === 'authelia')).toMatchObject({ ok: true });
+  });
+
+  it('records a real error outcome but still completes the run', async () => {
+    const { io } = fakeIO({
+      buildTar: vi.fn(async (_d: string, m: ServiceBackupManifest) => {
+        if (m.service === 'adguard') throw new Error('disk exploded');
+        return { files: 1, bytes: 50 };
+      }),
+    });
+    const final = await runWorker(opts, io);
+    expect(final.phase).toBe('done');
+    expect(final.results.find(r => r.service === 'adguard')).toMatchObject({ ok: false, outcome: 'error', detail: 'disk exploded' });
+  });
+
+  it('marks an unknown service as an error', async () => {
+    const { io } = fakeIO();
+    const final = await runWorker({ ...opts, services: ['nope'] }, io);
+    expect(final.results[0]).toMatchObject({ service: 'nope', ok: false, outcome: 'error' });
+    expect(io.buildTar).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backup-worker/src/cli/main.ts
+++ b/packages/backup-worker/src/cli/main.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * backup-worker — one-shot, resource-capped container entrypoint (#1955).
+ *
+ * This is the heavy external/config backup path, moved OUT of the servicebay
+ * control plane. servicebay launches this as a one-shot container:
+ *
+ *   podman run --rm --memory=2g \
+ *     -v /mnt/data/stacks:/mnt/stacks:ro \
+ *     -v <shared-out>:/out \
+ *     -e BACKUP_RUN_ID=<id> \
+ *     backup-worker --stacks /mnt/stacks --out /out --services home-assistant,authelia,nginx
+ *
+ * For each requested service it resolves the config dir under the RO-mounted
+ * stacks root, applies the include/exclude/strip/transform manifest, copies the
+ * config into a temp staging dir, and tars it to `<out>/<service>.tar` — all in
+ * ITS OWN `--memory`-bounded process. It writes a COMPACT `status.json`
+ * (phase/counts + a per-service rollup) frequently; servicebay reads only that +
+ * streams each tar to the NAS one at a time. An OOM/kill of THIS container never
+ * touches servicebay (feedback_control_plane_vs_worker).
+ *
+ * A live WAL-mode SQLite (NPM's database.sqlite) is snapshotted host-side by
+ * servicebay BEFORE launch (it needs to exec into the running NPM container, which
+ * the worker can't); the worker just stages the resulting `…sqlite.sb-backup`
+ * under its canonical name when the npm-sqlite collector manifest sees it.
+ *
+ * Per-service failures do NOT abort the run — they land in the status `results`
+ * as outcome "error"/"skip"; the container still exits 0 so servicebay reads a
+ * terminal `done` (a vanished worker, not a clean done, is the real failure).
+ */
+import { writeFileSync, mkdirSync, renameSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getServiceManifest,
+  type ServiceBackupManifest,
+} from '../engine/serviceManifest';
+import { buildServiceBackupTar } from '../engine/staging';
+import {
+  STATUS_FILE,
+  initialStatus,
+  type ServiceBackupResult,
+  type WorkerStatus,
+} from '../contract/status';
+
+/** Thrown for user-facing failures (bad args). */
+export class WorkerArgError extends Error {}
+
+export interface WorkerOptions {
+  /** Path the host stacks root is mounted at (read-only) inside the container. */
+  stacks: string;
+  /** Shared out-volume dir the per-service tars + status.json are written to. */
+  out: string;
+  /** Services to back up (manifest names). */
+  services: string[];
+  /** Opaque run id (mirrors the servicebay launch handle). */
+  runId: string;
+}
+
+export const USAGE = `Usage: backup-worker --stacks <path> --out <dir> --services a,b,c [--run-id <id>]
+
+One-shot config-backup worker. For each service, walks its config dir under the
+RO-mounted stacks root, applies the backup manifest, and writes <service>.tar plus
+a compact status.json to the out-volume. Default is a read-only copy — it never
+writes back into a stack.
+
+Options:
+  --stacks <path>     Host stacks root mounted read-only (e.g. /mnt/stacks)
+  --out <dir>         Shared out-volume for <service>.tar + status.json
+  --services <list>   Comma-separated service names to back up
+  --run-id <id>       Run id (default: env BACKUP_RUN_ID or a random id)
+  --help, -h          Show this help`;
+
+const VALUE_ARGS = new Set(['--stacks', '--out', '--services', '--run-id']);
+
+function defaultRunId(): string {
+  return process.env.BACKUP_RUN_ID ?? Math.random().toString(36).slice(2, 14);
+}
+
+export function parseWorkerArgs(argv: string[]): WorkerOptions | { help: true } {
+  const draft: Partial<WorkerOptions> & { services?: string[] } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') return { help: true };
+    if (VALUE_ARGS.has(arg)) {
+      const value = argv[++i];
+      if (value === undefined) throw new WorkerArgError(`Missing value for ${arg}`);
+      if (arg === '--stacks') draft.stacks = value;
+      else if (arg === '--out') draft.out = value;
+      else if (arg === '--run-id') draft.runId = value;
+      else draft.services = value.split(',').map(s => s.trim()).filter(Boolean);
+    } else {
+      throw new WorkerArgError(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!draft.stacks) throw new WorkerArgError('--stacks is required');
+  if (!draft.out) throw new WorkerArgError('--out is required');
+  if (!draft.services || draft.services.length === 0) throw new WorkerArgError('--services is required');
+  return {
+    stacks: draft.stacks,
+    out: draft.out,
+    services: draft.services,
+    runId: draft.runId ?? defaultRunId(),
+  };
+}
+
+/** Resolve a service's config dir under the (RO-mounted) stacks root. */
+export function resolveServiceDataDir(stacksRoot: string, manifest: ServiceBackupManifest): string {
+  return path.join(stacksRoot, manifest.dataSubdir ?? manifest.service);
+}
+
+/**
+ * When the npm-sqlite collector ran host-side, the consistent snapshot lives at
+ * `data/database.sqlite.sb-backup`. Remap the manifest to stage THAT under the
+ * canonical `data/database.sqlite` name (mirrors the backend producer's
+ * post-collector manifest). A no-op for any other manifest, or when the snapshot
+ * isn't present (servicebay then left the live file in place to copy as-is).
+ */
+export async function applyCollectorRemap(
+  serviceDataDir: string,
+  manifest: ServiceBackupManifest,
+): Promise<ServiceBackupManifest> {
+  if (manifest.collector?.kind !== 'npm-sqlite') return manifest;
+  const snap = path.join(serviceDataDir, 'data/database.sqlite.sb-backup');
+  try {
+    await fs.access(snap);
+  } catch {
+    return manifest; // snapshot not taken — copy the live file under its own name
+  }
+  return {
+    ...manifest,
+    include: manifest.include.map(p => (p === 'data/database.sqlite' ? 'data/database.sqlite.sb-backup' : p)),
+    renames: { 'data/database.sqlite.sb-backup': 'data/database.sqlite' },
+  };
+}
+
+/** IO seam so the run is unit-testable without a real fs/tar. */
+export interface WorkerIO {
+  /** Stage + tar one service's config to `tarPath`; throws on "no config". */
+  buildTar: (serviceDataDir: string, manifest: ServiceBackupManifest, tarPath: string) => Promise<{ files: number; bytes: number }>;
+  /** Persist the compact status doc. */
+  writeStatus: (out: string, status: WorkerStatus) => void;
+}
+
+/**
+ * Run the worker: for each requested service, stage + tar its config into the
+ * out-volume, ticking the compact status as it goes. Per-service failures are
+ * captured into `results` (the run continues); the final phase is `done` unless
+ * the whole run aborts. Returns the final status doc.
+ */
+export async function runWorker(opts: WorkerOptions, io: WorkerIO): Promise<WorkerStatus> {
+  let status = initialStatus(opts.runId, opts.services.length);
+  const tick = (patch: Partial<WorkerStatus>): void => {
+    status = { ...status, ...patch, updatedAt: Date.now() };
+    io.writeStatus(opts.out, status);
+  };
+  tick({ step: 'Starting config backup …' });
+
+  const results: ServiceBackupResult[] = [];
+  for (const service of opts.services) {
+    const manifest = getServiceManifest(service);
+    if (!manifest) {
+      results.push({ service, ok: false, tarName: null, bytes: 0, files: 0, outcome: 'error', detail: `No backup manifest for service "${service}"` });
+      tick({ processed: results.length, results: [...results], step: `Skipped ${service} (no manifest)` });
+      continue;
+    }
+    tick({ step: `Backing up ${service} …` });
+    const serviceDataDir = resolveServiceDataDir(opts.stacks, manifest);
+    const tarName = `${service}.tar`;
+    try {
+      const effective = await applyCollectorRemap(serviceDataDir, manifest);
+      const { files, bytes } = await io.buildTar(serviceDataDir, effective, path.join(opts.out, tarName));
+      results.push({ service, ok: true, tarName, bytes, files, outcome: 'ok', detail: null });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // "No config files to back up" is a skip (service has no config yet),
+      // anything else is a real error — but neither aborts the run.
+      const outcome = /No config files to back up/.test(message) ? 'skip' : 'error';
+      results.push({ service, ok: false, tarName: null, bytes: 0, files: 0, outcome, detail: message });
+    }
+    tick({ processed: results.length, results: [...results] });
+  }
+
+  tick({ phase: 'done', results: [...results], step: `Done: ${results.filter(r => r.ok).length}/${results.length} services backed up` });
+  return status;
+}
+
+/** Default (real) IO: the fs staging engine + atomic-write status. */
+function realIO(): WorkerIO {
+  return {
+    buildTar: buildServiceBackupTar,
+    writeStatus: (out, status) => {
+      const file = path.join(out, STATUS_FILE);
+      mkdirSync(path.dirname(file), { recursive: true });
+      const tmp = `${file}.tmp`;
+      writeFileSync(tmp, JSON.stringify(status));
+      renameSync(tmp, file); // atomic swap so a polling reader never sees a half file
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseWorkerArgs(process.argv.slice(2));
+  if ('help' in parsed) {
+    console.log(USAGE);
+    return;
+  }
+  await runWorker(parsed, realIO());
+}
+
+// Only run when executed directly (not when imported by tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error: unknown) => {
+    if (error instanceof WorkerArgError) console.error(`error: ${error.message}`);
+    else console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/backup-worker/src/contract/status.ts
+++ b/packages/backup-worker/src/contract/status.ts
@@ -1,0 +1,91 @@
+// backup-worker ↔ servicebay status-file contract (#1955, slice of #1949).
+//
+// THE CONTRACT. The worker runs the heavy walk/copy/tar of every installed
+// service's config in its OWN resource-capped container and writes its progress
+// to a SHARED volume. servicebay launches + monitors the worker and reads ONLY
+// the compact status.json — it never pulls the file lists / tar bytes (which
+// OOM'd the control plane in-process at ~5.3 GB, see #1894 /
+// feedback_control_plane_vs_worker) into its own process.
+//
+// The heavy artifacts are the per-service `<service>.tar` files the worker writes
+// alongside status.json into the out-volume. servicebay streams each tar to the
+// NAS one at a time (light, bounded I/O) — it never holds them all in memory.
+//
+// The shape lives HERE, in one module, so the worker (writer) and servicebay
+// (reader) cannot drift (operator decision 2026-06-18: shared contracts stay in
+// one place).
+
+/** Canonical file name the worker writes into the shared out-volume. */
+export const STATUS_FILE = 'status.json';
+
+/** Schema version of the status contract. Bump on any breaking shape change. */
+export const STATUS_CONTRACT_VERSION = 1 as const;
+
+/**
+ * The phase the worker is in. Linear, two terminal states (`done`/`error`).
+ *   staging  — walking each service's config dir (read-only) + copying/tarring.
+ *   done     — every requested service processed (each result has ok/skip/error).
+ *   error    — the run aborted before completing (see `error`); per-service
+ *              failures do NOT abort the run, they land in `results`.
+ */
+export type WorkerPhase = 'staging' | 'done' | 'error';
+
+/** One service's outcome — compact: a tar name + size, never the file list. */
+export interface ServiceBackupResult {
+  service: string;
+  /** Did the service produce a tar? false for a skip (no config on disk) or error. */
+  ok: boolean;
+  /** Relative tar name in the out-volume (`<service>.tar`) when ok, else null. */
+  tarName: string | null;
+  /** Tar size in bytes when ok, else 0. */
+  bytes: number;
+  /** Number of config files staged into the tar (rollup count, not the list). */
+  files: number;
+  /** "skip" when the service had no config to back up; "error" on a failure. */
+  outcome: 'ok' | 'skip' | 'error';
+  /** Failure message when outcome is "error"; the skip reason for "skip"; else null. */
+  detail: string | null;
+}
+
+/**
+ * The compact status document. Small enough to rewrite on every per-service tick
+ * without I/O pressure. Holds NO file lists and NO tar bytes — only scalars and
+ * the per-service rollup. The heavy tars live beside it in the out-volume.
+ */
+export interface WorkerStatus {
+  /** Contract schema version (=== STATUS_CONTRACT_VERSION when written by this worker). */
+  version: typeof STATUS_CONTRACT_VERSION;
+  /** Opaque id servicebay assigns the run (mirrors the launch handle). */
+  runId: string;
+  phase: WorkerPhase;
+  /** Human-readable one-liner for the current step (e.g. "Backing up home-assistant …"). */
+  step: string;
+  /** Total services the run will process. */
+  total: number;
+  /** Services processed so far (ok + skip + error), grows during `staging`. */
+  processed: number;
+  /** Per-service rollup — compact (tar name/size/file count), no file lists. */
+  results: ServiceBackupResult[];
+  /** Set only in `error` phase: the run-level failure message. null otherwise. */
+  error: string | null;
+  /** Epoch ms of the last write — servicebay's liveness/staleness signal. */
+  updatedAt: number;
+  /** Epoch ms the worker started. */
+  startedAt: number;
+}
+
+/** A fresh status doc at run start (phase `staging`, nothing processed yet). */
+export function initialStatus(runId: string, total: number, now: number = Date.now()): WorkerStatus {
+  return {
+    version: STATUS_CONTRACT_VERSION,
+    runId,
+    phase: 'staging',
+    step: 'Starting …',
+    total,
+    processed: 0,
+    results: [],
+    error: null,
+    updatedAt: now,
+    startedAt: now,
+  };
+}

--- a/packages/backup-worker/src/engine/serviceManifest.ts
+++ b/packages/backup-worker/src/engine/serviceManifest.ts
@@ -1,0 +1,255 @@
+// Per-service config-backup manifest — the worker's copy of "what counts as
+// per-service config" (#1190 / #1955).
+//
+// This is the SAME include/exclude/strip/transform spec the backend's
+// externalBackup/serviceManifest.ts carries; it lives here too because the heavy
+// staging now runs in THIS worker container (not the control plane), and the
+// worker must be self-contained (it can't import the backend at runtime — the
+// backend imports FROM the workers, never the reverse). The backend keeps its own
+// copy for the restore/install/wipe paths that don't run in the worker. Pure data
+// + pure helpers — no I/O. Keep the two in sync when a service's config scope
+// changes; a divergence only affects which files land in the tar, caught by the
+// backup round-trip tests.
+
+import yaml from 'js-yaml';
+
+export interface StripRule {
+  /** Config file (relative to the service data dir) the rule applies to. */
+  file: string;
+  /** YAML keys to remove wherever they appear — e.g. `password` hashes. */
+  dropYamlKeys: string[];
+}
+
+export interface TransformRule {
+  /** Config file (relative to the service data dir) the rule applies to. */
+  file: string;
+  /** Which transform to run — a closed set so the engine stays pure data. */
+  kind: 'ha-config-entries-addon';
+}
+
+/** zwave_js / matter add-on → in-pod container url translations for HA (#1595). */
+const HA_ADDON_ENTRY_TRANSLATIONS: Record<string, { url: string }> = {
+  zwave_js: { url: 'ws://localhost:3001' },
+  matter: { url: 'ws://localhost:5580/ws' },
+};
+
+/** Supervisor-only HA config-entry domains dropped on import (#1601). */
+const HA_SUPERVISOR_ONLY_DOMAINS: ReadonlySet<string> = new Set([
+  'hassio',
+  'cloud',
+  'backup',
+  'default_config',
+]);
+
+/** An in-container snapshot step the producer runs before staging (e.g. a
+ *  consistent SQLite `.backup`). The snapshot itself is host-side (servicebay's
+ *  collector) — the worker only stages the resulting file; this descriptor lets
+ *  the worker know a `renames` remap is expected. */
+export interface BackupCollector {
+  kind: 'npm-sqlite';
+}
+
+export interface ServiceBackupManifest {
+  /** ServiceBay template/service name (also the `installedTemplates` key). */
+  service: string;
+  /** On-disk data subdir under the stacks root, when it differs from `service`. */
+  dataSubdir?: string;
+  /** Sibling-store manifest (#1594): gates on the named template, not its own
+   *  service name. */
+  gateOn?: string;
+  /** CONFIG paths/dirs worth preserving across a reinstall (the tar contents). */
+  include: string[];
+  /** Paths/dirs to never back up — bulk data, logs, caches, valueless secrets. */
+  exclude: string[];
+  /** Large on-RAID artifacts a wipe-config KEEPS (informational here). */
+  data?: string[];
+  /** Per-file key-removal transforms applied before a file enters the tarball. */
+  strip?: StripRule[];
+  /** Per-file value-rewrite transforms applied before a file enters the tarball. */
+  transform?: TransformRule[];
+  /** Optional in-container snapshot step run host-side before staging. */
+  collector?: BackupCollector;
+  /** Stage a source rel-path under a different rel-path in the tarball. */
+  renames?: Record<string, string>;
+}
+
+/** Per-service config scope, transcribed from the table in #1190. */
+export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
+  {
+    service: 'home-assistant',
+    dataSubdir: 'home-assistant/homeassistant',
+    include: [
+      'automations.yaml', 'scripts.yaml', 'scenes.yaml', 'configuration.yaml',
+      '.storage/core.config_entries', '.storage/core.device_registry',
+      '.storage/core.entity_registry', '.storage/core.area_registry',
+      '.storage/lovelace*',
+      '.storage/zwave_js',
+      'custom_components',
+      '.storage/hacs*',
+    ],
+    exclude: [
+      'home-assistant_v2.db', 'home-assistant_v2.db-wal', 'home-assistant_v2.db-shm',
+      'history', 'logs', 'home-assistant.log', 'tts', 'image', 'www', 'deps',
+      'custom_components/hacs/hacs_frontend',
+      'custom_components/hacs_frontend',
+    ],
+    data: [
+      'home-assistant_v2.db', 'home-assistant_v2.db-wal', 'home-assistant_v2.db-shm',
+      'zwave_js_network.db',
+    ],
+    transform: [{ file: '.storage/core.config_entries', kind: 'ha-config-entries-addon' }],
+  },
+  {
+    service: 'home-assistant-zwave',
+    dataSubdir: 'home-assistant/zwave-js',
+    gateOn: 'home-assistant',
+    include: ['settings.json', 'sb-external-settings.json'],
+    exclude: ['logs', 'store.jsonl'],
+    data: ['store.jsonl'],
+  },
+  {
+    service: 'authelia',
+    include: ['users_database.yml'],
+    exclude: [],
+    strip: [{ file: 'users_database.yml', dropYamlKeys: ['password'] }],
+  },
+  {
+    service: 'adguard',
+    include: ['conf/AdGuardHome.yaml'],
+    exclude: ['data/querylog.json', 'data/stats.db', 'data/sessions.db', 'data/filters'],
+  },
+  {
+    service: 'syncthing',
+    include: ['config.xml'],
+    exclude: ['index-v0.14.0.db', 'index'],
+    data: ['index-v0.14.0.db', 'index'],
+  },
+  {
+    service: 'hermes',
+    include: ['config.yaml'],
+    exclude: ['vectordb', 'embeddings', 'conversations', 'history'],
+    data: ['vectordb', 'embeddings'],
+    strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
+  },
+  {
+    service: 'nginx',
+    dataSubdir: 'nginx-proxy-manager',
+    include: ['data/database.sqlite', 'letsencrypt', 'data/custom_ssl'],
+    exclude: ['letsencrypt/logs', 'data/nginx', 'data/logs'],
+    collector: { kind: 'npm-sqlite' },
+  },
+];
+
+export function getServiceManifest(service: string): ServiceBackupManifest | undefined {
+  return SERVICE_BACKUP_MANIFESTS.find(m => m.service === service);
+}
+
+/** The installedTemplates key whose presence activates this manifest's backup. */
+export function getBackupGate(manifest: ServiceBackupManifest): string {
+  return manifest.gateOn ?? manifest.service;
+}
+
+/**
+ * Remove `dropKeys` from a YAML document wherever they appear. Best-effort:
+ * returns the original text unchanged if it doesn't parse as YAML.
+ */
+export function stripYamlKeys(content: string, dropKeys: string[]): string {
+  let doc: unknown;
+  try {
+    doc = yaml.load(content);
+  } catch {
+    return content;
+  }
+  if (doc === undefined || doc === null) return content;
+  const drop = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(drop);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      const rec = node as Record<string, unknown>;
+      for (const k of dropKeys) delete rec[k];
+      for (const v of Object.values(rec)) drop(v);
+    }
+  };
+  drop(doc);
+  return yaml.dump(doc);
+}
+
+/** Apply a manifest's strip rules to one file's content. */
+export function applyStripRules(
+  manifest: ServiceBackupManifest,
+  file: string,
+  content: string,
+): string {
+  const rule = manifest.strip?.find(r => r.file === file);
+  if (!rule) return content;
+  return stripYamlKeys(content, rule.dropYamlKeys);
+}
+
+interface HaConfigEntry {
+  domain?: string;
+  data?: { use_addon?: unknown; integration_created_addon?: unknown; url?: unknown };
+}
+
+function isHaEntryOnAddon(data: NonNullable<HaConfigEntry['data']>): boolean {
+  if (data.use_addon === true || data.integration_created_addon === true) return true;
+  return typeof data.url === 'string' && data.url.startsWith('ws://core-');
+}
+
+/**
+ * Translate a HA(-OS) backup's `.storage/core.config_entries` from the Supervisor
+ * add-on model to ServiceBay's in-pod-container model (#1595/#1601). Idempotent;
+ * best-effort (returns content unchanged on a parse failure).
+ */
+export function translateHaAddonConfigEntries(content: string): string {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(content);
+  } catch {
+    return content;
+  }
+  const data = (doc as { data?: { entries?: unknown } })?.data;
+  const entries = data?.entries;
+  if (!Array.isArray(entries)) return content;
+
+  let changed = false;
+  for (const entry of entries as HaConfigEntry[]) {
+    if (!entry || typeof entry !== 'object') continue;
+    const translation = entry.domain ? HA_ADDON_ENTRY_TRANSLATIONS[entry.domain] : undefined;
+    if (!translation) continue;
+    const entryData = entry.data;
+    if (!entryData || typeof entryData !== 'object') continue;
+    if (!isHaEntryOnAddon(entryData)) continue;
+    entryData.use_addon = false;
+    entryData.integration_created_addon = false;
+    entryData.url = translation.url;
+    changed = true;
+  }
+
+  const kept = (entries as HaConfigEntry[]).filter(
+    e => !(e && typeof e === 'object' && typeof e.domain === 'string'
+      && HA_SUPERVISOR_ONLY_DOMAINS.has(e.domain)),
+  );
+  if (kept.length !== entries.length) {
+    (data as { entries: unknown }).entries = kept;
+    changed = true;
+  }
+
+  if (!changed) return content;
+  return JSON.stringify(doc, null, 2);
+}
+
+/** Apply a manifest's transform rules to one file's content. */
+export function applyTransformRules(
+  manifest: ServiceBackupManifest,
+  file: string,
+  content: string,
+): string {
+  const rule = manifest.transform?.find(r => r.file === file);
+  if (!rule) return content;
+  if (rule.kind === 'ha-config-entries-addon') {
+    return translateHaAddonConfigEntries(content);
+  }
+  return content;
+}

--- a/packages/backup-worker/src/engine/staging.test.ts
+++ b/packages/backup-worker/src/engine/staging.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { stageServiceBackup, buildServiceBackupTar } from './staging';
+import { getServiceManifest, type ServiceBackupManifest } from './serviceManifest';
+
+const execFileAsync = promisify(execFile);
+
+let tmpDirs: string[] = [];
+
+async function mkTmp(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'bw-stage-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function write(base: string, rel: string, content: string): Promise<void> {
+  const full = path.join(base, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+
+beforeEach(() => { tmpDirs = []; });
+afterEach(async () => {
+  await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+});
+
+describe('stageServiceBackup', () => {
+  it('stages includes and skips excludes', async () => {
+    const src = await mkTmp();
+    await write(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+    await write(src, 'data/querylog.json', '[]'); // excluded
+    const staging = await mkTmp();
+
+    const staged = await stageServiceBackup(src, getServiceManifest('adguard')!, staging);
+
+    expect(staged).toEqual(['conf/AdGuardHome.yaml']);
+    await expect(fs.readFile(path.join(staging, 'conf/AdGuardHome.yaml'), 'utf8')).resolves.toBe('bind_host: 0.0.0.0');
+    await expect(fs.access(path.join(staging, 'data/querylog.json'))).rejects.toThrow();
+  });
+
+  it('expands a trailing-* glob include (HA dashboards)', async () => {
+    const src = await mkTmp();
+    await write(src, '.storage/lovelace.lovelace', 'dash');
+    await write(src, '.storage/lovelace_dashboards', 'list');
+    await write(src, 'configuration.yaml', 'default_config:');
+    const staging = await mkTmp();
+
+    const staged = await stageServiceBackup(src, getServiceManifest('home-assistant')!, staging);
+
+    expect(staged).toContain('.storage/lovelace.lovelace');
+    expect(staged).toContain('.storage/lovelace_dashboards');
+    expect(staged).toContain('configuration.yaml');
+  });
+
+  it('applies strip rules (password hashes never enter the tar)', async () => {
+    const src = await mkTmp();
+    await write(src, 'users_database.yml', 'users:\n  a:\n    password: $argon2$SEKRIT\n    email: a@x\n');
+    const staging = await mkTmp();
+
+    await stageServiceBackup(src, getServiceManifest('authelia')!, staging);
+
+    const out = await fs.readFile(path.join(staging, 'users_database.yml'), 'utf8');
+    expect(out).not.toContain('SEKRIT');
+    expect(out).toContain('a@x');
+  });
+
+  it('stages a renamed source path under its canonical tar name', async () => {
+    const src = await mkTmp();
+    await write(src, 'data/database.sqlite.sb-backup', 'SNAPSHOT');
+    const staging = await mkTmp();
+    const manifest: ServiceBackupManifest = {
+      service: 'nginx',
+      include: ['data/database.sqlite.sb-backup'],
+      exclude: [],
+      renames: { 'data/database.sqlite.sb-backup': 'data/database.sqlite' },
+    };
+
+    const staged = await stageServiceBackup(src, manifest, staging);
+
+    expect(staged).toEqual(['data/database.sqlite']);
+    await expect(fs.readFile(path.join(staging, 'data/database.sqlite'), 'utf8')).resolves.toBe('SNAPSHOT');
+  });
+
+  it('returns [] when nothing matches', async () => {
+    const src = await mkTmp();
+    const staging = await mkTmp();
+    expect(await stageServiceBackup(src, getServiceManifest('adguard')!, staging)).toEqual([]);
+  });
+});
+
+describe('buildServiceBackupTar', () => {
+  it('produces a tar holding the staged config', async () => {
+    const src = await mkTmp();
+    await write(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+    const out = await mkTmp();
+    const tarPath = path.join(out, 'adguard.tar');
+
+    const { files, bytes } = await buildServiceBackupTar(src, getServiceManifest('adguard')!, tarPath);
+
+    expect(files).toBe(1);
+    expect(bytes).toBeGreaterThan(0);
+    const extracted = await mkTmp();
+    await execFileAsync('tar', ['-xf', tarPath, '-C', extracted]);
+    await expect(fs.readFile(path.join(extracted, 'conf/AdGuardHome.yaml'), 'utf8')).resolves.toBe('bind_host: 0.0.0.0');
+  });
+
+  it('throws "No config files to back up" when nothing matched', async () => {
+    const src = await mkTmp();
+    const out = await mkTmp();
+    await expect(
+      buildServiceBackupTar(src, getServiceManifest('adguard')!, path.join(out, 'x.tar')),
+    ).rejects.toThrow(/No config files/);
+  });
+});

--- a/packages/backup-worker/src/engine/staging.ts
+++ b/packages/backup-worker/src/engine/staging.ts
@@ -1,0 +1,162 @@
+// backup-worker — config staging engine (#1955, slice of #1949).
+//
+// The heavy part of the external/config backup, moved OUT of the servicebay
+// control plane: walk a service's config dir, select the manifest's include −
+// exclude paths, apply strip/transform rewrites, copy the bytes into a staging
+// dir, and tar it. This runs IN the worker container against the RO-mounted
+// stacks dir (`/mnt/stacks/...`) — so a HACS HA config (thousands of files) is
+// copied + tarred inside the worker's `--memory` cap, never in the box's Node
+// process (the in-process per-file copy + held tar bytes OOM'd the box, #1894).
+//
+// The old backend producer had a `BackupFileBackend` seam so the SAME logic could
+// run either in-container (local fs) or host-side via the agent. The worker only
+// ever needs the local-fs path (it IS the container, with the stacks dir mounted),
+// so this engine is plain `node:fs` — no agent, no backend abstraction. Pure,
+// unit-testable logic; the CLI wires it to the real mount + out volume.
+
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import {
+  applyStripRules,
+  applyTransformRules,
+  type ServiceBackupManifest,
+} from './serviceManifest';
+
+const execFileAsync = promisify(execFile);
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** A relative path is excluded when it equals an exclude entry or lives under
+ *  one (an exclude dir). Excludes always win over includes. */
+function isExcluded(relPath: string, excludes: string[]): boolean {
+  return excludes.some(ex => relPath === ex || relPath.startsWith(ex + '/'));
+}
+
+/**
+ * Resolve a manifest include that may carry a trailing-`*` glob in its leaf
+ * component (e.g. `.storage/lovelace*`) to the concrete relative paths under
+ * `serviceDataDir`. A plain include resolves to itself. Only a single
+ * trailing-`*` on the leaf is supported (#1595/#1596).
+ */
+async function resolveIncludeGlob(serviceDataDir: string, include: string): Promise<string[]> {
+  if (!include.includes('*')) return [include];
+  const dir = path.posix.dirname(include);
+  const leaf = path.posix.basename(include);
+  if (leaf.indexOf('*') !== leaf.length - 1) return [include];
+  const prefix = leaf.slice(0, -1);
+  const parentAbs = path.join(serviceDataDir, dir);
+  if (!(await pathExists(parentAbs))) return [];
+  const entries = await fs.readdir(parentAbs, { withFileTypes: true });
+  return entries
+    .filter(e => e.name.startsWith(prefix))
+    .map(e => path.posix.join(dir, e.name));
+}
+
+/** Walk an included directory, returning the relative (posix) paths of every
+ *  file inside it that isn't excluded. */
+async function collectDirFiles(
+  serviceDataDir: string,
+  relDir: string,
+  excludes: string[],
+): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await fs.readdir(path.join(serviceDataDir, relDir), { withFileTypes: true });
+  for (const entry of entries) {
+    const rel = path.posix.join(relDir, entry.name);
+    if (isExcluded(rel, excludes)) continue;
+    if (entry.isDirectory()) {
+      out.push(...(await collectDirFiles(serviceDataDir, rel, excludes)));
+    } else if (entry.isFile()) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+/**
+ * Copy the manifest-selected config files from `serviceDataDir` into
+ * `stagingDir`, applying excludes and strip/transform rules. Returns the sorted
+ * list of relative paths actually staged. Plain (byte-for-byte) copies keep
+ * binary config intact; only strip/transform targets are read as text.
+ */
+export async function stageServiceBackup(
+  serviceDataDir: string,
+  manifest: ServiceBackupManifest,
+  stagingDir: string,
+): Promise<string[]> {
+  const staged: string[] = [];
+  const includes: string[] = [];
+  for (const include of manifest.include) {
+    includes.push(...(await resolveIncludeGlob(serviceDataDir, include)));
+  }
+  for (const include of includes) {
+    if (isExcluded(include, manifest.exclude)) continue;
+    const absInclude = path.join(serviceDataDir, include);
+    if (!(await pathExists(absInclude))) continue;
+    const isDir = (await fs.stat(absInclude)).isDirectory();
+    const relFiles = isDir
+      ? await collectDirFiles(serviceDataDir, include, manifest.exclude)
+      : [include];
+    for (const rel of relFiles) {
+      const tarRel = manifest.renames?.[rel] ?? rel;
+      const needsRewrite =
+        manifest.strip?.some(r => r.file === rel) ||
+        manifest.transform?.some(r => r.file === rel);
+      const dest = path.join(stagingDir, tarRel);
+      await fs.mkdir(path.dirname(dest), { recursive: true });
+      if (needsRewrite) {
+        const content = await fs.readFile(path.join(serviceDataDir, rel), 'utf8');
+        const stripped = applyStripRules(manifest, rel, content);
+        await fs.writeFile(dest, applyTransformRules(manifest, rel, stripped));
+      } else {
+        await fs.copyFile(path.join(serviceDataDir, rel), dest);
+      }
+      staged.push(tarRel);
+    }
+  }
+  return staged.sort();
+}
+
+/** Result of staging + tarring one service's config. */
+export interface BuiltServiceTar {
+  /** Number of config files staged into the tar. */
+  files: number;
+  /** Tar size in bytes. */
+  bytes: number;
+}
+
+/**
+ * Stage a service's config into a fresh temp dir, tar it to `tarPath`, and return
+ * the file/size rollup. Throws when nothing matched the manifest (the caller maps
+ * that to a "skip" — the service has no config on disk yet).
+ */
+export async function buildServiceBackupTar(
+  serviceDataDir: string,
+  manifest: ServiceBackupManifest,
+  tarPath: string,
+): Promise<BuiltServiceTar> {
+  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-bw-'));
+  try {
+    const staged = await stageServiceBackup(serviceDataDir, manifest, stagingDir);
+    if (staged.length === 0) {
+      throw new Error(`No config files to back up for "${manifest.service}" under ${serviceDataDir}`);
+    }
+    await fs.mkdir(path.dirname(tarPath), { recursive: true });
+    await execFileAsync('tar', ['-cf', tarPath, '-C', stagingDir, '.']);
+    const { size } = await fs.stat(tarPath);
+    return { files: staged.length, bytes: size };
+  } finally {
+    await fs.rm(stagingDir, { recursive: true, force: true });
+  }
+}

--- a/packages/backup-worker/src/index.ts
+++ b/packages/backup-worker/src/index.ts
@@ -1,0 +1,17 @@
+// @servicebay/backup-worker — public surface.
+//
+// The config-staging engine (walk/select/strip/transform/copy/tar) + the manifest
+// + the compact status-file contract shared with servicebay. The heavy path runs
+// in this package's OWN capped container (src/cli/main.ts); servicebay imports the
+// manifest + the status contract from here and reads the worker's status.json via
+// the contract (./contract — re-exported below).
+//
+// Second application of #1949: heavy jobs live in a resource-capped worker, the
+// control plane stays thin (feedback_control_plane_vs_worker).
+
+// --- Engine + manifest ---
+export * from './engine/serviceManifest';
+export * from './engine/staging';
+
+// --- Status-file contract (shared with servicebay) ---
+export * from './contract/status';

--- a/packages/backup-worker/tsconfig.json
+++ b/packages/backup-worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {}
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What
Extract the external/config backup off the servicebay control plane into a resource-capped one-shot worker container (mirrors the disk-import-worker pattern). servicebay launches it via `podman run --memory` and monitors a compact status.json; the in-process file-by-file backup copy path in producer.ts is replaced by worker launch+poll. The launcher resolves the host out-volume path via `resolveHostDataDir(exec)`.

## Why
Closes #1955

## Risk
Medium — backup is a path-mandated critical path; behaviour is verified on the box before the release ships (box_verify owed).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2827 passed)
- [x] npm run knip
- [x] npx tsc --noEmit (0 errors)
- [ ] /verify on FCoS :dev box (path-mandated — new worker container + launcher + image build)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._