### PR TITLE
fix(backup-worker): register backup-worker as workspace in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/api-client/package.json ./packages/api-client/package.json
 COPY packages/backend/package.json ./packages/backend/package.json
 COPY packages/frontend/package.json ./packages/frontend/package.json
 COPY packages/disk-import-worker/package.json ./packages/disk-import-worker/package.json
+COPY packages/backup-worker/package.json ./packages/backup-worker/package.json
 RUN npm ci
 
 # Rebuild the source code only when needed
@@ -47,6 +48,7 @@ COPY packages/api-client/package.json ./packages/api-client/package.json
 COPY packages/backend/package.json ./packages/backend/package.json
 COPY packages/frontend/package.json ./packages/frontend/package.json
 COPY packages/disk-import-worker/package.json ./packages/disk-import-worker/package.json
+COPY packages/backup-worker/package.json ./packages/backup-worker/package.json
 # Install prod deps (builds native modules). tsx/typescript are no longer
 # needed at runtime because the custom server is pre-bundled to CJS.
 RUN npm ci --omit=dev


### PR DESCRIPTION
## Problem
The Release Docker build (run 27743055844) failed `next build` with `Type error: Cannot find module '@servicebay/backup-worker'`, so the 4.128.0 `:dev`/release image never built and box-verify couldn't run.

## Root cause
`Dockerfile` `deps` + `prod-deps` stages `COPY` each worker's `package.json` **except** backup-worker → `npm ci` doesn't register it as a workspace → no `node_modules/@servicebay/backup-worker` symlink. disk-import-worker builds fine only because its manifest is copied.

## Fix
Add `COPY packages/backup-worker/package.json` to both stages (mirrors disk-import-worker). Validated locally with `podman build --target builder` — the previously-failing `npm run build` now succeeds.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._