### PR TITLE
fix(disk-import): write replan-request inside the worker container (SELinux EACCES)

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -134,35 +134,43 @@ describe('triggerScan', () => {
 });
 
 describe('replanImport', () => {
-  it('writes the rules to the out dir and podman-execs the worker --replan', async () => {
+  it('writes the rules IN the container (worker SELinux label) then execs --replan', async () => {
     const exec = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '' });
-    await replanImport({
-      exec,
-      runId: 'run1',
-      container: 'disk-import-worker-run1',
-      request: { explicit: { alice: { owner: 'alice' } }, rootDefault: { owner: 'shared' } },
-    });
+    const request = { explicit: { alice: { owner: 'alice' } }, rootDefault: { owner: 'shared' } };
+    await replanImport({ exec, runId: 'run1', container: 'disk-import-worker-run1', request });
 
-    // The rules went to replan-request.json in the run out dir.
-    const reqWrite = writes.find(w => w.file.endsWith('replan-request.json'));
-    expect(reqWrite).toBeDefined();
-    expect(JSON.parse(reqWrite!.data)).toEqual({
-      explicit: { alice: { owner: 'alice' } },
-      rootDefault: { owner: 'shared' },
-    });
+    // 1st exec: write replan-request.json INSIDE the container (not servicebay fs —
+    // a servicebay write is unreadable by the worker due to SELinux MCS).
+    const writeArgv = exec.mock.calls[0][0] as string[];
+    expect(writeArgv.slice(0, 4)).toEqual(['podman', 'exec', 'disk-import-worker-run1', 'node']);
+    expect(writeArgv).toContain('/out/replan-request.json');
+    expect(writeArgv).toContain(JSON.stringify(request));
+    // No servicebay fs write of the request.
+    expect(writes.find(w => w.file.endsWith('replan-request.json'))).toBeUndefined();
 
-    // It ran a one-shot --replan IN the running serve container, over /out.
-    const argv = exec.mock.calls[0][0] as string[];
-    expect(argv.slice(0, 3)).toEqual(['podman', 'exec', 'disk-import-worker-run1']);
-    expect(argv).toContain('--replan');
-    expect(argv).toContain('/out');
+    // 2nd exec: the one-shot --replan over /out in the serve container.
+    const replanArgv = exec.mock.calls[1][0] as string[];
+    expect(replanArgv.slice(0, 3)).toEqual(['podman', 'exec', 'disk-import-worker-run1']);
+    expect(replanArgv).toContain('--replan');
+    expect(replanArgv).toContain('/out');
   });
 
   it('throws when the worker re-plan exits non-zero', async () => {
-    const exec = vi.fn().mockResolvedValue({ code: 1, stdout: '', stderr: 'no plan' });
+    // 1st exec (write request) succeeds; 2nd (--replan) fails.
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'no plan' });
     await expect(
       replanImport({ exec, runId: 'run1', container: 'c', request: { explicit: {} } }),
     ).rejects.toThrow(/re-plan failed/);
+  });
+
+  it('throws when writing the replan request into the container fails', async () => {
+    const exec = vi.fn().mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'denied' });
+    await expect(
+      replanImport({ exec, runId: 'run1', container: 'c', request: { explicit: {} } }),
+    ).rejects.toThrow(/writing replan request failed/);
   });
 });
 

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -114,12 +114,23 @@ export interface ReplanImportArgs {
  */
 export async function replanImport(args: ReplanImportArgs): Promise<void> {
   const { exec, runId, container, request } = args;
-  const outDir = runOutDir(runId);
-  // Write the request the worker reads. servicebay sees the out dir in-container at
-  // runOutDir() (same bytes as the worker's host-bind-mounted /out), so a direct fs
-  // write here lands in the worker's /out.
-  await mkdir(outDir, { recursive: true });
-  await writeFile(path.join(outDir, REPLAN_REQUEST_FILE), JSON.stringify(request), 'utf-8');
+  void runId;
+  // Write the request the worker reads INSIDE the container, not from servicebay's
+  // fs. A servicebay write lands with servicebay's PRIVATE SELinux MCS category, so
+  // the worker (different category) gets EACCES reading /out/replan-request.json
+  // even though the dir is `:z`-shared (feedback_worker_container_user_root_rootless).
+  // Writing it via `podman exec node` makes the worker create the file, so it carries
+  // the worker's own label and the --replan child can read it. JSON is passed as a
+  // clean argv element (no shell), so no escaping concerns.
+  const reqPath = `${WORKER_OUT_IN_CONTAINER}/${REPLAN_REQUEST_FILE}`;
+  const wr = await exec([
+    'podman', 'exec', container,
+    'node', '-e', 'require("fs").writeFileSync(process.argv[1], process.argv[2])',
+    reqPath, JSON.stringify(request),
+  ]);
+  if (wr.code !== 0) {
+    throw new Error(`disk-import: writing replan request failed (code ${wr.code}): ${wr.stderr || wr.stdout}`);
+  }
 
   // Run a one-shot `--replan` process IN the serve container (it has /mnt/src +
   // /out): reads replan-request.json + plan.json, re-plans over the live mount,


### PR DESCRIPTION
## Problem
"Re-plan & import" failed: `re-plan failed (code 1): EACCES: permission denied, open '/out/replan-request.json'`.

`replanImport` wrote `replan-request.json` from **servicebay's** container, so the file carried servicebay's **private SELinux MCS category**. The worker (different category) got EACCES reading it — even though `/out` is `:z`-shared. (The worker's own status/plan files work because the worker wrote them; only servicebay's hand-off file was unreadable — the `feedback_worker_container_user_root_rootless` class.)

## Fix
Write the request via `podman exec <c> node -e 'writeFileSync(argv[1], argv[2])'` so the **worker** creates the file (its own label) → the `--replan` child reads it fine. JSON passed as a clean argv element (no shell escaping). Backend-only — no worker image change.

## Found by
Clicking the actual "Re-plan & import" button (not the API). Verified the re-plan step on `:dev` (re-plan only, no full import).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._