### PR TITLE
fix(claude-dev)+feat(frontend): pin claude-dev UIDs + add /status health route

### DIFF
--- a/docs/UX_DECISIONS.md
+++ b/docs/UX_DECISIONS.md
@@ -54,6 +54,40 @@ moves heavy features (disk-import, backup) to their own apps + tiles.
 
 ---
 
+## Status is the box-wide health noun; Diagnostics/`/health` is its alias
+
+**What.** The IA redesign's four-noun nav (Services · **Status** · Settings ·
+Backup) names the box-wide "is it OK?" screen **Status** (spec §4.3). A
+top-level `Status` nav entry at `/status` renders the box-wide health
+view — health checks, diagnose `actions[]`, box-wide containers, and
+system info — i.e. the same `HealthDashboard` as the old `/health`. The
+`HealthDashboard` reads its active tab from the URL, so
+`/status?tab=containers` absorbs the old `/health?tab=containers`
+surface. The pre-existing `Diagnostics` entry at `/health` stays as a
+working alias rendering the same dashboard (rip-and-replace of the rest
+of the flat IA continues across the slices; the alias is not a permanent
+compat shim, it's the un-renamed remainder until the diagnostics surface
+is folded into Status).
+
+**Why.** Slice 2 of the IA redesign (#2030, epic #1950). The 3-tier
+disclosure, goal-based groups, and global search already shipped in
+slice 1 (#1956/#2029); the remaining slice-2 gap was the `Status` route
+and its nav entry so the box has **one** named health screen instead of
+the per-container health tab living under "Diagnostics". `Status` is
+marked `hiddenOnMobileBottom` so the phone bottom bar stays at five
+entries (it surfaces in the mobile top-bar icon row, like Settings and
+Backup).
+
+**Where enforced.**
+- Route: `packages/frontend/src/app/(dashboard)/status/page.tsx`
+  (renders `@/dashboards/HealthDashboard`, same as `/health`).
+- Nav entry: `packages/frontend/src/config/navigation.ts`
+  (`id: 'status'`, `path: '/status'`).
+- Test: `packages/frontend/src/config/navigation.test.ts`
+  ("has a Status entry linking to /status…").
+
+---
+
 ## Self-heal first, diagnose-with-actions second
 
 **What.** Every error path walks this hierarchy: (1) heal silently

--- a/packages/frontend/src/app/(dashboard)/status/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/status/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import HealthDashboard from '@/dashboards/HealthDashboard';
+
+/**
+ * Status — the box-wide health view (IA redesign slice 2, spec §4.3).
+ *
+ * The single "is the box OK?" screen: health checks, diagnose actions,
+ * box-wide containers and system info. Renders the same HealthDashboard
+ * as `/health` for parity — the dashboard reads its active tab from the
+ * URL, so `/status?tab=containers` absorbs the old `/health?tab=containers`
+ * surface. `/health` stays as a working alias; Status is the IA-canonical
+ * entry going forward.
+ */
+export default function StatusPage() {
+  return <HealthDashboard />;
+}

--- a/packages/frontend/src/config/navigation.test.ts
+++ b/packages/frontend/src/config/navigation.test.ts
@@ -31,6 +31,16 @@ describe('mobile reachability (#1992)', () => {
     expect(backup?.hiddenOnMobileBottom).toBe(true);
   });
 
+  it('has a Status entry linking to /status, kept off the bottom bar (#2030)', () => {
+    const status = NAVIGATION_ENTRIES.find(e => e.id === 'status');
+    expect(status, 'Status must be a top-level nav entry (IA slice 2)').toBeDefined();
+    expect(status?.path).toBe('/status');
+    expect(status?.name).toBe('Status');
+    // Bottom bar already holds 5 (home/services/network/health/terminal); Status
+    // surfaces in the mobile top-bar icon row instead, like Settings/Backup.
+    expect(status?.hiddenOnMobileBottom).toBe(true);
+  });
+
   it('every entry is reachable on mobile (bottom bar OR top-bar icon row)', () => {
     const bottom = NAVIGATION_ENTRIES.filter(e => !e.hiddenOnMobileBottom);
     const top = NAVIGATION_ENTRIES.filter(e => e.hiddenOnMobileBottom);

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -15,7 +15,7 @@
  *      bar's icon row instead, so they're still reachable on a phone;
  *      see MobileNav.tsx #1992).
  */
-import { Box, Terminal, Activity, Settings, Network, Home, DatabaseBackup } from 'lucide-react';
+import { Box, Terminal, Activity, HeartPulse, Settings, Network, Home, DatabaseBackup } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 export interface NavigationEntry {
@@ -62,6 +62,13 @@ export const NAVIGATION_ENTRIES: NavigationEntry[] = [
   { id: 'home', name: 'Home', shortLabel: 'Home', icon: Home, path: '/' },
   { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
   { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
+  // Status is the box-wide health noun in the IA redesign (slice 2, spec §4.3):
+  // the single "is the box OK?" screen (checks + diagnose actions + box-wide
+  // containers/system info), absorbing the old /health?tab=containers surface.
+  // hiddenOnMobileBottom keeps the phone bottom bar at 5 (it surfaces in the
+  // mobile top-bar icon row instead, like Settings/Backup). /health remains a
+  // working alias rendering the same dashboard.
+  { id: 'status', name: 'Status', shortLabel: 'Status', icon: HeartPulse, path: '/status', hiddenOnMobileBottom: true },
   { id: 'health', name: 'Diagnostics', shortLabel: 'Health', icon: Activity, path: '/health' },
   { id: 'terminal', name: 'SSH Terminal', shortLabel: 'Terminal', icon: Terminal, path: '/terminal' },
   // Disk import is NOT a primary nav entry — it's a one-or-twice-ever maintenance

--- a/templates/claude-dev/Dockerfile
+++ b/templates/claude-dev/Dockerfile
@@ -50,8 +50,20 @@ RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
 # user belong to it so they can collaborate on the same /workspace checkouts.
 # umask 002 (login shells) makes new files group-writable; paired with the
 # setgid bit the entrypoint puts on /workspace, new clones stay shared.
-RUN groupadd devshare \
- && useradd --create-home --home-dir /workspace --shell /bin/bash -G devshare dev \
+#
+# UIDs/GIDs are PINNED to their current deterministic values so the persistent
+# /workspace volume's host-mapped ownership (rootless keep-id) stays valid
+# across image rebuilds — otherwise a base-image bump or an extra system user
+# renumbers `dev` and the persisted ~/.claude login (owned by the old UID)
+# becomes unreadable. Pin order matters: devshare (gid 1001) before `dev` so it
+# keeps 1001; `dev` gets uid 1001 and its own `dev` primary group at gid 1002;
+# `ldapusers` (the runtime-provisioned LDAP login group) is pinned to gid 1003
+# here so the entrypoint's `groupadd -f ldapusers` is a no-op that reuses it.
+RUN groupadd --gid 1001 devshare \
+ && groupadd --gid 1002 dev \
+ && useradd --create-home --home-dir /workspace --shell /bin/bash \
+      --uid 1001 --gid 1002 -G devshare dev \
+ && groupadd --gid 1003 ldapusers \
  && printf '%s\n' 'umask 002' > /etc/profile.d/claude-dev-umask.sh
 
 # LDAP auth wiring (nss-pam-ldapd), baked deterministically at build time.

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -116,6 +116,16 @@ EOF
       else
         usermod -aG devshare "$u" 2>/dev/null || true
       fi
+      # Reconcile the persisted per-user home to the CURRENT uid/gid every
+      # boot. LDAP users get a runtime-assigned uid (the entrypoint can't pin
+      # it the way the Dockerfile pins `dev`), so a rebuild that shifts the uid
+      # would leave the old-uid-owned ~/.claude unreadable → silent re-login.
+      # These homes are small and mode-700 (the heavy shared checkouts live in
+      # /workspace itself, not here), so a recursive chown is cheap and safe.
+      user_home="$DEV_HOME/home/$u"
+      if [ -d "$user_home" ]; then
+        chown -R "$u":"$u" "$user_home" 2>/dev/null || true
+      fi
     done
     echo "claude-dev: LDAP login enabled — members of group '${CLAUDE_DEV_LDAP_GROUP}' sign in with their LLDAP password (bind ${ldap_uri}; ${provisioned} new local account(s) provisioned)."
   else


### PR DESCRIPTION
## What
- claude-dev: pin dev user UID/GID and devshare/ldapusers group GIDs in the Dockerfile, and reconcile ownership of each persisted `/workspace/home/<user>` to the current UID at boot so persisted homes (incl. `~/.claude`) survive image rebuilds.
- frontend (Settings IA slice 2): add a top-level `/status` box-wide health route + a "Status" nav entry; `/health` (Diagnostics) kept as a working alias.

## Why
Closes #2034
Closes #2030

## Risk
Low — claude-dev change is a no-op on disk when UIDs are stable; the /status route reuses the existing HealthDashboard with no backend changes.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 2993 passed)
- [ ] /verify on FCoS :dev box (claude-dev template rebuild: log in as mdopp over SSH, confirm `claude --continue` resumes without re-login; frontend nav shows Status and /status renders the health view)

AI-generated
<!-- sb-ai-comment -->