### PR TITLE
feat(disk-import): per-folder routing-tree review UI — owner + target pickers, per-owner re-plan (#2000)

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -20,6 +20,7 @@ vi.mock('@servicebay/disk-import-worker', () => ({
   scanLibrariesForOwners: (...a: unknown[]) => scanLibrariesForOwnersMock(...a),
   STATUS_FILE: 'status.json',
   PLAN_SIDECAR_FILE: 'plan.json',
+  REPLAN_REQUEST_FILE: 'replan-request.json',
 }));
 
 vi.mock('@/lib/dirs', () => ({ DATA_DIR: '/app/data' }));
@@ -64,7 +65,7 @@ function hoistedSidecar() {
   };
 }
 
-import { applyImport, rebasePlanSource } from './apply';
+import { applyImport, rebasePlanSource, replanImport } from './apply';
 
 function recordOf(sourcePath: string) {
   return { sourcePath, size: 10, mtimeMs: 1, ext: 'jpg', name: 'a.jpg' };
@@ -110,6 +111,39 @@ describe('rebasePlanSource', () => {
     sc.plan.items[0].record.sourcePath = '/somewhere/else/a.jpg';
     const plan = rebasePlanSource(sc, '/run/servicebay/disk-import/sda1');
     expect(plan.items[0].record.sourcePath).toBe('/somewhere/else/a.jpg');
+  });
+});
+
+describe('replanImport', () => {
+  it('writes the rules to the out dir and podman-execs the worker --replan', async () => {
+    const exec = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '' });
+    await replanImport({
+      exec,
+      runId: 'run1',
+      container: 'disk-import-worker-run1',
+      request: { explicit: { alice: { owner: 'alice' } }, rootDefault: { owner: 'shared' } },
+    });
+
+    // The rules went to replan-request.json in the run out dir.
+    const reqWrite = writes.find(w => w.file.endsWith('replan-request.json'));
+    expect(reqWrite).toBeDefined();
+    expect(JSON.parse(reqWrite!.data)).toEqual({
+      explicit: { alice: { owner: 'alice' } },
+      rootDefault: { owner: 'shared' },
+    });
+
+    // It ran a one-shot --replan IN the running serve container, over /out.
+    const argv = exec.mock.calls[0][0] as string[];
+    expect(argv.slice(0, 3)).toEqual(['podman', 'exec', 'disk-import-worker-run1']);
+    expect(argv).toContain('--replan');
+    expect(argv).toContain('/out');
+  });
+
+  it('throws when the worker re-plan exits non-zero', async () => {
+    const exec = vi.fn().mockResolvedValue({ code: 1, stdout: '', stderr: 'no plan' });
+    await expect(
+      replanImport({ exec, runId: 'run1', container: 'c', request: { explicit: {} } }),
+    ).rejects.toThrow(/re-plan failed/);
   });
 });
 

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -35,10 +35,12 @@ import {
   scanLibrariesForOwners,
   STATUS_FILE,
   PLAN_SIDECAR_FILE,
+  REPLAN_REQUEST_FILE,
   type SafeExec,
   type PlanSidecar,
   type WorkerStatus,
   type ImportRecord,
+  type ReplanRequest,
 } from '@servicebay/disk-import-worker';
 
 import { DATA_DIR } from '@/lib/dirs';
@@ -82,6 +84,54 @@ export function rebasePlanSource(sidecar: PlanSidecar, hostMountpoint: string): 
     ...sidecar.plan,
     items: sidecar.plan.items.map(it => ({ ...it, record: { ...it.record, sourcePath: rebase(it.record.sourcePath) } })),
   };
