### PR TITLE
fix(media): single Jellyfin "Media" card on the portal (fold audiobooks in)

### DIFF
--- a/templates/media/user-guide.md
+++ b/templates/media/user-guide.md
@@ -1,36 +1,24 @@
 ---
-# The `media` template hosts two services on different subdomains —
-# Audiobookshelf at <books>.<domain> and Jellyfin at <music>.<domain>.
-# One card per service so the family-portal "Open" button per row
-# routes to the right place.
+# Jellyfin serves everything behind this template — music, audiobooks and
+# (optionally) video/photos — on one subdomain. Audiobookshelf was retired
+# (#1725/#1730); audiobooks are now a Jellyfin library, so the family portal
+# shows ONE "Media" card whose Open button routes to Jellyfin. The legacy
+# `books.<domain>` URL still resolves (it redirects to Jellyfin) but no longer
+# gets its own tile.
 cards:
-  - subdomain_var: "ABS_SUBDOMAIN"
-    label: "Audiobooks"
-    lucide_icon: "book-open"
-    tagline: "Listen to audiobooks and podcasts — offline on your phone, with bookmark + progress sync between devices."
-    setup_assets:
-      - kind: "audiobookshelf_deeplink"
-        label: "Open in Audiobookshelf app"
-        description: "Pre-configures the server URL — works only after you've installed the app."
-    recommended_apps:
-      - name: "Audiobookshelf"
-        url: "https://www.audiobookshelf.org/docs#mobile-apps"
-        platforms: ["ios", "android"]
-        note: "Official audiobook + podcast player. Bookmarks + progress sync between phone and tablet."
-
   - subdomain_var: "MEDIA_SUBDOMAIN"
-    label: "Music"
-    lucide_icon: "music"
-    tagline: "Stream your music collection — pair mobile apps with Quick Connect, no shared password needed."
+    label: "Media"
+    lucide_icon: "headphones"
+    tagline: "Music, audiobooks and video from your Jellyfin library — pair mobile apps with Quick Connect, no shared password needed."
     recommended_apps:
       - name: "Symfonium"
         url: "https://symfonium.app/"
         platforms: ["android"]
-        note: "Polished music client with first-class Jellyfin support — great for car audio + offline play. Paid, but worth it."
+        note: "Polished music + audiobook client with first-class Jellyfin support — great for car audio + offline play. Paid, but worth it."
       - name: "Streamyfin"
         url: "https://apps.apple.com/app/streamyfin/id6593660679"
         platforms: ["ios"]
-        note: "Native Jellyfin client for iPhone — music and video, with Quick Connect pairing."
+        note: "Native Jellyfin client for iPhone — music, audiobooks and video, with Quick Connect pairing."
       - name: "Findroid"
         url: "https://github.com/jarnedemeulemeester/findroid"
         platforms: ["android"]
@@ -39,36 +27,41 @@ cards:
 
 # Getting started with Media
 
-Two services live behind this card:
-- **Audiobookshelf** for audiobooks and podcasts.
-- **Jellyfin** for music (and optionally video and photos later).
+Everything here is served by **Jellyfin** — music, audiobooks, and optionally
+video and photos. One server, one login, polished mobile apps that work offline
+once content is downloaded.
 
-Both have polished mobile apps that work offline once content is downloaded.
+## Pick an app and pair it
 
-## Audiobooks (Audiobookshelf)
+Pick a client and pair it with **Quick Connect** — no shared password to type on
+the phone:
 
-1. Install **Audiobookshelf** on your phone (links above).
-2. Open it, tap *Add Server*, paste the URL from the *Open* button on this card (look for the audiobook subdomain — e.g. `http://audiobooks.home.arpa`).
-3. Log in with the family password.
-4. Tap a book → *Download* to keep it on the phone for offline listening (great for flights / commute).
-
-Bookmarks, playback position, and listening history sync between devices — start in the car, finish on the couch.
-
-## Music (Jellyfin)
-
-Jellyfin serves your music collection (and video/photos if you add those libraries). Pick a client and pair it with **Quick Connect** — no shared password to type on the phone:
-
-- **Symfonium** (Android) — fast, polished music client with great Jellyfin support and Bluetooth car audio. Paid app but worth it.
-- **Streamyfin** (iOS) — native Jellyfin client for iPhone, music and video.
+- **Symfonium** (Android) — fast, polished client for music *and* audiobooks, with Bluetooth car audio. Paid app but worth it.
+- **Streamyfin** (iOS) — native Jellyfin client for iPhone: music, audiobooks and video.
+- **Findroid** (Android) — clean open-source client focused on video.
 - **Browser** — Jellyfin's web UI works on every device without an app install.
 
