### PR TITLE
fix(health): self-diagnose checks can't be deleted — stop the fake-success no-op

### DIFF
--- a/packages/backend/src/lib/health/store.test.ts
+++ b/packages/backend/src/lib/health/store.test.ts
@@ -110,3 +110,31 @@ describe('HealthStore.markLastResultAlerted (#1661)', () => {
     expect(HealthStore.getResults('never-run')).toEqual([]);
   });
 });
+
+describe('HealthStore.deleteCheck — honest return (synthetic rows can\'t be deleted)', () => {
+  let HealthStore: typeof import('./store').HealthStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'healthstore-'));
+    vi.resetModules();
+    process.env.DATA_DIR = tmpDir;
+    ({ HealthStore } = await import('./store'));
+  });
+  afterEach(async () => {
+    delete process.env.DATA_DIR;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns true when a stored check is actually removed', () => {
+    HealthStore.saveCheck(serviceCheck('immich'));
+    expect(HealthStore.deleteCheck('id-immich')).toBe(true);
+    expect(HealthStore.getChecks()).toHaveLength(0);
+  });
+
+  it('returns false (no fake success) for an id that is not stored — e.g. a synthetic diagnose row', () => {
+    HealthStore.saveCheck(serviceCheck('immich'));
+    expect(HealthStore.deleteCheck('diagnose:sso_verify')).toBe(false);
+    // the stored check is untouched — nothing was silently rewritten.
+    expect(HealthStore.getChecks().map(c => c.target)).toEqual(['immich']);
+  });
+});

--- a/packages/backend/src/lib/health/store.ts
+++ b/packages/backend/src/lib/health/store.ts
@@ -54,10 +54,17 @@ export class HealthStore {
     fs.writeFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
   }
 
-  static deleteCheck(id: string) {
+  /** Delete a STORED check by id. Returns false when nothing matched — e.g. a
+   *  synthetic `diagnose:<probeId>` row (those live only in the live diagnose
+   *  bridge, never in checks.json), so the caller can report honestly instead of
+   *  a fake success that silently no-ops and lets the row reappear. */
+  static deleteCheck(id: string): boolean {
     ensureDirs();
-    const checks = this.getChecks().filter(c => c.id !== id);
-    fs.writeFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
+    const checks = this.getChecks();
+    const remaining = checks.filter(c => c.id !== id);
+    if (remaining.length === checks.length) return false;
+    fs.writeFileSync(CHECKS_FILE, JSON.stringify(remaining, null, 2));
+    return true;
   }
 
   /**

--- a/packages/frontend/src/app/api/health/checks/route.ts
+++ b/packages/frontend/src/app/api/health/checks/route.ts
@@ -85,6 +85,26 @@ export const POST = withApiHandler({ body: CheckPostBody }, async ({ body, auth 
 const CheckDeleteQuery = z.object({ id: z.string().min(1).max(64) });
 
 export const DELETE = withApiHandler({ query: CheckDeleteQuery }, async ({ query }) => {
-  HealthStore.deleteCheck(query.id);
+  // `Self-diagnose: …` rows are synthetic `diagnose:<probeId>` projections of the
+  // live diagnose probes — never stored, so deleting them is impossible by design.
+  // Say so honestly instead of returning a fake success that no-ops and lets the row
+  // reappear on the next poll. It clears once the underlying probe passes.
+  if (query.id.startsWith('diagnose:')) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: 'DIAGNOSE_NOT_DELETABLE',
+        error:
+          "This is a self-diagnose check — it reflects a live probe result, not a stored check, so it can't be deleted. It clears on its own once the underlying issue is resolved.",
+      },
+      { status: 400 },
+    );
+  }
+  if (!HealthStore.deleteCheck(query.id)) {
+    return NextResponse.json(
+      { ok: false, code: 'CHECK_NOT_FOUND', error: `No deletable check with id "${query.id}".` },
+      { status: 404 },
+    );
+  }
   return { success: true };
 });


### PR DESCRIPTION
Fixes "I can't delete the health checks."

The `Self-diagnose: …` rows are **synthetic** `diagnose:<probeId>` projections of the live diagnose probes — they're never stored in `checks.json`. But DELETE did `getChecks().filter(id != …)` over `checks.json` (where they don't exist), wrote it back unchanged, and returned `{success:true}`. So delete **lied**: reported success, removed nothing, and the row reappeared on the next poll. (Stored checks — domains/gateway/per-service — delete fine.)

- `HealthStore.deleteCheck` now returns whether it actually removed a row.
- DELETE route: a `diagnose:` id → honest **400** ("self-diagnose checks reflect a live probe result and clear once the issue is resolved — not deletable"); an unknown id → **404** instead of fake success.

**Scope note:** this is the *honesty* fix only. The failing self-diagnose rows still clear by fixing their **causes** (OIDC/SSO reconcile, Authelia admin-ACL, ollama forward-auth) — that's the post-import box pass.

store + route tests; full health suite (147+) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
