### PR TITLE
fix(disk-import): launchScan starts the worker scan walk (was stuck at 'Starting…')

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -65,7 +65,7 @@ function hoistedSidecar() {
   };
 }
 
-import { applyImport, rebasePlanSource, replanImport } from './apply';
+import { applyImport, rebasePlanSource, replanImport, triggerScan } from './apply';
 
 function recordOf(sourcePath: string) {
   return { sourcePath, size: 10, mtimeMs: 1, ext: 'jpg', name: 'a.jpg' };
@@ -111,6 +111,25 @@ describe('rebasePlanSource', () => {
     sc.plan.items[0].record.sourcePath = '/somewhere/else/a.jpg';
     const plan = rebasePlanSource(sc, '/run/servicebay/disk-import/sda1');
     expect(plan.items[0].record.sourcePath).toBe('/somewhere/else/a.jpg');
+  });
+});
+
+describe('triggerScan', () => {
+  it('detached-execs the scan walk in the serve container over the live mount', async () => {
+    const exec = vi.fn().mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    await triggerScan(exec, 'disk-import-worker-run1', 973);
+    const argv = exec.mock.calls[0][0] as string[];
+    expect(argv.slice(0, 4)).toEqual(['podman', 'exec', '-d', 'disk-import-worker-run1']);
+    expect(argv).toContain('--mount');
+    expect(argv).toContain('/mnt/src');
+    expect(argv).toContain('--out');
+    expect(argv).toContain('/out');
+    expect(argv).toContain('973');
+  });
+
+  it('throws when the scan trigger exits non-zero', async () => {
+    const exec = vi.fn().mockResolvedValue({ code: 1, stdout: '', stderr: 'boom' });
+    await expect(triggerScan(exec, 'c', 973)).rejects.toThrow(/scan trigger failed/);
   });
 });
 

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -134,6 +134,34 @@ export async function replanImport(args: ReplanImportArgs): Promise<void> {
   }
 }
 
+/** Source device mountpoint inside the serve container (its `…:/mnt/src:ro` bind). */
+const WORKER_SRC_IN_CONTAINER = '/mnt/src';
+
+/**
+ * Start the dry-run SCAN walk inside the already-launched serve container.
+ *
+ * The worker runs in `--serve` mode and only walks the disk when something POSTs
+ * `/api/scan`. The original trigger was the in-browser worker app; the in-page
+ * review flow has no such page, so launching a scan left the worker idle forever
+ * ("Starting the import worker…" with no status.json). servicebay must kick it
+ * off itself: a DETACHED (`-d`) one-shot `npx tsx main.ts --mount /mnt/src --out
+ * /out` in the container — the same command the serve server spawns on POST —
+ * which walks the live mount and writes status.json/plan.json while the serve
+ * server keeps running for the review tree. Detached so the launch call returns
+ * immediately (a real disk takes minutes); the page polls status.json.
+ */
+export async function triggerScan(exec: SafeExec, container: string, shareGid: number): Promise<void> {
+  const { code, stdout, stderr } = await exec([
+    'podman', 'exec', '-d', container,
+    'npx', 'tsx', 'packages/disk-import-worker/src/cli/main.ts',
+    '--mount', WORKER_SRC_IN_CONTAINER, '--out', WORKER_OUT_IN_CONTAINER,
+    '--share-gid', String(shareGid),
+  ]);
+  if (code !== 0) {
+    throw new Error(`disk-import: scan trigger failed (code ${code}): ${stderr || stdout}`);
+  }
+}
+
 export interface ApplyImportArgs {
   /** servicebay's REAL agent SafeExec (runs mkdir/rsync/chown on the host as core). */
   exec: SafeExec;

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -25,7 +25,7 @@ import {
 } from './launcher';
 import { listImportDevices } from './devices';
 import { setActiveRun, getActiveRun, clearActiveRun } from './runStore';
-import { applyImport, replanImport, type ApplyImportResult } from './apply';
+import { applyImport, replanImport, triggerScan, type ApplyImportResult } from './apply';
 
 export type { ImportDevice } from './launcher';
 
@@ -84,6 +84,10 @@ export async function launchScan(args: {
   // (/mnt/data/servicebay), never the in-container /app/data (read-only on host).
   const run = await launchWorker({ ...args, shareGid, runId });
   await setActiveRun(run);
+  // Kick off the scan walk in the serve container — without this the worker sits
+  // idle and the page never leaves "Starting the import worker…" (no in-browser
+  // app POSTs /api/scan in the in-page review flow).
+  await triggerScan(args.exec, run.container, shareGid);
   return { runId: run.runId };
 }
 


### PR DESCRIPTION
## Problem
Clicking **Scan disk** launched the worker container but the scan **never started** — the page sat at "Starting the import worker…" forever, no `status.json` ever written.

The worker runs in `--serve` mode and only walks the disk when something POSTs `/api/scan`. The original trigger was the in-browser worker app (`/disk-import-app/`); the new **in-page** review flow has no such page, and nothing replaced the trigger. So a launched worker stayed idle.

**This was masked** because every test + the on-box verification (mine and the #2000 agent's) triggered the walk manually over the worker's API — the real UI button was never exercised end-to-end.

## Fix
`launchScan` now starts the scan itself after launch: `triggerScan` runs a **detached** (`podman exec -d`) one-shot `main.ts --mount /mnt/src --out /out --share-gid …` in the serve container — the same command the serve server spawns on POST — so the walk runs and writes `status.json`/`plan.json` while the serve server stays up for the review tree. Detached so the launch returns immediately; the page polls status.

Tests added (`triggerScan` detached-exec + non-zero throw); 20/20 apply+service tests green. Backend-only → `:dev` rebuild, no worker image change.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._