### PR TITLE
fix(diagnose): two self-diagnose false positives (SSO redirect_uri + cumulative restart count)

### DIFF
--- a/packages/backend/src/lib/diagnose/isContainerCurrentlyStable.test.ts
+++ b/packages/backend/src/lib/diagnose/isContainerCurrentlyStable.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isContainerCurrentlyStable, restartCountIndicatesLoop } from './runDiagnose';
+
+// The cumulative-RestartCount crash-loop signal is gated on this predicate so a
+// container with a high LIFETIME restart count that has since been up for hours
+// is not falsely flagged as "in a restart loop" (#crash-loop-cumulative — the
+// real solaris-tts-bridge case: RestartCount=24 yet Up 44 hours, ExitCode 0).
+describe('isContainerCurrentlyStable', () => {
+  it('treats Up minutes/hours/days as stable (a high lifetime count there is historical)', () => {
+    for (const s of ['Up 44 hours', 'Up 2 days', 'Up 5 minutes', 'Up About a minute', 'Up About an hour', 'Up 3 weeks']) {
+      expect(isContainerCurrentlyStable(s)).toBe(true);
+    }
+  });
+
+  it('treats freshly-up / restarting / exited as NOT stable (a real loop is always one of these)', () => {
+    for (const s of ['Up 5 seconds', 'Up 29 seconds', 'Up Less than a second', 'Restarting (1) 3 seconds ago', 'Exited (0) 2 hours ago', 'Created']) {
+      expect(isContainerCurrentlyStable(s)).toBe(false);
+    }
+  });
+
+  it('is whitespace-tolerant', () => {
+    expect(isContainerCurrentlyStable('  Up 44 hours  ')).toBe(true);
+    expect(isContainerCurrentlyStable('Up 10 seconds ')).toBe(false);
+  });
+});
+
+describe('restartCountIndicatesLoop', () => {
+  const T = 3;
+  it('does NOT flag a high cumulative count on a currently-stable container', () => {
+    // The real solaris-tts-bridge: 24 restarts but Up 44h → historical, not a loop.
+    expect(restartCountIndicatesLoop(24, 'Up 44 hours', T)).toBe(false);
+    expect(restartCountIndicatesLoop(99, 'Up 5 minutes', T)).toBe(false);
+  });
+  it('flags a high count on a freshly-up / restarting container (a genuine loop)', () => {
+    expect(restartCountIndicatesLoop(13801, 'Restarting (1) 2 seconds ago', T)).toBe(true);
+    expect(restartCountIndicatesLoop(5, 'Up 4 seconds', T)).toBe(true);
+  });
+  it('ignores a count below the threshold regardless of status', () => {
+    expect(restartCountIndicatesLoop(2, 'Restarting', T)).toBe(false);
+    expect(restartCountIndicatesLoop(0, 'Up 2 seconds', T)).toBe(false);
+  });
+  it('never trips on a non-numeric / NaN count', () => {
+    expect(restartCountIndicatesLoop(NaN, 'Restarting', T)).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -156,6 +156,40 @@ export interface DiagnoseProbe {
  *  already in the store and counts toward the trend / last-ok. A probe
  *  whose history can't be read (none yet, flaky disk) simply ships
  *  without the field — the UI degrades to status + detail. */
+/**
+ * True when a `podman ps` Status string shows the container is CURRENTLY
+ * long-stable — `Up` for a minute or longer. Used to suppress the cumulative-
+ * RestartCount crash-loop signal: a high lifetime restart count on a container
+ * that has since been up for hours is historical, not an active loop
+ * (#crash-loop-cumulative). Defined as "starts with `Up` and is NOT measured in
+ * seconds" — which covers podman's `Up 44 hours`, `Up 2 days`, `Up 5 minutes`,
+ * `Up About a minute`, `Up About an hour` while excluding `Up <N> seconds`,
+ * `Up Less than a second`, and the non-`Up` states (`Restarting…`, `Exited…`,
+ * `Created`) — a genuinely-looping container is always one of those. Exported
+ * for unit testing.
+ */
+export function isContainerCurrentlyStable(status: string): boolean {
+  const s = status.trim();
+  if (!/^Up\b/i.test(s)) return false; // Restarting / Exited / Created → not stable
+  if (/^Up\s+Less than a second/i.test(s)) return false;
+  if (/^Up\s+\d+\s+seconds?\b/i.test(s)) return false; // Up N seconds → not yet stable
+  return true; // Up minutes / hours / days / About a minute / About an hour
+}
+
+/**
+ * True when a container's RestartCount marks it as an ACTIVE restart loop.
+ * RestartCount is CUMULATIVE/monotonic, so a container that crashed a few times
+ * early on but has since been `Up` for hours is NOT looping now (the real
+ * solaris-tts-bridge case: RestartCount=24 yet Up 44h, ExitCode 0 — a false
+ * "restart loop"). So a count at/over the threshold only counts as a loop when
+ * the container isn't currently long-stable. A genuinely-looping container
+ * (Authelia's #622 had 13,801) is Restarting/freshly-up, never long-stable, so it
+ * still fires. A non-numeric count never trips. Exported for unit testing.
+ */
+export function restartCountIndicatesLoop(restartCount: number, status: string, threshold: number): boolean {
+  return Number.isFinite(restartCount) && restartCount >= threshold && !isContainerCurrentlyStable(status);
+}
+
 function withHistory(probes: DiagnoseProbe[]): DiagnoseProbe[] {
   return probes.map(p => {
     const history = buildProbeHistory(p.id);
@@ -568,11 +602,9 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     const restartCountRaw = (parts[2] ?? '').trim();
     const restartCount = parseInt(restartCountRaw, 10);
     // Restart-count check first — it's the only signal that survives
-    // the status-string heuristics' boot/install grace window. If
-    // podman has had to restart this container several times since
-    // its current db generation, it's looping regardless of when the
-    // last attempt happened.
-    if (Number.isFinite(restartCount) && restartCount >= RESTART_COUNT_LOOP_THRESHOLD) return true;
+    // the status-string heuristics' boot/install grace window. (The CUMULATIVE-
+    // count vs current-stability nuance lives in restartCountIndicatesLoop.)
+    if (restartCountIndicatesLoop(restartCount, status, RESTART_COUNT_LOOP_THRESHOLD)) return true;
     if (/^Restarting/i.test(status)) return true;
     if (/^Initialized/i.test(status)) return true;
     // Only flag "Up <30s" when the system has been up long enough that a

--- a/packages/backend/src/lib/diagnose/ssoVerify.test.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.test.ts
@@ -73,7 +73,7 @@ function happyDeps(opts: { forwardAuthHosts?: string[] } = {}): { deps: SsoVerif
       return gated.has(host);
     }),
     // OIDC-backed apps issue a real code by default.
-    probeOidcAuthorization: vi.fn(async (_pd: string, clientId: string): Promise<OidcAuthProbe> => ({
+    probeOidcAuthorization: vi.fn(async (_pd: string, clientId: string, _redirectUri: string): Promise<OidcAuthProbe> => ({
       ok: true, code: 302, detail: `code issued for ${clientId}`,
     })),
   };
@@ -316,14 +316,21 @@ describe('classifyOidcAuthorization (#1685)', () => {
     expect(r.status).toBe('pass');
     expect(r.detail).toMatch(/healthy/i);
   });
-  it('fails on invalid_client (the #1559 secret-mismatch signature)', () => {
+  it('fails on invalid_client (the #1559 registration signature) without claiming a secret fault', () => {
     const r = classifyOidcAuthorization('photos.dopp.cloud', 'immich', { ok: false, code: 302, oauthError: 'invalid_client', detail: 'x' });
     expect(r.status).toBe('fail');
     expect(r.detail).toMatch(/invalid_client/);
-    expect(r.detail).toMatch(/mismatch|broken/i);
+    expect(r.detail).toMatch(/registration|config/i);
+    // The authorization endpoint never validates the client SECRET — don't claim it.
+    expect(r.detail).not.toMatch(/secret/i);
   });
   it('fails on server_error', () => {
     expect(classifyOidcAuthorization('books.dopp.cloud', 'audiobookshelf', { ok: false, code: 500, oauthError: 'server_error', detail: 'x' }).status).toBe('fail');
+  });
+  it('SKIPs on invalid_request (a probe/redirect_uri setup issue, NOT a service fault — #sso-redirect-uri)', () => {
+    const r = classifyOidcAuthorization('photos.dopp.cloud', 'immich', { ok: false, code: 400, oauthError: 'invalid_request', detail: 'x' });
+    expect(r.status).toBe('skip');
+    expect(r.detail).toMatch(/could not run|setup/i);
   });
   it('fails on a redirect with no code', () => {
     expect(classifyOidcAuthorization('vault.dopp.cloud', 'vaultwarden', { ok: false, code: 302, detail: 'no code' }).status).toBe('fail');
@@ -423,9 +430,12 @@ describe('verifySso — #1685 OIDC apps exercise the real handshake', () => {
 
     expect(report.ok).toBe(true);
     // OIDC apps go through probeOidcAuthorization, NOT probeDomain
-    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'immich', expect.any(String));
-    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'vaultwarden', expect.any(String));
-    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'audiobookshelf', expect.any(String));
+    // The probe must send each client's REAL registered redirect_uri
+    // (https://<subdomain>.<domain><registered path>), not a placeholder —
+    // otherwise Authelia rejects an unregistered redirect_uri for every client.
+    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'immich', 'https://photos.dopp.cloud/auth/login', expect.any(String));
+    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'vaultwarden', 'https://vault.dopp.cloud/identity/connect/oidc-signin', expect.any(String));
+    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'audiobookshelf', 'https://books.dopp.cloud/auth/login', expect.any(String));
   });
 
   it('catches an invalid_client OIDC app RED even though its page loads 200 (#1559)', async () => {

--- a/packages/backend/src/lib/diagnose/ssoVerify.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.ts
@@ -112,13 +112,20 @@ export const FORWARD_AUTH_DERIVED_SUBDOMAINS: readonly string[] = ['ollama'];
  * app's login page still renders 200). For these we additionally drive the
  * real OIDC authorization flow and assert it reaches a redirect with a code
  * — not `invalid_client`/`server_error` (#1685, the #1559 immich case).
- * Maps the subdomain → its Authelia `client_id` (from the template's
- * `oidcClient.client_id`).
+ *
+ * Maps the subdomain → its Authelia `client_id` AND the client's REGISTERED
+ * redirect path (the first entry of the template's `oidcClient.redirect_uris`).
+ * The probe MUST send a redirect_uri that matches one the client is registered
+ * with, or Authelia (correctly, as a security control) rejects it with
+ * `invalid_request`. The old probe sent a placeholder `https://auth.<domain>/`
+ * for EVERY client → it always failed and mislabelled the legitimate rejection
+ * as a broken secret. The real redirect_uri is
+ * `https://<subdomain>.<publicDomain><redirectPath>`.
  */
-export const OIDC_CLIENT_SUBDOMAINS: Readonly<Record<string, string>> = {
-  vault: 'vaultwarden',
-  photos: 'immich',
-  books: 'audiobookshelf',
+export const OIDC_CLIENT_SUBDOMAINS: Readonly<Record<string, { clientId: string; redirectPath: string }>> = {
+  vault: { clientId: 'vaultwarden', redirectPath: '/identity/connect/oidc-signin' },
+  photos: { clientId: 'immich', redirectPath: '/auth/login' },
+  books: { clientId: 'audiobookshelf', redirectPath: '/auth/login' },
 };
 
 /**
@@ -208,10 +215,13 @@ export interface SsoVerifyDeps {
    *  hard-coded list says so (#1685). */
   hostHasForwardAuth: (host: string) => Promise<boolean>;
   /** Drive a service's OIDC authorization flow as the signed-in ephemeral
-   *  user and report whether Authelia issued a real `code` (#1685). */
+   *  user and report whether Authelia issued a real `code` (#1685). The
+   *  `redirectUri` MUST be one the client is registered with, else Authelia
+   *  rejects the request (`invalid_request`) regardless of client health. */
   probeOidcAuthorization: (
     publicDomain: string,
     clientId: string,
+    redirectUri: string,
     cookie: string,
   ) => Promise<OidcAuthProbe>;
 }
@@ -277,7 +287,17 @@ export function classifyOidcAuthorization(host: string, clientId: string, probe:
     return { domain, status: 'pass', code: probe.code, detail: `OIDC authorization issued a code for client "${clientId}" (handshake healthy)` };
   }
   if (probe.oauthError) {
-    return { domain, status: 'fail', code: probe.code, detail: `OIDC authorization for "${clientId}" returned ${probe.oauthError} — client secret/registration mismatch (real login is broken)` };
+    // `invalid_client` / `unauthorized_client` / `access_denied` / `server_error`
+    // are genuine client-registration/config problems. The authorization endpoint
+    // does NOT validate the client SECRET (that's the token exchange), so this is a
+    // registration/config fault, not a "secret mismatch". A bare `invalid_request`
+    // means Authelia rejected the probe's REQUEST (e.g. a redirect_uri we no longer
+    // build wrong) — treat that as "couldn't validly test" (skip), never a red
+    // "login broken" that scares toward a needless reinstall (#sso-redirect-uri).
+    if (probe.oauthError === 'invalid_request') {
+      return { domain, status: 'skip', code: probe.code, detail: `OIDC authorization probe for "${clientId}" could not run (Authelia: invalid_request — likely a probe/redirect_uri setup issue, not a service fault)` };
+    }
+    return { domain, status: 'fail', code: probe.code, detail: `OIDC authorization for "${clientId}" returned ${probe.oauthError} — client registration/config problem (login is affected)` };
   }
   if (probe.code === 0) {
     return { domain, status: 'fail', code: 0, detail: `OIDC authorization for "${clientId}" did not respond: ${probe.detail}` };
@@ -489,9 +509,9 @@ function realHostHasForwardAuth(node: string) {
 async function realProbeOidcAuthorization(
   publicDomain: string,
   clientId: string,
+  redirectUri: string,
   cookie: string,
 ): Promise<OidcAuthProbe> {
-  const redirectUri = `https://auth.${publicDomain}/`;
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -645,8 +665,13 @@ async function probeForwardAuthHost(deps: SsoVerifyDeps, run: SsoRun, host: stri
  *  client secret is mismatched (the app's own login page still renders 200),
  *  so the OIDC handshake must be driven directly (#1685, the #1559 case). */
 async function probeOidcHost(deps: SsoVerifyDeps, run: SsoRun, host: string, cookie: string): Promise<void> {
-  const clientId = OIDC_CLIENT_SUBDOMAINS[host];
-  const probe = await deps.probeOidcAuthorization(run.publicDomain, clientId, cookie);
+  const { clientId, redirectPath } = OIDC_CLIENT_SUBDOMAINS[host];
+  // The redirect_uri must be one the client is registered with (#sso-redirect-uri):
+  // `https://<subdomain>.<publicDomain><redirectPath>`. Sending the auth-portal URL
+  // here is what produced the false "secret mismatch" — Authelia rejects an
+  // unregistered redirect_uri before any client-health check.
+  const redirectUri = `https://${host}.${run.publicDomain}${redirectPath}`;
+  const probe = await deps.probeOidcAuthorization(run.publicDomain, clientId, redirectUri, cookie);
   run.userDomains.push(classifyOidcAuthorization(`${host}.${run.publicDomain}`, clientId, probe));
 }
 

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -604,6 +604,7 @@ describe('OIDC client_id single source of truth', () => {
     'packages/backend/src/lib/capabilities/credentials.test.ts',            // unit tests use fixture meta to drive the handler
     'packages/backend/src/lib/capabilities/autheliaClientMerge.test.ts',    // unit tests use fixture client_id literals to drive the merge
     'packages/backend/src/lib/diagnose/probes/reconcileOidcClients.test.ts', // unit tests use fixture oidcClient meta to drive the reconcile action
+    'packages/backend/src/lib/diagnose/ssoVerify.ts',                        // SSO probe maps each gated subdomain → its client_id + registered redirect to drive the real OIDC handshake (the value it TESTS, not a declaration)
   ]);
 
   it('no src/ file hardcodes a client_id / username literal that mirrors an OIDC declaration', () => {


### PR DESCRIPTION
Two of the four red rows on the health dashboard were **probe bugs, not real faults** — confirmed against the live box.

## 1. SSO "client secret mismatch — login is broken" → false positive
The OIDC handshake probe sent a **placeholder** `redirect_uri` (`https://auth.<domain>/`) for *every* client. That matches no client's registered redirect_uris, so Authelia **correctly** rejected it with `invalid_request` (redirect_uri enforcement is a security control working as designed) — for vault, immich *and* audiobookshelf, every run — and the probe **mislabelled** the rejection as "client secret/registration mismatch (real login is broken)."

Real login was fine the whole time. The box confirms the clients are registered with their true callbacks:
- `vaultwarden` → `https://vault.dopp.cloud/identity/connect/oidc-signin`
- `immich` → `https://photos.dopp.cloud/auth/login`

Also: the **authorization** endpoint never validates the client *secret* (that's the token exchange), so the "secret mismatch" wording was wrong on its face.

**Fix:** send each client's **real registered redirect_uri** (`https://<subdomain>.<domain><registered path>`); reword `invalid_client`/`server_error` as a registration/config fault (not "secret"); reclassify a bare `invalid_request` as **skip** ("probe could not run") rather than a red "login broken."

## 2. "Containers stable: 1 may be in a restart loop" → false positive
`RestartCount` is **cumulative**, but the probe flagged any container with a lifetime count ≥3 as looping — including `solaris-tts-bridge`, which has `RestartCount=24` yet has been **Up 44 hours, ExitCode 0** (those restarts were historical).

**Fix:** gate the count signal on a new `isContainerCurrentlyStable(status)` — a container `Up` for minutes+ isn't looping now; a genuine loop (Authelia's #622 had 13,801) is always Restarting/freshly-up, so it still fires.

## Tests
New units for the redirect_uri wiring, the reworded/skip classification, and `isContainerCurrentlyStable`. Full diagnose suite (317) + the whole repo suite (2940) green; exempted `ssoVerify.ts` in the client_id single-source-of-truth check (it maps subdomain→client_id to drive the probe — the same de-facto mapping the old code had, now explicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
