### PR TITLE
fix(diagnose): admin-ACL check asks Authelia directly; ollama is admin-only

### DIFF
--- a/packages/backend/src/lib/diagnose/ssoVerify.test.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.test.ts
@@ -20,6 +20,7 @@ import {
   classifyOidcAuthorization,
   classifyOidcRedirect,
   realProbeOidcAuthorization,
+  realProbeAdminDecision,
   extractAutheliaCookie,
   extractOauthError,
   makeEphemeralUsername,
@@ -61,14 +62,15 @@ function happyDeps(opts: { forwardAuthHosts?: string[] } = {}): { deps: SsoVerif
     deleteUser: vi.fn(async (id: string) => { calls.deleted.push(id); return { ok: true as const }; }),
     autheliaFirstFactor: vi.fn(async () => ({ ok: true, cookie: 'authelia_session=abc', detail: 'ok' })),
     probeDomain: vi.fn(async (_pd: string, host: string, _c: string | null, follow: boolean): Promise<DomainProbe> => {
-      // user apps follow redirects → 200 + matching signature; admin hosts
-      // don't follow → 302 (correctly blocked).
+      // user apps follow redirects → 200 + matching signature.
       if (follow) {
         const sig = USER_APP_SIGNATURES[host] ?? '';
         return { code: 200, body: sig || 'anything' };
       }
       return { code: 302, body: '' };
     }),
+    // Authelia denies a family user on admin hosts → 403 (correctly blocked).
+    probeAdminDecision: vi.fn(async (): Promise<DomainProbe> => ({ code: 403, body: '' })),
     // ollama.<domain> is gated iff opted in; FQDN-keyed.
     hostHasForwardAuth: vi.fn(async (fqdn: string) => {
       const host = fqdn.split('.')[0];
@@ -140,10 +142,8 @@ describe('verifySso orchestrator', () => {
 
   it('fails when a family user can REACH an admin domain (ACL bypass) — and still cleans up', async () => {
     const { deps, calls } = happyDeps();
-    deps.probeDomain = vi.fn(async (_pd, host, _c, follow) => {
-      if (!follow) return { code: 200, body: 'admin panel' }; // bypass!
-      return { code: 200, body: USER_APP_SIGNATURES[host] || 'ok' };
-    });
+    // Authelia ALLOWS the family user on the admin host (200) = a real bypass.
+    deps.probeAdminDecision = vi.fn(async () => ({ code: 200, body: '' }));
 
     const report = await verifySso({ deps });
 
@@ -380,6 +380,29 @@ describe('realProbeOidcAuthorization — drives Authelia /api/oidc/authorization
   });
 });
 
+describe('realProbeAdminDecision — asks Authelia /api/authz/auth-request directly', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports Authelia allowing the family user (200 = bypass) and sends the right shape', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ status: 200 } as unknown as Response);
+    const r = await realProbeAdminDecision('dopp.cloud', 'nginx', 'authelia_session=x');
+    expect(r.code).toBe(200);
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/api\/authz\/auth-request$/);
+    const h = init.headers as Record<string, string>;
+    expect(h['X-Original-URL']).toBe('https://nginx.dopp.cloud/');
+    expect(h['X-Original-Method']).toBe('GET');
+    expect(h.Cookie).toBe('authelia_session=x');
+  });
+
+  it('reports a deny (403) and a transport failure (0)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ status: 403 } as unknown as Response);
+    expect((await realProbeAdminDecision('dopp.cloud', 'dns', 'c')).code).toBe(403);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    expect((await realProbeAdminDecision('dopp.cloud', 'ldap', 'c')).code).toBe(0);
+  });
+});
+
 describe('classifyOidcRedirect — Location-header outcome (#sso-redirect-uri)', () => {
   it('passes a code= redirect (full handshake)', () => {
     const r = classifyOidcRedirect('https://photos.dopp.cloud/auth/login?code=abc&state=x', 302);
@@ -451,33 +474,13 @@ describe('verifySso — #1673 set_password + couldNotRun', () => {
   });
 });
 
-describe('verifySso — #1685 ollama forward-auth gating', () => {
-  it('includes ollama when its proxy host carries forward-auth', async () => {
+describe('verifySso — ollama is admin-only, never probed as a family app', () => {
+  // Operator decision: ollama.dopp.cloud is admin-only (the chat uses ollama over
+  // internal loopback, not this gated host), so it's NOT in the family-app set and
+  // is never reported as a user domain — even if a forward-auth host exists for it.
+  it('does not probe ollama as a user domain (FORWARD_AUTH_DERIVED is empty)', async () => {
+    expect(FORWARD_AUTH_DERIVED_SUBDOMAINS).not.toContain('ollama');
     const { deps } = happyDeps({ forwardAuthHosts: ['ollama'] });
-    const report = await verifySso({ deps });
-
-    expect(report.ok).toBe(true);
-    expect(report.userDomains.some(d => d.domain === 'ollama.dopp.cloud')).toBe(true);
-    expect(deps.hostHasForwardAuth).toHaveBeenCalledWith('ollama.dopp.cloud');
-  });
-
-  it('catches a 403-ing ollama RED (the live breakage)', async () => {
-    const { deps } = happyDeps({ forwardAuthHosts: ['ollama'] });
-    deps.probeDomain = vi.fn(async (_pd, host, _c, follow) => {
-      if (!follow) return { code: 302, body: '' };
-      if (host === 'ollama') return { code: 403, body: 'Forbidden' };
-      return { code: 200, body: USER_APP_SIGNATURES[host] || 'ok' };
-    });
-
-    const report = await verifySso({ deps });
-
-    expect(report.ok).toBe(false);
-    expect(report.couldNotRun).toBe(false);
-    expect(report.userDomains.find(d => d.domain === 'ollama.dopp.cloud')?.status).toBe('fail');
-  });
-
-  it('does NOT probe ollama when its host carries no forward-auth', async () => {
-    const { deps } = happyDeps(); // ollama not gated
     const report = await verifySso({ deps });
     expect(report.userDomains.some(d => d.domain === 'ollama.dopp.cloud')).toBe(false);
   });

--- a/packages/backend/src/lib/diagnose/ssoVerify.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.ts
@@ -75,7 +75,9 @@ export const USER_APP_SIGNATURES: Readonly<Record<string, string>> = {
   files: '',
   sync: '',
   caldav: '',
-  ollama: 'Ollama is running',
+  // ollama is intentionally absent: it's admin-only, not a family-reachable app
+  // (the chat uses ollama over internal loopback, not this gated host). See
+  // FORWARD_AUTH_DERIVED_SUBDOMAINS.
 };
 
 /**
@@ -104,7 +106,13 @@ export const SUBDOMAIN_TEMPLATE: Readonly<Record<string, string>> = {
  * the first: it's installed by the external honcho/OSCAR stack and got a
  * forward-auth NPM host this run.
  */
-export const FORWARD_AUTH_DERIVED_SUBDOMAINS: readonly string[] = ['ollama'];
+// Empty by operator decision: `ollama.dopp.cloud` is ADMIN-ONLY, not a family app.
+// The solaris chat reaches ollama over internal loopback (`OLLAMA_URL=
+// http://127.0.0.1:11434`), NOT this Authelia-gated public host — so a family user
+// never needs it and probing it as a family-reachable app was wrong (it returns 403
+// to family). Genuinely enforcing admin-only on it (an Authelia access rule) +
+// verifying via the admin-reject check is a follow-up tied to the auth template.
+export const FORWARD_AUTH_DERIVED_SUBDOMAINS: readonly string[] = [];
 
 /**
  * Subdomains backed by their OWN OIDC client (not Authelia forward-auth):
@@ -210,6 +218,17 @@ export interface SsoVerifyDeps {
     cookie: string | null,
     followRedirects: boolean,
   ) => Promise<DomainProbe>;
+  /**
+   * Ask Authelia DIRECTLY whether the signed-in family user is allowed to reach
+   * an admin host — by querying its forward-auth decision endpoint
+   * (`/api/authz/auth-request`) with the cookie + `X-Original-URL`, exactly the
+   * subrequest nginx makes. `200` = Authelia ALLOWS (a family user reaching an
+   * admin host = bypass); `401/403` = correctly denied. This replaces hitting the
+   * host on `http:80`, where the first hop is the HTTP→HTTPS 301 — before the auth
+   * decision — so the old probe never saw the real deny and false-flagged a bypass
+   * (#admin-acl-port). The `code` maps straight into {@link classifyAdminReject}.
+   */
+  probeAdminDecision: (publicDomain: string, host: string, cookie: string | null) => Promise<DomainProbe>;
   /** True iff the proxy host for `host` carries `auth_request /authelia`
    *  forward-auth — so a host is probed because it IS gated, not because a
    *  hard-coded list says so (#1685). */
@@ -447,6 +466,33 @@ async function realProbeDomain(
   }
 }
 
+/**
+ * Ask Authelia's forward-auth decision endpoint whether the family user may reach
+ * an admin host — the same `/api/authz/auth-request` subrequest nginx makes (the
+ * proven shape from portal/auth.ts: Cookie + X-Original-URL + X-Original-Method,
+ * no Host override). 200 = allowed (= bypass for a family user on an admin host);
+ * 401/403 = correctly denied. This is the real ACL decision, on plain http
+ * loopback — no TLS, and far more precise than scraping the host's HTTP status.
+ */
+export async function realProbeAdminDecision(publicDomain: string, host: string, cookie: string | null): Promise<DomainProbe> {
+  const originalUrl = `https://${host}.${publicDomain}/`;
+  try {
+    const res = await fetch(`http://127.0.0.1:${autheliaPort()}/api/authz/auth-request`, {
+      method: 'GET',
+      headers: {
+        'X-Original-URL': originalUrl,
+        'X-Original-Method': 'GET',
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+      redirect: 'manual',
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    return { code: res.status, body: '' };
+  } catch (e) {
+    return { code: 0, body: '', error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 
 /** Resolve NPM's admin API base URL on this node (the admin port, not 80/443).
  *  Mirrors the local helper in danglingProxy.ts; kept local to avoid coupling. */
@@ -591,6 +637,7 @@ function buildDeps(node: string, overrides?: Partial<SsoVerifyDeps>): SsoVerifyD
     setPassword: realSetPassword(node),
     autheliaFirstFactor: realAutheliaFirstFactor,
     probeDomain: realProbeDomain,
+    probeAdminDecision: realProbeAdminDecision,
     hostHasForwardAuth: realHostHasForwardAuth(node),
     probeOidcAuthorization: realProbeOidcAuthorization,
     ...overrides,
@@ -725,7 +772,7 @@ async function probeAllDomains(deps: SsoVerifyDeps, run: SsoRun, cookie: string)
     await probeForwardAuthHost(deps, run, host, cookie);
   }
   for (const host of ADMIN_ONLY_HOSTS) {
-    const probe = await deps.probeDomain(run.publicDomain, host, cookie, false);
+    const probe = await deps.probeAdminDecision(run.publicDomain, host, cookie);
     run.adminDomains.push(classifyAdminReject(`${host}.${run.publicDomain}`, probe));
   }
 }


### PR DESCRIPTION
The last two SSO false positives, resolved cleanly (no TLS/CodeQL friction this time).

## 1. admin-ACL "bypass" (nginx/dns/ldap) — was a port-80 artifact
The probe hit `http://…:80`, whose first hop is the HTTP→HTTPS **301** — *before* Authelia's access decision — so it never saw the real **403** a family user gets and false-flagged a bypass. **Verified on-box**: an ephemeral family user gets 403 on the real path.

New **`probeAdminDecision`** dep asks Authelia's forward-auth decision endpoint **directly** — `/api/authz/auth-request` on http loopback:9091, the proven shape from `portal/auth.ts` (`Cookie` + `X-Original-URL` + `X-Original-Method`). That's the *exact* ACL decision nginx makes: **200** = Authelia allows the family user (real bypass) · **401/403** = correctly denied. Plain HTTP, mockable, no TLS/CodeQL issues.

## 2. ollama is admin-only (your call) — stop probing it as a family app
The solaris chat reaches ollama over **internal loopback** (`OLLAMA_URL=http://127.0.0.1:11434`), **not** the gated `ollama.dopp.cloud` host — so family never needs it, and probing it as a family-reachable app (expecting `200 "Ollama is running"`) was wrong (it returns 403 to family). Removed ollama from `FORWARD_AUTH_DERIVED_SUBDOMAINS` + `USER_APP_SIGNATURES`.

**Follow-up (not here):** genuinely *enforcing* admin-only on ollama needs an Authelia access rule in the auth template — a sensitive auth redeploy. Once that lands, ollama can join the admin-reject set and be verified.

## Result
After deploy, the SSO check's admin rows (nginx/dns/ldap) read correctly, and ollama no longer false-fails — leaving SSO green (vault/immich already fixed by #2021's consent change).

tsc + full diagnose suite (330) green; new fetch-mocked units (100% diff-coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
