### PR TITLE
feat: mobile nav, disk-import worker refresh, audiobooks→Bookshelf, per-service Operate page

### DIFF
--- a/packages/backend/src/lib/diskImport/launcher.test.ts
+++ b/packages/backend/src/lib/diskImport/launcher.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/hostDataDir', () => ({
   resolveHostDataDir: vi.fn(async () => '/data'),
 }));
 
-import { launchWorker, readStatus, isWorkerRunning, stopWorker, cleanupRunMount, ensureWorkerImage, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
+import { launchWorker, readStatus, isWorkerRunning, stopWorker, cleanupRunMount, ensureWorkerImage, refreshWorkerImage, WORKER_IMAGE, WORKER_MEMORY } from './launcher';
 import { resolveImmichProvisionEnv } from './immichProvisionEnv';
 import type { SafeExec } from '@servicebay/disk-import-worker';
 
@@ -213,6 +213,30 @@ describe('ensureWorkerImage', () => {
       return { stdout: '', stderr: '', code: argv[1] === 'image' ? 1 : 0 };
     });
     await ensureWorkerImage(exec);
+    expect(optsSeen[0]?.timeoutMs).toBeGreaterThanOrEqual(120_000);
+  });
+});
+
+describe('refreshWorkerImage', () => {
+  // #1995: the scan hot path only pulls when the image is MISSING (#1993), so a
+  // `:latest` worker rebuild never reaches the box without this out-of-band
+  // refresh. Unlike ensureWorkerImage it must ALWAYS pull (and must NOT gate on
+  // `podman image exists`), so a present-but-stale image gets the new build.
+  it('always pulls, even when the image is already present', async () => {
+    const { exec, calls } = recExec({ 'podman image exists': { code: 0 } });
+    await refreshWorkerImage(exec);
+    expect(calls).toContainEqual(['podman', 'pull', WORKER_IMAGE]);
+    // No `image exists` gate — refresh is unconditional.
+    expect(calls.some(c => c[1] === 'image' && c[2] === 'exists')).toBe(false);
+  });
+
+  it('passes a generous timeout so a slow pull does not trip the 30s default', async () => {
+    const optsSeen: Array<{ timeoutMs?: number } | undefined> = [];
+    const exec: SafeExec = vi.fn(async (argv: string[], options?: { timeoutMs?: number; sudo?: boolean }) => {
+      if (argv[0] === 'podman' && argv[1] === 'pull') optsSeen.push(options);
+      return { stdout: '', stderr: '', code: 0 };
+    });
+    await refreshWorkerImage(exec);
     expect(optsSeen[0]?.timeoutMs).toBeGreaterThanOrEqual(120_000);
   });
 });

--- a/packages/backend/src/lib/diskImport/launcher.ts
+++ b/packages/backend/src/lib/diskImport/launcher.ts
@@ -256,3 +256,22 @@ export async function ensureWorkerImage(exec: SafeExec): Promise<void> {
   if (code === 0) return; // already present — don't re-pull on the scan hot path
   await exec(['podman', 'pull', WORKER_IMAGE], { timeoutMs: SLOW_OP_TIMEOUT_MS });
 }
+
+/**
+ * Refresh the worker image OUT-OF-BAND — always `podman pull`, regardless of
+ * whether it's already present. This is the counterpart to {@link ensureWorkerImage}'s
+ * pull-only-when-missing hot-path behaviour (#1993): since the scan path never
+ * re-pulls a present image, a `:latest` worker rebuild (build-images.yml on main)
+ * would otherwise never reach the box — a worker-side fix needed a manual
+ * `podman pull` (#1995). Call this in the BACKGROUND on servicebay startup/update
+ * (off the scan hot path) so the next scan picks up the current image without a
+ * manual pull and without the 30s-timeout regression the hot-path pull caused.
+ *
+ * Best-effort: a pull failure (offline box, registry hiccup) is logged-and-swallowed
+ * by the caller, never thrown — a stale-but-present image is still usable; the next
+ * startup retries. Uses the same generous timeout as the cold pull so a slow
+ * registry round-trip doesn't trip the agent's 30s default.
+ */
+export async function refreshWorkerImage(exec: SafeExec): Promise<void> {
+  await exec(['podman', 'pull', WORKER_IMAGE], { timeoutMs: SLOW_OP_TIMEOUT_MS });
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -698,6 +698,31 @@ app.prepare().then(() => {
       );
     }, 60_000);
 
