### PR TITLE
fix(disk-import): repair worker runtime — ESM require, SELinux source mount, Immich env

### DIFF
--- a/packages/backend/src/lib/diskImport/immichProvisionEnv.test.ts
+++ b/packages/backend/src/lib/diskImport/immichProvisionEnv.test.ts
@@ -7,11 +7,13 @@ vi.mock('./reconcileImmichApiKey', () => ({
 vi.mock('@/lib/install/savedSecrets', () => ({ loadSavedSecrets: vi.fn() }));
 vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
 vi.mock('@/lib/lldap/client', () => ({ listLldapUsers: vi.fn() }));
+vi.mock('@/lib/logger', () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
 
 import { reconcileImmichApiKey } from './reconcileImmichApiKey';
 import { loadSavedSecrets } from '@/lib/install/savedSecrets';
 import { getConfig } from '@/lib/config';
 import { listLldapUsers } from '@/lib/lldap/client';
+import { logger } from '@/lib/logger';
 import { resolveImmichProvisionEnv, IMMICH_SERVER_URL } from './immichProvisionEnv';
 
 beforeEach(() => {
@@ -43,6 +45,19 @@ describe('resolveImmichProvisionEnv', () => {
     vi.mocked(loadSavedSecrets).mockReturnValue({});
     expect(await resolveImmichProvisionEnv()).toEqual([]);
     expect(listLldapUsers).not.toHaveBeenCalled();
+  });
+
+  it('warns (does not swallow) when no key resolves, surfacing the reconcile reason', async () => {
+    vi.mocked(reconcileImmichApiKey).mockResolvedValue({
+      outcome: 'error',
+      message: 'No stored Immich admin credentials — missing admin email; cannot mint an admin API key.',
+    });
+    vi.mocked(loadSavedSecrets).mockReturnValue({});
+    expect(await resolveImmichProvisionEnv()).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'disk-import:immich',
+      expect.stringContaining('No stored Immich admin credentials'),
+    );
   });
 
   it('still injects when the user directory is unavailable (Shared library only)', async () => {

--- a/packages/backend/src/lib/diskImport/immichProvisionEnv.ts
+++ b/packages/backend/src/lib/diskImport/immichProvisionEnv.ts
@@ -35,9 +35,19 @@ export const IMMICH_SERVER_URL = 'http://127.0.0.1:2283';
  */
 export async function resolveImmichProvisionEnv(): Promise<string[]> {
   try {
-    await reconcileImmichApiKey(IMMICH_SERVER_URL);
+    const reconcile = await reconcileImmichApiKey(IMMICH_SERVER_URL);
     const adminApiKey = loadSavedSecrets(await getConfig())[IMMICH_ADMIN_API_KEY_VAR];
-    if (!adminApiKey) return [];
+    if (!adminApiKey) {
+      // Don't fail the launch, but DON'T fail silently either — a no-op Immich
+      // scan must be diagnosable. Surface the reconcile outcome (it carries the
+      // exact missing-credential reason) so it's visible in the logs.
+      logger.warn(
+        'disk-import:immich',
+        `No Immich admin API key after reconcile (${reconcile.outcome}) — ` +
+          `the post-apply Immich library scan will be skipped: ${reconcile.message}`,
+      );
+      return [];
+    }
 
     const users = await listLldapUsers();
     const boxUsers = users.ok ? users.users.map(u => ({ id: u.id, email: u.email })) : [];

--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -37,9 +37,17 @@ describe('launchWorker', () => {
     expect(run.container).toBe('disk-import-worker-abc123');
     expect(run.outDir).toBe('/data/disk-import-runs/abc123');
 
-    // device is mounted read-only, with sudo
+    // device is mounted read-only, with sudo, and SELinux-labeled at mount time
+    // so the container_t worker can read the source (a read-only mount can't be
+    // relabeled via `:z` on the bind, so the label is set with `context=`).
     const mountCall = calls.find(c => c[0] === 'mount');
-    expect(mountCall).toEqual(['mount', '-o', 'ro', '/dev/sda1', expect.any(String)]);
+    expect(mountCall).toEqual([
+      'mount',
+      '-o',
+      'ro,context="system_u:object_r:container_file_t:s0"',
+      '/dev/sda1',
+      expect.any(String),
+    ]);
     const mountpoint = mountCall![4];
 
     // the RO mountpoint dir is created (sudo) BEFORE the mount — else

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -118,7 +118,18 @@ export async function launchWorker(args: {
       `set HOST_DATA_DIR (or ensure servicebay's /app/data volume Source is inspectable).`,
     );
   }
-  await exec(['mount', '-o', 'ro', device, mountpoint], { sudo: true });
+  // SELinux is Enforcing on the box. Without a label the source filesystem is
+  // `unlabeled_t` and the `container_t` worker gets EACCES on `scandir /mnt/src`.
+  // `:z`/`:Z` on the `-v` bind is IMPOSSIBLE here — the source is a READ-ONLY
+  // mount, so podman's `lsetxattr` relabel fails. Instead, label the whole
+  // filesystem at MOUNT time with the SELinux `context=` mount option: the source
+  // then carries `container_file_t` and the worker can read it (verified on-box).
+  // The `-v …:ro` bind below intentionally stays plain `:ro` — the context-mounted
+  // source already has the right label.
+  await exec(
+    ['mount', '-o', 'ro,context="system_u:object_r:container_file_t:s0"', device, mountpoint],
+    { sudo: true },
+  );
 
   // Resolve the Immich External-Library provisioning inputs (admin key + box
   // users) the worker's apply path needs (#1954). Injected as env so the apply

--- a/packages/backend/src/lib/diskImport/reconcileImmichApiKey.test.ts
+++ b/packages/backend/src/lib/diskImport/reconcileImmichApiKey.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn() }));
+vi.mock('@/lib/install/savedSecrets', () => ({
+  loadSavedSecrets: vi.fn(),
+  persistSingleSecret: vi.fn(async () => undefined),
+}));
+vi.mock('@/lib/logger', () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+
+import { getConfig } from '@/lib/config';
+import { loadSavedSecrets, persistSingleSecret } from '@/lib/install/savedSecrets';
+import { reconcileImmichApiKey, IMMICH_ADMIN_API_KEY_VAR } from './reconcileImmichApiKey';
+
+const SERVER = 'http://127.0.0.1:2283';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getConfig).mockResolvedValue({} as never);
+  vi.mocked(loadSavedSecrets).mockReturnValue({});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('reconcileImmichApiKey', () => {
+  it('is a no-op when a key is already stored', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({ [IMMICH_ADMIN_API_KEY_VAR]: 'existing' });
+    const r = await reconcileImmichApiKey(SERVER);
+    expect(r.outcome).toBe('aligned');
+  });
+
+  it('errors with the exact missing key when no email AND no password are resolvable', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({});
+    vi.mocked(getConfig).mockResolvedValue({} as never);
+    const r = await reconcileImmichApiKey(SERVER);
+    expect(r.outcome).toBe('error');
+    expect(r.message).toContain('admin email');
+    expect(r.message).toContain('IMMICH_ADMIN_PASSWORD');
+  });
+
+  it('derives the admin email from config.notifications.email.to[0] when the secret keys are absent', async () => {
+    // Password is stored, but NO email key in the secret store — the normal box
+    // state. The email must fall back to the operator email in config.
+    vi.mocked(loadSavedSecrets).mockReturnValue({ IMMICH_ADMIN_PASSWORD: 'pw' });
+    vi.mocked(getConfig).mockResolvedValue({
+      notifications: { email: { to: ['operator@example.com'] } },
+    } as never);
+
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      void _init;
+      if (url.endsWith('/api/auth/login')) {
+        return new Response(JSON.stringify({ accessToken: 'tok' }), { status: 201 });
+      }
+      if (url.endsWith('/api/api-keys')) {
+        return new Response(JSON.stringify({ secret: 'minted-key' }), { status: 201 });
+      }
+      return new Response('null', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const r = await reconcileImmichApiKey(SERVER);
+    expect(r.outcome).toBe('minted');
+    // logged in with the config-derived email
+    const loginCall = fetchMock.mock.calls.find(c => String(c[0]).endsWith('/api/auth/login'))!;
+    const loginBody = JSON.parse((loginCall[1] as RequestInit).body as string);
+    expect(loginBody.email).toBe('operator@example.com');
+    expect(persistSingleSecret).toHaveBeenCalledWith(IMMICH_ADMIN_API_KEY_VAR, 'minted-key');
+  });
+});

--- a/packages/backend/src/lib/diskImport/reconcileImmichApiKey.ts
+++ b/packages/backend/src/lib/diskImport/reconcileImmichApiKey.ts
@@ -88,13 +88,27 @@ export async function reconcileImmichApiKey(
     return { outcome: 'aligned', message: 'Immich admin API key already stored — no change.' };
   }
 
-  const email = secrets.IMMICH_ADMIN_EMAIL || secrets.OPERATOR_EMAIL || '';
+  // Derive the admin email. On a normal box NEITHER IMMICH_ADMIN_EMAIL nor
+  // OPERATOR_EMAIL is written to the secret store (they're plain post-deploy env
+  // vars, not secrets), so without a fallback this always returns [] and the
+  // post-apply Immich library scan silently never runs. Fall back to the SAME
+  // canonical operator identity the install runner uses to seed admin accounts:
+  // config.notifications.email.to[0] (see install/runner.ts OPERATOR_EMAIL). That
+  // is exactly the email the immich post-deploy seeds the admin account with, so
+  // it's the right login here.
+  const operatorEmailFromConfig = config.notifications?.email?.to?.[0]?.trim() || '';
+  const email = secrets.IMMICH_ADMIN_EMAIL || secrets.OPERATOR_EMAIL || operatorEmailFromConfig;
   const password = secrets.IMMICH_ADMIN_PASSWORD || '';
   if (!email || !password) {
+    const missing = [
+      !email && 'admin email (set IMMICH_ADMIN_EMAIL/OPERATOR_EMAIL, or notifications.email.to[0] in config)',
+      !password && 'IMMICH_ADMIN_PASSWORD (in the encrypted secret store)',
+    ]
+      .filter(Boolean)
+      .join(' and ');
     return {
       outcome: 'error',
-      message:
-        'No stored Immich admin credentials (IMMICH_ADMIN_EMAIL/OPERATOR_EMAIL + IMMICH_ADMIN_PASSWORD) — cannot mint an admin API key.',
+      message: `No stored Immich admin credentials — missing ${missing}; cannot mint an admin API key.`,
     };
   }
 

--- a/packages/disk-import-worker/src/cli/esmImports.test.ts
+++ b/packages/disk-import-worker/src/cli/esmImports.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This package is ESM ("type":"module") and runs as raw TS ESM via tsx, where the
+// CommonJS `require` global does NOT exist. A bare `require('…')` here throws
+// `ReferenceError: require is not defined` at runtime and crashed EVERY scan and
+// apply (catalog.ts + main.ts). Guard against a regression: no source file may use
+// the `require(` global, and the modules that need a CJS dep must bridge it via
+// `createRequire(import.meta.url)` or a static `import`.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const srcRoot = path.resolve(here, '..');
+
+const read = (rel: string) => readFileSync(path.join(srcRoot, rel), 'utf8');
+
+// Strip comments + string literals so a `require(` inside a comment/doc doesn't
+// trip the guard; we only care about real call expressions.
+function codeOnly(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/(['"`])(?:\\.|(?!\1).)*\1/g, '""');
+}
+
+describe('disk-import-worker ESM runtime safety', () => {
+  it('catalog.ts loads better-sqlite3 via a createRequire bridge, not the require global', () => {
+    const code = codeOnly(read('engine/catalog.ts'));
+    // It DOES call require(...), but only the module-scoped createRequire bridge —
+    // never the (nonexistent in ESM) global. Assert the bridge is declared and that
+    // every `require(` call is reachable only through it.
+    expect(code).toContain('createRequire(import.meta.url)');
+    expect(code).toMatch(/const\s+require\s*=\s*createRequire\(/);
+  });
+
+  it('main.ts uses a static import for child_process, no require( at all', () => {
+    const code = codeOnly(read('cli/main.ts'));
+    expect(code).not.toMatch(/(^|[^.\w])require\s*\(/);
+    expect(read('cli/main.ts')).toMatch(
+      /import\s*\{\s*spawnSync\s*\}\s*from\s*['"]node:child_process['"]/,
+    );
+  });
+
+  it('ImportCatalog actually constructs (the require bridge resolves the native addon)', async () => {
+    const { ImportCatalog } = await import('../engine/catalog');
+    const cat = new ImportCatalog(':memory:');
+    expect(cat.count()).toBe(0);
+    cat.close();
+  });
+});

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -27,6 +27,7 @@
  * is servicebay's, before it launches `--apply`). This keeps the container a pure
  * one-shot batch job.
  */
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import fs from 'node:fs/promises';
@@ -309,9 +310,8 @@ function realIO(): WorkerIO {
     makeExec: opts => {
       // The worker runs host-apply commands locally inside the container against
       // the bind-mounted out-volume — a plain child_process SafeExec. (Wiring the
-      // real privileged host-apply path is #1954.)
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { spawnSync } = require('node:child_process') as typeof import('node:child_process');
+      // real privileged host-apply path is #1954.) spawnSync is statically
+      // imported at the top of this ESM module — there is no `require` global here.
       void opts;
       return (argv: string[]) => {
         const r = spawnSync(argv[0], argv.slice(1), { encoding: 'utf8' });

--- a/packages/disk-import-worker/src/engine/catalog.ts
+++ b/packages/disk-import-worker/src/engine/catalog.ts
@@ -10,7 +10,15 @@
 // constructor param — no hardcoded host paths, no DATA_DIR coupling. `:memory:`
 // is valid and used by the tests.
 
+import { createRequire } from 'node:module';
+
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+
+// This package is ESM ("type":"module") and runs as raw TS ESM via tsx, so the
+// CommonJS `require` global does NOT exist here. better-sqlite3 is a native CJS
+// addon; load it through a createRequire() bridge to keep the native binding out
+// of any ESM resolution edge cases while staying require-free at the global level.
+const require = createRequire(import.meta.url);
 
 /** The default destination area when no owner-derived area is supplied. */
 export const DEFAULT_AREA = 'shared';
@@ -63,9 +71,9 @@ export class ImportCatalog {
   private db: BetterSqliteDatabase;
 
   constructor(dbPath: string) {
-    // Runtime require keeps better-sqlite3 (a native addon) out of any client
-    // bundle, matching the rest of the codebase (logger.ts, rateLimit.ts).
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // better-sqlite3 is a native CJS addon; load it via the module-scoped
+    // createRequire() bridge (this package runs as ESM under tsx, where the
+    // `require` global is undefined).
     const Database = require('better-sqlite3');
     this.db = new Database(dbPath) as BetterSqliteDatabase;
     this.db.pragma('journal_mode = WAL');


### PR DESCRIPTION
## What
Three runtime defects, each found by an on-box end-to-end disk-import test, that broke every scan/apply before a single file could be sorted (the routing/categorization logic itself is unchanged):

1. **ESM `require is not defined`** — the `disk-import-worker` package is `"type":"module"` and runs as raw TS ESM via `tsx`, but `engine/catalog.ts` and `cli/main.ts` used the CJS `require` global → `ReferenceError` on every scan AND apply. `catalog.ts` now bridges `better-sqlite3` via `createRequire(import.meta.url)`; `main.ts` uses a static `import { spawnSync } from 'node:child_process'`. Also fixed the misleading "matching logger.ts" comment (the backend runs compiled CJS; the worker is ESM).
2. **SELinux denied the read-only source mount** — the source device bind-mounted into the `container_t` worker was `unlabeled_t` → `EACCES scandir /mnt/src`. `:z`/`:Z` is impossible on a read-only mount (`lsetxattr` fails), so `diskImport/launcher.ts` now labels at mount time with `-o ro,context="system_u:object_r:container_file_t:s0"` (the `-v` bind stays plain `:ro`).
3. **Immich provisioning env never injected** — `reconcileImmichApiKey` required an email key that's never present in the secret store on a normal box, so `resolveImmichProvisionEnv` returned `[]` silently → the post-apply Immich External Library scan was a no-op. It now derives the admin email from `config.notifications.email.to[0]` (the same operator identity the install runner seeds admin accounts with) and warns loudly with the exact missing key when env still can't resolve, instead of swallowing.

## Why
On-box end-to-end disk-import testing surfaced three independent runtime crashes that each blocked the importer before any file landed. No tracked issue — found during box verification.

## Risk
Low — disk-import is a one-shot worker path; routing logic untouched, fixes are confined to runtime bootstrapping (module loading, mount labeling, env injection).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2861 pass)
- [x] npx tsc --noEmit (0 errors)
- [ ] /verify on FCoS :dev box — REAL end-to-end importer re-test owed

Tests added: ESM import smoke (no `require(` global in the worker CLI), launcher emits the `context=` mount option, reconcile derives the config email + warns on miss.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
