### PR TITLE
fix(disk-import): chown the mkdir'd directory chain to core (the relabel crash-loop)

### DIFF
--- a/packages/disk-import-worker/src/engine/plan.test.ts
+++ b/packages/disk-import-worker/src/engine/plan.test.ts
@@ -154,15 +154,20 @@ describe('applyPlan — copy + chown', () => {
     expect(rsync[2].startsWith(MOUNT + '/')).toBe(true);
     expect(rsync[3].startsWith('/mnt/data/stacks/file-share/data/')).toBe(true);
 
-    const chown = calls.find(c => c[0] === 'chown')!;
-    // owner=core + group=share gid — files must end up core-owned (rsync runs via
-    // sudo → would be root otherwise; a non-core stray crash-loops file-share's
-    // :Z relabel). Never -R, never a per-user uid.
-    expect(chown).toEqual(['chown', `core:${GID}`, dest]);
-    expect(chown).not.toContain('-R');
-    expect(chown[1]).toBe(`core:${GID}`);
-    expect(chown[1]).toMatch(/^core:\d+$/);
-    expect(chown[1].startsWith('root')).toBe(false);
+    // TWO chowns to core:<gid>: the freshly-mkdir'd dir chain AND the copied file.
+    // BOTH must end up core-owned — mkdir + rsync run via sudo → root otherwise, and
+    // a non-core stray (file OR dir) crash-loops file-share's :Z relabel. Never -R,
+    // never a per-user uid.
+    const chowns = calls.filter(c => c[0] === 'chown');
+    const fileChown = chowns.find(c => c.includes(dest))!;
+    const dirChown = chowns.find(c => c.includes(resolveShareTarget('music')))!;
+    expect(fileChown).toEqual(['chown', `core:${GID}`, dest]);
+    expect(dirChown).toEqual(['chown', `core:${GID}`, resolveShareTarget('music')]);
+    for (const c of chowns) {
+      expect(c).not.toContain('-R');
+      expect(c[1]).toMatch(/^core:\d+$/);
+      expect(c[1].startsWith('root')).toBe(false);
+    }
 
     // The /mnt/data writes all run privileged (#1713): mkdir, rsync, chown.
     expect(sudoFor(calls, opts, 'mkdir')).toBe(true);
@@ -199,21 +204,54 @@ describe('applyPlan — batched mkdir/chown (#1898)', () => {
     const mkdirs = calls.filter(c => c[0] === 'mkdir');
     const rsyncs = calls.filter(c => c[0] === 'rsync');
     const chowns = calls.filter(c => c[0] === 'chown');
-    // mkdir + chown are batched: one each for the whole batch. rsync stays
-    // per-file (the byte copy + resume granularity).
+    // mkdir is batched (one for the whole batch). chown is batched too — ONE for all
+    // copied files + ONE for the dir chain — never one-per-file. rsync stays per-file.
     expect(mkdirs).toHaveLength(1);
-    expect(chowns).toHaveLength(1);
     expect(rsyncs).toHaveLength(n);
-    // The single chown carries every dest, owner=core + group=share gid, never -R.
-    expect(chowns[0][0]).toBe('chown');
-    expect(chowns[0][1]).toBe(`core:${GID}`);
-    expect(chowns[0]).not.toContain('-R');
-    expect(chowns[0].slice(2)).toEqual(items.map(i => resolveShareTarget(i.target!)));
+    expect(chowns.length).toBeLessThanOrEqual(2); // files + dirs, bounded — NOT n
+    // The FILE chown carries every dest, owner=core + group=share gid, never -R.
+    const fileChown = chowns.find(c => c.slice(2).length === n)!;
+    expect(fileChown[1]).toBe(`core:${GID}`);
+    expect(fileChown).not.toContain('-R');
+    expect(fileChown.slice(2)).toEqual(items.map(i => resolveShareTarget(i.target!)));
+    // The dir-chain chown keeps the mkdir'd dir core-owned too (#feedback_fileshare_relabel).
+    const dirChown = chowns.find(c => c.length === 3 && c[2] === '/mnt/data/stacks/file-share/data/music')!;
+    expect(dirChown).toEqual(['chown', `core:${GID}`, '/mnt/data/stacks/file-share/data/music']);
     // The single mkdir -p carries the (deduped) dest dir.
     expect(mkdirs[0]).toEqual(['mkdir', '-p', '/mnt/data/stacks/file-share/data/music']);
     expect(res.applied).toBe(n);
     expect(res.items.every(i => i.outcome === 'copied')).toBe(true);
     expect(items.every(i => catalog.has('a'.repeat(64), i.target!))).toBe(true);
+    catalog.close();
+  });
+
+  it('chowns the FULL nested dir chain to core (the audiobooks/Bro.Code/CD1 case that broke media 2026-06-21)', async () => {
+    const { exec, calls } = mockExec();
+    const catalog = new ImportCatalog(':memory:');
+    // A deep target — mkdir -p creates audiobooks/, Bro.Code/, CD1/ all root-owned.
+    const deep = item({
+      category: 'audiobooks',
+      target: 'audiobooks/Bro.Code/CD1/track.mp3',
+      record: record({ sourcePath: `${MOUNT}/track.mp3`, name: 'track.mp3' }),
+    });
+    await applyPlan(planOf(deep), baseOpts(exec, catalog, hashConst('a'.repeat(64))));
+
+    const chowns = calls.filter(c => c[0] === 'chown');
+    const chownedPaths = new Set(chowns.flatMap(c => c.slice(2)));
+    const R = '/mnt/data/stacks/file-share/data';
+    // EVERY intermediate dir mkdir created must be chowned — a single root-owned dir
+    // crash-loops the :Z relabel just like a file does.
+    expect(chownedPaths.has(`${R}/audiobooks`)).toBe(true);
+    expect(chownedPaths.has(`${R}/audiobooks/Bro.Code`)).toBe(true);
+    expect(chownedPaths.has(`${R}/audiobooks/Bro.Code/CD1`)).toBe(true);
+    expect(chownedPaths.has(`${R}/audiobooks/Bro.Code/CD1/track.mp3`)).toBe(true); // the file
+    // The share data ROOT itself is never chowned (file-share owns it).
+    expect(chownedPaths.has(R)).toBe(false);
+    // All chowns are core:<gid>, never root, never -R.
+    for (const c of chowns) {
+      expect(c[1]).toBe(`core:${GID}`);
+      expect(c).not.toContain('-R');
+    }
     catalog.close();
   });
 });