-**Pairing with Quick Connect:** open the Jellyfin app → *Quick Connect* → the app shows a 6-digit code → open Jellyfin web (signed in) → *Dashboard → Quick Connect* → enter the code. The app is paired — no password shared. (For SSO on the web login, the admin can install `jellyfin-plugin-sso` later.)
+**Pairing with Quick Connect:** open the app → *Quick Connect* → the app shows a
+6-digit code → open Jellyfin web (signed in) → *Dashboard → Quick Connect* →
+enter the code. The app is paired — no password shared. (For SSO on the web
+login, the admin can install `jellyfin-plugin-sso` later.)
+
+## Audiobooks
+
+Audiobooks are a Jellyfin library too — browse them in the same app, alongside
+your music. Tap a book → *Download* to keep it on the phone for offline
+listening (great for flights / commute). Playback position and finished/unfinished
+state stay per-user, so each family member keeps their own progress.
 
 ## Adding content
 
-The admin drops audiobooks/podcasts into the server's **Audiobookshelf library folder** and music into the **file-share `music/` folder** (browse via the *Files* card / Samba). Jellyfin's library scan picks up `music/` automatically; Audiobookshelf picks up new files within a minute or two — no manual import. Other folders (`movies/`, `tv/`, `photos/`) the admin adds as Jellyfin libraries under *Dashboard → Libraries*.
+The admin drops music into the **file-share `music/` folder** and audiobooks into
+the **`audiobooks/` folder** (browse via the *Files* card / Samba). Jellyfin's
+library scan picks them up automatically — no manual import. Other folders
+(`movies/`, `tv/`, `photos/`) the admin adds as Jellyfin libraries under
+*Dashboard → Libraries*.
 
 ## Tips
 
 - **Offline downloads are per-device.** Downloading a book or album on your phone doesn't take it off the server; it's just cached locally.
-- **Multiple users keep separate progress.** Each family member's listening position, bookmarks, and finished/unfinished list is private to them.
+- **Multiple users keep separate progress.** Each family member's playback position, bookmarks, and finished/unfinished list is private to them.


### PR DESCRIPTION
## Problem

Audiobookshelf was retired (#1725/#1730) — audiobooks are now a Jellyfin library. Both `ABS_SUBDOMAIN` (`books.*`) and `MEDIA_SUBDOMAIN` (`media.*`) route to the **same** Jellyfin, yet `media/user-guide.md` still declared **two** portal cards ("Audiobooks" + "Music") that both open Jellyfin.

The stale "Audiobooks" card was also actively misleading: it recommended the **Audiobookshelf** mobile app and an `audiobookshelf_deeplink` setup asset that dead-end (no Audiobookshelf backend exists anymore).

## Fix

Consolidate to a **single "Media" card**:
- `subdomain_var: MEDIA_SUBDOMAIN` → Open routes to Jellyfin (`media.<domain>`).
- `headphones` icon → lands in the **Media** section (`portalAccent`: rose).
- Audiobooks folded into the guide body as a Jellyfin library; recommended apps are Jellyfin clients (Symfonium / Streamyfin / Findroid).

The legacy `books.<domain>` URL still redirects to Jellyfin (kept in `variables.json`) — it just no longer gets its own tile.

## Notes / scope

- Only `templates/media/user-guide.md` changes (portal content). `template.yml` / `variables.json` already point `books.*` at Jellyfin; left as-is by design.
- The `audiobookshelf_deeplink` asset-kind code is now unused by any template but left in place (own cleanup, has its own tests).

## Tests

- Portal + frontend suites green (157 tests); validated the guide parses to exactly one `MEDIA_SUBDOMAIN`/Media/headphones card with 3 recommended apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)