### PR TITLE
fix(workers): run worker containers as root for rootless-podman /out writes

### DIFF
--- a/packages/backup-worker/Containerfile
+++ b/packages/backup-worker/Containerfile
@@ -46,9 +46,13 @@ RUN npm ci
 COPY tsconfig.json ./tsconfig.json
 COPY packages/backup-worker ./packages/backup-worker
 
-# Non-root by default; the host bind-mounts (stacks ro, out rw) are owned by core
-# on the box. The worker only READS the stacks dir and WRITES tars into /out — it
-# never chowns or writes back into a stack (feedback_fileshare_relabel_crashloop).
-USER node
+# Run as root INSIDE the container. Under rootless podman (UserNS=keep-id, as on
+# the box) container-root maps to the host `core` user, which owns the bind-mounts
+# (stacks ro, out rw) — so root can write status.json + tars into /out. `USER node`
+# (UID 1000) maps to host 525287, which has NO write access to the core-owned /out
+# → EACCES on /out/status.json. Same reason the main servicebay container runs as
+# root. The worker only READS the stacks dir and WRITES into /out; it never chowns
+# or writes back into a stack (feedback_fileshare_relabel_crashloop).
+USER root
 
 ENTRYPOINT ["npx", "tsx", "packages/backup-worker/src/cli/main.ts"]

--- a/packages/disk-import-worker/Containerfile
+++ b/packages/disk-import-worker/Containerfile
@@ -44,10 +44,14 @@ COPY tsconfig.json ./tsconfig.json
 COPY packages/disk-import-worker ./packages/disk-import-worker
 COPY packages/api-client ./packages/api-client
 
-# Non-root by default; the host bind-mounts (source ro, out rw) are owned by core
-# on the box. The worker never chowns imported files to a per-user uid — apply
-# chowns to the file-share gid only (feedback_fileshare_relabel_crashloop).
-USER node
+# Run as root INSIDE the container. Under rootless podman (UserNS=keep-id, as on
+# the box) container-root maps to the host `core` user, which owns the bind-mounts
+# (source ro, out rw) — so root can write status.json into the core-owned /out.
+# `USER node` (UID 1000) maps to host 525287, which has NO write access → EACCES on
+# /out/status.json. Same reason the main servicebay container runs as root. The
+# worker never chowns imported files to a per-user uid — apply chowns to the
+# file-share gid only (feedback_fileshare_relabel_crashloop).
+USER root
 
 # The app server listens here in --serve mode; servicebay maps it behind the NPM
 # proxy + Authelia forward-auth (admin-gated), like every other service UI.


### PR DESCRIPTION
## Problem
box-verify @e4d88b04: the backup-worker fails every run with `EACCES: permission denied, open '/out/status.json.tmp'`.

## Root cause
Both worker Containerfiles set `USER node` (UID 1000). Under rootless podman (`UserNS=keep-id`, as on the box) the uid_map is `container 0 → host core (1000)`, `container 1000 → host 525287`. The `/out` bind-mount is created by `core` (host 1000 = **container root**), so `node` (container 1000 → host 525287) has no write access. disk-import-worker has the **same latent bug** (its green verify didn't exercise the status write rigorously).

## Fix
`USER node` → `USER root` in both worker Containerfiles. Container-root maps to host `core` under keep-id, which owns the mounts — the same reason the main servicebay container runs as root. Image-only change; verified on box via re-verify.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._