### PR TITLE
feat(ux): Services als Liste/Cards, Home klickbar, Coverage zurück

### DIFF
--- a/packages/frontend/src/components/ServiceRow.tsx
+++ b/packages/frontend/src/components/ServiceRow.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { AlertCircle, Download, RotateCcw } from 'lucide-react';
+import type { ServiceViewModel } from '@servicebay/api-client';
+import { ServiceActionBar } from '@/components/ServiceActionBar';
+import { DomainHealthDot } from '@/components/DomainHealthDot';
+
+// #2067: the Services overview reads as a list on desktop, not a card grid
+// (operator feedback on 4.138.0). ServiceRow is the desktop list-row twin of
+// ServiceCard: same data (ServiceViewModel), same action callbacks, same lean
+// content (status dot + name + badges + address + ServiceActionBar) — just laid
+// out as one tight table-like row instead of a card. ServiceCard stays for the
+// mobile single-column stack; the dashboard renders one or the other per
+// breakpoint (`hidden md:flex` vs `md:hidden`).
+
+export interface ServiceRowProps {
+  service: ServiceViewModel;
+  /** Domains NPM is serving over HTTPS — picks the scheme for the per-domain
+   *  link so LAN-only services don't TLS-error on click. */
+  httpsDomains: Set<string>;
+  /** Registry has a newer image digest than the running one (#1860). */
+  imageUpdateAvailable?: boolean;
+  onMonitor: (service: ServiceViewModel) => void;
+  onEdit: (service: ServiceViewModel) => void;
+  onActions: (service: ServiceViewModel) => void;
+  onEditLink: (service: ServiceViewModel) => void;
+  onDelete: (service: ServiceViewModel) => void;
+  onRestart: (service: ServiceViewModel) => void;
+}
+
+const badgeBase = 'text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 border rounded';
+
+export default function ServiceRow({
+  service,
+  httpsDomains,
+  imageUpdateAvailable,
+  onMonitor,
+  onEdit,
+  onActions,
+  onEditLink,
+  onDelete,
+  onRestart,
+}: ServiceRowProps) {
+  // 3-state status dot (mirrors ServiceCard): systemd transitional states and
+  // the crash-loop "auto-restart" subState are amber, active is green, else red.
+  const transitional =
+    ['activating', 'reloading', 'deactivating'].includes(service.activeState ?? '') ||
+    service.subState === 'auto-restart';
+  const dotClass = transitional ? 'bg-amber-500 animate-pulse' : service.active ? 'bg-green-500' : 'bg-red-500';
+  const dotTitle = transitional
+    ? `${service.activeState ?? 'transitioning'}${service.subState ? ` (${service.subState})` : ''}`
+    : service.status;
+
+  const showFailedNudge = !service.active && service.type !== 'gateway' && service.type !== 'link';
+
+  return (
+    <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-colors min-w-0">
+      {/* Status dot */}
+      <div className={`w-3 h-3 shrink-0 rounded-full ${dotClass}`} title={dotTitle} />
+
+      {/* Name + badges */}
+      <div className="flex items-center gap-2 min-w-0 basis-1/3 shrink-0">
+        <h3
+          className="font-semibold text-sm text-gray-900 dark:text-gray-100 truncate"
+          title={service.name}
+          data-testid={`service-name-${service.displayName}`}
+        >
+          {service.displayName}
+        </h3>
+        {service.nodeName && service.nodeName !== 'Local' && (
+          <span className={`${badgeBase} bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800`}>
+            {service.nodeName}
+          </span>
+        )}
+        {service.type === 'link' && (
+          <span className={`${badgeBase} bg-cyan-100 dark:bg-cyan-900/40 text-cyan-700 dark:text-cyan-400 border-cyan-200 dark:border-cyan-800`}>
+            External Link
+          </span>
+        )}
+        {service.type === 'gateway' && (
+          <span className={`${badgeBase} bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-400 border-orange-200 dark:border-orange-800`}>
+            Gateway
+          </span>
+        )}
+        {service.labels && service.labels['servicebay.role'] === 'reverse-proxy' && (
+          <span className={`${badgeBase} bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800`}>
+            Reverse Proxy
+          </span>
+        )}
+        {service.labels && service.labels['servicebay.role'] === 'system' && (
+          <span className={`${badgeBase} bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800`}>
+            System
+          </span>
+        )}
+        {imageUpdateAvailable && (
+          <span
+            className={`inline-flex items-center gap-1 ${badgeBase} bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800`}
+            title="A newer image is available in the registry. Re-deploy this service to pull it."
+          >
+            <Download size={10} /> Update available
+          </span>
+        )}
+      </div>
+
+      {/* Address — same shapes as ServiceCard (gateway IPs / link URL /
+          verified domains with health dots / "No public address"). */}
+      <div className="flex-1 min-w-0">
+        {service.type === 'gateway' ? (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            <span className="font-mono text-gray-600 dark:text-gray-300">{service.externalIP || 'N/A'}</span>
+            {service.internalIP && <span className="font-mono text-gray-400 dark:text-gray-500">· {service.internalIP}</span>}
+          </div>
+        ) : service.type === 'link' ? (
+          <a href={service.url} target="_blank" rel="noopener noreferrer" className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline break-all">
+            {service.url}
+          </a>
+        ) : service.verifiedDomains && service.verifiedDomains.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {service.verifiedDomains.map(d => {
+              const bareDomain = d.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+              const looksLikeDomain = /\./.test(bareDomain);
+              const scheme = httpsDomains.has(bareDomain.toLowerCase()) ? 'https' : 'http';
+              const href = d.startsWith('http') ? d : `${scheme}://${d}`;
+              return (
+                <span key={d} className="inline-flex items-center gap-1.5 text-xs font-mono text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 px-1.5 py-0.5 rounded">
+                  {looksLikeDomain && <DomainHealthDot domain={bareDomain} />}
+                  <a href={href} target="_blank" rel="noopener noreferrer" className="hover:underline">{d}</a>
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <span className="text-xs text-gray-400 dark:text-gray-500">No public address</span>
+        )}
+      </div>
+
+      {/* Failed-state nudge — compact inline restart/logs, mirrors ServiceCard. */}
+      {showFailedNudge && (
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className="hidden xl:inline-flex items-center gap-1 text-xs text-red-700 dark:text-red-300" title={service.status}>
+            <AlertCircle size={12} className="shrink-0" /> {service.status || 'inactive'}
+          </span>
+          <button
+            type="button"
+            onClick={() => onRestart(service)}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded border border-red-300 dark:border-red-700 text-red-800 dark:text-red-100 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
+            title="Restart this service"
+          >
+            <RotateCcw size={12} /> Restart
+          </button>
+        </div>
+      )}
+
+      {/* Action bar */}
+      <ServiceActionBar
+        service={service}
+        className="shrink-0"
+        onMonitor={onMonitor}
+        onEdit={onEdit}
+        onActions={onActions}
+        onEditLink={onEditLink}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+}

--- a/packages/frontend/src/dashboards/OverviewDashboard.diagnose.test.ts
+++ b/packages/frontend/src/dashboards/OverviewDashboard.diagnose.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Home Overview Diagnose card breakdown (#1873).
+ *
+ * The Diagnose OverviewCard surfaces the LATEST PERSISTED diagnose run from
+ * GET /api/health/checks (same endpoint HealthDashboard polls) — no diagnose
+ * run is triggered on render. These tests cover the two pure helpers that
+ * derive the card's counts + tone from the enriched check rows:
+ *  - summarizeDiagnoseRows: filter to `diagnose:*` rows, bucket by the
+ *    four-way diagnose.status (ok→healthy, warn→warning, fail→failure,
+ *    info/none→unknown).
+ *  - diagnoseCardView: metric/description/tone with worst-status tone.
+ */
+import { describe, it, expect } from 'vitest';
+import { summarizeDiagnoseRows, diagnoseCardView } from './OverviewDashboard';
+
+describe('summarizeDiagnoseRows', () => {
+  it('buckets the four-way diagnose.status and ignores non-diagnose rows', () => {
+    const rows = [
+      { id: 'diagnose:agent', diagnose: { status: 'ok' } },
+      { id: 'diagnose:dns', diagnose: { status: 'warn' } },
+      { id: 'diagnose:cert', diagnose: { status: 'fail' } },
+      { id: 'diagnose:sso', diagnose: { status: 'info' } },
+      { id: 'diagnose:legacy', diagnose: { status: undefined } },
+      // Non-diagnose check rows must not be counted.
+      { id: 'http-portal', status: 'ok' },
+      { id: 'ping-router', status: 'fail' },
+    ];
+    expect(summarizeDiagnoseRows(rows)).toEqual({
+      healthy: 1,
+      warning: 1,
+      failure: 1,
+      unknown: 2, // info + missing-status
+      total: 5,
+    });
+  });
+
+  it('falls back to the row status when diagnose field is absent', () => {
+    const rows = [
+      { id: 'diagnose:a', status: 'ok' },
+      { id: 'diagnose:b', status: 'fail' },
+    ];
+    expect(summarizeDiagnoseRows(rows)).toEqual({
+      healthy: 1,
+      warning: 0,
+      failure: 1,
+      unknown: 0,
+      total: 2,
+    });
+  });
+
+  it('returns all-zero for zero diagnose rows (never run)', () => {
+    expect(summarizeDiagnoseRows([{ id: 'http-x', status: 'ok' }])).toEqual({
+      healthy: 0,
+      warning: 0,
+      failure: 0,
+      unknown: 0,
+      total: 0,
+    });
+  });
+});
+
+describe('diagnoseCardView', () => {
+  const base = { healthy: 0, warning: 0, failure: 0, unknown: 0, total: 0, loaded: true };
+
+  it('is neutral "Reading…" while not loaded', () => {
+    const v = diagnoseCardView({ ...base, loaded: false });
+    expect(v.tone).toBe('neutral');
+  });
+
+  it('renders "Not run yet" / neutral when no persisted results', () => {
+    const v = diagnoseCardView({ ...base, total: 0 });
+    expect(v.metric).toBe('Not run yet');
+    expect(v.tone).toBe('neutral');
+  });
+
+  it('tone is bad when any failure present', () => {
+    const v = diagnoseCardView({ ...base, healthy: 3, warning: 1, failure: 2, total: 6 });
+    expect(v.tone).toBe('bad');
+    expect(v.metric).toBe('3 healthy · 1 warning · 2 failure');
+  });
+
+  it('tone is warn when warnings but no failures', () => {
+    const v = diagnoseCardView({ ...base, healthy: 4, warning: 1, failure: 0, total: 5 });
+    expect(v.tone).toBe('warn');
+  });
+
+  it('tone is good when run with no warnings or failures', () => {
+    const v = diagnoseCardView({ ...base, healthy: 5, total: 5 });
+    expect(v.tone).toBe('good');
+    expect(v.description).toBe('All probes healthy');
+  });
+});

--- a/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Home OverviewDashboard render smoke test (#2067).
+ *
+ * The diagnose-helper unit tests (OverviewDashboard.diagnose.test.ts) cover the
+ * pure summarize/cardView functions; this mounts the actual dashboard so the
+ * render path — health headline + the now-CLICKABLE StatCards (operator
+ * feedback: the Home cards used to be inert) — is exercised. We assert the
+ * headline renders and the cards are real navigation links (href to
+ * /services and /status), which is the whole point of the fix.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import OverviewDashboard from './OverviewDashboard';
+
+// Next <Link> renders a plain <a> in jsdom; no router needed for href checks.
+vi.mock('@/providers/DigitalTwinProvider', () => ({
+  useDigitalTwinContext: () => ({
+    data: {
+      serverName: 'test-box',
+      gateway: { upstreamStatus: 'up' },
+      nodes: {
+        Local: {
+          services: [
+            { name: 'a.service', activeState: 'active' },
+            { name: 'b.service', activeState: 'active' },
+          ],
+        },
+      },
+    },
+    isConnected: true,
+  }),
+}));
+
+vi.mock('@/hooks/useCoreHealth', () => ({
+  useCoreHealth: () => ({ unhealthy: false }),
+}));
+
+describe('OverviewDashboard render', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // /api/health/checks read — return zero diagnose rows (neutral card).
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => [],
+    })) as unknown as typeof fetch);
+  });
+
+  it('renders the health headline and links the cards to /services and /status', () => {
+    render(<OverviewDashboard />);
+
+    // Healthy box (2/2 active, gateway up, core healthy) → the good headline.
+    expect(screen.getByText('Everything looks healthy')).toBeDefined();
+
+    // The Home cards are now clickable navigation, not inert blocks.
+    const servicesCard = screen.getByText('Services').closest('a');
+    expect(servicesCard).not.toBeNull();
+    expect(servicesCard?.getAttribute('href')).toBe('/services');
+
+    const diagnosticsCard = screen.getByText('Diagnostics').closest('a');
+    expect(diagnosticsCard).not.toBeNull();
+    expect(diagnosticsCard?.getAttribute('href')).toBe('/status');
+  });
+});

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Activity, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
 import { useCoreHealth } from '@/hooks/useCoreHealth';
