### PR TITLE
fix: backup-worker direct tar read + disk-import mount idempotency

### DIFF
--- a/packages/backend/src/lib/backupWorker/launcher.test.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.test.ts
@@ -146,7 +146,7 @@ describe('readBackupTar', () => {
     readFileMock.mockRejectedValue(new Error('ENOENT: no such file'));
     const { exec } = recExec();
     await expect(readBackupTar(exec, run, 'x.tar')).rejects.toThrow(
-      new RegExp(`failed to read x\\.tar from ${inContainerTar('x.tar').replace(/[/.]/g, '\\$&')}`),
+      new RegExp(`failed to read x\\.tar from ${inContainerTar('x.tar').replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}`),
     );
   });
 });

--- a/packages/backend/src/lib/backupWorker/launcher.test.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+const readFileMock = vi.fn();
+vi.mock('node:fs/promises', () => {
+  const readFile = (...args: unknown[]) => readFileMock(...args);
+  return { readFile, default: { readFile } };
+});
+
+import { DATA_DIR } from '@/lib/dirs';
 
 import {
   launchBackupWorker,
@@ -101,14 +109,44 @@ describe('stopBackupWorker', () => {
 });
 
 describe('readBackupTar', () => {
-  const run = { runId: 'r', outDir: '/out/r', container: 'backup-worker-r' };
-  it('decodes the base64 tar bytes', async () => {
-    const tar = Buffer.from('hello tar');
-    const { exec } = recExec({ 'base64 /out/r/adguard.tar': { stdout: tar.toString('base64') } });
-    expect((await readBackupTar(exec, run, 'adguard.tar')).equals(tar)).toBe(true);
+  // run.outDir is the HOST path; servicebay reads the SAME bytes off its own
+  // in-container data mount (DATA_DIR). The read goes through fs.readFile
+  // directly — never the agent seam / `base64` exec (#1973).
+  const run = { runId: 'r', outDir: '/mnt/data/servicebay/backup-runs/r', container: 'backup-worker-r' };
+  const inContainerTar = (name: string) => `${DATA_DIR}/backup-runs/r/${name}`;
+
+  beforeEach(() => {
+    readFileMock.mockReset();
   });
-  it('throws on a read failure', async () => {
-    const { exec } = recExec({ base64: { code: 1, stdout: 'no such file' } });
-    await expect(readBackupTar(exec, run, 'x.tar')).rejects.toThrow(/failed to read/);
+
+  it('reads the tar directly off the in-container out dir, never via the agent', async () => {
+    const tar = Buffer.from('hello tar');
+    readFileMock.mockImplementation(async (p: string) =>
+      p === inContainerTar('adguard.tar') ? tar : Promise.reject(new Error(`ENOENT: ${p}`)),
+    );
+    const { exec, calls } = recExec();
+
+    const got = await readBackupTar(exec, run, 'adguard.tar');
+
+    expect(got.equals(tar)).toBe(true);
+    expect(readFileMock).toHaveBeenCalledWith(inContainerTar('adguard.tar'));
+    // The agent exec seam (and therefore `base64`) is NOT used for the read.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('translates the HOST outDir to the in-container path (not run.outDir)', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('x'));
+    const { exec } = recExec();
+    await readBackupTar(exec, run, 'npm.tar');
+    expect(readFileMock).toHaveBeenCalledWith(inContainerTar('npm.tar'));
+    expect(readFileMock).not.toHaveBeenCalledWith(`${run.outDir}/npm.tar`);
+  });
+
+  it('throws a path-tagged error on a read failure', async () => {
+    readFileMock.mockRejectedValue(new Error('ENOENT: no such file'));
+    const { exec } = recExec();
+    await expect(readBackupTar(exec, run, 'x.tar')).rejects.toThrow(
+      new RegExp(`failed to read x\\.tar from ${inContainerTar('x.tar').replace(/[/.]/g, '\\$&')}`),
+    );
   });
 });

--- a/packages/backend/src/lib/backupWorker/launcher.ts
+++ b/packages/backend/src/lib/backupWorker/launcher.ts
@@ -6,7 +6,10 @@
 // plane on a HACS HA config (~5.3 GB, #1894 — feedback_control_plane_vs_worker).
 // Now the heavy walk/copy/tar runs in a resource-capped worker CONTAINER:
 // servicebay only launches it, reads the compact status.json it writes, and
-// streams the per-service tars it produced to the NAS one at a time.
+// streams the per-service tars it produced to the NAS one at a time. The out dir
+// is also mounted into servicebay's own /app/data, so it reads the produced tars
+// DIRECTLY off its filesystem rather than shelling them back through the agent
+// (the agent doesn't allowlist `base64`, which broke the tar→NAS read, #1973).
 //
 //   servicebay ──"Back up config"──▶ podman run --rm --memory=2g <worker> --stacks …
 //      reads status.json (compact)        (stacks ro at /mnt/stacks, out volume /out)
@@ -17,8 +20,12 @@
 // bookkeeping. The worker mounts the stacks dir READ-ONLY and writes only into
 // /out — it never writes back into a stack (feedback_fileshare_relabel_crashloop).
 
+import { readFile } from 'node:fs/promises';
+
 import type { WorkerStatus } from '@servicebay/backup-worker';
 import { STATUS_FILE } from '@servicebay/backup-worker';
+
+import { DATA_DIR } from '@/lib/dirs';
 
 /** Result of one structured `safe_exec` argv invocation (the agent seam). */
 export interface SafeExecResult {
@@ -27,10 +34,11 @@ export interface SafeExecResult {
   code: number;
 }
 
-/** The host-exec seam the launcher runs `podman`/`mkdir`/`cat`/`base64` through —
- *  the agent's structured `safe_exec` (no shell). Mirrors the disk-import worker's
+/** The host-exec seam the launcher runs `podman`/`mkdir`/`cat` through — the
+ *  agent's structured `safe_exec` (no shell). Mirrors the disk-import worker's
  *  SafeExec shape; defined locally so backup-worker doesn't depend on the
- *  disk-import worker package. */
+ *  disk-import worker package. Tars are read DIRECTLY off the filesystem
+ *  (readBackupTar), not through this seam (#1973). */
 export type SafeExec = (argv: string[], options?: { timeoutMs?: number; sudo?: boolean }) => Promise<SafeExecResult>;
 
 /** The published worker image — built + pushed by .github/workflows/build-images.yml. */
@@ -158,13 +166,31 @@ export async function ensureBackupWorkerImage(exec: SafeExec): Promise<void> {
   await exec(['podman', 'pull', BACKUP_WORKER_IMAGE]);
 }
 
-/** Read one produced tar's bytes from the out volume (host-side, base64 over the
- *  agent channel — the agent's read path is utf-8-only, so base64 keeps binary
- *  config intact). servicebay streams these to the NAS one at a time. */
-export async function readBackupTar(exec: SafeExec, run: BackupWorkerRun, tarName: string): Promise<Buffer> {
-  const { stdout, code, stderr } = await exec(['base64', `${run.outDir}/${tarName}`]);
-  if (code !== 0) {
-    throw new Error(`backup-worker: failed to read ${tarName} from ${run.outDir}: ${stderr || stdout}`);
+/**
+ * The IN-CONTAINER path of a run's out dir. `run.outDir` is the HOST path
+ * (`${HOST_DATA_DIR}/backup-runs/<runId>`) used to bind-mount the worker's /out;
+ * servicebay sees the SAME bytes at its own data mount (`${DATA_DIR}/backup-runs/
+ * <runId>`), so it can read the produced tars directly off its filesystem — no
+ * shelling `base64` through the agent seam (which doesn't allowlist `base64`,
+ * #1973). In dev/test HOST_DATA_DIR === DATA_DIR so this is identity.
+ */
+function inContainerOutDir(run: BackupWorkerRun): string {
+  return `${backupWorkerOutBase(DATA_DIR)}/${run.runId}`;
+}
+
+/**
+ * Read one produced tar's bytes from the out volume. The worker wrote it into the
+ * shared out dir, which is also mounted into servicebay's own /app/data — so we
+ * read it DIRECTLY off the filesystem (in-container path), never through the agent
+ * `base64` exec (`base64` isn't on the agent allowlist → the tars never reached
+ * the NAS, #1973). servicebay streams these to the NAS one at a time.
+ */
+export async function readBackupTar(_exec: SafeExec, run: BackupWorkerRun, tarName: string): Promise<Buffer> {
+  const path = `${inContainerOutDir(run)}/${tarName}`;
+  try {
+    return await readFile(path);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`backup-worker: failed to read ${tarName} from ${path}: ${message}`);
   }
-  return Buffer.from(stdout.replace(/\s+/g, ''), 'base64');
 }

--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/hostDataDir', () => ({
   resolveHostDataDir: vi.fn(async () => '/data'),
 }));
 
-import { launchWorker, readStatus, isWorkerRunning, stopWorker, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
+import { launchWorker, readStatus, isWorkerRunning, stopWorker, cleanupRunMount, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
 import { resolveImmichProvisionEnv } from './immichProvisionEnv';
 import type { SafeExec } from '@servicebay/disk-import-worker';
 
@@ -58,6 +58,36 @@ describe('launchWorker', () => {
     expect(podmanRun).toContain('--serve');
     // source mounted read-only into the container
     expect(podmanRun.some(a => a.endsWith(':/mnt/src:ro'))).toBe(true);
+
+    // the run handle carries device + mountpoint so teardown can unmount (#1941)
+    expect(run.device).toBe('/dev/sda1');
+    expect(run.mountpoint).toBe(mountpoint);
+  });
+
+  // #1941 — repeated scans of the same device must never stack mounts. The
+  // launcher sweeps every existing mount of the device/mountpoint BEFORE mounting.
+  it('sweeps stale mounts of the device before mounting, so scans never stack (#1941)', async () => {
+    const { exec, calls } = recExec();
+    await launchWorker({ exec, device: '/dev/sda1', runId: 'abc123', shareGid: 1024 });
+
+    const mountIdx = calls.findIndex(c => c[0] === 'mount');
+    // umount -A on both the device and the mountpoint runs BEFORE the fresh mount
+    const sweepDevIdx = calls.findIndex(c => c[0] === 'umount' && c[1] === '-A' && c[2] === '/dev/sda1');
+    const sweepMpIdx = calls.findIndex(c => c[0] === 'umount' && c[1] === '-A' && c[2]?.startsWith('/run/servicebay/disk-import/'));
+    expect(sweepDevIdx).toBeGreaterThanOrEqual(0);
+    expect(sweepMpIdx).toBeGreaterThanOrEqual(0);
+    expect(sweepDevIdx).toBeLessThan(mountIdx);
+    expect(sweepMpIdx).toBeLessThan(mountIdx);
+    // exactly one fresh `mount` call — never stacked
+    expect(calls.filter(c => c[0] === 'mount')).toHaveLength(1);
+  });
+
+  it('launches cleanly even when the sweep umount fails (cold/clean device) (#1941)', async () => {
+    // "not mounted" → non-zero umount exit must NOT abort the launch.
+    const { exec, calls } = recExec({ 'umount -A': { code: 1 } });
+    const run = await launchWorker({ exec, device: '/dev/sda1', runId: 'abc123', shareGid: 1024 });
+    expect(run.container).toBe('disk-import-worker-abc123');
+    expect(calls.some(c => c[0] === 'mount')).toBe(true);
   });
 
   it('injects the resolved Immich provisioning env into the container (#1954)', async () => {
@@ -82,7 +112,7 @@ describe('launchWorker', () => {
 });
 
 describe('readStatus', () => {
-  const run = { runId: 'r', outDir: '/data/runs/r', container: 'disk-import-worker-r' };
+  const run = { runId: 'r', outDir: '/data/runs/r', container: 'disk-import-worker-r', device: '/dev/sda1', mountpoint: '/run/servicebay/disk-import/sda1' };
 
   it('parses the compact status.json', async () => {
     const { exec } = recExec({ 'cat /data/runs/r/status.json': { stdout: JSON.stringify({ phase: 'done', planned: 5 }) } });
@@ -96,7 +126,7 @@ describe('readStatus', () => {
 });
 
 describe('isWorkerRunning', () => {
-  const run = { runId: 'r', outDir: '/o', container: 'disk-import-worker-r' };
+  const run = { runId: 'r', outDir: '/o', container: 'disk-import-worker-r', device: '/dev/sda1', mountpoint: '/run/servicebay/disk-import/sda1' };
 
   it('is true when podman ps lists the container', async () => {
     const { exec } = recExec({ 'podman ps': { stdout: 'disk-import-worker-r\n' } });
@@ -110,9 +140,40 @@ describe('isWorkerRunning', () => {
 });
 
 describe('stopWorker', () => {
+  const run = { runId: 'r', outDir: '/o', container: 'disk-import-worker-r', device: '/dev/sda1', mountpoint: '/run/servicebay/disk-import/sda1' };
+
   it('force-removes the container', async () => {
     const { exec, calls } = recExec();
-    await stopWorker(exec, { runId: 'r', outDir: '/o', container: 'disk-import-worker-r' });
+    await stopWorker(exec, run);
     expect(calls).toContainEqual(['podman', 'rm', '-f', 'disk-import-worker-r']);
+  });
+
+  // #1941 — teardown must unmount the source device so the one-shot worker
+  // leaves no mount behind (a crashed worker's mount would otherwise leak).
+  it('unmounts the source device + drops the mountpoint on teardown (#1941)', async () => {
+    const { exec, calls } = recExec();
+    await stopWorker(exec, run);
+    expect(calls).toContainEqual(['umount', '-A', '/dev/sda1']);
+    expect(calls).toContainEqual(['umount', '-A', '/run/servicebay/disk-import/sda1']);
+    expect(calls).toContainEqual(['rmdir', '/run/servicebay/disk-import/sda1']);
+  });
+
+  it('unmounts even if podman rm fails — a crashed worker still cleans up (#1941)', async () => {
+    const { exec, calls } = recExec({ 'podman rm': { code: 1 } });
+    await stopWorker(exec, run);
+    expect(calls).toContainEqual(['umount', '-A', '/dev/sda1']);
+  });
+});
+
+describe('cleanupRunMount', () => {
+  it('sweeps the run device mounts; no-ops when the handle has no device (#1941)', async () => {
+    const { exec, calls } = recExec();
+    await cleanupRunMount(exec, { runId: 'r', outDir: '/o', container: 'c', device: '/dev/sdb1', mountpoint: '/run/servicebay/disk-import/sdb1' });
+    expect(calls).toContainEqual(['umount', '-A', '/dev/sdb1']);
+
+    const { exec: exec2, calls: calls2 } = recExec();
+    // legacy handle without device/mountpoint (e.g. persisted before #1941)
+    await cleanupRunMount(exec2, { runId: 'r', outDir: '/o', container: 'c' } as never);
+    expect(calls2).toHaveLength(0);
   });
 });

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -41,6 +41,10 @@ export interface WorkerRun {
   outDir: string;
   /** The container name (`disk-import-worker-<runId>`). */
   container: string;
+  /** The source device node (`/dev/sda1`) — so teardown can unmount it (#1941). */
+  device: string;
+  /** The host-side RO mountpoint of the device (under MOUNT_BASE) (#1941). */
+  mountpoint: string;
 }
 
 /** A removable partition the tile offers as an import source. */
@@ -89,6 +93,13 @@ export async function launchWorker(args: {
   const outDir = `${workerOutBase(hostDataDir)}/${runId}`;
   const container = containerName(runId);
 
+  // IDEMPOTENT MOUNT (#1941): a prior scan (incl. one that crashed before its
+  // teardown unmount) can leave the device stacked-mounted at `mountpoint`.
+  // `mount -o ro` does NOT check this and just stacks another layer; after a few
+  // the kernel mount on the over-stacked device blocks and the next scan hangs at
+  // "Starting…". So sweep EVERY existing mount of this device/mountpoint first,
+  // then mount exactly once — repeated scans of the same disk leave one mount.
+  await sweepDeviceMounts(exec, device, mountpoint);
   // The mountpoint dir must exist before `mount` (same as mounter.mountReadOnly).
   // It lives under /run (root-owned), so creating it needs sudo — without this
   // the mount fails with "mount point does not exist" and the worker never runs.
@@ -134,7 +145,39 @@ export async function launchWorker(args: {
     '--serve', '--share-gid', String(shareGid),
   ]);
 
-  return { runId, outDir, container };
+  return { runId, outDir, container, device, mountpoint };
+}
+
+/**
+ * Unmount EVERY mount of `device` at `mountpoint` and tear the dir down, so a
+ * fresh mount can't stack on a leftover (#1941). Idempotent + best-effort: if
+ * nothing is mounted, `umount` reports "not mounted" — we ignore that and any
+ * other umount error so a cold/clean device never blocks the launch. `umount -A`
+ * detaches all of the device's mounts in one go (clears a stack), then we drop
+ * the (now-empty) controlled mountpoint dir.
+ */
+async function sweepDeviceMounts(exec: SafeExec, device: string, mountpoint: string): Promise<void> {
+  assertSafeDevice(device);
+  // `umount -A <device>` unmounts every mount of the device wherever it sits —
+  // exactly the stacked-layer case the issue hit. Best-effort: ignore the
+  // "not mounted" exit for a clean device. Then `umount -A <mountpoint>` mops up
+  // any mount left there by a different device node (defence in depth).
+  await exec(['umount', '-A', device], { sudo: true }).catch(() => undefined);
+  await exec(['umount', '-A', mountpoint], { sudo: true }).catch(() => undefined);
+  // Drop the now-empty controlled mountpoint dir (re-created before the mount).
+  // `rmdir` (not `rm -rf`) — it only removes an EMPTY dir, so a still-mounted
+  // path is left intact rather than risking a recursive delete into a mount.
+  await exec(['rmdir', mountpoint], { sudo: true }).catch(() => undefined);
+}
+
+/**
+ * Unmount a finished/aborted run's source device and remove its mountpoint
+ * (#1941). Called on worker teardown so the one-shot `--rm` worker leaves no
+ * mount behind. Best-effort + idempotent — ignores "not mounted"/missing-dir.
+ */
+export async function cleanupRunMount(exec: SafeExec, run: WorkerRun): Promise<void> {
+  if (!run.device || !run.mountpoint) return;
+  await sweepDeviceMounts(exec, run.device, run.mountpoint);
 }
 
 /**
@@ -158,9 +201,15 @@ export async function isWorkerRunning(exec: SafeExec, run: WorkerRun): Promise<b
   return stdout.split('\n').some(line => line.trim() === run.container);
 }
 
-/** Stop a worker container (the tile's "Start over" / abort). Best-effort. */
+/**
+ * Stop a worker container (the tile's "Start over" / abort) AND unmount its
+ * source device (#1941). Both steps are best-effort so a half-gone run still
+ * fully cleans up — and the unmount runs even if the container is already gone,
+ * so a crashed worker's mount can't leak past teardown.
+ */
 export async function stopWorker(exec: SafeExec, run: WorkerRun): Promise<void> {
   await exec(['podman', 'rm', '-f', run.container]).catch(() => {});
+  await cleanupRunMount(exec, run);
 }
 
 /** Ensure the worker image is present on the node (pull if missing). */


### PR DESCRIPTION
## What
Two worker-architecture follow-ups: (1) the backup-worker now reads produced per-service tars directly off the host-mounted out-volume instead of shelling out a non-allowlisted `base64` exec; (2) the disk-import worker device mount is made idempotent — stale mounts are swept before mounting and unmount is guaranteed on scan error/teardown so repeated scans never stack mounts.

## Why
Closes #1973
Closes #1941

## Risk
low — both are scoped to the worker launch/read paths; no schema or install-path config changes.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full)
- [x] npm run knip
- [x] npx tsc --noEmit (0 errors)
- [ ] /verify on FCoS :dev box (backup completes + tars land at NAS; double-scan = one mount, none after worker exit)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._