### PR TITLE
feat(disk-import): per-folder "base root" strip toggle

### DIFF
--- a/packages/disk-import-worker/src/engine/routing.test.ts
+++ b/packages/disk-import-worker/src/engine/routing.test.ts
@@ -156,6 +156,45 @@ describe('dirOfRel', () => {
   });
 });
 
+describe('effectiveRule — base-root anchor (#2006 follow-up)', () => {
+  it('a base-marked folder becomes the anchor (its name is dropped)', () => {
+    const explicit = new Map<string, Rule>([['backup_2025', { base: true }]]);
+    expect(effectiveRule('backup_2025/docs', explicit).anchor).toBe('backup_2025');
+  });
+
+  it('base does NOT inherit down-tree like owner — only the marked folder anchors', () => {
+    const explicit = new Map<string, Rule>([['backup_2025', { base: true }]]);
+    // A sibling subtree with its own deeper structure still anchors at backup_2025.
+    expect(effectiveRule('backup_2025/docs/2021', explicit).anchor).toBe('backup_2025');
+    // An unrelated top-level folder is unaffected (no base above it → root anchor).
+    expect(effectiveRule('Photos/2021', explicit).anchor).toBe('');
+  });
+
+  it('base:false is not a base mark', () => {
+    const explicit = new Map<string, Rule>([['backup_2025', { base: false }]]);
+    expect(effectiveRule('backup_2025/docs', explicit).anchor).toBe('');
+  });
+
+  it('a deeper owner/disposition anchor still wins over a shallower base', () => {
+    const explicit = new Map<string, Rule>([
+      ['backup_2025', { base: true }],
+      ['backup_2025/Work', { owner: 'mdopp' }],
+    ]);
+    expect(effectiveRule('backup_2025/Work/report.pdf', explicit).anchor).toBe('backup_2025/Work');
+  });
+
+  it('end-to-end: two backup roots stripped → same target (then content dedup collapses)', () => {
+    const explicit = new Map<string, Rule>([
+      ['backup_2025', { base: true }],
+      ['backup_2026', { base: true }],
+    ]);
+    const a = resolveTargetPath('backup_2025/docs/note.txt', 'documents', effectiveRule('backup_2025/docs', explicit));
+    const b = resolveTargetPath('backup_2026/docs/note.txt', 'documents', effectiveRule('backup_2026/docs', explicit));
+    expect(a).toBe('documents/docs/note.txt');
+    expect(b).toBe('documents/docs/note.txt');
+  });
+});
+
 describe('resolveTargetPath — layout is category-driven (#2006)', () => {
   it('music (flat category) flattens to the folder by basename; shared omits the owner segment', () => {
     expect(resolveTargetPath('Backup/sub/track.mp3', 'music', { owner: 'shared', anchor: '' }))

--- a/packages/disk-import-worker/src/engine/routing.ts
+++ b/packages/disk-import-worker/src/engine/routing.ts
@@ -104,20 +104,34 @@ export function effectiveRule(
     mode: (mode?.value as RoutingMode | undefined) ?? base.mode,
     owner: (owner?.value as Owner | undefined) ?? base.owner,
     // The preserve anchor (where the kept source subtree starts, #1913/#2006)
-    // follows the DEEPEST folder carrying an explicit rule on EITHER axis: putting
-    // a folder under an owner (or a disposition) means its contents belong there
-    // WITHOUT repeating that folder's name, so `backup_2025/docs/a.txt` assigned to
-    // mdopp lands at `mdopp/documents/docs/a.txt` (and `backup_2026/docs/a.txt`
-    // lands on the same target → identical bytes collapse). Root when inherited.
-    anchor: deeperAnchor(disposition?.anchor, owner?.anchor),
+    // follows the DEEPEST folder carrying an explicit rule on owner/disposition OR
+    // an explicit BASE-ROOT mark: putting a folder under an owner/disposition (or
+    // marking it a base root) means its contents belong there WITHOUT repeating
+    // that folder's name, so `backup_2025/docs/a.txt` lands at `…/documents/docs/a.txt`
+    // (and `backup_2026/docs/a.txt` on the same target → identical bytes collapse).
+    // Root when inherited.
+    anchor: deeperAnchor(disposition?.anchor, owner?.anchor, resolveBaseAnchor(dir, explicit)),
   };
 }
 
-/** The deeper (more specific) of two optional rule anchors; `''` (root) when both
- *  are inherited. Depth: undefined < root('') < 'a' < 'a/b'. */
-function deeperAnchor(a: string | undefined, b: string | undefined): string {
+/** The deepest folder at/above `dir` explicitly marked `base: true`, or undefined.
+ *  Unlike owner/disposition, `base` does NOT inherit — it only anchors itself. */
+function resolveBaseAnchor(dir: string, explicit: ReadonlyMap<string, Rule>): string | undefined {
+  let cursor: string | null = dir;
+  while (cursor !== null) {
+    if (explicit.get(cursor)?.base === true) return cursor;
+    cursor = parentDir(cursor);
+  }
+  return undefined;
+}
+
+/** The deepest (most specific) of the given optional rule anchors; `''` (root) when
+ *  all are inherited. Depth: undefined < root('') < 'a' < 'a/b'. */
+function deeperAnchor(...anchors: (string | undefined)[]): string {
   const depth = (s: string | undefined): number => (s === undefined ? -1 : s === '' ? 0 : s.split('/').length);
-  return depth(a) >= depth(b) ? a ?? '' : b ?? '';
+  let best: string | undefined;
+  for (const a of anchors) if (depth(a) >= depth(best)) best = a;
+  return best ?? '';
 }
 
 /** Walk up from `dir` to the first ancestor whose rule sets `axis`. */

--- a/packages/disk-import-worker/src/engine/types.ts
+++ b/packages/disk-import-worker/src/engine/types.ts
@@ -128,6 +128,15 @@ export interface Rule {
   mode?: RoutingMode;
   /** `shared` or a box user id. Inherits up-tree independently of `mode`. */
   owner?: Owner;
+  /**
+   * Mark this folder as a BASE ROOT (#2006 follow-up): its OWN name is dropped and
+   * only the structure BELOW it is kept in the library. Use it on redundant top-level
+   * wrappers (`backup_2025/`, `Backup copy 3/`) so `backup_2025/docs/a.txt` and
+   * `backup_2026/docs/a.txt` both land at `documents/docs/a.txt` (then identical bytes
+   * dedupe to one). It only moves the preserve ANCHOR — does NOT inherit down-tree
+   * like owner/disposition, and `false`/absent means "not a base".
+   */
+  base?: boolean;
 }
 
 /**

--- a/packages/frontend/src/app/(dashboard)/disk-import/_lib/RoutingTree.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/_lib/RoutingTree.tsx
@@ -159,6 +159,12 @@ function Row({
           </span>
         )}
         <div className="ml-auto flex items-center gap-2">
+          {node.dir !== '' && (
+            <BaseToggle
+              active={explicit.base === true}
+              onToggle={() => onSetRule(node.dir, { base: !(explicit.base === true) })}
+            />
+          )}
           <OwnerPicker
             owners={data.owners}
             value={node.resolved.owner}
@@ -193,6 +199,32 @@ function Row({
           />
         ))}
     </>
+  );
+}
+
+/**
+ * "Base root" toggle. When active, this folder's OWN name is dropped and only the
+ * structure below it is kept (e.g. mark `backup_2025/` so its contents merge with
+ * `backup_2026/`'s at `documents/docs/…`). Off by default; inherited folders keep
+ * their full path.
+ */
+function BaseToggle({ active, onToggle }: { active: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={onToggle}
+      title={
+        active
+          ? "Base root — this folder's name is dropped; the structure below it is kept"
+          : "Mark as a base/backup root — drop this folder's name, keep what's inside"
+      }
+      className={`rounded border px-1.5 py-0.5 text-[11px] ${
+        active
+          ? 'bg-blue-600 text-white border-blue-600 font-medium'
+          : 'bg-white dark:bg-gray-900 text-gray-400 border-gray-200 dark:border-gray-700 hover:text-gray-600 dark:hover:text-gray-300'
+      }`}
+    >
+      strip
+    </button>
   );
 }
 

--- a/packages/frontend/src/app/(dashboard)/disk-import/_lib/types.ts
+++ b/packages/frontend/src/app/(dashboard)/disk-import/_lib/types.ts
@@ -25,6 +25,8 @@ export interface Rule {
   disposition?: Disposition;
   mode?: RoutingMode;
   owner?: Owner;
+  /** Base-root mark: drop this folder's own name, keep the structure below it. */
+  base?: boolean;
 }
 
 /** A folder's fully-resolved rule (inherited where not explicit) + the anchor. */

--- a/packages/frontend/src/app/api/system/disk-import/profiles/route.ts
+++ b/packages/frontend/src/app/api/system/disk-import/profiles/route.ts
@@ -14,6 +14,7 @@ const ruleSchema = z
     disposition: z.string().optional(),
     mode: z.enum(['merge', 'parallel']).optional(),
     owner: z.string().optional(),
+    base: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/frontend/src/app/api/system/disk-import/replanBody.ts
+++ b/packages/frontend/src/app/api/system/disk-import/replanBody.ts
@@ -20,6 +20,9 @@ const ruleSchema = z
     // owner is `shared` or a box-user id (free string); the engine clamps it to a
     // single clean path segment before it ever forms a target (#1929).
     owner: z.string().optional(),
+    // Base-root mark: drop this folder's own name, keep the structure below it
+    // (#2006 follow-up — strips redundant backup wrappers).
+    base: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
Follow-up to the per-category dedup redesign (#2014). Answers the operator's question: how to make `backup_2025/docs/note.txt` + `backup_2026/docs/note.txt` land at `documents/docs/note.txt` instead of keeping the `backup_YYYY` wrapper.

## Why
Preserve-layout keeps the full source path by default, so a redundant top wrapper stays in the target (`documents/backup_2025/docs/note.txt`). Identical files still dedupe by content, but the surviving copy carries `backup_2025`. There was no discoverable way to drop it (only a side effect of assigning an owner). Auto-detecting "which top folders are noise" is inherently a guess, so this adds an **explicit, deterministic** control instead.

## What
A per-folder **`base` mark** ("strip" toggle). Marking a folder a base root moves the preserve **anchor** to it — its own name is dropped, the structure below is kept:

```
[strip] backup_2025/docs/note.txt  ┐ same bytes
[strip] backup_2026/docs/note.txt  ┘ → documents/docs/note.txt   (one copy)
        Photos/IMG.jpg                → photos/Photos/IMG.jpg     (kept)
```

- **engine**: `Rule.base?: boolean`; `effectiveRule` folds the nearest base-marked ancestor into the anchor (variadic `deeperAnchor`). `base` does **not** inherit down-tree (only the marked folder anchors); `false`/absent = not a base; a deeper owner/disposition anchor still wins.
- **wire**: `base` added to the replan + profile rule schemas (so it survives re-plan and saved presets).
- **UI**: a `strip` toggle per folder in the routing tree (hidden on the disk root); the live target preview re-resolves to show the stripped path.

## Tests
5 new routing tests: anchor moves to the marked folder, non-inheritance, `base:false` is inert, deeper owner wins, two roots → same target. tsc + disk-import suite (**324**) green.

## Box-verify owed
Real disk: mark a couple of backup wrappers → their contents merge under the category root, identical files collapse to one. Verify via the rendered routing tree + preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
