### PR TITLE
feat(frontend): Home tiles v2, image-update banner refresh, portal design migration, service focus, settings flatten

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -200,6 +200,14 @@ export interface AppConfig {
      * not "available". Written after a successful pull; null until first seen.
      */
     appliedImageDigest?: string;
+    /**
+     * ISO-8601 timestamp of the last successful in-place ServiceBay image
+     * update (the moment `performUpdate` advanced `appliedImageDigest` to a
+     * newer image). Surfaced on Home as a "Last updated" freshness/security
+     * indicator (#2104) — recent = ok, long ago = warn. Undefined until the
+     * first applied update on this box.
+     */
+    appliedImageUpdatedAt?: string;
   };
   /**
    * Unified auto-update window. ServiceBay manages three independent

--- a/packages/backend/src/lib/updater.test.ts
+++ b/packages/backend/src/lib/updater.test.ts
@@ -204,6 +204,9 @@ describe('performUpdate — honest pull result', () => {
     expect(res.success).toBe(true);
     expect(res.updated).toBe(true);
     expect(mockConfig.current.autoUpdate.appliedImageDigest).toBe('sha256:NEW');
+    // #2104: stamp the moment of the applied update so Home can show "Last updated".
+    expect(typeof mockConfig.current.autoUpdate.appliedImageUpdatedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(mockConfig.current.autoUpdate.appliedImageUpdatedAt as string))).toBe(false);
     // #2063: a plain restart keeps the old container — recreate with rm -f first.
     const recreated = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('rm -f servicebay'));
     const restarted = mockExec.exec.mock.calls.some((c) => String(c[0]).includes('systemctl'));

--- a/packages/backend/src/lib/updater.ts
+++ b/packages/backend/src/lib/updater.ts
@@ -348,9 +348,11 @@ export async function performUpdate(version: string): Promise<PerformUpdateResul
 
     // Persist the digest we advanced to so the next availability check knows
     // what we're actually running (closes the tag→image false-positive window).
+    // Stamp the moment too (#2104) — Home surfaces it as "Last updated" so the
+    // operator can see how fresh/secure the box is.
     if (afterDigest) {
       await updateConfig({
-        autoUpdate: { ...config.autoUpdate, appliedImageDigest: afterDigest },
+        autoUpdate: { ...config.autoUpdate, appliedImageDigest: afterDigest, appliedImageUpdatedAt: new Date().toISOString() },
       });
     }
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/SettingDisclosure.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/SettingDisclosure.test.tsx
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { Users } from 'lucide-react';
 import SettingDisclosure from './SettingDisclosure';
 
 describe('SettingDisclosure (#2079 primitive migration)', () => {
@@ -35,5 +36,58 @@ describe('SettingDisclosure (#2079 primitive migration)', () => {
     // Card surface + token chrome, no raw gray literals.
     expect(container.querySelector('.bg-surface')).not.toBeNull();
     expect(container.innerHTML).not.toMatch(/(bg|text|border)-gray-\d/);
+  });
+});
+
+// #2109 — the disclosure section IS the single container + title: icon, title
+// and one-line description live in this header (the box-in-box / duplicate-
+// title inner Card is gone). The section body holds the controls directly.
+describe('SettingDisclosure (#2109 single container)', () => {
+  it('carries the icon + title + description in the header, content directly in the body', () => {
+    render(
+      <SettingDisclosure
+        id="portal-access"
+        tier="essential"
+        label="Portal access"
+        icon={Users}
+        description="Limits for the family portal."
+      >
+        <input aria-label="Maximum users" />
+      </SettingDisclosure>,
+    );
+    // Header carries the title + description...
+    const title = screen.getByText('Portal access');
+    expect(title.tagName).toBe('H3');
+    expect(screen.getByText('Limits for the family portal.')).toBeDefined();
+    // ...and an icon chip (lucide renders an <svg>).
+    expect(title.closest('h3')?.parentElement?.parentElement?.querySelector('svg')).not.toBeNull();
+    // The control is rendered directly in the single body.
+    expect(screen.getByLabelText('Maximum users')).toBeDefined();
+  });
+
+  it('exposes exactly ONE container Card (no nested box-in-box) for an essential section', () => {
+    const { container } = render(
+      <SettingDisclosure id="x" tier="essential" label="Server identity" icon={Users} description="d">
+        <button>Save</button>
+      </SettingDisclosure>,
+    );
+    // The single surface is the disclosure Card itself; the section content
+    // contributes no second bordered Card (no rounded-card border wrapper).
+    const cards = container.querySelectorAll('.rounded-card.border');
+    expect(cards.length).toBe(1);
+  });
+
+  it('advanced section: a single header toggle owns the title; one container only', () => {
+    const { container } = render(
+      <SettingDisclosure id="mcp" tier="advanced" label="MCP access" icon={Users} description="d">
+        <p>body</p>
+      </SettingDisclosure>,
+    );
+    // One title, in the toggle button; no duplicate title text anywhere.
+    expect(screen.getAllByText('MCP access')).toHaveLength(1);
+    expect(screen.getByText('Advanced')).toBeDefined();
+    // Closed → no body; single Card container.
+    expect(screen.queryByText('body')).toBeNull();
+    expect(container.querySelectorAll('.rounded-card.border').length).toBe(1);
   });
 });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/SettingDisclosure.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/SettingDisclosure.tsx
@@ -1,9 +1,20 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, type LucideIcon } from 'lucide-react';
 import { Card } from '@/components/ui';
 import type { SettingTier } from './ia';
+
+/** Icon-chip tone — maps to a semantic token pair (bg/10 + text). */
+export type DisclosureTone = 'accent' | 'warn' | 'ok' | 'fail' | 'info';
+
+const TONE_CHIP: Record<DisclosureTone, string> = {
+  accent: 'bg-accent/10 text-accent',
+  warn: 'bg-status-warn/10 text-status-warn',
+  ok: 'bg-status-ok/10 text-status-ok',
+  fail: 'bg-status-fail/10 text-status-fail',
+  info: 'bg-status-info/10 text-status-info',
+};
 
 interface SettingDisclosureProps {
   /** Stable id — the in-page anchor target for deep links / search jumps. */
@@ -11,23 +22,48 @@ interface SettingDisclosureProps {
   /** Disclosure tier: 'essential' renders open and flat; 'advanced' collapses. */
   tier: SettingTier;
   label: string;
+  /** Icon shown in the section header chip (lives in the header now, not a
+   *  nested inner card — #2109). */
+  icon?: LucideIcon;
+  /** Icon-chip tone. Defaults to 'accent'. */
+  iconTone?: DisclosureTone;
+  /** One-line description shown as a subline under the header title. */
+  description?: React.ReactNode;
+  /** Optional right-aligned header accessory (status badge, count, …) the
+   *  section feeds in. Stays out of the collapse toggle hit-area. */
+  headerAccessory?: React.ReactNode;
   children: React.ReactNode;
 }
 
 /**
- * Three-tier disclosure wrapper (#1956, feedback_ux_philosophy).
+ * Three-tier disclosure wrapper (#1956, feedback_ux_philosophy) and the SINGLE
+ * settings-section container (#2109).
  *
- * - `essential` → rendered open, no chrome: the handful of settings people
- *   actually change are shown by default.
- * - `advanced` → collapsed behind a single click, defaults intact, the
- *   expert knob still 100% reachable (nothing removed — only relocated).
+ * The disclosure section IS the container + title: the icon, title and one-line
+ * description live in this header, and the controls sit directly in the body —
+ * no second nested <Card> repeating the same title (the old "box-in-box" that
+ * wasted vertical space). Section components render only their controls.
+ *
+ * - `essential` → header + body always shown, no collapse chrome.
+ * - `advanced`  → collapsed behind a single click on the header; the title
+ *   carries an ADVANCED tag and a chevron. Defaults intact, knob 100% reachable.
  *
  * Deep links (search "jump to it", or a `#id` href) auto-expand the matching
  * advanced item and scroll it into view, so any setting is findable by name.
  */
-export default function SettingDisclosure({ id, tier, label, children }: SettingDisclosureProps) {
+export default function SettingDisclosure({
+  id,
+  tier,
+  label,
+  icon: Icon,
+  iconTone = 'accent',
+  description,
+  headerAccessory,
+  children,
+}: SettingDisclosureProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(tier === 'essential');
+  const advanced = tier === 'advanced';
 
   // Auto-expand + scroll when the URL hash targets this setting (search jump
   // or a deep link from elsewhere in the app).
@@ -45,34 +81,64 @@ export default function SettingDisclosure({ id, tier, label, children }: Setting
     return () => window.removeEventListener('hashchange', applyHash);
   }, [id]);
 
-  if (tier === 'essential') {
+  const chip = Icon ? (
+    <div className={`p-2 rounded-card shrink-0 ${TONE_CHIP[iconTone]}`}>
+      <Icon size={20} />
+    </div>
+  ) : null;
+
+  const heading = (
+    <div className="flex-1 min-w-0">
+      <h3 className="font-semibold text-text flex items-center gap-space-2">
+        {label}
+        {advanced && (
+          <span className="text-[10px] uppercase font-semibold tracking-wide text-text-subtle">
+            Advanced
+          </span>
+        )}
+      </h3>
+      {description && <p className="text-xs text-text-muted">{description}</p>}
+    </div>
+  );
+
+  const bodyClass = 'p-space-5 space-y-6';
+
+  // Essential: a single open Card — header (icon+title+desc) over the body, one
+  // border, no collapse chrome.
+  if (!advanced) {
     return (
-      <div ref={ref} id={id} className="scroll-mt-24">
-        {children}
-      </div>
+      <Card ref={ref} id={id} padding="none" className="w-full overflow-hidden scroll-mt-24">
+        {(chip || description || headerAccessory) && (
+          <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
+            {chip}
+            {heading}
+            {headerAccessory && <div className="shrink-0">{headerAccessory}</div>}
+          </div>
+        )}
+        <div className={bodyClass}>{children}</div>
+      </Card>
     );
   }
 
+  // Advanced: the same single Card, but the header is a collapse toggle.
   return (
-    <Card
-      ref={ref}
-      id={id}
-      padding="none"
-      className="scroll-mt-24 overflow-hidden"
-    >
-      <button
-        type="button"
-        onClick={() => setOpen(o => !o)}
-        aria-expanded={open}
-        className="w-full flex items-center gap-2 px-4 py-3 text-left text-sm font-medium text-text-muted hover:bg-surface-2 hover:text-text transition-colors"
-      >
-        {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-        <span>{label}</span>
-        <span className="ml-2 text-[10px] uppercase font-semibold tracking-wide text-text-subtle">
-          Advanced
-        </span>
-      </button>
-      {open && <div className="border-t border-border p-4 space-y-6">{children}</div>}
+    <Card ref={ref} id={id} padding="none" className="w-full overflow-hidden scroll-mt-24">
+      <div className={`flex items-center bg-surface-2 ${open ? 'border-b border-border' : ''}`}>
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          aria-expanded={open}
+          className="flex-1 flex items-center gap-space-3 px-space-4 py-space-3 text-left hover:bg-surface-muted transition-colors"
+        >
+          <span className="shrink-0 text-text-muted">
+            {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          </span>
+          {chip}
+          {heading}
+        </button>
+        {headerAccessory && <div className="shrink-0 pr-space-4">{headerAccessory}</div>}
+      </div>
+      {open && <div className={bodyClass}>{children}</div>}
     </Card>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Bot, Check, ExternalLink, Globe, Loader2, Mail, Send, Trash2, UserCheck, UserPlus } from 'lucide-react';
+import { Bot, Check, ExternalLink, Globe, Loader2, Mail, Send, Trash2, UserCheck } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 import { Badge, Button, Card, SectionHeading, StatusDot } from '@/components/ui';
 
@@ -138,43 +138,32 @@ export default function AccessRequestsSection() {
 
   if (busy === 'load') {
     return (
-      <Card className="w-full p-space-5 text-sm text-text-muted">
+      <p className="text-sm text-text-muted">
         <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
         Loading access requests…
-      </Card>
+      </p>
     );
   }
 
   return (
-    <Card padding="none" className="w-full overflow-hidden scroll-mt-24">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-accent/10 text-accent">
-          <UserPlus size={20} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="flex items-center gap-space-2 font-semibold text-text">
-            People &amp; access requests
-            {pending.length > 0 && (
-              <Badge variant="warn" aria-label={`${pending.length} pending`}>{pending.length}</Badge>
+    <>
+        {(pending.length > 0 || lldapUrl) && (
+          <div className="flex items-center justify-between gap-space-3">
+            {pending.length > 0 ? (
+              <Badge variant="warn" aria-label={`${pending.length} pending`}>{pending.length} pending</Badge>
+            ) : <span />}
+            {lldapUrl && (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="shrink-0"
+                onClick={() => window.open(lldapUrl, '_blank', 'noopener,noreferrer')}
+              >
+                Open LLDAP <ExternalLink size={14} />
+              </Button>
             )}
-          </h3>
-          <p className="text-xs text-text-muted">
-            Family members on the LAN can submit a request from the portal at <span className="font-mono">/portal</span>. Click <span className="font-medium">Approve</span> to provision the user in LLDAP and open their group-assignment page.
-          </p>
-        </div>
-        {lldapUrl && (
-          <Button
-            variant="secondary"
-            size="sm"
-            className="shrink-0"
-            onClick={() => window.open(lldapUrl, '_blank', 'noopener,noreferrer')}
-          >
-            Open LLDAP <ExternalLink size={14} />
-          </Button>
+          </div>
         )}
-      </div>
-
-      <div className="p-space-5 space-y-6">
         {requests.length === 0 ? (
           <p className="text-sm text-text-muted italic">
             No access requests yet. They appear here when a family member fills the form on the portal.
@@ -220,8 +209,7 @@ export default function AccessRequestsSection() {
             )}
           </>
         )}
-      </div>
-    </Card>
+    </>
   );
 }
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.test.tsx
@@ -29,12 +29,14 @@ function mockFetch(tokens: unknown[]) {
 describe('ApiTokensSection (#2100 settings migration)', () => {
   beforeEach(() => vi.unstubAllGlobals());
 
-  it('renders on a token Card surface with a Button-primitive revoke and no raw colour literals', async () => {
+  it('renders its controls with a Button-primitive revoke and no inner duplicate title (#2109)', async () => {
     mockFetch([TOKEN]);
     const { container } = render(<ApiTokensSection />);
     await waitFor(() => expect(screen.getByText('workstation')).toBeDefined());
 
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // The section no longer renders its own titled Card+header — that lives in
+    // the SettingDisclosure now (#2109). No "API tokens" h2/h3 title here.
+    expect(container.querySelector('h2, h3')).toBeNull();
     const revoke = screen.getByRole('button', { name: /revoke workstation/i });
     expect(revoke.getAttribute('data-variant')).toBe('danger');
     const html = container.innerHTML;

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, Copy, Key, Plus, Trash2 } from 'lucide-react';
-import { Button, Card } from '@/components/ui';
+import { Check, Copy, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui';
 import { copyToClipboard } from '../clipboard';
 
 type ApiScope = 'read' | 'lifecycle' | 'mutate' | 'reboot' | 'destroy' | 'exec';
@@ -291,22 +291,10 @@ export default function ApiTokensSection() {
   };
 
   return (
-    <Card padding="lg">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="p-2 bg-status-ok/10 rounded-card">
-          <Key size={20} className="text-status-ok" />
-        </div>
-        <div>
-          <h2 className="text-lg font-semibold text-text">API tokens</h2>
-          <p className="text-sm text-text-muted">
-            Named, revocable, scoped credentials. One token authenticates both the MCP server and opt-in REST API routes (e.g. the ServiceBay TUI or a script).
-          </p>
-        </div>
-      </div>
-
+    <>
       {bootstrap && <BootstrapBanner status={bootstrap} revoking={revokingBootstrap} reactivating={reactivatingBootstrap} onRevoke={revokeBootstrap} onReactivate={reactivateBootstrap} />}
 
-      <div className="mt-4 space-y-3">
+      <div className="space-y-3">
         <p className="text-xs text-text-muted">
           Pass as <span className="font-mono">Authorization: Bearer sb_…</span> on MCP requests and on opt-in REST API routes. Each token is revocable here without disturbing other clients, and appears as <span className="font-mono">caller</span> in the MCP audit log.
         </p>
@@ -347,6 +335,6 @@ export default function ApiTokensSection() {
           </Button>
         )}
       </div>
-    </Card>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApprovalsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApprovalsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, ChevronDown, ChevronRight, Loader2, ShieldAlert, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, Loader2, X } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 import { Badge, Button, Card } from '@/components/ui';
 
@@ -158,53 +158,33 @@ export default function ApprovalsSection() {
 
   if (busy === 'load') return <ApprovalsLoadingState />;
 
-  return (
-    <Card id="approvals" padding="none" className="w-full overflow-hidden scroll-mt-24">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-status-warn/10 text-status-warn">
-          <ShieldAlert size={20} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="flex items-center gap-space-2 font-semibold text-text">
-            Approvals
-            {pending.length > 0 && (
-              <Badge variant="warn" aria-label={`${pending.length} pending`}>{pending.length}</Badge>
-            )}
-          </h3>
-          <p className="text-xs text-text-muted">
-            Requests that need your review before a service runs them. Inspect the details, then <span className="font-medium">Approve</span> to run the requested action or <span className="font-medium">Reject</span> to discard it.
-          </p>
-        </div>
-      </div>
-
-      <div className="p-space-5">
-        {pending.length === 0 ? (
-          <p className="text-sm text-text-muted italic">
-            No pending approvals. Requests will appear here when a service needs your sign-off.
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {pending.map(request => (
-              <ApprovalCard
-                key={request.id}
-                request={request}
-                busy={busy}
-                onApprove={(id, title) => void resolveRequest(id, 'approve', title)}
-                onReject={(id, title) => void resolveRequest(id, 'reject', title)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    </Card>
+  return pending.length === 0 ? (
+    <p className="text-sm text-text-muted italic">
+      No pending approvals. Requests will appear here when a service needs your sign-off.
+    </p>
+  ) : (
+    <div className="space-y-2">
+      {pending.length > 0 && (
+        <Badge variant="warn" aria-label={`${pending.length} pending`}>{pending.length} pending</Badge>
+      )}
+      {pending.map(request => (
+        <ApprovalCard
+          key={request.id}
+          request={request}
+          busy={busy}
+          onApprove={(id, title) => void resolveRequest(id, 'approve', title)}
+          onReject={(id, title) => void resolveRequest(id, 'reject', title)}
+        />
+      ))}
+    </div>
   );
 }
 
 function ApprovalsLoadingState() {
   return (
-    <Card className="w-full p-space-5 text-sm text-text-muted">
+    <p className="text-sm text-text-muted">
       <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
       Loading approvals…
-    </Card>
+    </p>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Download, ExternalLink, Eye, EyeOff, Key, Loader2, Trash2 } from 'lucide-react';
+import { Download, ExternalLink, Eye, EyeOff, Loader2, Trash2 } from 'lucide-react';
 import {
   buildBitwardenCsv,
   isHttpUrl,
@@ -119,29 +119,22 @@ export default function CredentialsSection() {
 
   if (busy === 'load') {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
         <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
         Loading credentials…
-      </div>
+      </p>
     );
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-        <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
-          <Key size={20} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-bold text-gray-900 dark:text-white">Saved credentials</h3>
+    <>
+        {manifest && (
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            {manifest
-              ? `Persisted at ${new Date(manifest.savedAt).toLocaleString()} — encrypted at rest, visible to logged-in admins.`
-              : 'No credentials saved. Install a service via the wizard to populate this list.'}
+            Persisted at {new Date(manifest.savedAt).toLocaleString()} — encrypted at rest, visible to logged-in admins.
           </p>
-        </div>
+        )}
         {manifest && manifest.credentials.length > 0 && (
-          <div className="shrink-0 flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <button
               onClick={downloadCsv}
               className="inline-flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg"
@@ -173,9 +166,8 @@ export default function CredentialsSection() {
             </button>
           </div>
         )}
-      </div>
 
-      <div className="p-6">
+      <div>
         {!manifest || manifest.credentials.length === 0 ? (
           <p className="text-sm text-gray-500 dark:text-gray-400 italic">
             Nothing saved yet. The install wizard writes here at the end of every successful run.
@@ -244,6 +236,6 @@ export default function CredentialsSection() {
           </div>
         )}
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/EmailNotificationsSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/EmailNotificationsSection.test.tsx
@@ -32,9 +32,12 @@ vi.mock('../SettingsContext', () => ({
 describe('EmailNotificationsSection (#2100 settings migration)', () => {
   beforeEach(() => { vi.clearAllMocks(); enabled = true; recipients = ['a@example.com']; });
 
-  it('renders on a token Card surface with no raw colour literals', () => {
+  it('renders its controls with no inner duplicate title and no raw colour literals (#2109)', () => {
     const { container } = render(<EmailNotificationsSection />);
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "Email (SMTP)" h3 inside the section — the SettingDisclosure header
+    // carries the icon+title+description now (#2109).
+    expect(container.querySelector('h3')).toBeNull();
+    expect(screen.getByRole('switch', { name: /enable email/i })).toBeDefined();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|rose|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|rose|purple|indigo)-\d/);

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/EmailNotificationsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/EmailNotificationsSection.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Mail, Plus, Trash2, Send, CheckCircle2, AlertCircle } from 'lucide-react';
-import { Button, Card } from '@/components/ui';
+import { Plus, Trash2, Send, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui';
 import { useSettings } from '../SettingsContext';
 
 // Shared token-based input chrome for this section's text fields.
@@ -79,31 +79,23 @@ export default function EmailNotificationsSection() {
   };
 
   return (
-    <Card padding="none" className="w-full overflow-hidden">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-accent/10 text-accent">
-          <Mail size={20} />
-        </div>
-        <div>
-          <h3 className="font-semibold text-text">Email (SMTP)</h3>
-          <p className="text-xs text-text-muted">Configure SMTP settings for ServiceBay alerts</p>
-        </div>
-        <div className="ml-auto">
-          <button
-            role="switch"
-            aria-checked={emailEnabled}
-            aria-label="Enable email notifications"
-            onClick={() => handleEnabledToggle(!emailEnabled)}
-            disabled={saving}
-            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-chip transition-colors disabled:opacity-50 ${emailEnabled ? 'bg-accent' : 'bg-surface-muted border border-border'}`}
-          >
-            <span className={`inline-block h-4 w-4 transform rounded-chip bg-white transition-transform ${emailEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
-          </button>
-        </div>
-      </div>
+    <>
+      <label className="flex items-center justify-between gap-space-3">
+        <span className="text-sm font-medium text-text">Enable email notifications</span>
+        <button
+          role="switch"
+          aria-checked={emailEnabled}
+          aria-label="Enable email notifications"
+          onClick={() => handleEnabledToggle(!emailEnabled)}
+          disabled={saving}
+          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-chip transition-colors disabled:opacity-50 ${emailEnabled ? 'bg-accent' : 'bg-surface-muted border border-border'}`}
+        >
+          <span className={`inline-block h-4 w-4 transform rounded-chip bg-white transition-transform ${emailEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
+        </button>
+      </label>
 
       {emailEnabled && (
-        <div className="p-space-5 space-y-6">
+        <div className="space-y-6">
           <div className="rounded-card border border-status-info/30 bg-status-info/10 p-4 text-sm text-text">
             <p className="font-medium mb-1">Need help finding these settings?</p>
             <ul className="list-disc list-inside space-y-1 text-text-muted">
@@ -273,6 +265,6 @@ export default function EmailNotificationsSection() {
           </div>
         </div>
       )}
-    </Card>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { AlertTriangle, Loader2, Trash2 } from 'lucide-react';
+import { Loader2, Trash2 } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 
 /**
@@ -60,18 +60,7 @@ export default function FactoryResetSection() {
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-red-200 dark:border-red-900/50 shadow-sm overflow-hidden w-full">
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-red-50 dark:bg-red-950/30 flex items-center gap-3">
-        <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg text-red-600 dark:text-red-400">
-          <AlertTriangle size={20} />
-        </div>
-        <div>
-          <h3 className="font-bold text-gray-900 dark:text-white">Factory Reset</h3>
-          <p className="text-xs text-gray-500 dark:text-gray-400">Wipe every service + clear saved credentials. Start from zero.</p>
-        </div>
-      </div>
-
-      <div className="p-6 space-y-4">
+    <div className="space-y-4">
         <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
           <p>This deletes every installed service (photos, vault, identity, proxy, all of it) and clears the saved credentials in ServiceBay&apos;s config. The next wizard run goes through the full first-install flow with no pre-filled values.</p>
           <p className="font-medium text-red-700 dark:text-red-400">
@@ -120,7 +109,6 @@ export default function FactoryResetSection() {
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">Open the install wizard to set up the server from scratch.</p>
           </div>
         )}
-      </div>
     </div>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Copy, KeyRound, Loader2, RefreshCw, Users } from 'lucide-react';
+import { Copy, KeyRound, Loader2, RefreshCw } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 
 interface SambaUser {
@@ -101,30 +101,21 @@ export default function FileShareSection() {
   }, [addToast]);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400">
-          <Users size={20} />
+    <>
+        <div className="flex justify-end">
+          <button
+            onClick={loadUsers}
+            disabled={loading}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+            type="button"
+            title="Re-run LLDAP → Samba sync"
+          >
+            {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+            Sync
+          </button>
         </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-bold text-gray-900 dark:text-white">File Share — Samba accounts</h3>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            Every LLDAP user mounts the Samba share with their own credentials. Samba can&apos;t speak OIDC, so the password lives in Samba&apos;s own DB — set it here.
-          </p>
-        </div>
-        <button
-          onClick={loadUsers}
-          disabled={loading}
-          className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-50"
-          type="button"
-          title="Re-run LLDAP → Samba sync"
-        >
-          {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
-          Sync
-        </button>
-      </div>
 
-      <div className="p-6 space-y-3">
+      <div className="space-y-3">
         {error && (
           <div className="p-3 rounded-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800">
             {error}
@@ -187,6 +178,6 @@ export default function FileShareSection() {
           </ul>
         )}
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/GatewaySection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/GatewaySection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Router, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
 
 interface GatewayState {
@@ -89,37 +89,28 @@ export default function GatewaySection() {
 
   if (busy === 'load' || !state) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
         <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
         Loading gateway settings…
-      </div>
+      </p>
     );
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400">
-          <Router size={20} />
+    <>
+        <div className="flex justify-end">
+          {state.configured ? (
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+              <CheckCircle2 size={14} /> Configured
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+              <AlertCircle size={14} /> Not configured
+            </span>
+          )}
         </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-bold text-gray-900 dark:text-white">Internet Gateway (FritzBox)</h3>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            Credentials for TR-064 access — used to read external IP, port-forward status, and (with the router-DNS probe) push DHCP-DNS settings.
-          </p>
-        </div>
-        {state.configured ? (
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
-            <CheckCircle2 size={14} /> Configured
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-300">
-            <AlertCircle size={14} /> Not configured
-          </span>
-        )}
-      </div>
 
-      <div className="p-6 space-y-4">
+      <div className="space-y-4">
         <div className="grid sm:grid-cols-2 gap-4">
           <label className="flex flex-col gap-1">
             <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Host</span>
@@ -190,6 +181,6 @@ export default function GatewaySection() {
           The TR-064 user needs the &quot;Smart Home&quot; permission in the FritzBox UI (System → FRITZ!Box-Benutzer). The password is stored encrypted at rest in <span className="font-mono">config.gateway.password</span>.
         </p>
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.test.tsx
@@ -25,12 +25,14 @@ function mockFetch(allowMutations: boolean) {
 describe('McpSection (#2100 settings migration)', () => {
   beforeEach(() => vi.unstubAllGlobals());
 
-  it('renders on a token Card surface with no raw colour literals', async () => {
+  it('renders its controls with no inner duplicate title and no raw colour literals (#2109)', async () => {
     mockFetch(true);
     const { container } = render(<McpSection />);
-    await waitFor(() => expect(screen.getByText('MCP Server')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('MCP endpoint')).toBeDefined());
 
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "MCP Server" h2/h3 title inside the section — the SettingDisclosure
+    // header carries the icon+title+description now (#2109).
+    expect(container.querySelector('h2, h3')).toBeNull();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|purple|indigo|amber)-\d/);
@@ -40,7 +42,7 @@ describe('McpSection (#2100 settings migration)', () => {
   it('toggling mutations still POSTs to /api/settings (behaviour preserved)', async () => {
     mockFetch(true);
     render(<McpSection />);
-    await waitFor(() => expect(screen.getByText('MCP Server')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('MCP endpoint')).toBeDefined());
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     const switches = screen.getAllByRole('switch');
     fireEvent.click(switches[0]);

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Bot, Check, Copy, ShieldAlert, History, RefreshCw, ShieldCheck } from 'lucide-react';
+import { Check, Copy, ShieldAlert, History, RefreshCw, ShieldCheck } from 'lucide-react';
 import SectionHelp from '@/components/SectionHelp';
-import { Button, Card } from '@/components/ui';
+import { Button } from '@/components/ui';
 import { copyToClipboard } from '../clipboard';
 
 interface AuditEntry {
@@ -308,19 +308,8 @@ export default function McpSection() {
   };
 
   return (
-    <Card padding="lg">
-      <div className="flex items-start justify-between gap-4 mb-4">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-accent/10 rounded-card">
-            <Bot size={20} className="text-accent" />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-text">MCP Server</h2>
-            <p className="text-sm text-text-muted">
-              Let an AI assistant (Claude Code, Claude Desktop, …) drive ServiceBay through the Model Context Protocol.
-            </p>
-          </div>
-        </div>
+    <>
+      <div className="flex justify-end">
         <SectionHelp
           helpId="mcp"
           title="Connecting an LLM via MCP"
@@ -328,7 +317,7 @@ export default function McpSection() {
         />
       </div>
 
-      <div className="mt-4">
+      <div>
         <label className="block text-xs font-semibold uppercase tracking-wider text-text-muted mb-1">
           MCP endpoint
         </label>
@@ -403,6 +392,6 @@ export default function McpSection() {
         </button>
         {auditOpen && <McpAuditFeed entries={audit} loading={auditLoading} onRefresh={loadAudit} />}
       </div>
-    </Card>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.test.tsx
@@ -35,9 +35,11 @@ vi.mock('../SettingsContext', () => ({
 describe('NodesSection (#2100 settings migration)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('renders on a token Card surface with no raw colour literals', () => {
+  it('renders its controls with no inner duplicate title and no raw colour literals (#2109)', () => {
     const { container } = render(<NodesSection />);
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "System Connections" h3 inside the section — the SettingDisclosure
+    // header carries the icon+title+description now (#2109).
+    expect(container.querySelector('h3')).toBeNull();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|purple|indigo|green|yellow)-\d/);

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import {
-  Server,
   Key,
   Terminal,
   Plus,
@@ -16,7 +15,7 @@ import {
   ShieldAlert,
   WifiOff,
 } from 'lucide-react';
-import { Badge, Button, Card } from '@/components/ui';
+import { Badge, Button } from '@/components/ui';
 import { useSettings } from '../SettingsContext';
 import { PodmanConnection } from '@/lib/nodes';
 
@@ -99,24 +98,14 @@ export default function NodesSection() {
   };
 
   return (
-    <Card padding="none" className="w-full overflow-hidden">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-accent/10 text-accent">
-          <Server size={20} />
-        </div>
-        <div>
-          <h3 className="font-semibold text-text">System Connections</h3>
-          <p className="text-xs text-text-muted">Manage remote Podman nodes</p>
-        </div>
-        <div className="ml-auto">
+    <>
+        <div className="flex justify-end">
           <Button variant="ghost" size="sm" onClick={() => openSSHModal()}>
             <Terminal size={14} />
             Setup SSH Keys
           </Button>
         </div>
-      </div>
 
-      <div className="p-space-5 space-y-6">
         <div className="bg-accent/10 border border-accent/20 rounded-card p-3 flex gap-3 items-start">
           <div className="mt-0.5 text-accent">
             <Key size={16} />
@@ -357,7 +346,6 @@ export default function NodesSection() {
             </div>
           )}
         </div>
-      </div>
-    </Card>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.test.tsx
@@ -21,12 +21,14 @@ function mockFetch() {
 describe('PortalAccessSection (#2100 settings migration)', () => {
   beforeEach(() => vi.unstubAllGlobals());
 
-  it('renders on a token Card surface with no raw colour literals', async () => {
+  it('renders its controls with no inner duplicate title and no raw colour literals (#2109)', async () => {
     mockFetch();
     const { container } = render(<PortalAccessSection />);
-    await waitFor(() => expect(screen.getByText('Portal access')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Maximum users')).toBeDefined());
 
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "Portal access" h3 inside the section — the SettingDisclosure header
+    // carries the icon+title+description now (#2109).
+    expect(container.querySelector('h3')).toBeNull();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|purple|indigo)-\d/);
@@ -36,7 +38,7 @@ describe('PortalAccessSection (#2100 settings migration)', () => {
   it('Save still PUTs the portal settings (behaviour preserved)', async () => {
     mockFetch();
     render(<PortalAccessSection />);
-    await waitFor(() => expect(screen.getByText('Portal access')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('Maximum users')).toBeDefined());
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     await waitFor(() =>

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PortalAccessSection.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Loader2, Save, Users } from 'lucide-react';
+import { Loader2, Save } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
-import { Button, Card } from '@/components/ui';
+import { Button } from '@/components/ui';
 
 /**
  * Settings section for the family-portal access limits (#1456):
@@ -69,28 +69,15 @@ export default function PortalAccessSection() {
 
   if (busy === 'load') {
     return (
-      <Card className="w-full p-space-5 text-sm text-text-muted">
+      <p className="text-sm text-text-muted">
         <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
         Loading portal settings…
-      </Card>
+      </p>
     );
   }
 
   return (
-    <Card id="portal-access" padding="none" className="w-full overflow-hidden scroll-mt-24">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-accent/10 text-accent">
-          <Users size={20} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-semibold text-text">Portal access</h3>
-          <p className="text-xs text-text-muted">
-            Limits for the family portal at <span className="font-mono">/portal</span>.
-          </p>
-        </div>
-      </div>
-
-      <div className="p-space-5 space-y-6">
+    <>
         <div>
           <label htmlFor="max-users" className="block text-sm font-medium text-text">
             Maximum users
@@ -139,7 +126,6 @@ export default function PortalAccessSection() {
             <span className={`inline-block h-4 w-4 transform rounded-chip bg-white transition-transform ${lanOnly ? 'translate-x-6' : 'translate-x-1'}`} />
           </button>
         </div>
-      </div>
-    </Card>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PublicDomainSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PublicDomainSection.tsx
@@ -206,10 +206,10 @@ export default function PublicDomainSection() {
 
   if (phase === 'loading' || !info) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
         <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
         Loading mode…
-      </div>
+      </p>
     );
   }
 
@@ -217,8 +217,8 @@ export default function PublicDomainSection() {
   const Icon = isLan ? Home : Globe;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden w-full">
-      <PublicDomainHeader isLan={isLan} Icon={Icon} info={info} />
+    <>
+      <PublicDomainModeBanner isLan={isLan} Icon={Icon} info={info} />
       <PublicDomainBody
         phase={phase}
         info={info}
@@ -236,20 +236,21 @@ export default function PublicDomainSection() {
         setResult={setResult}
         setPreflight={setPreflight}
       />
-    </div>
+    </>
   );
 }
 
-function PublicDomainHeader({isLan, Icon, info}: {isLan: boolean; Icon: LucideIcon; info: ModeInfo}) {
+/** Compact in-body mode banner (#2109). Not a bordered box-in-box — the
+ *  disclosure header already carries the "Public domain" title; this conveys
+ *  the live LAN-vs-public state. */
+function PublicDomainModeBanner({isLan, Icon, info}: {isLan: boolean; Icon: LucideIcon; info: ModeInfo}) {
   return (
-    <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 flex items-center gap-3">
-      <div className={`p-2 rounded-lg ${isLan ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400' : 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'}`}>
-        <Icon size={20} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <h3 className="font-bold text-gray-900 dark:text-white">
+    <div className={`flex items-start gap-3 rounded-card p-3 ${isLan ? 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800' : 'bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800'}`}>
+      <Icon size={18} className={`shrink-0 mt-0.5 ${isLan ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`} />
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-gray-900 dark:text-white">
           {isLan ? 'Internal-only mode' : 'Public-domain mode'}
-        </h3>
+        </p>
         <p className="text-xs text-gray-500 dark:text-gray-400">
           {isLan
             ? `Services live on <sub>.${info.activeDomain} via AdGuard DNS rewrites. No HTTPS, no external access.`
@@ -271,7 +272,7 @@ function PublicDomainBody({
   setResult: (r: MigrationResult | null) => void; setPreflight: (p: PreflightStatus | null) => void;
 }) {
   return (
-    <div className="p-6 space-y-4">
+    <div className="space-y-4">
       {phase === 'public' && info.publicDomain && <PublicModeBody info={info} />}
       {phase === 'idle' && (
         <IdleForm

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ReverseProxySection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ReverseProxySection.test.tsx
@@ -21,12 +21,14 @@ function mockFetch(status: string) {
 describe('ReverseProxySection (#2100 settings migration)', () => {
   beforeEach(() => vi.unstubAllGlobals());
 
-  it('renders on a token Card surface with a status Badge and no raw colour literals', async () => {
+  it('renders its controls with the status Badge and no inner duplicate title (#2109)', async () => {
     mockFetch('ok');
     const { container } = render(<ReverseProxySection />);
     await waitFor(() => expect(screen.getByText('Verified')).toBeDefined());
 
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "Reverse Proxy (NPM)" h3 inside the section — the SettingDisclosure
+    // header carries the icon+title+description now (#2109).
+    expect(container.querySelector('h3')).toBeNull();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|purple|indigo|amber)-\d/);

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ReverseProxySection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ReverseProxySection.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { AlertTriangle, CheckCircle2, HelpCircle, KeyRound, Loader2, Shield, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, HelpCircle, KeyRound, Loader2, XCircle } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
-import { Badge, Button, Card } from '@/components/ui';
+import { Badge, Button } from '@/components/ui';
 
 /**
  * Settings → Networking → Reverse Proxy (NPM) (#1530 — derive, don't ask).
@@ -76,18 +76,8 @@ export default function ReverseProxySection() {
   const diverged = status === 'rejected' || status === 'no-creds';
 
   return (
-    <Card padding="none" className="w-full overflow-hidden">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-status-ok/10 text-status-ok">
-          <Shield size={20} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-semibold text-text">Reverse Proxy (NPM)</h3>
-          <p className="text-xs text-text-muted">
-            ServiceBay owns the Nginx Proxy Manager admin credential automatically — it&apos;s read from NPM&apos;s own database, never typed in, so it can&apos;t silently drift out of sync.
-          </p>
-        </div>
-        <div className="shrink-0">
+    <>
+        <div className="flex justify-end">
           {busy === 'load' ? (
             <Badge variant="neutral"><Loader2 size={12} className="animate-spin" /> Checking</Badge>
           ) : verified ? (
@@ -98,9 +88,7 @@ export default function ReverseProxySection() {
             <Badge variant="neutral"><XCircle size={12} /> Unknown</Badge>
           )}
         </div>
-      </div>
 
-      <div className="p-space-5 space-y-4">
         <div>
           <label className="block text-sm font-medium text-text-muted mb-1">Admin identity (from NPM database)</label>
           <div className="flex items-center gap-2 w-full p-2 rounded-card border border-border bg-surface-2 text-text font-mono text-sm">
@@ -152,7 +140,6 @@ export default function ReverseProxySection() {
             </Button>
           )}
         </div>
-      </div>
-    </Card>
+    </>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ServerIdentitySection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ServerIdentitySection.test.tsx
@@ -15,9 +15,12 @@ vi.mock('../SettingsContext', () => ({
 }));
 
 describe('ServerIdentitySection (#2100 settings migration)', () => {
-  it('renders on a token Card surface with no raw colour literals', () => {
+  it('renders its control with no inner duplicate title and no raw colour literals (#2109)', () => {
     const { container } = render(<ServerIdentitySection />);
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "Server Identity" h3 inside the section — the SettingDisclosure header
+    // carries the icon+title+description now (#2109).
+    expect(container.querySelector('h3')).toBeNull();
+    expect(screen.getByRole('textbox')).toBeDefined();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|purple|indigo)-\d/);

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ServerIdentitySection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ServerIdentitySection.tsx
@@ -1,44 +1,28 @@
 'use client';
 
-import { Server } from 'lucide-react';
-import { Button, Card } from '@/components/ui';
+import { Button } from '@/components/ui';
 import { useSettings } from '../SettingsContext';
 
 export default function ServerIdentitySection() {
   const { saving, serverName, setServerName, persistSettings } = useSettings();
 
   return (
-    <Card padding="none" className="w-full overflow-hidden">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-accent/10 text-accent">
-          <Server size={20} />
-        </div>
-        <div>
-          <h3 className="font-semibold text-text">Server Identity</h3>
-          <p className="text-xs text-text-muted">
-            Custom display name shown in the browser tab and system info instead of the detected hostname.
-          </p>
-        </div>
-      </div>
-      <div className="p-space-5">
-        <div className="flex items-center gap-space-3">
-          <input
-            type="text"
-            value={serverName}
-            onChange={e => setServerName(e.target.value)}
-            disabled={saving}
-            className="flex-1 p-2 rounded-card border border-border bg-surface-2 text-text focus:ring-2 focus:ring-accent outline-none disabled:opacity-50"
-            placeholder="e.g. HomeServer, NAS, Production"
-          />
-          <Button
-            onClick={() => persistSettings()}
-            disabled={saving}
-            className="shrink-0"
-          >
-            {saving ? 'Saving...' : 'Save'}
-          </Button>
-        </div>
-      </div>
-    </Card>
+    <div className="flex items-center gap-space-3">
+      <input
+        type="text"
+        value={serverName}
+        onChange={e => setServerName(e.target.value)}
+        disabled={saving}
+        className="flex-1 p-2 rounded-card border border-border bg-surface-2 text-text focus:ring-2 focus:ring-accent outline-none disabled:opacity-50"
+        placeholder="e.g. HomeServer, NAS, Production"
+      />
+      <Button
+        onClick={() => persistSettings()}
+        disabled={saving}
+        className="shrink-0"
+      >
+        {saving ? 'Saving...' : 'Save'}
+      </Button>
+    </div>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdateWindowSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdateWindowSection.test.tsx
@@ -21,12 +21,14 @@ function mockFetch() {
 describe('UpdateWindowSection (#2100 settings migration)', () => {
   beforeEach(() => vi.unstubAllGlobals());
 
-  it('renders on a token Card surface with no raw colour literals', async () => {
+  it('renders its controls with no inner duplicate title and no raw colour literals (#2109)', async () => {
     mockFetch();
     const { container } = render(<UpdateWindowSection />);
-    await waitFor(() => expect(screen.getByText('Auto-update window')).toBeDefined());
+    await waitFor(() => expect(screen.getByRole('button', { name: /save & apply/i })).toBeDefined());
 
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // No "Auto-update window" h3 inside the section — the SettingDisclosure
+    // header carries the icon+title+description now (#2109).
+    expect(container.querySelector('h3')).toBeNull();
     const html = container.innerHTML;
     expect(html).not.toMatch(/bg-(blue|amber|emerald|green|red|rose|purple|indigo)-\d/);
     expect(html).not.toMatch(/text-(blue|emerald|red|rose|purple|indigo|amber)-\d/);
@@ -36,7 +38,7 @@ describe('UpdateWindowSection (#2100 settings migration)', () => {
   it('Save & apply still PUTs the window (behaviour preserved)', async () => {
     mockFetch();
     render(<UpdateWindowSection />);
-    await waitFor(() => expect(screen.getByText('Auto-update window')).toBeDefined());
+    await waitFor(() => expect(screen.getByRole('button', { name: /save & apply/i })).toBeDefined());
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     fireEvent.click(screen.getByRole('button', { name: /save & apply/i }));
     await waitFor(() =>

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdateWindowSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/UpdateWindowSection.tsx
@@ -19,9 +19,9 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { CalendarClock, Loader2, Lock } from 'lucide-react';
+import { Loader2, Lock } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
-import { Button, Card } from '@/components/ui';
+import { Button } from '@/components/ui';
 
 type Day = 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun';
 
@@ -171,20 +171,7 @@ export default function UpdateWindowSection() {
   const groupDisabled = saving || !window.enabled;
 
   return (
-    <Card padding="none" className="w-full overflow-hidden">
-      <div className="flex items-center gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
-        <div className="p-2 rounded-card bg-status-warn/10 text-status-warn">
-          <CalendarClock size={20} />
-        </div>
-        <div className="min-w-0">
-          <h3 className="font-semibold text-text">Auto-update window</h3>
-          <p className="text-xs text-text-muted">
-            Decide when ServiceBay applies OS updates, container image refreshes, and its own updates. Until you save an enabled window, all auto-updates are locked.
-          </p>
-        </div>
-      </div>
-
-      <div className="p-space-5 space-y-5">
+    <div className="space-y-5">
         {loading ? (
           <div className="flex items-center gap-2 text-sm text-text-muted">
             <Loader2 size={14} className="animate-spin" /> Loading current setting…
@@ -328,7 +315,6 @@ export default function UpdateWindowSection() {
             </div>
           </>
         )}
-      </div>
-    </Card>
+    </div>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/access/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/access/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Bot, Key, ShieldAlert, UserPlus, Users } from 'lucide-react';
 import GroupIntro from '../_lib/GroupIntro';
 import SettingDisclosure from '../_lib/SettingDisclosure';
 import { SETTINGS_GROUPS } from '../_lib/ia';
@@ -17,25 +18,70 @@ export default function AccessSettingsPage() {
   return (
     <div className="space-y-6">
       <GroupIntro intent={GROUP.intent} />
-      <SettingDisclosure id="access-requests" tier="essential" label="Access requests">
+      <SettingDisclosure
+        id="access-requests"
+        tier="essential"
+        label="People & access requests"
+        icon={UserPlus}
+        description={<>Family members on the LAN can request access from the portal at <span className="font-mono">/portal</span>. Approve to provision the user in LLDAP.</>}
+      >
         <AccessRequestsSection />
       </SettingDisclosure>
-      <SettingDisclosure id="credentials" tier="essential" label="Credentials">
+      <SettingDisclosure
+        id="credentials"
+        tier="essential"
+        label="Saved credentials"
+        icon={Key}
+        description="Credentials the install wizard persisted — encrypted at rest, visible to logged-in admins."
+      >
         <CredentialsSection />
       </SettingDisclosure>
-      <SettingDisclosure id="api-tokens" tier="advanced" label="API tokens">
+      <SettingDisclosure
+        id="api-tokens"
+        tier="advanced"
+        label="API tokens"
+        icon={Key}
+        iconTone="ok"
+        description="Named, revocable, scoped credentials. One token authenticates both the MCP server and opt-in REST API routes."
+      >
         <ApiTokensSection />
       </SettingDisclosure>
-      <SettingDisclosure id="mcp" tier="advanced" label="MCP access">
+      <SettingDisclosure
+        id="mcp"
+        tier="advanced"
+        label="MCP access"
+        icon={Bot}
+        description="Let an AI assistant (Claude Code, Claude Desktop, …) drive ServiceBay through the Model Context Protocol."
+      >
         <McpSection />
       </SettingDisclosure>
-      <SettingDisclosure id="portal-access" tier="advanced" label="Portal access">
+      <SettingDisclosure
+        id="portal-access"
+        tier="advanced"
+        label="Portal access"
+        icon={Users}
+        description={<>Limits for the family portal at <span className="font-mono">/portal</span>.</>}
+      >
         <PortalAccessSection />
       </SettingDisclosure>
-      <SettingDisclosure id="approvals" tier="advanced" label="Action approvals">
+      <SettingDisclosure
+        id="approvals"
+        tier="advanced"
+        label="Action approvals"
+        icon={ShieldAlert}
+        iconTone="warn"
+        description="Requests that need your review before a service runs them. Inspect, then Approve or Reject."
+      >
         <ApprovalsSection />
       </SettingDisclosure>
-      <SettingDisclosure id="file-share" tier="advanced" label="File sharing">
+      <SettingDisclosure
+        id="file-share"
+        tier="advanced"
+        label="File sharing"
+        icon={Users}
+        iconTone="ok"
+        description="Per-LLDAP-user Samba passwords. Samba can't speak OIDC, so the password lives in its own DB — set it here."
+      >
         <FileShareSection />
       </SettingDisclosure>
     </div>

--- a/packages/frontend/src/app/(dashboard)/settings/network-domain/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/network-domain/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Globe, Router, Server, Shield } from 'lucide-react';
 import GroupIntro from '../_lib/GroupIntro';
 import SettingDisclosure from '../_lib/SettingDisclosure';
 import { SETTINGS_GROUPS } from '../_lib/ia';
@@ -14,16 +15,42 @@ export default function NetworkDomainSettingsPage() {
   return (
     <div className="space-y-6">
       <GroupIntro intent={GROUP.intent} />
-      <SettingDisclosure id="public-domain" tier="essential" label="Public domain">
+      <SettingDisclosure
+        id="public-domain"
+        tier="essential"
+        label="Public domain"
+        icon={Globe}
+        description="Reach the box from the internet over your own domain, or keep it internal-only."
+      >
         <PublicDomainSection />
       </SettingDisclosure>
-      <SettingDisclosure id="reverse-proxy" tier="advanced" label="Reverse proxy">
+      <SettingDisclosure
+        id="reverse-proxy"
+        tier="advanced"
+        label="Reverse proxy (NPM)"
+        icon={Shield}
+        iconTone="ok"
+        description="ServiceBay owns the Nginx Proxy Manager admin credential automatically — read from NPM's own database, never typed in."
+      >
         <ReverseProxySection />
       </SettingDisclosure>
-      <SettingDisclosure id="gateway" tier="advanced" label="Router / gateway">
+      <SettingDisclosure
+        id="gateway"
+        tier="advanced"
+        label="Router / gateway (FritzBox)"
+        icon={Router}
+        iconTone="warn"
+        description="Credentials for TR-064 access — external IP, port-forward status, and DHCP-DNS push."
+      >
         <GatewaySection />
       </SettingDisclosure>
-      <SettingDisclosure id="nodes" tier="advanced" label="Nodes & connections">
+      <SettingDisclosure
+        id="nodes"
+        tier="advanced"
+        label="Nodes & connections"
+        icon={Server}
+        description="Manage remote Podman nodes."
+      >
         <NodesSection />
       </SettingDisclosure>
     </div>

--- a/packages/frontend/src/app/(dashboard)/settings/notifications/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/notifications/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Mail } from 'lucide-react';
 import GroupIntro from '../_lib/GroupIntro';
 import SettingDisclosure from '../_lib/SettingDisclosure';
 import { SETTINGS_GROUPS } from '../_lib/ia';
@@ -11,7 +12,13 @@ export default function NotificationsSettingsPage() {
   return (
     <div className="space-y-6">
       <GroupIntro intent={GROUP.intent} />
-      <SettingDisclosure id="email" tier="essential" label="Email notifications">
+      <SettingDisclosure
+        id="email"
+        tier="essential"
+        label="Email (SMTP)"
+        icon={Mail}
+        description="Configure SMTP settings for ServiceBay alerts."
+      >
         <EmailNotificationsSection />
       </SettingDisclosure>
     </div>

--- a/packages/frontend/src/app/(dashboard)/settings/system/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/system/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AlertTriangle, CalendarClock, RefreshCw, Server } from 'lucide-react';
 import LogLevelControl from '@/components/LogLevelControl';
 import GroupIntro from '../_lib/GroupIntro';
 import SettingDisclosure from '../_lib/SettingDisclosure';
@@ -15,13 +16,32 @@ export default function SystemSettingsPage() {
   return (
     <div className="space-y-6">
       <GroupIntro intent={GROUP.intent} />
-      <SettingDisclosure id="server-identity" tier="essential" label="Server identity">
+      <SettingDisclosure
+        id="server-identity"
+        tier="essential"
+        label="Server identity"
+        icon={Server}
+        description="Custom display name shown in the browser tab and system info instead of the detected hostname."
+      >
         <ServerIdentitySection />
       </SettingDisclosure>
-      <SettingDisclosure id="updates" tier="essential" label="Updates">
+      <SettingDisclosure
+        id="updates"
+        tier="essential"
+        label="Updates"
+        icon={RefreshCw}
+        description="Keep ServiceBay current, and reinstall or recover the base OS from a boot USB."
+      >
         <UpdatesSection />
       </SettingDisclosure>
-      <SettingDisclosure id="update-window" tier="advanced" label="Update window">
+      <SettingDisclosure
+        id="update-window"
+        tier="advanced"
+        label="Update window"
+        icon={CalendarClock}
+        iconTone="warn"
+        description="Decide when ServiceBay applies OS, container, and its own updates. Until you save a window, auto-updates stay locked."
+      >
         <UpdateWindowSection />
       </SettingDisclosure>
       <SettingDisclosure id="log-level" tier="advanced" label="Log level">
@@ -37,7 +57,14 @@ export default function SystemSettingsPage() {
       {/* Disk import left Settings for its own app + launch tile (#1949/#1953):
           the heavy job runs in a resource-capped worker container, reached via a
           dashboard tile — not an in-process Settings subsection. */}
-      <SettingDisclosure id="factory-reset" tier="advanced" label="Factory reset">
+      <SettingDisclosure
+        id="factory-reset"
+        tier="advanced"
+        label="Factory reset"
+        icon={AlertTriangle}
+        iconTone="fail"
+        description="Wipe every service + clear saved credentials. Start from zero."
+      >
         <FactoryResetSection />
       </SettingDisclosure>
     </div>

--- a/packages/frontend/src/app/portal/AccessRequestStatusCTA.tsx
+++ b/packages/frontend/src/app/portal/AccessRequestStatusCTA.tsx
@@ -91,12 +91,12 @@ export default function AccessRequestStatusCTA({ fallback }: { fallback: React.R
 
   if (fetched.status === 'pending') {
     return (
-      <div className="mt-12 max-w-md mx-auto text-center bg-amber-50/70 dark:bg-amber-900/10 border border-amber-200/60 dark:border-amber-800/40 rounded-2xl p-6">
-        <Clock size={28} className="mx-auto text-amber-600 dark:text-amber-400" />
-        <h2 className="mt-3 text-lg font-bold text-gray-900 dark:text-white">
+      <div className="mt-space-7 max-w-md mx-auto text-center bg-status-warn/10 border border-status-warn/40 rounded-card p-space-5">
+        <Clock size={28} className="mx-auto text-status-warn" />
+        <h2 className="mt-space-3 text-lg font-bold text-text">
           Your access request is being reviewed
         </h2>
-        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+        <p className="mt-space-2 text-sm text-text-muted leading-relaxed">
           {fetched.firstName ? `Hi ${fetched.firstName} — ` : ''}we&apos;ll email you as soon as the family admin sets your account up. No action needed from you right now.
         </p>
       </div>
@@ -104,19 +104,19 @@ export default function AccessRequestStatusCTA({ fallback }: { fallback: React.R
   }
 
   if (fetched.status === 'resolved') {
-    const buttonClasses = 'inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-lg transition-colors';
+    const buttonClasses = 'inline-flex items-center justify-center gap-space-2 px-space-4 py-2.5 bg-accent hover:bg-accent-strong text-on-accent text-sm font-semibold rounded-card transition-colors';
     return (
-      <div className="mt-12 max-w-md mx-auto text-center bg-emerald-50/70 dark:bg-emerald-900/10 border border-emerald-200/60 dark:border-emerald-800/40 rounded-2xl p-6">
-        <KeyRound size={28} className="mx-auto text-emerald-600 dark:text-emerald-400" />
-        <h2 className="mt-3 text-lg font-bold text-gray-900 dark:text-white">
+      <div className="mt-space-7 max-w-md mx-auto text-center bg-status-ok/10 border border-status-ok/40 rounded-card p-space-5">
+        <KeyRound size={28} className="mx-auto text-status-ok" />
+        <h2 className="mt-space-3 text-lg font-bold text-text">
           {fetched.firstName ? `Welcome, ${fetched.firstName}!` : 'Your account is ready'}
         </h2>
-        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+        <p className="mt-space-2 text-sm text-text-muted leading-relaxed">
           {fetched.username
             ? <>Your username is <span className="font-mono">{fetched.username}</span>. Set your password to sign in:</>
             : <>Set your password to sign in:</>}
         </p>
-        <div className="mt-4">
+        <div className="mt-space-4">
           {fetched.authUrl
             ? (
               <a href={fetched.authUrl} className={buttonClasses}>
@@ -124,7 +124,7 @@ export default function AccessRequestStatusCTA({ fallback }: { fallback: React.R
               </a>
             )
             : (
-              <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+              <p className="text-xs text-text-subtle italic">
                 Open your welcome email — it includes the password-set link.
               </p>
             )}

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -237,11 +237,12 @@ describe('PortalGrid', () => {
 
   describe('sizeTier → column span (#1700)', () => {
     /** Walk up from the card heading to the grid-cell wrapper (the div
-     *  that carries the `col-span-*` class). The wrapper is the heading's
-     *  nearest ancestor div with `rounded-2xl` (the card chrome). */
+     *  that carries the `col-span-*` class). Post design-system migration
+     *  (#2107) the wrapper is the <Card> primitive — the heading's nearest
+     *  ancestor div with `rounded-card` (the token card chrome). */
     const cardWrapper = (label: string): HTMLElement => {
       const heading = screen.getByRole('heading', { name: label });
-      const wrapper = heading.closest('div.rounded-2xl');
+      const wrapper = heading.closest('div.rounded-card');
       expect(wrapper).not.toBeNull();
       return wrapper as HTMLElement;
     };
@@ -308,6 +309,93 @@ describe('PortalGrid', () => {
       const badge = screen.getByText('Degraded');
       expect(badge).toBeDefined();
       expect(badge.closest('span')?.getAttribute('title')).toBe('Partially unhealthy');
+    });
+  });
+
+  describe('design-system migration (#2107)', () => {
+    /** Nearest <Card> ancestor of the card heading. */
+    const wrapperOf = (label: string): HTMLElement => {
+      const w = screen.getByRole('heading', { name: label }).closest('div.rounded-card');
+      expect(w).not.toBeNull();
+      return w as HTMLElement;
+    };
+
+    it('renders the card surface on semantic tokens, not raw gray/white literals', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      const cls = wrapperOf('Photos').className;
+      expect(cls).toContain('bg-surface');
+      expect(cls).toContain('border-border');
+      // No bespoke raw-colour card chrome.
+      expect(cls).not.toContain('bg-white');
+      expect(cls).not.toContain('dark:bg-gray-800');
+      expect(cls).not.toContain('rounded-2xl');
+    });
+
+    it('renders the Open CTA on the accent token (no raw blue-600)', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      const open = screen.getByRole('link', { name: /^open$/i });
+      expect(open.className).toContain('bg-accent');
+      expect(open.className).not.toContain('bg-blue-600');
+    });
+
+    it('renders the appless primary action on the accent token', () => {
+      const applessCard: PortalCard = {
+        ...baseCard,
+        id: 'claude-dev:default',
+        name: 'claude-dev',
+        label: 'Claude Dev',
+        url: '',
+        primaryAction: {
+          type: 'in_app',
+          label: 'Open terminal',
+          href: '/terminal?node=Local&container=claude-dev',
+          desktop_only: false,
+        },
+      };
+      render(<PortalGrid cards={[applessCard]} />);
+      const cta = screen.getByRole('link', { name: /open terminal/i });
+      expect(cta.className).toContain('bg-accent');
+      expect(cta.className).not.toContain('bg-blue-600');
+    });
+
+    it('renders the card icon chip on the accent token', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      // The lucide icon chip wraps the svg in an accent-tinted div.
+      const heading = screen.getByRole('heading', { name: 'Photos' });
+      const header = heading.closest('div.rounded-card')!.querySelector('div.bg-accent\\/15');
+      expect(header).not.toBeNull();
+    });
+
+    it('renders the recommended-app link on the accent token (function preserved)', () => {
+      const card: PortalCard = {
+        ...baseCard,
+        recommendedApps: [{ name: 'Immich App', url: 'https://immich.app', platforms: ['ios'] }],
+      };
+      render(<PortalGrid cards={[card]} />);
+      const app = screen.getByRole('link', { name: 'Immich App' });
+      expect(app.getAttribute('href')).toBe('https://immich.app');
+      expect(app.className).toContain('text-accent');
+    });
+  });
+
+  describe('Syncthing pairing QR preserved through migration (#2107)', () => {
+    const syncCard: PortalCard = {
+      ...baseCard,
+      id: 'file-share:SYNCTHING_SUBDOMAIN',
+      name: 'file-share',
+      label: 'File Share',
+      setupAssets: [{ kind: 'syncthing_qr', description: 'Pair your phone.' }],
+    };
+
+    it('renders the pair button on tokens and keeps the fetch-on-click QR flow', () => {
+      render(<PortalGrid cards={[syncCard]} />);
+      const btn = screen.getByRole('button', { name: /pair/i });
+      expect(btn.className).toContain('bg-accent');
+      expect(btn.className).not.toContain('bg-emerald-600');
+      // Modal heading appears only after click (QR fetched lazily).
+      expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
+      fireEvent.click(btn);
+      expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
     });
   });
 });

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -13,6 +13,7 @@ import {
   Sparkles, X,
 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
+import { Card } from '@/components/ui';
 import type { PortalCard } from '@/lib/portal/services';
 import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
 
@@ -29,6 +30,29 @@ const SIZE_TIER_SPAN: Record<PortalCard['sizeTier'], string> = {
   regular: 'md:col-span-4', // 3 per row
   feature: 'md:col-span-6', // 2 per row
 };
+
+/**
+ * Shared anchor/button class-chains on the design-system tokens (epic
+ * #2071). The portal's primary affordances are links (Open the service,
+ * download an asset) rather than <button>s, so they can't use the
+ * <Button> primitive directly — these mirror its primary/secondary
+ * padding/radius/hover story on the same `accent`/`surface` tokens so
+ * the portal stays coherent with the admin dashboard. The portal keeps a
+ * slightly friendlier full-width pill feel, but every colour resolves
+ * through a token (dark-mode-correct, no raw hex / blue-600 literals).
+ */
+const PORTAL_CTA_BUTTON =
+  'flex items-center justify-center gap-space-2 w-full rounded-card font-medium py-2.5 ' +
+  'bg-accent text-on-accent hover:bg-accent-strong transition-colors';
+/** Smaller full-width accent link for per-card setup-asset actions
+ *  (download / pair / install). Same accent token, compact height. */
+const PORTAL_LINK_BUTTON =
+  'flex items-center justify-center gap-space-2 w-full rounded-card text-sm font-medium py-2 ' +
+  'bg-accent text-on-accent hover:bg-accent-strong transition-colors';
+/** Neutral, bordered secondary action on surface tokens. */
+const PORTAL_SECONDARY_BUTTON =
+  'flex items-center justify-center gap-space-2 w-full rounded-card text-sm font-medium py-2 ' +
+  'bg-surface-2 text-text border border-border hover:bg-surface-muted hover:border-border-strong transition-colors';
 
 /** Maps the kebab-case Lucide names allowlisted in user-guide
  *  frontmatter to their imported components. Keep in sync with
@@ -174,38 +198,39 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
     <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-start">
       {cards.map(card => {
         return (
-          <div
+          <Card
             key={card.id}
-            className={`bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden flex flex-col col-span-1 ${SIZE_TIER_SPAN[card.sizeTier]}`}
+            padding="none"
+            className={`overflow-hidden flex flex-col col-span-1 ${SIZE_TIER_SPAN[card.sizeTier]}`}
           >
             {/* Header — icon + title + tagline. The tagline is clamped
                 to 3 lines; height is content-driven now (#1700), so the
                 old `min-h` equal-Y filler is dropped — `items-start` on
                 the grid stops the row-stretch. */}
-            <div className="p-6 pb-3">
+            <div className="p-space-5 pb-space-3">
               <CardIcon card={card} />
-              <div className="flex items-center gap-2">
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">{card.label}</h2>
+              <div className="flex items-center gap-space-2">
+                <h2 className="text-xl font-bold text-text">{card.label}</h2>
                 <StatusBadge status={card.status} reason={card.statusReason} />
               </div>
-              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-3">
+              <p className="mt-space-2 text-sm text-text-muted line-clamp-3">
                 {card.tagline ?? ''}
               </p>
             </div>
 
             {/* CTA — at fixed offset from card top thanks to the
                 clamped header above. Consistent Y across cards. An
-                Open-URL card shows the blue "Open" button; a URL-less
+                Open-URL card shows the accent "Open" button; a URL-less
                 appless card (#1618) shows its primary action instead,
                 followed by any secondary action buttons. */}
-            <div className="px-6 space-y-2">
+            <div className="px-space-5 space-y-space-2">
               <CardCta card={card} isMobile={isMobile} />
             </div>
 
             {/* Variable content below. Height is content-driven (#1700) —
                 no `flex-1` filler; cards no longer stretch to a row's
                 tallest sibling. */}
-            <div className="px-6 pt-3 pb-6 space-y-3">
+            <div className="px-space-5 pt-space-3 pb-space-5 space-y-space-3">
 
               {card.setupAssets.length > 0 && (
                 <div className="space-y-1.5">
@@ -219,12 +244,12 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                         <div key={asset.kind}>
                           <a
                             href={`/api/portal/asset/${card.name}/${asset.kind}?subdomain_var=${encodeURIComponent(card.subdomainVar)}`}
-                            className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+                            className={PORTAL_LINK_BUTTON}
                           >
                             <Icon size={14} /> {label}
                           </a>
                           {asset.description && (
-                            <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 leading-snug text-center">{asset.description}</p>
+                            <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{asset.description}</p>
                           )}
                         </div>
                       );
@@ -254,8 +279,8 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
               )}
 
               {card.recommendedApps.length > 0 && (
-                <div className="pt-2 space-y-1.5">
-                  <div className="text-[11px] uppercase tracking-wide font-medium text-gray-500 dark:text-gray-400">
+                <div className="pt-space-2 space-y-1.5">
+                  <div className="text-[11px] uppercase tracking-wide font-medium text-text-muted">
                     <Sparkles size={11} className="inline align-middle -mt-0.5" /> Recommended apps
                   </div>
                   <ul className="space-y-1.5">
@@ -266,21 +291,21 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                             href={app.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="font-medium text-blue-700 dark:text-blue-300 hover:underline"
+                            className="font-medium text-accent hover:underline"
                           >
                             {app.name}
                           </a>
                           {app.platforms?.map(p => (
                             <span
                               key={p}
-                              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-chip bg-surface-2 text-text-muted"
                             >
                               {PLATFORM_LABELS[p]}
                             </span>
                           ))}
                         </div>
                         {app.note && (
-                          <p className="text-gray-500 dark:text-gray-400 mt-0.5 leading-snug">
+                          <p className="text-text-subtle mt-0.5 leading-snug">
                             {app.note}
                           </p>
                         )}
@@ -294,7 +319,7 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                 <div>
                   <button
                     onClick={() => setActiveCardId(card.id)}
-                    className="flex items-center gap-1 text-sm text-blue-700 dark:text-blue-300 hover:underline mt-2"
+                    className="flex items-center gap-1 text-sm text-accent hover:underline mt-space-2"
                     aria-haspopup="dialog"
                   >
                     How do I use this?
@@ -302,7 +327,7 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                 </div>
               )}
             </div>
-          </div>
+          </Card>
         );
       })}
     </div>
@@ -331,22 +356,22 @@ function StatusBadge({ status, reason }: { status: PortalCard['status']; reason?
     return (
       <span
         title={reason ?? 'Online'}
-        className="inline-block w-2 h-2 rounded-full bg-emerald-500 shrink-0"
+        className="inline-block w-2 h-2 rounded-chip bg-status-ok shrink-0"
         aria-label="Online"
       />
     );
   }
   const isDown = status === 'down';
   const classes = isDown
-    ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300'
-    : 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300';
-  const dot = isDown ? 'bg-red-500' : 'bg-amber-500';
+    ? 'bg-status-fail/15 text-status-fail'
+    : 'bg-status-warn/15 text-status-warn';
+  const dot = isDown ? 'bg-status-fail' : 'bg-status-warn';
   return (
     <span
       title={reason ?? (isDown ? 'Down' : 'Degraded')}
-      className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded shrink-0 ${classes}`}
+      className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-chip shrink-0 ${classes}`}
     >
-      <span className={`inline-block w-1.5 h-1.5 rounded-full ${dot}`} />
+      <span className={`inline-block w-1.5 h-1.5 rounded-chip ${dot}`} />
       {isDown ? 'Down' : 'Degraded'}
     </span>
   );
@@ -370,7 +395,7 @@ function CardCta({ card, isMobile }: { card: PortalCard; isMobile: boolean }) {
         href={card.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center justify-center gap-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors"
+        className={PORTAL_CTA_BUTTON}
       >
         Open <ExternalLink size={16} />
       </a>
@@ -384,7 +409,7 @@ function CardCta({ card, isMobile }: { card: PortalCard; isMobile: boolean }) {
         <ActionButton action={card.primaryAction} variant="primary" />
       )}
       {card.primaryAction && primaryHidden && (
-        <p className="text-[11px] text-gray-500 dark:text-gray-400 text-center leading-snug">
+        <p className="text-[11px] text-text-subtle text-center leading-snug">
           {card.primaryAction.label} is available on desktop.
         </p>
       )}
@@ -412,10 +437,7 @@ function ActionButton({
   variant: 'primary' | 'secondary';
 }) {
   const Icon = action.icon ? PORTAL_ICON_MAP[action.icon] : action.type === 'external_scheme' ? Code : TerminalSquare;
-  const className =
-    variant === 'primary'
-      ? 'flex items-center justify-center gap-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors'
-      : 'flex items-center justify-center gap-2 w-full bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-100 text-sm font-medium py-2 rounded-lg transition-colors';
+  const className = variant === 'primary' ? PORTAL_CTA_BUTTON : PORTAL_SECONDARY_BUTTON;
   // in_app links stay in the tab (same-origin app surface); external
   // schemes open via the same anchor — the OS intercepts the scheme.
   const sameTab = action.type === 'in_app';
@@ -449,19 +471,20 @@ function CardHelpModal({ card, onClose }: { card: PortalCard; onClose: () => voi
       onClick={onClose}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 sm:p-8"
     >
-      <div
+      <Card
+        padding="none"
         onClick={e => e.stopPropagation()}
-        className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[85vh] overflow-hidden flex flex-col"
+        className="shadow-2xl max-w-2xl w-full max-h-[85vh] overflow-hidden flex flex-col"
       >
-        <div className="flex items-start justify-between gap-4 p-5 border-b border-gray-100 dark:border-gray-800">
-          <div className="flex items-center gap-3 min-w-0">
+        <div className="flex items-start justify-between gap-space-4 p-space-4 border-b border-border">
+          <div className="flex items-center gap-space-3 min-w-0">
             <CardIcon card={card} compact />
             <div className="min-w-0">
-              <h2 id={`help-${card.id}-title`} className="text-lg font-bold text-gray-900 dark:text-white truncate">
+              <h2 id={`help-${card.id}-title`} className="text-lg font-bold text-text truncate">
                 {card.label}
               </h2>
               {card.tagline && (
-                <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{card.tagline}</p>
+                <p className="text-sm text-text-muted truncate">{card.tagline}</p>
               )}
             </div>
           </div>
@@ -469,17 +492,17 @@ function CardHelpModal({ card, onClose }: { card: PortalCard; onClose: () => voi
             type="button"
             aria-label="Close"
             onClick={onClose}
-            className="shrink-0 p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+            className="shrink-0 p-1 rounded-card text-text-subtle hover:text-text hover:bg-surface-2"
           >
             <X size={20} />
           </button>
         </div>
-        <div className="overflow-y-auto px-6 py-5">
-          <div className="prose prose-sm dark:prose-invert max-w-none text-gray-700 dark:text-gray-300">
+        <div className="overflow-y-auto px-space-5 py-space-4">
+          <div className="prose prose-sm dark:prose-invert max-w-none text-text-muted">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{card.body}</ReactMarkdown>
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 }
@@ -494,15 +517,15 @@ function CardHelpModal({ card, onClose }: { card: PortalCard; onClose: () => voi
  */
 function ManualPairingPanel({ steps }: { steps: PortalCard['manualPairing'] }) {
   return (
-    <div className="pt-2 space-y-2 rounded-lg border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 p-3">
-      <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide font-semibold text-amber-700 dark:text-amber-300">
+    <div className="pt-space-2 space-y-space-2 rounded-card border border-status-warn/40 bg-status-warn/10 p-space-3">
+      <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide font-semibold text-status-warn">
         <Terminal size={12} className="shrink-0" /> Manual setup needed
       </div>
       {steps.map(step => (
-        <div key={step.title} className="space-y-1">
-          <p className="text-xs font-medium text-amber-900 dark:text-amber-100">{step.title}</p>
+        <div key={step.title} className="space-y-space-1">
+          <p className="text-xs font-medium text-text">{step.title}</p>
           {step.why && (
-            <p className="text-[11px] text-amber-800/90 dark:text-amber-200/80 leading-snug">{step.why}</p>
+            <p className="text-[11px] text-text-muted leading-snug">{step.why}</p>
           )}
           <CommandBlock command={step.command} />
         </div>
@@ -533,14 +556,14 @@ function CommandBlock({ command }: { command: string }) {
   };
   return (
     <div className="flex items-stretch gap-1.5">
-      <code className="flex-1 min-w-0 overflow-x-auto rounded bg-amber-100/70 dark:bg-amber-950/40 px-2 py-1.5 text-[11px] font-mono text-amber-900 dark:text-amber-100 whitespace-pre">
+      <code className="flex-1 min-w-0 overflow-x-auto rounded-chip bg-surface-muted px-2 py-1.5 text-[11px] font-mono text-text whitespace-pre">
         {command}
       </code>
       <button
         type="button"
         onClick={onCopy}
         aria-label={copied ? 'Copied' : 'Copy command'}
-        className="shrink-0 inline-flex items-center justify-center w-8 rounded bg-amber-200/70 dark:bg-amber-800/40 text-amber-800 dark:text-amber-200 hover:bg-amber-300/70 dark:hover:bg-amber-700/50 transition-colors"
+        className="shrink-0 inline-flex items-center justify-center w-8 rounded-chip bg-surface-2 text-text-muted hover:bg-surface-muted hover:text-text transition-colors"
       >
         {copied ? <Check size={14} /> : <Copy size={14} />}
       </button>
@@ -606,15 +629,15 @@ function DeepLinkButton({
     <div>
       <button
         onClick={onClick}
-        className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+        className={PORTAL_LINK_BUTTON}
       >
         <Icon size={14} /> {label}
       </button>
       {description && !error && (
-        <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 leading-snug text-center">{description}</p>
+        <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
       )}
       {error && (
-        <p className="text-[11px] text-red-600 dark:text-red-400 mt-1 leading-snug text-center">{error}</p>
+        <p className="text-[11px] text-status-fail mt-space-1 leading-snug text-center">{error}</p>
       )}
     </div>
   );
@@ -653,12 +676,12 @@ function BasicSyncInstallQrButton({
       <div>
         <button
           onClick={() => setOpen(true)}
-          className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+          className={PORTAL_LINK_BUTTON}
         >
           <Icon size={14} /> {label}
         </button>
         {description && (
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 leading-snug text-center">{description}</p>
+          <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
         )}
       </div>
 
@@ -671,15 +694,17 @@ function BasicSyncInstallQrButton({
  *  to keep the button under the per-function line budget. */
 function BasicSyncInstallModal({ qrUrl, onClose }: { qrUrl: string; onClose: () => void }) {
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={onClose}>
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-sm w-full p-6 text-center" onClick={e => e.stopPropagation()}>
-        <h2 className="text-lg font-bold text-gray-900 dark:text-white">Install BasicSync</h2>
-        <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-space-4 z-50" onClick={onClose}>
+      <Card className="shadow-xl max-w-sm w-full p-space-5 text-center" onClick={e => e.stopPropagation()}>
+        <h2 className="text-lg font-bold text-text">Install BasicSync</h2>
+        <p className="text-xs text-text-muted mt-space-1">
           Point your phone camera at this QR to download the BasicSync app — a trusted, open-source Syncthing client. Once it&apos;s installed, use the <strong>Pair this device</strong> button to connect.
         </p>
 
-        <div className="mt-5 flex justify-center">
-          <div className="bg-white p-4 rounded-lg">
+        <div className="mt-space-4 flex justify-center">
+          {/* QR stays on a literal white tile — scanners need maximum
+              contrast regardless of light/dark theme. */}
+          <div className="bg-white p-space-3 rounded-card">
             <QRCodeSVG value={qrUrl} size={192} level="M" />
           </div>
         </div>
@@ -688,11 +713,11 @@ function BasicSyncInstallModal({ qrUrl, onClose }: { qrUrl: string; onClose: () 
           href={BASICSYNC_INSTALL_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-block text-xs text-blue-700 dark:text-blue-300 hover:underline break-all"
+          className="mt-space-3 inline-block text-xs text-accent hover:underline break-all"
         >
           Or open the download link directly
         </a>
-      </div>
+      </Card>
     </div>
   );
 }
@@ -752,48 +777,49 @@ function SyncthingQrButton({
       <div>
         <button
           onClick={onOpen}
-          className="flex items-center justify-center gap-2 w-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+          className={PORTAL_LINK_BUTTON}
         >
           <Icon size={14} /> {label}
         </button>
         {description && (
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1 leading-snug text-center">{description}</p>
+          <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
         )}
       </div>
 
       {open && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={() => setOpen(false)}>
-          <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl max-w-sm w-full p-6 text-center" onClick={e => e.stopPropagation()}>
-            <h2 className="text-lg font-bold text-gray-900 dark:text-white">Pair this device</h2>
-            <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-space-4 z-50" onClick={() => setOpen(false)}>
+          <Card className="shadow-xl max-w-sm w-full p-space-5 text-center" onClick={e => e.stopPropagation()}>
+            <h2 className="text-lg font-bold text-text">Pair this device</h2>
+            <p className="text-xs text-text-muted mt-space-1">
               In the Syncthing Android app, tap <strong>+</strong> → <strong>Add Device</strong> → <strong>Scan QR</strong>, then point your camera here.
             </p>
 
-            <div className="mt-5 flex justify-center min-h-[12rem] items-center">
-              {loading && <Loader2 className="animate-spin text-blue-500" size={32} />}
+            <div className="mt-space-4 flex justify-center min-h-[12rem] items-center">
+              {loading && <Loader2 className="animate-spin text-accent" size={32} />}
               {!loading && error && (
-                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+                <p className="text-sm text-status-fail">{error}</p>
               )}
               {!loading && deviceId && (
-                <div className="bg-white p-4 rounded-lg">
+                /* QR stays on a literal white tile for scanner contrast. */
+                <div className="bg-white p-space-3 rounded-card">
                   <QRCodeSVG value={deviceId} size={192} level="M" />
                 </div>
               )}
             </div>
 
             {deviceId && (
-              <p className="mt-3 text-[10px] font-mono text-gray-500 dark:text-gray-400 break-all">
+              <p className="mt-space-3 text-[10px] font-mono text-text-subtle break-all">
                 {deviceId}
               </p>
             )}
 
             <button
               onClick={() => setOpen(false)}
-              className="mt-4 px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+              className="mt-space-4 px-space-4 py-space-2 text-sm text-text-muted hover:text-text"
             >
               Close
             </button>
-          </div>
+          </Card>
         </div>
       )}
     </>
@@ -815,22 +841,22 @@ function CardIcon({ card, compact = false }: { card: PortalCard; compact?: boole
   // shrinks the chip + drops the trailing margin so the icon sits
   // flush with the title block. The card grid keeps the original size.
   const wrapper = compact
-    ? 'inline-flex items-center justify-center w-10 h-10 rounded-xl'
-    : 'mb-3 inline-flex items-center justify-center w-14 h-14 rounded-2xl';
+    ? 'inline-flex items-center justify-center w-10 h-10 rounded-card'
+    : 'mb-space-3 inline-flex items-center justify-center w-14 h-14 rounded-card';
   const iconSize = compact ? 22 : 28;
   if (card.lucideIcon) {
     const Icon = PORTAL_ICON_MAP[card.lucideIcon];
     return (
-      <div className={`${wrapper} bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400`}>
+      <div className={`${wrapper} bg-accent/15 text-accent`}>
         <Icon size={iconSize} strokeWidth={1.75} />
       </div>
     );
   }
   if (card.icon) {
-    return <div className={compact ? 'text-3xl' : 'text-5xl mb-3'} aria-hidden>{card.icon}</div>;
+    return <div className={compact ? 'text-3xl' : 'text-5xl mb-space-3'} aria-hidden>{card.icon}</div>;
   }
   return (
-    <div className={`${wrapper} bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400`}>
+    <div className={`${wrapper} bg-surface-2 text-text-muted`}>
       <Package size={iconSize} strokeWidth={1.75} />
     </div>
   );

--- a/packages/frontend/src/app/portal/PortalLogoutLink.tsx
+++ b/packages/frontend/src/app/portal/PortalLogoutLink.tsx
@@ -28,10 +28,10 @@ function derive(): string {
 export default function PortalLogoutLink() {
   const href = useSyncExternalStore(noopSubscribe, derive, () => '/portal');
   return (
-    <div className="mt-4">
+    <div className="mt-space-4">
       <a
         href={href}
-        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+        className="inline-flex items-center gap-1.5 text-sm text-text-muted hover:text-text"
       >
         <LogOut size={14} />
         Log out

--- a/packages/frontend/src/app/portal/PortalUserChip.tsx
+++ b/packages/frontend/src/app/portal/PortalUserChip.tsx
@@ -34,16 +34,16 @@ export default function PortalUserChip({ displayName }: { displayName: string })
   const initial = displayName.charAt(0).toUpperCase();
 
   return (
-    <div className="absolute top-6 right-6 flex items-center gap-2 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-full pl-2 pr-1 py-1 shadow-sm">
-      <div className="shrink-0 w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-700 dark:text-blue-300 font-bold text-xs">
+    <div className="absolute top-space-5 right-space-5 flex items-center gap-space-2 bg-surface/80 backdrop-blur border border-border rounded-full pl-2 pr-1 py-1 shadow-sm">
+      <div className="shrink-0 w-7 h-7 rounded-full bg-accent/15 flex items-center justify-center text-accent font-bold text-xs">
         {initial || <UserIcon size={14} />}
       </div>
-      <span className="text-sm font-semibold text-gray-800 dark:text-gray-200 max-w-[10rem] truncate">
+      <span className="text-sm font-semibold text-text max-w-[10rem] truncate">
         {displayName}
       </span>
       <a
         href={logoutHref}
-        className="ml-1 inline-flex items-center justify-center w-7 h-7 rounded-full text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-700/60 transition-colors"
+        className="ml-1 inline-flex items-center justify-center w-7 h-7 rounded-full text-text-muted hover:text-text hover:bg-surface-2 transition-colors"
         title="Log out — drops the Authelia session"
         aria-label="Log out"
       >

--- a/packages/frontend/src/app/portal/RequestAccessButton.tsx
+++ b/packages/frontend/src/app/portal/RequestAccessButton.tsx
@@ -13,6 +13,14 @@ import { UserPlus, Loader2 } from 'lucide-react';
  * gather the profile data so approval is one click rather than a
  * round-trip to ask the requester for a username.
  */
+/** Shared token-wired classes for the request-access form controls so
+ *  the inputs/labels read as one consistent, design-system surface
+ *  (dark-mode-correct, no raw gray-300/blue-500 literals). */
+const FIELD_LABEL = 'block text-xs font-medium text-text-muted';
+const FIELD_INPUT =
+  'w-full px-space-3 py-space-2 text-sm rounded-card border border-border bg-surface-2 ' +
+  'text-text placeholder:text-text-subtle focus:outline-none focus:ring-2 focus:ring-accent';
+
 export default function RequestAccessButton() {
   const [open, setOpen] = useState(false);
   const [firstName, setFirstName] = useState('');
@@ -89,10 +97,10 @@ export default function RequestAccessButton() {
 
   return (
     <>
-      <div className="mt-12 text-center">
+      <div className="mt-space-7 text-center">
         <button
           onClick={() => setOpen(true)}
-          className="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 hover:border-blue-500 hover:text-blue-700 dark:hover:text-blue-300 text-sm font-medium text-gray-700 dark:text-gray-300 rounded-full transition-colors"
+          className="inline-flex items-center gap-space-2 px-space-4 py-2.5 bg-surface border border-border hover:border-accent hover:text-accent text-sm font-medium text-text-muted rounded-full transition-colors"
         >
           <UserPlus size={16} />
           Don&apos;t have an account yet?
@@ -105,36 +113,36 @@ export default function RequestAccessButton() {
           onClick={onClose}
         >
           <div
-            className="glass-panel rounded-2xl shadow-2xl max-w-md w-full p-8 max-h-[90vh] overflow-y-auto border border-gray-200/50 dark:border-white/10"
+            className="glass-panel rounded-card shadow-2xl max-w-md w-full p-space-6 max-h-[90vh] overflow-y-auto border border-border"
             onClick={e => e.stopPropagation()}
           >
             {submitted ? (
-              <div className="text-center py-8 space-y-4">
+              <div className="text-center py-space-6 space-y-space-4">
                 <div className="text-5xl animate-bounce">✨</div>
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white tracking-wide">Request Sent Successfully!</h2>
-                <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed font-medium">
+                <h2 className="text-2xl font-bold text-text tracking-wide">Request Sent Successfully!</h2>
+                <p className="text-sm text-text-muted leading-relaxed font-medium">
                   The family administrator has been notified. They will create your account in the local identity pool and notify you when it is ready.
                 </p>
                 <button
                   onClick={onClose}
-                  className="mt-4 px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-lg shadow transition-colors"
+                  className="mt-space-4 px-space-5 py-2.5 bg-accent hover:bg-accent-strong text-on-accent text-sm font-semibold rounded-card shadow transition-colors"
                 >
                   Got it
                 </button>
               </div>
             ) : (
-              <form onSubmit={onSubmit} className="space-y-5">
+              <form onSubmit={onSubmit} className="space-y-space-5">
                 <div>
-                  <h2 className="text-2xl font-extrabold text-gray-900 dark:text-white tracking-wide">Request Access</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1.5 font-medium leading-relaxed">
+                  <h2 className="text-2xl font-extrabold text-text tracking-wide">Request Access</h2>
+                  <p className="text-sm text-text-muted mt-1.5 font-medium leading-relaxed">
                     The administrator will create your personal account. Enter your details below to get started.
                   </p>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1">
-                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                      First name <span className="text-red-500">*</span>
+                <div className="grid grid-cols-2 gap-space-3">
+                  <div className="space-y-space-1">
+                    <label className={FIELD_LABEL}>
+                      First name <span className="text-status-fail">*</span>
                     </label>
                     <input
                       type="text"
@@ -143,12 +151,12 @@ export default function RequestAccessButton() {
                       required
                       maxLength={60}
                       autoComplete="given-name"
-                      className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={FIELD_INPUT}
                     />
                   </div>
-                  <div className="space-y-1">
-                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                      Last name <span className="text-red-500">*</span>
+                  <div className="space-y-space-1">
+                    <label className={FIELD_LABEL}>
+                      Last name <span className="text-status-fail">*</span>
                     </label>
                     <input
                       type="text"
@@ -157,14 +165,14 @@ export default function RequestAccessButton() {
                       required
                       maxLength={60}
                       autoComplete="family-name"
-                      className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={FIELD_INPUT}
                     />
                   </div>
                 </div>
 
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                    Desired username <span className="text-red-500">*</span>
+                <div className="space-y-space-1">
+                  <label className={FIELD_LABEL}>
+                    Desired username <span className="text-status-fail">*</span>
                   </label>
                   <input
                     type="text"
@@ -176,16 +184,16 @@ export default function RequestAccessButton() {
                     pattern="[a-z0-9._\-]{1,60}"
                     autoComplete="username"
                     placeholder="e.g. max.mustermann"
-                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={FIELD_INPUT}
                   />
-                  <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] text-text-subtle">
                     Your login — lowercase letters, digits, dots, underscores, and hyphens only. Can&apos;t be changed later.
                   </p>
                 </div>
 
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                    Your email <span className="text-red-500">*</span>
+                <div className="space-y-space-1">
+                  <label className={FIELD_LABEL}>
+                    Your email <span className="text-status-fail">*</span>
                   </label>
                   <input
                     type="email"
@@ -194,13 +202,13 @@ export default function RequestAccessButton() {
                     required
                     maxLength={200}
                     autoComplete="email"
-                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={FIELD_INPUT}
                   />
                 </div>
 
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                    Anything else? <span className="text-gray-400">(optional)</span>
+                <div className="space-y-space-1">
+                  <label className={FIELD_LABEL}>
+                    Anything else? <span className="text-text-subtle">(optional)</span>
                   </label>
                   <textarea
                     value={message}
@@ -208,28 +216,28 @@ export default function RequestAccessButton() {
                     maxLength={1000}
                     rows={3}
                     placeholder="e.g. which services you'd like access to"
-                    className="w-full px-3 py-2 text-sm rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={FIELD_INPUT}
                   />
                 </div>
 
                 {error && (
-                  <div className="px-3 py-2 text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 rounded">
+                  <div className="px-space-3 py-space-2 text-xs text-status-fail bg-status-fail/10 rounded-card">
                     {error}
                   </div>
                 )}
 
-                <div className="flex justify-end gap-2 pt-2">
+                <div className="flex justify-end gap-space-2 pt-space-2">
                   <button
                     type="button"
                     onClick={onClose}
-                    className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+                    className="px-space-4 py-space-2 text-sm text-text-muted hover:text-text"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
                     disabled={submitting}
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+                    className="inline-flex items-center gap-space-2 px-space-4 py-space-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-card disabled:opacity-50"
                   >
                     {submitting && <Loader2 size={14} className="animate-spin" />}
                     Send request

--- a/packages/frontend/src/app/portal/layout.tsx
+++ b/packages/frontend/src/app/portal/layout.tsx
@@ -31,7 +31,7 @@ export const viewport: Viewport = {
 
 export default function PortalLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950">
+    <div className="min-h-screen bg-gradient-to-b from-accent/5 to-surface-muted">
       {children}
     </div>
   );

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -65,45 +65,45 @@ export default async function PortalPage() {
   const adminUrl = getAdminBaseUrl(config);
 
   return (
-    <main className="relative max-w-6xl mx-auto px-6 py-12">
+    <main className="relative max-w-6xl mx-auto px-space-5 py-space-7">
       {isLoggedIn && displayName && <PortalUserChip displayName={displayName} />}
-      <header className="mb-10 text-center">
-        <div className="flex items-center justify-center gap-3">
-          <ServiceBayLogo size={36} className="text-blue-600 dark:text-blue-400 shrink-0" />
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
-            Home <span className="text-gray-400 dark:text-gray-600 font-normal">— your family&apos;s private cloud</span>
+      <header className="mb-space-7 text-center">
+        <div className="flex items-center justify-center gap-space-3">
+          <ServiceBayLogo size={36} className="text-accent shrink-0" />
+          <h1 className="text-4xl font-bold text-text">
+            Home <span className="text-text-subtle font-normal">— your family&apos;s private cloud</span>
           </h1>
         </div>
-        <p className="mt-3 text-base text-gray-600 dark:text-gray-400">
+        <p className="mt-space-3 text-base text-text-muted">
           {isLoggedIn && firstName
             ? `Welcome back, ${firstName} — pick a service below to get started.`
             : 'Pick a service below to get started.'}
         </p>
         {isLoggedIn && <PortalLogoutLink />}
         {adminUrl && (
-          <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+          <p className="mt-space-4 text-sm text-text-subtle">
             <a
               href={adminUrl}
-              className="inline-flex items-center gap-1.5 text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline-offset-2 hover:underline"
+              className="inline-flex items-center gap-1.5 text-text-muted hover:text-text underline-offset-2 hover:underline"
             >
               <Settings size={14} />
               Admin dashboard
             </a>
-            <span className="ml-1.5 text-gray-400 dark:text-gray-500">(separate login)</span>
+            <span className="ml-1.5 text-text-subtle">(separate login)</span>
           </p>
         )}
       </header>
 
       {!isLoggedIn && (
-        <div className="mb-10">
+        <div className="mb-space-7">
           <AccessRequestStatusCTA fallback={<RequestAccessButton />} />
         </div>
       )}
 
       {cards.length === 0 ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-16">
+        <div className="text-center text-text-muted py-space-8">
           <p className="text-lg">No services available yet.</p>
-          <p className="text-sm mt-2 italic">
+          <p className="text-sm mt-space-2 italic">
             (Services appear here once they&apos;re running and a user-guide is shipped with their template.)
           </p>
         </div>
@@ -118,15 +118,15 @@ export default async function PortalPage() {
  *  visitor isn't on the home network (#1456). */
 function PortalLanOnlyNotice() {
   return (
-    <main className="relative max-w-2xl mx-auto px-6 py-24 text-center">
-      <div className="flex items-center justify-center gap-3 mb-6">
-        <ServiceBayLogo size={36} className="text-blue-600 dark:text-blue-400 shrink-0" />
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Home</h1>
+    <main className="relative max-w-2xl mx-auto px-space-5 py-space-8 text-center">
+      <div className="flex items-center justify-center gap-space-3 mb-space-5">
+        <ServiceBayLogo size={36} className="text-accent shrink-0" />
+        <h1 className="text-3xl font-bold text-text">Home</h1>
       </div>
-      <p className="text-lg text-gray-700 dark:text-gray-300">
+      <p className="text-lg text-text">
         This page is available on the home network only.
       </p>
-      <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+      <p className="mt-space-3 text-sm text-text-muted">
         Connect to the home Wi-Fi (or its VPN) and reload to request access or open a service.
       </p>
     </main>

--- a/packages/frontend/src/components/ServiceCard.test.tsx
+++ b/packages/frontend/src/components/ServiceCard.test.tsx
@@ -8,6 +8,9 @@ import { render, screen } from '@testing-library/react';
 import type { ServiceViewModel } from '@servicebay/api-client';
 import ServiceCard, { type ServiceCardProps } from './ServiceCard';
 
+const push = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+
 vi.mock('@/components/DomainHealthDot', () => ({
   DomainHealthDot: () => null,
 }));
@@ -55,6 +58,15 @@ describe('ServiceCard (#2079 primitive migration)', () => {
     );
     screen.getByRole('button', { name: /update now/i }).click();
     expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('#2108 renders the network-focus button and navigates to /network?focus=<name>', () => {
+    push.mockClear();
+    render(<ServiceCard service={svc()} httpsDomains={new Set()} {...handlers} />);
+    const btn = screen.getByRole('button', { name: 'Im Netzwerk anzeigen' });
+    expect(btn.getAttribute('data-variant')).toBe('ghost');
+    btn.click();
+    expect(push).toHaveBeenCalledWith('/network?focus=immich.service');
   });
 
   it('surfaces the failed-state restart nudge (and uses no raw colour literals)', () => {

--- a/packages/frontend/src/components/ServiceCard.tsx
+++ b/packages/frontend/src/components/ServiceCard.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { AlertCircle, Download, RotateCcw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { AlertCircle, Crosshair, Download, RotateCcw } from 'lucide-react';
 import type { EnrichedContainer, ServiceViewModel } from '@servicebay/api-client';
 import { ServiceActionBar } from '@/components/ServiceActionBar';
+import { networkFocusHref } from '@/components/networkFocus';
 import { DomainHealthDot } from '@/components/DomainHealthDot';
 import { serviceDotState } from '@/components/ServiceRow';
 import { Badge, Button, Card, StatusDot } from '@/components/ui';
@@ -65,7 +67,10 @@ export default function ServiceCard({
   onDelete,
   onRestart,
 }: ServiceCardProps) {
+  const router = useRouter();
   const dot = serviceDotState(service);
+  // #2108: per-service "focus in network map" jump (managed services only).
+  const showNetworkFocus = service.type !== 'gateway' && service.type !== 'link';
   return (
     <Card padding="md" className="group self-start hover:shadow-md transition-all duration-200 relative overflow-hidden min-w-0">
       <div className="flex items-start gap-4 justify-between mb-3">
@@ -115,6 +120,19 @@ export default function ServiceCard({
             </div>
           </div>
         </div>
+        {showNetworkFocus && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push(networkFocusHref(service.name))}
+            aria-label="Im Netzwerk anzeigen"
+            title="Im Netzwerk anzeigen"
+            className="shrink-0 px-2"
+            data-testid={`network-focus-${service.displayName}`}
+          >
+            <Crosshair size={16} />
+          </Button>
+        )}
         <ServiceActionBar
           service={service}
           onMonitor={onMonitor}

--- a/packages/frontend/src/components/ServiceRow.test.tsx
+++ b/packages/frontend/src/components/ServiceRow.test.tsx
@@ -9,6 +9,9 @@ import { render, screen } from '@testing-library/react';
 import type { ServiceViewModel } from '@servicebay/api-client';
 import ServiceRow, { serviceDotState } from './ServiceRow';
 
+const push = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+
 vi.mock('@/components/DomainHealthDot', () => ({
   DomainHealthDot: () => null,
 }));
@@ -65,6 +68,20 @@ describe('ServiceRow (#2079 primitive migration)', () => {
     btn.click();
     expect(onUpdate).toHaveBeenCalledOnce();
     expect(btn.getAttribute('data-variant')).toBe('secondary');
+  });
+
+  it('#2108 renders the network-focus button and navigates to /network?focus=<name>', () => {
+    push.mockClear();
+    render(<ServiceRow service={svc()} httpsDomains={new Set()} {...handlers} />);
+    const btn = screen.getByRole('button', { name: 'Im Netzwerk anzeigen' });
+    expect(btn.getAttribute('data-variant')).toBe('ghost');
+    btn.click();
+    expect(push).toHaveBeenCalledWith('/network?focus=immich.service');
+  });
+
+  it('#2108 hides the network-focus button for external-link "services"', () => {
+    render(<ServiceRow service={svc({ type: 'link', url: 'http://x' })} httpsDomains={new Set()} {...handlers} />);
+    expect(screen.queryByRole('button', { name: 'Im Netzwerk anzeigen' })).toBeNull();
   });
 
   it('uses semantic tokens, not raw gray/blue/green colour literals', () => {

--- a/packages/frontend/src/components/ServiceRow.tsx
+++ b/packages/frontend/src/components/ServiceRow.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { AlertCircle, Download, RotateCcw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { AlertCircle, Crosshair, Download, RotateCcw } from 'lucide-react';
 import type { ServiceViewModel } from '@servicebay/api-client';
 import { ServiceActionBar } from '@/components/ServiceActionBar';
+import { networkFocusHref } from '@/components/networkFocus';
 import { DomainHealthDot } from '@/components/DomainHealthDot';
 import { Badge, Button, StatusDot, type StatusState } from '@/components/ui';
 
@@ -68,8 +70,12 @@ export default function ServiceRow({
   onDelete,
   onRestart,
 }: ServiceRowProps) {
+  const router = useRouter();
   const dot = serviceDotState(service);
   const showFailedNudge = !service.active && service.type !== 'gateway' && service.type !== 'link';
+  // #2108: per-service "focus in network map" jump. Only managed services have
+  // a `service-<name>` node to centre on — gateway/link nodes are out of scope.
+  const showNetworkFocus = service.type !== 'gateway' && service.type !== 'link';
 
   return (
     <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-surface-2 transition-colors min-w-0">
@@ -166,6 +172,21 @@ export default function ServiceRow({
             <RotateCcw size={12} /> Restart
           </Button>
         </div>
+      )}
+
+      {/* #2108: focus this service in the Network Map. */}
+      {showNetworkFocus && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(networkFocusHref(service.name))}
+          aria-label="Im Netzwerk anzeigen"
+          title="Im Netzwerk anzeigen"
+          className="shrink-0 px-2"
+          data-testid={`network-focus-${service.displayName}`}
+        >
+          <Crosshair size={16} />
+        </Button>
       )}
 
       {/* Action bar */}

--- a/packages/frontend/src/components/networkFocus.test.ts
+++ b/packages/frontend/src/components/networkFocus.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Network-map focus link helpers (#2108). Pure mapping between a service's
+ * canonical unit name and the graph node id the Network Map focuses on.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  NETWORK_FOCUS_PARAM,
+  networkFocusHref,
+  matchesFocusParam,
+  resolveFocusNodeId,
+  planDeepLinkFocus,
+} from './networkFocus';
+
+describe('networkFocusHref (#2108)', () => {
+  it('builds /network?focus=<encoded unit name>', () => {
+    expect(networkFocusHref('immich.service')).toBe('/network?focus=immich.service');
+    expect(NETWORK_FOCUS_PARAM).toBe('focus');
+  });
+
+  it('encodes names with special characters', () => {
+    expect(networkFocusHref('a b.service')).toBe('/network?focus=a%20b.service');
+  });
+
+  it('falls back to the bare /network route when there is no name', () => {
+    expect(networkFocusHref(undefined)).toBe('/network');
+    expect(networkFocusHref('')).toBe('/network');
+    expect(networkFocusHref('   ')).toBe('/network');
+  });
+});
+
+describe('matchesFocusParam (#2108)', () => {
+  it('matches the local service node id', () => {
+    expect(matchesFocusParam('service-immich.service', 'immich.service')).toBe(true);
+  });
+
+  it('matches the remote-host-prefixed node id', () => {
+    expect(matchesFocusParam('box2:service-immich.service', 'immich.service')).toBe(true);
+  });
+
+  it('does not match a different service or a substring', () => {
+    expect(matchesFocusParam('service-immich-extra.service', 'immich.service')).toBe(false);
+    expect(matchesFocusParam('service-other.service', 'immich.service')).toBe(false);
+    expect(matchesFocusParam('service-immich.service', '')).toBe(false);
+  });
+});
+
+describe('resolveFocusNodeId (#2108)', () => {
+  const ids = ['internet', 'service-immich.service', 'box2:service-paperless.service'];
+
+  it('resolves a local service param to its node id', () => {
+    expect(resolveFocusNodeId(ids, 'immich.service')).toBe('service-immich.service');
+  });
+
+  it('resolves a remote service param to its prefixed node id', () => {
+    expect(resolveFocusNodeId(ids, 'paperless.service')).toBe('box2:service-paperless.service');
+  });
+
+  it('returns null for a stale link (no matching node) or no param', () => {
+    expect(resolveFocusNodeId(ids, 'gone.service')).toBeNull();
+    expect(resolveFocusNodeId(ids, null)).toBeNull();
+    expect(resolveFocusNodeId(ids, undefined)).toBeNull();
+  });
+});
+
+describe('planDeepLinkFocus (#2108)', () => {
+  const ids = ['internet', 'service-immich.service'];
+
+  it('plans to focus a fresh, resolvable param', () => {
+    expect(planDeepLinkFocus(ids, 'immich.service', null)).toEqual({
+      nodeId: 'service-immich.service',
+      appliedParam: 'immich.service',
+      clearApplied: false,
+    });
+  });
+
+  it('is a no-op once the param has already been applied (manual focus stays)', () => {
+    expect(planDeepLinkFocus(ids, 'immich.service', 'immich.service')).toEqual({
+      nodeId: null,
+      appliedParam: null,
+      clearApplied: false,
+    });
+  });
+
+  it('does not focus (but records nothing) when the param matches no node', () => {
+    expect(planDeepLinkFocus(ids, 'gone.service', null)).toEqual({
+      nodeId: null,
+      appliedParam: null,
+      clearApplied: false,
+    });
+  });
+
+  it('signals clearApplied when there is no focus param (so a later re-link re-applies)', () => {
+    expect(planDeepLinkFocus(ids, null, 'immich.service')).toEqual({
+      nodeId: null,
+      appliedParam: null,
+      clearApplied: true,
+    });
+  });
+});

--- a/packages/frontend/src/components/networkFocus.ts
+++ b/packages/frontend/src/components/networkFocus.ts
@@ -1,0 +1,74 @@
+/**
+ * Network-map focus link helpers (#2108).
+ *
+ * The Services list (ServiceRow / ServiceCard) gets a per-service "focus"
+ * affordance that jumps to the Network Map with that service highlighted /
+ * centred. This module is the single source of truth for:
+ *   - the href the list button navigates to (`networkFocusHref`), and
+ *   - how the dashboard turns the `?focus=` param back into a graph node id
+ *     (`matchesFocusParam`).
+ *
+ * The network graph keys service nodes on `service-<unit-name>`, optionally
+ * prefixed with `<node>:` for remote managed hosts (see
+ * packages/backend/src/lib/network/service.ts `prefix(\`service-${name}\`)`).
+ * The list only knows the canonical unit name (`ServiceViewModel.name`, e.g.
+ * "immich.service"), so we pass that bare and let the dashboard resolve it
+ * against the rendered nodes — which transparently handles the remote-host
+ * prefix without the list having to reconstruct it.
+ */
+
+/** The query-param key the Network Map reads to focus a node. */
+export const NETWORK_FOCUS_PARAM = 'focus';
+
+/** Href to the Network Map focused on this service, keyed on the canonical
+ *  unit name. Returns the bare `/network` route when there is no name to
+ *  focus (defensive — a real service always has one). */
+export function networkFocusHref(serviceName: string | undefined | null): string {
+  const name = serviceName?.trim();
+  if (!name) return '/network';
+  return `/network?${NETWORK_FOCUS_PARAM}=${encodeURIComponent(name)}`;
+}
+
+/**
+ * True when `nodeId` is the graph node for the service named `focus`.
+ * Matches both the local form (`service-immich.service`) and the remote
+ * form (`box2:service-immich.service`) so a remote service focuses too.
+ */
+export function matchesFocusParam(nodeId: string, focus: string): boolean {
+  if (!focus) return false;
+  const wanted = `service-${focus}`;
+  return nodeId === wanted || nodeId.endsWith(`:${wanted}`);
+}
+
+/**
+ * Resolve the focus param to a concrete graph node id present in `nodeIds`,
+ * or null when nothing matches (stale link / service gone). Prefers an exact
+ * local match, then any remote-prefixed match.
+ */
+export function resolveFocusNodeId(
+  nodeIds: readonly string[],
+  focus: string | null | undefined,
+): string | null {
+  if (!focus) return null;
+  return nodeIds.find((id) => matchesFocusParam(id, focus)) ?? null;
+}
+
+/**
+ * Decide how the Network Map should react to the `?focus=` deep-link for a
+ * freshly-laid-out graph (#2108). Keeps the once-per-param-value semantics out
+ * of the dashboard's already-dense layout effect:
+ *  - `nodeId`        — the resolved node to focus (apply to layout + state), or null.
+ *  - `appliedParam`  — the param value to record as applied once committed, or null.
+ *  - `clearApplied`  — true when there is no param, so the guard ref resets and a
+ *                      later return to the same service re-applies.
+ */
+export function planDeepLinkFocus(
+  nodeIds: readonly string[],
+  focus: string | null | undefined,
+  alreadyApplied: string | null,
+): { nodeId: string | null; appliedParam: string | null; clearApplied: boolean } {
+  if (!focus) return { nodeId: null, appliedParam: null, clearApplied: true };
+  if (focus === alreadyApplied) return { nodeId: null, appliedParam: null, clearApplied: false };
+  const nodeId = resolveFocusNodeId(nodeIds, focus);
+  return { nodeId, appliedParam: nodeId ? focus : null, clearApplied: false };
+}

--- a/packages/frontend/src/dashboards/NetworkDashboard.test.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.test.tsx
@@ -18,6 +18,11 @@ import type { ReactNode } from 'react';
 
 const fetchGraph = vi.fn(() => Promise.resolve());
 
+// Mutable test doubles for the data + routing layers so individual cases can
+// drive a focus deep-link (#2108) without re-mocking per test.
+let topologyRawData: { nodes: unknown[]; edges: unknown[] } | null = null;
+let focusSearchParam: string | null = null;
+
 // @xyflow/react is heavy + canvas-bound; render Panel/ReactFlow children as
 // plain divs so the dashboard's surrounding chrome (toolbar, legend, shell)
 // mounts in jsdom. The graph itself isn't under test here.
@@ -43,7 +48,7 @@ vi.mock('@xyflow/react', () => {
 vi.mock('@xyflow/react/dist/style.css', () => ({}));
 
 vi.mock('@/hooks/useTopologyData', () => ({
-  useTopologyData: () => ({ rawData: null, fetchGraph, twin: null }),
+  useTopologyData: () => ({ rawData: topologyRawData, fetchGraph, twin: null }),
 }));
 vi.mock('@/hooks/useServiceActions', () => ({
   useServiceActions: () => ({ overlays: null }),
@@ -51,7 +56,10 @@ vi.mock('@/hooks/useServiceActions', () => ({
 vi.mock('@/providers/ToastProvider', () => ({
   useToast: () => ({ addToast: vi.fn(), updateToast: vi.fn(), removeToast: vi.fn() }),
 }));
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(focusSearchParam ? `focus=${focusSearchParam}` : ''),
+}));
 vi.mock('@/components/ExternalLinkModal', () => ({ __esModule: true, default: () => null }));
 vi.mock('@/components/serviceDetail/ServiceDetailSummary', () => ({
   __esModule: true,
@@ -64,6 +72,8 @@ import NetworkDashboard from './NetworkDashboard';
 describe('NetworkDashboard (#2100 dashboards migration)', () => {
   beforeEach(() => {
     fetchGraph.mockClear();
+    topologyRawData = null;
+    focusSearchParam = null;
     vi.stubGlobal('EventSource', class { close() {} } as unknown as typeof EventSource);
   });
 
@@ -96,5 +106,36 @@ describe('NetworkDashboard (#2100 dashboards migration)', () => {
     render(<NetworkDashboard />);
     // The map mounts the search toolbar regardless of graph state.
     expect(await screen.findByPlaceholderText('Search...')).toBeDefined();
+  });
+
+  it('#2108 applies the ?focus= deep-link → enters focus mode for the matching service node', async () => {
+    // Graph carries the immich service node the list links to.
+    topologyRawData = {
+      nodes: [
+        { id: 'internet', type: 'internet', label: 'Internet' },
+        { id: 'service-immich.service', type: 'service', label: 'immich' },
+      ],
+      edges: [],
+    };
+    focusSearchParam = 'immich.service';
+
+    render(<NetworkDashboard />);
+
+    // Focus mode is on ⇒ the "Full map" exit control renders (only present
+    // when focusNodeId is set). That proves the param was read + resolved to
+    // the matching node id and applied.
+    expect(await screen.findByTestId('focus-back')).toBeDefined();
+  });
+
+  it('#2108 does NOT enter focus mode when the focus param matches no node (stale link)', async () => {
+    topologyRawData = {
+      nodes: [{ id: 'service-other.service', type: 'service', label: 'other' }],
+      edges: [],
+    };
+    focusSearchParam = 'gone.service';
+
+    render(<NetworkDashboard />);
+    await screen.findByPlaceholderText('Search...');
+    expect(screen.queryByTestId('focus-back')).toBeNull();
   });
 });

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -2,9 +2,10 @@
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useTopologyData } from '@/hooks/useTopologyData';
+import { NETWORK_FOCUS_PARAM, planDeepLinkFocus } from '@/components/networkFocus';
 import type { PortMapping, ServiceUnit } from '@servicebay/api-client';
 import { buildServiceViewModel } from '@servicebay/api-client';
 import type { ServiceViewModel } from '@servicebay/api-client';
@@ -802,6 +803,14 @@ function NetworkLegend() {
 
 export default function NetworkDashboard() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    // #2108 — `?focus=<service-name>` from the Services list jumps here with a
+    // service to centre. We resolve it to a graph node id (handling the remote
+    // `<node>:` prefix) once the graph has loaded, and apply each distinct
+    // param value exactly once so a manual click / Back doesn't get clobbered
+    // on re-render.
+    const focusParam = searchParams.get(NETWORK_FOCUS_PARAM);
+    const appliedFocusParamRef = useRef<string | null>(null);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<GraphNodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -1252,6 +1261,9 @@ export default function NetworkDashboard() {
       return { nodes: flowNodes, edges: flowEdges };
   }, [rawData, handleCreateExternalLink]);
 
+  // #2108 — apply the `?focus=` deep-link once the graph nodes exist. Resolving
+  // against the live node ids handles both local (`service-x`) and remote
+  // (`box2:service-x`) forms without the linking page reconstructing the prefix.
   const selectedNodeName = useMemo(() => deriveNodeNameFromGraph(selectedNodeData), [selectedNodeData]);
 
   const selectedServiceViewModel = useMemo<ServiceViewModel | null>(() => {
@@ -1279,6 +1291,10 @@ export default function NetworkDashboard() {
       if (!graphData) return;
 
       let currentCollapsed = collapsedGroups;
+      // The focus to lay out with this pass — the live state, unless we resolve
+      // a fresh `?focus=` deep-link below (whose setState won't be visible until
+      // the next render, so we feed the resolved id straight into this layout).
+      let currentFocus = focusNodeId;
       if (!rawGraphData.current && graphData.nodes.length > 0) {
                   const groups = graphData.nodes
                       .filter(n => ['group', 'service', 'pod', 'proxy', 'unmanaged-service'].includes(n.data.type as string))
@@ -1287,13 +1303,36 @@ export default function NetworkDashboard() {
               setCollapsedGroups(currentCollapsed);
       }
 
+      // #2108 — resolve the `?focus=<service-name>` deep-link from the Services
+      // list to a concrete graph node id (handles the remote `<node>:` prefix).
+      // Each distinct param value is applied exactly once (ref-guard) so a
+      // manual node click / Back control isn't clobbered when this layout effect
+      // re-runs. The setState is deferred into the async runLayout callback
+      // below (not the synchronous effect body) so the first focused layout uses
+      // `currentFocus` and the Back control reflects state on the next render.
+      const focusPlan = planDeepLinkFocus(
+          graphData.nodes.map(n => n.id),
+          focusParam,
+          appliedFocusParamRef.current,
+      );
+      if (focusPlan.clearApplied) appliedFocusParamRef.current = null;
+      if (focusPlan.nodeId) currentFocus = focusPlan.nodeId;
+
       rawGraphData.current = graphData;
       let cancelled = false;
 
       const runLayout = async () => {
           try {
-                await processAndLayout(graphData.nodes, graphData.edges, currentCollapsed, searchQuery, focusNodeId);
+                await processAndLayout(graphData.nodes, graphData.edges, currentCollapsed, searchQuery, currentFocus);
                 if (!cancelled) {
+                     // #2108 — commit the resolved deep-link focus to state from
+                     // the async callback (subscription-style), so the Back
+                     // control + Esc-exit reflect it without a synchronous
+                     // setState in the effect body.
+                     if (focusPlan.appliedParam && focusPlan.nodeId) {
+                         appliedFocusParamRef.current = focusPlan.appliedParam;
+                         setFocusNodeId(focusPlan.nodeId);
+                     }
                      resolveReloadToast('success', 'Latest network topology is ready');
                 }
           } catch {
@@ -1308,7 +1347,7 @@ export default function NetworkDashboard() {
       return () => {
           cancelled = true;
       };
-  }, [graphData, processAndLayout, collapsedGroups, searchQuery, focusNodeId, resolveReloadToast]);
+  }, [graphData, processAndLayout, collapsedGroups, searchQuery, focusNodeId, focusParam, resolveReloadToast]);
 
   useEffect(() => {
     // Setup SSE for progress updates

--- a/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
@@ -10,7 +10,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import OverviewDashboard, { systemStatusView } from './OverviewDashboard';
+import OverviewDashboard, { systemStatusView, lastUpdatedView } from './OverviewDashboard';
 import { ToastProvider } from '@/providers/ToastProvider';
 
 // Mutable so individual tests can inject a `resources` slice for the System
@@ -222,8 +222,9 @@ describe('OverviewDashboard render', () => {
     expect(html).toMatch(/accent/);
   });
 
-  it('renders the System-status tile linking to Status→System (#2096)', () => {
-    // Inject a resources slice on the twin so the tile shows real metrics.
+  it('renders the System-status tile linking to Status→System (#2096) with split disk + Last updated (#2104)', () => {
+    // Inject a resources slice on the twin so the tile shows real metrics,
+    // including per-mount disks[] for the System/Data split (#2104).
     twinNode = {
       ...twinNode,
       resources: {
@@ -231,6 +232,10 @@ describe('OverviewDashboard render', () => {
         memoryUsage: 4 * 1024 * 1024 * 1024,
         totalMemory: 16 * 1024 * 1024 * 1024,
         diskUsage: 47,
+        disks: [
+          { mountpoint: '/', total: 100, used: 30 }, // System 30%
+          { mountpoint: '/var/mnt/data', total: 100, used: 78 }, // Data 78%
+        ],
         os: { uptime: 90000 },
       },
     };
@@ -242,16 +247,65 @@ describe('OverviewDashboard render', () => {
     );
 
     // The tile renders and is a clickable link to the Status→System view.
-    const systemLink = screen.getByText('System').closest('a');
+    // (Disambiguate: "System" is now both the tile <h2> AND a disk <dt> row.)
+    const systemLink = screen.getByText('System', { selector: 'h2' }).closest('a');
     expect(systemLink).not.toBeNull();
     expect(systemLink?.getAttribute('href')).toBe('/status?tab=system');
-    // CPU / RAM / Disk / Uptime rows are present.
+    // CPU / RAM rows present; Disk is split into System + Data; Uptime is gone,
+    // replaced by Last updated (#2104).
     expect(screen.getByText('CPU')).toBeDefined();
     expect(screen.getByText('RAM')).toBeDefined();
-    expect(screen.getByText('Disk')).toBeDefined();
-    expect(screen.getByText('Uptime')).toBeDefined();
+    expect(screen.getByText('System', { selector: 'dt' })).toBeDefined();
+    expect(screen.getByText('Data')).toBeDefined();
+    expect(screen.getByText('30%')).toBeDefined();
+    expect(screen.getByText('78%')).toBeDefined();
+    expect(screen.getByText('Last updated')).toBeDefined();
+    expect(screen.queryByText('Uptime')).toBeNull();
     expect(screen.getByText('12%')).toBeDefined();
-    expect(screen.getByText('1d 1h')).toBeDefined();
+  });
+
+  it('gives every Home tile an icon + title on one header row (#2103)', () => {
+    twinNode = {
+      ...twinNode,
+      resources: {
+        cpuUsage: 12,
+        memoryUsage: 4 * 1024 * 1024 * 1024,
+        totalMemory: 16 * 1024 * 1024 * 1024,
+        disks: [{ mountpoint: '/', total: 100, used: 30 }],
+        os: { uptime: 3600 },
+      },
+    };
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+    // Every tile's <h2> title sits in a flex row that also carries an <svg>
+    // icon as a sibling — icon + title inline, no tile missing its icon.
+    for (const title of ['Services', 'Diagnostics']) {
+      const heading = screen.getByText(title, { selector: 'h2' });
+      const header = heading.parentElement!;
+      expect(header.className).toContain('flex');
+      expect(header.querySelector('svg')).not.toBeNull();
+    }
+    // System tile header (its <h2> is "System", dt label is different).
+    const sysHeading = screen.getByText('System', { selector: 'h2' });
+    expect(sysHeading.parentElement!.className).toContain('flex');
+    expect(sysHeading.parentElement!.querySelector('svg')).not.toBeNull();
+  });
+
+  it('orders the Diagnostics tile last on mobile, natural order on desktop (#2105)', () => {
+    render(
+      <ToastProvider>
+        <OverviewDashboard />
+      </ToastProvider>,
+    );
+    // The Diagnostics tile link carries the responsive order utilities:
+    // order-last on mobile, reset to source order at ≥sm.
+    const diagnosticsLink = screen.getByText('Diagnostics', { selector: 'h2' }).closest('a');
+    expect(diagnosticsLink).not.toBeNull();
+    expect(diagnosticsLink!.className).toContain('order-last');
+    expect(diagnosticsLink!.className).toContain('sm:order-none');
   });
 
   it('renders the System tile in a neutral waiting state when no agent report is present', () => {
@@ -276,17 +330,50 @@ describe('systemStatusView (#2096)', () => {
     expect(systemStatusView({ cpuUsage: 10 })).toEqual({ loaded: false, tone: 'neutral', rows: [] });
   });
 
-  it('computes good tone for low usage and lists all four rows', () => {
-    const view = systemStatusView({
-      cpuUsage: 10,
-      memoryUsage: 2 * 1024 * 1024 * 1024,
-      totalMemory: 16 * 1024 * 1024 * 1024,
-      diskUsage: 30,
-      os: { uptime: 3600 },
-    });
+  it('splits Disk into System + Data and ends with Last updated (#2104)', () => {
+    const view = systemStatusView(
+      {
+        cpuUsage: 10,
+        memoryUsage: 2 * 1024 * 1024 * 1024,
+        totalMemory: 16 * 1024 * 1024 * 1024,
+        disks: [
+          { mountpoint: '/', total: 100, used: 30 },
+          { mountpoint: '/var/mnt/data', total: 100, used: 50 },
+        ],
+        os: { uptime: 3600 },
+      },
+      new Date().toISOString(),
+    );
     expect(view.loaded).toBe(true);
     expect(view.tone).toBe('good');
-    expect(view.rows.map(r => r.label)).toEqual(['CPU', 'RAM', 'Disk', 'Uptime']);
+    expect(view.rows.map(r => r.label)).toEqual(['CPU', 'RAM', 'System', 'Data', 'Last updated']);
+    expect(view.rows.find(r => r.label === 'System')?.value).toBe('30%');
+    expect(view.rows.find(r => r.label === 'Data')?.value).toBe('50%');
+    expect(view.rows.find(r => r.label === 'Last updated')?.value).toBe('Just now');
+  });
+
+  it('accepts /mnt/data (non-FCoS mount path) for the Data partition (#2104)', () => {
+    const view = systemStatusView({
+      disks: [
+        { mountpoint: '/', total: 100, used: 20 },
+        { mountpoint: '/mnt/data', total: 100, used: 60 },
+      ],
+      os: { uptime: 60 },
+    });
+    expect(view.rows.find(r => r.label === 'Data')?.value).toBe('60%');
+  });
+
+  it('falls back to the single Disk figure when no per-mount breakdown exists (#2104)', () => {
+    const view = systemStatusView({
+      diskUsage: 47,
+      os: { uptime: 60 },
+    });
+    // No disks[] → surface the one figure, do NOT fake a split.
+    const labels = view.rows.map(r => r.label);
+    expect(labels).toContain('Disk');
+    expect(labels).not.toContain('System');
+    expect(labels).not.toContain('Data');
+    expect(view.rows.find(r => r.label === 'Disk')?.value).toBe('47%');
   });
 
   it('escalates the tone to the worst metric (bad wins over warn/good)', () => {
@@ -294,10 +381,26 @@ describe('systemStatusView (#2096)', () => {
       cpuUsage: 85, // warn
       memoryUsage: 15.5 * 1024 * 1024 * 1024,
       totalMemory: 16 * 1024 * 1024 * 1024, // ~97% → bad
-      diskUsage: 10, // good
+      disks: [{ mountpoint: '/', total: 100, used: 10 }], // good
       os: { uptime: 120 },
     });
     expect(view.tone).toBe('bad');
+  });
+
+  it('Last updated tone does not escalate the worst-of system tone (#2104)', () => {
+    // A stale box (Last updated = warn) with all-good metrics stays good — a
+    // freshness warning is not a resource-pressure problem.
+    const old = new Date(Date.now() - 120 * 86400000).toISOString();
+    const view = systemStatusView(
+      {
+        cpuUsage: 10,
+        disks: [{ mountpoint: '/', total: 100, used: 10 }],
+        os: { uptime: 60 },
+      },
+      old,
+    );
+    expect(view.rows.find(r => r.label === 'Last updated')?.tone).toBe('warn');
+    expect(view.tone).toBe('good');
   });
 
   it('degrades gracefully to neutral rows when a metric is missing', () => {
@@ -306,5 +409,26 @@ describe('systemStatusView (#2096)', () => {
     // No usage figures → no escalation, neutral overall.
     expect(view.tone).toBe('neutral');
     expect(view.rows.find(r => r.label === 'CPU')?.value).toBe('—');
+  });
+});
+
+describe('lastUpdatedView (#2104)', () => {
+  const now = Date.parse('2026-06-23T12:00:00Z');
+
+  it('is neutral "Never" when there is no applied-update timestamp', () => {
+    expect(lastUpdatedView(undefined, now)).toEqual({ value: 'Never', tone: 'neutral' });
+    expect(lastUpdatedView(null, now)).toEqual({ value: 'Never', tone: 'neutral' });
+    expect(lastUpdatedView('not-a-date', now)).toEqual({ value: 'Never', tone: 'neutral' });
+  });
+
+  it('reports a recent update as good with a relative age', () => {
+    expect(lastUpdatedView('2026-06-23T11:30:00Z', now)).toEqual({ value: 'Just now', tone: 'good' });
+    expect(lastUpdatedView('2026-06-23T09:00:00Z', now)).toEqual({ value: '3h ago', tone: 'good' });
+    expect(lastUpdatedView('2026-06-20T12:00:00Z', now)).toEqual({ value: '3d ago', tone: 'good' });
+  });
+
+  it('warns once the last update is older than the freshness threshold', () => {
+    const old = new Date(now - 90 * 86400000).toISOString();
+    expect(lastUpdatedView(old, now)).toEqual({ value: '90d ago', tone: 'warn' });
   });
 });

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Activity, AlertCircle, CheckCircle2, Server } from 'lucide-react';
+import { Activity, AlertCircle, Boxes, CheckCircle2, Server } from 'lucide-react';
 import type { ServiceViewModel } from '@servicebay/api-client';
 import { useDigitalTwinContext } from '@/providers/DigitalTwinProvider';
 import { useCoreHealth } from '@/hooks/useCoreHealth';
@@ -119,6 +119,70 @@ export function diagnoseCardView(b: DiagnoseBreakdown): {
 }
 
 /**
+ * "Last updated" freshness/security view (#2104).
+ *
+ * Reads the applied-update timestamp the updater stamps into config
+ * (`autoUpdate.appliedImageUpdatedAt`, surfaced by GET /api/system/update which
+ * returns the full config). Renders a human-relative value with an ok/warn
+ * tone: a box updated recently is current/secure (ok); one that hasn't seen an
+ * update in a long time is a freshness risk (warn). Never-updated (fresh
+ * install, no applied update yet) is neutral, not a warning — there may simply
+ * be nothing newer than the shipped image.
+ */
+export interface LastUpdatedView {
+  value: string;
+  tone: 'good' | 'warn' | 'neutral';
+}
+
+/** Warn once the last applied update is older than this (days). 60d ≈ several
+ *  release cycles for this repo — long enough to flag a stale box without
+ *  nagging a current one. */
+const LAST_UPDATE_WARN_DAYS = 60;
+
+export function lastUpdatedView(
+  appliedAt: string | null | undefined,
+  now: number = Date.now(),
+): LastUpdatedView {
+  if (!appliedAt) return { value: 'Never', tone: 'neutral' };
+  const then = Date.parse(appliedAt);
+  if (Number.isNaN(then)) return { value: 'Never', tone: 'neutral' };
+  const ageMs = Math.max(0, now - then);
+  const days = Math.floor(ageMs / 86400000);
+  const hours = Math.floor(ageMs / 3600000);
+  const value =
+    days >= 1 ? `${days}d ago` : hours >= 1 ? `${hours}h ago` : 'Just now';
+  const tone: 'good' | 'warn' = days >= LAST_UPDATE_WARN_DAYS ? 'warn' : 'good';
+  return { value, tone };
+}
+
+/** Read the applied-update timestamp off GET /api/system/update (same endpoint
+ *  the ServiceBay updater card uses). Read-only background fetch; failure keeps
+ *  the value neutral ("Never") rather than surfacing a transient blip. */
+function useLastUpdated(): string | null {
+  const [appliedAt, setAppliedAt] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/system/update');
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          config?: { autoUpdate?: { appliedImageUpdatedAt?: string } };
+        };
+        if (cancelled) return;
+        setAppliedAt(data.config?.autoUpdate?.appliedImageUpdatedAt ?? null);
+      } catch (error) {
+        console.error('[OverviewDashboard] Failed to read last-update time', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return appliedAt;
+}
+
+/**
  * Home — the lean, status-led landing (IA redesign, spec §4.3 spirit).
  *
  * Restored from the old OverviewDashboard but lightened to answer ONE
@@ -166,10 +230,16 @@ export default function OverviewDashboard() {
   const diagnose = useDiagnoseOverview();
   const diagnoseView = diagnoseCardView(diagnose);
 
+  // "Last updated" freshness indicator (#2104) — applied-update timestamp from
+  // config via GET /api/system/update. Read-only background fetch.
+  const lastUpdatedAt = useLastUpdated();
+
   // Compact System-status tile (#2096) — sourced from the SAME twin snapshot
   // Status→System reads (firstNode.resources). No new polling: the twin is
   // already in context. Unavailable (no agent report yet) → neutral, no crash.
-  const systemView = systemStatusView(firstNode?.resources);
+  // Disk is split into System (/) + Data (/mnt/data) from resources.disks[];
+  // Uptime is replaced by "Last updated" (#2104).
+  const systemView = systemStatusView(firstNode?.resources, lastUpdatedAt);
 
   // Pending service-image updates — box status, so it belongs on Home too
   // (#1860). The banner's "Update now" re-deploys each listed service via the
@@ -236,10 +306,15 @@ export default function OverviewDashboard() {
         </section>
 
         {/* Box-wide at-a-glance: services running + latest diagnose breakdown
-            + a compact System-status tile (CPU/RAM/Disk/Uptime, #2096). */}
+            + a compact System-status tile (#2096). Every tile shares ONE header
+            layout — icon + title on a single row (#2103). On narrow screens the
+            Diagnostics/Health tile drops to the bottom (#2105): the more
+            important Services + System tiles come first; desktop order (grid
+            source order) is unchanged. */}
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           <StatCard
             title="Services"
+            icon={Boxes}
             metric={hasFirstSnapshot ? `${activeCount} of ${totalCount} running` : '…'}
             description={
               failedCount > 0
@@ -260,6 +335,8 @@ export default function OverviewDashboard() {
             icon={Activity}
             tone={diagnoseView.tone}
             href="/status"
+            /* Mobile: push to bottom; ≥sm: back to natural source order (2nd). */
+            className="order-last sm:order-none"
           />
           <SystemStatusCard view={systemView} />
         </section>
@@ -297,29 +374,53 @@ function HealthHeadline({ tone, text }: { tone: 'good' | 'warn' | 'bad' | 'neutr
   );
 }
 
+/**
+ * Shared Home-tile header (#2103) — icon + title on ONE row, icon left, title
+ * beside it. The single source of truth for every Home tile's heading so they
+ * can't drift apart again (the bug: Services had no icon, Diagnostics/System
+ * stacked the icon ABOVE the title). `accent` colours the icon to the tile's
+ * tone; an optional `trailing` slot carries the System tile's StatusDot.
+ */
+function TileHeader({
+  title,
+  icon: Icon,
+  accent,
+  trailing,
+}: {
+  title: string;
+  icon: typeof Activity;
+  accent: string;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <Icon size={20} className={cn('shrink-0', accent)} />
+      <h2 className="font-bold text-text tracking-wide text-base">{title}</h2>
+      {trailing && <div className="ml-auto">{trailing}</div>}
+    </div>
+  );
+}
+
 interface StatCardProps {
   title: string;
   metric: string;
   description: string;
-  icon?: typeof Activity;
+  icon: typeof Activity;
   tone: 'good' | 'warn' | 'bad' | 'neutral';
   /** Where clicking the card navigates (#2067 — the Home cards used to be
    *  inert; the operator clicked them and nothing happened). When set, the
    *  card renders as a Next <Link> with a clear hover affordance. */
   href?: string;
+  /** Extra wrapper classes — e.g. responsive `order-*` for mobile reordering. */
+  className?: string;
 }
 
-function StatCard({ title, metric, description, icon: Icon, tone, href }: StatCardProps) {
+function StatCard({ title, metric, description, icon: Icon, tone, href, className }: StatCardProps) {
   const accent = TONE_ACCENT[tone];
   const inner = (
     <>
-      {Icon && (
-        <div className="mb-3">
-          <Icon size={20} className={accent} />
-        </div>
-      )}
-      <h2 className="font-bold text-text tracking-wide text-base">{title}</h2>
-      <p className={cn('text-sm font-semibold mt-1', accent)}>{metric}</p>
+      <TileHeader title={title} icon={Icon} accent={accent} />
+      <p className={cn('text-sm font-semibold', accent)}>{metric}</p>
       <p className="text-xs text-text-muted mt-2 font-medium leading-relaxed">{description}</p>
     </>
   );
@@ -328,23 +429,32 @@ function StatCard({ title, metric, description, icon: Icon, tone, href }: StatCa
     // the href) wrapping a <Card> surface, with a token-driven hover affordance
     // (accent border + accent ring).
     return (
-      <Link href={href} className="block rounded-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
+      <Link href={href} className={cn('block rounded-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent', className)}>
         <Card padding="lg" className="cursor-pointer transition-all hover:border-accent hover:shadow-md">
           {inner}
         </Card>
       </Link>
     );
   }
-  return <Card padding="lg">{inner}</Card>;
+  return <Card padding="lg" className={className}>{inner}</Card>;
 }
 
 /** Shape of the resources slice the System tile reads off the twin — a subset
- *  of the agent's `SystemResources` (the same object Status→System binds to). */
+ *  of the agent's `SystemResources` (the same object Status→System binds to).
+ *  `disks[]` is the per-mount partition breakdown the System report carries
+ *  (same source SystemInfoDashboard reads); used to split System (/) vs Data
+ *  (/mnt/data) usage (#2104). `diskUsage` is the single fallback figure. */
+interface DiskLike {
+  mountpoint?: string;
+  total?: number;
+  used?: number;
+}
 interface SystemResourcesLike {
   cpuUsage?: number;
   memoryUsage?: number;
   totalMemory?: number;
   diskUsage?: number;
+  disks?: DiskLike[];
   os?: { uptime?: number };
 }
 
@@ -371,15 +481,6 @@ function formatBytesShort(bytes: number): string {
   return `${(bytes / Math.pow(k, i)).toFixed(i === 0 ? 0 : 1)} ${sizes[i]}`;
 }
 
-function formatUptime(seconds: number): string {
-  if (!seconds || seconds <= 0) return '—';
-  const days = Math.floor(seconds / 86400);
-  const hours = Math.floor((seconds % 86400) / 3600);
-  if (days > 0) return `${days}d ${hours}h`;
-  const mins = Math.floor((seconds % 3600) / 60);
-  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
-}
-
 /** A usage percentage → tone, matching the Status→System thresholds
  *  (>90 fail, >80 warn, else ok). */
 function usageTone(percent: number): 'good' | 'warn' | 'bad' {
@@ -388,10 +489,66 @@ function usageTone(percent: number): 'good' | 'warn' | 'bad' {
   return 'good';
 }
 
-/** Build the compact System-status view from the twin's resources slice.
- *  Read-only, no fetch — the parent already holds the snapshot. Missing /
- *  partial data degrades gracefully to neutral rows rather than crashing. */
-export function systemStatusView(resources: SystemResourcesLike | null | undefined): SystemStatusView {
+/** The mountpoints that identify the two partitions the box runs on. The OS
+ *  root and the /mnt/data RAID (FCoS mounts it under /var/mnt/data; pre-FCoS or
+ *  bind setups use /mnt/data — accept both). Mirrors SystemInfoDashboard's
+ *  `describeMountRole`. */
+const SYSTEM_MOUNTS = ['/', '/sysroot'];
+const DATA_MOUNTS = ['/var/mnt/data', '/mnt/data'];
+
+function findDisk(disks: DiskLike[] | undefined, mounts: string[]): DiskLike | undefined {
+  if (!disks) return undefined;
+  for (const m of mounts) {
+    const hit = disks.find(d => d.mountpoint === m);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** A disk mount → a usage row (used%/tone). Returns null when the figure can't
+ *  be computed (mount absent / no total) so the caller can render an em-dash. */
+function diskRow(label: string, disk: DiskLike | undefined): { row: SystemRow; tone: 'good' | 'warn' | 'bad' } | { row: SystemRow; tone: null } {
+  if (disk && typeof disk.used === 'number' && typeof disk.total === 'number' && disk.total > 0) {
+    const pct = (disk.used / disk.total) * 100;
+    const t = usageTone(pct);
+    return { row: { label, value: `${Math.round(pct)}%`, tone: t }, tone: t };
+  }
+  return { row: { label, value: '—', tone: 'neutral' }, tone: null };
+}
+
+/** The disk section (#2104): System (/) + Data (/mnt/data) split from the
+ *  report's per-mount `disks[]`. Falls back to the single `diskUsage` figure
+ *  (one "Disk" row) when the agent carries no per-mount breakdown — rather than
+ *  fabricate a split. Returns the rows + the tones that should escalate the
+ *  worst-of system tone. */
+function diskSection(resources: SystemResourcesLike): { rows: SystemRow[]; tones: ('good' | 'warn' | 'bad')[] } {
+  if (Array.isArray(resources.disks) && resources.disks.length > 0) {
+    const sys = diskRow('System', findDisk(resources.disks, SYSTEM_MOUNTS));
+    const dat = diskRow('Data', findDisk(resources.disks, DATA_MOUNTS));
+    const tones = [sys.tone, dat.tone].filter((t): t is 'good' | 'warn' | 'bad' => t !== null);
+    return { rows: [sys.row, dat.row], tones };
+  }
+  if (typeof resources.diskUsage === 'number') {
+    const t = usageTone(resources.diskUsage);
+    return { rows: [{ label: 'Disk', value: `${Math.round(resources.diskUsage)}%`, tone: t }], tones: [t] };
+  }
+  return { rows: [{ label: 'Disk', value: '—', tone: 'neutral' }], tones: [] };
+}
+
+/** Build the compact System-status view from the twin's resources slice +
+ *  the last-applied-update timestamp. Read-only, no fetch — the parent already
+ *  holds the snapshot. Missing / partial data degrades gracefully to neutral
+ *  rows rather than crashing.
+ *
+ *  #2104: Disk is split into System (/) and Data (/mnt/data) from the report's
+ *  per-mount `disks[]` (the same source SystemInfoDashboard uses). When the
+ *  agent only carries the single `diskUsage` figure (older report, no
+ *  per-mount breakdown), we surface that one "Disk" row rather than fake a
+ *  split. Uptime is replaced by "Last updated" (update freshness/security). */
+export function systemStatusView(
+  resources: SystemResourcesLike | null | undefined,
+  lastUpdatedAt?: string | null,
+): SystemStatusView {
   if (!resources || resources.os === undefined) {
     return { loaded: false, tone: 'neutral', rows: [] };
   }
@@ -420,15 +577,16 @@ export function systemStatusView(resources: SystemResourcesLike | null | undefin
     rows.push({ label: 'RAM', value: '—', tone: 'neutral' });
   }
 
-  if (typeof resources.diskUsage === 'number') {
-    const t = usageTone(resources.diskUsage);
-    tones.push(t);
-    rows.push({ label: 'Disk', value: `${Math.round(resources.diskUsage)}%`, tone: t });
-  } else {
-    rows.push({ label: 'Disk', value: '—', tone: 'neutral' });
-  }
+  // Disk split (#2104): System (/) + Data (/mnt/data), or a single fallback.
+  const disk = diskSection(resources);
+  rows.push(...disk.rows);
+  tones.push(...disk.tones);
 
-  rows.push({ label: 'Uptime', value: formatUptime(resources.os?.uptime ?? 0), tone: 'neutral' });
+  // Last updated (#2104) — replaces Uptime. Update freshness/security; its own
+  // ok/warn tone does NOT escalate the worst-of system tone (a stale box isn't
+  // a CPU/RAM/disk pressure problem), so it's pushed as a row only.
+  const lu = lastUpdatedView(lastUpdatedAt);
+  rows.push({ label: 'Last updated', value: lu.value, tone: lu.tone });
 
   const tone: 'good' | 'warn' | 'bad' | 'neutral' = tones.includes('bad')
     ? 'bad'
@@ -459,11 +617,12 @@ function SystemStatusCard({ view }: { view: SystemStatusView }) {
       className="block rounded-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
     >
       <Card padding="lg" className="cursor-pointer transition-all hover:border-accent hover:shadow-md">
-        <div className="mb-3 flex items-center justify-between">
-          <Server size={20} className={TONE_ACCENT[view.tone]} />
-          <StatusDot state={TONE_TO_DOT[view.tone]} />
-        </div>
-        <h2 className="font-bold text-text tracking-wide text-base">System</h2>
+        <TileHeader
+          title="System"
+          icon={Server}
+          accent={TONE_ACCENT[view.tone]}
+          trailing={<StatusDot state={TONE_TO_DOT[view.tone]} />}
+        />
         {view.loaded ? (
           <dl className="mt-2 space-y-1.5">
             {view.rows.map(row => (

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -244,7 +244,7 @@ export default function OverviewDashboard() {
   // Pending service-image updates — box status, so it belongs on Home too
   // (#1860). The banner's "Update now" re-deploys each listed service via the
   // same `update` action the Services list uses (pull latest image → restart).
-  const { available: imageUpdates, refresh: refreshImageUpdates } = useImageUpdates();
+  const { available: imageUpdates, refresh: refreshImageUpdates, verifyAfterUpdate } = useImageUpdates();
   const { updateServiceImage, overlays: serviceActionOverlays } = useServiceActions({ onRefresh: refreshImageUpdates });
 
   // Resolve a bare service name from the image-update report to a minimal
@@ -264,8 +264,10 @@ export default function OverviewDashboard() {
       } as unknown as ServiceViewModel;
       await updateServiceImage(target);
     }
-    await refreshImageUpdates();
-  }, [services, firstNodeName, updateServiceImage, refreshImageUpdates]);
+    // Re-check on a short back-off: the registry report lags the pull/restart,
+    // so a single immediate refresh can still show the stale entry (#2106).
+    await verifyAfterUpdate();
+  }, [services, firstNodeName, updateServiceImage, verifyAfterUpdate]);
 
   const healthHeadline = (() => {
     if (!hasFirstSnapshot) return { tone: 'neutral' as const, text: 'Reading status…' };

--- a/packages/frontend/src/dashboards/ServicesDashboard.tsx
+++ b/packages/frontend/src/dashboards/ServicesDashboard.tsx
@@ -49,7 +49,7 @@ const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: fa
 export default function ServicesDashboard() {
     const { data: twin, isConnected, lastUpdate, isNodeSynced } = useDigitalTwin();
     const { addToast, updateToast } = useToast();
-    const { available: imageUpdates, availableServices: imageUpdateServices, refresh: refreshImageUpdates } = useImageUpdates();
+    const { available: imageUpdates, availableServices: imageUpdateServices, verifyAfterUpdate } = useImageUpdates();
 
     const [filteredServices, setFilteredServices] = useState<ServiceViewModel[]>([]);
     const [filteredBundles, setFilteredBundles] = useState<ServiceBundle[]>([]);
@@ -417,8 +417,12 @@ export default function ServicesDashboard() {
 
     const handleUpdateService = useCallback(async (service: ServiceViewModel) => {
         await updateServiceImage(service);
-        await refreshImageUpdates();
-    }, [updateServiceImage, refreshImageUpdates]);
+        // Re-check on a short back-off: the registry report lags the
+        // pull/restart, so a single immediate refresh can still show the stale
+        // badge/banner (#2106). On a failed update updateServiceImage already
+        // surfaced its error toast and the report stays unchanged.
+        await verifyAfterUpdate();
+    }, [updateServiceImage, verifyAfterUpdate]);
 
     // Banner "Update now": re-deploy every listed service sequentially (no
     // single "update all" endpoint exists), then refresh the report once.
@@ -431,8 +435,8 @@ export default function ServicesDashboard() {
                 await updateServiceImage(service);
             }
         }
-        await refreshImageUpdates();
-    }, [resolveServiceByName, updateServiceImage, refreshImageUpdates]);
+        await verifyAfterUpdate();
+    }, [resolveServiceByName, updateServiceImage, verifyAfterUpdate]);
 
     useEffect(() => {
         if (!containerIdParam || !allContainers.length) return;

--- a/packages/frontend/src/hooks/useImageUpdates.test.tsx
+++ b/packages/frontend/src/hooks/useImageUpdates.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useImageUpdates, type ServiceImageUpdate } from './useImageUpdates';
+
+const upd = (service: string, updateAvailable: boolean): ServiceImageUpdate => ({
+  service,
+  image: `ghcr.io/${service}:latest`,
+  runningDigest: updateAvailable ? 'sha256:old' : 'sha256:same',
+  registryDigest: updateAvailable ? 'sha256:new' : 'sha256:same',
+  updateAvailable,
+});
+
+function respond(services: ServiceImageUpdate[]): Response {
+  return new Response(JSON.stringify({ services }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const fetchMock = vi.fn();
+
+/** Mount the hook and flush the on-mount fetch (microtasks). */
+async function mount() {
+  const hook = renderHook(() => useImageUpdates());
+  // Flush the effect's async fetch + state updates.
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  return hook;
+}
+
+describe('useImageUpdates', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('exposes pending updates from the on-mount fetch', async () => {
+    fetchMock.mockResolvedValue(respond([upd('ollama', true), upd('immich', false)]));
+    const { result } = await mount();
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.available.map(u => u.service)).toEqual(['ollama']);
+    expect([...result.current.availableServices]).toEqual(['ollama']);
+  });
+
+  it('verifyAfterUpdate hides the banner once a later re-poll reports the report clean (registry lag, #2106)', async () => {
+    // Mount with one pending update, then the action runs. The immediate refresh
+    // STILL reports it (registry lags the restart); only the delayed re-poll
+    // sees it cleared. The banner must end empty without a reload.
+    fetchMock
+      .mockResolvedValueOnce(respond([upd('ollama', true)])) // on-mount
+      .mockResolvedValueOnce(respond([upd('ollama', true)])) // immediate refresh — still stale
+      .mockResolvedValue(respond([])); // delayed re-poll — now clean
+
+    const { result } = await mount();
+    expect(result.current.available).toHaveLength(1);
+
+    let done: Promise<void>;
+    await act(async () => {
+      done = result.current.verifyAfterUpdate();
+      await vi.runAllTimersAsync();
+      await done;
+    });
+
+    expect(result.current.available).toHaveLength(0);
+    // on-mount + immediate + at least one delayed re-poll.
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('verifyAfterUpdate stops early once the report is clean (no spinning)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(respond([upd('ollama', true)])) // on-mount
+      .mockResolvedValue(respond([])); // immediate refresh is already clean
+
+    const { result } = await mount();
+
+    let done: Promise<void>;
+    await act(async () => {
+      done = result.current.verifyAfterUpdate();
+      await vi.runAllTimersAsync();
+      await done;
+    });
+
+    expect(result.current.available).toHaveLength(0);
+    // on-mount + exactly one (immediate) refresh — no further delayed re-polls.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('verifyAfterUpdate keeps the banner when the update did not take (report stays)', async () => {
+    // The update genuinely failed/didn't propagate: every poll still reports it.
+    // The banner must STAY (feedback_dont_mask_failures) — never hide on a
+    // persistent report.
+    fetchMock.mockResolvedValue(respond([upd('ollama', true)]));
+
+    const { result } = await mount();
+
+    let done: Promise<void>;
+    await act(async () => {
+      done = result.current.verifyAfterUpdate();
+      await vi.runAllTimersAsync();
+      await done;
+    });
+
+    expect(result.current.available).toHaveLength(1);
+  });
+
+  it('refresh leaves existing state intact on a failed fetch (never falsely clears)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(respond([upd('ollama', true)])) // on-mount: populate
+      .mockResolvedValueOnce(new Response('boom', { status: 500 })); // refresh fails
+
+    const { result } = await mount();
+    expect(result.current.available).toHaveLength(1);
+
+    let count: number | null = 0;
+    await act(async () => { count = await result.current.refresh(); });
+
+    expect(count).toBeNull();
+    expect(result.current.available).toHaveLength(1); // unchanged, not wiped
+  });
+});

--- a/packages/frontend/src/hooks/useImageUpdates.ts
+++ b/packages/frontend/src/hooks/useImageUpdates.ts
@@ -3,6 +3,17 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 /**
+ * Re-poll schedule (ms) used by `verifyAfterUpdate` after a successful update
+ * action. The registry image-update report lags the actual pull/restart: an
+ * immediate re-fetch can still see the *old* running digest because the
+ * container hasn't restarted (or re-reported) yet, which is why the banner
+ * appeared to "stick" until a manual reload (#2106). We re-check on a short,
+ * bounded back-off and stop as soon as the report is clean — never spinning
+ * forever. An immediate refresh runs first (offset 0), then these delays.
+ */
+const VERIFY_REPOLL_DELAYS_MS = [1500, 4000];
+
+/**
  * One service's running-vs-registry image comparison, as returned by
  * `GET /api/system/stacks/image-updates` (#1859, child 1 of #1858). The
  * backend shape is `ServiceImageUpdate` in `@/lib/imageDigest`; this mirrors
@@ -37,20 +48,46 @@ export function useImageUpdates() {
   const [updates, setUpdates] = useState<ServiceImageUpdate[]>([]);
   const [loaded, setLoaded] = useState(false);
 
-  const refresh = useCallback(async () => {
+  /**
+   * Re-fetch the report once. Returns the count of services still reporting an
+   * available update so callers can decide whether another re-poll is worth it.
+   * A failed fetch returns `null` (unknown) and leaves the current state alone —
+   * we never wipe the banner on a transient error (feedback_dont_mask_failures:
+   * we don't claim "up to date" on a failed check, we keep what we last knew).
+   */
+  const refresh = useCallback(async (): Promise<number | null> => {
     try {
       const res = await fetch('/api/system/stacks/image-updates', { cache: 'no-store' });
-      if (!res.ok) return;
+      if (!res.ok) return null;
       const data: ImageUpdatesResponse = await res.json();
-      setUpdates(Array.isArray(data?.services) ? data.services : []);
+      const services = Array.isArray(data?.services) ? data.services : [];
+      setUpdates(services);
+      return services.filter(u => u.updateAvailable).length;
     } catch {
-      // Best-effort: a failed check just leaves no badges — never block the
-      // dashboard (feedback_dont_mask_failures: we don't claim "up to date",
-      // we simply show nothing until the next successful poll).
+      // Best-effort: a failed check just leaves the existing badges in place —
+      // never block the dashboard and never falsely clear the banner.
+      return null;
     } finally {
       setLoaded(true);
     }
   }, []);
+
+  /**
+   * Refresh after a successful update action. Because the registry report lags
+   * the pull/restart (#2106), one immediate refresh can still show the stale
+   * entry, so we re-check on the bounded `VERIFY_REPOLL_DELAYS_MS` back-off and
+   * stop early the moment the report is clean (`count === 0`). This hides the
+   * banner without a page reload while never spinning forever; on a persistent
+   * report (e.g. the update genuinely didn't take) the banner correctly stays.
+   */
+  const verifyAfterUpdate = useCallback(async (): Promise<void> => {
+    const remaining = await refresh();
+    if (remaining === 0) return;
+    for (const delay of VERIFY_REPOLL_DELAYS_MS) {
+      await new Promise(resolve => setTimeout(resolve, delay));
+      if ((await refresh()) === 0) return;
+    }
+  }, [refresh]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async image-update check on mount
@@ -63,5 +100,5 @@ export function useImageUpdates() {
     [available],
   );
 
-  return { available, availableServices, loaded, refresh };
+  return { available, availableServices, loaded, refresh, verifyAfterUpdate };
 }


### PR DESCRIPTION
## What
Operator UI polish batch: Home tiles v2 (inline icon headers, Disk System/Data split, Uptime→Last-updated, mobile Diagnostics-to-bottom), image-update banner auto-refresh after an update, /portal migrated to the design system, a per-service focus→Network-Map highlight button, and Settings box-in-box flattening across 15 sections.

## Why
Closes #2103
Closes #2104
Closes #2105
Closes #2106
Closes #2107
Closes #2108
Closes #2109

## Risk
Medium — extensive frontend dashboard/portal/settings surface; logic preserved, mostly markup/layout + a banner re-poll hook.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 354 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (full — 3310 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: dashboards/ + app/portal/ + app/(dashboard)/ + lib/config.ts) — operator dark-mode pixel-confirm owed

<!-- sb-ai-comment -->
AI-generated