### PR TITLE
feat(portal): redesign /portal as a uniform accented launcher grid

### DIFF
--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -143,6 +143,56 @@
   }
 }
 
+/*
+ * Per-service accent identity (#2126). The family portal scans like an
+ * app launcher: each service's icon-chip carries its own subtle tint so
+ * the grid is recognizable at a glance. These are an INTENTIONAL,
+ * named accent map — distinct from the semantic token layer above (those
+ * are for chrome; these are decorative per-service brand hues). Each
+ * `.svc-chip-*` utility sets only the icon-chip background + icon colour:
+ * a soft tinted fill + a saturated icon, never a full-card colour. Both
+ * dark (:root default) and light (prefers-color-scheme below) ramps are
+ * tuned so the chip reads on either surface. Driven from PortalGrid's
+ * SERVICE_ACCENT map → a literal class name (no interpolation).
+ */
+:root {
+  --svc-amber-bg: rgba(245, 158, 11, 0.16);  --svc-amber-fg: #fbbf24;  /* Smart Home */
+  --svc-blue-bg: rgba(59, 130, 246, 0.16);   --svc-blue-fg: #60a5fa;   /* Passwords */
+  --svc-teal-bg: rgba(20, 184, 166, 0.16);   --svc-teal-fg: #2dd4bf;   /* Photos */
+  --svc-orange-bg: rgba(249, 115, 22, 0.16); --svc-orange-fg: #fb923c; /* Files */
+  --svc-violet-bg: rgba(139, 92, 246, 0.16); --svc-violet-fg: #a78bfa; /* Audiobooks */
+  --svc-rose-bg: rgba(244, 63, 94, 0.16);    --svc-rose-fg: #fb7185;   /* Music */
+  --svc-red-bg: rgba(239, 68, 68, 0.16);     --svc-red-fg: #f87171;    /* Calendar */
+  --svc-indigo-bg: rgba(99, 102, 241, 0.16); --svc-indigo-fg: #818cf8; /* Claude Dev */
+  --svc-green-bg: rgba(34, 197, 94, 0.16);   --svc-green-fg: #4ade80;  /* Syncthing */
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    /* Lighter tinted fill + a darker 600-ramp icon so the chip reads on
+       white surfaces. */
+    --svc-amber-bg: rgba(245, 158, 11, 0.14);  --svc-amber-fg: #d97706;
+    --svc-blue-bg: rgba(59, 130, 246, 0.12);   --svc-blue-fg: #2563eb;
+    --svc-teal-bg: rgba(20, 184, 166, 0.14);   --svc-teal-fg: #0d9488;
+    --svc-orange-bg: rgba(249, 115, 22, 0.14); --svc-orange-fg: #ea580c;
+    --svc-violet-bg: rgba(139, 92, 246, 0.12); --svc-violet-fg: #7c3aed;
+    --svc-rose-bg: rgba(244, 63, 94, 0.12);    --svc-rose-fg: #e11d48;
+    --svc-red-bg: rgba(239, 68, 68, 0.12);     --svc-red-fg: #dc2626;
+    --svc-indigo-bg: rgba(99, 102, 241, 0.12); --svc-indigo-fg: #4f46e5;
+    --svc-green-bg: rgba(34, 197, 94, 0.12);   --svc-green-fg: #16a34a;
+  }
+}
+
+.svc-chip-amber  { background: var(--svc-amber-bg);  color: var(--svc-amber-fg); }
+.svc-chip-blue   { background: var(--svc-blue-bg);   color: var(--svc-blue-fg); }
+.svc-chip-teal   { background: var(--svc-teal-bg);   color: var(--svc-teal-fg); }
+.svc-chip-orange { background: var(--svc-orange-bg); color: var(--svc-orange-fg); }
+.svc-chip-violet { background: var(--svc-violet-bg); color: var(--svc-violet-fg); }
+.svc-chip-rose   { background: var(--svc-rose-bg);   color: var(--svc-rose-fg); }
+.svc-chip-red    { background: var(--svc-red-bg);    color: var(--svc-red-fg); }
+.svc-chip-indigo { background: var(--svc-indigo-bg); color: var(--svc-indigo-fg); }
+.svc-chip-green  { background: var(--svc-green-bg);  color: var(--svc-green-fg); }
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -1,15 +1,19 @@
 /**
- * PortalGrid component tests — covers the ManualPairingPanel (#1253)
- * and the per-card layout invariants.
+ * PortalGrid component tests (#2126 redesign).
  *
- * ManualPairingPanel is pure-presentational: it takes `steps[]` from
- * the PortalCard's `manualPairing` array and renders the amber
- * "Manual setup needed" callout with each step's title, optional
- * why-note, and a copyable command block. These tests exercise that
- * path directly by passing a card with `manualPairing` populated.
+ * The portal is now a uniform launcher grid: every card is the same size,
+ * grouped into small labelled sections. Each card's FRONT is calm (accent
+ * icon-chip + name + status dot + one-line description + a single Open
+ * CTA) and EVERYTHING secondary — recommended apps, manual-pairing steps,
+ * setup assets (Syncthing install + pairing QRs, calendar one-tap
+ * profile, audiobook deep-link), the how-to body — collapses behind a
+ * per-card "Apps & setup" disclosure, closed by default. These tests pin
+ * the disclosure behaviour, the uniform grid (no bento/full-row), the
+ * per-service accent, the grouping sections, and that all prior function
+ * is preserved.
  */
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import PortalGrid from './PortalGrid';
 import type { PortalCard } from '@/lib/portal/services';
 
@@ -34,6 +38,29 @@ const baseCard: PortalCard = {
   sizeTier: 'compact',
 };
 
