### PR TITLE
fix(diagnose): drop the flaky per-domain HTTP GET from external-reachability (stop the cry-wolf)

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/domainExternalReachability.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainExternalReachability.test.ts
@@ -212,58 +212,26 @@ describe('checkDomainExternalReachability', () => {
     expect(r.items![0].detail).toMatch(/DNS check could not run/);
   });
 
-  it('#611 — flags DNS-green + HTTP-fail combo (the v4.0.x outage shape)', async () => {
-    // DNS is healthy for both domains.
-    state.results.set('domain:one.example.com', {
-      check_id: 'domain:one.example.com',
-      timestamp: isoAgo(60_000),
-      status: 'ok',
-      payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
-    });
-    state.results.set('domain:two.example.com', {
-      check_id: 'domain:two.example.com',
-      timestamp: isoAgo(60_000),
-      status: 'ok',
-      payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
-    });
-    // But the HTTPS GET surfaces a 502 for one.example.com (proxy
-    // forwarding to a crash-looping upstream).
-    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString();
-      if (url.includes('one.example.com')) {
-        return new Response('', { status: 502 }) as Response;
-      }
-      return new Response('', { status: 200 }) as Response;
-    }) as typeof fetch);
-
-    const r = await checkDomainExternalReachability();
-    expect(r.status).toBe('fail');
-    expect(r.items).toHaveLength(1);
-    expect(r.items![0].id).toBe('one.example.com');
-    expect(r.items![0].detail).toMatch(/HTTP 502/);
-    expect(r.items![0].detail).toMatch(/DNS layer OK/);
-  });
-
-  it('#611 — accepts 302 → auth.<publicDomain> as a healthy redirect (forward-auth)', async () => {
+  it('is DNS-routing only — DNS-green is ok and it does NO per-domain HTTP fetch', async () => {
+    // The flaky/redundant per-domain HTTPS GET (old #611) was removed: it
+    // false-timed-out under concurrent diagnose load and duplicated the upstream
+    // check that `domain_unreachable` already does via a Host-header fetch. This
+    // probe now judges DNS routing only; a DNS-green domain is ok regardless of
+    // upstream HTTP, and crucially it makes no outbound fetch (no cry-wolf).
     state.config.reverseProxy.publicDomain = 'example.com';
-    state.results.set('domain:one.example.com', {
-      check_id: 'domain:one.example.com',
-      timestamp: isoAgo(60_000),
-      status: 'ok',
-      payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
-    });
-    state.results.set('domain:two.example.com', {
-      check_id: 'domain:two.example.com',
-      timestamp: isoAgo(60_000),
-      status: 'ok',
-      payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
-    });
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('', { status: 302, headers: { location: 'https://auth.example.com/' } }) as Response,
-    );
+    for (const d of ['one.example.com', 'two.example.com']) {
+      state.results.set(`domain:${d}`, {
+        check_id: `domain:${d}`,
+        timestamp: isoAgo(60_000),
+        status: 'ok',
+        payload: dnsRoutingPayload({ expected: '203.0.113.5', resolved: ['203.0.113.5'], matched: true }),
+      });
+    }
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const r = await checkDomainExternalReachability();
     expect(r.status).toBe('ok');
-    expect(r.items).toBeUndefined(); // healthy rows are collapsed
+    expect(r.items).toBeUndefined(); // healthy DNS-green rows collapse
+    expect(fetchSpy).not.toHaveBeenCalled(); // no flaky per-domain HTTP GET
   });
 
   it('appends letsdebug summary to a flagged row when one exists', async () => {
@@ -378,125 +346,5 @@ describe('_internalsForTesting', () => {
 
   it('returns null for a plaintext message', () => {
     expect(_internalsForTesting.decodeDnsRouting('connect ETIMEDOUT')).toBeNull();
-  });
-});
-
-describe('probeHttpStatus (#611)', () => {
-  // Run the helper directly via dependency injection so the test
-  // doesn't have to mock globalThis.fetch.
-  async function probe(
-    domain: string,
-    publicDomain: string | null,
-    fetchImpl: typeof fetch,
-  ): Promise<{ status: 'ok' | 'warn' | 'fail'; detail: string }> {
-    const { probeHttpStatus } = await import('./domainExternalReachability');
-    return probeHttpStatus(domain, publicDomain, fetchImpl, 1_000);
-  }
-
-  function fakeFetch(response: Response): typeof fetch {
-    return (async () => response) as typeof fetch;
-  }
-
-  it('200 → ok', async () => {
-    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 200 })));
-    expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/HTTP 200/);
-  });
-
-  it('302 → auth.<publicDomain> → ok (forward-auth)', async () => {
-    const r = await probe(
-      'vault.example.com',
-      'example.com',
-      fakeFetch(new Response('', {
-        status: 302,
-        headers: { location: 'https://auth.example.com/?rd=https://vault.example.com/' },
-      })),
-    );
-    expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/forward-auth/);
-  });
-
-  it('302 to an unrelated host → warn', async () => {
-    const r = await probe(
-      'vault.example.com',
-      'example.com',
-      fakeFetch(new Response('', {
-        status: 302,
-        headers: { location: 'https://google.com/' },
-      })),
-    );
-    expect(r.status).toBe('warn');
-  });
-
-  it('302 to a relative path → ok (Navidrome / HA / Radicale same-origin)', async () => {
-    // music.dopp.cloud → /web/ (Navidrome), home.dopp.cloud → /onboarding.html (HA),
-    // caldav.dopp.cloud → /.web (Radicale). All are healthy "go to my UI" redirects.
-    for (const path of ['/web/', '/onboarding.html', '/.web']) {
-      const r = await probe(
-        'music.example.com',
-        'example.com',
-        fakeFetch(new Response('', { status: 302, headers: { location: path } })),
-      );
-      expect(r.status).toBe('ok');
-      expect(r.detail).toMatch(/same-origin/);
-    }
-  });
-
-  it('302 to an absolute same-host URL → ok', async () => {
-    const r = await probe(
-      'music.example.com',
-      'example.com',
-      fakeFetch(new Response('', {
-        status: 302,
-        headers: { location: 'https://music.example.com/web/' },
-      })),
-    );
-    expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/same-origin/);
-  });
-
-  it('401 → ok (auth-gated)', async () => {
-    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 401 })));
-    expect(r.status).toBe('ok');
-    expect(r.detail).toMatch(/auth-gated/);
-  });
-
-  it('502 → fail with status code', async () => {
-    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 502 })));
-    expect(r.status).toBe('fail');
-    expect(r.detail).toMatch(/HTTP 502/);
-  });
-
-  it('500 → fail', async () => {
-    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 500 })));
-    expect(r.status).toBe('fail');
-  });
-
-  it('404 (other 4xx) → warn — many apps don\'t serve /', async () => {
-    const r = await probe('x.example.com', 'example.com', fakeFetch(new Response('', { status: 404 })));
-    expect(r.status).toBe('warn');
-  });
-
-  it('network error → fail with the message', async () => {
-    const failingFetch = (async () => {
-      throw new Error('connect ECONNREFUSED');
-    }) as typeof fetch;
-    const r = await probe('x.example.com', 'example.com', failingFetch);
-    expect(r.status).toBe('fail');
-    expect(r.detail).toMatch(/ECONNREFUSED/);
-  });
-
-  it('no public-domain suffix → 302 to anything is warn (can\'t recognise auth host)', async () => {
-    const r = await probe(
-      'vault.home.arpa',
-      null,
-      fakeFetch(new Response('', {
-        status: 302,
-        headers: { location: 'https://auth.home.arpa/' },
-      })),
-    );
-    // Without a configured publicDomain we can't tell forward-auth from
-    // any other redirect.
-    expect(r.status).toBe('warn');
   });
 });

