### PR TITLE
fix(disk-import): rename in-tree name clashes instead of dropping them (#2006)

### DIFF
--- a/packages/disk-import-worker/src/contract/status.test.ts
+++ b/packages/disk-import-worker/src/contract/status.test.ts
@@ -51,11 +51,24 @@ describe('status contract', () => {
     const rollup = summarizeCategories(plan);
     expect(rollup.map(r => r.category)).toEqual(['music', 'photos']); // sorted
     const photos = rollup.find(r => r.category === 'photos')!;
-    expect(photos).toEqual({ category: 'photos', files: 2, bytes: 30, copy: 1, skipDupe: 1, conflict: 0 });
+    expect(photos).toEqual({ category: 'photos', files: 2, bytes: 30, copy: 1, skipDupe: 1, conflict: 0, renamed: 0 });
     const music = rollup.find(r => r.category === 'music')!;
-    expect(music).toEqual({ category: 'music', files: 2, bytes: 12, copy: 1, skipDupe: 0, conflict: 1 });
+    expect(music).toEqual({ category: 'music', files: 2, bytes: 12, copy: 1, skipDupe: 0, conflict: 1, renamed: 0 });
     // Rollup entries are scalar-only — no file records leak in.
     expect(Object.keys(photos)).not.toContain('record');
+  });
+
+  it('counts a disambiguated copy under both copy and renamed (#2006)', () => {
+    const plan: ImportPlan = {
+      items: [
+        { record: rec('a.jpg', 10), category: 'photos', target: 'photos/a.jpg', action: 'copy' },
+        { record: rec('b.jpg', 10), category: 'photos', target: 'photos/a (2).jpg', action: 'copy', renamed: true },
+      ],
+      conflicts: [],
+    };
+    const photos = summarizeCategories(plan).find(r => r.category === 'photos')!;
+    // The renamed file IS imported (copy) and ALSO tallied as renamed (a subset).
+    expect(photos).toMatchObject({ files: 2, copy: 2, renamed: 1, conflict: 0 });
   });
 
   it('exposes stable file-name constants for the shared volume', () => {

--- a/packages/disk-import-worker/src/contract/status.ts
+++ b/packages/disk-import-worker/src/contract/status.ts
@@ -50,6 +50,13 @@ export interface CategoryRollup {
   copy: number;
   skipDupe: number;
   conflict: number;
+  /**
+   * Files imported (action `copy`) under a disambiguated name because a different
+   * file already claimed the natural one (#2006). A subset of `copy` — counted
+   * separately so the review can say "renamed, nothing lost" instead of dropping
+   * them as conflicts.
+   */
+  renamed: number;
 }
 
 /**
@@ -113,11 +120,13 @@ export function summarizeCategories(plan: ImportPlan): CategoryRollup[] {
   for (const item of plan.items) {
     const r =
       byCat.get(item.category) ??
-      ({ category: item.category, files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0 } as CategoryRollup);
+      ({ category: item.category, files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0, renamed: 0 } as CategoryRollup);
     r.files += 1;
     r.bytes += item.record.size;
-    if (item.action === 'copy') r.copy += 1;
-    else if (item.action === 'skip-dupe') r.skipDupe += 1;
+    if (item.action === 'copy') {
+      r.copy += 1;
+      if (item.renamed) r.renamed += 1; // a disambiguated copy (#2006) — subset of copy
+    } else if (item.action === 'skip-dupe') r.skipDupe += 1;
     else if (item.action === 'conflict') r.conflict += 1;
     byCat.set(item.category, r);
   }

--- a/packages/disk-import-worker/src/engine/dedup.test.ts
+++ b/packages/disk-import-worker/src/engine/dedup.test.ts
@@ -45,6 +45,10 @@ function actionOf(items: ImportPlanItem[], sourcePath: string) {
   return items.find(i => i.record.sourcePath === sourcePath)?.action;
 }
 
+function itemOf(items: ImportPlanItem[], sourcePath: string) {
+  return items.find(i => i.record.sourcePath === sourcePath);
+}
+
 describe('targetFor', () => {
   it('places files under their category folder with the base name', () => {
     const r = buildInventory([{ path: '/disk/sub/Photo.JPG', size: 1, mtimeMs: 0 }])[0];
@@ -100,21 +104,84 @@ describe('buildPlan — size→hash dedup within the tree', () => {
   });
 });
 
-describe('buildPlan — conflicts (same target, different content)', () => {
-  it('flags two different files competing for the same target path', () => {
+describe('buildPlan — in-tree name clashes RENAME, never drop (#2006)', () => {
+  it('two different files at the same target → both import, the later renamed', () => {
     const files: ScannedFile[] = [
       { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
       { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
     ];
     const result = plan(files, { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('b') });
-    expect(actionOf(result.items, '/diskA/report.pdf')).toBe('copy');
-    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('conflict');
-    expect(result.conflicts).toHaveLength(1);
-    expect(result.conflicts[0]).toMatchObject({
+    // The first claims the natural name; the distinct second is imported renamed.
+    expect(itemOf(result.items, '/diskA/report.pdf')).toMatchObject({
+      action: 'copy',
       target: 'documents/report.pdf',
-      existing: { sourcePath: '/diskA/report.pdf' },
-      incoming: { sourcePath: '/diskB/report.pdf' },
     });
+    expect(itemOf(result.items, '/diskB/report.pdf')).toMatchObject({
+      action: 'copy',
+      target: 'documents/report (2).pdf',
+      renamed: true,
+    });
+    // Nothing dropped — no unresolved conflicts.
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it('N distinct same-name files import as (2),(3)…; byte-identical ones still dedupe', () => {
+    const files: ScannedFile[] = [
+      { path: '/d1/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d2/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d3/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d4/IMG_0001.jpg', size: 5000, mtimeMs: 0 }, // byte-identical to /d1
+    ];
+    const result = plan(files, {
+      '/d1/IMG_0001.jpg': sha('a'),
+      '/d2/IMG_0001.jpg': sha('b'),
+      '/d3/IMG_0001.jpg': sha('c'),
+      '/d4/IMG_0001.jpg': sha('a'),
+    });
+    expect(itemOf(result.items, '/d1/IMG_0001.jpg')).toMatchObject({ action: 'copy', target: 'photos/img_0001.jpg' });
+    expect(itemOf(result.items, '/d2/IMG_0001.jpg')).toMatchObject({ action: 'copy', target: 'photos/img_0001 (2).jpg', renamed: true });
+    expect(itemOf(result.items, '/d3/IMG_0001.jpg')).toMatchObject({ action: 'copy', target: 'photos/img_0001 (3).jpg', renamed: true });
+    // True duplicate of /d1 dedupes — only DISTINCT files get renamed.
+    expect(actionOf(result.items, '/d4/IMG_0001.jpg')).toBe('skip-dupe');
+    expect(result.conflicts).toHaveLength(0);
+    // Renames are imports, not conflicts.
+    expect(result.items.filter(i => i.action === 'conflict')).toHaveLength(0);
+  });
+
+  it('is deterministic — re-running yields the same names', () => {
+    const files: ScannedFile[] = [
+      { path: '/d1/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/d2/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/d3/report.pdf', size: 5000, mtimeMs: 0 },
+    ];
+    const hashes = { '/d1/report.pdf': sha('a'), '/d2/report.pdf': sha('b'), '/d3/report.pdf': sha('c') };
+    const first = plan(files, hashes);
+    const second = plan(files, hashes);
+    expect(first.items.map(i => i.target)).toEqual(second.items.map(i => i.target));
+    expect(first.items.map(i => i.target).sort()).toEqual([
+      'documents/report (2).pdf',
+      'documents/report (3).pdf',
+      'documents/report.pdf',
+    ]);
+  });
+
+  it('a renamed file does not collide with a real source file already named (2)', () => {
+    const files: ScannedFile[] = [
+      { path: '/d1/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d2/IMG_0001.jpg', size: 5000, mtimeMs: 0 }, // distinct → wants (2)
+      { path: '/d3/IMG_0001 (2).jpg', size: 5000, mtimeMs: 0 }, // a REAL file already named (2)
+    ];
+    const result = plan(files, {
+      '/d1/IMG_0001.jpg': sha('a'),
+      '/d2/IMG_0001.jpg': sha('b'),
+      '/d3/IMG_0001 (2).jpg': sha('c'),
+    });
+    const targets = result.items.map(i => i.target).sort();
+    // All three distinct files land on distinct names; nothing dropped.
+    expect(new Set(targets).size).toBe(3);
+    expect(targets).toContain('photos/img_0001.jpg');
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.items.filter(i => i.action === 'conflict')).toHaveLength(0);
   });
 });
 
@@ -124,7 +191,7 @@ describe('buildPlan — conflicts (same target, different content)', () => {
 // target (delta run). Source is read-only/copy-only, so a (near-impossible)
 // fingerprint false-match means one file not copied, never data loss.
 describe('buildPlan — fingerprint-trust dedup (#1995)', () => {
-  it('same size + DIFFERENT fingerprint → conflict WITHOUT reading either file whole', () => {
+  it('same size + DIFFERENT fingerprint → distinct, so renamed WITHOUT reading either file whole', () => {
     const files: ScannedFile[] = [
       { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
       { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
@@ -134,7 +201,12 @@ describe('buildPlan — fingerprint-trust dedup (#1995)', () => {
       { '/diskA/report.pdf': 'fpA', '/diskB/report.pdf': 'fpB' },
       {}, // no full-hash fixtures: full-hashing either file would throw
     );
-    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('conflict');
+    // Distinct fingerprints ⇒ distinct files ⇒ the later one is imported renamed (#2006).
+    expect(itemOf(result.items, '/diskB/report.pdf')).toMatchObject({
+      action: 'copy',
+      target: 'documents/report (2).pdf',
+      renamed: true,
+    });
     expect(fullHashed).toEqual([]); // distinct fingerprints settle it cheaply
   });
 

--- a/packages/disk-import-worker/src/engine/dedup.ts
+++ b/packages/disk-import-worker/src/engine/dedup.ts
@@ -207,18 +207,28 @@ export function buildPlan(
   // `shared` vs a user area) is two distinct slots — private dedups within
   // itself, `shared` merges across sources.
   const targetOwner = new Map<string, { key: string; sha256?: string; sourcePath: string }>();
+  // Per-original-slot probe cursor for disambiguating renames (#2006), so N
+  // distinct files at one name resolve to (2),(3)… in O(N) not O(N²).
+  const renameCounters = new Map<string, number>();
 
   // 3. Decide each kept record from its precomputed content key.
   for (const c of ordered) {
     const target = c.target!;
     const area = areaOf(c.record);
     const slot = dedupSlot(area, target);
-    const action = decide(c, target, area, slot, keys.get(c.record.sourcePath)!, {
+    const decision = decide(c, target, area, slot, keys.get(c.record.sourcePath)!, {
       targetOwner,
+      renameCounters,
       catalog,
       conflicts,
     });
-    items.push({ record: c.record, category: c.category, target, action });
+    items.push({
+      record: c.record,
+      category: c.category,
+      target: decision.target,
+      action: decision.action,
+      ...(decision.renamed ? { renamed: true } : {}),
+    });
   }
 
   // Stable output ordering.
@@ -310,6 +320,13 @@ function resolveContentKeys(
   return out;
 }
 
+/** A decided record: its (possibly disambiguated) target, the action, and whether the name was changed. */
+interface Decision {
+  action: ImportAction;
+  target: string;
+  renamed?: boolean;
+}
+
 function decide(
   c: Classified,
   target: string,
@@ -318,17 +335,20 @@ function decide(
   info: KeyInfo,
   ctx: {
     targetOwner: Map<string, { key: string; sha256?: string; sourcePath: string }>;
+    renameCounters: Map<string, number>;
     catalog?: ImportCatalog;
     conflicts: Conflict[];
   },
-): ImportAction {
+): Decision {
   const { key, sha256 } = info;
 
   // Catalog dedup compares FULL hashes (the catalog stores full sha256). sha256
   // is present exactly when this record was fully hashed, which resolveContentKeys
-  // guarantees whenever the target is already cataloged.
+  // guarantees whenever the target is already cataloged. This is the cross-run
+  // newer-wins path (apply routes the existing file to _superseded) — left as a
+  // conflict on purpose; #2006 only changes the in-tree distinct-name case below.
   if (sha256 !== undefined) {
-    if (ctx.catalog?.has(sha256, target, area)) return 'skip-dupe';
+    if (ctx.catalog?.has(sha256, target, area)) return { action: 'skip-dupe', target };
     const catHit = ctx.catalog?.getByTarget(target, area);
     if (catHit && catHit.sha256 !== sha256) {
       ctx.conflicts.push({
@@ -336,23 +356,65 @@ function decide(
         existing: { sourcePath: catHit.sourcePath, sha256: catHit.sha256 },
         incoming: { sourcePath: c.record.sourcePath, sha256 },
       });
-      return 'conflict';
+      return { action: 'conflict', target };
     }
   }
 
   // In-tree collision at this slot (same area + target)? Compare by content key.
   const owner = ctx.targetOwner.get(slot);
   if (owner) {
-    if (owner.key === key) return 'skip-dupe'; // same content, different path
-    ctx.conflicts.push({
-      target,
-      existing: { sourcePath: owner.sourcePath, sha256: owner.sha256 ?? '' },
-      incoming: { sourcePath: c.record.sourcePath, sha256: sha256 ?? '' },
-    });
-    return 'conflict';
+    if (owner.key === key) return { action: 'skip-dupe', target }; // same content, different path
+    // DISTINCT files clashing on one name are NOT the same photo/doc — import the
+    // later one under a disambiguated name (`IMG_0001 (2).jpg`) instead of dropping
+    // it as an unresolved conflict (#2006, DATA SAFETY). Deterministic: stable
+    // sourcePath order + a per-original-slot probe cursor make re-runs reproduce
+    // the same names; a 3rd distinct clash → `(3)`, etc.
+    const renamedTarget = uniquifyTarget(target, area, slot, ctx);
+    ctx.targetOwner.set(dedupSlot(area, renamedTarget), { key, sha256, sourcePath: c.record.sourcePath });
+    return { action: 'copy', target: renamedTarget, renamed: true };
   }
 
   // First file to claim this slot.
   ctx.targetOwner.set(slot, { key, sha256, sourcePath: c.record.sourcePath });
-  return 'copy';
+  return { action: 'copy', target };
+}
+
+/**
+ * Split a target path into directory, stem and extension so a disambiguating
+ * suffix lands BEFORE the extension (`photos/IMG_0001.jpg` → `photos/IMG_0001 (2).jpg`).
+ * A leading dot (dotfile, e.g. `.bashrc`) is treated as no extension.
+ */
+function splitTarget(target: string): { dir: string; stem: string; ext: string } {
+  const slash = target.lastIndexOf('/');
+  const dir = slash >= 0 ? target.slice(0, slash + 1) : '';
+  const base = target.slice(slash + 1);
+  const dot = base.lastIndexOf('.');
+  if (dot > 0) return { dir, stem: base.slice(0, dot), ext: base.slice(dot) };
+  return { dir, stem: base, ext: '' };
+}
+
+/**
+ * Find a free disambiguated target for a name already claimed by different
+ * content (#2006). Probes `<stem> (2)<ext>`, `(3)`… within the same area, skipping
+ * any slot already claimed (including a real source file that genuinely has that
+ * name). `renameCounters` (keyed by the ORIGINAL slot) remembers where the last
+ * probe stopped so M clashes on one name cost O(M), not O(M²). Returns the new
+ * target relative path; the caller claims its slot.
+ */
+function uniquifyTarget(
+  target: string,
+  area: string,
+  originalSlot: string,
+  ctx: { targetOwner: Map<string, unknown>; renameCounters: Map<string, number> },
+): string {
+  const { dir, stem, ext } = splitTarget(target);
+  let n = ctx.renameCounters.get(originalSlot) ?? 2;
+  for (;;) {
+    const candidate = `${dir}${stem} (${n})${ext}`;
+    n += 1;
+    if (!ctx.targetOwner.has(dedupSlot(area, candidate))) {
+      ctx.renameCounters.set(originalSlot, n);
+      return candidate;
+    }
+  }
 }

--- a/packages/disk-import-worker/src/engine/types.ts
+++ b/packages/disk-import-worker/src/engine/types.ts
@@ -152,10 +152,19 @@ export interface ImportPlanItem {
   category: Category;
   /**
    * Target path relative to `file-share/data/` (e.g. `photos/IMG_0001.jpg`),
-   * or `null` for junk (nothing is written).
+   * or `null` for junk (nothing is written). When two DISTINCT files resolve to
+   * the same target, the later one is imported under a disambiguated name
+   * (`IMG_0001 (2).jpg`) — see `renamed` — so nothing is dropped (#2006).
    */
   target: string | null;
   action: ImportAction;
+  /**
+   * True when `target` was disambiguated because a different-content file already
+   * claimed the natural name (in-tree, #2006). The action is still `copy` (the
+   * file IS imported); this flag only drives the review wording ("renamed, nothing
+   * lost") so renames aren't confused with plain copies. Absent ⇒ false.
+   */
+  renamed?: boolean;
 }
 
 /**

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -48,6 +48,8 @@ interface CategoryRollup {
   copy: number;
   skipDupe: number;
   conflict: number;
+  /** Files imported under a disambiguated name (a subset of `copy`, #2006). */
+  renamed?: number;
 }
 
 /** Human-readable size (e.g. "457 GB") for the review table. */
@@ -352,7 +354,7 @@ function WorkerProgress({ run, onStartOver }: { run: RunStatus; onStartOver: () 
 
 /** Scan/plan complete — review out in the worker app, then APPLY on the host. */
 /** Sum a list of category rollups into a single totals row. */
-function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category'> {
+function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category' | 'renamed'> & { renamed: number } {
   return cats.reduce(
     (t, c) => ({
       files: t.files + c.files,
@@ -360,8 +362,9 @@ function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category'>
       copy: t.copy + c.copy,
       skipDupe: t.skipDupe + c.skipDupe,
       conflict: t.conflict + c.conflict,
+      renamed: t.renamed + (c.renamed ?? 0),
     }),
-    { files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0 },
+    { files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0, renamed: 0 },
   );
 }
 
@@ -380,6 +383,9 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
         </p>
         <p className="text-xs text-gray-500 dark:text-gray-400">
           <span className="font-medium text-blue-600 dark:text-blue-400">{totals.copy.toLocaleString()}</span> to import
+          {totals.renamed > 0 && (
+            <> {' ('}{totals.renamed.toLocaleString()} renamed to avoid clashes{')'}</>
+          )}
           {' · '}{totals.skipDupe.toLocaleString()} duplicate{totals.skipDupe === 1 ? '' : 's'} skipped
           {totals.conflict > 0 && (
             <> {' · '}<span className={`font-medium ${amber}`}>{totals.conflict.toLocaleString()} conflict{totals.conflict === 1 ? '' : 's'}</span></>
@@ -396,6 +402,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                 <th className="py-1.5 px-2 text-right font-medium">Files</th>
                 <th className="py-1.5 px-2 text-right font-medium">Size</th>
                 <th className="py-1.5 px-2 text-right font-medium">Import</th>
+                <th className="py-1.5 px-2 text-right font-medium">Renamed</th>
                 <th className="py-1.5 px-2 text-right font-medium">Dupes</th>
                 <th className="py-1.5 pl-2 text-right font-medium">Conflicts</th>
               </tr>
@@ -407,6 +414,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                   <td className="py-1.5 px-2 text-right tabular-nums">{c.files.toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{formatBytes(c.bytes)}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums text-blue-600 dark:text-blue-400">{c.copy.toLocaleString()}</td>
+                  <td className="py-1.5 px-2 text-right tabular-nums">{(c.renamed ?? 0).toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{c.skipDupe.toLocaleString()}</td>
                   <td className={`py-1.5 pl-2 text-right tabular-nums ${c.conflict ? `font-medium ${amber}` : ''}`}>
                     {c.conflict.toLocaleString()}
@@ -420,6 +428,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.files.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{formatBytes(totals.bytes)}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums text-blue-600 dark:text-blue-400">{totals.copy.toLocaleString()}</td>
+                <td className="py-1.5 px-2 text-right tabular-nums">{totals.renamed.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.skipDupe.toLocaleString()}</td>
                 <td className={`py-1.5 pl-2 text-right tabular-nums ${totals.conflict ? amber : ''}`}>
                   {totals.conflict.toLocaleString()}
@@ -432,10 +441,18 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
         <p className="text-xs text-gray-500 dark:text-gray-400">No category breakdown available for this run.</p>
       )}
 
+      {totals.renamed > 0 && (
+        <p className="rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
+          {totals.renamed.toLocaleString()} file{totals.renamed === 1 ? '' : 's'} shared a name with a <strong>different</strong> file headed to the same folder
+          (e.g. two cameras both naming a photo <code>IMG_0001.jpg</code>). Each is imported under a disambiguated
+          name like <code>IMG_0001 (2).jpg</code> — <strong>nothing is dropped and nothing is overwritten</strong>.
+        </p>
+      )}
+
       {totals.conflict > 0 && (
         <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
-          {totals.conflict.toLocaleString()} file{totals.conflict === 1 ? '' : 's'} clash with a different file headed to the same name/folder.
-          These are <strong>not imported</strong> in this pass — the others import normally; nothing is overwritten.
+          {totals.conflict.toLocaleString()} file{totals.conflict === 1 ? '' : 's'} match a previously imported target with different
+          content — the earlier copy is preserved under <code>_superseded/</code> and the newer one imported. Nothing is lost.
         </p>
       )}
     </>


### PR DESCRIPTION
Fixes #2006.

## Problem
On a real 1.8 TB backup disk the plan reported **36,508 "conflicts"** — different photos/docs that merely share a name (every camera names files `IMG_0001.jpg`). They were marked `conflict` and **not imported**, so distinct files never reached the library and the source disk couldn't be retired.

## Fix
When two **distinct-content** files resolve to the same **in-tree** target, import BOTH:
- The later one gets a disambiguated name (`report (2).pdf`, `IMG_0001 (2).jpg`, then `(3)`…) with a plain `copy` action — nothing dropped.
- **Byte-identical files still dedupe** (`skip-dupe`); only distinct ones are renamed.
- Deterministic: stable `sourcePath` order + a per-original-slot probe cursor → O(N), reproducible across re-runs, and it skips any name a real source file already holds.
- The cross-run catalog/`_superseded` newer-wins path is **unchanged** (different feature).

`apply` needs no change — a renamed item is a `copy` to its (renamed) target; the path jail rejects only `..`/NUL/absolute (spaces & parens are fine) and exec runs via argv (no shell).

## Review UI
The rollup gains a `renamed` count (a subset of `copy`); the review shows a **Renamed** column and a blue "renamed, nothing lost" note. In-tree `conflict`s drop to ~0.

## Tests
- `dedup.test.ts`: two distinct files → both import (later renamed); N distinct → `(2),(3)…` while byte-identical dedupes; determinism across re-runs; a renamed file doesn't collide with a real source file already named `(2)`; fingerprint-distinct → renamed without a full read.
- `status.test.ts`: a disambiguated copy is counted under both `copy` and `renamed`.
- Full disk-import suite (307) + `tsc --noEmit` green.

## Acceptance / box-verify owed
Real-disk scan: `conflicts → 0`, `renamed →` the former conflict count, every distinct file imported, review wording reflects "renamed, nothing lost".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