+/** A file-share/Syncthing card carrying the heavy QR pairing block. */
+const syncthingCard: PortalCard = {
+  ...baseCard,
+  id: 'file-share:SYNCTHING_SUBDOMAIN',
+  name: 'file-share',
+  label: 'Syncthing',
+  lucideIcon: 'refresh-cw',
+  url: 'https://files.home.arpa',
+  setupAssets: [
+    { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone', description: 'Install the app first.' },
+    { kind: 'syncthing_qr', label: 'Pair this device', description: 'Use /var/syncthing/Sync/<name> for the shared drive.' },
+  ],
+  recommendedApps: [{ name: 'Syncthing', url: 'https://syncthing.net', platforms: ['android'] }],
+};
+
+/** Open the "Apps & setup" disclosure on the card whose heading matches. */
+const openDisclosure = (label: string): void => {
+  const summary = screen.getByRole('heading', { name: label })
+    .closest('[data-testid="service-card"]')!
+    .querySelector('summary')!;
+  fireEvent.click(summary);
+};
+
 describe('PortalGrid', () => {
   it('renders a card with its label and open button', () => {
     render(<PortalGrid cards={[baseCard]} />);
@@ -41,129 +68,407 @@ describe('PortalGrid', () => {
     expect(screen.getByRole('link', { name: /open/i })).toBeDefined();
   });
 
+  it('still shows the Open-URL button for ordinary URL-based cards', () => {
+    render(<PortalGrid cards={[baseCard]} />);
+    const open = screen.getByRole('link', { name: /^open$/i });
+    expect(open.getAttribute('href')).toBe('https://photos.home.arpa');
+    expect(open.getAttribute('target')).toBe('_blank');
+  });
+});
+
+describe('uniform launcher grid (#2126)', () => {
+  const gridOf = (label: string): HTMLElement =>
+    screen.getByRole('heading', { name: label }).closest('div.grid') as HTMLElement;
+  const cardOf = (label: string): HTMLElement =>
+    screen.getByRole('heading', { name: label }).closest('[data-testid="service-card"]') as HTMLElement;
+
+  it('lays out a responsive 1 / 2 / 3-column grid with even gaps', () => {
+    render(<PortalGrid cards={[baseCard]} />);
+    const grid = gridOf('Photos');
+    expect(grid.className).toContain('grid-cols-1');
+    expect(grid.className).toContain('sm:grid-cols-2');
+    expect(grid.className).toContain('lg:grid-cols-3');
+    expect(grid.className).toContain('gap-space-5');
+  });
+
+  it('makes every card equal-sized — no full-row / bento col-span special-casing', () => {
+    render(<PortalGrid cards={[baseCard, syncthingCard]} />);
+    for (const label of ['Photos', 'Syncthing']) {
+      const card = cardOf(label);
+      expect(card.className).toContain('h-full');
+      // No bento footprint hooks survive the redesign.
+      expect(card.className).not.toContain('md:col-span-full');
+      expect(card.className).not.toContain('col-span');
+      expect(card.getAttribute('data-footprint')).toBeNull();
+    }
+  });
+
+  it('stretches cards to a shared height (items-stretch, not bento items-start)', () => {
+    render(<PortalGrid cards={[baseCard]} />);
+    const grid = gridOf('Photos');
+    expect(grid.className).toContain('items-stretch');
+    expect(grid.className).not.toContain('items-start');
+  });
+
+  it('renders the Syncthing card as an ordinary equal-sized tile (no wide slot)', () => {
+    render(<PortalGrid cards={[syncthingCard]} />);
+    const card = cardOf('Syncthing');
+    expect(card.className).not.toContain('md:col-span-full');
+    // Its heavy pairing block is collapsed behind the disclosure, not inline.
+    expect(card.querySelector('[data-testid="card-disclosure"]')).not.toBeNull();
+  });
+});
+
+describe('per-card "Apps & setup" disclosure (#2126)', () => {
+  it('hides the recommended apps + how-to body behind a closed disclosure', () => {
+    const card: PortalCard = {
+      ...baseCard,
+      body: 'How to use Photos.',
+      recommendedApps: [{ name: 'Immich App', url: 'https://immich.app', platforms: ['ios'] }],
+    };
+    render(<PortalGrid cards={[card]} />);
+    const details = screen.getByTestId('card-disclosure');
+    // Closed by default.
+    expect((details as HTMLDetailsElement).open).toBe(false);
+    // The disclosure trigger is present...
+    expect(screen.getByText(/apps & setup/i)).toBeDefined();
+    // ...and the secondary affordances live inside it (not on the front).
+    expect(within(details as HTMLElement).getByRole('link', { name: 'Immich App' })).toBeDefined();
+    expect(within(details as HTMLElement).getByRole('button', { name: /how do i use this/i })).toBeDefined();
+  });
+
+  it('renders NO disclosure for a bare Open-only card (calm front)', () => {
+    render(<PortalGrid cards={[baseCard]} />);
+    expect(screen.queryByTestId('card-disclosure')).toBeNull();
+    expect(screen.queryByText(/apps & setup/i)).toBeNull();
+  });
+
+  it('keeps the Open CTA on the FRONT, outside the disclosure', () => {
+    render(<PortalGrid cards={[syncthingCard]} />);
+    const cta = screen.getByTestId('card-cta');
+    expect(cta.querySelector('a')?.getAttribute('href')).toBe('https://files.home.arpa');
+    // The CTA is not nested inside the <details> disclosure.
+    expect(cta.closest('details')).toBeNull();
+  });
+
+  it('reveals the Syncthing install + pairing QR buttons when the disclosure opens', () => {
+    render(<PortalGrid cards={[syncthingCard]} />);
+    // The QR buttons exist in the DOM (collapsed), but the disclosure is closed.
+    const details = screen.getByTestId('card-disclosure') as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+    openDisclosure('Syncthing');
+    expect(details.open).toBe(true);
+    expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /pair this device/i })).toBeDefined();
+  });
+
+  it('opens the pairing-QR modal from the disclosed button (function preserved)', () => {
+    render(<PortalGrid cards={[syncthingCard]} />);
+    openDisclosure('Syncthing');
+    // Modal heading only appears after clicking the pair button (lazy QR fetch).
+    expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /pair this device/i }));
+    expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
+  });
+
+  it('opens the BasicSync install QR modal from the disclosed button', () => {
+    render(<PortalGrid cards={[syncthingCard]} />);
+    openDisclosure('Syncthing');
+    expect(screen.queryByRole('heading', { name: /install basicsync/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /install basicsync on your phone/i }));
+    expect(screen.getByRole('heading', { name: /install basicsync/i })).toBeDefined();
+    const link = screen.getByRole('link', { name: /open the download link directly/i });
+    expect(link.getAttribute('href')).toContain('/api/system/downloads/basicsync');
+  });
+
+  it('keeps the storage-path note + recommended apps inside the disclosure', () => {
+    render(<PortalGrid cards={[syncthingCard]} />);
+    openDisclosure('Syncthing');
+    expect(screen.getByText(/\/var\/syncthing\/sync/i)).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Syncthing' }).getAttribute('href')).toBe('https://syncthing.net');
+  });
+});
+
+describe('Calendar one-tap iOS setup preserved behind disclosure (#2126)', () => {
+  const calendarCard: PortalCard = {
+    ...baseCard,
+    id: 'radicale:CALDAV_SUBDOMAIN',
+    name: 'radicale',
+    subdomainVar: 'CALDAV_SUBDOMAIN',
+    label: 'Calendar & Contacts',
+    lucideIcon: 'calendar-days',
+    setupAssets: [
+      { kind: 'ios_calendar_profile', label: 'Add to iPhone (Calendar + Contacts)', description: 'One-tap setup.' },
+    ],
+  };
+
+  it('hides the iOS profile download by default and reveals it on open', () => {
+    render(<PortalGrid cards={[calendarCard]} />);
+    // The download link is inside the collapsed disclosure.
+    const details = screen.getByTestId('card-disclosure') as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+    openDisclosure('Calendar & Contacts');
+    const link = screen.getByRole('link', { name: /add to iphone/i });
+    expect(link.getAttribute('href')).toContain('/api/portal/asset/radicale/ios_calendar_profile');
+    expect(link.getAttribute('href')).toContain('subdomain_var=CALDAV_SUBDOMAIN');
+  });
+});
+
+describe('per-service accent identity (#2126)', () => {
+  const chipOf = (label: string): HTMLElement => {
+    const chip = screen.getByRole('heading', { name: label })
+      .closest('[data-testid="service-card"]')!
+      .querySelector('[data-accent]');
+    expect(chip).not.toBeNull();
+    return chip as HTMLElement;
+  };
+
+  const cases: [PortalCard, string, string][] = [
+    [{ ...baseCard, label: 'Photos', lucideIcon: 'camera' }, 'teal', 'svc-chip-teal'],
+    [{ ...baseCard, id: 'v:1', label: 'Passwords', lucideIcon: 'shield' }, 'blue', 'svc-chip-blue'],
+    [{ ...baseCard, id: 'f:1', label: 'Files', lucideIcon: 'folder-open' }, 'orange', 'svc-chip-orange'],
+    [{ ...baseCard, id: 'a:1', label: 'Audiobooks', lucideIcon: 'book-open' }, 'violet', 'svc-chip-violet'],
+    [{ ...baseCard, id: 'm:1', label: 'Music', lucideIcon: 'music' }, 'rose', 'svc-chip-rose'],
+    [{ ...baseCard, id: 'c:1', label: 'Calendar & Contacts', lucideIcon: 'calendar-days' }, 'red', 'svc-chip-red'],
+    [{ ...baseCard, id: 'h:1', label: 'Smart Home', lucideIcon: 'lightbulb' }, 'amber', 'svc-chip-amber'],
+    [{ ...baseCard, id: 'd:1', label: 'Claude Dev', lucideIcon: 'bot' }, 'indigo', 'svc-chip-indigo'],
+    [{ ...baseCard, id: 's:1', label: 'Syncthing', lucideIcon: 'refresh-cw' }, 'green', 'svc-chip-green'],
+  ];
+
+  for (const [card, accent, cls] of cases) {
+    it(`tints the ${card.label} chip ${accent}`, () => {
+      render(<PortalGrid cards={[card]} />);
+      const chip = chipOf(card.label);
+      expect(chip.getAttribute('data-accent')).toBe(accent);
+      expect(chip.className).toContain(cls);
+    });
+  }
+
+  it('does not paint the whole card — only the icon chip carries the accent', () => {
+    render(<PortalGrid cards={[{ ...baseCard, label: 'Music', lucideIcon: 'music' }]} />);
+    const wrapper = screen.getByRole('heading', { name: 'Music' }).closest('[data-testid="service-card"]')!;
+    // The card surface stays on the neutral semantic token, no garish fill.
+    expect(wrapper.className).toContain('bg-surface');
+    expect(wrapper.className).not.toContain('svc-chip-rose');
+  });
+});
+
+describe('light section grouping (#2126)', () => {
+  const sectionHeading = (name: string) =>
+    screen.getByRole('heading', { name, level: 2 });
+
+  it('groups cards under Media / Productivity / Files & Sync / Smart Home & Dev headers', () => {
+    const cards: PortalCard[] = [
+      { ...baseCard, id: 'photos:1', label: 'Photos', lucideIcon: 'camera' },
+      { ...baseCard, id: 'music:1', label: 'Music', lucideIcon: 'music' },
+      { ...baseCard, id: 'pw:1', label: 'Passwords', lucideIcon: 'shield' },
+      { ...baseCard, id: 'cal:1', label: 'Calendar', lucideIcon: 'calendar-days' },
+      { ...baseCard, id: 'files:1', label: 'Files', lucideIcon: 'folder-open' },
+      { ...baseCard, id: 'sync:1', label: 'Syncthing', lucideIcon: 'refresh-cw' },
+      { ...baseCard, id: 'ha:1', label: 'Smart Home', lucideIcon: 'lightbulb' },
+      { ...baseCard, id: 'dev:1', label: 'Claude Dev', lucideIcon: 'bot' },
+    ];
+    render(<PortalGrid cards={cards} />);
+    for (const name of ['Media', 'Productivity', 'Files & Sync', 'Smart Home & Dev']) {
+      expect(sectionHeading(name)).toBeDefined();
+    }
+  });
+
+  it('files each card under the right section', () => {
+    const cards: PortalCard[] = [
+      { ...baseCard, id: 'music:1', label: 'Music', lucideIcon: 'music' },
+      { ...baseCard, id: 'pw:1', label: 'Passwords', lucideIcon: 'shield' },
+    ];
+    render(<PortalGrid cards={cards} />);
+    const media = sectionHeading('Media').closest('section')!;
+    const productivity = sectionHeading('Productivity').closest('section')!;
+    expect(within(media).getByRole('heading', { name: 'Music' })).toBeDefined();
+    expect(within(productivity).getByRole('heading', { name: 'Passwords' })).toBeDefined();
+  });
+
+  it('drops empty sections (only renders sections that have cards)', () => {
+    render(<PortalGrid cards={[{ ...baseCard, label: 'Photos', lucideIcon: 'camera' }]} />);
+    expect(sectionHeading('Media')).toBeDefined();
+    expect(screen.queryByRole('heading', { name: 'Productivity', level: 2 })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Files & Sync', level: 2 })).toBeNull();
+  });
+
+  it('renders Media before Productivity before Files & Sync before Smart Home & Dev', () => {
+    const cards: PortalCard[] = [
+      { ...baseCard, id: 'dev:1', label: 'Claude Dev', lucideIcon: 'bot' },
+      { ...baseCard, id: 'files:1', label: 'Files', lucideIcon: 'folder-open' },
+      { ...baseCard, id: 'pw:1', label: 'Passwords', lucideIcon: 'shield' },
+      { ...baseCard, id: 'photos:1', label: 'Photos', lucideIcon: 'camera' },
+    ];
+    render(<PortalGrid cards={cards} />);
+    const order = screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent);
+    expect(order).toEqual(['Media', 'Productivity', 'Files & Sync', 'Smart Home & Dev']);
+  });
+});
+
+describe('manual-pairing panel preserved behind disclosure (#1253/#2126)', () => {
+  const hermesCard: PortalCard = {
+    ...baseCard,
+    id: 'hermes:HERMES_SUBDOMAIN',
+    name: 'hermes',
+    label: 'Hermes',
+    manualPairing: [
+      {
+        title: 'Pair the Signal account',
+        command: 'podman exec -it hermes signal-cli link -n HermesAgent',
+        why: 'Scan the QR shown in the terminal with Signal → Linked devices.',
+      },
+    ],
+  };
+
   it('does not render the manual-setup panel when manualPairing is empty', () => {
     render(<PortalGrid cards={[baseCard]} />);
     expect(screen.queryByText(/manual setup needed/i)).toBeNull();
   });
 
-  it('renders the amber "Manual setup needed" panel when manualPairing is present (#1253)', () => {
-    const card: PortalCard = {
-      ...baseCard,
-      id: 'hermes:HERMES_SUBDOMAIN',
-      name: 'hermes',
-      label: 'Hermes',
-      manualPairing: [
-        {
-          title: 'Pair the Signal account',
-          command: 'podman exec -it hermes signal-cli link -n HermesAgent',
-          why: 'Scan the QR shown in the terminal with Signal → Linked devices → Link new device.',
-        },
-      ],
-    };
-    render(<PortalGrid cards={[card]} />);
+  it('renders the panel + step title + command + why + copy button on open', () => {
+    render(<PortalGrid cards={[hermesCard]} />);
+    openDisclosure('Hermes');
     expect(screen.getByText(/manual setup needed/i)).toBeDefined();
-  });
-
-  it('renders the step title and command for each manual_pairing entry (#1253)', () => {
-    const card: PortalCard = {
-      ...baseCard,
-      manualPairing: [
-        {
-          title: 'Pair the Signal account',
-          command: 'podman exec -it hermes signal-cli link -n HermesAgent',
-        },
-      ],
-    };
-    render(<PortalGrid cards={[card]} />);
     expect(screen.getByText('Pair the Signal account')).toBeDefined();
     expect(screen.getByText('podman exec -it hermes signal-cli link -n HermesAgent')).toBeDefined();
-  });
-
-  it('renders the why-note when provided (#1253)', () => {
-    const card: PortalCard = {
-      ...baseCard,
-      manualPairing: [
-        {
-          title: 'Pair the Signal account',
-          command: 'podman exec -it hermes signal-cli link -n HermesAgent',
-          why: 'Scan the QR in the terminal with Signal on your phone.',
-        },
-      ],
-    };
-    render(<PortalGrid cards={[card]} />);
-    expect(screen.getByText(/scan the qr in the terminal/i)).toBeDefined();
-  });
-
-  it('renders a copy button for each command block (#1253)', () => {
-    const card: PortalCard = {
-      ...baseCard,
-      manualPairing: [
-        {
-          title: 'Pair the Signal account',
-          command: 'podman exec -it hermes signal-cli link -n HermesAgent',
-        },
-      ],
-    };
-    render(<PortalGrid cards={[card]} />);
+    expect(screen.getByText(/scan the qr shown in the terminal/i)).toBeDefined();
     expect(screen.getByRole('button', { name: /copy command/i })).toBeDefined();
   });
 
-  it('renders multiple manual_pairing steps (#1253)', () => {
+  it('renders multiple manual_pairing steps with a copy button each', () => {
     const card: PortalCard = {
-      ...baseCard,
+      ...hermesCard,
       manualPairing: [
         { title: 'Step one', command: 'cmd-one' },
         { title: 'Step two', command: 'cmd-two' },
       ],
     };
     render(<PortalGrid cards={[card]} />);
+    openDisclosure('Hermes');
     expect(screen.getByText('Step one')).toBeDefined();
-    expect(screen.getByText('cmd-one')).toBeDefined();
     expect(screen.getByText('Step two')).toBeDefined();
-    expect(screen.getByText('cmd-two')).toBeDefined();
-    // Two copy buttons — one per step.
     expect(screen.getAllByRole('button', { name: /copy command/i })).toHaveLength(2);
   });
+});
 
-  describe('BasicSync install QR asset (#1560)', () => {
-    const basicSyncCard: PortalCard = {
-      ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'File Share',
-      setupAssets: [{ kind: 'basicsync_install_qr', description: 'Open-source Syncthing client.' }],
-    };
+describe('appless cards + action links (#1618)', () => {
+  const applessCard: PortalCard = {
+    ...baseCard,
+    id: 'claude-dev:default',
+    name: 'claude-dev',
+    label: 'Claude Dev',
+    lucideIcon: 'bot',
+    url: '', // no subdomain → no Open-URL button
+    primaryAction: {
+      type: 'in_app',
+      label: 'Open terminal',
+      href: '/terminal?node=Local&container=claude-dev',
+      desktop_only: false,
+    },
+  };
 
-    it('renders the install button inline (full-row card, no expander), no modal yet', () => {
-      render(<PortalGrid cards={[basicSyncCard]} />);
-      // QR-bearing assets are inline columns in the full-row card (#2120).
-      expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
-      expect(screen.getByText('Open-source Syncthing client.')).toBeDefined();
-      // Modal heading is not present until the button is clicked.
-      expect(screen.queryByRole('heading', { name: /install basicsync/i })).toBeNull();
-    });
-
-    it('opens the QR modal on click and closes it on backdrop click', () => {
-      render(<PortalGrid cards={[basicSyncCard]} />);
-      fireEvent.click(screen.getByRole('button', { name: /install basicsync on your phone/i }));
-      // Modal now shows: heading + the direct-download link.
-      expect(screen.getByRole('heading', { name: /install basicsync/i })).toBeDefined();
-      const link = screen.getByRole('link', { name: /open the download link directly/i });
-      expect(link.getAttribute('href')).toContain('/api/system/downloads/basicsync');
-
-      // Clicking the backdrop (the outermost overlay div) closes the modal.
-      fireEvent.click(screen.getByRole('heading', { name: /install basicsync/i }).closest('div')!.parentElement!);
-      expect(screen.queryByRole('heading', { name: /install basicsync/i })).toBeNull();
-    });
+  it('renders the primary action as the CTA when there is no URL', () => {
+    render(<PortalGrid cards={[applessCard]} />);
+    expect(screen.queryByRole('link', { name: /^open$/i })).toBeNull();
+    const cta = screen.getByRole('link', { name: /open terminal/i });
+    expect(cta.getAttribute('href')).toBe('/terminal?node=Local&container=claude-dev');
   });
 
-  describe('appless cards + action links (#1618)', () => {
+  it('keeps in-app deep-links in the same tab (no target=_blank)', () => {
+    render(<PortalGrid cards={[applessCard]} />);
+    const cta = screen.getByRole('link', { name: /open terminal/i });
+    expect(cta.getAttribute('target')).toBeNull();
+  });
+
+  it('renders secondary actions as extra buttons', () => {
+    const card: PortalCard = {
+      ...applessCard,
+      secondaryActions: [
+        { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://vscode-remote/ssh-remote+box', desktop_only: true },
+      ],
+    };
+    render(<PortalGrid cards={[card]} />);
+    const vscode = screen.getByRole('link', { name: /open in vs code/i });
+    expect(vscode.getAttribute('href')).toBe('vscode://vscode-remote/ssh-remote+box');
+    expect(vscode.getAttribute('target')).toBe('_blank');
+  });
+
+  it('hides a desktop-only primary action on a phone UA', () => {
+    const original = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148',
+      configurable: true,
+    });
+    try {
+      const card: PortalCard = {
+        ...applessCard,
+        primaryAction: { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://x', desktop_only: true },
+      };
+      render(<PortalGrid cards={[card]} />);
+      expect(screen.queryByRole('link', { name: /open in vs code/i })).toBeNull();
+      expect(screen.getByText(/available on desktop/i)).toBeDefined();
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', { value: original, configurable: true });
+    }
+  });
+});
+
+describe('per-service status badge (#1654)', () => {
+  it('renders a subtle online dot for ok status (no text label)', () => {
+    render(<PortalGrid cards={[{ ...baseCard, status: 'ok' }]} />);
+    expect(screen.getByLabelText('Online')).toBeDefined();
+    expect(screen.queryByText('Down')).toBeNull();
+    expect(screen.queryByText('Degraded')).toBeNull();
+  });
+
+  it('renders nothing for unknown status', () => {
+    render(<PortalGrid cards={[{ ...baseCard, status: 'unknown' }]} />);
+    expect(screen.queryByLabelText('Online')).toBeNull();
+  });
+
+  it('renders a red Down badge with the reason as its tooltip', () => {
+    render(<PortalGrid cards={[{ ...baseCard, status: 'down', statusReason: 'Not reachable' }]} />);
+    const badge = screen.getByText('Down');
+    expect(badge.closest('span')?.getAttribute('title')).toBe('Not reachable');
+  });
+
+  it('renders an amber Degraded badge', () => {
+    render(<PortalGrid cards={[{ ...baseCard, status: 'degraded', statusReason: 'Partially unhealthy' }]} />);
+    const badge = screen.getByText('Degraded');
+    expect(badge.closest('span')?.getAttribute('title')).toBe('Partially unhealthy');
+  });
+});
+
+describe('design-system tokens preserved (#2107/#2126)', () => {
+  const wrapperOf = (label: string): HTMLElement =>
+    screen.getByRole('heading', { name: label }).closest('[data-testid="service-card"]') as HTMLElement;
+
+  it('renders the card surface on semantic tokens, not raw gray/white literals', () => {
+    render(<PortalGrid cards={[baseCard]} />);
+    const cls = wrapperOf('Photos').className;
+    expect(cls).toContain('bg-surface');
+    expect(cls).toContain('border-border');
+    expect(cls).not.toContain('bg-white');
+    expect(cls).not.toContain('dark:bg-gray-800');
+    expect(cls).not.toContain('rounded-2xl');
+  });
+
+  it('renders the Open CTA on the accent token (no raw blue-600)', () => {
+    render(<PortalGrid cards={[baseCard]} />);
+    const open = screen.getByRole('link', { name: /^open$/i });
+    expect(open.className).toContain('bg-accent');
+    expect(open.className).not.toContain('bg-blue-600');
+  });
+
+  it('renders the appless primary action on the accent token', () => {
     const applessCard: PortalCard = {
       ...baseCard,
       id: 'claude-dev:default',
       name: 'claude-dev',
       label: 'Claude Dev',
-      url: '', // no subdomain → no Open-URL button
+      lucideIcon: 'bot',
+      url: '',
       primaryAction: {
         type: 'in_app',
         label: 'Open terminal',
@@ -171,493 +476,21 @@ describe('PortalGrid', () => {
         desktop_only: false,
       },
     };
-
-    it('renders the primary action as the CTA when there is no URL', () => {
-      render(<PortalGrid cards={[applessCard]} />);
-      // No "Open" link (no url), but the primary action link is present.
-      expect(screen.queryByRole('link', { name: /^open$/i })).toBeNull();
-      const cta = screen.getByRole('link', { name: /open terminal/i });
-      expect(cta.getAttribute('href')).toBe('/terminal?node=Local&container=claude-dev');
-    });
-
-    it('keeps in-app deep-links in the same tab (no target=_blank)', () => {
-      render(<PortalGrid cards={[applessCard]} />);
-      const cta = screen.getByRole('link', { name: /open terminal/i });
-      expect(cta.getAttribute('target')).toBeNull();
-    });
-
-    it('renders secondary actions as extra buttons', () => {
-      const card: PortalCard = {
-        ...applessCard,
-        secondaryActions: [
-          { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://vscode-remote/ssh-remote+box', desktop_only: true },
-        ],
-      };
-      render(<PortalGrid cards={[card]} />);
-      const vscode = screen.getByRole('link', { name: /open in vs code/i });
-      expect(vscode.getAttribute('href')).toBe('vscode://vscode-remote/ssh-remote+box');
-      // External scheme opens in a new tab/handoff.
-      expect(vscode.getAttribute('target')).toBe('_blank');
-    });
-
-    it('shows desktop-only actions on desktop (default jsdom UA)', () => {
-      const card: PortalCard = {
-        ...applessCard,
-        primaryAction: { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://x', desktop_only: true },
-      };
-      render(<PortalGrid cards={[card]} />);
-      // jsdom's default UA is non-mobile → desktop-only action is visible.
-      expect(screen.getByRole('link', { name: /open in vs code/i })).toBeDefined();
-    });
-
-    it('hides a desktop-only primary action on a phone UA', () => {
-      const original = navigator.userAgent;
-      Object.defineProperty(navigator, 'userAgent', {
-        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148',
-        configurable: true,
-      });
-      try {
-        const card: PortalCard = {
-          ...applessCard,
-          primaryAction: { type: 'external_scheme', label: 'Open in VS Code', href: 'vscode://x', desktop_only: true },
-        };
-        render(<PortalGrid cards={[card]} />);
-        expect(screen.queryByRole('link', { name: /open in vs code/i })).toBeNull();
-        // A graceful "available on desktop" hint replaces it.
-        expect(screen.getByText(/available on desktop/i)).toBeDefined();
-      } finally {
-        Object.defineProperty(navigator, 'userAgent', { value: original, configurable: true });
-      }
-    });
-
-    it('still shows the Open-URL button for ordinary URL-based cards', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      expect(screen.getByRole('link', { name: /^open$/i })).toBeDefined();
-    });
+    render(<PortalGrid cards={[applessCard]} />);
+    const cta = screen.getByRole('link', { name: /open terminal/i });
+    expect(cta.className).toContain('bg-accent');
+    expect(cta.className).not.toContain('bg-blue-600');
   });
 
-  describe('bento footprint → grid span (#2120)', () => {
-    /** Walk up from the card heading to the grid-cell wrapper (the <Card>
-     *  primitive — the heading's nearest ancestor div with `rounded-card`,
-     *  which carries the `col-span-*` footprint class). */
-    const cardWrapper = (label: string): HTMLElement => {
-      const heading = screen.getByRole('heading', { name: label });
-      const wrapper = heading.closest('div.rounded-card');
-      expect(wrapper).not.toBeNull();
-      return wrapper as HTMLElement;
-    };
-
-    /** A file-share card carrying the heavy Syncthing pairing block →
-     *  derives the `full-row` footprint. */
-    const syncthingCard: PortalCard = {
+  it('renders the recommended-app link on the accent token (function preserved)', () => {
+    const card: PortalCard = {
       ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'Syncthing',
-      setupAssets: [
-        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone' },
-        { kind: 'syncthing_qr', label: 'Pair this device' },
-      ],
+      recommendedApps: [{ name: 'Immich App', url: 'https://immich.app', platforms: ['ios'] }],
     };
-
-    it('renders an ordinary service card as a 1×1 tile (single column)', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const cls = cardWrapper('Photos').className;
-      expect(cls).toContain('col-span-1');
-      expect(cls).not.toContain('md:col-span-full'); // not full-row
-    });
-
-    it('gives the Syncthing pairing card the full-row footprint (spans the grid width)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const cls = cardWrapper('Syncthing').className;
-      expect(cls).toContain('md:col-span-full');
-      expect(cls).toContain('col-span-1'); // narrow screens stay full-width single column
-    });
-
-    it('marks the full-row card with a data-footprint hook', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const wrapper = cardWrapper('Syncthing');
-      expect(wrapper.getAttribute('data-footprint')).toBe('full-row');
-    });
-
-    it('renders the bento grid as a fixed multi-column composition (3-col md, 1-col mobile)', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const grid = screen.getByRole('heading', { name: 'Photos' }).closest('div.grid')!;
-      expect(grid.className).toContain('grid-cols-1');
-      expect(grid.className).toContain('md:grid-cols-3');
-      // Intentional bento, not content-driven equal-height stretch.
-      expect(grid.className).not.toContain('items-stretch');
-      expect(grid.className).toContain('items-start');
-    });
-
-    it('keeps a 1×1 tile equal-height with its peers (h-full) for an even bento row', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      expect(cardWrapper('Photos').className).toContain('h-full');
-    });
-  });
-
-  describe('full-row card horizontal layout (#2120)', () => {
-    const syncthingCard: PortalCard = {
-      ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'Syncthing',
-      url: 'https://files.home.arpa',
-      setupAssets: [
-        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone', description: 'Install the app first.' },
-        { kind: 'syncthing_qr', label: 'Pair this device', description: 'Use /var/syncthing/Sync/<name> for the shared drive.' },
-      ],
-      recommendedApps: [{ name: 'Syncthing', url: 'https://syncthing.net', platforms: ['android'] }],
-    };
-
-    const cardWrapper = (label: string): HTMLElement =>
-      screen.getByRole('heading', { name: label }).closest('div.rounded-card') as HTMLElement;
-
-    it('lays the full-row card sections out horizontally side-by-side (md:flex-row + section column grid)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const wrapper = cardWrapper('Syncthing');
-      // Top-level row container goes horizontal on md+.
-      const row = wrapper.querySelector('div.md\\:flex-row');
-      expect(row).not.toBeNull();
-      // The section block is a horizontal column grid (not a tall stack).
-      const sectionGrid = wrapper.querySelector('div.md\\:grid-cols-2');
-      expect(sectionGrid).not.toBeNull();
-    });
-
-    it('shows the BasicSync install + Pair QRs inline (NOT collapsed behind an expander)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      // No "How to pair" expander in the full-row layout — buttons are
-      // directly reachable as side-by-side columns.
-      expect(screen.queryByText(/so koppelst du/i)).toBeNull();
-      expect(screen.getByRole('button', { name: /install basicsync on your phone/i })).toBeDefined();
-      expect(screen.getByRole('button', { name: /pair this device/i })).toBeDefined();
-    });
-
-    it('keeps the Open CTA + storage-path note + recommended apps in the full-row card', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const open = screen.getByRole('link', { name: /^open$/i });
-      expect(open.getAttribute('href')).toBe('https://files.home.arpa');
-      expect(screen.getByText(/\/var\/syncthing\/sync/i)).toBeDefined();
-      expect(screen.getByRole('link', { name: 'Syncthing' }).getAttribute('href')).toBe('https://syncthing.net');
-    });
-
-    it('still opens the pairing QR modal from the inline button (function preserved)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
-      fireEvent.click(screen.getByRole('button', { name: /pair this device/i }));
-      expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
-    });
-
-    it('stacks the full-row card columns on narrow screens (flex-col base, md:flex-row)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const row = cardWrapper('Syncthing').querySelector('div.flex-col.md\\:flex-row');
-      expect(row).not.toBeNull();
-    });
-  });
-
-  describe('per-service status badge (#1654)', () => {
-    it('renders no down/degraded badge text when status is ok', () => {
-      render(<PortalGrid cards={[{ ...baseCard, status: 'ok' }]} />);
-      // ok renders a subtle dot (aria-label Online), not a text label.
-      expect(screen.getByLabelText('Online')).toBeDefined();
-      expect(screen.queryByText('Down')).toBeNull();
-      expect(screen.queryByText('Degraded')).toBeNull();
-    });
-
-    it('renders nothing for unknown status', () => {
-      render(<PortalGrid cards={[{ ...baseCard, status: 'unknown' }]} />);
-      expect(screen.queryByLabelText('Online')).toBeNull();
-      expect(screen.queryByText('Down')).toBeNull();
-      expect(screen.queryByText('Degraded')).toBeNull();
-    });
-
-    it('renders a red Down badge with the reason as its tooltip', () => {
-      render(
-        <PortalGrid
-          cards={[{ ...baseCard, status: 'down', statusReason: 'Not reachable' }]}
-        />,
-      );
-      const badge = screen.getByText('Down');
-      expect(badge).toBeDefined();
-      expect(badge.closest('span')?.getAttribute('title')).toBe('Not reachable');
-    });
-
-    it('renders an amber Degraded badge', () => {
-      render(
-        <PortalGrid
-          cards={[{ ...baseCard, status: 'degraded', statusReason: 'Partially unhealthy' }]}
-        />,
-      );
-      const badge = screen.getByText('Degraded');
-      expect(badge).toBeDefined();
-      expect(badge.closest('span')?.getAttribute('title')).toBe('Partially unhealthy');
-    });
-  });
-
-  describe('design-system migration (#2107)', () => {
-    /** Nearest <Card> ancestor of the card heading. */
-    const wrapperOf = (label: string): HTMLElement => {
-      const w = screen.getByRole('heading', { name: label }).closest('div.rounded-card');
-      expect(w).not.toBeNull();
-      return w as HTMLElement;
-    };
-
-    it('renders the card surface on semantic tokens, not raw gray/white literals', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const cls = wrapperOf('Photos').className;
-      expect(cls).toContain('bg-surface');
-      expect(cls).toContain('border-border');
-      // No bespoke raw-colour card chrome.
-      expect(cls).not.toContain('bg-white');
-      expect(cls).not.toContain('dark:bg-gray-800');
-      expect(cls).not.toContain('rounded-2xl');
-    });
-
-    it('renders the Open CTA on the accent token (no raw blue-600)', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const open = screen.getByRole('link', { name: /^open$/i });
-      expect(open.className).toContain('bg-accent');
-      expect(open.className).not.toContain('bg-blue-600');
-    });
-
-    it('renders the appless primary action on the accent token', () => {
-      const applessCard: PortalCard = {
-        ...baseCard,
-        id: 'claude-dev:default',
-        name: 'claude-dev',
-        label: 'Claude Dev',
-        url: '',
-        primaryAction: {
-          type: 'in_app',
-          label: 'Open terminal',
-          href: '/terminal?node=Local&container=claude-dev',
-          desktop_only: false,
-        },
-      };
-      render(<PortalGrid cards={[applessCard]} />);
-      const cta = screen.getByRole('link', { name: /open terminal/i });
-      expect(cta.className).toContain('bg-accent');
-      expect(cta.className).not.toContain('bg-blue-600');
-    });
-
-    it('renders the card icon chip on the accent token', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      // The lucide icon chip wraps the svg in an accent-tinted div.
-      const heading = screen.getByRole('heading', { name: 'Photos' });
-      const header = heading.closest('div.rounded-card')!.querySelector('div.bg-accent\\/15');
-      expect(header).not.toBeNull();
-    });
-
-    it('renders the recommended-app link on the accent token (function preserved)', () => {
-      const card: PortalCard = {
-        ...baseCard,
-        recommendedApps: [{ name: 'Immich App', url: 'https://immich.app', platforms: ['ios'] }],
-      };
-      render(<PortalGrid cards={[card]} />);
-      const app = screen.getByRole('link', { name: 'Immich App' });
-      expect(app.getAttribute('href')).toBe('https://immich.app');
-      expect(app.className).toContain('text-accent');
-    });
-  });
-
-  describe('Syncthing pairing QR preserved through migration (#2107)', () => {
-    const syncCard: PortalCard = {
-      ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'File Share',
-      setupAssets: [{ kind: 'syncthing_qr', description: 'Pair your phone.' }],
-    };
-
-    it('renders the pair button on tokens and keeps the fetch-on-click QR flow', () => {
-      render(<PortalGrid cards={[syncCard]} />);
-      // The pairing block is an inline column in the full-row card (#2120) —
-      // the pair button is directly reachable, no expander.
-      const btn = screen.getByRole('button', { name: /pair/i });
-      expect(btn.className).toContain('bg-accent');
-      expect(btn.className).not.toContain('bg-emerald-600');
-      // Modal heading appears only after click (QR fetched lazily).
-      expect(screen.queryByRole('heading', { name: /pair this device/i })).toBeNull();
-      fireEvent.click(btn);
-      expect(screen.getByRole('heading', { name: /pair this device/i })).toBeDefined();
-    });
-  });
-
-  describe('even bento tile composition (#2120)', () => {
-    /** The grid container is the heading's nearest ancestor div carrying
-     *  the `grid` class. */
-    const gridOf = (label: string): HTMLElement => {
-      const grid = screen.getByRole('heading', { name: label }).closest('div.grid');
-      expect(grid).not.toBeNull();
-      return grid as HTMLElement;
-    };
-    const cardOf = (label: string): HTMLElement =>
-      screen.getByRole('heading', { name: label }).closest('div.rounded-card') as HTMLElement;
-
-    it('renders a fixed bento composition (md:grid-cols-3, items-start, not stretch)', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const grid = gridOf('Photos');
-      expect(grid.className).toContain('md:grid-cols-3');
-      expect(grid.className).toContain('items-start');
-      expect(grid.className).not.toContain('items-stretch');
-    });
-
-    it('keeps a responsive 1 / multi-col layout (1 col mobile, 3-col md track)', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const grid = gridOf('Photos');
-      expect(grid.className).toContain('grid-cols-1');
-      expect(grid.className).toContain('md:grid-cols-3');
-      expect(grid.className).toContain('gap-6');
-    });
-
-    it('renders an even row of three 1×1 tiles that each fill the row height', () => {
-      const a: PortalCard = { ...baseCard, id: 'a:x', label: 'Alpha' };
-      const b: PortalCard = { ...baseCard, id: 'b:y', label: 'Beta' };
-      const c: PortalCard = { ...baseCard, id: 'c:z', label: 'Gamma' };
-      render(<PortalGrid cards={[a, b, c]} />);
-      for (const label of ['Alpha', 'Beta', 'Gamma']) {
-        expect(cardOf(label).className).toContain('h-full');
-        expect(cardOf(label).className).toContain('col-span-1');
-      }
-    });
-  });
-
-  describe('1×1 tile keeps light setup assets inline (#2120)', () => {
-    it('renders a single light asset inline (no expander) — 1×1 tiles never grow a heavy block', () => {
-      const absCard: PortalCard = {
-        ...baseCard,
-        id: 'abs:ABS_SUBDOMAIN',
-        name: 'audiobookshelf',
-        label: 'Audiobooks',
-        setupAssets: [{ kind: 'audiobookshelf_deeplink', label: 'Open in Audiobookshelf app' }],
-      };
-      render(<PortalGrid cards={[absCard]} />);
-      // No expander; the deep-link button is directly reachable.
-      expect(screen.queryByText(/so koppelst du/i)).toBeNull();
-      expect(screen.getByRole('button', { name: /open in audiobookshelf app/i })).toBeDefined();
-    });
-  });
-
-  describe('bento packing — empty space accumulates at the bottom (#2123)', () => {
-    /** A full-row Syncthing card (heavy pairing block → full-row). */
-    const syncthingCard: PortalCard = {
-      ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'Syncthing',
-      setupAssets: [
-        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone' },
-        { kind: 'syncthing_qr', label: 'Pair this device' },
-      ],
-    };
-
-    /** The shared bento grid container. */
-    const grid = (): HTMLElement =>
-      screen.getAllByRole('heading')[0].closest('div.grid') as HTMLElement;
-
-    /** Ordered list of the direct grid-cell <Card>s (each carries
-     *  `col-span-*`), top-to-bottom in render order. */
-    const gridCells = (): HTMLElement[] =>
-      Array.from(grid().children).filter(
-        c => c.className.includes('col-span'),
-      ) as HTMLElement[];
-
-    it('renders the full-row card LAST even when declared mid-list (no mid-grid hole)', () => {
-      // Source order interleaves the full-row card between 1×1 tiles —
-      // the exact case that stranded the cell beside the lone Files tile.
-      const a: PortalCard = { ...baseCard, id: 'a:x', label: 'Alpha' };
-      const b: PortalCard = { ...baseCard, id: 'b:y', label: 'Beta' };
-      const files: PortalCard = { ...baseCard, id: 'f:z', label: 'Files' };
-      render(<PortalGrid cards={[a, syncthingCard, b, files]} />);
-
-      const cells = gridCells();
-      // The full-row card is the LAST grid cell; every 1×1 tile precedes it.
-      const last = cells[cells.length - 1];
-      expect(last.getAttribute('data-footprint')).toBe('full-row');
-      const fullRowCount = cells.filter(
-        c => c.getAttribute('data-footprint') === 'full-row',
-      ).length;
-      expect(fullRowCount).toBe(1);
-      // No 1×1 tile renders after the full-row card → empty cells (if any)
-      // land at the very end, not mid-grid.
-      const fullRowIndex = cells.findIndex(
-        c => c.getAttribute('data-footprint') === 'full-row',
-      );
-      const tilesAfter = cells
-        .slice(fullRowIndex + 1)
-        .filter(c => c.getAttribute('data-footprint') !== 'full-row');
-      expect(tilesAfter).toHaveLength(0);
-    });
-
-    it('preserves the relative order of the 1×1 tiles (stable sort)', () => {
-      const a: PortalCard = { ...baseCard, id: 'a:x', label: 'Alpha' };
-      const b: PortalCard = { ...baseCard, id: 'b:y', label: 'Beta' };
-      const c: PortalCard = { ...baseCard, id: 'c:w', label: 'Gamma' };
-      render(<PortalGrid cards={[a, syncthingCard, b, c]} />);
-      const labels = gridCells().map(
-        cell => cell.querySelector('h2')?.textContent,
-      );
-      // Tiles keep A, B, Gamma order; Syncthing trails at the end.
-      expect(labels).toEqual(['Alpha', 'Beta', 'Gamma', 'Syncthing']);
-    });
-  });
-
-  describe('uniform CTA-bottom pattern across card variants (#2123)', () => {
-    const cardOf = (label: string): HTMLElement =>
-      screen.getByRole('heading', { name: label }).closest('div.rounded-card') as HTMLElement;
-
-    const syncthingCard: PortalCard = {
-      ...baseCard,
-      id: 'file-share:SYNCTHING_SUBDOMAIN',
-      name: 'file-share',
-      label: 'Syncthing',
-      url: 'https://files.home.arpa',
-      setupAssets: [
-        { kind: 'basicsync_install_qr', label: 'Install BasicSync on your phone' },
-        { kind: 'syncthing_qr', label: 'Pair this device' },
-      ],
-    };
-
-    it('pins the 1×1 tile primary CTA at the bottom (mt-auto) below the content', () => {
-      render(<PortalGrid cards={[baseCard]} />);
-      const cta = cardOf('Photos').querySelector('[data-testid="card-cta"]') as HTMLElement;
-      expect(cta).not.toBeNull();
-      // mt-auto = pushed to the bottom of the flex column.
-      expect(cta.className).toContain('mt-auto');
-      // The Open link lives inside the bottom-pinned CTA block, not above it.
-      expect(cta.querySelector('a')?.textContent?.toLowerCase()).toContain('open');
-    });
-
-    it('pins the full-row lead-column CTA at the bottom too (same pattern, wider)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const cta = cardOf('Syncthing').querySelector('[data-testid="card-cta"]') as HTMLElement;
-      expect(cta).not.toBeNull();
-      expect(cta.className).toContain('mt-auto');
-      expect(cta.querySelector('a')?.getAttribute('href')).toBe('https://files.home.arpa');
-    });
-
-    it('bottom-aligns the full-row section CTAs (Syncthing buttons NOT top-floating)', () => {
-      render(<PortalGrid cards={[syncthingCard]} />);
-      const wrapper = cardOf('Syncthing');
-      // Each setup-asset section column bottom-aligns its action button
-      // (flex-col + justify-end) so the Install/Pair buttons sit on the
-      // shared baseline, not floating at the top of the card.
-      const install = screen.getByRole('button', { name: /install basicsync on your phone/i });
-      const pair = screen.getByRole('button', { name: /pair this device/i });
-      for (const btn of [install, pair]) {
-        const column = btn.closest('div.justify-end');
-        expect(column).not.toBeNull();
-        expect((column as HTMLElement).className).toContain('flex-col');
-      }
-      // The horizontal section row stretches its columns so the baselines
-      // align (items-stretch, not items-start which would top-float them).
-      const sectionGrid = wrapper.querySelector('div.md\\:grid-cols-2') as HTMLElement;
-      expect(sectionGrid.className).toContain('items-stretch');
-      expect(sectionGrid.className).not.toContain('items-start');
-      // The top-level full-row row also stretches lead + sections to a
-      // shared height so every CTA shares one baseline.
-      const row = wrapper.querySelector('div.md\\:flex-row') as HTMLElement;
-      expect(row.className).toContain('md:items-stretch');
-    });
+    render(<PortalGrid cards={[card]} />);
+    openDisclosure('Photos');
+    const app = screen.getByRole('link', { name: 'Immich App' });
+    expect(app.getAttribute('href')).toBe('https://immich.app');
+    expect(app.className).toContain('text-accent');
   });
 });

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -12,71 +12,14 @@ import {
   Terminal, TerminalSquare, Video,
   Sparkles, X,
 } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { Card } from '@/components/ui';
 import type { PortalCard } from '@/lib/portal/services';
 import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
