### PR TITLE
feat(install): prune orphaned installedTemplates entries (un-removable Hermes ghost)

### DIFF
--- a/packages/backend/src/lib/install/pruneOrphanedTemplates.test.ts
+++ b/packages/backend/src/lib/install/pruneOrphanedTemplates.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// In-memory config + a controllable template-manifest resolver.
+let config: { installedTemplates?: Record<string, { schemaVersion: number; installedAt: string }> };
+const manifests = new Set<string>(); // names that DO have a manifest
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(async () => config),
+  saveConfig: vi.fn(async (c: typeof config) => { config = c; }),
+}));
+vi.mock('@/lib/registry', () => ({
+  getTemplateVariables: vi.fn(async (name: string) => (manifests.has(name) ? { SOME_VAR: {} } : null)),
+}));
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+const { findOrphanedTemplates, pruneOrphanedTemplates } = await import('./pruneOrphanedTemplates');
+
+const entry = () => ({ schemaVersion: 1, installedAt: '2026-01-01T00:00:00Z' });
+
+beforeEach(() => {
+  manifests.clear();
+  config = {
+    installedTemplates: {
+      immich: entry(),   // has manifest + container → keep
+      solaris: entry(),  // NO manifest but HAS containers → keep
+      hermes: entry(),   // NO manifest, NO container → ORPHAN
+      solbay: entry(),   // NO manifest, NO container → ORPHAN
+    },
+  };
+  manifests.add('immich');
+});
+
+const RUNNING = ['immich-immich-server', 'immich-redis', 'solaris-chat', 'solaris-tts', 'nginx-nginx-proxy-manager'];
+
+describe('findOrphanedTemplates', () => {
+  it('flags manifest-less + container-less entries only', async () => {
+    const orphans = await findOrphanedTemplates(RUNNING);
+    expect(orphans.map(o => o.name).sort()).toEqual(['hermes', 'solbay']);
+  });
+
+  it('keeps a manifest-less template that still has running containers (solaris)', async () => {
+    const orphans = await findOrphanedTemplates(RUNNING);
+    expect(orphans.find(o => o.name === 'solaris')).toBeUndefined();
+  });
+
+  it('keeps an entry whose manifest exists even with no container', async () => {
+    manifests.add('hermes'); // pretend the manifest is back
+    const orphans = await findOrphanedTemplates([]);
+    expect(orphans.find(o => o.name === 'hermes')).toBeUndefined();
+  });
+
+  it('is a pure read — does not mutate config', async () => {
+    await findOrphanedTemplates(RUNNING);
+    expect(Object.keys(config.installedTemplates!).sort()).toEqual(['hermes', 'immich', 'solaris', 'solbay']);
+  });
+});
+
+describe('pruneOrphanedTemplates', () => {
+  it('removes only the orphans, leaving live + manifested entries', async () => {
+    const pruned = await pruneOrphanedTemplates(RUNNING);
+    expect(pruned.map(o => o.name).sort()).toEqual(['hermes', 'solbay']);
+    expect(Object.keys(config.installedTemplates!).sort()).toEqual(['immich', 'solaris']);
+  });
+
+  it('is a no-op (no write) when nothing is orphaned', async () => {
+    const { saveConfig } = await import('@/lib/config');
+    manifests.add('hermes'); manifests.add('solbay');
+    config.installedTemplates = { immich: entry(), hermes: entry(), solbay: entry() };
+    manifests.add('immich');
+    vi.mocked(saveConfig).mockClear();
+    const pruned = await pruneOrphanedTemplates(RUNNING);
+    expect(pruned).toEqual([]);
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/lib/install/pruneOrphanedTemplates.ts
+++ b/packages/backend/src/lib/install/pruneOrphanedTemplates.ts
@@ -1,0 +1,71 @@
+// Prune ORPHANED installedTemplates entries (#health-hermes-ghost).
+//
+// A template can be removed/renamed in the catalogue (the OSCAR→solbay→solaris
+// churn deleted `hermes`, `hermes-chat`, `solilos-chat`, `solbay`, `solilos`,
+// `oscar-household`) while its entry lingers in `config.installedTemplates`. The
+// normal stack wipe can't clear it ("Stack has no manifest"), so it sticks
+// forever — and self-diagnose probes keyed on `installedTemplates` (e.g.
+// `hermes_chat`) keep firing for a service that no longer exists, nagging the
+// operator about a thing they already uninstalled.
+//
+// This prunes an entry IFF it is BOTH:
+//   1. manifest-less — `getTemplateVariables(name)` is null (no variables.json in
+//      local or any registry), so it can never be (re)installed/rendered, AND
+//   2. not backed by any RUNNING container.
+// The double guard is critical: a still-running family (e.g. `solaris`, whose 6
+// containers are live) is NEVER pruned even if its manifest moved, and a valid
+// template whose registry is momentarily unreachable is protected by guard 2 if
+// it has containers. (A registry blip on a manifest-less AND container-less entry
+// is the only false-positive window — and such an entry is already dead weight.)
+
+import { getConfig, saveConfig } from '@/lib/config';
+import { getTemplateVariables } from '@/lib/registry';
+import { logger } from '@/lib/logger';
+
+export interface OrphanedTemplate {
+  name: string;
+  reason: string;
+}
+
+/** True when a running-container name belongs to template `name` — either the
+ *  container IS the template (`name`) or is one of its pod containers
+ *  (`name-<container>`, the Quadlet/kube naming). */
+function hasRunningContainer(name: string, runningContainers: readonly string[]): boolean {
+  return runningContainers.some(c => c === name || c.startsWith(`${name}-`));
+}
+
+/**
+ * Find installedTemplates entries that are orphaned (manifest-less AND not
+ * backed by a running container). Pure read — does not mutate. `runningContainers`
+ * is the live `podman ps` name list, injected so this stays testable and the
+ * caller controls the node/exec.
+ */
+export async function findOrphanedTemplates(runningContainers: readonly string[]): Promise<OrphanedTemplate[]> {
+  const config = await getConfig();
+  const installed = config.installedTemplates ?? {};
+  const orphans: OrphanedTemplate[] = [];
+  for (const name of Object.keys(installed)) {
+    const meta = await getTemplateVariables(name).catch(() => null);
+    if (meta !== null) continue; // manifest exists → installable/renderable → keep
+    if (hasRunningContainer(name, runningContainers)) continue; // still running → keep
+    orphans.push({ name, reason: 'no template manifest and no running container (removed/renamed service)' });
+  }
+  return orphans;
+}
+
+/**
+ * Remove orphaned installedTemplates entries from the persisted config and return
+ * what was pruned. Uses read→mutate→saveConfig (NOT updateConfig, whose deepMerge
+ * can't delete keys). A no-op (empty result, no write) when nothing is orphaned.
+ */
+export async function pruneOrphanedTemplates(runningContainers: readonly string[]): Promise<OrphanedTemplate[]> {
+  const orphans = await findOrphanedTemplates(runningContainers);
+  if (orphans.length === 0) return [];
+  const config = await getConfig();
+  const next = { ...(config.installedTemplates ?? {}) };
+  for (const o of orphans) delete next[o.name];
+  config.installedTemplates = next;
+  await saveConfig(config);
+  logger.info('install:prune', `pruned ${orphans.length} orphaned template(s): ${orphans.map(o => o.name).join(', ')}`);
+  return orphans;
+}

--- a/packages/frontend/src/app/api/system/templates/prune-orphans/route.ts
+++ b/packages/frontend/src/app/api/system/templates/prune-orphans/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { AgentExecutor } from '@/lib/agent/executor';
+import { getNodeIds } from '@/lib/store/repository';
+import { findOrphanedTemplates, pruneOrphanedTemplates } from '@/lib/install/pruneOrphanedTemplates';
+import { withApiHandler } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+
+export const dynamic = 'force-dynamic';
+
+/** The live running-container name list from `podman ps` on the node. */
+async function runningContainers(): Promise<string[]> {
+  const node = getNodeIds()[0] || 'Local';
+  const { stdout } = await new AgentExecutor(node).exec('podman ps --format "{{.Names}}"', { timeoutMs: 10_000 });
+  return stdout.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+/**
+ * GET — PREVIEW orphaned installedTemplates entries (#health-hermes-ghost): entries
+ * with no template manifest AND no running container (a removed/renamed service whose
+ * config entry lingers and keeps probes like `hermes_chat` firing). Read-only.
+ */
+export const GET = withApiHandler(
+  { tokenScope: 'mutate' },
+  async () => {
+    try {
+      return NextResponse.json({ ok: true, orphans: await findOrphanedTemplates(await runningContainers()) });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:templates:prune-orphans:preview', status: 400, exposeMessage: true });
+    }
+  },
+);
+
+/**
+ * POST — PRUNE the orphaned entries (same double guard: manifest-less AND no running
+ * container, so the live `solaris` family is never touched). Returns what was removed.
+ */
+export const POST = withApiHandler(
+  { tokenScope: 'destroy' },
+  async () => {
+    try {
+      return NextResponse.json({ ok: true, pruned: await pruneOrphanedTemplates(await runningContainers()) });
+    } catch (e) {
+      return apiError(e, { tag: 'api:system:templates:prune-orphans', status: 400, exposeMessage: true });
+    }
+  },
+);


### PR DESCRIPTION
Fixes the "I can't delete the Hermes health check" / un-removable ghost.

## Problem
The OSCAR→solbay→solaris rename deleted several templates (`hermes`, `hermes-chat`, `solilos-chat`, `solbay`, `solilos`, `oscar-household`) but left their entries in `config.installedTemplates`. The normal stack wipe refuses them (**"Stack has no manifest"**), so they linger forever — and self-diagnose probes keyed on `installedTemplates` (e.g. `hermes_chat`) keep nagging about a service the operator already uninstalled.

## Fix
A prune that removes an `installedTemplates` entry **only if BOTH**:
1. **manifest-less** — `getTemplateVariables(name)` is `null` (no `variables.json` in local or any registry → can't be rendered/reinstalled), AND
2. **no running container** backs it.

The double guard is the safety: the still-running **`solaris`** family (6 live containers, manifest moved during the rename) is **never** pruned, and a valid template whose registry is momentarily unreachable is protected if it has containers. Uses read→mutate→`saveConfig` (`updateConfig`'s `deepMerge` can't delete keys).

- `GET /api/system/templates/prune-orphans` — preview (read-only).
- `POST` (destroy-scope) — apply, returns what was removed.

## Box-confirmed
On the live node, the candidates are exactly: `hermes, hermes-chat, solilos-chat, solbay, solilos, oscar-household` — all manifest-less + container-less. `solaris` (6 running containers) is correctly retained.

## Tests
6 units: orphan detection, solaris-retained, manifest-back-keeps, pure-read, prune-removes-only-orphans, no-op-when-clean. Full repo suite green (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
