### PR TITLE
fix+feat: updater/channel recreate fixes + Home design polish + grouping optic consistency

### DIFF
--- a/packages/backend/src/lib/servicebayChannel.test.ts
+++ b/packages/backend/src/lib/servicebayChannel.test.ts
@@ -29,15 +29,33 @@ describe('servicebayChannel', () => {
     expect(await getServicebayChannel()).toBe('dev');
   });
 
-  it('re-points the quadlet tag (channel as $1, not interpolated), then pulls + reloads + restarts', async () => {
+  it('re-points the quadlet tag (channel as $1, not interpolated), then pulls + reloads + recreates + restarts', async () => {
     await setServicebayChannel('dev');
-    await flush(); // let the detached pull/restart run
+    await flush(); // let the detached recreate/restart run
     const flat = calls.map(c => c.join(' '));
     const sed = calls.find(c => c.join(' ').includes('sed'));
     expect(sed?.includes('dev')).toBe(true); // channel passed as a positional arg
     expect(flat.some(c => c.includes('podman pull') && c.includes('servicebay:dev'))).toBe(true);
     expect(flat.some(c => c.includes('daemon-reload'))).toBe(true);
+    // #2063: a plain restart reuses the old container — force a recreate so the
+    // freshly-pulled image actually lands (rm -f before the restart).
+    expect(flat.some(c => c.includes('rm -f servicebay'))).toBe(true);
     expect(flat.some(c => c.includes('restart --no-block servicebay.service'))).toBe(true);
+  });
+
+  it('surfaces a pull failure to the caller instead of swallowing it (#2064)', async () => {
+    // The :dev tag is missing / ghcr auth fails → the pull rejects. The switch
+    // must NOT resolve ok while silently rolling back; the error propagates.
+    execMock.mockImplementation(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv.includes('pull')) throw new Error('manifest unknown: :dev not found');
+      return { stdout: '', stderr: '' };
+    });
+    await expect(setServicebayChannel('dev')).rejects.toThrow(/:dev not found/);
+    // We never reached the recreate/restart since the pull failed up front.
+    const flat = calls.map(c => c.join(' '));
+    expect(flat.some(c => c.includes('rm -f servicebay'))).toBe(false);
+    expect(flat.some(c => c.includes('restart --no-block'))).toBe(false);
   });
 
   it('refuses an unknown channel before touching the box', async () => {

--- a/packages/backend/src/lib/servicebayChannel.ts
+++ b/packages/backend/src/lib/servicebayChannel.ts
@@ -41,11 +41,22 @@ export async function getServicebayChannel(): Promise<string> {
 }
 
 /**
- * Re-point the quadlet to `:<channel>`, then pull + restart in the background.
+ * Re-point the quadlet to `:<channel>`, pull the new image (errors surfaced to
+ * the caller), then recreate + restart the container in the background.
  *
- * The tag swap is awaited (so a bad write surfaces synchronously); the slow
- * pull + the `--no-block` restart run detached so the caller's HTTP response
- * returns before the container is replaced (same pattern as `performUpdate`).
+ * The tag swap and the pull are **awaited** so a bad quadlet write or a pull
+ * failure (e.g. `:dev` not found / ghcr auth) surfaces synchronously — the
+ * caller must not get `ok:true` while the switch silently rolls back (#2064).
+ * Only the recreate + `--no-block` restart run detached, so the HTTP response
+ * returns before ServiceBay (which is serving it) goes down.
+ *
+ * Recreate, not a plain restart: `systemctl restart` reuses the *existing*
+ * container definition, so it keeps running the OLD image even after the new
+ * one is pulled — a same-tag (`:latest`→`:latest`) re-pull silently no-ops
+ * (#2063). `podman rm -f` forces the quadlet unit to recreate the container
+ * from the freshly-pulled, re-pointed image on the next start, so the switch
+ * actually lands. (rm runs detached with the restart because it tears down the
+ * very process serving this request.)
  */
 export async function setServicebayChannel(channel: Channel): Promise<void> {
   if (!isChannel(channel)) {
@@ -54,16 +65,20 @@ export async function setServicebayChannel(channel: Channel): Promise<void> {
   const executor = getExecutor('Local');
   // Swap `…/servicebay:<anything>` → `…/servicebay:<channel>` ($1 = channel).
   await executor.execArgv(['sh', '-c', SWAP_TAG_SH, 'sh', channel]);
-  // Pull the new tag, reload the unit, restart non-blocking. Detached so the
-  // request can return before ServiceBay (which is serving it) goes down.
+  // Pull the new tag and reload the unit up front, AWAITED — a missing/unauthed
+  // tag throws here and propagates to the caller instead of being swallowed in
+  // a detached async (which left the box reporting the old channel, #2064).
+  await executor.execArgv(['podman', 'pull', `${IMAGE}:${channel}`], { timeoutMs: 5 * 60 * 1000 });
+  await executor.execArgv(['systemctl', '--user', 'daemon-reload']);
+  // Recreate + restart, detached: rm -f tears down the running container (us)
+  // so the quadlet recreates it from the new image; the request returns first.
   void (async () => {
     try {
-      await executor.execArgv(['podman', 'pull', `${IMAGE}:${channel}`], { timeoutMs: 5 * 60 * 1000 });
-      await executor.execArgv(['systemctl', '--user', 'daemon-reload']);
+      await executor.execArgv(['podman', 'rm', '-f', 'servicebay']);
       await executor.execArgv(['systemctl', '--user', 'restart', '--no-block', 'servicebay.service']);
-      logger.info('channel', `Switched ServiceBay to '${channel}' and triggered restart.`);
+      logger.info('channel', `Switched ServiceBay to '${channel}' and triggered container recreate.`);
     } catch (e) {
-      logger.error('channel', `Channel switch to '${channel}' failed during pull/restart: ${e instanceof Error ? e.message : String(e)}`);
+      logger.error('channel', `Channel switch to '${channel}' failed during recreate/restart: ${e instanceof Error ? e.message : String(e)}`);
     }
   })();
 }

--- a/packages/backend/src/lib/updater.test.ts
+++ b/packages/backend/src/lib/updater.test.ts
@@ -15,6 +15,13 @@ vi.mock('@/lib/config', () => ({
 }));
 
 // executor.exec / execArgv are stubbed per test.
+//
+// execArgv now serves two distinct podman calls: `manifest inspect` (registry
+// digest) and `inspect servicebay --format {{.ImageDigest}}` (running container
+// digest). The default impl routes by argv so a test that only sets the
+// registry manifest still gets a sane "running digest" answer; tests that care
+// about the running digest set `mockRunningDigest`.
+const mockRunningDigest = vi.hoisted(() => ({ value: null as string | null }));
 const mockExec = vi.hoisted(() => ({
   exec: vi.fn(async (_cmd: string, _opts?: unknown) => ({ stdout: '', stderr: '' })),
   execArgv: vi.fn(async (_argv: string[], _opts?: unknown) => ({ stdout: '', stderr: '' })),
@@ -52,9 +59,25 @@ function mockReleaseTag(tag: string) {
   ) as typeof fetch;
 }
 
+// Route execArgv by which podman subcommand it is. `manifestStdout` is the
+// `podman manifest inspect` (registry) answer; `mockRunningDigest.value` is the
+// running container's digest. Tests that set execArgv via mockResolvedValue
+// override this entirely (their value answers BOTH calls — fine where the
+// running-digest lookup just needs to not be the registry digest).
+function routeExecArgv(manifestStdout: string) {
+  mockExec.execArgv.mockImplementation(async (argv: string[]) => {
+    if (argv.includes('manifest')) return { stdout: manifestStdout, stderr: '' };
+    if (argv.includes('inspect')) {
+      return { stdout: mockRunningDigest.value ?? '', stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockConfig.current = { autoUpdate: { enabled: false, schedule: '0 0 * * *' } };
+  mockRunningDigest.value = null;
   mockExec.exec.mockResolvedValue({ stdout: '', stderr: '' });
   mockExec.execArgv.mockResolvedValue({ stdout: '', stderr: '' });
   global.fetch = ORIG_FETCH;
@@ -85,7 +108,8 @@ describe('checkForUpdates — tag/image reconciliation', () => {
   it('tag ahead AND image newer → update available', async () => {
     mockReleaseTag('4.104.0');
     mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:OLD';
-    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:NEW'), stderr: '' });
+    mockRunningDigest.value = 'sha256:OLD';
+    routeExecArgv(manifestList('sha256:NEW'));
 
     const res = await checkForUpdates();
     expect(res.hasUpdate).toBe(true);
@@ -95,12 +119,29 @@ describe('checkForUpdates — tag/image reconciliation', () => {
   it('tag ahead but image digest unchanged → NOT available, building', async () => {
     mockReleaseTag('4.104.0');
     mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:SAME';
-    mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:SAME'), stderr: '' });
+    mockRunningDigest.value = 'sha256:SAME';
+    routeExecArgv(manifestList('sha256:SAME'));
 
     const res = await checkForUpdates();
     expect(res.hasUpdate).toBe(false);
     expect(res.imageBuilding).toBe(true);
     expect(res.latest?.version).toBe('4.104.0');
+  });
+
+  it('#2062: appliedImageDigest drifted ahead but the running container is OLD → update available, NOT building', async () => {
+    // performUpdate once persisted the registry digest while the restart no-op'd
+    // and kept the old image, so config now lies: appliedImageDigest == remote.
+    // The OLD comparison ('remoteDigest === appliedDigest') would falsely report
+    // "still building" forever. Reconciling against the RUNNING container's real
+    // digest (which is still the old one) restores the truth: an update IS ready.
+    mockReleaseTag('4.137.0');
+    mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:e2476319'; // drifted == remote
+    mockRunningDigest.value = 'sha256:61d8725e'; // actually running the old 4.136.0 image
+    routeExecArgv(manifestList('sha256:e2476319')); // registry :latest is the new image
+
+    const res = await checkForUpdates();
+    expect(res.hasUpdate).toBe(true);
+    expect(res.imageBuilding).toBeFalsy();
   });
 
   it('tag ahead but remote digest unknown (registry unreachable) → falls back to tag (available)', async () => {
@@ -134,30 +175,39 @@ describe('checkForUpdates — tag/image reconciliation', () => {
 });
 
 describe('performUpdate — honest pull result', () => {
-  it('pull unchanged (image not ready) → reports building, does NOT restart', async () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it('pull unchanged (image not ready) → reports building, does NOT recreate/restart', async () => {
     mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:SAME';
     mockExec.exec.mockResolvedValue({ stdout: 'up to date', stderr: '' }); // podman pull
     mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:SAME'), stderr: '' }); // remote digest
 
     const res = await performUpdate('4.104.0');
+    await flush();
     expect(res.success).toBe(true);
     expect(res.updated).toBe(false);
     expect(res.message).toMatch(/still building|latest/i);
-    // never issued the systemctl restart
+    // never issued the recreate or the systemctl restart
+    const recreated = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('rm -f servicebay'));
     const restarted = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('systemctl'));
+    expect(recreated).toBe(false);
     expect(restarted).toBe(false);
   });
 
-  it('pull advanced the image → persists new digest and restarts', async () => {
+  it('pull advanced the image → persists new digest, recreates (rm -f) and restarts (#2063)', async () => {
     mockConfig.current.autoUpdate.appliedImageDigest = 'sha256:OLD';
     mockExec.exec.mockResolvedValue({ stdout: 'Pulled new layers', stderr: '' });
     mockExec.execArgv.mockResolvedValue({ stdout: manifestList('sha256:NEW'), stderr: '' });
 
     const res = await performUpdate('4.104.0');
+    await flush(); // let the detached recreate/restart run
     expect(res.success).toBe(true);
     expect(res.updated).toBe(true);
     expect(mockConfig.current.autoUpdate.appliedImageDigest).toBe('sha256:NEW');
+    // #2063: a plain restart keeps the old container — recreate with rm -f first.
+    const recreated = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('rm -f servicebay'));
     const restarted = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('systemctl'));
+    expect(recreated).toBe(true);
     expect(restarted).toBe(true);
   });
 });

--- a/packages/backend/src/lib/updater.ts
+++ b/packages/backend/src/lib/updater.ts
@@ -84,6 +84,32 @@ async function getRemoteImageDigest(): Promise<string | null> {
   }
 }
 
+/**
+ * Resolve the image digest the **running** `servicebay` container was actually
+ * created from — the ground truth for "what are we running right now", as
+ * opposed to `appliedImageDigest` in config (which can drift: `performUpdate`
+ * used to persist the registry digest even when the restart no-op'd and kept
+ * the old image, leaving every later check falsely reporting "still building",
+ * #2062). `podman inspect … {{.Image}}` returns the image ID; we map it to the
+ * registry-style manifest digest via the image's RepoDigests so it's
+ * comparable to `getRemoteImageDigest()`. Returns null on any failure — callers
+ * treat null as "unknown" and fall back to the config baseline.
+ */
+async function getRunningImageDigest(): Promise<string | null> {
+  try {
+    const executor = getExecutor('Local');
+    const { stdout } = await executor.execArgv(
+      ['podman', 'inspect', 'servicebay', '--format', '{{.ImageDigest}}'],
+      { timeoutMs: 30 * 1000 },
+    );
+    const digest = stdout.trim();
+    return /^sha256:[0-9a-f]+$/.test(digest) ? digest : null;
+  } catch (e) {
+    logger.warn('Updater', `getRunningImageDigest failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
 async function getCurrentVersion(): Promise<string> {
   try {
     const pkgPath = path.join(process.cwd(), 'package.json');
@@ -184,24 +210,29 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
 
   // The release tag is ahead. Reconcile against the *actual* image so we don't
   // advertise an update that would pull an unchanged image (the tag→image
-  // window). Compare the registry's current `:latest` digest to the digest we
-  // last applied. Equal → the new image isn't published yet → "building".
+  // window). Prefer the digest the RUNNING container was created from — it's
+  // ground truth. `appliedImageDigest` in config is only a fallback: it could
+  // have drifted ahead of reality if a past restart no-op'd while config
+  // recorded the registry digest, which is exactly what made a genuinely-new
+  // `:latest` look "still building" forever (#2062).
   const remoteDigest = await getRemoteImageDigest();
-  const appliedDigest = config.autoUpdate.appliedImageDigest;
+  const baselineDigest = (await getRunningImageDigest()) ?? config.autoUpdate.appliedImageDigest;
 
-  // If we can't resolve the remote digest (registry unreachable / no podman),
-  // fall back to the tag check alone — never block a genuine update on a
-  // transient digest-lookup failure, and never claim "building" on unknown.
-  if (!remoteDigest || !appliedDigest) {
+  // If we can't resolve the remote digest (registry unreachable / no podman) or
+  // have no baseline at all, fall back to the tag check alone — never block a
+  // genuine update on a transient digest-lookup failure, and never claim
+  // "building" on unknown.
+  if (!remoteDigest || !baselineDigest) {
     return { hasUpdate: true, current, latest: latestInfo };
   }
 
-  if (remoteDigest === appliedDigest) {
-    // Tag advanced but the image we're running is still what the registry
-    // serves — the new image is still building. Not actionable yet.
+  if (remoteDigest === baselineDigest) {
+    // Tag advanced but the image we're running is genuinely the one the
+    // registry serves — the new image is still building. Not actionable yet.
     return { hasUpdate: false, imageBuilding: true, current, latest: latestInfo };
   }
 
+  // Registry `:latest` differs from what we're actually running → real update.
   return { hasUpdate: true, current, latest: latestInfo };
 }
 
@@ -323,11 +354,24 @@ export async function performUpdate(version: string): Promise<PerformUpdateResul
       });
     }
 
-    // 2. Restart via systemd instead of auto-update to ensure deterministic restart
-    logger.info('updater', 'Restarting service...');
-    emitProgress('restart', 0, 'Restarting service via systemctl --user restart --no-block servicebay.service');
-    await executor.exec('systemctl --user restart --no-block servicebay.service');
-    emitProgress('restart', 100, 'Restart triggered. ServiceBay will restart with the new image.');
+    // 2. Recreate + restart. A plain `systemctl restart` reuses the existing
+    // container definition and keeps running the OLD image even after the pull
+    // (#2063), so a fresh image silently never lands. Force a recreate by
+    // removing the container first; the quadlet unit then rebuilds it from the
+    // freshly-pulled image on start. `--no-block` so this request can return
+    // before ServiceBay (which is serving it) is torn down.
+    logger.info('updater', 'Recreating service container with the new image...');
+    emitProgress('restart', 0, 'Recreating container via podman rm -f + systemctl --user restart --no-block servicebay.service');
+    void (async () => {
+      try {
+        await executor.exec('podman rm -f servicebay');
+        await executor.exec('systemctl --user restart --no-block servicebay.service');
+        logger.info('updater', 'Container recreate + restart triggered.');
+      } catch (e) {
+        logger.error('updater', 'Recreate/restart failed:', e);
+      }
+    })();
+    emitProgress('restart', 100, 'Recreate triggered. ServiceBay will restart with the new image.');
 
     return { success: true, updated: true, message: 'Update applied. Service is restarting with the new image.' };
   } catch (e) {

--- a/packages/frontend/src/components/ImageUpdatesPendingBanner.test.tsx
+++ b/packages/frontend/src/components/ImageUpdatesPendingBanner.test.tsx
@@ -17,6 +17,18 @@ describe('ImageUpdatesPendingBanner', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('renders on the token Card surface, not the old ad-hoc blue literals (#2093)', () => {
+    const { container } = render(
+      <ImageUpdatesPendingBanner updates={[update('immich', 'ghcr.io/immich/server:latest')]} />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    // The migrated banner is a <Card> (bg-surface) with a token accent.
+    expect(root.className).toMatch(/bg-surface|border-accent|bg-accent/);
+    const html = root.outerHTML;
+    expect(html).not.toMatch(/(border|bg|text)-blue-\d/);
+    expect(html).not.toMatch(/text-gray-\d/);
+  });
+
   it('lists every affected service with its image', () => {
     render(
       <ImageUpdatesPendingBanner

--- a/packages/frontend/src/components/ImageUpdatesPendingBanner.tsx
+++ b/packages/frontend/src/components/ImageUpdatesPendingBanner.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
 import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
+import { Button, Card, StatusDot } from '@/components/ui';
 
 /**
  * Pending-updates overview for managed stacks (#1860, child 2 of #1858).
@@ -25,6 +26,11 @@ import type { ServiceImageUpdate } from '@/hooks/useImageUpdates';
  * `update` action the actions menu uses → pulls each new image, then restarts).
  * Without `onUpdate` it stays purely informational. The button owns only its
  * own in-flight flag; success/error feedback comes from the parent's toast.
+ *
+ * Migrated onto the design-system primitives (#2093): a `Card` with a
+ * token-driven accent (an "update available" tint via the `accent` token, no
+ * raw blue literals) + the shared `Button`/`StatusDot`. Dark-mode-correct by
+ * construction — every colour resolves through a semantic CSS variable.
  */
 export default function ImageUpdatesPendingBanner({
   updates,
@@ -50,44 +56,40 @@ export default function ImageUpdatesPendingBanner({
   };
 
   return (
-    <div className="mb-4 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50/70 dark:bg-blue-900/20">
-      <div className="p-4 flex items-start gap-3">
-        <div className="shrink-0 p-1.5 rounded bg-blue-100 dark:bg-blue-800/30 text-blue-700 dark:text-blue-300">
+    <Card padding="md" className="border-accent/40 bg-accent/5">
+      <div className="flex items-start gap-space-3">
+        <div className="shrink-0 rounded-card bg-accent/10 p-1.5 text-accent">
           <Download size={16} />
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-start justify-between gap-space-3">
             <div className="min-w-0">
-              <div className="font-semibold text-sm text-gray-900 dark:text-white">
+              <div className="flex items-center gap-space-2 text-sm font-semibold text-text">
+                <StatusDot state="warn" label="Update available" />
                 {updates.length} service image update{updates.length === 1 ? '' : 's'} available
               </div>
-              <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
+              <p className="mt-0.5 text-xs text-text-muted">
                 The registry is serving a newer image than what these services are running.
                 Re-deploy a service to pull its latest image.
               </p>
             </div>
             {onUpdate && (
-              <button
-                type="button"
-                onClick={handleUpdate}
-                disabled={running}
-                className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-60 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-              >
+              <Button size="sm" onClick={handleUpdate} disabled={running}>
                 {running ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
                 {running ? 'Updating…' : 'Update now'}
-              </button>
+              </Button>
             )}
           </div>
-          <ul className="mt-2 space-y-1.5 text-xs text-gray-700 dark:text-gray-300">
+          <ul className="mt-space-2 space-y-1.5 text-xs text-text-muted">
             {updates.map(u => (
-              <li key={`${u.service}:${u.image}`} className="flex items-center gap-2 flex-wrap">
-                <span className="font-mono font-medium">{u.service}</span>
-                <span className="text-gray-500 dark:text-gray-400 font-mono break-all">{u.image}</span>
+              <li key={`${u.service}:${u.image}`} className="flex flex-wrap items-center gap-space-2">
+                <span className="font-mono font-medium text-text">{u.service}</span>
+                <span className="break-all font-mono text-text-subtle">{u.image}</span>
               </li>
             ))}
           </ul>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/packages/frontend/src/components/ServiceBayUpdateCard.tsx
+++ b/packages/frontend/src/components/ServiceBayUpdateCard.tsx
@@ -5,6 +5,7 @@ import { CheckCircle2, Clock, Download, Loader2, RefreshCw, XCircle } from 'luci
 import ReactMarkdown from 'react-markdown';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useToast } from '@/providers/ToastProvider';
+import { Button, Card, StatusDot } from '@/components/ui';
 
 /**
  * ServiceBay self-update status.
@@ -49,6 +50,11 @@ export interface AppUpdateStatus {
  * Self-contained: owns its own status fetch (on mount + on "Check Now") and
  * the update progress/confirm modals. Renders nothing destructive — the
  * OS-reinstall block stays in `UpdatesSection` (settings only).
+ *
+ * Migrated onto the design-system primitives (#2093): the surface is a `Card`,
+ * the actions are `Button`s, the version state uses `StatusDot` + status/accent
+ * tokens (no raw purple/green/amber literals). Dark-mode-correct by
+ * construction — every colour resolves through a semantic CSS variable.
  */
 export default function ServiceBayUpdateCard() {
   const { addToast } = useToast();
@@ -184,142 +190,141 @@ export default function ServiceBayUpdateCard() {
 
   if (!appUpdate) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
-        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+      <Card padding="md" className="flex items-center gap-space-2 text-sm text-text-muted">
+        <Loader2 className="h-4 w-4 animate-spin" />
         Loading update status…
-      </div>
+      </Card>
     );
   }
 
+  const updateAvailable = appUpdate.hasUpdate && appUpdate.latest;
+
   return (
     <>
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-          <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg text-purple-600 dark:text-purple-400">
+      <Card padding="none" className={updateAvailable ? 'border-accent/40' : undefined}>
+        <div className="flex items-center gap-space-3 border-b border-border bg-surface-2 px-space-4 py-space-3">
+          <div className="rounded-card bg-accent/10 p-2 text-accent">
             <RefreshCw size={20} className={updateStatus === 'updating' || checkingUpdate ? 'animate-spin' : ''} />
           </div>
           <div>
-            <h3 className="font-bold text-gray-900 dark:text-white">ServiceBay Updates</h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Manage application updates</p>
+            <h3 className="font-bold text-text">ServiceBay Updates</h3>
+            <p className="text-xs text-text-muted">Manage application updates</p>
           </div>
-          <div className="ml-auto flex items-center gap-4">
-            <button
+          <div className="ml-auto flex items-center gap-space-3">
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={handleCheckUpdate}
               disabled={checkingUpdate || updateStatus === 'updating'}
-              className="text-xs text-purple-600 dark:text-purple-400 hover:underline disabled:opacity-50"
             >
               {checkingUpdate ? 'Checking...' : 'Check Now'}
-            </button>
-            <div className="h-4 w-px bg-gray-300 dark:bg-gray-600"></div>
-            <label className="relative inline-flex items-center cursor-pointer" title="Enable Auto-Updates">
+            </Button>
+            <div className="h-4 w-px bg-border"></div>
+            <label className="relative inline-flex cursor-pointer items-center" title="Enable Auto-Updates">
               <input
                 type="checkbox"
-                className="sr-only peer"
+                className="peer sr-only"
                 checked={appUpdate.config.autoUpdate.enabled}
                 onChange={toggleAutoUpdate}
               />
-              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 dark:peer-focus:ring-purple-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-purple-600"></div>
+              <div className="peer h-6 w-11 rounded-full bg-surface-muted after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-border after:bg-surface after:transition-all after:content-[''] peer-checked:bg-accent peer-checked:after:translate-x-full peer-checked:after:border-on-accent peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-accent"></div>
             </label>
           </div>
         </div>
-        <div className="p-6">
-          <div className="flex flex-col md:flex-row gap-6 items-start md:items-center justify-between">
+        <div className="p-space-5">
+          <div className="flex flex-col items-start justify-between gap-space-5 md:flex-row md:items-center">
             <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-500 dark:text-gray-400">Current Version:</span>
-                <span className="font-mono font-medium text-gray-900 dark:text-white">{appUpdate.current}</span>
+              <div className="flex items-center gap-space-2">
+                <span className="text-sm text-text-muted">Current Version:</span>
+                <span className="font-mono font-medium text-text">{appUpdate.current}</span>
               </div>
-              {appUpdate.hasUpdate && appUpdate.latest ? (
-                <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
+              {updateAvailable ? (
+                <div className="flex items-center gap-space-2 text-status-ok">
+                  <StatusDot state="ok" label="Update available" />
                   <Download size={16} />
-                  <span className="text-sm font-medium">New version available: {appUpdate.latest.version}</span>
+                  <span className="text-sm font-medium">New version available: {appUpdate.latest!.version}</span>
                 </div>
               ) : appUpdate.imageBuilding && appUpdate.latest ? (
-                <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                <div className="flex items-center gap-space-2 text-status-warn">
+                  <StatusDot state="warn" label="Image building" />
                   <Clock size={16} />
                   <span className="text-sm font-medium">Version {appUpdate.latest.version} released — image still building, try again shortly</span>
                 </div>
               ) : (
-                <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+                <div className="flex items-center gap-space-2 text-text-muted">
+                  <StatusDot state="ok" label="Up to date" />
                   <Clock size={16} />
                   <span className="text-sm">You are on the latest version</span>
                 </div>
               )}
             </div>
 
-            {appUpdate.hasUpdate && appUpdate.latest && (
-              <button
-                onClick={handleAppUpdate}
-                disabled={updateStatus === 'updating'}
-                className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors shadow-sm flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+            {updateAvailable && (
+              <Button onClick={handleAppUpdate} disabled={updateStatus === 'updating'}>
                 <Download size={18} />
                 {updateStatus === 'updating' ? 'Updating...' : 'Update Now'}
-              </button>
+              </Button>
             )}
           </div>
 
-          {appUpdate.hasUpdate && appUpdate.latest && appUpdate.latest.notes && (
-            <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
-              <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-2">Release Notes</h4>
-              <div className="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300">
-                <ReactMarkdown>{appUpdate.latest.notes}</ReactMarkdown>
+          {updateAvailable && appUpdate.latest!.notes && (
+            <Card padding="md" className="mt-space-4 bg-surface-muted">
+              <h4 className="mb-2 text-sm font-bold text-text">Release Notes</h4>
+              <div className="prose prose-sm dark:prose-invert max-w-none text-text-muted">
+                <ReactMarkdown>{appUpdate.latest!.notes}</ReactMarkdown>
               </div>
-            </div>
+            </Card>
           )}
         </div>
-      </div>
+      </Card>
 
       {updateStatus !== 'idle' && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4">
-          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl max-w-md w-full border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="p-6 text-center space-y-6">
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+          <Card padding="none" className="w-full max-w-md overflow-hidden shadow-2xl">
+            <div className="space-y-6 p-space-5 text-center">
               {updateStatus === 'error' ? (
-                <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-status-fail/10 text-status-fail">
                   <XCircle size={32} />
                 </div>
               ) : updateStatus === 'building' ? (
-                <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 rounded-full flex items-center justify-center mx-auto">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-status-warn/10 text-status-warn">
                   <Clock size={32} />
                 </div>
               ) : updateStatus === 'restarting' ? (
-                <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center mx-auto animate-pulse">
+                <div className="mx-auto flex h-16 w-16 animate-pulse items-center justify-center rounded-full bg-status-ok/10 text-status-ok">
                   <CheckCircle2 size={32} />
                 </div>
               ) : (
-                <div className="w-16 h-16 bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 rounded-full flex items-center justify-center mx-auto">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-accent/10 text-accent">
                   <Loader2 size={32} className="animate-spin" />
                 </div>
               )}
 
               <div>
-                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+                <h3 className="mb-2 text-xl font-bold text-text">
                   {updateStatus === 'error' ? 'Update Failed' :
                     updateStatus === 'building' ? 'New Version Still Building' :
                       updateStatus === 'restarting' ? 'Update Complete' :
                         'Updating ServiceBay'}
                 </h3>
-                <p className="text-gray-500 dark:text-gray-400 text-sm">
+                <p className="text-sm text-text-muted">
                   {updateStatus === 'error' ? updateError : updateMessage}
                 </p>
               </div>
 
               {updateStatus === 'updating' && (
-                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 overflow-hidden">
-                  <div className="bg-purple-600 h-2.5 rounded-full transition-all duration-300 ease-out" style={{ width: `${updateProgress}%` }}></div>
+                <div className="h-2.5 w-full overflow-hidden rounded-full bg-surface-2">
+                  <div className="h-2.5 rounded-full bg-accent transition-all duration-300 ease-out" style={{ width: `${updateProgress}%` }}></div>
                 </div>
               )}
 
               {(updateStatus === 'error' || updateStatus === 'building') && (
-                <button
-                  onClick={() => setUpdateStatus('idle')}
-                  className="px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors font-medium text-sm"
-                >
+                <Button variant="secondary" size="sm" onClick={() => setUpdateStatus('idle')}>
                   Close
-                </button>
+                </Button>
               )}
             </div>
-          </div>
+          </Card>
         </div>
       )}
 

--- a/packages/frontend/src/dashboards/ContainersDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/ContainersDashboard.smoke.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ContainersDashboard render smoke test (#2095).
+ *
+ * Status→Containers used to be a flat table while /services is stack-grouped.
+ * This mounts the dashboard so the render path exercises the new grouping
+ * optic: containers render under labelled SectionHeading sections (a "Core
+ * services" section for the reverse-proxy/system containers, owning-stack
+ * sections for the rest) using the same Card surface as /services — and all
+ * container data (name, image, status) is preserved.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const twinRef: { current: unknown } = { current: null };
+
+vi.mock('@/hooks/useDigitalTwin', () => ({
+  useDigitalTwin: () => ({
+    data: twinRef.current,
+    isConnected: true,
+    isNodeSynced: () => true,
+  }),
+}));
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/status',
+}));
+vi.mock('@/hooks/useContainerActions', () => ({
+  useContainerActions: () => ({
+    openActions: vi.fn(),
+    closeActions: vi.fn(),
+    overlay: null,
+    isOpen: false,
+  }),
+}));
+vi.mock('@/hooks/useEscapeKey', () => ({ useEscapeKey: () => {} }));
+
+import ContainersDashboard from './ContainersDashboard';
+
+// A box with two services (nginx in the atomic-wipe core stack; immich a
+// feature stack) each owning one container, plus a loose standalone container.
+function makeTwin() {
+  return {
+    nodes: {
+      Local: {
+        services: [
+          { name: 'nginx.service', associatedContainerIds: ['nginx-c'] },
+          { name: 'immich.service', associatedContainerIds: ['immich-c'] },
+        ],
+        containers: [
+          { id: 'nginx-c', names: ['/nginx'], image: 'nginx:latest', state: 'running', status: 'Up', created: 0, ports: [] },
+          { id: 'immich-c', names: ['/immich-server'], image: 'immich:v1', state: 'running', status: 'Up', created: 0, ports: [] },
+          { id: 'loose-c', names: ['/loose'], image: 'busybox', state: 'exited', status: 'Exited', created: 0, ports: [] },
+        ],
+        unmanagedBundles: [],
+      },
+    },
+  };
+}
+
+const STACKS = {
+  stacks: [
+    { name: 'basic', manifest: { name: 'basic', label: 'Core', tier: 'core', lifecycle: 'atomic-wipe', dependsOnStacks: [], templates: ['nginx', 'auth'] } },
+    { name: 'immich', manifest: { name: 'immich', label: 'Photos', tier: 'feature', lifecycle: 'wipeable', dependsOnStacks: [], templates: ['immich'] } },
+  ],
+};
+
+beforeEach(() => {
+  twinRef.current = makeTwin();
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.includes('/api/system/stacks')) {
+      return { ok: true, json: async () => STACKS };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+});
+
+describe('ContainersDashboard grouping optic (#2095)', () => {
+  it('renders containers in labelled stack-grouped sections, not a flat table', async () => {
+    render(<ContainersDashboard />);
+
+    // The grouped container wrapper is present (replaces the flat table).
+    expect(await screen.findByTestId('containers-stack-groups')).toBeDefined();
+
+    // Core services section (nginx is in the atomic-wipe core stack) renders
+    // once the stack manifests load.
+    await waitFor(() => {
+      expect(screen.getByTestId('container-group-__core__')).toBeDefined();
+    });
+    expect(screen.getByText('Core services')).toBeDefined();
+    expect(screen.getByText('Photos')).toBeDefined();
+
+    // All container data is preserved — names + images still render.
+    expect(screen.getByText('immich-server')).toBeDefined();
+    expect(screen.getByText('immich:v1')).toBeDefined();
+    expect(screen.getByText('nginx:latest')).toBeDefined();
+  });
+});

--- a/packages/frontend/src/dashboards/ContainersDashboard.tsx
+++ b/packages/frontend/src/dashboards/ContainersDashboard.tsx
@@ -3,13 +3,18 @@ import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 import DashboardHydrationGate, { type HydrationPhase } from '@/components/DashboardHydrationGate';
-import { Box, Terminal as TerminalIcon, MoreVertical, X, Activity, Search, RefreshCw, Eraser } from 'lucide-react';
+import { Terminal as TerminalIcon, MoreVertical, X, Activity, Search, RefreshCw, Eraser } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useContainerActions } from '@/hooks/useContainerActions';
 import ContainerLogsPanel, { ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
 import type { TerminalRef } from '@/components/Terminal';
-import type { ServiceBundle } from '@servicebay/api-client';
+import { logger, type ServiceBundle } from '@servicebay/api-client';
+import { Card, SectionHeading, StatusDot } from '@/components/ui';
+import {
+    groupContainersByStack,
+    type StackSummaryLite,
+} from './_lib/servicesDashboard';
 
 const DynamicTerminal = dynamic(() => import('@/components/Terminal'), {
     ssr: false,
@@ -53,7 +58,29 @@ export default function ContainersDashboard() {
     const [showInfra, setShowInfra] = useState(false);
     const [drawerMode, setDrawerMode] = useState<'logs' | 'terminal' | null>(null);
     const [drawerContainer, setDrawerContainer] = useState<Container | null>(null);
+    const [stackSummaries, setStackSummaries] = useState<StackSummaryLite[]>([]);
         const terminalRef = useRef<TerminalRef>(null);
+
+    // Stack membership so Status→Containers groups mirror the /services
+    // stack-grouping (#2095). Non-fatal: on failure the grouper falls back to
+    // per-service / "Other containers" buckets.
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch('/api/system/stacks', { cache: 'no-store' });
+                if (!res.ok) throw new Error('Failed to load stacks');
+                const payload = await res.json();
+                const stacks: StackSummaryLite[] = Array.isArray(payload?.stacks)
+                    ? payload.stacks.map((s: StackSummaryLite) => ({ name: s.name, manifest: s.manifest ?? null }))
+                    : [];
+                if (!cancelled) setStackSummaries(stacks);
+            } catch (error) {
+                logger.error('ContainersDashboard', 'Failed to load stacks', error);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
 
     const closeDrawer = useCallback(() => {
         setDrawerMode(null);
@@ -205,34 +232,25 @@ export default function ContainersDashboard() {
         });
     }, [openContainerActions]);
 
-  const getGroupName = (c: Container) => {
-    if (c.PodName) return `Pod: ${c.PodName}`;
-    if (c.Labels) {
-        if (c.Labels['io.kubernetes.pod.name']) return `Pod: ${c.Labels['io.kubernetes.pod.name']}`;
-        if (c.Labels['io.podman.pod.name']) return `Pod: ${c.Labels['io.podman.pod.name']}`;
-        if (c.Labels['com.docker.compose.project']) return `Compose: ${c.Labels['com.docker.compose.project']}`;
-    }
-    return 'Standalone Containers';
-  };
-
     const getVisiblePorts = (container: Container) => {
         if (!container.Ports || container.Ports.length === 0) return [];
         if (container.PodName && !container.isInfra) return [];
         return container.Ports;
     };
 
-  const groupedContainers = filteredContainers.reduce((acc, c) => {
-    const group = getGroupName(c);
-    if (!acc[group]) acc[group] = [];
-    acc[group].push(c);
-    return acc;
-  }, {} as Record<string, Container[]>);
-
-  const sortedGroups = Object.keys(groupedContainers).sort((a, b) => {
-    if (a === 'Standalone Containers') return 1;
-    if (b === 'Standalone Containers') return -1;
-    return a.localeCompare(b);
-  });
+  // Group containers under the same stack identity the /services view uses
+  // (#2095): each container's parent service maps to its owning stack, with a
+  // Core services group for infra/system containers and an "Other containers"
+  // bucket for everything stack-less. Mirrors groupServicesByStack's optic.
+  const containerGroups = useMemo(
+    () =>
+      groupContainersByStack(
+        filteredContainers,
+        c => ({ serviceName: c.parent?.type === 'service' ? c.parent.name : null, isInfra: c.isInfra }),
+        stackSummaries,
+      ),
+    [filteredContainers, stackSummaries],
+  );
 
     const drawerNode = drawerContainer?.nodeName && drawerContainer.nodeName !== 'Local'
         ? drawerContainer.nodeName
@@ -296,24 +314,25 @@ export default function ContainersDashboard() {
                             {containers.length > 0 ? 'No containers match your filters.' : 'No active containers found.'}
                         </div>
                     ) : (
-                        <div className="space-y-6">
-                            {sortedGroups.map(group => (
-                                <div key={group} className="bg-gray-50/60 dark:bg-gray-900/30 border border-gray-200 dark:border-gray-800 rounded-xl p-4">
-                                    <div className="flex items-center gap-2 mb-4 pb-2 border-b border-gray-200 dark:border-gray-800">
-                                        <Box className="text-indigo-500" size={18} />
-                                        <h3 className="text-xs font-bold uppercase tracking-wider text-gray-600 dark:text-gray-300">{group}</h3>
-                                        <span className="ml-auto text-[11px] font-mono bg-gray-200 dark:bg-gray-800 px-2 py-0.5 rounded-full text-gray-600 dark:text-gray-400">
-                                            {groupedContainers[group].length} containers
-                                        </span>
-                                    </div>
-                                    <div className="grid gap-3">
-                                        {groupedContainers[group].map((c) => {
+                        <div className="space-y-8" data-testid="containers-stack-groups">
+                            {containerGroups.map(group => (
+                                <section key={group.id} className="space-y-3" data-testid={`container-group-${group.id}`}>
+                                    <SectionHeading
+                                        description={`${group.containers.length} container${group.containers.length === 1 ? '' : 's'}`}
+                                    >
+                                        {group.label}
+                                    </SectionHeading>
+                                    <Card padding="none" className="divide-y divide-border overflow-hidden">
+                                        {group.containers.map((c) => {
                                             const ports = getVisiblePorts(c);
                                             return (
-                                                <div key={c.Id} className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-3 hover:border-blue-200 dark:hover:border-blue-700 transition-colors">
+                                                <div key={c.Id} className="p-space-3 hover:bg-surface-2 transition-colors">
                                                     <div className="flex flex-col md:flex-row md:items-center gap-3 justify-between">
                                                         <div className="flex items-center gap-3">
-                                                            <span className={`w-2.5 h-2.5 rounded-full ${c.State === 'running' ? 'bg-emerald-500' : 'bg-gray-400'}`} />
+                                                            <StatusDot
+                                                                state={c.State === 'running' ? 'ok' : 'unknown'}
+                                                                label={c.State === 'running' ? 'Running' : c.State}
+                                                            />
                                                             <div>
                                                                 <div className="flex flex-wrap items-center gap-2 text-base font-semibold text-gray-900 dark:text-gray-100">
                                                                     {c.Names[0].replace(/^\//, '')}
@@ -404,8 +423,8 @@ export default function ContainersDashboard() {
                                                 </div>
                                             );
                                         })}
-                                    </div>
-                                </div>
+                                    </Card>
+                                </section>
                             ))}
                         </div>
                     )}

--- a/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
@@ -10,8 +10,17 @@
  */
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import OverviewDashboard from './OverviewDashboard';
+import OverviewDashboard, { systemStatusView } from './OverviewDashboard';
 import { ToastProvider } from '@/providers/ToastProvider';
+
+// Mutable so individual tests can inject a `resources` slice for the System
+// tile (#2096) without re-mocking the whole module.
+let twinNode: Record<string, unknown> = {
+  services: [
+    { name: 'a.service', activeState: 'active' },
+    { name: 'b.service', activeState: 'active' },
+  ],
+};
 
 // Next <Link> renders a plain <a> in jsdom; no router needed for href checks.
 vi.mock('@/providers/DigitalTwinProvider', () => ({
@@ -20,12 +29,7 @@ vi.mock('@/providers/DigitalTwinProvider', () => ({
       serverName: 'test-box',
       gateway: { upstreamStatus: 'up' },
       nodes: {
-        Local: {
-          services: [
-            { name: 'a.service', activeState: 'active' },
-            { name: 'b.service', activeState: 'active' },
-          ],
-        },
+        Local: twinNode,
       },
     },
     isConnected: true,
@@ -62,6 +66,13 @@ function routedFetch(extra: (url: string) => unknown | undefined) {
 describe('OverviewDashboard render', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the twin node to the default (no resources slice) before each test.
+    twinNode = {
+      services: [
+        { name: 'a.service', activeState: 'active' },
+        { name: 'b.service', activeState: 'active' },
+      ],
+    };
     // Default: /api/health/checks → zero diagnose rows; /api/system/update →
     // up-to-date; everything else → [].
     vi.stubGlobal('fetch', routedFetch(() => undefined));
@@ -177,5 +188,123 @@ describe('OverviewDashboard render', () => {
     // Two distinct "Update Now/now" triggers (SB updater + image banner).
     const triggers = await screen.findAllByRole('button', { name: /update now/i });
     expect(triggers.length).toBe(2);
+  });
+
+  it('renders the Updates section image banner on the token Card surface, not the old ad-hoc blue literals (#2093)', async () => {
+    vi.stubGlobal('fetch', routedFetch(url => {
+      if (url.includes('/api/system/stacks/image-updates')) {
+        return {
+          ok: true,
+          json: async () => ({
+            services: [
+              { service: 'a', image: 'ghcr.io/a:latest', runningDigest: 'sha256:old', registryDigest: 'sha256:new', updateAvailable: true },
+            ],
+          }),
+        };
+      }
+      return undefined;
+    }));
+
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+
+    // The migrated banner sits on a <Card> (bg-surface) with a token accent —
+    // no raw blue literals (border-blue-200 / bg-blue-50 / bg-blue-600) anymore.
+    const bannerText = await screen.findByText(/1 service image update available/i);
+    const card = bannerText.closest('.bg-surface');
+    expect(card).not.toBeNull();
+    const html = (card as HTMLElement).outerHTML;
+    expect(html).not.toMatch(/(border|bg|text)-blue-\d/);
+    // Token accent present for the "update available" state.
+    expect(html).toMatch(/accent/);
+  });
+
+  it('renders the System-status tile linking to Status→System (#2096)', () => {
+    // Inject a resources slice on the twin so the tile shows real metrics.
+    twinNode = {
+      ...twinNode,
+      resources: {
+        cpuUsage: 12,
+        memoryUsage: 4 * 1024 * 1024 * 1024,
+        totalMemory: 16 * 1024 * 1024 * 1024,
+        diskUsage: 47,
+        os: { uptime: 90000 },
+      },
+    };
+
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+
+    // The tile renders and is a clickable link to the Status→System view.
+    const systemLink = screen.getByText('System').closest('a');
+    expect(systemLink).not.toBeNull();
+    expect(systemLink?.getAttribute('href')).toBe('/status?tab=system');
+    // CPU / RAM / Disk / Uptime rows are present.
+    expect(screen.getByText('CPU')).toBeDefined();
+    expect(screen.getByText('RAM')).toBeDefined();
+    expect(screen.getByText('Disk')).toBeDefined();
+    expect(screen.getByText('Uptime')).toBeDefined();
+    expect(screen.getByText('12%')).toBeDefined();
+    expect(screen.getByText('1d 1h')).toBeDefined();
+  });
+
+  it('renders the System tile in a neutral waiting state when no agent report is present', () => {
+    // Default twinNode has no `resources` slice.
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+    const systemLink = screen.getByText('System').closest('a');
+    expect(systemLink).not.toBeNull();
+    expect(systemLink?.getAttribute('href')).toBe('/status?tab=system');
+    expect(screen.getByText(/Waiting for system report/i)).toBeDefined();
+  });
+});
+
+describe('systemStatusView (#2096)', () => {
+  it('returns a neutral unloaded view when resources are absent', () => {
+    expect(systemStatusView(undefined)).toEqual({ loaded: false, tone: 'neutral', rows: [] });
+    expect(systemStatusView(null)).toEqual({ loaded: false, tone: 'neutral', rows: [] });
+    // No os slice yet (agent hasn't reported) → still unloaded.
+    expect(systemStatusView({ cpuUsage: 10 })).toEqual({ loaded: false, tone: 'neutral', rows: [] });
+  });
+
+  it('computes good tone for low usage and lists all four rows', () => {
+    const view = systemStatusView({
+      cpuUsage: 10,
+      memoryUsage: 2 * 1024 * 1024 * 1024,
+      totalMemory: 16 * 1024 * 1024 * 1024,
+      diskUsage: 30,
+      os: { uptime: 3600 },
+    });
+    expect(view.loaded).toBe(true);
+    expect(view.tone).toBe('good');
+    expect(view.rows.map(r => r.label)).toEqual(['CPU', 'RAM', 'Disk', 'Uptime']);
+  });
+
+  it('escalates the tone to the worst metric (bad wins over warn/good)', () => {
+    const view = systemStatusView({
+      cpuUsage: 85, // warn
+      memoryUsage: 15.5 * 1024 * 1024 * 1024,
+      totalMemory: 16 * 1024 * 1024 * 1024, // ~97% → bad
+      diskUsage: 10, // good
+      os: { uptime: 120 },
+    });
+    expect(view.tone).toBe('bad');
+  });
+
+  it('degrades gracefully to neutral rows when a metric is missing', () => {
+    const view = systemStatusView({ os: { uptime: 60 } });
+    expect(view.loaded).toBe(true);
+    // No usage figures → no escalation, neutral overall.
+    expect(view.tone).toBe('neutral');
+    expect(view.rows.find(r => r.label === 'CPU')?.value).toBe('—');
   });
 });

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Activity, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Activity, AlertCircle, CheckCircle2, Server } from 'lucide-react';
 import type { ServiceViewModel } from '@servicebay/api-client';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
 import { useCoreHealth } from '@/hooks/useCoreHealth';
@@ -10,7 +10,7 @@ import { useImageUpdates, type ServiceImageUpdate } from '@/hooks/useImageUpdate
 import { useServiceActions } from '@/hooks/useServiceActions';
 import ImageUpdatesPendingBanner from '@/components/ImageUpdatesPendingBanner';
 import ServiceBayUpdateCard from '@/components/ServiceBayUpdateCard';
-import { Card, SectionHeading } from '@/components/ui';
+import { Card, SectionHeading, StatusDot } from '@/components/ui';
 import { cn } from '@/components/ui';
 
 /**
@@ -166,6 +166,11 @@ export default function OverviewDashboard() {
   const diagnose = useDiagnoseOverview();
   const diagnoseView = diagnoseCardView(diagnose);
 
+  // Compact System-status tile (#2096) — sourced from the SAME twin snapshot
+  // Status→System reads (firstNode.resources). No new polling: the twin is
+  // already in context. Unavailable (no agent report yet) → neutral, no crash.
+  const systemView = systemStatusView(firstNode?.resources);
+
   // Pending service-image updates — box status, so it belongs on Home too
   // (#1860). The banner's "Update now" re-deploys each listed service via the
   // same `update` action the Services list uses (pull latest image → restart).
@@ -230,8 +235,9 @@ export default function OverviewDashboard() {
           <ImageUpdatesPendingBanner updates={imageUpdates} onUpdate={handleUpdateAll} />
         </section>
 
-        {/* Box-wide at-a-glance: services running + latest diagnose breakdown. */}
-        <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Box-wide at-a-glance: services running + latest diagnose breakdown
+            + a compact System-status tile (CPU/RAM/Disk/Uptime, #2096). */}
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           <StatCard
             title="Services"
             metric={hasFirstSnapshot ? `${activeCount} of ${totalCount} running` : '…'}
@@ -255,6 +261,7 @@ export default function OverviewDashboard() {
             tone={diagnoseView.tone}
             href="/status"
           />
+          <SystemStatusCard view={systemView} />
         </section>
       </div>
     </div>
@@ -329,4 +336,147 @@ function StatCard({ title, metric, description, icon: Icon, tone, href }: StatCa
     );
   }
   return <Card padding="lg">{inner}</Card>;
+}
+
+/** Shape of the resources slice the System tile reads off the twin — a subset
+ *  of the agent's `SystemResources` (the same object Status→System binds to). */
+interface SystemResourcesLike {
+  cpuUsage?: number;
+  memoryUsage?: number;
+  totalMemory?: number;
+  diskUsage?: number;
+  os?: { uptime?: number };
+}
+
+interface SystemRow {
+  label: string;
+  value: string;
+  /** Per-metric tone so the worst metric drives the dot, but each row keeps
+   *  its own colour. Undefined → neutral (no usage figure available). */
+  tone: 'good' | 'warn' | 'bad' | 'neutral';
+}
+
+export interface SystemStatusView {
+  loaded: boolean;
+  /** Worst-of tone across the metrics — drives the StatusDot. */
+  tone: 'good' | 'warn' | 'bad' | 'neutral';
+  rows: SystemRow[];
+}
+
+function formatBytesShort(bytes: number): string {
+  if (!bytes || bytes <= 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  return `${(bytes / Math.pow(k, i)).toFixed(i === 0 ? 0 : 1)} ${sizes[i]}`;
+}
+
+function formatUptime(seconds: number): string {
+  if (!seconds || seconds <= 0) return '—';
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  if (days > 0) return `${days}d ${hours}h`;
+  const mins = Math.floor((seconds % 3600) / 60);
+  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+}
+
+/** A usage percentage → tone, matching the Status→System thresholds
+ *  (>90 fail, >80 warn, else ok). */
+function usageTone(percent: number): 'good' | 'warn' | 'bad' {
+  if (percent > 90) return 'bad';
+  if (percent > 80) return 'warn';
+  return 'good';
+}
+
+/** Build the compact System-status view from the twin's resources slice.
+ *  Read-only, no fetch — the parent already holds the snapshot. Missing /
+ *  partial data degrades gracefully to neutral rows rather than crashing. */
+export function systemStatusView(resources: SystemResourcesLike | null | undefined): SystemStatusView {
+  if (!resources || resources.os === undefined) {
+    return { loaded: false, tone: 'neutral', rows: [] };
+  }
+
+  const rows: SystemRow[] = [];
+  const tones: ('good' | 'warn' | 'bad')[] = [];
+
+  if (typeof resources.cpuUsage === 'number') {
+    const t = usageTone(resources.cpuUsage);
+    tones.push(t);
+    rows.push({ label: 'CPU', value: `${Math.round(resources.cpuUsage)}%`, tone: t });
+  } else {
+    rows.push({ label: 'CPU', value: '—', tone: 'neutral' });
+  }
+
+  if (typeof resources.memoryUsage === 'number' && typeof resources.totalMemory === 'number' && resources.totalMemory > 0) {
+    const pct = (resources.memoryUsage / resources.totalMemory) * 100;
+    const t = usageTone(pct);
+    tones.push(t);
+    rows.push({
+      label: 'RAM',
+      value: `${formatBytesShort(resources.memoryUsage)} / ${formatBytesShort(resources.totalMemory)}`,
+      tone: t,
+    });
+  } else {
+    rows.push({ label: 'RAM', value: '—', tone: 'neutral' });
+  }
+
+  if (typeof resources.diskUsage === 'number') {
+    const t = usageTone(resources.diskUsage);
+    tones.push(t);
+    rows.push({ label: 'Disk', value: `${Math.round(resources.diskUsage)}%`, tone: t });
+  } else {
+    rows.push({ label: 'Disk', value: '—', tone: 'neutral' });
+  }
+
+  rows.push({ label: 'Uptime', value: formatUptime(resources.os?.uptime ?? 0), tone: 'neutral' });
+
+  const tone: 'good' | 'warn' | 'bad' | 'neutral' = tones.includes('bad')
+    ? 'bad'
+    : tones.includes('warn')
+      ? 'warn'
+      : tones.length > 0
+        ? 'good'
+        : 'neutral';
+
+  return { loaded: true, tone, rows };
+}
+
+const TONE_TO_DOT: Record<'good' | 'warn' | 'bad' | 'neutral', 'ok' | 'warn' | 'fail' | 'unknown'> = {
+  good: 'ok',
+  warn: 'warn',
+  bad: 'fail',
+  neutral: 'unknown',
+};
+
+/** Compact System-status tile (#2096) — CPU / RAM / Disk / Uptime at a glance,
+ *  clickable → Status→System (`/status?tab=system`). Reads off the twin
+ *  resources the parent already holds (no new heavy polling); a box with no
+ *  agent report yet renders a neutral "Waiting" state, never a crash. */
+function SystemStatusCard({ view }: { view: SystemStatusView }) {
+  return (
+    <Link
+      href="/status?tab=system"
+      className="block rounded-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+    >
+      <Card padding="lg" className="cursor-pointer transition-all hover:border-accent hover:shadow-md">
+        <div className="mb-3 flex items-center justify-between">
+          <Server size={20} className={TONE_ACCENT[view.tone]} />
+          <StatusDot state={TONE_TO_DOT[view.tone]} />
+        </div>
+        <h2 className="font-bold text-text tracking-wide text-base">System</h2>
+        {view.loaded ? (
+          <dl className="mt-2 space-y-1.5">
+            {view.rows.map(row => (
+              <div key={row.label} className="flex items-center justify-between gap-2 text-xs">
+                <dt className="text-text-muted font-medium">{row.label}</dt>
+                <dd className={cn('font-semibold tabular-nums', TONE_ACCENT[row.tone])}>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <p className="text-xs text-text-muted mt-2 font-medium leading-relaxed">Waiting for system report…</p>
+        )}
+      </Card>
+    </Link>
+  );
 }

--- a/packages/frontend/src/dashboards/_lib/servicesDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/servicesDashboard.test.ts
@@ -3,13 +3,17 @@ import type { ServiceViewModel, StackManifest } from '@servicebay/api-client';
 
 import {
   groupServicesByStack,
+  groupContainersByStack,
   baseUnitName,
+  isCoreInfraService,
   UNGROUPED_STACK_ID,
+  CORE_STACK_ID,
+  OTHER_CONTAINERS_ID,
   type StackSummaryLite,
 } from './servicesDashboard';
 
-function svc(name: string): ServiceViewModel {
-  return { id: name, name, displayName: name } as ServiceViewModel;
+function svc(name: string, over: Partial<ServiceViewModel> = {}): ServiceViewModel {
+  return { id: name, name, displayName: name, ...over } as ServiceViewModel;
 }
 
 function manifest(over: Partial<StackManifest>): StackManifest {
@@ -32,12 +36,55 @@ describe('groupServicesByStack (#2081)', () => {
 
   it('groups services under their owning stack, by template membership', () => {
     const groups = groupServicesByStack(
+      [svc('jellyfin'), svc('immich.service')],
+      [
+        ...stacks,
+        { name: 'media', manifest: manifest({ name: 'media', label: 'Media', templates: ['jellyfin'] }) },
+      ],
+    );
+    const byId = Object.fromEntries(groups.map(g => [g.id, g]));
+    expect(byId.media.services.map(s => s.name)).toEqual(['jellyfin']);
+    expect(byId.immich.services.map(s => s.name)).toEqual(['immich.service']);
+  });
+
+  it('folds core (atomic-wipe) stack services into the Core services group', () => {
+    const groups = groupServicesByStack(
       [svc('nginx.service'), svc('auth'), svc('immich.service')],
       stacks,
     );
     const byId = Object.fromEntries(groups.map(g => [g.id, g]));
-    expect(byId.basic.services.map(s => s.name)).toEqual(['nginx.service', 'auth']);
-    expect(byId.immich.services.map(s => s.name)).toEqual(['immich.service']);
+    expect(byId.basic).toBeUndefined();
+    expect(byId[CORE_STACK_ID].label).toBe('Core services');
+    expect(byId[CORE_STACK_ID].services.map(s => s.name)).toEqual(['nginx.service', 'auth']);
+    expect(byId[CORE_STACK_ID].wipeable).toBe(false);
+  });
+
+  it('groups the gateway / reverse proxy / system service under Core services, sorted first', () => {
+    const groups = groupServicesByStack(
+      [
+        svc('immich.service'),
+        svc('Internet Gateway', { type: 'gateway' }),
+        svc('nginx', { labels: { 'servicebay.role': 'reverse-proxy' } }),
+        svc('servicebay', { labels: { 'servicebay.role': 'system' } }),
+      ],
+      stacks,
+    );
+    expect(groups[0].id).toBe(CORE_STACK_ID);
+    expect(groups[0].label).toBe('Core services');
+    expect(groups[0].services.map(s => s.name)).toEqual([
+      'Internet Gateway',
+      'nginx',
+      'servicebay',
+    ]);
+    // No Ungrouped bucket for the infra services.
+    expect(groups.some(g => g.id === UNGROUPED_STACK_ID)).toBe(false);
+  });
+
+  it('detects core infra services from type / servicebay.role', () => {
+    expect(isCoreInfraService(svc('gw', { type: 'gateway' }))).toBe(true);
+    expect(isCoreInfraService(svc('nginx', { labels: { 'servicebay.role': 'reverse-proxy' } }))).toBe(true);
+    expect(isCoreInfraService(svc('sb', { labels: { 'servicebay.role': 'system' } }))).toBe(true);
+    expect(isCoreInfraService(svc('immich.service'))).toBe(false);
   });
 
   it('matches on base name regardless of the .service suffix', () => {
@@ -55,7 +102,8 @@ describe('groupServicesByStack (#2081)', () => {
 
   it('marks only feature/wipeable stacks wipeable; core + atomic-wipe are blocked', () => {
     const groups = groupServicesByStack([svc('nginx.service'), svc('immich.service')], stacks);
-    expect(groups.find(g => g.id === 'basic')?.wipeable).toBe(false);
+    // basic's services fold into the never-wipeable Core group.
+    expect(groups.find(g => g.id === CORE_STACK_ID)?.wipeable).toBe(false);
     expect(groups.find(g => g.id === 'immich')?.wipeable).toBe(true);
   });
 
@@ -69,5 +117,67 @@ describe('groupServicesByStack (#2081)', () => {
     const noLabel: StackSummaryLite = { name: 'media', manifest: manifest({ name: 'media', label: '', templates: ['jellyfin'] }) };
     const groups = groupServicesByStack([svc('jellyfin')], [noLabel]);
     expect(groups[0].label).toBe('media');
+  });
+});
+
+describe('groupContainersByStack (#2095)', () => {
+  const stacks: StackSummaryLite[] = [
+    { name: 'basic', manifest: manifest({ name: 'basic', label: 'Core', tier: 'core', lifecycle: 'atomic-wipe', templates: ['nginx', 'auth'] }) },
+    { name: 'immich', manifest: manifest({ name: 'immich', label: 'Photos', templates: ['immich'] }) },
+  ];
+
+  type C = { id: string; serviceName?: string | null; isInfra?: boolean };
+  const accessor = (c: C) => ({ serviceName: c.serviceName, isInfra: c.isInfra });
+
+  it('mirrors the /services stack grouping — same group ids/labels/membership', () => {
+    const groups = groupContainersByStack(
+      [
+        { id: 'c1', serviceName: 'immich' },
+        { id: 'c2', serviceName: 'nginx' },
+        { id: 'c3', serviceName: 'auth' },
+      ],
+      accessor,
+      stacks,
+    );
+    const byId = Object.fromEntries(groups.map(g => [g.id, g]));
+    // nginx/auth belong to the atomic-wipe core stack -> Core services.
+    expect(byId[CORE_STACK_ID].label).toBe('Core services');
+    expect(byId[CORE_STACK_ID].containers.map(c => c.id)).toEqual(['c2', 'c3']);
+    // immich keeps its own labelled stack section, mirroring /services.
+    expect(byId.immich.label).toBe('Photos');
+    expect(byId.immich.containers.map(c => c.id)).toEqual(['c1']);
+  });
+
+  it('routes infra containers to Core, sorted first', () => {
+    const groups = groupContainersByStack(
+      [{ id: 'photo', serviceName: 'immich' }, { id: 'pause', isInfra: true }],
+      accessor,
+      stacks,
+    );
+    expect(groups[0].id).toBe(CORE_STACK_ID);
+    expect(groups[0].containers.map(c => c.id)).toEqual(['pause']);
+  });
+
+  it('buckets stack-less containers into "Other containers", listed last', () => {
+    const groups = groupContainersByStack(
+      [{ id: 'immich-c', serviceName: 'immich' }, { id: 'loose' }],
+      accessor,
+      stacks,
+    );
+    const last = groups[groups.length - 1];
+    expect(last.id).toBe(OTHER_CONTAINERS_ID);
+    expect(last.label).toBe('Other containers');
+    expect(last.containers.map(c => c.id)).toEqual(['loose']);
+  });
+
+  it('keeps a service with no matching stack as its own labelled section', () => {
+    const groups = groupContainersByStack(
+      [{ id: 'x', serviceName: 'standalone-svc' }],
+      accessor,
+      [],
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('standalone-svc');
+    expect(groups[0].containers.map(c => c.id)).toEqual(['x']);
   });
 });

--- a/packages/frontend/src/dashboards/_lib/servicesDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/servicesDashboard.ts
@@ -88,6 +88,32 @@ export interface StackSummaryLite {
 /** Synthetic bucket id for services not owned by any stack. */
 export const UNGROUPED_STACK_ID = '__ungrouped__';
 
+/** Synthetic group id for the infrastructure / core services (#2094):
+ *  the gateway, the reverse proxy, the ServiceBay system service, and any
+ *  core-tier (atomic-wipe) stack. These have no wipe button and used to fall
+ *  into the Ungrouped bucket; they belong together under "Core services". */
+export const CORE_STACK_ID = '__core__';
+
+/** Is this an infrastructure / core service that belongs in the Core group?
+ *  Detected from the view-model shape the backend already computes:
+ *   - the gateway is `type === 'gateway'`;
+ *   - the reverse proxy carries `labels['servicebay.role'] === 'reverse-proxy'`;
+ *   - the ServiceBay system service carries `labels['servicebay.role'] === 'system'`.
+ *  (See serviceViewModel.ts — `isReverseProxy` / `isServiceBay`.) */
+export function isCoreInfraService(service: ServiceViewModel): boolean {
+  if (service.type === 'gateway') return true;
+  const role = service.labels?.['servicebay.role'];
+  return role === 'reverse-proxy' || role === 'system';
+}
+
+/** Is this stack a core / atomic-wipe stack (e.g. basic/auth)? Its services
+ *  fold into the Core group rather than rendering their own wipeable section. */
+function isCoreStack(stack: StackSummaryLite | null): boolean {
+  const manifest = stack?.manifest;
+  if (!manifest) return false;
+  return manifest.tier === 'core' || manifest.lifecycle === 'atomic-wipe';
+}
+
 /** A stack and the services rendered beneath its header. */
 export interface ServiceStackGroup {
   /** Stack name (matches the wipe endpoint path segment), or UNGROUPED_STACK_ID. */
@@ -107,6 +133,34 @@ export function baseUnitName(name: string): string {
   return name.replace(/\.service$/, '');
 }
 
+/** Order the built groups: `firstId` group first, `lastId` group last, the rest
+ *  in insertion order. Shared by the service + container groupers so both views
+ *  read with the same Core-first / bucket-last optic. */
+function orderGroups<G>(
+  groups: Map<string, G>,
+  order: string[],
+  firstId: string,
+  lastId: string,
+): G[] {
+  const first = groups.has(firstId) ? [groups.get(firstId)!] : [];
+  const middle = order.filter(id => id !== firstId && id !== lastId).map(id => groups.get(id)!);
+  const last = groups.has(lastId) ? [groups.get(lastId)!] : [];
+  return first.concat(middle, last);
+}
+
+/** Build the template-base-name → owning-stack map. First writer wins; the API
+ *  already de-dupes stack names, and a template should belong to one stack. */
+function buildTemplateToStack(stacks: StackSummaryLite[]): Map<string, StackSummaryLite> {
+  const map = new Map<string, StackSummaryLite>();
+  for (const stack of stacks) {
+    for (const template of stack.manifest?.templates ?? []) {
+      const key = baseUnitName(template);
+      if (!map.has(key)) map.set(key, stack);
+    }
+  }
+  return map;
+}
+
 /**
  * Group services under their owning stack.
  *
@@ -120,18 +174,28 @@ export function groupServicesByStack(
   services: ServiceViewModel[],
   stacks: StackSummaryLite[],
 ): ServiceStackGroup[] {
-  // template base name -> owning stack manifest. First writer wins; the API
-  // already de-dupes stack names, and a template should belong to one stack.
-  const templateToStack = new Map<string, StackSummaryLite>();
-  for (const stack of stacks) {
-    for (const template of stack.manifest?.templates ?? []) {
-      const key = baseUnitName(template);
-      if (!templateToStack.has(key)) templateToStack.set(key, stack);
-    }
-  }
+  const templateToStack = buildTemplateToStack(stacks);
 
   const groups = new Map<string, ServiceStackGroup>();
   const order: string[] = [];
+
+  const ensureCoreGroup = (): ServiceStackGroup => {
+    let group = groups.get(CORE_STACK_ID);
+    if (!group) {
+      group = {
+        id: CORE_STACK_ID,
+        label: 'Core services',
+        manifest: null,
+        // The Core group bundles the gateway, reverse proxy, system service and
+        // the atomic-wipe core stacks — none of which expose a per-stack wipe.
+        wipeable: false,
+        services: [],
+      };
+      groups.set(CORE_STACK_ID, group);
+      order.push(CORE_STACK_ID);
+    }
+    return group;
+  };
 
   const ensureGroup = (stack: StackSummaryLite | null): ServiceStackGroup => {
     const id = stack ? stack.name : UNGROUPED_STACK_ID;
@@ -157,12 +221,99 @@ export function groupServicesByStack(
 
   for (const service of services) {
     const owner = templateToStack.get(baseUnitName(service.name)) ?? null;
+    // Core services (#2094): the gateway / reverse proxy / system service, plus
+    // any service owned by a core (atomic-wipe) stack, fold into one "Core
+    // services" group instead of leaking into the Ungrouped bucket or rendering
+    // a wipeless single-stack section.
+    if (isCoreInfraService(service) || isCoreStack(owner)) {
+      ensureCoreGroup().services.push(service);
+      continue;
+    }
     ensureGroup(owner).services.push(service);
   }
 
-  // Stack groups in the API-provided order (core first), ungrouped always last.
-  return order
-    .filter(id => id !== UNGROUPED_STACK_ID)
-    .map(id => groups.get(id)!)
-    .concat(groups.has(UNGROUPED_STACK_ID) ? [groups.get(UNGROUPED_STACK_ID)!] : []);
+  // Core services first, stack groups in API order, ungrouped bucket last.
+  return orderGroups(groups, order, CORE_STACK_ID, UNGROUPED_STACK_ID);
+}
+
+// ---------------------------------------------------------------------------
+// Container grouping (#2095)
+// ---------------------------------------------------------------------------
+//
+// Status→Containers used to be a flat table while /services is stack-grouped,
+// so the two views read inconsistently. We bring containers into the SAME
+// grouping language by reusing the template→stack map: each container resolves
+// to its owning service (the parent service name from the twin), that service
+// resolves to its stack, and the container lands in the matching stack group.
+// Group names + ordering mirror groupServicesByStack (Core first, feature
+// stacks next, an "Other containers" bucket last) so the optic lines up.
+
+/** Generic shape the container grouper needs from a container row. */
+export interface GroupableContainer {
+  /** Base name of the owning service (`.service` stripped), if known. */
+  serviceName?: string | null;
+  /** Infrastructure / system container (pause/sidecar) — routes to Core. */
+  isInfra?: boolean;
+}
+
+/** A stack group of containers, mirroring ServiceStackGroup's identity. */
+export interface ContainerStackGroup<C> {
+  id: string;
+  label: string;
+  containers: C[];
+}
+
+/** Synthetic group id for containers with no resolvable owning stack. */
+export const OTHER_CONTAINERS_ID = '__other_containers__';
+
+/**
+ * Group containers under the same stack identity the /services view uses.
+ *
+ * Pure: takes the container list, an accessor for each container's groupable
+ * fields, and the stack summaries. Returns ordered groups (Core first, feature
+ * stacks in API order, the "Other containers" bucket last). Empty groups are
+ * omitted. Infra containers and services owned by a core stack fold into the
+ * Core group so the membership matches groupServicesByStack.
+ */
+/** Resolve the {id,label} group target for one container's groupable fields. */
+function containerGroupTarget(
+  { serviceName, isInfra }: GroupableContainer,
+  templateToStack: Map<string, StackSummaryLite>,
+): { id: string; label: string } {
+  const owner = serviceName ? templateToStack.get(baseUnitName(serviceName)) ?? null : null;
+  if (isInfra || isCoreStack(owner)) return { id: CORE_STACK_ID, label: 'Core services' };
+  if (owner) return { id: owner.name, label: owner.manifest?.label || owner.name };
+  // Owned by a service with no stack manifest — key on the service name so each
+  // service still reads as its own labelled section.
+  if (serviceName) return { id: `svc:${serviceName}`, label: serviceName };
+  return { id: OTHER_CONTAINERS_ID, label: 'Other containers' };
+}
+
+export function groupContainersByStack<C>(
+  containers: C[],
+  accessor: (container: C) => GroupableContainer,
+  stacks: StackSummaryLite[],
+): ContainerStackGroup<C>[] {
+  const templateToStack = buildTemplateToStack(stacks);
+
+  const groups = new Map<string, ContainerStackGroup<C>>();
+  const order: string[] = [];
+
+  const ensure = (id: string, label: string): ContainerStackGroup<C> => {
+    let group = groups.get(id);
+    if (!group) {
+      group = { id, label, containers: [] };
+      groups.set(id, group);
+      order.push(id);
+    }
+    return group;
+  };
+
+  for (const container of containers) {
+    const { id, label } = containerGroupTarget(accessor(container), templateToStack);
+    ensure(id, label).containers.push(container);
+  }
+
+  // Core services first, stack groups in order, "Other containers" bucket last.
+  return orderGroups(groups, order, CORE_STACK_ID, OTHER_CONTAINERS_ID);
 }

--- a/tests/backend/updater.test.ts
+++ b/tests/backend/updater.test.ts
@@ -23,24 +23,26 @@ describe('performUpdate', () => {
     vi.clearAllMocks();
   });
 
-  it('pulls image, emits pull output, and restarts service via systemctl', async () => {
-    execMock
-      .mockResolvedValueOnce({ stdout: 'pull ok\nstatus: done', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '', stderr: '' });
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it('pulls image, emits pull output, and recreates + restarts service', async () => {
+    execMock.mockResolvedValue({ stdout: 'pull ok\nstatus: done', stderr: '' });
 
     const { performUpdate } = await import('@/lib/updater');
 
     await performUpdate('v1.2.3');
+    await flush(); // let the detached recreate/restart run
 
     expect(execMock).toHaveBeenNthCalledWith(
       1,
       'podman pull ghcr.io/mdopp/servicebay:latest',
       { timeoutMs: 5 * 60 * 1000 }
     );
-    expect(execMock).toHaveBeenNthCalledWith(
-      2,
-      'systemctl --user restart --no-block servicebay.service'
-    );
+    // #2063: recreate the container (rm -f) so the freshly-pulled image lands,
+    // then restart via systemd.
+    const cmds = execMock.mock.calls.map((c) => String(c[0]));
+    expect(cmds).toContain('podman rm -f servicebay');
+    expect(cmds).toContain('systemctl --user restart --no-block servicebay.service');
 
     const progressEvents = emitMock.mock.calls
       .filter(([event]) => event === 'update:progress')


### PR DESCRIPTION
## What
Three coherent units across the deploy pipeline and dashboards:
- **updater/channel bugs** (#2062 #2063 #2064): recreate-not-restart so a fresh image actually lands (incl. same-tag re-pull), :dev channel pull awaited + error-surfaced, and checkForUpdates reconciles against the RUNNING container digest (fixes the frozen "still building").
- **Home design polish** (#2093 #2096): migrate the Updates banner + self-updater card onto components/ui Card/Button/StatusDot with semantic accent tokens (no raw hex); add a compact System-status tile (CPU/RAM/Disk/Uptime) clickable to Status→System.
- **grouping optic consistency** (#2094 #2095): a "Core services" group (Gateway/Reverse-Proxy/ServiceBay-System) sorted first instead of leaking into Ungrouped, and Status→Containers grouped to mirror the /services stack optic.

## Why
Closes #2062
Closes #2063
Closes #2064
Closes #2093
Closes #2096
Closes #2094
Closes #2095

## Risk
Medium — the updater/channel recreate path is real-box-observable and box-verify owed; dashboard changes are visual.

## Rollback
git revert is enough (no schema/migration).

## Verification
- [x] npm run lint (0 errors, 351 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (full — 3193 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — flip :dev then back to :latest, confirm running image digest changes (path-mandated: dashboards/, app/(dashboard)/; updater channel path real-box-observable)