### PR TITLE
fix(disk-import): chown imported files to core:<real file-share gid>, not :1024

### DIFF
--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -21,12 +21,16 @@ vi.mock('./runStore', () => ({
   clearActiveRun: vi.fn(async () => undefined),
 }));
 
-import { applyRun } from './service';
+import { applyRun, resolveShareGid } from './service';
 import { applyImport } from './apply';
 import { cleanupRunMount } from './launcher';
 import { getActiveRun, clearActiveRun } from './runStore';
 
-const exec = (() => undefined) as unknown as SafeExec;
+/** A SafeExec that reports the file-share data dir is owned by `gid`. */
+function statExec(gid: number): SafeExec {
+  return (async () => ({ stdout: `${gid}\n`, stderr: '', code: 0 })) as unknown as SafeExec;
+}
+const exec = statExec(973);
 const RUN = { runId: 'r1', outDir: '/o', container: 'c', device: '/dev/sdb1', mountpoint: '/run/servicebay/disk-import/sdb1' };
 
 describe('applyRun teardown (#1982)', () => {
@@ -39,6 +43,9 @@ describe('applyRun teardown (#1982)', () => {
     const result = await applyRun(exec, 1000);
 
     expect(result).toEqual({ copied: 3 });
+    // The apply runs against the REAL host-resolved file-share gid (973), NOT the
+    // 1000 fallback the route passed in.
+    expect(vi.mocked(applyImport).mock.calls[0]![0]).toMatchObject({ shareGid: 973 });
     expect(cleanupRunMount).toHaveBeenCalledWith(exec, RUN);
     expect(clearActiveRun).toHaveBeenCalledOnce();
   });
@@ -58,5 +65,37 @@ describe('applyRun teardown (#1982)', () => {
     await expect(applyRun(exec, 1000)).rejects.toThrow('no active run');
     expect(applyImport).not.toHaveBeenCalled();
     expect(cleanupRunMount).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveShareGid — real file-share group, not the 1024 fallback', () => {
+  it('stats the file-share data dir and returns its actual gid (973), not the fallback', async () => {
+    const calls: string[][] = [];
+    const exec973: SafeExec = (async (argv: string[]) => {
+      calls.push(argv);
+      return { stdout: '973\n', stderr: '', code: 0 };
+    }) as unknown as SafeExec;
+
+    const gid = await resolveShareGid(exec973, 1024);
+
+    expect(gid).toBe(973);
+    expect(gid).not.toBe(1024);
+    // Resolved by `stat -c %g` on the file-share share root (host-side).
+    expect(calls[0]).toEqual(['stat', '-c', '%g', '/mnt/data/stacks/file-share/data']);
+  });
+
+  it('falls back only when stat exits non-zero (share not deployed yet)', async () => {
+    const execFail: SafeExec = (async () => ({ stdout: '', stderr: 'no such file', code: 1 })) as unknown as SafeExec;
+    expect(await resolveShareGid(execFail, 1024)).toBe(1024);
+  });
+
+  it('falls back when stat emits a non-numeric gid', async () => {
+    const execJunk: SafeExec = (async () => ({ stdout: 'nope\n', stderr: '', code: 0 })) as unknown as SafeExec;
+    expect(await resolveShareGid(execJunk, 1024)).toBe(1024);
+  });
+
+  it('falls back when exec throws, never propagating', async () => {
+    const execThrow: SafeExec = (async () => { throw new Error('agent down'); }) as unknown as SafeExec;
+    expect(await resolveShareGid(execThrow, 1024)).toBe(1024);
   });
 });

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -9,7 +9,9 @@
 // tile's API routes call.
 
 import type { SafeExec } from '@servicebay/disk-import-worker';
-import type { WorkerStatus } from '@servicebay/disk-import-worker';
+import { SHARE_DATA_ROOT, type WorkerStatus } from '@servicebay/disk-import-worker';
+
+import { logger } from '@/lib/logger';
 
 import {
   launchWorker,
@@ -33,6 +35,33 @@ export async function getImportDevices(exec: SafeExec): Promise<ImportDevice[]> 
 }
 
 /**
+ * Resolve the REAL gid that owns file-share's data dir, host-side, by `stat`ing
+ * {@link SHARE_DATA_ROOT} (the same way `ensureSambaPosixUser` resolves the share
+ * owner — `stat -c %g`). Imported files are chown'd to `core:<this gid>`, so it
+ * MUST be the actual file-share group (973 on the box), not the stale 1024
+ * fallback the route hard-codes — a wrong gid leaves the files in an unnamed
+ * group the containers can't read. Falls back to `fallbackGid` only when the
+ * stat can't produce a non-negative integer (share not deployed yet / unexpected
+ * output); never throws.
+ */
+export async function resolveShareGid(exec: SafeExec, fallbackGid: number): Promise<number> {
+  try {
+    const { stdout, code } = await exec(['stat', '-c', '%g', SHARE_DATA_ROOT]);
+    if (code === 0) {
+      const parsed = Number.parseInt(stdout.trim(), 10);
+      if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+    }
+    logger.warn(
+      'DiskImport',
+      `resolveShareGid: \`stat -c %g ${SHARE_DATA_ROOT}\` gave ${JSON.stringify(stdout.trim())} (exit ${code}) — using fallback ${fallbackGid}`,
+    );
+  } catch (e) {
+    logger.warn('DiskImport', `resolveShareGid: stat failed — using fallback ${fallbackGid}`, e);
+  }
+  return fallbackGid;
+}
+
+/**
  * Launch a worker container to scan `device` (read-only). Pulls the worker image
  * if absent, mounts the device, runs the container detached, and persists the run
  * handle so a reopened tile re-attaches. Returns the run id; the worker app is
@@ -45,11 +74,15 @@ export async function launchScan(args: {
 }): Promise<{ runId: string }> {
   const runId = randomRunId();
   await ensureWorkerImage(args.exec);
+  // Resolve the REAL file-share group gid host-side (the passed `shareGid` is only
+  // the fallback) so the worker's apply chowns to `core:<file-share gid>`, never
+  // the stale 1024 fallback (feedback_fileshare_relabel_crashloop).
+  const shareGid = await resolveShareGid(args.exec, args.shareGid);
   // launchWorker resolves the HOST data dir itself (env → self-inspect via the
   // mounted podman socket → conventional default): the worker's out dir is
   // created + bind-mounted host-side via `podman run`, so it must be the box path
   // (/mnt/data/servicebay), never the in-container /app/data (read-only on host).
-  const run = await launchWorker({ ...args, runId });
+  const run = await launchWorker({ ...args, shareGid, runId });
   await setActiveRun(run);
   return { runId: run.runId };
 }
@@ -81,7 +114,13 @@ export async function getRunStatus(exec: SafeExec): Promise<RunStatus | null> {
 export async function applyRun(exec: SafeExec, shareGid: number): Promise<ApplyImportResult> {
   const run = await getActiveRun();
   if (!run) throw new Error('disk-import: no active run to apply');
-  const result = await applyImport({ exec, runId: run.runId, mountpoint: run.mountpoint, shareGid });
+  // Resolve the REAL file-share group gid host-side — the passed `shareGid` is the
+  // fallback. The apply chowns every copied file to `core:<this gid>`; a wrong gid
+  // (the 1024 fallback) leaves files in an unnamed group the containers can't read
+  // AND risks a non-core stray crash-looping file-share on its next redeploy
+  // (feedback_fileshare_relabel_crashloop).
+  const realGid = await resolveShareGid(exec, shareGid);
+  const result = await applyImport({ exec, runId: run.runId, mountpoint: run.mountpoint, shareGid: realGid });
   // Apply succeeded — unmount the source device and forget the run (#1982) so the
   // USB doesn't leak a mount and a reopened tile lands on the picker, not a stale
   // "active run". Both are best-effort/idempotent (cleanupRunMount ignores

--- a/packages/disk-import-worker/src/engine/plan.test.ts
+++ b/packages/disk-import-worker/src/engine/plan.test.ts
@@ -138,7 +138,7 @@ describe('resolveTargetPath — owner prefix + merge/parallel (#1913)', () => {
 });
 
 describe('applyPlan — copy + chown', () => {
-  it('rsyncs from the read-only mount into file-share/data and chowns to the share gid only', async () => {
+  it('rsyncs from the read-only mount into file-share/data and chowns to core:<share gid>', async () => {
     const { exec, calls, opts } = mockExec();
     const catalog = new ImportCatalog(':memory:');
     const res = await applyPlan(planOf(item()), baseOpts(exec, catalog, hashConst('a'.repeat(64))));
@@ -155,9 +155,14 @@ describe('applyPlan — copy + chown', () => {
     expect(rsync[3].startsWith('/mnt/data/stacks/file-share/data/')).toBe(true);
 
     const chown = calls.find(c => c[0] === 'chown')!;
-    expect(chown).toEqual(['chown', `:${GID}`, dest]); // group only, never uid, never -R
+    // owner=core + group=share gid — files must end up core-owned (rsync runs via
+    // sudo → would be root otherwise; a non-core stray crash-loops file-share's
+    // :Z relabel). Never -R, never a per-user uid.
+    expect(chown).toEqual(['chown', `core:${GID}`, dest]);
     expect(chown).not.toContain('-R');
-    expect(chown[1]).toMatch(/^:\d+$/);
+    expect(chown[1]).toBe(`core:${GID}`);
+    expect(chown[1]).toMatch(/^core:\d+$/);
+    expect(chown[1].startsWith('root')).toBe(false);
 
     // The /mnt/data writes all run privileged (#1713): mkdir, rsync, chown.
     expect(sudoFor(calls, opts, 'mkdir')).toBe(true);
@@ -199,9 +204,9 @@ describe('applyPlan — batched mkdir/chown (#1898)', () => {
     expect(mkdirs).toHaveLength(1);
     expect(chowns).toHaveLength(1);
     expect(rsyncs).toHaveLength(n);
-    // The single chown carries every dest, group-only, never -R.
+    // The single chown carries every dest, owner=core + group=share gid, never -R.
     expect(chowns[0][0]).toBe('chown');
-    expect(chowns[0][1]).toBe(`:${GID}`);
+    expect(chowns[0][1]).toBe(`core:${GID}`);
     expect(chowns[0]).not.toContain('-R');
     expect(chowns[0].slice(2)).toEqual(items.map(i => resolveShareTarget(i.target!)));
     // The single mkdir -p carries the (deduped) dest dir.

--- a/packages/disk-import-worker/src/engine/plan.ts
+++ b/packages/disk-import-worker/src/engine/plan.ts
@@ -14,8 +14,11 @@
 //   - conflict    → the superseded version is MOVED to
 //                    `file-share/data/_superseded/<date>/<target>` (nothing is
 //                    deleted), then the newer file is copied in.
-//   - ownership   → each copied file is `chown`ed to the share gid so the
-//                    containers can read it.
+//   - ownership   → each copied file is `chown`ed to `core:<share gid>` so it is
+//                    core-owned (rsync runs via sudo, which would leave it
+//                    root-owned — a non-core stray under file-share's `:Z` data
+//                    dir crash-loops the stack, feedback_fileshare_relabel_crashloop)
+//                    and group-readable by the containers.
 //   - catalog     → every done file is upserted into the catalog, which makes
 //                    the whole apply RESUMABLE: an interrupted run re-runs and
 //                    skips anything already cataloged (same sha+target).
@@ -86,8 +89,9 @@ export interface ApplyOptions {
   catalog: ImportCatalog;
   /**
    * Numeric gid that owns existing `file-share/data` content (rootless-podman
-   * subgid). Copied files are `chown :<gid>` so containers can read them. Must
-   * be a non-negative integer — never a name, never arbitrary uid:gid.
+   * subgid). Copied files are `chown core:<gid>` (core owner + share group) so
+   * they stay core-owned (no root strays) and containers can read them. Must be a
+   * non-negative integer — never a name, never an arbitrary uid:gid pair.
    */
   shareGid: number;
   /**
@@ -114,7 +118,7 @@ export interface ApplyOptions {
  * How many copied files to group into one batched `mkdir`/`chown` flush (#1898).
  * The apply pass used to issue THREE sudo agent round-trips per copied file
  * (`mkdir -p`, `rsync`, `chown`); now the dir-creation and ownership are batched
- * across a chunk (`mkdir -p <dirs…>`, `chown :gid <files…>`) so a big disk no
+ * across a chunk (`mkdir -p <dirs…>`, `chown core:gid <files…>`) so a big disk no
  * longer costs one mkdir + one chown round-trip per file. rsync stays per-file
  * (one byte-copy invocation each) so the catalog row — the resume marker — is
  * only written once a file is fully copied AND chowned.
@@ -294,7 +298,7 @@ async function classifyItem(
 /**
  * Flush a batch of queued copies: one `mkdir -p <dirs…>` for the union of
  * destination dirs, one `rsync` per file (the byte copy — kept per-file so the
- * resume marker tracks exactly which files landed), then one `chown :gid
+ * resume marker tracks exactly which files landed), then one `chown core:gid
  * <files…>` + catalog over the files that successfully copied. A file is
  * cataloged ONLY after it is copied AND chowned, so an interrupted run re-copies
  * AND re-chowns anything not yet cataloged — resume semantics are unchanged. If
@@ -334,15 +338,20 @@ async function copyBatch(
 }
 
 /**
- * chown (group-only) + catalog the files that successfully rsync'd this batch.
+ * chown (owner + group) + catalog the files that successfully rsync'd this batch.
  * Runs even when a mid-batch rsync threw, so every fully-copied file is marked
  * done before the error propagates (resume skips it next pass).
  */
 async function finalizeCopied(copied: CopyJob[], ctx: ItemCtx): Promise<void> {
   if (copied.length === 0) return;
-  // chown to the share GID ONLY (`:<gid>` leaves uid untouched; never recursive,
-  // never an arbitrary path).
-  await runOk(ctx.exec, ['chown', `:${ctx.shareGid}`, ...copied.map(j => j.dest)], 'chown', { sudo: true });
+  // chown to `core:<shareGid>` — owner AND group. rsync runs via `sudo` so the
+  // copied file would otherwise land root-owned; a non-`core`-owned stray under
+  // file-share's `:Z` data dir crash-loops the stack on the next redeploy
+  // (feedback_fileshare_relabel_crashloop — data/ must stay core-owned).
+  // `<shareGid>` is the REAL file-share group (resolved host-side, not the 1024
+  // fallback) so the containers can read it. Never recursive, never an arbitrary
+  // path — every dest is resolved under file-share/data/.
+  await runOk(ctx.exec, ['chown', `core:${ctx.shareGid}`, ...copied.map(j => j.dest)], 'chown', { sudo: true });
   for (const job of copied) {
     // The catalog row needs the content sha as its key. For a fresh-target copy we
     // didn't hash during classification (no collision), so resolve it NOW on the

--- a/packages/frontend/src/app/api/system/disk-import/wiring.ts
+++ b/packages/frontend/src/app/api/system/disk-import/wiring.ts
@@ -11,9 +11,12 @@ import { AgentExecutor } from '@/lib/agent/executor';
 import { getNodeIds } from '@/lib/store/repository';
 import type { SafeExec } from '@servicebay/disk-import-worker';
 
-/** Numeric gid that owns file-share data (rootless-podman subgid). The worker's
- *  apply chowns copies to this gid — never a per-user uid
- *  (feedback_fileshare_relabel_crashloop). */
+/** FALLBACK gid for file-share data, used ONLY when the real gid can't be
+ *  resolved host-side. The service layer resolves the ACTUAL file-share group
+ *  (`stat -c %g` on the share data dir — 973 on the box) at launch/apply time and
+ *  chowns copies to `core:<that gid>`, never a per-user uid
+ *  (feedback_fileshare_relabel_crashloop). This constant is the last-resort
+ *  default for a not-yet-deployed share, not the value normally used. */
 export const SHARE_GID = 1024;
 
 /** Resolve the node the host commands run on (the first/only node by default). */


### PR DESCRIPTION
## Disk-import: chown imported files to `core:<real file-share gid>`, not `:1024`

Follow-up to the green 4.129.1 import verify (#1985). Files copy correctly, but the on-box test found they land **`root:gid1024` mode 0755** instead of core-owned with the file-share group. Two defects:

1. **Owner was `root`** (copy runs via sudo → inherits root). Non-`core`-owned strays under a stack's `:Z` data dir can crash-loop the file-share stack on the next reboot/redeploy (the file-share relabel trap). Apply now ends with files owned by `core`.
2. **Group was unnamed `gid 1024`**, a stale fallback — not the real file-share group. The `shareGid` is now resolved from the actual file-share group rather than defaulting to 1024.

### Changes
- `engine/plan.ts` `applyPlan` — `chown` now sets **both** owner and group (`core:${shareGid}`), still batched, sudo.
- `diskImport/service.ts` + `api/.../disk-import/wiring.ts` — resolve `shareGid` from the real file-share group, not the 1024 fallback.
- Tests assert the chown target is `core:<shareGid>` and that shareGid resolution picks the file-share group.

### Verification owed
`gate:verify` — the on-box re-test must confirm imported files land `core:973` and a file-share redeploy after an import does not crash-loop.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
