### PR TITLE
fix(ux): kompakte Kacheln, Home zurück (lean), Settings nur Quer-Themen

### DIFF
--- a/packages/frontend/src/app/(dashboard)/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/page.tsx
@@ -1,13 +1,16 @@
-import { redirect } from 'next/navigation';
+'use client';
+
+import OverviewDashboard from '@/dashboards/OverviewDashboard';
 
 /**
- * Root → Services (IA redesign slice 2, spec §2/§4.1: "the list of services is
- * the home"). The old Home hub (OverviewDashboard) is retired from the top nav;
- * its one piece of unique live content — the install-progress monitor — is
- * folded into the Services list (ServicesDashboard), so nothing is lost. Every
- * other Home card (Services / Network / Diagnostics / SSH Terminal / Settings)
- * was a pure navigation shortcut now covered by the collapsed top nav.
+ * Home — the lean, status-led landing (IA redesign, spec §4.3 spirit).
+ *
+ * Restored by operator request as the first thing you see: a clean answer to
+ * "is my box OK?" (health headline + latest diagnose breakdown). The old
+ * navigation-shortcut grid is gone (covered by the top nav), and the live
+ * install-progress monitor stays folded into the Services list, so Home
+ * carries no duplicate nav.
  */
 export default function HomePage() {
-  redirect('/services');
+  return <OverviewDashboard />;
 }

--- a/packages/frontend/src/app/(dashboard)/redirects.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/redirects.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// IA redesign slice 2 (#2030/#1950): the collapsed top nav drops Home and
-// Diagnostics as nouns. `/` redirects to the Services landing, and `/health`
-// folds into `/status` (carrying its tab query so deep links survive).
+// IA redesign slice 2 (#2030/#1950) + Home restore: `/` now RENDERS the lean
+// Home overview (it no longer redirects to /services). `/health` still folds
+// into `/status` (carrying its tab query so deep links survive).
 //
 // We assert the redirect TARGET via a spy rather than the thrown control-flow:
 // Next's real redirect() throws to unwind, but the unit under test is purely
@@ -13,11 +13,11 @@ vi.mock('next/navigation', () => ({ redirect }));
 
 beforeEach(() => redirect.mockClear());
 
