### PR TITLE
fix(disk-import): disable SELinux label confinement on the worker (/out EACCES)

### DIFF
--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -64,6 +64,9 @@ describe('launchWorker', () => {
     expect(podmanRun).toContain(`--memory=${WORKER_MEMORY}`);
     expect(podmanRun).toContain(WORKER_IMAGE);
     expect(podmanRun).toContain('--serve');
+    // SELinux confinement disabled for the trusted one-shot worker so /out access
+    // isn't gated by fragile MCS categories (the `:z` relabel was unreliable).
+    expect(podmanRun).toContain('label=disable');
     // source mounted read-only into the container
     expect(podmanRun.some(a => a.endsWith(':/mnt/src:ro'))).toBe(true);
 

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -155,12 +155,17 @@ export async function launchWorker(args: {
     `--memory=${WORKER_MEMORY}`,
     `--memory-swap=${WORKER_MEMORY}`,
     '-p', `${WORKER_PORT}`,
+    // SELinux: disable label confinement for this trusted, first-party one-shot
+    // worker. The `:z`/`:Z` relabel of /out proved fragile — podman assigned the
+    // mount MCS categories (c1022,c1023) that the worker's processes (the serve
+    // server, scan/replan children, and `podman exec` triggers) did NOT reliably
+    // get, so /out reads/writes hit EACCES inconsistently per run (scan could
+    // write but replan/exec could not). `label=disable` removes MCS gating so
+    // every worker process can read/write its own /out + the read-only source.
+    // Acceptable: the worker image is our code, runs one-shot, single-tenant box.
+    '--security-opt', 'label=disable',
     '-v', `${mountpoint}:/mnt/src:ro`,
-    // `:z` relabels the out dir to a SHARED SELinux label so the worker can
-    // write it — otherwise it keeps servicebay's private MCS categories and the
-    // worker gets EACCES on /out/status.json even as root. Shared (`:z`) because
-    // servicebay reads status/plan back from here. (#1955 box-verify.)
-    '-v', `${outDir}:/out:z`,
+    '-v', `${outDir}:/out`,
     '-e', `DISK_IMPORT_RUN_ID=${runId}`,
     '-e', `DISK_IMPORT_SHARE_GID=${shareGid}`,
     ...immichEnv,


### PR DESCRIPTION
## Root cause of the recurring /out failures
The worker's `/out` (where status.json/plan.json/replan-request.json live) is shared across processes, and the `:z` relabel gave it MCS categories (`c1022,c1023`) that the worker's processes did **not** reliably get. So `/out` access hit EACCES **inconsistently per run**: the scan child could write `plan.json`, but the serve server + `--replan` + `podman exec` triggers could not read/write it → "Re-plan & import" failed with `EACCES … /out/replan-request.json`, and the serve server's `/api/replan` 409'd (couldn't read `plan.json`).

Confirmed on box: `/out` labeled `…:c1022,c1023`; `podman exec` as root → `ls/touch /out` = Permission denied.

## Fix
Run the worker with `--security-opt label=disable` and drop the fragile `:z`. The worker is **first-party code, one-shot, single-tenant box** — disabling MCS confinement lets all its processes access their own `/out` + the read-only source without the brittle relabel. Resolves the whole `/out` EACCES class (scan write, replan read/write, exec triggers).

## Verification
`gate:verify` — re-plan over the real `/dev/sda` plan (re-plan only, no import) must succeed and re-route targets to `data/<owner>/…`.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._