### PR TITLE
feat(settings): move disk-import from main nav to Settings → Maintenance + searchable

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/ia.test.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/ia.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+import { SETTINGS_GROUPS, SEARCH_INDEX, searchSettings } from './ia';
+
+describe('settings IA — Maintenance launcher (#1958 follow-up)', () => {
+  it('has a Maintenance group with the disk-import launcher', () => {
+    const group = SETTINGS_GROUPS.find(g => g.id === 'maintenance');
+    expect(group).toBeDefined();
+    const importEntry = group!.entries.find(e => e.id === 'disk-import');
+    expect(importEntry?.launchHref).toBe('/disk-import');
+  });
+
+  it('searching "import" jumps straight to the importer route, not a settings anchor', () => {
+    const hits = searchSettings('import');
+    const importHit = hits.find(h => h.entry.id === 'disk-import');
+    expect(importHit).toBeDefined();
+    expect(importHit!.href).toBe('/disk-import');
+  });
+
+  it('also finds the importer by synonyms (usb, sort, photos)', () => {
+    for (const term of ['usb', 'sort', 'photos']) {
+      expect(searchSettings(term).some(h => h.entry.id === 'disk-import')).toBe(true);
+    }
+  });
+
+  it('non-launcher entries still deep-link to their in-page settings anchor', () => {
+    const updates = SEARCH_INDEX.find(h => h.entry.id === 'updates');
+    expect(updates?.href).toBe('/settings/system#updates');
+  });
+});

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/ia.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/ia.ts
@@ -26,6 +26,7 @@ import {
   Network,
   Server,
   Users,
+  Wrench,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -41,6 +42,11 @@ export interface SettingEntry {
   tier: SettingTier;
   /** Extra search keywords (synonyms users might type). */
   keywords?: string[];
+  /** When set, this entry is a LAUNCHER for a feature that lives at its own
+   *  top-level route (e.g. the disk-import worker app at `/disk-import`), not an
+   *  in-page Settings section. Search links straight here, and the group page
+   *  renders it as a launch card instead of a disclosure section. */
+  launchHref?: string;
 }
 
 /** A goal-based cross-cutting group = one nav entry = one route. */
@@ -128,6 +134,19 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
       { id: 'factory-reset', label: 'Factory reset', tier: 'advanced', keywords: ['reset', 'wipe', 'erase', 'danger'] },
     ],
   },
+  {
+    // Occasional one-off tools that don't belong in the primary sidebar. Disk
+    // import (run once or twice ever) lives here as a launch card → the resource-
+    // capped worker app at /disk-import, rather than a permanent nav entry
+    // (#1958 follow-up). The heavy UI still runs in its own route/worker.
+    id: 'maintenance',
+    label: 'Maintenance',
+    intent: 'Occasional one-off tools — import a disk into the box.',
+    icon: Wrench,
+    entries: [
+      { id: 'disk-import', label: 'Import data', tier: 'essential', launchHref: '/disk-import', keywords: ['import', 'disk', 'usb', 'drive', 'sort', 'photos', 'music', 'copy', 'ingest', 'sd card'] },
+    ],
+  },
 ];
 
 export const DEFAULT_GROUP = SETTINGS_GROUPS[0];
@@ -144,7 +163,10 @@ export const SEARCH_INDEX: SearchHit[] = SETTINGS_GROUPS.flatMap(group =>
   group.entries.map(entry => ({
     group,
     entry,
-    href: `/settings/${group.id}#${entry.id}`,
+    // Launcher entries link straight to their own route (e.g. /disk-import) so
+    // searching "import" jumps right into the importer; everything else deep-
+    // links to the in-page Settings anchor.
+    href: entry.launchHref ?? `/settings/${group.id}#${entry.id}`,
   })),
 );
 

