### PR TITLE
fix: approvals service-name jail + disk-import apply status race

### DIFF
--- a/packages/backend/src/lib/approvals/index.test.ts
+++ b/packages/backend/src/lib/approvals/index.test.ts
@@ -229,6 +229,53 @@ describe('move-jail authorization (#1884)', () => {
   });
 });
 
+describe('service-name jail anchor (#2043)', () => {
+  // A traversal-style `service` would let `serviceJailRoot` collapse the jail
+  // anchor outside /mnt/data/stacks/<service> (e.g. '../../../etc' -> '/etc'),
+  // so submitApproval must refuse it BEFORE anything is stored.
+  async function expectServiceRejected(service: string) {
+    await expect(submitApproval({ service, title: 't' })).rejects.toThrow(
+      /not a valid service name/,
+    );
+    // Nothing persisted — the store stays empty.
+    expect(await listApprovals()).toEqual([]);
+  }
+
+  it('rejects a ../ traversal that would anchor the jail at /etc', async () => {
+    await expectServiceRejected('../../../etc');
+  });
+
+  it('rejects a name with an embedded path separator', async () => {
+    await expectServiceRejected('svc/../../etc');
+  });
+
+  it('rejects a bare .. segment', async () => {
+    await expectServiceRejected('..');
+  });
+
+  it('rejects a leading-slash absolute name', async () => {
+    await expectServiceRejected('/etc');
+  });
+
+  it('rejects an empty service name', async () => {
+    await expectServiceRejected('');
+  });
+
+  it('accepts a valid single-segment service name and anchors the jail under it', async () => {
+    const SVC = '/mnt/data/stacks/svc';
+    fakeFs[`${SVC}/draft`] = 'c';
+    const r = await submitApproval({
+      service: 'svc',
+      title: 't',
+      on_approve: { move: { src: `${SVC}/draft`, dst: `${SVC}/done` } },
+    });
+    expect(r.service).toBe('svc');
+    const res = await approveApproval(r.id);
+    expect(res.request.status).toBe('approved');
+    expect(executor.rename).toHaveBeenCalledWith(`${SVC}/draft`, `${SVC}/done`);
+  });
+});
+
 describe('restart-target authorization (#1884)', () => {
   it('rejects restarting a load-bearing service (authelia) that is not the requester', async () => {
     const r = await submitApproval({

--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -38,6 +38,24 @@ const STACKS_ROOT = '/mnt/data/stacks';
  *  traversal). Mirrors the MCP/`npmAdminRekey` container-name guard. */
 const SERVICE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
 
+/**
+ * Reject a `service` name that is not a single safe path segment. A name
+ * with a separator or a `..` segment would let `serviceJailRoot` collapse
+ * the anchor outside `/mnt/data/stacks/<service>` (e.g. `../../../etc` →
+ * `/etc`), silently widening the move jail to a system path. The pure-regex
+ * check rejects separators and traversal both; `.` / `..` pass the charset
+ * (they are valid segment chars) so we name them explicitly. Mirrors the
+ * shape of `assertRestartTarget`'s guard.
+ */
+function assertServiceName(service: string): void {
+  if (typeof service !== 'string' || !SERVICE_NAME_RE.test(service)) {
+    throw new Error(`service is not a valid service name: "${service}".`);
+  }
+  if (service === '.' || service === '..') {
+    throw new Error(`service is not a valid service name: "${service}".`);
+  }
+}
+
 /** Absolute jail root for `service`'s declared move actions on the box. */
 function serviceJailRoot(service: string): string {
   return path.posix.join(STACKS_ROOT, service);
@@ -174,6 +192,10 @@ export async function getApproval(id: string): Promise<ApprovalRequest | null> {
 
 /** Persist a new pending request and return it. */
 export async function submitApproval(input: SubmitApprovalInput): Promise<ApprovalRequest> {
+  // AUTHORIZE the jail anchor at submit time so a traversal-style name
+  // (`../../../etc`) never reaches the store — `serviceJailRoot` would
+  // otherwise collapse it to a system path on approve.
+  assertServiceName(input.service);
   const request: ApprovalRequest = {
     id: randomUUID(),
     service: input.service,

--- a/packages/backend/src/lib/diskImport/apply.test.ts
+++ b/packages/backend/src/lib/diskImport/apply.test.ts
@@ -32,8 +32,26 @@ vi.mock('./immichProvisionEnv', () => ({
 }));
 
 // Capture status.json writes; stub plan.json reads.
-const { writes } = vi.hoisted(() => ({ writes: [] as Array<{ file: string; data: string }> }));
+//
+// MODEL the real tmp→rename atomic write so the #2044 race test is faithful: a
+// write's bytes only become the "persisted" status.json on `rename` (the commit),
+// not on the tmp `writeFile`. `tmpData` holds the in-flight tmp bytes; `committed`
+// holds what a poller would actually read; `renameGate` lets a test stall a specific
+// commit so a late progress rename can be ordered AFTER the done rename.
+const { writes, committed, writeGate } = vi.hoisted(() => ({
+  writes: [] as Array<{ file: string; data: string }>,
+  committed: { value: '' },
+  // A test sets `.hold` to a gate: given the bytes a tmp-write is about to stage, it
+  // returns a promise that write awaits (stalling that one writeOutStatus call mid
+  // flight) or null to proceed. Lets a test interleave a fire-and-forget progress
+  // write so its commit attempt lands AFTER the `done` tick (#2044).
+  writeGate: { hold: null as null | ((data: string) => Promise<void> | null) },
+}));
 vi.mock('node:fs/promises', () => {
+  // Model the real tmp→rename atomic write: bytes are staged to a tmp file and only
+  // become the persisted status.json on `rename` (the commit). `committed.value` is
+  // what a poller would actually read.
+  const tmpStage = { value: '' };
   const fsMock = {
     readFile: vi.fn(async (file: string) => {
       if (file.endsWith('plan.json')) return JSON.stringify(hoistedSidecar());
@@ -43,8 +61,14 @@ vi.mock('node:fs/promises', () => {
     writeFile: vi.fn(async (file: string, data: string) => {
       // status writes go via tmp + rename; record under the final name either way.
       writes.push({ file: file.replace(/\.tmp$/, ''), data });
+      const gate = writeGate.hold?.(data);
+      if (gate) await gate; // stall this writeOutStatus call mid-flight if gated
+      if (file.endsWith('.tmp')) tmpStage.value = data;
+      else committed.value = data; // direct (fallback-path) write commits immediately
     }),
-    rename: vi.fn(async () => {}),
+    rename: vi.fn(async () => {
+      committed.value = tmpStage.value; // the commit point
+    }),
     mkdir: vi.fn(async () => {}),
   };
   return { ...fsMock, default: fsMock };
@@ -88,6 +112,8 @@ function sidecarFixture(): PlanSidecar {
 beforeEach(() => {
   vi.clearAllMocks();
   writes.length = 0;
+  committed.value = '';
+  writeGate.hold = null;
   applyPlanMock.mockResolvedValue({ applied: 1, photoOwners: ['shared'] });
   resolveImmichProvisionMock.mockResolvedValue({
     cfg: { serverUrl: 'http://127.0.0.1:2283', adminApiKey: 'k' },
@@ -243,6 +269,43 @@ describe('applyImport', () => {
     const phases = writes.map(w => (JSON.parse(w.data) as { phase: string }).phase);
     expect(phases).toContain('applying');
     expect(phases.at(-1)).toBe('done');
+  });
+
+  it('keeps the terminal status when a late progress write lands after done (#2044)', async () => {
+    // Reproduce the race: applyPlan fires a fire-and-forget `onProgress` write
+    // (phase:applying) whose disk write is STALLED until after the `done` tick has
+    // committed. Without the monotonic-updatedAt guard the stale `applying` write
+    // would clobber `done` and strand the tile on "Applying…"; with it the late write
+    // is detected as superseded and dropped before it can commit.
+    let releaseLateWrite!: () => void;
+    const lateWriteResumed = new Promise<void>(res => (releaseLateWrite = res));
+    let progressFired = false;
+
+    applyPlanMock.mockImplementation(async (_plan, opts: { onProgress: (p: { copied: number }) => void }) => {
+      // Stall ONLY the progress write (the one staging applied:7) mid-flight, so the
+      // subsequent `done` tick wins the commit race.
+      writeGate.hold = (data: string) =>
+        (JSON.parse(data) as { applied: number }).applied === 7 ? lateWriteResumed : null;
+      opts.onProgress({ copied: 7 }); // fire-and-forget progress write (phase:applying)
+      writeGate.hold = null; // the `done` tick is not gated
+      progressFired = true;
+      return { applied: 9, photoOwners: [] };
+    });
+
+    await applyImport({ exec, runId: 'run1', mountpoint: '/m', shareGid: 1024 });
+    expect(progressFired).toBe(true);
+
+    // The `done` tick has committed; status.json is terminal.
+    expect((JSON.parse(committed.value) as { phase: string }).phase).toBe('done');
+
+    // NOW let the stalled progress write resume — the late, stale write.
+    releaseLateWrite();
+    await new Promise(r => setTimeout(r, 0)); // flush the resumed write's microtasks
+
+    // It must NOT have overwritten the terminal status — the tile stays on done.
+    const persisted = JSON.parse(committed.value) as { phase: string; applied: number };
+    expect(persisted.phase).toBe('done');
+    expect(persisted.applied).toBe(9);
   });
 
   it('records an error-phase status and rethrows on a real apply failure', async () => {

--- a/packages/backend/src/lib/diskImport/apply.ts
+++ b/packages/backend/src/lib/diskImport/apply.ts
@@ -289,10 +289,24 @@ export async function applyImport(args: ApplyImportArgs): Promise<ApplyImportRes
 
   // Seed the status doc so the tile poll keeps ticking through the apply. We patch
   // the worker's last status (its plan counts) rather than inventing a new one.
+  //
+  // RACE GUARD (#2044): `onProgress` fires a FIRE-AND-FORGET `writeOutStatus`
+  // (`void`, tmp→rename) so a slow disk poll never blocks rsync. But the final
+  // `done` tick is just another such write, and the last in-flight progress
+  // `rename` can land AFTER it — re-stamping status.json back to `phase:'applying'`
+  // and stranding the tile on "Applying…" forever. A monotonic in-process highwater
+  // makes every write carry a STRICTLY-increasing `updatedAt`, and writeOutStatus
+  // drops any write whose `updatedAt` is not the latest issued — so a stale progress
+  // write can never clobber a newer terminal status, regardless of rename ordering.
   let status = await readOutStatus(outDir, runId);
+  const nextUpdatedAt = makeMonotonicClock();
+  // The highwater is read LAZILY at write-execution time (a getter, not a snapshot):
+  // a fire-and-forget progress write's `rename` can run after the `done` tick has
+  // already advanced the highwater, and only then can we tell it is stale (#2044).
+  const isLatest = (updatedAt: number): boolean => updatedAt >= nextUpdatedAt.highwater;
   const tick = async (patch: Partial<WorkerStatus>): Promise<void> => {
-    status = { ...status, ...patch, mode: 'apply', updatedAt: Date.now() };
-    await writeOutStatus(outDir, status);
+    status = { ...status, ...patch, mode: 'apply', updatedAt: nextUpdatedAt() };
+    await writeOutStatus(outDir, status, isLatest);
   };
   await tick({ phase: 'applying', step: 'Applying plan …', applied: 0 });
 
@@ -305,7 +319,10 @@ export async function applyImport(args: ApplyImportArgs): Promise<ApplyImportRes
       hashOf: makeHostHashOf(exec),
       onProgress: p => {
         // Fire-and-forget the progress write; a slow disk poll must not block rsync.
-        void writeOutStatus(outDir, { ...status, mode: 'apply', applied: p.copied, updatedAt: Date.now() });
+        // The monotonic `updatedAt` + highwater guard keeps a late landing from
+        // overwriting a newer (terminal) status (#2044).
+        const at = nextUpdatedAt();
+        void writeOutStatus(outDir, { ...status, mode: 'apply', applied: p.copied, updatedAt: at }, isLatest);
       },
     });
     catalog.close();
@@ -374,15 +391,53 @@ async function readOutStatus(outDir: string, runId: string): Promise<WorkerStatu
   }
 }
 
-/** Atomic-ish status write (tmp + rename) so a polling reader never sees a half file. */
-async function writeOutStatus(outDir: string, status: WorkerStatus): Promise<void> {
+/**
+ * Hand out strictly-increasing `updatedAt` stamps for one apply's status writes
+ * (#2044). `Date.now()` can return the SAME ms for two writes issued back-to-back,
+ * so a coarse clock alone can't order a late progress write against the `done` tick;
+ * the counter guarantees monotonicity even within a millisecond. `.highwater`
+ * exposes the latest stamp issued so an `isLatest` predicate can drop a write that a
+ * newer one has already superseded.
+ */
+function makeMonotonicClock(): { (): number; readonly highwater: number } {
+  let last = 0;
+  const next = (): number => {
+    const now = Date.now();
+    last = now > last ? now : last + 1;
+    return last;
+  };
+  Object.defineProperty(next, 'highwater', { get: () => last });
+  return next as { (): number; readonly highwater: number };
+}
+
+/** Predicate: is this write's `updatedAt` still the most recent one issued? Re-checked
+ *  right before the `rename` so a stale fire-and-forget progress write that lost the
+ *  race to a newer (terminal) status is dropped, not persisted (#2044). */
+type IsLatest = (updatedAt: number) => boolean;
+
+/**
+ * Atomic-ish status write (tmp + rename) so a polling reader never sees a half file.
+ *
+ * `isLatest` (#2044): a FIRE-AND-FORGET progress write whose `updatedAt` has already
+ * been overtaken by a newer status must NOT land — its late `rename` would re-stamp
+ * status.json back to an earlier phase and strand the tile on "Applying…". The
+ * predicate is checked before building the tmp file AND again right before the
+ * `rename` (the commit point where ordering against a concurrent write matters), so a
+ * superseded write is committed neither path.
+ */
+async function writeOutStatus(outDir: string, status: WorkerStatus, isLatest?: IsLatest): Promise<void> {
+  if (isLatest && !isLatest(status.updatedAt)) return; // already superseded — skip the write
   const file = path.join(outDir, STATUS_FILE);
   const tmp = `${file}.tmp`;
   try {
     await mkdir(outDir, { recursive: true });
     await writeFile(tmp, JSON.stringify(status), 'utf-8');
+    // Re-check at the commit point: a newer status may have been issued while the tmp
+    // file was being written, in which case this rename would clobber it.
+    if (isLatest && !isLatest(status.updatedAt)) return;
     await rename(tmp, file);
   } catch {
+    if (isLatest && !isLatest(status.updatedAt)) return;
     await writeFile(file, JSON.stringify(status), 'utf-8').catch(() => {});
   }
 }

--- a/packages/frontend/src/app/api/approvals/route.ts
+++ b/packages/frontend/src/app/api/approvals/route.ts
@@ -13,8 +13,19 @@ const Action = z
   })
   .strict();
 
+// A service name anchors the move-action jail (`/mnt/data/stacks/<service>`),
+// so it must be a single safe path segment — no separators, no `..` traversal
+// — or the jail collapses to a system path (#2043). Mirrors the backend's
+// `assertServiceName`; the backend re-checks regardless (this is the outer
+// guard so a bad name 400s before it reaches the store).
+const ServiceName = z
+  .string()
+  .min(1)
+  .regex(/^[a-zA-Z0-9_.-]+$/, 'service must be a single safe path segment')
+  .refine(s => s !== '.' && s !== '..', 'service must be a single safe path segment');
+
 const Body = z.object({
-  service: z.string().min(1),
+  service: ServiceName,
   title: z.string().min(1),
   description: z.string().nullish(),
   payload: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
## What
Two independent fix units. (1) approvals: validate the `service` field at submit time so the move-action jail can only anchor under a single segment of `/mnt/data/stacks/` — a traversal-style value now returns 400 instead of being stored. (2) disk-import: a late fire-and-forget progress write can no longer clobber the final terminal apply status, so a completed apply never leaves the tile stuck "Applying...".

## Why
Closes #2043
Closes #2044

## Risk
Low — both are narrow, defensive guards with new unit tests; no API surface or schema change.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 3005 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — #2044 disk-import apply is real-disk-observable

<!-- sb-ai-comment -->
AI-generated