### PR TITLE
feat(frontend): design-system foundation + Operate scroll, health mapping, Home Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
       "packages/frontend": {
         "entry": [
           "src/app/**/{page,layout,route,loading,error,not-found,template,default,global-error,sitemap,robots,manifest,opengraph-image,twitter-image,icon,apple-icon}.{ts,tsx}",
-          "src/mocks/browser.ts"
+          "src/mocks/browser.ts",
+          "src/components/ui/index.ts"
         ]
       },
       "packages/backend": {

--- a/packages/backend/src/lib/diagnose/diagnoseChecks.test.ts
+++ b/packages/backend/src/lib/diagnose/diagnoseChecks.test.ts
@@ -145,6 +145,9 @@ describe('getDiagnoseChecksEnriched', () => {
     expect(row.name).toBe('Self-diagnose: Pods');
     expect(row.status).toBe('fail');
     expect(row.lastRun).not.toBeNull();
+    // #2080: every diagnose row is box-wide so the per-service Health tab files
+    // it under "Box-wide" instead of force-matching it onto a service.
+    expect(row.boxWide).toBe(true);
     // The four-way diagnose payload is preserved for the popup slice.
     expect(row.diagnose?.status).toBe('warn');
     expect(row.diagnose?.detail).toBe('one down');

--- a/packages/backend/src/lib/diagnose/diagnoseChecks.ts
+++ b/packages/backend/src/lib/diagnose/diagnoseChecks.ts
@@ -118,6 +118,11 @@ export function getDiagnoseChecksEnriched() {
       // Surface the four-way diagnose status + self-repair payload for
       // the row's badge / popup (the popup slice consumes `diagnose`).
       diagnose: decoded ?? undefined,
+      // #2080: every diagnose probe is box-wide (it inspects the node — TLS,
+      // DNS, SSO, storage, the engine — not a single stack). Mark it so the
+      // per-service Health tab files it under "Box-wide" instead of trying to
+      // substring-match it onto a service (which always failed → empty tab).
+      boxWide: true,
       history,
     };
   });

--- a/packages/backend/src/lib/health/types.ts
+++ b/packages/backend/src/lib/health/types.ts
@@ -186,4 +186,17 @@ export interface Check extends CheckConfig {
   history: { status: 'ok' | 'fail'; latency: number; timestamp: string }[];
   /** Present only on synthetic diagnose rows (#1423). */
   diagnose?: DiagnoseCheckPayload;
+  /**
+   * The check is box-wide (#2080) — it monitors the node as a whole rather
+   * than a single service, so it must NOT be force-attributed to one service
+   * in the per-service Health tab. Set on the synthetic `diagnose:<probeId>`
+   * rows (cert/dns/sso/storage/… diagnostics target the box, not one stack)
+   * and on the node-scoped singleton checks (agent, gateway, the Phase-3b
+   * `cert_expiry`/`lan_ip_drift`/`npm_auth`/… rows that target `Local`/a
+   * domain). The Operate Health tab shows these in a clearly-labelled
+   * "Box-wide" section instead of dropping them — they used to silently
+   * vanish from every service because their `target` never substring-matched
+   * a service base name, leaving the tab reading "1 ok".
+   */
+  boxWide?: boolean;
 }

--- a/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperatePage.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperatePage.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+// #2077 regression guard: the per-service Operate page MUST own a scroll region,
+// because the dashboard <main> (app/(dashboard)/layout.tsx) is overflow-hidden.
+// Without it, an overlong tab (the operator hit it on Settings) clips at the
+// bottom with no scrollbar. We assert the rendered page root carries the
+// canonical PageScroll chain (min-h-0 + overflow-y-auto) — the exact classes
+// that the load-bearing fix depends on.
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Render the loading state — it still mounts the PageScroll root, which is the
+// only thing we need to assert, and avoids constructing a full ServiceViewModel.
+vi.mock('../../../settings/services/_lib/useOperateServices', () => ({
+  useOperateService: () => ({ service: null, loading: true }),
+}));
+
+import OperatePage from './OperatePage';
+
+describe('OperatePage scroll container (#2077)', () => {
+  it('renders a single canonical scroll region (min-h-0 + overflow-y-auto)', () => {
+    const { container } = render(<OperatePage name="immich" />);
+    const scrollers = Array.from(container.querySelectorAll<HTMLElement>('div')).filter(
+      el =>
+        el.className.includes('min-h-0') &&
+        el.className.includes('overflow-y-auto'),
+    );
+    expect(scrollers.length).toBeGreaterThanOrEqual(1);
+    // and it fills the shell so it can scroll inside the overflow-hidden <main>
+    expect(scrollers[0].className).toContain('h-full');
+  });
+});

--- a/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperatePage.tsx
+++ b/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperatePage.tsx
@@ -11,6 +11,7 @@ import OperateSettingsTab from '../../../settings/services/_lib/OperateSettingsT
 import OperateActionsTab from '../../../settings/services/_lib/OperateActionsTab';
 import OperateContainersTab from './OperateContainersTab';
 import ServiceDetailSummary from '@/components/serviceDetail/ServiceDetailSummary';
+import { PageScroll } from '@/components/ui';
 
 type OperateTab = 'health' | 'settings' | 'containers' | 'actions';
 
@@ -38,7 +39,10 @@ export default function OperatePage({ name }: { name: string }) {
   const { service, loading } = useOperateService(name);
 
   return (
-    <div className="space-y-6">
+    // Canonical scroll pattern (#2077): the dashboard <main> is overflow-hidden,
+    // so the page must own its own scroll region or overlong tabs (e.g. Settings)
+    // clip with no scrollbar. PageScroll = h-full min-h-0 overflow-y-auto.
+    <PageScroll spacing="lg" className="pb-8">
       <Link
         href="/services"
         className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 dark:hover:text-gray-200"
@@ -60,7 +64,7 @@ export default function OperatePage({ name }: { name: string }) {
       ) : (
         <OperateBody service={service} />
       )}
-    </div>
+    </PageScroll>
   );
 }
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/helpers.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/helpers.ts
@@ -15,28 +15,10 @@ export const DEFAULT_TEMPLATE_SCHEMA: Record<string, TemplateSettingsSchemaEntry
   },
 };
 
-export interface AppUpdateStatus {
-  hasUpdate: boolean;
-  current: string;
-  /**
-   * Release tag is ahead but the `:latest` image hasn't been published yet
-   * (release-please cuts the tag before the Release workflow pushes the image).
-   * Shown as "new version building" rather than an actionable update.
-   */
-  imageBuilding?: boolean;
-  latest: {
-    version: string;
-    url: string;
-    date: string;
-    notes: string;
-  } | null;
-  config: {
-    autoUpdate: {
-      enabled: boolean;
-      schedule: string;
-    };
-  };
-}
+// The self-update status shape now lives with the shared updater card so both
+// Settings and Home can use it (#2082). Re-exported here for back-compat with
+// existing settings importers.
+export type { AppUpdateStatus } from '@/components/ServiceBayUpdateCard';
 
 export type SettingsOverrides = Partial<{
   templateValues: Record<string, string>;

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdatesSection.tsx
@@ -1,22 +1,21 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { CheckCircle2, Clock, Download, Loader2, RefreshCw, XCircle, AlertTriangle, Power } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
+import { AlertTriangle, Power } from 'lucide-react';
 import ConfirmModal from '@/components/ConfirmModal';
+import ServiceBayUpdateCard from '@/components/ServiceBayUpdateCard';
 import { useToast } from '@/providers/ToastProvider';
-import type { AppUpdateStatus } from '../helpers';
 
+/**
+ * Settings → System updates tab.
+ *
+ * Composes the shared ServiceBay self-updater card (also rendered on Home —
+ * #2082) with the OS-reinstall control. The reinstall block stays here (and
+ * NOT on Home) because it is destructive/recovery-only — Home only carries
+ * the routine update surfaces.
+ */
 export default function UpdatesSection() {
   const { addToast } = useToast();
-  const [appUpdate, setAppUpdate] = useState<AppUpdateStatus | null>(null);
-  const [checkingUpdate, setCheckingUpdate] = useState(false);
-  const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
-
-  const [updateStatus, setUpdateStatus] = useState<'idle' | 'updating' | 'restarting' | 'error' | 'success' | 'building'>('idle');
-  const [updateProgress, setUpdateProgress] = useState(0);
-  const [updateMessage, setUpdateMessage] = useState('');
-  const [updateError, setUpdateError] = useState('');
 
   const [bootStatus, setBootStatus] = useState<{
     entries: Array<{ bootNum: string; name: string; active: boolean; description: string; current: boolean }>;
@@ -110,278 +109,13 @@ export default function UpdatesSection() {
   };
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch('/api/system/update');
-        if (!res.ok) return;
-        const data: AppUpdateStatus = await res.json();
-        if (!cancelled) setAppUpdate(data);
-      } catch {
-        // ignore — keeps null and user can hit Check Now
-      }
-    })();
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- async update-status fetch on mount, guarded by a cancelled flag
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async boot-status fetch on mount
     fetchBootStatus();
-    return () => { cancelled = true; };
   }, []);
