### PR TITLE
fix(disk-import): apply timeout clobbered by {timeoutMs: undefined} (re-broke at 30s)

### DIFF
--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -189,9 +189,16 @@ describe('applyImport', () => {
     expect(opts.shareGid).toBe(1024);
     // The exec is WRAPPED to inject a generous per-op timeout (a multi-GB file's
     // rsync/hash blows the agent's 30s default → #2010-class apply failure). It
-    // still delegates to the real exec, and a per-call option overrides the default.
+    // still delegates to the real exec, and a per-call NUMBER overrides the default.
     opts.exec(['rsync', 'a', 'b'], { sudo: true });
-    expect(exec).toHaveBeenCalledWith(['rsync', 'a', 'b'], { timeoutMs: 1_800_000, sudo: true });
+    expect(exec).toHaveBeenLastCalledWith(['rsync', 'a', 'b'], { sudo: true, timeoutMs: 1_800_000 });
+    // REGRESSION: runSha256sum passes an explicit `{ timeoutMs: undefined }`; the
+    // wrap must NOT let that clobber the default back to undefined (that re-broke
+    // the apply at 30s). undefined/absent → default; a real number still wins.
+    opts.exec(['sha256sum', 'big.zip'], { timeoutMs: undefined });
+    expect(exec).toHaveBeenLastCalledWith(['sha256sum', 'big.zip'], { timeoutMs: 1_800_000 });
+    opts.exec(['x'], { timeoutMs: 5_000 });
+    expect(exec).toHaveBeenLastCalledWith(['x'], { timeoutMs: 5_000 });
     // the plan handed to applyPlan reads the source from the HOST mount
     expect(plan.items[0].record.sourcePath).toBe('/run/servicebay/disk-import/sda1/dcim/a.jpg');
   });

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -269,10 +269,14 @@ export async function applyImport(args: ApplyImportArgs): Promise<ApplyImportRes
   // batched mkdir/chown) goes through this exec. The agent's DEFAULT command
   // timeout is 30s — which a multi-GB media file's rsync or hash blows right past,
   // erroring the whole apply mid-run ("Agent request timeout (safe_exec after
-  // 30000ms)"; box-verified on the real disk at ~66%). Same 30s-default trap #2010
+  // 30000ms)"; box-verified on the real disk twice). Same 30s-default trap #2010
   // fixed for the re-plan exec — give the apply the same generous per-op ceiling.
-  // (Per-call options still win, so a caller can override.)
-  const exec: SafeExec = (argv, options) => args.exec(argv, { timeoutMs: APPLY_EXEC_TIMEOUT_MS, ...options });
+  // CRITICAL: callers like runSha256sum pass an explicit `{ timeoutMs: undefined }`,
+  // so a `{ timeoutMs: DEFAULT, ...options }` spread is CLOBBERED back to undefined
+  // → 30s. Use a `??` fallback so an explicit number wins but undefined/absent gets
+  // the default (this exact bug re-broke the apply on the first fix).
+  const exec: SafeExec = (argv, options) =>
+    args.exec(argv, { ...options, timeoutMs: options?.timeoutMs ?? APPLY_EXEC_TIMEOUT_MS });
   const outDir = runOutDir(runId);
 
   const sidecar = JSON.parse(await readFile(path.join(outDir, PLAN_SIDECAR_FILE), 'utf-8')) as PlanSidecar;


### PR DESCRIPTION
**Box-verify caught my own fix being wrong.** #2016 wrapped the apply exec as `{ timeoutMs: DEFAULT, ...options }` — but `runSha256sum` passes an explicit `{ timeoutMs: undefined }`, and the spread put that **after** the default, clobbering it back to undefined → the agent's 30 s default. The resume's re-verify hash of a multi-GB VM zip (`sha256sum …/WinXP-Development.zip`) timed out at 30 s and errored the whole apply *again*, even though #2016 was deployed (confirmed `18e5` in the bundle).

## Fix
`{ ...options, timeoutMs: options?.timeoutMs ?? APPLY_EXEC_TIMEOUT_MS }` — an explicit **number** still wins, but `undefined`/absent falls back to the 30-min ceiling. Plus a regression test for the exact `{ timeoutMs: undefined }` clobber.

tsc + apply suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
