### PR TITLE
feat(auth): token chain-of-trust — cascading revocation + sb token delegate CLI

### DIFF
--- a/packages/backend/src/lib/auth/apiTokens.cascade.test.ts
+++ b/packages/backend/src/lib/auth/apiTokens.cascade.test.ts
@@ -17,7 +17,10 @@ beforeEach(async () => {
   dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-cascade-'));
 });
 afterEach(async () => {
-  await fsp.rm(dataDir, { recursive: true, force: true });
+  // Drain verifyToken's fire-and-forget lastUsedAt write so it can't land in the
+  // next test's dataDir (DATA_DIR is a live getter) or race the rm (ENOTEMPTY).
+  await (await load()).flushPendingStamps();
+  await fsp.rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 });
 
 const load = () => import('@/lib/auth/apiTokens');
@@ -64,6 +67,7 @@ describe('verifyToken cascading revocation (#2049)', () => {
     });
     // Child valid before revoke.
     expect(await verifyToken(childRaw)).not.toBeNull();
+    await (await load()).flushPendingStamps(); // settle the lastUsedAt write before mutating the store
 
     await revokeToken(parent.id);
     expect(await verifyToken(childRaw)).toBeNull();
@@ -81,6 +85,7 @@ describe('verifyToken cascading revocation (#2049)', () => {
       parentRaw: pRaw, name: 'grandchild', scopes: ['read'],
     });
     expect(await verifyToken(gcRaw)).not.toBeNull();
+    await (await load()).flushPendingStamps(); // settle the lastUsedAt write before mutating the store
 
     await revokeToken(gp.id);
     expect(await verifyToken(gcRaw)).toBeNull();
@@ -98,6 +103,7 @@ describe('verifyToken cascading revocation (#2049)', () => {
       parentRaw, name: 'child', scopes: ['read'], expiresAt: future,
     });
     expect(await verifyToken(childRaw)).not.toBeNull();
+    await (await load()).flushPendingStamps(); // settle the lastUsedAt write before mutating the store
 
     // Rewrite the parent's expiry into the past directly in the store; the
     // child itself is still unexpired, so only the cascade can reject it.
