### PR TITLE
fix(workers): :z relabel worker /out mount (SELinux MCS) so status.json writes

### DIFF
--- a/packages/backend/src/lib/backupWorker/launcher.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.ts
@@ -109,7 +109,13 @@ export async function launchBackupWorker(args: {
     `--memory=${BACKUP_WORKER_MEMORY}`,
     `--memory-swap=${BACKUP_WORKER_MEMORY}`,
     '-v', `${stacksDir}:${STACKS_MOUNT}:ro`,
-    '-v', `${outDir}:/out`,
+    // `:z` relabels the out dir to a SHARED SELinux label so the worker
+    // container can write it. Without it the dir keeps servicebay's private
+    // MCS categories (container_file_t:s0:cNNN,cMMM) and the freshly-spawned
+    // worker gets different categories → EACCES on /out/status.json even as
+    // root. Shared (`:z`) not private (`:Z`) because servicebay also reads the
+    // status + tars back from this dir. (#1955 box-verify, rootless podman.)
+    '-v', `${outDir}:/out:z`,
     '-e', `BACKUP_RUN_ID=${runId}`,
     BACKUP_WORKER_IMAGE,
     '--stacks', STACKS_MOUNT,

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -122,7 +122,11 @@ export async function launchWorker(args: {
     `--memory-swap=${WORKER_MEMORY}`,
     '-p', `${WORKER_PORT}`,
     '-v', `${mountpoint}:/mnt/src:ro`,
-    '-v', `${outDir}:/out`,
+    // `:z` relabels the out dir to a SHARED SELinux label so the worker can
+    // write it — otherwise it keeps servicebay's private MCS categories and the
+    // worker gets EACCES on /out/status.json even as root. Shared (`:z`) because
+    // servicebay reads status/plan back from here. (#1955 box-verify.)
+    '-v', `${outDir}:/out:z`,
     '-e', `DISK_IMPORT_RUN_ID=${runId}`,
     '-e', `DISK_IMPORT_SHARE_GID=${shareGid}`,
     ...immichEnv,


### PR DESCRIPTION
## Problem
box-verify: both workers fail with `EACCES: permission denied, open '/out/status.json.tmp'` — even after `USER root` (#1971). The backup/disk-import jobs never write a status file.

## Root cause (SELinux MCS, not uid)
The per-run out dir under `/mnt/data/servicebay/{backup,disk-import}-runs/` inherits servicebay's **private** MCS categories (`container_file_t:s0:cNNN,cMMM`). A freshly-spawned worker container gets **different** categories, so it can't access `/out` even as root. `--security-opt label=disable` made writes succeed → confirms SELinux is the blocker.

## Fix
Add `:z` (**shared** relabel) to the `-v outDir:/out` mount in both launchers. `:z` not `:Z` because servicebay reads status/plan/tars back from the same dir. `USER root` (#1971) is **kept** — it's required for the unix/DAC write (the dir is 0755, owned by host `core` = container root under keep-id); `:z` only fixes the SELinux label. The two together resolve both DAC + MCS.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._