### PR TITLE
fix(disk-import): generous timeout for the re-plan exec (was 30s agent default)

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -89,6 +89,10 @@ export function rebasePlanSource(sidecar: PlanSidecar, hostMountpoint: string): 
 /** The worker container's in-container out path (its `-v <outDir>:/out` mount). */
 const WORKER_OUT_IN_CONTAINER = '/out';
 
+/** Re-plan over a real disk re-dedups every record — minutes, like the scan. The
+ *  agent's 30s default would kill it; give it a generous ceiling. (#2009) */
+const REPLAN_TIMEOUT_MS = 600_000; // 10 min
+
 export interface ReplanImportArgs {
   /** servicebay's REAL agent SafeExec (runs `podman exec` on the host as core). */
   exec: SafeExec;
@@ -135,11 +139,18 @@ export async function replanImport(args: ReplanImportArgs): Promise<void> {
   // Run a one-shot `--replan` process IN the serve container (it has /mnt/src +
   // /out): reads replan-request.json + plan.json, re-plans over the live mount,
   // rewrites plan.json + status.json. The serve server keeps running alongside.
-  const { code, stdout, stderr } = await exec([
-    'podman', 'exec', container,
-    'npx', 'tsx', 'packages/disk-import-worker/src/cli/main.ts',
-    '--replan', '--out', WORKER_OUT_IN_CONTAINER,
-  ]);
+  const { code, stdout, stderr } = await exec(
+    [
+      'podman', 'exec', container,
+      'npx', 'tsx', 'packages/disk-import-worker/src/cli/main.ts',
+      '--replan', '--out', WORKER_OUT_IN_CONTAINER,
+    ],
+    // Re-planning a real disk re-runs buildPlan over every record (re-dedup per
+    // owner) — minutes on a 234k-file drive, like the scan. The agent's default
+    // 30s command timeout killed it ("Agent request timeout after 30000ms"), so
+    // give it the same generous timeout the scan/mount use.
+    { timeoutMs: REPLAN_TIMEOUT_MS },
+  );
   if (code !== 0) {
     throw new Error(`disk-import: re-plan failed (code ${code}): ${stderr || stdout}`);
   }


### PR DESCRIPTION
After the /out SELinux fix (#2008) unblocked re-plan, it hit `Agent request timeout (safe_exec after 30000ms)` on a real 234k-file disk — `replanImport`'s `podman exec --replan` re-runs buildPlan over every record (re-dedup per owner), minutes like the scan, but used the agent's 30s default. Give it a 10-min ceiling (matches the scan/mount slow-op timeout).

Verified on-box: /out EACCES is gone (#2008); re-plan now gets past it and just needed the longer timeout to complete. tsc + 14 apply tests green.

Follow-up (#2009): re-plan is still SYNCHRONOUS (multi-minute) — should become detached+poll like the scan.

Deploy + verify owed: merge → :dev → fresh /dev/sda scan → POST /api/system/disk-import/replan (owner rule, NO apply) → confirm plan.json re-routes (e.g. Backup-2021 → data/mdopp/…).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._