+    // Refresh the disk-import worker image in the BACKGROUND on startup (#1995).
+    // The scan hot path only pulls the worker image when it's MISSING (#1993 —
+    // re-pulling on every scan blew the agent's 30s timeout), so a `:latest`
+    // worker rebuild shipped by build-images.yml would otherwise never reach the
+    // box without a manual `podman pull`. A servicebay update restarts this
+    // process, so doing the pull here makes "update servicebay" also refresh the
+    // worker image. Deferred 90s (after the agent + podman socket are up),
+    // fire-and-forget, best-effort: a failure is logged and the next startup
+    // retries; a stale-but-present image still works for the next scan. Off the
+    // hot path, so no 30s-timeout regression.
+    setTimeout(() => {
+      void (async () => {
+        try {
+          const { AgentExecutor } = await import('./lib/agent/executor');
+          const { refreshWorkerImage } = await import('./lib/diskImport/launcher');
+          const node = (await listNodes())[0]?.Name ?? 'Local';
+          const executor = new AgentExecutor(node);
+          await refreshWorkerImage((argv, options) => executor.execSafe(argv, options ?? {}));
+          logger.info('Server', 'Disk-import worker image refreshed in background.');
+        } catch (err) {
+          logger.warn('Server', `Disk-import worker image refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })();
+    }, 90_000);
+
     // Auto-update logic to be migrated to Executor Task
   });
 });

--- a/packages/disk-import-worker/src/engine/dedup.test.ts
+++ b/packages/disk-import-worker/src/engine/dedup.test.ts
@@ -497,4 +497,38 @@ describe('buildPlan — per-category layout + identity (#2006 redesign)', () => 
     });
     expect(result.conflicts).toHaveLength(0);
   });
+
+  it('audiobooks flatten disc folders AND dedupe byte-identical copies at DIFFERENT paths (#2028)', () => {
+    // The real box case: `hoerspiele/Bro.Code/CD1/…` was a byte-identical copy of
+    // `Bro.Code/CD1/…`. The disc folders flatten into the book folder (disc-prefixed)
+    // and the cross-path identical copy is deduped by CONTENT (not by relative path).
+    const files: ScannedFile[] = [
+      { path: '/disk/Bro.Code/CD1/01.mp3', size: 100, mtimeMs: 0 },
+      { path: '/disk/Bro.Code/CD2/01.mp3', size: 200, mtimeMs: 0 }, // distinct disc-2 track
+      { path: '/disk/hoerspiele/Bro.Code/CD1/01.mp3', size: 100, mtimeMs: 0 }, // identical bytes to CD1/01
+    ];
+    const fixture = {
+      '/disk/Bro.Code/CD1/01.mp3': sha('a'),
+      '/disk/Bro.Code/CD2/01.mp3': sha('b'),
+      '/disk/hoerspiele/Bro.Code/CD1/01.mp3': sha('a'),
+    };
+    const result = buildPlan(buildInventory(files), hasherFrom(fixture), {
+      // The whole disk is marked audiobooks at the ROOT (anchor stays root), so the
+      // book folder (`Bro.Code`) is preserved while disc subfolders flatten into it.
+      routing: routingFor({ '': { disposition: 'audiobooks' } }),
+      // Force the size-collision fingerprint pass to confirm true content dedup.
+      fingerprintOf: hasherFrom(fixture),
+    });
+    // Disc folders flattened into the book folder with collision-safe disc prefixes.
+    expect(itemOf(result.items, '/disk/Bro.Code/CD1/01.mp3')).toMatchObject({
+      action: 'copy', target: 'audiobooks/Bro.Code/d01-01.mp3',
+    });
+    expect(itemOf(result.items, '/disk/Bro.Code/CD2/01.mp3')).toMatchObject({
+      action: 'copy', target: 'audiobooks/Bro.Code/d02-01.mp3',
+    });
+    // The cross-path byte-identical copy is deduped by content (same area `shared`),
+    // even though its source path differed — the gap #2028 closes.
+    expect(actionOf(result.items, '/disk/hoerspiele/Bro.Code/CD1/01.mp3')).toBe('skip-dupe');
+    expect(result.conflicts).toHaveLength(0);
+  });
 });

--- a/packages/disk-import-worker/src/engine/routing.test.ts
+++ b/packages/disk-import-worker/src/engine/routing.test.ts
@@ -232,6 +232,51 @@ describe('resolveTargetPath — layout is category-driven (#2006)', () => {
   });
 });
 
+describe('resolveTargetPath — audiobooks Bookshelf flatten (#2028)', () => {
+  const ab = (rel: string, anchor = '') =>
+    resolveTargetPath(rel, 'audiobooks', { owner: 'shared', anchor });
+
+  it('a plain Author/Book/track is kept unchanged', () => {
+    expect(ab('Author/Book/01.mp3')).toBe('audiobooks/Author/Book/01.mp3');
+  });
+
+  it('flattens a single disc folder into the book folder with a disc prefix', () => {
+    expect(ab('Author/Book/CD1/01.mp3')).toBe('audiobooks/Author/Book/d01-01.mp3');
+    expect(ab('Author/Book/CD2/01.mp3')).toBe('audiobooks/Author/Book/d02-01.mp3');
+  });
+
+  it('collapses a DOUBLE-nested disc folder (CD1/CD1) to one prefix from the outer disc', () => {
+    expect(ab('Bro.Code/CD1/CD1/01 Track 1.mp3')).toBe('audiobooks/Bro.Code/d01-01 Track 1.mp3');
+  });
+
+  it('two discs’ same-named tracks never collide in the flat book folder', () => {
+    expect(ab('Book/CD1/01.mp3')).toBe('audiobooks/Book/d01-01.mp3');
+    expect(ab('Book/CD2/01.mp3')).toBe('audiobooks/Book/d02-01.mp3');
+  });
+
+  it('recognises Disc/Disk/Part/Vol + German Teil/Folge disc wrappers', () => {
+    expect(ab('Book/Disc 3/t.mp3')).toBe('audiobooks/Book/d03-t.mp3');
+    expect(ab('Book/Disk1/t.mp3')).toBe('audiobooks/Book/d01-t.mp3');
+    expect(ab('Book/Part 2/t.mp3')).toBe('audiobooks/Book/d02-t.mp3');
+    expect(ab('Book/Vol. 4/t.mp3')).toBe('audiobooks/Book/d04-t.mp3');
+    expect(ab('Book/Teil 5/t.mp3')).toBe('audiobooks/Book/d05-t.mp3');
+  });
+
+  it('caps audio depth at Author/Book/ — extra-deep non-disc dirs are trimmed to the deepest two', () => {
+    expect(ab('a/b/Author/Book/01.mp3')).toBe('audiobooks/Author/Book/01.mp3');
+    expect(ab('a/b/Author/Book/CD1/01.mp3')).toBe('audiobooks/Author/Book/d01-01.mp3');
+  });
+
+  it('a bare disc wrapper with no number flattens without a prefix', () => {
+    expect(ab('Book/CD/01.mp3')).toBe('audiobooks/Book/01.mp3');
+  });
+
+  it('owner prefix + anchor still apply under the flatten', () => {
+    expect(resolveTargetPath('mdopp/Book/CD1/01.mp3', 'audiobooks', { owner: 'mdopp', anchor: 'mdopp' }))
+      .toBe('mdopp/audiobooks/Book/d01-01.mp3');
+  });
+});
+
 describe('buildFolderTree (#1915)', () => {
   const files = [
     { dir: '', category: 'documents' as const, size: 1 },

--- a/packages/disk-import-worker/src/engine/routing.ts
+++ b/packages/disk-import-worker/src/engine/routing.ts
@@ -288,6 +288,13 @@ export function resolveTargetPath(
     // A file sitting exactly at the anchor (no deeper subtree) still keeps its
     // own basename so it isn't dropped.
     if (tailSegs.length === 0) tailSegs = fileSegs.slice(-1);
+    // Audiobooks are a Bookshelf-shaped library (#2028): one folder per book,
+    // audio at most `Author/Book/track` deep. A ripped audiobook nests its
+    // tracks in disc folders (`Book/CD1/01.mp3`, even double-nested `CD1/CD1/`)
+    // — which Bookshelf treats as separate (broken) items. Flatten the disc
+    // folders into the book folder with a collision-safe disc prefix on the
+    // track name, and cap the kept depth at `Author/Book/`.
+    if (category === 'audiobooks') tailSegs = flattenAudiobookTail(tailSegs);
   } else {
     // flat: everything lands directly in the category folder (basename only).
     tailSegs = fileSegs.slice(-1);
@@ -303,6 +310,61 @@ export function resolveTargetPath(
     ownerPrefix = [rule.owner];
   }
   return [...ownerPrefix, folder, ...tailSegs].join('/');
+}
+
+// --- audiobook disc flattening (#2028) --------------------------------------
+
+/**
+ * A path segment that is a DISC folder of a ripped audiobook (`CD1`, `CD 2`,
+ * `Disc-3`, `Disk1`, `Part 2`, `Volume 4`, `Vol. 1`, German `Teil 3`/`Folge 2`).
+ * Matched case-insensitively; the captured group is the disc NUMBER (e.g. `1`)
+ * used to build the collision-safe track prefix. A bare `CD`/`Disc` with no
+ * number still matches (number group empty) so a stray disc wrapper is flattened.
+ */
+const DISC_FOLDER_RE =
+  /^(?:cd|disc|disk|part|teil|folge|vol(?:ume)?\.?)\s*[-_ ]?(\d*)$/i;
+
+/**
+ * Flatten the disc subfolders of an audiobook's preserved tail so the library is
+ * Bookshelf-shaped: one folder per book, audio no deeper than `Author/Book/`
+ * (#2028).
+ *
+ * Input is the path tail BELOW the anchor (e.g. `['Author','Book','CD1','01.mp3']`
+ * or the double-nested `['Book','CD1','CD1','01.mp3']`). Every trailing DISC
+ * folder is removed from the directory path and folded into the file name with a
+ * `dNN-` prefix (`01.mp3` → `d01-01.mp3`) so two discs' identically-named tracks
+ * (`CD1/01.mp3` + `CD2/01.mp3`) never collide in the flat book folder. Multiple
+ * stacked disc folders (the double-nested `CD1/CD1/` case) collapse to a single
+ * prefix from the OUTERMOST disc number. After disc removal the kept directory
+ * depth is capped at two (`Author/Book/`) by dropping the SHALLOWEST extra dirs,
+ * so audio never sits deeper than Bookshelf accepts.
+ *
+ * A tail with no disc folders and ≤2 dir levels is returned unchanged. The
+ * basename is always preserved (nothing is dropped).
+ */
+function flattenAudiobookTail(tail: string[]): string[] {
+  if (tail.length <= 1) return tail; // just a basename — nothing to flatten.
+  const file = tail[tail.length - 1];
+  const dirs = tail.slice(0, -1);
+
+  // Strip trailing disc folders, remembering the OUTERMOST disc number for the
+  // prefix (so a double-nested `CD1/CD1` yields one `d01-` prefix, not `d01-d01-`).
+  let discNum: string | undefined;
+  let end = dirs.length;
+  while (end > 0) {
+    const match = DISC_FOLDER_RE.exec(dirs[end - 1]);
+    if (!match) break;
+    if (match[1]) discNum = match[1]; // outermost numbered disc wins (loop walks inward→out)
+    end -= 1;
+  }
+  let keptDirs = dirs.slice(0, end);
+
+  // Cap the kept directory depth at two (`Author/Book/`). Drop the SHALLOWEST
+  // extra dirs so the book folder (the deepest, most specific) is preserved.
+  if (keptDirs.length > 2) keptDirs = keptDirs.slice(keptDirs.length - 2);
+
+  const name = discNum ? `d${discNum.padStart(2, '0')}-${file}` : file;
+  return [...keptDirs, name];
 }
 
 // --- relative-dir helpers ---------------------------------------------------

--- a/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperateContainersTab.tsx
+++ b/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperateContainersTab.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Box } from 'lucide-react';
+import type { ServiceViewModel } from '@servicebay/api-client';
+import ContainerList from '@/components/ContainerList';
+
+/**
+ * Containers tab of a service's Operate page (IA slice 1, #2029 / spec §4.2).
+ * Absorbs the per-service rows of the old `/health?tab=containers` surface so a
+ * service's containers live on its one Operate page. Reuses ContainerList (the
+ * same component the box-wide containers view uses) fed with only THIS service's
+ * attached containers, so the per-container logs/shell/actions stay available.
+ */
+export default function OperateContainersTab({ service }: { service: ServiceViewModel }) {
+  const containers = (service.attachedContainers ?? []).map(c => ({
+    ...c,
+    nodeName: c.nodeName || service.nodeName,
+  }));
+
+  if (containers.length === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500 border border-dashed border-gray-200 dark:border-gray-700 rounded-xl">
+        <Box className="w-10 h-10 mx-auto mb-3 opacity-20" />
+        <p>No containers are currently running for this service.</p>
+      </div>
+    );
+  }
+
+  return <ContainerList containers={containers} />;
+}

--- a/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperatePage.tsx
+++ b/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperatePage.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { Activity, Settings as SettingsIcon, Zap, Box, ArrowLeft, RefreshCw } from 'lucide-react';
+import type { ServiceViewModel } from '@servicebay/api-client';
+import { useOperateService } from '../../../settings/services/_lib/useOperateServices';
+import OperateHealthTab from '../../../settings/services/_lib/OperateHealthTab';
+import OperateSettingsTab from '../../../settings/services/_lib/OperateSettingsTab';
+import OperateActionsTab from '../../../settings/services/_lib/OperateActionsTab';
+import OperateContainersTab from './OperateContainersTab';
+import ServiceDetailSummary from '@/components/serviceDetail/ServiceDetailSummary';
+
+type OperateTab = 'health' | 'settings' | 'containers' | 'actions';
+
+const TABS: { id: OperateTab; label: string; Icon: typeof Activity }[] = [
+  { id: 'health', label: 'Health', Icon: Activity },
+  { id: 'settings', label: 'Settings', Icon: SettingsIcon },
+  { id: 'containers', label: 'Containers', Icon: Box },
+  { id: 'actions', label: 'Actions', Icon: Zap },
+];
+
+function isTab(v: string | null): v is OperateTab {
+  return v === 'health' || v === 'settings' || v === 'containers' || v === 'actions';
+}
+
+/**
+ * The per-service **Operate page** — the keystone of IA slice 1 (#2029, spec
+ * §4.2). One service = one page: status + health + settings + containers +
+ * actions, all co-located (feedback_services_are_the_grouping_unit). This is
+ * THE per-service surface at `/services/[name]`; it absorbs the old
+ * `/settings/services`, the per-service half of `/settings/system`, the
+ * per-service rows of `/health?tab=containers`, and the bespoke network-map
+ * sidebar — which now all reuse the same shared ServiceDetailSummary header.
+ */
+export default function OperatePage({ name }: { name: string }) {
+  const { service, loading } = useOperateService(name);
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href="/services"
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 dark:hover:text-gray-200"
+      >
+        <ArrowLeft size={16} /> Services
+      </Link>
+
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 p-8 text-gray-500">
+          <RefreshCw className="w-4 h-4 animate-spin" /> Loading service…
+        </div>
+      ) : !service ? (
+        <div className="p-8 text-center text-gray-500 border border-dashed border-gray-200 dark:border-gray-700 rounded-xl">
+          <p>Service <strong>{name}</strong> was not found.</p>
+          <Link href="/services" className="text-blue-600 dark:text-blue-400 hover:underline text-sm mt-2 inline-block">
+            Back to all services
+          </Link>
+        </div>
+      ) : (
+        <OperateBody service={service} />
+      )}
+    </div>
+  );
+}
+
+function OperateBody({ service }: { service: ServiceViewModel }) {
+  const searchParams = useSearchParams();
+  const initialTab = searchParams.get('tab');
+  const [tab, setTab] = useState<OperateTab>(isTab(initialTab) ? initialTab : 'health');
+
+  return (
+    <>
+      {/* The shared per-service detail — identical to the one shown in the
+          network-map node sidebar, so the two never drift. */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5">
+        <ServiceDetailSummary service={service} showOperateLink={false} />
+      </div>
+
+      <div className="flex border-b border-gray-200 dark:border-gray-700">
+        {TABS.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            onClick={() => setTab(id)}
+            className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              tab === id
+                ? 'border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            <Icon size={16} /> {label}
+          </button>
+        ))}
+      </div>
+
+      <div>
+        {tab === 'health' && <OperateHealthTab service={service} />}
+        {tab === 'settings' && <OperateSettingsTab service={service} />}
+        {tab === 'containers' && <OperateContainersTab service={service} />}
+        {tab === 'actions' && <OperateActionsTab service={service} deletedHref="/services" />}
+      </div>
+    </>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/services/[name]/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/services/[name]/page.tsx
@@ -1,7 +1,19 @@
-import ServiceMonitor from '@/components/ServiceMonitor';
+import { Suspense } from 'react';
+import { RefreshCw } from 'lucide-react';
+import OperatePage from './_lib/OperatePage';
 
 export default async function ServiceDetailPage({ params }: { params: Promise<{ name: string }> }) {
   const { name: rawName } = await params;
   const name = decodeURIComponent(rawName);
-  return <ServiceMonitor serviceName={name} />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center gap-2 p-8 text-gray-500">
+          <RefreshCw className="w-4 h-4 animate-spin" /> Loading service…
+        </div>
+      }
+    >
+      <OperatePage name={name} />
+    </Suspense>
+  );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateActionsTab.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateActionsTab.tsx
@@ -14,7 +14,15 @@ import { useToast } from '@/providers/ToastProvider';
  * the service's Health and Settings: start / stop / restart / update, back up
  * config to NAS, and delete.
  */
-export default function OperateActionsTab({ service }: { service: ServiceViewModel }) {
+export default function OperateActionsTab({
+  service,
+  deletedHref = '/settings/services',
+}: {
+  service: ServiceViewModel;
+  /** Where to navigate after the service is deleted (defaults to the settings
+   *  services index; the primary `/services/[name]` Operate page passes `/services`). */
+  deletedHref?: string;
+}) {
   const router = useRouter();
   const { addToast, updateToast } = useToast();
   const serviceName = service.id || service.name;
@@ -88,7 +96,7 @@ export default function OperateActionsTab({ service }: { service: ServiceViewMod
       const res = await fetch(`/api/services/${encodeURIComponent(serviceName)}${query}`, { method: 'DELETE' });
       if (res.ok) {
         updateToast(toastId, 'success', 'Service deleted', `${service.name} has been removed.`);
-        router.push('/settings/services');
+        router.push(deletedHref);
       } else {
         const data = await res.json().catch(() => ({}));
         updateToast(toastId, 'error', 'Delete failed', data.error);
@@ -99,7 +107,7 @@ export default function OperateActionsTab({ service }: { service: ServiceViewMod
       setDeleteInFlight(false);
       setDeleteOpen(false);
     }
-  }, [addToast, updateToast, deleteInFlight, router, service.name, serviceName, nodeParam]);
+  }, [addToast, updateToast, deleteInFlight, router, service.name, serviceName, nodeParam, deletedHref]);
 
   return (
     <div className="space-y-6 max-w-xl">

--- a/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateHealthTab.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateHealthTab.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Activity, CheckCircle, XCircle, AlertTriangle, AlertCircle, Play, RefreshCw } from 'lucide-react';
 import { logger, type Check, type ServiceViewModel } from '@servicebay/api-client';
 import { rowStatus, lastCheckedLabel, type RowStatus } from '@/components/HealthChecks';
+import { useServiceHealth } from '@/components/serviceDetail/serviceHealth';
 
 const ROW_META: Record<RowStatus, { color: string; bg: string; Icon: typeof CheckCircle }> = {
   ok: { color: 'text-green-500', bg: 'bg-green-50 dark:bg-green-900/20', Icon: CheckCircle },
@@ -12,16 +13,6 @@ const ROW_META: Record<RowStatus, { color: string; bg: string; Icon: typeof Chec
   unknown: { color: 'text-gray-400', bg: 'bg-gray-50 dark:bg-gray-800', Icon: AlertCircle },
 };
 
-/** Does this health check belong to the given service? Matches on the bare
- *  service name against the check's target / name (covers service, http,
- *  podman and systemd checks plus the per-service `Link:`/diagnose rows). */
-function checkBelongsToService(check: Check, baseName: string): boolean {
-  const needle = baseName.toLowerCase();
-  const target = (check.target || '').toLowerCase();
-  const name = (check.name || '').toLowerCase();
-  return target === needle || target.includes(needle) || name.includes(needle);
-}
-
 /**
  * Health tab of a service's Operate page (#1957). Co-locates the service's
  * health checks + daily self-diagnose rows with its Settings and Actions,
@@ -29,29 +20,8 @@ function checkBelongsToService(check: Check, baseName: string): boolean {
  * the per-service page rather than a global health dashboard.
  */
 export default function OperateHealthTab({ service }: { service: ServiceViewModel }) {
-  const baseName = (service.id || service.name).replace(/\.(service|scope|socket|timer)$/, '');
-  const [checks, setChecks] = useState<Check[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { checks, counts, loading, reload: load } = useServiceHealth(service);
   const [running, setRunning] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await fetch('/api/health/checks', { cache: 'no-store' });
-      if (!res.ok) throw new Error('Failed to load health checks');
-      const all: Check[] = await res.json();
-      setChecks(all.filter(c => checkBelongsToService(c, baseName)));
-    } catch (e) {
-      logger.error('OperateHealthTab', 'Failed to load checks', e);
-    } finally {
-      setLoading(false);
-    }
-  }, [baseName]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- async health-checks load on mount/service change
-    void load();
-  }, [load]);
 
   const handleRun = useCallback(async (id: string) => {
     setRunning(id);
@@ -64,13 +34,6 @@ export default function OperateHealthTab({ service }: { service: ServiceViewMode
       setRunning(null);
     }
   }, [load]);
-
-  const counts = useMemo(() => ({
-    ok: checks.filter(c => rowStatus(c) === 'ok').length,
-    warn: checks.filter(c => rowStatus(c) === 'warn').length,
-    fail: checks.filter(c => rowStatus(c) === 'fail').length,
-    unknown: checks.filter(c => rowStatus(c) === 'unknown').length,
-  }), [checks]);
 
   if (loading) {
     return (

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -108,6 +108,17 @@ body {
   background: rgba(255, 255, 255, 0.15);
 }
 
+/* Opt-out for elements that scroll but shouldn't show a scrollbar — used by
+   the mobile bottom nav (#1992), which scrolls horizontally when the
+   top-level entries don't fit but mustn't show a bar over a 72px row. */
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE/Edge */
+  scrollbar-width: none;    /* Firefox */
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;            /* WebKit */
+}
+
 /* Global theme switching fluid transitions */
 *, *::before, *::after {
   transition: background-color 300ms cubic-bezier(0.16, 1, 0.3, 1),

--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { Code, Settings, Wrench } from 'lucide-react';
+import { Code, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import DomainTag from './DomainTag';
 import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
@@ -68,6 +68,12 @@ export function MobileTopBar() {
 
   const setupActive = pathname.startsWith('/setup');
 
+  // #1992 — entries the bottom bar omits (Backup, Settings) must still be
+  // reachable on a phone. Surface them as icons in the top bar's right row,
+  // driven by the same navigation schema (no hand-coded duplication), so a
+  // future `hiddenOnMobileBottom` entry stays reachable automatically.
+  const topBarEntries = NAVIGATION_ENTRIES.filter(p => p.hiddenOnMobileBottom);
+
   return (
     <div className="h-14 bg-gray-100 dark:bg-black border-b border-gray-200 dark:border-gray-800 flex items-center justify-between px-4 shrink-0 md:hidden z-20">
        {/* Left: Logo + Text */}
@@ -102,13 +108,25 @@ export function MobileTopBar() {
               <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
             </button>
           )}
-          <button
-            onClick={() => router.push(`/settings${node ? `?node=${node}` : ''}`)}
-            className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
-            aria-label="Open settings"
-          >
-             <Settings size={20} />
-          </button>
+          {topBarEntries.map(p => {
+            const Icon = p.icon;
+            const isActive = isNavActive(pathname, p.path);
+            return (
+              <button
+                key={p.id}
+                onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
+                className={`transition-colors ${
+                  isActive
+                    ? 'text-blue-600 dark:text-blue-400'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+                }`}
+                aria-label={p.name}
+                title={p.name}
+              >
+                <Icon size={20} />
+              </button>
+            );
+          })}
           <a href="https://github.com/mdopp/servicebay" target="_blank" rel="noreferrer" className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
              <Code size={20} />
           </a>
@@ -124,11 +142,20 @@ export function MobileBottomBar() {
   const node = searchParams?.get('node');
 
   // Honor the per-entry `hiddenOnMobileBottom` flag from the navigation
-  // schema — Settings opts out (it's in the mobile top bar's icon row).
+  // schema — Settings & Backup opt out of the bottom bar (they live in the
+  // mobile top bar's icon row instead, so the bottom bar doesn't overflow).
   const bottomDashboards = NAVIGATION_ENTRIES.filter(p => !p.hiddenOnMobileBottom);
 
+  // #1992 — as top-level entries grow, a fixed `justify-around` row crowds the
+  // labels and eventually overflows on narrow phones. Use an x-scrollable flex
+  // row with non-shrinking, min-width items: it stays evenly spread when the
+  // entries fit and degrades to a horizontal scroll (never a clipped/crushed
+  // row) when they don't. `justify-around` centres the content while it fits.
   return (
-    <div className="h-[72px] bg-gray-100 dark:bg-black border-t border-gray-200 dark:border-gray-800 flex items-center justify-around px-2 shrink-0 md:hidden z-20 pb-2">
+    <nav
+      aria-label="Primary"
+      className="h-[72px] bg-gray-100 dark:bg-black border-t border-gray-200 dark:border-gray-800 flex items-center justify-around gap-1 px-2 shrink-0 md:hidden z-20 pb-2 overflow-x-auto no-scrollbar"
+    >
        {bottomDashboards.map(p => {
           const Icon = p.icon;
           const isActive = isNavActive(pathname, p.path);
@@ -138,7 +165,7 @@ export function MobileBottomBar() {
                 onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
                 title={p.name}
                 aria-label={p.name}
-                className={`p-2 rounded-xl flex flex-col items-center justify-center gap-1 transition-all ${
+                className={`p-2 rounded-xl flex flex-col items-center justify-center gap-1 shrink-0 min-w-[3.5rem] transition-all ${
                     isActive
                     ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20'
                     : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
@@ -149,6 +176,6 @@ export function MobileBottomBar() {
              </button>
           )
        })}
-    </div>
+    </nav>
   );
 }

--- a/packages/frontend/src/components/serviceDetail/ServiceDetailSummary.test.tsx
+++ b/packages/frontend/src/components/serviceDetail/ServiceDetailSummary.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * ServiceDetailSummary (IA slice 1, #2029) — the ONE shared per-service detail
+ * rendered on the Operate page header AND the Network-map node sidebar. These
+ * render tests pin its observable behaviour (status dot/label, subtitle,
+ * Open/Restart/Logs actions, the useServiceHealth-fed roll-up, and the
+ * Operate-page link) so the two surfaces never drift apart.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { Check, ServiceViewModel } from '@servicebay/api-client';
+import ServiceDetailSummary from './ServiceDetailSummary';
+import { ToastProvider } from '@/providers/ToastProvider';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+// Fresh Response per call — a shared body can only be read once
+// (feedback_vitest_fetch_response_reuse).
+function mockChecks(checks: Check[]) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.startsWith('/api/health/checks')) {
+      return new Response(JSON.stringify(checks), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  });
+}
+
+function svc(over: Partial<ServiceViewModel> = {}): ServiceViewModel {
+  return {
+    name: 'jellyfin.service',
+    displayName: 'Jellyfin',
+    yamlBasename: null,
+    kubeBasename: null,
+    active: true,
+    type: 'kube',
+    ports: [],
+    ...over,
+  };
+}
+
+function check(over: Partial<Check> & { diagnose?: { status?: string } }): Check {
+  return { id: Math.random().toString(36), name: 'x', type: 'http', status: 'ok', target: 'jellyfin', ...over } as Check;
+}
+
+function renderSummary(ui: React.ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('ServiceDetailSummary', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('renders the service health roll-up from /api/health/checks (worst-status-wins dot + counts)', async () => {
+    global.fetch = mockChecks([
+      check({ name: 'jellyfin http', status: 'ok' }),
+      check({ name: 'jellyfin libraries', status: 'ok' }),
+      // a synthetic diagnose row whose four-way status is `warn`
+      // (rowStatus reads diagnose.status; the check-level status folds warn into fail).
+      check({ name: 'jellyfin cert', status: 'fail', diagnose: { status: 'warn' } }),
+      check({ name: 'immich photos', status: 'fail', target: 'immich' }), // not this service
+    ]);
+    renderSummary(<ServiceDetailSummary service={svc()} />);
+
+    await waitFor(() => expect(screen.getByText('2 ok')).toBeDefined());
+    // warn present, but the unrelated immich fail must be filtered out -> no "failing" count, dot is Warning.
+    expect(screen.getByText('1 warning')).toBeDefined();
+    expect(screen.queryByText(/failing/)).toBeNull();
+    expect(screen.getByText('Warning')).toBeDefined();
+    expect(screen.getByText('jellyfin cert')).toBeDefined();
+  });
+
+  it('shows "Stopped" and an unknown dot for an inactive service regardless of checks', async () => {
+    global.fetch = mockChecks([check({ status: 'ok' })]);
+    renderSummary(<ServiceDetailSummary service={svc({ active: false })} />);
+    expect(await screen.findByText('Stopped')).toBeDefined();
+  });
+
+  it('renders an Open link to the primary URL, a subtitle, and the Operate-page link by default', async () => {
+    global.fetch = mockChecks([]);
+    renderSummary(<ServiceDetailSummary service={svc({ verifiedDomains: ['media.dopp.cloud'], uptime: 7200 })} />);
+
+    await waitFor(() => expect(screen.getByText('No health checks for this service.')).toBeDefined());
+    const open = screen.getByText('Open').closest('a')!;
+    expect(open.getAttribute('href')).toBe('https://media.dopp.cloud');
+    // subtitle = address · uptime
+    expect(screen.getByText(/media\.dopp\.cloud · up 2h/)).toBeDefined();
+    const operate = screen.getByText('Open full Operate page').closest('a')!;
+    expect(operate.getAttribute('href')).toBe('/services/jellyfin.service');
+  });
+
+  it('hides the Operate-page link when showOperateLink is false, and hides Open when nothing to open', async () => {
+    global.fetch = mockChecks([]);
+    renderSummary(<ServiceDetailSummary service={svc()} showOperateLink={false} />);
+    await waitFor(() => expect(screen.getByText('No health checks for this service.')).toBeDefined());
+    expect(screen.queryByText('Open full Operate page')).toBeNull();
+    expect(screen.queryByText('Open')).toBeNull();
+  });
+
+  it('Restart POSTs the service action and reports success', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.startsWith('/api/health/checks')) {
+        return new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.includes('/action') && init?.method === 'POST') {
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404 });
+    });
+    global.fetch = fetchMock;
+    renderSummary(<ServiceDetailSummary service={svc()} />);
+
+    fireEvent.click(screen.getByText('Restart').closest('button')!);
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([u, i]) =>
+        String(u).includes('/api/services/jellyfin.service/action') && (i as RequestInit)?.method === 'POST',
+      )).toBe(true),
+    );
+  });
+});

--- a/packages/frontend/src/components/serviceDetail/ServiceDetailSummary.tsx
+++ b/packages/frontend/src/components/serviceDetail/ServiceDetailSummary.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import Link from 'next/link';
+import {
+  ExternalLink,
+  RotateCw,
+  ScrollText,
+  ArrowRight,
+  CheckCircle,
+  AlertTriangle,
+  XCircle,
+  AlertCircle,
+  Loader2,
+} from 'lucide-react';
+import { logger, type Check, type ServiceViewModel } from '@servicebay/api-client';
+import type { RowStatus } from '@/components/HealthChecks';
+import { useToast } from '@/providers/ToastProvider';
+import { useServiceHealth, overallHealth, serviceBaseName } from './serviceHealth';
+
+const DOT_META: Record<RowStatus, { dot: string; label: string; text: string }> = {
+  ok: { dot: 'bg-green-500', label: 'Healthy', text: 'text-green-600 dark:text-green-400' },
+  warn: { dot: 'bg-amber-500', label: 'Warning', text: 'text-amber-600 dark:text-amber-400' },
+  fail: { dot: 'bg-red-500', label: 'Failing', text: 'text-red-600 dark:text-red-400' },
+  unknown: { dot: 'bg-gray-400', label: 'Unknown', text: 'text-gray-500' },
+};
+
+const CHECK_ICON: Record<RowStatus, typeof CheckCircle> = {
+  ok: CheckCircle,
+  warn: AlertTriangle,
+  fail: XCircle,
+  unknown: AlertCircle,
+};
+
+/** The primary clickable address for a service (first verified domain, else a
+ *  host-port URL on the current host), or null when there's nothing to open. */
+export function primaryServiceUrl(service: ServiceViewModel): string | null {
+  const domain = service.verifiedDomains?.find(d => /\./.test(d.replace(/^https?:\/\//, '')));
+  if (domain) return domain.startsWith('http') ? domain : `https://${domain}`;
+  if (service.url) return service.url;
+  const hostPort = service.ports?.find(p => p.host)?.host;
+  if (hostPort) {
+    const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+    return `http://${host}:${hostPort}`;
+  }
+  return null;
+}
+
+function formatUptime(seconds?: number): string | null {
+  if (!seconds || seconds <= 0) return null;
+  const h = Math.floor(seconds / 3600);
+  if (h >= 24) return `up ${Math.floor(h / 24)}d`;
+  if (h >= 1) return `up ${h}h`;
+  return `up ${Math.max(1, Math.floor(seconds / 60))}m`;
+}
+
+/**
+ * The ONE shared per-service detail summary (IA slice 1, #2029 / spec §4.2).
+ *
+ * Status + quick actions + a health roll-up + a link to the full Operate page.
+ * Rendered everywhere a single service is selected — the Operate page header AND
+ * the Network-map node sidebar (replacing the old bespoke, out-of-sync sidebar)
+ * — so there is exactly one source of truth for "what is this service and what
+ * can I do with it." A service is the grouping unit
+ * (feedback_services_are_the_grouping_unit).
+ */
+export default function ServiceDetailSummary({
+  service,
+  showOperateLink = true,
+  className = '',
+}: {
+  service: ServiceViewModel;
+  /** Hide the "Open full Operate page" link when already ON the Operate page. */
+  showOperateLink?: boolean;
+  className?: string;
+}) {
+  const { counts, checks, loading } = useServiceHealth(service);
+  const { restarting, handleRestart } = useServiceRestart(service);
+
+  const serviceName = service.id || service.name;
+  const operateHref = `/services/${encodeURIComponent(serviceName)}`;
+  const logsHref = `${operateHref}?tab=health`;
+  const openUrl = primaryServiceUrl(service);
+  const meta = DOT_META[service.active ? overallHealth(counts) : 'unknown'];
+  const subtitle = buildSubtitle(service, openUrl);
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      <SummaryHeader displayName={service.displayName} active={service.active} meta={meta} subtitle={subtitle} />
+      <SummaryActions openUrl={openUrl} logsHref={logsHref} restarting={restarting} onRestart={handleRestart} />
+      <HealthRollup checks={checks} counts={counts} loading={loading} />
+      {showOperateLink && (
+        <Link
+          href={operateHref}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+          data-service-base={serviceBaseName(service)}
+        >
+          Open full Operate page <ArrowRight size={14} />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/** Build the one-line subtitle (address · uptime · node), falling back to the
+ *  description when nothing networky is known. */
+function buildSubtitle(service: ServiceViewModel, openUrl: string | null): string {
+  const node = service.nodeName && service.nodeName !== 'Local' ? service.nodeName : null;
+  return (
+    [openUrl?.replace(/^https?:\/\//, ''), formatUptime(service.uptime), node].filter(Boolean).join(' · ') ||
+    (service.description ?? '')
+  );
+}
+
+/** Restart-this-service action shared by the summary's Restart button. */
+function useServiceRestart(service: ServiceViewModel) {
+  const { addToast, updateToast } = useToast();
+  const [restarting, setRestarting] = useState(false);
+  const serviceName = service.id || service.name;
+  const nodeParam = service.nodeName && service.nodeName !== 'Local' ? `?node=${service.nodeName}` : '';
+
+  const handleRestart = useCallback(async () => {
+    if (restarting) return;
+    setRestarting(true);
+    const toastId = addToast('loading', 'Restarting…', service.displayName, 0);
+    try {
+      const res = await fetch(`/api/services/${encodeURIComponent(serviceName)}/action${nodeParam}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'restart' }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        updateToast(toastId, 'error', 'Restart failed', data.error || `HTTP ${res.status}`);
+      } else {
+        updateToast(toastId, 'success', 'Restart initiated', service.displayName);
+      }
+    } catch (e) {
+      logger.error('ServiceDetailSummary', 'restart failed', e);
+      updateToast(toastId, 'error', 'Restart failed', 'An unexpected error occurred.');
+    } finally {
+      setRestarting(false);
+    }
+  }, [restarting, addToast, updateToast, service.displayName, serviceName, nodeParam]);
+
+  return { restarting, handleRestart };
+}
+
+function SummaryHeader({
+  displayName,
+  active,
+  meta,
+  subtitle,
+}: {
+  displayName: string;
+  active: boolean;
+  meta: { dot: string; label: string; text: string };
+  subtitle: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="flex items-center gap-2">
+        <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${meta.dot}`} aria-hidden />
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate" title={displayName}>
+          {displayName}
+        </h3>
+        <span className={`text-xs font-medium ${meta.text}`}>{active ? meta.label : 'Stopped'}</span>
+      </div>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">{subtitle}</p>
+    </div>
+  );
+}
+
+const ACTION_CLS =
+  'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors';
+
+function SummaryActions({
+  openUrl,
+  logsHref,
+  restarting,
+  onRestart,
+}: {
+  openUrl: string | null;
+  logsHref: string;
+  restarting: boolean;
+  onRestart: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {openUrl && (
+        <a href={openUrl} target="_blank" rel="noopener noreferrer" className={ACTION_CLS}>
+          <ExternalLink size={14} /> Open
+        </a>
+      )}
+      <button type="button" onClick={onRestart} disabled={restarting} className={`${ACTION_CLS} disabled:opacity-60`}>
+        {restarting ? <Loader2 size={14} className="animate-spin" /> : <RotateCw size={14} />} Restart
+      </button>
+      <Link href={logsHref} className={ACTION_CLS}>
+        <ScrollText size={14} /> Logs
+      </Link>
+    </div>
+  );
+}
+
+/** Compact per-service health roll-up: counts + the few most relevant checks. */
+function HealthRollup({
+  checks,
+  counts,
+  loading,
+}: {
+  checks: Check[];
+  counts: Record<RowStatus, number>;
+  loading: boolean;
+}) {
+  const topChecks = [...checks].sort((a, b) => failRank(a.status) - failRank(b.status)).slice(0, 4);
+  return (
+    <div className="rounded-lg border border-gray-100 dark:border-gray-800 p-3">
+      <div className="flex gap-3 text-xs mb-2">
+        <span className="text-green-600 dark:text-green-400 font-medium">{counts.ok} ok</span>
+        {counts.warn > 0 && <span className="text-amber-600 dark:text-amber-400 font-medium">{counts.warn} warning</span>}
+        {counts.fail > 0 && <span className="text-red-600 dark:text-red-400 font-medium">{counts.fail} failing</span>}
+      </div>
+      {loading ? (
+        <p className="text-xs text-gray-400">Loading health…</p>
+      ) : topChecks.length === 0 ? (
+        <p className="text-xs text-gray-400">No health checks for this service.</p>
+      ) : (
+        <ul className="space-y-1">
+          {topChecks.map(check => {
+            const rs = (check.status as RowStatus) in CHECK_ICON ? (check.status as RowStatus) : 'unknown';
+            const Icon = CHECK_ICON[rs];
+            return (
+              <li key={check.id} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300 min-w-0">
+                <Icon size={13} className={DOT_META[rs].text + ' shrink-0'} />
+                <span className="truncate" title={check.name}>{check.name}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Sort failing/warning checks ahead of healthy ones in the roll-up. */
+function failRank(status: string): number {
+  if (status === 'fail') return 0;
+  if (status === 'warn') return 1;
+  if (status === 'unknown') return 2;
+  return 3;
+}

--- a/packages/frontend/src/components/serviceDetail/serviceDetail.test.ts
+++ b/packages/frontend/src/components/serviceDetail/serviceDetail.test.ts
@@ -1,0 +1,71 @@
+/**
+ * IA slice 1 (#2029) — the shared per-service detail relies on these pure
+ * helpers to stay in sync between the Operate page header and the Network-map
+ * node sidebar. They are the single source of truth for "does this check belong
+ * to this service", "what's the rolled-up health dot", and "what URL do we
+ * open" — so pin them here.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Check, ServiceViewModel } from '@servicebay/api-client';
+import {
+  checkBelongsToService,
+  overallHealth,
+  serviceBaseName,
+} from './serviceHealth';
+import { primaryServiceUrl } from './ServiceDetailSummary';
+
+function svc(over: Partial<ServiceViewModel> = {}): ServiceViewModel {
+  return {
+    name: 'jellyfin.service',
+    displayName: 'Jellyfin',
+    yamlBasename: null,
+    kubeBasename: null,
+    active: true,
+    type: 'kube',
+    ports: [],
+    ...over,
+  };
+}
+
+function check(over: Partial<Check>): Check {
+  return { id: 'c', name: 'x', type: 'http', status: 'ok', ...over } as Check;
+}
+
+describe('serviceBaseName', () => {
+  it('strips the systemd unit suffix and prefers id', () => {
+    expect(serviceBaseName({ id: 'media.service', name: 'x' })).toBe('media');
+    expect(serviceBaseName({ name: 'immich.socket' })).toBe('immich');
+  });
+});
+
+describe('checkBelongsToService', () => {
+  it('matches on target equality, substring and name', () => {
+    expect(checkBelongsToService(check({ target: 'jellyfin' }), 'jellyfin')).toBe(true);
+    expect(checkBelongsToService(check({ target: 'media-jellyfin' }), 'jellyfin')).toBe(true);
+    expect(checkBelongsToService(check({ name: 'Jellyfin libraries indexed' }), 'jellyfin')).toBe(true);
+    expect(checkBelongsToService(check({ target: 'immich', name: 'photos' }), 'jellyfin')).toBe(false);
+  });
+});
+
+describe('overallHealth', () => {
+  it('worst-status-wins, then ok, then unknown', () => {
+    expect(overallHealth({ ok: 3, warn: 1, fail: 2, unknown: 0 })).toBe('fail');
+    expect(overallHealth({ ok: 3, warn: 1, fail: 0, unknown: 0 })).toBe('warn');
+    expect(overallHealth({ ok: 3, warn: 0, fail: 0, unknown: 5 })).toBe('ok');
+    expect(overallHealth({ ok: 0, warn: 0, fail: 0, unknown: 0 })).toBe('unknown');
+  });
+});
+
+describe('primaryServiceUrl', () => {
+  it('prefers a verified domain (https), then url, then host port', () => {
+    expect(primaryServiceUrl(svc({ verifiedDomains: ['media.dopp.cloud'] }))).toBe('https://media.dopp.cloud');
+    expect(primaryServiceUrl(svc({ verifiedDomains: ['https://x.dopp.cloud'] }))).toBe('https://x.dopp.cloud');
+    expect(primaryServiceUrl(svc({ url: 'http://example.com' }))).toBe('http://example.com');
+    // internal markers without a dot are skipped as domains.
+    expect(primaryServiceUrl(svc({ verifiedDomains: ['localhost-marker'] }))).toBeNull();
+  });
+
+  it('returns null when there is nothing to open', () => {
+    expect(primaryServiceUrl(svc())).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/serviceDetail/serviceHealth.ts
+++ b/packages/frontend/src/components/serviceDetail/serviceHealth.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { logger, type Check, type ServiceViewModel } from '@servicebay/api-client';
+import { rowStatus, type RowStatus } from '@/components/HealthChecks';
+
+/** Strip the systemd unit suffix to get the bare service base name. */
+export function serviceBaseName(service: Pick<ServiceViewModel, 'id' | 'name'>): string {
+  return (service.id || service.name).replace(/\.(service|scope|socket|timer)$/, '');
+}
+
+/** Does this health check belong to the given service? Matches on the bare
+ *  service name against the check's target / name (covers service, http,
+ *  podman and systemd checks plus the per-service `Link:`/diagnose rows).
+ *  Shared by the Operate Health tab and the shared service-detail summary so
+ *  the two surfaces never disagree about which checks belong to a service. */
+export function checkBelongsToService(check: Check, baseName: string): boolean {
+  const needle = baseName.toLowerCase();
+  const target = (check.target || '').toLowerCase();
+  const name = (check.name || '').toLowerCase();
+  return target === needle || target.includes(needle) || name.includes(needle);
+}
+
+export interface ServiceHealthState {
+  checks: Check[];
+  counts: Record<RowStatus, number>;
+  loading: boolean;
+  reload: () => Promise<void>;
+}
+
+/**
+ * Loads the health checks that belong to ONE service. The single source of
+ * truth for per-service health, used by both the Operate page Health tab and
+ * the shared per-service detail summary (which renders in the Services list,
+ * the Operate page header and the Network-map node sidebar) — so every place a
+ * service is shown agrees on its health.
+ */
+export function useServiceHealth(service: Pick<ServiceViewModel, 'id' | 'name'>): ServiceHealthState {
+  const baseName = serviceBaseName(service);
+  const [checks, setChecks] = useState<Check[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/health/checks', { cache: 'no-store' });
+      if (!res.ok) throw new Error('Failed to load health checks');
+      const all: Check[] = await res.json();
+      setChecks(all.filter(c => checkBelongsToService(c, baseName)));
+    } catch (e) {
+      logger.error('useServiceHealth', 'Failed to load checks', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [baseName]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async health-checks load on mount/service change
+    void reload();
+  }, [reload]);
+
+  const counts = useMemo<Record<RowStatus, number>>(() => ({
+    ok: checks.filter(c => rowStatus(c) === 'ok').length,
+    warn: checks.filter(c => rowStatus(c) === 'warn').length,
+    fail: checks.filter(c => rowStatus(c) === 'fail').length,
+    unknown: checks.filter(c => rowStatus(c) === 'unknown').length,
+  }), [checks]);
+
+  return { checks, counts, loading, reload };
+}
+
+/** Roll the per-service check counts up into one honest health dot state. */
+export function overallHealth(counts: Record<RowStatus, number>): RowStatus {
+  if (counts.fail > 0) return 'fail';
+  if (counts.warn > 0) return 'warn';
+  if (counts.ok > 0) return 'ok';
+  return 'unknown';
+}

--- a/packages/frontend/src/config/navigation.test.ts
+++ b/packages/frontend/src/config/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isNavActive } from './navigation';
+import { isNavActive, NAVIGATION_ENTRIES } from './navigation';
 
 describe('isNavActive', () => {
   it('marks Home (root) active ONLY on the exact root path', () => {
@@ -18,5 +18,25 @@ describe('isNavActive', () => {
   it('does not match a different section sharing a prefix', () => {
     expect(isNavActive('/servicesX', '/services')).toBe(false);
     expect(isNavActive('/health', '/services')).toBe(false);
+  });
+});
+
+describe('mobile reachability (#1992)', () => {
+  // MobileNav renders the bottom bar from entries WITHOUT hiddenOnMobileBottom
+  // and the top-bar icon row from entries WITH it. Every entry must land in
+  // exactly one of those buckets, so nothing is unreachable on a phone.
+  it('keeps Backup top-level but off the bottom bar (surfaced in the top bar)', () => {
+    const backup = NAVIGATION_ENTRIES.find(e => e.id === 'backup');
+    expect(backup, 'Backup must stay a top-level nav entry (operator preference)').toBeDefined();
+    expect(backup?.hiddenOnMobileBottom).toBe(true);
+  });
+
+  it('every entry is reachable on mobile (bottom bar OR top-bar icon row)', () => {
+    const bottom = NAVIGATION_ENTRIES.filter(e => !e.hiddenOnMobileBottom);
+    const top = NAVIGATION_ENTRIES.filter(e => e.hiddenOnMobileBottom);
+    expect(bottom.length + top.length).toBe(NAVIGATION_ENTRIES.length);
+    // Bottom bar must stay small enough that a phone row doesn't overflow into
+    // a crush; the scroll fallback exists, but the default set should fit.
+    expect(bottom.length).toBeLessThanOrEqual(5);
   });
 });

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -10,9 +10,10 @@
  *   1. Build a route at `/<path>`.
  *   2. Append a NavigationEntry below.
  *   3. (Optional) hide from the mobile bottom bar with
- *      `hiddenOnMobileBottom: true` — Settings does this so the
- *      bottom bar doesn't get cluttered (it's still in the top
- *      bar's icon row).
+ *      `hiddenOnMobileBottom: true` — Settings & Backup do this so the
+ *      bottom bar stays uncluttered (they surface in the mobile top
+ *      bar's icon row instead, so they're still reachable on a phone;
+ *      see MobileNav.tsx #1992).
  */
 import { Box, Terminal, Activity, Settings, Network, Home, DatabaseBackup } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -31,9 +32,10 @@ export interface NavigationEntry {
   /** Route path. The `usePathname().startsWith(path)` test marks an
    *  entry active, so prefer "/X" over "/X/" or "/X/index". */
   path: string;
-  /** When true, the mobile bottom bar omits this entry. The desktop
-   *  sidebar always renders every entry. Used today for Settings
-   *  (already in the mobile top bar's icon row). */
+  /** When true, the mobile bottom bar omits this entry; instead it is
+   *  rendered as an icon in the mobile top bar's right-hand row, so it
+   *  stays reachable on a phone (#1992). The desktop sidebar always
+   *  renders every entry. Used for Settings and Backup. */
   hiddenOnMobileBottom?: boolean;
 }
 

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -4,20 +4,14 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: false });
-import dynamic from 'next/dynamic';
 import { useTopologyData } from '@/hooks/useTopologyData';
-import type { PortMapping, EnrichedContainer, ServiceUnit } from '@servicebay/api-client';
+import type { PortMapping, ServiceUnit } from '@servicebay/api-client';
 import { buildServiceViewModel } from '@servicebay/api-client';
 import type { ServiceViewModel } from '@servicebay/api-client';
 import { useServiceActions } from '@/hooks/useServiceActions';
-import { useContainerActions } from '@/hooks/useContainerActions';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
-import ContainerLogsPanel, { ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
 import { DomainHealthDot } from '@/components/DomainHealthDot';
-import type { TerminalRef } from '@/components/Terminal';
-import { ServiceActionBar } from '@/components/ServiceActionBar';
-import { AttachedContainerList } from '@/components/AttachedContainerList';
+import ServiceDetailSummary from '@/components/serviceDetail/ServiceDetailSummary';
 
 import { 
   ReactFlow, 
@@ -42,7 +36,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { getLayoutedElements } from '@servicebay/api-client';
-import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkIcon, ChevronDown, LayoutGrid, Plus, Terminal as TerminalIcon, RefreshCw, Eraser, ArrowRight, ArrowLeft, Lock } from 'lucide-react';
+import { X, Trash2, Edit, Info, Globe, Search, FileText, Activity, Link as LinkIcon, ChevronDown, LayoutGrid, Plus, ArrowRight, ArrowLeft, Lock } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { useToast } from '@/providers/ToastProvider';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
@@ -821,12 +815,6 @@ export default function NetworkDashboard() {
   const rawGraphData = React.useRef<{ nodes: Node[], edges: Edge[] } | null>(null);
     const activeToastRef = React.useRef<string | null>(null);
     const { addToast, updateToast, removeToast } = useToast();
-    const {
-        openActions: openContainerActions,
-        closeActions: closeContainerActions,
-        overlay: containerActionsOverlay,
-        isOpen: containerActionsOpen,
-    } = useContainerActions();
 
   const startReloadToast = useCallback((description = 'Reloading network graph...') => {
       if (activeToastRef.current) {
@@ -864,9 +852,6 @@ export default function NetworkDashboard() {
   const [pendingConnection, setPendingConnection] = useState<Connection | null>(null);
   const [connectionPort, setConnectionPort] = useState('');
   const [availablePorts, setAvailablePorts] = useState<number[]>([]);
-    const [containerDrawerMode, setContainerDrawerMode] = useState<'logs' | 'terminal' | null>(null);
-    const [drawerContainer, setDrawerContainer] = useState<EnrichedContainer | null>(null);
-    const terminalRef = useRef<TerminalRef>(null);
     const selectedEdgeDetails = useMemo(() => {
         if (!selectedEdge) return null;
         return edges.find(edge => edge.id === selectedEdge) || null;
@@ -1143,13 +1128,11 @@ export default function NetworkDashboard() {
     onLoadError: (message) => resolveReloadToast('error', message),
   });
 
-  const {
-      openMonitorDrawer,
-      openEditDrawer,
-      openActions: openServiceActions,
-      requestDelete: requestServiceDelete,
-      overlays: serviceActionOverlays,
-  } = useServiceActions({ onRefresh: fetchGraph });
+  // The service-action overlays (start/stop/restart/delete modals) still mount
+  // so deletions triggered elsewhere resolve cleanly; the per-service controls
+  // that used to open them moved to the shared ServiceDetailSummary → Operate
+  // page (IA slice 1, #2029).
+  const { overlays: serviceActionOverlays } = useServiceActions({ onRefresh: fetchGraph });
 
   // const refreshing = false; // Hidden
 
@@ -1289,48 +1272,6 @@ export default function NetworkDashboard() {
       }
   }, [selectedNodeData, selectedNodeName, twin]);
 
-  const nodeAttachedContainers = useMemo<EnrichedContainer[]>(() => {
-      if (selectedServiceViewModel?.attachedContainers?.length) {
-          return selectedServiceViewModel.attachedContainers;
-      }
-
-      if (selectedNodeData?.rawData?.containers) {
-          const containers = selectedNodeData.rawData.containers as EnrichedContainer[];
-          return containers.map(container => ({
-              ...container,
-              nodeName: container.nodeName || selectedNodeName || container.nodeName,
-          }));
-      }
-
-      return [];
-  }, [selectedNodeData, selectedNodeName, selectedServiceViewModel]);
-
-  const drawerNode = drawerContainer?.nodeName && drawerContainer.nodeName !== 'Local'
-      ? drawerContainer.nodeName
-      : drawerContainer
-          ? 'Local'
-          : null;
-
-  const logsPanelData = useMemo<ContainerLogsPanelData | null>(() => {
-      if (!drawerContainer) return null;
-      return {
-          id: drawerContainer.id,
-          name: drawerContainer.names?.[0]?.replace(/^\//, '') || drawerContainer.id,
-          image: drawerContainer.image,
-          state: drawerContainer.state,
-          status: drawerContainer.status,
-          created: drawerContainer.created,
-          ports: drawerContainer.ports?.map(port => ({
-              hostIp: port.hostIp,
-              containerPort: port.containerPort || 0,
-              hostPort: port.hostPort,
-              protocol: port.protocol,
-          })),
-          mounts: drawerContainer.mounts as ContainerLogsPanelData['mounts'],
-          hideMeta: true,
-      };
-  }, [drawerContainer]);
-
 
 
   useEffect(() => {
@@ -1388,11 +1329,6 @@ export default function NetworkDashboard() {
     };
   }, [updateToast]);
 
-    const closeContainerDrawer = useCallback(() => {
-            setContainerDrawerMode(null);
-            setDrawerContainer(null);
-    }, []);
-
         const closeNodeDetails = useCallback(() => {
             setSelectedNodeData(null);
         }, []);
@@ -1407,13 +1343,11 @@ export default function NetworkDashboard() {
             setFocusNodeId(null);
         }, []);
 
-        useEscapeKey(closeContainerActions, containerActionsOpen, true);
-        useEscapeKey(closeContainerDrawer, Boolean(containerDrawerMode), true);
         useEscapeKey(closeNodeDetails, Boolean(selectedNodeData), true);
         useEscapeKey(closeEdgeDetails, Boolean(selectedEdge), true);
         // Esc exits focus only when no overlay panel is open above it
         // (the panels' own Esc handlers take precedence via topMostOnly).
-        useEscapeKey(exitFocus, Boolean(focusNodeId) && !selectedNodeData && !selectedEdge && !containerDrawerMode, true);
+        useEscapeKey(exitFocus, Boolean(focusNodeId) && !selectedNodeData && !selectedEdge, true);
 
   const handleEditLink = () => {
       if (!selectedNodeData || !selectedNodeData.rawData) return;
@@ -1500,26 +1434,6 @@ export default function NetworkDashboard() {
       setSelectedNodeData(null);
       router.push(`/services?${params.toString()}`);
   }, [addToast, router, selectedNodeName]);
-
-  const openContainerLogs = useCallback((container: EnrichedContainer) => {
-      setDrawerContainer(container);
-      setContainerDrawerMode('logs');
-  }, []);
-
-  const openContainerTerminal = useCallback((container: EnrichedContainer) => {
-      setDrawerContainer(container);
-      setContainerDrawerMode('terminal');
-  }, []);
-
-  const openAttachedContainerActions = useCallback((container: EnrichedContainer) => {
-      openContainerActions({
-          id: container.id,
-          name: container.names?.[0]?.replace(/^\//, '') || container.id,
-          nodeName: container.nodeName,
-      });
-  }, [openContainerActions]);
-
-
 
   const handleDeleteEdge = async () => {
       if (!selectedEdge) return;
@@ -1812,70 +1726,14 @@ export default function NetworkDashboard() {
         </div>
       )}
 
-      {containerDrawerMode && drawerContainer && (
-          <div className="fixed inset-0 z-[60] flex justify-end bg-gray-950/70 backdrop-blur-sm">
-              <div className="w-full max-w-5xl h-full bg-white dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800 shadow-2xl animate-in slide-in-from-right-10">
-                  {containerDrawerMode === 'logs' && logsPanelData ? (
-                      <ContainerLogsPanel
-                          container={logsPanelData}
-                          nodeName={drawerNode ?? undefined}
-                          onClose={closeContainerDrawer}
-                      />
-                  ) : (
-                      <div className="h-full flex flex-col bg-gray-950">
-                          <div className="flex items-start justify-between px-6 py-4 border-b border-gray-800 bg-gray-900">
-                              <div>
-                                  <p className="text-xs uppercase tracking-wider text-gray-500">Terminal</p>
-                                  <div className="flex items-center gap-3 text-white text-lg font-semibold">
-                                      <TerminalIcon size={18} />
-                                      <span>{drawerContainer.names?.[0]?.replace(/^\//, '') || drawerContainer.id}</span>
-                                  </div>
-                                  {drawerNode && (
-                                      <div className="mt-2 inline-flex items-center gap-2 text-xs text-gray-400">
-                                          <span className="uppercase tracking-wide">Node</span>
-                                          <span className="px-2 py-0.5 rounded-full bg-gray-800 text-gray-200 border border-gray-700">{drawerNode}</span>
-                                      </div>
-                                  )}
-                              </div>
-                              <div className="flex items-center gap-2">
-                                  <button
-                                      onClick={() => terminalRef.current?.clear()}
-                                      className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-800"
-                                      title="Clear terminal"
-                                  >
-                                      <Eraser size={18} />
-                                  </button>
-                                  <button
-                                      onClick={() => terminalRef.current?.reconnect()}
-                                      className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-800"
-                                      title="Reconnect"
-                                  >
-                                      <RefreshCw size={18} />
-                                  </button>
-                                  <button
-                                      onClick={closeContainerDrawer}
-                                      className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-800"
-                                      title="Close"
-                                  >
-                                      <X size={18} />
-                                  </button>
-                              </div>
-                          </div>
-                          <div className="flex-1 overflow-hidden">
-                              <DynamicTerminal
-                                  ref={terminalRef}
-                                  id={`container:${(drawerNode && drawerNode !== 'Local' ? drawerNode : 'local')}:${drawerContainer.id}`}
-                                  showControls={false}
-                              />
-                          </div>
-                      </div>
-                  )}
-              </div>
-          </div>
-      )}
+      {/* IA slice 1 (#2029): the network map's bespoke per-service controls
+          (service-action overlays + per-container logs/terminal drawer) were
+          only reachable from the old sidebar's ServiceActionBar /
+          AttachedContainerList, which the shared ServiceDetailSummary replaced.
+          Those actions now live on the linked per-service Operate page, so there
+          is one source of truth. */}
       {serviceActionOverlays}
-      {containerActionsOverlay}
-      
+
       {/* Context Menu / Details Panel */}
       {selectedNodeData && (
           <div className="fixed inset-0 z-50 flex justify-end bg-gray-950/60 backdrop-blur-sm">
@@ -2009,28 +1867,17 @@ export default function NetworkDashboard() {
                         )}
                       </div>
 
+                      {/* IA slice 1 (#2029, spec §4.2): the per-service detail is
+                          the ONE shared ServiceDetailSummary — identical to the
+                          Operate page header — so the map sidebar can no longer
+                          drift from the rest of the UI. The old bespoke
+                          ServiceActionBar + AttachedContainerList panel is gone;
+                          full lifecycle + per-container logs/shell live on the
+                          linked Operate page (status + health + settings +
+                          containers + actions). */}
                       {selectedServiceViewModel && (
-                          <div className="border border-gray-100 dark:border-gray-800 rounded-lg p-3 space-y-3">
-                              <div className="flex items-center gap-3">
-                                  <div>
-                                      <p className="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 font-semibold">Managed Service</p>
-                                      <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{selectedServiceViewModel.name}</p>
-                                  </div>
-                                  <ServiceActionBar
-                                      service={selectedServiceViewModel}
-                                      onMonitor={openMonitorDrawer}
-                                      onEdit={openEditDrawer}
-                                      onActions={openServiceActions}
-                                      onDelete={requestServiceDelete}
-                                      className="ml-auto"
-                                  />
-                              </div>
-                              <AttachedContainerList
-                                  containers={nodeAttachedContainers}
-                                  onLogs={openContainerLogs}
-                                  onTerminal={openContainerTerminal}
-                                  onActions={openAttachedContainerActions}
-                              />
+                          <div className="border border-gray-100 dark:border-gray-800 rounded-lg p-3">
+                              <ServiceDetailSummary service={selectedServiceViewModel} />
                           </div>
                       )}
 

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import dynamic from 'next/dynamic';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { logger } from '@servicebay/api-client';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin'; // V4 Hook
 import { useEscapeKey } from '@/hooks/useEscapeKey';
@@ -190,6 +190,20 @@ export default function ServicesDashboard() {
         closeOverlays,
         hasOpenOverlay
     } = useServiceActions({ onRefresh: fetchData });
+
+    const router = useRouter();
+
+    // IA slice 1 (#2029): a tile is a service is one page — opening/monitoring a
+    // managed service navigates to its per-service Operate page (status + health
+    // + settings + containers + actions) instead of a logs drawer. Gateway/link
+    // "services" have no Operate page, so they keep the monitor drawer.
+    const openServiceDetail = useCallback((service: ServiceViewModel) => {
+        if (service.type === 'gateway' || service.type === 'link') {
+            openMonitorDrawer(service);
+            return;
+        }
+        router.push(`/services/${encodeURIComponent(service.id || service.name)}`);
+    }, [router, openMonitorDrawer]);
 
     const {
         openActions: openContainerActions,
@@ -673,7 +687,7 @@ export default function ServicesDashboard() {
                                     attachNodeContext={attachNodeContext}
                                     httpsDomains={httpsDomains}
                                     imageUpdateAvailable={imageUpdateServices.has(entry.service.name.replace(/\.service$/, ''))}
-                                    onMonitor={openMonitorDrawer}
+                                    onMonitor={openServiceDetail}
                                     onEdit={openEditDrawer}
                                     onActions={openActions}
                                     onEditLink={handleEditLink}

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -308,6 +308,31 @@ def _jellyfin_create_library(base_url: str, token: str, name: str, collection_ty
     return "error"
 
 
+def ensure_jellyfin_bookshelf_plugin(base_url: str, token: str) -> bool:
+    """Install the official `jellyfin-plugin-bookshelf` so a `books`-type library
+    indexes AUDIOBOOKS (mp3/m4a/m4b/flac) as playable AudioBook items, not just
+    ebooks (#2028). Jellyfin's built-in Books collection type only handles
+    pdf/epub WITHOUT this plugin — the audiobooks library would show 0 playable
+    tracks. Must run BEFORE jellyfin_provision_libraries creates the `books`
+    library.
+
+    Best-effort + idempotent: Jellyfin no-ops a re-install of an already-present
+    plugin, so this is safe every deploy. A failure just logs a note (the
+    operator can install 'Bookshelf' from Dashboard → Plugins → Catalog) — it
+    never blocks the deploy."""
+    code, _ = request_json(
+        "POST", f"{base_url}/Packages/Installed/Bookshelf",
+        None,
+        extra_headers={"X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"'},
+    )
+    if code in (200, 204):
+        log("   ✅ Jellyfin Bookshelf plugin install requested (audiobooks → playable AudioBook items).")
+        return True
+    log(f"   (note) Could not request Bookshelf plugin install via API (HTTP {code}); "
+        "if audiobooks don't appear, install 'Bookshelf' from Dashboard → Plugins → Catalog.")
+    return False
+
+
 def jellyfin_provision_libraries(base_url: str, token: str, media_root: str) -> dict[str, object]:
     """Create PUBLIC libraries from the shared `file-share/data/<category>` dirs
     and PRIVATE per-user libraries from `data/<owner>/<category>` dirs, mirroring
@@ -632,6 +657,9 @@ def main() -> int:
                 # audiobooks now). Then grant each user the public libs + their own
                 # private libs. Music/Movies/Shows/Audiobooks; photos→Immich,
                 # documents→Filebrowser.
+                # Bookshelf MUST be installed before the `books`-type Audiobooks
+                # library so audiobooks index as playable AudioBook items (#2028).
+                ensure_jellyfin_bookshelf_plugin(jellyfin_base, jf_token)
                 libs = jellyfin_provision_libraries(
                     jellyfin_base, jf_token,
                     env("JELLYFIN_MEDIA_PATH", "/mnt/data/stacks/file-share/data"),

--- a/tests/frontend/MobileNav.test.tsx
+++ b/tests/frontend/MobileNav.test.tsx
@@ -26,15 +26,25 @@ describe('MobileNav', () => {
         renderWithToast(<MobileTopBar />);
         expect(screen.getByText('ServiceBay')).toBeDefined();
 
-        const settingsBtn = screen.getByLabelText('Open settings');
+        // Top-bar icon row is schema-driven (#1992): entries flagged
+        // hiddenOnMobileBottom (Settings, Backup) get an aria-label of their
+        // full `name`.
+        const settingsBtn = screen.getByLabelText('Settings');
         fireEvent.click(settingsBtn);
         expect(mockPush).toHaveBeenCalledWith('/settings');
+    });
+
+    it('MobileTopBar exposes Backup so it is reachable on mobile (#1992)', () => {
+        renderWithToast(<MobileTopBar />);
+        const backupBtn = screen.getByLabelText('Backup & restore');
+        fireEvent.click(backupBtn);
+        expect(mockPush).toHaveBeenCalledWith('/backup');
     });
 
     it('MobileTopBar preserves ?node= on Settings click', () => {
         currentNode = 'edge-1';
         renderWithToast(<MobileTopBar />);
-        fireEvent.click(screen.getByLabelText('Open settings'));
+        fireEvent.click(screen.getByLabelText('Settings'));
         expect(mockPush).toHaveBeenCalledWith('/settings?node=edge-1');
     });
 

--- a/tests/frontend/responsive-layout.test.tsx
+++ b/tests/frontend/responsive-layout.test.tsx
@@ -89,11 +89,19 @@ describe('Responsive layout guards (#806)', () => {
       expect(root?.className).toMatch(/\bmd:hidden\b/);
     });
 
-    it('exposes Settings via the touch-target row, never as a tappable label', () => {
+    it('exposes Settings via the touch-target icon row, never as a bottom-bar row', () => {
       withToast(<MobileTopBar />);
       // Settings reaches the mobile user via the icon button, not by
-      // adding clutter as a row in the bottom nav.
-      expect(screen.getByLabelText('Open settings')).toBeDefined();
+      // adding clutter as a row in the bottom nav. Schema-driven label
+      // is the entry's full `name` (#1992).
+      expect(screen.getByLabelText('Settings')).toBeDefined();
+    });
+
+    it('exposes Backup in the top-bar icon row so it stays reachable on mobile (#1992)', () => {
+      withToast(<MobileTopBar />);
+      // Backup is hiddenOnMobileBottom (operator keeps it top-level but it
+      // would crowd the bottom row), so it must surface in the top bar.
+      expect(screen.getByLabelText('Backup & restore')).toBeDefined();
     });
   });
 

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -833,6 +833,27 @@ class MediaScript(unittest.TestCase):
         self.assertEqual(set(result["public"]), {"id-Music", "id-Movies"})
         self.assertEqual(result["private_by_user"], {"mdopp": ["id-Movies (mdopp)"]})
 
+    def test_jellyfin_bookshelf_plugin_install_requested(self):
+        """ensure_jellyfin_bookshelf_plugin POSTs the Bookshelf package install
+        (so a books-type library indexes audiobooks as playable AudioBook items,
+        #2028) and returns True on a 204."""
+        m = load_script("media")
+        import urllib.request
+        responses = {"/Packages/Installed/Bookshelf": {"status": 204, "body": None}}
+        with mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory(responses)):
+            ok = m.ensure_jellyfin_bookshelf_plugin("http://127.0.0.1:8096", "jf-token")
+        self.assertTrue(ok)
+
+    def test_jellyfin_bookshelf_plugin_install_failsoft(self):
+        """A failed Bookshelf install is best-effort: returns False, never raises
+        (the deploy must not be blocked by a plugin-catalog hiccup)."""
+        m = load_script("media")
+        import urllib.request
+        # No matching response → URLError → request_json reports a non-2xx code.
+        with mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory({})):
+            ok = m.ensure_jellyfin_bookshelf_plugin("http://127.0.0.1:8096", "jf-token")
+        self.assertFalse(ok)
+
     def test_jellyfin_set_user_access_grants_public_plus_own_private(self):
         """Each non-admin user gets the public libs + their OWN private libs;
         admins are left untouched (keep EnableAllFolders)."""


### PR DESCRIPTION
## What
Four units off batch/2026-06-21a:
- **#1992** Mobile top-level nav: bottom bar x-scrolls, off-bottom entries (Settings + Backup) surface in the mobile top-bar icon row so Backup stays reachable on phones.
- **#1995** Disk-import worker image refresh: a deferred, best-effort `podman pull <worker>` on servicebay startup so an updated worker image reaches the box off the scan hot path (no manual pull, no 30s-timeout regression).
- **#2028** Audiobooks → Jellyfin Bookshelf: media post-deploy installs the Bookshelf plugin before the books-type library; import flattens disc subfolders (CD1/CD2, double-nested, DE Teil/Folge) into the book folder with collision-safe `dNN-` track prefixes and caps audio depth; cross-path content dedup catches byte-identical audio.
- **#2029** IA slice 1: per-service Operate page + a shared per-service detail component reused in the network-map node sidebar; `/services` tiles link to Operate; every old per-service knob carried across.

## Why
Closes #1992
Closes #1995
Closes #2028
Closes #2029

## Risk
Medium — #2029 reworks the per-service surface and network-map sidebar (UI-heavy); rest is additive/best-effort.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 353 warnings baseline)
- [x] npm run check:arch
- [x] npm test (full: 330 files / 2987 tests pass; +65 media post-deploy py tests)
- [ ] /verify on FCoS :dev box — path-mandated: (dashboard)/ (#2029) + disk-import worker/launcher (#1995, #2028)