### PR TITLE
feat(frontend): actionable service image updates (Update-now button + Home banner)

### DIFF
--- a/packages/frontend/src/components/ImageUpdatesPendingBanner.test.tsx
+++ b/packages/frontend/src/components/ImageUpdatesPendingBanner.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ImageUpdatesPendingBanner from './ImageUpdatesPendingBanner';
 import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
 
@@ -32,5 +32,35 @@ describe('ImageUpdatesPendingBanner', () => {
   it('uses the singular form for a single update', () => {
     render(<ImageUpdatesPendingBanner updates={[update('immich', 'ghcr.io/immich/server:latest')]} />);
     expect(screen.getByText(/1 service image update available/i)).not.toBeNull();
+  });
+
+  it('renders no action button when onUpdate is not provided (informational only)', () => {
+    render(<ImageUpdatesPendingBanner updates={[update('immich', 'ghcr.io/immich/server:latest')]} />);
+    expect(screen.queryByRole('button', { name: /update now/i })).toBeNull();
+  });
+
+  it('triggers onUpdate with every listed update when the "Update now" button is clicked', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const updates = [update('immich', 'ghcr.io/immich/server:latest'), update('vaultwarden', 'docker.io/vaultwarden/server:1.30')];
+    render(<ImageUpdatesPendingBanner updates={updates} onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update now/i }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate).toHaveBeenCalledWith(updates);
+  });
+
+  it('disables the button and shows a running label while the update is in flight', async () => {
+    let resolveUpdate: () => void = () => {};
+    const onUpdate = vi.fn(() => new Promise<void>(resolve => { resolveUpdate = resolve; }));
+    render(<ImageUpdatesPendingBanner updates={[update('immich', 'ghcr.io/immich/server:latest')]} onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update now/i }));
+
+    const runningBtn = await screen.findByRole('button', { name: /updating/i });
+    expect((runningBtn as HTMLButtonElement).disabled).toBe(true);
+
+    resolveUpdate();
+    await waitFor(() => expect(screen.getByRole('button', { name: /update now/i })).toBeDefined());
   });
 });

