### PR TITLE
fix(disk-import): run APPLY on the host from servicebay, not the sandboxed worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14466,6 +14466,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@servicebay/api-client": "*",
+        "@servicebay/disk-import-worker": "*",
         "better-sqlite3": "^12.11.1",
         "elkjs": "^0.11.1",
         "gray-matter": "^4.0.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,6 +5,7 @@
   "description": "Server-side modules: agent, install, diagnose, network, store, etc. Phase 3.3 of #753.",
   "dependencies": {
     "@servicebay/api-client": "*",
+    "@servicebay/disk-import-worker": "*",
     "better-sqlite3": "^12.11.1",
     "elkjs": "^0.11.1",
     "gray-matter": "^4.0.3",

--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PlanSidecar } from '@servicebay/disk-import-worker';
+
+// The heavy apply (rsync/chown/catalog) lives in the worker package; stub it so
+// these tests assert servicebay's HOST-apply WIRING (#1972): it reads the worker's
+// plan.json from the out dir, rebases the source from the worker mountBase to the
+// HOST mountpoint, runs applyPlan with the real exec, and fires Immich post-apply.
+const applyPlanMock = vi.fn();
+const catalogClose = vi.fn();
+const provisionExternalLibrariesMock = vi.fn();
+const scanLibrariesForOwnersMock = vi.fn();
+
+vi.mock('@servicebay/disk-import-worker', () => ({
+  applyPlan: (...args: unknown[]) => applyPlanMock(...args),
+  ImportCatalog: class { close = catalogClose; },
+  provisionExternalLibraries: (...a: unknown[]) => provisionExternalLibrariesMock(...a),
+  scanLibrariesForOwners: (...a: unknown[]) => scanLibrariesForOwnersMock(...a),
+  STATUS_FILE: 'status.json',
+  PLAN_SIDECAR_FILE: 'plan.json',
+}));
+
+vi.mock('@/lib/dirs', () => ({ DATA_DIR: '/app/data' }));
+vi.mock('@/lib/logger', () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+
+const resolveImmichProvisionMock = vi.fn();
+vi.mock('./immichProvisionEnv', () => ({
+  resolveImmichProvision: () => resolveImmichProvisionMock(),
+}));
+
+// Capture status.json writes; stub plan.json reads.
+const { writes } = vi.hoisted(() => ({ writes: [] as Array<{ file: string; data: string }> }));
+vi.mock('node:fs/promises', () => {
+  const fsMock = {
+    readFile: vi.fn(async (file: string) => {
+      if (file.endsWith('plan.json')) return JSON.stringify(hoistedSidecar());
+      if (file.endsWith('status.json')) throw new Error('no status yet');
+      throw new Error(`unexpected read ${file}`);
+    }),
+    writeFile: vi.fn(async (file: string, data: string) => {
+      // status writes go via tmp + rename; record under the final name either way.
+      writes.push({ file: file.replace(/\.tmp$/, ''), data });
+    }),
+    rename: vi.fn(async () => {}),
+    mkdir: vi.fn(async () => {}),
+  };
+  return { ...fsMock, default: fsMock };
+});
+
+/** Plan fixture the fs mock returns for plan.json (hoisted-safe). */
+function hoistedSidecar() {
+  return {
+    version: 1,
+    runId: 'run1',
+    mountBase: '/mnt/src',
+    plan: {
+      items: [
+        { category: 'photos', action: 'copy', target: 'photos/a.jpg', record: { sourcePath: '/mnt/src/dcim/a.jpg', size: 10, mtimeMs: 1, ext: 'jpg', name: 'a.jpg' } },
+      ],
+      conflicts: [],
+    },
+  };
+}
+
+import { applyImport, rebasePlanSource } from './apply';
+
+function recordOf(sourcePath: string) {
+  return { sourcePath, size: 10, mtimeMs: 1, ext: 'jpg', name: 'a.jpg' };
+}
+
+function sidecarFixture(): PlanSidecar {
+  return {
+    version: 1,
+    runId: 'run1',
+    mountBase: '/mnt/src',
+    plan: {
+      items: [
+        { category: 'photos', action: 'copy', target: 'photos/a.jpg', record: recordOf('/mnt/src/dcim/a.jpg') },
+      ],
+      conflicts: [],
+    } as PlanSidecar['plan'],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  writes.length = 0;
+  applyPlanMock.mockResolvedValue({ applied: 1, photoOwners: ['shared'] });
+  resolveImmichProvisionMock.mockResolvedValue({
+    cfg: { serverUrl: 'http://127.0.0.1:2283', adminApiKey: 'k' },
+    boxUsers: [],
+  });
+  provisionExternalLibrariesMock.mockResolvedValue({ libraryIdByOwner: new Map([['shared', 'lib1']]), unmatchedUsers: [] });
+  scanLibrariesForOwnersMock.mockResolvedValue(undefined);
+});
+
+describe('rebasePlanSource', () => {
+  it('rewrites source paths from the worker mountBase to the host mountpoint', () => {
+    const plan = rebasePlanSource(sidecarFixture(), '/run/servicebay/disk-import/sda1');
+    expect(plan.items[0].record.sourcePath).toBe('/run/servicebay/disk-import/sda1/dcim/a.jpg');
+    // target / action untouched
+    expect(plan.items[0].target).toBe('photos/a.jpg');
+  });
+
+  it('leaves a non-matching source path as-is', () => {
+    const sc = sidecarFixture();
+    sc.plan.items[0].record.sourcePath = '/somewhere/else/a.jpg';
+    const plan = rebasePlanSource(sc, '/run/servicebay/disk-import/sda1');
+    expect(plan.items[0].record.sourcePath).toBe('/somewhere/else/a.jpg');
+  });
+});
+
+describe('applyImport', () => {
+  const exec = vi.fn();
+
+  it('runs applyPlan with the real exec, the HOST mountpoint, and the rebased plan', async () => {
+    await applyImport({ exec, runId: 'run1', mountpoint: '/run/servicebay/disk-import/sda1', shareGid: 1024 });
+
+    expect(applyPlanMock).toHaveBeenCalledTimes(1);
+    const [plan, opts] = applyPlanMock.mock.calls[0];
+    expect(opts.exec).toBe(exec);
+    expect(opts.mountpoint).toBe('/run/servicebay/disk-import/sda1');
+    expect(opts.shareGid).toBe(1024);
+    // the plan handed to applyPlan reads the source from the HOST mount
+    expect(plan.items[0].record.sourcePath).toBe('/run/servicebay/disk-import/sda1/dcim/a.jpg');
+  });
+
+  it('fires the Immich provision + scan for the photo owners after apply', async () => {
+    await applyImport({ exec, runId: 'run1', mountpoint: '/run/servicebay/disk-import/sda1', shareGid: 1024 });
+    expect(provisionExternalLibrariesMock).toHaveBeenCalled();
+    expect(scanLibrariesForOwnersMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Map),
+      ['shared'],
+    );
+  });
+
+  it('skips Immich when no photos were written', async () => {
+    applyPlanMock.mockResolvedValue({ applied: 1, photoOwners: [] });
+    const r = await applyImport({ exec, runId: 'run1', mountpoint: '/m', shareGid: 1024 });
+    expect(provisionExternalLibrariesMock).not.toHaveBeenCalled();
+    expect(r.immichNote).toBe('');
+  });
+
+  it('writes an applying-phase then a done-phase status.json for the tile poll', async () => {
+    await applyImport({ exec, runId: 'run1', mountpoint: '/m', shareGid: 1024 });
+    const phases = writes.map(w => (JSON.parse(w.data) as { phase: string }).phase);
+    expect(phases).toContain('applying');
+    expect(phases.at(-1)).toBe('done');
+  });
+
+  it('records an error-phase status and rethrows on a real apply failure', async () => {
+    applyPlanMock.mockRejectedValue(new Error('rsync failed (code 1)'));
+    await expect(applyImport({ exec, runId: 'run1', mountpoint: '/m', shareGid: 1024 })).rejects.toThrow('rsync failed');
+    const last = JSON.parse(writes.at(-1)!.data) as { phase: string; error: string };
+    expect(last.phase).toBe('error');
+    expect(last.error).toContain('rsync failed');
+    expect(catalogClose).toHaveBeenCalled();
+  });
+
+  it('does not fail apply when Immich provisioning throws (best-effort)', async () => {
+    provisionExternalLibrariesMock.mockRejectedValue(new Error('immich down'));
+    const r = await applyImport({ exec, runId: 'run1', mountpoint: '/m', shareGid: 1024 });
+    expect(r.applied).toBe(1);
+    expect(r.immichNote).toContain('skipped');
+  });
+});

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -1,0 +1,213 @@
+// Disk-import — HOST-side apply, run from servicebay (#1972, slice of #1949).
+//
+// THE FIX-FORWARD for "apply does nothing / rsync failed (code -1)": the worker
+// container is SANDBOXED — rsync isn't installed there, `sudo` is ignored, and the
+// host `file-share/data` isn't mounted, so its stub-exec apply could never land a
+// byte. The worker now does ONLY the heavy scan/classify/dedup/PLAN (which is the
+// OOM-prone part — feedback_control_plane_vs_worker — and stays capped). The
+// privileged host-apply runs HERE, in servicebay, where the agent's real
+// `safe_exec` runs `mkdir`/`rsync`/`chown` on the host as core (honoring `sudo`)
+// and `file-share/data` actually exists.
+//
+// This is memory-safe: the byte copy is the rsync subprocess (it streams), and
+// applyPlan already batches mkdir/chown across a chunk (#1898), so servicebay's
+// Node heap stays bounded. The control plane never re-walks/re-hashes the whole
+// disk — it reads the worker's compact plan.json + catalog sidecar from the shared
+// out dir (host `${HOST_DATA_DIR}/disk-import-runs/<runId>/`, which servicebay sees
+// in-container at `${DATA_DIR}/disk-import-runs/<runId>/`).
+//
+// SOURCE: the worker scanned at its OWN mountpoint (`mountBase`, e.g. `/mnt/src`),
+// so the plan's `record.sourcePath`s are absolute under that container path. The
+// host rsync must read the device at the HOST mountpoint servicebay mounted it at
+// (`run.mountpoint`, under MOUNT_BASE) — the same read-only mount persists from the
+// scan. We therefore REBASE every source path from `mountBase` → host mountpoint
+// before applyPlan rsyncs it. The mount stays present until apply completes; the
+// tile's "Start over" / teardown unmounts it.
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { readFile, mkdir, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  applyPlan,
+  ImportCatalog,
+  provisionExternalLibraries,
+  scanLibrariesForOwners,
+  STATUS_FILE,
+  PLAN_SIDECAR_FILE,
+  type SafeExec,
+  type PlanSidecar,
+  type WorkerStatus,
+  type ImportRecord,
+} from '@servicebay/disk-import-worker';
+
+import { DATA_DIR } from '@/lib/dirs';
+import { logger } from '@/lib/logger';
+import { resolveImmichProvision } from './immichProvisionEnv';
+
+/** Where servicebay reads the worker's out dir IN-CONTAINER (same data as the
+ *  host `${HOST_DATA_DIR}/disk-import-runs/<runId>` the worker bind-mounted). */
+export function runOutDir(runId: string): string {
+  return path.join(DATA_DIR, 'disk-import-runs', runId);
+}
+
+/** Host-side sha256 of a file's bytes (catalog row key) — mirrors the worker's
+ *  hashFileContent. Used only on size-collisions by the resume catalog. */
+function hashFileContent(record: ImportRecord): string {
+  return createHash('sha256').update(readFileSync(record.sourcePath)).digest('hex');
+}
+
+/**
+ * Rebase a plan's source paths from the worker mountBase (`/mnt/src`) to the host
+ * mountpoint, so the HOST rsync reads the real device. Returns a NEW plan (the
+ * records are shallow-cloned with the rewritten sourcePath; everything else —
+ * target, action, size — is untouched). A path that doesn't start with mountBase
+ * is left as-is (defensive; shouldn't happen for a worker-produced plan).
+ */
+export function rebasePlanSource(sidecar: PlanSidecar, hostMountpoint: string): PlanSidecar['plan'] {
+  const base = sidecar.mountBase.replace(/\/+$/, '');
+  const rebase = (p: string): string =>
+    p === base ? hostMountpoint : p.startsWith(`${base}/`) ? path.join(hostMountpoint, p.slice(base.length + 1)) : p;
+  return {
+    ...sidecar.plan,
+    items: sidecar.plan.items.map(it => ({ ...it, record: { ...it.record, sourcePath: rebase(it.record.sourcePath) } })),
+  };
+}
+
+export interface ApplyImportArgs {
+  /** servicebay's REAL agent SafeExec (runs mkdir/rsync/chown on the host as core). */
+  exec: SafeExec;
+  /** The run whose plan.json + catalog to apply. */
+  runId: string;
+  /** Host RO mountpoint of the source device (the rsync source root). */
+  mountpoint: string;
+  /** gid that owns file-share data — copies are chown'd to it, never a uid. */
+  shareGid: number;
+}
+
+export interface ApplyImportResult {
+  applied: number;
+  photoOwners: string[];
+  immichNote: string;
+}
+
+/**
+ * Read the worker's plan.json + catalog from the out dir and APPLY it on the host
+ * via applyPlan + servicebay's real exec. Streams status.json progress so the
+ * tile's poll keeps reflecting the apply (phase `applying` → `done`/`error`). On
+ * a photo-writing apply, fires the Immich External-Library provision + scan from
+ * servicebay (it owns the secret store + LLDAP). Throws on a real apply failure
+ * (so the route surfaces it) AFTER recording an `error`-phase status.
+ */
+export async function applyImport(args: ApplyImportArgs): Promise<ApplyImportResult> {
+  const { exec, runId, mountpoint, shareGid } = args;
+  const outDir = runOutDir(runId);
+
+  const sidecar = JSON.parse(await readFile(path.join(outDir, PLAN_SIDECAR_FILE), 'utf-8')) as PlanSidecar;
+  const plan = rebasePlanSource(sidecar, mountpoint);
+
+  // Resume basis: the same catalog file the worker created in the out dir. Opened
+  // in-container (better-sqlite3 is a backend dep); the out dir is the same bytes
+  // host-side.
+  const catalog = new ImportCatalog(path.join(outDir, 'catalog.sqlite'));
+
+  // Seed the status doc so the tile poll keeps ticking through the apply. We patch
+  // the worker's last status (its plan counts) rather than inventing a new one.
+  let status = await readOutStatus(outDir, runId);
+  const tick = async (patch: Partial<WorkerStatus>): Promise<void> => {
+    status = { ...status, ...patch, mode: 'apply', updatedAt: Date.now() };
+    await writeOutStatus(outDir, status);
+  };
+  await tick({ phase: 'applying', step: 'Applying plan …', applied: 0 });
+
+  try {
+    const result = await applyPlan(plan, {
+      exec,
+      mountpoint,
+      catalog,
+      shareGid,
+      hashOf: hashFileContent,
+      onProgress: p => {
+        // Fire-and-forget the progress write; a slow disk poll must not block rsync.
+        void writeOutStatus(outDir, { ...status, mode: 'apply', applied: p.copied, updatedAt: Date.now() });
+      },
+    });
+    catalog.close();
+
+    // #1904/#1954: photos written → provision + scan the owning Immich libraries
+    // from servicebay (it owns the admin key + LLDAP directory). Best-effort — the
+    // files are already on disk; a scan failure must NOT fail the import.
+    let immichNote = '';
+    if (result.photoOwners.length > 0) immichNote = await provisionImmichForOwners(result.photoOwners);
+
+    await tick({
+      phase: 'done',
+      applied: result.applied,
+      step: `Applied ${result.applied} file(s).` + (immichNote ? ` ${immichNote}` : ''),
+    });
+    return { applied: result.applied, photoOwners: result.photoOwners, immichNote };
+  } catch (e) {
+    catalog.close();
+    const message = e instanceof Error ? e.message : String(e);
+    await tick({ phase: 'error', step: 'Apply failed', error: message });
+    throw e;
+  }
+}
+
+/**
+ * Provision the per-owner Immich External Libraries and trigger the owning ones'
+ * scan after a photo-writing apply (#1954, moved into servicebay). Never throws —
+ * returns a one-line note for the status step.
+ */
+async function provisionImmichForOwners(photoOwners: string[]): Promise<string> {
+  const provision = await resolveImmichProvision();
+  if (!provision) return '';
+  try {
+    const { libraryIdByOwner } = await provisionExternalLibraries(provision.cfg, provision.boxUsers);
+    await scanLibrariesForOwners(provision.cfg, libraryIdByOwner, photoOwners);
+    return 'Immich External Libraries provisioned + scan triggered.';
+  } catch (e) {
+    logger.warn('disk-import:immich', `Immich library scan skipped: ${e instanceof Error ? e.message : String(e)}`);
+    return `Immich library scan skipped: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+/** Read the worker's last status.json, or a minimal apply-phase doc when absent. */
+async function readOutStatus(outDir: string, runId: string): Promise<WorkerStatus> {
+  try {
+    return JSON.parse(await readFile(path.join(outDir, STATUS_FILE), 'utf-8')) as WorkerStatus;
+  } catch {
+    const now = Date.now();
+    return {
+      version: 1,
+      runId,
+      phase: 'applying',
+      step: 'Applying plan …',
+      mode: 'apply',
+      scanned: 0,
+      planned: 0,
+      applied: 0,
+      conflicts: 0,
+      categories: [],
+      totalBytes: 0,
+      planSidecar: PLAN_SIDECAR_FILE,
+      error: null,
+      updatedAt: now,
+      startedAt: now,
+    };
+  }
+}
+
+/** Atomic-ish status write (tmp + rename) so a polling reader never sees a half file. */
+async function writeOutStatus(outDir: string, status: WorkerStatus): Promise<void> {
+  const file = path.join(outDir, STATUS_FILE);
+  const tmp = `${file}.tmp`;
+  try {
+    await mkdir(outDir, { recursive: true });
+    await writeFile(tmp, JSON.stringify(status), 'utf-8');
+    await rename(tmp, file);
+  } catch {
+    await writeFile(file, JSON.stringify(status), 'utf-8').catch(() => {});
+  }
+}

--- a/packages/backend/src/lib/diskImport/immichProvisionEnv.test.ts
+++ b/packages/backend/src/lib/diskImport/immichProvisionEnv.test.ts
@@ -14,7 +14,7 @@ import { loadSavedSecrets } from '@/lib/install/savedSecrets';
 import { getConfig } from '@/lib/config';
 import { listLldapUsers } from '@/lib/lldap/client';
 import { logger } from '@/lib/logger';
-import { resolveImmichProvisionEnv, IMMICH_SERVER_URL } from './immichProvisionEnv';
+import { resolveImmichProvisionEnv, resolveImmichProvision, IMMICH_SERVER_URL } from './immichProvisionEnv';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -71,5 +71,30 @@ describe('resolveImmichProvisionEnv', () => {
   it('never throws — a reconcile error yields []', async () => {
     vi.mocked(reconcileImmichApiKey).mockRejectedValue(new Error('immich down'));
     expect(await resolveImmichProvisionEnv()).toEqual([]);
+  });
+});
+
+describe('resolveImmichProvision (host-apply, #1972)', () => {
+  it('returns the resolved admin cfg + box users for the servicebay host apply', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({ IMMICH_ADMIN_API_KEY: 'k-123' });
+    vi.mocked(listLldapUsers).mockResolvedValue({
+      ok: true,
+      users: [{ id: 'mdopp', email: 'm@x' }],
+    });
+    const r = await resolveImmichProvision();
+    expect(r).toEqual({
+      cfg: { serverUrl: IMMICH_SERVER_URL, adminApiKey: 'k-123' },
+      boxUsers: [{ id: 'mdopp', email: 'm@x' }],
+    });
+  });
+
+  it('returns null when no admin key is available (graceful skip)', async () => {
+    vi.mocked(loadSavedSecrets).mockReturnValue({});
+    expect(await resolveImmichProvision()).toBeNull();
+  });
+
+  it('never throws — a reconcile error yields null', async () => {
+    vi.mocked(reconcileImmichApiKey).mockRejectedValue(new Error('immich down'));
+    expect(await resolveImmichProvision()).toBeNull();
   });
 });

--- a/packages/backend/src/lib/diskImport/immichProvisionEnv.ts
+++ b/packages/backend/src/lib/diskImport/immichProvisionEnv.ts
@@ -15,6 +15,8 @@
 // NOTHING and the worker's apply just places photos in the folder (graceful skip).
 // The key is passed via `-e` (env), never logged.
 
+import type { BoxUser, ImmichAdminConfig } from '@servicebay/disk-import-worker';
+
 import { loadSavedSecrets } from '@/lib/install/savedSecrets';
 import { getConfig } from '@/lib/config';
 import { listLldapUsers } from '@/lib/lldap/client';
@@ -24,6 +26,40 @@ import { IMMICH_ADMIN_API_KEY_VAR, reconcileImmichApiKey } from './reconcileImmi
 
 /** Immich loopback base URL on the box (host network). No trailing slash. */
 export const IMMICH_SERVER_URL = 'http://127.0.0.1:2283';
+
+/**
+ * Resolve the Immich admin config + box-user list for the HOST-side apply
+ * (#1954/#1972). The control plane owns the encrypted secret store, the seeded
+ * admin credentials, and the LLDAP directory; the post-apply Immich External
+ * Library provision/scan now runs IN servicebay (not the worker), so it resolves
+ * the same inputs HERE and uses them directly. Returns `null` when no admin key
+ * is available (Immich not installed / login rejected) — the apply then just
+ * places photos in the folder and skips the scan (graceful no-op). Never throws,
+ * never logs the key.
+ */
+export async function resolveImmichProvision(): Promise<{ cfg: ImmichAdminConfig; boxUsers: BoxUser[] } | null> {
+  try {
+    const reconcile = await reconcileImmichApiKey(IMMICH_SERVER_URL);
+    const adminApiKey = loadSavedSecrets(await getConfig())[IMMICH_ADMIN_API_KEY_VAR];
+    if (!adminApiKey) {
+      logger.warn(
+        'disk-import:immich',
+        `No Immich admin API key after reconcile (${reconcile.outcome}) — ` +
+          `the post-apply Immich library scan will be skipped: ${reconcile.message}`,
+      );
+      return null;
+    }
+    const users = await listLldapUsers();
+    const boxUsers: BoxUser[] = users.ok ? users.users.map(u => ({ id: u.id, email: u.email })) : [];
+    return { cfg: { serverUrl: IMMICH_SERVER_URL, adminApiKey }, boxUsers };
+  } catch (e) {
+    logger.warn(
+      'disk-import:immich',
+      `Skipping Immich provisioning (apply will place photos only): ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return null;
+  }
+}
 
 /**
  * Resolve the worker's Immich-provisioning env args. Reconciles (mint-once,

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -22,6 +22,7 @@ import {
 } from './launcher';
 import { listImportDevices } from './devices';
 import { setActiveRun, getActiveRun, clearActiveRun } from './runStore';
+import { applyImport, type ApplyImportResult } from './apply';
 
 export type { ImportDevice } from './launcher';
 
@@ -66,6 +67,20 @@ export async function getRunStatus(exec: SafeExec): Promise<RunStatus | null> {
   if (!run) return null;
   const [status, running] = await Promise.all([readStatus(exec, run), isWorkerRunning(exec, run)]);
   return { runId: run.runId, status, running };
+}
+
+/**
+ * Apply the active run's APPROVED plan ON THE HOST (#1972). The worker only
+ * scanned/planned (it's sandboxed — it can't do privileged host I/O); servicebay
+ * reads the worker's plan.json + catalog from the out dir and runs applyPlan with
+ * its REAL agent exec, reading the source from the HOST mountpoint the device is
+ * still mounted at. Status.json is updated through the apply so the tile poll keeps
+ * reflecting progress. Throws when there's no active run, or on a real apply error.
+ */
+export async function applyRun(exec: SafeExec, shareGid: number): Promise<ApplyImportResult> {
+  const run = await getActiveRun();
+  if (!run) throw new Error('disk-import: no active run to apply');
+  return applyImport({ exec, runId: run.runId, mountpoint: run.mountpoint, shareGid });
 }
 
 /** Stop the active worker container and forget it (the tile's "Start over"). */

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -308,10 +308,14 @@ function realIO(): WorkerIO {
     writeStatus: (out, status) => writeJson(path.join(out, STATUS_FILE), status),
     writePlanSidecar: (out, sidecar) => writeJson(path.join(out, PLAN_SIDECAR_FILE), sidecar),
     makeExec: opts => {
-      // The worker runs host-apply commands locally inside the container against
-      // the bind-mounted out-volume — a plain child_process SafeExec. (Wiring the
-      // real privileged host-apply path is #1954.) spawnSync is statically
-      // imported at the top of this ESM module — there is no `require` global here.
+      // PRODUCTION DOES NOT USE THIS. The worker is sandboxed — rsync isn't
+      // installed, `sudo` is ignored, and the host file-share isn't mounted — so a
+      // host apply can't land a byte here (it failed with "rsync failed (code -1)").
+      // The real privileged host apply now runs in SERVICEBAY over the host mount
+      // (#1972: packages/backend/src/lib/diskImport/apply.ts); serve mode no longer
+      // launches an `--apply` child. This stub child_process SafeExec only backs the
+      // standalone `--apply` CLI for tests. spawnSync is statically imported at the
+      // top of this ESM module — there is no `require` global here.
       void opts;
       return (argv: string[]) => {
         const r = spawnSync(argv[0], argv.slice(1), { encoding: 'utf8' });

--- a/packages/disk-import-worker/src/server/appHtml.ts
+++ b/packages/disk-import-worker/src/server/appHtml.ts
@@ -61,8 +61,10 @@ The scan runs in its own resource-capped container — it can't slow down the bo
   <p class="muted">Each folder shows its whole contents. Expand to drill in — only the
   level you open is loaded, so even a huge disk stays responsive.</p>
   <div id="tree"></div>
-  <div class="row" style="margin-top:1rem">
-    <button id="apply">Confirm &amp; import</button>
+  <p class="muted" style="margin-top:1rem">Reviewed everything? Go back to the
+  <strong>Import data from a disk</strong> page in ServiceBay and press
+  <strong>Import now</strong> to copy the files into your library.</p>
+  <div class="row" style="margin-top:.5rem">
     <button id="cancel" class="secondary">Start over</button>
   </div>
 </section>
@@ -155,17 +157,12 @@ function nodeRow(node, depth) {
   return wrap;
 }
 
-async function apply() {
-  showError(''); $('apply').disabled = true;
-  const r = await fetch('api/apply', { method: 'POST', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ device: lastDevice }) });
-  if (!r.ok) { showError('Import failed to start'); $('apply').disabled = false; return; }
-  $('review').hidden = true; $('progress').hidden = false; poll();
-}
+// APPLY runs in ServiceBay over the host mount (#1972), NOT in this sandboxed
+// worker — so there is no apply button here; the review tree is the confirm
+// surface and "Import now" lives on the control-plane tile.
 
 $('refresh').onclick = loadDevices;
 $('scan').onclick = startScan;
-$('apply').onclick = apply;
 $('cancel').onclick = () => location.reload();
 loadDevices();
 </script>

--- a/packages/disk-import-worker/src/server/index.ts
+++ b/packages/disk-import-worker/src/server/index.ts
@@ -29,8 +29,8 @@ export interface ServeOptions {
   shareGid: number;
 }
 
-/** Spawn the one-shot worker CLI as a detached child for a scan/apply pass. */
-function launchWorkerChild(opts: ServeOptions, mode: 'dry-run' | 'apply'): void {
+/** Spawn the one-shot worker CLI as a detached child for a DRY-RUN scan pass. */
+function launchWorkerChild(opts: ServeOptions): void {
   const cliEntry = path.join(moduleDir(), '..', 'cli', 'main.ts');
   const args = [
     'tsx', cliEntry,
@@ -38,7 +38,6 @@ function launchWorkerChild(opts: ServeOptions, mode: 'dry-run' | 'apply'): void 
     '--out', opts.out,
     '--run-id', opts.runId,
     '--share-gid', String(opts.shareGid),
-    ...(mode === 'apply' ? ['--apply', '--catalog', path.join(opts.out, 'catalog.sqlite')] : []),
   ];
   const child = spawn('npx', args, { stdio: 'inherit', detached: true });
   child.unref();
@@ -51,7 +50,13 @@ export function serveDeps(opts: ServeOptions): ServerDeps {
     readJson: fileReader(opts.out),
     // The device is pre-mounted by servicebay; the picker shows the one disk.
     listDevices: async () => [{ path: opts.mount, display: 'Imported disk' }],
-    launchJob: async mode => launchWorkerChild(opts, mode),
+    // The worker only SCANS/PLANS (it's sandboxed — no privileged host I/O, no
+    // rsync, no host file-share mount). APPLY runs in servicebay over the host
+    // mount (#1972), so serve mode never launches the stub `--apply` child:
+    // `apply` is a no-op here and the control plane drives the real host apply.
+    launchJob: async mode => {
+      if (mode === 'dry-run') launchWorkerChild(opts);
+    },
   };
 }
 

--- a/packages/disk-import-worker/src/server/server.ts
+++ b/packages/disk-import-worker/src/server/server.ts
@@ -10,9 +10,12 @@
 //   GET  /                 → the self-contained lazy-tree SPA (one HTML file)
 //   GET  /api/devices      → removable partitions to pick from
 //   POST /api/scan         → launch a dry-run scan job (writes status.json)
-//   POST /api/apply        → launch an --apply job
 //   GET  /api/status       → the COMPACT status.json (poll target)
 //   GET  /api/tree?dir=…   → ONE directory's immediate children (lazy fetch)
+//
+// There is NO /api/apply here: the worker is sandboxed (no rsync, no `sudo`, no
+// host file-share mount), so it can't land a byte. APPLY runs in SERVICEBAY over
+// the host mount (#1972); this container only scans/plans + serves the review.
 //
 // Auth is NOT handled here — the container sits behind the existing NPM +
 // Authelia forward-auth (admin-gated), exactly like every other service UI, so
@@ -38,8 +41,9 @@ export interface ServerDeps {
   readJson: <T>(file: string) => Promise<T | null>;
   /** List removable partitions for the device picker. */
   listDevices: () => Promise<Array<{ path: string; display: string }>>;
-  /** Launch a heavy job (dry-run or apply) as a detached child. */
-  launchJob: (mode: 'dry-run' | 'apply', device: string) => Promise<void>;
+  /** Launch the heavy DRY-RUN scan/plan job as a detached child. (Apply runs in
+   *  servicebay over the host mount, #1972 — never in this sandboxed worker.) */
+  launchJob: (mode: 'dry-run', device: string) => Promise<void>;
 }
 
 /** JSON response helper. */
@@ -83,12 +87,11 @@ async function handleTree(deps: ServerDeps, url: URL, res: ServerResponse): Prom
   sendJson(res, 200, level);
 }
 
-/** POST /api/scan|/api/apply → launch the heavy job. */
+/** POST /api/scan → launch the heavy dry-run scan/plan job. */
 async function handleLaunch(
   deps: ServerDeps,
   req: IncomingMessage,
   res: ServerResponse,
-  mode: 'dry-run' | 'apply',
 ): Promise<void> {
   const body = await readBody(req);
   const device = typeof body.device === 'string' ? body.device : '';
@@ -96,7 +99,7 @@ async function handleLaunch(
     sendJson(res, 400, { error: 'device is required' });
     return;
   }
-  await deps.launchJob(mode, device);
+  await deps.launchJob('dry-run', device);
   sendJson(res, 202, { ok: true });
 }
 
@@ -130,8 +133,8 @@ export async function handleRequest(deps: ServerDeps, req: IncomingMessage, res:
     if (req.method === 'GET') {
       const handled = getRoute(deps, url, res);
       if (handled) return await handled;
-    } else if (req.method === 'POST' && (url.pathname === '/api/scan' || url.pathname === '/api/apply')) {
-      return await handleLaunch(deps, req, res, url.pathname === '/api/apply' ? 'apply' : 'dry-run');
+    } else if (req.method === 'POST' && url.pathname === '/api/scan') {
+      return await handleLaunch(deps, req, res);
     }
     sendJson(res, 404, { error: 'not found' });
   } catch (e) {

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -26,6 +26,7 @@ interface RunStatus {
     step: string;
     scanned: number;
     planned: number;
+    applied: number;
     conflicts: number;
     error: string | null;
   } | null;
@@ -56,6 +57,18 @@ function useDevices() {
   return { devices, loading, refresh };
 }
 
+/** POST a disk-import action, surfacing `{error}` on failure. Shared by scan +
+ *  apply so the hook stays thin. Returns the failure message, or '' on success. */
+async function postAction(path: string, body?: unknown): Promise<string> {
+  const r = await fetch(path, {
+    method: 'POST',
+    ...(body !== undefined ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) } : {}),
+  });
+  if (r.ok) return '';
+  const d = (await r.json().catch(() => ({}))) as { error?: string };
+  return d.error || 'Request failed';
+}
+
 /** Poll the active worker run + expose launch/abort. Kept out of the component
  *  so the page stays a thin render container. */
 function useDiskImportRun(selected: string, onAfterAbort: () => void) {
@@ -79,24 +92,18 @@ function useDiskImportRun(selected: string, onAfterAbort: () => void) {
     };
   }, []);
 
