### PR TITLE
fix(docker): copy workspace node_modules in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ RUN npm ci
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
+# Copy workspace-scoped node_modules that npm did not hoist to root.
+# npm may deoptimize hoisting for some packages (e.g. nodemailer, semver),
+# leaving them under packages/*/node_modules instead of the root.
+# Without this copy the Turbopack build fails with "Module not found" when a
+# frontend API route imports a backend module that depends on those packages
+# (email.ts → nodemailer, approve/route.ts → email.ts, #2148 regression).
+COPY --from=deps /app/packages/backend/node_modules ./packages/backend/node_modules
 COPY . .
 
 # Next.js collects completely anonymous telemetry data about general usage.


### PR DESCRIPTION
## What
Adds `COPY --from=deps /app/packages/backend/node_modules ./packages/backend/node_modules` to the Dockerfile builder stage, alongside the existing root `node_modules` copy.

## Why
The nodemailer `^9.0.1`→`^9.0.3` bump in the dep-sweep batch (#2148, from #2138) made npm stop hoisting `nodemailer`/`semver` to the root `node_modules`, leaving them under `packages/backend/node_modules`. The builder stage only restored root `node_modules` from the deps stage, so the Turbopack image build failed "Module not found" when a frontend API route (#2139 token-approve) imports a backend module that depends on nodemailer (`email.ts`). Invisible to PR CI (runs `npm test`, not the image build); only breaks the release/`:dev` image build (box-verify verdict red on main @0b2bb454).

Closes the #2148 release-image regression.

## Risk
Low — additive one-line Dockerfile copy; does not clobber the root `node_modules` copy.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full, 3392 passed)
- [ ] /verify on FCoS :dev box — re-check the :dev image build (PR CI does NOT build the image)

AI-generated
<!-- sb-ai-comment -->