### PR TITLE
fix(portal): equal-height card grid + collapse Syncthing pairing block

### DIFF
--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -136,6 +136,8 @@ describe('PortalGrid', () => {
 
     it('renders the install button (closed by default, no modal)', () => {
       render(<PortalGrid cards={[basicSyncCard]} />);
+      // QR-bearing assets sit behind the "How to pair" expander (#2116).
+      fireEvent.click(screen.getByText(/so koppelst du/i));
       expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
       expect(screen.getByText('Open-source Syncthing client.')).toBeDefined();
       // Modal heading is not present until the button is clicked.
@@ -144,6 +146,7 @@ describe('PortalGrid', () => {
 
     it('opens the QR modal on click and closes it on backdrop click', () => {
       render(<PortalGrid cards={[basicSyncCard]} />);
+      fireEvent.click(screen.getByText(/so koppelst du/i));
       fireEvent.click(screen.getByRole('button', { name: /install basicsync on your phone/i }));
       // Modal now shows: heading + the direct-download link.
       expect(screen.getByRole('heading', { name: /install basicsync/i })).toBeDefined();
@@ -389,6 +392,9 @@ describe('PortalGrid', () => {
 
     it('renders the pair button on tokens and keeps the fetch-on-click QR flow', () => {
       render(<PortalGrid cards={[syncCard]} />);
+      // The pairing block is now behind a "How to pair" expander (#2116);
+      // open it first, then the pair button is reachable.
+      fireEvent.click(screen.getByText(/so koppelst du/i));
       const btn = screen.getByRole('button', { name: /pair/i });
       expect(btn.className).toContain('bg-accent');
       expect(btn.className).not.toContain('bg-emerald-600');
@@ -396,6 +402,107 @@ describe('PortalGrid', () => {
       expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
       fireEvent.click(btn);
       expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
+    });
+  });
+
+  describe('balanced equal-height card grid (#2116)', () => {
+    /** The grid container is the heading's nearest ancestor div carrying
+     *  the `grid` class. */
+    const gridOf = (label: string): HTMLElement => {
+      const grid = screen.getByRole('heading', { name: label }).closest('div.grid');
+      expect(grid).not.toBeNull();
+      return grid as HTMLElement;
+    };
+    const cardOf = (label: string): HTMLElement =>
+      screen.getByRole('heading', { name: label }).closest('div.rounded-card') as HTMLElement;
+
+    it('stretches grid rows so same-row cards share a height (items-stretch + h-full)', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      const grid = gridOf('Photos');
+      expect(grid.className).toContain('items-stretch');
+      expect(grid.className).not.toContain('items-start');
+      // Each card fills the stretched row.
+      expect(cardOf('Photos').className).toContain('h-full');
+    });
+
+    it('keeps a responsive 1 / multi-col layout (1 col mobile, 12-col md track)', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      const grid = gridOf('Photos');
+      expect(grid.className).toContain('grid-cols-1');
+      expect(grid.className).toContain('md:grid-cols-12');
+      expect(grid.className).toContain('gap-6');
+    });
+
+    it('renders an even row of three regular cards that each fill the row height', () => {
+      const a: PortalCard = { ...baseCard, id: 'a:x', label: 'Alpha', sizeTier: 'regular' };
+      const b: PortalCard = { ...baseCard, id: 'b:y', label: 'Beta', sizeTier: 'regular' };
+      const c: PortalCard = { ...baseCard, id: 'c:z', label: 'Gamma', sizeTier: 'regular' };
+      render(<PortalGrid cards={[a, b, c]} />);
+      for (const label of ['Alpha', 'Beta', 'Gamma']) {
+        expect(cardOf(label).className).toContain('h-full');
+        expect(cardOf(label).className).toContain('md:col-span-4');
+      }
+    });
+  });
+
+  describe('Syncthing pairing block collapsed behind expander (#2116)', () => {
+    const syncCard: PortalCard = {
+      ...baseCard,
+      id: 'file-share:SYNCTHING_SUBDOMAIN',
+      name: 'file-share',
+      label: 'Syncthing',
+      setupAssets: [
+        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone', description: 'Install the app first.' },
+        { kind: 'syncthing_qr', label: 'Pair this device', description: 'Use /var/syncthing/Sync/<name> for the shared drive.' },
+      ],
+    };
+
+    it('keeps the primary Open CTA visible at rest, like other cards', () => {
+      render(<PortalGrid cards={[syncCard]} />);
+      expect(screen.getByRole('link', { name: /^open$/i })).toBeDefined();
+    });
+
+    it('hides the pairing buttons behind a collapsed "How to pair" expander by default', () => {
+      render(<PortalGrid cards={[syncCard]} />);
+      // The summary is present...
+      const summary = screen.getByText(/so koppelst du/i);
+      expect(summary).toBeDefined();
+      // ...and its <details> is closed by default → buttons not actionable yet.
+      const details = summary.closest('details');
+      expect(details).not.toBeNull();
+      expect((details as HTMLDetailsElement).open).toBe(false);
+    });
+
+    it('reveals the BasicSync install QR + pairing QR + storage-path note when opened', () => {
+      render(<PortalGrid cards={[syncCard]} />);
+      fireEvent.click(screen.getByText(/so koppelst du/i));
+      // Both QR-launching buttons are now reachable.
+      expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
+      expect(screen.getByRole('button', { name: /pair this device/i })).toBeDefined();
+      // The storage-path note (asset description) is revealed.
+      expect(screen.getByText(/\/var\/syncthing\/sync/i)).toBeDefined();
+    });
+
+    it('still opens the pairing QR modal from inside the expander (function preserved)', () => {
+      render(<PortalGrid cards={[syncCard]} />);
+      fireEvent.click(screen.getByText(/so koppelst du/i));
+      expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
+      fireEvent.click(screen.getByRole('button', { name: /pair this device/i }));
+      expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
+    });
+
+    it('renders a single light asset inline (no expander) — only heavy blocks collapse', () => {
+      const absCard: PortalCard = {
+        ...baseCard,
+        id: 'abs:ABS_SUBDOMAIN',
+        name: 'audiobookshelf',
+        label: 'Audiobooks',
+        setupAssets: [{ kind: 'audiobookshelf_deeplink', label: 'Open in Audiobookshelf app' }],
+      };
+      render(<PortalGrid cards={[absCard]} />);
+      // No expander; the deep-link button is directly reachable.
+      expect(screen.queryByText(/so koppelst du/i)).toBeNull();
+      expect(screen.getByRole('button', { name: /open in audiobookshelf app/i })).toBeDefined();
     });
   });
 });

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useSyncExternalStore } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
-  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, Code, Copy,
+  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, ChevronDown, Code, Copy,
   Download, ExternalLink, Files, Film, Folder, FolderOpen, Globe,
   Headphones, House, Image as ImageIcon, Images, KeyRound, Lightbulb,
   Lightbulb as LightbulbIcon, Loader2, Lock, Mail, MessageSquare,
@@ -195,18 +195,20 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
 
   return (
     <>
-    <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-start">
+    <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-stretch">
       {cards.map(card => {
         return (
           <Card
             key={card.id}
             padding="none"
-            className={`overflow-hidden flex flex-col col-span-1 ${SIZE_TIER_SPAN[card.sizeTier]}`}
+            className={`overflow-hidden flex flex-col h-full col-span-1 ${SIZE_TIER_SPAN[card.sizeTier]}`}
           >
             {/* Header — icon + title + tagline. The tagline is clamped
-                to 3 lines; height is content-driven now (#1700), so the
-                old `min-h` equal-Y filler is dropped — `items-start` on
-                the grid stops the row-stretch. */}
+                to 3 lines so the header height is consistent across
+                cards; the grid stretches rows to equal height
+                (`items-stretch` + card `h-full`, #2116) and the
+                variable-content region below carries `flex-1` to absorb
+                the slack — cards in a row line up cleanly. */}
             <div className="p-space-5 pb-space-3">
               <CardIcon card={card} />
               <div className="flex items-center gap-space-2">
@@ -222,56 +224,19 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
                 clamped header above. Consistent Y across cards. An
                 Open-URL card shows the accent "Open" button; a URL-less
                 appless card (#1618) shows its primary action instead,
-                followed by any secondary action buttons. */}
+                followed by any secondary action buttons. Stays visible
+                like every other card's primary affordance (#2116). */}
             <div className="px-space-5 space-y-space-2">
               <CardCta card={card} isMobile={isMobile} />
             </div>
 
-            {/* Variable content below. Height is content-driven (#1700) —
-                no `flex-1` filler; cards no longer stretch to a row's
-                tallest sibling. */}
-            <div className="px-space-5 pt-space-3 pb-space-5 space-y-space-3">
+            {/* Variable content below. `flex-1` lets the card stretch to
+                the row's tallest sibling (#2116) so a row of cards lines
+                up; the footer "How do I use this?" sits at the bottom. */}
+            <div className="flex-1 px-space-5 pt-space-3 pb-space-5 space-y-space-3">
 
               {card.setupAssets.length > 0 && (
-                <div className="space-y-1.5">
-                  {card.setupAssets.map(asset => {
-                    if (!shouldShowAsset(asset.kind, isIOS, isMobile)) return null;
-                    const meta = ASSET_LABELS[asset.kind];
-                    const Icon = meta.icon;
-                    const label = assetLabel(asset.kind, asset.label, isIOS);
-                    if (asset.kind === 'ios_calendar_profile') {
-                      return (
-                        <div key={asset.kind}>
-                          <a
-                            href={`/api/portal/asset/${card.name}/${asset.kind}?subdomain_var=${encodeURIComponent(card.subdomainVar)}`}
-                            className={PORTAL_LINK_BUTTON}
-                          >
-                            <Icon size={14} /> {label}
-                          </a>
-                          {asset.description && (
-                            <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{asset.description}</p>
-                          )}
-                        </div>
-                      );
-                    }
-                    if (asset.kind === 'audiobookshelf_deeplink') {
-                      return (
-                        <DeepLinkButton key={asset.kind} card={card} kind={asset.kind} label={label} description={asset.description} Icon={Icon} />
-                      );
-                    }
-                    if (asset.kind === 'syncthing_qr') {
-                      return (
-                        <SyncthingQrButton key={asset.kind} card={card} label={label} description={asset.description} Icon={Icon} />
-                      );
-                    }
-                    if (asset.kind === 'basicsync_install_qr') {
-                      return (
-                        <BasicSyncInstallQrButton key={asset.kind} label={label} description={asset.description} Icon={Icon} />
-                      );
-                    }
-                    return null;
-                  })}
-                </div>
+                <SetupAssets card={card} isIOS={isIOS} isMobile={isMobile} />
               )}
 
               {card.manualPairing.length > 0 && (
@@ -337,6 +302,108 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
     )}
     </>
   );
+}
+
+/**
+ * Setup-asset list, collapsed behind a "How to pair" / "So koppelst du"
+ * expander (#2116). Several services (notably file-share / Syncthing)
+ * ship a verbose pairing block — Install BasicSync, Pair this device,
+ * the storage-path note, two QR codes — that dwarfed the other service
+ * cards and left the grid ragged. We tuck the whole asset block behind a
+ * `<details>` (closed by default) so the card's resting size matches its
+ * peers; the primary "Open" CTA above stays visible like every other
+ * card. Opening the expander reveals the BasicSync-install QR + the
+ * pairing QR + the storage-path/description notes — every asset stays
+ * reachable, the QR fetch-on-click flows are unchanged.
+ *
+ * A single light-weight asset (e.g. an audiobookshelf deep-link on a
+ * card that's otherwise compact) doesn't need hiding — only collapse
+ * when the block is genuinely heavy (a QR-bearing asset, or 2+ assets).
+ */
+function SetupAssets({
+  card,
+  isIOS,
+  isMobile,
+}: {
+  card: PortalCard;
+  isIOS: boolean;
+  isMobile: boolean;
+}) {
+  const visible = card.setupAssets.filter(a => shouldShowAsset(a.kind, isIOS, isMobile));
+  if (visible.length === 0) return null;
+
+  const buttons = (
+    <div className="space-y-1.5">
+      {visible.map(asset => (
+        <SetupAssetButton key={asset.kind} card={card} asset={asset} isIOS={isIOS} />
+      ))}
+    </div>
+  );
+
+  // Heavy pairing block (a QR-bearing asset, or several assets) → tuck
+  // behind a collapsed expander so the card stays compact. A single
+  // light asset renders inline (no expander needed).
+  const isHeavy =
+    visible.some(a => a.kind === 'syncthing_qr' || a.kind === 'basicsync_install_qr') ||
+    visible.length > 1;
+  if (!isHeavy) return buttons;
+
+  return (
+    <details className="group rounded-card border border-border bg-surface-2/50">
+      <summary className="flex items-center justify-between gap-space-2 cursor-pointer select-none px-space-3 py-space-2 text-sm font-medium text-text marker:content-none [&::-webkit-details-marker]:hidden">
+        <span className="flex items-center gap-space-2">
+          <QrCode size={14} className="text-accent shrink-0" /> So koppelst du
+          <span className="text-text-subtle font-normal">/ How to pair</span>
+        </span>
+        <ChevronDown size={16} className="text-text-subtle shrink-0 transition-transform group-open:rotate-180" />
+      </summary>
+      <div className="px-space-3 pb-space-3 pt-space-1">{buttons}</div>
+    </details>
+  );
+}
+
+/**
+ * Renders a single setup asset as its kind-specific button/link (#2116
+ * split out of {@link SetupAssets} to keep that under the per-function
+ * line budget). The QR-bearing kinds delegate to their own modal-owning
+ * components; the iOS calendar profile is a direct download link.
+ */
+function SetupAssetButton({
+  card,
+  asset,
+  isIOS,
+}: {
+  card: PortalCard;
+  asset: PortalCard['setupAssets'][number];
+  isIOS: boolean;
+}) {
+  const Icon = ASSET_LABELS[asset.kind].icon;
+  const label = assetLabel(asset.kind, asset.label, isIOS);
+  if (asset.kind === 'ios_calendar_profile') {
+    return (
+      <div>
+        <a
+          href={`/api/portal/asset/${card.name}/${asset.kind}?subdomain_var=${encodeURIComponent(card.subdomainVar)}`}
+          className={PORTAL_LINK_BUTTON}
+        >
+          <Icon size={14} /> {label}
+        </a>
+        {asset.description && (
+          <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{asset.description}</p>
+        )}
+      </div>
+    );
+  }
+  if (asset.kind === 'audiobookshelf_deeplink') {
+    return <DeepLinkButton card={card} kind={asset.kind} label={label} description={asset.description} Icon={Icon} />;
+  }
+  if (asset.kind === 'syncthing_qr') {
+    return <SyncthingQrButton card={card} label={label} description={asset.description} Icon={Icon} />;
+  }
+  if (asset.kind === 'basicsync_install_qr') {
+    return <BasicSyncInstallQrButton label={label} description={asset.description} Icon={Icon} />;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## What
Fixes the broken /portal layout: switches the card grid to an equal-height row (items-stretch + h-full + flex-1 content region) so same-row cards line up, and collapses the verbose Syncthing pairing block (BasicSync install QR + pairing QR + storage-path note) behind a default-closed "So koppelst du / How to pair" expander so the Syncthing card's resting size matches the other service cards. Builds on the #2107 token layer.

## Why
Closes #2116

## Risk
Low — frontend layout only on the public /portal surface; all functions preserved (Open links, recommended-apps, BasicSync install QR, pairing QR, create-account flow), no token regression.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 354 warnings = baseline)
- [x] npm run check:arch (invariants + depcruise 969 modules)
- [x] npm test (full — 3318 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: app/portal/ — operator dark-mode pixel-confirm owed)

<!-- sb-ai-comment -->
AI-generated