### PR TITLE
fix(nginx): expand forward-auth sentinel in the proxy-host API (the files.dopp.cloud root cause)

### DIFF
--- a/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AUTHELIA_FORWARD_AUTH_SENTINEL,
+  expandForwardAuthSentinel,
+  renderForwardAuthAdvancedConfig,
+  DEFAULT_AUTHELIA_PORT,
+} from './forwardAuth';
+
+describe('expandForwardAuthSentinel', () => {
+  it('expands the bare sentinel into the auth_request snippet (still {{AUTHELIA_PORT}}-templated)', () => {
+    const out = expandForwardAuthSentinel(AUTHELIA_FORWARD_AUTH_SENTINEL)!;
+    expect(out).toContain('auth_request /authelia;');
+    expect(out).toContain('{{AUTHELIA_PORT}}'); // installer Mustache-renders this later
+    expect(out).not.toContain(AUTHELIA_FORWARD_AUTH_SENTINEL);
+  });
+  it('expands the prefix form and keeps the appended extras', () => {
+    const out = expandForwardAuthSentinel(`${AUTHELIA_FORWARD_AUTH_SENTINEL}\nclient_max_body_size 0;`)!;
+    expect(out).toContain('auth_request /authelia;');
+    expect(out).toContain('client_max_body_size 0;');
+  });
+  it('leaves a non-sentinel config untouched, and undefined as undefined', () => {
+    expect(expandForwardAuthSentinel('proxy_set_header X 1;')).toBe('proxy_set_header X 1;');
+    expect(expandForwardAuthSentinel(undefined)).toBeUndefined();
+  });
+});
+
+describe('renderForwardAuthAdvancedConfig — the no-Mustache (direct API) path', () => {
+  it('expands the sentinel AND substitutes the port — no sentinel or placeholder survives', () => {
+    const out = renderForwardAuthAdvancedConfig(AUTHELIA_FORWARD_AUTH_SENTINEL, '9091')!;
+    expect(out).toContain('proxy_pass http://127.0.0.1:9091/api/authz/auth-request;');
+    expect(out).not.toContain('{{AUTHELIA_PORT}}'); // would be an invalid nginx directive
+    expect(out).not.toContain(AUTHELIA_FORWARD_AUTH_SENTINEL); // the #files-down bug
+  });
+  it('defaults the port to DEFAULT_AUTHELIA_PORT when none is given', () => {
+    const out = renderForwardAuthAdvancedConfig(AUTHELIA_FORWARD_AUTH_SENTINEL)!;
+    expect(out).toContain(`http://127.0.0.1:${DEFAULT_AUTHELIA_PORT}/api/authz/auth-request;`);
+  });
+  it('renders the prefix-form extras with the port substituted too', () => {
+    const out = renderForwardAuthAdvancedConfig(`${AUTHELIA_FORWARD_AUTH_SENTINEL}\nproxy_read_timeout 1h;`, '9091')!;
+    expect(out).toContain('proxy_pass http://127.0.0.1:9091/api/authz/auth-request;');
+    expect(out).toContain('proxy_read_timeout 1h;');
+  });
+  it('passes a non-forward-auth config through unchanged', () => {
+    expect(renderForwardAuthAdvancedConfig('add_header X 1;', '9091')).toBe('add_header X 1;');
+    expect(renderForwardAuthAdvancedConfig(undefined, '9091')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -169,3 +169,25 @@ export function expandForwardAuthSentinel(advancedConfig: string | undefined): s
   }
   return advancedConfig;
 }
+
+/**
+ * Fully render a forward-auth `advanced_config` for code paths that have NO
+ * Mustache step — chiefly the direct proxy-host API (`/api/system/nginx/
+ * proxy-hosts`), used by manual creates and diagnose/heal re-asserts. The stack
+ * INSTALLER expands the sentinel then Mustache-renders `{{AUTHELIA_PORT}}`; a
+ * direct API call does neither, so without this both the literal sentinel AND the
+ * `{{AUTHELIA_PORT}}` placeholder land verbatim in the .conf →
+ * `nginx: [emerg] unknown directive "__authelia_forward_auth__"` (and an invalid
+ * `proxy_pass …:{{AUTHELIA_PORT}}/…`), leaving the host permanently offline. This
+ * expands the sentinel AND substitutes the Authelia port, so the API path emits a
+ * valid block exactly like the installer. A config that carries neither token is
+ * returned unchanged. `port` defaults to {@link DEFAULT_AUTHELIA_PORT}.
+ */
+export function renderForwardAuthAdvancedConfig(
+  advancedConfig: string | undefined,
+  port: string = DEFAULT_AUTHELIA_PORT,
+): string | undefined {
+  const expanded = expandForwardAuthSentinel(advancedConfig);
+  if (expanded === undefined) return expanded;
+  return expanded.replace(/\{\{AUTHELIA_PORT\}\}/g, port);
+}

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -7,7 +7,7 @@ import { withApiHandler } from '@/lib/api/handler';
 import { logger } from '@/lib/logger';
 import { agentManager } from '@/lib/agent/manager';
 import { listNodes } from '@/lib/nodes';
-import { AUTHELIA_LOCATION_HEADERS, sanitizeForwardAuthPort } from '@/lib/stackInstall/forwardAuth';
+import { AUTHELIA_LOCATION_HEADERS, sanitizeForwardAuthPort, renderForwardAuthAdvancedConfig, DEFAULT_AUTHELIA_PORT } from '@/lib/stackInstall/forwardAuth';
 import { checkPublicARecord, missingARecordMessage } from '@/lib/reverseProxy/publicDnsCheck';
 import {
     withLanDeniedPage,
@@ -1005,7 +1005,24 @@ export const POST = withApiHandler({}, async ({ request }) => {
 
         const results: { domain: string; success: boolean; error?: string; certIssued?: boolean; certError?: string; lanRestricted?: boolean }[] = [];
 
+        // The `__authelia_forward_auth__` sentinel is normally expanded by the
+        // STACK INSTALLER (postInstall) right before Mustache renders. A DIRECT
+        // call to this endpoint (a manual create, or a diagnose/heal that re-asserts
+        // a host) has no installer/Mustache step — so without this, the literal
+        // sentinel (and the `{{AUTHELIA_PORT}}` placeholder inside the expanded
+        // snippet) get written verbatim into the .conf → `nginx: [emerg] unknown
+        // directive "__authelia_forward_auth__"` → the host never goes online and
+        // generates no conf (a broken host that this very create then "reconciles"
+        // forever). Expand the sentinel AND substitute the Authelia port here so the
+        // API path produces a valid forward-auth block, exactly like the installer.
+        const authPort = config.templateSettings?.AUTHELIA_PORT ?? DEFAULT_AUTHELIA_PORT;
         for (const host of hosts) {
+            if (host.proxyConfig?.advanced_config) {
+                host.proxyConfig = {
+                    ...host.proxyConfig,
+                    advanced_config: renderForwardAuthAdvancedConfig(host.proxyConfig.advanced_config, authPort),
+                };
+            }
             // Default forward host = node LAN IP (NPM is in a container,
             // 127.0.0.1 would only reach the NPM pod itself)
             if (!host.forwardHost) {


### PR DESCRIPTION
The root-cause code fix behind the `files.dopp.cloud` outage.

## Bug
The `__authelia_forward_auth__` sentinel (and the `{{AUTHELIA_PORT}}` placeholder inside its expanded snippet) is only resolved by the **stack installer** — it expands the sentinel, then Mustache-renders the port. A **direct** call to `POST /api/system/nginx/proxy-hosts` (a manual create, or a diagnose/heal that re-asserts a host) does neither, so the literal sentinel + placeholder were written verbatim into the `.conf`:

```
nginx: [emerg] unknown directive "__authelia_forward_auth__" in proxy_host/NN.conf
```

→ the host never goes online and generates no conf. Worse, the create's `findProxyHostByDomain` then **matched that broken host** on every retry and reported **false success** ("created + cert issued") while it stayed dark. That's exactly what took **`files.dopp.cloud`** (and `sync`) down — they ended up with the unexpanded sentinel and couldn't be repaired through the API.

## Fix
Render the forward-auth `advanced_config` in the API path too. New pure helper **`renderForwardAuthAdvancedConfig(advancedConfig, port)`** (forwardAuth.ts) expands the sentinel **and** substitutes the Authelia port; the proxy-host POST loop applies it to every host **before create/reconcile**, so the API emits a valid block exactly like the installer (covers both fresh creates and heal re-asserts of an existing host). A config carrying neither token passes through unchanged.

## Tests
7 units for the expander + the new renderer: sentinel gone, port substituted, prefix-form extras preserved, defaults to `DEFAULT_AUTHELIA_PORT`, non-forward-auth passthrough. tsc + lint clean.

(`files.dopp.cloud` itself is already fixed live — recreated with the expanded block — so this prevents recurrence on any future create/heal.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