@@ -194,6 +195,7 @@ export default function OverviewDashboard() {
                     : `${totalCount - activeCount} service${totalCount - activeCount === 1 ? '' : 's'} stopped`
             }
             tone={failedCount > 0 ? 'bad' : totalCount === 0 ? 'neutral' : activeCount === totalCount ? 'good' : 'warn'}
+            href="/services"
           />
           <StatCard
             title="Diagnostics"
@@ -201,6 +203,7 @@ export default function OverviewDashboard() {
             description={diagnoseView.description}
             icon={Activity}
             tone={diagnoseView.tone}
+            href="/status"
           />
         </section>
       </div>
@@ -230,17 +233,21 @@ interface StatCardProps {
   description: string;
   icon?: typeof Activity;
   tone: 'good' | 'warn' | 'bad' | 'neutral';
+  /** Where clicking the card navigates (#2067 — the Home cards used to be
+   *  inert; the operator clicked them and nothing happened). When set, the
+   *  card renders as a Next <Link> with a clear hover affordance. */
+  href?: string;
 }
 
-function StatCard({ title, metric, description, icon: Icon, tone }: StatCardProps) {
+function StatCard({ title, metric, description, icon: Icon, tone, href }: StatCardProps) {
   const accentClasses: Record<typeof tone, string> = {
     good: 'text-emerald-600 dark:text-emerald-400',
     warn: 'text-amber-600 dark:text-amber-400',
     bad: 'text-red-600 dark:text-red-400',
     neutral: 'text-blue-600 dark:text-blue-400',
   };
-  return (
-    <div className="block rounded-xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
+  const inner = (
+    <>
       {Icon && (
         <div className="mb-3">
           <Icon size={20} className={accentClasses[tone]} />
@@ -249,6 +256,18 @@ function StatCard({ title, metric, description, icon: Icon, tone }: StatCardProp
       <h2 className="font-bold text-gray-900 dark:text-gray-100 tracking-wide text-base">{title}</h2>
       <p className={`text-sm font-semibold mt-1 ${accentClasses[tone]}`}>{metric}</p>
       <p className="text-xs text-gray-600 dark:text-gray-300 mt-2 font-medium leading-relaxed">{description}</p>
-    </div>
+    </>
   );
+  const baseClasses = 'block rounded-xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800';
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={`${baseClasses} cursor-pointer transition-all hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-md dark:hover:bg-gray-800/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={baseClasses}>{inner}</div>;
 }

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -18,6 +18,7 @@ import ExternalLinkModal from '@/components/ExternalLinkModal';
 import FileViewerOverlay from '@/components/FileViewerOverlay';
 import RegistryDashboard from '@/dashboards/RegistryDashboard';
 import ServiceCard from '@/components/ServiceCard';
+import ServiceRow from '@/components/ServiceRow';
 import { useServiceActions } from '@/hooks/useServiceActions';
 import { useContainerActions } from '@/hooks/useContainerActions';
 import { buildServiceViewModel } from '@servicebay/api-client';
@@ -679,7 +680,31 @@ export default function ServicesDashboard() {
 
         return (
             <div className="space-y-4">
-                <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-6 auto-rows-fr">
+                {/* Desktop (md+): a dense list — one tight row per service, so
+                    the overview reads as a table with columns (status · name ·
+                    address · actions), not a sparse card grid (#2067 operator
+                    feedback). Bundles keep their card shape inline. */}
+                <div className="hidden md:block rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800 overflow-hidden">
+                    {combinedItems.map(entry => (
+                        entry.type === 'service'
+                            ? <ServiceRow
+                                    key={entry.id}
+                                    service={entry.service}
+                                    httpsDomains={httpsDomains}
+                                    imageUpdateAvailable={imageUpdateServices.has(entry.service.name.replace(/\.service$/, ''))}
+                                    onMonitor={openServiceDetail}
+                                    onEdit={openEditDrawer}
+                                    onActions={openActions}
+                                    onEditLink={handleEditLink}
+                                    onDelete={requestDelete}
+                                    onRestart={triggerRestart}
+                              />
+                            : <div key={entry.id} className="p-3"><BundleCard bundle={entry.bundle} /></div>
+                    ))}
+                </div>
+
+                {/* Mobile (below md): the existing single-column card stack. */}
+                <div className="md:hidden grid grid-cols-1 gap-6">
                     {combinedItems.map(entry => (
                         entry.type === 'service'
                             ? <ServiceCard

--- a/tests/frontend/ServicesDashboard.test.tsx
+++ b/tests/frontend/ServicesDashboard.test.tsx
@@ -80,11 +80,18 @@ describe('ServicesDashboard', () => {
         currentMockData = defaultTwinData;
     });
 
+    // #2067: the Services overview now renders TWICE in jsdom — the desktop
+    // list (ServiceRow, `hidden md:block`) and the mobile card stack
+    // (ServiceCard, `md:hidden`). CSS hides one per breakpoint in a real
+    // browser, but jsdom applies no styles, so every service name/badge
+    // appears in both. Assertions that used `getBy*` (expects exactly one)
+    // now use `getAllBy*` + length checks.
+
     it('keeps ports off the lean list tile (they live on the Operate page)', async () => {
         render(<ServicesDashboard />);
 
-        // The service still renders in the list…
-        await waitFor(() => screen.getByTestId('service-name-redis'));
+        // The service still renders in the list (desktop row + mobile card)…
+        await waitFor(() => expect(screen.getAllByTestId('service-name-redis').length).toBeGreaterThan(0));
         // …but the lean list tile (IA spec §4.1: "one dot = one honest health
         // state") no longer crowds in per-port links — ports moved to the
         // per-service Operate page.
@@ -93,35 +100,31 @@ describe('ServicesDashboard', () => {
 
     it('displays verified domains', async () => {
         render(<ServicesDashboard />);
-        
-        // Find Nginx card (It is renamed to Reverse Proxy (Nginx) because of proxy provider mock)
-        await waitFor(() => screen.getByText('Reverse Proxy (Nginx)'));
-        
+
+        // Find Nginx (renamed to Reverse Proxy (Nginx) because of proxy provider mock)
+        await waitFor(() => expect(screen.getAllByText('Reverse Proxy (Nginx)').length).toBeGreaterThan(0));
+
         // Check for Verified Domain badge or text
-        expect(screen.getByText('app.example.com')).toBeDefined();
+        expect(screen.getAllByText('app.example.com').length).toBeGreaterThan(0);
     });
 
     it('shows Internet Gateway as a service card', async () => {
         render(<ServicesDashboard />);
-        
+
         // Should find "FritzBox Gateway" or "Internet Gateway" (based on mock data provider=fritzbox)
-        await waitFor(() => screen.getByText('FritzBox Gateway'));
-        
+        await waitFor(() => expect(screen.getAllByText('FritzBox Gateway').length).toBeGreaterThan(0));
+
         // Check for specific Gateway badge
-        expect(screen.getByText('Gateway')).toBeDefined(); // Badge text
-        expect(screen.getByText('1.2.3.4')).toBeDefined(); // Public IP
+        expect(screen.getAllByText('Gateway').length).toBeGreaterThan(0); // Badge text
+        expect(screen.getAllByText('1.2.3.4').length).toBeGreaterThan(0); // Public IP
     });
 
     it('identifies ServiceBay special services', async () => {
         // Nginx is the proxy provider in mock, so 'nginx.service' should be identified as Reverse Proxy
         render(<ServicesDashboard />);
-        
-        await waitFor(() => screen.getByText('Reverse Proxy (Nginx)'));
-        
-        // Check for "Reverse Proxy" badge
-        // Note: The logic in ServicesDashboard replaces the name "nginx" with "Reverse Proxy (Nginx)"
-        // And adds a "Reverse Proxy" badge.
-        
+
+        await waitFor(() => expect(screen.getAllByText('Reverse Proxy (Nginx)').length).toBeGreaterThan(0));
+
         // We look for the badge specifically
         const badges = screen.getAllByText('Reverse Proxy');
         expect(badges.length).toBeGreaterThan(0);
@@ -152,9 +155,9 @@ describe('ServicesDashboard', () => {
         };
 
         render(<ServicesDashboard />);
-        
+
         // Expect to see it
-        await waitFor(() => screen.getByText('Reverse Proxy (Nginx)'));
+        await waitFor(() => expect(screen.getAllByText('Reverse Proxy (Nginx)').length).toBeGreaterThan(0));
     });
 
     it('shows Unmanaged ServiceBay service (Agent V4)', async () => {
@@ -180,12 +183,12 @@ describe('ServicesDashboard', () => {
         };
 
         render(<ServicesDashboard />);
-        
-        // Should show up even if unmanaged
-        await waitFor(() => screen.getByText('ServiceBay System'));
-        
+
+        // Should show up even if unmanaged (desktop row + mobile card)
+        await waitFor(() => expect(screen.getAllByText('ServiceBay System').length).toBeGreaterThan(0));
+
         // Check for System badge
-        await waitFor(() => screen.getByText('System'));
+        await waitFor(() => expect(screen.getAllByText('System').length).toBeGreaterThan(0));
     });
 
     it('keeps unmanaged kube-style service ports off the lean list tile (Agent V4)', async () => {
@@ -216,8 +219,8 @@ describe('ServicesDashboard', () => {
         };
 
         render(<ServicesDashboard />);
-        
-        await waitFor(() => screen.getByText('Reverse Proxy (Nginx)'));
+
+        await waitFor(() => expect(screen.getAllByText('Reverse Proxy (Nginx)').length).toBeGreaterThan(0));
         // Lean list tile (spec §4.1): the service renders, but its container
         // ports are not shown here — they live on the Operate page.
         expect(screen.queryByText(':80')).toBeNull();
@@ -259,9 +262,9 @@ spec:
         };
 
         render(<ServicesDashboard />);
-        
-        await waitFor(() => screen.getByText('Reverse Proxy (Nginx)'));
-        
+
+        await waitFor(() => expect(screen.getAllByText('Reverse Proxy (Nginx)').length).toBeGreaterThan(0));
+
         // Should find the Yaml link/badge (implicit check for Managed logic working)
         // Since we didn't mock the link behavior, we assume if no crash and rendering happens it worked.
     });
@@ -284,12 +287,15 @@ spec:
         };
 
         render(<ServicesDashboard />);
-        
-        await waitFor(() => screen.getByText('Reverse Proxy (Nginx)'));
-        
-        // Check uniqueness using getAllByText matching the Header Title
+
+        await waitFor(() => expect(screen.getAllByText('Reverse Proxy (Nginx)').length).toBeGreaterThan(0));
+
+        // Dedup check: the two aliases collapse to ONE logical service. It now
+        // renders once per breakpoint layout (desktop ServiceRow + mobile
+        // ServiceCard, both present in jsdom), so the title appears exactly
+        // twice — not once per alias (which would be four).
         const headers = screen.getAllByTitle('Reverse Proxy (Nginx)');
-        expect(headers.length).toBe(1);
+        expect(headers.length).toBe(2);
     });
 
     it('renders the Fritzbox Gateway as a lean card (ports off the list)', async () => {
@@ -306,8 +312,8 @@ spec:
         };
 
         render(<ServicesDashboard />);
-        // The gateway still renders as its own card…
-        await waitFor(() => screen.getByText('FritzBox Gateway'));
+        // The gateway still renders as its own row/card…
+        await waitFor(() => expect(screen.getAllByText('FritzBox Gateway').length).toBeGreaterThan(0));
         // …but the lean tile (spec §4.1) doesn't crowd in port mappings.
         expect(screen.queryByText(':8080')).toBeNull();
     });

--- a/tests/frontend/ServicesDashboard_Twin.test.tsx
+++ b/tests/frontend/ServicesDashboard_Twin.test.tsx
@@ -110,7 +110,9 @@ describe('ServicesDashboard E2E Data Rendering', () => {
 
         // 2. Assert Service Card Rendering — the systemd→container link still
         // flows into the view model, so the service renders in the list.
-        expect(await screen.findByText('Reverse Proxy (Nginx)')).toBeDefined();
+        // (#2067: it renders twice in jsdom — desktop ServiceRow + mobile
+        // ServiceCard, CSS hides one per breakpoint in a real browser.)
+        expect((await screen.findAllByText('Reverse Proxy (Nginx)')).length).toBeGreaterThan(0);
 
         // 3. The lean list tile (spec §4.1) no longer renders ports — they live
         // on the per-service Operate page — so :8080 must NOT appear in the list.
@@ -159,7 +161,7 @@ describe('ServicesDashboard E2E Data Rendering', () => {
 
         render(<ServicesDashboard />);
 
-        expect(await screen.findByText('broken-service')).toBeDefined();
+        expect((await screen.findAllByText('broken-service')).length).toBeGreaterThan(0);
         // Should not crash, maybe show "-" or empty space
         // We just ensure it renders.
     });


### PR DESCRIPTION
UX-Iteration 2 nach Operator-Feedback auf 4.138.0.

## Änderungen
1. **Services = Liste (Desktop) / Cards (Mobile)** — die schlanken Kacheln sind im Grunde Listenzeilen; auf Desktop jetzt eine dichte Liste (neue `ServiceRow`: Status · Name+Badges · Adresse · Aktionen), auf Mobile die `ServiceCard` einspaltig. `auto-rows-fr` raus → kein Leerraum mehr.
2. **Home-Karten klickbar** — `StatCard`s sind jetzt `<Link>` (Services→/services, Diagnose→/status) mit Hover/Focus.
3. **Coverage-Test zurück** — `OverviewDashboard.diagnose.test.ts` wiederhergestellt + Smoke-Test; diff-coverage 97.6% (grün).

## Verifikation
- tsc 0, eslint 0, 21 Tests grün, diff-coverage PASS, Pre-Push (volle Suite + Build) grün.
- Struktur self-verifiziert. **Pixel prüft der Operator** (Headless-Font-Bug auf meiner Seite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