-
-  const handleCheckUpdate = async () => {
-    setCheckingUpdate(true);
-    try {
-      const res = await fetch('/api/system/update');
-      if (res.ok) {
-        const data = await res.json();
-        setAppUpdate(data);
-        const latestVer = data.latest?.version || 'Unknown';
-        if (data.hasUpdate) {
-          addToast('success', 'Update available', `Version ${latestVer} is available.`);
-        } else if (data.imageBuilding) {
-          addToast('info', 'New version building', `Version ${latestVer} was released but its image is still building. Try again shortly.`);
-        } else {
-          addToast('info', 'System up to date', `You are using the latest version (${latestVer}).`);
-        }
-      } else {
-        const errorData = await res.json().catch(() => ({}));
-        const errorMessage = errorData.error || `Server error (${res.status})`;
-        throw new Error(errorMessage);
-      }
-    } catch (e) {
-      console.error(e);
-      const msg = e instanceof Error ? e.message : 'Unknown error';
-      addToast('error', 'Update Check Failed', msg);
-    } finally {
-      setCheckingUpdate(false);
-    }
-  };
-
-  const handleAppUpdate = () => {
-    if (!appUpdate?.latest) return;
-    setIsUpdateModalOpen(true);
-  };
-
-  const confirmAppUpdate = async () => {
-    if (!appUpdate?.latest) return;
-    setIsUpdateModalOpen(false);
-    setUpdateStatus('updating');
-    setUpdateProgress(0);
-    setUpdateMessage('Initializing update...');
-
-    try {
-      const { io } = await import('socket.io-client');
-      const socket = io();
-
-      socket.on('update:progress', (data: { step: string; progress: number; message: string }) => {
-        setUpdateProgress(data.progress);
-        setUpdateMessage(data.message);
-        if (data.step === 'restart') {
-          setUpdateStatus('restarting');
-          setUpdateMessage('Service is restarting. This page will reload automatically...');
-          setTimeout(() => { window.location.reload(); }, 5000);
-        }
-      });
-
-      socket.on('update:noop', (data: { message: string }) => {
-        // The pull found no newer image (the tag raced ahead of the image
-        // push). Report it honestly instead of leaving the spinner running or
-        // claiming success — no silent no-op (feedback_dont_mask_failures).
-        setUpdateStatus('building');
-        setUpdateMessage(data.message);
-        socket.disconnect();
-      });
-
-      socket.on('update:error', (data: { error: string }) => {
-        setUpdateStatus('error');
-        setUpdateError(data.error);
-        socket.disconnect();
-      });
-
-      const res = await fetch('/api/system/update', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'update', version: appUpdate.latest.version }),
-      });
-
-      if (!res.ok) {
-        throw new Error('Update failed to start');
-      }
-    } catch (e) {
-      setUpdateStatus('error');
-      setUpdateError(e instanceof Error ? e.message : 'Unknown error');
-    }
-  };
-
-  const toggleAutoUpdate = async () => {
-    if (!appUpdate) return;
-    const newState = !appUpdate.config.autoUpdate.enabled;
-
-    try {
-      const res = await fetch('/api/system/update', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'configure', autoUpdate: { enabled: newState } }),
-      });
-
-      if (res.ok) {
-        const data = await res.json();
-        setAppUpdate(prev => (prev ? { ...prev, config: data.config } : null));
-        addToast('success', 'Settings saved', `Auto-update ${newState ? 'enabled' : 'disabled'}.`);
-      }
-    } catch {
-      addToast('error', 'Error', 'Failed to save settings.');
-    }
-  };
-
-
-  if (!appUpdate) {
-    return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
-        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
-        Loading update status…
-      </div>
-    );
-  }
 
   return (
     <>
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-          <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg text-purple-600 dark:text-purple-400">
-            <RefreshCw size={20} className={updateStatus === 'updating' || checkingUpdate ? 'animate-spin' : ''} />
-          </div>
-          <div>
-            <h3 className="font-bold text-gray-900 dark:text-white">ServiceBay Updates</h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Manage application updates</p>
-          </div>
-          <div className="ml-auto flex items-center gap-4">
-            <button
-              onClick={handleCheckUpdate}
-              disabled={checkingUpdate || updateStatus === 'updating'}
-              className="text-xs text-purple-600 dark:text-purple-400 hover:underline disabled:opacity-50"
-            >
-              {checkingUpdate ? 'Checking...' : 'Check Now'}
-            </button>
-            <div className="h-4 w-px bg-gray-300 dark:bg-gray-600"></div>
-            <label className="relative inline-flex items-center cursor-pointer" title="Enable Auto-Updates">
-              <input
-                type="checkbox"
-                className="sr-only peer"
-                checked={appUpdate.config.autoUpdate.enabled}
-                onChange={toggleAutoUpdate}
-              />
-              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 dark:peer-focus:ring-purple-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-purple-600"></div>
-            </label>
-          </div>
-        </div>
-        <div className="p-6">
-          <div className="flex flex-col md:flex-row gap-6 items-start md:items-center justify-between">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-500 dark:text-gray-400">Current Version:</span>
-                <span className="font-mono font-medium text-gray-900 dark:text-white">{appUpdate.current}</span>
-              </div>
-              {appUpdate.hasUpdate && appUpdate.latest ? (
-                <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
-                  <Download size={16} />
-                  <span className="text-sm font-medium">New version available: {appUpdate.latest.version}</span>
-                </div>
-              ) : appUpdate.imageBuilding && appUpdate.latest ? (
-                <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
-                  <Clock size={16} />
-                  <span className="text-sm font-medium">Version {appUpdate.latest.version} released — image still building, try again shortly</span>
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
-                  <Clock size={16} />
-                  <span className="text-sm">You are on the latest version</span>
-                </div>
-              )}
-            </div>
-
-            {appUpdate.hasUpdate && appUpdate.latest && (
-              <button
-                onClick={handleAppUpdate}
-                disabled={updateStatus === 'updating'}
-                className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors shadow-sm flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <Download size={18} />
-                {updateStatus === 'updating' ? 'Updating...' : 'Update Now'}
-              </button>
-            )}
-          </div>
-
-          {appUpdate.hasUpdate && appUpdate.latest && appUpdate.latest.notes && (
-            <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
-              <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-2">Release Notes</h4>
-              <div className="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300">
-                <ReactMarkdown>{appUpdate.latest.notes}</ReactMarkdown>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {updateStatus !== 'idle' && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4">
-          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl max-w-md w-full border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="p-6 text-center space-y-6">
-              {updateStatus === 'error' ? (
-                <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
-                  <XCircle size={32} />
-                </div>
-              ) : updateStatus === 'building' ? (
-                <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 rounded-full flex items-center justify-center mx-auto">
-                  <Clock size={32} />
-                </div>
-              ) : updateStatus === 'restarting' ? (
-                <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center mx-auto animate-pulse">
-                  <CheckCircle2 size={32} />
-                </div>
-              ) : (
-                <div className="w-16 h-16 bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 rounded-full flex items-center justify-center mx-auto">
-                  <Loader2 size={32} className="animate-spin" />
-                </div>
-              )}
-
-              <div>
-                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-                  {updateStatus === 'error' ? 'Update Failed' :
-                    updateStatus === 'building' ? 'New Version Still Building' :
-                      updateStatus === 'restarting' ? 'Update Complete' :
-                        'Updating ServiceBay'}
-                </h3>
-                <p className="text-gray-500 dark:text-gray-400 text-sm">
-                  {updateStatus === 'error' ? updateError : updateMessage}
-                </p>
-              </div>
-
-              {updateStatus === 'updating' && (
-                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 overflow-hidden">
-                  <div className="bg-purple-600 h-2.5 rounded-full transition-all duration-300 ease-out" style={{ width: `${updateProgress}%` }}></div>
-                </div>
-              )}
-
-              {(updateStatus === 'error' || updateStatus === 'building') && (
-                <button
-                  onClick={() => setUpdateStatus('idle')}
-                  className="px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors font-medium text-sm"
-                >
-                  Close
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
-      <ConfirmModal
-        isOpen={isUpdateModalOpen}
-        title="Update ServiceBay"
-        message={`Are you sure you want to update ServiceBay to version ${appUpdate?.latest?.version}? The service will restart automatically.`}
-        confirmText="Update Now"
-        onConfirm={confirmAppUpdate}
-        onCancel={() => setIsUpdateModalOpen(false)}
-      />
+      <ServiceBayUpdateCard />
 
       {/* Reinstall Operating System Section */}
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full mt-6">
@@ -396,7 +130,7 @@ export default function UpdatesSection() {
         </div>
         <div className="p-6 space-y-4">
           <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
-            Configure the server to boot into a connected installation USB to perform a fresh operating system reinstallation. 
+            Configure the server to boot into a connected installation USB to perform a fresh operating system reinstallation.
             This process will clear the base system files, but your personal data and stack volumes will be preserved.
           </p>
 

--- a/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateHealthTab.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateHealthTab.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * OperateHealthTab (#2080) — the per-service Operate Health tab. These render
+ * tests encode the corrected check→service attribution: a service's own checks
+ * are shown, and box-wide diagnose probes are surfaced in a clearly-labelled
+ * "Box-wide" section instead of silently vanishing (the "1 ok" symptom).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import type { Check, ServiceViewModel } from '@servicebay/api-client';
+import OperateHealthTab from './OperateHealthTab';
+
+// Fresh Response per call (feedback_vitest_fetch_response_reuse).
+function mockChecks(checks: Partial<Check>[]) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.startsWith('/api/health/checks')) {
+      return new Response(JSON.stringify(checks), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  });
+}
+
+function svc(over: Partial<ServiceViewModel> = {}): ServiceViewModel {
+  return {
+    name: 'jellyfin.service',
+    displayName: 'Jellyfin',
+    yamlBasename: null,
+    kubeBasename: null,
+    active: true,
+    type: 'kube',
+    ports: [],
+    ...over,
+  };
+}
+
+const row = (over: Partial<Check>): Partial<Check> => ({
+  id: Math.random().toString(36),
+  name: 'x',
+  type: 'http',
+  status: 'ok',
+  target: '',
+  history: [],
+  lastRun: null,
+  lastResult: null,
+  ...over,
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+beforeEach(() => { vi.restoreAllMocks(); });
+
+describe('OperateHealthTab (#2080 attribution)', () => {
+  it('shows the service own checks AND the box-wide diagnose rows in a labelled section', async () => {
+    global.fetch = mockChecks([
+      // this service's own check
+      row({ name: 'Service: jellyfin', type: 'service', target: 'jellyfin', status: 'ok' }),
+      // box-wide diagnose probes — these used to vanish from every service tab
+      row({ id: 'diagnose:cert_expiry', name: 'Self-diagnose: TLS certificates', boxWide: true, status: 'ok' }),
+      row({ id: 'diagnose:dns_routing', name: 'Self-diagnose: DNS routing', boxWide: true, status: 'fail' }),
+      // node singleton check (targets Local) — box-wide too
+      row({ name: 'TLS certificate expiry', type: 'cert_expiry', target: 'Local', status: 'ok' }),
+      // a DIFFERENT service's check must not appear here
+      row({ name: 'Service: immich', type: 'service', target: 'immich', status: 'fail' }),
+    ]);
+
+    render(<OperateHealthTab service={svc()} />);
+
+    // service own check present
+    await waitFor(() => expect(screen.getByText('Service: jellyfin')).toBeDefined());
+    // box-wide section is rendered, clearly labelled, with the diagnose rows
+    const boxWide = screen.getByLabelText('Box-wide health checks');
+    expect(within(boxWide).getByText('Self-diagnose: TLS certificates')).toBeDefined();
+    expect(within(boxWide).getByText('Self-diagnose: DNS routing')).toBeDefined();
+    expect(within(boxWide).getByText('TLS certificate expiry')).toBeDefined();
+    // the other service's check is not shown on this tab at all
+    expect(screen.queryByText('Service: immich')).toBeNull();
+  });
+
+  it('shows box-wide diagnostics even when the service has zero own checks (no more "empty" tab)', async () => {
+    global.fetch = mockChecks([
+      row({ id: 'diagnose:cert_expiry', name: 'Self-diagnose: TLS certificates', boxWide: true, status: 'ok' }),
+    ]);
+    render(<OperateHealthTab service={svc()} />);
+
+    await waitFor(() => expect(screen.getByText('No service-specific health checks yet.')).toBeDefined());
+    const boxWide = screen.getByLabelText('Box-wide health checks');
+    expect(within(boxWide).getByText('Self-diagnose: TLS certificates')).toBeDefined();
+  });
+});

--- a/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateHealthTab.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/services/_lib/OperateHealthTab.tsx
@@ -20,7 +20,7 @@ const ROW_META: Record<RowStatus, { color: string; bg: string; Icon: typeof Chec
  * the per-service page rather than a global health dashboard.
  */
 export default function OperateHealthTab({ service }: { service: ServiceViewModel }) {
-  const { checks, counts, loading, reload: load } = useServiceHealth(service);
+  const { checks, boxWideChecks, counts, loading, reload: load } = useServiceHealth(service);
   const [running, setRunning] = useState<string | null>(null);
 
   const handleRun = useCallback(async (id: string) => {
@@ -64,22 +64,67 @@ export default function OperateHealthTab({ service }: { service: ServiceViewMode
       {checks.length === 0 ? (
         <div className="p-8 text-center text-gray-500 border border-dashed border-gray-200 dark:border-gray-700 rounded-xl">
           <Activity className="w-10 h-10 mx-auto mb-3 opacity-20" />
-          <p>No health checks for this service yet.</p>
+          <p>No service-specific health checks yet.</p>
+          {boxWideChecks.length > 0 && (
+            <p className="text-xs mt-1">Box-wide diagnostics for this node are listed below.</p>
+          )}
         </div>
       ) : (
-        <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
-          {checks.map((check, i) => (
-            <CheckRow
-              key={check.id}
-              check={check}
-              last={i === checks.length - 1}
-              running={running === check.id}
-              onRun={() => handleRun(check.id)}
-            />
-          ))}
-        </div>
+        <CheckList checks={checks} running={running} onRun={handleRun} />
       )}
+
+      <BoxWideSection checks={boxWideChecks} serviceName={service.displayName} running={running} onRun={handleRun} />
     </div>
+  );
+}
+
+/** A bordered card listing a set of check rows. Shared by the service-specific
+ *  list and the box-wide section so both render identically (#2080). */
+function CheckList({ checks, running, onRun }: { checks: Check[]; running: string | null; onRun: (id: string) => void }) {
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+      {checks.map((check, i) => (
+        <CheckRow
+          key={check.id}
+          check={check}
+          last={i === checks.length - 1}
+          running={running === check.id}
+          onRun={() => onRun(check.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Box-wide diagnostics (#2080) — diagnose probes + node singletons — in a
+ * clearly-labelled section rather than dropped. They used to silently vanish
+ * from every per-service tab because their `target` never substring-matched a
+ * service name (the "1 ok" symptom). They monitor the whole node, so they're
+ * separated from this service's own checks.
+ */
+function BoxWideSection({
+  checks,
+  serviceName,
+  running,
+  onRun,
+}: {
+  checks: Check[];
+  serviceName: string;
+  running: string | null;
+  onRun: (id: string) => void;
+}) {
+  if (checks.length === 0) return null;
+  return (
+    <section className="space-y-2" aria-label="Box-wide health checks">
+      <h2 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        Box-wide checks
+        <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500">
+          monitor the whole node, not just {serviceName}
+        </span>
+      </h2>
+      <CheckList checks={checks} running={running} onRun={onRun} />
+    </section>
   );
 }
 

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -1,6 +1,18 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/*
+ * Design-system semantic token layer (#2072, epic #2071).
+ *
+ * Tokens are defined as raw CSS custom properties on :root (the DARK default —
+ * the app has no .dark toggle; :root IS dark, and prefers-color-scheme:light
+ * overrides below) and registered in @theme inline so Tailwind v4 generates
+ * semantic utilities: bg-surface, bg-surface-2, border-border, text-status-ok,
+ * text-accent, rounded (one radius), and the spacing scale (p-1..p-8 etc.).
+ *
+ * Primitives (#2073-#2076) and migrations (#2078/#2079) reference THESE — never
+ * raw Tailwind color literals for semantic values.
+ */
 :root {
   --background: #050505;
   --foreground: #f0f0f0;
@@ -12,6 +24,48 @@
   --success: #10b981;
   --error: #ef4444;
   --warning: #f59e0b;
+
+  /* --- Semantic surfaces (dark default) --- */
+  --surface: #111114;          /* base panel/card surface (≈ gray-900) */
+  --surface-2: #1c1c20;        /* raised surface: nested rows, inputs, hover (≈ gray-800) */
+  --surface-muted: #0a0a0c;    /* recessed wells, table-zebra, code blocks */
+
+  /* --- Borders --- */
+  --border: #2a2a30;           /* default hairline (≈ gray-700/800) */
+  --border-strong: #3a3a42;    /* emphasized divider / focused control */
+
+  /* --- Text on surfaces --- */
+  --text: #f0f0f0;             /* primary text */
+  --text-muted: #a1a1aa;       /* secondary/labels (≈ zinc-400) */
+  --text-subtle: #6b7280;      /* placeholders, disabled (≈ gray-500) */
+
+  /* --- Status (dark-tuned: legible on dark surfaces) --- */
+  --status-ok: #34d399;        /* emerald-400 */
+  --status-warn: #fbbf24;      /* amber-400 */
+  --status-fail: #f87171;      /* red-400 */
+  --status-info: #60a5fa;      /* blue-400 */
+
+  /* --- Accent (brand / primary action) --- */
+  --accent: #3b82f6;           /* blue-500 — matches --accent-primary */
+  --accent-strong: #2563eb;    /* blue-600 — hover/active */
+  --on-accent: #ffffff;        /* text/icon on an accent fill */
+
+  /* --- Radius: ONE canonical semantic scale (was rounded-lg vs -xl ad-hoc).
+     Named distinctly (chip/card/panel) so primitives standardize on these and
+     the existing numeric rounded-sm/-lg utilities keep their defaults. --- */
+  --r-chip: 0.375rem;          /* 6px — chips, badges, status dots */
+  --r-card: 0.625rem;          /* 10px — DEFAULT: cards, panels, buttons, inputs */
+  --r-panel: 0.875rem;         /* 14px — large containers/modals */
+
+  /* --- Spacing scale (4px base; the only step set primitives should use) --- */
+  --space-1: 0.25rem;          /* 4px */
+  --space-2: 0.5rem;           /* 8px */
+  --space-3: 0.75rem;          /* 12px */
+  --space-4: 1rem;             /* 16px */
+  --space-5: 1.5rem;           /* 24px */
+  --space-6: 2rem;             /* 32px */
+  --space-7: 3rem;             /* 48px */
+  --space-8: 4rem;             /* 64px */
 }
 
 @theme inline {
@@ -23,6 +77,43 @@
   --color-accent-secondary: var(--accent-secondary);
   --font-sans: var(--font-geist-sans), "Inter", "Outfit", sans-serif;
   --font-mono: var(--font-geist-mono), "Fira Code", monospace;
+
+  /* --- Semantic colors → bg-surface, border-border, text-status-ok, … --- */
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-surface-muted: var(--surface-muted);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-text: var(--text);
+  --color-text-muted: var(--text-muted);
+  --color-text-subtle: var(--text-subtle);
+  --color-status-ok: var(--status-ok);
+  --color-status-warn: var(--status-warn);
+  --color-status-fail: var(--status-fail);
+  --color-status-info: var(--status-info);
+  --color-accent: var(--accent);
+  --color-accent-strong: var(--accent-strong);
+  --color-on-accent: var(--on-accent);
+
+  /* --- Radius scale → rounded-chip, rounded-card (the new default), rounded-panel.
+     Distinct from Tailwind's numeric rounded-sm/-lg so existing utilities are
+     untouched (acceptance: existing UI unchanged). --- */
+  --radius-chip: var(--r-chip);
+  --radius-card: var(--r-card);
+  --radius-panel: var(--r-panel);
+
+  /* --- Spacing scale → p-space-1..space-8, gap-space-*, m-space-*, etc. ---
+     Registered under a distinct `space-N` namespace, NOT the numeric Tailwind
+     scale, so existing p-5/gap-6 utilities keep their default values (the
+     acceptance: existing UI unchanged). Primitives opt in via p-space-4 etc. */
+  --spacing-space-1: var(--space-1);
+  --spacing-space-2: var(--space-2);
+  --spacing-space-3: var(--space-3);
+  --spacing-space-4: var(--space-4);
+  --spacing-space-5: var(--space-5);
+  --spacing-space-6: var(--space-6);
+  --spacing-space-7: var(--space-7);
+  --spacing-space-8: var(--space-8);
 }
 
 @media (prefers-color-scheme: light) {
@@ -32,6 +123,23 @@
     --card-bg: rgba(255, 255, 255, 0.6);
     --glass-bg: rgba(0, 0, 0, 0.02);
     --glass-border: rgba(15, 23, 42, 0.08);
+
+    /* Light-mode overrides for the semantic surfaces/borders/text.
+       Status & accent stay vivid but shift to the darker 500/600 ramps so
+       they read on light backgrounds. Radius/spacing are mode-independent. */
+    --surface: #ffffff;
+    --surface-2: #f1f5f9;       /* slate-100 */
+    --surface-muted: #f8fafc;   /* slate-50 */
+    --border: #e2e8f0;          /* slate-200 */
+    --border-strong: #cbd5e1;   /* slate-300 */
+    --text: #0f172a;            /* slate-900 */
+    --text-muted: #475569;      /* slate-600 */
+    --text-subtle: #94a3b8;     /* slate-400 */
+
+    --status-ok: #059669;       /* emerald-600 */
+    --status-warn: #d97706;     /* amber-600 */
+    --status-fail: #dc2626;     /* red-600 */
+    --status-info: #2563eb;     /* blue-600 */
   }
 }
 

--- a/packages/frontend/src/app/globals.tokens.test.ts
+++ b/packages/frontend/src/app/globals.tokens.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Design-system semantic token layer (#2072, epic #2071).
+ *
+ * Encodes the acceptance criterion ("all tokens defined and resolvable;
+ * theme extended; dark-mode correct") so #2073-#2079 build on a stable
+ * foundation and a later refactor can't silently drop a token. We parse
+ * globals.css textually (jsdom doesn't resolve @theme/@import), which is
+ * enough to assert each token is declared in :root, registered in @theme
+ * inline, and overridden for light mode.
+ */
+const cssPath = path.resolve(__dirname, './globals.css');
+const css = readFileSync(cssPath, 'utf8');
+
+const block = (header: string): string => {
+  const start = css.indexOf(header);
+  expect(start, `block "${header}" present`).toBeGreaterThan(-1);
+  const open = css.indexOf('{', start);
+  // naive brace match — these blocks have no nested braces except the light
+  // @media, which we handle by passing the inner ":root" header for that case.
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') {
+      depth--;
+      if (depth === 0) return css.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unbalanced braces for ${header}`);
+};
+
+// The first ":root {" is the dark default; the light override is inside
+// "@media (prefers-color-scheme: light)".
+const rootDark = block(':root {');
+const lightMedia = block('@media (prefers-color-scheme: light)');
+const themeInline = block('@theme inline {');
+
+const SEMANTIC_COLOR_TOKENS = [
+  'surface',
+  'surface-2',
+  'surface-muted',
+  'border',
+  'border-strong',
+  'text',
+  'text-muted',
+  'text-subtle',
+  'status-ok',
+  'status-warn',
+  'status-fail',
+  'status-info',
+  'accent',
+  'accent-strong',
+  'on-accent',
+];
+
+describe('design-system semantic tokens (#2072)', () => {
+  it.each(SEMANTIC_COLOR_TOKENS)('defines --%s on :root (dark default)', (token) => {
+    expect(rootDark).toMatch(new RegExp(`--${token}\\s*:`));
+  });
+
+  it.each(SEMANTIC_COLOR_TOKENS)('registers --color-%s in @theme inline', (token) => {
+    expect(themeInline).toMatch(new RegExp(`--color-${token}\\s*:\\s*var\\(--${token}\\)`));
+  });
+
+  it('overrides surface/border/text/status for light mode', () => {
+    for (const token of [
+      'surface',
+      'surface-2',
+      'border',
+      'text',
+      'text-muted',
+      'status-ok',
+      'status-warn',
+      'status-fail',
+      'status-info',
+    ]) {
+      expect(lightMedia, `light override for --${token}`).toMatch(
+        new RegExp(`--${token}\\s*:`),
+      );
+    }
+  });
+
+  it('exposes ONE canonical radius scale without clobbering numeric rounded-*', () => {
+    for (const r of ['radius-chip', 'radius-card', 'radius-panel']) {
+      expect(themeInline).toMatch(new RegExp(`--${r}\\s*:`));
+    }
+    // must NOT redefine Tailwind's numeric radius scale (would change existing UI)
+    expect(themeInline).not.toMatch(/--radius-sm\s*:/);
+    expect(themeInline).not.toMatch(/--radius-lg\s*:/);
+  });
+
+  it('exposes a 4px-base spacing scale under the space-N namespace (not numeric)', () => {
+    for (let n = 1; n <= 8; n++) {
+      expect(themeInline).toMatch(new RegExp(`--spacing-space-${n}\\s*:`));
+    }
+    // must NOT redefine numeric spacing (p-5/gap-6 must keep Tailwind defaults)
+    expect(themeInline).not.toMatch(/--spacing-5\s*:/);
+  });
+
+  it('dark status colors use the legible 400-ramp (operator uses dark mode)', () => {
+    expect(rootDark).toMatch(/--status-ok\s*:\s*#34d399/i); // emerald-400
+    expect(rootDark).toMatch(/--status-warn\s*:\s*#fbbf24/i); // amber-400
+    expect(rootDark).toMatch(/--status-fail\s*:\s*#f87171/i); // red-400
+    expect(rootDark).toMatch(/--status-info\s*:\s*#60a5fa/i); // blue-400
+  });
+});

--- a/packages/frontend/src/components/ServiceBayUpdateCard.tsx
+++ b/packages/frontend/src/components/ServiceBayUpdateCard.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Clock, Download, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import ConfirmModal from '@/components/ConfirmModal';
+import { useToast } from '@/providers/ToastProvider';
+
+/**
+ * ServiceBay self-update status.
+ *
+ * Lives here (not in the settings `_lib/helpers`) so both the Settings →
+ * System tab AND the Home overview can share this card without duplicating the
+ * shape (#2082 consolidates the updater onto Home). Re-exported from
+ * settings `_lib/helpers` for backward-compat with its existing importers.
+ */
+export interface AppUpdateStatus {
+  hasUpdate: boolean;
+  current: string;
+  /**
+   * Release tag is ahead but the `:latest` image hasn't been published yet
+   * (release-please cuts the tag before the Release workflow pushes the image).
+   * Shown as "new version building" rather than an actionable update.
+   */
+  imageBuilding?: boolean;
+  latest: {
+    version: string;
+    url: string;
+    date: string;
+    notes: string;
+  } | null;
+  config: {
+    autoUpdate: {
+      enabled: boolean;
+      schedule: string;
+    };
+  };
+}
+
+/**
+ * ServiceBay self-updater card (#2082).
+ *
+ * The version-update half of the old `UpdatesSection` — current version,
+ * "Check Now", the auto-update toggle, "Update Now" + its progress modal —
+ * extracted into one shared component so it can sit on BOTH the Settings →
+ * System tab and the Home overview's consolidated "Updates" area without
+ * duplicating the `GET/POST /api/system/update` logic.
+ *
+ * Self-contained: owns its own status fetch (on mount + on "Check Now") and
+ * the update progress/confirm modals. Renders nothing destructive — the
+ * OS-reinstall block stays in `UpdatesSection` (settings only).
+ */
+export default function ServiceBayUpdateCard() {
+  const { addToast } = useToast();
+  const [appUpdate, setAppUpdate] = useState<AppUpdateStatus | null>(null);
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+
+  const [updateStatus, setUpdateStatus] = useState<'idle' | 'updating' | 'restarting' | 'error' | 'success' | 'building'>('idle');
+  const [updateProgress, setUpdateProgress] = useState(0);
+  const [updateMessage, setUpdateMessage] = useState('');
+  const [updateError, setUpdateError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/system/update');
+        if (!res.ok) return;
+        const data: AppUpdateStatus = await res.json();
+        if (!cancelled) setAppUpdate(data);
+      } catch {
+        // ignore — keeps null and user can hit Check Now
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleCheckUpdate = async () => {
+    setCheckingUpdate(true);
+    try {
+      const res = await fetch('/api/system/update');
+      if (res.ok) {
+        const data = await res.json();
+        setAppUpdate(data);
+        const latestVer = data.latest?.version || 'Unknown';
+        if (data.hasUpdate) {
+          addToast('success', 'Update available', `Version ${latestVer} is available.`);
+        } else if (data.imageBuilding) {
+          addToast('info', 'New version building', `Version ${latestVer} was released but its image is still building. Try again shortly.`);
+        } else {
+          addToast('info', 'System up to date', `You are using the latest version (${latestVer}).`);
+        }
+      } else {
+        const errorData = await res.json().catch(() => ({}));
+        const errorMessage = errorData.error || `Server error (${res.status})`;
+        throw new Error(errorMessage);
+      }
+    } catch (e) {
+      console.error(e);
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      addToast('error', 'Update Check Failed', msg);
+    } finally {
+      setCheckingUpdate(false);
+    }
+  };
+
+  const handleAppUpdate = () => {
+    if (!appUpdate?.latest) return;
+    setIsUpdateModalOpen(true);
+  };
+
+  const confirmAppUpdate = async () => {
+    if (!appUpdate?.latest) return;
+    setIsUpdateModalOpen(false);
+    setUpdateStatus('updating');
+    setUpdateProgress(0);
+    setUpdateMessage('Initializing update...');
+
+    try {
+      const { io } = await import('socket.io-client');
+      const socket = io();
+
+      socket.on('update:progress', (data: { step: string; progress: number; message: string }) => {
+        setUpdateProgress(data.progress);
+        setUpdateMessage(data.message);
+        if (data.step === 'restart') {
+          setUpdateStatus('restarting');
+          setUpdateMessage('Service is restarting. This page will reload automatically...');
+          setTimeout(() => { window.location.reload(); }, 5000);
+        }
+      });
+
+      socket.on('update:noop', (data: { message: string }) => {
+        // The pull found no newer image (the tag raced ahead of the image
+        // push). Report it honestly instead of leaving the spinner running or
+        // claiming success — no silent no-op (feedback_dont_mask_failures).
+        setUpdateStatus('building');
+        setUpdateMessage(data.message);
+        socket.disconnect();
+      });
+
+      socket.on('update:error', (data: { error: string }) => {
+        setUpdateStatus('error');
+        setUpdateError(data.error);
+        socket.disconnect();
+      });
+
+      const res = await fetch('/api/system/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'update', version: appUpdate.latest.version }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Update failed to start');
+      }
+    } catch (e) {
+      setUpdateStatus('error');
+      setUpdateError(e instanceof Error ? e.message : 'Unknown error');
+    }
+  };
+
+  const toggleAutoUpdate = async () => {
+    if (!appUpdate) return;
+    const newState = !appUpdate.config.autoUpdate.enabled;
+
+    try {
+      const res = await fetch('/api/system/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'configure', autoUpdate: { enabled: newState } }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setAppUpdate(prev => (prev ? { ...prev, config: data.config } : null));
+        addToast('success', 'Settings saved', `Auto-update ${newState ? 'enabled' : 'disabled'}.`);
+      }
+    } catch {
+      addToast('error', 'Error', 'Failed to save settings.');
+    }
+  };
+
+  if (!appUpdate) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading update status…
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
+          <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg text-purple-600 dark:text-purple-400">
+            <RefreshCw size={20} className={updateStatus === 'updating' || checkingUpdate ? 'animate-spin' : ''} />
+          </div>
+          <div>
+            <h3 className="font-bold text-gray-900 dark:text-white">ServiceBay Updates</h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Manage application updates</p>
+          </div>
+          <div className="ml-auto flex items-center gap-4">
+            <button
+              onClick={handleCheckUpdate}
+              disabled={checkingUpdate || updateStatus === 'updating'}
+              className="text-xs text-purple-600 dark:text-purple-400 hover:underline disabled:opacity-50"
+            >
+              {checkingUpdate ? 'Checking...' : 'Check Now'}
+            </button>
+            <div className="h-4 w-px bg-gray-300 dark:bg-gray-600"></div>
+            <label className="relative inline-flex items-center cursor-pointer" title="Enable Auto-Updates">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={appUpdate.config.autoUpdate.enabled}
+                onChange={toggleAutoUpdate}
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 dark:peer-focus:ring-purple-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-purple-600"></div>
+            </label>
+          </div>
+        </div>
+        <div className="p-6">
+          <div className="flex flex-col md:flex-row gap-6 items-start md:items-center justify-between">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-gray-500 dark:text-gray-400">Current Version:</span>
+                <span className="font-mono font-medium text-gray-900 dark:text-white">{appUpdate.current}</span>
+              </div>
+              {appUpdate.hasUpdate && appUpdate.latest ? (
+                <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
+                  <Download size={16} />
+                  <span className="text-sm font-medium">New version available: {appUpdate.latest.version}</span>
+                </div>
+              ) : appUpdate.imageBuilding && appUpdate.latest ? (
+                <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                  <Clock size={16} />
+                  <span className="text-sm font-medium">Version {appUpdate.latest.version} released — image still building, try again shortly</span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+                  <Clock size={16} />
+                  <span className="text-sm">You are on the latest version</span>
+                </div>
+              )}
+            </div>
+
+            {appUpdate.hasUpdate && appUpdate.latest && (
+              <button
+                onClick={handleAppUpdate}
+                disabled={updateStatus === 'updating'}
+                className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors shadow-sm flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Download size={18} />
+                {updateStatus === 'updating' ? 'Updating...' : 'Update Now'}
+              </button>
+            )}
+          </div>
+
+          {appUpdate.hasUpdate && appUpdate.latest && appUpdate.latest.notes && (
+            <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
+              <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-2">Release Notes</h4>
+              <div className="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300">
+                <ReactMarkdown>{appUpdate.latest.notes}</ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {updateStatus !== 'idle' && (
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl max-w-md w-full border border-gray-200 dark:border-gray-800 overflow-hidden">
+            <div className="p-6 text-center space-y-6">
+              {updateStatus === 'error' ? (
+                <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
+                  <XCircle size={32} />
+                </div>
+              ) : updateStatus === 'building' ? (
+                <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 rounded-full flex items-center justify-center mx-auto">
+                  <Clock size={32} />
+                </div>
+              ) : updateStatus === 'restarting' ? (
+                <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center mx-auto animate-pulse">
+                  <CheckCircle2 size={32} />
+                </div>
+              ) : (
+                <div className="w-16 h-16 bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 rounded-full flex items-center justify-center mx-auto">
+                  <Loader2 size={32} className="animate-spin" />
+                </div>
+              )}
+
+              <div>
+                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+                  {updateStatus === 'error' ? 'Update Failed' :
+                    updateStatus === 'building' ? 'New Version Still Building' :
+                      updateStatus === 'restarting' ? 'Update Complete' :
+                        'Updating ServiceBay'}
+                </h3>
+                <p className="text-gray-500 dark:text-gray-400 text-sm">
+                  {updateStatus === 'error' ? updateError : updateMessage}
+                </p>
+              </div>
+
+              {updateStatus === 'updating' && (
+                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 overflow-hidden">
+                  <div className="bg-purple-600 h-2.5 rounded-full transition-all duration-300 ease-out" style={{ width: `${updateProgress}%` }}></div>
+                </div>
+              )}
+
+              {(updateStatus === 'error' || updateStatus === 'building') && (
+                <button
+                  onClick={() => setUpdateStatus('idle')}
+                  className="px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors font-medium text-sm"
+                >
+                  Close
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        isOpen={isUpdateModalOpen}
+        title="Update ServiceBay"
+        message={`Are you sure you want to update ServiceBay to version ${appUpdate?.latest?.version}? The service will restart automatically.`}
+        confirmText="Update Now"
+        onConfirm={confirmAppUpdate}
+        onCancel={() => setIsUpdateModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/packages/frontend/src/components/serviceDetail/serviceDetail.test.ts
+++ b/packages/frontend/src/components/serviceDetail/serviceDetail.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import type { Check, ServiceViewModel } from '@servicebay/api-client';
 import {
   checkBelongsToService,
+  isBoxWideCheck,
   overallHealth,
   serviceBaseName,
 } from './serviceHealth';
@@ -38,12 +39,46 @@ describe('serviceBaseName', () => {
   });
 });
 
-describe('checkBelongsToService', () => {
-  it('matches on target equality, substring and name', () => {
-    expect(checkBelongsToService(check({ target: 'jellyfin' }), 'jellyfin')).toBe(true);
-    expect(checkBelongsToService(check({ target: 'media-jellyfin' }), 'jellyfin')).toBe(true);
-    expect(checkBelongsToService(check({ name: 'Jellyfin libraries indexed' }), 'jellyfin')).toBe(true);
+describe('checkBelongsToService (#2080 structural attribution)', () => {
+  it('matches the canonical per-service check shapes', () => {
+    // init.ts creates `type:'service'` with target === serviceName …
+    expect(checkBelongsToService(check({ type: 'service', target: 'jellyfin' }), 'jellyfin')).toBe(true);
+    // … or the legacy `name === "Service: <name>"` row …
+    expect(checkBelongsToService(check({ name: 'Service: jellyfin' }), 'jellyfin')).toBe(true);
+    // … and a systemd-suffixed target still resolves to the bare name.
+    expect(checkBelongsToService(check({ type: 'systemd', target: 'jellyfin.service' }), 'jellyfin')).toBe(true);
+    // template/post-deploy probes carry id === <svc> or id.startsWith("<svc>-")
+    expect(checkBelongsToService(check({ id: 'jellyfin-api', target: 'http://x' }), 'jellyfin')).toBe(true);
+  });
+
+  it('does NOT over-match on loose substrings (the old "1 ok" bug)', () => {
+    // The old impl matched any check whose name/target CONTAINED the needle,
+    // sweeping unrelated rows onto a service. A free-text name no longer counts.
+    expect(checkBelongsToService(check({ name: 'Jellyfin libraries indexed' }), 'jellyfin')).toBe(false);
+    expect(checkBelongsToService(check({ target: 'media-jellyfin' }), 'jellyfin')).toBe(false);
     expect(checkBelongsToService(check({ target: 'immich', name: 'photos' }), 'jellyfin')).toBe(false);
+  });
+
+  it('never attributes a box-wide check to a service', () => {
+    expect(checkBelongsToService(check({ id: 'diagnose:cert_expiry', target: 'cert_expiry', boxWide: true }), 'jellyfin')).toBe(false);
+    expect(checkBelongsToService(check({ type: 'cert_expiry', target: 'Local' }), 'jellyfin')).toBe(false);
+    expect(checkBelongsToService(check({ type: 'agent', target: 'Local' }), 'jellyfin')).toBe(false);
+  });
+});
+
+describe('isBoxWideCheck (#2080)', () => {
+  it('flags diagnose probes, node-singleton types and Local-targeted checks', () => {
+    expect(isBoxWideCheck(check({ id: 'diagnose:cert_expiry', boxWide: true }))).toBe(true);
+    // boxWide flag absent but the synthetic id prefix still classifies it.
+    expect(isBoxWideCheck(check({ id: 'diagnose:dns_routing' }))).toBe(true);
+    expect(isBoxWideCheck(check({ type: 'cert_expiry', target: 'Local' }))).toBe(true);
+    expect(isBoxWideCheck(check({ type: 'agent', target: 'Local' }))).toBe(true);
+    expect(isBoxWideCheck(check({ type: 'service', target: 'Local' }))).toBe(true);
+  });
+
+  it('does NOT flag a normal per-service check', () => {
+    expect(isBoxWideCheck(check({ type: 'service', target: 'jellyfin' }))).toBe(false);
+    expect(isBoxWideCheck(check({ type: 'http', target: 'jellyfin' }))).toBe(false);
   });
 });
 

--- a/packages/frontend/src/components/serviceDetail/serviceHealth.ts
+++ b/packages/frontend/src/components/serviceDetail/serviceHealth.ts
@@ -9,35 +9,96 @@ export function serviceBaseName(service: Pick<ServiceViewModel, 'id' | 'name'>):
   return (service.id || service.name).replace(/\.(service|scope|socket|timer)$/, '');
 }
 
-/** Does this health check belong to the given service? Matches on the bare
- *  service name against the check's target / name (covers service, http,
- *  podman and systemd checks plus the per-service `Link:`/diagnose rows).
- *  Shared by the Operate Health tab and the shared service-detail summary so
- *  the two surfaces never disagree about which checks belong to a service. */
+/**
+ * Check types that monitor the *node*, not a single service (#2080): the SSH
+ * agent reachability, the gateway/router, and the Phase-3b singletons
+ * (`cert_expiry`, `lan_ip_drift`, `npm_auth`, `cert_request_failure`,
+ * `nginx_config_valid`, `dns_routing`). These always target `Local` or a bare
+ * domain, never a service name, so they belong in the box-wide bucket.
+ */
+const BOX_WIDE_CHECK_TYPES = new Set<Check['type']>([
+  'agent',
+  'fritzbox',
+  'node',
+  'lan_ip_drift',
+  'npm_auth',
+  'cert_expiry',
+  'cert_request_failure',
+  'nginx_config_valid',
+  'dns_routing',
+  'domain',
+  'letsdebug',
+]);
+
+/**
+ * Is this a box-wide check (#2080) — one that monitors the node as a whole
+ * rather than a single service? True for the synthetic `diagnose:<probeId>`
+ * rows (backend stamps `boxWide`), the node-scoped singleton check types, and
+ * any check explicitly targeting the `Local` node. Box-wide checks are never
+ * force-attributed to a service; the Operate Health tab lists them in a
+ * clearly-labelled "Box-wide" section so they're surfaced honestly, not hidden.
+ */
+export function isBoxWideCheck(check: Check): boolean {
+  if (check.boxWide) return true;
+  if (typeof check.id === 'string' && check.id.startsWith('diagnose:')) return true;
+  if (BOX_WIDE_CHECK_TYPES.has(check.type)) return true;
+  if ((check.target || '') === 'Local') return true;
+  return false;
+}
+
+/**
+ * Does this health check belong to the given service (#2080)? Structural,
+ * not substring-guessing: a per-service check is created with
+ * `target === <serviceName>` (init.ts) or the canonical `name === "Service:
+ * <name>"`, and template/post-deploy probes carry `id === <svc>` /
+ * `id.startsWith("<svc>-")`. Box-wide checks (diagnose probes, node
+ * singletons) never belong to a service — they're surfaced separately. The
+ * old loose `target.includes(needle) || name.includes(needle)` both
+ * over-matched (a one-letter service swept up everything) and never caught
+ * box-wide rows, which is why the tab read "1 ok". Shared by the Operate
+ * Health tab and the service-detail summary so the two surfaces agree.
+ */
 export function checkBelongsToService(check: Check, baseName: string): boolean {
+  if (isBoxWideCheck(check)) return false;
   const needle = baseName.toLowerCase();
-  const target = (check.target || '').toLowerCase();
+  if (!needle) return false;
+  const target = (check.target || '').toLowerCase().replace(/\.(service|scope|socket|timer)$/, '');
+  const id = (check.id || '').toLowerCase();
   const name = (check.name || '').toLowerCase();
-  return target === needle || target.includes(needle) || name.includes(needle);
+  return (
+    target === needle ||
+    id === needle ||
+    id.startsWith(`${needle}-`) ||
+    name === `service: ${needle}`
+  );
 }
 
 export interface ServiceHealthState {
+  /** Checks attributed to THIS service (drives the health dot + roll-up). */
   checks: Check[];
+  /**
+   * Box-wide checks (#2080) — diagnose probes + node singletons. Surfaced in
+   * the Operate Health tab's "Box-wide" section so they're not hidden, but
+   * deliberately excluded from `checks`/`counts` so one service's health dot
+   * isn't dragged red by a node-wide TLS/DNS problem.
+   */
+  boxWideChecks: Check[];
   counts: Record<RowStatus, number>;
   loading: boolean;
   reload: () => Promise<void>;
 }
 
 /**
- * Loads the health checks that belong to ONE service. The single source of
- * truth for per-service health, used by both the Operate page Health tab and
- * the shared per-service detail summary (which renders in the Services list,
- * the Operate page header and the Network-map node sidebar) — so every place a
- * service is shown agrees on its health.
+ * Loads the health checks for ONE service plus the box-wide checks (#2080).
+ * The single source of truth for per-service health, used by both the Operate
+ * page Health tab and the shared per-service detail summary (which renders in
+ * the Services list, the Operate page header and the Network-map node sidebar)
+ * — so every place a service is shown agrees on its health.
  */
 export function useServiceHealth(service: Pick<ServiceViewModel, 'id' | 'name'>): ServiceHealthState {
   const baseName = serviceBaseName(service);
   const [checks, setChecks] = useState<Check[]>([]);
+  const [boxWideChecks, setBoxWideChecks] = useState<Check[]>([]);
   const [loading, setLoading] = useState(true);
 
   const reload = useCallback(async () => {
@@ -47,6 +108,7 @@ export function useServiceHealth(service: Pick<ServiceViewModel, 'id' | 'name'>)
       if (!res.ok) throw new Error('Failed to load health checks');
       const all: Check[] = await res.json();
       setChecks(all.filter(c => checkBelongsToService(c, baseName)));
+      setBoxWideChecks(all.filter(isBoxWideCheck));
     } catch (e) {
       logger.error('useServiceHealth', 'Failed to load checks', e);
     } finally {
@@ -66,7 +128,7 @@ export function useServiceHealth(service: Pick<ServiceViewModel, 'id' | 'name'>)
     unknown: checks.filter(c => rowStatus(c) === 'unknown').length,
   }), [checks]);
 
-  return { checks, counts, loading, reload };
+  return { checks, boxWideChecks, counts, loading, reload };
 }
 
 /** Roll the per-service check counts up into one honest health dot state. */

--- a/packages/frontend/src/components/ui/Badge.test.tsx
+++ b/packages/frontend/src/components/ui/Badge.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Badge } from './Badge';
+
+describe('ui/Badge', () => {
+  it('renders neutral by default', () => {
+    render(<Badge>label</Badge>);
+    const el = screen.getByText('label');
+    expect(el.getAttribute('data-variant')).toBe('neutral');
+    expect(el.className).toContain('rounded-chip');
+  });
+
+  it.each(['neutral', 'ok', 'warn', 'fail', 'info', 'accent'] as const)(
+    'applies the %s variant via status/accent tokens (no raw color literals)',
+    (variant) => {
+      render(<Badge variant={variant}>v</Badge>);
+      const el = screen.getByText('v');
+      expect(el.getAttribute('data-variant')).toBe(variant);
+      expect(el.className).not.toMatch(/green-\d|amber-\d|red-\d|blue-\d/);
+    },
+  );
+});

--- a/packages/frontend/src/components/ui/Badge.tsx
+++ b/packages/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,38 @@
+import { cn } from './cn';
+
+/**
+ * <Badge> — small status/label chip (#2076, epic #2071).
+ *
+ * Replaces the audited 27 ad-hoc badge styles with one chip wired to the
+ * status/accent tokens. Tinted-fill on a translucent status colour so it
+ * reads on both the dark default and the light theme.
+ */
+export type BadgeVariant = 'neutral' | 'ok' | 'warn' | 'fail' | 'info' | 'accent';
+
+const variants: Record<BadgeVariant, string> = {
+  neutral: 'bg-surface-2 text-text-muted border border-border',
+  ok: 'bg-status-ok/10 text-status-ok border border-status-ok/20',
+  warn: 'bg-status-warn/10 text-status-warn border border-status-warn/20',
+  fail: 'bg-status-fail/10 text-status-fail border border-status-fail/20',
+  info: 'bg-status-info/10 text-status-info border border-status-info/20',
+  accent: 'bg-accent/10 text-accent border border-accent/20',
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+export function Badge({ variant = 'neutral', className, ...rest }: BadgeProps) {
+  return (
+    <span
+      data-variant={variant}
+      className={cn(
+        'inline-flex items-center gap-space-1 rounded-chip px-space-2 py-px text-xs font-medium',
+        variants[variant],
+        className,
+      )}
+      {...rest}
+    />
+  );
+}
+

--- a/packages/frontend/src/components/ui/Button.test.tsx
+++ b/packages/frontend/src/components/ui/Button.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from './Button';
+
+describe('ui/Button', () => {
+  it('renders its children and defaults to type=button (no accidental submit)', () => {
+    render(<Button>Save</Button>);
+    const btn = screen.getByRole('button', { name: 'Save' });
+    expect(btn.getAttribute('type')).toBe('button');
+    expect(btn.getAttribute('data-variant')).toBe('primary');
+  });
+
+  it.each(['primary', 'secondary', 'ghost', 'danger'] as const)(
+    'applies the %s variant token classes',
+    (variant) => {
+      render(<Button variant={variant}>x</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.getAttribute('data-variant')).toBe(variant);
+      // every variant resolves through semantic tokens, never raw color literals
+      expect(btn.className).not.toMatch(/blue-\d|gray-\d|red-\d/);
+    },
+  );
+
+  it.each(['sm', 'md'] as const)('applies the %s size', (size) => {
+    render(<Button size={size}>x</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain(size === 'sm' ? 'h-8' : 'h-10');
+  });
+
+  it('forwards onClick and respects disabled', () => {
+    const onClick = vi.fn();
+    const { rerender } = render(<Button onClick={onClick}>go</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    rerender(<Button onClick={onClick} disabled>go</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1); // disabled blocks the second click
+  });
+
+  it('honours an explicit submit type', () => {
+    render(<Button type="submit">submit</Button>);
+    expect(screen.getByRole('button').getAttribute('type')).toBe('submit');
+  });
+});

--- a/packages/frontend/src/components/ui/Button.tsx
+++ b/packages/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { forwardRef } from 'react';
+import { cn } from './cn';
+
+/**
+ * <Button> — the shared action primitive (#2073, epic #2071).
+ *
+ * Replaces the audited 124 ad-hoc button class-chains with one consistent
+ * padding / radius / hover / focus / disabled story, wired to the semantic
+ * tokens from #2072 (no raw blue-600 / gray-800 literals). Dark-mode-correct
+ * by construction: every colour resolves through a CSS variable that already
+ * has a light/dark value.
+ *
+ * Variants:
+ *  - primary   — accent fill, the page's main action.
+ *  - secondary — bordered surface, neutral.
+ *  - ghost     — no chrome until hover, for low-emphasis / icon actions.
+ *  - danger    — destructive (delete/uninstall); status-fail tinted.
+ *
+ * Sizes: sm (compact rows/toolbars) · md (default).
+ */
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md';
+
+const base =
+  'inline-flex items-center justify-center gap-space-2 rounded-card font-medium ' +
+  'transition-colors select-none ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ' +
+  'focus-visible:ring-offset-surface ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';
+
+const variants: Record<ButtonVariant, string> = {
+  primary: 'bg-accent text-on-accent hover:bg-accent-strong',
+  secondary:
+    'bg-surface-2 text-text border border-border hover:bg-surface-muted hover:border-border-strong',
+  ghost: 'bg-transparent text-text-muted hover:bg-surface-2 hover:text-text',
+  danger:
+    'bg-transparent text-status-fail border border-status-fail/40 hover:bg-status-fail/10 ' +
+    'focus-visible:ring-status-fail',
+};
+
+const sizes: Record<ButtonSize, string> = {
+  sm: 'h-8 px-space-3 text-xs',
+  md: 'h-10 px-space-4 text-sm',
+};
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', size = 'md', className, type, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      // Default to type="button" so a primitive dropped inside a <form> doesn't
+      // submit it by surprise — opt into "submit" explicitly.
+      type={type ?? 'button'}
+      data-variant={variant}
+      className={cn(base, variants[variant], sizes[size], className)}
+      {...rest}
+    />
+  );
+});
+

--- a/packages/frontend/src/components/ui/Card.test.tsx
+++ b/packages/frontend/src/components/ui/Card.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Card, Panel } from './Card';
+
+describe('ui/Card', () => {
+  it('renders children on a token surface', () => {
+    render(<Card>body</Card>);
+    const el = screen.getByText('body');
+    expect(el.className).toContain('bg-surface');
+    expect(el.className).toContain('border-border');
+    expect(el.className).toContain('rounded-card');
+  });
+
+  it('applies the padding scale and supports padding=none', () => {
+    const { rerender } = render(<Card padding="lg">x</Card>);
+    expect(screen.getByText('x').className).toContain('p-space-5');
+    rerender(<Card padding="none">x</Card>);
+    expect(screen.getByText('x').className).not.toMatch(/p-space-/);
+  });
+});
+
+describe('ui/Panel', () => {
+  it('renders a header with title + actions and a divided body', () => {
+    render(
+      <Panel title="Lifecycle" actions={<button>act</button>}>
+        content
+      </Panel>,
+    );
+    expect(screen.getByRole('heading', { name: 'Lifecycle' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'act' })).toBeDefined();
+    expect(screen.getByText('content')).toBeDefined();
+  });
+
+  it('omits the header when no title/actions are given', () => {
+    render(<Panel>just body</Panel>);
+    expect(screen.queryByRole('heading')).toBeNull();
+    expect(screen.getByText('just body')).toBeDefined();
+  });
+});

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,77 @@
+import { cn } from './cn';
+
+/**
+ * <Card> / <Panel> — the canonical surface primitives (#2074, epic #2071).
+ *
+ * Collapses the audited 10+ ad-hoc card styles (rounded-xl…p-6 shadow-sm vs
+ * rounded-lg…bg-gray-800 p-4 vs border-gray-700/-800…) into ONE surface:
+ * bg-surface, border-border, rounded-card, token spacing.
+ *
+ *  - <Card>  — a bare surface; pass children, control padding via `padding`.
+ *  - <Panel> — a Card with an optional header (title + actions) over a divider.
+ */
+
+export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+
+const paddings: Record<CardPadding, string> = {
+  none: '',
+  sm: 'p-space-3',
+  md: 'p-space-4',
+  lg: 'p-space-5',
+};
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  padding?: CardPadding;
+}
+
+export function Card({ padding = 'md', className, ...rest }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-surface border border-border rounded-card',
+        paddings[padding],
+        className,
+      )}
+      {...rest}
+    />
+  );
+}
+
+export interface PanelProps extends Omit<CardProps, 'title'> {
+  /** Header title — string or any node. Omit for a header-less panel. */
+  title?: React.ReactNode;
+  /** Optional right-aligned header actions (buttons, badges). */
+  actions?: React.ReactNode;
+  /** Padding applied to the body region (the header keeps its own). */
+  padding?: CardPadding;
+}
+
+export function Panel({
+  title,
+  actions,
+  padding = 'md',
+  className,
+  children,
+  ...rest
+}: PanelProps) {
+  return (
+    <div
+      className={cn(
+        'bg-surface border border-border rounded-card overflow-hidden',
+        className,
+      )}
+      {...rest}
+    >
+      {(title || actions) && (
+        <div className="flex items-center justify-between gap-space-3 px-space-4 py-space-3 border-b border-border">
+          {title && (
+            <h3 className="text-sm font-semibold text-text truncate">{title}</h3>
+          )}
+          {actions && <div className="flex items-center gap-space-2 shrink-0">{actions}</div>}
+        </div>
+      )}
+      <div className={paddings[padding]}>{children}</div>
+    </div>
+  );
+}
+

--- a/packages/frontend/src/components/ui/DataTable.test.tsx
+++ b/packages/frontend/src/components/ui/DataTable.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DataTable, type Column } from './DataTable';
+
+interface Row {
+  id: string;
+  name: string;
+}
+const columns: Column<Row>[] = [
+  { key: 'id', header: 'ID', cell: (r) => r.id, className: 'font-mono' },
+  { key: 'name', header: 'Name', cell: (r) => r.name, align: 'right' },
+];
+const rows: Row[] = [
+  { id: 'a1', name: 'alpha' },
+  { id: 'b2', name: 'beta' },
+];
+
+describe('ui/DataTable', () => {
+  it('renders a uniform token header and one row per item', () => {
+    render(<DataTable columns={columns} rows={rows} rowKey={(r) => r.id} />);
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers.map((h) => h.textContent)).toEqual(['ID', 'Name']);
+    // header uses the muted token, not an ad-hoc per-column color
+    expect(headers[0].className).toContain('text-text-muted');
+    expect(screen.getByText('alpha')).toBeDefined();
+    expect(screen.getByText('beta')).toBeDefined();
+  });
+
+  it('applies per-column className and alignment to header and cell', () => {
+    render(<DataTable columns={columns} rows={rows} rowKey={(r) => r.id} />);
+    expect(screen.getByText('a1').className).toContain('font-mono');
+    expect(screen.getByText('alpha').className).toContain('text-right');
+  });
+
+  it('fires onRowClick with the row', () => {
+    const onRowClick = vi.fn();
+    render(
+      <DataTable columns={columns} rows={rows} rowKey={(r) => r.id} onRowClick={onRowClick} />,
+    );
+    fireEvent.click(screen.getByText('alpha'));
+    expect(onRowClick).toHaveBeenCalledWith(rows[0], 0);
+  });
+
+  it('renders the empty state spanning all columns', () => {
+    render(<DataTable columns={columns} rows={[]} rowKey={(r) => r.id} empty="Nothing here" />);
+    const cell = screen.getByText('Nothing here');
+    expect(cell.getAttribute('colspan')).toBe('2');
+  });
+});

--- a/packages/frontend/src/components/ui/DataTable.tsx
+++ b/packages/frontend/src/components/ui/DataTable.tsx
@@ -1,0 +1,136 @@
+import { cn } from './cn';
+
+/**
+ * <DataTable> — the uniform table primitive (#2075, epic #2071).
+ *
+ * Replaces the audited 6 tables / 5 header styles (incl. the random
+ * per-column colours of the Containers tab — Node purple, ID blue, Image
+ * green…) with ONE quiet, consistent header/row/hover/divider story on the
+ * surface tokens. Generic over the row type; columns declare a header, a
+ * cell renderer, and optional alignment / className.
+ */
+export interface Column<Row> {
+  /** Stable key for React + a11y. */
+  key: string;
+  header: React.ReactNode;
+  /** Cell renderer for a given row. */
+  cell: (row: Row, index: number) => React.ReactNode;
+  align?: 'left' | 'center' | 'right';
+  /** Extra classes applied to BOTH the <th> and the <td> (e.g. width, font-mono). */
+  className?: string;
+}
+
+export interface DataTableProps<Row> {
+  columns: Column<Row>[];
+  rows: Row[];
+  /** Stable key per row. */
+  rowKey: (row: Row, index: number) => string;
+  /** Optional per-row click — makes the row a button-like target. */
+  onRowClick?: (row: Row, index: number) => void;
+  /** Shown (spanning all columns) when `rows` is empty. */
+  empty?: React.ReactNode;
+  /** Classes on the scroll container. */
+  className?: string;
+  /** Min table width to force horizontal scroll on narrow viewports. */
+  minWidthClassName?: string;
+}
+
+const alignClass: Record<NonNullable<Column<unknown>['align']>, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+};
+
+function HeaderRow<Row>({ columns }: { columns: Column<Row>[] }) {
+  return (
+    <tr className="border-b border-border bg-surface-muted">
+      {columns.map((col) => (
+        <th
+          key={col.key}
+          scope="col"
+          className={cn(
+            'px-space-3 py-space-2 text-xs font-semibold uppercase tracking-wide text-text-muted',
+            col.align && alignClass[col.align],
+            col.className,
+          )}
+        >
+          {col.header}
+        </th>
+      ))}
+    </tr>
+  );
+}
+
+function BodyRow<Row>({
+  columns,
+  row,
+  index,
+  onRowClick,
+}: {
+  columns: Column<Row>[];
+  row: Row;
+  index: number;
+  onRowClick?: (row: Row, index: number) => void;
+}) {
+  return (
+    <tr
+      onClick={onRowClick ? () => onRowClick(row, index) : undefined}
+      className={cn(
+        'border-b border-border last:border-0 text-text',
+        onRowClick && 'cursor-pointer hover:bg-surface-2',
+      )}
+    >
+      {columns.map((col) => (
+        <td
+          key={col.key}
+          className={cn('px-space-3 py-space-2', col.align && alignClass[col.align], col.className)}
+        >
+          {col.cell(row, index)}
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export function DataTable<Row>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  empty = 'No data',
+  className,
+  minWidthClassName,
+}: DataTableProps<Row>) {
+  return (
+    <div className={cn('overflow-x-auto rounded-card border border-border', className)}>
+      <table className={cn('w-full text-left text-sm', minWidthClassName)}>
+        <thead>
+          <HeaderRow columns={columns} />
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="px-space-3 py-space-4 text-center text-sm text-text-subtle"
+              >
+                {empty}
+              </td>
+            </tr>
+          ) : (
+            rows.map((row, i) => (
+              <BodyRow
+                key={rowKey(row, i)}
+                columns={columns}
+                row={row}
+                index={i}
+                onRowClick={onRowClick}
+              />
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/packages/frontend/src/components/ui/Field.test.tsx
+++ b/packages/frontend/src/components/ui/Field.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Field } from './Field';
+
+describe('ui/Field', () => {
+  it('wires the label to the control via a generated id', () => {
+    render(
+      <Field label="Domain">
+        {(props) => <input {...props} />}
+      </Field>,
+    );
+    const input = screen.getByLabelText('Domain');
+    expect(input.getAttribute('id')).toBeTruthy();
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('renders help text linked via aria-describedby', () => {
+    render(
+      <Field label="Port" help="1-65535">
+        {(props) => <input {...props} />}
+      </Field>,
+    );
+    const input = screen.getByLabelText('Port');
+    const help = screen.getByText('1-65535');
+    expect(input.getAttribute('aria-describedby')).toContain(help.getAttribute('id'));
+  });
+
+  it('announces an error and marks the control invalid (error overrides help)', () => {
+    render(
+      <Field label="Email" help="ignored" error="Required">
+        {(props) => <input {...props} />}
+      </Field>,
+    );
+    const input = screen.getByLabelText('Email');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    const err = screen.getByRole('alert');
+    expect(err.textContent).toBe('Required');
+    expect(input.getAttribute('aria-describedby')).toContain(err.getAttribute('id'));
+    expect(screen.queryByText('ignored')).toBeNull();
+  });
+
+  it('shows a required marker', () => {
+    render(
+      <Field label="Name" required>
+        {(props) => <input {...props} />}
+      </Field>,
+    );
+    expect(screen.getByText('*')).toBeDefined();
+  });
+});

--- a/packages/frontend/src/components/ui/Field.tsx
+++ b/packages/frontend/src/components/ui/Field.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useId } from 'react';
+import { cn } from './cn';
+
+/**
+ * <Field> — the shared label+control wrapper (#2076, epic #2071).
+ *
+ * Unifies the uneven label/control/help/error combos into one accessible
+ * layout: a real <label> wired to the control via a generated id, an optional
+ * help line, and an error line announced with role="alert" + aria-invalid on
+ * the control. Pass the control as a render-prop so the field owns the id and
+ * aria wiring without cloning children.
+ */
+export interface FieldProps {
+  label: React.ReactNode;
+  /** Render-prop receiving the wired control props (id + aria-*). */
+  children: (props: {
+    id: string;
+    'aria-describedby'?: string;
+    'aria-invalid'?: boolean;
+  }) => React.ReactNode;
+  /** Help text under the control. */
+  help?: React.ReactNode;
+  /** Error message — shown in status-fail and announced. Overrides help tone. */
+  error?: React.ReactNode;
+  /** Mark the label with a required asterisk. */
+  required?: boolean;
+  className?: string;
+}
+
+export function Field({
+  label,
+  children,
+  help,
+  error,
+  required,
+  className,
+}: FieldProps) {
+  const id = useId();
+  const helpId = help ? `${id}-help` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [errorId, helpId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <div className={cn('flex flex-col gap-space-1', className)}>
+      <label htmlFor={id} className="text-xs font-medium text-text-muted">
+        {label}
+        {required && <span className="ml-space-1 text-status-fail" aria-hidden="true">*</span>}
+      </label>
+      {children({
+        id,
+        'aria-describedby': describedBy,
+        'aria-invalid': error ? true : undefined,
+      })}
+      {error ? (
+        <p id={errorId} role="alert" className="text-xs text-status-fail">
+          {error}
+        </p>
+      ) : (
+        help && (
+          <p id={helpId} className="text-xs text-text-subtle">
+            {help}
+          </p>
+        )
+      )}
+    </div>
+  );
+}
+

--- a/packages/frontend/src/components/ui/PageScroll.test.tsx
+++ b/packages/frontend/src/components/ui/PageScroll.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PageScroll, PageShell, PageScrollRegion } from './PageScroll';
+
+// The whole point of #2077: the canonical scroll region must carry the
+// load-bearing flex-chain classes — `min-h-0` (so a flex child can shrink below
+// its content) AND `overflow-y-auto` (so the shrunk region produces a scrollbar).
+// Without `min-h-0` a flex child defaults to min-height:auto and never scrolls —
+// that's the operator's "Settings zu groß, keine Scrollbar" bug.
+
+describe('ui/PageScroll', () => {
+  it('is a self-contained scroll region: h-full + min-h-0 + overflow-y-auto', () => {
+    render(<PageScroll>body</PageScroll>);
+    const el = screen.getByText('body');
+    expect(el.className).toContain('h-full');
+    expect(el.className).toContain('min-h-0');
+    expect(el.className).toContain('overflow-y-auto');
+    // never clips: must NOT pin the body height with an overflow-hidden
+    expect(el.className).not.toContain('overflow-hidden');
+  });
+
+  it('applies the spacing scale and merges a passed className', () => {
+    const { rerender } = render(<PageScroll spacing="md" className="pb-8">x</PageScroll>);
+    let el = screen.getByText('x');
+    expect(el.className).toContain('space-y-4');
+    expect(el.className).toContain('pb-8');
+    rerender(<PageScroll spacing="none">x</PageScroll>);
+    el = screen.getByText('x');
+    expect(el.className).not.toMatch(/space-y-/);
+  });
+});
+
+describe('ui/PageShell + PageScrollRegion (fixed header + scrolling body)', () => {
+  it('PageShell is a flex column that fills the shell', () => {
+    render(<PageShell>shell</PageShell>);
+    const el = screen.getByText('shell');
+    expect(el.className).toContain('h-full');
+    expect(el.className).toContain('min-h-0');
+    expect(el.className).toContain('flex');
+    expect(el.className).toContain('flex-col');
+  });
+
+  it('PageScrollRegion is the scrolling flex child: flex-1 + min-h-0 + overflow-y-auto', () => {
+    render(<PageScrollRegion>region</PageScrollRegion>);
+    const el = screen.getByText('region');
+    expect(el.className).toContain('flex-1');
+    expect(el.className).toContain('min-h-0');
+    expect(el.className).toContain('overflow-y-auto');
+  });
+});

--- a/packages/frontend/src/components/ui/PageScroll.tsx
+++ b/packages/frontend/src/components/ui/PageScroll.tsx
@@ -1,0 +1,92 @@
+import { cn } from './cn';
+
+/**
+ * <PageScroll> — the ONE canonical scrollable page/content pattern (#2077, epic #2071).
+ *
+ * The dashboard shell (`app/(dashboard)/layout.tsx`) is a fixed-height flex
+ * column whose `<main>` is `overflow-hidden` — so a page that simply stacks
+ * content overflows the viewport with **no scrollbar** and clips at the bottom
+ * (operator bug: "Settings zu groß, keine Scrollbar"). The audit found this is
+ * re-invented inconsistently across pages (82× overflow-hidden vs 44×
+ * overflow-y-auto): some pages get `h-full overflow-y-auto`, some get nothing.
+ *
+ * The fix is a single flex-chain rule, captured here so pages don't re-author it:
+ *
+ *   - the page root fills the shell and is a flex column (`h-full flex flex-col`);
+ *   - the **scrollable content region is `min-h-0 overflow-y-auto`** — `min-h-0`
+ *     is the load-bearing part: a flex child defaults to `min-height:auto`, which
+ *     refuses to shrink below its content and so never produces a scrollbar.
+ *
+ * Two pieces so a page can keep a sticky/non-scrolling header (e.g. a back link
+ * + tab bar) above the scroll region:
+ *
+ *   <PageScroll>                  ← single scroll region for the whole page
+ *     …content…
+ *   </PageScroll>
+ *
+ *   <PageShell>                   ← flex-column shell; put a fixed header, then
+ *     <header/>                     a <PageScrollRegion> for the scrolling body
+ *     <PageScrollRegion>…</…>
+ *   </PageShell>
+ */
+
+export interface PageScrollProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Vertical rhythm between direct children of the scroll region. */
+  spacing?: 'none' | 'sm' | 'md' | 'lg';
+}
+
+const spacings: Record<NonNullable<PageScrollProps['spacing']>, string> = {
+  none: '',
+  sm: 'space-y-3',
+  md: 'space-y-4',
+  lg: 'space-y-6',
+};
+
+/**
+ * The whole page is one scroll region. Fills the shell, scrolls its overflow.
+ * Use when there is no part of the page that must stay pinned while scrolling.
+ */
+export function PageScroll({ spacing = 'lg', className, ...rest }: PageScrollProps) {
+  return (
+    <div
+      className={cn(
+        'h-full min-h-0 overflow-y-auto',
+        spacings[spacing],
+        className,
+      )}
+      {...rest}
+    />
+  );
+}
+
+/**
+ * A flex-column page shell. Pair a fixed (non-scrolling) header with a
+ * <PageScrollRegion> for the body, so the header stays put while the body scrolls.
+ */
+export function PageShell({
+  className,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('h-full min-h-0 flex flex-col', className)} {...rest} />;
+}
+
+/**
+ * The scrolling body inside a <PageShell>. `min-h-0` lets the flex child shrink
+ * below its content so `overflow-y-auto` actually produces a scrollbar.
+ */
+export function PageScrollRegion({
+  spacing = 'lg',
+  className,
+  ...rest
+}: PageScrollProps) {
+  return (
+    <div
+      className={cn(
+        'flex-1 min-h-0 overflow-y-auto',
+        spacings[spacing],
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/frontend/src/components/ui/SectionHeading.test.tsx
+++ b/packages/frontend/src/components/ui/SectionHeading.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SectionHeading } from './SectionHeading';
+
+describe('ui/SectionHeading', () => {
+  it('renders an h2 by default with default tone', () => {
+    render(<SectionHeading>Configuration</SectionHeading>);
+    const h = screen.getByRole('heading', { name: 'Configuration', level: 2 });
+    expect(h.className).toContain('text-text');
+  });
+
+  it('uses status-fail for the danger tone (Danger zone)', () => {
+    render(<SectionHeading tone="danger">Danger zone</SectionHeading>);
+    expect(screen.getByRole('heading', { name: 'Danger zone' }).className).toContain(
+      'text-status-fail',
+    );
+  });
+
+  it('honours the as prop and renders description + actions', () => {
+    render(
+      <SectionHeading as="h3" description="desc text" actions={<button>edit</button>}>
+        Lifecycle
+      </SectionHeading>,
+    );
+    expect(screen.getByRole('heading', { name: 'Lifecycle', level: 3 })).toBeDefined();
+    expect(screen.getByText('desc text')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'edit' })).toBeDefined();
+  });
+});

--- a/packages/frontend/src/components/ui/SectionHeading.tsx
+++ b/packages/frontend/src/components/ui/SectionHeading.tsx
@@ -1,0 +1,60 @@
+import { cn } from './cn';
+
+/**
+ * <SectionHeading> — the shared in-page section label (#2076, epic #2071).
+ *
+ * Unifies the audited 33 ad-hoc section-heading styles ('Lifecycle',
+ * 'Danger zone', 'Configuration', …) into one component. A `tone="danger"`
+ * variant tints destructive sections via status-fail instead of an ad-hoc
+ * red literal. Renders a real heading element (default <h2>) for document
+ * outline / a11y; override via `as`.
+ */
+export type SectionHeadingTone = 'default' | 'muted' | 'danger';
+
+const tones: Record<SectionHeadingTone, string> = {
+  default: 'text-text',
+  muted: 'text-text-muted',
+  danger: 'text-status-fail',
+};
+
+export interface SectionHeadingProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {
+  tone?: SectionHeadingTone;
+  /** Optional secondary description under the heading. */
+  description?: React.ReactNode;
+  /** Optional right-aligned actions on the heading row. */
+  actions?: React.ReactNode;
+  /** Heading level element. Default h2. */
+  as?: 'h1' | 'h2' | 'h3' | 'h4';
+}
+
+export function SectionHeading({
+  tone = 'default',
+  description,
+  actions,
+  as: Heading = 'h2',
+  className,
+  children,
+  ...rest
+}: SectionHeadingProps) {
+  return (
+    <div className={cn('flex items-start justify-between gap-space-3', className)}>
+      <div className="min-w-0">
+        <Heading
+          className={cn(
+            'text-sm font-semibold uppercase tracking-wide',
+            tones[tone],
+          )}
+          {...rest}
+        >
+          {children}
+        </Heading>
+        {description && (
+          <p className="mt-space-1 text-xs text-text-muted">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex items-center gap-space-2 shrink-0">{actions}</div>}
+    </div>
+  );
+}
+

--- a/packages/frontend/src/components/ui/StatusDot.test.tsx
+++ b/packages/frontend/src/components/ui/StatusDot.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusDot } from './StatusDot';
+
+describe('ui/StatusDot', () => {
+  it.each([
+    ['ok', 'OK', 'bg-status-ok'],
+    ['warn', 'Warning', 'bg-status-warn'],
+    ['fail', 'Failed', 'bg-status-fail'],
+    ['unknown', 'Unknown', 'bg-text-subtle'],
+  ] as const)('renders %s with an accessible label and token color', (state, label, color) => {
+    const { container } = render(<StatusDot state={state} />);
+    const root = screen.getByRole('status');
+    expect(root.getAttribute('data-state')).toBe(state);
+    // default label is screen-reader-only but present for a11y
+    expect(screen.getByText(label)).toBeDefined();
+    expect(container.querySelector(`.${color.replace('/', '\\/')}`)).not.toBeNull();
+  });
+
+  it('shows the label inline when showLabel is set', () => {
+    render(<StatusDot state="ok" label="Healthy" showLabel />);
+    const text = screen.getByText('Healthy');
+    expect(text.className).not.toContain('sr-only');
+  });
+});

--- a/packages/frontend/src/components/ui/StatusDot.tsx
+++ b/packages/frontend/src/components/ui/StatusDot.tsx
@@ -1,0 +1,58 @@
+import { cn } from './cn';
+
+/**
+ * <StatusDot> — the canonical health/status indicator dot (#2076, epic #2071).
+ *
+ * One dot, four states, all on status tokens (no ad-hoc green-500/red-400…).
+ * Carries an accessible label: a visually-hidden text plus role="status" so a
+ * screen reader announces the state, not just a coloured circle.
+ */
+export type StatusState = 'ok' | 'warn' | 'fail' | 'unknown';
+
+const colors: Record<StatusState, string> = {
+  ok: 'bg-status-ok',
+  warn: 'bg-status-warn',
+  fail: 'bg-status-fail',
+  unknown: 'bg-text-subtle',
+};
+
+const defaultLabels: Record<StatusState, string> = {
+  ok: 'OK',
+  warn: 'Warning',
+  fail: 'Failed',
+  unknown: 'Unknown',
+};
+
+export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
+  state: StatusState;
+  /** Accessible label; defaults to a human-readable name for the state. */
+  label?: string;
+  /** Render the label text next to the dot (otherwise it's SR-only). */
+  showLabel?: boolean;
+}
+
+export function StatusDot({
+  state,
+  label,
+  showLabel = false,
+  className,
+  ...rest
+}: StatusDotProps) {
+  const text = label ?? defaultLabels[state];
+  return (
+    <span
+      role="status"
+      data-state={state}
+      className={cn('inline-flex items-center gap-space-2', className)}
+      {...rest}
+    >
+      <span className={cn('inline-block h-2 w-2 rounded-chip shrink-0', colors[state])} aria-hidden="true" />
+      {showLabel ? (
+        <span className="text-xs text-text-muted">{text}</span>
+      ) : (
+        <span className="sr-only">{text}</span>
+      )}
+    </span>
+  );
+}
+

--- a/packages/frontend/src/components/ui/cn.ts
+++ b/packages/frontend/src/components/ui/cn.ts
@@ -1,0 +1,12 @@
+/**
+ * Tiny class-name joiner for the design-system primitives (#2071).
+ *
+ * The repo has no clsx/tailwind-merge dependency, and the primitives only need
+ * to drop falsy values and join with spaces (variant maps are authored to not
+ * collide, so we don't need conflict-resolution merging). Keep it dependency-free.
+ */
+export type ClassValue = string | false | null | undefined;
+
+export function cn(...parts: ClassValue[]): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/frontend/src/components/ui/index.ts
+++ b/packages/frontend/src/components/ui/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Design-system primitives (epic #2071, foundation tokens #2072).
+ *
+ * One shared, token-wired library for the app's surfaces — import from
+ * `@/components/ui` rather than re-authoring ad-hoc class-chains. Migrations of
+ * existing surfaces onto these land in #2078/#2079.
+ */
+export { Button } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+
+export { Card, Panel } from './Card';
+export type { CardProps, PanelProps, CardPadding } from './Card';
+
+export { DataTable } from './DataTable';
+export type { DataTableProps, Column } from './DataTable';
+
+export { Badge } from './Badge';
+export type { BadgeProps, BadgeVariant } from './Badge';
+
+export { StatusDot } from './StatusDot';
+export type { StatusDotProps, StatusState } from './StatusDot';
+
+export { SectionHeading } from './SectionHeading';
+export type { SectionHeadingProps, SectionHeadingTone } from './SectionHeading';
+
+export { Field } from './Field';
+export type { FieldProps } from './Field';
+
+export { cn } from './cn';
+export type { ClassValue } from './cn';

--- a/packages/frontend/src/components/ui/index.ts
+++ b/packages/frontend/src/components/ui/index.ts
@@ -26,5 +26,8 @@ export type { SectionHeadingProps, SectionHeadingTone } from './SectionHeading';
 export { Field } from './Field';
 export type { FieldProps } from './Field';
 
+export { PageScroll, PageShell, PageScrollRegion } from './PageScroll';
+export type { PageScrollProps } from './PageScroll';
+
 export { cn } from './cn';
 export type { ClassValue } from './cn';

--- a/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
@@ -36,14 +36,35 @@ vi.mock('@/hooks/useCoreHealth', () => ({
   useCoreHealth: () => ({ unhealthy: false }),
 }));
 
+// A well-formed self-update status: on the latest version, auto-update off.
+const UP_TO_DATE_STATUS = {
+  hasUpdate: false,
+  current: '4.140.0',
+  latest: null,
+  config: { autoUpdate: { enabled: false, schedule: '' } },
+};
+
+/** Route-aware fetch: the consolidated Updates section (#2082) mounts the
+ *  ServiceBay updater card (GET /api/system/update) alongside the image-updates
+ *  banner, so the mock must answer the updater endpoint with a valid status. */
+function routedFetch(extra: (url: string) => unknown | undefined) {
+  return vi.fn(async (url: string) => {
+    const u = typeof url === 'string' ? url : '';
+    const override = extra(u);
+    if (override !== undefined) return override;
+    if (u.includes('/api/system/update')) {
+      return { ok: true, json: async () => UP_TO_DATE_STATUS };
+    }
+    return { ok: true, json: async () => [] };
+  }) as unknown as typeof fetch;
+}
+
 describe('OverviewDashboard render', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // /api/health/checks read — return zero diagnose rows (neutral card).
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => [],
-    })) as unknown as typeof fetch);
+    // Default: /api/health/checks → zero diagnose rows; /api/system/update →
+    // up-to-date; everything else → [].
+    vi.stubGlobal('fetch', routedFetch(() => undefined));
   });
 
   it('renders the health headline and links the cards to /services and /status', () => {
@@ -68,8 +89,8 @@ describe('OverviewDashboard render', () => {
 
   it('renders the image-updates banner on Home when the report has pending updates (#1860)', async () => {
     // image-updates report returns one pending service; everything else neutral.
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (typeof url === 'string' && url.includes('/api/system/stacks/image-updates')) {
+    vi.stubGlobal('fetch', routedFetch(url => {
+      if (url.includes('/api/system/stacks/image-updates')) {
         return {
           ok: true,
           json: async () => ({
@@ -79,8 +100,8 @@ describe('OverviewDashboard render', () => {
           }),
         };
       }
-      return { ok: true, json: async () => [] };
-    }) as unknown as typeof fetch);
+      return undefined;
+    }));
 
     render(
       <ToastProvider>
@@ -90,5 +111,52 @@ describe('OverviewDashboard render', () => {
 
     expect(await screen.findByText(/1 service image update available/i)).toBeDefined();
     expect(await screen.findByRole('button', { name: /update now/i })).toBeDefined();
+  });
+
+  it('consolidates the SB self-updater and service image-updates under one Updates section (#2082)', async () => {
+    // SB updater reports an available version (its own "Update Now" trigger),
+    // AND an image update is pending (the banner's trigger) — both must sit in
+    // the single Updates area, each with its button.
+    vi.stubGlobal('fetch', routedFetch(url => {
+      if (url.includes('/api/system/update')) {
+        return {
+          ok: true,
+          json: async () => ({
+            hasUpdate: true,
+            current: '4.140.0',
+            latest: { version: '4.141.0', url: '', date: '', notes: '' },
+            config: { autoUpdate: { enabled: false, schedule: '' } },
+          }),
+        };
+      }
+      if (url.includes('/api/system/stacks/image-updates')) {
+        return {
+          ok: true,
+          json: async () => ({
+            services: [
+              { service: 'a', image: 'ghcr.io/a:latest', runningDigest: 'sha256:old', registryDigest: 'sha256:new', updateAvailable: true },
+            ],
+          }),
+        };
+      }
+      return undefined;
+    }));
+
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+
+    // One Updates section heading.
+    expect(await screen.findByRole('heading', { name: /^Updates$/ })).toBeDefined();
+    // The SB self-updater half: its status + its own Update Now trigger.
+    expect(await screen.findByText(/ServiceBay Updates/)).toBeDefined();
+    expect(await screen.findByText(/New version available: 4\.141\.0/)).toBeDefined();
+    // The per-service image-updates half: its roll-up + its own trigger.
+    expect(await screen.findByText(/1 service image update available/i)).toBeDefined();
+    // Two distinct "Update Now/now" triggers (SB updater + image banner).
+    const triggers = await screen.findAllByRole('button', { name: /update now/i });
+    expect(triggers.length).toBe(2);
   });
 });

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -9,6 +9,8 @@ import { useCoreHealth } from '@/hooks/useCoreHealth';
 import { useImageUpdates, type ServiceImageUpdate } from '@/hooks/useImageUpdates';
 import { useServiceActions } from '@/hooks/useServiceActions';
 import ImageUpdatesPendingBanner from '@/components/ImageUpdatesPendingBanner';
+import ServiceBayUpdateCard from '@/components/ServiceBayUpdateCard';
+import { SectionHeading } from '@/components/ui';
 
 /**
  * Latest persisted diagnose breakdown for the Home card (#1873).
@@ -215,9 +217,17 @@ export default function OverviewDashboard() {
         {/* Headline status — the single sentence that answers "is everything OK?" */}
         <HealthHeadline tone={healthHeadline.tone} text={healthHeadline.text} />
 
-        {/* Pending image updates — box status, actionable right here (#1860).
-            Renders nothing when there are none. */}
-        <ImageUpdatesPendingBanner updates={imageUpdates} onUpdate={handleUpdateAll} />
+        {/* Updates — one coherent area (#2082): the ServiceBay self-updater
+            (version status + "Update now", GET/POST /api/system/update) and the
+            per-service image updates (#1860/#2069) together, each with its own
+            trigger. The image banner renders nothing when no images are pending,
+            but the SB updater card always shows current version + Check Now, so
+            the section is never empty. */}
+        <section className="space-y-3">
+          <SectionHeading description="Keep ServiceBay and your services up to date">Updates</SectionHeading>
+          <ServiceBayUpdateCard />
+          <ImageUpdatesPendingBanner updates={imageUpdates} onUpdate={handleUpdateAll} />
+        </section>
 
         {/* Box-wide at-a-glance: services running + latest diagnose breakdown. */}
         <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">


### PR DESCRIPTION
## What
Lands the design-system foundation (semantic CSS token layer + 7 UI primitives), a canonical page-scroll pattern that fixes Operate-tab clipping, a health-check→service mapping fix that surfaces box-wide diagnostics in the Operate Health tab, and a consolidated Updates area on Home (ServiceBay self-updater + pending service image-updates together).

## Why
Closes #2072
Closes #2073
Closes #2074
Closes #2075
Closes #2076
Closes #2077
Closes #2080
Closes #2082

## Risk
Low-to-medium — mostly additive frontend (new tokens/primitives unused by old surfaces yet); the health-check mapping reclassifies box-wide checks (separated from per-service counts) and Home Updates consolidates two existing surfaces with unchanged API calls.

## Rollback
git revert is enough — no migrations, no schema/version bumps.

## Verification
- [x] npm run lint (0 errors, 356 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (full — 3134 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — path-mandated: app/(dashboard)/ (Home Updates, Operate scroll shell, OperateHealthTab box-wide section); operator visual pixel-confirm in DARK MODE owed