--- a/packages/disk-import-worker/src/engine/plan.ts
+++ b/packages/disk-import-worker/src/engine/plan.ts
@@ -34,6 +34,7 @@ import { ImportCatalog, type CatalogEntry } from './catalog';
 import {
   resolveShareTarget,
   resolveSupersededPath,
+  SHARE_DATA_ROOT,
   type SafeExec,
 } from './hostExec';
 import type {
@@ -316,6 +317,13 @@ async function copyBatch(
   // still hold — every dest was resolved under file-share/data/).
   const dirs = [...new Set(jobs.map(j => j.dest.slice(0, j.dest.lastIndexOf('/'))))];
   await runOk(ctx.exec, ['mkdir', '-p', ...dirs], 'mkdir dest dirs', { sudo: true });
+  // `mkdir -p` runs via sudo, so the directories it just created land ROOT-owned.
+  // The file-chown (#8fbf6aaf) only covers the copied files — it missed the dirs.
+  // A non-`core` DIRECTORY under file-share's `:Z` data dir crash-loops the stack
+  // on the next redeploy exactly like a non-core file does (this took media down
+  // 2026-06-21: 6k root-owned import dirs broke the SELinux relabel →
+  // feedback_fileshare_relabel_crashloop). Chown the freshly-created dir chain too.
+  await chownShareDirChain(dirs, ctx);
 
   // rsync each file (per-file byte copy, no globbing / --delete), advancing the
   // progress cursor as we go so the live count still ticks within the batch.
@@ -375,7 +383,39 @@ async function supersedeExisting(target: string, ctx: ItemCtx): Promise<void> {
   // resolved under file-share/data/ (resolveShareTarget / resolveSupersededPath)
   // — neither can escape the share root.
   await runOk(ctx.exec, ['mkdir', '-p', parkedDir], 'mkdir superseded dir', { sudo: true });
+  // Same root-owned-dir trap as copyBatch: the `_superseded/<date>/…` dirs mkdir
+  // just created are root-owned (sudo) and would otherwise crash-loop the stack.
+  await chownShareDirChain([parkedDir], ctx);
   await runOk(ctx.exec, ['mv', current, parked], 'mv to _superseded', { sudo: true });
+}
+
+/**
+ * Chown to `core:<shareGid>` every directory `mkdir -p` may have freshly created:
+ * each given dir AND its ancestors UP TO (but excluding) {@link SHARE_DATA_ROOT}.
+ * `mkdir -p` runs via sudo, so new dirs land root-owned; DIRECTORIES must stay
+ * core-owned just like files or the next `:Z` relabel fails
+ * (feedback_fileshare_relabel_crashloop). Idempotent — re-chowning an
+ * already-core dir is a no-op, and the share data root itself is never touched.
+ * Path-safe: every input is a resolved dest under file-share/data/.
+ */
+function shareDirChain(dirs: string[]): string[] {
+  const set = new Set<string>();
+  for (const dir of dirs) {
+    let cur = dir;
+    while (cur.length > SHARE_DATA_ROOT.length && cur.startsWith(`${SHARE_DATA_ROOT}/`)) {
+      set.add(cur);
+      const slash = cur.lastIndexOf('/');
+      if (slash <= 0) break;
+      cur = cur.slice(0, slash);
+    }
+  }
+  return [...set];
+}
+
+async function chownShareDirChain(dirs: string[], ctx: ItemCtx): Promise<void> {
+  const chain = shareDirChain(dirs);
+  if (chain.length === 0) return;
+  await runOk(ctx.exec, ['chown', `core:${ctx.shareGid}`, ...chain], 'chown dest dirs', { sudo: true });
 }
 
 function catalogEntry(sha: string, target: string, record: ImportRecord, atMs: number): CatalogEntry {


### PR DESCRIPTION
The disk-import bug that took the **media pod down 2026-06-21**.

## Bug
The apply's `mkdir -p <dirs>` runs via `sudo`, so every directory it creates lands **root-owned**. The file-chown (8fbf6aaf) only chowns the copied **files** — never those directories. A single non-`core` directory under file-share's `:Z` data dir crash-loops the stack on the next redeploy exactly like a non-core file does (`feedback_fileshare_relabel_crashloop`).

On the box, ~6,000 root-owned import directories under `file-share/data/audiobooks/…` failed the rootless SELinux relabel (`lsetxattr … operation not permitted` as `core`) → `kube play` exit 125 → Jellyfin + file-share couldn't restart. Dormant because a *running* pod doesn't relabel; the next reboot/redeploy would have hit it regardless.

## Fix
A `shareDirChain` helper chowns `core:<shareGid>` every directory `mkdir -p` may have freshly created — each dest dir **and its ancestors up to (excluding) `SHARE_DATA_ROOT`** — in both the copy batch and the `_superseded` move path. Idempotent, never recursive, never touches the share root, path-safe (all inputs resolved under `file-share/data/`).

## Tests
File + dir chown both asserted `core:gid`; the exact deep `audiobooks/Bro.Code/CD1` case asserts every intermediate dir is chowned and the data root never is. 28 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)