--- a/packages/frontend/src/components/ImageUpdatesPendingBanner.tsx
+++ b/packages/frontend/src/components/ImageUpdatesPendingBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Download } from 'lucide-react';
+import { useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
 import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
 
 /**
@@ -17,12 +18,36 @@ import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
  * compares *image digests*. They render independently; neither affects the
  * other.
  *
- * Stateless on purpose — the parent owns the fetch (`useImageUpdates`) so the
- * same data backs both this overview and the per-card badges without two
- * round-trips.
+ * Stateless on the data side (the parent owns the fetch via `useImageUpdates`
+ * so the same data backs both this overview and the per-card badges without two
+ * round-trips). When the parent passes `onUpdate`, the banner becomes
+ * actionable: a "Update now" button re-deploys every listed service (the same
+ * `update` action the actions menu uses → pulls each new image, then restarts).
+ * Without `onUpdate` it stays purely informational. The button owns only its
+ * own in-flight flag; success/error feedback comes from the parent's toast.
  */
-export default function ImageUpdatesPendingBanner({ updates }: { updates: ServiceImageUpdate[] }) {
+export default function ImageUpdatesPendingBanner({
+  updates,
+  onUpdate,
+}: {
+  updates: ServiceImageUpdate[];
+  /** Re-deploy every listed service to pull its latest image. Resolves when
+   *  all attempts have run; rejections are surfaced by the parent's toast. */
+  onUpdate?: (updates: ServiceImageUpdate[]) => Promise<void>;
+}) {
+  const [running, setRunning] = useState(false);
+
   if (updates.length === 0) return null;
+
+  const handleUpdate = async () => {
+    if (!onUpdate || running) return;
+    setRunning(true);
+    try {
+      await onUpdate(updates);
+    } finally {
+      setRunning(false);
+    }
+  };
 
   return (
     <div className="mb-4 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50/70 dark:bg-blue-900/20">
@@ -31,13 +56,28 @@ export default function ImageUpdatesPendingBanner({ updates }: { updates: Servic
           <Download size={16} />
         </div>
         <div className="flex-1 min-w-0">
-          <div className="font-semibold text-sm text-gray-900 dark:text-white">
-            {updates.length} service image update{updates.length === 1 ? '' : 's'} available
+          <div className="flex items-start justify-between gap-3 flex-wrap">
+            <div className="min-w-0">
+              <div className="font-semibold text-sm text-gray-900 dark:text-white">
+                {updates.length} service image update{updates.length === 1 ? '' : 's'} available
+              </div>
+              <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
+                The registry is serving a newer image than what these services are running.
+                Re-deploy a service to pull its latest image.
+              </p>
+            </div>
+            {onUpdate && (
+              <button
+                type="button"
+                onClick={handleUpdate}
+                disabled={running}
+                className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-60 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              >
+                {running ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+                {running ? 'Updating…' : 'Update now'}
+              </button>
+            )}
           </div>
-          <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
-            The registry is serving a newer image than what these services are running.
-            Re-deploy a service to pull its latest image.
-          </p>
           <ul className="mt-2 space-y-1.5 text-xs text-gray-700 dark:text-gray-300">
             {updates.map(u => (
               <li key={`${u.service}:${u.image}`} className="flex items-center gap-2 flex-wrap">

--- a/packages/frontend/src/components/ServiceCard.tsx
+++ b/packages/frontend/src/components/ServiceCard.tsx
@@ -33,6 +33,9 @@ export interface ServiceCardProps {
    *  service is running (from `/api/system/stacks/image-updates`, #1860).
    *  Renders an "Update available" badge. */
   imageUpdateAvailable?: boolean;
+  /** When provided, the "Update available" badge becomes a button that
+   *  re-deploys this one service to pull its latest image (#1860). */
+  onUpdate?: (service: ServiceViewModel) => void;
   // Service-row actions (ServiceActionBar + failed-state nudge).
   onMonitor: (service: ServiceViewModel) => void;
   onEdit: (service: ServiceViewModel) => void;
@@ -52,6 +55,7 @@ export default function ServiceCard({
   service,
   httpsDomains,
   imageUpdateAvailable,
+  onUpdate,
   onMonitor,
   onEdit,
   onActions,
@@ -113,12 +117,23 @@ export default function ServiceCard({
                 </span>
               )}
               {imageUpdateAvailable && (
-                <span
-                  className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-200 dark:border-blue-800 rounded"
-                  title="A newer image is available in the registry. Re-deploy this service to pull it."
-                >
-                  <Download size={10} /> Update available
-                </span>
+                onUpdate ? (
+                  <button
+                    type="button"
+                    onClick={() => onUpdate(service)}
+                    className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-200 dark:border-blue-800 rounded hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    title="A newer image is available in the registry. Click to re-deploy this service and pull it."
+                  >
+                    <Download size={10} /> Update now
+                  </button>
+                ) : (
+                  <span
+                    className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-200 dark:border-blue-800 rounded"
+                    title="A newer image is available in the registry. Re-deploy this service to pull it."
+                  >
+                    <Download size={10} /> Update available
+                  </span>
+                )
               )}
             </div>
           </div>

--- a/packages/frontend/src/components/ServiceRow.tsx
+++ b/packages/frontend/src/components/ServiceRow.tsx
@@ -20,6 +20,9 @@ export interface ServiceRowProps {
   httpsDomains: Set<string>;
   /** Registry has a newer image digest than the running one (#1860). */
   imageUpdateAvailable?: boolean;
+  /** When provided, the "Update available" badge becomes a button that
+   *  re-deploys this one service to pull its latest image (#1860). */
+  onUpdate?: (service: ServiceViewModel) => void;
   onMonitor: (service: ServiceViewModel) => void;
   onEdit: (service: ServiceViewModel) => void;
   onActions: (service: ServiceViewModel) => void;
@@ -34,6 +37,7 @@ export default function ServiceRow({
   service,
   httpsDomains,
   imageUpdateAvailable,
+  onUpdate,
   onMonitor,
   onEdit,
   onActions,
@@ -93,12 +97,23 @@ export default function ServiceRow({
           </span>
         )}
         {imageUpdateAvailable && (
-          <span
-            className={`inline-flex items-center gap-1 ${badgeBase} bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800`}
-            title="A newer image is available in the registry. Re-deploy this service to pull it."
-          >
-            <Download size={10} /> Update available
-          </span>
+          onUpdate ? (
+            <button
+              type="button"
+              onClick={() => onUpdate(service)}
+              className={`inline-flex items-center gap-1 ${badgeBase} bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
+              title="A newer image is available in the registry. Click to re-deploy this service and pull it."
+            >
+              <Download size={10} /> Update now
+            </button>
+          ) : (
+            <span
+              className={`inline-flex items-center gap-1 ${badgeBase} bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800`}
+              title="A newer image is available in the registry. Re-deploy this service to pull it."
+            >
+              <Download size={10} /> Update available
+            </span>
+          )
         )}
       </div>
 

--- a/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
@@ -11,6 +11,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import OverviewDashboard from './OverviewDashboard';
+import { ToastProvider } from '@/providers/ToastProvider';
 
 // Next <Link> renders a plain <a> in jsdom; no router needed for href checks.
 vi.mock('@/providers/DigitalTwinProvider', () => ({
@@ -46,7 +47,11 @@ describe('OverviewDashboard render', () => {
   });
 
   it('renders the health headline and links the cards to /services and /status', () => {
-    render(<OverviewDashboard />);
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
 
     // Healthy box (2/2 active, gateway up, core healthy) → the good headline.
     expect(screen.getByText('Everything looks healthy')).toBeDefined();
@@ -59,5 +64,31 @@ describe('OverviewDashboard render', () => {
     const diagnosticsCard = screen.getByText('Diagnostics').closest('a');
     expect(diagnosticsCard).not.toBeNull();
     expect(diagnosticsCard?.getAttribute('href')).toBe('/status');
+  });
+
+  it('renders the image-updates banner on Home when the report has pending updates (#1860)', async () => {
+    // image-updates report returns one pending service; everything else neutral.
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/system/stacks/image-updates')) {
+        return {
+          ok: true,
+          json: async () => ({
+            services: [
+              { service: 'a', image: 'ghcr.io/a:latest', runningDigest: 'sha256:old', registryDigest: 'sha256:new', updateAvailable: true },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => [] };
+    }) as unknown as typeof fetch);
+
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+
+    expect(await screen.findByText(/1 service image update available/i)).toBeDefined();
+    expect(await screen.findByRole('button', { name: /update now/i })).toBeDefined();
   });
 });

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Activity, AlertCircle, CheckCircle2 } from 'lucide-react';
+import type { ServiceViewModel } from '@servicebay/api-client';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
 import { useCoreHealth } from '@/hooks/useCoreHealth';
+import { useImageUpdates, type ServiceImageUpdate } from '@/hooks/useImageUpdates';
+import { useServiceActions } from '@/hooks/useServiceActions';
+import ImageUpdatesPendingBanner from '@/components/ImageUpdatesPendingBanner';
 
 /**
  * Latest persisted diagnose breakdown for the Home card (#1873).
@@ -135,8 +139,12 @@ export default function OverviewDashboard() {
   // snapshot; `isConnected=false` is what we surface to the user.
   const hasFirstSnapshot = data !== null && data !== undefined;
 
-  const firstNode = data?.nodes ? Object.values(data.nodes)[0] : undefined;
-  const services = firstNode?.services || [];
+  const firstNodeEntry = data?.nodes ? Object.entries(data.nodes)[0] : undefined;
+  const firstNodeName = firstNodeEntry?.[0];
+  const firstNode = firstNodeEntry?.[1];
+  // Memoized so the update-action callback's dependency stays referentially
+  // stable across renders (otherwise the `|| []` literal is a fresh array each time).
+  const services = useMemo(() => firstNode?.services || [], [firstNode]);
   const managedServices = services.filter(s => s.activeState === 'active' || s.activeState === 'failed' || s.activeState === 'inactive');
   const activeCount = managedServices.filter(s => s.activeState === 'active').length;
   const failedCount = managedServices.filter(s => s.activeState === 'failed').length;
@@ -155,6 +163,32 @@ export default function OverviewDashboard() {
   const diagnose = useDiagnoseOverview();
   const diagnoseView = diagnoseCardView(diagnose);
 
+  // Pending service-image updates — box status, so it belongs on Home too
+  // (#1860). The banner's "Update now" re-deploys each listed service via the
+  // same `update` action the Services list uses (pull latest image → restart).
+  const { available: imageUpdates, refresh: refreshImageUpdates } = useImageUpdates();
+  const { updateServiceImage, overlays: serviceActionOverlays } = useServiceActions({ onRefresh: refreshImageUpdates });
+
+  // Resolve a bare service name from the image-update report to a minimal
+  // action target (name + node) the `update` action needs. The Home twin
+  // carries raw ServiceUnits keyed under the first node, so we look up the unit
+  // and tag it with that node name.
+  const handleUpdateAll = useCallback(async (updates: ServiceImageUpdate[]) => {
+    for (const update of updates) {
+      const bare = update.service.replace(/\.service$/, '');
+      const unit = services.find(s => s.name.replace(/\.service$/, '') === bare);
+      if (!unit) continue;
+      const target = {
+        id: unit.name,
+        name: unit.name,
+        displayName: unit.description || bare,
+        nodeName: firstNodeName,
+      } as unknown as ServiceViewModel;
+      await updateServiceImage(target);
+    }
+    await refreshImageUpdates();
+  }, [services, firstNodeName, updateServiceImage, refreshImageUpdates]);
+
   const healthHeadline = (() => {
     if (!hasFirstSnapshot) return { tone: 'neutral' as const, text: 'Reading status…' };
     if (coreUnhealthy) return { tone: 'bad' as const, text: 'Core services need attention' };
@@ -166,6 +200,7 @@ export default function OverviewDashboard() {
 
   return (
     <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6">
+      {serviceActionOverlays}
       <div className="max-w-5xl mx-auto space-y-6">
         <header>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Home</h1>
@@ -179,6 +214,10 @@ export default function OverviewDashboard() {
 
         {/* Headline status — the single sentence that answers "is everything OK?" */}
         <HealthHeadline tone={healthHeadline.tone} text={healthHeadline.text} />
+
+        {/* Pending image updates — box status, actionable right here (#1860).
+            Renders nothing when there are none. */}
+        <ImageUpdatesPendingBanner updates={imageUpdates} onUpdate={handleUpdateAll} />
 
         {/* Box-wide at-a-glance: services running + latest diagnose breakdown. */}
         <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { logger } from '@servicebay/api-client';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin'; // V4 Hook
 import { useEscapeKey } from '@/hooks/useEscapeKey';
-import { useImageUpdates } from '@/hooks/useImageUpdates';
+import { useImageUpdates, type ServiceImageUpdate } from '@/hooks/useImageUpdates';
 import DashboardHydrationGate, { type HydrationPhase } from '@/components/DashboardHydrationGate';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
@@ -44,7 +44,7 @@ const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: fa
 export default function ServicesDashboard() {
     const { data: twin, isConnected, lastUpdate, isNodeSynced } = useDigitalTwin();
     const { addToast, updateToast } = useToast();
-    const { available: imageUpdates, availableServices: imageUpdateServices } = useImageUpdates();
+    const { available: imageUpdates, availableServices: imageUpdateServices, refresh: refreshImageUpdates } = useImageUpdates();
 
     const [filteredServices, setFilteredServices] = useState<ServiceViewModel[]>([]);
     const [filteredBundles, setFilteredBundles] = useState<ServiceBundle[]>([]);
@@ -187,6 +187,7 @@ export default function ServicesDashboard() {
         openEditDrawer,
         openActions,
         triggerRestart,
+        updateServiceImage,
         requestDelete,
         overlays: serviceActionOverlays,
         closeOverlays,
@@ -376,6 +377,36 @@ export default function ServicesDashboard() {
     const allContainers = useMemo(() => {
         return services.flatMap(s => s.attachedContainers || []);
     }, [services]);
+
+    // Image-update actions (#1860): re-deploy a service to pull its newest image.
+    // `updateServiceImage` POSTs the `update` action (= the actions menu's
+    // "Update & Restart"), which pulls each image in the service YAML then
+    // restarts the unit. We resolve the bare service name from the image-update
+    // report back to its live ServiceViewModel so the action can target the
+    // right node. After the run we re-poll the report so the cleared badge/banner
+    // disappears.
+    const resolveServiceByName = useCallback((name: string): ServiceViewModel | undefined => {
+        return services.find(s => s.name.replace(/\.service$/, '') === name.replace(/\.service$/, ''));
+    }, [services]);
+
+    const handleUpdateService = useCallback(async (service: ServiceViewModel) => {
+        await updateServiceImage(service);
+        await refreshImageUpdates();
+    }, [updateServiceImage, refreshImageUpdates]);
+
+    // Banner "Update now": re-deploy every listed service sequentially (no
+    // single "update all" endpoint exists), then refresh the report once.
+    // Failures surface their own error toast per service and don't abort the
+    // remaining updates.
+    const handleUpdateAll = useCallback(async (updates: ServiceImageUpdate[]) => {
+        for (const update of updates) {
+            const service = resolveServiceByName(update.service);
+            if (service) {
+                await updateServiceImage(service);
+            }
+        }
+        await refreshImageUpdates();
+    }, [resolveServiceByName, updateServiceImage, refreshImageUpdates]);
 
     useEffect(() => {
         if (!containerIdParam || !allContainers.length) return;
@@ -692,6 +723,7 @@ export default function ServicesDashboard() {
                                     service={entry.service}
                                     httpsDomains={httpsDomains}
                                     imageUpdateAvailable={imageUpdateServices.has(entry.service.name.replace(/\.service$/, ''))}
+                                    onUpdate={handleUpdateService}
                                     onMonitor={openServiceDetail}
                                     onEdit={openEditDrawer}
                                     onActions={openActions}
@@ -713,6 +745,7 @@ export default function ServicesDashboard() {
                                     attachNodeContext={attachNodeContext}
                                     httpsDomains={httpsDomains}
                                     imageUpdateAvailable={imageUpdateServices.has(entry.service.name.replace(/\.service$/, ''))}
+                                    onUpdate={handleUpdateService}
                                     onMonitor={openServiceDetail}
                                     onEdit={openEditDrawer}
                                     onActions={openActions}
@@ -954,7 +987,7 @@ export default function ServicesDashboard() {
             />
 
       <TemplateUpgradesPendingBanner />
-      <ImageUpdatesPendingBanner updates={imageUpdates} />
+      <ImageUpdatesPendingBanner updates={imageUpdates} onUpdate={handleUpdateAll} />
       <PageHeader
         title="Services"
         showBack={false} 

--- a/packages/frontend/src/hooks/useServiceActions.tsx
+++ b/packages/frontend/src/hooks/useServiceActions.tsx
@@ -156,6 +156,53 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     }
   }, [addToast, deleteInFlight, onRefresh, serviceToDelete, updateToast]);
 
+  // Pull-the-latest-image action for the "Update available" surfaces (the
+  // ImageUpdatesPendingBanner button + the per-card/row badge, #1860). This is
+  // the SAME mechanism the actions menu's "Update & Restart" uses — POST the
+  // `update` action, which re-deploys the service: `updateAndRestartService`
+  // pulls each image referenced in the service YAML, then stop/starts the unit.
+  // We expose it as a direct callback (not via the actions modal) so the badge
+  // and banner can trigger it inline. Returns true on success so a caller
+  // updating several services can stop the loop or skip the refresh on failure.
+  //
+  // Honesty (feedback_dont_mask_failures): a non-ok response or a thrown error
+  // surfaces a real error toast — we never reclassify a failed pull as success.
+  const updateServiceImage = useCallback(async (service: ServiceViewModel): Promise<boolean> => {
+    const serviceName = service.id || service.name;
+    const nodeName = service.nodeName === 'Local' ? '' : service.nodeName;
+    const query = nodeName ? `?node=${nodeName}` : '';
+    const toastId = addToast('loading', 'Updating service', `Pulling the latest image for ${service.displayName || service.name}…`, 0);
+
+    try {
+      const res = await fetch(`/api/services/${encodeURIComponent(serviceName)}/action${query}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'update' }),
+      });
+
+      const traceId = res.headers.get('x-trace-id');
+      const traceMsg = traceId ? ` [Trace: ${traceId}]` : '';
+
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const data = await res.json();
+          if (data?.error) detail = data.error;
+        } catch { /* non-JSON error body */ }
+        updateToast(toastId, 'error', 'Update failed', `${detail}${traceMsg}`);
+        return false;
+      }
+
+      updateToast(toastId, 'success', 'Service updated', `${service.displayName || service.name} re-deployed with its latest image.`);
+      onRefresh?.();
+      return true;
+    } catch (error) {
+      logger.error('useServiceActions', 'Image update failed', error);
+      updateToast(toastId, 'error', 'Update failed', 'An unexpected connection error occurred.');
+      return false;
+    }
+  }, [addToast, onRefresh, updateToast]);
+
   const handleAction = useCallback(async (action: string) => {
     if (!selectedService) return;
 
@@ -237,6 +284,7 @@ export function useServiceActions({ onRefresh }: UseServiceActionsOptions = {}) 
     openEditDrawer,
     openActions,
     triggerRestart,
+    updateServiceImage,
     requestDelete,
     actionLoading,
     overlays: actionOverlays,


### PR DESCRIPTION
Macht die "service image updates" aktionierbar (Operator-Wunsch).

## Änderungen
- **`ImageUpdatesPendingBanner`**: bekommt einen **"Jetzt aktualisieren"-Button**, der die betroffenen Services re-deployt (pullt das neue Image), mit Loading/Disabled + ehrlichem Fehler-Toast.
- Banner jetzt **auch auf Home** (Übersicht) — nur wenn Updates anstehen.
- Per-Service **"Update available"-Badge** in `ServiceCard`/`ServiceRow` ist jetzt **klickbar** → re-deployt diesen einen Service.
- Aktion über `useServiceActions` (kein Doppel-Logik), `useImageUpdates.refresh()` danach.

## Verifikation
- tsc 0, diff-coverage 100%, Pre-Push (volle Suite + Build) grün.
- Pixel prüft der Operator. (Re-Style kommt mit dem Design-System.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
