### PR TITLE
fix(disk-import): generous timeout for the host-apply exec (30s default errored mid-copy)

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -185,9 +185,13 @@ describe('applyImport', () => {
 
     expect(applyPlanMock).toHaveBeenCalledTimes(1);
     const [plan, opts] = applyPlanMock.mock.calls[0];
-    expect(opts.exec).toBe(exec);
     expect(opts.mountpoint).toBe('/run/servicebay/disk-import/sda1');
     expect(opts.shareGid).toBe(1024);
+    // The exec is WRAPPED to inject a generous per-op timeout (a multi-GB file's
+    // rsync/hash blows the agent's 30s default → #2010-class apply failure). It
+    // still delegates to the real exec, and a per-call option overrides the default.
+    opts.exec(['rsync', 'a', 'b'], { sudo: true });
+    expect(exec).toHaveBeenCalledWith(['rsync', 'a', 'b'], { timeoutMs: 1_800_000, sudo: true });
     // the plan handed to applyPlan reads the source from the HOST mount
     expect(plan.items[0].record.sourcePath).toBe('/run/servicebay/disk-import/sda1/dcim/a.jpg');
   });
@@ -203,7 +207,11 @@ describe('applyImport', () => {
     // source bytes can only flow through the host exec.
     const sha = await opts.hashOf({ sourcePath: '/run/servicebay/disk-import/sda1/dcim/a.jpg' });
     expect(sha).toBe('a'.repeat(64));
-    expect(hashSourceFileMock).toHaveBeenCalledWith(exec, '/run/servicebay/disk-import/sda1/dcim/a.jpg');
+    // Hashes via the host exec (the wrapped one, with the generous timeout), never fs.
+    expect(hashSourceFileMock).toHaveBeenCalledWith(expect.any(Function), '/run/servicebay/disk-import/sda1/dcim/a.jpg');
+    const wrapped = hashSourceFileMock.mock.calls[0][0] as (a: string[], o?: object) => unknown;
+    wrapped(['sha256sum', 'x']);
+    expect(exec).toHaveBeenCalledWith(['sha256sum', 'x'], { timeoutMs: 1_800_000 });
   });
 
   it('fires the Immich provision + scan for the photo owners after apply', async () => {

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -94,6 +94,11 @@ const WORKER_OUT_IN_CONTAINER = '/out';
  *  gives up (#2009). */
 const REPLAN_TIMEOUT_MS = 600_000; // 10 min
 
+/** Per-op ceiling for the host-apply's safe_exec calls (rsync/sha256sum/chown a
+ *  large media file or a big batch). The agent's 30s default errored the apply on
+ *  a multi-GB file mid-run (#2010-class bug, box-verified). 30 min is generous. */
+const APPLY_EXEC_TIMEOUT_MS = 1_800_000; // 30 min
+
 export interface ReplanImportArgs {
   /** servicebay's REAL agent SafeExec (runs `podman exec` on the host as core). */
   exec: SafeExec;
@@ -259,7 +264,15 @@ export interface ApplyImportResult {
  * (so the route surfaces it) AFTER recording an `error`-phase status.
  */
 export async function applyImport(args: ApplyImportArgs): Promise<ApplyImportResult> {
-  const { exec, runId, mountpoint, shareGid } = args;
+  const { runId, mountpoint, shareGid } = args;
+  // Every host op the apply runs (rsync a single file, sha256sum a single file,
+  // batched mkdir/chown) goes through this exec. The agent's DEFAULT command
+  // timeout is 30s — which a multi-GB media file's rsync or hash blows right past,
+  // erroring the whole apply mid-run ("Agent request timeout (safe_exec after
+  // 30000ms)"; box-verified on the real disk at ~66%). Same 30s-default trap #2010
+  // fixed for the re-plan exec — give the apply the same generous per-op ceiling.
+  // (Per-call options still win, so a caller can override.)
+  const exec: SafeExec = (argv, options) => args.exec(argv, { timeoutMs: APPLY_EXEC_TIMEOUT_MS, ...options });
   const outDir = runOutDir(runId);
 
   const sidecar = JSON.parse(await readFile(path.join(outDir, PLAN_SIDECAR_FILE), 'utf-8')) as PlanSidecar;


### PR DESCRIPTION
**Found by the on-box verify you asked for.** Applying your real 1.8 TB disk, the import copied **~70,872 / 107,218 files (154 GB)** then died with `Agent request timeout (safe_exec after 30000ms)`.

## Cause
Every host op the apply runs — per-file `rsync`, per-file `sha256sum` (lazy/resume hash), batched `mkdir`/`chown` — goes through the agent `SafeExec`, which defaults to a **30-second** command timeout. A single multi-GB media file's rsync/hash exceeds 30 s → the whole apply errors and stops. Same 30 s-default trap #2010 fixed for the **re-plan** exec; the **apply** path never got the longer ceiling.

## Fix
Wrap the apply's exec at the `applyImport` boundary to inject a generous **30-min** per-op timeout — one place, covering rsync/hash/mkdir/chown/mv (a per-call option still overrides). The agent honors long timeouts (`servicebayChannel` already uses 5 min for `podman pull`).

The apply is resumable, so the killed run **resumes** (catalog-skips the 70 k already-copied files) and now gets past the big file.

tsc + disk-import suite (324) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