--- a/packages/backend/src/lib/diagnose/probes/domainExternalReachability.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainExternalReachability.ts
@@ -20,6 +20,15 @@
  * so the 4 h sweep 429'd in practice. This rewrite moves continuous
  * monitoring onto DoH and keeps letsdebug as the deep-diagnostic
  * affordance.
+ *
+ * It ALSO used to fold in a per-domain `https://<domain>/` GET from inside the
+ * container (#611). That was removed: from the box's vantage the fetch is a
+ * hairpin/self-resolution that times out under concurrent diagnose load even when
+ * the service is perfectly reachable — a chronic FALSE fatal that trains operators
+ * to ignore the dashboard. The upstream-health signal it was meant to provide
+ * ("DNS green but the backend 502s") is already covered, reliably, by the
+ * `domain_unreachable` probe's Host-header fetch straight to NPM on the LAN IP — so
+ * dropping it here loses no coverage and removes the cry-wolf.
  */
 
 import { getConfig } from '@/lib/config';
@@ -117,10 +126,6 @@ async function listPublicDomains(): Promise<string[]> {
   return Array.from(new Set(hosts.filter(isPublicEntry).map(h => h.domain)));
 }
 
-async function getPublicDomainSuffix(): Promise<string | null> {
-  const config = await getConfig();
-  return config.reverseProxy?.publicDomain ?? null;
-}
 
 function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'warn' | 'fail' {
   if (a === 'fail' || b === 'fail') return 'fail';
@@ -128,103 +133,6 @@ function worst(a: 'ok' | 'warn' | 'fail', b: 'ok' | 'warn' | 'fail'): 'ok' | 'wa
   return 'ok';
 }
 
-/** Outcome of one HTTP-status check (#611). */
-interface HttpStatusResult {
-  status: 'ok' | 'warn' | 'fail';
-  detail: string;
-}
-
-/**
- * HTTP-status check for a single public domain (#611).
- *
- * Probes `https://<domain>/` from inside the ServiceBay container.
- * Caught the v4.0.x outage where every proxied service was 502-ing
- * because Authelia was crash-looping but DNS still resolved fine.
- *
- * Classification:
- *   - 2xx → ok
- *   - 3xx → ok if Location is same-origin (a relative path, or an
- *     absolute URL whose host equals `domain`) — Navidrome's `/web/`,
- *     Radicale's `/.web`, Home Assistant's `/onboarding.html` are the
- *     normal "go to my UI" redirects from a healthy backend. Also ok
- *     when Location points at `auth.<publicDomain>` (Authelia
- *     forward-auth). Cross-origin redirects to anywhere else → warn.
- *   - 401 / 403 → ok (auth-gated endpoint serving an unauthenticated
- *     request; the proxy is healthy, the app just wants creds).
- *   - 5xx → fail with the status code in the detail.
- *   - 4xx other than 401/403 → warn (some apps 404 on `/` by design,
- *     which is normal — don't fail-fast on it).
- *   - Network error / timeout → fail.
- *
- * Internal probe by design — runs from inside the container, hits the
- * local NPM. Cheap, no third-party dep, no rate limits. Catches "NPM
- * up + backend down" which is the failure mode #611 was filed for.
- * The DNS layer (Cloudflare DoH) and letsdebug already cover the
- * external-reachability question for cases where the upstream firewall
- * itself is the problem.
- */
-/** True when `location` resolves under `domain`. Accepts either a
- *  relative path (no scheme → always same-origin) or an absolute URL
- *  whose hostname equals `domain` exactly. */
-function isSameOrigin(location: string, domain: string): boolean {
-  if (!location) return false;
-  // Relative — path-only redirect, always same-origin.
-  if (!/^https?:\/\//i.test(location)) return true;
-  try {
-    return new URL(location).hostname.toLowerCase() === domain.toLowerCase();
-  } catch {
-    return false;
-  }
-}
-
-export async function probeHttpStatus(
-  domain: string,
-  publicDomain: string | null,
-  fetchImpl: typeof fetch = fetch,
-  timeoutMs = 5_000,
-): Promise<HttpStatusResult> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetchImpl(`https://${domain}/`, {
-      method: 'GET',
-      redirect: 'manual',
-      headers: { 'Accept': 'text/html,*/*' },
-      signal: controller.signal,
-    });
-    const code = res.status;
-    if (code >= 200 && code < 300) return { status: 'ok', detail: `HTTP ${code}` };
-    if (code >= 300 && code < 400) {
-      const location = res.headers.get('location') || '';
-      const authHost = publicDomain ? `auth.${publicDomain}` : null;
-      if (authHost && location.includes(authHost)) {
-        return { status: 'ok', detail: `HTTP ${code} → ${authHost} (forward-auth)` };
-      }
-      // Same-origin redirects (relative path, or absolute URL whose host
-      // matches the probed domain) are how Navidrome / Radicale / Home
-      // Assistant tell a fresh client "go to my UI" — proxy + backend are
-      // healthy, not a misroute.
-      if (location && isSameOrigin(location, domain)) {
-        return { status: 'ok', detail: `HTTP ${code} → ${location} (same-origin)` };
-      }
-      return { status: 'warn', detail: `HTTP ${code} → ${location || 'no Location header'}` };
-    }
-    if (code === 401 || code === 403) {
-      return { status: 'ok', detail: `HTTP ${code} (auth-gated, proxy healthy)` };
-    }
-    if (code >= 500) return { status: 'fail', detail: `HTTP ${code}` };
-    // 400, 404, 405, 410, etc. — common on apps that don't serve `/`.
-    return { status: 'warn', detail: `HTTP ${code}` };
-  } catch (e) {
-    const aborted = e instanceof Error && e.name === 'AbortError';
-    return {
-      status: 'fail',
-      detail: aborted ? `timeout after ${timeoutMs}ms` : (e instanceof Error ? e.message : String(e)),
-    };
-  } finally {
-    clearTimeout(timer);
-  }
-}
 
 export async function checkDomainExternalReachability(): Promise<DomainExternalReachabilityResult> {
   const publicDomains = await listPublicDomains();
@@ -235,15 +143,6 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
     };
   }
 
