### PR TITLE
feat(disk-import): save & re-run the per-folder routing selection (#2007)

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -134,10 +134,12 @@ describe('triggerScan', () => {
 });
 
 describe('replanImport', () => {
-  it('writes the rules IN the container (worker SELinux label) then execs --replan', async () => {
+  it('writes the rules IN the container then LAUNCHES --replan DETACHED (#2009)', async () => {
     const exec = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '' });
     const request = { explicit: { alice: { owner: 'alice' } }, rootDefault: { owner: 'shared' } };
-    await replanImport({ exec, runId: 'run1', container: 'disk-import-worker-run1', request });
+    const preUpdatedAt = await replanImport({ exec, runId: 'run1', container: 'disk-import-worker-run1', request });
+    // Returns the pre-launch status timestamp so the poller can spot the NEW done.
+    expect(typeof preUpdatedAt).toBe('number');
 
     // 1st exec: write replan-request.json INSIDE the container (not servicebay fs —
     // a servicebay write is unreadable by the worker due to SELinux MCS).
@@ -148,22 +150,23 @@ describe('replanImport', () => {
     // No servicebay fs write of the request.
     expect(writes.find(w => w.file.endsWith('replan-request.json'))).toBeUndefined();
 
-    // 2nd exec: the one-shot --replan over /out in the serve container.
+    // 2nd exec: the one-shot --replan over /out, launched DETACHED (`-d`) so the
+    // multi-minute re-plan doesn't block the POST (#2009).
     const replanArgv = exec.mock.calls[1][0] as string[];
-    expect(replanArgv.slice(0, 3)).toEqual(['podman', 'exec', 'disk-import-worker-run1']);
+    expect(replanArgv.slice(0, 4)).toEqual(['podman', 'exec', '-d', 'disk-import-worker-run1']);
     expect(replanArgv).toContain('--replan');
     expect(replanArgv).toContain('/out');
   });
 
-  it('throws when the worker re-plan exits non-zero', async () => {
-    // 1st exec (write request) succeeds; 2nd (--replan) fails.
+  it('throws when the worker re-plan launch exits non-zero', async () => {
+    // 1st exec (write request) succeeds; 2nd (--replan launch) fails.
     const exec = vi
       .fn()
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
       .mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'no plan' });
     await expect(
       replanImport({ exec, runId: 'run1', container: 'c', request: { explicit: {} } }),
-    ).rejects.toThrow(/re-plan failed/);
+    ).rejects.toThrow(/re-plan launch failed/);
   });
 
   it('throws when writing the replan request into the container fails', async () => {

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -90,7 +90,8 @@ export function rebasePlanSource(sidecar: PlanSidecar, hostMountpoint: string): 
 const WORKER_OUT_IN_CONTAINER = '/out';
 
 /** Re-plan over a real disk re-dedups every record — minutes, like the scan. The
- *  agent's 30s default would kill it; give it a generous ceiling. (#2009) */
+ *  detached re-plan is polled up to this ceiling before {@link waitForReplanDone}
+ *  gives up (#2009). */
 const REPLAN_TIMEOUT_MS = 600_000; // 10 min
 
 export interface ReplanImportArgs {
@@ -105,7 +106,8 @@ export interface ReplanImportArgs {
 }
 
 /**
- * RE-PLAN the active run with the page's per-folder routing rules (#2000).
+ * LAUNCH a RE-PLAN of the active run with the page's per-folder routing rules and
+ * return immediately (#2000 + async #2009).
  *
  * The re-plan must re-dedup PER OWNER (so a cross-owner duplicate lands in BOTH
  * owners' areas instead of being dropped as a `shared`-scope dupe) — which needs
@@ -114,11 +116,21 @@ export interface ReplanImportArgs {
  * writes the routing rules into the shared out dir and `podman exec`s the running
  * serve container to re-plan in-place: it reads the existing plan.json (no re-scan),
  * re-routes/re-dedups over the live mount, and rewrites plan.json + status.json.
- * The subsequent host-apply then applies the rewritten plan.json UNCHANGED.
+ *
+ * #2009: re-planning a real disk re-runs buildPlan over every record (minutes), so
+ * the `--replan` exec is now DETACHED (`-d`) — like {@link triggerScan} — and the
+ * caller polls status.json via {@link waitForReplanDone} instead of awaiting a
+ * multi-minute synchronous `podman exec` (which blocked the POST and risked
+ * NPM/Authelia/browser timeouts). Returns the status doc's `updatedAt` from BEFORE
+ * the launch so the poller can tell the re-plan's `done` apart from the prior scan's
+ * `done` (both are `phase:done`).
  */
-export async function replanImport(args: ReplanImportArgs): Promise<void> {
+export async function replanImport(args: ReplanImportArgs): Promise<number> {
   const { exec, runId, container, request } = args;
-  void runId;
+  // Snapshot the pre-launch status timestamp — the wait loop returns only once a
+  // NEW `done` (updatedAt changed) appears, never the scan's stale `done`.
+  const preUpdatedAt = (await readOutStatus(runOutDir(runId), runId)).updatedAt;
+
   // Write the request the worker reads INSIDE the container, not from servicebay's
   // fs. A servicebay write lands with servicebay's PRIVATE SELinux MCS category, so
   // the worker (different category) gets EACCES reading /out/replan-request.json
@@ -136,24 +148,61 @@ export async function replanImport(args: ReplanImportArgs): Promise<void> {
     throw new Error(`disk-import: writing replan request failed (code ${wr.code}): ${wr.stderr || wr.stdout}`);
   }
 
-  // Run a one-shot `--replan` process IN the serve container (it has /mnt/src +
-  // /out): reads replan-request.json + plan.json, re-plans over the live mount,
-  // rewrites plan.json + status.json. The serve server keeps running alongside.
-  const { code, stdout, stderr } = await exec(
-    [
-      'podman', 'exec', container,
-      'npx', 'tsx', 'packages/disk-import-worker/src/cli/main.ts',
-      '--replan', '--out', WORKER_OUT_IN_CONTAINER,
-    ],
-    // Re-planning a real disk re-runs buildPlan over every record (re-dedup per
-    // owner) — minutes on a 234k-file drive, like the scan. The agent's default
-    // 30s command timeout killed it ("Agent request timeout after 30000ms"), so
-    // give it the same generous timeout the scan/mount use.
-    { timeoutMs: REPLAN_TIMEOUT_MS },
-  );
+  // Launch the one-shot `--replan` DETACHED in the serve container (it has /mnt/src
+  // + /out): reads replan-request.json + plan.json, re-plans over the live mount,
+  // and rewrites plan.json + status.json (phase `planning` → `done`) on completion.
+  // The serve server keeps running alongside; servicebay returns now (#2009).
+  const { code, stdout, stderr } = await exec([
+    'podman', 'exec', '-d', container,
+    'npx', 'tsx', 'packages/disk-import-worker/src/cli/main.ts',
+    '--replan', '--out', WORKER_OUT_IN_CONTAINER,
+  ]);
   if (code !== 0) {
-    throw new Error(`disk-import: re-plan failed (code ${code}): ${stderr || stdout}`);
+    throw new Error(`disk-import: re-plan launch failed (code ${code}): ${stderr || stdout}`);
   }
+  return preUpdatedAt;
+}
+
+/** Poll cadence for {@link waitForReplanDone}; the ceiling reuses REPLAN_TIMEOUT_MS. */
+const REPLAN_POLL_MS = 2_000;
+
+const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Wait for a DETACHED re-plan ({@link replanImport}) to finish by polling its
+ * status.json (#2009). Resolves once the worker writes a fresh `done`/dry-run doc
+ * (updatedAt changed from `preUpdatedAt`); throws on the worker's `error` phase or
+ * after the timeout. Reads the out dir host-side — the worker owns the writes, so
+ * servicebay never relabels the file mid-replan.
+ */
+export async function waitForReplanDone(args: {
+  runId: string;
+  preUpdatedAt: number;
+  pollMs?: number;
+  timeoutMs?: number;
+}): Promise<void> {
+  const { runId, preUpdatedAt } = args;
+  const outDir = runOutDir(runId);
+  const deadline = Date.now() + (args.timeoutMs ?? REPLAN_TIMEOUT_MS);
+  for (;;) {
+    const s = await readOutStatus(outDir, runId);
+    if (s.phase === 'error') throw new Error(`disk-import: re-plan failed: ${s.error ?? 'unknown error'}`);
+    if (s.phase === 'done' && s.mode === 'dry-run' && s.updatedAt !== preUpdatedAt) return;
+    if (Date.now() > deadline) throw new Error('disk-import: re-plan timed out');
+    await delay(args.pollMs ?? REPLAN_POLL_MS);
+  }
+}
+
+/**
+ * Record a terminal `error` on the run's status doc so the page surfaces it (#2009).
+ * Used by the DETACHED apply flow when something fails AFTER the route returned (the
+ * caller can no longer throw to the HTTP response). Written host-side — by apply time
+ * the worker is idle (serve mode, not writing status), so no relabel race.
+ */
+export async function recordRunError(runId: string, message: string): Promise<void> {
+  const outDir = runOutDir(runId);
+  const status = await readOutStatus(outDir, runId);
+  await writeOutStatus(outDir, { ...status, phase: 'error', step: 'Import failed', error: message, updatedAt: Date.now() });
 }
 
 /** Source device mountpoint inside the serve container (its `…:/mnt/src:ro` bind). */

--- a/packages/backend/src/lib/diskImport/profiles.test.ts
+++ b/packages/backend/src/lib/diskImport/profiles.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, writeFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Point DATA_DIR at a throwaway temp dir so the store writes real files we can read
+// back — profiles.ts joins DATA_DIR/disk-import-profiles at module load.
+let TMP = '';
+vi.mock('@/lib/dirs', () => ({ get DATA_DIR() { return TMP; } }));
+
+const { profilesDir, saveProfile, listProfiles, deleteProfile } = await import('./profiles');
+
+beforeEach(async () => {
+  TMP = await mkdtemp(path.join(tmpdir(), 'di-profiles-'));
+});
+afterEach(async () => {
+  await rm(TMP, { recursive: true, force: true });
+});
+
+describe('disk-import routing presets (#2007)', () => {
+  const rules = { '': { owner: 'shared' }, photos: { owner: 'mdopp', disposition: 'photos_immich' } } as never;
+
+  it('saves a preset and lists it back (round-trip)', async () => {
+    const saved = await saveProfile({ name: 'Family backup', rules });
+    expect(saved).toMatchObject({ name: 'Family backup', rules });
+    expect(saved.savedAt).toBeGreaterThan(0);
+
+    const list = await listProfiles();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ name: 'Family backup', rules });
+  });
+
+  it('re-saving the same name OVERWRITES (slug is the on-disk key), not duplicates', async () => {
+    await saveProfile({ name: 'Trip 2021', rules: {} as never });
+    await saveProfile({ name: 'trip 2021', rules: { docs: { owner: 'mdopp' } } as never });
+    const list = await listProfiles();
+    expect(list).toHaveLength(1);
+    expect(list[0].rules).toMatchObject({ docs: { owner: 'mdopp' } });
+  });
+
+  it('lists newest first and deletes by name', async () => {
+    await saveProfile({ name: 'first', rules: {} as never });
+    await new Promise(r => setTimeout(r, 2));
+    await saveProfile({ name: 'second', rules: {} as never });
+    expect((await listProfiles()).map(p => p.name)).toEqual(['second', 'first']);
+
+    await deleteProfile('first');
+    expect((await listProfiles()).map(p => p.name)).toEqual(['second']);
+    // Deleting a missing preset is a no-op.
+    await expect(deleteProfile('gone')).resolves.toBeUndefined();
+  });
+
+  it('neutralizes path-traversal in a name to a safe stem inside the dir', async () => {
+    // The slug strips separators/dots, so this can't escape — it saves as a tame
+    // `etc-passwd.json` UNDER the profiles dir, never `../../etc/passwd`.
+    await saveProfile({ name: '../../etc/passwd', rules: {} as never });
+    const files = await readdir(profilesDir());
+    expect(files).toEqual(['etc-passwd.json']);
+    files.forEach(f => expect(f.includes('/')).toBe(false));
+  });
+
+  it('rejects a blank name and one that slugs to nothing', async () => {
+    await expect(saveProfile({ name: '   ', rules: {} as never })).rejects.toThrow(/preset name required/);
+    await expect(saveProfile({ name: '...', rules: {} as never })).rejects.toThrow(/invalid preset name/);
+    const files = await readdir(profilesDir()).catch(() => []);
+    expect(files).toEqual([]);
+  });
+
+  it('skips a corrupt preset file rather than failing the whole list', async () => {
+    await saveProfile({ name: 'good', rules: {} as never });
+    await writeFile(path.join(profilesDir(), 'broken.json'), '{ not json', 'utf-8');
+    const list = await listProfiles();
+    expect(list.map(p => p.name)).toEqual(['good']);
+  });
+});

--- a/packages/backend/src/lib/diskImport/profiles.ts
+++ b/packages/backend/src/lib/diskImport/profiles.ts
@@ -1,0 +1,111 @@
+// Disk-import — saved ROUTING PRESETS (#2007).
+//
+// The routing tree (#2000) lets the operator assign owner + target per folder — on
+// a real disk that's 30+ deliberate picks that today live only in the page's React
+// state and vanish on reload/re-scan. A preset persists that explicit rule map
+// (relDir → Rule) under servicebay's data dir so the operator can re-load it on a
+// fresh scan and go straight to "Re-plan & import" with zero re-entry.
+//
+// Manual, NAMED presets (operator's call) — no disk-signature auto-recall. These are
+// servicebay's OWN files (DATA_DIR, core-owned), never the worker's `:Z` out dir, so
+// there's no SELinux relabel concern (feedback_fileshare_relabel_crashloop).
+
+import { mkdir, readdir, readFile, writeFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { Rule } from '@servicebay/disk-import-worker';
+
+import { DATA_DIR } from '@/lib/dirs';
+
+/** Where presets live (one JSON file per preset). Resolved at call time so DATA_DIR
+ *  is read live (not frozen at module load) — keeps it testable + env-overridable. */
+export function profilesDir(): string {
+  return path.join(DATA_DIR, 'disk-import-profiles');
+}
+
+/** A saved routing selection. `rules` is the same explicit map the page POSTs to
+ *  /replan + /apply; `rootDefault` is the optional disk-default owner. */
+export interface RoutingProfile {
+  /** Operator-facing display name (free text, as entered). */
+  name: string;
+  /** relDir → the explicit (partial) Rule the operator set on that folder (`''` = root). */
+  rules: Record<string, Rule>;
+  /** Optional disk-default / root default applied where no folder sets an owner. */
+  rootDefault?: Partial<Rule>;
+  /** Epoch ms the preset was last saved (drives newest-first listing). */
+  savedAt: number;
+}
+
+/**
+ * Map a free-text preset name to a SAFE filename stem. Lowercased, non-`[a-z0-9._-]`
+ * runs collapsed to `-`, trimmed + length-capped. The original name is preserved
+ * inside the file for display; the slug is only the on-disk key (so re-saving the
+ * same name overwrites rather than duplicating).
+ */
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|-+$/g, '')
+    .slice(0, 64);
+}
+
+/** Resolve a preset's file path, refusing any name that can't slug to a safe stem. */
+function profilePath(name: string): string {
+  const stem = slugify(name);
+  if (!stem || stem === '.' || stem === '..') {
+    throw new Error('disk-import: invalid preset name');
+  }
+  const dir = profilesDir();
+  const file = path.join(dir, `${stem}.json`);
+  // Defence in depth: the resolved file must sit directly under the profiles dir.
+  if (path.dirname(file) !== dir) {
+    throw new Error('disk-import: invalid preset name');
+  }
+  return file;
+}
+
+/** Persist (create or overwrite) a preset; returns the stored record. */
+export async function saveProfile(input: {
+  name: string;
+  rules: Record<string, Rule>;
+  rootDefault?: Partial<Rule>;
+}): Promise<RoutingProfile> {
+  if (!input.name?.trim()) throw new Error('disk-import: preset name required');
+  await mkdir(profilesDir(), { recursive: true });
+  const profile: RoutingProfile = {
+    name: input.name.trim(),
+    rules: input.rules ?? {},
+    rootDefault: input.rootDefault,
+    savedAt: Date.now(),
+  };
+  await writeFile(profilePath(input.name), JSON.stringify(profile), 'utf-8');
+  return profile;
+}
+
+/** List all saved presets, newest first. Missing dir → none; corrupt files skipped. */
+export async function listProfiles(): Promise<RoutingProfile[]> {
+  const dir = profilesDir();
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: RoutingProfile[] = [];
+  for (const f of files) {
+    if (!f.endsWith('.json')) continue;
+    try {
+      out.push(JSON.parse(await readFile(path.join(dir, f), 'utf-8')) as RoutingProfile);
+    } catch {
+      // Skip a corrupt/partial preset rather than failing the whole list.
+    }
+  }
+  return out.sort((a, b) => b.savedAt - a.savedAt);
+}
+
+/** Delete a preset by name (idempotent — a missing preset is not an error). */
+export async function deleteProfile(name: string): Promise<void> {
+  await rm(profilePath(name), { force: true });
+}

--- a/packages/backend/src/lib/diskImport/service.test.ts
+++ b/packages/backend/src/lib/diskImport/service.test.ts
@@ -5,7 +5,13 @@ import type { SafeExec } from '@servicebay/disk-import-worker';
 // service.ts is a thin facade over apply/launcher/runStore — mock all three so
 // these tests assert the FACADE's wiring (teardown-on-apply-success #1982), not
 // the collaborators (each has its own unit tests).
-vi.mock('./apply', () => ({ applyImport: vi.fn() }));
+vi.mock('./apply', () => ({
+  applyImport: vi.fn(),
+  replanImport: vi.fn(),
+  triggerScan: vi.fn(),
+  waitForReplanDone: vi.fn(async () => undefined),
+  recordRunError: vi.fn(async () => undefined),
+}));
 vi.mock('./launcher', () => ({
   launchWorker: vi.fn(),
   readStatus: vi.fn(),
@@ -21,8 +27,8 @@ vi.mock('./runStore', () => ({
   clearActiveRun: vi.fn(async () => undefined),
 }));
 
-import { applyRun, resolveShareGid } from './service';
-import { applyImport } from './apply';
+import { startApplyFlow, runApplyFlow, resolveShareGid } from './service';
+import { applyImport, replanImport, waitForReplanDone, recordRunError } from './apply';
 import { cleanupRunMount } from './launcher';
 import { getActiveRun, clearActiveRun } from './runStore';
 
@@ -33,14 +39,13 @@ function statExec(gid: number): SafeExec {
 const exec = statExec(973);
 const RUN = { runId: 'r1', outDir: '/o', container: 'c', device: '/dev/sdb1', mountpoint: '/run/servicebay/disk-import/sdb1' };
 
-describe('applyRun teardown (#1982)', () => {
+describe('runApplyFlow teardown (#1982) + async flow (#2009)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('unmounts the device and clears the run after a successful apply', async () => {
-    vi.mocked(getActiveRun).mockResolvedValue(RUN as never);
     vi.mocked(applyImport).mockResolvedValue({ copied: 3 } as never);
 
-    const result = await applyRun(exec, 1000);
+    const result = await runApplyFlow(exec, 1000, RUN as never, null);
 
     expect(result).toEqual({ copied: 3 });
     // The apply runs against the REAL host-resolved file-share gid (973), NOT the
@@ -48,23 +53,58 @@ describe('applyRun teardown (#1982)', () => {
     expect(vi.mocked(applyImport).mock.calls[0]![0]).toMatchObject({ shareGid: 973 });
     expect(cleanupRunMount).toHaveBeenCalledWith(exec, RUN);
     expect(clearActiveRun).toHaveBeenCalledOnce();
+    // No rules → no re-plan wait.
+    expect(waitForReplanDone).not.toHaveBeenCalled();
   });
 
-  it('leaves the mount live (no cleanup) when the apply throws', async () => {
-    vi.mocked(getActiveRun).mockResolvedValue(RUN as never);
+  it('waits for the detached re-plan before applying when one was launched', async () => {
+    vi.mocked(applyImport).mockResolvedValue({ copied: 1 } as never);
+
+    await runApplyFlow(exec, 1000, RUN as never, 1234);
+
+    // preUpdatedAt threaded through so the wait can spot the NEW done.
+    expect(waitForReplanDone).toHaveBeenCalledWith({ runId: RUN.runId, preUpdatedAt: 1234 });
+    expect(applyImport).toHaveBeenCalledOnce();
+  });
+
+  it('records an error and leaves the mount live (no cleanup) when the apply throws', async () => {
     vi.mocked(applyImport).mockRejectedValue(new Error('apply boom'));
 
-    await expect(applyRun(exec, 1000)).rejects.toThrow('apply boom');
+    // The route already returned (#2009), so the flow swallows + records, never throws.
+    const result = await runApplyFlow(exec, 1000, RUN as never, null);
+
+    expect(result).toBeNull();
+    expect(recordRunError).toHaveBeenCalledWith(RUN.runId, 'apply boom');
     expect(cleanupRunMount).not.toHaveBeenCalled();
     expect(clearActiveRun).not.toHaveBeenCalled();
   });
+});
 
-  it('throws when there is no active run, without touching cleanup', async () => {
+describe('startApplyFlow pre-flight (#2009)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('throws promptly when there is no active run, without touching apply/re-plan', async () => {
     vi.mocked(getActiveRun).mockResolvedValue(null as never);
 
-    await expect(applyRun(exec, 1000)).rejects.toThrow('no active run');
+    await expect(startApplyFlow(exec, 1000)).rejects.toThrow('no active run');
     expect(applyImport).not.toHaveBeenCalled();
-    expect(cleanupRunMount).not.toHaveBeenCalled();
+    expect(replanImport).not.toHaveBeenCalled();
+  });
+
+  it('launches the detached re-plan synchronously when rules are passed', async () => {
+    vi.mocked(getActiveRun).mockResolvedValue(RUN as never);
+    vi.mocked(replanImport).mockResolvedValue(42 as never);
+    vi.mocked(applyImport).mockResolvedValue({ copied: 0 } as never);
+
+    await startApplyFlow(exec, 1000, { explicit: { docs: { owner: 'mdopp' } } } as never);
+
+    // The re-plan launch happens before the route returns (preUpdatedAt captured).
+    expect(replanImport).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: RUN.runId, container: RUN.container }),
+    );
+    // The heavy continuation is fire-and-forget — let its microtasks settle.
+    await new Promise(r => setImmediate(r));
+    expect(waitForReplanDone).toHaveBeenCalledWith({ runId: RUN.runId, preUpdatedAt: 42 });
   });
 });
 

--- a/packages/backend/src/lib/diskImport/service.ts
+++ b/packages/backend/src/lib/diskImport/service.ts
@@ -25,7 +25,14 @@ import {
 } from './launcher';
 import { listImportDevices } from './devices';
 import { setActiveRun, getActiveRun, clearActiveRun } from './runStore';
-import { applyImport, replanImport, triggerScan, type ApplyImportResult } from './apply';
+import {
+  applyImport,
+  replanImport,
+  triggerScan,
+  waitForReplanDone,
+  recordRunError,
+  type ApplyImportResult,
+} from './apply';
 
 export type { ImportDevice } from './launcher';
 
@@ -117,9 +124,10 @@ export async function getRunStatus(exec: SafeExec): Promise<RunStatus | null> {
  */
 /**
  * Re-plan the active run with the page's per-folder routing rules (#2000) WITHOUT
- * applying — re-routes/re-dedups per owner in the worker (over the live mount) and
- * rewrites plan.json + status.json so the tile poll reflects the new owner-aware
- * plan. Used to preview the effect of the routing picks before "Import now".
+ * applying — LAUNCHES the detached re-plan (#2009) and returns immediately; the
+ * worker re-routes/re-dedups per owner over the live mount and rewrites
+ * plan.json + status.json (phase `planning` → `done`), which the tile poll reflects.
+ * Used to preview the effect of the routing picks before "Import now".
  */
 export async function replanRun(exec: SafeExec, request: ReplanRequest): Promise<void> {
   const run = await getActiveRun();
@@ -128,39 +136,73 @@ export async function replanRun(exec: SafeExec, request: ReplanRequest): Promise
 }
 
 /**
- * Apply the active run. When `request` is given, RE-PLAN with the page's routing
- * rules first (#2000) so files land in `data/<owner>/<category>/…` and the dedup
- * splits per owner; then the host-apply applies the rewritten plan.json unchanged.
+ * START the apply of the active run and return PROMPTLY (#2009). When `request` is
+ * given, the detached re-plan is LAUNCHED synchronously (so the page immediately
+ * sees the re-plan run) — but neither the multi-minute re-plan nor the host-apply is
+ * awaited here: they run in {@link runApplyFlow} in the background while the page
+ * polls status.json. Replaces the old synchronous `applyRun` that blocked the POST
+ * for the whole re-plan + copy (risking proxy/browser timeouts on a big disk).
+ *
+ * Throws only on the fast pre-flight failures (no active run / re-plan launch
+ * failed); everything after is reported through status.json (`error` phase).
  */
-export async function applyRun(
+export async function startApplyFlow(
   exec: SafeExec,
   shareGid: number,
   request?: ReplanRequest,
-): Promise<ApplyImportResult> {
+): Promise<void> {
   const run = await getActiveRun();
   if (!run) throw new Error('disk-import: no active run to apply');
-  // #2000: re-plan with the routing rules BEFORE applying, so the host-apply reads
-  // the owner-aware, per-owner-deduped plan.json. Skipped when no rules were sent
-  // (a plain apply of the auto-sorted plan).
-  if (request) {
-    await replanImport({ exec, runId: run.runId, container: run.container, request });
+  // #2000/#2009: launch the re-plan (detached) BEFORE returning, so the routing
+  // rules are in flight and the page sees `planning`. preUpdatedAt lets the flow
+  // tell the re-plan's `done` apart from the prior scan's. Skipped with no rules.
+  const preUpdatedAt = request
+    ? await replanImport({ exec, runId: run.runId, container: run.container, request })
+    : null;
+  // Fire-and-forget the heavy work — the route returns now, the page polls.
+  void runApplyFlow(exec, shareGid, run, preUpdatedAt).catch((e: unknown) =>
+    logger.error('disk-import:apply', `apply flow crashed: ${e instanceof Error ? e.message : String(e)}`),
+  );
+}
+
+/**
+ * The background apply continuation (#2009): wait for any launched re-plan to
+ * finish, resolve the real file-share gid, run the privileged host-apply, then tear
+ * the run down. Never throws — a failure is recorded on status.json (the route has
+ * already returned) and the mount is LEFT LIVE for retry/inspection (mirrors the old
+ * apply-error path). Exported for unit tests.
+ */
+export async function runApplyFlow(
+  exec: SafeExec,
+  shareGid: number,
+  run: WorkerRun,
+  preUpdatedAt: number | null,
+): Promise<ApplyImportResult | null> {
+  try {
+    // Block on the detached re-plan completing (polls status.json) before applying
+    // the rewritten plan.json.
+    if (preUpdatedAt !== null) await waitForReplanDone({ runId: run.runId, preUpdatedAt });
+    // Resolve the REAL file-share group gid host-side — the passed `shareGid` is the
+    // fallback. The apply chowns every copied file to `core:<this gid>`; a wrong gid
+    // (the 1024 fallback) leaves files in an unnamed group the containers can't read
+    // AND risks a non-core stray crash-looping file-share on its next redeploy
+    // (feedback_fileshare_relabel_crashloop).
+    const realGid = await resolveShareGid(exec, shareGid);
+    const result = await applyImport({ exec, runId: run.runId, mountpoint: run.mountpoint, shareGid: realGid });
+    // Apply succeeded — unmount the source device and forget the run (#1982) so the
+    // USB doesn't leak a mount and a reopened tile lands on the picker, not a stale
+    // "active run". Both are best-effort/idempotent.
+    await cleanupRunMount(exec, run);
+    await clearActiveRun();
+    return result;
+  } catch (e) {
+    // The route already returned, so surface the failure through status.json and
+    // leave the mount live (no cleanup/clear) for retry/inspection.
+    const message = e instanceof Error ? e.message : String(e);
+    await recordRunError(run.runId, message).catch(() => {});
+    logger.error('disk-import:apply', `apply flow failed: ${message}`);
+    return null;
   }
-  // Resolve the REAL file-share group gid host-side — the passed `shareGid` is the
-  // fallback. The apply chowns every copied file to `core:<this gid>`; a wrong gid
-  // (the 1024 fallback) leaves files in an unnamed group the containers can't read
-  // AND risks a non-core stray crash-looping file-share on its next redeploy
-  // (feedback_fileshare_relabel_crashloop).
-  const realGid = await resolveShareGid(exec, shareGid);
-  const result = await applyImport({ exec, runId: run.runId, mountpoint: run.mountpoint, shareGid: realGid });
-  // Apply succeeded — unmount the source device and forget the run (#1982) so the
-  // USB doesn't leak a mount and a reopened tile lands on the picker, not a stale
-  // "active run". Both are best-effort/idempotent (cleanupRunMount ignores
-  // not-mounted/missing-dir), and only run on success: on an apply ERROR we throw
-  // above WITHOUT cleanup, leaving the mount live for retry/inspection until the
-  // user's explicit "Start over" (abortRun).
-  await cleanupRunMount(exec, run);
-  await clearActiveRun();
-  return result;
 }
 
 /** Stop the active worker container and forget it (the tile's "Start over"). */

--- a/packages/backend/src/lib/diskImport/tree.ts
+++ b/packages/backend/src/lib/diskImport/tree.ts
@@ -9,7 +9,8 @@
 //
 // The user then edits owner + disposition per folder; those edits flow back to
 // the apply call as an explicit rule map and re-plan the import with routing
-// (see service.applyRun → applyImport, which threads a RoutingResolution).
+// (see service.startApplyFlow → replanImport/applyImport, which thread a
+// RoutingResolution; the re-plan + apply run async, #2009).
 
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -429,8 +429,19 @@ export async function runReplanCli(opts: ReplanArgs, io?: ReplanIO): Promise<voi
   const resolved = io ?? realReplanIO(opts.out);
   const reqPath = path.join(opts.out, REPLAN_REQUEST_FILE);
   const request = JSON.parse(readFileSync(reqPath, 'utf8')) as ReplanRequest;
-  const plan = await runReplan(request, resolved);
-  console.log(`disk-import: re-planned ${plan.items.length} items, ${plan.conflicts.length} conflict(s).`);
+  try {
+    const plan = await runReplan(request, resolved);
+    console.log(`disk-import: re-planned ${plan.items.length} items, ${plan.conflicts.length} conflict(s).`);
+  } catch (e) {
+    // The re-plan now runs DETACHED (#2009), so nobody reads our exit code — write an
+    // `error` status so servicebay's poller (waitForReplanDone) surfaces the failure
+    // promptly instead of waiting out the full timeout.
+    const message = e instanceof Error ? e.message : String(e);
+    const prev = await resolved.readJson<WorkerStatus>(STATUS_FILE);
+    const base = prev ?? initialStatus('', 'dry-run');
+    await resolved.writeStatus({ ...base, phase: 'error', step: 'Re-plan failed', error: message, updatedAt: Date.now() });
+    throw e;
+  }
 }
 
 /** Real (fs-backed) re-plan IO: reads the out dir, hashes via the live mount. */

--- a/packages/disk-import-worker/src/contract/status.test.ts
+++ b/packages/disk-import-worker/src/contract/status.test.ts
@@ -51,11 +51,24 @@ describe('status contract', () => {
     const rollup = summarizeCategories(plan);
     expect(rollup.map(r => r.category)).toEqual(['music', 'photos']); // sorted
     const photos = rollup.find(r => r.category === 'photos')!;
-    expect(photos).toEqual({ category: 'photos', files: 2, bytes: 30, copy: 1, skipDupe: 1, conflict: 0 });
+    expect(photos).toEqual({ category: 'photos', files: 2, bytes: 30, copy: 1, skipDupe: 1, conflict: 0, renamed: 0 });
     const music = rollup.find(r => r.category === 'music')!;
-    expect(music).toEqual({ category: 'music', files: 2, bytes: 12, copy: 1, skipDupe: 0, conflict: 1 });
+    expect(music).toEqual({ category: 'music', files: 2, bytes: 12, copy: 1, skipDupe: 0, conflict: 1, renamed: 0 });
     // Rollup entries are scalar-only — no file records leak in.
     expect(Object.keys(photos)).not.toContain('record');
+  });
+
+  it('counts a disambiguated copy under both copy and renamed (#2006)', () => {
+    const plan: ImportPlan = {
+      items: [
+        { record: rec('a.jpg', 10), category: 'photos', target: 'photos/a.jpg', action: 'copy' },
+        { record: rec('b.jpg', 10), category: 'photos', target: 'photos/a (2).jpg', action: 'copy', renamed: true },
+      ],
+      conflicts: [],
+    };
+    const photos = summarizeCategories(plan).find(r => r.category === 'photos')!;
+    // The renamed file IS imported (copy) and ALSO tallied as renamed (a subset).
+    expect(photos).toMatchObject({ files: 2, copy: 2, renamed: 1, conflict: 0 });
   });
 
   it('exposes stable file-name constants for the shared volume', () => {

--- a/packages/disk-import-worker/src/contract/status.ts
+++ b/packages/disk-import-worker/src/contract/status.ts
@@ -50,6 +50,13 @@ export interface CategoryRollup {
   copy: number;
   skipDupe: number;
   conflict: number;
+  /**
+   * Files imported (action `copy`) under a disambiguated name because a different
+   * file already claimed the natural one (#2006). A subset of `copy` — counted
+   * separately so the review can say "renamed, nothing lost" instead of dropping
+   * them as conflicts.
+   */
+  renamed: number;
 }
 
 /**
@@ -113,11 +120,13 @@ export function summarizeCategories(plan: ImportPlan): CategoryRollup[] {
   for (const item of plan.items) {
     const r =
       byCat.get(item.category) ??
-      ({ category: item.category, files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0 } as CategoryRollup);
+      ({ category: item.category, files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0, renamed: 0 } as CategoryRollup);
     r.files += 1;
     r.bytes += item.record.size;
-    if (item.action === 'copy') r.copy += 1;
-    else if (item.action === 'skip-dupe') r.skipDupe += 1;
+    if (item.action === 'copy') {
+      r.copy += 1;
+      if (item.renamed) r.renamed += 1; // a disambiguated copy (#2006) — subset of copy
+    } else if (item.action === 'skip-dupe') r.skipDupe += 1;
     else if (item.action === 'conflict') r.conflict += 1;
     byCat.set(item.category, r);
   }

--- a/packages/disk-import-worker/src/engine/dedup.test.ts
+++ b/packages/disk-import-worker/src/engine/dedup.test.ts
@@ -45,6 +45,10 @@ function actionOf(items: ImportPlanItem[], sourcePath: string) {
   return items.find(i => i.record.sourcePath === sourcePath)?.action;
 }
 
+function itemOf(items: ImportPlanItem[], sourcePath: string) {
+  return items.find(i => i.record.sourcePath === sourcePath);
+}
+
 describe('targetFor', () => {
   it('places files under their category folder with the base name', () => {
     const r = buildInventory([{ path: '/disk/sub/Photo.JPG', size: 1, mtimeMs: 0 }])[0];
@@ -100,21 +104,84 @@ describe('buildPlan — size→hash dedup within the tree', () => {
   });
 });
 
-describe('buildPlan — conflicts (same target, different content)', () => {
-  it('flags two different files competing for the same target path', () => {
+describe('buildPlan — in-tree name clashes RENAME, never drop (#2006)', () => {
+  it('two different files at the same target → both import, the later renamed', () => {
     const files: ScannedFile[] = [
       { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
       { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
     ];
     const result = plan(files, { '/diskA/report.pdf': sha('a'), '/diskB/report.pdf': sha('b') });
-    expect(actionOf(result.items, '/diskA/report.pdf')).toBe('copy');
-    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('conflict');
-    expect(result.conflicts).toHaveLength(1);
-    expect(result.conflicts[0]).toMatchObject({
+    // The first claims the natural name; the distinct second is imported renamed.
+    expect(itemOf(result.items, '/diskA/report.pdf')).toMatchObject({
+      action: 'copy',
       target: 'documents/report.pdf',
-      existing: { sourcePath: '/diskA/report.pdf' },
-      incoming: { sourcePath: '/diskB/report.pdf' },
     });
+    expect(itemOf(result.items, '/diskB/report.pdf')).toMatchObject({
+      action: 'copy',
+      target: 'documents/report (2).pdf',
+      renamed: true,
+    });
+    // Nothing dropped — no unresolved conflicts.
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it('N distinct same-name files import as (2),(3)…; byte-identical ones still dedupe', () => {
+    const files: ScannedFile[] = [
+      { path: '/d1/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d2/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d3/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d4/IMG_0001.jpg', size: 5000, mtimeMs: 0 }, // byte-identical to /d1
+    ];
+    const result = plan(files, {
+      '/d1/IMG_0001.jpg': sha('a'),
+      '/d2/IMG_0001.jpg': sha('b'),
+      '/d3/IMG_0001.jpg': sha('c'),
+      '/d4/IMG_0001.jpg': sha('a'),
+    });
+    expect(itemOf(result.items, '/d1/IMG_0001.jpg')).toMatchObject({ action: 'copy', target: 'photos/img_0001.jpg' });
+    expect(itemOf(result.items, '/d2/IMG_0001.jpg')).toMatchObject({ action: 'copy', target: 'photos/img_0001 (2).jpg', renamed: true });
+    expect(itemOf(result.items, '/d3/IMG_0001.jpg')).toMatchObject({ action: 'copy', target: 'photos/img_0001 (3).jpg', renamed: true });
+    // True duplicate of /d1 dedupes — only DISTINCT files get renamed.
+    expect(actionOf(result.items, '/d4/IMG_0001.jpg')).toBe('skip-dupe');
+    expect(result.conflicts).toHaveLength(0);
+    // Renames are imports, not conflicts.
+    expect(result.items.filter(i => i.action === 'conflict')).toHaveLength(0);
+  });
+
+  it('is deterministic — re-running yields the same names', () => {
+    const files: ScannedFile[] = [
+      { path: '/d1/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/d2/report.pdf', size: 5000, mtimeMs: 0 },
+      { path: '/d3/report.pdf', size: 5000, mtimeMs: 0 },
+    ];
+    const hashes = { '/d1/report.pdf': sha('a'), '/d2/report.pdf': sha('b'), '/d3/report.pdf': sha('c') };
+    const first = plan(files, hashes);
+    const second = plan(files, hashes);
+    expect(first.items.map(i => i.target)).toEqual(second.items.map(i => i.target));
+    expect(first.items.map(i => i.target).sort()).toEqual([
+      'documents/report (2).pdf',
+      'documents/report (3).pdf',
+      'documents/report.pdf',
+    ]);
+  });
+
+  it('a renamed file does not collide with a real source file already named (2)', () => {
+    const files: ScannedFile[] = [
+      { path: '/d1/IMG_0001.jpg', size: 5000, mtimeMs: 0 },
+      { path: '/d2/IMG_0001.jpg', size: 5000, mtimeMs: 0 }, // distinct → wants (2)
+      { path: '/d3/IMG_0001 (2).jpg', size: 5000, mtimeMs: 0 }, // a REAL file already named (2)
+    ];
+    const result = plan(files, {
+      '/d1/IMG_0001.jpg': sha('a'),
+      '/d2/IMG_0001.jpg': sha('b'),
+      '/d3/IMG_0001 (2).jpg': sha('c'),
+    });
+    const targets = result.items.map(i => i.target).sort();
+    // All three distinct files land on distinct names; nothing dropped.
+    expect(new Set(targets).size).toBe(3);
+    expect(targets).toContain('photos/img_0001.jpg');
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.items.filter(i => i.action === 'conflict')).toHaveLength(0);
   });
 });
 
@@ -124,7 +191,7 @@ describe('buildPlan — conflicts (same target, different content)', () => {
 // target (delta run). Source is read-only/copy-only, so a (near-impossible)
 // fingerprint false-match means one file not copied, never data loss.
 describe('buildPlan — fingerprint-trust dedup (#1995)', () => {
-  it('same size + DIFFERENT fingerprint → conflict WITHOUT reading either file whole', () => {
+  it('same size + DIFFERENT fingerprint → distinct, so renamed WITHOUT reading either file whole', () => {
     const files: ScannedFile[] = [
       { path: '/diskA/report.pdf', size: 5000, mtimeMs: 0 },
       { path: '/diskB/report.pdf', size: 5000, mtimeMs: 0 },
@@ -134,7 +201,12 @@ describe('buildPlan — fingerprint-trust dedup (#1995)', () => {
       { '/diskA/report.pdf': 'fpA', '/diskB/report.pdf': 'fpB' },
       {}, // no full-hash fixtures: full-hashing either file would throw
     );
-    expect(actionOf(result.items, '/diskB/report.pdf')).toBe('conflict');
+    // Distinct fingerprints ⇒ distinct files ⇒ the later one is imported renamed (#2006).
+    expect(itemOf(result.items, '/diskB/report.pdf')).toMatchObject({
+      action: 'copy',
+      target: 'documents/report (2).pdf',
+      renamed: true,
+    });
     expect(fullHashed).toEqual([]); // distinct fingerprints settle it cheaply
   });
 

--- a/packages/disk-import-worker/src/engine/dedup.ts
+++ b/packages/disk-import-worker/src/engine/dedup.ts
@@ -207,18 +207,28 @@ export function buildPlan(
   // `shared` vs a user area) is two distinct slots — private dedups within
   // itself, `shared` merges across sources.
   const targetOwner = new Map<string, { key: string; sha256?: string; sourcePath: string }>();
+  // Per-original-slot probe cursor for disambiguating renames (#2006), so N
+  // distinct files at one name resolve to (2),(3)… in O(N) not O(N²).
+  const renameCounters = new Map<string, number>();
 
   // 3. Decide each kept record from its precomputed content key.
   for (const c of ordered) {
     const target = c.target!;
     const area = areaOf(c.record);
     const slot = dedupSlot(area, target);
-    const action = decide(c, target, area, slot, keys.get(c.record.sourcePath)!, {
+    const decision = decide(c, target, area, slot, keys.get(c.record.sourcePath)!, {
       targetOwner,
+      renameCounters,
       catalog,
       conflicts,
     });
-    items.push({ record: c.record, category: c.category, target, action });
+    items.push({
+      record: c.record,
+      category: c.category,
+      target: decision.target,
+      action: decision.action,
+      ...(decision.renamed ? { renamed: true } : {}),
+    });
   }
 
   // Stable output ordering.
@@ -310,6 +320,13 @@ function resolveContentKeys(
   return out;
 }
 
+/** A decided record: its (possibly disambiguated) target, the action, and whether the name was changed. */
+interface Decision {
+  action: ImportAction;
+  target: string;
+  renamed?: boolean;
+}
+
 function decide(
   c: Classified,
   target: string,
@@ -318,17 +335,20 @@ function decide(
   info: KeyInfo,
   ctx: {
     targetOwner: Map<string, { key: string; sha256?: string; sourcePath: string }>;
+    renameCounters: Map<string, number>;
     catalog?: ImportCatalog;
     conflicts: Conflict[];
   },
-): ImportAction {
+): Decision {
   const { key, sha256 } = info;
 
   // Catalog dedup compares FULL hashes (the catalog stores full sha256). sha256
   // is present exactly when this record was fully hashed, which resolveContentKeys
-  // guarantees whenever the target is already cataloged.
+  // guarantees whenever the target is already cataloged. This is the cross-run
+  // newer-wins path (apply routes the existing file to _superseded) — left as a
+  // conflict on purpose; #2006 only changes the in-tree distinct-name case below.
   if (sha256 !== undefined) {
-    if (ctx.catalog?.has(sha256, target, area)) return 'skip-dupe';
+    if (ctx.catalog?.has(sha256, target, area)) return { action: 'skip-dupe', target };
     const catHit = ctx.catalog?.getByTarget(target, area);
     if (catHit && catHit.sha256 !== sha256) {
       ctx.conflicts.push({
@@ -336,23 +356,65 @@ function decide(
         existing: { sourcePath: catHit.sourcePath, sha256: catHit.sha256 },
         incoming: { sourcePath: c.record.sourcePath, sha256 },
       });
-      return 'conflict';
+      return { action: 'conflict', target };
     }
   }
 
   // In-tree collision at this slot (same area + target)? Compare by content key.
   const owner = ctx.targetOwner.get(slot);
   if (owner) {
-    if (owner.key === key) return 'skip-dupe'; // same content, different path
-    ctx.conflicts.push({
-      target,
-      existing: { sourcePath: owner.sourcePath, sha256: owner.sha256 ?? '' },
-      incoming: { sourcePath: c.record.sourcePath, sha256: sha256 ?? '' },
-    });
-    return 'conflict';
+    if (owner.key === key) return { action: 'skip-dupe', target }; // same content, different path
+    // DISTINCT files clashing on one name are NOT the same photo/doc — import the
+    // later one under a disambiguated name (`IMG_0001 (2).jpg`) instead of dropping
+    // it as an unresolved conflict (#2006, DATA SAFETY). Deterministic: stable
+    // sourcePath order + a per-original-slot probe cursor make re-runs reproduce
+    // the same names; a 3rd distinct clash → `(3)`, etc.
+    const renamedTarget = uniquifyTarget(target, area, slot, ctx);
+    ctx.targetOwner.set(dedupSlot(area, renamedTarget), { key, sha256, sourcePath: c.record.sourcePath });
+    return { action: 'copy', target: renamedTarget, renamed: true };
   }
 
   // First file to claim this slot.
   ctx.targetOwner.set(slot, { key, sha256, sourcePath: c.record.sourcePath });
-  return 'copy';
+  return { action: 'copy', target };
+}
+
+/**
+ * Split a target path into directory, stem and extension so a disambiguating
+ * suffix lands BEFORE the extension (`photos/IMG_0001.jpg` → `photos/IMG_0001 (2).jpg`).
+ * A leading dot (dotfile, e.g. `.bashrc`) is treated as no extension.
+ */
+function splitTarget(target: string): { dir: string; stem: string; ext: string } {
+  const slash = target.lastIndexOf('/');
+  const dir = slash >= 0 ? target.slice(0, slash + 1) : '';
+  const base = target.slice(slash + 1);
+  const dot = base.lastIndexOf('.');
+  if (dot > 0) return { dir, stem: base.slice(0, dot), ext: base.slice(dot) };
+  return { dir, stem: base, ext: '' };
+}
+
+/**
+ * Find a free disambiguated target for a name already claimed by different
+ * content (#2006). Probes `<stem> (2)<ext>`, `(3)`… within the same area, skipping
+ * any slot already claimed (including a real source file that genuinely has that
+ * name). `renameCounters` (keyed by the ORIGINAL slot) remembers where the last
+ * probe stopped so M clashes on one name cost O(M), not O(M²). Returns the new
+ * target relative path; the caller claims its slot.
+ */
+function uniquifyTarget(
+  target: string,
+  area: string,
+  originalSlot: string,
+  ctx: { targetOwner: Map<string, unknown>; renameCounters: Map<string, number> },
+): string {
+  const { dir, stem, ext } = splitTarget(target);
+  let n = ctx.renameCounters.get(originalSlot) ?? 2;
+  for (;;) {
+    const candidate = `${dir}${stem} (${n})${ext}`;
+    n += 1;
+    if (!ctx.targetOwner.has(dedupSlot(area, candidate))) {
+      ctx.renameCounters.set(originalSlot, n);
+      return candidate;
+    }
+  }
 }

--- a/packages/disk-import-worker/src/engine/replan.ts
+++ b/packages/disk-import-worker/src/engine/replan.ts
@@ -113,9 +113,37 @@ export async function runReplan(req: ReplanRequest, io: ReplanIO): Promise<Impor
   const records: ImportRecord[] = sidecar.plan.items.map(i => i.record);
   const routing = toRoutingResolution(req, sidecar.mountBase);
 
+  const nowFn = io.now ?? Date.now;
+  // Carry the scan's status forward (scanned count, startedAt) so the rollup stays
+  // coherent; fall back defensively if none was written yet.
+  const base = (await io.readJson<WorkerStatus>(STATUS_FILE)) ?? freshStatus(sidecar.runId, nowFn());
+
+  // In-flight signal (#2009): the re-plan now runs DETACHED and servicebay/the page
+  // poll status.json for completion. Scan-done and replan-done are BOTH `phase:done`,
+  // so without flipping to an in-flight phase here a poller can't tell a launched
+  // re-plan from the prior scan result. Write `planning` first, then progress while
+  // the (multi-minute) re-dedup hashes, then `done` at the end.
+  await io.writeStatus({
+    ...base,
+    phase: 'planning',
+    mode: 'dry-run',
+    step: 'Re-planning …',
+    error: null,
+    updatedAt: nowFn(),
+  });
+
   const plan = buildPlan(records, io.hashOf, {
     routing,
     fingerprintOf: io.fingerprintOf,
+    onProgress: (done, total) =>
+      void io.writeStatus({
+        ...base,
+        phase: 'planning',
+        mode: 'dry-run',
+        step: `Re-planning … hashed ${done}/${total}`,
+        error: null,
+        updatedAt: nowFn(),
+      }),
   });
 
   const newSidecar: PlanSidecar = {
@@ -127,12 +155,12 @@ export async function runReplan(req: ReplanRequest, io: ReplanIO): Promise<Impor
   await io.writePlanSidecar(newSidecar);
 
   // Refresh the compact status rollup so the tile poll reflects the re-plan
-  // (new per-category copy/skip/conflict counts + the dropped conflict total).
-  const prev = await io.readJson<WorkerStatus>(STATUS_FILE);
-  const now = (io.now ?? Date.now)();
+  // (new per-category copy/skip/conflict/renamed counts). `done` marks it ready
+  // for the host-apply.
+  const now = nowFn();
   const totalBytes = plan.items.reduce((sum, i) => sum + i.record.size, 0);
   const status: WorkerStatus = {
-    ...(prev ?? freshStatus(sidecar.runId, now)),
+    ...base,
     phase: 'done',
     mode: 'dry-run',
     step: `Re-planned: ${plan.items.length} items, ${plan.conflicts.length} conflict(s).`,

--- a/packages/disk-import-worker/src/engine/types.ts
+++ b/packages/disk-import-worker/src/engine/types.ts
@@ -152,10 +152,19 @@ export interface ImportPlanItem {
   category: Category;
   /**
    * Target path relative to `file-share/data/` (e.g. `photos/IMG_0001.jpg`),
-   * or `null` for junk (nothing is written).
+   * or `null` for junk (nothing is written). When two DISTINCT files resolve to
+   * the same target, the later one is imported under a disambiguated name
+   * (`IMG_0001 (2).jpg`) — see `renamed` — so nothing is dropped (#2006).
    */
   target: string | null;
   action: ImportAction;
+  /**
+   * True when `target` was disambiguated because a different-content file already
+   * claimed the natural name (in-tree, #2006). The action is still `copy` (the
+   * file IS imported); this flag only drives the review wording ("renamed, nothing
+   * lost") so renames aren't confused with plain copies. Absent ⇒ false.
+   */
+  renamed?: boolean;
 }
 
 /**

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -48,6 +48,8 @@ interface CategoryRollup {
   copy: number;
   skipDupe: number;
   conflict: number;
+  /** Files imported under a disambiguated name (a subset of `copy`, #2006). */
+  renamed?: number;
 }
 
 /** Human-readable size (e.g. "457 GB") for the review table. */
@@ -352,7 +354,7 @@ function WorkerProgress({ run, onStartOver }: { run: RunStatus; onStartOver: () 
 
 /** Scan/plan complete — review out in the worker app, then APPLY on the host. */
 /** Sum a list of category rollups into a single totals row. */
-function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category'> {
+function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category' | 'renamed'> & { renamed: number } {
   return cats.reduce(
     (t, c) => ({
       files: t.files + c.files,
@@ -360,8 +362,9 @@ function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category'>
       copy: t.copy + c.copy,
       skipDupe: t.skipDupe + c.skipDupe,
       conflict: t.conflict + c.conflict,
+      renamed: t.renamed + (c.renamed ?? 0),
     }),
-    { files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0 },
+    { files: 0, bytes: 0, copy: 0, skipDupe: 0, conflict: 0, renamed: 0 },
   );
 }
 
@@ -380,6 +383,9 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
         </p>
         <p className="text-xs text-gray-500 dark:text-gray-400">
           <span className="font-medium text-blue-600 dark:text-blue-400">{totals.copy.toLocaleString()}</span> to import
+          {totals.renamed > 0 && (
+            <> {' ('}{totals.renamed.toLocaleString()} renamed to avoid clashes{')'}</>
+          )}
           {' · '}{totals.skipDupe.toLocaleString()} duplicate{totals.skipDupe === 1 ? '' : 's'} skipped
           {totals.conflict > 0 && (
             <> {' · '}<span className={`font-medium ${amber}`}>{totals.conflict.toLocaleString()} conflict{totals.conflict === 1 ? '' : 's'}</span></>
@@ -396,6 +402,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                 <th className="py-1.5 px-2 text-right font-medium">Files</th>
                 <th className="py-1.5 px-2 text-right font-medium">Size</th>
                 <th className="py-1.5 px-2 text-right font-medium">Import</th>
+                <th className="py-1.5 px-2 text-right font-medium">Renamed</th>
                 <th className="py-1.5 px-2 text-right font-medium">Dupes</th>
                 <th className="py-1.5 pl-2 text-right font-medium">Conflicts</th>
               </tr>
@@ -407,6 +414,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                   <td className="py-1.5 px-2 text-right tabular-nums">{c.files.toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{formatBytes(c.bytes)}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums text-blue-600 dark:text-blue-400">{c.copy.toLocaleString()}</td>
+                  <td className="py-1.5 px-2 text-right tabular-nums">{(c.renamed ?? 0).toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{c.skipDupe.toLocaleString()}</td>
                   <td className={`py-1.5 pl-2 text-right tabular-nums ${c.conflict ? `font-medium ${amber}` : ''}`}>
                     {c.conflict.toLocaleString()}
@@ -420,6 +428,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.files.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{formatBytes(totals.bytes)}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums text-blue-600 dark:text-blue-400">{totals.copy.toLocaleString()}</td>
+                <td className="py-1.5 px-2 text-right tabular-nums">{totals.renamed.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.skipDupe.toLocaleString()}</td>
                 <td className={`py-1.5 pl-2 text-right tabular-nums ${totals.conflict ? amber : ''}`}>
                   {totals.conflict.toLocaleString()}
@@ -432,10 +441,18 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
         <p className="text-xs text-gray-500 dark:text-gray-400">No category breakdown available for this run.</p>
       )}
 
+      {totals.renamed > 0 && (
+        <p className="rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
+          {totals.renamed.toLocaleString()} file{totals.renamed === 1 ? '' : 's'} shared a name with a <strong>different</strong> file headed to the same folder
+          (e.g. two cameras both naming a photo <code>IMG_0001.jpg</code>). Each is imported under a disambiguated
+          name like <code>IMG_0001 (2).jpg</code> — <strong>nothing is dropped and nothing is overwritten</strong>.
+        </p>
+      )}
+
       {totals.conflict > 0 && (
         <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
-          {totals.conflict.toLocaleString()} file{totals.conflict === 1 ? '' : 's'} clash with a different file headed to the same name/folder.
-          These are <strong>not imported</strong> in this pass — the others import normally; nothing is overwritten.
+          {totals.conflict.toLocaleString()} file{totals.conflict === 1 ? '' : 's'} match a previously imported target with different
+          content — the earlier copy is preserved under <code>_superseded/</code> and the newer one imported. Nothing is lost.
         </p>
       )}
     </>

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -11,7 +11,7 @@
 // proxied, admin-gated route — NOT rendered in this control-plane page.
 
 import { useCallback, useEffect, useState } from 'react';
-import { Loader2, HardDrive, RefreshCw, Download } from 'lucide-react';
+import { Loader2, HardDrive, RefreshCw, Download, Save, Trash2 } from 'lucide-react';
 import { RoutingTree } from './_lib/RoutingTree';
 import type { ReviewTree, Rule } from './_lib/types';
 
@@ -215,7 +215,62 @@ function useRoutingTree(active: boolean) {
     [fetchTree],
   );
 
-  return { data, rules, setRule };
+  // Replace the whole rule map at once (loading a saved preset, #2007) and
+  // re-resolve the tree against it.
+  const loadRules = useCallback(
+    (next: Record<string, Rule>) => {
+      setRules(next);
+      void fetchTree(next).then(t => {
+        if (t) setData(t);
+      });
+    },
+    [fetchTree],
+  );
+
+  return { data, rules, setRule, loadRules };
+}
+
+/** A saved routing selection (#2007) — mirrors the backend `RoutingProfile`. */
+interface RoutingProfile {
+  name: string;
+  rules: Record<string, Rule>;
+  savedAt: number;
+}
+
+/** List/save/delete named routing presets (#2007). */
+function useRoutingProfiles() {
+  const [profiles, setProfiles] = useState<RoutingProfile[]>([]);
+  const reload = useCallback(() => {
+    fetch('/api/system/disk-import/profiles')
+      .then(r => (r.ok ? r.json() : null))
+      .then((d: { profiles?: RoutingProfile[] } | null) => setProfiles(d?.profiles ?? []))
+      .catch(() => {});
+  }, []);
+  useEffect(reload, [reload]);
+
+  const save = useCallback(
+    async (name: string, rules: Record<string, Rule>) => {
+      await fetch('/api/system/disk-import/profiles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, rules }),
+      }).catch(() => {});
+      reload();
+    },
+    [reload],
+  );
+
+  const remove = useCallback(
+    async (name: string) => {
+      await fetch(`/api/system/disk-import/profiles?name=${encodeURIComponent(name)}`, {
+        method: 'DELETE',
+      }).catch(() => {});
+      reload();
+    },
+    [reload],
+  );
+
+  return { profiles, save, remove };
 }
 
 export default function DiskImportPage() {
@@ -227,7 +282,8 @@ export default function DiskImportPage() {
   });
   // The routing tree is only meaningful once a scan has produced a plan to review.
   const planReady = tileState(run) === 'plan-ready';
-  const { data: tree, rules, setRule } = useRoutingTree(planReady);
+  const { data: tree, rules, setRule, loadRules } = useRoutingTree(planReady);
+  const { profiles, save: savePreset, remove: deletePreset } = useRoutingProfiles();
 
   return (
     <div className="p-6 max-w-3xl space-y-4 overflow-auto">
@@ -255,7 +311,11 @@ export default function DiskImportPage() {
         launching={launching}
         tree={tree}
         rules={rules}
+        profiles={profiles}
         onSetRule={setRule}
+        onLoadPreset={loadRules}
+        onSavePreset={name => void savePreset(name, rules)}
+        onDeletePreset={name => void deletePreset(name)}
         onSelect={setSelected}
         onRefresh={refresh}
         onLaunch={() => void launch()}
@@ -302,7 +362,11 @@ function TileBody({
   launching,
   tree,
   rules,
+  profiles,
   onSetRule,
+  onLoadPreset,
+  onSavePreset,
+  onDeletePreset,
   onSelect,
   onRefresh,
   onLaunch,
@@ -317,7 +381,11 @@ function TileBody({
   launching: boolean;
   tree: ReviewTree | null;
   rules: Record<string, Rule>;
+  profiles: RoutingProfile[];
   onSetRule: (dir: string, patch: Rule) => void;
+  onLoadPreset: (rules: Record<string, Rule>) => void;
+  onSavePreset: (name: string) => void;
+  onDeletePreset: (name: string) => void;
   onSelect: (path: string) => void;
   onRefresh: () => void;
   onLaunch: () => void;
@@ -338,7 +406,11 @@ function TileBody({
         applying={launching}
         tree={tree}
         rules={rules}
+        profiles={profiles}
         onSetRule={onSetRule}
+        onLoadPreset={onLoadPreset}
+        onSavePreset={onSavePreset}
+        onDeletePreset={onDeletePreset}
         onApply={onApply}
         onStartOver={onStartOver}
       />
@@ -489,6 +561,77 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
   );
 }
 
+/** Save / load named routing presets (#2007). Loading a preset replaces the whole
+ *  rule map; Save persists the current picks under a name (disabled until something
+ *  is picked + a name typed). Lets the operator re-run a 30+-folder selection on a
+ *  fresh scan with zero re-entry. */
+function RoutingPresets({
+  profiles,
+  edited,
+  onLoad,
+  onSave,
+  onDelete,
+}: {
+  profiles: RoutingProfile[];
+  edited: boolean;
+  onLoad: (rules: Record<string, Rule>) => void;
+  onSave: (name: string) => void;
+  onDelete: (name: string) => void;
+}) {
+  const [name, setName] = useState('');
+  const [selected, setSelected] = useState('');
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs rounded-lg bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2">
+      <span className="text-gray-500 dark:text-gray-400">Saved selections:</span>
+      <select
+        value={selected}
+        onChange={e => {
+          const picked = e.target.value;
+          setSelected(picked);
+          const p = profiles.find(x => x.name === picked);
+          if (p) onLoad(p.rules);
+        }}
+        className="rounded border px-1.5 py-1 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-200"
+      >
+        <option value="">{profiles.length ? 'Load a preset…' : 'No saved presets'}</option>
+        {profiles.map(p => (
+          <option key={p.name} value={p.name}>{p.name}</option>
+        ))}
+      </select>
+      {selected && (
+        <button
+          onClick={() => {
+            onDelete(selected);
+            setSelected('');
+          }}
+          className="inline-flex items-center gap-1 text-red-600 hover:text-red-700 dark:text-red-400"
+          title={`Delete preset “${selected}”`}
+        >
+          <Trash2 size={12} /> Delete
+        </button>
+      )}
+      <span className="mx-1 text-gray-300 dark:text-gray-600">|</span>
+      <input
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="Name this selection"
+        className="rounded border px-2 py-1 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-200"
+      />
+      <button
+        onClick={() => {
+          onSave(name.trim());
+          setName('');
+        }}
+        disabled={!edited || !name.trim()}
+        className="inline-flex items-center gap-1 rounded bg-gray-200 dark:bg-gray-700 px-2 py-1 font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+        title={edited ? 'Save the current owner/target picks as a named preset' : 'Pick owners/targets first'}
+      >
+        <Save size={12} /> Save selection
+      </button>
+    </div>
+  );
+}
+
 /** Scan/plan complete — show the per-category summary + the per-folder routing
  *  tree (owner + target pickers), then APPLY on the host (#2000). The apply
  *  re-plans with the operator's picks first (re-route + re-dedup per owner). */
@@ -497,7 +640,11 @@ function PlanReady({
   applying,
   tree,
   rules,
+  profiles,
   onSetRule,
+  onLoadPreset,
+  onSavePreset,
+  onDeletePreset,
   onApply,
   onStartOver,
 }: {
@@ -505,7 +652,11 @@ function PlanReady({
   applying: boolean;
   tree: ReviewTree | null;
   rules: Record<string, Rule>;
+  profiles: RoutingProfile[];
   onSetRule: (dir: string, patch: Rule) => void;
+  onLoadPreset: (rules: Record<string, Rule>) => void;
+  onSavePreset: (name: string) => void;
+  onDeletePreset: (name: string) => void;
   onApply: () => void;
   onStartOver: () => void;
 }) {
@@ -523,6 +674,13 @@ function PlanReady({
             person&apos;s area + their Immich.
           </p>
         </div>
+        <RoutingPresets
+          profiles={profiles}
+          edited={edited}
+          onLoad={onLoadPreset}
+          onSave={onSavePreset}
+          onDelete={onDeletePreset}
+        />
         {tree ? (
           <RoutingTree data={tree} rules={rules} onSetRule={onSetRule} />
         ) : (

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -99,6 +99,11 @@ async function postAction(path: string, body?: unknown): Promise<string> {
 function useDiskImportRun(selected: string, onAfterAbort: () => void) {
   const [run, setRun] = useState<RunStatus | null>(null);
   const [launching, setLaunching] = useState(false);
+  // True from an apply CLICK until the (now async, #2009) re-plan + host-apply reach
+  // a terminal phase. Bridges the brief window where status.json still shows the
+  // prior `plan-ready` before the detached re-plan/apply flips it in-flight, so the
+  // tile shows progress instead of re-offering the Import button (no double-submit).
+  const [flowActive, setFlowActive] = useState(false);
   const [error, setError] = useState('');
 
   // Re-attach to an already-running worker on open + poll while one is active.
@@ -107,7 +112,16 @@ function useDiskImportRun(selected: string, onAfterAbort: () => void) {
     const poll = async () => {
       const r = await fetch('/api/system/disk-import/status');
       if (!active) return;
-      setRun(r.ok ? ((await r.json()) as RunStatus) : null);
+      const next = r.ok ? ((await r.json()) as RunStatus) : null;
+      setRun(next);
+      // Clear the client flow flag (and surface a background error) once the async
+      // apply flow reaches a terminal phase — the work runs detached now (#2009).
+      const s = next?.status;
+      if (!s) setFlowActive(false);
+      else if (s.phase === 'error') {
+        setFlowActive(false);
+        setError(s.error || 'Import failed');
+      } else if (s.phase === 'done' && s.mode === 'apply') setFlowActive(false);
     };
     void poll();
     const id = setInterval(poll, 2000);
@@ -133,17 +147,26 @@ function useDiskImportRun(selected: string, onAfterAbort: () => void) {
   const startOver = async () => {
     await fetch('/api/system/disk-import/abort', { method: 'POST' }).catch(() => {});
     setRun(null);
+    setFlowActive(false);
     onAfterAbort();
   };
 
   // APPLY runs on the HOST in servicebay (#1972) — the sandboxed worker only
-  // scanned/planned. POST kicks off the privileged host apply; when routing rules
-  // are passed (#2000) servicebay re-plans with them (re-route + re-dedup per
-  // owner) BEFORE applying. The status poll reflects `applying` → `done`.
-  const apply = (rules?: Record<string, Rule>, rootDefault?: Rule) =>
-    runAction('/api/system/disk-import/apply', rules ? { rules, rootDefault } : undefined);
+  // scanned/planned. POST RETURNS PROMPTLY now (#2009): when routing rules are
+  // passed (#2000) servicebay launches the detached re-plan first, then the apply
+  // runs in the background. The status poll reflects `planning` → `applying` →
+  // `done`; `flowActive` keeps the tile on progress for the whole flow.
+  const apply = async (rules?: Record<string, Rule>, rootDefault?: Rule) => {
+    setError('');
+    setFlowActive(true);
+    const err = await postAction('/api/system/disk-import/apply', rules ? { rules, rootDefault } : undefined);
+    if (err) {
+      setError(err);
+      setFlowActive(false);
+    }
+  };
 
-  return { run, launching, error, launch, startOver, apply };
+  return { run, launching, flowActive, error, launch, startOver, apply };
 }
 
 /** Fetch + edit the per-folder routing tree (#2000). Holds the explicit rule map
@@ -198,7 +221,7 @@ function useRoutingTree(active: boolean) {
 export default function DiskImportPage() {
   const { devices, loading, refresh } = useDevices();
   const [selected, setSelected] = useState('');
-  const { run, launching, error, launch, startOver, apply } = useDiskImportRun(selected, () => {
+  const { run, launching, flowActive, error, launch, startOver, apply } = useDiskImportRun(selected, () => {
     setSelected('');
     refresh();
   });
@@ -225,6 +248,7 @@ export default function DiskImportPage() {
 
       <TileBody
         run={run}
+        flowActive={flowActive}
         devices={devices}
         loading={loading}
         selected={selected}
@@ -271,6 +295,7 @@ function tileState(run: RunStatus | null): TileState {
  *  page stays a thin shell and the phase-selection complexity lives here. */
 function TileBody({
   run,
+  flowActive,
   devices,
   loading,
   selected,
@@ -285,6 +310,7 @@ function TileBody({
   onStartOver,
 }: {
   run: RunStatus | null;
+  flowActive: boolean;
   devices: DeviceView[];
   loading: boolean;
   selected: string;
@@ -298,7 +324,11 @@ function TileBody({
   onApply: () => void;
   onStartOver: () => void;
 }) {
-  const state = tileState(run);
+  // While an apply flow is in flight (#2009), force the progress view — even if
+  // status.json momentarily still reads `plan-ready` before the detached re-plan/
+  // apply flips it — so the Import button isn't briefly re-offered (no double-submit).
+  const base = tileState(run);
+  const state = flowActive && base !== 'apply-done' ? 'active' : base;
   if (state === 'active') return <WorkerProgress run={run!} onStartOver={onStartOver} />;
   if (state === 'apply-done') return <ApplyDone run={run!} onStartOver={onStartOver} />;
   if (state === 'plan-ready')

--- a/packages/frontend/src/app/api/system/disk-import/apply/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/apply/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { applyRun } from '@/lib/diskImport/service';
+import { startApplyFlow } from '@/lib/diskImport/service';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { makeExec, resolveNode, SHARE_GID } from '../wiring';
@@ -21,6 +21,12 @@ export const dynamic = 'force-dynamic';
  * RE-PLANS with them first (re-routes/re-dedups per owner in the worker, over the
  * live mount) so files land in `data/<owner>/<category>/…` — then applies the
  * rewritten plan.json unchanged. An empty/absent body applies the auto-sorted plan.
+ *
+ * #2009: this returns PROMPTLY. The (multi-minute) re-plan + host-apply run in the
+ * background — `startApplyFlow` launches the detached re-plan synchronously then
+ * fires the apply, and the page polls status.json to completion. The route no longer
+ * blocks for the whole copy (which risked NPM/Authelia/browser timeouts on a big
+ * disk); the applied count + Immich note land in status.json, not the response.
  */
 export const POST = withApiHandler(
   { tokenScope: 'mutate' },
@@ -28,8 +34,8 @@ export const POST = withApiHandler(
     try {
       const node = resolveNode();
       const replanReq = await parseReplanBody(request);
-      const result = await applyRun(makeExec(node), SHARE_GID, replanReq);
-      return NextResponse.json({ ok: true, ...result });
+      await startApplyFlow(makeExec(node), SHARE_GID, replanReq);
+      return NextResponse.json({ ok: true });
     } catch (e) {
       return apiError(e, { tag: 'api:system:disk-import:apply', status: 400, exposeMessage: true });
     }

--- a/packages/frontend/src/app/api/system/disk-import/profiles/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/profiles/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listProfiles, saveProfile, deleteProfile } from '@/lib/diskImport/profiles';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import type { Rule } from '@servicebay/disk-import-worker';
+
+export const dynamic = 'force-dynamic';
+
+/** A single folder's explicit (partial) routing rule — every axis optional. Values
+ *  are re-validated by the apply/replan body before they ever form a path. */
+const ruleSchema = z
+  .object({
+    disposition: z.string().optional(),
+    mode: z.enum(['merge', 'parallel']).optional(),
+    owner: z.string().optional(),
+  })
+  .strict();
+
+/** Save body: a named selection (the explicit rule map + optional disk default). */
+const saveSchema = z
+  .object({
+    name: z.string().min(1).max(80),
+    rules: z.record(z.string(), ruleSchema).default({}),
+    rootDefault: ruleSchema.optional(),
+  })
+  .strict();
+
+const deleteQuery = z.object({ name: z.string().min(1) });
+
+/**
+ * GET — list saved routing presets (#2007), newest first. Presets persist the
+ * operator's per-folder owner/target selection so a fresh scan of the same disk can
+ * re-load it and go straight to "Re-plan & import" with zero re-entry.
+ */
+export const GET = withApiHandler(
+  { tokenScope: 'mutate' },
+  async () => {
+    try {
+      return NextResponse.json({ ok: true, profiles: await listProfiles() });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:profiles:list', status: 400, exposeMessage: true });
+    }
+  },
+);
+
+/** POST — save (create or overwrite) a named preset from the page's current picks. */
+export const POST = withApiHandler<z.infer<typeof saveSchema>>(
+  { tokenScope: 'mutate', body: saveSchema },
+  async ({ body }) => {
+    try {
+      // The zod schema validates values at runtime; the cast narrows the inferred
+      // `string` disposition to the engine's literal union (mirrors replanBody).
+      const profile = await saveProfile({
+        name: body.name,
+        rules: body.rules as Record<string, Rule>,
+        rootDefault: body.rootDefault as Partial<Rule> | undefined,
+      });
+      return NextResponse.json({ ok: true, profile });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:profiles:save', status: 400, exposeMessage: true });
+    }
+  },
+);
+
+/** DELETE — remove a preset by `?name=` (idempotent). */
+export const DELETE = withApiHandler<undefined, z.infer<typeof deleteQuery>>(
+  { tokenScope: 'mutate', query: deleteQuery },
+  async ({ query }) => {
+    try {
+      await deleteProfile(query.name);
+      return NextResponse.json({ ok: true });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:disk-import:profiles:delete', status: 400, exposeMessage: true });
+    }
+  },
+);


### PR DESCRIPTION
Fixes #2007.

> **Stacked on #2012** (base `fix/disk-import-async-replan`, which is itself on #2011). Retarget to `main` as the parents merge. The diff below is #2007 only.

## Problem
The routing tree (#2000) lets the operator assign owner + target per folder — on a real disk that's **30+ deliberate picks** that today live only in the page's React state and **vanish on reload/re-scan**. The operator wants to **save** a selection and **re-run** it.

## Fix — named manual presets
Per the operator's call: **named manual presets, no disk-signature auto-recall.**

- **Backend `profiles.ts`**: a small JSON store under `${DATA_DIR}/disk-import-profiles/` (servicebay's own data dir, core-owned — no worker `:Z`/SELinux relabel concern). `saveProfile` (create/overwrite; filename slugged from the name → path-traversal proof, re-saving a name overwrites), `listProfiles` (newest first, corrupt files skipped), `deleteProfile` (idempotent).
- **Route** `GET/POST/DELETE /api/system/disk-import/profiles` — mutate-scoped, zod-validated.
- **Page**: a "Saved selections" bar in the review:
  - **Load** a preset → replaces the whole rule map + re-resolves the tree (via the existing `/tree` POST).
  - **Name** + **Save** the current picks (disabled until something's picked + a name typed).
  - **Delete** the selected preset.
  - New `useRoutingProfiles` hook + a `loadRules` bulk setter on the routing-tree hook.

## Tests
`profiles.test.ts`: save→list round-trip, same-name overwrite, newest-first ordering, delete (incl. missing = no-op), path-traversal **neutralization** (`../../etc/passwd` → a tame `etc-passwd.json` inside the dir), blank/empty-slug rejection, corrupt-file skip. tsc + full disk-import suite (315) green.

## Acceptance / box-verify owed
Assign owners/targets → Save; start a fresh scan of the same disk → Load the preset → "Re-plan & import" with zero re-entry. Verify on-box via the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
