### PR TITLE
fix(disk-import): two-tier fingerprint dedup + planning progress

### DIFF
--- a/packages/disk-import-worker/src/cli/main.test.ts
+++ b/packages/disk-import-worker/src/cli/main.test.ts
@@ -25,6 +25,7 @@ function makeIO(overrides: Partial<WorkerIO> = {}): {
         { path: '/mnt/src/thumbs.db', size: 1, mtimeMs: 3 },
       ] satisfies ScannedFile[],
     hashOf: r => `hash-${r.sourcePath}`,
+    fingerprintOf: r => `fp-${r.sourcePath}`,
     writeStatus: (_out, status) => statuses.push({ ...status }),
     writePlanSidecar: (_out, sidecar) => sidecars.push(sidecar),
     makeExec: () => {

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -29,7 +29,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, openSync, readSync, closeSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -192,15 +192,50 @@ export async function walkMount(mount: string, fsImpl: typeof fs = fs): Promise<
   return out;
 }
 
-/** Lazy sha256 of a file's bytes — used by dedup on size collisions only. */
+/** Lazy sha256 of a file's bytes — the full hash, used only to CONFIRM a
+ *  fingerprint collision (so a real backup disk is never read whole). */
 export function hashFileContent(record: ImportRecord): string {
   return createHash('sha256').update(readFileSync(record.sourcePath)).digest('hex');
+}
+
+/** Bytes read from each end for the cheap dedup fingerprint (#1995). */
+const FINGERPRINT_EDGE_BYTES = 64 * 1024;
+
+/**
+ * Cheap content FINGERPRINT: sha256 of (size + first 64KB + last 64KB) — reads
+ * at most 128KB instead of the whole file. Two files with the same size AND
+ * fingerprint are almost certainly identical; the planner still full-hashes
+ * those to be sure, so this never causes a wrong dedup — it just avoids reading
+ * hundreds of GB of same-size files on a backup disk (#1995).
+ */
+export function fingerprintFileContent(record: ImportRecord): string {
+  const size = record.size;
+  const h = createHash('sha256').update(String(size));
+  const fd = openSync(record.sourcePath, 'r');
+  try {
+    if (size <= FINGERPRINT_EDGE_BYTES * 2) {
+      const buf = Buffer.allocUnsafe(size);
+      readSync(fd, buf, 0, size, 0);
+      h.update(buf);
+    } else {
+      const head = Buffer.allocUnsafe(FINGERPRINT_EDGE_BYTES);
+      readSync(fd, head, 0, FINGERPRINT_EDGE_BYTES, 0);
+      const tail = Buffer.allocUnsafe(FINGERPRINT_EDGE_BYTES);
+      readSync(fd, tail, 0, FINGERPRINT_EDGE_BYTES, size - FINGERPRINT_EDGE_BYTES);
+      h.update(head).update(tail);
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return h.digest('hex');
 }
 
 /** IO seams — injected so the run is testable without a real device/agent. */
 export interface WorkerIO {
   scan: (mount: string) => Promise<ScannedFile[]>;
   hashOf: HashResolver;
+  /** Cheap fingerprint resolver for the two-tier dedup (#1995). */
+  fingerprintOf: HashResolver;
   /** Persist the compact status doc (atomic-ish: caller passes the full object). */
   writeStatus: (out: string, status: WorkerStatus) => void;
   /** Persist the heavy plan sidecar once. */
@@ -239,7 +274,14 @@ export async function runWorker(opts: WorkerOptions, io: WorkerIO): Promise<Work
     const catalog = new ImportCatalog(opts.catalog);
     let plan: ImportPlan;
     try {
-      plan = buildPlan(records, io.hashOf, { catalog });
+      plan = buildPlan(records, io.hashOf, {
+        catalog,
+        fingerprintOf: io.fingerprintOf,
+        // Live progress over the dedup fingerprint pass so a big disk never
+        // looks hung (#1995). Throttled by buildPlan to ~every 1000 files.
+        onProgress: (done, total) =>
+          tick({ step: `Planning: deduplicating ${done}/${total} same-size files …` }),
+      });
     } finally {
       if (opts.mode === 'dry-run') catalog.close();
     }
@@ -307,6 +349,7 @@ function realIO(): WorkerIO {
   return {
     scan: mount => walkMount(mount),
     hashOf: hashFileContent,
+    fingerprintOf: fingerprintFileContent,
     writeStatus: (out, status) => writeJson(path.join(out, STATUS_FILE), status),
     writePlanSidecar: (out, sidecar) => writeJson(path.join(out, PLAN_SIDECAR_FILE), sidecar),
     makeExec: opts => {

--- a/packages/disk-import-worker/src/engine/dedup.test.ts
+++ b/packages/disk-import-worker/src/engine/dedup.test.ts
@@ -19,6 +19,28 @@ function plan(files: ScannedFile[], hashes: Record<string, string>, catalog?: Im
   return buildPlan(buildInventory(files), hasherFrom(hashes), { catalog });
 }
 
+/**
+ * Two-tier plan: explicit cheap `fingerprints` + full `hashes`, with both
+ * resolvers spied so a test can assert WHICH files were actually read full
+ * (#1995). A full-hash fixture may be omitted for files that should never be
+ * fully read — the spy throws if such a file is full-hashed.
+ */
+function planFp(
+  files: ScannedFile[],
+  fingerprints: Record<string, string>,
+  hashes: Record<string, string>,
+  catalog?: ImportCatalog,
+) {
+  const fullHashed: string[] = [];
+  const hashOf = vi.fn((r: ImportRecord) => {
+    fullHashed.push(r.sourcePath);
+    return hasherFrom(hashes)(r);
+  });
+  const fingerprintOf = vi.fn(hasherFrom(fingerprints));
+  const result = buildPlan(buildInventory(files), hashOf, { catalog, fingerprintOf });
+  return { result, fullHashed, hashOf, fingerprintOf };
+}
+
 function actionOf(items: ImportPlanItem[], sourcePath: string) {
   return items.find(i => i.record.sourcePath === sourcePath)?.action;
 }
@@ -90,9 +112,71 @@ describe('buildPlan — conflicts (same target, different content)', () => {
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0]).toMatchObject({
       target: 'documents/report.pdf',
+      existing: { sourcePath: '/diskA/report.pdf' },
+      incoming: { sourcePath: '/diskB/report.pdf' },
+    });
+  });
+});
+
+// Two-tier dedup (#1995): cheap fingerprint first, full hash only on a
+// fingerprint collision — so a backup disk full of same-size files is not read
+// whole, and dedup stays exact (a fingerprint match is CONFIRMED by full hash).
+describe('buildPlan — two-tier fingerprint dedup (#1995)', () => {
+  it('same size + DIFFERENT fingerprint → conflict WITHOUT reading either file whole', () => {
+    const files: ScannedFile[] = [
+      { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
+    ];
+    const { result, fullHashed } = planFp(
+      files,
+      { '/diskA/report.pdf': 'fpA', '/diskB/report.pdf': 'fpB' },
+      {}, // no full-hash fixtures: full-hashing either file would throw
+    );
+    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('conflict');
+    expect(fullHashed).toEqual([]); // distinct fingerprints settle it cheaply
+  });
+
+  it('same size + SAME fingerprint → full-hash CONFIRMS: identical content is skip-dupe', () => {
+    const files: ScannedFile[] = [
+      { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
+    ];
+    const { result, fullHashed } = planFp(
+      files,
+      { '/diskA/report.pdf': 'fp', '/diskB/report.pdf': 'fp' },
+      { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('a') },
+    );
+    expect(actionOf(result.items, '/diskA/report.pdf')).toBe('copy');
+    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('skip-dupe');
+    expect(fullHashed.sort()).toEqual(['/diskA/report.pdf', '/diskB/report.pdf']);
+  });
+
+  it('same size + SAME fingerprint but DIFFERENT full hash → confirmed conflict with full shas', () => {
+    const files: ScannedFile[] = [
+      { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
+    ];
+    const { result } = planFp(
+      files,
+      { '/diskA/report.pdf': 'fp', '/diskB/report.pdf': 'fp' },
+      { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('b') },
+    );
+    expect(result.conflicts[0]).toMatchObject({
       existing: { sourcePath: '/diskA/report.pdf', sha256: sha('a') },
       incoming: { sourcePath: '/diskB/report.pdf', sha256: sha('b') },
     });
+  });
+
+  it('size-unique file is NEVER fingerprinted or hashed', () => {
+    const files: ScannedFile[] = [
+      { path: '/disk/a.jpg', size: 111, mtimeMs: 0 },
+      { path: '/disk/b.mp3', size: 222, mtimeMs: 0 },
+    ];
+    const { result, fullHashed, fingerprintOf } = planFp(files, {}, {});
+    expect(actionOf(result.items, '/disk/a.jpg')).toBe('copy');
+    expect(actionOf(result.items, '/disk/b.mp3')).toBe('copy');
+    expect(fullHashed).toEqual([]);
+    expect(fingerprintOf).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/disk-import-worker/src/engine/dedup.ts
+++ b/packages/disk-import-worker/src/engine/dedup.ts
@@ -29,6 +29,22 @@ import type {
 export type HashResolver = (record: ImportRecord) => string;
 
 export interface PlanOptions {
+  /**
+   * Cheap content FINGERPRINT resolver (e.g. sha256 of the first+last 64KB +
+   * size) used to dedup same-size files WITHOUT reading them whole. Only when
+   * two files also share a fingerprint do we fall back to the full `hashOf` to
+   * confirm they're truly identical (avoids a false "duplicate" → never drops a
+   * file). On a backup disk full of same-size files this turns hours of full
+   * reads into a few MB. Defaults to `hashOf` when omitted (correct, just not
+   * faster). (#1995)
+   */
+  fingerprintOf?: HashResolver;
+  /**
+   * Progress callback fired while fingerprinting the size-colliding files (the
+   * only expensive, I/O-bound part of planning a large disk). Lets the worker
+   * write live progress so a long plan never looks hung. (#1995)
+   */
+  onProgress?: (done: number, total: number) => void;
   /** Per-record classification hints (keyed by source path). */
   hints?: Record<string, ClassifyHints>;
   /** Optional LLM-residue classifier seam (#1695); never invoked here itself. */
@@ -169,41 +185,35 @@ export function buildPlan(
     else bySize.set(c.record.size, [c]);
   }
 
-  // Hash a record at most once.
-  const hashCache = new Map<string, string>();
-  const hashFor = (record: ImportRecord): string => {
-    if (record.sha256) return record.sha256;
-    const cached = hashCache.get(record.sourcePath);
-    if (cached) return cached;
-    const h = hashOf(record);
-    hashCache.set(record.sourcePath, h);
-    return h;
-  };
-
-  // Track, within this tree, the content hash already claiming each destination
-  // slot. The slot key is (area, target): the SAME target in two areas (e.g.
-  // `shared` vs a user area) is two distinct slots — private dedups within
-  // itself, `shared` merges across sources.
-  const targetOwner = new Map<string, { sha256: string; sourcePath: string }>();
-
-  // 3. Decide each kept record. Iterate in stable (sourcePath) order so the
-  //    first file at a target is the deterministic winner.
+  // Stable (sourcePath) iteration order so the first file at a target wins.
   const ordered = keep
     .slice()
     .sort((a, b) =>
       a.record.sourcePath < b.record.sourcePath ? -1 : a.record.sourcePath > b.record.sourcePath ? 1 : 0,
     );
 
+  // Two-tier content keys: cheap fingerprint first, full hash only on a
+  // fingerprint collision or a cataloged target (#1995).
+  const keys = resolveContentKeys(ordered, bySize, {
+    hashOf,
+    fingerprintOf: opts.fingerprintOf ?? hashOf,
+    catalog,
+    areaOf,
+    onProgress: opts.onProgress,
+  });
+
+  // Track, within this tree, the content hash already claiming each destination
+  // slot. The slot key is (area, target): the SAME target in two areas (e.g.
+  // `shared` vs a user area) is two distinct slots — private dedups within
+  // itself, `shared` merges across sources.
+  const targetOwner = new Map<string, { key: string; sha256?: string; sourcePath: string }>();
+
+  // 3. Decide each kept record from its precomputed content key.
   for (const c of ordered) {
     const target = c.target!;
     const area = areaOf(c.record);
     const slot = dedupSlot(area, target);
-    const sizeGroup = bySize.get(c.record.size)!;
-    const catHit = catalog?.getByTarget(target, area);
-    // Hash only when this size collides in-tree, the slot already has an in-tree
-    // owner, or the catalog already holds this content slot.
-    const mustHash = sizeGroup.length > 1 || targetOwner.has(slot) || catHit !== undefined;
-    const action = decide(c, target, area, slot, mustHash ? hashFor : null, {
+    const action = decide(c, target, area, slot, keys.get(c.record.sourcePath)!, {
       targetOwner,
       catalog,
       conflicts,
@@ -224,52 +234,129 @@ function dedupSlot(area: string, target: string): string {
   return `${area} ${target}`;
 }
 
+/**
+ * A record's comparable content identity. `key` is what dedup compares (equal
+ * keys mean same content); `sha256` is the FULL hash, present only when the
+ * record was fully hashed (needed for catalog comparison, which stores full
+ * hashes).
+ */
+interface KeyInfo {
+  key: string;
+  sha256?: string;
+}
+
+/**
+ * Two-tier dedup keying (#1995). Reads as little as possible:
+ *  - size-unique files are NEVER read (`u:` key, can't duplicate anything);
+ *  - size-colliding files get a cheap FINGERPRINT (`f:` key, first/last 64KB);
+ *  - only files that ALSO collide on fingerprint, or whose target is already in
+ *    the catalog (which stores full hashes), are FULLY hashed (`h:` key).
+ * Progress is reported across the fingerprint pass (the dominant I/O on a big
+ * disk) so the worker can show live planning progress and never look hung.
+ */
+function resolveContentKeys(
+  ordered: Classified[],
+  bySize: Map<number, Classified[]>,
+  opts: {
+    hashOf: HashResolver;
+    fingerprintOf: HashResolver;
+    catalog?: ImportCatalog;
+    areaOf: (record: ImportRecord) => string;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Map<string, KeyInfo> {
+  const { hashOf, fingerprintOf, catalog, areaOf, onProgress } = opts;
+
+  // Pass 1: fingerprint every size-colliding record (the heavy, I/O-bound pass).
+  const colliding = ordered.filter(c => (bySize.get(c.record.size)?.length ?? 0) > 1);
+  const total = colliding.length;
+  const fpOf = new Map<string, string>();
+  let done = 0;
+  for (const c of colliding) {
+    fpOf.set(c.record.sourcePath, c.record.sha256 ?? fingerprintOf(c.record));
+    done += 1;
+    if (onProgress && (done % 1000 === 0 || done === total)) onProgress(done, total);
+  }
+
+  // Count (size, fingerprint) groups to find what still collides after pass 1.
+  const byFp = new Map<string, number>();
+  for (const c of colliding) {
+    const k = `${c.record.size}:${fpOf.get(c.record.sourcePath)}`;
+    byFp.set(k, (byFp.get(k) ?? 0) + 1);
+  }
+
+  // Full-hash cache (each record at most once).
+  const fullCache = new Map<string, string>();
+  const fullHash = (record: ImportRecord): string => {
+    if (record.sha256) return record.sha256;
+    const cached = fullCache.get(record.sourcePath);
+    if (cached) return cached;
+    const h = hashOf(record);
+    fullCache.set(record.sourcePath, h);
+    return h;
+  };
+
+  // Pass 2: assign each record its comparable key.
+  const out = new Map<string, KeyInfo>();
+  for (const c of ordered) {
+    const fp = fpOf.get(c.record.sourcePath);
+    const catHit = catalog?.getByTarget(c.target!, areaOf(c.record));
+    const fpCollides = fp !== undefined && (byFp.get(`${c.record.size}:${fp}`) ?? 0) > 1;
+    if (catHit !== undefined || fpCollides) {
+      const sha = fullHash(c.record);
+      out.set(c.record.sourcePath, { key: `h:${sha}`, sha256: sha });
+    } else if (fp !== undefined) {
+      out.set(c.record.sourcePath, { key: `f:${fp}` });
+    } else {
+      out.set(c.record.sourcePath, { key: `u:${c.record.sourcePath}` });
+    }
+  }
+  return out;
+}
+
 function decide(
   c: Classified,
   target: string,
   area: string,
   slot: string,
-  hashFor: HashResolver | null,
+  info: KeyInfo,
   ctx: {
-    targetOwner: Map<string, { sha256: string; sourcePath: string }>;
+    targetOwner: Map<string, { key: string; sha256?: string; sourcePath: string }>;
     catalog?: ImportCatalog;
     conflicts: Conflict[];
   },
 ): ImportAction {
-  // No hashing needed → unique file, plain copy, claim the slot.
-  if (!hashFor) {
-    return 'copy';
+  const { key, sha256 } = info;
+
+  // Catalog dedup compares FULL hashes (the catalog stores full sha256). sha256
+  // is present exactly when this record was fully hashed, which resolveContentKeys
+  // guarantees whenever the target is already cataloged.
+  if (sha256 !== undefined) {
+    if (ctx.catalog?.has(sha256, target, area)) return 'skip-dupe';
+    const catHit = ctx.catalog?.getByTarget(target, area);
+    if (catHit && catHit.sha256 !== sha256) {
+      ctx.conflicts.push({
+        target,
+        existing: { sourcePath: catHit.sourcePath, sha256: catHit.sha256 },
+        incoming: { sourcePath: c.record.sourcePath, sha256 },
+      });
+      return 'conflict';
+    }
   }
 
-  const sha = hashFor(c.record);
-
-  // Already imported this exact content to this exact area+target (delta run)?
-  if (ctx.catalog?.has(sha, target, area)) return 'skip-dupe';
-
-  // A different content already cataloged at this area+target → conflict.
-  const catHit = ctx.catalog?.getByTarget(target, area);
-  if (catHit && catHit.sha256 !== sha) {
-    ctx.conflicts.push({
-      target,
-      existing: { sourcePath: catHit.sourcePath, sha256: catHit.sha256 },
-      incoming: { sourcePath: c.record.sourcePath, sha256: sha },
-    });
-    return 'conflict';
-  }
-
-  // In-tree collision at this slot (same area + target)?
+  // In-tree collision at this slot (same area + target)? Compare by content key.
   const owner = ctx.targetOwner.get(slot);
   if (owner) {
-    if (owner.sha256 === sha) return 'skip-dupe'; // same bytes, different path
+    if (owner.key === key) return 'skip-dupe'; // same content, different path
     ctx.conflicts.push({
       target,
-      existing: { sourcePath: owner.sourcePath, sha256: owner.sha256 },
-      incoming: { sourcePath: c.record.sourcePath, sha256: sha },
+      existing: { sourcePath: owner.sourcePath, sha256: owner.sha256 ?? '' },
+      incoming: { sourcePath: c.record.sourcePath, sha256: sha256 ?? '' },
     });
     return 'conflict';
   }
 
-  // First copy to this slot — claim it.
-  ctx.targetOwner.set(slot, { sha256: sha, sourcePath: c.record.sourcePath });
+  // First file to claim this slot.
+  ctx.targetOwner.set(slot, { key, sha256, sourcePath: c.record.sourcePath });
   return 'copy';
 }


### PR DESCRIPTION
## Why
Verifying the importer on a **real 1.8 TB backup disk** exposed the next wall after the scan-timeout fix: the walk found 234,508 files, then *planning* sat for minutes at planned:0 with no progress — looking hung. Root cause: buildPlan content-hashed **every same-size file by reading it whole**; a backup drive is full of same-size duplicates → hundreds of GB read, single-threaded.

## Fix (operator chose "fast fingerprint + progress")
**Two-tier dedup** (engine/dedup.ts): size-unique files never read; same-size files get a cheap **fingerprint** (size + first/last 64 KB, ≤128 KB); only files that **also** collide on fingerprint (or whose target is cataloged) are fully hashed to confirm. Exact — a fingerprint match is always confirmed by full hash, so a file is never wrongly dropped.

**Live progress** (cli/main.ts): buildPlan reports across the fingerprint pass; the worker writes it to status.json (~every 1000 files).

## Tests
278 disk-import tests pass incl. new two-tier cases.

## Notes
- Worker-only → build-images rebuilds the worker image.
- Worker image won't auto-refresh on the box (#1995) — pulled manually on deploy until that lands.
- gate:verify — re-scan real /dev/sda; planning should finish in minutes with live progress.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._