### PR TITLE
feat(portal,dashboards): portal bento grid + Network Map no-reset on poll

### DIFF
--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -134,10 +134,9 @@ describe('PortalGrid', () => {
       setupAssets: [{ kind: 'basicsync_install_qr', description: 'Open-source Syncthing client.' }],
     };
 
-    it('renders the install button (closed by default, no modal)', () => {
+    it('renders the install button inline (full-row card, no expander), no modal yet', () => {
       render(<PortalGrid cards={[basicSyncCard]} />);
-      // QR-bearing assets sit behind the "How to pair" expander (#2116).
-      fireEvent.click(screen.getByText(/so koppelst du/i));
+      // QR-bearing assets are inline columns in the full-row card (#2120).
       expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
       expect(screen.getByText('Open-source Syncthing client.')).toBeDefined();
       // Modal heading is not present until the button is clicked.
@@ -146,7 +145,6 @@ describe('PortalGrid', () => {
 
     it('opens the QR modal on click and closes it on backdrop click', () => {
       render(<PortalGrid cards={[basicSyncCard]} />);
-      fireEvent.click(screen.getByText(/so koppelst du/i));
       fireEvent.click(screen.getByRole('button', { name: /install basicsync on your phone/i }));
       // Modal now shows: heading + the direct-download link.
       expect(screen.getByRole('heading', { name: /install basicsync/i })).toBeDefined();
@@ -238,11 +236,10 @@ describe('PortalGrid', () => {
     });
   });
 
-  describe('sizeTier → column span (#1700)', () => {
-    /** Walk up from the card heading to the grid-cell wrapper (the div
-     *  that carries the `col-span-*` class). Post design-system migration
-     *  (#2107) the wrapper is the <Card> primitive — the heading's nearest
-     *  ancestor div with `rounded-card` (the token card chrome). */
+  describe('bento footprint → grid span (#2120)', () => {
+    /** Walk up from the card heading to the grid-cell wrapper (the <Card>
+     *  primitive — the heading's nearest ancestor div with `rounded-card`,
+     *  which carries the `col-span-*` footprint class). */
     const cardWrapper = (label: string): HTMLElement => {
       const heading = screen.getByRole('heading', { name: label });
       const wrapper = heading.closest('div.rounded-card');
@@ -250,29 +247,111 @@ describe('PortalGrid', () => {
       return wrapper as HTMLElement;
     };
 
-    it('gives a compact card md:col-span-3', () => {
-      render(<PortalGrid cards={[{ ...baseCard, sizeTier: 'compact' }]} />);
+    /** A file-share card carrying the heavy Syncthing pairing block →
+     *  derives the `full-row` footprint. */
+    const syncthingCard: PortalCard = {
+      ...baseCard,
+      id: 'file-share:SYNCTHING_SUBDOMAIN',
+      name: 'file-share',
+      label: 'Syncthing',
+      setupAssets: [
+        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone' },
+        { kind: 'syncthing_qr', label: 'Pair this device' },
+      ],
+    };
+
+    it('renders an ordinary service card as a 1×1 tile (single column)', () => {
+      render(<PortalGrid cards={[baseCard]} />);
       const cls = cardWrapper('Photos').className;
-      expect(cls).toContain('md:col-span-3');
-      expect(cls).toContain('col-span-1'); // mobile stays 1 col
+      expect(cls).toContain('col-span-1');
+      expect(cls).not.toContain('md:col-span-full'); // not full-row
     });
 
-    it('gives a regular card md:col-span-4', () => {
-      render(<PortalGrid cards={[{ ...baseCard, sizeTier: 'regular' }]} />);
-      expect(cardWrapper('Photos').className).toContain('md:col-span-4');
+    it('gives the Syncthing pairing card the full-row footprint (spans the grid width)', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      const cls = cardWrapper('Syncthing').className;
+      expect(cls).toContain('md:col-span-full');
+      expect(cls).toContain('col-span-1'); // narrow screens stay full-width single column
     });
 
-    it('gives a feature card md:col-span-6 (action-rich → wider)', () => {
-      render(<PortalGrid cards={[{ ...baseCard, sizeTier: 'feature' }]} />);
-      expect(cardWrapper('Photos').className).toContain('md:col-span-6');
+    it('marks the full-row card with a data-footprint hook', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      const wrapper = cardWrapper('Syncthing');
+      expect(wrapper.getAttribute('data-footprint')).toBe('full-row');
     });
 
-    it('renders a feature (action-rich) card wider than a compact one', () => {
-      const compact: PortalCard = { ...baseCard, id: 'a:x', label: 'Bare', sizeTier: 'compact' };
-      const feature: PortalCard = { ...baseCard, id: 'b:y', label: 'Files', sizeTier: 'feature' };
-      render(<PortalGrid cards={[compact, feature]} />);
-      expect(cardWrapper('Bare').className).toContain('md:col-span-3');
-      expect(cardWrapper('Files').className).toContain('md:col-span-6');
+    it('renders the bento grid as a fixed multi-column composition (3-col md, 1-col mobile)', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      const grid = screen.getByRole('heading', { name: 'Photos' }).closest('div.grid')!;
+      expect(grid.className).toContain('grid-cols-1');
+      expect(grid.className).toContain('md:grid-cols-3');
+      // Intentional bento, not content-driven equal-height stretch.
+      expect(grid.className).not.toContain('items-stretch');
+      expect(grid.className).toContain('items-start');
+    });
+
+    it('keeps a 1×1 tile equal-height with its peers (h-full) for an even bento row', () => {
+      render(<PortalGrid cards={[baseCard]} />);
+      expect(cardWrapper('Photos').className).toContain('h-full');
+    });
+  });
+
+  describe('full-row card horizontal layout (#2120)', () => {
+    const syncthingCard: PortalCard = {
+      ...baseCard,
+      id: 'file-share:SYNCTHING_SUBDOMAIN',
+      name: 'file-share',
+      label: 'Syncthing',
+      url: 'https://files.home.arpa',
+      setupAssets: [
+        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone', description: 'Install the app first.' },
+        { kind: 'syncthing_qr', label: 'Pair this device', description: 'Use /var/syncthing/Sync/<name> for the shared drive.' },
+      ],
+      recommendedApps: [{ name: 'Syncthing', url: 'https://syncthing.net', platforms: ['android'] }],
+    };
+
+    const cardWrapper = (label: string): HTMLElement =>
+      screen.getByRole('heading', { name: label }).closest('div.rounded-card') as HTMLElement;
+
+    it('lays the full-row card sections out horizontally side-by-side (md:flex-row + section column grid)', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      const wrapper = cardWrapper('Syncthing');
+      // Top-level row container goes horizontal on md+.
+      const row = wrapper.querySelector('div.md\\:flex-row');
+      expect(row).not.toBeNull();
+      // The section block is a horizontal column grid (not a tall stack).
+      const sectionGrid = wrapper.querySelector('div.md\\:grid-cols-2');
+      expect(sectionGrid).not.toBeNull();
+    });
+
+    it('shows the BasicSync install + Pair QRs inline (NOT collapsed behind an expander)', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      // No "How to pair" expander in the full-row layout — buttons are
+      // directly reachable as side-by-side columns.
+      expect(screen.queryByText(/so koppelst du/i)).toBeNull();
+      expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
+      expect(screen.getByRole('button', { name: /pair this device/i })).toBeDefined();
+    });
+
+    it('keeps the Open CTA + storage-path note + recommended apps in the full-row card', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      const open = screen.getByRole('link', { name: /^open$/i });
+      expect(open.getAttribute('href')).toBe('https://files.home.arpa');
+      expect(screen.getByText(/\/var\/syncthing\/sync/i)).toBeDefined();
+      expect(screen.getByRole('link', { name: 'Syncthing' }).getAttribute('href')).toBe('https://syncthing.net');
+    });
+
+    it('still opens the pairing QR modal from the inline button (function preserved)', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
+      fireEvent.click(screen.getByRole('button', { name: /pair this device/i }));
+      expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
+    });
+
+    it('stacks the full-row card columns on narrow screens (flex-col base, md:flex-row)', () => {
+      render(<PortalGrid cards={[syncthingCard]} />);
+      const row = cardWrapper('Syncthing').querySelector('div.flex-col.md\\:flex-row');
+      expect(row).not.toBeNull();
     });
   });
 
@@ -392,9 +471,8 @@ describe('PortalGrid', () => {
 
     it('renders the pair button on tokens and keeps the fetch-on-click QR flow', () => {
       render(<PortalGrid cards={[syncCard]} />);
-      // The pairing block is now behind a "How to pair" expander (#2116);
-      // open it first, then the pair button is reachable.
-      fireEvent.click(screen.getByText(/so koppelst du/i));
+      // The pairing block is an inline column in the full-row card (#2120) —
+      // the pair button is directly reachable, no expander.
       const btn = screen.getByRole('button', { name: /pair/i });
       expect(btn.className).toContain('bg-accent');
       expect(btn.className).not.toContain('bg-emerald-600');
@@ -405,7 +483,7 @@ describe('PortalGrid', () => {
     });
   });
 
-  describe('balanced equal-height card grid (#2116)', () => {
+  describe('even bento tile composition (#2120)', () => {
     /** The grid container is the heading's nearest ancestor div carrying
      *  the `grid` class. */
     const gridOf = (label: string): HTMLElement => {
@@ -416,82 +494,36 @@ describe('PortalGrid', () => {
     const cardOf = (label: string): HTMLElement =>
       screen.getByRole('heading', { name: label }).closest('div.rounded-card') as HTMLElement;
 
-    it('stretches grid rows so same-row cards share a height (items-stretch + h-full)', () => {
+    it('renders a fixed bento composition (md:grid-cols-3, items-start, not stretch)', () => {
       render(<PortalGrid cards={[baseCard]} />);
       const grid = gridOf('Photos');
-      expect(grid.className).toContain('items-stretch');
-      expect(grid.className).not.toContain('items-start');
-      // Each card fills the stretched row.
-      expect(cardOf('Photos').className).toContain('h-full');
+      expect(grid.className).toContain('md:grid-cols-3');
+      expect(grid.className).toContain('items-start');
+      expect(grid.className).not.toContain('items-stretch');
     });
 
-    it('keeps a responsive 1 / multi-col layout (1 col mobile, 12-col md track)', () => {
+    it('keeps a responsive 1 / multi-col layout (1 col mobile, 3-col md track)', () => {
       render(<PortalGrid cards={[baseCard]} />);
       const grid = gridOf('Photos');
       expect(grid.className).toContain('grid-cols-1');
-      expect(grid.className).toContain('md:grid-cols-12');
+      expect(grid.className).toContain('md:grid-cols-3');
       expect(grid.className).toContain('gap-6');
     });
 
-    it('renders an even row of three regular cards that each fill the row height', () => {
-      const a: PortalCard = { ...baseCard, id: 'a:x', label: 'Alpha', sizeTier: 'regular' };
-      const b: PortalCard = { ...baseCard, id: 'b:y', label: 'Beta', sizeTier: 'regular' };
-      const c: PortalCard = { ...baseCard, id: 'c:z', label: 'Gamma', sizeTier: 'regular' };
+    it('renders an even row of three 1×1 tiles that each fill the row height', () => {
+      const a: PortalCard = { ...baseCard, id: 'a:x', label: 'Alpha' };
+      const b: PortalCard = { ...baseCard, id: 'b:y', label: 'Beta' };
+      const c: PortalCard = { ...baseCard, id: 'c:z', label: 'Gamma' };
       render(<PortalGrid cards={[a, b, c]} />);
       for (const label of ['Alpha', 'Beta', 'Gamma']) {
         expect(cardOf(label).className).toContain('h-full');
-        expect(cardOf(label).className).toContain('md:col-span-4');
+        expect(cardOf(label).className).toContain('col-span-1');
       }
     });
   });
 
-  describe('Syncthing pairing block collapsed behind expander (#2116)', () => {
-    const syncCard: PortalCard = {
-      ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'Syncthing',
-      setupAssets: [
-        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone', description: 'Install the app first.' },
-        { kind: 'syncthing_qr', label: 'Pair this device', description: 'Use /var/syncthing/Sync/<name> for the shared drive.' },
-      ],
-    };
-
-    it('keeps the primary Open CTA visible at rest, like other cards', () => {
-      render(<PortalGrid cards={[syncCard]} />);
-      expect(screen.getByRole('link', { name: /^open$/i })).toBeDefined();
-    });
-
-    it('hides the pairing buttons behind a collapsed "How to pair" expander by default', () => {
-      render(<PortalGrid cards={[syncCard]} />);
-      // The summary is present...
-      const summary = screen.getByText(/so koppelst du/i);
-      expect(summary).toBeDefined();
-      // ...and its <details> is closed by default → buttons not actionable yet.
-      const details = summary.closest('details');
-      expect(details).not.toBeNull();
-      expect((details as HTMLDetailsElement).open).toBe(false);
-    });
-
-    it('reveals the BasicSync install QR + pairing QR + storage-path note when opened', () => {
-      render(<PortalGrid cards={[syncCard]} />);
-      fireEvent.click(screen.getByText(/so koppelst du/i));
-      // Both QR-launching buttons are now reachable.
-      expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
-      expect(screen.getByRole('button', { name: /pair this device/i })).toBeDefined();
-      // The storage-path note (asset description) is revealed.
-      expect(screen.getByText(/\/var\/syncthing\/sync/i)).toBeDefined();
-    });
-
-    it('still opens the pairing QR modal from inside the expander (function preserved)', () => {
-      render(<PortalGrid cards={[syncCard]} />);
-      fireEvent.click(screen.getByText(/so koppelst du/i));
-      expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
-      fireEvent.click(screen.getByRole('button', { name: /pair this device/i }));
-      expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
-    });
-
-    it('renders a single light asset inline (no expander) — only heavy blocks collapse', () => {
+  describe('1×1 tile keeps light setup assets inline (#2120)', () => {
+    it('renders a single light asset inline (no expander) — 1×1 tiles never grow a heavy block', () => {
       const absCard: PortalCard = {
         ...baseCard,
         id: 'abs:ABS_SUBDOMAIN',

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useSyncExternalStore } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
-  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, ChevronDown, Code, Copy,
+  BookOpen, Bot, Calendar, CalendarDays, Camera, Check, Code, Copy,
   Download, ExternalLink, Files, Film, Folder, FolderOpen, Globe,
   Headphones, House, Image as ImageIcon, Images, KeyRound, Lightbulb,
   Lightbulb as LightbulbIcon, Loader2, Lock, Mail, MessageSquare,
@@ -19,16 +19,48 @@ import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '
 
 type IconComponent = typeof Camera;
 
-/** Per-tier column span on the 12-col `md` grid (#1700). Action-rich
- *  cards get more width; light cards get less; height stays
- *  content-driven (the grid uses `items-start`, not stretch). These MUST
- *  be literal Tailwind classes — Tailwind can't see an interpolated
- *  `col-span-${n}`, so they'd get purged. Keyed by the server-derived
- *  `sizeTier` (`packages/backend/src/lib/portal/services.ts`). */
-const SIZE_TIER_SPAN: Record<PortalCard['sizeTier'], string> = {
-  compact: 'md:col-span-3', // 4 per row
-  regular: 'md:col-span-4', // 3 per row
-  feature: 'md:col-span-6', // 2 per row
+/**
+ * A card's grid footprint (#2120, portal-layout v2). The portal is a
+ * deliberate **bento composition**, not a content-driven equal-height
+ * grid: each card declares how much of the grid it occupies and its
+ * content adapts to that slot.
+ *   - `1x1`      — a standard service tile. One column on the bento
+ *                  grid; on narrow screens it stacks to full width.
+ *                  Text wraps/truncates to fit the tile.
+ *   - `full-row` — a content-heavy card (today: Syncthing/file-share,
+ *                  which carries the Install-BasicSync + Pair-device QRs
+ *                  + storage-path note). Spans the entire grid width and
+ *                  lays its sections out HORIZONTALLY side-by-side in one
+ *                  row — compact, not a tall pile.
+ */
+type CardFootprint = '1x1' | 'full-row';
+
+/**
+ * Derive a card's bento {@link CardFootprint} (#2120) from what it
+ * carries. The only full-row citizen today is the Syncthing/file-share
+ * card — it ships the heavy pairing block (Install-BasicSync QR + Pair
+ * QR + storage-path note) that dwarfed every 1×1 tile. We key off the
+ * QR-bearing setup assets (`syncthing_qr` / `basicsync_install_qr`)
+ * rather than the service name so the rule travels with the *content*:
+ * any future card that grows the same heavy pairing block gets the wide
+ * horizontal slot automatically, and a card that loses it drops back to
+ * 1×1. Everything else is a standard 1×1 tile.
+ */
+function cardFootprint(card: PortalCard): CardFootprint {
+  const hasPairingBlock = card.setupAssets.some(
+    a => a.kind === 'syncthing_qr' || a.kind === 'basicsync_install_qr',
+  );
+  return hasPairingBlock ? 'full-row' : '1x1';
+}
+
+/** Per-footprint grid-cell span (#2120). The bento grid is a fixed
+ *  3-column composition on `md`+; a 1×1 tile takes one column, a
+ *  full-row card spans every column. These MUST be literal Tailwind
+ *  classes — Tailwind can't see an interpolated `col-span-${n}`, so an
+ *  interpolated value would be purged. */
+const FOOTPRINT_SPAN: Record<CardFootprint, string> = {
+  '1x1': 'col-span-1',
+  'full-row': 'col-span-1 md:col-span-full',
 };
 
 /**
@@ -195,106 +227,22 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
 
   return (
     <>
-    <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-stretch">
-      {cards.map(card => {
-        return (
-          <Card
-            key={card.id}
-            padding="none"
-            className={`overflow-hidden flex flex-col h-full col-span-1 ${SIZE_TIER_SPAN[card.sizeTier]}`}
-          >
-            {/* Header — icon + title + tagline. The tagline is clamped
-                to 3 lines so the header height is consistent across
-                cards; the grid stretches rows to equal height
-                (`items-stretch` + card `h-full`, #2116) and the
-                variable-content region below carries `flex-1` to absorb
-                the slack — cards in a row line up cleanly. */}
-            <div className="p-space-5 pb-space-3">
-              <CardIcon card={card} />
-              <div className="flex items-center gap-space-2">
-                <h2 className="text-xl font-bold text-text">{card.label}</h2>
-                <StatusBadge status={card.status} reason={card.statusReason} />
-              </div>
-              <p className="mt-space-2 text-sm text-text-muted line-clamp-3">
-                {card.tagline ?? ''}
-              </p>
-            </div>
-
-            {/* CTA — at fixed offset from card top thanks to the
-                clamped header above. Consistent Y across cards. An
-                Open-URL card shows the accent "Open" button; a URL-less
-                appless card (#1618) shows its primary action instead,
-                followed by any secondary action buttons. Stays visible
-                like every other card's primary affordance (#2116). */}
-            <div className="px-space-5 space-y-space-2">
-              <CardCta card={card} isMobile={isMobile} />
-            </div>
-
-            {/* Variable content below. `flex-1` lets the card stretch to
-                the row's tallest sibling (#2116) so a row of cards lines
-                up; the footer "How do I use this?" sits at the bottom. */}
-            <div className="flex-1 px-space-5 pt-space-3 pb-space-5 space-y-space-3">
-
-              {card.setupAssets.length > 0 && (
-                <SetupAssets card={card} isIOS={isIOS} isMobile={isMobile} />
-              )}
-
-              {card.manualPairing.length > 0 && (
-                <ManualPairingPanel steps={card.manualPairing} />
-              )}
-
-              {card.recommendedApps.length > 0 && (
-                <div className="pt-space-2 space-y-1.5">
-                  <div className="text-[11px] uppercase tracking-wide font-medium text-text-muted">
-                    <Sparkles size={11} className="inline align-middle -mt-0.5" /> Recommended apps
-                  </div>
-                  <ul className="space-y-1.5">
-                    {card.recommendedApps.map(app => (
-                      <li key={app.url} className="text-xs">
-                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-                          <a
-                            href={app.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="font-medium text-accent hover:underline"
-                          >
-                            {app.name}
-                          </a>
-                          {app.platforms?.map(p => (
-                            <span
-                              key={p}
-                              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-chip bg-surface-2 text-text-muted"
-                            >
-                              {PLATFORM_LABELS[p]}
-                            </span>
-                          ))}
-                        </div>
-                        {app.note && (
-                          <p className="text-text-subtle mt-0.5 leading-snug">
-                            {app.note}
-                          </p>
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {card.body.trim().length > 0 && (
-                <div>
-                  <button
-                    onClick={() => setActiveCardId(card.id)}
-                    className="flex items-center gap-1 text-sm text-accent hover:underline mt-space-2"
-                    aria-haspopup="dialog"
-                  >
-                    How do I use this?
-                  </button>
-                </div>
-              )}
-            </div>
-          </Card>
-        );
-      })}
+    {/* Deliberate bento composition (#2120). A fixed 3-column grid on
+        `md`+: 1×1 service tiles tile evenly; a `full-row` card spans
+        every column and lays its sections out horizontally. `auto-rows`
+        keeps tile rows even; `items-start` lets a full-row card own its
+        own (shorter) height instead of stretching the whole row. On
+        narrow screens everything collapses to a single column. */}
+    <div className="grid grid-cols-1 md:grid-cols-3 auto-rows-auto gap-6 items-start">
+      {cards.map(card => (
+        <BentoCard
+          key={card.id}
+          card={card}
+          isIOS={isIOS}
+          isMobile={isMobile}
+          onHelp={() => setActiveCardId(card.id)}
+        />
+      ))}
     </div>
 
     {activeCard && (
@@ -304,21 +252,257 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
   );
 }
 
+/** Dispatch a card to its bento footprint renderer (#2120): a content-
+ *  heavy `full-row` card to {@link FullRowCard}, everything else to the
+ *  standard 1×1 {@link StandardCard}. */
+function BentoCard(props: {
+  card: PortalCard;
+  isIOS: boolean;
+  isMobile: boolean;
+  onHelp: () => void;
+}) {
+  return cardFootprint(props.card) === 'full-row' ? (
+    <FullRowCard {...props} />
+  ) : (
+    <StandardCard {...props} />
+  );
+}
+
 /**
- * Setup-asset list, collapsed behind a "How to pair" / "So koppelst du"
- * expander (#2116). Several services (notably file-share / Syncthing)
- * ship a verbose pairing block — Install BasicSync, Pair this device,
- * the storage-path note, two QR codes — that dwarfed the other service
- * cards and left the grid ragged. We tuck the whole asset block behind a
- * `<details>` (closed by default) so the card's resting size matches its
- * peers; the primary "Open" CTA above stays visible like every other
- * card. Opening the expander reveals the BasicSync-install QR + the
- * pairing QR + the storage-path/description notes — every asset stays
- * reachable, the QR fetch-on-click flows are unchanged.
- *
- * A single light-weight asset (e.g. an audiobookshelf deep-link on a
- * card that's otherwise compact) doesn't need hiding — only collapse
- * when the block is genuinely heavy (a QR-bearing asset, or 2+ assets).
+ * Standard 1×1 service tile (#2120). One column of the bento grid (full
+ * width on narrow screens). Content adapts to the tile: the label
+ * truncates and the tagline clamps to fit the fixed slot. Tiles in a row
+ * share a height (`h-full`) so the bento composition reads as even and
+ * intentional rather than ragged.
+ */
+function StandardCard({
+  card,
+  isIOS,
+  isMobile,
+  onHelp,
+}: {
+  card: PortalCard;
+  isIOS: boolean;
+  isMobile: boolean;
+  onHelp: () => void;
+}) {
+  return (
+    <Card
+      padding="none"
+      className={`overflow-hidden flex flex-col h-full ${FOOTPRINT_SPAN['1x1']}`}
+    >
+      {/* Header — icon + title + tagline. Title truncates and tagline
+          clamps so the tile content fits its 1×1 slot (#2120). */}
+      <div className="p-space-5 pb-space-3">
+        <CardIcon card={card} />
+        <div className="flex items-center gap-space-2 min-w-0">
+          <h2 className="text-xl font-bold text-text truncate min-w-0">{card.label}</h2>
+          <StatusBadge status={card.status} reason={card.statusReason} />
+        </div>
+        <p className="mt-space-2 text-sm text-text-muted line-clamp-3">
+          {card.tagline ?? ''}
+        </p>
+      </div>
+
+      {/* CTA — Open-URL card shows the accent "Open" button; a URL-less
+          appless card (#1618) shows its primary action instead. */}
+      <div className="px-space-5 space-y-space-2">
+        <CardCta card={card} isMobile={isMobile} />
+      </div>
+
+      {/* Variable content. `flex-1` lets the tile stretch to its row's
+          tallest sibling so the bento row stays even (#2120). */}
+      <div className="flex-1 px-space-5 pt-space-3 pb-space-5 space-y-space-3">
+        {card.setupAssets.length > 0 && (
+          <SetupAssets card={card} isIOS={isIOS} isMobile={isMobile} />
+        )}
+        {card.manualPairing.length > 0 && (
+          <ManualPairingPanel steps={card.manualPairing} />
+        )}
+        {card.recommendedApps.length > 0 && (
+          <RecommendedApps apps={card.recommendedApps} />
+        )}
+        {card.body.trim().length > 0 && <HowToButton onClick={onHelp} />}
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * Full-row bento card (#2120). A content-heavy card (Syncthing) that
+ * spans the whole grid width and lays its sections out HORIZONTALLY
+ * side-by-side — the "Open" CTA, the BasicSync-install QR, the Pair QR,
+ * and the recommended-apps/storage-path note become adjacent columns
+ * instead of a tall stack. On narrow screens the columns stack and the
+ * card stays full width — keeping the verbose pairing block from
+ * towering over the 1×1 tiles while every affordance stays directly
+ * reachable (QRs inline, not collapsed).
+ */
+function FullRowCard({
+  card,
+  isIOS,
+  isMobile,
+  onHelp,
+}: {
+  card: PortalCard;
+  isIOS: boolean;
+  isMobile: boolean;
+  onHelp: () => void;
+}) {
+  return (
+    <Card
+      padding="none"
+      data-footprint="full-row"
+      className={`overflow-hidden ${FOOTPRINT_SPAN['full-row']}`}
+    >
+      <div className="p-space-5 flex flex-col md:flex-row md:items-start gap-space-5">
+        <FullRowLeadColumn card={card} isMobile={isMobile} onHelp={onHelp} />
+
+        {/* Horizontal section columns — the pairing block + extras flow
+            side-by-side on `md`+, stacking on narrow screens. */}
+        <div className="flex-1 min-w-0 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-space-4 items-start">
+          {card.setupAssets.length > 0 && (
+            <FullRowSetupColumns card={card} isIOS={isIOS} isMobile={isMobile} />
+          )}
+          {card.manualPairing.length > 0 && (
+            <div className="min-w-0">
+              <ManualPairingPanel steps={card.manualPairing} />
+            </div>
+          )}
+          {card.recommendedApps.length > 0 && (
+            <div className="min-w-0">
+              <RecommendedApps apps={card.recommendedApps} />
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+/** The full-row card's lead column (#2120): icon + title + status +
+ *  tagline + the Open CTA + the help button. Fixed-ish width so the
+ *  horizontal section columns get the remaining width. Split out to keep
+ *  {@link FullRowCard} under the per-function line budget. */
+function FullRowLeadColumn({
+  card,
+  isMobile,
+  onHelp,
+}: {
+  card: PortalCard;
+  isMobile: boolean;
+  onHelp: () => void;
+}) {
+  return (
+    <div className="md:w-64 md:shrink-0 space-y-space-3">
+      <CardIcon card={card} />
+      <div className="flex items-center gap-space-2 min-w-0">
+        <h2 className="text-xl font-bold text-text truncate min-w-0">{card.label}</h2>
+        <StatusBadge status={card.status} reason={card.statusReason} />
+      </div>
+      {card.tagline && (
+        <p className="text-sm text-text-muted leading-snug">{card.tagline}</p>
+      )}
+      <div className="space-y-space-2">
+        <CardCta card={card} isMobile={isMobile} />
+      </div>
+      {card.body.trim().length > 0 && <HowToButton onClick={onHelp} />}
+    </div>
+  );
+}
+
+/** "How do I use this?" footer button (#2120, extracted so the standard
+ *  and full-row cards share it). Opens the markdown help modal. */
+function HowToButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1 text-sm text-accent hover:underline mt-space-2"
+      aria-haspopup="dialog"
+    >
+      How do I use this?
+    </button>
+  );
+}
+
+/** Recommended-apps list (#2120, extracted to share between the 1×1 and
+ *  full-row card layouts). Each app link keeps its href/target/rel. */
+function RecommendedApps({ apps }: { apps: PortalCard['recommendedApps'] }) {
+  return (
+    <div className="pt-space-2 space-y-1.5">
+      <div className="text-[11px] uppercase tracking-wide font-medium text-text-muted">
+        <Sparkles size={11} className="inline align-middle -mt-0.5" /> Recommended apps
+      </div>
+      <ul className="space-y-1.5">
+        {apps.map(app => (
+          <li key={app.url} className="text-xs">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <a
+                href={app.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-accent hover:underline"
+              >
+                {app.name}
+              </a>
+              {app.platforms?.map(p => (
+                <span
+                  key={p}
+                  className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-chip bg-surface-2 text-text-muted"
+                >
+                  {PLATFORM_LABELS[p]}
+                </span>
+              ))}
+            </div>
+            {app.note && (
+              <p className="text-text-subtle mt-0.5 leading-snug">{app.note}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The full-row card's setup assets laid out as horizontal columns
+ * (#2120). Each visible asset (Install-BasicSync, Pair-this-device, …)
+ * becomes its own column cell in the full-row section grid — side-by-side
+ * on `md`+, stacking on narrow screens. The wide-slot counterpart to
+ * {@link SetupAssets}'s collapsed expander: here there's room to show
+ * every QR/install action inline. Buttons + fetch-on-click QR modals are
+ * unchanged — only the arrangement differs.
+ */
+function FullRowSetupColumns({
+  card,
+  isIOS,
+  isMobile,
+}: {
+  card: PortalCard;
+  isIOS: boolean;
+  isMobile: boolean;
+}) {
+  const visible = card.setupAssets.filter(a => shouldShowAsset(a.kind, isIOS, isMobile));
+  if (visible.length === 0) return null;
+  return (
+    <>
+      {visible.map(asset => (
+        <div key={asset.kind} className="min-w-0">
+          <SetupAssetButton card={card} asset={asset} isIOS={isIOS} />
+        </div>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Setup-asset list for a 1×1 tile (#2116/#2120). The heavy QR pairing
+ * block now lives in the `full-row` card ({@link FullRowSetupColumns}),
+ * so in a 1×1 tile this only ever renders light assets (an iOS calendar
+ * profile, an audiobookshelf deep-link). A single light asset renders
+ * inline; if a tile happens to carry 2+ light assets we still tuck them
+ * behind a collapsed "How to pair" / "So koppelst du" `<details>` so the
+ * tile's resting size matches its peers — every asset stays reachable.
  */
 function SetupAssets({
   card,
@@ -332,33 +516,15 @@ function SetupAssets({
   const visible = card.setupAssets.filter(a => shouldShowAsset(a.kind, isIOS, isMobile));
   if (visible.length === 0) return null;
 
-  const buttons = (
+  // In a 1×1 tile the assets are always light (the heavy QR pairing
+  // block forces a `full-row` card → FullRowSetupColumns), so they
+  // render inline directly — no collapse needed.
+  return (
     <div className="space-y-1.5">
       {visible.map(asset => (
         <SetupAssetButton key={asset.kind} card={card} asset={asset} isIOS={isIOS} />
       ))}
     </div>
-  );
-
-  // Heavy pairing block (a QR-bearing asset, or several assets) → tuck
-  // behind a collapsed expander so the card stays compact. A single
-  // light asset renders inline (no expander needed).
-  const isHeavy =
-    visible.some(a => a.kind === 'syncthing_qr' || a.kind === 'basicsync_install_qr') ||
-    visible.length > 1;
-  if (!isHeavy) return buttons;
-
-  return (
-    <details className="group rounded-card border border-border bg-surface-2/50">
-      <summary className="flex items-center justify-between gap-space-2 cursor-pointer select-none px-space-3 py-space-2 text-sm font-medium text-text marker:content-none [&::-webkit-details-marker]:hidden">
-        <span className="flex items-center gap-space-2">
-          <QrCode size={14} className="text-accent shrink-0" /> So koppelst du
-          <span className="text-text-subtle font-normal">/ How to pair</span>
-        </span>
-        <ChevronDown size={16} className="text-text-subtle shrink-0 transition-transform group-open:rotate-180" />
-      </summary>
-      <div className="px-space-3 pb-space-3 pt-space-1">{buttons}</div>
-    </details>
   );
 }
 

--- a/packages/frontend/src/dashboards/NetworkDashboard.test.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.test.tsx
@@ -47,6 +47,17 @@ vi.mock('@xyflow/react', () => {
 });
 vi.mock('@xyflow/react/dist/style.css', () => ({}));
 
+// #2119 — spy on the ELK layout so a test can assert an identical-topology
+// poll does NOT re-run it. getLayoutedElements just echoes its input here.
+// Hoisted so the (hoisted) vi.mock factory can reference it safely.
+const { getLayoutedElements } = vi.hoisted(() => ({
+  getLayoutedElements: vi.fn(async (nodes: unknown[], edges: unknown[]) => ({ nodes, edges })),
+}));
+vi.mock('@servicebay/api-client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getLayoutedElements };
+});
+
 vi.mock('@/hooks/useTopologyData', () => ({
   useTopologyData: () => ({ rawData: topologyRawData, fetchGraph, twin: null }),
 }));
@@ -125,6 +136,61 @@ describe('NetworkDashboard (#2100 dashboards migration)', () => {
     // when focusNodeId is set). That proves the param was read + resolved to
     // the matching node id and applied.
     expect(await screen.findByTestId('focus-back')).toBeDefined();
+  });
+
+  it('#2119 does NOT re-run the ELK layout when a poll returns an identical topology', async () => {
+    getLayoutedElements.mockClear();
+    topologyRawData = {
+      nodes: [
+        { id: 'internet', type: 'internet', label: 'Internet' },
+        { id: 'service-immich.service', type: 'service', label: 'immich', status: 'up' },
+      ],
+      edges: [{ id: 'e1', source: 'internet', target: 'service-immich.service' }],
+    };
+
+    const { rerender } = render(<NetworkDashboard />);
+    await waitFor(() => expect(getLayoutedElements).toHaveBeenCalled());
+    // Let the initial layout (+ the initial-collapse re-render) settle.
+    await new Promise((r) => setTimeout(r, 20));
+    const layoutCallsAfterInitialLoad = getLayoutedElements.mock.calls.length;
+
+    // A poll: same node + edge ids, only the status flips. New object identity
+    // (as a real fetch produces) but an identical topology signature.
+    topologyRawData = {
+      nodes: [
+        { id: 'internet', type: 'internet', label: 'Internet' },
+        { id: 'service-immich.service', type: 'service', label: 'immich', status: 'down' },
+      ],
+      edges: [{ id: 'e1', source: 'internet', target: 'service-immich.service' }],
+    };
+    rerender(<NetworkDashboard />);
+
+    // No further ELK pass — the status update merges onto the existing positions.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(getLayoutedElements.mock.calls.length).toBe(layoutCallsAfterInitialLoad);
+  });
+
+  it('#2119 re-runs the ELK layout when the topology actually changes (node added)', async () => {
+    getLayoutedElements.mockClear();
+    topologyRawData = {
+      nodes: [{ id: 'service-a.service', type: 'service', label: 'a' }],
+      edges: [],
+    };
+    const { rerender } = render(<NetworkDashboard />);
+    await waitFor(() => expect(getLayoutedElements).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 20));
+    const before = getLayoutedElements.mock.calls.length;
+
+    topologyRawData = {
+      nodes: [
+        { id: 'service-a.service', type: 'service', label: 'a' },
+        { id: 'service-b.service', type: 'service', label: 'b' },
+      ],
+      edges: [],
+    };
+    rerender(<NetworkDashboard />);
+    // Topology changed → a fresh ELK pass runs.
+    await waitFor(() => expect(getLayoutedElements.mock.calls.length).toBeGreaterThan(before));
   });
 
   it('#2108 does NOT enter focus mode when the focus param matches no node (stale link)', async () => {

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -51,7 +51,9 @@ import {
   DOWN_EDGE_DASHES,
   deriveNodeNameFromGraph,
   labelForEdgeKind,
+  mergeGraphPreservingPositions,
   styleForEdgeKind,
+  topologyLayoutSignature,
   type GraphNodeData,
   type HealthData,
   type LegacyPortMapping,
@@ -823,6 +825,15 @@ export default function NetworkDashboard() {
   const [selectedEdge, setSelectedEdge] = useState<string | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const rawGraphData = React.useRef<{ nodes: Node[], edges: Edge[] } | null>(null);
+  // #2119 — the topology signature (node ids + edge ids + collapsed set +
+  // focus) of the currently laid-out graph, and a snapshot of that laid-out
+  // graph. A poll whose signature is unchanged does NOT re-run ELK or reset the
+  // viewport — it merges fresh status/health onto the existing positions. We
+  // fitView only on the FIRST layout and on a focus change (intentional camera
+  // moves), never on a steady-state refresh.
+  const layoutSignatureRef = React.useRef<string | null>(null);
+  const laidOutGraphRef = React.useRef<{ nodes: Node<GraphNodeData>[]; edges: Edge[] } | null>(null);
+  const hasFitViewRef = React.useRef(false);
     const activeToastRef = React.useRef<string | null>(null);
     const { addToast, updateToast, removeToast } = useToast();
 
@@ -1119,16 +1130,81 @@ export default function NetworkDashboard() {
 
     // 4. Layout
     const layouted = await getLayoutedElements(layoutNodes, layoutEdges);
-    setNodes(applyFilter(layouted.nodes as Node<GraphNodeData>[], search));
-    setEdges(layouted.edges);
+    const filteredNodes = applyFilter(layouted.nodes as Node<GraphNodeData>[], search);
+    const layoutedEdges = layouted.edges;
+    setNodes(filteredNodes);
+    setEdges(layoutedEdges);
+    // #2119 — snapshot the laid-out graph so a subsequent identical-topology
+    // poll can merge fresh status/health onto these positions in-place
+    // (no ELK, no viewport reset).
+    laidOutGraphRef.current = { nodes: filteredNodes, edges: layoutedEdges };
 
-    // After a focus re-layout, zoom the viewport to the reduced subgraph.
+    // #2119 — fit the viewport only on the FIRST layout (empty → first data)
+    // and on a focus change (the #2108 ego-action is an intentional camera
+    // move). Steady-state polls never reach here, so the pan/zoom is preserved.
     if (focus) {
         requestAnimationFrame(() => {
             reactFlowInstance.current?.fitView({ padding: 0.2, duration: 400 });
         });
+    } else if (!hasFitViewRef.current) {
+        hasFitViewRef.current = true;
+        requestAnimationFrame(() => {
+            reactFlowInstance.current?.fitView({ padding: 0.18, minZoom: 0.7, maxZoom: 1.2 });
+        });
     }
   }, [setNodes, setEdges, applyFilter]);
+
+  // #2119 — identical-topology poll path: merge the fresh status/health data
+  // onto the already-laid-out positions and re-apply the search filter, without
+  // running ELK or touching the viewport. Requires a prior laid-out snapshot.
+  const mergeInPlace = useCallback((freshNodes: Node<GraphNodeData>[], freshEdges: Edge[], search: string) => {
+      const prev = laidOutGraphRef.current;
+      if (!prev) return;
+      const merged = mergeGraphPreservingPositions(prev.nodes, prev.edges, freshNodes, freshEdges);
+      const filtered = applyFilter(merged.nodes, search);
+      laidOutGraphRef.current = { nodes: filtered, edges: merged.edges };
+      setNodes(filtered);
+      setEdges(merged.edges);
+  }, [applyFilter, setNodes, setEdges]);
+
+  // #2119 — run-generation guard: each layout effect bumps this; an async
+  // pass only commits its focus/toast if it's still the latest run.
+  const layoutRunRef = React.useRef(0);
+
+  // #2119 — apply a fresh topology: merge in place when the signature is
+  // unchanged (no ELK, no viewport reset), else re-layout. #2108 — commit the
+  // resolved deep-link focus to state from the async callback so Back/Esc
+  // reflect it. Extracted from the effect to keep both under the size budget.
+  const applyTopology = useCallback(async (
+      gd: { nodes: Node<GraphNodeData>[]; edges: Edge[] },
+      currentCollapsed: Set<string>,
+      currentFocus: string | null,
+      signature: string,
+      focusPlan: ReturnType<typeof planDeepLinkFocus>,
+      runId: number,
+  ) => {
+      const topologyUnchanged =
+          layoutSignatureRef.current === signature && laidOutGraphRef.current !== null;
+      const hasFreshDeepLinkFocus = Boolean(focusPlan.appliedParam && focusPlan.nodeId);
+      const isStale = () => layoutRunRef.current !== runId;
+      try {
+          if (topologyUnchanged && !hasFreshDeepLinkFocus) {
+              mergeInPlace(gd.nodes, gd.edges, searchQuery);
+              if (!isStale()) resolveReloadToast('success', 'Latest network topology is ready');
+              return;
+          }
+          await processAndLayout(gd.nodes, gd.edges, currentCollapsed, searchQuery, currentFocus);
+          layoutSignatureRef.current = signature;
+          if (isStale()) return;
+          if (focusPlan.appliedParam && focusPlan.nodeId) {
+              appliedFocusParamRef.current = focusPlan.appliedParam;
+              setFocusNodeId(focusPlan.nodeId);
+          }
+          resolveReloadToast('success', 'Latest network topology is ready');
+      } catch {
+          if (!isStale()) resolveReloadToast('error', 'Unable to render network map');
+      }
+  }, [mergeInPlace, processAndLayout, searchQuery, resolveReloadToast, setFocusNodeId]);
 
   // #1071 phase 1: data layer (graph fetch + twin-driven auto-refresh
   // + the two effects that drive them) is in useTopologyData. Toast
@@ -1290,10 +1366,9 @@ export default function NetworkDashboard() {
   useEffect(() => {
       if (!graphData) return;
 
+      // currentFocus = the live focus state unless a fresh `?focus=` deep-link
+      // resolves below (its setState isn't visible until the next render).
       let currentCollapsed = collapsedGroups;
-      // The focus to lay out with this pass — the live state, unless we resolve
-      // a fresh `?focus=` deep-link below (whose setState won't be visible until
-      // the next render, so we feed the resolved id straight into this layout).
       let currentFocus = focusNodeId;
       if (!rawGraphData.current && graphData.nodes.length > 0) {
                   const groups = graphData.nodes
@@ -1303,13 +1378,9 @@ export default function NetworkDashboard() {
               setCollapsedGroups(currentCollapsed);
       }
 
-      // #2108 — resolve the `?focus=<service-name>` deep-link from the Services
-      // list to a concrete graph node id (handles the remote `<node>:` prefix).
-      // Each distinct param value is applied exactly once (ref-guard) so a
-      // manual node click / Back control isn't clobbered when this layout effect
-      // re-runs. The setState is deferred into the async runLayout callback
-      // below (not the synchronous effect body) so the first focused layout uses
-      // `currentFocus` and the Back control reflects state on the next render.
+      // #2108 — resolve the `?focus=` deep-link to a concrete node id, applied
+      // once per distinct param (ref-guard) so a manual click / Back isn't
+      // clobbered when this effect re-runs.
       const focusPlan = planDeepLinkFocus(
           graphData.nodes.map(n => n.id),
           focusParam,
@@ -1319,35 +1390,19 @@ export default function NetworkDashboard() {
       if (focusPlan.nodeId) currentFocus = focusPlan.nodeId;
 
       rawGraphData.current = graphData;
-      let cancelled = false;
 
-      const runLayout = async () => {
-          try {
-                await processAndLayout(graphData.nodes, graphData.edges, currentCollapsed, searchQuery, currentFocus);
-                if (!cancelled) {
-                     // #2108 — commit the resolved deep-link focus to state from
-                     // the async callback (subscription-style), so the Back
-                     // control + Esc-exit reflect it without a synchronous
-                     // setState in the effect body.
-                     if (focusPlan.appliedParam && focusPlan.nodeId) {
-                         appliedFocusParamRef.current = focusPlan.appliedParam;
-                         setFocusNodeId(focusPlan.nodeId);
-                     }
-                     resolveReloadToast('success', 'Latest network topology is ready');
-                }
-          } catch {
-                if (!cancelled) {
-                     resolveReloadToast('error', 'Unable to render network map');
-                }
-          }
-      };
-
-      runLayout();
-
-      return () => {
-          cancelled = true;
-      };
-  }, [graphData, processAndLayout, collapsedGroups, searchQuery, focusNodeId, focusParam, resolveReloadToast]);
+      // #2119 — signature folds the node/edge ids + collapsed set + focus
+      // (everything that moves POSITIONS); status/health/label are excluded, so
+      // a steady-state poll keeps the same signature → merge in place.
+      const signature = topologyLayoutSignature(
+          graphData.nodes,
+          graphData.edges,
+          currentCollapsed,
+          currentFocus,
+      );
+      const runId = ++layoutRunRef.current;
+      applyTopology(graphData, currentCollapsed, currentFocus, signature, focusPlan, runId);
+  }, [graphData, applyTopology, collapsedGroups, focusNodeId, focusParam]);
 
   useEffect(() => {
     // Setup SSE for progress updates
@@ -1524,7 +1579,9 @@ export default function NetworkDashboard() {
             onConnect={onConnect}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
-            fitView
+            // #2119 — fitView is driven imperatively (first layout + #2108 focus
+            // only). The declarative `fitView` prop refits whenever the node set
+            // changes, which would reset the viewport on every poll.
             fitViewOptions={{ padding: 0.18, minZoom: 0.7, maxZoom: 1.2 }}
             minZoom={0.1}
             maxZoom={2}

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { Node, Edge } from '@xyflow/react';
-import { computeEgoNodeIds, buildOrthogonalPath } from './networkDashboard';
+import {
+  computeEgoNodeIds,
+  buildOrthogonalPath,
+  topologyLayoutSignature,
+  mergeGraphPreservingPositions,
+} from './networkDashboard';
 
 // Minimal graph mirroring the map's shape:
 //   internet → router → nginx → {hermes, auth, immich}
@@ -195,5 +200,90 @@ describe('buildOrthogonalPath — line-hops (#1784)', () => {
       [{ x: 100, y: 999 }],
     );
     expect(path).not.toContain(' A ');
+  });
+});
+
+describe('#2119 topologyLayoutSignature', () => {
+  const n = (id: string, status?: string): Node =>
+    ({ id, type: 'custom', position: { x: 0, y: 0 }, data: { type: 'service', label: id, status } });
+  const e = (s: string, t: string): Edge => ({ id: `e-${s}-${t}`, source: s, target: t });
+
+  it('is identical when only node STATUS changes (no re-layout on a status poll)', () => {
+    const a = topologyLayoutSignature([n('s1', 'up'), n('s2', 'up')], [e('s1', 's2')]);
+    const b = topologyLayoutSignature([n('s1', 'down'), n('s2', 'up')], [e('s1', 's2')]);
+    expect(a).toBe(b);
+  });
+
+  it('is order-independent (same ids in a different array order match)', () => {
+    const a = topologyLayoutSignature([n('s1'), n('s2')], [e('s1', 's2')]);
+    const b = topologyLayoutSignature([n('s2'), n('s1')], [e('s1', 's2')]);
+    expect(a).toBe(b);
+  });
+
+  it('changes when a node is added', () => {
+    const a = topologyLayoutSignature([n('s1')], []);
+    const b = topologyLayoutSignature([n('s1'), n('s2')], []);
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when an edge is added', () => {
+    const a = topologyLayoutSignature([n('s1'), n('s2')], []);
+    const b = topologyLayoutSignature([n('s1'), n('s2')], [e('s1', 's2')]);
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when the collapsed set or focus changes', () => {
+    const base = topologyLayoutSignature([n('s1'), n('s2')], [e('s1', 's2')]);
+    expect(base).not.toBe(
+      topologyLayoutSignature([n('s1'), n('s2')], [e('s1', 's2')], new Set(['s1'])),
+    );
+    expect(base).not.toBe(
+      topologyLayoutSignature([n('s1'), n('s2')], [e('s1', 's2')], null, 's1'),
+    );
+  });
+});
+
+describe('#2119 mergeGraphPreservingPositions', () => {
+  const laid = (id: string, x: number, status?: string): Node =>
+    ({ id, type: 'custom', position: { x, y: x }, data: { type: 'service', label: id, status }, style: { width: 320 } });
+  const fresh = (id: string, status?: string): Node =>
+    ({ id, type: 'custom', position: { x: 0, y: 0 }, data: { type: 'service', label: id, status } });
+
+  it('carries the laid-out position forward while taking the fresh data', () => {
+    const { nodes } = mergeGraphPreservingPositions(
+      [laid('s1', 100, 'up'), laid('s2', 200, 'up')],
+      [],
+      [fresh('s1', 'down'), fresh('s2', 'up')],
+      [],
+    );
+    // positions preserved (NOT reset to the fresh {0,0})
+    expect(nodes.find((x) => x.id === 's1')!.position).toEqual({ x: 100, y: 100 });
+    expect(nodes.find((x) => x.id === 's2')!.position).toEqual({ x: 200, y: 200 });
+    // fresh status flows through
+    expect((nodes.find((x) => x.id === 's1')!.data as { status?: string }).status).toBe('down');
+    // layout-sized style preserved
+    expect(nodes.find((x) => x.id === 's1')!.style).toEqual({ width: 320 });
+  });
+
+  it('keeps the laid-out routed edge geometry, refreshing only styling/label', () => {
+    const laidEdge: Edge = {
+      id: 'e-s1-s2', source: 's1', target: 's2',
+      data: { points: [{ x: 1, y: 2 }], originalId: 'orig' },
+      style: { stroke: 'old' }, label: 'old',
+    };
+    const freshEdge: Edge = {
+      id: 'different', source: 's1', target: 's2',
+      data: { kind: 'observed' }, style: { stroke: 'new' }, label: 'new', animated: true,
+    };
+    const { edges } = mergeGraphPreservingPositions(
+      [laid('s1', 1), laid('s2', 2)], [laidEdge],
+      [fresh('s1'), fresh('s2')], [freshEdge],
+    );
+    const m = edges[0];
+    expect(m.id).toBe('e-s1-s2'); // routed/generated id preserved
+    expect((m.data as { points?: unknown }).points).toEqual([{ x: 1, y: 2 }]); // geometry preserved
+    expect((m.data as { kind?: string }).kind).toBe('observed'); // fresh provenance merged
+    expect(m.style).toEqual({ stroke: 'new' }); // styling refreshed
+    expect(m.label).toBe('new');
   });
 });

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -272,6 +272,93 @@ export function computeEgoNodeIds(
 }
 
 // ────────────────────────────────────────────────────────────────────
+// #2119 — topology signature + in-place data merge.
+//
+// The map polls every 1–3s. Re-running the ELK layout (and resetting node
+// positions + the pan/zoom viewport) on every poll made the map impossible
+// to navigate. The fix is to only re-layout when the *topology* actually
+// changed — and otherwise merge the fresh status/health data onto the
+// already-laid-out nodes, keeping their `position`.
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * A stable signature of what would change the layout: the set of node ids,
+ * the set of edge ids (source→target pairs), plus the collapsed-group set and
+ * the active focus node. Order-independent (ids are sorted) so a poll that
+ * returns the same topology in a different array order yields the SAME
+ * signature → no re-layout. Status / health / label changes do NOT move a
+ * node, so they are deliberately excluded from the signature.
+ */
+export function topologyLayoutSignature(
+  nodes: Node[],
+  edges: Edge[],
+  collapsed?: Set<string> | null,
+  focus?: string | null,
+): string {
+  const nodeIds = nodes.map((n) => n.id).sort();
+  // Use source→target (not the volatile generated edge id) so a stable
+  // topology keeps a stable edge signature across polls.
+  const edgeKeys = edges.map((e) => `${e.source}->${e.target}`).sort();
+  const collapsedIds = collapsed ? Array.from(collapsed).sort() : [];
+  return JSON.stringify({
+    n: nodeIds,
+    e: edgeKeys,
+    c: collapsedIds,
+    f: focus ?? null,
+  });
+}
+
+/**
+ * Merge a freshly-fetched graph onto the currently-laid-out nodes WITHOUT
+ * re-running the layout: for every existing node, carry its `position` (and
+ * layout-affecting `style` width/height) forward while taking the new `data`
+ * (status / metadata / label). Nodes that vanished are dropped; nodes that
+ * appeared are kept at their incoming position (shouldn't happen when the
+ * topology signature is unchanged, but handled defensively). Edges adopt the
+ * fresh styling/label but are matched to the laid-out edge by source→target
+ * so the routed `points`/`hops`/positions survive the poll.
+ */
+export function mergeGraphPreservingPositions<TNode extends Node, TEdge extends Edge>(
+  laidOutNodes: TNode[],
+  laidOutEdges: TEdge[],
+  freshNodes: TNode[],
+  freshEdges: TEdge[],
+): { nodes: TNode[]; edges: TEdge[] } {
+  const laidOutById = new Map(laidOutNodes.map((n) => [n.id, n]));
+  const nodes = freshNodes.map((fresh) => {
+    const prev = laidOutById.get(fresh.id);
+    if (!prev) return fresh;
+    return {
+      ...prev,
+      data: fresh.data,
+      // Keep the laid-out position + layout-sized style; refresh everything
+      // else (className etc.) from the fresh node.
+      position: prev.position,
+      style: prev.style,
+    } as TNode;
+  });
+
+  const laidOutEdgeByPair = new Map(
+    laidOutEdges.map((e) => [`${e.source}->${e.target}`, e]),
+  );
+  const edges = freshEdges.map((fresh) => {
+    const prev = laidOutEdgeByPair.get(`${fresh.source}->${fresh.target}`);
+    if (!prev) return fresh;
+    // Keep the routed geometry (data.points / hops / lpos, the generated id,
+    // sourceHandle/targetHandle) from the laid-out edge; refresh styling.
+    return {
+      ...prev,
+      label: fresh.label,
+      style: fresh.style,
+      animated: fresh.animated,
+      data: { ...(prev.data ?? {}), ...(fresh.data ?? {}) },
+    } as TEdge;
+  });
+
+  return { nodes, edges };
+}
+
+// ────────────────────────────────────────────────────────────────────
 // Edge-kind styling (#813). The backend stamps each edge with `kind`
 // (gateway | proxy | observed | declared | manual). The map must
 // render "I just saw this TCP flow" (observed, solid blue) and "the


### PR DESCRIPTION
## What
Two user-facing frontend fixes. The Network Map no longer resets its layout/viewport on every poll — re-layout is gated on a topology signature, so steady-state polls preserve pan/zoom and node positions (#2108 ego-focus intact). The public /portal page is rebuilt as a deliberate bento grid: each card declares a footprint (Syncthing = full-row with horizontal side-by-side sections, others 1×1), responsive on narrow screens.

## Why
Closes #2119
Closes #2120

## Risk
medium — both touch path-mandated frontend surfaces (NetworkDashboard layout effect; portal grid). Logic-verified; visual/interaction confirm owed to box-verify.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 352 warnings = baseline)
- [x] npm run check:arch
- [x] npm test (full — 3329 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: dashboards/NetworkDashboard.tsx + app/portal/)