### PR TITLE
fix(portal): show registry-installed services (Solaris) on /portal

### DIFF
--- a/packages/backend/src/lib/portal/buildPortalCards.test.ts
+++ b/packages/backend/src/lib/portal/buildPortalCards.test.ts
@@ -26,28 +26,24 @@ vi.mock('@/lib/store/repository', () => ({
 vi.mock('@/lib/health/store', () => ({
   HealthStore: { getLastResult: (id: string) => getLastResult(id) },
 }));
+// readTemplateFile is the source-chain reader behind template.yml +
+// variables.json (and user-guide.md). The portal calls it per service,
+// so a registry-installed service is read just like a built-in one.
 vi.mock('@/lib/registry', () => ({
   getTemplateUserGuide: vi.fn(async () => '# guide\nbody'),
+  readTemplateFile: vi.fn(async (_name: string, filename: string) => {
+    if (filename === 'variables.json') {
+      return JSON.stringify({ IMMICH_SUBDOMAIN: { type: 'subdomain', default: 'photos' } });
+    }
+    if (filename === 'template.yml') return 'apiVersion: v1\n';
+    return null;
+  }),
 }));
 vi.mock('@/lib/templateTier', () => ({ parseTemplateTier: () => 'app' }));
 vi.mock('@/lib/templateLabel', () => ({ parseTemplateLabel: () => 'Immich' }));
 vi.mock('./userGuide', () => ({
   parseUserGuide: () => ({ frontmatter: {}, body: 'body' }),
   DEFAULT_PORTAL_CATEGORY: 'System',
-}));
-
-// fs reads: template.yml (any non-null string) + variables.json (a subdomain var).
-vi.mock('fs/promises', () => ({
-  default: {
-    readFile: vi.fn(async (p: string) => {
-      if (p.endsWith('variables.json')) {
-        return JSON.stringify({
-          IMMICH_SUBDOMAIN: { type: 'subdomain', default: 'photos' },
-        });
-      }
-      return 'apiVersion: v1\n'; // template.yml
-    }),
-  },
 }));
 
 import { buildPortalCards } from './services';

--- a/packages/backend/src/lib/portal/claudeDevCard.test.ts
+++ b/packages/backend/src/lib/portal/claudeDevCard.test.ts
@@ -55,22 +55,18 @@ actions:
 body
 `;
 
+// claude-dev has no subdomain var; its variables.json carries CLAUDE_DEV_SSH_PORT.
+// readTemplateFile is the source-chain reader the portal uses for
+// template.yml + variables.json.
 vi.mock('@/lib/registry', () => ({
   getTemplateUserGuide: vi.fn(async () => CLAUDE_DEV_GUIDE),
-}));
-
-// claude-dev has no subdomain var; its variables.json carries CLAUDE_DEV_SSH_PORT.
-vi.mock('fs/promises', () => ({
-  default: {
-    readFile: vi.fn(async (p: string) => {
-      if (p.endsWith('variables.json')) {
-        return JSON.stringify({
-          CLAUDE_DEV_SSH_PORT: { type: 'text', default: '2222' },
-        });
-      }
-      return 'apiVersion: v1\n'; // template.yml
-    }),
-  },
+  readTemplateFile: vi.fn(async (_name: string, filename: string) => {
+    if (filename === 'variables.json') {
+      return JSON.stringify({ CLAUDE_DEV_SSH_PORT: { type: 'text', default: '2222' } });
+    }
+    if (filename === 'template.yml') return 'apiVersion: v1\n';
+    return null;
+  }),
 }));
 
 import { buildPortalCards, interpolateActionHref } from './services';

--- a/packages/backend/src/lib/portal/services.ts
+++ b/packages/backend/src/lib/portal/services.ts
@@ -18,8 +18,6 @@
  * persist resolved subdomain values into config.
  */
 
-import path from 'path';
-import fs from 'fs/promises';
 import { getConfig, type AppConfig } from '@/lib/config';
 import { getActiveDomain, getMode } from '@/lib/mode';
 import { ServiceManager } from '@/lib/services/ServiceManager';
@@ -27,11 +25,9 @@ import { getServices } from '@/lib/store/repository';
 import { HealthStore } from '@/lib/health/store';
 import { parseTemplateTier } from '@/lib/templateTier';
 import { parseTemplateLabel } from '@/lib/templateLabel';
-import { getTemplateUserGuide } from '@/lib/registry';
+import { getTemplateUserGuide, readTemplateFile } from '@/lib/registry';
 import { logger } from '@/lib/logger';
 import { parseUserGuide, DEFAULT_PORTAL_CATEGORY, type PortalIconName, type RecommendedApp, type SetupAsset, type ManualPairing, type PortalAction, type PortalCategory } from './userGuide';
-
-const TEMPLATES_PATH = path.join(process.cwd(), 'templates');
 
 export interface PortalCard {
   /** Stable id, e.g. "media:ABS_SUBDOMAIN" or "immich:IMMICH_SUBDOMAIN".
@@ -269,16 +265,18 @@ function resolveVarValue(
  *  ambiguous. See `resolveServiceUrl` for the lookup. */
 async function readVariables(templateName: string): Promise<Record<string, { type?: string; default?: string; proxyPort?: string }>> {
   try {
-    const content = await fs.readFile(path.join(TEMPLATES_PATH, templateName, 'variables.json'), 'utf-8');
-    return JSON.parse(content);
+    const content = await readTemplateFile(templateName, 'variables.json');
+    return content ? JSON.parse(content) : {};
   } catch { return {}; }
 }
 
-/** Read a template's template.yml (best-effort). */
+/** Read a template's template.yml (best-effort). Resolves through the
+ *  full template source chain (local → registries → built-in) so a
+ *  registry-installed service (e.g. `solaris` from the `solbay`
+ *  registry) is read just like a bundled one — otherwise it never
+ *  passes the tier filter and silently drops off /portal. */
 async function readTemplateYaml(templateName: string): Promise<string | null> {
-  try {
-    return await fs.readFile(path.join(TEMPLATES_PATH, templateName, 'template.yml'), 'utf-8');
-  } catch { return null; }
+  return readTemplateFile(templateName, 'template.yml');
 }
 
 /**

--- a/packages/backend/src/lib/registry.local.test.ts
+++ b/packages/backend/src/lib/registry.local.test.ts
@@ -41,6 +41,8 @@ import {
   getTemplateYaml,
   getTemplateVariables,
   getStackManifest,
+  readTemplateFile,
+  getTemplateUserGuide,
 } from './registry';
 
 const LOCAL_DIR = path.join(ROOTS.dataRoot, 'local-templates');
@@ -149,6 +151,34 @@ describe('local persistent source (#1919)', () => {
     expect(broken).toBeDefined();
     expect(broken!.tier).toBe('feature'); // readTemplateMeta default on parse failure
     warn.mockRestore();
+  });
+
+  it('readTemplateFile resolves arbitrary files for a non-built-in template (portal regression)', async () => {
+    // A template that exists ONLY in a non-built-in source (here: local;
+    // a registry resolves the same way). The portal reads template.yml +
+    // variables.json + user-guide.md through readTemplateFile — before the
+    // fix the portal read template.yml/variables.json from the built-in
+    // dir only, so such a service never rendered a card.
+    await seedLocal({
+      'templates/solaris/template.yml': tmplYaml('solaris', 'AI Assistant (Solaris)'),
+      'templates/solaris/variables.json': JSON.stringify({
+        CHAT_SUBDOMAIN: { type: 'subdomain', default: 'chat' },
+      }),
+      'templates/solaris/user-guide.md': '---\nlucide_icon: "bot"\ncategory: "Productivity"\n---\nSolaris',
+    });
+
+    const yaml = await readTemplateFile('solaris', 'template.yml');
+    expect(yaml).toContain('name: solaris');
+
+    const vars = await readTemplateFile('solaris', 'variables.json');
+    expect(JSON.parse(vars!).CHAT_SUBDOMAIN.default).toBe('chat');
+
+    // getTemplateUserGuide now delegates to readTemplateFile.
+    const guide = await getTemplateUserGuide('solaris');
+    expect(guide).toContain('category: "Productivity"');
+
+    // A file the template doesn't ship resolves to null, not a throw.
+    expect(await readTemplateFile('solaris', 'does-not-exist.md')).toBeNull();
   });
 
   it('returns no local items when the local dir is absent', async () => {

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -1022,9 +1022,34 @@ export async function getTemplateAssetFiles(
  * or null if the template ships no post-deploy script.
  */
 export async function getTemplatePostDeployScript(name: string, source?: string): Promise<string | null> {
+  return readTemplateFile(name, 'post-deploy.py', source);
+}
+
+/**
+ * Read one file out of a template's directory, walking the same
+ * source-resolution chain every template lookup uses:
+ *
+ *   source === 'Local'        → only the persisted local-templates dir
+ *   source (a registry name)  → only that registry
+ *   no source                 → local → every configured registry →
+ *                               bundled built-in templates
+ *
+ * Returns the raw file content, or `null` when the file isn't present in
+ * the resolved location(s). This is the single primitive behind
+ * `getTemplateUserGuide`, `getTemplateChangelog`,
+ * `getTemplatePostDeployScript` and the portal's `template.yml` /
+ * `variables.json` readers — so a registry-installed service (e.g.
+ * `solaris` from the `solbay` registry) is found exactly like a
+ * built-in one rather than silently dropping out of `/portal`.
+ */
+export async function readTemplateFile(
+  name: string,
+  filename: string,
+  source?: string,
+): Promise<string | null> {
   const tryRead = async (dir: string): Promise<string | null> => {
     try {
-      return await fs.readFile(path.join(dir, 'post-deploy.py'), 'utf-8');
+      return await fs.readFile(path.join(dir, filename), 'utf-8');
     } catch { return null; }
   };
 
@@ -1061,32 +1086,7 @@ export async function getTemplatePostDeployScript(name: string, source?: string)
  * no guide is found.
  */
 export async function getTemplateUserGuide(name: string, source?: string): Promise<string | null> {
-  const tryRead = async (dir: string): Promise<string | null> => {
-    try {
-      return await fs.readFile(path.join(dir, 'user-guide.md'), 'utf-8');
-    } catch { return null; }
-  };
-
-  if (source === 'Local') {
-    return tryRead(localItemPath('template', name));
-  }
-
-  if (source && source !== 'Built-in') {
-    return tryRead(await resolveRegistryItemPath(source, 'template', name));
-  }
-
-  if (!source) {
-    const local = await tryRead(localItemPath('template', name));
-    if (local !== null) return local;
-    const config = await getConfig();
-    const registries = getRegistries(config);
-    for (const reg of registries) {
-      const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
-      if (found !== null) return found;
-    }
-  }
-
-  return tryRead(path.join(TEMPLATES_PATH, name));
+  return readTemplateFile(name, 'user-guide.md', source);
 }
 
 /**
@@ -1095,32 +1095,7 @@ export async function getTemplateUserGuide(name: string, source?: string): Promi
  * markdown text or null when missing. See #353.
  */
 export async function getTemplateChangelog(name: string, source?: string): Promise<string | null> {
-  const tryRead = async (dir: string): Promise<string | null> => {
-    try {
-      return await fs.readFile(path.join(dir, 'CHANGELOG.md'), 'utf-8');
-    } catch { return null; }
-  };
-
-  if (source === 'Local') {
-    return tryRead(localItemPath('template', name));
-  }
-
-  if (source && source !== 'Built-in') {
-    return tryRead(await resolveRegistryItemPath(source, 'template', name));
-  }
-
-  if (!source) {
-    const local = await tryRead(localItemPath('template', name));
-    if (local !== null) return local;
-    const config = await getConfig();
-    const registries = getRegistries(config);
-    for (const reg of registries) {
-      const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
-      if (found !== null) return found;
-    }
-  }
-
-  return tryRead(path.join(TEMPLATES_PATH, name));
+  return readTemplateFile(name, 'CHANGELOG.md', source);
 }
 
 /**


### PR DESCRIPTION
## Problem

`/portal` only ever rendered the **8 built-in** services. Registry-installed services — notably **Solaris** (`solaris`, from the `solbay`/`solarisbay` registry) — never appeared, even though they're installed and active on the box.

Root cause: `buildPortalCards` filters each service through `readTemplateYaml` and `readVariables`, both of which read **only** the bundled built-in `templates/<name>/` dir. A registry service's `template.yml` is never found → it fails the first filter and is silently dropped. Meanwhile `getTemplateUserGuide` already walked the full `local → registries → built-in` chain — pure inconsistency.

## Fix

- Extract the source-resolution chain into one `readTemplateFile(name, filename, source?)` primitive in `registry.ts`, de-duping the three existing readers (`getTemplateUserGuide`, `getTemplateChangelog`, `getTemplatePostDeployScript`).
- Route the portal's `template.yml` / `variables.json` readers through it. Now a registry/local service is read exactly like a built-in one.

## Tests

- `registry.local.test.ts`: new `readTemplateFile` case proving a non-built-in (local/registry) template's files resolve, and a missing file → `null`.
- Updated `buildPortalCards.test.ts` / `claudeDevCard.test.ts` registry mocks to the new `readTemplateFile` reader.
- Verified the real Solaris guide + `template.yml` parse to a `Productivity`/feature card against the live parsers.

## Pairs with

`mdopp/solarisbay` PR adding `templates/solaris/user-guide.md` — the portal shows only services that ship a guide, so both are needed for Solaris to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)