### PR TITLE
chore(deps): ignore jlaffaye/ftp >=0.2.1 (needs Go 1.26, declined #1801)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # jlaffaye/ftp v0.2.1+ declares `go 1.26`; tools/sb stays on Go 1.24, so
+      # taking it would force a toolchain bump. Declined (#1801) — pin to 0.2.0
+      # until the Go toolchain is intentionally bumped, then drop this ignore.
+      - dependency-name: "github.com/jlaffaye/ftp"
+        versions: [">=0.2.1"]
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
ftp v0.2.1 declares `go 1.26`; `tools/sb` stays on Go 1.24, so the bump would force a toolchain upgrade. Operator declined — pin ftp at 0.2.0 via a Dependabot ignore until the Go toolchain is intentionally bumped (then drop the ignore).

Dependabot PR #1801 closed with the same rationale.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._