--- a/packages/frontend/src/app/(dashboard)/settings/maintenance/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/maintenance/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+// Settings → Maintenance: occasional one-off tools that don't warrant a permanent
+// primary-nav entry (#1958 follow-up). Disk import (run once or twice ever) is a
+// LAUNCH CARD here → the resource-capped worker app at /disk-import; the heavy job
+// still runs in its own worker container, this is just the entry point.
+
+import Link from 'next/link';
+import { Download, ChevronRight } from 'lucide-react';
+
+import GroupIntro from '../_lib/GroupIntro';
+import { SETTINGS_GROUPS } from '../_lib/ia';
+
+const GROUP = SETTINGS_GROUPS.find(g => g.id === 'maintenance')!;
+
+export default function MaintenanceSettingsPage() {
+  const launchers = GROUP.entries.filter(e => e.launchHref);
+
+  return (
+    <div className="space-y-6">
+      <GroupIntro intent={GROUP.intent} />
+
+      <div className="space-y-3">
+        {launchers.map(entry => (
+          <Link
+            key={entry.id}
+            href={entry.launchHref!}
+            id={entry.id}
+            data-testid={`maintenance-launch-${entry.id}`}
+            className="flex items-center gap-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-sm transition-colors"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+              <Download className="h-5 w-5" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block font-medium text-gray-900 dark:text-gray-100">{entry.label}</span>
+              <span className="block text-sm text-gray-500 dark:text-gray-400">
+                Sort a USB disk or drive into the box (photos, music, documents…). Runs in a one-shot worker — opens the importer.
+              </span>
+            </span>
+            <ChevronRight className="h-5 w-5 shrink-0 text-gray-400" />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -14,7 +14,7 @@
  *      bottom bar doesn't get cluttered (it's still in the top
  *      bar's icon row).
  */
-import { Box, Terminal, Activity, Settings, Network, Home, Download, DatabaseBackup } from 'lucide-react';
+import { Box, Terminal, Activity, Settings, Network, Home, DatabaseBackup } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 export interface NavigationEntry {
@@ -62,9 +62,10 @@ export const NAVIGATION_ENTRIES: NavigationEntry[] = [
   { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
   { id: 'health', name: 'Diagnostics', shortLabel: 'Health', icon: Activity, path: '/health' },
   { id: 'terminal', name: 'SSH Terminal', shortLabel: 'Terminal', icon: Terminal, path: '/terminal' },
-  // Disk import is its own launch tile (#1949/#1953) — it opens the resource-
-  // capped worker app, not an in-process Settings subsection.
-  { id: 'disk-import', name: 'Import data', shortLabel: 'Import', icon: Download, path: '/disk-import', hiddenOnMobileBottom: true },
+  // Disk import is NOT a primary nav entry — it's a one-or-twice-ever maintenance
+  // task, so it lives under Settings → Maintenance (a launch card) and the global
+  // search, reachable at /disk-import. Keeping it out of the sidebar avoids giving
+  // a rarely-used tool permanent prominence (#1958 follow-up).
   // Backup & restore is its own launch tile (#1949/#1958) — the heavy backup/
   // restore UI left Settings entirely; the actions run in the capped backup
   // worker (#1955), surfaced here rather than as an in-process Settings page.


### PR DESCRIPTION
## Why
Disk import is used once or twice ever, but the rebuild (#1958) made it a permanent **main-nav** sidebar entry — too prominent — and the global search returned nothing for "import" because the feature had left Settings entirely.

## What
- **Removed** `disk-import` from `NAVIGATION_ENTRIES` (the sidebar). **Backup stays** in the nav (run/checked more often).
- **New Settings → Maintenance group** (`/settings/maintenance`) with an **Import launch card** → `/disk-import`.
- Added `launchHref` to the Settings IA so search hits for launcher features link **straight to their own route**; searching `import` / `usb` / `sort` / `photos` now jumps right into the importer.
- The heavy importer UI is unchanged — still its own route + capped worker. Only the entry point moved.

Unit-tested in `ia.test.ts` (Maintenance group, search→/disk-import, synonyms, non-launcher anchors intact). Frontend-only.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._