-describe('root page → Services landing', () => {
-  it('redirects / to /services', async () => {
+describe('root page → renders Home (no redirect)', () => {
+  it('does not redirect / — it renders the Home overview', async () => {
     const { default: HomePage } = await import('./page');
-    HomePage();
-    expect(redirect).toHaveBeenCalledWith('/services');
+    expect(typeof HomePage).toBe('function');
+    expect(redirect).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/ia.test.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/ia.test.ts
@@ -1,6 +1,31 @@
 import { describe, it, expect } from 'vitest';
 
-import { SETTINGS_GROUPS, SEARCH_INDEX, searchSettings } from './ia';
+import { SETTINGS_GROUPS, SEARCH_INDEX, DEFAULT_GROUP, searchSettings } from './ia';
+
+describe('settings IA — cross-cutting only, no Services group (spec §4.4 / §8)', () => {
+  it('has no Services group — services live on the Services nav + Operate page', () => {
+    expect(SETTINGS_GROUPS.find(g => g.id === 'services')).toBeUndefined();
+  });
+
+  it('exposes exactly the cross-cutting groups + Maintenance', () => {
+    expect(SETTINGS_GROUPS.map(g => g.id)).toEqual([
+      'network-domain',
+      'access',
+      'notifications',
+      'system',
+      'maintenance',
+    ]);
+  });
+
+  it('lands on Network & Domain, not Services', () => {
+    expect(DEFAULT_GROUP.id).toBe('network-domain');
+  });
+
+  it('drops the services search entry', () => {
+    expect(searchSettings('immich').some(h => h.group.id === 'services')).toBe(false);
+    expect(SEARCH_INDEX.some(h => h.group.id === 'services')).toBe(false);
+  });
+});
 
 describe('settings IA — Maintenance launcher (#1958 follow-up)', () => {
   it('has a Maintenance group with the disk-import launcher', () => {

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/ia.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/ia.ts
@@ -22,7 +22,6 @@
 
 import {
   Bell,
-  Boxes,
   Network,
   Server,
   Users,
@@ -61,22 +60,12 @@ export interface SettingsGroup {
   entries: SettingEntry[];
 }
 
+// Services are NOT a Settings concern (spec §4.4 / §8): a service lives on the
+// Services nav and its own Operate page, never in cross-cutting Settings. The
+// old `services` group (a duplicate service list that Settings even LANDED on)
+// is removed; `/settings/services` now redirects to `/services` for old
+// bookmarks. Settings carry only true cross-cutting concerns below.
 export const SETTINGS_GROUPS: SettingsGroup[] = [
-  {
-    // Per-service Operate pages (#1957 / slice 2 of #1950). This group is the
-    // entry point to one Operate page PER SERVICE (Health + Settings + Actions
-    // co-located — feedback_services_are_the_grouping_unit). Its `entries` are
-    // the dynamic list of installed services, resolved at render time from the
-    // digital twin (useOperateServices), so the static list here carries only
-    // the group itself as a searchable hit ("Services" jumps to the index).
-    id: 'services',
-    label: 'Services',
-    intent: 'Operate each service in one place — health, settings and actions.',
-    icon: Boxes,
-    entries: [
-      { id: '', label: 'Services', tier: 'essential', keywords: ['service', 'operate', 'immich', 'jellyfin', 'adguard', 'vaultwarden', 'home assistant', 'app', 'health', 'restart'] },
-    ],
-  },
   {
     id: 'network-domain',
     label: 'Network & Domain',
@@ -154,7 +143,9 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   },
 ];
 
-export const DEFAULT_GROUP = SETTINGS_GROUPS[0];
+// Settings lands on Network & Domain — the first cross-cutting group (services
+// no longer live in Settings, so they're no longer the landing).
+export const DEFAULT_GROUP = SETTINGS_GROUPS.find(g => g.id === 'network-domain') ?? SETTINGS_GROUPS[0];
 
 /** Flattened search index: every setting + its group, for the command palette. */
 export interface SearchHit {

--- a/packages/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from 'next/navigation';
 
+import { DEFAULT_GROUP } from './_lib/ia';
+
+// Settings lands on the first cross-cutting group (Network & Domain). Services
+// no longer live in Settings (spec §4.4 / §8) — they're on the Services nav and
+// their own Operate page.
 export default function SettingsRootPage() {
-  redirect('/settings/services');
+  redirect(`/settings/${DEFAULT_GROUP.id}`);
 }

--- a/packages/frontend/src/app/(dashboard)/settings/services/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/services/page.tsx
@@ -1,61 +1,10 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import Link from 'next/link';
-import { Box, ChevronRight, RefreshCw } from 'lucide-react';
-import GroupIntro from '../_lib/GroupIntro';
-import { SETTINGS_GROUPS } from '../_lib/ia';
-import { useOperateServices } from './_lib/useOperateServices';
-
-const GROUP = SETTINGS_GROUPS.find(g => g.id === 'services')!;
-
-/**
- * Services index (#1957). Lists every managed service, each linking to its
- * per-service Operate page (Health + Settings + Actions). A service is the
- * grouping unit — one tile, one Operate page (feedback_services_are_the_grouping_unit).
- */
-export default function ServicesIndexPage() {
-  const { services, loading } = useOperateServices();
-
-  return (
-    <div className="space-y-6">
-      <GroupIntro intent={GROUP.intent} />
-
-      {loading ? (
-        <div className="flex items-center justify-center gap-2 p-8 text-gray-500">
-          <RefreshCw className="w-4 h-4 animate-spin" /> Loading services…
-        </div>
-      ) : services.length === 0 ? (
-        <div className="p-8 text-center text-gray-500 border border-dashed border-gray-200 dark:border-gray-700 rounded-xl">
-          <Box className="w-10 h-10 mx-auto mb-3 opacity-20" />
-          <p>No managed services found.</p>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {services.map(service => (
-            <Link
-              key={`${service.nodeName}:${service.name}`}
-              href={`/settings/services/${encodeURIComponent(service.id || service.name)}`}
-              className="flex items-center justify-between gap-3 p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-sm transition-all"
-            >
-              <div className="flex items-center gap-3 min-w-0">
-                <span
-                  className={`w-2.5 h-2.5 rounded-full shrink-0 ${
-                    service.active ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
-                  title={service.active ? 'Active' : 'Inactive'}
-                />
-                <div className="min-w-0">
-                  <p className="font-medium text-gray-900 dark:text-gray-100 truncate">{service.displayName}</p>
-                  {service.nodeName && service.nodeName !== 'Local' && (
-                    <p className="text-xs text-gray-400 dark:text-gray-500 truncate">{service.nodeName}</p>
-                  )}
-                </div>
-              </div>
-              <ChevronRight size={18} className="text-gray-400 shrink-0" />
-            </Link>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+// Services left Settings (spec §4.4 / §8): the service list lives on the
+// Services nav, and each service on its own Operate page. This route is kept
+// only so an old `/settings/services` bookmark still resolves — it forwards to
+// the real services home. (The per-service Operate redirect at
+// `/settings/services/[name]` → `/services/[name]` stays as-is.)
+export default function SettingsServicesIndexPage() {
+  redirect('/services');
 }

--- a/packages/frontend/src/components/ServiceCard.tsx
+++ b/packages/frontend/src/components/ServiceCard.tsx
@@ -60,7 +60,7 @@ export default function ServiceCard({
   onRestart,
 }: ServiceCardProps) {
   return (
-    <div className="group bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-4 hover:shadow-md transition-all duration-200 relative overflow-hidden flex flex-col h-full min-w-0">
+    <div className="group self-start bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-4 hover:shadow-md transition-all duration-200 relative overflow-hidden min-w-0">
       <div className="flex items-start gap-4 justify-between mb-3">
         <div className="flex items-start gap-3 flex-1 min-w-0">
           {(() => {
@@ -160,8 +160,10 @@ export default function ServiceCard({
       )}
 
       {/* Address — the one thing a tile needs beyond name + health: where the
-          service lives. Gateway/link carry their own "address" shape. */}
-      <div className="mt-auto pt-1">
+          service lives. Sits directly under the name (no mt-auto: the tile is
+          content-height, not stretched, so there's no empty gap). Gateway/link
+          carry their own "address" shape. */}
+      <div className="mt-2">
         {service.type === 'gateway' ? (
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
             <span className="font-mono text-gray-600 dark:text-gray-300">{service.externalIP || 'N/A'}</span>

--- a/packages/frontend/src/config/navigation.test.ts
+++ b/packages/frontend/src/config/navigation.test.ts
@@ -22,23 +22,29 @@ describe('isNavActive', () => {
   });
 });
 
-describe('top nav — the four nouns + Network Map (IA slice 2, #2030/#1950)', () => {
-  // Spec §3/§4.1/§8: the flat 8-item nav collapses to the four nouns
-  // (Services · Status · Settings · Backup) plus Network Map, kept top-level by
-  // operator preference. Home, Diagnostics and SSH Terminal leave the top nav.
+describe('top nav — Home + the four nouns + Network Map (IA slice 2, #2030/#1950)', () => {
+  // Spec §3/§4.1/§8: the four nouns (Services · Status · Settings · Backup) plus
+  // Network Map, kept top-level by operator preference. Home is restored by
+  // operator request as a lean, status-led landing (spec §4.3 spirit).
+  // Diagnostics and SSH Terminal stay off the top nav.
   const ids = NAVIGATION_ENTRIES.map(e => e.id);
 
-  it('is exactly Services · Status · Settings · Backup · Network Map', () => {
-    expect(ids).toEqual(['services', 'status', 'settings', 'backup', 'network']);
+  it('is exactly Home · Services · Status · Settings · Backup · Network Map', () => {
+    expect(ids).toEqual(['home', 'services', 'status', 'settings', 'backup', 'network']);
   });
 
-  it('drops Home, Diagnostics and SSH Terminal from the top nav', () => {
-    expect(ids).not.toContain('home');
+  it('Home is the first entry and renders at /', () => {
+    expect(ids[0]).toBe('home');
+    const home = NAVIGATION_ENTRIES.find(e => e.id === 'home');
+    expect(home?.path).toBe('/');
+  });
+
+  it('drops Diagnostics and SSH Terminal from the top nav', () => {
     expect(ids).not.toContain('health');
     expect(ids).not.toContain('terminal');
   });
 
-  it('Services is the landing noun (the list of services is the home)', () => {
+  it('Services links to /services (the list of every app)', () => {
     const services = NAVIGATION_ENTRIES.find(e => e.id === 'services');
     expect(services?.path).toBe('/services');
   });

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -15,7 +15,7 @@
  *      bar's icon row instead, so they're still reachable on a phone;
  *      see MobileNav.tsx #1992).
  */
-import { Box, HeartPulse, Settings, Network, DatabaseBackup } from 'lucide-react';
+import { Home, Box, HeartPulse, Settings, Network, DatabaseBackup } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 export interface NavigationEntry {
@@ -52,14 +52,15 @@ export function isNavActive(pathname: string, path: string): boolean {
 }
 
 /**
- * The four nouns + Network Map — the collapsed top nav of the IA redesign
- * (slice 2, spec §3/§4.1/§8). The flat 8-item list (Home, Services, Network
- * Map, Status, Diagnostics, SSH Terminal, Backup, Settings) is rip-and-
- * replaced by **Services · Status · Settings · Backup · Network Map**:
+ * The collapsed top nav of the IA redesign (slice 2, spec §3/§4.1/§8):
+ * **Home · Services · Status · Settings · Backup · Network Map**.
  *
- *   - Services is the home — "the list of services is the home" (spec §2/§4.1).
- *     `/` redirects to `/services`; the old Home hub's live install monitor is
- *     folded into the Services list so nothing is lost.
+ *   - Home is a lean, status-led landing (restored by operator request, spec
+ *     §4.3 spirit): the box-wide health headline + latest diagnose breakdown
+ *     ("is my box OK?"). It carries no navigation-shortcut cards (the old hub's
+ *     pure-nav grid is covered by this nav), and the live install-progress
+ *     monitor stays folded into the Services list, so nothing is duplicated.
+ *   - Services is the list of every app (spec §2/§4.1).
  *   - Status is the single box-wide health screen — it absorbs the old
  *     Diagnostics (`/health`), which now redirects to `/status` (spec §4.3/§8).
  *     Box-wide containers live here (and ONLY here); the per-container tab is
@@ -78,6 +79,7 @@ export function isNavActive(pathname: string, path: string): boolean {
  * surface in the mobile top-bar icon row instead).
  */
 export const NAVIGATION_ENTRIES: NavigationEntry[] = [
+  { id: 'home', name: 'Home', shortLabel: 'Home', icon: Home, path: '/' },
   { id: 'services', name: 'Services', shortLabel: 'Services', icon: Box, path: '/services' },
   { id: 'status', name: 'Status', shortLabel: 'Status', icon: HeartPulse, path: '/status', hiddenOnMobileBottom: true },
   { id: 'settings', name: 'Settings', shortLabel: 'Settings', icon: Settings, path: '/settings', hiddenOnMobileBottom: true },

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Activity, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
+import { useCoreHealth } from '@/hooks/useCoreHealth';
+
+/**
+ * Latest persisted diagnose breakdown for the Home card (#1873).
+ *
+ * Reads GET /api/health/checks — the SAME endpoint HealthDashboard already
+ * polls — which returns the enriched check rows including the synthetic
+ * `diagnose:*` probe rows persisted by the daily self-diagnose run
+ * (getDiagnoseChecksEnriched). This is a pure read of the LAST persisted
+ * results: it does NOT trigger a diagnose run (no POST /api/system/diagnose).
+ * A fresh box with no persisted results returns zero diagnose rows → the
+ * card renders "Not run yet" / neutral.
+ */
+export interface DiagnoseBreakdown {
+  healthy: number;
+  warning: number;
+  failure: number;
+  unknown: number;
+  total: number;
+  loaded: boolean;
+}
+
+interface EnrichedCheckRow {
+  id: string;
+  status?: string;
+  diagnose?: { status?: string };
+}
+
+/** Map a diagnose row to one of the four buckets. The four-way status lives
+ *  on `diagnose.status` (ok/warn/fail/info); the row-level `status` only
+ *  carries the folded binary ok/fail, so we prefer the diagnose field and
+ *  fall back to it when absent. Per #1873: ok→healthy, warn→warning,
+ *  fail→failure, info/none/unknown→unknown. */
+function bucketForDiagnoseRow(row: EnrichedCheckRow): keyof Omit<DiagnoseBreakdown, 'total' | 'loaded'> {
+  const status = row.diagnose?.status ?? row.status;
+  if (status === 'ok') return 'healthy';
+  if (status === 'warn') return 'warning';
+  if (status === 'fail') return 'failure';
+  return 'unknown';
+}
+
+export function summarizeDiagnoseRows(rows: EnrichedCheckRow[]): Omit<DiagnoseBreakdown, 'loaded'> {
+  const breakdown = { healthy: 0, warning: 0, failure: 0, unknown: 0, total: 0 };
+  for (const row of rows) {
+    if (!row.id?.startsWith('diagnose:')) continue;
+    breakdown[bucketForDiagnoseRow(row)] += 1;
+    breakdown.total += 1;
+  }
+  return breakdown;
+}
+
+function useDiagnoseOverview(): DiagnoseBreakdown {
+  const [breakdown, setBreakdown] = useState<DiagnoseBreakdown>({
+    healthy: 0,
+    warning: 0,
+    failure: 0,
+    unknown: 0,
+    total: 0,
+    loaded: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/health/checks');
+        if (!res.ok) return;
+        const rows = (await res.json()) as EnrichedCheckRow[];
+        if (cancelled) return;
+        setBreakdown({ ...summarizeDiagnoseRows(rows), loaded: true });
+      } catch (error) {
+        // Background read — keep the card neutral on failure rather than
+        // surfacing a transient fetch blip as a diagnose state.
+        console.error('[OverviewDashboard] Failed to read diagnose results', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return breakdown;
+}
+
+/** Card metric/description/tone from the persisted diagnose breakdown.
+ *  Tone mirrors the headline (worst status wins):
+ *  any failure → bad, else any warning → warn, else a run with no issues →
+ *  good, else (never run) → neutral. */
+export function diagnoseCardView(b: DiagnoseBreakdown): {
+  metric: string;
+  description: string;
+  tone: 'good' | 'warn' | 'bad' | 'neutral';
+} {
+  if (!b.loaded) return { metric: '…', description: 'Reading diagnose status…', tone: 'neutral' };
+  if (b.total === 0) {
+    return { metric: 'Not run yet', description: 'No diagnostics have run on this box yet', tone: 'neutral' };
+  }
+  const metric = `${b.healthy} healthy · ${b.warning} warning · ${b.failure} failure`;
+  if (b.failure > 0) {
+    return { metric, description: `${b.failure} probe${b.failure === 1 ? '' : 's'} failing`, tone: 'bad' };
+  }
+  if (b.warning > 0) {
+    return { metric, description: `${b.warning} probe${b.warning === 1 ? '' : 's'} warning`, tone: 'warn' };
+  }
+  return { metric, description: 'All probes healthy', tone: 'good' };
+}
+
+/**
+ * Home — the lean, status-led landing (IA redesign, spec §4.3 spirit).
+ *
+ * Restored from the old OverviewDashboard but lightened to answer ONE
+ * question at a glance: *"is my box OK?"*. The old grid of pure-navigation
+ * shortcut cards (Services / Network Map / Diagnostics / SSH Terminal) is
+ * gone — that's all covered by the top nav now — and the install-progress
+ * monitor stays where it was folded, on the Services list. What remains is
+ * the value: the box-wide health headline + the latest persisted diagnose
+ * breakdown.
+ *
+ * Backed entirely by the existing DigitalTwinProvider snapshot + the
+ * read-only /api/health/checks endpoint — no new endpoints, no diagnose run
+ * kicked off.
+ */
+export default function OverviewDashboard() {
+  const { data, isConnected } = useDigitalTwinContext();
+  // Truthy `data` is the readiness signal — DigitalTwinProvider holds
+  // the snapshot in a useState, so on a fast machine the first render
+  // already sees data and the "Reading status…" headline never shows.
+  // On reconnect after a drop, `data` stays populated from the last
+  // snapshot; `isConnected=false` is what we surface to the user.
+  const hasFirstSnapshot = data !== null && data !== undefined;
+
+  const firstNode = data?.nodes ? Object.values(data.nodes)[0] : undefined;
+  const services = firstNode?.services || [];
+  const managedServices = services.filter(s => s.activeState === 'active' || s.activeState === 'failed' || s.activeState === 'inactive');
+  const activeCount = managedServices.filter(s => s.activeState === 'active').length;
+  const failedCount = managedServices.filter(s => s.activeState === 'failed').length;
+  const totalCount = managedServices.length;
+
+  const gatewayUp = data?.gateway?.upstreamStatus === 'up';
+
+  // Same signal the CoreHealthBanner uses. The twin only carries systemd
+  // `activeState`, so a core service that's "active" but crash-looping
+  // (e.g. authelia failing its LDAP bind) counted as healthy here — which
+  // contradicted the banner's "Core stack unhealthy". Reading core-health
+  // directly keeps the headline and the banner in agreement.
+  const { unhealthy: coreUnhealthy } = useCoreHealth();
+
+  // Latest persisted diagnose breakdown (#1873) — read-only, no run kicked off.
+  const diagnose = useDiagnoseOverview();
+  const diagnoseView = diagnoseCardView(diagnose);
+
+  const healthHeadline = (() => {
+    if (!hasFirstSnapshot) return { tone: 'neutral' as const, text: 'Reading status…' };
+    if (coreUnhealthy) return { tone: 'bad' as const, text: 'Core services need attention' };
+    if (failedCount > 0) return { tone: 'bad' as const, text: `${failedCount} service${failedCount === 1 ? '' : 's'} need${failedCount === 1 ? 's' : ''} attention` };
+    if (totalCount === 0) return { tone: 'neutral' as const, text: 'No services installed yet' };
+    if (!gatewayUp) return { tone: 'warn' as const, text: 'Internet gateway is unreachable' };
+    return { tone: 'good' as const, text: 'Everything looks healthy' };
+  })();
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <header>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Home</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            {data?.serverName || firstNode?.resources?.os?.hostname || 'ServiceBay'}
+            {!isConnected && hasFirstSnapshot && (
+              <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">· reconnecting…</span>
+            )}
+          </p>
+        </header>
+
+        {/* Headline status — the single sentence that answers "is everything OK?" */}
+        <HealthHeadline tone={healthHeadline.tone} text={healthHeadline.text} />
+
+        {/* Box-wide at-a-glance: services running + latest diagnose breakdown. */}
+        <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <StatCard
+            title="Services"
+            metric={hasFirstSnapshot ? `${activeCount} of ${totalCount} running` : '…'}
+            description={
+              failedCount > 0
+                ? `${failedCount} need attention`
+                : totalCount === 0
+                  ? 'No services installed yet'
+                  : activeCount === totalCount
+                    ? 'All services are running'
+                    : `${totalCount - activeCount} service${totalCount - activeCount === 1 ? '' : 's'} stopped`
+            }
+            tone={failedCount > 0 ? 'bad' : totalCount === 0 ? 'neutral' : activeCount === totalCount ? 'good' : 'warn'}
+          />
+          <StatCard
+            title="Diagnostics"
+            metric={diagnoseView.metric}
+            description={diagnoseView.description}
+            icon={Activity}
+            tone={diagnoseView.tone}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function HealthHeadline({ tone, text }: { tone: 'good' | 'warn' | 'bad' | 'neutral'; text: string }) {
+  const toneClasses: Record<typeof tone, string> = {
+    good: 'bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-900/50 text-emerald-800 dark:text-emerald-300',
+    warn: 'bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-900/50 text-amber-800 dark:text-amber-300',
+    bad: 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900/50 text-red-800 dark:text-red-300',
+    neutral: 'bg-gray-50 dark:bg-gray-900/40 border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300',
+  };
+  const Icon = tone === 'bad' || tone === 'warn' ? AlertCircle : CheckCircle2;
+  return (
+    <div className={`flex items-center gap-3 rounded-xl border px-4 py-3.5 transition-all duration-300 ${toneClasses[tone]}`}>
+      <Icon size={20} className="shrink-0" />
+      <span className="text-sm font-semibold tracking-wide">{text}</span>
+    </div>
+  );
+}
+
+interface StatCardProps {
+  title: string;
+  metric: string;
+  description: string;
+  icon?: typeof Activity;
+  tone: 'good' | 'warn' | 'bad' | 'neutral';
+}
+
+function StatCard({ title, metric, description, icon: Icon, tone }: StatCardProps) {
+  const accentClasses: Record<typeof tone, string> = {
+    good: 'text-emerald-600 dark:text-emerald-400',
+    warn: 'text-amber-600 dark:text-amber-400',
+    bad: 'text-red-600 dark:text-red-400',
+    neutral: 'text-blue-600 dark:text-blue-400',
+  };
+  return (
+    <div className="block rounded-xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
+      {Icon && (
+        <div className="mb-3">
+          <Icon size={20} className={accentClasses[tone]} />
+        </div>
+      )}
+      <h2 className="font-bold text-gray-900 dark:text-gray-100 tracking-wide text-base">{title}</h2>
+      <p className={`text-sm font-semibold mt-1 ${accentClasses[tone]}`}>{metric}</p>
+      <p className="text-xs text-gray-600 dark:text-gray-300 mt-2 font-medium leading-relaxed">{description}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
UX-Iteration nach Operator-Feedback auf der echten Box (4.137.0).

## Änderungen
1. **Kompakte Services-Kachel** — `h-full`/`mt-auto` machten jede Kachel so hoch wie die vollste der Reihe (Loch in der Mitte). Jetzt `self-start` + inhaltshoch, Adresse direkt unter dem Namen.
2. **Home zurück (lean, status-geführt)** — alte Overview-Übersicht wiederhergestellt aus `58cb9a75^`, entrümpelt: Health/Diagnose-Zusammenfassung bleibt, alte Nav-Shortcut-Kacheln raus. `Home` wieder erster Nav-Eintrag, `/` rendert die Übersicht (kein Redirect mehr).
3. **Settings = nur Quer-Themen** — `services`-Gruppe aus Settings entfernt (Services leben in der Services-Nav + auf ihrer Operate-Seite), `DEFAULT_GROUP` → `network-domain`, `/settings` landet dort. `/settings/services` → Redirect auf `/services` (Per-Service-Operate-Redirect bleibt).

## Verifikation
- tsc 0 Fehler, eslint 0 Fehler, Pre-Push (volle Suite + Build) grün.
- **Visuell noch nicht bestätigt** — der Headless-Render rendert die Schrift mit Höhe 0 (Font-Bug), deshalb prüft der Operator die Pixel nach dem Deploy. Struktur (Routen/Nav/Gruppen) ist self-verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
