### PR TITLE
fix(disk-import): per-category layout + dedup (preserve folders, dedup right)

### DIFF
--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -38,7 +38,7 @@ import { buildInventory, type ScannedFile } from '../engine/inventory';
 import { buildPlan, type HashResolver } from '../engine/dedup';
 import { ImportCatalog } from '../engine/catalog';
 import { applyPlan } from '../engine/plan';
-import { runReplan, REPLAN_REQUEST_FILE, type ReplanRequest, type ReplanIO } from '../engine/replan';
+import { runReplan, toRoutingResolution, REPLAN_REQUEST_FILE, type ReplanRequest, type ReplanIO } from '../engine/replan';
 import {
   immichProvisionFromEnv,
   provisionExternalLibraries,
@@ -303,6 +303,11 @@ export async function runWorker(opts: WorkerOptions, io: WorkerIO): Promise<Work
       plan = buildPlan(records, io.hashOf, {
         catalog,
         fingerprintOf: io.fingerprintOf,
+        // Route the INITIAL plan through the default routing too (anchor = disk
+        // root, owner = shared) so the first review already reflects per-category
+        // layout — preserve source folders for photos/docs/…, flatten music
+        // (#2006 redesign) — not a flat dump. The user's owner edits later re-plan.
+        routing: toRoutingResolution({ explicit: {} }, opts.mount),
         // Live progress over the dedup fingerprint pass so a big disk never
         // looks hung (#1995). Throttled by buildPlan to ~every 1000 files.
         onProgress: (done, total) =>

--- a/packages/disk-import-worker/src/engine/categories.ts
+++ b/packages/disk-import-worker/src/engine/categories.ts
@@ -14,6 +14,27 @@ import type { Category } from './types';
 // emits — are RELATIVE to that root; the host-apply step (a later issue) joins
 // them onto the real mount point.
 
+/**
+ * How a category lays out its files in the library (#2006 redesign):
+ *  - `preserve` — keep the source sub-folders under the category root
+ *    (`documents/holiday/notes/a.txt`). Distinct files in different folders never
+ *    collide, so their structure + context survive.
+ *  - `flat` — drop the source path; everything lands directly in the category
+ *    folder by basename (`music/track01.mp3`). The directory a file sat in is noise.
+ */
+export type CategoryLayout = 'preserve' | 'flat';
+
+/**
+ * What makes two files "the same" for dedup (#2006 redesign):
+ *  - `content` — identical BYTES (fingerprint/sha). A reused name (`IMG_0001.jpg`
+ *    from two cameras) is two DIFFERENT files → both kept; only byte-identical
+ *    copies collapse. Right for photos/videos/documents.
+ *  - `nameSize` — same FILENAME + byte-size, regardless of directory. Right for
+ *    music: the same track scattered across folders is one song; needs NO hashing.
+ *    Size guards against two distinct songs sharing a generic name (`01.mp3`).
+ */
+export type CategoryIdentity = 'content' | 'nameSize';
+
 export interface CategoryDef {
   /**
    * Folder under `file-share/data/`, lower-case (convention #1018), trailing
@@ -27,6 +48,10 @@ export interface CategoryDef {
    * audiobook) are resolved by heuristics in classify.ts, not here.
    */
   extensions: string[];
+  /** How files lay out in the library (preserve source folders vs flatten). */
+  layout: CategoryLayout;
+  /** What counts as a duplicate (bytes vs name+size). */
+  identity: CategoryIdentity;
 }
 
 /**
@@ -47,6 +72,11 @@ export const CATEGORIES: Record<Category, CategoryDef> = {
       'raw', 'cr2', 'cr3', 'nef', 'arw', 'orf', 'rw2', 'dng',
       'mov', 'mp4', 'm4v', 'avi', 'mkv', '3gp',
     ],
+    // A reused name (every camera's IMG_0001.jpg) is a DIFFERENT photo → identity
+    // is bytes only; keep source folders so distinct photos coexist (Immich
+    // reorganizes by EXIF date regardless).
+    layout: 'preserve',
+    identity: 'content',
   },
   movies: {
     folder: 'movies/',
@@ -55,22 +85,34 @@ export const CATEGORIES: Record<Category, CategoryDef> = {
     // subtree is video-dominant or carries an explicit `movies_jellyfin`
     // disposition (classify.ts) — never by the bare extension rule.
     extensions: [],
+    layout: 'preserve',
+    identity: 'content',
   },
   music: {
     folder: 'music/',
     extensions: ['mp3', 'flac', 'm4a', 'aac', 'ogg', 'opus', 'wav', 'wma', 'aiff'],
+    // The same track scattered across folders is one song → flatten + dedup by
+    // name+size (no hashing). Two distinct songs sharing a generic name differ in
+    // size, so they're kept (and the loser of a flat-name clash is renamed).
+    layout: 'flat',
+    identity: 'nameSize',
   },
   audiobooks: {
     folder: 'audiobooks/',
     // m4b is unambiguously an audiobook; mp3 audiobooks are reclassified out of
-    // `music` by heuristic / LLM (classify.ts).
+    // `music` by heuristic / LLM (classify.ts). Series chapters reuse names like
+    // `01.mp3` across books → identity is bytes, structure preserved.
     extensions: ['m4b', 'aax', 'aa'],
+    layout: 'preserve',
+    identity: 'content',
   },
   podcasts: {
     folder: 'podcasts/',
     // No extensions are podcast-exclusive — podcasts are detected by heuristic /
     // LLM from the (audio) residue, not by extension.
     extensions: [],
+    layout: 'preserve',
+    identity: 'content',
   },
   documents: {
     folder: 'documents/',
@@ -81,10 +123,17 @@ export const CATEGORIES: Record<Category, CategoryDef> = {
       'ppt', 'pptx', 'odp',
       'md', 'html', 'htm',
     ],
+    // docs/note1.txt and notes/note1.txt are different files → keep folders;
+    // identical bytes across yearly backups collapse by content.
+    layout: 'preserve',
+    identity: 'content',
   },
   junk: {
+    // Never written — defaults are placeholders so the map stays total.
     folder: '',
     extensions: [],
+    layout: 'flat',
+    identity: 'content',
   },
 };
 

--- a/packages/disk-import-worker/src/engine/dedup.test.ts
+++ b/packages/disk-import-worker/src/engine/dedup.test.ts
@@ -428,3 +428,73 @@ describe('buildPlan — routing tree (#1915)', () => {
     expect(result.items.map(i => i.target).sort()).toEqual(['cdopp/photos/IMG.jpg', 'mdopp/photos/IMG.jpg']);
   });
 });
+
+describe('buildPlan — per-category layout + identity (#2006 redesign)', () => {
+  // A routing resolution rooted at the disk (strips the `/disk/` prefix), default
+  // shared owner — the same shape the worker threads through for the initial plan.
+  const routingFor = (rules: Record<string, import('./types').Rule> = {}) => ({
+    relPathOf: (r: ImportRecord) => r.sourcePath.replace(/^\/disk\//, ''),
+    explicit: new Map(Object.entries(rules)),
+    rootDefault: {},
+  });
+
+  it('documents PRESERVE source folders; identical bytes across folders collapse by content', () => {
+    const files: ScannedFile[] = [
+      { path: '/disk/backup_2025/docs/note.txt', size: 10, mtimeMs: 0 },
+      { path: '/disk/backup_2026/docs/note.txt', size: 10, mtimeMs: 0 }, // identical bytes
+      { path: '/disk/backup_2023/notes/note.txt', size: 10, mtimeMs: 0 }, // DIFFERENT bytes
+    ];
+    const result = buildPlan(buildInventory(files), hasherFrom({
+      '/disk/backup_2025/docs/note.txt': sha('a'),
+      '/disk/backup_2026/docs/note.txt': sha('a'),
+      '/disk/backup_2023/notes/note.txt': sha('b'),
+    }), { routing: routingFor() });
+    // 2025 copies at its preserved path; 2026 (same bytes) dedupes; notes/ (different
+    // bytes, different folder) is kept distinct — exactly the operator's model.
+    expect(itemOf(result.items, '/disk/backup_2025/docs/note.txt')).toMatchObject({
+      action: 'copy', target: 'documents/backup_2025/docs/note.txt',
+    });
+    expect(actionOf(result.items, '/disk/backup_2026/docs/note.txt')).toBe('skip-dupe');
+    expect(itemOf(result.items, '/disk/backup_2023/notes/note.txt')).toMatchObject({
+      action: 'copy', target: 'documents/backup_2023/notes/note.txt',
+    });
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it('photos dedupe by CONTENT only — same name, different bytes → BOTH kept (preserved paths)', () => {
+    const files: ScannedFile[] = [
+      { path: '/disk/2019/IMG_0001.jpg', size: 10, mtimeMs: 0 },
+      { path: '/disk/2021/IMG_0001.jpg', size: 10, mtimeMs: 0 }, // same name, different photo
+    ];
+    const result = buildPlan(buildInventory(files), hasherFrom({
+      '/disk/2019/IMG_0001.jpg': sha('a'),
+      '/disk/2021/IMG_0001.jpg': sha('b'),
+    }), { routing: routingFor() });
+    expect(result.items.every(i => i.action === 'copy')).toBe(true);
+    expect(result.items.map(i => i.target).sort()).toEqual([
+      'photos/2019/IMG_0001.jpg', 'photos/2021/IMG_0001.jpg',
+    ]);
+    expect(result.items.some(i => i.renamed)).toBe(false); // distinct paths, no rename
+  });
+
+  it('music dedupes by NAME+SIZE, flattened, WITHOUT hashing', () => {
+    const hashOf = vi.fn<HashResolver>(() => { throw new Error('music must not be hashed'); });
+    // Stable order is by sourcePath: backup < mix < rock.
+    const files: ScannedFile[] = [
+      { path: '/disk/backup/01.mp3', size: 100, mtimeMs: 0 }, // first claimant of music/01.mp3
+      { path: '/disk/mix/01.mp3', size: 200, mtimeMs: 0 },    // same name, different size → different track
+      { path: '/disk/rock/01.mp3', size: 100, mtimeMs: 0 },   // same name+size as backup → same track
+    ];
+    const result = buildPlan(buildInventory(files), hashOf, {
+      routing: routingFor(), fingerprintOf: hashOf,
+    });
+    expect(hashOf).not.toHaveBeenCalled(); // name+size identity → zero reads
+    expect(itemOf(result.items, '/disk/backup/01.mp3')).toMatchObject({ action: 'copy', target: 'music/01.mp3' });
+    expect(actionOf(result.items, '/disk/rock/01.mp3')).toBe('skip-dupe'); // same name+size as backup
+    // Different size = different track → kept, renamed off the flat clash.
+    expect(itemOf(result.items, '/disk/mix/01.mp3')).toMatchObject({
+      action: 'copy', target: 'music/01 (2).mp3', renamed: true,
+    });
+    expect(result.conflicts).toHaveLength(0);
+  });
+});

--- a/packages/disk-import-worker/src/engine/dedup.ts
+++ b/packages/disk-import-worker/src/engine/dedup.ts
@@ -177,14 +177,6 @@ export function buildPlan(
   // 1. Classify; junk is emitted as skip-junk, the rest kept for dedup.
   const keep = classifyAndSplit(records, opts, items);
 
-  // 2. Group by size to decide what must be hashed.
-  const bySize = new Map<number, Classified[]>();
-  for (const c of keep) {
-    const arr = bySize.get(c.record.size);
-    if (arr) arr.push(c);
-    else bySize.set(c.record.size, [c]);
-  }
-
   // Stable (sourcePath) iteration order so the first file at a target wins.
   const ordered = keep
     .slice()
@@ -192,9 +184,18 @@ export function buildPlan(
       a.record.sourcePath < b.record.sourcePath ? -1 : a.record.sourcePath > b.record.sourcePath ? 1 : 0,
     );
 
-  // Two-tier content keys: cheap fingerprint first, full hash only on a
-  // fingerprint collision or a cataloged target (#1995).
-  const keys = resolveContentKeys(ordered, bySize, {
+  // 2. CONTENT-identity files (photos/docs/audiobooks/podcasts/movies) dedupe by
+  //    BYTES — group them by size + fingerprint (cheap, #1995). Music (`nameSize`
+  //    identity) is deduped by name+size and is NEVER hashed, so it's excluded from
+  //    the (size→fingerprint) pass entirely.
+  const contentFiles = ordered.filter(c => CATEGORIES[c.category].identity === 'content');
+  const bySize = new Map<number, Classified[]>();
+  for (const c of contentFiles) {
+    const arr = bySize.get(c.record.size);
+    if (arr) arr.push(c);
+    else bySize.set(c.record.size, [c]);
+  }
+  const contentKeys = resolveContentKeys(contentFiles, bySize, {
     hashOf,
     fingerprintOf: opts.fingerprintOf ?? hashOf,
     catalog,
@@ -202,22 +203,33 @@ export function buildPlan(
     onProgress: opts.onProgress,
   });
 
-  // Track, within this tree, the content hash already claiming each destination
-  // slot. The slot key is (area, target): the SAME target in two areas (e.g.
-  // `shared` vs a user area) is two distinct slots — private dedups within
-  // itself, `shared` merges across sources.
-  const targetOwner = new Map<string, { key: string; sha256?: string; sourcePath: string }>();
-  // Per-original-slot probe cursor for disambiguating renames (#2006), so N
-  // distinct files at one name resolve to (2),(3)… in O(N) not O(N²).
+  // A file's dedup IDENTITY within its area: content bytes for content cats, or
+  // `name+size` for music (dir-independent, no hashing). `sha256` is the FULL hash,
+  // present only when the file was fully hashed (for catalog comparison).
+  const identityOf = (c: Classified): KeyInfo => {
+    if (CATEGORIES[c.category].identity === 'nameSize') {
+      return { key: `n:${baseName(c.record.sourcePath).toLowerCase()}:${c.record.size}` };
+    }
+    return contentKeys.get(c.record.sourcePath)!;
+  };
+
+  // In-tree dedup is by IDENTITY within an area (area\0identity), NOT by target
+  // slot — so identical content collapses no matter where it sits / what it's named
+  // (and a music track collapses across folders). `targetClaim` (area\0target) is a
+  // SEPARATE concern: it only resolves the rare case where two genuinely-distinct
+  // files want the same target path (mostly same-name/different-size music) → the
+  // loser is renamed `(2)`/`(3)`… so nothing is dropped or overwritten.
+  const seen = new Set<string>();
+  const targetClaim = new Map<string, string>();
   const renameCounters = new Map<string, number>();
 
-  // 3. Decide each kept record from its precomputed content key.
+  // 3. Decide each kept record.
   for (const c of ordered) {
-    const target = c.target!;
     const area = areaOf(c.record);
-    const slot = dedupSlot(area, target);
-    const decision = decide(c, target, area, slot, keys.get(c.record.sourcePath)!, {
-      targetOwner,
+    const target = c.target!;
+    const decision = decide(c, target, area, identityOf(c), {
+      seen,
+      targetClaim,
       renameCounters,
       catalog,
       conflicts,
@@ -331,10 +343,10 @@ function decide(
   c: Classified,
   target: string,
   area: string,
-  slot: string,
   info: KeyInfo,
   ctx: {
-    targetOwner: Map<string, { key: string; sha256?: string; sourcePath: string }>;
+    seen: Set<string>;
+    targetClaim: Map<string, string>;
     renameCounters: Map<string, number>;
     catalog?: ImportCatalog;
     conflicts: Conflict[];
@@ -342,13 +354,19 @@ function decide(
 ): Decision {
   const { key, sha256 } = info;
 
-  // Catalog dedup compares FULL hashes (the catalog stores full sha256). sha256
-  // is present exactly when this record was fully hashed, which resolveContentKeys
-  // guarantees whenever the target is already cataloged. This is the cross-run
-  // newer-wins path (apply routes the existing file to _superseded) — left as a
-  // conflict on purpose; #2006 only changes the in-tree distinct-name case below.
+  // In-tree dedup by IDENTITY within the area: this exact identity (content bytes,
+  // or name+size for music) was already imported → it's a duplicate, drop it.
+  const idSlot = `${area} ${key}`;
+  if (ctx.seen.has(idSlot)) return { action: 'skip-dupe', target };
+
+  // Cross-run catalog. CONTENT cats (sha known): same bytes already at this target
+  // → skip; different bytes at a cataloged target → newer-wins conflict (apply
+  // routes the old copy to `_superseded/`).
   if (sha256 !== undefined) {
-    if (ctx.catalog?.has(sha256, target, area)) return { action: 'skip-dupe', target };
+    if (ctx.catalog?.has(sha256, target, area)) {
+      ctx.seen.add(idSlot);
+      return { action: 'skip-dupe', target };
+    }
     const catHit = ctx.catalog?.getByTarget(target, area);
     if (catHit && catHit.sha256 !== sha256) {
       ctx.conflicts.push({
@@ -358,24 +376,32 @@ function decide(
       });
       return { action: 'conflict', target };
     }
+  } else if (ctx.catalog) {
+    // nameSize cats (music): the catalog stores no usable content key for us, so we
+    // dedupe cross-run by the (flat) target + size — the same name+size already
+    // imported is the same track. A different size at that name is a distinct track
+    // and falls through to placement (renamed if the slot is taken). Best-effort +
+    // empty on a first import.
+    const catHit = ctx.catalog.getByTarget(target, area);
+    if (catHit && catHit.size === c.record.size) {
+      ctx.seen.add(idSlot);
+      return { action: 'skip-dupe', target };
+    }
   }
 
-  // In-tree collision at this slot (same area + target)? Compare by content key.
-  const owner = ctx.targetOwner.get(slot);
-  if (owner) {
-    if (owner.key === key) return { action: 'skip-dupe', target }; // same content, different path
-    // DISTINCT files clashing on one name are NOT the same photo/doc — import the
-    // later one under a disambiguated name (`IMG_0001 (2).jpg`) instead of dropping
-    // it as an unresolved conflict (#2006, DATA SAFETY). Deterministic: stable
-    // sourcePath order + a per-original-slot probe cursor make re-runs reproduce
-    // the same names; a 3rd distinct clash → `(3)`, etc.
+  // A new, distinct file. Claim its identity, then place it at its target. Renaming
+  // only kicks in when a DIFFERENT distinct file already took this exact target
+  // (mostly same-name/different-size music in a flat folder; preserve-layout targets
+  // carry the unique source sub-path so they don't collide). Deterministic: stable
+  // sourcePath order + a per-target probe cursor → reproducible `(2)`/`(3)` names.
+  ctx.seen.add(idSlot);
+  const slot = dedupSlot(area, target);
+  if (ctx.targetClaim.has(slot)) {
     const renamedTarget = uniquifyTarget(target, area, slot, ctx);
-    ctx.targetOwner.set(dedupSlot(area, renamedTarget), { key, sha256, sourcePath: c.record.sourcePath });
+    ctx.targetClaim.set(dedupSlot(area, renamedTarget), key);
     return { action: 'copy', target: renamedTarget, renamed: true };
   }
-
-  // First file to claim this slot.
-  ctx.targetOwner.set(slot, { key, sha256, sourcePath: c.record.sourcePath });
+  ctx.targetClaim.set(slot, key);
   return { action: 'copy', target };
 }
 
@@ -405,14 +431,14 @@ function uniquifyTarget(
   target: string,
   area: string,
   originalSlot: string,
-  ctx: { targetOwner: Map<string, unknown>; renameCounters: Map<string, number> },
+  ctx: { targetClaim: Map<string, unknown>; renameCounters: Map<string, number> },
 ): string {
   const { dir, stem, ext } = splitTarget(target);
   let n = ctx.renameCounters.get(originalSlot) ?? 2;
   for (;;) {
     const candidate = `${dir}${stem} (${n})${ext}`;
     n += 1;
-    if (!ctx.targetOwner.has(dedupSlot(area, candidate))) {
+    if (!ctx.targetClaim.has(dedupSlot(area, candidate))) {
       ctx.renameCounters.set(originalSlot, n);
       return candidate;
     }

--- a/packages/disk-import-worker/src/engine/plan.test.ts
+++ b/packages/disk-import-worker/src/engine/plan.test.ts
@@ -54,84 +54,84 @@ function baseOpts(exec: SafeExec, catalog: ImportCatalog, hashOf: AsyncHashResol
   return { exec, mountpoint: MOUNT, catalog, shareGid: GID, hashOf, now: () => FIXED_NOW };
 }
 
-describe('resolveTargetPath — owner prefix + merge/parallel (#1913)', () => {
+describe('resolveTargetPath — owner prefix + category layout (#1913/#2006)', () => {
   describe('owner prefix', () => {
     it('shared owner omits the owner segment', () => {
       expect(
-        resolveTargetPath('Musik/song.mp3', 'music', { owner: 'shared', mode: 'merge', anchor: '' }),
+        resolveTargetPath('Musik/song.mp3', 'music', { owner: 'shared', anchor: '' }),
       ).toBe('music/song.mp3');
     });
 
     it('a user owner prefixes data/<owner>/<category>/…', () => {
       expect(
-        resolveTargetPath('Musik/song.mp3', 'music', { owner: 'cdopp', mode: 'merge', anchor: '' }),
+        resolveTargetPath('Musik/song.mp3', 'music', { owner: 'cdopp', anchor: '' }),
       ).toBe('cdopp/music/song.mp3');
     });
 
-    it('the same file under different owners lands in different areas', () => {
+    it('the same file under different owners lands in different areas (preserve cat)', () => {
       const rel = 'inbox/report.pdf';
-      expect(resolveTargetPath(rel, 'documents', { owner: 'shared', mode: 'merge', anchor: '' })).toBe(
-        'documents/report.pdf',
+      expect(resolveTargetPath(rel, 'documents', { owner: 'shared', anchor: '' })).toBe(
+        'documents/inbox/report.pdf',
       );
-      expect(resolveTargetPath(rel, 'documents', { owner: 'mdopp', mode: 'merge', anchor: '' })).toBe(
-        'mdopp/documents/report.pdf',
+      expect(resolveTargetPath(rel, 'documents', { owner: 'mdopp', anchor: '' })).toBe(
+        'mdopp/documents/inbox/report.pdf',
       );
     });
   });
 
-  describe('mode: merge flattens into the category folder', () => {
+  describe('flat categories (music) flatten into the category folder', () => {
     it('drops the source subtree, keeping only the basename', () => {
       expect(
-        resolveTargetPath('Docs/2023/Q1/report.pdf', 'documents', { owner: 'shared', mode: 'merge', anchor: 'Docs' }),
-      ).toBe('documents/report.pdf');
+        resolveTargetPath('Musik/2023/Q1/track.mp3', 'music', { owner: 'shared', anchor: 'Musik' }),
+      ).toBe('music/track.mp3');
     });
 
     it('flattens identically regardless of how deep the source nests', () => {
       expect(
-        resolveTargetPath('a/b/c/d/track.flac', 'music', { owner: 'cdopp', mode: 'merge', anchor: 'a' }),
+        resolveTargetPath('a/b/c/d/track.flac', 'music', { owner: 'cdopp', anchor: 'a' }),
       ).toBe('cdopp/music/track.flac');
     });
   });
 
-  describe('mode: parallel preserves the source subtree below the anchor', () => {
+  describe('preserve categories (documents) keep the source subtree below the anchor', () => {
     it('keeps the structure under the category folder (shared)', () => {
       expect(
-        resolveTargetPath('Code/proj/src/main.ts', 'documents', { owner: 'shared', mode: 'parallel', anchor: 'Code' }),
+        resolveTargetPath('Code/proj/src/main.ts', 'documents', { owner: 'shared', anchor: 'Code' }),
       ).toBe('documents/proj/src/main.ts');
     });
 
     it('keeps the structure under data/<owner>/<category>/… (user owner)', () => {
       expect(
-        resolveTargetPath('Code/proj/src/main.ts', 'documents', { owner: 'mdopp', mode: 'parallel', anchor: 'Code' }),
+        resolveTargetPath('Code/proj/src/main.ts', 'documents', { owner: 'mdopp', anchor: 'Code' }),
       ).toBe('mdopp/documents/proj/src/main.ts');
     });
 
     it('a file sitting exactly at the anchor keeps its basename (not dropped)', () => {
       expect(
-        resolveTargetPath('Archive/readme.txt', 'documents', { owner: 'shared', mode: 'parallel', anchor: 'Archive/readme.txt' }),
+        resolveTargetPath('Archive/readme.txt', 'documents', { owner: 'shared', anchor: 'Archive/readme.txt' }),
       ).toBe('documents/readme.txt');
     });
 
     it('a root anchor preserves the whole relative path', () => {
       expect(
-        resolveTargetPath('top/inner/file.bin', 'documents', { owner: 'shared', mode: 'parallel', anchor: '' }),
+        resolveTargetPath('top/inner/file.bin', 'documents', { owner: 'shared', anchor: '' }),
       ).toBe('documents/top/inner/file.bin');
     });
   });
 
   describe('junk + edge cases', () => {
     it('junk has no destination folder → null', () => {
-      expect(resolveTargetPath('x/thumbs.db', 'junk', { owner: 'shared', mode: 'merge', anchor: '' })).toBeNull();
+      expect(resolveTargetPath('x/thumbs.db', 'junk', { owner: 'shared', anchor: '' })).toBeNull();
     });
 
     it('an empty / dot-only relative path → null', () => {
-      expect(resolveTargetPath('', 'music', { owner: 'shared', mode: 'merge', anchor: '' })).toBeNull();
-      expect(resolveTargetPath('./.', 'music', { owner: 'cdopp', mode: 'parallel', anchor: '' })).toBeNull();
+      expect(resolveTargetPath('', 'music', { owner: 'shared', anchor: '' })).toBeNull();
+      expect(resolveTargetPath('./.', 'music', { owner: 'cdopp', anchor: '' })).toBeNull();
     });
 
-    it('normalises backslash separators and strips empty segments', () => {
+    it('normalises backslash separators and strips empty segments (preserve cat)', () => {
       expect(
-        resolveTargetPath('Code\\proj\\\\main.ts', 'documents', { owner: 'shared', mode: 'parallel', anchor: 'Code' }),
+        resolveTargetPath('Code\\proj\\\\main.ts', 'documents', { owner: 'shared', anchor: 'Code' }),
       ).toBe('documents/proj/main.ts');
     });
   });

--- a/packages/disk-import-worker/src/engine/routing.test.ts
+++ b/packages/disk-import-worker/src/engine/routing.test.ts
@@ -156,14 +156,18 @@ describe('dirOfRel', () => {
   });
 });
 
-describe('resolveTargetPath (moved from plan.ts)', () => {
-  it('shared owner omits the owner segment, merge flattens to basename', () => {
-    expect(resolveTargetPath('Backup/IMG.jpg', 'photos', { owner: 'shared', mode: 'merge', anchor: '' }))
-      .toBe('photos/IMG.jpg');
+describe('resolveTargetPath — layout is category-driven (#2006)', () => {
+  it('music (flat category) flattens to the folder by basename; shared omits the owner segment', () => {
+    expect(resolveTargetPath('Backup/sub/track.mp3', 'music', { owner: 'shared', anchor: '' }))
+      .toBe('music/track.mp3');
   });
-  it('user owner prefixes; parallel preserves the subtree below the anchor', () => {
+  it('photos (preserve category) keep the source subtree below the anchor', () => {
+    expect(resolveTargetPath('Backup/IMG.jpg', 'photos', { owner: 'shared', anchor: '' }))
+      .toBe('photos/Backup/IMG.jpg');
+  });
+  it('user owner prefixes; preserve keeps the subtree below the anchor', () => {
     expect(
-      resolveTargetPath('Code/src/main.ts', 'documents', { owner: 'mdopp', mode: 'parallel', anchor: 'Code' }),
+      resolveTargetPath('Code/src/main.ts', 'documents', { owner: 'mdopp', anchor: 'Code' }),
     ).toBe('mdopp/documents/src/main.ts');
   });
 
@@ -175,7 +179,7 @@ describe('resolveTargetPath (moved from plan.ts)', () => {
   it('rejects a traversal owner before building a target', () => {
     for (const evil of ['..', '../etc', '../../etc/cron.d', '.']) {
       expect(() =>
-        resolveTargetPath('Backup/IMG.jpg', 'photos', { owner: evil, mode: 'merge', anchor: '' }),
+        resolveTargetPath('Backup/IMG.jpg', 'photos', { owner: evil, anchor: '' }),
       ).toThrow(/invalid owner segment/);
     }
   });
@@ -183,7 +187,7 @@ describe('resolveTargetPath (moved from plan.ts)', () => {
   it('rejects an owner carrying a path separator, backslash, or NUL', () => {
     for (const evil of ['a/b', 'a\\b', 'mdopp/../cdopp', 'x\0y', '']) {
       expect(() =>
-        resolveTargetPath('Backup/IMG.jpg', 'photos', { owner: evil, mode: 'merge', anchor: '' }),
+        resolveTargetPath('Backup/IMG.jpg', 'photos', { owner: evil, anchor: '' }),
       ).toThrow(/invalid owner segment/);
     }
   });

--- a/packages/disk-import-worker/src/engine/routing.ts
+++ b/packages/disk-import-worker/src/engine/routing.ts
@@ -103,10 +103,21 @@ export function effectiveRule(
     disposition: (disposition?.value as Disposition | undefined) ?? base.disposition,
     mode: (mode?.value as RoutingMode | undefined) ?? base.mode,
     owner: (owner?.value as Owner | undefined) ?? base.owner,
-    // Anchor follows the disposition axis (it drives relative-path math in #1913);
-    // falls back to the root when the disposition is inherited from the default.
-    anchor: disposition?.anchor ?? '',
+    // The preserve anchor (where the kept source subtree starts, #1913/#2006)
+    // follows the DEEPEST folder carrying an explicit rule on EITHER axis: putting
+    // a folder under an owner (or a disposition) means its contents belong there
+    // WITHOUT repeating that folder's name, so `backup_2025/docs/a.txt` assigned to
+    // mdopp lands at `mdopp/documents/docs/a.txt` (and `backup_2026/docs/a.txt`
+    // lands on the same target → identical bytes collapse). Root when inherited.
+    anchor: deeperAnchor(disposition?.anchor, owner?.anchor),
   };
+}
+
+/** The deeper (more specific) of two optional rule anchors; `''` (root) when both
+ *  are inherited. Depth: undefined < root('') < 'a' < 'a/b'. */
+function deeperAnchor(a: string | undefined, b: string | undefined): string {
+  const depth = (s: string | undefined): number => (s === undefined ? -1 : s === '' ? 0 : s.split('/').length);
+  return depth(a) >= depth(b) ? a ?? '' : b ?? '';
 }
 
 /** Walk up from `dir` to the first ancestor whose rule sets `axis`. */
@@ -230,18 +241,23 @@ function assertOwnerSegment(owner: string): void {
 /**
  * Resolve the relative target path (under `file-share/data/`) for a file given
  * its resolved routing rule and category. Returns `null` for the `junk` category
- * (nothing is written). Owner prefixes the path (shared omits the segment); the
- * mode decides whether the source subtree below the rule's anchor is preserved
- * (`parallel`) or flattened to the basename (`merge`).
+ * (nothing is written). Owner prefixes the path (shared omits the segment).
+ *
+ * The LAYOUT comes from the CATEGORY (#2006 redesign), not the routing `mode`:
+ * `preserve` categories (photos/documents/audiobooks/podcasts/movies) keep the
+ * source subtree BELOW the rule's anchor, so distinct files in different folders
+ * never collide; `flat` categories (music) drop the path to the basename. (The old
+ * per-folder merge/parallel `mode` axis was never surfaced in the UI; layout is now
+ * a property of WHAT the file is, which is what actually disambiguates it.)
  *
  * @param relPath the file's path RELATIVE to the imported disk root
  * @param category the classified category
- * @param rule the file's `effectiveRule` (owner + mode + anchor)
+ * @param rule the file's `effectiveRule` (owner + anchor)
  */
 export function resolveTargetPath(
   relPath: string,
   category: Category,
-  rule: Pick<ResolvedRule, 'owner' | 'mode' | 'anchor'>,
+  rule: Pick<ResolvedRule, 'owner' | 'anchor'>,
 ): string | null {
   const folder = categoryFolder(category);
   if (folder === '') return null; // junk — no destination folder.
@@ -250,7 +266,7 @@ export function resolveTargetPath(
   if (fileSegs.length === 0) return null; // nothing addressable.
 
   let tailSegs: string[];
-  if (rule.mode === 'parallel') {
+  if (CATEGORIES[category].layout === 'preserve') {
     // Preserve the source subtree BELOW the anchor (the dir that supplied the
     // rule). Drop the anchor prefix so the kept structure starts at the anchor.
     const anchorSegs = relSegments(rule.anchor);
@@ -259,7 +275,7 @@ export function resolveTargetPath(
     // own basename so it isn't dropped.
     if (tailSegs.length === 0) tailSegs = fileSegs.slice(-1);
   } else {
-    // merge: flatten — everything lands directly in the category folder.
+    // flat: everything lands directly in the category folder (basename only).
     tailSegs = fileSegs.slice(-1);
   }
 

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -543,11 +543,17 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
         <p className="text-xs text-gray-500 dark:text-gray-400">No category breakdown available for this run.</p>
       )}
 
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Source folders are kept (photos, videos, documents). Identical files are merged:
+        photos/videos/documents by content, music by name — so the same track in several
+        folders becomes one copy.
+      </p>
+
       {totals.renamed > 0 && (
         <p className="rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
-          {totals.renamed.toLocaleString()} file{totals.renamed === 1 ? '' : 's'} shared a name with a <strong>different</strong> file headed to the same folder
-          (e.g. two cameras both naming a photo <code>IMG_0001.jpg</code>). Each is imported under a disambiguated
-          name like <code>IMG_0001 (2).jpg</code> — <strong>nothing is dropped and nothing is overwritten</strong>.
+          {totals.renamed.toLocaleString()} file{totals.renamed === 1 ? '' : 's'} would land on a name another
+          file already took (e.g. two <strong>different</strong> tracks both called <code>01.mp3</code>). Each is kept
+          under a disambiguated name like <code>01 (2).mp3</code> — <strong>nothing is dropped or overwritten</strong>.
         </p>
       )}
 


### PR DESCRIPTION
Reworks the conflict handling shipped in #2006 into the correct model.

## Why
The operator spotted it on the real 1.8 TB disk: 23k document "conflicts" weren't 23k genuinely-clashing files — the importer **flattened every file to `<category>/<basename>`**, smashing `docs/note.txt` and `notes/note.txt` (across yearly backups) onto one name. #2006's "rename everything flat" would have produced a flat pile of `note (2).txt … note (23000).txt` with all folder context lost. The fix is to lay out + dedup **per category**, by what the files actually are.

## Model
| Category | Layout | Dedup identity |
|---|---|---|
| documents, photos, videos, audiobooks, podcasts | **preserve** source folders | **content** (bytes) |
| music | **flatten** to `music/` | **name + size** (no hashing) |

- Distinct files in different folders never collide; byte-identical copies anywhere (same doc in `backup_2025` + `backup_2026`) collapse to one. A reused name (two cameras' `IMG_0001.jpg`) = two different files, both kept.
- Music: the same track scattered across folders is one song; two distinct songs sharing `01.mp3` differ in size → both kept (flat-name loser renamed). **Zero hashing for music.**

## Engine
- `categories.ts` — each category tagged `layout` + `identity`.
- `routing.ts` — `resolveTargetPath` takes layout from the **category** (not the never-surfaced `mode` axis); the preserve anchor now follows the **deepest** explicit rule on either axis, so assigning a folder to an owner strips that folder (no `mdopp/photos/mdopp/…`) and `backup_2025`/`backup_2026` land on the same target.
- `dedup.ts` — in-tree dedup by per-category **identity** within an area (not target slot); music skips the fingerprint pass; the `(2)/(3)` rename is now just the rare target-collision safety net. Cross-run: content cats by sha, music by target+size.
- `cli/main.ts` — the **initial** scan plan routes through the default resolution too, so the first review already shows the real layout (not a flat dump).

## UI
Review explains "folders kept; identical merged (photos/docs by content, music by name)"; the renamed note now reflects genuine name clashes (music), not photos.

## Result
On the real disk: conflicts → ~0, the 35k "conflicts" become correct imports/dupes, folder structure preserved, nothing dropped or overwritten.

## Tests
New `dedup.test.ts` block locks all three behaviours (documents preserve+content-collapse, photos content-only/both-kept, music name+size/no-hash/rename); `routing.test.ts` + `plan.test.ts` updated for category-driven layout. tsc + full disk-import suite (**319**) green.

## Box-verify owed
Real `/dev/sda`: conflicts ≈ 0; documents/photos keep their folders; identical files merge; music collapses by name. Drive the real UI + render the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
