### PR TITLE
fix(disk-import): trust the fingerprint for dedup — no full-hash confirm

### DIFF
--- a/packages/disk-import-worker/src/cli/main.test.ts
+++ b/packages/disk-import-worker/src/cli/main.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import {
   parseWorkerArgs,
   runWorker,
+  fingerprintFileContent,
   WorkerArgError,
   type WorkerIO,
   type WorkerOptions,
 } from './main';
 import type { ScannedFile } from '../engine/inventory';
+import type { ImportRecord } from '../engine/types';
 import type { WorkerStatus, PlanSidecar } from '../contract/status';
 
 function makeIO(overrides: Partial<WorkerIO> = {}): {
@@ -154,5 +159,47 @@ describe('runWorker (apply)', () => {
     });
     await runWorker({ ...dryOpts, mode: 'apply' }, io);
     expect(provisionImmich).not.toHaveBeenCalled();
+  });
+});
+
+describe('fingerprintFileContent (#1995)', () => {
+  const rec = (sourcePath: string, size: number): ImportRecord =>
+    ({ sourcePath, size, mtimeMs: 0 }) as ImportRecord;
+
+  it('small file (<=192KB): deterministic; same bytes -> same fp, different -> different', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sb-fp-'));
+    try {
+      writeFileSync(path.join(dir, 'a'), 'hello world');
+      writeFileSync(path.join(dir, 'b'), 'hello world');
+      writeFileSync(path.join(dir, 'c'), 'HELLO WORLD');
+      const fa = fingerprintFileContent(rec(path.join(dir, 'a'), 11));
+      const fb = fingerprintFileContent(rec(path.join(dir, 'b'), 11));
+      const fc = fingerprintFileContent(rec(path.join(dir, 'c'), 11));
+      expect(fa).toBe(fb);
+      expect(fa).not.toBe(fc);
+      expect(fa).toMatch(/^[0-9a-f]{64}$/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('large file (>192KB): differs only in the MIDDLE -> different fingerprint', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sb-fp-'));
+    try {
+      const size = 64 * 1024 * 4; // 256KB -> head/middle/tail path
+      const base = Buffer.alloc(size, 0x41); // all 'A'
+      const mid = Buffer.from(base);
+      mid[Math.floor(size / 2)] = 0x42; // flip one byte in the middle
+      writeFileSync(path.join(dir, 'big1'), base);
+      writeFileSync(path.join(dir, 'big2'), base);
+      writeFileSync(path.join(dir, 'bigM'), mid);
+      const f1 = fingerprintFileContent(rec(path.join(dir, 'big1'), size));
+      const f2 = fingerprintFileContent(rec(path.join(dir, 'big2'), size));
+      const fM = fingerprintFileContent(rec(path.join(dir, 'bigM'), size));
+      expect(f1).toBe(f2);
+      expect(f1).not.toBe(fM); // middle sample catches a mid-file difference
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -202,27 +202,34 @@ export function hashFileContent(record: ImportRecord): string {
 const FINGERPRINT_EDGE_BYTES = 64 * 1024;
 
 /**
- * Cheap content FINGERPRINT: sha256 of (size + first 64KB + last 64KB) — reads
- * at most 128KB instead of the whole file. Two files with the same size AND
- * fingerprint are almost certainly identical; the planner still full-hashes
- * those to be sure, so this never causes a wrong dedup — it just avoids reading
- * hundreds of GB of same-size files on a backup disk (#1995).
+ * Cheap content FINGERPRINT: sha256 of (size + 64KB head + 64KB middle + 64KB
+ * tail) — reads at most 192KB instead of the whole file. This IS the dedup
+ * identity (#1995): equal size+fingerprint is treated as the same content, with
+ * no full-hash confirm, so a backup disk full of same-size duplicates is not
+ * read whole. A head+middle+tail+size collision between two genuinely different
+ * files is astronomically unlikely, and the import is copy-only over a READ-ONLY
+ * source — worst case of a false match is one file not copied (still on the
+ * disk), never data loss.
  */
 export function fingerprintFileContent(record: ImportRecord): string {
   const size = record.size;
   const h = createHash('sha256').update(String(size));
   const fd = openSync(record.sourcePath, 'r');
   try {
-    if (size <= FINGERPRINT_EDGE_BYTES * 2) {
+    if (size <= FINGERPRINT_EDGE_BYTES * 3) {
       const buf = Buffer.allocUnsafe(size);
       readSync(fd, buf, 0, size, 0);
       h.update(buf);
     } else {
-      const head = Buffer.allocUnsafe(FINGERPRINT_EDGE_BYTES);
-      readSync(fd, head, 0, FINGERPRINT_EDGE_BYTES, 0);
-      const tail = Buffer.allocUnsafe(FINGERPRINT_EDGE_BYTES);
-      readSync(fd, tail, 0, FINGERPRINT_EDGE_BYTES, size - FINGERPRINT_EDGE_BYTES);
-      h.update(head).update(tail);
+      const seg = Buffer.allocUnsafe(FINGERPRINT_EDGE_BYTES);
+      for (const offset of [
+        0,
+        Math.floor(size / 2 - FINGERPRINT_EDGE_BYTES / 2),
+        size - FINGERPRINT_EDGE_BYTES,
+      ]) {
+        readSync(fd, seg, 0, FINGERPRINT_EDGE_BYTES, offset);
+        h.update(seg);
+      }
     }
   } finally {
     closeSync(fd);

--- a/packages/disk-import-worker/src/engine/dedup.test.ts
+++ b/packages/disk-import-worker/src/engine/dedup.test.ts
@@ -118,10 +118,12 @@ describe('buildPlan — conflicts (same target, different content)', () => {
   });
 });
 
-// Two-tier dedup (#1995): cheap fingerprint first, full hash only on a
-// fingerprint collision — so a backup disk full of same-size files is not read
-// whole, and dedup stays exact (a fingerprint match is CONFIRMED by full hash).
-describe('buildPlan — two-tier fingerprint dedup (#1995)', () => {
+// Fingerprint-trust dedup (#1995): the cheap fingerprint IS the dedup identity —
+// NO full-hash confirm on a first import — so a backup disk full of same-size
+// duplicates is never read whole. Full hashing happens ONLY for a cataloged
+// target (delta run). Source is read-only/copy-only, so a (near-impossible)
+// fingerprint false-match means one file not copied, never data loss.
+describe('buildPlan — fingerprint-trust dedup (#1995)', () => {
   it('same size + DIFFERENT fingerprint → conflict WITHOUT reading either file whole', () => {
     const files: ScannedFile[] = [
       { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
@@ -136,7 +138,7 @@ describe('buildPlan — two-tier fingerprint dedup (#1995)', () => {
     expect(fullHashed).toEqual([]); // distinct fingerprints settle it cheaply
   });
 
-  it('same size + SAME fingerprint → full-hash CONFIRMS: identical content is skip-dupe', () => {
+  it('same size + SAME fingerprint → skip-dupe WITHOUT a full read (first import)', () => {
     const files: ScannedFile[] = [
       { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
       { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
@@ -144,27 +146,25 @@ describe('buildPlan — two-tier fingerprint dedup (#1995)', () => {
     const { result, fullHashed } = planFp(
       files,
       { '/diskA/report.pdf': 'fp', '/diskB/report.pdf': 'fp' },
-      { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('a') },
+      {}, // a full read would throw — proves we never do one
     );
     expect(actionOf(result.items, '/diskA/report.pdf')).toBe('copy');
     expect(actionOf(result.items, '/diskB/report.pdf')).toBe('skip-dupe');
-    expect(fullHashed.sort()).toEqual(['/diskA/report.pdf', '/diskB/report.pdf']);
+    expect(fullHashed).toEqual([]);
   });
 
-  it('same size + SAME fingerprint but DIFFERENT full hash → confirmed conflict with full shas', () => {
-    const files: ScannedFile[] = [
-      { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
-      { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
-    ];
-    const { result } = planFp(
+  it('a cataloged target IS full-hashed (delta run compares against stored sha256)', () => {
+    const catalog = new ImportCatalog(':memory:');
+    catalog.upsert({ sha256: sha('a'), target: 'documents/report.pdf', sourcePath: '/old/report.pdf', size: 5000, importedAtMs: 0 });
+    const files: ScannedFile[] = [{ path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 }];
+    const { result, fullHashed } = planFp(
       files,
-      { '/diskA/report.pdf': 'fp', '/diskB/report.pdf': 'fp' },
-      { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('b') },
+      { '/diskA/report.pdf': 'fp' },
+      { '/diskA/report.pdf': sha('a') },
+      catalog,
     );
-    expect(result.conflicts[0]).toMatchObject({
-      existing: { sourcePath: '/diskA/report.pdf', sha256: sha('a') },
-      incoming: { sourcePath: '/diskB/report.pdf', sha256: sha('b') },
-    });
+    expect(actionOf(result.items, '/diskA/report.pdf')).toBe('skip-dupe');
+    expect(fullHashed).toEqual(['/diskA/report.pdf']);
   });
 
   it('size-unique file is NEVER fingerprinted or hashed', () => {

--- a/packages/disk-import-worker/src/engine/dedup.ts
+++ b/packages/disk-import-worker/src/engine/dedup.ts
@@ -246,13 +246,21 @@ interface KeyInfo {
 }
 
 /**
- * Two-tier dedup keying (#1995). Reads as little as possible:
+ * Fingerprint-trust dedup keying (#1995). Reads as little as possible:
  *  - size-unique files are NEVER read (`u:` key, can't duplicate anything);
- *  - size-colliding files get a cheap FINGERPRINT (`f:` key, first/last 64KB);
- *  - only files that ALSO collide on fingerprint, or whose target is already in
- *    the catalog (which stores full hashes), are FULLY hashed (`h:` key).
- * Progress is reported across the fingerprint pass (the dominant I/O on a big
- * disk) so the worker can show live planning progress and never look hung.
+ *  - size-colliding files are deduped by a cheap FINGERPRINT (`f:` key, sha256 of
+ *    size + head/middle/tail 64KB) — equal fingerprint ⇒ treated as the same
+ *    content. A full read is NOT used to confirm: on a backup disk almost every
+ *    same-size file is a true duplicate, so confirming by full hash means reading
+ *    hundreds of GB (the original bug, just moved later). A head+middle+tail+size
+ *    match between two genuinely different files is astronomically unlikely, and
+ *    the import is copy-only over a READ-ONLY source — so the worst case of a
+ *    false match is one file not COPIED (still safe on the disk), never data loss.
+ *  - the ONLY full hash is for a record whose target is already in the catalog
+ *    (a delta/re-run), because the catalog stores full sha256 (`h:` key). A first
+ *    import has an empty catalog, so it does ZERO full reads.
+ * Progress is reported across the fingerprint pass (the dominant I/O) so a large
+ * plan shows live progress and never looks hung.
  */
 function resolveContentKeys(
   ordered: Classified[],
@@ -267,46 +275,34 @@ function resolveContentKeys(
 ): Map<string, KeyInfo> {
   const { hashOf, fingerprintOf, catalog, areaOf, onProgress } = opts;
 
-  // Pass 1: fingerprint every size-colliding record (the heavy, I/O-bound pass).
-  const colliding = ordered.filter(c => (bySize.get(c.record.size)?.length ?? 0) > 1);
-  const total = colliding.length;
-  const fpOf = new Map<string, string>();
+  // Records whose target is already cataloged need a FULL hash to compare with
+  // the catalog (it stores full sha256). Empty on a first import.
+  const needsFullForCatalog = (c: Classified): boolean =>
+    catalog?.getByTarget(c.target!, areaOf(c.record)) !== undefined;
+
+  // The work to report progress over: every size-colliding file is fingerprinted,
+  // plus any cataloged-target file is full-hashed.
+  const reads = ordered.filter(
+    c => (bySize.get(c.record.size)?.length ?? 0) > 1 || needsFullForCatalog(c),
+  );
+  const total = reads.length;
   let done = 0;
-  for (const c of colliding) {
-    fpOf.set(c.record.sourcePath, c.record.sha256 ?? fingerprintOf(c.record));
+  const tick = (): void => {
     done += 1;
     if (onProgress && (done % 1000 === 0 || done === total)) onProgress(done, total);
-  }
-
-  // Count (size, fingerprint) groups to find what still collides after pass 1.
-  const byFp = new Map<string, number>();
-  for (const c of colliding) {
-    const k = `${c.record.size}:${fpOf.get(c.record.sourcePath)}`;
-    byFp.set(k, (byFp.get(k) ?? 0) + 1);
-  }
-
-  // Full-hash cache (each record at most once).
-  const fullCache = new Map<string, string>();
-  const fullHash = (record: ImportRecord): string => {
-    if (record.sha256) return record.sha256;
-    const cached = fullCache.get(record.sourcePath);
-    if (cached) return cached;
-    const h = hashOf(record);
-    fullCache.set(record.sourcePath, h);
-    return h;
   };
 
-  // Pass 2: assign each record its comparable key.
   const out = new Map<string, KeyInfo>();
   for (const c of ordered) {
-    const fp = fpOf.get(c.record.sourcePath);
-    const catHit = catalog?.getByTarget(c.target!, areaOf(c.record));
-    const fpCollides = fp !== undefined && (byFp.get(`${c.record.size}:${fp}`) ?? 0) > 1;
-    if (catHit !== undefined || fpCollides) {
-      const sha = fullHash(c.record);
+    const sizeCollides = (bySize.get(c.record.size)?.length ?? 0) > 1;
+    if (needsFullForCatalog(c)) {
+      const sha = c.record.sha256 ?? hashOf(c.record);
       out.set(c.record.sourcePath, { key: `h:${sha}`, sha256: sha });
-    } else if (fp !== undefined) {
+      tick();
+    } else if (sizeCollides) {
+      const fp = c.record.sha256 ?? fingerprintOf(c.record);
       out.set(c.record.sourcePath, { key: `f:${fp}` });
+      tick();
     } else {
       out.set(c.record.sourcePath, { key: `u:${c.record.sourcePath}` });
     }


### PR DESCRIPTION
## Why
Re-scanning the real 1.8 TB **backup** disk after the two-tier change showed the *confirm* pass became the new wall: a backup drive is ~all same-size **true duplicates**, so "full-hash to confirm a fingerprint match" still read hundreds of GB — planning stalled >4 min at 100% fingerprinted, `planned:0`. (Live progress worked: "deduplicating 149574/149574".)

## Fix
The **fingerprint IS the dedup identity** — equal size+fingerprint ⇒ same content, **no full-hash confirm**. Full hashing happens ONLY for a target already in the catalog (a delta/re-run; the catalog stores full sha256). A **first import (empty catalog) does ZERO full reads** → planning ≈ the fingerprint pass (~2–3 min on this disk).

Fingerprint strengthened to `sha256(size + 64KB head + middle + tail)`.

## Safety
A head+middle+tail+size collision between two genuinely different files is astronomically unlikely, **and the import is copy-only over a READ-ONLY source** — so the worst case of a false match is one file not *copied* (still safe on the disk), never data loss. (This is the deliberate "sufficient, not over-perfect" tradeoff for a backup disk; reverses the earlier confirm-on-collision approach that the real disk proved impractical.)

## Tests
58 worker dedup/cli tests pass: fingerprint-trust skip-dupe with **no full read**, distinct-fingerprint conflict cheap, size-unique never read, and the catalog-delta full-hash path.

gate:verify — re-scan real /dev/sda; planning must reach **phase=done** with a category plan.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._