### PR TITLE
fix(disk-import): scan no longer times out — skip redundant image pull, longer mount timeout

### DIFF
--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/hostDataDir', () => ({
   resolveHostDataDir: vi.fn(async () => '/data'),
 }));
 
-import { launchWorker, readStatus, isWorkerRunning, stopWorker, cleanupRunMount, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
+import { launchWorker, readStatus, isWorkerRunning, stopWorker, cleanupRunMount, ensureWorkerImage, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
 import { resolveImmichProvisionEnv } from './immichProvisionEnv';
 import type { SafeExec } from '@servicebay/disk-import-worker';
 
@@ -98,6 +98,18 @@ describe('launchWorker', () => {
     expect(calls.some(c => c[0] === 'mount')).toBe(true);
   });
 
+  it('mounts a real disk with a generous timeout, not the agent 30s default', async () => {
+    // A large/USB ext4 can take >30s to mount (spin-up, journal recovery); the
+    // mount must override the agent default or the scan times out before launch.
+    let mountOpts: { timeoutMs?: number } | undefined;
+    const exec: SafeExec = vi.fn(async (argv: string[], options?: { timeoutMs?: number; sudo?: boolean }) => {
+      if (argv[0] === 'mount') mountOpts = options;
+      return { stdout: '', stderr: '', code: 0 };
+    });
+    await launchWorker({ exec, device: '/dev/sda1', runId: 'tmo', shareGid: 1024 });
+    expect(mountOpts?.timeoutMs).toBeGreaterThanOrEqual(120_000);
+  });
+
   it('injects the resolved Immich provisioning env into the container (#1954)', async () => {
     vi.mocked(resolveImmichProvisionEnv).mockResolvedValueOnce([
       '-e', 'IMMICH_SERVER_URL=http://127.0.0.1:2283',
@@ -170,6 +182,35 @@ describe('stopWorker', () => {
     const { exec, calls } = recExec({ 'podman rm': { code: 1 } });
     await stopWorker(exec, run);
     expect(calls).toContainEqual(['umount', '-A', '/dev/sda1']);
+  });
+});
+
+describe('ensureWorkerImage', () => {
+  // Regression: re-pulling on every scan blew the agent's 30s timeout while a
+  // ~50s `podman pull` ran ("Agent request timeout (safe_exec after 30000ms)"),
+  // so the scan never reached the mount. When the image is already present we
+  // must NOT pull on the hot path.
+  it('does NOT pull when the image already exists', async () => {
+    const { exec, calls } = recExec({ 'podman image exists': { code: 0 } });
+    await ensureWorkerImage(exec);
+    expect(calls).toContainEqual(['podman', 'image', 'exists', WORKER_IMAGE]);
+    expect(calls.some(c => c[0] === 'podman' && c[1] === 'pull')).toBe(false);
+  });
+
+  it('pulls only when the image is missing', async () => {
+    const { exec, calls } = recExec({ 'podman image exists': { code: 1 } });
+    await ensureWorkerImage(exec);
+    expect(calls).toContainEqual(['podman', 'pull', WORKER_IMAGE]);
+  });
+
+  it('passes a generous timeout to the cold pull (default 30s is too short)', async () => {
+    const optsSeen: Array<{ timeoutMs?: number } | undefined> = [];
+    const exec: SafeExec = vi.fn(async (argv: string[], options?: { timeoutMs?: number; sudo?: boolean }) => {
+      if (argv[0] === 'podman' && argv[1] === 'pull') optsSeen.push(options);
+      return { stdout: '', stderr: '', code: argv[1] === 'image' ? 1 : 0 };
+    });
+    await ensureWorkerImage(exec);
+    expect(optsSeen[0]?.timeoutMs).toBeGreaterThanOrEqual(120_000);
   });
 });
 

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -33,6 +33,16 @@ export const WORKER_MEMORY = '1g';
 /** Port the worker app server listens on inside the container (Containerfile EXPOSE). */
 export const WORKER_PORT = 8080;
 
+/**
+ * Timeout for slow host ops in the scan path (image pull, mounting a real
+ * disk). The agent's default command timeout is only 30s (handler
+ * `timeoutMs ?? 30000`); a scan that fell back to it died with "Agent request
+ * timeout (safe_exec after 30000ms)" while a ~50s `podman pull` was still
+ * running. A cold pull or a large/USB ext4 mount legitimately takes minutes, so
+ * these ops pass this generous timeout explicitly.
+ */
+const SLOW_OP_TIMEOUT_MS = 600_000; // 10 min
+
 /** A launched worker run servicebay tracks by container name + out dir. */
 export interface WorkerRun {
   /** Opaque run id (also the container name suffix + out-dir name). */
@@ -128,7 +138,9 @@ export async function launchWorker(args: {
   // source already has the right label.
   await exec(
     ['mount', '-o', 'ro,context="system_u:object_r:container_file_t:s0"', device, mountpoint],
-    { sudo: true },
+    // A real large/USB ext4 can take well over 30s to mount (drive spin-up,
+    // journal recovery), so override the agent's 30s default here too.
+    { sudo: true, timeoutMs: SLOW_OP_TIMEOUT_MS },
   );
 
   // Resolve the Immich External-Library provisioning inputs (admin key + box
@@ -223,9 +235,19 @@ export async function stopWorker(exec: SafeExec, run: WorkerRun): Promise<void> 
   await cleanupRunMount(exec, run);
 }
 
-/** Ensure the worker image is present on the node (pull if missing). */
+/**
+ * Ensure the worker image is present on the node — pull ONLY if missing.
+ *
+ * Re-pulling on every scan was the bug behind the "Agent request timeout
+ * (safe_exec after 30000ms)" failure: `podman pull` does a registry round-trip
+ * even when the image is already local, which took ~50s here and blew the 30s
+ * agent timeout, so the scan errored before it ever mounted the disk. The image
+ * is refreshed out-of-band when servicebay is updated, so on the hot path we
+ * skip the pull entirely when it already exists, and give the cold pull (first
+ * ever scan) a generous timeout.
+ */
 export async function ensureWorkerImage(exec: SafeExec): Promise<void> {
-  const { stdout } = await exec(['podman', 'image', 'exists', WORKER_IMAGE]).catch(() => ({ stdout: '', stderr: '', code: 1 }));
-  void stdout;
-  await exec(['podman', 'pull', WORKER_IMAGE]);
+  const { code } = await exec(['podman', 'image', 'exists', WORKER_IMAGE]).catch(() => ({ stdout: '', stderr: '', code: 1 }));
+  if (code === 0) return; // already present — don't re-pull on the scan hot path
+  await exec(['podman', 'pull', WORKER_IMAGE], { timeoutMs: SLOW_OP_TIMEOUT_MS });
 }


### PR DESCRIPTION
## The real bug behind "it still doesn't work"

Scanning a real disk failed with **`Agent request timeout (safe_exec after 30000ms)`**. From the box logs:

```
safe_exec: podman pull ghcr.io/mdopp/servicebay-disk-import-worker:latest
→ timed out at 30000ms … actually completed at +50s (code 0)
```

`ensureWorkerImage` ran `podman pull` on **every scan even when the image was already local**. That registry round-trip took ~50s and blew the agent's 30s default command timeout, so the scan errored before it ever mounted the disk. Nothing to do with disk size — the 64 MB test only passed because that pull happened to finish under 30s.

## Fix
- `ensureWorkerImage`: pull **only when the image is missing** — the scan hot path now skips the pull entirely.
- Give the cold pull and the disk `mount` an explicit **10-min timeout** — a first-ever pull and a real large/USB ext4 mount legitimately exceed 30s.

## Verified on-box (read-only, non-destructive)
- Worker image present → pull skipped.
- Read-only mount of the real **1.8 TB `/dev/sda`** completes in **0.04s**.
- 17/17 launcher unit tests pass (new skip-pull + timeout assertions).

`gate:verify` — a real scan of the live disk is re-run on `:dev` after deploy.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._