### PR TITLE
feat(template): media — enable Jellyfin music metadata providers + LrcLib on deploy

### DIFF
--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -617,6 +617,118 @@ def ensure_jellyfin_ldap_plugin(
     return True
 
 
+# ── Jellyfin music metadata providers + LrcLib lyrics (durable on reinstall) ──
+
+
+# TheAudioDB + MusicBrainz are BUNDLED metadata providers (no plugin install);
+# enabling them on the Music library makes Jellyfin fetch artist/album art +
+# tags. These are the fetcher ids Jellyfin uses for the MusicArtist/MusicAlbum
+# item types.
+_MUSIC_METADATA_FETCHERS = ["TheAudioDB", "MusicBrainz"]
+_MUSIC_IMAGE_FETCHERS = ["TheAudioDB"]
+
+
+def jellyfin_enable_music_providers(base_url: str, token: str, folders: object) -> None:
+    """Turn on internet metadata providers (TheAudioDB + MusicBrainz) for every
+    `music` library, so artist/album art + tags are fetched. Read-modify-write:
+    each library's EXISTING LibraryOptions (from GET /Library/VirtualFolders) is
+    preserved and only the provider fields are merged in, then POSTed back via
+    /Library/VirtualFolders/LibraryOptions.
+
+    Best-effort + idempotent: re-asserts the same values every deploy, so a fresh
+    reinstall never loses the music-metadata config. A failure just logs a note;
+    it never blocks the deploy."""
+    if not isinstance(folders, list):
+        return
+    auth = {"X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"'}
+    type_options = [
+        {
+            "Type": item_type,
+            "MetadataFetchers": list(_MUSIC_METADATA_FETCHERS),
+            "MetadataFetcherOrder": list(_MUSIC_METADATA_FETCHERS),
+            "ImageFetchers": list(_MUSIC_IMAGE_FETCHERS),
+            "ImageFetcherOrder": list(_MUSIC_IMAGE_FETCHERS),
+        }
+        for item_type in ("MusicArtist", "MusicAlbum")
+    ]
+    for folder in folders:
+        if not isinstance(folder, dict) or folder.get("CollectionType") != "music":
+            continue
+        item_id = folder.get("ItemId")
+        if not item_id:
+            continue
+        # Read-modify-write: keep the library's existing options, merge providers.
+        options = dict(folder.get("LibraryOptions") or {})
+        options["EnableInternetProviders"] = True
+        options["TypeOptions"] = type_options
+        code, _ = request_json(
+            "POST", f"{base_url}/Library/VirtualFolders/LibraryOptions",
+            {"Id": item_id, "LibraryOptions": options},
+            extra_headers=auth,
+        )
+        name = folder.get("Name", item_id)
+        if code in (200, 204):
+            log(f"   ✅ Jellyfin music metadata providers enabled for '{name}' (TheAudioDB + MusicBrainz).")
+        else:
+            log(f"   (note) Could not enable music metadata providers for '{name}' (HTTP {code}); "
+                "set them in Dashboard → Libraries → (Music) → Metadata downloaders.")
+
+
+# LrcLib is a COMMUNITY-repo plugin (lyrics provider). Its manifest is not in
+# Jellyfin's default catalog, so the plugin repository has to be registered
+# before the package install can resolve it.
+JELLYFIN_LRCLIB_REPO_NAME = "LrcLib"
+JELLYFIN_LRCLIB_REPO_URL = (
+    "https://raw.githubusercontent.com/dishmoth/jellyfin-plugin-lrclib/main/manifest.json"
+)
+JELLYFIN_LRCLIB_PACKAGE = "LrcLib"
+
+
+def ensure_jellyfin_lrclib_plugin(base_url: str, token: str) -> bool:
+    """Register the LrcLib community plugin repository (if not already present)
+    and request the LrcLib package install, so Jellyfin can fetch lyrics. (The
+    Solaris engine reading those lyrics is a separate ticket.)
+
+    Best-effort + idempotent: the repo-add is skipped when the manifest URL is
+    already registered, and Jellyfin no-ops a re-install of a present plugin. A
+    failure just logs a breadcrumb (operator can add it from Dashboard → Plugins
+    → Catalog) and continues — it never blocks the deploy."""
+    auth = {"X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"'}
+
+    # 1. Ensure the community plugin repository is registered.
+    code, repos = request_json("GET", f"{base_url}/Repositories", None, extra_headers=auth)
+    if code not in (200, 204) or not isinstance(repos, list):
+        log(f"   (note) Could not read Jellyfin plugin repositories (HTTP {code}); "
+            "add LrcLib from Dashboard → Plugins → Catalog if lyrics are missing.")
+        return False
+    have_repo = any(
+        isinstance(r, dict) and r.get("Url") == JELLYFIN_LRCLIB_REPO_URL for r in repos
+    )
+    if not have_repo:
+        merged = [r for r in repos if isinstance(r, dict)]
+        merged.append({
+            "Name": JELLYFIN_LRCLIB_REPO_NAME,
+            "Url": JELLYFIN_LRCLIB_REPO_URL,
+            "Enabled": True,
+        })
+        code, _ = request_json("POST", f"{base_url}/Repositories", merged, extra_headers=auth)
+        if code not in (200, 204):
+            log(f"   (note) Could not register the LrcLib plugin repository (HTTP {code}); "
+                "add it from Dashboard → Plugins → Catalog if lyrics are missing.")
+            return False
+        log("   ✅ Jellyfin LrcLib plugin repository registered.")
+
+    # 2. Request the package install (idempotent — Jellyfin no-ops a re-install).
+    pkg = urllib.parse.quote(JELLYFIN_LRCLIB_PACKAGE)
+    code, _ = request_json("POST", f"{base_url}/Packages/Installed/{pkg}", None, extra_headers=auth)
+    if code in (200, 204):
+        log("   ✅ Jellyfin LrcLib plugin install requested (lyrics provider).")
+        return True
+    log(f"   (note) Could not request LrcLib plugin install via API (HTTP {code}); "
+        "install 'LrcLib' from Dashboard → Plugins → Catalog if lyrics are missing.")
+    return False
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
 
@@ -669,6 +781,15 @@ def main() -> int:
                     jellyfin_base, jf_token,
                     public_lib_guids, libs["private_by_user"],  # type: ignore[arg-type]
                 )
+                # Enable music metadata providers (TheAudioDB + MusicBrainz) on
+                # the Music library + register the LrcLib lyrics plugin, so a
+                # fresh reinstall never loses them. Best-effort, never blocks.
+                _, folders = request_json(
+                    "GET", f"{jellyfin_base}/Library/VirtualFolders", None,
+                    extra_headers={"X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{jf_token}"'},
+                )
+                jellyfin_enable_music_providers(jellyfin_base, jf_token, folders)
+                ensure_jellyfin_lrclib_plugin(jellyfin_base, jf_token)
 
         # ── Jellyfin → LLDAP SSO (#1718) ──────────────────────────────
         # Wire the LDAP-Auth plugin against LLDAP so the family signs in

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1105,6 +1105,157 @@ class MediaScript(unittest.TestCase):
             )
             self.assertFalse(os.path.isfile(cfg_path))
 
+    def test_jellyfin_enable_music_providers_music_only_and_merges(self):
+        """The music library gets EnableInternetProviders=true + the two
+        fetchers; non-music libraries are untouched; the POST is a
+        read-modify-write that preserves existing LibraryOptions."""
+        m = load_script("media")
+        import urllib.request, json
+        folders = [
+            {"Name": "Music", "ItemId": "id-music", "CollectionType": "music",
+             "LibraryOptions": {"EnableRealtimeMonitor": False, "KeepExisting": "yes"}},
+            {"Name": "Movies", "ItemId": "id-movies", "CollectionType": "movies",
+             "LibraryOptions": {}},
+        ]
+        posts: list[dict] = []
+        outer = self
+
+        def urlopen(req, *a, **k):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if req.get_method() == "POST" and "/Library/VirtualFolders/LibraryOptions" in url:
+                posts.append(json.loads(req.data.decode()))
+                return outer._resp(204, "")
+            return outer._resp(204, "{}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            m.jellyfin_enable_music_providers("http://jf", "tok", folders)
+
+        # Only the music library is POSTed.
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0]["Id"], "id-music")
+        opts = posts[0]["LibraryOptions"]
+        self.assertTrue(opts["EnableInternetProviders"])
+        # Existing settings preserved (read-modify-write, not a bare object).
+        self.assertEqual(opts["KeepExisting"], "yes")
+        self.assertFalse(opts["EnableRealtimeMonitor"])
+        types = {t["Type"]: t for t in opts["TypeOptions"]}
+        self.assertEqual(set(types), {"MusicArtist", "MusicAlbum"})
+        for t in types.values():
+            self.assertEqual(t["MetadataFetchers"], ["TheAudioDB", "MusicBrainz"])
+
+    def test_jellyfin_enable_music_providers_idempotent(self):
+        """Re-running posts the same EnableInternetProviders + fetchers."""
+        m = load_script("media")
+        import urllib.request, json
+        folders = [
+            {"Name": "Music", "ItemId": "id-music", "CollectionType": "music",
+             "LibraryOptions": {}},
+        ]
+        posts: list[dict] = []
+        outer = self
+
+        def urlopen(req, *a, **k):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if req.get_method() == "POST" and "/Library/VirtualFolders/LibraryOptions" in url:
+                posts.append(json.loads(req.data.decode()))
+                return outer._resp(204, "")
+            return outer._resp(204, "{}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            m.jellyfin_enable_music_providers("http://jf", "tok", folders)
+            m.jellyfin_enable_music_providers("http://jf", "tok", folders)
+
+        self.assertEqual(len(posts), 2)
+        self.assertEqual(posts[0]["LibraryOptions"], posts[1]["LibraryOptions"])
+
+    def test_jellyfin_enable_music_providers_failsoft(self):
+        """A raising HTTP call is swallowed — the deploy is never blocked."""
+        m = load_script("media")
+        import urllib.request
+        folders = [
+            {"Name": "Music", "ItemId": "id-music", "CollectionType": "music",
+             "LibraryOptions": {}},
+        ]
+        # No matching response → URLError inside request_json → non-2xx, no raise.
+        with mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory({})):
+            m.jellyfin_enable_music_providers("http://jf", "tok", folders)  # must not raise
+
+    def test_jellyfin_lrclib_repo_added_then_install(self):
+        """ensure_jellyfin_lrclib_plugin registers the LrcLib community repo (when
+        absent) and then requests the package install."""
+        m = load_script("media")
+        import urllib.request, json
+        repo_posts: list[list] = []
+        install_called: list[str] = []
+        outer = self
+
+        def urlopen(req, *a, **k):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            meth = req.get_method()
+            if meth == "GET" and url.endswith("/Repositories"):
+                return outer._resp(200, json.dumps([
+                    {"Name": "Jellyfin Stable", "Url": "https://repo.jellyfin.org/manifest.json", "Enabled": True},
+                ]))
+            if meth == "POST" and url.endswith("/Repositories"):
+                repo_posts.append(json.loads(req.data.decode()))
+                return outer._resp(204, "")
+            if meth == "POST" and "/Packages/Installed/" in url:
+                install_called.append(url)
+                return outer._resp(204, "")
+            return outer._resp(204, "{}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            ok = m.ensure_jellyfin_lrclib_plugin("http://jf", "tok")
+
+        self.assertTrue(ok)
+        # The existing repo is preserved and the LrcLib manifest is appended.
+        self.assertEqual(len(repo_posts), 1)
+        urls = {r["Url"] for r in repo_posts[0]}
+        self.assertIn(m.JELLYFIN_LRCLIB_REPO_URL, urls)
+        self.assertIn("https://repo.jellyfin.org/manifest.json", urls)
+        # The package install was requested.
+        self.assertTrue(any("/Packages/Installed/" in u for u in install_called))
+
+    def test_jellyfin_lrclib_repo_skipped_when_present(self):
+        """When the LrcLib manifest is already registered, no repo POST is made;
+        only the install is requested (idempotent on a redeploy)."""
+        m = load_script("media")
+        import urllib.request, json
+        repo_posts: list = []
+        install_called: list[str] = []
+        outer = self
+
+        def urlopen(req, *a, **k):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            meth = req.get_method()
+            if meth == "GET" and url.endswith("/Repositories"):
+                return outer._resp(200, json.dumps([
+                    {"Name": "LrcLib", "Url": m.JELLYFIN_LRCLIB_REPO_URL, "Enabled": True},
+                ]))
+            if meth == "POST" and url.endswith("/Repositories"):
+                repo_posts.append(json.loads(req.data.decode()))
+                return outer._resp(204, "")
+            if meth == "POST" and "/Packages/Installed/" in url:
+                install_called.append(url)
+                return outer._resp(204, "")
+            return outer._resp(204, "{}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            ok = m.ensure_jellyfin_lrclib_plugin("http://jf", "tok")
+
+        self.assertTrue(ok)
+        self.assertEqual(repo_posts, [])  # repo already present → no add
+        self.assertTrue(install_called)
+
+    def test_jellyfin_lrclib_failsoft(self):
+        """If the repositories can't be read, log-and-continue: returns False,
+        never raises (the deploy must not be blocked)."""
+        m = load_script("media")
+        import urllib.request
+        with mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory({})):
+            ok = m.ensure_jellyfin_lrclib_plugin("http://jf", "tok")  # must not raise
+        self.assertFalse(ok)
+
 
 class HomeAssistantScript(unittest.TestCase):
     """The HA post-deploy is gated on Z-Wave device presence (skips


### PR DESCRIPTION
## What

The `media` post-deploy hook now configures music metadata + lyrics on **every (re)deploy**, so a fresh reinstall (which wipes Jellyfin config) never loses them. Both functions are wired into `main()` right after the library-provision / user-access block, guarded by `if jf_token:`.

- **`jellyfin_enable_music_providers`** — for each library whose `CollectionType == "music"`, read-modify-write its **existing** `LibraryOptions` (from `GET /Library/VirtualFolders` — preserves other settings, not a bare object), set `EnableInternetProviders: true` and `TypeOptions` for `MusicArtist` + `MusicAlbum` with `MetadataFetchers: ["TheAudioDB","MusicBrainz"]` (+ order + `ImageFetchers: ["TheAudioDB"]`), then `POST /Library/VirtualFolders/LibraryOptions`. TheAudioDB + MusicBrainz are **bundled** providers (no install). Non-music libraries untouched. Idempotent (re-asserts the same values each deploy).
- **`ensure_jellyfin_lrclib_plugin`** — LrcLib is a **community-repo** plugin: ensure its plugin repository is registered (`GET /Repositories`; add via `POST /Repositories` only if the manifest URL is absent, preserving existing repos), then `POST /Packages/Installed/LrcLib` (Jellyfin no-ops a re-install → idempotent). Prepares Jellyfin to fetch lyrics; the Solaris engine reading them is a separate ticket.

Both are **best-effort**: any failure logs a Dashboard breadcrumb and continues — never blocks the deploy.

## Why durable-on-reinstall

A fresh media reinstall wipes Jellyfin's config volume, so previously hand-configured music metadata downloaders + the LrcLib plugin would be lost. Running this in the post-deploy hook (same pattern as the LDAP-Auth + Bookshelf wiring) makes the config self-healing on every deploy.

## Tests

6 mocked-HTTP unit tests added in `tests/templates/test_post_deploy.py`, mirroring the existing `test_jellyfin_provision_libraries_*` / `test_jellyfin_bookshelf_plugin_*`: music library gets `EnableInternetProviders=true` + the two fetchers in its POSTed options; non-music untouched; idempotent (re-run posts same); LrcLib repo-add-then-install; repo-add skipped when already present; both best-effort (a raising HTTP call doesn't propagate). Full suite: 71 tests, all green via `python3 -m unittest tests.templates.test_post_deploy`.

## Verification

Not redeployed here — a real media redeploy would interrupt an in-progress metadata refresh + cause Jellyfin downtime. **Live-verify = a future media redeploy**, then `GET /Library/VirtualFolders` (Music library shows `EnableInternetProviders` + the fetchers) and the `/Plugins` / Dashboard → Plugins check for LrcLib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiJfQqGmg9mPznf1wjwrqP