-  // #611 — also issue an internal HTTPS GET per domain to catch the
-  // "DNS green but upstream returning 5xx" class that v4.0.x had
-  // silently. Run in parallel so the probe round-trip stays roughly
-  // the same wall-time as the existing DNS-only path.
-  const publicDomainSuffix = await getPublicDomainSuffix();
-  const httpResults: Map<string, HttpStatusResult> = new Map();
-  await Promise.all(publicDomains.map(async domain => {
-    httpResults.set(domain, await probeHttpStatus(domain, publicDomainSuffix));
-  }));
 
   let overall: 'ok' | 'warn' | 'fail' = 'ok';
   const items: ProbeItem[] = [];
@@ -335,24 +234,6 @@ export async function checkDomainExternalReachability(): Promise<DomainExternalR
       }
     }
 
-    // #611 — fold in the HTTP-status check. Worst-of aggregation
-    // matches the existing DNS+letsdebug pattern.
-    const httpResult = httpResults.get(domain);
-    if (httpResult) {
-      const httpLayerOk = httpResult.status === 'ok';
-      const dnsLayerOk = rowStatus === 'ok';
-      if (!httpLayerOk) {
-        // Spell out which layer the operator should investigate. A
-        // DNS-green + HTTP-fail row almost always means upstream
-        // crash (the v4.0.x Authelia case) — name it so the operator
-        // doesn't re-run `dig` on a row that's already DNS-correct.
-        const hint = dnsLayerOk
-          ? 'DNS layer OK — issue is in the upstream backend (NPM → service is failing).'
-          : 'DNS layer also has findings — fix that first; HTTP may resolve once DNS is correct.';
-        rowDetail += `\n${hint} HTTPS GET: ${httpResult.detail}`;
-        rowStatus = worst(rowStatus, httpResult.status);
-      }
-    }
 
     // Skip healthy rows from the items list so the probe collapses to a happy summary.
     if (rowStatus === 'ok' && dnsPayload.matched) continue;


