### PR TITLE
feat(media+diagnose): rename Jellyfin subdomain to media; verify its LDAP login end-to-end

### DIFF
--- a/packages/backend/src/lib/diagnose/ssoVerify.test.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.test.ts
@@ -21,6 +21,7 @@ import {
   classifyOidcRedirect,
   realProbeOidcAuthorization,
   realProbeAdminDecision,
+  realProbeJellyfinLogin,
   extractAutheliaCookie,
   extractOauthError,
   makeEphemeralUsername,
@@ -30,9 +31,11 @@ import {
   FORWARD_AUTH_DERIVED_SUBDOMAINS,
   ADMIN_ONLY_HOSTS,
   probeableUserSubdomains,
+  classifyJellyfinLogin,
   type SsoVerifyDeps,
   type DomainProbe,
   type OidcAuthProbe,
+  type JellyfinLoginProbe,
 } from './ssoVerify';
 
 const tmpl = (n: string) => ({ [n]: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' } });
@@ -40,7 +43,9 @@ const tmpl = (n: string) => ({ [n]: { schemaVersion: 1, installedAt: '2026-05-01
 // A "full" install: auth + every template that backs a user subdomain. Used
 // by the happy-path tests so all USER_APP_SIGNATURES hosts are probed.
 const fullTemplates = Object.assign(
-  { auth: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' } },
+  // `media` (Jellyfin) is checked via probeJellyfinLogin, not SUBDOMAIN_TEMPLATE,
+  // so it's added explicitly here for the happy-path login probe to run.
+  { auth: { schemaVersion: 1, installedAt: '2026-05-01T00:00:00Z' }, ...tmpl('media') },
   ...[...new Set(Object.values(SUBDOMAIN_TEMPLATE))].map(tmpl),
 );
 
@@ -80,6 +85,8 @@ function happyDeps(opts: { forwardAuthHosts?: string[] } = {}): { deps: SsoVerif
     probeOidcAuthorization: vi.fn(async (_pd: string, clientId: string, _redirectUri: string): Promise<OidcAuthProbe> => ({
       ok: true, code: 302, detail: `code issued for ${clientId}`,
     })),
+    // Jellyfin LDAP login succeeds by default (plugin healthy).
+    probeJellyfinLogin: vi.fn(async (): Promise<JellyfinLoginProbe> => ({ ok: true, code: 200, detail: 'LDAP-Auth healthy' })),
   };
   return { deps, calls };
 }
@@ -96,10 +103,11 @@ describe('verifySso orchestrator', () => {
 
     expect(report.ok).toBe(true);
     expect(report.cleanedUp).toBe(true);
-    // every templated user app + every admin host probed (ollama is gated on
-    // actual forward-auth, off by default here).
+    // every templated user app + the Jellyfin (media) LDAP-login entry + every
+    // admin host probed (ollama is gated on actual forward-auth, off by default here).
     const templatedHosts = Object.keys(USER_APP_SIGNATURES).filter(h => SUBDOMAIN_TEMPLATE[h]);
-    expect(report.userDomains).toHaveLength(templatedHosts.length);
+    expect(report.userDomains).toHaveLength(templatedHosts.length + 1); // +1 = media (Jellyfin) login
+    expect(report.userDomains.some(d => d.domain === 'media.dopp.cloud')).toBe(true);
     expect(report.adminDomains).toHaveLength(ADMIN_ONLY_HOSTS.length);
     // ephemeral user deleted exactly once, matching the reported username
     expect(calls.deleted).toEqual([report.ephemeralUser]);
@@ -403,6 +411,56 @@ describe('realProbeAdminDecision — asks Authelia /api/authz/auth-request direc
   });
 });
 
+describe('realProbeJellyfinLogin — logs the ephemeral user into Jellyfin via LDAP-Auth', () => {
+  const jres = (status: number, body: unknown = {}) => ({ status, json: async () => body } as unknown as Response);
+  afterEach(() => vi.restoreAllMocks());
+
+  it('passes on a 200 + AccessToken and cleans up the auto-created profile', async () => {
+    mockGetConfig.mockResolvedValue({ installedSecrets: [{ varName: 'JELLYFIN_ADMIN_PASSWORD', password: 'adminpw' }] });
+    const deletes: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const u = String(url);
+      if ((init?.method ?? 'GET') === 'DELETE') { deletes.push(u); return jres(204); }
+      const username = JSON.parse(String(init?.body)).Username as string;
+      return jres(200, { AccessToken: username === 'admin' ? 'admintok' : 'usertok', User: { Id: 'ephem-jf-id' } });
+    });
+    const r = await realProbeJellyfinLogin('sb-ssoverify-x', 'pw');
+    expect(r.ok).toBe(true);
+    expect(r.code).toBe(200);
+    expect(deletes.some(u => u.includes('/Users/ephem-jf-id'))).toBe(true); // orphan profile deleted
+  });
+
+  it('fails RED on a 401 — the LDAP-Auth plugin missing/misconfigured', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jres(401));
+    const r = await realProbeJellyfinLogin('sb-ssoverify-x', 'pw');
+    expect(r).toMatchObject({ ok: false, code: 401 });
+    expect(r.detail).toMatch(/LDAP-Auth plugin/);
+  });
+
+  it('fails on a 200 with no AccessToken (not actually authenticating)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jres(200, {}));
+    const r = await realProbeJellyfinLogin('sb-ssoverify-x', 'pw');
+    expect(r).toMatchObject({ ok: false, code: 200 });
+  });
+
+  it('still PASSES the login even when cleanup is impossible (admin creds absent)', async () => {
+    mockGetConfig.mockResolvedValue({ installedSecrets: [] }); // no JELLYFIN_ADMIN_PASSWORD
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_u, init) => {
+      const username = JSON.parse(String(init?.body)).Username as string;
+      return jres(200, { AccessToken: username === 'admin' ? 'admintok' : 'usertok', User: { Id: 'id' } });
+    });
+    const r = await realProbeJellyfinLogin('sb-ssoverify-x', 'pw');
+    expect(r.ok).toBe(true); // login result must not hinge on cleanup
+    expect(r.detail).toMatch(/left behind/);
+  });
+
+  it('returns a transport failure when fetch throws', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const r = await realProbeJellyfinLogin('sb-ssoverify-x', 'pw');
+    expect(r).toMatchObject({ ok: false, code: 0 });
+  });
+});
+
 describe('classifyOidcRedirect — Location-header outcome (#sso-redirect-uri)', () => {
   it('passes a code= redirect (full handshake)', () => {
     const r = classifyOidcRedirect('https://photos.dopp.cloud/auth/login?code=abc&state=x', 302);
@@ -487,7 +545,7 @@ describe('verifySso — ollama is admin-only, never probed as a family app', () 
 });
 
 describe('verifySso — #1685 OIDC apps exercise the real handshake', () => {
-  it('drives the OIDC authorization flow for vault/photos/books (not just reachability)', async () => {
+  it('drives the OIDC authorization flow for vault/photos (not just reachability)', async () => {
     const { deps } = happyDeps();
     const report = await verifySso({ deps });
 
@@ -498,7 +556,41 @@ describe('verifySso — #1685 OIDC apps exercise the real handshake', () => {
     // otherwise Authelia rejects an unregistered redirect_uri for every client.
     expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'immich', 'https://photos.dopp.cloud/auth/login', expect.any(String));
     expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'vaultwarden', 'https://vault.dopp.cloud/identity/connect/oidc-signin', expect.any(String));
-    expect(deps.probeOidcAuthorization).toHaveBeenCalledWith('dopp.cloud', 'audiobookshelf', 'https://books.dopp.cloud/auth/login', expect.any(String));
+    // `books`/audiobookshelf was retired — Jellyfin serves audiobooks via LDAP now.
+    expect(deps.probeOidcAuthorization).not.toHaveBeenCalledWith('dopp.cloud', 'audiobookshelf', expect.anything(), expect.anything());
+  });
+
+  it('verifies Jellyfin (media) by actually logging the ephemeral user in via LDAP-Auth', async () => {
+    const { deps } = happyDeps();
+    const report = await verifySso({ deps });
+    expect(report.ok).toBe(true);
+    expect(deps.probeJellyfinLogin).toHaveBeenCalledWith(expect.stringContaining('sb-ssoverify-'), expect.any(String));
+    const media = report.userDomains.find(d => d.domain === 'media.dopp.cloud')!;
+    expect(media.status).toBe('pass');
+  });
+
+  it('a BROKEN Jellyfin login (missing LDAP-Auth plugin) fails the run RED — the 2026-06-21 silent break', async () => {
+    const { deps } = happyDeps();
+    deps.probeJellyfinLogin = vi.fn(async (): Promise<JellyfinLoginProbe> => ({
+      ok: false, code: 401, detail: 'Jellyfin rejected the LLDAP login (HTTP 401) — LDAP-Auth plugin missing',
+    }));
+    const report = await verifySso({ deps });
+    const media = report.userDomains.find(d => d.domain === 'media.dopp.cloud')!;
+    expect(media.status).toBe('fail');
+    expect(report.ok).toBe(false); // a broken Jellyfin login is loud, not silent
+  });
+
+  it('does NOT probe Jellyfin when the media template is not installed', async () => {
+    const { deps } = happyDeps();
+    mockGetConfig.mockResolvedValue({ reverseProxy: { publicDomain: 'dopp.cloud' }, installedTemplates: tmpl('vaultwarden') });
+    await verifySso({ deps });
+    expect(deps.probeJellyfinLogin).not.toHaveBeenCalled();
+  });
+
+  it('classifyJellyfinLogin: pass on ok, fail on rejection, skip on transport error', () => {
+    expect(classifyJellyfinLogin('media.dopp.cloud', { ok: true, code: 200, detail: 'healthy' }).status).toBe('pass');
+    expect(classifyJellyfinLogin('media.dopp.cloud', { ok: false, code: 401, detail: 'plugin missing' }).status).toBe('fail');
+    expect(classifyJellyfinLogin('media.dopp.cloud', { ok: false, code: 0, detail: 'ECONNREFUSED' }).status).toBe('skip');
   });
 
   it('catches an invalid_client OIDC app RED even though its page loads 200 (#1559)', async () => {

--- a/packages/backend/src/lib/diagnose/ssoVerify.ts
+++ b/packages/backend/src/lib/diagnose/ssoVerify.ts
@@ -69,12 +69,17 @@ const SET_PASSWORD_TIMEOUT_MS = 15_000;
 export const USER_APP_SIGNATURES: Readonly<Record<string, string>> = {
   vault: 'Vaultwarden Web',
   photos: '',
-  music: '',
-  books: 'Audiobookshelf',
   home: '',
   files: '',
   sync: '',
   caldav: '',
+  // `music`/`books` were RETIRED: Jellyfin is one general media server at
+  // `media.<domain>` now (#media-rename), and it does its OWN auth (LDAP-Auth →
+  // LLDAP), NOT Authelia forward-auth/OIDC — so a reachability probe here told us
+  // nothing about whether login works (it 200s on the login page regardless). It
+  // is verified end-to-end instead by the dedicated Jellyfin LDAP-login check
+  // below (probeJellyfinLogin) — that's what would have caught the missing
+  // LDAP-Auth plugin that locked everyone out 2026-06-21.
   // ollama is intentionally absent: it's admin-only, not a family-reachable app
   // (the chat uses ollama over internal loopback, not this gated host). See
   // FORWARD_AUTH_DERIVED_SUBDOMAINS.
@@ -89,12 +94,12 @@ export const USER_APP_SIGNATURES: Readonly<Record<string, string>> = {
 export const SUBDOMAIN_TEMPLATE: Readonly<Record<string, string>> = {
   vault: 'vaultwarden',
   photos: 'immich',
-  music: 'media',
-  books: 'media',
   home: 'home-assistant',
   files: 'file-share',
   sync: 'file-share',
   caldav: 'radicale',
+  // `media` (Jellyfin) is intentionally absent — it isn't a forward-auth/OIDC
+  // host; its login is verified by probeJellyfinLogin, gated on installedTemplates.media.
 };
 
 /**
@@ -133,7 +138,8 @@ export const FORWARD_AUTH_DERIVED_SUBDOMAINS: readonly string[] = [];
 export const OIDC_CLIENT_SUBDOMAINS: Readonly<Record<string, { clientId: string; redirectPath: string }>> = {
   vault: { clientId: 'vaultwarden', redirectPath: '/identity/connect/oidc-signin' },
   photos: { clientId: 'immich', redirectPath: '/auth/login' },
-  books: { clientId: 'audiobookshelf', redirectPath: '/auth/login' },
+  // `books`/audiobookshelf was retired (#1725) — Jellyfin serves audiobooks now
+  // and authenticates via LDAP, not OIDC. Verified by probeJellyfinLogin instead.
 };
 
 /**
@@ -198,6 +204,15 @@ export interface OidcAuthProbe {
   detail: string;
 }
 
+/** Outcome of attempting a real Jellyfin login as the ephemeral LLDAP user.
+ *  `ok` ⇒ Jellyfin's LDAP-Auth plugin authenticated the LLDAP user end-to-end. */
+export interface JellyfinLoginProbe {
+  ok: boolean;
+  /** HTTP status of /Users/AuthenticateByName (0 = transport error). */
+  code: number;
+  detail: string;
+}
+
 export interface SsoVerifyDeps {
   createUser: typeof createLldapUser;
   addToGroup: typeof addUserToLldapGroup;
@@ -243,6 +258,11 @@ export interface SsoVerifyDeps {
     redirectUri: string,
     cookie: string,
   ) => Promise<OidcAuthProbe>;
+  /** Log into Jellyfin (`media`) AS the ephemeral LLDAP user via its LDAP-Auth
+   *  plugin — the only end-to-end check that the plugin is installed AND can bind
+   *  LLDAP. Jellyfin does its own auth (not Authelia), so nothing else covers this;
+   *  a missing plugin silently locked everyone out 2026-06-21. */
+  probeJellyfinLogin: (ephemeralUser: string, password: string) => Promise<JellyfinLoginProbe>;
 }
 
 export interface SsoVerifyOptions {
@@ -345,6 +365,20 @@ export function classifyOidcAuthorization(host: string, clientId: string, probe:
     return { domain, status: 'fail', code: 0, detail: `OIDC authorization for "${clientId}" did not respond: ${probe.detail}` };
   }
   return { domain, status: 'fail', code: probe.code, detail: `OIDC authorization for "${clientId}" did not reach a redirect (HTTP ${probe.code}): ${probe.detail}` };
+}
+
+/** Classify the Jellyfin LDAP-login probe. `ok` ⇒ the LDAP-Auth plugin
+ *  authenticated the LLDAP user end-to-end (plugin installed + LLDAP bind works).
+ *  A transport error (code 0) is "couldn't test" (skip) — Jellyfin may simply be
+ *  down/restarting — not a login-broken fail that scares toward a reinstall. */
+export function classifyJellyfinLogin(host: string, probe: JellyfinLoginProbe): SsoDomainResult {
+  if (probe.ok) {
+    return { domain: host, status: 'pass', code: probe.code, detail: probe.detail };
+  }
+  if (probe.code === 0) {
+    return { domain: host, status: 'skip', code: 0, detail: `Jellyfin LDAP-login probe could not run (Jellyfin unreachable): ${probe.detail}` };
+  }
+  return { domain: host, status: 'fail', code: probe.code, detail: probe.detail };
 }
 
 /** Pull the `authelia_session` cookie value out of a Set-Cookie header list. */
@@ -618,6 +652,86 @@ export async function realProbeOidcAuthorization(
   }
 }
 
+// Jellyfin's fixed container port (templates/media/template.yml) + the
+// X-Emby-Authorization client identifier every /Users/AuthenticateByName needs
+// (the server 400s without it).
+const JELLYFIN_PORT = 8096;
+function jellyfinAuthHeader(deviceId: string, token?: string): string {
+  const base = `MediaBrowser Client="servicebay-ssoverify", Device="servicebay", DeviceId="${deviceId}", Version="1"`;
+  return token ? `${base}, Token="${token}"` : base;
+}
+
+/** Log into Jellyfin AS the ephemeral LLDAP user through its LDAP-Auth plugin.
+ *  A `200` + AccessToken proves the plugin is installed AND bound LLDAP — the only
+ *  end-to-end check of Jellyfin's (non-Authelia) auth. `401` ⇒ the plugin is
+ *  missing/misconfigured (the exact silent break of 2026-06-21). A successful
+ *  login auto-creates a Jellyfin profile (`CreateUsersFromLdap`), so we delete it
+ *  again (best-effort, via the stored admin creds) to avoid orphan accrual. */
+export async function realProbeJellyfinLogin(ephemeralUser: string, password: string): Promise<JellyfinLoginProbe> {
+  const base = `http://127.0.0.1:${JELLYFIN_PORT}`;
+  const deviceId = `sb-ssoverify-${randomBytes(3).toString('hex')}`;
+  try {
+    const res = await fetch(`${base}/Users/AuthenticateByName`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Emby-Authorization': jellyfinAuthHeader(deviceId) },
+      body: JSON.stringify({ Username: ephemeralUser, Pw: password }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    if (res.status !== 200) {
+      return {
+        ok: false,
+        code: res.status,
+        detail: `Jellyfin rejected the LLDAP login (HTTP ${res.status}) — LDAP-Auth plugin missing or its LLDAP bind is broken`,
+      };
+    }
+    const body = (await res.json().catch(() => null)) as { AccessToken?: string; User?: { Id?: string } } | null;
+    if (!body?.AccessToken) {
+      return { ok: false, code: 200, detail: 'Jellyfin returned 200 but no AccessToken — LDAP-Auth not actually authenticating' };
+    }
+    const cleaned = await cleanupJellyfinProfile(base, body.User?.Id);
+    return {
+      ok: true,
+      code: 200,
+      detail: cleaned
+        ? 'Jellyfin authenticated the LLDAP user (LDAP-Auth plugin healthy)'
+        : 'Jellyfin authenticated the LLDAP user (LDAP-Auth healthy) — but the ephemeral test profile was left behind (admin cleanup unavailable)',
+    };
+  } catch (e) {
+    return { ok: false, code: 0, detail: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Delete the Jellyfin profile auto-created by the probe login. Best-effort:
+ *  mints an admin token from the stored `JELLYFIN_ADMIN_PASSWORD` (decrypted by
+ *  getConfig) and DELETEs the user. Returns false (never throws) when the admin
+ *  creds are unavailable/drifted — the login result must not hinge on cleanup. */
+export async function cleanupJellyfinProfile(base: string, userId: string | undefined): Promise<boolean> {
+  if (!userId) return false;
+  try {
+    const config = await getConfig();
+    const adminPw = config.installedSecrets?.find(s => s.varName === 'JELLYFIN_ADMIN_PASSWORD')?.password;
+    if (!adminPw) return false;
+    const deviceId = `sb-ssoverify-cleanup-${randomBytes(3).toString('hex')}`;
+    const auth = await fetch(`${base}/Users/AuthenticateByName`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Emby-Authorization': jellyfinAuthHeader(deviceId) },
+      body: JSON.stringify({ Username: 'admin', Pw: adminPw }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    if (auth.status !== 200) return false;
+    const token = ((await auth.json().catch(() => null)) as { AccessToken?: string } | null)?.AccessToken;
+    if (!token) return false;
+    const del = await fetch(`${base}/Users/${userId}`, {
+      method: 'DELETE',
+      headers: { 'X-Emby-Authorization': jellyfinAuthHeader(deviceId, token) },
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    return del.status === 200 || del.status === 204;
+  } catch {
+    return false;
+  }
+}
+
 /** Pull an OAuth2 `error=` code out of a redirect Location or a JSON/HTML
  *  error body. Returns the bare error token (e.g. `invalid_client`). */
 export function extractOauthError(text: string): string | undefined {
@@ -640,6 +754,7 @@ function buildDeps(node: string, overrides?: Partial<SsoVerifyDeps>): SsoVerifyD
     probeAdminDecision: realProbeAdminDecision,
     hostHasForwardAuth: realHostHasForwardAuth(node),
     probeOidcAuthorization: realProbeOidcAuthorization,
+    probeJellyfinLogin: realProbeJellyfinLogin,
     ...overrides,
   };
 }
@@ -770,6 +885,14 @@ async function probeAllDomains(deps: SsoVerifyDeps, run: SsoRun, cookie: string)
   }
   for (const host of await forwardAuthDerivedHosts(deps, run)) {
     await probeForwardAuthHost(deps, run, host, cookie);
+  }
+  // Jellyfin (`media`) authenticates via its OWN LDAP-Auth plugin → LLDAP, NOT
+  // Authelia — so the forward-auth/OIDC probes above never touch it. Verify it
+  // end-to-end by actually logging the ephemeral user in. Gated on the `media`
+  // template being installed (no false-fail on a box without Jellyfin).
+  if (run.installedTemplates.media != null) {
+    const probe = await deps.probeJellyfinLogin(run.ephemeralUser, run.password);
+    run.userDomains.push(classifyJellyfinLogin(`media.${run.publicDomain}`, probe));
   }
   for (const host of ADMIN_ONLY_HOSTS) {
     const probe = await deps.probeAdminDecision(run.publicDomain, host, cookie);

--- a/templates/media/README.md
+++ b/templates/media/README.md
@@ -29,7 +29,7 @@ Override `JELLYFIN_MEDIA_PATH` in the wizard's Configure step if your media live
 
 ## Subdomains
 
-* `https://music.<your-domain>` → Jellyfin (LLDAP login; mobile apps via Quick Connect)
+* `https://media.<your-domain>` → Jellyfin (LLDAP login; mobile apps via Quick Connect)
 
 ## Data Layout
 

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -85,8 +85,8 @@
   },
   "MEDIA_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for Jellyfin (web UI + Symfonium/Findroid/Streamyfin endpoint). Quick Connect handles mobile-app pairing — the app shows a 6-digit code, you confirm it once in the web UI (which can be SSO'd via jellyfin-plugin-sso if installed) and the app is paired without a shared password.",
-    "default": "music",
+    "description": "Subdomain for Jellyfin — the general media server (music + audiobooks + video), so `media` fits better than the old per-content `music`/`books`. Web UI + Symfonium/Findroid/Streamyfin endpoint. Quick Connect handles mobile-app pairing — the app shows a 6-digit code, you confirm it once in the web UI and the app is paired without a shared password.",
+    "default": "media",
     "exposure": "public",
     "proxyPort": "JELLYFIN_PORT",
     "proxyConfig": {


### PR DESCRIPTION
The persistence + loud-failure half of the Jellyfin incident follow-up.

## 1. `MEDIA_SUBDOMAIN` default `music` → `media`
Jellyfin is one general media server (music + audiobooks + video), so `media.<domain>` fits — `music`/`books` were per-content leftovers (the live box is already switched; this makes it the default so a reinstall keeps `media`).

## 2. sso_verify now actually tests Jellyfin login
**This is the gap that let the incident happen silently.** Jellyfin authenticates via its **own LDAP-Auth plugin → LLDAP**, not Authelia — so the existing forward-auth/OIDC probes never touched it, and a reachability check only proved the login *page* renders. When the plugin went missing, every dashboard signal stayed green while nobody could log in.

Now, when `media` is installed, the run **logs the ephemeral LLDAP user into Jellyfin** (`/Users/AuthenticateByName`); a `401` fails the run **RED**. The auto-created (`CreateUsersFromLdap`) test profile is deleted afterward — best-effort via the stored admin creds; the login verdict never hinges on cleanup.

Retired the now-dead `music`/`books` SSO probes (deleted subdomains; `audiobookshelf` OIDC was already retired in #1725) so they don't start false-failing post-rename.

## Tests
New `JellyfinLoginProbe` / `classifyJellyfinLogin` / `realProbeJellyfinLogin` + `cleanupJellyfinProfile`. **66** sso_verify tests — orchestrator wiring incl. the **RED-on-broken-login** case, the classifier, and 5 fetch-mock cases. **100% diff-coverage**; full diagnose suite (327) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)