### PR TITLE
fix(disk-import): buildFolderTree returns root node on an empty scan (no crash)

### DIFF
--- a/packages/disk-import-worker/src/engine/routing.test.ts
+++ b/packages/disk-import-worker/src/engine/routing.test.ts
@@ -196,6 +196,12 @@ describe('buildFolderTree (#1915)', () => {
     { dir: 'mdopp/Filme', category: 'movies' as const, size: 3 },
   ];
 
+  it('returns just the root node for an EMPTY scan (no crash on 0 files)', () => {
+    const tree = buildFolderTree([], new Map());
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ dir: '', files: 0, bytes: 0, categories: [] });
+  });
+
   it('emits one connected node per dir incl. the root, with tallies + categories', () => {
     const tree = buildFolderTree(files, new Map());
     expect(tree.map(n => n.dir)).toEqual(['', 'mdopp', 'mdopp/Filme']);

--- a/packages/disk-import-worker/src/engine/routing.ts
+++ b/packages/disk-import-worker/src/engine/routing.ts
@@ -344,6 +344,12 @@ export function buildFolderTree(
     return tally.get(dir)!;
   };
 
+  // The root always exists in `dirs`; tally it up front so an EMPTY scan (0
+  // files — e.g. a disk of only excluded/lost+found entries) still yields the
+  // root node instead of crashing on `tally.get('')!` (undefined → "reading
+  // 'files'"). With files present the ancestor walk below touches it anyway.
+  touch('');
+
   for (const f of files) {
     const t = touch(f.dir);
     t.files += 1;


### PR DESCRIPTION
## Problem
Found while verifying #2000 on-box: a **0-file scan** (a disk of only excluded / lost+found entries) crashed the review tree with `Cannot read properties of undefined (reading 'files')` (400 on `/api/system/disk-import/tree`).

`buildFolderTree` seeds `dirs` with the root `''`, but `tally` only got the root via the per-file ancestor walk — so with **no files** the loop never runs, `tally.get('')!` is undefined, and the `.map` over `dirs` dereferences it.

## Fix
Tally the root up front (`touch('')`) so an empty scan yields the single root node instead of crashing. With files present the ancestor walk touches it anyway (no behaviour change for non-empty scans). Test added for the empty case; 25/25 routing tests green.

(The real-disk path doesn't hit this — every file touches the root — but a junk-only disk would.)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._