+}
+
+/** The worker container's in-container out path (its `-v <outDir>:/out` mount). */
+const WORKER_OUT_IN_CONTAINER = '/out';
+
+export interface ReplanImportArgs {
+  /** servicebay's REAL agent SafeExec (runs `podman exec` on the host as core). */
+  exec: SafeExec;
+  /** The run whose plan.json to re-plan. */
+  runId: string;
+  /** The serve container name to `podman exec --replan` into (#2000). */
+  container: string;
+  /** The page's routing rules + disk-default owner. */
+  request: ReplanRequest;
+}
+
+/**
+ * RE-PLAN the active run with the page's per-folder routing rules (#2000).
+ *
+ * The re-plan must re-dedup PER OWNER (so a cross-owner duplicate lands in BOTH
+ * owners' areas instead of being dropped as a `shared`-scope dupe) — which needs
+ * CONTENT HASHING, and only the worker can hash (the source disk is bind-mounted
+ * `/mnt/src` in the worker, NOT in servicebay's container — #1983). So servicebay
+ * writes the routing rules into the shared out dir and `podman exec`s the running
+ * serve container to re-plan in-place: it reads the existing plan.json (no re-scan),
+ * re-routes/re-dedups over the live mount, and rewrites plan.json + status.json.
+ * The subsequent host-apply then applies the rewritten plan.json UNCHANGED.
+ */
+export async function replanImport(args: ReplanImportArgs): Promise<void> {
+  const { exec, runId, container, request } = args;
+  const outDir = runOutDir(runId);
+  // Write the request the worker reads. servicebay sees the out dir in-container at
+  // runOutDir() (same bytes as the worker's host-bind-mounted /out), so a direct fs
+  // write here lands in the worker's /out.
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(outDir, REPLAN_REQUEST_FILE), JSON.stringify(request), 'utf-8');
+
+  // Run a one-shot `--replan` process IN the serve container (it has /mnt/src +
+  // /out): reads replan-request.json + plan.json, re-plans over the live mount,
+  // rewrites plan.json + status.json. The serve server keeps running alongside.
+  const { code, stdout, stderr } = await exec([
+    'podman', 'exec', container,
+    'npx', 'tsx', 'packages/disk-import-worker/src/cli/main.ts',
+    '--replan', '--out', WORKER_OUT_IN_CONTAINER,
+  ]);
+  if (code !== 0) {
+    throw new Error(`disk-import: re-plan failed (code ${code}): ${stderr || stdout}`);
+  }
 }
 
 export interface ApplyImportArgs {

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -8,7 +8,7 @@
 // reached via a launch TILE; this facade is the small launch/status glue the
 // tile's API routes call.
 
-import type { SafeExec } from '@servicebay/disk-import-worker';
+import type { SafeExec, ReplanRequest } from '@servicebay/disk-import-worker';
 import { SHARE_DATA_ROOT, type WorkerStatus } from '@servicebay/disk-import-worker';
 
 import { logger } from '@/lib/logger';
@@ -25,7 +25,7 @@ import {
 } from './launcher';
 import { listImportDevices } from './devices';
 import { setActiveRun, getActiveRun, clearActiveRun } from './runStore';
-import { applyImport, type ApplyImportResult } from './apply';
+import { applyImport, replanImport, type ApplyImportResult } from './apply';
 
 export type { ImportDevice } from './launcher';
 
@@ -111,9 +111,36 @@ export async function getRunStatus(exec: SafeExec): Promise<RunStatus | null> {
  * still mounted at. Status.json is updated through the apply so the tile poll keeps
  * reflecting progress. Throws when there's no active run, or on a real apply error.
  */
-export async function applyRun(exec: SafeExec, shareGid: number): Promise<ApplyImportResult> {
+/**
+ * Re-plan the active run with the page's per-folder routing rules (#2000) WITHOUT
+ * applying — re-routes/re-dedups per owner in the worker (over the live mount) and
+ * rewrites plan.json + status.json so the tile poll reflects the new owner-aware
+ * plan. Used to preview the effect of the routing picks before "Import now".
+ */
+export async function replanRun(exec: SafeExec, request: ReplanRequest): Promise<void> {
+  const run = await getActiveRun();
+  if (!run) throw new Error('disk-import: no active run to re-plan');
+  await replanImport({ exec, runId: run.runId, container: run.container, request });
+}
+
+/**
+ * Apply the active run. When `request` is given, RE-PLAN with the page's routing
+ * rules first (#2000) so files land in `data/<owner>/<category>/…` and the dedup
+ * splits per owner; then the host-apply applies the rewritten plan.json unchanged.
+ */
+export async function applyRun(
+  exec: SafeExec,
+  shareGid: number,
+  request?: ReplanRequest,
+): Promise<ApplyImportResult> {
   const run = await getActiveRun();
   if (!run) throw new Error('disk-import: no active run to apply');
+  // #2000: re-plan with the routing rules BEFORE applying, so the host-apply reads
+  // the owner-aware, per-owner-deduped plan.json. Skipped when no rules were sent
+  // (a plain apply of the auto-sorted plan).
+  if (request) {
+    await replanImport({ exec, runId: run.runId, container: run.container, request });
+  }
   // Resolve the REAL file-share group gid host-side — the passed `shareGid` is the
   // fallback. The apply chowns every copied file to `core:<this gid>`; a wrong gid
   // (the 1024 fallback) leaves files in an unnamed group the containers can't read

--- a/packages/backend/src/lib/diskImport/tree.test.ts
+++ b/packages/backend/src/lib/diskImport/tree.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PlanSidecar } from '@servicebay/disk-import-worker';
+
+vi.mock('@/lib/dirs', () => ({ DATA_DIR: '/app/data' }));
+
+const listLldapUsersMock = vi.fn();
+vi.mock('@/lib/lldap/client', () => ({
+  listLldapUsers: () => listLldapUsersMock(),
+}));
+
+const { sidecarRef } = vi.hoisted(() => ({ sidecarRef: { current: null as PlanSidecar | null } }));
+vi.mock('node:fs/promises', () => {
+  const m = {
+    readFile: vi.fn(async (file: string) => {
+      if (file.endsWith('plan.json')) return JSON.stringify(sidecarRef.current);
+      throw new Error(`unexpected read ${file}`);
+    }),
+  };
+  return { ...m, default: m };
+});
+
+import { buildReviewTree, relDirOf } from './tree';
+
+function planItem(sourcePath: string, category: string, size: number) {
+  const name = sourcePath.split('/').pop()!.toLowerCase();
+  return {
+    record: { sourcePath, size, mtimeMs: 0, ext: name.split('.').pop() ?? '', name },
+    category,
+    target: null,
+    action: 'copy',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listLldapUsersMock.mockResolvedValue({
+    ok: true,
+    users: [
+      { id: 'mdopp', displayName: 'Mark' },
+      { id: 'cdopp', displayName: 'Clara' },
+    ],
+  });
+  sidecarRef.current = {
+    version: 1,
+    runId: 'run1',
+    mountBase: '/mnt/src',
+    plan: {
+      items: [
+        planItem('/mnt/src/mdopp/photos/a.jpg', 'photos', 100),
+        planItem('/mnt/src/Backup/doc.pdf', 'documents', 50),
+      ],
+      conflicts: [],
+    },
+  } as PlanSidecar;
+});
+
+describe('relDirOf', () => {
+  it('returns the source-relative dir under the mountBase', () => {
+    expect(relDirOf('/mnt/src/mdopp/photos/a.jpg', '/mnt/src')).toBe('mdopp/photos');
+    expect(relDirOf('/mnt/src/a.jpg', '/mnt/src')).toBe('');
+  });
+});
+
+describe('buildReviewTree', () => {
+  it('auto-assigns a top-level folder named like a box user', async () => {
+    const review = await buildReviewTree('run1');
+    const mdoppNode = review.tree.find(n => n.dir === 'mdopp');
+    expect(mdoppNode?.resolved.owner).toBe('mdopp');
+    // explicit owner seeded by the auto-assign (overridable in the UI).
+    expect(mdoppNode?.explicit.owner).toBe('mdopp');
+  });
+
+  it('offers shared + every box user as owner options', async () => {
+    const review = await buildReviewTree('run1');
+    expect(review.owners.map(o => o.id)).toEqual(['shared', 'mdopp', 'cdopp']);
+  });
+
+  it('previews data/<owner>/<category>/… per folder', async () => {
+    const review = await buildReviewTree('run1');
+    // mdopp/photos inherits owner mdopp from the auto-assigned parent.
+    const photos = review.tree.find(n => n.dir === 'mdopp/photos');
+    expect(photos?.preview).toBe('data/mdopp/photos/…');
+    // Backup is shared by default → no owner segment.
+    const backup = review.tree.find(n => n.dir === 'Backup');
+    expect(backup?.preview).toBe('data/documents/…');
+  });
+
+  it('applies an explicit edit + the disk-default owner', async () => {
+    const review = await buildReviewTree('run1', {
+      diskDefaultOwner: 'cdopp',
+      explicit: new Map([['Backup', { disposition: 'photos_immich' }]]),
+    });
+    const backup = review.tree.find(n => n.dir === 'Backup');
+    // owner inherits the disk default (cdopp); disposition forced to photos.
+    expect(backup?.preview).toBe('data/cdopp/photos/…');
+  });
+
+  it('previews a skip folder as not-imported', async () => {
+    const review = await buildReviewTree('run1', {
+      explicit: new Map([['Backup', { disposition: 'skip' }]]),
+    });
+    const backup = review.tree.find(n => n.dir === 'Backup');
+    expect(backup?.preview).toBe('(skipped — not imported)');
+  });
+});

--- a/packages/backend/src/lib/diskImport/tree.ts
+++ b/packages/backend/src/lib/diskImport/tree.ts
@@ -1,0 +1,114 @@
+// Disk-import — review-tree builder for the routing UI (#1915 / epic #1901).
+//
+// Turns the worker's compact `plan.json` (which servicebay already reads for the
+// host-apply) into the per-folder review tree the importer page renders: one
+// FolderNode per directory with file/byte/category rollups, the auto-assigned
+// owner (top-level folder name == a box user), and the resolved effective rule.
+// NO worker change + NO re-scan: the plan sidecar already has every file's
+// source path + category + size, so the tree is derived host-side here.
+//
+// The user then edits owner + disposition per folder; those edits flow back to
+// the apply call as an explicit rule map and re-plan the import with routing
+// (see service.applyRun → applyImport, which threads a RoutingResolution).
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  buildFolderTree,
+  autoAssignOwners,
+  ROOT_DEFAULT,
+  PLAN_SIDECAR_FILE,
+  DISPOSITIONS,
+  type PlanSidecar,
+  type FolderNode,
+  type TreeFileInput,
+  type Rule,
+  type Owner,
+  type Disposition,
+} from '@servicebay/disk-import-worker';
+
+import { listLldapUsers } from '@/lib/lldap/client';
+import { runOutDir } from './apply';
+
+/** An owner choice for the picker: `shared` plus each box user. */
+export interface ReviewOwner {
+  /** The owner id used in `data/<owner>/…` and rules (`shared` or a username). */
+  id: Owner;
+  /** Human label for the dropdown. */
+  label: string;
+}
+
+export interface ReviewTree {
+  /** Every folder that holds files (+ ancestors), with rollups + resolved rule. */
+  tree: FolderNode[];
+  /** Owner picker options: `shared` first, then box users. */
+  owners: ReviewOwner[];
+  /** Disposition (target) picker options, in presentation order. */
+  dispositions: readonly Disposition[];
+  /** The worker mountBase the source paths are relative to. */
+  mountBase: string;
+}
+
+/** Relative dir of a source path under the worker mountBase (`''` = root). */
+export function relDirOf(sourcePath: string, mountBase: string): string {
+  const base = mountBase.replace(/\/+$/, '');
+  const rel =
+    sourcePath === base
+      ? ''
+      : sourcePath.startsWith(`${base}/`)
+        ? sourcePath.slice(base.length + 1)
+        : sourcePath;
+  const dir = path.posix.dirname(rel);
+  return dir === '.' || dir === '/' ? '' : dir;
+}
+
+async function loadSidecar(runId: string): Promise<PlanSidecar> {
+  const raw = await readFile(path.join(runOutDir(runId), PLAN_SIDECAR_FILE), 'utf8');
+  return JSON.parse(raw) as PlanSidecar;
+}
+
+/**
+ * Build the review tree for a completed scan. `explicit` carries the user's
+ * in-progress edits (relDir → partial Rule) so the resolved rules reflect them;
+ * empty on first load (only the exact-match owner auto-assign applies).
+ */
+export async function buildReviewTree(
+  runId: string,
+  opts: { diskDefaultOwner?: Owner; explicit?: Map<string, Rule> } = {},
+): Promise<ReviewTree> {
+  const sidecar = await loadSidecar(runId);
+
+  // Every planned file → its folder coordinate (junk included so the tree shows
+  // the whole disk; the user can mark a junk-heavy folder skip/archive).
+  const files: TreeFileInput[] = sidecar.plan.items.map(i => ({
+    dir: relDirOf(i.record.sourcePath, sidecar.mountBase),
+    category: i.category,
+    size: i.record.size,
+  }));
+
+  const usersRes = await listLldapUsers();
+  const users = usersRes.ok ? usersRes.users : [];
+  const owners: ReviewOwner[] = [
+    { id: 'shared', label: 'Shared' },
+    ...users.map(u => ({ id: u.id, label: u.displayName || u.id })),
+  ];
+
+  // Exact-match auto-assign: a top-level folder named like a box user is seeded
+  // to that owner (overridable). Merge the user's in-progress edits on top.
+  const topLevel = new Set<string>();
+  for (const f of files) {
+    const seg = f.dir.split('/')[0];
+    if (seg) topLevel.add(seg);
+  }
+  const explicit = autoAssignOwners(
+    [...topLevel],
+    users.map(u => u.id),
+    opts.explicit ?? new Map(),
+  );
+
+  const rootDefault: Partial<Rule> = { owner: opts.diskDefaultOwner ?? ROOT_DEFAULT.owner };
+  const tree = buildFolderTree(files, explicit, rootDefault);
+
+  return { tree, owners, dispositions: DISPOSITIONS, mountBase: sidecar.mountBase };
+}

--- a/packages/backend/src/lib/diskImport/tree.ts
+++ b/packages/backend/src/lib/diskImport/tree.ts
@@ -17,6 +17,8 @@ import path from 'node:path';
 import {
   buildFolderTree,
   autoAssignOwners,
+  dispositionCategory,
+  CATEGORIES,
   ROOT_DEFAULT,
   PLAN_SIDECAR_FILE,
   DISPOSITIONS,
@@ -26,6 +28,7 @@ import {
   type Rule,
   type Owner,
   type Disposition,
+  type Category,
 } from '@servicebay/disk-import-worker';
 
 import { listLldapUsers } from '@/lib/lldap/client';
@@ -39,15 +42,49 @@ export interface ReviewOwner {
   label: string;
 }
 
+/** A review-tree node: the folder rollup + resolved rule, plus a live target preview. */
+export interface ReviewNode extends FolderNode {
+  /**
+   * Live `data/<owner>/<category>/…` destination preview for this folder, derived
+   * from its resolved rule (#2000). `shared` omits the owner segment; a `skip`
+   * disposition previews as `(skipped)`. The category is the disposition's forced
+   * category, or the folder's dominant classified category for `auto`.
+   */
+  preview: string;
+}
+
 export interface ReviewTree {
-  /** Every folder that holds files (+ ancestors), with rollups + resolved rule. */
-  tree: FolderNode[];
+  /** Every folder that holds files (+ ancestors), with rollups + resolved rule + preview. */
+  tree: ReviewNode[];
   /** Owner picker options: `shared` first, then box users. */
   owners: ReviewOwner[];
   /** Disposition (target) picker options, in presentation order. */
   dispositions: readonly Disposition[];
   /** The worker mountBase the source paths are relative to. */
   mountBase: string;
+}
+
+/** The folder name (no trailing slash) a category lands in (`documents`, …). */
+function categoryFolder(category: Category): string {
+  return CATEGORIES[category].folder.replace(/\/+$/, '');
+}
+
+/**
+ * The live destination preview for a folder node (#2000): `data/<owner?>/<cat>/…`.
+ * The category is the resolved disposition's forced category (`movies_jellyfin` →
+ * `movies`), or the folder's dominant own category for `auto`. A `skip` folder
+ * previews as `(skipped — not imported)`. A folder with no files of its own (a
+ * pure ancestor) previews the owner area only.
+ */
+function previewFor(node: FolderNode): string {
+  const { owner, disposition } = node.resolved;
+  if (disposition === 'skip') return '(skipped — not imported)';
+  const ownerSeg = owner === 'shared' ? '' : `${owner}/`;
+  const forced = dispositionCategory(disposition);
+  const cat = forced ?? node.categories.find(c => c !== 'junk');
+  if (!cat) return `data/${ownerSeg}…`;
+  const folder = categoryFolder(cat);
+  return folder ? `data/${ownerSeg}${folder}/…` : `data/${ownerSeg}…`;
 }
 
 /** Relative dir of a source path under the worker mountBase (`''` = root). */
@@ -108,7 +145,8 @@ export async function buildReviewTree(
   );
 
   const rootDefault: Partial<Rule> = { owner: opts.diskDefaultOwner ?? ROOT_DEFAULT.owner };
-  const tree = buildFolderTree(files, explicit, rootDefault);
+  const folders = buildFolderTree(files, explicit, rootDefault);
+  const tree: ReviewNode[] = folders.map(node => ({ ...node, preview: previewFor(node) }));
 
   return { tree, owners, dispositions: DISPOSITIONS, mountBase: sidecar.mountBase };
 }

--- a/packages/backend/src/lib/diskImport/tree.ts
+++ b/packages/backend/src/lib/diskImport/tree.ts
@@ -64,9 +64,12 @@ export interface ReviewTree {
   mountBase: string;
 }
 
-/** The folder name (no trailing slash) a category lands in (`documents`, …). */
+/** The folder name (no trailing slash) a category lands in (`documents`, …).
+ *  CATEGORIES folders carry a single trailing `/` (or are empty); strip it
+ *  without a backtracking `/\/+$/` regex (ReDoS-safe; CodeQL flags `+$`). */
 function categoryFolder(category: Category): string {
-  return CATEGORIES[category].folder.replace(/\/+$/, '');
+  const folder = CATEGORIES[category].folder;
+  return folder.endsWith('/') ? folder.slice(0, -1) : folder;
 }
 
 /**
@@ -87,9 +90,16 @@ function previewFor(node: FolderNode): string {
   return folder ? `data/${ownerSeg}${folder}/…` : `data/${ownerSeg}…`;
 }
 
+/** Strip trailing `/` linearly (ReDoS-safe; CodeQL flags the `/\/+$/` form). */
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end -= 1;
+  return s.slice(0, end);
+}
+
 /** Relative dir of a source path under the worker mountBase (`''` = root). */
 export function relDirOf(sourcePath: string, mountBase: string): string {
-  const base = mountBase.replace(/\/+$/, '');
+  const base = stripTrailingSlashes(mountBase);
   const rel =
     sourcePath === base
       ? ''

--- a/packages/disk-import-worker/src/cli/main.test.ts
+++ b/packages/disk-import-worker/src/cli/main.test.ts
@@ -76,6 +76,11 @@ describe('parseWorkerArgs', () => {
   it('--help short-circuits', () => {
     expect(parseWorkerArgs(['--help'])).toEqual({ help: true });
   });
+
+  it('--replan returns replan-mode opts with mount/out defaults (#2000)', () => {
+    expect(parseWorkerArgs(['--replan'])).toEqual({ replan: true, mount: '/mnt/src', out: '/out' });
+    expect(parseWorkerArgs(['--replan', '--out', '/o'])).toEqual({ replan: true, mount: '/mnt/src', out: '/o' });
+  });
 });
 
 describe('runWorker (dry-run)', () => {

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -38,6 +38,7 @@ import { buildInventory, type ScannedFile } from '../engine/inventory';
 import { buildPlan, type HashResolver } from '../engine/dedup';
 import { ImportCatalog } from '../engine/catalog';
 import { applyPlan } from '../engine/plan';
+import { runReplan, REPLAN_REQUEST_FILE, type ReplanRequest, type ReplanIO } from '../engine/replan';
 import {
   immichProvisionFromEnv,
   provisionExternalLibraries,
@@ -106,6 +107,7 @@ interface ArgDraft {
   shareGid: number;
   serve?: boolean;
   port?: number;
+  replan?: boolean;
 }
 
 const VALUE_ARGS = new Set(['--mount', '--out', '--catalog', '--run-id', '--share-gid', '--port']);
@@ -141,20 +143,37 @@ export interface ServeArgs {
   shareGid: number;
 }
 
+/**
+ * Re-plan-mode options (#2000). servicebay writes the routing rules to
+ * `replan-request.json` in the shared out dir, then `podman exec`s the running
+ * serve container with `--replan` so the re-plan hashes via the LIVE mount
+ * (`mount`) — the control plane can't hash (#1983). Reads the existing plan.json
+ * (no re-scan) and rewrites it + the status rollup in place.
+ */
+export interface ReplanArgs {
+  replan: true;
+  mount: string;
+  out: string;
+}
+
 function defaultRunId(): string {
   return process.env.DISK_IMPORT_RUN_ID ?? createHash('sha1').update(String(Date.now())).digest('hex').slice(0, 12);
 }
 
-export function parseWorkerArgs(argv: string[]): WorkerOptions | ServeArgs | { help: true } {
+export function parseWorkerArgs(argv: string[]): WorkerOptions | ServeArgs | ReplanArgs | { help: true } {
   const draft: ArgDraft = { shareGid: DEFAULT_SHARE_GID };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') return { help: true };
     else if (arg === '--serve') draft.serve = true;
+    else if (arg === '--replan') draft.replan = true;
     else if (arg === '--apply') draft.mode = 'apply';
     else if (arg === '--dry-run') draft.mode = 'dry-run';
     else if (VALUE_ARGS.has(arg)) applyValueArg(draft, arg, argv[++i]);
     else throw new WorkerArgError(`Unknown argument: ${arg}`);
+  }
+  if (draft.replan) {
+    return { replan: true, mount: draft.mount ?? '/mnt/src', out: draft.out ?? '/out' };
   }
   if (draft.serve) {
     return {
@@ -400,10 +419,51 @@ export async function realProvisionImmich(photoOwners: string[]): Promise<string
   }
 }
 
+/**
+ * Run the re-plan over the already-scanned plan.json with the routing rules from
+ * `replan-request.json` in the out dir (#2000). Hashes via the LIVE read-only
+ * mount (the worker can; servicebay can't, #1983), rewrites plan.json + status.
+ * Invoked by servicebay via `podman exec <serve-container> … --replan`.
+ */
+export async function runReplanCli(opts: ReplanArgs, io?: ReplanIO): Promise<void> {
+  const resolved = io ?? realReplanIO(opts.out);
+  const reqPath = path.join(opts.out, REPLAN_REQUEST_FILE);
+  const request = JSON.parse(readFileSync(reqPath, 'utf8')) as ReplanRequest;
+  const plan = await runReplan(request, resolved);
+  console.log(`disk-import: re-planned ${plan.items.length} items, ${plan.conflicts.length} conflict(s).`);
+}
+
+/** Real (fs-backed) re-plan IO: reads the out dir, hashes via the live mount. */
+function realReplanIO(out: string): ReplanIO {
+  const writeJson = async (file: string, data: unknown): Promise<void> => {
+    mkdirSync(path.dirname(file), { recursive: true });
+    const tmp = `${file}.tmp`;
+    writeFileSync(tmp, JSON.stringify(data));
+    await fs.rename(tmp, file).catch(() => writeFileSync(file, JSON.stringify(data)));
+  };
+  return {
+    readJson: async <T>(file: string): Promise<T | null> => {
+      try {
+        return JSON.parse(readFileSync(path.join(out, file), 'utf8')) as T;
+      } catch {
+        return null;
+      }
+    },
+    writePlanSidecar: sidecar => writeJson(path.join(out, PLAN_SIDECAR_FILE), sidecar),
+    writeStatus: status => writeJson(path.join(out, STATUS_FILE), status),
+    hashOf: hashFileContent,
+    fingerprintOf: fingerprintFileContent,
+  };
+}
+
 async function main(): Promise<void> {
   const parsed = parseWorkerArgs(process.argv.slice(2));
   if ('help' in parsed) {
     console.log(USAGE);
+    return;
+  }
+  if ('replan' in parsed) {
+    await runReplanCli(parsed);
     return;
   }
   if ('serve' in parsed) {

--- a/packages/disk-import-worker/src/engine/replan.test.ts
+++ b/packages/disk-import-worker/src/engine/replan.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { runReplan, relPathUnder, toRoutingResolution, type ReplanIO } from './replan';
+import { PLAN_SIDECAR_FILE, STATUS_FILE, type PlanSidecar, type WorkerStatus } from '../contract/status';
+import type { ImportPlan, ImportPlanItem, ImportRecord } from './types';
+
+/** A scanned record under /mnt/src. */
+function rec(sourcePath: string, size: number): ImportRecord {
+  const name = sourcePath.split('/').pop()!.toLowerCase();
+  return { sourcePath, size, mtimeMs: 0, ext: name.split('.').pop() ?? '', name };
+}
+
+/** A plan item carrying just the record (replan reads only item.record). */
+function item(r: ImportRecord): ImportPlanItem {
+  return { record: r, category: 'documents', target: null, action: 'copy' };
+}
+
+/** Build an in-memory ReplanIO seam. `hashOf` keys by content map (path→sha). */
+function makeIO(sidecar: PlanSidecar, contentByPath: Record<string, string>) {
+  const written: { sidecar?: PlanSidecar; status?: WorkerStatus } = {};
+  const files: Record<string, unknown> = {
+    [PLAN_SIDECAR_FILE]: sidecar,
+    [STATUS_FILE]: { version: 1, runId: sidecar.runId, scanned: sidecar.plan.items.length } as Partial<WorkerStatus>,
+  };
+  const hashOf = vi.fn((r: ImportRecord) => contentByPath[r.sourcePath] ?? r.sourcePath);
+  const io: ReplanIO = {
+    readJson: async <T>(f: string) => (files[f] as T) ?? null,
+    writePlanSidecar: async s => {
+      written.sidecar = s;
+      files[PLAN_SIDECAR_FILE] = s;
+    },
+    writeStatus: async s => {
+      written.status = s;
+    },
+    hashOf,
+    fingerprintOf: hashOf,
+    now: () => 1000,
+  };
+  return { io, written, hashOf };
+}
+
+describe('relPathUnder', () => {
+  it('strips the mountBase prefix', () => {
+    expect(relPathUnder('/mnt/src/mdopp/photos/a.jpg', '/mnt/src')).toBe('mdopp/photos/a.jpg');
+    expect(relPathUnder('/mnt/src', '/mnt/src')).toBe('');
+    expect(relPathUnder('/mnt/src/', '/mnt/src')).toBe(''); // trailing-slash base
+  });
+});
+
+describe('toRoutingResolution', () => {
+  it('builds an explicit Map + relPathOf from the wire request', () => {
+    const res = toRoutingResolution({ explicit: { mdopp: { owner: 'mdopp' } }, rootDefault: { owner: 'shared' } }, '/mnt/src');
+    expect(res.explicit.get('mdopp')).toEqual({ owner: 'mdopp' });
+    expect(res.rootDefault).toEqual({ owner: 'shared' });
+    expect(res.relPathOf(rec('/mnt/src/mdopp/x.txt', 1))).toBe('mdopp/x.txt');
+  });
+});
+
+describe('runReplan — per-owner re-dedup (the #2000 architectural finding)', () => {
+  // The SAME bytes live in two top-level folders. A flat (shared-scope) plan
+  // dedups them — only ONE copies. Assigning each folder a different owner must
+  // re-dedup PER OWNER so BOTH copy, each into its owner's area.
+  const sidecar: PlanSidecar = {
+    version: 1,
+    runId: 'run1',
+    mountBase: '/mnt/src',
+    plan: {
+      items: [
+        item(rec('/mnt/src/alice/report.pdf', 100)),
+        item(rec('/mnt/src/bob/report.pdf', 100)),
+      ],
+      conflicts: [],
+    } as ImportPlan,
+  };
+  // Identical content → same hash → would dedup in a single area.
+  const content = { '/mnt/src/alice/report.pdf': 'sha-X', '/mnt/src/bob/report.pdf': 'sha-X' };
+
+  it('drops the cross-folder duplicate when both are shared (baseline)', async () => {
+    const { io } = makeIO(sidecar, content);
+    const plan = await runReplan({ explicit: {} }, io);
+    const copies = plan.items.filter(i => i.action === 'copy');
+    const dupes = plan.items.filter(i => i.action === 'skip-dupe');
+    expect(copies).toHaveLength(1); // shared scope → second is a dupe
+    expect(dupes).toHaveLength(1);
+  });
+
+  it('lets the same bytes land in BOTH owners’ areas when assigned per owner', async () => {
+    const { io, written } = makeIO(sidecar, content);
+    const plan = await runReplan(
+      { explicit: { alice: { owner: 'alice' }, bob: { owner: 'bob' } } },
+      io,
+    );
+    const copies = plan.items.filter(i => i.action === 'copy');
+    expect(copies).toHaveLength(2); // per-owner dedup → both copy
+    const targets = copies.map(c => c.target).sort();
+    expect(targets).toEqual(['alice/documents/report.pdf', 'bob/documents/report.pdf']);
+    // The sidecar was rewritten with the new plan.
+    expect(written.sidecar?.plan.items.filter(i => i.action === 'copy')).toHaveLength(2);
+    // The status rollup reflects the re-plan.
+    expect(written.status?.planned).toBe(2);
+    expect(written.status?.phase).toBe('done');
+    expect(written.status?.conflicts).toBe(0);
+  });
+
+  it('routes a forced disposition + owner into data/<owner>/<category>', async () => {
+    const photos: PlanSidecar = {
+      ...sidecar,
+      plan: { items: [item(rec('/mnt/src/cam/IMG_1.jpg', 5))], conflicts: [] },
+    };
+    const { io } = makeIO(photos, { '/mnt/src/cam/IMG_1.jpg': 'sha-c' });
+    const plan = await runReplan(
+      { explicit: { cam: { owner: 'mdopp', disposition: 'photos_immich' } } },
+      io,
+    );
+    expect(plan.items[0].target).toBe('mdopp/photos/IMG_1.jpg');
+    expect(plan.items[0].category).toBe('photos');
+  });
+
+  it('skips a folder marked skip', async () => {
+    const { io } = makeIO(sidecar, content);
+    const plan = await runReplan({ explicit: { alice: { disposition: 'skip' } } }, io);
+    const aliceItem = plan.items.find(i => i.record.sourcePath.includes('/alice/'));
+    expect(aliceItem?.action).toBe('skip-junk');
+    expect(aliceItem?.target).toBeNull();
+  });
+
+  it('throws when there is no plan to re-plan', async () => {
+    const { io } = makeIO(sidecar, content);
+    const empty: ReplanIO = { ...io, readJson: async () => null };
+    await expect(runReplan({ explicit: {} }, empty)).rejects.toThrow(/no plan/);
+  });
+});

--- a/packages/disk-import-worker/src/engine/replan.ts
+++ b/packages/disk-import-worker/src/engine/replan.ts
@@ -63,9 +63,19 @@ export interface ReplanIO {
   now?: () => number;
 }
 
+/**
+ * Strip trailing `/` without a backtracking `/\/+$/` regex (ReDoS-safe — the
+ * CodeQL `js/polynomial-redos` rule flags the `+$` form; this is linear).
+ */
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end -= 1;
+  return s.slice(0, end);
+}
+
 /** The relative dir of a source path under `mountBase` (`''` = the disk root). */
 export function relPathUnder(sourcePath: string, mountBase: string): string {
-  const base = mountBase.replace(/\/+$/, '');
+  const base = stripTrailingSlashes(mountBase);
   if (sourcePath === base) return '';
   if (sourcePath.startsWith(`${base}/`)) return sourcePath.slice(base.length + 1);
   return sourcePath; // not under the base (defensive) — route by its own path.

--- a/packages/disk-import-worker/src/engine/replan.ts
+++ b/packages/disk-import-worker/src/engine/replan.ts
@@ -1,0 +1,173 @@
+// disk-import-worker — RE-PLAN with the per-folder routing rules (#2000 / epic
+// #1901, the routing-tree review UI).
+//
+// THE ARCHITECTURAL FINDING (issue #2000): making the operator's per-folder owner
+// + disposition picks actually route requires RE-PLANNING with the routing rules
+// AND re-deduping PER OWNER. A naive "rewrite the copy targets to `<owner>/…` on
+// the existing flat plan" is WRONG: the first plan deduped in the single `shared`
+// scope, so a file that's a cross-owner duplicate was marked `skip-dupe` and the
+// 2nd owner would never get it. The dedup area follows the resolved owner, so a
+// re-plan splits the conflicts per person and lets the same bytes land in two
+// owners' areas. Re-dedup needs CONTENT HASHING, and ONLY the worker can hash:
+// the source disk is bind-mounted read-only at `mountBase` (`/mnt/src`) HERE, but
+// NOT in servicebay's control-plane container (#1983). So the re-plan runs in the
+// worker, over the already-scanned records (no re-walk) + the live mount.
+//
+// The records come straight from the existing `plan.json` sidecar (every item
+// already carries its full `ImportRecord` — sourcePath + size + mtime + ext),
+// so re-planning never re-scans the disk; it only re-classifies/re-dedups/re-routes
+// with the routing tree and rewrites the sidecar + the compact status rollup.
+// servicebay's host-apply then applies the rewritten `plan.json` UNCHANGED.
+
+import path from 'node:path';
+
+import { buildPlan, type HashResolver, type RoutingResolution } from './dedup';
+import { effectiveRule } from './routing';
+import type { ImportPlan, ImportRecord, Rule } from './types';
+import {
+  PLAN_SIDECAR_FILE,
+  STATUS_FILE,
+  STATUS_CONTRACT_VERSION,
+  summarizeCategories,
+  type PlanSidecar,
+  type WorkerStatus,
+} from '../contract/status';
+
+/**
+ * The re-plan request the page produces: the explicit (auto-assigned + edited)
+ * routing rules keyed by source-relative directory, plus the disk-default owner
+ * (the root-level default applied where no folder sets an owner). This is the wire
+ * shape servicebay writes to `replan-request.json` in the shared out dir and the
+ * body of `POST /api/replan`.
+ */
+export interface ReplanRequest {
+  /** relDir → the (partial) Rule the operator set on that folder (`''` = root). */
+  explicit: Record<string, Rule>;
+  /** The disk-default owner / root default (e.g. `{ owner: 'mdopp' }`). */
+  rootDefault?: Partial<Rule>;
+}
+
+/** IO seams so the re-plan is unit-testable without a real filesystem. */
+export interface ReplanIO {
+  /** Read + parse a JSON file under the out dir; null when absent/unparseable. */
+  readJson: <T>(file: string) => Promise<T | null>;
+  /** Persist the heavy plan sidecar (atomic-ish). */
+  writePlanSidecar: (sidecar: PlanSidecar) => Promise<void>;
+  /** Persist the compact status doc (atomic-ish). */
+  writeStatus: (status: WorkerStatus) => Promise<void>;
+  /** FULL content hash (sha256) of a record's bytes — reads via the live mount. */
+  hashOf: HashResolver;
+  /** Cheap content FINGERPRINT (head/middle/tail + size) — the dedup identity. */
+  fingerprintOf: HashResolver;
+  /** Clock for deterministic dates/tests. */
+  now?: () => number;
+}
+
+/** The relative dir of a source path under `mountBase` (`''` = the disk root). */
+export function relPathUnder(sourcePath: string, mountBase: string): string {
+  const base = mountBase.replace(/\/+$/, '');
+  if (sourcePath === base) return '';
+  if (sourcePath.startsWith(`${base}/`)) return sourcePath.slice(base.length + 1);
+  return sourcePath; // not under the base (defensive) — route by its own path.
+}
+
+/**
+ * Turn the wire request's plain object rule map into the engine's `Map` and a
+ * {@link RoutingResolution} over the plan's records. `relPathOf` strips the worker
+ * `mountBase` so the routing tree's folder coordinates match the page's relDirs.
+ */
+export function toRoutingResolution(req: ReplanRequest, mountBase: string): RoutingResolution {
+  const explicit = new Map<string, Rule>(Object.entries(req.explicit ?? {}));
+  return {
+    relPathOf: (record: ImportRecord) => relPathUnder(record.sourcePath, mountBase),
+    explicit,
+    rootDefault: req.rootDefault ?? {},
+  };
+}
+
+/**
+ * Re-run the deterministic plan over the already-scanned records with the routing
+ * tree applied (per-owner dedup + owner-aware targets + forced dispositions), then
+ * rewrite the plan sidecar and the compact status rollup. Returns the new plan.
+ *
+ * Reads the records from the EXISTING `plan.json` (no re-scan); hashes via the
+ * injected resolvers (which read the live read-only mount). Idempotent: re-planning
+ * with the same request yields the same plan.
+ *
+ * @throws if there is no plan sidecar yet (a re-plan before a scan completed).
+ */
+export async function runReplan(req: ReplanRequest, io: ReplanIO): Promise<ImportPlan> {
+  const sidecar = await io.readJson<PlanSidecar>(PLAN_SIDECAR_FILE);
+  if (!sidecar) throw new Error('disk-import: no plan to re-plan — scan first');
+
+  const records: ImportRecord[] = sidecar.plan.items.map(i => i.record);
+  const routing = toRoutingResolution(req, sidecar.mountBase);
+
+  const plan = buildPlan(records, io.hashOf, {
+    routing,
+    fingerprintOf: io.fingerprintOf,
+  });
+
+  const newSidecar: PlanSidecar = {
+    version: STATUS_CONTRACT_VERSION,
+    runId: sidecar.runId,
+    plan,
+    mountBase: sidecar.mountBase,
+  };
+  await io.writePlanSidecar(newSidecar);
+
+  // Refresh the compact status rollup so the tile poll reflects the re-plan
+  // (new per-category copy/skip/conflict counts + the dropped conflict total).
+  const prev = await io.readJson<WorkerStatus>(STATUS_FILE);
+  const now = (io.now ?? Date.now)();
+  const totalBytes = plan.items.reduce((sum, i) => sum + i.record.size, 0);
+  const status: WorkerStatus = {
+    ...(prev ?? freshStatus(sidecar.runId, now)),
+    phase: 'done',
+    mode: 'dry-run',
+    step: `Re-planned: ${plan.items.length} items, ${plan.conflicts.length} conflict(s).`,
+    planned: plan.items.length,
+    conflicts: plan.conflicts.length,
+    categories: summarizeCategories(plan),
+    totalBytes,
+    planSidecar: PLAN_SIDECAR_FILE,
+    error: null,
+    updatedAt: now,
+  };
+  await io.writeStatus(status);
+
+  return plan;
+}
+
+/** A minimal status doc when none exists yet (the worker always writes one first
+ *  during the scan, so this is only a defensive fallback). */
+function freshStatus(runId: string, now: number): WorkerStatus {
+  return {
+    version: STATUS_CONTRACT_VERSION,
+    runId,
+    phase: 'planning',
+    step: 'Re-planning …',
+    mode: 'dry-run',
+    scanned: 0,
+    planned: 0,
+    applied: 0,
+    conflicts: 0,
+    categories: [],
+    totalBytes: 0,
+    planSidecar: PLAN_SIDECAR_FILE,
+    error: null,
+    updatedAt: now,
+    startedAt: now,
+  };
+}
+
+/** Re-export so callers needn't reach into routing.ts for a target preview. */
+export { effectiveRule };
+
+/** The canonical file name servicebay writes the re-plan request to (shared out). */
+export const REPLAN_REQUEST_FILE = 'replan-request.json';
+
+/** Resolve the request file path under an out dir (worker CLI + servicebay share). */
+export function replanRequestPath(outDir: string): string {
+  return path.join(outDir, REPLAN_REQUEST_FILE);
+}

--- a/packages/disk-import-worker/src/index.ts
+++ b/packages/disk-import-worker/src/index.ts
@@ -22,6 +22,7 @@ export * from './engine/inventory';
 export * from './engine/mounter';
 export * from './engine/ollama';
 export * from './engine/plan';
+export * from './engine/replan';
 export * from './engine/routing';
 export * from './engine/suggest';
 

--- a/packages/disk-import-worker/src/server/index.ts
+++ b/packages/disk-import-worker/src/server/index.ts
@@ -11,9 +11,14 @@
 // it does NOT re-enumerate or re-mount inside the container.
 
 import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { startServer, fileReader, moduleDir, type ServerDeps } from './server';
+import { runReplan, type ReplanIO, type ReplanRequest } from '../engine/replan';
+import { PLAN_SIDECAR_FILE, STATUS_FILE } from '../contract/status';
+import { hashFileContent, fingerprintFileContent } from '../cli/main';
 
 /** The read-only mount + shared out paths the container is launched with. */
 export interface ServeOptions {
@@ -57,8 +62,35 @@ export function serveDeps(opts: ServeOptions): ServerDeps {
     launchJob: async mode => {
       if (mode === 'dry-run') launchWorkerChild(opts);
     },
+    // RE-PLAN runs IN-PROCESS here: serve mode has the device bind-mounted at
+    // `opts.mount`, so the hashers can read the bytes to re-dedup per owner (the
+    // control plane can't, #1983). Reads/rewrites plan.json + status in the out dir.
+    replan: async request => {
+      const plan = await runReplan(request, serveReplanIO(opts.out));
+      return { planned: plan.items.length, conflicts: plan.conflicts.length };
+    },
   };
 }
+
+/** fs-backed re-plan IO over the out dir, hashing via the live mount. */
+function serveReplanIO(out: string): ReplanIO {
+  const writeJson = async (file: string, data: unknown): Promise<void> => {
+    mkdirSync(path.dirname(file), { recursive: true });
+    const tmp = `${file}.tmp`;
+    writeFileSync(tmp, JSON.stringify(data));
+    await fs.rename(tmp, file).catch(() => writeFileSync(file, JSON.stringify(data)));
+  };
+  return {
+    readJson: fileReader(out),
+    writePlanSidecar: sidecar => writeJson(path.join(out, PLAN_SIDECAR_FILE), sidecar),
+    writeStatus: status => writeJson(path.join(out, STATUS_FILE), status),
+    hashOf: hashFileContent,
+    fingerprintOf: fingerprintFileContent,
+  };
+}
+
+/** Re-export the request type for callers building the serve deps. */
+export type { ReplanRequest };
 
 /** Start the worker app server over the bind-mounted device + out volume. */
 export function serve(opts: ServeOptions) {

--- a/packages/disk-import-worker/src/server/server.test.ts
+++ b/packages/disk-import-worker/src/server/server.test.ts
@@ -95,4 +95,32 @@ describe('worker server handleRequest', () => {
     await handleRequest(deps(), mockReq('GET', '/nope'), res);
     expect(res.statusCode).toBe(404);
   });
+
+  it('re-plans via POST /api/replan and returns the new counts', async () => {
+    const replan = vi.fn(async () => ({ planned: 5, conflicts: 0 }));
+    const res = mockRes();
+    await handleRequest(
+      deps({ replan }),
+      mockReq('POST', '/api/replan', { explicit: { mdopp: { owner: 'mdopp' } } }),
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ ok: true, planned: 5, conflicts: 0 });
+    expect(replan).toHaveBeenCalledWith({ explicit: { mdopp: { owner: 'mdopp' } }, rootDefault: undefined });
+  });
+
+  it('503s /api/replan when the seam is absent (sandboxed deps)', async () => {
+    const res = mockRes();
+    await handleRequest(deps(), mockReq('POST', '/api/replan', { explicit: {} }), res);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('409s /api/replan when there is no plan yet', async () => {
+    const replan = vi.fn(async () => {
+      throw new Error('disk-import: no plan to re-plan — scan first');
+    });
+    const res = mockRes();
+    await handleRequest(deps({ replan }), mockReq('POST', '/api/replan', { explicit: {} }), res);
+    expect(res.statusCode).toBe(409);
+  });
 });

--- a/packages/disk-import-worker/src/server/server.ts
+++ b/packages/disk-import-worker/src/server/server.ts
@@ -31,6 +31,7 @@ import { fileURLToPath } from 'node:url';
 
 import { STATUS_FILE, PLAN_SIDECAR_FILE, type WorkerStatus, type PlanSidecar } from '../contract/status';
 import { lazyChildren, type LazyTreeLevel } from '../contract/lazyTree';
+import type { ReplanRequest } from '../engine/replan';
 import { APP_HTML } from './appHtml';
 
 /** Seams so the server is testable without a real filesystem / child process. */
@@ -44,6 +45,14 @@ export interface ServerDeps {
   /** Launch the heavy DRY-RUN scan/plan job as a detached child. (Apply runs in
    *  servicebay over the host mount, #1972 — never in this sandboxed worker.) */
   launchJob: (mode: 'dry-run', device: string) => Promise<void>;
+  /**
+   * RE-PLAN the existing plan with the page's routing rules (#2000): re-classify /
+   * re-route / re-dedup PER OWNER over the already-scanned records, hashing via the
+   * live read-only mount (only the worker can — #1983), then rewrite plan.json +
+   * the status rollup. Returns the new planned/conflict counts. Throws when no
+   * plan exists yet. Optional so the one-shot ServerDeps (tests) needn't supply it.
+   */
+  replan?: (request: ReplanRequest) => Promise<{ planned: number; conflicts: number }>;
 }
 
 /** JSON response helper. */
@@ -103,6 +112,31 @@ async function handleLaunch(
   sendJson(res, 202, { ok: true });
 }
 
+/**
+ * POST /api/replan → re-plan the existing plan with the page's routing rules
+ * (#2000). Body: `{ explicit: Record<relDir, Rule>, rootDefault?: Partial<Rule> }`.
+ * 409 when no plan exists yet (re-plan before a scan completed); 503 when this
+ * server wasn't given a `replan` seam (the sandboxed one-shot deps).
+ */
+async function handleReplan(deps: ServerDeps, req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!deps.replan) {
+    sendJson(res, 503, { error: 're-plan not available in this mode' });
+    return;
+  }
+  const body = (await readBody(req)) as unknown as ReplanRequest;
+  const request: ReplanRequest = {
+    explicit: body.explicit ?? {},
+    rootDefault: body.rootDefault,
+  };
+  try {
+    const result = await deps.replan(request);
+    sendJson(res, 200, { ok: true, ...result });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    sendJson(res, message.includes('no plan') ? 409 : 500, { error: message });
+  }
+}
+
 /** Dispatch a GET request to its handler, or null when none matches. */
 function getRoute(
   deps: ServerDeps,
@@ -135,6 +169,8 @@ export async function handleRequest(deps: ServerDeps, req: IncomingMessage, res:
       if (handled) return await handled;
     } else if (req.method === 'POST' && url.pathname === '/api/scan') {
       return await handleLaunch(deps, req, res);
+    } else if (req.method === 'POST' && url.pathname === '/api/replan') {
+      return await handleReplan(deps, req, res);
     }
     sendJson(res, 404, { error: 'not found' });
   } catch (e) {

--- a/packages/frontend/src/app/(dashboard)/disk-import/_lib/RoutingTree.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/_lib/RoutingTree.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+// Disk-import — per-folder ROUTING TREE review UI (#2000, epic #1901).
+//
+// A REAL expandable folder tree (not a flat list of text fields, per the operator):
+// each folder shows its file/size rollup and gets an Owner picker (shared / box
+// users) + a Target/disposition picker. Edits are INHERITED down the tree, so a
+// child reflects its ancestor's pick (shown muted "inherited") until the operator
+// sets it explicitly (shown solid). A top-level folder named like a box user is
+// auto-assigned to that owner and shown pre-selected. Each folder previews its live
+// `data/<owner>/<category>/…` destination. The collected explicit rule map drives
+// the re-plan (re-route + re-dedup per owner in the worker) → review → Import.
+
+import { useMemo, useState } from 'react';
+import { ChevronRight, ChevronDown, Folder, FileText } from 'lucide-react';
+import {
+  DISPOSITION_LABELS,
+  type Disposition,
+  type ReviewNode,
+  type ReviewOwner,
+  type ReviewTree,
+  type Rule,
+} from './types';
+
+/** Initial auto-expand depth — show the disk root + its top-level folders. */
+const DEFAULT_EXPAND_DEPTH = 2;
+
+/** Bytes → short human size (e.g. "457 GB"). */
+function fmtBytes(bytes: number): string {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const val = bytes / 1024 ** i;
+  return `${val >= 100 || i === 0 ? Math.round(val) : val.toFixed(1)} ${units[i]}`;
+}
+
+/** Display name of a folder (its last path segment); the root is "Disk root". */
+function dirLabel(dir: string): string {
+  if (dir === '') return 'Disk root';
+  const segs = dir.split('/');
+  return segs[segs.length - 1];
+}
+
+/** Depth of a dir (root = 0). */
+function depthOf(dir: string): number {
+  return dir === '' ? 0 : dir.split('/').length;
+}
+
+/** A node plus its children, assembled from the flat (sorted) node list. */
+interface TreeRow {
+  node: ReviewNode;
+  children: TreeRow[];
+}
+
+/** Build the nested tree from the flat node list (each node knows its full dir). */
+function nest(nodes: ReviewNode[]): TreeRow | null {
+  const byDir = new Map<string, TreeRow>();
+  for (const node of nodes) byDir.set(node.dir, { node, children: [] });
+  let root: TreeRow | null = null;
+  for (const row of byDir.values()) {
+    const dir = row.node.dir;
+    if (dir === '') {
+      root = row;
+      continue;
+    }
+    const slash = dir.lastIndexOf('/');
+    const parentDir = slash === -1 ? '' : dir.slice(0, slash);
+    byDir.get(parentDir)?.children.push(row);
+  }
+  // Stable child order by name.
+  for (const row of byDir.values()) {
+    row.children.sort((a, b) => (a.node.dir < b.node.dir ? -1 : 1));
+  }
+  return root;
+}
+
+export interface RoutingTreeProps {
+  data: ReviewTree;
+  /** The current explicit rule map (relDir → edited Rule), controlled by the page. */
+  rules: Record<string, Rule>;
+  /** Set/clear one folder's axis; the page re-fetches the tree to re-resolve. */
+  onSetRule: (dir: string, patch: Rule) => void;
+}
+
+/** The routing tree: a real expandable folder tree with owner + target pickers. */
+export function RoutingTree({ data, rules, onSetRule }: RoutingTreeProps) {
+  const root = useMemo(() => nest(data.tree), [data.tree]);
+  // Auto-expand the first couple of levels; the operator drills deeper on demand.
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const init = new Set<string>();
+    for (const n of data.tree) if (depthOf(n.dir) < DEFAULT_EXPAND_DEPTH) init.add(n.dir);
+    return init;
+  });
+  const toggle = (dir: string) =>
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(dir)) next.delete(dir);
+      else next.add(dir);
+      return next;
+    });
+
+  if (!root) return null;
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800">
+      <Row
+        row={root}
+        data={data}
+        rules={rules}
+        onSetRule={onSetRule}
+        expanded={expanded}
+        toggle={toggle}
+      />
+    </div>
+  );
+}
+
+function Row({
+  row,
+  data,
+  rules,
+  onSetRule,
+  expanded,
+  toggle,
+}: {
+  row: TreeRow;
+  data: ReviewTree;
+  rules: Record<string, Rule>;
+  onSetRule: (dir: string, patch: Rule) => void;
+  expanded: Set<string>;
+  toggle: (dir: string) => void;
+}) {
+  const { node } = row;
+  const isOpen = expanded.has(node.dir);
+  const hasChildren = row.children.length > 0;
+  const depth = depthOf(node.dir);
+  const explicit = rules[node.dir] ?? node.explicit;
+  const indent = 8 + depth * 16;
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-2 py-1.5 pr-3 text-xs hover:bg-gray-50 dark:hover:bg-gray-800/40"
+        style={{ paddingLeft: `${indent}px` }}
+      >
+        <button
+          onClick={() => hasChildren && toggle(node.dir)}
+          className={`shrink-0 ${hasChildren ? 'text-gray-500' : 'invisible'}`}
+          aria-label={isOpen ? 'Collapse' : 'Expand'}
+        >
+          {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </button>
+        <Folder size={14} className="shrink-0 text-amber-500" />
+        <span className="font-medium text-gray-800 dark:text-gray-200 truncate" title={node.dir || '/'}>
+          {dirLabel(node.dir)}
+        </span>
+        {node.files > 0 && (
+          <span className="shrink-0 text-gray-400 tabular-nums">
+            {node.files.toLocaleString()} · {fmtBytes(node.bytes)}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          <OwnerPicker
+            owners={data.owners}
+            value={node.resolved.owner}
+            explicit={explicit.owner}
+            onChange={owner => onSetRule(node.dir, { owner })}
+          />
+          <TargetPicker
+            dispositions={data.dispositions}
+            value={node.resolved.disposition}
+            explicit={explicit.disposition}
+            onChange={disposition => onSetRule(node.dir, { disposition })}
+          />
+        </div>
+      </div>
+      <div
+        className="flex items-center gap-1.5 pb-1.5 text-[11px] text-gray-400"
+        style={{ paddingLeft: `${indent + 22}px` }}
+      >
+        <FileText size={11} className="shrink-0" />
+        <span className="font-mono truncate" title={node.preview}>{node.preview}</span>
+      </div>
+      {isOpen &&
+        row.children.map(child => (
+          <Row
+            key={child.node.dir}
+            row={child}
+            data={data}
+            rules={rules}
+            onSetRule={onSetRule}
+            expanded={expanded}
+            toggle={toggle}
+          />
+        ))}
+    </>
+  );
+}
+
+/** Owner dropdown. Muted when the value is inherited (not set on this node). */
+function OwnerPicker({
+  owners,
+  value,
+  explicit,
+  onChange,
+}: {
+  owners: ReviewOwner[];
+  value: string;
+  explicit?: string;
+  onChange: (owner: string) => void;
+}) {
+  const inherited = explicit === undefined;
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      title={inherited ? 'Inherited — pick to set explicitly' : 'Set on this folder'}
+      className={`rounded border px-1.5 py-0.5 text-[11px] bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 ${
+        inherited ? 'text-gray-400 italic' : 'text-gray-800 dark:text-gray-200 font-medium'
+      }`}
+    >
+      {owners.map(o => (
+        <option key={o.id} value={o.id}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/** Target/disposition dropdown. Muted when inherited. */
+function TargetPicker({
+  dispositions,
+  value,
+  explicit,
+  onChange,
+}: {
+  dispositions: Disposition[];
+  value: Disposition;
+  explicit?: Disposition;
+  onChange: (d: Disposition) => void;
+}) {
+  const inherited = explicit === undefined;
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value as Disposition)}
+      title={inherited ? 'Inherited — pick to set explicitly' : 'Set on this folder'}
+      className={`rounded border px-1.5 py-0.5 text-[11px] bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 ${
+        inherited ? 'text-gray-400 italic' : 'text-gray-800 dark:text-gray-200 font-medium'
+      }`}
+    >
+      {dispositions.map(d => (
+        <option key={d} value={d}>
+          {DISPOSITION_LABELS[d]}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/disk-import/_lib/types.ts
+++ b/packages/frontend/src/app/(dashboard)/disk-import/_lib/types.ts
@@ -1,0 +1,74 @@
+// Disk-import routing-tree review UI — wire types (#2000).
+//
+// These mirror the backend `buildReviewTree` response + the engine Rule/Owner/
+// Disposition shapes. They live HERE (a feature-local `_lib`, relative import)
+// rather than importing `@servicebay/disk-import-worker`: that barrel pulls
+// better-sqlite3 + node:fs (catalog.ts/hostExec.ts) and would break the browser
+// bundle. The route validates the values server-side; the UI only needs the shapes.
+
+export type Owner = string; // `shared` or a box-user id.
+export type RoutingMode = 'merge' | 'parallel';
+export type Disposition =
+  | 'auto'
+  | 'photos_immich'
+  | 'movies_jellyfin'
+  | 'music'
+  | 'audiobooks'
+  | 'podcasts'
+  | 'documents_merge'
+  | 'code_parallel'
+  | 'archive_1to1'
+  | 'skip';
+
+/** A folder's explicit (partial) routing rule — every axis optional. */
+export interface Rule {
+  disposition?: Disposition;
+  mode?: RoutingMode;
+  owner?: Owner;
+}
+
+/** A folder's fully-resolved rule (inherited where not explicit) + the anchor. */
+export interface ResolvedRule {
+  disposition: Disposition;
+  mode: RoutingMode;
+  owner: Owner;
+  anchor: string;
+}
+
+/** One review-tree node (folder rollup + resolved rule + live target preview). */
+export interface ReviewNode {
+  dir: string;
+  files: number;
+  bytes: number;
+  categories: string[];
+  explicit: Rule;
+  resolved: ResolvedRule;
+  preview: string;
+}
+
+export interface ReviewOwner {
+  id: Owner;
+  label: string;
+}
+
+export interface ReviewTree {
+  ok: boolean;
+  tree: ReviewNode[];
+  owners: ReviewOwner[];
+  dispositions: Disposition[];
+  mountBase: string;
+}
+
+/** Human label for each disposition in the target picker. */
+export const DISPOSITION_LABELS: Record<Disposition, string> = {
+  auto: 'Auto-sort',
+  photos_immich: 'Photos & videos → Immich',
+  movies_jellyfin: 'Movies → Jellyfin',
+  music: 'Music',
+  audiobooks: 'Audiobooks',
+  podcasts: 'Podcasts',
+  documents_merge: 'Documents (merge)',
+  code_parallel: 'Code / folders (keep structure)',
+  archive_1to1: 'Archive 1:1',
+  skip: 'Skip (don’t import)',
+};

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -12,6 +12,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, HardDrive, RefreshCw, Download } from 'lucide-react';
+import { RoutingTree } from './_lib/RoutingTree';
+import type { ReviewTree, Rule } from './_lib/types';
 
 interface DeviceView {
   path: string;
@@ -133,11 +135,62 @@ function useDiskImportRun(selected: string, onAfterAbort: () => void) {
   };
 
   // APPLY runs on the HOST in servicebay (#1972) — the sandboxed worker only
-  // scanned/planned. POST kicks off the privileged host apply; the status poll
-  // then reflects the `applying` → `done` phase the backend writes.
-  const apply = () => runAction('/api/system/disk-import/apply');
+  // scanned/planned. POST kicks off the privileged host apply; when routing rules
+  // are passed (#2000) servicebay re-plans with them (re-route + re-dedup per
+  // owner) BEFORE applying. The status poll reflects `applying` → `done`.
+  const apply = (rules?: Record<string, Rule>, rootDefault?: Rule) =>
+    runAction('/api/system/disk-import/apply', rules ? { rules, rootDefault } : undefined);
 
   return { run, launching, error, launch, startOver, apply };
+}
+
+/** Fetch + edit the per-folder routing tree (#2000). Holds the explicit rule map
+ *  and re-fetches the tree (host-side re-resolution) on each edit so resolved
+ *  rules + the live target preview stay current. */
+function useRoutingTree(active: boolean) {
+  const [data, setData] = useState<ReviewTree | null>(null);
+  const [rules, setRules] = useState<Record<string, Rule>>({});
+
+  const fetchTree = useCallback(async (currentRules: Record<string, Rule>) => {
+    const hasEdits = Object.keys(currentRules).length > 0;
+    const res = await fetch('/api/system/disk-import/tree', {
+      method: hasEdits ? 'POST' : 'GET',
+      ...(hasEdits
+        ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ rules: currentRules }) }
+        : {}),
+    });
+    return res.ok ? ((await res.json()) as ReviewTree) : null;
+  }, []);
+
+  // Load the tree when the plan becomes ready. The setState is in the async
+  // callback (post-await), guarded by a cancellation flag — never synchronous.
+  useEffect(() => {
+    if (!active) return;
+    let live = true;
+    void fetchTree({}).then(t => {
+      if (live && t) setData(t);
+    });
+    return () => {
+      live = false;
+    };
+  }, [active, fetchTree]);
+
+  // Set one folder's axis (or clear it when re-picking the inherited value is not
+  // needed — we keep explicit picks; the engine treats absent axes as inherited).
+  const setRule = useCallback(
+    (dir: string, patch: Rule) => {
+      setRules(prev => {
+        const next = { ...prev, [dir]: { ...prev[dir], ...patch } };
+        void fetchTree(next).then(t => {
+          if (t) setData(t);
+        });
+        return next;
+      });
+    },
+    [fetchTree],
+  );
+
+  return { data, rules, setRule };
 }
 
 export default function DiskImportPage() {
@@ -147,9 +200,12 @@ export default function DiskImportPage() {
     setSelected('');
     refresh();
   });
+  // The routing tree is only meaningful once a scan has produced a plan to review.
+  const planReady = tileState(run) === 'plan-ready';
+  const { data: tree, rules, setRule } = useRoutingTree(planReady);
 
   return (
-    <div className="p-6 max-w-2xl space-y-4 overflow-auto">
+    <div className="p-6 max-w-3xl space-y-4 overflow-auto">
       <header className="flex items-center gap-3">
         <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
           <Download size={20} />
@@ -171,10 +227,13 @@ export default function DiskImportPage() {
         loading={loading}
         selected={selected}
         launching={launching}
+        tree={tree}
+        rules={rules}
+        onSetRule={setRule}
         onSelect={setSelected}
         onRefresh={refresh}
         onLaunch={() => void launch()}
-        onApply={() => void apply()}
+        onApply={() => void apply(Object.keys(rules).length ? rules : undefined)}
         onStartOver={() => void startOver()}
       />
     </div>
@@ -206,6 +265,9 @@ function TileBody({
   loading,
   selected,
   launching,
+  tree,
+  rules,
+  onSetRule,
   onSelect,
   onRefresh,
   onLaunch,
@@ -217,6 +279,9 @@ function TileBody({
   loading: boolean;
   selected: string;
   launching: boolean;
+  tree: ReviewTree | null;
+  rules: Record<string, Rule>;
+  onSetRule: (dir: string, patch: Rule) => void;
   onSelect: (path: string) => void;
   onRefresh: () => void;
   onLaunch: () => void;
@@ -227,7 +292,17 @@ function TileBody({
   if (state === 'active') return <WorkerProgress run={run!} onStartOver={onStartOver} />;
   if (state === 'apply-done') return <ApplyDone run={run!} onStartOver={onStartOver} />;
   if (state === 'plan-ready')
-    return <PlanReady run={run!} applying={launching} onApply={onApply} onStartOver={onStartOver} />;
+    return (
+      <PlanReady
+        run={run!}
+        applying={launching}
+        tree={tree}
+        rules={rules}
+        onSetRule={onSetRule}
+        onApply={onApply}
+        onStartOver={onStartOver}
+      />
+    );
   return (
     <DevicePicker
       devices={devices}
@@ -359,28 +434,57 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
   );
 }
 
-/** Scan/plan complete — show the in-page review, then APPLY on the host. */
+/** Scan/plan complete — show the per-category summary + the per-folder routing
+ *  tree (owner + target pickers), then APPLY on the host (#2000). The apply
+ *  re-plans with the operator's picks first (re-route + re-dedup per owner). */
 function PlanReady({
   run,
   applying,
+  tree,
+  rules,
+  onSetRule,
   onApply,
   onStartOver,
 }: {
   run: RunStatus;
   applying: boolean;
+  tree: ReviewTree | null;
+  rules: Record<string, Rule>;
+  onSetRule: (dir: string, patch: Rule) => void;
   onApply: () => void;
   onStartOver: () => void;
 }) {
+  const edited = Object.keys(rules).length > 0;
   return (
     <div className="space-y-4 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
       <PlanReview status={run.status!} />
+
+      <div className="space-y-2">
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Where each folder goes</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Pick an owner and a target per folder — sub-folders inherit unless you change them.
+            Assigning each person their own folders splits duplicate clashes and files land in that
+            person&apos;s area + their Immich.
+          </p>
+        </div>
+        {tree ? (
+          <RoutingTree data={tree} rules={rules} onSetRule={onSetRule} />
+        ) : (
+          <p className="text-xs text-gray-500 flex items-center gap-2">
+            <Loader2 size={12} className="animate-spin" /> Loading folders…
+          </p>
+        )}
+      </div>
+
       <div>
         <button
           onClick={onApply}
           disabled={applying}
           className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
         >
-          {applying && <Loader2 size={14} className="animate-spin" />} <Download size={14} /> Import now
+          {applying && <Loader2 size={14} className="animate-spin" />} <Download size={14} />{' '}
+          {edited ? 'Re-plan & import' : 'Import now'}
         </button>
       </div>
       <button

--- a/packages/frontend/src/app/api/system/disk-import/apply/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/apply/route.ts
@@ -3,6 +3,7 @@ import { applyRun } from '@/lib/diskImport/service';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { makeExec, resolveNode, SHARE_GID } from '../wiring';
+import { parseReplanBody } from '../replanBody';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,13 +16,19 @@ export const dynamic = 'force-dynamic';
  * copy is the rsync subprocess (streams) and mkdir/chown are batched, so the
  * control-plane heap stays bounded. Status.json reflects apply progress for the
  * tile poll.
+ *
+ * When the body carries the page's per-folder routing rules (#2000), servicebay
+ * RE-PLANS with them first (re-routes/re-dedups per owner in the worker, over the
+ * live mount) so files land in `data/<owner>/<category>/…` — then applies the
+ * rewritten plan.json unchanged. An empty/absent body applies the auto-sorted plan.
  */
 export const POST = withApiHandler(
   { tokenScope: 'mutate' },
-  async () => {
+  async ({ request }) => {
     try {
       const node = resolveNode();
-      const result = await applyRun(makeExec(node), SHARE_GID);
+      const replanReq = await parseReplanBody(request);
+      const result = await applyRun(makeExec(node), SHARE_GID, replanReq);
       return NextResponse.json({ ok: true, ...result });
     } catch (e) {
       return apiError(e, { tag: 'api:system:disk-import:apply', status: 400, exposeMessage: true });

--- a/packages/frontend/src/app/api/system/disk-import/replan/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/replan/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { replanRun } from '@/lib/diskImport/service';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { makeExec, resolveNode } from '../wiring';
+import { parseReplanBody } from '../replanBody';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST — RE-PLAN the active run with the page's per-folder routing rules WITHOUT
+ * applying (#2000). servicebay writes the rules to the shared out dir and
+ * `podman exec`s the running worker to re-route + re-dedup PER OWNER over the live
+ * mount (only the worker can hash — #1983), rewriting plan.json + status.json. The
+ * tile's status poll then shows the owner-aware plan (new per-category counts +
+ * the dropped conflict total) for review before "Import now" applies it.
+ */
+export const POST = withApiHandler(
+  { tokenScope: 'mutate' },
+  async ({ request }) => {
+    try {
+      const req = await parseReplanBody(request);
+      if (!req) {
+        return NextResponse.json({ ok: false, error: 'no routing rules to re-plan' }, { status: 400 });
+      }
+      const node = resolveNode();
+      await replanRun(makeExec(node), req);
+      return NextResponse.json({ ok: true });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:replan', status: 400, exposeMessage: true });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/system/disk-import/replanBody.ts
+++ b/packages/frontend/src/app/api/system/disk-import/replanBody.ts
@@ -1,0 +1,63 @@
+// Disk-import — re-plan request body schema (#2000, the routing-tree review UI).
+//
+// The review page POSTs the operator's per-folder routing picks (owner +
+// disposition/target per source folder) so servicebay can RE-PLAN with them:
+// re-route + re-dedup PER OWNER in the worker (over the live mount) so files land
+// in `data/<owner>/<category>/…`. Shared by the apply route (re-plan-then-apply)
+// and the replan route (preview without applying). Validates the rule map shape so
+// a malformed body fails fast; the engine's `assertOwnerSegment` is the real
+// path-traversal guard at apply time (the owner becomes a path segment).
+
+import { z } from 'zod';
+import type { NextRequest } from 'next/server';
+import { DISPOSITIONS, type ReplanRequest } from '@servicebay/disk-import-worker';
+
+/** A single folder's explicit (partial) routing rule — every axis optional. */
+const ruleSchema = z
+  .object({
+    disposition: z.enum(DISPOSITIONS as unknown as [string, ...string[]]).optional(),
+    mode: z.enum(['merge', 'parallel']).optional(),
+    // owner is `shared` or a box-user id (free string); the engine clamps it to a
+    // single clean path segment before it ever forms a target (#1929).
+    owner: z.string().optional(),
+  })
+  .strict();
+
+/** The re-plan request: explicit rules keyed by source-relative dir + root default. */
+export const replanBodySchema = z
+  .object({
+    /** relDir → the (partial) Rule the operator set on that folder (`''` = root). */
+    rules: z.record(z.string(), ruleSchema).default({}),
+    /** The disk-default owner / root default applied where no folder sets one. */
+    rootDefault: ruleSchema.optional(),
+  })
+  .strict();
+
+export type ReplanBody = z.infer<typeof replanBodySchema>;
+
+/** Map the validated body to the worker's {@link ReplanRequest} wire shape. The
+ *  zod enums validate the values at runtime; the cast narrows the inferred
+ *  `string` to the engine's literal-union types (`Disposition`/`Owner`). */
+export function toReplanRequest(body: ReplanBody): ReplanRequest {
+  return {
+    explicit: body.rules as ReplanRequest['explicit'],
+    rootDefault: body.rootDefault as ReplanRequest['rootDefault'],
+  };
+}
+
+/**
+ * Parse the apply/replan body from a raw request, returning the worker request or
+ * `undefined` when the body is empty (a plain apply of the auto-sorted plan). The
+ * apply route reads the body directly (its handler has no `body` schema so it can
+ * also be called with no body at all).
+ */
+export async function parseReplanBody(req: NextRequest): Promise<ReplanRequest | undefined> {
+  const ct = req.headers.get('content-type') || '';
+  if (!ct.includes('application/json')) return undefined;
+  const text = await req.text();
+  if (!text.trim()) return undefined;
+  const parsed = replanBodySchema.parse(JSON.parse(text));
+  // No rules and no root default → nothing to re-plan; apply the auto-sorted plan.
+  if (Object.keys(parsed.rules).length === 0 && !parsed.rootDefault) return undefined;
+  return toReplanRequest(parsed);
+}

--- a/packages/frontend/src/app/api/system/disk-import/tree/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/tree/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { getActiveRun } from '@/lib/diskImport/runStore';
+import { buildReviewTree } from '@/lib/diskImport/tree';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET — the per-folder REVIEW TREE for the active disk-import run (#1915 / epic
+ * #1901). Derived host-side from the worker's compact `plan.json` (no re-scan):
+ * one node per folder with file/byte/category rollups, the auto-assigned owner
+ * (top-level folder == box user), the resolved effective rule, plus the owner +
+ * disposition picker options. The page renders the tree, the user edits owner +
+ * disposition per folder, and those edits flow to the apply call to re-plan with
+ * routing. `404` until a scan has produced a plan.
+ */
+export const GET = withApiHandler(
+  { tokenScope: 'mutate' },
+  async () => {
+    try {
+      const run = await getActiveRun();
+      if (!run) {
+        return NextResponse.json({ ok: false, error: 'no active run' }, { status: 404 });
+      }
+      const review = await buildReviewTree(run.runId);
+      return NextResponse.json({ ok: true, ...review });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:tree', status: 400, exposeMessage: true });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/system/disk-import/tree/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/tree/route.ts
@@ -3,30 +3,56 @@ import { getActiveRun } from '@/lib/diskImport/runStore';
 import { buildReviewTree } from '@/lib/diskImport/tree';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
+import { parseReplanBody } from '../replanBody';
+import type { Rule, Owner } from '@servicebay/disk-import-worker';
 
 export const dynamic = 'force-dynamic';
 
+/** Build the review-tree opts from a (possibly absent) re-plan request body. */
+function treeOpts(req?: { explicit: Record<string, Rule>; rootDefault?: Partial<Rule> }) {
+  if (!req) return {};
+  return {
+    explicit: new Map<string, Rule>(Object.entries(req.explicit ?? {})),
+    diskDefaultOwner: req.rootDefault?.owner as Owner | undefined,
+  };
+}
+
 /**
- * GET — the per-folder REVIEW TREE for the active disk-import run (#1915 / epic
- * #1901). Derived host-side from the worker's compact `plan.json` (no re-scan):
- * one node per folder with file/byte/category rollups, the auto-assigned owner
- * (top-level folder == box user), the resolved effective rule, plus the owner +
- * disposition picker options. The page renders the tree, the user edits owner +
- * disposition per folder, and those edits flow to the apply call to re-plan with
- * routing. `404` until a scan has produced a plan.
+ * GET — the per-folder REVIEW TREE for the active disk-import run (#1915/#2000).
+ * Derived host-side from the worker's compact `plan.json` (no re-scan): one node
+ * per folder with file/byte/category rollups, the auto-assigned owner (top-level
+ * folder == box user), the resolved effective rule, a live `data/<owner>/<cat>/…`
+ * preview, plus the owner + disposition picker options. `404` until a scan has
+ * produced a plan.
  */
 export const GET = withApiHandler(
   { tokenScope: 'mutate' },
-  async () => {
-    try {
-      const run = await getActiveRun();
-      if (!run) {
-        return NextResponse.json({ ok: false, error: 'no active run' }, { status: 404 });
-      }
-      const review = await buildReviewTree(run.runId);
-      return NextResponse.json({ ok: true, ...review });
-    } catch (e) {
-      return apiError(e, { tag: 'api:system:disk-import:tree', status: 400, exposeMessage: true });
-    }
-  },
+  async () => buildTreeResponse(),
 );
+
+/**
+ * POST — recompute the review tree with the page's IN-PROGRESS routing edits
+ * (#2000) so resolved rules + the live target preview reflect the operator's picks
+ * without a re-plan/apply. Body is the same `{ rules, rootDefault }` the apply
+ * route takes. Cheap + host-side (no hashing, no worker round-trip) — just a
+ * re-resolution of the existing tree.
+ */
+export const POST = withApiHandler(
+  { tokenScope: 'mutate' },
+  async ({ request }) => buildTreeResponse(await parseReplanBody(request)),
+);
+
+async function buildTreeResponse(
+  req?: { explicit: Record<string, Rule>; rootDefault?: Partial<Rule> },
+): Promise<NextResponse> {
+  try {
+    const run = await getActiveRun();
+    if (!run) {
+      return NextResponse.json({ ok: false, error: 'no active run' }, { status: 404 });
+    }
+    const review = await buildReviewTree(run.runId, treeOpts(req));
+    return NextResponse.json({ ok: true, ...review });
+  } catch (e) {
+    return apiError(e, { tag: 'api:system:disk-import:tree', status: 400, exposeMessage: true });
+  }
+}


### PR DESCRIPTION
Resolves #2000. Builds the per-folder routing-tree review UI on top of Piece 1's review-tree data layer (commit 44c7af07).

## What
A **real expandable folder tree** where each source folder gets an **Owner** picker (shared / box users) and a **Target/disposition** picker, so files land in `data/<owner>/<category>/…` and that person's Immich — and the ~36k filename conflicts split per owner.

### Worker re-plan (image rebuild)
- `engine/replan.ts` `runReplan`: re-runs `buildPlan` over the already-scanned records (from `plan.json`, **no re-scan**) with a `RoutingResolution` from the page's rule map + disk-default owner. Re-dedups **per owner** — the #2000 architectural finding: a naive shared-scope target rewrite drops cross-owner duplicates; re-planning lets the same bytes land in **both** owners' areas. Hashes via the live `/mnt/src` mount (#1983 — only the worker can hash). Rewrites `plan.json` + the status rollup.
- CLI `--replan` mode and serve `POST /api/replan` both call `runReplan`.

### Backend wiring
- `apply.ts` `replanImport`: writes the rules to the shared out dir and `podman exec`s the running serve container `--replan` (server-to-server, no HTTP client needed). The existing host-apply then applies the rewritten `plan.json` **unchanged**. `service.applyRun` re-plans first when rules are passed; a new `/api/system/disk-import/replan` route previews without applying.
- `tree.ts`: per-node live `data/<owner>/<category>/…` preview; the tree route gains a POST that re-resolves the tree with in-progress edits.

### Frontend
- `_lib/RoutingTree.tsx`: expandable tree (collapsed to ~2 levels), per-folder owner + target dropdowns, inherited-vs-explicit styling, auto-assigned top-level owner shown pre-selected, live target preview. Drives rule map → re-plan → Import. Engine types mirrored locally (the worker barrel pulls node-only deps, can't enter the browser bundle).

## Tests
Per-owner re-dedup (same bytes land in BOTH owners' areas vs dropped in shared scope), forced-disposition routing, skip, `/api/replan` handler (200/409/503), `replanImport` podman-exec wiring, tree preview + auto-assign. Local gates green: tsc, eslint (0 errors), knip, check:arch, vitest (disk-import suites).

## Deploy
Per the operator workflow this ships to `:dev` (not a `:latest` release). Worker image also rebuilds — pull `servicebay-disk-import-worker:latest` manually on the box (#1995).

🤖 Generated with [Claude Code](https://claude.com/claude-code)