### PR TITLE
feat(auth): token chain-of-trust mint + per-capability scope audit

### DIFF
--- a/docs/SCOPE_AUDIT.md
+++ b/docs/SCOPE_AUDIT.md
@@ -1,0 +1,146 @@
+# API scope ↔ capability audit
+
+The authoritative "what does each token scope let you do" table, derived from the
+real route guards and tool maps in the codebase — not from intent. Regenerate by
+re-walking the sources listed under [Sources](#sources) whenever a guard changes.
+
+Related: [ADR 0009 — Tokens & trust](adr/0009-service-tokens-and-trust.md) §3 (the
+*why*), [`MCP.md`](MCP.md) (the MCP tool catalogue). This doc is the *what* —
+the per-capability mapping #2050 asked to make authoritative.
+
+## The ladder
+
+`ApiScope` (`packages/backend/src/lib/auth/apiScope.ts`), least → most destructive:
+
+```
+read  <  lifecycle  <  mutate  <  reboot  <  destroy  <  exec
+```
+
+Scopes are **not** automatically nested — holding `mutate` does **not** imply
+`read`. A token carries an explicit set, and `scopeSatisfiedBy(held, required)`
+checks membership with exactly two implication rules (the back-compat carve-outs
+from when `reboot`/`exec` were folded into `destroy`):
+
+- `destroy` implies `reboot` (#1765 — `reboot` was split out of `destroy`)
+- `destroy` implies `exec` (pre-#591 exec-via-destroy back-compat)
+
+So a `destroy` token may call a `reboot`- or `exec`-gated capability; nothing else
+crosses tiers. The same function gates MCP tool calls (`tokenHasScope`) and the
+delegated child-mint subset check (`scopesAreSubset`, #2048) — one source of truth.
+
+| Scope | Intent |
+|---|---|
+| `read` | lookups + diagnose + log/file readers — no state change |
+| `lifecycle` | start/stop/restart, run-check-now, refresh, run-backup, channel-set — transient operational verbs |
+| `mutate` | create/update/add + config writes — **additive** changes |
+| `reboot` | `reboot_node` — transient, recoverable host restart (#1765); split out so a token can operate+reboot **without** irreversible delete/wipe |
+| `destroy` | delete/restore/purge/factory_reset — **irreversible** state edits |
+| `exec` | `exec_command` / `container_exec` — arbitrary shell |
+
+## Two enforcement surfaces
+
+ServiceBay gates a token at two independent layers, and **both** consult the same
+ladder:
+
+1. **MCP tools** — every tool name maps to a required scope in `TOOL_SCOPES`
+   (`packages/backend/src/lib/mcp/server.ts`). The dispatcher checks
+   `tokenHasScope(auth.scopes, TOOL_SCOPES[tool] ?? 'read')` before any tool runs.
+   This map is centralized and complete by construction — every tool has a row.
+
+2. **REST routes** — there is **no** central map. Each route opts into Bearer-token
+   acceptance per-handler via `withApiHandler({ tokenScope })`
+   (`packages/backend/src/lib/api/handler.ts` → `requireSession.ts`). A route that
+   omits `tokenScope` rejects Bearer tokens entirely and stays cookie/internal-only
+   (#1264). A **cookie session carries all scopes** (legacy back-compat), so the
+   `tokenScope` guard only constrains `sb_…` named-token callers, never the browser.
+
+The table below is the per-route audit of surface (2) — the one with no central map,
+hence the one #2050 had to walk by hand.
+
+## MCP tool → scope (surface 1)
+
+Source of truth is `TOOL_SCOPES`. Summary by tier (see `server.ts` for the full list):
+
+| Scope | Tools |
+|---|---|
+| `read` | `list_*`, `get_*`, `diagnose`, `read_file`, `list_dir`, `disk_usage`, `verify_node_connection`, `verify_usb_boot`, … |
+| `lifecycle` | `start_service`, `stop_service`, `restart_service`, `run_check_now`, `refresh_agent`, `run_backup`, `set_channel` |
+| `mutate` | `deploy_service`, `update_service_yaml`, `rename_service`, `add_proxy_route`, `create_health_check`, `restore_trashed_service`, `file_access_request`, `update_config` |
+| `reboot` | `reboot_node` |
+| `destroy` | `delete_service`, `delete_health_check`, `remove_proxy_route`, `restore_backup`, `purge_trashed_service`, `set_boot_next_usb`, `factory_reset` |
+| `exec` | `exec_command`, `container_exec` |
+
+## REST route → scope (surface 2)
+
+Every REST route that accepts a named API token, with the scope it gates on. Routes
+not listed here reject Bearer tokens (cookie/internal-token only).
+
+| Route | Method | Scope | Capability |
+|---|---|---|---|
+| `/api/system/stacks` | GET | `read` | enumerate stacks |
+| `/api/system/channel` | GET | `read` | read release channel |
+| `/api/system/boot/usb-next` | GET | `read` | poll USB-boot readiness |
+| `/api/install/current` | GET | `read` | poll install progress |
+| `/api/install/plan` | POST | `read` | compute install plan (inspect-only) |
+| `/api/settings` | GET | `read` | read settings |
+| `/api/settings/backups` | GET | `read` | list config backups |
+| `/api/system/external-backup/list` | GET | `read` | list NAS backups |
+| `/api/system/external-backup/target` | GET | `read` | read NAS target config |
+| `/api/install/assemble` | POST | `lifecycle` | assemble install artifacts |
+| `/api/install/skip-credentials` | POST | `lifecycle` | resolve a credential step |
+| `/api/install/start` | POST | `lifecycle` | start a stack install |
+| `/api/install/abort` | POST | `lifecycle` | abort a stuck install |
+| `/api/settings/backups` | POST | `lifecycle` | trigger a backup |
+| `/api/system/external-backup/export-lldap` | POST | `lifecycle` | stage LLDAP export onto NAS |
+| `/api/system/external-backup/import-ha` | POST | `lifecycle` | stage an HA-OS backup onto NAS |
+| `/api/system/external-backup/upload` | POST | `lifecycle` | upload a backup to NAS |
+| `/api/system/external-backup/orphans` | GET | `lifecycle` | list NAS backups for uninstalled services (read-only; gated stricter than its `read` sibling — harmless, do not loosen) |
+| `/api/settings` | POST | `mutate` | write settings/config |
+| `/api/system/channel` | POST | `mutate` | set release channel |
+| `/api/system/boot/usb-next` | POST/DELETE | `mutate` | set/clear firmware BootNext |
+| `/api/system/disk-import/*` | GET/POST | `mutate` | scan/plan/apply a drive import (file moves into canonical folders = additive) |
+| `/api/system/external-backup/register` | POST | `mutate` | register a NAS backup source (config write) |
+| `/api/system/external-backup/target` | POST | `mutate` | write NAS target config |
+| `/api/system/external-backup/delete` | POST | `mutate` | delete one NAS archive file |
+| `/api/system/external-backup/backup-now` | POST | `mutate` | trigger an off-box backup |
+| `/api/system/templates/prune-orphans` | GET | `mutate` | list orphan template dirs |
+| `/api/system/templates/prune-orphans` | DELETE | `destroy` | delete orphan template dirs |
+| `/api/settings/backups/restore` | POST | `destroy` | restore the box config over current state |
+| `/api/system/external-backup/restore` | POST | `destroy` | restore a service's data dir from NAS — clobbers a live service's data when `force` (corrected from `lifecycle`, #2050) |
+| `/api/system/stacks/[name]/wipe` | DELETE | `destroy` | wipe a stack's data |
+
+The delegated-mint route `/api/system/api-tokens/delegate` is **not** in this table:
+it is `skipAuth` and authenticates by verifying the **parent Bearer token** itself
+(any scope), then enforces `child ⊆ parent` (#2048). It carries no fixed `tokenScope`.
+
+## Audit findings (#2050)
+
+One under-scoped destructive endpoint was found and corrected; the rest of the
+guards already matched intent.
+
+- **`/api/system/external-backup/restore` (POST): `lifecycle` → `destroy`.** This
+  route restores a service's config/data backup *into its live data dir*, clobbering
+  current data when `force:true` — an irreversible state overwrite, the `destroy`
+  tier. It was gated only at `lifecycle`, so a `lifecycle`-only token could overwrite
+  a live service's data. It now matches its siblings: the config-restore route
+  (`/api/settings/backups/restore`, `destroy`) and the MCP `restore_backup` tool
+  (`destroy`). **No caller breaks:** the only HTTP caller is the cookie-authenticated
+  Backup page (cookies carry all scopes); the reinstall auto-restore path calls
+  `restoreServiceBackup()` in-process and never crosses the HTTP guard.
+
+- **`/api/system/external-backup/orphans` (GET) is gated `lifecycle`** though it is
+  read-only. This is *stricter* than its `read` sibling (`external-backup/list`).
+  Loosening it to `read` would widen access, which a security audit must not do, so
+  it is **left as-is** and documented here as an intentional (harmless) asymmetry.
+
+No guard was loosened. No route was found that allows a *lower* scope than its
+capability warrants other than the `restore` case above.
+
+## Sources
+
+Regenerate this audit from:
+
+- `packages/backend/src/lib/auth/apiScope.ts` — ladder + `scopeSatisfiedBy`/`scopesAreSubset`
+- `packages/backend/src/lib/mcp/server.ts` — `TOOL_SCOPES`, `tokenHasScope`
+- `packages/backend/src/lib/api/requireSession.ts` + `handler.ts` — the `tokenScope` opt-in mechanism
+- the REST routes: `grep -rln "tokenScope:" packages/frontend/src/app --include=route.ts`

--- a/docs/adr/0009-service-tokens-and-trust.md
+++ b/docs/adr/0009-service-tokens-and-trust.md
@@ -72,7 +72,9 @@ Wire format `sb_<id>_<secret>` (Bearer). Stored in `api-tokens.json` as
 is for UI display. **One token authenticates both the MCP server and the REST API.**
 
 - **Scope ladder** (`ApiScope`, `packages/backend/src/lib/auth/apiScope.ts`):
-  `read` < `lifecycle` < `mutate` < `destroy` < `exec`.
+  `read` < `lifecycle` < `mutate` < `reboot` < `destroy` < `exec` (`destroy` implies
+  `reboot` and `exec`). The authoritative per-capability / per-route mapping —
+  *which scope gates which endpoint* — lives in [`SCOPE_AUDIT.md`](../SCOPE_AUDIT.md).
 - **Consumers:** the `sb` CLI, OSCAR/Hermes (`oscar-hermes`, `hermes-mcp`), scripts.
 - **Decision:** named scoped tokens are the **preferred** machine credential — least
   privilege, individually revocable, hash-at-rest. A consumer is granted only the scopes

--- a/packages/backend/src/lib/api/apiTokenRoutes.ts
+++ b/packages/backend/src/lib/api/apiTokenRoutes.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { listTokens, createToken, revokeToken, ALL_SCOPES, type ApiScope } from '@/lib/auth/apiTokens';
+import { listTokens, createToken, createDelegatedToken, DelegateError, revokeToken, ALL_SCOPES, type ApiScope } from '@/lib/auth/apiTokens';
 import { revokeBootstrapToken } from '@/lib/mcp/bootstrapToken';
 import { requireSession } from '@/lib/api/requireSession';
 import { apiError } from '@/lib/api/errors';
@@ -56,6 +56,47 @@ export async function createTokenHandler({ request }: { request: Request }) {
     return NextResponse.json({ token: result.token, secret: result.secret });
   } catch (e) {
     return apiError(e, { tag: 'api:system:api-tokens:post', status: 400 });
+  }
+}
+
+const DelegateBody = z.object({
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.enum(ALL_SCOPES as [ApiScope, ...ApiScope[]])).min(1),
+  expiresAt: z.string().datetime().optional(),
+});
+
+/**
+ * Delegated child-mint (#2048): a *holder* of an existing API token mints a
+ * child whose scopes ⊆ parent and whose TTL ≤ parent. The parent token is the
+ * credential — presented as `Authorization: Bearer sb_…`, NOT a session cookie
+ * — so a non-interactive automation can self-delegate. The route is mounted
+ * with `skipAuth: true`: there is no fixed `tokenScope` to gate on (the parent
+ * may hold any scope), so authentication is the parent-token verification
+ * inside createDelegatedToken, which rejects an unknown/expired/bad parent 403.
+ *
+ * `parentId` is derived server-side from the verified parent — never accepted
+ * from the request body — so a caller can't forge a lineage.
+ */
+export async function delegateTokenHandler({ request }: { request: Request }) {
+  const authz = request.headers.get('authorization') ?? '';
+  const parentRaw = authz.startsWith('Bearer ') ? authz.slice(7).trim() : '';
+  if (!parentRaw) {
+    return NextResponse.json({ error: 'Bearer parent token required' }, { status: 401 });
+  }
+  try {
+    const body = DelegateBody.parse(await request.json());
+    const result = await createDelegatedToken({
+      parentRaw,
+      name: body.name,
+      scopes: body.scopes,
+      expiresAt: body.expiresAt,
+    });
+    return NextResponse.json({ token: result.token, secret: result.secret });
+  } catch (e) {
+    if (e instanceof DelegateError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    return apiError(e, { tag: 'api:system:api-tokens:delegate', status: 400 });
   }
 }
 

--- a/packages/backend/src/lib/auth/apiScope.ts
+++ b/packages/backend/src/lib/auth/apiScope.ts
@@ -24,3 +24,30 @@
  */
 export type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'reboot' | 'destroy' | 'exec';
 export const ALL_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate', 'reboot', 'destroy', 'exec'];
+
+/**
+ * Whether a held scope set satisfies a single `required` scope, honoring the
+ * implication rules carved out of the original `destroy` tier:
+ *   - `destroy` implies `exec`  (the pre-#591 exec-via-destroy back-compat)
+ *   - `destroy` implies `reboot` (#1765 — reboot split out of destroy)
+ *
+ * Single source of truth for scope implication. `mcp/server.ts`'s
+ * `tokenHasScope` and the delegated-mint subset check (#2048) both route
+ * through this so the ladder stays consistent in one place.
+ */
+export function scopeSatisfiedBy(held: readonly ApiScope[], required: ApiScope): boolean {
+  if (held.includes(required)) return true;
+  if (required === 'exec' && held.includes('destroy')) return true;
+  if (required === 'reboot' && held.includes('destroy')) return true;
+  return false;
+}
+
+/**
+ * Whether `child` is a (possibly implied) subset of `parent` — every scope the
+ * child wants is held, directly or by implication, by the parent. Used to gate
+ * delegated child-token minting (#2048): a parent with `destroy` may mint a
+ * child with `reboot`/`exec`, but a child may never widen beyond its parent.
+ */
+export function scopesAreSubset(child: readonly ApiScope[], parent: readonly ApiScope[]): boolean {
+  return child.every(s => scopeSatisfiedBy(parent, s));
+}

--- a/packages/backend/src/lib/auth/apiTokens.delegate.test.ts
+++ b/packages/backend/src/lib/auth/apiTokens.delegate.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+// #2048 — delegated child-mint: a token holder mints a child whose scopes are
+// a (possibly implied) subset of the parent and whose TTL is no longer than
+// the parent. Real-fs DATA_DIR per test, mirroring apiTokens.migration.test.ts.
+let dataDir = '';
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return { ...actual, get DATA_DIR() { return dataDir; } };
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-delegate-'));
+});
+afterEach(async () => {
+  await fsp.rm(dataDir, { recursive: true, force: true });
+});
+
+const load = () => import('@/lib/auth/apiTokens');
+
+describe('createDelegatedToken (#2048)', () => {
+  it('mints a child with a subset of parent scopes and records parentId', async () => {
+    const { createToken, createDelegatedToken, listTokens } = await load();
+    const { secret: parentRaw, token: parent } = await createToken({
+      name: 'parent', scopes: ['read', 'mutate', 'lifecycle'], createdBy: 'admin',
+    });
+
+    const { token: child, secret } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['read', 'mutate'],
+    });
+
+    expect(child.scopes).toEqual(['read', 'mutate']);
+    expect(child.parentId).toBe(parent.id);
+    expect(secret).toMatch(/^sb_[0-9a-f]{8}_[A-Z2-9]+$/);
+
+    // parentId is surfaced read-only in listTokens.
+    const listed = (await listTokens()).find(t => t.id === child.id);
+    expect(listed?.parentId).toBe(parent.id);
+  });
+
+  it('rejects a child requesting a scope the parent lacks (403)', async () => {
+    const { createToken, createDelegatedToken, DelegateError } = await load();
+    const { secret: parentRaw } = await createToken({
+      name: 'parent', scopes: ['read', 'mutate'], createdBy: 'admin',
+    });
+
+    await expect(
+      createDelegatedToken({ parentRaw, name: 'child', scopes: ['read', 'destroy'] }),
+    ).rejects.toMatchObject({ status: 403 });
+    await expect(
+      createDelegatedToken({ parentRaw, name: 'child', scopes: ['read', 'destroy'] }),
+    ).rejects.toBeInstanceOf(DelegateError);
+  });
+
+  it('allows an implied scope: a destroy parent may mint a reboot/exec child', async () => {
+    const { createToken, createDelegatedToken } = await load();
+    const { secret: parentRaw } = await createToken({
+      name: 'parent', scopes: ['read', 'destroy'], createdBy: 'admin',
+    });
+
+    const { token: child } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['reboot', 'exec'],
+    });
+    expect(child.scopes).toEqual(['reboot', 'exec']);
+  });
+
+  it('rejects a child whose expiry is later than the parent (403)', async () => {
+    const { createToken, createDelegatedToken } = await load();
+    const parentExp = new Date(Date.now() + 60 * 60 * 1000).toISOString(); // +1h
+    const childExp = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(); // +2h
+    const { secret: parentRaw } = await createToken({
+      name: 'parent', scopes: ['read'], expiresAt: parentExp, createdBy: 'admin',
+    });
+
+    await expect(
+      createDelegatedToken({ parentRaw, name: 'child', scopes: ['read'], expiresAt: childExp }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rejects a child with no expiry when the parent expires (403)', async () => {
+    const { createToken, createDelegatedToken } = await load();
+    const parentExp = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const { secret: parentRaw } = await createToken({
+      name: 'parent', scopes: ['read'], expiresAt: parentExp, createdBy: 'admin',
+    });
+
+    await expect(
+      createDelegatedToken({ parentRaw, name: 'child', scopes: ['read'] }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('accepts a child expiry no later than the parent', async () => {
+    const { createToken, createDelegatedToken } = await load();
+    const parentExp = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+    const childExp = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const { secret: parentRaw } = await createToken({
+      name: 'parent', scopes: ['read'], expiresAt: parentExp, createdBy: 'admin',
+    });
+
+    const { token: child } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['read'], expiresAt: childExp,
+    });
+    expect(child.expiresAt).toBe(childExp);
+  });
+
+  it('rejects an unknown / bad parent token (403)', async () => {
+    const { createDelegatedToken } = await load();
+    await expect(
+      createDelegatedToken({ parentRaw: 'sb_deadbeef_BADSECRETBADSECRET', name: 'c', scopes: ['read'] }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rejects an expired parent token (403)', async () => {
+    const { createToken, createDelegatedToken } = await load();
+    const past = new Date(Date.now() - 1000).toISOString();
+    const { secret: parentRaw } = await createToken({
+      name: 'parent', scopes: ['read'], expiresAt: past, createdBy: 'admin',
+    });
+    await expect(
+      createDelegatedToken({ parentRaw, name: 'child', scopes: ['read'] }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rejects a revoked parent token (403)', async () => {
+    const { createToken, createDelegatedToken, revokeToken } = await load();
+    const { secret: parentRaw, token: parent } = await createToken({
+      name: 'parent', scopes: ['read'], createdBy: 'admin',
+    });
+    await revokeToken(parent.id);
+    await expect(
+      createDelegatedToken({ parentRaw, name: 'child', scopes: ['read'] }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('apiScope subset helpers (#2048)', () => {
+  it('scopesAreSubset honors destroy→reboot/exec implication', async () => {
+    const { scopesAreSubset } = await import('@/lib/auth/apiScope');
+    expect(scopesAreSubset(['reboot', 'exec'], ['destroy'])).toBe(true);
+    expect(scopesAreSubset(['read'], ['read', 'mutate'])).toBe(true);
+    expect(scopesAreSubset(['destroy'], ['reboot'])).toBe(false);
+    expect(scopesAreSubset(['mutate'], ['read'])).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/auth/apiTokens.ts
+++ b/packages/backend/src/lib/auth/apiTokens.ts
@@ -44,7 +44,7 @@ import { logger } from '@/lib/logger';
 // for everything they previously could — we additively add `exec`
 // without removing `destroy`'s grants.
 export { type ApiScope, ALL_SCOPES } from './apiScope';
-import { ALL_SCOPES, type ApiScope } from './apiScope';
+import { ALL_SCOPES, type ApiScope, scopesAreSubset } from './apiScope';
 
 export interface ApiToken {
   id: string;            // 8-hex public id
@@ -56,6 +56,20 @@ export interface ApiToken {
   expiresAt?: string;
   lastUsedAt?: string;
   createdBy: string;     // session.user at creation time
+  // Lineage (#2048): set when a token holder delegates a child token. The id
+  // of the parent token this one was minted from. Absent on directly-minted
+  // (session/admin) tokens — existing tokens have no parentId, which is fine;
+  // this is purely additive and never settable by an external caller.
+  parentId?: string;
+}
+
+/** Raised by createDelegatedToken when the parent credential or the requested
+ *  narrowing is invalid. The route maps `status` to the HTTP response. */
+export class DelegateError extends Error {
+  constructor(message: string, readonly status: 400 | 403) {
+    super(message);
+    this.name = 'DelegateError';
+  }
 }
 
 const TOKENS_FILE = path.join(DATA_DIR, 'api-tokens.json');
@@ -134,6 +148,9 @@ export async function createToken(input: {
   scopes: ApiScope[];
   expiresAt?: string;
   createdBy: string;
+  // Lineage marker (#2048). Set only by the delegated-mint path — the public
+  // mint route never passes it, so an external caller can't forge a parent.
+  parentId?: string;
 }): Promise<{ token: Omit<ApiToken, 'hash'>; secret: string }> {
   if (!input.name?.trim()) throw new Error('Token name is required');
   if (!input.scopes?.length) throw new Error('At least one scope is required');
@@ -152,10 +169,11 @@ export async function createToken(input: {
     createdAt: new Date().toISOString(),
     expiresAt: input.expiresAt,
     createdBy: input.createdBy,
+    ...(input.parentId ? { parentId: input.parentId } : {}),
   };
   data.tokens.push(token);
   await saveFile(data);
-  logger.info('auth:apiTokens', `Created API token ${id} ("${token.name}") scopes=[${token.scopes.join(',')}] by ${input.createdBy}`);
+  logger.info('auth:apiTokens', `Created API token ${id} ("${token.name}") scopes=[${token.scopes.join(',')}]${token.parentId ? ` parent=${token.parentId}` : ''} by ${input.createdBy}`);
 
   // The "first user-minted token revokes the bootstrap" rule (#322) used
   // to live here as a dynamic `await import('../mcp/bootstrapToken')` —
@@ -165,6 +183,65 @@ export async function createToken(input: {
 
   // The clear-text token is `sb_<id>_<secret>` — returned exactly once.
   return { token: publicView(token), secret: `sb_${id}_${secret}` };
+}
+
+/**
+ * Delegated child-mint (#2048) — the foundation of the token chain-of-trust
+ * (epic #2047). A *holder* of a raw parent token ("sb_<id>_<secret>") mints a
+ * child whose authority is strictly bounded by the parent:
+ *   - scopes ⊆ parent.scopes (implied scopes count — a `destroy` parent may
+ *     mint a `reboot`/`exec` child; see scopesAreSubset)
+ *   - expiresAt ≤ parent.expiresAt (TTL can only narrow, never extend; if the
+ *     parent never expires the child may set any expiry)
+ * The parent must be present, unexpired, and verify against its stored hash.
+ * The child records `parentId` = the parent's id.
+ *
+ * NOTE: this does NOT implement cascading revocation in verifyToken — that's
+ * #2049, which builds on the parentId chain landed here.
+ */
+export async function createDelegatedToken(input: {
+  parentRaw: string;
+  name: string;
+  scopes: ApiScope[];
+  expiresAt?: string;
+}): Promise<{ token: Omit<ApiToken, 'hash'>; secret: string }> {
+  if (!input.scopes?.length) throw new DelegateError('At least one scope is required', 400);
+  for (const s of input.scopes) {
+    if (!ALL_SCOPES.includes(s)) throw new DelegateError(`Unknown scope: ${s}`, 400);
+  }
+
+  // Resolve + authenticate the parent credential. verifyToken returns null for
+  // a malformed/unknown/expired token or a bad secret — all of which mean the
+  // caller doesn't hold a valid parent, so the delegation is forbidden.
+  const parent = await verifyToken(input.parentRaw);
+  if (!parent) throw new DelegateError('Invalid, expired, or revoked parent token', 403);
+
+  // Scope narrowing: every requested scope must be held (directly or implied)
+  // by the parent. A child can never widen beyond its parent's authority.
+  if (!scopesAreSubset(input.scopes, parent.scopes)) {
+    throw new DelegateError('Requested scopes exceed the parent token’s scopes', 403);
+  }
+
+  // TTL narrowing: a child may expire no later than its parent. An
+  // unbounded-lifetime parent imposes no upper bound on the child.
+  if (parent.expiresAt) {
+    const parentExp = Date.parse(parent.expiresAt);
+    if (!input.expiresAt) {
+      throw new DelegateError('Child token must expire no later than its parent (parent has an expiry)', 403);
+    }
+    const childExp = Date.parse(input.expiresAt);
+    if (!Number.isFinite(childExp) || childExp > parentExp) {
+      throw new DelegateError('Child token expiry exceeds the parent token’s expiry', 403);
+    }
+  }
+
+  return createToken({
+    name: input.name,
+    scopes: input.scopes,
+    expiresAt: input.expiresAt,
+    createdBy: `token:${parent.id}`,
+    parentId: parent.id,
+  });
 }
 
 export async function revokeToken(id: string): Promise<boolean> {

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -32,7 +32,7 @@ import { recordAudit } from './audit';
 import { notifyDestructiveOp } from './notify';
 import { createPendingApproval } from './pendingApprovals';
 import { redactLogText, redactServiceFiles } from './redact';
-import type { ApiScope } from '@/lib/auth/apiScope';
+import { type ApiScope, scopeSatisfiedBy } from '@/lib/auth/apiScope';
 import { parseEfibootmgr, assessUsbBootReadiness } from './efibootmgr';
 import { performStackReset, StackResetError } from '@/lib/install/performStackReset';
 import { jailPath, realPathInJail, JAIL_ROOT } from './pathJail';
@@ -205,10 +205,9 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
  * spinning up the whole MCP server.
  */
 export function tokenHasScope(tokenScopes: readonly ApiScope[], required: ApiScope): boolean {
-  if (tokenScopes.includes(required)) return true;
-  if (required === 'exec' && tokenScopes.includes('destroy')) return true;
-  if (required === 'reboot' && tokenScopes.includes('destroy')) return true;
-  return false;
+  // Single-sourced scope-implication ladder lives in apiScope.ts (#2048) so
+  // the delegated-mint subset check and this MCP gate can't drift.
+  return scopeSatisfiedBy(tokenScopes, required);
 }
 
 /**

--- a/packages/frontend/src/app/api/system/api-tokens/delegate/route.ts
+++ b/packages/frontend/src/app/api/system/api-tokens/delegate/route.ts
@@ -1,0 +1,13 @@
+import { withApiHandler } from '@/lib/api/handler';
+import { delegateTokenHandler } from '@/lib/api/apiTokenRoutes';
+
+// Delegated child-mint (#2048) — foundation of the token chain-of-trust epic
+// (#2047). A holder of an existing API token mints a child whose scopes ⊆ the
+// parent and whose TTL ≤ the parent, presenting the parent as
+// `Authorization: Bearer sb_…`. `skipAuth: true` because the parent token IS
+// the credential: there is no fixed `tokenScope` to gate on (the parent may
+// hold any scope), so authentication is the parent-token verification inside
+// the handler, which rejects an unknown/expired/bad parent with 403.
+export const dynamic = 'force-dynamic';
+
+export const POST = withApiHandler({ skipAuth: true }, delegateTokenHandler);

--- a/packages/frontend/src/app/api/system/external-backup/restore/route.test.ts
+++ b/packages/frontend/src/app/api/system/external-backup/restore/route.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * Scope-guard lock-in for the per-capability audit (#2050, docs/SCOPE_AUDIT.md).
+ *
+ * The destructive REST routes have no central scope map (unlike MCP TOOL_SCOPES) —
+ * each declares its guard inline via `withApiHandler({ tokenScope })`. This test
+ * pins the intended scope for the security-sensitive destructive routes so a
+ * regression (e.g. loosening restore back to `lifecycle`) fails CI.
+ *
+ * Source-level assertion rather than a request round-trip: the guard is the literal
+ * `tokenScope` baked into the route's `withApiHandler` options, and these routes
+ * pull in heavy host/NAS deps that a unit test should not load to read one string.
+ */
+const ROUTES_DIR = path.resolve(__dirname, '../../../..');
+
+function tokenScopeOf(relPath: string): string | null {
+  const src = readFileSync(path.join(ROUTES_DIR, relPath), 'utf8');
+  // Match the POST/DELETE handler's tokenScope; these single-mutating-verb
+  // routes declare exactly one.
+  const m = src.match(/tokenScope:\s*'([a-z]+)'/);
+  return m ? m[1] : null;
+}
+
+describe('destructive REST route scope guards (#2050 audit lock-in)', () => {
+  it('external-backup/restore POST is gated at destroy (corrected from lifecycle)', () => {
+    // Restoring into a live service data dir with force clobbers data —
+    // an irreversible state edit, the destroy tier. Matches the config-restore
+    // route and the MCP restore_backup tool.
+    expect(tokenScopeOf('api/system/external-backup/restore/route.ts')).toBe('destroy');
+  });
+
+  it('settings/backups/restore POST is gated at destroy', () => {
+    expect(tokenScopeOf('api/settings/backups/restore/route.ts')).toBe('destroy');
+  });
+
+  it('stacks wipe DELETE is gated at destroy', () => {
+    expect(tokenScopeOf('api/system/stacks/[name]/wipe/route.ts')).toBe('destroy');
+  });
+});

--- a/packages/frontend/src/app/api/system/external-backup/restore/route.ts
+++ b/packages/frontend/src/app/api/system/external-backup/restore/route.ts
@@ -12,10 +12,14 @@ export const dynamic = 'force-dynamic';
  * on the NAS; this pulls one back. Restores the most-recent dated snapshot by
  * default; pass `tarName` to restore a specific one (#1865). Refuses a non-empty
  * data dir unless `force` is set, so it never clobbers a live service.
- * `tokenScope: 'lifecycle'` so the sb flow can trigger it with a scoped `sb_`
- * token.
+ *
+ * `tokenScope: 'destroy'` (#2050): with `force` this overwrites a live service's
+ * data dir — an irreversible state edit, the `destroy` tier — matching the sibling
+ * config-restore route and the MCP `restore_backup` tool. The only HTTP caller is
+ * the cookie-authenticated Backup page (cookies carry all scopes); the reinstall
+ * auto-restore path calls `restoreServiceBackup()` in-process, never via this guard.
  */
-export const POST = withApiHandler({ tokenScope: 'lifecycle' }, async ({ request }) => {
+export const POST = withApiHandler({ tokenScope: 'destroy' }, async ({ request }) => {
   try {
     const body = (await request.json().catch(() => ({}))) as { service?: unknown; force?: unknown; tarName?: unknown };
     if (typeof body.service !== 'string' || !body.service) {


### PR DESCRIPTION
## What
Adds the foundation for the token chain-of-trust epic (#2047): a `parentId` field on `ApiToken` plus a subset-and-TTL-narrowed delegated child-mint path (`createDelegatedToken`) exposed at `POST /api/system/api-tokens/delegate`. Ships an authoritative per-capability/per-route scope map (`docs/SCOPE_AUDIT.md`), corrects a stale ladder in ADR 0009, and tightens one mismatched route guard: `/api/system/external-backup/restore` POST `lifecycle` -> `destroy`.

## Why
Closes #2048
Closes #2050

## Risk
Low. #2048 is new auth-layer surface (no existing caller changes). #2050 raises the scope required on `external-backup/restore` POST; the sole HTTP caller is the cookie-authed Backup page (carries all scopes) and the reinstall auto-restore runs in-process (bypasses the HTTP scope guard) — no scoped-token/sb-CLI caller breaks.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 3018 passed / 2 skipped)

Both units are flagged `security:true` for post-deploy review.

AI-generated
<!-- sb-ai-comment -->