### PR TITLE
fix(docker): ship workspace-scoped runtime deps in the runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,17 @@ COPY --from=builder /app/packages/backend/src/lib/agent/v4/scripts ./src/lib/age
 
 # Copy production node_modules (with built native modules)
 COPY --from=prod-deps /app/node_modules ./node_modules
+# npm sometimes deoptimizes hoisting and leaves runtime deps under
+# packages/*/node_modules instead of the root (e.g. nodemailer + semver after
+# the ^9.0.3 bump in 6a37174e). The pre-bundled server (dist-server/server.cjs)
+# require()s these externals and node resolves them from /app/node_modules at
+# runtime — it never looks in packages/backend/node_modules. The builder-stage
+# fix (98cd90ba) only unblocked the Turbopack build; the runner still shipped
+# without them, so the container crash-looped on boot with "Cannot find module
+# 'nodemailer'". Merge any workspace-scoped deps into root (no-clobber so
+# hoisted copies always win) regardless of npm's hoisting decision.
+COPY --from=prod-deps /app/packages ./packages-proddeps
+RUN for d in packages-proddeps/*/node_modules; do [ -d "$d" ] && cp -rn "$d/." node_modules/; done; rm -rf packages-proddeps
 COPY --from=builder /app/package.json ./package.json
 
 # We run as root inside the container to ensure access to mapped volumes (ssh keys)


### PR DESCRIPTION
## What broke

The `servicebay` `:dev` container (rev `3de87e19`, current `main` tip) crash-looped 26× and the box was **down for 4 days** (2026-07-02 → 07-06). Boot log:

```
Error: Cannot find module 'nodemailer'
  at /app/dist-server/server.cjs
```

## Root cause

- Dependabot bump `nodemailer ^9.0.1→^9.0.3` (`6a37174e`) made npm **deoptimize hoisting** — `package-lock.json` now deterministically places `nodemailer@9.0.3` under `packages/backend/node_modules`, not root.
- `nodemailer` is an esbuild `external` in `scripts/build-server.mjs`, so it is *not* bundled — node `require()`s it at runtime and resolves it from `/app/node_modules` (it never looks in `packages/backend/node_modules`).
- The runner stage only copied **root** `node_modules` from `prod-deps` → the dep was absent at runtime → crash-loop.
- The earlier fix `98cd90ba` copied `packages/backend/node_modules` into the **builder** stage only (unblocked the Turbopack build); runtime resolution was never covered.

## Fix

In the runner stage, after copying root `node_modules`, merge every `packages/*/node_modules` into root **no-clobber** (`cp -rn`, so hoisted native builds always win). Independent of npm's hoisting decision, so it survives future deopt flips.

## Box status

Box already recovered out-of-band onto a local patch image (dev code + `nodemailer` grafted from `:latest`) — `active/running`, 0 restarts. Once this merges and CI rebuilds `:dev`, redeploy the box onto the official image and revert the quadlet `Image=` back to `ghcr.io/mdopp/servicebay:dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