@@ -118,6 +124,8 @@ describe('verifyToken cascading revocation (#2049)', () => {
     const { secret: childRaw } = await createDelegatedToken({
       parentRaw, name: 'child', scopes: ['read'],
     });
+
+    await (await load()).flushPendingStamps(); // createDelegatedToken verified the parent → settle its stamp
 
     // Drop the parent record directly (not via revokeToken) to simulate a
     // store inconsistency; the child still points at a now-absent parentId.

--- a/packages/backend/src/lib/auth/apiTokens.cascade.test.ts
+++ b/packages/backend/src/lib/auth/apiTokens.cascade.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+// #2049 — lazy cascading revocation: verifyToken walks UP the parentId chain
+// and rejects a token whose any ancestor is revoked, expired, or missing.
+// Real-fs DATA_DIR per test, mirroring apiTokens.delegate.test.ts.
+let dataDir = '';
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return { ...actual, get DATA_DIR() { return dataDir; } };
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-cascade-'));
+});
+afterEach(async () => {
+  await fsp.rm(dataDir, { recursive: true, force: true });
+});
+
+const load = () => import('@/lib/auth/apiTokens');
+
+const TOKENS_FILE = () => path.join(dataDir, 'api-tokens.json');
+async function readStore() {
+  return JSON.parse(await fsp.readFile(TOKENS_FILE(), 'utf-8')) as {
+    tokens: Array<Record<string, unknown>>;
+  };
+}
+async function writeStore(data: unknown) {
+  await fsp.writeFile(TOKENS_FILE(), JSON.stringify(data, null, 2));
+}
+
+describe('verifyToken cascading revocation (#2049)', () => {
+  it('a root token (no parentId) verifies and is unaffected by the walk', async () => {
+    const { createToken, verifyToken } = await load();
+    const { secret } = await createToken({ name: 'root', scopes: ['read'], createdBy: 'admin' });
+    const v = await verifyToken(secret);
+    expect(v).not.toBeNull();
+    expect(v?.parentId).toBeUndefined();
+  });
+
+  it('a child verifies while its parent is live', async () => {
+    const { createToken, createDelegatedToken, verifyToken } = await load();
+    const { secret: parentRaw, token: parent } = await createToken({
+      name: 'parent', scopes: ['read', 'mutate'], createdBy: 'admin',
+    });
+    const { secret: childRaw } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['read'],
+    });
+    const v = await verifyToken(childRaw);
+    expect(v).not.toBeNull();
+    expect(v?.parentId).toBe(parent.id);
+  });
+
+  it('revoking the parent makes the child fail verification', async () => {
+    const { createToken, createDelegatedToken, verifyToken, revokeToken } = await load();
+    const { secret: parentRaw, token: parent } = await createToken({
+      name: 'parent', scopes: ['read'], createdBy: 'admin',
+    });
+    const { secret: childRaw } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['read'],
+    });
+    // Child valid before revoke.
+    expect(await verifyToken(childRaw)).not.toBeNull();
+
+    await revokeToken(parent.id);
+    expect(await verifyToken(childRaw)).toBeNull();
+  });
+
+  it('revoking the grandparent makes the grandchild fail (multi-hop walk)', async () => {
+    const { createToken, createDelegatedToken, verifyToken, revokeToken } = await load();
+    const { secret: gpRaw, token: gp } = await createToken({
+      name: 'grandparent', scopes: ['read'], createdBy: 'admin',
+    });
+    const { secret: pRaw } = await createDelegatedToken({
+      parentRaw: gpRaw, name: 'parent', scopes: ['read'],
+    });
+    const { secret: gcRaw } = await createDelegatedToken({
+      parentRaw: pRaw, name: 'grandchild', scopes: ['read'],
+    });
+    expect(await verifyToken(gcRaw)).not.toBeNull();
+
+    await revokeToken(gp.id);
+    expect(await verifyToken(gcRaw)).toBeNull();
+    // The (now orphaned) middle parent also fails — its grandparent is gone.
+    expect(await verifyToken(pRaw)).toBeNull();
+  });
+
+  it('an expired ancestor makes the descendant fail', async () => {
+    const { createToken, createDelegatedToken, verifyToken } = await load();
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const { secret: parentRaw, token: parent } = await createToken({
+      name: 'parent', scopes: ['read'], expiresAt: future, createdBy: 'admin',
+    });
+    const { secret: childRaw, token: child } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['read'], expiresAt: future,
+    });
+    expect(await verifyToken(childRaw)).not.toBeNull();
+
+    // Rewrite the parent's expiry into the past directly in the store; the
+    // child itself is still unexpired, so only the cascade can reject it.
+    const store = await readStore();
+    const p = store.tokens.find(t => t.id === parent.id)!;
+    p.expiresAt = new Date(Date.now() - 1000).toISOString();
+    await writeStore(store);
+
+    expect(child.expiresAt).toBe(future); // sanity: child not expired itself
+    expect(await verifyToken(childRaw)).toBeNull();
+  });
+
+  it('a missing parent (store inconsistency) makes the child fail', async () => {
+    const { createToken, createDelegatedToken, verifyToken } = await load();
+    const { secret: parentRaw, token: parent } = await createToken({
+      name: 'parent', scopes: ['read'], createdBy: 'admin',
+    });
+    const { secret: childRaw } = await createDelegatedToken({
+      parentRaw, name: 'child', scopes: ['read'],
+    });
+
+    // Drop the parent record directly (not via revokeToken) to simulate a
+    // store inconsistency; the child still points at a now-absent parentId.
+    const store = await readStore();
+    store.tokens = store.tokens.filter(t => t.id !== parent.id);
+    await writeStore(store);
+
+    expect(await verifyToken(childRaw)).toBeNull();
+  });
+
+  it('a self-referential parentId (cycle) is treated as invalid', async () => {
+    const { createToken, verifyToken } = await load();
+    const { secret } = await createToken({ name: 'loop', scopes: ['read'], createdBy: 'admin' });
+
+    const store = await readStore();
+    // Point the token's parentId at itself — a 1-node cycle.
+    store.tokens[0].parentId = store.tokens[0].id;
+    await writeStore(store);
+
+    expect(await verifyToken(secret)).toBeNull();
+  });
+
+  it('an over-deep / cyclic chain (A→B→A) is treated as invalid', async () => {
+    const { createToken, verifyToken } = await load();
+    // Mint two tokens, then wire them into a mutual cycle in the store.
+    const { secret: aRaw } = await createToken({ name: 'a', scopes: ['read'], createdBy: 'admin' });
+    await createToken({ name: 'b', scopes: ['read'], createdBy: 'admin' });
+
+    const store = await readStore();
+    const a = store.tokens[0];
+    const b = store.tokens[1];
+    a.parentId = b.id;
+    b.parentId = a.id;
+    await writeStore(store);
+
+    expect(await verifyToken(aRaw)).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/auth/apiTokens.delegate.test.ts
+++ b/packages/backend/src/lib/auth/apiTokens.delegate.test.ts
@@ -17,7 +17,10 @@ beforeEach(async () => {
   dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-delegate-'));
 });
 afterEach(async () => {
-  await fsp.rm(dataDir, { recursive: true, force: true });
+  // Drain verifyToken's fire-and-forget lastUsedAt write so it can't land in the
+  // next test's dataDir (DATA_DIR is a live getter) or race the rm (ENOTEMPTY).
+  await (await load()).flushPendingStamps();
+  await fsp.rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 });
 
 const load = () => import('@/lib/auth/apiTokens');

--- a/packages/backend/src/lib/auth/apiTokens.migration.test.ts
+++ b/packages/backend/src/lib/auth/apiTokens.migration.test.ts
@@ -22,7 +22,10 @@ beforeEach(async () => {
   dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-apitokens-'));
 });
 afterEach(async () => {
-  await fsp.rm(dataDir, { recursive: true, force: true });
+  // Drain verifyToken's fire-and-forget lastUsedAt write so it can't land in the
+  // next test's dataDir (DATA_DIR is a live getter) or race the rm (ENOTEMPTY).
+  await (await load()).flushPendingStamps();
+  await fsp.rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 });
 
 const legacyPath = () => path.join(dataDir, 'mcp-tokens.json');

--- a/packages/backend/src/lib/auth/apiTokens.ts
+++ b/packages/backend/src/lib/auth/apiTokens.ts
@@ -111,6 +111,18 @@ async function saveFile(data: TokensFile): Promise<void> {
   try { await fsp.chmod(TOKENS_FILE, 0o600); } catch { /* best-effort */ }
 }
 
+// Tracks verifyToken's most recent fire-and-forget lastUsedAt write. Auth never
+// awaits it inline (the stamp must not block auth), but the mutating ops
+// (createToken/revokeToken) await it before their own read-modify-write so a
+// stale stamp snapshot can't clobber a concurrent mint/revoke. Tests drain it
+// via flushPendingStamps() so a leaked write doesn't land mid-teardown.
+let pendingStamp: Promise<unknown> = Promise.resolve();
+
+/** Await the most recent lastUsedAt stamp write. Test/teardown helper only. */
+export async function flushPendingStamps(): Promise<void> {
+  await pendingStamp;
+}
+
 function genId(): string {
   return crypto.randomBytes(4).toString('hex');
 }
@@ -157,6 +169,7 @@ export async function createToken(input: {
   for (const s of input.scopes) {
     if (!ALL_SCOPES.includes(s)) throw new Error(`Unknown scope: ${s}`);
   }
+  await pendingStamp; // settle any in-flight lastUsedAt write so it can't clobber this append
   const data = await loadFile();
   const id = genId();
   const secret = genSecret();
@@ -215,6 +228,9 @@ export async function createDelegatedToken(input: {
   // caller doesn't hold a valid parent, so the delegation is forbidden.
   const parent = await verifyToken(input.parentRaw);
   if (!parent) throw new DelegateError('Invalid, expired, or revoked parent token', 403);
+  // Note: verifyToken stamped the parent's lastUsedAt via a detached write; the
+  // createToken below awaits that pending stamp before it appends, so the
+  // (childless) stamp snapshot can't land after the append and drop the child.
 
   // Scope narrowing: every requested scope must be held (directly or implied)
   // by the parent. A child can never widen beyond its parent's authority.
@@ -245,6 +261,7 @@ export async function createDelegatedToken(input: {
 }
 
 export async function revokeToken(id: string): Promise<boolean> {
+  await pendingStamp; // settle any in-flight lastUsedAt write so it can't resurrect this revoked token
   const data = await loadFile();
   const before = data.tokens.length;
   data.tokens = data.tokens.filter(t => t.id !== id);
@@ -322,9 +339,20 @@ export async function verifyToken(raw: string): Promise<Omit<ApiToken, 'hash'> |
   // still be live, else this token is effectively revoked.
   if (!ancestorChainIsLive(token, data.tokens)) return null;
 
-  // Stamp lastUsedAt — best-effort, doesn't block auth.
-  token.lastUsedAt = new Date().toISOString();
-  saveFile(data).catch(e => logger.warn('auth:apiTokens', `Could not update lastUsedAt for ${id}: ${e instanceof Error ? e.message : String(e)}`));
+  // Stamp lastUsedAt — best-effort, doesn't block auth. Re-read the file and
+  // patch only this token's lastUsedAt rather than writing back our (possibly
+  // stale) `data` snapshot: a fire-and-forget overwrite from a snapshot taken
+  // before a concurrent revoke / expiry change / sibling stamp would clobber
+  // that change (e.g. resurrect a just-revoked ancestor). Re-reading keeps the
+  // stamp from undoing another writer's work.
+  const stampedAt = new Date().toISOString();
+  pendingStamp = (async () => {
+    const fresh = await loadFile();
+    const t = fresh.tokens.find(tok => tok.id === id);
+    if (!t) return; // token revoked/removed in the meantime — nothing to stamp
+    t.lastUsedAt = stampedAt;
+    await saveFile(fresh);
+  })().catch(e => logger.warn('auth:apiTokens', `Could not update lastUsedAt for ${id}: ${e instanceof Error ? e.message : String(e)}`));
 
-  return publicView(token);
+  return publicView({ ...token, lastUsedAt: stampedAt });
 }

--- a/packages/backend/src/lib/auth/apiTokens.ts
+++ b/packages/backend/src/lib/auth/apiTokens.ts
@@ -254,6 +254,42 @@ export async function revokeToken(id: string): Promise<boolean> {
   return true;
 }
 
+// Max ancestor hops walked by verifyToken before treating the chain as
+// invalid (#2049). A real token store is root→leaf, depth ~2; the cap exists
+// only to bound a corrupt/cyclic parentId chain. An over-deep or cyclic chain
+// is treated as invalid (fail closed) rather than authenticating.
+const MAX_ANCESTOR_DEPTH = 16;
+
+/**
+ * Lazy cascading revocation (#2049). Given a verified leaf `token`, walk UP the
+ * `parentId` chain over the already-loaded in-memory `tokens` array. The chain
+ * is valid only if every ancestor is present, not expired, and not revoked
+ * (revocation = absence from the store, since revokeToken filters it out).
+ *
+ * Returns true when the whole chain up to the root is live; false when any
+ * ancestor is missing/expired, or the walk is over-deep or cyclic. This makes
+ * "revoke a parent → every descendant instantly invalid" free at mint time —
+ * no eager tree-walk, just an O(depth) lookup per verify.
+ *
+ * A root token (no parentId) trivially passes.
+ */
+function ancestorChainIsLive(token: ApiToken, tokens: ApiToken[]): boolean {
+  const now = Date.now();
+  const seen = new Set<string>([token.id]);
+  let parentId = token.parentId;
+  let depth = 0;
+  while (parentId) {
+    if (++depth > MAX_ANCESTOR_DEPTH) return false; // over-deep → fail closed
+    if (seen.has(parentId)) return false;           // cycle → fail closed
+    seen.add(parentId);
+    const parent = tokens.find(t => t.id === parentId);
+    if (!parent) return false;                       // missing/revoked ancestor
+    if (parent.expiresAt && Date.parse(parent.expiresAt) < now) return false; // expired ancestor
+    parentId = parent.parentId;
+  }
+  return true;
+}
+
 /**
  * Verify a Bearer-style raw token string ("sb_<id>_<secret>"). Returns the
  * token (without hash) on success, or null. Side effect: stamps lastUsedAt
@@ -262,6 +298,11 @@ export async function revokeToken(id: string): Promise<boolean> {
  *
  * Constant-time comparison via crypto.timingSafeEqual to avoid timing
  * oracles on the hash check (both sides are sha-256 of equal length).
+ *
+ * After the token's own hash/expiry check passes, the `parentId` chain is
+ * walked (#2049): a token is rejected if any ancestor is revoked, expired, or
+ * missing — lazy cascading revocation, so revoking a parent kills every
+ * descendant on their next verify.
  */
 export async function verifyToken(raw: string): Promise<Omit<ApiToken, 'hash'> | null> {
   const m = raw.match(/^sb_([0-9a-f]{8})_([A-Z2-9]+)$/);
@@ -276,6 +317,10 @@ export async function verifyToken(raw: string): Promise<Omit<ApiToken, 'hash'> |
   const storedHash = Buffer.from(token.hash, 'hex');
   if (incomingHash.length !== storedHash.length) return null;
   if (!crypto.timingSafeEqual(incomingHash, storedHash)) return null;
+
+  // Cascading revocation: a live secret is not enough — every ancestor must
+  // still be live, else this token is effectively revoked.
+  if (!ancestorChainIsLive(token, data.tokens)) return null;
 
   // Stamp lastUsedAt — best-effort, doesn't block auth.
   token.lastUsedAt = new Date().toISOString();

--- a/tools/sb/internal/cli/cli.go
+++ b/tools/sb/internal/cli/cli.go
@@ -120,6 +120,8 @@ Non-interactive box control (flags; add --json for machine output):
   sb boot usb-enable --yes                set one-shot USB boot + reboot
   sb nas register --host H --user U --pass P   register the FritzBox NAS source
   sb token mint --user U --pass P [--json]     sign in + mint/save a scoped token
+  sb token mint --parent T --scopes a,b --ttl 4h   delegate a scoped leaf child token
+  sb token delegate --parent T --scopes a,b --ttl 4h   (alias for mint --parent)
 
 Target + auth come from SB_HOST/SB_PORT (or build/fcos/install-settings.env)
 and a saved token (or SB_TOKEN). Mint one with: sb token mint

--- a/tools/sb/internal/cli/cli_test.go
+++ b/tools/sb/internal/cli/cli_test.go
@@ -78,6 +78,47 @@ func TestDestructiveGateWithoutYes(t *testing.T) {
 	}
 }
 
+// TestTokenDelegateValidation: the `sb token mint --parent …` / `sb token
+// delegate …` surface validates its flags BEFORE any network call, so these run
+// hermetically (no box) and must all return exit code 2. SB_TOKEN is cleared so
+// the parent-from-env fallback doesn't accidentally satisfy a "missing parent"
+// case.
+func TestTokenDelegateValidation(t *testing.T) {
+	t.Setenv("SB_TOKEN", "")
+	cases := []struct {
+		name string
+		args []string
+	}{
+		// --parent routes to delegate mode; --scopes is required.
+		{"mint parent without scopes", []string{"mint", "--parent", "sb_p", "--ttl", "4h"}},
+		// delegate verb with no parent and no SB_TOKEN.
+		{"delegate without parent", []string{"delegate", "--scopes", "read"}},
+		// invalid Go duration.
+		{"delegate bad ttl", []string{"delegate", "--parent", "sb_p", "--scopes", "read", "--ttl", "soon"}},
+		// non-positive ttl.
+		{"delegate zero ttl", []string{"delegate", "--parent", "sb_p", "--scopes", "read", "--ttl", "0s"}},
+	}
+	for _, c := range cases {
+		if code := Token(c.args); code != 2 {
+			t.Errorf("%s: exit = %d, want 2", c.name, code)
+		}
+	}
+}
+
+// TestTokenDelegateRouting: `token mint` with a delegate-only flag routes to the
+// delegate path (which then fails validation at exit 2), while bare `token mint`
+// without --user/--pass is the admin sign-in path (also exit 2 on missing creds)
+// — both hermetic, no box.
+func TestTokenDelegateRouting(t *testing.T) {
+	t.Setenv("SB_TOKEN", "")
+	if code := Token([]string{"mint", "--scopes", "read"}); code != 2 {
+		t.Errorf("mint --scopes (delegate route, missing parent): exit = %d, want 2", code)
+	}
+	if code := Token([]string{"mint"}); code != 2 {
+		t.Errorf("bare mint (admin route, missing creds): exit = %d, want 2", code)
+	}
+}
+
 func TestUnknownSubcommandUsage(t *testing.T) {
 	cases := []struct {
 		name string

--- a/tools/sb/internal/cli/nas_token.go
+++ b/tools/sb/internal/cli/nas_token.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"sb/internal/probes"
 	"sb/internal/rest"
@@ -37,18 +39,46 @@ func Nas(args []string) int {
 	})
 }
 
-// Token implements `sb token mint --user U --pass P`: sign in with the box admin
-// credentials, mint a scoped `sb_` token, and save it per-host so every later
-// `sb` command reuses it. The non-interactive replacement for the TUI sign-in.
+// Token dispatches the `sb token …` group:
+//
+//	sb token mint --user U --pass P            sign in + mint/save a scoped token
+//	sb token mint --parent T --scopes a,b --ttl 4h    delegate a scoped leaf child
+//	sb token delegate --parent T --scopes a,b --ttl 4h   (alias for the above)
+//
+// `mint` with --parent (or any delegate flag) and the explicit `delegate` verb
+// both route to tokenDelegate; bare `mint --user/--pass` is the admin sign-in.
 func Token(args []string) int {
-	if len(args) == 0 || args[0] != "mint" {
-		return usageErr(os.Stderr, "usage: sb token mint --user U --pass P [--json]")
+	if len(args) == 0 {
+		return usageErr(os.Stderr, "usage: sb token mint --user U --pass P | sb token mint --parent T --scopes a,b --ttl 4h")
 	}
+	switch args[0] {
+	case "delegate":
+		return tokenDelegate(args[1:])
+	case "mint":
+		// Delegate mode when a parent credential or a delegate-only flag is given.
+		for _, a := range args[1:] {
+			if a == "--parent" || strings.HasPrefix(a, "--parent=") ||
+				a == "--scopes" || strings.HasPrefix(a, "--scopes=") ||
+				a == "--ttl" || strings.HasPrefix(a, "--ttl=") {
+				return tokenDelegate(args[1:])
+			}
+		}
+		return tokenMint(args[1:])
+	default:
+		return usageErr(os.Stderr, "usage: sb token mint … | sb token delegate …")
+	}
+}
+
+// tokenMint implements `sb token mint --user U --pass P`: sign in with the box
+// admin credentials, mint a scoped `sb_` token, and save it per-host so every
+// later `sb` command reuses it. The non-interactive replacement for the TUI
+// sign-in.
+func tokenMint(args []string) int {
 	fs := newFlags("token mint")
 	user := fs.String("user", "", "box admin username")
 	pass := fs.String("pass", "", "box admin password")
 	jsonMode := fs.Bool("json", false, "machine-readable output")
-	if err := fs.Parse(args[1:]); err != nil {
+	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if *user == "" || *pass == "" {
@@ -68,5 +98,59 @@ func Token(args []string) int {
 	}
 	return emit(*jsonMode, map[string]string{"host": t.Host, "status": "minted", "saved": "true"}, func() {
 		fmt.Printf("✓ minted + saved a scoped token for %s\n", t.Host)
+	})
+}
+
+// tokenDelegate implements `sb token mint --parent T --scopes a,b --ttl 4h`
+// (and the `sb token delegate` alias): mint a short-lived, narrow-scope CHILD
+// token from an existing parent token via POST /api/system/api-tokens/delegate
+// (#2048). The box enforces scopes ⊆ parent and TTL ≤ parent — a super-scope or
+// longer-TTL request is rejected and surfaced as an error. The minted child
+// secret is printed (NOT saved); the caller owns revoking it when done.
+func tokenDelegate(args []string) int {
+	fs := newFlags("token delegate")
+	parent := fs.String("parent", "", "raw parent sb_… token (default: SB_TOKEN)")
+	scopes := fs.String("scopes", "", "comma-separated scope subset (e.g. read,lifecycle)")
+	ttl := fs.String("ttl", "", "Go duration for the child TTL, e.g. 4h, 30m (≤ parent)")
+	name := fs.String("name", "sb-delegate", "name the child token is created under")
+	jsonMode := fs.Bool("json", false, "machine-readable output")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	parentTok := *parent
+	if parentTok == "" {
+		parentTok = strings.TrimSpace(os.Getenv("SB_TOKEN"))
+	}
+	if parentTok == "" {
+		return usageErr(os.Stderr, "token delegate: a parent token is required (--parent or SB_TOKEN)")
+	}
+	scopeList := splitCSV(*scopes)
+	if len(scopeList) == 0 {
+		return usageErr(os.Stderr, "token delegate: --scopes is required (comma-separated subset)")
+	}
+	var expiresAt string
+	if *ttl != "" {
+		d, err := time.ParseDuration(*ttl)
+		if err != nil {
+			return usageErr(os.Stderr, fmt.Sprintf("token delegate: invalid --ttl %q: %v", *ttl, err))
+		}
+		if d <= 0 {
+			return usageErr(os.Stderr, "token delegate: --ttl must be positive")
+		}
+		expiresAt = time.Now().Add(d).UTC().Format(time.RFC3339)
+	}
+	t := probes.ResolveTarget()
+	if t.Host == "" {
+		fmt.Fprintln(os.Stderr, "no box target — set SB_HOST (and SB_PORT), or build an ISO first.")
+		return 2
+	}
+	secret, err := rest.Delegate(ctx(), t.Host, t.Port, parentTok, *name, scopeList, expiresAt)
+	if err != nil {
+		return fail(err)
+	}
+	return emit(*jsonMode, map[string]string{"host": t.Host, "status": "delegated", "secret": secret}, func() {
+		// Human mode prints the bare secret on its own line so it's pipe-friendly
+		// (e.g. SB_TOKEN=$(sb token delegate …)); the caller must revoke it.
+		fmt.Println(secret)
 	})
 }

--- a/tools/sb/internal/rest/auth.go
+++ b/tools/sb/internal/rest/auth.go
@@ -60,6 +60,43 @@ func Login(ctx context.Context, host, port, username, password string) (string, 
 	return minted.Secret, nil
 }
 
+// Delegate mints a delegated CHILD token from an existing parent token (#2051).
+// The parent `sb_…` token is the credential, presented as `Authorization:
+// Bearer …` against POST /api/system/api-tokens/delegate (#2048). The box mints
+// a child whose scopes ⊆ parent and whose TTL ≤ parent, deriving the parent
+// lineage server-side from the verified token. The minted child secret is
+// returned; the caller owns revoking it when the work is done.
+//
+// scopes is the requested subset; expiresAt is an RFC3339 timestamp (caller
+// converts a --ttl duration). A super-scope or longer-TTL request is rejected
+// by the box (403/400) and surfaced as a typed *APIError.
+func Delegate(ctx context.Context, host, port, parentToken, name string, scopes []string, expiresAt string) (string, error) {
+	if strings.TrimSpace(parentToken) == "" {
+		return "", &APIError{Message: "delegate: a parent token is required (--parent or SB_TOKEN)"}
+	}
+	httpc := &http.Client{Timeout: defaultTimeout}
+	base := fmt.Sprintf("http://%s:%s", host, port)
+
+	body := map[string]any{
+		"name":   name,
+		"scopes": scopes,
+	}
+	if expiresAt != "" {
+		body["expiresAt"] = expiresAt
+	}
+
+	var minted struct {
+		Secret string `json:"secret"`
+	}
+	if err := postBearerJSON(ctx, httpc, base+"/api/system/api-tokens/delegate", parentToken, body, &minted); err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(minted.Secret, "sb_") {
+		return "", &APIError{Message: "delegate succeeded but the box returned no usable token"}
+	}
+	return minted.Secret, nil
+}
+
 // EnsureUSBBoot logs in with the box admin credentials and sets a one-shot UEFI
 // BootNext to the USB stick (then reboots the box), so the next boot installs
 // from the USB instead of the existing disk. It uses cookie auth — so it works
@@ -91,6 +128,42 @@ func EnsureUSBBoot(ctx context.Context, host, port, username, password string) (
 		resp.Message = "One-shot USB boot set; the box is rebooting."
 	}
 	return resp.Message, nil
+}
+
+// postBearerJSON POSTs body as JSON authenticated with `Authorization: Bearer
+// <token>` (the delegate flow's parent credential) and decodes a 2xx response
+// into out (when non-nil), or returns a typed error. A 401/403 surfaces as an
+// *APIError carrying the box's explanation (bad/expired/super-scope parent).
+func postBearerJSON(ctx context.Context, httpc *http.Client, url, token string, body, out any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return &APIError{Message: err.Error()}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(raw)))
+	if err != nil {
+		return &APIError{Message: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	// Same-origin header for the proxy CSRF gate (see postJSON); the Bearer
+	// alone also satisfies it, but matching keeps the two mint paths uniform.
+	req.Header.Set("Origin", req.URL.Scheme+"://"+req.URL.Host)
+	resp, err := httpc.Do(req)
+	if err != nil {
+		return &APIError{Message: fmt.Sprintf("cannot reach box: %v", err)}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf := make([]byte, 4096)
+		n, _ := resp.Body.Read(buf)
+		return &APIError{Status: resp.StatusCode, Message: serverError(buf[:n], resp.StatusCode)}
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return &APIError{Message: "malformed response: " + err.Error()}
+		}
+	}
+	return nil
 }
 
 // postJSON POSTs body as JSON on httpc (carrying its cookie jar) and decodes a

--- a/tools/sb/internal/rest/auth_test.go
+++ b/tools/sb/internal/rest/auth_test.go
@@ -74,6 +74,94 @@ func TestLoginRejected(t *testing.T) {
 	}
 }
 
+// TestDelegateSubset covers the happy path: a parent token is presented as a
+// Bearer credential to POST /api/system/api-tokens/delegate, requesting a scope
+// subset + a TTL (expiresAt), and the box returns the minted child secret.
+func TestDelegateSubset(t *testing.T) {
+	var gotBearer, gotExpiresAt string
+	var gotScopes []any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/system/api-tokens/delegate" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			return
+		}
+		if o := r.Header.Get("Origin"); o != "http://"+r.Host {
+			t.Errorf("Origin = %q, want http://%s", o, r.Host)
+		}
+		gotBearer = r.Header.Get("Authorization")
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if s, ok := body["scopes"].([]any); ok {
+			gotScopes = s
+		}
+		if e, ok := body["expiresAt"].(string); ok {
+			gotExpiresAt = e
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"secret": "sb_child_xyz"})
+	}))
+	defer srv.Close()
+
+	host, port := hostPort(t, srv)
+	secret, err := Delegate(context.Background(), host, port, "sb_parent_123",
+		"sb-delegate", []string{"read", "lifecycle"}, "2026-06-22T12:00:00Z")
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if secret != "sb_child_xyz" {
+		t.Errorf("secret = %q, want sb_child_xyz", secret)
+	}
+	if gotBearer != "Bearer sb_parent_123" {
+		t.Errorf("Authorization = %q, want Bearer sb_parent_123", gotBearer)
+	}
+	if len(gotScopes) != 2 || gotScopes[0] != "read" || gotScopes[1] != "lifecycle" {
+		t.Errorf("scopes = %v, want [read lifecycle]", gotScopes)
+	}
+	if gotExpiresAt != "2026-06-22T12:00:00Z" {
+		t.Errorf("expiresAt = %q, want it forwarded verbatim", gotExpiresAt)
+	}
+}
+
+// TestDelegateRejected covers the box rejecting a request that exceeds the
+// parent's grant — a super-scope or longer-TTL ask comes back 403 with the
+// box's explanation, which Delegate must surface as a typed *APIError (not a
+// silent success).
+func TestDelegateRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error": "requested scopes exceed parent grant",
+		})
+	}))
+	defer srv.Close()
+
+	host, port := hostPort(t, srv)
+	_, err := Delegate(context.Background(), host, port, "sb_parent_123",
+		"sb-delegate", []string{"read", "exec", "destroy"}, "2027-01-01T00:00:00Z")
+	if err == nil {
+		t.Fatal("Delegate with super-scope request should error")
+	}
+	ae, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *APIError", err)
+	}
+	if ae.Status != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", ae.Status)
+	}
+	if !strings.Contains(ae.Message, "exceed parent grant") {
+		t.Errorf("message = %q, want the box's explanation", ae.Message)
+	}
+}
+
+// TestDelegateRequiresParent: an empty parent token fails fast before any
+// network call (no box needed).
+func TestDelegateRequiresParent(t *testing.T) {
+	_, err := Delegate(context.Background(), "127.0.0.1", "1", "  ",
+		"sb-delegate", []string{"read"}, "")
+	if err == nil {
+		t.Fatal("Delegate with empty parent should error")
+	}
+}
+
 // hostPort splits an httptest server URL (http://127.0.0.1:PORT) into host+port
 // so Login can rebuild it through its own base-URL formatting.
 func hostPort(t *testing.T, srv *httptest.Server) (string, string) {


### PR DESCRIPTION
## What
Completes the token chain-of-trust epic (#2047). Two security units:
- **#2049** — `verifyToken` now walks UP the `parentId` chain: a leaf token is rejected if any ancestor is revoked/deleted, expired, missing, or the chain is over-deep/cyclic (fail closed). Root tokens unaffected.
- **#2051** — `sb token delegate` (alias `sb token mint`) CLI: mints a scoped, short-TTL child token from a parent via `POST /api/system/api-tokens/delegate` (parent as Bearer); `--scopes` subset, `--ttl` Go-duration → RFC3339 `expiresAt`, child secret printed not saved.

## Why
Closes #2049
Closes #2051

## Risk
Low — #2049 is fail-closed and only tightens leaf-token verification (existing single-token auth unaffected); #2051 is new opt-in CLI surface over an existing delegate endpoint.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 352 warnings, == baseline)
- [x] npm run check:arch
- [x] npm test (full — 3026 passed / 2 skipped)
- [ ] Go jobs (go test/vet/gofmt) — DEFERRED to CI for #2051's tools/sb/ changes

<!-- sb-ai-comment -->
AI-generated