### PR DESCRIPTION
You nailed it: a chronically-wrong red is worse than no check — it trains you to ignore the whole dashboard. This makes the "Domains reachable" row correct so it only goes red when something's actually wrong.

## Root cause
`checkDomainExternalReachability` folded in a per-domain `https://<domain>/` GET from inside the container (#611). From the box's own vantage that's a **hairpin / self-resolution** fetch that **times out under concurrent diagnose load** — even when the services are perfectly reachable. Verified on-box every other way (LAN clients, the container's own fetch of all 10 domains, a real-external-style connect to the public IP with SNI) → all **200/302**. So the "10 fatal" was the probe, not reality, and it had been red across two different public IPs and every restart.

## Why removing it is safe (no false negative)
The "DNS-green but the backend 502s" signal that GET was meant to catch is **already** covered, reliably, by the **`domain_unreachable`** probe — it fetches NPM directly via the LAN IP with a `Host:` header (no hairpin, no public DNS). So:
- DNS misrouted → `domain_external_reachability` fails (DoH, accurate).
- Upstream down → `domain_unreachable` fails (Host-header, reliable).
- flaky hairpin GET → **gone**.

The probe is now its documented design: continuous DoH DNS-routing + on-demand letsdebug.

## Changes
Removed `probeHttpStatus` / `isSameOrigin` / the now-unused `getPublicDomainSuffix` and the #611 tests; added one asserting the probe makes **no** per-domain fetch and stays green on a DNS-correct domain. tsc + full diagnose suite (**318**) + knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