+import { ACCENT_CHIP_CLASS, serviceAccent, groupCardsBySection } from './portalAccent';
 
 type IconComponent = typeof Camera;
-
-/**
- * A card's grid footprint (#2120, portal-layout v2). The portal is a
- * deliberate **bento composition**, not a content-driven equal-height
- * grid: each card declares how much of the grid it occupies and its
- * content adapts to that slot.
- *   - `1x1`      — a standard service tile. One column on the bento
- *                  grid; on narrow screens it stacks to full width.
- *                  Text wraps/truncates to fit the tile.
- *   - `full-row` — a content-heavy card (today: Syncthing/file-share,
- *                  which carries the Install-BasicSync + Pair-device QRs
- *                  + storage-path note). Spans the entire grid width and
- *                  lays its sections out HORIZONTALLY side-by-side in one
- *                  row — compact, not a tall pile.
- */
-type CardFootprint = '1x1' | 'full-row';
-
-/**
- * Derive a card's bento {@link CardFootprint} (#2120) from what it
- * carries. The only full-row citizen today is the Syncthing/file-share
- * card — it ships the heavy pairing block (Install-BasicSync QR + Pair
- * QR + storage-path note) that dwarfed every 1×1 tile. We key off the
- * QR-bearing setup assets (`syncthing_qr` / `basicsync_install_qr`)
- * rather than the service name so the rule travels with the *content*:
- * any future card that grows the same heavy pairing block gets the wide
- * horizontal slot automatically, and a card that loses it drops back to
- * 1×1. Everything else is a standard 1×1 tile.
- */
-function cardFootprint(card: PortalCard): CardFootprint {
-  const hasPairingBlock = card.setupAssets.some(
-    a => a.kind === 'syncthing_qr' || a.kind === 'basicsync_install_qr',
-  );
-  return hasPairingBlock ? 'full-row' : '1x1';
-}
-
-/**
- * Order the cards for dense top-down packing (#2123). The bento grid
- * fills row-by-row in source order, so a `full-row` card placed amid the
- * 1×1 tiles forces a line break and strands the cells beside the last
- * tile of the row above it (the "Lücke mitten drin" next to the lone
- * Files card). Emitting all 1×1 tiles first and every full-row card last
- * packs the tiles tightly across the top and pushes any empty cells to
- * the very END. The key is binary (1×1 → 0, full-row → 1) and `.sort` is
- * stable, so cards keep their relative order within each group.
- */
-function orderForPacking(cards: PortalCard[]): PortalCard[] {
-  // stable sort: 1×1 (rank 0) before full-row (rank 1), order kept within group.
-  return [...cards].sort((a, b) => Number(cardFootprint(a) === 'full-row') - Number(cardFootprint(b) === 'full-row'));
-}
-
-/** Per-footprint grid-cell span (#2120). The bento grid is a fixed
- *  3-column composition on `md`+; a 1×1 tile takes one column, a
- *  full-row card spans every column. These MUST be literal Tailwind
- *  classes — Tailwind can't see an interpolated `col-span-${n}`, so an
- *  interpolated value would be purged. */
-const FOOTPRINT_SPAN: Record<CardFootprint, string> = {
-  '1x1': 'col-span-1',
-  'full-row': 'col-span-1 md:col-span-full',
-};
 
 /**
  * Shared anchor/button class-chains on the design-system tokens (epic
@@ -212,9 +155,19 @@ function assetLabel(kind: SetupAssetKind, override: string | undefined, isIOS: b
 }
 
 /**
- * Renders the portal card grid + per-card collapsible Getting-started
- * section. Server passes the per-card payload pre-built (incl. parsed
- * markdown body) — this component handles only the UI state.
+ * Renders the portal card grid (#2126). Cards are grouped into small
+ * labelled sections (Media / Productivity / Files & Sync / Smart Home &
+ * Dev) and laid out in ONE uniform responsive grid — every card is the
+ * same size (no bento / full-row special-casing; supersedes #2120/#2123).
+ * Each card's FRONT is calm: accent icon-chip + name + status dot + one
+ * descriptive line + a single "Open" CTA; everything secondary
+ * (recommended apps, setup steps, the Syncthing install + pairing QRs,
+ * the calendar one-tap setup, the how-to body) collapses behind a
+ * per-card "Apps & setup" disclosure, closed by default.
+ *
+ * The "How do I use this?" markdown body opens in a centered modal (the
+ * disclosure surfaces the trigger). Server passes the per-card payload
+ * pre-built; this component handles only the UI state.
  */
 export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
   const [activeCardId, setActiveCardId] = useState<string | null>(null);