-  const launch = async () => {
-    if (!selected) return setError('Pick a USB disk first');
+  const runAction = async (path: string, body?: unknown) => {
     setError('');
     setLaunching(true);
     try {
-      const r = await fetch('/api/system/disk-import/scan', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device: selected }),
-      });
-      if (!r.ok) {
-        const d = (await r.json().catch(() => ({}))) as { error?: string };
-        setError(d.error || 'Could not launch the import worker');
-      }
+      setError(await postAction(path, body));
     } finally {
       setLaunching(false);
     }
   };
+
+  const launch = () =>
+    selected ? runAction('/api/system/disk-import/scan', { device: selected }) : setError('Pick a USB disk first');
 
   const startOver = async () => {
     await fetch('/api/system/disk-import/abort', { method: 'POST' }).catch(() => {});
@@ -104,18 +111,27 @@ function useDiskImportRun(selected: string, onAfterAbort: () => void) {
     onAfterAbort();
   };
 
-  return { run, launching, error, launch, startOver };
+  // APPLY runs on the HOST in servicebay (#1972) — the sandboxed worker only
+  // scanned/planned. POST kicks off the privileged host apply; the status poll
+  // then reflects the `applying` → `done` phase the backend writes.
+  const apply = () => runAction('/api/system/disk-import/apply');
+
+  return { run, launching, error, launch, startOver, apply };
 }
 
 export default function DiskImportPage() {
   const { devices, loading, refresh } = useDevices();
   const [selected, setSelected] = useState('');
-  const { run, launching, error, launch, startOver } = useDiskImportRun(selected, () => {
+  const { run, launching, error, launch, startOver, apply } = useDiskImportRun(selected, () => {
     setSelected('');
     refresh();
   });
 
   const active = run?.running || (run?.status && run.status.phase !== 'done' && run.status.phase !== 'error');
+  // The dry-run scan finished (worker is gone, phase `done`) and there's a plan to
+  // apply — offer the host-apply action (#1972). The apply itself runs in
+  // servicebay; the status poll then shows the `applying` phase the backend writes.
+  const planReady = !run?.running && run?.status?.phase === 'done' && (run.status.planned ?? 0) > 0;
 
   return (
     <div className="p-6 max-w-2xl space-y-4 overflow-auto">
@@ -136,6 +152,13 @@ export default function DiskImportPage() {
 
       {active ? (
         <WorkerProgress run={run!} onStartOver={() => void startOver()} />
+      ) : planReady ? (
+        <PlanReady
+          run={run!}
+          applying={launching}
+          onApply={() => void apply()}
+          onStartOver={() => void startOver()}
+        />
       ) : (
         <DevicePicker
           devices={devices}
@@ -180,6 +203,51 @@ function WorkerProgress({ run, onStartOver }: { run: RunStatus; onStartOver: () 
         className="block text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 inline-flex items-center gap-1"
       >
         <RefreshCw size={12} /> Stop and start over
+      </button>
+    </div>
+  );
+}
+
+/** Scan/plan complete — review out in the worker app, then APPLY on the host. */
+function PlanReady({
+  run,
+  applying,
+  onApply,
+  onStartOver,
+}: {
+  run: RunStatus;
+  applying: boolean;
+  onApply: () => void;
+  onStartOver: () => void;
+}) {
+  const s = run.status!;
+  return (
+    <div className="space-y-3 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+      <p className="text-sm text-gray-800 dark:text-gray-200">
+        Scan complete — {s.planned} file(s) planned{s.conflicts ? `, ${s.conflicts} conflict(s)` : ''}.
+      </p>
+      <a
+        href={WORKER_APP_PATH}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+      >
+        <ExternalLink size={14} /> Review the plan
+      </a>
+      <div>
+        <button
+          onClick={onApply}
+          disabled={applying}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+        >
+          {applying && <Loader2 size={14} className="animate-spin" />} <Download size={14} /> Import now
+        </button>
+      </div>
+      <button
+        onClick={onStartOver}
+        className="block text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 inline-flex items-center gap-1"
+      >
+        <RefreshCw size={12} /> Start over
       </button>
     </div>
   );

--- a/packages/frontend/src/app/api/system/disk-import/apply/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/apply/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { applyRun } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { makeExec, resolveNode, SHARE_GID } from '../wiring';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST — APPLY the active run's approved plan ON THE HOST (#1972). The worker only
+ * scanned/planned (it's sandboxed); servicebay reads the worker's plan.json +
+ * catalog from the out dir and runs the privileged host apply (mkdir/rsync/chown
+ * over the still-mounted device) with its real agent exec, then provisions +
+ * scans the owning Immich External Libraries for any photos written. The byte
+ * copy is the rsync subprocess (streams) and mkdir/chown are batched, so the
+ * control-plane heap stays bounded. Status.json reflects apply progress for the
+ * tile poll.
+ */
+export const POST = withApiHandler(
+  { tokenScope: 'mutate' },
+  async () => {
+    try {
+      const node = resolveNode();
+      const result = await applyRun(makeExec(node), SHARE_GID);
+      return NextResponse.json({ ok: true, ...result });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:apply', status: 400, exposeMessage: true });
+    }
+  },
+);


### PR DESCRIPTION
## Disk-import: run APPLY on the host, not the sandboxed worker

Final fix in the disk-import end-to-end chain. The worker container does the heavy, capped **scan → classify → dedup → PLAN** (memory-safe, `--memory=1g`); but **APPLY** (mkdir/rsync/chown into `file-share/data/<category>` + Immich external-library provisioning) needs host privilege and a writable destination mount — which the sandboxed rootless worker does not have. APPLY inside the worker failed with `rsync failed (code -1)` (no rsync, no host dest mount, no privilege). It was a stub deferred as #1954; this wires it up properly.

### What changed
- **`packages/backend/src/lib/diskImport/apply.ts`** (new) — host-side apply. Reads the worker's `plan.json` + `catalog.sqlite` from `${DATA_DIR}/disk-import-runs/<runId>/`, rebases each `record.sourcePath` from the worker mount base (`/mnt/src`) to the host RO mountpoint, then runs the worker's `applyPlan` with servicebay's real agent `SafeExec` (mkdir/rsync/chown as `core`, sudo honored). Memory-safe: rsync streams, mkdir/chown batched (#1898).
- **`apply/route.ts`** (new) — the `/api/system/disk-import/apply` endpoint.
- **`service.ts`** — `applyRun` routes to `applyImport`.
- **`immichProvisionEnv.ts`** — `resolveImmichProvision()` returns structured admin cfg + box users (admin-email fallback from `config.notifications.email.to[0]`; loud warning instead of silent `[]`).
- **Worker serve-mode is now dry-run only** — `/api/apply` removed from the in-container server; the SPA directs the user to "Import now" on the tile. `--apply` CLI kept for tests.
- **`disk-import/page.tsx`** — "Import now" action calls the host-apply endpoint.
- Backend now depends on `@servicebay/disk-import-worker` as a workspace dep.

### Verification owed
Path-mandated (import critical path) → `box_verify=owed`. The on-box re-test must show files **actually landing** in `file-share/data/{photos,music,documents,audiobooks}` and a photo appearing in Immich — not just "container launched".

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