@@ -240,28 +193,34 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
     };
   }, [activeCard]);
 
-  // Packing order (#2123): 1×1 tiles first, full-row card(s) last, so
-  // empty cells accumulate at the END instead of stranding a hole
-  // mid-grid beside a lone tile. See orderForPacking.
-  const ordered = orderForPacking(cards);
+  // Light grouping (#2126): cards file under Media / Productivity / Files
+  // & Sync / Smart Home & Dev (+ a More catch-all), in a fixed order,
+  // empty sections dropped. Each section renders the SAME uniform grid.
+  const sections = groupCardsBySection(cards);
 
   return (
     <>
-    {/* Deliberate bento composition (#2120/#2123). A fixed 3-column grid
-        on `md`+: 1×1 service tiles tile evenly; a `full-row` card spans
-        every column and — packed last — sits at the bottom. `auto-rows`
-        keeps tile rows even; `items-start` lets a full-row card own its
-        own (shorter) height instead of stretching the whole row. On
-        narrow screens everything collapses to a single column. */}
-    <div className="grid grid-cols-1 md:grid-cols-3 auto-rows-auto gap-6 items-start">
-      {ordered.map(card => (
-        <BentoCard
-          key={card.id}
-          card={card}
-          isIOS={isIOS}
-          isMobile={isMobile}
-          onHelp={() => setActiveCardId(card.id)}
-        />
+    <div className="space-y-space-7">
+      {sections.map(({ section, cards: sectionCards }) => (
+        <section key={section} aria-label={section}>
+          <h2 className="mb-space-4 text-xs font-semibold uppercase tracking-wider text-text-subtle">
+            {section}
+          </h2>
+          {/* ONE uniform responsive grid (#2126) — 1 / 2 / 3 columns, even
+              gaps, every card equal-sized (`items-stretch` + `h-full`).
+              No col-span / full-row footprints. */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-space-5 items-stretch">
+            {sectionCards.map(card => (
+              <ServiceCard
+                key={card.id}
+                card={card}
+                isIOS={isIOS}
+                isMobile={isMobile}
+                onHelp={() => setActiveCardId(card.id)}
+              />
+            ))}
+          </div>
+        </section>
       ))}
     </div>
 
@@ -272,30 +231,29 @@ export default function PortalGrid({ cards }: { cards: PortalCard[] }) {
   );
 }
 
-/** Dispatch a card to its bento footprint renderer (#2120): a content-
- *  heavy `full-row` card to {@link FullRowCard}, everything else to the
- *  standard 1×1 {@link StandardCard}. */
-function BentoCard(props: {
-  card: PortalCard;
-  isIOS: boolean;
-  isMobile: boolean;
-  onHelp: () => void;
-}) {
-  return cardFootprint(props.card) === 'full-row' ? (
-    <FullRowCard {...props} />
-  ) : (
-    <StandardCard {...props} />
+/**
+ * Does this card carry any secondary content worth a disclosure (#2126)?
+ * Setup assets (QRs, calendar profile, deep-links), manual-pairing steps,
+ * recommended apps, or a how-to body all live behind the toggle. A bare
+ * Open-only card shows no disclosure — its front says everything.
+ */
+function hasSecondaryContent(card: PortalCard): boolean {
+  return (
+    card.setupAssets.length > 0 ||
+    card.manualPairing.length > 0 ||
+    card.recommendedApps.length > 0 ||
+    card.body.trim().length > 0
   );
 }
 
 /**
- * Standard 1×1 service tile (#2120). One column of the bento grid (full
- * width on narrow screens). Content adapts to the tile: the label
- * truncates and the tagline clamps to fit the fixed slot. Tiles in a row
- * share a height (`h-full`) so the bento composition reads as even and
- * intentional rather than ragged.
+ * One uniform service card (#2126). Front = accent icon-chip + name +
+ * status dot + one descriptive line + the single "Open" CTA pinned at the
+ * bottom. Everything secondary collapses behind the "Apps & setup"
+ * disclosure (closed by default). Every card is the same size — a clean
+ * launcher tile — so the grid scans evenly.
  */
-function StandardCard({
+function ServiceCard({
   card,
   isIOS,
   isMobile,
@@ -309,23 +267,71 @@ function StandardCard({
   return (
     <Card
       padding="none"
-      className={`overflow-hidden flex flex-col h-full ${FOOTPRINT_SPAN['1x1']}`}
+      data-testid="service-card"
+      className="overflow-hidden flex flex-col h-full"
     >
-      {/* Header — icon + title inline (#2103/#2123) + clamped tagline. */}
+      {/* Calm front — accent chip + title inline + one-line description. */}
       <div className="p-space-5 pb-space-3">
         <CardIcon card={card} />
         <div className="flex items-center gap-space-2 min-w-0">
-          <h2 className="text-xl font-bold text-text truncate min-w-0">{card.label}</h2>
+          <h3 className="text-xl font-bold text-text truncate min-w-0">{card.label}</h3>
           <StatusBadge status={card.status} reason={card.statusReason} />
         </div>
-        <p className="mt-space-2 text-sm text-text-muted line-clamp-3">
+        <p className="mt-space-2 text-sm text-text-muted line-clamp-2">
           {card.tagline ?? ''}
         </p>
       </div>
 
-      {/* Variable content — `flex-1` keeps the bento row even (#2120) and
-          pushes the CTA to a consistent bottom baseline (#2123). */}
-      <div className="flex-1 px-space-5 pt-space-3 space-y-space-3">
+      {/* Spacer keeps the CTA + disclosure pinned to a shared bottom
+          baseline so every card front reads uniform. */}
+      <div className="flex-1" />
+
+      {/* Primary CTA — the ONE front affordance (Open URL, or the appless
+          primary action — #1618). */}
+      <div data-testid="card-cta" className="px-space-5 pt-space-3 space-y-space-2">
+        <CardCta card={card} isMobile={isMobile} />
+      </div>
+
+      {/* Everything else collapses behind the per-card disclosure (#2126),
+          closed by default. Renders only when there's secondary content. */}
+      {hasSecondaryContent(card) && (
+        <CardDisclosure card={card} isIOS={isIOS} isMobile={isMobile} onHelp={onHelp} />
+      )}
+      <div className="pb-space-5" />
+    </Card>
+  );
+}
+
+/**
+ * Per-card "Apps & setup" disclosure (#2126). A native <details> (closed
+ * by default) that hides every secondary affordance behind a calm front:
+ * recommended apps, the manual-pairing steps, the setup assets (Syncthing
+ * install + pairing QRs, the calendar one-tap profile, audiobook
+ * deep-link), and the how-to-use markdown trigger. Native <details> keeps
+ * it keyboard-accessible + works without JS for the open/close itself
+ * (the QR/asset buttons inside still hydrate their own modals).
+ */
+function CardDisclosure({
+  card,
+  isIOS,
+  isMobile,
+  onHelp,
+}: {
+  card: PortalCard;
+  isIOS: boolean;
+  isMobile: boolean;
+  onHelp: () => void;
+}) {
+  return (
+    <details data-testid="card-disclosure" className="group mt-space-3 border-t border-border">
+      <summary className="flex items-center gap-space-2 px-space-5 py-space-3 cursor-pointer list-none select-none text-sm font-medium text-text-muted hover:text-text">
+        <ChevronRight
+          size={16}
+          className="shrink-0 transition-transform group-open:rotate-90"
+        />
+        Apps &amp; setup
+      </summary>
+      <div className="px-space-5 pb-space-2 pt-space-1 space-y-space-3">
         {card.setupAssets.length > 0 && (
           <SetupAssets card={card} isIOS={isIOS} isMobile={isMobile} />
         )}
@@ -337,110 +343,12 @@ function StandardCard({
         )}
         {card.body.trim().length > 0 && <HowToButton onClick={onHelp} />}
       </div>
-
-      {/* Primary CTA — bottom-pinned (#2123) so every card shares one CTA
-          baseline (Open URL, or the appless primary action — #1618). */}
-      <div data-testid="card-cta" className="mt-auto px-space-5 pt-space-3 pb-space-5 space-y-space-2">
-        <CardCta card={card} isMobile={isMobile} />
-      </div>
-    </Card>
+    </details>
   );
 }
 
-/**
- * Full-row bento card (#2120). A content-heavy card (Syncthing) that
- * spans the whole grid width and lays its sections out HORIZONTALLY
- * side-by-side — the "Open" CTA, the BasicSync-install QR, the Pair QR,
- * and the recommended-apps/storage-path note become adjacent columns
- * instead of a tall stack. On narrow screens the columns stack and the
- * card stays full width — keeping the verbose pairing block from
- * towering over the 1×1 tiles while every affordance stays directly
- * reachable (QRs inline, not collapsed).
- */
-function FullRowCard({
-  card,
-  isIOS,
-  isMobile,
-  onHelp,
-}: {
-  card: PortalCard;
-  isIOS: boolean;
-  isMobile: boolean;
-  onHelp: () => void;
-}) {
-  return (
-    <Card
-      padding="none"
-      data-footprint="full-row"
-      className={`overflow-hidden ${FOOTPRINT_SPAN['full-row']}`}
-    >
-      {/* `md:items-stretch` stretches the lead + section columns to one
-          height so their bottom-pinned CTAs/QRs land on ONE baseline
-          (#2123) — same header-top / CTA-bottom pattern as a 1×1, wider. */}
-      <div className="p-space-5 flex flex-col md:flex-row md:items-stretch gap-space-5">
-        <FullRowLeadColumn card={card} isMobile={isMobile} onHelp={onHelp} />
-
-        {/* Horizontal section columns — pairing block + extras flow
-            side-by-side on `md`+, stacking on narrow. Each stretches and
-            bottom-pins its action to the lead column's baseline (#2123). */}
-        <div className="flex-1 min-w-0 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-space-4 items-stretch">
-          {card.setupAssets.length > 0 && (
-            <FullRowSetupColumns card={card} isIOS={isIOS} isMobile={isMobile} />
-          )}
-          {card.manualPairing.length > 0 && (
-            <div className="min-w-0 flex flex-col">
-              <ManualPairingPanel steps={card.manualPairing} />
-            </div>
-          )}
-          {card.recommendedApps.length > 0 && (
-            <div className="min-w-0 flex flex-col">
-              <RecommendedApps apps={card.recommendedApps} />
-            </div>
-          )}
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-/** The full-row card's lead column (#2120): icon + title + status +
- *  tagline + the Open CTA + the help button. Fixed-ish width so the
- *  horizontal section columns get the remaining width. Split out to keep
- *  {@link FullRowCard} under the per-function line budget. */
-function FullRowLeadColumn({
-  card,
-  isMobile,
-  onHelp,
-}: {
-  card: PortalCard;
-  isMobile: boolean;
-  onHelp: () => void;
-}) {
-  return (
-    <div className="md:w-64 md:shrink-0 flex flex-col">
-      {/* Header — icon + title inline, then tagline (#2103/#2123). */}
-      <div className="space-y-space-3">
-        <CardIcon card={card} />
-        <div className="flex items-center gap-space-2 min-w-0">
-          <h2 className="text-xl font-bold text-text truncate min-w-0">{card.label}</h2>
-          <StatusBadge status={card.status} reason={card.statusReason} />
-        </div>
-        {card.tagline && (
-          <p className="text-sm text-text-muted leading-snug">{card.tagline}</p>
-        )}
-      </div>
-      {/* Primary CTA pinned at the BOTTOM (#2123) — same baseline as the
-          1×1 tiles and the bottom-aligned section columns. */}
-      <div data-testid="card-cta" className="mt-auto pt-space-3 space-y-space-2">
-        <CardCta card={card} isMobile={isMobile} />
-        {card.body.trim().length > 0 && <HowToButton onClick={onHelp} />}
-      </div>
-    </div>
-  );
-}
-
-/** "How do I use this?" footer button (#2120, extracted so the standard
- *  and full-row cards share it). Opens the markdown help modal. */
+/** "How do I use this?" button inside the disclosure (#2126). Opens the
+ *  markdown help modal. */
 function HowToButton({ onClick }: { onClick: () => void }) {
   return (
     <button
@@ -453,8 +361,8 @@ function HowToButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-/** Recommended-apps list (#2120, extracted to share between the 1×1 and
- *  full-row card layouts). Each app link keeps its href/target/rel. */
+/** Recommended-apps list (shown inside the per-card disclosure, #2126).
+ *  Each app link keeps its href/target/rel. */
 function RecommendedApps({ apps }: { apps: PortalCard['recommendedApps'] }) {
   return (
     <div className="pt-space-2 space-y-1.5">
@@ -493,46 +401,11 @@ function RecommendedApps({ apps }: { apps: PortalCard['recommendedApps'] }) {
 }
 
 /**
- * The full-row card's setup assets laid out as horizontal columns
- * (#2120). Each visible asset (Install-BasicSync, Pair-this-device, …)
- * becomes its own column cell in the full-row section grid — side-by-side
- * on `md`+, stacking on narrow screens. The wide-slot counterpart to
- * {@link SetupAssets}'s collapsed expander: here there's room to show
- * every QR/install action inline. Buttons + fetch-on-click QR modals are
- * unchanged — only the arrangement differs.
- */
-function FullRowSetupColumns({
-  card,
-  isIOS,
-  isMobile,
-}: {
-  card: PortalCard;
-  isIOS: boolean;
-  isMobile: boolean;
-}) {
-  const visible = card.setupAssets.filter(a => shouldShowAsset(a.kind, isIOS, isMobile));
-  if (visible.length === 0) return null;
-  return (
-    <>
-      {visible.map(asset => (
-        // `flex-col` + `justify-end` bottom-aligns each section's action
-        // button to the shared CTA baseline (#2123) — no top-floating.
-        <div key={asset.kind} className="min-w-0 flex flex-col justify-end">
-          <SetupAssetButton card={card} asset={asset} isIOS={isIOS} />
-        </div>
-      ))}
-    </>
-  );
-}
-
-/**
- * Setup-asset list for a 1×1 tile (#2116/#2120). The heavy QR pairing
- * block now lives in the `full-row` card ({@link FullRowSetupColumns}),
- * so in a 1×1 tile this only ever renders light assets (an iOS calendar
- * profile, an audiobookshelf deep-link). A single light asset renders
- * inline; if a tile happens to carry 2+ light assets we still tuck them
- * behind a collapsed "How to pair" / "So koppelst du" `<details>` so the
- * tile's resting size matches its peers — every asset stays reachable.
+ * Setup-asset list (#2126). Lives inside the per-card "Apps & setup"
+ * disclosure, so every visible asset — the Syncthing install + pairing
+ * QRs, the calendar one-tap profile, the audiobook deep-link — renders
+ * directly inline, no second nested collapse. Device-gated by
+ * {@link shouldShowAsset} (iOS-only assets hide on Android phones).
  */
 function SetupAssets({
   card,
@@ -546,9 +419,6 @@ function SetupAssets({
   const visible = card.setupAssets.filter(a => shouldShowAsset(a.kind, isIOS, isMobile));
   if (visible.length === 0) return null;
 
-  // In a 1×1 tile the assets are always light (the heavy QR pairing
-  // block forces a `full-row` card → FullRowSetupColumns), so they
-  // render inline directly — no collapse needed.
   return (
     <div className="space-y-1.5">
       {visible.map(asset => (
@@ -1090,14 +960,15 @@ function SyncthingQrButton({
 }
 
 /**
- * Card hero icon. Renders the Lucide line-art icon when the
- * frontmatter declares `lucide_icon`; falls back to the legacy
- * emoji for any user-guide that hasn't migrated; finally falls
- * back to a neutral Package icon for guides with neither.
+ * Card hero icon-chip (#2126). Renders the Lucide line-art icon tinted
+ * with the card's PER-SERVICE accent (Photos=teal, Passwords=blue,
+ * Files=orange, …) so the grid scans like an app launcher — a subtle
+ * tinted chip + a saturated icon, never a full-card colour. Falls back to
+ * the legacy emoji for any guide that hasn't migrated, then a neutral
+ * Package chip for guides with neither.
  *
- * The line-art rendering matches ServiceBay's dashboard chrome
- * (Sidebar, header logos) so the family portal feels like the
- * same product, not a separate emoji-themed surface.
+ * The line-art rendering matches ServiceBay's dashboard chrome (Sidebar,
+ * header logos) so the family portal feels like the same product.
  */
 function CardIcon({ card, compact = false }: { card: PortalCard; compact?: boolean }) {
   // The modal header reuses CardIcon at a smaller size — `compact`
@@ -1107,10 +978,13 @@ function CardIcon({ card, compact = false }: { card: PortalCard; compact?: boole
     ? 'inline-flex items-center justify-center w-10 h-10 rounded-card'
     : 'mb-space-3 inline-flex items-center justify-center w-14 h-14 rounded-card';
   const iconSize = compact ? 22 : 28;
+  // Per-service accent chip class (token-driven, dark-mode-correct) — a
+  // literal `.svc-chip-*` name from the accent map (no interpolation).
+  const accentClass = ACCENT_CHIP_CLASS[serviceAccent(card)];
   if (card.lucideIcon) {
     const Icon = PORTAL_ICON_MAP[card.lucideIcon];
     return (
-      <div className={`${wrapper} bg-accent/15 text-accent`}>
+      <div data-accent={serviceAccent(card)} className={`${wrapper} ${accentClass}`}>
         <Icon size={iconSize} strokeWidth={1.75} />
       </div>
     );
@@ -1119,7 +993,7 @@ function CardIcon({ card, compact = false }: { card: PortalCard; compact?: boole
     return <div className={compact ? 'text-3xl' : 'text-5xl mb-space-3'} aria-hidden>{card.icon}</div>;
   }
   return (
-    <div className={`${wrapper} bg-surface-2 text-text-muted`}>
+    <div data-accent={serviceAccent(card)} className={`${wrapper} ${accentClass}`}>
       <Package size={iconSize} strokeWidth={1.75} />
     </div>
   );

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -67,32 +67,7 @@ export default async function PortalPage() {
   return (
     <main className="relative max-w-6xl mx-auto px-space-5 py-space-7">
       {isLoggedIn && displayName && <PortalUserChip displayName={displayName} />}
-      <header className="mb-space-7 text-center">
-        <div className="flex items-center justify-center gap-space-3">
-          <ServiceBayLogo size={36} className="text-accent shrink-0" />
-          <h1 className="text-4xl font-bold text-text">
-            Home <span className="text-text-subtle font-normal">— your family&apos;s private cloud</span>
-          </h1>
-        </div>
-        <p className="mt-space-3 text-base text-text-muted">
-          {isLoggedIn && firstName
-            ? `Welcome back, ${firstName} — pick a service below to get started.`
-            : 'Pick a service below to get started.'}
-        </p>
-        {isLoggedIn && <PortalLogoutLink />}
-        {adminUrl && (
-          <p className="mt-space-4 text-sm text-text-subtle">
-            <a
-              href={adminUrl}
-              className="inline-flex items-center gap-1.5 text-text-muted hover:text-text underline-offset-2 hover:underline"
-            >
-              <Settings size={14} />
-              Admin dashboard
-            </a>
-            <span className="ml-1.5 text-text-subtle">(separate login)</span>
-          </p>
-        )}
-      </header>
+      <PortalHero isLoggedIn={isLoggedIn} firstName={firstName} adminUrl={adminUrl} />
 
       {!isLoggedIn && (
         <div className="mb-space-7">
@@ -111,6 +86,58 @@ export default async function PortalPage() {
         <PortalGrid cards={cards} />
       )}
     </main>
+  );
+}
+
+/**
+ * Warmer portal hero (#2126): a soft token-driven accent gradient
+ * backdrop + a framed box icon + generous spacing so the landing feels
+ * inviting, not like a bare list. Carries the welcome line + the
+ * admin-dashboard link (separate login). Dark-mode-first, tasteful — no
+ * raw colour literals.
+ */
+function PortalHero({
+  isLoggedIn,
+  firstName,
+  adminUrl,
+}: {
+  isLoggedIn: boolean;
+  firstName: string | null;
+  adminUrl: string | null;
+}) {
+  return (
+    <header className="relative mb-space-7 overflow-hidden rounded-panel border border-border bg-gradient-to-b from-accent/10 via-surface to-surface px-space-5 py-space-7 text-center">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 -top-24 mx-auto h-48 w-48 rounded-full bg-accent/20 blur-3xl"
+      />
+      <div className="relative flex items-center justify-center gap-space-3">
+        <span className="inline-flex items-center justify-center w-14 h-14 rounded-card bg-accent/15 text-accent shrink-0">
+          <ServiceBayLogo size={32} className="shrink-0" />
+        </span>
+        <h1 className="text-3xl sm:text-4xl font-bold text-text">
+          Home <span className="text-text-subtle font-normal">— your family&apos;s private cloud</span>
+        </h1>
+      </div>
+      <p className="relative mt-space-4 text-base text-text-muted">
+        {isLoggedIn && firstName
+          ? `Welcome back, ${firstName} — pick a service below to get started.`
+          : 'Pick a service below to get started.'}
+      </p>
+      {isLoggedIn && <PortalLogoutLink />}
+      {adminUrl && (
+        <p className="relative mt-space-4 text-sm text-text-subtle">
+          <a
+            href={adminUrl}
+            className="inline-flex items-center gap-1.5 text-text-muted hover:text-text underline-offset-2 hover:underline"
+          >
+            <Settings size={14} />
+            Admin dashboard
+          </a>
+          <span className="ml-1.5 text-text-subtle">(separate login)</span>
+        </p>
+      )}
+    </header>
   );
 }
 

--- a/packages/frontend/src/app/portal/portalAccent.test.ts
+++ b/packages/frontend/src/app/portal/portalAccent.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the per-service accent + section grouping map (#2126).
+ * Pure functions — no DOM — so the accent/section rules are pinned in
+ * isolation from the component layout.
+ */
+import { describe, it, expect } from 'vitest';
+import type { PortalCard } from '@/lib/portal/services';
+import type { PortalIconName } from '@/lib/portal/userGuide';
+import {
+  serviceAccent,
+  portalSection,
+  groupCardsBySection,
+  ACCENT_CHIP_CLASS,
+} from './portalAccent';
+
+const card = (over: Partial<PortalCard>): PortalCard => ({
+  id: 'x:1',
+  name: 'x',
+  subdomainVar: 'X_SUBDOMAIN',
+  label: 'X',
+  category: 'System',
+  lucideIcon: null,
+  icon: '',
+  tagline: '',
+  url: '',
+  status: 'ok',
+  primaryAction: null,
+  secondaryActions: [],
+  body: '',
+  recommendedApps: [],
+  setupAssets: [],
+  manualPairing: [],
+  sizeTier: 'compact',
+  ...over,
+});
+
+describe('serviceAccent (#2126)', () => {
+  const iconCases: [PortalIconName, string][] = [
+    ['camera', 'teal'],
+    ['shield', 'blue'],
+    ['folder-open', 'orange'],
+    ['book-open', 'violet'],
+    ['music', 'rose'],
+    ['calendar-days', 'red'],
+    ['lightbulb', 'amber'],
+    ['bot', 'indigo'],
+    ['refresh-cw', 'green'],
+  ];
+
+  for (const [icon, accent] of iconCases) {
+    it(`maps lucide ${icon} → ${accent}`, () => {
+      expect(serviceAccent(card({ lucideIcon: icon }))).toBe(accent);
+    });
+  }
+
+  it('falls back to a label keyword when the icon is missing', () => {
+    expect(serviceAccent(card({ lucideIcon: null, label: 'Passwords' }))).toBe('blue');
+    expect(serviceAccent(card({ lucideIcon: null, label: 'Music' }))).toBe('rose');
+  });
+
+  it('returns neutral for an unrecognized service', () => {
+    expect(serviceAccent(card({ lucideIcon: null, label: 'Mystery Box' }))).toBe('neutral');
+  });
+
+  it('every accent has a chip utility class', () => {
+    for (const accent of Object.values(ACCENT_CHIP_CLASS)) {
+      expect(accent.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('portalSection (#2126)', () => {
+  it('files services into the right section', () => {
+    expect(portalSection(card({ lucideIcon: 'camera' }))).toBe('Media');
+    expect(portalSection(card({ lucideIcon: 'music' }))).toBe('Media');
+    expect(portalSection(card({ lucideIcon: 'book-open' }))).toBe('Media');
+    expect(portalSection(card({ lucideIcon: 'shield' }))).toBe('Productivity');
+    expect(portalSection(card({ lucideIcon: 'calendar-days' }))).toBe('Productivity');
+    expect(portalSection(card({ lucideIcon: 'folder-open' }))).toBe('Files & Sync');
+    expect(portalSection(card({ lucideIcon: 'refresh-cw' }))).toBe('Files & Sync');
+    expect(portalSection(card({ lucideIcon: 'lightbulb' }))).toBe('Smart Home & Dev');
+    expect(portalSection(card({ lucideIcon: 'bot' }))).toBe('Smart Home & Dev');
+  });
+
+  it('routes an unmapped card to More', () => {
+    expect(portalSection(card({ lucideIcon: null, label: 'Mystery' }))).toBe('More');
+  });
+});
+
+describe('groupCardsBySection (#2126)', () => {
+  it('orders sections Media → Productivity → Files & Sync → Smart Home & Dev and drops empties', () => {
+    const cards = [
+      card({ id: 'dev:1', lucideIcon: 'bot' }),
+      card({ id: 'pw:1', lucideIcon: 'shield' }),
+      card({ id: 'photo:1', lucideIcon: 'camera' }),
+      card({ id: 'files:1', lucideIcon: 'folder-open' }),
+    ];
+    const groups = groupCardsBySection(cards);
+    expect(groups.map(g => g.section)).toEqual([
+      'Media', 'Productivity', 'Files & Sync', 'Smart Home & Dev',
+    ]);
+  });
+
+  it('keeps each card relative order within its section (stable)', () => {
+    const cards = [
+      card({ id: 'music:1', lucideIcon: 'music', label: 'Music' }),
+      card({ id: 'photo:1', lucideIcon: 'camera', label: 'Photos' }),
+      card({ id: 'book:1', lucideIcon: 'book-open', label: 'Audiobooks' }),
+    ];
+    const media = groupCardsBySection(cards).find(g => g.section === 'Media')!;
+    expect(media.cards.map(c => c.label)).toEqual(['Music', 'Photos', 'Audiobooks']);
+  });
+
+  it('every input card lands in exactly one section', () => {
+    const cards = [
+      card({ id: 'a:1', lucideIcon: 'camera' }),
+      card({ id: 'b:1', lucideIcon: null, label: 'Mystery' }),
+    ];
+    const total = groupCardsBySection(cards).reduce((n, g) => n + g.cards.length, 0);
+    expect(total).toBe(cards.length);
+  });
+});

--- a/packages/frontend/src/app/portal/portalAccent.ts
+++ b/packages/frontend/src/app/portal/portalAccent.ts
@@ -1,0 +1,115 @@
+/**
+ * Per-service accent identity + light section grouping for the family
+ * portal (#2126). Keyed off the card's stable `lucideIcon` (the
+ * frontmatter icon a template ships) with a label fallback, so the
+ * launcher-style tint and the section a card files under travel with the
+ * service rather than a hand-maintained id list.
+ *
+ * The accent is purely the icon-chip tint — a named class from the
+ * `.svc-chip-*` utilities defined in globals.css (an intentional,
+ * dark-mode-correct per-service accent map, distinct from the semantic
+ * token chrome). No raw colour literals leak into the component; this
+ * module only ever returns a literal class name Tailwind can see.
+ */
+import type { PortalCard } from '@/lib/portal/services';
+import type { PortalIconName } from '@/lib/portal/userGuide';
+
+/** The named accent hues (→ `.svc-chip-<hue>` in globals.css). */
+export type ServiceAccent =
+  | 'amber' | 'blue' | 'teal' | 'orange' | 'violet'
+  | 'rose' | 'red' | 'indigo' | 'green' | 'neutral';
+
+/** Icon-chip utility class per accent. `neutral` is the default token
+ *  tint for any service without a mapped identity (keeps the grid calm
+ *  rather than guessing a hue). */
+export const ACCENT_CHIP_CLASS: Record<ServiceAccent, string> = {
+  amber: 'svc-chip-amber',
+  blue: 'svc-chip-blue',
+  teal: 'svc-chip-teal',
+  orange: 'svc-chip-orange',
+  violet: 'svc-chip-violet',
+  rose: 'svc-chip-rose',
+  red: 'svc-chip-red',
+  indigo: 'svc-chip-indigo',
+  green: 'svc-chip-green',
+  neutral: 'bg-accent/15 text-accent',
+};
+
+/** Map a card's lucide icon → its service accent. Photos=teal,
+ *  Passwords=blue, Files=orange, Audiobooks=violet, Music=rose,
+ *  Calendar=red, Smart Home=amber, Claude Dev=indigo, Syncthing=green. */
+const ICON_ACCENT: Partial<Record<PortalIconName, ServiceAccent>> = {
+  'camera': 'teal', 'image': 'teal', 'images': 'teal',          // Photos
+  'shield': 'blue', 'lock': 'blue', 'key-round': 'blue',        // Passwords
+  'folder-open': 'orange', 'folder': 'orange', 'files': 'orange', // Files
+  'book-open': 'violet',                                         // Audiobooks
+  'music': 'rose', 'headphones': 'rose',                        // Music
+  'calendar': 'red', 'calendar-days': 'red',                    // Calendar
+  'lightbulb': 'amber', 'house': 'amber',                       // Smart Home
+  'bot': 'indigo', 'package': 'indigo',                         // Claude Dev
+  'refresh-cw': 'green',                                        // Syncthing
+};
+
+/** Label-keyword fallback when the icon is missing/unmapped — keeps the
+ *  accent stable even for a guide that ships an emoji or a custom icon. */
+function accentFromLabel(label: string): ServiceAccent {
+  const l = label.toLowerCase();
+  if (/photo|immich/.test(l)) return 'teal';
+  if (/password|vault/.test(l)) return 'blue';
+  if (/file|browser/.test(l)) return 'orange';
+  if (/audiobook|book|podcast/.test(l)) return 'violet';
+  if (/music|jellyfin|stream/.test(l)) return 'rose';
+  if (/calendar|contact/.test(l)) return 'red';
+  if (/smart home|home assistant|light|automation/.test(l)) return 'amber';
+  if (/claude|dev|code|terminal/.test(l)) return 'indigo';
+  if (/sync/.test(l)) return 'green';
+  return 'neutral';
+}
+
+/** Resolve a card's per-service accent (#2126). */
+export function serviceAccent(card: PortalCard): ServiceAccent {
+  if (card.lucideIcon && ICON_ACCENT[card.lucideIcon]) {
+    return ICON_ACCENT[card.lucideIcon] as ServiceAccent;
+  }
+  return accentFromLabel(card.label);
+}
+
+/** The light grouping sections, in display order (#2126). */
+export type PortalSection = 'Media' | 'Productivity' | 'Files & Sync' | 'Smart Home & Dev' | 'More';
+
+export const SECTION_ORDER: PortalSection[] = [
+  'Media', 'Productivity', 'Files & Sync', 'Smart Home & Dev', 'More',
+];
+
+/** Per-accent → section. Drives the small section headers so cards group
+ *  by what they're FOR, not by template internals. `More` collects
+ *  anything unmapped so no card ever vanishes. */
+const ACCENT_SECTION: Record<ServiceAccent, PortalSection> = {
+  teal: 'Media', violet: 'Media', rose: 'Media',              // Photos, Audiobooks, Music
+  blue: 'Productivity', red: 'Productivity',                  // Passwords, Calendar
+  orange: 'Files & Sync', green: 'Files & Sync',              // Files, Syncthing
+  amber: 'Smart Home & Dev', indigo: 'Smart Home & Dev',      // Smart Home, Claude Dev
+  neutral: 'More',
+};
+
+/** Section a card files under (#2126), derived from its accent. */
+export function portalSection(card: PortalCard): PortalSection {
+  return ACCENT_SECTION[serviceAccent(card)];
+}
+
+/** Group cards into the ordered sections, dropping empty ones and keeping
+ *  each card's relative order within its section (stable). */
+export function groupCardsBySection(
+  cards: PortalCard[],
+): { section: PortalSection; cards: PortalCard[] }[] {
+  const buckets = new Map<PortalSection, PortalCard[]>();
+  for (const card of cards) {
+    const section = portalSection(card);
+    const list = buckets.get(section) ?? [];
+    list.push(card);
+    buckets.set(section, list);
+  }
+  return SECTION_ORDER
+    .filter(s => buckets.has(s))
+    .map(section => ({ section, cards: buckets.get(section)! }));
+}


### PR DESCRIPTION
## What
Full visual redesign of the public /portal page as a calm, uniform app-launcher grid. Each card front shows only an accent icon-chip + name + status dot + one descriptive line + a single Open CTA; all secondary content (recommended apps, Syncthing install/pairing QR, Calendar iOS setup, how-to-use, manual pairing) collapses behind a per-card "Apps & setup" disclosure that is closed by default. Cards are equal-sized in one responsive grid (bento/full-row removed), carry per-service token-based accent identity, and are grouped into Media / Productivity / Files & Sync / Smart Home & Dev sections under a warmer gradient hero. All existing function preserved.

## Why
Closes #2126

## Risk
Medium — large frontend rewrite of the portal surface; function preserved and covered by DOM tests, but dark-mode visual pixel-confirm is owed to the operator.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 351 warnings = baseline)
- [x] npm run check:arch (invariants + depcruise pass)
- [x] npm test (full — 3350 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: app/portal/ + globals.css accent map) — operator dark-mode pixel-confirm owed